### PR TITLE
feat(dsp): 2x/4x oversampling quality mode for AestraComp (#228)

### DIFF
--- a/AestraAudio/include/DSP/Oversampler.h
+++ b/AestraAudio/include/DSP/Oversampler.h
@@ -148,16 +148,26 @@ public:
     static constexpr uint32_t kLatency4x = (kStage1Taps - 1) / 2 + (kStage2Taps - 1) / 4; // 30
     static constexpr uint32_t kReportedLatency = kLatency4x;                              // both OS modes report this
 
-    /// Non-RT. factor must be 1, 2, or 4 (anything else falls back to 1).
-    void prepare(uint32_t factor) {
-        m_factor = (factor == 2u || factor == 4u) ? factor : 1u;
-        if (m_factor >= 2u) {
-            m_stage1.design(kStage1Taps, kKaiserBeta);
-        }
-        if (m_factor == 4u) {
-            m_stage2.design(kStage2Taps, kKaiserBeta);
-        }
+    /// Non-RT: design both stage kernels (factor-independent). Call once from
+    /// the owner's initialize/activate; after that setFactor() is enough.
+    void prepareKernels() {
+        m_stage1.design(kStage1Taps, kKaiserBeta);
+        m_stage2.design(kStage2Taps, kKaiserBeta);
+        m_kernelsReady = true;
         reset();
+    }
+
+    /// RT-safe factor switch: selects 1/2/4 (anything else falls back to 1)
+    /// and resets filter state. Requires prepareKernels() to have run.
+    void setFactor(uint32_t factor) {
+        m_factor = (m_kernelsReady && (factor == 2u || factor == 4u)) ? factor : 1u;
+        reset();
+    }
+
+    /// Non-RT convenience: design kernels and select the factor in one call.
+    void prepare(uint32_t factor) {
+        prepareKernels();
+        setFactor(factor);
     }
 
     void reset() {
@@ -223,6 +233,7 @@ private:
     std::array<float, kPadLen> m_padHist{};
     uint32_t m_padPos = 0;
     uint32_t m_factor = 1;
+    bool m_kernelsReady = false;
 };
 
 } // namespace DSP

--- a/AestraAudio/include/DSP/Oversampler.h
+++ b/AestraAudio/include/DSP/Oversampler.h
@@ -1,0 +1,230 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Oversampler — per-sample polyphase halfband FIR oversampling for nonlinear DSP.
+//
+// Designed for plugins that process sample-by-sample (AestraComp, AestraLimit):
+// upsample one input sample into 2/4 subsamples, run the nonlinear stage at the
+// higher rate, then downsample back. Linear-phase Kaiser-windowed-sinc halfband
+// kernels are computed once in prepare() (non-RT); processing does no allocation,
+// no locks, and bounded work per sample.
+//
+// Latency (input-rate samples, integer by construction):
+//   Off = 0, oversampled = 30 (47-tap stage at 2fs + 29-tap stage at 4fs; the
+//   2x path is padded so 2x and 4x report identical latency).
+// Tap counts chosen by measurement: 47 taps at 2fs keeps 18 kHz round-trip
+// error below -79 dB (31 taps: -30 dB, audible ~0.3 dB droop).
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+
+namespace Aestra {
+namespace Audio {
+namespace DSP {
+
+/// One 2x halfband stage: polyphase interpolator + decimating FIR sharing the
+/// same linear-phase kernel. Mono; instantiate per channel.
+class HalfbandStage {
+public:
+    static constexpr uint32_t kMaxTaps = 47;
+
+    /// Compute the Kaiser-windowed-sinc halfband kernel. Non-RT (called from
+    /// plugin initialize/prepare). numTaps must be odd and <= kMaxTaps.
+    void design(uint32_t numTaps, double kaiserBeta) {
+        if (numTaps > kMaxTaps || (numTaps & 1u) == 0u) {
+            numTaps = kMaxTaps;
+        }
+        m_numTaps = numTaps;
+        const int32_t center = static_cast<int32_t>(numTaps - 1) / 2;
+        const double i0Beta = besselI0(kaiserBeta);
+        for (uint32_t n = 0; n < numTaps; ++n) {
+            const int32_t k = static_cast<int32_t>(n) - center;
+            const double window =
+                besselI0(kaiserBeta * std::sqrt(std::max(0.0, 1.0 - sq((2.0 * n) / (numTaps - 1) - 1.0)))) / i0Beta;
+            m_coeffs[n] = static_cast<float>(0.5 * sinc(0.5 * k) * window);
+        }
+        for (uint32_t n = numTaps; n < kMaxTaps; ++n) {
+            m_coeffs[n] = 0.0f;
+        }
+        reset();
+    }
+
+    void reset() {
+        m_upHist.fill(0.0f);
+        m_downHist.fill(0.0f);
+        m_downPos = 0;
+    }
+
+    uint32_t numTaps() const { return m_numTaps; }
+
+    /// One input sample -> two output samples at 2x rate.
+    /// out[p] = 2 * sum_j h[2j + p] * x[n - j]  (zero-stuff + FIR, gain 2)
+    void upsample(float in, float* out2) {
+        for (uint32_t j = kUpHistLen - 1; j > 0; --j) {
+            m_upHist[j] = m_upHist[j - 1];
+        }
+        m_upHist[0] = in;
+
+        float even = 0.0f;
+        float odd = 0.0f;
+        for (uint32_t j = 0; 2 * j < m_numTaps; ++j) {
+            even += m_coeffs[2 * j] * m_upHist[j];
+        }
+        for (uint32_t j = 0; 2 * j + 1 < m_numTaps; ++j) {
+            odd += m_coeffs[2 * j + 1] * m_upHist[j];
+        }
+        out2[0] = 2.0f * even;
+        out2[1] = 2.0f * odd;
+    }
+
+    /// Two input samples at 2x rate -> one output sample (decimating FIR).
+    /// The dot product is taken after the even subsample so the round-trip
+    /// group delay stays integer at the input rate: y[n] = sum_k h[k]*x2[2n-k].
+    float downsample(const float* in2) {
+        pushDown(in2[0]);
+        float acc = 0.0f;
+        uint32_t idx = m_downPos;
+        for (uint32_t k = 0; k < m_numTaps; ++k) {
+            acc += m_coeffs[k] * m_downHist[idx];
+            idx = (idx + 1u) % kMaxTaps;
+        }
+        pushDown(in2[1]);
+        return acc;
+    }
+
+private:
+    static constexpr uint32_t kUpHistLen = (kMaxTaps + 1) / 2;
+
+    void pushDown(float value) {
+        m_downPos = (m_downPos + kMaxTaps - 1u) % kMaxTaps;
+        m_downHist[m_downPos] = value;
+    }
+
+    static double sinc(double x) {
+        if (std::abs(x) < 1.0e-9) {
+            return 1.0;
+        }
+        const double px = 3.14159265358979323846 * x;
+        return std::sin(px) / px;
+    }
+
+    static double sq(double x) { return x * x; }
+
+    /// Zeroth-order modified Bessel function (series), for the Kaiser window.
+    static double besselI0(double x) {
+        double sum = 1.0;
+        double term = 1.0;
+        const double halfX = x * 0.5;
+        for (uint32_t k = 1; k < 32; ++k) {
+            term *= (halfX / k) * (halfX / k);
+            sum += term;
+            if (term < 1.0e-16 * sum) {
+                break;
+            }
+        }
+        return sum;
+    }
+
+    std::array<float, kMaxTaps> m_coeffs{};
+    std::array<float, kUpHistLen> m_upHist{};
+    std::array<float, kMaxTaps> m_downHist{};
+    uint32_t m_downPos = 0;
+    uint32_t m_numTaps = kMaxTaps;
+};
+
+/// Mono 1x/2x/4x oversampler built from cascaded halfband stages.
+/// The 2x path is padded with extra dry delay so 2x and 4x report the same
+/// total latency — switching between oversampled modes never changes plugin
+/// latency; only Off <-> On does.
+class Oversampler {
+public:
+    static constexpr uint32_t kStage1Taps = 47; // runs at 2x rate
+    static constexpr uint32_t kStage2Taps = 29; // runs at 4x rate
+    static constexpr double kKaiserBeta = 8.5;
+
+    // (taps-1) at 2fs halves at fs; (taps-1) at 4fs quarters at fs.
+    static constexpr uint32_t kLatency2x = (kStage1Taps - 1) / 2;                         // 23
+    static constexpr uint32_t kLatency4x = (kStage1Taps - 1) / 2 + (kStage2Taps - 1) / 4; // 30
+    static constexpr uint32_t kReportedLatency = kLatency4x;                              // both OS modes report this
+
+    /// Non-RT. factor must be 1, 2, or 4 (anything else falls back to 1).
+    void prepare(uint32_t factor) {
+        m_factor = (factor == 2u || factor == 4u) ? factor : 1u;
+        if (m_factor >= 2u) {
+            m_stage1.design(kStage1Taps, kKaiserBeta);
+        }
+        if (m_factor == 4u) {
+            m_stage2.design(kStage2Taps, kKaiserBeta);
+        }
+        reset();
+    }
+
+    void reset() {
+        m_stage1.reset();
+        m_stage2.reset();
+        m_padHist.fill(0.0f);
+        m_padPos = 0;
+    }
+
+    uint32_t factor() const { return m_factor; }
+
+    uint32_t latencySamples() const { return m_factor >= 2u ? kReportedLatency : 0u; }
+
+    /// One input sample -> factor() subsamples in out (out must hold >= 4).
+    void upsample(float in, float* out) {
+        switch (m_factor) {
+        case 2u:
+            m_stage1.upsample(in, out);
+            break;
+        case 4u: {
+            float mid[2];
+            m_stage1.upsample(in, mid);
+            m_stage2.upsample(mid[0], out);
+            m_stage2.upsample(mid[1], out + 2);
+            break;
+        }
+        default:
+            out[0] = in;
+            break;
+        }
+    }
+
+    /// factor() subsamples -> one output sample. The 2x path adds
+    /// kLatency4x - kLatency2x samples of pure delay so latencySamples()
+    /// matches the reported constant.
+    float downsample(const float* in) {
+        switch (m_factor) {
+        case 2u:
+            return pad(m_stage1.downsample(in));
+        case 4u: {
+            float mid[2];
+            mid[0] = m_stage2.downsample(in);
+            mid[1] = m_stage2.downsample(in + 2);
+            return m_stage1.downsample(mid);
+        }
+        default:
+            return in[0];
+        }
+    }
+
+private:
+    static constexpr uint32_t kPadLen = kLatency4x - kLatency2x; // 7
+
+    float pad(float value) {
+        const float delayed = m_padHist[m_padPos];
+        m_padHist[m_padPos] = value;
+        m_padPos = (m_padPos + 1u) % kPadLen;
+        return delayed;
+    }
+
+    HalfbandStage m_stage1;
+    HalfbandStage m_stage2;
+    std::array<float, kPadLen> m_padHist{};
+    uint32_t m_padPos = 0;
+    uint32_t m_factor = 1;
+};
+
+} // namespace DSP
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/AestraComp.h
+++ b/AestraAudio/include/Plugin/AestraComp.h
@@ -1,8 +1,11 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
-// AestraComp V1 — zero-latency feed-forward compressor.
+// AestraComp V1 — feed-forward compressor. Zero latency with oversampling Off
+// (the default); 2x/4x oversampling adds DSP::Oversampler::kReportedLatency
+// samples, reported via getLatencySamples().
 
 #pragma once
 
+#include "DSP/Oversampler.h"
 #include "Plugin/PluginHost.h"
 
 #include <algorithm>
@@ -47,17 +50,18 @@ public:
 
     enum Param : uint32_t {
         kThreshold = 0, // -60 dB to 0 dB
-        kRatio,        // 1:1 to 20:1
-        kAttack,       // 0.1 ms to 100 ms
-        kRelease,      // 10 ms to 1000 ms
-        kMakeup,       // 0 dB to +24 dB
-        kKnee,         // 0 dB to 24 dB
-        kMix,          // 0% to 100%
+        kRatio,         // 1:1 to 20:1
+        kAttack,        // 0.1 ms to 100 ms
+        kRelease,       // 10 ms to 1000 ms
+        kMakeup,        // 0 dB to +24 dB
+        kKnee,          // 0 dB to 24 dB
+        kMix,           // 0% to 100%
         kBypass,
         kInputGain,    // -24 dB to +24 dB
         kOutputGain,   // -24 dB to +24 dB
         kDetectorHPF,  // Off, then 20 Hz to 500 Hz
         kCompMode,     // 0=Clean, 1=Classic, 2=Optical
+        kOversampling, // 0=Off, 1=2x, 2=4x (nonlinear stage anti-aliasing)
         kParamCount,
 
         // Deprecated aliases. These names are kept so older tests and helpers still
@@ -103,6 +107,8 @@ public:
         for (const auto& param : getParameters()) {
             m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
         }
+        applyOversamplingConfig();
+        m_oversamplingDirty.store(false, std::memory_order_release);
         resetRuntimeState();
         snapSmoothedParamsToTargets();
         updateDetectorHPF();
@@ -114,6 +120,8 @@ public:
 
     void activate() override {
         m_active.store(true, std::memory_order_relaxed);
+        applyOversamplingConfig();
+        m_oversamplingDirty.store(false, std::memory_order_release);
         resetRuntimeState();
         snapSmoothedParamsToTargets();
         updateDetectorHPF();
@@ -130,9 +138,20 @@ public:
         (void)midiInput;
         (void)midiOutput;
 
+        if (m_oversamplingDirty.exchange(false, std::memory_order_acq_rel)) {
+            applyOversamplingConfig();
+        }
+        const uint32_t osFactor = m_osFactor;
+
         if (!m_active.load(std::memory_order_relaxed) ||
             m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
-            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            if (osFactor <= 1u) {
+                copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            } else {
+                // With oversampling active the plugin reports nonzero latency;
+                // internal bypass must delay by the same amount to stay aligned.
+                copyDelayed(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            }
             return;
         }
 
@@ -180,8 +199,11 @@ public:
                 m_feedbackR = 0.0f;
             }
 
-            const float attackCoeff = std::exp(-1.0f / (static_cast<float>(m_sampleRate) * attackSec));
-            const float releaseCoeff = std::exp(-1.0f / (static_cast<float>(m_sampleRate) * releaseSec));
+            // Envelope coefficients live at the detector rate: native fs with
+            // oversampling Off, fs * factor when the nonlinear stage runs
+            // oversampled. m_detectorRate == (float)m_sampleRate for factor 1.
+            const float attackCoeff = std::exp(-1.0f / (m_detectorRate * attackSec));
+            const float releaseCoeff = std::exp(-1.0f / (m_detectorRate * releaseSec));
             const float makeupOut = makeupLinear * outputLinear;
 
             for (uint32_t i = blockStart; i < blockEnd; ++i) {
@@ -193,81 +215,54 @@ public:
             const float inR = dryR * inputLinear;
             blockInputPeak = std::max(blockInputPeak, std::max(std::abs(inL), std::abs(inR)));
 
-            float detInputL, detInputR;
-            if (m_mode == kModeClassic) {
-                detInputL = m_feedbackL;
-                detInputR = m_feedbackR;
-            } else {
-                detInputL = inL;
-                detInputR = inR;
-            }
-
-            float detL = detInputL;
-            float detR = detInputR;
-            if (m_detectorHPFEnabled) {
-                detL = m_hpfA0 * detL + m_hpfA1 * hpfXL + m_hpfB1 * hpfYL;
-                hpfXL = detInputL;
-                hpfYL = detL;
-                detR = m_hpfA0 * detR + m_hpfA1 * hpfXR + m_hpfB1 * hpfYR;
-                hpfXR = detInputR;
-                hpfYR = detR;
-            }
-
-            const float powerInstant = (detL * detL + detR * detR) * 0.5f;
-            float sampleRmsCoeff;
-            if (m_mode == kModeOptical) {
-                static constexpr float kOpticalWindowMin = 0.005f;
-                static constexpr float kOpticalWindowMax = 0.030f;
-                static constexpr float kOpticalEnvelopeRef = 0.1f;
-                float t = std::clamp(m_rmsEnvelope / kOpticalEnvelopeRef, 0.0f, 1.0f);
-                float window = kOpticalWindowMax - t * (kOpticalWindowMax - kOpticalWindowMin);
-                // Gate exp() — only recompute when window changes by >0.5ms
-                if (std::abs(window - m_prevOpticalWindow) > 0.0005f || m_prevOpticalWindow < 0.0f) {
-                    m_prevOpticalWindow = window;
-                    m_opticalRmsCoeff = std::exp(-1.0f / (static_cast<float>(m_sampleRate) * window));
+            float wetL = 0.0f;
+            float wetR = 0.0f;
+            float outL;
+            float outR;
+            if (osFactor <= 1u) {
+                processCore(inL, inR, attackCoeff, releaseCoeff, thresholdDb, ratio, kneeDb, makeupLinear, env, hpfXL,
+                            hpfYL, hpfXR, hpfYR, blockGainReductionDb, wetL, wetR);
+                outL = (dryL * (1.0f - mix) + wetL * mix) * outputLinear;
+                outR = (dryR * (1.0f - mix) + wetR * mix) * outputLinear;
+                if (m_mode == kModeClassic) {
+                    m_feedbackL = outL;
+                    m_feedbackR = outR;
                 }
-                sampleRmsCoeff = m_opticalRmsCoeff;
             } else {
-                sampleRmsCoeff = m_rmsCoeff;
-                m_prevOpticalWindow = -1.0f; // force recompute on next optical entry
+                // Oversampled nonlinear stage: detector + gain computer + VCA run
+                // at m_detectorRate; only the wet path is filtered, the dry path
+                // is delayed by the same amount so mix stays phase-aligned.
+                float osInL[4];
+                float osInR[4];
+                float osWetL[4];
+                float osWetR[4];
+                m_osL.upsample(inL, osInL);
+                m_osR.upsample(inR, osInR);
+                for (uint32_t sub = 0; sub < osFactor; ++sub) {
+                    processCore(osInL[sub], osInR[sub], attackCoeff, releaseCoeff, thresholdDb, ratio, kneeDb,
+                                makeupLinear, env, hpfXL, hpfYL, hpfXR, hpfYR, blockGainReductionDb, osWetL[sub],
+                                osWetR[sub]);
+                    if (m_mode == kModeClassic) {
+                        // Feedback topology needs an output estimate per subsample;
+                        // synthesize it from the oversampled dry/wet pair.
+                        m_feedbackL = (osInL[sub] * (1.0f - mix) + osWetL[sub] * mix) * outputLinear;
+                        m_feedbackR = (osInR[sub] * (1.0f - mix) + osWetR[sub] * mix) * outputLinear;
+                    }
+                }
+                wetL = m_osL.downsample(osWetL);
+                wetR = m_osR.downsample(osWetR);
+                float dryDelayedL;
+                float dryDelayedR;
+                pushDryDelay(dryL, dryR, dryDelayedL, dryDelayedR);
+                outL = (dryDelayedL * (1.0f - mix) + wetL * mix) * outputLinear;
+                outR = (dryDelayedR * (1.0f - mix) + wetR * mix) * outputLinear;
             }
-            m_rmsEnvelope = powerInstant + sampleRmsCoeff * (m_rmsEnvelope - powerInstant);
-            const float detector = std::sqrt(m_rmsEnvelope);
-
-            float aCoeff, rCoeff;
-            if (m_mode == kModeOptical) {
-                static constexpr float kOpticalEnvelopeRef = 0.1f;
-                float grNorm = std::clamp(m_rmsEnvelope / kOpticalEnvelopeRef, 0.0f, 1.0f);
-                aCoeff = attackCoeff * (1.0f + grNorm * 2.0f);
-                rCoeff = releaseCoeff * (1.0f - grNorm * 0.5f);
-            } else {
-                aCoeff = attackCoeff;
-                rCoeff = releaseCoeff;
-            }
-            const float coeff = detector > env ? aCoeff : rCoeff;
-            env = coeff * env + (1.0f - coeff) * detector;
-            if (env != env || env < 1.0e-12f) env = 0.0f; // NaN check + denormal flush
-
-            const float detectorDb = linearToDb(env);
-            const float reductionDb = computeGainReductionDb(detectorDb, thresholdDb, ratio, kneeDb);
-            const float reductionLinear = dbToLinear(reductionDb);
-            blockGainReductionDb = std::max(blockGainReductionDb, -reductionDb);
-
-            const float wetL = (inL * reductionLinear) * makeupLinear;
-            const float wetR = (inR * reductionLinear) * makeupLinear;
-            const float outL = (dryL * (1.0f - mix) + wetL * mix) * outputLinear;
-            const float outR = (dryR * (1.0f - mix) + wetR * mix) * outputLinear;
             blockOutputPeak = std::max(blockOutputPeak, std::max(std::abs(outL), std::abs(outR)));
 
             // Accumulate mono sum for FFT
             const uint32_t fftIdx = i - blockStart;
             fftInBlock[fftIdx] = (inL + inR) * 0.5f;
             fftOutBlock[fftIdx] = (outL + outR) * 0.5f;
-
-            if (m_mode == kModeClassic) {
-                m_feedbackL = outL;
-                m_feedbackR = outR;
-            }
 
             if (numOutputChannels > 0 && outputs[0]) outputs[0][i] = flushDenormal(outL);
             if (numOutputChannels > 1 && outputs[1]) outputs[1][i] = flushDenormal(outR);
@@ -309,6 +304,9 @@ public:
         if (id == kDetectorHPF) {
             m_detectorHPFDirty.store(true, std::memory_order_release);
         }
+        if (id == kOversampling) {
+            m_oversamplingDirty.store(true, std::memory_order_release);
+        }
 
         if (!m_hasProcessed.load(std::memory_order_relaxed)) {
             switch (id) {
@@ -328,18 +326,19 @@ public:
 
     std::vector<PluginParameter> getParameters() const override {
         return {
-            { kThreshold, "Threshold", "THR", "dB", 0.6667f, 0.0f, 1.0f, true },
-            { kRatio, "Ratio", "RAT", ":1", 0.1579f, 0.0f, 1.0f, true },
-            { kAttack, "Attack", "ATK", "ms", 0.0991f, 0.0f, 1.0f, true },
-            { kRelease, "Release", "REL", "ms", 0.1414f, 0.0f, 1.0f, true },
-            { kMakeup, "Makeup Gain", "MKP", "dB", 0.0f, 0.0f, 1.0f, true },
-            { kKnee, "Knee", "KNE", "dB", 0.0f, 0.0f, 1.0f, true },
-            { kMix, "Mix", "MIX", "%", 1.0f, 0.0f, 1.0f, true },
-            { kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1 },
-            { kInputGain, "Input Gain", "IN", "dB", 0.5f, 0.0f, 1.0f, true },
-            { kOutputGain, "Output Gain", "OUT", "dB", 0.5f, 0.0f, 1.0f, true },
-            { kDetectorHPF, "Detector HPF", "HPF", "Hz", 0.0f, 0.0f, 1.0f, true },
-            { kCompMode, "Mode", "MODE", "", 0.0f, 0.0f, 1.0f, true },
+            {kThreshold, "Threshold", "THR", "dB", 0.6667f, 0.0f, 1.0f, true},
+            {kRatio, "Ratio", "RAT", ":1", 0.1579f, 0.0f, 1.0f, true},
+            {kAttack, "Attack", "ATK", "ms", 0.0991f, 0.0f, 1.0f, true},
+            {kRelease, "Release", "REL", "ms", 0.1414f, 0.0f, 1.0f, true},
+            {kMakeup, "Makeup Gain", "MKP", "dB", 0.0f, 0.0f, 1.0f, true},
+            {kKnee, "Knee", "KNE", "dB", 0.0f, 0.0f, 1.0f, true},
+            {kMix, "Mix", "MIX", "%", 1.0f, 0.0f, 1.0f, true},
+            {kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1},
+            {kInputGain, "Input Gain", "IN", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kOutputGain, "Output Gain", "OUT", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kDetectorHPF, "Detector HPF", "HPF", "Hz", 0.0f, 0.0f, 1.0f, true},
+            {kCompMode, "Mode", "MODE", "", 0.0f, 0.0f, 1.0f, true},
+            {kOversampling, "Oversampling", "OS", "", 0.0f, 0.0f, 1.0f, true, false, false, 2},
         };
     }
 
@@ -370,6 +369,14 @@ public:
             if (mode == kModeOptical) return "Optical";
             return "Clean";
         }
+        case kOversampling: {
+            const uint32_t factor = oversamplingFactorFromNorm(v);
+            if (factor == 4u)
+                return "4x";
+            if (factor == 2u)
+                return "2x";
+            return "Off";
+        }
         default: return "";
         }
     }
@@ -377,14 +384,16 @@ public:
     std::vector<uint8_t> saveState() const override {
         struct Blob {
             uint32_t magic = kStateMagicV2;
-            uint32_t version = 4;
+            uint32_t version = 5;
             float params[kLegacyParamCount] = {};
         } blob;
 
+        // v5: slot 12 (formerly the unused legacy Range filler) now carries
+        // kOversampling. Older readers never consume slot 12, so v5 blobs
+        // load cleanly in pre-oversampling builds.
         for (uint32_t i = 0; i < kParamCount; ++i) {
             blob.params[i] = getParameter(i);
         }
-        blob.params[kLegacyRangeIndex] = 0.0f;
         blob.params[kLegacyLookaheadIndex] = 0.0f;
         blob.params[kLegacyStereoLinkIndex] = 1.0f;
         blob.params[kLegacyStereoLinkLawIndex] = 0.0f;
@@ -415,6 +424,12 @@ public:
             loadDefaults();
             for (uint32_t i = 0; i < std::min<uint32_t>(8, kParamCount); ++i) {
                 setParameter(i, blob.params[i]);
+            }
+            if (blob.version >= 5) {
+                setParameter(kOversampling,
+                             isNormalized(blob.params[kOversampling]) ? blob.params[kOversampling] : 0.0f);
+            } else {
+                setParameter(kOversampling, 0.0f);
             }
             if (blob.version >= 4) {
                 setParameter(kInputGain, isNormalized(blob.params[kInputGain]) ? blob.params[kInputGain] : 0.5f);
@@ -466,7 +481,13 @@ public:
     bool resizeEditor(int, int) override { return false; }
 
     const PluginInfo& getInfo() const override { return m_info; }
-    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getLatencySamples() const override {
+        // NOTE: latency changes when kOversampling toggles Off <-> On, but the
+        // host currently only re-reads plugin latency on graph rebuild
+        // (insert/remove/bypass/reload) — see #270. Both oversampled modes
+        // report the same value so switching 2x <-> 4x never misaligns.
+        return m_reportedLatency.load(std::memory_order_relaxed);
+    }
     uint32_t getTailSamples() const override { return 256; }
     WatchdogStats getWatchdogStats() const override { return {}; }
     void resetWatchdog() override {}
@@ -498,6 +519,140 @@ private:
         updateRmsCoeff();
     }
 
+    /// One step of the nonlinear stage (detector -> envelope -> gain computer ->
+    /// VCA) at the detector rate. With oversampling Off this is called once per
+    /// input sample and matches the pre-oversampling implementation exactly;
+    /// with 2x/4x it is called once per subsample.
+    void processCore(float inL, float inR, float attackCoeff, float releaseCoeff, float thresholdDb, float ratio,
+                     float kneeDb, float makeupLinear, float& env, float& hpfXL, float& hpfYL, float& hpfXR,
+                     float& hpfYR, float& blockGainReductionDb, float& wetL, float& wetR) {
+        float detInputL, detInputR;
+        if (m_mode == kModeClassic) {
+            detInputL = m_feedbackL;
+            detInputR = m_feedbackR;
+        } else {
+            detInputL = inL;
+            detInputR = inR;
+        }
+
+        float detL = detInputL;
+        float detR = detInputR;
+        if (m_detectorHPFEnabled) {
+            detL = m_hpfA0 * detL + m_hpfA1 * hpfXL + m_hpfB1 * hpfYL;
+            hpfXL = detInputL;
+            hpfYL = detL;
+            detR = m_hpfA0 * detR + m_hpfA1 * hpfXR + m_hpfB1 * hpfYR;
+            hpfXR = detInputR;
+            hpfYR = detR;
+        }
+
+        const float powerInstant = (detL * detL + detR * detR) * 0.5f;
+        float sampleRmsCoeff;
+        if (m_mode == kModeOptical) {
+            static constexpr float kOpticalWindowMin = 0.005f;
+            static constexpr float kOpticalWindowMax = 0.030f;
+            static constexpr float kOpticalEnvelopeRef = 0.1f;
+            float t = std::clamp(m_rmsEnvelope / kOpticalEnvelopeRef, 0.0f, 1.0f);
+            float window = kOpticalWindowMax - t * (kOpticalWindowMax - kOpticalWindowMin);
+            // Gate exp() — only recompute when window changes by >0.5ms
+            if (std::abs(window - m_prevOpticalWindow) > 0.0005f || m_prevOpticalWindow < 0.0f) {
+                m_prevOpticalWindow = window;
+                m_opticalRmsCoeff = std::exp(-1.0f / (m_detectorRate * window));
+            }
+            sampleRmsCoeff = m_opticalRmsCoeff;
+        } else {
+            sampleRmsCoeff = m_rmsCoeff;
+            m_prevOpticalWindow = -1.0f; // force recompute on next optical entry
+        }
+        m_rmsEnvelope = powerInstant + sampleRmsCoeff * (m_rmsEnvelope - powerInstant);
+        const float detector = std::sqrt(m_rmsEnvelope);
+
+        float aCoeff, rCoeff;
+        if (m_mode == kModeOptical) {
+            static constexpr float kOpticalEnvelopeRef = 0.1f;
+            float grNorm = std::clamp(m_rmsEnvelope / kOpticalEnvelopeRef, 0.0f, 1.0f);
+            aCoeff = attackCoeff * (1.0f + grNorm * 2.0f);
+            rCoeff = releaseCoeff * (1.0f - grNorm * 0.5f);
+        } else {
+            aCoeff = attackCoeff;
+            rCoeff = releaseCoeff;
+        }
+        const float coeff = detector > env ? aCoeff : rCoeff;
+        env = coeff * env + (1.0f - coeff) * detector;
+        if (env != env || env < 1.0e-12f)
+            env = 0.0f; // NaN check + denormal flush
+
+        const float detectorDb = linearToDb(env);
+        const float reductionDb = computeGainReductionDb(detectorDb, thresholdDb, ratio, kneeDb);
+        const float reductionLinear = dbToLinear(reductionDb);
+        blockGainReductionDb = std::max(blockGainReductionDb, -reductionDb);
+
+        wetL = (inL * reductionLinear) * makeupLinear;
+        wetR = (inR * reductionLinear) * makeupLinear;
+    }
+
+    static uint32_t oversamplingFactorFromNorm(float value) {
+        const auto step = static_cast<uint32_t>(std::round(std::clamp(value * 2.0f, 0.0f, 2.0f)));
+        if (step == 2u)
+            return 4u;
+        if (step == 1u)
+            return 2u;
+        return 1u;
+    }
+
+    /// Reconfigure the oversampling stage from the current parameter value.
+    /// Bounded work (kernel design is a few thousand flops, no allocation), so
+    /// it is safe to run on the audio thread when the parameter changes.
+    void applyOversamplingConfig() {
+        const uint32_t factor = oversamplingFactorFromNorm(m_params[kOversampling].load(std::memory_order_relaxed));
+        m_osFactor = factor;
+        m_detectorRate = static_cast<float>(m_sampleRate) * static_cast<float>(factor);
+        if (factor > 1u) {
+            m_osL.prepare(factor);
+            m_osR.prepare(factor);
+        }
+        m_dryDelayL.fill(0.0f);
+        m_dryDelayR.fill(0.0f);
+        m_dryDelayPos = 0;
+        m_reportedLatency.store(factor > 1u ? DSP::Oversampler::kReportedLatency : 0u, std::memory_order_relaxed);
+        m_prevOpticalWindow = -1.0f;
+        updateRmsCoeff();
+        updateDetectorHPF();
+    }
+
+    void pushDryDelay(float inL, float inR, float& outL, float& outR) {
+        outL = m_dryDelayL[m_dryDelayPos];
+        outR = m_dryDelayR[m_dryDelayPos];
+        m_dryDelayL[m_dryDelayPos] = inL;
+        m_dryDelayR[m_dryDelayPos] = inR;
+        m_dryDelayPos = (m_dryDelayPos + 1u) % DSP::Oversampler::kReportedLatency;
+    }
+
+    /// Bypass copy delayed by the reported oversampling latency. Channels >= 2
+    /// pass through like copyOrClear (the active path zeroes them instead, which
+    /// matches the pre-oversampling bypass behavior).
+    void copyDelayed(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                     uint32_t numFrames) {
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            const float inL = readInput(inputs, numInputChannels, 0, i);
+            const float inR = readInput(inputs, numInputChannels, 1, i);
+            float outL;
+            float outR;
+            pushDryDelay(inL, inR, outL, outR);
+            if (numOutputChannels > 0 && outputs[0])
+                outputs[0][i] = outL;
+            if (numOutputChannels > 1 && outputs[1])
+                outputs[1][i] = outR;
+        }
+        for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
     void resetRuntimeState() {
         m_env = 0.0f;
         m_rmsEnvelope = 0.0f;
@@ -508,6 +663,11 @@ private:
         m_hpfYR = 0.0f;
         m_feedbackL = 0.0f;
         m_feedbackR = 0.0f;
+        m_osL.reset();
+        m_osR.reset();
+        m_dryDelayL.fill(0.0f);
+        m_dryDelayR.fill(0.0f);
+        m_dryDelayPos = 0;
         m_currentGainReductionDb.store(0.0f, std::memory_order_relaxed);
         m_inputLevel.store(0.0f, std::memory_order_relaxed);
         m_outputLevel.store(0.0f, std::memory_order_relaxed);
@@ -556,16 +716,14 @@ private:
 
         const float frequency = detectorHPFHzFromNorm(raw);
         const float rc = 1.0f / (2.0f * 3.14159265358979323846f * frequency);
-        const float dt = 1.0f / static_cast<float>(m_sampleRate);
+        const float dt = 1.0f / m_detectorRate;
         const float alpha = rc / (rc + dt);
         m_hpfA0 = alpha;
         m_hpfA1 = -alpha;
         m_hpfB1 = alpha;
     }
 
-    void updateRmsCoeff() {
-        m_rmsCoeff = std::exp(-1.0f / std::max(1.0f, static_cast<float>(m_sampleRate) * kRmsWindowSec));
-    }
+    void updateRmsCoeff() { m_rmsCoeff = std::exp(-1.0f / std::max(1.0f, m_detectorRate * kRmsWindowSec)); }
 
     void initHannWindow() {
         for (uint32_t i = 0; i < kFftSize; ++i) {
@@ -797,6 +955,18 @@ private:
     uint32_t m_mode = 0;
     float m_prevOpticalWindow = -1.0f;
     float m_opticalRmsCoeff = 0.0f;
+
+    // Oversampling (issue #228). m_detectorRate is the rate the nonlinear
+    // stage runs at: (float)m_sampleRate * m_osFactor.
+    std::atomic<bool> m_oversamplingDirty{false};
+    std::atomic<uint32_t> m_reportedLatency{0};
+    uint32_t m_osFactor = 1;
+    float m_detectorRate = 48000.0f;
+    DSP::Oversampler m_osL;
+    DSP::Oversampler m_osR;
+    std::array<float, DSP::Oversampler::kReportedLatency> m_dryDelayL{};
+    std::array<float, DSP::Oversampler::kReportedLatency> m_dryDelayR{};
+    uint32_t m_dryDelayPos = 0;
 
     float m_thresholdSmoothed = 0.6667f;
     float m_ratioSmoothed = 0.1579f;

--- a/AestraAudio/include/Plugin/AestraComp.h
+++ b/AestraAudio/include/Plugin/AestraComp.h
@@ -107,6 +107,8 @@ public:
         for (const auto& param : getParameters()) {
             m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
         }
+        m_osL.prepareKernels();
+        m_osR.prepareKernels();
         applyOversamplingConfig();
         m_oversamplingDirty.store(false, std::memory_order_release);
         resetRuntimeState();
@@ -120,6 +122,8 @@ public:
 
     void activate() override {
         m_active.store(true, std::memory_order_relaxed);
+        m_osL.prepareKernels();
+        m_osR.prepareKernels();
         applyOversamplingConfig();
         m_oversamplingDirty.store(false, std::memory_order_release);
         resetRuntimeState();
@@ -601,20 +605,19 @@ private:
     }
 
     /// Reconfigure the oversampling stage from the current parameter value.
-    /// Bounded work (kernel design is a few thousand flops, no allocation), so
-    /// it is safe to run on the audio thread when the parameter changes.
+    /// Kernels are designed once in initialize/activate (non-RT); this path
+    /// only switches the factor, resets filter state, and rescales the
+    /// detector-rate coefficients, so it is safe on the audio thread.
     void applyOversamplingConfig() {
         const uint32_t factor = oversamplingFactorFromNorm(m_params[kOversampling].load(std::memory_order_relaxed));
-        m_osFactor = factor;
-        m_detectorRate = static_cast<float>(m_sampleRate) * static_cast<float>(factor);
-        if (factor > 1u) {
-            m_osL.prepare(factor);
-            m_osR.prepare(factor);
-        }
+        m_osL.setFactor(factor);
+        m_osR.setFactor(factor);
+        m_osFactor = m_osL.factor();
+        m_detectorRate = static_cast<float>(m_sampleRate) * static_cast<float>(m_osFactor);
         m_dryDelayL.fill(0.0f);
         m_dryDelayR.fill(0.0f);
         m_dryDelayPos = 0;
-        m_reportedLatency.store(factor > 1u ? DSP::Oversampler::kReportedLatency : 0u, std::memory_order_relaxed);
+        m_reportedLatency.store(m_osFactor > 1u ? DSP::Oversampler::kReportedLatency : 0u, std::memory_order_relaxed);
         m_prevOpticalWindow = -1.0f;
         updateRmsCoeff();
         updateDetectorHPF();

--- a/Tests/AestraAudio/AestraCompOversamplingTest.cpp
+++ b/Tests/AestraAudio/AestraCompOversamplingTest.cpp
@@ -1,0 +1,308 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraCompOversamplingTest — oversampling quality-mode contract tests (#228).
+//
+// Covers: latency reporting, bypass parity under reported latency, dry/wet
+// alignment, aliasing reduction with 2x/4x, and v5 state round-trip with
+// backward-compatible defaults for pre-v5 blobs.
+
+#include "DSP/Oversampler.h"
+#include "Plugin/AestraComp.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::DSP::Oversampler;
+using Aestra::Audio::Plugins::AestraComp;
+
+namespace {
+
+constexpr double kSampleRate = 48000.0;
+constexpr uint32_t kBlockSize = 256;
+
+void processAll(AestraComp& comp, const std::vector<float>& inL, const std::vector<float>& inR,
+                std::vector<float>& outL, std::vector<float>& outR) {
+    const uint32_t total = static_cast<uint32_t>(inL.size());
+    outL.assign(total, 0.0f);
+    outR.assign(total, 0.0f);
+    for (uint32_t start = 0; start < total; start += kBlockSize) {
+        const uint32_t frames = std::min<uint32_t>(kBlockSize, total - start);
+        const float* ins[2] = {inL.data() + start, inR.data() + start};
+        float* outs[2] = {outL.data() + start, outR.data() + start};
+        comp.process(ins, outs, 2, 2, frames);
+    }
+}
+
+/// Goertzel magnitude at a single frequency over [begin, end).
+double toneMagnitude(const std::vector<float>& signal, size_t begin, size_t end, double freqHz) {
+    const double w = 2.0 * 3.14159265358979323846 * freqHz / kSampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (size_t n = begin; n < end; ++n) {
+        s0 = signal[n] + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double n = static_cast<double>(end - begin);
+    const double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    return std::sqrt(std::max(0.0, power)) / (n * 0.5);
+}
+
+double db(double linear) {
+    return 20.0 * std::log10(std::max(1.0e-12, linear));
+}
+
+void setupAggressiveComp(AestraComp& comp, float oversamplingNorm) {
+    comp.initialize(kSampleRate, kBlockSize);
+    comp.activate();
+    // Aggressive clean compression: low threshold, max ratio, fastest attack.
+    comp.setParameter(AestraComp::kThreshold, 0.0f); // -60 dB
+    comp.setParameter(AestraComp::kRatio, 1.0f);     // 20:1
+    comp.setParameter(AestraComp::kAttack, 0.0f);    // 0.1 ms
+    comp.setParameter(AestraComp::kRelease, 0.0f);   // 10 ms
+    comp.setParameter(AestraComp::kKnee, 0.0f);
+    comp.setParameter(AestraComp::kMix, 1.0f);
+    comp.setParameter(AestraComp::kOversampling, oversamplingNorm);
+}
+
+bool testLatencyReporting() {
+    AestraComp comp;
+    comp.initialize(kSampleRate, kBlockSize);
+    comp.activate();
+    if (comp.getLatencySamples() != 0) {
+        std::cerr << "latency: expected 0 with oversampling Off\n";
+        return false;
+    }
+
+    std::vector<float> in(kBlockSize, 0.0f), l, r;
+    for (float norm : {0.5f, 1.0f}) {
+        comp.setParameter(AestraComp::kOversampling, norm);
+        processAll(comp, in, in, l, r); // config applies on next process()
+        if (comp.getLatencySamples() != Oversampler::kReportedLatency) {
+            std::cerr << "latency: expected " << Oversampler::kReportedLatency << " at norm " << norm << ", got "
+                      << comp.getLatencySamples() << "\n";
+            return false;
+        }
+    }
+
+    comp.setParameter(AestraComp::kOversampling, 0.0f);
+    processAll(comp, in, in, l, r);
+    if (comp.getLatencySamples() != 0) {
+        std::cerr << "latency: expected 0 after switching oversampling back off\n";
+        return false;
+    }
+    return true;
+}
+
+bool testBypassParityUnderLatency() {
+    AestraComp comp;
+    setupAggressiveComp(comp, 1.0f);
+    comp.setParameter(AestraComp::kBypass, 1.0f);
+
+    std::vector<float> inL(2048), inR(2048), outL, outR;
+    for (size_t n = 0; n < inL.size(); ++n) {
+        inL[n] = static_cast<float>(std::sin(2.0 * 3.14159265358979323846 * 1000.0 * n / kSampleRate));
+        inR[n] = 0.5f * inL[n];
+    }
+    processAll(comp, inL, inR, outL, outR);
+
+    const uint32_t lat = comp.getLatencySamples();
+    if (lat != Oversampler::kReportedLatency) {
+        std::cerr << "bypass parity: unexpected latency " << lat << "\n";
+        return false;
+    }
+    for (size_t n = lat; n < inL.size(); ++n) {
+        if (outL[n] != inL[n - lat] || outR[n] != inR[n - lat]) {
+            std::cerr << "bypass parity: bypassed output is not an exact " << lat << "-sample delay at n=" << n << "\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testTransparentPathAlignment() {
+    // Ratio 1:1 disables gain reduction, mix 100%: the oversampled path should
+    // return the input delayed by the reported latency, within filter accuracy.
+    AestraComp comp;
+    comp.initialize(kSampleRate, kBlockSize);
+    comp.activate();
+    comp.setParameter(AestraComp::kRatio, 0.0f); // 1:1
+    comp.setParameter(AestraComp::kOversampling, 1.0f);
+
+    const size_t total = 8192;
+    std::vector<float> in(total), outL, outR;
+    for (size_t n = 0; n < total; ++n) {
+        in[n] = static_cast<float>(0.25 * std::sin(2.0 * 3.14159265358979323846 * 1000.0 * n / kSampleRate));
+    }
+    processAll(comp, in, in, outL, outR);
+
+    const uint32_t lat = comp.getLatencySamples();
+    double errAcc = 0.0, refAcc = 0.0;
+    for (size_t n = 1024; n < total; ++n) {
+        const double e = outL[n] - in[n - lat];
+        errAcc += e * e;
+        refAcc += in[n - lat] * in[n - lat];
+    }
+    const double errDb = 10.0 * std::log10(std::max(1.0e-20, errAcc / refAcc));
+    std::cout << "  transparent path error: " << errDb << " dB\n";
+    if (errDb > -60.0) {
+        std::cerr << "alignment: oversampled 1:1 path deviates from delayed input (" << errDb << " dB)\n";
+        return false;
+    }
+    return true;
+}
+
+bool testOversamplerAliasRejection() {
+    // Component-level guarantee: wrapping a genuinely hard nonlinearity
+    // (hard clip) in the Oversampler must attenuate folded harmonics. A
+    // 15 kHz sine clipped at native rate folds its 3rd harmonic (45 kHz)
+    // to 3 kHz and its 5th (75 kHz) to 21 kHz.
+    const size_t total = 1 << 15;
+    const double f0 = 15000.0;
+    auto clip = [](float v) { return std::clamp(v, -0.25f, 0.25f); };
+
+    std::vector<float> nativeOut(total), osOut(total);
+    for (uint32_t factorNorm = 0; factorNorm < 2; ++factorNorm) {
+        Oversampler os;
+        os.prepare(factorNorm == 0 ? 1u : 4u);
+        std::vector<float>& out = factorNorm == 0 ? nativeOut : osOut;
+        for (size_t n = 0; n < total; ++n) {
+            const float in = static_cast<float>(0.5 * std::sin(2.0 * 3.14159265358979323846 * f0 * n / kSampleRate));
+            float up[4];
+            os.upsample(in, up);
+            for (uint32_t s = 0; s < os.factor(); ++s) {
+                up[s] = clip(up[s]);
+            }
+            out[n] = os.downsample(up);
+        }
+    }
+
+    const double alias3Native = db(toneMagnitude(nativeOut, total / 2, total, 3000.0));
+    const double alias3Os = db(toneMagnitude(osOut, total / 2, total, 3000.0));
+    std::cout << "  hard-clip alias @3kHz: native=" << alias3Native << " dB, 4x=" << alias3Os << " dB\n";
+
+    if (alias3Native > -40.0 && alias3Os > alias3Native - 20.0) {
+        std::cerr << "aliasing: 4x oversampled hard clip did not attenuate the folded 3rd harmonic by 20 dB\n";
+        return false;
+    }
+    if (alias3Native <= -40.0) {
+        std::cerr << "aliasing: stimulus produced no measurable native alias — test is not exercising anything\n";
+        return false;
+    }
+    return true;
+}
+
+bool testCompAliasBandNotWorse() {
+    // Integration-level guard: AestraComp's RMS-windowed detector already keeps
+    // steady-state gain aliasing very low (measured near -120 dB), so assert
+    // that enabling oversampling never makes the alias band worse. The printed
+    // numbers are the honest record of what oversampling does for this
+    // detector topology.
+    const size_t total = 1 << 16;
+    const double f0 = 15000.0;
+    std::vector<float> in(total);
+    for (size_t n = 0; n < total; ++n) {
+        const bool on = (static_cast<size_t>(n * 100.0 / kSampleRate) % 2) == 0;
+        in[n] = on ? static_cast<float>(0.5 * std::sin(2.0 * 3.14159265358979323846 * f0 * n / kSampleRate)) : 0.0f;
+    }
+
+    auto spuriousDb = [&](float osNorm) {
+        AestraComp comp;
+        setupAggressiveComp(comp, osNorm);
+        std::vector<float> outL, outR;
+        processAll(comp, in, in, outL, outR);
+        double acc = 0.0;
+        for (double f : {3000.0, 4500.0, 6000.0, 7500.0, 9000.0}) {
+            const double m = toneMagnitude(outL, total / 2, total, f);
+            acc += m * m;
+        }
+        return db(std::sqrt(acc));
+    };
+
+    const double off = spuriousDb(0.0f);
+    const double x2 = spuriousDb(0.5f);
+    const double x4 = spuriousDb(1.0f);
+    std::cout << "  comp alias-band energy: off=" << off << " dB, 2x=" << x2 << " dB, 4x=" << x4 << " dB\n";
+
+    if (x2 > off + 3.0 || x4 > off + 3.0) {
+        std::cerr << "aliasing: oversampling made the alias band worse (off=" << off << ", 2x=" << x2 << ", 4x=" << x4
+                  << ")\n";
+        return false;
+    }
+    return true;
+}
+
+bool testStateRoundtripAndBackCompat() {
+    AestraComp comp;
+    comp.initialize(kSampleRate, kBlockSize);
+    comp.setParameter(AestraComp::kOversampling, 1.0f);
+    const auto state = comp.saveState();
+
+    AestraComp restored;
+    restored.initialize(kSampleRate, kBlockSize);
+    if (!restored.loadState(state)) {
+        std::cerr << "state: v5 load failed\n";
+        return false;
+    }
+    if (restored.getParameter(AestraComp::kOversampling) != 1.0f) {
+        std::cerr << "state: oversampling not restored\n";
+        return false;
+    }
+
+    // Patch the version field down to 4: the oversampling slot must then be
+    // ignored and default to Off, regardless of its stored content.
+    auto v4state = state;
+    const uint32_t v4 = 4;
+    std::memcpy(v4state.data() + sizeof(uint32_t), &v4, sizeof(uint32_t));
+    AestraComp legacy;
+    legacy.initialize(kSampleRate, kBlockSize);
+    if (!legacy.loadState(v4state)) {
+        std::cerr << "state: v4 load failed\n";
+        return false;
+    }
+    if (legacy.getParameter(AestraComp::kOversampling) != 0.0f) {
+        std::cerr << "state: pre-v5 blob must default oversampling to Off\n";
+        return false;
+    }
+    return true;
+}
+
+bool testNonFiniteInputStaysFinite() {
+    AestraComp comp;
+    setupAggressiveComp(comp, 1.0f);
+    std::vector<float> in(1024, 0.1f), outL, outR;
+    in[100] = std::numeric_limits<float>::quiet_NaN();
+    in[200] = std::numeric_limits<float>::infinity();
+    processAll(comp, in, in, outL, outR);
+    for (float v : outL) {
+        if (!std::isfinite(v)) {
+            std::cerr << "nan: non-finite output with oversampling enabled\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "AestraComp Oversampling Tests\n";
+    bool ok = true;
+    ok &= testLatencyReporting();
+    ok &= testBypassParityUnderLatency();
+    ok &= testTransparentPathAlignment();
+    ok &= testOversamplerAliasRejection();
+    ok &= testCompAliasBandNotWorse();
+    ok &= testStateRoundtripAndBackCompat();
+    ok &= testNonFiniteInputStaysFinite();
+    if (!ok) {
+        std::cerr << "AestraComp oversampling tests FAILED\n";
+        return 1;
+    }
+    std::cout << "All AestraComp oversampling tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AestraCompPhase1Test.cpp
+++ b/Tests/AestraAudio/AestraCompPhase1Test.cpp
@@ -33,8 +33,8 @@ bool testPublicParameterSurface() {
     }
 
     const char* expected[] = {
-        "Threshold", "Ratio", "Attack", "Release", "Makeup Gain", "Knee",
-        "Mix", "Bypass", "Input Gain", "Output Gain", "Detector HPF", "Mode",
+        "Threshold", "Ratio",      "Attack",      "Release",      "Makeup Gain", "Knee",         "Mix",
+        "Bypass",    "Input Gain", "Output Gain", "Detector HPF", "Mode",        "Oversampling",
     };
 
     for (uint32_t i = 0; i < AestraComp::kParamCount; ++i) {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1048,6 +1048,17 @@ target_include_directories(AestraCompPhase1Test PRIVATE
 add_test(NAME AestraCompPhase1Test COMMAND AestraCompPhase1Test)
 set_tests_properties(AestraCompPhase1Test PROPERTIES LABELS "audio;plugins;comp;phase1")
 
+# Aestra Comp Oversampling Test (#228)
+add_executable(AestraCompOversamplingTest AestraAudio/AestraCompOversamplingTest.cpp)
+target_link_libraries(AestraCompOversamplingTest PRIVATE AestraAudio)
+target_include_directories(AestraCompOversamplingTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraCompOversamplingTest COMMAND AestraCompOversamplingTest)
+set_tests_properties(AestraCompOversamplingTest PROPERTIES LABELS "audio;plugins;comp;oversampling")
+
 # Aestra Comp Upgrade Test
 add_executable(AestraCompUpgradeTest AestraAudio/AestraCompUpgradeTest.cpp)
 target_link_libraries(AestraCompUpgradeTest PRIVATE AestraAudio)


### PR DESCRIPTION
## Summary

Part of #228 (AestraComp half; AestraLimit is a follow-up — see Risk notes).

Adds `AestraAudio/include/DSP/Oversampler.h`, a reusable per-sample polyphase halfband FIR oversampler (Kaiser-windowed sinc; kernels computed in `prepare()`; no allocation, locks, or unbounded work in the process path), and wires it into AestraComp as a new stepped **Oversampling** parameter (Off/2x/4x, default **Off**).

With oversampling on, the nonlinear stage (detector → envelope → gain computer → VCA) runs at `fs × factor` with rate-scaled envelope/HPF/RMS coefficients; the dry mix path is delayed to stay phase-aligned with the filtered wet path. With Off, the code path is numerically identical to before (`processCore` is a verbatim extraction of the previous per-sample loop) — verified by the existing Phase0/Phase1/MaterialLab/Upgrade tests.

## Measurements (honest record)

- **Oversampler component**: hard-clipped 15 kHz sine @48k — folded 3rd harmonic at 3 kHz drops from **−23.6 dB to −57.4 dB** (≈34 dB alias reduction at 4x). Round-trip transparency: −124 dB @1 kHz, −79 dB @18 kHz; impulse delay exactly 30 samples.
- **AestraComp integration**: steady-state alias-band energy is **already ≈ −121 dB with oversampling Off** — the RMS-windowed (10 ms) detector plus envelope smoothing suppresses steady-state gain aliasing by design. Oversampling keeps it unchanged (asserted "not worse"). The practical benefit is confined to fast-attack transient splash and any future harder nonlinearities (saturation modes, Classic feedback extremes) — the PR does not claim steady-state audio improvement for the current topology, because none was measured.
- **Cost** (stereo instance @48k, 4 GB-class dev machine): 0.87% (Off) / 3.3% (2x) / 6.2% (4x) of realtime.

## Latency & compatibility

- `getLatencySamples()`: 0 (Off) / 30 (2x and 4x — deliberately equal, so switching between oversampled modes never changes latency). Internal bypass routes through the same delay when OS is on, preserving bypass parity against the reported latency (asserted sample-exact in the test).
- **Known limitation**: toggling Off↔On at runtime changes reported latency, but the host only re-reads plugin latency on graph rebuild (plugin→host latency-change notification doesn't exist yet — same gap as #270). Documented in code; heals on rebuild/reload.
- **State**: blob version 4 → 5 using previously-unwritten legacy slot 12. Pre-v5 blobs load with oversampling Off; v5 blobs load in older builds (slot 12 was never read there). Covered by roundtrip + version-patched backcompat test; existing `AestraCompUpgradeTest` (v1/v2 blobs) still passes.

## Testing performed

- New `AestraCompOversamplingTest` (registered in ctest, labels `audio;plugins;comp;oversampling`): latency reporting incl. toggle-back, sample-exact bypass parity under latency, transparent-path alignment (−91.5 dB), component alias rejection, comp alias-band guard, v5 roundtrip + v4 backcompat, NaN/Inf input stays finite.
- `ctest -L audio`: 48 tests — all pass except one unrelated flake (`AestraMixerChannelScratchBufferTest` was OOM-killed once under parallel load on this 4 GB machine; passes in isolation and passed in the first full run; my change doesn't touch MixerChannel).
- Full build clean; `git clang-format` applied.

## Change type

- DSP changed: yes (opt-in only; Off path numerically identical, default Off)
- Latency changed: only when the new parameter is enabled (reported via `getLatencySamples`)
- UI changed: no (param reachable via generic plugin param UI; custom `AestraCompEditor` exposure is follow-up)
- Serialization/state format changed: yes — plugin state v5, backward and forward compatible as described
- Build/CI config changed: test registration only
- Public docs changed: no

## Risk / rollback

- Default-Off + numerically-identical Off path keeps existing projects bit-exact.
- Follow-ups: AestraLimit integration (#228 second half), editor exposure of the parameter, latency-change notification (#270).
- Rollback: revert the commit. v5 states still load in pre-oversampling builds (the loader ignores slot 12 and does not reject newer versions), so rollback is clean; only the oversampling setting itself would be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Behavior/compatibility:** Compressor reported latency is now non-zero when **Oversampling** is enabled (Off remains latency 0), and plugin state serialization is bumped **blob v4 → v5** to persist the new setting (older blobs load with Oversampling defaulting to Off; forward compatibility handled via the versioned loader).
- Added a reusable DSP **polyphase halfband oversampler** (`DSP/Oversampler.h`) with prepared (non-RT) kernels and runtime factor switching (1x/2x/4x).
- Integrated oversampling into `AestraComp` via a new **Oversampling** parameter (Off/2x/4x, default Off): detector nonlinear stage runs at `fs × factor` with rate-scaled coefficients, and the **dry path is delayed** to keep wet/dry alignment.
- Updated processing/bypass/feedback flow to remain aligned with the oversampled wet path (including correct latency shifting for bypass and classic-mode feedback).
- Added `AestraCompOversamplingTest` and registered it in CTest; test coverage includes latency changes, bypass parity/alignment, alias rejection, state round-trip and back-compat, and NaN/Inf robustness.
- Updated the existing parameter-surface test to include the new **Oversampling** parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->