### PR TITLE
fix(sampler): make one-shots shorter than the release audible

### DIFF
--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -356,19 +356,32 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
                 }
             }
 
-            // In one-shot mode there may be no note-off; trigger a timed release near the end
-            if (!loopEnabled && v.stage != EnvStage::Release && v.stage != EnvStage::Off) {
-                const double framesToEnd = endFrame - v.position;
-                const double releaseFrames = static_cast<double>(releaseMs) * m_sampleRate;
-                if (framesToEnd <= releaseFrames) {
-                    v.stage = EnvStage::Release;
-                    v.stageTime = 0.0;
-                    v.releaseGain = std::max(0.0f, v.currentGain);
+            // One-shot end-of-sample fade (#452). No note-off may ever arrive
+            // in one-shot mode, so fade toward the endpoint with a bounded,
+            // stateless multiplier on top of the normal ADSR — never by
+            // mutating the ADSR stage (the old code entered Release at
+            // trigger time for samples shorter than the release, capturing
+            // releaseGain from a still-zero attack: permanent silence).
+            //
+            // Units: v.position/endFrame are SOURCE frames; the configured
+            // release is OUTPUT time. Convert via |playbackRate|, and clamp
+            // the effective fade to the playable one-shot duration so short
+            // samples fade across what they have instead of starting at zero.
+            float oneShotTail = 1.0f;
+            if (!loopEnabled) {
+                const double absRate = std::abs(v.playbackRate);
+                if (absRate > 1.0e-9) {
+                    const double remainingOutputFrames = (endFrame - v.position) / absRate;
+                    const double configuredReleaseFrames = static_cast<double>(releaseMs) * m_sampleRate;
+                    const double playableOutputFrames = (endFrame - startFrame) / absRate;
+                    const double effectiveTailFrames =
+                        std::max(1.0, std::min(configuredReleaseFrames, playableOutputFrames));
+                    oneShotTail = static_cast<float>(std::clamp(remainingOutputFrames / effectiveTailFrames, 0.0, 1.0));
                 }
             }
 
             // Envelope (uses preloaded ADSR — no atomic loads)
-            float env = getEnvelopeLevel(v, invSampleRate, attackMs, decayMs, sustainLevel, releaseMs);
+            float env = getEnvelopeLevel(v, invSampleRate, attackMs, decayMs, sustainLevel, releaseMs) * oneShotTail;
             if (v.stage == EnvStage::Off) {
                 v.active = false;
                 activeVoiceCountDirty = true;

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -119,6 +119,26 @@ if(TARGET AestraAudioCore)
     )
 endif()
 
+# Sampler One-Shot Envelope Test — regression for #452: one-shot samples
+# shorter than the configured release must be audible with the DEFAULT
+# envelope. Drives SamplerPlugin directly; core-linked, every CI lane.
+# No EXISTS guard: a missing committed test source must fail configure.
+if(TARGET AestraAudioCore)
+    add_executable(SamplerOneShotEnvelopeTest
+        SamplerOneShotEnvelopeTest.cpp
+    )
+    target_link_libraries(SamplerOneShotEnvelopeTest PRIVATE AestraAudioCore)
+    target_include_directories(SamplerOneShotEnvelopeTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME SamplerOneShotEnvelopeTest COMMAND SamplerOneShotEnvelopeTest)
+    set_tests_properties(SamplerOneShotEnvelopeTest PROPERTIES
+        LABELS "headless;sampler;audio;dsp;regression"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 # PDC v2 P1 — scaffolding tests (see AestraDocs/PDC-v2-Design.md §12)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCFlatChainTest.cpp")
     add_executable(PDCFlatChainTest PDCFlatChainTest.cpp)

--- a/Tests/Headless/LiveMidiInputTest.cpp
+++ b/Tests/Headless/LiveMidiInputTest.cpp
@@ -65,11 +65,9 @@ int main() {
     auto sampler = std::make_shared<Plugins::SamplerPlugin>();
     require(sampler->initialize(sampleRate, blockSize), "SamplerPlugin failed to initialize");
     sampler->activate();
-    // Short release: with the 300 ms default, a one-shot sample shorter than
-    // the release time enters Release at trigger with releaseGain captured at 0
-    // and never sounds (filed as a sampler bug; this test targets the live-MIDI
-    // routing path, not that envelope quirk).
-    sampler->setEnvelope(0.005f, 0.05f, 0.8f, 0.05f);
+    // Default envelope on purpose: a 250 ms one-shot under the default 300 ms
+    // release is the #452 shape, so this doubles as engine-level regression
+    // coverage (primary coverage: SamplerOneShotEnvelopeTest).
     {
         const uint32_t sampleFrames = sampleRate / 4;
         std::vector<float> data(sampleFrames, 0.0f);

--- a/Tests/Headless/SamplerOneShotEnvelopeTest.cpp
+++ b/Tests/Headless/SamplerOneShotEnvelopeTest.cpp
@@ -1,0 +1,227 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// SamplerOneShotEnvelopeTest
+// Regression for #452: one-shot samples shorter than the configured release
+// time rendered pure silence, because the automatic end-of-sample release
+// fired at trigger time and captured releaseGain from a still-zero attack.
+// Drives the built-in SamplerPlugin directly (no engine, no files, no
+// devices) at 48 kHz with the DEFAULT envelope: attack 10 ms, decay 100 ms,
+// sustain 0.8, release 300 ms.
+
+#include "Plugin/PluginHost.h"
+#include "Plugin/SamplerPlugin.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 256;
+constexpr uint8_t kNoteOn = 0x90;
+constexpr uint8_t kNoteOff = 0x80;
+constexpr uint8_t kRootNote = 60;
+constexpr uint8_t kVelocity = 110; // clearly audible; sampler squares velocity
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+std::vector<float> makeSineMono(double seconds, double freqHz = 220.0, float amp = 0.5f) {
+    const uint32_t frames = static_cast<uint32_t>(seconds * kSampleRate);
+    std::vector<float> data(frames, 0.0f);
+    for (uint32_t i = 0; i < frames; ++i) {
+        data[i] = amp * static_cast<float>(
+                            std::sin(2.0 * 3.14159265358979 * freqHz * (static_cast<double>(i) / kSampleRate)));
+    }
+    return data;
+}
+
+struct MidiAt {
+    uint32_t frame; // global output frame time
+    uint8_t status;
+    uint8_t note;
+    uint8_t velocity;
+};
+
+struct Rendered {
+    // max(|L|,|R|) per output frame — windowed analysis never depends on
+    // where block boundaries happen to fall.
+    std::vector<float> envelope;
+    bool hasInvalid = false;
+};
+
+Rendered render(Aestra::Audio::Plugins::SamplerPlugin& sampler, uint32_t totalFrames,
+                const std::vector<MidiAt>& events) {
+    Rendered out;
+    out.envelope.resize(totalFrames, 0.0f);
+    std::vector<float> left(kBlockSize), right(kBlockSize);
+    float* channels[2] = {left.data(), right.data()};
+
+    for (uint32_t start = 0; start < totalFrames; start += kBlockSize) {
+        const uint32_t frames = std::min(kBlockSize, totalFrames - start);
+        Aestra::Audio::MidiBuffer midi;
+        for (const auto& e : events) {
+            if (e.frame >= start && e.frame < start + frames) {
+                const uint8_t data[3] = {e.status, e.note, e.velocity};
+                midi.addEvent(e.frame - start, data, 3);
+            }
+        }
+        sampler.process(nullptr, channels, 0, 2, frames, &midi, nullptr);
+        for (uint32_t i = 0; i < frames; ++i) {
+            if (!std::isfinite(left[i]) || !std::isfinite(right[i])) {
+                out.hasInvalid = true;
+            }
+            out.envelope[start + i] = std::max(std::abs(left[i]), std::abs(right[i]));
+        }
+    }
+    return out;
+}
+
+uint32_t ms(double milliseconds) {
+    return static_cast<uint32_t>(milliseconds * kSampleRate / 1000.0);
+}
+
+float peakIn(const Rendered& r, uint32_t fromFrame, uint32_t toFrame) {
+    float peak = 0.0f;
+    toFrame = std::min<uint32_t>(toFrame, static_cast<uint32_t>(r.envelope.size()));
+    for (uint32_t i = fromFrame; i < toFrame; ++i) {
+        peak = std::max(peak, r.envelope[i]);
+    }
+    return peak;
+}
+
+float rmsIn(const Rendered& r, uint32_t fromFrame, uint32_t toFrame) {
+    toFrame = std::min<uint32_t>(toFrame, static_cast<uint32_t>(r.envelope.size()));
+    if (toFrame <= fromFrame) {
+        return 0.0f;
+    }
+    double acc = 0.0;
+    for (uint32_t i = fromFrame; i < toFrame; ++i) {
+        acc += static_cast<double>(r.envelope[i]) * r.envelope[i];
+    }
+    return static_cast<float>(std::sqrt(acc / (toFrame - fromFrame)));
+}
+
+std::unique_ptr<Aestra::Audio::Plugins::SamplerPlugin> makeSampler(double sampleSeconds, const char* name) {
+    auto sampler = std::make_unique<Aestra::Audio::Plugins::SamplerPlugin>();
+    require(sampler->initialize(kSampleRate, kBlockSize), std::string(name) + ": initialize failed");
+    sampler->activate();
+    // Default envelope deliberately untouched: A 10 ms / D 100 ms / S 0.8 / R 300 ms.
+    require(sampler->loadSampleData(name, makeSineMono(sampleSeconds), kSampleRate, 1),
+            std::string(name) + ": loadSampleData failed");
+    return sampler;
+}
+
+constexpr float kAudible = 1.0e-3f; // meaningful signal, far above numeric noise
+constexpr float kSilence = 1.0e-4f; // "returned to silence"
+
+} // namespace
+
+int main() {
+    // ---------------- 1. Primary regression (#452): 100 ms one-shot, default
+    // envelope, loop disabled — must be audible, then return to silence.
+    {
+        auto sampler = makeSampler(0.100, "oneshot-100ms");
+        const auto r = render(*sampler, ms(300.0), {{0, kNoteOn, kRootNote, kVelocity}});
+        const float peak = peakIn(r, 0, ms(100.0));
+        const float rms = rmsIn(r, 0, ms(100.0));
+        std::cout << "100ms one-shot: peak=" << peak << " rms=" << rms << "\n";
+        require(!r.hasInvalid, "100ms: output contains NaN/Inf");
+        require(peak > kAudible, "100ms one-shot with default envelope is silent (#452 regression)");
+        require(rms > 1.0e-4f, "100ms one-shot has no integrated energy (#452 regression)");
+        require(peakIn(r, ms(150.0), ms(300.0)) < kSilence, "100ms: output did not return to silence after sample end");
+    }
+
+    // ---------------- 1b. Same contract through the mono voice path.
+    {
+        auto sampler = makeSampler(0.100, "oneshot-100ms-mono");
+        sampler->setMonoMode(true);
+        const auto r = render(*sampler, ms(300.0), {{0, kNoteOn, kRootNote, kVelocity}});
+        require(!r.hasInvalid, "mono: output contains NaN/Inf");
+        require(peakIn(r, 0, ms(100.0)) > kAudible, "mono-mode 100ms one-shot is silent");
+        require(peakIn(r, ms(150.0), ms(300.0)) < kSilence, "mono: no return to silence");
+    }
+
+    // ---------------- 2. Very short transient (5 ms — shorter than the 10 ms
+    // default attack): must not be identically silent, must stay bounded, and
+    // the voice must terminate.
+    {
+        auto sampler = makeSampler(0.005, "transient-5ms");
+        const auto r = render(*sampler, ms(100.0), {{0, kNoteOn, kRootNote, kVelocity}});
+        const float peak = peakIn(r, 0, ms(10.0));
+        std::cout << "5ms transient: peak=" << peak << "\n";
+        require(!r.hasInvalid, "5ms: output contains NaN/Inf");
+        require(peak > 1.0e-4f, "5ms transient is identically silent");
+        require(peak < 1.0f, "5ms transient exceeds unity bound");
+        require(peakIn(r, ms(50.0), ms(100.0)) < kSilence, "5ms: voice did not terminate to silence");
+    }
+
+    // ---------------- 3. Longer one-shot (750 ms > 300 ms release): body stays
+    // audible, only the final release window fades, ends in silence.
+    {
+        auto sampler = makeSampler(0.750, "oneshot-750ms");
+        const auto r = render(*sampler, ms(1000.0), {{0, kNoteOn, kRootNote, kVelocity}});
+        const float body = peakIn(r, ms(300.0), ms(400.0));
+        const float tail = peakIn(r, ms(700.0), ms(750.0));
+        require(!r.hasInvalid, "750ms: output contains NaN/Inf");
+        require(body > kAudible, "750ms one-shot body is not audible");
+        // Not faded wholesale: mid-body must hold a healthy fraction of the peak.
+        require(peakIn(r, ms(400.0), ms(450.0)) > 0.3f * peakIn(r, 0, ms(750.0)),
+                "750ms: body was faded by the automatic tail");
+        // Final region decreases toward silence.
+        require(tail < 0.5f * body, "750ms: no fade in the final release region");
+        require(peakIn(r, ms(800.0), ms(1000.0)) < kSilence, "750ms: no silence after sample end");
+    }
+
+    // ---------------- 4. Playback-rate correctness: +12 semitones (rate 2.0)
+    // on a 200 ms sample plays out in ~100 ms of output time. The tail math
+    // must convert source frames to output frames — not compare them raw.
+    {
+        auto sampler = makeSampler(0.200, "oneshot-200ms-up12");
+        const auto r = render(*sampler, ms(300.0), {{0, kNoteOn, kRootNote + 12, kVelocity}});
+        require(!r.hasInvalid, "+12st: output contains NaN/Inf");
+        require(peakIn(r, 0, ms(50.0)) > kAudible, "+12st transposed one-shot is silent");
+        require(peakIn(r, ms(120.0), ms(300.0)) < kSilence,
+                "+12st: voice still sounding past its shortened playback window (stuck voice or unit mix-up)");
+    }
+
+    // ---------------- 5. Explicit note-off still drives the normal ADSR
+    // release: 750 ms sample, note-off at 200 ms, silent well before the
+    // natural endpoint, no restart from the automatic tail.
+    {
+        auto sampler = makeSampler(0.750, "oneshot-noteoff");
+        const auto r =
+            render(*sampler, ms(900.0), {{0, kNoteOn, kRootNote, kVelocity}, {ms(200.0), kNoteOff, kRootNote, 0}});
+        require(!r.hasInvalid, "note-off: output contains NaN/Inf");
+        require(peakIn(r, 0, ms(200.0)) > kAudible, "note-off: no audio before note-off");
+        // Release is 300 ms → decaying through it, gone afterwards.
+        require(peakIn(r, ms(450.0), ms(500.0)) < peakIn(r, ms(250.0), ms(300.0)), "note-off: release is not decaying");
+        require(peakIn(r, ms(560.0), ms(900.0)) < kSilence, "note-off: release did not reach silence");
+    }
+
+    // ---------------- 6. Loop exclusion: with looping enabled the automatic
+    // end-of-sample fade must not exist — a 100 ms loop keeps sounding far
+    // past one sample length until note-off.
+    {
+        auto sampler = makeSampler(0.100, "loop-100ms");
+        sampler->setLoopEnabled(true);
+        const auto r =
+            render(*sampler, ms(900.0), {{0, kNoteOn, kRootNote, kVelocity}, {ms(500.0), kNoteOff, kRootNote, 0}});
+        require(!r.hasInvalid, "loop: output contains NaN/Inf");
+        require(peakIn(r, ms(300.0), ms(400.0)) > kAudible,
+                "loop: sound stopped after one sample length (automatic fade leaked into loop mode)");
+        require(peakIn(r, ms(850.0), ms(900.0)) < kSilence, "loop: no silence after note-off release");
+    }
+
+    std::cout << "[PASS] SamplerOneShotEnvelopeTest\n";
+    return 0;
+}


### PR DESCRIPTION
Closes #452. Velocity-curve question split to #462.

## Summary

One-shot samples shorter than the configured release rendered **permanent silence** — the automatic end-of-sample release compared `framesToEnd` (source frames) against `releaseFrames` (output frames) on the voice's first rendered frame and entered `EnvStage::Release` with `releaseGain` captured from a still-zero attack. At the default 300 ms release this silenced every hat, click, rim, and short kick under ~300 ms — the core material of the target producer.

**Measured reproduction (pinned by test before the fix was written): 100 ms one-shot, default envelope → peak 0.0 / RMS 0.0. After: peak 0.074 / RMS 0.029.**

The fix replaces the ADSR-mutating auto-release with a bounded, stateless tail multiplier on top of the normal envelope:

```
tail = clamp(remainingOutputFrames / min(configuredReleaseFrames, playableOutputFrames), 0, 1)
finalEnvelope = adsr * tail
```

- **Unit correctness:** source-frame positions convert to output time via `|playbackRate|` (the old code compared source frames with output frames raw); near-zero rates guarded.
- **Short samples** fade across their playable duration instead of starting released at zero; **long samples** fade only inside the configured final release window (750 ms case verifies the body is untouched).
- **Loop mode** bypasses the tail entirely; **manual note-off** keeps the existing ADSR release unchanged.
- **RT-safe:** pure per-voice arithmetic — no allocation, no locks, no logging, no new voice state (`SamplerPlugin.h` untouched).

## Audio behavior report (DSP rules)

- Audio output changed: yes — previously-silent short one-shots now sound; long one-shots keep their body and gain a correctly-timed endpoint fade equivalent in span to the old intent. Attack/decay/sustain and note-off release shapes unchanged.
- Latency changed: no. State format changed: no. Plugin/parameter IDs: unchanged.

## Testing performed

- **New `SamplerOneShotEnvelopeTest`** (plugin-level, deterministic, 48 kHz, synthetic samples, core-linked, labels `headless;sampler;audio;dsp;regression`, no `EXISTS` guard): primary 100 ms regression with peak/RMS/silence-after assertions, mono-voice-path variant, 5 ms transient (shorter than the default attack — guards against fixes that need the attack to complete), 750 ms body/tail shape, +12 st transposition (rate-unit correctness: ends within its halved output window), explicit note-off through ADSR release, loop exclusion. **Verified to fail against the pre-fix build and pass with the fix.** Windowed analysis; sample lengths and event times deliberately not block-aligned.
- **`LiveMidiInputTest` workaround removed**: its 50 ms release hack existed only because of this bug; it now runs the true default envelope (250 ms one-shot under a 300 ms release — the #452 shape) and passes, giving engine-level secondary coverage.
- Headless suite **14/14**. Full suite 144/146: `NUITextInputLayoutTest` fails identically with this diff stashed (pre-existing, #458); `SecOutOfProcessPluginHost` failed once under `-j2` parallelism and passes standalone (already on CI's sanitizer-exclusion list for environment sensitivity).

## Docs updated?

No public docs (behavior fix; no new feature claims).

## Risk / rollback

Single bounded region in `SamplerPlugin::process` plus tests; revert of one commit. Short one-shots fade linearly across their full length by design — if a future listening session wants a different curve shape, that layers on top without revisiting correctness. Velocity-squared gain intentionally untouched; policy decision tracked in #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed one-shot samples shorter than the configured release becoming silent by applying a bounded tail fade over the playable duration without mutating ADSR state.
- Preserved normal ADSR release for manual note-off and bypassed the automatic tail in loop mode.
- Corrected playback-rate timing conversion and guarded near-zero rates.
- Added headless sampler regression coverage for short samples, release behavior, playback-rate changes, looping, mono mode, and output safety.
- Removed the related `LiveMidiInputTest` release workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->