### PR TITLE
fix: preserve persisted trackColorIndex on mixer rebuild (#283)

### DIFF
--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -203,12 +203,21 @@ void MixerViewModel::syncFromEngine(const Audio::TrackManager& trackManager,
             channel->slotIndex = info.slot;
             channel->channel = info.channel;
             channel->name = info.name;
-            channel->trackColorIndex = AestraUI::nearestPaletteIndex(info.color);
-            if (channel->trackColorIndex < 0) {
-                channel->trackColorIndex = static_cast<int>(newChannels.size()) % AestraUI::PALETTE_SIZE;
-            }
-            if (channel->channel) {
-                channel->channel->setTrackColorIndex(channel->trackColorIndex);
+            // The engine channel's palette index is the persisted source of truth
+            // (restored by ProjectSerializer on load). Derive from the RGBA color
+            // only when unset, and only then write the derived value back —
+            // otherwise a rebuild after load would clobber the saved index.
+            const int persistedIndex = info.channel ? info.channel->getTrackColorIndex() : -1;
+            if (persistedIndex >= 0 && persistedIndex < AestraUI::PALETTE_SIZE) {
+                channel->trackColorIndex = persistedIndex;
+            } else {
+                channel->trackColorIndex = AestraUI::nearestPaletteIndex(info.color);
+                if (channel->trackColorIndex < 0) {
+                    channel->trackColorIndex = static_cast<int>(newChannels.size()) % AestraUI::PALETTE_SIZE;
+                }
+                if (channel->channel) {
+                    channel->channel->setTrackColorIndex(channel->trackColorIndex);
+                }
             }
             channel->muted = info.muted;
             channel->soloed = info.soloed;

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -707,6 +707,82 @@ void testMixerLaneStateNumbersClampBeforeCast() {
     std::filesystem::remove_all(testDir);
 }
 
+void testTrackColorIndexRoundtrip() {
+    std::cout << "[TEST] trackColorIndex survives save/load roundtrip..." << std::endl;
+
+    auto testDir = makeTempDir();
+    std::filesystem::path testProject = testDir / "project.aes";
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "trackColorIndex": 5,
+                "clips": []
+            },
+            {
+                "name": "Track 2",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "trackColorIndex": 2,
+                "clips": []
+            },
+            {
+                "name": "Track 3",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(trackManager->getChannelCount() == 3);
+
+    assert(trackManager->getChannel(0)->getTrackColorIndex() == 5);
+    assert(trackManager->getChannel(1)->getTrackColorIndex() == 2);
+    // Lane without the field keeps the unset default.
+    assert(trackManager->getChannel(2)->getTrackColorIndex() == -1);
+
+    // Re-save and reload to verify the write side emits the field.
+    std::string saved = ProjectSerializer::serialize(trackManager, 120.0, 0.0, 0).contents;
+    assert(!saved.empty());
+
+    std::filesystem::path testProject2 = testDir / "project2.aes";
+    std::ofstream out2(testProject2);
+    out2 << saved;
+    out2.close();
+
+    auto trackManager2 = std::make_shared<TrackManager>();
+    auto result2 = ProjectSerializer::load(testProject2.string(), trackManager2);
+    assert(result2.ok);
+    assert(trackManager2->getChannelCount() == 3);
+    assert(trackManager2->getChannel(0)->getTrackColorIndex() == 5);
+    assert(trackManager2->getChannel(1)->getTrackColorIndex() == 2);
+    assert(trackManager2->getChannel(2)->getTrackColorIndex() == -1);
+
+    std::cout << "[PASS] trackColorIndex survives save/load roundtrip" << std::endl;
+
+    std::filesystem::remove_all(testDir);
+}
+
 void testProjectLoadWarningsAreBounded() {
     std::cout << "[TEST] Project load warnings are bounded..." << std::endl;
 
@@ -787,6 +863,7 @@ int main() {
     testV1FixtureMigratesToCurrentVersion();
     testAutomationTarget256DoesNotWrapToVolume();
     testMixerLaneStateNumbersClampBeforeCast();
+    testTrackColorIndexRoundtrip();
     testProjectLoadWarningsAreBounded();
 
     std::cout << "=== All tests passed ===" << std::endl;


### PR DESCRIPTION
## Summary

Fixes the user-visible half of #283: track colors reset on every project load even though `trackColorIndex` is saved and restored by `ProjectSerializer` (since 07ae3a61).

Root cause: `MixerViewModel`'s channel-rebuild path derived the palette index from the channel's RGBA color via `nearestPaletteIndex(info.color)` and **wrote that derived value back into the `MixerChannel`**, clobbering the value the serializer had just restored. The palette picker in `UIMixerStrip` only ever sets `trackColorIndex` — never the RGBA color — so the derivation always fell back to position-based defaults.

## Why

Users lose their track color customization on every project reload (#283).

## Changes

- `Source/Components/MixerViewModel.cpp`: on rebuild, prefer the engine channel's persisted `trackColorIndex` when it's a valid palette index; only derive from color (and only then write back) when unset.
- `Tests/Integration/ProjectLoadRegressionTest.cpp`: new `testTrackColorIndexRoundtrip` — loads a project with explicit indices (5, 2, absent), asserts restore, then re-serializes and reloads to prove the write side, including the unset (-1) default.

## Testing performed

- `ctest -R ProjectLoadRegressionTest` — passed (new roundtrip case confirmed in output).
- `Source/Components/MixerViewModel.cpp` syntax-checked with the app's include set (`g++ -fsyntax-only`) — the canonical local build dir is headless (UI off), so full UI compile is validated by CI's UI lanes.
- `git clang-format develop` — no changes needed.

## Change type

- DSP changed: no
- UI changed: yes (view-model logic only, no rendering)
- Serialization/project format changed: no (field already existed; test added)
- Build/CI config changed: no
- Public docs changed: no

## Risk / rollback

- Low risk: single code path, falls back to previous behavior when no persisted index exists (old projects, new tracks).
- Rollback: revert this commit; no state format involved.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserved `trackColorIndex` during mixer channel rebuild so a loaded project keeps its saved track color selection instead of recalculating and overwriting it from RGBA color.
- Added a fallback to derive a palette index from the channel color only when no valid saved index exists, keeping newly created or incomplete channels valid.
- Added a regression test covering `ProjectSerializer` save/load round-tripping for explicit `trackColorIndex` values and the default unset case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->