### PR TITLE
fix(ui): restore per-track palette cycling for track colors

### DIFF
--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -10,7 +10,10 @@ namespace Aestra {
 namespace Audio {
 
 MixerChannel::MixerChannel(const std::string& name, uint32_t channelId)
-    : m_name(name), m_uuid(AestraUUID::generate()), m_channelId(channelId), m_color(0xFF4080FF)
+    // 0 = color unset: the UI derives a palette color per track instead. A
+    // concrete default here would win nearestPaletteIndex() for every channel
+    // and pin all tracks to the same palette entry.
+    : m_name(name), m_uuid(AestraUUID::generate()), m_channelId(channelId), m_color(0)
 
 {
     // m_uuid.low = m_channelId; // REMOVED: Do not overwrite generated UUID with 0!

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -431,8 +431,9 @@ void TrackUIComponent::updateTrackNameColors() {
 
     int colorIndex = m_channel->getTrackColorIndex();
     if (colorIndex < 0 || colorIndex >= AestraUI::PALETTE_SIZE) {
+        // trackId is unsigned; guard id 0 or the subtraction wraps to UINT32_MAX.
         uint32_t trackId = m_channel->getChannelId();
-        colorIndex = static_cast<int>((trackId - 1) % AestraUI::PALETTE_SIZE);
+        colorIndex = static_cast<int>((trackId > 0 ? trackId - 1 : 0) % AestraUI::PALETTE_SIZE);
     }
     m_nameLabel->setTextColor(
         AestraUI::NUIColor::fromARGB(AestraUI::paletteIndexToARGB(colorIndex)).withAlpha(0.82f));

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -29,6 +29,7 @@
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
+#include "../AestraUI/Widgets/TrackColorPalette.h"
 
 // Component includes
 #include "AudioVisualizer.h"
@@ -2921,12 +2922,9 @@ void AestraContent::addDemoTracks() {
         m_trackManager->addChannel(name);
 
         if (auto* lane = playlist.getLane(laneId)) {
-            if (i % 3 == 1)
-                lane->colorRGBA = 0xFFbb86fc;
-            else if (i % 3 == 2)
-                lane->colorRGBA = 0xFF00bcd4;
-            else
-                lane->colorRGBA = 0xFF9a9aa3;
+            // Cycle the shared track palette so the lane strip matches the
+            // name ink and mixer tint derived from the same index.
+            lane->colorRGBA = AestraUI::TRACK_PALETTE[(i - 1) % AestraUI::PALETTE_SIZE];
 
             if (i == 1) {
                 AutomationCurve vol("Volume", AutomationTarget::Volume);


### PR DESCRIPTION
## Summary
Fixes #409 — all track names rendered the same indigo. `MixerChannel` defaulted `m_color` to legacy blue `0xFF4080FF`; `nearestPaletteIndex` maps that to palette index 7 for every channel, so `MixerViewModel`'s position-based cycling fallback was unreachable and the stamped index persisted into saves.

Changes:
- `MixerChannel`: default `m_color` to 0 (unset). The only direct color consumer (`MixerView`) already guards `c != 0`; `nearestPaletteIndex(0)` returns -1, which activates the intended position-based cycling.
- `TrackUIComponent::updateTrackNameColors`: guard the unsigned `trackId - 1` fallback against wrap to `UINT32_MAX` when `channelId == 0` (this wrap also lands on index 7).
- `AestraContent::addDemoTracks`: seed lane strips from the shared `TRACK_PALETTE` (8-color cycle) instead of the legacy 3-color set, so the lane strip, name ink, and mixer tint derive from the same palette per track.

## Why
Follow-up from the 2026-07-05 UI pass. The unified track palette shipped in #407 never actually cycled — every track collapsed to indigo through the legacy default color.

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest -R 'Project|Roundtrip|Mixer|Channel|Serializ'`: 8/8 pass, including project roundtrip.
- Visual verification: needs owner screenshot with fresh `build-linux/bin/Aestra` — expect Track 1..8 to cycle Teal/Purple/Amber/Coral/Sky/Sage/Pink/Indigo.

## Docs updated?
No.

## Risk/rollback notes
- Serialization format unchanged. Persisted `trackColorIndex` remains the source of truth on load — existing projects keep their saved colors (including ones stamped indigo by this bug; only unset defaults cycle).
- Live/export parity unaffected (UI-only color derivation).
- Rollback = revert single commit.

Closes #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)