### PR TITLE
Mixer visual identity + flat/consistency pass

### DIFF
--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -827,14 +827,21 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
     // Shared vertical midline for the slot row — center everything around it
     const float slotMid = slotRect.y + slotRect.height * 0.5f;
 
-    // Slot Number (Left side, stylistic) — centered on slotMid
+    // Slot Number (Left side, stylistic) — centered on slotMid.
+    // Populated slots get a solid index chip (it shows chain order). Empty slots
+    // stay quiet — a faint bare number revealed only on hover — so an empty rack
+    // reads as a column of available slots rather than a numbered debug table.
     char numBuf[8];
     std::snprintf(numBuf, sizeof(numBuf), "%d", index + 1);
     const float chipH = 14.0f;
     const NUIRect indexChip{slotRect.x + 8.0f, slotMid - chipH * 0.5f, 18.0f, chipH};
-    renderer.fillRoundedRect(indexChip, 7.0f, Colors::buttonBackgroundHover.withAlpha(slot.isEmpty ? 0.62f : 0.76f));
-    renderer.strokeRoundedRect(indexChip, 7.0f, 1.0f, Colors::panelBorder.withAlpha(0.35f));
-    renderer.drawTextCentered(numBuf, indexChip, 9.0f, Colors::textDisabled.withAlpha(0.68f));
+    if (!slot.isEmpty) {
+        renderer.fillRoundedRect(indexChip, 7.0f, Colors::buttonBackgroundHover.withAlpha(0.76f));
+        renderer.strokeRoundedRect(indexChip, 7.0f, 1.0f, Colors::panelBorder.withAlpha(0.35f));
+        renderer.drawTextCentered(numBuf, indexChip, 9.0f, Colors::textDisabled.withAlpha(0.68f));
+    } else if (isHovered) {
+        renderer.drawTextCentered(numBuf, indexChip, 9.0f, Colors::textDisabled.withAlpha(0.55f));
+    }
 
     // Available text area to the right of the chip.
     // Use the same vertical extent as the chip so drawTextCentered aligns identically.
