### PR TITLE
feat(audio): anti-alias downsampled clips via worker-thread Kaiser prefilter (Phase 4)

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -180,13 +180,14 @@ set(AESTRA_AUDIO_CORE_SOURCES
     
     # Models
     src/Models/TrackManager.cpp
+    src/Models/ClipPrefilterService.cpp
     src/Models/PlaylistModel.cpp
     src/Models/UnitManager.cpp
     src/Models/PatternManager.cpp
     src/Models/ClipSource.cpp
     src/Models/AudioClip.cpp
     src/Models/PlaylistTrack.cpp
-    
+
     # DSP
     src/DSP/AudioProcessor.cpp
     src/DSP/Filter.cpp
@@ -194,6 +195,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/DSP/ReverbSIMD.cpp
     src/DSP/SincAVX512.cpp
     src/DSP/SampleRateConverter.cpp
+    src/DSP/ClipPrefilter.cpp
     src/DSP/TruePeakMeter.cpp
 
     # IO

--- a/AestraAudio/include/DSP/ClipPrefilter.h
+++ b/AestraAudio/include/DSP/ClipPrefilter.h
@@ -1,0 +1,44 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// ClipPrefilter — anti-alias low-pass for DOWNSAMPLED clip playback (Phase 4, F1).
+//
+// Architecture selected by measurement (AestraDocs/audio-research-bench.md §9,
+// "Option B"): a designed linear-phase Kaiser low-pass applied ONCE to the clip at
+// its source rate, off the audio thread, feeding the existing interpolation kernels
+// unchanged. Spec: passband edge 0.9x destination Nyquist, stopband edge at the
+// destination Nyquist, 100 dB attenuation; odd length; output is compensated by the
+// filter's integer group delay so clip timing does not move. Measured (lab, §9.3):
+// alias rejection -101.5 to -139.1 dBc, passband exact to <0.0001 dB, DC exact.
+//
+// These are pure, deterministic, allocation-explicit functions. They must NEVER be
+// called on the audio thread (ClipPrefilterService owns the worker that runs them).
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace ClipPrefilter {
+
+/// Bump when the filter spec changes so stored filtered copies invalidate.
+constexpr uint32_t kSpecVersion = 1;
+
+/// A clip needs prefiltering only when it will be DOWNSAMPLED into the session.
+inline bool isNeeded(uint32_t sourceRate, uint32_t targetRate) {
+    return sourceRate > 0 && targetRate > 0 && sourceRate > targetRate;
+}
+
+/// Kaiser low-pass design for sourceRate -> targetRate (see spec above).
+/// Returns odd-length coefficients normalized to unity DC gain.
+std::vector<double> design(uint32_t sourceRate, uint32_t targetRate);
+
+/// Apply `h` (odd length, from design()) to interleaved audio, compensating the
+/// integer group delay (taps-1)/2: output frame i is the filtered signal at input
+/// frame i. Same frame count; edges taper as the kernel support leaves the clip.
+/// `out` may not alias `in`.
+void apply(const float* in, float* out, uint64_t frames, uint32_t channels,
+           const std::vector<double>& h);
+
+} // namespace ClipPrefilter
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/ClipPrefilterService.h
+++ b/AestraAudio/include/Models/ClipPrefilterService.h
@@ -1,0 +1,92 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// ClipPrefilterService — background computation of anti-aliased clip copies
+// (Phase 4, F1; design: AestraDocs/clip-prefilter-lifecycle.md).
+//
+// Threading model (deliberately narrow):
+//   * enqueue()/drainCompleted()/waitIdle() are called on the graph-build thread
+//     (TrackManager::ensureClipPrefilters) or another non-audio thread.
+//   * One lazily-started worker thread runs the pure ClipPrefilter math on job
+//     data it OWNS (shared_ptr copies) — it never touches SourceManager/ClipSource
+//     (their containers are not thread-safe), and it never runs on or blocks the
+//     audio thread.
+//   * On completion the worker invokes the (atomic-only) rebuild-request callback
+//     so the app's graph pump picks the filtered copy up on its next drain.
+#pragma once
+
+#include "ClipSource.h"
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <tuple>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+class ClipPrefilterService {
+public:
+    /// `onJobComplete` is invoked FROM THE WORKER THREAD after each finished job;
+    /// it must only touch atomics (TrackManager::requestAudioGraphRebuild is).
+    explicit ClipPrefilterService(std::function<void()> onJobComplete);
+    ~ClipPrefilterService();
+
+    ClipPrefilterService(const ClipPrefilterService&) = delete;
+    ClipPrefilterService& operator=(const ClipPrefilterService&) = delete;
+
+    struct Job {
+        uint64_t sourceId{0};
+        uint64_t contentRevision{0};
+        uint32_t targetRate{0};
+        std::shared_ptr<const AudioBufferData> source; // owned copy; worker-safe
+    };
+
+    struct Result {
+        uint64_t sourceId{0};
+        uint64_t contentRevision{0};
+        uint32_t targetRate{0};
+        uint32_t specVersion{0};
+        std::shared_ptr<AudioBufferData> filtered;
+        double buildMillis{0.0}; // diagnostic, quoted by the research bench
+    };
+
+    /// Queue a job unless the same (sourceId, revision, targetRate) is already
+    /// queued, running, or completed-but-undrained. Starts the worker on first use.
+    void enqueue(Job job);
+
+    /// Move out all completed results (graph-build thread applies them).
+    std::vector<Result> drainCompleted();
+
+    /// True if any job is queued, running, or completed-but-undrained.
+    bool hasWork() const;
+
+    /// Block the CALLING (non-audio) thread until queue and worker are idle.
+    /// Completed results still need drainCompleted() + a graph rebuild to apply.
+    void waitIdle();
+
+private:
+    void workerLoop();
+
+    using Key = std::tuple<uint64_t, uint64_t, uint32_t>;
+
+    std::function<void()> m_onJobComplete;
+
+    mutable std::mutex m_mutex;
+    std::condition_variable m_wakeWorker;
+    std::condition_variable m_idle;
+    std::deque<Job> m_queue;
+    std::vector<Result> m_completed;
+    std::set<Key> m_tracked; // queued + running + undrained keys (dedupe)
+    bool m_running{false};   // a job is being computed right now
+    bool m_shutdown{false};
+    std::thread m_worker;
+    bool m_workerStarted{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/ClipSource.h
+++ b/AestraAudio/include/Models/ClipSource.h
@@ -93,9 +93,12 @@ public:
     // (contentRevision, targetRate, filter spec) key. Produced off the audio
     // thread by ClipPrefilterService; selected by PlaylistModel's runtime
     // snapshot when a clip is DOWNSAMPLED into the session.
-    // THREADING CONTRACT: these fields are read and written ONLY on the
-    // graph-build thread (TrackManager::ensureClipPrefilters / snapshot build) —
-    // the prefilter worker never touches ClipSource. No lock needed.
+    // THREADING CONTRACT: these fields are accessed ONLY on the model thread —
+    // the thread that mutates TrackManager state and pumps graph rebuilds (the
+    // app's main thread). That covers all three touch points: snapshot reads and
+    // ensureClipPrefilters writes (graph build) plus the clearFilteredVariant()
+    // in setBuffer above (import/project-load/record, same thread). The prefilter
+    // WORKER never touches ClipSource. No lock needed under this contract.
 
     /// Filtered copy valid for `targetRate` and the CURRENT buffer content, or null.
     std::shared_ptr<const AudioBufferData> getFilteredBufferFor(uint32_t targetRate) const {

--- a/AestraAudio/include/Models/ClipSource.h
+++ b/AestraAudio/include/Models/ClipSource.h
@@ -82,10 +82,48 @@ public:
         m_buffer = std::move(buffer);
         m_waveformCache.reset();
         ++m_contentRevision;
+        clearFilteredVariant(); // new content invalidates any anti-aliased copy
     }
 
     std::shared_ptr<WaveformCache> getWaveformCache() const { return m_waveformCache; }
     void setWaveformCache(std::shared_ptr<WaveformCache> cache) { m_waveformCache = std::move(cache); }
+
+    // ---- Anti-aliased filtered variant (Phase 4, F1) -------------------------
+    // One optional low-pass-filtered copy of m_buffer, valid for exactly one
+    // (contentRevision, targetRate, filter spec) key. Produced off the audio
+    // thread by ClipPrefilterService; selected by PlaylistModel's runtime
+    // snapshot when a clip is DOWNSAMPLED into the session.
+    // THREADING CONTRACT: these fields are read and written ONLY on the
+    // graph-build thread (TrackManager::ensureClipPrefilters / snapshot build) —
+    // the prefilter worker never touches ClipSource. No lock needed.
+
+    /// Filtered copy valid for `targetRate` and the CURRENT buffer content, or null.
+    std::shared_ptr<const AudioBufferData> getFilteredBufferFor(uint32_t targetRate) const {
+        if (m_filteredBuffer && m_filteredForRate == targetRate &&
+            m_filteredContentRevision == m_contentRevision) {
+            return m_filteredBuffer;
+        }
+        return nullptr;
+    }
+
+    void setFilteredVariant(std::shared_ptr<AudioBufferData> filtered, uint32_t targetRate,
+                            uint64_t contentRevision, uint32_t specVersion) {
+        m_filteredBuffer = std::move(filtered);
+        m_filteredForRate = targetRate;
+        m_filteredContentRevision = contentRevision;
+        m_filteredSpecVersion = specVersion;
+    }
+
+    void clearFilteredVariant() {
+        m_filteredBuffer.reset();
+        m_filteredForRate = 0;
+        m_filteredContentRevision = 0;
+        m_filteredSpecVersion = 0;
+    }
+
+    uint32_t filteredVariantRate() const { return m_filteredForRate; }
+    uint32_t filteredVariantSpec() const { return m_filteredSpecVersion; }
+    bool hasFilteredVariant() const { return m_filteredBuffer != nullptr; }
 
 private:
     ClipSourceID m_id;
@@ -94,6 +132,12 @@ private:
     std::shared_ptr<AudioBufferData> m_buffer;
     std::shared_ptr<WaveformCache> m_waveformCache;
     uint64_t m_contentRevision{0};
+
+    // Filtered-variant slot (see threading contract above).
+    std::shared_ptr<AudioBufferData> m_filteredBuffer;
+    uint32_t m_filteredForRate{0};
+    uint64_t m_filteredContentRevision{0};
+    uint32_t m_filteredSpecVersion{0};
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -422,8 +422,18 @@ public:
                     if (pattern && pattern->isAudio()) {
                         auto& audioPayload = std::get<AudioSlicePayload>(pattern->payload);
                         if (auto* source = sources.getSource(audioPayload.audioSourceId)) {
-                            clipInfo.audioData = const_cast<AudioBufferData*>(source->getRawBuffer());
-                            clipInfo.sharedAudioData = source->getSharedBuffer();
+                            // Phase 4 (F1): prefer the anti-aliased filtered copy when
+                            // this clip is DOWNSAMPLED into the session and the copy is
+                            // ready; otherwise the original buffer (pre-Phase-4 path).
+                            // The filtered copy keeps the SOURCE sample rate, so all
+                            // timing math below is identical either way.
+                            auto renderBuffer = source->getFilteredBufferFor(
+                                static_cast<uint32_t>(m_projectSampleRate));
+                            if (!renderBuffer) {
+                                renderBuffer = source->getSharedBuffer();
+                            }
+                            clipInfo.audioData = const_cast<AudioBufferData*>(renderBuffer.get());
+                            clipInfo.sharedAudioData = renderBuffer;
                             if (clipInfo.audioData) {
                                 clipInfo.sourceSampleRate = clipInfo.audioData->sampleRate;
                                 clipInfo.sourceChannels = clipInfo.audioData->numChannels;

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -12,6 +12,7 @@
 #include "../Playback/TimelineClock.h"
 #include "../RealtimeThreadGuard.h"
 #include "AestraLog.h"
+#include "ClipPrefilterService.h"
 #include "MeterSnapshot.h"
 #include "PatternManager.h"
 #include "PlaylistModel.h"
@@ -63,6 +64,12 @@ public:
         int inputIndex{-1};
         float volume{1.0f};
     };
+
+    /**
+     * @brief Destructor (out-of-line, TrackManager.cpp): documents that the
+     * prefilter worker joins first via member-declaration order.
+     */
+    ~TrackManager();
 
     /**
      * @brief Construct a track manager and wire its internal playback helpers.
@@ -1522,6 +1529,26 @@ private:
     bool m_recordingSessionUsesPlacementOverride{false};
     bool m_recordingNoArmLogged{false};
     std::string m_recordingProjectPath;
+
+    // Anti-aliased clip prefiltering (Phase 4, F1; AestraDocs/clip-prefilter-lifecycle.md).
+    // Declared LAST so it is destroyed FIRST: the worker joins while every member its
+    // completion callback touches (the graph-dirty atomics above) is still alive.
+    std::unique_ptr<ClipPrefilterService> m_clipPrefilterService;
+
+public:
+    /**
+     * @brief Drain finished anti-alias prefilter results into their sources, clear
+     * stale filtered variants, and queue missing work for downsampled clips.
+     * Called by AudioGraphBuilder before every runtime snapshot (graph-build thread).
+     */
+    void ensureClipPrefilters();
+
+    /**
+     * @brief Block the calling NON-AUDIO thread until all queued prefilter jobs are
+     * done, then apply them. Deterministic completion for offline render and tests.
+     * A graph rebuild is still required for the engine to pick the copies up.
+     */
+    void waitForClipPrefilters();
 };
 
 } // namespace Audio

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -122,6 +122,11 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
 }
 
 AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) {
+    // Phase 4 (F1): apply finished anti-alias prefilter results and queue missing
+    // work for downsampled clips BEFORE the snapshot resolves clip buffers, so this
+    // build picks up every copy that is ready (never blocks; fallback = original).
+    trackManager.ensureClipPrefilters();
+
     AudioGraph graph;
     const size_t channelCount = trackManager.getChannelCount();
     graph.tracks.reserve(channelCount);

--- a/AestraAudio/src/DSP/ClipPrefilter.cpp
+++ b/AestraAudio/src/DSP/ClipPrefilter.cpp
@@ -1,0 +1,78 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+#include "DSP/ClipPrefilter.h"
+
+#include "DSP/Interpolators.h" // PI, sinc(), kaiserWindow()
+
+#include <algorithm>
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+namespace ClipPrefilter {
+
+namespace {
+constexpr double kAttenDb = 100.0;
+constexpr double kPassbandFraction = 0.9; // passband edge as a fraction of dst Nyquist
+} // namespace
+
+std::vector<double> design(uint32_t sourceRate, uint32_t targetRate) {
+    std::vector<double> h;
+    if (!isNeeded(sourceRate, targetRate)) {
+        return h;
+    }
+    const double passHz = kPassbandFraction * 0.5 * static_cast<double>(targetRate);
+    const double stopHz = 0.5 * static_cast<double>(targetRate);
+
+    // Textbook Kaiser design: beta = 0.1102(A - 8.7) for A > 50 dB,
+    // N ~= (A - 7.95) / (2.285 * transitionWidthRadians), odd length so the group
+    // delay (taps-1)/2 is an integer and apply() can compensate it exactly.
+    const double dOmega = 2.0 * Interpolators::PI * (stopHz - passHz) / static_cast<double>(sourceRate);
+    int taps = static_cast<int>(std::ceil((kAttenDb - 7.95) / (2.285 * dOmega))) + 1;
+    if ((taps % 2) == 0) {
+        ++taps;
+    }
+    const double beta = 0.1102 * (kAttenDb - 8.7);
+    const double fc = 0.5 * (passHz + stopHz) / static_cast<double>(sourceRate); // cycles/sample
+    const int mid = (taps - 1) / 2;
+
+    h.resize(static_cast<size_t>(taps));
+    double sum = 0.0;
+    for (int i = 0; i < taps; ++i) {
+        const double x = static_cast<double>(i - mid);
+        const double v = 2.0 * fc * Interpolators::sinc(2.0 * fc * x) *
+                         Interpolators::kaiserWindow(static_cast<double>(i), static_cast<double>(taps), beta);
+        h[static_cast<size_t>(i)] = v;
+        sum += v;
+    }
+    for (double& v : h) {
+        v /= sum; // unity DC gain, exactly (matches the legacy kernel's normalization policy)
+    }
+    return h;
+}
+
+void apply(const float* in, float* out, uint64_t frames, uint32_t channels, const std::vector<double>& h) {
+    if (in == nullptr || out == nullptr || frames == 0 || channels == 0 || h.empty()) {
+        return;
+    }
+    const int taps = static_cast<int>(h.size());
+    const int mid = (taps - 1) / 2;
+    const int64_t n = static_cast<int64_t>(frames);
+    for (int64_t i = 0; i < n; ++i) {
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            double acc = 0.0;
+            for (int k = 0; k < taps; ++k) {
+                const int64_t j = i + mid - k; // delay-compensated read
+                if (j < 0 || j >= n) {
+                    continue;
+                }
+                acc += h[static_cast<size_t>(k)] *
+                       static_cast<double>(in[(static_cast<uint64_t>(j) * channels) + ch]);
+            }
+            out[(static_cast<uint64_t>(i) * channels) + ch] = static_cast<float>(acc);
+        }
+    }
+}
+
+} // namespace ClipPrefilter
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Models/ClipPrefilterService.cpp
+++ b/AestraAudio/src/Models/ClipPrefilterService.cpp
@@ -1,0 +1,128 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+#include "Models/ClipPrefilterService.h"
+
+#include "DSP/ClipPrefilter.h"
+
+#include <chrono>
+#include <utility>
+
+namespace Aestra {
+namespace Audio {
+
+ClipPrefilterService::ClipPrefilterService(std::function<void()> onJobComplete)
+    : m_onJobComplete(std::move(onJobComplete)) {}
+
+ClipPrefilterService::~ClipPrefilterService() {
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_shutdown = true;
+    }
+    m_wakeWorker.notify_all();
+    if (m_worker.joinable()) {
+        m_worker.join();
+    }
+}
+
+void ClipPrefilterService::enqueue(Job job) {
+    if (!job.source || !job.source->isValid() ||
+        !ClipPrefilter::isNeeded(job.source->sampleRate, job.targetRate)) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_shutdown) {
+            return;
+        }
+        const Key key{job.sourceId, job.contentRevision, job.targetRate};
+        if (m_tracked.count(key) != 0) {
+            return; // already queued, running, or awaiting drain
+        }
+        m_tracked.insert(key);
+        m_queue.push_back(std::move(job));
+        if (!m_workerStarted) {
+            m_worker = std::thread(&ClipPrefilterService::workerLoop, this);
+            m_workerStarted = true;
+        }
+    }
+    m_wakeWorker.notify_one();
+}
+
+std::vector<ClipPrefilterService::Result> ClipPrefilterService::drainCompleted() {
+    std::vector<Result> out;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    out.swap(m_completed);
+    for (const Result& r : out) {
+        m_tracked.erase(Key{r.sourceId, r.contentRevision, r.targetRate});
+    }
+    return out;
+}
+
+bool ClipPrefilterService::hasWork() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return !m_queue.empty() || m_running || !m_completed.empty();
+}
+
+void ClipPrefilterService::waitIdle() {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_idle.wait(lock, [this] { return (m_queue.empty() && !m_running) || m_shutdown; });
+}
+
+void ClipPrefilterService::workerLoop() {
+    for (;;) {
+        Job job;
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_wakeWorker.wait(lock, [this] { return m_shutdown || !m_queue.empty(); });
+            if (m_shutdown) {
+                m_idle.notify_all();
+                return;
+            }
+            job = std::move(m_queue.front());
+            m_queue.pop_front();
+            m_running = true;
+        }
+
+        // Pure math on worker-owned data; no model access, no audio-thread contact.
+        const auto t0 = std::chrono::steady_clock::now();
+        Result result;
+        result.sourceId = job.sourceId;
+        result.contentRevision = job.contentRevision;
+        result.targetRate = job.targetRate;
+        result.specVersion = ClipPrefilter::kSpecVersion;
+        const std::vector<double> h = ClipPrefilter::design(job.source->sampleRate, job.targetRate);
+        if (!h.empty()) {
+            auto filtered = std::make_shared<AudioBufferData>();
+            filtered->sampleRate = job.source->sampleRate; // filtering does NOT resample
+            filtered->numChannels = job.source->numChannels;
+            filtered->numFrames = job.source->numFrames;
+            filtered->interleavedData.resize(job.source->interleavedData.size());
+            ClipPrefilter::apply(job.source->interleavedData.data(), filtered->interleavedData.data(),
+                                 job.source->numFrames, job.source->numChannels, h);
+            result.filtered = std::move(filtered);
+        }
+        result.buildMillis =
+            std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+                std::chrono::steady_clock::now() - t0)
+                .count();
+
+        bool notify = false;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_running = false;
+            if (result.filtered) {
+                m_completed.push_back(std::move(result));
+                notify = true;
+            } else {
+                // Nothing produced (spec said not needed): stop tracking the key.
+                m_tracked.erase(Key{job.sourceId, job.contentRevision, job.targetRate});
+            }
+        }
+        m_idle.notify_all();
+        if (notify && m_onJobComplete) {
+            m_onJobComplete(); // atomic-only by contract (graph dirty request)
+        }
+    }
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Models/TrackManager.cpp
+++ b/AestraAudio/src/Models/TrackManager.cpp
@@ -1,11 +1,97 @@
 #include "TrackManager.h"
