### PR TITLE
fix: correct SRC history position indexing

### DIFF
--- a/AestraAudio/src/DSP/SampleRateConverter.cpp
+++ b/AestraAudio/src/DSP/SampleRateConverter.cpp
@@ -417,7 +417,6 @@ uint32_t SampleRateConverter::process(const float* input, uint32_t inputFrames, 
 
     // Hoisted constants (invariant across all frames in this call)
     const double historySizeD = static_cast<double>(m_history.size);
-    const double historySizeMinus1 = historySizeD - 1.0;
     const double historySizeMinusHalfTaps = historySizeD - static_cast<double>(halfTaps);
     const double halfTapsD = static_cast<double>(halfTaps);
     const double polyPhaseScale = static_cast<double>(SRCConstants::POLYPHASE_PHASES);
@@ -461,9 +460,9 @@ uint32_t SampleRateConverter::process(const float* input, uint32_t inputFrames, 
         const double srcPosMinusHalfTaps = srcPosition - halfTapsD;
         const double srcPosMinusHistorySize = srcPosition - historySizeMinusHalfTaps;
 
-        // Track historyPos directly: starts at historySizeMinus1 - srcNextDiff,
+        // Track historyPos directly: starts at historySizeD - srcNextDiff,
         // increases by invRatio each output sample iteration
-        double historyPos = historySizeMinus1 - srcNextDiff;
+        double historyPos = historySizeD - srcNextDiff;
 
         // Generate output samples while we have enough history
         while (outputFrames < maxOutputFrames) {
@@ -476,7 +475,7 @@ uint32_t SampleRateConverter::process(const float* input, uint32_t inputFrames, 
             if (nextOutputSrcPos < srcPosMinusHistorySize) {
                 nextOutputSrcPos = srcPosMinusHalfTaps;
                 srcNextDiff = srcPosition - nextOutputSrcPos;
-                historyPos = historySizeMinus1 - srcNextDiff;
+                historyPos = historySizeD - srcNextDiff;
             }
 
             const uint32_t intPos = static_cast<uint32_t>(historyPos);


### PR DESCRIPTION
## Summary

Corrects the sample-rate converter history-position calculation so the direct history cursor starts from `historySizeD - srcNextDiff` instead of `historySizeMinus1 - srcNextDiff`.

This came from the local `stash@{1}` candidate `wip/src-history-position-tweak` and is kept to the single SRC implementation change.

## Validation

- `git diff --check`
- `cmake --build build-linux -j2 --target CommandHistoryTest`
- `ctest --test-dir build-linux -R "CommandHistoryTest" --output-on-failure`
- `cmake --build build-linux -j2 --target ResamplerWarTest AestraSampleRateConverterTest`
- `ctest --test-dir build-linux -R "ResamplerWarTest" --output-on-failure`
- `./build-linux/Tests/AestraSampleRateConverterTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed the sample-rate converter’s history-position calculation so the direct history cursor now starts from `historySizeD - srcNextDiff` instead of `historySizeMinus1 - srcNextDiff`.
- Kept the update scoped to `SampleRateConverter::process()`, including the reset path when `nextOutputSrcPos` is reinitialized after a large seek/back-pressure case.
- This corrects internal resampling history indexing and coefficient/window selection without changing any public or exported API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->