### PR TITLE
fix(ui): file preview panel — wire dead update loop, strip half-baked features

### DIFF
--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -816,8 +816,17 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
                       {navHeader.right(), navHeader.y + 27.0f},
                       1.0f, themeManager.getColor("border").withAlpha(0.65f));
 
+    // Scrollable content region below the fixed folder-name header. When the
+    // preview dock steals height the tail rows would clip; instead the content
+    // scrolls under the header exactly like the file list below it.
+    const float navContentTop = layout.navPane.y + 28.0f;
+    navViewportHeight_ = std::max(0.0f, layout.navPane.bottom() - navContentTop);
+    const float navMaxScroll = std::max(0.0f, navContentHeight_ - navViewportHeight_);
+    navScrollOffset_ = std::clamp(navScrollOffset_, 0.0f, navMaxScroll);
+    renderer.setClipRect(NUIRect(layout.navPane.x, navContentTop, layout.navPane.width, navViewportHeight_));
+
     // Start nav content at the same Y as the right column labels
-    float y = layout.navPane.y + 28.0f;
+    float y = navContentTop - navScrollOffset_;
     int hitIndex = 0;
 
     auto collectionCount = [&](const std::string& tag) {
@@ -1007,6 +1016,23 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
             renderer.fillRect(placesOverlay, NUIColor(0.486f, 0.227f, 0.929f, 0.15f));
             renderer.strokeRoundedRect(placesOverlay, 4.0f, 1.0f, NUIColor(0.486f, 0.227f, 0.929f, 0.6f));
         }
+    }
+
+    // Measure content for next frame's scroll clamp (y is post-offset screen
+    // space; add the offset back to recover the intrinsic content height).
+    navContentHeight_ = (y + navScrollOffset_) - navContentTop;
+
+    // Restore the full-pane clip and draw a thin scroll thumb when content
+    // overflows the (preview-shortened) viewport.
+    renderer.setClipRect(layout.navPane);
+    const float navOverflow = navContentHeight_ - navViewportHeight_;
+    if (navOverflow > 0.5f && navViewportHeight_ > 0.0f) {
+        const float sbW = 3.0f;
+        const float sbX = layout.navPane.right() - sbW - 2.0f;
+        const float thumbH = std::max(24.0f, navViewportHeight_ * (navViewportHeight_ / navContentHeight_));
+        const float thumbY = navContentTop + (navScrollOffset_ / navOverflow) * (navViewportHeight_ - thumbH);
+        renderer.fillRoundedRect(NUIRect(sbX, thumbY, sbW, thumbH), sbW * 0.5f,
+                                 themeManager.getColor("textSecondary").withAlpha(0.30f));
     }
 
     renderer.clearClipRect();