+
+#include "ClipPrefilterService.h"
+#include "DSP/ClipPrefilter.h"
+
 namespace Aestra {
 namespace Audio {
+
+// Out-of-line: m_clipPrefilterService is a unique_ptr to a type that is only
+// forward-declared in the header. It is the LAST declared member, so it is
+// destroyed FIRST here — the worker joins while the graph-dirty atomics its
+// completion callback touches are still alive.
+TrackManager::~TrackManager() = default;
 
 void TrackManager::rebuildAndPushSnapshot() {
     // Effect chain snapshots are retrieved during graph building (AudioGraphBuilder::buildFromTrackManager)
     // via getSnapshot(). Dirty state is consumed by PlaybackGraphController::consumePendingGraphRebuild().
     // This method is kept as a post-graph-rebuild hook for existing callers.
+}
+
+void TrackManager::ensureClipPrefilters() {
+    // Graph-build thread only (see the ClipSource threading contract).
+    const double projectRate = m_playlistModel.getProjectSampleRate();
+    const uint32_t targetRate = projectRate > 0.0 ? static_cast<uint32_t>(projectRate) : 0;
+
+    // 1. Apply finished results whose key still matches the live state.
+    if (m_clipPrefilterService) {
+        for (auto& result : m_clipPrefilterService->drainCompleted()) {
+            ClipSource* source = m_sourceManager.getSource(ClipSourceID{result.sourceId});
+            if (source == nullptr || !result.filtered) {
+                continue;
+            }
+            if (source->getContentRevision() != result.contentRevision ||
+                result.targetRate != targetRate ||
+                result.specVersion != ClipPrefilter::kSpecVersion) {
+                continue; // stale (buffer replaced / rate changed since enqueue) — discard
+            }
+            source->setFilteredVariant(std::move(result.filtered), result.targetRate,
+                                       result.contentRevision, result.specVersion);
+        }
+    }
+
+    if (targetRate == 0) {
+        return;
+    }
+
+    // 2. Clear stale variants; queue missing work for downsampled sources.
+    for (const ClipSourceID id : m_sourceManager.getAllSourceIDs()) {
+        ClipSource* source = m_sourceManager.getSource(id);
+        if (source == nullptr) {
+            continue;
+        }
+        const auto buffer = source->getBuffer();
+        const bool needed =
+            buffer && buffer->isValid() && ClipPrefilter::isNeeded(buffer->sampleRate, targetRate);
+
+        if (!needed) {
+            if (source->hasFilteredVariant()) {
+                source->clearFilteredVariant(); // rate no longer qualifies — free the copy
+            }
+            continue;
+        }
+        if (source->hasFilteredVariant() && !source->getFilteredBufferFor(targetRate)) {
+            source->clearFilteredVariant(); // keyed for an old rate/content — free it
+        }
+        if (source->filteredVariantSpec() != 0 &&
+            source->filteredVariantSpec() != ClipPrefilter::kSpecVersion) {
+            source->clearFilteredVariant(); // filter spec changed
+        }
+        if (source->getFilteredBufferFor(targetRate)) {
+            continue; // ready
+        }
+
+        if (!m_clipPrefilterService) {
+            // Completion callback: atomic-only graph-dirty request (thread-safe from
+            // the worker), so the app's graph pump applies the copy on next drain.
+            m_clipPrefilterService = std::make_unique<ClipPrefilterService>(
+                [this] { requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged); });
+        }
+        ClipPrefilterService::Job job;
+        job.sourceId = id.value;
+        job.contentRevision = source->getContentRevision();
+        job.targetRate = targetRate;
+        job.source = source->getSharedBuffer();
+        m_clipPrefilterService->enqueue(std::move(job)); // dedupes internally
+    }
+}
+
+void TrackManager::waitForClipPrefilters() {
+    if (!m_clipPrefilterService) {
+        return;
+    }
+    m_clipPrefilterService->waitIdle();
+    ensureClipPrefilters(); // apply the drained results deterministically
 }
 
 } // namespace Audio

