### PR TITLE
Idle frame elision — skip render/swap when nothing can change

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -938,8 +938,22 @@ void AestraApp::run() {
             }
         }
 
-        {
+        // ---- Idle frame elision (labs/perf/idle-frame-elision-spec.md) ----
+        // Events and updates above always run at full cadence (input latency
+        // is untouched); only the render+swap work is elided when nothing can
+        // have changed on screen. A ~3 fps heartbeat keeps the window alive.
+        const bool presentThisFrame = shouldRenderThisFrame();
+
+        if (presentThisFrame) {
             AESTRA_ZONE("Render_Prep");
+            // Consume the pending-invalidation bit at render START: everything
+            // dirty up to this point is included in this frame; anything that
+            // dirties DURING render survives and triggers the next frame.
+            // (Clearing after present would eat mid-render invalidations; the
+            // skip path never clears.)
+            if (auto* root = m_windowManager->getRootComponent()) {
+                root->setDirty(false);
+            }
             m_windowManager->render();
         }
 
@@ -953,7 +967,10 @@ void AestraApp::run() {
         }
 
         double sleepTime = m_windowManager->endFrame();
-        m_windowManager->swapBuffers();
+        if (presentThisFrame) {
+            m_windowManager->swapBuffers();
+            m_lastPresentedFrame = std::chrono::steady_clock::now();
+        }
         if (sleepTime > 0.0) {
              if (auto fps = m_windowManager->getAdaptiveFPS()) {
                  fps->sleep(sleepTime);
@@ -964,6 +981,46 @@ void AestraApp::run() {
 
         UnifiedProfiler::getInstance().endFrame();
     }
+}
+
+bool AestraApp::shouldRenderThisFrame() {
+    // Conservative v1 gate: render unless EVERY skip condition holds
+    // (dirty == false && realtime_visuals == false && input_recent == false).
+
+    // Pending invalidation — any component's setDirty(true) propagates here.
+    auto* root = m_windowManager->getRootComponent();
+    if (!root || root->isDirty())
+        return true;
+
+    // Input recency — the adaptive FPS governor already tracks this (fed by
+    // mouse/key callbacks); align with its idle timeout.
+    auto* fps = m_windowManager->getAdaptiveFPS();
+    if (!fps || fps->getIdleTime() < 2.0)
+        return true;
+
+    // Realtime visuals — transport (playhead/meters), record-arm input
+    // monitoring, file preview, and Audition playback.
+    if (m_audioController && m_audioController->getEngine() && m_audioController->getEngine()->isTransportPlaying()) {
+        return true;
+    }
+    if (m_content) {
+        if (auto tm = m_content->getTrackManager()) {
+            if (tm->isPlaying() || tm->isRecordArmed())
+                return true;
+        }
+        if (m_content->hasRealtimePlaybackVisuals())
+            return true;
+    }
+
+    // Overlays that animate or need fresh samples (HUD, dialogs, menus).
+    if (m_windowManager->requiresContinuousRender())
+        return true;
+
+    // Deeply idle: heartbeat only (~3.3 fps) so caret blink, tooltips and any
+    // unsignaled change still surface within ~300 ms.
+    const auto now = std::chrono::steady_clock::now();
+    const double sinceLastPresent = std::chrono::duration<double>(now - m_lastPresentedFrame).count();
+    return sinceLastPresent >= 0.3;
 }
 
 void AestraApp::shutdown() {

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -1,17 +1,18 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
-#include "AestraWindowManager.h"
-#include "AestraAudioController.h"
-#include "AestraContent.h"
-#include "ProjectSerializer.h"
-#include "AutosaveManager.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "../Core/UIState.h"
+#include "AestraAudioController.h"
+#include "AestraContent.h"
+#include "AestraWindowManager.h"
+#include "AutosaveManager.h"
+#include "ProjectSerializer.h"
 
+#include <chrono>
+#include <filesystem>
 #include <memory>
 #include <string>
-#include <filesystem>
 
 /**
  * @brief Main application class
@@ -63,6 +64,10 @@ private:
     void initializeContent();
     void initializeAutosave(bool enabled);
     void buildRecoveryDialog();              // lightweight — needed during startup
+    // Idle frame elision (labs/perf/idle-frame-elision-spec.md)
+    bool shouldRenderThisFrame();
+    std::chrono::steady_clock::time_point m_lastPresentedFrame{};
+
     void buildSettingsAndDialogs();          // heavy — deferred until first open
     void ensureSettingsAndDialogs();         // lazy guard
     void buildMenuBar();

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -55,10 +55,38 @@ TimelineMinimapBar::TimelineMinimapBar()
     cacheThemeColors_();
 }
 
+namespace {
+inline bool rangesEqual(const TimelineRange& a, const TimelineRange& b) {
+    return a.start == b.start && a.end == b.end;
+}
+} // namespace
+
 void TimelineMinimapBar::setModel(const TimelineMinimapModel& model)
 {
+    // Only repaint when the model actually changed. setModel is called every
+    // frame from TrackManagerUI::onUpdate, and an unconditional repaint() kept
+    // the root component permanently dirty — which would defeat idle frame
+    // elision (labs/perf/idle-frame-elision-spec.md).
+    // The snapshot is referenced by pointer and its version can be bumped
+    // in place, so the last-seen version must be remembered by value —
+    // comparing old->version against new->version through the same pointer
+    // would always pass.
+    const TimelineMinimapModel& o = model_;
+    const uint64_t newSummaryVersion = model.summary ? model.summary->version : 0;
+    const bool sameSummary = (o.summary == model.summary) && (lastSeenSummaryVersion_ == newSummaryVersion);
+    const bool unchanged = sameSummary && rangesEqual(o.view, model.view) && o.playheadBeat == model.playheadBeat &&
+                           rangesEqual(o.loop, model.loop) && rangesEqual(o.selection, model.selection) &&
+                           o.marks == model.marks && o.markCount == model.markCount && o.mode == model.mode &&
+                           o.aggregation == model.aggregation && o.beatsPerBar == model.beatsPerBar &&
+                           o.showSelection == model.showSelection && o.showLoop == model.showLoop &&
+                           o.showMarkers == model.showMarkers && o.showDiagnostics == model.showDiagnostics &&
+                           o.showPlayhead == model.showPlayhead;
+
     model_ = model;
-    repaint();
+    lastSeenSummaryVersion_ = newSummaryVersion;
+    if (!unchanged) {
+        repaint();
+    }
 }
 
 void TimelineMinimapBar::onUpdate(double deltaTime)

--- a/Source/Components/TimelineMinimapBar.h
+++ b/Source/Components/TimelineMinimapBar.h
@@ -76,6 +76,9 @@ private:
     void endDrag_();
 
     TimelineMinimapModel model_;
+    /// Version of model_.summary at the last setModel(), stored by value
+    /// (the snapshot pointer's contents mutate in place).
+    uint64_t lastSeenSummaryVersion_ = 0;
     TimelineMinimapRenderer renderer_;
     TimelineMinimapRenderColors colors_{};
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3283,6 +3283,14 @@ bool AestraContent::isPlayingPreview() const {
     return m_previewIsPlaying;
 }
 
+bool AestraContent::hasRealtimePlaybackVisuals() const {
+    if (m_previewIsPlaying)
+        return true;
+    if (m_auditionEngine && m_auditionEngine->isPlaying())
+        return true;
+    return false;
+}
+
 void AestraContent::updatePreviewPlayhead() {
     if (m_previewPanel && m_previewEngine) {
         m_previewPanel->setDuration(m_previewEngine->getDuration());

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -257,6 +257,9 @@ public:
     void seekSoundPreview(double seconds);
     /** @brief Check whether file preview playback is active. */
     bool isPlayingPreview() const;
+    /** @brief True while any non-transport audio playback drives visuals
+        (file preview or Audition engine) — used by idle frame elision. */
+    bool hasRealtimePlaybackVisuals() const;
     /** @brief Update the preview playhead visible in the UI. */
     void updatePreviewPlayhead();
     

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -549,6 +549,22 @@ void AestraWindowManager::setExportDialog(std::shared_ptr<ExportDialog> dialog) 
     }
 }
 
+bool AestraWindowManager::requiresContinuousRender() const {
+    if (m_unifiedHUD && m_unifiedHUD->isVisible())
+        return true; // profiler needs fresh samples
+    if (m_activeMenu)
+        return true;
+    if (m_recoveryDialog && m_recoveryDialog->isDialogVisible())
+        return true;
+    if (m_confirmationDialog && m_confirmationDialog->isDialogVisible())
+        return true;
+    if (m_settingsDialog && m_settingsDialog->isVisible())
+        return true;
+    if (m_exportDialog && m_exportDialog->isVisible())
+        return true;
+    return false;
+}
+
 void AestraWindowManager::setUnifiedHUD(std::shared_ptr<UnifiedHUD> hud) {
     m_unifiedHUD = hud;
     if (m_rootComponent) m_rootComponent->setUnifiedHUD(m_unifiedHUD);

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -62,6 +62,12 @@ public:
     AestraUI::NUIRenderer* getRenderer() { return m_renderer.get(); }
     /** @brief Get the root component attached to the window. */
     AestraRootComponent* getRootComponent() { return m_rootComponent.get(); }
+
+    /// True when some overlay needs rendering every frame regardless of
+    /// dirtiness: the performance HUD (needs fresh profiler samples), any
+    /// visible dialog, or an open menu. Used by idle frame elision
+    /// (labs/perf/idle-frame-elision-spec.md).
+    bool requiresContinuousRender() const;
     /** @brief Get the custom window chrome widget. */
     AestraUI::NUICustomWindow* getCustomWindow() { return m_customWindow.get(); }
     /** @brief Get the unified HUD overlay. */

--- a/labs/perf/2026-07-04-ui-render-baseline.md
+++ b/labs/perf/2026-07-04-ui-render-baseline.md
@@ -54,3 +54,12 @@ Mouse-active + HUD open: **53.7 FPS against the 60 target, 14.12 ms frame** (Act
 | TrackMgrUI_Render | 3.79 | 3.04 |
 
 Key insight: the uncached FileBrowser costs **11.5 ms/frame under mouse activity** (hover-state repaints) — alone it nearly consumes the 16.6 ms budget at 60 FPS, which is why the target isn't reached. Roster item 2 (FileBrowser FBO cache) is promoted to the top payoff for perceived smoothness; item 1 (idle elision) remains the top battery/CPU win.
+
+## Addendum 2 — idle frame elision result (owner-verified)
+
+With the elision gate (perf/idle-frame-elision): **idle CPU ~2%** (from ~30% of
+a core), instant wake on input/dirty/transport, HUD-open forces normal
+rendering as specified. Remaining active-state heat + occasional audio
+crackles are the next program targets — note the active-state capture earlier
+showed audio WCET 16.06 ms against a 10.67 ms buffer budget, which is where
+crackles live.


### PR DESCRIPTION
## Summary

Implements the owner-authored spec (`labs/perf/idle-frame-elision-spec.md`): the app rendered ~9.8 ms frames 30×/s while completely idle. Now render+swap are skipped when **all** conservative conditions hold — root not dirty, input idle >2 s (governor from #400), transport stopped ∧ not record-armed ∧ no preview ∧ no audition, no HUD/dialog/menu — with a 300 ms heartbeat while deeply idle. Event polling and updates keep full cadence, so input latency is untouched and wake is instant.

Key semantics:
- The root component's dirty flag is the loop's pending-invalidation bit: any `setDirty(true)` propagates to the root; the gate **consumes it at render start** (mid-render invalidations survive to the next frame; the skip path never consumes).
- HUD open forces normal rendering — the profiler must stay meaningful (per spec).

Also fixes the first hidden "dirty every frame" path the gate exposed: `TimelineMinimapBar::setModel` (called every frame from `onUpdate`) repainted unconditionally, which kept the root permanently dirty and would have silently defeated elision. It now diffs the model, remembering the snapshot version **by value** since the cache mutates it behind a stable pointer.

## Why

Structural power/CPU win for the 4 GB target (owner: machine runs hot with Aestra open). Distinct from local hot-path work like #401 — not rendering is cheaper than any rendering.

## Testing performed (owner, on the target-spec box)

- Idle, HUD closed: **CPU ~2%** (baseline ~30% of a core), window alive via heartbeat.
- Wake: instant on mouse/keyboard; dialogs/menus render normally.
- Playback/record-arm/preview/audition: no elision, meters and playhead live.
- Idle, HUD open: normal rendering; `HUD_Render`/`Renderer_Flush` zones (from #401) balance the Render_Prep ledger.
- Full Release UI build clean; changed lines clang-formatted. No automated test (GL + display required; CI doesn't build UI — #397).

## Docs updated?

`labs/` baseline doc updated with the verified result. Spec doc landed in #401.

## Risk/rollback notes

- Known v1 tradeoffs (documented in the spec): caret blink quantizes to the heartbeat while deeply idle; any visual state that mutates without `setDirty` updates within ≤300 ms instead of instantly — such finds are missing invalidations to tag individually (none observed in owner testing).
- Rollback: revert the single commit (the gate is additive; removing it restores continuous rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)