### PR TITLE
feat(automation): plugin-parameter automation for internal plugins

### DIFF
--- a/AestraAudio/include/Core/AutomationCurve.h
+++ b/AestraAudio/include/Core/AutomationCurve.h
@@ -55,6 +55,15 @@ struct AutomationCurve {
     AutomationTarget target{AutomationTarget::Custom};
     float defaultValue{0.0f};
 
+    // Plugin-parameter addressing — meaningful only when target == Custom.
+    // effectSlot indexes the lane's channel effect chain; paramId is the
+    // plugin's stable parameter id (stability guaranteed per AGENTS.md §19).
+    // The engine applies Custom curves to Internal-format plugins only:
+    // their parameter storage is atomic, so per-block setParameter from the
+    // render thread is RT-safe; third-party formats need host param queues.
+    uint32_t effectSlot{0};
+    uint32_t paramId{0};
+
     AutomationCurve() = default;
     AutomationCurve(const std::string& n, AutomationTarget t) : name(n), target(t) {}
 

--- a/AestraAudio/include/Plugin/AestraDrift.h
+++ b/AestraAudio/include/Plugin/AestraDrift.h
@@ -85,6 +85,11 @@ public:
         // so automation or fast knob moves glide instead of zippering. Coeff is
         // computed once per block; ~8 ms time constant.
         const float smoothCoeff = 1.0f - std::exp(-1.0f / (static_cast<float>(m_sampleRate) * 0.008f));
+        // Once the smoother is within this of its target, snap exactly onto it.
+        // A one-pole only asymptotes, so without this the residual decays into
+        // denormal floats — a CPU penalty on the audio thread. 1e-6 is far below
+        // the audible resolution of these normalized (0..1) params.
+        constexpr float kSmoothSnapEps = 1.0e-6f;
         const float pitchTarget = m_params[kPitch].load(std::memory_order_relaxed);
         const float mixTarget = m_params[kMix].load(std::memory_order_relaxed);
         float pitchSmoothed = m_pitchSmoothed;
@@ -122,6 +127,7 @@ public:
             outR *= norm;
 
             pitchSmoothed += smoothCoeff * (pitchTarget - pitchSmoothed);
+            if (std::fabs(pitchTarget - pitchSmoothed) < kSmoothSnapEps) pitchSmoothed = pitchTarget;
             const float pitchNorm = pitchSmoothed;
             const float pitchSemitones = -12.0f + pitchNorm * 24.0f;
             const float pitchRatio = std::pow(2.0f, pitchSemitones / 12.0f);
@@ -137,6 +143,7 @@ public:
             writePos = (writePos + 1) & kBufferMask;
 
             mixSmoothed += smoothCoeff * (mixTarget - mixSmoothed);
+            if (std::fabs(mixTarget - mixSmoothed) < kSmoothSnapEps) mixSmoothed = mixTarget;
             const float mix = mixSmoothed;
             const float wet = mix;
             const float dry = 1.0f - wet;

--- a/AestraAudio/include/Plugin/AestraDrift.h
+++ b/AestraAudio/include/Plugin/AestraDrift.h
@@ -81,6 +81,15 @@ public:
 
         const float twoPi = 2.0f * kPi;
 
+        // Per-sample one-pole smoothing for the automatable params (Pitch, Mix),
+        // so automation or fast knob moves glide instead of zippering. Coeff is
+        // computed once per block; ~8 ms time constant.
+        const float smoothCoeff = 1.0f - std::exp(-1.0f / (static_cast<float>(m_sampleRate) * 0.008f));
+        const float pitchTarget = m_params[kPitch].load(std::memory_order_relaxed);
+        const float mixTarget = m_params[kMix].load(std::memory_order_relaxed);
+        float pitchSmoothed = m_pitchSmoothed;
+        float mixSmoothed = m_mixSmoothed;
+
         for (uint32_t i = 0; i < numFrames; ++i) {
             const float inL = (numInputChannels > 0 && inputs[0]) ? inputs[0][i] : 0.0f;
             const float inR = stereo ? ((numInputChannels > 1 && inputs[1]) ? inputs[1][i] : inL) : inL;
@@ -112,7 +121,8 @@ public:
             outL *= norm;
             outR *= norm;
 
-            const float pitchNorm = m_params[kPitch].load(std::memory_order_relaxed);
+            pitchSmoothed += smoothCoeff * (pitchTarget - pitchSmoothed);
+            const float pitchNorm = pitchSmoothed;
             const float pitchSemitones = -12.0f + pitchNorm * 24.0f;
             const float pitchRatio = std::pow(2.0f, pitchSemitones / 12.0f);
             const float delta = 1.0f - pitchRatio;
@@ -126,7 +136,8 @@ public:
 
             writePos = (writePos + 1) & kBufferMask;
 
-            const float mix = m_params[kMix].load(std::memory_order_relaxed);
+            mixSmoothed += smoothCoeff * (mixTarget - mixSmoothed);
+            const float mix = mixSmoothed;
             const float wet = mix;
             const float dry = 1.0f - wet;
 
@@ -142,6 +153,8 @@ public:
         m_writePos = writePos;
         m_tapPhase[0] = tapPhase[0];
         m_tapPhase[1] = tapPhase[1];
+        m_pitchSmoothed = pitchSmoothed;
+        m_mixSmoothed = mixSmoothed;
     }
 
     uint32_t getParameterCount() const override { return kParamCount; }
@@ -153,6 +166,7 @@ public:
 
     void setParameter(uint32_t id, float value) override {
         if (id >= kParamCount) return;
+        if (!std::isfinite(value)) return; // NaN survives clamp and would poison the Pitch/Mix smoothers
         m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
     }
 
@@ -257,6 +271,9 @@ private:
         m_baseDelay = kBaseDelay;
         m_tapPhase[0] = 0.0f;
         m_tapPhase[1] = kGrainSizeF * 0.5f;
+        // Snap smoothers to the current targets so load/activate doesn't glide.
+        m_pitchSmoothed = m_params[kPitch].load(std::memory_order_relaxed);
+        m_mixSmoothed = m_params[kMix].load(std::memory_order_relaxed);
     }
 
     PluginInfo m_info;
