### PR TITLE
Audio Research Bench Phase 1: measurement core + deterministic signal suite

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1291,6 +1291,21 @@ add_test(NAME ExportBounceParityTest COMMAND ExportBounceParityTest)
 set_tests_properties(ExportBounceParityTest PROPERTIES LABELS "audio;quality;export;s-tier")
 
 # =============================================================================
+# Audio Research Bench (Tests/Research)
+# =============================================================================
+# Scientific audio-quality measurement layer: deterministic signal generators
+# (SignalLab.h) + analysis routines (AudioMeasure.h), validated against
+# closed-form analytic expectations. Header-only, test-side, no engine deps.
+# Doc: AestraDocs/audio-research-bench.md.
+
+# Measurement Core Self-Test — proves the measurement layer itself (peak, RMS,
+# DC, tone fit/SINAD-style residual, THD, impulse stats, stereo correlation,
+# diff forensics) against analytic math before it is used to measure DSP.
+add_executable(MeasurementCoreSelfTest Research/MeasurementCoreSelfTest.cpp)
+add_test(NAME MeasurementCoreSelfTest COMMAND MeasurementCoreSelfTest)
+set_tests_properties(MeasurementCoreSelfTest PROPERTIES LABELS "audio;research;audio-research" TIMEOUT 120)
+
+# =============================================================================
 # AestraPlat Tests
 # =============================================================================
 

