### PR TITLE
Rate limit login challenge emails

### DIFF
--- a/workers/license-signing/src/loginChallengeStore.ts
+++ b/workers/license-signing/src/loginChallengeStore.ts
@@ -3,6 +3,9 @@ import type { Env } from "./signing";
 
 const LOGIN_TTL_SECONDS = 10 * 60;
 const MAX_ATTEMPTS = 5;
+const LOGIN_START_COOLDOWN_SECONDS = 60;
+const MAX_LOGIN_STARTS_PER_HOUR = 5;
+const MAX_PENDING_CHALLENGES_PER_EMAIL = 3;
 
 export class LoginChallengeError extends Error {
   readonly status: number;
@@ -39,9 +42,44 @@ function challengeHash(email: string, challengeId: string, code: string): Promis
   return sha256Hex(`${normalizeEmail(email)}:${challengeId}:${code}`);
 }
 
+type LoginStartQuotaRow = {
+  recent_count: number | string | null;
+  pending_count: number | string | null;
+  latest_created_at: number | string | null;
+};
+
+async function assertCanCreateLoginChallenge(env: Env, email: string, nowSeconds: number): Promise<void> {
+  const normalizedEmail = normalizeEmail(email);
+  const db = requireD1(env);
+  const windowStart = nowSeconds - 60 * 60;
+  const row = await db.prepare(`
+      SELECT
+        COUNT(*) AS recent_count,
+        SUM(CASE WHEN status = 'pending' AND expires_at > ? THEN 1 ELSE 0 END) AS pending_count,
+        MAX(created_at) AS latest_created_at
+      FROM account_login_challenges
+      WHERE email = ? AND created_at > ?
+    `).bind(nowSeconds, normalizedEmail, windowStart).first<LoginStartQuotaRow>();
+
+  const recentCount = Number(row?.recent_count ?? 0);
+  const pendingCount = Number(row?.pending_count ?? 0);
+  const latestCreatedAt = row?.latest_created_at === null || row?.latest_created_at === undefined
+    ? null
+    : Number(row.latest_created_at);
+
+  if (latestCreatedAt !== null && nowSeconds - latestCreatedAt < LOGIN_START_COOLDOWN_SECONDS) {
+    throw new LoginChallengeError(429, "login_start_rate_limited", "login challenge creation is rate limited");
+  }
+  if (pendingCount >= MAX_PENDING_CHALLENGES_PER_EMAIL || recentCount >= MAX_LOGIN_STARTS_PER_HOUR) {
+    throw new LoginChallengeError(429, "login_start_rate_limited", "login challenge creation is rate limited");
+  }
+}
+
 export async function createLoginChallenge(env: Env, email: string, nowSeconds: number):
     Promise<CreatedLoginChallenge> {
   const db = requireD1(env);
+  await assertCanCreateLoginChallenge(env, email, nowSeconds);
+
   const challengeId = `lc_${randomHex(16)}`;
   const code = randomCode();
   const expiresAt = nowSeconds + LOGIN_TTL_SECONDS;

--- a/workers/license-signing/test/storage.test.ts
+++ b/workers/license-signing/test/storage.test.ts
@@ -114,6 +114,19 @@ class FakeD1Statement {
         status: account.status,
       } as T;
     }
+    if (this.sql.includes("COUNT(*) AS recent_count") && this.sql.includes("FROM account_login_challenges")) {
+      const nowSeconds = this.args[0] as number;
+      const email = this.args[1] as string;
+      const windowStart = this.args[2] as number;
+      const recent = this.state.challenges.filter((row) => row.email === email && row.created_at > windowStart);
+      const pending = recent.filter((row) => row.status === "pending" && row.expires_at > nowSeconds);
+      const latest = recent.reduce<number | null>((best, row) => best === null ? row.created_at : Math.max(best, row.created_at), null);
+      return {
+        recent_count: recent.length,
+        pending_count: pending.length,
+        latest_created_at: latest,
+      } as T;
+    }
     if (this.sql.includes("FROM account_login_challenges")) {
       const id = this.args[0] as string;
       const email = this.args[1] as string;
@@ -808,6 +821,17 @@ describe("D1 account login and session issuance boundary", () => {
     expect(missingBody.ok).toBe(true);
     expect(existingBody.fixture_code).toHaveLength(6);
     expect(missingBody.fixture_code).toHaveLength(6);
+  });
+
+  it("rate limits repeated login challenge creation for the same recipient", async () => {
+    const state = emptyState();
+    const env = await makeLoginEnv(state);
+    const first = await loginStart(env, "target@example.test");
+    const second = await loginStart(env, "target@example.test");
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(await second.json()).toMatchObject({ error: { code: "login_start_rate_limited" } });
+    expect(state.challenges).toHaveLength(1);
   });
 
   it("verifies a challenge, creates a Core account, returns a raw session once, and stores only token hash", async () => {


### PR DESCRIPTION
## Summary
- add per-recipient login-start cooldown, pending challenge cap, and hourly challenge cap before creating challenges
- return a 429 login_start_rate_limited error before inserting a new D1 row or sending email
- extend the Worker storage tests to cover repeated login-start throttling

## Why
The public login-start endpoint could create unlimited D1 challenges and trigger Resend delivery to arbitrary recipients. The creation path now enforces recipient-level throttles before email delivery.

## Testing
- npm test
- git diff --check

## Risk / rollback
Legitimate users may need to wait 60 seconds before requesting another login code for the same email. Limits are intentionally conservative and can be tuned later if product needs a different cadence.