### PR TITLE
Bound account cache badge refresh work

### DIFF
--- a/AestraLicense/src/LocalAccountCache.cpp
+++ b/AestraLicense/src/LocalAccountCache.cpp
@@ -154,7 +154,12 @@ LocalAccountCacheLoadResult LocalAccountCache::load() const {
     LocalAccountCacheLoadResult result;
     std::error_code sizeEc;
     const std::uintmax_t cacheSize = std::filesystem::file_size(m_cachePath, sizeEc);
-    if (!sizeEc && cacheSize > kMaxAccountCacheBytes) {
+    if (sizeEc) {
+        // file_size failed (special file, FUSE mount, etc.) — treat as unreadable
+        result.status = LocalAccountCacheLoadStatus::Missing;
+        return result;
+    }
+    if (cacheSize > kMaxAccountCacheBytes) {
         result.status = LocalAccountCacheLoadStatus::Malformed;
         return result;
     }

--- a/AestraLicense/src/LocalAccountCache.cpp
+++ b/AestraLicense/src/LocalAccountCache.cpp
@@ -12,6 +12,7 @@ namespace License {
 
 namespace {
 constexpr int kSchemaVersion = 1;
+constexpr std::uintmax_t kMaxAccountCacheBytes = 64u * 1024u;
 
 std::filesystem::path defaultDataDir() {
     if (const char* envDir = std::getenv("AESTRA_DATA_DIR")) {
@@ -151,6 +152,13 @@ LocalAccountCache::LocalAccountCache(std::filesystem::path cachePath) : m_cacheP
 
 LocalAccountCacheLoadResult LocalAccountCache::load() const {
     LocalAccountCacheLoadResult result;
+    std::error_code sizeEc;
+    const std::uintmax_t cacheSize = std::filesystem::file_size(m_cachePath, sizeEc);
+    if (!sizeEc && cacheSize > kMaxAccountCacheBytes) {
+        result.status = LocalAccountCacheLoadStatus::Malformed;
+        return result;
+    }
+
     std::ifstream file(m_cachePath, std::ios::binary);
     if (!file.good()) {
         result.status = LocalAccountCacheLoadStatus::Missing;
@@ -212,22 +220,29 @@ bool LocalAccountCache::save(const LocalAccountRecord& record) const {
     }
 
     try {
+        std::ostringstream payload;
+        payload << "{\n"
+                << "  \"schema_version\": " << kSchemaVersion << ",\n"
+                << "  \"user_id\": \"" << escapeJsonString(record.identity.userId) << "\",\n"
+                << "  \"email\": \"" << escapeJsonString(record.identity.email) << "\",\n"
+                << "  \"display_name\": \"" << escapeJsonString(record.identity.displayName) << "\",\n"
+                << "  \"avatar_url\": \"" << escapeJsonString(record.identity.avatarUrl) << "\",\n"
+                << "  \"session_token\": \"" << escapeJsonString(record.sessionToken) << "\",\n"
+                << "  \"last_sync_unix\": " << record.lastSyncUnix << ",\n"
+                << "  \"session_state\": \"" << accountSessionStateToString(record.state) << "\"\n"
+                << "}\n";
+        const std::string serialized = payload.str();
+        if (serialized.size() > kMaxAccountCacheBytes) {
+            return false;
+        }
+
         std::filesystem::create_directories(m_cachePath.parent_path());
 
         std::ofstream file(m_cachePath, std::ios::binary | std::ios::trunc);
         if (!file.good()) {
             return false;
         }
-        file << "{\n"
-             << "  \"schema_version\": " << kSchemaVersion << ",\n"
-             << "  \"user_id\": \"" << escapeJsonString(record.identity.userId) << "\",\n"
-             << "  \"email\": \"" << escapeJsonString(record.identity.email) << "\",\n"
-             << "  \"display_name\": \"" << escapeJsonString(record.identity.displayName) << "\",\n"
-             << "  \"avatar_url\": \"" << escapeJsonString(record.identity.avatarUrl) << "\",\n"
-             << "  \"session_token\": \"" << escapeJsonString(record.sessionToken) << "\",\n"
-             << "  \"last_sync_unix\": " << record.lastSyncUnix << ",\n"
-             << "  \"session_state\": \"" << accountSessionStateToString(record.state) << "\"\n"
-             << "}\n";
+        file << serialized;
         return file.good();
     } catch (const std::exception&) {
         return false;

--- a/Source/Core/AestraRootComponent.h
+++ b/Source/Core/AestraRootComponent.h
@@ -14,8 +14,9 @@
 #include "LocalAccountCache.h"
 #include "MembershipViewModel.h"
 #endif
-#include <memory>
+#include <algorithm>
 #include <functional>
+#include <memory>
 
 using namespace AestraUI;
 
@@ -35,6 +36,8 @@ private:
     class AestraContent* m_rootContent{nullptr};
     std::function<void(TransportAction)> m_rootTransportCallback;
     std::function<void()> m_rootSaveCallback;
+    static constexpr double kMembershipBadgeRefreshIntervalSeconds = 1.0;
+    double m_membershipBadgeRefreshSeconds = kMembershipBadgeRefreshIntervalSeconds;
 
 public:
     AestraRootComponent() = default;
@@ -70,7 +73,7 @@ public:
     }
     
     void onUpdate(double deltaTime) override {
-        updateMembershipBadge();
+        updateMembershipBadge(deltaTime);
         NUIComponent::updateGlobalTooltip(deltaTime);
         NUIComponent::onUpdate(deltaTime);
     }
@@ -104,10 +107,18 @@ public:
     }
 
 private:
-    void updateMembershipBadge() {
+    void updateMembershipBadge(double deltaTime) {
         if (!m_rootCustomWindow || !m_rootCustomWindow->getTitleBar()) {
             return;
         }
+        if (m_membershipBadgeRefreshSeconds < kMembershipBadgeRefreshIntervalSeconds) {
+            if (deltaTime > 0.0) {
+                m_membershipBadgeRefreshSeconds +=
+                    std::min(deltaTime, kMembershipBadgeRefreshIntervalSeconds);
+            }
+            return;
+        }
+        m_membershipBadgeRefreshSeconds = 0.0;
 
         std::string tier = "Core";
         std::string status = "Signed out";

--- a/Source/Core/AestraRootComponent.h
+++ b/Source/Core/AestraRootComponent.h
@@ -112,10 +112,8 @@ private:
             return;
         }
         if (m_membershipBadgeRefreshSeconds < kMembershipBadgeRefreshIntervalSeconds) {
-            if (deltaTime > 0.0) {
-                m_membershipBadgeRefreshSeconds +=
-                    std::min(deltaTime, kMembershipBadgeRefreshIntervalSeconds);
-            }
+            m_membershipBadgeRefreshSeconds +=
+                std::max(std::min(deltaTime, kMembershipBadgeRefreshIntervalSeconds), 0.0);
             return;
         }
         m_membershipBadgeRefreshSeconds = 0.0;

--- a/Tests/AestraLicense/LocalAccountCacheTest.cpp
+++ b/Tests/AestraLicense/LocalAccountCacheTest.cpp
@@ -1,0 +1,78 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "LocalAccountCache.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using Aestra::License::AccountSessionState;
+using Aestra::License::LocalAccountCache;
+using Aestra::License::LocalAccountCacheLoadStatus;
+using Aestra::License::LocalAccountRecord;
+
+namespace {
+
+std::filesystem::path testCachePath() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return std::filesystem::temp_directory_path() /
+           ("aestra_local_account_cache_test_" + std::to_string(stamp) + ".json");
+}
+
+LocalAccountRecord validRecord() {
+    LocalAccountRecord record;
+    record.identity.userId = "user-123";
+    record.identity.email = "user@example.test";
+    record.identity.displayName = "Test User";
+    record.identity.avatarUrl = "https://example.test/avatar.png";
+    record.sessionToken = "session-token";
+    record.lastSyncUnix = 123456789;
+    record.state = AccountSessionState::SignedInFresh;
+    record.hasIdentity = true;
+    return record;
+}
+
+void testRoundTrip() {
+    const std::filesystem::path path = testCachePath();
+    LocalAccountCache cache(path);
+    assert(cache.save(validRecord()));
+
+    const auto loaded = cache.load();
+    assert(loaded.status == LocalAccountCacheLoadStatus::Loaded);
+    assert(loaded.record.identity.userId == "user-123");
+    assert(cache.clear());
+}
+
+void testOversizedCacheLoadIsMalformed() {
+    const std::filesystem::path path = testCachePath();
+    {
+        std::ofstream file(path, std::ios::binary | std::ios::trunc);
+        file << std::string(64u * 1024u + 1u, 'x');
+    }
+
+    LocalAccountCache cache(path);
+    const auto loaded = cache.load();
+    assert(loaded.status == LocalAccountCacheLoadStatus::Malformed);
+    assert(cache.clear());
+}
+
+void testOversizedCacheSaveIsRejected() {
+    const std::filesystem::path path = testCachePath();
+    LocalAccountCache cache(path);
+    LocalAccountRecord record = validRecord();
+    record.sessionToken = std::string(64u * 1024u, 'x');
+
+    assert(!cache.save(record));
+    assert(!std::filesystem::exists(path));
+}
+
+} // namespace
+
+int main() {
+    testRoundTrip();
+    testOversizedCacheLoadIsMalformed();
+    testOversizedCacheSaveIsRejected();
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -20,6 +20,22 @@ else()
 endif()
 
 # =============================================================================
+# License Tests
+# =============================================================================
+
+if(TARGET AestraLicense)
+    add_executable(LocalAccountCacheTest AestraLicense/LocalAccountCacheTest.cpp)
+    target_link_libraries(LocalAccountCacheTest PRIVATE AestraLicense)
+    target_include_directories(LocalAccountCacheTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraLicense/include
+    )
+    add_test(NAME LocalAccountCacheTest COMMAND LocalAccountCacheTest)
+    set_tests_properties(LocalAccountCacheTest PROPERTIES LABELS "license;account;security")
+else()
+    message(STATUS "LocalAccountCacheTest skipped (AestraLicense target unavailable)")
+endif()
+
+# =============================================================================
 # Integration Tests (Cross-Module)
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- throttle membership badge refresh work to at most once per second instead of every frame
- reject oversized local account cache files before streaming and parsing JSON
- reject oversized account cache writes before creating or truncating the cache file
- add a LocalAccountCache regression for normal roundtrip, oversized load, and oversized save

## Why
With the custom window attached, the root component updates the membership badge every frame. In license-gated builds that path rebuilt account/session view state and repeatedly parsed the local account cache. A poisoned or oversized cache could force persistent UI CPU/memory pressure.

## Testing
- cmake -S . -B build
- cmake --build build --target LocalAccountCacheTest -j2
- ctest --test-dir build --output-on-failure -R "^LocalAccountCacheTest$"
- cmake --build build-ui --target Aestra -j2
- git diff --check

## Risk / rollback
The badge can lag account-state changes by up to one second, which is acceptable for title-bar status. Cache files above 64 KiB are treated as malformed and oversized saves are rejected.