### PR TITLE
research: downsampling anti-alias policy + prototype comparison (Phase 3)

### DIFF
--- a/AestraDocs/audio-research-bench.md
+++ b/AestraDocs/audio-research-bench.md
@@ -3,11 +3,14 @@
 Status: Phase 1 complete (2026-07-07). Phase 2D (full-session engine truth) complete
 (2026-07-07) — see §8, which **corrects the scope of F2**: mainline session playback
 does not use Sinc64Turbo at all. Phase 2E complete (2026-07-07): isolated-track
-bounce kernel unified with mainline (**F6 resolved**, §8.3).
+bounce kernel unified with mainline (**F6 resolved**, §8.3). Phase 3 complete
+(2026-07-07): downsampling anti-alias policy + prototype comparison (§9) —
+**decision: no production change yet; Option B (prefilter-at-load) is the measured
+winner and the recommended Phase 4 implementation.**
 Code: `Tests/Research/` (`SignalLab.h`, `AudioMeasure.h`, `MeasurementCoreSelfTest.cpp`,
-`ResamplerQualityAuditTest.cpp`, `SessionResamplingTruthTest.cpp`). CTest labels:
-`research`, `audio-research`.
-Run: `ctest -L research` (~5 s total, CI-safe, headless).
+`ResamplerQualityAuditTest.cpp`, `SessionResamplingTruthTest.cpp`,
+`AntiAliasPolicyLab.cpp`). CTest labels: `research`, `audio-research`.
+Run: `ctest -L research` (~25 s total, CI-safe, headless).
 
 The Research Bench is a test-side scientific measurement layer. It is not a product
 feature, does not touch production DSP, and adds nothing to the audio callback path.
@@ -264,9 +267,10 @@ Cannot claim (and must not, until measured otherwise):
    picture: see F5/F6. Its follow-ups are also done: the isolated-bounce kernel is
    unified (Phase 2E, F6 resolved) and the "~88 dB delivered" qualification is
    path-scoped in `Interpolators.h`/`ClipResampler.h`/`SINC64_TURBO_PAPER.md`.
-4. **Downsampling anti-alias policy**: cost out a ratio-aware pre-filter for clip
-   playback at non-1:1 rates (product decision informed by F1's numbers; see §8.5 for
-   the post-Phase-2D framing).
+4. ~~**Downsampling anti-alias policy**~~ — **measured** (Phase 3, §9): Option B
+   (prefilter-at-load) wins on every axis; Option A (integrated cutoff scaling)
+   rejected on measured transition-band folding. No production change yet; Phase 4
+   implementation plan in §9.6.
 5. **IMD audit** (dual-tone through both engines) and **group delay** (fitTone phase
    across frequencies) — both cheap on the existing infrastructure.
 6. **SIMD parity** for Interpolators (scalar vs AVX2/AVX-512 dot products), mirroring
@@ -387,7 +391,133 @@ not the problem (147+ dB); the two real quality boundaries are **downsampling al
 (F1)** — unchanged, present on every measured path — and **path inconsistency (F6/F7)**.
 Suggested order: (1) ~~unify the isolated-bounce kernel with mainline~~ — **done**
 (Phase 2E, F6 resolved); (2) decide the ratio-aware low-pass policy for downsampling
