### PR TITLE
fix: autosave atomic rename — use POSIX rename-over on non-Windows

### DIFF
--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -403,10 +403,14 @@ bool AutosaveManager::performAutosave() {
         }
     }
     
+    // Atomic replace: on POSIX, rename() atomically replaces the target.
+    // On Windows, we must remove first (no atomic rename-over-existing in std::filesystem).
+#ifdef _WIN32
     if (fs::exists(target, ec)) {
         fs::remove(target, ec);
     }
-    
+#endif
+
     fs::rename(tmp, target, ec);
     if (ec) {
         notifyError("Autosave failed: cannot replace target file");


### PR DESCRIPTION
## Summary
- Only does remove+rename on Windows (where std::filesystem::rename cannot atomically replace)
- On POSIX, rename() atomically replaces the target — no preceding remove needed

## Why
Closes #246 — autosave non-atomic remove+rename can lose the autosave file if process crashes between the two operations.

## Test plan
- [ ] Verify autosave works on Linux
- [ ] Verify autosave works on Windows

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)