### PR TITLE
Clamp mixer lane state before casting

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1359,19 +1359,15 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         if (lj[i].has("monitorInput") && lj[i]["monitorInput"].isBool())
                             channel->setMonitoringEnabled(lj[i]["monitorInput"].asBool());
                         if (lj[i].has("inputChannelIndex") && lj[i]["inputChannelIndex"].isNumber()) {
-                            const double raw = lj[i]["inputChannelIndex"].asNumber();
-                            if (std::isfinite(raw))
-                                channel->setInputChannelIndex(std::clamp(static_cast<int>(raw), -2, 1024));
+                            channel->setInputChannelIndex(
+                                static_cast<int>(finiteNumberOr(lj[i], "inputChannelIndex", -2.0, -2.0, 1024.0)));
                         }
                         if (lj[i].has("width") && lj[i]["width"].isNumber()) {
-                            const double raw = lj[i]["width"].asNumber();
-                            if (std::isfinite(raw))
-                                channel->setWidth(static_cast<float>(std::clamp(raw, 0.0, 4.0)));
+                            channel->setWidth(static_cast<float>(finiteNumberOr(lj[i], "width", 1.0, 0.0, 4.0)));
                         }
                         if (lj[i].has("trackColorIndex") && lj[i]["trackColorIndex"].isNumber()) {
-                            const double raw = lj[i]["trackColorIndex"].asNumber();
-                            if (std::isfinite(raw))
-                                channel->setTrackColorIndex(std::clamp(static_cast<int>(raw), -1, 1024));
+                            channel->setTrackColorIndex(
+                                static_cast<int>(finiteNumberOr(lj[i], "trackColorIndex", -1.0, -1.0, 1024.0)));
                         }
 
                         if (lj[i].has("routing") && lj[i]["routing"].isObject()) {

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1359,15 +1359,24 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         if (lj[i].has("monitorInput") && lj[i]["monitorInput"].isBool())
                             channel->setMonitoringEnabled(lj[i]["monitorInput"].asBool());
                         if (lj[i].has("inputChannelIndex") && lj[i]["inputChannelIndex"].isNumber()) {
-                            channel->setInputChannelIndex(
-                                static_cast<int>(finiteNumberOr(lj[i], "inputChannelIndex", -2.0, -2.0, 1024.0)));
+                            const double raw = lj[i]["inputChannelIndex"].asNumber();
+                            if (std::isfinite(raw)) {
+                                channel->setInputChannelIndex(
+                                    static_cast<int>(std::clamp(raw, -2.0, 1024.0)));
+                            }
                         }
                         if (lj[i].has("width") && lj[i]["width"].isNumber()) {
-                            channel->setWidth(static_cast<float>(finiteNumberOr(lj[i], "width", 1.0, 0.0, 4.0)));
+                            const double raw = lj[i]["width"].asNumber();
+                            if (std::isfinite(raw)) {
+                                channel->setWidth(static_cast<float>(std::clamp(raw, 0.0, 4.0)));
+                            }
                         }
                         if (lj[i].has("trackColorIndex") && lj[i]["trackColorIndex"].isNumber()) {
-                            channel->setTrackColorIndex(
-                                static_cast<int>(finiteNumberOr(lj[i], "trackColorIndex", -1.0, -1.0, 1024.0)));
+                            const double raw = lj[i]["trackColorIndex"].asNumber();
+                            if (std::isfinite(raw)) {
+                                channel->setTrackColorIndex(
+                                    static_cast<int>(std::clamp(raw, -1.0, 1024.0)));
+                            }
                         }
 
                         if (lj[i].has("routing") && lj[i]["routing"].isObject()) {

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -624,6 +624,53 @@ void testAutomationTarget256DoesNotWrapToVolume() {
     std::filesystem::remove_all(testDir);
 }
 
+void testMixerLaneStateNumbersClampBeforeCast() {
+    std::cout << "[TEST] Mixer lane state numbers clamp before cast..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testProject = testDir / "project.aes";
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "inputChannelIndex": 2147483648,
+                "width": 1e100,
+                "trackColorIndex": 1e100,
+                "clips": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(trackManager->getChannelCount() == 1);
+
+    auto* channel = trackManager->getChannel(0);
+    assert(channel != nullptr);
+    assert(channel->getInputChannelIndex() == 1024);
+    assert(channel->getTrackColorIndex() == 1024);
+    assert(std::abs(channel->getWidth() - 4.0f) < 1e-6f);
+
+    std::cout << "[PASS] Mixer lane state numbers clamp before cast" << std::endl;
+
+    std::filesystem::remove_all(testDir);
+}
+
 }
 
 int main() {
@@ -638,6 +685,7 @@ int main() {
     testUnresolvedRouteTargetNonFatal();
     testV1FixtureMigratesToCurrentVersion();
     testAutomationTarget256DoesNotWrapToVolume();
+    testMixerLaneStateNumbersClampBeforeCast();
 
     std::cout << "=== All tests passed ===" << std::endl;
     return 0;

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -646,6 +646,15 @@ void testMixerLaneStateNumbersClampBeforeCast() {
                 "width": 1e100,
                 "trackColorIndex": 1e100,
                 "clips": []
+            },
+            {
+                "name": "Track 2",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "inputChannelIndex": -1e100,
+                "trackColorIndex": -1e100,
+                "clips": []
             }
         ],
         "arsenal": {"nextId": 1, "units": []}
@@ -658,13 +667,18 @@ void testMixerLaneStateNumbersClampBeforeCast() {
     auto trackManager = std::make_shared<TrackManager>();
     auto result = ProjectSerializer::load(testProject.string(), trackManager);
     assert(result.ok);
-    assert(trackManager->getChannelCount() == 1);
+    assert(trackManager->getChannelCount() == 2);
 
     auto* channel = trackManager->getChannel(0);
     assert(channel != nullptr);
     assert(channel->getInputChannelIndex() == 1024);
     assert(channel->getTrackColorIndex() == 1024);
     assert(std::abs(channel->getWidth() - 4.0f) < 1e-6f);
+
+    auto* negativeChannel = trackManager->getChannel(1);
+    assert(negativeChannel != nullptr);
+    assert(negativeChannel->getInputChannelIndex() == -2);
+    assert(negativeChannel->getTrackColorIndex() == -1);
 
     std::cout << "[PASS] Mixer lane state numbers clamp before cast" << std::endl;
 


### PR DESCRIPTION
## Summary
- parse persisted mixer lane input, width, and track color numbers through finite bounded helpers before casting
- add project-load regression coverage for large finite mixer state values

## Why
Project files are untrusted. The previous load path clamped after casting large finite doubles to int, which can invoke undefined behavior for values outside the target type range.

## Testing
- cmake --build build --target ProjectLoadRegressionTest -j2
- ctest --test-dir build --output-on-failure -R '^ProjectLoadRegressionTest$'
- git diff --check

## Docs updated?
No.

## Risk / rollback
Low. The change preserves existing bounds (-2..1024 input, 0..4 width, -1..1024 color index) but applies them before narrowing conversions. Roll back this commit if project-load compatibility unexpectedly depends on unbounded mixer lane values.