### PR TITLE
build: remove dead AestraLicense PUBLIC link from AestraAudioCore

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -494,9 +494,12 @@ if(TARGET AestraCore)
     target_link_libraries(AestraAudioCore PUBLIC AestraCore)
 endif()
 
-if(TARGET AestraLicense)
-    target_link_libraries(AestraAudioCore PUBLIC AestraLicense)
-endif()
+# AestraAudioCore stays license-free: no AestraAudio source references any
+# AestraLicense symbol (grep-verified 2026-07-09), and a PUBLIC link here dragged
+# licensing into every headless/test/core consumer, contradicting core-mode
+# semantics (AGENTS.md §2; architecture audit 2026Q2 §1.1). Consumers that
+# genuinely need licensing (the app at Source/CMakeLists.txt, license tests)
+# link AestraLicense directly.
 target_link_libraries(AestraAudioCore PUBLIC AestraPlat)
 
 # macOS frameworks needed by VST3 hosting


### PR DESCRIPTION
## Summary
Deletes the `AestraLicense` PUBLIC link from `AestraAudioCore` — the P0 layering violation from the 2026Q2 architecture audit (§1.1).

## Why
- **The dependency is dead**: no AestraAudio source references any AestraLicense symbol (grep-verified).
- **PUBLIC made it viral**: every headless build, lab harness, and test binary transitively inherited the license layer, contradicting core-mode semantics (AGENTS.md §2: "Do not make public/core builds depend on premium/private modules").
- Real consumers already link it directly: the app (`Source/CMakeLists.txt:124`, PRIVATE, with its own hard requirement check) and `LocalAccountCacheTest`.

## Testing performed
- Clean reconfigure; `AestraHeadless` + `SampleRateBufferTruthTest` build and link without the transitive edge.
- The app target's own direct AestraLicense link is untouched — the new UI/App compile CI lane (#443) proves the full app build on this PR.

## Risk / rollback
One CMake block removed, replaced by a comment stating the invariant. If anything out-of-tree relied on the transitive link, the fix is to link AestraLicense at that consumer, not here. Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)