### PR TITLE
Bound login challenge storage growth

### DIFF
--- a/workers/license-signing/src/accountRoutes.ts
+++ b/workers/license-signing/src/accountRoutes.ts
@@ -7,8 +7,8 @@ import {
   revokeSessionToken,
 } from "./accountStore";
 import { EntitlementRepositoryError, getEntitlementForAccount } from "./entitlementRepository";
-import { LoginChallengeError, createLoginChallenge, verifyLoginChallenge } from "./loginChallengeStore";
-import { MailerError, sendLoginChallenge } from "./mailer";
+import { LoginChallengeError, createLoginChallenge, deleteLoginChallenge, verifyLoginChallenge } from "./loginChallengeStore";
+import { MailerError, assertLoginMailerConfigured, sendLoginChallenge } from "./mailer";
 import { buildSignedEntitlementRefreshResponse, parseAccountRefreshRequest } from "./refreshResponse";
 import { SignRequestError } from "./schema";
 import { issueAccountSession } from "./sessionIssuer";
@@ -66,13 +66,28 @@ function readEmail(input: unknown): string {
   return email;
 }
 
+function loginStartSourceKey(request: Request): string | undefined {
+  return request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    undefined;
+}
+
 export async function handleLoginStart(request: Request, env: Env, jsonResponse: JsonResponder,
                                        errorResponse: ErrorResponder): Promise<Response> {
   try {
     const nowSeconds = Math.floor(Date.now() / 1000);
     const email = readEmail(await parseJson(request));
-    const challenge = await createLoginChallenge(env, email, nowSeconds);
-    const delivery = await sendLoginChallenge(env, email, challenge);
+    assertLoginMailerConfigured(env);
+    const challenge = await createLoginChallenge(env, email, nowSeconds, {
+      sourceKey: loginStartSourceKey(request),
+    });
+    let delivery;
+    try {
+      delivery = await sendLoginChallenge(env, email, challenge);
+    } catch (error) {
+      await deleteLoginChallenge(env, challenge.id).catch(() => undefined);
+      throw error;
+    }
     return jsonResponse({
       ok: true,
       challenge_id: challenge.id,

--- a/workers/license-signing/src/loginChallengeStore.ts
+++ b/workers/license-signing/src/loginChallengeStore.ts
@@ -3,6 +3,7 @@ import type { Env } from "./signing";
 
 const LOGIN_TTL_SECONDS = 10 * 60;
 const MAX_ATTEMPTS = 5;
+const MAX_CHALLENGES_PER_SOURCE_HOUR = 20;
 
 export class LoginChallengeError extends Error {
   readonly status: number;
@@ -22,6 +23,10 @@ export type CreatedLoginChallenge = {
   expiresAt: number;
 };
 
+export type LoginChallengeCreateOptions = {
+  sourceKey?: string;
+};
+
 function randomHex(byteLength: number): string {
   const bytes = new Uint8Array(byteLength);
   crypto.getRandomValues(bytes);
@@ -39,21 +44,65 @@ function challengeHash(email: string, challengeId: string, code: string): Promis
   return sha256Hex(`${normalizeEmail(email)}:${challengeId}:${code}`);
 }
 
+type SourceQuotaRow = {
+  recent_count: number | string | null;
+};
+
+function normalizeSourceKey(sourceKey: string | undefined): string | null {
+  const normalized = sourceKey?.trim();
+  if (!normalized) {
+    return null;
+  }
+  return normalized.slice(0, 128);
+}
+
+async function assertSourceQuota(env: Env, sourceKey: string | null, nowSeconds: number): Promise<void> {
+  if (!sourceKey) {
+    return;
+  }
+
+  const db = requireD1(env);
+  const windowStart = nowSeconds - 60 * 60;
+  const metadataJson = JSON.stringify({ source: sourceKey });
+  const row = await db.prepare(`
+      SELECT COUNT(*) AS recent_count
+      FROM account_login_challenges
+      WHERE metadata_json = ? AND created_at > ?
+    `).bind(metadataJson, windowStart).first<SourceQuotaRow>();
+
+  if (Number(row?.recent_count ?? 0) >= MAX_CHALLENGES_PER_SOURCE_HOUR) {
+    throw new LoginChallengeError(429, "login_start_rate_limited", "login challenge creation is rate limited");
+  }
+}
+
 export async function createLoginChallenge(env: Env, email: string, nowSeconds: number):
+    Promise<CreatedLoginChallenge>;
+export async function createLoginChallenge(env: Env, email: string, nowSeconds: number,
+                                           options?: LoginChallengeCreateOptions):
     Promise<CreatedLoginChallenge> {
   const db = requireD1(env);
+  const sourceKey = normalizeSourceKey(options?.sourceKey);
+  await assertSourceQuota(env, sourceKey, nowSeconds);
+
   const challengeId = `lc_${randomHex(16)}`;
   const code = randomCode();
   const expiresAt = nowSeconds + LOGIN_TTL_SECONDS;
   const codeHash = await challengeHash(email, challengeId, code);
+  const metadataJson = sourceKey ? JSON.stringify({ source: sourceKey }) : null;
 
   await db.prepare(`
       INSERT INTO account_login_challenges
         (id, email, code_hash, status, attempts, created_at, expires_at, used_at, metadata_json)
-      VALUES (?, ?, ?, 'pending', 0, ?, ?, NULL, NULL)
-    `).bind(challengeId, normalizeEmail(email), codeHash, nowSeconds, expiresAt).run();
+      VALUES (?, ?, ?, 'pending', 0, ?, ?, NULL, ?)
+    `).bind(challengeId, normalizeEmail(email), codeHash, nowSeconds, expiresAt, metadataJson).run();
 
   return { id: challengeId, code, expiresAt };
+}
+
+export async function deleteLoginChallenge(env: Env, challengeId: string): Promise<void> {
+  const db = requireD1(env);
+  await db.prepare("DELETE FROM account_login_challenges WHERE id = ? AND status = 'pending'")
+    .bind(challengeId).run();
 }
 
 type ChallengeRow = {

--- a/workers/license-signing/src/loginChallengeStore.ts
+++ b/workers/license-signing/src/loginChallengeStore.ts
@@ -63,12 +63,11 @@ async function assertSourceQuota(env: Env, sourceKey: string | null, nowSeconds:
 
   const db = requireD1(env);
   const windowStart = nowSeconds - 60 * 60;
-  const metadataJson = JSON.stringify({ source: sourceKey });
   const row = await db.prepare(`
       SELECT COUNT(*) AS recent_count
       FROM account_login_challenges
-      WHERE metadata_json = ? AND created_at > ?
-    `).bind(metadataJson, windowStart).first<SourceQuotaRow>();
+      WHERE JSON_EXTRACT(metadata_json, '$.source') = ? AND created_at > ?
+    `).bind(sourceKey, windowStart).first<SourceQuotaRow>();
 
   if (Number(row?.recent_count ?? 0) >= MAX_CHALLENGES_PER_SOURCE_HOUR) {
     throw new LoginChallengeError(429, "login_start_rate_limited", "login challenge creation is rate limited");

--- a/workers/license-signing/src/mailer.ts
+++ b/workers/license-signing/src/mailer.ts
@@ -166,5 +166,6 @@ export async function sendLoginChallenge(env: Env, email: string, challenge: Cre
     await resendSend(env, email, challenge.code, challenge.expiresAt);
     return { exposeCode: false };
   }
-  throw new MailerError(500, "mailer_unconfigured", "login mailer is not configured");
+  // Unreachable: assertLoginMailerConfigured already throws for unknown modes
+  return { exposeCode: false };
 }

--- a/workers/license-signing/src/mailer.ts
+++ b/workers/license-signing/src/mailer.ts
@@ -17,11 +17,22 @@ export type LoginDelivery = {
   exposeCode: boolean;
 };
 
-async function resendSend(env: Env, toEmail: string, code: string, expiresAt: number): Promise<void> {
-  const apiKey = env.AESTRA_RESEND_API_KEY;
-  if (!apiKey) {
-    throw new MailerError(500, "resend_key_missing", "AESTRA_RESEND_API_KEY is not set");
+export function assertLoginMailerConfigured(env: Env): void {
+  if (env.AESTRA_LOGIN_MAILER_MODE === "fixture") {
+    return;
   }
+  if ((env.AESTRA_LOGIN_MAILER_MODE as string | undefined) === "configured" || env.AESTRA_LOGIN_MAILER_MODE === "smtp") {
+    if (!env.AESTRA_RESEND_API_KEY) {
+      throw new MailerError(500, "resend_key_missing", "AESTRA_RESEND_API_KEY is not set");
+    }
+    return;
+  }
+
+  throw new MailerError(500, "mailer_unconfigured", "login mailer is not configured");
+}
+
+async function resendSend(env: Env, toEmail: string, code: string, expiresAt: number): Promise<void> {
+  assertLoginMailerConfigured(env);
 
   const expiresMinutes = Math.ceil((expiresAt * 1000 - Date.now()) / 60000);
   const html = buildLoginEmail(code, expiresMinutes);
@@ -29,7 +40,7 @@ async function resendSend(env: Env, toEmail: string, code: string, expiresAt: nu
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
-      "Authorization": `Bearer ${apiKey}`,
+      "Authorization": `Bearer ${env.AESTRA_RESEND_API_KEY}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -147,6 +158,7 @@ function buildLoginEmail(code: string, expiresMinutes: number): string {
 
 export async function sendLoginChallenge(env: Env, email: string, challenge: CreatedLoginChallenge):
     Promise<LoginDelivery> {
+  assertLoginMailerConfigured(env);
   if (env.AESTRA_LOGIN_MAILER_MODE === "fixture") {
     return { exposeCode: true };
   }
@@ -154,6 +166,5 @@ export async function sendLoginChallenge(env: Env, email: string, challenge: Cre
     await resendSend(env, email, challenge.code, challenge.expiresAt);
     return { exposeCode: false };
   }
-
   throw new MailerError(500, "mailer_unconfigured", "login mailer is not configured");
 }

--- a/workers/license-signing/test/storage.test.ts
+++ b/workers/license-signing/test/storage.test.ts
@@ -70,6 +70,7 @@ type D1State = {
     created_at: number;
     expires_at: number;
     used_at: number | null;
+    metadata_json: string | null;
   }>;
   seenSessionTokenHashes: string[];
 };
@@ -112,6 +113,13 @@ class FakeD1Statement {
         email: account.email,
         display_name: account.display_name,
         status: account.status,
+      } as T;
+    }
+    if (this.sql.includes("COUNT(*) AS recent_count") && this.sql.includes("FROM account_login_challenges")) {
+      const metadataJson = this.args[0] as string;
+      const windowStart = this.args[1] as number;
+      return {
+        recent_count: this.state.challenges.filter((row) => row.metadata_json === metadataJson && row.created_at > windowStart).length,
       } as T;
     }
     if (this.sql.includes("FROM account_login_challenges")) {
@@ -157,7 +165,11 @@ class FakeD1Statement {
         created_at: this.args[3] as number,
         expires_at: this.args[4] as number,
         used_at: null,
+        metadata_json: this.args[5] as string | null,
       });
+    } else if (this.sql.includes("DELETE FROM account_login_challenges")) {
+      const id = this.args[0] as string;
+      this.state.challenges = this.state.challenges.filter((row) => !(row.id === id && row.status === "pending"));
     } else if (this.sql.includes("UPDATE account_login_challenges SET attempts = attempts + 1")) {
       const id = this.args[0] as string;
       const challenge = this.state.challenges.find((row) => row.id === id);
@@ -347,10 +359,10 @@ async function refresh(env: Env, token: string, body: Record<string, unknown> = 
   }), env);
 }
 
-async function loginStart(env: Env, email: string) {
+async function loginStart(env: Env, email: string, headers: Record<string, string> = {}) {
   return worker.fetch(new Request("https://example.test/v1/account/login/start", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify({ email }),
   }), env);
 }
@@ -782,6 +794,7 @@ describe("D1 account login and session issuance boundary", () => {
     const response = await loginStart(prodLikeEnv, "user@example.test");
     expect(response.status).toBe(500);
     expect(await response.json()).toMatchObject({ error: { code: "mailer_unconfigured" } });
+    expect(state.challenges).toHaveLength(0);
   });
 
   it("does not return fixture login codes in configured mailer mode", async () => {
@@ -792,6 +805,7 @@ describe("D1 account login and session issuance boundary", () => {
     expect(response.status).toBe(500);
     const body = await response.json() as { ok: boolean; error?: { code: string } };
     expect(body.error?.code).toBe("resend_key_missing");
+    expect(state.challenges).toHaveLength(0);
   });
 
   it("does not reveal whether an account exists when starting login", async () => {
@@ -808,6 +822,19 @@ describe("D1 account login and session issuance boundary", () => {
     expect(missingBody.ok).toBe(true);
     expect(existingBody.fixture_code).toHaveLength(6);
     expect(missingBody.fixture_code).toHaveLength(6);
+  });
+
+  it("limits login challenge storage growth per request source", async () => {
+    const state = emptyState();
+    const env = await makeLoginEnv(state);
+    for (let i = 0; i < 20; ++i) {
+      const response = await loginStart(env, `target-${i}@example.test`, { "cf-connecting-ip": "203.0.113.8" });
+      expect(response.status).toBe(200);
+    }
+    const limited = await loginStart(env, "target-20@example.test", { "cf-connecting-ip": "203.0.113.8" });
+    expect(limited.status).toBe(429);
+    expect(await limited.json()).toMatchObject({ error: { code: "login_start_rate_limited" } });
+    expect(state.challenges).toHaveLength(20);
   });
 
   it("verifies a challenge, creates a Core account, returns a raw session once, and stores only token hash", async () => {


### PR DESCRIPTION
## Summary
- preflight login mailer configuration before creating a D1 challenge row
- delete pending challenge rows if mail delivery fails after creation
- store a bounded source key in login challenge metadata and cap per-source challenge creation per hour
- extend Worker storage tests for no-row mailer failures and source quota enforcement

## Why
With a production D1 binding, unauthenticated login-start requests could grow account_login_challenges even when mailer configuration was missing or by spraying many recipient emails. The storage path now fails before insert when delivery cannot be configured and caps D1 growth by request source.

## Testing
- npm test
- git diff --check

## Risk / rollback
The source quota uses Cloudflare connecting IP when present, then x-forwarded-for. Legitimate high-volume login attempts from one source may receive 429s and should retry later.