### PR TITLE
Reshape master safety limiter

### DIFF
--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -68,6 +68,9 @@ public:
         // layer manages its own autosave location (e.g., global app-data
         // autosave independent of project path).
         std::string autosavePathOverride;
+
+        // Optional callback invoked after an autosave has been committed.
+        std::function<void(const std::string& autosavePath)> onAutosaveCommitted;
     };
     
     struct RecoveryInfo {

--- a/AestraAudio/include/Core/MasterSafetyLimiter.h
+++ b/AestraAudio/include/Core/MasterSafetyLimiter.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace Aestra {
@@ -24,9 +25,12 @@ public:
         return limited;
     }
 
-    void process(float& L, float& R) {
+    bool process(float& L, float& R) {
+        const float inL = L;
+        const float inR = R;
         L = apply(L);
         R = apply(R);
+        return (L != inL) || (R != inR);
     }
 
     void reset() {}
@@ -36,7 +40,8 @@ public:
     static constexpr float kCeiling = 0.9997f;
     static constexpr float kKneeRange = kCeiling - kKneeStart;
 
-    // Backward-compatible aliases for older tests/tools.
+    // Compilation-compatible aliases. Values intentionally reflect the
+    // reshaped limiter, not the old 0.85/0.95 thresholds.
     static constexpr double SOFT_KNEE_START = kKneeStart;
     static constexpr double OUTPUT_CEILING = kCeiling;
 
@@ -58,7 +63,7 @@ public:
         if (a >= kCeiling) {
             return std::copysign(kCeiling, s);
         }
-        return std::copysign(softKnee(a), s);
+        return std::copysign(std::min(softKnee(a), a), s);
     }
 
     static double apply(double s) {
@@ -76,7 +81,8 @@ public:
 
         const double t = (a - static_cast<double>(kKneeStart)) / static_cast<double>(kKneeRange);
         const double shaped = t * t * (3.0 - 2.0 * t);
-        return std::copysign(static_cast<double>(kKneeStart) + shaped * static_cast<double>(kKneeRange), s);
+        const double soft = static_cast<double>(kKneeStart) + shaped * static_cast<double>(kKneeRange);
+        return std::copysign(std::min(soft, a), s);
     }
 };
 

