### PR TITLE
sprint2: Plugin crash protection Linux-only

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -92,6 +92,7 @@ if(EXISTS ${VST3_SDK_DIR}/pluginterfaces AND EXISTS ${VST3_SDK_DIR}/public.sdk)
     set(VST3_HOST_SOURCES
         ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module.cpp
         ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/hostclasses.cpp
+        ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/pluginterfacesupport.cpp
         ${VST3_SDK_DIR}/public.sdk/source/vst/hosting/plugprovider.cpp
         ${VST3_SDK_DIR}/public.sdk/source/common/memorystream.cpp
         ${VST3_SDK_DIR}/public.sdk/source/vst/utility/stringconvert.cpp
@@ -530,6 +531,11 @@ set_target_properties(AestraPluginHost PROPERTIES
 
 if(AESTRA_ENABLE_TESTS)
     target_compile_definitions(AestraPluginHost PRIVATE AESTRA_ENABLE_TEST_HOOKS)
+endif()
+
+if(AESTRA_HAS_VST3)
+    target_compile_definitions(AestraPluginHost PRIVATE AESTRA_HAS_VST3)
+    target_link_libraries(AestraPluginHost PRIVATE AestraAudioCore)
 endif()
 
 # ENFORCEMENT: AestraAudioCore MUST NOT link Windows libraries

--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -52,9 +52,9 @@ public:
     uint32_t getLatencySamples() const override { return m_maxBlockSize; }
     uint32_t getTailSamples() const override { return 0; }
 
-    WatchdogStats getWatchdogStats() const override { return m_watchdogStats; }
+    WatchdogStats getWatchdogStats() const override;
     void resetWatchdog() override;
-    bool isBypassedByWatchdog() const override { return m_watchdogStats.isBypassed; }
+    bool isBypassedByWatchdog() const override;
     bool isCrashed() const override { return m_crashed.load(std::memory_order_acquire); }
 
 private:
@@ -76,7 +76,10 @@ private:
     std::atomic<bool> m_loaded{false};
     std::atomic<bool> m_active{false};
     std::atomic<bool> m_crashed{false};
-    WatchdogStats m_watchdogStats;
+    std::atomic<uint64_t> m_watchdogMaxExecutionTimeNs{0};
+    std::atomic<uint64_t> m_watchdogAvgExecutionTimeNs{0};
+    std::atomic<uint64_t> m_watchdogViolationCount{0};
+    std::atomic<bool> m_watchdogBypassed{false};
 
     double m_sampleRate = 44100.0;
     uint32_t m_maxBlockSize = 0;

--- a/AestraAudio/include/Plugin/VST3Host.h
+++ b/AestraAudio/include/Plugin/VST3Host.h
@@ -3,6 +3,7 @@
 
 #include "PluginHost.h"
 
+#include <atomic>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -95,20 +96,23 @@ public:
     uint32_t getTailSamples() const override;
 
     // Watchdog implementation
-    WatchdogStats getWatchdogStats() const override { return m_watchdogStats; }
+    WatchdogStats getWatchdogStats() const override;
     void resetWatchdog() override;
-    bool isBypassedByWatchdog() const override { return m_watchdogStats.isBypassed; }
-    bool isCrashed() const override { return m_crashed; }
+    bool isBypassedByWatchdog() const override;
+    bool isCrashed() const override;
 
 private:
     bool m_loaded = false;
     bool m_active = false;
     bool m_editorOpen = false;
-    bool m_crashed = false;
 
     // Watchdog state
-    WatchdogStats m_watchdogStats;
     static constexpr uint64_t WATCHDOG_VIOLATION_LIMIT = 50; // Bypass after 50 violations
+    std::atomic<uint64_t> m_watchdogMaxExecutionTimeNs{0};
+    std::atomic<uint64_t> m_watchdogAvgExecutionTimeNs{0};
+    std::atomic<uint64_t> m_watchdogViolationCount{0};
+    std::atomic<bool> m_watchdogBypassed{false};
+    std::atomic<bool> m_crashed{false};
 
     PluginInfo m_info;
 
@@ -116,12 +120,13 @@ private:
     uint32_t m_maxBlockSize = 512;
 
     // VST3 SDK objects (using void* to avoid header pollution, cast in .cpp)
-    void* m_module = nullptr;     // VST3::Hosting::Module
-    void* m_factory = nullptr;    // IPluginFactory*
-    void* m_component = nullptr;  // IComponent*
-    void* m_processor = nullptr;  // IAudioProcessor*
-    void* m_controller = nullptr; // IEditController*
-    void* m_plugView = nullptr;   // IPlugView* (editor)
+    void* m_module = nullptr;          // VST3::Hosting::Module
+    void* m_factory = nullptr;         // IPluginFactory*
+    void* m_hostApplication = nullptr; // VST3::HostApplication
+    void* m_component = nullptr;       // IComponent*
+    void* m_processor = nullptr;       // IAudioProcessor*
+    void* m_controller = nullptr;      // IEditController*
+    void* m_plugView = nullptr;        // IPlugView* (editor)
 
     // Audio buffers for VST3 ProcessData
     std::vector<float*> m_inputBuffers;
@@ -135,6 +140,10 @@ private:
     // Internal helpers
     void buildParameterCache() const;
     void setupProcessing();
+    void reportDeferredRealtimeEvents() const;
+
+    mutable std::atomic<bool> m_watchdogReportPending{false};
+    mutable std::atomic<bool> m_crashReportPending{false};
 };
 
 /**

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -11,6 +11,10 @@
 #include <string>
 #include <vector>
 
+#ifdef AESTRA_HAS_VST3
+#include "Plugin/VST3Host.h"
+#endif
+
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -579,6 +583,154 @@ struct ClapModule {
 };
 #endif
 
+#ifdef AESTRA_HAS_VST3
+struct Vst3Module {
+    std::shared_ptr<Aestra::Audio::VST3PluginInstance> plugin;
+    uint32_t maxBlockSize = 0;
+    std::vector<float> inputStorage[2];
+    std::vector<float> outputStorage[2];
+    Aestra::Audio::MidiBuffer midiInput;
+
+    ~Vst3Module() { close(); }
+
+    Vst3Module() = default;
+    Vst3Module(const Vst3Module&) = delete;
+    Vst3Module& operator=(const Vst3Module&) = delete;
+
+    void close() {
+        if (plugin) {
+            plugin->shutdown();
+            plugin->unload();
+            plugin.reset();
+        }
+        maxBlockSize = 0;
+        for (auto& storage : inputStorage) {
+            storage.clear();
+        }
+        for (auto& storage : outputStorage) {
+            storage.clear();
+        }
+        midiInput.clear();
+    }
+
+    bool load(const std::string& path, const std::string& pluginId, std::string& error) {
+        close();
+
+        Aestra::Audio::PluginInfo info;
+        info.id = pluginId;
+        info.name = pluginId;
+        info.vendor = "Unknown";
+        info.version = {};
+        info.category = {};
+        info.format = Aestra::Audio::PluginFormat::VST3;
+        info.type = Aestra::Audio::PluginType::Effect;
+        info.path = path;
+        info.numAudioInputs = 2;
+        info.numAudioOutputs = 2;
+
+        plugin = Aestra::Audio::VST3PluginFactory::createInstance(info);
+        if (!plugin || !plugin->isLoaded()) {
+            plugin.reset();
+            error = "vst3-load-failed";
+            return false;
+        }
+        return true;
+    }
+
+    bool initialize(double sampleRate, uint32_t blockSize, std::string& error) {
+        if (!plugin || sampleRate <= 0.0 || blockSize == 0 || blockSize > 65536) {
+            error = "invalid-vst3-init";
+            return false;
+        }
+        if (!plugin->initialize(sampleRate, blockSize)) {
+            error = "vst3-initialize-failed";
+            return false;
+        }
+        maxBlockSize = blockSize;
+        for (auto& storage : inputStorage) {
+            storage.assign(maxBlockSize, 0.0f);
+        }
+        for (auto& storage : outputStorage) {
+            storage.assign(maxBlockSize, 0.0f);
+        }
+        return true;
+    }
+
+    bool activate() {
+        if (!plugin) {
+            return false;
+        }
+        plugin->activate();
+        return plugin->isActive();
+    }
+
+    void deactivate() {
+        if (plugin) {
+            plugin->deactivate();
+        }
+    }
+
+    bool process(const std::vector<float>& interleavedInput, uint32_t channels, uint32_t frames,
+                 const std::vector<uint8_t>* midiData, size_t midiBytes, std::vector<float>& interleavedOutput) {
+        if (!plugin || !plugin->isActive() || channels == 0 || channels > 2 || frames == 0 || frames > maxBlockSize ||
+            interleavedInput.size() < static_cast<size_t>(channels) * frames) {
+            return false;
+        }
+
+        for (uint32_t ch = 0; ch < 2; ++ch) {
+            std::fill(outputStorage[ch].begin(), outputStorage[ch].begin() + frames, 0.0f);
+            for (uint32_t frame = 0; frame < frames; ++frame) {
+                inputStorage[ch][frame] =
+                    (ch < channels) ? interleavedInput[static_cast<size_t>(frame) * channels + ch] : 0.0f;
+            }
+        }
+
+        midiInput.clear();
+        if (midiData && midiBytes <= midiData->size() && (midiBytes % 8) == 0) {
+            for (size_t offset = 0; offset < midiBytes; offset += 8) {
+                const uint8_t size = (*midiData)[offset + 4];
+                if (size == 0 || size > 3) {
+                    continue;
+                }
+                uint32_t sampleOffset = 0;
+                std::memcpy(&sampleOffset, midiData->data() + offset, sizeof(sampleOffset));
+                midiInput.addEvent(std::min<uint32_t>(sampleOffset, frames - 1), midiData->data() + offset + 5, size);
+            }
+        }
+
+        const float* inputPlanes[2] = {inputStorage[0].data(), inputStorage[1].data()};
+        float* outputPlanes[2] = {outputStorage[0].data(), outputStorage[1].data()};
+        plugin->process(inputPlanes, outputPlanes, channels, channels, frames,
+                        midiInput.isEmpty() ? nullptr : &midiInput, nullptr);
+        if (plugin->isCrashed()) {
+            return false;
+        }
+
+        interleavedOutput.resize(static_cast<size_t>(channels) * frames);
+        for (uint32_t frame = 0; frame < frames; ++frame) {
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                interleavedOutput[static_cast<size_t>(frame) * channels + ch] = outputStorage[ch][frame];
+            }
+        }
+        return true;
+    }
+
+    std::vector<uint8_t> saveState() const {
+        if (!plugin) {
+            return {};
+        }
+        return plugin->saveState();
+    }
+
+    bool loadState(const std::vector<uint8_t>& stateData) {
+        if (!plugin) {
+            return false;
+        }
+        return plugin->loadState(stateData);
+    }
+};
+#endif
+
 int hexValue(char c) {
     if (c >= '0' && c <= '9')
         return c - '0';
@@ -696,6 +848,9 @@ int main(int argc, char** argv) {
 #ifndef _WIN32
     ClapModule clapModule;
 #endif
+#ifdef AESTRA_HAS_VST3
+    Vst3Module vst3Module;
+#endif
 
     while (std::getline(std::cin, line)) {
         std::istringstream input(line);
@@ -764,6 +919,9 @@ int main(int argc, char** argv) {
             }
 #ifndef _WIN32
             if (format == "clap" && id != "__aestra_test_echo__") {
+#ifdef AESTRA_HAS_VST3
+                vst3Module.close();
+#endif
                 std::string error;
                 if (!clapModule.load(path, id, error)) {
                     reply("ERR " + error);
@@ -771,6 +929,20 @@ int main(int argc, char** argv) {
                 }
             } else {
                 clapModule.close();
+            }
+#endif
+#ifdef AESTRA_HAS_VST3
+            if (format == "vst3" && id != "__aestra_test_echo__") {
+#ifndef _WIN32
+                clapModule.close();
+#endif
+                std::string error;
+                if (!vst3Module.load(path, id, error)) {
+                    reply("ERR " + error);
+                    continue;
+                }
+            } else {
+                vst3Module.close();
             }
 #endif
             loaded = true;
@@ -795,18 +967,36 @@ int main(int argc, char** argv) {
                 }
             }
 #endif
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin) {
+                std::string error;
+                if (!vst3Module.initialize(sampleRate, maxBlockSize, error)) {
+                    reply("ERR " + error);
+                    continue;
+                }
+            }
+#endif
             reply("OK INIT");
         } else if (command == "ACTIVATE") {
             if (!loaded) {
                 reply("ERR not-loaded");
                 continue;
             }
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin && !vst3Module.activate()) {
+                reply("ERR vst3-activate-failed");
+                continue;
+            }
+#endif
             active = true;
             reply("OK ACTIVE");
         } else if (command == "DEACTIVATE") {
             active = false;
 #ifndef _WIN32
             clapModule.deactivate();
+#endif
+#ifdef AESTRA_HAS_VST3
+            vst3Module.deactivate();
 #endif
             reply("OK INACTIVE");
         } else if (command == "SAVESTATE") {
@@ -821,6 +1011,13 @@ int main(int argc, char** argv) {
                     reply("ERR state-unavailable");
                     continue;
                 }
+                reply("OK " + hexEncodeBytes(stateBuffer.data(), stateBuffer.size()));
+                continue;
+            }
+#endif
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin) {
+                stateBuffer = vst3Module.saveState();
                 reply("OK " + hexEncodeBytes(stateBuffer.data(), stateBuffer.size()));
                 continue;
             }
@@ -847,6 +1044,16 @@ int main(int argc, char** argv) {
                 continue;
             }
 #endif
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin) {
+                if (!vst3Module.loadState(stateBuffer)) {
+                    reply("ERR state-load-failed");
+                    continue;
+                }
+                reply("OK STATE");
+                continue;
+            }
+#endif
             reply(stateBuffer.empty() ? "OK STATE" : "ERR state-unavailable");
         } else if (command == "SHUTDOWN") {
             active = false;
@@ -854,10 +1061,16 @@ int main(int argc, char** argv) {
 #ifndef _WIN32
             clapModule.close();
 #endif
+#ifdef AESTRA_HAS_VST3
+            vst3Module.close();
+#endif
             reply("OK SHUTDOWN");
         } else if (command == "EXIT") {
 #ifndef _WIN32
             clapModule.close();
+#endif
+#ifdef AESTRA_HAS_VST3
+            vst3Module.close();
 #endif
             reply("OK EXIT");
             return 0;
@@ -897,6 +1110,19 @@ int main(int argc, char** argv) {
                 const std::vector<uint8_t>* midiData = midiBuffer.empty() ? nullptr : &midiBuffer;
                 if (!clapModule.process(processBuffer, channels, frames, midiData, midiBuffer.size(), processed)) {
                     reply("ERR clap-process-failed");
+                    continue;
+                }
+                const size_t byteCount = static_cast<size_t>(channels) * frames * sizeof(float);
+                reply("OK " + hexEncodeBytes(processed.data(), byteCount));
+                continue;
+            }
+#endif
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin) {
+                std::vector<float> processed;
+                const std::vector<uint8_t>* midiData = midiBuffer.empty() ? nullptr : &midiBuffer;
+                if (!vst3Module.process(processBuffer, channels, frames, midiData, midiBuffer.size(), processed)) {
+                    reply("ERR vst3-process-failed");
                     continue;
                 }
                 const size_t byteCount = static_cast<size_t>(channels) * frames * sizeof(float);

--- a/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
+++ b/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
@@ -522,8 +522,24 @@ bool OutOfProcessPluginInstance::resizeEditor(int width, int height) {
     return false;
 }
 
+IPluginInstance::WatchdogStats OutOfProcessPluginInstance::getWatchdogStats() const {
+    WatchdogStats stats;
+    stats.maxExecutionTimeNs = static_cast<double>(m_watchdogMaxExecutionTimeNs.load(std::memory_order_relaxed));
+    stats.avgExecutionTimeNs = static_cast<double>(m_watchdogAvgExecutionTimeNs.load(std::memory_order_relaxed));
+    stats.violationCount = m_watchdogViolationCount.load(std::memory_order_relaxed);
+    stats.isBypassed = m_watchdogBypassed.load(std::memory_order_acquire);
+    return stats;
+}
+
+bool OutOfProcessPluginInstance::isBypassedByWatchdog() const {
+    return m_watchdogBypassed.load(std::memory_order_acquire);
+}
+
 void OutOfProcessPluginInstance::resetWatchdog() {
-    m_watchdogStats = WatchdogStats{};
+    m_watchdogMaxExecutionTimeNs.store(0, std::memory_order_release);
+    m_watchdogAvgExecutionTimeNs.store(0, std::memory_order_release);
+    m_watchdogViolationCount.store(0, std::memory_order_release);
+    m_watchdogBypassed.store(false, std::memory_order_release);
     if (m_process && m_process->isRunning()) {
         m_crashed.store(false, std::memory_order_release);
     }
@@ -636,8 +652,8 @@ bool OutOfProcessPluginInstance::processBlockInHelper(const std::vector<float>& 
 void OutOfProcessPluginInstance::markCrashed() {
     m_crashed.store(true, std::memory_order_release);
     m_active.store(false, std::memory_order_release);
-    m_watchdogStats.isBypassed = true;
-    m_watchdogStats.violationCount++;
+    m_watchdogBypassed.store(true, std::memory_order_release);
+    m_watchdogViolationCount.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void OutOfProcessPluginInstance::passThrough(const float* const* inputs, float** outputs, uint32_t numInputChannels,

--- a/AestraAudio/src/Plugin/VST3Host.cpp
+++ b/AestraAudio/src/Plugin/VST3Host.cpp
@@ -13,8 +13,8 @@
 
 // VST3 SDK includes
 #include "pluginterfaces/base/funknown.h"
-#include "pluginterfaces/base/ipluginbase.h"
 #include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/base/ipluginbase.h"
 #include "pluginterfaces/gui/iplugview.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 #include "pluginterfaces/vst/ivstcomponent.h"
@@ -69,6 +69,8 @@ static bool SafeProcessCall(IAudioProcessor* processor, ProcessData& data) {
         return false; // Crashed
     }
 #else
+    // POSIX signal recovery is process-global and not realtime-safe. Linux/macOS
+    // crash containment is provided by OutOfProcessPluginInstance instead.
     processor->process(data);
     return true;
 #endif
@@ -117,6 +119,8 @@ bool VST3PluginInstance::load(const std::filesystem::path& path, int classIndex)
 
         m_module = new VST3::Hosting::Module::Ptr(std::move(module));
         auto& mod = *static_cast<VST3::Hosting::Module::Ptr*>(m_module);
+        m_hostApplication = new HostApplication();
+        auto hostApplication = static_cast<HostApplication*>(m_hostApplication);
 
         // Get the factory
         auto factory = mod->getFactory();
@@ -172,7 +176,7 @@ bool VST3PluginInstance::load(const std::filesystem::path& path, int classIndex)
 
         // Initialize component
         auto comp = static_cast<IComponent*>(m_component);
-        if (comp->initialize(nullptr) != kResultOk) {
+        if (comp->initialize(hostApplication) != kResultOk) {
             Log::error("VST3: Failed to initialize component: " + m_info.name);
             unload();
             return false;
@@ -196,7 +200,7 @@ bool VST3PluginInstance::load(const std::filesystem::path& path, int classIndex)
                 if (editController) {
                     m_controller = editController.take();
                     auto ctrl = static_cast<IEditController*>(m_controller);
-                    ctrl->initialize(nullptr);
+                    ctrl->initialize(hostApplication);
                 }
             }
         }
@@ -207,15 +211,11 @@ bool VST3PluginInstance::load(const std::filesystem::path& path, int classIndex)
         m_info.numAudioInputs = discoveredInputs > 0 ? discoveredInputs : 2;
         m_info.numAudioOutputs = discoveredOutputs > 0 ? discoveredOutputs : 2;
 
-        // Check for editor
-        if (m_controller) {
-            auto ctrl = static_cast<IEditController*>(m_controller);
-            auto view = ctrl->createView("editor");
-            m_info.hasEditor = (view != nullptr);
-            if (view) {
-                view->release();
-            }
-        }
+        // Do not instantiate the editor during plugin load. Some Linux VST3s
+        // allocate UI/toolkit state or crash when createView() is called from a
+        // headless scan/load path. openEditor()/getEditorSize() create the view
+        // only when the UI explicitly requests it.
+        m_info.hasEditor = (m_controller != nullptr);
 
         m_loaded = true;
         Log::info("VST3: Loaded plugin: " + m_info.name + " (" + m_info.vendor + ")");
@@ -266,6 +266,11 @@ void VST3PluginInstance::unload() {
     if (m_module) {
         delete static_cast<VST3::Hosting::Module::Ptr*>(m_module);
         m_module = nullptr;
+    }
+
+    if (m_hostApplication) {
+        delete static_cast<HostApplication*>(m_hostApplication);
+        m_hostApplication = nullptr;
     }
 
     m_loaded = false;
@@ -337,7 +342,7 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
     }
 
     // Watchdog Check
-    if (m_watchdogStats.isBypassed || m_crashed) {
+    if (m_watchdogBypassed.load(std::memory_order_acquire) || m_crashed.load(std::memory_order_acquire)) {
         // Clear outputs to silence
         for (uint32_t i = 0; i < numOutputChannels; ++i) {
             if (outputs[i]) {
@@ -379,12 +384,18 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
         int32 count = 0;
 
         tresult addEvent(Event& e) override {
-            if (count < 256) { events[count++] = e; return kResultOk; }
+            if (count < 256) {
+                events[count++] = e;
+                return kResultOk;
+            }
             return kOutOfMemory;
         }
         int32 getEventCount() override { return count; }
         tresult getEvent(int32 index, Event& e) override {
-            if (index >= 0 && index < count) { e = events[index]; return kResultOk; }
+            if (index >= 0 && index < count) {
+                e = events[index];
+                return kResultOk;
+            }
             return kInvalidArgument;
         }
         uint32 addRef() override { return 1; }
@@ -436,12 +447,18 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
         int32 count = 0;
 
         tresult addEvent(Event& e) override {
-            if (count < 256) { events[count++] = e; return kResultOk; }
+            if (count < 256) {
+                events[count++] = e;
+                return kResultOk;
+            }
             return kOutOfMemory;
         }
         int32 getEventCount() override { return count; }
         tresult getEvent(int32 index, Event& e) override {
-            if (index >= 0 && index < count) { e = events[index]; return kResultOk; }
+            if (index >= 0 && index < count) {
+                e = events[index];
+                return kResultOk;
+            }
             return kInvalidArgument;
         }
         uint32 addRef() override { return 1; }
@@ -456,12 +473,8 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
     bool success = SafeProcessCall(processor, data);
 
     if (!success) {
-        m_crashed = true;
-#ifdef _WIN32
-        Log::error("VST3: CRASH DETECTED in " + m_info.name + "! (Access Violation trapped)");
-#else
-        Log::error("VST3: Crash detected (Signal trapped)");
-#endif
+        m_crashed.store(true, std::memory_order_release);
+        m_crashReportPending.store(true, std::memory_order_release);
 
         // Silence output buffers immediately
         for (uint32_t i = 0; i < numOutputChannels; ++i) {
@@ -473,13 +486,24 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
 
     auto endTime = std::chrono::high_resolution_clock::now();
     double durationNs = std::chrono::duration<double, std::nano>(endTime - startTime).count();
+    const auto durationNsU64 = durationNs > 0.0 ? static_cast<uint64_t>(durationNs) : 0;
 
     // Update stats
-    if (durationNs > m_watchdogStats.maxExecutionTimeNs) {
-        m_watchdogStats.maxExecutionTimeNs = durationNs;
+    if (durationNsU64 > m_watchdogMaxExecutionTimeNs.load(std::memory_order_relaxed)) {
+        m_watchdogMaxExecutionTimeNs.store(durationNsU64, std::memory_order_relaxed);
+    }
+
+    const auto previousAvg = m_watchdogAvgExecutionTimeNs.load(std::memory_order_relaxed);
+    uint64_t nextAvg = durationNsU64;
+    if (previousAvg != 0) {
+        if (durationNsU64 > previousAvg) {
+            nextAvg = previousAvg + ((durationNsU64 - previousAvg) / 100);
+        } else {
+            nextAvg = previousAvg - ((previousAvg - durationNsU64) / 100);
+        }
     }
     // Exponential moving average (alpha ~ 0.01)
-    m_watchdogStats.avgExecutionTimeNs = m_watchdogStats.avgExecutionTimeNs * 0.99 + durationNs * 0.01;
+    m_watchdogAvgExecutionTimeNs.store(nextAvg, std::memory_order_relaxed);
 
     // Check budget
     // Budget is the duration of the audio block itself
@@ -489,17 +513,19 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
     // A stricter budget might be 80% to leave room for other tracks.
     // For now, let's use 100% of the block time.
     if (durationNs > budgetNs) {
-        m_watchdogStats.violationCount++;
+        const auto violationCount = m_watchdogViolationCount.fetch_add(1, std::memory_order_acq_rel) + 1;
 
-        if (m_watchdogStats.violationCount > WATCHDOG_VIOLATION_LIMIT) {
-            m_watchdogStats.isBypassed = true;
-            Log::error("VST3: Plugin " + m_info.name + " exceeded time budget " +
-                       std::to_string(WATCHDOG_VIOLATION_LIMIT) + " times. Auto-bypassing.");
+        if (violationCount > WATCHDOG_VIOLATION_LIMIT) {
+            const bool wasBypassed = m_watchdogBypassed.exchange(true, std::memory_order_acq_rel);
+            if (!wasBypassed) {
+                m_watchdogReportPending.store(true, std::memory_order_release);
+            }
         }
     } else {
         // Slowly decay violation count if behaving well (optional recovery)
-        if (m_watchdogStats.violationCount > 0) {
-            m_watchdogStats.violationCount--;
+        const auto violationCount = m_watchdogViolationCount.load(std::memory_order_relaxed);
+        if (violationCount > 0) {
+            m_watchdogViolationCount.store(violationCount - 1, std::memory_order_relaxed);
         }
     }
 
@@ -508,18 +534,14 @@ void VST3PluginInstance::process(const float* const* inputs, float** outputs, ui
         for (int32 i = 0; i < outputEvents.count; ++i) {
             const Event& ev = outputEvents.events[i];
             if (ev.type == Event::kNoteOnEvent) {
-                uint8_t data[3] = {
-                    static_cast<uint8_t>(0x90 | (ev.noteOn.channel & 0x0F)),
-                    static_cast<uint8_t>(ev.noteOn.pitch),
-                    static_cast<uint8_t>(ev.noteOn.velocity * 127.0f)
-                };
+                uint8_t data[3] = {static_cast<uint8_t>(0x90 | (ev.noteOn.channel & 0x0F)),
+                                   static_cast<uint8_t>(ev.noteOn.pitch),
+                                   static_cast<uint8_t>(ev.noteOn.velocity * 127.0f)};
                 midiOutput->addEvent(ev.sampleOffset, data, 3);
             } else if (ev.type == Event::kNoteOffEvent) {
-                uint8_t data[3] = {
-                    static_cast<uint8_t>(0x80 | (ev.noteOff.channel & 0x0F)),
-                    static_cast<uint8_t>(ev.noteOff.pitch),
-                    static_cast<uint8_t>(ev.noteOff.velocity * 127.0f)
-                };
+                uint8_t data[3] = {static_cast<uint8_t>(0x80 | (ev.noteOff.channel & 0x0F)),
+                                   static_cast<uint8_t>(ev.noteOff.pitch),
+                                   static_cast<uint8_t>(ev.noteOff.velocity * 127.0f)};
                 midiOutput->addEvent(ev.sampleOffset, data, 3);
             }
         }
@@ -579,29 +601,35 @@ std::vector<uint8_t> VST3PluginInstance::saveState() const {
         FUnknown* i = nullptr;
 
         MemStream() { addRef(); }
-        ~MemStream() { if (i) i->release(); }
+        ~MemStream() {
+            if (i)
+                i->release();
+        }
 
         tresult write(void* buffer, int32 numBytes, int32* numBytesWritten) override {
             if (!buffer || numBytes < 0 || pos < 0) {
-                if (numBytesWritten) *numBytesWritten = 0;
+                if (numBytesWritten)
+                    *numBytesWritten = 0;
                 return kInvalidArgument;
             }
             // [SEC-FIX] Cap stream size to prevent malicious plugins from exhausting memory.
             constexpr int64_t MAX_MEMSTREAM_SIZE = 256LL * 1024 * 1024; // 256 MiB
-            if (pos > MAX_MEMSTREAM_SIZE || numBytes > MAX_MEMSTREAM_SIZE ||
-                pos + numBytes > MAX_MEMSTREAM_SIZE) {
-                if (numBytesWritten) *numBytesWritten = 0;
+            if (pos > MAX_MEMSTREAM_SIZE || numBytes > MAX_MEMSTREAM_SIZE || pos + numBytes > MAX_MEMSTREAM_SIZE) {
+                if (numBytesWritten)
+                    *numBytesWritten = 0;
                 return kInvalidArgument;
             }
             if (pos + numBytes > static_cast<int64_t>(data.size()))
                 data.resize(pos + numBytes);
             std::memcpy(data.data() + pos, buffer, numBytes);
-            if (numBytesWritten) *numBytesWritten = numBytes;
+            if (numBytesWritten)
+                *numBytesWritten = numBytes;
             pos += numBytes;
             return kResultOk;
         }
         tresult read(void* buffer, int32 numBytes, int32* numBytesRead) override {
-            if (numBytesRead) *numBytesRead = 0;
+            if (numBytesRead)
+                *numBytesRead = 0;
             if (!buffer || numBytes < 0 || pos < 0) {
                 return kInvalidArgument;
             }
@@ -612,33 +640,47 @@ std::vector<uint8_t> VST3PluginInstance::saveState() const {
             if (toRead > 0) {
                 std::memcpy(buffer, data.data() + pos, toRead);
             }
-            if (numBytesRead) *numBytesRead = toRead;
+            if (numBytesRead)
+                *numBytesRead = toRead;
             pos += toRead;
             return kResultOk;
         }
         tresult seek(int64 pos, int32 type, int64* result) override {
-            if (type == kIBSeekSet) this->pos = pos;
-            else if (type == kIBSeekCur) this->pos += pos;
-            else if (type == kIBSeekEnd) this->pos = static_cast<int64_t>(data.size()) + pos;
-            else return kInvalidArgument;
+            if (type == kIBSeekSet)
+                this->pos = pos;
+            else if (type == kIBSeekCur)
+                this->pos += pos;
+            else if (type == kIBSeekEnd)
+                this->pos = static_cast<int64_t>(data.size()) + pos;
+            else
+                return kInvalidArgument;
             this->pos = std::max<int64_t>(0, std::min<int64_t>(this->pos, static_cast<int64_t>(data.size())));
-            if (result) *result = this->pos;
+            if (result)
+                *result = this->pos;
             return kResultOk;
         }
         tresult tell(int64* pos) override {
-            if (pos) *pos = this->pos;
+            if (pos)
+                *pos = this->pos;
             return kResultOk;
         }
         uint32 addRef() override { return ++refCount; }
         uint32 release() override {
             uint32 r = --refCount;
-            if (r == 0) { /* don't delete - stack allocated */ return 0; }
+            if (r == 0) { /* don't delete - stack allocated */
+                return 0;
+            }
             return r;
         }
         tresult queryInterface(const TUID iid, void** obj) override {
-            if (iid == IBStream::iid || iid == FUnknown::iid) { *obj = static_cast<IBStream*>(this); addRef(); return kResultOk; }
+            if (iid == IBStream::iid || iid == FUnknown::iid) {
+                *obj = static_cast<IBStream*>(this);
+                addRef();
+                return kResultOk;
+            }
             return kNoInterface;
         }
