### PR TITLE
Guard AestraVerb active state rebuilds

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -174,11 +174,13 @@ public:
 
     void shutdown() override {}
     void activate() override {
-        m_active.store(true, std::memory_order_relaxed);
-        clearBuffers(true);
+        if (!m_active.load(std::memory_order_acquire)) {
+            clearBuffers(true);
+            m_active.store(true, std::memory_order_release);
+        }
     }
-    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
-    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+    void deactivate() override { m_active.store(false, std::memory_order_release); }
+    bool isActive() const override { return m_active.load(std::memory_order_acquire); }
 
     void process(const float* const* inputs, float** outputs,
                  uint32_t numInputChannels, uint32_t numOutputChannels,
@@ -187,14 +189,13 @@ public:
         (void)midiInput;
         (void)midiOutput;
 
-        if (!m_active.load(std::memory_order_relaxed) ||
+        if (!m_active.load(std::memory_order_acquire) ||
             m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
             copyDry(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
             return;
         }
 
-        // RT-safe: prepareDelayLines only runs in activate()/loadState(), never concurrently with process()
-        // No lock needed - audio thread reads current state, control thread updates atomically
+        // Buffer storage is rebuilt only while inactive. Runtime control changes are atomic scalars.
 
         if (m_predelayL.empty() || m_delayLines[0].empty()) {
             copyDry(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
@@ -614,7 +615,9 @@ public:
         for (size_t i = 0; i < std::min<size_t>(availableParams, kParamCount); ++i) {
             setParameter(static_cast<uint32_t>(i), params[i]);
         }
-        prepareDelayLines(false);
+        if (!m_active.load(std::memory_order_acquire)) {
+            prepareDelayLines(false);
+        }
         return true;
     }
 

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -3,10 +3,12 @@
 #include "AestraVerb.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <thread>
 #include <vector>
 
 using Aestra::Audio::Plugins::AestraVerb;
@@ -207,6 +209,55 @@ bool runHighFrequencyBuildupChecks() {
     return ok;
 }
 
+bool runActiveLoadStateSafetyCheck() {
+    AestraVerb verb;
+    verb.initialize(kSampleRate, 128);
+    setUsableDefaults(verb, 1);
+    verb.activate();
+
+    const std::vector<uint8_t> state = verb.saveState();
+    std::atomic<bool> stop{false};
+    std::atomic<bool> renderOk{true};
+
+    std::thread audioThread([&]() {
+        std::vector<float> inL(128, 0.0f);
+        std::vector<float> inR(128, 0.0f);
+        std::vector<float> outL(128, 0.0f);
+        std::vector<float> outR(128, 0.0f);
+        inL[0] = 0.5f;
+        inR[0] = 0.5f;
+
+        while (!stop.load(std::memory_order_acquire)) {
+            const float* inputs[2] = {inL.data(), inR.data()};
+            float* outputs[2] = {outL.data(), outR.data()};
+            verb.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+            for (size_t i = 0; i < outL.size(); ++i) {
+                if (!std::isfinite(outL[i]) || !std::isfinite(outR[i])) {
+                    renderOk.store(false, std::memory_order_release);
+                    stop.store(true, std::memory_order_release);
+                    break;
+                }
+            }
+            inL[0] = 0.0f;
+            inR[0] = 0.0f;
+        }
+    });
+
+    bool ok = true;
+    for (int i = 0; i < 1000; ++i) {
+        ok &= require(verb.loadState(state), "active state load failed");
+        if (!ok || !renderOk.load(std::memory_order_acquire)) {
+            break;
+        }
+    }
+
+    stop.store(true, std::memory_order_release);
+    audioThread.join();
+
+    ok &= require(renderOk.load(std::memory_order_acquire), "active state load render produced NaN/Inf");
+    return ok;
+}
+
 } // namespace
 
 int main() {
@@ -215,6 +266,7 @@ int main() {
     ok &= runParameterExtremeChecks();
     ok &= runModeSwitchAndDeterminismChecks();
     ok &= runHighFrequencyBuildupChecks();
+    ok &= runActiveLoadStateSafetyCheck();
 
     if (!ok) {
         return 1;


### PR DESCRIPTION
## Summary
- rebuild and clear AestraVerb vector-backed delay storage only while the plugin is inactive
- keep active state loads to atomic parameter updates so process() never races vector resize/clear
- add a regression that repeatedly loads saved state while another thread renders through process()

## Testing
- cmake --build build --target ReverbSafetyRegressionTest -j2
- ctest --test-dir build --output-on-failure -R '^ReverbSafetyRegressionTest$'
- git diff --check

## Risk
- DSP output is unchanged for normal parameter automation; active loadState no longer resets live tails/buffers until the instance is inactive/reactivated.
- No serialization format changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## No breaking changes
- DSP output remains unchanged for normal parameter automation
- Serialization format unchanged
- No exported/public API signatures changed

## What changed

- **Thread safety fix**: AestraVerb now guards buffer rebuild operations (`prepareDelayLines()`) to execute only when the plugin is inactive, preventing race conditions between audio processing and state loading
  
- **State loading behavior**: When `loadState()` is called while the plugin is active, parameter updates are applied atomically but buffer layout changes (predelay, room size) are deferred until the next deactivate→activate cycle. The function still returns true, so callers should be aware state application may be partial while active.

- **Synchronization improvements**: Upgraded atomic memory ordering from `relaxed` to `acquire`/`release` for `m_active` checks in `activate()` and `process()` to establish proper happens-before relationships across threads

- **Idempotency guard**: Added check in `activate()` to skip redundant buffer resets if already active

- **Regression test**: New `ReverbSafetyRegressionTest` validates the fix by repeatedly calling `loadState()` while a background thread concurrently processes audio (1000+ iterations), confirming no NaN/Inf output or crashes occur

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->