### PR TITLE
ci: add Linux lane that compiles the UI/app targets (#397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,31 @@ jobs:
           EOF
           curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" --data @discord_payload.json "$DISCORD_WEBHOOK"
 
+  # Compiles the full desktop app (Source/ + AestraUI) — the one lane that
+  # catches UI/app build breakage. Every other lane passes AESTRA_CI=ON, which
+  # force-disables the UI, so without this job the app can silently stop
+  # building (it did once for a week, #396). Compile-only by design: tests are
+  # owned by the headless lanes. Do NOT add AESTRA_CI=ON here — it would turn
+  # this lane back into a headless build.
+  build-linux-app:
+    name: Linux (UI/App compile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libsdl2-dev libfreetype-dev
+
+      - name: Configure (UI enabled)
+        run: cmake -B build-app -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_ENABLE_UI=ON -DAESTRA_ENABLE_TESTS=OFF
+
+      - name: Build app target
+        run: cmake --build build-app --config ${{env.BUILD_TYPE}} --target Aestra --parallel
+
   build-windows:
     name: Windows (MSVC)
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
Adds one job to `ci.yml` — **Linux (UI/App compile)** — that configures with `AESTRA_ENABLE_UI=ON` and builds the `Aestra` app target. Compile-only; no tests.

## Why
Every existing lane passes `AESTRA_CI=ON`, which force-disables the UI (`CMakeLists.txt:48-54`), so `Source/` and `AestraUI` never compile in CI. App build breakage is invisible until someone builds locally — it already happened once for a week (#396). This is MUST-FIX item 1 in the beta gameplan (`AestraDocs/product/beta-gameplan-2026-07.md` §2).

Closes #397.

## Design notes
- **No `AESTRA_CI=ON` here** — it would force the UI back off. A comment in the workflow warns against re-adding it.
- **System SDL2 + FreeType from apt** (`libsdl2-dev`, `libfreetype-dev`) — the same resolution path the local canonical build uses (`find_package` first; vendored `freetype_local` is only the fallback). ThorVG/glad are vendored in-tree, no submodules needed (`submodules: false` kept, matching the other lanes).
- **`--target Aestra`** pulls in AestraUI/AestraPlat/Source as deps while skipping test executables — scoped exactly to what no other lane covers.
- **`AESTRA_ENABLE_TESTS=OFF`** keeps the lane fast; tests remain owned by the headless lanes.

## Testing performed
- Configure step verified locally with the exact lane flags (clean dir): configures successfully, UI + app targets generated.
- Full compile proof is the lane itself on this PR's run — this branch adds the first CI job that can compile these targets.
- Workflow YAML validated.

## Docs updated?
No public docs affected. `AGENTS.md` CI table already generic (`ci.yml` — main build/test gate).

## Risk / rollback
Additive job only; no existing lane touched. Rollback = delete the job. Worst case is a red lane that surfaces a real (currently invisible) app build break — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)