### PR TITLE
sprint2: Plugin NaN/Inf only validated at master

### DIFF
--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -17,12 +18,21 @@ class PluginManager;
 class EffectChainSnapshot;
 
 /**
+ * @brief RT-visible automatic bypass state for unsafe plugin output.
+ */
+struct EffectSlotFaultState {
+    std::atomic<bool> bypassedByNonFiniteOutput{false};
+    std::atomic<uint64_t> nonFiniteOutputCount{0};
+};
+
+/**
  * @brief Single slot in an effect chain
  */
 struct EffectSlot {
     PluginInstancePtr plugin;           ///< Plugin instance (nullptr = empty)
     std::atomic<bool> bypassed{false};  ///< Bypass this slot
     std::atomic<float> dryWetMix{1.0f}; ///< 0.0 = dry only, 1.0 = wet only
+    std::shared_ptr<EffectSlotFaultState> faultState{std::make_shared<EffectSlotFaultState>()};
 
     bool isEmpty() const { return plugin == nullptr; }
 };
@@ -166,6 +176,16 @@ public:
     bool isSlotBypassed(size_t slotIndex) const;
 
     /**
+     * @brief Check if a slot was automatically bypassed after unsafe non-finite output.
+     */
+    bool isSlotBypassedByNonFiniteOutput(size_t slotIndex) const;
+
+    /**
+     * @brief Number of times a slot produced non-finite output and was quarantined.
+     */
+    uint64_t getSlotNonFiniteOutputCount(size_t slotIndex) const;
+
+    /**
      * @brief Bypass entire chain
      */
     void setChainBypassed(bool bypassed) { m_chainBypassed.store(bypassed); }
@@ -293,9 +313,10 @@ private:
  * so plugin instances stay alive while any snapshot exists.
  */
 struct EffectChainSnapshotSlot {
-    PluginInstancePtr plugin;    ///< Plugin instance (copied shared_ptr)
-    bool bypassed;               ///< Bypass state (copied value)
-    float dryWetMix;            ///< Dry/wet mix (copied value)
+    PluginInstancePtr plugin;                         ///< Plugin instance (copied shared_ptr)
+    bool bypassed;                                    ///< Bypass state (copied value)
+    float dryWetMix;                                  ///< Dry/wet mix (copied value)
+    std::shared_ptr<EffectSlotFaultState> faultState; ///< Shared RT-visible fault state
 
     bool isEmpty() const { return plugin == nullptr; }
 };
@@ -320,6 +341,7 @@ public:
             m_slots[i].plugin = slots[i].plugin;
             m_slots[i].bypassed = slots[i].bypassed.load(std::memory_order_acquire);
             m_slots[i].dryWetMix = slots[i].dryWetMix.load(std::memory_order_acquire);
+            m_slots[i].faultState = slots[i].faultState;
         }
         m_slotCount = MAX_SLOTS;
     }

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -65,21 +65,6 @@ void markNonFiniteOutputFault(const std::shared_ptr<EffectSlotFaultState>& fault
     faultState->bypassedByNonFiniteOutput.store(true, std::memory_order_release);
 }
 
