### PR TITLE
Timeline visual pass + fix double sRGB-linearization of cached rendering

### DIFF
--- a/AestraUI/Graphics/OpenGL/NUIRenderCache.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRenderCache.cpp
@@ -252,13 +252,6 @@ namespace AestraUI {
             m_renderer->flush();
         }
 
-        // Flush pending screen-target geometry BEFORE binding the cache FBO —
-        // otherwise batched-but-unflushed draws from earlier in the frame would
-        // be emitted into the cache texture instead of the screen.
-        if (m_renderer) {
-            m_renderer->flush();
-        }
-
         // Save current FBO
         GLint currentFBO;
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFBO);

--- a/AestraUI/Graphics/OpenGL/NUIRenderCache.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRenderCache.cpp
@@ -252,6 +252,13 @@ namespace AestraUI {
             m_renderer->flush();
         }
 
+        // Flush pending screen-target geometry BEFORE binding the cache FBO —
+        // otherwise batched-but-unflushed draws from earlier in the frame would
+        // be emitted into the cache texture instead of the screen.
+        if (m_renderer) {
+            m_renderer->flush();
+        }
+
         // Save current FBO
         GLint currentFBO;
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFBO);

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -2807,7 +2807,7 @@ void NUIRendererGL::drawTexture(const NUIRect& bounds, const unsigned char* rgba
     glUseProgram(primitiveShader_.id);
     glUniformMatrix4fv(primitiveShader_.projectionLoc, 1, GL_FALSE, projectionMatrix_);
     glUniform1i(primitiveShader_.primitiveTypeLoc, 0);
-    glUniform1i(primitiveShader_.outputLinearLoc, framebufferSRGBEnabled_ ? 1 : 0);
+    glUniform1i(primitiveShader_.outputLinearLoc, (framebufferSRGBEnabled_ && !renderingToLinearTarget_) ? 1 : 0);
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
@@ -3042,6 +3042,17 @@ uint32_t NUIRendererGL::getGLTextureId(uint32_t textureId) const {
 }
 
 void NUIRendererGL::beginOffscreen(int width, int height) {
+    // Offscreen caches render into linear GL_RGBA8 textures where
+    // GL_FRAMEBUFFER_SRGB does NOT re-encode on write. The shader's
+    // sRGB->linear conversion (uOutputLinear) must therefore be disabled while
+    // rendering into them: values are stored as-authored (sRGB), and the
+    // conversion happens exactly once when the cached texture is composited to
+    // the sRGB screen. With the flag left on, cached content was linearized
+    // on the way in AND on the way out — one uncompensated pow(2.2) that
+    // crushed every dark color drawn through the cache (#observed as the
+    // timeline rendering far darker than its authored palette).
+    renderingToLinearTarget_ = true;
+
     // Backup current size and projection
     widthBackup_ = width_;
     heightBackup_ = height_;
@@ -3056,6 +3067,10 @@ void NUIRendererGL::beginOffscreen(int width, int height) {
 }
 
 void NUIRendererGL::endOffscreen() {
+    // Flush offscreen geometry before restoring the screen color-space mode.
+    flush();
+    renderingToLinearTarget_ = false;
+
     // Restore original projection and size
     width_ = widthBackup_;
     height_ = heightBackup_;
@@ -3095,7 +3110,7 @@ void NUIRendererGL::flush() {
     // Use shader
     glUseProgram(primitiveShader_.id);
     glUniformMatrix4fv(primitiveShader_.projectionLoc, 1, GL_FALSE, projectionMatrix_);
-    glUniform1i(primitiveShader_.outputLinearLoc, framebufferSRGBEnabled_ ? 1 : 0);
+    glUniform1i(primitiveShader_.outputLinearLoc, (framebufferSRGBEnabled_ && !renderingToLinearTarget_) ? 1 : 0);
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.h
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.h
@@ -449,7 +449,13 @@ private:
     float projectionBackup_[16];
     int widthBackup_ = 0;
     int heightBackup_ = 0;
-    
+
+    // True while rendering into a linear (non-sRGB) offscreen target such as
+    // the FBO render cache. Disables the shader's sRGB->linear output
+    // conversion so cached content is stored as-authored and converted exactly
+    // once when composited to the sRGB screen (see beginOffscreen()).
+    bool renderingToLinearTarget_ = false;
+
     // Glassmorphism Pass
     GlassmorphismPass glassPass_; 
 };

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -152,7 +152,9 @@ void TimelineMinimapBar::endDrag_()
 void TimelineMinimapBar::cacheThemeColors_()
 {
     auto& theme = NUIThemeManager::getInstance();
-    colors_.glassFill = theme.getColor("surfaceRaised").darkened(0.06f).withAlpha(0.98f);
+    // Near-black shell matching the ruler material exactly (one continuous
+    // band; the old surfaceRaised tint read blue against neighboring rows).
+    colors_.glassFill = NUIColor(0.012f, 0.012f, 0.016f, 0.98f);
     colors_.glassBorder = theme.getColor("border").withAlpha(0.28f);
     colors_.cornerSeparator = theme.getColor("border").withAlpha(0.28f);
 

--- a/Source/Components/TimelineMinimapRenderer.cpp
+++ b/Source/Components/TimelineMinimapRenderer.cpp
@@ -75,10 +75,9 @@ void TimelineMinimapRenderer::render(NUIRenderer& renderer, const TimelineMinima
     const NUIRect& b = layout.bounds;
     if (b.isEmpty()) return;
 
-    // Piano-roll style glass shell.
+    // Glass shell — flat dark base. The old lightened top half was a frosty
+    // highlight that fought the neutral black/grey material language.
     renderer.fillRoundedRect(b, 7.0f, colors.glassFill);
-    renderer.fillRoundedRect(NUIRect(b.x + 1.0f, b.y + 1.0f, b.width - 2.0f, b.height * 0.45f), 6.0f,
-                             colors.glassFill.lightened(0.025f).withAlpha(0.70f));
     if (colors.glassBorder.a > 0.0f) {
         renderer.strokeRoundedRect(b, 7.0f, 1.0f, colors.glassBorder);
     }

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1777,24 +1777,19 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
     // Draw background (control area + full grid area - no bounds restriction)
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor(0.070f, 0.075f, 0.090f, 1.0f);
-    const auto depthTop = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.025f);
-    const auto depthBottom = AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.08f);
+    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor::black(); // pure black grid (owner direction)
 
     if (m_playlistVisible) {
         // Background for control area (always visible)
         AestraUI::NUIRect controlBg(bounds.x, bounds.y, controlAreaWidth, bounds.height);
-        renderer.fillRect(controlBg, AestraUI::NUIColor(0.078f, 0.084f, 0.102f, 1.0f));
+        renderer.fillRect(controlBg, AestraUI::NUIColor(0.034f, 0.035f, 0.040f, 1.0f));
 
         // Background for grid area (match track background; zebra grid provides contrast)
         float scrollbarWidth = 15.0f;
         float gridWidth = bounds.width - controlAreaWidth - scrollbarWidth - 5;
         AestraUI::NUIRect gridBg(bounds.x + gridStartX, bounds.y, gridWidth, bounds.height);
         renderer.fillRect(gridBg, gridBgColor);
-        renderer.fillRect({gridBg.x, gridBg.y, gridBg.width, std::max(1.0f, gridBg.height * 0.12f)}, depthTop);
-        renderer.fillRect({gridBg.x, gridBg.bottom() - std::max(8.0f, gridBg.height * 0.10f), gridBg.width,
-                           std::max(8.0f, gridBg.height * 0.10f)},
-                          depthBottom);
+        // No depth bands: the grid is uniform pure black.
 
         // Draw border
         AestraUI::NUIColor borderColor = themeManager.getColor("border");
@@ -1869,14 +1864,13 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
         // Alternating row shade
         const bool isEven = (i % 2) == 0;
-        const AestraUI::NUIColor evenRowColor = AestraUI::NUIColor(0.070f, 0.075f, 0.090f, 1.0f);
-        const AestraUI::NUIColor oddRowColor = AestraUI::NUIColor(0.062f, 0.067f, 0.082f, 1.0f);
+        const AestraUI::NUIColor evenRowColor = AestraUI::NUIColor::black();
+        const AestraUI::NUIColor oddRowColor = AestraUI::NUIColor::black();
         renderer.fillRect(trackBounds, isEven ? evenRowColor : oddRowColor);
 
-        // 1px bottom border across full track width (control + grid)
-        renderer.drawLine(AestraUI::NUIPoint(trackBounds.x, trackBounds.bottom() - 1.0f),
-                          AestraUI::NUIPoint(trackBounds.right(), trackBounds.bottom() - 1.0f), 1.0f,
-                          AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.10f));
+        // Row separation is drawn once, softly, by TrackUIComponent::renderStatic.
+        // The extra 1px white line that used to stack on top of it produced the
+        // harsh horizontal grid the timeline was criticized for.
 
         track->renderStatic(renderer);
     }
@@ -1894,8 +1888,20 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
         float headerHeight = 38.0f;
         AestraUI::NUIRect headerRect(bounds.x, bounds.y, headerWidth, headerHeight);
-        renderer.fillRect(headerRect, AestraUI::NUIColor(0.078f, 0.084f, 0.102f, 1.0f));
-        // Removed gradient for flatter aesthetic
+        // Elevated header: base fill + soft vertical gradient + glass top edge.
+        // Rendered into the playlist FBO cache, so the richness is free per frame.
+        renderer.fillRect(headerRect, AestraUI::NUIColor(0.030f, 0.031f, 0.036f, 1.0f));
+        // Shade-only elevation — any white component reads as a sheen on this
+        // near-black chrome (owner direction: no light gradients anywhere).
+        renderer.fillRectGradient(headerRect, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
+                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.075f),
+                                  /*vertical=*/true);
+        // Soft drop below the header so it reads as a raised surface.
+        const float shadowH = 7.0f;
+        renderer.fillRectGradient(AestraUI::NUIRect(headerRect.x, headerRect.bottom(), headerRect.width, shadowH),
+                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.22f),
+                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
+                                  /*vertical=*/true);
         const auto headerBorder = borderColor.withAlpha(0.50f);
         renderer.drawLine({headerRect.x, headerRect.y}, {headerRect.x, headerRect.bottom()}, 1.0f, headerBorder);
         renderer.drawLine({headerRect.right(), headerRect.y}, {headerRect.right(), headerRect.bottom()}, 1.0f,
@@ -3718,7 +3724,9 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
     auto borderColor = AestraUI::NUIColor::white().withAlpha(0.075f);
     auto accentColor = AestraUI::NUIColor(0.486f, 0.361f, 0.749f, 1.0f);
 
-    auto glassBg = themeManager.getColor("backgroundPrimary").darkened(0.02f);
+    // Opaque near-black ruler material — identical across the full row and the
+    // grid shell so the corner over the track controls is flush by construction.
+    auto glassBg = AestraUI::NUIColor(0.012f, 0.012f, 0.016f, 1.0f);
     auto glassHighlight = AestraUI::NUIColor::white().withAlpha(0.014f);
 
     auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
@@ -3736,6 +3744,11 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
     float gridWidth = std::max(0.0f, trackWidth - controlAreaWidth - 10.0f);
 
     AestraUI::NUIRect gridRulerRect(gridStartX, rulerBounds.y, gridWidth, rulerBounds.height);
+
+    // One material across the whole ruler row: fill the full row (including the
+    // corner over the track controls) with the ruler base so the left edge is
+    // flush with the rest of the ruler instead of showing the layer beneath.
+    renderer.fillRect(rulerBounds, glassBg);
 
     float cornerRadius = 3.0f;
     renderer.fillRoundedRect(gridRulerRect, cornerRadius, glassBg);

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1862,11 +1862,9 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         if (trackBounds.bottom() < viewportTop || trackBounds.y > viewportBottom)
             continue;
 
-        // Alternating row shade
-        const bool isEven = (i % 2) == 0;
-        const AestraUI::NUIColor evenRowColor = AestraUI::NUIColor::black();
-        const AestraUI::NUIColor oddRowColor = AestraUI::NUIColor::black();
-        renderer.fillRect(trackBounds, isEven ? evenRowColor : oddRowColor);
+        // Uniform pure-black row base (owner direction: no row zebra; the bar
+        // zebra inside drawPlaylistGrid provides the only alternation).
+        renderer.fillRect(trackBounds, AestraUI::NUIColor::black());
 
         // Row separation is drawn once, softly, by TrackUIComponent::renderStatic.
         // The extra 1px white line that used to stack on top of it produced the

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1024,10 +1024,10 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
     const auto& layout = themeManager.getLayoutDimensions();
     
     // Zebra striping moved to TrackManagerUI for guaranteed rendering order
-    
-    AestraUI::NUIColor trackBgColor =
-        (m_rowIndex % 2 == 0) ? AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.014f)
-                              : AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.042f);
+
+    // No zebra: the grid is uniform pure black (owner direction). Only the
+    // selection/hover states below tint the row.
+    AestraUI::NUIColor trackBgColor = AestraUI::NUIColor::transparent();
 
     // Selection Highlight (Static base)
     if (isSelected()) {
@@ -1040,23 +1040,23 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
     // Apply background
     renderer.fillRect(bounds, trackBgColor);
 
-    // Faint bottom row divider for cleaner track separation
-    renderer.drawLine(
-        AestraUI::NUIPoint(bounds.x, bounds.bottom() - 1.0f),
-        AestraUI::NUIPoint(bounds.right(), bounds.bottom() - 1.0f),
-        1.0f,
-        themeManager.getColor("borderSubtle").withAlpha(0.38f)
-    );
+    // Faint bottom row divider for cleaner track separation.
+    // Kept deliberately soft — this is the only per-row separator (the old
+    // second line in TrackManagerUI stacked on top of it made the harsh grid).
+    renderer.drawLine(AestraUI::NUIPoint(bounds.x, bounds.bottom() - 1.0f),
+                      AestraUI::NUIPoint(bounds.right(), bounds.bottom() - 1.0f), 1.0f,
+                      themeManager.getColor("borderSubtle").withAlpha(0.20f));
     AestraUI::NUIColor borderColor = themeManager.getColor("border");
     
     float controlAreaWidth = std::min(layout.trackControlsWidth, bounds.width);
     
     if (m_isPrimaryForLane) {
         AestraUI::NUIRect controlBounds(bounds.x, bounds.y, controlAreaWidth, bounds.height);
-        
+
         // Control Area base: elevated surface from palette.
-        AestraUI::NUIColor baseControlColor = themeManager.getColor("surfaceTertiary");
-        
+        // Near-black chrome per owner direction (was surfaceTertiary, read bluish-grey).
+        AestraUI::NUIColor baseControlColor(0.038f, 0.039f, 0.045f, 1.0f);
+
         // Static Control Area State
         if (m_channel) {
             if (m_selected) {
@@ -1069,10 +1069,18 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
                  baseControlColor = themeManager.getColor("surfaceRaised").withAlpha(0.70f);
              }
         }
-        
-        // Render Control Area Background
+
+        // Render Control Area Background with a soft vertical elevation gradient
+        // (state color stays the base; the gradient just adds depth). This runs
+        // inside the playlist FBO cache, so the extra fills cost nothing per frame.
         renderer.fillRect(controlBounds, baseControlColor);
-        
+        // Elevation via shade ONLY — no light component at all. Even ~1% white
+        // reads as a sheen on near-black (and this pipeline amplifies low-alpha
+        // fills), so depth comes purely from the darker bottom.
+        renderer.fillRectGradient(controlBounds, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
+                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.070f),
+                                  /*vertical=*/true);
+
         // Separator Line (Bright Glass Border) between Controls and Timeline
         renderer.drawLine(
             AestraUI::NUIPoint(controlBounds.right(), controlBounds.y),
@@ -1475,7 +1483,8 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                          m_channel->isArmed(), recordActive);
     }
 
