### PR TITLE
fix(ui): neutralize blue-tinged dark chrome to pure greys

### DIFF
--- a/AestraUI/Base/NUIScrollbar.h
+++ b/AestraUI/Base/NUIScrollbar.h
@@ -190,14 +190,14 @@ private:
 
     // Visual properties
     Orientation orientation_ = Orientation::Vertical;
-    NUIColor trackColor_ = NUIColor(0.15f, 0.15f, 0.18f, 1.0f);          // Track base (alpha applied at draw time)
-    NUIColor thumbColor_ = NUIColor(0.85f, 0.85f, 0.90f, 0.28f);         // Quiet thumb default
-    NUIColor thumbHoverColor_ = NUIColor(0.95f, 0.95f, 1.00f, 0.45f);    // Brighter on hover
-    NUIColor thumbPressedColor_ = NUIColor(0.70f, 0.70f, 0.80f, 0.65f);  // Stronger on press
-    NUIColor arrowColor_ = NUIColor(0.85f, 0.85f, 0.90f, 0.25f);         // Subtle arrows
-    NUIColor arrowHoverColor_ = NUIColor(0.95f, 0.95f, 1.00f, 0.45f);    // Brighter on hover
-    NUIColor arrowPressedColor_ = NUIColor(0.70f, 0.70f, 0.80f, 0.65f);  // Stronger on press
-    NUIColor borderColor_ = NUIColor(0.30f, 0.30f, 0.35f, 0.35f);        // Subtle border
+    NUIColor trackColor_ = NUIColor(0.15f, 0.15f, 0.15f, 1.0f);          // Track base (alpha applied at draw time)
+    NUIColor thumbColor_ = NUIColor(0.85f, 0.85f, 0.85f, 0.28f);         // Quiet thumb default
+    NUIColor thumbHoverColor_ = NUIColor(0.95f, 0.95f, 0.95f, 0.45f);    // Brighter on hover
+    NUIColor thumbPressedColor_ = NUIColor(0.70f, 0.70f, 0.70f, 0.65f);  // Stronger on press
+    NUIColor arrowColor_ = NUIColor(0.85f, 0.85f, 0.85f, 0.25f);         // Subtle arrows
+    NUIColor arrowHoverColor_ = NUIColor(0.95f, 0.95f, 0.95f, 0.45f);    // Brighter on hover
+    NUIColor arrowPressedColor_ = NUIColor(0.70f, 0.70f, 0.70f, 0.65f);  // Stronger on press
+    NUIColor borderColor_ = NUIColor(0.30f, 0.30f, 0.30f, 0.35f);        // Subtle border
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float arrowSize_ = 12.0f;

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -549,8 +549,8 @@ void NUIComponent::renderGlobalTooltip(NUIRenderer& renderer) {
     const NUIRect tipRect(x, y, w, h);
     
     // Theme colors (matching minimap style)
-    const NUIColor bg = NUIColor(0.12f, 0.12f, 0.15f, 0.92f * s_tooltipState.alpha);
-    const NUIColor border = NUIColor(0.4f, 0.4f, 0.45f, 0.65f * s_tooltipState.alpha);
+    const NUIColor bg = NUIColor(0.12f, 0.12f, 0.12f, 0.92f * s_tooltipState.alpha);
+    const NUIColor border = NUIColor(0.4f, 0.4f, 0.4f, 0.65f * s_tooltipState.alpha);
     const NUIColor text = NUIColor(0.95f, 0.95f, 0.95f, 0.92f * s_tooltipState.alpha);
     
     renderer.fillRoundedRect(tipRect, kTooltipRadius, bg);

--- a/AestraUI/Core/NUITheme.cpp
+++ b/AestraUI/Core/NUITheme.cpp
@@ -46,9 +46,9 @@ std::shared_ptr<NUITheme> NUITheme::createDefault() {
     auto theme = std::make_shared<NUITheme>();
     
     // Aestra landing-aligned premium dark palette
-    theme->setColor("background", NUIColor::fromHex(0x080a0e));
-    theme->setColor("surface", NUIColor::fromHex(0x0f1118, 0.96f));
-    theme->setColor("surfaceLight", NUIColor::fromHex(0x13161e));
+    theme->setColor("background", NUIColor::fromHex(0x0a0a0a));
+    theme->setColor("surface", NUIColor::fromHex(0x101010, 0.96f));
+    theme->setColor("surfaceLight", NUIColor::fromHex(0x161616));
     
     // Accents
     theme->setColor("primary", NUIColor::fromHex(0x8b7de8));      // Brand purple
@@ -58,14 +58,14 @@ std::shared_ptr<NUITheme> NUITheme::createDefault() {
     theme->setColor("error", NUIColor::fromHex(0xe06a4e));        // Coral
     
     // UI Elements
-    theme->setColor("text", NUIColor::fromHex(0xc0c8e0));
-    theme->setColor("textSecondary", NUIColor::fromHex(0x8b95b0));
-    theme->setColor("textDisabled", NUIColor::fromHex(0x3a4060));
-    
-    theme->setColor("border", NUIColor::fromHex(0x2a2f42, 0.86f));
+    theme->setColor("text", NUIColor::fromHex(0xc8c8c8));
+    theme->setColor("textSecondary", NUIColor::fromHex(0x999999));
+    theme->setColor("textDisabled", NUIColor::fromHex(0x474747));
+
+    theme->setColor("border", NUIColor::fromHex(0x2d2d2d, 0.86f));
     theme->setColor("hover", NUIColor::fromHex(0xffffff, 0.06f));
     theme->setColor("active", NUIColor::fromHex(0x8b7de8, 0.2f));
-    theme->setColor("disabled", NUIColor::fromHex(0x1a1e2a, 0.58f));
+    theme->setColor("disabled", NUIColor::fromHex(0x1d1d1d, 0.58f));
 
     // Dimensions
     theme->setDimension("borderRadius", 12.0f);        // Soft Geometry

--- a/AestraUI/Core/NUIThemeSystem.cpp
+++ b/AestraUI/Core/NUIThemeSystem.cpp
@@ -516,10 +516,10 @@ NUIThemeProperties NUIThemePresets::createAestraDark() {
     // ========================================================================
 
     // --- Surface Hierarchy ---
-    theme.backgroundPrimary   = NUIColor::fromHex(0x0a0a0f);  // Deeper void for timeline backdrop
-    theme.backgroundSecondary = NUIColor::fromHex(0x111116);
-    theme.surfaceTertiary     = NUIColor::fromHex(0x181822);  // More contrast from background for controls
-    theme.surfaceRaised       = NUIColor::fromHex(0x20202c);  // Slightly brighter for raised elements
+    theme.backgroundPrimary   = NUIColor::fromHex(0x0a0a0a);  // Deeper void for timeline backdrop
+    theme.backgroundSecondary = NUIColor::fromHex(0x111111);
+    theme.surfaceTertiary     = NUIColor::fromHex(0x191919);  // More contrast from background for controls
+    theme.surfaceRaised       = NUIColor::fromHex(0x212121);  // Slightly brighter for raised elements
 
     // Legacy aliases
     theme.background    = theme.backgroundPrimary;
@@ -555,12 +555,12 @@ NUIThemeProperties NUIThemePresets::createAestraDark() {
     theme.textCritical  = theme.error;
 
     // --- Borders & Dividers ---
-    theme.borderSubtle   = NUIColor::fromHex(0x2a2a38, 0.90f);  // Brighter for visible row dividers
-    theme.border         = NUIColor::fromHex(0x2a2a38);          // Structural separator edge
+    theme.borderSubtle   = NUIColor::fromHex(0x2b2b2b, 0.90f);  // Brighter for visible row dividers
+    theme.border         = NUIColor::fromHex(0x2b2b2b);          // Structural separator edge
     theme.borderActive   = theme.primary;
-    theme.divider        = NUIColor::fromHex(0x242430, 0.95f);
-    theme.outline        = NUIColor::fromHex(0x323244);
-    theme.outlineVariant = NUIColor::fromHex(0x242430, 0.80f);
+    theme.divider        = NUIColor::fromHex(0x252525, 0.95f);
+    theme.outline        = NUIColor::fromHex(0x333333);
+    theme.outlineVariant = NUIColor::fromHex(0x252525, 0.80f);
 
     // --- Glass Aesthetic ---
     theme.glassHover  = NUIColor::white().withAlpha(0.040f);
@@ -568,19 +568,19 @@ NUIThemeProperties NUIThemePresets::createAestraDark() {
     theme.glassActive = theme.primary.withAlpha(0.16f);
 
     // --- Buttons (backlit key gradient feel) ---
-    theme.buttonBgDefault  = NUIColor::fromHex(0x111116);
-    theme.buttonBgHover    = NUIColor::fromHex(0x16161e);
+    theme.buttonBgDefault  = NUIColor::fromHex(0x111111);
+    theme.buttonBgHover    = NUIColor::fromHex(0x171717);
     theme.buttonBgActive   = NUIColor::fromHex(0x7c5cbf, 0.30f);
     theme.buttonTextDefault = theme.textPrimary;
     theme.buttonTextActive  = theme.textPrimary;
 
     // --- Toggle ---
-    theme.toggleDefault = NUIColor::fromHex(0x111116);
-    theme.toggleHover   = NUIColor::fromHex(0x16161e);
+    theme.toggleDefault = NUIColor::fromHex(0x111111);
+    theme.toggleHover   = NUIColor::fromHex(0x171717);
     theme.toggleActive  = theme.primary.withAlpha(0.85f);
 
     // --- Sliders ---
-    theme.sliderTrack         = NUIColor::fromHex(0x22222f);
+    theme.sliderTrack         = NUIColor::fromHex(0x232323);
     theme.sliderHandle        = theme.primary;
     theme.sliderHandleHover   = theme.primaryHover;
     theme.sliderHandlePressed = theme.primaryPressed;
@@ -608,7 +608,7 @@ NUIThemeProperties NUIThemePresets::createAestraDark() {
     theme.shadowXL = NUIThemeProperties::Shadow(0, 16, 32, 0, NUIColor::black(), 0.30f);
 
     // --- Mixer ---
-    theme.mixerStripBg      = NUIColor::fromHex(0x13131a);
+    theme.mixerStripBg      = NUIColor::fromHex(0x141414);
     theme.mixerMasterBorder = theme.primary.withAlpha(0.34f);
 
     return theme;

--- a/AestraUI/Core/NUITypes.h
+++ b/AestraUI/Core/NUITypes.h
@@ -167,9 +167,9 @@ struct NUIColor {
     static NUIColor Info() { return NUIColor(0.1f, 0.6f, 0.8f, 1.0f); }
     
     // Dark theme colors
-    static NUIColor DarkBackground() { return NUIColor(0.1f, 0.1f, 0.15f, 1.0f); }
-    static NUIColor DarkSurface() { return NUIColor(0.15f, 0.15f, 0.2f, 1.0f); }
-    static NUIColor DarkBorder() { return NUIColor(0.3f, 0.3f, 0.35f, 1.0f); }
+    static NUIColor DarkBackground() { return NUIColor(0.1f, 0.1f, 0.1f, 1.0f); }
+    static NUIColor DarkSurface() { return NUIColor(0.15f, 0.15f, 0.15f, 1.0f); }
+    static NUIColor DarkBorder() { return NUIColor(0.3f, 0.3f, 0.3f, 1.0f); }
     static NUIColor DarkText() { return NUIColor(0.9f, 0.9f, 0.9f, 1.0f); }
     static NUIColor DarkTextSecondary() { return NUIColor(0.6f, 0.6f, 0.6f, 1.0f); }
     

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -31,7 +31,7 @@ void UIMixerFader::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();
     // Track: Deep Glass Slot
-    m_trackBg = AestraUI::NUIColor(0.05f, 0.05f, 0.08f, 0.6f); 
+    m_trackBg = AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.6f);
     // Fill: Gradient handled in render
     m_trackFg = theme.getColor("accentPrimary"); 
     m_handle = theme.getColor("backgroundSecondary"); // Handle Core
@@ -137,7 +137,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
     renderer.drawShadow(handleRect, 0.0f, 2.0f, 6.0f, NUIColor(0, 0, 0, 0.4f));
 
     // Handle Body (dark surface)
-    renderer.fillRoundedRect(handleRect, handleRad, NUIColor(0.18f, 0.18f, 0.22f, 0.98f));
+    renderer.fillRoundedRect(handleRect, handleRad, NUIColor(0.18f, 0.18f, 0.18f, 0.98f));
 
     // Handle Border (accent when active/hovered, subtle white otherwise)
     bool handleActive = isHovered() || m_dragging;
@@ -170,7 +170,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
             tipY = handleY + handleH + 4.0f;
         }
 
-        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, NUIColor(0.05f, 0.05f, 0.08f, 0.95f));
+        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, NUIColor(0.05f, 0.05f, 0.05f, 0.95f));
         renderer.strokeRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, 1.0f, m_trackFg.withAlpha(0.5f));
         renderer.drawTextCentered(m_cachedText, {tipX, tipY, tipW, tipH}, 10.5f, m_text);
     }

--- a/Source/Components/AudioVisualizer.cpp
+++ b/Source/Components/AudioVisualizer.cpp
@@ -376,7 +376,7 @@ void AudioVisualizer::renderWaveform(NUIRenderer& renderer) {
     
     // Liminal Dark v2.0 background gradient - top: #121214 â†’ bottom: #18181b
     NUIColor topColor = backgroundColor_;  // #121214 - Deep charcoal
-    NUIColor bottomColor = NUIColor(0.094f, 0.094f, 0.106f, 1.0f);  // #18181b - Slightly lighter
+    NUIColor bottomColor = NUIColor(0.094f, 0.094f, 0.094f, 1.0f);  // #181818 - Slightly lighter
     
     // Draw gradient background
     for (int i = 0; i < static_cast<int>(bounds.height); ++i) {

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -172,7 +172,7 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
         
         // Meter background (Dark Slot)
         AestraUI::NUIRect meterBg(meterX, meterY, meterW, meterH);
-        renderer.fillRoundedRect(meterBg, 2.0f, AestraUI::NUIColor(0.05f, 0.05f, 0.08f, 0.8f));
+        renderer.fillRoundedRect(meterBg, 2.0f, AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.8f));
         
         // Get current level (Mock/Placeholder)
         float level = m_track->getVolume(); // Simple mapping
@@ -274,7 +274,7 @@ void MixerView::onRender(AestraUI::NUIRenderer& renderer) {
     auto bounds = getBounds();
     
     // Deep Void Background
-    auto bgColor = AestraUI::NUIColor::fromHex(0x050508); // Matches Playlist
+    auto bgColor = AestraUI::NUIColor::fromHex(0x050505); // Matches Playlist
     renderer.fillRect(bounds, bgColor);
     
     // Subtle Top Gradient (Header Shadow)

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -182,7 +182,7 @@ void TimelineMinimapBar::cacheThemeColors_()
     auto& theme = NUIThemeManager::getInstance();
     // Near-black shell matching the ruler material exactly (one continuous
     // band; the old surfaceRaised tint read blue against neighboring rows).
-    colors_.glassFill = NUIColor(0.012f, 0.012f, 0.016f, 0.98f);
+    colors_.glassFill = NUIColor(0.012f, 0.012f, 0.012f, 0.98f);
     colors_.glassBorder = theme.getColor("border").withAlpha(0.28f);
     colors_.cornerSeparator = theme.getColor("border").withAlpha(0.28f);
 

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1782,7 +1782,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
     if (m_playlistVisible) {
         // Background for control area (always visible)
         AestraUI::NUIRect controlBg(bounds.x, bounds.y, controlAreaWidth, bounds.height);
-        renderer.fillRect(controlBg, AestraUI::NUIColor(0.034f, 0.035f, 0.040f, 1.0f));
+        renderer.fillRect(controlBg, AestraUI::NUIColor(0.035f, 0.035f, 0.035f, 1.0f));
 
         // Background for grid area (match track background; zebra grid provides contrast)
         float scrollbarWidth = 15.0f;
@@ -1888,7 +1888,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         AestraUI::NUIRect headerRect(bounds.x, bounds.y, headerWidth, headerHeight);
         // Elevated header: base fill + soft vertical gradient + glass top edge.
         // Rendered into the playlist FBO cache, so the richness is free per frame.
-        renderer.fillRect(headerRect, AestraUI::NUIColor(0.030f, 0.031f, 0.036f, 1.0f));
+        renderer.fillRect(headerRect, AestraUI::NUIColor(0.031f, 0.031f, 0.031f, 1.0f));
         // Shade-only elevation — any white component reads as a sheen on this
         // near-black chrome (owner direction: no light gradients anywhere).
         renderer.fillRectGradient(headerRect, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
@@ -3725,11 +3725,11 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
 
     // Opaque near-black ruler material — identical across the full row and the
     // grid shell so the corner over the track controls is flush by construction.
-    auto glassBg = AestraUI::NUIColor(0.012f, 0.012f, 0.016f, 1.0f);
+    auto glassBg = AestraUI::NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
     auto glassHighlight = AestraUI::NUIColor::white().withAlpha(0.014f);
 
     auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
-    auto tickCol = AestraUI::NUIColor::fromHex(0x2c2c3b).withAlpha(0.82f);
+    auto tickCol = AestraUI::NUIColor::fromHex(0x2e2e2e).withAlpha(0.82f);
 
     // Restore layout definition
     const auto& layout = themeManager.getLayoutDimensions();
@@ -3824,7 +3824,7 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
                 float beatX = x + (beat * m_pixelsPerBeat);
 
                 float beatTickHeight = rulerBounds.height * 0.22f;
-                AestraUI::NUIColor beatTickColor = AestraUI::NUIColor::fromHex(0x242431).withAlpha(0.36f);
+                AestraUI::NUIColor beatTickColor = AestraUI::NUIColor::fromHex(0x262626).withAlpha(0.36f);
 
                 renderer.drawLine(AestraUI::NUIPoint(beatX, rulerBounds.y + rulerBounds.height - beatTickHeight),
                                   AestraUI::NUIPoint(beatX, rulerBounds.y + rulerBounds.height), 1.0f, beatTickColor);
@@ -4144,7 +4144,7 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
 
     AestraUI::NUIRect textureBounds(0, 0, static_cast<float>(width), static_cast<float>(height));
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor(0.08235f, 0.08235f, 0.11765f, 1.0f); // #15151e
+    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor(0.08235f, 0.08235f, 0.08235f, 1.0f); // #151515
     AestraUI::NUIColor borderColor = themeManager.getColor("border");
 
     // Draw background panels
@@ -4182,9 +4182,9 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
     double maxExtentInBeats = maxExtent / secondsPerBeat;
 
     // Ruler Render: "Mature" Playlist Style
-    auto bg = AestraUI::NUIColor(0.08f, 0.08f, 0.10f, 1.0f);
+    auto bg = AestraUI::NUIColor(0.08f, 0.08f, 0.08f, 1.0f);
     auto textCol = AestraUI::NUIColor(0.82f, 0.82f, 0.82f, 1.0f); // bright gray for ruler labels
-    auto tickCol = AestraUI::NUIColor(0.45f, 0.45f, 0.50f, 1.0f); // visible tick marks
+    auto tickCol = AestraUI::NUIColor(0.45f, 0.45f, 0.45f, 1.0f); // visible tick marks
 
     // Draw ruler background
     renderer.fillRect(rulerRect, bg);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1037,7 +1037,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
     }
 
     const float clipRadius = 5.0f;
-    renderer.fillRoundedRect(clipBounds, clipRadius, AestraUI::NUIColor(0.07f, 0.072f, 0.09f, 0.96f));
+    renderer.fillRoundedRect(clipBounds, clipRadius, AestraUI::NUIColor(0.071f, 0.071f, 0.071f, 0.96f));
     renderer.fillRoundedRect(clipBounds, clipRadius, baseColor.withAlpha(isSelected ? 0.38f : 0.28f));
     renderer.strokeRoundedRect(
         clipBounds,

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -101,7 +101,7 @@ public:
         auto b = getBounds();
         auto& theme = NUIThemeManager::getInstance();
 
-        renderer.fillRect(b, NUIColor(0.045f, 0.045f, 0.065f, 1.0f));
+        renderer.fillRect(b, NUIColor(0.045f, 0.045f, 0.045f, 1.0f));
 
         const float pad = 8.0f;
         const float gutter = 6.0f;
@@ -150,7 +150,7 @@ void ADSRDisplayComponent::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.055f, 0.055f, 0.075f, 1.0f));
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.055f, 0.055f, 0.055f, 1.0f));
     renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.22f));
 
     const auto g = calculateADSRGeometry(b, m_attack, m_decay, m_sustain, m_release);
