### PR TITLE
fix: return false and clean up partial file on bounce write error

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -432,6 +432,10 @@ public:
     void setForceBounceWriteErrorForTests(bool enabled) {
         m_forceBounceWriteErrorForTests.store(enabled, std::memory_order_relaxed);
     }
+    /** @brief Test hook: indicates whether the last bounce wrote at least one full block. */
+    bool didLastBounceWriteAnyFramesForTests() const {
+        return m_lastBounceWroteAnyFramesForTests.load(std::memory_order_relaxed);
+    }
 
     /** @brief Get the waveform-history buffer capacity in frames. */
     uint32_t getWaveformHistoryCapacity() const { return m_waveformHistoryFrames.load(std::memory_order_relaxed); }
@@ -895,6 +899,7 @@ private:
     // Test Tone State
     std::atomic<bool> m_testToneEnabled{false};
     std::atomic<bool> m_forceBounceWriteErrorForTests{false};
+    std::atomic<bool> m_lastBounceWroteAnyFramesForTests{false};
     double m_testTonePhase{0.0};
 
     // Dependencies

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -428,6 +428,10 @@ public:
     void setTestToneEnabled(bool enabled) { m_testToneEnabled.store(enabled, std::memory_order_relaxed); }
     /** @brief Check whether the internal test tone is enabled. */
     bool isTestToneEnabled() const { return m_testToneEnabled.load(std::memory_order_relaxed); }
+    /** @brief Test hook: force bounce write error on first write attempt. */
+    void setForceBounceWriteErrorForTests(bool enabled) {
+        m_forceBounceWriteErrorForTests.store(enabled, std::memory_order_relaxed);
+    }
 
     /** @brief Get the waveform-history buffer capacity in frames. */
     uint32_t getWaveformHistoryCapacity() const { return m_waveformHistoryFrames.load(std::memory_order_relaxed); }
@@ -890,6 +894,7 @@ private:
 
     // Test Tone State
     std::atomic<bool> m_testToneEnabled{false};
+    std::atomic<bool> m_forceBounceWriteErrorForTests{false};
     double m_testTonePhase{0.0};
 
     // Dependencies

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3056,6 +3056,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
 
     uint64_t currentFrame = startSample;
     uint64_t framesRemaining = totalFrames;
+    bool writeError = false;
 
     // Playback stopped at start of function
     m_transportPlaying.store(false, std::memory_order_relaxed); // Ensure redundant enforce
@@ -3133,6 +3134,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         if (result != MA_SUCCESS || framesWritten != framesThisBlock) {
             Aestra::Log::error("[AudioEngine] Write error during bounce: result=" + std::to_string(result) +
                                ", written=" + std::to_string(framesWritten));
+            writeError = true;
             break;
         }
 
@@ -3145,6 +3147,13 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     // Restore playback state
     if (wasPlaying)
         setTransportPlaying(true);
+
+    if (writeError) {
+        // Clean up partial file on write error
+        std::remove(outputPath.c_str());
+        Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
+        return false;
+    }
 
     Aestra::Log::info("[AudioEngine] Bounce complete.");
     return true;

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -25,7 +25,6 @@
 #include <cerrno>
 #include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <queue>
@@ -3059,7 +3058,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     uint64_t currentFrame = startSample;
     uint64_t framesRemaining = totalFrames;
     bool writeError = false;
-    const bool forceWriteErrorForTests = std::getenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR") != nullptr;
+    const bool forceWriteErrorForTests = m_forceBounceWriteErrorForTests.load(std::memory_order_relaxed);
     bool forcedWriteErrorTriggered = false;
 
     // Playback stopped at start of function

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3135,14 +3135,16 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
 
         // Write
         ma_uint64 framesWritten = 0;
