### PR TITLE
fix: add bounds check to MidiBuffer::getEvent() to prevent OOB read

### DIFF
--- a/AestraAudio/include/Plugin/PluginHost.h
+++ b/AestraAudio/include/Plugin/PluginHost.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -372,7 +373,10 @@ public:
         size_t count = m_eventCount.load(std::memory_order_acquire);
         return count > kMaxEvents ? kMaxEvents : count;
     }
-    const Event& getEvent(size_t index) const { return m_events[index]; }
+    const Event& getEvent(size_t index) const {
+        assert(index < kMaxEvents);
+        return m_events[index];
+    }
 
     /**
      * @brief Helper to add a Note On event


### PR DESCRIPTION
## Summary

Adds `assert(index < kMaxEvents)` to `MidiBuffer::getEvent()` to prevent out-of-bounds array access.

## Why

The method had no bounds validation. If a caller passes `index >= kMaxEvents` (1024), this is an out-of-bounds read on the fixed array `m_events[1024]`.

## Testing performed
- Code review of MidiBuffer usage
- Verified assert catches OOB access in debug builds

## Docs updated?
No

## Risk/rollback notes
- Low risk: adds defensive assertion
- Rollback: revert commit if assertion triggers in valid usage

Fixes #199