### PR TITLE
Fix pattern restore and timeline persistence

### DIFF
--- a/AestraAudio/include/Commands/AddClipCommand.h
+++ b/AestraAudio/include/Commands/AddClipCommand.h
@@ -18,6 +18,7 @@ public:
     std::string getName() const override { return "Add Clip"; }
     size_t getSizeInBytes() const override { return sizeof(*this); }
     bool changesProjectState() const override { return true; }
+    bool isUndoable() const override { return m_executed; }
 
     std::string serialize() const override;
     std::string type() const override { return "add_clip"; }

--- a/AestraAudio/include/Commands/ICommand.h
+++ b/AestraAudio/include/Commands/ICommand.h
@@ -45,6 +45,11 @@ public:
     virtual bool changesProjectState() const { return true; }
 
     /**
+     * @brief Whether the most recent execute/redo produced an undoable change.
+     */
+    virtual bool isUndoable() const { return true; }
+
+    /**
      * @brief Serialize command to JSON string for persistence
      * @return JSON representation of command data
      */

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -70,6 +70,7 @@ struct ClipInstance {
     uint32_t colorRGBA{0xFFFFFFFF}; // Clip color
     double startBeat = 0.0;
     double durationBeats = 4.0;
+    double durationSeconds = 0.0; // Canonical duration for audio clips; MIDI clips remain beat-native.
     double sourceOffset = 0.0; // Offset into source material
 
     ClipEdits edits;

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -71,7 +71,8 @@ struct ClipInstance {
     double startBeat = 0.0;
     double durationBeats = 4.0;
     double durationSeconds = 0.0; // Canonical duration for audio clips; MIDI clips remain beat-native.
-    double sourceOffset = 0.0; // Offset into source material
+    double sourceOffset = 0.0;        // Beat offset into source material.
+    double sourceOffsetSeconds = 0.0; // Canonical audio-source offset; MIDI clips remain beat-native.
 
     ClipEdits edits;
 

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -225,12 +225,22 @@ public:
      * @param duration New clip duration in beats.
      */
     void setClipDuration(const ClipInstanceID& clipId, double duration) {
-        auto* clip = getClip(clipId);
-        if (clip) {
+        bool changed = false;
+        {
+            std::unique_lock<std::shared_mutex> lock(m_mutex);
+            auto* clip = getClipInternal(clipId);
+            if (!clip) {
+                return;
+            }
+
             clip->durationBeats = duration;
-            if (isAudioClip(*clip) && duration > 0.0) {
+            if (isAudioClipUnlocked(*clip) && duration > 0.0) {
                 clip->durationSeconds = beatToSeconds(duration);
             }
+            changed = true;
+        }
+
+        if (changed) {
             notifyClipChanged(clipId);
         }
     }
@@ -342,6 +352,7 @@ public:
         newClip.durationBeats = clip->endBeat() - splitBeat;
         newClip.sourceId = clip->sourceId;
         newClip.sourceOffset = clip->sourceOffset + (splitBeat - clip->startBeat);
+        newClip.sourceOffsetSeconds = clip->sourceOffsetSeconds;
         newClip.edits = clip->edits;
         newClip.edits.fadeInBeats = 0.0f; // Clear fades at split point
 
@@ -349,6 +360,8 @@ public:
         clip->durationBeats = splitBeat - clip->startBeat;
         clip->edits.fadeOutBeats = 0.0f;
         if (isAudioClipUnlocked(*clip)) {
+            const double splitOffsetSeconds = beatToSeconds(splitBeat - clip->startBeat);
+            newClip.sourceOffsetSeconds = clip->sourceOffsetSeconds + splitOffsetSeconds;
             clip->durationSeconds = beatToSeconds(clip->durationBeats);
             newClip.durationSeconds = beatToSeconds(newClip.durationBeats);
         }
@@ -462,8 +475,11 @@ public:
                         continue;
                     }
                     const double newDurationBeats = secondsToBeatsUnlocked(clip.durationSeconds);
-                    if (std::abs(newDurationBeats - clip.durationBeats) > 1.0e-9) {
+                    const double newSourceOffsetBeats = secondsToBeatsUnlocked(clip.sourceOffsetSeconds);
+                    if (std::abs(newDurationBeats - clip.durationBeats) > 1.0e-9 ||
+                        std::abs(newSourceOffsetBeats - clip.sourceOffset) > 1.0e-9) {
                         clip.durationBeats = newDurationBeats;
+                        clip.sourceOffset = newSourceOffsetBeats;
                         changedClips.push_back(clip.id);
                     }
                 }

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -8,6 +8,7 @@
 #include "SourceManager.h"
 
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
@@ -227,6 +228,9 @@ public:
         auto* clip = getClip(clipId);
         if (clip) {
             clip->durationBeats = duration;
+            if (isAudioClip(*clip) && duration > 0.0) {
+                clip->durationSeconds = beatToSeconds(duration);
+            }
             notifyClipChanged(clipId);
         }
     }
@@ -344,6 +348,10 @@ public:
         // Trim original clip
         clip->durationBeats = splitBeat - clip->startBeat;
         clip->edits.fadeOutBeats = 0.0f;
+        if (isAudioClipUnlocked(*clip)) {
+            clip->durationSeconds = beatToSeconds(clip->durationBeats);
+            newClip.durationSeconds = beatToSeconds(newClip.durationBeats);
+        }
 
         // Add new clip
         m_lanes[laneIdxIt->second].clips.push_back(newClip);
@@ -439,7 +447,33 @@ public:
     /**
      * @brief Set BPM
      */
-    void setBPM(double bpm) { m_bpm = bpm; }
+    void setBPM(double bpm) {
+        if (!std::isfinite(bpm) || bpm <= 0.0) {
+            return;
+        }
+
+        std::vector<ClipInstanceID> changedClips;
+        {
+            std::unique_lock<std::shared_mutex> lock(m_mutex);
+            m_bpm = bpm;
+            for (auto& lane : m_lanes) {
+                for (auto& clip : lane.clips) {
+                    if (!isAudioClipUnlocked(clip) || clip.durationSeconds <= 0.0) {
+                        continue;
+                    }
+                    const double newDurationBeats = secondsToBeatsUnlocked(clip.durationSeconds);
+                    if (std::abs(newDurationBeats - clip.durationBeats) > 1.0e-9) {
+                        clip.durationBeats = newDurationBeats;
+                        changedClips.push_back(clip.id);
+                    }
+                }
+            }
+        }
+
+        for (const auto& clipId : changedClips) {
+            notifyClipChanged(clipId);
+        }
+    }
 
     /**
      * @brief Get BPM
@@ -455,6 +489,11 @@ public:
 
     double secondsToBeats(double seconds) const {
         return seconds * m_bpm / 60.0;
+    }
+
+    bool isAudioClip(const ClipInstance& clip) const {
+        std::shared_lock<std::shared_mutex> lock(m_mutex);
+        return isAudioClipUnlocked(clip);
     }
 
     double getTotalDurationBeats() const {
@@ -501,6 +540,17 @@ public:
         clip.durationBeats = durationBeats;
         clip.patternId = patternId;
         clip.sourceId = patternId.value; // Store pattern ID in sourceId for now
+        if (m_patternManager) {
+            const auto* pattern = m_patternManager->getPattern(patternId);
+            if (pattern && pattern->isAudio()) {
+                const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
+                if (payload.durationSeconds > 0.0) {
+                    clip.durationSeconds = payload.durationSeconds;
+                } else {
+                    clip.durationSeconds = beatToSeconds(durationBeats);
+                }
+            }
+        }
 
         m_lanes[it->second].clips.push_back(clip);
         m_clipLaneMap[clip.id] = laneId;
@@ -607,6 +657,18 @@ private:
     double m_bpm{120.0};
     double m_projectSampleRate{48000.0}; // Default, configurable
     PatternManager* m_patternManager{nullptr};
+
+    bool isAudioClipUnlocked(const ClipInstance& clip) const {
+        if (!m_patternManager || !clip.patternId.isValid()) {
+            return false;
+        }
+        const auto* pattern = m_patternManager->getPattern(clip.patternId);
+        return pattern && pattern->isAudio();
+    }
+
+    double secondsToBeatsUnlocked(double seconds) const {
+        return seconds * m_bpm / 60.0;
+    }
 
     ClipInstance* getClipInternal(const ClipInstanceID& clipId) {
         auto laneIt = m_clipLaneMap.find(clipId);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -69,6 +69,7 @@ public:
     TrackManager() : m_patternPlaybackEngine(&m_timelineClock, &m_patternManager, &m_unitManager) {
         m_continuousParams = std::make_shared<ContinuousParamBuffer>();
         m_channelSlotMap = std::make_shared<ChannelSlotMap>();
+        m_playlistModel.setPatternManager(&m_patternManager);
         // Wire up playlist model to trigger audio graph rebuild when clips change
         m_playlistModel.setClipChangedCallback(
             [this](const ClipInstanceID&) { requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged); });
@@ -1187,6 +1188,8 @@ private:
         if (durationBeats <= 0.0) {
             return;
         }
+        const double durationSeconds =
+            static_cast<double>(conditionedSamples.size()) / std::max(1.0, m_inputSampleRate);
         const float playbackGain = computeRecordedTakeGain(conditionedSamples);
 
         auto buffer = std::make_shared<AudioBufferData>();
@@ -1215,6 +1218,7 @@ private:
 
         AudioSlicePayload payload;
         payload.audioSourceId = sourceId;
+        payload.durationSeconds = durationSeconds;
         payload.slices.push_back({0.0, static_cast<double>(buffer->numFrames)});
 
         PatternID patternId = m_patternManager.createAudioPattern(takeName, durationBeats, payload);
@@ -1228,6 +1232,7 @@ private:
         clip.name = takeName;
         clip.startBeat = startBeat;
         clip.durationBeats = durationBeats;
+        clip.durationSeconds = durationSeconds;
         clip.patternId = patternId;
         clip.sourceId = patternId.value;
         clip.edits.gain = playbackGain;

--- a/AestraAudio/src/Commands/AddClipCommand.cpp
+++ b/AestraAudio/src/Commands/AddClipCommand.cpp
@@ -1,6 +1,7 @@
 #include "Commands/AddClipCommand.h"
 
 #include "AestraAudio.h"
+#include <stdexcept>
 #include <sstream>
 
 namespace Aestra {
@@ -18,7 +19,10 @@ void AddClipCommand::execute() {
         m_clip.id = ClipInstanceID::generate();
     }
 
-    m_playlist.addClip(m_laneId, m_clip);
+    const ClipInstanceID addedId = m_playlist.addClip(m_laneId, m_clip);
+    if (!addedId.isValid()) {
+        throw std::runtime_error("AddClipCommand failed: target lane not found");
+    }
     m_executed = true;
 }
 
@@ -35,7 +39,10 @@ void AddClipCommand::redo() {
         return;
 
     // Re-add using the exact same ID so it restores state correctly
-    m_playlist.addClip(m_laneId, m_clip);
+    const ClipInstanceID addedId = m_playlist.addClip(m_laneId, m_clip);
+    if (!addedId.isValid()) {
+        throw std::runtime_error("AddClipCommand redo failed: target lane not found");
+    }
     m_executed = true;
 }
 

--- a/AestraAudio/src/Commands/AddClipCommand.cpp
+++ b/AestraAudio/src/Commands/AddClipCommand.cpp
@@ -1,7 +1,6 @@
 #include "Commands/AddClipCommand.h"
 
 #include "AestraAudio.h"
-#include <stdexcept>
 #include <sstream>
 
 namespace Aestra {
@@ -20,10 +19,7 @@ void AddClipCommand::execute() {
     }
 
     const ClipInstanceID addedId = m_playlist.addClip(m_laneId, m_clip);
-    if (!addedId.isValid()) {
-        throw std::runtime_error("AddClipCommand failed: target lane not found");
-    }
-    m_executed = true;
+    m_executed = addedId.isValid();
 }
 
 void AddClipCommand::undo() {
@@ -40,10 +36,7 @@ void AddClipCommand::redo() {
 
     // Re-add using the exact same ID so it restores state correctly
     const ClipInstanceID addedId = m_playlist.addClip(m_laneId, m_clip);
-    if (!addedId.isValid()) {
-        throw std::runtime_error("AddClipCommand redo failed: target lane not found");
-    }
-    m_executed = true;
+    m_executed = addedId.isValid();
 }
 
 std::string AddClipCommand::serialize() const {

--- a/AestraAudio/src/Commands/CommandHistory.cpp
+++ b/AestraAudio/src/Commands/CommandHistory.cpp
@@ -32,6 +32,9 @@ void CommandHistory::pushAndExecute(std::shared_ptr<ICommand> cmd) {
         std::cerr << "Command execution failed: " << e.what() << std::endl;
         return;
     }
+    if (!cmd->isUndoable()) {
+        return;
+    }
 
     bool stateChanged = false;
     {

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -39,7 +39,9 @@ HeadlessMusicGenerator& HeadlessMusicGenerator::createProject(const std::string&
 
 HeadlessMusicGenerator& HeadlessMusicGenerator::setTempo(double bpm) {
     m_tempo = bpm;
-    // m_trackManager.getTimelineClock().setTempo(bpm);  // TODO: Set tempo on track manager
+    m_trackManager.getPlaylistModel().setBPM(bpm);
+    m_trackManager.getTimelineClock().setTempo(bpm);
+    m_trackManager.getPatternPlaybackEngine().flush();
     m_engine.setBPM(static_cast<float>(bpm));
     return *this;
 }

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -7,6 +7,7 @@
 #include "Plugin/BuiltInPlugins.h"
 #include "Plugin/PluginManager.h"
 #include "Plugin/SamplerPlugin.h"
+#include "AestraJSON.h"
 #include "AestraLog.h"
 
 #include <algorithm>
@@ -25,6 +26,17 @@ bool shouldRestoreArsenalPluginFromProject(const PluginInfo& plugin) noexcept {
 }
 
 namespace {
+bool samplerStateHasSamplePath(const std::vector<uint8_t>& state) {
+    if (state.empty()) {
+        return false;
+    }
+
+    const std::string text(state.begin(), state.end());
+    const auto json = Aestra::JSON::parse(text);
+    return json.isObject() && json.has("samplePath") && json["samplePath"].isString() &&
+           !json["samplePath"].asString().empty();
+}
+
 UnitGroup unitGroupForType(UnitType type) {
     switch (type) {
     case UnitType::Instrument: return UnitGroup::Synth;
@@ -724,8 +736,11 @@ void UnitManager::loadFromJSON(const JSON& json) {
 
                 // Load state BEFORE activation to ensure plugin is ready before processing audio.
                 // This matches EffectChain lifecycle: create -> initialize -> loadState -> activate.
+                bool stateLoaded = true;
+                const bool samplerStateIncludesSamplePath = samplerStateHasSamplePath(unit.pluginState);
                 if (!unit.pluginState.empty()) {
                     if (!unit.plugin->loadState(unit.pluginState)) {
+                        stateLoaded = false;
                         Aestra::Log::warning("[UnitManager] Failed to load state for unit " +
                                              std::to_string(unit.id) + " — using default state");
                     }
@@ -733,7 +748,7 @@ void UnitManager::loadFromJSON(const JSON& json) {
 
                 // Older project saves kept the sampler file only in UnitInfo::audioClipPath.
                 // Rehydrate that path so restored MIDI has sample data even when pluginState lacks samplePath.
-                if (!unit.audioClipPath.empty()) {
+                if (!unit.audioClipPath.empty() && (!samplerStateIncludesSamplePath || !stateLoaded)) {
                     if (auto sampler = std::dynamic_pointer_cast<Plugins::SamplerPlugin>(unit.plugin)) {
                         if (sampler->loadSample(unit.audioClipPath)) {
                             unit.pluginState = sampler->saveState();

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -731,6 +731,19 @@ void UnitManager::loadFromJSON(const JSON& json) {
                     }
                 }
 
+                // Older project saves kept the sampler file only in UnitInfo::audioClipPath.
+                // Rehydrate that path so restored MIDI has sample data even when pluginState lacks samplePath.
+                if (!unit.audioClipPath.empty()) {
+                    if (auto sampler = std::dynamic_pointer_cast<Plugins::SamplerPlugin>(unit.plugin)) {
+                        if (sampler->loadSample(unit.audioClipPath)) {
+                            unit.pluginState = sampler->saveState();
+                        } else {
+                            Aestra::Log::warning("[UnitManager] Failed to reload sampler audio for unit " +
+                                                 std::to_string(unit.id) + ": " + unit.audioClipPath);
+                        }
+                    }
+                }
+
                 if (unit.enabled || unit.isEnabled) {
                     unit.plugin->activate();
                 }

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -154,23 +154,19 @@ bool SamplerPlugin::loadSample(const std::string& path) {
         return false;
     }
 
-    // Convert planar to interleaved for Sinc64Turbo
-    // Decoder produces: [L0,L1,L2...,R0,R1,R2...] or [L0,L1,L2...] for mono
-    // Need: [L0,R0,L1,R1,L2,R2...] (always stereo for Sinc64Turbo)
+    // Decode output is interleaved. Keep stereo data in-place and only upmix
+    // mono defensively for callers that bypass decodeAudioFile's forceStereo().
     const size_t numFrames = data.size() / std::max<uint32_t>(channels, 1);
-    std::vector<float> interleaved(numFrames * 2);
-    if (channels == 2) {
-        for (size_t i = 0; i < numFrames; ++i) {
-            interleaved[i * 2] = data[i];
-            interleaved[i * 2 + 1] = data[numFrames + i];
-        }
-    } else {
+    if (channels == 1) {
+        std::vector<float> interleaved(numFrames * 2);
         for (size_t i = 0; i < numFrames; ++i) {
             interleaved[i * 2] = data[i];
             interleaved[i * 2 + 1] = data[i];
         }
+        data = std::move(interleaved);
+    } else if (channels != 2) {
+        return false;
     }
-    data = std::move(interleaved);
 
     // Prepare new data container
     auto newData = std::make_shared<SampleData>();

--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -97,9 +97,11 @@ bool PlatformWindowLinux::pollEvents() {
     while (SDL_PollEvent(&e)) {
         switch (e.type) {
         case SDL_QUIT:
-            if (m_closeCallback)
+            if (m_closeCallback) {
                 m_closeCallback();
-            return false; // Or let the app decide via callback
+                return true;
+            }
+            return false;
 
         case SDL_WINDOWEVENT:
             if (e.window.windowID == SDL_GetWindowID(m_window)) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -610,16 +610,26 @@ void PianoRollToolbar::setupUI() {
     m_eraserBtn = std::make_shared<NUIButton>("");
     m_eraserBtn->setOnClick([this](){ setActiveTool(GlobalTool::Eraser); });
 
+    m_patternDropdown = std::make_shared<NUIDropdown>();
+    m_patternDropdown->setPlaceholderText("Pattern");
+    m_patternDropdown->setMaxVisibleItems(8);
+    m_patternDropdown->setItemHeight(24.0f);
+    m_patternDropdown->setOnSelectionChanged([this](int, int value, const std::string&) {
+        if (!m_updatingPatternDropdown && onPatternChoiceSelected_) {
+            onPatternChoiceSelected_(value);
+        }
+    });
+
     m_lengthDownBtn = std::make_shared<NUIButton>("");
-    m_lengthDownBtn->setTooltip("Shorten Pattern By 4 Bars");
+    m_lengthDownBtn->setTooltip("Shorten Pattern By 2 Bars");
     m_lengthDownBtn->setOnClick([this]() {
-        if (onAdjustPatternLength_) onAdjustPatternLength_(-4);
+        if (onAdjustPatternLength_) onAdjustPatternLength_(-2);
     });
 
     m_lengthUpBtn = std::make_shared<NUIButton>("");
-    m_lengthUpBtn->setTooltip("Extend Pattern By 4 Bars");
+    m_lengthUpBtn->setTooltip("Extend Pattern By 2 Bars");
     m_lengthUpBtn->setOnClick([this]() {
-        if (onAdjustPatternLength_) onAdjustPatternLength_(4);
+        if (onAdjustPatternLength_) onAdjustPatternLength_(2);
     });
     
     // Icons
@@ -641,6 +651,7 @@ void PianoRollToolbar::setupUI() {
     addChild(m_ptrBtn);
     addChild(m_pencilBtn);
     addChild(m_eraserBtn);
+    addChild(m_patternDropdown);
     addChild(m_lengthDownBtn);
     addChild(m_lengthUpBtn);
 }
@@ -651,7 +662,22 @@ void PianoRollToolbar::setPatternName(const std::string& name) {
 }
 
 void PianoRollToolbar::setPatternLengthBeats(double beats) {
-    m_patternLengthBeats = std::max(4.0, beats);
+    m_patternLengthBeats = std::max(8.0, beats);
+    repaint();
+}
+
+void PianoRollToolbar::setPatternChoices(const std::vector<PatternChoice>& choices, int selectedValue) {
+    if (!m_patternDropdown) {
+        return;
+    }
+
+    m_updatingPatternDropdown = true;
+    m_patternDropdown->clearItems();
+    for (const auto& choice : choices) {
+        m_patternDropdown->addItem(choice.label, choice.value);
+    }
+    m_patternDropdown->setSelectedByValue(selectedValue);
+    m_updatingPatternDropdown = false;
     repaint();
 }
 
@@ -730,6 +756,19 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
     renderButton(m_pencilBtn, m_pencilIcon, activeTool_ == GlobalTool::Pencil);
     renderButton(m_eraserBtn, m_eraserIcon, activeTool_ == GlobalTool::Eraser);
 
+    float patternDropdownRight = currentX;
+    if (m_patternDropdown) {
+        currentX += 4.0f;
+        renderer.drawLine(NUIPoint(currentX, currentY + 4), NUIPoint(currentX, currentY + buttonSize - 4), 1.0f, borderCol.withAlpha(0.45f));
+        currentX += 10.0f;
+
+        const float dropdownW = 190.0f;
+        m_patternDropdown->setBounds(NUIRect(currentX, currentY, dropdownW, buttonSize));
+        m_patternDropdown->onRender(renderer);
+        patternDropdownRight = currentX + dropdownW;
+        currentX += dropdownW + buttonSpacing;
+    }
+
     currentX += 4.0f;
     renderer.drawLine(NUIPoint(currentX, currentY + 4), NUIPoint(currentX, currentY + buttonSize - 4), 1.0f, borderCol.withAlpha(0.45f));
     currentX += 10.0f;
@@ -756,9 +795,15 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
 
     // Editing Pattern Label (Right Side)
     if (!m_patternName.empty()) {
+        const float labelLeft = std::max(patternDropdownRight + 10.0f, currentX + 6.0f);
+        const float labelRight = b.right() - innerPad - 4.0f;
+        const float maxLabelWidth = labelRight - labelLeft;
+        if (maxLabelWidth < 24.0f) {
+            return;
+        }
+
         std::string labelStr = m_patternName;
         float fontSize = 10.0f;
-        const float maxLabelWidth = std::max(120.0f, b.width * 0.28f);
         auto measured = renderer.measureText(labelStr, fontSize);
         while (measured.width > maxLabelWidth && labelStr.length() > 3) {
             labelStr.pop_back();
@@ -770,7 +815,7 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
             labelStr += "...";
         }
         auto size = renderer.measureText(labelStr, fontSize);
-        float lx = b.right() - size.width - innerPad - 4.0f;
+        float lx = std::max(labelLeft, labelRight - size.width);
         renderer.drawText(labelStr, NUIPoint(lx, currentY + (buttonSize - size.height) * 0.5f + 2.0f), fontSize, themeManager.getColor("textSecondary").withAlpha(0.72f));
     }
 
@@ -2603,8 +2648,14 @@ void PianoRollView::setPatternName(const std::string& name) {
     if (m_toolbar) m_toolbar->setPatternName(name);
 }
 
+void PianoRollView::setPatternChoices(const std::vector<PianoRollToolbar::PatternChoice>& choices, int selectedValue) {
+    if (m_toolbar) {
+        m_toolbar->setPatternChoices(choices, selectedValue);
+    }
+}
+
 void PianoRollView::setPatternLengthBeats(double beats) {
-    m_patternLengthBeats = std::max(16.0, beats);
+    m_patternLengthBeats = std::max(8.0, beats);
     if (m_toolbar) {
         m_toolbar->setPatternLengthBeats(m_patternLengthBeats);
     }
@@ -2639,7 +2690,7 @@ void PianoRollView::setPlayheadBeat(double beat, bool follow) {
 }
 
 void PianoRollView::setTotalDurationBeats(double beats) {
-    m_totalDurationBeats = std::max(16.0, beats);
+    m_totalDurationBeats = std::max(8.0, beats);
     m_patternLengthBeats = m_totalDurationBeats;
     if (m_toolbar) {
         m_toolbar->setPatternLengthBeats(m_patternLengthBeats);
@@ -2651,6 +2702,12 @@ void PianoRollView::setTotalDurationBeats(double beats) {
 void PianoRollView::setOnAdjustPatternLength(std::function<void(int barsDelta)> cb) {
     if (m_toolbar) {
         m_toolbar->setOnAdjustPatternLength(std::move(cb));
+    }
+}
+
+void PianoRollView::setOnPatternChoiceSelected(std::function<void(int patternValue)> cb) {
+    if (m_toolbar) {
+        m_toolbar->setOnPatternChoiceSelected(std::move(cb));
     }
 }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -142,6 +142,11 @@ class NUIContextMenu; // Forward declaration
 // -----------------------------------------------------------------------------
 class PianoRollToolbar : public NUIComponent {
 public:
+    struct PatternChoice {
+        int value = 0;
+        std::string label;
+    };
+
     /** @brief Create the internal piano-roll toolbar. */
     PianoRollToolbar();
     
@@ -155,7 +160,11 @@ public:
     /** @brief Bind the note layer controlled by the toolbar tools. */
     void setNoteLayer(std::shared_ptr<PianoRollNoteLayer> notes); // To set tools directly
     void setPatternLengthBeats(double beats);
+    void setPatternChoices(const std::vector<PatternChoice>& choices, int selectedValue);
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb) { onAdjustPatternLength_ = std::move(cb); }
+    void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb) {
+        onPatternChoiceSelected_ = std::move(cb);
+    }
     /** @brief Get the currently open context menu, if any. */
     std::shared_ptr<NUIComponent> getActiveContextMenu() const { return m_activeContextMenu; }
     /** @brief Close and remove the currently open context menu, if any. */