@@ -843,38 +850,33 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
     const float rowH = chipH; // 14 px — same height as the index chip
 
     if (slot.isEmpty) {
-        const NUIRect textRect{textX, slotMid - rowH * 0.5f, textW, rowH};
+        // Empty rows surface the affordance only on hover; the recessed row and
+        // subtle centre line already signal an available drop target, so the
+        // redundant em-dash placeholder is gone.
         if (isHovered) {
+            const NUIRect textRect{textX, slotMid - rowH * 0.5f, textW, rowH};
             renderer.drawTextCentered("+ Add Insert", textRect, 10.0f, Colors::textPrimary);
-        } else {
-            const NUIColor dashColor = NUIColor(1.0f, 1.0f, 1.0f, 0.12f);
-            renderer.drawTextCentered("\xe2\x80\x94", textRect, 10.0f, dashColor);
         }
     } else {
-        // Name line plus state indicators. Active state is shown by the purple dot;
-        // bypass and auto-quarantine need a text label.
+        // A user bypass simply greys the slot — no text label. The dimmed name
+        // (plus the recessed row background) carries the state. Auto-quarantine
+        // is a safety fault, not a user choice, so it still gets its warning.
+        const bool autoFaulted = slot.bypassed && slot.nonFiniteOutputFault;
         NUIColor nameColor = slot.bypassed ? Colors::textDisabled.withAlpha(0.6f) : Colors::textPrimary;
-        if (slot.bypassed) {
+        if (autoFaulted) {
             const NUIRect nameRect{textX, slotMid - rowH, textW, rowH};
             renderer.drawText(fitText(renderer, slot.name, 10.5f, nameRect.width),
                               {nameRect.x, nameRect.y + 2.0f},
                               10.5f,
                               nameColor);
+            const NUIRect statusRect{textX, slotMid, textW, rowH};
+            renderer.drawText("Output fault", {statusRect.x, statusRect.y + 2.0f}, 8.5f,
+                              NUIThemeManager::getInstance().getColor("warning").withAlpha(0.92f));
         } else {
             renderer.drawTextCentered(fitText(renderer, slot.name, 10.5f, textW),
                                       {textX, slotRect.y, textW, slotRect.height},
                                       10.5f,
                                       nameColor);
-        }
-
-        if (slot.bypassed) {
-            const NUIRect statusRect{textX, slotMid, textW, rowH};
-            const bool autoFaulted = slot.nonFiniteOutputFault;
-            const char* statusText = autoFaulted ? "Output fault" : "Bypassed";
-            const NUIColor statusColor = autoFaulted
-                                             ? NUIThemeManager::getInstance().getColor("warning").withAlpha(0.92f)
-                                             : Colors::textDisabled.withAlpha(0.72f);
-            renderer.drawText(statusText, {statusRect.x, statusRect.y + 2.0f}, 8.5f, statusColor);
         }
 
         // Active indicator / Bypass toggle

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -3,8 +3,12 @@
 
 #include "NUIThemeSystem.h"
 #include "NUIRenderer.h"
+#include "../Graphics/NUISVGParser.h"
 
 #include <algorithm>
+#include <cmath>
+#include <memory>
+#include <unordered_map>
 
 namespace AestraUI {
 
@@ -13,6 +17,25 @@ namespace {
     constexpr float BTN_H = 20.0f;
     constexpr float BTN_GAP = 5.0f;
     constexpr float BTN_RADIUS = 8.0f;
+
+    // Mute/solo/record glyphs — authored on a 24x24 grid, identical to the
+    // track-header control icons (Source/Components/TrackUIComponent.cpp) so the
+    // mixer and the arrangement lanes speak one icon language.
+    constexpr const char* kMuteIconSvg =
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="#fff"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="#fff" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
+    constexpr const char* kSoloIconSvg =
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="#fff"/></svg>)";
+    constexpr const char* kRecordIconSvg =
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="#fff" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="#fff"/></svg>)";
+
+    // Parsed once, then rasterized+cached per size/tint by NUISVGRenderer, so the
+    // per-frame cost is a single texture draw.
+    const NUISVGDocument* mixerControlIcon(const char* svg) {
+        static std::unordered_map<const char*, std::shared_ptr<NUISVGDocument>> docs;
+        auto& doc = docs[svg];
+        if (!doc) doc = NUISVGParser::parse(svg);
+        return doc.get();
+    }
 }
 
 UIMixerButtonRow::UIMixerButtonRow()
@@ -95,7 +118,7 @@ void UIMixerButtonRow::onResize(int width, int height)
 
 void UIMixerButtonRow::onRender(NUIRenderer& renderer)
 {
-    static constexpr const char* labels[kButtonCount] = {"M", "S", "R"};
+    static constexpr const char* icons[kButtonCount] = {kMuteIconSvg, kSoloIconSvg, kRecordIconSvg};
     auto& theme = NUIThemeManager::getInstance();
 
     for (int i = 0; i < kButtonCount; ++i) {
@@ -147,18 +170,24 @@ void UIMixerButtonRow::onRender(NUIRenderer& renderer)
             bg = active ? activeBg.withAlpha(0.28f) : theme.getColor("buttonBgActive").withAlpha(0.99f);
         }
 
-        // Active glow behind pill
-        if (active) {
-            renderer.drawGlow(visualRect, BTN_RADIUS, 0.6f, activeBg.withAlpha(0.45f));
-        }
-
+        // Flat active state (no glow): the coloured fill + border + white icon
+        // carry the on-state, matching the flat-active language used elsewhere.
         renderer.fillRoundedRect(visualRect, BTN_RADIUS, bg);
         renderer.strokeRoundedRect(visualRect, BTN_RADIUS, 1.0f, border);
         renderer.strokeRoundedRect({visualRect.x + 1.0f, visualRect.y + 1.0f, visualRect.width - 2.0f, visualRect.height - 2.0f},
                                    std::max(0.0f, BTN_RADIUS - 1.0f),
                                    1.0f,
                                    NUIColor::white().withAlpha(0.025f));
-        renderer.drawTextCentered(labels[i], visualRect, 10.0f, textColor);
+        // Centre the glyph in the raw button bounds (not the half-pixel-inset
+        // visualRect) so the offsets stay symmetric integers — matches the
+        // track-header control icons exactly.
+        if (const auto* doc = mixerControlIcon(icons[i])) {
+            const float iconSize = std::round(std::min(rect.width, rect.height) - 6.0f);
+            const NUIRect iconRect(std::round(rect.x + (rect.width - iconSize) * 0.5f),
+                                   std::round(rect.y + (rect.height - iconSize) * 0.5f),
+                                   iconSize, iconSize);
+            NUISVGRenderer::render(renderer, *doc, iconRect, textColor);
+        }
     }
 }
 

