### PR TITLE
feat(hud): visible RT-scheduling status readout

### DIFF
--- a/Source/HUD/UnifiedHUD.h
+++ b/Source/HUD/UnifiedHUD.h
@@ -1,19 +1,21 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
-#include "../AestraUI/Core/NUIComponent.h"
+#include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraUI/Core/NUIAdaptiveFPS.h"
+#include "../AestraUI/Core/NUIComponent.h"
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
-#include "../AestraCore/include/AestraUnifiedProfiler.h"
-#include "AudioEngine.h"
 #include "AudioCommandQueue.h"
-#include <memory>
-#include <sstream>
-#include <iomanip>
-#include <vector>
+#include "AudioEngine.h"
+
 #include <algorithm>
 #include <array>
+#include <cstring>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <vector>
 
 /**
  * @brief Rocket Engine Profiler - Professional DAW Performance HUD
@@ -377,7 +379,36 @@ private:
         oss << "Buffer: " << bufFrames << " @ " << sampleRate << " Hz";
         if (qDrops > 0) oss << "  Drops: " << qDrops;
         renderer.drawText(oss.str(), AestraUI::NUIPoint(x, y), 9.0f, labelColor);
-        y += LINE_HEIGHT + SECTION_SPACING;
+        y += LINE_HEIGHT;
+
+        // Realtime scheduling state (#255): degraded audio priority must be
+        // impossible to miss — it is the difference between "crackles are a
+        // bug" and "crackles are an unconfigured system". Three states:
+        // RT + mlock = healthy (green); RT without mlock = partial, page
+        // faults can still glitch (warning); no RT = degraded (error).
+        {
+            const uint32_t prioBits = tel.getThreadPriorityStatus();
+            const int32_t rtErrno = tel.getLinuxRtPriorityErrno();
+            const bool rtActive = (prioBits & 0x01) != 0;
+            const bool memLocked = (prioBits & 0x02) != 0;
+            oss.str("");
+            const char* statusColor;
+            if (rtActive && memLocked) {
+                oss << "RT: SCHED_FIFO active  mlock: yes";
+                statusColor = "success";
+            } else if (rtActive) {
+                oss << "RT: SCHED_FIFO active  mlock: NO (page faults may glitch)";
+                statusColor = "warning";
+            } else {
+                oss << "RT: DEGRADED (normal priority";
+                if (rtErrno != 0)
+                    oss << ", err " << rtErrno << " (" << std::strerror(rtErrno) << ")";
+                oss << ") — check rtprio limits";
+                statusColor = "error";
+            }
+            renderer.drawText(oss.str(), AestraUI::NUIPoint(x, y), 9.0f, theme.getColor(statusColor));
+            y += LINE_HEIGHT + SECTION_SPACING;
+        }
     }
 
     void renderZoneHotspots(AestraUI::NUIRenderer& renderer, float& y) {

--- a/labs/perf/rt-audio-scheduling-spec.md
+++ b/labs/perf/rt-audio-scheduling-spec.md
@@ -1,0 +1,56 @@
+# RT Audio Scheduling (#255) + Callback Overrun Breadcrumbs — Spec (owner-authored, 2026-07-04)
+
+Sequence: elision (#402) → #255 RT scheduling → callback spike attribution → TrackMgrUI dynamic-pass audit.
+Crackles outrank heat: audio dropouts break the trust contract of a DAW.
+
+## #255 — surgical constraints
+
+- Configure audio thread priority at stream/thread start ONLY
+- No callback logic changes; no allocations/locks added to the callback
+- Failure degrades gracefully with a clear warning — never prevents audio
+- Linux: try the proper RT route first (SCHED_FIFO/rtkit), fall back cleanly
+  when the user lacks permissions (rtprio limits)
+
+Question it must answer: "When the UI/compositor gets hot, can the audio
+thread still make its deadline?"
+
+## Pass/fail (brutal)
+
+- Loop playback under UI stress: no crackles, RT priority active when available
+- WCET stops casually exceeding the buffer budget (10.67 ms @ 512/48k) under
+  the same repro conditions
+- If permissions prevent RT: app still runs; HUD/log makes the degraded state
+  obvious (readable warning)
+
+## Callback overrun breadcrumbs (don't overbuild)
+
+Per overrun event, fixed-size record captured FROM the audio thread:
+- max callback time, overrun count, timestamp/frame index
+- buffer size / sample rate, transport state, active plugin count
+- whether a graph swap / plugin activation / file preview / audition was nearby
+- backend xrun/underrun signal if available
+
+RT-safety requirement: fixed-size event, atomic/SPSC publication, no
+formatting or string allocation on the audio thread. UI/log side formats.
+
+## Caveat
+
+RT scheduling fixes preemption-caused crackles, not intrinsically slow
+callback work. If WCET spikes persist after #255, breadcrumbs become the
+source of truth and the suspect shifts to "audio thread doing something
+non-realtime or unexpectedly expensive."
+
+## Result (owner-verified, 2026-07-04)
+
+Two-act experiment on the 4 GB-target box (ulimit -r 0, no realtime group →
+then `realtime-privileges` + re-login):
+
+| | Degraded | RT active |
+|---|---|---|
+| HUD RT line | red, "DEGRADED (normal priority, err 1)" | green, "SCHED_FIFO active  mlock: yes" |
+| WCET under UI stress | 6.49 ms (16.06 ms in the original baseline capture) | **2.55 ms** |
+| Buffer budget | 10.67 ms (512 @ 48 kHz) | 10.67 ms |
+| XRuns / Underruns | 0 in sample | 0 |
+
+Pass criteria met: WCET stopped casually approaching the budget; degraded
+state is loudly visible in HUD + log with the remedy named.


### PR DESCRIPTION
## Summary

Adds a visible realtime-scheduling status line to the audio HUD so a degraded audio thread is impossible to miss.

**Scope change from the original PR:** this branch originally shipped an audio-thread *self-elevation* RT-priority mechanism. That approach was superseded by the **worker-thread mechanism that landed on develop via #404** (elevates the audio thread externally via its published token — works even when the callback thread itself lacks `RLIMIT_RTPRIO`, retries, and resets telemetry on stream restart). Keeping both would have stacked two competing SCHED_FIFO paths fighting over the same `m_callbackRtPriorityAttempted` CAS.

So this branch is reduced to the parts develop still lacks:
- **HUD RT-status readout** (`UnifiedHUD.h`) — reads #404's telemetry (`getThreadPriorityStatus` / `getLinuxRtPriorityErrno`).
- **`labs/perf/rt-audio-scheduling-spec.md`** — owner-authored, mechanism-agnostic, accurate to what ships.

## Why

Crackles break the trust contract of a DAW. A normal-priority audio thread was the crackle root cause; #404 fixes it, but the *degraded* state was invisible. This surfaces it, three states:

| State | Meaning | Color |
|---|---|---|
| SCHED_FIFO + mlock | healthy | success (green) |
| SCHED_FIFO, no mlock | partial — page faults can still glitch | warning (amber) |
| no RT priority | degraded | error (red), with `strerror()` next to errno |

## CodeRabbit

Addresses the prior-revision review: no-mlock is now a **warning**, not a false-green success; errno is shown with its `strerror()` text.

## Testing

- App target (`Aestra`) builds clean on Linux (`-j2`, 4GB-target box). `UnifiedHUD.cpp` compiles the header in-target.
- HUD line is display-only, reads lock-free atomics already published by the shipped engine mechanism — no RT-path change.

## Risk / rollback

Low. Display-only UI change + a doc. No engine, DSP, serialization, or RT-callback changes. Revert = drop the two files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a Linux-only HUD realtime status readout so users can see whether audio RT scheduling is active or degraded, including `mlockall` state and human-readable errno text when RT setup fails.
- Introduced a new spec document for RT audio scheduling and callback overrun breadcrumbs, clarifying the intended Linux startup behavior, RT-safe callback constraints, degraded-mode fallback, and acceptance criteria for stress playback.
- Kept the scope limited to diagnostics and documentation; the audio output, latency behavior, and state format were not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->