### PR TITLE
docs: add versioning/tagging policy and nightly build workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: nightly-${{ github.run_id }}
+  group: nightly-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -14,6 +14,9 @@ jobs:
     name: Nightly Headless Build & Test (ASan+UBSan)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,73 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 23 * * *' # 2:00 AM EAT (UTC+3)
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  nightly-headless:
+    name: Nightly Headless Build & Test (ASan+UBSan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y cmake ninja-build libgl1-mesa-dev libasound2-dev \
+            libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libsodium-dev \
+            libsecret-1-dev libgtest-dev
+
+      - name: Configure (headless, ASan+UBSan)
+        run: |
+          cmake -S . -B build-nightly \
+            -G Ninja \
+            -DAestra_CORE_MODE=ON \
+            -DAESTRA_HEADLESS_ONLY=ON \
+            -DAESTRA_ENABLE_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
+
+      - name: Build
+        run: cmake --build build-nightly --parallel
+
+      - name: Test
+        run: ctest --test-dir build-nightly --output-on-failure
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-linux-${{ github.run_id }}
+          path: build-nightly/
+          retention-days: 7
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Nightly] Build or test failure — ${date}`,
+              labels: ['nightly-failure', 'ci'],
+              body: [
+                `Nightly build failed on \`develop\`.\n`,
+                `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `**Commit:** ${context.sha}`,
+                `**Date:** ${date}`,
+                ``,
+                `Investigate the failing run and resolve before closing this issue.`
+              ].join('\n')
+            });

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,11 +17,15 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
 
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+          ref: develop
 
       - name: Install dependencies
         run: |
@@ -37,14 +41,16 @@ jobs:
             -DAestra_CORE_MODE=ON \
             -DAESTRA_HEADLESS_ONLY=ON \
             -DAESTRA_ENABLE_TESTS=ON \
+            -DAESTRA_CI=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer"
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 
       - name: Build
         run: cmake --build build-nightly --parallel
 
       - name: Test
-        run: ctest --test-dir build-nightly --output-on-failure
+        run: ctest --test-dir build-nightly --output-on-failure -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
 
       - name: Upload build artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -773,14 +773,10 @@ git tag -a v0.4.0-alpha -m "Hardening milestone: security audit, audio quality s
 git push origin v0.4.0-alpha
 ```
 
-### Existing Tags
+### Release History
 
-| Tag                  | Status   | Notes                                     |
-| -------------------- | -------- | ----------------------------------------- |
-| `v0.1.0-foundation`  | Keep     | Historical engine foundation, Oct 2025    |
-| `v0.1.0-alpha`       | Deleted  | Redundant with foundation tag             |
-| `v1.0.0`             | Deleted  | Premature — do not recreate until release |
-| `v0.4.0-alpha`       | Current  | Hardening milestone, May 2026             |
+See `RELEASES.md` for the current tag inventory, milestone history, and release status.
+Do not duplicate that table in this file.
 
 ### What Agents Must Not Do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,15 +413,18 @@ CI is part of the product contract.
 
 Typical workflows may include:
 
-| Workflow                           | Purpose                     |
-| ---------------------------------- | --------------------------- |
-| `ci.yml`                           | Main build/test matrix      |
-| `public-ci.yml`                    | Public branch guard         |
-| `docs-check.yml`                   | Documentation validation    |
-| `deploy-docs.yml`                  | Public docs deployment      |
-| `gitleaks.yml` / `gitleaks-pr.yml` | Secret scanning             |
-| `api-docs.yml`                     | Doxygen/API docs            |
-| `private-release.yml`              | Manual/private release flow |
+| Workflow                           | Purpose                          |
+| ---------------------------------- | -------------------------------- |
+| `ci.yml`                           | Main build/test gate (push/PR)   |
+| `nightly.yml`                      | Scheduled nightly build + tests  |
+| `public-ci.yml`                    | Public branch guard (Windows)    |
+| `docs-check.yml`                   | Documentation validation         |
+| `deploy-docs.yml`                  | Public docs deployment           |
+| `gitleaks.yml` / `gitleaks-pr.yml` | Secret scanning                  |
+| `api-docs.yml`                     | Doxygen/API docs                 |
+| `aestra-reverb-simd-lab.yml`       | Reverb SIMD lab (develop/audio)  |
+| `dsp-benchmark.yml`                | DSP benchmark (develop/DSP)      |
+| `private-release.yml`              | Manual/private release flow      |
 
 General CI rules:
 
