### PR TITLE
fix(automation): connect lane curves to playback, beat-domain evaluation

### DIFF
--- a/AestraAudio/include/Core/AutomationCurve.h
+++ b/AestraAudio/include/Core/AutomationCurve.h
@@ -34,10 +34,15 @@ inline AutomationTarget automationTargetFromRawInt(int rawValue) noexcept {
 }
 
 struct AutomationPoint {
+    // beat is the authoritative position domain: it is what the serializer
+    // persists, what the UI edits, and what evaluation/sorting use. sample is
+    // a legacy cache computed at addPoint() time with that moment's tempo —
+    // it goes stale on tempo changes and UI drags, so nothing may evaluate or
+    // sort by it.
     uint64_t sample{0};
     float value{0.0f};
-    double beat{0.0};  // For serialization
-    float curve{0.0f}; // For serialization (curve tension)
+    double beat{0.0};
+    float curve{0.0f};    // Curve tension (serialized; rendering does not use it yet)
     bool selected{false}; // Selection state for UI
 };
 
@@ -76,24 +81,27 @@ struct AutomationCurve {
     std::vector<AutomationPoint>& getPoints() { return points; }
 
     /**
-     * @brief Get interpolated value at a given beat position
+     * @brief Get interpolated value at a given beat position.
+     *
+     * Evaluation is purely beat-domain. The old implementation compared the
+     * stale sample cache against a target derived from the *current* tempo,
+     * which shifted every point in musical time after a BPM change and made
+     * UI point drags (which update beat only) inaudible.
+     *
      * @param beat The beat position
-     * @param samplesPerBeat Samples per beat for the current project tempo/rate
      * @return Interpolated value, or defaultValue if no points
      */
-    float getValueAtBeat(double beat, double samplesPerBeat) const {
+    float getValueAtBeat(double beat) const {
         if (points.empty()) {
             return defaultValue;
         }
 
-        const uint64_t targetSample = static_cast<uint64_t>(beat * samplesPerBeat);
-
-        // Find surrounding points
+        // Find surrounding points (points are sorted by beat)
         const AutomationPoint* prev = nullptr;
         const AutomationPoint* next = nullptr;
 
         for (const auto& pt : points) {
-            if (pt.sample <= targetSample) {
+            if (pt.beat <= beat) {
                 prev = &pt;
             } else {
                 next = &pt;
@@ -111,15 +119,23 @@ struct AutomationCurve {
             return prev->value;
         }
 
-        // Linear interpolation
-        const double sampleRange = static_cast<double>(next->sample - prev->sample);
-        if (sampleRange <= 0.0) {
+        // Linear interpolation in beat domain
+        const double beatRange = next->beat - prev->beat;
+        if (beatRange <= 0.0) {
             return prev->value;
         }
 
-        const double t = static_cast<double>(targetSample - prev->sample) / sampleRange;
+        const double t = (beat - prev->beat) / beatRange;
         return prev->value + static_cast<float>(t) * (next->value - prev->value);
     }
+
+    /**
+     * @brief Legacy overload — samplesPerBeat is ignored; beat is authoritative.
+     *
+     * Kept so older call sites/tests compile; new code should call the
+     * single-argument form.
+     */
+    float getValueAtBeat(double beat, double /*samplesPerBeat*/) const { return getValueAtBeat(beat); }
 
     /**
      * @brief Set the default value for this curve
@@ -143,9 +159,9 @@ struct AutomationCurve {
         pt.beat = beat;
         pt.curve = tension;
 
-        // Insert in sorted order
+        // Insert in sorted order (beat domain — see AutomationPoint docs)
         auto it = points.begin();
-        while (it != points.end() && it->sample < pt.sample) {
+        while (it != points.end() && it->beat < pt.beat) {
             ++it;
         }
         points.insert(it, pt);
@@ -158,9 +174,10 @@ struct AutomationCurve {
     }
 
     void sortPoints() {
-        std::sort(points.begin(), points.end(), [](const AutomationPoint& a, const AutomationPoint& b) {
-            return a.sample < b.sample;
-        });
+        // Beat domain: the UI drag path updates beat (not the sample cache),
+        // so sorting by sample could scramble order after edits.
+        std::sort(points.begin(), points.end(),
+                  [](const AutomationPoint& a, const AutomationPoint& b) { return a.beat < b.beat; });
     }
 
     bool isVisible() const { return true; }

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -447,6 +447,11 @@ public:
                 laneInfo.clips.push_back(clipInfo);
             }
 
+            // Automation rides the same snapshot as clips — this copy is what
+            // connects drawn/loaded curves to the render graph. It was missing
+            // entirely, so automation persisted and displayed but never played.
+            laneInfo.automationCurves = lane.automationCurves;
+
             snapshot->lanes.push_back(std::move(laneInfo));
         }
 

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -178,7 +178,9 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
             }
 
             auto& trackState = graph.tracks[laneIdx];
-            const auto& laneInfo = snapshot->lanes[laneIdx];
+            // Non-const: automationCurves below is genuinely moved out of the
+            // snapshot (std::move through a const ref silently copies).
+            auto& laneInfo = snapshot->lanes[laneIdx];
 
             for (const auto& clipInfo : laneInfo.clips) {
                 if (!clipInfo.isValid())

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2039,16 +2039,17 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         double volTarget = static_cast<double>(track.volume) * gain;
         double panTarget = clampD(static_cast<double>(track.pan) + static_cast<double>(panParam), -1.0, 1.0);
 
-        // Apply Automation Override (v3.1)
+        // Apply Automation Override (v3.1). Beat-domain evaluation: the curve
+        // interpolates on point beats directly, so tempo changes and UI point
+        // drags (which edit beats) stay musically aligned.
         if (!track.automationCurves.empty() && cachedSampleRate > 0) {
             uint64_t globalPos = m_globalSamplePos.load(std::memory_order_relaxed);
-            const double samplesPerBeat = (static_cast<double>(cachedSampleRate) * 60.0) / std::max(graph.bpm, 1.0);
             double currentBeat = (static_cast<double>(globalPos) / cachedSampleRate) * (graph.bpm / 60.0);
             for (const auto& curve : track.automationCurves) {
                 if (curve.getAutomationTarget() == AutomationTarget::Volume) {
-                    volTarget = curve.getValueAtBeat(currentBeat, samplesPerBeat);
+                    volTarget = curve.getValueAtBeat(currentBeat);
                 } else if (curve.getAutomationTarget() == AutomationTarget::Pan) {
-                    panTarget = clampD(curve.getValueAtBeat(currentBeat, samplesPerBeat), -1.0, 1.0);
+                    panTarget = clampD(curve.getValueAtBeat(currentBeat), -1.0, 1.0);
                 }
             }
         }

--- a/Tests/AestraAudio/AutomationStressTest.cpp
+++ b/Tests/AestraAudio/AutomationStressTest.cpp
@@ -69,20 +69,24 @@ void test_out_of_range() {
     testsPassed++;
 }
 
-// 2a-IV: Sample rate mismatch (different SPB)
+// 2a-IV: Tempo/sample-rate independence. Points added at one samplesPerBeat
+// must evaluate identically at any other: beat is the authoritative domain.
+// (The old 0.594 expectation at beat 1.5 was computed FROM the mixed-domain
+// bug — stale sample cache vs current-tempo target — which shifted automation
+// after BPM changes. Beat-domain interpolation gives the musical midpoint.)
 void test_sample_rate_mismatch() {
     AutomationCurve curve;
     EXPECT_NO_CRASH(curve.addPoint(1.0, 0.5f, 480.0));
     EXPECT_NO_CRASH(curve.addPoint(2.0, 0.75f, 480.0));
 
-    // Query at same beat, diff sample rate
-    // Note: At 441 spb, beat 1.5 = sample 661.5, between points at 480 & 960
-    // Linear interp: 0.5 + (661.5-480)/(960-480)*(0.75-0.5) = 0.594
     EXPECT_NO_CRASH(float v1 = curve.getValueAtBeat(1.0, 441.0));
     EXPECT_FLOAT_EQ(curve.getValueAtBeat(1.0, 441.0), 0.5f, 0.01f);
 
+    // Midpoint between (1.0, 0.5) and (2.0, 0.75) regardless of tempo.
     EXPECT_NO_CRASH(float v2 = curve.getValueAtBeat(1.5, 441.0));
-    EXPECT_FLOAT_EQ(curve.getValueAtBeat(1.5, 441.0), 0.594f, 0.01f);
+    EXPECT_FLOAT_EQ(curve.getValueAtBeat(1.5, 441.0), 0.625f, 0.01f);
+    EXPECT_FLOAT_EQ(curve.getValueAtBeat(1.5, 480.0), 0.625f, 0.01f);
+    EXPECT_FLOAT_EQ(curve.getValueAtBeat(1.5), 0.625f, 0.01f);
 
     // Out of range queries
     EXPECT_NO_CRASH(float v3 = curve.getValueAtBeat(1000.0, 441.0));

--- a/Tests/Headless/AutomationPlaybackTest.cpp
+++ b/Tests/Headless/AutomationPlaybackTest.cpp
@@ -1,0 +1,273 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AutomationPlaybackTest
+// End-to-end regression for the automation playback pipe:
+//
+//   1. Drawn/loaded curves must actually reach the engine and shape output.
+//      (PlaylistModel::buildRuntimeSnapshot never copied lane automation into
+//      the snapshot, so automation persisted and displayed but NEVER played.)
+//   2. Tempo changes must not shift automation in musical time (evaluation was
+//      mixed-domain: stale add-time sample cache vs current-tempo target).
+//   3. UI point drags edit point beats only; playback must follow the beat.
+//   4. Pan automation pans; volume-only lanes keep the fader path intact.
+//
+// Drives the real RT path (AudioEngine::processBlock) with a deterministic
+// generator plugin — no clips, no devices, no file I/O.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraph.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Core/AutomationCurve.h"
+#include "Core/MixerChannel.h"
+#include "Models/PlaylistModel.h"
+#include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockFrames = 256;
+constexpr uint32_t kChannels = 2;
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+// Constant-amplitude sine on both channels: gain changes read directly as
+// RMS ratios, and pan gains read as L/R dominance.
+class SineGeneratorPlugin : public IPluginInstance {
+public:
+    SineGeneratorPlugin() {
+        m_info.id = "aestra.test.automation_generator";
+        m_info.name = "AutomationGenerator";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override { m_active = true; }
+    void deactivate() override { m_active = false; }
+    bool isActive() const override { return m_active; }
+
+    void process(const float* const* /*inputs*/, float** outputs, uint32_t /*numInputChannels*/,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* = nullptr,
+                 MidiBuffer* = nullptr) override {
+        if (!outputs || numOutputChannels < 2 || !outputs[0] || !outputs[1]) {
+            return;
+        }
+        for (uint32_t k = 0; k < numFrames; ++k) {
+            const double phase =
+                2.0 * 3.14159265358979 * 220.0 * (static_cast<double>(m_sampleIndex + k) / kSampleRate);
+            const float s = 0.25f * static_cast<float>(std::sin(phase));
+            outputs[0][k] = s;
+            outputs[1][k] = s;
+        }
+        m_sampleIndex += numFrames;
+    }
+
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+private:
+    PluginInfo m_info{};
+    uint64_t m_sampleIndex{0};
+    bool m_active{false};
+};
+
+struct Rendered {
+    std::vector<float> left;
+    std::vector<float> right;
+    bool hasInvalid = false;
+};
+
+// Builds a one-track project whose lane carries `curves`, sets the playlist
+// BPM to `renderBpm`, and renders `beats` beats of transport playback.
+Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double renderBpm, double beats) {
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
+
+    MixerChannel* src = trackManager->addChannel("src");
+    require(src != nullptr, "addChannel failed");
+    require(src->getEffectChain().insertPlugin(0, std::make_shared<SineGeneratorPlugin>()), "generator insert failed");
+
+    auto& playlist = trackManager->getPlaylistModel();
+    playlist.setProjectSampleRate(static_cast<double>(kSampleRate));
+    playlist.setBPM(renderBpm);
+    const auto laneId = playlist.createLane("lane0");
+    auto* lane = playlist.getLane(laneId);
+    require(lane != nullptr, "getLane failed");
+    lane->automationCurves = curves;
+
+    AudioEngine engine;
+    engine.setTrackManager(trackManager);
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockFrames, kChannels);
+    trackManager->buildAndShareSlotMap();
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*trackManager));
+    engine.setSafetyLimiterEnabled(false);
+    engine.setTransportPlaying(true); // automation position tracks the transport
+
+    const double samplesPerBeat = (static_cast<double>(kSampleRate) * 60.0) / renderBpm;
+    const uint64_t totalFrames = static_cast<uint64_t>(beats * samplesPerBeat);
+
+    Rendered out;
+    out.left.reserve(totalFrames);
+    out.right.reserve(totalFrames);
+    std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    uint64_t rendered = 0;
+    while (rendered < totalFrames) {
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, kBlockFrames, static_cast<double>(rendered) / kSampleRate);
+        for (uint32_t k = 0; k < kBlockFrames && rendered + k < totalFrames; ++k) {
+            const float l = block[static_cast<size_t>(k) * 2];
+            const float r = block[static_cast<size_t>(k) * 2 + 1];
+            if (!std::isfinite(l) || !std::isfinite(r)) {
+                out.hasInvalid = true;
+            }
+            out.left.push_back(l);
+            out.right.push_back(r);
+        }
+        rendered += kBlockFrames;
+    }
+    return out;
+}
+
+double rmsWindow(const std::vector<float>& x, double fromBeat, double toBeat, double bpm) {
+    const double samplesPerBeat = (static_cast<double>(kSampleRate) * 60.0) / bpm;
+    const size_t from = static_cast<size_t>(fromBeat * samplesPerBeat);
+    const size_t to = std::min(static_cast<size_t>(toBeat * samplesPerBeat), x.size());
+    if (to <= from) {
+        return 0.0;
+    }
+    double acc = 0.0;
+    for (size_t i = from; i < to; ++i) {
+        acc += static_cast<double>(x[i]) * x[i];
+    }
+    return std::sqrt(acc / static_cast<double>(to - from));
+}
+
+AutomationCurve volumeCurve(std::initializer_list<std::pair<double, float>> pts, double addTimeSamplesPerBeat) {
+    AutomationCurve curve("Volume", AutomationTarget::Volume);
+    curve.setDefaultValue(1.0f);
+    for (const auto& [beat, value] : pts) {
+        curve.addPoint(beat, value, addTimeSamplesPerBeat, 0.5f);
+    }
+    return curve;
+}
+
+constexpr double kSpbAt120 = (static_cast<double>(kSampleRate) * 60.0) / 120.0; // 24000
+
+} // namespace
+
+int main() {
+    // ---------------- 1. Primary regression: a drawn volume curve is audible
+    // end-to-end. Full gain until beat 2, linear fade to silence at beat 4.
+    {
+        const auto r =
+            renderWithAutomation({volumeCurve({{0.0, 1.0f}, {2.0, 1.0f}, {4.0, 0.0f}}, kSpbAt120)}, 120.0, 6.0);
+        require(!r.hasInvalid, "volume: output contains NaN/Inf");
+        const double loud = rmsWindow(r.left, 0.5, 1.5, 120.0);
+        const double mid = rmsWindow(r.left, 2.9, 3.1, 120.0);
+        const double silent = rmsWindow(r.left, 4.5, 5.5, 120.0);
+        std::cout << "volume automation: loud=" << loud << " mid=" << mid << " tail=" << silent << "\n";
+        require(loud > 1.0e-3, "volume automation region is silent (curve never reached the engine)");
+        require(mid > 0.35 * loud && mid < 0.65 * loud, "volume automation midpoint is not ~half gain");
+        require(silent < 0.02 * loud, "volume automation did not fade to silence (curve ignored)");
+    }
+
+    // ---------------- 2. Tempo-change correctness: the same curve added while
+    // the project was at 120 BPM must stay beat-aligned when rendered at 240.
+    // (Pre-fix, the stale sample cache stretched the fade to twice as long.)
+    {
+        const auto r =
+            renderWithAutomation({volumeCurve({{0.0, 1.0f}, {2.0, 1.0f}, {4.0, 0.0f}}, kSpbAt120)}, 240.0, 8.0);
+        require(!r.hasInvalid, "tempo: output contains NaN/Inf");
+        const double loud = rmsWindow(r.left, 0.5, 1.5, 240.0);
+        const double silent = rmsWindow(r.left, 5.0, 7.0, 240.0);
+        require(loud > 1.0e-3, "tempo: automation region is silent");
+        require(silent < 0.02 * loud,
+                "tempo: automation shifted in musical time after BPM change (sample-domain evaluation)");
+    }
+
+    // ---------------- 3. UI drag contract: drags edit point beats in place and
+    // re-sort; playback must follow the new beat, not a stale sample cache.
+    {
+        auto curve = volumeCurve({{0.0, 1.0f}, {4.0, 1.0f}}, kSpbAt120);
+        auto& pts = curve.getPoints();
+        pts[1].beat = 1.0;   // drag the beat-4 point to beat 1...
+        pts[1].value = 0.0f; // ...and to zero gain (exactly what TrackUIComponent does)
+        curve.sortPoints();
+        const auto r = renderWithAutomation({curve}, 120.0, 4.0);
+        require(!r.hasInvalid, "drag: output contains NaN/Inf");
+        const double loud = rmsWindow(r.left, 0.0, 0.7, 120.0);
+        const double silent = rmsWindow(r.left, 1.5, 3.5, 120.0);
+        require(loud > 1.0e-3, "drag: pre-fade region is silent");
+        require(silent < 0.02 * loud, "drag: playback ignored the dragged point (stale sample cache)");
+    }
+
+    // ---------------- 4. Pan automation pans; the volume path stays fader-driven
+    // when no volume curve exists.
+    {
+        AutomationCurve pan("Pan", AutomationTarget::Pan);
+        pan.setDefaultValue(0.0f);
+        pan.addPoint(0.0, -1.0f, kSpbAt120, 0.5f);
+        pan.addPoint(2.0, -1.0f, kSpbAt120, 0.5f);
+        pan.addPoint(2.5, 1.0f, kSpbAt120, 0.5f);
+        const auto r = renderWithAutomation({pan}, 120.0, 5.0);
+        require(!r.hasInvalid, "pan: output contains NaN/Inf");
+        const double leftEarly = rmsWindow(r.left, 0.5, 1.5, 120.0);
+        const double rightEarly = rmsWindow(r.right, 0.5, 1.5, 120.0);
+        const double leftLate = rmsWindow(r.left, 3.5, 4.5, 120.0);
+        const double rightLate = rmsWindow(r.right, 3.5, 4.5, 120.0);
+        std::cout << "pan automation: earlyL=" << leftEarly << " earlyR=" << rightEarly << " lateL=" << leftLate
+                  << " lateR=" << rightLate << "\n";
+        require(leftEarly > 1.0e-3, "pan: hard-left region has no left signal");
+        require(rightEarly < 0.05 * leftEarly, "pan: hard-left region leaks right signal");
+        require(rightLate > 1.0e-3, "pan: hard-right region has no right signal");
+        require(leftLate < 0.05 * rightLate, "pan: hard-right region leaks left signal");
+    }
+
+    std::cout << "[PASS] AutomationPlaybackTest\n";
+    return 0;
+}

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -139,6 +139,26 @@ if(TARGET AestraAudioCore)
     )
 endif()
 