+
     private:
         uint32 refCount = 0;
     } stream;
@@ -665,7 +707,8 @@ bool VST3PluginInstance::loadState(const std::vector<uint8_t>& state) {
 
         tresult write(void*, int32, int32*) override { return kNotImplemented; }
         tresult read(void* buffer, int32 numBytes, int32* numBytesRead) override {
-            if (numBytesRead) *numBytesRead = 0;
+            if (numBytesRead)
+                *numBytesRead = 0;
             if (!buffer || numBytes < 0 || pos < 0) {
                 return kInvalidArgument;
             }
@@ -676,26 +719,46 @@ bool VST3PluginInstance::loadState(const std::vector<uint8_t>& state) {
             if (toRead > 0) {
                 std::memcpy(buffer, data.data() + pos, toRead);
             }
-            if (numBytesRead) *numBytesRead = toRead;
+            if (numBytesRead)
+                *numBytesRead = toRead;
             pos += toRead;
             return kResultOk;
         }
         tresult seek(int64 p, int32 type, int64* result) override {
-            if (type == kIBSeekSet) pos = p;
-            else if (type == kIBSeekCur) pos += p;
-            else if (type == kIBSeekEnd) pos = static_cast<int64_t>(data.size()) + p;
-            else return kInvalidArgument;
+            if (type == kIBSeekSet)
+                pos = p;
+            else if (type == kIBSeekCur)
+                pos += p;
+            else if (type == kIBSeekEnd)
+                pos = static_cast<int64_t>(data.size()) + p;
+            else
+                return kInvalidArgument;
             pos = std::max<int64_t>(0, std::min<int64_t>(pos, static_cast<int64_t>(data.size())));
-            if (result) *result = pos;
+            if (result)
+                *result = pos;
             return kResultOk;
         }
-        tresult tell(int64* p) override { if (p) *p = pos; return kResultOk; }
+        tresult tell(int64* p) override {
+            if (p)
+                *p = pos;
+            return kResultOk;
+        }
         uint32 addRef() override { return ++refCount; }
-        uint32 release() override { uint32 r = --refCount; if (r == 0) return 0; return r; }
+        uint32 release() override {
+            uint32 r = --refCount;
+            if (r == 0)
+                return 0;
+            return r;
+        }
         tresult queryInterface(const TUID iid, void** obj) override {
-            if (iid == IBStream::iid || iid == FUnknown::iid) { *obj = static_cast<IBStream*>(this); addRef(); return kResultOk; }
+            if (iid == IBStream::iid || iid == FUnknown::iid) {
+                *obj = static_cast<IBStream*>(this);
+                addRef();
+                return kResultOk;
+            }
             return kNoInterface;
         }
+
     private:
         uint32 refCount = 0;
     } stream(state);
@@ -816,10 +879,52 @@ void VST3PluginInstance::setupProcessing() {
     // Called after initialize to prepare buffers
 }
 
+IPluginInstance::WatchdogStats VST3PluginInstance::getWatchdogStats() const {
+    reportDeferredRealtimeEvents();
+
+    WatchdogStats stats;
+    stats.maxExecutionTimeNs = static_cast<double>(m_watchdogMaxExecutionTimeNs.load(std::memory_order_relaxed));
+    stats.avgExecutionTimeNs = static_cast<double>(m_watchdogAvgExecutionTimeNs.load(std::memory_order_relaxed));
+    stats.violationCount = m_watchdogViolationCount.load(std::memory_order_relaxed);
+    stats.isBypassed = m_watchdogBypassed.load(std::memory_order_acquire);
+    return stats;
+}
+
+bool VST3PluginInstance::isBypassedByWatchdog() const {
+    reportDeferredRealtimeEvents();
+    return m_watchdogBypassed.load(std::memory_order_acquire);
+}
+
+bool VST3PluginInstance::isCrashed() const {
+    reportDeferredRealtimeEvents();
+    return m_crashed.load(std::memory_order_acquire);
+}
+
 void VST3PluginInstance::resetWatchdog() {
-    m_watchdogStats = WatchdogStats(); // Reset to zero
-    m_crashed = false;                 // Reset crash state
+    reportDeferredRealtimeEvents();
+    m_watchdogMaxExecutionTimeNs.store(0, std::memory_order_release);
+    m_watchdogAvgExecutionTimeNs.store(0, std::memory_order_release);
+    m_watchdogViolationCount.store(0, std::memory_order_release);
+    m_watchdogBypassed.store(false, std::memory_order_release);
+    m_crashed.store(false, std::memory_order_release);
+    m_watchdogReportPending.store(false, std::memory_order_release);
+    m_crashReportPending.store(false, std::memory_order_release);
     Log::info("VST3: Watchdog reset for " + m_info.name);
+}
+
+void VST3PluginInstance::reportDeferredRealtimeEvents() const {
+    if (m_crashReportPending.exchange(false, std::memory_order_acq_rel)) {
+#ifdef _WIN32
+        Log::error("VST3: CRASH DETECTED in " + m_info.name + "! (Access Violation trapped)");
+#else
+        Log::error("VST3: Crash detected in " + m_info.name);
+#endif
+    }
+
+    if (m_watchdogReportPending.exchange(false, std::memory_order_acq_rel)) {
+        Log::error("VST3: Plugin " + m_info.name + " exceeded time budget " + std::to_string(WATCHDOG_VIOLATION_LIMIT) +
+                   " times. Auto-bypassing.");
+    }
 }
 
 // ============================================================================
@@ -884,8 +989,32 @@ std::shared_ptr<VST3PluginInstance> VST3PluginFactory::createInstance(const Plug
         return nullptr;
     }
 
+    int classIndex = 0;
+    if (!info.id.empty()) {
+        bool foundRequestedClass = false;
+        std::string errorMsg;
+        auto module = VST3::Hosting::Module::create(info.path.string(), errorMsg);
+        if (module) {
+            auto factory = module->getFactory();
+            if (factory.get()) {
+                auto classInfos = factory.classInfos();
+                for (size_t i = 0; i < classInfos.size(); ++i) {
+                    const auto& classInfo = classInfos[i];
+                    if (classInfo.category() == kVstAudioEffectClass && classInfo.ID().toString() == info.id) {
+                        classIndex = static_cast<int>(i);
+                        foundRequestedClass = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!foundRequestedClass) {
+            return nullptr;
+        }
+    }
+
     auto instance = std::make_shared<VST3PluginInstance>();
-    if (!instance->load(info.path)) {
+    if (!instance->load(info.path, classIndex)) {
         return nullptr;
     }
 

--- a/tests/security/out_of_process_plugin_host.cpp
+++ b/tests/security/out_of_process_plugin_host.cpp
@@ -133,6 +133,12 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    auto missingVst3 = create(factory, makeInfo("com.aestra.missing-vst3"));
+    if (missingVst3) {
+        std::cerr << "missing real VST3 plugin should not fall back to echo processing\n";
+        return 1;
+    }
+
     auto crashed = create(factory, makeInfo("__aestra_test_crash__"));
     if (crashed) {
         std::cerr << "crashing plugin should not produce a usable instance\n";


### PR DESCRIPTION
Closes #247

## Summary
- Hardened in-process VST3 crash/watchdog reporting so the audio callback no longer logs or mutates shared watchdog state through plain fields.
- Added a real VST3 host application context and avoided eager editor-view creation during headless load, which fixed a real Linux LSP VST3 crash during plugin creation.
- Added helper-process VST3 load/init/process/state handling so non-test VST3 plugins no longer fall back to echo/pass-through behavior.
- Made out-of-process plugin proxy watchdog status atomic across worker/control-thread access.

## Validation
- `cmake --build build --parallel 2`
- `/tmp/aestra_vst3_smoke /usr/lib/vst3/lsp-plugins.vst3 17` — passed with LSP Clipper Stereo
- `/tmp/aestra_vst3_oop_smoke /home/currentsuspect/Dev/Aestra/build/bin/AestraPluginHost /usr/lib/vst3/lsp-plugins.vst3` — passed with LSP Clipper Stereo
- `ctest --test-dir build -R "AestraWatchdogTest|AestraCrashTest|PluginHostStressTest|SecOutOfProcessPluginHost|SecPluginScanIsolation" --output-on-failure` — 5/5 passed
- `ctest --test-dir build --output-on-failure -E "SecAccountApiClient|SecAccountEndToEndSmoke"` — 104/104 passed
- `git diff --check HEAD~3..HEAD`

## Risk / Rollback
- The helper process now links `AestraAudioCore` when VST3 is enabled so it can host real VST3 instances.
- Real-plugin smoke coverage was performed with the system-installed LSP VST3 bundle; broader vendor/plugin compatibility remains follow-up validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Plugin Crash Protection for Linux VST3

**Key Changes:**
- **Hardened watchdog/crash reporting**: Refactored in-process VST3 watchdog state from plain structs to atomic fields (`std::atomic<bool>`, `std::atomic<uint64_t>`, etc.) so the audio callback can safely check crash/bypass status without logging or mutating shared state. Deferred violation/crash event reporting to avoid real-time safety violations.

- **Out-of-process plugin isolation**: Added real `Vst3Module` implementation in the helper process (`AestraPluginHostMain.cpp`) to properly load, initialize, activate, and process VST3 plugins—replacing the previous fallback to echo/pass-through behavior. The helper process now links `AestraAudioCore` when VST3 is enabled.

- **LSP VST3 Linux crash fix**: Created a proper `HostApplication` context instance during component/controller initialization in `VST3Host.cpp`, and deferred editor-view instantiation until explicitly requested (avoiding headless UI allocation that was crashing some Linux VST3s like LSP Clipper).

- **Atomic watchdog access**: Made out-of-process watchdog stats atomic to safely sync violation counts and bypass state between worker and control threads without locks in the audio callback.

**Testing Validation:**
- Smoke tests passed with system LSP Clipper Stereo VST3 in both in-process and out-of-process modes
- All watchdog, crash, and plugin-host stress tests passed (104/104 excluding unrelated Account API tests)
- Helper process now properly rejects missing VST3 identifiers instead of silently falling back

**Windows vs. Linux Approach:**
- Windows continues to use SEH-based `__try/__except` protection in `SafeProcessCall()`
- Linux relies on the helper-process isolation model; in-process VST3 is not supported on Linux due to lack of exception-based protection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->