### PR TITLE
feat(plugins): AestraSat — oversampled tape/tube/hard saturator

### DIFF
--- a/AestraAudio/include/Plugin/AestraSat.h
+++ b/AestraAudio/include/Plugin/AestraSat.h
@@ -77,8 +77,25 @@ public:
         (void)midiOutput;
 
         if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
-            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            // The plugin always reports the oversampler latency, so internal
+            // bypass must delay by the same amount (through the same ring,
+            // which keeps advancing) or this slot lands ~30 samples early
+            // relative to PDC-compensated tracks.
+            copyDelayed(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            m_wasBypassed = true;
             return;
+        }
+        if (m_wasBypassed) {
+            // Flush stale wet-path state from before the bypass so reactivation
+            // does not emit it; the dry ring stays hot for latency alignment.
+            for (auto& os : m_oversampler) {
+                os.reset();
+            }
+            m_dcX1[0] = m_dcX1[1] = 0.0f;
+            m_dcY1[0] = m_dcY1[1] = 0.0f;
+            m_toneState[0] = m_toneState[1] = 0.0f;
+            snapSmoothedParams();
+            m_wasBypassed = false;
         }
 
         const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
@@ -91,8 +108,12 @@ public:
         float blockInputPeak = 0.0f;
         float blockOutputPeak = 0.0f;
 
-        for (uint32_t i = 0; i < numFrames; ++i) {
-            // Smooth continuous params (2 ms one-pole, shared by both channels)
+        // Parameters are read and smoothed once per control block; the
+        // per-sample loop only does the oversampled shaper, DC blocker, tone
+        // one-pole and mix — no atomics or transcendentals in the hot path.
+        for (uint32_t blockStart = 0; blockStart < numFrames; blockStart += kCtrlBlock) {
+            const uint32_t blockEnd = std::min(blockStart + kCtrlBlock, numFrames);
+
             m_driveSmoothed += (getParameter(kDrive) - m_driveSmoothed) * m_smoothCoeff;
             m_toneSmoothed += (getParameter(kTone) - m_toneSmoothed) * m_smoothCoeff;
             m_outputSmoothed += (getParameter(kOutput) - m_outputSmoothed) * m_smoothCoeff;
@@ -104,45 +125,47 @@ public:
             const float dry = 1.0f - wet;
             const float toneCoeff = toneCoeffFromNorm(m_toneSmoothed);
 
-            for (uint32_t ch = 0; ch < channels; ++ch) {
-                const float in = sanitizeSample(readInput(inputs, numInputChannels, ch, i));
-                blockInputPeak = std::max(blockInputPeak, std::abs(in));
+            for (uint32_t i = blockStart; i < blockEnd; ++i) {
+                for (uint32_t ch = 0; ch < channels; ++ch) {
+                    const float in = sanitizeSample(readInput(inputs, numInputChannels, ch, i));
+                    blockInputPeak = std::max(blockInputPeak, std::abs(in));
 
-                // Latency-aligned dry tap
-                const float delayedDry = m_dryDelay[ch][m_dryPos];
-                m_dryDelay[ch][m_dryPos] = in;
+                    // Latency-aligned dry tap
+                    const float delayedDry = m_dryDelay[ch][m_dryPos];
+                    m_dryDelay[ch][m_dryPos] = in;
 
-                // Nonlinear stage at 4x
-                float osBuf[kOsFactor];
-                m_oversampler[ch].upsample(in * driveGain, osBuf);
-                for (uint32_t p = 0; p < kOsFactor; ++p) {
-                    osBuf[p] = shape(osBuf[p], mode);
+                    // Nonlinear stage at 4x
+                    float osBuf[kOsFactor];
+                    m_oversampler[ch].upsample(in * driveGain, osBuf);
+                    for (uint32_t p = 0; p < kOsFactor; ++p) {
+                        osBuf[p] = shape(osBuf[p], mode);
+                    }
+                    float sat = m_oversampler[ch].downsample(osBuf);
+
+                    // DC blocker (~10 Hz high-pass) — tube asymmetry adds DC
+                    const float dcOut = sat - m_dcX1[ch] + m_dcCoeff * m_dcY1[ch];
+                    m_dcX1[ch] = sat;
+                    m_dcY1[ch] = dcOut;
+
+                    // Tone: one-pole low-pass on the wet path
+                    m_toneState[ch] += (dcOut - m_toneState[ch]) * toneCoeff;
+
+                    const float out = delayedDry * dry + m_toneState[ch] * outGain * wet;
+                    blockOutputPeak = std::max(blockOutputPeak, std::abs(out));
+
+                    if (outputs[ch])
+                        outputs[ch][i] = out;
                 }
-                float sat = m_oversampler[ch].downsample(osBuf);
 
-                // DC blocker (~10 Hz high-pass) — tube asymmetry adds DC
-                const float dcOut = sat - m_dcX1[ch] + m_dcCoeff * m_dcY1[ch];
-                m_dcX1[ch] = sat;
-                m_dcY1[ch] = dcOut;
+                m_dryPos = (m_dryPos + 1u) % kDryDelayLen;
 
-                // Tone: one-pole low-pass on the wet path
-                m_toneState[ch] += (dcOut - m_toneState[ch]) * toneCoeff;
-
-                const float out = delayedDry * dry + m_toneState[ch] * outGain * wet;
-                blockOutputPeak = std::max(blockOutputPeak, std::abs(out));
-
-                if (outputs[ch])
-                    outputs[ch][i] = out;
-            }
-
-            m_dryPos = (m_dryPos + 1u) % kDryDelayLen;
-
-            if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
-                outputs[1][i] = outputs[0][i];
-            }
-            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
-                if (outputs[ch])
-                    outputs[ch][i] = 0.0f;
+                if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
+                    outputs[1][i] = outputs[0][i];
+                }
+                for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                    if (outputs[ch])
+                        outputs[ch][i] = 0.0f;
+                }
             }
         }
 
@@ -161,6 +184,8 @@ public:
     void setParameter(uint32_t id, float value) override {
         if (id >= kParamCount)
             return;
+        if (!std::isfinite(value))
+            return; // NaN survives clamp (comparisons are false) and would poison smoothing
         m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
     }
 
@@ -296,6 +321,31 @@ private:
     // Read-before-write circular buffer of length N delays by exactly N —
     // sized to match the oversampler round-trip latency.
     static constexpr uint32_t kDryDelayLen = DSP::Oversampler::kReportedLatency;