@@ -1506,6 +1532,19 @@ bool FileBrowser::onMouseEvent(const NUIMouseEvent& event) {
 
     if (handleNavigationMouseEvent(event, browserLayout)) {
         return true;
+    }
+
+    // === NAV PANE WHEEL (independent of the file list) ===
+    // Scroll the collections/categories/places column when it overflows —
+    // e.g. the preview dock is open and shortened the pane.
+    if (event.wheelDelta != 0 && browserLayout.navPane.contains(event.position)) {
+        const float navOverflow = std::max(0.0f, navContentHeight_ - navViewportHeight_);
+        if (navOverflow > 0.0f) {
+            navScrollOffset_ = std::clamp(navScrollOffset_ - event.wheelDelta * 3.0f * BROWSER_NAV_ROW_H,
+                                          0.0f, navOverflow);
+            invalidateCache();
+            return true;
+        }
     }
 
     // === MOUSE WHEEL SCROLLING (handle before bounds check so scrolling works on hover) ===
@@ -3327,7 +3366,10 @@ bool FileBrowser::handleScrollbarMouseEvent(const NUIMouseEvent& event) {
 bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const BrowserLayout& layout) {
     if (event.cursorCaptured) return false;
 
-    const bool insideNav = layout.navPane.contains(event.position);
+    // Ignore the fixed folder-name header band: rows scrolled up under it are
+    // visually clipped, so they must not be clickable there either.
+    const float navContentTop = layout.navPane.y + 28.0f;
+    const bool insideNav = layout.navPane.contains(event.position) && event.position.y >= navContentTop;
     int newHovered = -1;
     if (insideNav) {
         for (int i = 0; i < static_cast<int>(navHits_.size()); ++i) {

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -389,6 +389,10 @@ public:
         std::string activeNavPath_;
         int hoveredNavIndex_ = -1;
         std::vector<BrowserNavHit> navHits_;
+        // Nav pane vertical scroll (engages when the preview dock steals height).
+        float navScrollOffset_ = 0.0f;   // current offset, clamped in render
+        float navContentHeight_ = 0.0f;  // measured content height below the header
+        float navViewportHeight_ = 0.0f; // visible content height below the header
 	    std::shared_ptr<NUIContextMenu> popupMenu_;
 	    std::string popupMenuTargetPath_;
 	    bool popupMenuTargetIsDirectory_ = false;

--- a/Source/Components/FilePreviewPanel.cpp
+++ b/Source/Components/FilePreviewPanel.cpp
@@ -76,25 +76,6 @@ std::string truncateToWidth(NUIRenderer& renderer, const std::string& text, floa
     return "";
 }
 
-std::string formatTimeShort(double seconds) {
-    if (seconds <= 0.0) {
-        return "0:00";
-    }
-    const int total = static_cast<int>(std::round(seconds));
-    const int mins = total / 60;
-    const int secs = total % 60;
-    char buffer[16];
-    std::snprintf(buffer, sizeof(buffer), "%d:%02d", mins, secs);
-    return std::string(buffer);
-}
-
-std::string fileExtensionUpper(const std::string& path) {
-    std::string ext = std::filesystem::path(path).extension().string();
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::toupper);
-    if (!ext.empty() && ext[0] == '.') ext = ext.substr(1);
-    return ext;
-}
-
 } // namespace
 
 FilePreviewPanel::FilePreviewPanel() {
@@ -109,10 +90,6 @@ FilePreviewPanel::FilePreviewPanel() {
     playIcon_ = std::make_shared<NUIIcon>("<svg viewBox='0 0 24 24' fill='currentColor'><path d='M8 5v14l11-7z'/></svg>");
 
     stopIcon_ = std::make_shared<NUIIcon>("<svg viewBox='0 0 24 24' fill='currentColor'><path d='M6 6h12v12H6z'/></svg>");
-
-    loopIcon_ = std::make_shared<NUIIcon>("<svg viewBox='0 0 24 24' fill='currentColor'><path d='M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46A7.93 7.93 0 0020 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74A7.93 7.93 0 004 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z'/></svg>");
-
-    bpmSyncIcon_ = std::make_shared<NUIIcon>("<svg viewBox='0 0 24 24' fill='currentColor'><path d='M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z'/></svg>");
 }
 
 void FilePreviewPanel::setFile(const FileItem* file) {
@@ -195,17 +172,9 @@ void FilePreviewPanel::setDuration(double seconds) {
 }
 
 void FilePreviewPanel::onPreviewEnded() {
-    if (m_loopEnabled && !m_currentFilePath.empty()) {
-        if (onReplay_) onReplay_();
-    } else {
-        isPlaying_ = false;
-        playheadPosition_ = 0.0;
-        setDirty(true);
-    }
-}
-
-float FilePreviewPanel::getRequiredHeight() const {
-    return getBounds().height + kTransportBarHeight;
+    isPlaying_ = false;
+    playheadPosition_ = 0.0;
+    setDirty(true);
 }
 
 void FilePreviewPanel::onUpdate(double deltaTime) {
@@ -246,7 +215,19 @@ void FilePreviewPanel::generateWaveform(const std::string& path, size_t fileSize
 }
 
 void FilePreviewPanel::waveformWorker(const std::string& path, uint64_t generation) {
-    if (generation != currentGeneration_.load(std::memory_order_acquire)) return;
+    // Every exit must clear isWaveformLoading_ — a stale-generation early
+    // return that leaves it set pins the spinner on forever and blocks
+    // onUpdate() from ever dequeuing the next waveform job.
+    const auto finishStale = [this]() {
+        std::lock_guard<std::mutex> lock(waveformMutex_);
+        isWaveformLoading_ = false;
+        waveformJustCompleted_.store(true);
+    };
+
+    if (generation != currentGeneration_.load(std::memory_order_acquire)) {
+        finishStale();
+        return;
+    }
 
     std::vector<float> audioData;
     uint32_t sampleRate = 0;
@@ -256,7 +237,10 @@ void FilePreviewPanel::waveformWorker(const std::string& path, uint64_t generati
     constexpr double kPreviewMaxSeconds = static_cast<double>(kPreviewMaxFrames) / 48000.0;
     bool success = Aestra::Audio::decodeAudioPreview(path, audioData, sampleRate, numChannels, kPreviewMaxSeconds);
 
-    if (generation != currentGeneration_.load(std::memory_order_acquire)) return;
+    if (generation != currentGeneration_.load(std::memory_order_acquire)) {
+        finishStale();
+        return;
+    }
 
     if (success && !audioData.empty()) {
         std::vector<float> waveform = generateWaveformFromAudio(audioData, numChannels, 1024);
@@ -344,7 +328,6 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
     // === AUDIO FILE STATE ===
     const float padL = 14.0f;
     const float padR = 14.0f;
-    const float transportH = 18.0f;
     const float scrubberH = 3.0f;
     const float padB = 8.0f; // bottom padding below scrubber
     const float playBtnSize = 30.0f;
@@ -354,30 +337,26 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
     // Play button bounds
     playButtonBounds_ = NUIRect(playBtnX, centerY - playBtnSize * 0.5f, playBtnSize, playBtnSize);
 
-    // Transport bar positioned above scrubber
-    const float transportY = bounds.bottom() - padB - scrubberH - transportH - 2.0f;
-
     // Scrubber bounds (full width minus padding, at bottom)
     scrubberBounds_ = NUIRect(bounds.x + padL, bounds.bottom() - padB - scrubberH,
                               std::max(0.0f, bounds.width - padL - padR), scrubberH);
 
-    // Layout columns
+    // Text takes the full width right of the play button.
     const float textX = playButtonBounds_.right() + 12.0f;
-    const float timeW = 72.0f; // enough for "0:00 / 0:00"
-    const float timeX = bounds.right() - padR - timeW;
-    const float textMaxWidth = std::max(0.0f, timeX - textX - 10.0f);
+    const float textMaxWidth = std::max(0.0f, bounds.right() - padR - textX);
 
-    // -- Background waveform (full-width, subtle) --
-    bool hasData = false;
-    {
-        std::lock_guard<std::mutex> lock(waveformMutex_);
-        hasData = !waveformData_.empty();
+    float progress = 0.0f;
+    if (duration_ > 0.0) {
+        progress = std::clamp(static_cast<float>(playheadPosition_ / duration_), 0.0f, 1.0f);
     }
 
-    if (hasData) {
+    // -- Background waveform (full-width; played portion tinted brighter) --
+    {
         std::lock_guard<std::mutex> lock(waveformMutex_);
         if (!waveformData_.empty()) {
-            NUIColor waveformFill = accent.withAlpha(0.07f);
+            const NUIColor waveformFill = accent.withAlpha(0.16f);
+            const NUIColor waveformPlayed = accent.withAlpha(0.42f);
+            const float playedX = bounds.x + bounds.width * progress;
             float wfY = bounds.y + bounds.height * 0.5f;
             float maxAmp = bounds.height * 0.32f;
             float samplesPerPixel = static_cast<float>(waveformData_.size()) / bounds.width;
@@ -396,10 +375,11 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
 
                     float barHeight = std::max(1.0f, amplitude * maxAmp * 2.0f);
                     float yStart = wfY - barHeight * 0.5f;
+                    const bool played = isPlaying_ && (bounds.x + x) <= playedX;
                     renderer.drawLine(
                         NUIPoint(bounds.x + x, yStart),
                         NUIPoint(bounds.x + x, yStart + barHeight),
-                        1.0f, waveformFill
+                        1.0f, played ? waveformPlayed : waveformFill
                     );
                 }
             }
@@ -447,7 +427,8 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
     std::string displayName = truncateToWidth(renderer, currentFile_.name, 12.5f, nameMaxW);
     renderer.drawText(displayName, NUIPoint(nameX, infoTopY), 12.5f, theme.getColor("textPrimary").withAlpha(0.92f));
 
-    // BPM and key info line
+    // Metadata line only when the browser actually detected something —
+    // no extension fallback (it's already part of the file name).
     std::string infoLine;
     if (m_currentFileBpm > 0) {
         infoLine = std::to_string(m_currentFileBpm) + " BPM";
@@ -456,34 +437,12 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
         if (!infoLine.empty()) infoLine += "  ";
         infoLine += m_currentFileKey;
     }
-    if (infoLine.empty()) {
-        infoLine = fileExtensionUpper(currentFile_.path);
-    }
-    renderer.drawText(infoLine, NUIPoint(nameX, infoTopY + 15.0f), 10.0f, theme.getColor("textSecondary").withAlpha(0.55f));
-
-    // -- Time / Duration --
-    if (timeX > nameX + 40.0f) {
-        std::string timeStr;
-        if (duration_ > 0.0 && isPlaying_) {
-            timeStr = formatTimeShort(playheadPosition_) + " / " + formatTimeShort(duration_);
-        } else if (duration_ > 0.0) {
-            timeStr = formatTimeShort(duration_);
-        } else {
-            timeStr = "--:--";
-        }
-        auto timeSize = renderer.measureText(timeStr, 10.0f);
-        renderer.drawText(timeStr,
-            NUIPoint(timeX + timeW - timeSize.width, infoTopY + 7.0f),
-            10.0f, theme.getColor("textSecondary").withAlpha(0.55f));
+    if (!infoLine.empty()) {
+        renderer.drawText(infoLine, NUIPoint(nameX, infoTopY + 15.0f), 10.0f,
+                          theme.getColor("textSecondary").withAlpha(0.55f));
     }
 
     // -- Scrubber / Progress bar --
-    float progress = 0.0f;
-    if (duration_ > 0.0) {
-        progress = static_cast<float>(playheadPosition_ / duration_);
-        progress = std::clamp(progress, 0.0f, 1.0f);
-    }
-
     float trackY = scrubberBounds_.y + scrubberBounds_.height * 0.5f;
 
     // Track background
@@ -505,63 +464,6 @@ void FilePreviewPanel::onRender(NUIRenderer& renderer) {
             NUIPoint(playheadX, trackY + indicatorH * 0.5f),
             2.0f, accent.withAlpha(0.92f)
         );
-    }
-
-    // -- Transport bar (above scrubber) --
-    const float btnSize = 16.0f;
-    float tx = bounds.x + padL;
-
-    // Loop button
-    loopButtonBounds_ = NUIRect(tx, transportY, btnSize, btnSize);
-    if (m_loopEnabled) {
-        renderer.fillRoundedRect(loopButtonBounds_, 3.0f, accent.withAlpha(0.25f));
-        renderer.strokeRoundedRect(loopButtonBounds_, 3.0f, 1.0f, accent.withAlpha(0.5f));
-    } else {
-        renderer.strokeRoundedRect(loopButtonBounds_, 3.0f, 1.0f, theme.getColor("border").withAlpha(0.35f));
-    }
-    if (loopIcon_) {
-        loopIcon_->setBounds(NUIRect(tx + 1.5f, transportY + 1.5f, 13.0f, 13.0f));
-        loopIcon_->setColor(m_loopEnabled ? accent : theme.getColor("textSecondary").withAlpha(0.5f));
-        loopIcon_->onRender(renderer);
-    }
-    tx += btnSize + 8.0f;
-
-    // BPM sync button
-    bpmSyncButtonBounds_ = NUIRect(tx, transportY, btnSize, btnSize);
-    if (m_bpmSyncEnabled) {
-        renderer.fillRoundedRect(bpmSyncButtonBounds_, 3.0f, NUIColor(0.204f, 0.835f, 0.600f, 0.25f));
-        renderer.strokeRoundedRect(bpmSyncButtonBounds_, 3.0f, 1.0f, NUIColor(0.204f, 0.835f, 0.600f, 0.5f));
-    } else {
-        renderer.strokeRoundedRect(bpmSyncButtonBounds_, 3.0f, 1.0f, theme.getColor("border").withAlpha(0.35f));
-    }
-    if (bpmSyncIcon_) {
-        bpmSyncIcon_->setBounds(NUIRect(tx + 1.5f, transportY + 1.5f, 13.0f, 13.0f));
-        bpmSyncIcon_->setColor(m_bpmSyncEnabled ? NUIColor(0.204f, 0.835f, 0.600f, 1.0f) : theme.getColor("textSecondary").withAlpha(0.5f));
-        bpmSyncIcon_->onRender(renderer);
-    }
-    tx += btnSize + 12.0f;
-
-    // Time display
-    std::string timeStr = formatTimeShort(playheadPosition_) + " / " + formatTimeShort(duration_);
-    renderer.drawText(timeStr, {tx, transportY + 2.0f}, 10.0f, theme.getColor("textSecondary").withAlpha(0.45f));
-
-    // BPM display (right-aligned)
-    if (m_currentFileBpm > 0) {
-        float rate = 1.0f;
-        if (m_bpmSyncEnabled && m_projectBpm > 0) {
-            rate = std::clamp(static_cast<float>(m_projectBpm) / static_cast<float>(m_currentFileBpm), 0.5f, 2.0f);
-        }
-        char bpmBuf[32];
-        std::snprintf(bpmBuf, sizeof(bpmBuf), "%d BPM", m_currentFileBpm);
-        std::string bpmStr = bpmBuf;
-        if (m_bpmSyncEnabled && m_projectBpm > 0) {
-            char rateBuf[16];
-            std::snprintf(rateBuf, sizeof(rateBuf), "  x%.2f", rate);
-            bpmStr += rateBuf;
-        }
-        auto bpmSize = renderer.measureText(bpmStr, 10.0f);
-        renderer.drawText(bpmStr, {bounds.right() - padR - bpmSize.width, transportY + 2.0f}, 10.0f,
-                          m_bpmSyncEnabled ? NUIColor(0.204f, 0.835f, 0.600f, 0.9f) : theme.getColor("textSecondary").withAlpha(0.35f));
     }
 
     // -- Loading spinner overlay (small, near play button) --
@@ -594,16 +496,6 @@ bool FilePreviewPanel::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
         return false;
-    }
-
-    if (event.type == NUIMouseEventType::Move) {
-        if (stopButtonBounds_.contains(event.position)) {
-            showRemoteTooltip("Stop preview", event.position, this);
-        } else if (loopButtonBounds_.contains(event.position)) {
-            showRemoteTooltip(m_loopEnabled ? "Loop: On" : "Loop: Off", event.position, this);
-        } else if (bpmSyncButtonBounds_.contains(event.position)) {
-            showRemoteTooltip(m_bpmSyncEnabled ? "BPM Sync: On" : "BPM Sync: Off", event.position, this);
-        }
     }
 
     auto seekFromPosition = [&](const NUIPoint& pos) {
@@ -641,28 +533,6 @@ bool FilePreviewPanel::onMouseEvent(const NUIMouseEvent& event) {
         if (scrubberBounds_.contains(event.position) && duration_ > 0.0) {
             isSeekDragging_ = true;
             seekFromPosition(event.position);
-            setDirty(true);
-            return true;
-        }
-
-        // Stop button
-        if (stopButtonBounds_.contains(event.position)) {
-            if (onStop_) onStop_();
-            playheadPosition_ = 0.0;
-            setDirty(true);
-            return true;
-        }
-
-        // Loop button
-        if (loopButtonBounds_.contains(event.position)) {
-            m_loopEnabled = !m_loopEnabled;
-            setDirty(true);
-            return true;
-        }
-
-        // BPM sync button
-        if (bpmSyncButtonBounds_.contains(event.position)) {
-            m_bpmSyncEnabled = !m_bpmSyncEnabled;
             setDirty(true);
             return true;
         }

--- a/Source/Components/FilePreviewPanel.h
+++ b/Source/Components/FilePreviewPanel.h
@@ -38,21 +38,7 @@ public:
     void setDuration(double seconds);
     bool hasFileSelection() const { return hasCurrentFile_ && !currentFile_.isDirectory; }
 
-    // Loop and BPM sync
-    void setLoopEnabled(bool loop) { m_loopEnabled = loop; setDirty(true); }
-    bool isLoopEnabled() const { return m_loopEnabled; }
-    void setBpmSyncEnabled(bool sync) { m_bpmSyncEnabled = sync; setDirty(true); }
-    bool isBpmSyncEnabled() const { return m_bpmSyncEnabled; }
-    void setProjectBpm(int bpm) { m_projectBpm = bpm; }
-    void setCurrentFileBpm(int bpm) { m_currentFileBpm = bpm; }
     void onPreviewEnded();
-
-    // Transport bar height (scrubber + 4px gap + bar + padding)
-    static constexpr float kTransportBarHeight = 26.0f;
-    float getRequiredHeight() const;
-
-    // Replay callback for loop (bypasses setFile / waveform regen)
-    void setOnReplay(std::function<void()> callback) { onReplay_ = callback; }
 
 private:
     void generateWaveform(const std::string& path, size_t fileSize);
@@ -83,16 +69,10 @@ private:
     NUIRect playButtonBounds_;
     NUIRect scrubberBounds_;
 
-    // Transport controls
-    NUIRect stopButtonBounds_;
-    NUIRect loopButtonBounds_;
-    NUIRect bpmSyncButtonBounds_;
-
     // Callbacks
     std::function<void(const FileItem&)> onPlay_;
     std::function<void()> onStop_;
     std::function<void(double)> onSeek_;
-    std::function<void()> onReplay_;
 
     // Icons
     std::shared_ptr<NUIIcon> folderIcon_;
@@ -100,13 +80,8 @@ private:
     std::shared_ptr<NUIIcon> audioFileIcon_;
     std::shared_ptr<NUIIcon> playIcon_;
     std::shared_ptr<NUIIcon> stopIcon_;
-    std::shared_ptr<NUIIcon> loopIcon_;
-    std::shared_ptr<NUIIcon> bpmSyncIcon_;
 
-    // Loop and BPM sync state
-    bool m_loopEnabled = false;
-    bool m_bpmSyncEnabled = false;
-    int m_projectBpm = 0;
+    // File metadata (from browser detection)
     int m_currentFileBpm = 0;
     std::string m_currentFileKey;
     std::string m_currentFilePath;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -437,28 +437,6 @@ AestraContent::AestraContent() {
     m_previewPanel->setOnPlay([this](const AestraUI::FileItem& file) { playSoundPreview(file); });
     m_previewPanel->setOnStop([this]() { stopSoundPreview(); });
     m_previewPanel->setOnSeek([this](double seconds) { seekSoundPreview(seconds); });
-    m_previewPanel->setOnReplay([this]() {
-        if (m_previewEngine && !m_currentPreviewFile.empty()) {
-            m_previewEngine->stop();
-            double fullDuration = m_previewEngine->getDuration();
-            if (fullDuration <= 0.0) fullDuration = 300.0;
-            float rate = 1.0f;
-            if (m_previewPanel && m_previewPanel->isBpmSyncEnabled()) {
-                int fileBpm = 0;
-                int projectBpm = m_audioEngine ? static_cast<int>(m_audioEngine->getBPM()) : 120;
-                if (fileBpm > 0 && projectBpm > 0) {
-                    rate = std::clamp(static_cast<float>(projectBpm) / static_cast<float>(fileBpm), 0.5f, 2.0f);
-                }
-            }
-            auto result = m_previewEngine->play(m_currentPreviewFile, 0.0f, fullDuration, rate);
-            if (result == Audio::PreviewResult::Success || result == Audio::PreviewResult::Pending) {
-                m_previewIsPlaying = true;
-                m_previewStartTime = std::chrono::steady_clock::now();
-                if (m_previewPanel)
-                    m_previewPanel->setPlaying(true);
-            }
-        }
-    });
     m_workspaceLayer->addChild(m_previewPanel);
 
     // Link file selection to preview panel
@@ -1117,6 +1095,12 @@ AestraContent::AestraContent() {
 void AestraContent::onUpdate(double dt) {
     updatePendingCountIn();
 
+    // Drive preview state: clears the pending-load spinner once the decode
+    // is ready, feeds playhead/duration to the panel, and stops at the end.
+    // (This existed but was never called — the panel's spinner and progress
+    // were frozen because nothing pumped the preview engine state.)
+    updateSoundPreview();
+
     // Sync track changes to MixerViewModel
     auto tm = getTrackManager();
     if (tm && m_mixerPanel) {
@@ -1400,13 +1384,12 @@ void AestraContent::onResize(int width, int height) {
         float fbHeight = height - fbTop;
 
         if (showPreviewDock) {
-            const float previewHeight = 68.0f + AestraUI::FilePreviewPanel::kTransportBarHeight;
+            // Full browser width: the dock previously started at the nav-pane
+            // edge, leaving an unpainted (black) strip under the nav pane.
+            const float previewHeight = 68.0f;
             fbHeight -= previewHeight;
-            const float navWidth = std::clamp(fileBrowserWidth * 0.34f, 118.0f, 188.0f);
-            const float previewWidth = std::max(0.0f, fileBrowserWidth - navWidth);
-
-            m_previewPanel->setBounds(AestraUI::NUIAbsolute(contentBounds, navWidth, fbTop + fbHeight,
-                                                            previewWidth, previewHeight));
+            m_previewPanel->setBounds(
+                AestraUI::NUIAbsolute(contentBounds, 0, fbTop + fbHeight, fileBrowserWidth, previewHeight));
         }
 
         m_fileBrowser->setBounds(AestraUI::NUIAbsolute(contentBounds, 0, fbTop, fileBrowserWidth, fbHeight));
@@ -3034,15 +3017,7 @@ void AestraContent::playSoundPreview(const AestraUI::FileItem& file) {
     }
 
     m_previewDuration = 8.0;
-    float playbackRate = 1.0f;
-    if (m_previewPanel && m_previewPanel->isBpmSyncEnabled() && m_previewPanel->isLoopEnabled()) {
-        int fileBpm = file.detectedBpm;
-        int projectBpm = m_audioEngine ? static_cast<int>(m_audioEngine->getBPM()) : 120;
-        if (fileBpm > 0 && projectBpm > 0) {
-            playbackRate = std::clamp(static_cast<float>(projectBpm) / static_cast<float>(fileBpm), 0.5f, 2.0f);
-        }
-    }
-    auto result = m_previewEngine->play(file.path, 0.0f, m_previewDuration, playbackRate);
+    auto result = m_previewEngine->play(file.path, 0.0f, m_previewDuration);
 
     if (result == PreviewResult::Success || result == PreviewResult::Pending) {
         m_previewIsPlaying = true;


### PR DESCRIPTION
## Summary
The preview panel's functional complaints had one root cause: **`AestraContent::updateSoundPreview()` was defined but never called** — the only code that clears the pending-load spinner, feeds duration/playhead to the panel, and detects preview end. So the spinner froze on, time read 0:00/0:00, progress never moved, loop could never trigger. It is now pumped from `AestraContent::onUpdate()` (no-op while no preview plays).

With the machinery running, the half-baked features are stripped per owner direction, and two more bugs fixed, plus a follow-on nav-pane scroll:

**Preview panel**
- Loop + BPM-sync buttons removed — never worked (replay path hardcoded `fileBpm = 0`, sync rate always 1.0); their engine paths removed too.
- Time displays removed (both the "0:00 / 0:00" transport text and the top-right duration).
- Extension label removed — no "FLAC" fallback; it's already in the file name. BPM/key metadata still shows when detected.
- Transport row gone → dock slims 94px → 68px.
- **Black cover fixed**: the dock only spanned from the nav-pane edge, leaving an unpainted strip under the nav pane; it now spans full browser width.
- **Stuck spinner fixed**: `waveformWorker` stale-generation early returns left `isWaveformLoading_` set, pinning the spinner and blocking the next waveform job. All exits now clear it.
- Waveform is the hero — idle bars at accent 0.16, played portion 0.42, so progress reads in the wave.

**Nav pane scroll** (latest commit)
- The collections/categories/places column is fixed-height; the preview dock shortening the browser clipped its tail rows. The nav pane now scrolls under its fixed folder-name header (wheel over the pane, clamped to overflow), with a thin thumb only while overflowing. Rows scrolled under the header are excluded from hit testing.

## Why
Owner: preview "visual style needs an upgrade... functionality is half baked with confused features"; then "make the collections section push up like the file picker with a scrollbar when the preview comes to view so nothing is obstructed."

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest -L ui` (excluding known pre-existing `NUITextInputLayoutTest`): 4/4 pass.
- Manual (owner): select a wav → spinner shows and clears, waveform fills and progresses, no black strip; wheel the nav pane while the preview is open → collections scroll, tail rows reachable.

## Docs updated?
No.

## Risk/rollback notes
- `updateSoundPreview()` was dead code — wiring it in activates preview-end auto-stop and buffer-ready handling for the first time (intended, but a behavior activation, not just visual).
- Nav scroll is measured-during-render then clamped; no change to file-list scrolling. Idle frame elision preserved (wheel path calls invalidateCache like the list does).
- Rollback = revert the two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)