--- a/AestraUI/Widgets/UIMixerFXSummary.cpp
+++ b/AestraUI/Widgets/UIMixerFXSummary.cpp
@@ -75,7 +75,6 @@ void UIMixerFXSummary::onRender(NUIRenderer& renderer)
     if (m_pressed) {
         bg = NUIThemeManager::getInstance().getColor("buttonBgActive").withAlpha(0.99f);
     }
-    renderer.drawShadow(visualRect, 0.0f, 4.0f, 12.0f, NUIColor(0, 0, 0, 0.12f));
     renderer.fillRoundedRect(visualRect, RADIUS, bg);
     const bool hasFx = (m_fxCount > 0);
     const NUIColor border = hasFx

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -133,10 +133,8 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
     NUIRect handleRect{handleX, handleY, handleW, handleH};
     float handleRad = 4.0f;
 
-    // Drop shadow for depth
-    renderer.drawShadow(handleRect, 0.0f, 2.0f, 6.0f, NUIColor(0, 0, 0, 0.4f));
-
-    // Handle Body (dark surface)
+    // Handle Body (dark surface) — flat, no drop shadow; the border + slit
+    // give it enough definition.
     renderer.fillRoundedRect(handleRect, handleRad, NUIColor(0.18f, 0.18f, 0.18f, 0.98f));
 
     // Handle Border (accent when active/hovered, subtle white otherwise)

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -32,6 +32,9 @@ public:
     void setValueDb(float db);
     float getValueDb() const { return m_valueDb; }
 
+    // Per-channel accent: fill/handle-active colour follows the track colour.
+    void setAccentColor(const NUIColor& color) { m_trackFg = color; repaint(); }
+
     bool isDragging() const { return m_dragging; }
 
     std::function<void(float db)> onValueChanged;

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -210,6 +210,13 @@ void UIMixerInspector::setActiveTab(Tab tab)
         m_routingMap->setVisible(m_activeTab == Tab::Sends);
     }
 
+    // Tab-dependent layout (rack top pad, dropdowns, add-fx row) is computed in
+    // onResize, but a tab switch doesn't fire a resize. Re-run it for the new tab
+    // so the effect rack doesn't keep the previous tab's Y and overlap the
+    // Inserts section header.
+    const auto b = getBounds();
+    onResize(static_cast<int>(b.width), static_cast<int>(b.height));
+
     repaint();
 }
 
@@ -265,8 +272,10 @@ void UIMixerInspector::onResize(int width, int height)
     const auto b = getBounds();
     const float contentTop = PAD + TAB_H + SECTION_GAP + HEADER_H + SECTION_GAP;
     if (m_effectRack) {
-        // Inserts tab: keep the rack clear of the header breadcrumb/output line.
-        const float topPad = (m_activeTab == Tab::Inserts) ? 60.0f : 10.0f;
+        // Inserts tab: tuck the rack directly under the "INSERTS" section header
+        // + divider (headerBaseY+16 line, ~+20 from contentRect top) so the
+        // header reads as the list's title rather than a floating card.
+        const float topPad = (m_activeTab == Tab::Inserts) ? 28.0f : 10.0f;
         float rackH = std::max(0.0f, b.height - contentTop - topPad - PAD);
         m_effectRack->setBounds(b.x + PAD, b.y + contentTop + topPad, b.width - PAD * 2.0f, rackH);
     }
