### PR TITLE
Mixer accepts plugin drops on the strip under the cursor

### DIFF
--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -669,6 +669,11 @@ bool UIMixerPanel::loadPluginToChannel(Aestra::ChannelViewModel* vmChannel, cons
     if (slot < Aestra::Audio::EffectChain::MAX_SLOTS) {
         m_trackManager->getCommandHistory().pushAndExecute(
             std::make_shared<Aestra::Audio::AddPluginCommand>(*vmChannel->channel, slot, std::move(instance)));
+        // The playback graph only picks up chain changes on rebuild (which also
+        // re-prepares chains with the live sample rate/block size) — without
+        // this, the plugin sits in the chain but never processes already-playing
+        // tracks until something else dirties the graph.
+        m_trackManager->requestAudioGraphRebuild(Aestra::Audio::GraphDirtyReason::EffectChainChanged);
         // Ensure inspector reflects the new insert
         if (m_inspector) {
             m_inspector->setActiveTab(UIMixerInspector::Tab::Inserts);

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -773,6 +773,12 @@ DropResult UIMixerPanel::onDrop(const DragData& data, const NUIPoint& position) 
         return result;
     }
 
+    // Select the drop target so the inspector's Inserts tab shows the channel
+    // the plugin actually landed on — same call a strip click makes.
+    if (m_viewModel) {
+        m_viewModel->setSelectedChannelId(static_cast<int32_t>(strip->getChannelId()));
+    }
+
     if (!loadPluginToChannel(vmChannel, pluginId)) {
         result.accepted = false;
         result.message = "Failed to load plugin (see log)";

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -84,6 +84,10 @@ UIMixerPanel::UIMixerPanel(std::shared_ptr<Aestra::MixerViewModel> viewModel,
     refreshChannels();
 }
 
+UIMixerPanel::~UIMixerPanel() {
+    NUIDragDropManager::getInstance().unregisterDropTarget(this);
+}
+
 void UIMixerPanel::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();
@@ -266,6 +270,8 @@ void UIMixerPanel::onResize(int width, int height)
 
 void UIMixerPanel::onUpdate(double deltaTime)
 {
+    ensureDropTargetRegistration();
+
     const float maxScroll = getChannelMaxScroll();
     m_targetScrollX = safeClampMixerScroll(m_targetScrollX, maxScroll);
 
@@ -290,6 +296,44 @@ void UIMixerPanel::onUpdate(double deltaTime)
 
     // Update children
     updateChildren(deltaTime);
+}
+
+void UIMixerPanel::ensureDropTargetRegistration() {
+    auto& dnd = NUIDragDropManager::getInstance();
+
+    // One-time registration (shared_from_this is unavailable in the constructor).
+    if (!m_dropTargetRegistered) {
+        try {
+            if (auto sharedThis = std::dynamic_pointer_cast<IDropTarget>(shared_from_this())) {
+                dnd.registerDropTarget(sharedThis);
+                m_dropTargetRegistered = true;
+            }
+        } catch (const std::bad_weak_ptr&) {
+            // Not yet owned by a shared_ptr; retry next frame.
+            return;
+        }
+    }
+
+    // The drop manager scans targets in reverse registration order and the
+    // mixer overlays the timeline, so re-register once per drag to move this
+    // panel to the back of the list — it must be checked before TrackManagerUI
+    // or plugin drops fall through to the lane geometry behind it (#395).
+    // onUpdate only runs while the mixer is shown; when hidden, the manager's
+    // visibility eligibility check skips this target entirely.
+    if (dnd.isDragging()) {
+        if (!m_dropOrderClaimedForDrag) {
+            try {
+                if (auto sharedThis = std::dynamic_pointer_cast<IDropTarget>(shared_from_this())) {
+                    dnd.unregisterDropTarget(this);
+                    dnd.registerDropTarget(sharedThis);
+                    m_dropOrderClaimedForDrag = true;
+                }
+            } catch (const std::bad_weak_ptr&) {}
+        }
+    } else {
+        m_dropOrderClaimedForDrag = false;
+        m_dropHoverChannelId = -1; // clear highlight if a drag ended without onDragLeave
+    }
 }
 
 void UIMixerPanel::renderSeparators(NUIRenderer& renderer)
@@ -409,6 +453,18 @@ void UIMixerPanel::onRender(NUIRenderer& renderer)
         }
     }
 
+    // Drop-target highlight for channel strips (#395) — inside the clip so it
+    // never bleeds into the inspector/master area.
+    if (m_dropHoverChannelId >= 0) {
+        const NUIColor accent = NUIThemeManager::getInstance().getColor("accentPrimary");
+        for (const auto& strip : m_strips) {
+            if (strip && strip->isVisible() && static_cast<int64_t>(strip->getChannelId()) == m_dropHoverChannelId) {
+                renderer.strokeRoundedRect(strip->getBounds(), 6.0f, 2.0f, accent);
+                break;
+            }
+        }
+    }
+
     if (clipEnabled) {
         renderer.clearClipRect();
     }
@@ -420,6 +476,13 @@ void UIMixerPanel::onRender(NUIRenderer& renderer)
     // Master strip renders on top / outside the clip.
     if (m_masterStrip && m_masterStrip->isVisible()) {
         m_masterStrip->onRender(renderer);
+    }
+
+    // Drop-target highlight for the master strip (rendered outside the clip).
+    if (m_dropHoverChannelId >= 0 && m_masterStrip && m_masterStrip->isVisible() &&
+        static_cast<int64_t>(m_masterStrip->getChannelId()) == m_dropHoverChannelId) {
+        const NUIColor accent = NUIThemeManager::getInstance().getColor("accentPrimary");
+        renderer.strokeRoundedRect(m_masterStrip->getBounds(), 6.0f, 2.0f, accent);
     }
 
     // Plugin dropdown renders as a floating overlay on top of everything.
@@ -576,21 +639,25 @@ void UIMixerPanel::showPluginDropdown(uint32_t channelId)
 
 void UIMixerPanel::loadPluginToSelectedChannel(const std::string& pluginId)
 {
-    if (!m_trackManager || !m_viewModel) return;
+    if (!m_viewModel)
+        return;
+    loadPluginToChannel(m_viewModel->getSelectedChannel(), pluginId);
+}
 
-    auto* vmChannel = m_viewModel->getSelectedChannel();
-    if (!vmChannel || !vmChannel->channel) return;
+bool UIMixerPanel::loadPluginToChannel(Aestra::ChannelViewModel* vmChannel, const std::string& pluginId) {
+    if (!m_trackManager || !vmChannel || !vmChannel->channel)
+        return false;
 
     auto& pm = Aestra::Audio::PluginManager::getInstance();
     auto instance = pm.createInstanceById(pluginId);
     if (!instance) {
         AESTRA_LOG_ERROR("Failed to create plugin instance for: " + pluginId);
-        return;
+        return false;
     }
 
     if (!instance->initialize(pm.getDefaultSampleRate(), pm.getDefaultBlockSize())) {
         AESTRA_LOG_ERROR("Failed to initialize plugin instance for: " + pluginId);
-        return;
+        return false;
     }
     if (auto delay = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraDelay>(instance)) {
         delay->setBPM(static_cast<float>(m_trackManager->getPlaylistModel().getBPM()));
@@ -606,9 +673,117 @@ void UIMixerPanel::loadPluginToSelectedChannel(const std::string& pluginId)
         if (m_inspector) {
             m_inspector->setActiveTab(UIMixerInspector::Tab::Inserts);
         }
-    } else {
-        AESTRA_LOG_WARNING("No empty effect slots on channel " + std::to_string(vmChannel->id));
+        return true;
     }
+
+    AESTRA_LOG_WARNING("No empty effect slots on channel " + std::to_string(vmChannel->id));
+    return false;
+}
+
+// ============================================================================
+// IDropTarget (#395) — plugin drops target the strip under the cursor
+// ============================================================================
+
+UIMixerStrip* UIMixerPanel::stripAt(const NUIPoint& position) const {
+    // The inspector and master strip are pinned on the right and render above
+    // scrolled channel strips — resolve them first so occluded strips can't win.
+    if (m_inspector && m_inspector->isVisible() && m_inspector->getBounds().contains(position)) {
+        return nullptr; // inspector is not a drop surface
+    }
+    if (m_masterStrip && m_masterStrip->isVisible() && m_masterStrip->getBounds().contains(position)) {
+        return m_masterStrip.get();
+    }
+
+    // Channel strips are clipped to the viewport left of the inspector.
+    auto panelBounds = getBounds();
+    const float masterX = panelBounds.x + panelBounds.width - MASTER_STRIP_WIDTH;
+    const float viewportRight = masterX - STRIP_SPACING - INSPECTOR_WIDTH - STRIP_SPACING;
+    if (position.x > viewportRight) {
+        return nullptr;
+    }
+
+    for (const auto& strip : m_strips) {
+        if (strip && strip->isVisible() && strip->getBounds().contains(position)) {
+            return strip.get();
+        }
+    }
+    return nullptr;
+}
+
+Aestra::ChannelViewModel* UIMixerPanel::channelForStrip(const UIMixerStrip* strip) const {
+    if (!strip || !m_viewModel)
+        return nullptr;
+    if (m_masterStrip && strip == m_masterStrip.get()) {
+        return m_viewModel->getMaster();
+    }
+    return m_viewModel->getChannelById(strip->getChannelId());
+}
+
+DropFeedback UIMixerPanel::onDragEnter(const DragData& data, const NUIPoint& position) {
+    return onDragOver(data, position);
+}
+
+DropFeedback UIMixerPanel::onDragOver(const DragData& data, const NUIPoint& position) {
+    m_dropHoverChannelId = -1;
+    if (data.type != DragDataType::Plugin) {
+        return DropFeedback::Invalid;
+    }
+    auto* strip = stripAt(position);
+    if (!strip || !channelForStrip(strip)) {
+        return DropFeedback::Invalid;
+    }
+    m_dropHoverChannelId = static_cast<int64_t>(strip->getChannelId());
+    return DropFeedback::Copy;
+}
+
+void UIMixerPanel::onDragLeave() {
+    m_dropHoverChannelId = -1;
+}
+
+DropResult UIMixerPanel::onDrop(const DragData& data, const NUIPoint& position) {
+    DropResult result;
+    m_dropHoverChannelId = -1;
+
+    // The mixer claims every drop over its bounds, including ones it rejects:
+    // letting a rejected drop fall through to the timeline behind the mixer is
+    // exactly the misrouting this target exists to prevent (#395).
+    if (data.type != DragDataType::Plugin) {
+        result.accepted = false;
+        result.message = "Only plugins can be dropped on the mixer";
+        return result;
+    }
+
+    auto* strip = stripAt(position);
+    auto* vmChannel = channelForStrip(strip);
+    if (!strip || !vmChannel) {
+        result.accepted = false;
+        result.message = "No mixer strip under drop";
+        return result;
+    }
+
+    const std::string& pluginId = data.sourceClipIdString;
+    if (pluginId.empty()) {
+        result.accepted = false;
+        result.message = "Drag data missing plugin id";
+        return result;
+    }
+
+    if (!loadPluginToChannel(vmChannel, pluginId)) {
+        result.accepted = false;
+        result.message = "Failed to load plugin (see log)";
+        return result;
+    }
+
+    result.accepted = true;
+    result.targetTrackIndex = static_cast<int>(vmChannel->id);
+    result.message = "Loaded " + (data.displayName.empty() ? pluginId : data.displayName) + " on '" +
+                     vmChannel->channel->getName() + "'";
+    Aestra::Log::info("[UIMixerPanel] Plugin drop: " + result.message);
+    return result;
+}
+
+NUIRect UIMixerPanel::getDropBounds() const {
+    return getBounds();
 }
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -1,20 +1,23 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
-#include "NUIComponent.h"
-#include "NUITypes.h"
-#include "UIMixerMeter.h"
-#include "UIMixerStrip.h"
-#include "UIMixerInspector.h"
-#include "UIMixerPluginDropdown.h"
 #include "Base/NUISlider.h"
+#include "NUIComponent.h"
+#include "NUIDragDrop.h"
+#include "NUITypes.h"
+#include "UIMixerInspector.h"
+#include "UIMixerMeter.h"
+#include "UIMixerPluginDropdown.h"
+#include "UIMixerStrip.h"
+
+#include <functional>
 #include <memory>
 #include <vector>
-#include <functional>
 
 // Forward declarations
 namespace Aestra {
     class MixerViewModel;
+    struct ChannelViewModel;
     namespace Audio {
         class ContinuousParamBuffer;
         class MeterSnapshotBuffer;
@@ -33,7 +36,7 @@ namespace AestraUI {
  *
  * Requirements: 3.1 - Channel strips with fixed width (96-112px)
  */
-class UIMixerPanel : public NUIComponent {
+class UIMixerPanel : public NUIComponent, public IDropTarget {
 public:
     /**
      * @brief Construct a mixer panel.
@@ -44,12 +47,21 @@ public:
     UIMixerPanel(std::shared_ptr<Aestra::MixerViewModel> viewModel,
                  std::shared_ptr<Aestra::Audio::TrackManager> trackManager);
 
-    ~UIMixerPanel() override = default;
+    ~UIMixerPanel() override;
 
     void onRender(NUIRenderer& renderer) override;
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
+
+    // IDropTarget — plugin drops land on the strip under the cursor (#395).
+    // The mixer overlays the timeline, so it must claim drops before
+    // TrackManagerUI resolves them geometrically against the lanes behind it.
+    DropFeedback onDragEnter(const DragData& data, const NUIPoint& position) override;
+    DropFeedback onDragOver(const DragData& data, const NUIPoint& position) override;
+    void onDragLeave() override;
+    DropResult onDrop(const DragData& data, const NUIPoint& position) override;
+    NUIRect getDropBounds() const override;
 
     /**
      * @brief Refresh channel list from view model.
@@ -83,6 +95,16 @@ private:
 
     void showPluginDropdown(uint32_t channelId);
     void loadPluginToSelectedChannel(const std::string& pluginId);
+    bool loadPluginToChannel(Aestra::ChannelViewModel* vmChannel, const std::string& pluginId);
+
+    /// Strip under a screen position (channel strips + master), honoring the
+    /// inspector/master occlusion of scrolled strips. Null when none.
+    UIMixerStrip* stripAt(const NUIPoint& position) const;
+
+    /// View-model channel for a strip (master strip resolves to getMaster()).
+    Aestra::ChannelViewModel* channelForStrip(const UIMixerStrip* strip) const;
+
+    void ensureDropTargetRegistration();
 
     std::shared_ptr<Aestra::MixerViewModel> m_viewModel;
     std::shared_ptr<Aestra::Audio::TrackManager> m_trackManager;
@@ -101,6 +123,11 @@ private:
 
     /// Plugin finder dropdown (topmost, shown on Add Insert click)
     std::shared_ptr<UIMixerPluginDropdown> m_pluginDropdown;
+
+    // Drag-and-drop state (#395)
+    bool m_dropTargetRegistered{false};
+    bool m_dropOrderClaimedForDrag{false};
+    int64_t m_dropHoverChannelId{-1}; ///< Channel id of strip under an active plugin drag, -1 = none
 
     // Horizontal scroll offset for channel strips (pixels).
     float m_scrollX{0.0f};

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3344,6 +3344,10 @@ void AestraContent::loadEffectToSelectedTrack(const std::string& pluginId) {
     if (slot < Aestra::Audio::EffectChain::MAX_SLOTS) {
         m_trackManager->getCommandHistory().pushAndExecute(
             std::make_shared<Aestra::Audio::AddPluginCommand>(*channel, slot, std::move(instance)));
+        // The playback graph only picks up chain changes on rebuild (which also
+        // re-prepares chains with the live sample rate/block size) — without this,
+        // the plugin never processes already-playing tracks.
+        m_trackManager->requestAudioGraphRebuild(Aestra::Audio::GraphDirtyReason::EffectChainChanged);
         AESTRA_LOG_DEBUG("Loaded effect to channel '" + channel->getName() + "' slot " + std::to_string(slot));
     } else {
         AESTRA_LOG_WARNING("No empty effect slots on channel '" + channel->getName() + "'");


### PR DESCRIPTION
## Summary

Fixes #395. Plugin drag-drops were only handled by `TrackManagerUI::onDrop`, which resolves the target lane from the drop's **y-coordinate on the timeline** — so drops on the mixer overlay fell through to whatever lane sat behind the cursor. Owner repro confirmed the fingerprint: mixer strips 1 and 2 (different **x**, same **y**) both loaded the plugin into channel 4.

`UIMixerPanel` now implements `IDropTarget`:

- **Targeting**: hit-tests the strip under the cursor — channel strips (honoring the viewport clip so strips scrolled under the inspector/master area can't be hit), the master strip, and the inspector explicitly excluded as a drop surface.
- **Insertion**: shared `loadPluginToChannel()` split out of `loadPluginToSelectedChannel()` — same `AddPluginCommand` path as the panel's own Add Insert dropdown (undo support, playlist-BPM wiring for AestraDelay from #388), inspector switched to the Inserts tab on success.
- **No fall-through**: non-plugin drops over the mixer are rejected with a message rather than silently passed to the timeline behind it — a sample drop landing on a hidden lane is the same class of misroute this fixes.
- **Priority**: `NUIDragDropManager` scans targets in reverse registration order, so the panel re-registers once per drag (unregister+register moves it to the back of the list) to be checked ahead of `TrackManagerUI`. When the mixer is hidden, the manager's parent-chain visibility eligibility skips it entirely — timeline behavior is unchanged.
- **Feedback**: accent outline on the hovered strip while a plugin drag is over it (rendered inside the strip clip; master highlighted outside it).
- Destructor unregisters, mirroring `TrackManagerUI`.

## Why

Core workflow: drag a plugin onto the track you're mixing. Before this, the drop *succeeded on the wrong track* — worse than failing (#395, follow-up from the #277/#394 verification round).

## Testing performed

- Full Release UI build of the `Aestra` target compiles and links locally (this is the only compile validation that exists — CI never builds UI targets, see #397).
- `git clang-format origin/develop` applied to changed lines.
- Runtime verification is **manual and pending owner retest** with the fresh binary: drop on strip 1 → lands on strip 1's channel; drop on strip 2 → strip 2; drop on master → master chain; non-plugin drop over mixer → rejected, no timeline clip; timeline drops with mixer closed unchanged.
- No automated test: requires the full drag-drop manager + mixer UI stack (not constructible headless).

## Docs updated?

No.

## Risk/rollback notes

- Behavior change is confined to drags over a visible mixer panel; with the mixer hidden, the drop-target eligibility check reproduces today's behavior exactly.
- Plugin instantiation on drop is synchronous, matching the mixer's existing Add Insert dropdown path (`TrackManagerUI`'s drop path uses async creation; unifying them is a possible follow-up, not attempted here per scope).
- One pre-existing quirk inherited, not introduced: the master strip uses channel id 0, so the highlight-by-id could theoretically double-match a regular channel with id 0 — same assumption `showPluginDropdown` already makes.
- Rollback: revert the single commit.

Closes #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- The mixer now participates in drag-and-drop for plugins, so dropping a plugin onto a visible mixer strip inserts it into that strip’s channel instead of falling through to the timeline behind it.
- `UIMixerPanel` now registers/unregisters as a drop target, claims drag priority while a drag is active, and rejects non-plugin drops over the mixer so underlying UI doesn’t receive them.
- Hover feedback now highlights the actual strip under the cursor, including the master strip, to match the real drop target.
- Plugin loading was refactored through a shared channel-specific insert path, preserving the existing `AddPluginCommand` flow, undo support, and `AestraDelay` BPM wiring.
- Successful plugin inserts now request an audio graph rebuild immediately so new effects take effect right away, including both mixer drops and the existing browser/load flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->