--- a/AestraDocs/audio-research-bench.md
+++ b/AestraDocs/audio-research-bench.md
@@ -6,7 +6,9 @@ does not use Sinc64Turbo at all. Phase 2E complete (2026-07-07): isolated-track
 bounce kernel unified with mainline (**F6 resolved**, §8.3). Phase 3 complete
 (2026-07-07): downsampling anti-alias policy + prototype comparison (§9) —
 **decision: no production change yet; Option B (prefilter-at-load) is the measured
-winner and the recommended Phase 4 implementation.**
+winner and the recommended Phase 4 implementation.** Phase 4 complete (2026-07-07):
+clip prefilter implemented — **F1 resolved on the mainline paths** (§10; aliases now
+−104.9/−117.2 dBc, were −1.1/−0.0).
 Code: `Tests/Research/` (`SignalLab.h`, `AudioMeasure.h`, `MeasurementCoreSelfTest.cpp`,
 `ResamplerQualityAuditTest.cpp`, `SessionResamplingTruthTest.cpp`,
 `AntiAliasPolicyLab.cpp`). CTest labels: `research`, `audio-research`.
@@ -521,3 +523,69 @@ Implement Option B as **prefilter-at-load** behind the existing quality semantic
    already exist. `RTAllocationTrapTest` already fails the build if the filtering
    ever lands on the audio thread.
 5. Out of scope for Phase 4, revisit after: preview path (F7) and sampler (F8).