@@ -173,6 +182,7 @@ private:
     std::shared_ptr<NUIButton> m_eraserBtn;
     std::shared_ptr<NUIButton> m_lengthDownBtn;
     std::shared_ptr<NUIButton> m_lengthUpBtn;
+    std::shared_ptr<NUIDropdown> m_patternDropdown;
     
     GlobalTool activeTool_ = GlobalTool::Pencil;
     
@@ -189,6 +199,8 @@ private:
     
     std::shared_ptr<NUIComponent> m_activeContextMenu;
     std::function<void(int barsDelta)> onAdjustPatternLength_;
+    std::function<void(int patternValue)> onPatternChoiceSelected_;
+    bool m_updatingPatternDropdown = false;
 
     void closeActiveContextMenu();
     
@@ -196,7 +208,7 @@ private:
     void setActiveTool(GlobalTool tool);
     
     std::string m_patternName = "New Pattern";
-    double m_patternLengthBeats = 16.0;
+    double m_patternLengthBeats = 8.0;
     std::shared_ptr<NUILabel> m_patternLabel;
 };
 
@@ -470,6 +482,7 @@ public:
     void setNotes(const std::vector<MidiNote>& notes);
     const std::vector<MidiNote>& getNotes() const;
     void setPatternName(const std::string& name);
