### PR TITLE
feat(ui): musical typing — QWERTY plays the piano roll's instrument live

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -713,6 +713,21 @@ AestraContent::AestraContent() {
         m_pianoRollPanel->setAudioEngine(m_audioEngine);
     }
     m_pianoRollPanel->setVisible(false);
+
+    // Musical typing: QWERTY plays the piano roll's editing unit through the
+    // live-MIDI path. The target unit (tag) is captured at note-on, so
+    // note-offs reach the right unit even if the editing unit changes mid-hold.
+    m_keyboardNoteInput.setTagProvider([this]() -> uint64_t {
+        if (m_pianoRollPanel && m_pianoRollPanel->isVisible()) {
+            return static_cast<uint64_t>(m_pianoRollPanel->getEditingUnitId());
+        }
+        return 0;
+    });
+    m_keyboardNoteInput.setSink([this](uint8_t note, uint8_t velocity, bool on, uint64_t tag) {
+        if (m_audioEngine && tag != 0) {
+            m_audioEngine->postLiveMidiEvent(tag, on ? uint8_t{0x90} : uint8_t{0x80}, note, velocity);
+        }
+    });
     m_pianoRollPanel->setOnPatternEdited([this](PatternID patternId) {
         // Pattern already saved by PianoRollPanel before firing this callback.
         // Refresh every surface that can render the same pattern.
@@ -3728,6 +3743,13 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         m_spaceShortcutLatched = false;
         return true;
     }
+
+    // Musical-typing note-offs need key RELEASES, which nothing else consumes —
+    // handle them before the press-only early-return. Runs even if the piano
+    // roll closed mid-hold: releases only match keys that produced a note-on.
+    if (event.released && m_keyboardNoteInput.handleKeyEvent(event))
+        return true;
+
     if (!event.pressed)
         return false;
 
@@ -3735,6 +3757,13 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
     // and note shortcuts must take priority over global handlers
     if (m_pianoRollPanel && m_pianoRollPanel->isVisible()) {
         if (m_pianoRollPanel->handleKeyEvent(event))
+            return true;
+
+        // Musical typing: unconsumed plain keys play the editing unit live.
+        // After the piano roll's own shortcuts, before global handlers.
+        // (Focused text inputs never reach here — the window manager gives the
+        // focused widget first refusal.)
+        if (m_keyboardNoteInput.handleKeyEvent(event))
             return true;
     }
 

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -21,6 +21,7 @@
 #include "../AestraUI/Widgets/UIRoutingMap.h"
 #include "Events/Connection.h"
 #include "NUILabel.h"
+#include "KeyboardNoteInput.h"
 #include "NUISegmentedControl.h"
 #include "OverlayLayer.h"
 #include "PatternSource.h"
@@ -340,6 +341,8 @@ private:
 
     std::shared_ptr<Aestra::Audio::MixerPanel> m_mixerPanel;
     std::shared_ptr<Aestra::Audio::PianoRollPanel> m_pianoRollPanel;
+    // Musical typing: QWERTY plays the piano roll's editing unit live.
+    Aestra::KeyboardNoteInput m_keyboardNoteInput;
     std::shared_ptr<Aestra::Audio::ArsenalPanel> m_sequencerPanel;
     std::shared_ptr<Aestra::Audio::AestraHistoryPanel> m_historyPanel;
     std::shared_ptr<AestraUI::PluginUIController> m_pluginController;

--- a/Source/Core/KeyboardNoteInput.h
+++ b/Source/Core/KeyboardNoteInput.h
@@ -1,0 +1,175 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "../../AestraUI/Core/NUITypes.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+
+namespace Aestra {
+
+/**
+ * @brief Musical typing — the QWERTY keyboard as a piano.
+ *
+ * Pure key→note translation with held-key tracking; no engine or UI
+ * dependencies, so it is unit-testable headless. The owner (AestraContent)
+ * wires a sink that posts to AudioEngine::postLiveMidiEvent and a tag
+ * provider that resolves the current target unit.
+ *
+ * Layout (Ableton/GarageBand musical typing, restricted to keys that exist
+ * in NUIKeyCode):
+ *
+ *     W E   T Y U   O P        <- black keys (C# D#  F# G# A#  C#' D#')
+ *    A S D F G H J K L         <- white keys (C D E F G A B  C' D')
+ *     Z = octave down, X = octave up
+ *
+ * Rules:
+ *  - The sounding pitch AND target tag are captured at key-DOWN, so octave or
+ *    unit changes while a key is held never orphan the matching note-off.
+ *  - Auto-repeat presses of a held key are swallowed (no retrigger).
+ *  - Ctrl/Alt/Super-modified keys are never consumed (shortcuts win).
+ *  - releaseAll() emits note-offs for everything held (panel close, focus loss).
+ */
+class KeyboardNoteInput {
+public:
+    /// note, velocity, on/off, tag (target unit id captured at note-on).
+    using NoteSink = std::function<void(uint8_t note, uint8_t velocity, bool on, uint64_t tag)>;
+    /// Resolves the target tag (unit id) for a new note-on. 0 = no target; key not consumed.
+    using TagProvider = std::function<uint64_t()>;
+
+    void setSink(NoteSink sink) { m_sink = std::move(sink); }
+    void setTagProvider(TagProvider provider) { m_tagProvider = std::move(provider); }
+
+    /// Returns true when the event was consumed as musical input.
+    bool handleKeyEvent(const AestraUI::NUIKeyEvent& event) {
+        using AestraUI::NUIKeyCode;
+        using AestraUI::NUIModifiers;
+
+        if ((event.modifiers & NUIModifiers::Ctrl) || (event.modifiers & NUIModifiers::Alt) ||
+            (event.modifiers & NUIModifiers::Super)) {
+            return false;
+        }
+
+        // Octave shift (press only).
+        if (event.pressed && !event.repeat) {
+            if (event.keyCode == NUIKeyCode::Z) {
+                if (m_octave > kMinOctave)
+                    --m_octave;
+                return true;
+            }
+            if (event.keyCode == NUIKeyCode::X) {
+                if (m_octave < kMaxOctave)
+                    ++m_octave;
+                return true;
+            }
+        }
+
+        const int semitone = semitoneForKey(event.keyCode);
+        if (semitone < 0) {
+            return false;
+        }
+        const size_t slot = keySlot(event.keyCode);
+
+        if (event.pressed) {
+            if (m_held[slot].down) {
+                return true; // auto-repeat of a held key: swallow, no retrigger
+            }
+            const uint64_t tag = m_tagProvider ? m_tagProvider() : 0;
+            if (tag == 0) {
+                return false; // no target instrument — let others use the key
+            }
+            const int note = m_octave * 12 + semitone;
+            if (note < 0 || note > 127) {
+                return true;
+            }
+            m_held[slot].down = true;
+            m_held[slot].note = static_cast<uint8_t>(note);
+            m_held[slot].tag = tag;
+            ++m_activeCount;
+            if (m_sink) {
+                m_sink(m_held[slot].note, kVelocity, true, tag);
+            }
+            return true;
+        }
+
+        if (event.released && m_held[slot].down) {
+            m_held[slot].down = false;
+            if (m_activeCount > 0)
+                --m_activeCount;
+            if (m_sink) {
+                m_sink(m_held[slot].note, 0, false, m_held[slot].tag);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /// Note-off everything held (panel closed, focus lost, unit destroyed).
+    void releaseAll() {
+        for (auto& key : m_held) {
+            if (key.down) {
+                key.down = false;
+                if (m_sink) {
+                    m_sink(key.note, 0, false, key.tag);
+                }
+            }
+        }
+        m_activeCount = 0;
+    }
+
+    int activeNoteCount() const { return m_activeCount; }
+    int octave() const { return m_octave; }
+    void setOctave(int octave) { m_octave = octave < kMinOctave ? kMinOctave : (octave > kMaxOctave ? kMaxOctave : octave); }
+
+private:
+    static constexpr uint8_t kVelocity = 100;
+    // Octave addressing is note = octave*12 + semitone, so octave 5 puts the
+    // A key on MIDI 60 (middle C). Range keeps the full two-row layout legal.
+    static constexpr int kMinOctave = 0;
+    static constexpr int kMaxOctave = 9;
+
+    struct HeldKey {
+        bool down{false};
+        uint8_t note{0};
+        uint64_t tag{0};
+    };
+
+    // Semitone offset within the octave for each musical key, -1 = not musical.
+    static int semitoneForKey(AestraUI::NUIKeyCode key) {
+        using AestraUI::NUIKeyCode;
+        switch (key) {
+        case NUIKeyCode::A: return 0;   // C
+        case NUIKeyCode::W: return 1;   // C#
+        case NUIKeyCode::S: return 2;   // D
+        case NUIKeyCode::E: return 3;   // D#
+        case NUIKeyCode::D: return 4;   // E
+        case NUIKeyCode::F: return 5;   // F
+        case NUIKeyCode::T: return 6;   // F#
+        case NUIKeyCode::G: return 7;   // G
+        case NUIKeyCode::Y: return 8;   // G#
+        case NUIKeyCode::H: return 9;   // A
+        case NUIKeyCode::U: return 10;  // A#
+        case NUIKeyCode::J: return 11;  // B
+        case NUIKeyCode::K: return 12;  // C, next octave
+        case NUIKeyCode::O: return 13;  // C#'
+        case NUIKeyCode::L: return 14;  // D'
+        case NUIKeyCode::P: return 15;  // D#'
+        default: return -1;
+        }
+    }
+
+    static size_t keySlot(AestraUI::NUIKeyCode key) {
+        // Letters are contiguous (A=65..Z=90); slot by letter index.
+        return static_cast<size_t>(static_cast<int>(key) - static_cast<int>(AestraUI::NUIKeyCode::A));
+    }
+
+    std::array<HeldKey, 26> m_held{};
+    NoteSink m_sink;
+    TagProvider m_tagProvider;
+    int m_octave = 5; // C5 = MIDI 60 (middle C) under octave*12 addressing
+    int m_activeCount = 0;
+};
+
+} // namespace Aestra

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -55,6 +55,8 @@ public:
      * @param unitId Unit identifier used for new note creation.
      */
     void setEditingUnit(UnitID unitId);
+    /** @brief Unit currently bound for editing (0 = none) — musical typing target. */
+    UnitID getEditingUnitId() const { return m_editingUnitId; }
     /**
      * @brief Set the callback fired after the current pattern is edited.
      * @param callback Pattern-edited callback.

--- a/Tests/AestraUI/KeyboardNoteInputTest.cpp
+++ b/Tests/AestraUI/KeyboardNoteInputTest.cpp
@@ -1,0 +1,147 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// KeyboardNoteInputTest — musical-typing translation logic, headless.
+//
+// Pins the QWERTY→note contract the UI relies on: layout mapping, octave
+// shifts, note-on/off pairing across octave and unit changes (tag captured at
+// note-on), auto-repeat swallowing, modifier passthrough, releaseAll, and the
+// no-target behavior (keys not consumed so shortcuts keep working).
+
+#include "../../Source/Core/KeyboardNoteInput.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        ++g_failures;
+    }
+}
+
+struct SinkEvent {
+    uint8_t note;
+    uint8_t velocity;
+    bool on;
+    uint64_t tag;
+};
+
+AestraUI::NUIKeyEvent key(AestraUI::NUIKeyCode code, bool pressed, bool repeat = false,
+                          AestraUI::NUIModifiers mods = AestraUI::NUIModifiers::None) {
+    AestraUI::NUIKeyEvent ev;
+    ev.keyCode = code;
+    ev.pressed = pressed;
+    ev.released = !pressed;
+    ev.repeat = repeat;
+    ev.modifiers = mods;
+    return ev;
+}
+
+} // namespace
+
+int main() {
+    using AestraUI::NUIKeyCode;
+    using AestraUI::NUIModifiers;
+
+    Aestra::KeyboardNoteInput input;
+    std::vector<SinkEvent> events;
+    uint64_t currentUnit = 7;
+    input.setSink([&](uint8_t note, uint8_t velocity, bool on, uint64_t tag) {
+        events.push_back({note, velocity, on, tag});
+    });
+    input.setTagProvider([&]() { return currentUnit; });
+
+    // ---------------- Layout: A = C at the default octave (middle C = 60).
+    require(input.handleKeyEvent(key(NUIKeyCode::A, true)), "A press not consumed");
+    require(events.size() == 1 && events[0].on && events[0].note == 60, "A != middle C note-on");
+    require(events[0].tag == 7, "tag not captured from provider");
+    require(input.handleKeyEvent(key(NUIKeyCode::A, false)), "A release not consumed");
+    require(events.size() == 2 && !events[1].on && events[1].note == 60, "A note-off mismatch");
+
+    // Black key and next-octave keys.
+    events.clear();
+    input.handleKeyEvent(key(NUIKeyCode::W, true));
+    input.handleKeyEvent(key(NUIKeyCode::K, true));
+    require(events.size() == 2 && events[0].note == 61 && events[1].note == 72, "W/K mapping (C#, C+1)");
+    input.handleKeyEvent(key(NUIKeyCode::W, false));
+    input.handleKeyEvent(key(NUIKeyCode::K, false));
+
+    // ---------------- Auto-repeat of a held key: swallowed, no retrigger.
+    events.clear();
+    input.handleKeyEvent(key(NUIKeyCode::A, true));
+    require(input.handleKeyEvent(key(NUIKeyCode::A, true, /*repeat=*/true)), "repeat not consumed");
+    require(events.size() == 1, "auto-repeat retriggered the note");
+    input.handleKeyEvent(key(NUIKeyCode::A, false));
+
+    // ---------------- Octave shift moves NEW notes; held notes keep their pitch.
+    events.clear();
+    input.handleKeyEvent(key(NUIKeyCode::A, true)); // 60 held
+    require(input.handleKeyEvent(key(NUIKeyCode::X, true)), "octave-up not consumed");
+    input.handleKeyEvent(key(NUIKeyCode::S, true)); // D at the NEW octave: 62+12=74
+    require(events.size() == 2 && events[1].note == 74, "post-shift note not in new octave");
+    input.handleKeyEvent(key(NUIKeyCode::A, false));
+    require(events.size() == 3 && !events[2].on && events[2].note == 60,
+            "held note released at its original pitch after octave change");
+    input.handleKeyEvent(key(NUIKeyCode::S, false));
+    input.handleKeyEvent(key(NUIKeyCode::Z, true)); // restore octave
+
+    // ---------------- Unit switch mid-hold: note-off goes to the ORIGINAL unit.
+    events.clear();
+    input.handleKeyEvent(key(NUIKeyCode::A, true));
+    currentUnit = 9;
+    input.handleKeyEvent(key(NUIKeyCode::S, true));
+    input.handleKeyEvent(key(NUIKeyCode::A, false));
+    require(events.size() == 3, "unit-switch sequence event count");
+    if (events.size() == 3) {
+        require(events[0].tag == 7, "first note tagged with original unit");
+        require(events[1].tag == 9, "second note tagged with new unit");
+        require(events[2].tag == 7 && !events[2].on, "note-off routed to the unit that got the note-on");
+    }
+    input.handleKeyEvent(key(NUIKeyCode::S, false));
+
+    // ---------------- Modifiers pass through (shortcuts win).
+    events.clear();
+    require(!input.handleKeyEvent(key(NUIKeyCode::A, true, false, NUIModifiers::Ctrl)),
+            "Ctrl+A consumed by musical typing");
+    require(!input.handleKeyEvent(key(NUIKeyCode::Z, true, false, NUIModifiers::Ctrl)),
+            "Ctrl+Z consumed by musical typing");
+    require(events.empty(), "modified keys produced notes");
+
+    // ---------------- Non-musical keys pass through.
+    require(!input.handleKeyEvent(key(NUIKeyCode::I, true)), "non-musical letter consumed");
+    require(!input.handleKeyEvent(key(NUIKeyCode::F5, true)), "function key consumed");
+
+    // ---------------- No target unit: keys not consumed, no events.
+    events.clear();
+    currentUnit = 0;
+    require(!input.handleKeyEvent(key(NUIKeyCode::A, true)), "key consumed with no target unit");
+    require(events.empty(), "events emitted with no target unit");
+    currentUnit = 7;
+
+    // ---------------- releaseAll: note-offs for everything held, right tags.
+    events.clear();
+    input.handleKeyEvent(key(NUIKeyCode::A, true));
+    input.handleKeyEvent(key(NUIKeyCode::D, true));
+    require(input.activeNoteCount() == 2, "active count before releaseAll");
+    input.releaseAll();
+    require(input.activeNoteCount() == 0, "active count after releaseAll");
+    int offs = 0;
+    for (const auto& e : events) {
+        if (!e.on)
+            ++offs;
+    }
+    require(offs == 2, "releaseAll emitted wrong number of note-offs");
+    // Releases after releaseAll are not consumed (keys no longer held).
+    require(!input.handleKeyEvent(key(NUIKeyCode::A, false)), "stale release consumed after releaseAll");
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] KeyboardNoteInputTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] KeyboardNoteInputTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1437,6 +1437,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeJSONTest.cpp")
     message(STATUS "NUIThemeJSONTest added - Issue #259 theme JSON loading test")
 endif()
 
