### PR TITLE
Limit nightly workflow token permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-      issues: write
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
     env:
       ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
@@ -26,6 +27,7 @@ jobs:
         with:
           submodules: false
           ref: develop
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -64,13 +66,21 @@ jobs:
           path: build-nightly/
           retention-days: 7
 
+  open-issue-on-failure:
+    name: Open Nightly Failure Issue
+    runs-on: ubuntu-latest
+    needs: nightly-headless
+    if: ${{ needs.nightly-headless.result == 'failure' }}
+    permissions:
+      issues: write
+
+    steps:
       - name: Open issue on failure
-        if: failure()
         uses: actions/github-script@v7
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
-            const sha = '${{ steps.sha.outputs.sha }}';
+            const sha = '${{ needs.nightly-headless.outputs.sha || github.sha }}';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,10 @@ jobs:
           ref: develop
           persist-credentials: false
 
+      - name: Capture develop SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -48,10 +52,6 @@ jobs:
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 
-      - name: Capture develop SHA
-        id: sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Build
         run: cmake --build build-nightly --parallel
 
@@ -70,7 +70,7 @@ jobs:
     name: Open Nightly Failure Issue
     runs-on: ubuntu-latest
     needs: nightly-headless
-    if: ${{ needs.nightly-headless.result == 'failure' }}
+    if: ${{ always() && needs.nightly-headless.result == 'failure' }}
     permissions:
       issues: write
 
@@ -80,7 +80,7 @@ jobs:
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
-            const sha = '${{ needs.nightly-headless.outputs.sha || github.sha }}';
+            const sha = '${{ needs.nightly-headless.outputs.sha || 'develop checkout unavailable' }}';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- remove issues: write from the nightly build/test job
- disable persisted checkout credentials for the nightly checkout
- move failure issue creation into a separate failure-only job with issues: write

## Why
The nightly build executes repository code and dependencies. It should not expose an issue-write token to configure/build/test steps or persist credentials in the checkout.

## Testing
- python3 - <<'PY'
try:
    import yaml
except Exception as exc:
    raise SystemExit(f'pyyaml unavailable: {exc}')
with open('.github/workflows/nightly.yml') as f:
    yaml.safe_load(f)
print('yaml ok')
PY
- git diff --check

## Docs updated?
No.

## Risk / rollback
Low. The nightly failure issue logic is preserved in a separate job that runs only when the build/test job fails. Artifact upload remains in the read-only build job.