### PR TITLE
feat(ui): fractal grid (self-similar at any zoom) + flat active states

### DIFF
--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -1290,19 +1290,10 @@ void NUITextInput::triggerEscapeKey()
 void NUITextInput::drawEnhancedBackground(NUIRenderer& renderer)
 {
     NUIRect bounds = getBounds();
-    
-    // Focus glow effect
-    if (isFocused())
-    {
-        NUIRect glowRect = bounds;
-        glowRect.x -= 2;
-        glowRect.y -= 2;
-        glowRect.width += 4;
-        glowRect.height += 4;
-        renderer.fillRoundedRect(glowRect, borderRadius_ + 2,
-            focusedBorderColor_.withAlpha(0.3f));
-    }
-    
+
+    // No focus glow halo (owner direction: flat focus state) — the focused
+    // border color below is the focus indicator.
+
     // Inner shadow effect
     NUIRect innerShadowRect = bounds;
     innerShadowRect.x += 1;

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -152,7 +152,6 @@ void UIMixerButtonRow::onRender(NUIRenderer& renderer)
             renderer.drawGlow(visualRect, BTN_RADIUS, 0.6f, activeBg.withAlpha(0.45f));
         }
 
-        renderer.drawShadow(visualRect, 0.0f, 4.0f, 12.0f, NUIColor(0, 0, 0, 0.12f));
         renderer.fillRoundedRect(visualRect, BTN_RADIUS, bg);
         renderer.strokeRoundedRect(visualRect, BTN_RADIUS, 1.0f, border);
         renderer.strokeRoundedRect({visualRect.x + 1.0f, visualRect.y + 1.0f, visualRect.width - 2.0f, visualRect.height - 2.0f},

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1699,40 +1699,69 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     // (the old "frost" was the double-linearization amplifying it).
     const float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
 
-    // Ruler-synced bar stride, shared by the zebra and the grid lines below.
-    // Mirror TrackManagerUI::renderTimeRuler exactly so both always align
-    // with labeled bars (e.g., 1/9/17/25 at lower zoom).
+    // ==== FRACTAL GRID (owner direction: self-similar at every zoom) ====
+    // Every level of the hierarchy — half-beats, beats, bars, bars×2^k —
+    // fades purely as a function of its own pixel spacing. Zooming out
+    // dissolves the finest visible level while the next-coarser level takes
+    // its place, so the grid never pops and never collapses into a barcode;
+    // the same pattern just re-emerges one scale up, indefinitely.
+    constexpr float kLevelHidePx = 14.0f; // spacing below this: level invisible
+    constexpr float kLevelFullPx = 28.0f; // spacing at/above this: fully faded in
+    const auto levelFade = [](float spacingPx) {
+        return std::clamp((spacingPx - kLevelHidePx) / (kLevelFullPx - kLevelHidePx), 0.0f, 1.0f);
+    };
+    // One brightness law for every line: a newly-visible level starts at the
+    // sub-line strength and grows toward major strength as it widens.
+    const auto lineAlpha = [&](float spacingPx) {
+        const float strength =
+            0.028f + (0.105f - 0.028f) * std::clamp((spacingPx - kLevelFullPx) / (kLevelFullPx * 3.0f), 0.0f, 1.0f);
+        return strength * levelFade(spacingPx);
+    };
+
     const int beatsPerBar = std::max(1, m_beatsPerBar);
+    // Coarsest power-of-two bar stride with blocks >= kLevelFullPx, mirroring
+    // TrackManagerUI::renderTimeRuler so levels align with labeled bars.
     int barStride = 1;
-    const float minLabelSpacingPx = 28.0f; // matches TrackManagerUI::renderTimeRuler
-    while ((pixelsPerBar * static_cast<float>(barStride)) < minLabelSpacingPx && barStride < 128) {
+    while ((pixelsPerBar * static_cast<float>(barStride)) < kLevelFullPx && barStride < 128) {
         barStride *= 2;
     }
 
-    // Zebra alternates in stride-sized blocks, not single bars, so the
-    // light/dark rhythm holds a constant ~28-56px width at any zoom instead
-    // of collapsing into a dense barcode when bars get narrow.
+    // Zebra: crossfade two adjacent block levels so the coarse alternation
+    // continuously becomes the fine alternation while zooming (and vice
+    // versa) — the big strips turn into the small strips, never snapping.
     {
-        const float pixelsPerBlock = pixelsPerBar * static_cast<float>(barStride);
-        const int startBlock = static_cast<int>(m_timelineScrollOffset / pixelsPerBlock);
-        const int endBlock = static_cast<int>((m_timelineScrollOffset + gridWidth) / pixelsPerBlock) + 1;
-        for (int block = startBlock; block <= endBlock; ++block) {
-            if (block % 2 == 0)
-                continue;
-            float rectX = gridStartX + (block * pixelsPerBlock) - m_timelineScrollOffset;
-            float rectW = pixelsPerBlock;
-            if (rectX < gridStartX) {
-                rectW -= (gridStartX - rectX);
-                rectX = gridStartX;
+        constexpr float kZebraAlpha = 0.030f;
+        const auto drawZebraLevel = [&](int strideBars, float alpha) {
+            if (alpha <= 0.001f) {
+                return;
             }
-            if (rectX + rectW > gridEndX) {
-                rectW = gridEndX - rectX;
+            const float blockW = pixelsPerBar * static_cast<float>(strideBars);
+            const int startBlock = static_cast<int>(m_timelineScrollOffset / blockW);
+            const int endBlock = static_cast<int>((m_timelineScrollOffset + gridWidth) / blockW) + 1;
+            for (int block = startBlock; block <= endBlock; ++block) {
+                if (block % 2 == 0)
+                    continue;
+                float rectX = gridStartX + (block * blockW) - m_timelineScrollOffset;
+                float rectW = blockW;
+                if (rectX < gridStartX) {
+                    rectW -= (gridStartX - rectX);
+                    rectX = gridStartX;
+                }
+                if (rectX + rectW > gridEndX) {
+                    rectW = gridEndX - rectX;
+                }
+                if (rectW > 0.0f) {
+                    renderer.fillRect(AestraUI::NUIRect(rectX, bounds.y, rectW, bounds.height),
+                                      AestraUI::NUIColor(1.0f, 1.0f, 1.0f, alpha));
+                }
             }
-            if (rectW > 0.0f) {
-                renderer.fillRect(AestraUI::NUIRect(rectX, bounds.y, rectW, bounds.height),
-                                  AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.030f));
-            }
-        }
+        };
+        // fineT: 1 when the fine level is comfortably wide (56px blocks),
+        // 0 just as it would shrink past kLevelFullPx and hand off upward.
+        const float pixelsPerBlock = pixelsPerBar * static_cast<float>(barStride); // in [28, 56)
+        const float fineT = std::clamp((pixelsPerBlock - kLevelFullPx) / kLevelFullPx, 0.0f, 1.0f);
+        drawZebraLevel(barStride, kZebraAlpha * fineT);
+        drawZebraLevel(barStride * 2, kZebraAlpha * (1.0f - fineT));
     }
 
     const double startBeat = m_timelineScrollOffset / m_pixelsPerBeat;
@@ -1740,51 +1769,54 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     const int firstVisibleBar = static_cast<int>(std::floor(startBeat / static_cast<double>(beatsPerBar))) - 1;
     const int lastVisibleBar = static_cast<int>(std::ceil(endBeat / static_cast<double>(beatsPerBar))) + 1;
 
-    // Inverted grid (owner direction): near-black lanes with grey lines, so the
-    // grid reads as light structure on dark instead of dark cuts on grey.
-    const AestraUI::NUIColor barLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.105f);
-    const AestraUI::NUIColor beatLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.055f);
-    const AestraUI::NUIColor subBeatLineColor = AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.028f);
-    const bool drawBeatSubdivisions = (m_pixelsPerBeat >= 10.0f);
-    const bool drawFurtherSubdivisions = (m_pixelsPerBeat >= 54.0f);
+    // Inverted grid (owner direction): near-black lanes with grey lines, so
+    // the grid reads as light structure on dark. Line brightness comes from
+    // lineAlpha() so every level obeys the same fractal fade law: a bar line
+    // whose own level (largest power of two dividing its index) is too dense
+    // simply fades out instead of stacking into a barcode.
+    const auto drawGridLine = [&](float x, float alpha) {
+        renderer.drawLine(AestraUI::NUIPoint(x, bounds.y), AestraUI::NUIPoint(x, bounds.y + bounds.height), 1.0f,
+                          AestraUI::NUIColor(1.0f, 1.0f, 1.0f, alpha));
+    };
+    const float beatLineAlpha = lineAlpha(m_pixelsPerBeat);
+    const float halfBeatLineAlpha = lineAlpha(m_pixelsPerBeat * 0.5f);
 
     for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
         const float barX = gridStartX + (bar * pixelsPerBar) - m_timelineScrollOffset;
         if (barX >= gridStartX && barX <= gridEndX) {
-            const bool isPrimary = (barStride > 0) && (bar % barStride == 0);
-            renderer.drawLine(
-                AestraUI::NUIPoint(barX, bounds.y),
-                AestraUI::NUIPoint(barX, bounds.y + bounds.height),
-                isPrimary ? 1.05f : 1.0f,
-                isPrimary ? barLineColor : subBeatLineColor
-            );
-        }
-
-        // Unified subdivision visibility: beats at >=10 px, finer halves at >=30 px.
-        if (drawBeatSubdivisions) {
-            for (int beat = 1; beat < beatsPerBar; ++beat) {
-                const float beatX = barX + (beat * m_pixelsPerBeat);
-                if (beatX < gridStartX || beatX > gridEndX) continue;
-                renderer.drawLine(
-                    AestraUI::NUIPoint(beatX, bounds.y),
-                    AestraUI::NUIPoint(beatX, bounds.y + bounds.height),
-                    1.0f,
-                    beatLineColor
-                );
+            // Level = largest power of two dividing the bar index (bar 0 is
+            // effectively the coarsest — the timeline origin never fades).
+            int level = 20;
+            if (bar != 0) {
+                level = 0;
+                int b = std::abs(bar);
+                while ((b & 1) == 0 && level < 20) {
+                    b >>= 1;
+                    ++level;
+                }
+            }
+            const float levelSpacing = pixelsPerBar * static_cast<float>(1u << level);
+            const float alpha = lineAlpha(levelSpacing);
+            if (alpha > 0.001f) {
+                drawGridLine(barX, alpha);
             }
         }
 
-        if (drawFurtherSubdivisions) {
+        // Beats and half-beats are just the next levels down the same law.
+        if (beatLineAlpha > 0.001f) {
+            for (int beat = 1; beat < beatsPerBar; ++beat) {
+                const float beatX = barX + (beat * m_pixelsPerBeat);
+                if (beatX < gridStartX || beatX > gridEndX) continue;
+                drawGridLine(beatX, beatLineAlpha);
+            }
+        }
+
+        if (halfBeatLineAlpha > 0.001f) {
             const float halfBeatOffset = m_pixelsPerBeat * 0.5f;
             for (int beat = 0; beat < beatsPerBar; ++beat) {
                 const float subBeatX = barX + (beat * m_pixelsPerBeat) + halfBeatOffset;
                 if (subBeatX < gridStartX || subBeatX > gridEndX) continue;
-                renderer.drawLine(
-                    AestraUI::NUIPoint(subBeatX, bounds.y),
-                    AestraUI::NUIPoint(subBeatX, bounds.y + bounds.height),
-                    1.0f,
-                    subBeatLineColor
-                );
+                drawGridLine(subBeatX, halfBeatLineAlpha);
             }
         }
     }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1698,14 +1698,29 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     // gamma-correct cache pipeline this renders at its authored subtlety
     // (the old "frost" was the double-linearization amplifying it).
     const float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
+
+    // Ruler-synced bar stride, shared by the zebra and the grid lines below.
+    // Mirror TrackManagerUI::renderTimeRuler exactly so both always align
+    // with labeled bars (e.g., 1/9/17/25 at lower zoom).
+    const int beatsPerBar = std::max(1, m_beatsPerBar);
+    int barStride = 1;
+    const float minLabelSpacingPx = 28.0f; // matches TrackManagerUI::renderTimeRuler
+    while ((pixelsPerBar * static_cast<float>(barStride)) < minLabelSpacingPx && barStride < 128) {
+        barStride *= 2;
+    }
+
+    // Zebra alternates in stride-sized blocks, not single bars, so the
+    // light/dark rhythm holds a constant ~28-56px width at any zoom instead
+    // of collapsing into a dense barcode when bars get narrow.
     {
-        const int startBar = static_cast<int>(m_timelineScrollOffset / pixelsPerBar);
-        const int endBar = static_cast<int>((m_timelineScrollOffset + gridWidth) / pixelsPerBar) + 1;
-        for (int bar = startBar; bar <= endBar; ++bar) {
-            if (bar % 2 == 0)
+        const float pixelsPerBlock = pixelsPerBar * static_cast<float>(barStride);
+        const int startBlock = static_cast<int>(m_timelineScrollOffset / pixelsPerBlock);
+        const int endBlock = static_cast<int>((m_timelineScrollOffset + gridWidth) / pixelsPerBlock) + 1;
+        for (int block = startBlock; block <= endBlock; ++block) {
+            if (block % 2 == 0)
                 continue;
-            float rectX = gridStartX + (bar * pixelsPerBar) - m_timelineScrollOffset;
-            float rectW = pixelsPerBar;
+            float rectX = gridStartX + (block * pixelsPerBlock) - m_timelineScrollOffset;
+            float rectW = pixelsPerBlock;
             if (rectX < gridStartX) {
                 rectW -= (gridStartX - rectX);
                 rectX = gridStartX;
@@ -1718,16 +1733,6 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
                                   AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.030f));
             }
         }
-    }
-
-    // 2. GRID LINES SYNCED TO RULER LABEL INTERVAL
-    // Mirror the ruler's barStride logic exactly so major grid lines always align
-    // with labeled bars (e.g., 1/9/17/25 at lower zoom).
-    const int beatsPerBar = std::max(1, m_beatsPerBar);
-    int barStride = 1;
-    const float minLabelSpacingPx = 28.0f; // matches TrackManagerUI::renderTimeRuler
-    while ((pixelsPerBar * static_cast<float>(barStride)) < minLabelSpacingPx && barStride < 128) {
-        barStride *= 2;
     }
 
     const double startBeat = m_timelineScrollOffset / m_pixelsPerBeat;

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1698,6 +1698,9 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     // gamma-correct cache pipeline this renders at its authored subtlety
     // (the old "frost" was the double-linearization amplifying it).
     const float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
