### PR TITLE
Reject future-issued leases

### DIFF
--- a/AestraLicense/src/LicenseGate.cpp
+++ b/AestraLicense/src/LicenseGate.cpp
@@ -47,6 +47,7 @@ namespace License {
 
 namespace {
 constexpr int64_t kLeasePeriodSeconds = 604800;
+constexpr int64_t kMaxLeaseClockSkewSeconds = 300;
 constexpr double kMaxExactJsonInteger = 9007199254740991.0;
 constexpr size_t kSecretBoxNonceBytes = 24;
 constexpr size_t kSecretBoxMacBytes = 16;
@@ -710,6 +711,14 @@ bool leaseTierAllowedForBuild(const LeaseRecord& lease) {
 
 bool leaseStatusAtNow(const LeaseRecord& lease, EntitlementStatus& status) {
     const int64_t now = nowSeconds();
+    const int64_t latestAllowedIssueTime =
+        now > (std::numeric_limits<int64_t>::max)() - kMaxLeaseClockSkewSeconds
+            ? (std::numeric_limits<int64_t>::max)()
+            : now + kMaxLeaseClockSkewSeconds;
+    if (lease.issuedAt > latestAllowedIssueTime) {
+        status = EntitlementStatus::InvalidSignature;
+        return false;
+    }
     if (lease.expiresAt > (std::numeric_limits<int64_t>::max)() - kLeasePeriodSeconds) {
         status = EntitlementStatus::Expired;
         return false;
@@ -893,7 +902,7 @@ EntitlementStatus loadAndVerifyLease(LeaseRecord& outLease) {
 
     EntitlementStatus status = EntitlementStatus::Missing;
     if (!leaseStatusAtNow(lease, status)) {
-        return EntitlementStatus::Expired;
+        return status;
     }
 
     outLease = std::move(lease);
@@ -1039,7 +1048,7 @@ bool LicenseGate::installLeaseBlobForRefresh(const std::string& leaseBlob, std::
 
     EntitlementStatus status = EntitlementStatus::Missing;
     if (!leaseStatusAtNow(lease, status)) {
-        message = "Lease is expired.";
+        message = status == EntitlementStatus::InvalidSignature ? "Lease is not yet valid." : "Lease is expired.";
         return false;
     }
     if (!saveLeaseToPrimarySecretStore(blob) && !saveLeaseToEncryptedBackup(blob, fingerprint)) {

--- a/workers/license-signing/src/constants.ts
+++ b/workers/license-signing/src/constants.ts
@@ -1,0 +1,4 @@
+// Shared constants for license-signing worker
+
+/** Maximum acceptable client clock skew when validating issued_at timestamps. */
+export const MAX_CLIENT_CLOCK_SKEW_SECONDS = 300;

--- a/workers/license-signing/src/index.ts
+++ b/workers/license-signing/src/index.ts
@@ -81,7 +81,9 @@ const worker = {
       }
 
       try {
-        return jsonResponse(await buildSignedLeaseResponse(parseSignRequest(await parseJson(request)), env, false));
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        return jsonResponse(await buildSignedLeaseResponse(parseSignRequest(await parseJson(request), nowSeconds), env,
+          false, nowSeconds));
       } catch (error) {
         if (error instanceof SignRequestError) {
           return errorResponse(400, "invalid_request", error.message, error.issues);
@@ -100,7 +102,9 @@ const worker = {
       }
 
       try {
-        return jsonResponse(await buildSignedLeaseResponse(parseSignRequest(await parseJson(request)), env, true));
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        return jsonResponse(await buildSignedLeaseResponse(parseSignRequest(await parseJson(request), nowSeconds), env,
+          true, nowSeconds));
       } catch (error) {
         if (error instanceof SignRequestError) {
           return errorResponse(400, "invalid_request", error.message, error.issues);

--- a/workers/license-signing/src/refreshResponse.ts
+++ b/workers/license-signing/src/refreshResponse.ts
@@ -53,9 +53,10 @@ export function parseAccountRefreshRequest(input: unknown, nowSeconds: number): 
   return { deviceHash: deviceHash as string, issuedAt };
 }
 
-export async function buildSignedLeaseResponse(payload: LeasePayload, env: Env, includeLeaseBlob: boolean):
+export async function buildSignedLeaseResponse(payload: LeasePayload, env: Env, includeLeaseBlob: boolean,
+                                               nowSeconds?: number):
     Promise<Record<string, unknown>> {
-  const validatedPayload = parseSignRequest(payload);
+  const validatedPayload = parseSignRequest(payload, nowSeconds);
   const canonical = canonicalizeLease(validatedPayload);
   const signatureHex = await signCanonicalLease(canonical, env);
   return {

--- a/workers/license-signing/src/refreshResponse.ts
+++ b/workers/license-signing/src/refreshResponse.ts
@@ -1,11 +1,11 @@
 import { canonicalizeLease, type LeasePayload } from "./canonicalLease";
 import type { AccountAuthContext } from "./accountAuth";
 import type { EntitlementRecord } from "./entitlementRepository";
+import { MAX_CLIENT_CLOCK_SKEW_SECONDS } from "./constants";
 import { parseSignRequest, SignRequestError } from "./schema";
 import { signCanonicalLease, type Env } from "./signing";
 
 const LEASE_PERIOD_SECONDS = 604800;
-const MAX_CLIENT_CLOCK_SKEW_SECONDS = 300;
 
 export type AccountRefreshRequest = {
   deviceHash: string;

--- a/workers/license-signing/src/schema.ts
+++ b/workers/license-signing/src/schema.ts
@@ -1,6 +1,7 @@
 import type { LeasePayload, LicenseTier } from "./canonicalLease";
 
 const LEASE_PERIOD_SECONDS = 604800;
+const MAX_CLIENT_CLOCK_SKEW_SECONDS = 300;
 const MAX_STRING_LENGTH = 512;
 const MAX_ARRAY_LENGTH = 64;
 const MAX_ISSUE_COUNT = 32;
@@ -88,7 +89,7 @@ function readStringArray(record: Record<string, unknown>, key: string, issues: s
   return out;
 }
 
-export function parseSignRequest(input: unknown): LeasePayload {
+export function parseSignRequest(input: unknown, nowSeconds?: number): LeasePayload {
   const issues: string[] = [];
   if (!isRecord(input)) {
     throw new SignRequestError(["request body must be a JSON object"]);
@@ -105,6 +106,9 @@ export function parseSignRequest(input: unknown): LeasePayload {
   const deviceHash = readString(input, "device_hash", issues);
   const issuedAt = readInteger(input, "issued_at", issues);
   const expiresAt = readInteger(input, "expires_at", issues);
+  if (nowSeconds !== undefined && issuedAt > nowSeconds + MAX_CLIENT_CLOCK_SKEW_SECONDS) {
+    issues.push("issued_at must not be in the future");
+  }
   const gracePolicy = readString(input, "grace_policy", issues);
   if (gracePolicy !== "restrict") {
     issues.push("grace_policy must be restrict");

--- a/workers/license-signing/src/schema.ts
+++ b/workers/license-signing/src/schema.ts
@@ -1,7 +1,7 @@
 import type { LeasePayload, LicenseTier } from "./canonicalLease";
+import { MAX_CLIENT_CLOCK_SKEW_SECONDS } from "./constants";
 
 const LEASE_PERIOD_SECONDS = 604800;
-const MAX_CLIENT_CLOCK_SKEW_SECONDS = 300;
 const MAX_STRING_LENGTH = 512;
 const MAX_ARRAY_LENGTH = 64;
 const MAX_ISSUE_COUNT = 32;

--- a/workers/license-signing/test/signing.test.ts
+++ b/workers/license-signing/test/signing.test.ts
@@ -107,6 +107,19 @@ describe("parseSignRequest", () => {
     expect(() => parseSignRequest({ ...validLease, plugins: ["ok", 1] })).toThrow(SignRequestError);
     expect(() => parseSignRequest({ ...validLease, features: ["ok", false] })).toThrow(SignRequestError);
   });
+
+  it("rejects issue times beyond server clock skew", () => {
+    expect(parseSignRequest({
+      ...validLease,
+      issued_at: 1300,
+      expires_at: 606100,
+    }, 1000).issued_at).toBe(1300);
+    expect(() => parseSignRequest({
+      ...validLease,
+      issued_at: 1301,
+      expires_at: 606101,
+    }, 1000)).toThrow(SignRequestError);
+  });
 });
 
 describe("signCanonicalLease", () => {
@@ -211,6 +224,19 @@ describe("worker endpoints", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({ ...validLease, tier: "supporter" }),
+    }), env);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for future-issued admin sign payloads", async () => {
+    const issuedAt = Math.floor(Date.now() / 1000) + 3600;
+    const response = await worker.fetch(new Request("https://example.test/v1/entitlements/sign", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-admin-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ ...validLease, issued_at: issuedAt, expires_at: issuedAt + 604800 }),
     }), env);
     expect(response.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- reject admin-issued license leases whose issued_at is beyond a 300 second server clock skew
- reject future-issued leases in the native LicenseGate before treating them as valid/grace
- cover the worker parser and admin sign route with regression tests

## Testing
- npm test (workers/license-signing)
- cmake --build build --target AestraLicense -j2
- git diff --check

## Risk / rollback
- Limits only future-issued leases beyond the existing account refresh skew window; old leases remain accepted through the current expiry/grace rules.