### PR TITLE
test: expand v1 fixture and migration round-trip validation

### DIFF
--- a/Tests/Fixtures/ProjectFormat/v1_minimal.aes
+++ b/Tests/Fixtures/ProjectFormat/v1_minimal.aes
@@ -1,16 +1,36 @@
 {
   "version": 1,
-  "tempo": 120.0,
-  "playhead": 0.0,
+  "tempo": 133.5,
+  "playhead": 2.25,
   "sources": [],
-  "patterns": [],
+  "patterns": [
+    {
+      "id": 1,
+      "name": "V1 MIDI Pattern",
+      "type": "midi",
+      "length": 8.0,
+      "notes": [
+        {"pitch": 60, "startBeat": 0.0, "durationBeats": 1.0, "velocity": 0.75},
+        {"pitch": 64, "startBeat": 1.0, "durationBeats": 0.5, "velocity": 0.5}
+      ]
+    }
+  ],
   "lanes": [
     {
       "name": "Migrated Track",
       "color": "4294967295",
       "volume": 1.0,
       "pan": 0.0,
-      "clips": []
+      "clips": [
+        {
+          "id": "v1-fixture-clip",
+          "patternId": 1,
+          "start": 4.0,
+          "duration": 8.0,
+          "sourceOffset": 0.5,
+          "name": "Migrated Clip"
+        }
+      ]
     }
   ],
   "arsenal": {"nextId": 1, "units": []}

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -519,6 +519,7 @@ void testV1FixtureMigratesToCurrentVersion() {
     assert(roundTripLane->clips[0].name == "Migrated Clip");
     assert(std::abs(roundTripLane->clips[0].startBeat - 4.0) < 1e-9);
     assert(std::abs(roundTripLane->clips[0].durationBeats - 8.0) < 1e-9);
+    assert(std::abs(roundTripLane->clips[0].sourceOffset - 0.5) < 1e-9);
 
     auto roundTripPatterns = roundTripManager->getPatternManager().getAllPatterns();
     assert(roundTripPatterns.size() == 1);
@@ -526,6 +527,10 @@ void testV1FixtureMigratesToCurrentVersion() {
     assert(roundTripPatterns[0]->isMidi());
     assert(roundTripPatterns[0]->name == "V1 MIDI Pattern");
     assert(roundTripPatterns[0]->getMidiNotes().size() == 2);
+    assert(roundTripPatterns[0]->getMidiNotes()[0].pitch == 60);
+    assert(std::abs(roundTripPatterns[0]->getMidiNotes()[0].velocity - 0.75f) < 1e-6f);
+    assert(roundTripPatterns[0]->getMidiNotes()[1].pitch == 64);
+    assert(std::abs(roundTripPatterns[0]->getMidiNotes()[1].velocity - 0.5f) < 1e-6f);
 
     std::filesystem::remove_all(testDir);
 

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -8,10 +8,12 @@
 #include "Models/TrackManager.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string>
 
 using namespace Aestra;
@@ -457,9 +459,17 @@ void testV1FixtureMigratesToCurrentVersion() {
     auto fixturePath = std::filesystem::path(AESTRA_PROJECT_FIXTURE_DIR) / "v1_minimal.aes";
     assert(std::filesystem::exists(fixturePath));
 
+    std::ifstream fixtureIn(fixturePath);
+    std::string fixtureJson((std::istreambuf_iterator<char>(fixtureIn)), std::istreambuf_iterator<char>());
+    assert(fixtureJson.find("\"version\": 1") != std::string::npos ||
+           fixtureJson.find("\"version\":1") != std::string::npos);
+
     auto trackManager = std::make_shared<TrackManager>();
     auto result = ProjectSerializer::load(fixturePath.string(), trackManager);
     assert(result.ok);
+    assert(result.errorMessage.empty());
+    assert(std::abs(result.tempo - 133.5) < 1e-9);
+    assert(std::abs(result.playhead - 2.25) < 1e-9);
     assert(trackManager->getChannelCount() == 1);
 
     auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
@@ -467,10 +477,57 @@ void testV1FixtureMigratesToCurrentVersion() {
     auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
     assert(lane);
     assert(lane->name == "Migrated Track");
+    assert(lane->clips.size() == 1);
+    assert(lane->clips[0].name == "Migrated Clip");
+    assert(std::abs(lane->clips[0].startBeat - 4.0) < 1e-9);
+    assert(std::abs(lane->clips[0].durationBeats - 8.0) < 1e-9);
+    assert(std::abs(lane->clips[0].sourceOffset - 0.5) < 1e-9);
+
+    auto patterns = trackManager->getPatternManager().getAllPatterns();
+    assert(patterns.size() == 1);
+    assert(patterns[0]);
+    assert(patterns[0]->isMidi());
+    assert(patterns[0]->name == "V1 MIDI Pattern");
+    assert(std::abs(patterns[0]->lengthBeats - 8.0) < 1e-9);
+    assert(patterns[0]->getMidiNotes().size() == 2);
+    assert(patterns[0]->getMidiNotes()[0].pitch == 60);
+    assert(std::abs(patterns[0]->getMidiNotes()[0].velocity - 0.75f) < 1e-6f);
 
     std::string saved = ProjectSerializer::serialize(trackManager, result.tempo, result.playhead, 0).contents;
     assert(saved.find("\"version\": 2") != std::string::npos ||
            saved.find("\"version\":2") != std::string::npos);
+
+    auto testDir = makeTempDir();
+    auto migratedPath = testDir / "v1_migrated_roundtrip.aes";
+    std::ofstream migratedOut(migratedPath);
+    migratedOut << saved;
+    migratedOut.close();
+
+    auto roundTripManager = std::make_shared<TrackManager>();
+    auto roundTripResult = ProjectSerializer::load(migratedPath.string(), roundTripManager);
+    assert(roundTripResult.ok);
+    assert(roundTripResult.errorMessage.empty());
+    assert(std::abs(roundTripResult.tempo - 133.5) < 1e-9);
+    assert(std::abs(roundTripResult.playhead - 2.25) < 1e-9);
+
+    auto roundTripLaneIds = roundTripManager->getPlaylistModel().getLaneIDs();
+    assert(roundTripLaneIds.size() == 1);
+    auto* roundTripLane = roundTripManager->getPlaylistModel().getLane(roundTripLaneIds[0]);
+    assert(roundTripLane);
+    assert(roundTripLane->name == "Migrated Track");
+    assert(roundTripLane->clips.size() == 1);
+    assert(roundTripLane->clips[0].name == "Migrated Clip");
+    assert(std::abs(roundTripLane->clips[0].startBeat - 4.0) < 1e-9);
+    assert(std::abs(roundTripLane->clips[0].durationBeats - 8.0) < 1e-9);
+
+    auto roundTripPatterns = roundTripManager->getPatternManager().getAllPatterns();
+    assert(roundTripPatterns.size() == 1);
+    assert(roundTripPatterns[0]);
+    assert(roundTripPatterns[0]->isMidi());
+    assert(roundTripPatterns[0]->name == "V1 MIDI Pattern");
+    assert(roundTripPatterns[0]->getMidiNotes().size() == 2);
+
+    std::filesystem::remove_all(testDir);
 
     std::cout << "[PASS] v1 fixture migrates to current project version" << std::endl;
 }


### PR DESCRIPTION
Closes #249

Summary:
- Expands the stored `v1_minimal.aes` fixture into a meaningful legacy project with non-default tempo/playhead, one MIDI pattern, MIDI notes, and a clip reference.
- Strengthens `ProjectLoadRegressionTest` so it verifies the fixture is actually v1, loads through the v1→v2 migration path, validates the migrated project state, saves as current schema, reloads the saved v2 file, and verifies the round-trip state.

Testing:
- `cmake --build build --parallel 2`
- `ctest --test-dir build -R "ProjectLoadRegressionTest|ProjectRoundTripIntegrityTest|ProjectRoundTripTest" --output-on-failure`
- `build/Tests/ProjectRoundTripTest`
- `build/Tests/ProjectRoundTripIntegrityTest`
- `git diff --check`

Notes:
- `ProjectRoundTripTest` and `ProjectRoundTripIntegrityTest` are built but not registered in this build configuration, so they were run directly.
- The build emitted pre-existing unsigned-comparison warnings in `Tests/AestraAudio/TrackManagerStressTest.cpp`; no new warnings were observed from this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**No breaking changes**

- Enhanced v1 test fixture (Tests/Fixtures/ProjectFormat/v1_minimal.aes)
  - Replaced empty skeleton with a realistic v1 legacy project:
    - tempo: 133.5, playhead: 2.25
    - One MIDI pattern (id: 1, length: 8.0) with two notes (pitch 60 @ vel 0.75, pitch 64 @ vel 0.5)
    - One lane "Migrated Track" containing a clip (id: "v1-fixture-clip") that references patternId 1 with start 4.0, duration 8.0, sourceOffset 0.5, and a name

- Strengthened regression tests (Tests/Integration/ProjectLoadRegressionTest.cpp)
  - testV1FixtureMigratesToCurrentVersion now:
    - Verifies the fixture is v1 and asserts migrated tempo/playhead values
    - Asserts lane/clip fields and MIDI pattern contents (note pitches, velocities, counts)
    - Performs a save→reload round-trip of the migrated project and reasserts the same state to validate round-trip integrity
  - Adds helpers used by tests (temp WAV writer, temp dir creation) and necessary headers

Why:
- Implements issue `#249`: provides a real legacy fixture and exercises the v1→v2 migration path end-to-end, validating migration correctness and round-trip integrity before shipping schema changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->