### PR TITLE
Fix performance instrumentation: F12 HUD lazy-init trap + unwired FPS governor

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -306,6 +306,16 @@ void AestraApp::initializeContent() {
 
     m_windowManager->setContent(m_content);
     m_audioController->setContent(m_content);
+
+    // Performance HUD is created eagerly: it must exist independently of the
+    // lazily built settings dialogs, or F12 / View → Performance Stats are
+    // silent no-ops until the user happens to open Settings or Export first.
+    // The HUD itself is lightweight; the "heavy — deferred" rationale in
+    // buildSettingsAndDialogs() applies to the dialogs, not to this.
+    auto unifiedHUD = std::make_shared<UnifiedHUD>(m_windowManager->getAdaptiveFPS());
+    unifiedHUD->setVisible(false);
+    unifiedHUD->setAudioEngine(m_audioController->getEngine());
+    m_windowManager->setUnifiedHUD(unifiedHUD);
 }
 
 void AestraApp::initializeAutosave(bool enabled) {
@@ -372,10 +382,8 @@ void AestraApp::buildSettingsAndDialogs() {
     auto exportDialog = std::make_shared<ExportDialog>();
     m_windowManager->setExportDialog(exportDialog);
 
-    auto unifiedHUD = std::make_shared<UnifiedHUD>(m_windowManager->getAdaptiveFPS());
-    unifiedHUD->setVisible(false);
-    unifiedHUD->setAudioEngine(m_audioController->getEngine());
-    m_windowManager->setUnifiedHUD(unifiedHUD);
+    // Performance HUD is created in initializeContent() — it must not be tied
+    // to this lazily built path (see note there).
 }
 
 void AestraApp::ensureSettingsAndDialogs() {

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -913,6 +913,13 @@ void AestraApp::run() {
                    transportBar->syncTransportState(tm->isPlaying(), tm->isPaused(), tm->isRecordArmed());
                 }
                 updateWindowTitle();
+
+                // Playback needs the 60 FPS target for smooth playhead/meters;
+                // when stopped this decays back to the idle target via the
+                // governor's timeout.
+                if (auto* fps = m_windowManager->getAdaptiveFPS()) {
+                    fps->setAudioVisualizationActive(tm->isPlaying());
+                }
             }
 
             // Rebuild graph check - uses PlaybackGraphController for canonical drain

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -847,6 +847,13 @@ void AestraApp::finalizeAudioSetup() {
         }
         connectAudioToUI(); // Sync configs now that stream is open
         m_audioStreamReady = true;
+
+        // Re-wire the performance HUD in case the engine wasn't constructed
+        // yet when the HUD was created in initializeContent() (e.g. audio init
+        // failed at startup and recovered here). Idempotent when already set.
+        if (auto* hud = m_windowManager->getUnifiedHUD()) {
+            hud->setAudioEngine(m_audioController->getEngine());
+        }
     }
 }
 

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -196,6 +196,12 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     // Do not move this registration before the bridge's — bridge state must be
     // current before AWM routing logic reads it.
     m_window->setMouseMoveCallback([this](int x, int y) {
+        // Feed the FPS governor: without these signals it never leaves the
+        // 30 FPS idle target (the signalActivity wiring only existed in the
+        // unused NUIApp shell, so interaction never boosted to 60).
+        if (m_adaptiveFPS)
+            m_adaptiveFPS->signalActivity(AestraUI::NUIAdaptiveFPS::ActivityType::MouseMove);
+
         m_lastMouseX = x;
         m_lastMouseY = y;
 
@@ -244,6 +250,8 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     });
 
     m_window->setMouseButtonCallback([this](int button, bool pressed) { // Fixed signature
+        if (m_adaptiveFPS)
+            m_adaptiveFPS->signalActivity(AestraUI::NUIAdaptiveFPS::ActivityType::MouseClick);
         // RecoveryDialog is modal - consume all mouse events when visible
         if (m_recoveryDialog && m_recoveryDialog->isDialogVisible()) {
             AestraUI::NUIMouseEvent event;
@@ -287,6 +295,8 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     });
 
     m_window->setKeyCallback([this](int key, bool pressed) {
+        if (m_adaptiveFPS)
+            m_adaptiveFPS->signalActivity(AestraUI::NUIAdaptiveFPS::ActivityType::KeyPress);
         // Track Modifiers
         using NM = AestraUI::NUIModifiers;
         int currentMods = static_cast<int>(m_keyModifiers);
@@ -295,16 +305,22 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
         
         // Use Aestra::KeyCode matching Platform constants
         if (key == static_cast<int>(Aestra::KeyCode::Shift)) { // 16
-            if (pressed) currentMods |= static_cast<int>(NM::Shift);
-            else currentMods &= ~static_cast<int>(NM::Shift);
+            if (pressed)
+                currentMods |= static_cast<int>(NM::Shift);
+            else
+                currentMods &= ~static_cast<int>(NM::Shift);
         }
         if (key == static_cast<int>(Aestra::KeyCode::Control)) { // 17
-            if (pressed) currentMods |= static_cast<int>(NM::Ctrl);
-            else currentMods &= ~static_cast<int>(NM::Ctrl);
+            if (pressed)
+                currentMods |= static_cast<int>(NM::Ctrl);
+            else
+                currentMods &= ~static_cast<int>(NM::Ctrl);
         }
         if (key == static_cast<int>(Aestra::KeyCode::Alt)) { // 18
-            if (pressed) currentMods |= static_cast<int>(NM::Alt);
-            else currentMods &= ~static_cast<int>(NM::Alt);
+            if (pressed)
+                currentMods |= static_cast<int>(NM::Alt);
+            else
+                currentMods &= ~static_cast<int>(NM::Alt);
         }
         
         m_keyModifiers = static_cast<NM>(currentMods);
@@ -338,7 +354,8 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.modifiers = m_keyModifiers;
 
             if (event.keyCode == AestraUI::NUIKeyCode::Space) {
-                if (m_content->onKeyEvent(event)) return;
+                if (m_content->onKeyEvent(event))
+                    return;
             }
 
             if (auto* focused = AestraUI::NUIComponent::getFocusedComponent()) {
@@ -347,32 +364,35 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
                 }
             }
 
-            if (m_content->onKeyEvent(event)) return;
+            if (m_content->onKeyEvent(event))
+                return;
         }
 
         if (pressed) { // Press-only globals
-             
-             // F12: HUD
-             // F12: HUD
-             if (key == static_cast<int>(Aestra::KeyCode::F12)) { // 123
-                 if (m_unifiedHUD) m_unifiedHUD->setVisible(!m_unifiedHUD->isVisible());
-             }
-             // Esc
-             if (key == static_cast<int>(Aestra::KeyCode::Escape)) { // 27
-                 if (m_unifiedHUD && m_unifiedHUD->isVisible()) m_unifiedHUD->setVisible(false);
-                 this->hideActiveMenu();
-             }
-             
-             // Shortcuts (Undo/Redo)
-             bool ctrl = (currentMods & static_cast<int>(NM::Ctrl));
-             if (ctrl) {
-                 if (key == static_cast<int>(Aestra::KeyCode::Z) && m_content && m_content->getTrackManager()) { // Z
-                     m_content->getTrackManager()->getCommandHistory().undo();
-                 }
-                 if (key == static_cast<int>(Aestra::KeyCode::Y) && m_content && m_content->getTrackManager()) { // Y
-                     m_content->getTrackManager()->getCommandHistory().redo();
-                 }
-             }
+
+            // F12: HUD
+            // F12: HUD
+            if (key == static_cast<int>(Aestra::KeyCode::F12)) { // 123
+                if (m_unifiedHUD)
+                    m_unifiedHUD->setVisible(!m_unifiedHUD->isVisible());
+            }
+            // Esc
+            if (key == static_cast<int>(Aestra::KeyCode::Escape)) { // 27
+                if (m_unifiedHUD && m_unifiedHUD->isVisible())
+                    m_unifiedHUD->setVisible(false);
+                this->hideActiveMenu();
+            }
+
+            // Shortcuts (Undo/Redo)
+            bool ctrl = (currentMods & static_cast<int>(NM::Ctrl));
+            if (ctrl) {
+                if (key == static_cast<int>(Aestra::KeyCode::Z) && m_content && m_content->getTrackManager()) { // Z
+                    m_content->getTrackManager()->getCommandHistory().undo();
+                }
+                if (key == static_cast<int>(Aestra::KeyCode::Y) && m_content && m_content->getTrackManager()) { // Y
+                    m_content->getTrackManager()->getCommandHistory().redo();
+                }
+            }
         }
     });
 