+
+---
+
+## 10. Phase 4 — downsampled-clip Kaiser prefilter (implemented 2026-07-07)
+
+Production implementation of §9's Option B. Lifecycle design (ownership, keying,
+invalidation, memory, fallback): `AestraDocs/clip-prefilter-lifecycle.md`.
+
+**What changed in production:** `DSP/ClipPrefilter` (Kaiser design + delay-compensated
+apply, pure functions), `ClipPrefilterService` (one lazily-started worker thread; jobs
+own their data; completion raises the atomic graph-dirty flag), a filtered-variant
+slot on `ClipSource` (graph-build-thread only), `TrackManager::ensureClipPrefilters/
+waitForClipPrefilters`, one selection point in `PlaylistModel::buildRuntimeSnapshot`
+(prefer the filtered copy when a clip is downsampled and the copy is ready), and the
+enqueue hook in `AudioGraphBuilder::buildFromTrackManager`. The interpolation kernels
+are untouched; the audio thread is untouched (no filtering, allocation, locking,
+logging, or blocking was added to it).
+
+### 10.1 Before → after (measured through real sessions, `SessionResamplingTruthTest`)
+
+| Scenario | Before (F1) | **After (Phase 4)** |
+| --- | --- | --- |
+| 48k clip in 44.1k session, 23 kHz probe → 21.1 kHz alias | −1.10 dBc | **−104.91 dBc** |
+| 96k clip in 48k session, 30 kHz probe → 18 kHz alias | −0.00 dBc | **−117.24 dBc** |
+| 44.1k in 48k (upsampling control) | −21.69 dBc image | −21.69 dBc (unchanged) |
+| 48k in 96k (upsampling control) | −63.29 dBc image | −63.29 dBc (unchanged) |
+| Same-rate control | exact | exact (unchanged) |
+
+Everything else re-proven end-to-end: 1 kHz gain matches control to 0.000000 dB and
+SINAD stays 146.5–153.9 dB (the prefilter is passband-exact); DC exact; clip length
+truth witnessed on the in-band tone; impulses land on the exact mapped frame (the
+FIR's integer group delay is compensated exactly; −60 dB span 73 output frames on
+96→48, the designed transition's time-domain cost); session renders null the
+production-prefilter + legacy-kernel replica at −153.6 to −275.6 dB RMS; full-mix
+export nulls realtime at −164/−175 dB with identical artifact levels (parity
+preserved by construction — one snapshot feeds playback, export, and isolated
+bounce). A dedicated transition case proves the non-blocking fallback: the first
+graph build renders unfiltered (−1.10 dBc) while the worker runs, and after
+completion + rebuild the same session measures −104.91 dBc.
+
+### 10.2 Cost
+
+CPU: one-time per clip per session rate, on the worker thread — the lab's measured
+prefilter pass is ~1–2 ms per second of clip audio (§9.4); steady-state playback
+cost is exactly the pre-Phase-4 cost (same kernels, same per-voice loop). Memory:
+one filtered copy per DOWNSAMPLED source at the current session rate (2× RAM for
+those clips only; cleared automatically when the rate stops qualifying; eviction
+policy deliberately deferred — see the lifecycle doc §6).
+
+### 10.3 Covered / uncovered
+
+Covered: realtime playback, full-mix export, isolated-track bounce — every path
+that reads the runtime snapshot. Uncovered (unchanged, documented): PreviewEngine
+(F7, own Cubic pipeline), SamplerPlugin pitch-up (F8), AuditionEngine, and exports
+at a rate different from the session rate (the exporter renders the current graph;
+pre-existing behavior). **F1 is resolved for the mainline paths.**
+
+### 10.4 Remaining risks / follow-ups
+
+* Filtered copies double RAM for downsampled clips; revisit with an eviction cap if
+  real sessions show pressure (lifecycle doc §6).
+* The graph pump (`PlaybackGraphController::drainIfDirty`) applies finished copies;
+  a headless embedder that never drains would stay on the fallback path (tests use
+  `waitForClipPrefilters()`).
+* Preview/sampler/audition still alias (F7/F8) — fold into this policy or document
+  as tiers, per §8.5(3).

--- a/AestraDocs/clip-prefilter-lifecycle.md
+++ b/AestraDocs/clip-prefilter-lifecycle.md
@@ -31,8 +31,12 @@ source buffers into the runtime snapshot — that is the natural selection point
 
 * Storage: `ClipSource` gains one filtered slot
   (`m_filteredBuffer` + key fields). Exactly one filtered variant per source —
-  the current session rate only. The slot is only ever read/written on the
-  graph-build thread (see §7), so it needs no lock.
+  the current session rate only. The slot is accessed only on the MODEL thread
+  (the thread that mutates TrackManager state and pumps graph rebuilds — the
+  app's main thread): snapshot reads and `ensureClipPrefilters` writes at graph
+  build, plus the invalidating `clearFilteredVariant()` inside `setBuffer`
+  (import / project load / recorded takes, same thread). The prefilter worker
+  never touches it, so no lock is needed under this contract.
 * Computation: a new `ClipPrefilterService` (owned by `TrackManager`, declared
   as its last member so it shuts down first): one lazily-started worker thread
   with a mutex/cv job queue. The worker runs pure DSP on its own owned copies

--- a/AestraDocs/clip-prefilter-lifecycle.md
+++ b/AestraDocs/clip-prefilter-lifecycle.md
@@ -1,0 +1,125 @@
+# Clip Prefilter Lifecycle Design (Phase 4, F1 fix)
+
+Status: implemented 2026-07-07 (this document is the pre-implementation plan the
+mission required; measured results live in `audio-research-bench.md` §10).
+Scope: downsampled clip anti-aliasing via the Phase-3 Option B architecture —
+a designed Kaiser low-pass applied ONCE off the audio thread, feeding the
+existing render kernels unchanged.
+
+## 1. Where decoded clip audio lives now
+
+`AudioBufferData` (interleaved float + sampleRate/channels/frames,
+`Models/ClipSource.h:30`) owned as `shared_ptr` by `ClipSource::m_buffer`,
+inside `SourceManager` (a `TrackManager` member). Producers — all non-audio
+threads: sample import (`AestraContent.cpp:3310`, synchronous decode on the
+main thread), project load (`ProjectSerializer.cpp:1313`), recorded takes
+(`SourceManager::createRecordedSource`). Live render graphs co-own buffers via
+`ClipRenderState::bufferOwner` (`AudioGraphBuilder.cpp:189`), so buffer
+replacement never invalidates an in-flight graph.
+
+## 2. Where the rates become known
+
+Source rate: `AudioBufferData::sampleRate`, fixed at decode (native rate; no
+import-time resampling). Session/output rate: `TrackManager::setOutputSampleRate`
+→ `PlaylistModel::m_projectSampleRate` (callers: `AestraAudioController.cpp:342`,
+`AestraApp.cpp:772`, `HeadlessMain.cpp:351`, and `AudioExporter.cpp:203/277`
+temporarily around an export). The two meet in
+`PlaylistModel::buildRuntimeSnapshot` (`PlaylistModel.h:411+`), which resolves
+source buffers into the runtime snapshot — that is the natural selection point.
+
+## 3. Ownership of filtered copies
+
+* Storage: `ClipSource` gains one filtered slot
+  (`m_filteredBuffer` + key fields). Exactly one filtered variant per source —
+  the current session rate only. The slot is only ever read/written on the
+  graph-build thread (see §7), so it needs no lock.
+* Computation: a new `ClipPrefilterService` (owned by `TrackManager`, declared
+  as its last member so it shuts down first): one lazily-started worker thread
+  with a mutex/cv job queue. The worker runs pure DSP on its own owned copies
+  and NEVER touches `SourceManager`/`ClipSource` (the source map is not
+  thread-safe); completed results are drained back on the graph-build thread.
+* DSP: `DSP/ClipPrefilter.{h,cpp}` pure functions — the Phase-3 Option B
+  design: Kaiser low-pass, passband edge 0.9× destination Nyquist, stopband
+  edge at destination Nyquist, 100 dB attenuation, odd length, delay-compensated
+  by its integer group delay, double-precision accumulation.
+
+## 4. Keying
+
+`(ClipSourceID, ClipSource::contentRevision, source sampleRate, target/session
+rate, kClipPrefilterSpecVersion)`. Channel count is implicit in the buffer.
+Quality tier is deliberately NOT part of the key: prefiltering happens upstream
+of every interpolation kernel and applies uniformly to all tiers.
+
+## 5. Invalidation
+
+Stale = key mismatch, evaluated lazily at graph-build time (no observers):
+
+| Event | Effect |
+| --- | --- |
+| Session rate change | next `ensureClipPrefilters()` sees `filteredRate != projectRate` → slot cleared, falls back to original, re-enqueues if still downsampling; if new rate ≥ source rate the slot is simply cleared |
+| Clip source replacement / decoder reload | `setBuffer` bumps `contentRevision` → key mismatch; worker results carrying an old revision are discarded at drain time |
+| Quality setting change | no-op (not keyed) |
+| Project reload | `SourceManager::clear()` destroys sources and their filtered slots naturally |
+
+## 6. Memory policy (4 GB target)
+
+A filtered copy is the same size as its source (same rate/channels/float). Only
+sources with `sourceRate > sessionRate` get one → 2× RAM for downsampled clips
+only, 1× for everything else. Worst-case example: a 4-minute 96 kHz stereo clip
+≈ 184 MB → +184 MB. No eviction in this phase: invalidation already drops
+copies that stop qualifying, and typical 4 GB-machine sessions are not built
+from long 96 kHz sources. A size-capped eviction policy is the documented
+follow-up if telemetry ever shows pressure. ("Replace the original" was
+rejected: the original serves waveform UI and future rate changes, and
+replacing it would change `ClipSource` semantics — a bigger, riskier PR.)
+
+## 7. Fallback while the filtered copy is not ready
+
+`buildRuntimeSnapshot` prefers a ready, key-matching filtered buffer and
+otherwise uses the original — i.e. exactly the pre-Phase-4 render path. Nothing
+blocks anywhere; the audio thread never learns the service exists (graphs swap
+atomically as today). When a job completes, the worker calls
+`requestAudioGraphRebuild(...)` — fully atomic (`TrackManager.h:810`) — so the
+app's `PlaybackGraphController::drainIfDirty` pump rebuilds with the filtered
+copy in place. Deterministic completion for offline/export/tests:
+`TrackManager::waitForClipPrefilters()` blocks the CALLING (non-audio) thread
+until the queue is idle.
+
+## 8. Render integration points
+
+Exactly ONE selection point: the buffer resolution in
+`PlaylistModel::buildRuntimeSnapshot`. Realtime playback (`renderGraph`),
+full-mix export (`AudioExporter` → the same `processBlock`), and isolated-track
+bounce (`AudioRenderer`, same compiled graph) all consume that snapshot —
+**parity is preserved by construction**. The enqueue hook is
+`AudioGraphBuilder::buildFromTrackManager` → `TrackManager::ensureClipPrefilters()`
+(drains completed results into sources, clears stale slots, enqueues missing
+work, dedupes in-flight keys) before the snapshot is taken. The filtered buffer
+keeps the SOURCE sample rate (filtering does not resample), so
+`clip.sourceSampleRate`, `sampleOffset`, and all timing math are unchanged.
+Export at a different rate than the session: the exporter renders the engine's
+CURRENT graph (it does not rebuild at the export rate), so this pre-existing
+edge keeps its pre-Phase-4 behavior and is documented as uncovered rather than
+half-fixed; exports at the session rate — the `bounceRangeToWav` case all
+parity tests exercise — inherit the filtered copies from the live graph.
+
+## 9. Tests
+
+Before implementation (baseline, all green on develop@5761b370): research suite
+4/4, `ctest -L audio` 59/59. After:
+
+* `SessionResamplingTruthTest`: downsampling pairs wait for prefilters +
+  rebuild, then the alias gates flip from "KNOWN LIMITATION −1.1/−0.0 dBc" to
+  **< −95 dBc**; identity nulls compare against a
+  production-`ClipPrefilter` + legacy-interpolator replica; same-rate,
+  upsampling, control, export-parity and isolated-bounce unification gates all
+  stay as-is (proving no behavior change where none is intended).
+* `RTAllocationTrapTest`: stays green (the worker never touches the audio
+  thread; the audio callback path is unmodified).
+* Parity tests (`RealtimeExportParityTest`, `ExportBounceParityTest`,
+  Arsenal export tests): stay green unchanged.
+* Full `ctest -L audio` sweep before push.
+
+Out of scope (documented uncovered paths): PreviewEngine (F7), SamplerPlugin
+(F8), AuditionEngine — they own separate buffers/pipelines and keep their
+current behavior.

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -14,6 +14,11 @@
 //      (AudioEngine.cpp:2326, per-sample double-precision Kaiser sinc, no LUT) —
 //      NOT Sinc64Turbo. Phase 1's ~88 dB LUT-quantization floor therefore does NOT
 //      apply to mainline playback, which measures ~146-154 dB here.
+//      Phase 4: DOWNSAMPLED clips are additionally anti-aliased by the ClipPrefilter
+//      pipeline (worker-thread Kaiser low-pass at clip load / rate change; see
+//      AestraDocs/clip-prefilter-lifecycle.md) — the F1 downsampling gates in this
+//      test flipped from "KNOWN LIMITATION" to "< -95 dBc", and a dedicated case
+//      proves the non-blocking fallback (unfiltered until the copy is ready).
 //   2. Offline full-mix export: AudioEngine::bounceRangeToWav(trackId=-1) ->
 //      AudioExporter -> the same processBlock/renderGraph at a 4096-frame block size,
 //      written as Float_32. Same legacy kernel; proven sample-identical to realtime.
@@ -50,6 +55,7 @@
 
 #include "GoldenAudio/GoldenAudioHarness.h"
 
+#include "DSP/ClipPrefilter.h"
 #include "DSP/Interpolators.h"
 #include "DSP/PanLaw.h"
 #include "IO/MiniAudioDecoder.h"
@@ -117,10 +123,16 @@ void addAudioTrackAtRate(TrackManager& tm, const std::string& label, const AR::S
 }
 
 std::shared_ptr<TrackManager> buildSession(const std::string& label, const AR::Signal& clip,
-                                           const GA::SessionConfig& cfg) {
+                                           const GA::SessionConfig& cfg, bool waitForPrefilters = true) {
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
     addAudioTrackAtRate(*tm, label, clip, cfg);
+    if (waitForPrefilters) {
+        // Phase 4: queue + deterministically complete the anti-alias prefilter for
+        // downsampled clips before any render (no-op for same-rate/upsampling).
+        tm->ensureClipPrefilters();
+        tm->waitForClipPrefilters();
+    }
     return tm;
 }
 
@@ -174,6 +186,19 @@ AR::Signal resampleViaInterpolator(InterpFn fn, const AR::Signal& src, uint32_t 
     return out;
 }
 
+/// The Phase-4 anti-alias step, applied via the PRODUCTION ClipPrefilter functions:
+/// what a downsampled clip's buffer contains by the time the interpolator reads it.
+/// Returns the input unchanged when no prefilter applies (same-rate/upsampling).
+AR::Signal prefilterReplica(const AR::Signal& clip, uint32_t sessionRate) {
+    if (!ClipPrefilter::isNeeded(clip.sampleRate, sessionRate)) {
+        return clip;
+    }
+    const std::vector<double> h = ClipPrefilter::design(clip.sampleRate, sessionRate);
+    AR::Signal out = clip;
+    ClipPrefilter::apply(clip.samples.data(), out.samples.data(), clip.frames(), clip.channels, h);
+    return out;
+}
+
 /// Window [start, end) of a signal as a standalone Signal (for interior-only diffs).
 AR::Signal window(const AR::Signal& s, uint32_t startFrame, uint32_t endFrame) {
     AR::Signal w;
@@ -208,10 +233,15 @@ struct SessionPair {
 };
 
 const SessionPair kSessionPairs[] = {
-    // src     session   probe    artifact  down   turbo   ceiling (measured session: -21.7 / -1.1 / -0.0 / -63.3 dBc)
+    // src     session   probe    artifact  down   turbo   ceiling
+    // Upsampling ceilings unchanged (measured session: -21.7 / -63.3 dBc).
+    // Downsampling ceilings are the Phase-4 target: the clip prefilter must hold
+    // aliases below -95 dBc (measured through real sessions: -104.9 / -117.3 dBc;
+    // pre-Phase-4 these folded at -1.1 / -0.0 dBc — finding F1, now resolved on
+    // the mainline path).
     {44100, 48000, 21000.0, 23100.0, false, -21.7, -18.0},
-    {48000, 44100, 23000.0, 21100.0, true, -1.1, 1.0},
-    {96000, 48000, 30000.0, 18000.0, true, -0.0, 1.0},
+    {48000, 44100, 23000.0, 21100.0, true, -1.1, -95.0},
+    {96000, 48000, 30000.0, 18000.0, true, -0.0, -95.0},
     {48000, 96000, 21600.0, 26400.0, false, -60.5, -60.0},
 };
 
@@ -353,7 +383,8 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
         std::printf("[MEASURE] %s 1kHz gain=%.9f (vs control %+.6f dB), sinad=%.1f dB\n", name.c_str(), gain,
                     gainVsControlDb, fit.sinadDb);
         // Gate 0.05 dB vs control: Phase 1 measured interpolator passband gain exact
-        // to <1e-5 dB; the session must not add level error on top.
+        // to <1e-5 dB, and the Phase-4 clip prefilter is passband-exact to <0.0001 dB
+        // (lab §9.3); the session must not add level error on top.
         t.expect((name + ": 1 kHz level matches control within 0.05 dB").c_str(),
                  std::abs(gainVsControlDb) < 0.05, "deltaDb=" + std::to_string(gainVsControlDb));
         // FINDING + gate 140 dB: measured 149.3 / 146.5 / 153.9 / 147.1 dB across the
@@ -361,8 +392,29 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
         // (AudioEngine.cpp:2326), so it does NOT have Sinc64Turbo's ~88 dB LUT floor.
         // This gate deliberately fails if mainline clip rendering is ever switched to
         // the Turbo kernel (which would be a real, measurable quality regression).
+        // (Unaffected by the Phase-4 prefilter: 1 kHz is deep in its passband.)
         t.expect((name + ": 1 kHz residual SINAD > 140 dB (legacy exact-sinc kernel)").c_str(),
                  fit.sinadDb > 140.0, "sinadDb=" + std::to_string(fit.sinadDb));
+
+        // ---- length truth on the in-band tone (survives the anti-alias filter) ----
+        const double postPeak = AR::peak(out, -1, outClipFrames + 256, out.frames());
+        int64_t lastAudible = -1;
+        for (uint32_t i = outClipFrames + 255; i > 0; --i) {
+            if (std::abs(out.at(i, 0)) > 1e-4 || std::abs(out.at(i, 1)) > 1e-4) {
+                lastAudible = i;
+                break;
+            }
+        }
+        std::printf("[MEASURE] %s length: clip end expect frame %u, last audible=%lld, post-clip peak=%.2e\n",
+                    name.c_str(), outClipFrames, static_cast<long long>(lastAudible), postPeak);
+        t.expect((name + ": tone reaches the clip end (within edge fade)").c_str(),
+                 lastAudible >= static_cast<int64_t>(outClipFrames) - 130 &&
+                     lastAudible <= static_cast<int64_t>(outClipFrames) + 2,
+                 "lastAudible=" + std::to_string(lastAudible) + " expectedEnd=" + std::to_string(outClipFrames));
+        // Gate 1e-5: measured post-clip peak is exactly 0 (renderer writes silence
+        // past clip.endSample).
+        t.expect((name + ": silence after clip end").c_str(), postPeak < 1e-5,
+                 "postPeak=" + std::to_string(postPeak));
     }
 
     // ---- near-Nyquist probe: artifact level + IDENTITY null vs isolated replica ----
@@ -377,43 +429,41 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
         // chain (clip amp * pan gain), matching Phase 1's dBc-vs-input convention.
         const double artifactDbc = AR::toDb(artifactAmp / (kAmp * panGain));
 
-        // Isolated replica of the MAINLINE kernel (legacy Sinc64Interpolator), measured
-        // live with the same window — the headline isolated-vs-full-session agreement
-        // figure. The Sinc64Turbo replica (what Phase 1 audited, and what the
-        // isolated-track bounce path still uses) is printed alongside as the
-        // kernel-split delta.
+        // Isolated replica of the MAINLINE pipeline: the PRODUCTION clip prefilter
+        // (downsampling pairs only; identity otherwise) followed by the legacy
+        // exact-sinc kernel — measured live with the same window. This is the
+        // headline isolated-vs-full-session agreement figure.
+        const AR::Signal filteredClip = prefilterReplica(clip, p.sessionRate);
         const AR::Signal isolated =
-            resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, clip, p.sessionRate);
+            resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, filteredClip, p.sessionRate);
         const double isoArtifactAmp = AR::toneAmplitude(isolated, 0, p.artifactHz, kWinSkip, winEnd);
         const double isoArtifactDbc = AR::toDb(isoArtifactAmp / kAmp);
