### PR TITLE
feat(audio): live MIDI note input path — notes reach instruments with transport stopped

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -13,6 +13,7 @@
 #include "EngineState.h"
 #include "GarbageCollector.h"
 #include "Interpolators.h"
+#include "Playback/LiveMidiQueue.h"
 #include "LatencyTopology.h"
 #include "MasterSafetyLimiter.h"
 #include "MeterSnapshot.h"
@@ -344,6 +345,21 @@ public:
     /** @brief Get the loop end position in beats. */
     double getLoopEndBeat() const { return m_loopEndBeat.load(std::memory_order_relaxed); }
 
+    /**
+     * @brief Post a live MIDI event (note input) for an Arsenal unit.
+     *
+     * Lock-free, allocation-free; safe to call from exactly ONE non-RT
+     * producer thread (the UI thread today — a hardware MIDI callback thread
+     * will get its own queue). Events are drained on the audio thread each
+     * block and delivered to the unit's plugin alongside pattern playback,
+     * with or without the transport running.
+     *
+     * @return false if the queue was full and the event was dropped.
+     */
+    bool postLiveMidiEvent(uint64_t unitId, uint8_t status, uint8_t data1, uint8_t data2) noexcept {
+        return m_liveMidiQueue.push(LiveMidiQueue::Event{unitId, status, data1, data2});
+    }
+
     /** @brief Enable or disable Arsenal pattern playback mode. */
     void setPatternPlaybackMode(bool enabled, double lengthBeats) {
         m_patternPlaybackMode.store(enabled, std::memory_order_relaxed);
@@ -647,6 +663,11 @@ private:
     void syncCachedSamplerSampleRatesRt(uint32_t sampleRate) noexcept;
     void injectPendingUnitAudition(PatternPlaybackEngine::UnitMidiRoute* routes, size_t routeCount,
                                    uint32_t numFrames) noexcept;
+    void drainLiveMidi(PatternPlaybackEngine::UnitMidiRoute* routes, size_t routeCount) noexcept;
+
+    // Live note input (computer keyboard today, hardware MIDI later). One
+    // SPSC queue per producer thread; drained on the audio thread each block.
+    LiveMidiQueue m_liveMidiQueue;
 
     // Pre-allocated buffers for Arsenal unit processing (RT-safe)
     std::vector<double> m_unitBufferD;         // Stereo interleaved unit output

--- a/AestraAudio/include/Playback/LiveMidiQueue.h
+++ b/AestraAudio/include/Playback/LiveMidiQueue.h
@@ -1,0 +1,69 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Lock-free single-producer / single-consumer queue for live MIDI events.
+ *
+ * The live note-input path: UI keyboard input (and later each hardware MIDI
+ * callback thread) pushes raw events; the audio thread drains them once per
+ * processBlock into the per-unit MidiBuffers, alongside pattern playback.
+ *
+ * SPSC means exactly ONE producer thread per queue instance — a second input
+ * source (e.g. hardware MIDI) gets its own queue, drained by the same
+ * consumer. No locks, no allocation, fixed power-of-two capacity. push()
+ * returns false when full and the event is dropped: for live input, late is
+ * worse than lost.
+ *
+ * Each event carries its target unit id, so note-offs posted after the UI
+ * switches the active unit still reach the unit that received the note-on.
+ */
+class LiveMidiQueue {
+public:
+    struct Event {
+        uint64_t unitId{0}; ///< Target Arsenal unit (UnitID)
+        uint8_t status{0};  ///< MIDI status byte (e.g. 0x90 note-on ch1)
+        uint8_t data1{0};   ///< First data byte (note number)
+        uint8_t data2{0};   ///< Second data byte (velocity)
+    };
+
+    /// Producer side (one non-RT thread). Returns false if the queue is full.
+    bool push(const Event& ev) noexcept {
+        const uint32_t head = m_head.load(std::memory_order_relaxed);
+        const uint32_t next = (head + 1) & kMask;
+        if (next == m_tail.load(std::memory_order_acquire)) {
+            return false;
+        }
+        m_events[head] = ev;
+        m_head.store(next, std::memory_order_release);
+        return true;
+    }
+
+    /// Consumer side (audio thread). Returns false when empty.
+    bool pop(Event& out) noexcept {
+        const uint32_t tail = m_tail.load(std::memory_order_relaxed);
+        if (tail == m_head.load(std::memory_order_acquire)) {
+            return false;
+        }
+        out = m_events[tail];
+        m_tail.store((tail + 1) & kMask, std::memory_order_release);
+        return true;
+    }
+
+private:
+    static constexpr uint32_t kCapacity = 512; // power of two; ~= 5s of frantic playing
+    static constexpr uint32_t kMask = kCapacity - 1;
+
+    std::array<Event, kCapacity> m_events{};
+    std::atomic<uint32_t> m_head{0};
+    std::atomic<uint32_t> m_tail{0};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1946,7 +1946,13 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
                 drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
             }
+        } else if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
+            // No routable units in Timeline mode: drain-and-drop so stale live
+            // events cannot pile up and land as a burst when units appear.
+            drainLiveMidi(nullptr, 0);
         }