-    // Track number marker (left of name): 10px, 40% white.
+    // Track number marker (left of name): fixed white — no dynamic dimming
+    // (professional, defined feel per owner direction).
     if (m_nameLabel && m_channel) {
         constexpr float stripWidth = 3.0f;
         uint32_t trackNumber = m_channel->getChannelId();
@@ -1485,13 +1494,9 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             trackNumber = parsedNumber;
         }
         const auto nameBounds = m_nameLabel->getBounds();
-        renderer.drawText(
-            std::to_string(trackNumber),
-            AestraUI::NUIPoint(controlAreaBounds.x + stripWidth + 8.0f, nameBounds.y + 2.0f),
-            10.5f,
-            AestraUI::NUIColor(1.0f, 1.0f, 1.0f, m_selected ? 0.70f : 0.46f)
-        );
-
+        renderer.drawText(std::to_string(trackNumber),
+                          AestraUI::NUIPoint(controlAreaBounds.x + stripWidth + 8.0f, nameBounds.y + 2.0f), 10.5f,
+                          AestraUI::NUIColor::white());
     }
 }
 
@@ -1513,36 +1518,30 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     if (gridWidth <= 0.0f) {
         return;
     }
-    
-    // 1. LOW-CONTRAST BAR SHADING
-    float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
-    int startBar = static_cast<int>(m_timelineScrollOffset / pixelsPerBar);
-    int endBar = static_cast<int>((m_timelineScrollOffset + gridWidth) / pixelsPerBar) + 1;
-    
-    for (int bar = startBar; bar <= endBar; ++bar) {
-        float x = gridStartX + (bar * pixelsPerBar) - m_timelineScrollOffset;
-        
-        // Zebra Striping: Draw slightly lighter background for odd bars
-        if (bar % 2 != 0) {
-             float rectX = x;
-             float rectW = pixelsPerBar;
-             
-             // Manual clipping for zebra striping
-             if (rectX < gridStartX) {
-                 rectW -= (gridStartX - rectX);
-                 rectX = gridStartX;
-             }
-             
-             if (rectX + rectW > gridEndX) {
-                 rectW = gridEndX - rectX;
-             }
-             
-             if (rectW > 0 && rectX < gridEndX) {
-                 renderer.fillRect(
-                     AestraUI::NUIRect(rectX, bounds.y, rectW, bounds.height), 
-                     AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.008f)
-                 );
-             }
+
+    // 1. BAR ZEBRA on pure black: odd bars lift to a whisper of grey. With the
+    // gamma-correct cache pipeline this renders at its authored subtlety
+    // (the old "frost" was the double-linearization amplifying it).
+    const float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
+    {
+        const int startBar = static_cast<int>(m_timelineScrollOffset / pixelsPerBar);
+        const int endBar = static_cast<int>((m_timelineScrollOffset + gridWidth) / pixelsPerBar) + 1;
+        for (int bar = startBar; bar <= endBar; ++bar) {
+            if (bar % 2 == 0)
+                continue;
+            float rectX = gridStartX + (bar * pixelsPerBar) - m_timelineScrollOffset;
+            float rectW = pixelsPerBar;
+            if (rectX < gridStartX) {
+                rectW -= (gridStartX - rectX);
+                rectX = gridStartX;
+            }
+            if (rectX + rectW > gridEndX) {
+                rectW = gridEndX - rectX;
+            }
+            if (rectW > 0.0f) {
+                renderer.fillRect(AestraUI::NUIRect(rectX, bounds.y, rectW, bounds.height),
+                                  AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.030f));
+            }
         }
     }
 
