### PR TITLE
feat(AestraLimit): brickwall limiter + AestraComp FFT floor fix

### DIFF
--- a/AestraAudio/include/Plugin/AestraLimit.h
+++ b/AestraAudio/include/Plugin/AestraLimit.h
@@ -1,0 +1,471 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraLimit V1 — musical brickwall limiter with density-driven auto-release.
+//
+// OPTFLOOR: AestraLimit 2026-06-11
+// CPU: ~100 cycles/sample @ 48 kHz, 512-sample buffer
+//   Breakdown: log10 ~20c, exp (gain) ~20c, exp (release) ~20c, upsample 4x ~16c, misc ~24c
+// Memory: 3.5 KB hot working set per instance (840 bytes L1-active at 48 kHz)
+// Cache: fits in L1 at any instance count; fits in L2 up to 300+ instances
+// Transcendental floor: log10 and exp are accuracy-critical for gain computation;
+//   replacing with approximations introduces > 0.1 dB error — unacceptable for brickwall limiting.
+// SIMD: N/A — lookahead is a circular buffer (write 1, read 1), not a batch scan.
+//   4-sample peak detection loop is below SIMD threshold.
+// Denormals: handled by engine-level FTZ+DAZ. EMA state zeroed on reset/bypass.
+// Next review: when sample rate exceeds 192 kHz or lookahead exceeds 2 ms.
+
+#pragma once
+
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace Plugins {
+
+class AestraLimit : public IPluginInstance {
+public:
+    static constexpr uint32_t kStateMagic = 0x4C4D5431; // 'LMT1'
+
+    static constexpr float kLookaheadMs = 2.0f;
+    static constexpr float kCeilingMarginDb = 0.1f;
+    static constexpr uint32_t kOsRatio = 4;
+    static constexpr uint32_t kOsTapsPerPhase = 4;
+    static constexpr uint32_t kMaxLookaheadSamples = 400;
+
+    enum Param : uint32_t {
+        kCeiling = 0,    // -24 to 0 dBTP
+        kReleaseMode,    // 0=Auto, 1=Manual
+        kRelease,        // 10 to 500 ms (manual only)
+        kBypass,
+        kParamCount,
+    };
+
+    AestraLimit() = default;
+
+    bool initialize(double sampleRate, uint32_t maxBlockSize) override {
+        m_sampleRate = std::max(1.0, sampleRate);
+        m_maxBlockSize = maxBlockSize;
+        for (const auto& param : getParameters()) {
+            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        }
+        resetRuntimeState();
+        snapSmoothedParams();
+        updateLookaheadSize();
+        return true;
+    }
+
+    void shutdown() override {}
+
+    void activate() override {
+        m_active.store(true, std::memory_order_relaxed);
+        resetRuntimeState();
+        snapSmoothedParams();
+        updateLookaheadSize();
+    }
+
+    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
+    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+
+    void process(const float* const* inputs, float** outputs,
+                 uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* midiInput = nullptr,
+                 MidiBuffer* midiOutput = nullptr) override {
+        (void)midiInput;
+        (void)midiOutput;
+
+        if (!m_active.load(std::memory_order_relaxed) ||
+            m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            return;
+        }
+
+        const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
+        const bool stereo = channels >= 2;
+
+        // Cache per-block constants (avoids repeated atomic loads and transcendental calls)
+        const bool autoRelease = m_params[kReleaseMode].load(std::memory_order_relaxed) <= 0.5f;
+        const float clipLevel = m_clipLevel;
+
+        float blockInputPeak = 0.0f;
+        float blockOutputPeak = 0.0f;
+
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i));
+            const float inR = stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL;
+
+            // Update smoothed params
+            const float targetCeil = getParameter(kCeiling);
+            const float targetRel = getParameter(kRelease);
+            m_ceilingSmoothed += (targetCeil - m_ceilingSmoothed) * m_smoothCoeff;
+            m_releaseSmoothed += (targetRel - m_releaseSmoothed) * m_smoothCoeff;
+            if (autoRelease)
+                computeAutoReleaseMs();
+
+            // --- True Peak Detection (per channel, 4x oversample) ---
+            float osValsL[kOsRatio];
+            upsampleOs(m_tpUpsampleL, inL, osValsL);
+            float peakL = 0.0f;
+            for (uint32_t p = 0; p < kOsRatio; ++p)
+                peakL = std::max(peakL, std::abs(osValsL[p]));
+
+            float blockPeak = peakL;
+            if (stereo) {
+                float osValsR[kOsRatio];
+                upsampleOs(m_tpUpsampleR, inR, osValsR);
+                float peakR = 0.0f;
+                for (uint32_t p = 0; p < kOsRatio; ++p)
+                    peakR = std::max(peakR, std::abs(osValsR[p]));
+                blockPeak = std::max(peakL, peakR);
+            }
+
+            // --- Density Analysis (mono sum) ---
+            const float monoSum = (inL + inR) * 0.5f;
+            updateDensity(monoSum);
+
+            // --- Lookahead Write ---
+            m_lookaheadBuf[0][m_writeCursor] = inL;
+            if (stereo)
+                m_lookaheadBuf[1][m_writeCursor] = inR;
+            m_writeCursor = (m_writeCursor + 1) % m_lookaheadSize;
+
+            // --- Gain Computer ---
+            const float peakDbTP = linearToDb(blockPeak);
+            const float userCeilingDb = ceilingDbFromNorm(m_ceilingSmoothed);
+            const float internalCeilingDb = userCeilingDb - kCeilingMarginDb;
+
+            float targetGainDb;
+            if (peakDbTP > userCeilingDb) {
+                targetGainDb = internalCeilingDb - peakDbTP;
+            } else {
+                targetGainDb = 0.0f;
+            }
+
+            // --- Release Smoother ---
+            if (targetGainDb < m_appliedGainDb) {
+                m_appliedGainDb = targetGainDb;
+            } else {
+                const float releaseMs = autoRelease
+                    ? m_autoReleaseMs
+                    : releaseMsFromNorm(m_params[kRelease].load(std::memory_order_relaxed));
+                const float releaseCoeff = std::exp(-m_oneOverSampleRateMs / releaseMs);
+                m_appliedGainDb = releaseCoeff * m_appliedGainDb
+                                  + (1.0f - releaseCoeff) * targetGainDb;
+            }
+
+            // --- Lookahead Read ---
+            const uint32_t readOffset = (m_writeCursor + m_lookaheadSize - m_lookaheadSamples) % m_lookaheadSize;
+            const float delayedL = m_lookaheadBuf[0][readOffset];
+            const float delayedR = stereo ? m_lookaheadBuf[1][readOffset] : delayedL;
+
+            // --- VCA ---
+            const float gainLinear = dbToLinear(m_appliedGainDb);
+            const float vcaOutL = delayedL * gainLinear;
+            const float vcaOutR = delayedR * gainLinear;
+
+            // --- Output Safety Clip ---
+            const float outL = std::clamp(vcaOutL, -clipLevel, clipLevel);
+            const float outR = stereo ? std::clamp(vcaOutR, -clipLevel, clipLevel) : outL;
+
+            blockInputPeak = std::max(blockInputPeak, blockPeak);
+            blockOutputPeak = std::max(blockOutputPeak, std::max(std::abs(outL), std::abs(outR)));
+
+            if (numOutputChannels > 0 && outputs[0]) outputs[0][i] = outL;
+            if (numOutputChannels > 1 && outputs[1]) outputs[1][i] = outR;
+            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                if (outputs[ch]) outputs[ch][i] = 0.0f;
+            }
+        }
+
+        m_inputLevel.store(blockInputPeak, std::memory_order_relaxed);
+        m_outputLevel.store(blockOutputPeak, std::memory_order_relaxed);
+        m_gainReduction.store(std::max(0.0f, -m_appliedGainDb), std::memory_order_relaxed);
+    }
+
+    uint32_t getParameterCount() const override { return kParamCount; }
+
+    float getParameter(uint32_t id) const override {
+        if (id >= kParamCount) return 0.0f;
+        return m_params[id].load(std::memory_order_relaxed);
+    }
+
+    void setParameter(uint32_t id, float value) override {
+        if (id >= kParamCount) return;
+        m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    std::vector<PluginParameter> getParameters() const override {
+        return {
+            { kCeiling, "Ceiling", "CEIL", "dBTP", 0.9958f, 0.0f, 1.0f, true },
+            { kReleaseMode, "Release Mode", "RM", "", 0.0f, 0.0f, 1.0f, true, false, false, 1 },
+            { kRelease, "Release", "REL", "ms", 0.1837f, 0.0f, 1.0f, true },
+            { kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1 },
+        };
+    }
+
+    std::string getParameterDisplay(uint32_t id) const override {
+        if (id >= kParamCount) return "";
+        const float v = getParameter(id);
+        switch (id) {
+        case kCeiling: return formatDb(ceilingDbFromNorm(v));
+        case kReleaseMode: return v > 0.5f ? "Manual" : "Auto";
+        case kRelease: return formatMs(releaseMsFromNorm(v));
+        case kBypass: return v > 0.5f ? "ON" : "OFF";
+        default: return "";
+        }
+    }
+
+    std::vector<uint8_t> saveState() const override {
+        struct Blob {
+            uint32_t magic = kStateMagic;
+            uint32_t version = 1;
+            float params[kParamCount] = {};
+        } blob;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            blob.params[i] = getParameter(i);
+        }
+        const auto* data = reinterpret_cast<const uint8_t*>(&blob);
+        return { data, data + sizeof(blob) };
+    }
+
+    bool loadState(const std::vector<uint8_t>& state) override {
+        if (state.size() < sizeof(uint32_t) * 2) return false;
+        uint32_t magic = 0;
+        std::memcpy(&magic, state.data(), sizeof(magic));
+        if (magic != kStateMagic) return false;
+        if (state.size() < sizeof(uint32_t) * 2 + sizeof(float) * kParamCount) return false;
+        struct Blob {
+            uint32_t magic;
+            uint32_t version;
+            float params[kParamCount];
+        };
+        Blob blob{};
+        std::memcpy(&blob, state.data(), sizeof(blob));
+        (void)blob.version;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            setParameter(i, blob.params[i]);
+        }
+        return true;
+    }
+
+    bool hasEditor() const override { return true; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {520, 400}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override {
+        return static_cast<uint32_t>(std::ceil(kLookaheadMs * m_sampleRate * 0.001));
+    }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+    void setInfo(const PluginInfo& info) { m_info = info; }
+
+    // Metering
+    float getGainReductionDb() const { return m_gainReduction.load(std::memory_order_relaxed); }
+    float getInputLevel() const { return m_inputLevel.load(std::memory_order_relaxed); }
+    float getOutputLevel() const { return m_outputLevel.load(std::memory_order_relaxed); }
+
+private:
+    // ── OS Coefficients: 4-point Lagrange interpolation at 4x ──
+    static constexpr float kOsCoeffs[kOsRatio * kOsTapsPerPhase] = {
+        // Phase 0 (f=0.0)
+        0.0f, 1.0f, 0.0f, 0.0f,
+        // Phase 1 (f=0.25)
+        -0.0546875f, 0.8203125f, 0.2734375f, -0.0390625f,
+        // Phase 2 (f=0.5)
+        -0.0625f, 0.5625f, 0.5625f, -0.0625f,
+        // Phase 3 (f=0.75)
+        -0.0390625f, 0.2734375f, 0.8203125f, -0.0546875f,
+    };
+
+    struct UpsampleState {
+        float hist[kOsTapsPerPhase]{};
+    };
+
+    static void upsampleOs(UpsampleState& st, float input, float* output) {
+        for (int32_t i = kOsTapsPerPhase - 1; i > 0; --i)
+            st.hist[i] = st.hist[i - 1];
+        st.hist[0] = input;
+
+        for (uint32_t p = 0; p < kOsRatio; ++p) {
+            float sum = 0.0f;
+            const float* phaseCoeffs = &kOsCoeffs[p * kOsTapsPerPhase];
+            for (uint32_t t = 0; t < kOsTapsPerPhase; ++t) {
+                sum += phaseCoeffs[t] * st.hist[t];
+            }
+            output[p] = sum;
+        }
+    }
+
+    void updateDensity(float monoSum) {
+        const float inputSq = monoSum * monoSum;
+        m_shortEma = inputSq + m_alphaShort * (m_shortEma - inputSq);
+        m_longEma  = inputSq + m_alphaLong  * (m_longEma  - inputSq);
+    }
+
+    void computeAutoReleaseMs() {
+        const float density = (m_longEma > 1e-10f) ? (m_shortEma / m_longEma) : 0.0f;
+
+        static constexpr float kDenseThresh  = 0.7f;
+        static constexpr float kSparseThresh = 0.3f;
+        static constexpr float kReleaseMaxMs = 300.0f;
+        static constexpr float kReleaseMinMs = 60.0f;
+
+        if (density >= kDenseThresh) {
+            m_autoReleaseMs = kReleaseMaxMs;
+        } else if (density <= kSparseThresh) {
+            m_autoReleaseMs = kReleaseMinMs;
+        } else {
+            const float t = (density - kSparseThresh) / (kDenseThresh - kSparseThresh);
+            m_autoReleaseMs = kReleaseMinMs + t * (kReleaseMaxMs - kReleaseMinMs);
+        }
+    }
+
+    void updateLookaheadSize() {
+        const uint32_t newSize = std::max(1u, static_cast<uint32_t>(
+            std::ceil(kLookaheadMs * 0.001 * m_sampleRate)));
+        if (newSize != m_lookaheadSize) {
+            m_lookaheadSize = newSize;
+            m_lookaheadSamples = newSize;
+            std::fill_n(m_lookaheadBuf[0].begin(), m_lookaheadSize, 0.0f);
+            std::fill_n(m_lookaheadBuf[1].begin(), m_lookaheadSize, 0.0f);
+            m_writeCursor = 0;
+        }
+    }
+
+    void resetRuntimeState() {
+        m_tpUpsampleL = {};
+        m_tpUpsampleR = {};
+        m_shortEma = 0.0f;
+        m_longEma = 0.0f;
+        const float sr = static_cast<float>(m_sampleRate);
+        m_alphaShort = 1.0f - std::exp(-1.0f / (0.050f * sr));
+        m_alphaLong  = 1.0f - std::exp(-1.0f / (0.300f * sr));
+        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        m_oneOverSampleRateMs = 1.0f / (0.001f * sr);
+        m_clipLevel = dbToLinear(-kCeilingMarginDb);
+        m_appliedGainDb = 0.0f;
+        m_autoReleaseMs = 100.0f;
+        m_writeCursor = 0;
+        std::fill_n(m_lookaheadBuf[0].begin(), m_lookaheadSize, 0.0f);
+        std::fill_n(m_lookaheadBuf[1].begin(), m_lookaheadSize, 0.0f);
+        m_gainReduction.store(0.0f, std::memory_order_relaxed);
+        m_inputLevel.store(0.0f, std::memory_order_relaxed);
+        m_outputLevel.store(0.0f, std::memory_order_relaxed);
+    }
+
+    void snapSmoothedParams() {
+        m_ceilingSmoothed = getParameter(kCeiling);
+        m_releaseSmoothed = getParameter(kRelease);
+    }
+
+    // ── Parameter mapping ──
+    static float ceilingDbFromNorm(float value) {
+        return -24.0f + std::clamp(value, 0.0f, 1.0f) * 24.0f;
+    }
+
+    static float releaseMsFromNorm(float value) {
+        return 10.0f + std::clamp(value, 0.0f, 1.0f) * 490.0f;
+    }
+
+    // ── Utility ──
+    static void copyOrClear(const float* const* inputs, float** outputs,
+                            uint32_t numInputChannels, uint32_t numOutputChannels,
+                            uint32_t numFrames) {
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
+    static float readInput(const float* const* inputs, uint32_t channels, uint32_t channel, uint32_t frame) {
+        if (channel >= channels || !inputs[channel]) return 0.0f;
+        return inputs[channel][frame];
+    }
+
+    static float sanitizeSample(float sample) {
+        if (!std::isfinite(sample)) return 0.0f;
+        return std::clamp(sample, -16.0f, 16.0f);
+    }
+
+    static float linearToDb(float linear) {
+        if (!std::isfinite(linear) || linear <= 1.0e-12f) return -120.0f;
+        return std::max(-120.0f, 20.0f * std::log10(linear));
+    }
+
+    static float dbToLinear(float db) {
+        return std::exp(db * 0.11512925464970229f);
+    }
+
+    static std::string formatDb(float db) {
+        const int rounded = static_cast<int>(std::round(db * 10.0f));
+        if (rounded >= 0) return "0.0dB";
+        return "-" + std::to_string((-rounded) / 10) + "." + std::to_string((-rounded) % 10) + "dB";
+    }
+
+    static std::string formatMs(float ms) {
+        return std::to_string(static_cast<int>(std::round(ms))) + "ms";
+    }
+
+    // ── State ──
+    PluginInfo m_info;
+    double m_sampleRate = 48000.0;
+    uint32_t m_maxBlockSize = 512;
+    std::atomic<bool> m_active{false};
+    std::array<std::atomic<float>, kParamCount> m_params{};
+
+    // Oversampler states
+    UpsampleState m_tpUpsampleL;
+    UpsampleState m_tpUpsampleR;
+
+    // Lookahead buffer (fixed-size, no heap allocation)
+    std::array<std::array<float, kMaxLookaheadSamples>, 2> m_lookaheadBuf{};
+    uint32_t m_lookaheadSize = 0;
+    uint32_t m_lookaheadSamples = 0;
+    uint32_t m_writeCursor = 0;
+
+    // Density analysis
+    float m_shortEma = 0.0f;
+    float m_longEma = 0.0f;
+    float m_alphaShort = 0.0f;
+    float m_alphaLong = 0.0f;
+    float m_autoReleaseMs = 100.0f;
+
+    // Precomputed constants (set once in resetRuntimeState)
+    float m_smoothCoeff = 0.0f;
+    float m_oneOverSampleRateMs = 0.0f;
+    float m_clipLevel = 0.0f;
+
+    // Gain smoothing
+    float m_appliedGainDb = 0.0f;
+
+    // Smoothed parameters
+    float m_ceilingSmoothed = 0.9958f;
+    float m_releaseSmoothed = 0.1837f;
+
+    // Metering
+    std::atomic<float> m_gainReduction{0.0f};
+    std::atomic<float> m_inputLevel{0.0f};
+    std::atomic<float> m_outputLevel{0.0f};
+};
+
+} // namespace Plugins
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/AestraLimit.h
+++ b/AestraAudio/include/Plugin/AestraLimit.h
@@ -154,7 +154,7 @@ public:
             } else {
                 const float releaseMs = autoRelease
                     ? m_autoReleaseMs
-                    : releaseMsFromNorm(m_params[kRelease].load(std::memory_order_relaxed));
+                    : releaseMsFromNorm(m_releaseSmoothed);
                 const float releaseCoeff = std::exp(-m_oneOverSampleRateMs / releaseMs);
                 m_appliedGainDb = releaseCoeff * m_appliedGainDb
                                   + (1.0f - releaseCoeff) * targetGainDb;
@@ -248,7 +248,7 @@ public:
         };
         Blob blob{};
         std::memcpy(&blob, state.data(), sizeof(blob));
