### PR TITLE
Cache render main output slot lookup

### DIFF
--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2563,6 +2563,16 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         double* lfStateL = publishTrackSnapshot ? &m_meterLfStateL[slot] : nullptr;
         double* lfStateR = publishTrackSnapshot ? &m_meterLfStateR[slot] : nullptr;
 
+        const bool routesMainToMaster = track.mainOutputId == 0xFFFFFFFFu;
+        double* mainDestBuffer = nullptr;
+        if (!routesMainToMaster && audibleEligible && slotMap) {
+            const uint32_t destSlot = slotMap->getSlotIndex(track.mainOutputId);
+            if (destSlot != ChannelSlotMap::INVALID_SLOT && destSlot < availableTracks && destSlot != trackIdx &&
+                (!anySolo || m_rtAudibleEligible[destSlot])) {
+                mainDestBuffer = m_trackBuffersD[destSlot].data();
+            }
+        }
+
         bool hasPreFaderSend = std::any_of(track.sends.begin(), track.sends.end(),
                                            [](const auto& send) { return !send.mute && !send.postFader; });
         const size_t preFaderSize = static_cast<size_t>(numFrames) * 2u;
@@ -2595,17 +2605,12 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             buffer[i * 2 + 1] = outR;
 
             if (!muted) {
-                if (audibleEligible && track.mainOutputId == 0xFFFFFFFFu) {
+                if (audibleEligible && routesMainToMaster) {
                     masterBuf[i * 2] += outL;
                     masterBuf[i * 2 + 1] += outR;
-                } else if (audibleEligible && slotMap) {
-                    const uint32_t destSlot = slotMap->getSlotIndex(track.mainOutputId);
-                    if (destSlot != ChannelSlotMap::INVALID_SLOT && destSlot < availableTracks &&
-                        destSlot != trackIdx && (!anySolo || m_rtAudibleEligible[destSlot])) {
-                        auto& destBuffer = m_trackBuffersD[destSlot];
-                        destBuffer[i * 2] += outL;
-                        destBuffer[i * 2 + 1] += outR;
-                    }
+                } else if (mainDestBuffer) {
+                    mainDestBuffer[i * 2] += outL;
+                    mainDestBuffer[i * 2 + 1] += outR;
                 }
             }
 


### PR DESCRIPTION
## Summary
- resolve each track's main output slot once per render block instead of per frame
- route post-fader samples through the cached destination buffer pointer

## Why
Project routing is untrusted input. A project with many tracks routed to late or missing channel IDs could force repeated linear ChannelSlotMap scans inside the real-time per-frame loop.

## Testing
- cmake --build build --target AestraAudioCore -j2
- git diff --check

## Docs updated?
No.

## Risk / rollback
Low-medium. This preserves existing routing conditions and only hoists the slot lookup out of the frame loop. Runtime stress tests are intentionally gated behind AESTRA_ENABLE_RUNTIME_TESTS and were not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->