### PR TITLE
feat(midi): add computer-keyboard musical typing

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -22,6 +22,8 @@ set(Aestra_SOURCES
 	Core/AestraRootComponent.cpp
 	Core/AestraContent.h
 	Core/AestraContent.cpp
+	Core/MusicalTypingController.h
+	Core/MusicalTypingController.cpp
 	Core/ProjectSerializer.cpp
 	Core/TakeManager.h
 	Core/TakeManager.cpp

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -28,6 +28,7 @@
 
 // AestraUI includes
 #include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../AestraUI/Base/NUITextInput.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "../AestraUI/Widgets/TrackColorPalette.h"
@@ -142,6 +143,7 @@ std::vector<float> buildEditorWaveform(const std::vector<float>& samples, uint32
 // =============================================================================
 
 AestraContent::~AestraContent() {
+    m_musicalTyping.releaseAllNotes();
     if (m_audioEngine) {
         m_audioEngine->setPreviewEngine(nullptr);
     }
@@ -170,7 +172,10 @@ AestraContent::~AestraContent() {
     }
 }
 
-AestraContent::AestraContent() {
+AestraContent::AestraContent()
+    : m_musicalTyping([this](uint64_t unitId, uint8_t status, uint8_t data1, uint8_t data2) {
+        return m_audioEngine && m_audioEngine->postLiveMidiEvent(unitId, status, data1, data2);
+    }) {
     // Create layers
     m_workspaceLayer = std::make_shared<AestraUI::NUIComponent>();
     m_workspaceLayer->setId("WorkspaceLayer");
@@ -961,6 +966,7 @@ AestraContent::AestraContent() {
         if (m_midiInput) {
             m_midiInput->setTargetUnit(unitId);
         }
+        m_musicalTyping.setTargetUnit(unitId);
     });
     m_sequencerPanel->setOnPatternEdited([this](PatternID patternId) {
         if (m_patternBrowser) {
@@ -2919,11 +2925,13 @@ void AestraContent::setMidiInput(Aestra::Audio::MidiInputService* midiInput) {
 }
 
 void AestraContent::setAudioEngine(Aestra::Audio::AudioEngine* engine) {
+    m_musicalTyping.releaseAllNotes();
     // Detach preview from old engine before overwriting m_audioEngine
     if (m_audioEngine && m_previewEngine) {
         m_audioEngine->setPreviewEngine(nullptr);
     }
     m_audioEngine = engine;
+    m_musicalTyping.setTargetUnit(m_sequencerPanel ? m_sequencerPanel->getSelectedUnitId() : 0);
     Aestra::Audio::CommandRegistry::setAudioEngine(engine);
     if (m_audioEngine && m_previewEngine) {
         m_audioEngine->setPreviewEngine(m_previewEngine.get());
@@ -3741,6 +3749,14 @@ void AestraContent::toggleHistoryPanel() {
 
 // Global Shortcuts
 bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
+    // A note release must win even if focus moved after its note-on; otherwise
+    // an editable field can consume the key-up and leave a stuck voice.
+    if (event.released && m_musicalTyping.handleKeyEvent(event)) {
+        if (m_transportBar) {
+            m_transportBar->setMusicalTypingStatus(m_musicalTyping.isEnabled(), m_musicalTyping.displayOctave());
+        }
+        return true;
+    }
     if (event.keyCode == AestraUI::NUIKeyCode::Space && event.released) {
         m_spaceShortcutLatched = false;
         return true;
@@ -3852,7 +3868,22 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         }
     }
 
+    // Standard text inputs own letter keys. Most dispatch paths already give
+    // focused widgets first refusal; this explicit guard also protects the
+    // root-component path, which routes global shortcuts before focus.
+    if (dynamic_cast<AestraUI::NUITextInput*>(AestraUI::NUIComponent::getFocusedComponent()) == nullptr &&
+        m_musicalTyping.handleKeyEvent(event)) {
+        if (m_transportBar) {
+            m_transportBar->setMusicalTypingStatus(m_musicalTyping.isEnabled(), m_musicalTyping.displayOctave());
+        }
+        return true;
+    }
+
     return false;
+}
+
+void AestraContent::releaseMusicalTypingNotes() {
+    m_musicalTyping.releaseAllNotes();
 }
 
 Aestra::Audio::CommandResult AestraContent::executeMuseCommand(const std::string& input) {

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -24,6 +24,7 @@
 #include "NUISegmentedControl.h"
 #include "OverlayLayer.h"
 #include "PatternSource.h"
+#include "MusicalTypingController.h"
 #include "TransportBar.h"
 #include "ViewTypes.h"
 
@@ -147,6 +148,8 @@ public:
     bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
     /** @brief Handle global keyboard shortcuts for the workspace. */
     bool onKeyEvent(const AestraUI::NUIKeyEvent& event) override; // [NEW] Global shortcuts
+    /** @brief Release notes held by computer-keyboard musical typing. */
+    void releaseMusicalTypingNotes();
 
     /** @brief Open or close a specific workspace overlay. */
     void setViewOpen(Aestra::Audio::ViewType view, bool open);
@@ -357,6 +360,7 @@ private:
     std::shared_ptr<Aestra::AuditionPanel> m_auditionPanel;
 
     std::unique_ptr<Aestra::Audio::PreviewEngine> m_previewEngine;
+    Aestra::MusicalTypingController m_musicalTyping;
     bool m_spaceShortcutLatched{false};
     bool m_audioActive = false;
 

--- a/Source/Core/AestraRootComponent.cpp
+++ b/Source/Core/AestraRootComponent.cpp
@@ -13,8 +13,11 @@ bool AestraRootComponent::onKeyEvent(const NUIKeyEvent& event) {
         return true;
     }
 
-    // 1. Global app-level shortcuts (Ctrl+Z, Ctrl+Y, Space) — BEFORE focused component
-    if (m_rootContent) {
+    // 1. Global app-level shortcuts and key releases go first. Releases must
+    // reach musical typing even if focus moved after note-on.
+    const bool globalFirst = event.released || event.keyCode == NUIKeyCode::Space ||
+        (event.modifiers & NUIModifiers::Ctrl);
+    if (globalFirst && m_rootContent) {
         if (m_rootContent->onKeyEvent(event)) {
             return true;
         }
@@ -27,7 +30,12 @@ bool AestraRootComponent::onKeyEvent(const NUIKeyEvent& event) {
         }
     }
 
-    // 3. Fallback: F12 HUD toggle
+    // 3. Non-global fallback after the focused control declined the key.
+    if (!globalFirst && m_rootContent && m_rootContent->onKeyEvent(event)) {
+        return true;
+    }
+
+    // 4. Fallback: F12 HUD toggle
     if (event.pressed) {
         if (event.keyCode == NUIKeyCode::F12) {
             if (m_rootUnifiedHUD) {

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -354,7 +354,13 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.released = !pressed;
             event.modifiers = m_keyModifiers;
 
-            if (event.keyCode == AestraUI::NUIKeyCode::Space || event.released) {
+            // Global-first bucket mirrors AestraRootComponent: releases (note
+            // latches), Space, and Ctrl-chords (app shortcuts like Ctrl+Z must
+            // not be swallowed by a focused widget). Content only claims the
+            // undo/redo/history chords, so clipboard combos still reach
+            // focused text inputs.
+            if (event.keyCode == AestraUI::NUIKeyCode::Space || event.released ||
+                (event.modifiers & AestraUI::NUIModifiers::Ctrl)) {
                 if (m_content->onKeyEvent(event))
                     return;
             }

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -36,6 +36,7 @@ namespace {
         if (key == static_cast<int>(KC::Tab)) return NUIKC::Tab;
         if (key == static_cast<int>(KC::Backspace)) return NUIKC::Backspace;
         if (key == static_cast<int>(KC::Delete)) return NUIKC::Delete;
+        if (key == static_cast<int>(KC::CapsLock)) return NUIKC::CapsLock;
 
         // Arrow keys
         if (key == static_cast<int>(KC::Left)) return NUIKC::Left;
@@ -353,7 +354,7 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.released = !pressed;
             event.modifiers = m_keyModifiers;
 
-            if (event.keyCode == AestraUI::NUIKeyCode::Space) {
+            if (event.keyCode == AestraUI::NUIKeyCode::Space || event.released) {
                 if (m_content->onKeyEvent(event))
                     return;
             }
@@ -411,6 +412,10 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     });
 
     m_window->setFocusCallback([this](bool focused) {
+         m_windowFocused = focused;
+         if (!focused && m_content) {
+             m_content->releaseMusicalTypingNotes();
+         }
          if (m_useCustomCursor && m_window) {
              m_window->setCursorVisible(!focused); // Hide if focused (drawn manually)
          }

--- a/Source/Core/MusicalTypingController.cpp
+++ b/Source/Core/MusicalTypingController.cpp
@@ -83,14 +83,13 @@ int MusicalTypingController::semitoneForKey(AestraUI::NUIKeyCode keyCode) {
     }
 }
 
-bool MusicalTypingController::shiftOctave(int semitones) {
+void MusicalTypingController::shiftOctave(int semitones) {
     const int next = std::clamp(m_baseMidiNote + semitones, kMinimumBaseNote, kMaximumBaseNote);
     if (next == m_baseMidiNote) {
-        return true;
+        return;
     }
     releaseAllNotes();
     m_baseMidiNote = next;
-    return true;
 }
 
 bool MusicalTypingController::handleKeyEvent(const AestraUI::NUIKeyEvent& event) {
@@ -159,14 +158,14 @@ bool MusicalTypingController::handleKeyEvent(const AestraUI::NUIKeyEvent& event)
 }
 
 void MusicalTypingController::releaseAllNotes() {
-    for (auto it = m_activeNotes.begin(); it != m_activeNotes.end();) {
-        const ActiveNote active = it->second;
-        if (post(active.unitId, kNoteOff, active.note, 0)) {
-            it = m_activeNotes.erase(it);
-        } else {
-            ++it;
-        }
+    // Best-effort note-offs, then drop the latch unconditionally: keeping
+    // entries whose post() failed (null sink, full queue) would leave stale
+    // unit/note pairs that fire against a future sink instead of retrying.
+    for (const auto& [key, active] : m_activeNotes) {
+        (void)key;
+        post(active.unitId, kNoteOff, active.note, 0);
     }
+    m_activeNotes.clear();
 }
 
 } // namespace Aestra

--- a/Source/Core/MusicalTypingController.cpp
+++ b/Source/Core/MusicalTypingController.cpp
@@ -1,0 +1,172 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "MusicalTypingController.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace Aestra {
+
+namespace {
+constexpr uint8_t kNoteOff = 0x80;
+constexpr uint8_t kNoteOn = 0x90;
+constexpr uint8_t kDefaultVelocity = 100;
+constexpr int kMinimumBaseNote = 0;
+constexpr int kMaximumBaseNote = 96; // Upper row tops out at MIDI 124.
+} // namespace
+
+MusicalTypingController::MusicalTypingController(EventSink sink)
+    : m_sink(std::move(sink)) {}
+
+void MusicalTypingController::setEventSink(EventSink sink) {
+    releaseAllNotes();
+    m_sink = std::move(sink);
+}
+
+void MusicalTypingController::setTargetUnit(uint64_t unitId) {
+    if (m_targetUnit == unitId) {
+        return;
+    }
+    releaseAllNotes();
+    m_targetUnit = unitId;
+}
+
+void MusicalTypingController::setEnabled(bool enabled) {
+    if (m_enabled == enabled) {
+        return;
+    }
+    if (!enabled) {
+        releaseAllNotes();
+    }
+    m_enabled = enabled;
+}
+
+bool MusicalTypingController::post(uint64_t unitId, uint8_t status, uint8_t note, uint8_t velocity) {
+    return m_sink && unitId != 0 && m_sink(unitId, status, note, velocity);
+}
+
+int MusicalTypingController::semitoneForKey(AestraUI::NUIKeyCode keyCode) {
+    using Key = AestraUI::NUIKeyCode;
+    switch (keyCode) {
+    // Lower row: Z-M, one chromatic octave.
+    case Key::Z: return 0;
+    case Key::S: return 1;
+    case Key::X: return 2;
+    case Key::D: return 3;
+    case Key::C: return 4;
+    case Key::V: return 5;
+    case Key::G: return 6;
+    case Key::B: return 7;
+    case Key::H: return 8;
+    case Key::N: return 9;
+    case Key::J: return 10;
+    case Key::M: return 11;
+
+    // Upper row: Q-P with number-row black keys, matching common DAW layouts.
+    case Key::Q: return 12;
+    case Key::Num2: return 13;
+    case Key::W: return 14;
+    case Key::Num3: return 15;
+    case Key::E: return 16;
+    case Key::R: return 17;
+    case Key::Num5: return 18;
+    case Key::T: return 19;
+    case Key::Num6: return 20;
+    case Key::Y: return 21;
+    case Key::Num7: return 22;
+    case Key::U: return 23;
+    case Key::I: return 24;
+    case Key::Num9: return 25;
+    case Key::O: return 26;
+    case Key::Num0: return 27;
+    case Key::P: return 28;
+    default: return -1;
+    }
+}
+
+bool MusicalTypingController::shiftOctave(int semitones) {
+    const int next = std::clamp(m_baseMidiNote + semitones, kMinimumBaseNote, kMaximumBaseNote);
+    if (next == m_baseMidiNote) {
+        return true;
+    }
+    releaseAllNotes();
+    m_baseMidiNote = next;
+    return true;
+}
+
+bool MusicalTypingController::handleKeyEvent(const AestraUI::NUIKeyEvent& event) {
+    using Key = AestraUI::NUIKeyCode;
+
+    // Caps Lock is the explicit mode toggle and remains available while off.
+    if (event.keyCode == Key::CapsLock) {
+        if (event.pressed && !event.repeat) {
+            setEnabled(!m_enabled);
+        }
+        return event.pressed || event.released;
+    }
+
+    if (!m_enabled) {
+        return false;
+    }
+
+    // Modified keys belong to application shortcuts, never musical typing.
+    if (event.modifiers & AestraUI::NUIModifiers::Ctrl || event.modifiers & AestraUI::NUIModifiers::Alt ||
+        event.modifiers & AestraUI::NUIModifiers::Super) {
+        return false;
+    }
+
+    if (event.keyCode == Key::Up || event.keyCode == Key::Down) {
+        if (event.pressed && !event.repeat) {
+            shiftOctave(event.keyCode == Key::Up ? 12 : -12);
+        }
+        return event.pressed || event.released;
+    }
+
+    const int semitone = semitoneForKey(event.keyCode);
+    if (semitone < 0) {
+        return false;
+    }
+
+    const int key = static_cast<int>(event.keyCode);
+    if (event.released) {
+        const auto it = m_activeNotes.find(key);
+        if (it != m_activeNotes.end()) {
+            const ActiveNote active = it->second;
+            if (post(active.unitId, kNoteOff, active.note, 0)) {
+                m_activeNotes.erase(it);
+            }
+        }
+        return true;
+    }
+
+    if (!event.pressed) {
+        return false;
+    }
+
+    // The active-key latch also suppresses OS repeat on platforms that do not
+    // populate NUIKeyEvent::repeat.
+    if (event.repeat || m_activeNotes.find(key) != m_activeNotes.end()) {
+        return true;
+    }
+    if (m_targetUnit == 0) {
+        return true;
+    }
+
+    const auto note = static_cast<uint8_t>(m_baseMidiNote + semitone);
+    if (post(m_targetUnit, kNoteOn, note, kDefaultVelocity)) {
+        m_activeNotes.emplace(key, ActiveNote{m_targetUnit, note});
+    }
+    return true;
+}
+
+void MusicalTypingController::releaseAllNotes() {
+    for (auto it = m_activeNotes.begin(); it != m_activeNotes.end();) {
+        const ActiveNote active = it->second;
+        if (post(active.unitId, kNoteOff, active.note, 0)) {
+            it = m_activeNotes.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace Aestra

--- a/Source/Core/MusicalTypingController.h
+++ b/Source/Core/MusicalTypingController.h
@@ -50,7 +50,7 @@ private:
 
     static int semitoneForKey(AestraUI::NUIKeyCode keyCode);
     bool post(uint64_t unitId, uint8_t status, uint8_t note, uint8_t velocity);
-    bool shiftOctave(int semitones);
+    void shiftOctave(int semitones);
 
     EventSink m_sink;
     std::unordered_map<int, ActiveNote> m_activeNotes;

--- a/Source/Core/MusicalTypingController.h
+++ b/Source/Core/MusicalTypingController.h
@@ -1,0 +1,62 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "NUITypes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+
+namespace Aestra {
+
+/**
+ * @brief Converts computer-keyboard events into live MIDI notes.
+ *
+ * This class owns the key latch and note lifetime independently from UI focus
+ * routing. Callers decide when keyboard input is eligible, while this class
+ * guarantees one note-on per physical press and a matching note-off for the
+ * original unit/note when the key is released.
+ */
+class MusicalTypingController {
+public:
+    using EventSink = std::function<bool(uint64_t unitId, uint8_t status, uint8_t data1, uint8_t data2)>;
+
+    explicit MusicalTypingController(EventSink sink = {});
+
+    /** @brief Replace the live-MIDI event destination. Releases held notes first. */
+    void setEventSink(EventSink sink);
+    /** @brief Select the Arsenal unit that receives future note-ons. */
+    void setTargetUnit(uint64_t unitId);
+    /** @brief Enable or disable musical typing. Disabling releases all held notes. */
+    void setEnabled(bool enabled);
+    /** @brief Handle an eligible UI key event. */
+    bool handleKeyEvent(const AestraUI::NUIKeyEvent& event);
+    /** @brief Send note-offs for every held key, used on focus loss and shutdown. */
+    void releaseAllNotes();
+
+    bool isEnabled() const { return m_enabled; }
+    uint64_t targetUnit() const { return m_targetUnit; }
+    int baseMidiNote() const { return m_baseMidiNote; }
+    /** @brief Display octave using Aestra's convention where MIDI 60 is C3. */
+    int displayOctave() const { return (m_baseMidiNote / 12) - 2; }
+    size_t heldNoteCount() const { return m_activeNotes.size(); }
+
+private:
+    struct ActiveNote {
+        uint64_t unitId{0};
+        uint8_t note{0};
+    };
+
+    static int semitoneForKey(AestraUI::NUIKeyCode keyCode);
+    bool post(uint64_t unitId, uint8_t status, uint8_t note, uint8_t velocity);
+    bool shiftOctave(int semitones);
+
+    EventSink m_sink;
+    std::unordered_map<int, ActiveNote> m_activeNotes;
+    uint64_t m_targetUnit{0};
+    int m_baseMidiNote{60};
+    bool m_enabled{true};
+};
+
+} // namespace Aestra

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -43,6 +43,20 @@ TransportBar::TransportBar()
     
     createButtons();
 
+    m_musicalTypingLabel = std::make_shared<AestraUI::NUILabel>("KEYS C3");
+    m_musicalTypingLabel->setFontSize(11.0f);
+    m_musicalTypingLabel->setAlignment(AestraUI::NUILabel::Alignment::Center);
+    m_musicalTypingLabel->setTextColor(AestraUI::NUIThemeManager::getInstance().getColor("accentPrimary"));
+    m_musicalTypingLabel->setBackgroundVisible(true);
+    m_musicalTypingLabel->setBackgroundColor(
+        AestraUI::NUIThemeManager::getInstance().getColor("surfaceTertiary").withAlpha(0.72f));
+    m_musicalTypingLabel->setBorderVisible(true);
+    m_musicalTypingLabel->setBorderWidth(1.0f);
+    m_musicalTypingLabel->setBorderColor(
+        AestraUI::NUIThemeManager::getInstance().getColor("border").withAlpha(0.52f));
+    m_musicalTypingLabel->setTooltip("Computer keys: Caps Lock toggles, Up/Down shifts octave");
+    addChild(m_musicalTypingLabel);
+
     // Wire up BPM change callback from arrows
     if (m_infoContainer && m_infoContainer->getBPMDisplay()) {
         m_infoContainer->getBPMDisplay()->setOnBPMChange([this](float newBPM) {
@@ -414,6 +428,17 @@ void TransportBar::syncTransportState(bool playing, bool paused, bool recordArme
     }
 }
 
+void TransportBar::setMusicalTypingStatus(bool enabled, int octave) {
+    if (!m_musicalTypingLabel) {
+        return;
+    }
+    m_musicalTypingLabel->setText(enabled ? "KEYS C" + std::to_string(octave) : "KEYS OFF");
+    auto& theme = AestraUI::NUIThemeManager::getInstance();
+    m_musicalTypingLabel->setTextColor(
+        enabled ? theme.getColor("accentPrimary") : theme.getColor("textSecondary").withAlpha(0.62f));
+    setDirty(true);
+}
+
 void TransportBar::updateButtonStates() {
     // Clear textual fallbacks (we render SVG icons instead)
     if (m_playButton) {
@@ -608,7 +633,8 @@ void TransportBar::layoutComponents() {
     float group4Width = (buttonSize * 4) + (spacing * 3);
 
     // Total Content Width
-    float totalContentWidth = group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
+    float totalContentWidth =
+        group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
     float islandPadding = TRANSPORT_ISLAND_PADDING;
     float islandWidth = totalContentWidth + (islandPadding * 2.0f);
     
@@ -686,6 +712,18 @@ void TransportBar::layoutComponents() {
         // xCursor += buttonSize + spacing;
     }
 
+    if (m_musicalTypingLabel) {
+        constexpr float statusWidth = 82.0f;
+        constexpr float statusHeight = 24.0f;
+        const float statusX = islandX + islandWidth + 10.0f;
+        const bool hasRoom = statusX + statusWidth <= bounds.width - 8.0f;
+        m_musicalTypingLabel->setVisible(hasRoom);
+        if (hasRoom) {
+            m_musicalTypingLabel->setBounds(NUIAbsolute(
+                bounds, statusX, islandY + (islandHeight - statusHeight) * 0.5f, statusWidth, statusHeight));
+        }
+    }
+
     // Pass dimensions to Render via Theme or member not possible easily here without state.
     // We relying on onRender duplicating the math or us storing it?
     // Let's update onRender to match these hardcoded compaction values.
@@ -710,7 +748,8 @@ void TransportBar::onRender(AestraUI::NUIRenderer& renderer) {
     float infoWidth = 260.0f;
     float group4Width = (buttonSize * 4) + (spacing * 3);
 
-    float totalContentWidth = group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
+    float totalContentWidth =
+        group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
     float islandPadding = TRANSPORT_ISLAND_PADDING;
     float islandWidth = totalContentWidth + (islandPadding * 2.0f);
     

--- a/Source/Panels/TransportBar.h
+++ b/Source/Panels/TransportBar.h
@@ -88,6 +88,8 @@ public:
     // Push state from authority
     void setViewToggled(Audio::ViewType view, bool active);
     void syncTransportState(bool playing, bool paused, bool recordArmed);
+    /** @brief Show computer-keyboard note-input state and base octave. */
+    void setMusicalTypingStatus(bool enabled, int octave);
 
     // Global Tool & Scale Callbacks
 
@@ -118,6 +120,7 @@ private:
     std::shared_ptr<AestraUI::NUIButton> m_playlistButton;
 
     std::shared_ptr<TransportInfoContainer> m_infoContainer;  // Modular info container
+    std::shared_ptr<AestraUI::NUILabel> m_musicalTypingLabel;
     
     // Icons
     std::shared_ptr<AestraUI::NUIIcon> m_playIcon;

--- a/Tests/AestraUI/MusicalTypingControllerTest.cpp
+++ b/Tests/AestraUI/MusicalTypingControllerTest.cpp
@@ -94,6 +94,15 @@ int main() {
     }
     require(typing.baseMidiNote() == 96, "octave shift must clamp below MIDI 127 for upper row");
 
+    for (int i = 0; i < 20; ++i) {
+        typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Down));
+        typing.handleKeyEvent(release(AestraUI::NUIKeyCode::Down));
+    }
+    require(typing.baseMidiNote() == 0, "octave shift must clamp at MIDI 0 for the lower row");
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z));
+    require(events.back().status == 0x90 && events.back().note == 0, "lowest octave must still play valid notes");
+    typing.handleKeyEvent(release(AestraUI::NUIKeyCode::Z));
+
     std::cout << "[PASS] MusicalTypingControllerTest\n";
     return 0;
 }

--- a/Tests/AestraUI/MusicalTypingControllerTest.cpp
+++ b/Tests/AestraUI/MusicalTypingControllerTest.cpp
@@ -1,0 +1,99 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "MusicalTypingController.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace {
+struct MidiEvent {
+    uint64_t unitId;
+    uint8_t status;
+    uint8_t note;
+    uint8_t velocity;
+};
+
+[[noreturn]] void fail(const char* message) {
+    std::cerr << "[FAIL] " << message << '\n';
+    std::exit(1);
+}
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        fail(message);
+    }
+}
+
+AestraUI::NUIKeyEvent press(AestraUI::NUIKeyCode key, AestraUI::NUIModifiers modifiers = AestraUI::NUIModifiers::None) {
+    AestraUI::NUIKeyEvent event;
+    event.keyCode = key;
+    event.modifiers = modifiers;
+    event.pressed = true;
+    return event;
+}
+
+AestraUI::NUIKeyEvent release(AestraUI::NUIKeyCode key) {
+    AestraUI::NUIKeyEvent event;
+    event.keyCode = key;
+    event.released = true;
+    return event;
+}
+} // namespace
+
+int main() {
+    std::vector<MidiEvent> events;
+    Aestra::MusicalTypingController typing([&](uint64_t unitId, uint8_t status, uint8_t note, uint8_t velocity) {
+        events.push_back({unitId, status, note, velocity});
+        return true;
+    });
+    typing.setTargetUnit(7);
+
+    require(typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z)), "Z press should be handled");
+    require(events.size() == 1 && events[0].unitId == 7 && events[0].status == 0x90 && events[0].note == 60,
+            "Z should emit middle-C note-on for selected unit");
+
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z));
+    require(events.size() == 1, "held key must suppress repeated note-ons without relying on repeat flag");
+    typing.handleKeyEvent(release(AestraUI::NUIKeyCode::Z));
+    require(events.size() == 2 && events[1].status == 0x80 && events[1].note == 60,
+            "Z release should emit matching note-off");
+
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Q));
+    require(events.back().note == 72, "Q should begin the upper keyboard row one octave above Z");
+    typing.setTargetUnit(9);
+    require(events.back().unitId == 7 && events.back().status == 0x80 && events.back().note == 72,
+            "target changes must release held notes on their original unit");
+
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Up));
+    require(typing.displayOctave() == 4, "Up should shift the base octave by one");
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::M));
+    require(events.back().unitId == 9 && events.back().note == 83, "M should follow selected unit and shifted octave");
+    typing.releaseAllNotes();
+    require(typing.heldNoteCount() == 0 && events.back().status == 0x80,
+            "focus-loss panic should release every held key");
+
+    const size_t beforeShortcut = events.size();
+    require(!typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z, AestraUI::NUIModifiers::Ctrl)),
+            "modified application shortcut must not be claimed");
+    require(events.size() == beforeShortcut, "modified shortcut must not emit MIDI");
+
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z));
+    const size_t beforeDisable = events.size();
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::CapsLock));
+    require(!typing.isEnabled(), "Caps Lock should disable musical typing");
+    require(events.size() == beforeDisable + 1 && events.back().status == 0x80 && typing.heldNoteCount() == 0,
+            "disabling musical typing must send all-notes-off for held computer keys");
+    require(!typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Z)), "disabled mode should not claim note keys");
+    typing.handleKeyEvent(press(AestraUI::NUIKeyCode::CapsLock));
+    require(typing.isEnabled(), "Caps Lock should re-enable musical typing");
+
+    for (int i = 0; i < 20; ++i) {
+        typing.handleKeyEvent(press(AestraUI::NUIKeyCode::Up));
+        typing.handleKeyEvent(release(AestraUI::NUIKeyCode::Up));
+    }
+    require(typing.baseMidiNote() == 96, "octave shift must clamp below MIDI 127 for upper row");
+
+    std::cout << "[PASS] MusicalTypingControllerTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1527,18 +1527,18 @@ else()
     message(STATUS "NUITextInputLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/MusicalTypingControllerTest.cpp")
