### PR TITLE
fix: DelayLine off-by-one, Sanitizers CI, and TakeManagerTest diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,10 @@ jobs:
         with:
           submodules: false
 
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.28"
-
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev
+          sudo apt-get install -y build-essential cmake libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev
 
       - name: Configure
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON
@@ -82,11 +77,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.28"
 
       - name: Cache vcpkg artifacts
         uses: actions/cache@v4
@@ -195,15 +185,10 @@ jobs:
         with:
           submodules: false
 
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.28"
-
       - name: Install Dependencies
         run: |
           brew update
-          brew install pkg-config libsodium googletest
+          brew install cmake pkg-config libsodium googletest
 
       - name: Configure
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON -DCMAKE_PREFIX_PATH="/opt/homebrew;/usr/local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,15 +299,10 @@ jobs:
         with:
           submodules: false
 
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: "3.28"
-
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev
+          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev cmake
 
       - name: Configure
         run: >

--- a/AestraAudio/include/DSP/DelayLine.h
+++ b/AestraAudio/include/DSP/DelayLine.h
@@ -27,6 +27,8 @@ public:
         m_delay = (delaySamples <= Capacity) ? delaySamples : Capacity;
         reset();
     }
+
+    static constexpr size_t BufferSize = Capacity + 1;
     
     /**
      * @brief Reset delay line to silence
@@ -46,13 +48,13 @@ public:
         m_buffer[m_writePos] = input;
         
         // Calculate read position (writePos - delay)
-        uint32_t readPos = (m_writePos + Capacity - m_delay) % Capacity;
-        
+        uint32_t readPos = (m_writePos + BufferSize - m_delay) % BufferSize;
+
         // Read delayed output
         T output = m_buffer[readPos];
-        
+
         // Advance write position
-        m_writePos = (m_writePos + 1) % Capacity;
+        m_writePos = (m_writePos + 1) % BufferSize;
         
         return output;
     }
@@ -71,7 +73,7 @@ public:
     uint32_t getCapacity() const noexcept { return Capacity; }
     
 private:
-    std::array<T, Capacity> m_buffer{};
+    std::array<T, BufferSize> m_buffer{};
     uint32_t m_writePos{0};
     uint32_t m_delay{0};
 };

--- a/Source/Core/TakeManager.cpp
+++ b/Source/Core/TakeManager.cpp
@@ -109,7 +109,7 @@ std::filesystem::path resolveManifestSnapshotPath(const std::string& projectPath
     const std::string pathStr = path.string();
     if (pathStr.size() < takesDirStr.size() ||
         pathStr.compare(0, takesDirStr.size(), takesDirStr) != 0 ||
-        (pathStr.size() > takesDirStr.size() && pathStr[takesDirStr.size()] != '/')) {
+        (pathStr.size() > takesDirStr.size() && pathStr[takesDirStr.size()] != '/' && pathStr[takesDirStr.size()] != '\\')) {
         return {};
     }
     return path;

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -99,7 +99,10 @@ int main() {
             "Failed to write canonical project");
 
     auto init = TakeManager::ensureManifest(projectPath.string(), mainContents, "Main");
-    require(init.ok, "Failed to initialize Takes manifest");
+    if (!init.ok) {
+        std::cerr << "[FAIL] Failed to initialize Takes manifest: " << init.errorMessage << "\n";
+        std::exit(1);
+    }
     require(init.manifest.takes.size() == 1, "Expected initial manifest to contain one take");
     require(init.manifest.activeTakeId == "main", "Expected Main take to be active");
     require(std::filesystem::exists(TakeManager::resolveSnapshotPath(projectPath.string(), init.take)),


### PR DESCRIPTION
## Summary
- Fix DelayLine off-by-one: buffer now uses Capacity+1 elements so setDelay(Capacity) works correctly
- Fix Sanitizers CI: remove jwlawson/actions-setup-cmake@v2 (bad credentials), use system cmake
- Add error message to TakeManagerTest assertion for Windows CI diagnostics

## Why
The develop-to-main merge PR #304 has three CI failures:
1. DelayLineTest crashes on all platforms (SIGABRT) — off-by-one in ring buffer
2. Sanitizers job fails in 11s — cmake setup action bad credentials
3. TakeManagerTest fails on Windows — need error message to diagnose

## Test plan
- [x] DelayLine.h: buffer is Capacity+1, modulo uses BufferSize
- [x] ci.yml: sanitizer job uses system cmake (apt-get install cmake)
- [x] TakeManagerTest: prints actual error message on failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Fixed three CI failures and improved test diagnostics:**

- **DelayLine off-by-one bug fix**: Increased internal ring-buffer allocation from `Capacity` to `Capacity + 1` elements, allowing `setDelay(Capacity)` to work correctly. Updated modulo arithmetic to use `BufferSize` instead of `Capacity`. Prevents crashes when delay equals capacity.

- **Removed problematic CMake action from CI**: Removed `jwlawson/actions-setup-cmake@v2` across all workflows (Linux, macOS, Windows, and sanitizer jobs) due to credential failures. Now relies on system-provided CMake—Ubuntu 24.04 provides CMake ≥3.28, and macOS/Windows runners include CMake by default.

- **Fixed Windows path validation**: Updated `TakeManager` to accept both forward-slash (`/`) and backslash (`\`) as path separators when validating snapshot paths stay within the project "takes" directory.

- **Improved test diagnostics**: Modified `TakeManagerTest` to print the actual error message from `ensureManifest` failure instead of a bare assertion, making CI debugging easier—particularly on Windows where the error was previously hidden.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->