### PR TITLE
Audio integrity 4/N: callback deadline diagnostics consolidation

### DIFF
--- a/AestraAudio/include/Core/AudioTelemetry.h
+++ b/AestraAudio/include/Core/AudioTelemetry.h
@@ -192,8 +192,11 @@ struct AudioTelemetry {
         updateMaxCallbackNs(ns);
         totalCallbackNs.fetch_add(ns, std::memory_order_relaxed);
         timedCallbackCount.fetch_add(1, std::memory_order_relaxed);
-        lastBufferFrames.store(frames, std::memory_order_relaxed);
+        // Publish frames and rate together only when the rate is valid, so
+        // getCallbackBudgetNs() never combines a frames/rate pair that did
+        // not actually co-occur (CodeRabbit review, PR #430).
         if (sampleRate > 0) {
+            lastBufferFrames.store(frames, std::memory_order_relaxed);
             lastSampleRate.store(sampleRate, std::memory_order_relaxed);
             const uint64_t budgetNs =
                 (static_cast<uint64_t>(frames) * 1000000000ull) / static_cast<uint64_t>(sampleRate);

--- a/AestraAudio/include/Core/AudioTelemetry.h
+++ b/AestraAudio/include/Core/AudioTelemetry.h
@@ -33,6 +33,9 @@ struct AudioTelemetry {
     std::atomic<uint64_t> overruns{0};
     std::atomic<uint64_t> maxCallbackNs{0};
     std::atomic<uint64_t> lastCallbackNs{0};
+    // Running total + count of timed callbacks, for average callback time.
+    std::atomic<uint64_t> totalCallbackNs{0};
+    std::atomic<uint64_t> timedCallbackCount{0};
     std::atomic<uint64_t> rtAllocationViolations{0};
     std::atomic<uint64_t> rtLockViolations{0};
     std::atomic<uint64_t> rtLogViolations{0};
@@ -173,6 +176,45 @@ struct AudioTelemetry {
     void updateLastCallbackNs(uint64_t ns) noexcept { lastCallbackNs.store(ns, std::memory_order_relaxed); }
     void updateLastBufferFrames(uint32_t frames) noexcept { lastBufferFrames.store(frames, std::memory_order_relaxed); }
     void updateLastSampleRate(uint32_t rate) noexcept { lastSampleRate.store(rate, std::memory_order_relaxed); }
+
+    /**
+     * @brief Record one audio callback's measured duration and budget context.
+     *
+     * Consolidated deadline accounting for the device-callback wrapper:
+     * updates last/max duration, the running total for averages, the budget
+     * context (frames + sample rate), and counts a deadline overrun when the
+     * duration exceeds the buffer budget (frames / sampleRate).
+     *
+     * RT-safe: relaxed atomics only — no allocation, locks, or syscalls.
+     */
+    void recordCallbackDuration(uint64_t ns, uint32_t frames, uint32_t sampleRate) noexcept {
+        lastCallbackNs.store(ns, std::memory_order_relaxed);
+        updateMaxCallbackNs(ns);
+        totalCallbackNs.fetch_add(ns, std::memory_order_relaxed);
+        timedCallbackCount.fetch_add(1, std::memory_order_relaxed);
+        lastBufferFrames.store(frames, std::memory_order_relaxed);
+        if (sampleRate > 0) {
+            lastSampleRate.store(sampleRate, std::memory_order_relaxed);
+            const uint64_t budgetNs =
+                (static_cast<uint64_t>(frames) * 1000000000ull) / static_cast<uint64_t>(sampleRate);
+            if (budgetNs > 0 && ns > budgetNs) {
+                overruns.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    }
+
+    /** @brief Average timed-callback duration in ns (0 if none recorded). */
+    uint64_t getAverageCallbackNs() const noexcept {
+        const uint64_t n = timedCallbackCount.load(std::memory_order_relaxed);
+        return n ? totalCallbackNs.load(std::memory_order_relaxed) / n : 0;
+    }
+
+    /** @brief Current callback budget in ns from the last frames/rate context (0 if unknown). */
+    uint64_t getCallbackBudgetNs() const noexcept {
+        const uint32_t frames = lastBufferFrames.load(std::memory_order_relaxed);
+        const uint32_t rate = lastSampleRate.load(std::memory_order_relaxed);
+        return rate ? (static_cast<uint64_t>(frames) * 1000000000ull) / rate : 0;
+    }
     void updateCycleHz(uint64_t hz) noexcept { cycleHz.store(hz, std::memory_order_relaxed); }
     void updateLinuxRtPriorityErrno(int32_t value) noexcept {
         linuxRtPriorityErrno.store(value, std::memory_order_relaxed);

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -443,19 +443,16 @@ int AestraAudioController::audioCallback(float* outputBuffer, const float* input
     const uint64_t cbEndCycles = Aestra::Audio::RT::readCycleCounter();
     if (controller->m_audioEngine && cbEndCycles > cbStartCycles) {
         auto& tel = controller->m_audioEngine->telemetry();
-        tel.lastBufferFrames.store(nFrames, std::memory_order_relaxed);
-        tel.lastSampleRate.store(static_cast<uint32_t>(actualRate), std::memory_order_relaxed);
         const uint64_t hz = tel.cycleHz.load(std::memory_order_relaxed);
         if (hz > 0) {
-           const uint64_t deltaCycles = cbEndCycles - cbStartCycles;
-           const uint64_t ns = (deltaCycles * 1000000000ull) / hz;
-           tel.lastCallbackNs.store(ns, std::memory_order_relaxed);
-           tel.updateMaxCallbackNs(ns);
-           const uint64_t deadlineNs =
-               (static_cast<uint64_t>(nFrames) * 1000000000ull) / static_cast<uint64_t>(actualRate);
-           if (deadlineNs > 0 && ns > deadlineNs) {
-               tel.incrementOverruns();
-           }
+            const uint64_t deltaCycles = cbEndCycles - cbStartCycles;
+            const uint64_t ns = (deltaCycles * 1000000000ull) / hz;
+            // Consolidated deadline accounting: last/max/avg duration, budget
+            // context, and over-budget counting (AudioTelemetry).
+            tel.recordCallbackDuration(ns, nFrames, static_cast<uint32_t>(actualRate));
+        } else {
+            tel.lastBufferFrames.store(nFrames, std::memory_order_relaxed);
+            tel.lastSampleRate.store(static_cast<uint32_t>(actualRate), std::memory_order_relaxed);
         }
     }
 

--- a/Tests/AestraAudio/CallbackDeadlineTelemetryTest.cpp
+++ b/Tests/AestraAudio/CallbackDeadlineTelemetryTest.cpp
@@ -56,6 +56,16 @@ void syntheticMathCase() {
     require(tel2.overruns.load() == 0, "no overrun counted when sample rate unknown");
     require(tel2.getCallbackBudgetNs() == 0, "budget reports 0 when sample rate unknown");
     require(tel2.getAverageCallbackNs() == 5'000'000, "average still tracked without budget context");
+
+    // Pair coherence (CodeRabbit, PR #430): after a valid frames/rate pair, a
+    // later call with sampleRate == 0 must not advance frames independently —
+    // the budget must keep reflecting a pair that actually co-occurred.
+    AudioTelemetry tel3;
+    tel3.recordCallbackDuration(1'000'000, 512, 48000);
+    tel3.recordCallbackDuration(1'000'000, 4096, 0); // rate unknown: pair must not move
+    require(tel3.lastBufferFrames.load() == 512, "frames not advanced by rate-less call");
+    require(tel3.getCallbackBudgetNs() == (512ull * 1000000000ull) / 48000ull,
+            "budget still reflects the last coherent frames/rate pair");
 }
 
 void liveSmokeCase() {

--- a/Tests/AestraAudio/CallbackDeadlineTelemetryTest.cpp
+++ b/Tests/AestraAudio/CallbackDeadlineTelemetryTest.cpp
@@ -1,0 +1,103 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// CallbackDeadlineTelemetryTest — validates the consolidated callback deadline
+// accounting in AudioTelemetry::recordCallbackDuration():
+//   average callback time, worst (max) callback time, buffer budget, and
+//   over-budget (deadline overrun) counting.
+//
+// Part 1 checks the math with synthetic durations. Part 2 smoke-tests the
+// same API against real processBlock timings measured test-side, asserting
+// counter consistency (not absolute timing, which is machine-dependent).
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+
+#include "Core/AudioTelemetry.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool cond, const char* label) {
+    std::cout << "[" << (cond ? "PASS" : "FAIL") << "] " << label << "\n";
+    if (!cond) ++g_failures;
+}
+
+void syntheticMathCase() {
+    AudioTelemetry tel;
+
+    // 512 frames @ 48 kHz → budget = 10,666,666 ns.
+    constexpr uint32_t kFrames = 512;
+    constexpr uint32_t kRate = 48000;
+    constexpr uint64_t kExpectedBudgetNs = (static_cast<uint64_t>(kFrames) * 1000000000ull) / kRate;
+
+    tel.recordCallbackDuration(2'000'000, kFrames, kRate);  // 2 ms — under budget
+    tel.recordCallbackDuration(4'000'000, kFrames, kRate);  // 4 ms — under budget
+    tel.recordCallbackDuration(12'000'000, kFrames, kRate); // 12 ms — OVER budget
+
+    require(tel.getCallbackBudgetNs() == kExpectedBudgetNs, "budget = frames/sampleRate (10.667 ms)");
+    require(tel.lastCallbackNs.load() == 12'000'000, "last = most recent duration");
+    require(tel.maxCallbackNs.load() == 12'000'000, "worst = max duration");
+    require(tel.getAverageCallbackNs() == 6'000'000, "average = mean of recorded durations");
+    require(tel.overruns.load() == 1, "over-budget count = exactly the one 12 ms callback");
+    require(tel.timedCallbackCount.load() == 3, "timed callback count");
+
+    // Degenerate context: unknown sample rate must not divide by zero or
+    // count phantom overruns.
+    AudioTelemetry tel2;
+    tel2.recordCallbackDuration(5'000'000, kFrames, 0);
+    require(tel2.overruns.load() == 0, "no overrun counted when sample rate unknown");
+    require(tel2.getCallbackBudgetNs() == 0, "budget reports 0 when sample rate unknown");
+    require(tel2.getAverageCallbackNs() == 5'000'000, "average still tracked without budget context");
+}
+
+void liveSmokeCase() {
+    SessionConfig cfg;
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    tm->addChannel("DeadlineSmoke");
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+
+    AudioTelemetry tel;
+    std::vector<float> block(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    constexpr uint32_t kBlocks = 64;
+    for (uint32_t i = 0; i < kBlocks; ++i) {
+        const auto t0 = std::chrono::steady_clock::now();
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, cfg.blockSize, 0.0);
+        const auto t1 = std::chrono::steady_clock::now();
+        const uint64_t ns =
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+        tel.recordCallbackDuration(ns, cfg.blockSize, cfg.sampleRate);
+    }
+    engine.setTransportPlaying(false);
+
+    require(tel.timedCallbackCount.load() == kBlocks, "live: every block recorded");
+    require(tel.getAverageCallbackNs() > 0, "live: average is nonzero");
+    require(tel.getAverageCallbackNs() <= tel.maxCallbackNs.load(), "live: average <= worst");
+    require(tel.lastCallbackNs.load() <= tel.maxCallbackNs.load(), "live: last <= worst");
+    require(tel.getCallbackBudgetNs() > 0, "live: budget known");
+    std::cout << "  live timings: avg=" << tel.getAverageCallbackNs() / 1000 << " us, worst="
+              << tel.maxCallbackNs.load() / 1000 << " us, budget=" << tel.getCallbackBudgetNs() / 1000
+              << " us, over-budget=" << tel.overruns.load() << "/" << kBlocks << "\n";
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Aestra Callback Deadline Telemetry Test ===\n\n";
+    syntheticMathCase();
+    liveSmokeCase();
+    std::cout << "\n" << (g_failures == 0 ? "ALL PASS" : "FAILURES: " + std::to_string(g_failures)) << "\n";
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1197,6 +1197,20 @@ target_include_directories(RTAllocationTrapTest PRIVATE
 add_test(NAME RTAllocationTrapTest COMMAND RTAllocationTrapTest)
 set_tests_properties(RTAllocationTrapTest PROPERTIES LABELS "audio;rt-safety;integrity;s-tier" TIMEOUT 180)
 
+# Callback Deadline Telemetry — validates AudioTelemetry::recordCallbackDuration
+# (avg/worst/budget/over-budget math) synthetically, plus a live smoke over
+# real processBlock timings.
+add_executable(CallbackDeadlineTelemetryTest AestraAudio/CallbackDeadlineTelemetryTest.cpp)
+target_link_libraries(CallbackDeadlineTelemetryTest PRIVATE AestraAudio)
+target_include_directories(CallbackDeadlineTelemetryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME CallbackDeadlineTelemetryTest COMMAND CallbackDeadlineTelemetryTest)
+set_tests_properties(CallbackDeadlineTelemetryTest PROPERTIES LABELS "audio;diagnostics;deadline;integrity" TIMEOUT 120)
+
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
     add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)


### PR DESCRIPTION
## Summary
Fourth PR of the Audio Integrity series (stacked on #429; merge order #427 → #428 → #429 → this).

The device callback (`AestraAudioController::audioCallback`) already measured per-callback duration and counted deadline overruns inline — but nothing tracked the **average**, and none of the math was tested. Per the plan's consolidate-don't-duplicate rule:

- **`AudioTelemetry::recordCallbackDuration(ns, frames, sampleRate)`** — single RT-safe (relaxed-atomics-only) method: last/worst duration, running total+count for averages, budget context, over-budget counting. New accessors `getAverageCallbackNs()` / `getCallbackBudgetNs()`.
- **Controller** replaces its inline block with the one call — behavior preserved, including the `cycleHz==0` fallback.
- **`CallbackDeadlineTelemetryTest`** — synthetic validation of avg/worst/budget/over-budget math (incl. divide-by-zero guard for unknown sample rate) plus a live smoke over real `processBlock` timings. Observed on the dev machine: **avg 65 µs, worst 103 µs against a 10.67 ms budget** (512 @ 48 kHz), 0 overruns.

Mission coverage: average callback time ✅, worst callback time ✅, buffer budget ✅, over-budget count ✅ — usable from tests and any HUD via the telemetry accessors.

`DriverStatistics`' per-driver timing fields (WASAPI fills them on Windows; the Linux driver doesn't) are deliberately left alone — engine-level `AudioTelemetry` is the single source of truth.

## Testing
```
CallbackDeadlineTelemetryTest 14/14 · integrity label suite 4/4 green
Aestra app target compiles (controller TU) · build-linux -j2
```

## Risk / rollback
Small production diff: one new inline method + fields on AudioTelemetry, controller block swapped for the call. No behavior change on the hot path beyond two extra relaxed atomic adds per callback (~ns). Revert-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes were introduced.
- Consolidated callback deadline/timing bookkeeping into `AudioTelemetry` with a single RT-safe `recordCallbackDuration(ns, frames, sampleRate)` API.
- Added engine-level timing stats for average, worst, last callback duration, callback budget, and over-budget counts, plus accessors for average and budget queries.
- Simplified `AestraAudioController::audioCallback` to delegate deadline/overrun accounting to telemetry while preserving the `cycleHz == 0` fallback path.
- Added `CallbackDeadlineTelemetryTest` to cover both synthetic math cases and a live smoke test over real audio block timings.
- Registered the new test in CMake with audio/diagnostics/deadline/integrity labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->