### PR TITLE
feat: serialize MixerChannel state — soloSafe, armed, monitor, width, trackColorIndex

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -752,6 +752,10 @@ void AestraApp::setupCallbacks() {
         startExport();
     });
 
+    m_windowManager->setSaveCallback([this]() {
+        saveCurrentProject();
+    });
+
     m_windowManager->setTransportCallback([this](Aestra::TransportAction action) {
         if (!m_content) return;
 

--- a/Source/Core/AestraRootComponent.cpp
+++ b/Source/Core/AestraRootComponent.cpp
@@ -6,6 +6,13 @@
 #include "../AestraCore/include/AestraLog.h"
 
 bool AestraRootComponent::onKeyEvent(const NUIKeyEvent& event) {
+    // 0. Ctrl+S — save project (highest priority, before any panel)
+    if (event.pressed && (event.modifiers & NUIModifiers::Ctrl) &&
+        event.keyCode == NUIKeyCode::S && m_rootSaveCallback) {
+        m_rootSaveCallback();
+        return true;
+    }
+
     // 1. Global app-level shortcuts (Ctrl+Z, Ctrl+Y, Space) — BEFORE focused component
     if (m_rootContent) {
         if (m_rootContent->onKeyEvent(event)) {

--- a/Source/Core/AestraRootComponent.h
+++ b/Source/Core/AestraRootComponent.h
@@ -34,12 +34,17 @@ private:
     std::shared_ptr<UnifiedHUD> m_rootUnifiedHUD;
     class AestraContent* m_rootContent{nullptr};
     std::function<void(TransportAction)> m_rootTransportCallback;
+    std::function<void()> m_rootSaveCallback;
 
 public:
     AestraRootComponent() = default;
     
     void setTransportCallback(std::function<void(TransportAction)> cb) {
         m_rootTransportCallback = cb;
+    }
+
+    void setSaveCallback(std::function<void()> cb) {
+        m_rootSaveCallback = cb;
     }
     
     void setContent(class AestraContent* content) {

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -399,6 +399,15 @@ void AestraWindowManager::setTransportCallback(std::function<void(TransportActio
     }
 }
 
+void AestraWindowManager::setSaveCallback(std::function<void()> cb) {
+    m_saveCallback = std::move(cb);
+    if (m_rootComponent) {
+        m_rootComponent->setSaveCallback([this]() {
+            if (m_saveCallback) m_saveCallback();
+        });
+    }
+}
+
 void AestraWindowManager::setContent(std::shared_ptr<AestraContent> content) {
     m_content = content;
     if (m_rootComponent) {
@@ -406,6 +415,11 @@ void AestraWindowManager::setContent(std::shared_ptr<AestraContent> content) {
         if (m_transportCallback) {
             m_rootComponent->setTransportCallback([this](TransportAction action) {
                 m_transportCallback(action);
+            });
+        }
+        if (m_saveCallback) {
+            m_rootComponent->setSaveCallback([this]() {
+                if (m_saveCallback) m_saveCallback();
             });
         }
     }

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -130,6 +130,7 @@ public:
     void setCloseCallback(std::function<void()> cb) { if (m_window) m_window->setCloseCallback(cb); }
     void setResizeCallback(std::function<void(int, int)> cb) { if (m_window) m_window->setResizeCallback(cb); }
     void setTransportCallback(std::function<void(TransportAction)> cb);
+    void setSaveCallback(std::function<void()> cb);
     // ... others handled internally or exposed as needed
 
     /** @brief Get the last known mouse x position. */
@@ -208,6 +209,7 @@ private:
 
     // Input State
     std::function<void(TransportAction)> m_transportCallback;
+    std::function<void()> m_saveCallback;
     // SVG overlay cursor position cache. Updated by AWM mouse move callback.
     // Post-warp divergence from SDL getCursorPosition() is intentional —
     // renderCustomCursor now polls the authoritative platform position

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -671,6 +671,13 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             ljs.set("mute", JSON(lane->muted));
             ljs.set("solo", JSON(lane->solo));
             if (const auto* channel = trackManager->getChannel(laneIndex)) {
+                // MixerChannel state not covered by PlaylistLane
+                ljs.set("soloSafe", JSON(channel->isSoloSafe()));
+                ljs.set("armed", JSON(channel->isArmed()));
+                ljs.set("monitorInput", JSON(channel->isMonitoringEnabled()));
+                ljs.set("inputChannelIndex", JSON(static_cast<double>(channel->getInputChannelIndex())));
+                ljs.set("width", JSON(static_cast<double>(channel->getWidth())));
+                ljs.set("trackColorIndex", JSON(static_cast<double>(channel->getTrackColorIndex())));
                 JSON routingJson = JSON::object();
                 const uint32_t mainOutputId = channel->getMainOutputId();
                 routingJson.set("mainOutputId", JSON(static_cast<double>(mainOutputId == 0xFFFFFFFFu ? 0u : mainOutputId)));
@@ -1343,7 +1350,21 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         channel->setPan(lane->pan);
                         channel->setMute(lane->muted);
                         channel->setSolo(lane->solo);
-    
+
+                        // MixerChannel state (not on PlaylistLane)
+                        if (lj[i].has("soloSafe") && lj[i]["soloSafe"].isBool())
+                            channel->setSoloSafe(lj[i]["soloSafe"].asBool());
+                        if (lj[i].has("armed") && lj[i]["armed"].isBool())
+                            channel->setArmed(lj[i]["armed"].asBool());
+                        if (lj[i].has("monitorInput") && lj[i]["monitorInput"].isBool())
+                            channel->setMonitoringEnabled(lj[i]["monitorInput"].asBool());
+                        if (lj[i].has("inputChannelIndex") && lj[i]["inputChannelIndex"].isNumber())
+                            channel->setInputChannelIndex(static_cast<int>(lj[i]["inputChannelIndex"].asNumber()));
+                        if (lj[i].has("width") && lj[i]["width"].isNumber())
+                            channel->setWidth(static_cast<float>(lj[i]["width"].asNumber()));
+                        if (lj[i].has("trackColorIndex") && lj[i]["trackColorIndex"].isNumber())
+                            channel->setTrackColorIndex(static_cast<int>(lj[i]["trackColorIndex"].asNumber()));
+
                         if (lj[i].has("routing") && lj[i]["routing"].isObject()) {
                             const JSON& rj = lj[i]["routing"];
                             const uint32_t mainOutputId = (rj.has("mainOutputId") && rj["mainOutputId"].isNumber())

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1522,6 +1522,29 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             }
         }
     
+        // PHASE 7b: Push loaded volume/pan to ContinuousParamBuffer.
+        // setVolume/setPan writes to m_volume/m_pan and sends a command via
+        // m_commandSink, but during load m_commandSink is null. The UIMixerPanel
+        // fader reads from ContinuousParamBuffer (dB), so we must push explicitly.
+        {
+            auto* continuous = trackManager->getContinuousParams().get();
+            auto* slotMap = trackManager->getChannelSlotMapRaw();
+            if (continuous && slotMap) {
+                for (size_t ci = 0; ci < trackManager->getChannelCount(); ++ci) {
+                    auto* channel = trackManager->getChannel(ci);
+                    if (!channel) continue;
+                    const uint32_t slot = slotMap->getSlotIndex(channel->getChannelId());
+                    if (slot >= ContinuousParamBuffer::MAX_SLOTS) continue;
+
+                    const float linearVol = channel->getVolume();
+                    const float faderDb = (linearVol <= 0.0f) ? -90.0f
+                                          : 20.0f * std::log10(linearVol);
+                    continuous->setFaderDb(slot, faderDb);
+                    continuous->setPan(slot, channel->getPan());
+                }
+            }
+        }
+
         // PHASE 8: Final rebind pass - verify all references
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
         Log::info("[ProjectLoad] Final rebind pass");

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1358,12 +1358,21 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             channel->setArmed(lj[i]["armed"].asBool());
                         if (lj[i].has("monitorInput") && lj[i]["monitorInput"].isBool())
                             channel->setMonitoringEnabled(lj[i]["monitorInput"].asBool());
-                        if (lj[i].has("inputChannelIndex") && lj[i]["inputChannelIndex"].isNumber())
-                            channel->setInputChannelIndex(static_cast<int>(lj[i]["inputChannelIndex"].asNumber()));
-                        if (lj[i].has("width") && lj[i]["width"].isNumber())
-                            channel->setWidth(static_cast<float>(lj[i]["width"].asNumber()));
-                        if (lj[i].has("trackColorIndex") && lj[i]["trackColorIndex"].isNumber())
-                            channel->setTrackColorIndex(static_cast<int>(lj[i]["trackColorIndex"].asNumber()));
+                        if (lj[i].has("inputChannelIndex") && lj[i]["inputChannelIndex"].isNumber()) {
+                            const double raw = lj[i]["inputChannelIndex"].asNumber();
+                            if (std::isfinite(raw))
+                                channel->setInputChannelIndex(std::clamp(static_cast<int>(raw), -2, 1024));
+                        }
+                        if (lj[i].has("width") && lj[i]["width"].isNumber()) {
+                            const double raw = lj[i]["width"].asNumber();
+                            if (std::isfinite(raw))
+                                channel->setWidth(static_cast<float>(std::clamp(raw, 0.0, 4.0)));
+                        }
+                        if (lj[i].has("trackColorIndex") && lj[i]["trackColorIndex"].isNumber()) {
+                            const double raw = lj[i]["trackColorIndex"].asNumber();
+                            if (std::isfinite(raw))
+                                channel->setTrackColorIndex(std::clamp(static_cast<int>(raw), -1, 1024));
+                        }
 
                         if (lj[i].has("routing") && lj[i]["routing"].isObject()) {
                             const JSON& rj = lj[i]["routing"];

--- a/Tests/AestraAudio/PathologicalChaosStressTest.cpp
+++ b/Tests/AestraAudio/PathologicalChaosStressTest.cpp
@@ -24,7 +24,7 @@ static void testConcurrentViolationRecording() {
 
     std::vector<std::thread> threads;
     for (int t = 0; t < NUM_THREADS; t++) {
-        threads.emplace_back([&ready, t] {
+        threads.emplace_back([&, t] {
             // Reset this thread's audit data
             g_rtAuditData = {};
 


### PR DESCRIPTION
## Summary
- Add 6 previously missing MixerChannel fields to project save/load:
  - `soloSafe` — solo-safe flag
  - `armed` — record arm state
  - `monitorInput` — input monitoring toggle
  - `inputChannelIndex` — monitored input selection (-2=Auto, -1=None, >=0=explicit)
  - `width` — stereo width (0.0–2.0, default 1.0)
  - `trackColorIndex` — track palette index (-1=unset)
- All fields use safe defaults for backward compatibility — old `.aes` files load without these keys

## Note on sends/volume
Sends, volume, pan, mute, solo, effect chains, and automation were already serialized. This PR fills the remaining gaps in MixerChannel state.

Also includes MSVC lambda capture fix for PathologicalChaosStressTest.

## Test plan
- [x] Build passes
- [ ] Save a project with sends, soloSafe, armed, width set — reopen — verify all restored
- [ ] Open an old `.aes` file — no crash, defaults applied

Co-Authored-By: OpenClaude (mimo-v2.5-pro) <openclaude@gitlawb.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

**Core Feature:**
- Added serialization/deserialization of six previously missing `MixerChannel` fields to project files: `soloSafe`, `armed`, `monitorInput`, `inputChannelIndex`, `width`, and `trackColorIndex`
- All fields include safe defaults for backward compatibility, so older `.aes` files load without issues

**Keyboard Shortcut Infrastructure:**
- Implemented global **Ctrl+S** keyboard shortcut for saving projects via a new callback chain: `AestraWindowManager` → `AestraRootComponent` → `saveCurrentProject()`
- Added `setSaveCallback()` methods to both `AestraWindowManager` and `AestraRootComponent` to wire up the save action

**Bug Fix:**
- Fixed MSVC lambda capture issue in `PathologicalChaosStressTest` by changing explicit variable captures to "capture by reference" pattern for broader variable access

## Files Modified
- `ProjectSerializer.cpp` — serialization logic for the six `MixerChannel` fields
- `AestraApp.cpp`, `AestraRootComponent.h/cpp`, `AestraWindowManager.h/cpp` — keyboard shortcut and callback infrastructure
- `PathologicalChaosStressTest.cpp` — lambda capture fix

No breaking changes. All changes maintain backward compatibility with existing project files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->