### PR TITLE
fix(serialization): values must survive save/load — 3 data-fidelity bugs + ProjectValueFidelityTest (#273)

### DIFF
--- a/AestraAudio/include/Core/AutomationCurve.h
+++ b/AestraAudio/include/Core/AutomationCurve.h
@@ -131,12 +131,17 @@ struct AutomationCurve {
      * @param beat Beat position
      * @param samplesPerBeat Samples per beat for the current project tempo/rate
      * @param value Value at this point (normalized 0-1 for volume/pan)
-     * @param tension Curve tension (0-1, currently unused)
+     * @param tension Curve tension for serialization (rendering does not use it yet)
      */
-    void addPoint(double beat, float value, double samplesPerBeat, float /*tension*/ = 0.5f) {
+    void addPoint(double beat, float value, double samplesPerBeat, float tension = 0.5f) {
         AutomationPoint pt;
         pt.sample = static_cast<uint64_t>(beat * samplesPerBeat);
         pt.value = value;
+        // beat and curve are what ProjectSerializer persists — leaving them at
+        // their zero defaults made every point created through this API (loader,
+        // UI draw path) serialize at beat 0 on the next save.
+        pt.beat = beat;
+        pt.curve = tension;
 
         // Insert in sorted order
         auto it = points.begin();

--- a/AestraCore/include/AestraJSON.h
+++ b/AestraCore/include/AestraJSON.h
@@ -1,6 +1,10 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -192,6 +196,47 @@ private:
         return out;
     }
 
+    // Round-trip-precise, exponent-free decimal formatting for doubles.
+    // Plain stream insertion defaults to 6 significant digits, which silently
+    // truncated every double in saved projects (a clip at beat 1024.125 came
+    // back as 1024.12 — an audible position shift). Tries the fewest
+    // significant digits in [15..17] whose plain-decimal rendering strtod's
+    // back to the identical bits, then trims trailing zeros. Plain decimal
+    // (never exponent form) keeps output readable and parseable by every
+    // existing consumer. Note: like the stream insertion it replaces, this
+    // assumes the C numeric locale uses '.' as the decimal separator.
+    static void formatNumber(char* buf, size_t bufSize, double v) {
+        if (!std::isfinite(v)) {
+            // Preserve prior stream behavior for non-finite values ("nan"/"inf");
+            // they are invalid JSON either way and callers guard against them.
+            std::snprintf(buf, bufSize, "%g", v);
+            return;
+        }
+        const double magnitude = std::fabs(v);
+        const int exp10 = (magnitude > 0.0) ? static_cast<int>(std::floor(std::log10(magnitude))) : 0;
+        bool exact = false;
+        for (int sigDigits = 15; sigDigits <= 17 && !exact; ++sigDigits) {
+            // log10 can be off by one near powers of ten; bump decimals to recover.
+            for (int bump = 0; bump <= 2 && !exact; ++bump) {
+                int decimals = sigDigits - 1 - exp10 + bump;
+                decimals = decimals < 0 ? 0 : (decimals > 340 ? 340 : decimals);
+                std::snprintf(buf, bufSize, "%.*f", decimals, v);
+                exact = (std::strtod(buf, nullptr) == v);
+            }
+        }
+        char* dot = std::strchr(buf, '.');
+        if (dot != nullptr) {
+            char* end = buf + std::strlen(buf);
+            while (end > buf && *(end - 1) == '0') {
+                --end;
+            }
+            if (end > buf && *(end - 1) == '.') {
+                --end;
+            }
+            *end = '\0';
+        }
+    }
+
     void serialize(std::stringstream& ss, int indent, int depth) const {
         std::string indentStr(depth * indent, ' ');
         std::string nextIndentStr((depth + 1) * indent, ' ');
@@ -203,9 +248,12 @@ private:
         case Type::Boolean:
             ss << (boolValue_ ? "true" : "false");
             break;
-        case Type::Number:
-            ss << numberValue_;
+        case Type::Number: {
+            char numBuf[512];
+            formatNumber(numBuf, sizeof(numBuf), numberValue_);
+            ss << numBuf;
             break;
+        }
         case Type::String:
             ss << "\"" << escapeString(stringValue_) << "\"";
             break;

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1362,10 +1362,14 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             const JSON& slj = pj[i]["slices"];
                             for (size_t s = 0; s < slj.size(); ++s) {
                                 if (!slj[s].isObject()) continue;
-                                payload.slices.push_back({
-                                    finiteNumberOr(slj[s], "start", 0.0, 0.0, 1.0e15),
-                                    finiteNumberOr(slj[s], "length", 0.0, 0.0, 1.0e15)
-                                });
+                                // Mirror the writer, which persists startSamples/lengthSamples
+                                // (AudioSlice fields 3-4). The old first-two-field aggregate
+                                // filled startOffset/duration instead, so slice sample data
+                                // zeroed out on the next save.
+                                AudioSlice slice;
+                                slice.startSamples = finiteNumberOr(slj[s], "start", 0.0, 0.0, 1.0e15);
+                                slice.lengthSamples = finiteNumberOr(slj[s], "length", 0.0, 0.0, 1.0e15);
+                                payload.slices.push_back(slice);
                             }
                         }
                         PatternID newId = patternManager.createAudioPattern(name, length, payload);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -167,6 +167,31 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripIntegrityTest
     set_tests_properties(ProjectRoundTripIntegrityTest PROPERTIES LABELS "integration;serialization")
 endif()
 
+# Project Value Fidelity Test — numeric fields must roundtrip bit-exactly (#273)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectValueFidelityTest.cpp")
+    add_executable(ProjectValueFidelityTest
+        Integration/ProjectValueFidelityTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(ProjectValueFidelityTest PRIVATE AestraAudio)
+    target_include_directories(ProjectValueFidelityTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    add_test(NAME ProjectValueFidelityTest COMMAND ProjectValueFidelityTest)
+    set_tests_properties(ProjectValueFidelityTest PROPERTIES LABELS "integration;serialization")
+endif()
+
 # Project Load Regression Tests (routing safety, missing references, non-destructive load)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectLoadRegressionTest.cpp")
     add_executable(ProjectLoadRegressionTest

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -1,0 +1,423 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// ProjectValueFidelityTest — numeric values must survive save → load EXACTLY,
+// and stay stable across repeated save/load generations.
+//
+// Complements ProjectRoundTripTest (which checks a small value set at short,
+// low-precision magnitudes) by asserting bit-exact roundtrips for every
+// serialized numeric domain, deliberately using values that need more than 6
+// significant digits and beat positions deep into a long arrangement:
+//   - tempo / playhead
+//   - lane volume/pan/mute/solo, channel width/armed/soloSafe/trackColorIndex
+//   - clip start/duration(Seconds)/sourceOffset(Seconds) + all clip edits
+//   - MIDI note pitch/start/duration/velocity/pitchOffset/gate/slide
+//   - audio slice startSamples/lengthSamples
+//   - automation curve target/default + point beat/value/curve tension
+// The full assertion set runs against generation 2 (load of the original
+// save) AND generation 3 (load of generation 2's save), so any value that
+// only survives one cycle still fails.
+//
+// Guards three shipped bugs (2026-07): JSON doubles truncated to 6
+// significant digits by default stream precision; AutomationCurve::addPoint
+// dropping point beat/tension so every loaded or freshly drawn point re-saved
+// at beat 0; and the slice loader filling startOffset/duration instead of the
+// startSamples/lengthSamples fields the writer persists.
+//
+// NOT asserted here: byte-identical save->load->save output. Clip UUIDs and
+// pattern numeric IDs are re-minted by the loader (identity is session-scoped
+// today), which also reorders the patterns array between generations. Stable
+// persisted identity is tracked as its own serialization-cluster issue.
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "Core/AutomationCurve.h"
+#include "Models/ClipSource.h"
+#include "Models/PatternSource.h"
+#include "Models/TrackManager.h"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+std::filesystem::path makeTempDir() {
+    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
+    std::filesystem::create_directories(base);
+    for (int i = 0; i < 1000; ++i) {
+        auto candidate = base / ("ValueFidelity_" + std::to_string(i));
+        if (!std::filesystem::exists(candidate)) {
+            std::filesystem::create_directories(candidate);
+            return candidate;
+        }
+    }
+    auto fallback = base / "ValueFidelity_fallback";
+    std::filesystem::create_directories(fallback);
+    return fallback;
+}
+
+// Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager loading).
+bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
+    if (sampleRate <= 0 || numSamples <= 0)
+        return false;
+    const int numChannels = 1;
+    const int bitsPerSample = 16;
+    const int bytesPerSample = bitsPerSample / 8;
+    const int blockAlign = numChannels * bytesPerSample;
+    const int byteRate = sampleRate * blockAlign;
+    const std::uint32_t dataSize = static_cast<std::uint32_t>(numSamples * blockAlign);
+
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out)
+        return false;
+    auto writeU32 = [&](std::uint32_t v) { out.write(reinterpret_cast<const char*>(&v), 4); };
+    auto writeU16 = [&](std::uint16_t v) { out.write(reinterpret_cast<const char*>(&v), 2); };
+    out.write("RIFF", 4);
+    writeU32(36u + dataSize);
+    out.write("WAVE", 4);
+    out.write("fmt ", 4);
+    writeU32(16u);
+    writeU16(1u); // PCM
+    writeU16(static_cast<std::uint16_t>(numChannels));
+    writeU32(static_cast<std::uint32_t>(sampleRate));
+    writeU32(static_cast<std::uint32_t>(byteRate));
+    writeU16(static_cast<std::uint16_t>(blockAlign));
+    writeU16(static_cast<std::uint16_t>(bitsPerSample));
+    out.write("data", 4);
+    writeU32(dataSize);
+    std::vector<char> silence(dataSize, 0);
+    out.write(silence.data(), static_cast<std::streamsize>(silence.size()));
+    return static_cast<bool>(out);
+}
+
+int g_failures = 0;
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        ++g_failures;
+    }
+}
+
+void requireExactD(double actual, double expected, const std::string& what) {
+    if (actual != expected) {
+        std::cerr.precision(17);
+        std::cerr << "[FAIL] " << what << ": expected " << expected << ", got " << actual << "\n";
+        ++g_failures;
+    }
+}
+
+void requireExactF(float actual, float expected, const std::string& what) {
+    if (actual != expected) {
+        std::cerr.precision(9);
+        std::cerr << "[FAIL] " << what << ": expected " << expected << ", got " << actual << "\n";
+        ++g_failures;
+    }
+}
+
+// Values chosen to be unrepresentable in 6 significant digits and to sit deep
+// in a long arrangement (bar 256+), where the old formatter audibly moved clips.
+constexpr double kTempo = 174.998877;
+constexpr double kPlayhead = 2.345678901;
+constexpr double kMidiClipStart = 1024.125;
+constexpr double kMidiClipDuration = 8.53125;
+constexpr double kAudioClipStart = 512.0625;
+constexpr double kAudioClipDurationSeconds = 3.14159265358979;
+constexpr double kAudioClipSourceOffsetSeconds = 0.123456789012345;
+constexpr double kNoteStartFar = 1024.125;
+constexpr double kNoteDurationOdd = 1.0 / 7.0;
+constexpr double kAutoBeatFar = 1024.125;
+constexpr double kSliceStartSamples = 480.0625;
+constexpr double kSliceLengthSamples = 1920.125;
+constexpr float kVolA = 1.0f / 3.0f;
+constexpr float kPanA = -0.123456f;
+constexpr float kWidthA = 1.23456f;
+constexpr float kSendGain = 0.333333343f;
+constexpr float kSendPan = 0.111111f;
+
+// The full value-fidelity assertion set. Runs against every load generation so
+// values that survive one save/load cycle but not two still fail.
+// Note: ProjectSerializer currently lives in the global namespace (its header
+// closes `namespace Aestra` before declaring the class) — see the #266 move.
+void assertAllValues(Aestra::Audio::TrackManager& tm,
+                     const ProjectSerializer::LoadResult& load,
+                     const std::string& gen) {
+    using namespace Aestra::Audio;
+    auto tag = [&gen](const char* what) { return gen + ": " + what; };
+
+    requireExactD(load.tempo, kTempo, tag("tempo"));
+    requireExactD(load.playhead, kPlayhead, tag("playhead"));
+
+    auto& playlist = tm.getPlaylistModel();
+    const auto* laneA = playlist.getLane(playlist.getLaneId(0));
+    const auto* laneB = playlist.getLane(playlist.getLaneId(1));
+    require(laneA != nullptr && laneB != nullptr, tag("lanes missing after load"));
+    if (laneA == nullptr || laneB == nullptr)
+        return;
+
+    requireExactF(laneA->volume, kVolA, tag("lane A volume"));
+    requireExactF(laneA->pan, kPanA, tag("lane A pan"));
+    require(laneA->muted, tag("lane A muted=true lost"));
+    require(laneA->solo, tag("lane A solo=true lost"));
+
+    const auto* chanA = tm.getChannel(0);
+    const auto* chanB = tm.getChannel(1);
+    require(chanA != nullptr && chanB != nullptr, tag("channels missing after load"));
+    if (chanA == nullptr || chanB == nullptr)
+        return;
+    requireExactF(chanA->getVolume(), kVolA, tag("channel A volume"));
+    requireExactF(chanA->getPan(), kPanA, tag("channel A pan"));
+    requireExactF(chanA->getWidth(), kWidthA, tag("channel A width"));
+    require(chanA->isArmed(), tag("channel A armed=true lost"));
+    require(chanA->isSoloSafe(), tag("channel A soloSafe=true lost"));
+    require(chanA->getTrackColorIndex() == 5, tag("channel A trackColorIndex"));
+    require(chanA->getMainOutputId() == chanB->getChannelId(), tag("main output id"));
+
+    const auto sends = chanA->getSends();
+    require(sends.size() == 1, tag("send count"));
+    if (sends.size() == 1) {
+        requireExactF(sends[0].gain, kSendGain, tag("send gain"));
+        requireExactF(sends[0].pan, kSendPan, tag("send pan"));
+        require(sends[0].postFader, tag("send postFader=true lost"));
+    }
+
+    // MIDI clip position/duration.
+    require(laneA->clips.size() == 1, tag("lane A clip count"));
+    if (laneA->clips.size() == 1) {
+        requireExactD(laneA->clips[0].startBeat, kMidiClipStart, tag("midi clip startBeat"));
+        requireExactD(laneA->clips[0].durationBeats, kMidiClipDuration, tag("midi clip durationBeats"));
+    }
+
+    // Audio clip seconds-domain values + edits.
+    require(laneB->clips.size() == 1, tag("lane B clip count"));
+    if (laneB->clips.size() == 1) {
+        const auto& c = laneB->clips[0];
+        requireExactD(c.startBeat, kAudioClipStart, tag("audio clip startBeat"));
+        requireExactD(c.durationSeconds, kAudioClipDurationSeconds, tag("audio clip durationSeconds"));
+        requireExactD(c.sourceOffsetSeconds, kAudioClipSourceOffsetSeconds, tag("audio clip sourceOffsetSeconds"));
+        requireExactF(c.edits.gainLinear, 0.987654f, tag("clip gain"));
+        requireExactF(c.edits.pan, -0.054321f, tag("clip edit pan"));
+        require(c.edits.muted, tag("clip muted=true lost"));
+        requireExactF(c.edits.playbackRate, 1.5f, tag("clip playbackRate"));
+        requireExactD(c.edits.fadeInBeats, 0.125, tag("clip fadeInBeats"));
+        requireExactD(c.edits.fadeOutBeats, 0.0625, tag("clip fadeOutBeats"));
+        requireExactF(c.edits.sourceStart, 0.75f, tag("clip sourceStart"));
+    }
+
+    // Pattern payload values: MIDI notes and audio slices.
+    {
+        std::shared_ptr<PatternSource> midiPat;
+        std::shared_ptr<PatternSource> audioPat;
+        for (const auto& p : tm.getPatternManager().getAllPatterns()) {
+            if (p == nullptr)
+                continue;
+            if (p->isAudio())
+                audioPat = p;
+            else
+                midiPat = p;
+        }
+        require(midiPat != nullptr, tag("loaded MIDI pattern missing"));
+        if (midiPat != nullptr) {
+            const auto& notes = std::get<MidiPayload>(midiPat->payload).notes;
+            require(notes.size() == 2, tag("note count"));
+            if (notes.size() == 2) {
+                requireExactD(notes[0].startBeat, kNoteStartFar, tag("note1 startBeat"));
+                requireExactD(notes[0].durationBeats, 0.4375, tag("note1 durationBeats"));
+                requireExactF(notes[0].velocity, 0.87f, tag("note1 velocity"));
+                require(notes[0].pitch == 61, tag("note1 pitch"));
+                require(notes[0].pitchOffset == -3, tag("note1 pitchOffset"));
+                requireExactF(notes[0].gate, 0.75f, tag("note1 gate"));
+                require(notes[0].slide, tag("note1 slide=true lost"));
+                requireExactD(notes[1].startBeat, 1.0 / 3.0, tag("note2 startBeat"));
+                requireExactD(notes[1].durationBeats, kNoteDurationOdd, tag("note2 durationBeats"));
+                requireExactF(notes[1].velocity, 0.01f, tag("note2 velocity"));
+                require(notes[1].pitch == 127, tag("note2 pitch"));
+            }
+        }
+        require(audioPat != nullptr, tag("loaded audio pattern missing"));
+        if (audioPat != nullptr) {
+            const auto& slices = std::get<AudioSlicePayload>(audioPat->payload).slices;
+            require(slices.size() == 1, tag("slice count"));
+            if (slices.size() == 1) {
+                requireExactD(slices[0].startSamples, kSliceStartSamples, tag("slice startSamples"));
+                requireExactD(slices[0].lengthSamples, kSliceLengthSamples, tag("slice lengthSamples"));
+            }
+        }
+    }
+
+    // Automation curve values — the addPoint identity bug zeroed these.
+    require(laneA->automationCurves.size() == 1, tag("automation curve count"));
+    if (laneA->automationCurves.size() == 1) {
+        const auto& curve = laneA->automationCurves[0];
+        require(curve.getAutomationTarget() == AutomationTarget::Volume, tag("automation target"));
+        requireExactF(curve.getDefaultValue(), 0.42f, tag("automation default"));
+        require(curve.points.size() == 2, tag("automation point count"));
+        if (curve.points.size() == 2) {
+            requireExactD(curve.points[0].beat, 0.5, tag("automation point 1 beat"));
+            requireExactF(curve.points[0].value, 0.1f, tag("automation point 1 value"));
+            requireExactF(curve.points[0].curve, 0.25f, tag("automation point 1 tension"));
+            requireExactD(curve.points[1].beat, kAutoBeatFar, tag("automation point 2 beat"));
+            requireExactF(curve.points[1].value, 0.9f, tag("automation point 2 value"));
+            requireExactF(curve.points[1].curve, 0.5f, tag("automation point 2 tension"));
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    const auto tempDir = makeTempDir();
+    const auto wavPath = tempDir / "fidelity.wav";
+    const auto projectPath = tempDir / "fidelity.aes";
+    std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
+    if (!writeMinimalWavMono16(wavPath, 48000, 4800)) {
+        std::cerr << "[FAIL] could not write test WAV\n";
+        return 1;
+    }
+
+    // ---------------- Arrange: a project touching every numeric domain
+    auto tm1 = std::make_shared<TrackManager>();
+    tm1->getPlaylistModel().setPatternManager(&tm1->getPatternManager());
+    auto& playlist1 = tm1->getPlaylistModel();
+    playlist1.setBPM(kTempo);
+
+    // Lane/channel A — MIDI content, automation, "true" toggle states.
+    PlaylistLaneID laneAId = playlist1.createLane("Fidelity A");
+    auto* chanA = tm1->addChannel("Fidelity A");
+    // Lane/channel B — audio content, send target.
+    PlaylistLaneID laneBId = playlist1.createLane("Fidelity B");
+    auto* chanB = tm1->addChannel("Fidelity B");
+    if (!laneAId.isValid() || !laneBId.isValid() || chanA == nullptr || chanB == nullptr) {
+        std::cerr << "[FAIL] setup: lanes/channels\n";
+        return 1;
+    }
+
+    if (auto* lane = playlist1.getLane(laneAId)) {
+        lane->volume = kVolA;
+        lane->pan = kPanA;
+        lane->muted = true;
+        lane->solo = true;
+    }
+    chanA->setVolume(kVolA);
+    chanA->setPan(kPanA);
+    chanA->setMute(true);
+    chanA->setSolo(true);
+    chanA->setWidth(kWidthA);
+    chanA->setArmed(true);
+    chanA->setSoloSafe(true);
+    chanA->setTrackColorIndex(5);
+
+    // MIDI pattern: extended note fields + >6-sig-digit positions.
+    MidiPayload midi;
+    MidiNote n1;
+    n1.pitch = 61;
+    n1.startBeat = kNoteStartFar;
+    n1.durationBeats = 0.4375;
+    n1.velocity = 0.87f;
+    n1.pitchOffset = -3;
+    n1.gate = 0.75f;
+    n1.slide = true;
+    midi.notes.push_back(n1);
+    MidiNote n2;
+    n2.pitch = 127;
+    n2.startBeat = 1.0 / 3.0;
+    n2.durationBeats = kNoteDurationOdd;
+    n2.velocity = 0.01f;
+    midi.notes.push_back(n2);
+    PatternID midiPatId = tm1->getPatternManager().createMidiPattern("FidelityMelody", 16.0, midi);
+
+    // Audio pattern + source, with explicit slice sample values (the writer
+    // persists startSamples/lengthSamples — the loader used to drop them).
+    ClipSourceID srcId = tm1->getSourceManager().getOrCreateSource(wavPath.string());
+    AudioSlicePayload slicePayload;
+    slicePayload.audioSourceId = srcId;
+    AudioSlice slice;
+    slice.startSamples = kSliceStartSamples;
+    slice.lengthSamples = kSliceLengthSamples;
+    slicePayload.slices.push_back(slice);
+    PatternID audioPatId = tm1->getPatternManager().createAudioPattern("FidelityAudio", 4.0, slicePayload);
+    if (midiPatId.value == 0 || srcId.value == 0 || audioPatId.value == 0) {
+        std::cerr << "[FAIL] setup: patterns/source\n";
+        return 1;
+    }
+
+    // Clips: MIDI clip far into the arrangement, audio clip with full edits.
+    ClipInstanceID midiClipId = playlist1.addClipFromPattern(laneAId, midiPatId, kMidiClipStart, kMidiClipDuration);
+    ClipInstanceID audioClipId = playlist1.addClipFromPattern(laneBId, audioPatId, kAudioClipStart, 4.0);
+    if (!midiClipId.isValid() || !audioClipId.isValid()) {
+        std::cerr << "[FAIL] setup: clips\n";
+        return 1;
+    }
+    if (auto* clip = playlist1.getClip(audioClipId)) {
+        clip->durationSeconds = kAudioClipDurationSeconds;
+        clip->sourceOffsetSeconds = kAudioClipSourceOffsetSeconds;
+        clip->edits.gainLinear = 0.987654f;
+        clip->edits.pan = -0.054321f;
+        clip->edits.muted = true;
+        clip->edits.playbackRate = 1.5f;
+        clip->edits.fadeInBeats = 0.125;
+        clip->edits.fadeOutBeats = 0.0625;
+        clip->edits.sourceStart = 0.75f;
+    }
+
+    // Automation on lane A through the same API the loader and UI use.
+    {
+        auto* lane = playlist1.getLane(laneAId);
+        const double samplesPerBeat = (48000.0 * 60.0) / kTempo;
+        AutomationCurve vol("volume", AutomationTarget::Volume);
+        vol.setDefaultValue(0.42f);
+        vol.addPoint(0.5, 0.1f, samplesPerBeat, 0.25f);
+        vol.addPoint(kAutoBeatFar, 0.9f, samplesPerBeat, 0.5f);
+        lane->automationCurves.push_back(vol);
+    }
+
+    // Routing: A -> B send with awkward float gain.
+    chanA->setMainOutputId(chanB->getChannelId());
+    AudioRoute send{};
+    send.targetChannelId = chanB->getChannelId();
+    send.gain = kSendGain;
+    send.pan = kSendPan;
+    send.postFader = true;
+    send.mute = false;
+    send.sidechainOnly = false;
+    chanA->addSend(send);
+
+    // ---------------- Generation 2: save, load into a fresh manager, assert all values.
+    require(ProjectSerializer::save(projectPath.string(), tm1, kTempo, kPlayhead), "save failed");
+
+    auto tm2 = std::make_shared<TrackManager>();
+    tm2->getPlaylistModel().setPatternManager(&tm2->getPatternManager());
+    ProjectSerializer::LoadResult load1 = ProjectSerializer::load(projectPath.string(), tm2);
+    require(load1.ok, "generation-2 load failed");
+    if (!load1.ok)
+        return 1;
+    assertAllValues(*tm2, load1, "gen2");
+
+    // ---------------- Generation 3: save the loaded state, load it again, re-assert.
+    // Catches values that survive one cycle but decay on the second (the shipped
+    // automation and slice bugs were exactly this shape).
+    auto ser2 = ProjectSerializer::serialize(tm2, load1.tempo, load1.playhead, 2);
+    require(ser2.ok, "generation-3 serialize failed");
+    const auto cyclePath = tempDir / "fidelity_gen3.aes";
+    require(ProjectSerializer::writeAtomically(cyclePath.string(), ser2.contents), "generation-3 write failed");
+
+    auto tm3 = std::make_shared<TrackManager>();
+    tm3->getPlaylistModel().setPatternManager(&tm3->getPatternManager());
+    ProjectSerializer::LoadResult load2 = ProjectSerializer::load(cyclePath.string(), tm3);
+    require(load2.ok, "generation-3 load failed");
+    if (load2.ok) {
+        assertAllValues(*tm3, load2, "gen3");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] ProjectValueFidelityTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] ProjectValueFidelityTest\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
Serialization trust cluster PR 2 (**stacked on #444** — retarget to develop after it merges). Three shipped data-fidelity bugs found while building #273's value-fidelity test, each fixed at the source, plus the test that locks all of them:

1. **JSON doubles truncated to 6 significant digits** (`AestraJSON.h` used plain stream insertion). A clip at beat 1024.125 saved as 1024.12 — ~2.3 ms position error at 128 BPM, growing with arrangement length; tempo 174.998877 → 174.999. Now: fewest-digits [15..17] plain-decimal formatting verified by `strtod` round-trip, trailing zeros trimmed, never exponent form. Short values render unchanged.
2. **Automation flattened to beat 0.** `AutomationCurve::addPoint` never stored its `beat`/`tension` args — but `ProjectSerializer` persists `point.beat`, and the loader **and the UI draw path** (TrackUIComponent:2242) create points through `addPoint`. Draw automation → save → every point at beat 0; or load a project → next save flattens all automation.
3. **Slice sample data zeroed on save→load→save.** The slice loader aggregate-filled `AudioSlice.startOffset/duration` (fields 1–2) while the writer persists `startSamples/lengthSamples` (fields 3–4). Loader now mirrors the writer. (Slices have no runtime consumers today — creation-site field mismatch filed separately.)

## Test
`Tests/Integration/ProjectValueFidelityTest.cpp` (registered, `serialization` label): **bit-exact** assertions across every serialized numeric domain, deliberately using >6-sig-digit values and beat positions past bar 256. The full assertion set runs against generation 2 **and** generation 3 (load→save→load), catching values that decay on the second cycle — bugs 2 and 3 were exactly that shape.

**Red→green proof:** with the two fix commits reverted, the test reports 20+ failures across all three domains (tempo 174.999, beats at 1024.12, automation points at beat 0 in swapped order, slices 0/0); with them, PASS.

Not asserted: byte-identical save→load→save. Clip UUIDs and pattern numeric IDs are re-minted by the loader (identity is session-scoped today) — filed as a follow-up; it's a Takes/undo prerequisite.

## Testing performed
- `ProjectValueFidelityTest`: PASS (and verified red without fixes, output in PR discussion if wanted).
- JSON-sensitive regression set, all green: ProjectRoundTripTest, AutosaveRoundTripTest, ProjectRoundTripIntegrityTest, ProjectLoadRegressionTest, SessionRecoveryTest, AutosaveManagerTest, NUIThemeJSONTest, **SecJsonDos, SecJsonParserHardening**.

## Change type
- Serialization/project format changed: **output formatting only** — more digits where doubles need them; no schema/field changes; all existing files load unchanged (parser accepts both renderings).
- DSP/UI: no.

## Risk / rollback
Formatter is used by every JSON consumer (themes, prefs, autosave) — that's why the regression set above includes them. Locale caveat documented in-code (same assumption as the stream insertion it replaces). Rollback = revert commit 1 (precision), 2 (automation/slices), or 3 (test) independently.

Closes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)