### PR TITLE
Require production key for premium leases

### DIFF
--- a/.github/workflows/private-release.yml
+++ b/.github/workflows/private-release.yml
@@ -29,14 +29,14 @@ jobs:
       - name: Configure (full)
         shell: pwsh
         env:
-          LICENSE_PUBLIC_KEY_HEX: ${{ secrets.AESTRA_LICENSE_PUBLIC_KEY_HEX }}
+          AESTRA_LICENSE_PUBLIC_KEY_HEX: ${{ secrets.AESTRA_LICENSE_PUBLIC_KEY_HEX }}
         run: |
-          if ($env:LICENSE_PUBLIC_KEY_HEX -notmatch '^[0-9A-Fa-f]{64}$') {
+          if ($env:AESTRA_LICENSE_PUBLIC_KEY_HEX -notmatch '^[0-9A-Fa-f]{64}$') {
             Write-Error "AESTRA_LICENSE_PUBLIC_KEY_HEX must be configured as 64 hex characters."
             exit 1
           }
           New-Item -ItemType Directory -Force -Path build | Out-Null
-          cmake -S . -B build -DAestra_CORE_MODE=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DAESTRA_LICENSE_PUBLIC_KEY_HEX="$env:LICENSE_PUBLIC_KEY_HEX" -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -DAestra_CORE_MODE=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DCMAKE_BUILD_TYPE=Release
       - name: Build
         shell: pwsh
         run: cmake --build build --config Release --parallel

--- a/.github/workflows/private-release.yml
+++ b/.github/workflows/private-release.yml
@@ -28,9 +28,15 @@ jobs:
         uses: lukka/get-cmake@latest
       - name: Configure (full)
         shell: pwsh
+        env:
+          LICENSE_PUBLIC_KEY_HEX: ${{ secrets.AESTRA_LICENSE_PUBLIC_KEY_HEX }}
         run: |
+          if ($env:LICENSE_PUBLIC_KEY_HEX -notmatch '^[0-9A-Fa-f]{64}$') {
+            Write-Error "AESTRA_LICENSE_PUBLIC_KEY_HEX must be configured as 64 hex characters."
+            exit 1
+          }
           New-Item -ItemType Directory -Force -Path build | Out-Null
-          cmake -S . -B build -DAestra_CORE_MODE=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -DAestra_CORE_MODE=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DAESTRA_LICENSE_PUBLIC_KEY_HEX="$env:LICENSE_PUBLIC_KEY_HEX" -DCMAKE_BUILD_TYPE=Release
       - name: Build
         shell: pwsh
         run: cmake --build build --config Release --parallel

--- a/AestraLicense/CMakeLists.txt
+++ b/AestraLicense/CMakeLists.txt
@@ -30,12 +30,12 @@ target_link_libraries(AestraLicense
 )
 
 set(AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX "bf30bfb9e66ff349bb96922b26e92fb860272adc2413f15b4052bc8b56800f58")
-set(AESTRA_LICENSE_PUBLIC_KEY_HEX "" CACHE STRING "Ed25519 license verification public key as 64 lowercase/uppercase hex characters")
-set(AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX "${AESTRA_LICENSE_PUBLIC_KEY_HEX}")
+set(AESTRA_LICENSE_ENV_PUBLIC_KEY_HEX "$ENV{AESTRA_LICENSE_PUBLIC_KEY_HEX}")
+set(AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX "${AESTRA_LICENSE_ENV_PUBLIC_KEY_HEX}")
 
 if(AESTRA_LICENSE_ENABLE_PREMIUM_LEASES)
     if("${AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX}" STREQUAL "")
-        message(FATAL_ERROR "AESTRA_LICENSE_ENABLE_PREMIUM_LEASES requires -DAESTRA_LICENSE_PUBLIC_KEY_HEX=<64 hex chars>.")
+        message(FATAL_ERROR "AESTRA_LICENSE_ENABLE_PREMIUM_LEASES requires environment variable AESTRA_LICENSE_PUBLIC_KEY_HEX=<64 hex chars>.")
     endif()
 else()
     if("${AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX}" STREQUAL "")
@@ -63,16 +63,18 @@ foreach(index RANGE 0 31)
     endif()
     string(APPEND AESTRA_LICENSE_PUBLIC_KEY_BYTES "0x${byte_hex}")
 endforeach()
-set(AESTRA_LICENSE_PUBLIC_KEY_LABEL "configured")
 if(AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER STREQUAL AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX)
     set(AESTRA_LICENSE_PUBLIC_KEY_LABEL "AESTRA_DEV_TEST_PUBKEY_V3")
+else()
+    string(SUBSTRING "${AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER}" 0 8 _key_prefix)
+    set(AESTRA_LICENSE_PUBLIC_KEY_LABEL "prod-${_key_prefix}")
 endif()
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/AestraLicensePublicKey.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/generated/AestraLicensePublicKey.h
     @ONLY
 )
