### PR TITLE
Refresh effect chain bypass snapshots

### DIFF
--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -188,7 +188,7 @@ public:
     /**
      * @brief Bypass entire chain
      */
-    void setChainBypassed(bool bypassed) { m_chainBypassed.store(bypassed); }
+    void setChainBypassed(bool bypassed);
     bool isChainBypassed() const { return m_chainBypassed.load(); }
 
     // ==============================

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -292,6 +292,13 @@ bool EffectChain::isSlotBypassedByNonFiniteOutput(size_t slotIndex) const {
     return isFaultBypassed(m_slots[slotIndex].faultState);
 }
 
+void EffectChain::setChainBypassed(bool bypassed) {
+    m_chainBypassed.store(bypassed, std::memory_order_release);
+    if (!reportRealtimeMisuse("EffectChain::setChainBypassed")) {
+        publishSnapshot();
+    }
+}
+
 uint64_t EffectChain::getSlotNonFiniteOutputCount(size_t slotIndex) const {
     if (slotIndex >= MAX_SLOTS || !m_slots[slotIndex].faultState) {
         return 0;

--- a/Tests/AestraAudio/PluginGraphInvalidationTest.cpp
+++ b/Tests/AestraAudio/PluginGraphInvalidationTest.cpp
@@ -244,12 +244,46 @@ void PluginBypassPublishesSnapshotTest() {
     std::cout << "PASS: PluginBypassPublishesSnapshotTest\n";
 }
 
+void PluginDryWetPublishesSnapshotTest() {
+    auto trackManager = makeTrackManagerWithClip();
+    auto* channel = trackManager->getChannel(0);
+    assert(channel != nullptr);
+    auto plugin = std::make_shared<TestGainPlugin>(0.5f);
+    auto& chain = channel->getEffectChain();
+    chain.prepare(static_cast<double>(kSampleRate), kBlockFrames);
+    assert(chain.insertPlugin(0, plugin));
+
+    chain.setSlotDryWetMix(0, 0.25f);
+    auto snapshot = chain.getSnapshot();
+    assert(snapshot != nullptr);
+    assert(std::abs(snapshot->slot(0).dryWetMix - 0.25f) < 0.0001f);
+    std::cout << "PASS: PluginDryWetPublishesSnapshotTest\n";
+}
+
+void PluginChainBypassPublishesSnapshotTest() {
+    EffectChain chain;
+    chain.prepare(static_cast<double>(kSampleRate), kBlockFrames);
+
+    chain.setChainBypassed(true);
+    auto snapshot = chain.getSnapshot();
+    assert(snapshot != nullptr);
+    assert(snapshot->isChainBypassed);
+
+    chain.setChainBypassed(false);
+    snapshot = chain.getSnapshot();
+    assert(snapshot != nullptr);
+    assert(!snapshot->isChainBypassed);
+    std::cout << "PASS: PluginChainBypassPublishesSnapshotTest\n";
+}
+
 } // namespace
 
 int main() {
     PluginInsertTakesEffectWithoutClipMoveTest();
     PluginRemoveTakesEffectWithoutClipMoveTest();
     PluginBypassPublishesSnapshotTest();
+    PluginDryWetPublishesSnapshotTest();
+    PluginChainBypassPublishesSnapshotTest();
     std::cout << "All plugin graph invalidation tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- republish EffectChain snapshots when whole-chain bypass changes
- keep RT misuse guarded so the atomic bypass update remains the only realtime-side effect
- add regression coverage for dry/wet and whole-chain bypass snapshot freshness

## Testing
- cmake --build build --target AestraPluginGraphInvalidationTest -j2
- cmake --build build --target AestraAudioCore -j2
- ctest --test-dir build --output-on-failure -R 'Plugin(InsertTakesEffectWithoutClipMoveTest|RemoveTakesEffectWithoutClipMoveTest)'
- git diff --check

## Risk / rollback
- Audio output changes only when whole-chain bypass is toggled: the graph snapshot now observes the intended bypass state instead of stale state.