@@ -401,7 +401,7 @@ void WaveformDisplayComponent::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(b);
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.05f, 0.05f, 0.07f, 1.0f));
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.05f, 0.05f, 0.05f, 1.0f));
     renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.24f));
 
     // Center line

--- a/Source/Settings/RecoveryDialog.cpp
+++ b/Source/Settings/RecoveryDialog.cpp
@@ -141,8 +141,8 @@ void RecoveryDialog::onRender(AestraUI::NUIRenderer& renderer) {
                      AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.6f));
     
     // Dialog background
-    renderer.fillRoundedRect(m_dialogRect, 8.0f, AestraUI::NUIColor(0.15f, 0.15f, 0.18f, 1.0f));
-    renderer.strokeRoundedRect(m_dialogRect, 8.0f, 1.0f, AestraUI::NUIColor(0.3f, 0.3f, 0.35f, 1.0f));
+    renderer.fillRoundedRect(m_dialogRect, 8.0f, AestraUI::NUIColor(0.15f, 0.15f, 0.15f, 1.0f));
+    renderer.strokeRoundedRect(m_dialogRect, 8.0f, 1.0f, AestraUI::NUIColor(0.3f, 0.3f, 0.3f, 1.0f));
     
     // Title
     float titleY = m_dialogRect.y + 25.0f;


