### PR TITLE
Fix the app's Release build (exceptions/RTTI flags vs. actual code requirements)

### DIFF
--- a/Source/App/ServiceLocator.h
+++ b/Source/App/ServiceLocator.h
@@ -4,34 +4,37 @@
 /**
  * @file ServiceLocator.h
  * @brief B-003: Service locator for global services
- * 
+ *
  * Provides a centralized registry for application-wide services, replacing
  * scattered global singletons with a single point of access that can be
  * mocked for testing.
- * 
+ *
  * USAGE:
  *   // Registration (at startup):
  *   ServiceLocator::provide<IAudioEngine>(myAudioEngine);
- *   
+ *
  *   // Access (anywhere):
  *   auto* audio = ServiceLocator::get<IAudioEngine>();
  *   if (audio) audio->play();
- * 
+ *
  * THREAD SAFETY:
  * - Registration should only happen on MAIN THREAD during startup
  * - Lookups are thread-safe (read-only after startup)
  * - Services themselves must be thread-safe if accessed from multiple threads
- * 
+ *
  * DESIGN NOTES:
- * - Using type IDs avoids RTTI overhead
+ * - Keys are per-type static tag addresses, not typeid: the app target builds
+ *   Release with -fno-rtti (Source/CMakeLists.txt), and newer GCC rejects
+ *   typeid in template bodies under -fno-rtti. Tag addresses are unique per
+ *   type within a single binary, which is all Aestra needs (statically linked,
+ *   no services registered across shared-library boundaries).
  * - Services are stored as void* to allow any type
  * - Lifetime management is external (caller owns services)
  */
 
