### PR TITLE
Audio integrity 5/N: sample-rate & buffer truth + playlist rate fix

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -214,8 +214,19 @@ public:
     /**
      * @brief Set output sample rate
      * @param rate Output device sample rate in Hz.
+     *
+     * Also forwards to the playlist's project sample rate: that value is the
+     * timeline unit buildRuntimeSnapshot() uses to convert beats to engine
+     * samples, so it must track the engine output rate. When they diverge,
+     * clip positions and durations are wrong by the ratio on non-48 kHz
+     * devices (measured: a clip in a 96 kHz engine truncated to half its
+     * duration — SampleRateBufferTruthTest). Not persisted; beats remain the
+     * project's source of truth.
      */
-    void setOutputSampleRate(double rate) { m_outputSampleRate = rate; }
+    void setOutputSampleRate(double rate) {
+        m_outputSampleRate = rate;
+        m_playlistModel.setProjectSampleRate(rate);
+    }
 
     /**
      * @brief Set input sample rate

--- a/AestraDocs/audio-integrity-infrastructure.md
+++ b/AestraDocs/audio-integrity-infrastructure.md
@@ -164,6 +164,44 @@ driver behavior (tests run headless), Windows/macOS driver timing paths
   same 2-track gain+pan session are **identical to the bit** (max abs error
   = 0) on the compared overlap.
 
+### BUG (fixed): playlist timeline rate diverges from engine rate on non-48 kHz devices
+- **Evidence:** `SampleRateBufferTruthTest / CrossRate_48kClip_in_96kEngine` —
+  a 48 kHz clip in a 96 kHz engine played at the correct pitch but was
+  **truncated to half its duration** (first mismatch at ~0.477 s of a 1 s
+  clip; RMS −15 dB vs the analytic reference).
+- **Mechanism:** `PlaylistModel::m_projectSampleRate` (default 48000) is the
+  unit `buildRuntimeSnapshot()` uses to convert beats → engine samples.
+  The app forwards device-rate changes to `TrackManager::setOutputSampleRate`
+  in 4 places (`AestraAudioController.cpp:342`, `AestraApp.cpp:772`,
+  `HeadlessMain.cpp:351`, `AudioExporter.cpp:203`) — but **nothing in
+  `Source/` ever called `PlaylistModel::setProjectSampleRate`** (grep: the
+  only caller was a test working around it). On any non-48 kHz device, every
+  clip's timeline position and duration was wrong by the rate ratio.
+- **Fix (minimal):** `TrackManager::setOutputSampleRate` now forwards to
+  `getPlaylistModel().setProjectSampleRate(rate)`. One line; all existing
+  call sites become correct. Not a persistence change —
+  `m_projectSampleRate` is runtime-only (grep: `ProjectSerializer` only
+  reads it) and beats remain the project's source of truth.
+- **Post-fix:** the same cross-rate case measures **−118.3 dB RMS / 2.4e-6
+  maxAbs** against the analytic 96 kHz reference — the SRC path itself is
+  excellent; the defect was purely timeline math.
+
+### Preview/audition ownership boundary (area 6)
+- **Preview signal** joins the mix **only** in the device callback, additively,
+  after the engine block (`AestraAudioController.cpp:434-437`
+  `PreviewEngine::processRealtime`). The offline export path never executes
+  that code → exported audio structurally cannot contain preview signal.
+- **Audition signal** is mixed inside `processBlock` (AudioEngine.cpp:722)
+  but only when audition mode is enabled; `AudioExporter` disables it for the
+  render (and restores after).
+- **Preview ducking** was the one cross-boundary leak (computed inside
+  `processBlock` from `isAudiblyPlaying()`); fixed above and guarded by
+  `RealtimeExportParityTest / Export_Immune_To_Preview_Ducking`.
+- Rule going forward: monitoring conveniences (preview, audition, metronome,
+  ducking) may live in the realtime monitoring path but must be disabled or
+  neutralized by `AudioExporter::render` — that function is the single
+  checklist for "what must not reach an export."
+
 ### Finding (documented, not fixed): fresh-engine param-application latency
 - On a **freshly constructed** engine, values newly written to
   `ContinuousParamBuffer` do not reach the mix until after the first
@@ -179,3 +217,25 @@ driver behavior (tests run headless), Windows/macOS driver timing paths
 ## 7. RT-safety audit findings
 
 See `AestraDocs/rt-safety-audit.md` (PR-3).
+
+## 8. CI integration
+
+All integrity tests are plain CTest entries picked up by the existing
+`ci.yml`/`nightly.yml` `ctest` invocations — no workflow changes required.
+
+- **Run just this suite:** `ctest --test-dir build-linux -L integrity`
+- **Members + measured runtimes (dev machine, Release):**
+  `GoldenAudioRegressionTest` ~0.4 s · `RealtimeExportParityTest` ~0.4 s ·
+  `RTAllocationTrapTest` ~0.2 s · `CallbackDeadlineTelemetryTest` ~0.2 s ·
+  `SampleRateBufferTruthTest` ~1 s. Total ≈ 2 s — negligible CI cost, so
+  none are gated behind a separate preset.
+- Everything is headless/core-safe (no device, no UI); nothing added to the
+  runtime/experimental tiers.
+- Static RT sweep: `scripts/rt_safety_audit.sh --counts` (advisory, run on
+  demand; classified baseline in `rt-safety-audit.md`).
+- Updating golden expectations: they are analytic — change the expectation
+  math in the same PR as the deliberate engine change (§4). There are no
+  binary references to regenerate.
+- Failure messages: every comparison prints max abs error, RMS (dB), first
+  mismatching frame + channel + time, peaks, sample rate, rendered length,
+  and where to look — designed to be actionable from a CI log alone.

--- a/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
+++ b/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
@@ -1,0 +1,272 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// SampleRateBufferTruthTest — sample-rate correctness and buffer-boundary
+// behavior of the render path (audio-integrity series, area 5).
+//
+// Cases:
+//   1. 96 kHz end-to-end: an impulse in a 96 kHz session lands at the exact
+//      96 kHz frame position with the exact pan-law amplitude, and the
+//      rendered length is exactly the requested number of samples. Wrong
+//      sample-rate handling moves or smears the impulse — unmissable.
+//   2. Cross-rate truth: a 48 kHz clip in a 96 kHz engine must play at the
+//      correct pitch/time via the SRC path. Compared against the analytic
+//      96 kHz reference with a documented (looser) tolerance.
+//   3. Buffer-size independence: identical session rendered at block sizes
+//      64 / 193 / 512 / 1024 / 2048 must produce identical audio. 193 is
+//      deliberately odd to stress non-power-of-two boundaries.
+//   4. Output-overwrite guarantee: processBlock must fully overwrite the
+//      device buffer. Blocks are pre-filled with a sentinel; any surviving
+//      sentinel means stale/unwritten output — the driver does NOT zero
+//      device buffers, so accumulate-instead-of-overwrite would play garbage.
+//      Also verifies exact silence after the clip ends (no stale data across
+//      buffer boundaries).
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+
+#include "DSP/PanLaw.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+
+namespace {
+
+constexpr double kTau = 6.28318530717958647692;
+int g_failures = 0;
+
+void verdict(bool pass, const std::string& label) {
+    std::cout << "[" << (pass ? "PASS" : "FAIL") << "] " << label << "\n";
+    if (!pass) ++g_failures;
+}
+
+std::vector<float> makeSine(double freqHz, float amplitude, uint32_t frames, uint32_t sampleRate) {
+    std::vector<float> s(static_cast<size_t>(frames) * 2, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const float v = static_cast<float>(std::sin(kTau * freqHz * static_cast<double>(i) / sampleRate)) *
+                        amplitude;
+        s[static_cast<size_t>(i) * 2] = v;
+        s[static_cast<size_t>(i) * 2 + 1] = v;
+    }
+    return s;
+}
+
+// -----------------------------------------------------------------------------
+// Case 1: 96 kHz impulse — exact position, amplitude, and render length
+// -----------------------------------------------------------------------------
+void run96kImpulseCase() {
+    SessionConfig cfg;
+    cfg.sampleRate = 96000;
+    const uint32_t totalFrames = cfg.sampleRate; // 1 s
+    const uint32_t impulseFrame = cfg.blockSize + 64;
+    constexpr float kAmp = 0.5f;
+
+    std::vector<float> clip(static_cast<size_t>(totalFrames) * 2, 0.0f);
+    clip[static_cast<size_t>(impulseFrame) * 2] = kAmp;
+    clip[static_cast<size_t>(impulseFrame) * 2 + 1] = kAmp;
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    addAudioTrack(*tm, "Imp96k", clip, totalFrames, cfg);
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+    std::vector<float> output = renderBlocks(engine, totalFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    verdict(output.size() == static_cast<size_t>(totalFrames) * cfg.channels,
+            "96k: render length exactly " + std::to_string(totalFrames) + " frames");
+
+    // Locate the peak sample; it must be at the exact impulse frame.
+    size_t peakIdx = 0;
+    float peakVal = 0.0f;
+    for (size_t i = 0; i < output.size(); ++i) {
+        if (std::abs(output[i]) > peakVal) {
+            peakVal = std::abs(output[i]);
+            peakIdx = i;
+        }
+    }
+    const uint32_t peakFrame = static_cast<uint32_t>(peakIdx / cfg.channels);
+    verdict(peakFrame == impulseFrame,
+            "96k: impulse at exact frame (got " + std::to_string(peakFrame) + ", want " +
+                std::to_string(impulseFrame) + ")");
+    const float expectedAmp = kAmp * PanLaw::kEqualPowerCenterGain;
+    verdict(std::abs(peakVal - expectedAmp) <= 1e-6f,
+            "96k: impulse amplitude = pan-law expectation (got " + std::to_string(peakVal) + ")");
+}
+
+// -----------------------------------------------------------------------------
+// Case 2: 48 kHz clip in a 96 kHz engine — correct pitch/time via SRC
+// -----------------------------------------------------------------------------
+void runCrossRateCase() {
+    SessionConfig cfg;
+    cfg.sampleRate = 96000;
+    const uint32_t engineFrames = cfg.sampleRate; // 1 s at 96 kHz
+    const uint32_t clipRate = 48000;
+    const uint32_t clipFrames = clipRate; // 1 s of source material
+
+    // Build the clip at 48 kHz (buffer declares its true rate).
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    {
+        tm->addChannel("Cross48in96");
+        auto buffer = std::make_shared<AudioBufferData>();
+        buffer->sampleRate = clipRate;
+        buffer->numChannels = 2;
+        buffer->numFrames = clipFrames;
+        buffer->interleavedData = makeSine(1000.0, 0.5f, clipFrames, clipRate);
+        const std::string path = "/tmp/aestra_cross48.wav";
+        ClipSourceID sourceId = tm->getSourceManager().createRecordedSource(path, "Cross48", buffer);
+        AudioSlicePayload payload;
+        payload.audioSourceId = sourceId;
+        payload.durationSeconds = 1.0;
+        payload.slices.push_back({0.0, 1.0, 0.0, static_cast<double>(clipFrames)});
+        PlaylistLaneID laneId = tm->getPlaylistModel().createLane("Cross48");
+        PatternID patternId = tm->getPatternManager().createAudioPattern("Cross48", 2.0, payload);
+        tm->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
+    }
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+    std::vector<float> output = renderBlocks(engine, engineFrames, cfg);
+    engine.setTransportPlaying(false);
+
+    // Expected: a 1 kHz sine at 96 kHz, pan-law scaled. If the engine ignored
+    // the clip's rate it would play 2x too fast (2 kHz) and correlation with
+    // the 1 kHz reference collapses toward 0.
+    std::vector<float> expected = makeSine(1000.0, 0.5f * PanLaw::kEqualPowerCenterGain, engineFrames,
+                                           cfg.sampleRate);
+
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * 4 * cfg.channels;
+    const size_t trimEnd = static_cast<size_t>(4096) * cfg.channels; // SRC tail headroom
+    std::vector<float> outMid(output.begin() + static_cast<ptrdiff_t>(trimStart),
+                              output.end() - static_cast<ptrdiff_t>(trimEnd));
+    std::vector<float> expMid(expected.begin() + static_cast<ptrdiff_t>(trimStart),
+                              expected.end() - static_cast<ptrdiff_t>(trimEnd));
+
+    DiffReport r = compareBuffers(outMid, expMid, cfg.channels, cfg.sampleRate, 1e-3);
+    // Measured baseline after the project-rate fix: -118.3 dB RMS / 2.4e-6
+    // maxAbs. -80 dB keeps cross-platform SRC headroom while still catching a
+    // pitch/time error instantly (a 2x pitch error measures ~-3 dB).
+    const bool pass = (r.rmsErrorDb <= -80.0);
+    printReport("CrossRate_48kClip_in_96kEngine", r, pass,
+                "RMS <= -80 dB vs analytic 1 kHz @ 96 kHz (SRC path; measured -118 dB)");
+    if (!pass) ++g_failures;
+}
+
+// -----------------------------------------------------------------------------
+// Case 3: buffer-size independence — 64/193/512/1024/2048 render identically
+// -----------------------------------------------------------------------------
+void runBufferSizeSweepCase() {
+    const uint32_t kRate = 48000;
+    const uint32_t totalFrames = kRate; // 1 s
+    const std::vector<float> clip = makeSine(440.0, 0.4f, totalFrames, kRate);
+
+    auto renderWithBlock = [&](uint32_t blockSize) {
+        SessionConfig cfg;
+        cfg.sampleRate = kRate;
+        cfg.blockSize = blockSize;
+        auto tm = std::make_shared<TrackManager>();
+        tm->setOutputSampleRate(static_cast<double>(kRate));
+        addAudioTrack(*tm, "Sweep" + std::to_string(blockSize), clip, totalFrames, cfg);
+        AudioEngine engine;
+        prepareEngine(engine, tm, cfg);
+        engine.setTransportPlaying(true);
+        std::vector<float> out = renderBlocks(engine, totalFrames, cfg);
+        engine.setTransportPlaying(false);
+        return out;
+    };
+
+    const std::vector<float> baseline = renderWithBlock(512);
+    for (uint32_t bs : {64u, 193u, 1024u, 2048u}) {
+        std::vector<float> other = renderWithBlock(bs);
+        // Trim the transport fade-in region, whose length legitimately depends
+        // on block size; steady state must be identical.
+        const size_t trim = static_cast<size_t>(4096) * 2;
+        const size_t n = std::min(baseline.size(), other.size());
+        std::vector<float> a(baseline.begin() + static_cast<ptrdiff_t>(trim),
+                             baseline.begin() + static_cast<ptrdiff_t>(n));
+        std::vector<float> b(other.begin() + static_cast<ptrdiff_t>(trim),
+                             other.begin() + static_cast<ptrdiff_t>(n));
+        DiffReport r = compareBuffers(a, b, 2, kRate, 1e-6);
+        const bool pass = (r.maxAbsError <= 1e-6);
+        verdict(pass, "buffer sweep: block " + std::to_string(bs) + " == block 512 (maxAbs " +
+                          std::to_string(r.maxAbsError) + ")");
+        if (!pass) {
+            printReport("BufferSweep_" + std::to_string(bs), r, false, "maxAbs <= 1e-6 vs 512 baseline");
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Case 4: output-overwrite guarantee + exact silence after clip end
+// -----------------------------------------------------------------------------
+void runSentinelOverwriteCase() {
+    SessionConfig cfg;
+    const uint32_t clipFrames = cfg.sampleRate / 2; // 0.5 s of material
+    const uint32_t renderFrames = cfg.sampleRate;   // render a full second
+    const std::vector<float> clip = makeSine(440.0, 0.4f, clipFrames, cfg.sampleRate);
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    addAudioTrack(*tm, "Sentinel", clip, clipFrames, cfg);
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, cfg);
+    engine.setTransportPlaying(true);
+
+    constexpr float kSentinel = 0.123456f;
+    std::vector<float> output;
+    output.reserve(static_cast<size_t>(renderFrames) * cfg.channels);
+    std::vector<float> block(static_cast<size_t>(cfg.blockSize) * cfg.channels, 0.0f);
+    uint32_t rendered = 0;
+    while (rendered < renderFrames) {
+        const uint32_t frames = std::min(cfg.blockSize, renderFrames - rendered);
+        std::fill(block.begin(), block.end(), kSentinel); // device buffers are NOT zeroed
+        engine.processBlock(block.data(), nullptr, frames, 0.0);
+        output.insert(output.end(), block.begin(),
+                      block.begin() + static_cast<ptrdiff_t>(static_cast<size_t>(frames) * cfg.channels));
+        rendered += frames;
+    }
+    engine.setTransportPlaying(false);
+
+    // 4a: no sentinel value may survive anywhere (overwrite guarantee).
+    size_t sentinelSurvivors = 0;
+    for (float s : output) {
+        if (s == kSentinel) ++sentinelSurvivors;
+    }
+    verdict(sentinelSurvivors == 0,
+            "sentinel: processBlock fully overwrites the device buffer (" +
+                std::to_string(sentinelSurvivors) + " survivors)");
+
+    // 4b: after the clip ends (+ generous fade allowance), output is EXACT zeros.
+    const size_t tailStart = (static_cast<size_t>(clipFrames) + 4096) * cfg.channels;
+    size_t nonZeroTail = 0;
+    float maxTail = 0.0f;
+    for (size_t i = tailStart; i < output.size(); ++i) {
+        if (output[i] != 0.0f) {
+            ++nonZeroTail;
+            maxTail = std::max(maxTail, std::abs(output[i]));
+        }
+    }
+    verdict(nonZeroTail == 0, "tail: exact silence after clip end (" + std::to_string(nonZeroTail) +
+                                  " nonzero samples, max " + std::to_string(maxTail) + ")");
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Aestra Sample-Rate & Buffer Truth Test ===\n\n";
+    run96kImpulseCase();
+    runCrossRateCase();
+    runBufferSizeSweepCase();
+    runSentinelOverwriteCase();
+    std::cout << "\n" << (g_failures == 0 ? "ALL PASS" : "FAILURES: " + std::to_string(g_failures)) << "\n";
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1211,6 +1211,20 @@ target_include_directories(CallbackDeadlineTelemetryTest PRIVATE
 add_test(NAME CallbackDeadlineTelemetryTest COMMAND CallbackDeadlineTelemetryTest)
 set_tests_properties(CallbackDeadlineTelemetryTest PROPERTIES LABELS "audio;diagnostics;deadline;integrity" TIMEOUT 120)
 
+# Sample-Rate & Buffer Truth — 96 kHz impulse exactness, 48k-clip-in-96k-engine
+# SRC pitch/time truth, buffer-size independence sweep (64/193/512/1024/2048),
+# sentinel overwrite guarantee, exact post-clip silence.
+add_executable(SampleRateBufferTruthTest AestraAudio/SampleRateBufferTruthTest.cpp)
+target_link_libraries(SampleRateBufferTruthTest PRIVATE AestraAudio)
+target_include_directories(SampleRateBufferTruthTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME SampleRateBufferTruthTest COMMAND SampleRateBufferTruthTest)
+set_tests_properties(SampleRateBufferTruthTest PROPERTIES LABELS "audio;quality;samplerate;buffers;integrity;s-tier" TIMEOUT 180)
+
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
     add_executable(AudioQualityAuditTest AestraAudio/AudioQualityAuditTest.cpp)


### PR DESCRIPTION
## Summary
Fifth PR of the Audio Integrity series (stacked on #430; merge order #427 → #428 → #429 → #430 → this).

`SampleRateBufferTruthTest` proves:
- **96 kHz end-to-end** — impulse at the exact 96 kHz frame, exact pan-law amplitude, render length exact in samples.
- **Buffer-size independence** — block sizes 64 / **193 (odd)** / 512 / 1024 / 2048 render **bit-identical** audio at steady state.
- **Overwrite guarantee** — blocks pre-filled with a sentinel: `processBlock` fully overwrites the device buffer (drivers don't zero it), and output is **exact zeros** after the clip ends. No stale data across buffer boundaries.
- **Cross-rate truth** — a 48 kHz clip in a 96 kHz engine plays at correct pitch **and duration** through the SRC path (measured **−118.3 dB RMS** vs the analytic reference; gate −80 dB).

## Confirmed bug (fixed): playlist timeline rate never followed the device rate
`PlaylistModel::m_projectSampleRate` (default 48000) is the unit `buildRuntimeSnapshot()` uses to convert beats → engine samples. The app forwards device-rate changes to `TrackManager::setOutputSampleRate` in **4 places** (`AestraAudioController.cpp:342`, `AestraApp.cpp:772`, `HeadlessMain.cpp:351`, `AudioExporter.cpp:203`) — but **nothing in `Source/` ever called `setProjectSampleRate`** (only AudioPurityAuditTest, working around it). Consequence on any non-48 kHz device: every clip's timeline position and duration wrong by the rate ratio. The failing test measured a 48 kHz clip in a 96 kHz engine **truncated to half its duration** at correct pitch.

**Fix (one line):** `TrackManager::setOutputSampleRate` forwards to `getPlaylistModel().setProjectSampleRate(rate)` — every existing call site becomes correct.

**Serialization risk assessed:** `m_projectSampleRate` is runtime-only (grep: `ProjectSerializer` reads it for conversion, never writes/stores it); beats remain the project's source of truth. No format change.

## Testing
```
Full rebuild (TrackManager.h is widely included), then CI-equivalent suite:
129/130 pass — sole failure is the KNOWN pre-existing NUITextInputLayoutTest
(UI text layout; no UI files in this diff).
Audio label: 56/56 · serialization/recovery: green · integrity suite: green
```

## Audio impact statement (AGENTS §11)
- 48 kHz-device playback: **unchanged** (playlist default already matched).
- Non-48 kHz devices / exports: clip timing now **correct** (was wrong by the rate ratio — this is the bug fix, machine-guarded by the new test).
- Latency/state format: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)