### PR TITLE
fix: ChannelSlotMap flat arrays — eliminate unordered_map from RT path

### DIFF
--- a/AestraAudio/include/Core/ChannelSlotMap.h
+++ b/AestraAudio/include/Core/ChannelSlotMap.h
@@ -1,9 +1,9 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace Aestra {
@@ -24,6 +24,11 @@ class MixerChannel;
  * - After rebuild(), getSlotIndex() and getChannelId() are safe to call from any thread
  *   (read-only access to immutable data after rebuild)
  *
+ * RT Safety:
+ * - No heap allocation in any method. All storage is fixed-size std::array.
+ * - getSlotIndex() is O(n) with n <= 127 (linear scan), deterministic and cache-friendly.
+ * - getChannelId() is O(1) direct index lookup.
+ *
  * Requirements: 12.5 - Each channel control parameter SHALL be identified by stable
  * (channelId, paramId) pairs for automation readiness.
  */
@@ -38,7 +43,10 @@ public:
     /// Maximum number of channel slots (excluding master)
     static constexpr uint32_t MAX_CHANNEL_SLOTS = 127;
 
-    ChannelSlotMap() = default;
+    /// Total array size (slots 0..126 + master at 127)
+    static constexpr uint32_t ARRAY_SIZE = MAX_CHANNEL_SLOTS + 1;
+
+    ChannelSlotMap() : m_slotToId{}, m_channelCount{0} { m_slotToId.fill(INVALID_SLOT); }
     ~ChannelSlotMap() = default;
 
     // Copyable (UI snapshots) and movable
@@ -65,7 +73,8 @@ public:
     /**
      * @brief Get the dense slot index for a channel ID.
      *
-     * O(1) lookup. Safe to call from audio thread after rebuild().
+     * O(n) linear scan, n <= 127. Deterministic, no hash computation.
+     * Safe to call from audio thread after rebuild().
      *
      * @param channelId The track/channel ID
      * @return Dense slot index, or INVALID_SLOT if not found
@@ -75,7 +84,7 @@ public:
     /**
      * @brief Get the channel ID for a dense slot index.
      *
-     * O(1) lookup. Safe to call from audio thread after rebuild().
+     * O(1) direct index lookup. Safe to call from audio thread after rebuild().
      *
      * @param slotIndex Dense slot index (0..MAX_CHANNEL_SLOTS-1)
      * @return Channel ID, or INVALID_SLOT if not found
@@ -103,9 +112,11 @@ public:
     void clear();
 
 private:
-    std::unordered_map<uint32_t, uint32_t> m_idToSlot; ///< channelId -> slotIndex
-    std::unordered_map<uint32_t, uint32_t> m_slotToId; ///< slotIndex -> channelId
-    uint32_t m_channelCount{0};                        ///< Number of mapped channels
+    /// Slot-to-ID: direct index lookup. m_slotToId[slot] = channelId, or INVALID_SLOT.
+    std::array<uint32_t, ARRAY_SIZE> m_slotToId;
+
+    /// Number of mapped channels (excluding master)
+    uint32_t m_channelCount{0};
 };
 
 } // namespace Audio

--- a/AestraAudio/src/ChannelSlotMap.cpp
+++ b/AestraAudio/src/ChannelSlotMap.cpp
@@ -8,15 +8,13 @@ namespace Aestra {
 namespace Audio {
 
 void ChannelSlotMap::rebuild(const std::vector<std::unique_ptr<MixerChannel>>& channels) {
-    m_idToSlot.clear();
-    m_slotToId.clear();
+    m_slotToId.fill(INVALID_SLOT);
     m_channelCount = 0;
 
     uint32_t slot = 0;
     for (const auto& channel : channels) {
         if (channel && slot < MAX_CHANNEL_SLOTS) {
             uint32_t channelId = channel->getChannelId();
-            m_idToSlot[channelId] = slot;
             m_slotToId[slot] = channelId;
             ++slot;
         }
@@ -25,22 +23,28 @@ void ChannelSlotMap::rebuild(const std::vector<std::unique_ptr<MixerChannel>>& c
 }
 
 uint32_t ChannelSlotMap::getSlotIndex(uint32_t channelId) const {
-    auto it = m_idToSlot.find(channelId);
-    return (it != m_idToSlot.end()) ? it->second : INVALID_SLOT;
+    // Linear scan of at most 127 entries. Deterministic, cache-friendly,
+    // no hash computation. Called from RT path but n is tiny.
+    const uint32_t count = m_channelCount;
+    for (uint32_t i = 0; i < count; ++i) {
+        if (m_slotToId[i] == channelId)
+            return i;
+    }
+    return INVALID_SLOT;
 }
 
 uint32_t ChannelSlotMap::getChannelId(uint32_t slotIndex) const {
-    auto it = m_slotToId.find(slotIndex);
-    return (it != m_slotToId.end()) ? it->second : INVALID_SLOT;
+    if (slotIndex >= ARRAY_SIZE)
+        return INVALID_SLOT;
+    return m_slotToId[slotIndex];
 }
 
 bool ChannelSlotMap::hasChannel(uint32_t channelId) const {
-    return m_idToSlot.find(channelId) != m_idToSlot.end();
+    return getSlotIndex(channelId) != INVALID_SLOT;
 }
 
 void ChannelSlotMap::clear() {
-    m_idToSlot.clear();
-    m_slotToId.clear();
+    m_slotToId.fill(INVALID_SLOT);
     m_channelCount = 0;
 }
 

--- a/Tests/AestraAudio/PathologicalChaosStressTest.cpp
+++ b/Tests/AestraAudio/PathologicalChaosStressTest.cpp
@@ -24,7 +24,7 @@ static void testConcurrentViolationRecording() {
 
     std::vector<std::thread> threads;
     for (int t = 0; t < NUM_THREADS; t++) {
-        threads.emplace_back([&ready, t] {
+        threads.emplace_back([&, t] {
             // Reset this thread's audit data
             g_rtAuditData = {};
 


### PR DESCRIPTION
## Summary
- Replace `unordered_map<uint32_t, uint32_t>` in ChannelSlotMap with `std::array<uint32_t, 128>`
- `getSlotIndex()`: linear scan of ≤127 entries (deterministic, cache-friendly, no hash)
- `getChannelId()`: O(1) direct index lookup
- Eliminates the last `unordered_map` usage from the RT audio path

## Why
Issue #243: `getSlotIndex()` was called from `renderGraph()` (the audio callback) using `unordered_map::find()`. While `find()` doesn't allocate, it performs non-deterministic hash computation — a soft RT violation. This completes the RT allocation elimination started in commit `5f22b819`.

Also includes MSVC lambda capture fix for PathologicalChaosStressTest (same as #298).

## Test plan
- [x] Build passes (AestraAudioCore)
- [ ] CI passes on all platforms
- [ ] Verify ChannelSlotMap round-trips correctly (rebuild → getSlotIndex → getChannelId)

Fixes #243 (complete)

Co-Authored-By: OpenClaude (mimo-v2.5-pro) <openclaude@gitlawb.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Replaces `unordered_map` with fixed-size `std::array` in `ChannelSlotMap` to eliminate non-deterministic operations from the real-time audio path.**

- **Storage**: Replaced `unordered_map<uint32_t, uint32_t>` with `std::array<uint32_t, 128>` for the slot-to-ID mapping, eliminating heap allocations and hash operations in the audio callback
- **Performance trade-off**: `getSlotIndex()` changes from O(1) hash lookup to O(n) linear scan (max 127 entries), but gains determinism and cache-friendliness; `getChannelId()` remains O(1) direct array access
- **Implementation**: `rebuild()` now populates the array directly, `getSlotIndex()` performs a deterministic linear scan, and `getChannelId()` uses a bounds-checked array lookup
- **Constructor**: Updated to explicitly initialize the array with `INVALID_SLOT` values
- **Test fix**: Fixed MSVC lambda capture in `PathologicalChaosStressTest` to use `[&, t]` capturing (matching similar change in `#298`)

Closes issue `#243` by ensuring no heap allocations or non-deterministic operations occur in the routing render loop during audio callbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->