### PR TITLE
Validate Arsenal routeMode IDs before casting

### DIFF
--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -58,10 +58,28 @@ std::string arsenalRouteModeName(ArsenalRouteMode routeMode) {
     }
 }
 
+std::optional<ArsenalRouteMode> arsenalRouteModeFromNumber(const JSON& routeModeJson) {
+    if (!routeModeJson.isNumber()) {
+        return std::nullopt;
+    }
+
+    const double raw = routeModeJson.asNumber();
+    if (!std::isfinite(raw) || std::floor(raw) != raw) {
+        return std::nullopt;
+    }
+
+    switch (static_cast<int>(raw)) {
+    case static_cast<int>(ArsenalRouteMode::PreviewToMaster): return ArsenalRouteMode::PreviewToMaster;
+    case static_cast<int>(ArsenalRouteMode::RoutedToTimelineTrack): return ArsenalRouteMode::RoutedToTimelineTrack;
+    case static_cast<int>(ArsenalRouteMode::Draft): return ArsenalRouteMode::Draft;
+    default: return std::nullopt;
+    }
+}
+
 std::optional<ArsenalRouteMode> arsenalRouteModeFromJson(const JSON& routeModeJson) {
     if (routeModeJson.isObject()) {
-        if (routeModeJson.has("id")) {
-            return static_cast<ArsenalRouteMode>(routeModeJson["id"].asInt());
+        if (routeModeJson.has("id") && routeModeJson["id"].isNumber()) {
+            return arsenalRouteModeFromNumber(routeModeJson["id"]);
         }
         if (routeModeJson.has("name")) {
             const std::string name = routeModeJson["name"].asString();
@@ -70,7 +88,7 @@ std::optional<ArsenalRouteMode> arsenalRouteModeFromJson(const JSON& routeModeJs
             if (name == "Draft") return ArsenalRouteMode::Draft;
         }
     } else if (routeModeJson.isNumber()) {
-        return static_cast<ArsenalRouteMode>(routeModeJson.asInt());
+        return arsenalRouteModeFromNumber(routeModeJson);
     } else if (routeModeJson.isString()) {
         const std::string name = routeModeJson.asString();
         if (name == "PreviewToMaster") return ArsenalRouteMode::PreviewToMaster;

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <cctype>
 #include <cmath>
+#include <limits>
 #include <iomanip>
 #include <optional>
 #include <sstream>
@@ -64,7 +65,9 @@ std::optional<ArsenalRouteMode> arsenalRouteModeFromNumber(const JSON& routeMode
     }
 
     const double raw = routeModeJson.asNumber();
-    if (!std::isfinite(raw) || std::floor(raw) != raw) {
+    if (!std::isfinite(raw) || std::floor(raw) != raw ||
+        raw < static_cast<double>(std::numeric_limits<int>::min()) ||
+        raw > static_cast<double>(std::numeric_limits<int>::max())) {
         return std::nullopt;
     }
 

--- a/Tests/AestraAudio/ArsenalRouteModeCompatibilityTest.cpp
+++ b/Tests/AestraAudio/ArsenalRouteModeCompatibilityTest.cpp
@@ -75,6 +75,31 @@ void verifyExplicitRouteModeCompatibility() {
             "Explicit routeMode must remain routeId-compatible in current behavior");
 }
 
+void verifyOutOfRangeRouteModeDoesNotCast() {
+    using namespace Aestra::Audio;
+    UnitManager manager;
+    Aestra::JSON root = Aestra::JSON::object();
+    root.set("nextId", Aestra::JSON(2.0));
+    Aestra::JSON units = Aestra::JSON::array();
+    Aestra::JSON unit = Aestra::JSON::object();
+    unit.set("id", Aestra::JSON(1.0));
+    unit.set("name", Aestra::JSON("InvalidRouteMode"));
+    unit.set("enabled", Aestra::JSON(true));
+    unit.set("targetMixerRoute", Aestra::JSON(-1.0));
+    Aestra::JSON routeMode = Aestra::JSON::object();
+    routeMode.set("id", Aestra::JSON(1.0e308));
+    unit.set("routeMode", routeMode);
+    units.push(unit);
+    root.set("units", units);
+
+    manager.loadFromJSON(root);
+    const UnitInfo* loaded = manager.getUnit(1);
+    require(loaded != nullptr, "Unit with out-of-range routeMode failed to load");
+    require(loaded->targetMixerRoute == -1, "routeId should remain source-of-truth");
+    require(loaded->routeMode == ArsenalRouteMode::PreviewToMaster,
+            "Out-of-range routeMode should fall back to routeId-compatible behavior");
+}
+
 void verifyDraftIsScaffoldingOnly() {
     using namespace Aestra::Audio;
     ArsenalProcessingContext ctx;
@@ -103,6 +128,7 @@ int main() {
     verifyRouteIdMapping();
     verifyLegacyRouteIdOnlyLoad();
     verifyExplicitRouteModeCompatibility();
+    verifyOutOfRangeRouteModeDoesNotCast();
     verifyDraftIsScaffoldingOnly();
 
     std::cout << "[PASS] ArsenalRouteModeCompatibilityTest\n";


### PR DESCRIPTION
## Summary
- validate numeric Arsenal routeMode IDs as finite integral values in the defined enum range before casting
- reject out-of-range/object numeric IDs non-fatally so project load falls back to routeId-compatible behavior
- add a regression for routeMode.id = 1e308 to cover the project-load UB case

## Testing
- cmake --build build --target ArsenalRouteModeCompatibilityTest -j2
- ctest --test-dir build --output-on-failure -R '^ArsenalRouteModeCompatibilityTest$'
- git diff --check

## Risk
- Invalid routeMode values are ignored instead of converted to arbitrary enum values; routeId remains the compatibility authority.
- Serialization format unchanged.