-void copyFaultState(const std::shared_ptr<EffectSlotFaultState>& dst,
-                    const std::shared_ptr<EffectSlotFaultState>& src) noexcept {
-    if (!dst) {
-        return;
-    }
-    if (!src) {
-        clearFaultState(dst);
-        return;
-    }
-    dst->bypassedByNonFiniteOutput.store(src->bypassedByNonFiniteOutput.load(std::memory_order_acquire),
-                                         std::memory_order_release);
-    dst->nonFiniteOutputCount.store(src->nonFiniteOutputCount.load(std::memory_order_acquire),
-                                    std::memory_order_release);
-}
-
 void restoreDryChannels(float** buffer, const float* dryBuffer, uint32_t numChannels, uint32_t blendChannels,
                         uint32_t numFrames) noexcept {
     for (uint32_t ch = 0; ch < blendChannels; ++ch) {
@@ -130,7 +115,7 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
     m_slots[slotIndex].plugin = std::move(plugin);
     m_slots[slotIndex].bypassed.store(false);
     m_slots[slotIndex].dryWetMix.store(1.0f);
-    clearFaultState(m_slots[slotIndex].faultState);
+    m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
 
     publishSnapshot();
     if (m_onLatencyChanged) {
@@ -149,7 +134,7 @@ PluginInstancePtr EffectChain::removePlugin(size_t slotIndex) {
 
     auto plugin = std::move(m_slots[slotIndex].plugin);
     m_slots[slotIndex].plugin = nullptr;
-    clearFaultState(m_slots[slotIndex].faultState);
+    m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
 
     publishSnapshot();
     if (m_onLatencyChanged) {
@@ -178,12 +163,15 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
     m_slots[toSlot].plugin = std::move(m_slots[fromSlot].plugin);
     m_slots[toSlot].bypassed.store(m_slots[fromSlot].bypassed.load());
     m_slots[toSlot].dryWetMix.store(m_slots[fromSlot].dryWetMix.load());
-    copyFaultState(m_slots[toSlot].faultState, m_slots[fromSlot].faultState);
+    m_slots[toSlot].faultState = std::move(m_slots[fromSlot].faultState);
+    if (!m_slots[toSlot].faultState) {
+        m_slots[toSlot].faultState = std::make_shared<EffectSlotFaultState>();
+    }
 
     m_slots[fromSlot].plugin = nullptr;
     m_slots[fromSlot].bypassed.store(false);
     m_slots[fromSlot].dryWetMix.store(1.0f);
-    clearFaultState(m_slots[fromSlot].faultState);
+    m_slots[fromSlot].faultState = std::make_shared<EffectSlotFaultState>();
 
     publishSnapshot();
     return true;
@@ -265,7 +253,7 @@ void EffectChain::clear() {
         slot.plugin = nullptr;
         slot.bypassed.store(false);
         slot.dryWetMix.store(1.0f);
-        clearFaultState(slot.faultState);
+        slot.faultState = std::make_shared<EffectSlotFaultState>();
     }
     publishSnapshot();
 }
@@ -650,7 +638,7 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
         if (!hasPlugin) {
             m_slots[i].plugin = nullptr;
-            clearFaultState(m_slots[i].faultState);
+            m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
             continue;
         }
 
@@ -707,7 +695,7 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
             m_slots[i].plugin = std::move(instance);
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
-            clearFaultState(m_slots[i].faultState);
+            m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
         }
     }
 
@@ -723,7 +711,7 @@ uint32_t EffectChain::getTotalLatency() const {
     uint32_t total = 0;
 
     for (const auto& slot : m_slots) {
-        if (!slot.isEmpty() && !slot.bypassed.load() && !isFaultBypassed(slot.faultState) && slot.plugin) {
+        if (!slot.isEmpty() && !slot.bypassed.load() && slot.plugin) {
             total += slot.plugin->getLatencySamples();
         }
     }

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -22,7 +22,7 @@ bool processPluginNoexcept(IPluginInstance& plugin, const float* const* inputs, 
     }
 }
 
-void sanitizeFloatBuffers(float** buffer, uint32_t numChannels, uint32_t numFrames) noexcept {
+bool buffersAreFinite(float** buffer, uint32_t numChannels, uint32_t numFrames) noexcept {
     for (uint32_t ch = 0; ch < numChannels; ++ch) {
         float* channel = buffer[ch];
         if (!channel) {
@@ -30,12 +30,68 @@ void sanitizeFloatBuffers(float** buffer, uint32_t numChannels, uint32_t numFram
         }
         for (uint32_t i = 0; i < numFrames; ++i) {
             if (!std::isfinite(channel[i])) {
-                channel[i] = 0.0f;
+                return false;
             }
         }
     }
+    return true;
 }
+
+void clearFloatBuffers(float** buffer, uint32_t numChannels, uint32_t numFrames) noexcept {
+    for (uint32_t ch = 0; ch < numChannels; ++ch) {
+        if (buffer[ch]) {
+            std::fill(buffer[ch], buffer[ch] + numFrames, 0.0f);
+        }
+    }
 }
+
+bool isFaultBypassed(const std::shared_ptr<EffectSlotFaultState>& faultState) noexcept {
+    return faultState && faultState->bypassedByNonFiniteOutput.load(std::memory_order_acquire);
+}
+
+void clearFaultState(const std::shared_ptr<EffectSlotFaultState>& faultState) noexcept {
+    if (!faultState) {
+        return;
+    }
+    faultState->bypassedByNonFiniteOutput.store(false, std::memory_order_release);
+    faultState->nonFiniteOutputCount.store(0, std::memory_order_release);
+}
+
+void markNonFiniteOutputFault(const std::shared_ptr<EffectSlotFaultState>& faultState) noexcept {
+    if (!faultState) {
+        return;
+    }
+    faultState->nonFiniteOutputCount.fetch_add(1, std::memory_order_acq_rel);
+    faultState->bypassedByNonFiniteOutput.store(true, std::memory_order_release);
+}
+
+void copyFaultState(const std::shared_ptr<EffectSlotFaultState>& dst,
+                    const std::shared_ptr<EffectSlotFaultState>& src) noexcept {
+    if (!dst) {
+        return;
+    }
+    if (!src) {
+        clearFaultState(dst);
+        return;
+    }
+    dst->bypassedByNonFiniteOutput.store(src->bypassedByNonFiniteOutput.load(std::memory_order_acquire),
+                                         std::memory_order_release);
+    dst->nonFiniteOutputCount.store(src->nonFiniteOutputCount.load(std::memory_order_acquire),
+                                    std::memory_order_release);
+}
+
+void restoreDryChannels(float** buffer, const float* dryBuffer, uint32_t numChannels, uint32_t blendChannels,
+                        uint32_t numFrames) noexcept {
+    for (uint32_t ch = 0; ch < blendChannels; ++ch) {
+        std::memcpy(buffer[ch], dryBuffer + ch * numFrames, numFrames * sizeof(float));
+    }
+    for (uint32_t ch = blendChannels; ch < numChannels; ++ch) {
+        if (buffer[ch]) {
+            std::fill(buffer[ch], buffer[ch] + numFrames, 0.0f);
+        }
+    }
+}
+} // namespace
 
 EffectChain::EffectChain() = default;
 EffectChain::~EffectChain() = default;
@@ -74,6 +130,7 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
     m_slots[slotIndex].plugin = std::move(plugin);
     m_slots[slotIndex].bypassed.store(false);
     m_slots[slotIndex].dryWetMix.store(1.0f);
+    clearFaultState(m_slots[slotIndex].faultState);
 
     publishSnapshot();
     if (m_onLatencyChanged) {
@@ -92,6 +149,7 @@ PluginInstancePtr EffectChain::removePlugin(size_t slotIndex) {
 
     auto plugin = std::move(m_slots[slotIndex].plugin);
     m_slots[slotIndex].plugin = nullptr;
+    clearFaultState(m_slots[slotIndex].faultState);
 
     publishSnapshot();
     if (m_onLatencyChanged) {
@@ -120,10 +178,12 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
     m_slots[toSlot].plugin = std::move(m_slots[fromSlot].plugin);
     m_slots[toSlot].bypassed.store(m_slots[fromSlot].bypassed.load());
     m_slots[toSlot].dryWetMix.store(m_slots[fromSlot].dryWetMix.load());
+    copyFaultState(m_slots[toSlot].faultState, m_slots[fromSlot].faultState);
 
     m_slots[fromSlot].plugin = nullptr;
     m_slots[fromSlot].bypassed.store(false);
     m_slots[fromSlot].dryWetMix.store(1.0f);
+    clearFaultState(m_slots[fromSlot].faultState);
 
     publishSnapshot();
     return true;
@@ -142,6 +202,7 @@ bool EffectChain::swapPlugins(size_t slot1, size_t slot2) {
     }
 
     std::swap(m_slots[slot1].plugin, m_slots[slot2].plugin);
+    std::swap(m_slots[slot1].faultState, m_slots[slot2].faultState);
 
     bool bypass1 = m_slots[slot1].bypassed.load();
     float mix1 = m_slots[slot1].dryWetMix.load();
@@ -204,6 +265,7 @@ void EffectChain::clear() {
         slot.plugin = nullptr;
         slot.bypassed.store(false);
         slot.dryWetMix.store(1.0f);
+        clearFaultState(slot.faultState);
     }
     publishSnapshot();
 }
@@ -214,6 +276,9 @@ void EffectChain::clear() {
 
 void EffectChain::setSlotBypassed(size_t slotIndex, bool bypassed) {
     if (slotIndex < MAX_SLOTS) {
+        if (!bypassed) {
+            clearFaultState(m_slots[slotIndex].faultState);
+        }
         m_slots[slotIndex].bypassed.store(bypassed, std::memory_order_release);
         if (!reportRealtimeMisuse("EffectChain::setSlotBypassed")) {
             publishSnapshot();
@@ -228,7 +293,22 @@ bool EffectChain::isSlotBypassed(size_t slotIndex) const {
     if (slotIndex >= MAX_SLOTS) {
         return true;
     }
-    return m_slots[slotIndex].bypassed.load(std::memory_order_acquire);
+    return m_slots[slotIndex].bypassed.load(std::memory_order_acquire) ||
+           isFaultBypassed(m_slots[slotIndex].faultState);
+}
+
+bool EffectChain::isSlotBypassedByNonFiniteOutput(size_t slotIndex) const {
+    if (slotIndex >= MAX_SLOTS) {
+        return false;
+    }
+    return isFaultBypassed(m_slots[slotIndex].faultState);
+}
+
+uint64_t EffectChain::getSlotNonFiniteOutputCount(size_t slotIndex) const {
+    if (slotIndex >= MAX_SLOTS || !m_slots[slotIndex].faultState) {
+        return 0;
+    }
+    return m_slots[slotIndex].faultState->nonFiniteOutputCount.load(std::memory_order_acquire);
 }
 
 // ==============================
@@ -281,8 +361,8 @@ void EffectChain::prepare(double sampleRate, uint32_t maxBlockSize) {
     publishSnapshot();
 }
 
-void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFrames,
-                          const float* const* sidechainInputs, uint32_t numSidechainChannels) {
+void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFrames, const float* const* sidechainInputs,
+                          uint32_t numSidechainChannels) {
     // Skip if entire chain is bypassed
     if (m_chainBypassed.load(std::memory_order_acquire)) {
         return;
@@ -291,7 +371,7 @@ void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFram
     // Process each slot in sequence
     for (const auto& slot : m_slots) {
         // Skip empty or bypassed slots
-        if (slot.isEmpty() || slot.bypassed.load(std::memory_order_acquire)) {
+        if (slot.isEmpty() || slot.bypassed.load(std::memory_order_acquire) || isFaultBypassed(slot.faultState)) {
             continue;
         }
 
@@ -333,11 +413,11 @@ void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFram
             const bool processed =
                 processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
             if (!processed) {
-                for (uint32_t ch = 0; ch < numChannels; ++ch) {
-                    std::fill(buffer[ch], buffer[ch] + numFrames, 0.0f);
-                }
+                clearFloatBuffers(buffer, numChannels, numFrames);
+            } else if (!buffersAreFinite(buffer, numChannels, numFrames)) {
+                markNonFiniteOutputFault(slot.faultState);
+                clearFloatBuffers(buffer, numChannels, numFrames);
             }
-            sanitizeFloatBuffers(buffer, numChannels, numFrames);
         }
         // If not fully wet, need to blend
         else if (dryWet > 0.001f) {
@@ -346,13 +426,13 @@ void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFram
             if (m_dryBuffer.size() < requiredDry) {
                 // Not prepared (or prepared for a smaller block). Stay RT-safe: no allocation.
                 const bool processed =
-                processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
+                    processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
                 if (!processed) {
-                    for (uint32_t ch = 0; ch < numChannels; ++ch) {
-                        std::fill(buffer[ch], buffer[ch] + numFrames, 0.0f);
-                    }
+                    clearFloatBuffers(buffer, numChannels, numFrames);
+                } else if (!buffersAreFinite(buffer, numChannels, numFrames)) {
+                    markNonFiniteOutputFault(slot.faultState);
+                    clearFloatBuffers(buffer, numChannels, numFrames);
                 }
-                sanitizeFloatBuffers(buffer, numChannels, numFrames);
                 continue;
             }
 
@@ -364,12 +444,14 @@ void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFram
             const bool processed =
                 processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
             if (!processed) {
-                for (uint32_t ch = 0; ch < blendChannels; ++ch) {
-                    std::memcpy(buffer[ch], m_dryBuffer.data() + ch * numFrames, numFrames * sizeof(float));
-                }
+                restoreDryChannels(buffer, m_dryBuffer.data(), numChannels, blendChannels, numFrames);
                 continue;
             }
-            sanitizeFloatBuffers(buffer, numChannels, numFrames);
+            if (!buffersAreFinite(buffer, numChannels, numFrames)) {
+                markNonFiniteOutputFault(slot.faultState);
+                restoreDryChannels(buffer, m_dryBuffer.data(), numChannels, blendChannels, numFrames);
+                continue;
+            }
 
             // Blend dry/wet
             float wetGain = dryWet;
@@ -393,8 +475,8 @@ void EffectChain::process(float** buffer, uint32_t numChannels, uint32_t numFram
 // ==============================
 
 void EffectChainSnapshot::process(float** buffer, uint32_t numChannels, uint32_t numFrames,
-                                   const float* const* sidechainInputs, uint32_t numSidechainChannels,
-                                   float* dryBuffer) const {
+                                  const float* const* sidechainInputs, uint32_t numSidechainChannels,
+                                  float* dryBuffer) const {
     // Skip if entire chain is bypassed
     if (isChainBypassed) {
         return;
@@ -405,7 +487,7 @@ void EffectChainSnapshot::process(float** buffer, uint32_t numChannels, uint32_t
         const auto& slot = m_slots[slotIdx];
 
         // Skip empty or bypassed slots
-        if (slot.isEmpty() || slot.bypassed) {
+        if (slot.isEmpty() || slot.bypassed || isFaultBypassed(slot.faultState)) {
             continue;
         }
 
@@ -446,11 +528,11 @@ void EffectChainSnapshot::process(float** buffer, uint32_t numChannels, uint32_t
             const bool processed =
                 processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
             if (!processed) {
-                for (uint32_t ch = 0; ch < numChannels; ++ch) {
-                    std::fill(buffer[ch], buffer[ch] + numFrames, 0.0f);
-                }
+                clearFloatBuffers(buffer, numChannels, numFrames);
+            } else if (!buffersAreFinite(buffer, numChannels, numFrames)) {
+                markNonFiniteOutputFault(slot.faultState);
+                clearFloatBuffers(buffer, numChannels, numFrames);
             }
-            sanitizeFloatBuffers(buffer, numChannels, numFrames);
         }
         // If not fully wet, need to blend
         else if (dryWet > 0.001f) {
@@ -464,12 +546,14 @@ void EffectChainSnapshot::process(float** buffer, uint32_t numChannels, uint32_t
             const bool processed =
                 processPluginNoexcept(*plugin, processInputs, buffer, processInputChannels, numChannels, numFrames);
             if (!processed) {
-                for (uint32_t ch = 0; ch < blendChannels; ++ch) {
-                    std::memcpy(buffer[ch], dryBuffer + ch * numFrames, numFrames * sizeof(float));
-                }
+                restoreDryChannels(buffer, dryBuffer, numChannels, blendChannels, numFrames);
                 continue;
             }
-            sanitizeFloatBuffers(buffer, numChannels, numFrames);
+            if (!buffersAreFinite(buffer, numChannels, numFrames)) {
+                markNonFiniteOutputFault(slot.faultState);
+                restoreDryChannels(buffer, dryBuffer, numChannels, blendChannels, numFrames);
+                continue;
+            }
 
             // Blend dry/wet
             float wetGain = dryWet;
@@ -566,6 +650,7 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
         if (!hasPlugin) {
             m_slots[i].plugin = nullptr;
+            clearFaultState(m_slots[i].faultState);
             continue;
         }
 
@@ -614,14 +699,15 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
         if (instance) {
             instance->initialize(m_sampleRate, m_maxBlockSize);
             if (!instance->loadState(pluginState)) {
-                Aestra::Log::warning("[EffectChain] Failed to load state for plugin slot " +
-                                     std::to_string(i) + " — using default state");
+                Aestra::Log::warning("[EffectChain] Failed to load state for plugin slot " + std::to_string(i) +
+                                     " — using default state");
             }
             instance->activate();
 
             m_slots[i].plugin = std::move(instance);
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
+            clearFaultState(m_slots[i].faultState);
         }
     }
 
@@ -637,7 +723,7 @@ uint32_t EffectChain::getTotalLatency() const {
     uint32_t total = 0;
 
     for (const auto& slot : m_slots) {
-        if (!slot.isEmpty() && !slot.bypassed.load() && slot.plugin) {
+        if (!slot.isEmpty() && !slot.bypassed.load() && !isFaultBypassed(slot.faultState) && slot.plugin) {
             total += slot.plugin->getLatencySamples();
         }
     }

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -852,7 +852,7 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
         }
     } else {
         // Name line plus state indicators. Active state is shown by the purple dot;
-        // only bypass needs a text label.
+        // bypass and auto-quarantine need a text label.
         NUIColor nameColor = slot.bypassed ? Colors::textDisabled.withAlpha(0.6f) : Colors::textPrimary;
         if (slot.bypassed) {
             const NUIRect nameRect{textX, slotMid - rowH, textW, rowH};
@@ -869,10 +869,12 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
 
         if (slot.bypassed) {
             const NUIRect statusRect{textX, slotMid, textW, rowH};
-            renderer.drawText("Bypassed",
-                              {statusRect.x, statusRect.y + 2.0f},
-                              8.5f,
-                              Colors::textDisabled.withAlpha(0.72f));
+            const bool autoFaulted = slot.nonFiniteOutputFault;
+            const char* statusText = autoFaulted ? "Output fault" : "Bypassed";
+            const NUIColor statusColor = autoFaulted
+                                             ? NUIThemeManager::getInstance().getColor("warning").withAlpha(0.92f)
+                                             : Colors::textDisabled.withAlpha(0.72f);
+            renderer.drawText(statusText, {statusRect.x, statusRect.y + 2.0f}, 8.5f, statusColor);
         }
 
         // Active indicator / Bypass toggle

--- a/AestraUI/Widgets/PluginBrowserPanel.h
+++ b/AestraUI/Widgets/PluginBrowserPanel.h
@@ -277,6 +277,7 @@ public:
         bool isEmpty = true;    ///< No plugin loaded
         float dryWet = 1.0f;    ///< Dry/Wet mix (0.0 - 1.0), default 1.0 (Wet)
         bool pendingRemoval = false; ///< UI is waiting for engine to confirm removal
+        bool nonFiniteOutputFault = false; ///< Auto-bypassed after unsafe plugin output
     };
 
     EffectChainRack();

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -266,10 +266,12 @@ void PluginUIController::refreshRackDisplay(EffectChainRack* rack) {
             info.name = instance->getInfo().name;
             info.isEmpty = false;
             info.bypassed = chain->isSlotBypassed(i);
+            info.nonFiniteOutputFault = chain->isSlotBypassedByNonFiniteOutput(i);
         } else {
             info.name = "Empty";
             info.isEmpty = true;
             info.bypassed = false;
+            info.nonFiniteOutputFault = false;
         }
         
         rack->setSlot(i, info);

--- a/Tests/AestraAudio/EffectChainSnapshotTest.cpp
+++ b/Tests/AestraAudio/EffectChainSnapshotTest.cpp
@@ -5,14 +5,16 @@
 #include "Plugin/SamplerPlugin.h"
 #include "RealtimeThreadGuard.h"
 
+#include <array>
 #include <atomic>
+#include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <vector>
-
-#include <cassert>
-#define require(cond, msg) assert(cond && msg)
+#define require(cond, msg) assert((cond) && (msg))
 
 using namespace Aestra::Audio;
 
@@ -22,6 +24,98 @@ std::atomic<int> g_rtMisuseCount{0};
 void countRtMisuse(const char*) noexcept {
     g_rtMisuseCount.fetch_add(1, std::memory_order_relaxed);
 }
+
+class TestEffectPlugin : public IPluginInstance {
+public:
+    explicit TestEffectPlugin(const char* id) {
+        m_info.id = id;
+        m_info.name = id;
+        m_info.vendor = "Aestra Tests";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override { m_active = true; }
+    void deactivate() override { m_active = false; }
+    bool isActive() const override { return m_active; }
+
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+protected:
+    PluginInfo m_info;
+    bool m_active = false;
+};
+
+class NonFiniteOutputPlugin final : public TestEffectPlugin {
+public:
+    NonFiniteOutputPlugin() : TestEffectPlugin("test.nonfinite-output") {}
+
+    void process(const float* const*, float** outputs, uint32_t, uint32_t numOutputChannels, uint32_t numFrames,
+                 const MidiBuffer*, MidiBuffer*) override {
+        ++processCalls;
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                outputs[ch][i] = std::numeric_limits<float>::quiet_NaN();
+            }
+        }
+    }
+
+    int processCalls = 0;
+};
+
+class FiniteProbePlugin final : public TestEffectPlugin {
+public:
+    FiniteProbePlugin() : TestEffectPlugin("test.finite-probe") {}
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer*, MidiBuffer*) override {
+        ++processCalls;
+        for (uint32_t ch = 0; ch < numInputChannels; ++ch) {
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                if (!std::isfinite(inputs[ch][i])) {
+                    sawNonFiniteInput = true;
+                }
+            }
+        }
+
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                outputs[ch][i] = 0.25f;
+            }
+        }
+    }
+
+    int processCalls = 0;
+    bool sawNonFiniteInput = false;
+};
 
 void emptyChainSnapshotHasNoPlugins() {
     EffectChain chain;
@@ -260,6 +354,59 @@ void snapshotPublicationAfterAllMutations() {
     std::cout << "PASS: snapshotPublicationAfterAllMutations\n";
 }
 
+void snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing() {
+    constexpr uint32_t kChannels = 2;
+    constexpr uint32_t kFrames = 8;
+
+    EffectChain chain;
+    chain.prepare(48000.0, kFrames);
+
+    auto poison = std::make_shared<NonFiniteOutputPlugin>();
+    auto probe = std::make_shared<FiniteProbePlugin>();
+    chain.insertPlugin(0, poison);
+    chain.insertPlugin(1, probe);
+
+    auto snapshot = chain.getSnapshot();
+    require(snapshot != nullptr, "snapshotQuarantinesNonFinitePlugin: snapshot is null");
+
+    std::array<float, kFrames> left{};
+    std::array<float, kFrames> right{};
+    for (uint32_t i = 0; i < kFrames; ++i) {
+        left[i] = 0.5f;
+        right[i] = -0.5f;
+    }
+
+    float* channels[kChannels] = {left.data(), right.data()};
+    std::array<float, kFrames * kChannels> dryBuffer{};
+
+    snapshot->process(channels, kChannels, kFrames, nullptr, 0, dryBuffer.data());
+
+    require(poison->processCalls == 1, "snapshotQuarantinesNonFinitePlugin: poison not processed once");
+    require(probe->processCalls == 1, "snapshotQuarantinesNonFinitePlugin: downstream not processed");
+    require(!probe->sawNonFiniteInput, "snapshotQuarantinesNonFinitePlugin: downstream saw non-finite input");
+    require(chain.isSlotBypassed(0), "snapshotQuarantinesNonFinitePlugin: poisoned slot not bypassed");
+    require(chain.isSlotBypassedByNonFiniteOutput(0),
+            "snapshotQuarantinesNonFinitePlugin: poisoned slot missing non-finite fault");
+    require(chain.getSlotNonFiniteOutputCount(0) == 1, "snapshotQuarantinesNonFinitePlugin: fault count mismatch");
+    for (uint32_t ch = 0; ch < kChannels; ++ch) {
+        for (uint32_t i = 0; i < kFrames; ++i) {
+            require(std::isfinite(channels[ch][i]), "snapshotQuarantinesNonFinitePlugin: output is non-finite");
+            require(channels[ch][i] == 0.25f, "snapshotQuarantinesNonFinitePlugin: downstream output mismatch");
+        }
+    }
+
+    snapshot->process(channels, kChannels, kFrames, nullptr, 0, dryBuffer.data());
+    require(poison->processCalls == 1, "snapshotQuarantinesNonFinitePlugin: quarantined plugin processed again");
+    require(probe->processCalls == 2,
+            "snapshotQuarantinesNonFinitePlugin: downstream should keep processing after quarantine");
+
+    chain.setSlotBypassed(0, false);
+    require(!chain.isSlotBypassedByNonFiniteOutput(0),
+            "snapshotQuarantinesNonFinitePlugin: manual unbypass did not clear fault");
+
+    std::cout << "PASS: snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing\n";
+}
+
 } // namespace
 
 int main() {
@@ -275,6 +422,7 @@ int main() {
     realtimeMisuseGuardsStillWork();
     getSnapshotReturnsPublishedSnapshot();
     snapshotPublicationAfterAllMutations();
+    snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing();
 
     std::cout << "\n=== All EffectChainSnapshot tests passed ===\n";
     return 0;

--- a/Tests/AestraAudio/EffectChainSnapshotTest.cpp
+++ b/Tests/AestraAudio/EffectChainSnapshotTest.cpp
@@ -407,6 +407,69 @@ void snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing() {
     std::cout << "PASS: snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing\n";
 }
 
+void movedPluginCarriesFaultStateForInFlightSnapshots() {
+    constexpr uint32_t kChannels = 2;
+    constexpr uint32_t kFrames = 8;
+
+    EffectChain chain;
+    chain.prepare(48000.0, kFrames);
+
+    auto poison = std::make_shared<NonFiniteOutputPlugin>();
+    chain.insertPlugin(0, poison);
+
+    auto inFlightSnapshot = chain.getSnapshot();
+    require(inFlightSnapshot != nullptr, "movedPluginCarriesFaultState: snapshot is null");
+
+    require(chain.movePlugin(0, 2), "movedPluginCarriesFaultState: move failed");
+    require(!chain.isSlotBypassedByNonFiniteOutput(2), "movedPluginCarriesFaultState: destination pre-faulted");
+
+    std::array<float, kFrames> left{};
+    std::array<float, kFrames> right{};
+    float* channels[kChannels] = {left.data(), right.data()};
+    std::array<float, kFrames * kChannels> dryBuffer{};
+
+    inFlightSnapshot->process(channels, kChannels, kFrames, nullptr, 0, dryBuffer.data());
+
+    require(poison->processCalls == 1, "movedPluginCarriesFaultState: in-flight snapshot did not process poison");
+    require(chain.isSlotBypassedByNonFiniteOutput(2),
+            "movedPluginCarriesFaultState: moved plugin destination did not receive in-flight fault");
+    require(!chain.isSlotBypassedByNonFiniteOutput(0),
+            "movedPluginCarriesFaultState: empty source slot received moved plugin fault");
+
+    std::cout << "PASS: movedPluginCarriesFaultStateForInFlightSnapshots\n";
+}
+
+void replacingPluginIsolatedFromInFlightSnapshotFaults() {
+    constexpr uint32_t kChannels = 2;
+    constexpr uint32_t kFrames = 8;
+
+    EffectChain chain;
+    chain.prepare(48000.0, kFrames);
+
+    auto oldPoison = std::make_shared<NonFiniteOutputPlugin>();
+    auto replacement = std::make_shared<FiniteProbePlugin>();
+    chain.insertPlugin(0, oldPoison);
+
+    auto inFlightSnapshot = chain.getSnapshot();
+    require(inFlightSnapshot != nullptr, "replacingPluginIsolated: snapshot is null");
+
+    require(chain.insertPlugin(0, replacement), "replacingPluginIsolated: replacement insert failed");
+    require(!chain.isSlotBypassedByNonFiniteOutput(0), "replacingPluginIsolated: replacement pre-faulted");
+
+    std::array<float, kFrames> left{};
+    std::array<float, kFrames> right{};
+    float* channels[kChannels] = {left.data(), right.data()};
+    std::array<float, kFrames * kChannels> dryBuffer{};
+
+    inFlightSnapshot->process(channels, kChannels, kFrames, nullptr, 0, dryBuffer.data());
+
+    require(oldPoison->processCalls == 1, "replacingPluginIsolated: in-flight snapshot did not process old plugin");
+    require(!chain.isSlotBypassedByNonFiniteOutput(0),
+            "replacingPluginIsolated: stale snapshot fault quarantined replacement plugin");
+
+    std::cout << "PASS: replacingPluginIsolatedFromInFlightSnapshotFaults\n";
+}
+
 } // namespace
 
 int main() {
@@ -423,6 +486,8 @@ int main() {
     getSnapshotReturnsPublishedSnapshot();
     snapshotPublicationAfterAllMutations();
     snapshotQuarantinesNonFinitePluginBeforeDownstreamProcessing();
+    movedPluginCarriesFaultStateForInFlightSnapshots();
+    replacingPluginIsolatedFromInFlightSnapshotFaults();
 
     std::cout << "\n=== All EffectChainSnapshot tests passed ===\n";
     return 0;


### PR DESCRIPTION
Closes #248

Summary:
- Adds per-slot RT-visible non-finite output fault state shared with effect-chain snapshots.
- Quarantines a plugin immediately when its output contains NaN/Inf, clears or restores the current block before downstream plugins run, and skips the plugin on later blocks.
- Exposes the fault state to the rack UI so auto-bypassed inserts show `Output fault` instead of only a generic bypass label.

Testing:
- `cmake --build build --parallel 2`
- `ctest --test-dir build -R "AestraEffectChainSnapshotTest|AestraPluginGraphInvalidationTest|AestraMixerChannelScratchBufferTest|AestraAudioQualityRegressionTest" --output-on-failure`
- `git diff --check`

Notes:
- The build emitted pre-existing unsigned-comparison warnings in `Tests/AestraAudio/TrackManagerStressTest.cpp`; no new warnings were observed from this patch.