@@ -1561,10 +1560,11 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     const int firstVisibleBar = static_cast<int>(std::floor(startBeat / static_cast<double>(beatsPerBar))) - 1;
     const int lastVisibleBar = static_cast<int>(std::ceil(endBeat / static_cast<double>(beatsPerBar))) + 1;
 
-    // Grid hierarchy from palette tokens.
-    const AestraUI::NUIColor barLineColor = themeManager.getColor("border").withAlpha(0.48f);
-    const AestraUI::NUIColor beatLineColor = themeManager.getColor("borderSubtle").withAlpha(0.26f);
-    const AestraUI::NUIColor subBeatLineColor = themeManager.getColor("borderSubtle").withAlpha(0.11f);
+    // Inverted grid (owner direction): near-black lanes with grey lines, so the
+    // grid reads as light structure on dark instead of dark cuts on grey.
+    const AestraUI::NUIColor barLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.105f);
+    const AestraUI::NUIColor beatLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.055f);
+    const AestraUI::NUIColor subBeatLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.028f);
     const bool drawBeatSubdivisions = (m_pixelsPerBeat >= 10.0f);
     const bool drawFurtherSubdivisions = (m_pixelsPerBeat >= 54.0f);
 


### PR DESCRIPTION
## Summary

Two commits, reviewable separately:

