### PR TITLE
feat(serialization): content-integrity checksum on save, verified on load (#263)

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -88,6 +89,36 @@ namespace {
     private:
         std::array<size_t, static_cast<size_t>(ProjectLoadWarningCategory::Count)> m_counts{};
     };
+
+    // --- Content integrity (#263) -------------------------------------------
+    // FNV-1a 64-bit over the canonical compact serialization. Corruption
+    // detection only — keyless, so it authenticates nothing; it catches disk
+    // corruption, truncated writes, and accidental edits.
+    uint64_t fnv1a64(const std::string& data) {
+        uint64_t hash = 1469598103934665603ull;
+        for (const unsigned char c : data) {
+            hash ^= c;
+            hash *= 1099511628211ull;
+        }
+        return hash;
+    }
+
+    constexpr const char* INTEGRITY_ALGO = "fnv1a64";
+
+    // Computes the canonical content hash with the integrity hash field pinned
+    // to "" — save and load call this with an identical tree shape, so both
+    // hash identical bytes. NOTE: mutates root's integrity field; the caller
+    // either overwrites it with the real hash (save) or no longer needs it (load).
+    std::string computeIntegrityHashHex(JSON& root) {
+        JSON integrity = JSON::object();
+        integrity.set("algo", JSON(INTEGRITY_ALGO));
+        integrity.set("hash", JSON(""));
+        root.set("integrity", integrity);
+        const uint64_t hash = fnv1a64(root.toString(0));
+        char buf[17];
+        std::snprintf(buf, sizeof(buf), "%016llx", static_cast<unsigned long long>(hash));
+        return std::string(buf);
+    }
 
     std::string bytesToHex(const std::vector<uint8_t>& bytes) {
         std::ostringstream oss;
@@ -876,6 +907,17 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
         root.set("ui", ui);
     }
 
+    // Content integrity (#263): stamp a canonical-content checksum so load can
+    // detect corruption. Must be the LAST field written — the hash covers every
+    // other field, computed with the hash slot pinned to "".
+    {
+        const std::string hashHex = computeIntegrityHashHex(root);
+        JSON integrity = JSON::object();
+        integrity.set("algo", JSON(INTEGRITY_ALGO));
+        integrity.set("hash", JSON(hashHex));
+        root.set("integrity", integrity);
+    }
+
     result.contents = root.toString(indentSpaces);
     result.ok = true;
     return result;
@@ -986,6 +1028,36 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
 #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
     Log::info("[ProjectLoad] Parsed JSON ok");
 #endif
+
+    // Content integrity (#263): verify the checksum BEFORE migrations mutate
+    // the tree. Files that predate the integrity field (or use an unknown
+    // algo) load as Unchecked with no warning — backward compatible. A
+    // mismatch loads non-destructively but loudly: the session may be
+    // recoverable, and holding it hostage would betray recovery obligations;
+    // structurally corrupt files still hard-fail through the validators below.
+    if (root.has("integrity") && root["integrity"].isObject()) {
+        const JSON& integrityField = root["integrity"];
+        const std::string storedAlgo =
+            integrityField.has("algo") && integrityField["algo"].isString() ? integrityField["algo"].asString() : "";
+        const std::string storedHash =
+            integrityField.has("hash") && integrityField["hash"].isString() ? integrityField["hash"].asString() : "";
+        if (storedAlgo == INTEGRITY_ALGO && storedHash.size() == 16) {
+            // Recompute over the canonical form (hash slot pinned to "") — this
+            // overwrites root's integrity field, which nothing downstream reads.
+            const std::string computedHash = computeIntegrityHashHex(root);
+            if (computedHash == storedHash) {
+                result.integrity = LoadIntegrity::Verified;
+            } else {
+                result.integrity = LoadIntegrity::Mismatch;
+                Log::error("[ProjectLoad] CONTENT INTEGRITY MISMATCH: file was modified or corrupted since save "
+                           "(stored " + storedHash + ", computed " + computedHash +
+                           "). Loading non-destructively — verify the session before overwriting backups.");
+            }
+        } else {
+            Log::info("[ProjectLoad] Integrity field present but unrecognized (algo='" + storedAlgo +
+                      "') — skipping verification.");
+        }
+    }
 
     // Version check
     int fileVersion = 0;
@@ -1118,8 +1190,20 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     }
 
     // Build structured report for reference validation issues
