### PR TITLE
Fix audio settings UI freeze during device enumeration

### DIFF
--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -290,8 +290,8 @@ void AudioSettingsPage::createUI() {
              m_audioManager->setPreferredDriverType((AudioDriverType)m_driverDropdown->getSelectedValue());
         }
 
-        // When driver changes, we need to update device list (and potentially switch backend)
-        updateDeviceList();
+        // When driver changes, re-enumerate devices off the UI thread (#256)
+        startAsyncDeviceLoad();
     });
 
     m_deviceDropdown = createDropdown([this](int idx) {
@@ -424,13 +424,26 @@ void AudioSettingsPage::createUI() {
     });
     addChild(m_testSoundButton);
     Log::info("[AudioSettingsPage] Test sound button created");
-    
+
     // Initial Population
-    // Trigger update logic ONCE without recursion loop
-    Log::info("[AudioSettingsPage] createUI components created. Updating driver list...");
-    updateDriverList();
-    Log::info("[AudioSettingsPage] Initial updateDriverList complete.");
-    
+    // Sample-rate and buffer-size lists are static; populate them now so
+    // loadSettings() below can restore the saved selections. Driver and device
+    // lists require hardware enumeration, which blocks — they are filled in by
+    // startAsyncDeviceLoad() (called from the constructor) off the UI thread (#256).
+    const auto& currentConfig = m_audioManager->getCurrentConfig();
+    m_sampleRateDropdown->addItem("44100 Hz", 44100);
+    m_sampleRateDropdown->addItem("48000 Hz", 48000);
+    m_sampleRateDropdown->addItem("88200 Hz", 88200);
+    m_sampleRateDropdown->addItem("96000 Hz", 96000);
+    m_sampleRateDropdown->setSelectedByValue((int)currentConfig.sampleRate);
+
+    for (int s : {64, 128, 256, 512, 1024, 2048}) {
+        m_bufferSizeDropdown->addItem(std::to_string(s) + " samples", s);
+    }
+    m_bufferSizeDropdown->setSelectedByValue((int)currentConfig.bufferSize);
+
+    updateLatencyEstimate();
+
     // Load persisted settings (overrides defaults if exists)
     // NOTE: loadSettings() is called BEFORE m_isInitializing is set to false.
     // This prevents loadSettings() from triggering openStream calls during startup.
@@ -518,8 +531,8 @@ bool AudioSettingsPage::hasUnsavedChanges() const {
 }
 
 void AudioSettingsPage::onShow() {
-    // Refresh device lists in case hardware changed
-    updateDriverList();
+    // Refresh device lists in case hardware changed — off the UI thread (#256)
+    startAsyncDeviceLoad();
 }
 
 void AudioSettingsPage::onHide() {
@@ -547,88 +560,6 @@ void AudioSettingsPage::updateLatencyEstimate() {
         m_latencyLabel->setText("Est. Latency: -- ms");
     }
 }
-
-void AudioSettingsPage::updateDriverList() {
-    m_driverDropdown->clearItems();
-    
-    // In a real scenario with multiple backends, we'd list them.
-    // Aestras AudioDeviceManager might handle WASAPI/ASIO as "Driver Types"
-    // For now, let's query available driver types
-    auto types = m_audioManager->getAvailableDriverTypes();
-    
-    // Map types to UI
-    for (size_t i = 0; i < types.size(); ++i) {
-        std::string name = "Unknown";
-        if (types[i] == AudioDriverType::WASAPI_SHARED) name = "WASAPI Shared";
-        else if (types[i] == AudioDriverType::WASAPI_EXCLUSIVE) name = "WASAPI Exclusive";
-        else if (types[i] == AudioDriverType::ASIO_EXTERNAL) name = "ASIO (External)";
-        else if (types[i] == AudioDriverType::ASIO_Aestra) name = "ASIO (Aestra)";
-        else if (types[i] == AudioDriverType::DIRECTSOUND) name = "DirectSound";
-        else if (types[i] == AudioDriverType::RTAUDIO) name = "RtAudio (Auto)";
-        else if (types[i] == AudioDriverType::PULSEAUDIO) name = "PulseAudio";
-        else if (types[i] == AudioDriverType::ALSA) name = "ALSA";
-        else if (types[i] == AudioDriverType::JACK) name = "JACK";
-        
-        m_driverDropdown->addItem(name, (int)types[i]);
-    }
-
-    if (types.empty()) {
-        // Fallback
-        m_driverDropdown->addItem("DirectSound", (int)AudioDriverType::DIRECTSOUND);
-    }
-    
-    // Select current driver type
-    auto currentType = m_audioManager->getActiveDriverType();
-    m_driverDropdown->setSelectedByValue((int)currentType);
-    
-    // Update dependent lists
-    updateDeviceList();
-}
-
-void AudioSettingsPage::updateDeviceList() {
-    m_deviceDropdown->clearItems();
-    m_inputDeviceDropdown->clearItems();
-    
-    auto devices = m_audioManager->getDevices();
-    for (const auto& dev : devices) {
-        if (dev.maxOutputChannels > 0) {
-            m_deviceDropdown->addItem(dev.name, (int)dev.id);
-        }
-        if (dev.maxInputChannels > 0) {
-            m_inputDeviceDropdown->addItem(dev.name, (int)dev.id);
-        }
-    }
-    
-    if (m_deviceDropdown->getItemCount() == 0) {
-        m_deviceDropdown->addItem("No Output Devices Found", -1);
-    }
-    if (m_inputDeviceDropdown->getItemCount() == 0) {
-        m_inputDeviceDropdown->addItem("No Input Devices Found", -1);
-    }
-    
-    // Select active device
-    auto currentConfig = m_audioManager->getCurrentConfig();
-    m_deviceDropdown->setSelectedByValue((int)currentConfig.deviceId);
-    m_inputDeviceDropdown->setSelectedByValue((int)currentConfig.inputDeviceId);
-    
-    // Update Standard Rates/Buffers if empty
-    if (m_sampleRateDropdown->getItemCount() == 0) {
-        m_sampleRateDropdown->addItem("44100 Hz", 44100);
-        m_sampleRateDropdown->addItem("48000 Hz", 48000);
-        m_sampleRateDropdown->addItem("88200 Hz", 88200);
-        m_sampleRateDropdown->addItem("96000 Hz", 96000);
-        m_sampleRateDropdown->setSelectedByValue((int)currentConfig.sampleRate);
-    }
-    
-    if (m_bufferSizeDropdown->getItemCount() == 0) {
-        std::vector<int> sizes = {64, 128, 256, 512, 1024, 2048};
-        for (int s : sizes) m_bufferSizeDropdown->addItem(std::to_string(s) + " samples", s);
-        m_bufferSizeDropdown->setSelectedByValue((int)currentConfig.bufferSize);
-    }
-    
-    updateLatencyEstimate();
-}
-
 
 // Layout
 void AudioSettingsPage::layoutComponents() {
@@ -874,11 +805,9 @@ void AudioSettingsPage::setPlayingTestSound(bool playing) {
 //==============================================================================
 
 void AudioSettingsPage::startAsyncDeviceLoad() {
-    // TODO: Async loading implemented but freeze still occurs. 
-    // Likely cause: AudioDeviceManager::getDevices() or getAvailableDriverTypes() 
-    // are blocking on the UI thread before we even get here (called from somewhere else?)
-    // Need to investigate initialization order and cache devices at app startup instead.
-    
+    // This is the only path that may call getAvailableDriverTypes()/getDevices()
+    // (blocking hardware enumeration) — keep those calls on the worker thread (#256).
+
     // Don't start if already loading
     if (m_isLoadingDevices.load()) {
         return;

--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -649,7 +649,15 @@ void AudioSettingsPage::onUpdate(double deltaTime) {
     // Check for async device load completion
     if (m_deviceDataReady && !m_isLoadingDevices.load()) {
         m_deviceDataReady = false; // Consume the flag
-        onDeviceLoadComplete();
+        if (m_deviceReloadPending) {
+            // A refresh was requested while this load was in flight (e.g. the
+            // driver changed) — the results are stale. Discard them and
+            // re-enumerate; controls stay disabled with the loading indicator.
+            m_deviceReloadPending = false;
+            startAsyncDeviceLoad();
+        } else {
+            onDeviceLoadComplete();
+        }
     }
     
     // Animate loading indicator
@@ -808,8 +816,11 @@ void AudioSettingsPage::startAsyncDeviceLoad() {
     // This is the only path that may call getAvailableDriverTypes()/getDevices()
     // (blocking hardware enumeration) — keep those calls on the worker thread (#256).
 
-    // Don't start if already loading
+    // If a load is already in flight, don't drop this request — the in-flight
+    // results may be for a stale driver selection. Remember it and re-enumerate
+    // once the current load finishes (consumed in onUpdate()).
     if (m_isLoadingDevices.load()) {
+        m_deviceReloadPending = true;
         return;
     }
     
@@ -835,42 +846,65 @@ void AudioSettingsPage::startAsyncDeviceLoad() {
     
     m_deviceLoadThread = std::thread([this]() {
         CachedDeviceData data;
-        
-        // === Enumerate driver types ===
-        auto types = m_audioManager->getAvailableDriverTypes();
-        for (int i = 0; i < static_cast<int>(types.size()); ++i) {
-            std::string name = "Unknown";
-            if (types[i] == AudioDriverType::WASAPI_SHARED) name = "WASAPI Shared";
-            else if (types[i] == AudioDriverType::WASAPI_EXCLUSIVE) name = "WASAPI Exclusive";
-            else if (types[i] == AudioDriverType::ASIO_EXTERNAL) name = "ASIO (External)";
-            else if (types[i] == AudioDriverType::ASIO_Aestra) name = "ASIO (Aestra)";
-            else if (types[i] == AudioDriverType::DIRECTSOUND) name = "DirectSound";
-            else if (types[i] == AudioDriverType::RTAUDIO) name = "RtAudio (Auto)";
-            else if (types[i] == AudioDriverType::PULSEAUDIO) name = "PulseAudio";
-            else if (types[i] == AudioDriverType::ALSA) name = "ALSA";
-            else if (types[i] == AudioDriverType::JACK) name = "JACK";
-            
-            data.driverTypes.push_back({ name, static_cast<int>(types[i]) });
-        }
-        
-        // Fallback
-        if (data.driverTypes.empty()) {
-            data.driverTypes.push_back({ "DirectSound", static_cast<int>(AudioDriverType::DIRECTSOUND) });
-        }
-        
-        data.currentDriverType = static_cast<int>(m_audioManager->getActiveDriverType());
-        
-        // === Enumerate devices ===
-        auto devices = m_audioManager->getDevices();
-        for (const auto& dev : devices) {
-            if (dev.maxOutputChannels > 0) {
-                data.outputDevices.push_back({ dev.name, static_cast<int>(dev.id) });
+
+        // Backend enumeration can throw (e.g. RtAudio errors). An uncaught
+        // exception in a std::thread calls std::terminate, and the page would
+        // stay stuck in the loading state — catch, log, and publish fallback
+        // data so the UI always recovers.
+        try {
+            // === Enumerate driver types ===
+            auto types = m_audioManager->getAvailableDriverTypes();
+            for (int i = 0; i < static_cast<int>(types.size()); ++i) {
+                std::string name = "Unknown";
+                if (types[i] == AudioDriverType::WASAPI_SHARED)
+                    name = "WASAPI Shared";
+                else if (types[i] == AudioDriverType::WASAPI_EXCLUSIVE)
+                    name = "WASAPI Exclusive";
+                else if (types[i] == AudioDriverType::ASIO_EXTERNAL)
+                    name = "ASIO (External)";
+                else if (types[i] == AudioDriverType::ASIO_Aestra)
+                    name = "ASIO (Aestra)";
+                else if (types[i] == AudioDriverType::DIRECTSOUND)
+                    name = "DirectSound";
+                else if (types[i] == AudioDriverType::RTAUDIO)
+                    name = "RtAudio (Auto)";
+                else if (types[i] == AudioDriverType::PULSEAUDIO)
+                    name = "PulseAudio";
+                else if (types[i] == AudioDriverType::ALSA)
+                    name = "ALSA";
+                else if (types[i] == AudioDriverType::JACK)
+                    name = "JACK";
+
+                data.driverTypes.push_back({name, static_cast<int>(types[i])});
             }
-            if (dev.maxInputChannels > 0) {
-                data.inputDevices.push_back({ dev.name, static_cast<int>(dev.id) });
+
+            data.currentDriverType = static_cast<int>(m_audioManager->getActiveDriverType());
+
+            // === Enumerate devices ===
+            auto devices = m_audioManager->getDevices();
+            for (const auto& dev : devices) {
+                if (dev.maxOutputChannels > 0) {
+                    data.outputDevices.push_back({dev.name, static_cast<int>(dev.id)});
+                }
+                if (dev.maxInputChannels > 0) {
+                    data.inputDevices.push_back({dev.name, static_cast<int>(dev.id)});
+                }
             }
+
+            auto currentConfig = m_audioManager->getCurrentConfig();
+            data.currentDeviceId = static_cast<int>(currentConfig.deviceId);
+            data.currentInputDeviceId = static_cast<int>(currentConfig.inputDeviceId);
+            data.currentSampleRate = static_cast<int>(currentConfig.sampleRate);
+        } catch (const std::exception& e) {
+            Log::error(std::string("[AudioSettingsPage] Device enumeration failed: ") + e.what());
+        } catch (...) {
+            Log::error("[AudioSettingsPage] Device enumeration failed with unknown error");
         }
 
+        // Fallbacks apply to both the empty-hardware and the failure case
+        if (data.driverTypes.empty()) {
+            data.driverTypes.push_back({"DirectSound", static_cast<int>(AudioDriverType::DIRECTSOUND)});
+        }
         if (data.outputDevices.empty()) {
             data.outputDevices.push_back({ "No Output Devices Found", -1 });
         }
@@ -878,11 +912,6 @@ void AudioSettingsPage::startAsyncDeviceLoad() {
             data.inputDevices.push_back({ "No Input Devices Found", -1 });
         }
 
-        auto currentConfig = m_audioManager->getCurrentConfig();
-        data.currentDeviceId = static_cast<int>(currentConfig.deviceId);
-        data.currentInputDeviceId = static_cast<int>(currentConfig.inputDeviceId);
-        data.currentSampleRate = static_cast<int>(currentConfig.sampleRate);
-        
         // Store results thread-safely
         {
             std::lock_guard<std::mutex> lock(m_deviceDataMutex);

--- a/Source/Settings/AudioSettingsPage.h
+++ b/Source/Settings/AudioSettingsPage.h
@@ -189,6 +189,11 @@ private:
     CachedDeviceData m_cachedDevices;
     std::atomic<bool> m_deviceDataReady{false};
 
+    // Set when startAsyncDeviceLoad() is called while a load is in flight
+    // (e.g. driver changed mid-enumeration); onUpdate() then discards the
+    // stale results and re-enumerates. UI-thread only, no synchronization needed.
+    bool m_deviceReloadPending{false};
+
     // Loading indicator
     std::shared_ptr<AestraUI::NUILabel> m_loadingLabel;
     float m_loadingAnimTimer{0.0f};

--- a/Source/Settings/AudioSettingsPage.h
+++ b/Source/Settings/AudioSettingsPage.h
@@ -86,8 +86,6 @@ public:
 private:
     void createUI();
     void layoutComponents();
-    void updateDriverList();
-    void updateDeviceList();
     void updateSampleRateList();
     void updateBufferSizeList();
     void updateLatencyEstimate();
@@ -189,8 +187,8 @@ private:
         int currentSampleRate = 48000;
     };
     CachedDeviceData m_cachedDevices;
-    bool m_deviceDataReady{false};
-    
+    std::atomic<bool> m_deviceDataReady{false};
+
     // Loading indicator
     std::shared_ptr<AestraUI::NUILabel> m_loadingLabel;
     float m_loadingAnimTimer{0.0f};


### PR DESCRIPTION
## Summary

Moves all audio device enumeration in `AudioSettingsPage` off the UI thread. The async pipeline (`startAsyncDeviceLoad` → worker thread → `onDeviceLoadComplete` on `onUpdate`) already existed, but three call sites still ran blocking enumeration (`getAvailableDriverTypes()` / `getDevices()`) synchronously on the UI thread — which is exactly why the in-code TODO noted "async loading implemented but freeze still occurs":

- `createUI()` called `updateDriverList()` synchronously during construction, before the async load ever started.
- `onShow()` called `updateDriverList()` synchronously every time the settings page opened — the user-visible freeze from #256.
- The driver dropdown callback called `updateDeviceList()` synchronously.

All three now route through `startAsyncDeviceLoad()`. Changes:

- `createUI()` populates only the **static** sample-rate/buffer-size lists, with selections from `getCurrentConfig()` (a plain member getter, no enumeration), so `loadSettings()` can still restore saved selections before async data arrives — and the async completion path's `itemCount == 0` guards then preserve those selections.
- The now-unused synchronous `updateDriverList()` / `updateDeviceList()` are removed (.cpp definitions + header declarations).
- `m_deviceDataReady` is now `std::atomic<bool>`: it is written by the worker thread and read lock-free in `onUpdate()` on the UI thread; as a plain `bool` this was a data race the TSan lane could flag now that the async path is the only path.
- Replaced the stale TODO with a note that `startAsyncDeviceLoad()` is the only path allowed to call blocking enumeration.

## Why

Fixes #256 — UI froze when opening audio settings (poor first-run experience). Acceptance criteria: enumeration off the UI thread ✔, UI responsive during load (dropdowns disabled + animated "Loading audio devices..." label, both pre-existing) ✔, device list populates asynchronously ✔.

Concurrency notes: the driver switch (`setPreferredDriverType`) still happens on the UI thread *before* the worker starts, so enumeration sees the new backend; re-entry is guarded by `m_isLoadingDevices`; the worker is joined before restart and in the destructor; dropdown callbacks are suppressed during async population via `m_isPopulatingDeviceUI` (pre-existing guard).

## Testing performed

- `g++ -fsyntax-only` on `AudioSettingsPage.cpp` with the app include set — clean.
- `git clang-format origin/develop` applied to changed lines only (the file has pre-existing whole-file format debt; left untouched).
- No automated test added: `AudioSettingsPage` needs the UI stack and real audio backends; the local canonical build is headless. Runtime freeze/responsiveness verification is **manual** — needs a run on a machine with slow device enumeration (the original repro). CI UI lanes validate compilation; the TSan lane covers the touched threading.

## Docs updated?

No.

## Risk/rollback notes

- Behavior change: driver/device dropdowns are now empty (disabled, with loading indicator) for the brief period between page construction/show and async completion, instead of blocking the whole UI while populating. Selections after load come from the active audio config, same as the pre-existing async completion path.
- If saved settings reference a device that enumeration later doesn't find, the dropdown selection falls back the same way the old sync path did (`setSelectedByValue` with a missing value).
- No DSP, serialization, or state-format changes. Runtime state files untouched.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)