### PR TITLE
feat(midi): wire hardware input into app lifecycle

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -302,6 +302,7 @@ void AestraApp::initializeContent() {
     if (m_audioController->getEngine()) {
         m_content->setAudioEngine(m_audioController->getEngine());
     }
+    m_content->setMidiInput(m_audioController->getMidiInput());
     syncRecordingProjectPath(m_content, m_projectPath);
 
     m_windowManager->setContent(m_content);

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -174,6 +174,12 @@ bool AestraAudioController::initialize() {
 }
 
 void AestraAudioController::shutdown() {
+    // Detach the content's raw observer pointer before the service goes away:
+    // the content can outlive this shutdown (we hold a shared_ptr to it), and
+    // a late unit-selection callback must not touch a freed MidiInputService.
+    if (auto content = m_content.lock()) {
+        content->setMidiInput(nullptr);
+    }
     // Stop hardware MIDI first: cancels RtMidi callbacks so no producer can
     // touch the engine's queue once teardown proceeds.
     if (m_midiInput) {

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -4,6 +4,7 @@
 #include "AudioThreadConstraints.h"
 #include "AudioRT.h"
 #include "AudioTelemetry.h"
+#include "MidiInputService.h"
 #include "PreviewEngine.h"
 #include "TrackManager.h"
 #include "AestraPlatform.h"
@@ -141,6 +142,7 @@ const AudioDeviceInfo* choosePreferredInputDevice(const std::vector<AudioDeviceI
 AestraAudioController::AestraAudioController() {
     m_audioManager = std::make_unique<AudioDeviceManager>();
     m_audioEngine = std::make_unique<AudioEngine>();
+    m_midiInput = std::make_unique<MidiInputService>();
 }
 
 AestraAudioController::~AestraAudioController() {
@@ -154,10 +156,29 @@ bool AestraAudioController::initialize() {
         return false;
     }
     Log::info("Audio engine initialized");
+
+    // Hardware MIDI input: the RtMidi callback thread is the single producer
+    // of the engine's hardware SPSC queue. The raw engine pointer is safe: the
+    // engine is created in our constructor and destroyed only in shutdown(),
+    // after the service has been stopped. Zero ports (or the core-mode stub)
+    // is a normal, silent outcome — play/edit must work without a controller.
+    if (m_midiInput && m_audioEngine) {
+        AudioEngine* engine = m_audioEngine.get();
+        const size_t midiPorts =
+            m_midiInput->start([engine](uint64_t unitId, uint8_t status, uint8_t data1, uint8_t data2) {
+                engine->postHardwareMidiEvent(unitId, status, data1, data2);
+            });
+        Log::info("Hardware MIDI input ports opened: " + std::to_string(midiPorts));
+    }
     return true;
 }
 
 void AestraAudioController::shutdown() {
+    // Stop hardware MIDI first: cancels RtMidi callbacks so no producer can
+    // touch the engine's queue once teardown proceeds.
+    if (m_midiInput) {
+        m_midiInput->stop();
+    }
     if (m_initialized && m_audioManager) {
         stopStream();
         closeStream();
@@ -165,6 +186,7 @@ void AestraAudioController::shutdown() {
     if (m_audioEngine) {
         m_audioEngine->drainDeferredResourcesForShutdown();
     }
+    m_midiInput.reset();
     m_audioEngine.reset();
     m_audioManager.reset();
     m_initialized = false;

--- a/Source/Core/AestraAudioController.h
+++ b/Source/Core/AestraAudioController.h
@@ -14,6 +14,7 @@
 // Forward declarations
 class AestraContent;
 namespace Aestra::Audio {
+class MidiInputService;
 class PreviewEngine;
 class TrackManager;
 }
@@ -43,6 +44,7 @@ public:
     // Accessors
     Aestra::Audio::AudioEngine* getEngine() { return m_audioEngine.get(); }
     Aestra::Audio::AudioDeviceManager* getDeviceManager() { return m_audioManager.get(); }
+    Aestra::Audio::MidiInputService* getMidiInput() { return m_midiInput.get(); }
     const Aestra::Audio::AudioStreamConfig& getStreamConfig() const { return m_streamConfig; }
 
     // Helpers
@@ -55,6 +57,10 @@ public:
 private:
     std::unique_ptr<Aestra::Audio::AudioDeviceManager> m_audioManager;
     std::unique_ptr<Aestra::Audio::AudioEngine> m_audioEngine;
+    // Hardware MIDI input. Its RtMidi callback thread posts into the engine's
+    // hardware SPSC queue, so it must be stopped before m_audioEngine is
+    // destroyed (see shutdown()).
+    std::unique_ptr<Aestra::Audio::MidiInputService> m_midiInput;
 
     Aestra::Audio::AudioStreamConfig m_streamConfig;
     bool m_initialized{false};

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -17,6 +17,7 @@
 #include "AuditionEngine.h" // Audition Mode backend
 #include "AuditionPanel.h"  // Audition Mode UI
 #include "Commands/PluginCommands.h"
+#include "MidiInputService.h"
 #include "MixerChannel.h"
 #include "MixerPanel.h"
 #include "PatternBrowserPanel.h"
@@ -952,6 +953,13 @@ AestraContent::AestraContent() {
     m_sequencerPanel->setOnSelectedUnitChanged([this](UnitID unitId) {
         if (m_pianoRollPanel) {
             m_pianoRollPanel->setEditingUnit(unitId);
+        }
+        // Live hardware MIDI follows the selected unit (musical-typing
+        // semantics). Every selection path — clicks, refreshes, pattern
+        // switches, programmatic setSelectedUnit — fires this callback,
+        // so this is the single target-tracking choke point.
+        if (m_midiInput) {
+            m_midiInput->setTargetUnit(unitId);
         }
     });
     m_sequencerPanel->setOnPatternEdited([this](PatternID patternId) {
@@ -2898,6 +2906,15 @@ void AestraContent::setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) {
     }
     if (m_pianoRollPanel) {
         m_pianoRollPanel->setPlatformBridge(bridge);
+    }
+}
+
+void AestraContent::setMidiInput(Aestra::Audio::MidiInputService* midiInput) {
+    m_midiInput = midiInput;
+    // Push the current selection so a controller plays the right unit even if
+    // the user never re-selects after startup.
+    if (m_midiInput && m_sequencerPanel) {
+        m_midiInput->setTargetUnit(m_sequencerPanel->getSelectedUnitId());
     }
 }
 

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -51,6 +51,7 @@ namespace AestraUI {
 // Forward declarations - Aestra::Audio (includes panel classes)
 namespace Aestra::Audio {
     class AudioEngine;
+    class MidiInputService;
     class TrackManager;
     class TrackManagerUI;
     class PreviewEngine;
@@ -233,6 +234,8 @@ public:
     void setPlatformBridge(AestraUI::NUIPlatformBridge* bridge);
     /** @brief Bind the live audio engine used by transport-aware panels. */
     void setAudioEngine(Aestra::Audio::AudioEngine* engine);
+    /** @brief Bind hardware MIDI input; live notes follow the selected unit. */
+    void setMidiInput(Aestra::Audio::MidiInputService* midiInput);
     /** @brief Propagate transport tempo to tempo-aware internal plugins. */
     void setPluginTempo(float bpm);
     /** @brief Get the playback graph controller for canonical graph invalidation. */
@@ -337,6 +340,7 @@ private:
     std::shared_ptr<Aestra::Audio::TrackManagerUI> m_trackManagerUI;
     AestraUI::NUIPlatformBridge* m_platformBridge = nullptr;
     Aestra::Audio::AudioEngine* m_audioEngine = nullptr;
+    Aestra::Audio::MidiInputService* m_midiInput = nullptr;
 
     std::shared_ptr<Aestra::Audio::MixerPanel> m_mixerPanel;
     std::shared_ptr<Aestra::Audio::PianoRollPanel> m_pianoRollPanel;


### PR DESCRIPTION
Depends on #454. Closes #455.

## Summary

Closes the end-to-end gap left deliberately open by #454: the application now owns hardware MIDI input, so a connected controller plays the currently selected Arsenal unit. **App lifecycle wiring is complete; real-device validation remains tracked in #457** — no claim of validated controller support is made until that passes.

- **`AestraAudioController`** owns the `MidiInputService` alongside the engine. `initialize()` starts it with a sink posting into the engine's hardware SPSC queue (`postHardwareMidiEvent`); zero ports or the core-mode stub is a normal, silent outcome — play/edit never depends on a controller being present.
- **`AestraContent::setMidiInput`** binds the service and pushes the current selection; the existing `onSelectedUnitChanged` callback becomes the single target-tracking choke point.
- **`AestraApp::initializeContent`** passes the service to content alongside the engine.

Diff: 5 files, +50 lines, no deletions.

## Review points

1. **Start ordering:** `MidiInputService` starts only after the engine exists — the service is created in the controller's constructor next to the engine, and `start()` runs in `initialize()`, so the sink's raw `AudioEngine*` capture is valid for the service's entire producing lifetime.
2. **Teardown ordering:** `shutdown()` stops the MIDI service *first* — `stop()` cancels RtMidi callbacks, so no producer can touch the engine's queue once teardown proceeds — then resets the service before the engine. This resolves the teardown-lifetime review point flagged on #454.
3. **Target tracking:** selected-unit changes route through the existing single callback choke point (`onSelectedUnitChanged`). Every selection path — clicks, refreshes, pattern switches, programmatic `setSelectedUnit` — already fires it (verified: all six `setEditingUnit` sites pair with `setSelectedUnit`, which fires the callback unconditionally), matching musical-typing semantics. `setMidiInput` also pushes the current selection at bind time so the controller targets correctly without requiring a re-select after startup.
4. **Validation status:** headless coverage of the queue→engine path lives in #454's `HardwareMidiInputTest`; this PR's app-side wiring compiles and the app builds/links clean, but behavior with physical hardware is a manual smoke test tracked in #457. Docs make no controller-support claim until it completes.

## Why

July founder review Days 1–30 item ("Finish MIDI/computer-keyboard input") and issue #455. The keyboard path (`postLiveMidiEvent` UI caller) remains open under #455's sibling note and is not part of this PR.

## Testing performed

- `Aestra` app target builds clean on Linux (Release, `build-linux`).
- Headless suite 13/13 on the underlying branch (no engine changes in this PR — it is pure `Source/` wiring).
- Manual/device validation deliberately deferred to #457.

## Docs updated?

No public docs (per policy: no feature claim until validated end-to-end).

## Risk / rollback

Additive wiring; no DSP, serialization, or engine changes. Rollback is a revert of one commit. After #454 merges: rebase/retarget this PR to `develop`, confirm the diff is still the intended 5 files / ~+50 lines, then delete `feature/hardware-midi-in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Wired hardware MIDI input into the application lifecycle.
- `AestraAudioController` starts MIDI input, forwards events to the engine queue, and stops it before engine teardown.
- `AestraContent` tracks the selected unit as the MIDI target.
- `AestraApp` passes the MIDI service into content during initialization.
- Handles zero MIDI ports and core-mode stubs silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->