### PR TITLE
Fix sample load crackle and reduce realtime memory

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -177,7 +177,10 @@ public:
     bool isTransportPlaying() const { return m_transportPlaying.load(std::memory_order_relaxed); }
     /** @brief Replace the active audio graph and compile it for rendering. */
     void setGraph(const AudioGraph& graph) {
-        m_state.swapGraph(graph);
+        auto preparedGraph = graph;
+        finalizeAudioGraphRouting(preparedGraph);
+        prepareTrackStateForGraph(preparedGraph);
+        m_state.swapGraph(preparedGraph);
         compileGraph();
         m_graphGeneration.fetch_add(1, std::memory_order_release);
     }
@@ -600,6 +603,7 @@ private:
 
     TrackRTState& ensureTrackState(uint32_t trackId);
     void renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset = 0);
+    void prepareTrackStateForGraph(const AudioGraph& graph);
     void applyPendingCommands();
     void applyPendingMetronomeCountInRt();
     void clearMetronomeCountInRt();

--- a/AestraAudio/include/Core/AudioGraph.h
+++ b/AestraAudio/include/Core/AudioGraph.h
@@ -4,6 +4,7 @@
 #include "AutomationCurve.h"
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -72,13 +73,26 @@ struct TrackRenderState {
  * @brief Immutable graph snapshot consumed by the audio thread.
  */
 struct AudioGraph {
+    static constexpr size_t kInvalidTrackIndex = std::numeric_limits<size_t>::max();
+
     std::vector<TrackRenderState> tracks;
     bool anySolo{false};
     // Precomputed max end sample across all clips (engine sample rate).
     // Used for transport looping without scanning clips on the RT thread.
     uint64_t timelineEndSample{0};
     double bpm{120.0};
+
+    // Routing topology compiled off the audio thread.
+    std::vector<size_t> trackIndexById;
+    std::vector<std::vector<size_t>> audibleDownstream;
+    std::vector<std::vector<size_t>> audibleIncoming;
+    std::vector<std::vector<size_t>> sidechainIncoming;
+    std::vector<std::vector<size_t>> topologicalEdges;
+    std::vector<size_t> topologicalOrder;
+    bool hasRoutingCycle{false};
 };
+
+void finalizeAudioGraphRouting(AudioGraph& graph);
 
 } // namespace Audio
 } // namespace Aestra

