### PR TITLE
sprint2: No fsync in any write path

### DIFF
--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -403,7 +403,12 @@ bool AutosaveManager::performAutosave() {
             return false;
         }
         // Sync to disk before atomic rename to prevent data loss on crash
-        Aestra::syncOfstream(out, tmp.string());
+        if (!Aestra::syncOfstream(out, tmp.string())) {
+            notifyError("Autosave failed: sync error");
+            out.close();
+            fs::remove(tmp, ec);
+            return false;
+        }
     }
     
     // Atomic replace: on POSIX, rename() atomically replaces the target.
@@ -420,6 +425,13 @@ bool AutosaveManager::performAutosave() {
         fs::remove(tmp, ec);
         return false;
     }
+
+#ifndef _WIN32
+    if (!Aestra::fsyncParentDirectory(target.string())) {
+        notifyError("Autosave failed: directory sync error");
+        return false;
+    }
+#endif
     
     m_lastAutosaveTime = std::chrono::steady_clock::now();
     

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -1,6 +1,7 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "AutosaveManager.h"
+#include "AestraFile.h"
 #include "AestraLog.h"
 
 #include <filesystem>
@@ -401,6 +402,8 @@ bool AutosaveManager::performAutosave() {
             fs::remove(tmp, ec);
             return false;
         }
+        // Sync to disk before atomic rename to prevent data loss on crash
+        Aestra::syncOfstream(out, tmp.string());
     }
     
     // Atomic replace: on POSIX, rename() atomically replaces the target.

--- a/AestraAudio/src/IO/AudioExporter.cpp
+++ b/AestraAudio/src/IO/AudioExporter.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
@@ -276,8 +277,24 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
         file.seekp(0, std::ios::beg);
         writeWavHeader(file, config, result.framesRendered);
         file.flush();
-        Aestra::fsyncPath(config.outputPath);
+        if (!file || !Aestra::fsyncPath(config.outputPath)) {
+            result.errorMessage = "Failed to sync exported WAV to disk";
+            result.success = false;
+            file.close();
+            std::remove(config.outputPath.c_str());
+            updateProgress(1.0f);
+            return result;
+        }
         file.close();
+#ifndef _WIN32
+        if (!Aestra::fsyncParentDirectory(config.outputPath)) {
+            result.errorMessage = "Failed to sync exported WAV directory";
+            result.success = false;
+            std::remove(config.outputPath.c_str());
+            updateProgress(1.0f);
+            return result;
+        }
+#endif
 
         result.success = true;
         result.durationSeconds = static_cast<double>(result.framesRendered) / config.sampleRate;

--- a/AestraAudio/src/IO/AudioExporter.cpp
+++ b/AestraAudio/src/IO/AudioExporter.cpp
@@ -288,11 +288,7 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
         file.close();
 #ifndef _WIN32
         if (!Aestra::fsyncParentDirectory(config.outputPath)) {
-            result.errorMessage = "Failed to sync exported WAV directory";
-            result.success = false;
-            std::remove(config.outputPath.c_str());
-            updateProgress(1.0f);
-            return result;
+            Log::warning("[Export] Failed to sync exported WAV directory; keeping completed export");
         }
 #endif
 

--- a/AestraAudio/src/IO/AudioExporter.cpp
+++ b/AestraAudio/src/IO/AudioExporter.cpp
@@ -1,6 +1,7 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "AudioExporter.h"
+#include "AestraFile.h"
 #include "AestraLog.h"
 
 #include <fstream>
@@ -274,6 +275,8 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
         // Rewrite WAV header with actual frame count
         file.seekp(0, std::ios::beg);
         writeWavHeader(file, config, result.framesRendered);
+        file.flush();
+        Aestra::fsyncPath(config.outputPath);
         file.close();
 
         result.success = true;