@@ -736,3 +739,88 @@ Both `event.type` and `event.pressed`/`released` patterns are valid going forwar
 * Do not modify FreeType warning suppressions without explicit reason.
 * Do not delete `main` or `develop`.
 * Do not claim success without evidence.
+
+---
+
+## 27. Versioning and Tagging Policy
+
+Aestra uses semantic versioning with phase suffixes.
+
+### Version Scheme
+
+```text
+v0.MINOR.PATCH-alpha    — active development (current phase)
+v0.MINOR.PATCH-beta     — public beta (target: Dec 2026)
+v1.0.0                  — initial public release
+```
+
+MINOR increments on meaningful milestones: new plugin tiers, major engine work,
+major architecture changes, or hardening milestones.
+PATCH increments on hotfixes or minor maintenance between milestones.
+
+### Tag Rules
+
+* All release tags must be **annotated** (`git tag -a`), never lightweight.
+* Annotated tags must include a real message summarizing the milestone.
+* Tags live on `main` only — cut after a milestone branch has been merged.
+* Do not tag mid-feature, mid-fix, or on merge-conflict-resolution commits.
+* Do not create premature major-version tags (e.g. `v1.0.0` before beta).
+
+### Creating a Tag
+
+```bash
+git tag -a v0.4.0-alpha -m "Hardening milestone: security audit, audio quality session, repo hygiene"
+git push origin v0.4.0-alpha
+```
+
+### Existing Tags
+
+| Tag                  | Status   | Notes                                     |
+| -------------------- | -------- | ----------------------------------------- |
+| `v0.1.0-foundation`  | Keep     | Historical engine foundation, Oct 2025    |
+| `v0.1.0-alpha`       | Deleted  | Redundant with foundation tag             |
+| `v1.0.0`             | Deleted  | Premature — do not recreate until release |
+| `v0.4.0-alpha`       | Current  | Hardening milestone, May 2026             |
+
+### What Agents Must Not Do
+
+* Do not create or delete tags without explicit instruction.
+* Do not push tags.
+* Do not use lightweight tags for milestones.
+* Do not recreate deleted premature version tags.
+
+---
+
+## 28. Nightly Builds
+
+Nightly builds run on a schedule via `nightly.yml` and are the primary canary
+for regressions not caught by push/PR CI.
+
+### Schedule
+
+`nightly.yml` runs daily at 2:00 AM EAT (23:00 UTC) on `develop`.
+
+### Scope
+
+* Headless build only (`AESTRA_HEADLESS_ONLY=ON`, `Aestra_CORE_MODE=ON`)
+* Full test suite via `ctest`
+* ASan + UBSan enabled (`RelWithDebInfo` build type)
+* Build artifacts retained for 7 days
+
+### On Failure
+
+Nightly failure automatically opens a GitHub issue labeled `nightly-failure`
+with a link to the failing run. Do not suppress or close these issues without
+resolving the underlying cause.
+
+### What Agents Must Not Do
+
+* Do not remove the `nightly-failure` issue label or auto-open logic.
+* Do not add a schedule trigger to `ci.yml` — nightly scope belongs in `nightly.yml`.
+* Do not reduce artifact retention below 7 days without explicit approval.
+* Do not disable ASan/UBSan on nightly without explicit approval and a written reason.
+
+### What Agents May Do
+
+* Add additional nightly steps (e.g. macOS matrix, DSP benchmarks) when explicitly tasked.
+* Adjust cron timing when explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -799,8 +799,9 @@ for regressions not caught by push/PR CI.
 ### Scope
 
 * Headless build only (`AESTRA_HEADLESS_ONLY=ON`, `Aestra_CORE_MODE=ON`)
-* Full test suite via `ctest`
-* ASan + UBSan enabled (`RelWithDebInfo` build type)
+* Checks out `develop` explicitly (scheduled workflows run from the default branch by default)
+* Test suite via `ctest`, excluding `SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient` (same as ci.yml sanitizer job)
+* ASan + UBSan enabled (`RelWithDebInfo` build type) with linker flags and runtime options aligned to ci.yml's sanitizer job
 * Build artifacts retained for 7 days
 
 ### On Failure