+    } else if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
+        drainLiveMidi(nullptr, 0);
     }
 
     // Clear all per-track buffers for this block up front so routed audio can
@@ -3008,12 +3014,22 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     auto* patternEngine = m_patternEngine.load(std::memory_order_acquire);
     auto* unitManager = m_unitManager.load(std::memory_order_acquire);
 
-    if (!patternEngine || !unitManager)
+    if (!patternEngine || !unitManager) {
+        // Keep the live-queue safety net effective: drop stale live events so
+        // they cannot pile up and land as a burst when units appear later.
+        // Only the realtime block (targetBuffer == nullptr) may touch the
+        // SPSC queue — the offline bounce path runs on another thread.
+        if (targetBuffer == nullptr)
+            drainLiveMidi(nullptr, 0);
         return;
+    }
 
     const uint32_t sampleRate = m_sampleRate.load(std::memory_order_relaxed);
-    if (sampleRate == 0)
+    if (sampleRate == 0) {
+        if (targetBuffer == nullptr)
+            drainLiveMidi(nullptr, 0);
         return;
+    }
 
     // Sync logic moved after snapshot retrieval
 
@@ -3026,6 +3042,9 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     // Get Arsenal snapshot for RT-safe unit iteration
     auto snapshot = unitManager->getAudioSnapshot();
     if (!snapshot || snapshot->units.empty()) {
+        // No routable units: drain-and-drop live events (see note above).
+        if (targetBuffer == nullptr)
+            drainLiveMidi(nullptr, 0);
         return;
     }
 
@@ -3035,6 +3054,8 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     // Buffers must be pre-sized in setBufferConfig()
     if (m_unitBufferD.size() < requiredStereoSamples || m_pluginBufferF.size() < requiredStereoSamples ||
         m_silentBufferF.size() < numFrames) {
+        if (targetBuffer == nullptr)
+            drainLiveMidi(nullptr, 0);
         return;
     }
     // Always zero the silent buffer (just in case)
@@ -3066,7 +3087,12 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     // Live note input in Arsenal mode (this function early-returns unless
     // patternPlaybackMode, so this is the only drain per block here). Runs with
     // or without the transport — playing an instrument must not require play.
-    drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
+    // Offline isolated-track bounce (targetBuffer set) runs on a non-RT thread
+    // while the realtime callback may still be live: it must never touch the
+    // single-consumer queue, which also keeps live notes out of bounced files.
+    if (targetBuffer == nullptr) {
+        drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
+    }
 
     // Process each unit plugin
     bufIdx = 0;

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -374,6 +374,30 @@ void AudioEngine::injectPendingUnitAudition(PatternPlaybackEngine::UnitMidiRoute
     }
 }
 
+void AudioEngine::drainLiveMidi(PatternPlaybackEngine::UnitMidiRoute* routes, size_t routeCount) noexcept {
+    LiveMidiQueue::Event ev;
+    if (!routes || routeCount == 0) {
+        // No routable units this block: drain and drop so the queue can never
+        // build a backlog of stale notes that would all fire at once later.
+        while (m_liveMidiQueue.pop(ev)) {
+        }
+        return;
+    }
+    // Bounded: pop() can return at most kCapacity events, and MidiBuffer::addEvent
+    // itself caps at kMaxEvents. No allocation, no locks.
+    while (m_liveMidiQueue.pop(ev)) {
+        for (size_t i = 0; i < routeCount; ++i) {
+            if (routes[i].unitId == static_cast<UnitID>(ev.unitId) && routes[i].midiBuffer != nullptr) {
+                const uint8_t data[3] = {ev.status, ev.data1, ev.data2};
+                // Offset 0: live events sound at the start of the block they
+                // were drained in (worst-case latency = one block).
+                routes[i].midiBuffer->addEvent(0, data, 3);
+                break;
+            }
+        }
+    }
+}
+
 void AudioEngine::setThreadCount(int count) {
     if (count < 1)
         count = 1;
@@ -1915,6 +1939,13 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             }
 
             injectPendingUnitAudition(unitMidiRoutes.data(), unitMidiRouteCount, numFrames);
