### PR TITLE
Audio integrity 3/N: RT-safety allocation trap + audit baseline

### DIFF
--- a/AestraDocs/rt-safety-audit.md
+++ b/AestraDocs/rt-safety-audit.md
@@ -37,7 +37,7 @@ Offline export drives the same processBlock from the exporter thread
 
 | # | Finding | Evidence | Classification |
 |---|---|---|---|
-| 1 | Steady-state render path performs **zero heap allocations/frees** (3 tracks, fader/pan params, active insert, 186 blocks) | `RTAllocationTrapTest` | **verified safe** |
+| 1 | Render path performs **zero steady-state heap activity under tested conditions** (3 tracks, fader/pan params, active insert, 186 blocks) — with **one detected first-block 31-byte allocation when an active insert is present** (finding #3; zero absolutely without an insert). The claim is NOT unconditional until #3 is resolved. | `RTAllocationTrapTest` | **verified safe at steady state** |
 | 2 | Preview ducking attenuated offline exports by the full configured depth | `RealtimeExportParityTest` | **confirmed violation — FIXED** (AudioExporter save/disable/restore + duck-smoother snap) |
 | 3 | **1 allocation (31 bytes) in the first block after an active insert is added** — lazy init somewhere in the effect-chain path; xrun risk on the first callback after inserting a plugin during playback | `RTAllocationTrapTest` first-block counter (0 allocs without insert, 1 with) | **suspicious but unproven origin** — reproducible; origin hunt is follow-up (gdb conditional breakpoint on the trap) |
 | 4 | `AuditionEngine::processBlock` (RT, AudioEngine.cpp:722) invokes `m_onPositionChanged` — an arbitrary app-bound `std::function` — on the audio thread every 10th block (AuditionEngine.cpp:543-544) | grep + code read; **currently unbound in Source/** (no binder found) | **latent hazard by design** — safe today, one `setOnPositionChanged(ui_lambda)` away from UI work on the RT thread. Follow-up: route through an SPSC snapshot like meters |

--- a/AestraDocs/rt-safety-audit.md
+++ b/AestraDocs/rt-safety-audit.md
@@ -1,0 +1,70 @@
+# Real-Time-Safety Audit — Findings & Baseline
+
+**Scope:** all code reachable from the audio callback. **Method:** empirical
+allocation trap (`RTAllocationTrapTest`) + static sweep
+(`scripts/rt_safety_audit.sh`) + manual classification of every hot hit.
+**Baseline commit:** develop @ 80fbbf87 (+ integrity series).
+
+## Callback entry points (verified, with sources)
+
+```
+RtAudioDriver::rtAudioCallback            AestraAudio/src/Linux/RtAudioDriver.cpp:248
+  → AestraAudioController::audioCallback  Source/Core/AestraAudioController.cpp:407
+      → AudioEngine::processBlock         AestraAudio/src/Core/AudioEngine.cpp:593
+          (ScopedRealtimeAudioThread marks the thread at :594)
+          → renderGraph → per-track mix, EffectChain::process, plugins
+          → AuditionEngine::processBlock  (AudioEngine.cpp:722)
+      → TrackManager::mixInputMonitoring  (AestraAudioController.cpp:431)
+      → PreviewEngine::processRealtime    (AestraAudioController.cpp:436)
+Offline export drives the same processBlock from the exporter thread
+(AudioExporter.cpp render loop), also under the guard.
+```
+
+## Machine-checkable gates (added by this series)
+
+- **`RTAllocationTrapTest`** — overrides global operator new/delete; renders a
+  3-track session with fader/pan engaged and an active insert; asserts ZERO
+  steady-state heap activity while `isRealtimeAudioThread()`. Includes a
+  self-check proving the trap fires (it caught GCC's allocation elision faking
+  a pass during development). Scope: C++ new/delete; NOT raw malloc, mutex
+  waits, or syscalls.
+- **`scripts/rt_safety_audit.sh`** — static tripwire over 12 RT-reachable
+  sources; compare its output against the classified baseline below.
+- **`reportRealtimeMisuse()`** (pre-existing) — ~20 mutating APIs self-report
+  if called from the audio thread.
+
+## Findings
+
+| # | Finding | Evidence | Classification |
+|---|---|---|---|
+| 1 | Steady-state render path performs **zero heap allocations/frees** (3 tracks, fader/pan params, active insert, 186 blocks) | `RTAllocationTrapTest` | **verified safe** |
+| 2 | Preview ducking attenuated offline exports by the full configured depth | `RealtimeExportParityTest` | **confirmed violation — FIXED** (AudioExporter save/disable/restore + duck-smoother snap) |
+| 3 | **1 allocation (31 bytes) in the first block after an active insert is added** — lazy init somewhere in the effect-chain path; xrun risk on the first callback after inserting a plugin during playback | `RTAllocationTrapTest` first-block counter (0 allocs without insert, 1 with) | **suspicious but unproven origin** — reproducible; origin hunt is follow-up (gdb conditional breakpoint on the trap) |
+| 4 | `AuditionEngine::processBlock` (RT, AudioEngine.cpp:722) invokes `m_onPositionChanged` — an arbitrary app-bound `std::function` — on the audio thread every 10th block (AuditionEngine.cpp:543-544) | grep + code read; **currently unbound in Source/** (no binder found) | **latent hazard by design** — safe today, one `setOnPositionChanged(ui_lambda)` away from UI work on the RT thread. Follow-up: route through an SPSC snapshot like meters |
+| 5 | `AuditionEngine::processBlock` body (439-546): no direct locks/logs/allocs; its 26 mutex sites live in queue/load helpers (`loadCurrentTrack` etc.) | windowed grep | **acceptable by design** (helpers are non-RT) |
+| 6 | `PatternPlaybackEngine::processAudio` drains its RT queue lock-free; the file's 3 locks are in non-RT mutators, and `refillWindow` is guarded by `reportRealtimeMisuse` and called from `performNonRealtimeMaintenance` | code read :279+, :96/:124/:151 | **acceptable by design** |
+| 7 | `PreviewEngine::processRealtime` (:240) takes no locks; the 4 mutex sites are worker setup + `handleDeferredCompletion` (non-RT, called from maintenance) | code read | **acceptable by design** |
+| 8 | `MixerChannel` has 8 `m_sendMutex` guards — all on send *mutation* APIs; the RT path reads sends from the compiled graph snapshot, not MixerChannel | code read :168-213 | **acceptable by design** |
+| 9 | `AudioEngine` sleeps: :1769 is the LUFS worker thread loop (background, ~10 Hz); :3173 is the non-RT isolated-bounce path ("allow RT to spin down") | code read | **acceptable by design (non-RT)** |
+| 10 | 62 logging calls across the swept files — spot-checked hot ones are in non-RT methods (bounce, setup, error paths); `performNonRealtimeMaintenance` logs RT-misuse reports from the maintenance thread, not the RT thread | grep + spot checks | **acceptable by design**, not exhaustively proven per-site — the grep script keeps the count visible |
+| 11 | 97 container-growth hits — concentrated in `initialize()`/`setBufferConfig()` pre-allocation (`AudioEngine.cpp:1370-1390` reserves everything up front) and non-RT paths; the allocation trap proves none fire at render steady state | grep + trap test | **acceptable by design** (trap is the enforcement) |
+| 12 | Fresh-engine `ContinuousParamBuffer` values take one processBlock to reach the mix (~85 ms at export block size) | RMS trajectory, integrity doc §6 | **acceptable by design / documented sharp edge** |
+
+## What is NOT covered (honesty section)
+
+- Raw `malloc`/`free` (C paths) — not trapped; none observed in sweeps of RT
+  sources, but unproven.
+- Mutex *waits* — `reportRealtimeMisuse` covers instrumented APIs only; an
+  uninstrumented lock on a cold path would not be caught until it appears in
+  the grep sweep.
+- Third-party plugin process() internals (VST3/CLAP) — untrusted by policy
+  (AGENTS §19); EngineSupervisor timeout/quarantine is the mitigation.
+- Windows/macOS driver callback paths — compile-checked only on this machine.
+
+## How to use this
+
+1. After touching RT code, run `scripts/rt_safety_audit.sh --counts` and
+   `ctest -R RTAllocationTrapTest`.
+2. New grep hits → classify them here in the same PR.
+3. Trap failures → the test prints the first violating block; hunt with a
+   conditional breakpoint on the trap's operator new.

--- a/Tests/AestraAudio/RTAllocationTrapTest.cpp
+++ b/Tests/AestraAudio/RTAllocationTrapTest.cpp
@@ -1,0 +1,241 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// RTAllocationTrapTest — machine-checkable real-time-safety guard.
+//
+// This test binary overrides global operator new/delete. While the engine is
+// inside processBlock it marks the calling thread via ScopedRealtimeAudioThread
+// (AudioEngine.cpp:594) — so any allocation the trap counts while
+// isRealtimeAudioThread() is true happened ON THE AUDIO CALLBACK PATH.
+//
+// Policy asserted here (AGENTS §10):
+//   - Steady-state blocks (after the first) must perform ZERO heap
+//     allocations and ZERO deallocations.
+//   - First-block (warmup) allocations are reported separately: they are a
+//     latent xrun risk on stream start and belong in the findings table
+//     (AestraDocs/rt-safety-audit.md), but only steady state is a hard gate
+//     so this test stays green while any warmup work is triaged.
+//
+// Scope honesty: the trap covers C++ operator new/delete (all std containers,
+// strings, shared_ptr control blocks, etc). It does NOT cover raw malloc(),
+// pthread mutex waits, or syscalls — those are covered by the grep audit
+// (scripts/rt_safety_audit.sh) and reportRealtimeMisuse() instrumentation.
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+
+#include "RealtimeThreadGuard.h"
+#include "DSP/ContinuousParamBuffer.h"
+#include "Plugin/SamplerPlugin.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <vector>
+
+// =============================================================================
+// Global allocation trap (test binary only)
+// =============================================================================
+
+namespace {
+std::atomic<bool> g_trapArmed{false};
+std::atomic<uint64_t> g_rtAllocCount{0};
+std::atomic<uint64_t> g_rtAllocBytes{0};
+std::atomic<uint64_t> g_rtFreeCount{0};
+
+inline void noteAlloc(std::size_t size) noexcept {
+    if (g_trapArmed.load(std::memory_order_relaxed) && Aestra::Audio::isRealtimeAudioThread()) {
+        g_rtAllocCount.fetch_add(1, std::memory_order_relaxed);
+        g_rtAllocBytes.fetch_add(size, std::memory_order_relaxed);
+    }
+}
+
+inline void noteFree() noexcept {
+    if (g_trapArmed.load(std::memory_order_relaxed) && Aestra::Audio::isRealtimeAudioThread()) {
+        g_rtFreeCount.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+} // namespace
+
+void* operator new(std::size_t size) {
+    noteAlloc(size);
+    if (void* p = std::malloc(size ? size : 1)) return p;
+    throw std::bad_alloc();
+}
+void* operator new[](std::size_t size) {
+    noteAlloc(size);
+    if (void* p = std::malloc(size ? size : 1)) return p;
+    throw std::bad_alloc();
+}
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    noteAlloc(size);
+    return std::malloc(size ? size : 1);
+}
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+    noteAlloc(size);
+    return std::malloc(size ? size : 1);
+}
+void operator delete(void* p) noexcept {
+    noteFree();
+    std::free(p);
+}
+void operator delete[](void* p) noexcept {
+    noteFree();
+    std::free(p);
+}
+void operator delete(void* p, std::size_t) noexcept {
+    noteFree();
+    std::free(p);
+}
+void operator delete[](void* p, std::size_t) noexcept {
+    noteFree();
+    std::free(p);
+}
+void operator delete(void* p, const std::nothrow_t&) noexcept {
+    noteFree();
+    std::free(p);
+}
+void operator delete[](void* p, const std::nothrow_t&) noexcept {
+    noteFree();
+    std::free(p);
+}
+
+// =============================================================================
+// Test
+// =============================================================================
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+
+namespace {
+
+constexpr double kTau = 6.28318530717958647692;
+
+std::vector<float> makeSine(double freqHz, float amplitude, uint32_t frames, uint32_t sampleRate) {
+    std::vector<float> s(static_cast<size_t>(frames) * 2, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const float v = static_cast<float>(std::sin(kTau * freqHz * static_cast<double>(i) / sampleRate)) *
+                        amplitude;
+        s[static_cast<size_t>(i) * 2] = v;
+        s[static_cast<size_t>(i) * 2 + 1] = v;
+    }
+    return s;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Aestra RT Allocation Trap Test ===\n\n";
+
+    // Trap self-check: prove the override actually fires, so a zero result
+    // below is meaningful. Allocate inside a marked RT scope and verify the
+    // counters move.
+    {
+        g_trapArmed.store(true, std::memory_order_release);
+        const uint64_t a0 = g_rtAllocCount.load(std::memory_order_relaxed);
+        const uint64_t f0 = g_rtFreeCount.load(std::memory_order_relaxed);
+        {
+            ScopedRealtimeAudioThread rtScope;
+            // Call the operator directly with a runtime-derived size: paired
+            // new/delete expressions visible to the compiler are legal to
+            // elide (C++14 allocation elision), which would fake a pass here.
+            volatile std::size_t n = 64;
+            void* p = ::operator new(n);
+            ::operator delete(p);
+        }
+        g_trapArmed.store(false, std::memory_order_release);
+        const bool trapWorks = (g_rtAllocCount.load(std::memory_order_relaxed) == a0 + 1) &&
+                               (g_rtFreeCount.load(std::memory_order_relaxed) == f0 + 1);
+        std::cout << "[" << (trapWorks ? "PASS" : "FAIL") << "] trap self-check (counted "
+                  << (g_rtAllocCount.load(std::memory_order_relaxed) - a0) << " alloc, "
+                  << (g_rtFreeCount.load(std::memory_order_relaxed) - f0) << " free in RT scope)\n";
+        if (!trapWorks) return 1;
+        g_rtAllocCount.store(0, std::memory_order_relaxed);
+        g_rtAllocBytes.store(0, std::memory_order_relaxed);
+        g_rtFreeCount.store(0, std::memory_order_relaxed);
+    }
+
+    SessionConfig cfg;
+    const uint32_t totalFrames = cfg.sampleRate * 2; // 2 s
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    // Multi-track session with fader/pan engaged so the full mixing path runs.
+    addAudioTrack(*tm, "RTTrapA", makeSine(440.0, 0.30f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+    addAudioTrack(*tm, "RTTrapB", makeSine(660.0, 0.20f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+    addAudioTrack(*tm, "RTTrapC", makeSine(880.0, 0.15f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+
+    // Active insert on track 1 so EffectChain::process runs on the RT path too.
+    if (auto* ch = tm->getChannel(1)) {
+        auto plugin = std::make_shared<Plugins::SamplerPlugin>();
+        plugin->initialize(static_cast<double>(cfg.sampleRate), cfg.blockSize);
+        ch->getEffectChain().prepare(static_cast<double>(cfg.sampleRate), cfg.blockSize);
+        ch->getEffectChain().insertPlugin(0, plugin);
+    }
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    auto params = std::make_shared<ContinuousParamBuffer>();
+    params->setFaderDb(0, -3.0f);
+    params->setPan(0, -0.5f);
+    params->setFaderDb(1, -6.0f);
+    params->setPan(1, 0.5f);
+    engine.setContinuousParams(params);
+    engine.setTransportPlaying(true);
+
+    std::vector<float> block(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    const uint32_t numBlocks = totalFrames / cfg.blockSize;
+
+    uint64_t firstBlockAllocs = 0, firstBlockBytes = 0, firstBlockFrees = 0;
+    uint64_t steadyAllocs = 0, steadyBytes = 0, steadyFrees = 0;
+    uint32_t firstSteadyViolationBlock = 0;
+
+    g_trapArmed.store(true, std::memory_order_release);
+    for (uint32_t b = 0; b < numBlocks; ++b) {
+        const uint64_t a0 = g_rtAllocCount.load(std::memory_order_relaxed);
+        const uint64_t y0 = g_rtAllocBytes.load(std::memory_order_relaxed);
+        const uint64_t f0 = g_rtFreeCount.load(std::memory_order_relaxed);
+
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, cfg.blockSize, 0.0);
+
+        const uint64_t da = g_rtAllocCount.load(std::memory_order_relaxed) - a0;
+        const uint64_t dy = g_rtAllocBytes.load(std::memory_order_relaxed) - y0;
+        const uint64_t df = g_rtFreeCount.load(std::memory_order_relaxed) - f0;
+
+        if (b == 0) {
+            firstBlockAllocs = da;
+            firstBlockBytes = dy;
+            firstBlockFrees = df;
+        } else {
+            if ((da || df) && steadyAllocs == 0 && steadyFrees == 0) firstSteadyViolationBlock = b;
+            steadyAllocs += da;
+            steadyBytes += dy;
+            steadyFrees += df;
+        }
+    }
+    g_trapArmed.store(false, std::memory_order_release);
+    engine.setTransportPlaying(false);
+
+    std::cout << "first block (warmup):  " << firstBlockAllocs << " allocs / " << firstBlockBytes
+              << " bytes / " << firstBlockFrees << " frees\n";
+    std::cout << "steady state (" << (numBlocks - 1) << " blocks): " << steadyAllocs << " allocs / "
+              << steadyBytes << " bytes / " << steadyFrees << " frees\n";
+
+    const bool pass = (steadyAllocs == 0 && steadyFrees == 0);
+    if (!pass) {
+        std::cout << "\n[FAIL] heap activity on the audio callback path at steady state\n"
+                  << "  first violating block: " << firstSteadyViolationBlock << "\n"
+                  << "  Every allocation inside processBlock is an xrun risk (AGENTS §10).\n"
+                  << "  Find it: run this test under gdb with a breakpoint on the operator\n"
+                  << "  new in RTAllocationTrapTest.cpp conditioned on\n"
+                  << "  Aestra::Audio::isRealtimeAudioThread(), or use massif/heaptrack.\n";
+    } else {
+        std::cout << "\n[PASS] zero steady-state heap activity on the audio callback path\n";
+        if (firstBlockAllocs || firstBlockFrees) {
+            std::cout << "  note: first-block warmup performed " << firstBlockAllocs
+                      << " allocs — reported as a finding, not a failure (see\n"
+                      << "  AestraDocs/rt-safety-audit.md).\n";
+        }
+    }
+    return pass ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1182,6 +1182,21 @@ target_include_directories(RealtimeExportParityTest PRIVATE
 add_test(NAME RealtimeExportParityTest COMMAND RealtimeExportParityTest)
 set_tests_properties(RealtimeExportParityTest PROPERTIES LABELS "audio;quality;export;parity;integrity;s-tier" TIMEOUT 180)
 
+# RT Allocation Trap — overrides operator new/delete in the test binary and
+# renders a session; asserts ZERO steady-state heap activity on the audio
+# callback path (thread marked by ScopedRealtimeAudioThread in processBlock).
+# Findings doc: AestraDocs/rt-safety-audit.md.
+add_executable(RTAllocationTrapTest AestraAudio/RTAllocationTrapTest.cpp)
+target_link_libraries(RTAllocationTrapTest PRIVATE AestraAudio)
+target_include_directories(RTAllocationTrapTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME RTAllocationTrapTest COMMAND RTAllocationTrapTest)
+set_tests_properties(RTAllocationTrapTest PROPERTIES LABELS "audio;rt-safety;integrity;s-tier" TIMEOUT 180)
+
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
     add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)

--- a/scripts/rt_safety_audit.sh
+++ b/scripts/rt_safety_audit.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# rt_safety_audit.sh — static sweep of audio-callback-reachable sources for
+# patterns that are forbidden on the real-time path (AGENTS §10).
+#
+# This is a TRIPWIRE, not a verdict: these files mix RT and non-RT functions,
+# so every hit needs human classification. The classified baseline lives in
+# AestraDocs/rt-safety-audit.md — run this after touching RT code and explain
+# any NEW hits there. The empirical allocation gate is RTAllocationTrapTest.
+#
+# Usage: scripts/rt_safety_audit.sh [--counts]
+set -u
+cd "$(dirname "$0")/.."
+
+RT_SOURCES=(
+    "AestraAudio/src/Core/AudioEngine.cpp"
+    "AestraAudio/src/AudioRenderer.cpp"
+    "AestraAudio/src/Core/MixerBus.cpp"
+    "AestraAudio/src/Core/MixerChannel.cpp"
+    "AestraAudio/src/Plugin/EffectChain.cpp"
+    "AestraAudio/src/Playback/PatternPlaybackEngine.cpp"
+    "AestraAudio/src/Playback/PreviewEngine.cpp"
+    "AestraAudio/src/Playback/MetronomeEngine.cpp"
+    "AestraAudio/src/Playback/AuditionEngine.cpp"
+    "AestraAudio/src/Playback/TimelineClock.cpp"
+    "Source/Core/AestraAudioController.cpp"
+    "AestraAudio/src/Linux/RtAudioDriver.cpp"
+)
+
+# pattern|label
+PATTERNS=(
+    'std::mutex|mutex declaration'
+    'lock_guard|std::scoped_lock|unique_lock|lock acquisition'
+    'Aestra::Log::|Log::info|Log::warning|Log::error|logging call'
+    '\bnew \[|\bnew [A-Za-z_]|operator new|make_shared|make_unique|heap allocation'
+    '\.resize\(|\.reserve\(|push_back|emplace_back|container growth'
+    'this_thread::sleep|usleep\(|nanosleep|sleep'
+    'std::ifstream|std::ofstream|fopen\(|std::filesystem|file I/O'
+)
+
+counts_only=false
+[ "${1:-}" = "--counts" ] && counts_only=true
+
+total=0
+for entry in "${PATTERNS[@]}"; do
+    pattern="${entry%|*}"
+    label="${entry##*|}"
+    echo "== ${label} (${pattern}) =="
+    n=0
+    for f in "${RT_SOURCES[@]}"; do
+        [ -f "$f" ] || continue
+        if $counts_only; then
+            c=$(grep -cE "$pattern" "$f" 2>/dev/null || true)
+            [ "${c:-0}" -gt 0 ] && echo "  $f: $c" && n=$((n + c))
+        else
+            hits=$(grep -nE "$pattern" "$f" 2>/dev/null || true)
+            if [ -n "$hits" ]; then
+                echo "$hits" | sed "s|^|  $f:|"
+                n=$((n + $(echo "$hits" | wc -l)))
+            fi
+        fi
+    done
+    echo "  -> ${n} hit(s)"
+    echo ""
+    total=$((total + n))
+done
+
+echo "TOTAL: ${total} hits across ${#RT_SOURCES[@]} RT-reachable sources."
+echo "Compare against the classified baseline in AestraDocs/rt-safety-audit.md."


### PR DESCRIPTION
## Summary
Third PR of the Audio Integrity series. **Stacked on #428** (merge order: #427 → #428 → this, retargeting each).

**`RTAllocationTrapTest`** — the machine-checkable RT-safety gate. Overrides global `operator new/delete` in the test binary and renders a 3-track session (fader/pan engaged, active insert) through the real `processBlock`, whose `ScopedRealtimeAudioThread` marks the thread. Verified result, now enforced in CTest:

- **Zero steady-state heap activity under tested conditions** (blocks 1–186), with **one detected first-block 31-byte allocation when an active insert is present** — and zero absolutely, including the first block, without an insert. The steady-state gate is the CTest pass criterion; the first-block exception is printed on every run and tracked as finding #3 with a follow-up issue for the origin hunt. The zero claim is deliberately NOT unconditional until that lands.
- A trap **self-check** proves the override fires — it caught GCC's C++14 allocation elision faking a pass during development, so a zero result is trustworthy.

**`scripts/rt_safety_audit.sh`** — static tripwire over 12 RT-reachable sources (mutexes, locks, logging, allocation, container growth, sleeps, file I/O). New hits must be classified against the baseline.

**`AestraDocs/rt-safety-audit.md`** — the full audit: verified callback entry chain (driver → controller → processBlock → audition/preview/monitoring mix points), 12 classified findings, and an honest not-covered list (raw malloc, uninstrumented mutex waits, third-party plugin internals, non-Linux drivers).

## Notable findings
- **1×31-byte first-block allocation appears only with an active insert** — lazy init in the effect-chain path; an xrun risk on the first real device callback after inserting a plugin mid-playback (production insert is an off-RT mutation, so the first RT block of the new chain is where this lands). Reproducible via the trap's per-block counters; classified suspicious/bounded, **origin hunt tracked in a follow-up issue** with acceptance criteria that end with tightening the trap's gate to `firstBlockAllocs == 0`, making the zero claim unconditional.
- **`AuditionEngine::processBlock` invokes the app-bindable `m_onPositionChanged` std::function on the RT thread** every 10th block. Currently unbound in `Source/` (grep-verified) — a latent hazard one `setOnPositionChanged(ui_lambda)` away from UI work on the audio thread. Follow-up: SPSC snapshot like the meters.
- Everything else hot (pattern engine, preview, mixer sends, engine sleeps, container growth) spot-checked and classified **acceptable by design** with source citations.

## Testing
```
3/3 pass: RTAllocationTrapTest (0.15 s), GoldenAudioRegressionTest, RealtimeExportParityTest
```
No production code changed — tests, script, and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)