### PR TITLE
docs: add philosophy.md root vision document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ It is intentionally strict. Aestra is a native C++ DAW with real-time audio cons
 
 Read this file before making changes.
 
+## Philosophy
+
+Before working on Aestra, read [`philosophy.md`](philosophy.md). It defines the product vision, the people we build for, and the engineering values that underpin every decision here. When this policy and philosophy conflict on direction, philosophy wins. When this policy and philosophy conflict on safety, this policy wins.
+
 ---
 
 ## 1. Scope

--- a/philosophy.md
+++ b/philosophy.md
@@ -1,0 +1,261 @@
+# Aestra Philosophy
+`v1.0 — 2026-05-19`
+
+---
+
+## Core Belief
+
+A DAW is not merely software. It is a creative environment.
+
+The job of the environment is to reduce the distance between intention and sound.
+
+Everything that interrupts creative flow is friction. Friction compounds into fatigue. Fatigue kills experimentation. Experimentation is where art is born.
+
+Aestra exists to make creation feel immediate, stable, expressive, and emotionally alive.
+
+---
+
+## Who We Build For
+
+The producer on a 4 GB RAM laptop. The artist working late in a city where music gear costs a month's salary. The person who has real ideas and no margin for software that fights them.
+
+This is not a secondary consideration. It shapes every architectural decision, every default, every performance tradeoff. When we optimize for speed and efficiency, we are not chasing benchmarks — we are making the tool accessible to the people who need it most.
+
+Aestra does not assume elite hardware. Aestra does not assume a studio. Aestra assumes a person with something to say.
+
+---
+
+## The Three Pillars
+
+### 1. Sound First
+
+Audio integrity is sacred.
+
+The engine must feel trustworthy under pressure: stable timing, deterministic rendering, accurate latency behavior, responsive monitoring, predictable automation, realtime-safe execution, graceful degradation under load.
+
+Users should feel confidence when they press play. Not "technically acceptable." Confident.
+
+**We care about:**
+- Realtime correctness
+- Timing consistency
+- Low-latency responsiveness
+- Deterministic systems
+- Accurate compensation
+- Precision and stability under stress
+
+**We do not care about:**
+- Meaningless audio marketing
+- Fake analog mythology
+- Placebo DSP claims
+- Spec-sheet theater
+
+---
+
+### 2. Flow Above Features
+
+Creative momentum matters more than feature count.
+
+A fast incomplete idea is more valuable than a perfect interrupted one.
+
+The DAW should feel lightweight, immediate, predictable, frictionless, mentally compressible. The user should spend time creating, not managing software.
+
+**We care about:**
+- Startup speed
+- Iteration speed
+- Responsiveness
+- Intelligent defaults
+- Low cognitive load
+- Keyboard fluency
+- Discoverability
+- Fast recovery from mistakes
+
+**We do not care about:**
+- Feature bloat
+- Menu labyrinths
+- Modal overload
+- Legacy workflows preserved at the cost of coherence
+- Adding features without improving creation
+
+---
+
+### 3. Beauty With Purpose
+
+Visual design is cognitive design.
+
+Beauty is not decoration. Beauty shapes emotion, focus, fatigue, and trust. Aestra should feel calm, intentional, modern, cinematic, spatially coherent, emotionally inspiring. But visuals must never obstruct workflow.
+
+**We care about:**
+- Visual clarity
+- Motion with meaning
+- Hierarchy and readability
+- Emotional atmosphere
+- Smooth interaction
+- Tasteful animation
+- Coherent interaction language
+
+**We do not care about:**
+- Visual noise
+- Excessive skeuomorphism
+- Flashy motion for its own sake
+- Gamer UI
+- Clutter
+- Inconsistent interaction patterns
+
+---
+
+## On Trust
+
+Work should never disappear.
+
+Session loss is not a bug. It is a betrayal. The moment a producer loses an idea because software failed them, we have failed at the most fundamental level.
+
+A crash mid-session is not merely a stability issue — it is a violation of the creative contract between the tool and the person using it. Recovery from failure must be fast, automatic, and complete. Autosave, versioning, and state restoration are not features. They are obligations.
+
+The same principle extends to rendering: deterministic output means the export sounds like the session, every time, without surprises.
+
+**Session files must open correctly across versions, even if the UI or internals change. Backwards compatibility of project data is non-negotiable. Everything else may evolve.**
+
+UI, API, internal architecture, and workflow patterns can all change in service of coherence and improvement. The session file is the one contract that never breaks.
+
+---
+
+## Engineering Doctrine
+
+*This is the section agents should internalize most deeply.*
+
+### Realtime Safety Is Non-Negotiable
+
+No locks, allocations, blocking I/O, unpredictable waits, or hidden synchronization inside realtime audio paths.
+
+Realtime violations are architectural failures, not small issues.
+
+---
+
+### Third-Party Plugins Are Guests
+
+Aestra may isolate, disable, or warn about plugins that violate realtime safety or memory constraints. The host's integrity comes first.
+
+Third-party plugins operate outside our doctrine. We do not inherit their failures. When a plugin misbehaves, Aestra contains the damage — it does not propagate it to the session or the user.
+
+---
+
+### Performance Is a Feature
+
+Fast software changes behavior. Efficiency is not polish — efficiency is product design.
+
+Every subsystem should justify its memory usage, CPU usage, latency cost, and complexity cost. Optimization is accessibility. A tool that runs well on weak hardware is a tool more people can use.
+
+---
+
+### Complexity Must Earn Its Place
+
+Complexity is acceptable only when capability gained is substantial, workflow becomes meaningfully better, or architectural simplicity improves elsewhere.
+
+No subsystem should become complicated merely because it is technically interesting.
+
+---
+
+### Defaults Matter More Than Options
+
+Good defaults reduce decision fatigue. Aestra should guide users toward successful outcomes without overwhelming them with configuration.
+
+Configuration exists to empower edge cases, not to replace design clarity.
+
+Complex workflows should be expressible via direct manipulation — drag-and-drop, keyboard modifiers, inspector panels — before adding preference dialogs. Prefer progressive disclosure over "advanced" tabs. Power users deserve a path; that path should never be a buried settings screen.
+
+---
+
+### Portability Matters
+
+Creativity should not require elite hardware. Aestra must scale gracefully across laptops, weaker CPUs, low-memory systems, and varied OS conditions.
+
+Optimization is not a performance luxury. Optimization is how we make the tool available to more of the world.
+
+---
+
+## Anti-Values
+
+These exist because drift is subtle. Every bad DAW was built by people who thought they were making reasonable tradeoffs.
+
+Aestra must never become:
+- Bloated
+- Sluggish
+- Visually chaotic
+- Enterprise-feeling
+- Menu-driven
+- Emotionally sterile
+- Hostile to beginners
+- Unstable under pressure
+- Creatively interruptive
+
+---
+
+## UX Philosophy
+
+Every interaction should answer:
+
+1. Is this faster?
+2. Is this clearer?
+3. Does this preserve flow?
+4. Would a musician understand this instinctively?
+5. Is the system behavior predictable?
+6. Is this worth the cognitive load it introduces?
+
+If any answer is no, the interaction needs to change.
+
+---
+
+## On Muse
+
+Muse is the AI layer inside Aestra. It assists — it does not redirect.
+
+Muse exists to reduce friction: to surface the right control, complete the tedious step, translate an idea into action. It does not impose creative direction. It does not interrupt. It does not require the user to think in AI terms.
+
+The measure of Muse is not capability. The measure of Muse is invisibility — whether the user felt helped or handled.
+
+**Non-negotiable rules:**
+- No modal AI dialogs.
+- No "AI mode" toggle.
+- Every suggestion can be dismissed with a single keystroke or click, and the system remembers that preference per context.
+
+---
+
+## AI Agent Doctrine
+
+*For agents contributing to Aestra.*
+
+Agents should:
+- Prioritize realtime safety above all else
+- Prefer architectural clarity over hacks
+- Preserve workflow simplicity
+- Reduce cognitive load wherever possible
+- Avoid unnecessary abstraction
+- Prefer deterministic behavior
+- Optimize for responsiveness
+- Reject feature bloat
+- Question any addition that conflicts with this document
+
+Agents should explicitly flag:
+- RT violations
+- Unnecessary allocations
+- Lock contention
+- UX inconsistency
+- Visual clutter
+- Architectural drift
+- Configuration overload
+- Hidden complexity
+- Non-coherent interaction patterns
+
+When in doubt: does this serve the producer on a 4 GB laptop at midnight trying to finish something? If not, reconsider.
+
+---
+
+## Changelog
+
+| Version | Date | Notes |
+|---------|------|-------|
+| 1.0 | 2026-05-19 | Initial release |
+
+---
+
+*This document is the root. When requirements conflict, return here.*