-    add_executable(MusicalTypingControllerTest
-        AestraUI/MusicalTypingControllerTest.cpp
-        ${CMAKE_SOURCE_DIR}/Source/Core/MusicalTypingController.cpp
-    )
-    target_include_directories(MusicalTypingControllerTest PRIVATE
-        ${CMAKE_SOURCE_DIR}/Source/Core
-        ${CMAKE_SOURCE_DIR}/AestraUI/Core
-    )
-    add_test(NAME MusicalTypingControllerTest COMMAND MusicalTypingControllerTest)
-    set_tests_properties(MusicalTypingControllerTest PROPERTIES LABELS "ui;midi;regression")
-endif()
+# No EXISTS guard: a missing committed test source must fail configure, not
+# silently drop coverage (repo policy since #454/#463).
+add_executable(MusicalTypingControllerTest
+    AestraUI/MusicalTypingControllerTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/MusicalTypingController.cpp
+)
+target_include_directories(MusicalTypingControllerTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Core
+    ${CMAKE_SOURCE_DIR}/AestraUI/Core
+)
+add_test(NAME MusicalTypingControllerTest COMMAND MusicalTypingControllerTest)
+set_tests_properties(MusicalTypingControllerTest PROPERTIES LABELS "ui;midi;regression")
 
 # =============================================================================
 # Commands Tests (Phase 2 - Undo/Redo System)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1527,6 +1527,19 @@ else()
     message(STATUS "NUITextInputLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/MusicalTypingControllerTest.cpp")