--- a/Tests/Research/AudioMeasure.h
+++ b/Tests/Research/AudioMeasure.h
@@ -1,0 +1,437 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AudioMeasure — deterministic test-side audio analysis for the Aestra Audio Research Bench.
+//
+// All analysis runs in double precision over float buffers. Every routine is a pure
+// function of its inputs: no global state, no randomness, no wall-clock dependence.
+//
+// Measurement definitions (see AestraDocs/audio-research-bench.md for the full policy):
+//   * peak            — max |sample| over the window.
+//   * RMS             — sqrt(mean(sample^2)) over the window; dBFS via 20*log10.
+//   * DC offset       — arithmetic mean over the window.
+//   * tone fit        — 3-parameter least squares (a*sin + b*cos + c) at a KNOWN
+//                       frequency. Amplitude = sqrt(a^2+b^2). Exact when the window
+//                       holds an integer number of cycles; near-exact for long windows.
+//   * residual SINAD  — ratio of fitted-tone RMS to post-subtraction residual RMS.
+//                       The residual contains noise + distortion + aliasing across the
+//                       whole band. This is a THD+N-style figure for single-tone
+//                       stimuli, NOT a spectrum-analyzer SINAD; do not quote it as one.
+//   * THD             — sqrt(sum of harmonic-amplitude^2) / fundamental amplitude,
+//                       harmonics measured by per-harmonic tone fits BELOW Nyquist only.
+//                       Aliased harmonics are not attributed; callers must state the
+//                       harmonic range they counted.
+//   * impulse stats   — peak position/value, span above a relative threshold,
+//                       pre-span (pre-ring) RMS and post-span (tail) RMS.
+//   * stereo correlation — Pearson correlation of L vs R (mean-removed).
+//
+// Failure output is forensic: sample rate, channels, frames, peaks, RMS, max error,
+// first mismatching frame/channel, and an expected/actual snippet around the mismatch.
+//
+// Test-side only. This header must never be included from production code.
+#pragma once
+
+#include "SignalLab.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <string>
+
+namespace AudioResearch {
+
+// =============================================================================
+// Windows & scalar helpers
+// =============================================================================
+
+constexpr uint32_t kToEnd = std::numeric_limits<uint32_t>::max();
+
+inline double toDb(double linear) { return 20.0 * std::log10(std::max(linear, 1e-30)); }
+
+/// Clamp [startFrame, endFrame) to the signal length; endFrame = kToEnd means "to end".
+inline void clampWindow(const Signal& s, uint32_t& startFrame, uint32_t& endFrame) {
+    endFrame = std::min(endFrame, s.frames());
+    startFrame = std::min(startFrame, endFrame);
+}
+
+// =============================================================================
+// Basic statistics
+// =============================================================================
+
+/// Max |sample| over the window. channel = -1 scans all channels.
+inline double peak(const Signal& s, int channel = -1, uint32_t startFrame = 0, uint32_t endFrame = kToEnd) {
+    clampWindow(s, startFrame, endFrame);
+    double p = 0.0;
+    for (uint32_t i = startFrame; i < endFrame; ++i) {
+        for (uint32_t ch = 0; ch < s.channels; ++ch) {
+            if (channel >= 0 && static_cast<uint32_t>(channel) != ch) {
+                continue;
+            }
+            p = std::max(p, std::abs(static_cast<double>(s.at(i, ch))));
+        }
+    }
+    return p;
+}
+
+/// sqrt(mean(sample^2)) over the window. channel = -1 pools all channels.
+inline double rms(const Signal& s, int channel = -1, uint32_t startFrame = 0, uint32_t endFrame = kToEnd) {
+    clampWindow(s, startFrame, endFrame);
+    double sumSq = 0.0;
+    uint64_t count = 0;
+    for (uint32_t i = startFrame; i < endFrame; ++i) {
+        for (uint32_t ch = 0; ch < s.channels; ++ch) {
+            if (channel >= 0 && static_cast<uint32_t>(channel) != ch) {
+                continue;
+            }
+            const double v = static_cast<double>(s.at(i, ch));
+            sumSq += v * v;
+            ++count;
+        }
+    }
+    return count > 0 ? std::sqrt(sumSq / static_cast<double>(count)) : 0.0;
+}
+
+/// Arithmetic mean over the window (DC offset). channel = -1 pools all channels.
+inline double dcOffset(const Signal& s, int channel = -1, uint32_t startFrame = 0, uint32_t endFrame = kToEnd) {
+    clampWindow(s, startFrame, endFrame);
+    double sum = 0.0;
+    uint64_t count = 0;
+    for (uint32_t i = startFrame; i < endFrame; ++i) {
+        for (uint32_t ch = 0; ch < s.channels; ++ch) {
+            if (channel >= 0 && static_cast<uint32_t>(channel) != ch) {
+                continue;
+            }
+            sum += static_cast<double>(s.at(i, ch));
+            ++count;
+        }
+    }
+    return count > 0 ? sum / static_cast<double>(count) : 0.0;
+}
+
+/// First frame with |sample| > threshold on any channel; -1 if none.
+inline int64_t firstNonSilentFrame(const Signal& s, double threshold = 0.0) {
+    for (uint32_t i = 0; i < s.frames(); ++i) {
+        for (uint32_t ch = 0; ch < s.channels; ++ch) {
+            if (std::abs(static_cast<double>(s.at(i, ch))) > threshold) {
+                return static_cast<int64_t>(i);
+            }
+        }
+    }
+    return -1;
+}
+
+// =============================================================================
+// Null / difference forensics
+// =============================================================================
+
+struct DiffReport {
+    double maxAbsError{0.0};
+    double rmsError{0.0};        // linear
+    double rmsErrorDb{-999.0};
+    int64_t firstMismatchFrame{-1};  // first |a-b| > tolerance; -1 = none
+    int firstMismatchChannel{-1};
+    uint64_t framesCompared{0};
+    bool lengthMismatch{false};
+    uint32_t framesA{0};
+    uint32_t framesB{0};
+    double peakA{0.0};
+    double peakB{0.0};
+    double rmsA{0.0};
+    double rmsB{0.0};
+    uint32_t sampleRate{0};
+    uint32_t channels{0};
+};
+
+/// Null-difference over the common length of two equally-formatted signals.
+/// `tolerance` only localizes the first mismatch; pass/fail policy is the caller's.
+inline DiffReport diff(const Signal& a, const Signal& b, double tolerance = 0.0) {
+    DiffReport r;
+    r.sampleRate = a.sampleRate;
+    r.channels = a.channels;
+    r.framesA = a.frames();
+    r.framesB = b.frames();
+    r.lengthMismatch = (r.framesA != r.framesB) || (a.channels != b.channels);
+    r.peakA = peak(a);
+    r.peakB = peak(b);
+    r.rmsA = rms(a);
+    r.rmsB = rms(b);
+
+    const uint32_t frames = std::min(r.framesA, r.framesB);
+    const uint32_t chans = std::min(a.channels, b.channels);
+    r.framesCompared = frames;
+
+    double sumSq = 0.0;
+    uint64_t count = 0;
+    for (uint32_t i = 0; i < frames; ++i) {
+        for (uint32_t ch = 0; ch < chans; ++ch) {
+            const double d = static_cast<double>(a.at(i, ch)) - static_cast<double>(b.at(i, ch));
+            const double ad = std::abs(d);
+            sumSq += d * d;
+            ++count;
+            r.maxAbsError = std::max(r.maxAbsError, ad);
+            if (ad > tolerance && r.firstMismatchFrame < 0) {
+                r.firstMismatchFrame = static_cast<int64_t>(i);
+                r.firstMismatchChannel = static_cast<int>(ch);
+            }
+        }
+    }
+    r.rmsError = count > 0 ? std::sqrt(sumSq / static_cast<double>(count)) : 0.0;
+    r.rmsErrorDb = toDb(r.rmsError);
+    return r;
+}
+
+/// Full forensic dump for a failed comparison, including an actual/expected snippet
+/// around the first mismatch (or buffer start if there is none).
+inline void printDiffForensics(const std::string& label, const DiffReport& r, const Signal& actual,
+                               const Signal& expected, int snippetRadius = 3) {
+    std::printf("  ---- research-bench diff forensics: %s ----\n", label.c_str());
+    std::printf("  sample rate:     %u Hz\n", r.sampleRate);
+    std::printf("  channels:        %u\n", r.channels);
+    std::printf("  frames:          actual=%u expected=%u%s\n", r.framesA, r.framesB,
+                r.lengthMismatch ? "  (LENGTH MISMATCH)" : "");
+    std::printf("  peak:            actual=%.9f expected=%.9f\n", r.peakA, r.peakB);
+    std::printf("  RMS:             actual=%.9f expected=%.9f\n", r.rmsA, r.rmsB);
+    std::printf("  max abs error:   %.9g\n", r.maxAbsError);
+    std::printf("  RMS error:       %.9g (%.1f dB)\n", r.rmsError, r.rmsErrorDb);
+    std::printf("  first mismatch:  frame %lld, channel %d\n", static_cast<long long>(r.firstMismatchFrame),
+                r.firstMismatchChannel);
+    const int64_t center = r.firstMismatchFrame >= 0 ? r.firstMismatchFrame : 0;
+    const int64_t lo = std::max<int64_t>(0, center - snippetRadius);
+    const int64_t hi = std::min<int64_t>(static_cast<int64_t>(r.framesCompared), center + snippetRadius + 1);
+    const uint32_t chans = std::min(actual.channels, expected.channels);
+    for (int64_t i = lo; i < hi; ++i) {
+        std::printf("    frame %6lld:", static_cast<long long>(i));
+        for (uint32_t ch = 0; ch < chans; ++ch) {
+            std::printf("  ch%u actual=%+.9f expected=%+.9f", ch, actual.at(static_cast<uint32_t>(i), ch),
+                        expected.at(static_cast<uint32_t>(i), ch));
+        }
+        std::printf("\n");
+    }
+}
+
+// =============================================================================
+// Tone fitting (known-frequency least squares)
+// =============================================================================
+
+struct ToneFit {
+    double amplitude{0.0};     // sqrt(a^2 + b^2)
+    double phaseRad{0.0};      // atan2(b, a) for a*sin + b*cos
+    double dc{0.0};            // fitted constant term
+    double residualRms{0.0};   // RMS of (signal - fit), full band
+    double sinadDb{-999.0};    // 20*log10(fitted tone RMS / residual RMS); see header caveat
+};
+
+/// Least-squares fit of a*sin(w n) + b*cos(w n) + c at a KNOWN frequency, solved via
+/// 3x3 normal equations in double precision. Exact for integer-cycle windows; use
+/// windows >= ~100 cycles when the cycle count is fractional.
+inline ToneFit fitTone(const Signal& s, int channel, double freqHz, uint32_t startFrame = 0,
+                       uint32_t endFrame = kToEnd) {
+    clampWindow(s, startFrame, endFrame);
+    const uint32_t n = endFrame - startFrame;
+    ToneFit fit;
+    if (n < 8 || freqHz <= 0.0 || freqHz >= 0.5 * s.sampleRate) {
+        return fit;
+    }
+    const double w = kTau * freqHz / static_cast<double>(s.sampleRate);
+
+    // Accumulate normal-equation terms for basis {sin, cos, 1}.
+    double ss = 0.0, cc = 0.0, sc = 0.0, s1 = 0.0, c1 = 0.0;
+    double xs = 0.0, xc = 0.0, x1 = 0.0;
+    for (uint32_t i = 0; i < n; ++i) {
+        const double sn = std::sin(w * static_cast<double>(startFrame + i));
+        const double cs = std::cos(w * static_cast<double>(startFrame + i));
+        const double x = static_cast<double>(s.at(startFrame + i, static_cast<uint32_t>(channel)));
+        ss += sn * sn;
+        cc += cs * cs;
+        sc += sn * cs;
+        s1 += sn;
+        c1 += cs;
+        xs += x * sn;
+        xc += x * cs;
+        x1 += x;
+    }
+    const double nn = static_cast<double>(n);
+
+    // Solve [ss sc s1; sc cc c1; s1 c1 nn] * [a b c]' = [xs xc x1]' by Cramer's rule.
+    const double det = ss * (cc * nn - c1 * c1) - sc * (sc * nn - c1 * s1) + s1 * (sc * c1 - cc * s1);
+    if (std::abs(det) < 1e-12) {
+        return fit;
+    }
+    const double a =
+        (xs * (cc * nn - c1 * c1) - sc * (xc * nn - c1 * x1) + s1 * (xc * c1 - cc * x1)) / det;
+    const double b =
+        (ss * (xc * nn - c1 * x1) - xs * (sc * nn - c1 * s1) + s1 * (sc * x1 - xc * s1)) / det;
+    const double c =
+        (ss * (cc * x1 - xc * c1) - sc * (sc * x1 - xs * c1) + xs * (sc * c1 - cc * s1)) / det;
+
+    fit.amplitude = std::sqrt(a * a + b * b);
+    fit.phaseRad = std::atan2(b, a);
+    fit.dc = c;
+
+    double residSq = 0.0;
+    for (uint32_t i = 0; i < n; ++i) {
+        const double sn = std::sin(w * static_cast<double>(startFrame + i));
+        const double cs = std::cos(w * static_cast<double>(startFrame + i));
+        const double x = static_cast<double>(s.at(startFrame + i, static_cast<uint32_t>(channel)));
+        const double resid = x - (a * sn + b * cs + c);
+        residSq += resid * resid;
+    }
+    fit.residualRms = std::sqrt(residSq / nn);
+    const double toneRms = fit.amplitude / std::sqrt(2.0);
+    fit.sinadDb = fit.residualRms > 0.0 ? toDb(toneRms / fit.residualRms) : 999.0;
+    return fit;
+}
+
+/// Amplitude of a known-frequency component (convenience wrapper over fitTone).
+inline double toneAmplitude(const Signal& s, int channel, double freqHz, uint32_t startFrame = 0,
+                            uint32_t endFrame = kToEnd) {
+    return fitTone(s, channel, freqHz, startFrame, endFrame).amplitude;
+}
+
+// =============================================================================
+// Harmonic analysis (THD)
+// =============================================================================
+
+struct HarmonicReport {
+    double fundamentalAmplitude{0.0};
+    // harmonicAmplitudes[k] = amplitude at (k+2)*f0, i.e. index 0 is the 2nd harmonic.
+    std::vector<double> harmonicAmplitudes;
+    uint32_t harmonicsMeasured{0}; // number of harmonics that fit below Nyquist
+    double thdRatio{0.0};          // sqrt(sum h^2) / fundamental
+    double thdDb{-999.0};
+};
+
+/// Per-harmonic tone fits at k*f0 for k = 2..maxHarmonic, skipping any harmonic at or
+/// above Nyquist. Exact when the window holds integer periods of f0. Aliased harmonic
+/// energy is NOT attributed here — it lands in fitTone().residualRms instead.
+inline HarmonicReport measureHarmonics(const Signal& s, int channel, double f0Hz, uint32_t maxHarmonic = 15,
+                                       uint32_t startFrame = 0, uint32_t endFrame = kToEnd) {
+    HarmonicReport r;
+    r.fundamentalAmplitude = toneAmplitude(s, channel, f0Hz, startFrame, endFrame);
+    double sumSq = 0.0;
+    for (uint32_t k = 2; k <= maxHarmonic; ++k) {
+        const double f = f0Hz * static_cast<double>(k);
+        if (f >= 0.5 * s.sampleRate) {
+            break;
+        }
+        const double amp = toneAmplitude(s, channel, f, startFrame, endFrame);
+        r.harmonicAmplitudes.push_back(amp);
+        sumSq += amp * amp;
+        ++r.harmonicsMeasured;
+    }
+    if (r.fundamentalAmplitude > 0.0) {
+        r.thdRatio = std::sqrt(sumSq) / r.fundamentalAmplitude;
+        r.thdDb = toDb(r.thdRatio);
+    }
+    return r;
+}
+
+// =============================================================================
+// Impulse analysis
+// =============================================================================
+
+struct ImpulseReport {
+    double peakAbs{0.0};
+    int64_t peakFrame{-1};
+    // Contiguous extent of |x| > peakAbs * threshold (relative threshold, linear):
+    int64_t spanFirstFrame{-1};
+    int64_t spanLastFrame{-1};
+    int64_t spanFrames{0};      // spread of the response above threshold
+    double preSpanRms{0.0};     // energy before the span (pre-ring / acausal leakage)
+    double tailRms{0.0};        // energy after the span (post-ring / echo)
+};
+
+/// Characterize an impulse-like response on one channel. `relativeThresholdDb` sets the
+/// span cut (default -60 dB below the peak).
+inline ImpulseReport analyzeImpulse(const Signal& s, int channel, double relativeThresholdDb = -60.0) {
+    ImpulseReport r;
+    const uint32_t n = s.frames();
+    const uint32_t ch = static_cast<uint32_t>(channel);
+    for (uint32_t i = 0; i < n; ++i) {
+        const double v = std::abs(static_cast<double>(s.at(i, ch)));
+        if (v > r.peakAbs) {
+            r.peakAbs = v;
+            r.peakFrame = static_cast<int64_t>(i);
+        }
+    }
+    if (r.peakFrame < 0 || r.peakAbs <= 0.0) {
+        return r;
+    }
+    const double cut = r.peakAbs * std::pow(10.0, relativeThresholdDb / 20.0);
+    for (uint32_t i = 0; i < n; ++i) {
+        if (std::abs(static_cast<double>(s.at(i, ch))) > cut) {
+            if (r.spanFirstFrame < 0) {
+                r.spanFirstFrame = static_cast<int64_t>(i);
+            }
+            r.spanLastFrame = static_cast<int64_t>(i);
+        }
+    }
+    r.spanFrames = r.spanLastFrame - r.spanFirstFrame + 1;
+    if (r.spanFirstFrame > 0) {
+        r.preSpanRms = rms(s, channel, 0, static_cast<uint32_t>(r.spanFirstFrame));
+    }
+    if (r.spanLastFrame + 1 < static_cast<int64_t>(n)) {
+        r.tailRms = rms(s, channel, static_cast<uint32_t>(r.spanLastFrame + 1), n);
+    }
+    return r;
+}
+
+// =============================================================================
+// Stereo correlation
+// =============================================================================
+
+/// Pearson correlation (mean-removed) between channels 0 and 1 over the window.
+/// Returns 0 when either channel has ~zero variance (correlation is undefined there).
+inline double stereoCorrelation(const Signal& s, uint32_t startFrame = 0, uint32_t endFrame = kToEnd) {
+    clampWindow(s, startFrame, endFrame);
+    if (s.channels < 2 || endFrame <= startFrame) {
+        return 0.0;
+    }
+    const double meanL = dcOffset(s, 0, startFrame, endFrame);
+    const double meanR = dcOffset(s, 1, startFrame, endFrame);
+    double sLL = 0.0, sRR = 0.0, sLR = 0.0;
+    for (uint32_t i = startFrame; i < endFrame; ++i) {
+        const double l = static_cast<double>(s.at(i, 0)) - meanL;
+        const double r = static_cast<double>(s.at(i, 1)) - meanR;
+        sLL += l * l;
+        sRR += r * r;
+        sLR += l * r;
+    }
+    if (sLL < 1e-24 || sRR < 1e-24) {
+        return 0.0;
+    }
+    return sLR / std::sqrt(sLL * sRR);
+}
+
+// =============================================================================
+// Minimal check harness (shared PASS/FAIL accounting for research tests)
+// =============================================================================
+
+struct CheckSession {
+    int passed{0};
+    int failed{0};
+
+    bool expect(const char* name, bool ok, const std::string& detail = {}) {
+        std::printf("[%s] %s", ok ? "PASS" : "FAIL", name);
+        if (!detail.empty()) {
+            std::printf(" - %s", detail.c_str());
+        }
+        std::printf("\n");
+        ok ? ++passed : ++failed;
+        return ok;
+    }
+
+    /// Expect |value - expected| <= tolerance, with the numbers in the log either way.
+    bool expectNear(const char* name, double value, double expected, double tolerance) {
+        char buf[160];
+        std::snprintf(buf, sizeof(buf), "value=%.12g expected=%.12g tol=%.3g", value, expected, tolerance);
+        return expect(name, std::abs(value - expected) <= tolerance, buf);
+    }
+
+    int exitCode() const {
+        std::printf("\nResearch bench summary: %d passed, %d failed\n", passed, failed);
+        return failed == 0 ? 0 : 1;
+    }
+};
+
+} // namespace AudioResearch