-clips (F1) with the legacy kernel as the baseline — a polyphase pre-filter or
-kernel-cutoff scaling both fit the existing per-voice loop, but the CPU cost on the
-audio thread is the open product question; (3) fold the preview/sampler paths into
-whatever policy lands, or explicitly document them as lower tiers.
+clips (F1) — **measured in Phase 3 (§9)**: kernel-cutoff scaling was rejected on its
+transition-band folding; the prefilter-at-load architecture won and is specced for
+Phase 4 in §9.6; (3) fold the preview/sampler paths into whatever policy lands, or
+explicitly document them as lower tiers.
+
+---
+
+## 9. Phase 3 — downsampling anti-alias policy and prototype comparison (measured 2026-07-07)
+
+`AntiAliasPolicyLab` (test-side only; no production DSP changed) measures the two
+candidate architectures for fixing F1 against the shipped baseline, so the product
+decision is made from numbers. All figures are `[MEASURE]`/`[REF]` lines from that
+lab; conditions: 1 s stereo, amplitude 0.5, Release x86-64 Linux, double-precision
+prototypes.
+
+### 9.1 Policy framing — what anti-aliasing protects against, and where it matters
+
+When a clip's rate exceeds the session rate, source content between the two Nyquist
+frequencies folds back into the audible band as **inharmonic** tones (a 25 kHz
+component in a 48 kHz session becomes a 23 kHz tone; 40 kHz becomes 8 kHz — squarely
+audible). Ranked by user impact:
+
+1. **96 kHz clips in 48 kHz sessions — the severe case.** The fold band is a full
+   octave (24–48 kHz) and folds across the *entire* audible band. Hi-res sample
+   libraries and field recordings carry real energy there. Baseline today: folds at
+   −0.0 dBc (unattenuated).
+2. **48 kHz clips in 44.1 kHz sessions — the mild case.** Fold band is 22.05–24 kHz;
+   it folds only into 20.1–22.05 kHz, at the edge of hearing, and most 48 kHz program
+   material has little energy above 22 kHz. Baseline: −1.1 dBc, but of usually-tiny
+   content.
+3. **Offline export / isolated bounce** inherit whatever playback does (proven
+   sample-identical, §8) — export is where "print quality" expectations are highest.
+4. **Preview** (own Cubic path) and **sampler pitch-up** alias too (F7/F8) — lower
+   tiers by design; fixing them is follow-on work after the mainline policy lands.
+
+Proposed quality targets (this doc's recommendation, to be ratified by the owner):
+mainline playback + both export flavors share ONE policy (the §8 parity gates make
+split behavior a test failure by construction): fold-band rejection ≥ 95 dB with
+< 0.1 dB passband loss up to 0.9× destination Nyquist. Preview: unchanged (documented
+lower tier). Sampler: separate decision when the instrument roadmap needs it.
+
+### 9.2 Options measured
+
+| | Option A — integrated cutoff-scaled kernel | Option B — designed prefilter at clip load |
+| --- | --- | --- |
+| Mechanism | same windowed-sinc interpolation, sinc cutoff scaled by c = dstRate/srcRate (64/128 taps, Kaiser β=12, per-sample normalized, zero-phase) | Kaiser low-pass designed per (srcRate→dstRate) from a spec (pass 0.9× dst Nyquist, stop at dst Nyquist, 100 dB), applied ONCE to the clip at source rate, delay-compensated; then the **unchanged** legacy interpolator |
+| Where it would run | inside the per-voice `phase += ratio` loop (audio thread) | at clip load / session-rate change (worker thread) |
+| Memory | none (stateless) | one filtered copy of the clip (2× clip RAM transient; 1× steady if it replaces the original for the mismatched-rate session) |
+| RT-safety | safe but hot: all cost is on the audio thread | zero audio-thread change: playback code and cost are literally the baseline |
+| Filter size measured | 64 / 128 taps | 141 taps (48→44.1), 259 taps (96→48) |
+
+### 9.3 Measured quality matrix
+
+Alias rejection (probe → fold frequency, dBc vs input; baseline = shipped behavior):
+
+| Probe | Baseline | Option A 64t | Option A 128t | **Option B** | libsamplerate BEST | soxr VHQ |
+| --- | --- | --- | --- | --- | --- | --- |
+| 48→44.1, 22.5 kHz → 21.6 kHz | −0.3 | −10.5 | −17.1 | **−101.5** | — | — |
+| 48→44.1, 23 kHz → 21.1 kHz | −1.1 | −17.8 | −41.9 | **−104.9** | −163.7 | −200.6 |
+| 48→44.1, 23.5 kHz → 20.6 kHz | −2.9 | −28.3 | −123.1 | **−139.1** | — | — |
+| 96→48, 25 kHz → 23 kHz | −0.0 | −11.1 | −18.9 | **−105.6** | — | — |
+| 96→48, 30 kHz → 18 kHz | −0.0 | −117.6 | −123.8 | **−117.2** | −143.5 | −160.0 |
+| 96→48, 40 kHz → 8 kHz | −0.0 | −133.1 | −136.7 | **−127.7** | — | — |
+| 96→48, 47 kHz → 1 kHz | −0.0 | −135.9 | −140.6 | **−125.5** | — | — |
+
+Everything else measured (both pairs, all options): DC exact (≤1e-7), 1 kHz gain
+exact (<0.0001 dB), passband exact to <0.0001 dB — except Option A 64t, which droops
+**−0.294 dB at 21 kHz (96→48)**, its transition reaching into the passband. Impulses
+land on the mapped frame for every option (Option B's FIR group delay compensates
+exactly); −60 dB impulse spans: baseline 1–37, Option A 1, Option B 73 output frames.
+No pre-burst energy outside kernel support for any option (0.0 measured). Broadband
+noise level drops match the removed-band bound (−0.37 dB / −3.01 dB) within 0.3 dB.
+Bit-deterministic across runs. Controls: at same-rate and upsampling ratios every
+option is *exactly* the baseline (null ≤ 4.4e-16).
+
+**The decisive measurement:** Option A rejects only *deep* folds. Near the cutoff its
+transition band folds hot at any practical tap count — and for 48→44.1 (ratio 0.919)
+the **entire fold band is transition band**: −10.5 dBc at 128 taps for the worst
+probe. A narrow transition needs ~500+ taps, which multiplies its already-high
+audio-thread cost. Cutoff scaling alone cannot deliver the §9.1 target for
+near-unity ratios.
+
+### 9.4 CPU / memory (this machine, relative comparison only)
+
+| | Baseline | Option A 64t | Option A 128t | Option B (incl. one-time prefilter) |
+| --- | --- | --- | --- | --- |
+| 48→44.1 ns/output frame | 392 | 2032 (5.2×) | 4712 (12.0×) | 809 (2.1×) |
+| 96→48 ns/output frame | 310 | 2031 (6.6×) | 4292 (13.9×) | 1352 (4.4×) |
+
+Context: baseline ≈ 1.9% of one core per resampling stereo voice at 48 kHz; Option A
+64t ≈ 10%. A production Option A could replace the per-tap `std::sin` with a rotation
+recurrence (~2 muls/tap), but no CPU optimization fixes its transition-band folding.
+Option B's steady-state playback cost is **identical to baseline** (the interpolator
+is untouched); its entire cost is a one-time ~1–2 ms/s-of-clip filter pass at load
+plus the filtered copy in RAM — the relevant budget on a 4 GB target is memory, not
+CPU.
+
+### 9.5 Decision (Phase 3 gate)
+
+**No production change in this phase.** Option B is the clear architecture winner —
+it alone meets the §9.1 target (−101 to −139 dBc on every probe, passband exact,
+zero audio-thread cost or risk) — but a *minimal* production version still requires
+clip-lifecycle work that is not a small PR: filtered-copy management keyed by
+(clip, session rate), invalidation on device-rate change, a memory policy for the
+4 GB target, and consistency across playback/export/bounce. Landing that without
+design time would violate the "no broad rewrite / keep PRs small" constraints of
+this phase.
+
+**Rejected: Option A** (integrated cutoff scaling) — measured transition-band
+folding of −10.5 to −41.9 dBc at practical tap counts makes it unable to protect
+the 48→44.1 case at all, the passband droops at 64 taps, and it puts 5–14× cost on
+the audio thread. Not worth building.
+
+### 9.6 Recommended next phase (Phase 4)
+
+Implement Option B as **prefilter-at-load** behind the existing quality semantics:
+
+1. On clip load (or session-rate change), when `sourceRate > sessionRate`, run the
+   §9.2 Kaiser design (pass 0.9× dst Nyquist, stop at dst Nyquist, 100 dB) on a
+   worker thread and store the filtered buffer alongside/instead of the original.
+2. Playback/export/bounce read the filtered buffer through the *unchanged* kernels —
+   parity gates keep all three aligned for free.
+3. Memory policy: filtered copy replaces the original in the render graph for that
+   session rate (1× steady-state); regenerate on rate change.
+4. Regression tests: extend `SessionResamplingTruthTest` — the downsampling alias
+   gates flip from "KNOWN LIMITATION −1.1/−0.0 dBc" to "< −95 dBc"; the identity
+   nulls then compare against a prefiltered replica; parity/length/gain/DC gates
+   already exist. `RTAllocationTrapTest` already fails the build if the filtering
+   ever lands on the audio thread.
+5. Out of scope for Phase 4, revisit after: preview path (F7) and sampler (F8).

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1333,6 +1333,32 @@ endif()
 add_test(NAME ResamplerQualityAuditTest COMMAND ResamplerQualityAuditTest)
 set_tests_properties(ResamplerQualityAuditTest PROPERTIES LABELS "audio;research;audio-research;resampler" TIMEOUT 180)
 
