### PR TITLE
feat(ui): timeline/browser/transport polish pass

### DIFF
--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -359,9 +359,9 @@ FileBrowser::FileBrowser()
     searchInput_->setPadding(12.0f);
     searchInput_->setBorderRadius(0.0f);
     searchInput_->setBackgroundColor(themeManager.getColor("backgroundSecondary").darkened(0.02f));
-    searchInput_->setBorderColor(themeManager.getColor("textSecondary").withAlpha(0.35f));
+    searchInput_->setBorderColor(themeManager.getColor("border"));
     searchInput_->setFocusedBorderColor(NUIColor::fromHex(0xffa855f7));
-    searchInput_->setBorderWidth(2.0f);
+    searchInput_->setBorderWidth(1.0f);
 
     // Initialize icons with improved visibility for Liminal Dark v2.0
     // Use inline SVG content for reliable icon loading
@@ -748,7 +748,8 @@ void FileBrowser::processScanResults() {
 FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
     NUIRect bounds = getBounds();
     const float effectiveW = effectiveWidth_ > 0.0f ? effectiveWidth_ : bounds.width;
-    // Search bar fills the top gap (no BROWSER_TOP_PAD), inset 2px on sides
+    // Search bar sits flush with the browser panel: full width, no insets,
+    // 1px reserved at the bottom for the divider line.
     const float searchH = BROWSER_SEARCH_ROW_H;
     const float headerH = searchH;
     const float contentY = bounds.y + headerH;
@@ -758,8 +759,7 @@ FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
     const float listW = std::max(0.0f, effectiveW - navW);
 
     BrowserLayout layout;
-    layout.search = NUIRect(bounds.x + 2.0f, bounds.y + 2.0f,
-                            std::max(0.0f, effectiveW - 4.0f), searchH - 4.0f);
+    layout.search = NUIRect(bounds.x, bounds.y, std::max(0.0f, effectiveW), searchH - 1.0f);
     layout.navPane = NUIRect(bounds.x, contentY, navW, contentH);
     layout.listHeader = NUIRect(listX, contentY, listW, BROWSER_LIST_HEADER_H);
     layout.list = NUIRect(listX, contentY + BROWSER_LIST_HEADER_H,
@@ -1070,6 +1070,18 @@ void FileBrowser::renderStaticContent(NUIRenderer& renderer, const NUIRect& boun
     const BrowserLayout browserLayout = computeBrowserLayout();
     scrollbarTrackHeight_ = browserLayout.list.height;
 
+    // Keep the search input glued to the panel. onResize only fires on size
+    // changes, so a pure move (splitter drag, panel slide) would otherwise
+    // leave the input at its old absolute position while the panel renders
+    // at the new one. Diff before setting to avoid dirtying every frame.
+    if (searchInput_) {
+        const NUIRect cur = searchInput_->getBounds();
+        const NUIRect& tgt = browserLayout.search;
+        if (cur.x != tgt.x || cur.y != tgt.y || cur.width != tgt.width || cur.height != tgt.height) {
+            searchInput_->setBounds(tgt);
+        }
+    }
+
     NUIRect fileBrowserBounds(bounds.x, bounds.y, bounds.width, bounds.height);
 
     renderer.fillRect(fileBrowserBounds, themeManager.getColor("backgroundPrimary"));
@@ -1314,12 +1326,12 @@ void FileBrowser::onResize(int width, int height) {
 
         searchInput_->setTextColor(textColor_);
         searchInput_->setBackgroundColor(themeManager.getColor("backgroundSecondary").darkened(0.02f));
-        searchInput_->setBorderColor(themeManager.getColor("textSecondary").withAlpha(0.35f));
+        searchInput_->setBorderColor(themeManager.getColor("border"));
         searchInput_->setFocusedBorderColor(NUIColor::fromHex(0xffa855f7));
         searchInput_->setPlaceholderColor(themeManager.getColor("textSecondary").withAlpha(0.56f));
         searchInput_->setPadding(12.0f);
         searchInput_->setBorderRadius(0.0f);
-        searchInput_->setBorderWidth(2.0f);
+        searchInput_->setBorderWidth(1.0f);
     }
 
     itemHeight_ = BROWSER_LIST_ROW_H;
@@ -2677,19 +2689,10 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
                           selected ? themeManager.getColor("textPrimary")
                                    : item->isDirectory ? folderText : text);
 
-        // BPM column (right side, audio files only)
-        if (!item->isDirectory && item->detectedBpm > 0 &&
-            (activeQuickFilter_ == QuickFilter::Audio || activeQuickFilter_ == QuickFilter::All)) {
-            const float bpmW = 38.0f;
-            const float bpmX = itemRect.right() - bpmW - 12.0f;
-            std::string bpmStr = std::to_string(item->detectedBpm);
-            auto bpmSize = renderer.measureText(bpmStr, 10.0f);
-            renderer.drawText(bpmStr, {bpmX + (bpmW - bpmSize.width) * 0.5f,
-                                       std::round(renderer.calculateTextY(itemRect, 10.0f))},
-                              10.0f, muted);
-        }
+        // BPM stays in metadata (search/drag) but is not shown as a row
+        // column — owner direction: no number on the right of audio rows.
 
-        // Tag dots (between name and BPM)
+        // Tag dots (after name)
         if (!item->isDirectory) {
             const std::string key = mapKeyForPath(item->path);
             auto tagIt = tagsByPath_.find(key);

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1866,11 +1866,16 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         // zebra inside drawPlaylistGrid provides the only alternation).
         renderer.fillRect(trackBounds, AestraUI::NUIColor::black());
 
-        // Row separation is drawn once, softly, by TrackUIComponent::renderStatic.
-        // The extra 1px white line that used to stack on top of it produced the
-        // harsh horizontal grid the timeline was criticized for.
-
         track->renderStatic(renderer);
+
+        // Light separator strip filling the lane gap across the grid area
+        // (owner direction: the black gaps read as holes — lift them to a
+        // shade of white so rows stay legible). This is the only row
+        // separator; TrackUIComponent draws none.
+        const AestraUI::NUIRect gapRect(bounds.x + gridStartX, trackBounds.bottom(),
+                                        std::max(0.0f, trackWidth - gridStartX),
+                                        static_cast<float>(m_trackSpacing));
+        renderer.fillRect(gapRect, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.30f));
     }
 
     // Clear clip rect before drawing header/ruler (they should draw fully)

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -17,6 +17,7 @@
 
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
+#include "../AestraUI/Graphics/NUISVGParser.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraUI/Widgets/TrackColorPalette.h"
@@ -25,6 +26,7 @@
 #include <cmath>
 #include <chrono>
 #include <string_view>
+#include <unordered_map>
 
 namespace Aestra {
 namespace Audio {
@@ -56,6 +58,25 @@ void attachAndShowContextMenu(AestraUI::NUIComponent* owner,
     menu->showAt(position);
     root->repaint();
 }
+
+// Track control glyphs (mute/solo/record/monitor). Parsed once, rasterized
+// and cached per size+tint by NUISVGRenderer, so per-frame cost is a texture
+// draw. Geometry is authored on a 24x24 grid like the toolbar icons.
+const AestraUI::NUISVGDocument* trackControlIcon(const char* svg) {
+    static std::unordered_map<const char*, std::shared_ptr<AestraUI::NUISVGDocument>> docs;
+    auto& doc = docs[svg];
+    if (!doc) doc = AestraUI::NUISVGParser::parse(svg);
+    return doc.get();
+}
+
+constexpr const char* kMuteIconSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="#fff"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="#fff" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
+constexpr const char* kSoloIconSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="#fff"/></svg>)";
+constexpr const char* kRecordIconSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="#fff" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="#fff"/></svg>)";
+constexpr const char* kMonitorIconSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 12h3.2l2.2-5.5 3.4 11 2.2-5.5H21" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
 
 bool parseTrailingTrackNumber(const std::string& trackName, uint32_t& trackNumberOut) {
     const size_t numberPos = trackName.find_last_not_of("0123456789");
@@ -173,9 +194,9 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
         button->setCornerRadius(0.0f);
     };
 
-    // Create mute button
+    // Create mute button (glyph drawn by drawControlIcon; no text)
     m_muteButton = std::make_shared<AestraUI::NUIButton>();
-    m_muteButton->setText("M");
+    m_muteButton->setText("");
     configureFlatTrackButton(m_muteButton);
     m_muteButton->setToggleable(true);
     m_muteButton->setOnToggle([this](bool) { onMuteToggled(); });
@@ -184,7 +205,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
 
     // Create solo button
     m_soloButton = std::make_shared<AestraUI::NUIButton>();
-    m_soloButton->setText("S");
+    m_soloButton->setText("");
     configureFlatTrackButton(m_soloButton);
     m_soloButton->setToggleable(true);
     m_soloButton->setOnToggle([this](bool) { onSoloToggled(); });
@@ -193,7 +214,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
 
     // Create record button
     m_recordButton = std::make_shared<AestraUI::NUIButton>();
-    m_recordButton->setText("O");
+    m_recordButton->setText("");
     configureFlatTrackButton(m_recordButton);
     m_recordButton->setToggleable(true);
     m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
@@ -1196,12 +1217,8 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
     // Apply background
     renderer.fillRect(bounds, trackBgColor);
 
-    // Faint bottom row divider for cleaner track separation.
-    // Kept deliberately soft — this is the only per-row separator (the old
-    // second line in TrackManagerUI stacked on top of it made the harsh grid).
-    renderer.drawLine(AestraUI::NUIPoint(bounds.x, bounds.bottom() - 1.0f),
-                      AestraUI::NUIPoint(bounds.right(), bounds.bottom() - 1.0f), 1.0f,
-                      themeManager.getColor("borderSubtle").withAlpha(0.20f));
+    // Row separation is the light gap strip drawn by TrackManagerUI between
+    // lanes — no per-row line here, so separators never stack.
     AestraUI::NUIColor borderColor = themeManager.getColor("border");
     
     float controlAreaWidth = std::min(layout.trackControlsWidth, bounds.width);
@@ -1541,7 +1558,6 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         const auto muteActive = themeManager.getColor("warning").withAlpha(0.92f);
         const auto soloActive = themeManager.getColor("success").withAlpha(0.92f);
         const auto recordActive = themeManager.getColor("error").withAlpha(0.92f);
-        const float fontSize = 11.0f;
 
         const auto drawButtonShell = [&](const std::shared_ptr<AestraUI::NUIButton>& button,
                                          bool active,
@@ -1565,22 +1581,25 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             }
         };
 
