### PR TITLE
sprint2: Deprecated std::atomic_load on shared_ptr

### DIFF
--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include "AestraAtomicSharedPtr.h"
 #include <string>
 #include <vector>
 
@@ -247,7 +248,7 @@ public:
 
     /** @brief Set the effect chain snapshot for RT-safe processing (deprecated - snapshots are now owned by EffectChain). */
     void setEffectChainSnapshot(std::shared_ptr<const EffectChainSnapshot> snapshot) {
-        std::atomic_store(&m_effectChainSnapshot, std::move(snapshot));
+        m_effectChainSnapshot.store(std::move(snapshot));
     }
     /** @brief Get the current effect chain snapshot (Pass 3: returns canonical snapshot from EffectChain). */
     std::shared_ptr<const EffectChainSnapshot> getEffectChainSnapshot() const {
@@ -284,7 +285,7 @@ private:
     EffectChain m_effectChain;
 
     // Pass 3: Snapshot for RT-safe processing (updated by AudioGraph publication)
-    std::shared_ptr<const EffectChainSnapshot> m_effectChainSnapshot{nullptr};
+    AtomicSharedPtr<const EffectChainSnapshot> m_effectChainSnapshot{nullptr};
 
     // Dry buffer for RT-safe dry/wet mixing in snapshot processing
     std::vector<float> m_dryChannelBuf;

--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -248,7 +248,7 @@ public:
 
     /** @brief Set the effect chain snapshot for RT-safe processing (deprecated - snapshots are now owned by EffectChain). */
     void setEffectChainSnapshot(std::shared_ptr<const EffectChainSnapshot> snapshot) {
-        m_effectChainSnapshot.store(std::move(snapshot));
+        m_effectChainSnapshot.store(std::move(snapshot), std::memory_order_release);
     }
     /** @brief Get the current effect chain snapshot (Pass 3: returns canonical snapshot from EffectChain). */
     std::shared_ptr<const EffectChainSnapshot> getEffectChainSnapshot() const {

--- a/AestraAudio/include/Models/UnitManager.h
+++ b/AestraAudio/include/Models/UnitManager.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include "AestraAtomicSharedPtr.h"
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -337,7 +338,7 @@ private:
      * Read by getAudioSnapshot() on the audio thread via atomic_load.
      * Release semantics on store ensures the audio thread never sees a partial snapshot.
      */
-    mutable std::shared_ptr<AudioArsenalSnapshot> m_publishedSnapshot{std::make_shared<AudioArsenalSnapshot>()};
+    mutable AtomicSharedPtr<AudioArsenalSnapshot> m_publishedSnapshot{std::make_shared<AudioArsenalSnapshot>()};
 
 public:
     void setSampleRate(double rate) { m_sampleRate.store(rate, std::memory_order_relaxed); }

--- a/AestraAudio/include/Playback/AuditionEngine.h
+++ b/AestraAudio/include/Playback/AuditionEngine.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include "AestraAtomicSharedPtr.h"
 #include <mutex>
 #include <optional>
 #include <string>
@@ -290,7 +291,7 @@ private:
     // RT-safe source pointer (C++17 atomic shared_ptr via std::atomic_load/store)
     // NOTE: C++20+ has std::atomic<std::shared_ptr<T>> with member .load()/.store()
     //       C++17 requires free functions std::atomic_load_explicit/std::atomic_store_explicit
-    std::shared_ptr<ClipSource> m_currentSource;
+    AtomicSharedPtr<ClipSource> m_currentSource;
 
     // DSP
     AuditionDSPPreset m_currentPreset{AuditionDSPPreset::Bypass()};

--- a/AestraAudio/include/Playback/PreviewEngine.h
+++ b/AestraAudio/include/Playback/PreviewEngine.h
@@ -7,6 +7,7 @@
 #include <condition_variable>
 #include <functional>
 #include <memory>
+#include "AestraAtomicSharedPtr.h"
 #include <mutex>
 #include <optional>
 #include <string>
@@ -94,7 +95,7 @@ private:
     PreviewResult startVoiceWithBuffer(std::shared_ptr<AudioBuffer> buffer, const std::string& path, float gainDb,
                                        double maxSeconds);
 
-    std::shared_ptr<PreviewVoice> m_activeVoice;
+    AtomicSharedPtr<PreviewVoice> m_activeVoice;
     std::atomic<double> m_outputSampleRate;
     std::atomic<float> m_globalGainDb;
     std::atomic<float> m_playbackRate{1.0f};

--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -137,7 +137,8 @@ private:
     std::array<Voice, kMaxVoices> m_voices;
 
     // Helpers
-    void handleMidiEvent(const MidiBuffer::Event& event, double baseRate);
+    void handleMidiEvent(const MidiBuffer::Event& event, double baseRate,
+                         const std::shared_ptr<SampleData>& currentData);
     void renderVoice(Voice& voice, float* outL, float* outR, uint32_t frames);
     float getEnvelopeLevel(Voice& voice, double dt, float attack, float decay, float sustain, float release);
 };

--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include "AestraAtomicSharedPtr.h"
 #include <mutex>
 #include <string>
 #include <vector>
@@ -101,7 +102,7 @@ private:
 
     // Shared Ptr accessed atomically (C++11/17 free functions)
     // No mutex needed for access anymore!
-    std::shared_ptr<SampleData> m_data;
+    AtomicSharedPtr<SampleData> m_data;
 
     // Parameters
     enum ParamID { kParamAttack = 0, kParamDecay, kParamSustain, kParamRelease, kParamPitch, kParamCount };

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -114,7 +114,7 @@ void MixerChannel::processAudio(float* outputBuffer, uint32_t numFrames, double 
 
     // Process through insert effect chain (if any plugins loaded)
     // Pass 3: Use snapshot for RT-safety when available
-    auto snapshot = std::atomic_load(&m_effectChainSnapshot);
+    auto snapshot = m_effectChainSnapshot.load();
     if (snapshot && snapshot->getActiveSlotCount() > 0) {
         // Audio buffer is interleaved stereo (LRLRLRLR...)
         // Plugins expect planar format (LL...LL, RR...RR)

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -114,7 +114,7 @@ void MixerChannel::processAudio(float* outputBuffer, uint32_t numFrames, double 
 
     // Process through insert effect chain (if any plugins loaded)
     // Pass 3: Use snapshot for RT-safety when available
-    auto snapshot = m_effectChainSnapshot.load();
+    auto snapshot = m_effectChainSnapshot.load(std::memory_order_acquire);
     if (snapshot && snapshot->getActiveSlotCount() > 0) {
         // Audio buffer is interleaved stereo (LRLRLRLR...)
         // Plugins expect planar format (LL...LL, RR...RR)

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -252,14 +252,14 @@ void UnitManager::publishSnapshot() {
     }
 
     // Retire old snapshot through GC so the audio thread never dereferences freed memory.
-    auto old = m_publishedSnapshot.exchange( snapshot);
+    auto old = m_publishedSnapshot.exchange(snapshot, std::memory_order_acq_rel);
     if (old) {
         GarbageCollector::instance().release(old, "UnitManager::AudioArsenalSnapshot");
     }
 }
 
 std::shared_ptr<const AudioArsenalSnapshot> UnitManager::getAudioSnapshot() const {
-    auto snapshot = m_publishedSnapshot.load();
+    auto snapshot = m_publishedSnapshot.load(std::memory_order_acquire);
     return std::const_pointer_cast<const AudioArsenalSnapshot>(snapshot);
 }
 

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -252,14 +252,14 @@ void UnitManager::publishSnapshot() {
     }
 
     // Retire old snapshot through GC so the audio thread never dereferences freed memory.
-    auto old = std::atomic_exchange(&m_publishedSnapshot, snapshot);
+    auto old = m_publishedSnapshot.exchange( snapshot);
     if (old) {
         GarbageCollector::instance().release(old, "UnitManager::AudioArsenalSnapshot");
     }
 }
 
 std::shared_ptr<const AudioArsenalSnapshot> UnitManager::getAudioSnapshot() const {
-    auto snapshot = std::atomic_load(&m_publishedSnapshot);
+    auto snapshot = m_publishedSnapshot.load();
     return std::const_pointer_cast<const AudioArsenalSnapshot>(snapshot);
 }
 

--- a/AestraAudio/src/Playback/AuditionEngine.cpp
+++ b/AestraAudio/src/Playback/AuditionEngine.cpp
@@ -124,7 +124,7 @@ void AuditionEngine::clearQueue() {
     stop();
     m_queue.clear();
     m_currentIndex = -1;
-    m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
+    m_currentSource.store(std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
     Log::info("[AuditionEngine] Queue cleared");
 }
 
@@ -140,7 +140,7 @@ void AuditionEngine::removeFromQueue(size_t index) {
 
         if (m_queue.empty()) {
             m_currentIndex = -1;
-            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
             m_positionSeconds.store(0.0, std::memory_order_release);
             m_cachedDurationSeconds.store(0.0, std::memory_order_release);
             m_isPlaying.store(false, std::memory_order_release);
@@ -299,7 +299,7 @@ void AuditionEngine::jumpToTrack(size_t index) {
 void AuditionEngine::play() {
     if (m_currentIndex < 0 && !m_queue.empty()) {
         jumpToTrack(0);
-    } else if (m_currentIndex >= 0 && !m_currentSource.load()) {
+    } else if (m_currentIndex >= 0 && !m_currentSource.load(std::memory_order_acquire)) {
         // Track selected but not yet decoded — decode now (lazy load)
         std::string filePath;
         double lastPosition = 0.0;
@@ -370,7 +370,7 @@ void AuditionEngine::togglePlayPause() {
 }
 
 void AuditionEngine::seekNormalized(double position) {
-    auto currentSource = m_currentSource.load();
+    auto currentSource = m_currentSource.load(std::memory_order_acquire);
     if (currentSource) {
         double duration = getDurationSeconds();
         seekSeconds(position * duration);
@@ -414,7 +414,7 @@ double AuditionEngine::getPositionSeconds() const {
 }
 
 double AuditionEngine::getDurationSeconds() const {
-    auto currentSource = m_currentSource.load();
+    auto currentSource = m_currentSource.load(std::memory_order_acquire);
     if (currentSource) {
         return currentSource->getDurationSeconds();
     }
@@ -446,7 +446,7 @@ void AuditionEngine::processBlock(float* output, uint32_t numFrames, uint32_t nu
     // RT-safe atomic load - bumps refcount, keeps object alive for this scope
     // NOTE: C++17 uses free function std::atomic_load_explicit()
     //       C++20+ has member syntax: std::atomic<std::shared_ptr<T>>::load()
-    auto currentSource = m_currentSource.load();
+    auto currentSource = m_currentSource.load(std::memory_order_acquire);
     if (!currentSource) {
         return;
     }
@@ -553,7 +553,7 @@ void AuditionEngine::loadCurrentTrack(bool startPlayback) {
     {
         std::lock_guard<std::mutex> lock(m_queueMutex);
         if (m_currentIndex < 0 || m_currentIndex >= static_cast<int32_t>(m_queue.size())) {
-            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
             return;
         }
 
@@ -651,11 +651,11 @@ void AuditionEngine::decodeWorkerLoop() {
             Log::info("[AuditionEngine] Source loaded: " + std::to_string(bufferData->durationSeconds()) + "s");
 
             // Atomic publish to RT thread
-            m_currentSource.store(newSource);
+            m_currentSource.store(newSource, std::memory_order_release);
 
         } catch (const std::exception& e) {
             Log::error("[AuditionEngine] Exception creating source: " + std::string(e.what()));
-            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
             m_cachedDurationSeconds.store(0.0, std::memory_order_release);
             continue;
         }
@@ -697,7 +697,7 @@ void AuditionEngine::decodeWorkerLoop() {
 }
 
 std::shared_ptr<ClipSource> AuditionEngine::getCurrentSource() const {
-    return m_currentSource.load();
+    return m_currentSource.load(std::memory_order_acquire);
 }
 
 void AuditionEngine::applyDSPChain(float* buffer, uint32_t numFrames, uint32_t numChannels) {

--- a/AestraAudio/src/Playback/AuditionEngine.cpp
+++ b/AestraAudio/src/Playback/AuditionEngine.cpp
@@ -124,7 +124,7 @@ void AuditionEngine::clearQueue() {
     stop();
     m_queue.clear();
     m_currentIndex = -1;
-    std::atomic_store_explicit(&m_currentSource, std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
+    m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
     Log::info("[AuditionEngine] Queue cleared");
 }
 
@@ -140,7 +140,7 @@ void AuditionEngine::removeFromQueue(size_t index) {
 
         if (m_queue.empty()) {
             m_currentIndex = -1;
-            std::atomic_store_explicit(&m_currentSource, std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
             m_positionSeconds.store(0.0, std::memory_order_release);
             m_cachedDurationSeconds.store(0.0, std::memory_order_release);
             m_isPlaying.store(false, std::memory_order_release);
@@ -299,7 +299,7 @@ void AuditionEngine::jumpToTrack(size_t index) {
 void AuditionEngine::play() {
     if (m_currentIndex < 0 && !m_queue.empty()) {
         jumpToTrack(0);
-    } else if (m_currentIndex >= 0 && !std::atomic_load_explicit(&m_currentSource, std::memory_order_acquire)) {
+    } else if (m_currentIndex >= 0 && !m_currentSource.load()) {
         // Track selected but not yet decoded — decode now (lazy load)
         std::string filePath;
         double lastPosition = 0.0;
@@ -370,7 +370,7 @@ void AuditionEngine::togglePlayPause() {
 }
 
 void AuditionEngine::seekNormalized(double position) {
-    auto currentSource = std::atomic_load_explicit(&m_currentSource, std::memory_order_acquire);
+    auto currentSource = m_currentSource.load();
     if (currentSource) {
         double duration = getDurationSeconds();
         seekSeconds(position * duration);
@@ -414,7 +414,7 @@ double AuditionEngine::getPositionSeconds() const {
 }
 
 double AuditionEngine::getDurationSeconds() const {
-    auto currentSource = std::atomic_load_explicit(&m_currentSource, std::memory_order_acquire);
+    auto currentSource = m_currentSource.load();
     if (currentSource) {
         return currentSource->getDurationSeconds();
     }
@@ -446,7 +446,7 @@ void AuditionEngine::processBlock(float* output, uint32_t numFrames, uint32_t nu
     // RT-safe atomic load - bumps refcount, keeps object alive for this scope
     // NOTE: C++17 uses free function std::atomic_load_explicit()
     //       C++20+ has member syntax: std::atomic<std::shared_ptr<T>>::load()
-    auto currentSource = std::atomic_load_explicit(&m_currentSource, std::memory_order_acquire);
+    auto currentSource = m_currentSource.load();
     if (!currentSource) {
         return;
     }
@@ -553,7 +553,7 @@ void AuditionEngine::loadCurrentTrack(bool startPlayback) {
     {
         std::lock_guard<std::mutex> lock(m_queueMutex);
         if (m_currentIndex < 0 || m_currentIndex >= static_cast<int32_t>(m_queue.size())) {
-            std::atomic_store_explicit(&m_currentSource, std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
             return;
         }
 
@@ -651,11 +651,11 @@ void AuditionEngine::decodeWorkerLoop() {
             Log::info("[AuditionEngine] Source loaded: " + std::to_string(bufferData->durationSeconds()) + "s");
 
             // Atomic publish to RT thread
-            std::atomic_store_explicit(&m_currentSource, newSource, std::memory_order_release);
+            m_currentSource.store(newSource);
 
         } catch (const std::exception& e) {
             Log::error("[AuditionEngine] Exception creating source: " + std::string(e.what()));
-            std::atomic_store_explicit(&m_currentSource, std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
+            m_currentSource.store(std::shared_ptr<ClipSource>(nullptr));
             m_cachedDurationSeconds.store(0.0, std::memory_order_release);
             continue;
         }
@@ -697,7 +697,7 @@ void AuditionEngine::decodeWorkerLoop() {
 }
 
 std::shared_ptr<ClipSource> AuditionEngine::getCurrentSource() const {
-    return std::atomic_load_explicit(&m_currentSource, std::memory_order_acquire);
+    return m_currentSource.load();
 }
 
 void AuditionEngine::applyDSPChain(float* buffer, uint32_t numFrames, uint32_t numChannels) {

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -113,7 +113,7 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->bufferReady.store(true, std::memory_order_release);
     voice->playing.store(true, std::memory_order_release);
 
-    std::atomic_store_explicit(&m_activeVoice, voice, std::memory_order_release);
+    m_activeVoice.store(voice);
     Log::info("PreviewEngine: Playing '" + path + "' (" + std::to_string(sampleRate) + " Hz, " +
               std::to_string(voice->durationSeconds) + " sec)");
     return PreviewResult::Success;
@@ -167,7 +167,7 @@ void PreviewEngine::workerLoop() {
         // 4. Update Voice
         auto voice = job.voice;
         // Verify voice is still active (redundant with generation but safe)
-        auto currentVoice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+        auto currentVoice = m_activeVoice.load();
         if (currentVoice.get() != voice.get()) {
             voice->playing.store(false, std::memory_order_release);
             continue;
@@ -215,7 +215,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     voice->playing.store(true, std::memory_order_release);      // Voice is active
 
     // Set as active voice immediately (will output silence until buffer ready)
-    std::atomic_store_explicit(&m_activeVoice, voice, std::memory_order_release);
+    m_activeVoice.store(voice);
 
     // Start async decode (non-blocking)
     decodeAsync(path, voice, maxSeconds);
@@ -225,7 +225,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
 }
 
 void PreviewEngine::stop() {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     if (voice) {
         voice->stopRequested.store(true, std::memory_order_release);
         voice->fadeOutActive = true;
@@ -247,7 +247,7 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
     if (outputChannels == 0) {
         return;
     }
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     if (!voice || !voice->playing.load(std::memory_order_acquire) || !interleavedOutput) {
         return;
     }
@@ -580,12 +580,12 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
 }
 
 bool PreviewEngine::isPlaying() const {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     return voice && voice->playing.load(std::memory_order_acquire);
 }
 
 bool PreviewEngine::isBufferReady() const {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     return voice && voice->bufferReady.load(std::memory_order_acquire);
 }
 
@@ -602,26 +602,26 @@ float PreviewEngine::getGlobalPreviewVolume() const {
 }
 
 void PreviewEngine::seek(double seconds) {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     if (voice) {
         voice->seekRequestSeconds.store(seconds, std::memory_order_release);
     }
 }
 
 double PreviewEngine::getPlaybackPosition() const {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     return voice ? voice->elapsedSeconds : 0.0;
 }
 
 double PreviewEngine::getDuration() const {
-    auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+    auto voice = m_activeVoice.load();
     return voice ? voice->durationSeconds : 0.0;
 }
 
 void PreviewEngine::handleDeferredCompletion() {
     if (m_completionPending.exchange(false, std::memory_order_acq_rel)) {
         PreviewVoice* completed = m_completedVoice.exchange(nullptr, std::memory_order_acq_rel);
-        auto voice = std::atomic_load_explicit(&m_activeVoice, std::memory_order_acquire);
+        auto voice = m_activeVoice.load();
         if (!completed || !voice || voice.get() != completed) {
             return;
         }
@@ -634,7 +634,7 @@ void PreviewEngine::handleDeferredCompletion() {
         }
 
         std::shared_ptr<PreviewVoice> expected = voice;
-        std::atomic_compare_exchange_strong_explicit(&m_activeVoice, &expected, std::shared_ptr<PreviewVoice>(),
+        m_activeVoice.compare_exchange_strong(expected, std::shared_ptr<PreviewVoice>(),
                                                      std::memory_order_acq_rel, std::memory_order_relaxed);
 
         if (!path.empty() && m_onComplete) {

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -113,7 +113,7 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->bufferReady.store(true, std::memory_order_release);
     voice->playing.store(true, std::memory_order_release);
 
-    m_activeVoice.store(voice);
+    m_activeVoice.store(voice, std::memory_order_release);
     Log::info("PreviewEngine: Playing '" + path + "' (" + std::to_string(sampleRate) + " Hz, " +
               std::to_string(voice->durationSeconds) + " sec)");
     return PreviewResult::Success;
@@ -167,7 +167,7 @@ void PreviewEngine::workerLoop() {
         // 4. Update Voice
         auto voice = job.voice;
         // Verify voice is still active (redundant with generation but safe)
-        auto currentVoice = m_activeVoice.load();
+        auto currentVoice = m_activeVoice.load(std::memory_order_acquire);
         if (currentVoice.get() != voice.get()) {
             voice->playing.store(false, std::memory_order_release);
             continue;
@@ -215,7 +215,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     voice->playing.store(true, std::memory_order_release);      // Voice is active
 
     // Set as active voice immediately (will output silence until buffer ready)
-    m_activeVoice.store(voice);
+    m_activeVoice.store(voice, std::memory_order_release);
 
     // Start async decode (non-blocking)
     decodeAsync(path, voice, maxSeconds);
@@ -225,7 +225,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
 }
 
 void PreviewEngine::stop() {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     if (voice) {
         voice->stopRequested.store(true, std::memory_order_release);
         voice->fadeOutActive = true;
@@ -247,7 +247,7 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
     if (outputChannels == 0) {
         return;
     }
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     if (!voice || !voice->playing.load(std::memory_order_acquire) || !interleavedOutput) {
         return;
     }
@@ -580,12 +580,12 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
 }
 
 bool PreviewEngine::isPlaying() const {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     return voice && voice->playing.load(std::memory_order_acquire);
 }
 
 bool PreviewEngine::isBufferReady() const {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     return voice && voice->bufferReady.load(std::memory_order_acquire);
 }
 
@@ -602,26 +602,26 @@ float PreviewEngine::getGlobalPreviewVolume() const {
 }
 
 void PreviewEngine::seek(double seconds) {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     if (voice) {
         voice->seekRequestSeconds.store(seconds, std::memory_order_release);
     }
 }
 
 double PreviewEngine::getPlaybackPosition() const {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     return voice ? voice->elapsedSeconds : 0.0;
 }
 
 double PreviewEngine::getDuration() const {
-    auto voice = m_activeVoice.load();
+    auto voice = m_activeVoice.load(std::memory_order_acquire);
     return voice ? voice->durationSeconds : 0.0;
 }
 
 void PreviewEngine::handleDeferredCompletion() {
     if (m_completionPending.exchange(false, std::memory_order_acq_rel)) {
         PreviewVoice* completed = m_completedVoice.exchange(nullptr, std::memory_order_acq_rel);
-        auto voice = m_activeVoice.load();
+        auto voice = m_activeVoice.load(std::memory_order_acquire);
         if (!completed || !voice || voice.get() != completed) {
             return;
         }

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -121,7 +121,7 @@ bool SamplerPlugin::initialize(double sampleRate, uint32_t maxBlockSize) {
 void SamplerPlugin::shutdown() {
     m_active = false;
     // Force release of data to ensure cleanup
-    auto old = std::atomic_exchange(&m_data, std::shared_ptr<SampleData>(nullptr));
+    auto old = m_data.exchange( std::shared_ptr<SampleData>(nullptr));
     GarbageCollector::instance().release(old, "SamplerPlugin::SampleData shutdown");
 }
 
@@ -177,7 +177,7 @@ bool SamplerPlugin::loadSample(const std::string& path) {
 
     // Atomic Swap (Thread-Safe, Lock-Free-ish)
     // std::atomic_exchange uses standard atomics for shared_ptr
-    auto oldData = std::atomic_exchange(&m_data, newData);
+    auto oldData = m_data.exchange( newData);
 
     // Safely dispose of old data via Garbage Collector (avoids delete on Audio Thread)
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
@@ -186,7 +186,7 @@ bool SamplerPlugin::loadSample(const std::string& path) {
 }
 
 bool SamplerPlugin::normalizeSample(float targetPeak) {
-    auto currentData = std::atomic_load(&m_data);
+    auto currentData = m_data.load();
     if (!currentData || currentData->data.empty()) {
         return false;
     }
@@ -205,13 +205,13 @@ bool SamplerPlugin::normalizeSample(float targetPeak) {
         s *= gain;
     }
 
-    auto oldData = std::atomic_exchange(&m_data, edited);
+    auto oldData = m_data.exchange( edited);
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
     return true;
 }
 
 bool SamplerPlugin::reverseSample() {
-    auto currentData = std::atomic_load(&m_data);
+    auto currentData = m_data.load();
     if (!currentData || currentData->data.empty() || currentData->channels == 0) {
         return false;
     }
@@ -231,7 +231,7 @@ bool SamplerPlugin::reverseSample() {
         }
     }
 
-    auto oldData = std::atomic_exchange(&m_data, edited);
+    auto oldData = m_data.exchange( edited);
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
     return true;
 }
@@ -260,7 +260,7 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
     }
 
     // Thread-safe access to sample data
-    auto currentData = std::atomic_load(&m_data);
+    auto currentData = m_data.load();
     if (!currentData || currentData->data.empty())
         return;
 
@@ -427,7 +427,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
 
         if (m_monoMode.load(std::memory_order_relaxed)) {
             double noteStartFrame = 0.0;
-            if (auto currentData = std::atomic_load(&m_data); currentData && currentData->channels > 0) {
+            if (auto currentData = m_data.load(); currentData && currentData->channels > 0) {
                 const double totalFrames = static_cast<double>(currentData->data.size() / currentData->channels);
                 noteStartFrame = std::clamp(static_cast<double>(m_loopStartNorm.load(std::memory_order_relaxed)), 0.0, 0.999) *
                                  std::max(1.0, totalFrames - 1.0);
@@ -464,7 +464,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
 
         const int maxVoices = std::clamp(m_maxVoices.load(std::memory_order_relaxed), 1, kMaxVoices);
         double noteStartFrame = 0.0;
-        if (auto currentData = std::atomic_load(&m_data); currentData && currentData->channels > 0) {
+        if (auto currentData = m_data.load(); currentData && currentData->channels > 0) {
             const double totalFrames = static_cast<double>(currentData->data.size() / currentData->channels);
             noteStartFrame = std::clamp(static_cast<double>(m_loopStartNorm.load(std::memory_order_relaxed)), 0.0, 0.999) *
                              std::max(1.0, totalFrames - 1.0);
@@ -619,7 +619,7 @@ std::vector<uint8_t> SamplerPlugin::saveState() const {
 
     // Sample Path
     {
-        auto current = std::atomic_load(&m_data);
+        auto current = m_data.load();
         if (current && !current->path.empty()) {
             json.set("samplePath", Aestra::JSON(current->path));
         }

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -121,7 +121,7 @@ bool SamplerPlugin::initialize(double sampleRate, uint32_t maxBlockSize) {
 void SamplerPlugin::shutdown() {
     m_active = false;
     // Force release of data to ensure cleanup
-    auto old = m_data.exchange( std::shared_ptr<SampleData>(nullptr));
+    auto old = m_data.exchange(std::shared_ptr<SampleData>(nullptr), std::memory_order_acq_rel);
     GarbageCollector::instance().release(old, "SamplerPlugin::SampleData shutdown");
 }
 
@@ -177,7 +177,7 @@ bool SamplerPlugin::loadSample(const std::string& path) {
 
     // Atomic Swap (Thread-Safe, Lock-Free-ish)
     // std::atomic_exchange uses standard atomics for shared_ptr
-    auto oldData = m_data.exchange( newData);
+    auto oldData = m_data.exchange(newData, std::memory_order_acq_rel);
 
     // Safely dispose of old data via Garbage Collector (avoids delete on Audio Thread)
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
@@ -186,7 +186,7 @@ bool SamplerPlugin::loadSample(const std::string& path) {
 }
 
 bool SamplerPlugin::normalizeSample(float targetPeak) {
-    auto currentData = m_data.load();
+    auto currentData = m_data.load(std::memory_order_acquire);
     if (!currentData || currentData->data.empty()) {
         return false;
     }
@@ -205,13 +205,13 @@ bool SamplerPlugin::normalizeSample(float targetPeak) {
         s *= gain;
     }
 
-    auto oldData = m_data.exchange( edited);
+    auto oldData = m_data.exchange(edited, std::memory_order_acq_rel);
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
     return true;
 }
 
 bool SamplerPlugin::reverseSample() {
-    auto currentData = m_data.load();
+    auto currentData = m_data.load(std::memory_order_acquire);
     if (!currentData || currentData->data.empty() || currentData->channels == 0) {
         return false;
     }
@@ -231,7 +231,7 @@ bool SamplerPlugin::reverseSample() {
         }
     }
 
-    auto oldData = m_data.exchange( edited);
+    auto oldData = m_data.exchange(edited, std::memory_order_acq_rel);
     GarbageCollector::instance().release(oldData, "SamplerPlugin::SampleData");
     return true;
 }
@@ -260,7 +260,7 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
     }
 
     // Thread-safe access to sample data
-    auto currentData = m_data.load();
+    auto currentData = m_data.load(std::memory_order_acquire);
     if (!currentData || currentData->data.empty())
         return;
 
@@ -305,7 +305,7 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
         while (midiInput && eventIdx < eventCount) {
             const auto& e = midiInput->getEvent(eventIdx);
             if (e.sampleOffset == i) {
-                handleMidiEvent(e, baseRate);
+                handleMidiEvent(e, baseRate, currentData);
                 activeVoiceCountDirty = true;
                 eventIdx++;
             } else if (e.sampleOffset < i) {
@@ -412,7 +412,8 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
     }
 }
 
-void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseRate) {
+void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseRate,
+                                    const std::shared_ptr<SampleData>& currentData) {
     uint8_t status = event.data[0] & 0xF0;
     uint8_t note = event.data[1];
     uint8_t velocity = event.data[2];
@@ -427,7 +428,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
 
         if (m_monoMode.load(std::memory_order_relaxed)) {
             double noteStartFrame = 0.0;
-            if (auto currentData = m_data.load(); currentData && currentData->channels > 0) {
+            if (currentData && currentData->channels > 0) {
                 const double totalFrames = static_cast<double>(currentData->data.size() / currentData->channels);
                 noteStartFrame = std::clamp(static_cast<double>(m_loopStartNorm.load(std::memory_order_relaxed)), 0.0, 0.999) *
                                  std::max(1.0, totalFrames - 1.0);
@@ -464,7 +465,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
 
         const int maxVoices = std::clamp(m_maxVoices.load(std::memory_order_relaxed), 1, kMaxVoices);
         double noteStartFrame = 0.0;
-        if (auto currentData = m_data.load(); currentData && currentData->channels > 0) {
+        if (currentData && currentData->channels > 0) {
             const double totalFrames = static_cast<double>(currentData->data.size() / currentData->channels);
             noteStartFrame = std::clamp(static_cast<double>(m_loopStartNorm.load(std::memory_order_relaxed)), 0.0, 0.999) *
                              std::max(1.0, totalFrames - 1.0);
@@ -619,7 +620,7 @@ std::vector<uint8_t> SamplerPlugin::saveState() const {
 
     // Sample Path
     {
-        auto current = m_data.load();
+        auto current = m_data.load(std::memory_order_acquire);
         if (current && !current->path.empty()) {
             json.set("samplePath", Aestra::JSON(current->path));
         }

--- a/AestraCore/include/AestraAtomicSharedPtr.h
+++ b/AestraCore/include/AestraAtomicSharedPtr.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <memory>
+#include <utility>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+namespace Aestra {
+template <typename T>
+class AtomicSharedPtr {
+public:
+    AtomicSharedPtr() = default;
+    explicit AtomicSharedPtr(std::shared_ptr<T> ptr) : m_ptr(std::move(ptr)) {}
+    ~AtomicSharedPtr() = default;
+    AtomicSharedPtr(const AtomicSharedPtr&) = delete;
+    AtomicSharedPtr& operator=(const AtomicSharedPtr&) = delete;
+    std::shared_ptr<T> load() const noexcept { return std::atomic_load(&m_ptr); }
+    void store(std::shared_ptr<T> desired) noexcept { std::atomic_store(&m_ptr, std::move(desired)); }
+    std::shared_ptr<T> exchange(std::shared_ptr<T> desired) noexcept { return std::atomic_exchange(&m_ptr, std::move(desired)); }
+    bool compare_exchange_strong(std::shared_ptr<T>& expected, std::shared_ptr<T> desired,
+                                  std::memory_order success = std::memory_order_seq_cst,
+                                  std::memory_order failure = std::memory_order_seq_cst) noexcept {
+        return std::atomic_compare_exchange_strong_explicit(&m_ptr, &expected, std::move(desired), success, failure);
+    }
+private:
+    std::shared_ptr<T> m_ptr;
+};
+} // namespace Aestra
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/AestraCore/include/AestraAtomicSharedPtr.h
+++ b/AestraCore/include/AestraAtomicSharedPtr.h
@@ -1,7 +1,13 @@
 #pragma once
+#include <atomic>
 #include <memory>
 #include <utility>
 
+#if defined(__cpp_lib_atomic_shared_ptr) && __cpp_lib_atomic_shared_ptr >= 201711L
+#define AESTRA_HAS_STD_ATOMIC_SHARED_PTR 1
+#endif
+
+#ifndef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -11,6 +17,7 @@
 #elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4996)
+#endif
 #endif
 
 namespace Aestra {
@@ -22,19 +29,47 @@ public:
     ~AtomicSharedPtr() = default;
     AtomicSharedPtr(const AtomicSharedPtr&) = delete;
     AtomicSharedPtr& operator=(const AtomicSharedPtr&) = delete;
-    std::shared_ptr<T> load() const noexcept { return std::atomic_load(&m_ptr); }
-    void store(std::shared_ptr<T> desired) noexcept { std::atomic_store(&m_ptr, std::move(desired)); }
-    std::shared_ptr<T> exchange(std::shared_ptr<T> desired) noexcept { return std::atomic_exchange(&m_ptr, std::move(desired)); }
+    std::shared_ptr<T> load(std::memory_order order = std::memory_order_seq_cst) const noexcept {
+#ifdef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
+        return m_ptr.load(order);
+#else
+        return std::atomic_load_explicit(&m_ptr, order);
+#endif
+    }
+    void store(std::shared_ptr<T> desired, std::memory_order order = std::memory_order_seq_cst) noexcept {
+#ifdef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
+        m_ptr.store(std::move(desired), order);
+#else
+        std::atomic_store_explicit(&m_ptr, std::move(desired), order);
+#endif
+    }
+    std::shared_ptr<T> exchange(std::shared_ptr<T> desired,
+                                std::memory_order order = std::memory_order_seq_cst) noexcept {
+#ifdef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
+        return m_ptr.exchange(std::move(desired), order);
+#else
+        return std::atomic_exchange_explicit(&m_ptr, std::move(desired), order);
+#endif
+    }
     bool compare_exchange_strong(std::shared_ptr<T>& expected, std::shared_ptr<T> desired,
                                   std::memory_order success = std::memory_order_seq_cst,
                                   std::memory_order failure = std::memory_order_seq_cst) noexcept {
+#ifdef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
+        return m_ptr.compare_exchange_strong(expected, std::move(desired), success, failure);
+#else
         return std::atomic_compare_exchange_strong_explicit(&m_ptr, &expected, std::move(desired), success, failure);
+#endif
     }
 private:
+#ifdef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
+    std::atomic<std::shared_ptr<T>> m_ptr;
+#else
     std::shared_ptr<T> m_ptr;
+#endif
 };
 } // namespace Aestra
 
+#ifndef AESTRA_HAS_STD_ATOMIC_SHARED_PTR
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)
@@ -42,3 +77,6 @@ private:
 #elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#endif
+
+#undef AESTRA_HAS_STD_ATOMIC_SHARED_PTR


### PR DESCRIPTION
Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Replaced deprecated std::atomic_load/store free functions with atomic member operations**

- Introduced a new C++17-compatible wrapper `AestraAtomicSharedPtr<T>` that provides atomic operations on `std::shared_ptr` using the standard free functions internally while exposing a C++20-style API (load(), store(), exchange(), compare_exchange_strong())
- Migrated ~14 call sites across 5 source files to use the new wrapper:
  - **MixerChannel**: `m_effectChainSnapshot` now uses `AtomicSharedPtr` with `.load()` and `.store()` calls
  - **UnitManager**: `m_publishedSnapshot` now uses `AtomicSharedPtr` with `.load()` and `.exchange()` calls  
  - **AuditionEngine**: `m_currentSource` now uses `AtomicSharedPtr` with `.load()` and `.store()` calls
  - **PreviewEngine**: `m_activeVoice` now uses `AtomicSharedPtr` with `.load()`, `.store()`, and `.compare_exchange_strong()` calls
  - **SamplerPlugin**: `m_data` now uses `AtomicSharedPtr` with `.load()` and `.exchange()` calls
- The wrapper includes compiler-specific warning suppression for deprecated declarations, making the build pass with `-Wdeprecated-declarations -Werror`
- All public API signatures remain unchanged—this is purely an internal implementation refactor to future-proof against C++26 where these free functions were removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->