### PR TITLE
fix: consolidate duplicate TransportAction enum into shared TransportTypes.h

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -752,17 +752,16 @@ void AestraApp::setupCallbacks() {
         startExport();
     });
 
-    m_windowManager->setTransportCallback([this](AestraWindowManager::TransportAction action) {
+    m_windowManager->setTransportCallback([this](Aestra::TransportAction action) {
         if (!m_content) return;
-        using Action = AestraWindowManager::TransportAction;
 
-        if (action == Action::Play) {
+        if (action == Aestra::TransportAction::Play) {
             m_content->requestTransportPlay();
         }
-        else if (action == Action::Pause) {
+        else if (action == Aestra::TransportAction::Pause) {
             m_content->pauseFromCurrentFocus();
         }
-        else if (action == Action::Stop) {
+        else if (action == Aestra::TransportAction::Stop) {
             m_content->stopFromCurrentFocus(false);
         }
     });

--- a/Source/Core/AestraRootComponent.h
+++ b/Source/Core/AestraRootComponent.h
@@ -6,6 +6,7 @@
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "SettingsDialog.h"
 #include "UnifiedHUD.h"
+#include "TransportTypes.h"
 #include "../AestraPlat/include/AestraPlatform.h"
 #if defined(AESTRA_HAS_LICENSE_GATE) && AESTRA_HAS_LICENSE_GATE
 #include "AccountSession.h"
@@ -25,7 +26,7 @@ class AestraContent;
  */
 class AestraRootComponent : public NUIComponent {
 public:
-    enum class TransportAction { Stop, Play, Pause };
+    using TransportAction = Aestra::TransportAction;
 
 private:
     std::shared_ptr<NUICustomWindow> m_rootCustomWindow;

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -391,21 +391,9 @@ bool AestraWindowManager::processEvents() {
 void AestraWindowManager::setTransportCallback(std::function<void(TransportAction)> cb) {
     m_transportCallback = std::move(cb);
     if (m_rootComponent) {
-        m_rootComponent->setTransportCallback([this](AestraRootComponent::TransportAction action) {
-            if (!m_transportCallback) {
-                return;
-            }
-
-            switch (action) {
-                case AestraRootComponent::TransportAction::Play:
-                    m_transportCallback(TransportAction::Play);
-                    break;
-                case AestraRootComponent::TransportAction::Pause:
-                    m_transportCallback(TransportAction::Pause);
-                    break;
-                case AestraRootComponent::TransportAction::Stop:
-                    m_transportCallback(TransportAction::Stop);
-                    break;
+        m_rootComponent->setTransportCallback([this](TransportAction action) {
+            if (m_transportCallback) {
+                m_transportCallback(action);
             }
         });
     }
@@ -416,22 +404,8 @@ void AestraWindowManager::setContent(std::shared_ptr<AestraContent> content) {
     if (m_rootComponent) {
         m_rootComponent->setContent(m_content.get());
         if (m_transportCallback) {
-            m_rootComponent->setTransportCallback([this](AestraRootComponent::TransportAction action) {
-                if (!m_transportCallback) {
-                    return;
-                }
-
-                switch (action) {
-                    case AestraRootComponent::TransportAction::Play:
-                        m_transportCallback(TransportAction::Play);
-                        break;
-                    case AestraRootComponent::TransportAction::Pause:
-                        m_transportCallback(TransportAction::Pause);
-                        break;
-                    case AestraRootComponent::TransportAction::Stop:
-                        m_transportCallback(TransportAction::Stop);
-                        break;
-                }
+            m_rootComponent->setTransportCallback([this](TransportAction action) {
+                m_transportCallback(action);
             });
         }
     }

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -15,6 +15,7 @@
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "NUIMenuBar.h"
 #include "NUIContextMenu.h"
+#include "TransportTypes.h"
 
 // Forward declarations
 namespace Aestra {
@@ -44,7 +45,7 @@ public:
         bool fullscreen;
     };
 
-    enum class TransportAction { Stop, Play, Pause };
+    using TransportAction = Aestra::TransportAction;
 
     /** @brief Initialize the window, renderer, and root component. */
     bool initialize(const WindowConfig& config);

--- a/Source/Core/TransportTypes.h
+++ b/Source/Core/TransportTypes.h
@@ -1,0 +1,9 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+namespace Aestra {
+
+/// Transport control actions shared across UI and window management layers.
+enum class TransportAction { Stop, Play, Pause };
+
+} // namespace Aestra


### PR DESCRIPTION
## Summary

Creates a shared `TransportTypes.h` with `Aestra::TransportAction` and removes duplicate definitions from `AestraRootComponent.h` and `AestraWindowManager.h`.

## Why

The same enum was defined in two different headers, risking ODR violations and requiring redundant switch statements to translate between identical types.

## Testing performed
- Code review of all TransportAction usage
- Verified both classes now alias to shared enum
- Verified translation layer in AestraWindowManager.cpp eliminated

## Docs updated?
No

## Risk/rollback notes
- Low risk: refactoring only, no behavioral change
- Rollback: revert commit if compilation issues arise

Fixes #208