### PR TITLE
ci: fix API docs quality Graphviz dependency

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,6 +17,7 @@ on:
       - '**.hpp'
       - '**.cpp'
       - 'Doxyfile'
+      - '.github/workflows/api-docs.yml'
   workflow_dispatch:
 
 jobs:
@@ -125,7 +126,9 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt-get update
-          sudo apt-get install -y doxygen
+          sudo apt-get install -y doxygen graphviz
+          doxygen --version
+          dot -V
           
       - name: Run Documentation Check
         id: doc_check


### PR DESCRIPTION
Summary:
- Install Graphviz in the API documentation quality job so Doxygen DOT graph generation can find dot.
- Include api-docs.yml in the pull_request path filter so workflow-only fixes rerun the docs workflow.

Why:
- The quality job installed doxygen without graphviz, causing repeated 'dot: not found' warnings to be counted and reported as 1,895 documentation errors.

Testing:
- Verified the same workflow change on PR #332 produced a new API Documentation Quality comment with 0 documentation errors.
- git diff --check

Risk:
- CI-only change. No DSP, UI, serialization, or runtime behavior changes.