### PR TITLE
Own audition decode worker lifetime

### DIFF
--- a/AestraAudio/include/Playback/AuditionEngine.h
+++ b/AestraAudio/include/Playback/AuditionEngine.h
@@ -12,12 +12,14 @@
  */
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "ClipResampler.h"
@@ -216,13 +218,25 @@ public:
 
     // === Callbacks ===
 
-    void setOnTrackChanged(std::function<void(const AuditionQueueItem&)> cb) { m_onTrackChanged = std::move(cb); }
+    void setOnTrackChanged(std::function<void(const AuditionQueueItem&)> cb) {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        m_onTrackChanged = std::move(cb);
+    }
 
-    void setOnPlaybackStateChanged(std::function<void(bool isPlaying)> cb) { m_onPlaybackStateChanged = std::move(cb); }
+    void setOnPlaybackStateChanged(std::function<void(bool isPlaying)> cb) {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        m_onPlaybackStateChanged = std::move(cb);
+    }
 
-    void setOnPositionChanged(std::function<void(double seconds)> cb) { m_onPositionChanged = std::move(cb); }
+    void setOnPositionChanged(std::function<void(double seconds)> cb) {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        m_onPositionChanged = std::move(cb);
+    }
 
-    void setOnQueueUpdated(std::function<void()> cb) { m_onQueueUpdated = std::move(cb); }
+    void setOnQueueUpdated(std::function<void()> cb) {
+        std::lock_guard<std::mutex> lock(m_callbackMutex);
+        m_onQueueUpdated = std::move(cb);
+    }
 
     // === Audio Processing ===
 
@@ -237,12 +251,30 @@ public:
 
 private:
     void loadCurrentTrack(bool startPlayback);
-    /// Internal: decode and publish track. Caller must NOT hold m_queueMutex.
-    /// Spawns a background thread for the actual decode to keep the UI responsive.
+    /// Internal: queue decode and publish track. Caller must NOT hold m_queueMutex.
     void loadCurrentTrackImpl(const std::string& filePath, double lastPosition, bool isTimeline,
                               const std::string& title, bool startPlayback);
+    void decodeWorkerLoop();
+
+    struct DecodeJob {
+        std::string filePath;
+        double lastPosition{0.0};
+        bool isTimeline{false};
+        std::string title;
+        bool startPlayback{false};
+        uint64_t generation{0};
+    };
+
+    void cancelPendingDecodes();
+
     /// Generation counter: incremented on each load request so stale decode results are discarded
     std::atomic<uint64_t> m_loadGeneration{0};
+    std::thread m_decodeWorkerThread;
+    std::mutex m_decodeWorkerMutex;
+    std::condition_variable m_decodeWorkerCV;
+    std::optional<DecodeJob> m_pendingDecodeJob;
+    bool m_decodeWorkerRunning{true};
+
     // Queue (UI thread only - no RT access)
     std::vector<AuditionQueueItem> m_queue;
     int32_t m_currentIndex{-1};
@@ -308,6 +340,7 @@ private:
     std::function<void(bool)> m_onPlaybackStateChanged;
     std::function<void(double)> m_onPositionChanged;
     std::function<void()> m_onQueueUpdated;
+    mutable std::mutex m_callbackMutex;
 
     // Internal helpers
     void loadCurrentTrack();

--- a/AestraAudio/src/Playback/AuditionEngine.cpp
+++ b/AestraAudio/src/Playback/AuditionEngine.cpp
@@ -16,10 +16,22 @@ namespace Aestra {
 namespace Audio {
 
 AuditionEngine::AuditionEngine() {
+    m_decodeWorkerThread = std::thread(&AuditionEngine::decodeWorkerLoop, this);
     Log::info("[AuditionEngine] Created");
 }
 
 AuditionEngine::~AuditionEngine() {
+    cancelPendingDecodes();
+    {
+        std::lock_guard<std::mutex> lock(m_decodeWorkerMutex);
+        m_decodeWorkerRunning = false;
+        m_pendingDecodeJob.reset();
+    }
+    m_decodeWorkerCV.notify_one();
+    if (m_decodeWorkerThread.joinable()) {
+        m_decodeWorkerThread.join();
+    }
+
     stop();
     Log::info("[AuditionEngine] Destroyed");
 }
@@ -71,8 +83,11 @@ void AuditionEngine::addToQueue(const std::string& filePath, bool isReference) {
             shouldPreload = true;
         }
 
-        onQueueUpdated = m_onQueueUpdated;
         Log::info("[AuditionEngine] addToQueue complete");
+    }
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onQueueUpdated = m_onQueueUpdated;
     }
 
     Log::info("[AuditionEngine] Calling onQueueUpdated...");
