### PR TITLE
feat: RT safety infrastructure — diagnostics, supervisor, async cleanup, guard

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -166,7 +166,10 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Core/MixerBus.cpp
     src/Core/MixerChannel.cpp
     src/Core/ProjectValidator.cpp
-    
+    src/Core/EngineSupervisor.cpp
+    src/Core/AsyncCleanupManager.cpp
+    src/Core/RTGuard.cpp
+
     # Playback
     src/Playback/AuditionEngine.cpp
     src/Playback/PreviewEngine.cpp
@@ -296,6 +299,10 @@ set(AESTRA_AUDIO_CORE_HEADERS
     include/Core/AudioDeviceManager.h
     include/Core/AutosaveManager.h
     include/Core/ProjectValidator.h
+    include/Core/AudioEngineDiagnostics.h
+    include/Core/EngineSupervisor.h
+    include/Core/AsyncCleanupManager.h
+    include/Core/RTGuard.h
     include/Drivers/IAudioDriver.h
     include/Drivers/AudioDriver.h           # Legacy/Base types
     include/Drivers/AudioDriverTypes.h

--- a/AestraAudio/include/Core/AsyncCleanupManager.h
+++ b/AestraAudio/include/Core/AsyncCleanupManager.h
@@ -3,11 +3,13 @@
 
 #include <atomic>
 #include <cstdint>
-#include <functional>
 #include <thread>
 
 namespace Aestra {
 namespace Audio {
+
+/// Cleanup function type — uses function pointer + context to avoid std::function heap allocation
+using CleanupFn = void (*)(void* context);
 
 /**
  * Lock-free, background cleanup manager for quarantined plugin instances.
@@ -19,9 +21,9 @@ namespace Audio {
  *
  * Uses a fixed-size SPSC (Single-Producer, Single-Consumer) ring buffer
  * for lock-free communication from the audio thread to the cleanup thread.
+ * The enqueue path is lock-free and allocation-free (function pointer + context).
  *
- * The cleanup thread runs at below-normal priority and processes one item
- * per cycle to avoid CPU spikes.
+ * The cleanup thread processes one item per cycle to avoid CPU spikes.
  */
 class AsyncCleanupManager {
 public:
@@ -36,14 +38,15 @@ public:
 
     /**
      * Enqueue a cleanup task from the audio thread.
-     * Lock-free, wait-free. Returns false if queue is full.
-     * Thread-safe: called from audio thread only.
+     * Lock-free and allocation-free. Returns false if queue is full.
+     * The cleanup function is a plain function pointer (no std::function).
      */
-    bool enqueueCleanup(uint64_t pluginId, std::function<void()> cleanupFn) noexcept;
+    bool enqueueCleanup(uint64_t pluginId, CleanupFn fn, void* context) noexcept;
 
     /**
      * Start the background cleanup thread.
      * Must be called before any enqueue operations.
+     * Thread-safe: uses compare_exchange_strong to prevent double-start.
      */
     void start();
 
@@ -56,6 +59,7 @@ public:
     /**
      * Get the number of pending cleanup tasks.
      * Thread-safe: lock-free atomic read.
+     * Note: unsigned subtraction wraps correctly for monotonic indices.
      */
     size_t getPendingCount() const noexcept {
         return m_writeIndex.load(std::memory_order_relaxed) -
@@ -66,12 +70,15 @@ public:
      * Get the total number of cleanup tasks processed.
      * Thread-safe: lock-free atomic read.
      */
-    uint64_t getProcessedCount() const noexcept { return m_processedCount.load(std::memory_order_relaxed); }
+    [[nodiscard]] uint64_t getProcessedCount() const noexcept {
+        return m_processedCount.load(std::memory_order_relaxed);
+    }
 
 private:
     struct CleanupTask {
         uint64_t pluginId{0};
-        std::function<void()> fn;
+        CleanupFn fn{nullptr};
+        void* context{nullptr};
     };
 
     void cleanupThreadFunc();

--- a/AestraAudio/include/Core/AsyncCleanupManager.h
+++ b/AestraAudio/include/Core/AsyncCleanupManager.h
@@ -1,0 +1,88 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <thread>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Lock-free, background cleanup manager for quarantined plugin instances.
+ *
+ * When a plugin is quarantined by EngineSupervisor, it is logically detached
+ * from the audio graph immediately (zero further process() calls). Its physical
+ * teardown (destructor calls, resource release) is offloaded to this manager
+ * to prevent blocking the audio thread.
+ *
+ * Uses a fixed-size SPSC (Single-Producer, Single-Consumer) ring buffer
+ * for lock-free communication from the audio thread to the cleanup thread.
+ *
+ * The cleanup thread runs at below-normal priority and processes one item
+ * per cycle to avoid CPU spikes.
+ */
+class AsyncCleanupManager {
+public:
+    static constexpr size_t kQueueCapacity = 64;
+
+    AsyncCleanupManager();
+    ~AsyncCleanupManager();
+
+    // Non-copyable, non-movable
+    AsyncCleanupManager(const AsyncCleanupManager&) = delete;
+    AsyncCleanupManager& operator=(const AsyncCleanupManager&) = delete;
+
+    /**
+     * Enqueue a cleanup task from the audio thread.
+     * Lock-free, wait-free. Returns false if queue is full.
+     * Thread-safe: called from audio thread only.
+     */
+    bool enqueueCleanup(uint64_t pluginId, std::function<void()> cleanupFn) noexcept;
+
+    /**
+     * Start the background cleanup thread.
+     * Must be called before any enqueue operations.
+     */
+    void start();
+
+    /**
+     * Stop the background cleanup thread and drain remaining items.
+     * Blocks until all pending cleanups are complete.
+     */
+    void stop();
+
+    /**
+     * Get the number of pending cleanup tasks.
+     * Thread-safe: lock-free atomic read.
+     */
+    size_t getPendingCount() const noexcept {
+        return m_writeIndex.load(std::memory_order_relaxed) -
+               m_readIndex.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * Get the total number of cleanup tasks processed.
+     * Thread-safe: lock-free atomic read.
+     */
+    uint64_t getProcessedCount() const noexcept { return m_processedCount.load(std::memory_order_relaxed); }
+
+private:
+    struct CleanupTask {
+        uint64_t pluginId{0};
+        std::function<void()> fn;
+    };
+
+    void cleanupThreadFunc();
+
+    CleanupTask m_queue[kQueueCapacity];
+    std::atomic<size_t> m_writeIndex{0};
+    std::atomic<size_t> m_readIndex{0};
+    std::atomic<uint64_t> m_processedCount{0};
+    std::atomic<bool> m_running{false};
+    std::thread m_thread;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/AsyncCleanupManager.h
+++ b/AestraAudio/include/Core/AsyncCleanupManager.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <thread>
@@ -58,12 +59,13 @@ public:
 
     /**
      * Get the number of pending cleanup tasks.
-     * Thread-safe: lock-free atomic read.
-     * Note: unsigned subtraction wraps correctly for monotonic indices.
+     * Thread-safe: lock-free atomic reads with acquire ordering for consistency.
+     * Clamps to zero to avoid underflow if readIndex briefly leads writeIndex.
      */
     size_t getPendingCount() const noexcept {
-        return m_writeIndex.load(std::memory_order_relaxed) -
-               m_readIndex.load(std::memory_order_relaxed);
+        const size_t write = m_writeIndex.load(std::memory_order_acquire);
+        const size_t read = m_readIndex.load(std::memory_order_acquire);
+        return write >= read ? write - read : 0;
     }
 
     /**
@@ -88,6 +90,7 @@ private:
     std::atomic<size_t> m_readIndex{0};
     std::atomic<uint64_t> m_processedCount{0};
     std::atomic<bool> m_running{false};
+    std::atomic<bool> m_accepting{true};  ///< false after stop() begins — rejects new enqueues
     std::thread m_thread;
 };
 

--- a/AestraAudio/include/Core/AudioEngineDiagnostics.h
+++ b/AestraAudio/include/Core/AudioEngineDiagnostics.h
@@ -1,0 +1,92 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Transport event types for diagnostic epoch tracking.
+ * Used to correlate timing anomalies with transport state changes.
+ */
+enum class TransportEventType : uint32_t {
+    None = 0,
+    Seek,
+    LoopWrap,
+    StopToPlay,
+    TempoMapRebuild,
+    PrerollStart
+};
+
+/**
+ * Diagnostic epoch capturing the state at the start of a processing callback.
+ * Enables correlation of timing anomalies with specific engine states.
+ */
+struct DiagnosticEpoch {
+    uint64_t callbackId{0};
+    uint64_t graphGeneration{0};
+    uint64_t transportGeneration{0};
+    TransportEventType lastTransportEvent{TransportEventType::None};
+};
+
+/**
+ * Information about a denormal (subnormal) floating-point event.
+ * Severity levels:
+ *   0 = Flag altered only (FTZ/DAZ detected a change)
+ *   1 = Subnormal signal emitted from plugin
+ *   2 = Confirmed timing slowdown due to denormals
+ */
+struct DenormalEventInfo {
+    uint64_t pluginId{0};
+    uint64_t timestamp{0};
+    uint32_t severity{0};
+};
+
+/**
+ * Multi-tier audio engine diagnostics.
+ * Captures scheduling jitter, dispatch latency, callback duration,
+ * xruns, RT violations, plugin health, and denormal events.
+ *
+ * All fields are populated by the audio thread and read by the UI/telemetry
+ * thread via a seqlock snapshot mechanism.
+ */
+struct AudioEngineDiagnostics {
+    // Multi-tier timing breakdown
+    double schedulerJitterMs{0.0};   ///< Deviation between expected wake and actual signal wake
+    double dispatchJitterMs{0.0};    ///< Deviation between signal wake and thread execution start
+    double callbackDurationMs{0.0};  ///< Core DSP processing duration
+    double callbackBudgetMs{0.0};    ///< Allocated time budget for this callback
+
+    uint64_t xruns{0};
+    uint64_t rtAllocations{0};
+    uint64_t graphRebuilds{0};
+
+    uint64_t pluginTimeouts{0};
+    uint64_t pdcAdjustments{0};
+
+    size_t activeVoices{0};
+    size_t activePlugins{0};
+
+    double cpuLoad{0.0};
+    double peakCpuLoad{0.0};
+
+    uint64_t denormalEvents{0};
+    DenormalEventInfo lastDenormal{0};
+
+    uint64_t nonRtMutexWaitTimeNs{0};
+};
+
+/**
+ * Coherent diagnostics snapshot obtained via seqlock.
+ * The generation counter enables the reader to detect torn reads.
+ */
+struct CoherentDiagnosticsSnapshot {
+    uint64_t generation{0};
+    AudioEngineDiagnostics diagnostics;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/EngineSupervisor.h
+++ b/AestraAudio/include/Core/EngineSupervisor.h
@@ -146,10 +146,11 @@ private:
         uint32_t timeoutCount() const noexcept { return (flags.load(std::memory_order_relaxed) >> 2) & 0xFFu; }
 
         void setBypassed(bool v) noexcept {
-            auto f = flags.load(std::memory_order_relaxed);
+            uint32_t expected = flags.load(std::memory_order_relaxed);
+            uint32_t desired;
             do {
-                f = v ? (f | 1u) : (f & ~1u);
-            } while (!flags.compare_exchange_weak(f, f, std::memory_order_relaxed));
+                desired = v ? (expected | 1u) : (expected & ~1u);
+            } while (!flags.compare_exchange_weak(expected, desired, std::memory_order_relaxed));
         }
 
         void setQuarantined() noexcept {
@@ -158,14 +159,15 @@ private:
         }
 
         uint32_t incrementTimeout(uint32_t threshold) noexcept {
-            auto f = flags.load(std::memory_order_relaxed);
+            uint32_t expected = flags.load(std::memory_order_relaxed);
+            uint32_t desired;
             uint32_t count;
             do {
-                count = ((f >> 2) & 0xFFu) + 1;
+                count = ((expected >> 2) & 0xFFu) + 1;
                 if (count > 255) count = 255;
-                f = (f & ~(0xFFu << 2)) | (count << 2);
-                if (count >= threshold) f |= 1u;  // auto-bypass
-            } while (!flags.compare_exchange_weak(f, f, std::memory_order_relaxed));
+                desired = (expected & ~(0xFFu << 2)) | (count << 2);
+                if (count >= threshold) desired |= 1u;  // auto-bypass
+            } while (!flags.compare_exchange_weak(expected, desired, std::memory_order_relaxed));
             return count;
         }
 
@@ -189,6 +191,7 @@ private:
 
     static constexpr uint32_t kStudioTimeoutThreshold = 5;
     static constexpr uint32_t kLiveTimeoutThreshold = 2;
+    static constexpr uint32_t kOfflineTimeoutThreshold = 1;  ///< Strictest: halt on first timeout
     static constexpr double kDefaultDecayFactor = 0.95;
 };
 

--- a/AestraAudio/include/Core/EngineSupervisor.h
+++ b/AestraAudio/include/Core/EngineSupervisor.h
@@ -4,7 +4,6 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
-#include <string>
 #include <unordered_map>
 
 namespace Aestra {
@@ -14,7 +13,7 @@ namespace Audio {
  * Recovery policy profiles for the engine supervisor.
  * Different profiles apply different thresholds and actions.
  */
-enum class RecoveryProfile : uint32_t {
+enum class RecoveryProfile : uint8_t {
     Studio = 0,      ///< Conservative: warn, soft-limit, never auto-bypass
     LivePerformance,  ///< Aggressive: fast bypass, minimal latency impact
     OfflineRender     ///< Strict: halt on any anomaly, no fallback
@@ -23,6 +22,7 @@ enum class RecoveryProfile : uint32_t {
 /**
  * Health state for a single plugin, incorporating violation decay.
  * The rolling CPU score decays over time to avoid permanent penalization.
+ * Only accessed from non-RT threads (mutex-protected).
  */
 struct PluginHealthState {
     double rollingCpuScore{0.0};
@@ -41,11 +41,20 @@ struct PluginHealthState {
  * This separation allows distinct behaviors for Studio, Live, and Offline profiles
  * without touching DSP code.
  *
- * Thread safety: the supervisor is accessed from the audio thread (read-only,
- * lock-free) and from the UI/telemetry thread (read-write, mutex-protected).
+ * Thread safety:
+ * - Audio-thread methods (reportPluginTimeout, shouldBypassPlugin, isPluginQuarantined,
+ *   quarantinePlugin) use lock-free atomic operations on a fixed-size slot array.
+ * - Non-RT methods (getPluginHealth, decayHealthScores, reset) use mutex-protected
+ *   access to the detailed health map.
+ * - The slot array is indexed by pluginId % kMaxTrackedPlugins. Collisions are
+ *   acceptable — the worst case is a false bypass on an unrelated plugin, which
+ *   is safe (audio continues, just bypassed).
  */
 class EngineSupervisor {
 public:
+    /// Maximum number of plugins tracked in the lock-free slot array
+    static constexpr size_t kMaxTrackedPlugins = 256;
+
     EngineSupervisor();
     ~EngineSupervisor();
 
@@ -57,85 +66,129 @@ public:
 
     /**
      * Report a plugin timeout from the audio thread.
+     * Lock-free: uses atomic operations on the slot array.
      * Called when a plugin's process() exceeds its time budget.
-     * Thread-safe: lock-free, called from audio thread.
      */
     void reportPluginTimeout(uint64_t pluginId, uint64_t timestamp) noexcept;
 
     /**
      * Report an xrun event from the audio thread.
-     * Thread-safe: lock-free, called from audio thread.
+     * Lock-free: atomic increment.
      */
     void reportXrun() noexcept { m_xrunCount.fetch_add(1, std::memory_order_relaxed); }
 
     /**
      * Report a denormal event from the audio thread.
-     * Thread-safe: lock-free, called from audio thread.
+     * Lock-free: atomic increment.
      */
     void reportDenormal(uint64_t pluginId, uint32_t severity, uint64_t timestamp) noexcept;
 
     /**
      * Check if a plugin should be bypassed based on its health state.
      * Called from the audio thread during processBlock.
-     * Thread-safe: lock-free read.
+     * Lock-free: atomic read from slot array.
      */
     bool shouldBypassPlugin(uint64_t pluginId) const noexcept;
 
     /**
      * Check if a plugin is quarantined (logically detached from audio graph).
-     * Thread-safe: lock-free read.
+     * Lock-free: atomic read from slot array.
      */
     bool isPluginQuarantined(uint64_t pluginId) const noexcept;
 
     /**
      * Quarantine a plugin — logically detach from audio graph immediately.
      * Physical teardown is offloaded to AsyncCleanupManager.
-     * Thread-safe: lock-free write to atomic flag.
+     * Lock-free: atomic write to slot array.
      */
     void quarantinePlugin(uint64_t pluginId) noexcept;
 
     /**
      * Get a copy of a plugin's health state.
-     * Thread-safe: mutex-protected read.
+     * NOT lock-free: mutex-protected read. Only call from non-RT threads.
      */
     PluginHealthState getPluginHealth(uint64_t pluginId) const;
 
     /**
      * Decay rolling scores for all tracked plugins.
-     * Called periodically from a non-RT thread.
-     * Thread-safe: mutex-protected write.
+     * NOT lock-free: mutex-protected write. Only call from non-RT threads.
      */
     void decayHealthScores(double decayFactor = 0.95);
 
     /**
      * Get the total xrun count since engine start.
-     * Thread-safe: lock-free atomic read.
+     * Lock-free: atomic read.
      */
     uint64_t getXrunCount() const noexcept { return m_xrunCount.load(std::memory_order_relaxed); }
 
     /**
      * Get the total plugin timeout count since engine start.
-     * Thread-safe: lock-free atomic read.
+     * Lock-free: atomic read.
      */
     uint64_t getTimeoutCount() const noexcept { return m_timeoutCount.load(std::memory_order_relaxed); }
 
-    /// Reset all health state (e.g., on engine restart)
+    /// Reset all health state (e.g., on engine restart). NOT lock-free.
     void reset();
 
 private:
+    /**
+     * Lock-free slot for audio-thread-facing plugin state.
+     * Uses atomic uint32_t as a bitfield:
+     *   bit 0: isBypassed
+     *   bit 1: isQuarantined
+     *   bits 2-31: consecutiveTimeouts (saturating at 255)
+     */
+    struct alignas(64) PluginSlot {  // cacheline-aligned to avoid false sharing
+        std::atomic<uint32_t> flags{0};
+
+        bool isBypassed() const noexcept { return flags.load(std::memory_order_relaxed) & 1u; }
+        bool isQuarantined() const noexcept { return flags.load(std::memory_order_relaxed) & 2u; }
+        uint32_t timeoutCount() const noexcept { return (flags.load(std::memory_order_relaxed) >> 2) & 0xFFu; }
+
+        void setBypassed(bool v) noexcept {
+            auto f = flags.load(std::memory_order_relaxed);
+            do {
+                f = v ? (f | 1u) : (f & ~1u);
+            } while (!flags.compare_exchange_weak(f, f, std::memory_order_relaxed));
+        }
+
+        void setQuarantined() noexcept {
+            flags.fetch_or(2u, std::memory_order_relaxed);
+            flags.fetch_or(1u, std::memory_order_relaxed);  // quarantine implies bypass
+        }
+
+        uint32_t incrementTimeout(uint32_t threshold) noexcept {
+            auto f = flags.load(std::memory_order_relaxed);
+            uint32_t count;
+            do {
+                count = ((f >> 2) & 0xFFu) + 1;
+                if (count > 255) count = 255;
+                f = (f & ~(0xFFu << 2)) | (count << 2);
+                if (count >= threshold) f |= 1u;  // auto-bypass
+            } while (!flags.compare_exchange_weak(f, f, std::memory_order_relaxed));
+            return count;
+        }
+
+        void reset() noexcept { flags.store(0, std::memory_order_relaxed); }
+    };
+
+    PluginSlot& getSlot(uint64_t pluginId) noexcept { return m_slots[pluginId % kMaxTrackedPlugins]; }
+    const PluginSlot& getSlot(uint64_t pluginId) const noexcept { return m_slots[pluginId % kMaxTrackedPlugins]; }
+
     std::atomic<RecoveryProfile> m_profile{RecoveryProfile::Studio};
     std::atomic<uint64_t> m_xrunCount{0};
     std::atomic<uint64_t> m_timeoutCount{0};
     std::atomic<uint64_t> m_denormalCount{0};
 
+    /// Lock-free slot array for audio-thread operations
+    PluginSlot m_slots[kMaxTrackedPlugins];
+
+    /// Mutex-protected detailed health state for non-RT access
     mutable std::mutex m_healthMutex;
     std::unordered_map<uint64_t, PluginHealthState> m_pluginHealth;
 
-    /// Threshold for auto-bypass in Studio profile
     static constexpr uint32_t kStudioTimeoutThreshold = 5;
-    /// Threshold for auto-bypass in Live profile
     static constexpr uint32_t kLiveTimeoutThreshold = 2;
-    /// Decay factor applied per cycle (0.95 = 5% decay per cycle)
     static constexpr double kDefaultDecayFactor = 0.95;
 };
 

--- a/AestraAudio/include/Core/EngineSupervisor.h
+++ b/AestraAudio/include/Core/EngineSupervisor.h
@@ -1,0 +1,143 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Recovery policy profiles for the engine supervisor.
+ * Different profiles apply different thresholds and actions.
+ */
+enum class RecoveryProfile : uint32_t {
+    Studio = 0,      ///< Conservative: warn, soft-limit, never auto-bypass
+    LivePerformance,  ///< Aggressive: fast bypass, minimal latency impact
+    OfflineRender     ///< Strict: halt on any anomaly, no fallback
+};
+
+/**
+ * Health state for a single plugin, incorporating violation decay.
+ * The rolling CPU score decays over time to avoid permanent penalization.
+ */
+struct PluginHealthState {
+    double rollingCpuScore{0.0};
+    uint32_t consecutiveTimeouts{0};
+    uint64_t lastTimeoutTimestamp{0};
+    bool isBypassed{false};
+    bool isQuarantined{false};
+};
+
+/**
+ * Decoupled engine supervisor that coordinates plugin health, recovery policies,
+ * and asynchronous quarantine handling.
+ *
+ * Design principle: the audio thread emits facts (timeouts, xruns, denormals).
+ * The supervisor makes decisions (bypass, quarantine, mute, soft-limit).
+ * This separation allows distinct behaviors for Studio, Live, and Offline profiles
+ * without touching DSP code.
+ *
+ * Thread safety: the supervisor is accessed from the audio thread (read-only,
+ * lock-free) and from the UI/telemetry thread (read-write, mutex-protected).
+ */
+class EngineSupervisor {
+public:
+    EngineSupervisor();
+    ~EngineSupervisor();
+
+    /// Set the active recovery profile
+    void setProfile(RecoveryProfile profile) noexcept { m_profile.store(profile, std::memory_order_relaxed); }
+
+    /// Get the active recovery profile
+    RecoveryProfile getProfile() const noexcept { return m_profile.load(std::memory_order_relaxed); }
+
+    /**
+     * Report a plugin timeout from the audio thread.
+     * Called when a plugin's process() exceeds its time budget.
+     * Thread-safe: lock-free, called from audio thread.
+     */
+    void reportPluginTimeout(uint64_t pluginId, uint64_t timestamp) noexcept;
+
+    /**
+     * Report an xrun event from the audio thread.
+     * Thread-safe: lock-free, called from audio thread.
+     */
+    void reportXrun() noexcept { m_xrunCount.fetch_add(1, std::memory_order_relaxed); }
+
+    /**
+     * Report a denormal event from the audio thread.
+     * Thread-safe: lock-free, called from audio thread.
+     */
+    void reportDenormal(uint64_t pluginId, uint32_t severity, uint64_t timestamp) noexcept;
+
+    /**
+     * Check if a plugin should be bypassed based on its health state.
+     * Called from the audio thread during processBlock.
+     * Thread-safe: lock-free read.
+     */
+    bool shouldBypassPlugin(uint64_t pluginId) const noexcept;
+
+    /**
+     * Check if a plugin is quarantined (logically detached from audio graph).
+     * Thread-safe: lock-free read.
+     */
+    bool isPluginQuarantined(uint64_t pluginId) const noexcept;
+
+    /**
+     * Quarantine a plugin — logically detach from audio graph immediately.
+     * Physical teardown is offloaded to AsyncCleanupManager.
+     * Thread-safe: lock-free write to atomic flag.
+     */
+    void quarantinePlugin(uint64_t pluginId) noexcept;
+
+    /**
+     * Get a copy of a plugin's health state.
+     * Thread-safe: mutex-protected read.
+     */
+    PluginHealthState getPluginHealth(uint64_t pluginId) const;
+
+    /**
+     * Decay rolling scores for all tracked plugins.
+     * Called periodically from a non-RT thread.
+     * Thread-safe: mutex-protected write.
+     */
+    void decayHealthScores(double decayFactor = 0.95);
+
+    /**
+     * Get the total xrun count since engine start.
+     * Thread-safe: lock-free atomic read.
+     */
+    uint64_t getXrunCount() const noexcept { return m_xrunCount.load(std::memory_order_relaxed); }
+
+    /**
+     * Get the total plugin timeout count since engine start.
+     * Thread-safe: lock-free atomic read.
+     */
+    uint64_t getTimeoutCount() const noexcept { return m_timeoutCount.load(std::memory_order_relaxed); }
+
+    /// Reset all health state (e.g., on engine restart)
+    void reset();
+
+private:
+    std::atomic<RecoveryProfile> m_profile{RecoveryProfile::Studio};
+    std::atomic<uint64_t> m_xrunCount{0};
+    std::atomic<uint64_t> m_timeoutCount{0};
+    std::atomic<uint64_t> m_denormalCount{0};
+
+    mutable std::mutex m_healthMutex;
+    std::unordered_map<uint64_t, PluginHealthState> m_pluginHealth;
+
+    /// Threshold for auto-bypass in Studio profile
+    static constexpr uint32_t kStudioTimeoutThreshold = 5;
+    /// Threshold for auto-bypass in Live profile
+    static constexpr uint32_t kLiveTimeoutThreshold = 2;
+    /// Decay factor applied per cycle (0.95 = 5% decay per cycle)
+    static constexpr double kDefaultDecayFactor = 0.95;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/RTGuard.h
+++ b/AestraAudio/include/Core/RTGuard.h
@@ -1,0 +1,97 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "RealtimeThreadGuard.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Violation types for RT safety auditing.
+ * 'N' = heap allocation (new/malloc)
+ * 'D' = heap deallocation (delete/free)
+ * 'A' = mutex acquisition attempt
+ * 'B' = blocking I/O or system call
+ */
+enum class RTViolationType : char {
+    Allocation = 'N',
+    Deallocation = 'D',
+    MutexAcquire = 'A',
+    BlockingCall = 'B'
+};
+
+/**
+ * A single RT violation event with forensic diagnostic epoch info.
+ * Captures the return address, allocation size, thread ID,
+ * and the engine state at the time of violation.
+ */
+struct RTViolationEvent {
+    uint64_t timestamp{0};
+    void* returnAddress{nullptr};
+    size_t allocationSize{0};
+    uint64_t threadId{0};
+    uint64_t callbackId{0};
+    uint64_t graphGeneration{0};
+    RTViolationType type{RTViolationType::Allocation};
+};
+
+/// Maximum number of violation events stored per thread (circular buffer)
+constexpr size_t MAX_LOCAL_VIOLATIONS = 128;
+
+/**
+ * Thread-local RT audit data.
+ * Each audio thread gets its own circular buffer of violation events.
+ * All operations are strictly thread-local: zero allocations,
+ * zero reentrancy, zero lock contention.
+ */
+struct ThreadLocalRTAudit {
+    uint64_t violationCount{0};
+    uint64_t droppedCount{0};
+    size_t eventIndex{0};
+    RTViolationEvent lastEvents[MAX_LOCAL_VIOLATIONS];
+};
+
+/// Thread-local audit data, only active in AESTRA_AUDIT_MODE builds
+extern thread_local ThreadLocalRTAudit g_rtAuditData;
+
+// Reuse existing RT thread guard from RealtimeThreadGuard.h
+// ScopedRealtimeAudioThread and isInRealtimeAudioThread are defined there
+
+/**
+ * Record an RT violation event.
+ * Called from the allocation override or mutex guard.
+ * Thread-safe: all operations are thread-local.
+ */
+inline void recordRTViolation(RTViolationType type, void* returnAddress = nullptr,
+                               size_t allocSize = 0) noexcept {
+    auto& audit = g_rtAuditData;
+    auto& event = audit.lastEvents[audit.eventIndex % MAX_LOCAL_VIOLATIONS];
+    event.type = type;
+    event.returnAddress = returnAddress;
+    event.allocationSize = allocSize;
+    // Timestamp, threadId, callbackId, graphGeneration filled by caller if available
+    audit.eventIndex++;
+    audit.violationCount++;
+    if (audit.eventIndex > MAX_LOCAL_VIOLATIONS) {
+        audit.droppedCount++;
+    }
+}
+
+/**
+ * Get the total RT violation count for the current thread.
+ * Thread-safe: thread-local read.
+ */
+inline uint64_t getRTViolationCount() noexcept { return g_rtAuditData.violationCount; }
+
+/**
+ * Get the dropped event count for the current thread.
+ * Thread-safe: thread-local read.
+ */
+inline uint64_t getRTDroppedCount() noexcept { return g_rtAuditData.droppedCount; }
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/RTGuard.h
+++ b/AestraAudio/include/Core/RTGuard.h
@@ -55,7 +55,8 @@ struct ThreadLocalRTAudit {
     RTViolationEvent lastEvents[MAX_LOCAL_VIOLATIONS];
 };
 
-/// Thread-local audit data, only active in AESTRA_AUDIT_MODE builds
+/// Thread-local audit data. Always available for testing/diagnostics.
+/// The allocation override that populates it is gated behind AESTRA_AUDIT_MODE.
 extern thread_local ThreadLocalRTAudit g_rtAuditData;
 
 // Reuse existing RT thread guard from RealtimeThreadGuard.h

--- a/AestraAudio/src/Core/AsyncCleanupManager.cpp
+++ b/AestraAudio/src/Core/AsyncCleanupManager.cpp
@@ -13,6 +13,12 @@ AsyncCleanupManager::~AsyncCleanupManager() {
 }
 
 bool AsyncCleanupManager::enqueueCleanup(uint64_t pluginId, CleanupFn fn, void* context) noexcept {
+    // Reject null functions
+    if (!fn) return false;
+
+    // Reject enqueues after shutdown begins
+    if (!m_accepting.load(std::memory_order_acquire)) return false;
+
     const size_t write = m_writeIndex.load(std::memory_order_relaxed);
     const size_t read = m_readIndex.load(std::memory_order_acquire);
 
@@ -40,6 +46,8 @@ void AsyncCleanupManager::start() {
 }
 
 void AsyncCleanupManager::stop() {
+    // Stop accepting new enqueues first (release so producers see this)
+    m_accepting.store(false, std::memory_order_release);
     m_running.store(false, std::memory_order_relaxed);
     if (m_thread.joinable()) {
         m_thread.join();

--- a/AestraAudio/src/Core/AsyncCleanupManager.cpp
+++ b/AestraAudio/src/Core/AsyncCleanupManager.cpp
@@ -12,26 +12,30 @@ AsyncCleanupManager::~AsyncCleanupManager() {
     stop();
 }
 
-bool AsyncCleanupManager::enqueueCleanup(uint64_t pluginId, std::function<void()> cleanupFn) noexcept {
+bool AsyncCleanupManager::enqueueCleanup(uint64_t pluginId, CleanupFn fn, void* context) noexcept {
     const size_t write = m_writeIndex.load(std::memory_order_relaxed);
     const size_t read = m_readIndex.load(std::memory_order_acquire);
 
-    // Check if queue is full
+    // Check if queue is full (unsigned subtraction wraps correctly for monotonic indices)
     if (write - read >= kQueueCapacity) {
         return false;
     }
 
     auto& task = m_queue[write % kQueueCapacity];
     task.pluginId = pluginId;
-    task.fn = std::move(cleanupFn);
+    task.fn = fn;
+    task.context = context;
 
     m_writeIndex.store(write + 1, std::memory_order_release);
     return true;
 }
 
 void AsyncCleanupManager::start() {
-    if (m_running.load(std::memory_order_relaxed)) return;
-    m_running.store(true, std::memory_order_relaxed);
+    // Use compare_exchange_strong to prevent double-start race
+    bool expected = false;
+    if (!m_running.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return;  // Already running
+    }
     m_thread = std::thread(&AsyncCleanupManager::cleanupThreadFunc, this);
 }
 
@@ -55,8 +59,9 @@ void AsyncCleanupManager::cleanupThreadFunc() {
 
         auto& task = m_queue[read % kQueueCapacity];
         if (task.fn) {
-            task.fn();
+            task.fn(task.context);
             task.fn = nullptr;
+            task.context = nullptr;
         }
         m_readIndex.store(read + 1, std::memory_order_release);
         m_processedCount.fetch_add(1, std::memory_order_relaxed);
@@ -70,8 +75,9 @@ void AsyncCleanupManager::cleanupThreadFunc() {
 
         auto& task = m_queue[read % kQueueCapacity];
         if (task.fn) {
-            task.fn();
+            task.fn(task.context);
             task.fn = nullptr;
+            task.context = nullptr;
         }
         m_readIndex.store(read + 1, std::memory_order_release);
         m_processedCount.fetch_add(1, std::memory_order_relaxed);

--- a/AestraAudio/src/Core/AsyncCleanupManager.cpp
+++ b/AestraAudio/src/Core/AsyncCleanupManager.cpp
@@ -1,0 +1,82 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AsyncCleanupManager.h"
+
+#include <chrono>
+
+namespace Aestra {
+namespace Audio {
+
+AsyncCleanupManager::AsyncCleanupManager() = default;
+
+AsyncCleanupManager::~AsyncCleanupManager() {
+    stop();
+}
+
+bool AsyncCleanupManager::enqueueCleanup(uint64_t pluginId, std::function<void()> cleanupFn) noexcept {
+    const size_t write = m_writeIndex.load(std::memory_order_relaxed);
+    const size_t read = m_readIndex.load(std::memory_order_acquire);
+
+    // Check if queue is full
+    if (write - read >= kQueueCapacity) {
+        return false;
+    }
+
+    auto& task = m_queue[write % kQueueCapacity];
+    task.pluginId = pluginId;
+    task.fn = std::move(cleanupFn);
+
+    m_writeIndex.store(write + 1, std::memory_order_release);
+    return true;
+}
+
+void AsyncCleanupManager::start() {
+    if (m_running.load(std::memory_order_relaxed)) return;
+    m_running.store(true, std::memory_order_relaxed);
+    m_thread = std::thread(&AsyncCleanupManager::cleanupThreadFunc, this);
+}
+
+void AsyncCleanupManager::stop() {
+    m_running.store(false, std::memory_order_relaxed);
+    if (m_thread.joinable()) {
+        m_thread.join();
+    }
+}
+
+void AsyncCleanupManager::cleanupThreadFunc() {
+    while (m_running.load(std::memory_order_relaxed)) {
+        const size_t read = m_readIndex.load(std::memory_order_relaxed);
+        const size_t write = m_writeIndex.load(std::memory_order_acquire);
+
+        if (read == write) {
+            // Queue empty, sleep briefly to avoid busy-waiting
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
+        }
+
+        auto& task = m_queue[read % kQueueCapacity];
+        if (task.fn) {
+            task.fn();
+            task.fn = nullptr;
+        }
+        m_readIndex.store(read + 1, std::memory_order_release);
+        m_processedCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Drain remaining items on shutdown
+    while (true) {
+        const size_t read = m_readIndex.load(std::memory_order_relaxed);
+        const size_t write = m_writeIndex.load(std::memory_order_acquire);
+        if (read == write) break;
+
+        auto& task = m_queue[read % kQueueCapacity];
+        if (task.fn) {
+            task.fn();
+            task.fn = nullptr;
+        }
+        m_readIndex.store(read + 1, std::memory_order_release);
+        m_processedCount.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Core/EngineSupervisor.cpp
+++ b/AestraAudio/src/Core/EngineSupervisor.cpp
@@ -1,0 +1,89 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "EngineSupervisor.h"
+
+#include <algorithm>
+
+namespace Aestra {
+namespace Audio {
+
+EngineSupervisor::EngineSupervisor() = default;
+EngineSupervisor::~EngineSupervisor() = default;
+
+void EngineSupervisor::reportPluginTimeout(uint64_t pluginId, uint64_t timestamp) noexcept {
+    m_timeoutCount.fetch_add(1, std::memory_order_relaxed);
+
+    std::lock_guard lock(m_healthMutex);
+    auto& state = m_pluginHealth[pluginId];
+    state.consecutiveTimeouts++;
+    state.lastTimeoutTimestamp = timestamp;
+
+    // Check if we should auto-bypass based on profile
+    auto profile = m_profile.load(std::memory_order_relaxed);
+    uint32_t threshold = (profile == RecoveryProfile::LivePerformance) ? kLiveTimeoutThreshold : kStudioTimeoutThreshold;
+
+    if (state.consecutiveTimeouts >= threshold) {
+        state.isBypassed = true;
+    }
+}
+
+void EngineSupervisor::reportDenormal(uint64_t pluginId, uint32_t severity, uint64_t timestamp) noexcept {
+    m_denormalCount.fetch_add(1, std::memory_order_relaxed);
+
+    std::lock_guard lock(m_healthMutex);
+    auto& state = m_pluginHealth[pluginId];
+    // Increase rolling score based on severity
+    state.rollingCpuScore += static_cast<double>(severity + 1) * 0.1;
+}
+
+bool EngineSupervisor::shouldBypassPlugin(uint64_t pluginId) const noexcept {
+    // Lock-free read: check the bypassed flag directly
+    // The flag is set by reportPluginTimeout under lock
+    std::lock_guard lock(m_healthMutex);
+    auto it = m_pluginHealth.find(pluginId);
+    if (it == m_pluginHealth.end()) return false;
+    return it->second.isBypassed;
+}
+
+bool EngineSupervisor::isPluginQuarantined(uint64_t pluginId) const noexcept {
+    std::lock_guard lock(m_healthMutex);
+    auto it = m_pluginHealth.find(pluginId);
+    if (it == m_pluginHealth.end()) return false;
+    return it->second.isQuarantined;
+}
+
+void EngineSupervisor::quarantinePlugin(uint64_t pluginId) noexcept {
+    std::lock_guard lock(m_healthMutex);
+    auto& state = m_pluginHealth[pluginId];
+    state.isQuarantined = true;
+    state.isBypassed = true;
+}
+
+PluginHealthState EngineSupervisor::getPluginHealth(uint64_t pluginId) const {
+    std::lock_guard lock(m_healthMutex);
+    auto it = m_pluginHealth.find(pluginId);
+    if (it == m_pluginHealth.end()) return {};
+    return it->second;
+}
+
+void EngineSupervisor::decayHealthScores(double decayFactor) {
+    std::lock_guard lock(m_healthMutex);
+    for (auto& [id, state] : m_pluginHealth) {
+        state.rollingCpuScore *= decayFactor;
+        // Reset consecutive timeouts if score drops below threshold
+        if (state.rollingCpuScore < 0.01) {
+            state.consecutiveTimeouts = 0;
+            state.isBypassed = false;
+        }
+    }
+}
+
+void EngineSupervisor::reset() {
+    std::lock_guard lock(m_healthMutex);
+    m_pluginHealth.clear();
+    m_xrunCount.store(0, std::memory_order_relaxed);
+    m_timeoutCount.store(0, std::memory_order_relaxed);
+    m_denormalCount.store(0, std::memory_order_relaxed);
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Core/EngineSupervisor.cpp
+++ b/AestraAudio/src/Core/EngineSupervisor.cpp
@@ -12,53 +12,52 @@ EngineSupervisor::~EngineSupervisor() = default;
 void EngineSupervisor::reportPluginTimeout(uint64_t pluginId, uint64_t timestamp) noexcept {
     m_timeoutCount.fetch_add(1, std::memory_order_relaxed);
 
-    std::lock_guard lock(m_healthMutex);
-    auto& state = m_pluginHealth[pluginId];
-    state.consecutiveTimeouts++;
-    state.lastTimeoutTimestamp = timestamp;
-
-    // Check if we should auto-bypass based on profile
     auto profile = m_profile.load(std::memory_order_relaxed);
-    uint32_t threshold = (profile == RecoveryProfile::LivePerformance) ? kLiveTimeoutThreshold : kStudioTimeoutThreshold;
+    uint32_t threshold = (profile == RecoveryProfile::LivePerformance)
+                             ? kLiveTimeoutThreshold
+                             : kStudioTimeoutThreshold;
 
-    if (state.consecutiveTimeouts >= threshold) {
-        state.isBypassed = true;
+    // Lock-free: update slot
+    getSlot(pluginId).incrementTimeout(threshold);
+
+    // Also update detailed state for non-RT access (best-effort, not critical path)
+    if (m_healthMutex.try_lock()) {
+        auto& state = m_pluginHealth[pluginId];
+        state.consecutiveTimeouts++;
+        state.lastTimeoutTimestamp = timestamp;
+        state.isBypassed = getSlot(pluginId).isBypassed();
+        m_healthMutex.unlock();
     }
 }
 
 void EngineSupervisor::reportDenormal(uint64_t pluginId, uint32_t severity, uint64_t timestamp) noexcept {
+    (void)timestamp;
     m_denormalCount.fetch_add(1, std::memory_order_relaxed);
-
-    std::lock_guard lock(m_healthMutex);
-    auto& state = m_pluginHealth[pluginId];
-    // Increase rolling score based on severity
-    state.rollingCpuScore += static_cast<double>(severity + 1) * 0.1;
+    // Denormals increase rolling score — only tracked in detailed state (non-RT)
+    if (m_healthMutex.try_lock()) {
+        auto& state = m_pluginHealth[pluginId];
+        state.rollingCpuScore += static_cast<double>(severity + 1) * 0.1;
+        m_healthMutex.unlock();
+    }
 }
 
 bool EngineSupervisor::shouldBypassPlugin(uint64_t pluginId) const noexcept {
-    // Lock-free read: check the bypassed flag directly
-    // The flag is set by reportPluginTimeout under lock
-    std::lock_guard lock(m_healthMutex);
-    auto it = m_pluginHealth.find(pluginId);
-    if (it == m_pluginHealth.end()) return false;
-    return it->second.isBypassed;
+    // Lock-free: read from slot array
+    return getSlot(pluginId).isBypassed();
 }
 
 bool EngineSupervisor::isPluginQuarantined(uint64_t pluginId) const noexcept {
-    std::lock_guard lock(m_healthMutex);
-    auto it = m_pluginHealth.find(pluginId);
-    if (it == m_pluginHealth.end()) return false;
-    return it->second.isQuarantined;
+    // Lock-free: read from slot array
+    return getSlot(pluginId).isQuarantined();
 }
 
 void EngineSupervisor::quarantinePlugin(uint64_t pluginId) noexcept {
-    std::lock_guard lock(m_healthMutex);
-    auto& state = m_pluginHealth[pluginId];
-    state.isQuarantined = true;
-    state.isBypassed = true;
+    // Lock-free: write to slot array
+    getSlot(pluginId).setQuarantined();
 }
 
 PluginHealthState EngineSupervisor::getPluginHealth(uint64_t pluginId) const {
+    // NOT lock-free: mutex-protected. Only call from non-RT threads.
     std::lock_guard lock(m_healthMutex);
     auto it = m_pluginHealth.find(pluginId);
     if (it == m_pluginHealth.end()) return {};
@@ -66,20 +65,24 @@ PluginHealthState EngineSupervisor::getPluginHealth(uint64_t pluginId) const {
 }
 
 void EngineSupervisor::decayHealthScores(double decayFactor) {
+    // NOT lock-free: mutex-protected. Only call from non-RT threads.
     std::lock_guard lock(m_healthMutex);
     for (auto& [id, state] : m_pluginHealth) {
         state.rollingCpuScore *= decayFactor;
-        // Reset consecutive timeouts if score drops below threshold
         if (state.rollingCpuScore < 0.01) {
             state.consecutiveTimeouts = 0;
             state.isBypassed = false;
+            // Also clear the lock-free slot
+            getSlot(id).reset();
         }
     }
 }
 
 void EngineSupervisor::reset() {
+    // NOT lock-free: mutex-protected. Only call from non-RT threads.
     std::lock_guard lock(m_healthMutex);
     m_pluginHealth.clear();
+    for (auto& slot : m_slots) slot.reset();
     m_xrunCount.store(0, std::memory_order_relaxed);
     m_timeoutCount.store(0, std::memory_order_relaxed);
     m_denormalCount.store(0, std::memory_order_relaxed);

--- a/AestraAudio/src/Core/EngineSupervisor.cpp
+++ b/AestraAudio/src/Core/EngineSupervisor.cpp
@@ -2,6 +2,7 @@
 #include "EngineSupervisor.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace Aestra {
 namespace Audio {
@@ -10,35 +11,33 @@ EngineSupervisor::EngineSupervisor() = default;
 EngineSupervisor::~EngineSupervisor() = default;
 
 void EngineSupervisor::reportPluginTimeout(uint64_t pluginId, uint64_t timestamp) noexcept {
+    (void)timestamp;
     m_timeoutCount.fetch_add(1, std::memory_order_relaxed);
 
     auto profile = m_profile.load(std::memory_order_relaxed);
-    uint32_t threshold = (profile == RecoveryProfile::LivePerformance)
-                             ? kLiveTimeoutThreshold
-                             : kStudioTimeoutThreshold;
+    uint32_t threshold;
+    switch (profile) {
+        case RecoveryProfile::LivePerformance: threshold = kLiveTimeoutThreshold; break;
+        case RecoveryProfile::OfflineRender:   threshold = kOfflineTimeoutThreshold; break;
+        default:                               threshold = kStudioTimeoutThreshold; break;
+    }
 
-    // Lock-free: update slot
+    // Lock-free: update slot (only safe path on audio thread)
     getSlot(pluginId).incrementTimeout(threshold);
 
-    // Also update detailed state for non-RT access (best-effort, not critical path)
-    if (m_healthMutex.try_lock()) {
-        auto& state = m_pluginHealth[pluginId];
-        state.consecutiveTimeouts++;
-        state.lastTimeoutTimestamp = timestamp;
-        state.isBypassed = getSlot(pluginId).isBypassed();
-        m_healthMutex.unlock();
-    }
+    // Note: m_pluginHealth (mutex-protected, heap-allocating) is NOT updated from the
+    // audio thread. The slot array is the authoritative lock-free state. Non-RT threads
+    // that need detailed health info can read the slot flags and call getPluginHealth()
+    // which accesses m_pluginHealth under mutex.
 }
 
 void EngineSupervisor::reportDenormal(uint64_t pluginId, uint32_t severity, uint64_t timestamp) noexcept {
+    (void)pluginId;
+    (void)severity;
     (void)timestamp;
     m_denormalCount.fetch_add(1, std::memory_order_relaxed);
-    // Denormals increase rolling score — only tracked in detailed state (non-RT)
-    if (m_healthMutex.try_lock()) {
-        auto& state = m_pluginHealth[pluginId];
-        state.rollingCpuScore += static_cast<double>(severity + 1) * 0.1;
-        m_healthMutex.unlock();
-    }
+    // Denormals are counted atomically. Rolling score is updated by decayHealthScores()
+    // on a non-RT thread. The slot array is the authoritative lock-free state.
 }
 
 bool EngineSupervisor::shouldBypassPlugin(uint64_t pluginId) const noexcept {
@@ -66,8 +65,18 @@ PluginHealthState EngineSupervisor::getPluginHealth(uint64_t pluginId) const {
 
 void EngineSupervisor::decayHealthScores(double decayFactor) {
     // NOT lock-free: mutex-protected. Only call from non-RT threads.
+
+    // Sanitize decayFactor: NaN/Inf → 0.0, clamp to [0.0, 1.0]
+    if (!std::isfinite(decayFactor)) decayFactor = 0.0;
+    if (decayFactor < 0.0) decayFactor = 0.0;
+    if (decayFactor > 1.0) decayFactor = 1.0;
+
     std::lock_guard lock(m_healthMutex);
     for (auto& [id, state] : m_pluginHealth) {
+        // Defensive: reset non-finite scores to zero
+        if (!std::isfinite(state.rollingCpuScore)) {
+            state.rollingCpuScore = 0.0;
+        }
         state.rollingCpuScore *= decayFactor;
         if (state.rollingCpuScore < 0.01) {
             state.consecutiveTimeouts = 0;

--- a/AestraAudio/src/Core/RTGuard.cpp
+++ b/AestraAudio/src/Core/RTGuard.cpp
@@ -16,6 +16,14 @@ thread_local ThreadLocalRTAudit g_rtAuditData;
 #include <cstdlib>
 #include <new>
 
+// Cross-platform return address intrinsic
+#if defined(_MSC_VER)
+#include <intrin.h>
+#define AESTRA_RETURN_ADDRESS() _ReturnAddress()
+#else
+#define AESTRA_RETURN_ADDRESS() __builtin_return_address(0)
+#endif
+
 // Track if we're inside our own override to prevent reentrancy
 static thread_local bool g_inOverride = false;
 
@@ -23,7 +31,7 @@ void* operator new(std::size_t size) {
     if (!g_inOverride && Aestra::Audio::isRealtimeAudioThread()) {
         g_inOverride = true;
         Aestra::Audio::recordRTViolation(Aestra::Audio::RTViolationType::Allocation,
-                                          __builtin_return_address(0), size);
+                                          AESTRA_RETURN_ADDRESS(), size);
         g_inOverride = false;
     }
     void* ptr = std::malloc(size);
@@ -35,7 +43,7 @@ void operator delete(void* ptr) noexcept {
     if (!g_inOverride && Aestra::Audio::isRealtimeAudioThread()) {
         g_inOverride = true;
         Aestra::Audio::recordRTViolation(Aestra::Audio::RTViolationType::Deallocation,
-                                          __builtin_return_address(0));
+                                          AESTRA_RETURN_ADDRESS());
         g_inOverride = false;
     }
     std::free(ptr);
@@ -45,5 +53,7 @@ void operator delete(void* ptr) noexcept {
 void operator delete(void* ptr, std::size_t) noexcept {
     operator delete(ptr);
 }
+
+#undef AESTRA_RETURN_ADDRESS
 
 #endif // AESTRA_AUDIT_MODE

--- a/AestraAudio/src/Core/RTGuard.cpp
+++ b/AestraAudio/src/Core/RTGuard.cpp
@@ -1,0 +1,49 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "RTGuard.h"
+
+namespace Aestra {
+namespace Audio {
+
+// Thread-local audit data
+thread_local ThreadLocalRTAudit g_rtAuditData;
+
+} // namespace Audio
+} // namespace Aestra
+
+// Allocation override for AESTRA_AUDIT_MODE builds
+#if defined(AESTRA_AUDIT_MODE)
+
+#include <cstdlib>
+#include <new>
+
+// Track if we're inside our own override to prevent reentrancy
+static thread_local bool g_inOverride = false;
+
+void* operator new(std::size_t size) {
+    if (!g_inOverride && Aestra::Audio::isRealtimeAudioThread()) {
+        g_inOverride = true;
+        Aestra::Audio::recordRTViolation(Aestra::Audio::RTViolationType::Allocation,
+                                          __builtin_return_address(0), size);
+        g_inOverride = false;
+    }
+    void* ptr = std::malloc(size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+
+void operator delete(void* ptr) noexcept {
+    if (!g_inOverride && Aestra::Audio::isRealtimeAudioThread()) {
+        g_inOverride = true;
+        Aestra::Audio::recordRTViolation(Aestra::Audio::RTViolationType::Deallocation,
+                                          __builtin_return_address(0));
+        g_inOverride = false;
+    }
+    std::free(ptr);
+}
+
+// C++14 sized deallocation
+void operator delete(void* ptr, std::size_t) noexcept {
+    operator delete(ptr);
+}
+
+#endif // AESTRA_AUDIT_MODE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The public repository is currently on a `0.x` pre-beta line. The release target tracked in the roadmap is **v1 Beta in December 2026**.
 
+## v0.4.0-alpha — Hardening Milestone (2026-05-20)
+
+### Security
+- Full security audit — 11 findings, 8 fixed, 3 deferred with justification
+- Project load path hardened (structure, numeric, path, compression bomb validation)
+- Crash recovery hardened with opaque flag file and stale backup skip
+- Archive extraction path traversal protection
+- `MixerSettingsSerializationTest` disabled (heap exploitation vector)
+
+### Audio Quality
+- BS.1770 K-weighting for true-peak metering
+- Proper TPDF dither for 16-bit/24-bit export
+- Export quantization uses `std::lrint` (was truncation)
+- Denormal protection via `AESTRA_FTZ_MANUAL`
+- Removed Boost dependency
+
+### RT Safety
+- `GarbageCollector::flush()` lock-free
+- GC retirement from audio thread via SPSC ring buffer
+- `Mixer::m_effectChainSnapshot` race fixed
+- `fadeOutActive` atomic (was torn)
+- `EngineSupervisor` for audio thread liveness
+- `RTGuard` for RT-safety violation detection
+- `AsyncCleanupManager` for deferred resource cleanup
+
+### Build / CI
+- Nightly build workflow (`nightly.yml`) with ASan/UBSan, auto-issue on failure
+- Versioning/tagging policy (AGENTS.md §27) and nightly policy (AGENTS.md §28)
+- macOS CI test exclusions aligned (#229, #230)
+- CodeRabbit review fixes (#236, #237)
+
+### Known Issues (P0 beta-blockers)
+- OOP plugin parameters are no-ops (#238)
+- Autosave serializer data race (#239)
+- Routing: gain smoothing, cycle detection, RT allocation (#240, #241, #243)
+- CLAP MIDI input unimplemented (#244)
+- Full list: 69 issues at https://github.com/users/currentsuspect/projects/3
+
+---
+
 ## [Unreleased]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For the most truthful current status, start with:
 - [docs/technical/roadmap.md](docs/technical/roadmap.md)
 - [docs/technical/testing_ci.md](docs/technical/testing_ci.md)
 - [meta/CHANGELOGS/CHANGELOG_2026Q1.md](meta/CHANGELOGS/CHANGELOG_2026Q1.md)
+- [meta/CHANGELOGS/CHANGELOG_2026Q2.md](meta/CHANGELOGS/CHANGELOG_2026Q2.md)
 
 ## Repository Layout
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,10 +30,17 @@ v1.0.0                  — initial public release
 
 ### v0.4.0-alpha — Hardening Milestone (May 2026)
 
-- Security audit
-- Audio quality session (BS.1770 K-weighting, dither, export quantization, denormal protection)
-- Repo hygiene mega-pass
-- CI: nightly builds, versioning/tagging policy
+**Security audit** — 11 findings, 8 fixed (project load hardening, crash recovery, archive extraction), 3 deferred with justification.
+
+**Audio quality** — BS.1770 K-weighting, TPDF dither, export quantization fix, denormal protection, Boost removal.
+
+**RT safety** — Lock-free GC flush, SPSC retirement, effect chain snapshot race fix, fadeOutActive atomic, EngineSupervisor, RTGuard, AsyncCleanupManager.
+
+**CI/CD** — Nightly builds with ASan/UBSan, versioning/tagging policy, macOS test exclusions, CodeRabbit review fixes.
+
+**Project infrastructure** — 69 issues opened with full taxonomy, GitHub Projects board with 5 sprints through December beta.
+
+**Known P0 beta-blockers** — OOP plugin parameters no-ops (#238), autosave data race (#239), routing bugs (#240-#243), CLAP MIDI unimplemented (#244).
 
 ### v0.1.0-foundation — Engine Foundation (Oct 2025)
 

--- a/Tests/AestraAudio/AudioEngineDiagnosticsTest.cpp
+++ b/Tests/AestraAudio/AudioEngineDiagnosticsTest.cpp
@@ -1,0 +1,167 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AudioEngineDiagnosticsTest.cpp — Tests for diagnostic structs and RT guard
+
+#include "Core/AudioEngineDiagnostics.h"
+#include "Core/RTGuard.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+using namespace Aestra::Audio;
+
+static void testDiagnosticEpochDefaults() {
+    DiagnosticEpoch epoch;
+    assert(epoch.callbackId == 0);
+    assert(epoch.graphGeneration == 0);
+    assert(epoch.transportGeneration == 0);
+    assert(epoch.lastTransportEvent == TransportEventType::None);
+    printf("[PASS] DiagnosticEpoch defaults\n");
+}
+
+static void testDenormalEventInfoDefaults() {
+    DenormalEventInfo info;
+    assert(info.pluginId == 0);
+    assert(info.timestamp == 0);
+    assert(info.severity == 0);
+    printf("[PASS] DenormalEventInfo defaults\n");
+}
+
+static void testAudioEngineDiagnosticsDefaults() {
+    AudioEngineDiagnostics diag;
+    assert(diag.schedulerJitterMs == 0.0);
+    assert(diag.dispatchJitterMs == 0.0);
+    assert(diag.callbackDurationMs == 0.0);
+    assert(diag.xruns == 0);
+    assert(diag.rtAllocations == 0);
+    assert(diag.cpuLoad == 0.0);
+    assert(diag.denormalEvents == 0);
+    printf("[PASS] AudioEngineDiagnostics defaults\n");
+}
+
+static void testCoherentSnapshot() {
+    CoherentDiagnosticsSnapshot snap;
+    assert(snap.generation == 0);
+    assert(snap.diagnostics.xruns == 0);
+    printf("[PASS] CoherentDiagnosticsSnapshot defaults\n");
+}
+
+static void testRTViolationEventDefaults() {
+    RTViolationEvent event;
+    assert(event.timestamp == 0);
+    assert(event.returnAddress == nullptr);
+    assert(event.allocationSize == 0);
+    assert(event.threadId == 0);
+    assert(event.type == RTViolationType::Allocation);
+    printf("[PASS] RTViolationEvent defaults\n");
+}
+
+static void testThreadLocalRTAudit() {
+    // Reset audit data
+    g_rtAuditData = {};
+    assert(g_rtAuditData.violationCount == 0);
+    assert(g_rtAuditData.droppedCount == 0);
+    assert(g_rtAuditData.eventIndex == 0);
+    printf("[PASS] ThreadLocalRTAudit defaults\n");
+}
+
+static void testRTViolationRecording() {
+    g_rtAuditData = {};
+
+    // Record some violations
+    recordRTViolation(RTViolationType::Allocation, (void*)0x1234, 1024);
+    recordRTViolation(RTViolationType::MutexAcquire, (void*)0x5678, 0);
+    recordRTViolation(RTViolationType::BlockingCall, (void*)0x9ABC, 0);
+
+    assert(g_rtAuditData.violationCount == 3);
+    assert(g_rtAuditData.eventIndex == 3);
+    assert(g_rtAuditData.lastEvents[0].type == RTViolationType::Allocation);
+    assert(g_rtAuditData.lastEvents[0].returnAddress == (void*)0x1234);
+    assert(g_rtAuditData.lastEvents[0].allocationSize == 1024);
+    assert(g_rtAuditData.lastEvents[1].type == RTViolationType::MutexAcquire);
+    assert(g_rtAuditData.lastEvents[2].type == RTViolationType::BlockingCall);
+    printf("[PASS] RT violation recording\n");
+}
+
+static void testCircularBufferOverflow() {
+    g_rtAuditData = {};
+
+    // Fill beyond MAX_LOCAL_VIOLATIONS
+    for (size_t i = 0; i < MAX_LOCAL_VIOLATIONS + 10; i++) {
+        recordRTViolation(RTViolationType::Allocation, nullptr, i);
+    }
+
+    assert(g_rtAuditData.violationCount == MAX_LOCAL_VIOLATIONS + 10);
+    assert(g_rtAuditData.droppedCount == 10);
+    printf("[PASS] Circular buffer overflow handling\n");
+}
+
+static void testRTDepthTracking() {
+    g_realtimeAudioThreadDepth = 0;
+    assert(!isRealtimeAudioThread());
+
+    {
+        ScopedRealtimeAudioThread guard;
+        assert(isRealtimeAudioThread());
+        assert(g_realtimeAudioThreadDepth == 1);
+
+        {
+            ScopedRealtimeAudioThread innerGuard;
+            assert(g_realtimeAudioThreadDepth == 2);
+        }
+        assert(g_realtimeAudioThreadDepth == 1);
+    }
+    assert(g_realtimeAudioThreadDepth == 0);
+    assert(!isRealtimeAudioThread());
+    printf("[PASS] RT depth tracking with nested guards\n");
+}
+
+static void testThreadLocalIsolation() {
+    g_rtAuditData = {};
+    g_realtimeAudioThreadDepth = 0;
+
+    // Record violations on main thread
+    recordRTViolation(RTViolationType::Allocation, (void*)0x1111, 100);
+    assert(g_rtAuditData.violationCount == 1);
+
+    // Check isolation on another thread
+    std::thread other([] {
+        assert(g_rtAuditData.violationCount == 0);
+        assert(g_realtimeAudioThreadDepth == 0);
+        recordRTViolation(RTViolationType::Deallocation, (void*)0x2222, 200);
+        assert(g_rtAuditData.violationCount == 1);
+    });
+    other.join();
+
+    // Main thread should still have 1
+    assert(g_rtAuditData.violationCount == 1);
+    printf("[PASS] Thread-local isolation\n");
+}
+
+static void testTransportEventTypeValues() {
+    assert(static_cast<uint32_t>(TransportEventType::None) == 0);
+    assert(static_cast<uint32_t>(TransportEventType::Seek) == 1);
+    assert(static_cast<uint32_t>(TransportEventType::LoopWrap) == 2);
+    assert(static_cast<uint32_t>(TransportEventType::StopToPlay) == 3);
+    assert(static_cast<uint32_t>(TransportEventType::TempoMapRebuild) == 4);
+    assert(static_cast<uint32_t>(TransportEventType::PrerollStart) == 5);
+    printf("[PASS] TransportEventType values\n");
+}
+
+int main() {
+    printf("=== AudioEngineDiagnostics Tests ===\n");
+    testDiagnosticEpochDefaults();
+    testDenormalEventInfoDefaults();
+    testAudioEngineDiagnosticsDefaults();
+    testCoherentSnapshot();
+    testRTViolationEventDefaults();
+    testThreadLocalRTAudit();
+    testRTViolationRecording();
+    testCircularBufferOverflow();
+    testRTDepthTracking();
+    testThreadLocalIsolation();
+    testTransportEventTypeValues();
+    printf("\nAll tests passed.\n");
+    return 0;
+}

--- a/Tests/AestraAudio/PathologicalChaosStressTest.cpp
+++ b/Tests/AestraAudio/PathologicalChaosStressTest.cpp
@@ -28,16 +28,16 @@ static void testConcurrentViolationRecording() {
             // Reset this thread's audit data
             g_rtAuditData = {};
 
-            // Signal ready and wait for all threads
+            // Signal ready and wait for all threads (yield to avoid burning CPU)
             ready.fetch_add(1, std::memory_order_relaxed);
             while (ready.load(std::memory_order_relaxed) < NUM_THREADS) {
-                // spin
+                std::this_thread::yield();
             }
 
             // Record violations
             for (int i = 0; i < VIOLATIONS_PER_THREAD; i++) {
                 recordRTViolation(RTViolationType::Allocation,
-                                  reinterpret_cast<void*>(static_cast<uintptr_t>(t * 10000 + i)),
+                                  nullptr,
                                   static_cast<size_t>(i));
             }
 
@@ -84,7 +84,7 @@ static void testMixedWorkload() {
         // Simulate some allocations (violations)
         for (int a = 0; a < ALLOCATIONS_PER_CALLBACK; a++) {
             recordRTViolation(RTViolationType::Allocation,
-                              reinterpret_cast<void*>(static_cast<uintptr_t>(cb * 100 + a)),
+                              nullptr,
                               256);
         }
     }
@@ -105,7 +105,7 @@ static void testCircularBufferStress() {
     constexpr size_t TOTAL = MAX_LOCAL_VIOLATIONS * 3;
     for (size_t i = 0; i < TOTAL; i++) {
         recordRTViolation(RTViolationType::Allocation,
-                          reinterpret_cast<void*>(i),
+                          nullptr,
                           i * 10);
     }
 

--- a/Tests/AestraAudio/PathologicalChaosStressTest.cpp
+++ b/Tests/AestraAudio/PathologicalChaosStressTest.cpp
@@ -1,0 +1,126 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// PathologicalChaosStressTest.cpp — Stress test for RT safety under chaotic conditions
+
+#include "Core/AudioEngine.h"
+#include "Core/RTGuard.h"
+
+#include <cassert>
+#include <cstdio>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <chrono>
+
+using namespace Aestra::Audio;
+
+/**
+ * Stress test: multiple threads recording RT violations simultaneously.
+ * Verifies thread-local isolation and no data races.
+ */
+static void testConcurrentViolationRecording() {
+    constexpr int NUM_THREADS = 8;
+    constexpr int VIOLATIONS_PER_THREAD = 1000;
+    std::atomic<int> ready{0};
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < NUM_THREADS; t++) {
+        threads.emplace_back([&ready, t] {
+            // Reset this thread's audit data
+            g_rtAuditData = {};
+
+            // Signal ready and wait for all threads
+            ready.fetch_add(1, std::memory_order_relaxed);
+            while (ready.load(std::memory_order_relaxed) < NUM_THREADS) {
+                // spin
+            }
+
+            // Record violations
+            for (int i = 0; i < VIOLATIONS_PER_THREAD; i++) {
+                recordRTViolation(RTViolationType::Allocation,
+                                  reinterpret_cast<void*>(static_cast<uintptr_t>(t * 10000 + i)),
+                                  static_cast<size_t>(i));
+            }
+
+            // Verify count
+            assert(g_rtAuditData.violationCount == static_cast<uint64_t>(VIOLATIONS_PER_THREAD));
+        });
+    }
+
+    for (auto& t : threads) t.join();
+    printf("[PASS] Concurrent violation recording (%d threads x %d violations)\n",
+           NUM_THREADS, VIOLATIONS_PER_THREAD);
+}
+
+/**
+ * Stress test: rapid guard creation/destruction.
+ * Verifies no leaks or races in the RAII depth tracking.
+ */
+static void testRapidGuardLifecycle() {
+    constexpr int ITERATIONS = 100000;
+    g_realtimeAudioThreadDepth = 0;
+
+    for (int i = 0; i < ITERATIONS; i++) {
+        ScopedRealtimeAudioThread guard;
+        assert(g_realtimeAudioThreadDepth == 1);
+    }
+    assert(g_realtimeAudioThreadDepth == 0);
+    printf("[PASS] Rapid guard lifecycle (%d iterations)\n", ITERATIONS);
+}
+
+/**
+ * Stress test: mixed guard and violation recording under load.
+ * Simulates a realistic audio callback scenario.
+ */
+static void testMixedWorkload() {
+    constexpr int CALLBACKS = 1000;
+    constexpr int ALLOCATIONS_PER_CALLBACK = 5;
+
+    g_realtimeAudioThreadDepth = 0;
+    g_rtAuditData = {};
+
+    for (int cb = 0; cb < CALLBACKS; cb++) {
+        ScopedRealtimeAudioThread guard;
+
+        // Simulate some allocations (violations)
+        for (int a = 0; a < ALLOCATIONS_PER_CALLBACK; a++) {
+            recordRTViolation(RTViolationType::Allocation,
+                              reinterpret_cast<void*>(static_cast<uintptr_t>(cb * 100 + a)),
+                              256);
+        }
+    }
+
+    assert(g_rtAuditData.violationCount == static_cast<uint64_t>(CALLBACKS * ALLOCATIONS_PER_CALLBACK));
+    assert(g_realtimeAudioThreadDepth == 0);
+    printf("[PASS] Mixed workload (%d callbacks x %d allocations)\n",
+           CALLBACKS, ALLOCATIONS_PER_CALLBACK);
+}
+
+/**
+ * Stress test: circular buffer overflow behavior.
+ * Verifies that overflow doesn't corrupt data.
+ */
+static void testCircularBufferStress() {
+    g_rtAuditData = {};
+
+    constexpr size_t TOTAL = MAX_LOCAL_VIOLATIONS * 3;
+    for (size_t i = 0; i < TOTAL; i++) {
+        recordRTViolation(RTViolationType::Allocation,
+                          reinterpret_cast<void*>(i),
+                          i * 10);
+    }
+
+    assert(g_rtAuditData.violationCount == TOTAL);
+    assert(g_rtAuditData.droppedCount == TOTAL - MAX_LOCAL_VIOLATIONS);
+    printf("[PASS] Circular buffer stress (%zu events, %zu dropped)\n",
+           TOTAL, g_rtAuditData.droppedCount);
+}
+
+int main() {
+    printf("=== PathologicalChaosStressTest ===\n");
+    testConcurrentViolationRecording();
+    testRapidGuardLifecycle();
+    testMixedWorkload();
+    testCircularBufferStress();
+    printf("\nAll stress tests passed.\n");
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -572,6 +572,24 @@ target_include_directories(AestraMixerChannelScratchBufferTest PRIVATE
 add_test(NAME AestraMixerChannelScratchBufferTest COMMAND AestraMixerChannelScratchBufferTest)
 set_tests_properties(AestraMixerChannelScratchBufferTest PROPERTIES LABELS "audio;plugin;regression")
 
+# AudioEngineDiagnostics Test
+add_executable(AestraAudioEngineDiagnosticsTest AestraAudio/AudioEngineDiagnosticsTest.cpp)
+target_link_libraries(AestraAudioEngineDiagnosticsTest PRIVATE AestraAudio)
+target_include_directories(AestraAudioEngineDiagnosticsTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+)
+add_test(NAME AestraAudioEngineDiagnosticsTest COMMAND AestraAudioEngineDiagnosticsTest)
+set_tests_properties(AestraAudioEngineDiagnosticsTest PROPERTIES LABELS "audio;diagnostics;rt-safety")
+
+# PathologicalChaosStressTest
+add_executable(AestraPathologicalChaosStressTest AestraAudio/PathologicalChaosStressTest.cpp)
+target_link_libraries(AestraPathologicalChaosStressTest PRIVATE AestraAudio)
+target_include_directories(AestraPathologicalChaosStressTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+)
+add_test(NAME AestraPathologicalChaosStressTest COMMAND AestraPathologicalChaosStressTest)
+set_tests_properties(AestraPathologicalChaosStressTest PROPERTIES LABELS "audio;stress;rt-safety")
+
 # Watchdog Test (requires VST3 SDK headers)
 if(EXISTS "${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces/vst/ivstaudioprocessor.h")
     add_executable(AestraWatchdogTest AestraAudio/WatchdogTest.cpp)

--- a/meta/CHANGELOGS/CHANGELOG_2026Q2.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q2.md
@@ -1,0 +1,197 @@
+# Changelog — 2026 Q2 (March–May)
+
+All notable changes for Aestra in Q2 2026 are documented here.
+
+## v0.4.0-alpha — Hardening Milestone (2026-05-20)
+
+### Security
+
+- Full security audit completed — 11 findings identified, 8 fixed, 3 deferred with written justifications
+- Project load path hardened against malicious files (structure, numeric, path, compression bomb validation)
+- Crash recovery (`crash_flag`) hardened with opaque flag file, stale backup skip, max-load-size guard
+- Archive extraction path traversal protection (`../` and absolute path rejection)
+- `MixerSettingsSerializationTest` disabled (heap exploitation vector)
+
+### Audio Quality
+
+- BS.1770 K-weighting filter for true-peak metering
+- Proper TPDF dither for 16-bit and 24-bit export (replacing naive quantization)
+- Export quantization uses `std::lrint` instead of truncation
+- Denormal protection via `AESTRA_FTZ_MANUAL` macro
+- Removed Boost dependency (only user was sinc interpolator, replaced with manual `std::tgamma`)
+
+### RT Safety
+
+- `GarbageCollector::flush()` made lock-free
+- GC retirement from audio thread via SPSC ring buffer
+- `Mixer::m_effectChainSnapshot` race fixed (double-buffered, lock-free publish)
+- `fadeOutActive` moved to `std::atomic<bool>` (was torn under concurrent access)
+- `EngineSupervisor` added for audio thread liveness monitoring
+- `RTGuard` added for RT-safety violation detection
+- `AsyncCleanupManager` added for deferred resource cleanup
+
+### Build / CI
+
+- Nightly build workflow (`nightly.yml`) — scheduled headless build with ASan/UBSan, auto-issue on failure
+- Versioning and tagging policy (AGENTS.md Section 27)
+- Nightly build policy (AGENTS.md Section 28)
+- RELEASES.md tag inventory and milestone history
+- macOS CI test exclusions aligned with sanitizer config (#229, #230)
+- gitleaks PR trigger fix (workflow existed, issue closed)
+- CodeRabbit review findings fixed (PR #236, #237)
+- Deprecated `std::atomic_load` on `shared_ptr` identified (14+ sites, tracked as #251)
+- `-Wno-maybe-uninitialized` global suppression identified (tracked as #260)
+- Global warning suppressions documented
+
+### Plugin Hosting
+
+- OOP plugin parameters identified as no-ops (tracked as #238, P0 beta-blocker)
+- CLAP MIDI input identified as unimplemented (tracked as #244, P0 beta-blocker)
+- CLAP host callbacks identified as no-ops (tracked as #270)
+- Plugin crash protection identified as Linux-only (tracked as #247)
+- Per-plugin NaN/Inf validation identified as missing (tracked as #248)
+
+### Serialization / Project Persistence
+
+- Autosave serializer data race identified (tracked as #239, P0 beta-blocker)
+- No fsync in any write path identified (tracked as #245)
+- Autosave non-atomic remove+rename identified (tracked as #246)
+- Migration framework identified as unproven (tracked as #249)
+- Content integrity check identified as missing (tracked as #263)
+- Asset references identified as paths not hashes (tracked as #264)
+- ProjectSerializer layering violation identified (tracked as #266)
+- 13 unregistered test files identified (tracked as #250)
+
+### UI
+
+- Full UI token pass — theme tokens applied to Arsenal, Timeline, Audition, FileBrowser, Transport, MenuBar, TitleBar
+- Piano roll features completed (9 features, 7 bug fixes)
+- Mixer color palette, track color index, right-click swatch picker
+- Plugin browser filter redesign
+- File preview panel overhaul
+
+### Routing
+
+- Send gains not smoothed — identified as P0 (tracked as #240)
+- No cycle detection — identified as P0 (tracked as #241)
+- RT allocation in render loop — identified as P0 (tracked as #243)
+- Send pan law inconsistency — identified (tracked as #261)
+- Per-sample send iteration — identified (tracked as #262)
+
+### Platform
+
+- macOS platform identified as unimplemented (tracked as #267)
+- Linux RT scheduling identified as missing (tracked as #255)
+- Audio settings page device enumeration freeze identified (tracked as #256)
+
+### Testing
+
+- ArsenalExportLiveParityTest fixed (2026-05-15, re-fixed 2026-05-19)
+- NUITextInputLayoutTest identified as pre-existing failure
+- MixerChannelScratchBuffer and OfflineRenderRegression verified active
+- 13 unregistered test files documented
+
+### Documentation
+
+- AGENTS.md Sections 27 (Versioning/Tagging) and 28 (Nightly Builds) added
+- RELEASES.md created with tag inventory and milestone history
+- 69 GitHub issues opened with full priority/type/component taxonomy
+- GitHub Projects board created with sprint structure through December
+
+### Known Issues (as of v0.4.0-alpha)
+
+- OOP plugin parameters are no-ops (#238) — P0
+- Autosave serializer data race (#239) — P0
+- Routing gain smoothing, cycle detection, RT allocation (#240, #241, #243) — P0
+- CLAP MIDI input unimplemented (#244) — P0
+- 5 empty model stub files (#252) — P1
+- No fsync in write paths (#245) — P1
+- macOS platform unimplemented (#267) — P1
+- 13 unregistered test files (#250) — P1
+- Full list: https://github.com/users/currentsuspect/projects/3
+
+---
+
+## v0.3.0-alpha — Plugin Expansion (March–April 2026)
+
+### Audio Plugins
+
+- **AestraComp**: RMS-based detection, hardware compressor behavior
+- **AestraVerb**: SIMD optimizations (SSE/AVX), reverb quality lab
+- **AestraDelay**: Full delay plugin implementation
+- **Rumble**: 808-style bass synth with Arsenal integration
+- **AestraEQ**: Parametric equalizer
+
+### Arsenal
+
+- UnitManager runtime/persistence layer
+- Internal plugin metadata (`BuiltInPlugins`)
+- Arsenal unit enable/attach/load flows
+- Plugin state survives project round-trips
+
+### Piano Roll
+
+- Double-click pattern clips to open in Piano Roll
+- Unit routing (notes carry `unitId`)
+- Piano Roll ↔ Sequencer sync
+- Auto-save on note changes
+
+### Playlist / Clip Editing
+
+- Cut/Copy/Paste/Delete wired to edit menu and shortcuts
+- Split tool via blade tool click and `S` key
+- Clip split bug fix (patternId, name, colorRGBA preserved)
+
+### Export / Offline Render
+
+- AudioExporter rewrite — uses `AudioRenderer::renderBlock()`
+- Duration computed from actual playlist
+- Position advances correctly (sample-accurate)
+- Master output stage applied during export
+- Three render scopes: FullSong, LoopRegion, Selection
+- Bit depths: 16-bit, 24-bit, 32-bit float
+
+### Device Resilience
+
+- Driver-level underrun/xrun telemetry
+- Health monitor thread (500ms polling, 2s stall detection)
+- Hot-plug detection (WASAPI `IMMNotificationClient`)
+- RT safety: removed stdout/stderr from audio threads
+- PerformanceHUD enhancements
+
+### Build / CI
+
+- Low-memory build preset (`lowmem`) for 4GB RAM machines
+- CI pipeline fixes (macOS Security framework, Windows C++17 compat)
+- gitleaks expansion to PR trigger
+
+---
+
+## v0.2.0-alpha — First Plugin Generation (January–February 2026)
+
+### Audio Engine
+
+- ASIO driver support (dual-tier: ASIO + WASAPI/DirectSound)
+- Pan law optimization (per-block gain smoothing)
+- Resampling pre-calculated window tables
+- Master silence bug fix (buffer reallocation invalidating routing pointers)
+
+### UI
+
+- Audio preview scrubbing (real-time click/drag on waveforms)
+- File Preview Panel overhaul
+- Waveform generation and redraw fixes
+
+### Build
+
+- FreeType deprecation warning suppression
+- CMake build system improvements
+
+---
+
+## v0.1.0-foundation — Engine Foundation (October 2025)
+
+- Initial engine architecture
+- Core audio pipeline
+- Basic plugin hosting
+- Platform abstraction (Windows, Linux)


### PR DESCRIPTION
## Summary
- **AudioEngineDiagnostics.h** — DiagnosticEpoch, DenormalEventInfo, AudioEngineDiagnostics structs for multi-tier timing breakdown
- **EngineSupervisor.h/.cpp** — Plugin health tracking with rolling CPU score decay, multi-tier recovery profiles (Studio/Live/Offline), quarantine support
- **AsyncCleanupManager.h/.cpp** — SPSC ring buffer for lock-free audio→cleanup communication, background thread for deferred plugin teardown
- **RTGuard.h/.cpp** — RTViolationEvent, ThreadLocalRTAudit, thread-local circular buffer, allocation override in AESTRA_AUDIT_MODE builds
- **AudioEngineDiagnosticsTest** — 11 tests for structs and RT guard
- **PathologicalChaosStressTest** — 4 stress tests (concurrent, lifecycle, mixed, overflow)

## Why
Reconstructs the RT safety infrastructure that was lost when untracked files were deleted by `git clean -fd`. Rebuilt from the antigravity design spec with exact struct definitions.

## Test plan
- [x] AudioEngineDiagnosticsTest: 11/11 passed
- [x] PathologicalChaosStressTest: 4/4 passed
- [ ] Verify no regressions in existing tests

## Risk/rollback
- New files only — no changes to existing audio engine code
- RTGuard allocation override is gated behind `AESTRA_AUDIT_MODE`
- Rollback: revert commit

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Core RT Safety Infrastructure** — Rebuilt diagnostics, plugin supervision, and RT violation auditing after accidental removal:

- **AudioEngineDiagnostics** (`AudioEngineDiagnostics.h`) — New diagnostics types for multi-tier epoch/generation tracking, denormal events, callback timing jitter, xrun counts, and CPU load metrics

- **EngineSupervisor** (`EngineSupervisor.h/cpp`) — Plugin health manager with:
  - Lock-free slot array for audio-thread timeout/denormal reporting (no allocations)
  - Mutex-protected detailed health state (rolling CPU scores, bypass/quarantine flags)
  - Three recovery profiles (Studio/Live/Offline) controlling health thresholds
  - Health decay with automatic bypass clearing when scores recover

- **AsyncCleanupManager** (`AsyncCleanupManager.h/cpp`) — Background cleanup queue for quarantined plugins:
  - Fixed-capacity SPSC ring buffer (lock-free, allocation-free)
  - Function-pointer callbacks + context (avoids `std::function` allocations)
  - Graceful drain on shutdown with remaining task processing

- **RTGuard** (`RTGuard.h/cpp`) — RT violation auditing infrastructure:
  - Thread-local circular buffer for recording violations (allocations, deallocations, mutex acquires, blocking calls)
  - Global allocation override (only active under `AESTRA_AUDIT_MODE`)
  - Cross-platform return-address intrinsics for violation context
  - Per-thread violation counters and drop tracking

- **Tests** — Comprehensive test coverage:
  - AudioEngineDiagnosticsTest: 11 tests validating diagnostics structs and RT audit behavior
  - PathologicalChaosStressTest: 4 stress tests for concurrent violations and depth tracking

- **Build System** — Updated `CMakeLists.txt` to include new source/header files in `AestraAudioCore` target

- **Documentation** — Added v0.4.0-alpha changelog, updated releases/roadmap links

## Why

Reconstructs RT safety infrastructure removed by accidental `git clean`, rebuilt to match the Antigravity design spec. Code-review fixes applied to replace mutex-based maps with lock-free arrays on audio thread and eliminate allocation patterns.

## Impact

- **New files only** — no changes to existing audio engine code
- **Backward compatible** — allocation override gated by build flag
- **All tests passing** — 11/11 diagnostics, 4/4 stress tests verified

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->