--- a/AestraCore/include/AestraFile.h
+++ b/AestraCore/include/AestraFile.h
@@ -40,10 +40,14 @@ inline bool fsyncPath(const std::string& path) {
     CloseHandle(h);
     return ok;
 #else
-    int fd = open(path.c_str(), O_RDONLY);
+    int fd = open(path.c_str(), O_WRONLY);
     if (fd < 0)
         return false;
+#ifdef __APPLE__
+    bool ok = fcntl(fd, F_FULLFSYNC) == 0;
+#else
     bool ok = fsync(fd) == 0;
+#endif
     close(fd);
     return ok;
 #endif
@@ -69,7 +73,11 @@ inline bool fsyncParentDirectory(const std::string& path) {
     int fd = open(parent.c_str(), O_RDONLY | O_DIRECTORY);
     if (fd < 0)
         return false;
+#ifdef __APPLE__
+    bool ok = fcntl(fd, F_FULLFSYNC) == 0;
+#else
     bool ok = fsync(fd) == 0;
+#endif
     close(fd);
     return ok;
 #endif

--- a/AestraCore/include/AestraFile.h
+++ b/AestraCore/include/AestraFile.h
@@ -4,12 +4,19 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <io.h>
 #include <windows.h>
 #else
@@ -23,8 +30,10 @@ namespace Aestra {
 // autosave, export) to ensure data survives a crash.
 inline bool fsyncPath(const std::string& path) {
 #ifdef _WIN32
-    HANDLE h = CreateFileA(path.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
-                           FILE_ATTRIBUTE_NORMAL, nullptr);
+    const auto nativePath = std::filesystem::path(path).wstring();
+    HANDLE h = CreateFileW(nativePath.c_str(), GENERIC_WRITE,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                           nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (h == INVALID_HANDLE_VALUE)
         return false;
     bool ok = FlushFileBuffers(h) != 0;
@@ -32,6 +41,32 @@ inline bool fsyncPath(const std::string& path) {
     return ok;
 #else
     int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0)
+        return false;
+    bool ok = fsync(fd) == 0;
+    close(fd);
+    return ok;
+#endif
+}
+
+inline bool fsyncParentDirectory(const std::string& path) {
+    namespace fs = std::filesystem;
+    fs::path parent = fs::path(path).parent_path();
+    if (parent.empty())
+        parent = ".";
+
+#ifdef _WIN32
+    const auto nativePath = parent.wstring();
+    HANDLE h = CreateFileW(nativePath.c_str(), GENERIC_READ,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                           nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    if (h == INVALID_HANDLE_VALUE)
+        return false;
+    bool ok = FlushFileBuffers(h) != 0;
+    CloseHandle(h);
+    return ok;
+#else
+    int fd = open(parent.c_str(), O_RDONLY | O_DIRECTORY);
     if (fd < 0)
         return false;
     bool ok = fsync(fd) == 0;
@@ -116,6 +151,8 @@ public:
         if (!isOpen_)
             return false;
         stream_.flush();
+        if (!stream_)
+            return false;
         return Aestra::fsyncPath(path_);
     }
 

--- a/AestraCore/include/AestraFile.h
+++ b/AestraCore/include/AestraFile.h
@@ -2,13 +2,51 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 namespace Aestra {
+
+// Sync a file path to disk. Use after writing critical data (project save,
+// autosave, export) to ensure data survives a crash.
+inline bool fsyncPath(const std::string& path) {
+#ifdef _WIN32
+    HANDLE h = CreateFileA(path.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                           FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (h == INVALID_HANDLE_VALUE)
+        return false;
+    bool ok = FlushFileBuffers(h) != 0;
+    CloseHandle(h);
+    return ok;
+#else
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0)
+        return false;
+    bool ok = fsync(fd) == 0;
+    close(fd);
+    return ok;
+#endif
+}
+
+// Sync an ofstream flush+fsync. Call after writing and before rename.
+inline bool syncOfstream(std::ofstream& stream, const std::string& path) {
+    stream.flush();
+    if (!stream)
+        return false;
+    return fsyncPath(path);
+}
 
 // =============================================================================
 // File Abstraction Layer
@@ -71,6 +109,14 @@ public:
             return false;
         stream_.write(static_cast<const char*>(buffer), size);
         return stream_.good();
+    }
+
+    // Sync file data to disk (fsync on POSIX, FlushFileBuffers on Windows)
+    bool sync() {
+        if (!isOpen_)
+            return false;
+        stream_.flush();
+        return Aestra::fsyncPath(path_);
     }
 
     // Get file size

--- a/Source/Core/Preferences.cpp
+++ b/Source/Core/Preferences.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "Preferences.h"
+#include "AestraFile.h"
 #include "AestraPlatform.h"
 #include "AestraLog.h"
 
@@ -8,6 +9,52 @@
 #include <fstream>
 
 namespace Aestra {
+
+namespace {
+bool writeTextAtomically(const std::string& path, const std::string& contents, const std::string& label) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::path target(path);
+    fs::path tmp = target;
+    tmp += ".tmp";
+
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            Log::warning("[Preferences] Failed to open " + label + " temp file");
+            return false;
+        }
+        out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+        if (!Aestra::syncOfstream(out, tmp.string())) {
+            Log::warning("[Preferences] Failed to sync " + label + " temp file");
+            out.close();
+            fs::remove(tmp, ec);
+            return false;
+        }
+    }
+
+#ifdef _WIN32
+    if (fs::exists(target, ec)) {
+        fs::remove(target, ec);
+    }
+    ec.clear();
+#endif
+    fs::rename(tmp, target, ec);
+    if (ec) {
+        Log::warning("[Preferences] Failed to replace " + label + " file: " + ec.message());
+        fs::remove(tmp, ec);
+        return false;
+    }
+
+#ifndef _WIN32
+    if (!Aestra::fsyncParentDirectory(target.string())) {
+        Log::warning("[Preferences] Failed to sync " + label + " directory");
+        return false;
+    }
+#endif
+    return true;
+}
+} // namespace
 
 // =============================================================================
 // Singleton
@@ -101,23 +148,7 @@ void Preferences::save() {
     
     // Save preferences atomically
     std::string jsonStr = toJson().toString(2);
-    
-    std::error_code ec;
-    std::filesystem::path tmpPath = prefPath + ".tmp";
-    
-    {
-        std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
-        if (out) {
-            out.write(jsonStr.data(), static_cast<std::streamsize>(jsonStr.size()));
-            out.flush();
-        }
-    }
-    
-    // Replace existing file
-    if (std::filesystem::exists(prefPath, ec)) {
-        std::filesystem::remove(prefPath, ec);
-    }
-    std::filesystem::rename(tmpPath, prefPath, ec);
+    bool savedPreferences = writeTextAtomically(prefPath, jsonStr, "preferences");
     
     // Save recent files separately
     JSON recentJson = JSON::object();
@@ -128,20 +159,11 @@ void Preferences::save() {
     recentJson.set("recentFiles", filesArray);
     
     std::string recentJsonStr = recentJson.toString(2);
-    std::filesystem::path recentTmpPath = recentPath + ".tmp";
-    
-    {
-        std::ofstream out(recentTmpPath, std::ios::binary | std::ios::trunc);
-        if (out) {
-            out.write(recentJsonStr.data(), static_cast<std::streamsize>(recentJsonStr.size()));
-            out.flush();
-        }
+    bool savedRecent = writeTextAtomically(recentPath, recentJsonStr, "recent files");
+
+    if (!savedPreferences || !savedRecent) {
+        return;
     }
-    
-    if (std::filesystem::exists(recentPath, ec)) {
-        std::filesystem::remove(recentPath, ec);
-    }
-    std::filesystem::rename(recentTmpPath, recentPath, ec);
     
     Log::info("[Preferences] Saved to: " + prefPath);
 }

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "ProjectSerializer.h"
 #include "ProjectMigrations.h"
+#include "AestraFile.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "MiniAudioDecoder.h"
 #include "PluginManager.h"
@@ -450,6 +451,8 @@ static bool writeAtomicallyImpl(const std::string& path, const std::string& cont
             Log::error("Project save failed: write error: " + tmp.string());
             return false;
         }
+        // Sync to disk before atomic rename to prevent data loss on crash
+        Aestra::syncOfstream(out, tmp.string());
     }
 
 #ifdef _WIN32

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -452,7 +452,12 @@ static bool writeAtomicallyImpl(const std::string& path, const std::string& cont
             return false;
         }
         // Sync to disk before atomic rename to prevent data loss on crash
-        Aestra::syncOfstream(out, tmp.string());
+        if (!Aestra::syncOfstream(out, tmp.string())) {
+            Log::error("Project save failed: sync error: " + tmp.string());
+            out.close();
+            fs::remove(tmp, ec);
+            return false;
+        }
     }
 
 #ifdef _WIN32
@@ -470,6 +475,11 @@ static bool writeAtomicallyImpl(const std::string& path, const std::string& cont
         Log::error("Project save failed: cannot replace target: " + target.string() + " (" + ec.message() + ")");
         // Best-effort cleanup
         fs::remove(tmp, ec);
+        return false;
+    }
+
+    if (!Aestra::fsyncParentDirectory(target.string())) {
+        Log::error("Project save failed: directory sync error: " + target.parent_path().string());
         return false;
     }
 #endif

--- a/Source/Core/UIState.cpp
+++ b/Source/Core/UIState.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "UIState.h"
+#include "AestraFile.h"
 #include "AestraLog.h"
 #include "AestraPlatform.h"
 #include <filesystem>
@@ -64,14 +65,34 @@ void UIState::save() {
             return;
         }
         out.write(jsonStr.data(), static_cast<std::streamsize>(jsonStr.size()));
-        out.flush();
+        if (!Aestra::syncOfstream(out, tmpPath.string())) {
+            Log::warning("[UIState] Failed to sync UI state file");
+            out.close();
+            std::filesystem::remove(tmpPath, ec);
+            return;
+        }
     }
     
     // Replace existing file
+#ifdef _WIN32
     if (std::filesystem::exists(path, ec)) {
         std::filesystem::remove(path, ec);
     }
+#endif
+    ec.clear();
     std::filesystem::rename(tmpPath, path, ec);
+    if (ec) {
+        Log::warning("[UIState] Failed to replace UI state file: " + ec.message());
+        std::filesystem::remove(tmpPath, ec);
+        return;
+    }
+
+#ifndef _WIN32
+    if (!Aestra::fsyncParentDirectory(path)) {
+        Log::warning("[UIState] Failed to sync UI state directory");
+        return;
+    }
+#endif
     
     Log::info("[UIState] Saved to: " + path);
 }


### PR DESCRIPTION
Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Breaking changes:
  - Save/autosave/export now fail/abort early if disk-sync (fsync/FlushFileBuffers) fails. Code that relied on silent continuation after a I/O sync failure may observe different behavior.

- What changed:
  - Added cross-platform durability helpers in AestraCore/include/AestraFile.h:
    - Aestra::fsyncPath(path) — calls fsync on POSIX or FlushFileBuffers on Windows.
    - Aestra::fsyncParentDirectory(path) — syncs the parent directory.
    - Aestra::syncOfstream(stream, path) — flushes an std::ofstream and then calls fsyncPath.
    - File::sync() — new method to sync a File's underlying stream/path.
  - Hardened atomic write paths to persist data to disk:
    - Source/Core/ProjectSerializer.cpp: sync temp file before rename and fsync parent directory after rename (non-Windows).
    - AestraAudio/src/Core/AutosaveManager.cpp: sync temp autosave before atomic replace; fsync parent directory after rename (non-Windows).
    - AestraAudio/src/IO/AudioExporter.cpp: after rewriting WAV header, flush + fsync output file; fsync parent directory after closing (non-Windows).
    - Source/Core/UIState.cpp and Source/Core/Preferences.cpp: refactored atomic JSON writers to write temp file, sync it, perform atomic replace (Windows-aware), and sync parent directory on POSIX.
  - Error handling: on sync failure the code logs/errors, removes temp files, and returns failure instead of proceeding.

- Why:
  - Addresses issue `#245` by ensuring data is explicitly persisted to stable storage (avoids relying only on ofstream::flush which only reaches OS page cache), reducing risk of zero-byte/missing save or autosave files after power loss or kernel panic.

- Notes for reviewers:
  - Focus review on platform-specific sync implementations and correct error handling/cleanup.
  - Consider whether callers expect silent continuation on I/O sync errors (this PR makes failures observable).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->