+    if (pixelsPerBar <= 0.0f) {
+        return; // degenerate zoom — no grid, and guards the divisions below
+    }
 
     // ==== FRACTAL GRID (owner direction: self-similar at every zoom) ====
     // Every level of the hierarchy — half-beats, beats, bars, bars×2^k —
@@ -1719,10 +1722,14 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     };
 
     const int beatsPerBar = std::max(1, m_beatsPerBar);
-    // Coarsest power-of-two bar stride with blocks >= kLevelFullPx, mirroring
-    // TrackManagerUI::renderTimeRuler so levels align with labeled bars.
+    // Coarsest power-of-two bar stride with blocks >= kLevelFullPx. Labeled
+    // ruler bars are always a multiple of this stride (same power-of-two
+    // ladder as TrackManagerUI::renderTimeRuler). The cap is not a zoom
+    // assumption — it only bounds the loop; 2^20 bars per block is far past
+    // any zoom the timeline can reach, so the zebra keeps handing off
+    // upward instead of densifying at extreme zoom-out.
     int barStride = 1;
-    while ((pixelsPerBar * static_cast<float>(barStride)) < kLevelFullPx && barStride < 128) {
+    while ((pixelsPerBar * static_cast<float>(barStride)) < kLevelFullPx && barStride < (1 << 20)) {
         barStride *= 2;
     }
 

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -541,19 +541,8 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
         bool isPlaying = (m_state == TransportState::Playing);
         auto currentIcon = isPlaying ? m_pauseIcon : m_playIcon;
         renderGlassButton(m_playButton, currentIcon, isPlaying, false, true);
-
-        // Breathing glow when playing — subtle pulse so user can see transport is active
-        if (isPlaying) {
-            auto now = std::chrono::steady_clock::now();
-            float timeSec = std::chrono::duration<float>(now.time_since_epoch()).count();
-            float pulse = (std::sin(timeSec * 3.0f) * 0.5f + 0.5f); // 0..1 oscillation ~0.5Hz
-            AestraUI::NUIRect playRect = m_playButton->getBounds();
-            renderer.drawShadow(
-                {playRect.x, playRect.y, playRect.width, playRect.height},
-                4.0f, 1.0f, 6.0f,
-                themeManager.getColor("accentPrimary").withAlpha(0.08f + pulse * 0.06f)
-            );
-        }
+        // No breathing shadow while playing (owner direction: flat active
+        // state) — the accent plate from renderGlassButton is the indicator.
     }
 
     // Stop