--- a/Tests/Research/AudioMeasure.h
+++ b/Tests/Research/AudioMeasure.h
@@ -224,12 +224,16 @@ struct ToneFit {
 /// Least-squares fit of a*sin(w n) + b*cos(w n) + c at a KNOWN frequency, solved via
 /// 3x3 normal equations in double precision. Exact for integer-cycle windows; use
 /// windows >= ~100 cycles when the cycle count is fractional.
+/// Unlike peak/rms/dcOffset, `channel` must name ONE valid channel (no -1 pooling —
+/// a tone fit across interleaved channels is not meaningful); invalid channels
+/// return an empty fit.
 inline ToneFit fitTone(const Signal& s, int channel, double freqHz, uint32_t startFrame = 0,
                        uint32_t endFrame = kToEnd) {
     clampWindow(s, startFrame, endFrame);
     const uint32_t n = endFrame - startFrame;
     ToneFit fit;
-    if (n < 8 || freqHz <= 0.0 || freqHz >= 0.5 * s.sampleRate) {
+    if (n < 8 || freqHz <= 0.0 || freqHz >= 0.5 * s.sampleRate || channel < 0 ||
+        static_cast<uint32_t>(channel) >= s.channels) {
         return fit;
     }
     const double w = kTau * freqHz / static_cast<double>(s.sampleRate);
@@ -342,9 +346,13 @@ struct ImpulseReport {
 };
 
 /// Characterize an impulse-like response on one channel. `relativeThresholdDb` sets the
-/// span cut (default -60 dB below the peak).
+/// span cut (default -60 dB below the peak). `channel` must name one valid channel
+/// (no -1 pooling); invalid channels return an empty report.
 inline ImpulseReport analyzeImpulse(const Signal& s, int channel, double relativeThresholdDb = -60.0) {
     ImpulseReport r;
+    if (channel < 0 || static_cast<uint32_t>(channel) >= s.channels) {
+        return r;
+    }
     const uint32_t n = s.frames();
     const uint32_t ch = static_cast<uint32_t>(channel);
     for (uint32_t i = 0; i < n; ++i) {

--- a/Tests/Research/MeasurementCoreSelfTest.cpp
+++ b/Tests/Research/MeasurementCoreSelfTest.cpp
@@ -1,0 +1,207 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// MeasurementCoreSelfTest — proves the Audio Research Bench measurement core against
+// closed-form analytic expectations before any engine/DSP code is measured with it.
+//
+// Every expectation below is derived mathematically from the generator definition,
+// never from a recorded buffer. If a check fails, either the generator or the
+// measurement is wrong — both live in Tests/Research/.
+//
+// Doc: AestraDocs/audio-research-bench.md
+
+#include "AudioMeasure.h"
+#include "SignalLab.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AudioResearch;
+
+namespace {
+
+constexpr uint32_t kRate = 48000;
+constexpr uint32_t kFrames = 48000; // 1 s => integer cycle counts for all chosen tones
+
+void testSilence(CheckSession& t) {
+    std::printf("\n=== silence ===\n");
+    const Signal s = makeSilence(kRate, kFrames);
+    t.expectNear("silence peak == 0", peak(s), 0.0, 0.0);
+    t.expectNear("silence RMS == 0", rms(s), 0.0, 0.0);
+    t.expectNear("silence DC == 0", dcOffset(s), 0.0, 0.0);
+    t.expect("silence has no non-silent frame", firstNonSilentFrame(s) == -1);
+}
+
+void testDCAndStep(CheckSession& t) {
+    std::printf("\n=== DC / step ===\n");
+    const Signal dc = makeDC(kRate, kFrames, 0.25); // 0.25 is exactly representable in float
+    t.expectNear("DC offset == 0.25", dcOffset(dc), 0.25, 0.0);
+    t.expectNear("DC RMS == 0.25", rms(dc), 0.25, 0.0);
+    t.expectNear("DC peak == 0.25", peak(dc), 0.25, 0.0);
+
+    const Signal st = makeStep(kRate, kFrames, 24000, 0.75);
+    t.expectNear("step: pre-step DC == 0", dcOffset(st, -1, 0, 24000), 0.0, 0.0);
+    t.expectNear("step: post-step DC == level", dcOffset(st, -1, 24000, kFrames), 0.75, 0.0);
+    t.expect("step: first non-silent frame is the step", firstNonSilentFrame(st) == 24000);
+}
+
+void testSine(CheckSession& t) {
+    std::printf("\n=== sine (1 kHz, amp 0.5, integer cycles) ===\n");
+    const Signal s = makeSine(kRate, kFrames, 1000.0, 0.5);
+    // 48 samples/cycle; sample 12 sits exactly on the crest -> peak == amplitude.
+    t.expectNear("sine peak == amplitude", peak(s), 0.5, 1e-7);
+    t.expectNear("sine RMS == A/sqrt(2)", rms(s), 0.5 / std::sqrt(2.0), 1e-6);
+    t.expectNear("sine DC == 0", dcOffset(s), 0.0, 1e-7);
+
+    const ToneFit fit = fitTone(s, 0, 1000.0);
+    t.expectNear("fitTone recovers amplitude", fit.amplitude, 0.5, 1e-7);
+    t.expectNear("fitTone recovers DC", fit.dc, 0.0, 1e-7);
+    // Residual should be float-quantization noise only; ~152 dB in practice.
+    t.expect("fitTone residual SINAD > 120 dB (float quantization floor)", fit.sinadDb > 120.0,
+             "sinadDb=" + std::to_string(fit.sinadDb));
+    // Orthogonality: a tone probe at a different integer-cycle frequency sees ~nothing.
+    t.expectNear("off-frequency probe (3 kHz) sees no energy", toneAmplitude(s, 0, 3000.0), 0.0, 1e-6);
+
+    const Signal nyq = makeNearNyquistSine(kRate, kFrames, 0.5, 0.9); // 21.6 kHz, integer cycles
+    t.expectNear("near-Nyquist fitTone recovers amplitude", toneAmplitude(nyq, 0, 21600.0), 0.5, 1e-6);
+}
+
+void testDualTone(CheckSession& t) {
+    std::printf("\n=== dual tone (component separation) ===\n");
+    const Signal s = makeDualTone(kRate, kFrames, 1000.0, 0.4, 3000.0, 0.04);
+    t.expectNear("dual tone: f1 amplitude recovered", toneAmplitude(s, 0, 1000.0), 0.4, 1e-6);
+    t.expectNear("dual tone: f2 amplitude recovered", toneAmplitude(s, 0, 3000.0), 0.04, 1e-6);
+
+    // With f2 = 3*f1 the "harmonic distortion" is exactly a2/a1 = 0.1 (=-20 dB).
+    const HarmonicReport h = measureHarmonics(s, 0, 1000.0, 5);
+    t.expectNear("THD of synthetic 3rd harmonic == 0.1", h.thdRatio, 0.1, 1e-4);
+}
+
+void testSquareTHD(CheckSession& t) {
+    std::printf("\n=== square wave THD (discrete Fourier expectation) ===\n");
+    // Period 128 frames @48 kHz -> f0 = 375 Hz, 375 integer periods in the window.
+    // Discrete Fourier series of a 50%-duty square with period N=128 and amplitude A:
+    //   odd harmonic n has amplitude a_n = A / (32 * sin(pi*n/128))
+    // (derivation: geometric-sum DFT of the two half-period blocks), which converges to
+    // the continuous 4A/(pi*n) as N -> inf. Even harmonics are exactly zero.
+    constexpr double kAmp = 0.5;
+    constexpr uint32_t kPeriod = 128;
+    constexpr uint32_t kMaxHarmonic = 15;
+    const double f0 = static_cast<double>(kRate) / kPeriod; // 375 Hz
+    const Signal s = makeSquare(kRate, kFrames, kPeriod, kAmp);
+
+    auto discreteAmp = [&](uint32_t n) {
+        return kAmp / (32.0 * std::sin(kTau / 2.0 * static_cast<double>(n) / kPeriod));
+    };
+
+    const double a1 = discreteAmp(1);
+    t.expectNear("square fundamental amplitude matches DFT expectation", toneAmplitude(s, 0, f0), a1, 1e-6);
+
+    double expectedSumSq = 0.0;
+    for (uint32_t n = 3; n <= kMaxHarmonic; n += 2) {
+        expectedSumSq += discreteAmp(n) * discreteAmp(n);
+    }
+    const double expectedThd = std::sqrt(expectedSumSq) / a1;
+
+    const HarmonicReport h = measureHarmonics(s, 0, f0, kMaxHarmonic);
+    t.expect("square: all requested harmonics measured", h.harmonicsMeasured == kMaxHarmonic - 1,
+             "measured=" + std::to_string(h.harmonicsMeasured));
+    t.expectNear("square THD (harmonics 2..15) matches DFT expectation", h.thdRatio, expectedThd, 1e-4);
+    t.expectNear("square even harmonic (2nd) is zero", h.harmonicAmplitudes.empty() ? 1.0 : h.harmonicAmplitudes[0],
+                 0.0, 1e-6);
+}
+
+void testImpulse(CheckSession& t) {
+    std::printf("\n=== impulse ===\n");
+    const Signal s = makeImpulse(kRate, kFrames, 1000, 0.7);
+    const ImpulseReport r = analyzeImpulse(s, 0);
+    t.expect("impulse peak frame == 1000", r.peakFrame == 1000, "peakFrame=" + std::to_string(r.peakFrame));
+    t.expectNear("impulse peak value == 0.7", r.peakAbs, 0.7, 1e-7);
+    t.expect("impulse span is a single frame", r.spanFrames == 1, "spanFrames=" + std::to_string(r.spanFrames));
+    t.expectNear("impulse pre-span RMS == 0", r.preSpanRms, 0.0, 0.0);
+    t.expectNear("impulse tail RMS == 0", r.tailRms, 0.0, 0.0);
+}
+
+void testNoiseDeterminism(CheckSession& t) {
+    std::printf("\n=== fixed-seed noise ===\n");
+    const Signal a = makeNoise(kRate, kFrames, 42, 0.5);
+    const Signal b = makeNoise(kRate, kFrames, 42, 0.5);
+    const DiffReport d = diff(a, b);
+    t.expectNear("same seed -> bit-identical buffers", d.maxAbsError, 0.0, 0.0);
+    t.expect("noise peak <= amplitude", peak(a) <= 0.5, "peak=" + std::to_string(peak(a)));
+    // Uniform [-A, A): RMS -> A/sqrt(3); 48k samples make the estimate very tight.
+    t.expectNear("uniform noise RMS ~= A/sqrt(3)", rms(a), 0.5 / std::sqrt(3.0), 0.005);
+    t.expectNear("uniform noise DC ~= 0", dcOffset(a), 0.0, 0.005);
+
+    const Signal c = makeNoise(kRate, kFrames, 43, 0.5);
+    t.expect("different seed -> different buffer", diff(a, c).maxAbsError > 0.0);
+}
+
+void testStereoCorrelation(CheckSession& t) {
+    std::printf("\n=== stereo correlation / polarity ===\n");
+    const Signal inPhase = makeStereoCase(kRate, kFrames, StereoMode::InPhase);
+    const Signal inverted = makeStereoCase(kRate, kFrames, StereoMode::Inverted);
+    const Signal decorr = makeStereoCase(kRate, kFrames, StereoMode::Decorrelated);
+    t.expectNear("in-phase correlation == +1", stereoCorrelation(inPhase), 1.0, 1e-9);
+    t.expectNear("inverted correlation == -1", stereoCorrelation(inverted), -1.0, 1e-9);
+    t.expect("decorrelated |correlation| < 0.02", std::abs(stereoCorrelation(decorr)) < 0.02,
+             "corr=" + std::to_string(stereoCorrelation(decorr)));
+    t.expectNear("silence correlation defined as 0", stereoCorrelation(makeSilence(kRate, 1024)), 0.0, 0.0);
+}
+
+void testDiffForensics(CheckSession& t) {
+    std::printf("\n=== diff / first-mismatch forensics ===\n");
+    const Signal ref = makeSine(kRate, kFrames, 1000.0, 0.5);
+    Signal corrupted = ref;
+    corrupted.at(123, 1) += 0.01f;
+
+    const DiffReport d = diff(corrupted, ref, 1e-6);
+    t.expect("first mismatch frame located", d.firstMismatchFrame == 123,
+             "frame=" + std::to_string(d.firstMismatchFrame));
+    t.expect("first mismatch channel located", d.firstMismatchChannel == 1,
+             "channel=" + std::to_string(d.firstMismatchChannel));
+    t.expectNear("max abs error == injected corruption", d.maxAbsError, 0.01, 1e-6);
+    t.expect("no length mismatch flagged", !d.lengthMismatch);
+
+    // Demonstrate the forensic dump once so its format is visible in test logs.
+    printDiffForensics("intentional demo (not a failure)", d, corrupted, ref);
+
+    Signal shorter = ref;
+    shorter.samples.resize(shorter.samples.size() - 2);
+    t.expect("length mismatch flagged", diff(shorter, ref).lengthMismatch);
+}
+
+void testSweepAndBurst(CheckSession& t) {
+    std::printf("\n=== sweep / transient burst ===\n");
+    const Signal sweep = makeLinearSweep(kRate, kFrames, 20.0, 20000.0, 0.5);
+    // A constant-amplitude chirp has sine statistics over long windows.
+    t.expectNear("sweep RMS ~= A/sqrt(2)", rms(sweep), 0.5 / std::sqrt(2.0), 0.01);
+    t.expect("sweep peak <= amplitude", peak(sweep) <= 0.5 + 1e-7, "peak=" + std::to_string(peak(sweep)));
+
+    const Signal burst = makeTransientBurst(kRate, kFrames, 8000, 4800, 1000.0, 0.5);
+    t.expectNear("burst: leading silence is silent", rms(burst, -1, 0, 8000), 0.0, 0.0);
+    t.expectNear("burst: trailing silence is silent", rms(burst, -1, 8000 + 4800, kFrames), 0.0, 0.0);
+    const int64_t first = firstNonSilentFrame(burst);
+    t.expect("burst: first energy at burst start (+1 for sin(0)=0)", first == 8001,
+             "firstNonSilentFrame=" + std::to_string(first));
+    t.expectNear("burst: body RMS ~= A/sqrt(2)", rms(burst, -1, 8000, 8000 + 4800), 0.5 / std::sqrt(2.0), 1e-3);
+}
+
+} // namespace
+
+int main() {
+    std::printf("============================================================\n");
+    std::printf("  Aestra Audio Research Bench — Measurement Core Self-Test\n");
+    std::printf("============================================================\n");
+
+    CheckSession t;
+    testSilence(t);
+    testDCAndStep(t);
+    testSine(t);
+    testDualTone(t);
+    testSquareTHD(t);
+    testImpulse(t);
+    testNoiseDeterminism(t);
+    testStereoCorrelation(t);
+    testDiffForensics(t);
+    testSweepAndBurst(t);
+    return t.exitCode();
+}

--- a/Tests/Research/SignalLab.h
+++ b/Tests/Research/SignalLab.h
@@ -1,0 +1,243 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// SignalLab — deterministic test-signal generators for the Aestra Audio Research Bench.
+//
+// Design rules:
+//   * Every generator is fully deterministic: same arguments -> bit-identical buffer,
+//     on every platform. Noise uses a fixed-seed xorshift64* generator, never <random>
+//     distributions (their output is implementation-defined).
+//   * Expectations stay analytic: signals are simple closed forms so tests can compute
+//     the expected peak/RMS/DC/harmonic content instead of storing binary fixtures.
+//   * Test-side only. This header must never be included from production code.
+//
+// Doc: AestraDocs/audio-research-bench.md
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace AudioResearch {
+
+constexpr double kTau = 6.28318530717958647692;
+
+/// Interleaved deterministic test buffer. Channel-major sample layout matches the
+/// engine convention (frame-interleaved).
+struct Signal {
+    std::vector<float> samples; // interleaved
+    uint32_t channels{2};
+    uint32_t sampleRate{48000};
+
+    uint32_t frames() const { return channels > 0 ? static_cast<uint32_t>(samples.size() / channels) : 0; }
+
+    float at(uint32_t frame, uint32_t channel) const {
+        return samples[(static_cast<size_t>(frame) * channels) + channel];
+    }
+    float& at(uint32_t frame, uint32_t channel) {
+        return samples[(static_cast<size_t>(frame) * channels) + channel];
+    }
+};
+
+inline Signal makeSilence(uint32_t sampleRate, uint32_t frames, uint32_t channels = 2) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.assign(static_cast<size_t>(frames) * channels, 0.0f);
+    return s;
+}
+
+/// Single-sample unit impulse (Kronecker delta) at `position`, all channels.
+inline Signal makeImpulse(uint32_t sampleRate, uint32_t frames, uint32_t position, double amplitude = 1.0,
+                          uint32_t channels = 2) {
+    Signal s = makeSilence(sampleRate, frames, channels);
+    if (position < frames) {
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(position, ch) = static_cast<float>(amplitude);
+        }
+    }
+    return s;
+}
+
+/// 0 -> `level` step at frame `stepAt` (inclusive), all channels.
+inline Signal makeStep(uint32_t sampleRate, uint32_t frames, uint32_t stepAt, double level = 1.0,
+                       uint32_t channels = 2) {
+    Signal s = makeSilence(sampleRate, frames, channels);
+    for (uint32_t i = stepAt; i < frames; ++i) {
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(level);
+        }
+    }
+    return s;
+}
+
+/// Constant DC at `level`, all channels.
+inline Signal makeDC(uint32_t sampleRate, uint32_t frames, double level, uint32_t channels = 2) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.assign(static_cast<size_t>(frames) * channels, static_cast<float>(level));
+    return s;
+}
+
+/// Sine at `freqHz`, identical on all channels. Phase in radians.
+inline Signal makeSine(uint32_t sampleRate, uint32_t frames, double freqHz, double amplitude = 0.5,
+                       uint32_t channels = 2, double phaseRad = 0.0) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.resize(static_cast<size_t>(frames) * channels);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double v = amplitude * std::sin((kTau * freqHz * static_cast<double>(i) / sampleRate) + phaseRad);
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(v);
+        }
+    }
+    return s;
+}
+
+/// Sine at `fraction` of Nyquist (default 0.9 -> e.g. 21.6 kHz at 48 kHz).
+inline Signal makeNearNyquistSine(uint32_t sampleRate, uint32_t frames, double amplitude = 0.5,
+                                  double fractionOfNyquist = 0.9, uint32_t channels = 2) {
+    const double freq = fractionOfNyquist * 0.5 * static_cast<double>(sampleRate);
+    return makeSine(sampleRate, frames, freq, amplitude, channels);
+}
+
+/// Linear chirp from `f0Hz` to `f1Hz` over the buffer. Instantaneous phase is the
+/// integral of the linear frequency ramp: phi(t) = tau * (f0*t + (f1-f0)*t^2 / (2*T)).
+inline Signal makeLinearSweep(uint32_t sampleRate, uint32_t frames, double f0Hz, double f1Hz,
+                              double amplitude = 0.5, uint32_t channels = 2) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.resize(static_cast<size_t>(frames) * channels);
+    const double totalSeconds = static_cast<double>(frames) / sampleRate;
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        const double phase = kTau * ((f0Hz * t) + ((f1Hz - f0Hz) * t * t / (2.0 * totalSeconds)));
+        const double v = amplitude * std::sin(phase);
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(v);
+        }
+    }
+    return s;
+}
+
+/// Two simultaneous sines (classic IMD / component-separation stimulus).
+inline Signal makeDualTone(uint32_t sampleRate, uint32_t frames, double f1Hz, double a1, double f2Hz, double a2,
+                           uint32_t channels = 2) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.resize(static_cast<size_t>(frames) * channels);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        const double v = (a1 * std::sin(kTau * f1Hz * t)) + (a2 * std::sin(kTau * f2Hz * t));
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(v);
+        }
+    }
+    return s;
+}
+
+/// Ideal (non-band-limited) square wave built by sample index, +A for the first half
+/// of each period. `periodFrames` must be even so the duty cycle is exactly 50%.
+/// NOTE: deliberately aliased — this is a harmonic-rich torture signal whose
+/// low-order odd-harmonic amplitudes follow ~ (4A/pi) * 1/n; tests that assert THD
+/// must state which harmonics they count.
+inline Signal makeSquare(uint32_t sampleRate, uint32_t frames, uint32_t periodFrames, double amplitude = 0.5,
+                         uint32_t channels = 2) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.resize(static_cast<size_t>(frames) * channels);
+    const uint32_t half = periodFrames / 2;
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double v = ((i % periodFrames) < half) ? amplitude : -amplitude;
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(v);
+        }
+    }
+    return s;
+}
+
+/// Deterministic xorshift64* PRNG (public-domain construction; stable across platforms).
+struct DeterministicRng {
+    uint64_t state;
+    explicit DeterministicRng(uint64_t seed) : state(seed ? seed : 0x9E3779B97F4A7C15ull) {}
+
+    uint64_t next() {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        return state * 0x2545F4914F6CDD1Dull;
+    }
+
+    /// Uniform double in [-1, 1).
+    double nextBipolar() {
+        return static_cast<double>(next() >> 11) * (2.0 / 9007199254740992.0) - 1.0;
+    }
+};
+
+/// Fixed-seed uniform white noise in [-amplitude, amplitude).
+/// `independentChannels`=false writes the same sequence to every channel (correlation +1);
+/// true draws each channel independently (correlation ~ 0).
+inline Signal makeNoise(uint32_t sampleRate, uint32_t frames, uint64_t seed, double amplitude = 0.5,
+                        uint32_t channels = 2, bool independentChannels = false) {
+    Signal s;
+    s.sampleRate = sampleRate;
+    s.channels = channels;
+    s.samples.resize(static_cast<size_t>(frames) * channels);
+    DeterministicRng rng(seed);
+    for (uint32_t i = 0; i < frames; ++i) {
+        if (independentChannels) {
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                s.at(i, ch) = static_cast<float>(amplitude * rng.nextBipolar());
+            }
+        } else {
+            const float v = static_cast<float>(amplitude * rng.nextBipolar());
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                s.at(i, ch) = v;
+            }
+        }
+    }
+    return s;
+}
+
+/// Rectangular-gated sine burst: silence, then `burstFrames` of sine, then silence.
+/// Hard edges are intentional — this is the transient-smear stimulus.
+inline Signal makeTransientBurst(uint32_t sampleRate, uint32_t frames, uint32_t burstStart, uint32_t burstFrames,
+                                 double freqHz, double amplitude = 0.5, uint32_t channels = 2) {
+    Signal s = makeSilence(sampleRate, frames, channels);
+    const uint32_t end = std::min(frames, burstStart + burstFrames);
+    for (uint32_t i = burstStart; i < end; ++i) {
+        const double t = static_cast<double>(i - burstStart) / sampleRate;
+        const double v = amplitude * std::sin(kTau * freqHz * t);
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            s.at(i, ch) = static_cast<float>(v);
+        }
+    }
+    return s;
+}
+
+enum class StereoMode {
+    InPhase,      // R = L            (correlation +1)
+    Inverted,     // R = -L           (correlation -1)
+    Decorrelated  // independent noise (correlation ~ 0)
+};
+
+/// Stereo correlation/polarity stimulus. InPhase/Inverted use a sine; Decorrelated
+/// uses independent fixed-seed noise per channel.
+inline Signal makeStereoCase(uint32_t sampleRate, uint32_t frames, StereoMode mode, double freqHz = 997.0,
+                             double amplitude = 0.5, uint64_t seed = 0xA35712345678ull) {
+    if (mode == StereoMode::Decorrelated) {
+        return makeNoise(sampleRate, frames, seed, amplitude, 2, /*independentChannels=*/true);
+    }
+    Signal s = makeSine(sampleRate, frames, freqHz, amplitude, 2);
+    if (mode == StereoMode::Inverted) {
+        for (uint32_t i = 0; i < s.frames(); ++i) {
+            s.at(i, 1) = -s.at(i, 1);
+        }
+    }
+    return s;
+}
+
+} // namespace AudioResearch

