### PR TITLE
Avoid stale waveform source callbacks

### DIFF
--- a/AestraAudio/include/Models/ClipSource.h
+++ b/AestraAudio/include/Models/ClipSource.h
@@ -68,6 +68,8 @@ public:
 
     ClipSourceID getID() const { return m_id; }
 
+    uint64_t getContentRevision() const { return m_contentRevision; }
+
     bool isValid() const { return m_buffer && m_buffer->isValid(); }
 
     bool isReady() const { return isValid(); }
@@ -76,7 +78,11 @@ public:
     void setName(const std::string& name) { m_name = name; }
     void setFilePath(const std::string& path) { m_filePath = path; }
 
-    void setBuffer(std::shared_ptr<AudioBufferData> buffer) { m_buffer = std::move(buffer); }
+    void setBuffer(std::shared_ptr<AudioBufferData> buffer) {
+        m_buffer = std::move(buffer);
+        m_waveformCache.reset();
+        ++m_contentRevision;
+    }
 
     std::shared_ptr<WaveformCache> getWaveformCache() const { return m_waveformCache; }
     void setWaveformCache(std::shared_ptr<WaveformCache> cache) { m_waveformCache = std::move(cache); }
@@ -87,6 +93,7 @@ private:
     std::string m_filePath;
     std::shared_ptr<AudioBufferData> m_buffer;
     std::shared_ptr<WaveformCache> m_waveformCache;