@@ -269,6 +286,13 @@ private:
     int m_writePos = 0;
     float m_baseDelay = kBaseDelay;
     float m_tapPhase[2] = {0.0f, kGrainSizeF * 0.5f};
+
+    // Smoothed automatable params. Drift reads Pitch/Mix per-sample; without
+    // smoothing, automating Mix (a dry/wet gain crossfade) or Pitch zippers.
+    // setParameter only stores the atomic target; process() ramps toward it,
+    // matching the smoothing contract the other internal plugins follow.
+    float m_pitchSmoothed = 0.5f;
+    float m_mixSmoothed = 1.0f;
 };
 
 } // namespace Plugins

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2050,6 +2050,22 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                     volTarget = curve.getValueAtBeat(currentBeat);
                 } else if (curve.getAutomationTarget() == AutomationTarget::Pan) {
                     panTarget = clampD(curve.getValueAtBeat(currentBeat), -1.0, 1.0);
+                } else if (curve.getAutomationTarget() == AutomationTarget::Custom) {
+                    // Plugin-parameter automation. Internal-format plugins only:
+                    // their parameter storage is atomic, so a per-block
+                    // setParameter from this thread is lock-free and RT-safe.
+                    // Third-party formats are skipped until host param queues
+                    // exist (#467). Applied before the effect chain processes
+                    // this block, so the value is in effect for these frames.
+                    if (track.effectChainSnapshot && curve.effectSlot < EffectChainSnapshot::MAX_SLOTS) {
+                        const auto& slot = track.effectChainSnapshot->slot(curve.effectSlot);
+                        if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {
+                            const float value = curve.getValueAtBeat(currentBeat);
+                            if (std::isfinite(value)) {
+                                slot.plugin->setParameter(curve.paramId, value);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2057,6 +2057,15 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                     // Third-party formats are skipped until host param queues
                     // exist (#467). Applied before the effect chain processes
                     // this block, so the value is in effect for these frames.
+                    //
+                    // Smoothing policy: the *plugin* owns parameter smoothing.
+                    // setParameter only stores a target; each internal plugin's
+                    // process() ramps toward it — the same contract used for UI
+                    // knob moves. We deliberately hand the raw target over once
+                    // per block instead of ramping engine-side, so automation
+                    // and manual edits share one smoother and never cascade into
+                    // double-smoothing. Every internal effect honors this (Drift
+                    // was the last to gain per-sample Mix/Pitch smoothing).
                     if (track.effectChainSnapshot && curve.effectSlot < EffectChainSnapshot::MAX_SLOTS) {
                         const auto& slot = track.effectChainSnapshot->slot(curve.effectSlot);
                         if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -820,7 +820,13 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 cj.set("param", JSON(curve.getTarget()));
                 cj.set("targetEnum", JSON(static_cast<double>(curve.getAutomationTarget())));
                 cj.set("default", JSON(curve.getDefaultValue()));
-                
+                if (curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Custom) {
+                    // Plugin-parameter address (older builds ignore unknown keys;
+                    // loads without them default to slot 0 / param 0).
+                    cj.set("slot", JSON(static_cast<double>(curve.effectSlot)));
+                    cj.set("paramId", JSON(static_cast<double>(curve.paramId)));
+                }
+
                 JSON ptsJson = JSON::array();
                 for (const auto& p : curve.getPoints()) {
                     JSON pj = JSON::object();
@@ -1684,7 +1690,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             
                             AutomationCurve curve(param, target);
                             curve.setDefaultValue(finiteNumberOr(aj[a], "default", 0.0, -1.0e6, 1.0e6));
-                            
+                            // Plugin-parameter address (Custom target). Bounded:
+                            // slot to the effect-chain size, paramId defensively.
+                            curve.effectSlot = static_cast<uint32_t>(finiteNumberOr(aj[a], "slot", 0.0, 0.0, 9.0));
+                            curve.paramId = static_cast<uint32_t>(finiteNumberOr(aj[a], "paramId", 0.0, 0.0, 1.0e6));
+
                             if (!aj[a].has("points") || !aj[a]["points"].isArray()) continue;
                             const JSON& pts = aj[a]["points"];
                             for (size_t p = 0; p < pts.size(); ++p) {

--- a/Tests/Headless/AutomationPlaybackTest.cpp
+++ b/Tests/Headless/AutomationPlaybackTest.cpp
@@ -24,6 +24,7 @@
 #include "Plugin/PluginHost.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -112,6 +113,74 @@ private:
     bool m_active{false};
 };
 
+// Gain effect whose single parameter (id 0) scales the signal. Parameter
+// storage is atomic, mirroring the internal-plugin contract that makes
+// per-block automation writes RT-safe. The reported format is configurable so
+// the test can prove non-Internal formats are NOT driven by Custom curves.
+class GainParamPlugin : public IPluginInstance {
+public:
+    explicit GainParamPlugin(PluginFormat format) {
+        m_info.id = "aestra.test.automation_gain";
+        m_info.name = "AutomationGain";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = format;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override { m_active = true; }
+    void deactivate() override { m_active = false; }
+    bool isActive() const override { return m_active; }
+
+    void process(const float* const* /*inputs*/, float** outputs, uint32_t /*numInputChannels*/,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* = nullptr,
+                 MidiBuffer* = nullptr) override {
+        if (!outputs || numOutputChannels < 2 || !outputs[0] || !outputs[1]) {
+            return;
+        }
+        const float g = m_gain.load(std::memory_order_relaxed);
+        for (uint32_t k = 0; k < numFrames; ++k) {
+            outputs[0][k] *= g;
+            outputs[1][k] *= g;
+        }
+    }
+
+    std::vector<PluginParameter> getParameters() const override { return {{0, "Gain", "Gn", "", 1.0f, 0.0f, 1.0f}}; }
+    uint32_t getParameterCount() const override { return 1; }
+    float getParameter(uint32_t id) const override { return id == 0 ? m_gain.load(std::memory_order_relaxed) : 0.0f; }
+    void setParameter(uint32_t id, float value) override {
+        if (id == 0) {
+            m_gain.store(value, std::memory_order_relaxed);
+        }
+    }
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+private:
+    PluginInfo m_info{};
+    std::atomic<float> m_gain{1.0f};
+    bool m_active{false};
+};
+
 struct Rendered {
     std::vector<float> left;
     std::vector<float> right;
@@ -120,13 +189,18 @@ struct Rendered {
 
 // Builds a one-track project whose lane carries `curves`, sets the playlist
 // BPM to `renderBpm`, and renders `beats` beats of transport playback.
-Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double renderBpm, double beats) {
+// An optional extra effect is inserted at chain slot 1 (after the generator).
+Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double renderBpm, double beats,
+                              std::shared_ptr<IPluginInstance> slot1Fx = nullptr) {
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
 
     MixerChannel* src = trackManager->addChannel("src");
     require(src != nullptr, "addChannel failed");
     require(src->getEffectChain().insertPlugin(0, std::make_shared<SineGeneratorPlugin>()), "generator insert failed");
+    if (slot1Fx) {
+        require(src->getEffectChain().insertPlugin(1, std::move(slot1Fx)), "slot-1 effect insert failed");
+    }
 
     auto& playlist = trackManager->getPlaylistModel();
     playlist.setProjectSampleRate(static_cast<double>(kSampleRate));
@@ -266,6 +340,47 @@ int main() {
         require(rightEarly < 0.05 * leftEarly, "pan: hard-left region leaks right signal");
         require(rightLate > 1.0e-3, "pan: hard-right region has no right signal");
         require(leftLate < 0.05 * rightLate, "pan: hard-right region leaks left signal");
+    }
+
+    // ---------------- 5. Plugin-parameter automation (Custom target): a curve
+    // addressed at {effect slot 1, param 0} drives an Internal-format gain
+    // plugin — output fades even though volume/pan automation is absent.
+    {
+        AutomationCurve param("Gain", AutomationTarget::Custom);
+        param.setDefaultValue(1.0f);
+        param.effectSlot = 1;
+        param.paramId = 0;
+        param.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
+        param.addPoint(2.0, 1.0f, kSpbAt120, 0.5f);
+        param.addPoint(4.0, 0.0f, kSpbAt120, 0.5f);
+        const auto r =
+            renderWithAutomation({param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::Internal));
+        require(!r.hasInvalid, "param: output contains NaN/Inf");
+        const double loud = rmsWindow(r.left, 0.5, 1.5, 120.0);
+        const double mid = rmsWindow(r.left, 2.9, 3.1, 120.0);
+        const double silent = rmsWindow(r.left, 4.5, 5.5, 120.0);
+        std::cout << "param automation: loud=" << loud << " mid=" << mid << " tail=" << silent << "\n";
+        require(loud > 1.0e-3, "param automation region is silent");
+        require(mid > 0.35 * loud && mid < 0.65 * loud, "param automation midpoint is not ~half gain");
+        require(silent < 0.02 * loud, "param automation did not drive the plugin parameter");
+    }
+
+    // ---------------- 6. Third-party guard: the identical curve must NOT drive
+    // a non-Internal plugin (no host param queue yet — silently skipping is the
+    // contract until #467's third-party slice).
+    {
+        AutomationCurve param("Gain", AutomationTarget::Custom);
+        param.setDefaultValue(1.0f);
+        param.effectSlot = 1;
+        param.paramId = 0;
+        param.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
+        param.addPoint(4.0, 0.0f, kSpbAt120, 0.5f);
+        const auto r = renderWithAutomation({param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::VST3));
+        require(!r.hasInvalid, "guard: output contains NaN/Inf");
+        const double early = rmsWindow(r.left, 0.5, 1.5, 120.0);
+        const double late = rmsWindow(r.left, 4.5, 5.5, 120.0);
+        require(early > 1.0e-3, "guard: output is silent");
+        require(late > 0.8 * early, "guard: Custom curve drove a non-Internal plugin (RT-unsafe path)");
     }
 
     std::cout << "[PASS] AutomationPlaybackTest\n";

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -249,8 +249,8 @@ void assertAllValues(Aestra::Audio::TrackManager& tm,
     }
 
     // Automation curve values — the addPoint identity bug zeroed these.
-    require(laneA->automationCurves.size() == 1, tag("automation curve count"));
-    if (laneA->automationCurves.size() == 1) {
+    require(laneA->automationCurves.size() == 2, tag("automation curve count"));
+    if (laneA->automationCurves.size() == 2) {
         const auto& curve = laneA->automationCurves[0];
         require(curve.getAutomationTarget() == AutomationTarget::Volume, tag("automation target"));
         requireExactF(curve.getDefaultValue(), 0.42f, tag("automation default"));
@@ -262,6 +262,18 @@ void assertAllValues(Aestra::Audio::TrackManager& tm,
             requireExactD(curve.points[1].beat, kAutoBeatFar, tag("automation point 2 beat"));
             requireExactF(curve.points[1].value, 0.9f, tag("automation point 2 value"));
             requireExactF(curve.points[1].curve, 0.5f, tag("automation point 2 tension"));
+        }
+
+        // Plugin-parameter curve: Custom slot/paramId addressing (#467).
+        const auto& param = laneA->automationCurves[1];
+        require(param.getAutomationTarget() == AutomationTarget::Custom, tag("param curve target"));
+        requireExactF(param.getDefaultValue(), 0.7f, tag("param curve default"));
+        require(param.effectSlot == 3, tag("param curve effectSlot"));
+        require(param.paramId == 17, tag("param curve paramId"));
+        require(param.points.size() == 1, tag("param curve point count"));
+        if (param.points.size() == 1) {
+            requireExactD(param.points[0].beat, 1.0, tag("param curve point beat"));
+            requireExactF(param.points[0].value, 0.33f, tag("param curve point value"));
         }
     }
 }
@@ -374,6 +386,14 @@ int main() {
         vol.addPoint(0.5, 0.1f, samplesPerBeat, 0.25f);
         vol.addPoint(kAutoBeatFar, 0.9f, samplesPerBeat, 0.5f);
         lane->automationCurves.push_back(vol);
+
+        // Plugin-parameter curve: slot/paramId addressing must roundtrip.
+        AutomationCurve param("cutoff", AutomationTarget::Custom);
+        param.setDefaultValue(0.7f);
+        param.effectSlot = 3;
+        param.paramId = 17;
+        param.addPoint(1.0, 0.33f, samplesPerBeat, 0.5f);
+        lane->automationCurves.push_back(param);
     }
 
     // Routing: A -> B send with awkward float gain.


### PR DESCRIPTION
Second slice of the automation mission (first: #465). Addresses the internal-plugin half of #467 — leave the issue open for the third-party (host param queue) half.

## Summary

`AutomationTarget::Custom` was dead end-to-end: schema, serializer, and validation knew it, nothing evaluated it — no plugin parameter in Aestra could be automated. Now:

- **Addressing:** `AutomationCurve` gains `effectSlot` + `paramId`, meaningful only for `Custom` (stable parameter IDs are already a repo guarantee, AGENTS.md §19).
- **Engine:** Custom curves evaluate beat-domain per block and `setParameter` the addressed plugin *before* the effect chain processes that block. **Internal-format plugins only** — their parameter storage is atomic (`std::atomic<float>` arrays), so the per-block write from the render thread is lock-free and RT-safe. Non-Internal formats are skipped (contract pinned by test) until a host param-queue slice; non-finite values are dropped.
- **Serialization (flagged per §12 — high-risk area):** additive only. `"slot"`/`"paramId"` keys are written for Custom curves; loads without them default to `0/0`, so **existing projects are byte-compatible**, and older builds simply ignore the new keys (Custom curves were inert there anyway). Bounded ingress validation (slot ≤ chain size, paramId capped).

## Audio behavior report (DSP rules)

- Output changed: only for projects containing Custom curves — which previously did nothing. Volume/Pan automation, fader behavior, and everything else: unchanged (full regression suite green).
- Latency: no. Plugin/parameter IDs: unchanged. RT-safety: the new path is atomic stores + a finite check; no allocation, locks, logging, or unbounded work (bounded by curves-per-lane × O(points) linear scan, same cost class as the existing Volume/Pan evaluation).

## Testing performed

- **`AutomationPlaybackTest` +2 cases** on the real `processBlock` path: (5) Custom curve at `{slot 1, param 0}` fades an Internal-format gain plugin exactly like a volume fade — **fails pre-change with flat RMS `0.125/0.125/0.125`** (stash-verified), passes with `0.125/0.0629/0.0`; (6) the identical curve must **not** drive a VST3-format plugin — output stays constant, pinning the RT-safety guard.
- **`ProjectValueFidelityTest`** extended: a Custom curve with `slot=3, paramId=17` roundtrips exactly.
- Roundtrip, fixture-corpus, and stress suites pass; headless 15/15; full suite 147/148 (`NUITextInputLayoutTest` = pre-existing #458, clean-tree-verified twice today).

## What this does NOT include (tracked)

- Third-party (VST3/CLAP/out-of-process) parameter automation — needs host param queues (#467 remains open).
- UI for creating/addressing Custom curves (#468) and automation recording (#469).
- Override-vs-compose policy for Volume curves (#466, owner decision).

## Risk / rollback

Single-commit revert. Serialization change is additive-with-defaults in both directions; the engine change is gated behind `target == Custom` which no existing UI can produce yet, so exposure is limited to hand-authored/test projects until #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added plugin-parameter addressing to custom automation curves (effect slot + parameter ID) so engine automation can target specific plugin params.
- Implemented per-block evaluation of `AutomationTarget::Custom` and applied the resulting values to **Internal-format** plugins only, using RT-safe atomic parameter writes; non-finite automation values are skipped, and non-Internal formats (e.g., VST3) are ignored.
- Extended project serialization to persist/restore `slot` and `paramId` for Custom curves with backward-compatible defaults and bounded validation.
- Updated automation smoothing policy: smoothing is owned by each plugin, with engine updates storing raw per-block targets; audited internal effects, including updating `AestraDrift` to per-sample smooth Pitch/Mix, snap on reset/activation, and reject non-finite targets.
- Added/updated tests for internal plugin automation, explicit VST3 exclusion behavior, and project value fidelity/roundtripping for Custom targets.
- No breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->