### PR TITLE
fix: check loadState() return value in EffectChain and UnitManager

### DIFF
--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -710,7 +710,10 @@ void UnitManager::loadFromJSON(const JSON& json) {
                 // Load state BEFORE activation to ensure plugin is ready before processing audio.
                 // This matches EffectChain lifecycle: create -> initialize -> loadState -> activate.
                 if (!unit.pluginState.empty()) {
-                    unit.plugin->loadState(unit.pluginState);
+                    if (!unit.plugin->loadState(unit.pluginState)) {
+                        Aestra::Log::warning("[UnitManager] Failed to load state for unit " +
+                                             std::to_string(unit.id) + " — using default state");
+                    }
                 }
 
                 if (unit.enabled || unit.isEnabled) {

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -612,7 +612,10 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
         auto instance = manager.createInstanceById(pluginId);
         if (instance) {
             instance->initialize(m_sampleRate, m_maxBlockSize);
-            instance->loadState(pluginState);
+            if (!instance->loadState(pluginState)) {
+                Aestra::Log::warning("[EffectChain] Failed to load state for plugin slot " +
+                                     std::to_string(i) + " — using default state");
+            }
             instance->activate();
 
             m_slots[i].plugin = std::move(instance);


### PR DESCRIPTION
## Summary

Adds return value checking for `loadState()` calls in `EffectChain` and `UnitManager`. Logs a warning and continues with default state when loading fails.

## Why

Previously `loadState()` return value was ignored, allowing plugins with corrupt or incompatible state to be activated and added to the chain.

## Testing performed
- Code review of loadState usage
- Verified warning logged on failure
- Verified plugin still activated with default state on load failure

## Docs updated?
No

## Risk/rollback notes
- Low risk: only adds error logging, no behavioral change for successful loads
- Rollback: revert commit if warning spam occurs

Fixes #198