--- a/Tests/Research/SignalLab.h
+++ b/Tests/Research/SignalLab.h
@@ -12,6 +12,7 @@
 // Doc: AestraDocs/audio-research-bench.md
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <vector>
@@ -29,10 +30,14 @@ struct Signal {
 
     uint32_t frames() const { return channels > 0 ? static_cast<uint32_t>(samples.size() / channels) : 0; }
 
+    // Tests build with -UNDEBUG (Tests/CMakeLists.txt), so these asserts stay live
+    // in every test configuration and catch out-of-range access at the source.
     float at(uint32_t frame, uint32_t channel) const {
+        assert(channel < channels && frame < frames());
         return samples[(static_cast<size_t>(frame) * channels) + channel];
     }
     float& at(uint32_t frame, uint32_t channel) {
+        assert(channel < channels && frame < frames());
         return samples[(static_cast<size_t>(frame) * channels) + channel];
     }
 };


### PR DESCRIPTION
## Summary

First slice of the **Aestra Audio Research Bench**: a reusable, test-side scientific audio measurement layer under `Tests/Research/`, proven against closed-form analytic expectations before it is allowed to measure any engine/DSP code. No production code is touched; nothing runs on the audio callback path.

- `SignalLab.h` — deterministic generators: silence, impulse, step, DC, sine, near-Nyquist sine, linear sweep, dual tone, square, fixed-seed xorshift64* noise, transient burst, stereo polarity cases. Same arguments → bit-identical buffers on every platform.
- `AudioMeasure.h` — peak, RMS, DC offset, null-diff with forensic first-mismatch report (rate/channels/frames/peaks/RMS/max error + expected/actual snippet), known-frequency least-squares tone fit with a full-band residual SINAD-style figure, per-harmonic THD (below-Nyquist only), impulse stats (peak position, span, pre-ring, tail), stereo correlation.
- `MeasurementCoreSelfTest.cpp` — 50 checks, every expectation derived mathematically (square-wave THD vs the discrete Fourier series `a_n = A/(32·sin(πn/128))`, sine RMS = A/√2, float-quantization SINAD floor measured at 154.9 dB, etc.).

