### PR TITLE
docs: add v0.6.0-alpha changelog

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,7 +62,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.ENABLE_GITHUB_PAGES == 'true'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 - LeakSanitizer (LSan) advisory CI job added (#312)
 - API docs quality workflow Graphviz dependency fixed (#337)
-- GitHub Pages deploy gate removed — deploy now fires on every main push (#369)
+- GitHub Pages deploy gate changed from opt-in to opt-out — deploy fires on every main push unless `DISABLE_GITHUB_PAGES` is set to `'true'` (#369)
 
 ### Sprint 2 Tracking Issues Resolved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,44 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ---
 
+## v0.5.0-alpha — Feature & CI Milestone (2026-05-23)
+
+11 PRs merged (#291–#305). Multi-take recording system, CLAP parameter support, audio quality fixes, CI hardening.
+
+### Takes System
+
+- Multi-take recording with manifest, snapshots, transactional switching
+- Path traversal guards on take snapshot paths
+- UI integration for take management
+
+### CLAP Hosting
+
+- `ClapParamInfo` and `ClapPluginParams` structs for CLAP parameter enumeration
+- CLAP core constant definitions
+- Null `paramsExt` fix — prevents crash when plugin lacks parameter extension
+
+### Audio Quality
+
+- K-weight race fix — metering filter state no longer torn under concurrent access
+- ARM64 denormal handling — `fpcr` register access guarded for MSVC ARM64
+- Send gain smoother coefficient fix — correct smoothing time constant
+- Audition queue deadlock fix — lock ordering corrected
+- Autosave atomic rename — crash-safe save via POSIX rename
+
+### CI / Build
+
+- Removed `jwlawson/actions-setup-cmake@v2` from all CI jobs — uses system CMake
+- DelayLine off-by-one fix — `Capacity+1` buffer allocation
+- Windows path separator fix in test fixtures
+- 13 previously unregistered test files added to CMakeLists
+- Platform guards for Windows/Linux/macOS-specific code paths
+
+### Documentation
+
+- v0.5.0-alpha added to RELEASES.md
+
+---
+
 ## v0.6.0-alpha — Security & RT Hardening (2026-05-29)
 
 26 PRs merged. Security hardening across the plugin host, license gate, and project loader. RT-safety fixes for waveform callbacks, preview decodes, mixer state, and the master limiter. Plugin host crash resilience and non-finite output quarantine. Callback-safety architecture (triple-buffer graph, routing snapshot, PDC edge ownership, TSan CI). Sprint 2 tracking issues resolved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,93 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ---
 
+## v0.6.0-alpha — Security & RT Hardening (2026-05-29)
+
+26 PRs merged. Security hardening across the plugin host, license gate, and project loader. RT-safety fixes for waveform callbacks, preview decodes, mixer state, and the master limiter. Plugin host crash resilience and non-finite output quarantine. Callback-safety architecture (triple-buffer graph, routing snapshot, PDC edge ownership, TSan CI). Sprint 2 tracking issues resolved.
+
+### Security
+
+- Take snapshot paths confined within project `.takes` directory — traversal regression coverage (#338)
+- Scanned/cache plugins can no longer shadow registered internal plugin IDs (#338)
+- Hard-coded dev account API fallback removed — stale/future/premium lease rejection in default builds (#338)
+- Account refresh `issued_at` handling hardened; private release workflow token exposure fixed (#338)
+- Production key required for premium leases (#339)
+- Arsenal project plugin restore restricted to registered IDs only (#340)
+- CLAP scanner helper writes guarded from SIGPIPE (#365)
+- Nightly workflow token permissions limited to minimum required (#347)
+
+### RT Safety
+
+- Stale waveform source callbacks eliminated — preview engine no longer holds dangling lambdas (#341)
+- Async preview decodes bounded — prevents unbounded work accumulation on the audio thread (#342)
+- Audition decode worker lifetime owned explicitly — no more race on teardown (#343)
+- Render main output slot lookup cached per graph compile — removes per-block map lookup (#346)
+- Mixer lane state clamped before cast — prevents undefined values from reaching the audio path (#345)
+- OpenGL kerning cache bounded — prevents unbounded growth in glyph atlas (#350)
+- MSVC ARM64 denormal register access made safe — no more direct `fpcr` manipulation (#344)
+- AestraVerb active state rebuilds guarded — prevents spurious re-initialization during bypass transitions (#360)
+- Graph dirty UI signal guarded — prevents UI-triggered graph rebuilds from racing the audio thread (#358)
+- Master safety limiter reshaped to transparent cubic Hermite knee (0.98 → 0.9997 ceiling clamp) — never boosts input, preserves recovery compatibility (#367)
+
+### Plugin Hosting
+
+- VST3 host crash handling hardened — plugin helper runs real VST3 processing instead of stub (#334)
+- Plugin proxy watchdog state made atomic — prevents torn reads under concurrent access (#334)
+- Non-finite plugin output quarantined — NaN/Inf detected and reported instead of propagating (#333)
+- Effect-chain fault state ownership fixed — fault markers scoped correctly to prevent cross-channel bleed (#333)
+
+### Callback Safety
+
+- Triple-buffer `EngineState` with `GraphReadHandle` protecting RT graph access (#310)
+- `RecordingCaptureRoute` double-buffered snapshot — input capture reads immutable snapshot instead of live state (#310)
+- PDC edge state ownership fixed — latency compensation no longer races graph recompile (#310)
+- TSan CI added for callback-safety regression detection (#310)
+
+### Serialization / Project Persistence
+
+- Pattern restore and timeline persistence fixed — patterns survive project round-trips correctly (#368)
+- BPM changes synced through playlist/timeline/pattern playback — audio clip duration preserved in seconds (#368)
+- Arsenal sampler audio restored from `audioClipPath` when legacy plugin state lacks `samplePath` (#368)
+- Audio clip placement hardened — imports fail loudly instead of leaving orphan patterns (#368)
+- Migrated round-trip payload values asserted — migration framework validated against v1 fixtures (#332)
+- v1 project migration roundtrip proven — `ProjectRoundTripIntegrityTest` passing (#332)
+
+### Recovery
+
+- Autosave crash session binding — recovery autosaves tagged to crash session markers
+- Session recovery test fixed on Windows — path separator handling corrected
+
+### CI / Build
+
+- LeakSanitizer (LSan) advisory CI job added (#312)
+- API docs quality workflow Graphviz dependency fixed (#337)
+- GitHub Pages deploy gate removed — deploy now fires on every main push (#369)
+
+### Sprint 2 Tracking Issues Resolved
+
+- `std::atomic_load` on `shared_ptr` deprecated — replaced with `std::atomic<std::shared_ptr>` or direct member access (#331)
+- Plugin crash protection verified Linux-only — Windows/macOS behavior documented (#334)
+- Plugin NaN/Inf validation moved to master output — per-plugin validation planned for post-beta (#333)
+- Migration framework proven with v1 fixture roundtrip (#332)
+- fsync absence in write paths documented — deferred to post-beta (#335)
+
+### Documentation
+
+- Issue audit system Phase 1a/1b/1c — taxonomy review and priority alignment (#308)
+- Doxygen coverage for callback-safety public API (#311)
+
+### Known Issues (as of v0.6.0-alpha)
+
+- OOP plugin parameters are no-ops (#238) — P0
+- Autosave serializer data race (#239) — P0
+- Routing gain smoothing, cycle detection, RT allocation (#240, #241, #243) — P0
+- CLAP MIDI input unimplemented (#244) — P0
+- 5 empty model stub files (#252) — P1
+- macOS platform unimplemented (#267) — P1
+- Full list: https://github.com/users/currentsuspect/projects/3
+
+---
+
 ## [Unreleased]
 
 ### Fixed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -23,11 +23,28 @@ v1.0.0                  — initial public release
 | `v0.1.0-alpha`       | Deleted   | —          | Redundant with foundation tag             |
 | `v1.0.0`             | Deleted   | —          | Premature — do not recreate until release |
 | `v0.4.0-alpha`       | Superseded | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
-| `v0.5.0-alpha`       | Current   | 2026-05-23 | Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs merged |
+| `v0.5.0-alpha`       | Superseded | 2026-05-23 | Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs merged |
+| `v0.6.0-alpha`       | Current   | 2026-05-29 | Security & RT hardening, plugin host crash resilience, callback-safety architecture, 26 PRs merged |
 
 ---
 
 ## Milestone History
+
+### v0.6.0-alpha — Security & RT Hardening (May 2026)
+
+**Security** — Take snapshot path traversal guards, plugin ID shadowing prevention, premium lease hardening, CLAP SIGPIPE guard, nightly token permissions.
+
+**RT Safety** — Waveform callback lifetime, bounded preview decodes, mixer state clamping, master limiter reshaped to cubic Hermite knee, ARM64 denormals guarded.
+
+**Plugin Hosting** — VST3 crash handling hardened, non-finite output quarantine, effect-chain fault state ownership.
+
+**Callback Safety** — Triple-buffer EngineState, double-buffered routing snapshot, PDC edge ownership, TSan CI.
+
+**Serialization** — Pattern restore, BPM sync, migration roundtrip proven.
+
+**CI/Build** — LSan advisory job, GitHub Pages deploy toggle renamed to `DISABLE_GITHUB_PAGES`.
+
+**PRs merged** — #308, #310–#312, #331–#335, #337–#347, #350, #358, #360, #365, #367–#368 (26 PRs).
 
 ### v0.5.0-alpha — Feature & CI Milestone (May 2026)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ If you want the most accurate current picture, start with:
 - [Roadmap](technical/roadmap.md)
 - [Testing & CI](technical/testing_ci.md)
 - [Rumble MVP Plan](technical/RUMBLE_MVP_PLAN.md)
-- [Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q1.md)
+- [Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q2.md)
 
 ## 🎯 What is Aestra?
 
@@ -50,7 +50,7 @@ Aestra is a source-available digital audio workstation under active development.
 - **[Roadmap](technical/roadmap.md)** — High-level milestones and current execution plan
 - **[Testing & CI](technical/testing_ci.md)** — Current confidence suite and verification workflow
 - **[CI Workflows Map](technical/ci_workflows.md)** — What runs in GitHub Actions, what is blocking vs preview
-- **[Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q1.md)** — Current milestone history
+- **[Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q2.md)** — Current milestone history
 - **[License Reference](about/license-reference.md)** — Licensing information and ASSAL v1.1 details
 
 ### 📝 Templates
@@ -80,7 +80,7 @@ Aestra is a source-available digital audio workstation under active development.
 
 ### For Maintainers
 1. Review [Roadmap](technical/roadmap.md) for project milestones
-2. Check [Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q1.md) for recent milestone history
+2. Check [Current Changelog](../meta/CHANGELOGS/CHANGELOG_2026Q2.md) for recent milestone history
 3. Check [License Reference](about/license-reference.md) for ASSAL v1.1 details
 4. Use [Issue Template](TEMPLATE/ISSUE_TEMPLATE.md) for documentation issues
 

--- a/docs/meta/DOCUMENTATION_INDEX.md
+++ b/docs/meta/DOCUMENTATION_INDEX.md
@@ -28,7 +28,7 @@ Welcome to the comprehensive documentation hub for **Aestra**! This guide helps 
 6. **[🎛️ Rumble MVP](../technical/RUMBLE_MVP_PLAN.md)** - Internal instrument slice status
 
 ### For Project Management
-1. **[📋 Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q1.md)** - Current 2026 milestone history
+1. **[📋 Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q2.md)** - Current 2026 milestone history
 2. **[📚 Historical Meta Archive](../../meta/README.md)** - Older summaries, bug-fix notes, and archive context
 3. **[📜 License Reference](../about/license-reference.md)** - Licensing details
 4. **[🤝 Community](../community/)** - Support and guidelines
@@ -74,7 +74,7 @@ Welcome to the comprehensive documentation hub for **Aestra**! This guide helps 
 - **[Generated Docs](../../docs/api-reference/html/index.html)** - Doxygen-generated docs (generate with `doxygen Doxyfile`)
 
 ### 📋 **Release Information**
-- **[Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q1.md)** - Current 2026 milestone history
+- **[Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q2.md)** - Current 2026 milestone history
 - **[Historical Changelog Snapshot](../../meta/CHANGELOGS/CHANGELOG_2025Q1.md)** - Older release-era changelog
 - **[Historical Meta Archive](../../meta/README.md)** - Archived work logs, bug notes, and task summaries
 - **[Milestone Updates](../../meta/README.md)** - Entry point for archived implementation notes
@@ -111,7 +111,7 @@ Welcome to the comprehensive documentation hub for **Aestra**! This guide helps 
 
 ### 📊 **For Project Managers**
 1. Review [Roadmap](../technical/roadmap.md)
-2. Check [Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q1.md)
+2. Check [Current Changelog](../../meta/CHANGELOGS/CHANGELOG_2026Q2.md)
 3. Read [Development Logs](../../meta/SESSION_SUMMARY_DEC2024.md) for archive context
 4. Understand [Milestones](../technical/roadmap.md#roadmap-phases-now--dec-2026)
 

--- a/meta/CHANGELOGS/CHANGELOG_2026Q2.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q2.md
@@ -9,6 +9,7 @@ All notable changes for Aestra in Q2 2026 are documented here.
 - Take snapshot paths confined within project `.takes` directory — traversal regression coverage
 - Scanned/cache plugins can no longer shadow registered internal plugin IDs
 - Hard-coded dev account API fallback removed — stale/future/premium lease rejection in default builds
+- Account refresh `issued_at` handling hardened; private release workflow token exposure fixed (#338)
 - Production key required for premium leases
 - Arsenal project plugin restore restricted to registered IDs only
 - CLAP scanner helper writes guarded from SIGPIPE

--- a/meta/CHANGELOGS/CHANGELOG_2026Q2.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q2.md
@@ -2,6 +2,95 @@
 
 All notable changes for Aestra in Q2 2026 are documented here.
 
+## v0.6.0-alpha — Security & RT Hardening (2026-05-29)
+
+### Security
+
+- Take snapshot paths confined within project `.takes` directory — traversal regression coverage
+- Scanned/cache plugins can no longer shadow registered internal plugin IDs
+- Hard-coded dev account API fallback removed — stale/future/premium lease rejection in default builds
+- Production key required for premium leases
+- Arsenal project plugin restore restricted to registered IDs only
+- CLAP scanner helper writes guarded from SIGPIPE
+- Nightly workflow token permissions limited to minimum required
+
+### RT Safety
+
+- Stale waveform source callbacks eliminated
+- Async preview decodes bounded
+- Audition decode worker lifetime owned explicitly
+- Render main output slot lookup cached per graph compile
+- Mixer lane state clamped before cast
+- OpenGL kerning cache bounded
+- MSVC ARM64 denormal register access made safe
+- AestraVerb active state rebuilds guarded
+- Graph dirty UI signal guarded
+- Master safety limiter reshaped to transparent cubic Hermite knee
+
+### Plugin Hosting
+
+- VST3 host crash handling hardened — real VST3 processing in plugin helper
+- Plugin proxy watchdog state made atomic
+- Non-finite plugin output quarantined (NaN/Inf detection)
+- Effect-chain fault state ownership fixed
+
+### Callback Safety
+
+- Triple-buffer `EngineState` with `GraphReadHandle` for RT graph access
+- `RecordingCaptureRoute` double-buffered snapshot for input capture
+- PDC edge state ownership fixed
+- TSan CI added for callback-safety regression detection
+
+### Serialization / Project Persistence
+
+- Pattern restore and timeline persistence fixed
+- BPM changes synced through playlist/timeline/pattern playback
+- Arsenal sampler audio restored from `audioClipPath` for legacy states
+- Migration framework proven with v1 fixture roundtrip
+
+### Recovery
+
+- Autosave crash session binding
+- Session recovery test fixed on Windows
+
+### CI / Build
+
+- LeakSanitizer (LSan) advisory CI job
+- API docs quality workflow Graphviz dependency fix
+- GitHub Pages deploy gate removed
+
+### Sprint 2 Resolved
+
+- `std::atomic_load` on `shared_ptr` deprecated (#331)
+- Plugin crash protection verified Linux-only (#334)
+- Plugin NaN/Inf validation moved to master output (#333)
+- Migration framework proven (#332)
+- fsync absence documented, deferred to post-beta (#335)
+
+### Known Issues (as of v0.6.0-alpha)
+
+- OOP plugin parameters are no-ops (#238) — P0
+- Autosave serializer data race (#239) — P0
+- Routing gain smoothing, cycle detection, RT allocation (#240, #241, #243) — P0
+- CLAP MIDI input unimplemented (#244) — P0
+- Full list: https://github.com/users/currentsuspect/projects/3
+
+---
+
+## v0.5.0-alpha — Feature & CI Milestone (2026-05-23)
+
+**Takes system** — Multi-take recording with manifest, snapshots, transactional switching, path traversal guards, and UI integration.
+
+**CLAP parameter support** — ClapParamInfo, ClapPluginParams structs, CLAP core constant definitions, null paramsExt fix.
+
+**Audio quality** — K-weight race fix, ARM64 denormals, send gain smoother coefficient fix, audition queue deadlock fix, autosave atomic rename.
+
+**CI hardening** — Removed jwlawson/actions-setup-cmake@v2 from all jobs, system cmake, DelayLine off-by-one fix (Capacity+1 buffer), Windows path separator fix, 13 tests registered, platform guards.
+
+**PRs merged** — #291-#305 (11 PRs), develop→main merge (#304, 51 commits).
+
+---
+
 ## v0.4.0-alpha — Hardening Milestone (2026-05-20)
 
 ### Security

--- a/meta/CHANGELOGS/CHANGELOG_2026Q2.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q2.md
@@ -58,7 +58,7 @@ All notable changes for Aestra in Q2 2026 are documented here.
 
 - LeakSanitizer (LSan) advisory CI job
 - API docs quality workflow Graphviz dependency fix
-- GitHub Pages deploy gate removed
+- GitHub Pages deploy gate changed from opt-in to opt-out (`DISABLE_GITHUB_PAGES != 'true'`)
 
 ### Sprint 2 Resolved
 


### PR DESCRIPTION
## Summary

Adds v0.6.0-alpha changelog covering all 26 PRs merged since v0.5.0-alpha.
Adds missing v0.5.0-alpha section to main CHANGELOG.md.

### Fixes in this PR

- **P1**: v0.5.0-alpha was missing from CHANGELOG.md — added full section (Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs)
- **P2**: Account refresh  hardening entry missing from Q2 meta changelog Security section — added

### Sections (v0.6.0-alpha)

- **Security** — 8 items
- **RT Safety** — 10 items
- **Plugin Hosting** — 4 items
- **Callback Safety** — 4 items
- **Serialization** — 6 items
- **Recovery** — 2 items
- **CI/Build** — 3 items
- **Sprint 2 Resolved** — 5 items

### Files changed

- `CHANGELOG.md` — v0.5.0-alpha + v0.6.0-alpha sections
- `meta/CHANGELOGS/CHANGELOG_2026Q2.md` — v0.6.0-alpha security entry added