### PR TITLE
style(ui): neutralize tinted surfaces in plugin editors

### DIFF
--- a/AestraUI/Widgets/AestraCompEditor.cpp
+++ b/AestraUI/Widgets/AestraCompEditor.cpp
@@ -16,8 +16,8 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 
-NUIColor insetBg() { return NUIColor(0.018f, 0.020f, 0.024f, 0.960f); }
-NUIColor curveBg() { return NUIColor(0.035f, 0.037f, 0.042f, 1.0f); }
+NUIColor insetBg() { return NUIColor(0.02f, 0.02f, 0.02f, 0.960f); }
+NUIColor curveBg() { return NUIColor(0.037f, 0.037f, 0.037f, 1.0f); }
 NUIColor amber() { return NUIColor(0.88f, 0.63f, 0.14f, 1.0f); }
 NUIColor purple() { return NUIColor(0.50f, 0.35f, 0.94f, 1.0f); }
 NUIColor dimText() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
@@ -266,7 +266,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     // Zone backgrounds — curve gets its own bg, stats + modes get a slightly darker treatment
     renderer.fillRoundedRect({curveLeft - 4.0f, b.y, curveW + 8.0f, b.height}, 6.0f, curveBg());
     renderer.fillRoundedRect({statsX - 4.0f, b.y, kStatsW + kModesW + kDividerW + kRightMargin + 8.0f, b.height},
-                             6.0f, NUIColor(0.014f, 0.014f, 0.018f, 0.92f));
+                             6.0f, NUIColor(0.014f, 0.014f, 0.014f, 0.92f));
 
     renderer.strokeRoundedRect(b, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.05f));
     // Subtle top highlight
@@ -424,7 +424,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
             renderer.drawTextCentered(pillLabels[i], r, 9.5f, NUIColor(1, 1, 1, 0.98f));
         } else {
             // Body — deep dark inset
-            renderer.fillRoundedRect(r, 5.0f, NUIColor(0.018f, 0.018f, 0.024f, 0.90f));
+            renderer.fillRoundedRect(r, 5.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.90f));
             // Top inner shadow
             renderer.drawLine({r.x + 5.0f, r.y + 1.0f}, {r.x + r.width - 5.0f, r.y + 1.0f},
                               0.5f, NUIColor(0, 0, 0, 0.30f));