@@ -569,14 +578,22 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         float b = (argb & 0xFF) / 255.0f;
         titleAccent = NUIColor(r, g, b, a);
     }
-    const NUIRect titleChip{headerRect.x + 10.0f, headerRect.y + 10.0f, 56.0f, 18.0f};
-    renderer.fillRoundedRect(titleChip, 9.0f, m_bg.withAlpha(0.34f));
-    renderer.strokeRoundedRect(titleChip, 9.0f, 1.0f, titleAccent.withAlpha(0.22f));
-    renderer.drawTextCentered(channel->id == 0 ? "BUS" : "TRACK", titleChip, 10.0f, m_textSecondary.withAlpha(0.95f));
+    // Channel identity: a colour swatch beside the name. The old TRACK/BUS word
+    // pill was redundant with the "Track 1" title right below it — you're already
+    // in the mixer inspector, and the master reads as MASTER and is visually
+    // distinct. The swatch gives this spot a real job: it ties the inspector to
+    // the selected strip's colour.
+    const float swatchSize = 12.0f;
+    // Vertically centre the swatch on the title's optical middle. drawText places
+    // by glyph-top and the atlas renders a touch lower, so the swatch sits ~4px
+    // below the title top to line up with the text centre rather than its cap.
+    const NUIRect swatch{headerRect.x + 12.0f, headerRect.y + 18.0f, swatchSize, swatchSize};
+    renderer.fillRoundedRect(swatch, 4.0f, titleAccent.withAlpha(0.92f));
+    renderer.strokeRoundedRect(swatch, 4.0f, 1.0f, NUIColor::white().withAlpha(0.10f));
 
-    renderer.drawText(m_cachedHeaderTitle, {headerRect.x + 10.0f, headerRect.y + 30.0f}, 12.5f, m_text);
+    renderer.drawText(m_cachedHeaderTitle, {headerRect.x + 30.0f, headerRect.y + 13.0f}, 13.5f, m_text);
     if (!m_cachedHeaderSubtitle.empty()) {
-        renderer.drawText(m_cachedHeaderSubtitle, {headerRect.x + 10.0f, headerRect.y + 45.0f}, 11.0f, m_textSecondary.withAlpha(0.95f));
+        renderer.drawText(m_cachedHeaderSubtitle, {headerRect.x + 12.0f, headerRect.y + 34.0f}, 11.0f, m_textSecondary.withAlpha(0.95f));
     }
     {
         // Signal-flow breadcrumb: dim inactive steps, accent the active one,
@@ -586,41 +603,47 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         int activeIdx = -1;
         switch (m_activeTab) {
             case Tab::Inserts:
-                flowSteps[flowCount++] = "Input";
-                flowSteps[flowCount++] = "Trim";
-                flowSteps[flowCount++] = "Inserts"; activeIdx = flowCount - 1;
-                flowSteps[flowCount++] = "Output";
+                flowSteps[flowCount++] = "INPUT";
+                flowSteps[flowCount++] = "TRIM";
+                flowSteps[flowCount++] = "INSERTS"; activeIdx = flowCount - 1;
+                flowSteps[flowCount++] = "OUTPUT";
                 break;
             case Tab::Sends:
-                flowSteps[flowCount++] = "Inserts";
-                flowSteps[flowCount++] = "Sends"; activeIdx = flowCount - 1;
-                flowSteps[flowCount++] = "Fader";
-                flowSteps[flowCount++] = "Output";
+                flowSteps[flowCount++] = "INSERTS";
+                flowSteps[flowCount++] = "SENDS"; activeIdx = flowCount - 1;
+                flowSteps[flowCount++] = "FADER";
+                flowSteps[flowCount++] = "OUTPUT";
                 break;
             case Tab::IO:
-                flowSteps[flowCount++] = "Input"; activeIdx = flowCount - 1;
-                flowSteps[flowCount++] = "Monitor";
-                flowSteps[flowCount++] = "Record";
+                flowSteps[flowCount++] = "INPUT"; activeIdx = flowCount - 1;
+                flowSteps[flowCount++] = "MONITOR";
+                flowSteps[flowCount++] = "RECORD";
                 break;
         }
 
         float cursorX = headerRect.x + 10.0f;
         const float baselineY = headerRect.y + 62.0f;
-        const float stepFont = 9.5f;
+        const float stepFont = 9.0f;
 
         for (int i = 0; i < flowCount; ++i) {
             const std::string step = flowSteps[i];
             const bool active = (i == activeIdx);
-            const NUIColor stepColor = active ? accent.withAlpha(0.95f)
-                                              : m_textSecondary.withAlpha(0.55f);
+            // Active step follows the channel's own colour and carries a short
+            // underline "you are here" marker; inactive steps recede.
+            const NUIColor stepColor = active ? titleAccent.withAlpha(0.98f)
+                                              : m_textSecondary.withAlpha(0.50f);
             renderer.drawText(step, {cursorX, baselineY}, stepFont, stepColor);
             const float textW = renderer.measureText(step, stepFont).width;
-            cursorX += textW + 6.0f;
+            if (active) {
+                renderer.fillRect({cursorX, baselineY + 13.0f, textW, 1.5f},
+                                  titleAccent.withAlpha(0.90f));
+            }
+            cursorX += textW + 7.0f;
 
             if (i < flowCount - 1) {
                 renderer.drawText("›", {cursorX, baselineY}, stepFont,
-                                  m_textSecondary.withAlpha(0.40f));
-                cursorX += renderer.measureText("›", stepFont).width + 6.0f;
+                                  m_textSecondary.withAlpha(0.35f));
+                cursorX += renderer.measureText("›", stepFont).width + 7.0f;
             }
         }
     }
