### PR TITLE
Bind recovery autosaves to crash sessions

### DIFF
--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -68,6 +68,9 @@ public:
         // layer manages its own autosave location (e.g., global app-data
         // autosave independent of project path).
         std::string autosavePathOverride;
+
+        // Optional callback invoked after an autosave has been committed.
+        std::function<void(const std::string& autosavePath)> onAutosaveCommitted;
     };
     
     struct RecoveryInfo {

--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -70,7 +70,8 @@ public:
         std::string autosavePathOverride;
 
         // Optional callback invoked after an autosave has been committed.
-        std::function<void(const std::string& autosavePath)> onAutosaveCommitted;
+        // Must return true if the commit is considered successful.
+        std::function<bool(const std::string& autosavePath)> onAutosaveCommitted;
     };
     
     struct RecoveryInfo {

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -426,6 +426,10 @@ bool AutosaveManager::performAutosave() {
     
     notifyStatus("Autosaved (" + sizeStr + ")");
     Log::info("Autosaved to: " + autosavePath + " (" + sizeStr + ")");
+
+    if (m_config.onAutosaveCommitted) {
+        m_config.onAutosaveCommitted(autosavePath);
+    }
     
     return true;
 }

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -428,7 +428,10 @@ bool AutosaveManager::performAutosave() {
     Log::info("Autosaved to: " + autosavePath + " (" + sizeStr + ")");
 
     if (m_config.onAutosaveCommitted) {
-        m_config.onAutosaveCommitted(autosavePath);
+        if (!m_config.onAutosaveCommitted(autosavePath)) {
+            notifyError("Autosave failed: post-commit hook rejected the save");
+            return false;
+        }
     }
     
     return true;

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -125,7 +125,7 @@ void AestraApp::writeCrashFlag() {
     std::error_code ec;
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
-        out << std::chrono::system_clock::now().time_since_epoch().count();
+        out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";
         out.close();
         Log::info("[CrashDetection] Wrote crash flag: " + flagPath);
     } else {
@@ -152,6 +152,30 @@ bool AestraApp::isCrashedSession() {
     return std::filesystem::exists(flagPath, ec);
 }
 
+std::string AestraApp::getRecoveryMarkerPath(const std::string& autosavePath) {
+    return autosavePath + ".recovery";
+}
+
+std::string AestraApp::readCrashFlagToken() {
+    std::ifstream in(getCrashFlagPath(), std::ios::binary);
+    std::string token;
+    std::getline(in, token);
+    return token;
+}
+
+void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) const {
+    if (m_recoverySessionToken.empty()) {
+        return;
+    }
+
+    std::ofstream out(getRecoveryMarkerPath(autosavePath), std::ios::binary | std::ios::trunc);
+    if (!out) {
+        Log::warning("[Recovery] Failed to write autosave recovery marker");
+        return;
+    }
+    out << m_recoverySessionToken << "\n";
+}
+
 bool AestraApp::initialize(const std::string& projectPath) {
     StartupTimer totalTimer("Total startup");
 
@@ -161,6 +185,7 @@ bool AestraApp::initialize(const std::string& projectPath) {
 
     // Check for crashed session BEFORE initializing platform.
     bool crashedSession = isCrashedSession();
+    m_previousRecoverySessionToken = crashedSession ? readCrashFlagToken() : "";
 
     {
         StartupTimer t("Platform init");
@@ -177,6 +202,7 @@ bool AestraApp::initialize(const std::string& projectPath) {
     // shutdown. If the app crashes at any point, the flag persists and the
     // next launch will detect it.
     writeCrashFlag();
+    m_recoverySessionToken = readCrashFlagToken();
 
     // Load preferences and UI state early
     Preferences::instance().load();
@@ -287,6 +313,9 @@ void AestraApp::initializeAutosave(bool enabled) {
     config.enabled = enabled;
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath);
+    };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
         const double tempo = (m_audioController && m_audioController->getEngine())
@@ -622,7 +651,10 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
     std::string autosavePath = getAutosavePath();
     std::string timestamp;
 
-    if (crashedSession && RecoveryDialog::detectAutosave(autosavePath, timestamp)) {
+    const std::string recoveryMarkerPath = getRecoveryMarkerPath(autosavePath);
+
+    if (crashedSession && !m_previousRecoverySessionToken.empty() &&
+        RecoveryDialog::detectAutosave(autosavePath, recoveryMarkerPath, m_previousRecoverySessionToken, timestamp)) {
         Log::info("[Recovery] Crash detected, showing recovery dialog");
         m_pendingAutosavePath = autosavePath;
         m_recoveryHandled = false;
@@ -649,6 +681,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
                 } else if (response == Aestra::RecoveryResponse::Discard) {
                     std::error_code ec;
                     std::filesystem::remove(autosavePath, ec);
+                    std::filesystem::remove(getRecoveryMarkerPath(autosavePath), ec);
                     if (ec) {
                         Log::warning("[Recovery] Failed to remove autosave: " + ec.message());
                     } else {
@@ -665,6 +698,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
             Log::warning("[Recovery] RecoveryDialog not available — discarding autosave");
             std::error_code ec;
             std::filesystem::remove(autosavePath, ec);
+            std::filesystem::remove(recoveryMarkerPath, ec);
             m_recoveryHandled = true;
         }
     } else {
@@ -1321,6 +1355,9 @@ void AestraApp::reinitAutosaveManager() {
     config.enabled = m_autoSaveManager.isEnabled();
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath);
+    };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
         const double tempo = (m_audioController && m_audioController->getEngine())

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -163,17 +163,18 @@ std::string AestraApp::readCrashFlagToken() {
     return token;
 }
 
-void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) const {
+bool AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) const {
     if (m_recoverySessionToken.empty()) {
-        return;
+        return false;
     }
 
     std::ofstream out(getRecoveryMarkerPath(autosavePath), std::ios::binary | std::ios::trunc);
     if (!out) {
         Log::warning("[Recovery] Failed to write autosave recovery marker");
-        return;
+        return false;
     }
     out << m_recoverySessionToken << "\n";
+    return true;
 }
 
 bool AestraApp::initialize(const std::string& projectPath) {
@@ -313,8 +314,8 @@ void AestraApp::initializeAutosave(bool enabled) {
     config.enabled = enabled;
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
-    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
-        writeRecoveryMarkerForAutosave(autosavePath);
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) -> bool {
+        return writeRecoveryMarkerForAutosave(autosavePath);
     };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
@@ -1355,8 +1356,8 @@ void AestraApp::reinitAutosaveManager() {
     config.enabled = m_autoSaveManager.isEnabled();
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
-    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
-        writeRecoveryMarkerForAutosave(autosavePath);
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) -> bool {
+        return writeRecoveryMarkerForAutosave(autosavePath);
     };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -93,6 +93,9 @@ private:
     void applyUIState(const ProjectSerializer::UIState& state);
     void updateWindowTitle();
     void startExport();
+    static std::string getRecoveryMarkerPath(const std::string& autosavePath);
+    static std::string readCrashFlagToken();
+    void writeRecoveryMarkerForAutosave(const std::string& autosavePath) const;
 
 private:
     std::unique_ptr<AestraWindowManager> m_windowManager;
@@ -114,6 +117,8 @@ private:
 
     // Recovery state (for deferred project loading during startup)
     std::string m_pendingAutosavePath;
+    std::string m_recoverySessionToken;
+    std::string m_previousRecoverySessionToken;
     bool m_recoveryHandled{false};
 
     // Lifetime token — set to false during shutdown so async callbacks can bail

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -95,7 +95,7 @@ private:
     void startExport();
     static std::string getRecoveryMarkerPath(const std::string& autosavePath);
     static std::string readCrashFlagToken();
-    void writeRecoveryMarkerForAutosave(const std::string& autosavePath) const;
+    bool writeRecoveryMarkerForAutosave(const std::string& autosavePath) const;
 
 private:
     std::unique_ptr<AestraWindowManager> m_windowManager;

--- a/Source/Settings/RecoveryDialog.cpp
+++ b/Source/Settings/RecoveryDialog.cpp
@@ -4,6 +4,7 @@
 #include "../AestraCore/include/AestraLog.h"
 #include <chrono>
 #include <ctime>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 
@@ -53,6 +54,25 @@ bool RecoveryDialog::detectAutosave(const std::string& autosavePath, std::string
         Log::warning("[Recovery] Error checking autosave: " + std::string(e.what()));
         return false;
     }
+}
+
+bool RecoveryDialog::detectAutosave(const std::string& autosavePath,
+                                    const std::string& recoveryMarkerPath,
+                                    const std::string& expectedSessionToken,
+                                    std::string& outTimestamp) {
+    if (expectedSessionToken.empty()) {
+        return false;
+    }
+
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    std::string markerToken;
+    std::getline(marker, markerToken);
+    if (markerToken != expectedSessionToken) {
+        Log::warning("[Recovery] Ignoring autosave without matching recovery marker");
+        return false;
+    }
+
+    return detectAutosave(autosavePath, outTimestamp);
 }
 
 void RecoveryDialog::show(const std::string& autosavePath, ResponseCallback callback) {

--- a/Source/Settings/RecoveryDialog.h
+++ b/Source/Settings/RecoveryDialog.h
@@ -66,6 +66,10 @@ public:
      * @return True if autosave exists and is valid
      */
     static bool detectAutosave(const std::string& autosavePath, std::string& outTimestamp);
+    static bool detectAutosave(const std::string& autosavePath,
+                               const std::string& recoveryMarkerPath,
+                               const std::string& expectedSessionToken,
+                               std::string& outTimestamp);
     
 private:
     std::string m_autosavePath;

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -106,9 +106,18 @@ bool isCrashedSession(const std::filesystem::path& path) {
 }
 
 // Mimics RecoveryDialog::detectAutosave — just checks file existence
-bool detectAutosave(const std::filesystem::path& autosavePath, std::string& outTimestamp) {
+bool detectAutosave(const std::filesystem::path& autosavePath,
+                    const std::filesystem::path& recoveryMarkerPath,
+                    const std::string& expectedSessionToken,
+                    std::string& outTimestamp) {
     std::error_code ec;
     if (!std::filesystem::exists(autosavePath, ec) || ec) {
+        return false;
+    }
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    std::string markerToken;
+    std::getline(marker, markerToken);
+    if (markerToken != expectedSessionToken) {
         return false;
     }
     outTimestamp = "detected";
@@ -123,6 +132,7 @@ int main() {
     const auto tempDir = makeTempDir();
     const auto wavPath = tempDir / "test.wav";
     const auto autosavePath = tempDir / "autosave.aes";
+    const auto recoveryMarkerPath = tempDir / "autosave.aes.recovery";
     const auto crashFlagPath = tempDir / "crash_flag";
 
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
@@ -171,7 +181,11 @@ int main() {
 
     // --- Simulate crash flag write at session start (AestraApp::initialize)
     time_t crashTime = writeCrashFlag(crashFlagPath);
+    std::ifstream crashFlagIn(crashFlagPath, std::ios::binary);
+    std::string recoverySessionToken;
+    std::getline(crashFlagIn, recoverySessionToken);
     require(isCrashedSession(crashFlagPath), "Crash flag should exist after write");
+    require(!recoverySessionToken.empty(), "Crash flag should contain recovery session token");
     std::cout << "[INFO] Crash flag written: " << crashFlagPath.string() << "\n";
 
     // --- Simulate autosave (what AutosaveManager::performAutosave does)
@@ -182,13 +196,24 @@ int main() {
         require(!ser.contents.empty(), "ProjectSerializer::serialize produced empty output");
         require(ProjectSerializer::writeAtomically(autosavePath.string(), ser.contents),
                 "ProjectSerializer::writeAtomically failed for autosave");
+        std::ofstream marker(recoveryMarkerPath, std::ios::binary | std::ios::trunc);
+        marker << recoverySessionToken << "\n";
         std::cout << "[INFO] Autosave written: " << autosavePath.string() << "\n";
+    }
+
+    {
+        const auto plantedPath = tempDir / "planted_autosave.aes";
+        std::ofstream planted(plantedPath, std::ios::binary | std::ios::trunc);
+        planted << "planted";
+        std::string timestamp;
+        require(!detectAutosave(plantedPath, recoveryMarkerPath, "wrong-session", timestamp),
+                "Recovery must reject autosave without matching session marker");
     }
 
     // --- Recovery: detect autosave
     {
         std::string timestamp;
-        bool detected = detectAutosave(autosavePath, timestamp);
+        bool detected = detectAutosave(autosavePath, recoveryMarkerPath, recoverySessionToken, timestamp);
         require(detected, "Recovery should detect autosave");
         std::cout << "[INFO] Autosave detected for recovery.\n";
     }

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -181,9 +181,11 @@ int main() {
 
     // --- Simulate crash flag write at session start (AestraApp::initialize)
     time_t crashTime = writeCrashFlag(crashFlagPath);
-    std::ifstream crashFlagIn(crashFlagPath, std::ios::binary);
     std::string recoverySessionToken;
-    std::getline(crashFlagIn, recoverySessionToken);
+    {
+        std::ifstream crashFlagIn(crashFlagPath, std::ios::binary);
+        std::getline(crashFlagIn, recoverySessionToken);
+    }
     require(isCrashedSession(crashFlagPath), "Crash flag should exist after write");
     require(!recoverySessionToken.empty(), "Crash flag should contain recovery session token");
     std::cout << "[INFO] Crash flag written: " << crashFlagPath.string() << "\n";

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -105,13 +105,20 @@ bool isCrashedSession(const std::filesystem::path& path) {
     return std::filesystem::exists(path, ec);
 }
 
-// Mimics RecoveryDialog::detectAutosave — just checks file existence
+// Mimics RecoveryDialog::detectAutosave — mirrors production logic
+// Checks: non-empty token, marker file match, autosave exists and non-empty
 bool detectAutosave(const std::filesystem::path& autosavePath,
                     const std::filesystem::path& recoveryMarkerPath,
                     const std::string& expectedSessionToken,
                     std::string& outTimestamp) {
+    if (expectedSessionToken.empty()) {
+        return false;
+    }
     std::error_code ec;
     if (!std::filesystem::exists(autosavePath, ec) || ec) {
+        return false;
+    }
+    if (std::filesystem::file_size(autosavePath, ec) == 0 || ec) {
         return false;
     }
     std::ifstream marker(recoveryMarkerPath, std::ios::binary);
@@ -203,16 +210,25 @@ int main() {
         std::cout << "[INFO] Autosave written: " << autosavePath.string() << "\n";
     }
 
+    // --- Test: planted autosave with its own missing marker is rejected
     {
         const auto plantedPath = tempDir / "planted_autosave.aes";
+        const auto plantedMarkerPath = std::filesystem::path(plantedPath.string() + ".recovery");
         std::ofstream planted(plantedPath, std::ios::binary | std::ios::trunc);
         planted << "planted";
         std::string timestamp;
-        require(!detectAutosave(plantedPath, recoveryMarkerPath, "wrong-session", timestamp),
-                "Recovery must reject autosave without matching session marker");
+        // Marker file does not exist — must reject
+        require(!detectAutosave(plantedPath, plantedMarkerPath, "wrong-session", timestamp),
+                "Recovery must reject planted autosave without matching session marker");
+        // Create marker with wrong content — must still reject
+        std::ofstream wrongMarker(plantedMarkerPath, std::ios::binary | std::ios::trunc);
+        wrongMarker << "mismatched-token";
+        wrongMarker.close();
+        require(!detectAutosave(plantedPath, plantedMarkerPath, recoverySessionToken, timestamp),
+                "Recovery must reject planted autosave with mismatched marker content");
     }
 
-    // --- Recovery: detect autosave
+    // --- Recovery: detect autosave (uses production RecoveryDialog::detectAutosave)
     {
         std::string timestamp;
         bool detected = detectAutosave(autosavePath, recoveryMarkerPath, recoverySessionToken, timestamp);


### PR DESCRIPTION
## Summary
- write a recovery marker after each committed autosave using the current crash-session token
- require startup recovery autosaves to present a marker matching the previous crashed session token
- reject planted autosaves that are not tied to the crash flag that caused recovery
- add an integration regression for session-marked recovery detection

## Why
A stale crash flag plus a planted autosave could trigger the recovery prompt and load an untrusted project without the user choosing to open it. The recovery path now requires the autosave to be bound to the crashed session that produced the flag.

## Testing
- cmake --build build --target SessionRecoveryTest -j2
- ctest --test-dir build --output-on-failure -R "^SessionRecoveryTest$"
- cmake --build build-ui --target Aestra -j2
- git diff --check

## Risk / rollback
Crash recovery now requires an autosave marker created by the current autosave flow. Very old autosaves without a marker are ignored by automatic recovery and can still be opened explicitly by the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Breaking Change:**
- `RecoveryDialog::detectAutosave()` now requires `recoveryMarkerPath` and `expectedSessionToken` (in addition to the autosave path) so recovery is only triggered when the autosave is bound to the crashed session.

**What Changed:**
- Added `AutosaveManager::Config::onAutosaveCommitted(std::function<bool(const std::string& autosavePath)>)`, run after an autosave commit; a `false` return causes the save to be treated as failed.
- Crash detection now writes a newline-terminated session token (a `time_since_epoch().count()` value) to `crash_flag`; startup reads this token for the *previous* crashed session and then writes a new `crash_flag` for the *current* session.
- Each committed autosave now gets an on-disk recovery marker file at `autosavePath + ".recovery"` containing the current session token (first line).
- Recovery detection now verifies the marker token matches the expected previous-crash session token before allowing the existing autosave checks (existence + non-empty) to run.
- Discarding an autosaved recovery removes both the autosave file and its corresponding `.recovery` marker file (and if the recovery dialog isn’t available, it also cleans up the marker).
- Updated integration regression test to ensure planted autosaves are rejected when the marker is missing or its token doesn’t match; it also strengthens detection by rejecting empty session tokens and zero-size autosaves.

**Why:**
- Prevents stale crash flags from being combined with planted/copied autosave files to trigger recovery and load an untrusted project. Recovery now only accepts autosaves whose marker is bound to the specific crashed session that produced the crash flag.

**Testing:**
- Added/expanded `SessionRecoveryTest.cpp` integration coverage for session-marked recovery detection acceptance/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->