**Commit 1 — `fix(render)`: double sRGB-linearization of FBO-cached content.** The shader linearizes colors (`uOutputLinear`) for the sRGB default framebuffer to re-encode on write — but the render cache draws into linear `GL_RGBA8` textures where no re-encode happens, and the cached texture then goes through the shader (and linearization) *again* at composite. Net: one uncompensated `pow(2.2)` on everything drawn through the FBO cache. Authored 0.030 greys displayed as ~1/255; whites survived untouched. Every visual seam and "shouty highlight" chased during this pass traced back to this. Fix: `renderingToLinearTarget_` gates `uOutputLinear` off inside `beginOffscreen`/`endOffscreen`. Also fixes a latent flush-ordering bug: `beginCacheRender` bound the cache FBO without flushing pending batched geometry, so earlier screen-target draws could be emitted into the cache texture.

**Commit 2 — `feat(ui)`: timeline visual pass** (owner-driven, five screenshot rounds, final LGTM): pure-black grid with grey lines and a whisper-grey bar zebra; single soft row hairline (removed the stacked double separator); near-black track-header and toolbar chrome with shade-only elevation (zero white gradient components); fixed-white track numbers; ruler row as one flush material including the corner; minimap bar on the same near-black shell (was bluish `surfaceRaised`) with its frosty top band removed.