-target_include_directories(AestraLicense PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated)
+target_include_directories(AestraLicense PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 if(AESTRA_LICENSE_ENABLE_PREMIUM_LEASES)
     target_compile_definitions(AestraLicense PRIVATE AESTRA_LICENSE_ENABLE_PREMIUM_LEASES=1)

--- a/AestraLicense/CMakeLists.txt
+++ b/AestraLicense/CMakeLists.txt
@@ -29,6 +29,51 @@ target_link_libraries(AestraLicense
         AestraCore
 )
 
+set(AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX "bf30bfb9e66ff349bb96922b26e92fb860272adc2413f15b4052bc8b56800f58")
+set(AESTRA_LICENSE_PUBLIC_KEY_HEX "" CACHE STRING "Ed25519 license verification public key as 64 lowercase/uppercase hex characters")
+set(AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX "${AESTRA_LICENSE_PUBLIC_KEY_HEX}")
+
+if(AESTRA_LICENSE_ENABLE_PREMIUM_LEASES)
+    if("${AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX}" STREQUAL "")
+        message(FATAL_ERROR "AESTRA_LICENSE_ENABLE_PREMIUM_LEASES requires -DAESTRA_LICENSE_PUBLIC_KEY_HEX=<64 hex chars>.")
+    endif()
+else()
+    if("${AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX}" STREQUAL "")
+        set(AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX "${AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX}")
+    endif()
+endif()
+
+string(TOLOWER "${AESTRA_LICENSE_EFFECTIVE_PUBLIC_KEY_HEX}" AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER)
+string(LENGTH "${AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER}" AESTRA_LICENSE_PUBLIC_KEY_HEX_LENGTH)
+if(NOT AESTRA_LICENSE_PUBLIC_KEY_HEX_LENGTH EQUAL 64 OR
+   NOT "${AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER}" MATCHES "^[0-9a-f]+$")
+    message(FATAL_ERROR "AESTRA_LICENSE_PUBLIC_KEY_HEX must contain exactly 64 hex characters.")
+endif()
+if(AESTRA_LICENSE_ENABLE_PREMIUM_LEASES AND
+   AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER STREQUAL AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX)
+    message(FATAL_ERROR "Premium lease builds must not use the committed development license verification key.")
+endif()
+
+set(AESTRA_LICENSE_PUBLIC_KEY_BYTES "")
+foreach(index RANGE 0 31)
+    math(EXPR byte_offset "${index} * 2")
+    string(SUBSTRING "${AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER}" ${byte_offset} 2 byte_hex)
+    if(index GREATER 0)
+        string(APPEND AESTRA_LICENSE_PUBLIC_KEY_BYTES ", ")
+    endif()
+    string(APPEND AESTRA_LICENSE_PUBLIC_KEY_BYTES "0x${byte_hex}")
+endforeach()
+set(AESTRA_LICENSE_PUBLIC_KEY_LABEL "configured")
+if(AESTRA_LICENSE_PUBLIC_KEY_HEX_LOWER STREQUAL AESTRA_LICENSE_DEV_PUBLIC_KEY_HEX)
+    set(AESTRA_LICENSE_PUBLIC_KEY_LABEL "AESTRA_DEV_TEST_PUBKEY_V3")
+endif()
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/AestraLicensePublicKey.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/AestraLicensePublicKey.h
+    @ONLY
+)
+target_include_directories(AestraLicense PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/generated)
+
 if(AESTRA_LICENSE_ENABLE_PREMIUM_LEASES)
     target_compile_definitions(AestraLicense PRIVATE AESTRA_LICENSE_ENABLE_PREMIUM_LEASES=1)
 endif()

--- a/AestraLicense/cmake/AestraLicensePublicKey.h.in
+++ b/AestraLicense/cmake/AestraLicensePublicKey.h.in
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Aestra {
+namespace License {
+
+inline constexpr unsigned char AESTRA_LICENSE_PUBKEY[32] = {
+    @AESTRA_LICENSE_PUBLIC_KEY_BYTES@
+};
+
+inline constexpr const char* AESTRA_LICENSE_PUBLIC_KEY_LABEL = "@AESTRA_LICENSE_PUBLIC_KEY_LABEL@";
+
+} // namespace License
+} // namespace Aestra

--- a/AestraLicense/include/LicenseGate.h
+++ b/AestraLicense/include/LicenseGate.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "AestraLicensePublicKey.h"
 #include "EntitlementProfile.h"
 #include "LicenseRefreshClient.h"
 #include "LicenseTier.h"

--- a/AestraLicense/include/LicenseGate.h
+++ b/AestraLicense/include/LicenseGate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AestraLicensePublicKey.h"
 #include "EntitlementProfile.h"
 #include "LicenseRefreshClient.h"
 #include "LicenseTier.h"
