### PR TITLE
ci: cap LSan build/test parallelism to avoid OOM kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,11 +372,11 @@ jobs:
         run: cmake --preset ci-lsan
 
       - name: Build
-        run: cmake --build --preset ci-lsan
+        run: cmake --build --preset ci-lsan --parallel 2
 
       - name: Test
         working-directory: build/ci-lsan
-        run: ctest --output-on-failure --output-junit ctest-results-lsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
+        run: ctest --parallel 2 --output-on-failure --output-junit ctest-results-lsan.xml -E "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecAccountApiClient"
 
       - name: Upload LSan test report
         if: always()


### PR DESCRIPTION
## Summary
The advisory **LeakSanitizer** job keeps failing with **exit 143 (SIGTERM) during the *Build* step** — the runner OOMs on the memory-heavy sanitizer build (`gmake … Terminated` across dozens of targets), so the job dies before any test runs and no leak is ever detected.

The **TSan** job hit the identical problem and was fixed in `4a91e383` by capping build/test parallelism to `--parallel 2`. The LSan job never got the same treatment. This applies it.

## Change
`.github/workflows/ci.yml`, `lsan-linux` job:
- `cmake --build --preset ci-lsan` → `… --parallel 2`
- `ctest …` → `ctest --parallel 2 …`

## Why
Two build jobs at unbounded parallelism exhaust the GitHub runner's memory. Capping to 2 trades a bit of wall-clock for a build that actually completes, matching the proven TSan config.

## Testing
- YAML validated (`yaml.safe_load`).
- Behavioural parity with the existing TSan job (same flags, same runner class). The real proof is this job going green on CI here.

## Risk / rollback
- CI-only, no product code. Mirrors an already-merged pattern. Rollback = revert the one-line-per-step change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)