### PR TITLE
Sanitize AestraDrift state parameters

### DIFF
--- a/AestraAudio/include/Plugin/AestraDrift.h
+++ b/AestraAudio/include/Plugin/AestraDrift.h
@@ -153,6 +153,7 @@ public:
 
     void setParameter(uint32_t id, float value) override {
         if (id >= kParamCount) return;
+        if (!std::isfinite(value)) return;
         m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
     }
 

--- a/Tests/AestraAudio/AestraDriftStateTest.cpp
+++ b/Tests/AestraAudio/AestraDriftStateTest.cpp
@@ -1,0 +1,59 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Plugin/AestraDrift.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraDrift;
+
+namespace {
+
+void writeFloat(std::vector<uint8_t>& bytes, size_t offset, float value) {
+    assert(offset + sizeof(float) <= bytes.size());
+    std::memcpy(bytes.data() + offset, &value, sizeof(float));
+}
+
+void testNanStateDoesNotEnterParametersOrProcessing() {
+    AestraDrift drift;
+    assert(drift.initialize(48000.0, 64));
+    drift.setParameter(AestraDrift::kPitch, 0.25f);
+
+    std::vector<uint8_t> state = drift.saveState();
+    assert(state.size() >= sizeof(uint32_t) * 2 + sizeof(float) * AestraDrift::kParamCount);
+
+    constexpr size_t kParamOffset = sizeof(uint32_t) * 2;
+    writeFloat(state, kParamOffset + sizeof(float) * AestraDrift::kPitch, std::numeric_limits<float>::quiet_NaN());
+    writeFloat(state, kParamOffset + sizeof(float) * AestraDrift::kMix, 0.5f);
+
+    AestraDrift restored;
+    assert(restored.initialize(48000.0, 64));
+    assert(restored.loadState(state));
+    assert(restored.getParameter(AestraDrift::kPitch) == 0.5f);
+    assert(restored.getParameter(AestraDrift::kMix) == 0.5f);
+
+    restored.activate();
+    float inL[64] = {};
+    float inR[64] = {};
+    float outL[64] = {};
+    float outR[64] = {};
+    const float* inputs[2] = {inL, inR};
+    float* outputs[2] = {outL, outR};
+
+    restored.process(inputs, outputs, 2, 2, 64, nullptr, nullptr);
+    for (uint32_t i = 0; i < 64; ++i) {
+        assert(std::isfinite(outL[i]));
+        assert(std::isfinite(outR[i]));
+    }
+}
+
+} // namespace
+
+int main() {
+    testNanStateDoesNotEnterParametersOrProcessing();
+    return 0;
+}

--- a/Tests/AestraAudio/AestraDriftStateTest.cpp
+++ b/Tests/AestraAudio/AestraDriftStateTest.cpp
@@ -51,9 +51,43 @@ void testNanStateDoesNotEnterParametersOrProcessing() {
     }
 }
 
+void testInfStateDoesNotEnterParametersOrProcessing() {
+    AestraDrift drift;
+    assert(drift.initialize(48000.0, 64));
+    drift.setParameter(AestraDrift::kPitch, 0.25f);
+
+    std::vector<uint8_t> state = drift.saveState();
+    assert(state.size() >= sizeof(uint32_t) * 2 + sizeof(float) * AestraDrift::kParamCount);
+
+    constexpr size_t kParamOffset = sizeof(uint32_t) * 2;
+    writeFloat(state, kParamOffset + sizeof(float) * AestraDrift::kPitch, std::numeric_limits<float>::infinity());
+    writeFloat(state, kParamOffset + sizeof(float) * AestraDrift::kMix, 0.5f);
+
+    AestraDrift restored;
+    assert(restored.initialize(48000.0, 64));
+    assert(restored.loadState(state));
+    assert(restored.getParameter(AestraDrift::kPitch) == 0.5f);
+    assert(restored.getParameter(AestraDrift::kMix) == 0.5f);
+
+    restored.activate();
+    float inL[64] = {};
+    float inR[64] = {};
+    float outL[64] = {};
+    float outR[64] = {};
+    const float* inputs[2] = {inL, inR};
+    float* outputs[2] = {outL, outR};
+
+    restored.process(inputs, outputs, 2, 2, 64, nullptr, nullptr);
+    for (uint32_t i = 0; i < 64; ++i) {
+        assert(std::isfinite(outL[i]));
+        assert(std::isfinite(outR[i]));
+    }
+}
+
 } // namespace
 
 int main() {
     testNanStateDoesNotEnterParametersOrProcessing();
+    testInfStateDoesNotEnterParametersOrProcessing();
     return 0;
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -910,6 +910,17 @@ target_include_directories(AestraEQTest PRIVATE
 add_test(NAME AestraEQTest COMMAND AestraEQTest)
 set_tests_properties(AestraEQTest PROPERTIES LABELS "audio;plugins;eq")
 
+# Aestra Drift Plugin State Test
+add_executable(AestraDriftStateTest AestraAudio/AestraDriftStateTest.cpp)
+target_link_libraries(AestraDriftStateTest PRIVATE AestraAudio)
+target_include_directories(AestraDriftStateTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraDriftStateTest COMMAND AestraDriftStateTest)
+set_tests_properties(AestraDriftStateTest PROPERTIES LABELS "audio;plugins;drift;security")
+
 # Aestra Comp Phase 0 Test
 add_executable(AestraCompPhase0Test AestraAudio/AestraCompPhase0Test.cpp)
 target_link_libraries(AestraCompPhase0Test PRIVATE AestraAudio)


### PR DESCRIPTION
## Summary
- ignore non-finite AestraDrift parameter values before they enter atomic DSP state
- add a regression test that mutates saved Drift state to contain NaN and verifies finite processing output

## Why
Project-controlled built-in plugin state can restore AestraDrift parameter floats. NaN pitch values can propagate into tap phase/read positions in the realtime pitch shifter.

## Testing
- cmake -S . -B build
- cmake --build build --target AestraDriftStateTest -j2
- ctest --test-dir build --output-on-failure -R '^AestraDriftStateTest$'
- git diff --check

## Docs updated?
No.

## Risk / rollback
Low. Finite parameter behavior is unchanged; non-finite values are ignored, preserving the previous/default parameter value rather than entering DSP state.