### PR TITLE
Fix mixer delay insert BPM initialization

### DIFF
--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -593,8 +593,7 @@ void UIMixerPanel::loadPluginToSelectedChannel(const std::string& pluginId)
         return;
     }
     if (auto delay = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraDelay>(instance)) {
-        // TODO: wire BPM from transport when available
-        delay->setBPM(120.0f);
+        delay->setBPM(static_cast<float>(m_trackManager->getPlaylistModel().getBPM()));
     }
     instance->activate();
 


### PR DESCRIPTION
## Summary

Delay plugins inserted from the mixer panel (`UIMixerPanel::loadPluginToSelectedChannel`) now read BPM from `m_trackManager->getPlaylistModel().getBPM()` instead of a hardcoded `120.0f`. Mirrors the existing pattern in `AestraContent::loadEffectToSelectedTrack`.

## Why

Fixes the insert-time half of #276. Tempo *changes* were already handled — `AestraContent::setPluginTempo` runs on tempo change and project load and iterates all active instances — so only the initial value at insert was wrong. A delay inserted while the project tempo was, e.g., 90 BPM would sync at 120 until the next tempo edit.

Scope is deliberately limited to the mixer insert path. Related gaps noted on #276 as follow-ups (not included here): `TrackManagerUI` async insert path, `PluginUIController` insert path, and `AestraVerb` BPM propagation.

## Testing performed

- `g++ -fsyntax-only` on `UIMixerPanel.cpp` with the AestraUI_Core include set — clean.
- `clang-format --dry-run --Werror` — clean.
- No automated test added: this is one-line UI wiring into an already-clamped path (`AestraDelay::setBPM` clamps to 20–999; `PlaylistModel::setBPM` guarantees finite positive BPM), and local UI target compilation is headless-limited — full UI compile is validated by CI's UI lanes.

## Docs updated?

No — internal behavior fix, no user-facing docs affected.

## Risk/rollback notes

- One-line change on a UI-thread path; `m_trackManager` is null-checked at function entry. No DSP, serialization, or state-format changes.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixes delay plugin insertion from the mixer so `AestraDelay` now initializes with the current project BPM from the playlist model instead of a hardcoded `120.0f`.
- Keeps the rest of the mixer insert flow unchanged: plugin creation, activation, and slot insertion behavior still work as before.
- This aligns mixer-based delay insertion with the existing track insertion behavior and ensures delays start at the correct tempo when the project is not 120 BPM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->