### PR TITLE
code-review: fix PR #236 review findings

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,10 @@ jobs:
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 
+      - name: Capture develop SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build
         run: cmake --build build-nightly --parallel
 
@@ -66,6 +70,7 @@ jobs:
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
+            const sha = '${{ steps.sha.outputs.sha }}';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -74,7 +79,7 @@ jobs:
               body: [
                 `Nightly build failed on \`develop\`.\n`,
                 `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-                `**Commit:** ${context.sha}`,
+                `**Commit:** ${sha}`,
                 `**Date:** ${date}`,
                 ``,
                 `Investigate the failing run and resolve before closing this issue.`

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -428,7 +428,7 @@ public:
     void setTestToneEnabled(bool enabled) { m_testToneEnabled.store(enabled, std::memory_order_relaxed); }
     /** @brief Check whether the internal test tone is enabled. */
     bool isTestToneEnabled() const { return m_testToneEnabled.load(std::memory_order_relaxed); }
-    /** @brief Test hook: force bounce write error on first write attempt. */
+    /** @brief Test hook: force bounce write error after one successful full-block write. */
     void setForceBounceWriteErrorForTests(bool enabled) {
         m_forceBounceWriteErrorForTests.store(enabled, std::memory_order_relaxed);
     }

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -150,7 +150,7 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
     cardBounds.height = 56.0f;
 
     const auto& themeProps = theme.getCurrentTheme();
-    const float radius = themeProps.radiusM - 1.0f;
+    const float radius = std::max(0.0f, themeProps.radiusM - 1.0f);
     NUIColor cardBg = theme.getColor("backgroundSecondary");
     NUIColor border = theme.getColor("border").withAlpha(0.08f);
     if (m_isDropHighlighted) {

--- a/Tests/Commands/CommandRegistryParseSafetyTest.cpp
+++ b/Tests/Commands/CommandRegistryParseSafetyTest.cpp
@@ -2,10 +2,12 @@
 // CommandRegistry Parse Safety Tests
 // Tests: safeStoi, safeStof, safeStoull, requireFlag — malformed input handling
 
+#include <cctype>
 #include <cmath>
 #include <iostream>
 #include <limits>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>


### PR DESCRIPTION
## Summary
- Add `<cctype>` and `<stdexcept>` includes to CommandRegistryParseSafetyTest
- Fix `setForceBounceWriteErrorForTests` docstring to match actual behavior
- Clamp radius in UnitRow to `>= 0.0f`
- nightly.yml: capture develop SHA via `git rev-parse HEAD` instead of `context.sha`

## Why
CodeRabbit findings on PR #236 (develop → main). Fixes land in develop first.

## Test plan
- [ ] Build passes
- [ ] nightly.yml SHA capture step produces correct develop commit

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

Follow-up fixes for PR #236 CodeRabbit review findings.