@@ -634,19 +657,22 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         } else {
             std::snprintf(buf, sizeof(buf), "%d insert%s active", fxCount, fxCount == 1 ? "" : "s");
         }
-        const float cardH = 48.0f;
-        const NUIRect summaryCard{contentRect.x, contentRect.y, contentRect.width, cardH};
-        renderer.fillRoundedRect(summaryCard, 10.0f, m_tabBg.withAlpha(0.42f));
-        renderer.strokeRoundedRect(summaryCard, 10.0f, 1.0f, accent.withAlpha(0.15f));
-
+        // Section header for the rack below — a plain eyebrow + count with a
+        // hairline divider (no boxed card), so it clearly titles the slot list
+        // rather than floating as a separate compartment above it.
+        const float headerBaseY = contentRect.y + 4.0f;
         renderer.drawText("INSERTS",
-                          {summaryCard.x + 12.0f, summaryCard.y + 9.0f},
+                          {contentRect.x + 2.0f, headerBaseY},
                           9.0f, m_textSecondary.withAlpha(0.72f));
+        const float countW = renderer.measureText(buf, 9.5f).width;
         renderer.drawText(buf,
-                          {summaryCard.x + 12.0f, summaryCard.y + 24.0f},
-                          11.0f, m_text.withAlpha(0.96f));
+                          {contentRect.x + contentRect.width - countW - 2.0f, headerBaseY},
+                          9.5f, m_textSecondary.withAlpha(0.85f));
+        renderer.fillRect({contentRect.x + 2.0f, headerBaseY + 16.0f, contentRect.width - 4.0f, 1.0f},
+                          m_border.withAlpha(0.45f));
 
-        // Rack is rendered by renderChildren() if visible
+        // Rack is rendered by renderChildren() if visible, tucked right under
+        // the divider (see onResize topPad for the Inserts tab).
     } else if (m_activeTab == Tab::Sends) {
         const int sendCount = static_cast<int>(m_sendWidgets.size());
         const std::string routingWarning = m_viewModel ? m_viewModel->getRoutingWarning(channel->id) : std::string();

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -74,7 +74,7 @@ UIMixerInspector::UIMixerInspector(Aestra::MixerViewModel* viewModel)
     });
     addChild(m_tabControl);
     m_tabControl->setSelectedIndex(static_cast<size_t>(m_activeTab), false);