@@ -105,6 +120,7 @@ void AuditionEngine::addTimelineTrack(uint32_t trackId, const std::string& track
 
 void AuditionEngine::clearQueue() {
     std::lock_guard<std::mutex> lock(m_queueMutex);
+    cancelPendingDecodes();
     stop();
     m_queue.clear();
     m_currentIndex = -1;
@@ -137,6 +153,9 @@ void AuditionEngine::removeFromQueue(size_t index) {
             shouldReloadCurrent = true;
         }
 
+    }
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
         onQueueUpdated = m_onQueueUpdated;
     }
 
@@ -168,6 +187,9 @@ void AuditionEngine::moveQueueItem(size_t fromIndex, size_t toIndex) {
             ++m_currentIndex;
         }
 
+    }
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
         onQueueUpdated = m_onQueueUpdated;
     }
     if (onQueueUpdated) onQueueUpdated();
@@ -297,8 +319,13 @@ void AuditionEngine::play() {
     }
 
     bool wasPlaying = m_isPlaying.exchange(true);
-    if (!wasPlaying && m_onPlaybackStateChanged) {
-        m_onPlaybackStateChanged(true);
+    std::function<void(bool)> onPlaybackStateChanged;
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onPlaybackStateChanged = m_onPlaybackStateChanged;
+    }
+    if (!wasPlaying && onPlaybackStateChanged) {
+        onPlaybackStateChanged(true);
     }
 
     Log::info("[AuditionEngine] Play");