### PR DESCRIPTION
## Summary
- Add `philosophy.md` — the root vision document for Aestra covering core belief, the three pillars (Sound First, Flow Above Features, Beauty With Purpose), trust model, engineering doctrine, anti-values, UX philosophy, Muse rules, and AI agent doctrine
- Update `AGENTS.md` with a Philosophy section directing agents to read `philosophy.md` before working, with a clear conflict-resolution rule: philosophy governs direction, policy governs safety

## Test plan
- [ ] Verify `philosophy.md` renders correctly on GitHub
- [ ] Verify link in `AGENTS.md` resolves to `philosophy.md`
- [ ] Review content for accuracy against product vision

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Added `philosophy.md`** — A comprehensive root vision document establishing Aestra's creative and engineering principles:
  - Defines core belief: "A DAW is a creative environment"
  - Establishes "Three Pillars": Sound First, Flow Above Features, Beauty With Purpose
  - Documents trust model, session-file guarantees, and realtime-safety doctrine
  - Specifies explicit anti-values and UX decision framework
  - Provides guidance for AI agents and the Muse (AI layer) with non-negotiable rules

- **Updated `AGENTS.md`** — Added Philosophy section directing AI agents to read and follow `philosophy.md` before contributing, with a clear precedent rule: philosophy governs direction and safety when conflicts arise

**Why:** Establishes a documented foundation for product vision and AI agent behavior, ensuring all contributors (human and AI) operate from shared principles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of repo hygiene mega-pass — establishes the root vision document referenced by AGENTS.md.