### PR TITLE
callback-safety: triple-buffer graph, input routing snapshot, PDC edge ownership fix, TSan CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,3 +312,43 @@ jobs:
           name: ctest-results-asan
           path: build-asan/ctest-results-asan.xml
           if-no-files-found: ignore
+
+  tsan-linux:
+    name: ThreadSanitizer (TSan, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:suppress_equal_stacks=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
+
+      - name: Configure
+        run: >
+          cmake -B build-tsan -S .
+          -DCMAKE_BUILD_TYPE=Debug
+          -DAestra_CORE_MODE=ON
+          -DAESTRA_CI=ON
+          -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+
+      - name: Build
+        run: cmake --build build-tsan --config Debug
+
+      - name: Test
+        working-directory: build-tsan
+        run: ctest --test-dir . --output-on-failure --output-junit ctest-results-tsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
+
+      - name: Upload TSan test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-tsan
+          path: build-tsan/ctest-results-tsan.xml
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,5 +345,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-tsan
-          path: build-tsan/ctest-results-tsan.xml
+          path: build/ci-tsan/ctest-results-tsan.xml
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+          persist-credentials: false
 
       - name: Install Dependencies
         run: |
@@ -330,20 +331,14 @@ jobs:
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
 
       - name: Configure
-        run: >
-          cmake -B build-tsan -S .
-          -DCMAKE_BUILD_TYPE=Debug
-          -DAestra_CORE_MODE=ON
-          -DAESTRA_CI=ON
-          -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
-          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+        run: cmake --preset ci-tsan
 
       - name: Build
-        run: cmake --build build-tsan --config Debug
+        run: cmake --build --preset ci-tsan
 
       - name: Test
-        working-directory: build-tsan
-        run: ctest --test-dir . --output-on-failure --output-junit ctest-results-tsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
+        working-directory: build/ci-tsan
+        run: ctest --output-on-failure --output-junit ctest-results-tsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
 
       - name: Upload TSan test report
         if: always()

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -4,32 +4,30 @@
 #include "AestraThreading.h"
 #include "AudioCommandQueue.h"
 #include "AudioDriverTypes.h"
+#include "AudioGraphState.h"
+#include "AudioRenderer.h"
 #include "AudioTelemetry.h"
 #include "ChannelSlotMap.h"
 #include "ContinuousParamBuffer.h"
+#include "DSP/TruePeakMeter.h"
 #include "EngineState.h"
 #include "GarbageCollector.h"
 #include "Interpolators.h"
-#include "DSP/TruePeakMeter.h"
+#include "LatencyTopology.h"
 #include "MasterSafetyLimiter.h"
 #include "MeterSnapshot.h"
-#include "PluginHost.h" // For MidiBuffer [NEW]
+#include "MetronomeEngine.h"     // [NEW]
+#include "Models/TrackManager.h" // [NEW] For headless rendering
+#include "PluginHost.h"          // For MidiBuffer [NEW]
 
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <cstdint>
-#include <vector>
-
-#include "AudioGraphState.h"
-#include "AudioRenderer.h"
-#include "LatencyTopology.h"
-#include "MetronomeEngine.h"     // [NEW]
-#include "Models/TrackManager.h" // [NEW] For headless rendering
-
-#include <array>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace Aestra {
 namespace Audio {
@@ -228,13 +226,13 @@ public:
     }
 
     // === Plugin Delay Compensation ===
-    
+
     /**
      * @brief Calculate and apply plugin delay compensation across all tracks
-     * 
+     *
      * Computes max latency, sets compensation delays, and publishes new snapshot.
      * NOT RT-SAFE: Call from main thread only.
-     * 
+     *
      * Triggers:
      * - Plugin load/unload
      * - Plugin bypass toggle
@@ -242,13 +240,13 @@ public:
      * - Track enable/disable
      */
     void calculateLatencyCompensation();
-    
+
     /**
      * @brief Enable/disable global latency compensation
      */
     void setLatencyCompensationEnabled(bool enabled);
     bool isLatencyCompensationEnabled() const;
-    
+
     /**
      * @brief Get current max project latency in samples
      */
@@ -417,9 +415,7 @@ public:
         m_truePeakMeteringEnabled.store(enabled, std::memory_order_relaxed);
     }
     /** @brief Whether true-peak metering is currently enabled. */