## Why

Aestra has integrity tests (bit-exactness, parity, RT safety) but no *quantitative* audio-quality measurement infrastructure — each existing test reimplements its own RMS/sine-fit helpers. This layer is the foundation for the resampler audit stacked on top (#next) and future DSP quality work.

## Honest-limits note

THD+N/SINAD is implemented as a least-squares tone-removal residual (full-band, single-tone stimuli) and documented as such in-code — it is deliberately **not** claimed to be a spectrum-analyzer SINAD.

## Testing performed

- `ctest -R MeasurementCoreSelfTest` — 50/50 pass in 0.13 s (Release, Linux, build-linux).
- `ctest -L integrity` — 5/5 pass (no impact on existing suites).
- Labels: `research;audio-research`.

## Docs updated?

Research doc `AestraDocs/audio-research-bench.md` lands in the stacked PR together with the measured results it cites.

## Risk / rollback

Test-side only (new files + one additive CMake block). Rollback = revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a new test-only “Audio Research Bench” under `Tests/Research/`, including a CMake target and CTest registration for `MeasurementCoreSelfTest` with research/audio labels and a timeout.
- Introduced `SignalLab.h`, a deterministic signal-generator layer for reusable test stimuli: silence, impulse, step, DC, sine, near-Nyquist sine, sweeps, dual tones, square waves, fixed-seed noise, transient bursts, and stereo cases.
- Added `AudioMeasure.h`, a reusable measurement layer for peak/RMS/DC checks, silence detection, diff forensics, tone fitting, harmonic/THD analysis, impulse characterization, stereo correlation, and a small test assertion harness.
- Added `MeasurementCoreSelfTest.cpp`, 50 analytic self-checks that validate the measurement helpers against closed-form expectations across waveforms, noise, stereo behavior, and diff reporting.
- Documented the measurement scope as test-side only; no production/audio-callback code was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->