### PR TITLE
fix: scope NDEBUG to VST3 SDK files only, preserve assertions in Aestra audio code

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -398,37 +398,9 @@ add_library(AestraAudioCore STATIC
 # Do NOT apply to entire target — preserves assertions in Aestra audio code
 if(AESTRA_HAS_VST3)
     set_source_files_properties(
-        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/hostclasses.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/plugprovider.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/common/memorystream.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/vst/utility/stringconvert.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/common/commonstringconvert.cpp
-        ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
-        ${VST3_SDK_DIR}/base/source/fdebug.cpp
-        ${VST3_SDK_DIR}/base/source/fobject.cpp
-        ${VST3_SDK_DIR}/base/source/fstring.cpp
-        ${VST3_SDK_DIR}/pluginterfaces/base/funknown.cpp
-        ${VST3_SDK_DIR}/pluginterfaces/base/ustring.cpp
-        ${VST3_SDK_DIR}/pluginterfaces/base/coreiids.cpp
+        ${VST3_HOST_SOURCES}
         PROPERTIES COMPILE_DEFINITIONS NDEBUG
     )
-    if(WIN32)
-        set_source_files_properties(
-            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_win32.cpp
-            PROPERTIES COMPILE_DEFINITIONS NDEBUG
-        )
-    elseif(APPLE)
-        set_source_files_properties(
-            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_mac.mm
-            PROPERTIES COMPILE_DEFINITIONS NDEBUG
-        )
-    else()
-        set_source_files_properties(
-            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_linux.cpp
-            PROPERTIES COMPILE_DEFINITIONS NDEBUG
-        )
-    endif()
 endif()
 
 # Enable miniaudio for fast audio decoding (MP3, FLAC, etc.)

--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -394,8 +394,42 @@ add_library(AestraAudioCore STATIC
     ${AESTRA_AUDIO_CORE_HEADERS}
 )
 
-# Define NDEBUG for VST3 SDK compatibility (required by fdebug.h)
-target_compile_definitions(AestraAudioCore PRIVATE NDEBUG)
+# Apply NDEBUG only to VST3 SDK files (required by fdebug.h)
+# Do NOT apply to entire target — preserves assertions in Aestra audio code
+if(AESTRA_HAS_VST3)
+    set_source_files_properties(
+        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/hostclasses.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/plugprovider.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/common/memorystream.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/vst/utility/stringconvert.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/common/commonstringconvert.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
+        ${VST3_SDK_DIR}/base/source/fdebug.cpp
+        ${VST3_SDK_DIR}/base/source/fobject.cpp
+        ${VST3_SDK_DIR}/base/source/fstring.cpp
+        ${VST3_SDK_DIR}/pluginterfaces/base/funknown.cpp
+        ${VST3_SDK_DIR}/pluginterfaces/base/ustring.cpp
+        ${VST3_SDK_DIR}/pluginterfaces/base/coreiids.cpp
+        PROPERTIES COMPILE_DEFINITIONS NDEBUG
+    )
+    if(WIN32)
+        set_source_files_properties(
+            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_win32.cpp
+            PROPERTIES COMPILE_DEFINITIONS NDEBUG
+        )
+    elseif(APPLE)
+        set_source_files_properties(
+            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_mac.mm
+            PROPERTIES COMPILE_DEFINITIONS NDEBUG
+        )
+    else()
+        set_source_files_properties(
+            ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module_linux.cpp
+            PROPERTIES COMPILE_DEFINITIONS NDEBUG
+        )
+    endif()
+endif()
 
 # Enable miniaudio for fast audio decoding (MP3, FLAC, etc.)
 set(AESTRA_USE_MINIAUDIO ON)


### PR DESCRIPTION
## Summary

Moves `NDEBUG` from a global target compile definition to per-file compile definitions applied only to VST3 SDK source files.

## Why

`NDEBUG` was defined for the entire `AestraAudioCore` target, disabling all `assert()` calls in the audio engine. This was intended only for VST3 SDK compatibility (required by fdebug.h).

## Testing performed
- Verified VST3 SDK files still compile with NDEBUG
- Verified non-VST3 files no longer have NDEBUG defined
- CMake configuration tested

## Docs updated?
No

## Risk/rollback notes
- Low risk: VST3 SDK files still get NDEBUG, other files regain assertions
- Rollback: revert commit if VST3 compilation issues arise

Fixes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

- **Moved NDEBUG definition from global to targeted scope**: Previously, `NDEBUG` was defined for the entire `AestraAudioCore` CMake target via `target_compile_definitions()`, which disabled assertion checks across the entire audio engine. Now it's applied only to VST3 SDK source files via `set_source_files_properties()`.

- **Restored assertions in non-VST3 audio code**: Non-VST3 source files in the audio engine no longer have `NDEBUG` defined, allowing bounds checks, invariants, and safety guards to remain active and catch issues.

- **Preserved VST3 SDK compatibility**: VST3 SDK files continue to compile with `NDEBUG` (required by `fdebug.h`) while other audio code benefits from debug assertions.

## Why

The original implementation incorrectly applied a VST3-specific build requirement across the entire codebase. This unintentionally disabled all assertions in the audio engine, creating a silent UB hazard and making debugging harder. The fix scopes the requirement precisely to where it's needed.

## Changes Made

- `AestraAudio/CMakeLists.txt`: Removed `target_compile_definitions(AestraAudioCore PRIVATE NDEBUG)` and added conditional `set_source_files_properties()` for `${VST3_HOST_SOURCES}` to apply `NDEBUG` only when `AESTRA_HAS_VST3` is enabled.

**Lines changed**: +8/-2 | **Fixes**: `#194`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->