### PR TITLE
Debloat AGENTS.md and philosophy.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Preferred workflow:
 git status --short
 git branch --show-current
 git rev-parse --short HEAD
-````
+```
 
 ### Branching
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,12 @@ git branch --show-current
 git rev-parse --short HEAD
 ````
 
+### Branching
+
+- Branch from `develop`.
+- Never commit directly to `main` or `develop`.
+- Merge flow: `feature/*` → `develop` → `main`.
+
 ---
 
 ## 4. Required Final Report Format
@@ -593,13 +599,6 @@ git push origin v0.4.0-alpha
 
 See `RELEASES.md` for the current tag inventory, milestone history, and release status.
 Do not duplicate that table in this file.
-
-### What Agents Must Not Do
-
-* Do not create or delete tags without explicit instruction.
-* Do not push tags.
-* Do not use lightweight tags for milestones.
-* Do not recreate deleted premature version tags.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,6 @@
 
 This file defines how AI agents, bots, and automation tools should work inside the Aestra repository.
 
-It is intentionally strict. Aestra is a native C++ DAW with real-time audio constraints, project persistence, CI requirements, and source-available licensing. Small mistakes can cause crashes, data loss, broken exports, leaked private assets, or misleading public claims.
-
-Read this file before making changes.
-
 ## Philosophy
 
 Before working on Aestra, read [`philosophy.md`](philosophy.md). It defines the product vision, the people we build for, and the engineering values that underpin every decision here. When this policy and philosophy conflict on direction, philosophy wins. When this policy and philosophy conflict on safety, this policy wins.
@@ -14,25 +10,13 @@ Before working on Aestra, read [`philosophy.md`](philosophy.md). It defines the 
 
 ## 1. Scope
 
-This policy applies to:
-
-- Codex
-- Cursor
-- Copilot
-- CodeRabbit
-- ChatGPT-generated patches
-- Local automation scripts
-- Any bot-generated or AI-assisted contribution
+This policy applies to any bot-generated or AI-assisted contribution.
 
 Agents must keep changes small, reviewable, factual, and aligned with the real repository state.
-
-Do not invent roadmap claims, release status, architecture facts, benchmark results, or test results.
 
 ---
 
 ## 2. Non-Negotiable Rules
-
-These rules override convenience.
 
 - Do not delete, rename, reset, force-push, or rewrite `main` or `develop`.
 - Do not commit or push unless explicitly asked.
@@ -48,8 +32,6 @@ These rules override convenience.
 - Do not silence CodeRabbit, clang-tidy, compiler, sanitizer, or CI findings without a clear technical reason.
 - Do not change serialization/project format casually. Treat persistence changes as high-risk.
 - Do not “fix” dead/commented code unless the task explicitly targets it.
-
-When unsure, prefer reporting uncertainty over guessing. When the user's intent is ambiguous or unclear, ask for clarification rather than assuming.
 
 ---
 
@@ -77,8 +59,6 @@ git status --short
 git branch --show-current
 git rev-parse --short HEAD
 ````
-
-Do not proceed with destructive Git operations unless explicitly requested.
 
 ---
 
@@ -114,8 +94,6 @@ Every completed agent session must report:
 - Remaining risks:
 - Follow-up work:
 ```
-
-Never claim “all green” unless the relevant command was actually run and passed.
 
 ---
 
@@ -275,22 +253,6 @@ Follow `.clang-format` and `.clang-tidy`.
 | Files            | `PascalCase.h/.cpp` | `AudioEngine.cpp`      |
 | Namespace        | `Aestra`            | `Aestra::AudioEngine`  |
 
-### Include Layout
-
-Headers are organized by domain under `AestraAudio/include/`, including:
-
-* `Core/`
-* `DSP/`
-* `Models/`
-* `Playback/`
-* `IO/`
-* `Drivers/`
-* `Plugin/`
-* `Commands/`
-* `Headless/`
-
-Prefer existing locations and naming patterns.
-
 ---
 
 ## 10. Real-Time Audio Rules
@@ -333,8 +295,6 @@ Common safe communication pattern:
 UI/threaded command path -> SPSC queue/ring buffer -> audio thread consumes bounded commands
 ```
 
-Do not “just add a mutex” to fix audio-thread races.
-
 ---
 
 ## 11. DSP Rules
@@ -373,8 +333,6 @@ When touching save/load, project roundtrip, migration, clips, tracks, routes, pl
 * Fail loudly and diagnostically on corrupt/unresolvable critical state.
 * Add or update roundtrip/regression tests.
 * Validate both UI and headless/backend paths where applicable.
-
-Never treat “the UI still opens” as sufficient validation for project persistence.
 
 ---
 
@@ -458,12 +416,6 @@ Do not modify, regenerate, normalize, delete, or include changes to these files 
 
 If they change during local testing, revert them before finalizing unless the task explicitly requires updating them.
 
-Recommended check:
-
-```bash
-git status --short
-```
-
 ---
 
 ## 16. Known Dead or Sensitive Areas
@@ -502,8 +454,6 @@ Use:
 * `AestraDocs/` for internal design notes, architecture reports, implementation plans, and status documents.
 * `labs/` for experiments, generated evidence, quality reports, and benchmark artifacts.
 
-Do not put temporary project status into `AGENTS.md`.
-
 ---
 
 ## 18. Security and Licensing
@@ -528,18 +478,6 @@ Security-sensitive areas include:
 * Network access
 * Crash recovery
 * Export/write paths
-
-Vulnerability reports should go to:
-
-```text
-security@aestra.studio
-```
-
-Use subject format:
-
-```text
-SECURITY: [summary]
-```
 
 ---
 
@@ -566,8 +504,6 @@ com.Aestrastudios.verb
 com.Aestrastudios.delay
 ```
 
-Do not rename IDs without explicit migration work.
-
 ---
 
 ## 20. Export/Bounce Rules
@@ -588,18 +524,7 @@ Always report whether live/export parity was affected.
 
 ---
 
-## 21. Git and PR Hygiene
-
-### Commits
-
-* Keep commits surgical.
-* Group by concern.
-* Do not mix formatting-only changes with functional changes unless requested.
-* Do not include unrelated cleanup.
-* Do not commit generated files unless they are expected artifacts.
-* Do not commit local machine paths, caches, or runtime noise.
-
-### Pull Requests
+## 21. Pull Requests
 
 PRs should include:
 
@@ -608,17 +533,6 @@ PRs should include:
 * Testing performed
 * Docs updated?
 * Risk/rollback notes
-
-Do not merge bot-generated PRs blindly.
-
-### Branch Protection
-
-Never delete or rewrite:
-
-* `main`
-* `develop`
-
-Treat both as protected even if local Git allows the operation.
 
 ---
 
@@ -644,109 +558,7 @@ Unacceptable responses:
 
 ---
 
-## 23. Agent Decision Rules
-
-When choosing between options:
-
-Prefer:
-
-* Small patches over rewrites
-* Existing patterns over new frameworks
-* Explicit errors over silent failure
-* Deterministic behavior over cleverness
-* Headless validation over UI-only validation
-* Compatibility over convenience
-* Clear diagnostics over vague success
-* Real test evidence over assumptions
-
-Avoid:
-
-* Large speculative refactors
-* “While I’m here” cleanup
-* Premature abstraction
-* UI-only fixes for backend bugs
-* Backend-only fixes that leave UI state misleading
-* Serialization changes without migration
-* Performance claims without measurements
-
----
-
-## 24. Public Roadmap and Status Claims
-
-Do not add or update public claims about:
-
-* Release dates
-* Beta status
-* Pricing
-* Premium features
-* Cloud features
-* Benchmarks
-* Supported platforms
-* Plugin compatibility
-* Security guarantees
-* “Production-ready” status
-
-unless explicitly requested and supported by repository evidence.
-
-Status belongs in dedicated docs or reports, not in this file.
-
----
-
-## 25. Known Framework Debt
-
-### NUIPlatformBridge `NUIMouseEvent::type` — FIXED
-
-`NUIMouseEvent::type` is now populated correctly by `AestraUI/Platform/NUIPlatformBridge.cpp` and `Source/Core/AestraWindowManager.cpp` as of 2026-05-11. Use freely.
-
-Historical context: the field was previously left as `NUIMouseEventType::None` at every construction site, causing components that checked `event.type` to silently fail. The following components were affected and have been verified:
-
-* `MembershipSettingsPage` — now uses `event.pressed` directly (works regardless).
-* `AestraHistoryPanel` — `event.type` checks for Move/Scroll now fire correctly.
-* `NUIApp::handleMouseEvent` — adaptive FPS type checks now match correctly.
-* `UnitRow` — step-editing type checks are now functional (redundant with `pressed`/`released` but no longer dead).
-* `PluginBrowserPanel` — drag type check remains dead (`Drag` is not emitted by the bridge), but the `button == Left` path covers actual drag logic.
-
-Both `event.type` and `event.pressed`/`released` patterns are valid going forward.
-
----
-
-## 26. DO
-
-* Use `Aestra_CORE_MODE=ON` for public-facing builds.
-* Use `AESTRA_HEADLESS_ONLY=ON` when UI is not needed.
-* Gate hardware/device tests behind `AESTRA_ENABLE_RUNTIME_TESTS`.
-* Match docs to actual code and CI behavior.
-* Keep changes surgical.
-* Review automation output like human code.
-* Use clang-format and clang-tidy where practical.
-* Check existing components before adding new ones.
-* Preserve protected branches.
-* Report exact tests and commands.
-* Be honest about skipped validation.
-* Fail loudly on dangerous states.
-* Protect realtime audio constraints.
-
----
-
-## 26. DON'T
-
-* Do not blindly merge bot PRs.
-* Do not invent unsupported process, release, benchmark, or roadmap claims.
-* Do not add global AVX/AVX2/AVX512 flags.
-* Do not commit runtime state changes unless explicitly requested.
-* Do not use or revive dead code casually.
-* Do not make blocking calls in the audio thread.
-* Do not allocate memory in audio callbacks.
-* Do not override review findings without justification.
-* Do not use hidden automation-only feature flows.
-* Do not weaken secret scanning.
-* Do not modify FreeType warning suppressions without explicit reason.
-* Do not delete `main` or `develop`.
-* Do not claim success without evidence.
-
----
-
-## 27. Versioning and Tagging Policy
+## 23. Versioning and Tagging Policy
 
 Aestra uses semantic versioning with phase suffixes.
 
@@ -791,10 +603,7 @@ Do not duplicate that table in this file.
 
 ---
 
-## 28. Nightly Builds
-
-Nightly builds run on a schedule via `nightly.yml` and are the primary canary
-for regressions not caught by push/PR CI.
+## 24. Nightly Builds
 
 ### Schedule
 
@@ -822,8 +631,3 @@ resolving the underlying cause.
 * Do not disable ASan/UBSan on nightly without explicit approval and a written reason.
 * Do not remove the `ref: develop` from the checkout step — scheduled workflows default to the repository's default branch, not develop.
 * Do not remove the ctest `-E` exclusion filter without confirming those tests pass under ASan/UBSan.
-
-### What Agents May Do
-
-* Add additional nightly steps (e.g. macOS matrix, DSP benchmarks) when explicitly tasked.
-* Adjust cron timing when explicitly asked.

--- a/philosophy.md
+++ b/philosophy.md
@@ -116,4 +116,4 @@ The measure of Muse is invisibility — whether the user felt helped or handled.
 
 ---
 
-*This document is the root. When requirements conflict, return here.*
+*This document is the root for product direction. For safety constraints, follow `AGENTS.md`.*

--- a/philosophy.md
+++ b/philosophy.md
@@ -1,5 +1,4 @@
 # Aestra Philosophy
-`v1.0 — 2026-05-19`
 
 ---
 
@@ -9,7 +8,7 @@ A DAW is not merely software. It is a creative environment.
 
 The job of the environment is to reduce the distance between intention and sound.
 
-Everything that interrupts creative flow is friction. Friction compounds into fatigue. Fatigue kills experimentation. Experimentation is where art is born.
+Friction kills experimentation. Experimentation is where art is born.
 
 Aestra exists to make creation feel immediate, stable, expressive, and emotionally alive.
 
@@ -18,8 +17,6 @@ Aestra exists to make creation feel immediate, stable, expressive, and emotional
 ## Who We Build For
 
 The producer on a 4 GB RAM laptop. The artist working late in a city where music gear costs a month's salary. The person who has real ideas and no margin for software that fights them.
-
-This is not a secondary consideration. It shapes every architectural decision, every default, every performance tradeoff. When we optimize for speed and efficiency, we are not chasing benchmarks — we are making the tool accessible to the people who need it most.
 
 Aestra does not assume elite hardware. Aestra does not assume a studio. Aestra assumes a person with something to say.
 
@@ -33,160 +30,61 @@ Audio integrity is sacred.
 
 The engine must feel trustworthy under pressure: stable timing, deterministic rendering, accurate latency behavior, responsive monitoring, predictable automation, realtime-safe execution, graceful degradation under load.
 
-Users should feel confidence when they press play. Not "technically acceptable." Confident.
+**We care about:** realtime correctness, timing consistency, low-latency responsiveness.
 
-**We care about:**
-- Realtime correctness
-- Timing consistency
-- Low-latency responsiveness
-- Deterministic systems
-- Accurate compensation
-- Precision and stability under stress
-
-**We do not care about:**
-- Meaningless audio marketing
-- Fake analog mythology
-- Placebo DSP claims
-- Spec-sheet theater
+**We do not care about:** audio marketing, analog mythology, placebo DSP claims, spec-sheet theater.
 
 ---
 
 ### 2. Flow Above Features
 
-Creative momentum matters more than feature count.
+Creative momentum matters more than feature count. A fast incomplete idea is more valuable than a perfect interrupted one.
 
-A fast incomplete idea is more valuable than a perfect interrupted one.
+**We care about:** iteration speed, intelligent defaults, low cognitive load, keyboard fluency, fast recovery from mistakes.
 
-The DAW should feel lightweight, immediate, predictable, frictionless, mentally compressible. The user should spend time creating, not managing software.
-
-**We care about:**
-- Startup speed
-- Iteration speed
-- Responsiveness
-- Intelligent defaults
-- Low cognitive load
-- Keyboard fluency
-- Discoverability
-- Fast recovery from mistakes
-
-**We do not care about:**
-- Feature bloat
-- Menu labyrinths
-- Modal overload
-- Legacy workflows preserved at the cost of coherence
-- Adding features without improving creation
+**We do not care about:** feature bloat, menu labyrinths, modal overload, legacy workflows preserved at the cost of coherence.
 
 ---
 
 ### 3. Beauty With Purpose
 
-Visual design is cognitive design.
+Visual design is cognitive design. Beauty shapes emotion, focus, fatigue, and trust.
 
-Beauty is not decoration. Beauty shapes emotion, focus, fatigue, and trust. Aestra should feel calm, intentional, modern, cinematic, spatially coherent, emotionally inspiring. But visuals must never obstruct workflow.
+**We care about:** visual clarity, motion with meaning, hierarchy and readability, coherent interaction language.
 
-**We care about:**
-- Visual clarity
-- Motion with meaning
-- Hierarchy and readability
-- Emotional atmosphere
-- Smooth interaction
-- Tasteful animation
-- Coherent interaction language
-
-**We do not care about:**
-- Visual noise
-- Excessive skeuomorphism
-- Flashy motion for its own sake
-- Gamer UI
-- Clutter
-- Inconsistent interaction patterns
+**We do not care about:** visual noise, flashy motion for its own sake, gamer UI, clutter, inconsistent interaction patterns. Aestra must not feel enterprise-ey, hostile to beginners, or creatively interruptive.
 
 ---
 
 ## On Trust
 
-Work should never disappear.
+Work should never disappear. Session loss is not a bug. It is a betrayal.
 
-Session loss is not a bug. It is a betrayal. The moment a producer loses an idea because software failed them, we have failed at the most fundamental level.
+Autosave, versioning, and state restoration are obligations, not features. Recovery from failure must be fast, automatic, and complete. Rendering must be deterministic — export sounds like the session, every time.
 
-A crash mid-session is not merely a stability issue — it is a violation of the creative contract between the tool and the person using it. Recovery from failure must be fast, automatic, and complete. Autosave, versioning, and state restoration are not features. They are obligations.
-
-The same principle extends to rendering: deterministic output means the export sounds like the session, every time, without surprises.
-
-**Session files must open correctly across versions, even if the UI or internals change. Backwards compatibility of project data is non-negotiable. Everything else may evolve.**
-
-UI, API, internal architecture, and workflow patterns can all change in service of coherence and improvement. The session file is the one contract that never breaks.
+**Session files must open correctly across versions. Backwards compatibility of project data is non-negotiable.** Everything else — UI, API, internals, workflow — may evolve.
 
 ---
 
 ## Engineering Doctrine
 
-*This is the section agents should internalize most deeply.*
-
 ### Realtime Safety Is Non-Negotiable
-
-No locks, allocations, blocking I/O, unpredictable waits, or hidden synchronization inside realtime audio paths.
-
-Realtime violations are architectural failures, not small issues.
-
----
+No locks, allocations, blocking I/O, or hidden synchronization in realtime audio paths. Violations are architectural failures, not small issues.
 
 ### Third-Party Plugins Are Guests
-
-Aestra may isolate, disable, or warn about plugins that violate realtime safety or memory constraints. The host's integrity comes first.
-
-Third-party plugins operate outside our doctrine. We do not inherit their failures. When a plugin misbehaves, Aestra contains the damage — it does not propagate it to the session or the user.
-
----
+Aestra isolates, disables, or warns about plugins that violate realtime safety or memory constraints. The host's integrity comes first.
 
 ### Performance Is a Feature
-
-Fast software changes behavior. Efficiency is not polish — efficiency is product design.
-
-Every subsystem should justify its memory usage, CPU usage, latency cost, and complexity cost. Optimization is accessibility. A tool that runs well on weak hardware is a tool more people can use.
-
----
+Every subsystem must justify its memory, CPU, latency, and complexity cost. Optimization is accessibility — a tool that runs well on weak hardware is available to more people.
 
 ### Complexity Must Earn Its Place
-
-Complexity is acceptable only when capability gained is substantial, workflow becomes meaningfully better, or architectural simplicity improves elsewhere.
-
-No subsystem should become complicated merely because it is technically interesting.
-
----
+Complexity is acceptable only when capability gained is substantial or workflow becomes meaningfully better. No subsystem should be complicated because it is technically interesting.
 
 ### Defaults Matter More Than Options
-
-Good defaults reduce decision fatigue. Aestra should guide users toward successful outcomes without overwhelming them with configuration.
-
-Configuration exists to empower edge cases, not to replace design clarity.
-
-Complex workflows should be expressible via direct manipulation — drag-and-drop, keyboard modifiers, inspector panels — before adding preference dialogs. Prefer progressive disclosure over "advanced" tabs. Power users deserve a path; that path should never be a buried settings screen.
-
----
+Good defaults reduce decision fatigue. Configuration empowers edge cases — it does not replace design clarity. Prefer progressive disclosure over "advanced" tabs.
 
 ### Portability Matters
-
-Creativity should not require elite hardware. Aestra must scale gracefully across laptops, weaker CPUs, low-memory systems, and varied OS conditions.
-
-Optimization is not a performance luxury. Optimization is how we make the tool available to more of the world.
-
----
-
-## Anti-Values
-
-These exist because drift is subtle. Every bad DAW was built by people who thought they were making reasonable tradeoffs.
-
-Aestra must never become:
-- Bloated
-- Sluggish
-- Visually chaotic
-- Enterprise-feeling
-- Menu-driven
-- Emotionally sterile
-- Hostile to beginners
-- Unstable under pressure
-- Creatively interruptive
+Creativity should not require elite hardware. Aestra must scale across weak CPUs, low memory, and varied OS conditions. Optimization is how we make the tool available to more people.
 
 ---
 
@@ -207,54 +105,14 @@ If any answer is no, the interaction needs to change.
 
 ## On Muse
 
-Muse is the AI layer inside Aestra. It assists — it does not redirect.
+Muse is the AI layer inside Aestra. It assists — it does not redirect. It reduces friction without imposing creative direction.
 
-Muse exists to reduce friction: to surface the right control, complete the tedious step, translate an idea into action. It does not impose creative direction. It does not interrupt. It does not require the user to think in AI terms.
-
-The measure of Muse is not capability. The measure of Muse is invisibility — whether the user felt helped or handled.
+The measure of Muse is invisibility — whether the user felt helped or handled.
 
 **Non-negotiable rules:**
 - No modal AI dialogs.
 - No "AI mode" toggle.
 - Every suggestion can be dismissed with a single keystroke or click, and the system remembers that preference per context.
-
----
-
-## AI Agent Doctrine
-
-*For agents contributing to Aestra.*
-
-Agents should:
-- Prioritize realtime safety above all else
-- Prefer architectural clarity over hacks
-- Preserve workflow simplicity
-- Reduce cognitive load wherever possible
-- Avoid unnecessary abstraction
-- Prefer deterministic behavior
-- Optimize for responsiveness
-- Reject feature bloat
-- Question any addition that conflicts with this document
-
-Agents should explicitly flag:
-- RT violations
-- Unnecessary allocations
-- Lock contention
-- UX inconsistency
-- Visual clutter
-- Architectural drift
-- Configuration overload
-- Hidden complexity
-- Non-coherent interaction patterns
-
-When in doubt: does this serve the producer on a 4 GB laptop at midnight trying to finish something? If not, reconsider.
-
----
-
-## Changelog
-
-| Version | Date | Notes |
-|---------|------|-------|
-| 1.0 | 2026-05-19 | Initial release |
 
 ---
 

--- a/philosophy.md
+++ b/philosophy.md
@@ -52,7 +52,7 @@ Visual design is cognitive design. Beauty shapes emotion, focus, fatigue, and tr
 
 **We care about:** visual clarity, motion with meaning, hierarchy and readability, coherent interaction language.
 
-**We do not care about:** visual noise, flashy motion for its own sake, gamer UI, clutter, inconsistent interaction patterns. Aestra must not feel enterprise-ey, hostile to beginners, or creatively interruptive.
+**We do not care about:** visual noise, flashy motion for its own sake, gamer UI, clutter, inconsistent interaction patterns. Aestra must not feel enterprise-y, hostile to beginners, or creatively interruptive.
 
 ---
 


### PR DESCRIPTION
## Summary

Removed ~200 lines of redundant, duplicative, or stale content from AGENTS.md and philosophy.md.

### AGENTS.md (829→633 lines)

**Full sections removed:**
- §25 Known Framework Debt (resolved bug postmortem)
- §26 DO / §26 DON'T (every item stated elsewhere)
- §23 Agent Decision Rules (Prefer/Avoid list restated from other sections)
- §24 Public Roadmap (overlapped with §17 Documentation Rules)

**Subsections/lines removed:**
- §21 Commits + Branch Protection + line 582 (all dupe §2/§3)
- §1 tool name list (6 lines → 1 umbrella line) + line 25 (triplicated with §17/§24)
- §3 line 73 (destructive git ops — dupe of §2)
- §9 Include Layout (directory listing — `ls` provides this)
- §15 Recommended check (`git status --short` — dupe of §3)
- §24 intro paragraph + "What Agents May Do"
- Various one-liner filler throughout

**Renumbered** to close gaps.

### philosophy.md (261→119 lines)

**Removed:**
- AI Agent Doctrine (circular reference — AGENTS.md says read philosophy.md, philosophy.md said read AGENTS.md rules)
- Anti-Values (every item already in Three Pillars "We do not care about" lists)
- Changelog (stale, one entry)
- Version stamp

**Compressed:**
- Three Pillars "We care about" synonym lists (6-7 items → 3-4)
- On Trust elaboration
- Engineering Doctrine explanations
- Who We Build For justification paragraph

### Validation
- `git diff` reviewed — only two files touched, no collateral changes
- No serialization, UI, DSP, build, or CI changes
- AGENTS.md link to philosophy.md still valid

### Risk Notes
- None. Policy content preserved, only duplication/editorializing removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Cleanup and Debloating of Documentation Files

**No breaking changes.** These are purely documentation updates with no functional impact.

### AGENTS.md
- **Removed redundant and stale sections:** Known Framework Debt, DO/DON'T guide, Agent Decision Rules, and Public Roadmap sections eliminated
- **Condensed policy statements:** Simplified the agent/tool applicability language and removed duplicative guidance (e.g., "never claim all green" admonition, destructive Git operations prohibition that was already stated elsewhere)
- **Trimmed scattered guidance:** Removed uncertainty-handling advice, project-persistence validations, and other standalone editorial notes
- **Restructured and renumbered:** Reframed around PR handling and versioning; removed dated branch protection guidance and introductory prose
- **Preserved critical content:** Policy rules and links to philosophy.md remain intact
- **Line reduction:** 829 → 633 lines

### philosophy.md
- **Removed stale/circular sections:** Deleted AI Agent Doctrine (circular reference) and Changelog; removed version timestamp
- **Compressed without losing substance:** Tightened Three Pillars, Engineering Doctrine, and On Trust sections to use directive "We care about / We do not care about" statements instead of verbose prose
- **Streamlined accessibility discussion:** Removed lengthy justification paragraph about performance/accessibility tradeoffs in "Who We Build For"
- **Refined On Muse description:** Added clarification that Muse reduces friction without imposing creative direction; removed surrounding explanatory text
- **Line reduction:** 261 → 119 lines

### Rationale
Both files contained redundant content, duplicative rules, stale versioning info, and editorial bloat that distracted from core policies and philosophy. Consolidation improves maintainability without sacrificing policy substance or breaking any documented commitments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->