-        const auto drawControlLabel = [&](const std::shared_ptr<AestraUI::NUIButton>& button,
-                                          const std::string& label,
-                                          AestraUI::NUIColor color,
-                                          bool active,
-                                          AestraUI::NUIColor activeColor) {
+        const auto drawControlIcon = [&](const std::shared_ptr<AestraUI::NUIButton>& button,
+                                         const char* iconSvg,
+                                         AestraUI::NUIColor color,
+                                         bool active,
+                                         AestraUI::NUIColor activeColor) {
             if (!button) {
                 return;
             }
             drawButtonShell(button, active, activeColor);
+            const auto* doc = trackControlIcon(iconSvg);
+            if (!doc) {
+                return;
+            }
             const auto rect = button->getBounds();
-            const auto textSize = renderer.measureText(label, fontSize);
-            renderer.drawText(label,
-                              AestraUI::NUIPoint(rect.x + (rect.width - textSize.width) * 0.5f,
-                                                 std::round(renderer.calculateTextY(rect, fontSize))),
-                              fontSize,
-                              color);
+            const float iconSize = std::round(std::min(rect.width, rect.height) - 6.0f);
+            const AestraUI::NUIRect iconRect(std::round(rect.x + (rect.width - iconSize) * 0.5f),
+                                             std::round(rect.y + (rect.height - iconSize) * 0.5f),
+                                             iconSize, iconSize);
+            AestraUI::NUISVGRenderer::render(renderer, *doc, iconRect, color);
         };
 
         // Draw volume knob (replaces route button)
@@ -1630,13 +1649,13 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             }
         }
 