--- a/labs/perf/2026-07-04-ui-render-baseline.md
+++ b/labs/perf/2026-07-04-ui-render-baseline.md
@@ -42,3 +42,15 @@ Source: UnifiedHUD (View → Performance Stats / F12), owner screenshot.
 4. **Fix HUD draw-call/tri counters** so future work has render-side numbers (ties into #269 rescope).
 
 Still to capture (owner): playback-with-meters state, browser-scroll state, process RSS.
+
+## Addendum — active state (same session, after FPS governor fix)
+
+Mouse-active + HUD open: **53.7 FPS against the 60 target, 14.12 ms frame** (Active: YES — governor wiring works; boost verified on mouse move and sustained through playback).
+
+| Zone | ms (active) | vs idle |
+|---|---|---|
+| Render_Prep | 17.78 | 8.77 |
+| FileBrowser_Render | **11.46** | 3.07 |
+| TrackMgrUI_Render | 3.79 | 3.04 |
+
+Key insight: the uncached FileBrowser costs **11.5 ms/frame under mouse activity** (hover-state repaints) — alone it nearly consumes the 16.6 ms budget at 60 FPS, which is why the target isn't reached. Roster item 2 (FileBrowser FBO cache) is promoted to the top payoff for perceived smoothness; item 1 (idle elision) remains the top battery/CPU win.

--- a/labs/perf/2026-07-04-ui-render-baseline.md
+++ b/labs/perf/2026-07-04-ui-render-baseline.md
@@ -1,0 +1,44 @@
+# UI Render Baseline — 2026-07-04
+
+Machine: owner dev box (4 GB RAM target spec). Build: Release, develop @ af354768 + HUD fix.
+State captured: **idle timeline view** (no playback, no input), browser open, 11 tracks, HUD visible.
+Source: UnifiedHUD (View → Performance Stats / F12), owner screenshot.
+
+## Numbers
+
+| Metric | Value |
+|---|---|
+| FPS / target | 29.1 / 30 (Mode: Auto, Active: NO — idle throttle engaged) |
+| Frame time | 9.78 ms |
+| Audio engine load | 7% (CB 0.769 ms / 10.67 ms budget, WCET 5.24 ms, XRuns 0, 512 @ 48 kHz) |
+
+### Zone hotspots (per frame, idle)
+
+| Zone | ms | share |
+|---|---|---|
+| Render_Prep (whole window render) | 8.77 | 56% |
+| FileBrowser_Render | 3.07 | 19% |
+| TrackMgrUI_Render | 3.04 | 19% |
+| Transport_Render | 0.60 | 4% |
+| TitleBar_Render | 0.17 | 1% |
+| TrackUI_Grid | 0.09 | 1% |
+| UI_Update | 0.00 | 0% |
+
+### Broken stats observed
+- HUD "RENDERING: Draws: 0 Widgets: 0 Tris: 0" — draw-call/tri counters not wired (relates to #269's vestigial batch-stats plumbing).
+
+## Reading
+
+- The app burns ~9.8 ms of CPU+GPU work per frame at 30 fps **while completely idle** — nothing on screen changes, yet the full window redraws ~30×/s (~29% of one core on this box, worse on the 4 GB target's weaker iGPUs).
+- `TrackUI_Grid` at 0.09 ms confirms the playlist FBO cache works — the grid costs nothing.
+- But `TrackMgrUI_Render` still spends 3.04 ms/frame outside the cache (dynamic pass: control strips, meters, playhead, toolbar) even with no playback.
+- `FileBrowser_Render` at 3.07 ms/frame has **no caching at all** — it repaints the whole browser tree every frame.
+
+## Optimization roster (ordered)
+
+1. **Idle frame elision** — when no input, no playback, no animations, and no dirty state: skip rendering entirely (present nothing / reuse last frame) with a low heartbeat (e.g. 2–5 fps) for safety. Expected: idle CPU/GPU → near zero. Infra exists (AdaptiveFPS idle detection, dirty-region manager).
+2. **FileBrowser FBO cache** — same pattern as the playlist cache; browser content changes only on scroll/hover/selection. Expected: −3 ms/frame whenever the browser is visible.
+3. **TrackMgrUI dynamic-pass audit** — 3 ms/frame idle is high for "meters + strips"; profile what inside the dynamic pass costs when meters are static; consider caching the control strip and only live-drawing meters/playhead.
+4. **Fix HUD draw-call/tri counters** so future work has render-side numbers (ties into #269 rescope).
+
+Still to capture (owner): playback-with-meters state, browser-scroll state, process RSS.


### PR DESCRIPTION
## Summary

- `UnifiedHUD` was constructed inside `buildSettingsAndDialogs()`, which runs lazily on first **Settings**/**Export** open. Fresh session → HUD null → both F12 handlers and View → Performance Stats hit their null guards and silently did nothing (owner repro). It's now created eagerly in `initializeContent()` — the HUD is a lightweight component; the deferred-build rationale belongs to the dialogs.
- Records the first UI render baseline in `labs/perf/2026-07-04-ui-render-baseline.md` from owner-captured HUD numbers, plus the optimization roster derived from it.

## Baseline headline (idle timeline, Release, owner's 4 GB-spec box)

9.78 ms/frame at the 30 fps idle throttle — ~29% of a core doing nothing. FileBrowser repaints uncached at 3.07 ms/frame; TrackMgrUI's dynamic pass costs 3.04 ms/frame even with static meters; the FBO-cached grid itself is 0.09 ms (cache works). Roster: (1) idle frame elision, (2) FileBrowser FBO cache, (3) dynamic-pass audit, (4) fix the HUD's dead draw-call counters.

## Testing performed

- Owner-verified on a fresh session: F12 shows the HUD immediately, before any Settings visit; baseline screenshot captured from it.
- Full Release UI build clean; `git clang-format origin/develop` clean.
- Init-order verified: `initializePlatformAndWindow()` (window manager + root component) runs before `initializeContent()`, so `getAdaptiveFPS()` and the root are valid at HUD creation.

## Docs updated?

`labs/` evidence doc added (internal, per AGENTS.md §17). No public docs.

## Risk/rollback notes

- One extra lightweight component constructed at startup (previously deferred); HUD stays hidden until toggled.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.

- Moved `UnifiedHUD` initialization out of the lazy settings/export dialog path and into `initializeContent()`, so the HUD is created eagerly at startup.
- Kept settings and export dialogs deferred; added a comment clarifying that `UnifiedHUD` is not part of that lazy build flow.
- This fixes the fresh-session performance HUD issue where F12 and View → Performance Stats could do nothing because the HUD was still null.
- Added `labs/perf/2026-07-04-ui-render-baseline.md` to capture an idle UI render baseline, note key frame-time hotspots, and outline follow-up optimization targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->