### PR TITLE
fix(AestraComp): raise FFT display floor to -48 dB with data-driven axis labels

### DIFF
--- a/AestraAudio/include/Plugin/AestraComp.h
+++ b/AestraAudio/include/Plugin/AestraComp.h
@@ -32,6 +32,7 @@ public:
         while (n > 1) { n >>= 1; ++s; }
         return s;
     }(); // log2(2048) = 11
+    static constexpr float kFftDisplayMinDb = -48.0f;
 
     struct FftSpectrum {
         float inputBins[kFftBins]{};

--- a/AestraUI/Widgets/AestraCompEditor.cpp
+++ b/AestraUI/Widgets/AestraCompEditor.cpp
@@ -273,10 +273,11 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     renderer.drawLine({b.x + 6.0f, b.y + 1.0f}, {b.x + b.width - 6.0f, b.y + 1.0f},
                       1.0f, NUIColor(1, 1, 1, 0.06f));
 
-    // Spectrum analyzer — log frequency axis, -90 to 0 dB
+    // Spectrum analyzer — log frequency axis, kFftDisplayMinDb to 0 dB
     {
-        constexpr float kMinDb = -90.0f;
-        constexpr float kDbRange = 90.0f;
+        using Comp = Aestra::Audio::Plugins::AestraComp;
+        constexpr float kMinDb = Comp::kFftDisplayMinDb;
+        constexpr float kDbRange = -Comp::kFftDisplayMinDb;
         const int numCols = std::min(static_cast<int>(curveW), kMaxCurvePixels);
         if (numCols > 0) {
             m_numSpectrumPts = numCols + 1;
@@ -355,7 +356,10 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     renderer.drawText(kneeBuf, {statsX + 6.0f, b.y + 108.0f}, 14.0f, NUIColor(1, 1, 1, 0.88f));
 
     // Axis labels
-    renderer.drawText("-60", {b.x + 4.0f, curveBottom - 6.0f}, 7.0f, dimText());
+    char axisBottom[16]{};
+    std::snprintf(axisBottom, sizeof(axisBottom), "%.0f",
+                  static_cast<double>(Aestra::Audio::Plugins::AestraComp::kFftDisplayMinDb));
+    renderer.drawText(axisBottom, {b.x + 4.0f, curveBottom - 6.0f}, 7.0f, dimText());
     renderer.drawText("0 dB", {b.x + 6.0f, curveTop + 2.0f}, 7.0f, dimText());
 
     // 1:1 reference line
@@ -368,12 +372,14 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
 
     // Build transfer curve path
     constexpr int kCurveSteps = 128;
+    constexpr float kDbFloor = Aestra::Audio::Plugins::AestraComp::kFftDisplayMinDb;
+    constexpr float kDbRange = -kDbFloor;
     for (int i = 0; i <= kCurveSteps; ++i) {
         const float t = static_cast<float>(i) / static_cast<float>(kCurveSteps);
-        const float inputDb = -60.0f + t * 60.0f;
+        const float inputDb = kDbFloor + t * kDbRange;
         const float outputDb = compTransferDb(inputDb, thrDb, ratio, kneeDb);
         const float x = curveLeft + t * curveW;
-        const float yNorm = std::clamp((outputDb + 60.0f) / 60.0f, 0.0f, 1.0f);
+        const float yNorm = std::clamp((outputDb - kDbFloor) / kDbRange, 0.0f, 1.0f);
         const float y = curveBottom - yNorm * curveH;
         m_curvePts[i] = {x, y};
     }
@@ -385,7 +391,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     // Knee point
     const float kneeX = thrX;
     const float kneeOutDb = compTransferDb(thrDb, thrDb, ratio, kneeDb);
-    const float kneeYNorm = std::clamp((kneeOutDb + 60.0f) / 60.0f, 0.0f, 1.0f);
+    const float kneeYNorm = std::clamp((kneeOutDb - kDbFloor) / kDbRange, 0.0f, 1.0f);
     const float kneeY = curveBottom - kneeYNorm * curveH;
     renderer.fillCircle({kneeX, kneeY}, 4.0f, accent);
     char kneeLabelBuf[16]{};


### PR DESCRIPTION
## Summary

Adds a named kFftDisplayMinDb constant and raises the spectrum/transfer-curve display floor from -90 dB to -48 dB, making the analyzer more useful for typical compression ranges.

## Changes

- **`AestraComp.h`**: Added `static constexpr float kFftDisplayMinDb = -48.0f` alongside existing FFT constants.
- **`AestraCompEditor.cpp`**: 
  - Spectrum analyzer range now derives from `kFftDisplayMinDb` (was hardcoded -90 dB).
  - Transfer curve range and knee-point normalization now derive from the same constant.
  - Y-axis bottom label is now data-driven from the constant instead of hardcoded.

## Testing

- Build: clean (no warnings)
- Tests: all 3 AestraComp tests pass (Phase0, Phase1, MaterialLab)

## Risk Notes

- Changes the vertical range of the spectrum + transfer curve display from [-90, 0] dB to [-48, 0] dB.
- No DSP or parameter mapping changes -- display only.
- No serialization or project format changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What changed:**
- Added a new constant `kFftDisplayMinDb = -48.0f` to establish a configurable FFT display floor, replacing previously hardcoded display limits.
- Updated the spectrum analyzer's vertical range from [-90, 0] dB to [-48, 0] dB, raising the display floor by 42 dB.
- Modified the transfer-curve visualization to derive its scaling from the new FFT display floor, ensuring the display curves align consistently.
- Automatically generate the Y-axis bottom label based on `kFftDisplayMinDb` instead of using a hardcoded value.

**Why:**
This change improves the visibility and detail of the FFT display by focusing on a more perceptually relevant range, while maintaining internal consistency across all visualization elements.

**Impact:**
- Display-only change; no impact to DSP processing, parameter mapping, serialization, or project format.
- All existing tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->