-        drawControlLabel(m_muteButton, "M", m_channel->isMuted() ? muteActive : textIdle,
-                         m_channel->isMuted(), muteActive);
-        drawControlLabel(m_soloButton, "S", m_channel->isSoloed() ? soloActive : textIdle,
-                         m_channel->isSoloed(), soloActive);
-        drawControlLabel(m_recordButton, m_channel->isMonitoringEnabled() ? "I" : "R",
-                         m_channel->isArmed() ? recordActive : textIdle,
-                         m_channel->isArmed(), recordActive);
+        drawControlIcon(m_muteButton, kMuteIconSvg, m_channel->isMuted() ? muteActive : textIdle,
+                        m_channel->isMuted(), muteActive);
+        drawControlIcon(m_soloButton, kSoloIconSvg, m_channel->isSoloed() ? soloActive : textIdle,
+                        m_channel->isSoloed(), soloActive);
+        drawControlIcon(m_recordButton, m_channel->isMonitoringEnabled() ? kMonitorIconSvg : kRecordIconSvg,
+                        m_channel->isArmed() ? recordActive : textIdle,
+                        m_channel->isArmed(), recordActive);
     }
 
     // Track number marker (left of name): fixed white — no dynamic dimming

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -500,10 +500,10 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
          }
 
         if (isPrimaryTransport) {
-            if (!isRecording && !isActive && !isHovered) {
-                currentBg = themeManager.getColor("buttonBgHover").withAlpha(0.64f);
-                currentBorder = themeManager.getColor("border").withAlpha(0.38f);
-            } else if (isActive && !isRecording) {
+            // No idle backing plate: primaries sit flush on the group shell
+            // exactly like the time display (owner direction). State still
+            // brings the tinted plate in on hover/active/record.
+            if (isActive && !isRecording) {
                 currentBg = themeManager.getColor("accentPrimary").withAlpha(0.22f);
                 currentBorder = themeManager.getColor("accentPrimary").withAlpha(0.46f);
             }
@@ -511,9 +511,9 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
                 iconColor = themeManager.getColor("textPrimary").withAlpha(isActive || isHovered ? 1.0f : 0.94f);
             }
         }
