### PR TITLE
fix: run gitleaks secret scanning on pull requests

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,6 +3,8 @@ name: Gitleaks
 on:
   push:
     branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary

Adds `pull_request` trigger to gitleaks workflow so secret scanning runs on PRs to main/develop.

## Why

Previously gitleaks only ran on push to main/develop, allowing secrets to be introduced in PRs without detection until after merge.

## Testing performed
- Workflow syntax validated
- Verified PR trigger added for main and develop branches

## Docs updated?
No

## Risk/rollback notes
- No risk: only adds CI trigger
- Rollback: revert commit if needed

Fixes #209