### PR TITLE
fix: address review findings for CommandRegistry parse safety

### DIFF
--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -43,8 +43,11 @@ std::optional<std::string_view> requireFlag(const std::unordered_map<std::string
 }
 
 // Safe parsing helpers that return std::nullopt on malformed input
+// Reject leading/trailing whitespace, non-finite floats, and negative unsigned strings
 std::optional<int> safeStoi(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     try {
         size_t pos = 0;
         int val = std::stoi(std::string(s), &pos);
@@ -57,6 +60,8 @@ std::optional<int> safeStoi(std::string_view s) {
 
 std::optional<float> safeStof(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     try {
         size_t pos = 0;
         float val = std::stof(std::string(s), &pos);
@@ -70,6 +75,8 @@ std::optional<float> safeStof(std::string_view s) {
 
 std::optional<unsigned long long> safeStoull(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     if (s.front() == '-') return std::nullopt;
     try {
         size_t pos = 0;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -17,6 +17,7 @@
 
 #include <cctype>
 #include <cmath>
+#include <exception>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -16,6 +16,7 @@
 #include "AestraUUID.h"
 
 #include <cctype>
+#include <optional>
 #include <string>
 
 namespace Aestra {
@@ -31,6 +32,47 @@ bool parseFlagBool(const std::string& s) {
         lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
     }
     return lower == "true" || lower == "1" || lower == "yes";
+}
+
+// Safe parsing helpers that return std::nullopt on malformed input
+std::optional<int> safeStoi(const std::string& s) {
+    try {
+        size_t pos = 0;
+        int val = std::stoi(s, &pos);
+        if (pos != s.size()) return std::nullopt; // trailing characters
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> safeStof(const std::string& s) {
+    try {
+        size_t pos = 0;
+        float val = std::stof(s, &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<unsigned long long> safeStoull(const std::string& s) {
+    try {
+        size_t pos = 0;
+        unsigned long long val = std::stoull(s, &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+// Helper to safely get a flag value, returns nullopt if missing
+std::optional<std::string> getFlag(const std::unordered_map<std::string, std::string>& flags, const char* key) {
+    auto it = flags.find(key);
+    if (it == flags.end()) return std::nullopt;
+    return it->second;
 }
 
 AudioEngine* s_audioEngine = nullptr;
@@ -71,8 +113,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     reg.registerCommand("set_bpm", [](const auto& flags) -> std::unique_ptr<ICommand> {
         AudioEngine* engine = getAudioEngine();
         if (!engine) return nullptr;
-        float value = std::stof(flags.at("value"));
-        return std::make_unique<SetBpmCommand>(*engine, value);
+        auto valueOpt = safeStof(flags.at("value"));
+        if (!valueOpt) return nullptr;
+        return std::make_unique<SetBpmCommand>(*engine, *valueOpt);
     });
 
     reg.registerCommand("play", [](const auto&) -> std::unique_ptr<ICommand> {
@@ -113,65 +156,81 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     reg.registerCommand("delete_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
-        return std::make_unique<DeleteTrackCommand>(*tm, trackIndex);
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        return std::make_unique<DeleteTrackCommand>(*tm, *trackOpt);
     });
 
     reg.registerCommand("rename_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
-        return std::make_unique<RenameTrackCommand>(*tm, trackIndex, flags.at("name"));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        auto nameIt = flags.find("name");
+        if (nameIt == flags.end()) return nullptr;
+        return std::make_unique<RenameTrackCommand>(*tm, *trackOpt, nameIt->second);
     });
 
     reg.registerCommand("mute_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
         bool state = parseFlagBool(flags.at("state"));
-        MixerChannel* ch = tm->getChannel(static_cast<size_t>(trackIndex));
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetMuteCommand>(*ch, state);
     });
 
     reg.registerCommand("solo_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
         bool state = parseFlagBool(flags.at("state"));
-        MixerChannel* ch = tm->getChannel(static_cast<size_t>(trackIndex));
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetSoloCommand>(*ch, state);
     });
 
     reg.registerCommand("set_volume", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
-        float value = std::stof(flags.at("value"));
-        MixerChannel* ch = tm->getChannel(static_cast<size_t>(trackIndex));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        auto valueOpt = safeStof(flags.at("value"));
+        if (!valueOpt) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
-        return std::make_unique<SetVolumeCommand>(*ch, value);
+        return std::make_unique<SetVolumeCommand>(*ch, *valueOpt);
     });
 
     reg.registerCommand("set_pan", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        int trackIndex = std::stoi(flags.at("track"));
-        float value = std::stof(flags.at("value"));
-        MixerChannel* ch = tm->getChannel(static_cast<size_t>(trackIndex));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        auto valueOpt = safeStof(flags.at("value"));
+        if (!valueOpt) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
-        return std::make_unique<SetPanCommand>(*ch, value);
+        return std::make_unique<SetPanCommand>(*ch, *valueOpt);
     });
 
     // ===== Clip (5) =====
     reg.registerCommand("add_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        int trackIndex = std::stoi(flags.at("track"));
-        double bar = static_cast<double>(std::stoi(flags.at("bar")));
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        auto barOpt = safeStoi(flags.at("bar"));
+        if (!barOpt) return nullptr;
 
-        PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(trackIndex));
+        PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
         if (!laneId.isValid())
             return nullptr;
 
         ClipInstance clip;
-        clip.startBeat = (bar - 1) * 4.0;
+        clip.startBeat = (*barOpt - 1) * 4.0;
         clip.durationBeats = 4.0;
-        clip.name = flags.at("file");
+        auto fileIt = flags.find("file");
+        if (fileIt == flags.end()) return nullptr;
+        clip.name = fileIt->second;
 
-        auto it = flags.find("source");
-        if (it != flags.end()) {
-            clip.sourceId = std::stoull(it->second);
+        auto srcIt = flags.find("source");
+        if (srcIt != flags.end()) {
+            auto srcOpt = safeStoull(srcIt->second);
+            if (!srcOpt) return nullptr;
+            clip.sourceId = *srcOpt;
         }
 
         return std::make_unique<AddClipCommand>(*pm, laneId, clip);
@@ -179,43 +238,52 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
     reg.registerCommand("delete_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        int id = std::stoi(flags.at("id"));
+        auto idOpt = safeStoi(flags.at("id"));
+        if (!idOpt) return nullptr;
         ClipInstanceID clipId;
-        clipId.low = static_cast<uint64_t>(id);
+        clipId.low = static_cast<uint64_t>(*idOpt);
         return std::make_unique<RemoveClipCommand>(*pm, clipId);
     });
 
     reg.registerCommand("move_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        int id = std::stoi(flags.at("id"));
-        int trackIndex = std::stoi(flags.at("track"));
-        double start = static_cast<double>(std::stof(flags.at("start")));
+        auto idOpt = safeStoi(flags.at("id"));
+        if (!idOpt) return nullptr;
+        auto trackOpt = safeStoi(flags.at("track"));
+        if (!trackOpt) return nullptr;
+        auto startOpt = safeStof(flags.at("start"));
+        if (!startOpt) return nullptr;
 
         ClipInstanceID clipId;
-        clipId.low = static_cast<uint64_t>(id);
-        PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(trackIndex));
-        return std::make_unique<MoveClipCommand>(*pm, clipId, start, laneId);
+        clipId.low = static_cast<uint64_t>(*idOpt);
+        PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
+        return std::make_unique<MoveClipCommand>(*pm, clipId, *startOpt, laneId);
     });
 
     reg.registerCommand("duplicate_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        int id = std::stoi(flags.at("id"));
-        int bar = std::stoi(flags.at("bar"));
+        auto idOpt = safeStoi(flags.at("id"));
+        if (!idOpt) return nullptr;
+        auto barOpt = safeStoi(flags.at("bar"));
+        if (!barOpt) return nullptr;
 
         ClipInstanceID clipId;
-        clipId.low = static_cast<uint64_t>(id);
-        return std::make_unique<DuplicateClipCommand>(*pm, clipId, static_cast<double>(bar));
+        clipId.low = static_cast<uint64_t>(*idOpt);
+        return std::make_unique<DuplicateClipCommand>(*pm, clipId, static_cast<double>(*barOpt));
     });
 
     reg.registerCommand("trim_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        int id = std::stoi(flags.at("id"));
-        double start = static_cast<double>(std::stof(flags.at("start")));
-        double end = static_cast<double>(std::stof(flags.at("end")));
+        auto idOpt = safeStoi(flags.at("id"));
+        if (!idOpt) return nullptr;
+        auto startOpt = safeStof(flags.at("start"));
+        if (!startOpt) return nullptr;
+        auto endOpt = safeStof(flags.at("end"));
+        if (!endOpt) return nullptr;
 
         ClipInstanceID clipId;
-        clipId.low = static_cast<uint64_t>(id);
-        return std::make_unique<TrimClipCommand>(*pm, clipId, start, end);
+        clipId.low = static_cast<uint64_t>(*idOpt);
+        return std::make_unique<TrimClipCommand>(*pm, clipId, *startOpt, *endOpt);
     });
 }
 

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace Aestra {
 namespace Audio {
@@ -26,7 +27,7 @@ namespace Audio {
 namespace {
 // Mirror of CommandParser bool spellings — keep in sync with
 // CommandParser::convertAndValidateValue (FlagType::Bool).
-bool parseFlagBool(const std::string& s) {
+bool parseFlagBool(std::string_view s) {
     std::string lower;
     lower.reserve(s.size());
     for (char c : s) {
@@ -195,7 +196,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackOpt) return nullptr;
         auto stateRaw = requireFlag(flags, "state");
         if (!stateRaw) return nullptr;
-        bool state = parseFlagBool(std::string(*stateRaw));
+        bool state = parseFlagBool(*stateRaw);
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetMuteCommand>(*ch, state);
@@ -208,7 +209,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackOpt) return nullptr;
         auto stateRaw = requireFlag(flags, "state");
         if (!stateRaw) return nullptr;
-        bool state = parseFlagBool(std::string(*stateRaw));
+        bool state = parseFlagBool(*stateRaw);
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetSoloCommand>(*ch, state);

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -16,6 +16,7 @@
 #include "AestraUUID.h"
 
 #include <cctype>
+#include <cmath>
 #include <optional>
 #include <string>
 
@@ -34,45 +35,50 @@ bool parseFlagBool(const std::string& s) {
     return lower == "true" || lower == "1" || lower == "yes";
 }
 
-// Safe parsing helpers that return std::nullopt on malformed input
-std::optional<int> safeStoi(const std::string& s) {
-    try {
-        size_t pos = 0;
-        int val = std::stoi(s, &pos);
-        if (pos != s.size()) return std::nullopt; // trailing characters
-        return val;
-    } catch (const std::exception&) {
-        return std::nullopt;
-    }
-}
-
-std::optional<float> safeStof(const std::string& s) {
-    try {
-        size_t pos = 0;
-        float val = std::stof(s, &pos);
-        if (pos != s.size()) return std::nullopt;
-        return val;
-    } catch (const std::exception&) {
-        return std::nullopt;
-    }
-}
-
-std::optional<unsigned long long> safeStoull(const std::string& s) {
-    try {
-        size_t pos = 0;
-        unsigned long long val = std::stoull(s, &pos);
-        if (pos != s.size()) return std::nullopt;
-        return val;
-    } catch (const std::exception&) {
-        return std::nullopt;
-    }
-}
-
-// Helper to safely get a flag value, returns nullopt if missing
-std::optional<std::string> getFlag(const std::unordered_map<std::string, std::string>& flags, const char* key) {
+// Safe flag lookup — returns nullopt if key is missing
+std::optional<std::string_view> requireFlag(const std::unordered_map<std::string, std::string>& flags, const char* key) {
     auto it = flags.find(key);
     if (it == flags.end()) return std::nullopt;
     return it->second;
+}
+
+// Safe parsing helpers that return std::nullopt on malformed input
+std::optional<int> safeStoi(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    try {
+        size_t pos = 0;
+        int val = std::stoi(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> safeStof(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    try {
+        size_t pos = 0;
+        float val = std::stof(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        if (!std::isfinite(val)) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<unsigned long long> safeStoull(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    if (s.front() == '-') return std::nullopt;
+    try {
+        size_t pos = 0;
+        unsigned long long val = std::stoull(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
 }
 
 AudioEngine* s_audioEngine = nullptr;
@@ -113,7 +119,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     reg.registerCommand("set_bpm", [](const auto& flags) -> std::unique_ptr<ICommand> {
         AudioEngine* engine = getAudioEngine();
         if (!engine) return nullptr;
-        auto valueOpt = safeStof(flags.at("value"));
+        auto valueRaw = requireFlag(flags, "value");
+        if (!valueRaw) return nullptr;
+        auto valueOpt = safeStof(*valueRaw);
         if (!valueOpt) return nullptr;
         return std::make_unique<SetBpmCommand>(*engine, *valueOpt);
     });
@@ -156,13 +164,17 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     reg.registerCommand("delete_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
         return std::make_unique<DeleteTrackCommand>(*tm, *trackOpt);
     });
 
     reg.registerCommand("rename_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
         auto nameIt = flags.find("name");
         if (nameIt == flags.end()) return nullptr;
@@ -170,27 +182,39 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     reg.registerCommand("mute_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        bool state = parseFlagBool(flags.at("state"));
+        auto stateRaw = requireFlag(flags, "state");
+        if (!stateRaw) return nullptr;
+        bool state = parseFlagBool(std::string(*stateRaw));
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetMuteCommand>(*ch, state);
     });
 
     reg.registerCommand("solo_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        bool state = parseFlagBool(flags.at("state"));
+        auto stateRaw = requireFlag(flags, "state");
+        if (!stateRaw) return nullptr;
+        bool state = parseFlagBool(std::string(*stateRaw));
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
         return std::make_unique<SetSoloCommand>(*ch, state);
     });
 
     reg.registerCommand("set_volume", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        auto valueOpt = safeStof(flags.at("value"));
+        auto valueRaw = requireFlag(flags, "value");
+        if (!valueRaw) return nullptr;
+        auto valueOpt = safeStof(*valueRaw);
         if (!valueOpt) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
@@ -198,9 +222,13 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     reg.registerCommand("set_pan", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        auto valueOpt = safeStof(flags.at("value"));
+        auto valueRaw = requireFlag(flags, "value");
+        if (!valueRaw) return nullptr;
+        auto valueOpt = safeStof(*valueRaw);
         if (!valueOpt) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return nullptr;
@@ -210,9 +238,13 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     // ===== Clip (5) =====
     reg.registerCommand("add_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        auto barOpt = safeStoi(flags.at("bar"));
+        auto barRaw = requireFlag(flags, "bar");
+        if (!barRaw) return nullptr;
+        auto barOpt = safeStoi(*barRaw);
         if (!barOpt) return nullptr;
 
         PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
@@ -238,7 +270,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
     reg.registerCommand("delete_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        auto idOpt = safeStoi(flags.at("id"));
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = safeStoi(*idRaw);
         if (!idOpt) return nullptr;
         ClipInstanceID clipId;
         clipId.low = static_cast<uint64_t>(*idOpt);
@@ -247,11 +281,17 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
     reg.registerCommand("move_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        auto idOpt = safeStoi(flags.at("id"));
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = safeStoi(*idRaw);
         if (!idOpt) return nullptr;
-        auto trackOpt = safeStoi(flags.at("track"));
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
-        auto startOpt = safeStof(flags.at("start"));
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return nullptr;
+        auto startOpt = safeStof(*startRaw);
         if (!startOpt) return nullptr;
 
         ClipInstanceID clipId;
@@ -262,9 +302,13 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
     reg.registerCommand("duplicate_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        auto idOpt = safeStoi(flags.at("id"));
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = safeStoi(*idRaw);
         if (!idOpt) return nullptr;
-        auto barOpt = safeStoi(flags.at("bar"));
+        auto barRaw = requireFlag(flags, "bar");
+        if (!barRaw) return nullptr;
+        auto barOpt = safeStoi(*barRaw);
         if (!barOpt) return nullptr;
 
         ClipInstanceID clipId;
@@ -274,11 +318,17 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
     reg.registerCommand("trim_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
         if (!pm) return nullptr;
-        auto idOpt = safeStoi(flags.at("id"));
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = safeStoi(*idRaw);
         if (!idOpt) return nullptr;
-        auto startOpt = safeStof(flags.at("start"));
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return nullptr;
+        auto startOpt = safeStof(*startRaw);
         if (!startOpt) return nullptr;
-        auto endOpt = safeStof(flags.at("end"));
+        auto endRaw = requireFlag(flags, "end");
+        if (!endRaw) return nullptr;
+        auto endOpt = safeStof(*endRaw);
         if (!endOpt) return nullptr;
 
         ClipInstanceID clipId;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1051,6 +1051,15 @@ target_include_directories(CommandTransactionTest PRIVATE
 add_test(NAME CommandTransactionTest COMMAND CommandTransactionTest)
 set_tests_properties(CommandTransactionTest PROPERTIES LABELS "commands;phase2")
 
+# CommandRegistry Parse Safety Test (regression for #197)
+add_executable(CommandRegistryParseSafetyTest Commands/CommandRegistryParseSafetyTest.cpp)
+target_include_directories(CommandRegistryParseSafetyTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME CommandRegistryParseSafetyTest COMMAND CommandRegistryParseSafetyTest)
+set_tests_properties(CommandRegistryParseSafetyTest PROPERTIES LABELS "commands;regression")
+
 # Rumble State Test (requires runtime plugin system)
 if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/RumbleStateTest.cpp")
     add_executable(RumbleStateTest Commands/RumbleStateTest.cpp)

--- a/Tests/Commands/CommandRegistryParseSafetyTest.cpp
+++ b/Tests/Commands/CommandRegistryParseSafetyTest.cpp
@@ -1,0 +1,179 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// CommandRegistry Parse Safety Tests
+// Tests: safeStoi, safeStof, safeStoull, requireFlag — malformed input handling
+
+#include <cmath>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+// Replicate the helpers from CommandRegistry.cpp for isolated testing
+namespace Aestra {
+namespace Audio {
+namespace {
+
+std::optional<std::string_view> requireFlag(const std::unordered_map<std::string, std::string>& flags, const char* key) {
+    auto it = flags.find(key);
+    if (it == flags.end()) return std::nullopt;
+    return it->second;
+}
+
+std::optional<int> safeStoi(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    try {
+        size_t pos = 0;
+        int val = std::stoi(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> safeStof(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    try {
+        size_t pos = 0;
+        float val = std::stof(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        if (!std::isfinite(val)) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<unsigned long long> safeStoull(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+    if (s.front() == '-') return std::nullopt;
+    try {
+        size_t pos = 0;
+        unsigned long long val = std::stoull(std::string(s), &pos);
+        if (pos != s.size()) return std::nullopt;
+        return val;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+} // namespace
+} // namespace Audio
+} // namespace Aestra
+
+#define TEST(name) std::cout << "  " << name << "... "; bool name()
+#define PASS() do { std::cout << "PASS" << std::endl; return true; } while(0)
+#define FAIL(msg) do { std::cout << "FAIL: " << msg << std::endl; return false; } while(0)
+
+using namespace Aestra::Audio;
+
+TEST(safeStoi_valid_integers) {
+    if (safeStoi("42") != 42) FAIL("basic");
+    if (safeStoi("-7") != -7) FAIL("negative");
+    if (safeStoi("0") != 0) FAIL("zero");
+    if (safeStoi("2147483647") != 2147483647) FAIL("INT_MAX");
+    if (safeStoi("-2147483648") != -2147483648) FAIL("INT_MIN");
+    PASS();
+}
+
+TEST(safeStoi_rejects_malformed) {
+    if (safeStoi("").has_value()) FAIL("empty");
+    if (safeStoi("abc").has_value()) FAIL("letters");
+    if (safeStoi("12.34").has_value()) FAIL("float");
+    if (safeStoi("42abc").has_value()) FAIL("trailing");
+    if (safeStoi(" 42").has_value()) FAIL("leading space");
+    if (safeStoi("42 ").has_value()) FAIL("trailing space");
+    PASS();
+}
+
+TEST(safeStof_valid_floats) {
+    auto v1 = safeStof("3.14");
+    if (!v1 || std::abs(*v1 - 3.14f) > 0.001f) FAIL("basic");
+    auto v2 = safeStof("-2.5");
+    if (!v2 || std::abs(*v2 - (-2.5f)) > 0.001f) FAIL("negative");
+    auto v3 = safeStof("0.0");
+    if (!v3 || *v3 != 0.0f) FAIL("zero");
+    auto v4 = safeStof("120");
+    if (!v4 || *v4 != 120.0f) FAIL("integer string");
+    PASS();
+}
+
+TEST(safeStof_rejects_malformed) {
+    if (safeStof("").has_value()) FAIL("empty");
+    if (safeStof("abc").has_value()) FAIL("letters");
+    if (safeStof("3.14abc").has_value()) FAIL("trailing");
+    if (safeStof(" 3.14").has_value()) FAIL("leading space");
+    PASS();
+}
+
+TEST(safeStof_rejects_nan_inf) {
+    if (safeStof("nan").has_value()) FAIL("nan");
+    if (safeStof("NaN").has_value()) FAIL("NaN mixed case");
+    if (safeStof("inf").has_value()) FAIL("inf");
+    if (safeStof("Inf").has_value()) FAIL("Inf mixed case");
+    if (safeStof("-inf").has_value()) FAIL("-inf");
+    if (safeStof("infinity").has_value()) FAIL("infinity");
+    PASS();
+}
+
+TEST(safeStoull_valid_unsigned) {
+    if (safeStoull("0") != 0ull) FAIL("zero");
+    if (safeStoull("42") != 42ull) FAIL("basic");
+    if (safeStoull("18446744073709551615") != 18446744073709551615ull) FAIL("ULLONG_MAX");
+    PASS();
+}
+
+TEST(safeStoull_rejects_negative) {
+    if (safeStoull("-1").has_value()) FAIL("-1");
+    if (safeStoull("-42").has_value()) FAIL("-42");
+    PASS();
+}
+
+TEST(safeStoull_rejects_malformed) {
+    if (safeStoull("").has_value()) FAIL("empty");
+    if (safeStoull("abc").has_value()) FAIL("letters");
+    if (safeStoull("42abc").has_value()) FAIL("trailing");
+    PASS();
+}
+
+TEST(requireFlag_finds_present) {
+    std::unordered_map<std::string, std::string> flags = {{"key", "value"}};
+    auto result = requireFlag(flags, "key");
+    if (!result) FAIL("missing result");
+    if (*result != "value") FAIL("wrong value");
+    PASS();
+}
+
+TEST(requireFlag_returns_nullopt_for_missing) {
+    std::unordered_map<std::string, std::string> flags = {{"key", "value"}};
+    if (requireFlag(flags, "missing").has_value()) FAIL("should be nullopt");
+    PASS();
+}
+
+int main() {
+    std::cout << "CommandRegistry Parse Safety Tests" << std::endl;
+    std::cout << "===================================" << std::endl;
+
+    int passed = 0, failed = 0;
+
+    auto run = [&](const char* name, bool (*fn)()) {
+        if (fn()) passed++; else failed++;
+    };
+
+    run("safeStoi_valid_integers", safeStoi_valid_integers);
+    run("safeStoi_rejects_malformed", safeStoi_rejects_malformed);
+    run("safeStof_valid_floats", safeStof_valid_floats);
+    run("safeStof_rejects_malformed", safeStof_rejects_malformed);
+    run("safeStof_rejects_nan_inf", safeStof_rejects_nan_inf);
+    run("safeStoull_valid_unsigned", safeStoull_valid_unsigned);
+    run("safeStoull_rejects_negative", safeStoull_rejects_negative);
+    run("safeStoull_rejects_malformed", safeStoull_rejects_malformed);
+    run("requireFlag_finds_present", requireFlag_finds_present);
+    run("requireFlag_returns_nullopt_for_missing", requireFlag_returns_nullopt_for_missing);
+
+    std::cout << std::endl;
+    std::cout << "Results: " << passed << " passed, " << failed << " failed" << std::endl;
+
+    return failed == 0 ? 0 : 1;
+}

--- a/Tests/Commands/CommandRegistryParseSafetyTest.cpp
+++ b/Tests/Commands/CommandRegistryParseSafetyTest.cpp
@@ -4,12 +4,16 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
-// Replicate the helpers from CommandRegistry.cpp for isolated testing
+// IMPORTANT: Keep these helpers in sync with CommandRegistry.cpp
+// Last synced: 2026-05-17 (PR #222)
+// If CommandRegistry.cpp helpers change, mirror those changes here.
+// (Consider extracting to a shared header if more tests need these.)
 namespace Aestra {
 namespace Audio {
 namespace {
@@ -22,6 +26,8 @@ std::optional<std::string_view> requireFlag(const std::unordered_map<std::string
 
 std::optional<int> safeStoi(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     try {
         size_t pos = 0;
         int val = std::stoi(std::string(s), &pos);
@@ -34,6 +40,8 @@ std::optional<int> safeStoi(std::string_view s) {
 
 std::optional<float> safeStof(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     try {
         size_t pos = 0;
         float val = std::stof(std::string(s), &pos);
@@ -47,6 +55,8 @@ std::optional<float> safeStof(std::string_view s) {
 
 std::optional<unsigned long long> safeStoull(std::string_view s) {
     if (s.empty()) return std::nullopt;
+    if (std::isspace(static_cast<unsigned char>(s.front())) ||
+        std::isspace(static_cast<unsigned char>(s.back()))) return std::nullopt;
     if (s.front() == '-') return std::nullopt;
     try {
         size_t pos = 0;
@@ -73,7 +83,7 @@ TEST(safeStoi_valid_integers) {
     if (safeStoi("-7") != -7) FAIL("negative");
     if (safeStoi("0") != 0) FAIL("zero");
     if (safeStoi("2147483647") != 2147483647) FAIL("INT_MAX");
-    if (safeStoi("-2147483648") != -2147483648) FAIL("INT_MIN");
+    if (safeStoi("-2147483648") != std::numeric_limits<int>::min()) FAIL("INT_MIN");
     PASS();
 }
 
@@ -104,6 +114,7 @@ TEST(safeStof_rejects_malformed) {
     if (safeStof("abc").has_value()) FAIL("letters");
     if (safeStof("3.14abc").has_value()) FAIL("trailing");
     if (safeStof(" 3.14").has_value()) FAIL("leading space");
+    if (safeStof("3.14 ").has_value()) FAIL("trailing space");
     PASS();
 }
 
@@ -127,6 +138,7 @@ TEST(safeStoull_valid_unsigned) {
 TEST(safeStoull_rejects_negative) {
     if (safeStoull("-1").has_value()) FAIL("-1");
     if (safeStoull("-42").has_value()) FAIL("-42");
+    if (safeStoull(" -1").has_value()) FAIL("leading space then minus");
     PASS();
 }
 
@@ -134,6 +146,8 @@ TEST(safeStoull_rejects_malformed) {
     if (safeStoull("").has_value()) FAIL("empty");
     if (safeStoull("abc").has_value()) FAIL("letters");
     if (safeStoull("42abc").has_value()) FAIL("trailing");
+    if (safeStoull(" 42").has_value()) FAIL("leading space");
+    if (safeStoull("42 ").has_value()) FAIL("trailing space");
     PASS();
 }
 

--- a/Tests/Commands/CommandRegistryParseSafetyTest.cpp
+++ b/Tests/Commands/CommandRegistryParseSafetyTest.cpp
@@ -72,8 +72,8 @@ std::optional<unsigned long long> safeStoull(std::string_view s) {
 } // namespace Audio
 } // namespace Aestra
 
-#define TEST(name) std::cout << "  " << name << "... "; bool name()
-#define PASS() do { std::cout << "PASS" << std::endl; return true; } while(0)
+#define TEST(name) bool name()
+#define PASS() return true
 #define FAIL(msg) do { std::cout << "FAIL: " << msg << std::endl; return false; } while(0)
 
 using namespace Aestra::Audio;
@@ -172,7 +172,13 @@ int main() {
     int passed = 0, failed = 0;
 
     auto run = [&](const char* name, bool (*fn)()) {
-        if (fn()) passed++; else failed++;
+        std::cout << "  " << name << "... ";
+        if (fn()) {
+            std::cout << "PASS" << std::endl;
+            passed++;
+        } else {
+            failed++;
+        }
     };
 
     run("safeStoi_valid_integers", safeStoi_valid_integers);


### PR DESCRIPTION
## Summary

Addresses all CodeRabbit/Copilot review findings on the original CommandRegistry parse safety PR (#214, already merged).

## Changes

### 1. Missing flag crash path (critical)
- All command factories now use `requireFlag()` before parsing
- Previously `flags.at()` was called BEFORE the safe parser, so missing keys still threw `std::out_of_range`

### 2. `safeStof` accepts NaN/Inf (critical)
- Now rejects `nan`, `NaN`, `inf`, `Inf`, `-inf`, `infinity`
- Previously these would pass through and poison audio state

### 3. `safeStoull` accepts negative strings
- Now rejects strings starting with `-` (e.g. `"-1"` wraps to ULLONG_MAX)

### 4. Dead code removal
- Removed unused `getFlag()` helper

### 5. Regression tests
- Added `CommandRegistryParseSafetyTest.cpp` covering all parse helpers

## Testing performed
- All CI checks pass (Linux, Windows, macOS, sanitizers, clang-tidy)
- New test executable validates all parse helper edge cases

## Docs updated?
No

## Risk/rollback notes
- Low risk: purely defensive changes
- Rollback: revert commit if any command parsing regressions found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CommandRegistry parse safety improvements

**Key changes:**

- **Added safe parsing helpers** (`requireFlag()`, `safeStoi()`, `safeStof()`, `safeStoull()`) in CommandRegistry.cpp to prevent crashes from missing flags and malformed input
  - `requireFlag()` safely returns `std::nullopt` for missing keys (prevents `std::out_of_range` from `.at()` calls)
  - `safeStof()` explicitly rejects non-finite floats (NaN, Inf, -Inf, infinity)
  - `safeStoull()` rejects negative strings to prevent unsigned integer wrapping

- **Updated all command factories** (15+ factories) to call `requireFlag()` before parsing, catching missing required flags early and returning nullptr on any parse failure

- **Removed dead code**: unused `getFlag()` helper

- **Added comprehensive regression test suite** in `Tests/Commands/CommandRegistryParseSafetyTest.cpp` covering:
  - Valid integer/float/unsigned inputs
  - Malformed inputs (empty strings, letters, trailing whitespace, non-numeric chars)
  - NaN/Inf rejection for float parser
  - Negative string rejection for unsigned parser
  - `requireFlag()` nullopt behavior for missing keys

**Risk assessment:** Low—defensive changes with full test coverage and passing CI (Linux, Windows, macOS, sanitizers, clang-tidy)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->