-#include <unordered_map>
-#include <typeindex>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 
 namespace Aestra {
 
@@ -52,7 +55,7 @@ public:
     template<typename T>
     static void provide(T* service) {
         std::lock_guard<std::mutex> lock(getMutex());
-        getRegistry()[std::type_index(typeid(T))] = static_cast<void*>(service);
+        getRegistry()[serviceKey<T>()] = static_cast<void*>(service);
     }
     
     /**
@@ -77,7 +80,7 @@ public:
     template<typename T>
     static T* get() {
         std::lock_guard<std::mutex> lock(getMutex());
-        auto it = getRegistry().find(std::type_index(typeid(T)));
+        auto it = getRegistry().find(serviceKey<T>());
         if (it != getRegistry().end()) {
             return static_cast<T*>(it->second);
         }
@@ -99,7 +102,7 @@ public:
     template<typename T>
     static void remove() {
         std::lock_guard<std::mutex> lock(getMutex());
-        getRegistry().erase(std::type_index(typeid(T)));
+        getRegistry().erase(serviceKey<T>());
     }
     
     /**
@@ -111,11 +114,20 @@ public:
     }
 
 private:
-    static std::unordered_map<std::type_index, void*>& getRegistry() {
-        static std::unordered_map<std::type_index, void*> s_registry;
+    // Unique key per service type: the address of a per-instantiation static.
+    // RTTI-free equivalent of std::type_index for a statically linked binary.
+    using ServiceKey = const void*;
+
+    template <typename T> static ServiceKey serviceKey() {
+        static const char s_tag = 0;
+        return &s_tag;
+    }
+
+    static std::unordered_map<ServiceKey, void*>& getRegistry() {
+        static std::unordered_map<ServiceKey, void*> s_registry;
         return s_registry;
     }
-    
+
     static std::mutex& getMutex() {
         static std::mutex s_mutex;
         return s_mutex;

--- a/Source/App/ServiceLocator.h
+++ b/Source/App/ServiceLocator.h
@@ -23,11 +23,11 @@
  * - Services themselves must be thread-safe if accessed from multiple threads
  *
  * DESIGN NOTES:
- * - Keys are per-type static tag addresses, not typeid: the app target builds
- *   Release with -fno-rtti (Source/CMakeLists.txt), and newer GCC rejects
- *   typeid in template bodies under -fno-rtti. Tag addresses are unique per
- *   type within a single binary, which is all Aestra needs (statically linked,
- *   no services registered across shared-library boundaries).
+ * - Keys are per-type static tag addresses, not typeid, so this header stays
+ *   valid under -fno-rtti (newer GCC rejects typeid in template bodies even
+ *   uninstantiated). Tag addresses are unique per type within a single
+ *   binary, which is all Aestra needs (statically linked, no services
+ *   registered across shared-library boundaries).
  * - Services are stored as void* to allow any type
  * - Lifetime management is external (caller owns services)
  */

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -158,12 +158,17 @@ target_link_libraries(Aestra PRIVATE
 # NO -ffast-math: codebase has ~15 std::isfinite()/std::isnan() guards in audio hot paths.
 # Enabling -ffast-math silently disables those guards (compiler optimizes them away).
 # -ffast-math is a separate project: audit guards, replace with fast-math-safe equivalents, test.
+# NO -fno-exceptions: the app relies on exception handling — Main.cpp's top-level
+# catch, AestraJSON's SEC-RTM-013 parse guards, and std file/parse paths all catch.
+# Disabling exceptions turns those throws into aborts.
+# NO -fno-rtti: Source UI files use std::dynamic_pointer_cast (e.g. dropdown
+# resolution in AudioSettingsPage::onRender), which requires RTTI.
+# Note: CI runs with AESTRA_CI=ON, which forces headless mode — the Aestra app
+# target (and these flags) are NOT exercised by CI. Validate app builds locally.
 if(NOT MSVC)
     target_compile_options(Aestra PRIVATE
         $<$<CONFIG:Release>:-O3>
         $<$<CONFIG:Release>:-flto>
-        $<$<CONFIG:Release>:-fno-exceptions>
-        $<$<CONFIG:Release>:-fno-rtti>
     )
     target_link_options(Aestra PRIVATE
         $<$<CONFIG:Release>:-flto>


### PR DESCRIPTION
## Summary

The `Aestra` app target has been **unbuildable in Release since June 28** — dc6715ea added `-fno-exceptions` and `-fno-rtti` to its Release-only flags, but the code requires both. Nobody noticed because `AESTRA_CI=ON` forces headless mode on every CI lane, so **no CI job compiles the app target at all**.

Changes:
- `Source/CMakeLists.txt`: drop `-fno-exceptions` (the app relies on exception handling: `Main.cpp`'s top-level catch, `AestraJSON`'s SEC-RTM-013 parse guards, std file/parse paths — disabling exceptions turns those throws into aborts) and `-fno-rtti` (Source UI files use `std::dynamic_pointer_cast`, e.g. dropdown resolution in `AudioSettingsPage::onRender`). Keep `-O3`/`-flto`. The comment block now documents both constraints and the CI blind spot.
- `Source/App/ServiceLocator.h`: replace `typeid`/`std::type_index` keys with per-type static tag addresses. This matches the header's own design note ("avoids RTTI"), is equivalent within a statically linked binary, and keeps the header valid under `-fno-rtti` — newer GCC (14+) rejects `typeid` in template bodies under `-fno-rtti` even when uninstantiated, which is how this surfaced on a rolling-release toolchain.

## Why

Owner needs runnable local app builds to verify UI fixes (#256 freeze retest, #395 drop routing) — the stale June 10 binary invalidated a whole manual test round. Beyond that, a broken Release app build is a release-readiness defect regardless of local testing.

## Testing performed

- Full Release UI build of the `Aestra` target now compiles and links locally (build-linux, GCC, Linux, `-j2`): `[100%] Built target Aestra`, fresh 9 MB LTO binary.
- `ServiceLocator.h` verified standalone under `-fno-rtti` (`g++ -fsyntax-only -fno-rtti`).
- Headless/CI builds unaffected: flags were PRIVATE to the app target, which CI never builds; ServiceLocator's key change is behavior-preserving for a single binary.

## Docs updated?

No public docs. In-code comments document the flag constraints and CI blind spot.

## Risk/rollback notes

- Binary behavior: Release app now compiles *with* exceptions/RTTI, as every non-Release config already did — this restores intended semantics rather than changing them (with `-fno-exceptions`, the app could not even compile, so no shipped artifact can regress).
- Follow-up worth considering (not in this PR): a CI lane that compiles the app/UI targets so this class of breakage is caught — currently only local builds exercise `Source/` and `AestraUI/`.
- Rollback: revert the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Build Release now keeps exceptions and RTTI enabled for the Aestra app target, removing the `-fno-exceptions` and `-fno-rtti` flags while preserving `-O3` and `-flto`.
- `ServiceLocator` was refactored to avoid RTTI entirely by switching its registry keys from `std::type_index(typeid(T))` to per-type static tag addresses.
- Updated `ServiceLocator::provide`, `get`, and `remove` to use the new RTTI-free keying scheme, and changed the internal registry to `std::unordered_map<const void*, void*>`.
- Cleaned up the header docs and includes to match the new design and explain why RTTI-free tagging is used.
- This fixes the Release build breakage caused by code paths that rely on exceptions, RTTI, and `std::dynamic_pointer_cast`, and aligns the service locator with `-fno-rtti` compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->