### PR TITLE
Route content-panel effect loading to the selected track

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3299,12 +3299,23 @@ void AestraContent::loadEffectToSelectedTrack(const std::string& pluginId) {
     if (!m_trackManager)
         return;
 
-    // 2. Get first MixerChannel (track selection not implemented yet)
-    // TODO: Add track selection UI and pass selected index here
-    size_t trackIndex = 0;
-    auto channel = m_trackManager->getChannel(trackIndex);
+    // 2. Resolve the target channel: the selected track's mixer channel when a
+    //    track is selected (mirrors the sample-drop selection path), otherwise
+    //    fall back to the first channel. The shared_ptr keeps the selected
+    //    channel alive for the duration of this call.
+    MixerChannel* channel = nullptr;
+    std::shared_ptr<MixerChannel> selectedChannel;
+    if (m_trackManagerUI) {
+        if (auto* selectedTrack = m_trackManagerUI->getSelectedTrackUI()) {
+            selectedChannel = selectedTrack->getMixerChannel();
+            channel = selectedChannel.get();
+        }
+    }
     if (!channel) {
-        AESTRA_LOG_ERROR("Cannot load effect: No mixer channel at index " + std::to_string(trackIndex));
+        channel = m_trackManager->getChannel(0);
+    }
+    if (!channel) {
+        AESTRA_LOG_ERROR("Cannot load effect: no mixer channel available");
         return;
     }
 
@@ -3333,9 +3344,9 @@ void AestraContent::loadEffectToSelectedTrack(const std::string& pluginId) {
     if (slot < Aestra::Audio::EffectChain::MAX_SLOTS) {
         m_trackManager->getCommandHistory().pushAndExecute(
             std::make_shared<Aestra::Audio::AddPluginCommand>(*channel, slot, std::move(instance)));
-        AESTRA_LOG_DEBUG("Loaded effect to Track " + std::to_string(trackIndex + 1) + " slot " + std::to_string(slot));
+        AESTRA_LOG_DEBUG("Loaded effect to channel '" + channel->getName() + "' slot " + std::to_string(slot));
     } else {
-        AESTRA_LOG_WARNING("No empty effect slots on Track " + std::to_string(trackIndex + 1));
+        AESTRA_LOG_WARNING("No empty effect slots on channel '" + channel->getName() + "'");
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #277's actionable half: `AestraContent::loadEffectToSelectedTrack()` hardcoded mixer channel 0. It now uses the selected track's mixer channel, resolved directly through `TrackUIComponent::getMixerChannel()` — no index round-trip — with the exact resolution order specified in review:

1. `channel` starts null.
2. If `m_trackManagerUI` exists → `getSelectedTrackUI()`.
3. If a track is selected → `channel = selectedTrack->getMixerChannel()` (shared_ptr held for the call's duration).
4. Null channel (no selection, no UI, or selected track without a channel) → fall back to `m_trackManager->getChannel(0)`.
5. Existing final `if (!channel)` guard retained.

Selection *UI* already existed (`TrackManagerUI::selectTrack` / click handling); the issue's real gap was this wiring — same shape as the sample-drop path at `AestraContent.cpp:3152`, which is untouched.

## Edge cases verified (per review checklist)

- **Selected track with no valid mixer channel**: `TrackUIComponent` can hold a null channel by design; handled by step 4 fallback.
- **No selected track / no TrackManagerUI**: fallback to channel 0 — behavior identical to before this change.
- **Selection after track reorder/delete**: `getSelectedTrackUI()` scans the live `m_trackUIComponents` list for `isSelected()` — it cannot return a dangling pointer; a removed track simply yields nullptr → fallback.
- **Sample-drop parity**: the lane-based selection path (3152–3167) is unchanged; this PR mirrors its guard structure for the mixer-channel case.
- **Bounds/null safety**: `TrackManager::getChannel()` is bounds-checked (returns nullptr past `m_channels.size()`), and the final null guard covers the zero-channel case.

## Testing performed

- `g++ -fsyntax-only` on `AestraContent.cpp` with the app include set — clean.
- `git clang-format origin/develop` — no changes needed.
- No automated test: exercising this path requires the full `TrackManagerUI` + content panel stack (UI-tier, not constructible headless). Runtime verification is manual: select track N, add an effect from the content panel, confirm it lands on N's channel; with no selection, confirm it still lands on channel 0. CI UI lanes validate compilation.

## Docs updated?

No.

## Risk/rollback notes

- Behavior change is exactly the intended one: with a track selected, effects now land on that track instead of always track 0. No-selection behavior is unchanged.
- No selection-state, drag/drop, mixer-ownership, or track-creation changes. Logs now name the channel instead of a hardcoded index.
- Remaining #277 scope note: `loadInstrumentToArsenal` targets the UnitManager (different concept, no track index) — nothing else in the content panel consumes a hardcoded track index.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)