### PR TITLE
Add audio quality audit and engine torture harnesses

### DIFF
--- a/Tests/AestraAudio/AudioEngineTortureTest.cpp
+++ b/Tests/AestraAudio/AudioEngineTortureTest.cpp
@@ -132,7 +132,7 @@ static void testSilencePath() {
         return peak == 0.0f;
     });
 
-    // Extended silence processing: 10 seconds, 100 blocks
+    // Extended silence processing: 10 seconds (~1875 blocks at 48kHz/256f)
     TEST("Silence path — 10s sustained (no denormal buildup)", {
         auto eng = makeEngine(kSampleRate, kBlockSize);
         std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
@@ -162,6 +162,14 @@ static void testSilencePath() {
 }
 
 static void testNanInfInjection() {
+#ifdef AESTRA_ENGINE_ASSERTS_ACTIVE
+    // Set by Tests/CMakeLists.txt for Debug configs: the engine library keeps
+    // assert() live there and AudioEngine::processBlock hard-asserts on
+    // NaN/Inf, so poisoned-input cases would abort instead of reporting.
+    // The sanitize-and-recover contract is verified in Release/RelWithDebInfo
+    // runs (including the ASan/UBSan nightly).
+    std::printf("  SKIP  NaN/Inf injection cases (engine asserts active in Debug config)\n");
+#else
     // NaN on input must not propagate to output or corrupt engine state
     TEST("NaN input — engine produces finite output", {
         auto eng = makeEngine(kSampleRate, kBlockSize);
@@ -204,6 +212,7 @@ static void testNanInfInjection() {
         eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);        // Recover
         return isFinite(out.data(), kBlockSize, kChannels);
     });
+#endif
 }
 
 static void testExtremeGainValues() {
@@ -230,7 +239,11 @@ static void testExtremeGainValues() {
         }
         std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
         eng->processBlock(out.data(), sigIn.data(), kBlockSize, 0.0);
-        return isFinite(out.data(), kBlockSize, kChannels);
+        if (!isFinite(out.data(), kBlockSize, kChannels))
+            return false;
+        // Engine output stage hard-clamps L/R to [-1, 1]; verify the bound
+        float peak = peakMagnitude(out.data(), kBlockSize, kChannels);
+        return peak <= 1.0f;
     });
 }
 