+    uint64_t m_contentRevision{0};
 };
 
 } // namespace Audio

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4248,15 +4248,19 @@ void TrackManagerUI::buildAllWaveformCaches() {
         if (src && src->isReady() && !src->getWaveformCache()) {
             ++queued;
             m_waveformBuilder.buildAsync(
-                *src, [weakSelf, src](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
+                *src, [weakSelf, srcId](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
                     if (!cache) return;
                     auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                     if (!self) return;
 
                     std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
-                    self->m_pendingTasks.push_back([weakSelf, src, cache]() {
+                    self->m_pendingTasks.push_back([weakSelf, srcId, cache]() {
                         auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                         if (!self) return;
+                        if (!self->m_trackManager) return;
+
+                        auto* src = self->m_trackManager->getSourceManager().getSource(srcId);
+                        if (!src) return;
 
                         src->setWaveformCache(cache);
                         self->invalidateCache();
@@ -4760,16 +4764,22 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
                                 // Trigger waveform cache build
                                 self->m_waveformBuilder.buildAsync(
-                                    *src, [weakSelf, src](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
+                                    *src, [weakSelf, sourceId](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
                                         if (cache) {
                                             auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                                             if (!self)
                                                 return;
 
                                             std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
-                                            self->m_pendingTasks.push_back([weakSelf, src, cache]() {
+                                            self->m_pendingTasks.push_back([weakSelf, sourceId, cache]() {
                                                 auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                                                 if (!self)
+                                                    return;
+                                                if (!self->m_trackManager)
+                                                    return;
+
+                                                auto* src = self->m_trackManager->getSourceManager().getSource(sourceId);
+                                                if (!src)
                                                     return;
 
                                                 src->setWaveformCache(cache);

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4246,21 +4246,23 @@ void TrackManagerUI::buildAllWaveformCaches() {
     for (auto srcId : ids) {
         auto* src = srcMgr.getSource(srcId);
         if (src && src->isReady() && !src->getWaveformCache()) {
+            const uint64_t sourceRevision = src->getContentRevision();
             ++queued;
             m_waveformBuilder.buildAsync(
-                *src, [weakSelf, srcId](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
+                *src, [weakSelf, srcId, sourceRevision](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
                     if (!cache) return;
                     auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                     if (!self) return;
 
                     std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
-                    self->m_pendingTasks.push_back([weakSelf, srcId, cache]() {
+                    self->m_pendingTasks.push_back([weakSelf, srcId, sourceRevision, cache]() {
                         auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                         if (!self) return;
                         if (!self->m_trackManager) return;
 
                         auto* src = self->m_trackManager->getSourceManager().getSource(srcId);
                         if (!src) return;
+                        if (src->getContentRevision() != sourceRevision) return;
 
                         src->setWaveformCache(cache);
                         self->invalidateCache();
@@ -4759,19 +4761,21 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                                 buffer->numChannels = numChannels;
                                 buffer->numFrames = buffer->interleavedData.size() / numChannels;
                                 src->setBuffer(buffer);
+                                const uint64_t sourceRevision = src->getContentRevision();
 
                                 Log::info("[TrackManagerUI] Async load complete for: " + filePath);
 
                                 // Trigger waveform cache build
                                 self->m_waveformBuilder.buildAsync(
-                                    *src, [weakSelf, sourceId](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
+                                    *src, [weakSelf, sourceId,
+                                           sourceRevision](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
                                         if (cache) {
                                             auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                                             if (!self)
                                                 return;
 
                                             std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
-                                            self->m_pendingTasks.push_back([weakSelf, sourceId, cache]() {
+                                            self->m_pendingTasks.push_back([weakSelf, sourceId, sourceRevision, cache]() {
                                                 auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                                                 if (!self)
                                                     return;
@@ -4780,6 +4784,8 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
                                                 auto* src = self->m_trackManager->getSourceManager().getSource(sourceId);
                                                 if (!src)
+                                                    return;
+                                                if (src->getContentRevision() != sourceRevision)
                                                     return;
 
                                                 src->setWaveformCache(cache);

--- a/Tests/AestraAudio/WaveformCacheTest.cpp
+++ b/Tests/AestraAudio/WaveformCacheTest.cpp
@@ -2,6 +2,7 @@
 
 #include "WaveformCache.h"
 
+#include <cstdint>
 #include <cmath>
 #include <iostream>
 #include <string>
@@ -207,6 +208,37 @@ bool testCacheSharing() {
     return true;
 }
 
+bool testSourceRevisionTracksBufferContent() {
+    ClipSource source(ClipSourceID{1}, "Test");
+    auto first = std::make_shared<AudioBufferData>();
+    first->interleavedData = {0.1f, -0.2f};
+    first->numChannels = 1;
+    first->numFrames = 2;
+    first->sampleRate = 48000;
+
+    const uint64_t initialRevision = source.getContentRevision();
+    source.setBuffer(first);
+    if (source.getContentRevision() != initialRevision + 1U) return fail("setBuffer should increment source revision");
+
+    WaveformCacheBuilder builder;
+    auto cache = builder.buildSync(source);
+    if (!cache || !cache->isReady()) return fail("sync build should produce cache before buffer replacement");
+    source.setWaveformCache(cache);
+    if (source.getWaveformCache() != cache) return fail("cache should be stored before buffer replacement");
+
+    auto second = std::make_shared<AudioBufferData>();
+    second->interleavedData = {0.3f, -0.4f};
+    second->numChannels = 1;
+    second->numFrames = 2;
+    second->sampleRate = 48000;
+
+    source.setBuffer(second);
+    if (source.getContentRevision() != initialRevision + 2U) return fail("second setBuffer should increment revision");
+    if (source.getWaveformCache()) return fail("buffer replacement should clear stale waveform cache");
+
+    return true;
+}
+
 // 7. Failure safety
 bool testFailureSafety() {
     WaveformCache cache;
@@ -310,6 +342,7 @@ int main() {
     ok &= testLodSelection();
     ok &= testVisibleRangeClipping();
     ok &= testCacheSharing();
+    ok &= testSourceRevisionTracksBufferContent();
     ok &= testFailureSafety();
     ok &= testNanInfSanitization();
     ok &= testVeryShortFile();


### PR DESCRIPTION
## Summary
- stop detached waveform callbacks from carrying raw ClipSource pointers into queued UI tasks
- capture source IDs instead and re-resolve the source on the main-thread task before setting waveform cache data
- drop callbacks safely when the UI or source has gone away

## Testing
- cmake --build build-ui --target Aestra -j2
- cmake --build build --target AestraWaveformCacheTest -j2
- build/Tests/AestraWaveformCacheTest
- ctest --test-dir build --output-on-failure -R '^AestraWaveformCacheTest$' (no tests found; this build does not register the experimental waveform cache test)
- git diff --check

## Risk
- If a source is removed before its waveform worker completes, the completion is ignored instead of writing through a stale pointer. Existing successful sources still get their waveform cache on the main-thread task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Summary

**Prevents stale pointer dereferences in waveform cache callbacks** by capturing source IDs instead of raw `ClipSource*` pointers and re-resolving them on the main thread before applying updates.

### Key Changes

- **`buildAllWaveformCaches()` method**: Modified the waveform builder callback to capture `srcId` (source identifier) instead of a direct source pointer. The queued main-thread task now calls `self->m_trackManager->getSourceManager().getSource(srcId)` to re-resolve the source and validates it exists before calling `setWaveformCache(cache)`.

- **Async file-import path**: Applied the same pattern to the waveform builder callback triggered during file imports. The nested async continuation now captures `sourceId` and performs the same re-resolution and validation on the main thread before writing cache data.

- **Failure safety**: If a source is removed before its waveform worker completes, the callback safely ignores the result rather than writing through a stale pointer. Successfully resolved sources still receive their waveform cache updates.

### Impact

- Eliminates potential use-after-free bugs when sources are removed while waveform building is in progress
- No breaking API changes; refactoring is internal to callback/lambda logic
- Successfully resolved sources continue to receive waveform cache updates on the main thread

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->