@@ -306,8 +333,13 @@ void AuditionEngine::play() {
 
 void AuditionEngine::pause() {
     bool wasPlaying = m_isPlaying.exchange(false);
-    if (wasPlaying && m_onPlaybackStateChanged) {
-        m_onPlaybackStateChanged(false);
+    std::function<void(bool)> onPlaybackStateChanged;
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onPlaybackStateChanged = m_onPlaybackStateChanged;
+    }
+    if (wasPlaying && onPlaybackStateChanged) {
+        onPlaybackStateChanged(false);
     }
 
     Log::info("[AuditionEngine] Pause");
@@ -317,8 +349,13 @@ void AuditionEngine::stop() {
     m_isPlaying.store(false);
     m_positionSeconds.store(0.0);
 
-    if (m_onPlaybackStateChanged) {
-        m_onPlaybackStateChanged(false);
+    std::function<void(bool)> onPlaybackStateChanged;
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onPlaybackStateChanged = m_onPlaybackStateChanged;
+    }
+    if (onPlaybackStateChanged) {
+        onPlaybackStateChanged(false);
     }
 
     Log::info("[AuditionEngine] Stop");
@@ -350,8 +387,13 @@ void AuditionEngine::seekSeconds(double seconds) {
     //     m_currentSource->setPosition(seconds);
     // }
 
-    if (m_onPositionChanged) {
-        m_onPositionChanged(seconds);
+    std::function<void(double)> onPositionChanged;
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onPositionChanged = m_onPositionChanged;
+    }
+    if (onPositionChanged) {
+        onPositionChanged(seconds);
     }
 }
 
@@ -539,22 +581,52 @@ void AuditionEngine::loadCurrentTrackImpl(const std::string& filePath, double la
 
     Log::info("[AuditionEngine] Queuing async decode: " + filePath + " (gen=" + std::to_string(gen) + ")");
 
-    // Fire-and-forget decode on a detached thread — UI thread returns immediately.
-    // All captures are by value (safe for detached thread).
-    std::thread([this, filePath, lastPosition, title, startPlayback, gen]() {
+    {
+        std::lock_guard<std::mutex> lock(m_decodeWorkerMutex);
+        m_pendingDecodeJob = DecodeJob{filePath, lastPosition, false, title, startPlayback, gen};
+    }
+    m_decodeWorkerCV.notify_one();
+}
+
+void AuditionEngine::cancelPendingDecodes() {
+    m_loadGeneration.fetch_add(1, std::memory_order_acq_rel);
+    {
+        std::lock_guard<std::mutex> lock(m_decodeWorkerMutex);
+        m_pendingDecodeJob.reset();
+    }
+    m_decodeWorkerCV.notify_one();
+}
+
+void AuditionEngine::decodeWorkerLoop() {
+    while (true) {
+        DecodeJob job;
+        {
+            std::unique_lock<std::mutex> lock(m_decodeWorkerMutex);
+            m_decodeWorkerCV.wait(lock, [this] { return m_pendingDecodeJob.has_value() || !m_decodeWorkerRunning; });
+            if (!m_decodeWorkerRunning) {
+                return;
+            }
+            job = std::move(*m_pendingDecodeJob);
+            m_pendingDecodeJob.reset();
+        }
+
+        if (m_loadGeneration.load(std::memory_order_acquire) != job.generation) {
+            continue;
+        }
+
         std::vector<float> decodedData;
         uint32_t sr = 0;
         uint32_t ch = 0;
 
-        if (!decodeAudioFile(filePath, decodedData, sr, ch)) {
-            Log::error("[AuditionEngine] Failed to decode file: " + filePath);
-            return;
+        if (!decodeAudioFile(job.filePath, decodedData, sr, ch)) {
+            Log::error("[AuditionEngine] Failed to decode file: " + job.filePath);
+            continue;
         }
 
         // Discard stale results (user clicked something else)
-        if (m_loadGeneration.load(std::memory_order_acquire) != gen) {
-            Log::info("[AuditionEngine] Discarding stale decode (gen=" + std::to_string(gen) + ")");
-            return;
+        if (m_loadGeneration.load(std::memory_order_acquire) != job.generation) {
+            Log::info("[AuditionEngine] Discarding stale decode (gen=" + std::to_string(job.generation) + ")");
+            continue;
         }
 
         // Create AudioBufferData
@@ -567,7 +639,7 @@ void AuditionEngine::loadCurrentTrackImpl(const std::string& filePath, double la
         try {
             ClipSourceID id{0};
             auto newSource = std::make_shared<ClipSource>(id, "AuditionSource");
-            newSource->setFilePath(filePath);
+            newSource->setFilePath(job.filePath);
             newSource->setBuffer(bufferData);
 
             Log::info("[AuditionEngine] Source loaded: " + std::to_string(bufferData->durationSeconds()) + "s");
@@ -579,30 +651,37 @@ void AuditionEngine::loadCurrentTrackImpl(const std::string& filePath, double la
             Log::error("[AuditionEngine] Exception creating source: " + std::string(e.what()));
             std::atomic_store_explicit(&m_currentSource, std::shared_ptr<ClipSource>(nullptr), std::memory_order_release);
             m_cachedDurationSeconds.store(0.0, std::memory_order_release);
-            return;
+            continue;
         }
 
-        const double duration = getDurationSeconds();
-        const double clampedStart = (duration > 0.0) ? std::clamp(lastPosition, 0.0, duration) : std::max(0.0, lastPosition);
+        const double duration = bufferData->durationSeconds();
+        const double clampedStart =
+            (duration > 0.0) ? std::clamp(job.lastPosition, 0.0, duration) : std::max(0.0, job.lastPosition);
         m_positionSeconds.store(clampedStart, std::memory_order_release);
         m_cachedDurationSeconds.store(duration, std::memory_order_release);
 
-        // Notify callback directly (don't use notifyTrackChanged — it reads m_queue
-        // without the lock, which is unsafe from a background thread).
-        if (m_onTrackChanged) {
-            AuditionQueueItem item;
-            item.filePath = filePath;
-            item.title = title;
-            m_onTrackChanged(item);
+        std::function<void(const AuditionQueueItem&)> onTrackChanged;
+        std::function<void(bool)> onPlaybackStateChanged;
+        {
+            std::lock_guard<std::mutex> lock(m_callbackMutex);
+            onTrackChanged = m_onTrackChanged;
+            onPlaybackStateChanged = m_onPlaybackStateChanged;
         }
 
-        if (startPlayback && !m_isPlaying.load(std::memory_order_relaxed)) {
+        if (onTrackChanged) {
+            AuditionQueueItem item;
+            item.filePath = job.filePath;
+            item.title = job.title;
+            onTrackChanged(item);
+        }
+
+        if (job.startPlayback && !m_isPlaying.load(std::memory_order_relaxed)) {
             m_isPlaying.store(true, std::memory_order_release);
-            if (m_onPlaybackStateChanged) {
-                m_onPlaybackStateChanged(true);
+            if (onPlaybackStateChanged) {
+                onPlaybackStateChanged(true);
             }
         }
-    }).detach();
+    }
 }
 
 std::shared_ptr<ClipSource> AuditionEngine::getCurrentSource() const {
@@ -846,8 +925,20 @@ void AuditionEngine::handleDeferredTrackTransition() {
 }
 
 void AuditionEngine::notifyTrackChanged() {
-    if (m_onTrackChanged && m_currentIndex >= 0 && m_currentIndex < static_cast<int32_t>(m_queue.size())) {
-        m_onTrackChanged(m_queue[static_cast<size_t>(m_currentIndex)]);
+    std::optional<AuditionQueueItem> item;
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        if (m_currentIndex >= 0 && m_currentIndex < static_cast<int32_t>(m_queue.size())) {
+            item = m_queue[static_cast<size_t>(m_currentIndex)];
+        }
+    }
+    std::function<void(const AuditionQueueItem&)> onTrackChanged;
+    {
+        std::lock_guard<std::mutex> callbackLock(m_callbackMutex);
+        onTrackChanged = m_onTrackChanged;
+    }
+    if (item && onTrackChanged) {
+        onTrackChanged(*item);
     }
 }
 

--- a/AestraAudio/src/Playback/AuditionEngine.cpp
+++ b/AestraAudio/src/Playback/AuditionEngine.cpp
@@ -642,6 +642,12 @@ void AuditionEngine::decodeWorkerLoop() {
             newSource->setFilePath(job.filePath);
             newSource->setBuffer(bufferData);
 
+            if (m_loadGeneration.load(std::memory_order_acquire) != job.generation) {
+                Log::info("[AuditionEngine] Discarding stale decode before publish (gen=" +
+                          std::to_string(job.generation) + ")");
+                continue;
+            }
+
             Log::info("[AuditionEngine] Source loaded: " + std::to_string(bufferData->durationSeconds()) + "s");
 
             // Atomic publish to RT thread
@@ -659,6 +665,12 @@ void AuditionEngine::decodeWorkerLoop() {
             (duration > 0.0) ? std::clamp(job.lastPosition, 0.0, duration) : std::max(0.0, job.lastPosition);
         m_positionSeconds.store(clampedStart, std::memory_order_release);
         m_cachedDurationSeconds.store(duration, std::memory_order_release);
+
+        if (m_loadGeneration.load(std::memory_order_acquire) != job.generation) {
+            Log::info("[AuditionEngine] Discarding stale decode before callbacks (gen=" +
+                      std::to_string(job.generation) + ")");
+            continue;
+        }
 
         std::function<void(const AuditionQueueItem&)> onTrackChanged;
         std::function<void(bool)> onPlaybackStateChanged;

--- a/Tests/AestraAudio/AuditionEngineLifecycleTest.cpp
+++ b/Tests/AestraAudio/AuditionEngineLifecycleTest.cpp
@@ -1,0 +1,76 @@
+#include "Playback/AuditionEngine.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+void writeUint32(std::ofstream& out, uint32_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+    out.put(static_cast<char>((value >> 16) & 0xFF));
+    out.put(static_cast<char>((value >> 24) & 0xFF));
+}
+
+void writeUint16(std::ofstream& out, uint16_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+}
+
+bool writeTestWav(const std::string& path) {
+    std::ofstream wav(path, std::ios::binary);
+    if (!wav) {
+        return false;
+    }
+
+    const uint16_t channels = 1;
+    const uint16_t bitsPerSample = 16;
+    const uint32_t sampleRate = 48000;
+    const uint32_t samples = 512;
+    const uint32_t bytesPerSample = bitsPerSample / 8;
+    const uint32_t dataChunkSize = samples * bytesPerSample;
+    const uint32_t riffChunkSize = 4 + (8 + 16) + (8 + dataChunkSize);
+
+    wav.write("RIFF", 4);
+    writeUint32(wav, riffChunkSize);
+    wav.write("WAVE", 4);
+    wav.write("fmt ", 4);
+    writeUint32(wav, 16);
+    writeUint16(wav, 1);
+    writeUint16(wav, channels);
+    writeUint32(wav, sampleRate);
+    writeUint32(wav, sampleRate * channels * bytesPerSample);
+    writeUint16(wav, channels * bytesPerSample);
+    writeUint16(wav, bitsPerSample);
+    wav.write("data", 4);
+    writeUint32(wav, dataChunkSize);
+    for (uint32_t i = 0; i < samples; ++i) {
+        writeUint16(wav, static_cast<uint16_t>(i & 0x7FFFU));
+    }
+    return static_cast<bool>(wav);
+}
+} // namespace
+
+int main() {
+    const fs::path path = fs::temp_directory_path() / "Aestra_audition_lifecycle.wav";
+    if (!writeTestWav(path.string())) {
+        std::cerr << "failed to write audition lifecycle fixture\n";
+        return 1;
+    }
+
+    {
+        Aestra::Audio::AuditionEngine engine;
+        engine.addToQueue(path.string());
+        engine.play();
+        engine.clearQueue();
+    }
+
+    fs::remove(path);
+    std::cout << "AestraAuditionEngineLifecycleTest: PASS\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -676,6 +676,11 @@ add_executable(AestraWavLoaderTest AestraAudio/WavLoaderTest.cpp)
 target_link_libraries(AestraWavLoaderTest PRIVATE AestraAudio)
 add_test(NAME AestraWavLoaderTest COMMAND AestraWavLoaderTest)
 
+# Audition Engine lifecycle regression
+add_executable(AestraAuditionEngineLifecycleTest AestraAudio/AuditionEngineLifecycleTest.cpp)
+target_link_libraries(AestraAuditionEngineLifecycleTest PRIVATE AestraAudio)
+add_test(NAME AestraAuditionEngineLifecycleTest COMMAND AestraAuditionEngineLifecycleTest)
+
 # SamplePool Test
 add_executable(SamplePoolTest AestraAudio/SamplePoolTest.cpp)
 target_link_libraries(SamplePoolTest PRIVATE AestraAudio)


### PR DESCRIPTION
Summary:
- replace detached audition decode threads with one owned worker joined by AuditionEngine
- invalidate pending/in-flight decode jobs on queue clear and destruction
- publish decoded audition sources without reading the queue from the worker thread
- add an audition lifecycle regression test for clear/destroy during lazy decode

Why:
- fixes the CSV finding: Detached audition decode races queue and object lifetime

Testing:
- cmake -S . -B build
- cmake --build build --target AestraAuditionEngineLifecycleTest -j2
- ctest --test-dir build --output-on-failure -R '^AestraAuditionEngineLifecycleTest$'
- git diff --check

Docs updated: no
Risk/rollback:
- decode requests are now serialized through one worker; this favors lifecycle safety over spawning one detached thread per track click.