### PR TITLE
refactor: migrate last atomic_load/store call sites to AtomicSharedPtr (#251)

### DIFF
--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -172,7 +172,7 @@ void AestraAudioController::shutdown() {
 
 void AestraAudioController::setContent(std::shared_ptr<AestraContent> content) {
     m_content = content;
-    std::atomic_store_explicit(&m_rtContent, std::move(content), std::memory_order_release);
+    m_rtContent.store(std::move(content), std::memory_order_release);
 }
 
 bool AestraAudioController::openDefaultStream(void* userData) {
@@ -282,7 +282,7 @@ bool AestraAudioController::startStream() {
     if (!m_initialized || !m_audioManager) return false;
     if (m_isAudioRunning) return true;
     if (auto content = m_content.lock()) {
-        std::atomic_store_explicit(&m_rtContent, content, std::memory_order_release);
+        m_rtContent.store(std::move(content), std::memory_order_release);
     }
 
     // 1. Get Actual Rate/Buffer from Driver (if any) BEFORE starting thread
@@ -310,7 +310,7 @@ bool AestraAudioController::startStream() {
             auto* controller = static_cast<AestraAudioController*>(user);
             if (controller) {
                 // Load once and reuse to avoid repeated atomic operations
-                auto content = std::atomic_load_explicit(&controller->m_rtContent, std::memory_order_acquire);
+                auto content = controller->m_rtContent.load(std::memory_order_acquire);
                 if (content) {
                     if (auto trackManager = content->getTrackManager()) {
                         trackManager->updateInputDiagnostics(input, n);
@@ -363,7 +363,7 @@ bool AestraAudioController::startStream() {
 void AestraAudioController::stopStream() {
     if (m_audioManager) m_audioManager->stopStream();
     m_isAudioRunning = false;
-    std::atomic_store_explicit(&m_rtContent, std::shared_ptr<AestraContent>{}, std::memory_order_release);
+    m_rtContent.store(nullptr, std::memory_order_release);
 }
 
 void AestraAudioController::closeStream() {
@@ -419,7 +419,7 @@ int AestraAudioController::audioCallback(float* outputBuffer, const float* input
     }
 
     // Load content snapshot once and reuse for the entire callback to avoid repeated atomic operations
-    auto content = std::atomic_load_explicit(&controller->m_rtContent, std::memory_order_acquire);
+    auto content = controller->m_rtContent.load(std::memory_order_acquire);
 
     if (inputBuffer && content) {
         if (auto trackManager = content->getTrackManager()) {

--- a/Source/Core/AestraAudioController.h
+++ b/Source/Core/AestraAudioController.h
@@ -1,14 +1,15 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
-#include <memory>
+#include "AestraAtomicSharedPtr.h"
+#include "AestraAudio.h"
+#include "AudioDeviceManager.h"
+#include "AudioEngine.h"
+
 #include <atomic>
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "AestraAudio.h"
-#include "AudioEngine.h"
-#include "AudioDeviceManager.h"
 
 // Forward declarations
 class AestraContent;
@@ -61,5 +62,5 @@ private:
 
     // Weak UI reference plus atomically published ownership for callback routing.
     std::weak_ptr<AestraContent> m_content;
-    std::shared_ptr<AestraContent> m_rtContent;
+    Aestra::AtomicSharedPtr<AestraContent> m_rtContent;
 };


### PR DESCRIPTION
## Summary

Completes #251. `AestraAudioController::m_rtContent` was the last remaining user of the C++17 free functions `std::atomic_load_explicit`/`std::atomic_store_explicit` on `shared_ptr` (deprecated in C++20, removed in C++26). It now uses the existing `Aestra::AtomicSharedPtr` wrapper from AestraCore — the same pattern already used by `AuditionEngine::m_currentSource`.

The wrapper selects `std::atomic<std::shared_ptr>` when the standard library provides it and falls back to the free functions on C++17, with deprecation suppression centralized in one header. All memory orderings preserved (`release` stores, `acquire` loads in the RT callback paths). No functional change.

Repo-wide grep confirms zero remaining `std::atomic_load/store/exchange` call sites outside the wrapper itself.

## Why

#251 — the free functions break on newer standards, and 14+ scattered call sites each needed their own deprecation handling. The wrapper migration was already started; this finishes it.

## Testing performed

- `g++ -std=c++17 -fsyntax-only` on `AestraAudioController.cpp` with the app's include set — clean.
- No test target compiles this TU (it's app-target-only); CI's Linux/Windows/macOS jobs build the full app and cover it on all three toolchains, including MSVC where `__cpp_lib_atomic_shared_ptr` availability differs.
- `git clang-format` applied (include block re-sorted per repo style).

## Change type

- DSP changed: no
- UI changed: no
- Serialization/project format changed: no
- Build/CI config changed: no
- Public docs changed: no

## Risk / rollback

- Very low: mechanical substitution with identical semantics under C++17; RT-path memory orderings unchanged.
- Rollback: revert the commit.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Migrated `AestraAudioController::m_rtContent` from a plain `std::shared_ptr` plus `std::atomic_load/store_explicit` calls to `Aestra::AtomicSharedPtr`.
- Updated all publish/read sites in `AestraAudioController.cpp` to use member `load()`/`store()` with the same acquire/release ordering as before.
- Added the `AestraAtomicSharedPtr.h` include in the controller header and changed the member type accordingly.
- This removes the last remaining deprecated free-function atomic operations on `shared_ptr`, aligning the controller with the existing atomic shared-ptr pattern and keeping C++20/C++26 deprecation warnings at bay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->