### PR TITLE
feat(plugins): AestraFilter — envelope-modulated ZDF multimode filter

### DIFF
--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -7,6 +7,12 @@
 // ±4 octaves), which is what turns a static filter into an envelope shaper:
 // auto-wah upward sweeps, reverse "duck" filtering, dynamic brightness.
 //
+// Control-rate architecture: parameters are read and smoothed once per
+// 8-sample control block, transcendental coefficient recomputes (pow/exp/tan)
+// are gated on smoothed-target movement, and the TPT coefficient set is
+// linearly interpolated across the block. The per-sample path is the envelope
+// follower, the drive tanh and the SVF arithmetic.
+//
 // Signal path (per channel, per sample):
 //   in -> drive (transparent-at-zero tanh blend) -> ZDF SVF (LP/BP/HP)
 //      -> mix with dry (zero latency — no compensation needed)
@@ -82,94 +88,149 @@ public:
 
         if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
             copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            m_wasBypassed = true;
             return;
+        }
+        if (m_wasBypassed) {
+            // While bypassed the integrators and envelope stopped evolving;
+            // re-enabling must not restore stale resonance/envelope state.
+            m_ic1[0] = m_ic1[1] = 0.0f;
+            m_ic2[0] = m_ic2[1] = 0.0f;
+            m_envelope = 0.0f;
+            snapSmoothedParams();
+            m_coeffsDirty = true;
+            m_typeXfadeRemaining = 0;
+            m_wasBypassed = false;
         }
 
         const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
         const bool stereo = channels >= 2;
-        const auto type = typeFromNorm(m_params[kType].load(std::memory_order_relaxed));
         const float sr = static_cast<float>(m_sampleRate);
         const float maxCutoff = 0.45f * sr;
 
-        for (uint32_t i = 0; i < numFrames; ++i) {
-            // Smooth continuous params (2 ms one-pole, shared by both channels)
+        for (uint32_t blockStart = 0; blockStart < numFrames; blockStart += kCtrlInterval) {
+            const uint32_t blockEnd = std::min(blockStart + kCtrlInterval, numFrames);
+            const uint32_t blockLen = blockEnd - blockStart;
+
+            // ── Control block: smooth params, gated coefficient recomputes ──
             m_cutoffSmoothed += (getParameter(kCutoff) - m_cutoffSmoothed) * m_smoothCoeff;
             m_resoSmoothed += (getParameter(kReso) - m_resoSmoothed) * m_smoothCoeff;
             m_driveSmoothed += (getParameter(kDrive) - m_driveSmoothed) * m_smoothCoeff;
             m_envAmtSmoothed += (getParameter(kEnvAmount) - m_envAmtSmoothed) * m_smoothCoeff;
+            m_attackSmoothed += (getParameter(kEnvAttack) - m_attackSmoothed) * m_smoothCoeff;
+            m_releaseSmoothed += (getParameter(kEnvRelease) - m_releaseSmoothed) * m_smoothCoeff;
             m_mixSmoothed += (getParameter(kMix) - m_mixSmoothed) * m_smoothCoeff;
 
-            const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i));
-            const float inR = stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL;
+            if (m_coeffsDirty || std::abs(m_resoSmoothed - m_resoCached) > 1.0e-5f) {
+                m_resoCached = m_resoSmoothed;
+                m_k = 1.0f / qFromNorm(m_resoCached);
+            }
+            if (m_coeffsDirty || std::abs(m_driveSmoothed - m_driveCached) > 1.0e-5f) {
+                m_driveCached = m_driveSmoothed;
+                m_driveGain = dbToLinear(driveDbFromNorm(m_driveCached));
+                m_driveMakeup = 1.0f / std::sqrt(m_driveGain);
+            }
+            if (m_coeffsDirty || std::abs(m_attackSmoothed - m_attackCached) > 1.0e-4f) {
+                m_attackCached = m_attackSmoothed;
+                m_attackCoeff = 1.0f - std::exp(-1.0f / (attackMsFromNorm(m_attackCached) * 0.001f * sr));
+            }
+            if (m_coeffsDirty || std::abs(m_releaseSmoothed - m_releaseCached) > 1.0e-4f) {
+                m_releaseCached = m_releaseSmoothed;
+                m_releaseCoeff = 1.0f - std::exp(-1.0f / (releaseMsFromNorm(m_releaseCached) * 0.001f * sr));
+            }
+            if (m_coeffsDirty || std::abs(m_cutoffSmoothed - m_cutoffCached) > 1.0e-5f) {
+                m_cutoffCached = m_cutoffSmoothed;
+                m_baseCutoffHz = cutoffHzFromNorm(m_cutoffCached);
+            }
 
-            // ── Envelope follower (pre-drive stereo peak) ──
-            const float peak = std::max(std::abs(inL), std::abs(inR));
-            const float attackMs = attackMsFromNorm(getParameter(kEnvAttack));
-            const float releaseMs = releaseMsFromNorm(getParameter(kEnvRelease));
-            const float coeffMs = (peak > m_envelope) ? attackMs : releaseMs;
-            const float envCoeff = 1.0f - std::exp(-1.0f / (coeffMs * 0.001f * sr));
-            m_envelope += (peak - m_envelope) * envCoeff;
-
-            // ── Cutoff with bipolar envelope modulation (octave domain) ──
+            // Envelope-modulated TPT coefficient target for this block; the
+            // set is linearly interpolated across the block so per-sample cost
+            // is three adds instead of exp2 + tan.
             const float envAmount = 2.0f * m_envAmtSmoothed - 1.0f;
-            const float baseCutoff = cutoffHzFromNorm(m_cutoffSmoothed);
             const float modOctaves = envAmount * kEnvModOctaves * std::min(1.0f, m_envelope);
-            const float fc = std::clamp(baseCutoff * std::exp2(modOctaves), 20.0f, maxCutoff);
-
-            // ── ZDF SVF coefficients (shared by both channels) ──
+            const float fc = std::clamp(m_baseCutoffHz * std::exp2(modOctaves), 20.0f, maxCutoff);
             const float g = std::tan(3.14159265358979323846f * fc / sr);
-            const float q = qFromNorm(m_resoSmoothed);
-            const float k = 1.0f / q;
-            const float a1 = 1.0f / (1.0f + g * (g + k));
-            const float a2 = g * a1;
-            const float a3 = g * a2;
+            const float a1t = 1.0f / (1.0f + g * (g + m_k));
+            const float a2t = g * a1t;
+            const float a3t = g * a2t;
+            float da1, da2, da3;
+            if (m_coeffsDirty) {
+                m_a1 = a1t;
+                m_a2 = a2t;
+                m_a3 = a3t;
+                da1 = da2 = da3 = 0.0f;
+                m_coeffsDirty = false;
+            } else {
+                const float inv = 1.0f / static_cast<float>(blockLen);
+                da1 = (a1t - m_a1) * inv;
+                da2 = (a2t - m_a2) * inv;
+                da3 = (a3t - m_a3) * inv;
+            }
 
-            // ── Drive: transparent at 0, tanh soft clip as it rises.
-            // 1/sqrt(G) makeup keeps perceived loudness roughly level: small
-            // signals gain sqrt(G) (+9 dB max), the clip ceiling sits at
-            // 1/sqrt(G) (-9 dB max) instead of collapsing to 1/G. ──
-            const float driveNorm = m_driveSmoothed;
-            const float driveGain = dbToLinear(driveDbFromNorm(driveNorm));
-            const float driveMakeup = 1.0f / std::sqrt(driveGain);
+            // Type is stepped: crossfade LP/BP/HP over ~3 ms on change so
+            // automation cannot click (all three outputs are computed anyway).
+            const auto type = typeFromNorm(m_params[kType].load(std::memory_order_relaxed));
+            if (type != m_currentType) {
+                m_prevType = m_currentType;
+                m_currentType = type;
+                m_typeXfadeRemaining = m_typeXfadeLength;
+            }
 
             const float wet = m_mixSmoothed;
             const float dry = 1.0f - wet;
 
-            for (uint32_t ch = 0; ch < channels; ++ch) {
-                const float x = (ch == 0) ? inL : inR;
-                const float driven = x + driveNorm * (std::tanh(driveGain * x) * driveMakeup - x);
+            for (uint32_t i = blockStart; i < blockEnd; ++i) {
+                m_a1 += da1;
+                m_a2 += da2;
+                m_a3 += da3;
 
-                float& ic1 = m_ic1[ch];
-                float& ic2 = m_ic2[ch];
-                const float v3 = driven - ic2;
-                const float v1 = a1 * ic1 + a2 * v3;
-                const float v2 = ic2 + a2 * ic1 + a3 * v3;
-                ic1 = 2.0f * v1 - ic1;
-                ic2 = 2.0f * v2 - ic2;
+                const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i));
+                const float inR = stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL;
 
-                float filtered;
-                switch (type) {
-                case kTypeLowPass:
-                    filtered = v2;
-                    break;
-                case kTypeBandPass:
-                    filtered = v1;
-                    break;
-                default:
-                    filtered = driven - k * v1 - v2;
-                    break;
+                // ── Envelope follower (pre-drive stereo peak) ──
+                const float peak = std::max(std::abs(inL), std::abs(inR));
+                const float envCoeff = (peak > m_envelope) ? m_attackCoeff : m_releaseCoeff;
+                m_envelope += (peak - m_envelope) * envCoeff;
+
+                float xfade = 0.0f;
+                if (m_typeXfadeRemaining > 0) {
+                    xfade = static_cast<float>(m_typeXfadeRemaining) / static_cast<float>(m_typeXfadeLength);
+                    --m_typeXfadeRemaining;
                 }
 
-                if (outputs[ch])
-                    outputs[ch][i] = x * dry + filtered * wet;
-            }
+                for (uint32_t ch = 0; ch < channels; ++ch) {
+                    const float x = (ch == 0) ? inL : inR;
+                    // Drive: transparent at 0, tanh soft clip as it rises.
+                    // 1/sqrt(G) makeup keeps perceived loudness roughly level.
+                    const float driven = x + m_driveCached * (std::tanh(m_driveGain * x) * m_driveMakeup - x);
 
-            if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
-                outputs[1][i] = outputs[0][i];
-            }
-            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
-                if (outputs[ch])
-                    outputs[ch][i] = 0.0f;
+                    float& ic1 = m_ic1[ch];
+                    float& ic2 = m_ic2[ch];
+                    const float v3 = driven - ic2;
+                    const float v1 = m_a1 * ic1 + m_a2 * v3;
+                    const float v2 = ic2 + m_a2 * ic1 + m_a3 * v3;
+                    ic1 = 2.0f * v1 - ic1;
+                    ic2 = 2.0f * v2 - ic2;
+
+                    const float lp = v2;
+                    const float bp = v1;
+                    const float hp = driven - m_k * v1 - v2;
+                    float filtered = outputForType(m_currentType, lp, bp, hp);
+                    if (xfade > 0.0f) {
+                        filtered += (outputForType(m_prevType, lp, bp, hp) - filtered) * xfade;
+                    }
+
+                    if (outputs[ch])
+                        outputs[ch][i] = x * dry + filtered * wet;
+                }
+
+                if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
+                    outputs[1][i] = outputs[0][i];
+                }
+                for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                    if (outputs[ch])
+                        outputs[ch][i] = 0.0f;
+                }
             }
         }
 
@@ -187,6 +248,8 @@ public:
     void setParameter(uint32_t id, float value) override {
         if (id >= kParamCount)
             return;
+        if (!std::isfinite(value))
+            return; // NaN survives clamp (comparisons are false) and would poison the SVF coefficients
         m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
     }
 
@@ -341,12 +404,33 @@ public:
     static float normFromType(Type type) { return static_cast<float>(type) / static_cast<float>(kTypeCount - 1); }
 
 private:
