### PR TITLE
fix: remove fallback singleton in AudioEngine::getInstance()

### DIFF
--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <algorithm>
+#include <cstdlib>
 #include <cassert>
 #include <cerrno>
 #include <chrono>

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -121,11 +121,12 @@ inline void addMidiPanic(Aestra::Audio::MidiBuffer& buf) {
 static AudioEngine* g_audioEngineInstance = nullptr;
 
 AudioEngine& AudioEngine::getInstance() {
-    // Assert if null in debug builds
     if (!g_audioEngineInstance) {
-        // Critical error - engine not created yet
-        static AudioEngine fallback; // Emergency fallback
-        return fallback;
+        // Engine not registered — this is a programming error.
+        // In debug builds, assert to catch it early. In release, log and abort.
+        Aestra::Log::error("[AudioEngine] getInstance() called before engine was created!");
+        assert(g_audioEngineInstance && "AudioEngine::getInstance() called before engine was created");
+        std::abort();
     }
     return *g_audioEngineInstance;
 }
@@ -1547,11 +1548,7 @@ const AudioEngine::BiquadCoeff AudioEngine::kKWeightRLB = {
  */
 AudioEngine::AudioEngine() {
     installRealtimeMisuseHandler();
-    g_audioEngineInstance = this; // [NEW] Register singleton
-
-    if (g_audioEngineInstance == nullptr) {
-        g_audioEngineInstance = this;
-    }
+    g_audioEngineInstance = this; // Register singleton
     Aestra::Log::info("[AudioEngine] Created (Original Ctor). Ptr: " +
                       std::to_string(reinterpret_cast<uintptr_t>(this)));
 


### PR DESCRIPTION
## Summary
- Remove the static fallback `AudioEngine` that masked misuse of `getInstance()` before engine construction
- `getInstance()` now logs an error and aborts if called before the engine is registered
- Remove redundant null check in constructor (dead code — assignment always runs first)

## Why
The old fallback silently created a second AudioEngine instance if `getInstance()` was called before construction. This masked programming errors and could cause subtle bugs (wrong instance, duplicate state). A hard abort makes the misuse immediately visible.

## Test plan
- [x] Build passes (AestraAudioCore)
- [ ] Verify no code path calls `getInstance()` before engine construction in normal startup
- [ ] Debug build: assert fires on premature `getInstance()` call

Fixes #242

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to AudioEngine::getInstance() and constructor

**Breaking changes:** AudioEngine::getInstance() now aborts (terminates the process) if called before an AudioEngine instance is created, rather than silently constructing a fallback singleton.

- **getInstance() behavior**: Previously returned a static fallback AudioEngine when none was registered, which could silently create a second engine causing split-state bugs. Now logs an error, asserts (in debug builds), and calls `std::abort()` to surface misuse immediately.

- **Constructor simplified**: Removed redundant null-check logic when registering the singleton—now directly assigns `g_audioEngineInstance = this` unconditionally.

- **Include added**: `#include <cstdlib>` to support `std::abort()`.

**Rationale:** Eliminates the latent bug where the fallback could construct a duplicate engine; instead forces callers to either handle a nullptr or guarantee the engine exists at call time, making misuse visible during development and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->