### PR TITLE
fix: add missing AestraLog.h include in EffectChain.cpp

### DIFF
--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -2,6 +2,7 @@
 
 #include "PluginManager.h"
 #include "RealtimeThreadGuard.h"
+#include "AestraLog.h"
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
## Summary
- Add missing `#include "AestraLog.h"` to `EffectChain.cpp` to fix MSVC build error C2039: 'Log' is not a member of 'Aestra'

## Test plan
- [x] Verify MSVC CI build passes
- [x] Verify GCC/Clang builds still pass

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added missing `#include "AestraLog.h"` to `EffectChain.cpp` to resolve MSVC build error C2039 (Log not a member of Aestra namespace)
- No other logic or behavioral changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes EffectChain.cpp missing AestraLog.h include — pre-existing CI failure.