### PR TITLE
fix(audio): unify isolated-track bounce resampling with mainline (Phase 2E)

### DIFF
--- a/AestraAudio/include/DSP/Interpolators.h
+++ b/AestraAudio/include/DSP/Interpolators.h
@@ -39,11 +39,12 @@ namespace Audio {
  *   dispatch quality Sinc64 to the legacy exact-sinc Sinc64Interpolator and
  *   measured ~146-154 dB full-band single-tone residual SINAD at 1 kHz in
  *   full-session tests (SessionResamplingTruthTest).
- * - Sinc64Turbo consumers (isolated-track bounce via AudioRenderer,
- *   SamplerPlugin, AuditionEngine/ClipResampler) measured ~88 dB at
- *   FRACTIONAL rate ratios (bounded by nearest-phase LUT quantization, not
- *   the kernel) and ~154 dB at exact 2:1. Phase 1's ~88 dB figure describes
- *   these paths only, not Aestra resampling globally.
+ * - Sinc64Turbo consumers (SamplerPlugin, AuditionEngine/ClipResampler)
+ *   measured ~88 dB at FRACTIONAL rate ratios (bounded by nearest-phase LUT
+ *   quantization, not the kernel) and ~154 dB at exact 2:1. Phase 1's ~88 dB
+ *   figure describes these paths only, not Aestra resampling globally.
+ *   (Isolated-track bounce was in this class until Phase 2E unified its
+ *   kernel table with renderGraph's — it now measures mainline-equivalent.)
  * ALL of these kernels reconstruct at the SOURCE Nyquist: on every measured
  * path, downsampling is not anti-aliased by a ratio-aware low-pass, so
  * content between the output and source Nyquist frequencies folds back into
@@ -873,10 +874,11 @@ struct Sinc64Interpolator {
 
 // SNR figures below are kernel design targets; measured delivered behavior is
 // documented in AestraDocs/audio-research-bench.md and is path-specific:
-// quality Sinc64 measures ~146-154 dB SINAD through mainline playback/full-mix
-// export (renderGraph -> legacy exact-sinc Sinc64Interpolator) but ~88 dB at
-// fractional ratios through the Sinc64Turbo paths (isolated-track bounce,
-// sampler, audition). No path anti-aliases downsampling.
+// quality Sinc64 measures ~146-154 dB SINAD through mainline playback and both
+// export flavors (renderGraph/AudioRenderer -> legacy exact-sinc
+// Sinc64Interpolator, unified in Phase 2E) but ~88 dB at fractional ratios
+// through the Sinc64Turbo paths (sampler, audition). No path anti-aliases
+// downsampling.
 enum class InterpolationQuality {
     Cubic,  // 4-point, ~80dB target, lowest CPU
     Sinc8,  // 8-point Blackman, ~100dB target

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -244,7 +244,15 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
             }
         } else {
             using InterpFn = void (*)(const float*, int64_t, double, float&, float&);
-            InterpFn interpolateFunc = Interpolators::Sinc64Turbo::interpolate;
+            // Kernel table matches AudioEngine::renderGraph's clip loop exactly, so an
+            // isolated-track bounce (this renderer's only caller, via bounceRangeToWav
+            // trackId >= 0) resamples identically to mainline playback/full-mix export.
+            // Sinc32/Sinc64 previously dispatched to the Turbo LUT kernels here, giving
+            // solo bounces a measurably lower quality floor than the full mix (~88 dB vs
+            // ~147 dB SINAD at fractional ratios) — resolved F6, measured by
+            // SessionResamplingTruthTest; see AestraDocs/audio-research-bench.md §8.
+            // This path runs offline only, so the slower exact-sinc kernels are fine.
+            InterpFn interpolateFunc = Interpolators::Sinc64Interpolator::interpolate;
             switch (cachedInterpQuality) {
             case Interpolators::InterpolationQuality::Cubic:
                 interpolateFunc = Interpolators::CubicInterpolator::interpolate;
@@ -256,15 +264,15 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
                 interpolateFunc = Interpolators::Sinc16Interpolator::interpolate;
                 break;
             case Interpolators::InterpolationQuality::Sinc32:
-                interpolateFunc = Interpolators::Sinc32Turbo::interpolate;
+                interpolateFunc = Interpolators::Sinc32Interpolator::interpolate;
                 break;
             case Interpolators::InterpolationQuality::Sinc64:
-                interpolateFunc = Interpolators::Sinc64Turbo::interpolate;
+                interpolateFunc = Interpolators::Sinc64Interpolator::interpolate;
                 break;
             default: {
                 static_assert(static_cast<int>(Interpolators::InterpolationQuality::Sinc64) == 4,
                               "All InterpolationQuality values must be handled above");
-                interpolateFunc = Interpolators::Sinc64Turbo::interpolate;
+                interpolateFunc = Interpolators::Sinc64Interpolator::interpolate;
                 break;
             }
             }

--- a/AestraDocs/audio-research-bench.md
+++ b/AestraDocs/audio-research-bench.md
@@ -2,7 +2,8 @@
 
 Status: Phase 1 complete (2026-07-07). Phase 2D (full-session engine truth) complete
 (2026-07-07) — see §8, which **corrects the scope of F2**: mainline session playback
-does not use Sinc64Turbo at all.
+does not use Sinc64Turbo at all. Phase 2E complete (2026-07-07): isolated-track
+bounce kernel unified with mainline (**F6 resolved**, §8.3).
 Code: `Tests/Research/` (`SignalLab.h`, `AudioMeasure.h`, `MeasurementCoreSelfTest.cpp`,
 `ResamplerQualityAuditTest.cpp`, `SessionResamplingTruthTest.cpp`). CTest labels:
 `research`, `audio-research`.
@@ -155,9 +156,10 @@ comment overstates it; phase-error-induced residual also grows with signal frequ
 (not yet swept — see blind spots).
 **Phase 2D scope correction (F5, §8): this floor does NOT apply to mainline session
 playback or full-mix export**, which use the legacy exact-sinc kernel and measured
-146.5–153.9 dB through the whole engine. It DOES apply to the Sinc64Turbo consumers:
-the isolated-track bounce (measured 87.8 dB end-to-end, F6), the sampler (84.2 dB
-measured, §8.4), and AuditionEngine.
+146.5–153.9 dB through the whole engine. It DOES apply to the remaining Sinc64Turbo
+consumers: the sampler (84.2 dB measured, §8.4) and AuditionEngine. (It also applied
+to the isolated-track bounce — measured 87.8 dB end-to-end — until Phase 2E unified
+that path's kernel with mainline; F6, resolved.)
 
 **F3 — Streaming `SampleRateConverter` delivers only ~40–44 dB SINAD at fractional
 ratios** (39.7–44.3 dB measured; 127–142 dB at integer ratios), far below the
@@ -259,9 +261,9 @@ Cannot claim (and must not, until measured otherwise):
    error grows with frequency, so quantify SINAD vs frequency (100 Hz–20 kHz), not
    just at 1 kHz — this decides whether ~88 dB @1 kHz is ~68 dB @10 kHz.
 3. ~~**Engine-level resampling truth**~~ — **done** (Phase 2D, §8), and it changed the
-   picture: see F5/F6. New follow-ups it produced: unify the isolated-bounce kernel
-   (§8.5), and a wording pass on `Interpolators.h`/`ClipResampler.h`/
-   `SINC64_TURBO_PAPER.md` to path-scope the Phase-1 "~88 dB delivered" qualification.
+   picture: see F5/F6. Its follow-ups are also done: the isolated-bounce kernel is
+   unified (Phase 2E, F6 resolved) and the "~88 dB delivered" qualification is
+   path-scoped in `Interpolators.h`/`ClipResampler.h`/`SINC64_TURBO_PAPER.md`.
 4. **Downsampling anti-alias policy**: cost out a ratio-aware pre-filter for clip
    playback at non-1:1 rates (product decision informed by F1's numbers; see §8.5 for
    the post-Phase-2D framing).
@@ -289,7 +291,7 @@ by the test.
 | --- | --- | --- |
 | Realtime playback of a mismatched-rate clip | `processBlock` → `renderGraph` inline clip loop (AudioEngine.cpp:2066–2348) | **legacy `Sinc64Interpolator`** (exact double-precision Kaiser sinc, no LUT) |
 | Full-mix export / bounce (`trackId = -1`) | `bounceRangeToWav` → `AudioExporter` → same `processBlock`/`renderGraph` | **legacy `Sinc64Interpolator`** |
-| Isolated-track bounce (`trackId ≥ 0`) | `bounceRangeToWav` internal loop (AudioEngine.cpp:3102+) → `AudioRenderer::renderClipAudio` | **`Sinc64Turbo`** (2048-phase LUT) |
+| Isolated-track bounce (`trackId ≥ 0`) | `bounceRangeToWav` internal loop (AudioEngine.cpp:3102+) → `AudioRenderer::renderClipAudio` | ~~`Sinc64Turbo`~~ → **legacy `Sinc64Interpolator`** since Phase 2E (kernel table unified with renderGraph) |
 | File-browser preview | `PreviewEngine::processRealtime` (own per-voice loop, PreviewEngine.cpp:285+) | **own Cubic Hermite** — ignores the quality setting |
 | Sampler note playback (pitch ≠ root) | `SamplerPlugin::process` (SamplerPlugin.cpp:402) | **`Sinc64Turbo`** (hardcoded) |
 | Clip audition | `AuditionEngine` (AuditionEngine.cpp:497) | **`Sinc64Turbo`** (not separately measured at session level) |
@@ -330,18 +332,21 @@ mainline playback does not run — a wording follow-up is needed there and in
 `Interpolators.h`/`ClipResampler.h`, whose Phase-1 qualification ("delivered ~88 dB")
 is now known to be path-specific, not global.
 
-**F6 — Isolated-track bounce resamples with a different kernel than playback and
-full-mix export (KNOWN INCONSISTENCY, defect-class).** `bounceRangeToWav(trackId ≥ 0)`
-renders through `AudioRenderer::renderClipAudio` → `Sinc64Turbo`: measured 87.8 dB
-SINAD end-to-end vs 149.3 dB for the same 44.1k clip through the full-mix path — a
-61.5 dB quality split between two export flavors of identical content. Level and
-timing are unaffected (bounce is level-true to <0.001 dB). Both kernels are ≥16-bit
-clean, so this is inaudible for typical material, but it breaks the "offline export
-stays behaviorally aligned with live rendering" contract (AGENTS §20) in a measurable
-way. Pinned by a characterization gate that fails when the kernels are unified, so
-unification is a deliberate test-updating decision. Recommended direction: make the
-isolated bounce use the same renderGraph kernel (or unify both on one kernel after a
-CPU-budget decision).
+**F6 — RESOLVED (Phase 2E, 2026-07-07): isolated-track bounce resampled with a
+different kernel than playback and full-mix export.** As found in Phase 2D:
+`bounceRangeToWav(trackId ≥ 0)` rendered through `AudioRenderer::renderClipAudio` →
+`Sinc64Turbo`, measuring 87.8 dB SINAD end-to-end vs 149.3 dB for the same 44.1k clip
+through the full-mix path — a 61.5 dB quality split between two export flavors of
+identical content (level and timing were unaffected). **Fix:** Phase 2E replaced
+`renderClipAudio`'s Sinc32/Sinc64 dispatch rows (Turbo → legacy
+`Sinc32Interpolator`/`Sinc64Interpolator`), making its kernel table identical to
+`renderGraph`'s. The path is offline-only (single call site: the isolated-bounce loop
+in `bounceRangeToWav`), so the slower exact-sinc kernels carry no realtime cost.
+**Measured after:** isolated bounce 149.3 dB SINAD (was 87.8), agreeing with the
+full-mix path to 0.02 dB, level-true to <0.001 dB, and the bounced file **nulls
+against the full-mix realtime render at −176.0 dB RMS (maxErr 3e-8)**. The former
+KNOWN INCONSISTENCY characterization gate is replaced by unification gates (SINAD
+>140 dB, SINAD agreement ±3 dB, null ≤ −120 dB).
 
 **F7 — The file-browser preview has its own Cubic resampler and ignores the
 Resampling quality setting.** Measured through `PreviewEngine::processRealtime`:
@@ -367,9 +372,9 @@ content is a known sampler tradeoff; documented, not endorsed).
   Nyquist: 44.1k content above ~20.1 kHz images at up to −21.7 dBc (F4), and
   downsampled content between the Nyquists aliases at full level (F1: 48k-in-44.1k,
   96k-in-48k).
-* **Bouncing a soloed track:** quality silently drops to the Turbo 88 dB floor (F6) —
-  the only path where Phase 1's F2 number is what a user's rendered file actually
-  contains.
+* **Bouncing a soloed track:** since Phase 2E, identical to the full mix (nulls at
+  −176 dB; previously the one path where Phase 1's ~88 dB Turbo floor reached a
+  user's rendered file — F6, resolved).
 * **Previewing files in the browser:** Cubic tier regardless of settings (F7); 96k
   files preview with audible-in-principle aliasing of >24 kHz content.
 * **Pitching samples down** in the sampler: Turbo-class (fine). **Pitching
@@ -380,8 +385,8 @@ content is a known sampler tradeoff; documented, not endorsed).
 The engine-level numbers reframe Phase-2 target #4: mainline fractional-ratio SINAD is
 not the problem (147+ dB); the two real quality boundaries are **downsampling aliasing
 (F1)** — unchanged, present on every measured path — and **path inconsistency (F6/F7)**.
-Suggested order: (1) unify the isolated-bounce kernel with mainline (small, no product
-tradeoff, removes F6); (2) decide the ratio-aware low-pass policy for downsampling
+Suggested order: (1) ~~unify the isolated-bounce kernel with mainline~~ — **done**
+(Phase 2E, F6 resolved); (2) decide the ratio-aware low-pass policy for downsampling
 clips (F1) with the legacy kernel as the baseline — a polyphase pre-filter or
 kernel-cutoff scaling both fit the existing per-voice loop, but the CPU cost on the
 audio thread is the open product question; (3) fold the preview/sampler paths into

--- a/Tests/Research/ResamplerQualityAuditTest.cpp
+++ b/Tests/Research/ResamplerQualityAuditTest.cpp
@@ -4,12 +4,12 @@
 // Two distinct resampling engines exist in AestraAudio and this test measures BOTH:
 //
 //   1. The PRODUCTION clip-playback path: the Interpolators family (Cubic /
-//      Sinc64Turbo, etc.) driven by a `phase += ratio` accumulator. This is what
-//      AudioRenderer.cpp (isolated-track bounce), AuditionEngine.cpp and
-//      SamplerPlugin.cpp actually run. (Phase 2D correction: the MAINLINE session
-//      clip loop in AudioEngine::renderGraph dispatches Sinc64 to the legacy
-//      exact-sinc Sinc64Interpolator instead — measured end-to-end by
-//      SessionResamplingTruthTest; see AestraDocs/audio-research-bench.md §8.)
+//      Sinc64Turbo, etc.) driven by a `phase += ratio` accumulator. Sinc64Turbo is
+//      what AuditionEngine.cpp and SamplerPlugin.cpp actually run. (Phases 2D/2E:
+//      the MAINLINE session clip loop in AudioEngine::renderGraph — and, since the
+//      2E unification, AudioRenderer's isolated-bounce loop — dispatch Sinc64 to
+//      the legacy exact-sinc Sinc64Interpolator instead; measured end-to-end by
+//      SessionResamplingTruthTest, see AestraDocs/audio-research-bench.md §8.)
 //      The kernel cutoff sits at the SOURCE Nyquist and there is no
 //      ratio-aware anti-alias filtering: when downsampling, content between the two
 //      Nyquist frequencies is EXPECTED to alias. The audit pins that behavior as a

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -19,9 +19,9 @@
 //      written as Float_32. Same legacy kernel; proven sample-identical to realtime.
 //   3. Offline ISOLATED-TRACK bounce: bounceRangeToWav(trackId>=0) takes a different
 //      loop (AudioEngine.cpp:3102+) through AudioRenderer::renderClipAudio
-//      (AudioRenderer.cpp:246-320), which dispatches Sinc64 -> Sinc64Turbo — the LUT
-//      kernel Phase 1 measured. KNOWN INCONSISTENCY pinned by this test: soloing a
-//      track for bounce resamples with a different kernel than playing/exporting it.
+//      (AudioRenderer.cpp:246+). Phase 2D found it dispatching Sinc64 -> Sinc64Turbo
+//      (~88 dB floor) — finding F6; Phase 2E unified its kernel table with
+//      renderGraph's, and this test now proves solo bounces match the full mix.
 //   4. Preview: PreviewEngine::processRealtime — its OWN resampler (per-voice
 //      `phase += ratio` with a Cubic Hermite kernel, PreviewEngine.cpp:285+), NOT the
 //      Interpolators dispatch and NOT affected by the user's quality setting.
@@ -517,17 +517,17 @@ void runImpulseCases(AR::CheckSession& t) {
 }
 
 // =============================================================================
-// Case 3b: isolated-track bounce — the OTHER offline path and the OTHER kernel
+// Case 3b: isolated-track bounce — the OTHER offline path, now kernel-unified
 // =============================================================================
 
-// bounceRangeToWav(trackId >= 0) renders through AudioRenderer::renderClipAudio,
-// which dispatches Sinc64 -> Sinc64Turbo (AudioRenderer.cpp:261) — not the legacy
-// exact-sinc kernel the full mix uses. This case pins that KNOWN INCONSISTENCY:
-// the same clip bounced solo carries the Turbo LUT floor (~88 dB) instead of the
-// mainline ~147 dB, i.e. two export flavors differ in resampling quality. If the
-// kernels are intentionally unified later, update this case + the research doc.
+// bounceRangeToWav(trackId >= 0) renders through AudioRenderer::renderClipAudio.
+// Phase 2D found it dispatching Sinc64 -> Sinc64Turbo (measured 87.8 dB SINAD)
+// while the full mix used the legacy exact-sinc kernel (149.3 dB) — finding F6.
+// Phase 2E unified the dispatch table with renderGraph's, so this case now PROVES
+// the unification: a solo bounce must match the full-mix render of the same
+// single-track session at mainline quality.
 void runIsolatedBounceCase(AR::CheckSession& t, const fs::path& tempRoot) {
-    std::printf("\n--- isolated-track bounce (trackId>=0): the AudioRenderer/Sinc64Turbo path ---\n");
+    std::printf("\n--- isolated-track bounce (trackId>=0): AudioRenderer path, kernel-unified (2E) ---\n");
     GA::SessionConfig cfg;
     cfg.sampleRate = 48000;
     const uint32_t srcRate = 44100;
@@ -568,22 +568,31 @@ void runIsolatedBounceCase(AR::CheckSession& t, const fs::path& tempRoot) {
     const AR::ToneFit fullFit = AR::fitTone(fullMix, 0, kToneHz, kWinSkip, winEnd);
 
     std::printf("[MEASURE] isolated bounce 44.1->48 1 kHz sinad=%.1f dB vs full-mix path %.1f dB "
-                "(kernel split: Sinc64Turbo vs legacy Sinc64Interpolator)\n",
+                "(unified legacy Sinc64Interpolator; pre-2E bounce measured 87.8 dB)\n",
                 fit.sinadDb, fullFit.sinadDb);
     t.expect("isolated bounce: output is present and level-true (fit amplitude)",
              std::abs(AR::toDb(fit.amplitude / (kAmp * PanLaw::kEqualPowerCenterGain))) < 0.1,
              "ampDb=" + std::to_string(AR::toDb(fit.amplitude / (kAmp * PanLaw::kEqualPowerCenterGain))));
-    // Turbo-class floor (Phase-1 isolated: 87.8-89.9 dB at fractional ratios).
-    // One-sided regression gate; a future kernel unification (improvement) passes.
-    t.expect("isolated bounce: 1 kHz residual SINAD > 84 dB", fit.sinadDb > 84.0,
+    // UNIFIED (Phase 2E): the bounce must deliver mainline-class quality, not the
+    // pre-unification Turbo floor (was 87.8 dB; mainline measured 146.5-153.9 dB).
+    t.expect("isolated bounce: 1 kHz residual SINAD > 140 dB (mainline kernel)", fit.sinadDb > 140.0,
              "sinadDb=" + std::to_string(fit.sinadDb));
-    // KNOWN INCONSISTENCY characterization: today the two offline flavors measurably
-    // differ. This check documents the split; it fails when the kernels are unified,
-    // which is the signal to update this test + AestraDocs/audio-research-bench.md.
-    t.expect("isolated bounce: KNOWN INCONSISTENCY - solo bounce uses the lower-floor Turbo kernel",
-             fit.sinadDb < fullFit.sinadDb - 20.0,
-             "bounceSinad=" + std::to_string(fit.sinadDb) +
-                 " fullMixSinad=" + std::to_string(fullFit.sinadDb));
+    // Agreement with the full-mix path for the same single-track session.
+    t.expectNear("isolated bounce: SINAD agrees with full-mix path (dB)", fit.sinadDb, fullFit.sinadDb,
+                 3.0);
+    // Strongest form: the bounced file nulls against the full-mix realtime render on
+    // the interior window (same clip, same kernel, same gain staging).
+    const AR::Signal bWin = window(bounced, kWinSkip, winEnd);
+    const AR::Signal fWin = window(fullMix, kWinSkip, winEnd);
+    const AR::DiffReport d = AR::diff(bWin, fWin, 1e-6);
+    std::printf("[MEASURE] isolated bounce null vs full-mix realtime: maxErr=%.3e rmsErr=%.1f dB\n",
+                d.maxAbsError, d.rmsErrorDb);
+    if (!t.expect("isolated bounce: nulls against the full-mix realtime render",
+                  d.rmsErrorDb < -120.0 && d.maxAbsError < 1e-5,
+                  "rmsErrDb=" + std::to_string(d.rmsErrorDb) +
+                      " maxAbs=" + std::to_string(d.maxAbsError))) {
+        AR::printDiffForensics("isolated bounce vs full mix", d, bWin, fWin);
+    }
 }
 
 // =============================================================================

--- a/docs/technical/audio/SINC64_TURBO_PAPER.md
+++ b/docs/technical/audio/SINC64_TURBO_PAPER.md
@@ -15,10 +15,11 @@ We present the **Aestra Polyphase Resampling Engine**, a multi-tier interpolatio
 > **~88 dB at fractional rate ratios** (bounded by nearest-phase LUT quantization,
 > not the kernel) and **~154 dB at exact 2:1 ratios**. That figure is
 > **path-specific, not a statement about all Aestra resampling**: full-session
-> measurement (Phase 2D) shows mainline session playback and full-mix export
-> currently dispatch the Sinc64 quality setting to the *legacy exact-sinc*
+> measurement (Phases 2D/2E) shows mainline session playback and both export
+> flavors (full-mix and isolated-track bounce, kernel-unified in Phase 2E)
+> dispatch the Sinc64 quality setting to the *legacy exact-sinc*
 > `Sinc64Interpolator` and measured **~146–154 dB** end-to-end; Sinc64Turbo is
-> what the isolated-track bounce, sampler, and audition paths run (~88 dB class).
+> what the sampler and audition paths run (~88 dB class).
 > The interpolators on **all** measured paths reconstruct at the *source*
 > Nyquist: **downsampling is not currently anti-aliased by a ratio-aware
 > low-pass**, so content between the output and source Nyquist frequencies folds
@@ -198,10 +199,10 @@ The table below reflects the *filter design model*, not bench measurements.
 `AestraDocs/audio-research-bench.md`):** delivered full-band single-tone residual
 (THD+N-style) for Sinc64Turbo is **~-88 dB at fractional rate ratios** (phase-LUT
 quantization bound; ~-154 dB at exact 2:1) — a path-specific figure: mainline
-session playback and full-mix export currently run the legacy exact-sinc
-`Sinc64Interpolator` and measured ~-146 to -154 dB end-to-end (doc §8); the ~-88 dB
-class applies to the Sinc64Turbo paths (isolated-track bounce, sampler, audition).
-IMD has not been bench-measured yet.
+session playback and both export flavors run the legacy exact-sinc
+`Sinc64Interpolator` (kernel-unified in Phase 2E) and measured ~-146 to -154 dB
+end-to-end (doc §8); the ~-88 dB class applies to the Sinc64Turbo paths (sampler,
+audition). IMD has not been bench-measured yet.
 Aliasing is **not** "None": the kernels reconstruct at the *source* Nyquist and no
 ratio-aware anti-alias low-pass is applied, so when downsampling, content between
 the output and source Nyquist frequencies folds back (measured near full scale for


### PR DESCRIPTION
## Summary

Resolves **F6** from the Phase 2D full-session audit (#438): the isolated-track bounce (`bounceRangeToWav(trackId ≥ 0)`) resampled clips with a **different kernel** than mainline playback and full-mix export. `AudioRenderer::renderClipAudio`'s dispatch table now matches `AudioEngine::renderGraph`'s exactly — three rows changed (`Sinc32Turbo → Sinc32Interpolator`, `Sinc64Turbo → Sinc64Interpolator`, plus initializer/default).

## Why

Phase 2D measured a soloed-track bounce of a 44.1k clip in a 48k session at **87.8 dB** SINAD while the identical clip in a full-mix export measured **149.3 dB** — a 61.5 dB quality split between two export flavors of the same content, breaking the export/live alignment contract (AGENTS §20) in a measurable way.

## Safety of the change

- `AudioRenderer::renderBlock` has **exactly one call site**: the offline isolated-bounce loop in `bounceRangeToWav` (AudioEngine.cpp:3224). The slower exact-sinc kernels therefore carry **zero realtime cost**.
- Deterministic pure per-sample kernels (the same ones mainline playback already runs on the audio thread).
- **No anti-aliasing policy change**, no UI change, no state/serialization change, no latency change (both kernel families are 64-tap with the same phase convention).

## Measured before → after (`SessionResamplingTruthTest`, 44.1k clip in 48k session)

| Metric | Before (Turbo) | After (unified) |
|---|---|---|
| Isolated bounce 1 kHz SINAD | 87.8 dB | **149.3 dB** |
| Agreement with full-mix path | −61.5 dB split | **0.02 dB** |
| Null vs full-mix realtime render | n/a (different kernel) | **−176.0 dB RMS, maxErr 3e-8** |
| Level accuracy | <0.001 dB | <0.001 dB (unchanged) |

The former KNOWN INCONSISTENCY characterization gate (designed to fail on unification) is replaced by unification gates: SINAD > 140 dB, SINAD agreement ±3 dB, null ≤ −120 dB.

## Testing performed

- Full `-j2` rebuild of build-linux (all engine consumers relinked), then:
- `ctest -L audio` → **59/59 pass**, including `ExportBounceParityTest` (isolated bounces still sum to the master bounce), both Arsenal export parity tests, `RealtimeExportParityTest`, `SampleRateBufferTruthTest`
- `ctest -L research` → 3/3 (66 checks in the truth test, incl. the new unification proofs)

## Docs updated?

Yes — `AestraDocs/audio-research-bench.md`: F6 → resolved with after-measurements; §8.1 kernel table, §8.4 scenarios, §8.5 recommendation list updated. Comment-only touch-ups in `Interpolators.h` and the public `SINC64_TURBO_PAPER.md` measured-performance notes (remaining Sinc64Turbo consumers are SamplerPlugin and AuditionEngine).

## Risk / rollback

- Behavior change is confined to isolated-track bounce output at mismatched clip/session rates (quality improvement; level/timing identical). Same-rate bounces take the direct-copy branch and are bit-identical to before.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Aligned isolated-track bounce resampling with mainline playback/full-mix export by switching `AudioRenderer::renderClipAudio` from Turbo sinc kernels to the exact-sinc interpolators for the affected `Sinc32`/`Sinc64` dispatch paths.
- Updated DSP comments and audit/docs/tests to reflect the unified kernel behavior, revised SINAD expectations, and the fact that isolated bounces now match full-mix quality instead of the older ~88 dB floor.
- Strengthened research tests for isolated bounces to validate mainline-class quality and null-match against realtime full-mix renders.
- Refreshed the SINC64 Turbo paper and audio research docs to re-scope remaining Turbo-kernel consumers and mark the isolated-bounce inconsistency as resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->