### PR TITLE
perf(ui): stop syncing the mixer every frame when idle or closed

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1101,24 +1101,45 @@ void AestraContent::onUpdate(double dt) {
     // were frozen because nothing pumped the preview engine state.)
     updateSoundPreview();
 
-    // Sync track changes to MixerViewModel
+    // Sync the mixer view-model from the engine — but only while the mixer is
+    // visible and only when what it displays has actually changed. This block
+    // used to run every frame unconditionally AND redundantly (refreshChannels
+    // already calls syncFromEngine), so it re-dirtied the panel ~2x/frame even
+    // with the mixer closed, keeping the app off idle and hot with a plugin.
     auto tm = getTrackManager();
-    if (tm && m_mixerPanel) {
-        auto viewModel = m_mixerPanel->getViewModel();
-        if (viewModel) {
-            auto slotMap = tm->getChannelSlotMapRaw();
-            if (slotMap) {
-                viewModel->syncFromEngine(*tm, *slotMap);
-                m_mixerPanel->refreshChannels();
+    if (tm && m_mixerPanel && m_mixerPanel->isVisible() && m_mixerPanel->getViewModel()) {
+        // Cheap fingerprint of the displayed state: structural generation plus
+        // per-channel identity/state/level. Quantized levels so float noise
+        // doesn't force a resync; live values (automation, drags) still flip it.
+        uint64_t fp = tm->graphRebuildRequestGeneration() * 1099511628211ull;
+        const size_t channelCount = tm->getChannelCount();
+        fp = fp * 31 + channelCount;
+        for (size_t i = 0; i < channelCount; ++i) {
+            auto* ch = tm->getChannel(i);
+            if (!ch) continue;
+            uint64_t h = ch->getChannelId();
+            h = h * 31 + ch->getColor();
+            h = h * 31 + (static_cast<uint64_t>(ch->isMuted())
+                          | (static_cast<uint64_t>(ch->isSoloed()) << 1)
+                          | (static_cast<uint64_t>(ch->isArmed()) << 2)
+                          | (static_cast<uint64_t>(ch->isMonitoringEnabled()) << 3));
+            h = h * 31 + static_cast<uint64_t>(std::lround(ch->getVolume() * 1000.0f) & 0xFFFFF);
+            h = h * 31 + static_cast<uint64_t>(std::lround((ch->getPan() + 1.0f) * 1000.0f) & 0xFFFFF);
+            for (unsigned char c : ch->getName()) h = h * 31 + c;
+            fp ^= h + 0x9e3779b97f4a7c15ull + (fp << 6) + (fp >> 2);
+        }
 
-                // Force refresh the rack display if we have one bound
-                if (m_pluginController) {
-                    auto mixerUI = m_mixerPanel->getMixerUI();
-                    if (mixerUI) {
-                        auto inspector = mixerUI->getInspector();
-                        if (inspector && inspector->getEffectRack()) {
-                            m_pluginController->refreshRackDisplay(inspector->getEffectRack().get());
-                        }
+        if (fp != m_lastMixerFingerprint) {
+            m_lastMixerFingerprint = fp;
+            m_mixerPanel->refreshChannels(); // calls syncFromEngine internally
+
+            // Force refresh the rack display if we have one bound
+            if (m_pluginController) {
+                auto mixerUI = m_mixerPanel->getMixerUI();
+                if (mixerUI) {
+                    auto inspector = mixerUI->getInspector();
+                    if (inspector && inspector->getEffectRack()) {
+                        m_pluginController->refreshRackDisplay(inspector->getEffectRack().get());
                     }
                 }
             }
@@ -1156,10 +1177,11 @@ void AestraContent::onUpdate(double dt) {
         }
     }
 
-    // Update Mixer Meters (Real-time)
-    if (tm) {
+    // Update Mixer Meters (Real-time) — only while the mixer is visible; meters
+    // aren't shown otherwise, so smoothing them off-screen is wasted work.
+    if (tm && m_mixerPanel && m_mixerPanel->isVisible()) {
         auto snapshots = tm->getMeterSnapshots();
-        if (snapshots && m_mixerPanel) {
+        if (snapshots) {
             auto viewModel = m_mixerPanel->getViewModel();
             if (viewModel) {
                 viewModel->updateMeters(*snapshots, dt);

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -353,7 +353,11 @@ private:
     ViewFocus m_viewFocus = ViewFocus::Timeline;
     ViewFocus m_previousViewFocus = ViewFocus::Timeline;
     uint32_t m_lastSelectedChannelId = 0xFFFFFFFFu;
-    
+    // Fingerprint of the mixer's displayed state; the per-frame engine->view
+    // sync only runs when this changes (see onUpdate), so an idle mixer stops
+    // re-dirtying every frame.
+    uint64_t m_lastMixerFingerprint = 0;
+
     // Sound preview state
     bool m_previewIsPlaying = false;
     std::chrono::steady_clock::time_point m_previewStartTime{};


### PR DESCRIPTION
## Summary
Fixes the mixer FPS drop (30, sometimes 20) and the "hot with a plugin" feel. The mixer view-model sync ran on **every** `onUpdate`, **unconditionally and redundantly**:

- `onUpdate` called `viewModel->syncFromEngine()` **and** `m_mixerPanel->refreshChannels()` — but `refreshChannels()` already calls `syncFromEngine()` internally (plus a second slot-map snapshot, a device-manager query, and a per-channel loop). So the full structural rebuild — a channel snapshot, a `std::string` copy of every track name, and a map — ran **~2× per frame, even with the mixer closed.**
- That re-dirtied the panel every frame, keeping the app off idle-frame-elision and stacking with any plugin UI redraw → the "hot DAW."

### Changes
- **Gate the sync on `m_mixerPanel->isVisible()`** — a closed mixer does zero sync work.
- **Drop the redundant explicit `syncFromEngine`** in `onUpdate` (`refreshChannels` already does it) — halves the visible-case cost.
- **Change-gate `refreshChannels` on a cheap fingerprint** of the displayed state (graph generation + per-channel id/color/mute-solo-arm-monitor/quantized volume+pan/name). An open-but-idle mixer stops rebuilding and re-dirtying every frame, so idle elision (#402) can kick in. Live changes — automation, fader/pan drags, add/remove/rename/recolor — still flip the fingerprint and resync.
- **Gate the real-time meter smoothing on visibility** too — no point smoothing off-screen meters.

## Why
Owner flagged the mixer dropping to 20–30 fps on open, worse with a plugin. Root cause was the per-frame, doubled, ungated structural sync.

## Testing performed
- Full local UI build (`build-linux`, Release): clean.
- `ctest`: UI label tests 4/4, Mixer/Channel tests 6/6 pass.
- **FPS verification is the owner's**: open the mixer and watch the F12 HUD — idle should return toward 60 (was pinned re-dirtying), and open-with-plugin should stop cooking. I can't drive the GL app for a live frame-time read here.

## Risk/rollback notes
- Correctness rests on the fingerprint covering everything the mixer shows. It includes structure (graph generation + channel count), identity (id/color/name), state (mute/solo/arm/monitor), and levels (quantized volume/pan). Trim-only *external* changes (rare, e.g. automation with no other movement) could lag a frame until the next change — user trim drags update their strip directly and are unaffected. If that edge ever matters, add trim to the fingerprint.
- Meters unaffected while visible (separate pump); no DSP/serialization changes.
- Rollback = revert single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reduced mixer/UI work when the mixer is closed or idle by only syncing and refreshing mixer state when the panel is visible and the displayed engine state has actually changed.
- Added a lightweight mixer fingerprint cache so `refreshChannels()` and related rack updates only run when track/channel state, names, or relevant mixer values differ from the last frame.
- Stopped reading/updating mixer meters unless the mixer panel is visible, which avoids unnecessary per-frame meter smoothing work.
- Removed the redundant `syncFromEngine()` call from `onUpdate()`, helping idle-frame elision work again while preserving live updates for actions like automation, fader/pan drags, add/remove, rename, and recolor.
- Added a new private `m_lastMixerFingerprint` field to track the last rendered mixer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->