-        
+
         // Draw Button Background
-        if (isHovered || isActive || isRecording || isPrimaryTransport) {
+        if (isHovered || isActive || isRecording) {
             renderer.fillRoundedRect(buttonRect, 6.0f, currentBg);
             if (currentBorder.a > 0.0f) {
                 renderer.strokeRoundedRect(buttonRect, 6.0f, 1.0f, currentBorder);


### PR DESCRIPTION
## Summary
Six owner-directed fixes from the Timeline screenshot review:

1. **Lane separators**: the 3px black gaps between track lanes now render as a light strip (white @0.30) across the grid area. The vestigial faint per-row line in `TrackUIComponent` is removed so there is exactly one separator (the old harsh-grid regression came from two stacked lines — this keeps a single source).
2. **Search field border**: quieted from `textSecondary`@0.35 at 2px to the `border` token at 1px. Focus state (purple) unchanged.
3. **Search bar anchoring**: the input's bounds are now synced from the computed layout every render (with a diff guard so idle frames stay clean). Previously only `onResize` updated them, so a panel *move* left the search bar at its old absolute position — the "disconnected search bar" effect.
4. **Search bar flush**: full panel width, no 2px float inset; 1px reserved for the bottom divider.
5. **Audio row BPM column removed**: no number on the right of wav/audio rows. BPM detection itself is kept (search/metadata).
6. **Transport primaries flush**: play/stop/record no longer draw an idle backing plate + border — they sit on the group shell exactly like the time display. Hover/active/recording plates unchanged.
7. **M/S/R → SVG icons**: letter buttons replaced with tinted SVG glyphs (mute speaker-x, solo headphones, record ring, input-monitor wave) rendered through the existing ThorVG raster cache (per size+tint, so per-frame cost is one texture draw). Pill shells, state colors, tooltips, and hit areas unchanged.

## Why
Owner UI pass 2026-07-05: lane gaps read as holes, search bar floated and detached on panel moves, BPM column unwanted, transport primaries not flush with the timer, M/S/R letters read as debug UI.

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest -L ui`: 4/5 pass; the failure is `NUITextInputLayoutTest`, pre-existing on clean develop (verified by stash-baseline in the #408 session; headless CI never runs it).
- Visual verification: needs owner screenshot with fresh `build-linux/bin/Aestra`. Separator strength (white @0.30) and icon shapes are the two taste knobs to iterate on.

## Docs updated?
No.

## Risk/rollback notes
- UI-only; no DSP, serialization, or layout-model changes. Button hit areas and callbacks untouched.
- The per-render search bounds sync has a diff guard, so idle frame elision (#402 semantics) is not defeated.
- Rollback = revert single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Breaking/UI behavior change: track control buttons now use SVG icons instead of letter labels for mute/solo/record/monitor, and the audio row BPM column was removed from wav/audio rows.
- Timeline lane separators were cleaned up: the redundant per-row divider was removed, and the track manager now draws a lighter full-width gap strip between lanes for clearer separation.
- Browser search UI was tightened up: the search field border now uses a 1px theme border, the bar stays synced to computed panel bounds during layout changes, and it now sits flush to the panel with only 1px reserved for the bottom divider.
- Transport primary controls were restyled to sit flush on the group shell without an idle backing plate or border, while keeping hover/active/recording behavior intact.
- The existing ThorVG raster cache is now used to render the new track control icons efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->