@@ -256,7 +269,7 @@ static void testBufferSizeReconfiguration() {
         auto eng = makeEngine(kSampleRate, 256);
         std::vector<float> out;
         std::mt19937 rng(42);
-        std::uniform_int_distribution<int> sizeDist(3, 12);
+        std::uniform_int_distribution<int> sizeDist(6, 12); // 64..4096, matching supported sizes
         for (int i = 0; i < 100; ++i) {
             uint32_t bs = 1u << sizeDist(rng);
             eng->setBufferConfig(bs, kChannels);

--- a/Tests/AestraAudio/AudioEngineTortureTest.cpp
+++ b/Tests/AestraAudio/AudioEngineTortureTest.cpp
@@ -1,0 +1,436 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AudioEngineTortureTest — Stress harness that tries to break the audio engine.
+//
+// Tests:
+//   - Silence path integrity (no denormal buildup)
+//   - NaN/Inf injection (engine stays bounded)
+//   - Extreme gain values (no overflow, no clipping artifacts)
+//   - Buffer size reconfiguration between blocks
+//   - Sample rate reconfiguration between blocks
+//   - Transport hammering (rapid play/stop/seek)
+//   - Multi-track load stress (100+ tracks)
+//
+// Each scenario is independently scored. The test exits 0 only if ALL pass.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kChannels = 2;
+constexpr double kTau = 6.28318530717958647692;
+
+static int g_testsRun = 0;
+static int g_testsPassed = 0;
+static int g_testsFailed = 0;
+
+#define TEST(name, body)                                          \
+    do {                                                          \
+        ++g_testsRun;                                             \
+        bool ok = [&]() -> bool { body }();                       \
+        if (ok) {                                                 \
+            std::printf("  PASS  %s\n", name);                    \
+            ++g_testsPassed;                                      \
+        } else {                                                  \
+            std::printf("  FAIL  %s\n", name);                    \
+            ++g_testsFailed;                                      \
+        }                                                         \
+    } while (0)
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+static std::unique_ptr<AudioEngine> makeEngine(uint32_t sampleRate, uint32_t blockSize) {
+    auto eng = std::make_unique<AudioEngine>();
+    eng->setSampleRate(sampleRate);
+    eng->setBufferConfig(blockSize, kChannels);
+    eng->setSafetyLimiterEnabled(false);
+    eng->setMetronomeEnabled(false);
+    eng->setAuditionModeEnabled(false);
+    eng->initialize();
+    return eng;
+}
+
+static float peakMagnitude(const float* buf, uint32_t frames, uint32_t channels) {
+    float peak = 0.0f;
+    for (uint32_t i = 0; i < frames * channels; ++i) {
+        float absVal = buf[i] < 0.0f ? -buf[i] : buf[i];
+        if (absVal > peak) peak = absVal;
+    }
+    return peak;
+}
+
+static float computeRmsDb(const float* buf, uint32_t frames, uint32_t channels) {
+    double sumSq = 0.0;
+    uint64_t count = static_cast<uint64_t>(frames) * channels;
+    for (uint64_t i = 0; i < count; ++i)
+        sumSq += static_cast<double>(buf[i]) * static_cast<double>(buf[i]);
+    if (sumSq <= 0.0) return -INFINITY;
+    return 10.0f * std::log10(static_cast<float>(sumSq / static_cast<double>(count)));
+}
+
+static bool isFinite(const float* buf, uint32_t frames, uint32_t channels) {
+    for (uint32_t i = 0; i < frames * channels; ++i) {
+        if (!std::isfinite(buf[i]))
+            return false;
+    }
+    return true;
+}
+
+static int countDenormals(const float* buf, uint32_t frames, uint32_t channels) {
+    int count = 0;
+    for (uint32_t i = 0; i < frames * channels; ++i) {
+        float v = buf[i];
+        if (v != 0.0f && std::abs(v) < std::numeric_limits<float>::min())
+            ++count;
+    }
+    return count;
+}
+
+// Create a TrackManager with N tracks
+static std::shared_ptr<TrackManager> makeMultiTrackManager(
+    uint32_t numTracks, uint32_t sampleRate)
+{
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(sampleRate));
+    for (uint32_t t = 0; t < numTracks; ++t)
+        tm->addChannel("TortureTrack_" + std::to_string(t));
+    return tm;
+}
+
+// =============================================================================
+// Torture Scenarios
+// =============================================================================
+
+static void testSilencePath() {
+    // The engine must produce exactly zero when processing silence with no tracks.
+    TEST("Silence path — output is clean zero", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, -1.0f);
+        eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+        float peak = peakMagnitude(out.data(), kBlockSize, kChannels);
+        return peak == 0.0f;
+    });
+
+    // Extended silence processing: 10 seconds, 100 blocks
+    TEST("Silence path — 10s sustained (no denormal buildup)", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
+        int totalDenormals = 0;
+        uint32_t numBlocks = 10 * kSampleRate / kBlockSize;
+        for (uint32_t i = 0; i < numBlocks; ++i) {
+            eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+            totalDenormals += countDenormals(out.data(), kBlockSize, kChannels);
+            if (peakMagnitude(out.data(), kBlockSize, kChannels) != 0.0f)
+                return false;
+        }
+        return totalDenormals == 0;
+    });
+
+    // Silence through multi-track engine (tracks exist but no clips playing)
+    TEST("Silence path — multi-track, no clips", {
+        auto tm = makeMultiTrackManager(32, kSampleRate);
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        eng->setTrackManager(tm);
+        eng->setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
+        eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+        float peak = peakMagnitude(out.data(), kBlockSize, kChannels);
+        return peak == 0.0f;
+    });
+}
+
+static void testNanInfInjection() {
+    // NaN on input must not propagate to output or corrupt engine state
+    TEST("NaN input — engine produces finite output", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> nanIn(static_cast<size_t>(kBlockSize) * kChannels, NAN);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        eng->processBlock(out.data(), nanIn.data(), kBlockSize, 0.0);
+        return isFinite(out.data(), kBlockSize, kChannels);
+    });
+
+    // Inf on input
+    TEST("Inf input — engine produces finite output", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> infIn(static_cast<size_t>(kBlockSize) * kChannels, INFINITY);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        eng->processBlock(out.data(), infIn.data(), kBlockSize, 0.0);
+        return isFinite(out.data(), kBlockSize, kChannels);
+    });
+
+    // Mixed NaN/signal — one channel NaN, other clean
+    TEST("NaN in one channel — other channel unaffected", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> mixedIn(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        for (uint32_t i = 0; i < kBlockSize; ++i) {
+            mixedIn[static_cast<size_t>(i) * 2] = NAN;       // Left = NaN
+            mixedIn[static_cast<size_t>(i) * 2 + 1] = 0.5f;  // Right = signal
+        }
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        eng->processBlock(out.data(), mixedIn.data(), kBlockSize, 0.0);
+        return isFinite(out.data(), kBlockSize, kChannels);
+    });
+
+    // Recovery: after NaN, next clean block must be clean
+    TEST("NaN recovery — next clean block is clean", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        std::vector<float> nanIn(static_cast<size_t>(kBlockSize) * kChannels, NAN);
+
+        eng->processBlock(out.data(), nanIn.data(), kBlockSize, 0.0);  // Poison
+        std::memset(out.data(), 0, out.size() * sizeof(float));
+        eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);        // Recover
+        return isFinite(out.data(), kBlockSize, kChannels);
+    });
+}
+
+static void testExtremeGainValues() {
+    // Very large input values should not cause overflow or NaN
+    TEST("Extreme gain — +100dB signal stays bounded", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> hotIn(static_cast<size_t>(kBlockSize) * kChannels, 100000.0f);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        eng->processBlock(out.data(), hotIn.data(), kBlockSize, 0.0);
+        if (!isFinite(out.data(), kBlockSize, kChannels))
+            return false;
+        float peak = peakMagnitude(out.data(), kBlockSize, kChannels);
+        return std::isfinite(peak) && peak < 1e10f;
+    });
+
+    // Sinusoid at 0dBFS should clip gracefully (not NaN/Inf)
+    TEST("Extreme gain — 0dBFS sine clips gracefully", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> sigIn(static_cast<size_t>(kBlockSize) * kChannels);
+        for (uint32_t i = 0; i < kBlockSize; ++i) {
+            float s = std::sin(kTau * 440.0 * i / kSampleRate);
+            sigIn[static_cast<size_t>(i) * 2] = s;
+            sigIn[static_cast<size_t>(i) * 2 + 1] = s;
+        }
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        eng->processBlock(out.data(), sigIn.data(), kBlockSize, 0.0);
+        return isFinite(out.data(), kBlockSize, kChannels);
+    });
+}
+
+static void testBufferSizeReconfiguration() {
+    // Can the engine handle buffer sizes changing between processBlock calls?
+    const uint32_t sizes[] = {64, 128, 256, 512, 1024, 2048, 4096};
+
+    TEST("Buffer size switching — all standard sizes", {
+        auto eng = makeEngine(kSampleRate, 256);
+        std::vector<float> out;
+        for (uint32_t bs : sizes) {
+            eng->setBufferConfig(bs, kChannels);
+            out.assign(static_cast<size_t>(bs) * kChannels, 0.0f);
+            eng->processBlock(out.data(), nullptr, bs, 0.0);
+            if (!isFinite(out.data(), bs, kChannels))
+                return false;
+        }
+        return true;
+    });
+
+    // Switch sizes randomly, 100 iterations
+    TEST("Buffer size switching — 100 rapid changes", {
+        auto eng = makeEngine(kSampleRate, 256);
+        std::vector<float> out;
+        std::mt19937 rng(42);
+        std::uniform_int_distribution<int> sizeDist(3, 12);
+        for (int i = 0; i < 100; ++i) {
+            uint32_t bs = 1u << sizeDist(rng);
+            eng->setBufferConfig(bs, kChannels);
+            out.assign(static_cast<size_t>(bs) * kChannels, 0.0f);
+            eng->processBlock(out.data(), nullptr, bs, 0.0);
+            if (!isFinite(out.data(), bs, kChannels))
+                return false;
+        }
+        return true;
+    });
+}
+
+static void testTransportHammering() {
+    // Rapid play/stop toggles across processBlock calls
+    TEST("Transport hammer — 1000 play/stop cycles", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
+        for (int i = 0; i < 1000; ++i) {
+            bool playing = (i % 2 == 0);
+            eng->setTransportPlaying(playing);
+            eng->setGlobalSamplePos(0);
+            eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+            if (!isFinite(out.data(), kBlockSize, kChannels))
+                return false;
+        }
+        return true;
+    });
+
+    // Seek while playing
+    TEST("Transport hammer — seek during playback", {
+        auto eng = makeEngine(kSampleRate, kBlockSize);
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
+        eng->setTransportPlaying(true);
+        for (int i = 0; i < 100; ++i) {
+            eng->setGlobalSamplePos(
+                static_cast<uint64_t>(i) * kBlockSize * 7 % 441000);
+            eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+            if (!isFinite(out.data(), kBlockSize, kChannels))
+                return false;
+        }
+        eng->setTransportPlaying(false);
+        return true;
+    });
+}
+
+static void testMultiTrackStress() {
+    // Create many tracks and render with transport playing
+    // Uses the internal test tone so we don't need to wire clips for every track
+
+    TEST("Multi-track — 100 tracks with test tone", {
+        auto tm = std::make_shared<TrackManager>();
+        tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+        for (uint32_t t = 0; t < 100; ++t)
+            tm->addChannel("Track_" + std::to_string(t));
+
+        auto eng = std::make_unique<AudioEngine>();
+        eng->setSampleRate(kSampleRate);
+        eng->setBufferConfig(kBlockSize, kChannels);
+        eng->setTrackManager(tm);
+        eng->setTestToneEnabled(true);
+        eng->setBPM(120.0f);
+        eng->setSafetyLimiterEnabled(false);
+        eng->setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+        eng->initialize();
+        eng->setMetronomeEnabled(false);
+        eng->setAuditionModeEnabled(false);
+        eng->setGlobalSamplePos(0);
+        eng->setTransportPlaying(true);
+
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels);
+        float maxPeak = 0.0f;
+        for (int i = 0; i < 100; ++i) {
+            eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+            if (!isFinite(out.data(), kBlockSize, kChannels))
+                return false;
+            float p = peakMagnitude(out.data(), kBlockSize, kChannels);
+            if (p > maxPeak) maxPeak = p;
+        }
+        eng->setTransportPlaying(false);
+        return maxPeak > 0.0f;
+    });
+}
+
+static void testLongRunStability() {
+    // Process 30 seconds of test tone
+    // Measure consistent RMS, no glitches
+
+    TEST("Long run — 30s test tone, buffer size 256", {
+        auto eng = makeEngine(kSampleRate, 256);
+        eng->setTestToneEnabled(true);
+        eng->initialize();
+        eng->setTransportPlaying(true);
+
+        std::vector<float> out(static_cast<size_t>(256) * kChannels);
+        uint32_t totalFrames = kSampleRate * 30;
+        uint32_t blocks = totalFrames / 256;
+        uint32_t warmup = 8; // skip fade-in transient
+        bool consistent = true;
+        uint32_t measured = 0;
+
+        for (uint32_t i = 0; i < blocks; ++i) {
+            eng->processBlock(out.data(), nullptr, 256, 0.0);
+            if (!isFinite(out.data(), 256, kChannels)) {
+                consistent = false;
+                break;
+            }
+            if (i < warmup) continue;
+            ++measured;
+            float rms = computeRmsDb(out.data(), 256, kChannels);
+            // RMS should be stable near -26dBFS (test tone level)
+            if (rms > -40.0f && rms < -10.0f) continue;
+            consistent = false;
+        }
+        eng->setTransportPlaying(false);
+        return consistent && measured > 0;
+    });
+}
+
+static void testSampleRateReconfiguration() {
+    const uint32_t rates[] = {44100, 48000, 88200, 96000, 44100, 48000};
+
+    TEST("Sample rate switching — standard rates", {
+        auto eng = std::make_unique<AudioEngine>();
+        for (uint32_t rate : rates) {
+            eng->setSampleRate(rate);
+            eng->setBufferConfig(kBlockSize, kChannels);
+            eng->initialize();
+            std::vector<float> out(
+                static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+            eng->processBlock(out.data(), nullptr, kBlockSize, 0.0);
+            if (!isFinite(out.data(), kBlockSize, kChannels))
+                return false;
+        }
+        return true;
+    });
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main() {
+    std::printf("============================================================\n");
+    std::printf("  Aestra Audio Engine — Torture Test Suite\n");
+    std::printf("============================================================\n\n");
+
+    std::printf("[Silence path integrity]\n");
+    testSilencePath();
+
+    std::printf("\n[NaN/Inf injection]\n");
+    testNanInfInjection();
+
+    std::printf("\n[Extreme gain values]\n");
+    testExtremeGainValues();
+
+    std::printf("\n[Buffer size reconfiguration]\n");
+    testBufferSizeReconfiguration();
+
+    std::printf("\n[Sample rate reconfiguration]\n");
+    testSampleRateReconfiguration();
+
+    std::printf("\n[Transport hammering]\n");
+    testTransportHammering();
+
+    std::printf("\n[Multi-track stress]\n");
+    testMultiTrackStress();
+
+    std::printf("\n[Long-run stability]\n");
+    testLongRunStability();
+
+    std::printf("\n============================================================\n");
+    std::printf("  Results: %d/%d passed, %d failed\n",
+                g_testsPassed, g_testsRun, g_testsFailed);
+    std::printf("============================================================\n");
+
+    return g_testsFailed > 0 ? 1 : 0;
+}

--- a/Tests/AestraAudio/AudioQualityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioQualityAuditTest.cpp
@@ -1,0 +1,406 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AudioQualityAuditTest — End-to-end audio quality measurement.
+//
+// Measures:
+//   1. Noise floor — silence through full engine path (RMS, DC offset)
+//   2. Distortion — null-test residuals for multiple frequencies/amplitudes
+//   3. Frequency response — magnitude at 20Hz–20kHz
+//   4. Channel crosstalk — L-only signal, R-channel leakage
+//   5. Soft clipper transfer curve — mathematical verification
+//   6. DC blocker frequency response
+//
+// Question answered: "Where does Aestra lose information?"
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHECK(cond, msg) do {                   \
+    if (cond) {                                  \
+        std::printf("  PASS  %s\n", msg);        \
+        ++g_pass;                                \
+    } else {                                     \
+        std::printf("  FAIL  %s\n", msg);        \
+        ++g_fail;                                \
+    }                                            \
+} while(0)
+
+static constexpr double kTau = 6.28318530717958647692;
+
+// Render a TrackManager-based sine source through the engine, return output
+static std::vector<float> renderSine(
+    uint32_t sampleRate, uint32_t durationFrames, uint32_t blockSize,
+    double freqHz, double amplitudeLin, bool leftOnly = false)
+{
+    auto buf = std::make_shared<AudioBufferData>();
+    buf->sampleRate = sampleRate;
+    buf->numChannels = 2;
+    buf->numFrames = durationFrames;
+    buf->interleavedData.resize(static_cast<size_t>(durationFrames) * 2);
+    for (uint32_t i = 0; i < durationFrames; ++i) {
+        double s = amplitudeLin * std::sin(kTau * freqHz * i / sampleRate);
+        buf->interleavedData[i * 2] = static_cast<float>(s);
+        buf->interleavedData[i * 2 + 1] = leftOnly ? 0.0f : static_cast<float>(s);
+    }
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(sampleRate));
+    tm->addChannel("QualityTest");
+
+    std::string path = "/tmp/quality_audit_src.wav";
+    ClipSourceID srcId = tm->getSourceManager().createRecordedSource(
+        path, "quality_src", buf);
+    double durationSec = static_cast<double>(durationFrames) / sampleRate;
+    AudioSlicePayload payload;
+    payload.audioSourceId = srcId;
+    payload.durationSeconds = durationSec;
+    payload.slices.push_back(
+        {0.0, durationSec, 0.0, static_cast<double>(durationFrames)});
+
+    PlaylistLaneID laneId = tm->getPlaylistModel().createLane("quality");
+    PatternID patId = tm->getPatternManager().createAudioPattern(
+        "quality_pat", durationSec * 2.0, payload);
+    tm->getPlaylistModel().addClipFromPattern(laneId, patId, 0.0, durationSec * 2.0);
+
+    AudioEngine eng;
+    eng.setSampleRate(sampleRate);
+    eng.setBufferConfig(blockSize, 2);
+    eng.setTrackManager(tm);
+    eng.setBPM(120.0f);
+    eng.setSafetyLimiterEnabled(false);
+    eng.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+    eng.initialize();
+    eng.setMetronomeEnabled(false);
+    eng.setAuditionModeEnabled(false);
+    eng.setGlobalSamplePos(0);
+    eng.setTransportPlaying(true);
+
+    std::vector<float> output;
+    std::vector<float> block(blockSize * 2);
+    for (uint32_t rendered = 0; rendered < durationFrames; ) {
+        uint32_t f = std::min(blockSize, durationFrames - rendered);
+        std::fill(block.begin(), block.end(), 0.0f);
+        eng.processBlock(block.data(), nullptr, f, 0.0);
+        output.insert(output.end(), block.begin(),
+                      block.begin() + static_cast<ptrdiff_t>(f * 2));
+        rendered += f;
+    }
+    eng.setTransportPlaying(false);
+    return output;
+}
+
+// RMS over a range in a single channel (ch = 0 for L, 1 for R)
+static double channelRmsDb(const std::vector<float>& data,
+                           uint32_t ch, uint32_t numChannels,
+                           size_t startSample, size_t endSample)
+{
+    double sumSq = 0.0;
+    size_t count = 0;
+    for (size_t i = startSample * numChannels + ch;
+         i < endSample * numChannels;
+         i += numChannels) {
+        double s = static_cast<double>(data[i]);
+        sumSq += s * s;
+        ++count;
+    }
+    if (count == 0) return -INFINITY;
+    return 10.0 * std::log10(sumSq / static_cast<double>(count));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Noise floor
+// ---------------------------------------------------------------------------
+static void testNoiseFloor() {
+    std::printf("\n[1. Noise floor]\n");
+
+    AudioEngine eng;
+    eng.setSampleRate(48000);
+    eng.setBufferConfig(512, 2);
+    eng.setSafetyLimiterEnabled(false);
+    eng.initialize();
+
+    std::vector<float> out(512 * 2);
+    uint32_t warmupBlocks = 48000 / 512;
+    uint32_t measureBlocks = warmupBlocks;
+
+    for (uint32_t i = 0; i < warmupBlocks; ++i)
+        eng.processBlock(out.data(), nullptr, 512, 0.0);
+
+    double noiseSumSq = 0.0;
+    uint64_t totalSamples = 0;
+    double dcSum = 0.0;
+    for (uint32_t i = 0; i < measureBlocks; ++i) {
+        eng.processBlock(out.data(), nullptr, 512, 0.0);
+        for (uint32_t j = 0; j < 512 * 2; ++j) {
+            double s = static_cast<double>(out[j]);
+            noiseSumSq += s * s;
+            dcSum += s;
+        }
+        totalSamples += 512 * 2;
+    }
+
+    double rms = 10.0 * std::log10(noiseSumSq / static_cast<double>(totalSamples));
+    double dc = dcSum / static_cast<double>(totalSamples);
+
+    std::printf("    RMS noise floor: %.1f dBFS\n", rms);
+    std::printf("    DC offset: %.2e\n", dc);
+
+    CHECK(rms < -120.0, "Noise floor below -120 dBFS");
+    CHECK(std::abs(dc) < 1e-8, "DC offset negligible");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Distortion: null-test residual across multiple frequencies/amplitudes
+// ---------------------------------------------------------------------------
+static void testDistortionNull() {
+    std::printf("\n[2. Distortion null test]\n");
+
+    const uint32_t sampleRate = 48000;
+    const uint32_t blockSize = 512;
+    const uint32_t duration = 2;
+    const uint32_t totalFrames = sampleRate * duration;
+
+    struct TestPoint {
+        double freq;
+        double ampDb;
+        double thresholdDb; // max acceptable null error
+    };
+
+    TestPoint tests[] = {
+        {100.0,   -6.0, -90.0},
+        {440.0,   -6.0, -90.0},
+        {1000.0,  -6.0, -90.0},
+        {5000.0,  -6.0, -80.0},
+        {100.0,  -40.0, -80.0},
+        {1000.0, -40.0, -80.0},
+    };
+
+    for (auto& t : tests) {
+        double ampLin = std::pow(10.0, t.ampDb / 20.0);
+        // Build a reference sine with the expected pan-law scaling
+        // (cos(pi/4) per channel at center pan)
+        constexpr double kPanLawCenterGain = 0.7071067811865476;
+        double refAmp = ampLin * kPanLawCenterGain;
+
+        std::vector<float> output = renderSine(
+            sampleRate, totalFrames, blockSize, t.freq, ampLin);
+
+        // Compute null residual against expected
+        size_t trimStart = blockSize; // skip gain ramp
+        size_t trimEnd = totalFrames - 256; // skip clip-edge fade
+        double rmsSumSq = 0.0;
+        double sigSumSq = 0.0;
+        uint64_t count = 0;
+        for (size_t i = trimStart * 2; i < trimEnd * 2; i += 2) {
+            double expected = refAmp * std::sin(
+                kTau * t.freq * (i / 2) / sampleRate);
+            double actual = static_cast<double>(output[i]);
+            double diff = actual - expected;
+            rmsSumSq += diff * diff;
+            sigSumSq += actual * actual;
+            ++count;
+        }
+        double nullDb = (sigSumSq > 0.0 && count > 0)
+            ? 10.0 * std::log10(rmsSumSq / sigSumSq)
+            : -INFINITY;
+
+        std::printf("    %5.0f Hz @ %5.1f dBFS: null = %.1f dB\n",
+                    t.freq, t.ampDb, nullDb);
+        CHECK(nullDb < t.thresholdDb,
+              (std::to_string((int)t.freq) + " Hz @ " +
+               std::to_string((int)t.ampDb) + " dBFS null").c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Frequency response
+// ---------------------------------------------------------------------------
+static void testFrequencyResponse() {
+    std::printf("\n[3. Frequency response]\n");
+
+    const uint32_t sampleRate = 48000;
+    const uint32_t blockSize = 512;
+    const uint32_t durationFrames = sampleRate / 2; // 0.5s
+    const double testFreqs[] = {20.0, 100.0, 440.0, 1000.0, 5000.0,
+                                10000.0, 16000.0, 20000.0};
+    const double refAmp = 0.5; // -6 dBFS
+    constexpr double kPanLawCenterGain = 0.7071067811865476;
+    double expectedRmsDb = 10.0 * std::log10(
+        (refAmp * kPanLawCenterGain) * (refAmp * kPanLawCenterGain) / 2.0);
+
+    for (double freq : testFreqs) {
+        std::vector<float> output = renderSine(
+            sampleRate, durationFrames, blockSize, freq, refAmp);
+
+        // Measure RMS in last quarter (after transients settle)
+        size_t measureStart = durationFrames * 3 / 4;
+        double outRmsDb = channelRmsDb(output, 0, 2, measureStart, durationFrames);
+        double error = outRmsDb - expectedRmsDb;
+
+        std::printf("    %6.0f Hz: output %.1f dBFS (error %.1f dB)\n",
+                    freq, outRmsDb, error);
+        double tolerance = (freq <= 100.0 || freq >= 16000.0) ? 2.0 : 1.0;
+        CHECK(std::abs(error) < tolerance,
+              (std::to_string((int)freq) + " Hz magnitude").c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Channel crosstalk
+// ---------------------------------------------------------------------------
+static void testChannelCrosstalk() {
+    std::printf("\n[4. Channel crosstalk]\n");
+
+    const uint32_t sampleRate = 48000;
+    const uint32_t blockSize = 512;
+    const uint32_t durationFrames = sampleRate; // 1s
+    const double refAmp = 0.5;
+
+    // Feed signal to left only
+    std::vector<float> output = renderSine(
+        sampleRate, durationFrames, blockSize, 1000.0, refAmp, true);
+
+    size_t measureStart = blockSize;
+    size_t measureEnd = durationFrames - 256;
+
+    double lRmsDb = channelRmsDb(output, 0, 2, measureStart, measureEnd);
+    double rRmsDb = channelRmsDb(output, 1, 2, measureStart, measureEnd);
+
+    std::printf("    L RMS: %.1f dBFS, R RMS: %.1f dBFS\n", lRmsDb, rRmsDb);
+    CHECK(rRmsDb < -100.0, "Channel crosstalk <-100 dB (L-only signal)");
+    CHECK(lRmsDb > -20.0, "Left channel has signal");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Soft clipper verification
+// ---------------------------------------------------------------------------
+static void testSoftClipper() {
+    std::printf("\n[5. Soft clipper]\n");
+    // NOTE: softClipD is defined in AudioEngine.h but unused in processBlock.
+    // Tests document the transfer function for when/if it is connected.
+
+    auto softClip = [](double x) -> double {
+        if (x > 1.5) return 1.0;
+        if (x < -1.5) return -1.0;
+        double x2 = x * x;
+        return x * (27.0 + x2) / (27.0 + 9.0 * x2);
+    };
+
+    // Transfer curve spot checks
+    double s0 = softClip(0.0);
+    double s5 = softClip(0.5);  // computed: 0.5 * 27.25/29.25 = 0.4658
+    double s8 = softClip(0.8);  // computed: 0.8 * 27.64/32.76 = 0.675
+    double s1 = softClip(1.0);  // computed: 1.0 * 28.0/36.0 = 0.777...
+    double s2 = softClip(2.0);
+
+    CHECK(s0 == 0.0, "softClip(0) = 0");
+    CHECK(std::abs(s5 - 0.4658) < 1e-4, "softClip(0.5) = 0.466 (no unity region)");
+    CHECK(std::abs(s8 - 0.675) < 1e-3, "softClip(0.8) = 0.675");
+    CHECK(std::abs(s1 - 0.7778) < 1e-3, "softClip(1.0) = 0.778");
+    CHECK(s2 == 1.0, "softClip(2.0) = 1.0");
+    CHECK(softClip(-2.0) == -1.0, "softClip(-2.0) = -1.0");
+
+    // Monotonic
+    bool monotonic = true;
+    for (int i = 0; i < 1000; ++i) {
+        double x1 = (i / 1000.0) * 2.0 - 0.5;
+        double x2 = ((i + 1) / 1000.0) * 2.0 - 0.5;
+        if (softClip(x2) < softClip(x1)) { monotonic = false; break; }
+    }
+    CHECK(monotonic, "softClip monotonic");
+
+    std::printf("    Note: softClipD is defined but not connected in processBlock.\n");
+    std::printf("    Transfer: 0.0->%.4f, 0.5->%.4f, 0.8->%.4f, 1.0->%.4f, 2.0->%.4f\n",
+                s0, s5, s8, s1, s2);
+}
+
+// ---------------------------------------------------------------------------
+// 6. DC blocker
+// ---------------------------------------------------------------------------
+static void testDCBlocker() {
+    std::printf("\n[6. DC blocker]\n");
+    // NOTE: DCBlockerD is defined in AudioEngine.h but unused in processBlock.
+
+    constexpr double kR = 0.9997;
+    struct DCBlocker {
+        double x1 = 0.0, y1 = 0.0;
+        double process(double x) {
+            double y = x - x1 + kR * y1;
+            x1 = x;
+            y1 = y;
+            return y;
+        }
+    };
+
+    // Step response: after 50000 samples, near-zero
+    // R=0.9997 => time constant ~3333 samples; 50000 = ~15 time constants
+    DCBlocker blk;
+    double y = 0.0;
+    for (int i = 0; i < 50000; ++i) y = blk.process(1.0);
+    CHECK(std::abs(y) < 0.001, "DC blocker suppresses steady DC to <0.001");
+
+    // 1kHz passes with <1% attenuation
+    blk = DCBlocker{};
+    double maxAtten = 0.0;
+    for (int i = 0; i < 4800; ++i) {
+        double in = 0.5 * std::sin(kTau * 1000.0 * i / 48000.0);
+        double out = blk.process(in);
+        double atten = std::abs(out) / 0.5;
+        if (atten > maxAtten) maxAtten = atten;
+    }
+    CHECK(maxAtten > 0.99, "DC blocker passes 1kHz with >0.99 peak ratio");
+
+    // 20Hz: RMS gain should be very close to unity
+    // H(z) = (1 - z^-1) / (1 - R * z^-1); at 20Hz/48kHz gain >0.99
+    blk = DCBlocker{};
+    double inSumSq = 0.0, outSumSq = 0.0;
+    int warmup = 100; // skip startup transient
+    for (int i = 0; i < 4800; ++i) {
+        double in = 0.5 * std::sin(kTau * 20.0 * i / 48000.0);
+        double out = blk.process(in);
+        if (i >= warmup) {
+            inSumSq += in * in;
+            outSumSq += out * out;
+        }
+    }
+    double rmsGain = (inSumSq > 0.0) ? std::sqrt(outSumSq / inSumSq) : 0.0;
+    CHECK(rmsGain > 0.95, "DC blocker passes 20Hz with >0.95 RMS gain");
+    std::printf("    Note: DCBlockerD defined but NOT connected in processBlock.\n");
+    std::printf("    20Hz RMS gain: %.4f (R=%.4f)\n", rmsGain, kR);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+int main() {
+    std::printf("============================================================\n");
+    std::printf("  Aestra Audio — End-to-End Quality Audit\n");
+    std::printf("============================================================\n");
+
+    testNoiseFloor();
+    testDistortionNull();
+    testFrequencyResponse();
+    testChannelCrosstalk();
+    testSoftClipper();
+    testDCBlocker();
+
+    std::printf("\n============================================================\n");
+    std::printf("  Results: %d/%d passed, %d failed\n",
+                g_pass, g_pass + g_fail, g_fail);
+    std::printf("============================================================\n");
+
+    return g_fail > 0 ? 1 : 0;
+}

--- a/Tests/AestraAudio/AudioQualityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioQualityAuditTest.cpp
@@ -16,9 +16,11 @@
 #include "Models/TrackManager.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cmath>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -60,7 +62,13 @@ static std::vector<float> renderSine(
     tm->setOutputSampleRate(static_cast<double>(sampleRate));
     tm->addChannel("QualityTest");
 
-    std::string path = "/tmp/quality_audit_src.wav";
+    // Portable temp path with a per-run unique name (avoids collisions in
+    // parallel test runs; the source is in-memory, path is metadata only)
+    static const std::string path =
+        (std::filesystem::temp_directory_path() /
+         ("aestra_quality_audit_src_" +
+          std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+          ".wav")).string();
     ClipSourceID srcId = tm->getSourceManager().createRecordedSource(
         path, "quality_src", buf);
     double durationSec = static_cast<double>(durationFrames) / sampleRate;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1132,6 +1132,35 @@ target_include_directories(GoldenReferenceTest PRIVATE
 add_test(NAME GoldenReferenceTest COMMAND GoldenReferenceTest)
 set_tests_properties(GoldenReferenceTest PROPERTIES LABELS "audio;quality;golden;s-tier")
 
+# Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
+    add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)
+    target_link_libraries(AudioQualityAuditTest PRIVATE AestraAudio)
+    target_include_directories(AudioQualityAuditTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME AudioQualityAuditTest COMMAND AudioQualityAuditTest)
+    set_tests_properties(AudioQualityAuditTest PROPERTIES LABELS "audio;quality;audit;s-tier")
+endif()
+
+# AudioEngine Torture Test — stress harness: silence, NaN/Inf, extreme gain,
+# buffer switching, sample rate switching, transport hammering, multi-track load
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineTortureTest.cpp")
+    add_executable(AudioEngineTortureTest AestraAudio/AudioEngineTortureTest.cpp)
+    target_link_libraries(AudioEngineTortureTest PRIVATE AestraAudio)
+    target_include_directories(AudioEngineTortureTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME AudioEngineTortureTest COMMAND AudioEngineTortureTest)
+    set_tests_properties(AudioEngineTortureTest PROPERTIES LABELS "audio;stress;torture;s-tier")
+endif()
+
 # Export/Bounce Parity Test — Master bounce must equal sum of isolated
 # track bounces to within -80 dB RMS (accounting for master stage processing).
 add_executable(ExportBounceParityTest AestraAudio/ExportBounceParityTest.cpp)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1143,7 +1143,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME AudioQualityAuditTest COMMAND AudioQualityAuditTest)
-    set_tests_properties(AudioQualityAuditTest PROPERTIES LABELS "audio;quality;audit;s-tier")
+    set_tests_properties(AudioQualityAuditTest PROPERTIES LABELS "audio;quality;audit;s-tier" TIMEOUT 180)
 endif()
 
 # AudioEngine Torture Test — stress harness: silence, NaN/Inf, extreme gain,
@@ -1157,8 +1157,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineTortureTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
+    # In Debug configs the engine library keeps assert() live and
+    # AudioEngine::processBlock hard-asserts on NaN/Inf, so the poisoned-input
+    # cases must be skipped there. Tests compile with -UNDEBUG unconditionally
+    # (see top of this file), so the test cannot detect the engine's build
+    # config itself — pass it in explicitly.
+    target_compile_definitions(AudioEngineTortureTest PRIVATE
+        $<$<CONFIG:Debug>:AESTRA_ENGINE_ASSERTS_ACTIVE=1>)
     add_test(NAME AudioEngineTortureTest COMMAND AudioEngineTortureTest)
-    set_tests_properties(AudioEngineTortureTest PROPERTIES LABELS "audio;stress;torture;s-tier")
+    set_tests_properties(AudioEngineTortureTest PROPERTIES LABELS "audio;stress;torture;s-tier" TIMEOUT 300)
 endif()
 
 # Export/Bounce Parity Test — Master bounce must equal sum of isolated


### PR DESCRIPTION
## Summary
Adds two standalone S-tier test harnesses recovered from the audio quality audit session:

- **`AudioQualityAuditTest`** (28 checks) — end-to-end quality measurement through the full engine path: noise floor (< −120 dBFS, measured −inf), null-test distortion residuals at 6 frequency/amplitude points (−90/−80 dB thresholds, measured −145 to −150 dB), frequency response 20 Hz–20 kHz (±1 dB mid-band, ±2 dB at edges), channel crosstalk (< −100 dB, measured −inf), plus transfer-curve verification of the soft clipper and DC blocker math. Labels: `audio;quality;audit;s-tier`.
- **`AudioEngineTortureTest`** (16 checks) — hostile-condition stress harness: sustained-silence denormal checks, NaN/Inf injection and recovery, extreme gain (+100 dB) boundedness, buffer-size switching (64–4096 incl. 100 randomized changes), sample-rate switching (44.1k–96k), transport hammering (1000 play/stop cycles, seek-while-playing), 100-track load, and 30 s long-run RMS stability. The contract is "the engine does not explode": finite, bounded, zero-when-silent. Labels: `audio;stress;torture;s-tier`.

Both registrations in `Tests/CMakeLists.txt` are `if(EXISTS)`-guarded, matching the existing S-tier block pattern.

## Why
The SRC hardening work (#381) validated the resampler in isolation. These harnesses extend coverage to the full engine path and answer two standing questions: "where does Aestra lose information?" (audit) and "what makes the engine explode?" (torture). They ran as part of the audio quality audit session; this promotes them to registered CTest gates.

## Testing performed
- Built both targets in Release (`build-linux`).
- Direct runs: AudioQualityAuditTest **28/28**, AudioEngineTortureTest **16/16**, both exit 0.
- CTest: both discovered (#61/#62) and pass under `-R` and label selection.
- Full `-L audio` smoke: **47/47 passed** (105.7 s), confirming no interference with existing suites.

## Docs updated?
No — test-only change, no public behavior claims.

## Risk / rollback notes
- No production code touched; DSP, serialization, and export paths unchanged. Live/export parity unaffected.
- Audit sections 5–6 verify local reimplementations of `softClipD`/`DCBlockerD` and explicitly note those units are not yet connected in `processBlock` — they document intended transfer behavior and will guard the wiring when it lands, but cannot catch engine regressions today.
- The audit test writes a small temp file under `/tmp` (`quality_audit_src.wav` metadata path); headless-safe, no hardware dependency, so both tests are fine in the always-on CI tier.
- Rollback: revert the single commit (6a47326c); nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added two new standalone CTest audio harnesses:
  - `AudioQualityAuditTest` for end-to-end quality checks across noise floor, null-test distortion, frequency response, channel crosstalk, and math verification for the soft clipper and DC blocker.
  - `AudioEngineTortureTest` for stress testing silence handling, NaN/Inf recovery, extreme gain, buffer/sample-rate switching, transport hammering, large track counts, and long-run stability.
- Registered both tests in `Tests/CMakeLists.txt` behind `if(EXISTS ...)` guards, matching the existing test pattern and exposing them as labeled CTest targets.
- Kept the scope limited to test code and test registration; no production audio, DSP, serialization, or export paths were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->