### PR TITLE
Align preview and audition gain parity

### DIFF
--- a/AestraAudio/include/DSP/PanLaw.h
+++ b/AestraAudio/include/DSP/PanLaw.h
@@ -1,0 +1,30 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+namespace PanLaw {
+
+constexpr float kHalfPi = 1.57079632679489661923f;
+constexpr float kEqualPowerCenterGain = 0.7071067811865475f;
+
+inline void equalPower(float pan, float gain, float& leftGain, float& rightGain) noexcept {
+    const float clampedPan = std::clamp(pan, -1.0f, 1.0f);
+    const float p = (clampedPan + 1.0f) * 0.5f;
+    leftGain = std::cos(p * kHalfPi) * gain;
+    rightGain = std::sin(p * kHalfPi) * gain;
+}
+
+inline void equalPower(double pan, double gain, double& leftGain, double& rightGain) noexcept {
+    const double clampedPan = std::clamp(pan, -1.0, 1.0);
+    const double p = (clampedPan + 1.0) * 0.5;
+    leftGain = std::cos(p * static_cast<double>(kHalfPi)) * gain;
+    rightGain = std::sin(p * static_cast<double>(kHalfPi)) * gain;
+}
+
+} // namespace PanLaw
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -7,6 +7,7 @@
 #include "../Core/ChannelSlotMap.h"
 #include "../Core/MixerChannel.h"
 #include "../DSP/ContinuousParamBuffer.h"
+#include "../DSP/PanLaw.h"
 #include "../Playback/PatternPlaybackEngine.h"
 #include "../Playback/TimelineClock.h"
 #include "../RealtimeThreadGuard.h"
@@ -597,7 +598,7 @@ public:
             return;
         }
 
-        const float monitorMixScale = 0.85f / static_cast<float>(monitoredCount);
+        const float monitorMixScale = PanLaw::kEqualPowerCenterGain / static_cast<float>(monitoredCount);
         for (uint32_t frame = 0; frame < frames; ++frame) {
             const size_t inputBaseIndex = static_cast<size_t>(frame) * static_cast<size_t>(m_inputChannelCount);
             float monitoredSample = 0.0f;

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -4,6 +4,7 @@
 #include "../../AestraCore/include/AestraMath.h"
 #include "ArsenalProcessingContext.h"
 #include "AudioEngine.h"
+#include "DSP/PanLaw.h"
 #include "EffectChain.h"
 #include "Interpolators.h"
 #include "PatternPlaybackEngine.h"
@@ -61,9 +62,7 @@ inline double clampD(double v, double lo, double hi) {
 }
 
 inline void fastPanGainsD(double pan, double vol, double& gainL, double& gainR) {
-    float p = (static_cast<float>(pan) + 1.0f) * 0.5f;
-    gainL = static_cast<double>(std::cos(p * 1.57079632679f)) * vol;
-    gainR = static_cast<double>(std::sin(p * 1.57079632679f)) * vol;
+    PanLaw::equalPower(pan, vol, gainL, gainR);
 }
 } // namespace
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -4,6 +4,7 @@
 #include "../../AestraCore/include/AestraLog.h"
 #include "../../AestraCore/include/AestraMath.h"
 #include "AuditionEngine.h"
+#include "DSP/PanLaw.h"
 #include "EffectChain.h" // [NEW]
 #include "GarbageCollector.h"
 #include "IO/AudioExporter.h"
@@ -103,11 +104,8 @@ inline double dbToLinearD(double db) {
     return std::pow(10.0, db / 20.0);
 }
 
