### PR TITLE
feat: CLAP parameter support — ClapParamInfo, ClapPluginParams structs

### DIFF
--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -148,10 +148,38 @@ struct ClapPluginState {
     bool (*load)(const ClapPlugin* plugin, const ClapIstream* stream);
 };
 
-constexpr uint16_t kClapCoreEventSpaceId = 0;
-constexpr uint16_t kClapEventMidi = 10;
-constexpr const char* kClapPluginFactoryId = "clap.plugin-factory";
+struct ClapParamInfo {
+    uint32_t id;
+    uint32_t flags;
+    const void* cookie;
+    char name[256];
+    char module[256];
+    double minValue;
+    double maxValue;
+    double defaultValue;
+    char unit[32];
+    uint32_t valueCount;
+    int32_t stepCount;
+};
+
+constexpr uint32_t kClapParamIsAutomatable = (1u << 0);
+constexpr uint32_t kClapParamIsReadOnly = (1u << 1);
+constexpr uint32_t kClapParamIsBypass = (1u << 2);
+constexpr uint32_t kClapParamIsHidden = (1u << 3);
+constexpr uint32_t kClapParamIsAdvanced = (1u << 4);
+
+struct ClapPluginParams {
+    uint32_t (*count)(const ClapPlugin* plugin);
+    bool (*getParamInfo)(const ClapPlugin* plugin, uint32_t paramIndex, ClapParamInfo* info);
+    double (*getParamValue)(const ClapPlugin* plugin, uint32_t paramId);
+    bool (*getParamValueById)(const ClapPlugin* plugin, const ClapParamInfo* paramInfo, double* value);
+    bool (*valueToText)(const ClapPlugin* plugin, uint32_t paramId, double value, char* display, uint32_t size);
+    bool (*textToValue)(const ClapPlugin* plugin, uint32_t paramId, const char* display, double* value);
+    void (*flush)(const ClapPlugin* plugin, const void* inChanges, const void* outChanges);
+};
+
 constexpr const char* kClapExtState = "clap.state";
+constexpr const char* kClapExtParams = "clap.params";
 constexpr const char* kProbeFirstClapPluginId = "__aestra_probe_first__";
 
 bool isClapVersionCompatible(const ClapVersion& version) {
@@ -253,6 +281,7 @@ struct ClapModule {
     float* outputPlanes[2] = {nullptr, nullptr};
     ClapInputEvents emptyInputEvents = {nullptr, emptyInputEventsSize, emptyInputEventsGet};
     ClapOutputEvents outputEvents = {nullptr, dropOutputEvent};
+    const ClapPluginParams* paramsExt = nullptr;
 
     ~ClapModule() { close(); }
 
@@ -351,6 +380,9 @@ struct ClapModule {
             error = "clap-plugin-init-failed";
             close();
             return false;
+        }
+        if (plugin->getExtension) {
+            paramsExt = static_cast<const ClapPluginParams*>(plugin->getExtension(plugin, kClapExtParams));
         }
         return true;
     }

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -50,7 +50,7 @@ constexpr ClapProcessStatus kClapProcessError = 0;
 // CLAP core constants (from clap/include/clap/)
 constexpr const char* kClapPluginFactoryId = "clap.plugin-factory";
 constexpr uint16_t kClapCoreEventSpaceId = 0;
-constexpr uint16_t kClapEventMidi = 0;
+constexpr uint16_t kClapEventMidi = 10;
 
 struct ClapHost {
     ClapVersion clapVersion;

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -47,6 +47,11 @@ struct ClapEventHeader;
 using ClapProcessStatus = int32_t;
 constexpr ClapProcessStatus kClapProcessError = 0;
 
+// CLAP core constants (from clap/include/clap/)
+constexpr const char* kClapPluginFactoryId = "clap.plugin-factory";
+constexpr uint16_t kClapCoreEventSpaceId = 0;
+constexpr uint16_t kClapEventMidi = 0;
+
 struct ClapHost {
     ClapVersion clapVersion;
     void* hostData;

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -296,6 +296,7 @@ struct ClapModule {
 
     void close() {
         deactivate();
+        paramsExt = nullptr;
         if (plugin && plugin->destroy) {
             plugin->destroy(plugin);
         }


### PR DESCRIPTION
## Summary
- ClapParamInfo struct with id, flags, name, min/max/default values
- ClapPluginParams struct with count, getParamInfo, getParamValue, flush
- Parameter flags (automatable, readonly, bypass, hidden, advanced)
- kClapExtParams extension constant

## Why
Foundation for OOP plugin parameter automation (#238). The OOP plugin parameters are currently no-ops — this adds the CLAP parameter extension structures needed to implement parameter passing.

## Test plan
- [ ] Verify CLAP plugin parameter discovery works
- [ ] Verify parameter value read/write works

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Feature: CLAP Parameter Extension Support**
- Adds `ClapParamInfo` and `ClapPluginParams` structs to enable CLAP parameter discovery and automation
- Introduces parameter capability flags (automatable, readonly, bypass, hidden, advanced)
- Adds the `clap.params` extension constant (`kClapExtParams`) to identify the parameters extension
- Implements parameter extension retrieval in the plugin loading lifecycle

**Fixes for CI Failures**
- Restores three accidentally deleted CLAP core constants that were breaking GCC and Clang builds:
  - `kClapCoreEventSpaceId` (uint16_t, value: 0)
  - `kClapEventMidi` (uint16_t, value: 10)
  - `kClapPluginFactoryId` (const char*, value: "clap.plugin-factory")

**Minor Updates**
- Fixes MSVC lambda capture in `PathologicalChaosStressTest.cpp` to capture all local variables by reference for MSVC compatibility

**Purpose**: Provides the foundation for OOP plugin parameter automation (issue `#238`) and enables parameter passing that was previously non-functional.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->