+    void setPatternChoices(const std::vector<PianoRollToolbar::PatternChoice>& choices, int selectedValue);
     void setPatternLengthBeats(double beats);
     void setPlayheadBeat(double beat, bool follow = false);
     void setTotalDurationBeats(double beats);
@@ -489,6 +502,7 @@ public:
     /** @brief Forward preview note callback to key lane. */
     void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb);
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb);
+    void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb);
 
     void setPixelsPerBeat(float ppb);
     void setBeatsPerBar(int bpb);
@@ -525,7 +539,7 @@ private:
     float m_targetScrollY;
     double m_playheadBeat = 0.0;
     double m_totalDurationBeats = 400.0;
-    double m_patternLengthBeats = 16.0;
+    double m_patternLengthBeats = 8.0;
     bool m_showLocalMinimap = true;
 
     std::function<bool()> m_isPlayingCallback;

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -805,6 +805,14 @@ void AestraApp::connectAudioToUI() {
             }
             if (m_content) {
                 m_content->setPluginTempo(bpm);
+                if (auto trackManager = m_content->getTrackManager()) {
+                    trackManager->getPlaylistModel().setBPM(bpm);
+                    trackManager->getTimelineClock().setTempo(bpm);
+                    trackManager->getPatternPlaybackEngine().flush();
+                }
+                if (auto trackManagerUI = m_content->getTrackManagerUI()) {
+                    trackManagerUI->invalidateCache();
+                }
             }
         });
 
