### PR TITLE
Audio integrity follow-up: eliminate lazy PluginInfo init on the RT thread

### DIFF
--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -110,6 +110,14 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
         if (!plugin->isActive()) {
             plugin->activate();
         }
+        // Prewarm getInfo() here, off the RT path. Several implementations
+        // (e.g. BuiltInPlugins::samplerInfo) return a function-local static
+        // whose FIRST call constructs std::string fields — a heap allocation
+        // plus a __cxa_guard acquire. EffectChainSnapshot::process() calls
+        // getInfo() per slot on the audio thread, so without this the first
+        // block after an insert pays that cost on the RT thread (measured:
+        // 1x31-byte alloc; RTAllocationTrapTest, issue #432).
+        (void)plugin->getInfo();
     }
 
     m_slots[slotIndex].plugin = std::move(plugin);

--- a/AestraDocs/rt-safety-audit.md
+++ b/AestraDocs/rt-safety-audit.md
@@ -24,7 +24,9 @@ Offline export drives the same processBlock from the exporter thread
 
 - **`RTAllocationTrapTest`** — overrides global operator new/delete; renders a
   3-track session with fader/pan engaged and an active insert; asserts ZERO
-  steady-state heap activity while `isRealtimeAudioThread()`. Includes a
+  heap activity while `isRealtimeAudioThread()` — **from the first measured
+  block onward, no warmup exemption** (issue #432). Captures backtraces of the
+  first violations for forensics (resolve with `addr2line`). Includes a
   self-check proving the trap fires (it caught GCC's allocation elision faking
   a pass during development). Scope: C++ new/delete; NOT raw malloc, mutex
   waits, or syscalls.
@@ -37,9 +39,9 @@ Offline export drives the same processBlock from the exporter thread
 
 | # | Finding | Evidence | Classification |
 |---|---|---|---|
-| 1 | Render path performs **zero steady-state heap activity under tested conditions** (3 tracks, fader/pan params, active insert, 186 blocks) — with **one detected first-block 31-byte allocation when an active insert is present** (finding #3; zero absolutely without an insert). The claim is NOT unconditional until #3 is resolved. | `RTAllocationTrapTest` | **verified safe at steady state** |
+| 1 | Render path performs **zero heap activity from the first measured block onward** (3 tracks, fader/pan params, active insert, 187 blocks) — the former first-block exception (old finding #3) is resolved, so the claim is now unconditional under tested conditions | `RTAllocationTrapTest` (gate: `firstBlockAllocs == 0` too) | **verified safe** |
 | 2 | Preview ducking attenuated offline exports by the full configured depth | `RealtimeExportParityTest` | **confirmed violation — FIXED** (AudioExporter save/disable/restore + duck-smoother snap) |
-| 3 | **1 allocation (31 bytes) in the first block after an active insert is added** — lazy init somewhere in the effect-chain path; xrun risk on the first callback after inserting a plugin during playback | `RTAllocationTrapTest` first-block counter (0 allocs without insert, 1 with) | **suspicious but unproven origin** — reproducible; origin hunt is follow-up (gdb conditional breakpoint on the trap) |
+| 3 | **RESOLVED (issue #432):** the first-block 31-byte allocation was `BuiltInPlugins::samplerInfo()` (`BuiltInPlugins.cpp:20`) — a Meyers-singleton `PluginInfo` whose first call constructs `std::string` fields (only the `id` exceeds SSO → the 31 bytes) plus a `__cxa_guard` acquire, reached via `SamplerPlugin::getInfo()` from `EffectChainSnapshot::process()` (`EffectChain.cpp:500`) on the RT thread when the registry hadn't touched the static first. Fix: `EffectChain::insertPlugin()` prewarms `plugin->getInfo()` off-RT. Trap backtrace forensics + `addr2line` found it | trap backtrace → `addr2line`; post-fix run: first block 0/0/0 | **confirmed violation — FIXED** |
 | 4 | `AuditionEngine::processBlock` (RT, AudioEngine.cpp:722) invokes `m_onPositionChanged` — an arbitrary app-bound `std::function` — on the audio thread every 10th block (AuditionEngine.cpp:543-544) | grep + code read; **currently unbound in Source/** (no binder found) | **latent hazard by design** — safe today, one `setOnPositionChanged(ui_lambda)` away from UI work on the RT thread. Follow-up: route through an SPSC snapshot like meters |
 | 5 | `AuditionEngine::processBlock` body (439-546): no direct locks/logs/allocs; its 26 mutex sites live in queue/load helpers (`loadCurrentTrack` etc.) | windowed grep | **acceptable by design** (helpers are non-RT) |
 | 6 | `PatternPlaybackEngine::processAudio` drains its RT queue lock-free; the file's 3 locks are in non-RT mutators, and `refillWindow` is guarded by `reportRealtimeMisuse` and called from `performNonRealtimeMaintenance` | code read :279+, :96/:124/:151 | **acceptable by design** |

--- a/Tests/AestraAudio/RTAllocationTrapTest.cpp
+++ b/Tests/AestraAudio/RTAllocationTrapTest.cpp
@@ -33,7 +33,19 @@
 #include <new>
 #include <vector>
 
-#include <execinfo.h> // backtrace / backtrace_symbols_fd (glibc)
+// Backtrace forensics are glibc/libSystem-only. On other platforms (MSVC) the
+// trap still counts violations — it just can't name the culprit; run the test
+// on Linux for the backtrace.
+#if defined(__linux__) || defined(__APPLE__)
+#include <execinfo.h> // backtrace / backtrace_symbols_fd
+#define AESTRA_RT_TRAP_HAS_BACKTRACE 1
+#else
+#define AESTRA_RT_TRAP_HAS_BACKTRACE 0
+namespace {
+inline int backtrace(void**, int) { return 0; }
+inline void backtrace_symbols_fd(void* const*, int, int) {}
+} // namespace
+#endif
 
 // =============================================================================
 // Global allocation trap (test binary only)

--- a/Tests/AestraAudio/RTAllocationTrapTest.cpp
+++ b/Tests/AestraAudio/RTAllocationTrapTest.cpp
@@ -33,6 +33,8 @@
 #include <new>
 #include <vector>
 
+#include <execinfo.h> // backtrace / backtrace_symbols_fd (glibc)
+
 // =============================================================================
 // Global allocation trap (test binary only)
 // =============================================================================
@@ -43,10 +45,33 @@ std::atomic<uint64_t> g_rtAllocCount{0};
 std::atomic<uint64_t> g_rtAllocBytes{0};
 std::atomic<uint64_t> g_rtFreeCount{0};
 
+// Forensics: capture backtraces for the first few RT allocations so a failure
+// names its culprit. backtrace() is prewarmed in main() BEFORE the trap arms
+// (its first call lazily loads libgcc, which allocates); the thread_local
+// guard prevents recursion if it ever allocates anyway.
+constexpr int kMaxTraceEvents = 4;
+constexpr int kMaxTraceDepth = 24;
+struct TraceEvent {
+    void* frames[kMaxTraceDepth];
+    int depth{0};
+    std::size_t size{0};
+};
+TraceEvent g_traceEvents[kMaxTraceEvents];
+std::atomic<int> g_traceCount{0};
+thread_local bool g_inTrap = false;
+
 inline void noteAlloc(std::size_t size) noexcept {
-    if (g_trapArmed.load(std::memory_order_relaxed) && Aestra::Audio::isRealtimeAudioThread()) {
+    if (g_trapArmed.load(std::memory_order_relaxed) && Aestra::Audio::isRealtimeAudioThread() &&
+        !g_inTrap) {
+        g_inTrap = true;
         g_rtAllocCount.fetch_add(1, std::memory_order_relaxed);
         g_rtAllocBytes.fetch_add(size, std::memory_order_relaxed);
+        const int slot = g_traceCount.fetch_add(1, std::memory_order_relaxed);
+        if (slot < kMaxTraceEvents) {
+            g_traceEvents[slot].size = size;
+            g_traceEvents[slot].depth = backtrace(g_traceEvents[slot].frames, kMaxTraceDepth);
+        }
+        g_inTrap = false;
     }
 }
 
@@ -127,6 +152,14 @@ std::vector<float> makeSine(double freqHz, float amplitude, uint32_t frames, uin
 int main() {
     std::cout << "=== Aestra RT Allocation Trap Test ===\n\n";
 
+    // Prewarm backtrace() before the trap arms: its first call lazily loads
+    // libgcc (which allocates). Off-RT and unarmed here, so it never taints
+    // the counters.
+    {
+        void* warm[4];
+        (void)backtrace(warm, 4);
+    }
+
     // Trap self-check: prove the override actually fires, so a zero result
     // below is meaningful. Allocate inside a marked RT scope and verify the
     // counters move.
@@ -153,6 +186,7 @@ int main() {
         g_rtAllocCount.store(0, std::memory_order_relaxed);
         g_rtAllocBytes.store(0, std::memory_order_relaxed);
         g_rtFreeCount.store(0, std::memory_order_relaxed);
+        g_traceCount.store(0, std::memory_order_relaxed);
     }
 
     SessionConfig cfg;
@@ -221,21 +255,31 @@ int main() {
     std::cout << "steady state (" << (numBlocks - 1) << " blocks): " << steadyAllocs << " allocs / "
               << steadyBytes << " bytes / " << steadyFrees << " frees\n";
 
-    const bool pass = (steadyAllocs == 0 && steadyFrees == 0);
+    // Forensics: dump captured backtraces of RT allocations. Resolve with
+    //   addr2line -e ./build-linux/Tests/RTAllocationTrapTest -f -C <addr...>
+    const int traces = std::min(g_traceCount.load(std::memory_order_relaxed), kMaxTraceEvents);
+    for (int t = 0; t < traces; ++t) {
+        std::cout << "\nRT allocation #" << t << " (" << g_traceEvents[t].size << " bytes) backtrace:\n";
+        backtrace_symbols_fd(g_traceEvents[t].frames, g_traceEvents[t].depth, 1);
+    }
+
+    // Unconditional gate (issue #432 acceptance): ZERO heap activity from the
+    // FIRST measured block onward, active insert included. The former
+    // first-block exemption is gone — its one known cause (lazy PluginInfo
+    // static init reaching the RT thread) is prewarmed off-RT in
+    // EffectChain::insertPlugin.
+    const bool pass =
+        (firstBlockAllocs == 0 && firstBlockFrees == 0 && steadyAllocs == 0 && steadyFrees == 0);
     if (!pass) {
-        std::cout << "\n[FAIL] heap activity on the audio callback path at steady state\n"
-                  << "  first violating block: " << firstSteadyViolationBlock << "\n"
-                  << "  Every allocation inside processBlock is an xrun risk (AGENTS §10).\n"
-                  << "  Find it: run this test under gdb with a breakpoint on the operator\n"
-                  << "  new in RTAllocationTrapTest.cpp conditioned on\n"
-                  << "  Aestra::Audio::isRealtimeAudioThread(), or use massif/heaptrack.\n";
-    } else {
-        std::cout << "\n[PASS] zero steady-state heap activity on the audio callback path\n";
-        if (firstBlockAllocs || firstBlockFrees) {
-            std::cout << "  note: first-block warmup performed " << firstBlockAllocs
-                      << " allocs — reported as a finding, not a failure (see\n"
-                      << "  AestraDocs/rt-safety-audit.md).\n";
+        std::cout << "\n[FAIL] heap activity on the audio callback path\n";
+        if (steadyAllocs || steadyFrees) {
+            std::cout << "  first violating steady-state block: " << firstSteadyViolationBlock << "\n";
         }
+        std::cout << "  Every allocation inside processBlock is an xrun risk (AGENTS §10).\n"
+                  << "  The backtraces above name the culprit; resolve in-binary frames with\n"
+                  << "  addr2line -e ./build-linux/Tests/RTAllocationTrapTest -f -C <addr>.\n";
+    } else {
+        std::cout << "\n[PASS] zero heap activity on the audio callback path, first block included\n";
     }
     return pass ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
**Fixes #432** — the 31-byte first-block allocation on the audio callback path, hunted to its exact source and eliminated. The RT zero-allocation guarantee is now **unconditional** (no warmup exemption).

## The hunt (evidence)
`RTAllocationTrapTest` gained permanent backtrace forensics (prewarmed off-RT, recursion-guarded); the captured trace resolved via `addr2line` to:

```
operator new (31 bytes)
→ std::string::_M_replace                      (libstdc++)
→ BuiltInPlugins::samplerInfo()                AestraAudio/src/Plugin/BuiltInPlugins.cpp:20
→ EffectChainSnapshot::process()               EffectChain.cpp:500 (getInfo per slot)
→ AudioEngine::renderGraph → processBlock      [RT thread]
```

`samplerInfo()` is a Meyers singleton — `static const PluginInfo` constructed on **first call**: five `std::string` fields (only `id` exceeds SSO → exactly one 31-byte block) **plus a `__cxa_guard` acquire** — i.e. a heap allocation *and* a potential futex on the audio thread. Production usually dodges it because registry registration touches the static at startup; any plugin reaching a chain slot without the registry (direct construction) paid it on the first RT block after insert.

## The fix (one line of production code)
`EffectChain::insertPlugin()` — contractually non-RT (`reportRealtimeMisuse`-guarded) and the sole entry path into chain slots — prewarms `(void)plugin->getInfo()` after initialize/activate. Covers **every** `IPluginInstance`, not just built-ins.

## Acceptance criteria from #432 — all met
1. ✅ Exact source identified (above, file:line + mechanism).
2. ✅ Init moved off the RT path (insertPlugin prewarm).
3. ✅ `RTAllocationTrapTest` now **fails on `firstBlockAllocs > 0`** — exemption removed; backtrace forensics stay permanently so any future violation names its culprit.
4. ✅ Proven: post-fix run with active insert = `first block: 0 allocs / 0 bytes / 0 frees; steady state (186 blocks): 0/0/0` → PASS.

`AestraDocs/rt-safety-audit.md` findings #1/#3 updated to the unconditional claim with the resolution recorded.

## Testing
```
Full rebuild (build-linux, -j2) · CI-equivalent suite 129/130
(sole failure: known pre-existing NUITextInputLayoutTest, UI-only)
integrity label suite green · trap 0/0/0 from first block onward
```

## Audio impact (AGENTS §11)
None — `getInfo()` is a const accessor; prewarming it changes no audio, latency, or state format. The change removes work (lazy init) from the RT thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Tightened RT allocation guarantees: `RTAllocationTrapTest` now fails on any heap activity from the first measured block onward, captures backtraces for early violations, and prints them for debugging.
- Fixed the audio-thread allocation source by prewarming `plugin->getInfo()` inside `EffectChain::insertPlugin()`, moving lazy `PluginInfo` initialization off the realtime path.
- Updated `AestraDocs/rt-safety-audit.md` to reflect the resolved `#432` finding and state the zero-allocation result unconditionally under the tested conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->