### PR TITLE
Fix RT violations, update innovations, and repair VST3 integration

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -360,22 +360,15 @@ public:
         }
 
         struct RecordingWriteGuard {
-            RecordingWriteGuard(std::atomic<uint32_t>& writersIn,
-                                std::condition_variable& writersCvIn,
-                                std::mutex& writersMutexIn)
-                : writers(writersIn), writersCv(writersCvIn), writersMutex(writersMutexIn) {
+            explicit RecordingWriteGuard(std::atomic<uint32_t>& writersIn)
+                : writers(writersIn) {
                 writers.fetch_add(1, std::memory_order_acq_rel);
             }
             ~RecordingWriteGuard() {
-                if (writers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-                    std::lock_guard<std::mutex> lock(writersMutex);
-                    writersCv.notify_all();
-                }
+                writers.fetch_sub(1, std::memory_order_acq_rel);
             }
             std::atomic<uint32_t>& writers;
-            std::condition_variable& writersCv;
-            std::mutex& writersMutex;
-        } guard(m_recordingWriters, m_recordingWritersCv, m_recordingWritersMutex);
+        } guard(m_recordingWriters);
 
         if (!m_recordingCaptureAccepting.load(std::memory_order_acquire)) {
             return;
@@ -943,12 +936,17 @@ private:
     void finalizeCaptureSession() {
         m_recordingCaptureAccepting.store(false, std::memory_order_release);
         m_isCapturing.store(false, std::memory_order_relaxed);
-        std::unique_lock<std::mutex> writersLock(m_recordingWritersMutex);
-        const bool writersDrained =
-            m_recordingWritersCv.wait_for(writersLock, std::chrono::milliseconds(250), [this]() {
-                return m_recordingWriters.load(std::memory_order_acquire) == 0;
-            });
-        writersLock.unlock();
+
+        bool writersDrained = false;
+        auto startTime = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - startTime < std::chrono::milliseconds(250)) {
+            if (m_recordingWriters.load(std::memory_order_acquire) == 0) {
+                writersDrained = true;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
         if (!writersDrained) {
             Log::warning("[TrackManager] Timed out waiting for recording writers to drain before finalizing capture.");
         }
@@ -1290,8 +1288,6 @@ private:
     mutable std::mutex m_recordingMutex;
     std::unordered_map<uint32_t, std::unique_ptr<RecordingCapture>> m_recordingCaptures;
     std::atomic<uint32_t> m_recordingWriters{0};
-    mutable std::mutex m_recordingWritersMutex;
-    std::condition_variable m_recordingWritersCv;
     std::atomic<bool> m_recordingCaptureAccepting{false};
     std::array<std::atomic<float>, 8> m_inputPeaks{};
     double m_maxRecordingSeconds{15.0};

--- a/AestraAudio/src/Plugin/VST3Host.cpp
+++ b/AestraAudio/src/Plugin/VST3Host.cpp
@@ -19,6 +19,8 @@
 #include "pluginterfaces/vst/ivstcomponent.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"
 #include "pluginterfaces/vst/ivstprocesscontext.h"
+#include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/vst/ivstevents.h"
 #include "public.sdk/source/vst/hosting/hostclasses.h"
 #include "public.sdk/source/vst/hosting/module.h"
 #include "public.sdk/source/vst/hosting/plugprovider.h"
@@ -561,7 +563,7 @@ std::vector<uint8_t> VST3PluginInstance::saveState() const {
         MemStream() { addRef(); }
         ~MemStream() { if (i) i->release(); }
 
-        tresult STDCALL write(void* buffer, int32 numBytes, int32* numBytesWritten) override {
+        tresult PLUGIN_API write(void* buffer, int32 numBytes, int32* numBytesWritten) override {
             if (!buffer || numBytes < 0 || pos < 0) {
                 if (numBytesWritten) *numBytesWritten = 0;
                 return kInvalidArgument;
@@ -573,7 +575,7 @@ std::vector<uint8_t> VST3PluginInstance::saveState() const {
             pos += numBytes;
             return kResultOk;
         }
-        tresult STDCALL read(void* buffer, int32 numBytes, int32* numBytesRead) override {
+        tresult PLUGIN_API read(void* buffer, int32 numBytes, int32* numBytesRead) override {
             if (numBytesRead) *numBytesRead = 0;
             if (!buffer || numBytes < 0 || pos < 0) {
                 return kInvalidArgument;
@@ -589,26 +591,26 @@ std::vector<uint8_t> VST3PluginInstance::saveState() const {
             pos += toRead;
             return kResultOk;
         }
-        tresult STDCALL seek(int64 pos, int32 type, int64* result) override {
-            if (type == kIBSeekSet) this->pos = pos;
-            else if (type == kIBSeekCur) this->pos += pos;
-            else if (type == kIBSeekEnd) this->pos = static_cast<int64_t>(data.size()) + pos;
+        tresult PLUGIN_API seek(int64 pos, int32 type, int64* result) override {
+            if (type == IBStream::kIBSeekSet) this->pos = pos;
+            else if (type == IBStream::kIBSeekCur) this->pos += pos;
+            else if (type == IBStream::kIBSeekEnd) this->pos = static_cast<int64_t>(data.size()) + pos;
             else return kInvalidArgument;
             this->pos = std::clamp<int64_t>(this->pos, 0, static_cast<int64_t>(data.size()));
             if (result) *result = this->pos;
             return kResultOk;
         }
-        tresult STDCALL tell(int64* pos) override {
+        tresult PLUGIN_API tell(int64* pos) override {
             if (pos) *pos = this->pos;
             return kResultOk;
         }
-        uint32 STDCALL addRef() override { return ++refCount; }
-        uint32 STDCALL release() override {
+        uint32 PLUGIN_API addRef() override { return ++refCount; }
+        uint32 PLUGIN_API release() override {
             uint32 r = --refCount;
             if (r == 0) { /* don't delete - stack allocated */ return 0; }
             return r;
         }
-        tresult STDCALL queryInterface(const TUID iid, void** obj) override {
+        tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override {
             if (iid == IBStream::iid || iid == FUnknown::iid) { *obj = static_cast<IBStream*>(this); addRef(); return kResultOk; }
             return kNoInterface;
         }
@@ -636,8 +638,8 @@ bool VST3PluginInstance::loadState(const std::vector<uint8_t>& state) {
 
         MemStream(const std::vector<uint8_t>& d) : data(d) { addRef(); }
 
-        tresult STDCALL write(void*, int32, int32*) override { return kNotImplemented; }
-        tresult STDCALL read(void* buffer, int32 numBytes, int32* numBytesRead) override {
+        tresult PLUGIN_API write(void*, int32, int32*) override { return kNotImplemented; }
+        tresult PLUGIN_API read(void* buffer, int32 numBytes, int32* numBytesRead) override {
             if (numBytesRead) *numBytesRead = 0;
             if (!buffer || numBytes < 0 || pos < 0) {
                 return kInvalidArgument;
@@ -653,19 +655,19 @@ bool VST3PluginInstance::loadState(const std::vector<uint8_t>& state) {
             pos += toRead;
             return kResultOk;
         }
-        tresult STDCALL seek(int64 p, int32 type, int64* result) override {
-            if (type == kIBSeekSet) pos = p;
-            else if (type == kIBSeekCur) pos += p;
-            else if (type == kIBSeekEnd) pos = static_cast<int64_t>(data.size()) + p;
+        tresult PLUGIN_API seek(int64 p, int32 type, int64* result) override {
+            if (type == IBStream::kIBSeekSet) pos = p;
+            else if (type == IBStream::kIBSeekCur) pos += p;
+            else if (type == IBStream::kIBSeekEnd) pos = static_cast<int64_t>(data.size()) + p;
             else return kInvalidArgument;
             pos = std::clamp<int64_t>(pos, 0, static_cast<int64_t>(data.size()));
             if (result) *result = pos;
             return kResultOk;
         }
-        tresult STDCALL tell(int64* p) override { if (p) *p = pos; return kResultOk; }
-        uint32 STDCALL addRef() override { return ++refCount; }
-        uint32 STDCALL release() override { uint32 r = --refCount; if (r == 0) return 0; return r; }
-        tresult STDCALL queryInterface(const TUID iid, void** obj) override {
+        tresult PLUGIN_API tell(int64* p) override { if (p) *p = pos; return kResultOk; }
+        uint32 PLUGIN_API addRef() override { return ++refCount; }
+        uint32 PLUGIN_API release() override { uint32 r = --refCount; if (r == 0) return 0; return r; }
+        tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override {
             if (iid == IBStream::iid || iid == FUnknown::iid) { *obj = static_cast<IBStream*>(this); addRef(); return kResultOk; }
             return kNoInterface;
         }

--- a/audit_results.txt
+++ b/audit_results.txt
@@ -1,0 +1,4 @@
+AestraAudio/include/Models/TrackManager.h:365: Mutex usage (check for locks in RT) found in critical section candidate: 'std::mutex& writersMutexIn)'
+AestraAudio/include/Models/TrackManager.h:371: Mutex usage (check for locks in RT) found in critical section candidate: 'std::lock_guard<std::mutex> lock(writersMutex);'
+AestraAudio/include/Models/TrackManager.h:371: Lock guard usage found in critical section candidate: 'std::lock_guard<std::mutex> lock(writersMutex);'
+AestraAudio/include/Models/TrackManager.h:377: Mutex usage (check for locks in RT) found in critical section candidate: 'std::mutex& writersMutex;'

--- a/bolt.md
+++ b/bolt.md
@@ -4,6 +4,11 @@ As the performance and quality agent "Bolt", I propose the following innovations
 
 ## 1. Innovations
 
+### Aestra Unified Framework
+
+- **Innovation**: Implement a shared foundation layer that unifies data structures, plugin interfaces, and project serialization across both Aestra (timeline DAW) and Spot (modular ecosystem).
+- **Benefit**: Ensures seamless interoperability, zero-friction project sharing, and drastically reduced duplication of effort between the two DAWs.
+
 ### NeuralFX Suite
 
 Expand the prototype `NeuralAmp` into a full suite of differentiable DSP plugins.
@@ -47,6 +52,21 @@ Move from a linear processing list to a DAG (Directed Acyclic Graph) task schedu
 
 ## 2. Performance Boosts
 
+### GPU Accelerated DSP
+
+- **Innovation**: Offload highly parallel audio computations (e.g., FFT, heavy convolution, spectral processing) to the GPU using Vulkan or compute shaders.
+- **Benefit**: Frees up the CPU for critical real-time thread management and enables extremely dense processing that was previously impossible.
+
+### SimdLin Integration
+
+- **Plan**: Deeply integrate `SimdLin` (a SIMD-accelerated linear algebra library) into all core DSP operations requiring heavy math.
+- **Benefit**: Maximize vectorization opportunities across platforms, standardizing how SIMD instructions are dispatched.
+
+### Predictive Caching
+
+- **Innovation**: Anticipate upcoming heavy processing regions on the timeline and pre-compute/render them into a background cache before the playhead arrives.
+- **Benefit**: Reduces audio dropouts on massive sessions by dynamically load-balancing CPU usage across time.
+
 ### AVX-512 Everywhere
 
 - **Status**: Partially used in `SampleRateConverter`.
@@ -74,6 +94,11 @@ Move from a linear processing list to a DAG (Directed Acyclic Graph) task schedu
 - **Benefit**: Lower per-buffer overhead on dense sessions.
 
 ## 3. Sound Quality
+
+### Quantum-Modeled Reverb
+
+- **Innovation**: Develop a highly advanced spatial engine using quantum-inspired stochastic modeling to compute room reflections, scattering, and tail density.
+- **Benefit**: Produces astoundingly realistic and lush spaces that rival algorithmic classics, while retaining unique character.
 
 ### 64-bit End-to-End Mixing
 


### PR DESCRIPTION
- **RT Safety**: `TrackManager` audio callback writes are now completely lock-free via `std::atomic<uint32_t> m_recordingWriters`. The shutdown method utilizes a `250ms` active polling loop in place of `std::condition_variable` waiting.
- **Documentation**: Fully populated `bolt.md` with targeted DAW ecosystem innovations (Unified Framework, SimdLin, GPU DSP, etc).
- **Compile Fix**: Repaired build failures related to `STDCALL` in `VST3Host.cpp` via SDK `PLUGIN_API` macro and explicit enum scopes.

---
*PR created automatically by Jules for task [4516133937834080301](https://jules.google.com/task/4516133937834080301) started by @currentsuspect*