+    static constexpr uint32_t kCtrlInterval = 8; // control-rate interval for param/coefficient updates
+
+    static float outputForType(Type type, float lp, float bp, float hp) {
+        switch (type) {
+        case kTypeLowPass:
+            return lp;
+        case kTypeBandPass:
+            return bp;
+        default:
+            return hp;
+        }
+    }
+
     void resetRuntimeState() {
         m_ic1[0] = m_ic1[1] = 0.0f;
         m_ic2[0] = m_ic2[1] = 0.0f;
         m_envelope = 0.0f;
+        m_wasBypassed = false;
+        m_coeffsDirty = true;
+        m_currentType = typeFromNorm(getParameter(kType));
+        m_prevType = m_currentType;
+        m_typeXfadeRemaining = 0;
         const float sr = static_cast<float>(m_sampleRate);
-        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        // Smoothing runs once per control block, so the coefficient is scaled
+        // to the block interval to keep the 2 ms time constant.
+        m_smoothCoeff = 1.0f - std::exp(-static_cast<float>(kCtrlInterval) / (0.002f * sr));
+        m_typeXfadeLength = std::max(1u, static_cast<uint32_t>(0.003f * sr)); // ~3 ms
         m_envLevel.store(0.0f, std::memory_order_relaxed);
     }
 
@@ -355,7 +439,10 @@ private:
         m_resoSmoothed = getParameter(kReso);
         m_driveSmoothed = getParameter(kDrive);
         m_envAmtSmoothed = getParameter(kEnvAmount);
+        m_attackSmoothed = getParameter(kEnvAttack);
+        m_releaseSmoothed = getParameter(kEnvRelease);
         m_mixSmoothed = getParameter(kMix);
+        m_coeffsDirty = true;
     }
 
     // ── Utility ──
@@ -396,13 +483,42 @@ private:
     float m_ic2[2] = {0.0f, 0.0f};
 
     float m_envelope = 0.0f;
+    bool m_wasBypassed = false;
 
+    // Control-rate smoothed params
     float m_smoothCoeff = 0.0f;
     float m_cutoffSmoothed = 1.0f;
     float m_resoSmoothed = 0.116f;
     float m_driveSmoothed = 0.0f;
     float m_envAmtSmoothed = 0.5f;
+    float m_attackSmoothed = 0.567f;
+    float m_releaseSmoothed = 0.642f;
     float m_mixSmoothed = 1.0f;
+
+    // Cached coefficient inputs (recompute gated on movement)
+    bool m_coeffsDirty = true;
+    float m_resoCached = -1.0f;
+    float m_driveCached = -1.0f;
+    float m_attackCached = -1.0f;
+    float m_releaseCached = -1.0f;
+    float m_cutoffCached = -1.0f;
+    float m_k = 1.41421356f;
+    float m_driveGain = 1.0f;
+    float m_driveMakeup = 1.0f;
+    float m_attackCoeff = 0.0f;
+    float m_releaseCoeff = 0.0f;
+    float m_baseCutoffHz = 20000.0f;
+
+    // Interpolated TPT coefficients
+    float m_a1 = 0.0f;
+    float m_a2 = 0.0f;
+    float m_a3 = 0.0f;
+
+    // Type crossfade
+    Type m_currentType = kTypeLowPass;
+    Type m_prevType = kTypeLowPass;
+    uint32_t m_typeXfadeRemaining = 0;
+    uint32_t m_typeXfadeLength = 144;
 
     std::atomic<float> m_envLevel{0.0f};
 };

--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -99,7 +99,7 @@ public:
             m_envelope = 0.0f;
             snapSmoothedParams();
             m_coeffsDirty = true;
-            m_typeXfadeRemaining = 0;
+            snapTypeGains();
             m_wasBypassed = false;
         }
 
@@ -167,14 +167,13 @@ public:
                 da3 = (a3t - m_a3) * inv;
             }
 
-            // Type is stepped: crossfade LP/BP/HP over ~3 ms on change so
-            // automation cannot click (all three outputs are computed anyway).
-            const auto type = typeFromNorm(m_params[kType].load(std::memory_order_relaxed));
-            if (type != m_currentType) {
-                m_prevType = m_currentType;
-                m_currentType = type;
-                m_typeXfadeRemaining = m_typeXfadeLength;
-            }
+            // Type is stepped; each of LP/BP/HP carries a gain that continuously
+            // slews toward a one-hot target. A plain two-state crossfade drops
+            // the in-progress blend when a switch interrupts a fade (rapid
+            // LP->BP->HP), which can click; per-type gains morph through any
+            // interruption because the current audible blend is the state.
+            const uint32_t selType =
+                static_cast<uint32_t>(typeFromNorm(m_params[kType].load(std::memory_order_relaxed)));
 
             const float wet = m_mixSmoothed;
             const float dry = 1.0f - wet;
@@ -192,10 +191,10 @@ public:
                 const float envCoeff = (peak > m_envelope) ? m_attackCoeff : m_releaseCoeff;
                 m_envelope += (peak - m_envelope) * envCoeff;
 