-        (void)blob.version;
+        if (blob.version < 1 || blob.version > 1) return false;
         for (uint32_t i = 0; i < kParamCount; ++i) {
             setParameter(i, blob.params[i]);
         }
@@ -313,8 +313,8 @@ private:
 
     void updateDensity(float monoSum) {
         const float inputSq = monoSum * monoSum;
-        m_shortEma = inputSq + m_alphaShort * (m_shortEma - inputSq);
-        m_longEma  = inputSq + m_alphaLong  * (m_longEma  - inputSq);
+        m_shortEma = m_alphaShort * inputSq + (1.0f - m_alphaShort) * m_shortEma;
+        m_longEma  = m_alphaLong  * inputSq + (1.0f - m_alphaLong)  * m_longEma;
     }
 
     void computeAutoReleaseMs() {
@@ -336,8 +336,8 @@ private:
     }
 
     void updateLookaheadSize() {
-        const uint32_t newSize = std::max(1u, static_cast<uint32_t>(
-            std::ceil(kLookaheadMs * 0.001 * m_sampleRate)));
+        const uint32_t newSize = std::max(1u, std::min(kMaxLookaheadSamples,
+            static_cast<uint32_t>(std::ceil(kLookaheadMs * 0.001 * m_sampleRate))));
         if (newSize != m_lookaheadSize) {
             m_lookaheadSize = newSize;
             m_lookaheadSamples = newSize;

--- a/AestraAudio/include/Plugin/AestraLimit.h
+++ b/AestraAudio/include/Plugin/AestraLimit.h
@@ -264,7 +264,7 @@ public:
 
     const PluginInfo& getInfo() const override { return m_info; }
     uint32_t getLatencySamples() const override {
-        return static_cast<uint32_t>(std::ceil(kLookaheadMs * m_sampleRate * 0.001));
+        return m_lookaheadSamples;
     }
     uint32_t getTailSamples() const override { return 0; }
     WatchdogStats getWatchdogStats() const override { return {}; }

--- a/AestraAudio/include/Plugin/BuiltInPlugins.h
+++ b/AestraAudio/include/Plugin/BuiltInPlugins.h
@@ -15,6 +15,7 @@ const PluginInfo& compInfo();
 const PluginInfo& verbInfo();
 const PluginInfo& delayInfo();
 const PluginInfo& driftInfo();
+const PluginInfo& limiterInfo();
 void registerCoreBuiltIns();
 std::vector<PluginInfo> all();
 }

--- a/AestraAudio/src/Plugin/BuiltInPlugins.cpp
+++ b/AestraAudio/src/Plugin/BuiltInPlugins.cpp
@@ -9,6 +9,7 @@
 #include "Plugin/AestraVerb.h"
 #include "Plugin/AestraDelay.h"
 #include "Plugin/AestraDrift.h"
+#include "Plugin/AestraLimit.h"
 
 #include <mutex>
 
@@ -136,6 +137,26 @@ const PluginInfo& driftInfo() {
     return info;
 }
 
+const PluginInfo& limiterInfo() {
+    static const PluginInfo info = [] {
+        PluginInfo p;
+        p.id = "com.Aestrastudios.limiter";
+        p.name = "Aestra Limit";
+        p.vendor = "Aestra Studios";
+        p.version = "0.1.0";
+        p.category = "Dynamics";
+        p.format = PluginFormat::Internal;
+        p.type = PluginType::Effect;
+        p.numAudioInputs = 2;
+        p.numAudioOutputs = 2;
+        p.hasMidiInput = false;
+        p.hasMidiOutput = false;
+        p.hasEditor = true;
+        return p;
+    }();
+    return info;
+}
+
 namespace {
 void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
     if (!instance) {
@@ -156,6 +177,8 @@ void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
         delay->setInfo(info);
     } else if (auto drift = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraDrift>(instance)) {
         drift->setInfo(info);
+    } else if (auto limit = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLimit>(instance)) {
+        limit->setInfo(info);
     }
 }
 
@@ -183,6 +206,7 @@ void registerCoreBuiltIns() {
         registry.registerPlugin(makeRegistration<Plugins::AestraVerb>(verbInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraDelay>(delayInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraDrift>(driftInfo()));
+        registry.registerPlugin(makeRegistration<Plugins::AestraLimit>(limiterInfo()));
     });
 }
 

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -147,6 +147,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/AestraDelayEditor.cpp
     Widgets/AestraDriftEditor.h
     Widgets/AestraDriftEditor.cpp
+    Widgets/AestraLimitEditor.h
+    Widgets/AestraLimitEditor.cpp
 )
 
 if(AESTRAUI_ENABLE_PREMIUM_EDITORS)

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -1,0 +1,455 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AestraLimitEditor.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "Plugin/AestraLimit.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+
+namespace AestraUI {
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+NUIColor accentColor() { return NUIColor(0.95f, 0.60f, 0.12f, 1.0f); }
+NUIColor bgDark() { return NUIColor(0.018f, 0.020f, 0.024f, 0.96f); }
+NUIColor textDim() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
+NUIColor textBright() { return NUIColor(1.0f, 1.0f, 1.0f, 0.88f); }
+NUIColor meterBg() { return NUIColor(0.008f, 0.008f, 0.012f, 1.0f); }
+
+float smoothMeter(float current, float target, float attack, float release) {
+    const float coeff = target > current ? attack : release;
+    return current + (target - current) * coeff;
+}
+
+float levelToNorm(float linear) {
+    const float db = linear > 1.0e-8f ? 20.0f * std::log10(linear) : -60.0f;
+    return std::clamp((db + 60.0f) / 66.0f, 0.0f, 1.0f);
+}
+} // namespace
+
+AestraLimitEditor::AestraLimitEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance)
+    : m_instance(std::move(instance)) {
+    setId("AestraLimitEditor");
+    setPanelTitle("Aestra Limit");
+    setSize(kWinW, kWinH);
+    setEnforceParentBounds(true);
+
+    buildControls();
+}
+
+void AestraLimitEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
+    AestraPanelWindow::setPlatformBridge(bridge);
+    for (auto& control : m_controls) {
+        if (control.slider) control.slider->setPlatformBridge(bridge);
+    }
+}
+
+void AestraLimitEditor::buildControls() {
+    m_controls.clear();
+    if (!m_instance) return;
+
+    using Limit = Aestra::Audio::Plugins::AestraLimit;
+    struct Meta { const char* label; uint32_t id; bool primary; };
+    const Meta controls[] = {
+        {"Ceiling", Limit::kCeiling, true},
+        {"Release", Limit::kRelease, false},
+    };
+
+    for (const auto& item : controls) {
+        KnobControl control;
+        control.label = item.label;
+        control.paramId = item.id;
+        control.isPrimary = item.primary;
+
+        auto slider = std::make_shared<NUISlider>();
+        slider->setStyle(NUISlider::Style::Rotary);
+        slider->setRange(0.0, 1.0);
+        slider->setValue(std::clamp(m_instance->getParameter(item.id), 0.0f, 1.0f));
+        slider->setPlatformBridge(getPlatformBridge());
+        slider->setOnValueChange([this, paramId = item.id](double value) {
+            if (m_instance) {
+                m_instance->setParameter(paramId, static_cast<float>(std::clamp(value, 0.0, 1.0)));
+                repaint();
+            }
+        });
+
+        control.slider = slider;
+        addChild(slider);
+        m_controls.push_back(control);
+    }
+
+    layoutControls();
+}
+
+void AestraLimitEditor::layoutControls() {
+    auto b = getBounds();
+    if (b.width <= 0.0f || b.height <= 0.0f) {
+        setBounds(b.x, b.y, kWinW, kWinH);
+        b = getBounds();
+    }
+
+    const float cx = b.x + kPad;
+    const float cw = b.width - kPad * 2.0f;
+    const float titleH = AestraPanelWindow::TITLE_BAR_H;
+    const float y0 = b.y + titleH + 8.0f;
+
+    // GR Meter (left 60% of width)
+    const float grW = cw * 0.58f;
+    const float grH = 120.0f;
+    m_grBarRect = NUIRect(cx, y0, grW, grH);
+    m_grLabelRect = NUIRect(cx, y0 + grH + 2.0f, grW, 16.0f);
+
+    // Ceiling knob (right 40%)
+    const float ceilX = cx + grW + 12.0f;
+    const float ceilW = cw - grW - 12.0f;
+    m_ceilingKnobRect = NUIRect(ceilX, y0, ceilW, grH + 18.0f);
+    if (!m_controls.empty() && m_controls[0].slider) {
+        const float knobX = ceilX + (ceilW - kKnobSizePrimary) * 0.5f;
+        const float knobY = y0 + 8.0f;
+        m_controls[0].bounds = NUIRect(ceilX, y0, ceilW, grH + 18.0f);
+        m_controls[0].slider->setBounds(NUIRect(knobX, knobY, kKnobSizePrimary, kKnobSizePrimary));
+    }
+
+    // Bottom row: Release knob, Auto/Manual pill, Bypass
+    const float rowY = m_grLabelRect.bottom() + 14.0f;
+    const float knobW = 80.0f;
+
+    // Release knob (left)
+    m_releaseKnobRect = NUIRect(cx, rowY, knobW, 90.0f);
+    if (m_controls.size() > 1 && m_controls[1].slider) {
+        m_controls[1].bounds = NUIRect(cx, rowY, knobW, 90.0f);
+        const float kx = cx + (knobW - kKnobSizeSecondary) * 0.5f;
+        const float ky = rowY + 12.0f;
+        m_controls[1].slider->setBounds(NUIRect(kx, ky, kKnobSizeSecondary, kKnobSizeSecondary));
+    }
+
+    // Auto/Manual pills (center)
+    const float pillY = rowY + 28.0f;
+    const float pillGap = 6.0f;
+    const float pillX = cx + knobW + 16.0f;
+    m_autoPillRect = NUIRect(pillX, pillY, kPillW, kPillH);
+    m_manualPillRect = NUIRect(pillX + kPillW + pillGap, pillY, kPillW, kPillH);
+
+    // Bypass pill (right of release mode pills)
+    m_bypassPillRect = NUIRect(m_manualPillRect.right() + 16.0f, pillY, kPillW, kPillH);
+
+    // Bottom meter bar: IN / OUT / GR
+    const float meterY = m_releaseKnobRect.bottom() + 10.0f;
+    const float meterH = 26.0f;
+    const float thirdW = (cw - 8.0f) / 3.0f;
+    m_inMeterRect = NUIRect(cx, meterY, thirdW, meterH);
+    m_outMeterRect = NUIRect(cx + thirdW + 4.0f, meterY, thirdW, meterH);
+    m_grNumRect = NUIRect(cx + (thirdW + 4.0f) * 2.0f, meterY, thirdW, meterH);
+}
+
+void AestraLimitEditor::onResize(int width, int height) {
+    (void)width;
+    (void)height;
+    layoutControls();
+    AestraPanelWindow::onResize(width, height);
+}
+
+void AestraLimitEditor::syncControlsFromPlugin() {
+    if (!m_instance) return;
+    for (auto& control : m_controls) {
+        if (control.slider)
+            control.slider->setValue(std::clamp(m_instance->getParameter(control.paramId), 0.0f, 1.0f));
+    }
+}
+
+void AestraLimitEditor::onUpdate(double deltaTime) {
+    AestraPanelWindow::onUpdate(deltaTime);
+    m_meterTimer += deltaTime;
+    if (m_meterTimer < 1.0 / 30.0) return;
+    m_meterTimer = 0.0;
+
+    syncControlsFromPlugin();
+    if (auto limit = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLimit>(m_instance)) {
+        const float gr = std::clamp(limit->getGainReductionDb(), 0.0f, 48.0f);
+        const float in = std::clamp(limit->getInputLevel(), 0.0f, 16.0f);
+        const float out = std::clamp(limit->getOutputLevel(), 0.0f, 16.0f);
+        m_grDisplayDb = smoothMeter(m_grDisplayDb, gr, 0.60f, 0.15f);
+        m_inputDisplay = smoothMeter(m_inputDisplay, in, 0.55f, 0.16f);
+        m_outputDisplay = smoothMeter(m_outputDisplay, out, 0.55f, 0.16f);
+    }
+    repaint();
+}
+
+std::string AestraLimitEditor::valueText(uint32_t paramId) const {
+    if (!m_instance) return {};
+    return m_instance->getParameterDisplay(paramId);
+}
+
+void AestraLimitEditor::drawGrMeter(NUIRenderer& renderer) {
+    const auto& b = m_grBarRect;
+    const NUIColor accent = accentColor();
+
+    // Background
+    renderer.fillRoundedRect(b, 6.0f, meterBg());
+    renderer.strokeRoundedRect(b, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.06f));
+
+    // Fill bar (right-to-left for GR)
+    const float grNorm = std::clamp(m_grDisplayDb / 24.0f, 0.0f, 1.0f);
+    if (grNorm > 0.001f) {
+        const float fillW = b.width * grNorm;
+        const NUIRect fillRect(b.x + b.width - fillW, b.y, fillW, b.height);
+
+        // Gradient: dark amber at low GR, bright yellow-red at high GR
+        NUIColor fillColor = accent;
+        if (grNorm > 0.5f) {
+            fillColor = NUIColor(0.92f, 0.30f, 0.18f, 0.88f);
+        } else if (grNorm > 0.25f) {
+            fillColor = NUIColor(0.95f, 0.60f, 0.12f, 0.88f);
+        }
+        renderer.fillRoundedRect(fillRect, 6.0f, fillColor);
+
+        // Top specular
+        renderer.drawLine({fillRect.x + 4.0f, fillRect.y + 1.0f},
+                          {fillRect.right() - 4.0f, fillRect.y + 1.0f},
+                          1.0f, NUIColor(1, 1, 1, 0.15f));
+    }
+
+    // GR label
+    renderer.drawText("GAIN REDUCTION", {b.x + 10.0f, b.y + 6.0f}, 9.0f, textDim());
+
+    // GR numeric readout
+    char grBuf[32]{};
+    std::snprintf(grBuf, sizeof(grBuf), "-%.1f dB", m_grDisplayDb);
+    const float grTextW = renderer.measureText(grBuf, 28.0f).width;
+    renderer.drawText(grBuf, {b.right() - grTextW - 12.0f, b.y + 6.0f}, 28.0f,
+                      m_grDisplayDb > 6.0f ? NUIColor(0.96f, 0.35f, 0.22f, 0.95f)
+                                           : accent.withAlpha(0.92f));
+
+    // Reduction scale ticks
+    constexpr int kTicks = 6;
+    for (int i = 0; i <= kTicks; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(kTicks);
+        const float x = b.x + t * b.width;
+        const float tickH = (i == 0 || i == kTicks) ? 6.0f : 4.0f;
+        renderer.drawLine({x, b.bottom() - tickH}, {x, b.bottom()}, 1.0f, NUIColor(1, 1, 1, 0.10f));
+
+        if (i < kTicks && i > 0) {
+            char tickBuf[8]{};
+            std::snprintf(tickBuf, sizeof(tickBuf), "%d", static_cast<int>(24.0f * (1.0f - t)));
+            renderer.drawTextCentered(tickBuf, {x - 12.0f, b.bottom() + 2.0f, 24.0f, 12.0f},
+                                      7.0f, textDim());
+        }
+    }
+}
+
+void AestraLimitEditor::drawKnob(NUIRenderer& renderer, const KnobControl& control) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float value = control.slider ? static_cast<float>(control.slider->getValue()) : 0.0f;
+    const NUIColor accent = accentColor();
+    const NUIColor knobAccent = control.isPrimary ? accent : accent.withAlpha(0.72f);
+
+    // Cell background
+    renderer.fillRoundedRect(control.bounds, 8.0f, NUIColor(0.035f, 0.035f, 0.040f, 0.96f));
+    renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f,
+                               control.isPrimary ? NUIColor(0.28f, 0.18f, 0.06f, 1.0f)
+                                                 : NUIColor(0.118f, 0.118f, 0.133f, 1.0f));
+
+    const NUIRect knobRect = control.slider ? control.slider->getBounds() : NUIRect();
+    const float cx = knobRect.center().x;
+    const float cy = knobRect.center().y;
+    const float r = std::min(knobRect.width, knobRect.height) * 0.35f;
+
+    // Glow
+    renderer.fillCircle({cx, cy}, r + 6.0f, knobAccent.withAlpha(0.06f));
+
+    // Body
+    renderer.fillCircle({cx, cy}, r, bgDark());
+    renderer.strokeCircle({cx, cy}, r + 2.5f, 1.5f, NUIColor(1, 1, 1, 0.07f));
+
+    // Arc
+    const float start = kPi * 0.75f;
+    const float sweep = kPi * 1.5f * value;
+    std::array<NUIPoint, 32> arc{};
+    for (size_t i = 0; i < arc.size(); ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(arc.size() - 1);
+        const float a = start + sweep * t;
+        arc[i] = {cx + std::cos(a) * (r + 4.0f), cy + std::sin(a) * (r + 4.0f)};
+    }
+    renderer.drawPolyline(arc.data(), static_cast<int>(arc.size()),
+                          control.isPrimary ? 2.8f : 2.2f, knobAccent.withAlpha(0.90f));
+
+    // Pointer
+    const float pa = start + sweep;
+    const float pointerLen = r - (control.isPrimary ? 4.0f : 3.0f);
+    renderer.drawLine({cx, cy}, {cx + std::cos(pa) * pointerLen, cy + std::sin(pa) * pointerLen},
+                      control.isPrimary ? 1.8f : 1.5f, theme.getColor("textPrimary").withAlpha(0.82f));
+
+    // Label
+    renderer.drawTextCentered(control.label,
+                              {control.bounds.x, control.bounds.y + 4.0f, control.bounds.width, 12.0f},
+                              9.0f, NUIColor(1, 1, 1, 0.50f));
+
+    // Value
+    const float valY = control.isPrimary
+        ? control.bounds.bottom() - 18.0f
+        : knobRect.bottom() + 4.0f;
+    const NUIColor valColor = control.isPrimary
+        ? NUIColor(0.85f, 0.65f, 0.20f, 1.0f)
+        : NUIColor(1, 1, 1, 0.85f);
+    renderer.drawTextCentered(valueText(control.paramId),
+                              {control.bounds.x, valY, control.bounds.width, 14.0f},
+                              11.0f, valColor);
+}
+
+void AestraLimitEditor::drawPill(NUIRenderer& renderer, NUIRect rect,
+                                  bool selected, bool hovered,
+                                  const char* label, NUIColor accent) {
+    if (selected) {
+        renderer.fillRoundedRect({rect.x - 2.0f, rect.y - 2.0f, rect.width + 4.0f, rect.height + 4.0f},
+                                 7.0f, accent.withAlpha(0.12f));
+        renderer.fillRoundedRect(rect, 5.0f, accent.withAlpha(0.75f));
+        renderer.drawLine({rect.x + 5.0f, rect.y + 1.0f},
+                          {rect.x + rect.width - 5.0f, rect.y + 1.0f},
+                          1.0f, NUIColor(1, 1, 1, 0.18f));
+        renderer.strokeRoundedRect(rect, 5.0f, 1.0f, accent);
+        renderer.drawTextCentered(label, rect, 9.5f, NUIColor(1, 1, 1, 0.97f));
+    } else {
+        const NUIColor bg = hovered ? NUIColor(0.04f, 0.04f, 0.048f, 0.90f)
+                                    : NUIColor(0.022f, 0.022f, 0.028f, 0.90f);
+        renderer.fillRoundedRect(rect, 5.0f, bg);
+        renderer.drawLine({rect.x + 5.0f, rect.y + 1.0f},
+                          {rect.x + rect.width - 5.0f, rect.y + 1.0f},
+                          0.5f, NUIColor(0, 0, 0, 0.25f));
+        const NUIColor border = hovered ? NUIColor(1, 1, 1, 0.16f) : NUIColor(1, 1, 1, 0.08f);
+        renderer.strokeRoundedRect(rect, 5.0f, 1.0f, border);
+        renderer.drawTextCentered(label, rect, 9.0f,
+                                  hovered ? NUIColor(1, 1, 1, 0.72f) : NUIColor(1, 1, 1, 0.40f));
+    }
+}
+
+void AestraLimitEditor::drawMeterBar(NUIRenderer& renderer, NUIRect rect,
+                                      float norm, const char* label,
+                                      const char* value, NUIColor color) {
+    renderer.fillRoundedRect(rect, 5.0f, meterBg());
+    renderer.strokeRoundedRect(rect, 5.0f, 1.0f, NUIColor(1, 1, 1, 0.06f));
+
+    if (norm > 0.001f) {
+        renderer.fillRoundedRect({rect.x, rect.y, rect.width * norm, rect.height},
+                                 5.0f, color.withAlpha(0.85f));
+    }
+
+    const float textY = rect.y + (rect.height - 8.0f) * 0.5f;
+    renderer.drawText(label, {rect.x + 8.0f, textY}, 8.0f, textDim());
+
+    const NUISize valSize = renderer.measureText(value, 8.0f);
+    renderer.drawText(value, {rect.right() - valSize.width - 10.0f, textY}, 8.0f, textBright());
+}
+
+void AestraLimitEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    (void)contentRect;
+    auto& theme = NUIThemeManager::getInstance();
+    const NUIColor accent = accentColor();
+
+    // GR Meter
+    drawGrMeter(renderer);
+
+    // Ceiling knob
+    if (!m_controls.empty()) drawKnob(renderer, m_controls[0]);
+
+    // Release knob
+    if (m_controls.size() > 1) drawKnob(renderer, m_controls[1]);
+
+    // Release mode pills
+    const bool autoMode = m_instance &&
+        m_instance->getParameter(Aestra::Audio::Plugins::AestraLimit::kReleaseMode) <= 0.5f;
+    drawPill(renderer, m_autoPillRect, autoMode, m_autoHovered, "AUTO", accent);
+    drawPill(renderer, m_manualPillRect, !autoMode, m_manualHovered, "MANUAL", accent);
+
+    // Bypass pill
+    const bool bypassed = m_instance &&
+        m_instance->getParameter(Aestra::Audio::Plugins::AestraLimit::kBypass) > 0.5f;
+    drawPill(renderer, m_bypassPillRect, bypassed, m_bypassHovered, "BYPASS",
+             NUIColor(0.92f, 0.28f, 0.22f, 1.0f));
+
+    // Bottom meters
+    char inBuf[16]{}, outBuf[16]{}, grBuf[16]{};
+    const float inDb = m_inputDisplay > 1.0e-8f ? 20.0f * std::log10(m_inputDisplay) : -60.0f;
+    const float outDb = m_outputDisplay > 1.0e-8f ? 20.0f * std::log10(m_outputDisplay) : -60.0f;
+    std::snprintf(inBuf, sizeof(inBuf), "%.1f dB", inDb);
+    std::snprintf(outBuf, sizeof(outBuf), "%.1f dB", outDb);
+    std::snprintf(grBuf, sizeof(grBuf), "-%.1f dB", m_grDisplayDb);
+
+    drawMeterBar(renderer, m_inMeterRect, levelToNorm(m_inputDisplay), "IN", inBuf,
+                 NUIColor(0.35f, 0.45f, 1.0f, 1.0f));
+    drawMeterBar(renderer, m_outMeterRect, levelToNorm(m_outputDisplay), "OUT", outBuf,
+                 NUIColor(0.35f, 0.45f, 1.0f, 1.0f));
+    drawMeterBar(renderer, m_grNumRect, std::clamp(m_grDisplayDb / 24.0f, 0.0f, 1.0f),
+                 "GR", grBuf, accent);
+}
+
+bool AestraLimitEditor::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible()) return false;
+    if (AestraPanelWindow::onMouseEvent(event)) return true;
+
+    auto b = getBounds();
+    if (!b.contains(event.position) && !isDraggingWindow()) return false;
+
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        // Bypass pill
+        if (m_bypassPillRect.contains(event.position)) {
+            if (m_instance) {
+                const bool was = m_instance->getParameter(Aestra::Audio::Plugins::AestraLimit::kBypass) > 0.5f;
+                m_instance->setParameter(Aestra::Audio::Plugins::AestraLimit::kBypass, was ? 0.0f : 1.0f);
+                setDirty(true);
+            }
+            return true;
+        }
+
+        // Auto/Manual pill
+        if (m_autoPillRect.contains(event.position)) {
+            if (m_instance) {
+                m_instance->setParameter(Aestra::Audio::Plugins::AestraLimit::kReleaseMode, 0.0f);
+                setDirty(true);
+            }
+            return true;
+        }
+        if (m_manualPillRect.contains(event.position)) {
+            if (m_instance) {
+                m_instance->setParameter(Aestra::Audio::Plugins::AestraLimit::kReleaseMode, 1.0f);
+                setDirty(true);
+            }
+            return true;
+        }
+    }
+
+    // Double-click reset on knobs
+    if (event.pressed && event.button == NUIMouseButton::Left && event.doubleClick) {
+        for (auto& c : m_controls) {
+            if (c.slider && c.slider->getBounds().contains({event.position.x, event.position.y})) {
+                const float def = m_instance->getParameters()[c.paramId].defaultValue;
+                m_instance->setParameter(c.paramId, def);
+                c.slider->setValue(def);
+                setDirty(true);
+                return true;
+            }
+        }
+    }
+
+    // Hover tracking
+    if (!event.pressed && !event.released) {
+        const bool contains = b.contains(event.position);
+        const bool bh = contains && m_bypassPillRect.contains(event.position);
+        const bool ah = contains && m_autoPillRect.contains(event.position);
+        const bool mh = contains && m_manualPillRect.contains(event.position);
+        if (bh != m_bypassHovered || ah != m_autoHovered || mh != m_manualHovered) {
+            m_bypassHovered = bh;
+            m_autoHovered = ah;
+            m_manualHovered = mh;
+            repaint();
+        }
+    }
+
+    return NUIComponent::onMouseEvent(event);
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -6,6 +6,7 @@
 #include "Plugin/AestraLimit.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cmath>
 #include <cstring>
