### PR TITLE
Update bolt.md and fix platform abstraction leaks

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -16,10 +16,6 @@
 #include <vector>
 #include <atomic>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
 #include <memory>
 #include <mutex>
 #include <array>

--- a/AestraAudio/include/Drivers/ASIOInterface.h
+++ b/AestraAudio/include/Drivers/ASIOInterface.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #if defined(_WIN32)
-#include <windows.h>
+#include <windows.h> // ALLOW_PLATFORM_INCLUDE
 #include <objbase.h>
 #else
 #include <unistd.h>

--- a/AestraCore/CMakeLists.txt
+++ b/AestraCore/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(AestraCore STATIC
     src/AestraProfiler.cpp
     src/AestraUnifiedProfiler.cpp
     src/PointerRegistry.cpp
+    src/AestraThreading.cpp
 )
 
 target_include_directories(AestraCore PUBLIC

--- a/AestraCore/include/AestraThreading.h
+++ b/AestraCore/include/AestraThreading.h
@@ -10,14 +10,6 @@
 #include <condition_variable>
 #include <memory>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#endif
-
 namespace Aestra {
 
 // =============================================================================
@@ -26,29 +18,7 @@ namespace Aestra {
 // Dynamically loads Avrt.dll to avoid linker dependencies.
 class MMCSS {
 public:
-    static void setProAudio() {
-#ifdef _WIN32
-        static auto impl = []() {
-            HMODULE hAvrt = LoadLibraryA("Avrt.dll");
-            if (hAvrt) {
-                typedef HANDLE (WINAPI *AvSetMmThreadCharacteristicsA_t)(LPCSTR, LPDWORD);
-                auto pFunc = (AvSetMmThreadCharacteristicsA_t)GetProcAddress(hAvrt, "AvSetMmThreadCharacteristicsA");
-                if (pFunc) {
-                    DWORD taskIndex = 0;
-                    pFunc("Pro Audio", &taskIndex);
-                    // We knowingly leak the handle return/don't revert for this thread's lifetime 
-                    // (typical for dedicated audio threads).
-                    // Also leak lib handle to keep function pointer valid.
-                }
-            }
-            return 0;
-        }();
-        (void)impl;
-        
-        // Also boost Win32 priority
-        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
-#endif
-    }
+    static void setProAudio();
 };
 
 // =============================================================================
@@ -284,13 +254,13 @@ private:
     void workerLoop(uint32_t threadIdx) {
         (void)threadIdx;
         while (!m_stop) {
-            m_signal.wait([this] { return m_stop || m_taskCounter.load(std::memory_order_acquire) < m_taskCount; });
+            m_signal.wait([this] { return m_stop || m_taskCounter.load(std::memory_order_acquire) < static_cast<int>(m_taskCount); });
             
             if (m_stop) return;
 
             while (true) {
                 int idx = m_taskCounter.fetch_add(1, std::memory_order_acq_rel);
-                if (idx >= (int)m_taskCount) break;
+                if (idx >= static_cast<int>(m_taskCount)) break;
 
                 m_taskFunc(m_context, m_taskData[idx]);
                 

--- a/AestraCore/src/AestraThreading.cpp
+++ b/AestraCore/src/AestraThreading.cpp
@@ -1,0 +1,37 @@
+#include "AestraThreading.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h> // ALLOW_PLATFORM_INCLUDE
+#endif
+
+namespace Aestra {
+
+void MMCSS::setProAudio() {
+#ifdef _WIN32
+    static auto impl = []() {
+        HMODULE hAvrt = LoadLibraryA("Avrt.dll");
+        if (hAvrt) {
+            typedef HANDLE (WINAPI *AvSetMmThreadCharacteristicsA_t)(LPCSTR, LPDWORD);
+            auto pFunc = (AvSetMmThreadCharacteristicsA_t)GetProcAddress(hAvrt, "AvSetMmThreadCharacteristicsA");
+            if (pFunc) {
+                DWORD taskIndex = 0;
+                pFunc("Pro Audio", &taskIndex);
+                // We knowingly leak the handle return/don't revert for this thread's lifetime
+                // (typical for dedicated audio threads).
+                // Also leak lib handle to keep function pointer valid.
+            }
+        }
+        return 0;
+    }();
+    (void)impl;
+
+    // Also boost Win32 priority
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+#endif
+}
+
+} // namespace Aestra

--- a/bolt.md
+++ b/bolt.md
@@ -29,6 +29,16 @@ Move from a linear processing list to a DAG (Directed Acyclic Graph) task schedu
 - **Innovation**: Run third-party VST3s inside a WebAssembly container (using `wasm2c` or similar).
 - **Benefit**: Plugin crashes never crash the DAW. Security against malicious plugins.
 
+### Adaptive Polyphase Resampler
+
+- **Innovation**: Dynamically switch interpolation kernels (tap counts) based on signal complexity/content.
+- **Benefit**: Optimize CPU usage by using cheaper filters for simple signals or when high precision isn't audible, while reserving heavy Sinc64 filters for critical rendering.
+
+### Cockroach-Grade Metering
+
+- **Innovation**: Robust, infinite-runtime LUFS metering using circular buffers for block energy history.
+- **Benefit**: EBU R128 compliance without infinite RAM growth, ensuring the DAW can run indefinitely ("Cockroach" survival) without crashing or leaking memory in long sessions.
+
 ## 2. Performance Boosts
 
 ### AVX-512 Everywhere


### PR DESCRIPTION
### **User description**
This PR updates the innovation roadmap in `bolt.md` and addresses platform abstraction leaks and code quality issues. Specifically, it moves the Windows-specific `MMCSS` implementation out of the public header `AestraThreading.h` into a new source file, fixing a platform leak. It also cleans up `AudioEngine.h` includes and resolves compilation warnings in threading code.

---
*PR created automatically by Jules for task [12917698360821744946](https://jules.google.com/task/12917698360821744946) started by @currentsuspect*


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Move Windows-specific MMCSS implementation to source file

- Eliminate platform abstraction leaks from public headers

- Fix signed/unsigned comparison warnings in threading code

- Add two new innovations to bolt.md roadmap


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AestraThreading.h<br/>Public Header"] -->|Move Implementation| B["AestraThreading.cpp<br/>Source File"]
  C["windows.h Dependency"] -->|Remove| A
  D["AudioEngine.h"] -->|Remove windows.h| E["Clean Header"]
  F["Type Warnings"] -->|Fix Casts| G["Resolved Warnings"]
  H["bolt.md"] -->|Add Innovations| I["Updated Roadmap"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AestraThreading.cpp</strong><dd><code>Implement MMCSS platform code in source file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AestraCore/src/AestraThreading.cpp

<ul><li>New file containing Windows-specific MMCSS::setProAudio implementation<br> <li> Moved from header to isolate platform-specific code<br> <li> Includes windows.h with ALLOW_PLATFORM_INCLUDE comment<br> <li> Dynamically loads Avrt.dll for Pro Audio priority setting</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-320d1ff4f9afb62565e4e753a3832b20c2b3a36fb30bc39528b54785a38e677d">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AestraThreading.h</strong><dd><code>Remove platform dependencies from public header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AestraCore/include/AestraThreading.h

<ul><li>Remove windows.h and related preprocessor definitions<br> <li> Convert MMCSS::setProAudio to declaration-only<br> <li> Fix signed/unsigned comparison warnings using static_cast<br> <li> Eliminate platform abstraction leak from public header</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-a0421be68592e601361ec40a598d6252b0d5fc93a265e2e818b99ef479c6c50a">+3/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AudioEngine.h</strong><dd><code>Remove Windows-specific includes from header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AestraAudio/include/Core/AudioEngine.h

<ul><li>Remove windows.h and WIN32_LEAN_AND_MEAN definitions<br> <li> Clean up unnecessary platform-specific includes<br> <li> Maintain all other includes unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-8a55fbfe25718d1b8ff25a962590b3e8cbfd41ebc5686b66c84caa99c0c82f5e">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ASIOInterface.h</strong><dd><code>Annotate platform include for ASIO interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AestraAudio/include/Drivers/ASIOInterface.h

<ul><li>Add ALLOW_PLATFORM_INCLUDE comment to windows.h include<br> <li> Suppress linter false positive for ASIO platform headers</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-ad9d1cc54383ff7078c8d4d2c18031bc3269d023a650ea254c29659e7ad061cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add threading source file to build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AestraCore/CMakeLists.txt

<ul><li>Add src/AestraThreading.cpp to library sources<br> <li> Enable compilation of new platform-specific implementation file</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-a5cd06ccd807fd04f235d8d886befcd7387827c9afe5c1aa58e89dc841c7ad13">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Add two new innovations to roadmap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bolt.md

<ul><li>Add "Adaptive Polyphase Resampler" innovation section<br> <li> Add "Cockroach-Grade Metering" innovation section<br> <li> Describe benefits of dynamic interpolation and robust LUFS metering</ul>


</details>


  </td>
  <td><a href="https://github.com/currentsuspect/Aestra/pull/86/files#diff-dafc1fa49629b3049bf50ac931d04fb0afc8684df371a549eeff3e6867c221b7">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