-        ma_result result = ma_encoder_write_pcm_frames(&encoder, floatBuffer.data(), framesThisBlock, &framesWritten);
-        if (result == MA_SUCCESS && framesWritten == framesThisBlock) {
-            wroteAnyFrames = true;
-        }
+        ma_result result = MA_ERROR;
         if (forceWriteErrorForTests && wroteAnyFrames && !forcedWriteErrorTriggered) {
             forcedWriteErrorTriggered = true;
             result = MA_ERROR;
             framesWritten = 0;
+        } else {
+            result = ma_encoder_write_pcm_frames(&encoder, floatBuffer.data(), framesThisBlock, &framesWritten);
+            if (result == MA_SUCCESS && framesWritten == framesThisBlock) {
+                wroteAnyFrames = true;
+            }
         }
         if (result != MA_SUCCESS || framesWritten != framesThisBlock) {
             Aestra::Log::error("[AudioEngine] Write error during bounce: result=" + std::to_string(result) +
@@ -3165,7 +3167,10 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     if (writeError) {
         // Clean up partial file on write error
         const int removeResult = std::remove(outputPath.c_str());
-        const int removeErrno = (removeResult != 0) ? errno : 0;
+        int removeErrno = 0;
+        if (removeResult != 0) {
+            removeErrno = errno;
+        }
         if (removeResult == 0) {
             Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
         } else {

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -22,8 +22,10 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <queue>
@@ -3057,6 +3059,8 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     uint64_t currentFrame = startSample;
     uint64_t framesRemaining = totalFrames;
     bool writeError = false;
+    const bool forceWriteErrorForTests = std::getenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR") != nullptr;
+    bool forcedWriteErrorTriggered = false;
 
     // Playback stopped at start of function
     m_transportPlaying.store(false, std::memory_order_relaxed); // Ensure redundant enforce
@@ -3131,6 +3135,11 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         // Write
         ma_uint64 framesWritten = 0;
         ma_result result = ma_encoder_write_pcm_frames(&encoder, floatBuffer.data(), framesThisBlock, &framesWritten);
+        if (forceWriteErrorForTests && !forcedWriteErrorTriggered) {
+            forcedWriteErrorTriggered = true;
+            result = MA_ERROR;
+            framesWritten = 0;
+        }
         if (result != MA_SUCCESS || framesWritten != framesThisBlock) {
             Aestra::Log::error("[AudioEngine] Write error during bounce: result=" + std::to_string(result) +
                                ", written=" + std::to_string(framesWritten));
@@ -3150,8 +3159,13 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
 
     if (writeError) {
         // Clean up partial file on write error
-        std::remove(outputPath.c_str());
-        Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
+        const int removeResult = std::remove(outputPath.c_str());
+        if (removeResult == 0) {
+            Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
+        } else {
+            Aestra::Log::error("[AudioEngine] Bounce failed — could not remove partial file: " + outputPath +
+                               " (errno=" + std::to_string(errno) + ")");
+        }
         return false;
     }
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3167,7 +3167,12 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
 
     if (writeError) {
         // Clean up partial file on write error
+#ifdef _WIN32
+        std::wstring widePath = pathStringToWide(outputPath);
+        const int removeResult = _wremove(widePath.c_str());
+#else
         const int removeResult = std::remove(outputPath.c_str());
+#endif
         const int removeErrno = errno;
         if (removeResult == 0) {
             Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3014,6 +3014,7 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
 bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::string& outputPath, int32_t trackId) {
     if (endBeat <= startBeat)
         return false;
+    m_lastBounceWroteAnyFramesForTests.store(false, std::memory_order_relaxed);
 
     // 1. Calculate length
     double sampleRate = (double)m_sampleRate.load(std::memory_order_relaxed);
@@ -3060,6 +3061,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     bool writeError = false;
     const bool forceWriteErrorForTests = m_forceBounceWriteErrorForTests.load(std::memory_order_relaxed);
     bool forcedWriteErrorTriggered = false;
+    bool wroteAnyFrames = false;
 
     // Playback stopped at start of function
     m_transportPlaying.store(false, std::memory_order_relaxed); // Ensure redundant enforce
@@ -3134,7 +3136,10 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         // Write
         ma_uint64 framesWritten = 0;
         ma_result result = ma_encoder_write_pcm_frames(&encoder, floatBuffer.data(), framesThisBlock, &framesWritten);
-        if (forceWriteErrorForTests && !forcedWriteErrorTriggered) {
+        if (result == MA_SUCCESS && framesWritten == framesThisBlock) {
+            wroteAnyFrames = true;
+        }
+        if (forceWriteErrorForTests && wroteAnyFrames && !forcedWriteErrorTriggered) {
             forcedWriteErrorTriggered = true;
             result = MA_ERROR;
             framesWritten = 0;
@@ -3151,6 +3156,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     }
 
     ma_encoder_uninit(&encoder);
+    m_lastBounceWroteAnyFramesForTests.store(wroteAnyFrames, std::memory_order_relaxed);
 
     // Restore playback state
     if (wasPlaying)
@@ -3159,11 +3165,12 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     if (writeError) {
         // Clean up partial file on write error
         const int removeResult = std::remove(outputPath.c_str());
+        const int removeErrno = (removeResult != 0) ? errno : 0;
         if (removeResult == 0) {
             Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
         } else {
             Aestra::Log::error("[AudioEngine] Bounce failed — could not remove partial file: " + outputPath +
-                               " (errno=" + std::to_string(errno) + ")");
+                               " (errno=" + std::to_string(removeErrno) + ")");
         }
         return false;
     }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3137,6 +3137,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         ma_uint64 framesWritten = 0;
         ma_result result = MA_ERROR;
         if (forceWriteErrorForTests && wroteAnyFrames && !forcedWriteErrorTriggered) {
+            // Test hook: deterministically fail after one successful write block.
             forcedWriteErrorTriggered = true;
             result = MA_ERROR;
             framesWritten = 0;
@@ -3167,10 +3168,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     if (writeError) {
         // Clean up partial file on write error
         const int removeResult = std::remove(outputPath.c_str());
-        int removeErrno = 0;
-        if (removeResult != 0) {
-            removeErrno = errno;
-        }
+        const int removeErrno = errno;
         if (removeResult == 0) {
             Aestra::Log::error("[AudioEngine] Bounce failed — partial file removed: " + outputPath);
         } else {

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -459,10 +459,6 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
 }
 
 void runBounceWriteFailureCleanupScenario(const std::filesystem::path& tempRoot) {
-#if defined(_WIN32)
-    (void)tempRoot;
-    std::cout << "[INFO] Bounce write-failure cleanup scenario skipped on Windows\n";
-#else
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(kSampleRate));
     tm->getPlaylistModel().setBPM(kBpm);
@@ -490,10 +486,11 @@ void runBounceWriteFailureCleanupScenario(const std::filesystem::path& tempRoot)
     engine.setForceBounceWriteErrorForTests(false);
 
     require(!bounced, "bounceRangeToWav should fail when encoder write fails");
+    require(engine.didLastBounceWriteAnyFramesForTests(),
+            "Write-error scenario should fail only after at least one block was written");
     require(!std::filesystem::exists(outputPath), "Bounce output path should be removed after write failure");
 
     std::cout << "[INFO] Bounce write-failure cleanup scenario passed\n";
-#endif
 }
 } // namespace
 

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -457,6 +457,44 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
     std::cout << "[INFO] Bounce: full peak=" << fullPeak << " iso0 peak=" << iso0Peak
               << " iso1 peak=" << iso1Peak << "\n";
 }
+
+void runBounceWriteFailureCleanupScenario(const std::filesystem::path& tempRoot) {
+#if defined(_WIN32)
+    (void)tempRoot;
+    std::cout << "[INFO] Bounce write-failure cleanup scenario skipped on Windows\n";
+#else
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+    tm->getPlaylistModel().setBPM(kBpm);
+
+    AudioEngine engine;
+    require(engine.initialize(), "AudioEngine initialize failed in write-error scenario");
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockSize, kChannels);
+    engine.setTrackManager(tm);
+    engine.setBPM(static_cast<float>(kBpm));
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+    engine.setUnitManager(&tm->getUnitManager());
+    engine.setPatternPlaybackEngine(&tm->getPatternPlaybackEngine());
+    engine.setPatternPlaybackMode(true, kRenderBeats);
+    engine.setGlobalSamplePos(0);
+    engine.setMetronomeEnabled(false);
+    engine.setAuditionModeEnabled(false);
+
+    const std::filesystem::path outputPath = tempRoot / "bounce_write_error_cleanup.wav";
+    std::error_code ec;
+    std::filesystem::remove(outputPath, ec);
+    require(setenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR", "1", 1) == 0, "Failed to set bounce write-error test env");
+
+    const bool bounced = engine.bounceRangeToWav(0.0, kRenderBeats, outputPath.string(), -1);
+    unsetenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR");
+
+    require(!bounced, "bounceRangeToWav should fail when encoder write fails");
+    require(!std::filesystem::exists(outputPath), "Bounce output path should be removed after write failure");
+
+    std::cout << "[INFO] Bounce write-failure cleanup scenario passed\n";
+#endif
+}
 } // namespace
 
 int main() {
@@ -495,6 +533,9 @@ int main() {
     // correct output for the selected track and excludes non-selected paths.
     std::cout << "[INFO] Case 5: Isolated-track bounce (full vs isolated)\n";
     runIsolatedBounceScenario(tempRoot);
+
+    std::cout << "[INFO] Case 6: Write-failure cleanup (false return + partial file cleanup)\n";
+    runBounceWriteFailureCleanupScenario(tempRoot);
 
     std::cout << "[PASS] ArsenalExportLiveParityTest\n";
     return 0;

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -484,10 +484,10 @@ void runBounceWriteFailureCleanupScenario(const std::filesystem::path& tempRoot)
     const std::filesystem::path outputPath = tempRoot / "bounce_write_error_cleanup.wav";
     std::error_code ec;
     std::filesystem::remove(outputPath, ec);
-    require(setenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR", "1", 1) == 0, "Failed to set bounce write-error test env");
+    engine.setForceBounceWriteErrorForTests(true);
 
     const bool bounced = engine.bounceRangeToWav(0.0, kRenderBeats, outputPath.string(), -1);
-    unsetenv("AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR");
+    engine.setForceBounceWriteErrorForTests(false);
 
     require(!bounced, "bounceRangeToWav should fail when encoder write fails");
     require(!std::filesystem::exists(outputPath), "Bounce output path should be removed after write failure");


### PR DESCRIPTION
## Summary

`bounceRangeToWav` now tracks write errors, returns `false` on failure, and removes partial output files.

## Why

Previously the function returned `true` even after a write error (disk full, permission denied), leaving a partial/corrupt WAV file on disk with no indication of failure.

## Testing performed
- Code review of error path
- Verified partial file cleanup on write error
- Verified playback state restoration on both success and failure

## Docs updated?
No

## Risk/rollback notes
- Low risk: only changes error handling behavior
- Rollback: revert commit if bounce behavior regressions found

Fixes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

- **bounceRangeToWav now properly tracks and handles write errors**: The function detects when PCM writes fail during the render/export loop and sets a `writeError` flag to mark the operation as failed.

- **Returns correct failure status**: Returns `false` to callers when a write error occurs, preventing truncated or corrupted exports from being treated as successful bounces.

- **Cleans up partial files on failure**: When a write error is detected, the function attempts to delete any partially written output WAV file using `std::remove()`, logging whether the cleanup succeeded and any error codes (`errno`) if the deletion fails.

- **Added test coverage for write error handling**: New test case (`ArsenalExportLiveParityTest.cpp`) forces a bounce write failure via the `AESTRA_TEST_FORCE_BOUNCE_WRITE_ERROR` environment variable and verifies that:
  - The function returns `false` (failure signal)
  - The partial output file is removed from disk

## Why

Fixes issue `#195` — prevents silent data corruption by ensuring that when `bounceRangeToWav` encounters write errors (disk full, permission denied, I/O errors), the operation fails cleanly instead of reporting success and leaving corrupt files on disk. Callers can now reliably detect bounce failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->