-        const AR::Signal turbo =
-            resampleViaInterpolator(Interp::Sinc64Turbo::interpolate, clip, p.sessionRate);
-        const double turboArtifactDbc =
-            AR::toDb(AR::toneAmplitude(turbo, 0, p.artifactHz, kWinSkip, winEnd) / kAmp);
 
         std::printf("[MEASURE] %s probe %.0f Hz -> artifact %.0f Hz: session=%.2f dBc, "
-                    "isolated(legacy)=%.2f dBc (delta %.3f dB) | Sinc64Turbo=%.2f dBc "
-                    "(Phase-1 quoted %.1f dBc)\n",
+                    "isolated(prefilter+legacy)=%.2f dBc (delta %.3f dB) | pre-Phase-4 "
+                    "unfiltered path measured %.1f dBc\n",
                     name.c_str(), p.probeHz, p.artifactHz, artifactDbc, isoArtifactDbc,
-                    artifactDbc - isoArtifactDbc, turboArtifactDbc, p.turboArtifactDbc);
+                    artifactDbc - isoArtifactDbc, p.downsampling ? p.turboArtifactDbc : p.turboArtifactDbc);
 
-        // REGRESSION gate (one-sided): not hotter than the measured ceiling. A future
-        // anti-aliasing/imaging improvement lowers the artifact and still passes.
-        t.expect((name + (p.downsampling ? ": KNOWN LIMITATION - downsampling alias not above ceiling"
+        // Gate (one-sided): not hotter than the ceiling. Downsampling pairs carry the
+        // Phase-4 anti-alias target (< -95 dBc; measured -104.9 / -117.2 dBc through
+        // real sessions, vs -1.1 / -0.0 dBc before the clip prefilter — F1 resolved
+        // on this path). Upsampling ceilings are unchanged regression pins.
+        t.expect((name + (p.downsampling ? ": ANTI-ALIASED (Phase 4) - downsampling alias below -95 dBc"
                                          : ": upsampling image not above ceiling"))
                      .c_str(),
                  artifactDbc < p.artifactCeilingDbc,
                  "artifactDbc=" + std::to_string(artifactDbc) +
                      " ceiling=" + std::to_string(p.artifactCeilingDbc));
-        // AGREEMENT (characterization): session and legacy-replica artifact levels
-        // agree to 0.5 dB. This pins WHICH kernel the shipped mainline path runs.
-        // If mainline clip resampling intentionally changes (anti-aliasing, kernel
-        // unification), update this check and the research doc together (see header).
-        t.expectNear((name + ": isolated(legacy)-vs-session artifact agreement (dB)").c_str(), artifactDbc,
+        // AGREEMENT (characterization): session and replica artifact levels agree.
+        // This pins WHICH pipeline the shipped mainline path runs (prefilter+legacy
+        // kernel). If mainline clip resampling intentionally changes again, update
+        // this check and the research doc together (see header).
+        t.expectNear((name + ": isolated-vs-session artifact agreement (dB)").c_str(), artifactDbc,
                      isoArtifactDbc, 0.5);
 
-        // IDENTITY null: interior of the session render must equal the legacy-kernel
-        // replica scaled by the pan-law center gain, sample by sample.
+        // IDENTITY null: interior of the session render must equal the replica
+        // scaled by the pan-law center gain, sample by sample.
         AR::Signal expected = isolated;
         for (float& v : expected.samples) {
             v = static_cast<float>(static_cast<double>(v) * panGain);
@@ -421,12 +471,14 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
         const AR::Signal outWin = window(out, kWinSkip, winEnd);
         const AR::Signal expWin = window(expected, kWinSkip, winEnd);
         const AR::DiffReport d = AR::diff(outWin, expWin, 1e-4);
-        std::printf("[MEASURE] %s identity null vs isolated(legacy)*panGain: maxErr=%.3e rmsErr=%.1f dB\n",
+        std::printf("[MEASURE] %s identity null vs isolated(prefilter+legacy)*panGain: maxErr=%.3e "
+                    "rmsErr=%.1f dB\n",
                     name.c_str(), d.maxAbsError, d.rmsErrorDb);
-        // Gates: measured -153.6 to -162.6 dB RMS across the four pairs, maxErr
+        // Gates: measured -153.6 to -275.6 dB RMS across the four pairs, maxErr
         // <= 9e-8 (renderGraph recomputes phase per block from the same closed form
         // the replica accumulates, AudioEngine.cpp:2086; the legacy kernel is
-        // phase-continuous, so ~1e-12 phase slack is invisible in float).
+        // phase-continuous, and the replica applies the identical production
+        // prefilter, so the pipelines are the same math end to end).
         const bool nullPass = d.rmsErrorDb < -120.0 && d.maxAbsError < 1e-5;
         if (!t.expect((name + ": IDENTITY - session render nulls against isolated replica").c_str(),
                       nullPass,
@@ -434,31 +486,52 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
                           " maxAbs=" + std::to_string(d.maxAbsError))) {
             AR::printDiffForensics(name + " identity null", d, outWin, expWin);
         }
-
-        // ---- length truth: tone runs to the clip end, silence after ----
-        const uint32_t renderFrames = out.frames();
-        const double postPeak = AR::peak(out, -1, outClipFrames + 256, renderFrames);
-        int64_t lastAudible = -1;
-        for (uint32_t i = outClipFrames + 255; i > 0; --i) {
-            if (std::abs(out.at(i, 0)) > 1e-4 || std::abs(out.at(i, 1)) > 1e-4) {
-                lastAudible = i;
-                break;
-            }
-        }
-        std::printf("[MEASURE] %s length: clip end expect frame %u, last audible=%lld, post-clip peak=%.2e\n",
-                    name.c_str(), outClipFrames, static_cast<long long>(lastAudible), postPeak);
-        // The clip must fill its timeline slot: last audible frame within the 128-frame
-        // edge fade of the expected end (clip end is beats -> project samples, so a
-        // source-rate bookkeeping error shows up as a truncated or overlong tone).
-        t.expect((name + ": tone reaches the clip end (within edge fade)").c_str(),
-                 lastAudible >= static_cast<int64_t>(outClipFrames) - 130 &&
-                     lastAudible <= static_cast<int64_t>(outClipFrames) + 2,
-                 "lastAudible=" + std::to_string(lastAudible) + " expectedEnd=" + std::to_string(outClipFrames));
-        // Gate 1e-5: measured post-clip peak is exactly 0 (renderer writes silence
-        // past clip.endSample).
-        t.expect((name + ": silence after clip end").c_str(), postPeak < 1e-5,
-                 "postPeak=" + std::to_string(postPeak));
+        // (Length truth moved to the in-band 1 kHz render above: a between-Nyquists
+        // probe is REMOVED by the Phase-4 anti-alias filter, so it can no longer
+        // witness the clip end.)
     }
+}
+
+// =============================================================================
+// Case 2b: fallback transition — before the prefilter is ready, playback is the
+// pre-Phase-4 path; after wait + rebuild it is anti-aliased. Deterministic: the
+// filtered variant is only applied on the graph-build thread inside
+// ensureClipPrefilters(), so the FIRST graph build can never see it.
+// =============================================================================
+
+void runFallbackTransitionCase(AR::CheckSession& t) {
+    std::printf("\n--- fallback transition: 48k clip in 44.1k session, before/after prefilter ---\n");
+    GA::SessionConfig cfg;
+    cfg.sampleRate = 44100;
+    const uint32_t srcFrames = static_cast<uint32_t>(kClipSeconds * 48000);
+    const uint32_t outClipFrames = static_cast<uint32_t>(kClipSeconds * 44100);
+    const AR::Signal clip = AR::makeSine(48000, srcFrames, 23000.0, kAmp);
+    auto tm = buildSession("fallback", clip, cfg, /*waitForPrefilters=*/false);
+    const double panGain = static_cast<double>(PanLaw::kEqualPowerCenterGain);
+    const uint32_t winEnd = outClipFrames - kWinSkip;
+
+    // First-ever graph build: enqueues the job and renders with the ORIGINAL buffer.
+    const AR::Signal before =
+        renderSessionRealtime(tm, cfg, outClipFrames, Interp::InterpolationQuality::Sinc64);
+    const double beforeDbc =
+        AR::toDb(AR::toneAmplitude(before, 0, 21100.0, kWinSkip, winEnd) / (kAmp * panGain));
+
+    // Deterministic completion, then a fresh build picks the filtered copy up.
+    tm->waitForClipPrefilters();
+    const AR::Signal after =
+        renderSessionRealtime(tm, cfg, outClipFrames, Interp::InterpolationQuality::Sinc64);
+    const double afterDbc =
+        AR::toDb(AR::toneAmplitude(after, 0, 21100.0, kWinSkip, winEnd) / (kAmp * panGain));
+
+    std::printf("[MEASURE] fallback transition alias 21100 Hz: before=%.2f dBc, after=%.2f dBc\n",
+                beforeDbc, afterDbc);
+    // Before: the pre-Phase-4 characteristic (measured -1.1 dBc) — playback keeps
+    // running unfiltered rather than blocking while the copy is built.
+    t.expect("fallback: unfiltered render while prefilter pending (alias > -8 dBc)", beforeDbc > -8.0,
+             "beforeDbc=" + std::to_string(beforeDbc));
+    // After: the Phase-4 target on the same session object (measured -104.9 dBc).
+    t.expect("fallback: anti-aliased after wait + rebuild (alias < -95 dBc)", afterDbc < -95.0,
+             "afterDbc=" + std::to_string(afterDbc));
 }
 
 // =============================================================================
@@ -491,17 +564,21 @@ void runImpulseCases(AR::CheckSession& t) {
                     "preRms=%.2e tailRms=%.2e\n",
                     name.c_str(), r.peakAbs, static_cast<long long>(r.peakFrame), expectedPeakFrame,
                     static_cast<long long>(r.spanFrames), r.preSpanRms, r.tailRms);
+        // Position stays exact: the Phase-4 prefilter (applied on the 96->48
+        // downsampling pair only) compensates its integer group delay exactly.
         t.expect((name + ": impulse lands at the mapped session frame (+/-2)").c_str(),
                  std::abs(static_cast<double>(r.peakFrame) - expectedPeakFrame) <= 2.0,
                  "peakFrame=" + std::to_string(r.peakFrame));
-        // Span gate 160 output frames: Phase-1 isolated spans were 1 (96->48, exact
-        // 2:1) to 86 (44.1->96) frames; the session must not smear beyond that class.
+        // Span gate 160 output frames: measured 73 (96->48 — the anti-alias FIR's
+        // -60 dB response, the time-domain price of its designed transition; was 1
+        // pre-Phase-4) and 79 (48->96, upsampling, unchanged by Phase 4).
         t.expect((name + ": impulse -60 dB span < 160 frames").c_str(), r.spanFrames < 160,
                  "spanFrames=" + std::to_string(r.spanFrames));
 
-        // IDENTITY null against the legacy-kernel replica (same policy as the probe null).
-        AR::Signal expected =
-            resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate, clip, ip.sessionRate);
+        // IDENTITY null against the prefilter+legacy replica (same policy as the
+        // probe null; prefilterReplica is the identity for the upsampling pair).
+        AR::Signal expected = resampleViaInterpolator(Interp::Sinc64Interpolator::interpolate,
+                                                      prefilterReplica(clip, ip.sessionRate), ip.sessionRate);
         for (float& v : expected.samples) {
             v = static_cast<float>(static_cast<double>(v) * PanLaw::kEqualPowerCenterGain);
         }
@@ -966,6 +1043,7 @@ int main() {
     for (const SessionPair& p : kSessionPairs) {
         auditSessionPair(t, p, control);
     }
+    runFallbackTransitionCase(t);
     runImpulseCases(t);
     runIsolatedBounceCase(t, tempRoot);
     runExportParityCases(t, tempRoot);

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -443,7 +443,7 @@ void auditSessionPair(AR::CheckSession& t, const SessionPair& p, const ControlBa
                     "isolated(prefilter+legacy)=%.2f dBc (delta %.3f dB) | pre-Phase-4 "
                     "unfiltered path measured %.1f dBc\n",
                     name.c_str(), p.probeHz, p.artifactHz, artifactDbc, isoArtifactDbc,
-                    artifactDbc - isoArtifactDbc, p.downsampling ? p.turboArtifactDbc : p.turboArtifactDbc);
+                    artifactDbc - isoArtifactDbc, p.turboArtifactDbc);
 
         // Gate (one-sided): not hotter than the ceiling. Downsampling pairs carry the
         // Phase-4 anti-alias target (< -95 dBc; measured -104.9 / -117.2 dBc through


### PR DESCRIPTION
## Summary

Phase 4 of the Audio Research Bench: **resolves F1 on the mainline paths**. Downsampled clips (source rate > session rate) are now anti-aliased by a designed Kaiser low-pass built **once per clip on a worker thread**, feeding the existing interpolation kernels **unchanged**. This is the Phase-3 measured winner (Option B, `audio-research-bench.md` §9), implemented per the pre-written lifecycle plan (`AestraDocs/clip-prefilter-lifecycle.md` — ownership, keying, invalidation, memory, fallback, render integration).

## Measured before → after (real sessions, `SessionResamplingTruthTest`)

| Scenario | Before (F1) | **After** |
|---|---|---|
| 48k clip in 44.1k session (23 kHz → 21.1 kHz alias) | −1.10 dBc | **−104.91 dBc** |
| 96k clip in 48k session (30 kHz → 18 kHz alias) | −0.00 dBc | **−117.24 dBc** |
| Upsampling / same-rate / level / SINAD / DC / length / timing | — | unchanged & exact |

Session renders null a production-prefilter + legacy-kernel replica at −153.6 to −275.6 dB RMS; full-mix export nulls realtime at −164/−175 dB with identical artifact levels; impulses land on the exact mapped frame (the FIR's integer group delay is compensated exactly). A dedicated **fallback-transition case** proves the non-blocking design deterministically: the first graph build renders unfiltered (−1.10 dBc) while the worker runs; after completion + rebuild the same session measures −104.91 dBc.

## How it works (one selection point, zero audio-thread change)

- `DSP/ClipPrefilter` — pure Kaiser design/apply (pass 0.9× dst Nyquist, stop at dst Nyquist, 100 dB), double precision, deterministic.
- `ClipPrefilterService` — lazily-started worker; jobs own `shared_ptr` copies and **never touch SourceManager/ClipSource** (their containers aren't thread-safe); completion raises only the atomic graph-dirty flag.
- `ClipSource` — one filtered-variant slot keyed by (contentRevision, targetRate, spec version); graph-build-thread only; `setBuffer` invalidates.
- `TrackManager::ensureClipPrefilters()` — called by `AudioGraphBuilder` before every snapshot: drain results, clear stale slots, enqueue missing work. `waitForClipPrefilters()` gives offline/tests deterministic completion.
- `PlaylistModel::buildRuntimeSnapshot` — the **single** buffer-selection point; playback, full-mix export, and isolated bounce all consume the same snapshot, so **parity is preserved by construction**.
- Interpolation kernels untouched; audio callback path untouched (**RTAllocationTrapTest green** — no filtering, allocation, locking, logging, or blocking added to the audio thread).

## Memory / CPU

One-time filter pass ≈ 1–2 ms per second of clip audio on the worker (lab §9.4); steady-state playback cost identical to before (same kernels). Memory: +1× clip size for downsampled sources at the current session rate only, cleared when the rate stops qualifying; eviction policy deliberately deferred (lifecycle doc §6).

## Testing performed

- Full `-j2` rebuild; `ctest -L audio` → **60/60**; `ctest -L research` → 4/4 (truth test now 68 checks)
- Gates flipped honestly: downsampling aliases from "KNOWN LIMITATION −1.1/−0.0 dBc" characterization to **< −95 dBc** targets; replicas apply the production `ClipPrefilter` so identity nulls stay exact; length truth moved to the in-band tone (a between-Nyquists probe is *removed* by the filter and can no longer witness the clip end)
- Parity (`RealtimeExportParityTest`, `ExportBounceParityTest`, Arsenal exports) and `RTAllocationTrapTest`: green

## DSP change report

Audio output changed for **downsampled clips** on playback/export/bounce (anti-aliasing; in-band content passband-exact to <0.0001 dB). Latency unchanged. State/serialization unchanged (filtered copies are runtime-only). Live/export parity preserved (nulls above).

## Uncovered (documented, unchanged)

PreviewEngine (F7), SamplerPlugin (F8), AuditionEngine, and exports at a rate different from the session rate (exporter renders the current graph — pre-existing behavior).

## Risk / rollback

- Fallback path is byte-for-byte the pre-Phase-4 render; the filtered copy only enters via one guarded selection point.
- Worker lifetime: service is TrackManager's last member (joins first); jobs own their data.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Downsampled clip playback now uses an anti-aliasing Kaiser low-pass prefilter when the clip’s source sample rate is higher than the session rate, reducing measured aliasing while leaving same-rate behavior and audio-thread behavior unchanged.
- Runtime snapshot building now resolves clip audio via the same “filtered buffer if ready, otherwise raw buffer” selection path across realtime playback, full-mix export, and isolated bounce.
- Added an async `ClipPrefilterService` plus `TrackManager` lifecycle hooks to design/cache per-clip prefilter kernels off the audio path, publish filtered variants when ready, and safely invalidate caches on clip/content changes.
- Extended `ClipSource` to store a validated filtered-variant snapshot keyed by target rate, content revision, and a filter spec version, with explicit invalidation when the underlying buffer changes.
- Added the Kaiser FIR prefilter DSP implementation and integrated new service/model files into the build.
- Updated Audio Research Bench documentation and expanded `SessionResamplingTruthTest` to cover Phase 4 behavior, including a new fallback-readiness transition case and tighter alias-suppression assertions for cross-rate downsampling pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->