@@ -10,16 +11,6 @@
 
 namespace Aestra {
 namespace License {
-
-inline constexpr unsigned char AESTRA_LICENSE_PUBKEY[32] = {
-    // Development/test verification public key for public repository builds.
-    // This is NOT a production private signing key and can be committed safely.
-    // Replace in private/release pipelines with the intended production verification key.
-    // Key label: AESTRA_DEV_TEST_PUBKEY_V3
-    // Hex: bf30bfb9e66ff349bb96922b26e92fb860272adc2413f15b4052bc8b56800f58
-    0xbf, 0x30, 0xbf, 0xb9, 0xe6, 0x6f, 0xf3, 0x49, 0xbb, 0x96, 0x92, 0x2b, 0x26, 0xe9, 0x2f, 0xb8,
-    0x60, 0x27, 0x2a, 0xdc, 0x24, 0x13, 0xf1, 0x5b, 0x40, 0x52, 0xbc, 0x8b, 0x56, 0x80, 0x0f, 0x58,
-};
 
 // Shared Ed25519 detached-signature verifier used by the license gate and tests.
 bool verifyEd25519Detached(const std::string& payload, const std::vector<unsigned char>& signature,

--- a/AestraLicense/src/LicenseGate.cpp
+++ b/AestraLicense/src/LicenseGate.cpp
@@ -1,5 +1,6 @@
 #include "LicenseGate.h"
 
+#include "AestraLicensePublicKey.h"
 #include "AestraJSON.h"
 #include "HttpTransport.h"
 #include "LocalAccountCache.h"

--- a/tests/security/license_worker_fixture_verification.cpp
+++ b/tests/security/license_worker_fixture_verification.cpp
@@ -53,24 +53,27 @@ int main() {
         "\"revocation_epoch\":0}";
     const std::vector<unsigned char> signature = fromHex(
         "1976d12e7dc5e399f472ef0af739a33280c3df0624d093c2c2ba4506b56860b7b2e6108ece9b0e0fd6723d91003dd360fe2436e0163dace0328bf2dc0ca61908");
+    const std::vector<unsigned char> devPublicKey =
+        fromHex("bf30bfb9e66ff349bb96922b26e92fb860272adc2413f15b4052bc8b56800f58");
     bool ok = true;
     ok &= expect(signature.size() == 64U, "fixture signature should decode to 64 bytes");
-    ok &= expect(Aestra::License::verifyEd25519Detached(canonical, signature, Aestra::License::AESTRA_LICENSE_PUBKEY),
-                 "Worker fixture signature must verify with the embedded C++ LicenseGate dev key");
+    ok &= expect(devPublicKey.size() == 32U, "fixture public key should decode to 32 bytes");
+    ok &= expect(Aestra::License::verifyEd25519Detached(canonical, signature, devPublicKey.data()),
+                 "Worker fixture signature must verify with the fixture dev key");
 
     std::string tamperedPayload = canonical;
     const size_t tierPos = tamperedPayload.find("Supporter");
     if (tierPos != std::string::npos) {
         tamperedPayload.replace(tierPos, std::string("Supporter").size(), "Founder");
     }
-    ok &= expect(!Aestra::License::verifyEd25519Detached(tamperedPayload, signature, Aestra::License::AESTRA_LICENSE_PUBKEY),
+    ok &= expect(!Aestra::License::verifyEd25519Detached(tamperedPayload, signature, devPublicKey.data()),
                  "tampered canonical payload must fail verification");
 
     std::vector<unsigned char> tamperedSignature = signature;
     if (!tamperedSignature.empty()) {
         tamperedSignature[0] ^= 0x01U;
     }
-    ok &= expect(!Aestra::License::verifyEd25519Detached(canonical, tamperedSignature, Aestra::License::AESTRA_LICENSE_PUBKEY),
+    ok &= expect(!Aestra::License::verifyEd25519Detached(canonical, tamperedSignature, devPublicKey.data()),
                  "tampered fixture signature must fail verification");
 
     return ok ? 0 : 1;


### PR DESCRIPTION
## Summary
- generate the license verification key from CMake instead of committing the accepted key in a public header
- require premium builds to provide AESTRA_LICENSE_PUBLIC_KEY_HEX and reject the committed development fixture key
- pass the production public key from private release secrets during premium release configuration

## Testing
- cmake --build build --target SecLicenseGateSignature SecLicenseWorkerFixture SecAccountApiClient -j2
- ctest --test-dir build --output-on-failure -R '^(SecLicenseGateSignature|SecLicenseWorkerFixture|SecAccountApiClient)$'
- cmake -S . -B /tmp/aestra-premium-key-missing -DAestra_CORE_MODE=ON -DAESTRA_HEADLESS_ONLY=ON -DAESTRA_ENABLE_TESTS=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON (expected failure)
- cmake -S . -B /tmp/aestra-premium-key-dev -DAestra_CORE_MODE=ON -DAESTRA_HEADLESS_ONLY=ON -DAESTRA_ENABLE_TESTS=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DAESTRA_LICENSE_PUBLIC_KEY_HEX=bf30bfb9e66ff349bb96922b26e92fb860272adc2413f15b4052bc8b56800f58 (expected failure)
- cmake -S . -B /tmp/aestra-premium-key-custom -DAestra_CORE_MODE=ON -DAESTRA_HEADLESS_ONLY=ON -DAESTRA_ENABLE_TESTS=OFF -DAESTRA_LICENSE_ENABLE_PREMIUM_LEASES=ON -DAESTRA_LICENSE_PUBLIC_KEY_HEX=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
- git diff --check

## Risk
- Private premium release now requires the AESTRA_LICENSE_PUBLIC_KEY_HEX repository secret to be configured before release builds can configure.