+    add_executable(MusicalTypingControllerTest
+        AestraUI/MusicalTypingControllerTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/MusicalTypingController.cpp
+    )
+    target_include_directories(MusicalTypingControllerTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+    )
+    add_test(NAME MusicalTypingControllerTest COMMAND MusicalTypingControllerTest)
+    set_tests_properties(MusicalTypingControllerTest PROPERTIES LABELS "ui;midi;regression")
+endif()
+
 # =============================================================================
 # Commands Tests (Phase 2 - Undo/Redo System)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds computer-keyboard musical typing for the selected Arsenal unit.

- FL/Ableton-style lower `Z-M` and upper `Q-P` note rows, including number-row black keys
- Caps Lock toggles musical typing; Up/Down shifts the base octave
- Transport status shows `KEYS C3` or `KEYS OFF`
- Selected-unit changes retarget future notes
- Held-key latching suppresses OS repeat
- Note-offs retain the original unit and pitch
- Held notes are released on focus loss, unit/engine changes, mode disable, and shutdown

## Why

The engine live-MIDI queue existed, but no UI caller translated computer-keyboard input into playable notes. This completes the non-hardware half of the founder-review MIDI input item while protecting text editing and existing shortcut ownership.

Closes #461.

## Validation

- `cmake --build build-linux --target MusicalTypingControllerTest -j2`
- `ctest --test-dir build-linux -R '^MusicalTypingControllerTest$' --output-on-failure` — 1/1 passed
- Syntax-only compilation passed for:
  - `Source/Core/AestraContent.cpp`
  - `Source/Core/AestraRootComponent.cpp`
  - `Source/Core/AestraWindowManager.cpp`
  - `Source/Panels/TransportBar.cpp`
