### PR TITLE
Audio integrity 2/N: realtime/export parity + preview-duck export fix

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -490,6 +490,22 @@ public:
     }
 
     /**
+     * @brief Snap preview-duck smoothing to unity. Offline render only.
+     *
+     * Preview ducking is a monitoring convenience; it must never attenuate an
+     * offline render. AudioExporter disables the duck depth for the render,
+     * and calls this so an already-engaged duck's release tail (~120 ms)
+     * cannot bleed into the head of the exported file. Non-RT only — call
+     * while no realtime stream is driving processBlock.
+     */
+    void resetPreviewDuckForOfflineRender() {
+        m_smoothedPreviewDuckGain = 1.0f;
+        m_previewDuckHoldSecondsRemaining = 0.0f;
+        m_previewDuckGain.store(1.0f, std::memory_order_relaxed);
+        m_previewDuckSource.store(static_cast<uint8_t>(PreviewDuckSource::None), std::memory_order_relaxed);
+    }
+
+    /**
      * @brief Render a range of the timeline (or a specific track) to a WAV file.
      *
      * Uses miniaudio encoder and AudioRenderer for offline rendering.

--- a/AestraAudio/src/IO/AudioExporter.cpp
+++ b/AestraAudio/src/IO/AudioExporter.cpp
@@ -206,8 +206,15 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
     // mismatches between playback and export.
     const bool wasMetronomeEnabled = m_engine.isMetronomeEnabled();
     const bool wasAuditionEnabled = m_engine.isAuditionModeEnabled();
+    // Preview ducking is a monitoring convenience and must never attenuate an
+    // offline render: an audible browser preview during export was measured to
+    // duck the exported file by the full configured attenuation
+    // (RealtimeExportParityTest, Export_Immune_To_Preview_Ducking).
+    const float wasPreviewDuckDb = m_engine.getPreviewDuckingAttenuationDb();
     m_engine.setMetronomeEnabled(false);
     m_engine.setAuditionModeEnabled(false);
+    m_engine.setPreviewDuckingAttenuationDb(0.0f);
+    m_engine.resetPreviewDuckForOfflineRender();
     m_engine.setGlobalSamplePos(startSample);
     m_engine.setTransportPlaying(true);
 
@@ -270,6 +277,9 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
     m_trackManager.setOutputSampleRate(static_cast<double>(originalSampleRate));
     m_engine.setMetronomeEnabled(wasMetronomeEnabled);
     m_engine.setAuditionModeEnabled(wasAuditionEnabled);
+    // Restore the configured duck depth only; live playback re-smooths the
+    // duck gain naturally from the current preview state.
+    m_engine.setPreviewDuckingAttenuationDb(wasPreviewDuckDb);
     m_engine.setGlobalSamplePos(savedSamplePos);
     if (wasPlaying) {
         m_engine.setTransportPlaying(true);

--- a/AestraDocs/audio-integrity-infrastructure.md
+++ b/AestraDocs/audio-integrity-infrastructure.md
@@ -139,6 +139,43 @@ still needs ears), plugin-internal behavior beyond bypass/summing, hardware
 driver behavior (tests run headless), Windows/macOS driver timing paths
 (only compile-checked in CI).
 
-## 6. RT-safety audit findings
+## 6. Confirmed findings (PR-2)
+
+### BUG (fixed): preview ducking contaminated offline exports
+- **Evidence:** `RealtimeExportParityTest / Export_Immune_To_Preview_Ducking`
+  — with a real `PreviewEngine` audibly playing (pumped exactly as the device
+  callback pumps it) and 12 dB ducking configured, `bounceRangeToWav` produced
+  a file attenuated by exactly −12 dB relative to the clean export.
+- **Mechanism:** duck gain is computed inside `processBlock`
+  (`AudioEngine.cpp:925-971`) from `preview->isAudiblyPlaying()`;
+  `AudioExporter` forces `setTransportPlaying(true)`, so the duck engaged
+  during offline rendering.
+- **Fix (minimal):** `AudioExporter::render` now saves the configured duck
+  depth, sets it to 0, snaps the duck smoother to unity
+  (`AudioEngine::resetPreviewDuckForOfflineRender()` — also kills an
+  already-engaged duck's ~120 ms release tail), renders, and restores the
+  configured depth. Mirrors the exporter's existing metronome/audition
+  save-disable-restore. After the fix the ducked-preview export is
+  **bit-exact** with the clean export.
+
+### Steady-state realtime/export parity: BIT-EXACT
+- `RealtimeExportParityTest / Realtime_vs_Export_Parity`: the realtime
+  `processBlock` output and the offline `bounceRangeToWav` output for the
+  same 2-track gain+pan session are **identical to the bit** (max abs error
+  = 0) on the compared overlap.
+
+### Finding (documented, not fixed): fresh-engine param-application latency
+- On a **freshly constructed** engine, values newly written to
+  `ContinuousParamBuffer` do not reach the mix until after the first
+  `processBlock` (measured via RMS trajectory: first export block at unity
+  gain, all later blocks converged). At the exporter's 4096-frame block size
+  that is the first ~85 ms; at realtime block sizes it is ≤ ~11 ms.
+- **Classification: acceptable by design / test-only impact.** Real exports
+  run on the app's long-lived engine whose mixer state was applied long ago.
+  The parity test warms the engine (`warmupEngine`) to model that reality.
+  Left as a documented sharp edge for anyone constructing a fresh engine and
+  exporting immediately.
+
+## 7. RT-safety audit findings
 
 See `AestraDocs/rt-safety-audit.md` (PR-3).

--- a/Tests/AestraAudio/RealtimeExportParityTest.cpp
+++ b/Tests/AestraAudio/RealtimeExportParityTest.cpp
@@ -1,0 +1,271 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// RealtimeExportParityTest — proves that the realtime playback path and the
+// offline export path produce the same audio for an equivalent session, and
+// that monitoring conveniences (preview ducking) cannot contaminate an export.
+//
+// Paths under test (see AestraDocs/audio-integrity-infrastructure.md §1):
+//   realtime: AudioEngine::processBlock driven block-by-block (as the device
+//             callback does) — rendered here via GoldenAudio::renderBlocks.
+//   offline:  AudioEngine::bounceRangeToWav → AudioExporter::render, which
+//             drives the same processBlock with metronome/audition disabled
+//             and writes Float_32 (no quantization/dither in the comparison).
+//
+// Case 2 probes a specific contamination vector: preview ducking is computed
+// INSIDE processBlock from PreviewEngine::isAudiblyPlaying(), and the export
+// forces transport playing — so an audible browser preview during an offline
+// export can attenuate the exported file. This test reproduces it headlessly
+// by pumping the preview exactly as the device callback would.
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+
+#include "DSP/ContinuousParamBuffer.h"
+#include "IO/MiniAudioDecoder.h"
+#include "Playback/PreviewEngine.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr double kTau = 6.28318530717958647692;
+constexpr uint32_t kSeconds = 2;
+constexpr double kBeats = 4.0; // 2 s at 120 BPM
+
+std::vector<float> makeSine(double freqHz, float amplitude, uint32_t frames, uint32_t sampleRate) {
+    std::vector<float> s(static_cast<size_t>(frames) * 2, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const float v = static_cast<float>(std::sin(kTau * freqHz * static_cast<double>(i) / sampleRate)) *
+                        amplitude;
+        s[static_cast<size_t>(i) * 2] = v;
+        s[static_cast<size_t>(i) * 2 + 1] = v;
+    }
+    return s;
+}
+
+// Minimal 16-bit WAV writer for the preview source file (same as
+// ExportBounceParityTest's inline writer).
+bool writeWav16(const fs::path& path, const std::vector<float>& interleaved, uint32_t frames,
+                uint32_t channels, uint32_t sampleRate) {
+    std::ofstream f(path.string(), std::ios::binary);
+    if (!f) return false;
+    auto write16 = [&](uint16_t v) { f.write(reinterpret_cast<const char*>(&v), 2); };
+    auto write32 = [&](uint32_t v) { f.write(reinterpret_cast<const char*>(&v), 4); };
+    const uint32_t dataSize = frames * channels * 2;
+    f.write("RIFF", 4); write32(36 + dataSize); f.write("WAVE", 4);
+    f.write("fmt ", 4); write32(16);
+    write16(1); write16(static_cast<uint16_t>(channels));
+    write32(sampleRate);
+    write32(sampleRate * channels * 2);
+    write16(static_cast<uint16_t>(channels * 2)); write16(16);
+    f.write("data", 4); write32(dataSize);
+    for (float s : interleaved) {
+        const int16_t v = static_cast<int16_t>(std::clamp(s, -1.0f, 1.0f) * 32767.0f);
+        write16(static_cast<uint16_t>(v));
+    }
+    return f.good();
+}
+
+std::shared_ptr<TrackManager> buildSession(const SessionConfig& cfg, uint32_t totalFrames) {
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    addAudioTrack(*tm, "ParityA", makeSine(440.0, 0.30f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+    addAudioTrack(*tm, "ParityB", makeSine(660.0, 0.20f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+    return tm;
+}
+
+void applyParams(AudioEngine& engine) {
+    auto params = std::make_shared<ContinuousParamBuffer>();
+    params->setFaderDb(0, -3.0f);
+    params->setPan(0, -0.4f);
+    params->setFaderDb(1, -6.0f);
+    params->setPan(1, 0.6f);
+    engine.setContinuousParams(params);
+}
+
+double rmsOf(const std::vector<float>& v) {
+    if (v.empty()) return 0.0;
+    double sumSq = 0.0;
+    for (float s : v) sumSq += static_cast<double>(s) * static_cast<double>(s);
+    return std::sqrt(sumSq / static_cast<double>(v.size()));
+}
+
+// Warm the engine's param/track state to steady state before the measured
+// render, then rewind. This mirrors the real app, where exports run on the
+// long-lived engine whose mixer state was applied long ago. (Finding, kept
+// deliberately out of this test's assertions: on a FRESH engine, freshly set
+// ContinuousParamBuffer values take one processBlock to reach the mix — at
+// the exporter's 4096-frame block size that is the first ~85 ms. Documented
+// in AestraDocs/audio-integrity-infrastructure.md; real exports are unaffected
+// because the app's engine is warm.)
+void warmupEngine(AudioEngine& engine, const SessionConfig& cfg) {
+    engine.setTransportPlaying(true);
+    std::vector<float> block(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    for (int i = 0; i < 8; ++i) {
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, cfg.blockSize, 0.0);
+    }
+    engine.setTransportPlaying(false);
+    engine.setGlobalSamplePos(0);
+}
+
+bool runExport(const std::shared_ptr<TrackManager>& tm, const SessionConfig& cfg, const fs::path& outPath,
+               PreviewEngine* preview, float duckAttenuationDb, std::vector<float>& decodedOut) {
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    applyParams(engine);
+    warmupEngine(engine, cfg);
+    if (preview) {
+        engine.setPreviewEngine(preview);
+        engine.setPreviewDuckingAttenuationDb(duckAttenuationDb);
+    }
+
+    std::error_code ec;
+    fs::remove(outPath, ec);
+    if (!engine.bounceRangeToWav(0.0, kBeats, outPath.string(), -1)) {
+        std::cerr << "bounceRangeToWav failed for " << outPath << "\n";
+        return false;
+    }
+    uint32_t sr = 0, ch = 0;
+    if (!decodeAudioFile(outPath.string(), decodedOut, sr, ch)) {
+        std::cerr << "failed to decode " << outPath << "\n";
+        return false;
+    }
+    if (sr != cfg.sampleRate || ch != cfg.channels) {
+        std::cerr << "export format mismatch: " << sr << " Hz / " << ch << " ch, expected "
+                  << cfg.sampleRate << " Hz / " << cfg.channels << " ch\n";
+        return false;
+    }
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+// Case 1: realtime processBlock output ≈ offline export output, same session
+// -----------------------------------------------------------------------------
+bool runParityCase(const std::shared_ptr<TrackManager>& tm, const SessionConfig& cfg,
+                   const std::vector<float>& cleanExport) {
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    applyParams(engine);
+    warmupEngine(engine, cfg);
+    engine.setTransportPlaying(true);
+    std::vector<float> realtime = renderBlocks(engine, totalFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    // Compare the overlap, past the transport fade-in both paths perform.
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * 4 * cfg.channels;
+    const size_t n = std::min(realtime.size(), cleanExport.size());
+    if (n <= trimStart) {
+        std::cerr << "not enough overlap to compare (" << n << " samples)\n";
+        return false;
+    }
+    std::vector<float> rt(realtime.begin() + static_cast<ptrdiff_t>(trimStart),
+                          realtime.begin() + static_cast<ptrdiff_t>(n));
+    std::vector<float> ex(cleanExport.begin() + static_cast<ptrdiff_t>(trimStart),
+                          cleanExport.begin() + static_cast<ptrdiff_t>(n));
+
+    DiffReport r = compareBuffers(rt, ex, cfg.channels, cfg.sampleRate, 1e-6);
+    const bool pass = (r.rmsErrorDb <= -120.0) && (r.maxAbsError <= 1e-6);
+    printReport("Realtime_vs_Export_Parity", r, pass,
+                "RMS <= -120 dB and maxAbs <= 1e-6 on the trimmed overlap");
+    std::cout << "  realtime frames: " << realtime.size() / cfg.channels
+              << ", export frames: " << cleanExport.size() / cfg.channels << "\n";
+    return pass;
+}
+
+// -----------------------------------------------------------------------------
+// Case 2: an audible preview must NOT attenuate an offline export
+// -----------------------------------------------------------------------------
+bool runDuckContaminationCase(const std::shared_ptr<TrackManager>& tm, const SessionConfig& cfg,
+                              const std::vector<float>& cleanExport, const fs::path& tempRoot) {
+    // Build a real preview source and make it audibly playing, exactly as the
+    // device callback would: play() + pump processRealtime until the engine's
+    // audibility latch (output peak) is set.
+    const uint32_t previewFrames = cfg.sampleRate; // 1 s
+    const fs::path previewWav = tempRoot / "parity_preview_src.wav";
+    if (!writeWav16(previewWav, makeSine(330.0, 0.8f, previewFrames, cfg.sampleRate), previewFrames, 2,
+                    cfg.sampleRate)) {
+        std::cerr << "failed to write preview wav\n";
+        return false;
+    }
+
+    PreviewEngine preview;
+    preview.setOutputSampleRate(cfg.sampleRate);
+    preview.play(previewWav.string(), 0.0f, 10.0);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    std::vector<float> sink(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    while (!preview.isAudiblyPlaying() && std::chrono::steady_clock::now() < deadline) {
+        std::fill(sink.begin(), sink.end(), 0.0f);
+        preview.processRealtime(sink.data(), cfg.blockSize, cfg.channels);
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    if (!preview.isAudiblyPlaying()) {
+        std::cerr << "could not bring preview to audible state; cannot probe contamination\n";
+        return false;
+    }
+
+    // Export with the audible preview registered and ducking enabled (12 dB),
+    // as it would be during normal app use.
+    std::vector<float> duckedExport;
+    if (!runExport(tm, cfg, tempRoot / "parity_ducked.wav", &preview, 12.0f, duckedExport)) return false;
+
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * 4 * cfg.channels;
+    const size_t n = std::min(duckedExport.size(), cleanExport.size());
+    std::vector<float> ducked(duckedExport.begin() + static_cast<ptrdiff_t>(trimStart),
+                              duckedExport.begin() + static_cast<ptrdiff_t>(n));
+    std::vector<float> clean(cleanExport.begin() + static_cast<ptrdiff_t>(trimStart),
+                             cleanExport.begin() + static_cast<ptrdiff_t>(n));
+
+    const double duckedRms = rmsOf(ducked);
+    const double cleanRms = rmsOf(clean);
+    const double levelDeltaDb =
+        20.0 * std::log10(std::max(duckedRms, 1e-15) / std::max(cleanRms, 1e-15));
+
+    DiffReport r = compareBuffers(ducked, clean, cfg.channels, cfg.sampleRate, 1e-6);
+    const bool pass = (r.rmsErrorDb <= -120.0) && (r.maxAbsError <= 1e-6);
+    printReport("Export_Immune_To_Preview_Ducking", r, pass,
+                "export with audible preview must equal clean export (RMS <= -120 dB, maxAbs <= 1e-6)");
+    std::cout << "  export level delta vs clean: " << levelDeltaDb << " dB"
+              << (pass ? "" : "  <-- preview ducking contaminated the export") << "\n";
+    return pass;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Aestra Realtime/Export Parity Test ===\n\n";
+    const fs::path tempRoot = fs::temp_directory_path() / "aestra_rt_export_parity";
+    std::error_code ec;
+    fs::create_directories(tempRoot, ec);
+
+    SessionConfig cfg;
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+    auto tm = buildSession(cfg, totalFrames);
+
+    // Clean export once; both cases compare against it.
+    std::vector<float> cleanExport;
+    if (!runExport(tm, cfg, tempRoot / "parity_clean.wav", nullptr, 0.0f, cleanExport)) {
+        return 1;
+    }
+
+    int failures = 0;
+    if (!runParityCase(tm, cfg, cleanExport)) ++failures;
+    if (!runDuckContaminationCase(tm, cfg, cleanExport, tempRoot)) ++failures;
+
+    fs::remove_all(tempRoot, ec);
+    std::cout << "\n" << (failures == 0 ? "ALL PASS" : "FAILURES: " + std::to_string(failures)) << "\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1168,6 +1168,20 @@ target_include_directories(GoldenAudioRegressionTest PRIVATE
 add_test(NAME GoldenAudioRegressionTest COMMAND GoldenAudioRegressionTest)
 set_tests_properties(GoldenAudioRegressionTest PROPERTIES LABELS "audio;quality;golden;integrity;s-tier" TIMEOUT 180)
 
+# Realtime/Export Parity — realtime processBlock output vs offline
+# bounceRangeToWav output for the same session, plus the preview-ducking
+# export-contamination probe. Doc: AestraDocs/audio-integrity-infrastructure.md.
+add_executable(RealtimeExportParityTest AestraAudio/RealtimeExportParityTest.cpp)
+target_link_libraries(RealtimeExportParityTest PRIVATE AestraAudio)
+target_include_directories(RealtimeExportParityTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME RealtimeExportParityTest COMMAND RealtimeExportParityTest)
+set_tests_properties(RealtimeExportParityTest PROPERTIES LABELS "audio;quality;export;parity;integrity;s-tier" TIMEOUT 180)
+
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
     add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)


### PR DESCRIPTION
## Summary
Second PR of the Audio Integrity series. **Stacked on #427** (uses its GoldenAudio harness) — merge #427 first, then retarget this to develop.

`RealtimeExportParityTest` proves, for the same 2-track gain+pan session:

1. **Realtime `processBlock` output and offline `bounceRangeToWav` output are BIT-EXACT** (max abs error = 0) at steady state. Any future divergence in limiter state, master gain, transport handling, metronome leakage, or buffer initialization breaks an exact comparison — this is the parity guard the export path never had (`ExportBounceParityTest` only checks bounce self-consistency).

2. **Confirmed + fixed bug: preview ducking contaminated offline exports.** With a real `PreviewEngine` audibly playing (pumped exactly as the device callback pumps it) and 12 dB duck configured, the exported file measured exactly **−12 dB** vs the clean export. Root cause: duck gain is computed inside `processBlock` from `isAudiblyPlaying()`, and the exporter forces transport playing. Failing test was written first; then the minimal fix.

## The fix (production, minimal)
`AudioExporter::render` now: saves the configured duck depth → sets 0 → snaps the duck smoother to unity (`AudioEngine::resetPreviewDuckForOfflineRender()`, new inline; also prevents an already-engaged duck's ~120 ms release tail bleeding into the export head) → renders → restores the depth. Exactly mirrors the exporter's existing metronome/audition save-disable-restore. Post-fix, the ducked-preview export is **bit-exact** with the clean export.

## Also documented (classified, not fixed)
Fresh-engine param-application latency: newly written `ContinuousParamBuffer` values take one `processBlock` to reach the mix (~85 ms at the exporter's 4096-frame blocks, ≤ ~11 ms at realtime sizes; RMS-trajectory evidence in the doc). **Acceptable by design** — real exports run on the warm app engine. The test warms up accordingly; the sharp edge is documented in `AestraDocs/audio-integrity-infrastructure.md`.

## Testing
```
7/7 pass (4.25 s): RealtimeExportParityTest, ExportBounceParityTest,
AudioPurityAuditTest, GoldenReferenceTest, GoldenAudioRegressionTest,
PreviewAuditionGainParityTest, TrackManagerMasterDuckingAuditTest
```
Built `build-linux -j2`, clean.

## Audio impact statement (AGENTS §11/§20)
- Live playback output: **unchanged** (fix touches only the offline export path).
- Export output: changed **only** in the buggy scenario (audible preview during export) — it now matches live intent instead of being ducked. Live/export parity: improved and now machine-enforced.
- Latency/state format: unchanged.

## Risk / rollback
Small production diff (exporter save/disable/restore + one inline engine method). Revert restores the old (buggy) behavior; the test will flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)