@@ -815,6 +816,8 @@ resolving the underlying cause.
 * Do not add a schedule trigger to `ci.yml` — nightly scope belongs in `nightly.yml`.
 * Do not reduce artifact retention below 7 days without explicit approval.
 * Do not disable ASan/UBSan on nightly without explicit approval and a written reason.
+* Do not remove the `ref: develop` from the checkout step — scheduled workflows default to the repository's default branch, not develop.
+* Do not remove the ctest `-E` exclusion filter without confirming those tests pass under ASan/UBSan.
 
 ### What Agents May Do
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,42 @@
+# RELEASES.md — Aestra Release History and Tag Inventory
+
+This file tracks the current tag inventory, milestone history, and release status.
+AGENTS.md references this file for versioning policy (Section 27).
+
+---
+
+## Version Scheme
+
+```text
+v0.MINOR.PATCH-alpha    — active development (current phase)
+v0.MINOR.PATCH-beta     — public beta (target: Dec 2026)
+v1.0.0                  — initial public release
+```
+
+---
+
+## Tag Inventory
+
+| Tag                  | Status    | Date       | Notes                                     |
+| -------------------- | --------- | ---------- | ----------------------------------------- |
+| `v0.1.0-foundation`  | Keep      | 2025-10-26 | Historical engine foundation              |
+| `v0.1.0-alpha`       | Deleted   | —          | Redundant with foundation tag             |
+| `v1.0.0`             | Deleted   | —          | Premature — do not recreate until release |
+| `v0.4.0-alpha`       | Current   | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
+
+---
+
+## Milestone History
+
+### v0.4.0-alpha — Hardening Milestone (May 2026)
+
+- Security audit
+- Audio quality session (BS.1770 K-weighting, dither, export quantization, denormal protection)
+- Repo hygiene mega-pass
+- CI: nightly builds, versioning/tagging policy
+
+### v0.1.0-foundation — Engine Foundation (Oct 2025)
+
+- Initial engine architecture
+- Core audio pipeline
+- Basic plugin hosting


### PR DESCRIPTION
## Summary
- Add Section 27 (Versioning and Tagging Policy) to AGENTS.md
- Add Section 28 (Nightly Builds) to AGENTS.md
- Update Section 14 CI workflow table with missing workflows
- Create `nightly.yml`: scheduled headless build with ASan/UBSan, artifact upload, auto-issue on failure

## Why
Establishes the GitHub strategy decided in the 2026-05-20 session: versioning scheme, tag policy, and nightly canary builds. Required before cutting v0.4.0-alpha tag on main.

## Test plan
- [ ] Verify `nightly.yml` syntax is valid (workflow_dispatch test)
- [ ] Verify AGENTS.md sections 27 and 28 render correctly
- [ ] Verify Section 14 table includes all 10 workflows

## Risk/rollback
- Docs-only + new workflow, no runtime/DSP/serialization changes
- Rollback: revert merge commit

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Added nightly build workflow** (`nightly.yml`): New GitHub Actions workflow that runs on a daily schedule and supports manual dispatch. Performs headless builds with ASan/UBSan enabled, uploads artifacts for 7 days, and automatically creates GitHub issues with failure details (run link, commit SHA, date) when the build fails.

- **Updated AGENTS.md CI workflow documentation**: Expanded the workflow table to document all 10 pipelines including the new `nightly.yml`, `aestra-reverb-simd-lab.yml`, and `dsp-benchmark.yml` workflows with their purposes.

- **Added versioning and tagging policy** (AGENTS.md Section 27): Documents the semantic versioning scheme, requirements for annotated tags, and rules for existing tag status.

- **Added nightly builds policy** (AGENTS.md Section 28): Defines the nightly build schedule, scope, behavior on failure, and constraints on what agents can modify in canary builds.

## Why

Establishes the GitHub strategy finalized in the 2026-05-20 session to support versioning scheme, tag policy, and nightly canary builds—prerequisites for cutting the v0.4.0-alpha tag on main.

## Risk

Low—documentation-only changes plus a new workflow with no runtime, DSP, or serialization impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Implements AGENTS.md Sections 27 (Versioning/Tagging) and 28 (Nightly Builds). Part of the December beta initiative.