### PR DESCRIPTION
## Summary
Removes the navy/blue tinge from all dark chrome. Every dark surface carried a blue shift (B ≈ R+5..18) — the `createAestraDark()` token ladder (`0x0a0a0f`, `0x111116`, `0x181822`, `0x20202c`, borders `0x2a2a38`…), the legacy `NUITheme` defaults (including slate-blue text `0xc0c8e0`), and ~20 hardcoded near-greys across shell components (TrackManagerUI, MixerView, TimelineMinimapBar, TrackUIComponent, SampleEditorPanel, RecoveryDialog, UIMixerFader, NUIScrollbar, tooltip, NUITypes dark defaults). All flattened to neutral greys at matched luminance.

## Why
Owner feedback on the Timeline screenshot: the blue-tinged panels read as off against the pure-black timeline. Direction is pure black/grey surfaces with shade-only elevation; hue belongs to accents, not chrome.

Out of scope (kept as-is): brand purple/functional accents, plugin editor palettes (EQ/Verb/Comp/Delay/Drift/Limit/RoutingMap have their own identities — candidate for a follow-up pass), light theme.

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest`: theme tests pass; full suite (CI exclusions applied) passes except `NUITextInputLayoutTest`, which fails identically on clean `develop` (pre-existing, headless CI never runs it) and `AestraPlaybackPathSignalIntegrityTest` which only failed under `-j2` parallel contention and passes serially.
- Visual verification: needs owner screenshot pass with a freshly built `build-linux/bin/Aestra`.

## Docs updated?
No — no public behavior claims affected.

## Risk/rollback notes
Color-constants-only diff (58 lines, 13 files); no logic, layout, DSP, or serialization changes. Rollback = revert the single commit. Any component that hand-tuned against the old blue-tinted tokens will now render neutral — that is the intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Neutralized dark UI chrome across the app by shifting a set of blue-tinged greys toward pure greys in shared theme constants and hardcoded surface colors.
- Updated dark theme defaults/presets, scrollbar and tooltip styling, mixer fader visuals, timeline/minimap/ruler colors, track and playlist backgrounds, waveform and sample editor panels, and recovery dialog backgrounds to match the new neutral palette.
- Kept behavior unchanged: no logic, layout, DSP, serialization, or public API changes; brand accents, functional colors, plugin editor palettes, and light theme remain untouched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->