-                float xfade = 0.0f;
-                if (m_typeXfadeRemaining > 0) {
-                    xfade = static_cast<float>(m_typeXfadeRemaining) / static_cast<float>(m_typeXfadeLength);
-                    --m_typeXfadeRemaining;
+                // Continuous per-type gain slew toward the one-hot selection.
+                for (uint32_t t = 0; t < kTypeCount; ++t) {
+                    const float target = (t == selType) ? 1.0f : 0.0f;
+                    m_typeGain[t] += (target - m_typeGain[t]) * m_typeCoeff;
                 }
 
                 for (uint32_t ch = 0; ch < channels; ++ch) {
@@ -215,10 +214,8 @@ public:
                     const float lp = v2;
                     const float bp = v1;
                     const float hp = driven - m_k * v1 - v2;
-                    float filtered = outputForType(m_currentType, lp, bp, hp);
-                    if (xfade > 0.0f) {
-                        filtered += (outputForType(m_prevType, lp, bp, hp) - filtered) * xfade;
-                    }
+                    const float filtered =
+                        m_typeGain[kTypeLowPass] * lp + m_typeGain[kTypeBandPass] * bp + m_typeGain[kTypeHighPass] * hp;
 
                     if (outputs[ch])
                         outputs[ch][i] = x * dry + filtered * wet;
@@ -420,15 +417,12 @@ public:
 private:
     static constexpr uint32_t kCtrlInterval = 8; // control-rate interval for param/coefficient updates
 
-    static float outputForType(Type type, float lp, float bp, float hp) {
-        switch (type) {
-        case kTypeLowPass:
-            return lp;
-        case kTypeBandPass:
-            return bp;
-        default:
-            return hp;
-        }
+    // Snap the per-type gains to the current one-hot selection so activation
+    // and bypass->active transitions do not morph the filter type.
+    void snapTypeGains() {
+        const uint32_t sel = static_cast<uint32_t>(typeFromNorm(getParameter(kType)));
+        for (uint32_t t = 0; t < kTypeCount; ++t)
+            m_typeGain[t] = (t == sel) ? 1.0f : 0.0f;
     }
 
     void resetRuntimeState() {
@@ -437,14 +431,12 @@ private:
         m_envelope = 0.0f;
         m_wasBypassed = false;
         m_coeffsDirty = true;
-        m_currentType = typeFromNorm(getParameter(kType));
-        m_prevType = m_currentType;
-        m_typeXfadeRemaining = 0;
         const float sr = static_cast<float>(m_sampleRate);
         // Smoothing runs once per control block, so the coefficient is scaled
         // to the block interval to keep the 2 ms time constant.
         m_smoothCoeff = 1.0f - std::exp(-static_cast<float>(kCtrlInterval) / (0.002f * sr));
-        m_typeXfadeLength = std::max(1u, static_cast<uint32_t>(0.003f * sr)); // ~3 ms
+        m_typeCoeff = 1.0f - std::exp(-1.0f / (0.003f * sr)); // ~3 ms type morph (per sample)
+        snapTypeGains();
         m_envLevel.store(0.0f, std::memory_order_relaxed);
     }
 
@@ -532,11 +524,10 @@ private:
     float m_a2 = 0.0f;
     float m_a3 = 0.0f;
 
-    // Type crossfade
-    Type m_currentType = kTypeLowPass;
-    Type m_prevType = kTypeLowPass;
-    uint32_t m_typeXfadeRemaining = 0;
-    uint32_t m_typeXfadeLength = 144;
+    // Continuous per-type morph: one gain per LP/BP/HP, slewed toward the
+    // one-hot selection so switches (even mid-morph) never drop the blend.
+    float m_typeGain[kTypeCount] = {1.0f, 0.0f, 0.0f};
+    float m_typeCoeff = 0.0f;
 
     std::atomic<float> m_envLevel{0.0f};
 };

--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -1,0 +1,412 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraFilter V1 — creative resonant filter with envelope-follower modulation.
+//
+// Topology-preserving-transform (ZDF) state-variable filter (Cytomic/Simper
+// form) so cutoff can be modulated per sample without zipper noise or
+// instability. An input peak follower drives the cutoff bipolarly (up to
+// ±4 octaves), which is what turns a static filter into an envelope shaper:
+// auto-wah upward sweeps, reverse "duck" filtering, dynamic brightness.
+//
+// Signal path (per channel, per sample):
+//   in -> drive (transparent-at-zero tanh blend) -> ZDF SVF (LP/BP/HP)
+//      -> mix with dry (zero latency — no compensation needed)
+//
+// The envelope is derived from the pre-drive stereo peak so drive changes
+// never re-tune the sweep.
+
+#pragma once
+
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace Plugins {
+
+class AestraFilter : public IPluginInstance {
+public:
+    static constexpr uint32_t kStateMagic = 0x464C5431; // 'FLT1'
+    static constexpr float kEnvModOctaves = 4.0f;
+
+    enum Param : uint32_t {
+        kType = 0,   // 0=LP, 1=BP, 2=HP (stepped)
+        kCutoff,     // 20 Hz to 20 kHz (log)
+        kReso,       // Q 0.5 to 10 (log)
+        kDrive,      // 0 to +18 dB pre-filter, transparent at 0
+        kEnvAmount,  // -100% to +100% (bipolar cutoff modulation)
+        kEnvAttack,  // 0.1 to 100 ms (log)
+        kEnvRelease, // 5 to 1000 ms (log)
+        kMix,        // 0% to 100%
+        kBypass,
+        kParamCount,
+    };
+
+    enum Type : uint32_t { kTypeLowPass = 0, kTypeBandPass, kTypeHighPass, kTypeCount };
+
+    AestraFilter() = default;
+
+    bool initialize(double sampleRate, uint32_t maxBlockSize) override {
+        (void)maxBlockSize;
+        m_sampleRate = std::max(1.0, sampleRate);
+        for (const auto& param : getParameters()) {
+            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        }
+        resetRuntimeState();
+        snapSmoothedParams();
+        return true;
+    }
+
+    void shutdown() override {}
+
+    void activate() override {
+        m_active.store(true, std::memory_order_relaxed);
+        resetRuntimeState();
+        snapSmoothedParams();
+    }
+
+    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
+    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* midiInput = nullptr, MidiBuffer* midiOutput = nullptr) override {
+        (void)midiInput;
+        (void)midiOutput;
+
+        if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            return;
+        }
+
+        const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
+        const bool stereo = channels >= 2;
+        const auto type = typeFromNorm(m_params[kType].load(std::memory_order_relaxed));
+        const float sr = static_cast<float>(m_sampleRate);
+        const float maxCutoff = 0.45f * sr;
+
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            // Smooth continuous params (2 ms one-pole, shared by both channels)
+            m_cutoffSmoothed += (getParameter(kCutoff) - m_cutoffSmoothed) * m_smoothCoeff;
+            m_resoSmoothed += (getParameter(kReso) - m_resoSmoothed) * m_smoothCoeff;
+            m_driveSmoothed += (getParameter(kDrive) - m_driveSmoothed) * m_smoothCoeff;
+            m_envAmtSmoothed += (getParameter(kEnvAmount) - m_envAmtSmoothed) * m_smoothCoeff;
+            m_mixSmoothed += (getParameter(kMix) - m_mixSmoothed) * m_smoothCoeff;
+
+            const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i));
+            const float inR = stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL;
+
+            // ── Envelope follower (pre-drive stereo peak) ──
+            const float peak = std::max(std::abs(inL), std::abs(inR));
+            const float attackMs = attackMsFromNorm(getParameter(kEnvAttack));
+            const float releaseMs = releaseMsFromNorm(getParameter(kEnvRelease));
+            const float coeffMs = (peak > m_envelope) ? attackMs : releaseMs;
+            const float envCoeff = 1.0f - std::exp(-1.0f / (coeffMs * 0.001f * sr));
+            m_envelope += (peak - m_envelope) * envCoeff;
+
+            // ── Cutoff with bipolar envelope modulation (octave domain) ──
+            const float envAmount = 2.0f * m_envAmtSmoothed - 1.0f;
+            const float baseCutoff = cutoffHzFromNorm(m_cutoffSmoothed);
+            const float modOctaves = envAmount * kEnvModOctaves * std::min(1.0f, m_envelope);
+            const float fc = std::clamp(baseCutoff * std::exp2(modOctaves), 20.0f, maxCutoff);
+
+            // ── ZDF SVF coefficients (shared by both channels) ──
+            const float g = std::tan(3.14159265358979323846f * fc / sr);
+            const float q = qFromNorm(m_resoSmoothed);
+            const float k = 1.0f / q;
+            const float a1 = 1.0f / (1.0f + g * (g + k));
+            const float a2 = g * a1;
+            const float a3 = g * a2;
+
+            // ── Drive: transparent at 0, tanh soft clip as it rises.
+            // 1/sqrt(G) makeup keeps perceived loudness roughly level: small
+            // signals gain sqrt(G) (+9 dB max), the clip ceiling sits at
+            // 1/sqrt(G) (-9 dB max) instead of collapsing to 1/G. ──
+            const float driveNorm = m_driveSmoothed;
+            const float driveGain = dbToLinear(driveDbFromNorm(driveNorm));
+            const float driveMakeup = 1.0f / std::sqrt(driveGain);
+
+            const float wet = m_mixSmoothed;
+            const float dry = 1.0f - wet;
+
+            for (uint32_t ch = 0; ch < channels; ++ch) {
+                const float x = (ch == 0) ? inL : inR;
+                const float driven = x + driveNorm * (std::tanh(driveGain * x) * driveMakeup - x);
+
+                float& ic1 = m_ic1[ch];
+                float& ic2 = m_ic2[ch];
+                const float v3 = driven - ic2;
+                const float v1 = a1 * ic1 + a2 * v3;
+                const float v2 = ic2 + a2 * ic1 + a3 * v3;
+                ic1 = 2.0f * v1 - ic1;
+                ic2 = 2.0f * v2 - ic2;
+
+                float filtered;
+                switch (type) {
+                case kTypeLowPass:
+                    filtered = v2;
+                    break;
+                case kTypeBandPass:
+                    filtered = v1;
+                    break;
+                default:
+                    filtered = driven - k * v1 - v2;
+                    break;
+                }
+
+                if (outputs[ch])
+                    outputs[ch][i] = x * dry + filtered * wet;
+            }
+
+            if (!stereo && numOutputChannels > 1 && outputs[1] && outputs[0]) {
+                outputs[1][i] = outputs[0][i];
+            }
+            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                if (outputs[ch])
+                    outputs[ch][i] = 0.0f;
+            }
+        }
+
+        m_envLevel.store(std::min(1.0f, m_envelope), std::memory_order_relaxed);
+    }
+
+    uint32_t getParameterCount() const override { return kParamCount; }
+
+    float getParameter(uint32_t id) const override {
+        if (id >= kParamCount)
+            return 0.0f;
+        return m_params[id].load(std::memory_order_relaxed);
+    }
+
+    void setParameter(uint32_t id, float value) override {
+        if (id >= kParamCount)
+            return;
+        m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    std::vector<PluginParameter> getParameters() const override {
+        return {
+            {kType, "Type", "TYP", "", 0.0f, 0.0f, 1.0f, true, false, false, kTypeCount - 1},
+            {kCutoff, "Cutoff", "CUT", "Hz", 1.0f, 0.0f, 1.0f, true},
+            {kReso, "Resonance", "RES", "", 0.116f, 0.0f, 1.0f, true}, // ~Q 0.707
+            {kDrive, "Drive", "DRV", "dB", 0.0f, 0.0f, 1.0f, true},
+            {kEnvAmount, "Envelope", "ENV", "%", 0.5f, 0.0f, 1.0f, true},    // center = off
+            {kEnvAttack, "Attack", "ATK", "ms", 0.567f, 0.0f, 1.0f, true},   // ~5 ms
+            {kEnvRelease, "Release", "REL", "ms", 0.642f, 0.0f, 1.0f, true}, // ~150 ms
+            {kMix, "Mix", "MIX", "%", 1.0f, 0.0f, 1.0f, true},
+            {kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1},
+        };
+    }
+
+    std::string getParameterDisplay(uint32_t id) const override {
+        if (id >= kParamCount)
+            return "";
+        const float v = getParameter(id);
+        char buf[32];
+        switch (id) {
+        case kType:
+            switch (typeFromNorm(v)) {
+            case kTypeLowPass:
+                return "Low Pass";
+            case kTypeBandPass:
+                return "Band Pass";
+            default:
+                return "High Pass";
+            }
+        case kCutoff: {
+            const float hz = cutoffHzFromNorm(v);
+            if (hz >= 1000.0f) {
+                std::snprintf(buf, sizeof(buf), "%.2f kHz", hz / 1000.0f);
+            } else {
+                std::snprintf(buf, sizeof(buf), "%.0f Hz", hz);
+            }
+            return buf;
+        }
+        case kReso:
+            std::snprintf(buf, sizeof(buf), "Q %.2f", qFromNorm(v));
+            return buf;
+        case kDrive:
+            std::snprintf(buf, sizeof(buf), "%.1f dB", driveDbFromNorm(v));
+            return buf;
+        case kEnvAmount:
+            std::snprintf(buf, sizeof(buf), "%+d%%", static_cast<int>(std::round((2.0f * v - 1.0f) * 100.0f)));
+            return buf;
+        case kEnvAttack:
+            std::snprintf(buf, sizeof(buf), "%.1f ms", attackMsFromNorm(v));
+            return buf;
+        case kEnvRelease:
+            std::snprintf(buf, sizeof(buf), "%.0f ms", releaseMsFromNorm(v));
+            return buf;
+        case kMix:
+            return std::to_string(static_cast<int>(std::round(v * 100.0f))) + "%";
+        case kBypass:
+            return v > 0.5f ? "ON" : "OFF";
+        default:
+            return "";
+        }
+    }
+
+    std::vector<uint8_t> saveState() const override {
+        struct Blob {
+            uint32_t magic = kStateMagic;
+            uint32_t version = 1;
+            float params[kParamCount] = {};
+        } blob;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            blob.params[i] = getParameter(i);
+        }
+        const auto* data = reinterpret_cast<const uint8_t*>(&blob);
+        return {data, data + sizeof(blob)};
+    }
+
+    bool loadState(const std::vector<uint8_t>& state) override {
+        if (state.size() < sizeof(uint32_t) * 2)
+            return false;
+        uint32_t magic = 0;
+        std::memcpy(&magic, state.data(), sizeof(magic));
+        if (magic != kStateMagic)
+            return false;
+        struct Blob {
+            uint32_t magic;
+            uint32_t version;
+            float params[kParamCount];
+        };
+        if (state.size() < sizeof(Blob))
+            return false;
+        Blob blob{};
+        std::memcpy(&blob, state.data(), sizeof(blob));
+        if (blob.version < 1 || blob.version > 1)
+            return false;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            setParameter(i, blob.params[i]);
+        }
+        return true;
+    }
+
+    bool hasEditor() const override { return true; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {520, 320}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 4096; } // resonant ring-out
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+    void setInfo(const PluginInfo& info) { m_info = info; }
+
+    // Metering (for the editor's envelope indicator)
+    float getEnvelopeLevel() const { return m_envLevel.load(std::memory_order_relaxed); }
+
+    // ── Parameter mapping (public: shared with editor/tests) ──
+    static float cutoffHzFromNorm(float value) {
+        // 20 Hz .. 20 kHz, log
+        return 20.0f * std::pow(1000.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float qFromNorm(float value) {
+        // 0.5 .. 10, log
+        return 0.5f * std::pow(20.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float driveDbFromNorm(float value) { return std::clamp(value, 0.0f, 1.0f) * 18.0f; }
+
+    static float attackMsFromNorm(float value) {
+        // 0.1 .. 100 ms, log
+        return 0.1f * std::pow(1000.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float releaseMsFromNorm(float value) {
+        // 5 .. 1000 ms, log
+        return 5.0f * std::pow(200.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static Type typeFromNorm(float value) {
+        return static_cast<Type>(std::min<uint32_t>(
+            kTypeCount - 1,
+            static_cast<uint32_t>(std::clamp(value, 0.0f, 1.0f) * static_cast<float>(kTypeCount - 1) + 0.5f)));
+    }
+
+    static float normFromType(Type type) { return static_cast<float>(type) / static_cast<float>(kTypeCount - 1); }
+
+private:
+    void resetRuntimeState() {
+        m_ic1[0] = m_ic1[1] = 0.0f;
+        m_ic2[0] = m_ic2[1] = 0.0f;
+        m_envelope = 0.0f;
+        const float sr = static_cast<float>(m_sampleRate);
+        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        m_envLevel.store(0.0f, std::memory_order_relaxed);
+    }
+
+    void snapSmoothedParams() {
+        m_cutoffSmoothed = getParameter(kCutoff);
+        m_resoSmoothed = getParameter(kReso);
+        m_driveSmoothed = getParameter(kDrive);
+        m_envAmtSmoothed = getParameter(kEnvAmount);
+        m_mixSmoothed = getParameter(kMix);
+    }
+
+    // ── Utility ──
+    static void copyOrClear(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                            uint32_t numOutputChannels, uint32_t numFrames) {
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
+    static float readInput(const float* const* inputs, uint32_t channels, uint32_t channel, uint32_t frame) {
+        if (channel >= channels || !inputs[channel]) {
+            return (channel == 1 && channels > 0 && inputs[0]) ? inputs[0][frame] : 0.0f;
+        }
+        return inputs[channel][frame];
+    }
+
+    static float sanitizeSample(float sample) {
+        if (!std::isfinite(sample))
+            return 0.0f;
+        return std::clamp(sample, -16.0f, 16.0f);
+    }
+
+    static float dbToLinear(float db) { return std::exp(db * 0.11512925464970229f); }
+
+    // ── State ──
+    PluginInfo m_info;
+    double m_sampleRate = 48000.0;
+    std::atomic<bool> m_active{false};
+    std::array<std::atomic<float>, kParamCount> m_params{};
+
+    // ZDF SVF integrator state, per channel
+    float m_ic1[2] = {0.0f, 0.0f};
+    float m_ic2[2] = {0.0f, 0.0f};
+
+    float m_envelope = 0.0f;
+
+    float m_smoothCoeff = 0.0f;
+    float m_cutoffSmoothed = 1.0f;
+    float m_resoSmoothed = 0.116f;
+    float m_driveSmoothed = 0.0f;
+    float m_envAmtSmoothed = 0.5f;
+    float m_mixSmoothed = 1.0f;
+
+    std::atomic<float> m_envLevel{0.0f};
+};
+
+} // namespace Plugins
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -346,6 +346,13 @@ public:
         std::memcpy(&blob, state.data(), sizeof(blob));
         if (blob.version < 1 || blob.version > 1)
             return false;
+        // Validate the entire decoded set before mutating anything. setParameter
+        // silently drops non-finite values, so applying in place would leave a
+        // half-updated state while still reporting success — fail atomically.
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            if (!std::isfinite(blob.params[i]) || blob.params[i] < 0.0f || blob.params[i] > 1.0f)
+                return false;
+        }
         for (uint32_t i = 0; i < kParamCount; ++i) {
             setParameter(i, blob.params[i]);
         }
@@ -361,7 +368,14 @@ public:
 
     const PluginInfo& getInfo() const override { return m_info; }
     uint32_t getLatencySamples() const override { return 0; }
-    uint32_t getTailSamples() const override { return 4096; } // resonant ring-out
+    uint32_t getTailSamples() const override {
+        // Resonant ring-out is sample-rate-relative: a 2-pole resonator's -60 dB
+        // decay is ~ln(1000)*Q/(pi*f0), so the worst case here (20 Hz cutoff,
+        // Q 10) rings ~1.1 s. A fixed 4096 samples truncated that ring in
+        // offline bounce and drifted with sample rate — report ~1.2 s scaled to
+        // the current rate.
+        return static_cast<uint32_t>(m_sampleRate * 1.2);
+    }
     WatchdogStats getWatchdogStats() const override { return {}; }
     void resetWatchdog() override {}
     bool isBypassedByWatchdog() const override { return false; }
@@ -450,7 +464,11 @@ private:
                             uint32_t numOutputChannels, uint32_t numFrames) {
         for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
             if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
-                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+                // Skip the copy when the host renders in place (out == in):
+                // memcpy on aliased buffers is undefined and the data is already
+                // where it needs to be.
+                if (outputs[ch] != inputs[ch])
+                    std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
             } else if (outputs[ch]) {
                 std::memset(outputs[ch], 0, numFrames * sizeof(float));
             }

--- a/AestraAudio/include/Plugin/BuiltInPlugins.h
+++ b/AestraAudio/include/Plugin/BuiltInPlugins.h
@@ -17,6 +17,7 @@ const PluginInfo& delayInfo();
 const PluginInfo& driftInfo();
 const PluginInfo& limiterInfo();
 const PluginInfo& satInfo();
+const PluginInfo& filterInfo();
 void registerCoreBuiltIns();
 std::vector<PluginInfo> all();
 }

--- a/AestraAudio/src/Plugin/BuiltInPlugins.cpp
+++ b/AestraAudio/src/Plugin/BuiltInPlugins.cpp
@@ -11,6 +11,7 @@
 #include "Plugin/AestraDrift.h"
 #include "Plugin/AestraLimit.h"
 #include "Plugin/AestraSat.h"
+#include "Plugin/AestraFilter.h"
 
 #include <mutex>
 
@@ -178,6 +179,26 @@ const PluginInfo& satInfo() {
     return info;
 }
 
+const PluginInfo& filterInfo() {
+    static const PluginInfo info = [] {
+        PluginInfo p;
+        p.id = "com.Aestrastudios.filter";
+        p.name = "Aestra Filter";
+        p.vendor = "Aestra Studios";
+        p.version = "0.1.0";
+        p.category = "Filter";
+        p.format = PluginFormat::Internal;
+        p.type = PluginType::Effect;
+        p.numAudioInputs = 2;
+        p.numAudioOutputs = 2;
+        p.hasMidiInput = false;
+        p.hasMidiOutput = false;
+        p.hasEditor = true;
+        return p;
+    }();
+    return info;
+}
+
 namespace {
 void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
     if (!instance) {
@@ -202,6 +223,8 @@ void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
         limit->setInfo(info);
     } else if (auto sat = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraSat>(instance)) {
         sat->setInfo(info);
+    } else if (auto filter = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraFilter>(instance)) {
+        filter->setInfo(info);
     }
 }
 
@@ -231,6 +254,7 @@ void registerCoreBuiltIns() {
         registry.registerPlugin(makeRegistration<Plugins::AestraDrift>(driftInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraLimit>(limiterInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraSat>(satInfo()));
+        registry.registerPlugin(makeRegistration<Plugins::AestraFilter>(filterInfo()));
     });
 }
 

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -151,6 +151,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/AestraLimitEditor.cpp
     Widgets/AestraSatEditor.h
     Widgets/AestraSatEditor.cpp
+    Widgets/AestraFilterEditor.h
+    Widgets/AestraFilterEditor.cpp
 )
 
 if(AESTRAUI_ENABLE_PREMIUM_EDITORS)

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -1,0 +1,303 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AestraFilterEditor.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "Plugin/AestraFilter.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace AestraUI {
+
+namespace {
+using Aestra::Audio::Plugins::AestraFilter;
+
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kKnobSweep = kPi * 1.5f;
+constexpr float kKnobStart = kPi * 0.75f; // pointing down-left, sweeping clockwise
+constexpr float kDragRangePx = 160.0f;    // full param range per drag distance
+
+NUIColor accent() {
+    return NUIColor(0.28f, 0.72f, 0.62f, 1.0f);
+} // filter teal
+NUIColor panelSurface() {
+    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+}
+NUIColor insetSurface() {
+    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+}
+
+void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
+             NUIColor color) {
+    if (endAngle < startAngle)
+        std::swap(startAngle, endAngle);
+    if (endAngle - startAngle <= 0.001f)
+        return;
+    std::array<NUIPoint, 49> pts{};
+    const float div = static_cast<float>(pts.size() - 1);
+    for (size_t i = 0; i < pts.size(); ++i) {
+        const float t = static_cast<float>(i) / div;
+        const float a = startAngle + (endAngle - startAngle) * t;
+        pts[i] = {center.x + std::cos(a) * radius, center.y + std::sin(a) * radius};
+    }
+    renderer.drawPolyline(pts.data(), static_cast<int>(pts.size()), thickness, color);
+}
+} // namespace
+
+AestraFilterEditor::AestraFilterEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance)
+    : m_instance(std::move(instance)) {
+    setId("AestraFilterEditor");
+    setPanelTitle("Aestra Filter");
+    setBadgeText("Filter");
+    setSize(kWinW, kWinH);
+    setEnforceParentBounds(true);
+    layoutControls();
+}
+
+void AestraFilterEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
+    AestraPanelWindow::setPlatformBridge(bridge);
+}
+
+void AestraFilterEditor::layoutControls() {
+    const auto b = getBounds();
+    const float contentTop = b.y + AestraPanelWindow::TITLE_BAR_H;
+
+    // Type selector: three segments across the top-left
+    constexpr float kSegW = 58.0f;
+    constexpr float kSegH = 26.0f;
+    for (size_t i = 0; i < m_typeRects.size(); ++i) {
+        m_typeRects[i] =
+            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kSegW + 6.0f), contentTop + 16.0f, kSegW, kSegH);
+    }
+
+    constexpr float kBypassW = 88.0f;
+    constexpr float kBypassH = 26.0f;
+    m_bypassRect = NUIRect(b.right() - 44.0f - kBypassW, contentTop + 16.0f, kBypassW, kBypassH);
+
+    // Large cutoff knob on the left; two rows of small knobs to its right
+    const float knobTop = contentTop + 58.0f;
+    m_cutoffRect = NUIRect(b.x + 44.0f, knobTop + 6.0f, 118.0f, 118.0f);
+    m_resoRect = NUIRect(b.x + 208.0f, knobTop, 66.0f, 66.0f);
+    m_driveRect = NUIRect(b.x + 314.0f, knobTop, 66.0f, 66.0f);
+    m_envRect = NUIRect(b.x + 420.0f, knobTop, 66.0f, 66.0f);
+    m_attackRect = NUIRect(b.x + 261.0f, knobTop + 96.0f, 54.0f, 54.0f);
+    m_releaseRect = NUIRect(b.x + 367.0f, knobTop + 96.0f, 54.0f, 54.0f);
+
+    const float sliderY = std::min(knobTop + 172.0f, b.bottom() - 44.0f);
+    m_mixRect = NUIRect(b.x + 58.0f, sliderY, b.width - 116.0f, 34.0f);
+}
+
+void AestraFilterEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    if (!m_instance)
+        return;
+
+    const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
+                           contentRect.height - 18.0f};
+    renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+
+    drawTypeSelector(renderer);
+    drawBypassPill(renderer);
+    drawKnob(renderer, m_cutoffRect, AestraFilter::kCutoff, "Cutoff", true, false);
+    drawKnob(renderer, m_resoRect, AestraFilter::kReso, "Reso", false, false);
+    drawKnob(renderer, m_driveRect, AestraFilter::kDrive, "Drive", false, false);
+    drawKnob(renderer, m_envRect, AestraFilter::kEnvAmount, "Env", false, true);
+    drawKnob(renderer, m_attackRect, AestraFilter::kEnvAttack, "Atk", false, false);
+    drawKnob(renderer, m_releaseRect, AestraFilter::kEnvRelease, "Rel", false, false);
+    drawMixSlider(renderer);
+}
+
+void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label,
+                                  bool large, bool bipolar) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float value = m_instance ? m_instance->getParameter(paramId) : 0.0f;
+    const NUIPoint c = rect.center();
+    const float r = rect.width * 0.5f - 4.0f;
+    const float angle = kKnobStart + value * kKnobSweep;
+
+    renderer.fillCircle(c, r + 4.0f, insetSurface());
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+
+    drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
+            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+    if (bipolar) {
+        // Bipolar knobs fill from the top-center detent toward the value.
+        const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
+        drawArc(renderer, c, r - 3.0f, std::min(centerAngle, angle), std::max(centerAngle, angle), 3.0f,
+                accent().withAlpha(0.92f));
+    } else {
+        drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
+    }
+
+    const float needleLen = r - (large ? 14.0f : 9.0f);
+    const NUIPoint tip(c.x + std::cos(angle) * needleLen, c.y + std::sin(angle) * needleLen);
+    renderer.drawLine(c, tip, 2.0f, accent().withAlpha(0.85f));
+    renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
+
+    const float wellR = r * (large ? 0.34f : 0.28f);
+    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
+
+    renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
+                              theme.getColor("textPrimary").withAlpha(0.95f));
+    const std::string valStr = m_instance ? m_instance->getParameterDisplay(paramId) : "";
+    renderer.drawTextCentered(valStr, NUIRect(rect.x - 14.0f, rect.bottom() + 19.0f, rect.width + 28.0f, 13.0f),
+                              large ? 10.0f : 9.0f, accent().withAlpha(0.96f));
+}
+
+void AestraFilterEditor::drawTypeSelector(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const auto type = m_instance ? AestraFilter::typeFromNorm(m_instance->getParameter(AestraFilter::kType))
+                                 : AestraFilter::kTypeLowPass;
+    static constexpr const char* kLabels[] = {"LP", "BP", "HP"};
+    for (size_t i = 0; i < m_typeRects.size(); ++i) {
+        const bool selected = static_cast<uint32_t>(type) == i;
+        if (selected) {
+            renderer.fillRoundedRect(m_typeRects[i], 7.0f, accent().withAlpha(0.26f));
+            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, accent().withAlpha(0.62f));
+            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 10.5f, accent().withAlpha(0.98f));
+        } else {
+            renderer.fillRoundedRect(m_typeRects[i], 7.0f, insetSurface());
+            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 10.5f,
+                                      theme.getColor("textPrimary").withAlpha(0.62f));
+        }
+    }
+}
+
+void AestraFilterEditor::drawBypassPill(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const bool bypassed = m_instance && m_instance->getParameter(AestraFilter::kBypass) > 0.5f;
+    constexpr float kRadius = 7.0f;
+    constexpr float kFont = 10.0f;
+    if (bypassed) {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 NUIColor(0.92f, 0.28f, 0.22f).withAlpha(m_bypassHovered ? 0.94f : 0.78f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, NUIColor(0.92f, 0.28f, 0.22f).withAlpha(0.50f));
+        renderer.drawTextCentered("BYPASSED", m_bypassRect, kFont, theme.getColor("textPrimary"));
+    } else {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 theme.getColor("success").withAlpha(m_bypassHovered ? 0.30f : 0.18f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, theme.getColor("success").withAlpha(0.40f));
+        renderer.drawTextCentered("ACTIVE", m_bypassRect, kFont, theme.getColor("success"));
+    }
+}
+
+void AestraFilterEditor::drawMixSlider(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float mix = m_instance ? m_instance->getParameter(AestraFilter::kMix) : 1.0f;
+    const NUIRect track(m_mixRect.x + 38.0f, m_mixRect.y + 12.0f, m_mixRect.width - 78.0f, 8.0f);
+
+    renderer.fillRoundedRect(m_mixRect, 10.0f, insetSurface());
+    renderer.strokeRoundedRect(m_mixRect, 10.0f, 1.0f, accent().withAlpha(m_draggingMix ? 0.62f : 0.34f));
+    renderer.drawText("Mix", {m_mixRect.x + 14.0f, m_mixRect.y + 11.0f}, 10.5f,
+                      theme.getColor("textPrimary").withAlpha(0.95f));
+    renderer.fillRoundedRect(track, 4.0f, NUIColor(1, 1, 1, 0.10f));
+    renderer.fillRoundedRect({track.x, track.y, track.width * mix, track.height}, 4.0f, accent().withAlpha(0.92f));
+    const NUIPoint thumb{track.x + track.width * mix, track.center().y};
+    renderer.fillCircle(thumb, 10.0f, accent().withAlpha(0.18f));
+    renderer.fillCircle(thumb, 7.0f, theme.getColor("textPrimary"));
+    const std::string pctStr = std::to_string(static_cast<int>(std::round(mix * 100.0f))) + "%";
+    const float pctW = renderer.measureText(pctStr, 10.0f).width;
+    renderer.drawText(pctStr, {m_mixRect.right() - 14.0f - pctW, m_mixRect.y + 10.0f}, 10.0f,
+                      accent().withAlpha(0.96f));
+}
+
+bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible())
+        return false;
+    if (AestraPanelWindow::onMouseEvent(event))
+        return true;
+    if (!m_instance)
+        return false;
+
+    const float mx = event.position.x;
+    const float my = event.position.y;
+
+    // Bypass pill
+    if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
+        const float cur = m_instance->getParameter(AestraFilter::kBypass);
+        m_instance->setParameter(AestraFilter::kBypass, cur > 0.5f ? 0.0f : 1.0f);
+        setDirty();
+        return true;
+    }
+    m_bypassHovered = m_bypassRect.contains(event.position);
+
+    // Type segments
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        for (size_t i = 0; i < m_typeRects.size(); ++i) {
+            if (m_typeRects[i].contains(event.position)) {
+                m_instance->setParameter(AestraFilter::kType,
+                                         AestraFilter::normFromType(static_cast<AestraFilter::Type>(i)));
+                setDirty();
+                return true;
+            }
+        }
+    }
+
+    // Knob vertical drag
+    if (m_draggingParam >= 0) {
+        if (event.released) {
+            m_draggingParam = -1;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float delta = (m_dragStartY - my) / kDragRangePx;
+            m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
+                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        const struct {
+            NUIRect rect;
+            uint32_t param;
+        } knobs[] = {
+            {m_cutoffRect, AestraFilter::kCutoff},    {m_resoRect, AestraFilter::kReso},
+            {m_driveRect, AestraFilter::kDrive},      {m_envRect, AestraFilter::kEnvAmount},
+            {m_attackRect, AestraFilter::kEnvAttack}, {m_releaseRect, AestraFilter::kEnvRelease},
+        };
+        for (const auto& k : knobs) {
+            if (k.rect.contains(event.position)) {
+                m_draggingParam = static_cast<int>(k.param);
+                m_dragStartY = my;
+                m_dragStartValue = m_instance->getParameter(k.param);
+                return true;
+            }
+        }
+    }
+
+    // Mix slider drag
+    const NUIRect mixTrack(m_mixRect.x + 38.0f, m_mixRect.y + 6.0f, m_mixRect.width - 78.0f, m_mixRect.height - 12.0f);
+    if (m_draggingMix) {
+        if (event.released) {
+            m_draggingMix = false;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float t = std::clamp((mx - mixTrack.x) / mixTrack.width, 0.0f, 1.0f);
+            m_instance->setParameter(AestraFilter::kMix, t);
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left && mixTrack.contains(event.position)) {
+        m_draggingMix = true;
+        const float t = std::clamp((mx - mixTrack.x) / mixTrack.width, 0.0f, 1.0f);
+        m_instance->setParameter(AestraFilter::kMix, t);
+        setDirty();
+        return true;
+    }
+
+    return false;
+}
+
+void AestraFilterEditor::onResize(int width, int height) {
+    AestraPanelWindow::onResize(width, height);
+    layoutControls();
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -185,10 +185,15 @@ void AestraFilterEditor::drawBypassPill(NUIRenderer& renderer) {
     }
 }
 
+NUIRect AestraFilterEditor::mixTrackRect() const {
+    return NUIRect(m_mixRect.x + 38.0f, m_mixRect.y + 6.0f, m_mixRect.width - 78.0f, m_mixRect.height - 12.0f);
+}
+
 void AestraFilterEditor::drawMixSlider(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
     const float mix = m_instance ? m_instance->getParameter(AestraFilter::kMix) : 1.0f;
-    const NUIRect track(m_mixRect.x + 38.0f, m_mixRect.y + 12.0f, m_mixRect.width - 78.0f, 8.0f);
+    const NUIRect hit = mixTrackRect();
+    const NUIRect track(hit.x, m_mixRect.y + 12.0f, hit.width, 8.0f);
 
     renderer.fillRoundedRect(m_mixRect, 10.0f, insetSurface());
     renderer.strokeRoundedRect(m_mixRect, 10.0f, 1.0f, accent().withAlpha(m_draggingMix ? 0.62f : 0.34f));
@@ -271,7 +276,7 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
     }
 
     // Mix slider drag
-    const NUIRect mixTrack(m_mixRect.x + 38.0f, m_mixRect.y + 6.0f, m_mixRect.width - 78.0f, m_mixRect.height - 12.0f);
+    const NUIRect mixTrack = mixTrackRect();
     if (m_draggingMix) {
         if (event.released) {
             m_draggingMix = false;

--- a/AestraUI/Widgets/AestraFilterEditor.h
+++ b/AestraUI/Widgets/AestraFilterEditor.h
@@ -1,0 +1,56 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraPanelWindow.h"
+#include "NUITypes.h"
+#include "PluginHost.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+namespace AestraUI {
+
+class AestraFilterEditor : public AestraPanelWindow {
+public:
+    explicit AestraFilterEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
+    void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    void onResize(int width, int height) override;
+    using AestraPanelWindow::onResize;
+    void onResize() { layoutControls(); }
+    void setPlatformBridge(NUIPlatformBridge* bridge) override;
+
+private:
+    void layoutControls();
+    void drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label, bool large,
+                  bool bipolar);
+    void drawTypeSelector(NUIRenderer& renderer);
+    void drawBypassPill(NUIRenderer& renderer);
+    void drawMixSlider(NUIRenderer& renderer);
+
+    std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
+
+    NUIRect m_cutoffRect;
+    NUIRect m_resoRect;
+    NUIRect m_driveRect;
+    NUIRect m_envRect;
+    NUIRect m_attackRect;
+    NUIRect m_releaseRect;
+    std::array<NUIRect, 3> m_typeRects{};
+    NUIRect m_mixRect;
+    NUIRect m_bypassRect;
+
+    // Vertical-drag knob state: which param is being dragged, and the value
+    // at drag start so movement is relative, not absolute.
+    int m_draggingParam = -1;
+    float m_dragStartY = 0.0f;
+    float m_dragStartValue = 0.0f;
+    bool m_draggingMix = false;
+    bool m_bypassHovered = false;
+
+    static constexpr float kWinW = 520.0f;
+    static constexpr float kWinH = 320.0f;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraFilterEditor.h
+++ b/AestraUI/Widgets/AestraFilterEditor.h
@@ -28,6 +28,9 @@ private:
     void drawTypeSelector(NUIRenderer& renderer);
     void drawBypassPill(NUIRenderer& renderer);
     void drawMixSlider(NUIRenderer& renderer);
+    // Shared mix-slider hit area, so the drawn track and the drag hit-test
+    // cannot drift apart. drawMixSlider renders a thinner visual bar inside it.
+    NUIRect mixTrackRect() const;
 
     std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
 

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -11,6 +11,7 @@
 #include "AestraDriftEditor.h"
 #include "AestraLimitEditor.h"
 #include "AestraSatEditor.h"
+#include "AestraFilterEditor.h"
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
@@ -400,6 +401,14 @@ void PluginUIController::openPluginEditor(
         });
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
+    } else if (pluginId == "com.Aestrastudios.filter") {
+        auto ed = std::make_shared<AestraFilterEditor>(instance);
+        ed->setOnClose([this, ed]() {
+            if (m_popupLayer) m_popupLayer->removeChild(ed);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
+        });
+        ed->setPlatformBridge(m_platformBridge);
+        editor = ed;
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
         ed->setOnClose([this, ed]() {
@@ -428,6 +437,8 @@ void PluginUIController::openPluginEditor(
             limit->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto sat = std::dynamic_pointer_cast<AestraSatEditor>(editorComp)) {
             sat->onResize(static_cast<int>(width), static_cast<int>(height));
+        } else if (auto filter = std::dynamic_pointer_cast<AestraFilterEditor>(editorComp)) {
+            filter->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto generic = std::dynamic_pointer_cast<GenericPluginEditor>(editorComp)) {
             generic->onResize();
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS

--- a/Tests/AestraAudio/AestraFilterBench.cpp
+++ b/Tests/AestraAudio/AestraFilterBench.cpp
@@ -39,13 +39,18 @@ double benchConfig(uint32_t instances, double sampleRate) {
     std::vector<float> outL(kBlockSize), outR(kBlockSize);
     const double w = 2.0 * 3.14159265358979323846 * 220.0 / sampleRate;
 
-    const auto t0 = std::chrono::steady_clock::now();
+    // Pre-generate a representative input block so the timed region measures
+    // only process(), not the oscillator that fills the buffer (~1M std::sin
+    // calls per config would otherwise pollute us/callback at low instance
+    // counts).
     double phase = 0.0;
+    for (uint32_t i = 0; i < kBlockSize; ++i) {
+        inL[i] = inR[i] = static_cast<float>(0.5 * std::sin(phase));
+        phase += w;
+    }
+
+    const auto t0 = std::chrono::steady_clock::now();
     for (uint32_t b = 0; b < kBlocks; ++b) {
-        for (uint32_t i = 0; i < kBlockSize; ++i) {
-            inL[i] = inR[i] = static_cast<float>(0.5 * std::sin(phase));
-            phase += w;
-        }
         for (auto& f : filters) {
             const float* ins[] = {inL.data(), inR.data()};
             float* outs[] = {outL.data(), outR.data()};

--- a/Tests/AestraAudio/AestraFilterBench.cpp
+++ b/Tests/AestraAudio/AestraFilterBench.cpp
@@ -1,0 +1,76 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraFilterBench — multi-instance throughput benchmark for AestraFilter.
+//
+// Measures 1/4/8/16 instances at 44.1/48/96 kHz and reports per-callback cost
+// against the audio deadline. Run on the Folio-class target before merging
+// DSP changes; CI never runs this (gated behind AESTRA_ENABLE_EXPERIMENTAL_TESTS).
+
+#include "Plugin/AestraFilter.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraFilter;
+
+namespace {
+
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kBlocks = 4000; // ~21 s of audio at 48 kHz per config
+
+double benchConfig(uint32_t instances, double sampleRate) {
+    std::vector<std::unique_ptr<AestraFilter>> filters;
+    for (uint32_t n = 0; n < instances; ++n) {
+        auto f = std::make_unique<AestraFilter>();
+        f->initialize(sampleRate, kBlockSize);
+        // Worst-ish case: envelope modulation active, resonant, driven
+        f->setParameter(AestraFilter::kCutoff, 0.4f);
+        f->setParameter(AestraFilter::kReso, 0.8f);
+        f->setParameter(AestraFilter::kDrive, 0.7f);
+        f->setParameter(AestraFilter::kEnvAmount, 0.9f);
+        f->activate();
+        filters.push_back(std::move(f));
+    }
+
+    std::vector<float> inL(kBlockSize), inR(kBlockSize);
+    std::vector<float> outL(kBlockSize), outR(kBlockSize);
+    const double w = 2.0 * 3.14159265358979323846 * 220.0 / sampleRate;
+
+    const auto t0 = std::chrono::steady_clock::now();
+    double phase = 0.0;
+    for (uint32_t b = 0; b < kBlocks; ++b) {
+        for (uint32_t i = 0; i < kBlockSize; ++i) {
+            inL[i] = inR[i] = static_cast<float>(0.5 * std::sin(phase));
+            phase += w;
+        }
+        for (auto& f : filters) {
+            const float* ins[] = {inL.data(), inR.data()};
+            float* outs[] = {outL.data(), outR.data()};
+            f->process(ins, outs, 2, 2, kBlockSize);
+        }
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+    return std::chrono::duration<double>(t1 - t0).count();
+}
+
+} // namespace
+
+int main() {
+    std::printf("AestraFilter multi-instance benchmark (block %u, %u blocks/config)\n", kBlockSize, kBlocks);
+    std::printf("%-10s %-10s %-12s %-14s %-10s\n", "rate", "instances", "wall (s)", "us/callback", "% budget");
+
+    for (double sr : {44100.0, 48000.0, 96000.0}) {
+        const double budgetUs = 1.0e6 * kBlockSize / sr; // real-time deadline per callback
+        for (uint32_t n : {1u, 4u, 8u, 16u}) {
+            const double secs = benchConfig(n, sr);
+            const double usPerCallback = secs * 1.0e6 / kBlocks;
+            std::printf("%-10.0f %-10u %-12.3f %-14.2f %-10.1f\n", sr, n, secs, usPerCallback,
+                        100.0 * usPerCallback / budgetUs);
+        }
+    }
+    std::printf("Values are for this machine; gate merges on the Folio-class target.\n");
+    return 0;
+}

--- a/Tests/AestraAudio/AestraFilterPluginTest.cpp
+++ b/Tests/AestraAudio/AestraFilterPluginTest.cpp
@@ -100,17 +100,29 @@ bool testBypassPassesAudioUnchanged() {
     flt.setParameter(AestraFilter::kCutoff, 0.1f);
     flt.activate();
 
-    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
-    const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
-    auto out = processStereo(flt, inL, inR);
+    const auto refL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto refR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
 
-    for (uint32_t i = 0; i < inL.size(); ++i) {
-        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
-            return false;
-        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+    // (a) Separate buffers: bypass is a pure passthrough, so require exact
+    // byte-for-byte equality (not epsilon) on both channels.
+    auto out = processStereo(flt, refL, refR);
+    for (uint32_t i = 0; i < refL.size(); ++i) {
+        if (out.left[i] != refL[i] || out.right[i] != refR[i])
             return false;
     }
-    return true;
+
+    // (b) In-place buffers (output == input): the copyOrClear in-place guard
+    // must leave the samples untouched (and finite) on both channels.
+    std::vector<float> ioL = refL;
+    std::vector<float> ioR = refR;
+    const float* ins[] = {ioL.data(), ioR.data()};
+    float* outs[] = {ioL.data(), ioR.data()};
+    flt.process(ins, outs, 2, 2, static_cast<uint32_t>(ioL.size()));
+    for (uint32_t i = 0; i < refL.size(); ++i) {
+        if (ioL[i] != refL[i] || ioR[i] != refR[i])
+            return false;
+    }
+    return allFinite(ioL) && allFinite(ioR);
 }
 
 bool testSilenceProducesSilence() {
@@ -121,7 +133,8 @@ bool testSilenceProducesSilence() {
 
     const auto silence = makeSilence(4096);
     auto out = processStereo(flt, silence, silence);
-    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f && allFinite(out.left) &&
+           allFinite(out.right);
 }
 
 bool testLowPassResponse() {
@@ -437,6 +450,45 @@ bool testTypeSwitchIsClickFree() {
     return maxDelta < 0.15f;
 }
 
+// Rapid LP->BP->HP automation, switching faster than the type morph completes,
+// must stay continuous: the per-type-gain morph must not drop an in-progress
+// blend (a two-state crossfade would, and click).
+bool testRapidTypeAutomationIsStable() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kCutoff, normForHz(1000.0f));
+    flt.setParameter(AestraFilter::kReso, 0.3f);
+    flt.activate();
+
+    const auto in = makeSine(48000, 1000.0f, 0.5f, kSampleRate);
+    std::vector<float> outL(in.size(), 0.0f);
+    std::vector<float> outR(in.size(), 0.0f);
+    const AestraFilter::Type seq[] = {AestraFilter::kTypeLowPass, AestraFilter::kTypeBandPass,
+                                      AestraFilter::kTypeHighPass};
+    uint32_t pos = 0;
+    uint32_t s = 0;
+    while (pos < in.size()) {
+        // Switch every ~0.77 ms — well inside the ~3 ms morph, so every switch
+        // interrupts the previous one.
+        flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(seq[s % 3]));
+        ++s;
+        const uint32_t n = std::min<uint32_t>(37, static_cast<uint32_t>(in.size()) - pos);
+        const float* ins[] = {in.data() + pos, in.data() + pos};
+        float* outs[] = {outL.data() + pos, outR.data() + pos};
+        flt.process(ins, outs, 2, 2, n);
+        pos += n;
+    }
+
+    if (!allFinite(outL) || !allFinite(outR))
+        return false;
+    float maxDelta = 0.0f;
+    for (uint32_t i = 1; i < outL.size(); ++i)
+        maxDelta = std::max(maxDelta, std::abs(outL[i] - outL[i - 1]));
+    // Continuous morph keeps steps near the signal's own ~0.065/sample; a
+    // dropped-blend click would be a large fraction of the 0.5 amplitude.
+    return maxDelta < 0.15f;
+}
+
 // Rapid automation of every continuous parameter, with hostile block sizes.
 bool testAutomationStress() {
     AestraFilter flt;
@@ -524,6 +576,7 @@ int main() {
         {"SetParameterRejectsNonFinite", testSetParameterRejectsNonFinite},
         {"BypassToggleIsSafe", testBypassToggleIsSafe},
         {"TypeSwitchIsClickFree", testTypeSwitchIsClickFree},
+        {"RapidTypeAutomationIsStable", testRapidTypeAutomationIsStable},
         {"AutomationStress", testAutomationStress},
         {"StableAcrossSampleRates", testStableAcrossSampleRates},
     };

--- a/Tests/AestraAudio/AestraFilterPluginTest.cpp
+++ b/Tests/AestraAudio/AestraFilterPluginTest.cpp
@@ -1,0 +1,417 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraFilterTest — DSP contract tests for the envelope-modulated SVF.
+
+#include "Plugin/AestraFilter.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraFilter;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 512;
+
+struct StereoBuffer {
+    std::vector<float> left;
+    std::vector<float> right;
+};
+
+StereoBuffer processStereo(AestraFilter& flt, const std::vector<float>& inL, const std::vector<float>& inR) {
+    StereoBuffer out{std::vector<float>(inL.size(), 0.0f), std::vector<float>(inR.size(), 0.0f)};
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {out.left.data(), out.right.data()};
+    flt.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+    return out;
+}
+
+std::vector<float> makeSine(uint32_t numSamples, float freq, float amp, double sampleRate) {
+    std::vector<float> buf(numSamples);
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    for (uint32_t i = 0; i < numSamples; ++i)
+        buf[i] = static_cast<float>(amp * std::sin(w * static_cast<double>(i)));
+    return buf;
+}
+
+std::vector<float> makeSilence(uint32_t numSamples) {
+    return std::vector<float>(numSamples, 0.0f);
+}
+
+float peakAmplitude(const std::vector<float>& buf, size_t start = 0) {
+    float peak = 0.0f;
+    for (size_t i = start; i < buf.size(); ++i)
+        peak = std::max(peak, std::abs(buf[i]));
+    return peak;
+}
+
+bool allFinite(const std::vector<float>& buf) {
+    for (float s : buf) {
+        if (!std::isfinite(s))
+            return false;
+    }
+    return true;
+}
+
+/// Goertzel magnitude of one bin, normalized so a unit sine reads 1.0.
+float goertzelMag(const std::vector<float>& buf, size_t start, float freq, double sampleRate) {
+    const size_t n = buf.size() - start;
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (size_t i = start; i < buf.size(); ++i) {
+        s0 = buf[i] + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    return static_cast<float>(2.0 * std::sqrt(std::max(0.0, power)) / static_cast<double>(n));
+}
+
+// Configure, activate, feed a sine, return steady-state magnitude at its own
+// frequency (i.e. one point of the transfer function).
+float sineResponse(AestraFilter::Type type, float cutoffNorm, float resoNorm, float freq) {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(type));
+    flt.setParameter(AestraFilter::kCutoff, cutoffNorm);
+    flt.setParameter(AestraFilter::kReso, resoNorm);
+    flt.activate();
+
+    const auto in = makeSine(16384, freq, 0.1f, kSampleRate);
+    auto out = processStereo(flt, in, in);
+    return goertzelMag(out.left, 8192, freq, kSampleRate) / 0.1f;
+}
+
+float normForHz(float hz) {
+    // Inverse of cutoffHzFromNorm: 20 * 1000^v
+    return std::log(hz / 20.0f) / std::log(1000.0f);
+}
+
+bool testBypassPassesAudioUnchanged() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kBypass, 1.0f);
+    flt.setParameter(AestraFilter::kCutoff, 0.1f);
+    flt.activate();
+
+    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
+    auto out = processStereo(flt, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
+            return false;
+        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testSilenceProducesSilence() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kReso, 1.0f); // max Q must not self-oscillate
+    flt.activate();
+
+    const auto silence = makeSilence(4096);
+    auto out = processStereo(flt, silence, silence);
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+}
+
+bool testLowPassResponse() {
+    const float cutoff = normForHz(500.0f);
+    const float passband = sineResponse(AestraFilter::kTypeLowPass, cutoff, 0.116f, 100.0f);
+    const float stopband = sineResponse(AestraFilter::kTypeLowPass, cutoff, 0.116f, 5000.0f);
+    // 100 Hz well below 500 Hz cutoff: ~unity. 5 kHz is ~3.3 octaves above:
+    // 12 dB/oct SVF gives ~-40 dB.
+    return passband > 0.9f && passband < 1.1f && stopband < 0.05f;
+}
+
+bool testHighPassResponse() {
+    const float cutoff = normForHz(2000.0f);
+    const float passband = sineResponse(AestraFilter::kTypeHighPass, cutoff, 0.116f, 10000.0f);
+    const float stopband = sineResponse(AestraFilter::kTypeHighPass, cutoff, 0.116f, 100.0f);
+    return passband > 0.85f && passband < 1.15f && stopband < 0.05f;
+}
+
+bool testBandPassResponse() {
+    const float cutoff = normForHz(1000.0f);
+    const float center = sineResponse(AestraFilter::kTypeBandPass, cutoff, 0.5f, 1000.0f);
+    const float below = sineResponse(AestraFilter::kTypeBandPass, cutoff, 0.5f, 100.0f);
+    const float above = sineResponse(AestraFilter::kTypeBandPass, cutoff, 0.5f, 10000.0f);
+    return center > 0.7f && below < 0.2f && above < 0.2f;
+}
+
+bool testResonancePeaks() {
+    const float cutoff = normForHz(1000.0f);
+    const float lowQ = sineResponse(AestraFilter::kTypeLowPass, cutoff, 0.116f, 1000.0f);
+    const float highQ = sineResponse(AestraFilter::kTypeLowPass, cutoff, 1.0f, 1000.0f);
+    // At the cutoff, Q=0.707 sits at ~-3 dB, Q=10 peaks at ~+20 dB.
+    return highQ > 4.0f * lowQ && highQ > 5.0f;
+}
+
+bool testHighResonanceStaysBounded() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kReso, 1.0f);
+    flt.setParameter(AestraFilter::kCutoff, normForHz(1000.0f));
+    flt.activate();
+
+    // Impulse into max resonance: must ring but decay, never blow up.
+    std::vector<float> in(48000, 0.0f);
+    in[0] = 1.0f;
+    auto out = processStereo(flt, in, in);
+    if (!allFinite(out.left))
+        return false;
+    if (peakAmplitude(out.left) > 16.0f)
+        return false;
+    // Ring must have decayed to noise floor within a second.
+    return peakAmplitude(out.left, 40000) < 1e-4f;
+}
+
+// The envelope shaper: with positive env amount, loud input must open the
+// filter (more high-frequency content passes than with env amount at zero).
+bool testEnvelopeOpensFilter() {
+    auto highBandLevel = [](float envAmountNorm) {
+        AestraFilter flt;
+        flt.initialize(kSampleRate, kBlockSize);
+        flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(AestraFilter::kTypeLowPass));
+        flt.setParameter(AestraFilter::kCutoff, normForHz(200.0f));
+        flt.setParameter(AestraFilter::kEnvAmount, envAmountNorm);
+        flt.setParameter(AestraFilter::kEnvAttack, 0.0f); // fastest
+        flt.activate();
+
+        // Loud 100 Hz carrier (drives the envelope) + quiet 4 kHz probe.
+        const auto lo = makeSine(24000, 100.0f, 0.8f, kSampleRate);
+        const auto hi = makeSine(24000, 4000.0f, 0.05f, kSampleRate);
+        std::vector<float> in(lo.size());
+        for (size_t i = 0; i < in.size(); ++i)
+            in[i] = lo[i] + hi[i];
+        AestraFilter& ref = flt;
+        auto out = processStereo(ref, in, in);
+        return goertzelMag(out.left, 12000, 4000.0f, kSampleRate);
+    };
+
+    const float closed = highBandLevel(0.5f); // env amount 0
+    const float open = highBandLevel(1.0f);   // env amount +100%
+    // +4 octaves on a 0.8-peak envelope moves 200 Hz cutoff well past 2 kHz:
+    // the 4 kHz probe must come through much stronger.
+    return open > 4.0f * closed;
+}
+
+// Negative env amount must close the filter instead.
+bool testNegativeEnvelopeClosesFilter() {
+    auto probeLevel = [](float envAmountNorm) {
+        AestraFilter flt;
+        flt.initialize(kSampleRate, kBlockSize);
+        flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(AestraFilter::kTypeLowPass));
+        flt.setParameter(AestraFilter::kCutoff, normForHz(2000.0f));
+        flt.setParameter(AestraFilter::kEnvAmount, envAmountNorm);
+        flt.setParameter(AestraFilter::kEnvAttack, 0.0f);
+        flt.activate();
+
+        const auto lo = makeSine(24000, 100.0f, 0.8f, kSampleRate);
+        const auto probe = makeSine(24000, 1000.0f, 0.05f, kSampleRate);
+        std::vector<float> in(lo.size());
+        for (size_t i = 0; i < in.size(); ++i)
+            in[i] = lo[i] + probe[i];
+        auto out = processStereo(flt, in, in);
+        return goertzelMag(out.left, 12000, 1000.0f, kSampleRate);
+    };
+
+    const float neutral = probeLevel(0.5f);
+    const float ducked = probeLevel(0.0f); // env amount -100%
+    return ducked < 0.5f * neutral;
+}
+
+bool testDriveZeroIsTransparent() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    // Cutoff fully open, drive 0, mix 100%: output ~= input minus the small
+    // response of a 20 kHz LP at low frequencies.
+    flt.setParameter(AestraFilter::kCutoff, 1.0f);
+    flt.setParameter(AestraFilter::kDrive, 0.0f);
+    flt.activate();
+
+    const float freq = 200.0f;
+    const auto in = makeSine(16384, freq, 0.5f, kSampleRate);
+    auto out = processStereo(flt, in, in);
+    const float mag = goertzelMag(out.left, 8192, freq, kSampleRate) / 0.5f;
+    return mag > 0.98f && mag < 1.02f;
+}
+
+bool testDriveAddsHarmonics() {
+    auto thirdHarmonic = [](float driveNorm) {
+        AestraFilter flt;
+        flt.initialize(kSampleRate, kBlockSize);
+        flt.setParameter(AestraFilter::kCutoff, 1.0f);
+        flt.setParameter(AestraFilter::kDrive, driveNorm);
+        flt.activate();
+
+        const float freq = 500.0f;
+        const auto in = makeSine(16384, freq, 0.5f, kSampleRate);
+        auto out = processStereo(flt, in, in);
+        return goertzelMag(out.left, 8192, 3.0f * freq, kSampleRate);
+    };
+
+    const float clean = thirdHarmonic(0.0f);
+    const float driven = thirdHarmonic(1.0f);
+    return driven > 0.01f && driven > 10.0f * clean;
+}
+
+bool testMixZeroIsIdentity() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kMix, 0.0f);
+    flt.setParameter(AestraFilter::kCutoff, 0.0f); // fully closed LP
+    flt.setParameter(AestraFilter::kDrive, 1.0f);
+    flt.activate();
+
+    const auto in = makeSine(4096, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(flt, in, in);
+    for (uint32_t i = 0; i < in.size(); ++i) {
+        if (std::abs(out.left[i] - in[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testSurvivesHostileInput() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kReso, 1.0f);
+    flt.setParameter(AestraFilter::kDrive, 1.0f);
+    flt.activate();
+
+    std::vector<float> in(2048, 0.0f);
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = (i % 2 == 0) ? 100.0f : -100.0f;
+    in[100] = std::numeric_limits<float>::quiet_NaN();
+    in[200] = std::numeric_limits<float>::infinity();
+    in[300] = -std::numeric_limits<float>::infinity();
+
+    auto out = processStereo(flt, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+bool testStateRoundTrip() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.activate();
+    flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(AestraFilter::kTypeBandPass));
+    flt.setParameter(AestraFilter::kCutoff, 0.42f);
+    flt.setParameter(AestraFilter::kReso, 0.8f);
+    flt.setParameter(AestraFilter::kDrive, 0.3f);
+    flt.setParameter(AestraFilter::kEnvAmount, 0.75f);
+    flt.setParameter(AestraFilter::kEnvAttack, 0.2f);
+    flt.setParameter(AestraFilter::kEnvRelease, 0.9f);
+    flt.setParameter(AestraFilter::kMix, 0.6f);
+
+    const auto state = flt.saveState();
+
+    AestraFilter restored;
+    restored.initialize(kSampleRate, kBlockSize);
+    restored.activate();
+    if (!restored.loadState(state))
+        return false;
+
+    for (uint32_t i = 0; i < AestraFilter::kParamCount; ++i) {
+        if (std::abs(restored.getParameter(i) - flt.getParameter(i)) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testLoadStateRejectsGarbage() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.activate();
+
+    std::vector<uint8_t> tooShort = {0x31, 0x54};
+    if (flt.loadState(tooShort))
+        return false;
+
+    std::vector<uint8_t> wrongMagic(64, 0);
+    if (flt.loadState(wrongMagic))
+        return false;
+    return true;
+}
+
+bool testTypeMapping() {
+    if (AestraFilter::typeFromNorm(0.0f) != AestraFilter::kTypeLowPass)
+        return false;
+    if (AestraFilter::typeFromNorm(0.5f) != AestraFilter::kTypeBandPass)
+        return false;
+    if (AestraFilter::typeFromNorm(1.0f) != AestraFilter::kTypeHighPass)
+        return false;
+    return AestraFilter::typeFromNorm(AestraFilter::normFromType(AestraFilter::kTypeBandPass)) ==
+           AestraFilter::kTypeBandPass;
+}
+
+bool testStableAcrossSampleRates() {
+    for (double sr : {44100.0, 96000.0, 192000.0}) {
+        AestraFilter flt;
+        flt.initialize(sr, kBlockSize);
+        flt.setParameter(AestraFilter::kReso, 1.0f);
+        flt.setParameter(AestraFilter::kCutoff, 1.0f); // 20 kHz — near Nyquist at 44.1k
+        flt.activate();
+
+        const auto in = makeSine(8192, 1000.0f, 0.5f, sr);
+        auto out = processStereo(flt, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+        if (peakAmplitude(out.left, 2048) > 16.0f)
+            return false;
+    }
+    return true;
+}
+
+struct TestCase {
+    const char* name;
+    bool (*fn)();
+};
+
+} // namespace
+
+int main() {
+    const TestCase tests[] = {
+        {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
+        {"SilenceProducesSilence", testSilenceProducesSilence},
+        {"LowPassResponse", testLowPassResponse},
+        {"HighPassResponse", testHighPassResponse},
+        {"BandPassResponse", testBandPassResponse},
+        {"ResonancePeaks", testResonancePeaks},
+        {"HighResonanceStaysBounded", testHighResonanceStaysBounded},
+        {"EnvelopeOpensFilter", testEnvelopeOpensFilter},
+        {"NegativeEnvelopeClosesFilter", testNegativeEnvelopeClosesFilter},
+        {"DriveZeroIsTransparent", testDriveZeroIsTransparent},
+        {"DriveAddsHarmonics", testDriveAddsHarmonics},
+        {"MixZeroIsIdentity", testMixZeroIsIdentity},
+        {"SurvivesHostileInput", testSurvivesHostileInput},
+        {"StateRoundTrip", testStateRoundTrip},
+        {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
+        {"TypeMapping", testTypeMapping},
+        {"StableAcrossSampleRates", testStableAcrossSampleRates},
+    };
+
+    int failures = 0;
+    for (const auto& test : tests) {
+        const bool passed = test.fn();
+        std::cout << (passed ? "[PASS] " : "[FAIL] ") << test.name << "\n";
+        if (!passed)
+            ++failures;
+    }
+
+    if (failures > 0) {
+        std::cout << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All AestraFilter tests passed\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AestraFilterPluginTest.cpp
+++ b/Tests/AestraAudio/AestraFilterPluginTest.cpp
@@ -354,6 +354,129 @@ bool testTypeMapping() {
            AestraFilter::kTypeBandPass;
 }
 
+// NaN/Inf must not pass the parameter ingress: the previous value survives,
+// and a NaN-filled (but magic-intact) state blob cannot poison processing.
+bool testSetParameterRejectsNonFinite() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.activate();
+    flt.setParameter(AestraFilter::kCutoff, 0.42f);
+
+    for (float bad : {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity(),
+                      -std::numeric_limits<float>::infinity()}) {
+        flt.setParameter(AestraFilter::kCutoff, bad);
+        if (std::abs(flt.getParameter(AestraFilter::kCutoff) - 0.42f) > 1e-6f)
+            return false;
+    }
+
+    std::vector<uint8_t> state = flt.saveState();
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
+        std::memcpy(state.data() + off, &nan, sizeof(float));
+    }
+    flt.loadState(state);
+    for (uint32_t i = 0; i < AestraFilter::kParamCount; ++i) {
+        if (!std::isfinite(flt.getParameter(i)))
+            return false;
+    }
+
+    const auto in = makeSine(2048, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(flt, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Toggling bypass mid-stream must not replay stale resonance/envelope state.
+bool testBypassToggleIsSafe() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kReso, 1.0f); // max Q rings hard
+    flt.setParameter(AestraFilter::kCutoff, normForHz(1000.0f));
+    flt.activate();
+
+    const auto loud = makeSine(8192, 1000.0f, 0.9f, kSampleRate);
+    processStereo(flt, loud, loud); // charge the integrators at resonance
+
+    flt.setParameter(AestraFilter::kBypass, 1.0f);
+    const auto quiet = makeSine(4096, 200.0f, 0.05f, kSampleRate);
+    auto bypassed = processStereo(flt, quiet, quiet);
+    for (uint32_t i = 0; i < quiet.size(); ++i) {
+        if (std::abs(bypassed.left[i] - quiet[i]) > 1e-6f)
+            return false; // zero-latency bypass stays bit-exact
+    }
+
+    // Resume: no burst of stale high-Q ring from the loud era.
+    flt.setParameter(AestraFilter::kBypass, 0.0f);
+    auto resumed = processStereo(flt, quiet, quiet);
+    if (!allFinite(resumed.left))
+        return false;
+    return peakAmplitude(resumed.left) < 0.4f; // 0.05 input, Q10 peak ~+20 dB worst case
+}
+
+// Type is stepped; switching LP -> HP mid-stream must crossfade, not click.
+bool testTypeSwitchIsClickFree() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.setParameter(AestraFilter::kCutoff, normForHz(1000.0f));
+    flt.activate();
+
+    const auto in = makeSine(16384, 1000.0f, 0.5f, kSampleRate);
+    // First half LP...
+    std::vector<float> half1(in.begin(), in.begin() + 8192);
+    auto out1 = processStereo(flt, half1, half1);
+    // ...switch to HP for the second half.
+    flt.setParameter(AestraFilter::kType, AestraFilter::normFromType(AestraFilter::kTypeHighPass));
+    std::vector<float> half2(in.begin() + 8192, in.end());
+    auto out2 = processStereo(flt, half2, half2);
+
+    // A 1 kHz 0.5-amp sine at 48 kHz moves at most ~0.065/sample; an
+    // instantaneous LP->HP jump at the cutoff is a ~90 degree phase step.
+    float maxDelta = std::abs(out2.left[0] - out1.left.back());
+    for (uint32_t i = 1; i < out2.left.size(); ++i)
+        maxDelta = std::max(maxDelta, std::abs(out2.left[i] - out2.left[i - 1]));
+    return maxDelta < 0.15f;
+}
+
+// Rapid automation of every continuous parameter, with hostile block sizes.
+bool testAutomationStress() {
+    AestraFilter flt;
+    flt.initialize(kSampleRate, kBlockSize);
+    flt.activate();
+
+    uint32_t lcg = 0xC0FFEEu;
+    auto next01 = [&lcg]() {
+        lcg = lcg * 1664525u + 1013904223u;
+        return static_cast<float>(lcg >> 8) * (1.0f / 16777216.0f);
+    };
+
+    const auto in = makeSine(96000, 500.0f, 0.5f, kSampleRate); // 2 s
+    std::vector<float> outL(in.size(), 0.0f);
+    std::vector<float> outR(in.size(), 0.0f);
+    const uint32_t sizes[] = {1, 3, 17, 32, 64, 111};
+    uint32_t pos = 0;
+    uint32_t sizeIdx = 0;
+    while (pos < in.size()) {
+        // New random automation targets every chunk (~sub-ms to ~2 ms apart)
+        flt.setParameter(AestraFilter::kCutoff, next01());
+        flt.setParameter(AestraFilter::kReso, next01());
+        flt.setParameter(AestraFilter::kDrive, next01());
+        flt.setParameter(AestraFilter::kEnvAmount, next01());
+        flt.setParameter(AestraFilter::kEnvAttack, next01());
+        flt.setParameter(AestraFilter::kEnvRelease, next01());
+        flt.setParameter(AestraFilter::kType, next01());
+
+        const uint32_t n = std::min<uint32_t>(sizes[sizeIdx % 6], static_cast<uint32_t>(in.size()) - pos);
+        ++sizeIdx;
+        const float* ins[] = {in.data() + pos, in.data() + pos};
+        float* outs[] = {outL.data() + pos, outR.data() + pos};
+        flt.process(ins, outs, 2, 2, n);
+        pos += n;
+    }
+
+    if (!allFinite(outL) || !allFinite(outR))
+        return false;
+    return peakAmplitude(outL) < 16.0f;
+}
+
 bool testStableAcrossSampleRates() {
     for (double sr : {44100.0, 96000.0, 192000.0}) {
         AestraFilter flt;
@@ -397,6 +520,10 @@ int main() {
         {"StateRoundTrip", testStateRoundTrip},
         {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
         {"TypeMapping", testTypeMapping},
+        {"SetParameterRejectsNonFinite", testSetParameterRejectsNonFinite},
+        {"BypassToggleIsSafe", testBypassToggleIsSafe},
+        {"TypeSwitchIsClickFree", testTypeSwitchIsClickFree},
+        {"AutomationStress", testAutomationStress},
         {"StableAcrossSampleRates", testStableAcrossSampleRates},
     };
 

--- a/Tests/AestraAudio/AestraFilterPluginTest.cpp
+++ b/Tests/AestraAudio/AestraFilterPluginTest.cpp
@@ -374,7 +374,8 @@ bool testSetParameterRejectsNonFinite() {
     for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
         std::memcpy(state.data() + off, &nan, sizeof(float));
     }
-    flt.loadState(state);
+    if (flt.loadState(state))
+        return false; // an all-NaN blob must be rejected, not accepted as success
     for (uint32_t i = 0; i < AestraFilter::kParamCount; ++i) {
         if (!std::isfinite(flt.getParameter(i)))
             return false;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1220,6 +1220,22 @@ target_include_directories(AestraFilterPluginTest PRIVATE
 add_test(NAME AestraFilterPluginTest COMMAND AestraFilterPluginTest)
 set_tests_properties(AestraFilterPluginTest PROPERTIES LABELS "audio;plugins;filter")
 
+# Aestra Filter multi-instance benchmark — build always, register only when
+# experimental tests are enabled (never in the always-on CI tier).
+add_executable(AestraFilterBench AestraAudio/AestraFilterBench.cpp)
+target_link_libraries(AestraFilterBench PRIVATE AestraAudio)
+target_include_directories(AestraFilterBench PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
+    add_test(NAME AestraFilterBench COMMAND AestraFilterBench)
+    set_tests_properties(AestraFilterBench PROPERTIES LABELS "audio;benchmark;experimental")
+else()
+    message(STATUS "AestraFilterBench built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
+endif()
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1209,6 +1209,17 @@ target_include_directories(AestraSatTest PRIVATE
 add_test(NAME AestraSatTest COMMAND AestraSatTest)
 set_tests_properties(AestraSatTest PROPERTIES LABELS "audio;plugins;saturation")
 
+# Aestra Filter plugin test (AestraFilterTest is the DSP::Filter lab above)
+add_executable(AestraFilterPluginTest AestraAudio/AestraFilterPluginTest.cpp)
+target_link_libraries(AestraFilterPluginTest PRIVATE AestraAudio)
+target_include_directories(AestraFilterPluginTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraFilterPluginTest COMMAND AestraFilterPluginTest)
+set_tests_properties(AestraFilterPluginTest PROPERTIES LABELS "audio;plugins;filter")
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds **AestraFilter** (`com.Aestrastudios.filter`), the second plugin in the free-suite build-out (stacked on #472 / `feature/aestra-sat`). An envelope-modulated multimode filter: ZDF/TPT state-variable core (LP/BP/HP), pre-drive stereo peak envelope follower driving bipolar cutoff modulation (±4 octaves), transparent-at-zero tanh drive, dry/wet mix.

## Why

AestraFilter is on the Free Core Suite list but didn't exist in the repo. A modulated filter is a workhorse for electronic production (auto-wah, envelope ducking, sweeps) and the ZDF/TPT form stays stable under per-sample cutoff modulation where naive biquads blow up.

## Design

- **Core**: Simper-form ZDF SVF — `g = tan(π·fc/sr)`, integrator states per channel; cutoff recomputed per sample from smoothed base + envelope modulation in octave domain.
- **Params** (stable IDs 0–8): Type (stepped LP/BP/HP), Cutoff (20 Hz–20 kHz log), Reso (Q 0.5–10), Drive (0–18 dB, transparent at zero via blend with 1/√G makeup), Env Amount (bipolar ±4 oct), Attack (0.1–100 ms), Release (5–1000 ms), Mix, Bypass.
- **State**: `'FLT1'` magic + version + params; garbage blobs rejected.
- **RT safety**: no allocation/locks/IO in `process()`; NaN/Inf sanitized; relaxed-atomic params with 2 ms smoothing.
- **Latency**: zero. **Editor**: teal house-style panel (knobs w/ bipolar Env detent, type selector, mix slider, bypass pill), wired through `PluginUIController`.

## Testing performed

- `AestraFilterPluginTest` — 17 headless contract tests, all passing: bypass parity, silence at max Q (no self-oscillation), LP/HP/BP frequency-response points, resonance peaking, impulse-decay boundedness at max Q, envelope opens/closes filter (carrier+probe), drive transparency at zero and harmonics when hot, mix identity, hostile input (NaN/Inf/±100), state round-trip, garbage-state rejection, type mapping, 44.1/96/192 kHz stability.
- Full `build-linux` build of **all** targets (Release, core mode, UI on) clean, including `Aestra` app link.
- `ctest -L plugins`: **10/10 passed** (all existing plugin suites + new one).
- clang-format applied.

## Docs updated?

No — `docs/` has no plugin inventory page; nothing public claims this feature yet.

## Risk / rollback

- Purely additive: new files + registration lines; no existing DSP, serialization, or plugin touched. Revert = drop the commit.
- New state format only affects projects that saved an AestraFilter instance.
- Stacked on #472; merge that first (shared edits in `BuiltInPlugins.*`, `PluginUIController.cpp`, CMake lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Editor integration change:** `AestraFilter` reports `hasEditor()==true` but its `openEditor()` implementation always returns `false`; the actual filter UI is opened via `PluginUIController` when the plugin id is `com.Aestrastudios.filter`.
- Added the **AestraFilter** internal plugin (`com.Aestrastudios.filter`): a topology-preserving (ZDF/TPT) LP/BP/HP multimode SVF with bipolar envelope-driven cutoff modulation, drive + dry/wet mix, bypass, parameter smoothing, and zero-latency in-place safe processing.
- Implemented performance/robustness improvements: 8-sample control blocks to gate transcendental coefficient work, short crossfades for click-free filter-type switching, and integrator/envelope reset on re-enabling from bypass.
- Added **versioned state serialization** (`'FLT1'`, FLT1 v1) with atomic validation: rejects corrupt/invalid/NaN/∞ state blobs and exposes `getTailSamples()` scaled to sample rate to match resonant decay.
- Registered filter metadata in the built-in plugin catalog and added the **teal AestraFilterEditor** widget (type selector, bypass pill, knobs, mix slider), wired into editor relayout.
- Added **headless DSP coverage** (bypass/silence/frequency response/envelope modulation/drive/mix identity, hostile-input/NaN handling, state round-trip + corruption rejection, click-free switching, automation stress, stability across sample rates) plus a multi-instance **AestraFilterBench** and CMake test/benchmark targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->