- `git diff --check`

The local full UI configure was blocked by this container's missing OpenGL/X11 development headers. The repository's `Linux (UI/App compile)` CI lane is the authoritative full-target check.

## Manual verification requested

- Select an Arsenal unit and play both keyboard rows with transport stopped and running
- Hold/release chords; confirm no stuck notes
- Hold a note, switch units, and confirm the old unit releases
- Focus search/rename/settings text fields; confirm typing produces no notes
- Hold notes and alt-tab; confirm focus loss silences them
- Toggle Caps Lock and shift octaves with Up/Down; confirm the transport indicator
- Confirm existing timeline/piano-roll/global shortcuts retain priority

## Risk / rollback

The change is confined to UI/control-thread event routing and the existing lock-free live-MIDI producer queue. No DSP, serialization, or project-format changes. Rollback is the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added computer-keyboard musical typing for the selected Arsenal unit, using `Z–M` and `Q–P` rows with number-row black keys.
- Added Caps Lock enable/disable, Up/Down octave shifting, and transport status display (`KEYS C<octave>` / `KEYS OFF`).
- Routes note events through the live-MIDI engine path, retargeting future notes when the selected unit changes while preserving note-off ownership.
- Prevents key-repeat latching, respects text fields and existing shortcuts, and releases held notes on focus loss, mode/unit/engine changes, and shutdown.
- Added controller coverage for note mapping, octave shifts, retargeting, modifier handling, disabling, and note cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->