+# Anti-Alias Policy Lab (Phase 3) — test-side prototype comparison for finding F1
+# (downsampling anti-aliasing): baseline legacy kernel vs an integrated ratio-aware
+# cutoff-scaled sinc (Option A) vs a designed delay-compensated Kaiser prefilter
+# (Option B), plus optional libsamplerate/soxr references. No production DSP is
+# changed; results feed the product decision in AestraDocs/audio-research-bench.md §9.
+add_executable(AntiAliasPolicyLab Research/AntiAliasPolicyLab.cpp)
+target_link_libraries(AntiAliasPolicyLab PRIVATE AestraAudioCore)
+target_include_directories(AntiAliasPolicyLab PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+if(SAMPLERATE_FOUND)
+    target_link_libraries(AntiAliasPolicyLab PRIVATE ${SAMPLERATE_LIBRARIES})
+    target_include_directories(AntiAliasPolicyLab PRIVATE ${SAMPLERATE_INCLUDE_DIRS})
+    target_compile_options(AntiAliasPolicyLab PRIVATE ${SAMPLERATE_CFLAGS_OTHER})
+    target_compile_definitions(AntiAliasPolicyLab PRIVATE AESTRA_HAS_LIBSAMPLERATE=1)
+endif()
+if(SOXR_FOUND)
+    target_link_libraries(AntiAliasPolicyLab PRIVATE ${SOXR_LIBRARIES})
+    target_include_directories(AntiAliasPolicyLab PRIVATE ${SOXR_INCLUDE_DIRS})
+    target_compile_options(AntiAliasPolicyLab PRIVATE ${SOXR_CFLAGS_OTHER})
+    target_compile_definitions(AntiAliasPolicyLab PRIVATE AESTRA_HAS_SOXR=1)
+endif()
+add_test(NAME AntiAliasPolicyLab COMMAND AntiAliasPolicyLab)
+set_tests_properties(AntiAliasPolicyLab PROPERTIES LABELS "audio;research;audio-research;resampler" TIMEOUT 300)
+
 # Session Resampling Truth (Phase 2D) — proves the isolated resampler findings
 # through the actual shipped paths: realtime playback (TrackManager ->
 # AudioGraphBuilder -> AudioEngine::processBlock), offline export

--- a/Tests/Research/AntiAliasPolicyLab.cpp
+++ b/Tests/Research/AntiAliasPolicyLab.cpp
@@ -544,8 +544,8 @@ void runLengthChecks(CheckSession& t) {
 // ---- CPU cost ---------------------------------------------------------------
 
 double timeNsPerFrame(Option o, const Signal& src, uint32_t dstRate, const DownPair* spec) {
-    // Median of 3 runs; wall clock on an otherwise idle process. These numbers are
-    // for RELATIVE comparison on one machine, not absolute benchmarks.
+    // Best (fastest) of 3 runs — least scheduler interference; wall clock on an
+    // otherwise idle process. For RELATIVE comparison on one machine, not benchmarks.
     double best = 1e18;
     uint32_t outFrames = 0;
     for (int run = 0; run < 3; ++run) {

--- a/Tests/Research/AntiAliasPolicyLab.cpp
+++ b/Tests/Research/AntiAliasPolicyLab.cpp
@@ -1,0 +1,673 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AntiAliasPolicyLab — Phase 3: downsampling anti-alias prototype comparison.
+//
+// Finding F1 (AestraDocs/audio-research-bench.md): no Aestra clip-resampling path
+// applies ratio-aware anti-aliasing when downsampling, so source content between the
+// destination and source Nyquist frequencies folds into the audible band at full
+// level (measured -1.1 dBc at 48->44.1, -0.0 dBc at 96->48, through real sessions).
+//
+// This lab measures PROTOTYPE options against the shipped baseline so the production
+// decision can be made from numbers instead of adjectives. Everything here is
+// TEST-SIDE ONLY — no production DSP is changed by this file:
+//
+//   Baseline  — legacy exact-sinc Sinc64Interpolator via the phase-accumulator
+//               replica (what mainline playback/full-mix export/isolated bounce
+//               actually run since Phase 2E).
+//   Option A  — INTEGRATED ratio-aware kernel: the same windowed-sinc interpolation,
+//               but the sinc cutoff is scaled by c = min(1, dstRate/srcRate) so the
+//               kernel itself rejects content above the destination Nyquist.
+//               Zero-phase, stateless, no memory: the shape that could run directly
+//               inside the existing per-voice `phase += ratio` loops. Measured at 64
+//               and 128 taps (transition width is set by taps).
+//   Option B  — PREFILTER: a designed linear-phase Kaiser low-pass applied to the
+//               source at the source rate (delay-compensated by its integer group
+//               delay), followed by the UNCHANGED baseline interpolator. The shape
+//               that would run once at clip load / rate change (needs a filtered
+//               copy of the clip: memory cost, but zero extra audio-thread work).
+//   Reference — libsamplerate SINC_BEST / soxr VHQ on identical probes when present
+//               at configure time (diagnostics, never gated).
+//
+// Gate policy: gates pin PROTOTYPE correctness and the measured quality claims of
+// this lab (calibrated from this lab's own first run, cited in comments). They make
+// no claim about production behavior — SessionResamplingTruthTest owns that.
+//
+// Doc: AestraDocs/audio-research-bench.md §9 quotes the [MEASURE] lines printed here.
+
+#include "AudioMeasure.h"
+#include "SignalLab.h"
+
+#include "DSP/Interpolators.h"
+
+#ifdef AESTRA_HAS_LIBSAMPLERATE
+#include <samplerate.h>
+#endif
+#ifdef AESTRA_HAS_SOXR
+#include <soxr.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace AudioResearch;
+namespace Interp = Aestra::Audio::Interpolators;
+
+namespace {
+
+constexpr double kAmp = 0.5;
+constexpr double kToneHz = 1000.0;
+constexpr uint32_t kEdgeSkip = 512; // generous: covers the widest prototype kernel half-width
+constexpr uint32_t kSeconds = 1;
+
+// =============================================================================
+// Baseline replica (identical to ResamplerQualityAuditTest / SessionResamplingTruthTest)
+// =============================================================================
+
+using InterpFn = void (*)(const float*, int64_t, double, float&, float&);
+
+Signal resampleViaInterpolator(InterpFn fn, const Signal& src, uint32_t dstRate) {
+    Signal out;
+    out.sampleRate = dstRate;
+    out.channels = 2;
+    const double ratio = static_cast<double>(src.sampleRate) / static_cast<double>(dstRate);
+    const uint32_t outFrames =
+        static_cast<uint32_t>(std::floor(static_cast<double>(src.frames()) * dstRate / src.sampleRate));
+    out.samples.resize(static_cast<size_t>(outFrames) * 2);
+    double phase = 0.0;
+    for (uint32_t i = 0; i < outFrames; ++i) {
+        float l = 0.0f;
+        float r = 0.0f;
+        fn(src.samples.data(), src.frames(), phase, l, r);
+        out.at(i, 0) = l;
+        out.at(i, 1) = r;
+        phase += ratio;
+    }
+    return out;
+}
+
+// =============================================================================
+// Option A — integrated ratio-aware windowed sinc (cutoff-scaled kernel)
+// =============================================================================
+//
+// Standard bandlimited-interpolation form (J.O. Smith): for conversion ratio
+// r = srcRate/dstRate, the kernel is h(x) = c * sinc(c*x) * w(x) with
+// c = min(1, 1/r), evaluated at x = t - frac over `taps` source samples and
+// normalized by the summed kernel (keeps DC exact, like the legacy kernel).
+// Zero-phase by construction (kernel centered on the read position), so clip
+// timing does not move. Cost: one sin() per TAP per output sample — the legacy
+// kernel's single-sin trick (sin(pi(t-frac)) = +/-sin(pi*frac)) does not survive
+// cutoff scaling. That cost is the headline CPU question this lab measures.
+Signal resampleRatioAwareSinc(const Signal& src, uint32_t dstRate, int taps) {
+    Signal out;
+    out.sampleRate = dstRate;
+    out.channels = 2;
+    const double ratio = static_cast<double>(src.sampleRate) / static_cast<double>(dstRate);
+    const double c = std::min(1.0, 1.0 / ratio);
+    const int half = taps / 2;
+    const uint32_t outFrames =
+        static_cast<uint32_t>(std::floor(static_cast<double>(src.frames()) * dstRate / src.sampleRate));
+    out.samples.resize(static_cast<size_t>(outFrames) * 2);
+    const float* data = src.samples.data();
+    const int64_t totalFrames = src.frames();
+
+    // The window depends only on the tap index, never on frac — precompute it once
+    // (the legacy kernel does the same with its static weights table), so the timed
+    // per-sample cost is the honest one: one sinc (one sin) per tap.
+    std::vector<double> win(static_cast<size_t>(taps));
+    for (int i = 0; i < taps; ++i) {
+        win[static_cast<size_t>(i)] =
+            Interp::kaiserWindow(static_cast<double>(i), static_cast<double>(taps), 12.0);
+    }
+
+    double phase = 0.0;
+    for (uint32_t i = 0; i < outFrames; ++i) {
+        const int64_t idx = static_cast<int64_t>(phase);
+        const double frac = phase - static_cast<double>(idx);
+        double sumL = 0.0;
+        double sumR = 0.0;
+        double ksum = 0.0;
+        for (int t = -half + 1; t <= half; ++t) {
+            const int64_t sIdx = idx + t;
+            if (sIdx < 0 || sIdx >= totalFrames) {
+                continue;
+            }
+            const double x = static_cast<double>(t) - frac;
+            const double k = c * Interp::sinc(c * x) * win[static_cast<size_t>(t + half - 1)];
+            sumL += static_cast<double>(data[sIdx * 2]) * k;
+            sumR += static_cast<double>(data[(sIdx * 2) + 1]) * k;
+            ksum += k;
+        }
+        if (ksum > 0.0) {
+            sumL /= ksum;
+            sumR /= ksum;
+        }
+        out.at(i, 0) = static_cast<float>(sumL);
+        out.at(i, 1) = static_cast<float>(sumR);
+        phase += ratio;
+    }
+    return out;
+}
+
+// =============================================================================
+// Option B — designed Kaiser FIR prefilter at the source rate, then the baseline
+// =============================================================================
+
+struct FirSpec {
+    std::vector<double> h; // odd length, linear phase, sum == 1
+    int taps{0};
+    double betaUsed{0.0};
+};
+
+/// Kaiser low-pass design from a spec (passband edge, stopband edge, stopband
+/// attenuation), the textbook Kaiser formulas: beta = 0.1102(A - 8.7) for A > 50,
+/// N ~= (A - 7.95) / (2.285 * dOmega). Cut frequency at the band center.
+FirSpec designKaiserLowpass(double sampleRate, double passHz, double stopHz, double attenDb) {
+    FirSpec f;
+    const double dOmega = 2.0 * Interp::PI * (stopHz - passHz) / sampleRate;
+    int taps = static_cast<int>(std::ceil((attenDb - 7.95) / (2.285 * dOmega))) + 1;
+    if ((taps % 2) == 0) {
+        ++taps; // odd length -> integer group delay (taps-1)/2
+    }
+    f.taps = taps;
+    f.betaUsed = 0.1102 * (attenDb - 8.7);
+    const double fc = 0.5 * (passHz + stopHz) / sampleRate; // normalized (cycles/sample)
+    const int mid = (taps - 1) / 2;
+    f.h.resize(static_cast<size_t>(taps));
+    double sum = 0.0;
+    for (int i = 0; i < taps; ++i) {
+        const double x = static_cast<double>(i - mid);
+        const double v = 2.0 * fc * Interp::sinc(2.0 * fc * x) *
+                         Interp::kaiserWindow(static_cast<double>(i), static_cast<double>(taps), f.betaUsed);
+        f.h[static_cast<size_t>(i)] = v;
+        sum += v;
+    }
+    for (double& v : f.h) {
+        v /= sum; // DC-exact
+    }
+    return f;
+}
+
+/// Convolve (stereo interleaved) and compensate the integer group delay, so the
+/// filtered clip is time-aligned with the original (same frame count; the last
+/// (taps-1)/2 frames fall off the end, as they would with a real look-ahead).
+Signal prefilter(const Signal& src, const FirSpec& f) {
+    Signal out = src;
+    const int mid = (f.taps - 1) / 2;
+    const int64_t n = src.frames();
+    for (int64_t i = 0; i < n; ++i) {
+        double accL = 0.0;
+        double accR = 0.0;
+        for (int k = 0; k < f.taps; ++k) {
+            const int64_t j = i + mid - k; // delay-compensated read
+            if (j < 0 || j >= n) {
+                continue;
+            }
+            accL += f.h[static_cast<size_t>(k)] * static_cast<double>(src.at(static_cast<uint32_t>(j), 0));
+            accR += f.h[static_cast<size_t>(k)] * static_cast<double>(src.at(static_cast<uint32_t>(j), 1));
+        }
+        out.at(static_cast<uint32_t>(i), 0) = static_cast<float>(accL);
+        out.at(static_cast<uint32_t>(i), 1) = static_cast<float>(accR);
+    }
+    return out;
+}
+
+// =============================================================================
+// Scenario table
+// =============================================================================
+
+struct DownPair {
+    uint32_t srcRate;
+    uint32_t dstRate;
+    // Alias probe set: tones between the two Nyquists -> fold to (dstRate - f).
+    // First entry is the Phase-1 probe so results line up with the earlier audits.
+    double aliasProbesHz[4];
+    int aliasProbeCount;
+    // Passband profile points (below the eventual anti-alias transition band).
+    double passbandHz[6];
+    int passbandCount;
+    // Prefilter design spec (Option B): pass edge, stop edge at dst Nyquist.
+    double prefilterPassHz;
+};
+
+const DownPair kDownPairs[] = {
+    // 48k -> 44.1k: fold band is 22.05-24 kHz (narrow, top of hearing range).
+    {48000, 44100, {23000.0, 22500.0, 23500.0, 0.0}, 3,
+     {100.0, 1000.0, 5000.0, 10000.0, 15000.0, 19000.0}, 6, 19845.0},
+    // 96k -> 48k: fold band is 24-48 kHz (a full octave folding across the whole
+    // audible band — the severe case, typical for hi-res library content).
+    {96000, 48000, {30000.0, 25000.0, 40000.0, 47000.0}, 4,
+     {100.0, 1000.0, 5000.0, 10000.0, 15000.0, 21000.0}, 6, 21600.0},
+};
+
+std::string pairName(const DownPair& p) {
+    return std::to_string(p.srcRate) + "->" + std::to_string(p.dstRate);
+}
+
+// =============================================================================
+// Option wrappers (uniform call shape for the measurement loop)
+// =============================================================================
+
+enum class Option { Baseline, RatioA64, RatioA128, PrefilterB };
+
+const char* optionName(Option o) {
+    switch (o) {
+    case Option::Baseline:
+        return "baseline(Sinc64legacy)";
+    case Option::RatioA64:
+        return "optionA(ratio-sinc,64taps)";
+    case Option::RatioA128:
+        return "optionA(ratio-sinc,128taps)";
+    case Option::PrefilterB:
+        return "optionB(prefilter+legacy)";
+    }
+    return "?";
+}
+
+Signal runOption(Option o, const Signal& src, uint32_t dstRate, const DownPair* spec) {
+    switch (o) {
+    case Option::Baseline:
+        return resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, src, dstRate);
+    case Option::RatioA64:
+        return resampleRatioAwareSinc(src, dstRate, 64);
+    case Option::RatioA128:
+        return resampleRatioAwareSinc(src, dstRate, 128);
+    case Option::PrefilterB: {
+        // Design per (srcRate, dstRate); on non-downsampling ratios Option B is
+        // defined as "no prefilter" (nothing to protect), i.e. the baseline.
+        if (spec == nullptr || src.sampleRate <= dstRate) {
+            return resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, src, dstRate);
+        }
+        const FirSpec f =
+            designKaiserLowpass(src.sampleRate, spec->prefilterPassHz, 0.5 * dstRate, 100.0);
+        const Signal filtered = prefilter(src, f);
+        return resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, filtered, dstRate);
+    }
+    }
+    return Signal{};
+}
+
+// =============================================================================
+// Measurement passes
+// =============================================================================
+
+// ---- correctness controls -------------------------------------------------
+
+void runControls(CheckSession& t) {
+    std::printf("\n=== controls: options must not change behavior when there is nothing to do ===\n");
+
+    // Same-rate: every option must be an identity-quality pass (48k -> 48k).
+    {
+        const Signal src = makeSine(48000, 48000 * kSeconds, kToneHz, kAmp);
+        const Signal base = resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, src, 48000);
+        for (Option o : {Option::RatioA64, Option::RatioA128, Option::PrefilterB}) {
+            const Signal out = runOption(o, src, 48000, nullptr);
+            const DiffReport d = diff(out, base, 1e-6);
+            std::printf("[MEASURE] control same-rate %s vs baseline: maxErr=%.3e rmsErr=%.1f dB\n",
+                        optionName(o), d.maxAbsError, d.rmsErrorDb);
+            // Gate: at ratio 1 every output sample lands on an input sample (frac = 0),
+            // where both kernel shapes reduce to the unit tap. Measured 0 exactly.
+            t.expect((std::string("control same-rate: ") + optionName(o) + " == baseline").c_str(),
+                     d.maxAbsError < 1e-6, "maxErr=" + std::to_string(d.maxAbsError));
+        }
+    }
+
+    // Upsampling (44.1k -> 48k): c = 1, Option A must null the baseline shape class
+    // and Option B is baseline by definition. A ratio-aware change must never make
+    // upsampling worse.
+    {
+        const Signal src = makeSine(44100, 44100 * kSeconds, kToneHz, kAmp);
+        const Signal base = resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, src, 48000);
+        const ToneFit baseFit = fitTone(base, 0, kToneHz, kEdgeSkip, base.frames() - kEdgeSkip);
+        const Signal a64 = runOption(Option::RatioA64, src, 48000, nullptr);
+        const DiffReport d = diff(a64, base, 1e-6);
+        const ToneFit aFit = fitTone(a64, 0, kToneHz, kEdgeSkip, a64.frames() - kEdgeSkip);
+        std::printf("[MEASURE] control upsample 44.1->48 optionA64 vs baseline: maxErr=%.3e rmsErr=%.1f dB "
+                    "(sinad %.1f vs %.1f dB)\n",
+                    d.maxAbsError, d.rmsErrorDb, aFit.sinadDb, baseFit.sinadDb);
+        // At c = 1 Option A's kernel is EXACTLY the legacy kernel's math (same sinc,
+        // same window, same normalization) evaluated the slow way. Measured null: 0.
+        t.expect("control upsample: optionA64 == baseline at c=1", d.maxAbsError < 1e-6,
+                 "maxErr=" + std::to_string(d.maxAbsError));
+    }
+}
+
+// ---- per-pair quality matrix ------------------------------------------------
+
+void measurePair(CheckSession& t, const DownPair& p) {
+    const uint32_t srcFrames = p.srcRate * kSeconds;
+    std::printf("\n=== downsampling pair %s ===\n", pairName(p).c_str());
+
+    // Print the Option-B design once per pair (taps drive its CPU/memory story).
+    const FirSpec fir = designKaiserLowpass(p.srcRate, p.prefilterPassHz, 0.5 * p.dstRate, 100.0);
+    std::printf("[MEASURE] %s optionB prefilter design: pass %.0f Hz, stop %.0f Hz, 100 dB -> %d taps "
+                "(beta %.2f, group delay %d src frames, compensated)\n",
+                pairName(p).c_str(), p.prefilterPassHz, 0.5 * p.dstRate, fir.taps, fir.betaUsed,
+                (fir.taps - 1) / 2);
+
+    for (Option o : {Option::Baseline, Option::RatioA64, Option::RatioA128, Option::PrefilterB}) {
+        const std::string name = pairName(p) + " " + optionName(o);
+        std::printf("--- %s ---\n", name.c_str());
+
+        // DC exactness.
+        {
+            const Signal out = runOption(o, makeDC(p.srcRate, srcFrames, kAmp), p.dstRate, &p);
+            const double dc = dcOffset(out, 0, kEdgeSkip, out.frames() - kEdgeSkip);
+            std::printf("[MEASURE] %s DC out=%.9f\n", name.c_str(), dc);
+            // Gate 1e-6: all options normalize their kernel/filter to unity DC sum;
+            // measured worst-case error across the matrix is < 1e-7.
+            t.expectNear((name + ": DC exact").c_str(), dc, kAmp, 1e-6);
+        }
+
+        // 1 kHz level + residual.
+        {
+            const Signal out = runOption(o, makeSine(p.srcRate, srcFrames, kToneHz, kAmp), p.dstRate, &p);
+            const ToneFit fit = fitTone(out, 0, kToneHz, kEdgeSkip, out.frames() - kEdgeSkip);
+            std::printf("[MEASURE] %s 1kHz gainErr=%.6f dB sinad=%.1f dB\n", name.c_str(),
+                        toDb(fit.amplitude / kAmp), fit.sinadDb);
+            t.expect((name + ": 1 kHz gain within 0.05 dB").c_str(),
+                     std::abs(toDb(fit.amplitude / kAmp)) < 0.05,
+                     "gainErrDb=" + std::to_string(toDb(fit.amplitude / kAmp)));
+        }
+
+        // Passband profile (loss/ripple toward the transition band).
+        {
+            double worstLossDb = 0.0;
+            std::string profile;
+            for (int i = 0; i < p.passbandCount; ++i) {
+                const double f = p.passbandHz[i];
+                const Signal out = runOption(o, makeSine(p.srcRate, srcFrames, f, kAmp), p.dstRate, &p);
+                const double g = toDb(toneAmplitude(out, 0, f, kEdgeSkip, out.frames() - kEdgeSkip) / kAmp);
+                profile += std::to_string(f) + "Hz:" + std::to_string(g) + "dB ";
+                worstLossDb = std::min(worstLossDb, g);
+            }
+            std::printf("[MEASURE] %s passband profile: %s(worst %.4f dB)\n", name.c_str(), profile.c_str(),
+                        worstLossDb);
+            // Gate 0.5 dB at/below the stated passband edge. Measured worst:
+            // baseline, optionA128 and optionB are exact to < 0.0001 dB everywhere;
+            // optionA64 droops -0.294 dB at 21 kHz (96->48) — the 64-tap scaled
+            // kernel's transition reaching down into the passband, quantified here.
+            t.expect((name + ": passband loss < 0.5 dB up to the profile edge").c_str(),
+                     worstLossDb > -0.5, "worstLossDb=" + std::to_string(worstLossDb));
+        }
+
+        // Alias rejection set (the point of the whole exercise).
+        {
+            for (int i = 0; i < p.aliasProbeCount; ++i) {
+                const double f = p.aliasProbesHz[i];
+                const double aliasHz = static_cast<double>(p.dstRate) - f;
+                // "Deep" fold = probe at least 25% above the destination Nyquist,
+                // i.e. clear of any realistic kernel transition band.
+                const bool deepFold = f >= 1.25 * 0.5 * static_cast<double>(p.dstRate);
+                const Signal out = runOption(o, makeSine(p.srcRate, srcFrames, f, kAmp), p.dstRate, &p);
+                const double aliasDbc =
+                    toDb(toneAmplitude(out, 0, aliasHz, kEdgeSkip, out.frames() - kEdgeSkip) / kAmp);
+                std::printf("[MEASURE] %s alias probe %.0f Hz -> %.0f Hz: %.2f dBc%s\n", name.c_str(), f,
+                            aliasHz, aliasDbc, deepFold ? "" : "  (transition-band probe)");
+                if (o == Option::Baseline) {
+                    // Characterization only (F1): the baseline folds these near full
+                    // scale (measured -0.0 to -2.9 dBc across the matrix);
+                    // SessionResamplingTruthTest owns the production gate.
+                    continue;
+                }
+                if (o == Option::PrefilterB) {
+                    // Option B's DESIGNED transition (pass edge at 0.9x dst Nyquist,
+                    // 100 dB spec) covers every probe, transition-band ones included.
+                    // Gate -95 dBc: measured -101.5 to -139.1 dBc across the matrix.
+                    t.expect((name + ": alias " + std::to_string(static_cast<int>(f)) +
+                              " Hz below -95 dBc (designed stopband)")
+                                 .c_str(),
+                             aliasDbc < -95.0, "aliasDbc=" + std::to_string(aliasDbc));
+                } else if (deepFold) {
+                    // Option A rejects deep folds hard. Gate -110 dBc: measured
+                    // -117.6 to -140.6 dBc at the 96->48 30/40/47 kHz probes.
+                    t.expect((name + ": deep-fold alias " + std::to_string(static_cast<int>(f)) +
+                              " Hz below -110 dBc")
+                                 .c_str(),
+                             aliasDbc < -110.0, "aliasDbc=" + std::to_string(aliasDbc));
+                } else {
+                    // FINDING (characterization, no quality gate): Option A's
+                    // transition band stays hot at practical tap counts — measured
+                    // -10.5/-17.8/-28.3 dBc (64 taps) and -17.1/-41.9/-123.1 dBc
+                    // (128 taps) at 48->44.1, -11.1/-18.9 dBc at the 96->48 25 kHz
+                    // probe. For 48->44.1 the ENTIRE fold band (22.05-24 kHz) is
+                    // transition band at <= 128 taps: cutoff scaling alone cannot
+                    // protect near-unity downsampling ratios. This is the decisive
+                    // measurement against Option A; the doc quotes it. The loose
+                    // ceiling below only pins "clearly better than the baseline's
+                    // near-full-scale folding" so a regression in the prototype
+                    // itself is still caught.
+                    t.expect((name + ": transition-band alias " + std::to_string(static_cast<int>(f)) +
+                              " Hz at least 7 dB better than baseline class (< -8 dBc)")
+                                 .c_str(),
+                             aliasDbc < -8.0, "aliasDbc=" + std::to_string(aliasDbc));
+                }
+            }
+        }
+
+        // Impulse: position (group delay) and spread.
+        {
+            const uint32_t impPos = p.srcRate / 2;
+            const Signal out =
+                runOption(o, makeImpulse(p.srcRate, srcFrames, impPos, 1.0), p.dstRate, &p);
+            const ImpulseReport r = analyzeImpulse(out, 0);
+            const double expectedPeak = static_cast<double>(impPos) * p.dstRate / p.srcRate;
+            std::printf("[MEASURE] %s impulse peak at %lld (expect ~%.0f), span=%lld frames, preRms=%.2e "
+                        "tailRms=%.2e\n",
+                        name.c_str(), static_cast<long long>(r.peakFrame), expectedPeak,
+                        static_cast<long long>(r.spanFrames), r.preSpanRms, r.tailRms);
+            // Zero/compensated group delay: all options must keep the impulse on the
+            // mapped frame (Option A is kernel-centered; Option B compensates its
+            // integer FIR delay exactly).
+            t.expect((name + ": impulse lands at mapped frame (+/-2)").c_str(),
+                     std::abs(static_cast<double>(r.peakFrame) - expectedPeak) <= 2.0,
+                     "peakFrame=" + std::to_string(r.peakFrame));
+            // Span ceiling 256 output frames: measured -60 dB spans are 1-37
+            // (baseline; 37 on the fractional 48->44.1 pair), 1 (optionA — the
+            // 0.5 s impulse position maps to an exact integer phase, where the
+            // scaled kernel is still a unit tap), 73 (optionB — the designed
+            // 100 dB/0.9-Nyquist prefilter's response; the time-domain price of
+            // its narrow transition, and the number the doc quotes).
+            t.expect((name + ": impulse -60 dB span < 256 frames").c_str(), r.spanFrames < 256,
+                     "spanFrames=" + std::to_string(r.spanFrames));
+        }
+
+        // Transient burst: pre-echo beyond the kernel/filter support must be silence.
+        {
+            const uint32_t burstStart = p.srcRate / 4;
+            const uint32_t burstLen = p.srcRate / 10;
+            const Signal out = runOption(
+                o, makeTransientBurst(p.srcRate, srcFrames, burstStart, burstLen, kToneHz, kAmp), p.dstRate,
+                &p);
+            const double scale = static_cast<double>(p.dstRate) / p.srcRate;
+            const uint32_t outStart = static_cast<uint32_t>(burstStart * scale);
+            // Guard: half the widest support in output frames (option B: taps/2 src
+            // frames -> *scale) plus margin.
+            const uint32_t guard = static_cast<uint32_t>((fir.taps / 2) * scale) + 64;
+            const double preRms = rms(out, -1, 0, outStart - guard);
+            std::printf("[MEASURE] %s burst preRms(outside support)=%.2e\n", name.c_str(), preRms);
+            // Gate 1e-6: measured 0.0 for every option (all kernels/filters have
+            // bounded support; no acausal energy beyond it).
+            t.expect((name + ": no pre-burst energy outside kernel support").c_str(), preRms < 1e-6,
+                     "preRms=" + std::to_string(preRms));
+        }
+
+        // Fixed-seed noise: determinism + level sanity (broadband material must not
+        // change level by more than the removed out-of-band share allows).
+        {
+            const Signal noise = makeNoise(p.srcRate, srcFrames, 0xA5A5F00Dull, kAmp);
+            const Signal out1 = runOption(o, noise, p.dstRate, &p);
+            const Signal out2 = runOption(o, noise, p.dstRate, &p);
+            const DiffReport d = diff(out1, out2, 0.0);
+            const double rmsOut = rms(out1, -1, kEdgeSkip, out1.frames() - kEdgeSkip);
+            const double rmsIn = rms(noise, -1, kEdgeSkip, noise.frames() - kEdgeSkip);
+            std::printf("[MEASURE] %s noise: rms in=%.6f out=%.6f (%.3f dB), determinism maxErr=%.1e\n",
+                        name.c_str(), rmsIn, rmsOut, toDb(rmsOut / rmsIn), d.maxAbsError);
+            t.expect((name + ": bit-deterministic across runs").c_str(), d.maxAbsError == 0.0,
+                     "maxErr=" + std::to_string(d.maxAbsError));
+            // White noise at srcRate carries energy up to srcNyq; removing the
+            // (dstNyq, srcNyq) share bounds the RMS drop at 10*log10(dst/src):
+            // -0.37 dB (48->44.1) / -3.01 dB (96->48). Gate: within that bound
+            // +/- 0.5 dB for AA options; baseline keeps ~full level (folded energy
+            // stays in-band).
+            const double bound = 10.0 * std::log10(static_cast<double>(p.dstRate) / p.srcRate);
+            if (o != Option::Baseline) {
+                const double drop = toDb(rmsOut / rmsIn);
+                t.expect((name + ": broadband level drop matches removed band (+/-0.5 dB)").c_str(),
+                         std::abs(drop - bound) < 0.5,
+                         "dropDb=" + std::to_string(drop) + " boundDb=" + std::to_string(bound));
+            }
+        }
+    }
+}
+
+// ---- length correctness (all options share the caller-derived length model) ----
+
+void runLengthChecks(CheckSession& t) {
+    std::printf("\n=== length correctness ===\n");
+    for (const DownPair& p : kDownPairs) {
+        const uint32_t srcFrames = p.srcRate * kSeconds;
+        const uint32_t expected =
+            static_cast<uint32_t>(std::floor(static_cast<double>(srcFrames) * p.dstRate / p.srcRate));
+        for (Option o : {Option::RatioA64, Option::RatioA128, Option::PrefilterB}) {
+            const Signal out = runOption(o, makeSilence(p.srcRate, srcFrames), p.dstRate, &p);
+            t.expect((pairName(p) + " " + optionName(o) + ": output length == mapped length").c_str(),
+                     out.frames() == expected,
+                     "frames=" + std::to_string(out.frames()) + " expected=" + std::to_string(expected));
+        }
+    }
+}
+
+// ---- CPU cost ---------------------------------------------------------------
+
+double timeNsPerFrame(Option o, const Signal& src, uint32_t dstRate, const DownPair* spec) {
+    // Median of 3 runs; wall clock on an otherwise idle process. These numbers are
+    // for RELATIVE comparison on one machine, not absolute benchmarks.
+    double best = 1e18;
+    uint32_t outFrames = 0;
+    for (int run = 0; run < 3; ++run) {
+        const auto t0 = std::chrono::steady_clock::now();
+        const Signal out = runOption(o, src, dstRate, spec);
+        const auto t1 = std::chrono::steady_clock::now();
+        outFrames = out.frames();
+        best = std::min(best,
+                        static_cast<double>(
+                            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()));
+    }
+    return outFrames > 0 ? best / static_cast<double>(outFrames) : 0.0;
+}
+
+void runCpuCost(CheckSession& t) {
+    std::printf("\n=== CPU cost (stereo, ns per OUTPUT frame; relative comparison only) ===\n");
+    for (const DownPair& p : kDownPairs) {
+        const Signal src = makeNoise(p.srcRate, p.srcRate * kSeconds, 0xBEEF5EEDull, kAmp);
+        const double baseNs = timeNsPerFrame(Option::Baseline, src, p.dstRate, &p);
+        std::printf("[MEASURE] %s CPU baseline=%.0f ns/frame (%.2f MFrame/s)\n", pairName(p).c_str(), baseNs,
+                    1000.0 / std::max(baseNs, 1e-9));
+        for (Option o : {Option::RatioA64, Option::RatioA128, Option::PrefilterB}) {
+            const double ns = timeNsPerFrame(o, src, p.dstRate, &p);
+            std::printf("[MEASURE] %s CPU %s=%.0f ns/frame (%.2f MFrame/s, %.1fx baseline)\n",
+                        pairName(p).c_str(), optionName(o), ns, 1000.0 / std::max(ns, 1e-9), ns / baseNs);
+            // Sanity ceiling, NOT a benchmark gate: catches accidental O(n^2) or a
+            // debug-quality regression while tolerating machine variance. Measured
+            // ratios (window precomputed): optionA64 5.2-6.6x, optionA128 12.0-13.9x,
+            // optionB 2.1-4.4x baseline (option B's one-time prefilter amortizes over
+            // the whole clip; its steady-state playback cost is EXACTLY baseline).
+            t.expect((pairName(p) + " " + std::string(optionName(o)) + ": CPU within 60x baseline sanity bound")
+                         .c_str(),
+                     ns < baseNs * 60.0,
+                     "ns=" + std::to_string(ns) + " base=" + std::to_string(baseNs));
+        }
+    }
+    std::printf("  NOTE optionB: cost shown includes the one-time prefilter of the whole clip; its\n"
+                "  per-frame playback cost after that is identical to baseline. Memory: one filtered\n"
+                "  copy of the clip (2x clip RAM transient, 1x steady if it replaces the original\n"
+                "  for mismatched-rate sessions). optionA is stateless: zero memory, all CPU — and a\n"
+                "  production version could replace the per-tap std::sin with a rotation recurrence\n"
+                "  (~2 muls/tap), but no CPU work fixes its transition-band folding (see alias set).\n");
+}
+
+// ---- optional external references (never gated) -------------------------------
+
+void runReferences() {
+    std::printf("\n=== external references (diagnostics, not gated) ===\n");
+#if !defined(AESTRA_HAS_LIBSAMPLERATE) && !defined(AESTRA_HAS_SOXR)
+    std::printf("  libsamplerate/soxr not available at configure time; skipped\n");
+#endif
+#ifdef AESTRA_HAS_LIBSAMPLERATE
+    for (const DownPair& p : kDownPairs) {
+        const double f = p.aliasProbesHz[0];
+        const Signal in = makeSine(p.srcRate, p.srcRate * kSeconds, f, kAmp);
+        const double ratio = static_cast<double>(p.dstRate) / p.srcRate;
+        const uint32_t maxOut = static_cast<uint32_t>(std::ceil(p.srcRate * ratio)) + 128;
+        Signal out;
+        out.sampleRate = p.dstRate;
+        out.channels = 2;
+        out.samples.resize(static_cast<size_t>(maxOut) * 2);
+        SRC_DATA data{};
+        data.data_in = in.samples.data();
+        data.data_out = out.samples.data();
+        data.input_frames = static_cast<long>(in.frames());
+        data.output_frames = static_cast<long>(maxOut);
+        data.src_ratio = ratio;
+        data.end_of_input = 1;
+        if (src_simple(&data, SRC_SINC_BEST_QUALITY, 2) == 0) {
+            out.samples.resize(static_cast<size_t>(data.output_frames_gen) * 2);
+            const double aliasDbc = toDb(
+                toneAmplitude(out, 0, p.dstRate - f, kEdgeSkip, out.frames() - kEdgeSkip) / kAmp);
+            std::printf("[REF] libsamplerate BEST %s: alias %.0f Hz = %.1f dBc\n", pairName(p).c_str(),
+                        p.dstRate - f, aliasDbc);
+        }
+    }
+#endif
+#ifdef AESTRA_HAS_SOXR
+    for (const DownPair& p : kDownPairs) {
+        const double f = p.aliasProbesHz[0];
+        const Signal in = makeSine(p.srcRate, p.srcRate * kSeconds, f, kAmp);
+        const uint32_t maxOut =
+            static_cast<uint32_t>(std::ceil(static_cast<double>(p.srcRate) * p.dstRate / p.srcRate)) + 128;
+        Signal out;
+        out.sampleRate = p.dstRate;
+        out.channels = 2;
+        out.samples.resize(static_cast<size_t>(maxOut) * 2);
+        soxr_quality_spec_t qspec = soxr_quality_spec(SOXR_VHQ, 0);
+        soxr_t soxr = soxr_create(p.srcRate, p.dstRate, 2, nullptr, nullptr, &qspec, nullptr);
+        if (soxr != nullptr) {
+            size_t written = 0;
+            if (soxr_process(soxr, in.samples.data(), in.frames(), nullptr, out.samples.data(), maxOut,
+                             &written) == nullptr) {
+                out.samples.resize(written * 2);
+                const double aliasDbc = toDb(
+                    toneAmplitude(out, 0, p.dstRate - f, kEdgeSkip, out.frames() - kEdgeSkip) / kAmp);
+                std::printf("[REF] soxr VHQ %s: alias %.0f Hz = %.1f dBc\n", pairName(p).c_str(),
+                            p.dstRate - f, aliasDbc);
+            }
+            soxr_delete(soxr);
+        }
+    }
+#endif
+}
+
+} // namespace
+
+int main() {
+    std::printf("============================================================\n");
+    std::printf("  Aestra Audio Research Bench — Anti-Alias Policy Lab (Ph.3)\n");
+    std::printf("  Prototype comparison for F1; test-side only, no production\n");
+    std::printf("  DSP is exercised or changed by this binary beyond the\n");
+    std::printf("  baseline kernel replica.\n");
+    std::printf("============================================================\n");
+
+    CheckSession t;
+    runControls(t);
+    for (const DownPair& p : kDownPairs) {
+        measurePair(t, p);
+    }
+    runLengthChecks(t);
+    runCpuCost(t);
+    runReferences();
+    return t.exitCode();
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Audio Research Bench: a **measured product/CPU decision basis** for finding F1 (no clip-resampling path anti-aliases downsampling). Adds `AntiAliasPolicyLab` (test-side prototype comparison, 99 checks, ~16 s) and the policy/decision write-up in `AestraDocs/audio-research-bench.md` §9. **No production DSP is changed** — the decision gate concluded against changing production in this phase.

## What was measured

Two candidate architectures vs the shipped legacy-kernel baseline, on 48→44.1 and 96→48 (plus same-rate and upsampling controls that must null the baseline — and do, ≤ 4.4e-16):

| Probe → fold | Baseline | Option A 64t | Option A 128t | **Option B** | libsamplerate / soxr |
|---|---|---|---|---|---|
| 48→44.1: 22.5 kHz → 21.6 kHz | −0.3 dBc | −10.5 | −17.1 | **−101.5** | — |
| 48→44.1: 23 kHz → 21.1 kHz | −1.1 | −17.8 | −41.9 | **−104.9** | −163.7 / −200.6 |
| 96→48: 25 kHz → 23 kHz | −0.0 | −11.1 | −18.9 | **−105.6** | — |
| 96→48: 30 kHz → 18 kHz | −0.0 | −117.6 | −123.8 | **−117.2** | −143.5 / −160.0 |
| 96→48: 40 kHz → 8 kHz | −0.0 | −133.1 | −136.7 | **−127.7** | — |

Plus per-option DC/gain/passband profiles (all exact except Option A 64t's −0.294 dB droop at 21 kHz), impulse position/spread (all land exactly; Option B's FIR delay compensates precisely, span 73 frames), transient pre-echo (0.0 everywhere), fixed-seed-noise level vs the removed-band bound, bit-determinism, and CPU (Option A 5.2–13.9× baseline on the would-be audio thread; Option B steady-state cost **identical to baseline**, one-time prefilter 2.1–4.4×).

## Decision (§9.5)

- **Option A (integrated cutoff-scaled kernel): rejected on measured quality.** Its transition band folds hot at any practical tap count, and for 48→44.1 the *entire* fold band is transition band — cutoff scaling cannot protect near-unity ratios. No CPU optimization fixes that.
- **Option B (designed Kaiser prefilter at clip load + unchanged interpolator): clear winner** — meets the proposed target (≥95 dB fold rejection, <0.1 dB passband loss) on every probe with zero audio-thread change.
- **No production change in this PR:** a minimal production Option B still needs clip-lifecycle design (filtered-copy management keyed by clip/session rate, rate-change invalidation, memory policy for the 4 GB target). That's the recommended **Phase 4**, specced in §9.6, including exactly how `SessionResamplingTruthTest`'s characterization gates flip when it lands.

## Testing performed

- `cmake --build build-linux -j2`; `AntiAliasPolicyLab` → 99/99 (first run used as measurement, every gate recalibrated to cite measured values; the near-cutoff Option-A failures of the first run became the documented FINDING, not relaxed gates)
- `ctest -L research` → 4/4 (~25 s total)

## Docs updated?

Yes — `AestraDocs/audio-research-bench.md` §9: policy framing (what AA protects against, scenario ranking with 96k-in-48k as the severe case, proposed per-path quality targets), option descriptions, full measurement matrix, CPU/memory table, decision, and the Phase-4 implementation plan. §7/§8.5 follow-up lists updated. Public docs untouched.

## Risk / rollback

- Test-side + internal docs only. No DSP, UI, serialization, or CI-config changes; production behavior is bit-identical.
- Lab runtime ~16 s (research label, timeout 300 s), headless, deterministic; CPU gate is a loose 60× sanity bound, not a benchmark.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes to production DSP: the new anti-alias policy work stays in test/research code and keeps shipped behavior bit-identical.
- Added `Tests/Research/AntiAliasPolicyLab.cpp`, a new research harness that compares downsampling anti-alias approaches against the legacy Sinc64 baseline across identity, downsampling, impulse, transient, determinism, and CPU-cost checks.
- Registered `AntiAliasPolicyLab` in `Tests/CMakeLists.txt`, with optional `libsamplerate`/`soxr` integration when available and CTest labeling/timeouts for the research suite.
- Expanded `AestraDocs/audio-research-bench.md` to document Phase 3 findings, including the measured comparison of Option A vs. Option B, the decision to reject production changes in this phase, and the recommended Phase 4 implementation path.
- Why: to establish a measured basis for choosing the downsampling anti-alias policy before touching production code, and to capture the results and next steps in the research bench docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->