--- a/AestraAudio/include/Core/AudioTelemetry.h
+++ b/AestraAudio/include/Core/AudioTelemetry.h
@@ -141,6 +141,10 @@ struct AudioTelemetry {
      * Called from audio thread startup to record priority configuration status.
      */
     void setThreadPriorityBit(uint32_t bit) noexcept { threadPriorityStatus.fetch_or(bit, std::memory_order_relaxed); }
+    /// Clear all priority bits — call from the stream starter before a
+    /// (re)start so the audio thread's first-callback verification publishes
+    /// the NEW stream's truth instead of a latched stale success.
+    void clearThreadPriorityStatus() noexcept { threadPriorityStatus.store(0, std::memory_order_relaxed); }
 
     /**
      * @brief B-010: Get thread priority status

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -105,9 +105,9 @@ public:
             return nullptr;
         }
         // IDs start at 1 to avoid collision with Master (ID 0).
-        auto channel =
-            std::make_unique<MixerChannel>(name.empty() ? "Track " + std::to_string(m_channels.size() + 1) : name,
-                                           static_cast<uint32_t>(m_channels.size() + 1));
+        const uint32_t channelId = m_nextChannelId++;
+        auto channel = std::make_unique<MixerChannel>(
+            name.empty() ? "Track " + std::to_string(m_channels.size() + 1) : name, channelId);
         channel->setCommandSink(m_commandSink);
         channel->setInputMonitoringStateChangedCallback([this]() { publishInputMonitoringSnapshot(); });
         if (m_channelPrepareCallback) {
@@ -893,6 +893,7 @@ public:
      */
     void clearAllChannels() {
         m_channels.clear();
+        m_nextChannelId = 1;
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         if (m_channelSlotMap) {
             m_channelSlotMap->clear();
@@ -1452,6 +1453,7 @@ private:
     }
 
     std::vector<std::unique_ptr<MixerChannel>> m_channels;
+    uint32_t m_nextChannelId{1};
     PlaylistModel m_playlistModel;
     PatternManager m_patternManager;
     SourceManager m_sourceManager;

--- a/AestraAudio/include/Models/UnitManager.h
+++ b/AestraAudio/include/Models/UnitManager.h
@@ -282,6 +282,10 @@ public:
     int getUnitTimelineLane(UnitID id) const;
     /** @brief Attach an audio clip path to a unit. */
     void setUnitAudioClip(UnitID id, const std::string& path);
+    /** @brief Publish a pre-decoded audio clip to a unit without doing file I/O on the caller. */
+    bool setUnitAudioClipFromDecoded(UnitID id, const std::string& path, std::vector<float> decodedData,
+                                     uint32_t sampleRate, uint32_t numChannels, std::vector<float> previewWaveform,
+                                     double durationSeconds);
     /** @brief Set the UI accent color for a unit. */
     void setUnitColor(UnitID id, uint32_t color);
     /** @brief Set the unit group classification. */

--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -57,6 +57,7 @@ public:
 
     // Custom Methods
     bool loadSample(const std::string& path);
+    bool loadSampleData(const std::string& path, std::vector<float> data, uint32_t rate, uint32_t channels);
     void setSampleRate(double sampleRate) { m_sampleRate = sampleRate; }
     void setEnvelope(float attack, float decay, float sustain, float release) noexcept;
     void setCoarseSemitones(float semitones) noexcept;

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -7,10 +7,119 @@
 #include <cmath>
 #include "AestraLog.h"
 #include "AestraDebug.h"
+#include <cstddef>
 #include <limits>
 
 namespace Aestra {
 namespace Audio {
+
+void finalizeAudioGraphRouting(AudioGraph& graph) {
+    const size_t trackCount = graph.tracks.size();
+    graph.anySolo = false;
+    graph.audibleDownstream.assign(trackCount, {});
+    graph.audibleIncoming.assign(trackCount, {});
+    graph.sidechainIncoming.assign(trackCount, {});
+    graph.topologicalEdges.assign(trackCount, {});
+    graph.topologicalOrder.clear();
+    graph.topologicalOrder.reserve(trackCount);
+    graph.hasRoutingCycle = false;
+
+    uint32_t maxTrackId = 0;
+    for (const auto& track : graph.tracks) {
+        maxTrackId = std::max(maxTrackId, track.trackId);
+        graph.anySolo = graph.anySolo || track.solo;
+    }
+
+    graph.trackIndexById.assign(static_cast<size_t>(maxTrackId) + 1, AudioGraph::kInvalidTrackIndex);
+    for (size_t i = 0; i < trackCount; ++i) {
+        const uint32_t trackId = graph.tracks[i].trackId;
+        if (trackId < graph.trackIndexById.size()) {
+            graph.trackIndexById[trackId] = i;
+        }
+    }
+
+    auto findTrackIndex = [&graph](uint32_t trackId) -> size_t {
+        if (trackId < graph.trackIndexById.size()) {
+            return graph.trackIndexById[trackId];
+        }
+        return AudioGraph::kInvalidTrackIndex;
+    };
+
+    auto addEdge = [&](size_t sourceIndex, uint32_t targetTrackId, bool sidechainOnly) {
+        constexpr uint32_t kMasterOutputId = 0xFFFFFFFFu;
+        if (targetTrackId == kMasterOutputId) {
+            return;
+        }
+
+        const size_t targetIndex = findTrackIndex(targetTrackId);
+        if (targetIndex == AudioGraph::kInvalidTrackIndex || targetIndex == sourceIndex) {
+            return;
+        }
+
+        graph.topologicalEdges[sourceIndex].push_back(targetIndex);
+        if (sidechainOnly) {
+            graph.sidechainIncoming[targetIndex].push_back(sourceIndex);
+            return;
+        }
+
+        graph.audibleDownstream[sourceIndex].push_back(targetIndex);
+        graph.audibleIncoming[targetIndex].push_back(sourceIndex);
+    };
+
+    for (size_t i = 0; i < trackCount; ++i) {
+        const auto& track = graph.tracks[i];
+        addEdge(i, track.mainOutputId, false);
+        for (const auto& send : track.sends) {
+            if (send.mute) {
+                continue;
+            }
+            addEdge(i, send.targetChannelId, send.sidechainOnly);
+        }
+    }
+
+    std::vector<uint32_t> indegree(trackCount, 0);
+    for (const auto& edges : graph.topologicalEdges) {
+        for (const size_t targetIndex : edges) {
+            if (targetIndex < trackCount) {
+                ++indegree[targetIndex];
+            }
+        }
+    }
+
+    std::vector<size_t> queue;
+    queue.reserve(trackCount);
+    for (size_t i = 0; i < trackCount; ++i) {
+        if (indegree[i] == 0) {
+            queue.push_back(i);
+        }
+    }
+
+    size_t read = 0;
+    while (read < queue.size()) {
+        const size_t index = queue[read++];
+        graph.topologicalOrder.push_back(index);
+        for (const size_t targetIndex : graph.topologicalEdges[index]) {
+            if (targetIndex < trackCount && --indegree[targetIndex] == 0) {
+                queue.push_back(targetIndex);
+            }
+        }
+    }
+
+    graph.hasRoutingCycle = graph.topologicalOrder.size() != trackCount;
+    if (graph.hasRoutingCycle) {
+        std::vector<uint8_t> visited(trackCount, 0);
+        for (const size_t index : graph.topologicalOrder) {
+            if (index < trackCount) {
+                visited[index] = 1;
+            }
+        }
+        for (size_t i = 0; i < trackCount; ++i) {
+            if (visited[i] == 0) {
+                graph.topologicalOrder.push_back(i);
+            }
+        }
+    }
+}
 
 AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) {
     AudioGraph graph;
@@ -111,6 +220,7 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
         graph.bpm = snapshot->bpm;
     }
 
+    finalizeAudioGraphRouting(graph);
     return graph;
 }
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1267,7 +1267,7 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
 
     const size_t requiredSize =
         static_cast<size_t>(m_maxBufferFrames.load(std::memory_order_relaxed)) * kInternalRenderChannels;
-    const bool needAlloc = m_masterBufferD.size() < requiredSize || m_trackBuffersD.size() != kMaxTracks;
+    const bool needAlloc = m_masterBufferD.size() < requiredSize;
 
     if (needAlloc) {
         m_masterBufferD.resize(requiredSize);
@@ -1311,22 +1311,17 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
 
         std::memset(m_masterBufferD.data(), 0, requiredSize * sizeof(double));
 
-        m_trackBuffersD.clear();
-        m_trackBuffersD.resize(kMaxTracks);
-        for (auto& buf : m_trackBuffersD) {
-            buf.assign(requiredSize, 0.0);
+        if (m_trackBuffersD.capacity() < kMaxTracks) {
+            m_trackBuffersD.reserve(kMaxTracks);
         }
-        m_trackSidechainBuffersD.clear();
-        m_trackSidechainBuffersD.resize(kMaxTracks);
-        for (auto& buf : m_trackSidechainBuffersD) {
-            buf.assign(requiredSize, 0.0);
+        if (m_trackSidechainBuffersD.capacity() < kMaxTracks) {
+            m_trackSidechainBuffersD.reserve(kMaxTracks);
         }
-        if (m_trackState.size() != kMaxTracks) {
-            // TrackRTState contains std::unique_ptr members (PDC v2 P4b.3) and
-            // is move-only. Use resize() so elements are default-constructed in
-            // place rather than copy-assigned.
-            m_trackState.clear();
-            m_trackState.resize(kMaxTracks);
+        if (m_trackState.capacity() < kMaxTracks) {
+            // Reserve vector storage without constructing every TrackRTState.
+            // TrackRTState owns large compensation buffers, so constructing all
+            // kMaxTracks at startup is expensive on low-memory systems.
+            m_trackState.reserve(kMaxTracks);
         }
 
         // Pre-allocate all RT graph scratch vectors to avoid heap allocation in renderGraph.
@@ -1351,18 +1346,11 @@ void AudioEngine::setBufferConfig(uint32_t maxFrames, uint32_t numChannels) {
         m_rtSoloProcessQueue.reserve(kMaxTracks);
         m_rtCycleVisited.resize(kMaxTracks);
 
-        // Pre-size send scratch buffers for each track slot.
-        // Use resize() instead of reserve() so renderGraph() never triggers
-        // heap allocation on the audio thread.  kMaxSendsPerTrack is bounded
-        // (256) so the per-track cost is modest.
-        for (size_t i = 0; i < kMaxTracks; ++i) {
-            m_trackState[i].sendGainL.resize(kMaxSendsPerTrack);
-            m_trackState[i].sendGainR.resize(kMaxSendsPerTrack);
-            m_trackState[i].preFaderBuffer.reserve(requiredSize);
-        }
-
         // Pre-allocate prepared-routes scratch (max sends per track).
         m_preparedRoutesScratch.reserve(kMaxSendsPerTrack);
+
+        auto graphRead = m_state.activeGraphRead();
+        prepareTrackStateForGraph(graphRead.get());
 
 #ifdef _WIN32
         // Lock buffers in memory to prevent page faults during real-time processing
@@ -1779,69 +1767,18 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     const uint64_t blockEnd = blockStart + numFrames;
     const bool isPlaying = m_transportPlaying.load(std::memory_order_relaxed); // [NEW] Check transport
 
-    // Solo detection and routed solo support.
-    bool anySolo = false;
-    // Reset flat track-index map to sentinel for ALL entries.
-    // This clears stale indices from previous graphs where trackIds
-    // existed in previous block but not current graph.tracks.
-    std::fill(m_rtTrackIndexById.begin(), m_rtTrackIndexById.end(), kMaxTracks);
-    for (size_t i = 0; i < graph.tracks.size(); ++i) {
-        const uint32_t tid = graph.tracks[i].trackId;
-        if (tid < kMaxTracks) {
-            m_rtTrackIndexById[tid] = i;
-        }
-    }
-    m_rtTrackIndexByIdActiveCount = graph.tracks.size();
-
-    // Reset per-track edge lists (clear inner vectors; outer vector already sized).
+    // Solo state can still change through RT track state, while routing topology
+    // is compiled into AudioGraph before publication.
+    bool anySolo = graph.anySolo;
     const size_t numTracks = graph.tracks.size();
-    for (size_t i = 0; i < numTracks; ++i) {
-        m_rtAudibleDownstream[i].clear();
-        m_rtAudibleIncoming[i].clear();
-        m_rtSidechainIncoming[i].clear();
-    }
-    m_rtAudibleEligible.assign(availableTracks, false);
-    m_rtProcessActive.assign(availableTracks, false);
-
-    auto addTrackEdge = [&](size_t srcIndex, uint32_t destTrackId, bool sidechainOnly) {
-        if (destTrackId >= kMaxTracks || m_rtTrackIndexById[destTrackId] == kMaxTracks) {
-            return;
-        }
-        const size_t destIndex = m_rtTrackIndexById[destTrackId];
-        if (destIndex >= graph.tracks.size()) {
-            return;
-        }
-        if (destIndex == srcIndex) {
-            return;
-        }
-        if (sidechainOnly) {
-            if (m_rtSidechainIncoming[destIndex].size() < kMaxEdgesPerTrack) {
-                m_rtSidechainIncoming[destIndex].push_back(srcIndex);
-            }
-        } else {
-            if (m_rtAudibleDownstream[srcIndex].size() < kMaxEdgesPerTrack) {
-                m_rtAudibleDownstream[srcIndex].push_back(destIndex);
-            }
-            if (m_rtAudibleIncoming[destIndex].size() < kMaxEdgesPerTrack) {
-                m_rtAudibleIncoming[destIndex].push_back(srcIndex);
-            }
-        }
-    };
+    std::fill(m_rtAudibleEligible.begin(), m_rtAudibleEligible.begin() + availableTracks, false);
+    std::fill(m_rtProcessActive.begin(), m_rtProcessActive.begin() + availableTracks, false);
 
     for (size_t i = 0; i < graph.tracks.size(); ++i) {
         const auto& tr = graph.tracks[i];
         auto& state = ensureTrackState(tr.trackIndex);
         if (tr.solo || state.solo) {
             anySolo = true;
-        }
-        if (tr.mainOutputId != 0xFFFFFFFFu) {
-            addTrackEdge(i, tr.mainOutputId, false);
-        }
-        for (const auto& send : tr.sends) {
-            if (send.mute || send.targetChannelId == 0xFFFFFFFFu) {
-                continue;
-            }
-            addTrackEdge(i, send.targetChannelId, send.sidechainOnly);
         }
     }
 
@@ -1869,7 +1806,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         while (audibleQueueRead < m_rtIndexQueue.size()) {
             const size_t index = m_rtIndexQueue[audibleQueueRead++];
             m_rtSoloProcessQueue.push_back(index);
-            for (const size_t destIndex : m_rtAudibleDownstream[index]) {
+            for (const size_t destIndex : graph.audibleDownstream[index]) {
                 const uint32_t destTrackIndex = graph.tracks[destIndex].trackIndex;
                 if (static_cast<size_t>(destTrackIndex) >= availableTracks || m_rtAudibleEligible[destTrackIndex]) {
                     continue;
@@ -1898,8 +1835,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                 }
             };
 
-            enqueueUpstream(m_rtAudibleIncoming[index]);
-            enqueueUpstream(m_rtSidechainIncoming[index]);
+            enqueueUpstream(graph.audibleIncoming[index]);
+            enqueueUpstream(graph.sidechainIncoming[index]);
         }
     }
 
@@ -1961,7 +1898,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         auto& buffer = m_trackBuffersD[trackIdx];
         std::memset(buffer.data(), 0, static_cast<size_t>(numFrames) * 2 * sizeof(double));
 
-        const bool receivesSidechainThisBlock = !m_rtSidechainIncoming[gi].empty();
+        const bool receivesSidechainThisBlock = !graph.sidechainIncoming[gi].empty();
         const bool receivedSidechainLastBlock = m_rtSidechainReceiverFlags[trackIdx] != 0;
         if (receivesSidechainThisBlock || receivedSidechainLastBlock) {
             auto& sidechainBuffer = m_trackSidechainBuffersD[trackIdx];
@@ -1970,81 +1907,9 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         m_rtSidechainReceiverFlags[trackIdx] = receivesSidechainThisBlock ? 1 : 0;
     }
 
-    // Process tracks in audible topological order so any routed upstream
-    // content reaches a destination before that destination runs inserts/fader/metering.
-    m_rtProcessOrder.clear();
-    // All vectors pre-allocated in setBufferConfig(); no reserve()/resize() needed.
-    const size_t topoCount = graph.tracks.size();
-    for (size_t i = 0; i < topoCount; ++i) {
-        m_rtTopoIndegree[i] = 0u;
-    }
-    for (size_t i = 0; i < topoCount; ++i) {
-        m_rtTopoEdges[i].clear();
-    }
-    for (size_t i = 0; i < topoCount; ++i) {
-        const auto& track = graph.tracks[i];
-        auto addEdge = [&](uint32_t destTrackId) {
-            if (destTrackId >= kMaxTracks || m_rtTrackIndexById[destTrackId] == kMaxTracks) {
-                return;
-            }
-            const size_t destIndex = m_rtTrackIndexById[destTrackId];
-            if (destIndex == i) {
-                return;
-            }
-            if (m_rtTopoEdges[i].size() >= kMaxEdgesPerTrack) {
-                return;
-            }
-            m_rtTopoEdges[i].push_back(destIndex);
-            m_rtTopoIndegree[destIndex] += 1u;
-        };
-
-        if (track.mainOutputId != 0xFFFFFFFFu) {
-            addEdge(track.mainOutputId);
-        }
-        for (const auto& send : track.sends) {
-            if (send.mute || send.targetChannelId == 0xFFFFFFFFu) {
-                continue;
-            }
-            addEdge(send.targetChannelId);
-        }
-    }
-
-    m_rtIndexQueue.clear();
-    size_t readyRead = 0;
-    for (size_t i = 0; i < topoCount; ++i) {
-        if (m_rtTopoIndegree[i] == 0u) {
-            m_rtIndexQueue.push_back(i);
-        }
-    }
-    while (readyRead < m_rtIndexQueue.size()) {
-        const size_t index = m_rtIndexQueue[readyRead++];
-        m_rtProcessOrder.push_back(index);
-        for (const size_t destIndex : m_rtTopoEdges[index]) {
-            if (--m_rtTopoIndegree[destIndex] == 0u) {
-                m_rtIndexQueue.push_back(destIndex);
-            }
-        }
-    }
-    const bool cycleDetected = m_rtProcessOrder.size() != topoCount;
-    if (cycleDetected) {
-        // [RT-SAFE] Set atomic flag instead of logging on the audio thread.
-        // A non-RT thread can poll hasRoutingCycleDetected() and log once.
-        m_loggedRoutingCycleWarning.store(true, std::memory_order_relaxed);
-        // Zero cycle-visited flags using index writes (no alloc).
-        for (size_t i = 0; i < topoCount; ++i) {
-            m_rtCycleVisited[i] = false;
-        }
-        for (const size_t index : m_rtProcessOrder) {
-            m_rtCycleVisited[index] = true;
-        }
-        for (size_t i = 0; i < topoCount; ++i) {
-            if (!m_rtCycleVisited[i]) {
-                m_rtProcessOrder.push_back(i);
-            }
-        }
-    } else {
-        m_loggedRoutingCycleWarning.store(false, std::memory_order_relaxed);
-    }
+    // Process tracks in the precompiled topological order so routed upstream
+    // content reaches destinations before inserts/fader/metering.
+    m_loggedRoutingCycleWarning.store(graph.hasRoutingCycle, std::memory_order_relaxed);
 
     // Cache loop-invariant atomics before the per-track loop to avoid
     // redundant loads (12 loads x N tracks per audio block).
@@ -2060,7 +1925,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     const bool cachedPatternMode = m_patternPlaybackMode.load(std::memory_order_relaxed);
     const auto cachedInterpQuality = m_interpQuality.load(std::memory_order_relaxed);
 
-    for (const size_t orderedIndex : m_rtProcessOrder) {
+    for (const size_t orderedIndex : graph.topologicalOrder) {
         const auto& track = graph.tracks[orderedIndex];
         const uint32_t trackIdx = track.trackIndex;
         if (static_cast<size_t>(trackIdx) >= availableTracks) {
@@ -2818,6 +2683,56 @@ TrackRTState& AudioEngine::ensureTrackState(uint32_t trackIndex) {
         return m_dummyTrackState;
     }
     return m_trackState[trackIndex];
+}
+
+void AudioEngine::prepareTrackStateForGraph(const AudioGraph& graph) {
+    size_t requiredTrackSlots = 0;
+    for (const auto& track : graph.tracks) {
+        requiredTrackSlots = std::max(requiredTrackSlots, static_cast<size_t>(track.trackIndex) + 1);
+    }
+    if (requiredTrackSlots == 0) {
+        return;
+    }
+
+    if (m_trackState.capacity() < requiredTrackSlots) {
+        m_trackState.reserve(std::min(kMaxTracks, std::max(requiredTrackSlots, m_trackState.capacity() * 2)));
+    }
+    if (m_trackState.size() < requiredTrackSlots) {
+        m_trackState.resize(requiredTrackSlots);
+    }
+    if (m_trackBuffersD.size() < requiredTrackSlots) {
+        m_trackBuffersD.resize(requiredTrackSlots);
+    }
+    if (m_trackSidechainBuffersD.size() < requiredTrackSlots) {
+        m_trackSidechainBuffersD.resize(requiredTrackSlots);
+    }
+
+    const size_t preFaderSize =
+        static_cast<size_t>(m_maxBufferFrames.load(std::memory_order_relaxed)) * kInternalRenderChannels;
+    const size_t renderBufferSize = preFaderSize;
+    for (const auto& track : graph.tracks) {
+        if (track.trackIndex >= m_trackState.size()) {
+            continue;
+        }
+        if (m_trackBuffersD[track.trackIndex].size() < renderBufferSize) {
+            m_trackBuffersD[track.trackIndex].assign(renderBufferSize, 0.0);
+        }
+        if (m_trackSidechainBuffersD[track.trackIndex].size() < renderBufferSize) {
+            m_trackSidechainBuffersD[track.trackIndex].assign(renderBufferSize, 0.0);
+        }
+
+        auto& state = m_trackState[track.trackIndex];
+        const size_t sendCount = std::min(track.sends.size(), kMaxSendsPerTrack);
+        if (state.sendGainL.size() < sendCount) {
+            state.sendGainL.resize(sendCount);
+        }
+        if (state.sendGainR.size() < sendCount) {
+            state.sendGainR.resize(sendCount);
+        }
+        if (state.preFaderBuffer.capacity() < preFaderSize) {
+            state.preFaderBuffer.reserve(preFaderSize);
+        }
+    }
 }
 
 void AudioEngine::setLoopRegion(double startBeat, double endBeat) {

--- a/AestraAudio/src/Linux/RtAudioDriver.cpp
+++ b/AestraAudio/src/Linux/RtAudioDriver.cpp
@@ -1,9 +1,13 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "RtAudioDriver.h"
+
 #include "Core/AudioTelemetry.h"
 
-#include <iostream>
 #include <cerrno>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -15,6 +19,26 @@
 
 namespace Aestra {
 namespace Audio {
+
+#ifdef __linux__
+namespace {
+uintptr_t pthreadToToken(pthread_t threadId) {
+    if constexpr (std::is_pointer_v<pthread_t>) {
+        return reinterpret_cast<uintptr_t>(threadId);
+    } else {
+        return static_cast<uintptr_t>(threadId);
+    }
+}
+
+pthread_t tokenToPthread(uintptr_t threadToken) {
+    if constexpr (std::is_pointer_v<pthread_t>) {
+        return reinterpret_cast<pthread_t>(threadToken);
+    } else {
+        return static_cast<pthread_t>(threadToken);
+    }
+}
+} // namespace
+#endif
 
 RtAudioDriver::RtAudioDriver() {
     std::vector<RtAudio::Api> candidates;
@@ -138,6 +162,9 @@ void RtAudioDriver::closeStream() {
         return;
     }
 
+#ifdef __linux__
+    stopRealtimePriorityWorker();
+#endif
     if (m_rtAudio->isStreamRunning()) {
         stopStream();
     }
@@ -149,6 +176,9 @@ void RtAudioDriver::closeStream() {
     m_userData.store(nullptr, std::memory_order_relaxed);
     m_sampleRate.store(0, std::memory_order_relaxed);
     m_bufferSize.store(0, std::memory_order_relaxed);
+#ifdef __linux__
+    m_audioThreadToken.store(0, std::memory_order_relaxed);
+#endif
 }
 
 bool RtAudioDriver::startStream() {
@@ -161,7 +191,9 @@ bool RtAudioDriver::startStream() {
     }
 
 #ifdef __linux__
+    stopRealtimePriorityWorker();
     m_callbackRtPriorityAttempted.store(false, std::memory_order_release);
+    m_audioThreadToken.store(0, std::memory_order_release);
     if (m_telemetry) {
         m_telemetry->clearThreadPriorityStatus();
     }
@@ -181,10 +213,17 @@ bool RtAudioDriver::startStream() {
         return false;
     }
 
+#ifdef __linux__
+    startRealtimePriorityWorker();
+#endif
+
     return true;
 }
 
 void RtAudioDriver::stopStream() {
+#ifdef __linux__
+    stopRealtimePriorityWorker();
+#endif
     if (m_rtAudio && m_rtAudio->isStreamRunning()) {
         m_rtAudio->stopStream();
     }
@@ -211,20 +250,9 @@ int RtAudioDriver::rtAudioCallback(void* outputBuffer, void* inputBuffer, unsign
     auto* driver = static_cast<RtAudioDriver*>(userData);
 #ifdef __linux__
     bool expected = false;
-    if (driver && driver->m_callbackRtPriorityAttempted.compare_exchange_strong(expected, true,
-                                                                                std::memory_order_acq_rel)) {
-        struct sched_param param;
-        param.sched_priority = sched_get_priority_max(SCHED_FIFO);
-        param.sched_priority = (param.sched_priority + sched_get_priority_min(SCHED_FIFO)) / 2;
-        const int rtResult = pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
-        if (driver->m_telemetry) {
-            if (rtResult == 0) {
-                driver->m_telemetry->setThreadPriorityBit(0x01);
-                driver->m_telemetry->updateLinuxRtPriorityErrno(0);
-            } else {
-                driver->m_telemetry->updateLinuxRtPriorityErrno(rtResult);
-            }
-        }
+    if (driver &&
+        driver->m_callbackRtPriorityAttempted.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        driver->m_audioThreadToken.store(pthreadToToken(pthread_self()), std::memory_order_release);
     }
 #endif
 
@@ -243,8 +271,8 @@ int RtAudioDriver::rtAudioCallback(void* outputBuffer, void* inputBuffer, unsign
     }
 
     driver->m_stats.callbackCount++;
-    int result = callback(static_cast<float*>(outputBuffer), static_cast<const float*>(inputBuffer), numFrames, streamTime,
-                    callbackUserData);
+    int result = callback(static_cast<float*>(outputBuffer), static_cast<const float*>(inputBuffer), numFrames,
+                          streamTime, callbackUserData);
 
     // Update telemetry (lock-free, RT-safe)
     if (driver->m_telemetry) {
@@ -258,10 +286,50 @@ int RtAudioDriver::rtAudioCallback(void* outputBuffer, void* inputBuffer, unsign
     return result;
 }
 
+#ifdef __linux__
+void RtAudioDriver::startRealtimePriorityWorker() {
+    stopRealtimePriorityWorker();
+    m_rtPriorityWorkerStop.store(false, std::memory_order_release);
+    m_rtPriorityWorker = std::thread([this]() {
+        for (int attempt = 0; attempt < 100 && !m_rtPriorityWorkerStop.load(std::memory_order_acquire); ++attempt) {
+            const uintptr_t audioThreadToken = m_audioThreadToken.load(std::memory_order_acquire);
+            if (audioThreadToken != 0) {
+                applyLinuxRealtimePriority(tokenToPthread(audioThreadToken));
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+}
+
+void RtAudioDriver::stopRealtimePriorityWorker() {
+    m_rtPriorityWorkerStop.store(true, std::memory_order_release);
+    if (m_rtPriorityWorker.joinable()) {
+        m_rtPriorityWorker.join();
+    }
+}
+
+void RtAudioDriver::applyLinuxRealtimePriority(pthread_t audioThreadId) {
+    struct sched_param param;
+    param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+    param.sched_priority = (param.sched_priority + sched_get_priority_min(SCHED_FIFO)) / 2;
+    const int rtResult = pthread_setschedparam(audioThreadId, SCHED_FIFO, &param);
+    if (m_telemetry) {
+        if (rtResult == 0) {
+            m_telemetry->setThreadPriorityBit(0x01);
+            m_telemetry->updateLinuxRtPriorityErrno(0);
+        } else {
+            m_telemetry->updateLinuxRtPriorityErrno(rtResult);
+        }
+    }
+}
+#endif
+
 bool RtAudioDriver::tryInitializeBackend(const std::vector<RtAudio::Api>& candidates) {
     for (RtAudio::Api api : candidates) {
         try {
-            auto candidate = (api == RtAudio::UNSPECIFIED) ? std::make_unique<RtAudio>() : std::make_unique<RtAudio>(api);
+            auto candidate =
+                (api == RtAudio::UNSPECIFIED) ? std::make_unique<RtAudio>() : std::make_unique<RtAudio>(api);
             candidate->setErrorCallback([](RtAudioErrorType type, const std::string& errorText) {
                 if (type != RTAUDIO_NO_ERROR && type != RTAUDIO_WARNING) {
                     std::cerr << "RtAudio Linux error: " << errorText << std::endl;
@@ -274,8 +342,7 @@ bool RtAudioDriver::tryInitializeBackend(const std::vector<RtAudio::Api>& candid
                 m_rtAudio = std::move(candidate);
                 return true;
             }
-        } catch (const std::exception&) {
-        }
+        } catch (const std::exception&) {}
     }
 
     return false;

--- a/AestraAudio/src/Linux/RtAudioDriver.cpp
+++ b/AestraAudio/src/Linux/RtAudioDriver.cpp
@@ -126,6 +126,9 @@ bool RtAudioDriver::openStream(const AudioStreamConfig& config, AudioCallback ca
         return false;
     }
 
+    const uint32_t actualSampleRate =
+        (m_rtAudio && m_rtAudio->isStreamOpen()) ? static_cast<uint32_t>(m_rtAudio->getStreamSampleRate()) : sampleRate;
+    m_sampleRate.store(actualSampleRate, std::memory_order_relaxed);
     m_bufferSize.store(bufferFrames, std::memory_order_relaxed);
     return true;
 }
@@ -144,6 +147,8 @@ void RtAudioDriver::closeStream() {
 
     m_userCallback.store(nullptr, std::memory_order_relaxed);
     m_userData.store(nullptr, std::memory_order_relaxed);
+    m_sampleRate.store(0, std::memory_order_relaxed);
+    m_bufferSize.store(0, std::memory_order_relaxed);
 }
 
 bool RtAudioDriver::startStream() {
@@ -157,6 +162,9 @@ bool RtAudioDriver::startStream() {
 
 #ifdef __linux__
     m_callbackRtPriorityAttempted.store(false, std::memory_order_release);
+    if (m_telemetry) {
+        m_telemetry->clearThreadPriorityStatus();
+    }
     // mlockall is process-wide and can be requested from the starter thread.
     if (mlockall(MCL_CURRENT | MCL_FUTURE) == 0) {
         if (m_telemetry) {
@@ -164,21 +172,6 @@ bool RtAudioDriver::startStream() {
         }
     } else if (m_telemetry) {
         m_telemetry->updateLinuxRtPriorityErrno(errno);
-    }
-    bool expected = false;
-    if (m_callbackRtPriorityAttempted.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        struct sched_param param;
-        param.sched_priority = sched_get_priority_max(SCHED_FIFO);
-        param.sched_priority = (param.sched_priority + sched_get_priority_min(SCHED_FIFO)) / 2;
-        const int rtResult = pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
-        if (m_telemetry) {
-            if (rtResult == 0) {
-                m_telemetry->setThreadPriorityBit(0x01);
-                m_telemetry->updateLinuxRtPriorityErrno(0);
-            } else {
-                m_telemetry->updateLinuxRtPriorityErrno(rtResult);
-            }
-        }
     }
 #endif
 
@@ -206,7 +199,7 @@ double RtAudioDriver::getStreamLatency() const {
 }
 
 uint32_t RtAudioDriver::getStreamSampleRate() const {
-    return (m_rtAudio && m_rtAudio->isStreamOpen()) ? m_rtAudio->getStreamSampleRate() : 0;
+    return (m_rtAudio && m_rtAudio->isStreamOpen()) ? m_sampleRate.load(std::memory_order_relaxed) : 0;
 }
 
 uint32_t RtAudioDriver::getStreamBufferSize() const {
@@ -216,6 +209,25 @@ uint32_t RtAudioDriver::getStreamBufferSize() const {
 int RtAudioDriver::rtAudioCallback(void* outputBuffer, void* inputBuffer, unsigned int numFrames, double streamTime,
                                    RtAudioStreamStatus status, void* userData) {
     auto* driver = static_cast<RtAudioDriver*>(userData);
+#ifdef __linux__
+    bool expected = false;
+    if (driver && driver->m_callbackRtPriorityAttempted.compare_exchange_strong(expected, true,
+                                                                                std::memory_order_acq_rel)) {
+        struct sched_param param;
+        param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+        param.sched_priority = (param.sched_priority + sched_get_priority_min(SCHED_FIFO)) / 2;
+        const int rtResult = pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
+        if (driver->m_telemetry) {
+            if (rtResult == 0) {
+                driver->m_telemetry->setThreadPriorityBit(0x01);
+                driver->m_telemetry->updateLinuxRtPriorityErrno(0);
+            } else {
+                driver->m_telemetry->updateLinuxRtPriorityErrno(rtResult);
+            }
+        }
+    }
+#endif
+
     if (status != 0) {
         driver->m_stats.underrunCount++;
         if (driver->m_telemetry) {
@@ -237,7 +249,7 @@ int RtAudioDriver::rtAudioCallback(void* outputBuffer, void* inputBuffer, unsign
     // Update telemetry (lock-free, RT-safe)
     if (driver->m_telemetry) {
         driver->m_telemetry->updateLastBufferFrames(numFrames);
-        uint32_t sr = driver->getStreamSampleRate();
+        uint32_t sr = driver->m_sampleRate.load(std::memory_order_relaxed);
         if (sr > 0) {
             driver->m_telemetry->updateLastSampleRate(sr);
         }

--- a/AestraAudio/src/Linux/RtAudioDriver.h
+++ b/AestraAudio/src/Linux/RtAudioDriver.h
@@ -5,8 +5,14 @@
 #include "RtAudio.h"
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <thread>
+
+#ifdef __linux__
+#include <pthread.h>
+#endif
 
 namespace Aestra {
 namespace Audio {
@@ -45,6 +51,11 @@ private:
     static AudioDriverType apiToDriverType(RtAudio::Api api);
     static const char* apiName(RtAudio::Api api);
     std::string getDeviceName(unsigned int deviceId) const;
+#ifdef __linux__
+    void startRealtimePriorityWorker();
+    void stopRealtimePriorityWorker();
+    void applyLinuxRealtimePriority(pthread_t audioThreadId);
+#endif
 
     std::unique_ptr<RtAudio> m_rtAudio;
     AudioDriverType m_driverType{AudioDriverType::UNKNOWN};
@@ -53,6 +64,11 @@ private:
     std::atomic<uint32_t> m_sampleRate{0};
     std::atomic<uint32_t> m_bufferSize{0};
     std::atomic<bool> m_callbackRtPriorityAttempted{false};
+#ifdef __linux__
+    std::atomic<uintptr_t> m_audioThreadToken{0};
+    std::atomic<bool> m_rtPriorityWorkerStop{false};
+    std::thread m_rtPriorityWorker;
+#endif
     DriverStatistics m_stats;
     std::string m_lastError;
     struct AudioTelemetry* m_telemetry = nullptr; // RT-thread telemetry (atomic, lock-free)

--- a/AestraAudio/src/Linux/RtAudioDriver.h
+++ b/AestraAudio/src/Linux/RtAudioDriver.h
@@ -50,6 +50,7 @@ private:
     AudioDriverType m_driverType{AudioDriverType::UNKNOWN};
     std::atomic<AudioCallback> m_userCallback{nullptr};
     std::atomic<void*> m_userData{nullptr};
+    std::atomic<uint32_t> m_sampleRate{0};
     std::atomic<uint32_t> m_bufferSize{0};
     std::atomic<bool> m_callbackRtPriorityAttempted{false};
     DriverStatistics m_stats;

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -536,6 +536,59 @@ void UnitManager::setUnitAudioClip(UnitID id, const std::string& path) {
     }
     publishSnapshot();
 }
+
+bool UnitManager::setUnitAudioClipFromDecoded(UnitID id, const std::string& path, std::vector<float> decodedData,
+                                              uint32_t sampleRate, uint32_t numChannels,
+                                              std::vector<float> previewWaveform, double durationSeconds) {
+    auto* u = getUnit(id);
+    if (!u) {
+        return false;
+    }
+
+    u->audioClipPath = path;
+    u->audioDurationSeconds = std::isfinite(durationSeconds) && durationSeconds > 0.0 ? durationSeconds : 0.0;
+    u->audioPreviewWaveform = std::move(previewWaveform);
+
+    if (path.empty()) {
+        publishSnapshot();
+        return true;
+    }
+
+    if (u->type == UnitType::Audio) {
+        u->group = UnitGroup::Audio;
+        publishSnapshot();
+        return true;
+    }
+
+    const std::string samplerId = BuiltInPlugins::samplerInfo().id;
+    if (!u->plugin || u->pluginId != samplerId) {
+        auto& pluginManager = PluginManager::getInstance();
+        auto samplerInstance = pluginManager.createInstanceById(samplerId);
+        if (samplerInstance) {
+            const double sr = m_sampleRate.load(std::memory_order_relaxed);
+            const uint32_t blockSize = m_blockSize.load(std::memory_order_relaxed);
+            if (samplerInstance->initialize(sr > 0 ? sr : 48000.0, blockSize > 0 ? blockSize : 512)) {
+                if ((u->enabled || u->isEnabled) && !samplerInstance->isActive()) {
+                    samplerInstance->activate();
+                }
+                u->pluginId = samplerId;
+                u->plugin = std::move(samplerInstance);
+                applySamplerDefaultsForUnitType(*u);
+            }
+        }
+    }
+
+    bool loaded = false;
+    if (auto sampler = std::dynamic_pointer_cast<Plugins::SamplerPlugin>(u->plugin)) {
+        loaded = sampler->loadSampleData(path, std::move(decodedData), sampleRate, numChannels);
+        if (loaded) {
+            u->pluginState = sampler->saveState();
+        }
+    }
+
+    publishSnapshot();
+    return loaded;
+}
 void UnitManager::setUnitColor(UnitID id, uint32_t color) { if (auto* u = getUnit(id)) u->color = color; }
 void UnitManager::setUnitGroup(UnitID id, UnitGroup group) { if (auto* u = getUnit(id)) u->group = std::move(group); }
 UnitType UnitManager::getUnitType(UnitID id) const {

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -154,6 +154,14 @@ bool SamplerPlugin::loadSample(const std::string& path) {
         return false;
     }
 
+    return loadSampleData(path, std::move(data), rate, channels);
+}
+
+bool SamplerPlugin::loadSampleData(const std::string& path, std::vector<float> data, uint32_t rate, uint32_t channels) {
+    if (data.empty() || rate == 0 || channels == 0) {
+        return false;
+    }
+
     // Decode output is interleaved. Keep stereo data in-place and only upmix
     // mono defensively for callers that bypass decodeAudioFile's forceStereo().
     const size_t numFrames = data.size() / std::max<uint32_t>(channels, 1);

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -361,6 +361,9 @@ void AestraApp::buildSettingsAndDialogs() {
     audioPage->setOnStreamRestore([this]() {
          m_audioController->closeStream();
          m_audioStreamReady = false;
+         // Stream is restarting: let the RT-scheduling state be re-reported
+         // for the new stream (the audio thread re-verifies on first callback).
+         m_rtStateLogged = false;
          m_audioConfigSynced = false;
          if (m_audioController->openDefaultStream(nullptr)) {
              m_audioController->startStream();

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -132,4 +132,5 @@ private:
     // Startup optimization flags
     bool m_audioStreamReady = false;
     bool m_audioConfigSynced = false;
+    bool m_rtStateLogged = false;
 };

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -172,6 +172,10 @@ void AestraAudioController::shutdown() {
 
 void AestraAudioController::setContent(std::shared_ptr<AestraContent> content) {
     m_content = content;
+    Aestra::Audio::TrackManager* trackManager = content ? content->getTrackManager().get() : nullptr;
+    Aestra::Audio::PreviewEngine* previewEngine = content ? content->getPreviewEngine() : nullptr;
+    m_rtTrackManager.store(trackManager, std::memory_order_release);
+    m_rtPreviewEngine.store(previewEngine, std::memory_order_release);
     m_rtContent.store(std::move(content), std::memory_order_release);
 }
 
@@ -282,6 +286,8 @@ bool AestraAudioController::startStream() {
     if (!m_initialized || !m_audioManager) return false;
     if (m_isAudioRunning) return true;
     if (auto content = m_content.lock()) {
+        m_rtTrackManager.store(content->getTrackManager().get(), std::memory_order_release);
+        m_rtPreviewEngine.store(content->getPreviewEngine(), std::memory_order_release);
         m_rtContent.store(std::move(content), std::memory_order_release);
     }
 
@@ -309,13 +315,10 @@ bool AestraAudioController::startStream() {
         m_audioEngine->setInputCallback([](const float* input, uint32_t n, void* user) {
             auto* controller = static_cast<AestraAudioController*>(user);
             if (controller) {
-                // Load once and reuse to avoid repeated atomic operations
-                auto content = controller->m_rtContent.load(std::memory_order_acquire);
-                if (content) {
-                    if (auto trackManager = content->getTrackManager()) {
-                        trackManager->updateInputDiagnostics(input, n);
-                        trackManager->processInput(input, n, &controller->m_audioEngine->telemetry());
-                    }
+                auto* trackManager = controller->m_rtTrackManager.load(std::memory_order_acquire);
+                if (trackManager) {
+                    trackManager->updateInputDiagnostics(input, n);
+                    trackManager->processInput(input, n, &controller->m_audioEngine->telemetry());
                 }
             }
         }, this);
@@ -363,11 +366,16 @@ bool AestraAudioController::startStream() {
 void AestraAudioController::stopStream() {
     if (m_audioManager) m_audioManager->stopStream();
     m_isAudioRunning = false;
+    m_rtTrackManager.store(nullptr, std::memory_order_release);
+    m_rtPreviewEngine.store(nullptr, std::memory_order_release);
     m_rtContent.store(nullptr, std::memory_order_release);
 }
 
 void AestraAudioController::closeStream() {
     if (m_audioManager) m_audioManager->closeStream();
+    m_rtTrackManager.store(nullptr, std::memory_order_release);
+    m_rtPreviewEngine.store(nullptr, std::memory_order_release);
+    m_rtContent.store(nullptr, std::memory_order_release);
 }
 
 bool AestraAudioController::setBufferSize(uint32_t bufferSize) {
@@ -418,20 +426,14 @@ int AestraAudioController::audioCallback(float* outputBuffer, const float* input
         std::fill(outputBuffer, outputBuffer + static_cast<size_t>(nFrames) * outCh, 0.0f);
     }
 
-    // Load content snapshot once and reuse for the entire callback to avoid repeated atomic operations
-    auto content = controller->m_rtContent.load(std::memory_order_acquire);
-
-    if (inputBuffer && content) {
-        if (auto trackManager = content->getTrackManager()) {
-            trackManager->mixInputMonitoring(inputBuffer, outputBuffer, nFrames, controller->m_streamConfig.numOutputChannels);
-        }
+    auto* trackManager = controller->m_rtTrackManager.load(std::memory_order_acquire);
+    if (inputBuffer && trackManager) {
+        trackManager->mixInputMonitoring(inputBuffer, outputBuffer, nFrames, controller->m_streamConfig.numOutputChannels);
     }
 
-    // Preview mixing - reuse the same content snapshot
-    if (content) {
-        if (auto* previewEngine = content->getPreviewEngine()) {
-            previewEngine->processRealtime(outputBuffer, nFrames, controller->m_streamConfig.numOutputChannels);
-        }
+    auto* previewEngine = controller->m_rtPreviewEngine.load(std::memory_order_acquire);
+    if (previewEngine) {
+        previewEngine->processRealtime(outputBuffer, nFrames, controller->m_streamConfig.numOutputChannels);
     }
 
     if (controller->m_audioEngine) {

--- a/Source/Core/AestraAudioController.h
+++ b/Source/Core/AestraAudioController.h
@@ -63,4 +63,6 @@ private:
     // Weak UI reference plus atomically published ownership for callback routing.
     std::weak_ptr<AestraContent> m_content;
     Aestra::AtomicSharedPtr<AestraContent> m_rtContent;
+    std::atomic<Aestra::Audio::TrackManager*> m_rtTrackManager{nullptr};
+    std::atomic<Aestra::Audio::PreviewEngine*> m_rtPreviewEngine{nullptr};
 };

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3172,7 +3172,11 @@ void AestraContent::loadSampleIntoUnitAsync(UnitID unitId, const std::string& sa
         return;
     }
 
-    const uint64_t generation = m_sampleUnitLoadGeneration.fetch_add(1, std::memory_order_acq_rel) + 1;
+    uint64_t generation = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_sampleUnitLoadGenerationsMutex);
+        generation = ++m_sampleUnitLoadGenerations[unitId];
+    }
     auto weakSelf = weak_from_this();
 
     if (m_trackManager->getUnitManager().getUnit(unitId)) {
@@ -3229,8 +3233,12 @@ void AestraContent::loadSampleIntoUnitAsync(UnitID unitId, const std::string& sa
             if (!self || !self->m_trackManager) {
                 return;
             }
-            if (self->m_sampleUnitLoadGeneration.load(std::memory_order_acquire) != generation) {
-                return;
+            {
+                std::lock_guard<std::mutex> lock(self->m_sampleUnitLoadGenerationsMutex);
+                const auto generationIt = self->m_sampleUnitLoadGenerations.find(unitId);
+                if (generationIt == self->m_sampleUnitLoadGenerations.end() || generationIt->second != generation) {
+                    return;
+                }
             }
 
             auto& unitManager = self->m_trackManager->getUnitManager();

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -38,8 +38,8 @@
 #include "TransportBar.h"
 
 // Audio includes
-#include "../AestraCore/include/AestraLog.h"
 #include "../AestraAudio/include/Commands/CommandRegistry.h"
+#include "../AestraCore/include/AestraLog.h"
 #include "AudioEngine.h"
 #include "ChannelSlotMap.h"
 #include "ClipSource.h"
@@ -54,6 +54,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <thread>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -891,16 +892,7 @@ AestraContent::AestraContent() {
 
             // 2. Perform Load
             AESTRA_LOG_DEBUG("Loading sample into Unit " + std::to_string(id) + ": " + file.path);
-            if (m_trackManager) {
-                auto& unitManager = m_trackManager->getUnitManager();
-                unitManager.setUnitEnabled(id, true);
-                unitManager.setUnitAudioClip(id, file.path);
-                if (m_sequencerPanel) {
-                    m_sequencerPanel->setSelectedUnit(id);
-                    m_sequencerPanel->refreshUnits();
-                }
-                openSampleEditorForUnit(id, file.path);
-            }
+            loadSampleIntoUnitAsync(id, file.path, true);
         });
     });
     m_sequencerPanel->setOnRequestSampleEditor([this](UnitID id) {
@@ -913,7 +905,7 @@ AestraContent::AestraContent() {
     m_sequencerPanel->setOnPluginDroppedToUnit(
         [this](UnitID unitId, const std::string& pluginId) { loadInstrumentIntoArsenalUnit(unitId, pluginId); });
     m_sequencerPanel->setOnSampleDroppedToUnit(
-        [this](UnitID unitId, const std::string& samplePath) { openSampleEditorForUnit(unitId, samplePath); });
+        [this](UnitID unitId, const std::string& samplePath) { loadSampleIntoUnitAsync(unitId, samplePath, true); });
     m_sequencerPanel->setOnSelectedUnitChanged([this](UnitID unitId) {
         if (m_pianoRollPanel) {
             m_pianoRollPanel->setEditingUnit(unitId);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -50,6 +50,7 @@
 #include "PreviewEngine.h"
 #include "TrackManager.h"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -69,6 +70,69 @@ constexpr float kMinFileBrowserWidth = 300.0f;
 constexpr float kMinPatternBrowserWidth = 96.0f;
 constexpr float kMinTrackAreaWidth = 420.0f;
 constexpr float kResizeHitWidth = 6.0f;
+
+std::vector<float> buildPreviewWaveform(const std::vector<float>& samples, uint32_t channels, size_t targetSize = 128) {
+    std::vector<float> waveform(targetSize, 0.0f);
+    if (samples.empty() || channels == 0 || targetSize == 0) {
+        return waveform;
+    }
+
+    const size_t totalFrames = samples.size() / channels;
+    if (totalFrames == 0) {
+        return waveform;
+    }
+
+    const double framesPerBin = static_cast<double>(totalFrames) / static_cast<double>(targetSize);
+    for (size_t bin = 0; bin < targetSize; ++bin) {
+        const size_t startFrame = static_cast<size_t>(static_cast<double>(bin) * framesPerBin);
+        const size_t endFrame =
+            std::min(totalFrames, static_cast<size_t>(static_cast<double>(bin + 1) * framesPerBin) + 1);
+
+        float peak = 0.0f;
+        for (size_t frame = startFrame; frame < endFrame; ++frame) {
+            float sum = 0.0f;
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                sum += std::abs(samples[frame * channels + ch]);
+            }
+            peak = std::max(peak, sum / static_cast<float>(channels));
+        }
+        waveform[bin] = std::min(1.0f, peak);
+    }
+
+    return waveform;
+}
+
+std::vector<float> buildEditorWaveform(const std::vector<float>& samples, uint32_t channels, uint32_t sampleLength,
+                                       size_t buckets = 1024) {
+    std::vector<float> waveform;
+    if (samples.empty() || channels == 0 || sampleLength == 0 || buckets == 0) {
+        return waveform;
+    }
+
+    const size_t framesPerBucket = std::max<size_t>(1, static_cast<size_t>(sampleLength) / buckets);
+    waveform.reserve(buckets * 2);
+    for (size_t bucket = 0; bucket < buckets; ++bucket) {
+        const size_t startFrame = bucket * framesPerBucket;
+        const size_t endFrame = std::min<size_t>(static_cast<size_t>(sampleLength), startFrame + framesPerBucket);
+        if (startFrame >= endFrame) {
+            waveform.push_back(0.0f);
+            waveform.push_back(0.0f);
+            continue;
+        }
+
+        float minV = 1.0f;
+        float maxV = -1.0f;
+        for (size_t frame = startFrame; frame < endFrame; ++frame) {
+            const size_t idx = frame * channels;
+            const float mono = (channels > 1) ? 0.5f * (samples[idx] + samples[idx + 1]) : samples[idx];
+            minV = std::min(minV, mono);
+            maxV = std::max(maxV, mono);
+        }
+        waveform.push_back(maxV);
+        waveform.push_back(minV);
+    }
+    return waveform;
+}
 } // namespace
 
 // =============================================================================
@@ -1106,6 +1170,7 @@ AestraContent::AestraContent() {
 // =============================================================================
 
 void AestraContent::onUpdate(double dt) {
+    drainMainThreadTasks();
     updatePendingCountIn();
 
     // Sync track changes to MixerViewModel
@@ -3078,6 +3143,123 @@ void AestraContent::stopSoundPreview() {
         m_fileBrowser->setActivePlaybackPath("");
     }
     AESTRA_LOG_TRACE("Sound preview stopped");
+}
+
+void AestraContent::enqueueMainThreadTask(std::function<void()> task) {
+    if (!task) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(m_mainThreadTasksMutex);
+    m_mainThreadTasks.push_back(std::move(task));
+}
+
+void AestraContent::drainMainThreadTasks() {
+    std::vector<std::function<void()>> tasks;
+    {
+        std::lock_guard<std::mutex> lock(m_mainThreadTasksMutex);
+        tasks.swap(m_mainThreadTasks);
+    }
+
+    for (auto& task : tasks) {
+        if (task) {
+            task();
+        }
+    }
+}
+
+void AestraContent::loadSampleIntoUnitAsync(UnitID unitId, const std::string& samplePath, bool openEditorWhenReady) {
+    if (!m_trackManager || unitId == 0 || samplePath.empty()) {
+        return;
+    }
+
+    const uint64_t generation = m_sampleUnitLoadGeneration.fetch_add(1, std::memory_order_acq_rel) + 1;
+    auto weakSelf = weak_from_this();
+
+    if (m_trackManager->getUnitManager().getUnit(unitId)) {
+        std::string filename = std::filesystem::path(samplePath).stem().string();
+        if (!filename.empty()) {
+            m_trackManager->getUnitManager().setUnitName(unitId, filename);
+        }
+        m_trackManager->getUnitManager().setUnitEnabled(unitId, true);
+    }
+    if (m_sequencerPanel) {
+        m_sequencerPanel->setSelectedUnit(unitId);
+        m_sequencerPanel->refreshUnits();
+    }
+
+    std::thread([weakSelf, generation, unitId, samplePath, openEditorWhenReady]() {
+        std::vector<float> decodedData;
+        uint32_t sampleRate = 0;
+        uint32_t numChannels = 0;
+        const bool decoded = decodeAudioFile(samplePath, decodedData, sampleRate, numChannels);
+        const uint32_t sampleLength =
+            (decoded && numChannels > 0) ? static_cast<uint32_t>(decodedData.size() / numChannels) : 0;
+        std::vector<float> editorWaveform =
+            decoded ? buildEditorWaveform(decodedData, numChannels, sampleLength) : std::vector<float>();
+
+        std::vector<float> previewAudio;
+        uint32_t previewRate = 0;
+        uint32_t previewChannels = 0;
+        constexpr uint64_t kPreviewMaxFrames = 48000 * 24;
+        constexpr double kPreviewMaxSeconds = static_cast<double>(kPreviewMaxFrames) / 48000.0;
+        std::vector<float> previewWaveform;
+        double durationSeconds = 0.0;
+
+        if (decodeAudioPreview(samplePath, previewAudio, previewRate, previewChannels, kPreviewMaxSeconds)) {
+            previewWaveform = buildPreviewWaveform(previewAudio, previewChannels);
+            if (previewRate > 0 && previewChannels > 0) {
+                durationSeconds =
+                    static_cast<double>(previewAudio.size()) / static_cast<double>(previewRate * previewChannels);
+            }
+        }
+        if (durationSeconds <= 0.0 && sampleRate > 0 && numChannels > 0) {
+            durationSeconds = static_cast<double>(decodedData.size()) / static_cast<double>(sampleRate * numChannels);
+        }
+
+        auto self = std::dynamic_pointer_cast<AestraContent>(weakSelf.lock());
+        if (!self) {
+            return;
+        }
+
+        self->enqueueMainThreadTask([weakSelf, generation, unitId, samplePath, openEditorWhenReady, decoded,
+                                     decodedData = std::move(decodedData), sampleRate, numChannels,
+                                     sampleLength, editorWaveform = std::move(editorWaveform),
+                                     previewWaveform = std::move(previewWaveform), durationSeconds]() mutable {
+            auto self = std::dynamic_pointer_cast<AestraContent>(weakSelf.lock());
+            if (!self || !self->m_trackManager) {
+                return;
+            }
+            if (self->m_sampleUnitLoadGeneration.load(std::memory_order_acquire) != generation) {
+                return;
+            }
+
+            auto& unitManager = self->m_trackManager->getUnitManager();
+            if (!decoded ||
+                !unitManager.setUnitAudioClipFromDecoded(unitId, samplePath, std::move(decodedData), sampleRate,
+                                                         numChannels, std::move(previewWaveform), durationSeconds)) {
+                AESTRA_LOG_ERROR("Failed to load sample into Unit " + std::to_string(unitId) + ": " + samplePath);
+                return;
+            }
+
+            if (self->m_sequencerPanel) {
+                self->m_sequencerPanel->setSelectedUnit(unitId);
+                self->m_sequencerPanel->refreshUnits();
+            }
+            if (openEditorWhenReady) {
+                self->m_sampleEditorUnitId = unitId;
+                self->syncSampleEditorToUnit(unitId);
+                if (self->m_sampleEditorPanel) {
+                    self->m_sampleEditorPanel->loadPreparedSample(samplePath, static_cast<double>(sampleRate),
+                                                                  sampleLength, std::move(editorWaveform));
+                    self->m_sampleEditorPanel->setVisible(true);
+                    self->m_sampleEditorPanel->bringToFront();
+                    self->m_sampleEditorPanel->setDirty(true);
+                }
+                self->onResize(static_cast<int>(self->getBounds().width), static_cast<int>(self->getBounds().height));
+            }
+            AESTRA_LOG_DEBUG("Sample loaded into Unit " + std::to_string(unitId) + " asynchronously: " + samplePath);
+        });
+    }).detach();
 }
 
 void AestraContent::loadSampleIntoSelectedTrack(const std::string& filePath) {

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Forward declarations - AestraUI
@@ -154,7 +155,7 @@ public:
     void toggleFileBrowser();
     /** @brief Synchronize overlay state into owned child views. */
     void syncViewState();
-    
+
     /** @brief Get the active browser column width. */
     float getBrowserWidth() const;
     /** @brief Set the active browser column width. */
@@ -171,7 +172,7 @@ public:
     void setViewFocus(ViewFocus focus);
     /** @brief Get the active workspace mode. */
     ViewFocus getViewFocus() const { return m_viewFocus; }
-    
+
     /** @brief Explicitly show or hide the Arsenal panel. */
     void setArsenalPanelVisible(bool visible);
     /** @brief Toggle the Arsenal panel regardless of active mode. */
@@ -269,7 +270,7 @@ public:
     bool hasRealtimePlaybackVisuals() const;
     /** @brief Update the preview playhead visible in the UI. */
     void updatePreviewPlayhead();
-    
+
     /** @brief Load an effect plugin onto the selected track. */
     void loadEffectToSelectedTrack(const std::string& pluginId);
     /** @brief Load an instrument plugin into Arsenal. */
@@ -336,17 +337,17 @@ private:
     std::shared_ptr<Aestra::Audio::TrackManagerUI> m_trackManagerUI;
     AestraUI::NUIPlatformBridge* m_platformBridge = nullptr;
     Aestra::Audio::AudioEngine* m_audioEngine = nullptr;
-    
+
     std::shared_ptr<Aestra::Audio::MixerPanel> m_mixerPanel;
     std::shared_ptr<Aestra::Audio::PianoRollPanel> m_pianoRollPanel;
     std::shared_ptr<Aestra::Audio::ArsenalPanel> m_sequencerPanel;
     std::shared_ptr<Aestra::Audio::AestraHistoryPanel> m_historyPanel;
     std::shared_ptr<AestraUI::PluginUIController> m_pluginController;
     std::shared_ptr<AestraUI::UIRoutingMap> m_routingMapPanel;
-    
+
     // Temp files for Audition (v4.0)
     std::vector<std::string> m_tempFiles;
-    
+
     // Audition Mode
     std::shared_ptr<Aestra::Audio::AuditionEngine> m_auditionEngine;
     std::shared_ptr<Aestra::AuditionPanel> m_auditionPanel;
@@ -354,20 +355,20 @@ private:
     std::unique_ptr<Aestra::Audio::PreviewEngine> m_previewEngine;
     bool m_spaceShortcutLatched{false};
     bool m_audioActive = false;
-    
+
     // View state
     ViewState m_viewState;
     ViewFocus m_viewFocus = ViewFocus::Timeline;
     ViewFocus m_previousViewFocus = ViewFocus::Timeline;
     uint32_t m_lastSelectedChannelId = 0xFFFFFFFFu;
-    
+
     // Sound preview state
     bool m_previewIsPlaying = false;
     std::chrono::steady_clock::time_point m_previewStartTime{};
     double m_previewDuration = 300.0;
     std::string m_currentPreviewFile;
     std::vector<float> m_transportWaveformScratch;
-    
+
     // Playback state persistence
     double m_savedTimelinePosition = 0.0;
     bool m_patternClipPreviewActive{false};
@@ -397,7 +398,8 @@ private:
 
     std::mutex m_mainThreadTasksMutex;
     std::vector<std::function<void()>> m_mainThreadTasks;
-    std::atomic<uint64_t> m_sampleUnitLoadGeneration{0};
+    std::mutex m_sampleUnitLoadGenerationsMutex;
+    std::unordered_map<Aestra::Audio::UnitID, uint64_t> m_sampleUnitLoadGenerations;
 
     Aestra::Audio::CommandParser m_commandParser;
     std::unique_ptr<Aestra::Audio::SessionLog> m_sessionLog;

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -12,23 +12,28 @@
 
 #pragma once
 
-#include "../AestraUI/Core/NUIComponent.h"
-#include "../AestraUI/Core/NUIThemeSystem.h"
-#include "NUISegmentedControl.h"
-#include "NUILabel.h"
-#include "../AestraUI/Widgets/UIRoutingMap.h"
-#include "ViewTypes.h"
-#include "TransportBar.h"
-#include "PatternSource.h"
-#include "OverlayLayer.h"
-#include "../AestraAudio/include/Models/UnitManager.h"
 #include "../AestraAudio/include/Commands/CommandParser.h"
 #include "../AestraAudio/include/Commands/CommandResult.h"
 #include "../AestraAudio/include/Commands/SessionLog.h"
+#include "../AestraAudio/include/Models/UnitManager.h"
+#include "../AestraUI/Core/NUIComponent.h"
+#include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../AestraUI/Widgets/UIRoutingMap.h"
 #include "Events/Connection.h"
-#include <memory>
-#include <string>
+#include "NUILabel.h"
+#include "NUISegmentedControl.h"
+#include "OverlayLayer.h"
+#include "PatternSource.h"
+#include "TransportBar.h"
+#include "ViewTypes.h"
+
+#include <atomic>
 #include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 // Forward declarations - AestraUI
 namespace AestraUI {
@@ -251,6 +256,8 @@ public:
     void stopSoundPreview();
     /** @brief Load a sample into the currently selected track. */
     void loadSampleIntoSelectedTrack(const std::string& filePath);
+    /** @brief Decode and publish a sample to an Arsenal unit off the UI/drop path. */
+    void loadSampleIntoUnitAsync(Aestra::Audio::UnitID unitId, const std::string& samplePath, bool openEditorWhenReady);
     /** @brief Advance preview-state bookkeeping. */
     void updateSoundPreview();
     /** @brief Seek inside the active file preview. */
@@ -385,6 +392,12 @@ private:
 
     void openSampleEditorForUnit(Aestra::Audio::UnitID unitId, const std::string& samplePath);
     void syncSampleEditorToUnit(Aestra::Audio::UnitID unitId);
+    void enqueueMainThreadTask(std::function<void()> task);
+    void drainMainThreadTasks();
+
+    std::mutex m_mainThreadTasksMutex;
+    std::vector<std::function<void()>> m_mainThreadTasks;
+    std::atomic<uint64_t> m_sampleUnitLoadGeneration{0};
 
     Aestra::Audio::CommandParser m_commandParser;
     std::unique_ptr<Aestra::Audio::SessionLog> m_sessionLog;

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -997,7 +997,6 @@ AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const 
 
         unitMgr.setUnitName(targetUnit, filename);
         unitMgr.setUnitEnabled(targetUnit, true);
-        unitMgr.setUnitAudioClip(targetUnit, data.filePath);
         if (m_onSampleDroppedToUnit) {
             m_onSampleDroppedToUnit(targetUnit, data.filePath);
         }

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -786,6 +786,30 @@ void SampleEditorPanel::loadSample(const std::string& path) {
     m_adsrDisplay->repaint();
 }
 
+void SampleEditorPanel::loadPreparedSample(const std::string& path, double sampleRate, uint32_t sampleLength,
+                                           std::vector<float> waveformData) {
+    if (!m_trackManager) {
+        return;
+    }
+
+    Log::info("[SampleEditor] Loading prepared sample: " + path);
+    m_sampleRate = sampleRate > 0.0 ? sampleRate : 44100.0;
+    m_sampleLength = sampleLength;
+    m_waveformData = std::move(waveformData);
+    if (m_waveformData.empty()) {
+        m_waveformData.resize(1000 * 2);
+        for (size_t i = 0; i < 1000; ++i) {
+            float t = static_cast<float>(i) / 1000.0f;
+            m_waveformData[i * 2] = std::sin(t * 20.0f) * 0.5f;
+            m_waveformData[i * 2 + 1] = -std::sin(t * 20.0f) * 0.5f;
+        }
+    }
+
+    m_waveformDisplay->setWaveformData(m_waveformData);
+    m_waveformDisplay->repaint();
+    m_adsrDisplay->repaint();
+}
+
 void SampleEditorPanel::setADSR(const ADSRParams& params) {
     m_adsr = params;
     m_adsrDisplay->setADSR(params.attack, params.decay, params.sustain, params.release);

--- a/Source/Panels/SampleEditorPanel.h
+++ b/Source/Panels/SampleEditorPanel.h
@@ -40,6 +40,8 @@ public:
 
     // Load a sample for editing
     void loadSample(const std::string& path);
+    void loadPreparedSample(const std::string& path, double sampleRate, uint32_t sampleLength,
+                            std::vector<float> waveformData);
 
     // ADSR parameters (0-1 normalized)
     struct ADSRParams {

--- a/Tests/AestraAudio/RealtimePathStressTest.cpp
+++ b/Tests/AestraAudio/RealtimePathStressTest.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <system_error>
 #include <thread>
 #include <vector>
@@ -65,12 +66,31 @@ bool writeTestWav(const std::string& path, uint32_t sampleRate, uint32_t frames)
     return true;
 }
 
+size_t currentRssKb() {
+#if defined(__linux__)
+    std::ifstream status("/proc/self/status");
+    std::string key;
+    while (status >> key) {
+        if (key == "VmRSS:") {
+            size_t valueKb = 0;
+            status >> valueKb;
+            return valueKb;
+        }
+        std::string restOfLine;
+        std::getline(status, restOfLine);
+    }
+#endif
+    return 0;
+}
+
 } // namespace
 
-int main() {
+int main(int argc, char** argv) {
     constexpr uint32_t kSampleRate = 48000;
     constexpr uint32_t kFrames = 64;
     constexpr uint32_t kChannels = 2;
+    const bool lowMemoryProfile = argc > 1 && std::string(argv[1]) == "--low-memory-profile";
+    const int blockCount = lowMemoryProfile ? 512 : 256;
 
     // Use a guaranteed-writable temp directory instead of hardcoded /tmp/
     std::error_code ec;
@@ -143,8 +163,10 @@ int main() {
 
     const auto deadline = std::chrono::nanoseconds((static_cast<uint64_t>(kFrames) * 1000000000ull) / kSampleRate);
     uint64_t localOverruns = 0;
+    uint64_t lastCallbackNs = 0;
+    uint64_t maxCallbackNs = 0;
 
-    for (int block = 0; block < 256; ++block) {
+    for (int block = 0; block < blockCount; ++block) {
         if ((block % 7) == 0) {
             engine.setTransportPlaying(false);
             engine.setTransportPlaying(true);
@@ -159,6 +181,8 @@ int main() {
         preview.processRealtime(engineOut.data(), kFrames, kChannels);
         sampler.process(nullptr, samplerOutputs, 0, 2, kFrames, block == 0 ? &midi : nullptr, nullptr);
         const auto elapsed = std::chrono::steady_clock::now() - start;
+        lastCallbackNs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count());
+        maxCallbackNs = std::max(maxCallbackNs, lastCallbackNs);
 
         if (elapsed > deadline) {
             ++localOverruns;
@@ -166,6 +190,17 @@ int main() {
     }
 
     const auto& tel = engine.telemetry();
+    const size_t rssKb = currentRssKb();
+    std::cout << "profile=" << (lowMemoryProfile ? "low-memory" : "standard") << "\n";
+    std::cout << "blocks=" << blockCount << "\n";
+    std::cout << "lastCallbackNs=" << lastCallbackNs << "\n";
+    std::cout << "maxCallbackNs=" << maxCallbackNs << "\n";
+    std::cout << "xruns=" << tel.getXruns() << "\n";
+    std::cout << "underruns=" << tel.getUnderruns() << "\n";
+    if (rssKb > 0) {
+        std::cout << "rssKb=" << rssKb << "\n";
+        std::cout << "rssMiB=" << (static_cast<double>(rssKb) / 1024.0) << "\n";
+    }
     std::cout << "localOverruns=" << localOverruns << "\n";
     std::cout << "engineOverruns=" << tel.getOverruns() << "\n";
     std::cout << "rtLockViolations=" << tel.getRtLockViolations() << "\n";


### PR DESCRIPTION
## Summary
- Move sample drag/drop loading onto prepared async/main-thread handoff paths to avoid blocking realtime preview/audio callbacks.
- Cache audio graph routing topology off the realtime thread and reuse it in renderGraph().
- Lazily prepare active track render buffers/state so low-memory sessions do not allocate all 4096 track slots.
- Extend the realtime stress harness with low-memory callback/RSS telemetry.

## Validation
- cmake --build build-linux -j2 --target AestraAudioCore AestraRealtimePathStressTest RealtimeSchedulingTest Aestra
- ./build-linux/Tests/AestraRealtimePathStressTest --low-memory-profile
- ./build-linux/Tests/AestraRealtimePathStressTest
- ctest --test-dir build-linux -j2 -R "RealtimeSchedulingTest|RoutingSendPanParityTest|LatencyCompensationTest|AestraAudioEngineOutputChannelTest|AestraAudioEngineDiagnosticsTest|SamplerStereoParityTest|AestraPlaybackPathSignalIntegrityTest|SamplePoolTest|ArsenalBridgeContractTest|ArsenalProcessingContextRoutingTest|ArsenalRouteModeCompatibilityTest" --output-on-failure
- git diff --check

## Notes
- Low-memory profile reported rssMiB=25.3281 with zero xruns, underruns, local overruns, engine overruns, RT lock violations, and RT log violations.
- Standard stress reported rssMiB=25.1875 with zero xrun/overrun/RT violation counters.
- Live device drag/drop listening soak is still recommended before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Breaking change: sample loading now goes through prepared async/main-thread handoff paths instead of the old synchronous drop/load flow, and sample editor setup now expects pre-decoded waveform data.
- Reduced realtime work by caching audio graph routing/topology ahead of `renderGraph()`, so the audio thread no longer rebuilds routing state every block.
- Improved low-memory behavior by lazily preparing track render buffers/state only for tracks present in the active graph, instead of allocating all track slots up front.
- Split sample handling into decode/prepare vs. store/use paths: `UnitManager`, `SamplerPlugin`, and `SampleEditorPanel` now accept decoded sample data and waveform previews directly.
- Reworked Linux realtime startup so priority handling is deferred to a worker thread, and stream sample rate is cached instead of queried repeatedly.
- Tightened audio callback/runtime plumbing by caching track manager and preview engine pointers atomically, plus adding a main-thread task queue and render-loop idle-frame elision in the app.
- Extended realtime stress tests with low-memory mode support, callback timing telemetry, and RSS reporting to validate the memory/realtime improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->