### PR TITLE
Keep project assets inside project folder

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1224,8 +1224,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 idMap[oldId] = newId;
                 const bool assetPathAllowed = resolveProjectAssetPath(projectPath, storedPath, resolvedPath);
                 const bool assetReadable = assetPathAllowed &&
+                    !resolvedPath.empty() &&
                     std::filesystem::exists(resolvedPath) && std::filesystem::is_regular_file(resolvedPath);
-                const std::string filePath = resolvedPath.string(); // Use resolvedPath only for file I/O
+                const std::string filePath = assetPathAllowed ? resolvedPath.string() : std::string{}; // Use resolvedPath only for file I/O
                 if (!assetPathAllowed) {
                     result.missingAssets.push_back(storedPath);
                     Log::warning("[ProjectLoad] Blocked audio asset outside project: " + storedPath);

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -169,13 +169,59 @@ namespace {
                ext == ".ogg" || ext == ".aiff" || ext == ".aif" || ext == ".m4a";
     }
 
-    std::filesystem::path resolveProjectAssetPath(const std::filesystem::path& projectPath,
-                                                  const std::string& storedPath) {
-        std::filesystem::path assetPath(storedPath);
-        if (assetPath.is_relative() && projectPath.has_parent_path()) {
-            assetPath = projectPath.parent_path() / assetPath;
+    std::filesystem::path projectAssetRoot(const std::filesystem::path& projectPath) {
+        std::filesystem::path root = projectPath.has_parent_path() ? projectPath.parent_path() : std::filesystem::path(".");
+        return root.lexically_normal();
+    }
+
+    std::filesystem::path stableAbsolutePath(const std::filesystem::path& path) {
+        std::error_code ec;
+        std::filesystem::path resolved = std::filesystem::weakly_canonical(path, ec);
+        if (!ec) {
+            return resolved.lexically_normal();
         }
-        return assetPath.lexically_normal();
+
+        ec.clear();
+        resolved = std::filesystem::absolute(path, ec);
+        if (ec) {
+            return {};
+        }
+        return resolved.lexically_normal();
+    }
+
+    bool pathIsUnderDirectory(const std::filesystem::path& root, const std::filesystem::path& candidate) {
+        const std::filesystem::path stableRoot = stableAbsolutePath(root);
+        const std::filesystem::path stableCandidate = stableAbsolutePath(candidate);
+        if (stableRoot.empty() || stableCandidate.empty()) {
+            return false;
+        }
+
+        const std::filesystem::path relative = stableCandidate.lexically_relative(stableRoot);
+        if (relative.empty() || relative.is_absolute()) {
+            return stableCandidate == stableRoot;
+        }
+        for (const auto& part : relative) {
+            if (part == "..") {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool resolveProjectAssetPath(const std::filesystem::path& projectPath,
+                                 const std::string& storedPath,
+                                 std::filesystem::path& resolvedPath) {
+        const std::filesystem::path root = projectAssetRoot(projectPath);
+        std::filesystem::path assetPath(storedPath);
+        if (assetPath.is_relative()) {
+            assetPath = root / assetPath;
+        }
+        resolvedPath = assetPath.lexically_normal();
+        if (!pathIsUnderDirectory(root, resolvedPath)) {
+            resolvedPath.clear();
+            return false;
+        }
+        return true;
     }
 
     bool isRegularDecodableAsset(const std::filesystem::path& path) {
@@ -1050,8 +1096,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         for (size_t i = 0; i < sj.size(); ++i) {
             if (!sj[i].has("path")) continue;
             std::string storedPath = sj[i]["path"].asString();
-            std::filesystem::path filePath = resolveProjectAssetPath(projectPath, storedPath);
-            if (!std::filesystem::exists(filePath) || !std::filesystem::is_regular_file(filePath)) {
+            std::filesystem::path filePath;
+            if (!resolveProjectAssetPath(projectPath, storedPath, filePath)) {
+                result.missingAssets.push_back(storedPath);
+                Log::warning("[ProjectLoad] Blocked audio asset outside project: " + storedPath);
+            } else if (!std::filesystem::exists(filePath) || !std::filesystem::is_regular_file(filePath)) {
                 result.missingAssets.push_back(storedPath);
                 Log::warning("[ProjectLoad] Missing or unreadable audio asset: " + storedPath);
             }
@@ -1169,14 +1218,18 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 if (oldId == 0 || storedPath.empty()) {
                     continue;
                 }
-                std::filesystem::path resolvedPath = resolveProjectAssetPath(projectPath, storedPath);
+                std::filesystem::path resolvedPath;
                 const std::string sourcePath = storedPath; // Use original storedPath for serialization
-                const std::string filePath = resolvedPath.string(); // Use resolvedPath only for file I/O
                 ClipSourceID newId = sourceManager.getOrCreateSource(sourcePath);
                 idMap[oldId] = newId;
-                const bool assetReadable =
+                const bool assetPathAllowed = resolveProjectAssetPath(projectPath, storedPath, resolvedPath);
+                const bool assetReadable = assetPathAllowed &&
                     std::filesystem::exists(resolvedPath) && std::filesystem::is_regular_file(resolvedPath);
-                if (!assetReadable) {
+                const std::string filePath = resolvedPath.string(); // Use resolvedPath only for file I/O
+                if (!assetPathAllowed) {
+                    result.missingAssets.push_back(storedPath);
+                    Log::warning("[ProjectLoad] Blocked audio asset outside project: " + storedPath);
+                } else if (!assetReadable) {
                     result.missingAssets.push_back(storedPath);
                     Log::warning("[ProjectLoad] Missing or unreadable audio asset: " + storedPath);
                 }

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -394,6 +394,100 @@ void testProjectAssetTraversalDoesNotDecodeOutsideFile() {
     std::filesystem::remove_all(testDir);
 }
 
+void testAbsolutePathOutsideProjectBlocked() {
+    std::cout << "[TEST] Absolute path outside project is blocked..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path projectDir = testDir / "project";
+    std::filesystem::create_directories(projectDir);
+    std::filesystem::path outsideWav = testDir / "private.wav";
+    std::filesystem::path testProject = projectDir / "project.aes";
+
+    assert(writeMinimalWavMono16(outsideWav, 44100, 4410));
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [{"id": 1, "path": "/etc/shadow", "name": "Outside Audio"}],
+        "patterns": [
+            {"id": 1, "name": "Outside Pattern", "type": "audio", "length": 4.0, "sourceId": 1, "slices": []}
+        ],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(std::find(result.missingAssets.begin(), result.missingAssets.end(), "/etc/shadow") !=
+           result.missingAssets.end());
+
+    std::cout << "[PASS] Absolute path outside project is blocked" << std::endl;
+    std::filesystem::remove_all(testDir);
+}
+
+void testSamePrefixEscapeBlocked() {
+    std::cout << "[TEST] Same-prefix path escape is blocked..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path projectDir = testDir / "project";
+    std::filesystem::create_directories(projectDir);
+    // Create a file in a sibling dir that shares the project prefix
+    std::filesystem::path siblingDir = testDir / "project-secret";
+    std::filesystem::create_directories(siblingDir);
+    std::filesystem::path siblingWav = siblingDir / "stolen.wav";
+    std::filesystem::path testProject = projectDir / "project.aes";
+
+    assert(writeMinimalWavMono16(siblingWav, 44100, 4410));
+
+    // Use a path that resolves to the sibling directory
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [{"id": 1, "path": "../project-secret/stolen.wav", "name": "Outside Audio"}],
+        "patterns": [
+            {"id": 1, "name": "Outside Pattern", "type": "audio", "length": 4.0, "sourceId": 1, "slices": []}
+        ],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(std::find(result.missingAssets.begin(), result.missingAssets.end(), "../project-secret/stolen.wav") !=
+           result.missingAssets.end());
+
+    std::cout << "[PASS] Same-prefix path escape is blocked" << std::endl;
+    std::filesystem::remove_all(testDir);
+}
+
 void testUnresolvedRouteTargetNonFatal() {
     std::cout << "[TEST] Unresolved send routing targets are non-fatal..." << std::endl;
 
@@ -750,6 +844,8 @@ int main() {
     testUnitManagerSurvivesFailedLoad();
     testMissingAudioFileNonDestructive();
     testProjectAssetTraversalDoesNotDecodeOutsideFile();
+    testAbsolutePathOutsideProjectBlocked();
+    testSamePrefixEscapeBlocked();
     testUnresolvedRouteTargetNonFatal();
     testV1FixtureMigratesToCurrentVersion();
     testAutomationTarget256DoesNotWrapToVolume();

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -7,6 +7,7 @@
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -337,6 +338,58 @@ void testMissingAudioFileNonDestructive() {
     assert(!result.missingAssets.empty());
 
     std::cout << "[PASS] Missing audio file is non-destructive" << std::endl;
+
+    std::filesystem::remove_all(testDir);
+}
+
+void testProjectAssetTraversalDoesNotDecodeOutsideFile() {
+    std::cout << "[TEST] Project asset traversal does not decode outside file..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path projectDir = testDir / "project";
+    std::filesystem::create_directories(projectDir);
+    std::filesystem::path outsideWav = testDir / "private.wav";
+    std::filesystem::path testProject = projectDir / "project.aes";
+
+    assert(writeMinimalWavMono16(outsideWav, 44100, 4410));
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [{"id": 1, "path": "../private.wav", "name": "Outside Audio"}],
+        "patterns": [
+            {"id": 1, "name": "Outside Pattern", "type": "audio", "length": 4.0, "sourceId": 1, "slices": []}
+        ],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(std::find(result.missingAssets.begin(), result.missingAssets.end(), "../private.wav") !=
+           result.missingAssets.end());
+
+    const auto sourceIds = trackManager->getSourceManager().getAllSourceIDs();
+    assert(sourceIds.size() == 1);
+    const ClipSource* source = trackManager->getSourceManager().getSource(sourceIds.front());
+    assert(source != nullptr);
+    assert(!source->isReady());
+
+    std::cout << "[PASS] Project asset traversal does not decode outside file" << std::endl;
 
     std::filesystem::remove_all(testDir);
 }
@@ -696,6 +749,7 @@ int main() {
     testFailedValidationDoesNotClear();
     testUnitManagerSurvivesFailedLoad();
     testMissingAudioFileNonDestructive();
+    testProjectAssetTraversalDoesNotDecodeOutsideFile();
     testUnresolvedRouteTargetNonFatal();
     testV1FixtureMigratesToCurrentVersion();
     testAutomationTarget256DoesNotWrapToVolume();


### PR DESCRIPTION
## Summary
- require project source asset paths to resolve under the opened project directory before file I/O
- block relative traversal, outside absolute paths, and canonical/symlink escapes from being decoded
- preserve project/source shape by treating blocked assets as missing rather than failing the whole load
- add a regression for a project referencing ../private.wav outside its folder

## Testing
- cmake --build build --target ProjectLoadRegressionTest -j2
- ctest --test-dir build --output-on-failure -R '^ProjectLoadRegressionTest$'
- git diff --check

## Risk
- Existing projects with source files outside the project folder will now load those sources as missing/unready until the assets are copied into the project directory or relinked.
- Serialization format unchanged.