+    static constexpr uint32_t kCtrlBlock = 16; // control-rate interval for param/coefficient updates
+
+    /// Bypass copy delayed by the reported latency, through the same dry ring
+    /// the active path uses (so the ring stays hot across bypass toggles).
+    /// Channels >= 2 pass through like copyOrClear.
+    void copyDelayed(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                     uint32_t numFrames) {
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            for (uint32_t ch = 0; ch < 2; ++ch) {
+                const float in = sanitizeSample(readInput(inputs, numInputChannels, ch, i));
+                const float delayed = m_dryDelay[ch][m_dryPos];
+                m_dryDelay[ch][m_dryPos] = in;
+                if (ch < numOutputChannels && outputs[ch])
+                    outputs[ch][i] = delayed;
+            }
+            m_dryPos = (m_dryPos + 1u) % kDryDelayLen;
+        }
+        for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
 
     static float shape(float x, Mode mode) {
         switch (mode) {
@@ -328,8 +378,11 @@ private:
         m_dcX1[0] = m_dcX1[1] = 0.0f;
         m_dcY1[0] = m_dcY1[1] = 0.0f;
         m_toneState[0] = m_toneState[1] = 0.0f;
+        m_wasBypassed = false;
         const float sr = static_cast<float>(m_sampleRate);
-        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        // Smoothing runs once per control block, so the coefficient is scaled
+        // to the block interval to keep the 2 ms time constant.
+        m_smoothCoeff = 1.0f - std::exp(-static_cast<float>(kCtrlBlock) / (0.002f * sr));
         m_dcCoeff = 1.0f - 2.0f * 3.14159265358979323846f * 10.0f / sr;
         m_inputLevel.store(0.0f, std::memory_order_relaxed);
         m_outputLevel.store(0.0f, std::memory_order_relaxed);
@@ -378,6 +431,7 @@ private:
     std::array<DSP::Oversampler, 2> m_oversampler;
     std::array<std::array<float, kDryDelayLen>, 2> m_dryDelay{};
     uint32_t m_dryPos = 0;
+    bool m_wasBypassed = false;
 
     float m_dcX1[2] = {0.0f, 0.0f};
     float m_dcY1[2] = {0.0f, 0.0f};

--- a/AestraAudio/include/Plugin/AestraSat.h
+++ b/AestraAudio/include/Plugin/AestraSat.h
@@ -1,0 +1,399 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraSat V1 — oversampled waveshaping saturator (tape / tube / hard clip).
+//
+// Signal path (per channel, per sample):
+//   in -> drive gain -> 4x oversample -> waveshaper -> downsample
+//      -> DC blocker -> tone low-pass -> output trim -> mix with latency-aligned dry
+//
+// The nonlinear stage always runs at 4x via DSP::Oversampler (47/29-tap halfband
+// cascade), so latency is the oversampler's reported constant. The dry path is
+// delayed by the same amount so the Mix control never comb-filters.
+
+#pragma once
+
+#include "DSP/Oversampler.h"
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace Plugins {
+
+class AestraSat : public IPluginInstance {
+public:
+    static constexpr uint32_t kStateMagic = 0x53415431; // 'SAT1'
+    static constexpr uint32_t kOsFactor = 4;
+
+    enum Param : uint32_t {
+        kDrive = 0, // 0 to +36 dB pre-shaper gain
+        kMode,      // 0=Tape, 1=Tube, 2=Hard (stepped)
+        kTone,      // post low-pass, 1 kHz to 20 kHz (log)
+        kOutput,    // -12 to +12 dB trim
+        kMix,       // 0% to 100%
+        kBypass,
+        kParamCount,
+    };
+
+    enum Mode : uint32_t { kModeTape = 0, kModeTube, kModeHard, kModeCount };
+
+    AestraSat() = default;
+
+    bool initialize(double sampleRate, uint32_t maxBlockSize) override {
+        (void)maxBlockSize;
+        m_sampleRate = std::max(1.0, sampleRate);
+        for (const auto& param : getParameters()) {
+            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        }
+        for (auto& os : m_oversampler) {
+            os.prepare(kOsFactor);
+        }
+        resetRuntimeState();
+        snapSmoothedParams();
+        return true;
+    }
+
+    void shutdown() override {}
+
+    void activate() override {
+        m_active.store(true, std::memory_order_relaxed);
+        resetRuntimeState();
+        snapSmoothedParams();
+    }
+
+    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
+    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* midiInput = nullptr, MidiBuffer* midiOutput = nullptr) override {
+        (void)midiInput;
+        (void)midiOutput;
+
+        if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            return;
+        }
+
+        const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
+        const bool stereo = channels >= 2;
+        const auto mode = static_cast<Mode>(std::min<uint32_t>(
+            kModeCount - 1,
+            static_cast<uint32_t>(m_params[kMode].load(std::memory_order_relaxed) * static_cast<float>(kModeCount - 1) +
+                                  0.5f)));
+
+        float blockInputPeak = 0.0f;
+        float blockOutputPeak = 0.0f;
+
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            // Smooth continuous params (2 ms one-pole, shared by both channels)
+            m_driveSmoothed += (getParameter(kDrive) - m_driveSmoothed) * m_smoothCoeff;
+            m_toneSmoothed += (getParameter(kTone) - m_toneSmoothed) * m_smoothCoeff;
+            m_outputSmoothed += (getParameter(kOutput) - m_outputSmoothed) * m_smoothCoeff;
+            m_mixSmoothed += (getParameter(kMix) - m_mixSmoothed) * m_smoothCoeff;
+
+            const float driveGain = dbToLinear(driveDbFromNorm(m_driveSmoothed));
+            const float outGain = dbToLinear(outputDbFromNorm(m_outputSmoothed));
+            const float wet = m_mixSmoothed;
+            const float dry = 1.0f - wet;
+            const float toneCoeff = toneCoeffFromNorm(m_toneSmoothed);
+
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                const float in = sanitizeSample(readInput(inputs, numInputChannels, ch, i));
+                blockInputPeak = std::max(blockInputPeak, std::abs(in));
+
+                // Latency-aligned dry tap
+                const float delayedDry = m_dryDelay[ch][m_dryPos];
+                m_dryDelay[ch][m_dryPos] = in;
+
+                // Nonlinear stage at 4x
+                float osBuf[kOsFactor];
+                m_oversampler[ch].upsample(in * driveGain, osBuf);
+                for (uint32_t p = 0; p < kOsFactor; ++p) {
+                    osBuf[p] = shape(osBuf[p], mode);
+                }
+                float sat = m_oversampler[ch].downsample(osBuf);
+
+                // DC blocker (~10 Hz high-pass) — tube asymmetry adds DC
+                const float dcOut = sat - m_dcX1[ch] + m_dcCoeff * m_dcY1[ch];
+                m_dcX1[ch] = sat;
+                m_dcY1[ch] = dcOut;
+
+                // Tone: one-pole low-pass on the wet path
+                m_toneState[ch] += (dcOut - m_toneState[ch]) * toneCoeff;
+
+                const float out = delayedDry * dry + m_toneState[ch] * outGain * wet;
+                blockOutputPeak = std::max(blockOutputPeak, std::abs(out));
+
+                if (outputs[ch])
+                    outputs[ch][i] = out;
+            }
+
+            m_dryPos = (m_dryPos + 1u) % kDryDelayLen;
+
+            if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
+                outputs[1][i] = outputs[0][i];
+            }
+            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                if (outputs[ch])
+                    outputs[ch][i] = 0.0f;
+            }
+        }
+
+        m_inputLevel.store(blockInputPeak, std::memory_order_relaxed);
+        m_outputLevel.store(blockOutputPeak, std::memory_order_relaxed);
+    }
+
+    uint32_t getParameterCount() const override { return kParamCount; }
+
+    float getParameter(uint32_t id) const override {
+        if (id >= kParamCount)
+            return 0.0f;
+        return m_params[id].load(std::memory_order_relaxed);
+    }
+
+    void setParameter(uint32_t id, float value) override {
+        if (id >= kParamCount)
+            return;
+        m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    std::vector<PluginParameter> getParameters() const override {
+        return {
+            {kDrive, "Drive", "DRV", "dB", 0.25f, 0.0f, 1.0f, true},
+            {kMode, "Mode", "MOD", "", 0.0f, 0.0f, 1.0f, true, false, false, kModeCount - 1},
+            {kTone, "Tone", "TON", "Hz", 1.0f, 0.0f, 1.0f, true},
+            {kOutput, "Output", "OUT", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kMix, "Mix", "MIX", "%", 1.0f, 0.0f, 1.0f, true},
+            {kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1},
+        };
+    }
+
+    std::string getParameterDisplay(uint32_t id) const override {
+        if (id >= kParamCount)
+            return "";
+        const float v = getParameter(id);
+        char buf[32];
+        switch (id) {
+        case kDrive:
+            std::snprintf(buf, sizeof(buf), "%.1f dB", driveDbFromNorm(v));
+            return buf;
+        case kMode:
+            switch (modeFromNorm(v)) {
+            case kModeTape:
+                return "Tape";
+            case kModeTube:
+                return "Tube";
+            default:
+                return "Hard";
+            }
+        case kTone: {
+            const float hz = toneHzFromNorm(v);
+            if (hz >= 10000.0f) {
+                std::snprintf(buf, sizeof(buf), "%.1f kHz", hz / 1000.0f);
+            } else if (hz >= 1000.0f) {
+                std::snprintf(buf, sizeof(buf), "%.2f kHz", hz / 1000.0f);
+            } else {
+                std::snprintf(buf, sizeof(buf), "%.0f Hz", hz);
+            }
+            return buf;
+        }
+        case kOutput:
+            std::snprintf(buf, sizeof(buf), "%+.1f dB", outputDbFromNorm(v));
+            return buf;
+        case kMix:
+            return std::to_string(static_cast<int>(std::round(v * 100.0f))) + "%";
+        case kBypass:
+            return v > 0.5f ? "ON" : "OFF";
+        default:
+            return "";
+        }
+    }
+
+    std::vector<uint8_t> saveState() const override {
+        struct Blob {
+            uint32_t magic = kStateMagic;
+            uint32_t version = 1;
+            float params[kParamCount] = {};
+        } blob;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            blob.params[i] = getParameter(i);
+        }
+        const auto* data = reinterpret_cast<const uint8_t*>(&blob);
+        return {data, data + sizeof(blob)};
+    }
+
+    bool loadState(const std::vector<uint8_t>& state) override {
+        if (state.size() < sizeof(uint32_t) * 2)
+            return false;
+        uint32_t magic = 0;
+        std::memcpy(&magic, state.data(), sizeof(magic));
+        if (magic != kStateMagic)
+            return false;
+        struct Blob {
+            uint32_t magic;
+            uint32_t version;
+            float params[kParamCount];
+        };
+        if (state.size() < sizeof(Blob))
+            return false;
+        Blob blob{};
+        std::memcpy(&blob, state.data(), sizeof(blob));
+        if (blob.version < 1 || blob.version > 1)
+            return false;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            setParameter(i, blob.params[i]);
+        }
+        return true;
+    }
+
+    bool hasEditor() const override { return true; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {480, 300}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return DSP::Oversampler::kReportedLatency; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+    void setInfo(const PluginInfo& info) { m_info = info; }
+
+    // Metering
+    float getInputLevel() const { return m_inputLevel.load(std::memory_order_relaxed); }
+    float getOutputLevel() const { return m_outputLevel.load(std::memory_order_relaxed); }
+
+    // ── Parameter mapping (public: shared with editor/tests) ──
+    static float driveDbFromNorm(float value) { return std::clamp(value, 0.0f, 1.0f) * 36.0f; }
+
+    static float outputDbFromNorm(float value) { return -12.0f + std::clamp(value, 0.0f, 1.0f) * 24.0f; }
+
+    static float toneHzFromNorm(float value) {
+        // 1 kHz .. 20 kHz, log
+        return 1000.0f * std::pow(20.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static Mode modeFromNorm(float value) {
+        return static_cast<Mode>(std::min<uint32_t>(
+            kModeCount - 1,
+            static_cast<uint32_t>(std::clamp(value, 0.0f, 1.0f) * static_cast<float>(kModeCount - 1) + 0.5f)));
+    }
+
+    static float normFromMode(Mode mode) { return static_cast<float>(mode) / static_cast<float>(kModeCount - 1); }
+
+private:
+    // Read-before-write circular buffer of length N delays by exactly N —
+    // sized to match the oversampler round-trip latency.
+    static constexpr uint32_t kDryDelayLen = DSP::Oversampler::kReportedLatency;
+
+    static float shape(float x, Mode mode) {
+        switch (mode) {
+        case kModeTape:
+            return std::tanh(x);
+        case kModeTube:
+            // Asymmetric: the negative lobe saturates earlier (limit -1/1.5)
+            // which generates even harmonics. Both branches have unity slope
+            // at 0, so the curve is C1-continuous.
+            return x >= 0.0f ? std::tanh(x) : std::tanh(1.5f * x) * (1.0f / 1.5f);
+        default:
+            return std::clamp(x, -1.0f, 1.0f);
+        }
+    }
+
+    float toneCoeffFromNorm(float norm) const {
+        const float fc = toneHzFromNorm(norm);
+        const float x = 2.0f * 3.14159265358979323846f * fc / static_cast<float>(m_sampleRate);
+        return 1.0f - std::exp(-x);
+    }
+
+    void resetRuntimeState() {
+        for (auto& os : m_oversampler) {
+            os.reset();
+        }
+        for (auto& d : m_dryDelay) {
+            d.fill(0.0f);
+        }
+        m_dryPos = 0;
+        m_dcX1[0] = m_dcX1[1] = 0.0f;
+        m_dcY1[0] = m_dcY1[1] = 0.0f;
+        m_toneState[0] = m_toneState[1] = 0.0f;
+        const float sr = static_cast<float>(m_sampleRate);
+        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        m_dcCoeff = 1.0f - 2.0f * 3.14159265358979323846f * 10.0f / sr;
+        m_inputLevel.store(0.0f, std::memory_order_relaxed);
+        m_outputLevel.store(0.0f, std::memory_order_relaxed);
+    }
+
+    void snapSmoothedParams() {
+        m_driveSmoothed = getParameter(kDrive);
+        m_toneSmoothed = getParameter(kTone);
+        m_outputSmoothed = getParameter(kOutput);
+        m_mixSmoothed = getParameter(kMix);
+    }
+
+    // ── Utility ──
+    static void copyOrClear(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                            uint32_t numOutputChannels, uint32_t numFrames) {
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
+    static float readInput(const float* const* inputs, uint32_t channels, uint32_t channel, uint32_t frame) {
+        if (channel >= channels || !inputs[channel]) {
+            return (channel == 1 && channels > 0 && inputs[0]) ? inputs[0][frame] : 0.0f;
+        }
+        return inputs[channel][frame];
+    }
+
+    static float sanitizeSample(float sample) {
+        if (!std::isfinite(sample))
+            return 0.0f;
+        return std::clamp(sample, -16.0f, 16.0f);
+    }
+
+    static float dbToLinear(float db) { return std::exp(db * 0.11512925464970229f); }
+
+    // ── State ──
+    PluginInfo m_info;
+    double m_sampleRate = 48000.0;
+    std::atomic<bool> m_active{false};
+    std::array<std::atomic<float>, kParamCount> m_params{};
+
+    std::array<DSP::Oversampler, 2> m_oversampler;
+    std::array<std::array<float, kDryDelayLen>, 2> m_dryDelay{};
+    uint32_t m_dryPos = 0;
+
+    float m_dcX1[2] = {0.0f, 0.0f};
+    float m_dcY1[2] = {0.0f, 0.0f};
+    float m_dcCoeff = 0.9987f;
+    float m_toneState[2] = {0.0f, 0.0f};
+
+    float m_smoothCoeff = 0.0f;
+    float m_driveSmoothed = 0.25f;
+    float m_toneSmoothed = 1.0f;
+    float m_outputSmoothed = 0.5f;
+    float m_mixSmoothed = 1.0f;
+
+    std::atomic<float> m_inputLevel{0.0f};
+    std::atomic<float> m_outputLevel{0.0f};
+};
+
+} // namespace Plugins
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/BuiltInPlugins.h
+++ b/AestraAudio/include/Plugin/BuiltInPlugins.h
@@ -16,6 +16,7 @@ const PluginInfo& verbInfo();
 const PluginInfo& delayInfo();
 const PluginInfo& driftInfo();
 const PluginInfo& limiterInfo();
+const PluginInfo& satInfo();
 void registerCoreBuiltIns();
 std::vector<PluginInfo> all();
 }

--- a/AestraAudio/src/Plugin/BuiltInPlugins.cpp
+++ b/AestraAudio/src/Plugin/BuiltInPlugins.cpp
@@ -10,6 +10,7 @@
 #include "Plugin/AestraDelay.h"
 #include "Plugin/AestraDrift.h"
 #include "Plugin/AestraLimit.h"
+#include "Plugin/AestraSat.h"
 
 #include <mutex>
 
@@ -157,6 +158,26 @@ const PluginInfo& limiterInfo() {
     return info;
 }
 
+const PluginInfo& satInfo() {
+    static const PluginInfo info = [] {
+        PluginInfo p;
+        p.id = "com.Aestrastudios.sat";
+        p.name = "Aestra Sat";
+        p.vendor = "Aestra Studios";
+        p.version = "0.1.0";
+        p.category = "Distortion";
+        p.format = PluginFormat::Internal;
+        p.type = PluginType::Effect;
+        p.numAudioInputs = 2;
+        p.numAudioOutputs = 2;
+        p.hasMidiInput = false;
+        p.hasMidiOutput = false;
+        p.hasEditor = true;
+        return p;
+    }();
+    return info;
+}
+
 namespace {
 void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
     if (!instance) {
@@ -179,6 +200,8 @@ void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
         drift->setInfo(info);
     } else if (auto limit = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLimit>(instance)) {
         limit->setInfo(info);
+    } else if (auto sat = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraSat>(instance)) {
+        sat->setInfo(info);
     }
 }
 
@@ -207,6 +230,7 @@ void registerCoreBuiltIns() {
         registry.registerPlugin(makeRegistration<Plugins::AestraDelay>(delayInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraDrift>(driftInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraLimit>(limiterInfo()));
+        registry.registerPlugin(makeRegistration<Plugins::AestraSat>(satInfo()));
     });
 }
 

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -149,6 +149,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/AestraDriftEditor.cpp
     Widgets/AestraLimitEditor.h
     Widgets/AestraLimitEditor.cpp
+    Widgets/AestraSatEditor.h
+    Widgets/AestraSatEditor.cpp
 )
 
 if(AESTRAUI_ENABLE_PREMIUM_EDITORS)

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -1,0 +1,287 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AestraSatEditor.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "Plugin/AestraSat.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace AestraUI {
+
+namespace {
+using Aestra::Audio::Plugins::AestraSat;
+
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kKnobSweep = kPi * 1.5f;
+constexpr float kKnobStart = kPi * 0.75f; // pointing down-left, sweeping clockwise
+constexpr float kDragRangePx = 160.0f;    // full param range per drag distance
+
+NUIColor accent() {
+    return NUIColor(0.94f, 0.52f, 0.22f, 1.0f);
+} // heat orange
+NUIColor panelSurface() {
+    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+}
+NUIColor insetSurface() {
+    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+}
+
+void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
+             NUIColor color) {
+    if (endAngle - startAngle <= 0.001f)
+        return;
+    std::array<NUIPoint, 49> pts{};
+    const float div = static_cast<float>(pts.size() - 1);
+    for (size_t i = 0; i < pts.size(); ++i) {
+        const float t = static_cast<float>(i) / div;
+        const float a = startAngle + (endAngle - startAngle) * t;
+        pts[i] = {center.x + std::cos(a) * radius, center.y + std::sin(a) * radius};
+    }
+    renderer.drawPolyline(pts.data(), static_cast<int>(pts.size()), thickness, color);
+}
+} // namespace
+
+AestraSatEditor::AestraSatEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance)
+    : m_instance(std::move(instance)) {
+    setId("AestraSatEditor");
+    setPanelTitle("Aestra Sat");
+    setBadgeText("Saturator");
+    setSize(kWinW, kWinH);
+    setEnforceParentBounds(true);
+    layoutControls();
+}
+
+void AestraSatEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
+    AestraPanelWindow::setPlatformBridge(bridge);
+}
+
+void AestraSatEditor::layoutControls() {
+    const auto b = getBounds();
+    const float contentTop = b.y + AestraPanelWindow::TITLE_BAR_H;
+
+    // Mode selector: three segments across the top-left
+    constexpr float kSegW = 62.0f;
+    constexpr float kSegH = 26.0f;
+    for (size_t i = 0; i < m_modeRects.size(); ++i) {
+        m_modeRects[i] =
+            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kSegW + 6.0f), contentTop + 16.0f, kSegW, kSegH);
+    }
+
+    constexpr float kBypassW = 88.0f;
+    constexpr float kBypassH = 26.0f;
+    m_bypassRect = NUIRect(b.right() - 44.0f - kBypassW, contentTop + 16.0f, kBypassW, kBypassH);
+
+    // Large drive knob on the left, tone/output stacked on the right
+    const float knobTop = contentTop + 56.0f;
+    m_driveRect = NUIRect(b.x + 52.0f, knobTop, 128.0f, 128.0f);
+    m_toneRect = NUIRect(b.x + 232.0f, knobTop + 4.0f, 84.0f, 84.0f);
+    m_outputRect = NUIRect(b.x + 344.0f, knobTop + 4.0f, 84.0f, 84.0f);
+
+    const float sliderY = std::min(knobTop + 140.0f, b.bottom() - 44.0f);
+    m_mixRect = NUIRect(b.x + 58.0f, sliderY, b.width - 116.0f, 34.0f);
+}
+
+void AestraSatEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    if (!m_instance)
+        return;
+
+    const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
+                           contentRect.height - 18.0f};
+    renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+
+    drawModeSelector(renderer);
+    drawBypassPill(renderer);
+    drawKnob(renderer, m_driveRect, AestraSat::kDrive, "Drive", true);
+    drawKnob(renderer, m_toneRect, AestraSat::kTone, "Tone", false);
+    drawKnob(renderer, m_outputRect, AestraSat::kOutput, "Output", false);
+    drawMixSlider(renderer);
+}
+
+void AestraSatEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label,
+                               bool large) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float value = m_instance ? m_instance->getParameter(paramId) : 0.0f;
+    const NUIPoint c = rect.center();
+    const float r = rect.width * 0.5f - 4.0f;
+    const float angle = kKnobStart + value * kKnobSweep;
+
+    renderer.fillCircle(c, r + 4.0f, insetSurface());
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+
+    drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
+            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+    drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
+
+    const float needleLen = r - (large ? 14.0f : 10.0f);
+    const NUIPoint tip(c.x + std::cos(angle) * needleLen, c.y + std::sin(angle) * needleLen);
+    renderer.drawLine(c, tip, 2.0f, accent().withAlpha(0.85f));
+    renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
+
+    const float wellR = r * (large ? 0.34f : 0.30f);
+    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
+
+    renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
+                              theme.getColor("textPrimary").withAlpha(0.95f));
+    const std::string valStr = m_instance ? m_instance->getParameterDisplay(paramId) : "";
+    renderer.drawTextCentered(valStr, NUIRect(rect.x - 10.0f, rect.bottom() + 19.0f, rect.width + 20.0f, 13.0f),
+                              large ? 10.0f : 9.0f, accent().withAlpha(0.96f));
+}
+
+void AestraSatEditor::drawModeSelector(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const auto mode =
+        m_instance ? AestraSat::modeFromNorm(m_instance->getParameter(AestraSat::kMode)) : AestraSat::kModeTape;
+    static constexpr const char* kLabels[] = {"TAPE", "TUBE", "HARD"};
+    for (size_t i = 0; i < m_modeRects.size(); ++i) {
+        const bool selected = static_cast<uint32_t>(mode) == i;
+        if (selected) {
+            renderer.fillRoundedRect(m_modeRects[i], 7.0f, accent().withAlpha(0.26f));
+            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, accent().withAlpha(0.62f));
+            renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f, accent().withAlpha(0.98f));
+        } else {
+            renderer.fillRoundedRect(m_modeRects[i], 7.0f, insetSurface());
+            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f,
+                                      theme.getColor("textPrimary").withAlpha(0.62f));
+        }
+    }
+}
+
+void AestraSatEditor::drawBypassPill(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const bool bypassed = m_instance && m_instance->getParameter(AestraSat::kBypass) > 0.5f;
+    constexpr float kRadius = 7.0f;
+    constexpr float kFont = 10.0f;
+    if (bypassed) {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 NUIColor(0.92f, 0.28f, 0.22f).withAlpha(m_bypassHovered ? 0.94f : 0.78f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, NUIColor(0.92f, 0.28f, 0.22f).withAlpha(0.50f));
+        renderer.drawTextCentered("BYPASSED", m_bypassRect, kFont, theme.getColor("textPrimary"));
+    } else {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 theme.getColor("success").withAlpha(m_bypassHovered ? 0.30f : 0.18f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, theme.getColor("success").withAlpha(0.40f));
+        renderer.drawTextCentered("ACTIVE", m_bypassRect, kFont, theme.getColor("success"));
+    }
+}
+
+void AestraSatEditor::drawMixSlider(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float mix = m_instance ? m_instance->getParameter(AestraSat::kMix) : 1.0f;
+    const NUIRect track(m_mixRect.x + 38.0f, m_mixRect.y + 12.0f, m_mixRect.width - 78.0f, 8.0f);
+
+    renderer.fillRoundedRect(m_mixRect, 10.0f, insetSurface());
+    renderer.strokeRoundedRect(m_mixRect, 10.0f, 1.0f, accent().withAlpha(m_draggingMix ? 0.62f : 0.34f));
+    renderer.drawText("Mix", {m_mixRect.x + 14.0f, m_mixRect.y + 11.0f}, 10.5f,
+                      theme.getColor("textPrimary").withAlpha(0.95f));
+    renderer.fillRoundedRect(track, 4.0f, NUIColor(1, 1, 1, 0.10f));
+    renderer.fillRoundedRect({track.x, track.y, track.width * mix, track.height}, 4.0f, accent().withAlpha(0.92f));
+    const NUIPoint thumb{track.x + track.width * mix, track.center().y};
+    renderer.fillCircle(thumb, 10.0f, accent().withAlpha(0.18f));
+    renderer.fillCircle(thumb, 7.0f, theme.getColor("textPrimary"));
+    const std::string pctStr = std::to_string(static_cast<int>(std::round(mix * 100.0f))) + "%";
+    const float pctW = renderer.measureText(pctStr, 10.0f).width;
+    renderer.drawText(pctStr, {m_mixRect.right() - 14.0f - pctW, m_mixRect.y + 10.0f}, 10.0f,
+                      accent().withAlpha(0.96f));
+}
+
+bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible())
+        return false;
+    if (AestraPanelWindow::onMouseEvent(event))
+        return true;
+    if (!m_instance)
+        return false;
+
+    const float mx = event.position.x;
+    const float my = event.position.y;
+
+    // Bypass pill
+    if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
+        const float cur = m_instance->getParameter(AestraSat::kBypass);
+        m_instance->setParameter(AestraSat::kBypass, cur > 0.5f ? 0.0f : 1.0f);
+        setDirty();
+        return true;
+    }
+    m_bypassHovered = m_bypassRect.contains(event.position);
+
+    // Mode segments
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        for (size_t i = 0; i < m_modeRects.size(); ++i) {
+            if (m_modeRects[i].contains(event.position)) {
+                m_instance->setParameter(AestraSat::kMode, AestraSat::normFromMode(static_cast<AestraSat::Mode>(i)));
+                setDirty();
+                return true;
+            }
+        }
+    }
+
+    // Knob vertical drag
+    if (m_draggingParam >= 0) {
+        if (event.released) {
+            m_draggingParam = -1;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float delta = (m_dragStartY - my) / kDragRangePx;
+            m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
+                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        const struct {
+            NUIRect rect;
+            uint32_t param;
+        } knobs[] = {
+            {m_driveRect, AestraSat::kDrive},
+            {m_toneRect, AestraSat::kTone},
+            {m_outputRect, AestraSat::kOutput},
+        };
+        for (const auto& k : knobs) {
+            if (k.rect.contains(event.position)) {
+                m_draggingParam = static_cast<int>(k.param);
+                m_dragStartY = my;
+                m_dragStartValue = m_instance->getParameter(k.param);
+                return true;
+            }
+        }
+    }
+
+    // Mix slider drag
+    const NUIRect mixTrack(m_mixRect.x + 38.0f, m_mixRect.y + 6.0f, m_mixRect.width - 78.0f, m_mixRect.height - 12.0f);
+    if (m_draggingMix) {
+        if (event.released) {
+            m_draggingMix = false;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float t = std::clamp((mx - mixTrack.x) / mixTrack.width, 0.0f, 1.0f);
+            m_instance->setParameter(AestraSat::kMix, t);
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left && mixTrack.contains(event.position)) {
+        m_draggingMix = true;
+        const float t = std::clamp((mx - mixTrack.x) / mixTrack.width, 0.0f, 1.0f);
+        m_instance->setParameter(AestraSat::kMix, t);
+        setDirty();
+        return true;
+    }
+
+    return false;
+}
+
+void AestraSatEditor::onResize(int width, int height) {
+    AestraPanelWindow::onResize(width, height);
+    layoutControls();
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraSatEditor.h
+++ b/AestraUI/Widgets/AestraSatEditor.h
@@ -1,0 +1,52 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraPanelWindow.h"
+#include "NUITypes.h"
+#include "PluginHost.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+namespace AestraUI {
+
+class AestraSatEditor : public AestraPanelWindow {
+public:
+    explicit AestraSatEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
+    void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    void onResize(int width, int height) override;
+    using AestraPanelWindow::onResize;
+    void onResize() { layoutControls(); }
+    void setPlatformBridge(NUIPlatformBridge* bridge) override;
+
+private:
+    void layoutControls();
+    void drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label, bool large);
+    void drawModeSelector(NUIRenderer& renderer);
+    void drawBypassPill(NUIRenderer& renderer);
+    void drawMixSlider(NUIRenderer& renderer);
+
+    std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
+
+    NUIRect m_driveRect;
+    NUIRect m_toneRect;
+    NUIRect m_outputRect;
+    std::array<NUIRect, 3> m_modeRects{};
+    NUIRect m_mixRect;
+    NUIRect m_bypassRect;
+
+    // Vertical-drag knob state: which param is being dragged, and the value
+    // at drag start so movement is relative, not absolute.
+    int m_draggingParam = -1;
+    float m_dragStartY = 0.0f;
+    float m_dragStartValue = 0.0f;
+    bool m_draggingMix = false;
+    bool m_bypassHovered = false;
+
+    static constexpr float kWinW = 480.0f;
+    static constexpr float kWinH = 300.0f;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -10,6 +10,7 @@
 #include "AestraDelayEditor.h"
 #include "AestraDriftEditor.h"
 #include "AestraLimitEditor.h"
+#include "AestraSatEditor.h"
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
@@ -391,6 +392,14 @@ void PluginUIController::openPluginEditor(
         });
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
+    } else if (pluginId == "com.Aestrastudios.sat") {
+        auto ed = std::make_shared<AestraSatEditor>(instance);
+        ed->setOnClose([this, ed]() {
+            if (m_popupLayer) m_popupLayer->removeChild(ed);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
+        });
+        ed->setPlatformBridge(m_platformBridge);
+        editor = ed;
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
         ed->setOnClose([this, ed]() {
@@ -417,6 +426,8 @@ void PluginUIController::openPluginEditor(
             comp->onResize();
         } else if (auto limit = std::dynamic_pointer_cast<AestraLimitEditor>(editorComp)) {
             limit->onResize(static_cast<int>(width), static_cast<int>(height));
+        } else if (auto sat = std::dynamic_pointer_cast<AestraSatEditor>(editorComp)) {
+            sat->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto generic = std::dynamic_pointer_cast<GenericPluginEditor>(editorComp)) {
             generic->onResize();
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS

--- a/Tests/AestraAudio/AestraSatTest.cpp
+++ b/Tests/AestraAudio/AestraSatTest.cpp
@@ -90,23 +90,96 @@ float goertzelMag(const std::vector<float>& buf, size_t start, float freq, doubl
     return static_cast<float>(2.0 * std::sqrt(std::max(0.0, power)) / static_cast<double>(n));
 }
 
-bool testBypassPassesAudioUnchanged() {
+// The plugin reports a constant oversampler latency, so internal bypass must
+// pass audio through the same delay — an undelayed copy would land this slot
+// ~30 samples early relative to PDC-compensated tracks.
+bool testBypassMatchesReportedLatency() {
     AestraSat sat;
     initAndActivate(sat);
     sat.setParameter(AestraSat::kBypass, 1.0f);
     sat.setParameter(AestraSat::kDrive, 1.0f);
+    const uint32_t latency = sat.getLatencySamples();
 
     const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
     const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
     auto out = processStereo(sat, inL, inR);
 
     for (uint32_t i = 0; i < inL.size(); ++i) {
-        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
+        const float expectL = (i >= latency) ? inL[i - latency] : 0.0f;
+        const float expectR = (i >= latency) ? inR[i - latency] : 0.0f;
+        if (std::abs(out.left[i] - expectL) > 1e-6f)
             return false;
-        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+        if (std::abs(out.right[i] - expectR) > 1e-6f)
             return false;
     }
     return true;
+}
+
+// Toggling bypass mid-stream must keep the delay ring advancing (constant
+// alignment) and must not replay stale wet state on reactivation.
+bool testBypassToggleKeepsAlignmentAndState() {
+    AestraSat sat;
+    initAndActivate(sat);
+    sat.setParameter(AestraSat::kDrive, 1.0f); // hot wet path before bypass
+    sat.setParameter(AestraSat::kMix, 1.0f);
+    const uint32_t latency = sat.getLatencySamples();
+
+    const auto loud = makeSine(4096, 1000.0f, 0.9f, kSampleRate);
+    processStereo(sat, loud, loud); // build up wet/oversampler state
+
+    // Bypass: output must be the input delayed by the reported latency,
+    // seamlessly continuing the ring (first `latency` samples come from the
+    // tail of the previous active block).
+    sat.setParameter(AestraSat::kBypass, 1.0f);
+    const auto quiet = makeSine(4096, 500.0f, 0.1f, kSampleRate);
+    auto bypassed = processStereo(sat, quiet, quiet);
+    for (uint32_t i = latency; i < quiet.size(); ++i) {
+        if (std::abs(bypassed.left[i] - quiet[i - latency]) > 1e-6f)
+            return false;
+    }
+
+    // Reactivate at zero drive: output must stay finite and near the new
+    // quiet input level — any burst of stale pre-bypass oversampler/filter
+    // state (built from the loud driven signal) would exceed this.
+    sat.setParameter(AestraSat::kBypass, 0.0f);
+    sat.setParameter(AestraSat::kDrive, 0.0f);
+    auto resumed = processStereo(sat, quiet, quiet);
+    if (!allFinite(resumed.left) || !allFinite(resumed.right))
+        return false;
+    return peakAmplitude(resumed.left) < 0.3f;
+}
+
+// NaN/Inf must not pass the parameter ingress: the previous value survives.
+bool testSetParameterRejectsNonFinite() {
+    AestraSat sat;
+    initAndActivate(sat);
+    sat.setParameter(AestraSat::kDrive, 0.42f);
+
+    sat.setParameter(AestraSat::kDrive, std::numeric_limits<float>::quiet_NaN());
+    if (std::abs(sat.getParameter(AestraSat::kDrive) - 0.42f) > 1e-6f)
+        return false;
+    sat.setParameter(AestraSat::kDrive, std::numeric_limits<float>::infinity());
+    if (std::abs(sat.getParameter(AestraSat::kDrive) - 0.42f) > 1e-6f)
+        return false;
+    sat.setParameter(AestraSat::kDrive, -std::numeric_limits<float>::infinity());
+    if (std::abs(sat.getParameter(AestraSat::kDrive) - 0.42f) > 1e-6f)
+        return false;
+
+    // A corrupted state blob full of NaNs must not poison the params either.
+    std::vector<uint8_t> state = sat.saveState();
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
+        std::memcpy(state.data() + off, &nan, sizeof(float));
+    }
+    sat.loadState(state); // magic/version intact, params all NaN
+    for (uint32_t i = 0; i < AestraSat::kParamCount; ++i) {
+        if (!std::isfinite(sat.getParameter(i)))
+            return false;
+    }
+
+    const auto in = makeSine(2048, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(sat, in, in);
+    return allFinite(out.left) && allFinite(out.right);
 }
 
 bool testSilenceProducesSilence() {
@@ -404,7 +477,9 @@ struct TestCase {
 
 int main() {
     const TestCase tests[] = {
-        {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
+        {"BypassMatchesReportedLatency", testBypassMatchesReportedLatency},
+        {"BypassToggleKeepsAlignmentAndState", testBypassToggleKeepsAlignmentAndState},
+        {"SetParameterRejectsNonFinite", testSetParameterRejectsNonFinite},
         {"SilenceProducesSilence", testSilenceProducesSilence},
         {"DryPathIsExactDelay", testDryPathIsExactDelay},
         {"WetPathLatencyAligned", testWetPathLatencyAligned},

--- a/Tests/AestraAudio/AestraSatTest.cpp
+++ b/Tests/AestraAudio/AestraSatTest.cpp
@@ -1,0 +1,437 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraSatTest — DSP contract tests for the oversampled saturator.
+
+#include "Plugin/AestraSat.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraSat;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 512;
+
+struct StereoBuffer {
+    std::vector<float> left;
+    std::vector<float> right;
+};
+
+void initAndActivate(AestraSat& sat, double sampleRate = kSampleRate) {
+    sat.initialize(sampleRate, kBlockSize);
+    sat.activate();
+}
+
+StereoBuffer processStereo(AestraSat& sat, const std::vector<float>& inL, const std::vector<float>& inR) {
+    StereoBuffer out{std::vector<float>(inL.size(), 0.0f), std::vector<float>(inR.size(), 0.0f)};
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {out.left.data(), out.right.data()};
+    sat.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+    return out;
+}
+
+std::vector<float> makeSine(uint32_t numSamples, float freq, float amp, double sampleRate) {
+    // Phase accumulated in double: at high freq * long buffers the float
+    // sin() argument grows past the point where its phase noise (~-40 dB)
+    // would pollute spectral measurements.
+    std::vector<float> buf(numSamples);
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    for (uint32_t i = 0; i < numSamples; ++i)
+        buf[i] = static_cast<float>(amp * std::sin(w * static_cast<double>(i)));
+    return buf;
+}
+
+std::vector<float> makeSilence(uint32_t numSamples) {
+    return std::vector<float>(numSamples, 0.0f);
+}
+
+float peakAmplitude(const std::vector<float>& buf, size_t start = 0) {
+    float peak = 0.0f;
+    for (size_t i = start; i < buf.size(); ++i)
+        peak = std::max(peak, std::abs(buf[i]));
+    return peak;
+}
+
+float rmsAmplitude(const std::vector<float>& buf, size_t start = 0) {
+    if (start >= buf.size())
+        return 0.0f;
+    double acc = 0.0;
+    for (size_t i = start; i < buf.size(); ++i)
+        acc += static_cast<double>(buf[i]) * buf[i];
+    return static_cast<float>(std::sqrt(acc / static_cast<double>(buf.size() - start)));
+}
+
+bool allFinite(const std::vector<float>& buf) {
+    for (float s : buf) {
+        if (!std::isfinite(s))
+            return false;
+    }
+    return true;
+}
+
+/// Goertzel magnitude of one bin, normalized so a unit sine reads 1.0.
+float goertzelMag(const std::vector<float>& buf, size_t start, float freq, double sampleRate) {
+    const size_t n = buf.size() - start;
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (size_t i = start; i < buf.size(); ++i) {
+        s0 = buf[i] + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    return static_cast<float>(2.0 * std::sqrt(std::max(0.0, power)) / static_cast<double>(n));
+}
+
+bool testBypassPassesAudioUnchanged() {
+    AestraSat sat;
+    initAndActivate(sat);
+    sat.setParameter(AestraSat::kBypass, 1.0f);
+    sat.setParameter(AestraSat::kDrive, 1.0f);
+
+    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
+    auto out = processStereo(sat, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
+            return false;
+        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testSilenceProducesSilence() {
+    AestraSat sat;
+    initAndActivate(sat);
+    sat.setParameter(AestraSat::kDrive, 1.0f);
+
+    const auto silence = makeSilence(2048);
+    auto out = processStereo(sat, silence, silence);
+
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+}
+
+// Mix = 0 must be a pure delay of exactly getLatencySamples().
+bool testDryPathIsExactDelay() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kMix, 0.0f);
+    sat.setParameter(AestraSat::kDrive, 1.0f);
+    sat.activate();
+
+    const uint32_t latency = sat.getLatencySamples();
+    std::vector<float> in(1024, 0.0f);
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = std::sin(0.031f * static_cast<float>(i)) * 0.7f + std::sin(0.31f * static_cast<float>(i)) * 0.2f;
+    auto out = processStereo(sat, in, in);
+
+    for (uint32_t i = latency; i < in.size(); ++i) {
+        if (std::abs(out.left[i] - in[i - latency]) > 1e-6f)
+            return false;
+    }
+    for (uint32_t i = 0; i < latency && i < out.left.size(); ++i) {
+        if (std::abs(out.left[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+// At low drive and full mix the wet path must be time-aligned with the
+// reported latency (otherwise Mix would comb-filter).
+bool testWetPathLatencyAligned() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kDrive, 0.0f); // 0 dB — tanh(x) ~= x at low level
+    sat.setParameter(AestraSat::kMix, 1.0f);
+    sat.setParameter(AestraSat::kTone, 1.0f);
+    sat.activate();
+
+    const uint32_t latency = sat.getLatencySamples();
+    // Broadband probe: at a single low frequency the DC blocker's phase lead
+    // (~2 samples at 200 Hz) would bias the correlation peak. Deterministic
+    // noise spreads the energy so the peak sits on the true bulk delay.
+    std::vector<float> in(8192);
+    uint32_t lcg = 0x12345678u;
+    for (auto& s : in) {
+        lcg = lcg * 1664525u + 1013904223u;
+        s = (static_cast<float>(lcg >> 8) / 8388608.0f - 1.0f) * 0.1f;
+    }
+    auto out = processStereo(sat, in, in);
+
+    // Find the lag with the highest normalized cross-correlation: the bulk
+    // delay must equal the reported latency, and at that lag the low-drive
+    // wet path must track the input closely.
+    double bestCorr = -2.0;
+    uint32_t bestLag = 0;
+    for (uint32_t lag = 0; lag <= 2 * latency; ++lag) {
+        double dot = 0.0, inEnergy = 0.0, outEnergy = 0.0;
+        for (uint32_t i = 2048; i < in.size(); ++i) {
+            const double a = out.left[i];
+            const double b = in[i - lag];
+            dot += a * b;
+            inEnergy += b * b;
+            outEnergy += a * a;
+        }
+        const double denom = std::sqrt(inEnergy * outEnergy);
+        const double corr = denom > 0.0 ? dot / denom : 0.0;
+        if (corr > bestCorr) {
+            bestCorr = corr;
+            bestLag = lag;
+        }
+    }
+    // The tone pole and halfband transition band shave the top octave off the
+    // noise, so correlation won't be 1.0 — the lag is the real assertion.
+    return bestLag == latency && bestCorr > 0.98;
+}
+
+bool testHighDriveSaturates() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kDrive, 1.0f); // +36 dB
+    sat.setParameter(AestraSat::kMode, AestraSat::normFromMode(AestraSat::kModeHard));
+    sat.activate();
+
+    const auto in = makeSine(8192, 997.0f, 0.5f, kSampleRate);
+    auto out = processStereo(sat, in, in);
+
+    // A hard-clipped sine at 36 dB overdrive is nearly a square wave:
+    // peak ~1, crest factor (rms/peak) approaching 1.
+    const float peak = peakAmplitude(out.left, 2048);
+    const float rms = rmsAmplitude(out.left, 2048);
+    if (peak < 0.8f || peak > 1.2f)
+        return false;
+    if (rms / peak < 0.85f)
+        return false;
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Tube asymmetry shows up as even harmonics; symmetric tape/hard curves
+// produce only odd ones. (At extreme drive the DC blocker recentres the
+// clipped square and peak asymmetry vanishes, so measure spectrum at
+// moderate drive instead of comparing lobe peaks.)
+bool testTubeModeAddsEvenHarmonics() {
+    auto secondHarmonicRatio = [](AestraSat::Mode mode) {
+        AestraSat sat;
+        sat.initialize(kSampleRate, kBlockSize);
+        sat.setParameter(AestraSat::kDrive, 0.5f); // +18 dB — rich but not square
+        sat.setParameter(AestraSat::kMode, AestraSat::normFromMode(mode));
+        sat.activate();
+
+        const float freq = 250.0f;
+        const auto in = makeSine(16384, freq, 0.25f, kSampleRate);
+        auto out = processStereo(sat, in, in);
+
+        const float fund = goertzelMag(out.left, 4096, freq, kSampleRate);
+        const float second = goertzelMag(out.left, 4096, 2.0f * freq, kSampleRate);
+        return fund > 1e-6f ? second / fund : 0.0f;
+    };
+
+    const float tube = secondHarmonicRatio(AestraSat::kModeTube);
+    const float tape = secondHarmonicRatio(AestraSat::kModeTape);
+    // Tube: clearly audible 2nd harmonic (> -30 dB); tape: essentially none.
+    return tube > 0.03f && tube > 10.0f * tape;
+}
+
+// The DC blocker must keep the long-run mean near zero even in the
+// asymmetric tube mode.
+bool testTubeModeHasNoDcOffset() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kDrive, 1.0f);
+    sat.setParameter(AestraSat::kMode, AestraSat::normFromMode(AestraSat::kModeTube));
+    sat.activate();
+
+    const auto in = makeSine(48000, 250.0f, 0.5f, kSampleRate);
+    auto out = processStereo(sat, in, in);
+
+    double mean = 0.0;
+    for (size_t i = 24000; i < out.left.size(); ++i)
+        mean += out.left[i];
+    mean /= static_cast<double>(out.left.size() - 24000);
+    return std::abs(mean) < 0.02;
+}
+
+// 4x oversampling must suppress foldback aliasing. A 15 kHz sine driven
+// +18 dB into tanh puts its 3rd harmonic at 45 kHz (~-12 dB); without
+// oversampling that folds straight down to 3 kHz. With the 4x halfband
+// cascade it must be buried. (A hard clip at max drive is deliberately not
+// used here: a near-square wave keeps meaningful energy in harmonics past
+// the 4x Nyquist, so some fold-back is inherent to any finite oversampling
+// factor and the measurement would test the torture signal, not the filter.)
+bool testOversamplingSuppressesAliasing() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kDrive, 0.5f); // +18 dB
+    sat.setParameter(AestraSat::kMode, AestraSat::normFromMode(AestraSat::kModeTape));
+    sat.activate();
+
+    const float fundamental = 15000.0f;
+    const float aliasFreq = 3.0f * fundamental - static_cast<float>(kSampleRate); // 3 kHz
+    const auto in = makeSine(32768, fundamental, 0.25f, kSampleRate);
+    auto out = processStereo(sat, in, in);
+
+    const float fundMag = goertzelMag(out.left, 8192, fundamental, kSampleRate);
+    const float aliasMag = goertzelMag(out.left, 8192, aliasFreq, kSampleRate);
+    if (fundMag < 1e-4f)
+        return false;
+
+    const float ratioDb = 20.0f * std::log10(aliasMag / fundMag);
+    return ratioDb < -50.0f;
+}
+
+bool testToneDarkensOutput() {
+    auto renderWithTone = [](float tone) {
+        AestraSat sat;
+        sat.initialize(kSampleRate, kBlockSize);
+        sat.setParameter(AestraSat::kDrive, 0.5f);
+        sat.setParameter(AestraSat::kTone, tone);
+        sat.activate();
+        const auto in = makeSine(16384, 8000.0f, 0.25f, kSampleRate);
+        auto out = processStereo(sat, in, in);
+        return goertzelMag(out.left, 4096, 8000.0f, kSampleRate);
+    };
+
+    const float open = renderWithTone(1.0f); // 20 kHz
+    const float dark = renderWithTone(0.0f); // 1 kHz
+    // 8 kHz content through a 1 kHz one-pole should drop by roughly 18 dB.
+    return dark < open * 0.25f;
+}
+
+bool testSurvivesHostileInput() {
+    AestraSat sat;
+    sat.initialize(kSampleRate, kBlockSize);
+    sat.setParameter(AestraSat::kDrive, 1.0f);
+    sat.activate();
+
+    std::vector<float> in(2048, 0.0f);
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = (i % 2 == 0) ? 100.0f : -100.0f;
+    in[100] = std::numeric_limits<float>::quiet_NaN();
+    in[200] = std::numeric_limits<float>::infinity();
+    in[300] = -std::numeric_limits<float>::infinity();
+
+    auto out = processStereo(sat, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+bool testStateRoundTrip() {
+    AestraSat sat;
+    initAndActivate(sat);
+    sat.setParameter(AestraSat::kDrive, 0.7f);
+    sat.setParameter(AestraSat::kMode, AestraSat::normFromMode(AestraSat::kModeTube));
+    sat.setParameter(AestraSat::kTone, 0.3f);
+    sat.setParameter(AestraSat::kOutput, 0.6f);
+    sat.setParameter(AestraSat::kMix, 0.8f);
+
+    const auto state = sat.saveState();
+
+    AestraSat restored;
+    initAndActivate(restored);
+    if (!restored.loadState(state))
+        return false;
+
+    for (uint32_t i = 0; i < AestraSat::kParamCount; ++i) {
+        if (std::abs(restored.getParameter(i) - sat.getParameter(i)) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testLoadStateRejectsGarbage() {
+    AestraSat sat;
+    initAndActivate(sat);
+
+    std::vector<uint8_t> tooShort = {0x31, 0x54};
+    if (sat.loadState(tooShort))
+        return false;
+
+    std::vector<uint8_t> wrongMagic(64, 0);
+    if (sat.loadState(wrongMagic))
+        return false;
+    return true;
+}
+
+bool testModeMapping() {
+    if (AestraSat::modeFromNorm(0.0f) != AestraSat::kModeTape)
+        return false;
+    if (AestraSat::modeFromNorm(0.5f) != AestraSat::kModeTube)
+        return false;
+    if (AestraSat::modeFromNorm(1.0f) != AestraSat::kModeHard)
+        return false;
+    if (AestraSat::modeFromNorm(AestraSat::normFromMode(AestraSat::kModeTube)) != AestraSat::kModeTube)
+        return false;
+    return true;
+}
+
+bool testStableAcrossSampleRates() {
+    for (double sr : {44100.0, 96000.0, 192000.0}) {
+        AestraSat sat;
+        initAndActivate(sat, sr);
+        sat.setParameter(AestraSat::kDrive, 1.0f);
+
+        const auto in = makeSine(8192, 1000.0f, 0.5f, sr);
+        auto out = processStereo(sat, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+        if (peakAmplitude(out.left, 2048) > 4.5f)
+            return false; // +12 dB trim max headroom
+
+        const auto silence = makeSilence(8192);
+        AestraSat quiet;
+        initAndActivate(quiet, sr);
+        auto quietOut = processStereo(quiet, silence, silence);
+        if (peakAmplitude(quietOut.left) > 1e-8f)
+            return false;
+    }
+    return true;
+}
+
+struct TestCase {
+    const char* name;
+    bool (*fn)();
+};
+
+} // namespace
+
+int main() {
+    const TestCase tests[] = {
+        {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
+        {"SilenceProducesSilence", testSilenceProducesSilence},
+        {"DryPathIsExactDelay", testDryPathIsExactDelay},
+        {"WetPathLatencyAligned", testWetPathLatencyAligned},
+        {"HighDriveSaturates", testHighDriveSaturates},
+        {"TubeModeAddsEvenHarmonics", testTubeModeAddsEvenHarmonics},
+        {"TubeModeHasNoDcOffset", testTubeModeHasNoDcOffset},
+        {"OversamplingSuppressesAliasing", testOversamplingSuppressesAliasing},
+        {"ToneDarkensOutput", testToneDarkensOutput},
+        {"SurvivesHostileInput", testSurvivesHostileInput},
+        {"StateRoundTrip", testStateRoundTrip},
+        {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
+        {"ModeMapping", testModeMapping},
+        {"StableAcrossSampleRates", testStableAcrossSampleRates},
+    };
+
+    int failures = 0;
+    for (const auto& test : tests) {
+        const bool passed = test.fn();
+        std::cout << (passed ? "[PASS] " : "[FAIL] ") << test.name << "\n";
+        if (!passed)
+            ++failures;
+    }
+
+    if (failures > 0) {
+        std::cout << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All AestraSat tests passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1198,6 +1198,17 @@ target_include_directories(AestraLimitTest PRIVATE
 add_test(NAME AestraLimitTest COMMAND AestraLimitTest)
 set_tests_properties(AestraLimitTest PROPERTIES LABELS "audio;plugins;limiter")
 
+# Aestra Sat Test
+add_executable(AestraSatTest AestraAudio/AestraSatTest.cpp)
+target_link_libraries(AestraSatTest PRIVATE AestraAudio)
+target_include_directories(AestraSatTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraSatTest COMMAND AestraSatTest)
+set_tests_properties(AestraSatTest PROPERTIES LABELS "audio;plugins;saturation")
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================


### PR DESCRIPTION
## Summary
New internal plugin **AestraSat** (`com.Aestrastudios.sat`) — the first plugin of the Supporter suite build-out. Waveshaping saturator with three curves (Tape/tanh, Tube/asymmetric, Hard/clip), always processed at 4x oversampling via the existing `DSP::Oversampler` halfband cascade.

## Why
Best effort-to-impact item in the plugin-gap list: reuses the validated oversampling infrastructure, and saturation is the most-reached-for missing effect. Kicks off the Sat → Filter → OTT → LFO sequence.

## Design
- **Signal path**: drive gain → 4x upsample → shaper → downsample → DC blocker (10 Hz) → tone one-pole LP (1k–20k, wet only) → output trim (±12 dB) → mix with **latency-aligned dry** (read-before-write ring sized exactly to `Oversampler::kReportedLatency`, so Mix never comb-filters).
- **Tube curve** is C1-continuous asymmetric tanh (negative lobe saturates at −1/1.5) — generates even harmonics; DC blocker handles the resulting offset.
- Reported latency: 30 samples (constant; oversampling is always on).
- RT-safe: no allocation/locks/IO in `process()`; params are relaxed atomics with 2 ms smoothing; NaN/Inf inputs sanitized.

## Testing performed
- `AestraSatTest` (new, 14 contract tests, all pass): bypass parity, silence, dry-path exact delay, wet-path latency alignment (cross-correlation over broadband probe), saturation onset, tube even-harmonics (Goertzel), DC-offset bound, **aliasing suppression** (15 kHz tanh probe; 3 kHz foldback bin < −50 dB vs ~−12 dB un-oversampled), tone response, hostile-input survival, state roundtrip, garbage-state rejection, mode mapping, 44.1/96/192 kHz stability.
- Full `cmake --build` of all targets clean (incl. `Aestra` app link with the new editor).
- `ctest -L plugins`: 9/9 pass.

## Docs updated?
No public docs list plugins today; nothing to update.

## Risk/rollback notes
- Additive change: new plugin ID + registration, no existing plugin/DSP/serialization paths touched.
- State format: new `'SAT1'` magic, version 1, param-blob layout identical to other internal plugins.
- Rollback: revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added the internal **AestraSat** saturation plugin (`com.Aestrastudios.sat`) with tape, tube, and hard-clipping modes using constant **4× oversampling**.
- Implemented a latency-aware signal path (drive + waveshaping → downsample → DC block + tone filter → wet-only filtering → output trim → latency-aligned dry/wet mixing) with parameter smoothing and audio/parameter sanitization.
- Added **SAT1** state serialization/loading and plugin registration, plus input sanitization and metering for stable/hostile inputs.
- Added a dedicated **AestraSat** editor (knobs, mode selector, bypass pill, mix slider) and UI controller integration.
- Added/updated **17** DSP contract tests covering latency/bypass alignment, harmonics/alias suppression, state handling (including hostile/corrupted blobs), non-finite parameter rejection, mode mapping, and multiple sample rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->