-    m_tabControl->setAccentColor(NUIColor(0.62f, 0.58f, 0.98f, 1.0f));
+    m_tabControl->setAccentColor(NUIThemeManager::getInstance().getColor("primary"));
     
     // Bind Callbacks
     m_effectRack->setOnSlotBypassToggled([this](int slot, bool bypassed) {
@@ -185,12 +185,9 @@ void UIMixerInspector::setActiveTab(Tab tab)
     if (m_activeTab == tab) return;
     m_activeTab = tab;
 
-    NUIColor accent = NUIThemeManager::getInstance().getColor("accentPrimary");
-    switch (m_activeTab) {
-        case Tab::Inserts: accent = NUIColor(0.62f, 0.58f, 0.98f, 1.0f); break;
-        case Tab::Sends:   accent = NUIColor(0.42f, 0.86f, 0.92f, 1.0f); break;
-        case Tab::IO:      accent = NUIColor(0.90f, 0.74f, 0.50f, 1.0f); break;
-    }
+    // Active-tab accent is the app purple across all tabs — consistent with the
+    // transport/top-nav active state (was per-tab purple/cyan/amber).
+    const NUIColor accent = NUIThemeManager::getInstance().getColor("primary");
     if (m_tabControl) {
         m_tabControl->setAccentColor(accent);
         m_tabControl->setSelectedIndex(static_cast<size_t>(m_activeTab), false);
@@ -422,7 +419,7 @@ void UIMixerInspector::rebuildSendWidgets(const Aestra::ChannelViewModel* channe
     for (size_t i = 0; i < channel->sends.size(); ++i) {
         auto& sendData = channel->sends[i];
         auto widget = std::make_shared<UIMixerSend>();
-        widget->setAccentColor(NUIColor(0.42f, 0.86f, 0.92f, 0.92f));
+        widget->setAccentColor(NUIThemeManager::getInstance().getColor("primary").withAlpha(0.92f));
         
         widget->setSendIndex(static_cast<int>(i));
         widget->setLevel(sendData.gain);
@@ -491,19 +488,8 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
     const auto* channel = m_viewModel ? m_viewModel->getSelectedChannel() : nullptr;
     updateHeaderCache(channel);
 
-    NUIColor accent = NUIThemeManager::getInstance().getColor("accentPrimary");
-    switch (m_activeTab) {
-        case Tab::Inserts:
-            accent = NUIColor(0.62f, 0.58f, 0.98f, 1.0f);
-            break;
-        case Tab::Sends:
-            accent = NUIColor(0.42f, 0.86f, 0.92f, 1.0f);
-            break;
-        case Tab::IO:
-            accent = NUIColor(0.90f, 0.74f, 0.50f, 1.0f);
-            break;
-    }
-    
+    const NUIColor accent = NUIThemeManager::getInstance().getColor("primary");
+
     // Continuous sync for knobs to reflect automation/backend changes
     if (m_activeTab == Tab::Inserts && channel) {
         rebuildInsertRack(channel);
@@ -538,7 +524,6 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
             contentRect.width,
             std::min(emptyCardH, availableH)
         };
-        renderer.drawShadow(emptyCard, 0.0f, 4.0f, 14.0f, NUIColor(0, 0, 0, 0.12f));
         renderer.fillRoundedRect(emptyCard, HEADER_RADIUS, m_tabBg.withAlpha(0.62f));
         renderer.strokeRoundedRect(emptyCard, HEADER_RADIUS, 1.0f, m_border.withAlpha(0.42f));
         renderer.strokeRoundedRect({emptyCard.x + 1.0f, emptyCard.y + 1.0f, emptyCard.width - 2.0f, emptyCard.height - 2.0f},
@@ -561,7 +546,6 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         return;
     }
 
-    renderer.drawShadow(headerRect, 0.0f, 4.0f, 14.0f, NUIColor(0, 0, 0, 0.12f));
     renderer.fillRoundedRect(headerRect, HEADER_RADIUS, m_tabBg.withAlpha(0.70f));
     renderer.strokeRoundedRect(headerRect, HEADER_RADIUS, 1.0f, m_border.withAlpha(0.50f));
     renderer.strokeRoundedRect({headerRect.x + 1.0f, headerRect.y + 1.0f, headerRect.width - 2.0f, headerRect.height - 2.0f},
@@ -767,7 +751,6 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
              renderer.drawTextCentered("Master Output is fixed to Hardware Output 1/2", contentRect, 11.0f, m_textSecondary);
         } else if (m_activeTab == Tab::IO) {
              const NUIRect sourceCard{contentRect.x, contentRect.y, contentRect.width, 102.0f};
-             renderer.drawShadow(sourceCard, 0.0f, 4.0f, 12.0f, NUIColor(0, 0, 0, 0.10f));
              renderer.fillRoundedRect(sourceCard, 12.0f, m_tabBg.withAlpha(0.46f));
              renderer.strokeRoundedRect(sourceCard, 12.0f, 1.0f, accent.withAlpha(0.20f));
 

--- a/AestraUI/Widgets/UIMixerKnob.cpp
+++ b/AestraUI/Widgets/UIMixerKnob.cpp
@@ -225,10 +225,7 @@ void UIMixerKnob::onRender(NUIRenderer& renderer)
     NUIColor capColor = m_bg;
     if (hovered) capColor = m_bgHover;
 
-    // Drop shadow for depth — smaller blur when knob is tiny (three-knob row)
-    float shadowBlur = std::min(4.0f, capR * 0.5f);
-    renderer.drawShadow(NUIRect{cx - capR, cy - capR, capR * 2, capR * 2}, 0, 2, shadowBlur, NUIColor(0,0,0,0.5f));
-
+    // Flat cap: no drop shadow. The edge highlight below defines it.
     renderer.fillCircle({cx, cy}, capR, capColor);
 
     // Edge highlight for 3D feel

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -728,7 +728,7 @@ void UIMixerStrip::onRender(NUIRenderer& renderer)
     }
 
     if (selected) {
-        renderer.drawShadow(bounds, 0.0f, 8.0f, 18.0f, m_selectedGlow.withAlpha(0.08f));
+        // Flat selection: no drop shadow — a tint + top highlight + outline only.
         renderer.fillRoundedRect(bounds, radius, m_selectedTint);
 
         renderer.fillRect(NUIRect{bounds.x, bounds.y, bounds.width, SELECT_TOP_H}, m_selectedTopHighlight);

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -35,6 +35,16 @@ namespace {
     constexpr float SELECT_TOP_H = 3.0f;
     constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;
 
+    // Resolve a palette index to a renderer colour (matches UIMixerHeader::colorFromARGB).
+    NUIColor trackColorFromIndex(int index)
+    {
+        const uint32_t argb = paletteIndexToARGB(index);
+        return NUIColor(((argb >> 16) & 0xFF) / 255.0f,
+                        ((argb >> 8) & 0xFF) / 255.0f,
+                        (argb & 0xFF) / 255.0f,
+                        ((argb >> 24) & 0xFF) / 255.0f);
+    }
+
     std::string compactRouteName(uint32_t targetId, const std::string& targetName)
     {
         if (targetId == 0 || targetName == "Master" || targetName == "MASTER") {
@@ -577,6 +587,17 @@ void UIMixerStrip::onUpdate(double deltaTime)
         if (m_cachedTrackColorArgb != static_cast<uint32_t>(channel->trackColorIndex + 1)) {
             m_cachedTrackColorArgb = static_cast<uint32_t>(channel->trackColorIndex + 1);
             invalidateStaticCache();
+
+            // Thread the track colour through the strip's accent controls so each
+            // channel reads as its own instrument. Master (id 0) keeps the neutral
+            // primary accent, and unset tracks fall back to the widget defaults.
+            if (m_channelId != 0 && channel->trackColorIndex >= 0) {
+                const NUIColor accent = trackColorFromIndex(channel->trackColorIndex);
+                if (m_fader) m_fader->setAccentColor(accent);
+                if (m_trimKnob) m_trimKnob->setAccentColor(accent);
+                if (m_panKnob) m_panKnob->setAccentColor(accent);
+                if (m_widthKnob) m_widthKnob->setAccentColor(accent);
+            }
         }
         m_header->setTrackColorIndex(channel->trackColorIndex);
         m_header->setSelected(selected);

--- a/Source/Panels/WindowPanel.cpp
+++ b/Source/Panels/WindowPanel.cpp
@@ -205,11 +205,13 @@ void WindowPanel::onRender(AestraUI::NUIRenderer& renderer) {
     // Unified panel shell + flat titlebar treatment
     const float windowRadius = theme.getRadius("m");
     auto bodyColor = theme.getColor("surfaceTertiary");
-    auto titleBarColor = theme.getColor("surfaceRaised");
+    // Title bar shares the transport bar's charcoal (backgroundSecondary) so all
+    // docked-panel chrome reads as one consistent surface.
+    auto titleBarColor = theme.getColor("backgroundSecondary");
     auto borderColor = theme.getColor("border");
 
-    renderer.drawShadow(bounds, 0.0f, 10.0f, 28.0f, AestraUI::NUIColor(0, 0, 0, 0.22f));
-    
+    // Flat: no panel drop shadow — border + surface separation carry the frame.
+
     // Draw content background
     if (!m_minimized) {
         renderer.fillRoundedRect(bounds, windowRadius, bodyColor);


### PR DESCRIPTION
## Summary
An iterative, screenshot-driven pass giving the mixer real console identity and committing the mixer + docked panels to a flat, single-accent language.

- **Per-channel colour identity** — each strip's fader fill and knob arcs follow its own track colour (was global purple), so six strips read as six instruments. Master keeps the neutral accent.
- **M/S/R icons** — the strip's mute/solo/record use the same SVG glyphs as the arrangement track headers (one icon language), with a flat active state.
- **Inspector polish** — empty insert slots read as quiet available rows (no `N —` debug table); bypass greys the slot instead of a "Bypassed" label; the `INSERTS` eyebrow now titles the rack (no floating card); the signal-flow breadcrumb is uppercase micro-caps with the channel colour on the active step; the redundant `TRACK` word pill is replaced by a channel-colour swatch; tab switches re-layout so the rack no longer overlaps the header.
- **Flat pass** — removed every drop shadow across the mixer surfaces and the `WindowPanel` panel shadow. No 2.5D depth.
- **Consistency** — `WindowPanel` title bars now use the transport's charcoal (`backgroundSecondary`) across all docked panels; the inspector's active-tab accent is unified to the app purple (`primary`).

## Why
Owner-driven UI polish program. The mixer was a nice shell around a timeline but the strips were six purple clones and the inspector read as debug scaffolding. This gives the "engine room" identity and enforces one flat, one-accent grammar.

## Testing
- Built `AestraUI_Core` and the `Aestra` app target (`build-linux`, `-j2`) after each change — compiles clean.
- Verified each iteration visually via owner screenshots (colour identity, icon alignment, inspector header/breadcrumb/bypass, swatch centering, tab-overlap fix, flat pass, title-bar charcoal, tab unify).
- No DSP, serialization, or audio-path changes. UI/render only.

## Risk / rollback
- Pure render/styling changes to mixer widgets + `WindowPanel` chrome (shared by docked panels — piano roll etc. inherit the charcoal title bar and flat frame, intended).
- Rollback = revert the branch; no state/format impact.

## Follow-up
- Align the floating plugin-editor chrome (`AestraPanelWindow`) to the same charcoal/flat treatment (separate PR, to verify with an editor open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Replaced mixer M/S/R text labels with shared SVG icons and removed active-glow styling for a flatter, more consistent control look.
- Added per-strip accent handling so channel colors now flow into fader fills, knob accents, and strip selection styling; the master strip keeps the neutral accent.
- Simplified mixer/inspector/docked-panel chrome by removing drop shadows and switching title bars to flatter theme colors.
- Cleaned up the inspector UI: quieter empty insert slots, removed bypass text noise, simplified the INSERTS header, updated breadcrumbs to uppercase with active channel-color emphasis, and swapped the TRACK pill for a color swatch.
- Fixed inspector tab switching/layout so the Inserts rack positions correctly without waiting for a resize.
- Updated plugin rack slot rendering so empty slots are less visually noisy and bypass/fault status is shown more selectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->