@@ -426,7 +427,11 @@ bool AestraLimitEditor::onMouseEvent(const NUIMouseEvent& event) {
     if (event.pressed && event.button == NUIMouseButton::Left && event.doubleClick) {
         for (auto& c : m_controls) {
             if (c.slider && c.slider->getBounds().contains({event.position.x, event.position.y})) {
-                const float def = m_instance->getParameters()[c.paramId].defaultValue;
+                const auto params = m_instance->getParameters();
+                float def = 0.0f;
+                for (const auto& p : params) {
+                    if (p.id == c.paramId) { def = p.defaultValue; break; }
+                }
                 m_instance->setParameter(c.paramId, def);
                 c.slider->setValue(def);
                 setDirty(true);

--- a/AestraUI/Widgets/AestraLimitEditor.h
+++ b/AestraUI/Widgets/AestraLimitEditor.h
@@ -1,0 +1,79 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraPanelWindow.h"
+#include "NUISlider.h"
+#include "NUITypes.h"
+#include "PluginHost.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace AestraUI {
+
+class AestraLimitEditor : public AestraPanelWindow {
+public:
+    explicit AestraLimitEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
+
+    void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    void onUpdate(double deltaTime) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    using AestraPanelWindow::onResize;
+    void onResize() { layoutControls(); }
+    void onResize(int width, int height) override;
+    void setPlatformBridge(NUIPlatformBridge* bridge) override;
+
+private:
+    struct KnobControl {
+        std::shared_ptr<NUISlider> slider;
+        std::string label;
+        uint32_t paramId = 0;
+        NUIRect bounds;
+        bool isPrimary = false;
+    };
+
+    void buildControls();
+    void layoutControls();
+    void syncControlsFromPlugin();
+    void drawGrMeter(NUIRenderer& renderer);
+    void drawKnob(NUIRenderer& renderer, const KnobControl& control);
+    void drawPill(NUIRenderer& renderer, NUIRect rect, bool selected, bool hovered,
+                  const char* label, NUIColor accent);
+    void drawMeterBar(NUIRenderer& renderer, NUIRect rect, float norm,
+                      const char* label, const char* value, NUIColor color);
+    std::string valueText(uint32_t paramId) const;
+
+    std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
+    std::vector<KnobControl> m_controls;
+
+    NUIRect m_grBarRect;
+    NUIRect m_grLabelRect;
+    NUIRect m_ceilingKnobRect;
+    NUIRect m_releaseKnobRect;
+    NUIRect m_autoPillRect;
+    NUIRect m_manualPillRect;
+    NUIRect m_bypassPillRect;
+    NUIRect m_inMeterRect;
+    NUIRect m_outMeterRect;
+    NUIRect m_grNumRect;
+
+    bool m_bypassHovered = false;
+    bool m_autoHovered = false;
+    bool m_manualHovered = false;
+
+    float m_grDisplayDb = 0.0f;
+    float m_inputDisplay = 0.0f;
+    float m_outputDisplay = 0.0f;
+    double m_meterTimer = 0.0;
+
+    static constexpr float kWinW = 520.0f;
+    static constexpr float kWinH = 400.0f;
+    static constexpr float kPad = 16.0f;
+    static constexpr float kKnobSizePrimary = 64.0f;
+    static constexpr float kKnobSizeSecondary = 48.0f;
+    static constexpr float kPillW = 56.0f;
+    static constexpr float kPillH = 22.0f;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -415,6 +415,8 @@ void PluginUIController::openPluginEditor(
             verb->onResize();
         } else if (auto comp = std::dynamic_pointer_cast<AestraCompEditor>(editorComp)) {
             comp->onResize();
+        } else if (auto limit = std::dynamic_pointer_cast<AestraLimitEditor>(editorComp)) {
+            limit->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto generic = std::dynamic_pointer_cast<GenericPluginEditor>(editorComp)) {
             generic->onResize();
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -9,6 +9,7 @@
 #include "AestraVerbEditor.h"
 #include "AestraDelayEditor.h"
 #include "AestraDriftEditor.h"
+#include "AestraLimitEditor.h"
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
@@ -376,6 +377,14 @@ void PluginUIController::openPluginEditor(
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.drift") {
         auto ed = std::make_shared<AestraDriftEditor>(instance);
+        ed->setOnClose([this, ed]() {
+            if (m_popupLayer) m_popupLayer->removeChild(ed);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
+        });
+        ed->setPlatformBridge(m_platformBridge);
+        editor = ed;
+    } else if (pluginId == "com.Aestrastudios.limiter") {
+        auto ed = std::make_shared<AestraLimitEditor>(instance);
         ed->setOnClose([this, ed]() {
             if (m_popupLayer) m_popupLayer->removeChild(ed);
             m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());

--- a/Tests/AestraAudio/AestraLimitTest.cpp
+++ b/Tests/AestraAudio/AestraLimitTest.cpp
@@ -1,0 +1,262 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraLimitTest — DSP contract tests for the brickwall limiter.
+
+#include "Plugin/AestraLimit.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraLimit;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 512;
+
+struct StereoBuffer {
+    std::vector<float> left;
+    std::vector<float> right;
+};
+
+void initAndActivate(AestraLimit& lim) {
+    lim.initialize(kSampleRate, kBlockSize);
+    lim.activate();
+}
+
+StereoBuffer processStereo(AestraLimit& lim, const std::vector<float>& inL, const std::vector<float>& inR) {
+    StereoBuffer out{std::vector<float>(inL.size(), 0.0f), std::vector<float>(inR.size(), 0.0f)};
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {out.left.data(), out.right.data()};
+    lim.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+    return out;
+}
+
+std::vector<float> makeSine(uint32_t numSamples, float freq, float amp, double sampleRate) {
+    std::vector<float> buf(numSamples);
+    for (uint32_t i = 0; i < numSamples; ++i)
+        buf[i] = amp * std::sin(2.0f * 3.14159265f * freq * static_cast<float>(i) / static_cast<float>(sampleRate));
+    return buf;
+}
+
+std::vector<float> makeSilence(uint32_t numSamples) {
+    return std::vector<float>(numSamples, 0.0f);
+}
+
+float peakAmplitude(const std::vector<float>& buf) {
+    float peak = 0.0f;
+    for (float s : buf) peak = std::max(peak, std::abs(s));
+    return peak;
+}
+
+bool testBypassPassesAudioUnchanged() {
+    AestraLimit lim;
+    initAndActivate(lim);
+    lim.setParameter(AestraLimit::kBypass, 1.0f);
+
+    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto inR = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(lim, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i] - inL[i]) > 1e-6f) return false;
+        if (std::abs(out.right[i] - inR[i]) > 1e-6f) return false;
+    }
+    return true;
+}
+
+bool testSilenceProducesSilence() {
+    AestraLimit lim;
+    initAndActivate(lim);
+
+    const auto inL = makeSilence(1024);
+    const auto inR = makeSilence(1024);
+    auto out = processStereo(lim, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i]) > 1e-10f) return false;
+        if (std::abs(out.right[i]) > 1e-10f) return false;
+    }
+    return true;
+}
+
+bool testTruePeakDoesNotExceedCeiling() {
+    AestraLimit lim;
+    initAndActivate(lim);
+    lim.setParameter(AestraLimit::kCeiling, 0.5f);
+
+    const float ceilingDb = -24.0f + 0.5f * 24.0f;
+    const float internalCeilingLinear = std::pow(10.0f, (ceilingDb - 0.1f) / 20.0f);
+
+    const auto silence = makeSilence(kBlockSize);
+    processStereo(lim, silence, silence);
+
+    const auto inL = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
+    const auto inR = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
+    auto out = processStereo(lim, inL, inR);
+
+    float outPeak = std::max(peakAmplitude(out.left), peakAmplitude(out.right));
+    return outPeak <= internalCeilingLinear + 0.01f;
+}
+
+bool testGainReductionApplied() {
+    AestraLimit lim;
+    initAndActivate(lim);
+    lim.setParameter(AestraLimit::kCeiling, 0.25f);
+
+    const auto silence = makeSilence(kBlockSize);
+    processStereo(lim, silence, silence);
+
+    const auto inL = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
+    const auto inR = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
+    auto out = processStereo(lim, inL, inR);
+
+    const float outPeak = peakAmplitude(out.left);
+    return outPeak < 0.9f;
+}
+
+bool testStateSaveLoadRoundtrip() {
+    AestraLimit lim;
+    lim.initialize(kSampleRate, kBlockSize);
+    lim.setParameter(AestraLimit::kCeiling, 0.3f);
+    lim.setParameter(AestraLimit::kReleaseMode, 1.0f);
+    lim.setParameter(AestraLimit::kRelease, 0.7f);
+
+    const auto state = lim.saveState();
+    assert(state.size() > 8);
+
+    AestraLimit lim2;
+    lim2.initialize(kSampleRate, kBlockSize);
+    lim2.activate();
+    assert(lim2.loadState(state));
+
+    const float epsilon = 1e-5f;
+    if (std::abs(lim2.getParameter(AestraLimit::kCeiling) - 0.3f) > epsilon) return false;
+    if (std::abs(lim2.getParameter(AestraLimit::kReleaseMode) - 1.0f) > epsilon) return false;
+    if (std::abs(lim2.getParameter(AestraLimit::kRelease) - 0.7f) > epsilon) return false;
+    return true;
+}
+
+bool testStateRejectsBadMagic() {
+    AestraLimit lim;
+    lim.initialize(kSampleRate, kBlockSize);
+
+    std::vector<uint8_t> badState(64, 0xFF);
+    return !lim.loadState(badState);
+}
+
+bool testStateRejectsTooShort() {
+    AestraLimit lim;
+    lim.initialize(kSampleRate, kBlockSize);
+
+    std::vector<uint8_t> shortState(4, 0x00);
+    return !lim.loadState(shortState);
+}
+
+bool testParameterCount() {
+    AestraLimit lim;
+    return lim.getParameterCount() == AestraLimit::kParamCount;
+}
+
+bool testParameterClamping() {
+    AestraLimit lim;
+    lim.initialize(kSampleRate, kBlockSize);
+    lim.setParameter(AestraLimit::kCeiling, -0.5f);
+    if (lim.getParameter(AestraLimit::kCeiling) != 0.0f) return false;
+    lim.setParameter(AestraLimit::kCeiling, 2.0f);
+    if (lim.getParameter(AestraLimit::kCeiling) != 1.0f) return false;
+    return true;
+}
+
+bool testSanitizeNanInput() {
+    AestraLimit lim;
+    initAndActivate(lim);
+
+    float nanVal = std::nanf("");
+    const float* inputs[] = {&nanVal, &nanVal};
+    float outL = 0.0f, outR = 0.0f;
+    float* outputs[] = {&outL, &outR};
+    lim.process(inputs, outputs, 2, 2, 1);
+
+    return std::isfinite(outL) && std::isfinite(outR);
+}
+
+bool testLatencyMatchesLookahead() {
+    AestraLimit lim;
+    lim.initialize(kSampleRate, kBlockSize);
+
+    const uint32_t expected = static_cast<uint32_t>(
+        std::ceil(static_cast<double>(AestraLimit::kLookaheadMs) * 0.001 * static_cast<double>(kSampleRate)));
+    return lim.getLatencySamples() == expected;
+}
+
+bool testMeteringUpdatesAfterProcess() {
+    AestraLimit lim;
+    initAndActivate(lim);
+
+    const auto silence = makeSilence(kBlockSize);
+    processStereo(lim, silence, silence);
+
+    const auto inL = makeSine(kBlockSize, 1000.0f, 0.8f, kSampleRate);
+    const auto inR = makeSine(kBlockSize, 1000.0f, 0.8f, kSampleRate);
+    processStereo(lim, inL, inR);
+
+    return lim.getInputLevel() > 0.0f;
+}
+
+bool testOutputClipperBoundsOutput() {
+    AestraLimit lim;
+    initAndActivate(lim);
+    lim.setParameter(AestraLimit::kCeiling, 0.9f);
+
+    const auto silence = makeSilence(kBlockSize);
+    processStereo(lim, silence, silence);
+
+    const auto inL = makeSine(kBlockSize, 1000.0f, 2.0f, kSampleRate);
+    const auto inR = makeSine(kBlockSize, 1000.0f, 2.0f, kSampleRate);
+    auto out = processStereo(lim, inL, inR);
+
+    const float outPeak = std::max(peakAmplitude(out.left), peakAmplitude(out.right));
+    return outPeak <= 1.01f;
+}
+
+bool testZeroInputLatencyRamp() {
+    AestraLimit lim;
+    initAndActivate(lim);
+    lim.setParameter(AestraLimit::kCeiling, 0.5f);
+
+    const uint32_t latency = lim.getLatencySamples();
+    const auto silence = makeSilence(latency + kBlockSize);
+    auto out = processStereo(lim, silence, silence);
+
+    for (uint32_t i = 0; i < out.left.size(); ++i) {
+        if (std::abs(out.left[i]) > 1e-6f) return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "AestraLimit Tests\n";
+    if (!testBypassPassesAudioUnchanged()) { std::cout << "FAIL: bypass\n"; return 1; }
+    if (!testSilenceProducesSilence()) { std::cout << "FAIL: silence\n"; return 1; }
+    if (!testTruePeakDoesNotExceedCeiling()) { std::cout << "FAIL: true peak ceiling\n"; return 1; }
+    if (!testGainReductionApplied()) { std::cout << "FAIL: gain reduction\n"; return 1; }
+    if (!testStateSaveLoadRoundtrip()) { std::cout << "FAIL: state roundtrip\n"; return 1; }
+    if (!testStateRejectsBadMagic()) { std::cout << "FAIL: bad magic\n"; return 1; }
+    if (!testStateRejectsTooShort()) { std::cout << "FAIL: short state\n"; return 1; }
+    if (!testParameterCount()) { std::cout << "FAIL: param count\n"; return 1; }
+    if (!testParameterClamping()) { std::cout << "FAIL: param clamping\n"; return 1; }
+    if (!testSanitizeNanInput()) { std::cout << "FAIL: NaN sanitize\n"; return 1; }
+    if (!testLatencyMatchesLookahead()) { std::cout << "FAIL: latency\n"; return 1; }
+    if (!testMeteringUpdatesAfterProcess()) { std::cout << "FAIL: metering\n"; return 1; }
+    if (!testOutputClipperBoundsOutput()) { std::cout << "FAIL: output clipper\n"; return 1; }
+    if (!testZeroInputLatencyRamp()) { std::cout << "FAIL: zero input latency\n"; return 1; }
+    std::cout << "All AestraLimit tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AestraLimitTest.cpp
+++ b/Tests/AestraAudio/AestraLimitTest.cpp
@@ -53,6 +53,18 @@ float peakAmplitude(const std::vector<float>& buf) {
     return peak;
 }
 
+float oversampledPeak(const std::vector<float>& buf, uint32_t osRatio) {
+    float peak = 0.0f;
+    for (size_t i = 0; i + 1 < buf.size(); ++i) {
+        for (uint32_t t = 0; t < osRatio; ++t) {
+            const float frac = static_cast<float>(t) / static_cast<float>(osRatio);
+            const float interp = buf[i] + frac * (buf[i + 1] - buf[i]);
+            peak = std::max(peak, std::abs(interp));
+        }
+    }
+    return peak;
+}
+
 bool testBypassPassesAudioUnchanged() {
     AestraLimit lim;
     initAndActivate(lim);
@@ -99,7 +111,9 @@ bool testTruePeakDoesNotExceedCeiling() {
     const auto inR = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
     auto out = processStereo(lim, inL, inR);
 
-    float outPeak = std::max(peakAmplitude(out.left), peakAmplitude(out.right));
+    const float peakL = oversampledPeak(out.left, AestraLimit::kOsRatio);
+    const float peakR = oversampledPeak(out.right, AestraLimit::kOsRatio);
+    float outPeak = std::max(peakL, peakR);
     return outPeak <= internalCeilingLinear + 0.01f;
 }
 
@@ -115,8 +129,10 @@ bool testGainReductionApplied() {
     const auto inR = makeSine(kBlockSize, 1000.0f, 1.0f, kSampleRate);
     auto out = processStereo(lim, inL, inR);
 
+    const float ceilingDb = -24.0f + 0.25f * 24.0f;
+    const float expectedMax = std::pow(10.0f, ceilingDb / 20.0f) + 0.05f;
     const float outPeak = peakAmplitude(out.left);
-    return outPeak < 0.9f;
+    return outPeak < expectedMax;
 }
 
 bool testStateSaveLoadRoundtrip() {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1039,6 +1039,17 @@ target_include_directories(AestraDelayUpgradeTest PRIVATE
 add_test(NAME AestraDelayUpgradeTest COMMAND AestraDelayUpgradeTest)
 set_tests_properties(AestraDelayUpgradeTest PROPERTIES LABELS "audio;plugins;delay;upgrade")
 
+# Aestra Limit Test
+add_executable(AestraLimitTest AestraAudio/AestraLimitTest.cpp)
+target_link_libraries(AestraLimitTest PRIVATE AestraAudio)
+target_include_directories(AestraLimitTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraLimitTest COMMAND AestraLimitTest)
+set_tests_properties(AestraLimitTest PROPERTIES LABELS "audio;plugins;limiter")
+
 # Serialization Compatibility Test (Requires GTest)
 # add_executable(AestraSerializationCompatibilityTest AestraAudio/SerializationCompatibilityTest.cpp)
 # target_link_libraries(AestraSerializationCompatibilityTest PRIVATE AestraAudio)


### PR DESCRIPTION
## Summary
- **AestraLimit** — new built-in brickwall limiter plugin with 4x oversampled true peak detection, 2ms lookahead, density-driven auto-release, and full UI
- **AestraComp** — raise FFT display floor to -48 dB with data-driven axis labels

## AestraLimit
- `com.Aestrastudios.limiter` — registered in BuiltInPlugins, wired into PluginUIController
- DSP: true peak detection, auto/manual release, output safety clip, gain/input/output metering
- UI: GR meter, Ceiling + Release knobs, Auto/Manual + Bypass pills, IN/OUT/GR meters
- 14 contract tests (bypass, silence, true peak, gain reduction, state roundtrip, NaN, latency, metering, clipper)
- Optimized per OPTIMIZE.md: precomputed coefficients, fixed-size lookahead (3.5 KB, zero heap alloc), inlined hot path, OPTFLOOR documented

## AestraComp
- FFT display floor raised from -∞ to -48 dB
- Axis labels now driven by actual data range instead of hardcoded

## Testing
- `AestraLimitTest` — 14/14 passed
- `AestraCompPhase0Test`, `AestraCompPhase1Test` — existing tests pass

## Risk
- Low: new plugin, no changes to existing DSP or serialization
- AestraComp change is UI-only (display floor), no audio path impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Breaking changes: none — no public API or audio-path changes to existing plugins; AestraComp change is UI-only.

- New plugin: AestraLimit (com.Aestrastudios.limiter)
  - DSP: musical brickwall limiter with 4× oversampled true-peak detection, fixed-size capped 2 ms lookahead buffer (zero heap allocations), density-driven auto-release with manual mode (10–500 ms) and smoothed manual-release path, safety output clip, input/output/gain-reduction metering, and cached/capped latency reporting (getLatencySamples returns lookahead samples).
  - Implementation notes: precomputed coefficients, inlined hot path, fixed-size circular buffer, no per-sample heap allocations; lookahead size is capped and latency returns the capped value.
  - Serialization: LMT1 blob format with version/magic validation in loadState.
  - Tests: 14 contract tests added and passing (bypass, silence, true-peak ceiling enforcement—including oversampled peak checks—gain reduction, state roundtrip and malformed blob rejection, NaN sanitization, latency correctness, metering, clipping, and zero-input latency behavior).

- UI: AestraLimitEditor
  - Custom editor with Ceiling and Release knobs, Auto/Manual and Bypass pills, left GR meter, IN/OUT/GR bottom meters, responsive layout, parameter sync, knob double-click resets, and pill interactions.
  - Wired into PluginUIController and registered in BuiltInPlugins so the editor is instantiated automatically for the limiter.

- AestraComp
  - FFT display floor raised (from -∞ to -48 dB) and axis labels now reflect actual data range — UI-only change, no audio-path impact.

- Build & tests
  - Added CMake entries and a CTest target for AestraLimitTest; tests compile and run (14/14 in the new test).

- Risk & fixes
  - Risk: Low — new plugin addition and cosmetic UI tweak only.
  - Commit fixes include: capped lookahead/latency reporting, smoothed manual release usage, correct EMA weight update (alpha*input + (1-alpha)*prev), validating blob version on load, registering editor in relayout, using parameter default lookup for knob reset, and tightened test assertions for oversampled true-peak and ceiling thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->