-    if (!orphanClipPatternIds.empty() || !orphanNoteUnitIds.empty()) {
+    if (!orphanClipPatternIds.empty() || !orphanNoteUnitIds.empty() ||
+        result.integrity == LoadIntegrity::Mismatch) {
         auto report = std::make_unique<ProjectLoadReport>();
+        if (result.integrity == LoadIntegrity::Mismatch) {
+            report->issues.push_back({
+                LoadIssueSeverity::Warning,
+                "integrity",
+                "Project content checksum mismatch - file was modified or corrupted since save; "
+                "loaded non-destructively, verify the session before overwriting backups",
+                0,
+                "",
+                ""
+            });
+        }
         for (const auto& pid : orphanClipPatternIds) {
             report->issues.push_back({
                 LoadIssueSeverity::Warning,

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -63,12 +63,27 @@ public:
         std::vector<PanelState> panels;
     };
 
+    /**
+     * @brief Content-integrity verdict for a loaded project file (#263).
+     *
+     * Corruption detection, NOT tamper-proofing: the checksum is keyless, so
+     * anyone can recompute it. It exists to catch disk corruption, truncated
+     * writes, and accidental edits — never to authenticate a file.
+     * - Unchecked: file predates the integrity field (or unknown algo) — no warning.
+     * - Verified:  stored checksum matches the recomputed one.
+     * - Mismatch:  content changed since save; load proceeds non-destructively
+     *              with a loud warning (structural corruption still hard-fails
+     *              through the existing validators).
+     */
+    enum class LoadIntegrity { Unchecked, Verified, Mismatch };
+
     struct LoadResult {
         bool ok{false};
         double tempo{120.0};
         double playhead{0.0};
         std::string errorMessage;
         std::vector<std::string> missingAssets;
+        LoadIntegrity integrity{LoadIntegrity::Unchecked};
 
         std::optional<UIState> ui;
         std::unique_ptr<::Aestra::ProjectLoadReport> report;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -167,6 +167,35 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripIntegrityTest
     set_tests_properties(ProjectRoundTripIntegrityTest PROPERTIES LABELS "integration;serialization")
 endif()
 
+# Project Integrity Check Test — corrupt files must not load silently (#263)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectIntegrityCheckTest.cpp")
+    add_executable(ProjectIntegrityCheckTest
+        Integration/ProjectIntegrityCheckTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(ProjectIntegrityCheckTest PRIVATE AestraAudio)
+    target_include_directories(ProjectIntegrityCheckTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    target_compile_definitions(ProjectIntegrityCheckTest PRIVATE
+        AESTRA_PROJECT_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/Fixtures/ProjectFormat"
+        $<$<CONFIG:Debug>:AESTRA_ENABLE_PROJECT_LOAD_LOGS>
+    )
+    add_test(NAME ProjectIntegrityCheckTest COMMAND ProjectIntegrityCheckTest)
+    set_tests_properties(ProjectIntegrityCheckTest PROPERTIES LABELS "integration;serialization")
+endif()
+
 # Project Fixture Corpus Test — checked-in v1 files are the compatibility contract (#249)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectFixtureCorpusTest.cpp")
     add_executable(ProjectFixtureCorpusTest

--- a/Tests/Integration/ProjectIntegrityCheckTest.cpp
+++ b/Tests/Integration/ProjectIntegrityCheckTest.cpp
@@ -1,0 +1,145 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// ProjectIntegrityCheckTest — corrupt project files must not load silently (#263).
+//
+// The serializer stamps a keyless FNV-1a-64 checksum over the canonical
+// compact serialization (corruption detection, NOT tamper-proofing). This test
+// pins the contract:
+//   1. save -> load: Verified, no report issues.
+//   2. a flipped value in the file: loads non-destructively, Mismatch, and the
+//      structured report carries an "integrity" warning.
+//   3. legacy files without the field (v1_rich.aes fixture): Unchecked, silent.
+//   4. the autosave path (serialize + writeAtomically) carries the checksum too.
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "Models/TrackManager.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        ++g_failures;
+    }
+}
+
+std::filesystem::path makeTempDir() {
+    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
+    std::filesystem::create_directories(base);
+    for (int i = 0; i < 1000; ++i) {
+        auto candidate = base / ("IntegrityCheck_" + std::to_string(i));
+        if (!std::filesystem::exists(candidate)) {
+            std::filesystem::create_directories(candidate);
+            return candidate;
+        }
+    }
+    auto fallback = base / "IntegrityCheck_fallback";
+    std::filesystem::create_directories(fallback);
+    return fallback;
+}
+
+std::shared_ptr<Aestra::Audio::TrackManager> makeFreshManager() {
+    auto tm = std::make_shared<Aestra::Audio::TrackManager>();
+    tm->getPlaylistModel().setPatternManager(&tm->getPatternManager());
+    return tm;
+}
+
+bool reportHasIntegrityIssue(const ProjectSerializer::LoadResult& load) {
+    if (!load.report)
+        return false;
+    for (const auto& issue : load.report->issues) {
+        if (issue.category == "integrity")
+            return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    const auto tempDir = makeTempDir();
+    std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
+
+    // Build a small project.
+    auto tm1 = makeFreshManager();
+    tm1->getPlaylistModel().setBPM(133.25);
+    tm1->getPlaylistModel().createLane("Integrity Lane");
+    tm1->addChannel("Integrity Lane");
+
+    // ---------------- 1. Clean save -> load: Verified, no report.
+    const auto cleanPath = tempDir / "clean.aes";
+    require(ProjectSerializer::save(cleanPath.string(), tm1, 133.25, 0.5), "save failed");
+    {
+        auto tm2 = makeFreshManager();
+        auto load = ProjectSerializer::load(cleanPath.string(), tm2);
+        require(load.ok, "clean load failed");
+        require(load.integrity == ProjectSerializer::LoadIntegrity::Verified,
+                "clean file did not verify (expected Verified)");
+        require(!reportHasIntegrityIssue(load), "clean load raised an integrity issue");
+    }
+
+    // ---------------- 2. Corrupted value: loads, Mismatch, report issue.
+    {
+        std::ifstream in(cleanPath);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        in.close();
+        // Flip the tempo value in-place (structure stays valid, content lies).
+        const auto pos = contents.find("133.25");
+        require(pos != std::string::npos, "test setup: tempo literal not found in file");
+        contents.replace(pos, 6, "233.25");
+
+        const auto corruptPath = tempDir / "corrupt.aes";
+        std::ofstream(corruptPath) << contents;
+
+        auto tm3 = makeFreshManager();
+        auto load = ProjectSerializer::load(corruptPath.string(), tm3);
+        require(load.ok, "corrupted-value file must still load non-destructively");
+        require(load.integrity == ProjectSerializer::LoadIntegrity::Mismatch,
+                "corrupted file did not report Mismatch");
+        require(reportHasIntegrityIssue(load), "mismatch missing from the structured load report");
+    }
+
+    // ---------------- 3. Legacy file without integrity field: Unchecked, silent.
+    {
+        const auto legacyPath = std::filesystem::path(AESTRA_PROJECT_FIXTURE_DIR) / "v1_rich.aes";
+        require(std::filesystem::exists(legacyPath), "v1_rich.aes fixture missing");
+        auto tm4 = makeFreshManager();
+        auto load = ProjectSerializer::load(legacyPath.string(), tm4);
+        require(load.ok, "legacy fixture load failed");
+        require(load.integrity == ProjectSerializer::LoadIntegrity::Unchecked,
+                "legacy file without integrity field must load Unchecked");
+        require(!reportHasIntegrityIssue(load), "legacy load raised an integrity issue");
+    }
+
+    // ---------------- 4. Autosave path (serialize + writeAtomically) verifies too.
+    {
+        auto ser = ProjectSerializer::serialize(tm1, 133.25, 0.5, 0);
+        require(ser.ok, "serialize failed");
+        require(ser.contents.find("\"integrity\"") != std::string::npos,
+                "autosave-style serialization missing integrity field");
+        const auto autosavePath = tempDir / "autosave.aes";
+        require(ProjectSerializer::writeAtomically(autosavePath.string(), ser.contents), "atomic write failed");
+        auto tm5 = makeFreshManager();
+        auto load = ProjectSerializer::load(autosavePath.string(), tm5);
+        require(load.ok, "autosave load failed");
+        require(load.integrity == ProjectSerializer::LoadIntegrity::Verified,
+                "autosave did not verify (expected Verified)");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] ProjectIntegrityCheckTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] ProjectIntegrityCheckTest\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
Serialization trust cluster PR 4 (**stacked on #448** — retarget to develop after it merges). Closes #263, the last MUST-FIX item of the cluster (beta-gameplan §2.3).

Saves stamp a checksum over the canonical compact serialization; load verifies it **before migrations mutate the tree** and exposes a tri-state `LoadResult::integrity`:

| State | When | Behavior |
|---|---|---|
| `Verified` | checksum matches | silent |
| `Mismatch` | content changed since save | **loud** ERROR log with both hashes + `integrity` warning in the structured `ProjectLoadReport`; load proceeds non-destructively |
| `Unchecked` | file predates the field / unknown algo | silent — fully backward compatible |

## Design notes
- **Corruption detection, NOT tamper-proofing** — FNV-1a-64, keyless; documented as such in the header. It catches disk corruption, truncated writes, accidental edits. Authentication would need signing and belongs to the license layer, not here.
- **Non-destructive on mismatch, by philosophy**: 'recovery from failure must be fast, automatic, and complete' — a corrupt-but-parseable session may be mostly recoverable, so we warn loudly instead of refusing. Structurally corrupt files still hard-fail through the existing validators.
- Hash is computed over the canonical compact re-serialization with the hash slot pinned to `""`, so save and load hash identical bytes regardless of on-disk indentation. Deterministic thanks to sorted JSON keys + the round-trip-exact number formatter from #445.
- Autosaves carry the checksum by construction (stamping lives in `serialize()`).

## Testing performed
- **ProjectIntegrityCheckTest** (new, `serialization` label): clean→Verified; flipped-value file→loads + Mismatch + report issue; v1_rich legacy fixture→Unchecked silent; autosave path→Verified.
- Full save-path regression sweep, 10/10: RoundTrip, AutosaveRoundTrip, Integrity, FixtureCorpus, ValueFidelity, IntegrityCheck, LoadRegression, SessionRecovery, AutosaveManager, TakeManager.

## Change type
- Serialization/project format changed: **additive field only** (`integrity`). Old files load unchanged; new files remain loadable by older builds that ignore unknown keys.

## Risk / rollback
Additive; rollback = revert (files saved with the field simply load Unchecked... actually they'd verify or mismatch — on revert they load as before with the extra key ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)