--- a/AestraAudio/include/Core/MasterSafetyLimiter.h
+++ b/AestraAudio/include/Core/MasterSafetyLimiter.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cmath>
 
 namespace Aestra {
@@ -17,78 +16,68 @@ public:
 
     // Process a stereo frame in-place. Returns true if limiting occurred.
     bool process(double& L, double& R) {
-        bool limited = false;
-
-        // DC blocking
-        {
-            double y = L - m_dcBlockerL.x1 + m_dcCoeff * m_dcBlockerL.y1;
-            m_dcBlockerL.x1 = L;
-            m_dcBlockerL.y1 = y;
-            L = y;
-        }
-        {
-            double y = R - m_dcBlockerR.x1 + m_dcCoeff * m_dcBlockerR.y1;
-            m_dcBlockerR.x1 = R;
-            m_dcBlockerR.y1 = y;
-            R = y;
-        }
-
-        L = limitSample(L, limited);
-        R = limitSample(R, limited);
-
+        const double inL = L;
+        const double inR = R;
+        L = apply(L);
+        R = apply(R);
+        const bool limited = (L != inL) || (R != inR);
         return limited;
     }
 
-    void reset() {
-        m_dcBlockerL = {};
-        m_dcBlockerR = {};
+    void process(float& L, float& R) {
+        L = apply(L);
+        R = apply(R);
     }
 
-    void setDcCoeff(double coeff) { m_dcCoeff = coeff; }
-    double getDcCoeff() const { return m_dcCoeff; }
+    void reset() {}
 
-    // Default DC blocker coefficient (~30Hz cutoff at 48kHz)
-    static constexpr double DEFAULT_DC_COEFF = 0.997;
-    static constexpr double SOFT_KNEE_START = 0.85;
-    static constexpr double OUTPUT_CEILING = 0.95;
-    static constexpr double HARD_CLAMP = 1.25;
+    // Constants -- do not change without updating tests.
+    static constexpr float kKneeStart = 0.98f;
+    static constexpr float kCeiling = 0.9997f;
+    static constexpr float kKneeRange = kCeiling - kKneeStart;
 
-    static double limitSample(double x, bool& limited) {
-        if (!std::isfinite(x)) {
-            limited = true;
+    // Backward-compatible aliases for older tests/tools.
+    static constexpr double SOFT_KNEE_START = kKneeStart;
+    static constexpr double OUTPUT_CEILING = kCeiling;
+
+    static float softKnee(float x) {
+        const float t = (x - kKneeStart) / kKneeRange;
+        const float shaped = t * t * (3.0f - 2.0f * t);
+        return kKneeStart + shaped * kKneeRange;
+    }
+
+    static float apply(float s) {
+        if (!std::isfinite(s)) {
+            return 0.0f;
+        }
+
+        const float a = std::abs(s);
+        if (a <= kKneeStart) {
+            return s;
+        }
+        if (a >= kCeiling) {
+            return std::copysign(kCeiling, s);
+        }
+        return std::copysign(softKnee(a), s);
+    }
+
+    static double apply(double s) {
+        if (!std::isfinite(s)) {
             return 0.0;
         }
 
-        if (x > HARD_CLAMP) {
-            limited = true;
-            return OUTPUT_CEILING;
+        const double a = std::abs(s);
+        if (a <= static_cast<double>(kKneeStart)) {
+            return s;
         }
-        if (x < -HARD_CLAMP) {
-            limited = true;
-            return -OUTPUT_CEILING;
-        }
-
-        const double ax = std::abs(x);
-        if (ax <= SOFT_KNEE_START) {
-            return x;
+        if (a >= static_cast<double>(kCeiling)) {
+            return std::copysign(static_cast<double>(kCeiling), s);
         }
 
-        limited = true;
-        const double sign = (x >= 0.0) ? 1.0 : -1.0;
-        const double t = std::clamp((ax - SOFT_KNEE_START) / (HARD_CLAMP - SOFT_KNEE_START), 0.0, 1.0);
-        const double shaped = SOFT_KNEE_START + (OUTPUT_CEILING - SOFT_KNEE_START) * (1.0 - std::exp(-4.0 * t));
-        return sign * std::min(shaped, OUTPUT_CEILING);
+        const double t = (a - static_cast<double>(kKneeStart)) / static_cast<double>(kKneeRange);
+        const double shaped = t * t * (3.0 - 2.0 * t);
+        return std::copysign(static_cast<double>(kKneeStart) + shaped * static_cast<double>(kKneeRange), s);
     }
-
-private:
-    struct DCBlocker {
-        double x1 = 0.0;
-        double y1 = 0.0;
-    };
-
-    DCBlocker m_dcBlockerL;
-    DCBlocker m_dcBlockerR;
-    double m_dcCoeff = DEFAULT_DC_COEFF;
 };
 
 } // namespace Audio

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -426,6 +426,10 @@ bool AutosaveManager::performAutosave() {
     
     notifyStatus("Autosaved (" + sizeStr + ")");
     Log::info("Autosaved to: " + autosavePath + " (" + sizeStr + ")");
+
+    if (m_config.onAutosaveCommitted) {
+        m_config.onAutosaveCommitted(autosavePath);
+    }
     
     return true;
 }

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -125,7 +125,7 @@ void AestraApp::writeCrashFlag() {
     std::error_code ec;
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
-        out << std::chrono::system_clock::now().time_since_epoch().count();
+        out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";
         out.close();
         Log::info("[CrashDetection] Wrote crash flag: " + flagPath);
     } else {
@@ -152,6 +152,30 @@ bool AestraApp::isCrashedSession() {
     return std::filesystem::exists(flagPath, ec);
 }
 
+std::string AestraApp::getRecoveryMarkerPath(const std::string& autosavePath) {
+    return autosavePath + ".recovery";
+}
+
+std::string AestraApp::readCrashFlagToken() {
+    std::ifstream in(getCrashFlagPath(), std::ios::binary);
+    std::string token;
+    std::getline(in, token);
+    return token;
+}
+
+void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) const {
+    if (m_recoverySessionToken.empty()) {
+        return;
+    }
+
+    std::ofstream out(getRecoveryMarkerPath(autosavePath), std::ios::binary | std::ios::trunc);
+    if (!out) {
+        Log::warning("[Recovery] Failed to write autosave recovery marker");
+        return;
+    }
+    out << m_recoverySessionToken << "\n";
+}
+
 bool AestraApp::initialize(const std::string& projectPath) {
     StartupTimer totalTimer("Total startup");
 
@@ -161,6 +185,7 @@ bool AestraApp::initialize(const std::string& projectPath) {
 
     // Check for crashed session BEFORE initializing platform.
     bool crashedSession = isCrashedSession();
+    m_previousRecoverySessionToken = crashedSession ? readCrashFlagToken() : "";
 
     {
         StartupTimer t("Platform init");
@@ -177,6 +202,7 @@ bool AestraApp::initialize(const std::string& projectPath) {
     // shutdown. If the app crashes at any point, the flag persists and the
     // next launch will detect it.
     writeCrashFlag();
+    m_recoverySessionToken = readCrashFlagToken();
 
     // Load preferences and UI state early
     Preferences::instance().load();
@@ -287,6 +313,9 @@ void AestraApp::initializeAutosave(bool enabled) {
     config.enabled = enabled;
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath);
+    };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
         const double tempo = (m_audioController && m_audioController->getEngine())
@@ -622,7 +651,10 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
     std::string autosavePath = getAutosavePath();
     std::string timestamp;
 
-    if (crashedSession && RecoveryDialog::detectAutosave(autosavePath, timestamp)) {
+    const std::string recoveryMarkerPath = getRecoveryMarkerPath(autosavePath);
+
+    if (crashedSession && !m_previousRecoverySessionToken.empty() &&
+        RecoveryDialog::detectAutosave(autosavePath, recoveryMarkerPath, m_previousRecoverySessionToken, timestamp)) {
         Log::info("[Recovery] Crash detected, showing recovery dialog");
         m_pendingAutosavePath = autosavePath;
         m_recoveryHandled = false;
@@ -649,6 +681,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
                 } else if (response == Aestra::RecoveryResponse::Discard) {
                     std::error_code ec;
                     std::filesystem::remove(autosavePath, ec);
+                    std::filesystem::remove(getRecoveryMarkerPath(autosavePath), ec);
                     if (ec) {
                         Log::warning("[Recovery] Failed to remove autosave: " + ec.message());
                     } else {
@@ -665,6 +698,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
             Log::warning("[Recovery] RecoveryDialog not available — discarding autosave");
             std::error_code ec;
             std::filesystem::remove(autosavePath, ec);
+            std::filesystem::remove(recoveryMarkerPath, ec);
             m_recoveryHandled = true;
         }
     } else {
@@ -1321,6 +1355,9 @@ void AestraApp::reinitAutosaveManager() {
     config.enabled = m_autoSaveManager.isEnabled();
     config.autosaveInterval = std::chrono::seconds(60);
     config.autosavePathOverride = getAutosavePath();
+    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath);
+    };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
         const double tempo = (m_audioController && m_audioController->getEngine())

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -93,6 +93,9 @@ private:
     void applyUIState(const ProjectSerializer::UIState& state);
     void updateWindowTitle();
     void startExport();
+    static std::string getRecoveryMarkerPath(const std::string& autosavePath);
+    static std::string readCrashFlagToken();
+    void writeRecoveryMarkerForAutosave(const std::string& autosavePath) const;
 
 private:
     std::unique_ptr<AestraWindowManager> m_windowManager;
@@ -114,6 +117,8 @@ private:
 
     // Recovery state (for deferred project loading during startup)
     std::string m_pendingAutosavePath;
+    std::string m_recoverySessionToken;
+    std::string m_previousRecoverySessionToken;
     bool m_recoveryHandled{false};
 
     // Lifetime token — set to false during shutdown so async callbacks can bail

--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -826,6 +826,8 @@ void AudioSettingsPage::loadSettings() {
         }
         else if (key == "master_limiter") {
             m_softClippingToggle->setOn(val == 1);
+            if (m_audioEngine)
+                m_audioEngine->setSafetyLimiterEnabled(val == 1);
         }
         else if (key == "multi_threading") {
             m_multiThreadingToggle->setOn(val == 1);

--- a/Source/Settings/RecoveryDialog.cpp
+++ b/Source/Settings/RecoveryDialog.cpp
@@ -65,11 +65,21 @@ bool RecoveryDialog::detectAutosave(const std::string& autosavePath,
     }
 
     std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    if (!marker.good()) {
+        Log::warning("[Recovery] Recovery marker missing; falling back to legacy autosave detection");
+        return detectAutosave(autosavePath, outTimestamp);
+    }
+
     std::string markerToken;
     std::getline(marker, markerToken);
+    if (marker.fail() && !marker.eof()) {
+        Log::warning("[Recovery] Recovery marker unreadable; falling back to legacy autosave detection");
+        return detectAutosave(autosavePath, outTimestamp);
+    }
+
     if (markerToken != expectedSessionToken) {
-        Log::warning("[Recovery] Ignoring autosave without matching recovery marker");
-        return false;
+        Log::warning("[Recovery] Recovery marker does not match current session; falling back to legacy autosave detection");
+        return detectAutosave(autosavePath, outTimestamp);
     }
 
     return detectAutosave(autosavePath, outTimestamp);

--- a/Source/Settings/RecoveryDialog.cpp
+++ b/Source/Settings/RecoveryDialog.cpp
@@ -4,6 +4,7 @@
 #include "../AestraCore/include/AestraLog.h"
 #include <chrono>
 #include <ctime>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 
@@ -53,6 +54,25 @@ bool RecoveryDialog::detectAutosave(const std::string& autosavePath, std::string
         Log::warning("[Recovery] Error checking autosave: " + std::string(e.what()));
         return false;
     }
+}
+
+bool RecoveryDialog::detectAutosave(const std::string& autosavePath,
+                                    const std::string& recoveryMarkerPath,
+                                    const std::string& expectedSessionToken,
+                                    std::string& outTimestamp) {
+    if (expectedSessionToken.empty()) {
+        return false;
+    }
+
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    std::string markerToken;
+    std::getline(marker, markerToken);
+    if (markerToken != expectedSessionToken) {
+        Log::warning("[Recovery] Ignoring autosave without matching recovery marker");
+        return false;
+    }
+
+    return detectAutosave(autosavePath, outTimestamp);
 }
 
 void RecoveryDialog::show(const std::string& autosavePath, ResponseCallback callback) {

--- a/Source/Settings/RecoveryDialog.h
+++ b/Source/Settings/RecoveryDialog.h
@@ -66,6 +66,10 @@ public:
      * @return True if autosave exists and is valid
      */
     static bool detectAutosave(const std::string& autosavePath, std::string& outTimestamp);
+    static bool detectAutosave(const std::string& autosavePath,
+                               const std::string& recoveryMarkerPath,
+                               const std::string& expectedSessionToken,
+                               std::string& outTimestamp);
     
 private:
     std::string m_autosavePath;

--- a/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
+++ b/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
@@ -1,0 +1,301 @@
+#include "Core/AudioEngine.h"
+#include "Core/MasterSafetyLimiter.h"
+#include "Playback/AuditionEngine.h"
+#include "Playback/PreviewEngine.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kFrames = 4096;
+constexpr uint32_t kBlockFrames = 2048;
+
+void writeUint32(std::ofstream& out, uint32_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+    out.put(static_cast<char>((value >> 16) & 0xFF));
+    out.put(static_cast<char>((value >> 24) & 0xFF));
+}
+
+void writeUint16(std::ofstream& out, uint16_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+}
+
+bool writeConstantPcm16Wav(const fs::path& path, float sample) {
+    std::ofstream wav(path, std::ios::binary);
+    if (!wav) {
+        return false;
+    }
+
+    const uint16_t bitsPerSample = 16;
+    const uint32_t bytesPerSample = bitsPerSample / 8;
+    const uint32_t dataChunkSize = kFrames * kChannels * bytesPerSample;
+    const uint32_t riffChunkSize = 4 + (8 + 16) + (8 + dataChunkSize);
+    const auto pcm = static_cast<int16_t>(std::lrint(std::clamp(sample, -1.0f, 1.0f) * 32767.0f));
+
+    wav.write("RIFF", 4);
+    writeUint32(wav, riffChunkSize);
+    wav.write("WAVE", 4);
+    wav.write("fmt ", 4);
+    writeUint32(wav, 16);
+    writeUint16(wav, 1);
+    writeUint16(wav, static_cast<uint16_t>(kChannels));
+    writeUint32(wav, kSampleRate);
+    writeUint32(wav, kSampleRate * kChannels * bytesPerSample);
+    writeUint16(wav, static_cast<uint16_t>(kChannels * bytesPerSample));
+    writeUint16(wav, bitsPerSample);
+    wav.write("data", 4);
+    writeUint32(wav, dataChunkSize);
+    for (uint32_t i = 0; i < kFrames * kChannels; ++i) {
+        writeUint16(wav, static_cast<uint16_t>(pcm));
+    }
+    return static_cast<bool>(wav);
+}
+
+template <typename Predicate>
+bool waitUntil(Predicate&& predicate) {
+    for (int i = 0; i < 200; ++i) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+}
+
+float averageTail(const std::vector<float>& interleaved, uint32_t startFrame) {
+    double sum = 0.0;
+    uint32_t count = 0;
+    for (uint32_t frame = startFrame; frame < kBlockFrames; ++frame) {
+        for (uint32_t ch = 0; ch < kChannels; ++ch) {
+            sum += interleaved[static_cast<size_t>(frame) * kChannels + ch];
+            ++count;
+        }
+    }
+    return count > 0 ? static_cast<float>(sum / static_cast<double>(count)) : 0.0f;
+}
+
+float peakAbs(const std::vector<float>& interleaved, uint32_t startFrame = 0) {
+    float peak = 0.0f;
+    const uint32_t frames = static_cast<uint32_t>(interleaved.size() / kChannels);
+    for (uint32_t frame = startFrame; frame < frames; ++frame) {
+        for (uint32_t ch = 0; ch < kChannels; ++ch) {
+            peak = std::max(peak, std::abs(interleaved[static_cast<size_t>(frame) * kChannels + ch]));
+        }
+    }
+    return peak;
+}
+
+float renderAuditionAverageTail(const fs::path& path) {
+    Aestra::Audio::AuditionEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setVolume(1.0f);
+    engine.setDSPPreset(Aestra::Audio::AuditionDSPPreset::Bypass());
+    engine.addToQueue(path.string());
+    engine.play();
+
+    assert(waitUntil([&engine] { return engine.getCurrentSource() != nullptr; }));
+
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    engine.processBlock(out.data(), kBlockFrames, kChannels);
+    return averageTail(out, 1024);
+}
+
+float renderPreviewAverageTail(const fs::path& path, float gainDb) {
+    Aestra::Audio::PreviewEngine engine;
+    engine.setOutputSampleRate(kSampleRate);
+    const auto result = engine.play(path.string(), gainDb, 10.0);
+    assert(result == Aestra::Audio::PreviewResult::Pending || result == Aestra::Audio::PreviewResult::Success);
+    assert(waitUntil([&engine] { return engine.isBufferReady(); }));
+
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    engine.processRealtime(out.data(), kBlockFrames, kChannels);
+    return averageTail(out, 1024);
+}
+
+void auditionBypassIsUnityForSameRateSource(const fs::path& path, float decodedSample) {
+    const float audition = renderAuditionAverageTail(path);
+    assert(std::abs(audition - decodedSample) < 2.0e-4f);
+    std::cout << "PASS: audition bypass unity, tail average=" << audition << "\n";
+}
+
+void previewIsUnityBelowLimiterAfterGainCompensation(const fs::path& path, float decodedSample) {
+    // PreviewEngine applies a built-in -1 dB normalization. +1 dB test gain
+    // cancels that so sub-threshold material should match the source after
+    // the 20 ms fade-in has completed, within the fast dB approximation error.
+    const float preview = renderPreviewAverageTail(path, 1.0f);
+    const float diff = std::abs(preview - decodedSample);
+    assert(diff < 1.0e-2f);
+    std::cout << "PASS: preview sub-threshold level after gain compensation, tail average=" << preview
+              << ", source=" << decodedSample << ", diff=" << diff << "\n";
+}
+
+void previewLimiterChangesHotMaterialButAuditionBypassDoesNot(const fs::path& path, float decodedSample) {
+    const float audition = renderAuditionAverageTail(path);
+    const float preview = renderPreviewAverageTail(path, 1.0f);
+
+    assert(std::abs(audition - decodedSample) < 2.0e-4f);
+    assert(preview < audition - 0.005f);
+    assert(preview > 0.90f);
+    std::cout << "PASS: preview limiter changed hot source, audition=" << audition << ", preview=" << preview
+              << "\n";
+}
+
+void belowKneePassthrough() {
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    float l = 0.5f;
+    float r = -0.5f;
+    limiter.process(l, r);
+    assert(l == 0.5f);
+    assert(r == -0.5f);
+    std::cout << "PASS: below_knee_passthrough\n";
+}
+
+void kneeEntryPassthrough() {
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    float l = 0.9799f;
+    float r = -0.9799f;
+    limiter.process(l, r);
+    assert(l == 0.9799f);
+    assert(r == -0.9799f);
+    std::cout << "PASS: knee_entry_passthrough\n";
+}
+
+void kneeMonotonicity() {
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    float previous = Aestra::Audio::MasterSafetyLimiter::kKneeStart;
+    constexpr int kSteps = 1000;
+
+    for (int i = 0; i <= kSteps; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(kSteps);
+        float l = Aestra::Audio::MasterSafetyLimiter::kKneeStart +
+                  t * Aestra::Audio::MasterSafetyLimiter::kKneeRange;
+        float r = 0.0f;
+        limiter.process(l, r);
+        assert(l >= previous);
+        assert(l <= Aestra::Audio::MasterSafetyLimiter::kCeiling);
+        previous = l;
+    }
+
+    std::cout << "PASS: knee_monotonicity\n";
+}
+
+void ceilingClamp() {
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    float l = 1.0f;
+    float r = -1.0f;
+    limiter.process(l, r);
+    assert(l == Aestra::Audio::MasterSafetyLimiter::kCeiling);
+    assert(r == -Aestra::Audio::MasterSafetyLimiter::kCeiling);
+    std::cout << "PASS: ceiling_clamp\n";
+}
+
+void overCeilingClamp() {
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    float l = 2.0f;
+    float r = -3.5f;
+    limiter.process(l, r);
+    assert(l == Aestra::Audio::MasterSafetyLimiter::kCeiling);
+    assert(r == -Aestra::Audio::MasterSafetyLimiter::kCeiling);
+    std::cout << "PASS: over_ceiling_clamp\n";
+}
+
+void limiterDisabledPassthrough() {
+    Aestra::Audio::AudioEngine engine;
+    engine.setSafetyLimiterEnabled(false);
+    assert(!engine.isSafetyLimiterEnabled());
+
+    Aestra::Audio::MasterSafetyLimiter limiter;
+    double l = 1.0;
+    double r = 1.0;
+    if (engine.isSafetyLimiterEnabled()) {
+        limiter.process(l, r);
+    }
+
+    assert(l == 1.0);
+    assert(r == 1.0);
+    std::cout << "PASS: limiter_disabled_passthrough\n";
+}
+
+void mainAudioEngineSafetyLimiterChangesHotMasterOutput() {
+    Aestra::Audio::AudioEngine limited;
+    assert(limited.initialize());
+    limited.setSampleRate(kSampleRate);
+    limited.setBufferConfig(kBlockFrames, kChannels);
+    limited.setMetronomeEnabled(false);
+    limited.setTestToneEnabled(true);
+    limited.setMasterGain(20.0f);
+    limited.setSafetyLimiterEnabled(true);
+    limited.setTransportPlaying(true);
+
+    Aestra::Audio::AudioEngine raw;
+    assert(raw.initialize());
+    raw.setSampleRate(kSampleRate);
+    raw.setBufferConfig(kBlockFrames, kChannels);
+    raw.setMetronomeEnabled(false);
+    raw.setTestToneEnabled(true);
+    raw.setMasterGain(20.0f);
+    raw.setSafetyLimiterEnabled(false);
+    raw.setTransportPlaying(true);
+
+    std::vector<float> limitedOut(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    std::vector<float> rawOut(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+
+    limited.processBlock(limitedOut.data(), nullptr, kBlockFrames, 0.0);
+    raw.processBlock(rawOut.data(), nullptr, kBlockFrames, 0.0);
+
+    const float limitedPeak = peakAbs(limitedOut, 512);
+    const float rawPeak = peakAbs(rawOut, 512);
+
+    assert(rawPeak > 0.99f);
+    assert(limitedPeak >= Aestra::Audio::MasterSafetyLimiter::kKneeStart);
+    assert(limitedPeak >= rawPeak);
+    assert(limitedPeak <= static_cast<float>(Aestra::Audio::MasterSafetyLimiter::OUTPUT_CEILING) + 1.0e-4f);
+    std::cout << "PASS: main AudioEngine safety limiter preserves hot legal output, rawPeak=" << rawPeak
+              << ", limitedPeak=" << limitedPeak << "\n";
+}
+
+} // namespace
+
+int main() {
+    const fs::path coldPath = fs::temp_directory_path() / "Aestra_playback_path_cold.wav";
+    const fs::path hotPath = fs::temp_directory_path() / "Aestra_playback_path_hot.wav";
+    assert(writeConstantPcm16Wav(coldPath, 0.50f));
+    assert(writeConstantPcm16Wav(hotPath, 0.95f));
+
+    const float coldDecoded = static_cast<float>(std::lrint(0.50f * 32767.0f)) / 32768.0f;
+    const float hotDecoded = static_cast<float>(std::lrint(0.95f * 32767.0f)) / 32768.0f;
+
+    belowKneePassthrough();
+    kneeEntryPassthrough();
+    kneeMonotonicity();
+    ceilingClamp();
+    overCeilingClamp();
+    limiterDisabledPassthrough();
+    auditionBypassIsUnityForSameRateSource(coldPath, coldDecoded);
+    previewIsUnityBelowLimiterAfterGainCompensation(coldPath, coldDecoded);
+    previewLimiterChangesHotMaterialButAuditionBypassDoesNot(hotPath, hotDecoded);
+    mainAudioEngineSafetyLimiterChangesHotMasterOutput();
+
+    std::error_code ec;
+    fs::remove(coldPath, ec);
+    fs::remove(hotPath, ec);
+
+    std::cout << "AestraPlaybackPathSignalIntegrityTest: PASS\n";
+    return 0;
+}

--- a/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
+++ b/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
@@ -188,6 +188,8 @@ void kneeMonotonicity() {
         float r = 0.0f;
         limiter.process(l, r);
         assert(l >= previous);
+        assert(l <= Aestra::Audio::MasterSafetyLimiter::kKneeStart +
+                        t * Aestra::Audio::MasterSafetyLimiter::kKneeRange);
         assert(l <= Aestra::Audio::MasterSafetyLimiter::kCeiling);
         previous = l;
     }
@@ -264,7 +266,7 @@ void mainAudioEngineSafetyLimiterChangesHotMasterOutput() {
 
     assert(rawPeak > 0.99f);
     assert(limitedPeak >= Aestra::Audio::MasterSafetyLimiter::kKneeStart);
-    assert(limitedPeak >= rawPeak);
+    assert(limitedPeak <= rawPeak);
     assert(limitedPeak <= static_cast<float>(Aestra::Audio::MasterSafetyLimiter::OUTPUT_CEILING) + 1.0e-4f);
     std::cout << "PASS: main AudioEngine safety limiter preserves hot legal output, rawPeak=" << rawPeak
               << ", limitedPeak=" << limitedPeak << "\n";
@@ -276,10 +278,10 @@ int main() {
     const fs::path coldPath = fs::temp_directory_path() / "Aestra_playback_path_cold.wav";
     const fs::path hotPath = fs::temp_directory_path() / "Aestra_playback_path_hot.wav";
     assert(writeConstantPcm16Wav(coldPath, 0.50f));
-    assert(writeConstantPcm16Wav(hotPath, 0.95f));
+    assert(writeConstantPcm16Wav(hotPath, 0.985f));
 
     const float coldDecoded = static_cast<float>(std::lrint(0.50f * 32767.0f)) / 32768.0f;
-    const float hotDecoded = static_cast<float>(std::lrint(0.95f * 32767.0f)) / 32768.0f;
+    const float hotDecoded = static_cast<float>(std::lrint(0.985f * 32767.0f)) / 32768.0f;
 
     belowKneePassthrough();
     kneeEntryPassthrough();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -631,6 +631,12 @@ target_include_directories(AestraAudioQualityRegressionTest PRIVATE
 add_test(NAME AestraAudioQualityRegressionTest COMMAND AestraAudioQualityRegressionTest)
 set_tests_properties(AestraAudioQualityRegressionTest PROPERTIES LABELS "audio;quality;regression")
 
+# Playback path signal-integrity diagnostics
+add_executable(AestraPlaybackPathSignalIntegrityTest AestraAudio/PlaybackPathSignalIntegrityTest.cpp)
+target_link_libraries(AestraPlaybackPathSignalIntegrityTest PRIVATE AestraAudio)
+add_test(NAME AestraPlaybackPathSignalIntegrityTest COMMAND AestraPlaybackPathSignalIntegrityTest)
+set_tests_properties(AestraPlaybackPathSignalIntegrityTest PROPERTIES LABELS "audio;quality;regression;playback")
+
 # AudioEngine output channel safety regression test
 add_executable(AestraAudioEngineOutputChannelTest AestraAudio/AudioEngineOutputChannelTest.cpp)
 target_link_libraries(AestraAudioEngineOutputChannelTest PRIVATE AestraAudioCore)

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -106,9 +106,18 @@ bool isCrashedSession(const std::filesystem::path& path) {
 }
 
 // Mimics RecoveryDialog::detectAutosave — just checks file existence
-bool detectAutosave(const std::filesystem::path& autosavePath, std::string& outTimestamp) {
+bool detectAutosave(const std::filesystem::path& autosavePath,
+                    const std::filesystem::path& recoveryMarkerPath,
+                    const std::string& expectedSessionToken,
+                    std::string& outTimestamp) {
     std::error_code ec;
     if (!std::filesystem::exists(autosavePath, ec) || ec) {
+        return false;
+    }
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    std::string markerToken;
+    std::getline(marker, markerToken);
+    if (markerToken != expectedSessionToken) {
         return false;
     }
     outTimestamp = "detected";
@@ -123,6 +132,7 @@ int main() {
     const auto tempDir = makeTempDir();
     const auto wavPath = tempDir / "test.wav";
     const auto autosavePath = tempDir / "autosave.aes";
+    const auto recoveryMarkerPath = tempDir / "autosave.aes.recovery";
     const auto crashFlagPath = tempDir / "crash_flag";
 
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
@@ -171,7 +181,11 @@ int main() {
 
     // --- Simulate crash flag write at session start (AestraApp::initialize)
     time_t crashTime = writeCrashFlag(crashFlagPath);
+    std::ifstream crashFlagIn(crashFlagPath, std::ios::binary);
+    std::string recoverySessionToken;
+    std::getline(crashFlagIn, recoverySessionToken);
     require(isCrashedSession(crashFlagPath), "Crash flag should exist after write");
+    require(!recoverySessionToken.empty(), "Crash flag should contain recovery session token");
     std::cout << "[INFO] Crash flag written: " << crashFlagPath.string() << "\n";
 
     // --- Simulate autosave (what AutosaveManager::performAutosave does)
@@ -182,13 +196,24 @@ int main() {
         require(!ser.contents.empty(), "ProjectSerializer::serialize produced empty output");
         require(ProjectSerializer::writeAtomically(autosavePath.string(), ser.contents),
                 "ProjectSerializer::writeAtomically failed for autosave");
+        std::ofstream marker(recoveryMarkerPath, std::ios::binary | std::ios::trunc);
+        marker << recoverySessionToken << "\n";
         std::cout << "[INFO] Autosave written: " << autosavePath.string() << "\n";
+    }
+
+    {
+        const auto plantedPath = tempDir / "planted_autosave.aes";
+        std::ofstream planted(plantedPath, std::ios::binary | std::ios::trunc);
+        planted << "planted";
+        std::string timestamp;
+        require(!detectAutosave(plantedPath, recoveryMarkerPath, "wrong-session", timestamp),
+                "Recovery must reject autosave without matching session marker");
     }
 
     // --- Recovery: detect autosave
     {
         std::string timestamp;
-        bool detected = detectAutosave(autosavePath, timestamp);
+        bool detected = detectAutosave(autosavePath, recoveryMarkerPath, recoverySessionToken, timestamp);
         require(detected, "Recovery should detect autosave");
         std::cout << "[INFO] Autosave detected for recovery.\n";
     }

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -114,12 +114,16 @@ bool detectAutosave(const std::filesystem::path& autosavePath,
     if (!std::filesystem::exists(autosavePath, ec) || ec) {
         return false;
     }
-    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
-    std::string markerToken;
-    std::getline(marker, markerToken);
-    if (markerToken != expectedSessionToken) {
+    if (expectedSessionToken.empty()) {
         return false;
     }
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    if (!marker.good()) {
+        outTimestamp = "detected";
+        return true;
+    }
+    std::string markerToken;
+    std::getline(marker, markerToken);
     outTimestamp = "detected";
     return true;
 }
@@ -206,8 +210,10 @@ int main() {
         std::ofstream planted(plantedPath, std::ios::binary | std::ios::trunc);
         planted << "planted";
         std::string timestamp;
-        require(!detectAutosave(plantedPath, recoveryMarkerPath, "wrong-session", timestamp),
-                "Recovery must reject autosave without matching session marker");
+        require(detectAutosave(plantedPath, recoveryMarkerPath, "wrong-session", timestamp),
+                "Recovery should fall back to legacy autosave detection on marker mismatch");
+        require(!detectAutosave(plantedPath, recoveryMarkerPath, "", timestamp),
+                "Recovery must reject autosave when current session token is empty");
     }
 
     // --- Recovery: detect autosave

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -188,6 +188,7 @@ int main() {
     std::ifstream crashFlagIn(crashFlagPath, std::ios::binary);
     std::string recoverySessionToken;
     std::getline(crashFlagIn, recoverySessionToken);
+    crashFlagIn.close();
     require(isCrashedSession(crashFlagPath), "Crash flag should exist after write");
     require(!recoverySessionToken.empty(), "Crash flag should contain recovery session token");
     std::cout << "[INFO] Crash flag written: " << crashFlagPath.string() << "\n";


### PR DESCRIPTION
## Summary
- reshape the master safety limiter to a transparent 0.98 -> 0.9997 cubic Hermite knee that never boosts input samples
- restore the saved master limiter setting directly into AudioEngine during settings load
- add playback-path signal integrity regression coverage for limiter passthrough, knee monotonicity, ceiling clamp, disabled path, and hot-output behavior
- preserve recovery compatibility by falling back to legacy autosave detection when recovery markers are missing, unreadable, or mismatched

## Validation
- `cmake --build build/headless --target AestraPlaybackPathSignalIntegrityTest -j2`
- `cmake --build build/headless --target SessionRecoveryTest -j2`
- `ctest --test-dir build/headless -R AestraPlaybackPathSignalIntegrityTest --output-on-failure -j2`
- `ctest --test-dir build/headless -R SessionRecoveryTest --output-on-failure -j2`
- `git diff --check`

## Risk
- DSP changed: yes, master safety limiter only
- UI changed: no
- Serialization/project format changed: no
- Build/CI config changed: yes, test target registration only
- Public docs changed: no

## Review Notes
- Fixed CodeRabbit and Greptile comments for limiter no-boost behavior, test fixture level, peak assertion direction, float return parity, alias wording, and recovery fallback.
- The DC-blocking review thread remains intentionally unresolved because restoring stateful DC blocking inside `MasterSafetyLimiter` conflicts with the Trident spec's stateless per-sample limiter scope.