### PR TITLE
ci: add -E test exclusion to macOS workflow (fixes #229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Test
         working-directory: build
-        run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml
+        run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
 
       - name: Upload test report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,9 @@ jobs:
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
 
+      - name: License verification tests
+        run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
+
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add `-E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"` to macOS ctest invocation, matching Linux and Windows
- Add license verification tests step (`SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening`) to macOS, matching Linux and Windows

## Why
macOS CI was missing both the flaky test exclusion pattern and the license verification step that Linux and Windows already had. This caused macOS CI to fail on `SecOutOfProcessPluginHost` (flaky) and skip license hardening checks.

Fixes #229

## Test plan
- [x] macOS CI passes on this PR
- [x] License verification tests run on macOS
- [x] Linux/Windows CI unaffected

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)