### PR TITLE
Guard CLAP scanner helper writes from SIGPIPE

### DIFF
--- a/AestraAudio/src/Plugin/PluginScanner.cpp
+++ b/AestraAudio/src/Plugin/PluginScanner.cpp
@@ -9,6 +9,7 @@
 #include "Plugin/InternalPluginRegistry.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
 #include <chrono>
 #include <cstdlib>
@@ -155,6 +156,26 @@ std::string defaultPluginHostPath() {
 }
 
 #ifndef _WIN32
+class ScopedSigpipeIgnore {
+public:
+    ScopedSigpipeIgnore() {
+        struct sigaction action {};
+        action.sa_handler = SIG_IGN;
+        sigemptyset(&action.sa_mask);
+        m_valid = sigaction(SIGPIPE, &action, &m_previous) == 0;
+    }
+
+    ~ScopedSigpipeIgnore() {
+        if (m_valid) {
+            sigaction(SIGPIPE, &m_previous, nullptr);
+        }
+    }
+
+private:
+    struct sigaction m_previous {};
+    bool m_valid{false};
+};
+
 bool sendAll(int fd, const std::string& line) {
     std::string framed = line;
     framed.push_back('\n');
@@ -162,6 +183,9 @@ bool sendAll(int fd, const std::string& line) {
     size_t remaining = framed.size();
     while (remaining > 0) {
         const ssize_t written = write(fd, data, remaining);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
         if (written <= 0) {
             return false;
         }
@@ -203,6 +227,7 @@ std::vector<PluginInfo> scanClapMetadataOutOfProcess(const std::filesystem::path
     return {};
 #else
     const std::string hostPath = defaultPluginHostPath();
+    ScopedSigpipeIgnore sigpipeIgnore;
     int inPipe[2] = {-1, -1};
     int outPipe[2] = {-1, -1};
     if (pipe(inPipe) != 0 || pipe(outPipe) != 0) {

--- a/AestraAudio/src/Plugin/PluginScanner.cpp
+++ b/AestraAudio/src/Plugin/PluginScanner.cpp
@@ -156,35 +156,59 @@ std::string defaultPluginHostPath() {
 }
 
 #ifndef _WIN32
-class ScopedSigpipeIgnore {
+class ScopedSigpipeBlock {
 public:
-    ScopedSigpipeIgnore() {
-        struct sigaction action {};
-        action.sa_handler = SIG_IGN;
-        sigemptyset(&action.sa_mask);
-        m_valid = sigaction(SIGPIPE, &action, &m_previous) == 0;
+    ScopedSigpipeBlock() {
+        sigset_t mask;
+        sigemptyset(&mask);
+        sigaddset(&mask, SIGPIPE);
+        m_valid = pthread_sigmask(SIG_BLOCK, &mask, &m_previous) == 0;
     }
 
-    ~ScopedSigpipeIgnore() {
+    ~ScopedSigpipeBlock() {
         if (m_valid) {
-            sigaction(SIGPIPE, &m_previous, nullptr);
+            pthread_sigmask(SIG_SETMASK, &m_previous, nullptr);
         }
     }
 
+    bool isValid() const { return m_valid; }
+
 private:
-    struct sigaction m_previous {};
+    sigset_t m_previous {};
     bool m_valid{false};
 };
 
+bool isSigpipePending() {
+    sigset_t pending;
+    return sigpending(&pending) == 0 && sigismember(&pending, SIGPIPE) == 1;
+}
+
+void consumePendingSigpipe() {
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPIPE);
+    int signal = 0;
+    sigwait(&mask, &signal);
+}
+
 bool sendAll(int fd, const std::string& line) {
+    ScopedSigpipeBlock sigpipeBlock;
+    if (!sigpipeBlock.isValid()) {
+        return false;
+    }
+
     std::string framed = line;
     framed.push_back('\n');
     const char* data = framed.data();
     size_t remaining = framed.size();
     while (remaining > 0) {
+        const bool sigpipeWasPending = isSigpipePending();
         const ssize_t written = write(fd, data, remaining);
         if (written < 0 && errno == EINTR) {
             continue;
+        }
+        if (written < 0 && errno == EPIPE && !sigpipeWasPending) {
+            consumePendingSigpipe();
         }
         if (written <= 0) {
             return false;
@@ -195,7 +219,7 @@ bool sendAll(int fd, const std::string& line) {
     return true;
 }
 
-bool readLineWithTimeout(int fd, pid_t pid, std::string& line, std::chrono::milliseconds timeout) {
+bool readLineWithTimeout(int fd, pid_t pid, std::string& line, std::chrono::milliseconds timeout, bool& childReaped) {
     line.clear();
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
@@ -212,12 +236,35 @@ bool readLineWithTimeout(int fd, pid_t pid, std::string& line, std::chrono::mill
         } else {
             int status = 0;
             if (waitpid(pid, &status, WNOHANG) == pid) {
+                childReaped = true;
                 return false;
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
     return false;
+}
+
+bool waitForChildExit(pid_t pid, int& status, int attempts, std::chrono::milliseconds delay) {
+    for (int i = 0; i < attempts; ++i) {
+        const pid_t waitResult = waitpid(pid, &status, WNOHANG);
+        if (waitResult == pid) {
+            return true;
+        }
+        if (waitResult < 0 && errno == ECHILD) {
+            return true;
+        }
+        if (waitResult < 0 && errno == EINTR) {
+            continue;
+        }
+        std::this_thread::sleep_for(delay);
+    }
+    return false;
+}
+
+void reapChildAfterKill(pid_t pid, int& status) {
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    }
 }
 #endif
 
@@ -227,7 +274,6 @@ std::vector<PluginInfo> scanClapMetadataOutOfProcess(const std::filesystem::path
     return {};
 #else
     const std::string hostPath = defaultPluginHostPath();
-    ScopedSigpipeIgnore sigpipeIgnore;
     int inPipe[2] = {-1, -1};
     int outPipe[2] = {-1, -1};
     if (pipe(inPipe) != 0 || pipe(outPipe) != 0) {
@@ -261,8 +307,9 @@ std::vector<PluginInfo> scanClapMetadataOutOfProcess(const std::filesystem::path
     std::vector<PluginInfo> result;
     const std::string command = "SCAN clap " + hexEncodeString(path.string());
     std::string response;
+    bool childReaped = false;
     if (sendAll(inPipe[1], command) &&
-        readLineWithTimeout(outPipe[0], pid, response, std::chrono::milliseconds(1000)) &&
+        readLineWithTimeout(outPipe[0], pid, response, std::chrono::milliseconds(1000), childReaped) &&
         response.compare(0, 3, "OK ") == 0) {
         std::istringstream fields(response.substr(3));
         std::string idHex;
@@ -293,14 +340,17 @@ std::vector<PluginInfo> scanClapMetadataOutOfProcess(const std::filesystem::path
     close(inPipe[1]);
     close(outPipe[0]);
     int status = 0;
-    for (int i = 0; i < 10; ++i) {
-        if (waitpid(pid, &status, WNOHANG) == pid) {
-            return result;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if (childReaped) {
+        return result;
     }
-    kill(pid, SIGTERM);
-    waitpid(pid, &status, 0);
+    if (waitForChildExit(pid, status, 10, std::chrono::milliseconds(10))) {
+        return result;
+    }
+    if (kill(pid, SIGTERM) == 0 && waitForChildExit(pid, status, 10, std::chrono::milliseconds(10))) {
+        return result;
+    }
+    kill(pid, SIGKILL);
+    reapChildAfterKill(pid, status);
     return result;
 #endif
 }

--- a/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
+++ b/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
@@ -1,0 +1,69 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Plugin/PluginScanner.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace {
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+std::filesystem::path makeTempDir() {
+    const auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
+    std::filesystem::create_directories(base);
+    for (int i = 0; i < 1000; ++i) {
+        const auto candidate = base / ("PluginScannerSigpipe_" + std::to_string(i));
+        if (!std::filesystem::exists(candidate)) {
+            std::filesystem::create_directories(candidate);
+            return candidate;
+        }
+    }
+
+    const auto fallback = base / "PluginScannerSigpipe_fallback";
+    std::filesystem::create_directories(fallback);
+    return fallback;
+}
+} // namespace
+
+int main() {
+#ifdef _WIN32
+    std::cout << "[SKIP] PluginScannerSigpipeTest is Unix-only\n";
+    return 0;
+#else
+    const auto dir = makeTempDir();
+    const auto clapPath = dir / "broken.clap";
+    {
+        std::ofstream out(clapPath, std::ios::binary);
+        out << "not a clap plugin";
+    }
+
+    const char* previous = std::getenv("AESTRA_PLUGIN_HOST_PATH");
+    const std::string previousValue = previous ? previous : "";
+    setenv("AESTRA_PLUGIN_HOST_PATH", "/bin/false", 1);
+
+    Aestra::Audio::PluginScanner scanner;
+    const auto plugins = scanner.rescanPlugin(clapPath);
+
+    if (previous) {
+        setenv("AESTRA_PLUGIN_HOST_PATH", previousValue.c_str(), 1);
+    } else {
+        unsetenv("AESTRA_PLUGIN_HOST_PATH");
+    }
+
+    std::filesystem::remove_all(dir);
+
+    if (!plugins.empty()) {
+        require(plugins.front().format == Aestra::Audio::PluginFormat::CLAP, "Fallback plugin format should be CLAP");
+    }
+
+    std::cout << "[PASS] PluginScannerSigpipeTest\n";
+    return 0;
+#endif
+}

--- a/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
+++ b/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
@@ -7,6 +7,10 @@
 #include <fstream>
 #include <iostream>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 namespace {
 void require(bool cond, const char* msg) {
     if (!cond) {
@@ -30,6 +34,18 @@ std::filesystem::path makeTempDir() {
     std::filesystem::create_directories(fallback);
     return fallback;
 }
+
+#ifndef _WIN32
+std::string findFalseExecutable() {
+    const char* candidates[] = {"/bin/false", "/usr/bin/false", "/usr/local/bin/false"};
+    for (const char* candidate : candidates) {
+        if (access(candidate, X_OK) == 0) {
+            return candidate;
+        }
+    }
+    return {};
+}
+#endif
 } // namespace
 
 int main() {
@@ -44,9 +60,16 @@ int main() {
         out << "not a clap plugin";
     }
 
+    const std::string falseExecutable = findFalseExecutable();
+    if (falseExecutable.empty()) {
+        std::cout << "[SKIP] PluginScannerSigpipeTest: no false executable found\n";
+        std::filesystem::remove_all(dir);
+        return 0;
+    }
+
     const char* previous = std::getenv("AESTRA_PLUGIN_HOST_PATH");
     const std::string previousValue = previous ? previous : "";
-    setenv("AESTRA_PLUGIN_HOST_PATH", "/bin/false", 1);
+    setenv("AESTRA_PLUGIN_HOST_PATH", falseExecutable.c_str(), 1);
 
     Aestra::Audio::PluginScanner scanner;
     const auto plugins = scanner.rescanPlugin(clapPath);
@@ -59,9 +82,14 @@ int main() {
 
     std::filesystem::remove_all(dir);
 
+#ifdef AESTRA_TEST_HAS_CLAP
+    require(plugins.empty(), "Broken out-of-process CLAP scan should not return plugin metadata");
+#else
     if (!plugins.empty()) {
         require(plugins.front().format == Aestra::Audio::PluginFormat::CLAP, "Fallback plugin format should be CLAP");
+        require(plugins.front().id == "broken", "Core fallback should only use the broken CLAP filename");
     }
+#endif
 
     std::cout << "[PASS] PluginScannerSigpipeTest\n";
     return 0;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -855,6 +855,9 @@ if(NOT WIN32)
         ${CMAKE_SOURCE_DIR}/AestraAudio/include
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
+    if(AESTRA_HAS_CLAP)
+        target_compile_definitions(PluginScannerSigpipeTest PRIVATE AESTRA_TEST_HAS_CLAP=1)
+    endif()
     add_test(NAME PluginScannerSigpipeTest COMMAND PluginScannerSigpipeTest)
     set_tests_properties(PluginScannerSigpipeTest PROPERTIES LABELS "audio;plugin;security")
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -848,6 +848,17 @@ target_include_directories(ArsenalRouteModePolicyTest PRIVATE
 add_test(NAME ArsenalRouteModePolicyTest COMMAND ArsenalRouteModePolicyTest)
 set_tests_properties(ArsenalRouteModePolicyTest PROPERTIES LABELS "audio;arsenal;policy")
 
+if(NOT WIN32)
+    add_executable(PluginScannerSigpipeTest AestraAudio/PluginScannerSigpipeTest.cpp)
+    target_link_libraries(PluginScannerSigpipeTest PRIVATE AestraAudioCore)
+    target_include_directories(PluginScannerSigpipeTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PluginScannerSigpipeTest COMMAND PluginScannerSigpipeTest)
+    set_tests_properties(PluginScannerSigpipeTest PROPERTIES LABELS "audio;plugin;security")
+endif()
+
 # Arsenal bridge-mode terminology contract test (Phase 2B policy-only)
 add_executable(ArsenalBridgeContractTest AestraAudio/ArsenalBridgeContractTest.cpp)
 target_link_libraries(ArsenalBridgeContractTest PRIVATE)


### PR DESCRIPTION
## Summary
- block SIGPIPE in the calling thread while the Unix CLAP metadata scanner writes to the helper process pipe
- treat interrupted writes as retryable and broken helper pipes as scan failure instead of terminating the main process
- track child reaping from the timeout path and keep helper teardown bounded with SIGTERM then SIGKILL fallback
- tighten the Unix regression coverage around broken helper paths, portable false-executable discovery, and core-mode CLAP fallback behavior

## Testing
- `cmake --build build-linux -j2`
- `ctest --test-dir build-linux --output-on-failure -R "PluginScannerSigpipeTest|AestraPluginScanTest|SecPluginScanIsolation|SecOutOfProcessPluginHost"`
- `git diff --check`

## Risk
- SIGPIPE handling is now thread-local around helper pipe writes rather than process-wide.
- Helper teardown can send SIGKILL only after bounded SIGTERM wait fails.
- No plugin format, cache, or project serialization changes.