### PR TITLE
Guard graph dirty UI signal

### DIFF
--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -2104,7 +2104,9 @@ void TrackManagerUI::onUpdate(double deltaTime) {
     // Plugin insert/remove requests go through the PlaybackGraphController.
     // TrackManagerUI does NOT consume graph dirty state here - the controller drains in AestraApp::run().
     // UI code should only request rebuilds via requestAudioGraphRebuild().
-    graphDirty.emit();
+    if (m_trackManager && m_trackManager->hasPendingGraphRebuild()) {
+        graphDirty.emit();
+    }
 
     // One-time registration for drag-and-drop
     // We do this here because shared_from_this() is not available in the constructor


### PR DESCRIPTION
## Summary
- only emit TrackManagerUI graphDirty when TrackManager has a pending graph rebuild
- keep PlaybackGraphController as the sole consumer/drain point
- prevents per-frame rebuild requests when no graph-affecting state changed

## Testing
- cmake --build build-ui --target Aestra -j2
- cmake --build build --target AestraPluginGraphInvalidationTest -j2
- ctest --test-dir build --output-on-failure -R 'Plugin(InsertTakesEffectWithoutClipMoveTest|RemoveTakesEffectWithoutClipMoveTest)'
- git diff --check

## Risk / rollback
- Narrow UI signal gating; plugin insert/remove paths still call TrackManager::requestAudioGraphRebuild and are covered by existing graph invalidation tests.