-    bool isTruePeakMeteringEnabled() const {
-        return m_truePeakMeteringEnabled.load(std::memory_order_relaxed);
-    }
+    bool isTruePeakMeteringEnabled() const { return m_truePeakMeteringEnabled.load(std::memory_order_relaxed); }
     /** @brief Reset true-peak running max (does not disturb FIR history). */
     void clearTruePeakHold() {
         m_truePeakMeter.clearPeaks();
@@ -521,9 +517,7 @@ public:
             for (size_t i = 0; i < channelCount; ++i) {
                 if (auto* channel = current->getChannel(i)) {
                     prepareChannel(*channel);
-                    channel->setEffectChainLatencyCallback([this]() {
-                        calculateLatencyCompensation();
-                    });
+                    channel->setEffectChainLatencyCallback([this]() { calculateLatencyCompensation(); });
                 }
             }
             calculateLatencyCompensation();
@@ -583,6 +577,7 @@ private:
     static constexpr size_t kMaxSendsPerTrack = 256; // Matches PROJECT_MAX_SENDS_PER_LANE
     static constexpr size_t kMaxEdgesPerTrack = 16;  // Conservative max routing edges per track
     static constexpr uint32_t kWaveformHistoryFramesDefault = 2048;
+    static constexpr uint32_t kInternalRenderChannels = 2;
 
     // Fast Xorshift32 RNG for dither
     struct FastRNG {
@@ -1066,7 +1061,7 @@ private:
     // === Plugin Delay Compensation State ===
     bool m_latencyCompensationEnabled{true};
     uint32_t m_maxProjectLatency{0};
-    bool m_latencyDirty{true};  // Recalculate on next safe opportunity
+    bool m_latencyDirty{true}; // Recalculate on next safe opportunity
     // PDC v2 (P3): double-buffered, lock-free publish of SolvedLatencyTopology.
     //
     // The off-RT recompute writes the new topology to the inactive slot, then

--- a/AestraAudio/include/Core/AudioGraphState.h
+++ b/AestraAudio/include/Core/AudioGraphState.h
@@ -12,13 +12,20 @@
 namespace Aestra {
 namespace Audio {
 
-// Double-precision smoothed parameter for zero-zipper automation
+/**
+ * @brief Double-precision linear-ramp parameter smoother for zipper-free automation.
+ *
+ * Advances one sample at a time via next(). Call beginRamp() after setTarget()
+ * to start a finite-length linear ramp; snap() jumps immediately.
+ * NaN/Inf values are sanitized at every entry point to prevent propagation.
+ */
 struct SmoothedParamD {
-    double current{1.0};
-    double target{1.0};
-    double step{0.0};
-    uint32_t samplesRemaining{0};
+    double current{1.0};      ///< Current output value.
+    double target{1.0};       ///< Target value the ramp is heading toward.
+    double step{0.0};         ///< Per-sample increment (0 when idle).
+    uint32_t samplesRemaining{0}; ///< Frames left in the current ramp.
 
+    /** @brief Advance the smoother by one sample and return the current value. */
     inline double next() {
         if (samplesRemaining > 0) {
             current += step;
@@ -31,12 +38,17 @@ struct SmoothedParamD {
         return current;
     }
 
+    /** @brief Set a new target value. NaN/Inf are replaced with current to avoid clicks. */
     void setTarget(double t) {
         // Sanitize target to prevent NaN/Inf propagation
         // Fall back to current value to avoid audible clicks
         target = std::isfinite(t) ? t : current;
     }
 
+    /**
+     * @brief Begin a linear ramp from current to target over @p samples frames.
+     * @param samples Number of frames for the ramp. 0 or already-at-target snaps immediately.
+     */
     void beginRamp(uint32_t samples) {
         // Sanitize both current and target before computing step
         // Mirror setTarget behavior: fall back to the other finite value to avoid clicks
@@ -59,6 +71,7 @@ struct SmoothedParamD {
             current = target;
         }
     }
+    /** @brief Snap current to target immediately, cancelling any active ramp. */
     void snap() {
         // Sanitize target before assigning — same contract as setTarget()/beginRamp()
         if (!std::isfinite(target)) target = std::isfinite(current) ? current : 0.0;

--- a/AestraAudio/include/Core/AudioGraphState.h
+++ b/AestraAudio/include/Core/AudioGraphState.h
@@ -41,8 +41,14 @@ struct SmoothedParamD {
     /** @brief Set a new target value. NaN/Inf are replaced with current to avoid clicks. */
     void setTarget(double t) {
         // Sanitize target to prevent NaN/Inf propagation
-        // Fall back to current value to avoid audible clicks
-        target = std::isfinite(t) ? t : current;
+        // Fall back to current value, then to 0.0, to guarantee finite output
+        if (std::isfinite(t)) {
+            target = t;
+        } else if (std::isfinite(current)) {
+            target = current;
+        } else {
+            target = 0.0;
+        }
     }
 
     /**

--- a/AestraAudio/include/Core/AudioGraphState.h
+++ b/AestraAudio/include/Core/AudioGraphState.h
@@ -97,7 +97,7 @@ struct EdgeDelayState {
     /** @brief Stereo-interleaved buffer pointer (capacityMask+1 frames). RT reads. */
     std::atomic<float*> bufferPtr{nullptr};
     /** @brief RT-side write cursor (frame count); RT updates each block; off-RT zeroes on growth. */
-    uint32_t writePos{0};
+    std::atomic<uint32_t> writePos{0};
 
     // Off-RT-owned storage. RT never touches these directly; it goes through
     // bufferPtr.

--- a/AestraAudio/include/Core/AudioGraphState.h
+++ b/AestraAudio/include/Core/AudioGraphState.h
@@ -60,6 +60,8 @@ struct SmoothedParamD {
         }
     }
     void snap() {
+        // Sanitize target before assigning — same contract as setTarget()/beginRamp()
+        if (!std::isfinite(target)) target = std::isfinite(current) ? current : 0.0;
         current = target;
         step = 0.0;
         samplesRemaining = 0;

--- a/AestraAudio/include/Core/AudioRenderer.h
+++ b/AestraAudio/include/Core/AudioRenderer.h
@@ -83,7 +83,7 @@ private:
                          AudioEngine& engineRef);
 
     void processTrackEffects(const RenderTrack& track, AudioGraphState& state, uint32_t numFrames,
-                             uint32_t bufferOffset, AudioEngine& engineRef);
+                             uint32_t bufferOffset, AudioEngine& engineRef, const AudioGraph& graph);
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Core/EngineState.h
+++ b/AestraAudio/include/Core/EngineState.h
@@ -117,14 +117,8 @@ public:
 
     // Non-RT access for initialization or inspection.
     AudioGraph& mutableInactiveGraph() {
-        const int active = m_activeIndex.load(std::memory_order_relaxed);
-        for (int i = 0; i < kGraphSlots; ++i) {
-            if (i != active && m_readers[static_cast<size_t>(i)].load(std::memory_order_acquire) == 0) {
-                return m_graphs[static_cast<size_t>(i)];
-            }
-        }
-        // All non-active slots have readers — spin until one frees.
-        while (true) {
+        for (;;) {
+            const int active = m_activeIndex.load(std::memory_order_acquire);
             for (int i = 0; i < kGraphSlots; ++i) {
                 if (i != active && m_readers[static_cast<size_t>(i)].load(std::memory_order_acquire) == 0) {
                     return m_graphs[static_cast<size_t>(i)];

--- a/AestraAudio/include/Core/EngineState.h
+++ b/AestraAudio/include/Core/EngineState.h
@@ -101,7 +101,15 @@ public:
                 return m_graphs[static_cast<size_t>(i)];
             }
         }
-        return m_graphs[static_cast<size_t>((active + 1) % kGraphSlots)];
+        // All non-active slots have readers — spin until one frees.
+        while (true) {
+            for (int i = 0; i < kGraphSlots; ++i) {
+                if (i != active && m_readers[static_cast<size_t>(i)].load(std::memory_order_acquire) == 0) {
+                    return m_graphs[static_cast<size_t>(i)];
+                }
+            }
+            std::this_thread::yield();
+        }
     }
 
 private:

--- a/AestraAudio/include/Core/EngineState.h
+++ b/AestraAudio/include/Core/EngineState.h
@@ -4,6 +4,8 @@
 #include "AudioGraph.h"
 
 #include <atomic>
+#include <mutex>
+#include <thread>
 
 namespace Aestra {
 namespace Audio {
@@ -16,23 +18,99 @@ namespace Audio {
  */
 class EngineState {
 public:
+    class GraphReadHandle {
+    public:
+        GraphReadHandle() = default;
+        GraphReadHandle(const GraphReadHandle&) = delete;
+        GraphReadHandle& operator=(const GraphReadHandle&) = delete;
+
+        GraphReadHandle(GraphReadHandle&& other) noexcept : m_state(other.m_state), m_index(other.m_index) {
+            other.m_state = nullptr;
+            other.m_index = -1;
+        }
+
+        GraphReadHandle& operator=(GraphReadHandle&& other) noexcept {
+            if (this != &other) {
+                release();
+                m_state = other.m_state;
+                m_index = other.m_index;
+                other.m_state = nullptr;
+                other.m_index = -1;
+            }
+            return *this;
+        }
+
+        ~GraphReadHandle() { release(); }
+
+        const AudioGraph& get() const noexcept { return m_state->m_graphs[m_index]; }
+
+    private:
+        friend class EngineState;
+
+        GraphReadHandle(const EngineState* state, int index) noexcept : m_state(state), m_index(index) {}
+
+        void release() noexcept {
+            if (m_state && m_index >= 0) {
+                m_state->m_readers[static_cast<size_t>(m_index)].fetch_sub(1, std::memory_order_release);
+                m_state = nullptr;
+                m_index = -1;
+            }
+        }
+
+        const EngineState* m_state{nullptr};
+        int m_index{-1};
+    };
+
+    GraphReadHandle activeGraphRead() const noexcept {
+        for (;;) {
+            const int index = m_activeIndex.load(std::memory_order_acquire);
+            m_readers[static_cast<size_t>(index)].fetch_add(1, std::memory_order_acquire);
+            if (index == m_activeIndex.load(std::memory_order_acquire)) {
+                return GraphReadHandle(this, index);
+            }
+            m_readers[static_cast<size_t>(index)].fetch_sub(1, std::memory_order_release);
+        }
+    }
+
     const AudioGraph& activeGraph() const noexcept { return m_graphs[m_activeIndex.load(std::memory_order_acquire)]; }
 
     void swapGraph(const AudioGraph& next) {
-        const int inactive = 1 - m_activeIndex.load(std::memory_order_relaxed);
-        m_graphs[inactive] = next; // copy/move from builder thread
-        m_activeIndex.store(inactive, std::memory_order_release);
+        std::lock_guard<std::mutex> lock(m_swapMutex);
+        int target = -1;
+        while (target < 0) {
+            const int active = m_activeIndex.load(std::memory_order_acquire);
+            for (int i = 0; i < kGraphSlots; ++i) {
+                if (i != active && m_readers[static_cast<size_t>(i)].load(std::memory_order_acquire) == 0) {
+                    target = i;
+                    break;
+                }
+            }
+            if (target < 0) {
+                std::this_thread::yield();
+            }
+        }
+        m_graphs[static_cast<size_t>(target)] = next; // copy/move from builder thread
+        m_activeIndex.store(target, std::memory_order_release);
     }
 
     // Non-RT access for initialization or inspection.
     AudioGraph& mutableInactiveGraph() {
-        const int inactive = 1 - m_activeIndex.load(std::memory_order_relaxed);
-        return m_graphs[inactive];
+        const int active = m_activeIndex.load(std::memory_order_relaxed);
+        for (int i = 0; i < kGraphSlots; ++i) {
+            if (i != active && m_readers[static_cast<size_t>(i)].load(std::memory_order_acquire) == 0) {
+                return m_graphs[static_cast<size_t>(i)];
+            }
+        }
+        return m_graphs[static_cast<size_t>((active + 1) % kGraphSlots)];
     }
 
 private:
-    AudioGraph m_graphs[2];
+    static constexpr int kGraphSlots = 3;
+
+    AudioGraph m_graphs[kGraphSlots];
     std::atomic<int> m_activeIndex{0};
+    mutable std::atomic<uint32_t> m_readers[kGraphSlots]{};
+    std::mutex m_swapMutex;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Core/EngineState.h
+++ b/AestraAudio/include/Core/EngineState.h
@@ -18,17 +18,28 @@ namespace Audio {
  */
 class EngineState {
 public:
+    /**
+     * @brief RAII handle that pins a specific graph slot for reading.
+     *
+     * Acquires a reader count on construction and releases it on destruction,
+     * allowing the audio thread to read an immutable graph snapshot without
+     * blocking. Move-only — copying is disabled to prevent double-release.
+     *
+     * @see activeGraphRead()
+     */
     class GraphReadHandle {
     public:
         GraphReadHandle() = default;
         GraphReadHandle(const GraphReadHandle&) = delete;
         GraphReadHandle& operator=(const GraphReadHandle&) = delete;
 
+        /** @brief Move-constructs from another handle, transferring ownership. */
         GraphReadHandle(GraphReadHandle&& other) noexcept : m_state(other.m_state), m_index(other.m_index) {
             other.m_state = nullptr;
             other.m_index = -1;
         }
 
+        /** @brief Move-assigns from another handle, releasing the current slot first. */
         GraphReadHandle& operator=(GraphReadHandle&& other) noexcept {
             if (this != &other) {
                 release();
@@ -40,8 +51,10 @@ public:
             return *this;
         }
 
+        /** @brief Releases the reader count on the pinned slot. */
         ~GraphReadHandle() { release(); }
 
+        /** @brief Returns a const reference to the pinned graph snapshot. */
         const AudioGraph& get() const noexcept { return m_state->m_graphs[m_index]; }
 
     private:
@@ -61,6 +74,15 @@ public:
         int m_index{-1};
     };
 
+    /**
+     * @brief Acquires a read handle to the currently active graph slot.
+     *
+     * Spins until it can atomically increment the reader count on the active
+     * slot without racing a concurrent swap. The returned handle releases the
+     * count automatically when it goes out of scope.
+     *
+     * @return A move-only handle whose get() returns the active AudioGraph.
+     */
     GraphReadHandle activeGraphRead() const noexcept {
         for (;;) {
             const int index = m_activeIndex.load(std::memory_order_acquire);

--- a/AestraAudio/include/IO/AudioExportQuantization.h
+++ b/AestraAudio/include/IO/AudioExportQuantization.h
@@ -5,20 +5,38 @@
 #include <cmath>
 #include <cstdint>
 
+/**
+ * @file AudioExportQuantization.h
+ * @brief PCM quantization with optional triangular-pdf dither for offline export.
+ */
+
 namespace Aestra {
 namespace Audio {
 namespace ExportQuantization {
 
+/// Scale factor for 16-bit PCM (2^15).
 static constexpr double kPcm16Scale = 32768.0;
+/// Least-significant bit weight for 16-bit PCM.
 static constexpr double kPcm16Lsb = 1.0 / kPcm16Scale;
+/// Scale factor for 24-bit PCM (2^23).
 static constexpr double kPcm24Scale = 8388608.0;
+/// Least-significant bit weight for 24-bit PCM.
 static constexpr double kPcm24Lsb = 1.0 / kPcm24Scale;
 
+/**
+ * @brief Xorshift32 PRNG producing triangular-pdf (TPDF) dither samples.
+ *
+ * Two uniform random values are differenced to produce a triangular
+ * distribution, which is the optimal noise-shaping shape for linear
+ * quantization at a given bit depth.
+ */
 struct TpdfDither {
     uint32_t state{0xA357A11Du};
 
+    /** @brief Reseed the PRNG. Zero is remapped to a non-zero default. */
     void setSeed(uint32_t seed) noexcept { state = seed == 0 ? 0xA357A11Du : seed; }
 
+    /** @brief Advance the xorshift32 state and return the raw 32-bit output. */
     uint32_t next() noexcept {
         uint32_t x = state;
         x ^= x << 13;
@@ -28,11 +46,18 @@ struct TpdfDither {
         return x;
     }
 
+    /** @brief Return a uniform double in [0, 1) from the low 24 bits. */
     double nextFloat() noexcept { return static_cast<double>(next() & 0x00FFFFFFu) * (1.0 / 16777216.0); }
 
+    /** @brief Return a TPDF-scaled dither sample in the range [-lsb, +lsb]. */
     double nextTpdf(double lsb) noexcept { return (nextFloat() - nextFloat()) * lsb; }
 };
 
+/**
+ * @brief Sanitize a float sample: replace NaN/Inf with 0 and clamp to [-1, 1].
+ * @param sample Input sample.
+ * @return Clamped double in [-1, 1].
+ */
 inline double sanitizeAndClamp(float sample) noexcept {
     if (!std::isfinite(sample)) {
         return 0.0;
@@ -40,6 +65,7 @@ inline double sanitizeAndClamp(float sample) noexcept {
     return std::clamp(static_cast<double>(sample), -1.0, 1.0);
 }
 
+/** @brief Quantize a float sample to 16-bit PCM with an explicit dither offset. */
 inline int16_t quantizePcm16(float sample, double dither) noexcept {
     const double scaled = (sanitizeAndClamp(sample) + dither) * kPcm16Scale;
     const int64_t value = std::lrint(scaled);
@@ -47,10 +73,12 @@ inline int16_t quantizePcm16(float sample, double dither) noexcept {
     return static_cast<int16_t>(clamped);
 }
 
+/** @brief Quantize a float sample to 16-bit PCM with auto-generated TPDF dither. */
 inline int16_t quantizePcm16Dithered(float sample, TpdfDither& dither) noexcept {
     return quantizePcm16(sample, dither.nextTpdf(kPcm16Lsb));
 }
 
+/** @brief Quantize a float sample to 24-bit PCM with an explicit dither offset. */
 inline int32_t quantizePcm24(float sample, double dither) noexcept {
     const double scaled = (sanitizeAndClamp(sample) + dither) * kPcm24Scale;
     const int64_t value = std::lrint(scaled);
@@ -58,10 +86,12 @@ inline int32_t quantizePcm24(float sample, double dither) noexcept {
     return static_cast<int32_t>(clamped);
 }
 
+/** @brief Quantize a float sample to 24-bit PCM with auto-generated TPDF dither. */
 inline int32_t quantizePcm24Dithered(float sample, TpdfDither& dither) noexcept {
     return quantizePcm24(sample, dither.nextTpdf(kPcm24Lsb));
 }
 
+/** @brief Pack a 24-bit PCM sample into 3 bytes, little-endian. */
 inline void storePcm24LittleEndian(int32_t sample, uint8_t* dest) noexcept {
     const uint32_t packed = static_cast<uint32_t>(sample);
     dest[0] = static_cast<uint8_t>(packed & 0xFFu);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -63,12 +63,6 @@ public:
         float volume{1.0f};
     };
 
-    /// @brief Immutable snapshot of a recording capture route for RT path.
-    struct RecordingCaptureRoute {
-        RecordingCapture* capture{nullptr};
-        int inputIndex{-1};
-    };
-
     /**
      * @brief Construct a track manager and wire its internal playback helpers.
      */
@@ -401,11 +395,20 @@ public:
         m_recordingCaptureRouteCounts[inactive].store(count, std::memory_order_release);
         m_activeRecordingCaptureSnapshot.store(inactive, std::memory_order_release);
     }
-
     void processInput(const float* input, uint32_t frames, AudioTelemetry* telemetry = nullptr) {
         if (!m_isCapturing.load(std::memory_order_relaxed) || !input || frames == 0 || m_inputChannelCount <= 0) {
             return;
         }
+
+        // Increment writer count BEFORE reading snapshot index so
+        // finalizeCaptureSession() cannot destroy the snapshot while we read it.
+        m_recordingWriters.fetch_add(1, std::memory_order_acq_rel);
+
+        // RAII guard: ensures writer count is always decremented on any exit path.
+        struct WriterGuard {
+            std::atomic<uint32_t>& writers;
+            ~WriterGuard() { writers.fetch_sub(1, std::memory_order_acq_rel); }
+        } writerGuard{m_recordingWriters};
 
         // Read the immutable recording capture snapshot — avoids iterating the
         // live m_channels / m_recordingCaptures containers on the RT thread.
@@ -414,10 +417,6 @@ public:
         if (routeCount == 0) {
             return;
         }
-
-        // Bracket snapshot access with writer count so finalizeCaptureSession()
-        // drains in-flight RT readers before destroying captures.
-        m_recordingWriters.fetch_add(1, std::memory_order_acq_rel);
 
         const auto& routes = m_recordingCaptureSnapshots[snapIdx];
 
@@ -524,8 +523,7 @@ public:
             (void)telemetry;
             m_recordingNoArmLogged = true;
         }
-
-        m_recordingWriters.fetch_sub(1, std::memory_order_acq_rel);
+        // writerGuard destructor handles m_recordingWriters.fetch_sub
     }
 
     void publishInputMonitoringSnapshot() {
@@ -996,6 +994,31 @@ public:
     }
 
 private:
+    /// @brief Immutable snapshot of a recording capture route for RT path.
+    struct RecordingCaptureRoute {
+        RecordingCapture* capture{nullptr};
+        int inputIndex{-1};
+    };
+
+    void publishRecordingCaptureSnapshot() {
+        const uint32_t inactive = 1u - m_activeRecordingCaptureSnapshot.load(std::memory_order_relaxed);
+        auto& snap = m_recordingCaptureSnapshots[inactive];
+        uint32_t count = 0;
+        for (const auto& [channelId, capture] : m_recordingCaptures) {
+            if (!capture) {
+                continue;
+            }
+            if (count >= kMaxRecordingTracks) {
+                break;
+            }
+            snap[count].capture = capture.get();
+            snap[count].inputIndex = capture->inputIndex;
+            ++count;
+        }
+        m_recordingCaptureRouteCounts[inactive].store(count, std::memory_order_release);
+        m_activeRecordingCaptureSnapshot.store(inactive, std::memory_order_release);
+    }
+
     static double quantizePatternLengthBeats(double contentEndBeat) {
         constexpr double kBeatsPerBar = 4.0;
         constexpr double kBarsPerPatternBlock = 4.0;

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -375,9 +375,13 @@ public:
     bool isUserScrubbing() const { return m_userScrubbing.load(std::memory_order_relaxed); }
 
     /**
-     * @brief Process interleaved hardware input for armed tracks.
-     * @param input Input channel buffer.
-     * @param frames Number of frames available in the input buffer.
+     * @brief Publishes a double-buffered snapshot of active recording routes.
+     *
+     * Copies the current recording capture pointers into the inactive snapshot
+     * slot, then atomically flips the active index so the RT audio thread can
+     * read an immutable route list without locking.
+     *
+     * @note Must be called from the UI/command thread, not the audio thread.
      */
     void publishRecordingCaptureSnapshot() {
         const uint32_t inactive = 1u - m_activeRecordingCaptureSnapshot.load(std::memory_order_relaxed);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -384,7 +384,10 @@ public:
         auto& snap = m_recordingCaptureSnapshots[inactive];
         uint32_t count = 0;
         for (const auto& [channelId, capture] : m_recordingCaptures) {
-            if (!capture || count >= kMaxRecordingTracks) {
+            if (!capture) {
+                continue;
+            }
+            if (count >= kMaxRecordingTracks) {
                 break;
             }
             snap[count].capture = capture.get();
@@ -407,6 +410,11 @@ public:
         if (routeCount == 0) {
             return;
         }
+
+        // Bracket snapshot access with writer count so finalizeCaptureSession()
+        // drains in-flight RT readers before destroying captures.
+        m_recordingWriters.fetch_add(1, std::memory_order_acq_rel);
+
         const auto& routes = m_recordingCaptureSnapshots[snapIdx];
 
         const double captureBeat = getCurrentTransportBeat();
@@ -512,6 +520,8 @@ public:
             (void)telemetry;
             m_recordingNoArmLogged = true;
         }
+
+        m_recordingWriters.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     void publishInputMonitoringSnapshot() {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -368,33 +368,6 @@ public:
      */
     bool isUserScrubbing() const { return m_userScrubbing.load(std::memory_order_relaxed); }
 
-    /**
-     * @brief Publishes a double-buffered snapshot of active recording routes.
-     *
-     * Copies the current recording capture pointers into the inactive snapshot
-     * slot, then atomically flips the active index so the RT audio thread can
-     * read an immutable route list without locking.
-     *
-     * @note Must be called from the UI/command thread, not the audio thread.
-     */
-    void publishRecordingCaptureSnapshot() {
-        const uint32_t inactive = 1u - m_activeRecordingCaptureSnapshot.load(std::memory_order_relaxed);
-        auto& snap = m_recordingCaptureSnapshots[inactive];
-        uint32_t count = 0;
-        for (const auto& [channelId, capture] : m_recordingCaptures) {
-            if (!capture) {
-                continue;
-            }
-            if (count >= kMaxRecordingTracks) {
-                break;
-            }
-            snap[count].capture = capture.get();
-            snap[count].inputIndex = capture->inputIndex;
-            ++count;
-        }
-        m_recordingCaptureRouteCounts[inactive].store(count, std::memory_order_release);
-        m_activeRecordingCaptureSnapshot.store(inactive, std::memory_order_release);
-    }
     void processInput(const float* input, uint32_t frames, AudioTelemetry* telemetry = nullptr) {
         if (!m_isCapturing.load(std::memory_order_relaxed) || !input || frames == 0 || m_inputChannelCount <= 0) {
             return;

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -63,6 +63,12 @@ public:
         float volume{1.0f};
     };
 
+    /// @brief Immutable snapshot of a recording capture route for RT path.
+    struct RecordingCaptureRoute {
+        RecordingCapture* capture{nullptr};
+        int inputIndex{-1};
+    };
+
     /**
      * @brief Construct a track manager and wire its internal playback helpers.
      */
@@ -373,26 +379,35 @@ public:
      * @param input Input channel buffer.
      * @param frames Number of frames available in the input buffer.
      */
+    void publishRecordingCaptureSnapshot() {
+        const uint32_t inactive = 1u - m_activeRecordingCaptureSnapshot.load(std::memory_order_relaxed);
+        auto& snap = m_recordingCaptureSnapshots[inactive];
+        uint32_t count = 0;
+        for (const auto& [channelId, capture] : m_recordingCaptures) {
+            if (!capture || count >= kMaxRecordingTracks) {
+                break;
+            }
+            snap[count].capture = capture.get();
+            snap[count].inputIndex = capture->inputIndex;
+            ++count;
+        }
+        m_recordingCaptureRouteCounts[inactive].store(count, std::memory_order_release);
+        m_activeRecordingCaptureSnapshot.store(inactive, std::memory_order_release);
+    }
+
     void processInput(const float* input, uint32_t frames, AudioTelemetry* telemetry = nullptr) {
         if (!m_isCapturing.load(std::memory_order_relaxed) || !input || frames == 0 || m_inputChannelCount <= 0) {
             return;
         }
 
-        if (!m_recordingCaptureAccepting.load(std::memory_order_acquire)) {
+        // Read the immutable recording capture snapshot — avoids iterating the
+        // live m_channels / m_recordingCaptures containers on the RT thread.
+        const uint32_t snapIdx = m_activeRecordingCaptureSnapshot.load(std::memory_order_acquire);
+        const uint32_t routeCount = m_recordingCaptureRouteCounts[snapIdx].load(std::memory_order_acquire);
+        if (routeCount == 0) {
             return;
         }
-
-        struct RecordingWriteGuard {
-            explicit RecordingWriteGuard(std::atomic<uint32_t>& writersIn) : writers(writersIn) {
-                writers.fetch_add(1, std::memory_order_acq_rel);
-            }
-            ~RecordingWriteGuard() { writers.fetch_sub(1, std::memory_order_acq_rel); }
-            std::atomic<uint32_t>& writers;
-        } guard(m_recordingWriters);
-
-        if (!m_recordingCaptureAccepting.load(std::memory_order_acquire)) {
-            return;
-        }
+        const auto& routes = m_recordingCaptureSnapshots[snapIdx];
 
         const double captureBeat = getCurrentTransportBeat();
         const bool hasDeferredStart = m_hasDeferredRecordingStart.load(std::memory_order_acquire);
@@ -402,29 +417,24 @@ public:
         bool capturedAnyChannel = false;
         bool startedDeferredCapture = false;
 
-        for (const auto& channel : m_channels) {
-            if (!channel || !channel->isArmed()) {
+        for (uint32_t r = 0; r < routeCount; ++r) {
+            RecordingCapture* capture = routes[r].capture;
+            if (!capture) {
+                continue;
+            }
+            const int requestedInput = routes[r].inputIndex;
+            if (requestedInput < 0 && requestedInput != -2) {
                 continue;
             }
 
-            const int requestedInput = channel->getInputChannelIndex();
-            if (requestedInput == -1) {
+            const size_t capacity = capture->capacity;
+            if (capacity == 0 || !capture->samples) {
                 continue;
             }
 
-            auto captureIt = m_recordingCaptures.find(channel->getChannelId());
-            if (captureIt == m_recordingCaptures.end() || !captureIt->second) {
-                continue;
-            }
-            RecordingCapture& capture = *captureIt->second;
-            const size_t capacity = capture.capacity;
-            if (capacity == 0 || !capture.samples) {
-                continue;
-            }
-
-            size_t head = capture.headIndex.load(std::memory_order_relaxed);
-            size_t size = capture.size.load(std::memory_order_relaxed);
-            double startBeat = capture.startBeat.load(std::memory_order_relaxed);
+            size_t head = capture->headIndex.load(std::memory_order_relaxed);
+            size_t size = capture->size.load(std::memory_order_relaxed);
+            double startBeat = capture->startBeat.load(std::memory_order_relaxed);
             uint64_t droppedFrames = 0;
             uint32_t startFrame = 0;
             double effectiveCaptureBeat = captureBeat;
@@ -446,7 +456,7 @@ public:
 
             auto appendSample = [&](float sample) {
                 size_t writeIndex = (head + size) % capacity;
-                capture.samples[writeIndex].store(sample, std::memory_order_relaxed);
+                capture->samples[writeIndex].store(sample, std::memory_order_relaxed);
                 if (size < capacity) {
                     ++size;
                 } else {
@@ -478,19 +488,19 @@ public:
                 }
             }
             bool expectedStart = false;
-            if (capture.hasStarted.compare_exchange_strong(expectedStart, true, std::memory_order_acq_rel)) {
-                capture.startBeat.store(effectiveCaptureBeat, std::memory_order_release);
+            if (capture->hasStarted.compare_exchange_strong(expectedStart, true, std::memory_order_acq_rel)) {
+                capture->startBeat.store(effectiveCaptureBeat, std::memory_order_release);
                 if (hasDeferredStart) {
                     startedDeferredCapture = true;
                 }
             }
             if (droppedFrames > 0) {
                 startBeat += framesToBeats(static_cast<double>(droppedFrames));
-                capture.startBeat.store(startBeat, std::memory_order_release);
+                capture->startBeat.store(startBeat, std::memory_order_release);
             }
-            capture.headIndex.store(head, std::memory_order_release);
-            capture.size.store(size, std::memory_order_release);
-            capture.totalCapturedFrames.fetch_add(frames - startFrame, std::memory_order_relaxed);
+            capture->headIndex.store(head, std::memory_order_release);
+            capture->size.store(size, std::memory_order_release);
+            capture->totalCapturedFrames.fetch_add(frames - startFrame, std::memory_order_relaxed);
             capturedAnyChannel = true;
         }
 
@@ -1074,6 +1084,7 @@ private:
         m_recordingNoArmLogged = false;
         m_recordingCaptureAccepting.store(true, std::memory_order_release);
         m_isCapturing.store(true, std::memory_order_relaxed);
+        publishRecordingCaptureSnapshot();
         Log::info("[TrackManager] Recording session started. Armed tracks: " + std::to_string(getArmedTrackCount()) +
                   ", input channels: " + std::to_string(m_inputChannelCount));
     }
@@ -1090,6 +1101,11 @@ private:
         if (!writersDrained) {
             Log::warning("[TrackManager] Timed out waiting for recording writers to drain before finalizing capture.");
         }
+
+        // Publish empty snapshot so RT thread stops referencing captures.
+        m_recordingCaptureRouteCounts[0].store(0, std::memory_order_release);
+        m_recordingCaptureRouteCounts[1].store(0, std::memory_order_release);
+        m_activeRecordingCaptureSnapshot.store(0, std::memory_order_release);
 
         std::unordered_map<uint32_t, std::unique_ptr<RecordingCapture>> captures;
         double sessionStartBeat = 0.0;
@@ -1442,6 +1458,11 @@ private:
     std::array<RtInputMonitorRoute, 32> m_inputMonitorSnapshots[2]{};
     std::array<std::atomic<uint32_t>, 2> m_inputMonitorRouteCounts{};
     std::atomic<uint32_t> m_activeInputMonitorSnapshot{0};
+
+    static constexpr size_t kMaxRecordingTracks = 64;
+    std::array<RecordingCaptureRoute, kMaxRecordingTracks> m_recordingCaptureSnapshots[2]{};
+    std::array<std::atomic<uint32_t>, 2> m_recordingCaptureRouteCounts{};
+    std::atomic<uint32_t> m_activeRecordingCaptureSnapshot{0};
     double m_maxRecordingSeconds{15.0};
     double m_recordingSessionStartBeat{0.0};
     bool m_recordingSessionUsesPlacementOverride{false};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1108,7 +1108,6 @@ private:
 
     void finalizeCaptureSession() {
         m_recordingCaptureAccepting.store(false, std::memory_order_release);
-        m_isCapturing.store(false, std::memory_order_relaxed);
         const auto waitDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(250);
         bool writersDrained = m_recordingWriters.load(std::memory_order_acquire) == 0;
         while (!writersDrained && std::chrono::steady_clock::now() < waitDeadline) {
@@ -1116,8 +1115,15 @@ private:
             writersDrained = m_recordingWriters.load(std::memory_order_acquire) == 0;
         }
         if (!writersDrained) {
-            Log::warning("[TrackManager] Timed out waiting for recording writers to drain before finalizing capture.");
+            Log::warning("[TrackManager] Timed out waiting for recording writers to drain before finalizing capture. "
+                         "Deferring teardown — retry on next disarm.");
+            // Leave m_isCapturing, snapshots, captures, and session fields intact.
+            // processInput() callers still in-flight continue to hold valid pointers.
+            m_recordingCaptureAccepting.store(true, std::memory_order_release);
+            return;
         }
+
+        m_isCapturing.store(false, std::memory_order_relaxed);
 
         // Publish empty snapshot so RT thread stops referencing captures.
         m_recordingCaptureRouteCounts[0].store(0, std::memory_order_release);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1092,6 +1092,13 @@ private:
         }
         clearNextCapturePlacementStartBeat();
         m_recordingNoArmLogged = false;
+        const size_t armedCount = m_recordingCaptures.size();
+        if (armedCount > kMaxRecordingTracks) {
+            Log::warning("[TrackManager] Armed track count (" + std::to_string(armedCount) +
+                         ") exceeds kMaxRecordingTracks (" + std::to_string(kMaxRecordingTracks) +
+                         "). Only the first " + std::to_string(kMaxRecordingTracks) +
+                         " will be captured in the snapshot.");
+        }
         m_recordingCaptureAccepting.store(true, std::memory_order_release);
         m_isCapturing.store(true, std::memory_order_relaxed);
         publishRecordingCaptureSnapshot();

--- a/AestraAudio/include/Playback/PreviewEngine.h
+++ b/AestraAudio/include/Playback/PreviewEngine.h
@@ -42,6 +42,17 @@ public:
     void seek(double seconds); // New seek method
     void setOutputSampleRate(double sr);
     void process(float* interleavedOutput, uint32_t numFrames);
+
+    /**
+     * @brief RT-safe preview mix into the engine's interleaved output buffer.
+     *
+     * Called from the audio callback. Mixes decoded preview samples directly
+     * into the provided output buffer with no allocation or locking.
+     *
+     * @param interleavedOutput Destination buffer (interleaved, already sized).
+     * @param numFrames         Number of frames to render.
+     * @param outputChannels    Channel count of the destination buffer.
+     */
     void processRealtime(float* interleavedOutput, uint32_t numFrames, uint32_t outputChannels);
     bool isPlaying() const;
     bool isBufferReady() const; // True when buffer is decoded and ready for playback

--- a/AestraAudio/include/Playback/PreviewEngine.h
+++ b/AestraAudio/include/Playback/PreviewEngine.h
@@ -36,11 +36,13 @@ public:
     PreviewEngine(const PreviewEngine&) = delete;
     PreviewEngine& operator=(const PreviewEngine&) = delete;
 
-    PreviewResult play(const std::string& path, float gainDb = -6.0f, double maxSeconds = 30.0, float playbackRate = 1.0f);
+    PreviewResult play(const std::string& path, float gainDb = -6.0f, double maxSeconds = 30.0,
+                       float playbackRate = 1.0f);
     void stop();
     void seek(double seconds); // New seek method
     void setOutputSampleRate(double sr);
     void process(float* interleavedOutput, uint32_t numFrames);
+    void processRealtime(float* interleavedOutput, uint32_t numFrames, uint32_t outputChannels);
     bool isPlaying() const;
     bool isBufferReady() const; // True when buffer is decoded and ready for playback
     void setOnComplete(std::function<void(const std::string& path)> callback);
@@ -88,6 +90,7 @@ private:
 
     // Deferred completion (audio thread -> main thread)
     std::atomic<bool> m_completionPending{false};
+    std::atomic<PreviewVoice*> m_completedVoice{nullptr};
     std::string m_completedPathStr;
     std::mutex m_completedPathMutex;
 

--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -49,7 +49,7 @@ public:
     bool resizeEditor(int width, int height) override;
 
     const PluginInfo& getInfo() const override { return m_info; }
-    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getLatencySamples() const override { return m_maxBlockSize; }
     uint32_t getTailSamples() const override { return 0; }
 
     WatchdogStats getWatchdogStats() const override { return m_watchdogStats; }
@@ -64,8 +64,7 @@ private:
     void stopWorker();
     void workerLoop();
     bool processBlockInHelper(const std::vector<float>& input, uint32_t channels, uint32_t frames,
-                              const std::vector<uint8_t>& midiData, size_t midiBytes,
-                              std::vector<float>& output);
+                              const std::vector<uint8_t>& midiData, size_t midiBytes, std::vector<float>& output);
     void markCrashed();
     void passThrough(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
                      uint32_t numFrames) const;

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -222,8 +222,7 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
 
             if (fadeInFrames > 0) {
                 for (uint32_t i = 0; i < fadeInFrames; ++i) {
-                    const double fade =
-                        static_cast<double>(start + i - clip.startSample) / CLIP_EDGE_FADE_SAMPLES;
+                    const double fade = static_cast<double>(start + i - clip.startSample) / CLIP_EDGE_FADE_SAMPLES;
                     dst[i * 2] += static_cast<double>(src[i * 2]) * clipGainD * fade;
                     dst[i * 2 + 1] += static_cast<double>(src[i * 2 + 1]) * clipGainD * fade;
                 }
@@ -239,8 +238,7 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
             if (framesToRender > std::max(fadeOutBegin, fadeInFrames)) {
                 const uint32_t fadeOutStart = std::max(fadeOutBegin, fadeInFrames);
                 for (uint32_t i = fadeOutStart; i < framesToRender; ++i) {
-                    const double fade =
-                        static_cast<double>(clip.endSample - (start + i)) / CLIP_EDGE_FADE_SAMPLES;
+                    const double fade = static_cast<double>(clip.endSample - (start + i)) / CLIP_EDGE_FADE_SAMPLES;
                     dst[i * 2] += static_cast<double>(src[i * 2]) * clipGainD * fade;
                     dst[i * 2 + 1] += static_cast<double>(src[i * 2 + 1]) * clipGainD * fade;
                 }
@@ -266,7 +264,7 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
                 break;
             default: {
                 static_assert(static_cast<int>(Interpolators::InterpolationQuality::Sinc64) == 4,
-                             "All InterpolationQuality values must be handled above");
+                              "All InterpolationQuality values must be handled above");
                 interpolateFunc = Interpolators::Sinc64Turbo::interpolate;
                 break;
             }
@@ -329,7 +327,8 @@ void AudioRenderer::processTrackEffects(const RenderTrack& track, AudioGraphStat
     if (track.trackIndex >= graphState.trackStates.size())
         return;
     TrackRTState& state = graphState.trackStates[track.trackIndex];
-    const AudioGraph& graph = engineRef.engineState().activeGraph();
+    auto graphRead = engineRef.engineState().activeGraphRead();
+    const AudioGraph& graph = graphRead.get();
     if (track.trackIndex < graph.tracks.size()) {
         const auto& gt = graph.tracks[track.trackIndex];
 
@@ -386,8 +385,8 @@ void AudioRenderer::renderArsenalUnitsForTrack(uint32_t trackIndex, double* trac
             MidiBuffer mOut;
             const bool processed = processPluginNoexcept(*u.plugin, ins, outs, 2, 2, ctx.numFrames, mIn, &mOut);
             if (!processed) {
-                std::fill(engineRef.m_pluginBufferF.begin(),
-                          engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2, 0.0f);
+                std::fill(engineRef.m_pluginBufferF.begin(), engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2,
+                          0.0f);
             } else {
                 sanitizeFloatBuffers(outs, 2, ctx.numFrames);
             }
@@ -424,8 +423,8 @@ void AudioRenderer::processArsenalUnits(const Context& ctx, AudioEngine& engineR
             MidiBuffer mOut;
             const bool processed = processPluginNoexcept(*u.plugin, ins, outs, 2, 2, ctx.numFrames, mIn, &mOut);
             if (!processed) {
-                std::fill(engineRef.m_pluginBufferF.begin(),
-                          engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2, 0.0f);
+                std::fill(engineRef.m_pluginBufferF.begin(), engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2,
+                          0.0f);
             } else {
                 sanitizeFloatBuffers(outs, 2, ctx.numFrames);
             }

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -94,7 +94,7 @@ void AudioRenderer::renderBlock(const Context& ctx, AudioGraphState& state, Audi
         renderArsenalUnitsForTrack(track.trackIndex, track.selfBuffer, ctx, engineRef);
 
         // 2. Process Effects (In-Place) -> track.selfBuffer
-        processTrackEffects(track, state, ctx.numFrames, ctx.bufferOffset, engineRef);
+        processTrackEffects(track, state, ctx.numFrames, ctx.bufferOffset, engineRef, *ctx.graph);
 
         // 3. Calculate Track Meter Peaks (post-fader)
         if (!ctx.isOffline && track.selfBuffer && snaps && slotMap && track.trackIndex < ctx.graph->tracks.size()) {
@@ -323,12 +323,10 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
 }
 
 void AudioRenderer::processTrackEffects(const RenderTrack& track, AudioGraphState& graphState, uint32_t numFrames,
-                                        uint32_t bufferOffset, AudioEngine& engineRef) {
+                                        uint32_t bufferOffset, AudioEngine& engineRef, const AudioGraph& graph) {
     if (track.trackIndex >= graphState.trackStates.size())
         return;
     TrackRTState& state = graphState.trackStates[track.trackIndex];
-    auto graphRead = engineRef.engineState().activeGraphRead();
-    const AudioGraph& graph = graphRead.get();
     if (track.trackIndex < graph.tracks.size()) {
         const auto& gt = graph.tracks[track.trackIndex];
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -22,12 +22,12 @@
 #endif
 
 #include <algorithm>
-#include <cstdlib>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <queue>
 #if defined(_MSC_VER) || defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
@@ -45,16 +45,16 @@
 #define RESTORE_DENORMALS _mm_setcsr(oldMXCSR);
 #elif defined(__aarch64__) && !defined(_MSC_VER)
 // ARM64 on GCC/Clang-style compilers: set FPCR.FZ (bit 24) to flush denormals to zero
-#define DISABLE_DENORMALS           \
-    uint64_t oldFPCR;               \
+#define DISABLE_DENORMALS                             \
+    uint64_t oldFPCR;                                 \
     __asm__ volatile("mrs %0, fpcr" : "=r"(oldFPCR)); \
-    __asm__ volatile("msr fpcr, %0" :: "r"(oldFPCR | (1ULL << 24)));
+    __asm__ volatile("msr fpcr, %0" ::"r"(oldFPCR | (1ULL << 24)));
 
-#define RESTORE_DENORMALS __asm__ volatile("msr fpcr, %0" :: "r"(oldFPCR));
+#define RESTORE_DENORMALS __asm__ volatile("msr fpcr, %0" ::"r"(oldFPCR));
 #elif defined(_M_ARM64) || defined(_M_ARM64EC)
 // MSVC ARM64: use _ReadStatusReg/_WriteStatusReg to toggle FPCR.FZ (bit 24, flush-to-zero)
 #include <intrin.h>
-#define DISABLE_DENORMALS           \
+#define DISABLE_DENORMALS                      \
     uint64_t oldFPCR = _ReadStatusReg(0x4020); \
     _WriteStatusReg(0x4020, oldFPCR | (1ULL << 24));
 
@@ -460,14 +460,18 @@ void AudioEngine::performNonRealtimeMaintenance() {
         return;
     }
 
+    if (auto* preview = m_previewEngine.load(std::memory_order_acquire)) {
+        preview->handleDeferredCompletion();
+    }
+
     const uint64_t rtMisuseCount = g_rtMisuseCount.load(std::memory_order_relaxed);
     const uint64_t reportedCount = g_rtMisuseReportedCount.load(std::memory_order_relaxed);
     if (rtMisuseCount != reportedCount) {
         g_rtMisuseReportedCount.store(rtMisuseCount, std::memory_order_relaxed);
         const char* apiName = g_rtMisuseLastApi.load(std::memory_order_relaxed);
-        Aestra::Log::warning("[RTGuard] Non-real-time API reached audio thread: " +
-                             std::string(apiName ? apiName : "unknown") + " (count=" +
-                             std::to_string(rtMisuseCount) + ")");
+        Aestra::Log::warning(
+            "[RTGuard] Non-real-time API reached audio thread: " + std::string(apiName ? apiName : "unknown") +
+            " (count=" + std::to_string(rtMisuseCount) + ")");
     }
 
     // Pattern engine lookahead refill (non-RT, runs every main loop iteration)
@@ -508,7 +512,8 @@ void AudioEngine::drainDeferredResourcesForShutdown() {
 
 void AudioEngine::resetCachedSamplerVoicesRt() noexcept {
     auto* cache = m_samplerCacheRaw.load(std::memory_order_acquire);
-    if (!cache) return;
+    if (!cache)
+        return;
     const size_t cachedCount = cache->count;
     for (size_t i = 0; i < cachedCount && i < cache->samplers.size(); ++i) {
         if (cache->samplers[i]) {
@@ -522,7 +527,8 @@ void AudioEngine::syncCachedSamplerSampleRatesRt(uint32_t sampleRate) noexcept {
         return;
     }
     auto* cache = m_samplerCacheRaw.load(std::memory_order_acquire);
-    if (!cache) return;
+    if (!cache)
+        return;
     const size_t cachedCount = cache->count;
     for (size_t i = 0; i < cachedCount && i < cache->samplers.size(); ++i) {
         if (cache->samplers[i]) {
@@ -693,8 +699,9 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
             // Simple metering for Audition (optional, but good for UI feedback)
             float audPeakL = 0.0f, audPeakR = 0.0f;
             for (uint32_t i = 0; i < numFrames; ++i) {
-                float l = std::abs(outputBuffer[i * 2]);
-                float r = std::abs(outputBuffer[i * 2 + 1]);
+                const size_t frameBase = static_cast<size_t>(i) * numOutputChannels;
+                float l = std::abs(outputBuffer[frameBase]);
+                float r = numOutputChannels > 1 ? std::abs(outputBuffer[frameBase + 1]) : l;
                 if (l > audPeakL)
                     audPeakL = l;
                 if (r > audPeakR)
@@ -733,7 +740,8 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     }
 
     // Render to double-precision master buffer
-    const AudioGraph& graph = m_state.activeGraph();
+    auto graphRead = m_state.activeGraphRead();
+    const AudioGraph& graph = graphRead.get();
 
     // Loop & Position Logic Loop Calculation
     bool playing = isPlaying;
@@ -832,12 +840,12 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         } else {
             // === Pattern Mode: Clear Buffer ===
             std::fill(m_masterBufferD.begin(),
-                      m_masterBufferD.begin() + static_cast<size_t>(numFrames) * numOutputChannels, 0.0);
+                      m_masterBufferD.begin() + static_cast<size_t>(numFrames) * kInternalRenderChannels, 0.0);
         }
     } else {
         // Zero the double buffer
-        std::fill(m_masterBufferD.begin(), m_masterBufferD.begin() + static_cast<size_t>(numFrames) * numOutputChannels,
-                  0.0);
+        std::fill(m_masterBufferD.begin(),
+                  m_masterBufferD.begin() + static_cast<size_t>(numFrames) * kInternalRenderChannels, 0.0);
     }
 
     // === Arsenal Unit Processing (Pattern Playback) ===
@@ -1049,9 +1057,16 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
             clipCount++;
         }
 
-        // Output as float
-        outputBuffer[i * 2] = static_cast<float>(L);
-        outputBuffer[i * 2 + 1] = static_cast<float>(R);
+        const size_t frameBase = static_cast<size_t>(i) * numOutputChannels;
+        if (numOutputChannels == 1) {
+            outputBuffer[frameBase] = static_cast<float>((L + R) * 0.5);
+        } else {
+            outputBuffer[frameBase] = static_cast<float>(L);
+            outputBuffer[frameBase + 1] = static_cast<float>(R);
+            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                outputBuffer[frameBase + ch] = 0.0f;
+            }
+        }
 
         gain += gainDelta;
     }
@@ -1142,15 +1157,17 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
             }
             const double progress = 1.0 - (static_cast<double>(m_fadeSamplesRemaining) / fadeTotal);
             const double fadeGain = progress * progress * (3.0 - 2.0 * progress); // Smoothstep
-            outputBuffer[i * 2] *= static_cast<float>(fadeGain);
-            outputBuffer[i * 2 + 1] *= static_cast<float>(fadeGain);
+            const size_t frameBase = static_cast<size_t>(i) * numOutputChannels;
+            for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+                outputBuffer[frameBase + ch] *= static_cast<float>(fadeGain);
+            }
             --m_fadeSamplesRemaining;
         }
     } else if (m_fadeState.load(std::memory_order_relaxed) == FadeState::FadingOut) {
         const double fadeTotal = static_cast<double>(FADE_OUT_SAMPLES);
         for (uint32_t i = 0; i < numFrames; ++i) {
             if (m_fadeSamplesRemaining == 0) {
-                std::memset(outputBuffer + i * 2, 0,
+                std::memset(outputBuffer + static_cast<size_t>(i) * numOutputChannels, 0,
                             static_cast<size_t>(numFrames - i) * numOutputChannels * sizeof(float));
                 m_fadeState.store(FadeState::Silent, std::memory_order_relaxed);
                 break;
@@ -1158,8 +1175,10 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
             const double t = static_cast<double>(m_fadeSamplesRemaining) / fadeTotal;
             const double fadeGain = t * t * (3.0 - 2.0 * t); // Smoothstep
 
-            outputBuffer[i * 2] *= static_cast<float>(fadeGain);
-            outputBuffer[i * 2 + 1] *= static_cast<float>(fadeGain);
+            const size_t frameBase = static_cast<size_t>(i) * numOutputChannels;
+            for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+                outputBuffer[frameBase + ch] *= static_cast<float>(fadeGain);
+            }
             --m_fadeSamplesRemaining;
         }
     }
@@ -1205,8 +1224,7 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     // processing. The meter is single-writer (audio thread only); UI reads
     // the published atomics. Only enabled for stereo output (which is the
     // only case the meter has been validated for).
-    if (m_truePeakMeteringEnabled.load(std::memory_order_relaxed) && numOutputChannels == 2 &&
-        numFrames > 0) {
+    if (m_truePeakMeteringEnabled.load(std::memory_order_relaxed) && numOutputChannels == 2 && numFrames > 0) {
         m_truePeakMeter.processStereo(outputBuffer, numFrames);
         m_truePeakLAtomic.store(m_truePeakMeter.getTruePeakL(), std::memory_order_relaxed);
         m_truePeakRAtomic.store(m_truePeakMeter.getTruePeakR(), std::memory_order_relaxed);
@@ -1226,7 +1244,8 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
     // Treat maxFrames as a hint; never shrink RT buffers.
     // Some drivers deliver larger blocks than requested, and shrinking can cause
     // renderGraph() to early-out -> audible crackles.
-    m_outputChannels.store(numChannels, std::memory_order_relaxed);
+    const uint32_t outputChannels = std::max<uint32_t>(1, numChannels);
+    m_outputChannels.store(outputChannels, std::memory_order_relaxed);
     if (maxFrames > m_maxBufferFrames.load(std::memory_order_relaxed)) {
         m_maxBufferFrames.store(maxFrames, std::memory_order_relaxed);
     }
@@ -1237,8 +1256,8 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
                                                    std::memory_order_relaxed);
     }
 
-    const size_t requiredSize = static_cast<size_t>(m_maxBufferFrames.load(std::memory_order_relaxed)) *
-                                m_outputChannels.load(std::memory_order_relaxed);
+    const size_t requiredSize =
+        static_cast<size_t>(m_maxBufferFrames.load(std::memory_order_relaxed)) * kInternalRenderChannels;
     const bool needAlloc = m_masterBufferD.size() < requiredSize || m_trackBuffersD.size() != kMaxTracks;
 
     if (needAlloc) {
@@ -1376,8 +1395,8 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
     if (m_waveformHistoryFrames.load(std::memory_order_relaxed) == 0) {
         m_waveformHistoryFrames.store(kWaveformHistoryFramesDefault, std::memory_order_relaxed);
     }
-    const size_t historyRequired = static_cast<size_t>(m_waveformHistoryFrames.load(std::memory_order_relaxed)) *
-                                   m_outputChannels.load(std::memory_order_relaxed);
+    const size_t historyRequired =
+        static_cast<size_t>(m_waveformHistoryFrames.load(std::memory_order_relaxed)) * outputChannels;
     if (m_waveformHistory.size() < historyRequired) {
         m_waveformHistory.assign(historyRequired, 0.0f);
         m_waveformWriteIndex.store(0, std::memory_order_relaxed);
@@ -1483,10 +1502,8 @@ AudioEngine::BiquadCoeff AudioEngine::computeKWeightPreFilter(double sampleRate)
     // values within tolerance; fall back to the reference constants if they do not.
     if (std::abs(fs - 48000.0) < 1.0e-9) {
         constexpr double tolerance = 1.0e-9;
-        if (std::abs(b0 - kKWeightPreFilter.b0) > tolerance ||
-            std::abs(b1 - kKWeightPreFilter.b1) > tolerance ||
-            std::abs(b2 - kKWeightPreFilter.b2) > tolerance ||
-            std::abs(a1 - kKWeightPreFilter.a1) > tolerance ||
+        if (std::abs(b0 - kKWeightPreFilter.b0) > tolerance || std::abs(b1 - kKWeightPreFilter.b1) > tolerance ||
+            std::abs(b2 - kKWeightPreFilter.b2) > tolerance || std::abs(a1 - kKWeightPreFilter.a1) > tolerance ||
             std::abs(a2 - kKWeightPreFilter.a2) > tolerance) {
             return kKWeightPreFilter;
         }
@@ -1521,10 +1538,8 @@ AudioEngine::BiquadCoeff AudioEngine::computeKWeightRLB(double sampleRate) {
     // values within tolerance; fall back to the reference constants if they do not.
     if (std::abs(fs - 48000.0) < 1.0e-9) {
         constexpr double tolerance = 1.0e-9;
-        if (std::abs(coeff.b0 - kKWeightRLB.b0) > tolerance ||
-            std::abs(coeff.b1 - kKWeightRLB.b1) > tolerance ||
-            std::abs(coeff.b2 - kKWeightRLB.b2) > tolerance ||
-            std::abs(coeff.a1 - kKWeightRLB.a1) > tolerance ||
+        if (std::abs(coeff.b0 - kKWeightRLB.b0) > tolerance || std::abs(coeff.b1 - kKWeightRLB.b1) > tolerance ||
+            std::abs(coeff.b2 - kKWeightRLB.b2) > tolerance || std::abs(coeff.a1 - kKWeightRLB.a1) > tolerance ||
             std::abs(coeff.a2 - kKWeightRLB.a2) > tolerance) {
             return kKWeightRLB;
         }
@@ -1719,10 +1734,10 @@ void AudioEngine::loudnessWorkerLoop() {
 
 void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset) {
     bool srcActiveThisBlock = false;
-    const uint32_t numChannels = m_outputChannels.load(std::memory_order_relaxed);
+    constexpr uint32_t numChannels = kInternalRenderChannels;
 
     // Guard
-    if (numFrames > m_maxBufferFrames.load(std::memory_order_relaxed) || numChannels != 2) {
+    if (numFrames > m_maxBufferFrames.load(std::memory_order_relaxed)) {
         m_telemetry.incrementUnderruns();
         return;
     }
@@ -2487,25 +2502,28 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                     dOut[k * 2] = static_cast<double>(fL[k]);
                     dOut[k * 2 + 1] = static_cast<double>(fR[k]);
                 }
+            }
+        }
 
-                // === Apply Plugin Delay Compensation ===
-                if (state.compensationEnabled && state.compensationDelaySamples > 0) {
-                    const uint32_t delay = state.compensationDelaySamples;
-                    const uint32_t capacity = static_cast<uint32_t>(state.compensationBuffer.size() / 2);
-                    if (delay < capacity) {
-                        for (uint32_t k = 0; k < numFrames; ++k) {
-                            const uint32_t writePos = state.compensationWritePos;
-                            const uint32_t readPos = (writePos + capacity - delay) % capacity;
+        // === Apply Plugin Delay Compensation ===
+        // Compensation must apply to dry tracks too; those are often the tracks
+        // delayed to align with a parallel latent path elsewhere in the graph.
+        if (state.compensationEnabled && state.compensationDelaySamples > 0) {
+            const uint32_t delay = state.compensationDelaySamples;
+            const uint32_t capacity = static_cast<uint32_t>(state.compensationBuffer.size() / 2);
+            if (delay < capacity) {
+                double* dOut = buffer.data();
+                for (uint32_t k = 0; k < numFrames; ++k) {
+                    const uint32_t writePos = state.compensationWritePos;
+                    const uint32_t readPos = (writePos + capacity - delay) % capacity;
 
-                            state.compensationBuffer[writePos * 2] = static_cast<float>(dOut[k * 2]);
-                            state.compensationBuffer[writePos * 2 + 1] = static_cast<float>(dOut[k * 2 + 1]);
+                    state.compensationBuffer[writePos * 2] = static_cast<float>(dOut[k * 2]);
+                    state.compensationBuffer[writePos * 2 + 1] = static_cast<float>(dOut[k * 2 + 1]);
 
-                            dOut[k * 2] = static_cast<double>(state.compensationBuffer[readPos * 2]);
-                            dOut[k * 2 + 1] = static_cast<double>(state.compensationBuffer[readPos * 2 + 1]);
+                    dOut[k * 2] = static_cast<double>(state.compensationBuffer[readPos * 2]);
+                    dOut[k * 2 + 1] = static_cast<double>(state.compensationBuffer[readPos * 2 + 1]);
 
-                            state.compensationWritePos = (writePos + 1) % capacity;
-                        }
-                    }
+                    state.compensationWritePos = (writePos + 1) % capacity;
                 }
             }
         }
@@ -2622,9 +2640,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                 // PDC v2 (P4b.3): look up the per-edge compensation slot for
                 // this send. nullptr means "no compensation"; treated as a fast
                 // path in the consume loop below.
-                route.edgeDelay = (sendIndex < state.sendEdgeDelays.size())
-                                      ? state.sendEdgeDelays[sendIndex].get()
-                                      : nullptr;
+                route.edgeDelay =
+                    (sendIndex < state.sendEdgeDelays.size()) ? state.sendEdgeDelays[sendIndex].get() : nullptr;
 
                 if (send.sidechainOnly && send.targetChannelId != 0xFFFFFFFFu && slotMap) {
                     const uint32_t scDestSlot = slotMap->getSlotIndex(send.targetChannelId);
@@ -2737,7 +2754,6 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                 snaps->setClip(slot, peakL >= 1.0f, peakR >= 1.0f);
             }
         }
-
     }
 
     if (unitSnapshot) {
@@ -2808,7 +2824,8 @@ void AudioEngine::compileGraph() {
     targetOrder.reserve(slotMap->getChannelCount());
 
     // Access the current graph snapshot
-    const auto& graph = m_state.activeGraph(); // Fixed method name
+    auto graphRead = m_state.activeGraphRead();
+    const auto& graph = graphRead.get(); // Fixed method name
 
     // Iterate Tracks directly from the graph snapshot
     for (const auto& tr : graph.tracks) {
@@ -2907,9 +2924,8 @@ void AudioEngine::panic() {
     // We lock the graph mutex to ensure we don't access a graph that's being swapped
     std::lock_guard<std::mutex> lock(m_graphMutex);
 
-    // Note: accessing activeGraph() from Main Thread is safe given we hold the mutex
-    // that protects the swap.
-    const AudioGraph& graph = m_state.activeGraph();
+    auto graphRead = m_state.activeGraphRead();
+    const AudioGraph& graph = graphRead.get();
 
     // Reset effect chains via the original MixerChannels (not the snapshots)
     // We use the trackManager to access the actual channels for panic()
@@ -3122,7 +3138,8 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         return true;
     }
 
-    // Isolated track bounce: use existing renderBlock path (TODO: consolidate when AudioExporter adds isolated track support)
+    // Isolated track bounce: use existing renderBlock path (TODO: consolidate when AudioExporter adds isolated track
+    // support)
     // 1. Calculate length
     double sampleRate = (double)m_sampleRate.load(std::memory_order_relaxed);
     float bpm = m_metronomeEngine.getBPM();
@@ -3212,7 +3229,8 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         ctx.bufferOffset = 0;
         ctx.globalPos = currentFrame;
         ctx.sampleRate = (uint32_t)sampleRate;
-        ctx.graph = &m_state.activeGraph();
+        auto graphRead = m_state.activeGraphRead();
+        ctx.graph = &graphRead.get();
         ctx.isOffline = true;
         ctx.isolatedTrackIndex = isolatedTrackIndex;
 
@@ -3381,7 +3399,8 @@ void AudioEngine::calculateLatencyCompensation() {
 
     for (size_t i = 0; i < trackCount; ++i) {
         auto* channel = trackManager->getChannel(i);
-        if (!channel) continue;
+        if (!channel)
+            continue;
         LatencyGraph::Node node;
         node.channelId = channel->getChannelId();
         node.intrinsicLatency = channel->getEffectChain().getTotalLatency();
@@ -3412,9 +3431,11 @@ void AudioEngine::calculateLatencyCompensation() {
     // engine's render-time behavior in renderGraph() / addTrackEdge().
     for (size_t i = 0; i < trackCount; ++i) {
         auto* channel = trackManager->getChannel(i);
-        if (!channel) continue;
+        if (!channel)
+            continue;
         const auto srcIt = channelIdToNodeIdx.find(channel->getChannelId());
-        if (srcIt == channelIdToNodeIdx.end()) continue;
+        if (srcIt == channelIdToNodeIdx.end())
+            continue;
         const size_t srcNodeIdx = srcIt->second;
 
         // Primary output (mainOutputId). Implicit audible edge.
@@ -3435,10 +3456,13 @@ void AudioEngine::calculateLatencyCompensation() {
         const auto sends = channel->getSends();
         for (size_t sendSlot = 0; sendSlot < sends.size(); ++sendSlot) {
             const auto& send = sends[sendSlot];
-            if (send.mute) continue;
+            if (send.mute)
+                continue;
             const auto dit = channelIdToNodeIdx.find(send.targetChannelId);
-            if (dit == channelIdToNodeIdx.end()) continue;
-            if (dit->second == srcNodeIdx) continue; // self-loops dropped at the source.
+            if (dit == channelIdToNodeIdx.end())
+                continue;
+            if (dit->second == srcNodeIdx)
+                continue; // self-loops dropped at the source.
             LatencyGraph::Edge edge;
             edge.srcNodeIdx = static_cast<uint32_t>(srcNodeIdx);
             edge.dstNodeIdx = static_cast<uint32_t>(dit->second);
@@ -3462,7 +3486,8 @@ void AudioEngine::calculateLatencyCompensation() {
 
     for (size_t n = 0; n < topology.nodes.size(); ++n) {
         const size_t trackIdx = nodeTrackIdx[n];
-        if (trackIdx >= rtStates.size()) continue;
+        if (trackIdx >= rtStates.size())
+            continue;
         const auto& sol = topology.nodes[n];
 
         auto& rtState = rtStates[trackIdx];
@@ -3487,8 +3512,7 @@ void AudioEngine::calculateLatencyCompensation() {
     //         the buffer pointer at block entry.
     //       * compensationSamples / capacityMask atomically set after the
     //         buffer pointer so an acquiring reader observes a consistent slot.
-    auto ensureEdgeCapacity = [](std::unique_ptr<EdgeDelayState>& slotPtr,
-                                 uint32_t requiredSamples,
+    auto ensureEdgeCapacity = [](std::unique_ptr<EdgeDelayState>& slotPtr, uint32_t requiredSamples,
                                  uint32_t extraHeadroom) {
         if (requiredSamples == 0) {
             // Zero out the active comp value; keep any existing buffer alive
@@ -3505,12 +3529,14 @@ void AudioEngine::calculateLatencyCompensation() {
         // path room for one block of writes ahead of reads.
         uint32_t needed = requiredSamples + extraHeadroom;
         uint32_t capacity = 1;
-        while (capacity < needed) capacity <<= 1;
+        while (capacity < needed)
+            capacity <<= 1;
         const size_t bufferFrames = capacity;
         const size_t bufferSamples = bufferFrames * 2u; // stereo interleaved
 
         const uint32_t currentMask = slotPtr->capacityMask.load(std::memory_order_relaxed);
-        const bool needGrowth = (currentMask + 1u) < bufferFrames || slotPtr->bufferPtr.load(std::memory_order_relaxed) == nullptr;
+        const bool needGrowth =
+            (currentMask + 1u) < bufferFrames || slotPtr->bufferPtr.load(std::memory_order_relaxed) == nullptr;
 
         if (needGrowth) {
             // Retire the previous owning array. The single-deep retirement
@@ -3551,7 +3577,8 @@ void AudioEngine::calculateLatencyCompensation() {
         size_t maxSendSlot = 0;
         bool anySendSlot = false;
         for (const auto& pair : bookkeeping.sendEdgeBySlot) {
-            if (!anySendSlot || pair.first > maxSendSlot) maxSendSlot = pair.first;
+            if (!anySendSlot || pair.first > maxSendSlot)
+                maxSendSlot = pair.first;
             anySendSlot = true;
         }
         if (anySendSlot && state.sendEdgeDelays.size() <= maxSendSlot) {
@@ -3566,8 +3593,10 @@ void AudioEngine::calculateLatencyCompensation() {
         for (const auto& pair : bookkeeping.sendEdgeBySlot) {
             const size_t sendSlot = pair.first;
             const size_t edgeIdx = pair.second;
-            if (sendSlot >= state.sendEdgeDelays.size()) continue;
-            if (edgeIdx >= topology.edges.size()) continue;
+            if (sendSlot >= state.sendEdgeDelays.size())
+                continue;
+            if (edgeIdx >= topology.edges.size())
+                continue;
             const auto& edgeSol = topology.edges[edgeIdx];
             ensureEdgeCapacity(state.sendEdgeDelays[sendSlot], edgeSol.compensationSamples, kEdgeHeadroomSamples);
         }
@@ -3592,8 +3621,8 @@ void AudioEngine::calculateLatencyCompensation() {
     if (topology.projectAlignmentLatency > 0) {
         const uint32_t sr = m_sampleRate.load(std::memory_order_relaxed);
         double latencyMs = (sr > 0) ? ((topology.projectAlignmentLatency * 1000.0) / sr) : 0.0;
-        Aestra::Log::info("[PDC] Max latency = " + std::to_string(topology.projectAlignmentLatency) +
-                         " samples (" + std::to_string(latencyMs) + " ms)");
+        Aestra::Log::info("[PDC] Max latency = " + std::to_string(topology.projectAlignmentLatency) + " samples (" +
+                          std::to_string(latencyMs) + " ms)");
     }
 
     // Off-RT: log any solver warnings once per generation.
@@ -3622,12 +3651,14 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
 
     auto fillSlot = [](const std::unique_ptr<EdgeDelayState>& slotPtr) {
         TrackEdgeDelaySnapshot::EdgeSlotSnapshot s;
-        if (!slotPtr) return s;
+        if (!slotPtr)
+            return s;
         s.compensationSamples = slotPtr->compensationSamples.load(std::memory_order_acquire);
         s.capacityMask = slotPtr->capacityMask.load(std::memory_order_acquire);
-        const uint32_t capFrames = (s.capacityMask == 0 && slotPtr->bufferPtr.load(std::memory_order_acquire) == nullptr)
-                                       ? 0u
-                                       : (s.capacityMask + 1u);
+        const uint32_t capFrames =
+            (s.capacityMask == 0 && slotPtr->bufferPtr.load(std::memory_order_acquire) == nullptr)
+                ? 0u
+                : (s.capacityMask + 1u);
         s.bufferBytes = static_cast<size_t>(capFrames) * 2u * sizeof(float);
         s.writePos = slotPtr->writePos;
         return s;

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1228,6 +1228,9 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         m_truePeakMeter.processStereo(outputBuffer, numFrames);
         m_truePeakLAtomic.store(m_truePeakMeter.getTruePeakL(), std::memory_order_relaxed);
         m_truePeakRAtomic.store(m_truePeakMeter.getTruePeakR(), std::memory_order_relaxed);
+    } else {
+        m_truePeakLAtomic.store(0.0f, std::memory_order_relaxed);
+        m_truePeakRAtomic.store(0.0f, std::memory_order_relaxed);
     }
 
     // Telemetry (lightweight counter only on RT thread)
@@ -1594,6 +1597,11 @@ AudioEngine::AudioEngine() {
 AudioEngine::~AudioEngine() {
     if (auto trackMgr = m_trackManager.lock()) {
         trackMgr->setChannelPrepareCallback(nullptr);
+        for (size_t i = 0; i < trackMgr->getChannelCount(); ++i) {
+            if (auto* ch = trackMgr->getChannel(i)) {
+                ch->setEffectChainLatencyCallback(nullptr);
+            }
+        }
     }
     stopLoudnessWorker();
     if (g_audioEngineInstance == this) {
@@ -2716,7 +2724,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                     }
                     continue;
                 }
-                uint32_t writePos = edge->writePos;
+                uint32_t writePos = edge->writePos.load(std::memory_order_relaxed);
                 for (uint32_t i = 0; i < numFrames; ++i) {
                     const double sendGainL = route.gainL->next();
                     const double sendGainR = route.gainR->next();
@@ -2730,7 +2738,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                     route.dest[i * 2 + 1] += delayedR * sendGainR;
                     ++writePos;
                 }
-                edge->writePos = writePos;
+                edge->writePos.store(writePos, std::memory_order_release);
             }
         }
 
@@ -3561,7 +3569,7 @@ void AudioEngine::calculateLatencyCompensation() {
             // retired buffer is no longer referenced by any in-flight block.
             slotPtr->retiredBuffer = std::move(slotPtr->ownedBuffer);
             slotPtr->ownedBuffer = std::unique_ptr<float[]>(new float[bufferSamples]());
-            slotPtr->writePos = 0;
+            slotPtr->writePos.store(0, std::memory_order_release);
             // Publish: write pointer first, then mask (acquire-side reads
             // mask via the same critical section).
             slotPtr->bufferPtr.store(slotPtr->ownedBuffer.get(), std::memory_order_release);
@@ -3700,7 +3708,7 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
                 ? 0u
                 : (s.capacityMask + 1u);
         s.bufferBytes = static_cast<size_t>(capFrames) * 2u * sizeof(float);
-        s.writePos = slotPtr->writePos;
+        s.writePos = slotPtr->writePos.load(std::memory_order_acquire);
         return s;
     };
 
@@ -3708,14 +3716,14 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
     // Overlay writePos from goldenState (m_trackState) if available, since the
     // RT thread only updates writePos on the m_trackState-owned EdgeDelayState.
     if (goldenState && goldenState->mainOutEdgeDelay) {
-        snap.mainOutEdgeDelay.writePos = goldenState->mainOutEdgeDelay->writePos;
+        snap.mainOutEdgeDelay.writePos = goldenState->mainOutEdgeDelay->writePos.load(std::memory_order_acquire);
     }
 
     snap.sendEdgeDelays.reserve(state.sendEdgeDelays.size());
     for (size_t i = 0; i < state.sendEdgeDelays.size(); ++i) {
         auto s = fillSlot(state.sendEdgeDelays[i]);
         if (goldenState && i < goldenState->sendEdgeDelays.size() && goldenState->sendEdgeDelays[i]) {
-            s.writePos = goldenState->sendEdgeDelays[i]->writePos;
+            s.writePos = goldenState->sendEdgeDelays[i]->writePos.load(std::memory_order_acquire);
         }
         snap.sendEdgeDelays.push_back(s);
     }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3484,6 +3484,14 @@ void AudioEngine::calculateLatencyCompensation() {
         rtStates.resize(trackCount);
     }
 
+    // Also write to m_trackState (the "golden" state that renderGraph() reads
+    // via ensureTrackState()), not just the double-buffered m_graphStates slot.
+    // renderGraph() reads PDC state from m_trackState, so without this mirror
+    // the compensation values written below would be invisible on the RT path.
+    if (m_trackState.size() < trackCount) {
+        m_trackState.resize(trackCount);
+    }
+
     for (size_t n = 0; n < topology.nodes.size(); ++n) {
         const size_t trackIdx = nodeTrackIdx[n];
         if (trackIdx >= rtStates.size())
@@ -3494,6 +3502,14 @@ void AudioEngine::calculateLatencyCompensation() {
         const uint32_t prevDelay = rtState.compensationDelaySamples;
         rtState.pluginLatencySamples = sol.intrinsicLatency;
         rtState.compensationDelaySamples = sol.outputCompensationSamples;
+
+        // Mirror to m_trackState so renderGraph() (which reads through
+        // ensureTrackState() -> m_trackState) observes the same values.
+        if (trackIdx < m_trackState.size()) {
+            auto& goldenState = m_trackState[trackIdx];
+            goldenState.pluginLatencySamples = sol.intrinsicLatency;
+            goldenState.compensationDelaySamples = sol.outputCompensationSamples;
+        }
 
         // v1 parity: reset the ring buffer when the delay changes. P6 (G3 smooth
         // recompute) will replace this with a sample-hold / crossfade migration.
@@ -3559,48 +3575,61 @@ void AudioEngine::calculateLatencyCompensation() {
     const uint32_t maxBlock = m_maxBufferFrames.load(std::memory_order_relaxed);
     const uint32_t kEdgeHeadroomSamples = maxBlock > 0 ? maxBlock : 1024;
 
-    for (size_t i = 0; i < trackCount && i < rtStates.size(); ++i) {
-        auto& state = rtStates[i];
-        const auto& bookkeeping = trackEdgeIndices[i];
+    // P4b.2/P4b.3: Per-edge compensation must be allocated in m_trackState because
+    // renderGraph() reads edge delays from ensureTrackState() -> m_trackState, not
+    // from the double-buffered m_graphStates. The m_graphStates[activeIdx] copy
+    // intentionally does NOT own separate EdgeDelayState objects — they contain a
+    // non-atomic writePos that the RT thread updates each block, and duplicating
+    // them would cause both the writePos divergence and the ownership/teardown race.
+    //
+    // getTrackEdgeDelaySnapshot() reads from m_graphStates for diagnostic tooling;
+    // it returns the scalar atomic values that are correct in either copy.
+    auto applyEdgeDelays = [&](std::vector<TrackRTState>& target) {
+        for (size_t i = 0; i < trackCount && i < target.size(); ++i) {
+            auto& state = target[i];
+            const auto& bookkeeping = trackEdgeIndices[i];
 
-        // mainOutputId edge -> mainOutEdgeDelay slot.
-        if (bookkeeping.mainOutEdgeIdx != static_cast<size_t>(-1) &&
-            bookkeeping.mainOutEdgeIdx < topology.edges.size()) {
-            const auto& edgeSol = topology.edges[bookkeeping.mainOutEdgeIdx];
-            ensureEdgeCapacity(state.mainOutEdgeDelay, edgeSol.compensationSamples, kEdgeHeadroomSamples);
-        } else {
-            ensureEdgeCapacity(state.mainOutEdgeDelay, 0, kEdgeHeadroomSamples);
-        }
+            if (bookkeeping.mainOutEdgeIdx != static_cast<size_t>(-1) &&
+                bookkeeping.mainOutEdgeIdx < topology.edges.size()) {
+                const auto& edgeSol = topology.edges[bookkeeping.mainOutEdgeIdx];
+                ensureEdgeCapacity(state.mainOutEdgeDelay, edgeSol.compensationSamples, kEdgeHeadroomSamples);
+            } else {
+                ensureEdgeCapacity(state.mainOutEdgeDelay, 0, kEdgeHeadroomSamples);
+            }
 
-        // Sends -> sendEdgeDelays[slot].
-        // Grow the per-track vector if a send slot beyond current size is targeted.
-        size_t maxSendSlot = 0;
-        bool anySendSlot = false;
-        for (const auto& pair : bookkeeping.sendEdgeBySlot) {
-            if (!anySendSlot || pair.first > maxSendSlot)
-                maxSendSlot = pair.first;
-            anySendSlot = true;
-        }
-        if (anySendSlot && state.sendEdgeDelays.size() <= maxSendSlot) {
-            state.sendEdgeDelays.resize(maxSendSlot + 1);
-        }
-        // Zero out comp on any slots not touched this generation (e.g., sends removed).
-        for (auto& slotPtr : state.sendEdgeDelays) {
-            if (slotPtr) {
-                slotPtr->compensationSamples.store(0, std::memory_order_release);
+            size_t maxSendSlot = 0;
+            bool anySendSlot = false;
+            for (const auto& pair : bookkeeping.sendEdgeBySlot) {
+                if (!anySendSlot || pair.first > maxSendSlot)
+                    maxSendSlot = pair.first;
+                anySendSlot = true;
+            }
+            if (anySendSlot && state.sendEdgeDelays.size() <= maxSendSlot) {
+                state.sendEdgeDelays.resize(maxSendSlot + 1);
+            }
+            for (auto& slotPtr : state.sendEdgeDelays) {
+                if (slotPtr) {
+                    slotPtr->compensationSamples.store(0, std::memory_order_release);
+                }
+            }
+            for (const auto& pair : bookkeeping.sendEdgeBySlot) {
+                const size_t sendSlot = pair.first;
+                const size_t edgeIdx = pair.second;
+                if (sendSlot >= state.sendEdgeDelays.size())
+                    continue;
+                if (edgeIdx >= topology.edges.size())
+                    continue;
+                const auto& edgeSol = topology.edges[edgeIdx];
+                ensureEdgeCapacity(state.sendEdgeDelays[sendSlot], edgeSol.compensationSamples, kEdgeHeadroomSamples);
             }
         }
-        for (const auto& pair : bookkeeping.sendEdgeBySlot) {
-            const size_t sendSlot = pair.first;
-            const size_t edgeIdx = pair.second;
-            if (sendSlot >= state.sendEdgeDelays.size())
-                continue;
-            if (edgeIdx >= topology.edges.size())
-                continue;
-            const auto& edgeSol = topology.edges[edgeIdx];
-            ensureEdgeCapacity(state.sendEdgeDelays[sendSlot], edgeSol.compensationSamples, kEdgeHeadroomSamples);
-        }
+    };
+    // Apply to m_trackState (RT render path reads from here via ensureTrackState()).
+    if (m_trackState.size() >= trackCount) {
+        applyEdgeDelays(m_trackState);
     }
+    // Apply to m_graphStates[activeIdx] (getTrackEdgeDelaySnapshot reads from here).
+    applyEdgeDelays(rtStates);
 
     // 4. Update RT-side graph state metadata (v1 contract preserved).
     m_graphStates[activeIdx].maxProjectLatencySamples = topology.projectAlignmentLatency;
@@ -3641,15 +3670,26 @@ SolvedLatencyTopology AudioEngine::getLastSolvedLatencyTopology() const {
 
 AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_t trackIndex) const {
     TrackEdgeDelaySnapshot snap;
+
+    // Read ring-buffer sizing from m_graphStates (off-RT mirror) and
+    // per-block writePos from m_trackState (canonical RT writer side).
     const int activeIdx = m_activeRenderTrackIndex.load(std::memory_order_acquire);
     const auto& rtStates = m_graphStates[activeIdx].trackStates;
     if (trackIndex >= rtStates.size()) {
-        return snap; // valid = false
+        return snap;
     }
     const auto& state = rtStates[trackIndex];
     snap.valid = true;
 
-    auto fillSlot = [](const std::unique_ptr<EdgeDelayState>& slotPtr) {
+    // writePos is updated on m_trackState by the RT thread each block.
+    // m_graphStates edge delays do not have double-buffered EdgeDelayState
+    // objects (see step 4 notes); their writePos is stale, so we overlay
+    // from m_trackState when available.
+    const auto* goldenState =
+        (trackIndex < m_trackState.size()) ? &m_trackState[trackIndex] : nullptr;
+
+    // Overlay writePos from m_trackState where the RT thread updates it.
+    auto fillSlot = [](const std::unique_ptr<EdgeDelayState>& slotPtr) -> TrackEdgeDelaySnapshot::EdgeSlotSnapshot {
         TrackEdgeDelaySnapshot::EdgeSlotSnapshot s;
         if (!slotPtr)
             return s;
@@ -3665,9 +3705,19 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
     };
 
     snap.mainOutEdgeDelay = fillSlot(state.mainOutEdgeDelay);
+    // Overlay writePos from goldenState (m_trackState) if available, since the
+    // RT thread only updates writePos on the m_trackState-owned EdgeDelayState.
+    if (goldenState && goldenState->mainOutEdgeDelay) {
+        snap.mainOutEdgeDelay.writePos = goldenState->mainOutEdgeDelay->writePos;
+    }
+
     snap.sendEdgeDelays.reserve(state.sendEdgeDelays.size());
-    for (const auto& slot : state.sendEdgeDelays) {
-        snap.sendEdgeDelays.push_back(fillSlot(slot));
+    for (size_t i = 0; i < state.sendEdgeDelays.size(); ++i) {
+        auto s = fillSlot(state.sendEdgeDelays[i]);
+        if (goldenState && i < goldenState->sendEdgeDelays.size() && goldenState->sendEdgeDelays[i]) {
+            s.writePos = goldenState->sendEdgeDelays[i]->writePos;
+        }
+        snap.sendEdgeDelays.push_back(s);
     }
     return snap;
 }

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -99,8 +99,6 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->elapsedSeconds = 0.0;
     voice->fadeInPos = 0.0;
     voice->fadeOutPos = 0.0;
-    voice->fadeInPos = 0.0;
-    voice->fadeOutPos = 0.0;
     voice->stopRequested.store(false, std::memory_order_release);
     voice->seekRequestSeconds.store(-1.0, std::memory_order_release);
     voice->fadeOutActive = false;
@@ -208,7 +206,6 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     voice->phaseFrames = 0.0;
     voice->elapsedSeconds = 0.0;
     voice->fadeInPos = 0.0;
-    voice->fadeOutPos = 0.0;
     voice->fadeOutPos = 0.0;
     voice->stopRequested.store(false, std::memory_order_release);
     voice->seekRequestSeconds.store(-1.0, std::memory_order_release);

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -1,7 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "PreviewEngine.h"
 
-#include "RealtimeThreadGuard.h"
 #include "AestraLog.h"
 #include "FastMath.h"
 #include "MiniAudioDecoder.h"
@@ -93,7 +92,8 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->durationSeconds =
         (sampleRate > 0 && buffer->numFrames > 0) ? (static_cast<double>(buffer->numFrames) / sampleRate) : 0.0;
     voice->maxPlaySeconds = maxSeconds;
-    const float totalGain = dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
+    const float totalGain =
+        dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
     voice->gain = totalGain;
     voice->phaseFrames = 0.0;
     voice->elapsedSeconds = 0.0;
@@ -202,7 +202,8 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     // Cache miss: Create voice immediately for pending playback
     auto voice = std::make_shared<PreviewVoice>();
     voice->path = path;
-    voice->gain = dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
+    voice->gain =
+        dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
     voice->maxPlaySeconds = maxSeconds;
     voice->phaseFrames = 0.0;
     voice->elapsedSeconds = 0.0;
@@ -241,12 +242,13 @@ void PreviewEngine::setOutputSampleRate(double sr) {
 }
 
 void PreviewEngine::process(float* interleavedOutput, uint32_t numFrames) {
-    // WARNING: This function acquires a mutex and is NOT RT-safe.
-    // Must not be called from the audio callback thread.
-    // If wired into a new audio path, first refactor to remove the
-    // mutex in the completion handler below.
-    reportRealtimeMisuse("PreviewEngine::process");
+    processRealtime(interleavedOutput, numFrames, 2);
+}
 
+void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames, uint32_t outputChannels) {
+    if (outputChannels == 0) {
+        return;
+    }
     auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
     if (!voice || !voice->playing.load(std::memory_order_acquire) || !interleavedOutput) {
         return;
@@ -346,7 +348,7 @@ void PreviewEngine::process(float* interleavedOutput, uint32_t numFrames) {
     bool isFading = (voice->fadeInPos < fadeInSamples) || (voice->stopRequested.load(std::memory_order_relaxed)) ||
                     voice->fadeOutActive;
 
-    if (!isFading && safeLimit > 0) {
+    if (outputChannels == 2 && !isFading && safeLimit > 0) {
         for (; i + 4 <= numFrames; i += 4) {
             if (static_cast<uint64_t>(phase + ratio * 4.0) >= safeLimit) {
                 break;
@@ -446,7 +448,8 @@ void PreviewEngine::process(float* interleavedOutput, uint32_t numFrames) {
                 __m128 vOver = _mm_sub_ps(vAbs, vThreshold);
                 __m128 vSaturated = _mm_add_ps(vThreshold, _mm_div_ps(vOver, _mm_add_ps(vOne, vOver)));
                 __m128 vResult = _mm_or_ps(vSign, vSaturated); // apply sign
-                return _mm_or_ps(_mm_and_ps(vMask, vResult), _mm_andnot_ps(vMask, x)); // blend: limit where hot, pass-through where clean
+                return _mm_or_ps(_mm_and_ps(vMask, vResult),
+                                 _mm_andnot_ps(vMask, x)); // blend: limit where hot, pass-through where clean
             };
 
             vDestLo = simdSoftLimit(vDestLo);
@@ -534,19 +537,25 @@ void PreviewEngine::process(float* interleavedOutput, uint32_t numFrames) {
 
         // Soft limiter: transparent below threshold, saturates only excess
         // Preserves preview accuracy — signal sounds like itself until it clips
-        float rawL = interleavedOutput[i * 2] + outL * currentGain;
-        float rawR = interleavedOutput[i * 2 + 1] + outR * currentGain;
-
         auto softLimit = [](float x, float threshold) -> float {
             float abs_x = std::abs(x);
-            if (abs_x <= threshold) return x; // clean pass-through
+            if (abs_x <= threshold)
+                return x; // clean pass-through
             float sign = x > 0.0f ? 1.0f : -1.0f;
             float over = abs_x - threshold;
             return sign * (threshold + over / (1.0f + over)); // only saturates excess
         };
 
-        interleavedOutput[i * 2] = softLimit(rawL, 0.85f);
-        interleavedOutput[i * 2 + 1] = softLimit(rawR, 0.85f);
+        const size_t frameBase = static_cast<size_t>(i) * outputChannels;
+        if (outputChannels == 1) {
+            const float previewMono = (outL + outR) * 0.5f * currentGain;
+            interleavedOutput[frameBase] = softLimit(interleavedOutput[frameBase] + previewMono, 0.85f);
+        } else {
+            const float rawL = interleavedOutput[frameBase] + outL * currentGain;
+            const float rawR = interleavedOutput[frameBase + 1] + outR * currentGain;
+            interleavedOutput[frameBase] = softLimit(rawL, 0.85f);
+            interleavedOutput[frameBase + 1] = softLimit(rawR, 0.85f);
+        }
 
         phase += ratio;
     }
@@ -561,15 +570,10 @@ void PreviewEngine::process(float* interleavedOutput, uint32_t numFrames) {
     bool finished = voice->fadeOutActive && (voice->fadeOutPos >= fadeOutSamples);
     if (finished) {
         voice->playing.store(false, std::memory_order_release);
-        {
-            std::lock_guard<std::mutex> lock(m_completedPathMutex);
-            m_completedPathStr = voice->path;
-        }
+        PreviewVoice* expected = nullptr;
+        m_completedVoice.compare_exchange_strong(expected, voice.get(), std::memory_order_acq_rel,
+                                                 std::memory_order_relaxed);
         m_completionPending.store(true, std::memory_order_release);
-        // Clear only if still the active voice
-        std::shared_ptr<PreviewVoice> expected = voice;
-        std::atomic_compare_exchange_strong_explicit(&m_activeVoice, &expected, std::shared_ptr<PreviewVoice>(),
-                                                     std::memory_order_acq_rel, std::memory_order_relaxed);
     }
 }
 
@@ -614,12 +618,24 @@ double PreviewEngine::getDuration() const {
 
 void PreviewEngine::handleDeferredCompletion() {
     if (m_completionPending.exchange(false, std::memory_order_acq_rel)) {
+        PreviewVoice* completed = m_completedVoice.exchange(nullptr, std::memory_order_acq_rel);
+        auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+        if (!completed || !voice || voice.get() != completed) {
+            return;
+        }
+
         std::string path;
         {
             std::lock_guard<std::mutex> lock(m_completedPathMutex);
+            m_completedPathStr = voice->path;
             path = m_completedPathStr;
         }
-        if (m_onComplete) {
+
+        std::shared_ptr<PreviewVoice> expected = voice;
+        std::atomic_compare_exchange_strong_explicit(&m_activeVoice, &expected, std::shared_ptr<PreviewVoice>(),
+                                                     std::memory_order_acq_rel, std::memory_order_relaxed);
+
+        if (!path.empty() && m_onComplete) {
             m_onComplete(path);
         }
     }

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -568,9 +568,13 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
     if (finished) {
         voice->playing.store(false, std::memory_order_release);
         PreviewVoice* expected = nullptr;
-        m_completedVoice.compare_exchange_strong(expected, voice.get(), std::memory_order_acq_rel,
-                                                 std::memory_order_relaxed);
-        m_completionPending.store(true, std::memory_order_release);
+        if (m_completedVoice.compare_exchange_strong(expected, voice.get(), std::memory_order_acq_rel,
+                                                     std::memory_order_relaxed)) {
+            m_completionPending.store(true, std::memory_order_release);
+        }
+        // If CAS failed, another completion is already pending —
+        // handleDeferredCompletion() will fire for that voice; this voice's
+        // completion is close enough in time to share the same callback path.
     }
 }
 

--- a/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
+++ b/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
@@ -54,9 +54,12 @@ std::string hexEncodeBytes(const void* data, size_t size) {
 }
 
 int hexValue(char c) {
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return 10 + c - 'a';
-    if (c >= 'A' && c <= 'F') return 10 + c - 'A';
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return 10 + c - 'a';
+    if (c >= 'A' && c <= 'F')
+        return 10 + c - 'A';
     return -1;
 }
 
@@ -398,10 +401,6 @@ void OutOfProcessPluginInstance::process(const float* const* inputs, float** out
         midiOutput->clear();
     }
 
-    if (!m_process || !m_process->isRunning()) {
-        markCrashed();
-    }
-
     if (m_crashed.load(std::memory_order_acquire) || m_maxBlockSize == 0 || numFrames > m_maxBlockSize) {
         passThrough(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
         return;
@@ -447,8 +446,7 @@ void OutOfProcessPluginInstance::process(const float* const* inputs, float** out
                 if (event.size != 3 || midiBytes + 8 > m_pendingMidiData.size()) {
                     continue;
                 }
-                const uint32_t sampleOffset =
-                    std::min<uint32_t>(event.sampleOffset, numFrames > 0 ? numFrames - 1 : 0);
+                const uint32_t sampleOffset = std::min<uint32_t>(event.sampleOffset, numFrames > 0 ? numFrames - 1 : 0);
                 std::memcpy(m_pendingMidiData.data() + midiBytes, &sampleOffset, sizeof(sampleOffset));
                 m_pendingMidiData[midiBytes + 4] = event.size;
                 std::memcpy(m_pendingMidiData.data() + midiBytes + 5, event.data, 3);
@@ -532,7 +530,7 @@ void OutOfProcessPluginInstance::resetWatchdog() {
 }
 
 bool OutOfProcessPluginInstance::sendCommand(const std::string& command, std::string* response,
-                                                 std::chrono::milliseconds timeout) {
+                                             std::chrono::milliseconds timeout) {
     std::lock_guard<std::mutex> lock(m_ipcMutex);
     if (!m_process || !m_process->isRunning()) {
         return false;

--- a/AestraCore/include/AestraConfig.h
+++ b/AestraCore/include/AestraConfig.h
@@ -214,6 +214,12 @@ constexpr float SILENCE_THRESHOLD = -96.0f; // dB
 // Array size
 #define AESTRA_ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+// Document intentional allocation that outlives normal scope.
+// Use alongside LSAN suppressions so the connection between
+// code and suppression is auditable. Compiles to nothing.
+// Usage: AESTRA_LEAK_INTENTIONAL("AudioEngine global graph pool")
+#define AESTRA_LEAK_INTENTIONAL(reason) static_cast<void>(reason)
+
 // =============================================================================
 // Version Information
 // =============================================================================

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -48,6 +48,22 @@
       }
     },
     {
+      "name": "ci-tsan",
+      "displayName": "CI ThreadSanitizer headless tests (advisory)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "AESTRA_CI": "ON",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
       "name": "full",
       "displayName": "Full app (UI + tests default)",
       "inherits": "base",
@@ -109,6 +125,13 @@
       "name": "ci-asan",
       "displayName": "Build CI sanitizer tests",
       "configurePreset": "ci-asan",
+      "configuration": "Debug",
+      "jobs": 0
+    },
+    {
+      "name": "ci-tsan",
+      "displayName": "Build CI ThreadSanitizer tests",
+      "configurePreset": "ci-tsan",
       "configuration": "Debug",
       "jobs": 0
     },

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -430,7 +430,7 @@ int AestraAudioController::audioCallback(float* outputBuffer, const float* input
     // Preview mixing - reuse the same content snapshot
     if (content) {
         if (auto* previewEngine = content->getPreviewEngine()) {
-            previewEngine->process(outputBuffer, nFrames);
+            previewEngine->processRealtime(outputBuffer, nFrames, controller->m_streamConfig.numOutputChannels);
         }
     }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2802,6 +2802,10 @@ void AestraContent::setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) {
 }
 
 void AestraContent::setAudioEngine(Aestra::Audio::AudioEngine* engine) {
+    // Detach preview from old engine before overwriting m_audioEngine
+    if (m_audioEngine && m_previewEngine) {
+        m_audioEngine->setPreviewEngine(nullptr);
+    }
     m_audioEngine = engine;
     Aestra::Audio::CommandRegistry::setAudioEngine(engine);
     if (m_audioEngine && m_previewEngine) {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -75,6 +75,10 @@ constexpr float kResizeHitWidth = 6.0f;
 // =============================================================================
 
 AestraContent::~AestraContent() {
+    if (m_audioEngine) {
+        m_audioEngine->setPreviewEngine(nullptr);
+    }
+
     // TrackManager may be shared outside this component; clear the stored owner callback before member teardown.
     if (m_trackManager) {
         m_trackManager->setStopPreviewCallback(nullptr);
@@ -1080,6 +1084,9 @@ AestraContent::AestraContent() {
 
     // Initialize preview engine
     m_previewEngine = std::make_unique<PreviewEngine>();
+    if (m_audioEngine) {
+        m_audioEngine->setPreviewEngine(m_previewEngine.get());
+    }
     m_previewIsPlaying = false;
     m_previewDuration = 8.0;
 
@@ -2797,6 +2804,9 @@ void AestraContent::setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) {
 void AestraContent::setAudioEngine(Aestra::Audio::AudioEngine* engine) {
     m_audioEngine = engine;
     Aestra::Audio::CommandRegistry::setAudioEngine(engine);
+    if (m_audioEngine && m_previewEngine) {
+        m_audioEngine->setPreviewEngine(m_previewEngine.get());
+    }
     if (m_pianoRollPanel) {
         m_pianoRollPanel->setAudioEngine(m_audioEngine);
     }

--- a/Source/Core/TakeManager.h
+++ b/Source/Core/TakeManager.h
@@ -5,49 +5,88 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Manages project take snapshots — versioned copies of a project state.
+ *
+ * Each take is a self-contained snapshot stored under a takes/ directory
+ * alongside the project file. A manifest tracks which take is active and
+ * provides lookup by ID.
+ */
 class TakeManager {
 public:
+    /** @brief Metadata for a single take snapshot. */
     struct TakeEntry {
-        std::string id;
-        std::string name;
-        std::string parentId;
-        std::string snapshotPath;
-        uint64_t createdAtMs{0};
-        uint64_t updatedAtMs{0};
-        bool active{false};
+        std::string id;           ///< Unique take identifier.
+        std::string name;         ///< Human-readable take name.
+        std::string parentId;     ///< Parent take ID (empty for top-level).
+        std::string snapshotPath; ///< Relative path to the snapshot file.
+        uint64_t createdAtMs{0};  ///< Creation timestamp (epoch ms).
+        uint64_t updatedAtMs{0};  ///< Last-modified timestamp (epoch ms).
+        bool active{false};       ///< True if this is the currently active take.
     };
 
+    /** @brief The on-disk manifest listing all takes and the active selection. */
     struct Manifest {
-        bool ok{false};
-        std::string errorMessage;
-        std::string projectPath;
-        std::string activeTakeId;
-        std::vector<TakeEntry> takes;
+        bool ok{false};                  ///< True if the manifest loaded successfully.
+        std::string errorMessage;        ///< Error description when ok is false.
+        std::string projectPath;         ///< Absolute path to the project directory.
+        std::string activeTakeId;        ///< ID of the currently active take.
+        std::vector<TakeEntry> takes;    ///< All takes in this project.
 
+        /** @brief Look up a take by its unique ID. Returns nullptr if not found. */
         const TakeEntry* findTake(const std::string& id) const;
+        /** @brief Returns the currently active take, or nullptr if none. */
         const TakeEntry* activeTake() const;
     };
 
+    /** @brief Result of a take operation — carries the affected take and manifest. */
     struct Result {
-        bool ok{false};
-        std::string errorMessage;
-        TakeEntry take;
-        Manifest manifest;
+        bool ok{false};            ///< True if the operation succeeded.
+        std::string errorMessage;  ///< Error description when ok is false.
+        TakeEntry take;            ///< The take that was created/modified.
+        Manifest manifest;         ///< The manifest state after the operation.
     };
 
+    /** @brief Returns the takes/ directory path for a given project. */
     static std::string getTakesDirectory(const std::string& projectPath);
+    /** @brief Returns the manifest.json path for a given project. */
     static std::string getManifestPath(const std::string& projectPath);
+    /** @brief Returns the full snapshot file path for a specific take. */
     static std::string resolveSnapshotPath(const std::string& projectPath, const TakeEntry& take);
 
+    /** @brief Loads the manifest from disk. Returns ok=false if missing or corrupt. */
     static Manifest loadManifest(const std::string& projectPath);
 
+    /**
+     * @brief Ensures a manifest exists, creating one with an initial take if needed.
+     * @param projectPath          Path to the project directory.
+     * @param currentProjectContents Serialized project data for the initial snapshot.
+     * @param initialTakeName      Name for the auto-created take (default "Main").
+     */
     static Result ensureManifest(const std::string& projectPath, const std::string& currentProjectContents,
                                  const std::string& initialTakeName = "Main");
 
+    /**
+     * @brief Overwrites the active take's snapshot with the current project state.
+     * @param projectPath              Path to the project directory.
+     * @param currentProjectContents   Serialized project data to save.
+     */
     static Result saveActiveTake(const std::string& projectPath, const std::string& currentProjectContents);
 
+    /**
+     * @brief Creates a new take snapshot.
+     * @param projectPath              Path to the project directory.
+     * @param currentProjectContents   Serialized project data for the snapshot.
+     * @param name                     Human-readable take name.
+     * @param parentId                 Parent take ID (empty for top-level).
+     */
     static Result createTake(const std::string& projectPath, const std::string& currentProjectContents,
                              const std::string& name, const std::string& parentId = "");
 
+    /**
+     * @brief Switches the active take. Does not load the snapshot — caller must do that.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to activate.
+     */
     static Result setActiveTake(const std::string& projectPath, const std::string& takeId);
 };

--- a/Tests/AestraAudio/AudioEngineOutputChannelTest.cpp
+++ b/Tests/AestraAudio/AudioEngineOutputChannelTest.cpp
@@ -1,0 +1,65 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Core/AudioEngine.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+void testMonoOutputDoesNotWriteStereoStride() {
+    constexpr uint32_t kFrames = 128;
+    constexpr float kSentinel = 12345.0f;
+
+    AudioEngine engine;
+    engine.setSampleRate(48000);
+    engine.setBufferConfig(kFrames, 1);
+    engine.setTestToneEnabled(true);
+
+    std::vector<float> output(kFrames * 2, kSentinel);
+    assert(engine.processBlock(output.data(), nullptr, kFrames, 0.0) == 0);
+
+    for (uint32_t frame = 0; frame < kFrames; ++frame) {
+        assert(std::isfinite(output[frame]));
+    }
+    for (size_t i = kFrames; i < output.size(); ++i) {
+        assert(output[i] == kSentinel);
+    }
+
+    std::printf("[PASS] mono output uses mono stride without guard overwrite\n");
+}
+
+void testExtraOutputChannelsAreCleared() {
+    constexpr uint32_t kFrames = 64;
+    constexpr uint32_t kChannels = 4;
+
+    AudioEngine engine;
+    engine.setSampleRate(48000);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setTestToneEnabled(true);
+
+    std::vector<float> output(static_cast<size_t>(kFrames) * kChannels, 1.0f);
+    assert(engine.processBlock(output.data(), nullptr, kFrames, 0.0) == 0);
+
+    for (uint32_t frame = 0; frame < kFrames; ++frame) {
+        const size_t base = static_cast<size_t>(frame) * kChannels;
+        assert(std::isfinite(output[base]));
+        assert(std::isfinite(output[base + 1]));
+        assert(output[base + 2] == 0.0f);
+        assert(output[base + 3] == 0.0f);
+    }
+
+    std::printf("[PASS] extra output channels are cleared\n");
+}
+
+} // namespace
+
+int main() {
+    testMonoOutputDoesNotWriteStereoStride();
+    testExtraOutputChannelsAreCleared();
+    return 0;
+}

--- a/Tests/AestraAudio/RealtimePathStressTest.cpp
+++ b/Tests/AestraAudio/RealtimePathStressTest.cpp
@@ -156,7 +156,7 @@ int main() {
         const auto start = std::chrono::steady_clock::now();
         engine.processBlock(engineOut.data(), nullptr, kFrames, 0.0);
         tracks.mixInputMonitoring(input.data(), monitorOut.data(), kFrames, kChannels);
-        preview.process(engineOut.data(), kFrames);
+        preview.processRealtime(engineOut.data(), kFrames, kChannels);
         sampler.process(nullptr, samplerOutputs, 0, 2, kFrames, block == 0 ? &midi : nullptr, nullptr);
         const auto elapsed = std::chrono::steady_clock::now() - start;
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -631,6 +631,16 @@ target_include_directories(AestraAudioQualityRegressionTest PRIVATE
 add_test(NAME AestraAudioQualityRegressionTest COMMAND AestraAudioQualityRegressionTest)
 set_tests_properties(AestraAudioQualityRegressionTest PROPERTIES LABELS "audio;quality;regression")
 
+# AudioEngine output channel safety regression test
+add_executable(AestraAudioEngineOutputChannelTest AestraAudio/AudioEngineOutputChannelTest.cpp)
+target_link_libraries(AestraAudioEngineOutputChannelTest PRIVATE AestraAudioCore)
+target_include_directories(AestraAudioEngineOutputChannelTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraAudioEngineOutputChannelTest COMMAND AestraAudioEngineOutputChannelTest)
+set_tests_properties(AestraAudioEngineOutputChannelTest PROPERTIES LABELS "audio;rt-safety;regression")
+
 # Watchdog Test (requires VST3 SDK headers)
 if(EXISTS "${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces/vst/ivstaudioprocessor.h")
     add_executable(AestraWatchdogTest AestraAudio/WatchdogTest.cpp)


### PR DESCRIPTION
## Summary

Four surgical commits toward verified 98% callback-safety:

### Commit 1 — Triple-buffer EngineState + RT-safe preview + mono/multichannel output + PDC to dry tracks
- Triple-buffer EngineState with GraphReadHandle protecting RT graph access
- processRealtime() preview path in engine (adaptive FPS preview safe)
- Mono/multichannel output safety in processBlock()
- PDC compensation on dry tracks
- OPP liveness polling removed from RT path

### Commit 2 — Immutable RT routing snapshot for input capture
- RecordingCaptureRoute double-buffered snapshot in TrackManager
- publishRecordingCaptureSnapshot() called after beginCaptureSession()
- processInput() reads snapshot instead of live m_channels/m_recordingCaptures

### Commit 3 — PDC edge state ownership fix
- calculateLatencyCompensation() allocates per-edge EdgeDelayState on m_trackState (where RT path reads)
- getTrackEdgeDelaySnapshot() overlays writePos from canonical m_trackState objects
- Fixes non-atomic writePos divergence and pointer-replacement race between m_trackState and m_graphStates

### Commit 4 — TSan build preset + advisory CI job
- ci-tsan CMake preset (-fsanitize=thread)
- Advisory tsan-linux CI job (continue-on-error: true)

## Testing
- Full test suite: 106/106 pass (1 expected skip: SecAccountEndToEndSmoke)
- Key tests verified: AestraAudioEngineOutputChannelTest, RecordingPathTest, LatencyCompensationTest, all PDC tests
- Existing ASan/UBSan CI job unchanged

## Risk Notes
- Runtime audio-device validation remains out of scope for this PR (requires hardware + AESTRA_ENABLE_RUNTIME_TESTS)
- m_inputCallback in AudioEngine is still raw std::atomic<InputCallback> with no snapshot — not addressed
- m_rtContent atomic shared_ptr load may be non-lock-free on some platforms — not addressed
- TSAN CI job is advisory (continue-on-error) — real races will be surfaced but wont block PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Breaking changes
  - No API removals, but new public symbols require docs before merge: EngineState::GraphReadHandle / activeGraphRead(), PreviewEngine::processRealtime(), TrackManager::publishRecordingCaptureSnapshot(), and RecordingCaptureRoute.

- What changed and why
  - Triple-buffered graph handoff
    - Replaced 2-slot graph with 3-slot storage and added EngineState::GraphReadHandle (move-only RAII) and activeGraphRead() to pin graphs for realtime readers.
    - swapGraph()/mutableInactiveGraph() now wait for reader counters, preventing realtime use-after-free and non-atomic handoff races.

  - Immutable realtime routing snapshot for input capture
    - TrackManager gains a double-buffered RecordingCaptureRoute snapshot and publishRecordingCaptureSnapshot().
    - processInput() consumes the published immutable snapshot (and uses an RAII writer counter), eliminating races between live UI modifications and RT input capture.

  - PDC / edge-state ownership and concurrency fixes
    - EdgeDelayState::writePos is atomic; per-edge EdgeDelayState objects are allocated on the canonical m_trackState and mirrored into graph states.
    - calculateLatencyCompensation() and getTrackEdgeDelaySnapshot() were adjusted to overlay canonical writePos to avoid pointer-replacement races and non-atomic writePos divergence.

  - Realtime-safe preview and correct channel handling
    - Added PreviewEngine::processRealtime(interleavedOutput, numFrames, outputChannels), updated call sites, and added mono-downmix path and stereo-guarded SIMD handling.
    - processBlock()/render code uses kInternalRenderChannels / numOutputChannels to correctly handle mono vs multichannel output; tests verify no stride corruption and extra-channel clearing.

  - RT-path cleanup and other safety hardening
    - Removed liveness polling from realtime path for OOP plugin instances; OutOfProcessPluginInstance now reports latency as m_maxBlockSize.
    - Preview voice completion uses atomic CAS and deferred completion handling to be RT-safe.
    - SmoothedParamD::snap() sanitizes NaNs/Infs; other small CAS/gating and snapshot-sanitization fixes applied.

  - CI and tooling
    - Added ci-tsan CMake preset (-fsanitize=thread) and a GitHub Actions tsan-linux job run as advisory (continue-on-error) to surface thread races without blocking merges.
    - New test: AestraAudioEngineOutputChannelTest; stress test updated to use processRealtime. Full test suite reported passing (106/106, 1 expected skip); ASan/UBSan unchanged.

- Testing and risks
  - Key tests validated: output-channel behavior, recording path, latency compensation/PDC tests.
  - Remaining risks: runtime audio-device validation out of scope; m_inputCallback remains a raw std::atomic without snapshot; m_rtContent atomic shared_ptr loads may be non-lock-free on some platforms; TSAN job is advisory and will not block merges.
  - Actionable merge blocker: Doxygen/docstring coverage must be restored for newly public entities (GraphReadHandle, activeGraphRead(), processRealtime(), publishRecordingCaptureSnapshot(), RecordingCaptureRoute) to meet project doc coverage threshold.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->