### PR TITLE
Audio integrity 1/N: golden-audio regression harness

### DIFF
--- a/AestraDocs/audio-integrity-infrastructure.md
+++ b/AestraDocs/audio-integrity-infrastructure.md
@@ -108,7 +108,7 @@ deterministic silence render + one comparison + one CTest registration.
   case documents engine-legitimate processing (pan law, fades) which the
   expectation models explicitly, mirroring `GoldenReferenceTest`'s
   pan-law/trim handling.
-- **Measured baselines on develop @ 80bf87** (Linux, GCC, Release): silence and
+- **Measured baselines on develop @ 80fbbf87** (Linux, GCC, Release): silence and
   impulse render **bit-exact** (max abs error = 0); the 3-track gain+pan+
   bypassed-FX mix errs at one float ulp (5.96e-8, RMS −159.8 dB). Test
   thresholds (1e-6 / −120 dB) leave headroom for cross-platform FP/SIMD

--- a/AestraDocs/audio-integrity-infrastructure.md
+++ b/AestraDocs/audio-integrity-infrastructure.md
@@ -1,0 +1,144 @@
+# Audio Integrity Infrastructure — Survey & Plan
+
+**Status:** in progress · **Owner:** agent session 2026-07-06 · **Baseline:** develop @ 80fbbf87
+
+Mission: make it impossible for future PRs to silently change the sound, break
+render/playback parity, add unsafe audio-thread behavior, or hide timing
+regressions. This document records what already exists (with source
+locations), the gaps, and the PR plan. Claims below are backed by the cited
+files — nothing here is aspirational.
+
+---
+
+## 1. What already exists (survey findings)
+
+### Render paths — the ground truth
+
+- **Realtime path:** `RtAudioDriver::rtAudioCallback` (`AestraAudio/src/Linux/RtAudioDriver.cpp:248`)
+  → `AestraAudioController::audioCallback` (`Source/Core/AestraAudioController.cpp:407`)
+  → `AudioEngine::processBlock` (`AestraAudio/src/Core/AudioEngine.cpp:593`).
+  After the engine block, the device callback **additively mixes** input
+  monitoring (`TrackManager::mixInputMonitoring`) and browser preview
+  (`PreviewEngine::processRealtime`) into the same output buffer
+  (`AestraAudioController.cpp:429-437`).
+- **Offline export path:** `AudioEngine::bounceRangeToWav` (`AudioEngine.cpp:3096`)
+  → `AudioExporter::render` (`AestraAudio/src/IO/AudioExporter.cpp:83`), which
+  drives **the same `AudioEngine::processBlock`** in a loop with metronome and
+  audition disabled and transport forced playing (`AudioExporter.cpp:206-233`).
+  Isolated track bounce (trackId ≥ 0) still uses an older renderBlock path
+  (`AudioEngine.cpp:3120`, marked TODO in source).
+- Consequence: playback/export parity is testable by driving `processBlock`
+  directly ("realtime style") vs `bounceRangeToWav` on the same session.
+
+### Existing tests (registered in `Tests/CMakeLists.txt`)
+
+| Test | What it actually covers | Label |
+|---|---|---|
+| `GoldenReferenceTest` (`Tests/AestraAudio/GoldenReferenceTest.cpp`) | Analytic golden: 3 sines + impulse through engine `processBlock`, RMS/peak/correlation vs computed reference | `audio;quality;golden;s-tier` |
+| `ExportBounceParityTest` | Master bounce ≈ sum of isolated track bounces (bounce self-consistency, **not** realtime-vs-offline) | `audio;quality;export;s-tier` |
+| `AudioPurityAuditTest` | End-to-end purity truth test (no hidden master processing) | `audio;quality;audit;purity;s-tier` |
+| `PreviewAuditionGainParityTest` | Preview/audition gain behavior | `audio;preview;audition;gain;regression` |
+| `TrackManagerMasterDuckingAuditTest` | Preview→master ducking behavior (owner's audit, PR #419) | `audio;quality;regression;playback;metering` |
+| `OfflineRenderRegressionTest` + `Tests/Headless/*` | Offline renderer, PDC suite | headless |
+| `AudioEngineDiagnosticsTest` | Pokes `recordRTViolation` manually | `audio;diagnostics;rt-safety` |
+| `SampleRateConverterTest` | SRC unit test — **gated experimental/unstable, not in default CI** | `experimental;unstable` |
+
+### RT-safety infrastructure
+
+- `ScopedRealtimeAudioThread` marks the audio thread; **placed in
+  `processBlock`** (`AudioEngine.cpp:594`), so both realtime and offline export
+  run under the guard.
+- `reportRealtimeMisuse(api)` is called by ~20 non-RT APIs to self-report if
+  invoked from the audio thread (`EffectChain.cpp`, `AudioEngine.cpp`,
+  `TrackManager.h:105`, `GarbageCollector.h:203`, `PatternPlaybackEngine.cpp:145`).
+- `RTGuard.h` defines thread-local violation ring buffers +
+  `recordRTViolation()` — **but nothing hooks it**: there is no operator
+  new/delete trap, no mutex wrapper. The only caller is the test poking it
+  manually (`AudioEngineDiagnosticsTest.cpp:73`).
+- `AudioTelemetry` has `rtAllocationViolations` / `rtLockViolations` /
+  `rtLogViolations` counters — **no producer increments them** (verified by
+  grep; only the header defines them).
+
+### Callback timing (deadline) infrastructure
+
+- `AestraAudioController::audioCallback` already measures per-callback cycles
+  and publishes `lastCallbackNs`, `maxCallbackNs`, and increments `overruns`
+  when duration exceeds the buffer deadline (`AestraAudioController.cpp:443-459`).
+- `DriverStatistics` declares `averageCallbackTimeUs` / `maxCallbackTimeUs` /
+  `cpuLoadPercent`; **filled by WASAPI drivers on Windows**
+  (`WASAPISharedDriver.cpp:897`), **not filled by the Linux RtAudioDriver**
+  (callback at `RtAudioDriver.cpp:248` only counts callbacks/underruns).
+- `AudioEngineDiagnostics` struct (`include/Core/AudioEngineDiagnostics.h`)
+  declares a full multi-tier timing model — **no writer exists anywhere**
+  (grep: only header, CMake, and its test reference it). It is aspirational.
+- Missing everywhere: an **average** (no total-time accumulator) and a
+  test that validates the deadline math.
+
+### Preview/audition isolation — structural facts
+
+- Preview audio is mixed **post-engine, in the device callback only**
+  (`AestraAudioController.cpp:434-437`). The offline export path never runs
+  that code, so exported audio structurally cannot contain preview *signal*.
+- BUT: preview *ducking* is computed **inside `processBlock`**
+  (`AudioEngine.cpp:925-971`) from `preview->isAudiblyPlaying()`, and
+  `AudioExporter` forces `setTransportPlaying(true)`. **Candidate bug: an
+  audible preview during an offline export attenuates the export by the duck
+  gain.** Unproven until tested — PR-2 writes this test first.
+
+## 2. Gap analysis → PR plan
+
+Small PR series, every PR independently useful, all off `develop`:
+
+| PR | Content | Mission areas |
+|---|---|---|
+| **PR-1** | Golden-audio harness: shared diff/report header (max abs err, RMS, first-mismatch frame+channel, peak diff, SR, length), 3 new cases — silence/empty project, impulse via master, multi-track gain+pan+FX — plus reference-update policy doc. Reuses the analytic-expectation approach of `GoldenReferenceTest` (no binary fixtures). | 1, 7 |
+| **PR-2** | Realtime-vs-offline parity: same session through direct `processBlock` loop vs `bounceRangeToWav`; probes for limiter/master gain/dither/transport fades; **duck-during-export** regression test (fix minimally if it fails). | 2, 6 |
+| **PR-3** | RT-safety: test-binary-level operator new/delete trap that records violations while `isRealtimeAudioThread()`; render a session under the trap and assert zero allocations; grep-based static audit script + findings table with classifications. | 3 |
+| **PR-4** | Deadline diagnostics consolidation: add average accumulation (total ns counter) to `AudioTelemetry`, fill Linux `DriverStatistics` timing, test validating avg/max/budget/over-budget math. No new parallel system. | 4 |
+| **PR-5** | Sample-rate & buffer truth: 96 kHz end-to-end render test (impulse/sine where wrong SR is obvious), odd buffer-size sweep (e.g. 64/193/512/1024), stale-buffer leak check, render-length-in-samples assertions. | 5 |
+| **PR-6** | Preview isolation boundary doc + any residual regression tests not covered by PR-2's duck test. | 6 |
+
+Vertical slice inside PR-1 (built first, before anything else): one
+deterministic silence render + one comparison + one CTest registration.
+
+## 3. Tolerance policy (PR-1, applies everywhere)
+
+- Comparisons run on float32 output promoted to double.
+- **Analytic cases** (silence, impulse, sine): max abs error ≤ 1e-6 unless the
+  case documents engine-legitimate processing (pan law, fades) which the
+  expectation models explicitly, mirroring `GoldenReferenceTest`'s
+  pan-law/trim handling.
+- **Measured baselines on develop @ 80bf87** (Linux, GCC, Release): silence and
+  impulse render **bit-exact** (max abs error = 0); the 3-track gain+pan+
+  bypassed-FX mix errs at one float ulp (5.96e-8, RMS −159.8 dB). Test
+  thresholds (1e-6 / −120 dB) leave headroom for cross-platform FP/SIMD
+  reassociation only — they are tripwires, not shrugs.
+- **Cross-path parity** (PR-2): RMS diff ≤ −100 dB and max abs ≤ 1e-4 after
+  trimming documented transport fades; any bit-exact match is reported as such.
+- Failures always print: max abs error, RMS error (dB), first mismatching
+  frame + channel, peak difference, sample rate, rendered length in
+  samples — enough to diagnose without opening audio files.
+
+## 4. How golden references are generated/updated
+
+References are **analytic** (computed at test runtime from closed-form
+signals), not stored waveforms — nothing binary in git, nothing to regenerate.
+If a legitimate engine change shifts expected output (e.g. a deliberate pan-law
+change), update the expectation math in the test alongside the engine change,
+in the same PR, with the reasoning in the commit message.
+
+## 5. What this protects / does not protect
+
+**Protects:** the summing/master path (silence in = silence out, unity
+routing, pan law, multi-track summing), realtime-vs-export equivalence,
+allocation-freedom of the render path under test, callback deadline
+accounting, sample-rate/buffer-boundary correctness, preview isolation.
+
+**Does not protect:** perceptual quality of DSP algorithms (a "better verb"
+still needs ears), plugin-internal behavior beyond bypass/summing, hardware
+driver behavior (tests run headless), Windows/macOS driver timing paths
+(only compile-checked in CI).
+
+## 6. RT-safety audit findings
+
+See `AestraDocs/rt-safety-audit.md` (PR-3).

--- a/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
+++ b/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
@@ -1,0 +1,193 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// GoldenAudioHarness — shared helpers for golden-audio regression tests.
+//
+// Design: references are ANALYTIC (computed at runtime from closed-form
+// signals), never stored waveforms — nothing binary lives in git. If a
+// deliberate engine change shifts expected output, update the expectation
+// math in the same PR as the engine change, with reasoning in the commit.
+//
+// Every comparison produces a DiffReport with enough diagnostics to
+// understand a failure without opening audio files:
+//   max abs error, RMS error (dB), first mismatching frame + channel,
+//   per-buffer peaks and their difference, sample rate, rendered length.
+#pragma once
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace GoldenAudio {
+
+// =============================================================================
+// Diff / report
+// =============================================================================
+
+struct DiffReport {
+    double maxAbsError{0.0};
+    double rmsErrorDb{-999.0};
+    int64_t firstMismatchFrame{-1}; // -1 = no sample exceeded tolerance
+    int firstMismatchChannel{-1};
+    double peakActual{0.0};
+    double peakExpected{0.0};
+    double peakDifference{0.0};
+    uint32_t sampleRate{0};
+    uint64_t frames{0};
+    uint32_t channels{0};
+};
+
+/// Compare interleaved buffers. `tolerance` is the per-sample abs threshold
+/// used for first-mismatch localization (the pass/fail policy is the caller's).
+inline DiffReport compareBuffers(const std::vector<float>& actual, const std::vector<float>& expected,
+                                 uint32_t channels, uint32_t sampleRate, double tolerance) {
+    DiffReport r;
+    r.sampleRate = sampleRate;
+    r.channels = channels;
+    const size_t n = std::min(actual.size(), expected.size());
+    r.frames = (channels > 0) ? static_cast<uint64_t>(n / channels) : 0;
+
+    double sumSq = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        const double a = static_cast<double>(actual[i]);
+        const double e = static_cast<double>(expected[i]);
+        const double diff = std::abs(a - e);
+        sumSq += diff * diff;
+        r.maxAbsError = std::max(r.maxAbsError, diff);
+        r.peakActual = std::max(r.peakActual, std::abs(a));
+        r.peakExpected = std::max(r.peakExpected, std::abs(e));
+        if (diff > tolerance && r.firstMismatchFrame < 0) {
+            r.firstMismatchFrame = static_cast<int64_t>(i / channels);
+            r.firstMismatchChannel = static_cast<int>(i % channels);
+        }
+    }
+    r.peakDifference = std::abs(r.peakActual - r.peakExpected);
+    const double rms = (n > 0) ? std::sqrt(sumSq / static_cast<double>(n)) : 0.0;
+    r.rmsErrorDb = 20.0 * std::log10(std::max(rms, 1e-15));
+    return r;
+}
+
+/// Print a pass/fail line; on failure, dump full forensics plus a pointer to
+/// the paths a regression most likely came from.
+inline void printReport(const std::string& label, const DiffReport& r, bool pass,
+                        const std::string& toleranceDescription) {
+    std::cout << "[" << (pass ? "PASS" : "FAIL") << "] " << label
+              << "  maxAbsErr=" << r.maxAbsError
+              << "  rmsErr=" << r.rmsErrorDb << " dB\n";
+    if (!pass) {
+        std::cout << "  ---- golden-audio failure forensics ----\n"
+                  << "  tolerance:        " << toleranceDescription << "\n"
+                  << "  max abs error:    " << r.maxAbsError << "\n"
+                  << "  RMS error:        " << r.rmsErrorDb << " dB\n"
+                  << "  first mismatch:   frame " << r.firstMismatchFrame
+                  << ", channel " << r.firstMismatchChannel
+                  << (r.firstMismatchFrame >= 0 && r.sampleRate > 0
+                          ? "  (~" + std::to_string(static_cast<double>(r.firstMismatchFrame) /
+                                                    static_cast<double>(r.sampleRate)) + " s)"
+                          : std::string())
+                  << "\n"
+                  << "  peak actual:      " << r.peakActual << "\n"
+                  << "  peak expected:    " << r.peakExpected << "\n"
+                  << "  peak difference:  " << r.peakDifference << "\n"
+                  << "  sample rate:      " << r.sampleRate << " Hz\n"
+                  << "  rendered length:  " << r.frames << " frames x " << r.channels << " ch\n"
+                  << "  If this engine change is INTENTIONAL, update the analytic\n"
+                  << "  expectation in this test in the same PR and explain why in the\n"
+                  << "  commit message. Likely regression sources: AudioEngine::processBlock\n"
+                  << "  master stage, AudioRenderer summing/pan, clip playback interpolation.\n";
+    }
+}
+
+// =============================================================================
+// Session building (mirrors the setup used by GoldenReferenceTest)
+// =============================================================================
+
+struct SessionConfig {
+    uint32_t sampleRate{48000};
+    uint32_t blockSize{512};
+    uint32_t channels{2};
+    float bpm{120.0f};
+};
+
+/// Add one audio track whose clip contains `interleaved` (stereo) samples,
+/// starting at beat 0. Returns the lane's source id.
+inline Aestra::Audio::ClipSourceID addAudioTrack(Aestra::Audio::TrackManager& tm, const std::string& label,
+                                                 const std::vector<float>& interleaved, uint32_t frames,
+                                                 const SessionConfig& cfg) {
+    using namespace Aestra::Audio;
+    tm.addChannel(label);
+
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = cfg.sampleRate;
+    buffer->numChannels = cfg.channels;
+    buffer->numFrames = frames;
+    buffer->interleavedData = interleaved;
+
+    const std::string path =
+        (std::filesystem::temp_directory_path() / ("golden_audio_" + label + ".wav")).string();
+    ClipSourceID sourceId = tm.getSourceManager().createRecordedSource(path, label, buffer);
+
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = static_cast<double>(frames) / cfg.sampleRate;
+    payload.slices.push_back({0.0, payload.durationSeconds, 0.0, static_cast<double>(frames)});
+
+    PlaylistLaneID laneId = tm.getPlaylistModel().createLane(label);
+    const double durationBeats =
+        payload.durationSeconds * (static_cast<double>(cfg.bpm) / 60.0);
+    PatternID patternId =
+        tm.getPatternManager().createAudioPattern(label, durationBeats, payload);
+    tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+    return sourceId;
+}
+
+/// Configure an engine on the given session the same way the app does:
+/// graph from track manager, slot map shared, limiter/metronome/audition off
+/// (deterministic), transport at sample 0.
+inline void prepareEngine(Aestra::Audio::AudioEngine& engine,
+                          const std::shared_ptr<Aestra::Audio::TrackManager>& tm, const SessionConfig& cfg) {
+    using namespace Aestra::Audio;
+    engine.setSampleRate(cfg.sampleRate);
+    engine.setBufferConfig(cfg.blockSize, cfg.channels);
+    engine.setTrackManager(tm);
+    engine.setBPM(cfg.bpm);
+    engine.setSafetyLimiterEnabled(false);
+    tm->buildAndShareSlotMap();
+    if (auto slotMap = tm->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+    engine.initialize();
+    engine.setMetronomeEnabled(false);
+    engine.setAuditionModeEnabled(false);
+    engine.setGlobalSamplePos(0);
+}
+
+/// Drive processBlock exactly like the realtime device callback would:
+/// zero-filled output blocks, sequential frames. Returns interleaved output.
+inline std::vector<float> renderBlocks(Aestra::Audio::AudioEngine& engine, uint64_t totalFrames,
+                                       const SessionConfig& cfg) {
+    std::vector<float> output;
+    output.reserve(static_cast<size_t>(totalFrames) * cfg.channels);
+    std::vector<float> block(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    uint64_t rendered = 0;
+    while (rendered < totalFrames) {
+        const uint32_t frames =
+            static_cast<uint32_t>(std::min<uint64_t>(cfg.blockSize, totalFrames - rendered));
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, frames, 0.0);
+        output.insert(output.end(), block.begin(),
+                      block.begin() + static_cast<ptrdiff_t>(static_cast<size_t>(frames) * cfg.channels));
+        rendered += frames;
+    }
+    return output;
+}
+
+} // namespace GoldenAudio

--- a/Tests/AestraAudio/GoldenAudioRegressionTest.cpp
+++ b/Tests/AestraAudio/GoldenAudioRegressionTest.cpp
@@ -1,0 +1,252 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// GoldenAudioRegressionTest — deterministic golden-audio cases for the render
+// path. Complements GoldenReferenceTest (sine/impulse fidelity) with the cases
+// that catch silent contamination and summing/gain/pan regressions:
+//
+//   1. Silence — an empty playing project must render EXACT zeros. Catches
+//      metronome leakage, test-tone leakage, uninitialized buffers, denormal
+//      noise, and any hidden master processing that manufactures output.
+//   2. (added below in this series) Impulse through the master path.
+//   3. (added below in this series) Multi-track mix with gain and pan.
+//
+// References are analytic; tolerance policy and update procedure are
+// documented in AestraDocs/audio-integrity-infrastructure.md.
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+
+#include "Core/ChannelSlotMap.h"
+#include "DSP/ContinuousParamBuffer.h"
+#include "DSP/PanLaw.h"
+#include "Plugin/SamplerPlugin.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+
+namespace {
+
+constexpr uint32_t kSeconds = 1;
+constexpr double kTau = 6.28318530717958647692;
+
+std::vector<float> makeSine(double freqHz, float amplitude, uint32_t frames, uint32_t sampleRate) {
+    std::vector<float> s(static_cast<size_t>(frames) * 2, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const float v = static_cast<float>(std::sin(kTau * freqHz * static_cast<double>(i) / sampleRate)) *
+                        amplitude;
+        s[static_cast<size_t>(i) * 2] = v;
+        s[static_cast<size_t>(i) * 2 + 1] = v;
+    }
+    return s;
+}
+
+// -----------------------------------------------------------------------------
+// Case 1: silence / empty project → bit-exact zeros
+// -----------------------------------------------------------------------------
+bool runSilenceCase() {
+    SessionConfig cfg;
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    tm->addChannel("Empty"); // a real (empty) channel so the graph is non-trivial
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+
+    const uint64_t totalFrames = static_cast<uint64_t>(cfg.sampleRate) * kSeconds;
+    std::vector<float> output = renderBlocks(engine, totalFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    const std::vector<float> expected(output.size(), 0.0f);
+    DiffReport r = compareBuffers(output, expected, cfg.channels, cfg.sampleRate, 0.0);
+
+    // Policy: EXACT zeros. Any nonzero sample in an empty project is
+    // manufactured audio and is a bug, full stop.
+    const bool pass = (r.maxAbsError == 0.0) && (r.frames == totalFrames);
+    printReport("Silence_EmptyProject", r, pass, "exact zeros (0.0, no tolerance)");
+    if (r.frames != totalFrames) {
+        std::cout << "  render length wrong: got " << r.frames << " frames, expected " << totalFrames
+                  << "\n";
+    }
+    return pass;
+}
+
+// -----------------------------------------------------------------------------
+// Case 2: single impulse through the master path — exact position + amplitude
+// -----------------------------------------------------------------------------
+// The impulse is placed past the first block so the transport fade-in has
+// completed. Expectation models the engine's centre pan law (cos(π/4)).
+// A wrong sample rate, a shifted render, or a master-gain change moves or
+// scales the impulse and fails with the exact frame in the report.
+bool runImpulseCase() {
+    SessionConfig cfg;
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+    const uint32_t impulseFrame = cfg.blockSize + 64;
+    constexpr float kAmp = 0.5f;
+
+    std::vector<float> clip(static_cast<size_t>(totalFrames) * 2, 0.0f);
+    clip[static_cast<size_t>(impulseFrame) * 2] = kAmp;
+    clip[static_cast<size_t>(impulseFrame) * 2 + 1] = kAmp;
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    addAudioTrack(*tm, "Impulse", clip, totalFrames, cfg);
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+    std::vector<float> output = renderBlocks(engine, totalFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    // Expected: pan-law-scaled impulse at the same frame; zeros elsewhere.
+    std::vector<float> expected(output.size(), 0.0f);
+    const float panGain = PanLaw::kEqualPowerCenterGain;
+    expected[static_cast<size_t>(impulseFrame) * 2] = kAmp * panGain;
+    expected[static_cast<size_t>(impulseFrame) * 2 + 1] = kAmp * panGain;
+
+    // Trim start (fade-in ramp) and end (clip-edge fade), as GoldenReferenceTest does.
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * cfg.channels;
+    const size_t trimEnd = static_cast<size_t>(256) * cfg.channels;
+    std::vector<float> outMid(output.begin() + static_cast<ptrdiff_t>(trimStart),
+                              output.end() - static_cast<ptrdiff_t>(trimEnd));
+    std::vector<float> expMid(expected.begin() + static_cast<ptrdiff_t>(trimStart),
+                              expected.end() - static_cast<ptrdiff_t>(trimEnd));
+
+    // Measured on develop@80fbbf87: bit-exact (maxAbsErr = 0). Tolerance leaves
+    // headroom for cross-platform FP/SIMD variation only.
+    DiffReport r = compareBuffers(outMid, expMid, cfg.channels, cfg.sampleRate, 1e-6);
+    const bool lengthOk = (output.size() == static_cast<size_t>(totalFrames) * cfg.channels);
+    const bool pass = (r.rmsErrorDb <= -120.0) && (r.maxAbsError <= 1e-6) && lengthOk;
+    printReport("Impulse_MasterPath", r, pass, "RMS <= -120 dB and maxAbs <= 1e-6 after documented trims");
+    if (!lengthOk) {
+        std::cout << "  render length wrong: got " << output.size() / cfg.channels << " frames, expected "
+                  << totalFrames << "\n";
+    }
+    return pass;
+}
+
+// -----------------------------------------------------------------------------
+// Case 3: multi-track mix — 3 sines with distinct fader gains and pans, plus a
+// bypassed insert on one track (exercises the effect-chain path while keeping
+// the expectation analytic; bypass parity is engine policy, AGENTS §11).
+// -----------------------------------------------------------------------------
+bool runMultiTrackMixCase() {
+    SessionConfig cfg;
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+
+    struct TrackSpec {
+        double freq;
+        float amp;
+        float faderDb;
+        float pan;
+    };
+    const TrackSpec specs[3] = {
+        {440.0, 0.30f, 0.0f, 0.0f},   // unity, centre
+        {660.0, 0.20f, -6.0f, -0.5f}, // -6 dB, half-left
+        {880.0, 0.15f, -3.0f, 0.75f}, // -3 dB, right-leaning
+    };
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    for (int t = 0; t < 3; ++t) {
+        addAudioTrack(*tm, "Mix" + std::to_string(t), makeSine(specs[t].freq, specs[t].amp, totalFrames, cfg.sampleRate),
+                      totalFrames, cfg);
+    }
+
+    // Bypassed insert on track 1: the chain still runs its processing path,
+    // but a bypassed slot must be acoustically transparent.
+    if (auto* ch = tm->getChannel(1)) {
+        auto plugin = std::make_shared<Plugins::SamplerPlugin>();
+        plugin->initialize(static_cast<double>(cfg.sampleRate), cfg.blockSize);
+        ch->getEffectChain().prepare(static_cast<double>(cfg.sampleRate), cfg.blockSize);
+        ch->getEffectChain().insertPlugin(0, plugin);
+        ch->getEffectChain().setSlotBypassed(0, true);
+    }
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+
+    // Fader/pan via the same continuous-param path the UI uses (dense slots
+    // are assigned in track order by ChannelSlotMap::rebuild).
+    auto params = std::make_shared<ContinuousParamBuffer>();
+    for (uint32_t t = 0; t < 3; ++t) {
+        params->setFaderDb(t, specs[t].faderDb);
+        params->setPan(t, specs[t].pan);
+    }
+    engine.setContinuousParams(params);
+
+    engine.setTransportPlaying(true);
+    std::vector<float> output = renderBlocks(engine, totalFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    // Expected: sum of pan-law-scaled, fader-scaled sines.
+    std::vector<float> expected(static_cast<size_t>(totalFrames) * 2, 0.0f);
+    for (const auto& s : specs) {
+        const double gain = std::pow(10.0, static_cast<double>(s.faderDb) / 20.0);
+        double gL = 0.0, gR = 0.0;
+        PanLaw::equalPower(static_cast<double>(s.pan), gain, gL, gR);
+        for (uint32_t i = 0; i < totalFrames; ++i) {
+            const double v = std::sin(kTau * s.freq * static_cast<double>(i) / cfg.sampleRate) *
+                             static_cast<double>(s.amp);
+            expected[static_cast<size_t>(i) * 2] += static_cast<float>(v * gL);
+            expected[static_cast<size_t>(i) * 2 + 1] += static_cast<float>(v * gR);
+        }
+    }
+
+    // Trim start generously (fade-in + any fader/pan smoothing ramp) and the
+    // clip-edge fade at the end.
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * 4 * cfg.channels;
+    const size_t trimEnd = static_cast<size_t>(256) * cfg.channels;
+    std::vector<float> outMid(output.begin() + static_cast<ptrdiff_t>(trimStart),
+                              output.end() - static_cast<ptrdiff_t>(trimEnd));
+    std::vector<float> expMid(expected.begin() + static_cast<ptrdiff_t>(trimStart),
+                              expected.end() - static_cast<ptrdiff_t>(trimEnd));
+
+    // Measured on develop@80fbbf87: maxAbsErr = 5.96e-8 (~1 float ulp at this
+    // scale), RMS = -159.8 dB. Tolerance leaves headroom for cross-platform
+    // FP/SIMD reassociation while staying a real tripwire.
+    DiffReport r = compareBuffers(outMid, expMid, cfg.channels, cfg.sampleRate, 1e-6);
+    const bool pass = (r.rmsErrorDb <= -120.0) && (r.maxAbsError <= 1e-6);
+    printReport("MultiTrack_Gain_Pan_BypassedFX", r, pass,
+                "RMS <= -120 dB and maxAbs <= 1e-6 after documented trims");
+    return pass;
+}
+
+// -----------------------------------------------------------------------------
+// Case 0 (meta): prove the diff forensics themselves are correct, so a future
+// failure report can be trusted without re-deriving it by hand.
+// -----------------------------------------------------------------------------
+bool runDiffSelfCheck() {
+    // Stereo, 4 frames. Inject a known mismatch at frame 2, channel R.
+    const std::vector<float> expected = {0.0f, 0.0f, 0.1f, 0.1f, 0.2f, 0.2f, 0.3f, 0.3f};
+    std::vector<float> actual = expected;
+    actual[5] += 0.25f; // frame 2, channel 1
+
+    DiffReport r = compareBuffers(actual, expected, 2, 48000, 1e-6);
+    // Inputs are float32, so 0.45f − 0.2f only equals 0.25 to float precision.
+    const bool pass = r.firstMismatchFrame == 2 && r.firstMismatchChannel == 1 &&
+                      std::abs(r.maxAbsError - 0.25) < 1e-6 && r.frames == 4 &&
+                      std::abs(r.peakActual - 0.45) < 1e-6 && std::abs(r.peakExpected - 0.3) < 1e-6;
+    std::cout << "[" << (pass ? "PASS" : "FAIL") << "] DiffReport_SelfCheck"
+              << "  (mismatch localized to frame " << r.firstMismatchFrame << ", ch "
+              << r.firstMismatchChannel << ")\n";
+    return pass;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Aestra Golden Audio Regression Suite ===\n\n";
+    int failures = 0;
+    if (!runDiffSelfCheck()) ++failures;
+    if (!runSilenceCase()) ++failures;
+    if (!runImpulseCase()) ++failures;
+    if (!runMultiTrackMixCase()) ++failures;
+
+    std::cout << "\n" << (failures == 0 ? "ALL PASS" : "FAILURES: " + std::to_string(failures)) << "\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1153,6 +1153,21 @@ target_include_directories(GoldenReferenceTest PRIVATE
 add_test(NAME GoldenReferenceTest COMMAND GoldenReferenceTest)
 set_tests_properties(GoldenReferenceTest PROPERTIES LABELS "audio;quality;golden;s-tier")
 
+# Golden Audio Regression — analytic golden cases for the render path:
+# silence/empty project, impulse via master, multi-track gain+pan mix.
+# Harness: Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h.
+# Policy doc: AestraDocs/audio-integrity-infrastructure.md.
+add_executable(GoldenAudioRegressionTest AestraAudio/GoldenAudioRegressionTest.cpp)
+target_link_libraries(GoldenAudioRegressionTest PRIVATE AestraAudio)
+target_include_directories(GoldenAudioRegressionTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME GoldenAudioRegressionTest COMMAND GoldenAudioRegressionTest)
+set_tests_properties(GoldenAudioRegressionTest PROPERTIES LABELS "audio;quality;golden;integrity;s-tier" TIMEOUT 180)
+
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
     add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)


### PR DESCRIPTION
## Summary
First PR of the **Audio Integrity Infrastructure** series — a protection system so future PRs cannot silently change the sound. The full survey of existing infra (with source locations) and the PR-series plan live in `AestraDocs/audio-integrity-infrastructure.md`, added here.

This PR adds `GoldenAudioRegressionTest`, driving the real `AudioEngine::processBlock` path against **analytic references** computed at runtime (nothing binary in git):

1. **DiffReport self-check** — proves the failure forensics localize a known injected mismatch to the exact frame/channel/magnitude (this check caught a too-tight assertion during development).
2. **Silence / empty project** — a playing empty project must render **exact zeros**. Catches metronome/test-tone leakage, uninitialized buffers, denormal noise, hidden master processing. Measured on develop: bit-exact.
3. **Impulse through master** — exact position + equal-power-centre amplitude. Measured: bit-exact.
4. **Multi-track mix** — 3 sines with distinct fader gains (set through the same `ContinuousParamBuffer` path the UI uses) and pans, plus a **bypassed insert** exercising the effect-chain path. Verifies the engine's dB and pan-law math against the closed-form model. Measured: 1 float ulp (5.96e-8, RMS −159.8 dB).

Failure output includes max abs error, RMS (dB), first mismatching frame + channel (+ time), both peaks and their difference, sample rate, and rendered length — diagnosable without opening audio files.

## Why
`GoldenReferenceTest` covers sine/impulse playback fidelity; nothing covered manufactured-audio-in-silence, gain/pan summing correctness, or bypass transparency, and no test printed first-mismatch forensics. Thresholds (maxAbs ≤ 1e-6, RMS ≤ −120 dB) are calibrated from measured bit-exact/1-ulp baselines — tripwires, not shrugs.

## Testing
```
cmake --build build-linux --target GoldenAudioRegressionTest -j2   # clean
./build-linux/Tests/GoldenAudioRegressionTest                       # 4/4 PASS
ctest --test-dir build-linux -R "GoldenReferenceTest|GoldenAudioRegressionTest"  # 2/2, 0.83 s
```
Runtime ~0.4 s — negligible CI cost. Labels: `audio;quality;golden;integrity;s-tier`.

## Reference update policy
References are analytic — if a deliberate engine change shifts expected output, update the expectation math in the same PR with reasoning in the commit message. Documented in the doc.

## Risk / rollback
Test + docs only; zero production code changed. Rollback = revert.

## Series
Next: realtime-vs-offline export parity (incl. a duck-during-export probe), RT-safety allocation trap, callback deadline diagnostics consolidation, sample-rate/buffer truth, preview isolation boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a new golden-audio regression harness that renders through the real `AudioEngine::processBlock` path and compares output against analytic, runtime-computed references instead of stored waveform fixtures.
- Added shared test helpers for buffer diffing and reporting (`max abs error`, RMS dB, first mismatch location, peaks, sample rate, rendered length), plus engine/session setup and block-based rendering utilities.
- Added regression coverage for:
  - exact-zero output from an empty project,
  - exact timing and equal-power amplitude for a single impulse through the master path,
  - multi-track mixing with gain/pan-law behavior and a bypassed insert in the effect chain.
- Added a self-check that intentionally injects a mismatch to verify the diff report pinpoints the correct frame, channel, and magnitude.
- Documented the audio integrity infrastructure survey and planned PR series in `AestraDocs/audio-integrity-infrastructure.md`.
- Registered the new `GoldenAudioRegressionTest` as a CTest target with audio/quality/integrity labels.
- This change is test/docs only; no production code paths were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->