+# Automation Playback Test — end-to-end regression: lane automation curves
+# must reach the engine (snapshot copy), evaluate in the beat domain across
+# tempo changes, and follow UI point drags. Core-linked, every CI lane.
+# No EXISTS guard: a missing committed test source must fail configure.
+if(TARGET AestraAudioCore)
+    add_executable(AutomationPlaybackTest
+        AutomationPlaybackTest.cpp
+    )
+    target_link_libraries(AutomationPlaybackTest PRIVATE AestraAudioCore)
+    target_include_directories(AutomationPlaybackTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME AutomationPlaybackTest COMMAND AutomationPlaybackTest)
+    set_tests_properties(AutomationPlaybackTest PROPERTIES
+        LABELS "headless;automation;audio;engine;regression"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 # PDC v2 P1 — scaffolding tests (see AestraDocs/PDC-v2-Design.md §12)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCFlatChainTest.cpp")
     add_executable(PDCFlatChainTest PDCFlatChainTest.cpp)


### PR DESCRIPTION
## Summary

First slice of the automation-advancement mission. A code-first audit of the automation pipeline (curve primitive → playlist lane → runtime snapshot → graph → engine → UI → serializer) found that **track automation has never been audible**: `PlaylistModel::buildRuntimeSnapshot` never copied `lane.automationCurves` into the snapshot, so `AudioGraphBuilder` always received an empty vector and the engine's Volume/Pan automation rendering was dead code in practice. Curves drew in the UI and persisted in project files — they just never played. **Measured repro: a volume curve fading 1.0→0.0 over 4 beats rendered flat RMS `0.125 / 0.125 / 0.125` across the fade. After: `0.125 / 0.0633 / 0.0`.**

Two latent bugs in the previously-unreachable evaluation path are fixed with it — both rooted in a dual sample/beat position domain:

- **Tempo shift:** points cached an absolute sample computed at add-time tempo; evaluation compared against a target from the *current* tempo, so any BPM change after drawing shifted every point in musical time. Evaluation, insertion, and sorting are now purely **beat-domain** — beat is what the serializer persists (`"b"`) and what the UI edits.
- **Drag disconnect:** the UI point-drag updates `beat`/`value` only, so sample-domain evaluation ignored drags entirely (what you saw was not what you heard), and `sortPoints()` (sample-keyed) could scramble scan order after edits.

Minor: the graph builder now takes the snapshot lane by non-const ref so the curve move is a real move; the engine call site drops the unused `samplesPerBeat` argument (legacy two-arg `getValueAtBeat` overload retained, ignoring the parameter).

## Audio behavior report (DSP rules)

- Output changed: yes — automation curves now audibly apply (previously silent no-ops); tempo changes and point drags now track musically. Fader/pan behavior on lanes *without* curves: unchanged (verified by pan-only case keeping the volume path fader-driven).
- Existing override semantics deliberately untouched: a Volume curve still *replaces* fader×trim (flagged separately as a design decision — see follow-up).
- Latency: no. State format: **no** — beat was already the only persisted point position; `sample` was never serialized. Roundtrip/fixture/value-fidelity suites all pass.

## Testing performed

- **New `AutomationPlaybackTest`** (headless, core-linked, labels `headless;automation;audio;engine;regression`, no `EXISTS` guard) drives the real `processBlock` path with a deterministic sine generator: (1) end-to-end audibility + fade-to-silence — **fails on pre-fix code with flat RMS**, verified by stashing the production diff; (2) curve added at 120 BPM stays beat-aligned rendered at 240 BPM; (3) playback follows a UI-style point drag (in-place beat edit + re-sort); (4) pan automation hard-pans with ~zero opposite-channel leakage (`0.0` / `7.7e-9`).
- `AutomationStressTest`: the old `0.594` expectation at beat 1.5 was computed *from* the mixed-domain bug (points added at spb 480, evaluated at 441); the beat-domain musical midpoint `0.625` is now pinned at three tempi.
- Headless suite 15/15; full suite **147/148** — `NUITextInputLayoutTest` is the known pre-existing #458 failure.

## Follow-ups (rest of the automation audit)

1. Volume-automation **override vs compose** with fader×trim — owner design decision, currently override, documented in the test.
2. `Custom` automation target is dead — no plugin-parameter automation (the next big integration slice).
3. UI edits only `automationCurves[0]` (hardcoded Volume) — no target selector or pan lane editing.
4. No automation recording (write/touch).

## Risk / rollback

Single-commit revert. The riskiest surface (serialization) is untouched by construction. The behavior change is strictly "automation now works": projects without curves are bit-identical; projects with curves previously played as if the curves didn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Potential compatibility change:** The legacy `getValueAtBeat(beat, samplesPerBeat)` overload now ignores `samplesPerBeat`; automation evaluation, insertion, and sorting use beat positions exclusively.
- Connected playlist lane automation curves to runtime playback, restoring audible volume and pan automation.
- Moved automation curves into runtime track state to avoid unnecessary copying.
- Added regression coverage for volume, pan, tempo changes, and dragged automation points.
- Updated stress-test expectations for tempo- and sample-rate-independent interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->