-// Fast constant-power pan gains (replaces std::sin/cos)
 inline void fastPanGainsD(double pan, double vol, double& gainL, double& gainR) {
-    float p = (static_cast<float>(pan) + 1.0f) * 0.5f; // 0.0 to 1.0
-    gainL = static_cast<double>(std::cos(p * 1.57079632679f)) * vol;
-    gainR = static_cast<double>(std::sin(p * 1.57079632679f)) * vol;
+    PanLaw::equalPower(pan, vol, gainL, gainR);
 }
 
 inline void addMidiPanic(Aestra::Audio::MidiBuffer& buf) {

--- a/AestraAudio/src/Core/MixerBus.cpp
+++ b/AestraAudio/src/Core/MixerBus.cpp
@@ -1,7 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "MixerBus.h"
 
-#include "FastMath.h"
+#include "DSP/PanLaw.h"
 
 #include <algorithm>
 #include <cmath>
@@ -9,10 +9,6 @@
 
 namespace Aestra {
 namespace Audio {
-
-// Constants
-static constexpr float PI = 3.14159265358979323846f;
-static constexpr float SQRT2_OVER_2 = 0.70710678118654752440f; // sqrt(2)/2
 
 MixerBus::MixerBus(const char* name, uint32_t numChannels)
     : m_name(name), m_numChannels(numChannels), m_gain(1.0f), m_pan(0.0f), m_muted(false), m_soloed(false),
@@ -234,8 +230,7 @@ void MixerBus::setSolo(bool solo) {
 }
 
 void MixerBus::calculatePanGains(float pan, float& leftGain, float& rightGain) const {
-    // Fast constant power panning using polynomial approximation (~5x faster)
-    FastMath::fastPan(pan, leftGain, rightGain);
+    PanLaw::equalPower(pan, 1.0f, leftGain, rightGain);
 }
 
 // SimpleMixer implementation

--- a/AestraAudio/src/Playback/AuditionEngine.cpp
+++ b/AestraAudio/src/Playback/AuditionEngine.cpp
@@ -5,6 +5,7 @@
 #include "AestraLog.h"
 #include "ClipResampler.h" // Sinc64Turbo resampling
 #include "ClipSource.h"
+#include "DSP/PanLaw.h"
 #include "MetadataParser.h"
 #include "MiniAudioDecoder.h"
 
@@ -508,11 +509,13 @@ void AuditionEngine::processBlock(float* output, uint32_t numFrames, uint32_t nu
         }
     }
 
-    // Apply Master Volume
-    float vol = m_volume.load(std::memory_order_relaxed);
-    if (vol < 1.0f) {
+    // Match the main engine's centered-track reference gain. Audition is a
+    // separate listening surface, but bypass should not be louder than placing
+    // the same file on a default centered track.
+    const float outputGain = m_volume.load(std::memory_order_relaxed) * PanLaw::kEqualPowerCenterGain;
+    if (outputGain != 1.0f) {
         for (uint32_t i = 0; i < numFrames * numChannels; ++i) {
-            output[i] *= vol;
+            output[i] *= outputGain;
         }
     }
 

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -2,6 +2,7 @@
 #include "PreviewEngine.h"
 
 #include "AestraLog.h"
+#include "DSP/PanLaw.h"
 #include "FastMath.h"
 #include "MiniAudioDecoder.h"
 #include "PathUtils.h"
@@ -23,11 +24,6 @@
 namespace Aestra {
 namespace Audio {
 
-// Preview gain normalize: ensures preview output has built-in headroom
-// relative to 0dBFS, matching the audio engine's effective unity gain path
-// (which includes ~-3dB pan law, fader, and trim stages).
-// This prevents the preview from sounding hotter than track playback.
-static constexpr float kPreviewGainNormalizeDb = -1.0f;
 static constexpr double kPreviewDecodeDefaultSeconds = 30.0;
 static constexpr double kPreviewDecodeHardMaxSeconds = 60.0;
 
@@ -100,8 +96,7 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->durationSeconds =
         (sampleRate > 0 && buffer->numFrames > 0) ? (static_cast<double>(buffer->numFrames) / sampleRate) : 0.0;
     voice->maxPlaySeconds = maxSeconds;
-    const float totalGain =
-        dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
+    const float totalGain = dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed));
     voice->gain = totalGain;
     voice->phaseFrames = 0.0;
     voice->elapsedSeconds = 0.0;
@@ -201,8 +196,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     // Create voice immediately for pending playback
     auto voice = std::make_shared<PreviewVoice>();
     voice->path = path;
-    voice->gain =
-        dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed)) * dbToLinear(kPreviewGainNormalizeDb);
+    voice->gain = dbToLinear(gainDb + m_globalGainDb.load(std::memory_order_relaxed));
     voice->maxPlaySeconds = maxSeconds;
     voice->phaseFrames = 0.0;
     voice->elapsedSeconds = 0.0;
@@ -291,11 +285,7 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
     const float gain = voice->gain;
     const uint32_t srcChannels = voice->channels;
 
-    // Mono sources duplicate to stereo with no pan-law attenuation,
-    // making them ~+3 dB hotter than the audio engine's centered track path.
-    // Apply center-pan constant-power attenuation (~-3 dB per channel) to match.
-    constexpr float kCenterPanLawGain = 0.7071067811865475f; // sqrt(2)/2
-    const float effectiveGain = gain * ((srcChannels == 1) ? kCenterPanLawGain : 1.0f);
+    const float effectiveGain = gain * PanLaw::kEqualPowerCenterGain;
 
     uint32_t i = 0;
 

--- a/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
+++ b/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
@@ -1,5 +1,6 @@
 #include "Core/AudioEngine.h"
 #include "Core/MasterSafetyLimiter.h"
+#include "DSP/PanLaw.h"
 #include "Playback/AuditionEngine.h"
 #include "Playback/PreviewEngine.h"
 
@@ -23,6 +24,7 @@ constexpr uint32_t kSampleRate = 48000;
 constexpr uint32_t kChannels = 2;
 constexpr uint32_t kFrames = 4096;
 constexpr uint32_t kBlockFrames = 2048;
+constexpr float kCenterPanLawGain = Aestra::Audio::PanLaw::kEqualPowerCenterGain;
 
 void writeUint32(std::ofstream& out, uint32_t value) {
     out.put(static_cast<char>(value & 0xFF));
@@ -128,32 +130,31 @@ float renderPreviewAverageTail(const fs::path& path, float gainDb) {
     return averageTail(out, 1024);
 }
 
-void auditionBypassIsUnityForSameRateSource(const fs::path& path, float decodedSample) {
+void auditionBypassMatchesCenteredTrackGain(const fs::path& path, float decodedSample) {
     const float audition = renderAuditionAverageTail(path);
-    assert(std::abs(audition - decodedSample) < 2.0e-4f);
-    std::cout << "PASS: audition bypass unity, tail average=" << audition << "\n";
+    const float expected = decodedSample * kCenterPanLawGain;
+    assert(std::abs(audition - expected) < 2.0e-4f);
+    std::cout << "PASS: audition bypass matches centered track gain, tail average=" << audition << "\n";
 }
 
-void previewIsUnityBelowLimiterAfterGainCompensation(const fs::path& path, float decodedSample) {
-    // PreviewEngine applies a built-in -1 dB normalization. +1 dB test gain
-    // cancels that so sub-threshold material should match the source after
-    // the 20 ms fade-in has completed, within the fast dB approximation error.
-    const float preview = renderPreviewAverageTail(path, 1.0f);
-    const float diff = std::abs(preview - decodedSample);
-    assert(diff < 1.0e-2f);
-    std::cout << "PASS: preview sub-threshold level after gain compensation, tail average=" << preview
-              << ", source=" << decodedSample << ", diff=" << diff << "\n";
+void previewMatchesCenteredTrackGainBelowLimiter(const fs::path& path, float decodedSample) {
+    const float preview = renderPreviewAverageTail(path, 0.0f);
+    const float expected = decodedSample * kCenterPanLawGain;
+    const float diff = std::abs(preview - expected);
+    assert(diff < 1.0e-3f);
+    std::cout << "PASS: preview matches centered track gain below limiter, tail average=" << preview
+              << ", expected=" << expected << ", diff=" << diff << "\n";
 }
 
-void previewLimiterChangesHotMaterialButAuditionBypassDoesNot(const fs::path& path, float decodedSample) {
+void previewLimiterChangesBoostedHotMaterialButAuditionBypassDoesNot(const fs::path& path, float decodedSample) {
     const float audition = renderAuditionAverageTail(path);
-    const float preview = renderPreviewAverageTail(path, 1.0f);
+    const float preview = renderPreviewAverageTail(path, 3.0f);
 
-    assert(std::abs(audition - decodedSample) < 2.0e-4f);
-    assert(preview < audition - 0.005f);
-    assert(preview > 0.90f);
-    std::cout << "PASS: preview limiter changed hot source, audition=" << audition << ", preview=" << preview
-              << "\n";
+    assert(std::abs(audition - decodedSample * kCenterPanLawGain) < 2.0e-4f);
+    assert(preview > 0.85f);
+    assert(preview < 0.98f);
+    std::cout << "PASS: preview limiter changed boosted hot source, audition=" << audition
+              << ", preview=" << preview << "\n";
 }
 
 void belowKneePassthrough() {
@@ -289,9 +290,9 @@ int main() {
     ceilingClamp();
     overCeilingClamp();
     limiterDisabledPassthrough();
-    auditionBypassIsUnityForSameRateSource(coldPath, coldDecoded);
-    previewIsUnityBelowLimiterAfterGainCompensation(coldPath, coldDecoded);
-    previewLimiterChangesHotMaterialButAuditionBypassDoesNot(hotPath, hotDecoded);
+    auditionBypassMatchesCenteredTrackGain(coldPath, coldDecoded);
+    previewMatchesCenteredTrackGainBelowLimiter(coldPath, coldDecoded);
+    previewLimiterChangesBoostedHotMaterialButAuditionBypassDoesNot(hotPath, hotDecoded);
     mainAudioEngineSafetyLimiterChangesHotMasterOutput();
 
     std::error_code ec;

--- a/Tests/AestraAudio/PreviewAuditionGainParityTest.cpp
+++ b/Tests/AestraAudio/PreviewAuditionGainParityTest.cpp
@@ -1,0 +1,218 @@
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraph.h"
+#include "DSP/PanLaw.h"
+#include "IO/SamplePool.h"
+#include "Models/TrackManager.h"
+#include "Playback/AuditionEngine.h"
+#include "Playback/PreviewEngine.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockFrames = 512;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kTotalFrames = kSampleRate;
+constexpr float kSourceSample = 0.25f;
+constexpr float kExpectedOutput = kSourceSample * Aestra::Audio::PanLaw::kEqualPowerCenterGain;
+
+void writeUint32(std::ofstream& out, uint32_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+    out.put(static_cast<char>((value >> 16) & 0xFF));
+    out.put(static_cast<char>((value >> 24) & 0xFF));
+}
+
+void writeUint16(std::ofstream& out, uint16_t value) {
+    out.put(static_cast<char>(value & 0xFF));
+    out.put(static_cast<char>((value >> 8) & 0xFF));
+}
+
+bool writeMonoConstantWav(const fs::path& path) {
+    std::ofstream wav(path, std::ios::binary);
+    if (!wav) {
+        return false;
+    }
+
+    constexpr uint16_t channels = 1;
+    constexpr uint16_t bitsPerSample = 16;
+    constexpr uint32_t bytesPerSample = bitsPerSample / 8;
+    const uint32_t dataChunkSize = kTotalFrames * channels * bytesPerSample;
+    const uint32_t riffChunkSize = 4 + (8 + 16) + (8 + dataChunkSize);
+    const auto pcm = static_cast<int16_t>(std::lrint(kSourceSample * 32767.0f));
+
+    wav.write("RIFF", 4);
+    writeUint32(wav, riffChunkSize);
+    wav.write("WAVE", 4);
+    wav.write("fmt ", 4);
+    writeUint32(wav, 16);
+    writeUint16(wav, 1);
+    writeUint16(wav, channels);
+    writeUint32(wav, kSampleRate);
+    writeUint32(wav, kSampleRate * channels * bytesPerSample);
+    writeUint16(wav, channels * bytesPerSample);
+    writeUint16(wav, bitsPerSample);
+    wav.write("data", 4);
+    writeUint32(wav, dataChunkSize);
+
+    for (uint32_t i = 0; i < kTotalFrames; ++i) {
+        writeUint16(wav, static_cast<uint16_t>(pcm));
+    }
+    return static_cast<bool>(wav);
+}
+
+template <typename Predicate>
+bool waitUntil(Predicate&& predicate) {
+    for (int i = 0; i < 200; ++i) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+}
+
+float measuredMean(const std::vector<float>& interleaved) {
+    double sum = 0.0;
+    size_t count = 0;
+    for (const float sample : interleaved) {
+        sum += sample;
+        ++count;
+    }
+    return count > 0 ? static_cast<float>(sum / static_cast<double>(count)) : 0.0f;
+}
+
+void requireNear(const char* label, float value, float expected, float tolerance) {
+    const float diff = std::abs(value - expected);
+    std::cout << label << "=" << value << " expected=" << expected << " diff=" << diff << "\n";
+    assert(diff <= tolerance);
+}
+
+std::vector<float> renderMainEngineTrack() {
+    auto source = std::make_shared<Aestra::Audio::AudioBuffer>();
+    source->channels = 1;
+    source->sampleRate = kSampleRate;
+    source->numFrames = kTotalFrames;
+    source->data.assign(kTotalFrames, kSourceSample);
+    source->ready.store(true, std::memory_order_release);
+
+    Aestra::Audio::AudioGraph graph;
+    Aestra::Audio::TrackRenderState track;
+    track.trackId = 1;
+    track.trackIndex = 0;
+    track.volume = 1.0f;
+    track.pan = 0.0f;
+
+    Aestra::Audio::ClipRenderState clip;
+    clip.buffer = source;
+    clip.audioData = source->data.data();
+    clip.startSample = 0;
+    clip.endSample = kTotalFrames;
+    clip.totalFrames = kTotalFrames;
+    clip.sourceSampleRate = kSampleRate;
+    clip.channels = 1;
+    clip.gain = 1.0f;
+    track.clips.push_back(clip);
+    graph.tracks.push_back(std::move(track));
+    graph.timelineEndSample = kTotalFrames;
+
+    Aestra::Audio::AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockFrames, kChannels);
+    assert(engine.initialize());
+    engine.setGraph(graph);
+    engine.setTransportPlaying(true);
+
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    for (int i = 0; i < 4; ++i) {
+        std::fill(out.begin(), out.end(), 0.0f);
+        assert(engine.processBlock(out.data(), nullptr, kBlockFrames, 0.0) == 0);
+    }
+    return out;
+}
+
+std::vector<float> renderPreview(const fs::path& path) {
+    Aestra::Audio::PreviewEngine preview;
+    preview.setOutputSampleRate(kSampleRate);
+    const auto result = preview.play(path.string(), 0.0f, 5.0);
+    assert(result == Aestra::Audio::PreviewResult::Pending || result == Aestra::Audio::PreviewResult::Success);
+    assert(waitUntil([&preview] { return preview.isBufferReady(); }));
+
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    for (int i = 0; i < 4; ++i) {
+        std::fill(out.begin(), out.end(), 0.0f);
+        preview.processRealtime(out.data(), kBlockFrames, kChannels);
+    }
+    return out;
+}
+
+std::vector<float> renderAudition(const fs::path& path) {
+    Aestra::Audio::AuditionEngine audition;
+    audition.setSampleRate(kSampleRate);
+    audition.setVolume(1.0f);
+    audition.setDSPPreset(Aestra::Audio::AuditionDSPPreset::Bypass());
+    audition.addToQueue(path.string());
+    audition.play();
+    assert(waitUntil([&audition] { return audition.getCurrentSource() != nullptr; }));
+
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    audition.processBlock(out.data(), kBlockFrames, kChannels);
+    return out;
+}
+
+std::vector<float> renderInputMonitoring() {
+    Aestra::Audio::TrackManager tracks;
+    tracks.setInputChannelCount(1);
+    auto* channel = tracks.addChannel("Monitor");
+    assert(channel != nullptr);
+    channel->setArmed(true);
+    channel->setMonitoringEnabled(true);
+    channel->setInputChannelIndex(0);
+    tracks.publishInputMonitoringSnapshot();
+
+    std::vector<float> input(kBlockFrames, kSourceSample);
+    std::vector<float> out(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    tracks.mixInputMonitoring(input.data(), out.data(), kBlockFrames, kChannels);
+    return out;
+}
+
+} // namespace
+
+int main() {
+    const fs::path path = fs::temp_directory_path() / "Aestra_preview_audition_gain_parity.wav";
+    assert(writeMonoConstantWav(path));
+
+    const auto mainOut = renderMainEngineTrack();
+    const auto previewOut = renderPreview(path);
+    const auto auditionOut = renderAudition(path);
+    const auto monitorOut = renderInputMonitoring();
+
+    const float mainMean = measuredMean(mainOut);
+    const float previewMean = measuredMean(previewOut);
+    const float auditionMean = measuredMean(auditionOut);
+    const float monitorMean = measuredMean(monitorOut);
+
+    requireNear("main", mainMean, kExpectedOutput, 0.0025f);
+    requireNear("preview", previewMean, mainMean, 0.0035f);
+    requireNear("audition", auditionMean, mainMean, 0.0035f);
+    requireNear("monitor", monitorMean, mainMean, 0.0035f);
+
+    std::error_code ec;
+    fs::remove(path, ec);
+    std::cout << "PreviewAuditionGainParityTest: PASS\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -759,6 +759,11 @@ add_executable(AestraAuditionEngineLifecycleTest AestraAudio/AuditionEngineLifec
 target_link_libraries(AestraAuditionEngineLifecycleTest PRIVATE AestraAudio)
 add_test(NAME AestraAuditionEngineLifecycleTest COMMAND AestraAuditionEngineLifecycleTest)
 
+add_executable(PreviewAuditionGainParityTest AestraAudio/PreviewAuditionGainParityTest.cpp)
+target_link_libraries(PreviewAuditionGainParityTest PRIVATE AestraAudio)
+add_test(NAME PreviewAuditionGainParityTest COMMAND PreviewAuditionGainParityTest)
+set_tests_properties(PreviewAuditionGainParityTest PROPERTIES LABELS "audio;preview;audition;gain;regression")
+
 # SamplePool Test
 add_executable(SamplePoolTest AestraAudio/SamplePoolTest.cpp)
 target_link_libraries(SamplePoolTest PRIVATE AestraAudio)


### PR DESCRIPTION
## Summary
- Align browser preview, Audition bypass, and input monitoring to the main engine centered-track gain reference.
- Add a shared equal-power pan-law helper so preview, audition, monitoring, realtime render, offline render, and MixerBus do not drift.
- Add measured headless parity coverage for main engine, preview, audition, and input monitoring.

## Validation
- Physical confirmation: preview/audition/main level mismatch is fixed in local listening.
- cmake --build build-linux -j2 --target AestraAudioCore PreviewAuditionGainParityTest AestraPlaybackPathSignalIntegrityTest AestraAuditionEngineLifecycleTest Aestra
- ctest --test-dir build-linux -j2 -R "PreviewAuditionGainParityTest|AestraPlaybackPathSignalIntegrityTest|RoutingSendPanParityTest|SamplerStereoParityTest|AestraAuditionEngineLifecycleTest|RealtimeSchedulingTest" --output-on-failure
- git diff --check

## Notes
- Created follow-up tracker for selectable pan-law/stereo center-gain policy: #405.
