### PR TITLE
Headless roundtrip scenario and gating docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -34,6 +34,9 @@ cmake --build --preset headless-release
 pwsh -File scripts/watch_build.ps1 -Preset headless -Config Release
 ```
 
+Headless runner usage, gate thresholds, and failure codes are documented here:
+**[docs/technical/headless/HEADLESS.md](docs/technical/headless/HEADLESS.md)**
+
 Important note: CMake preset build directories are generator-specific. If you previously configured `build/headless` (or `build/full`) with a different generator (e.g. Ninja vs Visual Studio), delete that preset folder and re-run `cmake --preset ...`.
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessMain.cpp")
   target_include_directories(AestraHeadless PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include
     ${CMAKE_SOURCE_DIR}/AestraCore/include
-    ${CMAKE_SOURCE_DIR}/Source
   )
 
   if(WIN32)

--- a/Source/App/HeadlessMain.cpp
+++ b/Source/App/HeadlessMain.cpp
@@ -36,6 +36,7 @@ constexpr uint32_t kChannels = 2;
 
 enum class ScenarioType {
     Project,
+    RoundTrip,
     Tone,
     Stress,
 };
@@ -137,6 +138,7 @@ static bool jsonGetString(const JSON& obj, const char* key, std::string& out) {
 static ScenarioType parseScenarioType(const std::string& s, bool& ok) {
     ok = true;
     if (s == "project") return ScenarioType::Project;
+    if (s == "roundtrip" || s == "round_trip" || s == "round-trip") return ScenarioType::RoundTrip;
     if (s == "tone") return ScenarioType::Tone;
     if (s == "stress") return ScenarioType::Stress;
     ok = false;
@@ -253,6 +255,66 @@ static AudioGraph buildLoopGraph(const std::shared_ptr<AudioBuffer>& source,
     return graph;
 }
 
+static std::shared_ptr<TrackManager> makeTrackManager(uint32_t sampleRate) {
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputChannelCount(0);
+    return trackManager;
+}
+
+static std::string makeRoundTripPath(const std::string& name) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::path base = fs::temp_directory_path() / "AestraHeadless";
+    fs::create_directories(base, ec);
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    std::string safeName = name.empty() ? "roundtrip" : name;
+    fs::path file = base / (safeName + "_" + std::to_string(stamp) + ".aes");
+    return file.string();
+}
+
+static RunMetrics renderEngine(AudioEngine& engine,
+                               uint32_t sampleRate,
+                               uint32_t bufferFrames,
+                               uint32_t seconds,
+                               float minPeak,
+                               std::function<void(uint64_t /*blockIndex*/)> onBlock = {});
+
+static RunMetrics renderLoadedProject(const std::shared_ptr<TrackManager>& trackManager,
+                                      const ProjectSerializer::LoadResult& loadRes,
+                                      const Scenario& sc) {
+    AudioEngine engine;
+    engine.setSampleRate(sc.sampleRate);
+    engine.setBufferConfig(sc.bufferFrames, kChannels);
+
+    // Mirror app wiring for metering + routing.
+    auto meterBuffer = std::make_shared<MeterSnapshotBuffer>();
+    engine.setMeterSnapshots(meterBuffer);
+    trackManager->setMeterSnapshots(meterBuffer);
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+
+    engine.setBPM(static_cast<float>(loadRes.tempo));
+    trackManager->setPosition(loadRes.playhead);
+    engine.setGlobalSamplePos(static_cast<uint64_t>(loadRes.playhead * static_cast<double>(sc.sampleRate)));
+
+    auto graph = AudioGraphBuilder::buildFromTrackManager(*trackManager, static_cast<double>(sc.sampleRate));
+    engine.setGraph(graph);
+
+    engine.setTransportPlaying(true);
+    {
+        AudioQueueCommand cmd{};
+        cmd.type = AudioQueueCommandType::SetTransportState;
+        cmd.value1 = 1.0f;
+        cmd.samplePos = engine.getGlobalSamplePos();
+        engine.commandQueue().push(cmd);
+    }
+
+    return renderEngine(engine, sc.sampleRate, sc.bufferFrames, sc.seconds, sc.minPeak);
+}
+
 static RunMetrics renderEngine(AudioEngine& engine,
                                uint32_t sampleRate,
                                uint32_t bufferFrames,
@@ -334,6 +396,24 @@ static RunMetrics renderEngine(AudioEngine& engine,
         return m;
     }
 
+    if (const char* env = std::getenv("AESTRA_MAX_CPU_RATIO")) {
+        const double maxCpu = std::strtod(env, nullptr);
+        if (maxCpu > 0.0 && m.cpuRatio > maxCpu) {
+            m.ok = false;
+            m.failure = "cpu_ratio_exceeded";
+            return m;
+        }
+    }
+
+    if (const char* env = std::getenv("AESTRA_MAX_RENDER_MS")) {
+        const double maxRender = std::strtod(env, nullptr);
+        if (maxRender > 0.0 && m.renderMs > maxRender) {
+            m.ok = false;
+            m.failure = "render_time_exceeded";
+            return m;
+        }
+    }
+
     m.ok = true;
     return m;
 }
@@ -347,11 +427,7 @@ static RunMetrics runScenarioProject(const Scenario& sc) {
         return m;
     }
 
-    auto trackManager = std::make_shared<TrackManager>();
-    trackManager->setOutputSampleRate(static_cast<double>(sc.sampleRate));
-    trackManager->setInputSampleRate(static_cast<double>(sc.sampleRate));
-    trackManager->setInputChannelCount(0);
-
+    auto trackManager = makeTrackManager(sc.sampleRate);
     ProjectSerializer::LoadResult loadRes = ProjectSerializer::load(projectPath, trackManager);
     if (!loadRes.ok) {
         RunMetrics m;
@@ -360,35 +436,58 @@ static RunMetrics runScenarioProject(const Scenario& sc) {
         return m;
     }
 
-    AudioEngine engine;
-    engine.setSampleRate(sc.sampleRate);
-    engine.setBufferConfig(sc.bufferFrames, kChannels);
+    return renderLoadedProject(trackManager, loadRes, sc);
+}
 
-    // Mirror app wiring for metering + routing.
-    auto meterBuffer = std::make_shared<MeterSnapshotBuffer>();
-    engine.setMeterSnapshots(meterBuffer);
-    trackManager->setMeterSnapshots(meterBuffer);
-    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
-        engine.setChannelSlotMap(slotMap);
+static RunMetrics runScenarioRoundTrip(const Scenario& sc) {
+    const std::string projectPath = resolvePathRelativeToCwd(sc.projectPath);
+    if (projectPath.empty()) {
+        RunMetrics m;
+        m.ok = false;
+        m.failure = "missing_project";
+        return m;
     }
 
-    engine.setBPM(static_cast<float>(loadRes.tempo));
-    trackManager->setPosition(loadRes.playhead);
-    engine.setGlobalSamplePos(static_cast<uint64_t>(loadRes.playhead * static_cast<double>(sc.sampleRate)));
-
-    auto graph = AudioGraphBuilder::buildFromTrackManager(*trackManager, static_cast<double>(sc.sampleRate));
-    engine.setGraph(graph);
-
-    engine.setTransportPlaying(true);
-    {
-        AudioQueueCommand cmd{};
-        cmd.type = AudioQueueCommandType::SetTransportState;
-        cmd.value1 = 1.0f;
-        cmd.samplePos = engine.getGlobalSamplePos();
-        engine.commandQueue().push(cmd);
+    auto trackManager = makeTrackManager(sc.sampleRate);
+    ProjectSerializer::LoadResult loadRes = ProjectSerializer::load(projectPath, trackManager);
+    if (!loadRes.ok) {
+        RunMetrics m;
+        m.ok = false;
+        m.failure = "project_load_failed";
+        return m;
     }
 
-    return renderEngine(engine, sc.sampleRate, sc.bufferFrames, sc.seconds, sc.minPeak);
+    const std::string roundTripPath = makeRoundTripPath(sc.name);
+    const ProjectSerializer::UIState* uiState = loadRes.ui ? &(*loadRes.ui) : nullptr;
+    if (!ProjectSerializer::save(roundTripPath, trackManager, loadRes.tempo, loadRes.playhead, uiState)) {
+        RunMetrics m;
+        m.ok = false;
+        m.failure = "project_save_failed";
+        return m;
+    }
+
+    auto roundTripManager = makeTrackManager(sc.sampleRate);
+    ProjectSerializer::LoadResult loadResRoundTrip = ProjectSerializer::load(roundTripPath, roundTripManager);
+
+    std::error_code ec;
+    std::filesystem::remove(roundTripPath, ec);
+
+    if (!loadResRoundTrip.ok) {
+        RunMetrics m;
+        m.ok = false;
+        m.failure = "roundtrip_load_failed";
+        return m;
+    }
+
+    if (std::abs(loadResRoundTrip.tempo - loadRes.tempo) > 1.0e-6 ||
+        std::abs(loadResRoundTrip.playhead - loadRes.playhead) > 1.0e-6) {
+        RunMetrics m;
+        m.ok = false;
+        m.failure = "roundtrip_mismatch";
+        return m;
+    }
+
+    return renderLoadedProject(roundTripManager, loadResRoundTrip, sc);
 }
 
 static RunMetrics runScenarioTone(const Scenario& sc) {
@@ -494,6 +593,7 @@ static RunMetrics runScenarioStress(const Scenario& sc) {
 static RunMetrics runScenario(const Scenario& sc) {
     switch (sc.type) {
         case ScenarioType::Project: return runScenarioProject(sc);
+        case ScenarioType::RoundTrip: return runScenarioRoundTrip(sc);
         case ScenarioType::Tone: return runScenarioTone(sc);
         case ScenarioType::Stress: return runScenarioStress(sc);
     }
@@ -512,7 +612,11 @@ static JSON makeReportJson(const Scenario& sc, const RunMetrics& m) {
 
     JSON r = JSON::object();
     r.set("name", JSON(sc.name));
-    r.set("type", JSON(sc.type == ScenarioType::Project ? "project" : sc.type == ScenarioType::Tone ? "tone" : "stress"));
+    const char* typeStr = "project";
+    if (sc.type == ScenarioType::RoundTrip) typeStr = "roundtrip";
+    else if (sc.type == ScenarioType::Tone) typeStr = "tone";
+    else if (sc.type == ScenarioType::Stress) typeStr = "stress";
+    r.set("type", JSON(typeStr));
     r.set("ok", JSON(m.ok));
     if (!m.failure.empty()) r.set("failure", JSON(m.failure));
 
@@ -521,7 +625,9 @@ static JSON makeReportJson(const Scenario& sc, const RunMetrics& m) {
     cfg.set("frames", JSON(static_cast<double>(sc.bufferFrames)));
     cfg.set("seconds", JSON(static_cast<double>(sc.seconds)));
     cfg.set("minPeak", JSON(static_cast<double>(sc.minPeak)));
-    if (sc.type == ScenarioType::Project) cfg.set("project", JSON(sc.projectPath));
+    if (sc.type == ScenarioType::Project || sc.type == ScenarioType::RoundTrip) {
+        cfg.set("project", JSON(sc.projectPath));
+    }
     if (sc.type == ScenarioType::Tone) {
         cfg.set("frequencyHz", JSON(sc.frequencyHz));
         cfg.set("amplitude", JSON(sc.amplitude));

--- a/Tests/headless_scenarios.json
+++ b/Tests/headless_scenarios.json
@@ -21,6 +21,15 @@
       "project": "autosave.aes"
     },
     {
+      "name": "roundtrip_autosave",
+      "type": "roundtrip",
+      "sr": 44100,
+      "frames": 256,
+      "seconds": 10,
+      "minPeak": 0.000001,
+      "project": "autosave.aes"
+    },
+    {
       "name": "stress_graph_32_tracks",
       "type": "stress",
       "sr": 48000,

--- a/docs/technical/headless/HEADLESS.md
+++ b/docs/technical/headless/HEADLESS.md
@@ -1,0 +1,58 @@
+# 🧪 Headless Runner (AestraHeadless)
+
+AestraHeadless runs offline DSP scenarios without OpenGL/UI. Use it for CI, containers, and regression checks.
+
+## Build + Run
+
+```powershell
+cmake --preset headless
+cmake --build --preset headless-release
+
+# List scenarios
+./build/headless/bin/Release/AestraHeadless --list-scenarios
+
+# Run all scenarios (writes JSON to stdout)
+./build/headless/bin/Release/AestraHeadless --scenario-file Tests/headless_scenarios.json
+
+# Run a single scenario with a human-readable summary
+./build/headless/bin/Release/AestraHeadless --scenario roundtrip_autosave --human
+```
+
+## Gate Thresholds (CI/Headless)
+
+Use environment variables to enforce performance gates in CI:
+
+- `AESTRA_MIN_PEAK`: fail if max peak is below this (already supported)
+- `AESTRA_MAX_CPU_RATIO`: fail if `renderMs / audioMs` exceeds this
+- `AESTRA_MAX_RENDER_MS`: fail if total render time exceeds this (milliseconds)
+
+Example:
+
+```powershell
+$env:AESTRA_MAX_CPU_RATIO = "0.25"
+$env:AESTRA_MAX_RENDER_MS = "150"
+./build/headless/bin/Release/AestraHeadless --scenario roundtrip_autosave --human
+```
+
+## Failure Codes
+
+AestraHeadless returns **exit code 1** when any scenario fails. Reports include a `failure` string for the specific reason.
+
+Common failure strings:
+
+- `missing_project` – scenario requires a project path but none was provided
+- `project_load_failed` – failed to load the requested project
+- `project_save_failed` – failed to save during round-trip
+- `roundtrip_load_failed` – failed to reload the saved project
+- `roundtrip_mismatch` – tempo/playhead mismatch after round-trip
+- `nan_or_inf` – NaN/Inf samples detected
+- `invalid_peak` – peak sample computed as NaN/Inf
+- `near_silence` – max peak below `minPeak`
+- `cpu_ratio_exceeded` – exceeded `AESTRA_MAX_CPU_RATIO`
+- `render_time_exceeded` – exceeded `AESTRA_MAX_RENDER_MS`
+- `unknown_type` – scenario type not recognized
+
+**Exit codes:**
+- `0` – all scenarios passed
+- `1` – scenario failure (see `failure`)
+- `2` – invalid CLI/scenario file or missing scenario

--- a/scripts/run_stability_check.sh
+++ b/scripts/run_stability_check.sh
@@ -28,6 +28,14 @@ if [[ "${MIN_PEAK:-}" != "" ]]; then
   ARGS+=("--min-peak" "$MIN_PEAK")
 fi
 
+if [[ "${MAX_CPU_RATIO:-}" != "" ]]; then
+  export AESTRA_MAX_CPU_RATIO="$MAX_CPU_RATIO"
+fi
+
+if [[ "${MAX_RENDER_MS:-}" != "" ]]; then
+  export AESTRA_MAX_RENDER_MS="$MAX_RENDER_MS"
+fi
+
 RUNS=1
 MODE="${1:-}" 
 if [[ "$MODE" == "--stress" ]]; then


### PR DESCRIPTION
## Summary\n- add a round-trip scenario to the headless runner and JSON scenario list\n- add headless gate thresholds (CPU/render time) with documented failure codes\n- trim headless include paths and document headless usage\n\n## Testing\n- cmake -S . -B build/headless-quickwins -DAESTRA_HEADLESS_ONLY=ON -DCMAKE_BUILD_TYPE=Release *(fails: missing AestraAudio/src/Models/TrackManager.cpp + PlaylistModel.cpp in this checkout)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RoundTrip scenario type for headless testing, enabling project save/load validation workflows.
  * Added roundtrip_autosave test scenario.

* **Documentation**
  * Added comprehensive headless runner documentation covering build, execution, scenario configuration, and failure codes.
  * Updated build notes with headless reference.

* **Tests**
  * Enhanced stability checks with configurable CPU ratio and render time thresholds via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->