+# KeyboardNoteInput Test — musical-typing translation logic (header-only, no
+# UI targets needed, runs headless on every lane).
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/KeyboardNoteInputTest.cpp")
+    add_executable(KeyboardNoteInputTest AestraUI/KeyboardNoteInputTest.cpp)
+    target_include_directories(KeyboardNoteInputTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/Source/Core
+    )
+    add_test(NAME KeyboardNoteInputTest COMMAND KeyboardNoteInputTest)
+    set_tests_properties(KeyboardNoteInputTest PROPERTIES LABELS "ui;input;midi")
+endif()
+
 # PianoRollInteraction Test - tests for pure helper functions
 # Guard on target presence because headless/CI disables AestraUI targets.
 if(TARGET AestraUI_Core)


### PR DESCRIPTION
## Summary
**Second half of note input** (stacked on #451 — retarget after it merges): with the piano roll open, the computer keyboard is a playable instrument through #451's live-MIDI path. This is the gameplan's 'play notes from a keyboard' moment, on every machine including the 4GB target — no drivers, no hardware.

- **Layout** (Ableton/GarageBand musical typing, restricted to keys `NUIKeyCode` defines): `A W S E D F T G Y H U J K O L P` = two octave rows; `Z`/`X` = octave down/up; default octave puts A on **middle C**.
- **`KeyboardNoteInput`** — pure header-only translator, no engine/UI deps, unit-tested headless. Pitch **and** target unit are captured at key-down, so octave or editing-unit changes mid-hold never orphan a note-off. Auto-repeat swallowed; Ctrl/Alt/Super pass through; `releaseAll()` for panel-close safety.
- **Wiring preserves every existing key contract**: releases handled before the press-only early-return (nothing else consumes releases); presses run *after* the piano roll's own shortcuts; focused text inputs never reach content (window-manager dispatch gives the focused widget first refusal — verified at AestraWindowManager.cpp:362).

## Testing performed
- `KeyboardNoteInputTest` (new, headless, every lane): mapping, octave shift vs held notes, unit-switch note-off routing, repeat swallowing, modifier + no-target passthrough, releaseAll.
- Full `Aestra` app target compiles locally; the CI UI lane re-proves it here.
- **Manual test wanted from you**: open a project, open the piano roll on a unit, play A S D F — chords, octave shifts, switch units mid-hold. First real 'play a note into Aestra' moment; your ears are the acceptance test.

## Next in series
PR 3: RtMidi vendoring (owner-approved) + hardware MIDI-in on its own SPSC queue into the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)