## Why

Owner directive: make the DAW look clean/premium/rich, and optimize rendering for 4 GB-RAM users. The gamma fix is both a correctness win (all cached surfaces app-wide — timeline, and anything else using `NUIRenderCache` — now display authored colors) and the prerequisite for any sane visual tuning: five rounds of palette work were being distorted by the pipeline until it was found via pixel-sampling the owner's screenshots.

## Testing performed

- Full Release UI build after every round; final binary verified by owner on the live app ("LGTM", screenshot-documented iteration).
- Root cause verified quantitatively: pixel-sampled screenshots matched the `pow(2.2)` prediction (authored 0.030 → measured RGB 1), and post-fix palette values match on-screen values across cache boundaries.
- All visual-pass changes live in the FBO-cached static layer — no per-frame cost added; the gamma fix itself adds two boolean uniform gates and two flushes at cache boundaries (once per cache rebuild, not per frame).
- No automated test: rendering output requires a GL context + display; CI never builds UI targets (#397).

## Docs updated?

No.

## Risk/rollback notes

- The gamma fix changes the displayed appearance of **every FBO-cached surface** (intended — they now match their authored colors). Non-cached UI is unaffected.
- If any other cached view (piano roll etc.) was hand-tuned against the crushed pipeline, it will now render brighter than its author expected — palette follow-ups there are cosmetic, not regressions.
- Rollback: revert commit 2 for visuals only; reverting commit 1 restores the crushed pipeline (not recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed cached offscreen rendering so FBO-backed content is no longer sRGB-linearized twice, preserving authored colors when cached layers are composited back to the screen.
- Added a flush before switching to the cache framebuffer to ensure any pending batched geometry is emitted to the correct target.
- Updated timeline visuals to a darker, more consistent premium-style palette across the grid, row separators, headers, toolbar/ruler, and minimap.
- Simplified several chrome elements by removing lighter/frosted overlays, zebra striping, and theme-derived tints in favor of flatter near-black fills and subtler gradients.
- Adjusted grid and control-surface rendering to use clearer line/overlay treatment, including fixed white track numbers and more explicit grid line colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->