@@ -443,7 +443,7 @@ void AestraCompEditor::drawMeters(NUIRenderer& renderer, NUIColor accent) {
 
     auto drawMeter = [&](float x, const char* label, float norm, NUIColor color) {
         const NUIRect meterBounds(x, b.y, thirdW, b.height);
-        renderer.fillRoundedRect(meterBounds, 5.0f, NUIColor(0.008f, 0.008f, 0.012f, 1.0f));
+        renderer.fillRoundedRect(meterBounds, 5.0f, NUIColor(0.008f, 0.008f, 0.008f, 1.0f));
         renderer.strokeRoundedRect(meterBounds, 5.0f, 1.0f, NUIColor(1, 1, 1, 0.055f));
 
         // Fill
@@ -562,8 +562,8 @@ void AestraCompEditor::drawUtilityButtons(NUIRenderer& renderer, NUIColor accent
             renderer.strokeRoundedRect(btn.bounds, 5.0f, 1.0f, activeAccent.withAlpha(0.80f));
             renderer.drawTextCentered(btn.label, btn.bounds, 9.0f, NUIColor(1, 1, 1, 0.95f));
         } else {
-            const NUIColor bg = btn.hov ? NUIColor(0.04f, 0.04f, 0.048f, 0.90f)
-                                        : NUIColor(0.022f, 0.022f, 0.028f, 0.90f);
+            const NUIColor bg = btn.hov ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
+                                        : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
             renderer.fillRoundedRect(btn.bounds, 5.0f, bg);
             renderer.drawLine({btn.bounds.x + 5.0f, btn.bounds.y + 1.0f},
                               {btn.bounds.x + btn.bounds.width - 5.0f, btn.bounds.y + 1.0f},

--- a/AestraUI/Widgets/AestraDelayEditor.cpp
+++ b/AestraUI/Widgets/AestraDelayEditor.cpp
@@ -20,7 +20,7 @@ NUIColor cyanAccent() {
     return NUIColor(0.0f, 0.90f, 0.80f, 1.0f);
 }
 NUIColor cardBg() {
-    return NUIColor(0.085f, 0.080f, 0.115f, 0.95f);
+    return NUIColor(0.084f, 0.084f, 0.084f, 0.95f);
 }
 NUIRect offsetRect(const NUIRect& r, float dx, float dy) {
     return NUIRect(r.x + dx, r.y + dy, r.width, r.height);
@@ -216,7 +216,7 @@ void AestraDelayEditor::drawPillSwitches(NUIRenderer& renderer, float wx, float 
         NUIRect left = offsetRect(leftLocal, wx, wy);
         NUIRect right = offsetRect(rightLocal, wx, wy);
         const NUIRect outer(left.x, left.y, left.width + right.width, left.height);
-        renderer.fillRoundedRect(outer, 10.0f, NUIColor(0.032f, 0.030f, 0.044f, 0.96f));
+        renderer.fillRoundedRect(outer, 10.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
         renderer.strokeRoundedRect(outer, 10.0f, 1.0f, accent().withAlpha(0.45f));
         auto seg = [&](const NUIRect& rect, const char* label, bool active) {
             renderer.fillRoundedRect(rect, 9.0f, active ? activeColor : NUIColor(0, 0, 0, 0));
@@ -251,7 +251,7 @@ void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy)
             renderer.fillRoundedRect(r, 6.0f, accent());
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textPrimary"));
         } else {
-            NUIColor fill = hovered ? NUIColor(0.10f, 0.095f, 0.14f, 0.92f) : NUIColor(0.07f, 0.065f, 0.09f, 0.90f);
+            NUIColor fill = hovered ? NUIColor(0.099f, 0.099f, 0.099f, 0.92f) : NUIColor(0.068f, 0.068f, 0.068f, 0.90f);
             renderer.fillRoundedRect(r, 6.0f, fill);
             renderer.strokeRoundedRect(r, 6.0f, 1.0f, accent().withAlpha(0.32f));
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textSecondary").withAlpha(0.88f));
@@ -310,7 +310,7 @@ void AestraDelayEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, fl
     const float cy = knobRect.center().y;
     const float r = kKnobSize * 0.40f;
     renderer.fillCircle({cx, cy}, r + 7.0f, knobAccent.withAlpha(0.07f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.043f, 0.060f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, knobAccent.withAlpha(0.32f));
 
     const float sa = kPi * 0.75f;
@@ -337,7 +337,7 @@ void AestraDelayEditor::drawMixSlider(NUIRenderer& renderer, float wx, float wy)
     const float mix = m_instance ? m_instance->getParameter(Delay::kMix) : 0.0f;
     NUIRect mixRect = offsetRect(m_mixSliderRect, wx, wy);
     const NUIRect track(mixRect.x + 38.0f, mixRect.y + 12.0f, mixRect.width - 78.0f, 8.0f);
-    renderer.fillRoundedRect(mixRect, 10.0f, NUIColor(0.07f, 0.065f, 0.09f, 0.92f));
+    renderer.fillRoundedRect(mixRect, 10.0f, NUIColor(0.068f, 0.068f, 0.068f, 0.92f));
     renderer.strokeRoundedRect(mixRect, 10.0f, 1.0f, accent().withAlpha(0.35f));
     renderer.drawText("Mix", {mixRect.x + 14.0f, mixRect.y + 10.0f}, 10.5f,
                       theme.getColor("textPrimary").withAlpha(0.95f));

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -18,8 +18,8 @@ constexpr float kWheelEnd = kWheelSweep * 0.5f;    // +135°
 constexpr int kNumTicks = 25; // -12 to +12 inclusive
 
 NUIColor accent() { return NUIColor(0.55f, 0.40f, 0.92f, 1.0f); }
-NUIColor panelSurface() { return NUIColor(0.026f, 0.026f, 0.038f, 0.96f); }
-NUIColor insetSurface() { return NUIColor(0.038f, 0.036f, 0.052f, 0.96f); }
+NUIColor panelSurface() { return NUIColor(0.027f, 0.027f, 0.027f, 0.96f); }
+NUIColor insetSurface() { return NUIColor(0.038f, 0.038f, 0.038f, 0.96f); }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle,
              float thickness, NUIColor color) {
@@ -96,11 +96,11 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer, float cx, float cy
     const float angle = kWheelStart + (semitones + 12.0f) / 24.0f * kWheelSweep;
     const float r = m_wheelRadius;
 
-    renderer.fillCircle({cx, cy}, r + 15.0f, NUIColor(0.010f, 0.011f, 0.018f, 0.44f));
+    renderer.fillCircle({cx, cy}, r + 15.0f, NUIColor(0.011f, 0.011f, 0.011f, 0.44f));
     renderer.fillCircle({cx, cy}, r + 9.0f, insetSurface());
     renderer.strokeCircle({cx, cy}, r + 9.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
 
-    drawArc(renderer, {cx, cy}, r - 2.0f, kWheelStart, kWheelEnd, 4.0f, NUIColor(0.20f, 0.19f, 0.29f, 1.0f));
+    drawArc(renderer, {cx, cy}, r - 2.0f, kWheelStart, kWheelEnd, 4.0f, NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
     drawArc(renderer, {cx, cy}, r - 2.0f, kWheelStart, angle, 4.0f, accent().withAlpha(0.92f));
 
     // Tick marks
@@ -141,7 +141,7 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer, float cx, float cy
     // Center well — Aestra deep recessed knob body
     const float wellR = r * 0.30f;
     renderer.fillCircle({cx, cy}, wellR + 5.0f, accent().withAlpha(0.08f));
-    renderer.fillCircle({cx, cy}, wellR, NUIColor(0.045f, 0.043f, 0.060f, 0.96f));
+    renderer.fillCircle({cx, cy}, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
     renderer.strokeCircle({cx, cy}, wellR, 1.2f, accent().withAlpha(0.36f));
 
     // Value text in center well

--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -23,7 +23,7 @@ constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accent() { return NUIColor(0.55f, 0.40f, 0.92f, 1.0f); }
 NUIColor accentSoft() { return NUIColor(0.55f, 0.40f, 0.92f, 0.35f); }
-NUIColor graphBg() { return NUIColor(0.045f, 0.043f, 0.064f, 0.96f); }
+NUIColor graphBg() { return NUIColor(0.045f, 0.045f, 0.045f, 0.96f); }
 
 std::shared_ptr<NUIIcon> makeSvgIcon(const char* svg) {
     return std::make_shared<NUIIcon>(svg);
@@ -1398,7 +1398,7 @@ void AestraEQEditor::drawOutputGainPill(NUIRenderer& renderer) {
     const NUIColor outline =
         m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.44f) : NUIColor(1, 1, 1, 0.14f);
     const NUIColor fill = m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.11f)
-                                                                      : NUIColor(0.035f, 0.034f, 0.048f, 0.88f);
+                                                                      : NUIColor(0.035f, 0.035f, 0.035f, 0.88f);
     renderer.fillRoundedRect(m_outputGainRect, 7.0f, fill);
     renderer.strokeRoundedRect(m_outputGainRect, 7.0f, 1.0f, outline);
     std::string gainText = formatGain(gain);
@@ -1417,7 +1417,7 @@ void AestraEQEditor::drawPolarityPill(NUIRenderer& renderer) {
     const bool inverted = polarityInverted();
     const NUIColor base = inverted ? NUIColor(0.95f, 0.68f, 0.32f, 1.0f) : accent();
     const NUIColor fill = inverted ? base.withAlpha(m_polarityHovered ? 0.23f : 0.16f)
-                                   : NUIColor(0.035f, 0.034f, 0.048f, m_polarityHovered ? 0.96f : 0.88f);
+                                   : NUIColor(0.035f, 0.035f, 0.035f, m_polarityHovered ? 0.96f : 0.88f);
     renderer.fillRoundedRect(m_polarityRect, 7.0f, fill);
     renderer.strokeRoundedRect(m_polarityRect, 7.0f, 1.0f,
                                inverted ? base.withAlpha(m_polarityHovered ? 0.56f : 0.42f)
@@ -1435,7 +1435,7 @@ void AestraEQEditor::drawComparePills(NUIRenderer& renderer) {
         const NUIColor base = active ? accent() : NUIColor(1, 1, 1, 1);
         renderer.fillRoundedRect(r, 7.0f,
                                  active ? accent().withAlpha(hovered ? 0.16f : 0.10f)
-                                        : NUIColor(0.035f, 0.034f, 0.048f, hovered ? 0.98f : 0.88f));
+                                        : NUIColor(0.035f, 0.035f, 0.035f, hovered ? 0.98f : 0.88f));
         renderer.strokeRoundedRect(r, 7.0f, 1.0f,
                                    active ? base.withAlpha(hovered ? 0.50f : 0.34f)
                                           : NUIColor(1, 1, 1, hovered ? 0.22f : 0.13f));
@@ -1452,7 +1452,7 @@ void AestraEQEditor::drawComparePills(NUIRenderer& renderer) {
     const char* label = m_compareActiveSlot == 0 ? "A>B" : "B>A";
     renderer.fillRoundedRect(m_compareCopyRect, 7.0f,
                              m_compareCopyHovered ? accent().withAlpha(0.11f)
-                                                  : NUIColor(0.035f, 0.034f, 0.048f, 0.88f));
+                                                  : NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
     renderer.strokeRoundedRect(m_compareCopyRect, 7.0f, 1.0f,
                                m_compareCopyHovered ? accent().withAlpha(0.42f) : NUIColor(1, 1, 1, 0.13f));
     drawSvgIcon(renderer, compareCopyIcon(), {m_compareCopyRect.x + 7.0f, m_compareCopyRect.y + 5.0f, 14.0f, 14.0f},
@@ -1467,7 +1467,7 @@ void AestraEQEditor::drawCurveScalePill(NUIRenderer& renderer) {
     char label[16];
     std::snprintf(label, sizeof(label), "\u00B1%.0f", range);
     renderer.fillRoundedRect(m_curveScaleRect, 7.0f,
-                             NUIColor(0.045f, 0.043f, 0.064f, m_curveScaleHovered ? 0.94f : 0.76f));
+                             NUIColor(0.045f, 0.045f, 0.045f, m_curveScaleHovered ? 0.94f : 0.76f));
     renderer.strokeRoundedRect(m_curveScaleRect, 7.0f, 1.0f, accent().withAlpha(m_curveScaleHovered ? 0.50f : 0.28f));
     drawSvgIcon(renderer, rangeIcon(), {m_curveScaleRect.x + 5.0f, m_curveScaleRect.y + 5.0f, 14.0f, 14.0f},
                 theme.getColor("textSecondary").withAlpha(m_curveScaleHovered ? 0.92f : 0.66f), 12.5f);
@@ -1492,7 +1492,7 @@ void AestraEQEditor::drawAnalyzerSettingsPanel(NUIRenderer& renderer) {
         return;
 
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, NUIColor(0.030f, 0.030f, 0.045f, 0.94f));
+    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
     renderer.strokeRoundedRect(m_analyzerPanelRect, 8.0f, 1.0f, accent().withAlpha(0.34f));
     renderer.drawText("Analyzer", {m_analyzerPanelRect.x + 10.0f, m_analyzerPanelRect.y + 9.0f}, 9.5f,
                       theme.getColor("textPrimary").withAlpha(0.92f));
@@ -1518,7 +1518,7 @@ void AestraEQEditor::drawAnalyzerTiltPill(NUIRenderer& renderer) {
         std::snprintf(label, sizeof(label), "T %.1f", tilt);
     }
     renderer.fillRoundedRect(m_analyzerTiltRect, 7.0f,
-                             NUIColor(0.045f, 0.043f, 0.064f, m_analyzerTiltHovered ? 0.94f : 0.76f));
+                             NUIColor(0.045f, 0.045f, 0.045f, m_analyzerTiltHovered ? 0.94f : 0.76f));
     renderer.strokeRoundedRect(m_analyzerTiltRect, 7.0f, 1.0f,
                                accent().withAlpha(m_analyzerTiltHovered ? 0.50f : 0.28f));
     drawSvgIcon(renderer, tiltIcon(), {m_analyzerTiltRect.x + 6.0f, m_analyzerTiltRect.y + 5.0f, 13.0f, 13.0f},
@@ -1532,7 +1532,7 @@ void AestraEQEditor::drawAnalyzerSourcePill(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
     const bool pre = m_analyzerSourceIndex == 0;
     renderer.fillRoundedRect(m_analyzerSourceRect, 7.0f,
-                             NUIColor(0.045f, 0.043f, 0.064f, m_analyzerSourceHovered ? 0.94f : 0.76f));
+                             NUIColor(0.045f, 0.045f, 0.045f, m_analyzerSourceHovered ? 0.94f : 0.76f));
     renderer.strokeRoundedRect(
         m_analyzerSourceRect, 7.0f, 1.0f,
         (pre ? NUIColor(0.46f, 0.78f, 1.0f, 1.0f) : accent()).withAlpha(m_analyzerSourceHovered ? 0.52f : 0.30f));
@@ -1550,7 +1550,7 @@ void AestraEQEditor::drawAnalyzerStereoPill(NUIRenderer& renderer) {
     static constexpr const char* kLabels[] = {"ST", "L", "R", "M", "S"};
     const size_t idx = std::min<size_t>(m_analyzerStereoIndex, 4u);
     renderer.fillRoundedRect(m_analyzerStereoRect, 7.0f,
-                             NUIColor(0.045f, 0.043f, 0.064f, m_analyzerStereoHovered ? 0.94f : 0.76f));
+                             NUIColor(0.045f, 0.045f, 0.045f, m_analyzerStereoHovered ? 0.94f : 0.76f));
     renderer.strokeRoundedRect(m_analyzerStereoRect, 7.0f, 1.0f,
                                accent().withAlpha(m_analyzerStereoHovered ? 0.50f : 0.28f));
     renderer.drawTextCentered(kLabels[idx], m_analyzerStereoRect, 8.5f,
@@ -1562,7 +1562,7 @@ void AestraEQEditor::drawAnalyzerDecayPill(NUIRenderer& renderer) {
     static constexpr const char* kLabels[] = {"D F", "D M", "D S"};
     const size_t idx = std::min<size_t>(m_analyzerDecayIndex, 2u);
     renderer.fillRoundedRect(m_analyzerDecayRect, 7.0f,
-                             NUIColor(0.045f, 0.043f, 0.064f, m_analyzerDecayHovered ? 0.94f : 0.76f));
+                             NUIColor(0.045f, 0.045f, 0.045f, m_analyzerDecayHovered ? 0.94f : 0.76f));
     renderer.strokeRoundedRect(m_analyzerDecayRect, 7.0f, 1.0f,
                                accent().withAlpha(m_analyzerDecayHovered ? 0.50f : 0.28f));
     drawSvgIcon(renderer, decayIcon(), {m_analyzerDecayRect.x + 6.0f, m_analyzerDecayRect.y + 5.0f, 13.0f, 13.0f},
@@ -1632,7 +1632,7 @@ void AestraEQEditor::drawKnob(NUIRenderer& renderer, const NUIRect& bounds, floa
     const float r = bounds.width * 0.42f;
     const NUIColor col = active ? a : NUIColor(a.r, a.g, a.b, 0.30f);
     renderer.fillCircle({cx, cy}, r + 5.0f, col.withAlpha(active ? 0.08f : 0.04f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.043f, 0.060f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, col.withAlpha(active ? 0.34f : 0.18f));
 
     const float sa = kPi * 0.75f;
@@ -1665,7 +1665,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         return;
 
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, NUIColor(0.046f, 0.045f, 0.060f, 0.97f));
+    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, NUIColor(0.046f, 0.046f, 0.046f, 0.97f));
     renderer.strokeRoundedRect(m_bandInspectorRect, 7.0f, 1.0f, band.withAlpha(0.16f));
     renderer.fillRect({m_bandInspectorRect.x, m_bandInspectorRect.y, m_bandInspectorRect.width, 2.0f},
                       band.withAlpha(0.72f));
@@ -1746,7 +1746,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
                                                m_bandInspectorRect.right() - chipW - 10.0f);
                 const NUIRect hoverChip{chipX, slotRail.bottom() + 7.0f, chipW, 19.0f};
                 const NUIColor hoverColor = bandColor(hoverBand.slotIndex);
-                renderer.fillRoundedRect(hoverChip, 5.0f, NUIColor(0.026f, 0.025f, 0.036f, 0.96f));
+                renderer.fillRoundedRect(hoverChip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
                 renderer.strokeRoundedRect(hoverChip, 5.0f, 1.0f, hoverColor.withAlpha(0.34f));
                 renderer.drawTextCentered(hoverText, hoverChip, 7.8f, theme.getColor("textSecondary").withAlpha(0.88f));
             }
@@ -1818,7 +1818,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(bd.stereoButton.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           bd.stereoButton.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.025f, 0.036f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(modeHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1828,7 +1828,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(m_selectedCollapseRect.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           m_selectedCollapseRect.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.025f, 0.036f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(collapseHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1854,7 +1854,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const float trackY = lane.center().y;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(lane, 5.0f, NUIColor(0.026f, 0.025f, 0.036f, 0.95f));
+        renderer.fillRoundedRect(lane, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.95f));
         renderer.fillRoundedRect({lane.x, lane.y, labelW, lane.height}, 5.0f,
                                  bd.enabled ? band.withAlpha(0.050f) : band.withAlpha(0.018f));
         renderer.fillRoundedRect({trackX, trackY - 1.5f, trackW, 3.0f}, 1.5f, NUIColor(1, 1, 1, 0.080f));
@@ -2114,7 +2114,7 @@ void AestraEQEditor::drawAnalyzerCollisionOverlay(NUIRenderer& renderer, const N
             std::clamp(inner.x + peakNorm * inner.width - chipW * 0.5f, inner.x + 8.0f, inner.right() - chipW - 8.0f);
         const NUIRect chip{chipX, inner.y + 28.0f, chipW, 22.0f};
         const NUIColor heat(1.0f, 0.40f, 0.18f, 1.0f);
-        renderer.fillRoundedRect(chip, 6.0f, NUIColor(0.045f, 0.032f, 0.030f, 0.88f));
+        renderer.fillRoundedRect(chip, 6.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
         renderer.strokeRoundedRect(chip, 6.0f, 1.0f, heat.withAlpha(0.34f + peakMask * 0.22f));
         renderer.drawText(maskBuf, {chip.x + 8.0f, chip.y + 6.0f}, 8.3f, heat.withAlpha(0.92f));
         renderer.drawText(freqBuf, {chip.right() - 38.0f, chip.y + 6.0f}, 8.3f,
@@ -2212,7 +2212,7 @@ void AestraEQEditor::drawGraphCursorReadout(NUIRenderer& renderer, const NUIRect
     renderer.drawLine({inner.x, m_graphCursorPoint.y}, {inner.right(), m_graphCursorPoint.y}, 1.0f,
                       NUIColor(1.0f, 1.0f, 1.0f, canAddBand ? 0.070f : 0.035f));
     renderer.fillCircle(m_graphCursorPoint, 10.0f, preview.withAlpha(canAddBand ? 0.050f : 0.025f));
-    renderer.fillCircle(m_graphCursorPoint, 4.0f, NUIColor(0.045f, 0.043f, 0.060f, 0.64f));
+    renderer.fillCircle(m_graphCursorPoint, 4.0f, NUIColor(0.045f, 0.045f, 0.045f, 0.64f));
     renderer.strokeCircle(m_graphCursorPoint, 7.0f, 1.1f, preview.withAlpha(canAddBand ? 0.34f : 0.16f));
     renderer.drawLine({m_graphCursorPoint.x - 3.0f, m_graphCursorPoint.y},
                       {m_graphCursorPoint.x + 3.0f, m_graphCursorPoint.y}, 1.2f,
@@ -2236,7 +2236,7 @@ void AestraEQEditor::drawGraphCursorReadout(NUIRenderer& renderer, const NUIRect
     const float y = std::clamp(topSide ? m_graphCursorPoint.y + 12.0f : m_graphCursorPoint.y - kH - 12.0f,
                                bounds.y + 34.0f, bounds.bottom() - kH - 8.0f);
     const NUIRect r{x, y, kW, kH};
-    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.030f, 0.030f, 0.045f, canAddBand ? 0.82f : 0.62f));
+    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.031f, 0.031f, 0.031f, canAddBand ? 0.82f : 0.62f));
     renderer.strokeRoundedRect(r, 6.0f, 1.0f, preview.withAlpha(canAddBand ? 0.26f : 0.12f));
     const NUIRect labelChip{r.x + 7.0f, r.y + 5.0f, 44.0f, 16.0f};
     renderer.fillRoundedRect(labelChip, 4.0f, preview.withAlpha(canAddBand ? 0.13f : 0.050f));
@@ -2314,7 +2314,7 @@ void AestraEQEditor::drawNodeHoverTooltip(NUIRenderer& renderer, const NUIRect& 
     y = std::clamp(y, inner.y + 6.0f, inner.bottom() - h - 6.0f);
     const NUIRect r{x, y, w, h};
 
-    renderer.fillRoundedRect(r, 5.0f, NUIColor(0.030f, 0.030f, 0.040f, 0.90f));
+    renderer.fillRoundedRect(r, 5.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.90f));
     renderer.strokeRoundedRect(r, 5.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, r.x + 8.0f, r.right() - 8.0f);
     const float stemY = r.y > node.y ? r.y : r.bottom();
@@ -2344,7 +2344,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
     const bool canType = bd.typeId != 0 || !bd.legacySlot;
     const bool canDelete = !bd.legacySlot;
 
-    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, NUIColor(0.028f, 0.027f, 0.038f, 0.94f));
+    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, NUIColor(0.028f, 0.028f, 0.028f, 0.94f));
     renderer.strokeRoundedRect(m_nodeQuickActionRect, 7.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, m_nodeQuickActionRect.x + 10.0f, m_nodeQuickActionRect.right() - 10.0f);
     const float stemY = m_nodeQuickActionRect.y > node.y ? m_nodeQuickActionRect.y : m_nodeQuickActionRect.bottom();
@@ -2440,7 +2440,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
             }
             tipY = std::clamp(tipY, inner.y + 4.0f, inner.bottom() - 22.0f);
             const NUIRect tip{tipX, tipY, tipW, 18.0f};
-            renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.025f, 0.036f, 0.94f));
+            renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.94f));
             renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.26f));
             renderer.drawTextCentered(label, tip, 7.7f, theme.getColor("textSecondary").withAlpha(0.86f));
         }
@@ -2560,7 +2560,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
         renderer.fillCircle(
             node, radius + (quietDynamicNode ? 2.4f : 4.0f),
             c.withAlpha((selected || dragging || soloed ? 0.18f : (quietDynamicNode ? 0.050f : 0.10f)) * activeAlpha));
-        renderer.fillCircle(node, radius, NUIColor(0.045f, 0.043f, 0.060f, 0.96f));
+        renderer.fillCircle(node, radius, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
         renderer.strokeCircle(node, radius, bd.enabled ? (quietDynamicNode ? 1.1f : 1.6f) : 1.1f,
                               c.withAlpha(bd.enabled ? (quietDynamicNode ? 0.58f : 1.0f) : 0.42f));
         if (bd.enabled) {
@@ -2631,7 +2631,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     const NUIRect handle{x - 6.0f, y - 6.0f, 12.0f, 12.0f};
     renderer.fillRoundedRect({handle.x - 4.0f, handle.y - 4.0f, handle.width + 8.0f, handle.height + 8.0f}, 5.0f,
                              c.withAlpha(dragging ? 0.12f : 0.06f));
-    renderer.fillRoundedRect(handle, 3.0f, NUIColor(0.030f, 0.030f, 0.042f, 0.94f));
+    renderer.fillRoundedRect(handle, 3.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
     renderer.strokeRoundedRect(handle, 3.0f, dragging ? 1.6f : 1.1f, c.withAlpha(dragging ? 0.95f : 0.72f));
 
     char freqBuf[24];
@@ -2641,7 +2641,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     else
         std::snprintf(freqBuf, sizeof(freqBuf), "%.0f", hz);
     const NUIRect chip{std::clamp(x - 42.0f, inner.x + 6.0f, inner.right() - 84.0f), y + 11.0f, 84.0f, 19.0f};
-    renderer.fillRoundedRect(chip, 5.0f, NUIColor(0.025f, 0.025f, 0.036f, 0.86f));
+    renderer.fillRoundedRect(chip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.86f));
     renderer.strokeRoundedRect(chip, 5.0f, 1.0f, c.withAlpha(0.24f));
     renderer.drawText("DET", {chip.x + 7.0f, std::round(renderer.calculateTextY(chip, 7.4f))}, 7.4f,
                       c.withAlpha(0.76f));
@@ -2665,7 +2665,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
     const NUIRect r = layout.panel;
     const NUIColor c = bandColor(bd.slotIndex);
 
-    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.051f, 0.051f, 0.059f, 0.96f));
+    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.052f, 0.052f, 0.052f, 0.96f));
     renderer.strokeRoundedRect(r, 6.0f, 1.0f, c.withAlpha(bd.enabled ? 0.35f : 0.16f));
     const float connectorX = std::clamp(node.x, r.x + 12.0f, r.right() - 12.0f);
     const float connectorY = node.y < r.y ? r.y + 8.0f : r.bottom() - 8.0f;
@@ -2709,7 +2709,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
         const float trackY = row.center().y + 5.0f;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(row, 4.0f, NUIColor(0.018f, 0.018f, 0.024f, 0.86f));
+        renderer.fillRoundedRect(row, 4.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.86f));
         renderer.fillRoundedRect({row.x, row.y, labelW, row.height}, 4.0f,
                                  bd.enabled ? c.withAlpha(draggingThis ? 0.16f : 0.075f) : c.withAlpha(0.025f));
         renderer.fillRoundedRect({trackX, trackY - 1.0f, trackW, 2.0f}, 1.0f, NUIColor(1, 1, 1, 0.055f));
@@ -2797,7 +2797,7 @@ void AestraEQEditor::drawBandTypeMenu(NUIRenderer& renderer) {
                              quantizeTypeNorm(m_instance ? m_instance->getParameter(bd.typeId) : bd.typeNorm) * 3.0f)),
                          0, 3)
             : std::clamp(static_cast<int>(std::round(std::clamp(bd.typeNorm, 0.0f, 1.0f) * 7.0f)), 0, 7);
-    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, NUIColor(0.030f, 0.030f, 0.045f, 0.96f));
+    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
     renderer.strokeRoundedRect(m_typeMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     for (size_t i = 0; i < optionCount; ++i) {
@@ -2824,7 +2824,7 @@ void AestraEQEditor::drawBandStereoMenu(NUIRenderer& renderer) {
         (bd.legacySlot && bd.stereoId != 0 && m_instance) ? m_instance->getParameter(bd.stereoId) : bd.stereoNorm;
     const int current = std::clamp(static_cast<int>(std::round(quantizeStereoNorm(stereoNorm) * 4.0f)), 0, 4);
 
-    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, NUIColor(0.030f, 0.030f, 0.045f, 0.96f));
+    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
     renderer.strokeRoundedRect(m_stereoMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     static constexpr const char* kLabels[] = {"Stereo", "Left", "Right", "Mid", "Side"};
@@ -2855,7 +2855,7 @@ void AestraEQEditor::drawBandContextMenu(NUIRenderer& renderer) {
     const NUIColor band = bandColor(bd.slotIndex);
     const std::string bandId = bd.name.empty() ? bandIdLabel(static_cast<size_t>(m_bandContextMenuBand)) : bd.name;
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, NUIColor(0.030f, 0.030f, 0.045f, 0.96f));
+    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
     renderer.strokeRoundedRect(m_bandContextMenuRect, 8.0f, 1.0f, band.withAlpha(0.34f));
     renderer.drawText(bandId, {m_bandContextMenuRect.x + 10.0f, m_bandContextMenuRect.y + 10.0f}, 9.5f,
                       band.withAlpha(0.96f));
@@ -2948,7 +2948,7 @@ void AestraEQEditor::drawNumericEditBox(NUIRenderer& renderer) {
     const NUIColor band = m_numericEditBand >= 0 && m_numericEditBand < static_cast<int>(m_bands.size())
                               ? bandColor(m_bands[static_cast<size_t>(m_numericEditBand)].slotIndex)
                               : accent();
-    renderer.fillRoundedRect(r, 7.0f, NUIColor(0.030f, 0.030f, 0.045f, 0.96f));
+    renderer.fillRoundedRect(r, 7.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
     renderer.strokeRoundedRect(r, 7.0f, 1.2f, band.withAlpha(0.62f));
     const char* label = "VALUE";
     switch (m_numericEditTarget) {

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -17,10 +17,10 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accentColor() { return NUIColor(0.95f, 0.60f, 0.12f, 1.0f); }
-NUIColor bgDark() { return NUIColor(0.018f, 0.020f, 0.024f, 0.96f); }
+NUIColor bgDark() { return NUIColor(0.02f, 0.02f, 0.02f, 0.96f); }
 NUIColor textDim() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
 NUIColor textBright() { return NUIColor(1.0f, 1.0f, 1.0f, 0.88f); }
-NUIColor meterBg() { return NUIColor(0.008f, 0.008f, 0.012f, 1.0f); }
+NUIColor meterBg() { return NUIColor(0.008f, 0.008f, 0.008f, 1.0f); }
 
 float smoothMeter(float current, float target, float attack, float release) {
     const float coeff = target > current ? attack : release;
@@ -250,10 +250,10 @@ void AestraLimitEditor::drawKnob(NUIRenderer& renderer, const KnobControl& contr
     const NUIColor knobAccent = control.isPrimary ? accent : accent.withAlpha(0.72f);
 
     // Cell background
-    renderer.fillRoundedRect(control.bounds, 8.0f, NUIColor(0.035f, 0.035f, 0.040f, 0.96f));
+    renderer.fillRoundedRect(control.bounds, 8.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.96f));
     renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f,
                                control.isPrimary ? NUIColor(0.28f, 0.18f, 0.06f, 1.0f)
-                                                 : NUIColor(0.118f, 0.118f, 0.133f, 1.0f));
+                                                 : NUIColor(0.119f, 0.119f, 0.119f, 1.0f));
 
     const NUIRect knobRect = control.slider ? control.slider->getBounds() : NUIRect();
     const float cx = knobRect.center().x;
@@ -315,8 +315,8 @@ void AestraLimitEditor::drawPill(NUIRenderer& renderer, NUIRect rect,
         renderer.strokeRoundedRect(rect, 5.0f, 1.0f, accent);
         renderer.drawTextCentered(label, rect, 9.5f, NUIColor(1, 1, 1, 0.97f));
     } else {
-        const NUIColor bg = hovered ? NUIColor(0.04f, 0.04f, 0.048f, 0.90f)
-                                    : NUIColor(0.022f, 0.022f, 0.028f, 0.90f);
+        const NUIColor bg = hovered ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
+                                    : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
         renderer.fillRoundedRect(rect, 5.0f, bg);
         renderer.drawLine({rect.x + 5.0f, rect.y + 1.0f},
                           {rect.x + rect.width - 5.0f, rect.y + 1.0f},

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -36,8 +36,8 @@ constexpr float kPi = 3.14159265358979323846f;
 constexpr float kTwoPi = kPi * 2.0f;
 constexpr int kModeCount = 9;
 
-NUIColor verbSurfaceBg() { return NUIColor(0.043f, 0.043f, 0.051f, 0.985f); }
-NUIColor verbInsetBg() { return NUIColor(0.024f, 0.024f, 0.031f, 0.965f); }
+NUIColor verbSurfaceBg() { return NUIColor(0.044f, 0.044f, 0.044f, 0.985f); }
+NUIColor verbInsetBg() { return NUIColor(0.025f, 0.025f, 0.025f, 0.965f); }
 NUIColor verbGold() { return NUIColor(0.88f, 0.63f, 0.13f, 1.0f); }
 NUIColor verbAccent() { return NUIColor(0.498f, 0.353f, 0.941f, 1.0f); }
 float presetColumnWidth(float editorWidth) { return std::clamp(editorWidth * 0.22f, 138.0f, 168.0f); }
@@ -566,9 +566,9 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
         const bool active = static_cast<int>(i) == activePreset && bestDistance < 0.55f;
         const bool focused = static_cast<int>(i) == m_focusedPreset;
         const bool pressed = static_cast<int>(i) == m_pressedPreset;
-        const NUIColor presetFill = active ? NUIColor(0.050f, 0.043f, 0.043f, 0.98f)
-            : (pressed ? NUIColor(0.034f, 0.041f, 0.052f, 0.99f)
-                       : (p.hovered ? NUIColor(0.043f, 0.053f, 0.065f, 0.98f) : verbInsetBg().withAlpha(0.92f)));
+        const NUIColor presetFill = active ? NUIColor(0.044f, 0.044f, 0.044f, 0.98f)
+            : (pressed ? NUIColor(0.04f, 0.04f, 0.04f, 0.99f)
+                       : (p.hovered ? NUIColor(0.052f, 0.052f, 0.052f, 0.98f) : verbInsetBg().withAlpha(0.92f)));
         renderer.fillRoundedRect(p.bounds, 5.0f, presetFill);
         renderer.strokeRoundedRect(p.bounds, 5.0f, 1.0f,
                                    active ? NUIColor(1, 1, 1, 0.0f)
@@ -590,7 +590,7 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
             const float hue = modeHues[modeIdx];
             renderer.fillRectGradient(art,
                 NUIColor(hue * 0.8f + 0.15f, hue * 0.4f + 0.08f, 0.20f, 1.0f),
-                NUIColor(0.035f, 0.025f, 0.045f, 1.0f), true);
+                NUIColor(0.029f, 0.029f, 0.029f, 1.0f), true);
             static const char* modeInitials[] = {"R", "H", "P", "C", "Ch", "B", "A", "S", "Sp"};
             const char* initial = (modeIdx >= 0 && modeIdx < kModeCount) ? modeInitials[modeIdx] : "R";
             renderer.drawTextCentered(initial, art, 14.0f, accent.withAlpha(0.65f));
@@ -621,7 +621,7 @@ void AestraVerbEditor::drawCategoryPills(NUIRenderer& renderer, NUIColor accent)
     const auto outer = NUIRect(m_categoryPills.front().bounds.x, m_categoryPills.front().bounds.y,
                                m_categoryPills.back().bounds.right() - m_categoryPills.front().bounds.x,
                                m_categoryPills.front().bounds.height);
-    renderer.fillRoundedRect(outer, 13.0f, NUIColor(0.022f, 0.028f, 0.036f, 0.985f));
+    renderer.fillRoundedRect(outer, 13.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
     renderer.strokeRoundedRect(outer, 13.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
     const float pad = 2.0f;
     for (const auto& pill : m_categoryPills) {
@@ -695,7 +695,7 @@ void AestraVerbEditor::drawModeDropdown(NUIRenderer& renderer, NUIColor accent) 
     chevronIcon->onRender(renderer);
 
     if (m_dropdownOpen && !m_dropdownItems.empty()) {
-        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, NUIColor(0.022f, 0.028f, 0.036f, 0.985f));
+        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
         renderer.strokeRoundedRect(m_dropdownListBounds, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
         for (const auto& item : m_dropdownItems) {
             const bool isCurrent = item.mode == modeIdx;
@@ -730,7 +730,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
         renderer.drawShadow(NUIRect{cx - macroR * 0.82f, cy - macroR * 0.82f, macroR * 1.64f, macroR * 1.64f}, 0.0f, 3.0f, 6.0f,
                             NUIColor(0, 0, 0, 0.52f));
         // Background ring track
-        renderer.strokeCircle({cx, cy}, macroR, ringThickness, NUIColor(0.090f, 0.090f, 0.110f, 1.0f));
+        renderer.strokeCircle({cx, cy}, macroR, ringThickness, NUIColor(0.091f, 0.091f, 0.091f, 1.0f));
         // Accent arc (value)
         const float dStartAngle = -kPi * 0.5f;
         const float dSweep = kTwoPi * 0.80f;
@@ -759,7 +759,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     if (k.verticalLayout) {
         renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                             NUIColor(0, 0, 0, 0.48f));
-        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.034f, 0.040f, 0.049f, 1.0f));
+        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
         renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
         renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
         const float startAngle = kPi * 0.75f;
@@ -782,7 +782,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                         NUIColor(0, 0, 0, 0.48f));
     if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.25f));
-    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.034f, 0.040f, 0.049f, 1.0f));
+    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
     renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
     renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
     const float startAngle = kPi * 0.75f;
@@ -909,14 +909,14 @@ void AestraVerbEditor::drawParamRow(NUIRenderer& renderer, NUIColor accent) {
         const bool active = temp.slider ? temp.slider->isDragging() : false;
         const bool hover = temp.slider ? temp.slider->isHovered() : false;
         const float stateLift = active ? 1.0f : (hover ? 0.55f : 0.0f);
-        renderer.fillCircle({cx, cy}, r, NUIColor(0.010f, 0.010f, 0.012f, 1.0f));
-        renderer.strokeCircle({cx, cy}, r, 1.0f, NUIColor(0.165f, 0.165f, 0.180f, 1.0f + stateLift * 0.045f));
+        renderer.fillCircle({cx, cy}, r, NUIColor(0.01f, 0.01f, 0.01f, 1.0f));
+        renderer.strokeCircle({cx, cy}, r, 1.0f, NUIColor(0.166f, 0.166f, 0.166f, 1.0f + stateLift * 0.045f));
         if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.20f));
         const float startAngle = kPi * 0.75f;
         const float sweep = kPi * 1.5f;
         const float value = temp.slider ? temp.slider->getValue() : 0.0f;
         const float endAngle = startAngle + value * sweep;
-        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, NUIColor(0.165f, 0.165f, 0.180f, 1.0f));
+        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, NUIColor(0.166f, 0.166f, 0.166f, 1.0f));
         drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
         const float pa = startAngle + value * kPi * 1.5f;
         renderer.fillCircle({cx + std::cos(pa) * (r - 2.0f), cy + std::sin(pa) * (r - 2.0f)}, 2.5f,

--- a/AestraUI/Widgets/GenericPluginEditor.cpp
+++ b/AestraUI/Widgets/GenericPluginEditor.cpp
@@ -119,8 +119,8 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
                     LABEL_WIDTH + SLIDER_WIDTH + VALUE_WIDTH + PADDING * 3.0f + 12.0f,
                     PARAMETER_HEIGHT - 2.0f);
     renderer.fillRoundedRect(rowRect, 9.0f,
-        hovered || p.isDragging ? NUIColor(0.16f, 0.18f, 0.25f, 0.92f)
-                                : NUIColor(0.10f, 0.11f, 0.15f, 0.74f));
+        hovered || p.isDragging ? NUIColor(0.181f, 0.181f, 0.181f, 0.92f)
+                                : NUIColor(0.111f, 0.111f, 0.111f, 0.74f));
     renderer.strokeRoundedRect(rowRect, 9.0f, 1.0f,
         hovered || p.isDragging ? theme.getColor("accentPrimary").withAlpha(0.30f)
                                 : NUIColor(1.0f, 1.0f, 1.0f, 0.05f));
@@ -135,7 +135,7 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
     NUIRect track(offsetX + p.sliderBounds.x, trackY, 
                   p.sliderBounds.width, trackH);
 
-    renderer.fillRoundedRect(track, 3.0f, NUIColor(0.03f, 0.04f, 0.06f, 0.78f));
+    renderer.fillRoundedRect(track, 3.0f, NUIColor(0.039f, 0.039f, 0.039f, 0.78f));
 
     float fillWidth = track.width * p.normalizedValue;
     if (fillWidth > 0) {

--- a/AestraUI/Widgets/RumblePluginEditor.cpp
+++ b/AestraUI/Widgets/RumblePluginEditor.cpp
@@ -83,7 +83,7 @@ void RumblePluginEditor::onResize(int width, int height) {
 
 void RumblePluginEditor::drawHero(NUIRenderer& renderer, const NUIRect& bounds) {
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(bounds, kCardRadius, NUIColor(0.15f, 0.10f, 0.18f, 0.92f));
+    renderer.fillRoundedRect(bounds, kCardRadius, NUIColor(0.116f, 0.116f, 0.116f, 0.92f));
     renderer.strokeRoundedRect(bounds, kCardRadius, 1.0f, theme.getColor("accentPrimary").withAlpha(0.45f));
 
     renderer.drawText("Low-end first. Sweep and punch are derived from the current macros.",
@@ -95,8 +95,8 @@ void RumblePluginEditor::drawHero(NUIRenderer& renderer, const NUIRect& bounds) 
 void RumblePluginEditor::drawControl(NUIRenderer& renderer, const MacroControl& control, bool hovered) {
     auto& theme = NUIThemeManager::getInstance();
     const NUIColor accent = theme.getColor("accentPrimary");
-    const NUIColor cardColor = hovered || control.isDragging ? NUIColor(0.16f, 0.14f, 0.18f, 0.98f)
-                                                             : NUIColor(0.12f, 0.11f, 0.14f, 0.96f);
+    const NUIColor cardColor = hovered || control.isDragging ? NUIColor(0.147f, 0.147f, 0.147f, 0.98f)
+                                                             : NUIColor(0.114f, 0.114f, 0.114f, 0.96f);
 
     renderer.fillRoundedRect(control.cardBounds, kCardRadius, cardColor);
     renderer.strokeRoundedRect(control.cardBounds, kCardRadius, 1.0f,
@@ -111,7 +111,7 @@ void RumblePluginEditor::drawControl(NUIRenderer& renderer, const MacroControl& 
                       {control.cardBounds.x + 14.0f, control.cardBounds.y + 58.0f}, 10.0f,
                       accent.withAlpha(0.95f));
 
-    renderer.fillRoundedRect(control.trackBounds, 4.0f, NUIColor(0.02f, 0.02f, 0.03f, 0.78f));
+    renderer.fillRoundedRect(control.trackBounds, 4.0f, NUIColor(0.021f, 0.021f, 0.021f, 0.78f));
     const float filledWidth = std::max(0.0f, std::min(control.trackBounds.width, control.trackBounds.width * control.normalizedValue));
     if (filledWidth > 0.0f) {
         renderer.fillRoundedRect({control.trackBounds.x, control.trackBounds.y, filledWidth, control.trackBounds.height},

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -663,7 +663,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
     renderer.fillRoundedRect(shadow, kCornerRadius, NUIColor(0.0f, 0.0f, 0.0f, 0.55f));
 
     // Solid dark card so the workspace doesn't bleed through.
-    renderer.fillRoundedRect(bounds, kCornerRadius, NUIColor(0.045f, 0.045f, 0.060f, 1.0f));
+    renderer.fillRoundedRect(bounds, kCornerRadius, NUIColor(0.046f, 0.046f, 0.046f, 1.0f));
 
     // Subtle accent wash near the top for depth.
     NUIColor gradTop = m_accent.withAlpha(0.035f);
@@ -760,7 +760,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
             float itemH = 22.0f;
             float dropH = static_cast<float>(m_searchMatches.size()) * itemH + 4.0f;
             NUIRect dropRect{searchX, dropY, searchW, dropH};
-            renderer.fillRoundedRect(dropRect, 5.0f, NUIColor(0.09f, 0.08f, 0.12f, 0.98f));
+            renderer.fillRoundedRect(dropRect, 5.0f, NUIColor(0.085f, 0.085f, 0.085f, 0.98f));
             renderer.strokeRoundedRect(dropRect, 5.0f, 1.0f, m_border.withAlpha(0.35f));
             for (size_t i = 0; i < m_searchMatches.size() && i < 5; ++i) {
                 int nodeIdx = m_searchMatches[i];
@@ -1083,10 +1083,10 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
                                   : NUIColor(0.25f, 0.18f, 0.36f, 1.0f);
         } else {
             // Track nodes: elevated dark fill
-            bgBot = node.hovered ? NUIColor(0.135f, 0.135f, 0.165f, 1.0f)
-                                  : NUIColor(0.095f, 0.095f, 0.125f, 1.0f);
-            bgTop = node.hovered ? NUIColor(0.175f, 0.165f, 0.205f, 1.0f)
-                                  : NUIColor(0.125f, 0.120f, 0.155f, 1.0f);
+            bgBot = node.hovered ? NUIColor(0.137f, 0.137f, 0.137f, 1.0f)
+                                  : NUIColor(0.097f, 0.097f, 0.097f, 1.0f);
+            bgTop = node.hovered ? NUIColor(0.17f, 0.17f, 0.17f, 1.0f)
+                                  : NUIColor(0.124f, 0.124f, 0.124f, 1.0f);
         }
         renderer.fillRoundedRect(nodeRect, radius, bgBot);
         renderer.fillRectGradient({nx, ny, nw, nh * 0.6f}, bgTop, bgBot, true);
@@ -2270,7 +2270,7 @@ void UIRoutingMap::drawSendLevelLabel(NUIRenderer& renderer, const NUIPoint& a, 
     float textW = renderer.measureText(buf, fontSize).width;
     float textH = fontSize + 2.0f;
     NUIRect bg{mx - textW * 0.5f - 3.0f, my - textH * 0.5f, textW + 6.0f, textH};
-    renderer.fillRoundedRect(bg, 3.0f, NUIColor(0.07f, 0.06f, 0.10f, 0.85f));
+    renderer.fillRoundedRect(bg, 3.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.85f));
     renderer.strokeRoundedRect(bg, 3.0f, 0.5f, m_borderSecondary.withAlpha(0.4f));
     renderer.drawTextCentered(buf, bg, fontSize, m_textSecondary.withAlpha(0.85f));
 }
@@ -2366,7 +2366,7 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
     float offsetY = insetY + insetH * 0.5f - (m_worldMinY + worldH * 0.5f) * scale;
 
     // Background
-    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, NUIColor(0.06f, 0.05f, 0.09f, 0.92f));
+    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, NUIColor(0.055f, 0.055f, 0.055f, 0.92f));
     renderer.strokeRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, 1.0f, m_border.withAlpha(0.35f));
 
     // Draw all edges as thin faint lines
@@ -2394,7 +2394,7 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
         float ny = offsetY + node.y * scale;
         float nw = node.w * scale;
         float nh = node.h * scale;
-        NUIColor fill = NUIColor(0.18f, 0.16f, 0.22f, 0.85f);
+        NUIColor fill = NUIColor(0.169f, 0.169f, 0.169f, 0.85f);
         if (node.type == Node::Master) fill = NUIColor(0.25f, 0.18f, 0.36f, 0.85f);
         renderer.fillRoundedRect({nx, ny, nw, nh}, 2.0f, fill);
         renderer.strokeRoundedRect({nx, ny, nw, nh}, 2.0f, 0.5f, m_border.withAlpha(0.4f));
@@ -2454,7 +2454,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     m_inspectorPanelRect = NUIRect{insetX, insetY, kInspectorW, insetH};
 
     // Background
-    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, NUIColor(0.07f, 0.06f, 0.10f, 0.96f));
+    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.96f));
     renderer.strokeRoundedRect(m_inspectorPanelRect, 8.0f, 1.0f, m_border.withAlpha(0.45f));
 
     // Clip content to panel interior (scrollable area)


### PR DESCRIPTION
## Summary
Extends the neutral-chrome direction (#408) into the plugin editors. 87 dark near-grey surface colors across `AestraVerbEditor`, `AestraEQEditor`, `AestraCompEditor`, `AestraDelayEditor`, `AestraDriftEditor`, `AestraLimitEditor`, `RumblePluginEditor`, `GenericPluginEditor`, and `UIRoutingMap` carried blue/purple shifts (e.g. EQ graph bg `(0.045, 0.043, 0.064)`). All flattened to luminance-matched neutral greys (Rec. 709 luma), so brightness hierarchy is preserved while hue is removed.

Deliberately kept:
- EQ/Comp purple primary-cell borders and Limit amber primary border (plugin identity accents)
- Routing-map master-node purple fills — code comments document the intent ("visually distinct as the destination")
- All theme-token accent usage (`accentPrimary`, `warning`, `error`)

## Why
Owner queue from the 2026-07-05 UI pass: plugin editors were the remaining blue/purple-tinted area after the shell went neutral.

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest -L ui` (excluding the known pre-existing `NUITextInputLayoutTest`): 4/4 pass.
- Visual verification: owner screenshot pass pending — open each editor once; the surfaces should read as the same greys as the shell with the purple/amber accents unchanged.

## Docs updated?
No.

## Risk/rollback notes
- Color-constants-only; no logic, layout, or DSP changes. Plugin state/IDs untouched.
- Mechanical transform (flatten when max−min ≤ 0.12 and max < 0.5) with a hand-reviewed skip list for accents; diff is 86 lines of paired changes.
- Rollback = revert single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)