### PR DESCRIPTION
## Summary
Two owner-directed items, evolved over two commits:

1. **Fractal grid** (supersedes the first commit's discrete stride-snap zebra): every grid level — half-beats, beats, bars, bars×2^k — fades purely as a function of its own pixel spacing (invisible < 14px, fully in at 28px, brightness growing from sub-line to major strength as spacing widens). The zebra crossfades two adjacent block levels so the coarse alternation continuously *becomes* the fine alternation while zooming. Result: the grid is self-similar at every zoom — no pops, no barcode collapse, the pattern re-emerges one scale up indefinitely. Levels stay aligned with labeled ruler bars by construction.
2. **Flat active states** — three drop shadows removed: `NUITextInput` focus glow halo (search bar), play-button breathing pulse while playing (also removes a continuous animation during playback), and the always-on shadow under mixer M/S/R pills.

## Why
Owner: grid still went "barcode-y" when zoomed far out — requested a fractal/self-similar scheme where "the big strips become the small strips"; plus drop-shadow removals on search-active, play-active, and mixer M/S/R.

## Testing performed
- Full local UI build (`build-linux`, Release): clean, both commits.
- `ctest -L ui` (excluding known pre-existing `NUITextInputLayoutTest`): 4/4 pass.
- Continuity argument for the zebra handoff: at the stride boundary the fine level exits at alpha 0 exactly as the coarser level reaches full alpha, in both zoom directions; overlapping regions sum to a constant.
- Visual verification: owner screenshot sweep across zoom levels pending.

## Docs updated?
No.

## Risk/rollback notes
- UI-only, confined to `drawPlaylistGrid` + the three shadow sites. Grid geometry (positions of lines) unchanged — only visibility/alpha logic.
- `NUITextInput` glow removal is framework-wide (all inputs lose the halo), consistent with the flat direction.
- Rollback = revert the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **UI styling:** Removed multiple drop-shadow/glow effects to keep “active” states flatter—`NUITextInput` focus halo, the Play/Pause button’s playing-state breathing shadow, and the mixer button/M-S-R pill shadow.
- **Timeline grid zebra:** Reworked zebra striping to advance in **ruler-synced stride blocks** (zoom-dependent power-of-two blocks) instead of flipping every single bar, with smooth crossfades between adjacent stripe levels so the rhythm stays stable while zooming.
- **Grid line visibility:** Updated bar/beat/half-beat and sub-division line rendering to use the same stride-based “fractal” fade logic (zoom-dependent alpha) rather than hard visibility thresholds/major-vs-minor modulus checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->