### PR TITLE
docs: add v0.5.0-alpha to RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,11 +22,24 @@ v1.0.0                  — initial public release
 | `v0.1.0-foundation`  | Keep      | 2025-10-26 | Historical engine foundation              |
 | `v0.1.0-alpha`       | Deleted   | —          | Redundant with foundation tag             |
 | `v1.0.0`             | Deleted   | —          | Premature — do not recreate until release |
-| `v0.4.0-alpha`       | Current   | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
+| `v0.4.0-alpha`       | Superseded | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
+| `v0.5.0-alpha`       | Current   | 2026-05-23 | Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs merged |
 
 ---
 
 ## Milestone History
+
+### v0.5.0-alpha — Feature & CI Milestone (May 2026)
+
+**Takes system** — Multi-take recording with manifest, snapshots, transactional switching, path traversal guards, and UI integration.
+
+**CLAP parameter support** — ClapParamInfo, ClapPluginParams structs, CLAP core constant definitions, null paramsExt fix.
+
+**Audio quality** — K-weight race fix, ARM64 denormals, send gain smoother coefficient fix, audition queue deadlock fix, autosave atomic rename.
+
+**CI hardening** — Removed jwlawson/actions-setup-cmake@v2 from all jobs, system cmake, DelayLine off-by-one fix (Capacity+1 buffer), Windows path separator fix, 13 tests registered, platform guards.
+
+**PRs merged** — #291-#305 (11 PRs), develop→main merge (#304, 51 commits).
 
 ### v0.4.0-alpha — Hardening Milestone (May 2026)
 


### PR DESCRIPTION
## Summary
- Add v0.5.0-alpha tag to RELEASES.md tag inventory and milestone history
- Tag already pushed to origin at 5d7918d3

## Change type
- Public docs changed: yes