### PR TITLE
ci: add LeakSanitizer (LSan) advisory CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,3 +312,76 @@ jobs:
           name: ctest-results-asan
           path: build-asan/ctest-results-asan.xml
           if-no-files-found: ignore
+
+  tsan-linux:
+    name: ThreadSanitizer (TSan, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:suppress_equal_stacks=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
+
+      - name: Configure
+        run: cmake --preset ci-tsan
+
+      - name: Build
+        run: cmake --build --preset ci-tsan
+
+      - name: Test
+        working-directory: build/ci-tsan
+        run: ctest --output-on-failure --output-junit ctest-results-tsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
+
+      - name: Upload TSan test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-tsan
+          path: build/ci-tsan/ctest-results-tsan.xml
+          if-no-files-found: ignore
+
+  lsan-linux:
+    # LeakSanitizer CI is an advisory regression detector for
+    # unbounded or accidental allocations. LSan is informational
+    # only; failure is expected to be non-blocking.
+    name: LeakSanitizer (LSan, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      LSAN_OPTIONS: suppressions=.lsan-suppressions:print_suppressions=0:halt_on_error=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
+
+      - name: Configure
+        run: cmake --preset ci-lsan
+
+      - name: Build
+        run: cmake --build --preset ci-lsan
+
+      - name: Test
+        working-directory: build/ci-lsan
+        run: ctest --output-on-failure --output-junit ctest-results-lsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
+
+      - name: Upload LSan test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-results-lsan
+          path: build/ci-lsan/ctest-results-lsan.xml
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,9 @@ jobs:
     name: ThreadSanitizer (TSan, advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      actions: write
     env:
       TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:suppress_equal_stacks=1
     steps:
@@ -355,6 +358,9 @@ jobs:
     name: LeakSanitizer (LSan, advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      actions: write
     env:
       LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan-suppressions:print_suppressions=0:halt_on_error=1
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,9 +317,6 @@ jobs:
     name: ThreadSanitizer (TSan, advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      actions: write
     env:
       TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:suppress_equal_stacks=1
     steps:
@@ -358,9 +355,6 @@ jobs:
     name: LeakSanitizer (LSan, advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      actions: write
     env:
       LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan-suppressions:print_suppressions=0:halt_on_error=1
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
-      LSAN_OPTIONS: suppressions=.lsan-suppressions:print_suppressions=0:halt_on_error=1
+      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan-suppressions:print_suppressions=0:halt_on_error=1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.lsan-suppressions
+++ b/.lsan-suppressions
@@ -1,0 +1,17 @@
+# ---------------------------------------------------------------
+# Aestra LSAN suppression file
+#
+# LeakSanitizer CI is an advisory regression detector for
+# unbounded or accidental allocations. It is NOT a "zero leaks"
+# gate — DAW-style applications intentionally extend the lifetime
+# of audio graphs, plugin graphs, and UI caches.
+#
+# Rules:
+#   - Suppress only after seeing real stack traces in CI
+#   - Add a comment linking to the owning source location
+#   - If the leak is accidental, FIX THE CODE, don't suppress it
+#   - Mark intentional retentions in code with AESTRA_LEAK_INTENTIONAL
+# ---------------------------------------------------------------
+
+# Google Test internal allocations (not our code)
+leak:testing::internal

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1581,6 +1581,8 @@ AudioEngine::~AudioEngine() {
         trackMgr->setChannelPrepareCallback(nullptr);
     }
     stopLoudnessWorker();
+    delete m_unitManagerSnapshot.load(std::memory_order_relaxed);
+    m_unitManagerSnapshot.store(nullptr, std::memory_order_relaxed);
     if (g_audioEngineInstance == this) {
         g_audioEngineInstance = nullptr; // [NEW] Clear singleton
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,22 +93,6 @@
       }
     },
     {
-      "name": "ci-tsan",
-      "displayName": "CI ThreadSanitizer headless tests (advisory)",
-      "inherits": "base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "AESTRA_CI": "ON",
-        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Linux"
-      }
-    },
-    {
       "name": "ci-lsan",
       "displayName": "CI LeakSanitizer headless tests (advisory)",
       "inherits": "base",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,6 +75,39 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF"
       }
+    },
+    {
+      "name": "ci-tsan",
+      "displayName": "CI ThreadSanitizer headless tests (advisory)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "AESTRA_CI": "ON",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "ci-lsan",
+      "displayName": "CI LeakSanitizer headless tests (advisory)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "AESTRA_CI": "ON",
+        "CMAKE_CXX_FLAGS": "-fsanitize=leak -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=leak",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=leak"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
     }
   ],
   "buildPresets": [
@@ -109,6 +142,20 @@
       "name": "ci-asan",
       "displayName": "Build CI sanitizer tests",
       "configurePreset": "ci-asan",
+      "configuration": "Debug",
+      "jobs": 0
+    },
+    {
+      "name": "ci-tsan",
+      "displayName": "Build CI ThreadSanitizer tests",
+      "configurePreset": "ci-tsan",
+      "configuration": "Debug",
+      "jobs": 0
+    },
+    {
+      "name": "ci-lsan",
+      "displayName": "Build CI LeakSanitizer tests",
+      "configurePreset": "ci-lsan",
       "configuration": "Debug",
       "jobs": 0
     },


### PR DESCRIPTION
## Summary
- New `ci-lsan` CMake preset (Debug, `-fsanitize=leak`)
- New `lsan-linux` CI job in `ci.yml` (advisory, `continue-on-error`)
- `.lsan-suppressions` for gtest internal allocations

Complementary to the existing TSan advisory job. LSan catches unbounded or accidental allocations that could degrade RT stability on memory-constrained systems (4GB target).

## Test plan
- [ ] `cmake --preset ci-lsan` configures successfully
- [ ] `cmake --build --preset ci-lsan` compiles (pre-existing missing test file `AudioEngineOutputChannelTest.cpp` is unrelated)
- [ ] CI job runs as advisory (green or yellow, never blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Breaking changes: None.

- What changed
  - CI: Added an advisory LeakSanitizer job `lsan-linux` (continue-on-error) to .github/workflows/ci.yml; it checks out the repo with limited credentials, installs deps, configures/builds with a new CMake preset, runs ctest (JUnit output) with existing sanitizer exclusions, and uploads results as a JUnit artifact.
  - CMake: Added `ci-lsan` configure and build presets (Debug, -fsanitize=leak) in CMakePresets.json to enable LSan builds in CI.
  - Suppressions: Added .lsan-suppressions containing a suppression for Google Test internal allocations and guidance about marking intentional leaks.
  - Code fix: Deleted m_unitManagerSnapshot in AudioEngine::~AudioEngine() to address an LSan-reported leak.
  - CI permissions: Narrowed job permissions for sanitizer jobs (`contents: read`, `actions: write`) and applied least-privilege settings similar to the TSan job.
  - Commit message also references removal of a test file issue unrelated to LSan (pre-existing missing test).

- Why
  - To complement the existing ThreadSanitizer advisory checks by detecting unbounded or accidental memory allocations that could hurt real-time stability on memory-constrained systems (target ~4 GB). The job is advisory so it reports leaks without blocking CI for intentional long-lived allocations common in DAW-style apps.

- Notes / caveats
  - The LSan job is non-blocking (advisory) by design.
  - The suppression file documents a proposed AESTRA_LEAK_INTENTIONAL marker, but that macro was not added in the code changes — only suggested in the suppression file's docs.
  - Tests/build: `cmake --preset ci-lsan` and `cmake --build --preset ci-lsan` should succeed; a pre-existing missing test file (AudioEngineOutputChannelTest.cpp) was noted but is unrelated to this change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->