@@ -1015,10 +1023,23 @@ void AestraApp::shutdown() {
 
     uiState.save();
 
+    if (m_audioController) {
+        m_audioController->stopStream();
+        m_audioController->closeStream();
+    }
+
+    // AestraContent owns UI-facing preview state and detaches it from AudioEngine
+    // in its destructor. Destroy content while the engine still exists.
+    if (m_windowManager) {
+        m_windowManager->shutdown();
+    }
+    m_content.reset();
+
     Aestra::Audio::PluginManager::getInstance().shutdown();
 
-    m_audioController->shutdown();
-    m_windowManager->shutdown();
+    if (m_audioController) {
+        m_audioController->shutdown();
+    }
 
     Platform::shutdown();
     Log::info("Aestra shutdown complete");
@@ -1033,11 +1054,28 @@ void AestraApp::shutdown() {
 
 // Project Helpers
 void AestraApp::requestClose() {
+    if (m_pendingClose) {
+        if (m_windowManager) {
+            auto dialog = m_windowManager->getConfirmationDialog();
+            if (dialog && dialog->isDialogVisible()) {
+                if (auto* root = m_windowManager->getRootComponent()) {
+                    dialog->setBounds(root->getBounds());
+                    root->removeChild(dialog);
+                    root->addChild(dialog);
+                }
+                return;
+            }
+        }
+        m_pendingClose = false;
+    }
+
     auto trackManager = m_content ? m_content->getTrackManager() : nullptr;
     if (!trackManager || !trackManager->isModified()) {
         m_running = false;
         return;
     }
+
+    m_pendingClose = true;
 
     // Emergency autosave before showing close dialog — if the app is force-killed
     // while the dialog is open, the autosave is still recoverable.
@@ -1047,16 +1085,20 @@ void AestraApp::requestClose() {
     }
 
     if (!m_windowManager) {
+        m_pendingClose = false;
         return;
     }
 
     auto dialog = m_windowManager->getConfirmationDialog();
     if (!dialog) {
-        return;
+        dialog = std::make_shared<ConfirmationDialog>();
+        m_windowManager->setConfirmationDialog(dialog);
     }
 
     if (auto* root = m_windowManager->getRootComponent()) {
         dialog->setBounds(root->getBounds());
+        root->removeChild(dialog);
+        root->addChild(dialog);
     }
 
     dialog->show("Unsaved Changes",
@@ -1066,6 +1108,8 @@ void AestraApp::requestClose() {
                      case Aestra::DialogResponse::Save:
                          if (saveProject()) {
                              m_running = false;
+                         } else {
+                             m_pendingClose = false;
                          }
                          break;
                      case Aestra::DialogResponse::DontSave: {
@@ -1082,6 +1126,7 @@ void AestraApp::requestClose() {
                      case Aestra::DialogResponse::Cancel:
                      case Aestra::DialogResponse::None:
                      default:
+                         m_pendingClose = false;
                          break;
                      }
                  });
@@ -1121,6 +1166,9 @@ ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& 
 
     if (m_content) {
         if (auto trackManager = m_content->getTrackManager()) {
+            trackManager->getPlaylistModel().setBPM(result.tempo);
+            trackManager->getTimelineClock().setTempo(result.tempo);
+            trackManager->getPatternPlaybackEngine().flush();
             trackManager->setPosition(result.playhead);
             trackManager->setPlayStartPosition(result.playhead);
             trackManager->getCommandHistory().clear();

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -901,6 +901,9 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
             case BrowserNavAction::Plugins:
                 drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><rect x="9.5" y="9.5" width="5" height="5" rx="1.2"/><path d="M9 2.8V6"/><path d="M15 2.8V6"/><path d="M9 18v3.2"/><path d="M15 18v3.2"/><path d="M2.8 9H6"/><path d="M2.8 15H6"/><path d="M18 9h3.2"/><path d="M18 15h3.2"/></svg>)");
                 break;
+            case BrowserNavAction::Patterns:
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="14" rx="2"/><path d="M8 9h8"/><path d="M8 13h5"/><circle cx="16" cy="13" r="1.5"/></svg>)");
+                break;
             case BrowserNavAction::Clips:
                 drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="6" width="16" height="12" rx="2"/><path d="M10 9.5l5 2.5-5 2.5v-5z"/></svg>)");
                 break;
@@ -977,6 +980,7 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     drawRow(BrowserNavAction::Instruments, "Instruments");
     drawRow(BrowserNavAction::AudioEffects, "Effects");
     drawRow(BrowserNavAction::Plugins, "Plugins");
+    drawRow(BrowserNavAction::Patterns, "Patterns");
     drawRow(BrowserNavAction::Clips, "Clips");
     drawRow(BrowserNavAction::Samples, "Samples");
     drawDivider();
@@ -3376,6 +3380,10 @@ bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const B
             applyFilter();
             break;
         }
+        case BrowserNavAction::Patterns:
+            activeTagFilter_.clear();
+            setFilter(QuickFilter::All);
+            break;
         case BrowserNavAction::Clips: {
             auto path = std::filesystem::path(rootPath_) / "User Library" / "Clips";
             std::filesystem::create_directories(path);

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -199,6 +199,7 @@ public:
         Instruments,
         AudioEffects,
         Plugins,
+        Patterns,
         Clips,
         Samples,
         Packs,

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4487,13 +4487,19 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
     // 2. Resolve target lane
     PlaylistLaneID targetLaneId;
+    bool createdTargetLane = false;
+    uint32_t createdChannelId = 0;
     if (laneIndex == static_cast<int>(laneCount)) {
         // Create new lane if dropping at the end
         targetLaneId = playlist.createLane("Lane " + std::to_string(laneIndex + 1));
+        createdTargetLane = targetLaneId.isValid();
 
         // Ensure we also have a mixer channel (we maintain 1:1 mapping for now)
         if (m_trackManager->getChannelCount() <= static_cast<size_t>(laneIndex)) {
-            m_trackManager->addChannel("Channel " + std::to_string(m_trackManager->getChannelCount() + 1));
+            if (auto* channel =
+                    m_trackManager->addChannel("Channel " + std::to_string(m_trackManager->getChannelCount() + 1))) {
+                createdChannelId = channel->getChannelId();
+            }
         }
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
@@ -4621,7 +4627,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             // Helper to create clip once source is ready. Async decode and queued tasks capture only weakSelf so
             // they cannot call back into a destroyed TrackManagerUI.
             auto createClipFromSource = [weakSelf, sourceId, displayName = data.displayName, targetLaneId,
-                                         timePositionBeats]() {
+                                         createdTargetLane, createdChannelId, timePositionBeats]() {
                 auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                 if (!self || !self->m_trackManager)
                     return;
@@ -4644,11 +4650,32 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->m_onClipLibraryChanged();
                 }
 
-                if (!source || !source->isReady())
+                auto rollbackCreatedTrack = [&]() {
+                    if (!createdTargetLane) {
+                        return;
+                    }
+                    if (createdChannelId != 0) {
+                        self->m_trackManager->removeChannelById(createdChannelId);
+                    }
+                    self->m_trackManager->getPlaylistModel().removeLane(targetLaneId);
+                    self->refreshTracks();
+                    self->invalidateCache();
+                    self->scheduleTimelineMinimapRebuild();
+                };
+
+                if (!source || !source->isReady()) {
+                    rollbackCreatedTrack();
                     return;
+                }
 
                 double durationSeconds = source->getDurationSeconds();
                 double durationBeats = self->secondsToBeats(durationSeconds);
+                if (!std::isfinite(durationSeconds) || durationSeconds <= 0.0 ||
+                    !std::isfinite(durationBeats) || durationBeats <= 0.0) {
+                    rollbackCreatedTrack();
+                    Log::error("[TrackManagerUI] Invalid decoded duration for imported source");
+                    return;
+                }
                 Log::info("[TrackManagerUI] Duration: " + std::to_string(durationSeconds) +
                           "s, beats: " + std::to_string(durationBeats));
 
@@ -4677,6 +4704,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->m_trackManager->getCommandHistory().pushAndExecute(cmd);
                     if (!playlist.getClip(clip.id)) {
                         patternManager.removePattern(patternId);
+                        rollbackCreatedTrack();
                         Log::error("[TrackManagerUI] Failed to add imported clip to target lane; removed orphan audio pattern");
                         return;
                     }
@@ -4686,6 +4714,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->scheduleTimelineMinimapRebuild();
                     Log::info("[TrackManagerUI] Clip added successfully via command");
                 } else {
+                    rollbackCreatedTrack();
                     Log::error("[TrackManagerUI] PatternManager::createAudioPattern failed");
                 }
             };

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4655,6 +4655,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 // Create Audio Pattern
                 AudioSlicePayload payload;
                 payload.audioSourceId = sourceId;
+                payload.durationSeconds = durationSeconds;
                 payload.slices.push_back({0.0, static_cast<double>(source->getNumFrames())});
 
                 auto& patternManager = self->m_trackManager->getPatternManager();
@@ -4668,11 +4669,17 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     clip.id = ClipInstanceID::generate();
                     clip.startBeat = timePositionBeats;
                     clip.durationBeats = durationBeats;
+                    clip.durationSeconds = durationSeconds;
                     clip.patternId = patternId;
                     clip.sourceId = patternId.value;
 
                     auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
                     self->m_trackManager->getCommandHistory().pushAndExecute(cmd);
+                    if (!playlist.getClip(clip.id)) {
+                        patternManager.removePattern(patternId);
+                        Log::error("[TrackManagerUI] Failed to add imported clip to target lane; removed orphan audio pattern");
+                        return;
+                    }
 
                     self->refreshTracks();
                     self->invalidateCache();

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2148,12 +2148,20 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                             double endBeat = m_trimOriginalStart + m_trimOriginalDuration;
                             clip.startBeat = std::min(newStart, endBeat - 0.1); // Keep minimum duration
                             clip.durationBeats = endBeat - clip.startBeat;
+                            if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
+                                clip.durationSeconds =
+                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats);
+                            }
                         } else if (m_trimEdge == TrimEdge::Right) {
                             // Trim right: change end position (duration)
                             double newEnd = m_trimOriginalStart + m_trimOriginalDuration + deltaBeats;
                             newEnd = snapBeatToGrid(newEnd); // Apply snap
                             
                             clip.durationBeats = std::max(0.1, newEnd - clip.startBeat);
+                            if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
+                                clip.durationSeconds =
+                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats);
+                            }
                         }
                         
                         if (m_onCacheInvalidationCallback) {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -324,11 +324,21 @@ AestraContent::AestraContent() {
         playSoundPreview(file);
     });
     m_fileBrowser->setOnNavActionSelected([this](AestraUI::FileBrowser::BrowserNavAction action) {
-        if (!m_pluginBrowser)
-            return;
-        bool isPlugins = (action == AestraUI::FileBrowser::BrowserNavAction::Plugins);
-        m_pluginBrowser->setVisible(isPlugins);
-        if (isPlugins && m_fileBrowser) {
+        const bool isPlugins = (action == AestraUI::FileBrowser::BrowserNavAction::Plugins);
+        const bool isPatterns = (action == AestraUI::FileBrowser::BrowserNavAction::Patterns);
+        if (m_pluginBrowser) {
+            m_pluginBrowser->setVisible(isPlugins);
+        }
+        if (m_patternBrowser) {
+            if (isPatterns) {
+                m_patternBrowser->showPatternsTab();
+                m_patternBrowser->refreshPatterns();
+                m_patternBrowser->setVisible(true);
+            } else {
+                m_patternBrowser->setVisible(false);
+            }
+        }
+        if (isPlugins && m_fileBrowser && m_pluginBrowser) {
             float navW = m_fileBrowser->getNavPaneWidth();
             auto fbBounds = m_fileBrowser->getBounds();
             float pbWidth = std::max(0.0f, fbBounds.width - navW);
@@ -337,6 +347,7 @@ AestraContent::AestraContent() {
             m_pluginBrowser->setBounds(
                 AestraUI::NUIRect(fbBounds.x + navW, fbBounds.y + searchH, pbWidth, fbBounds.height - searchH));
         }
+        onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
     });
 
     m_fileBrowser->setOnSearchTextChanged([this](const std::string& text) {
@@ -1340,7 +1351,11 @@ void AestraContent::onResize(int width, int height) {
     }
 
     const size_t browserTab = m_browserToggle ? m_browserToggle->getSelectedIndex() : 0;
-    const bool browserPatternTabActive = browserTab == 2;
+    const auto activeNavAction =
+        m_fileBrowser ? m_fileBrowser->getActiveNavAction() : AestraUI::FileBrowser::BrowserNavAction::Sounds;
+    const bool legacyPatternTabActive = browserTab == 2;
+    const bool patternNavActive = activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Patterns;
+    const bool browserPatternTabActive = legacyPatternTabActive || patternNavActive;
     const bool clipsTabActive = browserTab == 3;
 
     const bool compactPatternDock = m_patternBrowser && m_patternBrowser->usesCompactRail();
@@ -1369,7 +1384,7 @@ void AestraContent::onResize(int width, int height) {
         m_patternBrowserWidthPref = patternBrowserWidth;
     }
 
-    const bool filesTabActive = browserTab == 0;
+    const bool filesTabActive = browserTab == 0 && !browserPatternTabActive;
     const bool pluginBrowserVisible = m_pluginBrowser && m_pluginBrowser->isVisible();
     const bool showPreviewDock = m_previewPanel && filesTabActive && m_fileBrowser && m_fileBrowser->isVisible() &&
                                  !pluginBrowserVisible && m_previewPanel->hasFileSelection();
@@ -1417,10 +1432,17 @@ void AestraContent::onResize(int width, int height) {
     }
 
     if (m_patternBrowser) {
-        if (browserPatternTabActive || clipsTabActive) {
+        if (legacyPatternTabActive || clipsTabActive) {
             float clipTop = sidebarTopY;
             m_patternBrowser->setBounds(
                 AestraUI::NUIAbsolute(contentBounds, 0.0f, clipTop, fileBrowserWidth, height - clipTop));
+        } else if (patternNavActive && m_fileBrowser) {
+            const float navW = m_fileBrowser->getNavPaneWidth();
+            constexpr float searchH = 28.0f;
+            const float patternTop = sidebarTopY + searchH;
+            const float patternWidth = std::max(0.0f, fileBrowserWidth - navW);
+            m_patternBrowser->setBounds(
+                AestraUI::NUIAbsolute(contentBounds, navW, patternTop, patternWidth, height - patternTop));
         } else {
             float patternBrowserX = fileBrowserWidth;
             float pbY = isAuditionMode ? 0.0f : transportHeight;
@@ -2010,7 +2032,10 @@ void AestraContent::setViewFocus(ViewFocus focus) {
             if (m_transportBar)
                 m_transportBar->setVisible(true);
             const size_t browserTab = m_browserToggle ? m_browserToggle->getSelectedIndex() : 0;
-            const bool showBrowserPatternPane = focus == ViewFocus::Timeline && (browserTab == 2 || browserTab == 3);
+            const bool patternNavActive =
+                m_fileBrowser && m_fileBrowser->getActiveNavAction() == AestraUI::FileBrowser::BrowserNavAction::Patterns;
+            const bool showBrowserPatternPane =
+                focus == ViewFocus::Timeline && (browserTab == 2 || browserTab == 3 || patternNavActive);
             if (m_patternBrowser)
                 m_patternBrowser->setVisible(showBrowserPatternPane);
             if (m_waveformVisualizer)
@@ -3108,6 +3133,7 @@ void AestraContent::loadSampleIntoSelectedTrack(const std::string& filePath) {
     auto& patternManager = m_trackManager->getPatternManager();
     AudioSlicePayload payload;
     payload.audioSourceId = sourceId;
+    payload.durationSeconds = durationSeconds;
     AudioSlice slice;
     slice.startOffset = 0.0;
     slice.duration = durationSeconds;
@@ -3143,7 +3169,20 @@ void AestraContent::loadSampleIntoSelectedTrack(const std::string& filePath) {
     double playheadPositionSeconds = m_transportBar ? m_transportBar->getPosition() : 0.0;
     double startBeat = m_trackManager->getPlaylistModel().secondsToBeats(playheadPositionSeconds);
 
-    playlist.addClipFromPattern(targetLaneId, patternId, startBeat, durationBeats);
+    Aestra::Audio::ClipInstance clip;
+    clip.id = Aestra::Audio::ClipInstanceID::generate();
+    clip.patternId = patternId;
+    clip.sourceId = patternId.value;
+    clip.startBeat = startBeat;
+    clip.durationBeats = durationBeats;
+    clip.durationSeconds = durationSeconds;
+    clip.name = patternName;
+    const auto clipId = playlist.addClip(targetLaneId, clip);
+    if (!clipId.isValid()) {
+        patternManager.removePattern(patternId);
+        AESTRA_LOG_ERROR("Failed to add sample clip to arrangement; removed orphan pattern");
+        return;
+    }
 
     if (m_trackManagerUI) {
         m_trackManagerUI->refreshTracks();

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -226,6 +226,16 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             m_recoveryDialog->onMouseEvent(event);
             return;
         }
+
+        if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
+            AestraUI::NUIMouseEvent event;
+            event.type = AestraUI::NUIMouseEventType::Move;
+            event.position = AestraUI::NUIPoint(static_cast<float>(x), static_cast<float>(y));
+            event.button = AestraUI::NUIMouseButton::None;
+            event.pressed = false;
+            m_confirmationDialog->onMouseEvent(event);
+            return;
+        }
         
         // Drag & Drop (convert to float for NUI)
         if (m_content) {
@@ -244,6 +254,18 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.pressed = pressed;
             m_recoveryDialog->onMouseEvent(event);
             return; // Block all other mouse handling while recovery dialog is shown
+        }
+
+        if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
+            AestraUI::NUIMouseEvent event;
+            event.type = pressed ? AestraUI::NUIMouseEventType::Down : AestraUI::NUIMouseEventType::Up;
+            event.position = AestraUI::NUIPoint(static_cast<float>(m_lastMouseX), static_cast<float>(m_lastMouseY));
+            event.button = (button == 0) ? AestraUI::NUIMouseButton::Left :
+                          (button == 1) ? AestraUI::NUIMouseButton::Right : AestraUI::NUIMouseButton::Middle;
+            event.pressed = pressed;
+            event.released = !pressed;
+            m_confirmationDialog->onMouseEvent(event);
+            return;
         }
         
         if (!pressed) { // Release
@@ -294,6 +316,16 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.pressed = pressed;
             m_recoveryDialog->onKeyEvent(event);
             return; // Block all other key handling while recovery dialog is shown
+        }
+
+        if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
+            AestraUI::NUIKeyEvent event;
+            event.keyCode = convertToNUIKeyCode(key);
+            event.pressed = pressed;
+            event.released = !pressed;
+            event.modifiers = m_keyModifiers;
+            m_confirmationDialog->onKeyEvent(event);
+            return;
         }
 
         // Dispatch to Content / Focused widgets for both press and release so
@@ -634,6 +666,16 @@ void AestraWindowManager::render() {
             m_recoveryDialog->setBounds(m_rootComponent->getBounds());
         }
         m_recoveryDialog->onRender(*m_renderer);
+    }
+
+    // Render close confirmation explicitly at the top level. It is also a root
+    // child for input handling, but drawing it last avoids being hidden behind
+    // app overlays that are added later in startup.
+    if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
+        if (m_rootComponent) {
+            m_confirmationDialog->setBounds(m_rootComponent->getBounds());
+        }
+        m_confirmationDialog->onRender(*m_renderer);
     }
 
     if (m_useCustomCursor && m_windowFocused) {

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -512,7 +512,8 @@ void AestraWindowManager::setSettingsDialog(std::shared_ptr<Aestra::SettingsDial
 
 void AestraWindowManager::setConfirmationDialog(std::shared_ptr<Aestra::ConfirmationDialog> dialog) {
     m_confirmationDialog = dialog;
-    if (m_rootComponent) m_rootComponent->addChild(m_confirmationDialog);
+    m_confirmationDialogRaised = false;
+    if (m_rootComponent && m_confirmationDialog) m_rootComponent->addChild(m_confirmationDialog);
 }
 
 void AestraWindowManager::setRecoveryDialog(std::shared_ptr<Aestra::RecoveryDialog> dialog) {
@@ -655,6 +656,16 @@ void AestraWindowManager::render() {
 
     m_renderer->clear(bgColor);
     m_renderer->beginFrame();
+    if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
+        m_confirmationDialog->setBounds(m_rootComponent->getBounds());
+        if (!m_confirmationDialogRaised) {
+            m_rootComponent->removeChild(m_confirmationDialog);
+            m_rootComponent->addChild(m_confirmationDialog);
+            m_confirmationDialogRaised = true;
+        }
+    } else {
+        m_confirmationDialogRaised = false;
+    }
     m_rootComponent->onRender(*m_renderer);
     NUIDragDropManager::getInstance().renderDragGhost(*m_renderer);
 
@@ -666,16 +677,6 @@ void AestraWindowManager::render() {
             m_recoveryDialog->setBounds(m_rootComponent->getBounds());
         }
         m_recoveryDialog->onRender(*m_renderer);
-    }
-
-    // Render close confirmation explicitly at the top level. It is also a root
-    // child for input handling, but drawing it last avoids being hidden behind
-    // app overlays that are added later in startup.
-    if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
-        if (m_rootComponent) {
-            m_confirmationDialog->setBounds(m_rootComponent->getBounds());
-        }
-        m_confirmationDialog->onRender(*m_renderer);
     }
 
     if (m_useCustomCursor && m_windowFocused) {

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -182,6 +182,7 @@ private:
 
     std::shared_ptr<Aestra::SettingsDialog> m_settingsDialog;
     std::shared_ptr<Aestra::ConfirmationDialog> m_confirmationDialog;
+    bool m_confirmationDialogRaised{false};
     std::shared_ptr<Aestra::RecoveryDialog> m_recoveryDialog;
     std::shared_ptr<UnifiedHUD> m_unifiedHUD;
     std::shared_ptr<class ExportDialog> m_exportDialog;

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -741,6 +741,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                                                        ? clip.durationSeconds
                                                        : clip.durationBeats * 60.0 / std::max(tempo, 1.0);
                     cjs.set("durationSeconds", JSON(durationSeconds));
+                    cjs.set("sourceOffsetSeconds", JSON(clip.sourceOffsetSeconds));
                 } else {
                     cjs.set("duration", JSON(clip.durationBeats));
                 }
@@ -1523,11 +1524,20 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                             finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
                                         clip.durationSeconds = legacyDurationBeats * 60.0 / std::max(result.tempo, 1.0);
                                     }
+                                    clip.sourceOffsetSeconds =
+                                        finiteNumberOr(cj[c], "sourceOffsetSeconds", 0.0, 0.0, 1000000.0);
+                                    if (clip.sourceOffsetSeconds <= 0.0) {
+                                        const double legacySourceOffsetBeats =
+                                            finiteNumberOr(cj[c], "sourceOffset", 0.0, 0.0, 1000000.0);
+                                        clip.sourceOffsetSeconds =
+                                            legacySourceOffsetBeats * 60.0 / std::max(result.tempo, 1.0);
+                                    }
                                     clip.durationBeats = playlist.secondsToBeats(clip.durationSeconds);
+                                    clip.sourceOffset = playlist.secondsToBeats(clip.sourceOffsetSeconds);
                                 } else {
                                     clip.durationBeats = finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
+                                    clip.sourceOffset = finiteNumberOr(cj[c], "sourceOffset", 0.0, 0.0, 1000000.0);
                                 }
-                                clip.sourceOffset = finiteNumberOr(cj[c], "sourceOffset", 0.0, 0.0, 1000000.0);
                                 clip.name = boundedStringOr(cj[c], "name", "", PROJECT_MAX_STRING_BYTES);
                                 if (cj[c].has("color") && cj[c]["color"].isString()) {
                                     try {

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -615,6 +615,9 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             pjs.set("type", JSON("audio"));
             const auto& payload = std::get<AudioSlicePayload>(p->payload);
             pjs.set("sourceId", JSON(static_cast<double>(payload.audioSourceId.value)));
+            if (payload.durationSeconds > 0.0) {
+                pjs.set("durationSeconds", JSON(payload.durationSeconds));
+            }
             
             JSON slicesArray = JSON::array();
             for (const auto& slice : payload.slices) {
@@ -731,7 +734,16 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 const uint64_t serializedPatternId = clip.patternId.value != 0 ? clip.patternId.value : clip.sourceId;
                 cjs.set("patternId", JSON(static_cast<double>(serializedPatternId)));
                 cjs.set("start", JSON(clip.startBeat));
-                cjs.set("duration", JSON(clip.durationBeats));
+                const auto* clipPattern = patternManager.getPattern(clip.patternId);
+                const bool isAudioClip = clipPattern && clipPattern->isAudio();
+                if (isAudioClip) {
+                    const double durationSeconds = clip.durationSeconds > 0.0
+                                                       ? clip.durationSeconds
+                                                       : clip.durationBeats * 60.0 / std::max(tempo, 1.0);
+                    cjs.set("durationSeconds", JSON(durationSeconds));
+                } else {
+                    cjs.set("duration", JSON(clip.durationBeats));
+                }
                 cjs.set("sourceOffset", JSON(clip.sourceOffset));
                 cjs.set("name", JSON(clip.name));
                 cjs.set("color", JSON(std::to_string(clip.colorRGBA)));
@@ -1155,6 +1167,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         sourceManager.clear();
         patternManager.clear();
         trackManager->clearAllChannels();
+        playlist.setPatternManager(&patternManager);
+        playlist.setBPM(result.tempo);
     
         // 2. Load Sources (and decode audio files)
         std::unordered_map<uint32_t, ClipSourceID> idMap;
@@ -1243,6 +1257,7 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     if (idMap.count(oldSrcId)) {
                         AudioSlicePayload payload;
                         payload.audioSourceId = idMap[oldSrcId];
+                        payload.durationSeconds = finiteNumberOr(pj[i], "durationSeconds", 0.0, 0.0, 1000000.0);
                         if (pj[i].has("slices")) {
                             const JSON& slj = pj[i]["slices"];
                             for (size_t s = 0; s < slj.size(); ++s) {
@@ -1300,6 +1315,29 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             }
                         }
                     }
+                }
+            }
+        }
+
+        // Arsenal unit default patterns are serialized with project-file IDs.
+        // Patterns are recreated during load, so rebind units to the new runtime IDs
+        // after both unit and pattern stores have been restored.
+        {
+            auto& unitManager = trackManager->getUnitManager();
+            for (UnitID unitId : unitManager.getAllUnitIDs()) {
+                auto* unit = unitManager.getUnit(unitId);
+                if (!unit || !unit->defaultPatternId.isValid()) {
+                    continue;
+                }
+
+                auto remapped = patternMap.find(unit->defaultPatternId.value);
+                if (remapped != patternMap.end()) {
+                    unit->defaultPatternId = remapped->second;
+                } else if (!patternManager.getPattern(unit->defaultPatternId)) {
+                    Log::warning("[ProjectLoad] Arsenal unit " + std::to_string(unitId) +
+                                 " references missing default pattern " +
+                                 std::to_string(unit->defaultPatternId.value) + "; clearing association.");
+                    unit->defaultPatternId = PatternID{};
                 }
             }
         }
@@ -1475,7 +1513,20 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                 clip.patternId = patternMap[oldPatId];
                                 clip.sourceId = clip.patternId.value;
                                 clip.startBeat = finiteNumberOr(cj[c], "start", 0.0, 0.0, 1000000.0);
-                                clip.durationBeats = finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
+                                const auto* loadedPattern = patternManager.getPattern(clip.patternId);
+                                const bool isAudioClip = loadedPattern && loadedPattern->isAudio();
+                                if (isAudioClip) {
+                                    clip.durationSeconds =
+                                        finiteNumberOr(cj[c], "durationSeconds", 0.0, 0.0, 1000000.0);
+                                    if (clip.durationSeconds <= 0.0) {
+                                        const double legacyDurationBeats =
+                                            finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
+                                        clip.durationSeconds = legacyDurationBeats * 60.0 / std::max(result.tempo, 1.0);
+                                    }
+                                    clip.durationBeats = playlist.secondsToBeats(clip.durationSeconds);
+                                } else {
+                                    clip.durationBeats = finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
+                                }
                                 clip.sourceOffset = finiteNumberOr(cj[c], "sourceOffset", 0.0, 0.0, 1000000.0);
                                 clip.name = boundedStringOr(cj[c], "name", "", PROJECT_MAX_STRING_BYTES);
                                 if (cj[c].has("color") && cj[c]["color"].isString()) {

--- a/Source/Panels/PatternBrowserPanel.cpp
+++ b/Source/Panels/PatternBrowserPanel.cpp
@@ -193,7 +193,7 @@ PatternBrowserPanel::PatternBrowserPanel(TrackManager* trackManager)
     m_createButton->setOnClick([this]() {
         if (m_trackManager) {
             MidiPayload payload;
-            auto id = m_trackManager->getPatternManager().createMidiPattern("New Pattern", 4.0, payload);
+            auto id = m_trackManager->getPatternManager().createMidiPattern("New Pattern", 8.0, payload);
             refreshPatterns();
             m_selectedPatternId = id;
             if (m_onPatternSelected) m_onPatternSelected(id);

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <random>
 #include <algorithm>
+#include <limits>
 
 using namespace Aestra::Audio;
 
@@ -52,11 +53,36 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
         adjustPatternLengthBars(barsDelta);
     });
     m_pianoRoll->setOnPatternChoiceSelected([this](int patternValue) {
-        PatternID patternId(static_cast<uint64_t>(std::max(0, patternValue)));
+        if (patternValue < 0) {
+            return;
+        }
+        PatternID patternId(static_cast<uint64_t>(patternValue));
         if (!patternId.isValid() || patternId == m_currentPatternId) {
             return;
         }
         savePattern();
+        UnitID resolvedUnitId = 0;
+        if (const auto* pattern = m_trackManager->getPatternManager().getPattern(patternId);
+            pattern && pattern->isMidi()) {
+            const auto& midiPayload = std::get<MidiPayload>(pattern->payload);
+            const auto noteIt = std::find_if(midiPayload.notes.begin(), midiPayload.notes.end(),
+                                             [](const MidiNote& note) { return note.unitId != 0; });
+            if (noteIt != midiPayload.notes.end()) {
+                resolvedUnitId = noteIt->unitId;
+            }
+        }
+        if (resolvedUnitId == 0) {
+            for (const auto unitId : m_trackManager->getUnitManager().getAllUnitIDs()) {
+                const auto* unit = m_trackManager->getUnitManager().getUnit(unitId);
+                if (unit && unit->defaultPatternId == patternId) {
+                    resolvedUnitId = unitId;
+                    break;
+                }
+            }
+        }
+        if (resolvedUnitId != 0 && resolvedUnitId != m_editingUnitId) {
+            setEditingUnit(resolvedUnitId);
+        }
         loadPattern(patternId);
     });
 
@@ -388,8 +414,25 @@ void PianoRollPanel::rebuildPatternSwitcher() {
     std::vector<AestraUI::PianoRollToolbar::PatternChoice> choices;
     auto patterns = m_trackManager->getPatternManager().getAllPatterns();
     choices.reserve(patterns.size());
+    const auto* editingUnit = m_editingUnitId != 0 ? m_trackManager->getUnitManager().getUnit(m_editingUnitId) : nullptr;
     for (const auto& pattern : patterns) {
         if (!pattern || !pattern->isMidi()) {
+            continue;
+        }
+        if (m_editingUnitId != 0 && pattern->id != m_currentPatternId &&
+            (!editingUnit || editingUnit->defaultPatternId != pattern->id)) {
+            const auto& midiPayload = std::get<MidiPayload>(pattern->payload);
+            const bool hasEditingUnitNotes = std::any_of(midiPayload.notes.begin(), midiPayload.notes.end(),
+                                                         [this](const MidiNote& note) {
+                                                             return note.unitId == m_editingUnitId;
+                                                         });
+            if (!hasEditingUnitNotes) {
+                continue;
+            }
+        }
+        if (pattern->id.value > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+            Log::warning("[PianoRollPanel] Skipping pattern with ID outside dropdown range: " +
+                         std::to_string(pattern->id.value));
             continue;
         }
         std::string label = pattern->name.empty() ? ("Pattern " + std::to_string(pattern->id.value)) : pattern->name;
@@ -402,7 +445,10 @@ void PianoRollPanel::rebuildPatternSwitcher() {
         }
         return lhs.value < rhs.value;
     });
-    m_pianoRoll->setPatternChoices(choices, static_cast<int>(m_currentPatternId.value));
+    const int selectedValue = m_currentPatternId.value <= static_cast<uint64_t>(std::numeric_limits<int>::max())
+                                  ? static_cast<int>(m_currentPatternId.value)
+                                  : -1;
+    m_pianoRoll->setPatternChoices(choices, selectedValue);
 }
 
 void PianoRollPanel::layoutTimelineMinimap() {

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -22,8 +22,8 @@ using namespace Aestra::Audio;
 namespace {
 double quantizePatternLengthBeats(double contentEndBeat) {
     constexpr double kBeatsPerBar = 4.0;
-    constexpr double kBarsPerPatternBlock = 4.0;
-    constexpr double kPatternBlockBeats = kBeatsPerBar * kBarsPerPatternBlock; // 16 beats = 4 bars
+    constexpr double kBarsPerPatternBlock = 2.0;
+    constexpr double kPatternBlockBeats = kBeatsPerBar * kBarsPerPatternBlock; // 8 beats = 2 bars
 
     const double safeContentEnd = std::max(0.0, contentEndBeat);
     const double blocksNeeded = std::max(1.0, std::ceil(safeContentEnd / kPatternBlockBeats));
@@ -50,6 +50,14 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
     m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);
     m_pianoRoll->setOnAdjustPatternLength([this](int barsDelta) {
         adjustPatternLengthBars(barsDelta);
+    });
+    m_pianoRoll->setOnPatternChoiceSelected([this](int patternValue) {
+        PatternID patternId(static_cast<uint64_t>(std::max(0, patternValue)));
+        if (!patternId.isValid() || patternId == m_currentPatternId) {
+            return;
+        }
+        savePattern();
+        loadPattern(patternId);
     });
 
     // Setup playback state check and note preview
@@ -159,7 +167,7 @@ void PianoRollPanel::loadPattern(PatternID patternId) {
             longestBeat = std::max(longestBeat, note.startBeat + note.durationBeats);
         }
         const double quantizedLengthBeats = quantizePatternLengthBeats(longestBeat);
-        const double resolvedLengthBeats = std::max(16.0, std::max(pattern->lengthBeats, quantizedLengthBeats));
+        const double resolvedLengthBeats = std::max(8.0, std::max(pattern->lengthBeats, quantizedLengthBeats));
         if (std::abs(resolvedLengthBeats - pattern->lengthBeats) > 0.001) {
             pm.applyPatch(patternId, [resolvedLengthBeats](PatternSource& p) {
                 p.lengthBeats = resolvedLengthBeats;
@@ -171,6 +179,7 @@ void PianoRollPanel::loadPattern(PatternID patternId) {
         m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);
         m_pianoRoll->setTotalDurationBeats(m_patternDurationBeats);
         m_pianoRoll->setPatternName(sourceLabel);
+        rebuildPatternSwitcher();
         setTitle("PIANO ROLL - " + pattern->name);
 
         // Capture note state for undo/redo diff detection
@@ -302,7 +311,7 @@ void PianoRollPanel::adjustPatternLengthBars(int barsDelta) {
 
     const double minLengthBeats = quantizePatternLengthBeats(contentEndBeat);
     const double requestedLengthBeats = m_patternDurationBeats + (static_cast<double>(barsDelta) * 4.0);
-    const double newLengthBeats = std::max(16.0, std::max(minLengthBeats, requestedLengthBeats));
+    const double newLengthBeats = std::max(8.0, std::max(minLengthBeats, requestedLengthBeats));
 
     if (std::abs(newLengthBeats - m_patternDurationBeats) <= 0.001) {
         m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);
@@ -336,6 +345,10 @@ void PianoRollPanel::setEditingUnit(UnitID unitId) {
 
 void PianoRollPanel::onUpdate(double deltaTime) {
     WindowPanel::onUpdate(deltaTime);
+    if (isVisible() && !m_wasVisible) {
+        rebuildPatternSwitcher();
+    }
+    m_wasVisible = isVisible();
     if (isVisible()) {
         updateGhostChannels();
         if (m_trackManager && m_pianoRoll) {
@@ -365,6 +378,31 @@ void PianoRollPanel::onUpdate(double deltaTime) {
 
         }
     }
+}
+
+void PianoRollPanel::rebuildPatternSwitcher() {
+    if (!m_trackManager || !m_pianoRoll) {
+        return;
+    }
+
+    std::vector<AestraUI::PianoRollToolbar::PatternChoice> choices;
+    auto patterns = m_trackManager->getPatternManager().getAllPatterns();
+    choices.reserve(patterns.size());
+    for (const auto& pattern : patterns) {
+        if (!pattern || !pattern->isMidi()) {
+            continue;
+        }
+        std::string label = pattern->name.empty() ? ("Pattern " + std::to_string(pattern->id.value)) : pattern->name;
+        choices.push_back({static_cast<int>(pattern->id.value), std::move(label)});
+    }
+
+    std::sort(choices.begin(), choices.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.label != rhs.label) {
+            return lhs.label < rhs.label;
+        }
+        return lhs.value < rhs.value;
+    });
+    m_pianoRoll->setPatternChoices(choices, static_cast<int>(m_currentPatternId.value));
 }
 
 void PianoRollPanel::layoutTimelineMinimap() {

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -86,6 +86,7 @@ public:
     
 private:
     void adjustPatternLengthBars(int barsDelta);
+    void rebuildPatternSwitcher();
     void updateGhostChannels();
     void rebuildTimelineMinimap();
     void layoutTimelineMinimap();
@@ -99,11 +100,12 @@ private:
     PatternID m_currentPatternId;
     UnitID m_editingUnitId{0};
     std::function<void(PatternID)> m_onPatternEdited;
-    double m_patternDurationBeats{16.0};
+    double m_patternDurationBeats{8.0};
 
     // Undo/redo support
     std::vector<MidiNote> m_notesBeforeEdit; // Captured state before user edits
     bool m_applyingUndoRedo{false};           // Guard flag to prevent re-entry
+    bool m_wasVisible{false};
 };
 
 } // namespace Audio

--- a/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
+++ b/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
@@ -1,0 +1,81 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Models/PatternManager.h"
+#include "Models/UnitManager.h"
+#include "Playback/PatternPlaybackEngine.h"
+#include "Playback/TimelineClock.h"
+
+#include <cstdint>
+#include <iostream>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+bool hasNoteOn(MidiBuffer& buffer, uint8_t pitch) {
+    for (size_t i = 0; i < buffer.getEventCount(); ++i) {
+        const auto& event = buffer.getEvent(i);
+        if ((event.data[0] & 0xF0) == 0x90 && event.data[1] == pitch && event.data[2] > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    constexpr int sampleRate = 48000;
+    constexpr UnitID unitId = 1;
+    constexpr uint8_t pitch = 60;
+
+    TimelineClock clock(120.0);
+    PatternManager patternManager;
+    UnitManager unitManager;
+    const UnitID createdUnit = unitManager.createUnit("Tempo Test Unit", UnitType::Sampler);
+    if (createdUnit != unitId) {
+        std::cerr << "unexpected unit id " << createdUnit << "\n";
+        return 1;
+    }
+
+    PatternID patternId = patternManager.createPattern();
+    auto* pattern = patternManager.getPattern(patternId);
+    if (!pattern) {
+        std::cerr << "failed to create pattern\n";
+        return 1;
+    }
+    pattern->type = PatternSource::Type::Midi;
+    pattern->name = "Tempo Change Pattern";
+    pattern->lengthBeats = 4.0;
+    pattern->payload = MidiPayload{};
+    auto& notes = std::get<MidiPayload>(pattern->payload).notes;
+    notes.push_back(MidiNote{pitch, 2.0, 0.5, 1.0f, unitId});
+
+    PatternPlaybackEngine playback(&clock, &patternManager, &unitManager);
+    playback.schedulePatternInstance(patternId, 0.0, 1);
+
+    playback.refillWindow(0, sampleRate, sampleRate * 3);
+
+    clock.setTempo(60.0);
+    playback.flush();
+    playback.refillWindow(0, sampleRate, sampleRate * 3);
+
+    MidiBuffer midiAtOldTempoFrame;
+    PatternPlaybackEngine::UnitMidiRoute route{unitId, &midiAtOldTempoFrame};
+    playback.processAudio(sampleRate, 128, &route, 1);
+    if (hasNoteOn(midiAtOldTempoFrame, pitch)) {
+        std::cerr << "stale note-on fired at old 120 BPM frame after tempo flush\n";
+        return 1;
+    }
+
+    MidiBuffer midiAtNewTempoFrame;
+    route.midiBuffer = &midiAtNewTempoFrame;
+    playback.processAudio(sampleRate * 2, 128, &route, 1);
+    if (!hasNoteOn(midiAtNewTempoFrame, pitch)) {
+        std::cerr << "note-on did not fire at recomputed 60 BPM frame\n";
+        return 1;
+    }
+
+    std::cout << "pattern playback tempo change reschedule passed\n";
+    return 0;
+}

--- a/Tests/AestraAudio/SamplerStereoParityTest.cpp
+++ b/Tests/AestraAudio/SamplerStereoParityTest.cpp
@@ -1,0 +1,163 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Plugin/SamplerPlugin.h"
+#include "PluginHost.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+void writeLe16(std::ofstream& out, uint16_t value) {
+    out.put(static_cast<char>(value & 0xff));
+    out.put(static_cast<char>((value >> 8) & 0xff));
+}
+
+void writeLe32(std::ofstream& out, uint32_t value) {
+    out.put(static_cast<char>(value & 0xff));
+    out.put(static_cast<char>((value >> 8) & 0xff));
+    out.put(static_cast<char>((value >> 16) & 0xff));
+    out.put(static_cast<char>((value >> 24) & 0xff));
+}
+
+bool writeMonoWav(const std::filesystem::path& path, uint32_t sampleRate, uint32_t frames) {
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        return false;
+    }
+
+    constexpr uint16_t channels = 1;
+    constexpr uint16_t bitsPerSample = 16;
+    const uint32_t dataBytes = frames * channels * (bitsPerSample / 8);
+
+    out.write("RIFF", 4);
+    writeLe32(out, 36 + dataBytes);
+    out.write("WAVEfmt ", 8);
+    writeLe32(out, 16);
+    writeLe16(out, 1);
+    writeLe16(out, channels);
+    writeLe32(out, sampleRate);
+    writeLe32(out, sampleRate * channels * (bitsPerSample / 8));
+    writeLe16(out, channels * (bitsPerSample / 8));
+    writeLe16(out, bitsPerSample);
+    out.write("data", 4);
+    writeLe32(out, dataBytes);
+
+    constexpr double twoPi = 6.28318530717958647692;
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(sampleRate);
+        const float sample = static_cast<float>((std::sin(twoPi * 220.0 * t) * 0.22) +
+                                                (std::sin(twoPi * 331.0 * t) * 0.08));
+        const auto pcm = static_cast<int16_t>(std::clamp(sample, -1.0f, 1.0f) * 32767.0f);
+        writeLe16(out, static_cast<uint16_t>(pcm));
+    }
+
+    return true;
+}
+
+bool renderStackedNotes(const std::filesystem::path& wavPath, uint8_t firstNote, uint8_t secondNote,
+                        std::string* error) {
+    constexpr uint32_t sampleRate = 48000;
+    constexpr uint32_t blockFrames = 256;
+    constexpr int blocks = 16;
+    constexpr float epsilon = 1.0e-7f;
+
+    Plugins::SamplerPlugin sampler;
+    if (!sampler.initialize(sampleRate, blockFrames)) {
+        *error = "sampler initialize failed";
+        return false;
+    }
+    if (!sampler.loadSample(wavPath.string())) {
+        *error = "sampler failed to load mono wav";
+        return false;
+    }
+    sampler.setRootMidiNote(60);
+    sampler.setMaxVoices(8);
+    sampler.setEnvelope(0.001f, 0.001f, 1.0f, 0.05f);
+    sampler.activate();
+
+    std::vector<float> left(blockFrames, 0.0f);
+    std::vector<float> right(blockFrames, 0.0f);
+    float* outputs[] = {left.data(), right.data()};
+
+    MidiBuffer midi;
+    midi.addNoteOn(1, firstNote, 110, 0);
+    midi.addNoteOn(1, secondNote, 110, 0);
+
+    float maxAbsDiff = 0.0f;
+    float maxSignal = 0.0f;
+
+    for (int block = 0; block < blocks; ++block) {
+        std::fill(left.begin(), left.end(), 0.0f);
+        std::fill(right.begin(), right.end(), 0.0f);
+
+        sampler.process(nullptr, outputs, 0, 2, blockFrames, block == 0 ? &midi : nullptr, nullptr);
+
+        for (uint32_t i = 0; i < blockFrames; ++i) {
+            maxAbsDiff = std::max(maxAbsDiff, std::abs(left[i] - right[i]));
+            maxSignal = std::max(maxSignal, std::max(std::abs(left[i]), std::abs(right[i])));
+        }
+    }
+
+    if (maxSignal <= epsilon) {
+        *error = "sampler output was silent";
+        return false;
+    }
+
+    if (maxAbsDiff > epsilon) {
+        *error = "mono sampler stack diverged between channels, max diff=" + std::to_string(maxAbsDiff);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+int main() {
+    constexpr uint32_t sampleRate = 48000;
+
+    std::error_code ec;
+    const auto tmpDir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        std::cerr << "failed to resolve temp directory: " << ec.message() << "\n";
+        return 1;
+    }
+
+    const auto uniqueId =
+        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "_" +
+        std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    const auto wavPath = tmpDir / ("aestra_sampler_stereo_parity_mono_" + uniqueId + ".wav");
+    if (!writeMonoWav(wavPath, sampleRate, sampleRate)) {
+        std::cerr << "failed to write mono wav: " << wavPath << "\n";
+        return 1;
+    }
+
+    std::string error;
+    if (!renderStackedNotes(wavPath, 60, 60, &error)) {
+        std::cerr << "same-pitch stack failed: " << error << "\n";
+        std::filesystem::remove(wavPath, ec);
+        return 1;
+    }
+
+    if (!renderStackedNotes(wavPath, 60, 72, &error)) {
+        std::cerr << "different-pitch stack failed: " << error << "\n";
+        std::filesystem::remove(wavPath, ec);
+        return 1;
+    }
+
+    std::filesystem::remove(wavPath, ec);
+    std::cout << "mono sampler stacked-note L/R parity passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -398,6 +398,32 @@ else()
     message(STATUS "AestraRealtimePathStressTest built but not registered (set AESTRA_ENABLE_RUNTIME_TESTS=ON to enable)")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerStereoParityTest.cpp")
+    add_executable(SamplerStereoParityTest AestraAudio/SamplerStereoParityTest.cpp)
+    target_link_libraries(SamplerStereoParityTest PRIVATE AestraAudio)
+    target_include_directories(SamplerStereoParityTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME SamplerStereoParityTest COMMAND SamplerStereoParityTest)
+    set_tests_properties(SamplerStereoParityTest PROPERTIES LABELS "audio;sampler;regression")
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternPlaybackTempoChangeTest.cpp")
+    add_executable(PatternPlaybackTempoChangeTest AestraAudio/PatternPlaybackTempoChangeTest.cpp)
+    target_link_libraries(PatternPlaybackTempoChangeTest PRIVATE AestraAudio)
+    target_include_directories(PatternPlaybackTempoChangeTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternPlaybackTempoChangeTest COMMAND PatternPlaybackTempoChangeTest)
+    set_tests_properties(PatternPlaybackTempoChangeTest PROPERTIES LABELS "audio;transport;pattern;regression")
+endif()
+
 # Sinc Interpolator Benchmark
 add_executable(AestraSincBenchmark AestraAudio/SincBenchmark.cpp)
 target_link_libraries(AestraSincBenchmark PRIVATE AestraAudioCore)

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -6,15 +6,19 @@
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
+#include "Plugin/PluginHost.h"
+#include "Plugin/PluginManager.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
 #include <regex>
+#include <string>
+#include <variant>
+#include <vector>
 
 namespace {
 
@@ -264,6 +268,148 @@ void testArsenalUnitsRoundTrip() {
 
     compareProjectSemantic(firstSave, secondSave, "arsenal_units");
     std::filesystem::remove_all(testDir);
+}
+
+void testArsenalDefaultPatternRebindsAfterLoad() {
+    std::cout << "[TEST] Arsenal default pattern rebinds after load..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testProject = testDir / "project.aes";
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [
+            {"id": 10, "name": "Other Pattern", "type": "midi", "length": 8.0, "notes": []},
+            {"id": 42, "name": "Sampler Restored Pattern", "type": "midi", "length": 8.0,
+             "notes": [{"pitch": 60, "startBeat": 0.0, "durationBeats": 1.0, "velocity": 1.0,
+                        "unitId": 7, "pitchOffset": 0, "gate": 1.0, "slide": false}]}
+        ],
+        "lanes": [],
+        "arsenal": {
+            "nextId": 8,
+            "units": [{
+                "id": 7,
+                "name": "Sampler 1",
+                "enabled": true,
+                "targetMixerRoute": -1,
+                "timelineLaneAssignment": -1,
+                "color": "4286611584",
+                "muted": false,
+                "solo": false,
+                "armed": false,
+                "audioClipPath": "",
+                "audioDurationSeconds": 0.0,
+                "defaultPatternId": 42,
+                "group": {"id": 2, "name": "Drums"},
+                "type": {"id": 1, "name": "Sampler"}
+            }]
+        }
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto tm = std::make_shared<Aestra::Audio::TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), tm);
+    assert(result.ok);
+
+    const auto* unit = tm->getUnitManager().getUnit(7);
+    assert(unit);
+    assert(unit->defaultPatternId.isValid());
+    assert(unit->defaultPatternId.value != 42);
+
+    const auto* pattern = tm->getPatternManager().getPattern(unit->defaultPatternId);
+    assert(pattern);
+    assert(pattern->name == "Sampler Restored Pattern");
+    assert(std::holds_alternative<Aestra::Audio::MidiPayload>(pattern->payload));
+    const auto& payload = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
+    assert(payload.notes.size() == 1);
+    assert(payload.notes[0].unitId == 7);
+
+    std::filesystem::remove_all(testDir);
+}
+
+void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
+    std::cout << "[TEST] Arsenal sampler audioClipPath rehydrates plugin after load..." << std::endl;
+
+    auto& pluginManager = Aestra::Audio::PluginManager::getInstance();
+    assert(pluginManager.initialize());
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testWav = testDir / "sampler.wav";
+    std::filesystem::path testProject = testDir / "project.aes";
+    assert(writeMinimalWavMono16(testWav, 48000, 4800));
+
+    const std::string wavPath = testWav.generic_string();
+    std::string projectJson = R"({
+        "version": 2,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [
+            {"id": 1, "name": "Sampler Pattern", "type": "midi", "length": 8.0,
+             "notes": [{"pitch": 60, "startBeat": 0.0, "durationBeats": 1.0, "velocity": 1.0,
+                        "unitId": 1, "pitchOffset": 0, "gate": 1.0, "slide": false}]}
+        ],
+        "lanes": [],
+        "arsenal": {
+            "nextId": 2,
+            "units": [{
+                "id": 1,
+                "name": "Sampler 1",
+                "enabled": true,
+                "targetMixerRoute": 0,
+                "timelineLaneAssignment": 0,
+                "color": "4286611584",
+                "muted": false,
+                "solo": false,
+                "armed": false,
+                "audioClipPath": ")" + wavPath + R"(",
+                "audioDurationSeconds": 0.1,
+                "defaultPatternId": 1,
+                "pluginId": "com.Aestrastudios.sampler",
+                "pluginStateHex": "7b22706172616d73223a5b302e3030312c322c312c302e3030312c305d2c22726f6f744d6964694e6f7465223a36307d",
+                "group": {"id": 2, "name": "Drums"},
+                "type": {"id": 1, "name": "Sampler"}
+            }]
+        }
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto tm = std::make_shared<Aestra::Audio::TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), tm);
+    assert(result.ok);
+
+    auto plugin = tm->getUnitManager().getUnitPlugin(1);
+    assert(plugin);
+    assert(plugin->isActive());
+
+    constexpr uint32_t kFrames = 256;
+    std::vector<float> left(kFrames, 0.0f);
+    std::vector<float> right(kFrames, 0.0f);
+    float* outputs[2] = {left.data(), right.data()};
+
+    Aestra::Audio::MidiBuffer midi;
+    const uint8_t noteOn[3] = {0x90, 60, 127};
+    midi.addEvent(0, noteOn, 3);
+    plugin->process(nullptr, outputs, 0, 2, kFrames, &midi, nullptr);
+
+    float peak = 0.0f;
+    for (uint32_t i = 0; i < kFrames; ++i) {
+        peak = std::max(peak, std::abs(left[i]));
+        peak = std::max(peak, std::abs(right[i]));
+    }
+    assert(peak > 1.0e-5f);
+
+    std::filesystem::remove_all(testDir);
+    std::cout << "[PASS] Arsenal sampler audioClipPath rehydrates plugin after load" << std::endl;
 }
 
 void testMissingPatternReferenceDoesNotCompound() {
@@ -539,6 +685,123 @@ void testLegacyProjectWithoutAutomation() {
     std::filesystem::remove_all(testDir);
 }
 
+void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
+    std::cout << "[TEST] Audio clip duration seconds migration and tempo recompute..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testProject = testDir / "project_audio_duration_migration.aes";
+
+    const std::string legacyJson = R"({
+        "version": 1,
+        "tempo": 120,
+        "playhead": 0,
+        "sources": [
+            {"id": 1, "path": "missing_audio.wav"}
+        ],
+        "patterns": [
+            {"id": 1, "name": "Audio Pattern", "type": "audio", "length": 4.0,
+             "sourceId": 1, "slices": [{"start": 0.0, "length": 44100.0}]},
+            {"id": 2, "name": "Midi Pattern", "type": "midi", "length": 4.0,
+             "notes": [{"pitch": 60, "startBeat": 0.0, "durationBeats": 1.0, "velocity": 1.0}]}
+        ],
+        "lanes": [
+            {"id": "lane-1", "name": "Track 1", "clips": [
+                {"id": "clip-audio", "patternId": 1, "start": 0.0, "duration": 4.0, "name": "Audio Clip"},
+                {"id": "clip-midi", "patternId": 2, "start": 4.0, "duration": 4.0, "name": "Midi Clip"}
+            ]}
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject, std::ios::binary | std::ios::trunc);
+    out << legacyJson;
+    out.close();
+
+    auto tm = std::make_shared<Aestra::Audio::TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), tm);
+    assert(result.ok);
+
+    auto laneIds = tm->getPlaylistModel().getLaneIDs();
+    assert(!laneIds.empty());
+    auto* lane = tm->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->clips.size() == 2);
+
+    auto* audioPattern = tm->getPatternManager().getPattern(lane->clips[0].patternId);
+    auto* midiPattern = tm->getPatternManager().getPattern(lane->clips[1].patternId);
+    assert(audioPattern && audioPattern->isAudio());
+    assert(midiPattern && midiPattern->isMidi());
+    assert(std::abs(lane->clips[0].durationSeconds - 2.0) < 1.0e-9);
+    assert(std::abs(lane->clips[0].durationBeats - 4.0) < 1.0e-9);
+    assert(std::abs(lane->clips[1].durationBeats - 4.0) < 1.0e-9);
+
+    tm->getPlaylistModel().setBPM(60.0);
+    lane = tm->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(std::abs(lane->clips[0].durationSeconds - 2.0) < 1.0e-9);
+    assert(std::abs(lane->clips[0].durationBeats - 2.0) < 1.0e-9);
+    assert(std::abs(lane->clips[1].durationBeats - 4.0) < 1.0e-9);
+
+    std::string saved = serializeProject(*tm, 60.0, 0.0);
+    assert(saved.find("\"durationSeconds\"") != std::string::npos);
+
+    std::cout << "[PASS] Audio clip duration seconds migration and tempo recompute" << std::endl;
+    std::filesystem::remove_all(testDir);
+}
+
+void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
+    std::cout << "[TEST] Audio clip placement helper persists clip and duration seconds..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testWav = testDir / "placed_audio.wav";
+    std::filesystem::path testProject = testDir / "project_audio_placement.aes";
+    assert(writeMinimalWavMono16(testWav, 48000, 48000));
+
+    auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
+    auto& sourceManager = tm1->getSourceManager();
+    const Aestra::Audio::ClipSourceID sourceId = sourceManager.getOrCreateSource(testWav.string());
+    assert(sourceId.isValid());
+
+    Aestra::Audio::AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = 1.0;
+    payload.slices.push_back({0.0, 1.0, 0.0, 48000.0});
+
+    auto& patternManager = tm1->getPatternManager();
+    const auto patternId = patternManager.createAudioPattern("Placed Audio", 2.0, payload);
+    assert(patternId.isValid());
+
+    auto& playlist = tm1->getPlaylistModel();
+    const auto laneId = playlist.createLane("Audio Lane");
+    const auto clipId = playlist.addClipFromPattern(laneId, patternId, 4.0, 2.0);
+    assert(clipId.isValid());
+
+    const auto* clip = playlist.getClip(clipId);
+    assert(clip);
+    assert(std::abs(clip->durationSeconds - 1.0) < 1.0e-9);
+
+    std::string firstSave = serializeProject(*tm1, 120.0, 0.0);
+    assert(firstSave.find("\"durationSeconds\"") != std::string::npos);
+
+    std::ofstream out(testProject, std::ios::binary | std::ios::trunc);
+    out << firstSave;
+    out.close();
+
+    auto tm2 = std::make_shared<Aestra::Audio::TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), tm2);
+    assert(result.ok);
+
+    const auto loadedLaneId = tm2->getPlaylistModel().getLaneId(0);
+    const auto* loadedLane = tm2->getPlaylistModel().getLane(loadedLaneId);
+    assert(loadedLane);
+    assert(loadedLane->clips.size() == 1);
+    assert(std::abs(loadedLane->clips[0].durationSeconds - 1.0) < 1.0e-9);
+    assert(std::abs(loadedLane->clips[0].durationBeats - 2.0) < 1.0e-9);
+
+    std::cout << "[PASS] Audio clip placement helper persists clip and duration seconds" << std::endl;
+    std::filesystem::remove_all(testDir);
+}
+
 }
 
 int main() {
@@ -547,10 +810,14 @@ int main() {
     testEmptyProjectRoundTrip();
     testSourcesLanesClipsPatternsRoundTrip();
     testArsenalUnitsRoundTrip();
+    testArsenalDefaultPatternRebindsAfterLoad();
+    testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad();
     testMissingPatternReferenceDoesNotCompound();
     testMultipleRoundTripCycles();
     testAutomationRoundTrip();
     testLegacyProjectWithoutAutomation();
+    testAudioClipDurationSecondsMigrationAndTempoRecompute();
+    testAudioClipPlacementHelperPersistsClipAndDurationSeconds();
 
     std::cout << "=== All tests passed ===" << std::endl;
     return 0;


### PR DESCRIPTION
## Summary
- add Patterns navigation and piano-roll pattern switching/layout fixes
- sync BPM changes through playlist/timeline/pattern playback and preserve audio clip duration in seconds
- restore Arsenal sampler audio from audioClipPath when legacy plugin state lacks samplePath
- harden audio clip placement so imports fail loudly instead of leaving orphan patterns
- fix close confirmation/button handling paths included in this branch

## Validation
- cmake --build build-linux -j2
- ./build-linux/Tests/ProjectRoundTripIntegrityTest
- ./build-linux/Tests/PatternPlaybackTempoChangeTest
- ./build-linux/Tests/SamplerStereoParityTest
- ctest --test-dir build-linux -R "ProjectRoundTripIntegrityTest|PatternPlaybackTempoChangeTest|SamplerStereoParityTest|PianoRoll|FileBrowser|Note|ClipCommands" --output-on-failure

## Risk
- serialization compatibility touched for audio clip durationSeconds with migration fallback
- live playback scheduling touched for tempo changes
- no DSP algorithm changes intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Audio Duration Persistence**
- Added `durationSeconds` field to `ClipInstance` to track audio clip durations in seconds, separate from beat-based durations (MIDI clips remain beat-native)
- Audio patterns now store and serialize `durationSeconds` to preserve the original audio length through project save/load cycles
- Audio clips derive `durationBeats` from `durationSeconds` during load/import, ensuring proper synchronization when BPM changes

**BPM Synchronization**
- Rewrote `PlaylistModel::setBPM()` to validate tempo values, then recalculate `durationBeats` for all audio clips based on their stored `durationSeconds`
- Extended tempo propagation throughout the app: BPM changes now sync to playlist model, timeline clock, and pattern playback engine together
- Added pattern playback cache flushing after tempo changes to prevent stale MIDI scheduling

**Arsenal Sampler Audio Restoration**
- When loading legacy projects with missing sample paths, `UnitManager` now attempts to reload audio from `UnitInfo::audioClipPath` and reinstate it into the plugin state
- Sampler channel handling simplified: assumes interleaved stereo from decoder, duplicates mono to stereo pairs; fails loudly if channel count is neither 1 nor 2

**Audio Clip Placement Hardening**
- `AddClipCommand` now verifies clip insertion succeeded and throws `std::runtime_error` if the lane is missing, preventing orphaned patterns
- Audio import in `TrackManagerUI` validates clip was added and removes the orphaned pattern if insertion fails

**Pattern Navigation & UI**
- Added "Patterns" entry to file browser navigation with dedicated SVG icon
- Extended piano roll with pattern dropdown selector; pattern switching now auto-saves current pattern before loading the new one
- Reduced minimum pattern length from 16 to 8 beats; pattern length adjustments now use 2-bar (8-beat) increments
- New `setPatternChoices()` and `setOnPatternChoiceSelected()` APIs for pattern selection control

**Close Confirmation Improvements**
- Confirmation dialogs now consume/block input while visible (mouse and keyboard events are intercepted)
- Reworked shutdown sequence: stop audio stream early, close window manager, then clean up plugins—ensuring window destruction happens while audio engine remains available
- Added `m_pendingClose` guard to prevent multiple concurrent confirmation dialogs

**Test Coverage**
- Added `PatternPlaybackTempoChangeTest`: verifies MIDI note scheduling updates correctly after BPM changes and pattern playback cache flushes
- Added `SamplerStereoParityTest`: validates mono WAV → stereo sampler output maintains channel parity
- Extended `ProjectRoundTripIntegrityTest` with arsenal pattern rebinding, sampler rehydration, and audio clip persistence test cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/currentsuspect/Aestra/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->