+
+            // Live note input in Timeline mode. Gated on !patternPlaybackMode so
+            // exactly one path drains the queue per block — Arsenal mode drains
+            // inside processArsenalUnits (which self-gates on the same flag).
+            if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
+                drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
+            }
         }
     }
 
@@ -3031,6 +3062,11 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     }
 
     injectPendingUnitAudition(unitMidiRoutes.data(), unitMidiRouteCount, numFrames);
+
+    // Live note input in Arsenal mode (this function early-returns unless
+    // patternPlaybackMode, so this is the only drain per block here). Runs with
+    // or without the transport — playing an instrument must not require play.
+    drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
 
     // Process each unit plugin
     bufIdx = 0;

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -78,6 +78,25 @@ if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins AND EXISTS "${CMAKE_CU
     )
 endif()
 
+# Live MIDI Input Test — live note input audible with transport stopped.
+# Core-mode: uses the built-in SamplerPlugin with an injected synthetic sample,
+# so it runs on every CI lane (no premium modules, no files, no devices).
+if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LiveMidiInputTest.cpp")
+    add_executable(LiveMidiInputTest
+        LiveMidiInputTest.cpp
+    )
+    target_link_libraries(LiveMidiInputTest PRIVATE AestraAudioCore)
+    target_include_directories(LiveMidiInputTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME LiveMidiInputTest COMMAND LiveMidiInputTest)
+    set_tests_properties(LiveMidiInputTest PROPERTIES
+        LABELS "headless;arsenal;audio;midi"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 # PDC v2 P1 — scaffolding tests (see AestraDocs/PDC-v2-Design.md §12)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCFlatChainTest.cpp")
     add_executable(PDCFlatChainTest PDCFlatChainTest.cpp)

--- a/Tests/Headless/LiveMidiInputTest.cpp
+++ b/Tests/Headless/LiveMidiInputTest.cpp
@@ -1,0 +1,161 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// LiveMidiInputTest
+// Proves live note input (AudioEngine::postLiveMidiEvent) reaches an Arsenal
+// unit's instrument and produces audible output with the transport STOPPED —
+// playing an instrument must not require pressing play. Uses the built-in
+// SamplerPlugin with an injected synthetic sample, so it runs in core mode on
+// every CI lane (no premium modules, no files, no devices).
+
+#include "Core/AudioEngine.h"
+#include "Models/PatternManager.h"
+#include "Models/UnitManager.h"
+#include "Playback/PatternPlaybackEngine.h"
+#include "Playback/TimelineClock.h"
+#include "Plugin/SamplerPlugin.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace {
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+struct Stats {
+    float peak = 0.0f;
+    bool hasInvalid = false;
+};
+
+Stats analyze(const std::vector<float>& interleaved) {
+    Stats stats;
+    for (float s : interleaved) {
+        if (!std::isfinite(s)) {
+            stats.hasInvalid = true;
+        }
+        stats.peak = std::max(stats.peak, std::abs(s));
+    }
+    return stats;
+}
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    constexpr uint32_t sampleRate = 48000;
+    constexpr uint32_t blockSize = 256;
+    constexpr uint32_t channels = 2;
+    constexpr uint8_t kNoteOn = 0x90;
+    constexpr uint8_t kNoteOff = 0x80;
+    constexpr uint8_t kMiddleC = 60;
+
+    UnitManager unitManager;
+    PatternManager patternManager;
+    TimelineClock clock(120.0);
+    PatternPlaybackEngine playbackEngine(&clock, &patternManager, &unitManager);
+
+    // Built-in sampler with an injected 0.25 s constant-tone sample — core-mode,
+    // no premium plugins, no file I/O.
+    auto sampler = std::make_shared<Plugins::SamplerPlugin>();
+    require(sampler->initialize(sampleRate, blockSize), "SamplerPlugin failed to initialize");
+    sampler->activate();
+    // Short release: with the 300 ms default, a one-shot sample shorter than
+    // the release time enters Release at trigger with releaseGain captured at 0
+    // and never sounds (filed as a sampler bug; this test targets the live-MIDI
+    // routing path, not that envelope quirk).
+    sampler->setEnvelope(0.005f, 0.05f, 0.8f, 0.05f);
+    {
+        const uint32_t sampleFrames = sampleRate / 4;
+        std::vector<float> data(sampleFrames, 0.0f);
+        for (uint32_t i = 0; i < sampleFrames; ++i) {
+            data[i] = 0.5f * std::sin(2.0 * 3.14159265358979 * 220.0 * (static_cast<double>(i) / sampleRate));
+        }
+        require(sampler->loadSampleData("live-midi-test-tone", std::move(data), sampleRate, 1),
+                "loadSampleData failed");
+    }
+
+    UnitID unitId = unitManager.createUnit("Live Sampler", UnitGroup::Synth);
+    unitManager.attachPlugin(unitId, "com.Aestrastudios.sampler", sampler);
+    unitManager.setUnitEnabled(unitId, true);
+    unitManager.setUnitMixerChannel(unitId, -1); // route directly to master in Arsenal mode
+    unitManager.captureUnitPluginState(unitId);
+
+    AudioEngine engine;
+    require(engine.initialize(), "AudioEngine failed to initialize");
+    engine.setSampleRate(sampleRate);
+    engine.setBufferConfig(blockSize, channels);
+    engine.setBPM(120.0f);
+    engine.setUnitManager(&unitManager);
+    engine.setPatternPlaybackEngine(&playbackEngine);
+    engine.setPatternPlaybackMode(true, 2.0);
+    // Deliberately NOT calling setTransportPlaying(true): live input must sound
+    // while the transport is stopped.
+
+    std::vector<float> output(blockSize * channels, 0.0f);
+    auto renderBlocks = [&](uint32_t blocks, std::vector<float>* capture) {
+        for (uint32_t b = 0; b < blocks; ++b) {
+            std::fill(output.begin(), output.end(), 0.0f);
+            engine.processBlock(output.data(), nullptr, blockSize, 0.0);
+            if (capture != nullptr) {
+                capture->insert(capture->end(), output.begin(), output.end());
+            }
+        }
+    };
+
+    // ---------------- 1. Silence before any input.
+    std::vector<float> silentLead;
+    renderBlocks(8, &silentLead);
+    const auto leadStats = analyze(silentLead);
+    require(!leadStats.hasInvalid, "Lead-in contains NaN/Inf");
+    require(leadStats.peak < 1.0e-6f, "Output not silent before any live input");
+
+    // ---------------- 2. Live note-on (transport stopped) becomes audible.
+    require(engine.postLiveMidiEvent(unitId, kNoteOn, kMiddleC, 110), "postLiveMidiEvent rejected note-on");
+    std::vector<float> noteAudio;
+    renderBlocks(32, &noteAudio); // ~170 ms, well inside the 250 ms sample
+    const auto noteStats = analyze(noteAudio);
+    require(!noteStats.hasInvalid, "Live-note audio contains NaN/Inf");
+    require(noteStats.peak > 1.0e-4f, "Live note-on produced silence with transport stopped");
+    require(noteStats.peak < 0.99f, "Live-note output peak too high");
+
+    // ---------------- 3. Voice ends (note-off / sample end): back to silence.
+    // This pins "no stuck voices", independent of the sampler's exact
+    // note-off envelope semantics.
+    engine.postLiveMidiEvent(unitId, kNoteOff, kMiddleC, 0);
+    renderBlocks(96, nullptr); // ~510 ms — beyond the sample length + release
+    std::vector<float> tail;
+    renderBlocks(16, &tail);
+    const auto tailStats = analyze(tail);
+    require(!tailStats.hasInvalid, "Post-note audio contains NaN/Inf");
+    require(tailStats.peak < 1.0e-3f, "Live voice did not return to silence");
+
+    // ---------------- 4. Chords: two simultaneous notes sound together.
+    require(engine.postLiveMidiEvent(unitId, kNoteOn, kMiddleC, 110), "chord note 1 rejected");
+    require(engine.postLiveMidiEvent(unitId, kNoteOn, kMiddleC + 7, 110), "chord note 2 rejected");
+    std::vector<float> chordAudio;
+    renderBlocks(32, &chordAudio);
+    const auto chordStats = analyze(chordAudio);
+    require(!chordStats.hasInvalid, "Chord audio contains NaN/Inf");
+    require(chordStats.peak > 1.0e-4f, "Chord produced silence");
+    engine.postLiveMidiEvent(unitId, kNoteOff, kMiddleC, 0);
+    engine.postLiveMidiEvent(unitId, kNoteOff, kMiddleC + 7, 0);
+    renderBlocks(112, nullptr);
+
+    // ---------------- 5. Events for unknown units are dropped harmlessly.
+    require(engine.postLiveMidiEvent(unitId + 999, kNoteOn, kMiddleC, 100),
+            "unknown-unit event rejected at queue");
+    std::vector<float> unknownUnit;
+    renderBlocks(16, &unknownUnit);
+    const auto unknownStats = analyze(unknownUnit);
+    require(unknownStats.peak < 1.0e-3f, "Event for unknown unit produced audio");
+
+    std::cout << "Live note peak: " << noteStats.peak << ", chord peak: " << chordStats.peak << "\n";
+    std::cout << "[PASS] LiveMidiInputTest\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
**First half of the note-input feature** (beta-gameplan §2.4, the core-loop existential gap): the engine can now receive live note events. Until now, nothing could play a note into Aestra in real time — pattern playback was the only route to an instrument.

- **`LiveMidiQueue`** — lock-free SPSC ring (512 events, fixed storage, zero allocation). One queue per producer thread: UI keyboard first (next PR), each hardware-MIDI callback thread (RtMidi, vendoring owner-approved) gets its own later. Full queue drops the newest event: for live input, late is worse than lost.
- **`AudioEngine::postLiveMidiEvent(unitId, status, d1, d2)`** — producer API. Events carry their target unit, so note-offs posted after the UI switches units still reach the unit holding the note (no stuck notes by construction).
- **`drainLiveMidi()`** — drained once per block on the audio thread into the existing per-unit `MidiBuffer`s, right beside `injectPendingUnitAudition`. Exactly one drain per block in every mode: the Timeline-mode site gates on `!patternPlaybackMode`; the Arsenal-mode site lives inside `processArsenalUnits`, which self-gates on the same flag. **Works with the transport stopped** — playing an instrument must not require pressing play.

## RT-safety
Bounded work (queue capacity bounds the drain; `MidiBuffer::addEvent` caps at kMaxEvents), no locks, no allocation, acquire/release SPSC. Gates re-run green: **RTAllocationTrapTest, RealtimeExportParityTest, GoldenAudioRegressionTest**.

## Testing performed
`LiveMidiInputTest` (new, **core-mode headless — runs on every CI lane**; built-in SamplerPlugin with an injected synthetic sample, no premium modules/files/devices):
1. silence before any input,
2. live note-on audible with transport stopped,
3. voice returns to silence (no stuck voices),
4. chords (two simultaneous notes),
5. events for unknown units dropped harmlessly.

## Found along the way
Building the test exposed a real sampler bug, filed separately: in one-shot mode, a sample **shorter than the release time** enters Release at trigger with `releaseGain` captured at 0 — the voice is permanently silent (SamplerPlugin.cpp:360-368). The test works around it with a short release and documents why.

## Next in this series
PR 2: computer-keyboard note entry (QWERTY-as-piano) feeding `postLiveMidiEvent` — owner-decided keyboard-first. PR 3: RtMidi vendoring + hardware MIDI-in on its own queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added live MIDI note input to the audio engine so instruments can be played in real time even when transport is stopped.
- Introduced `LiveMidiQueue`, a fixed-size lock-free SPSC ring buffer for handing off MIDI events safely from producer threads to the audio thread.
- Added `AudioEngine::postLiveMidiEvent(...)` to enqueue live note events with their target unit ID, ensuring note-offs still reach the correct instrument after unit switching.
- Wired live MIDI draining into the render path so queued events are merged into per-unit MIDI buffers each audio block alongside existing audition/pattern processing.
- Added a headless integration test covering silence before input, live note-on/note-off behavior, chord handling, and dropping events for unknown units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->