### PR TITLE
feat(plugins): AestraOTT — 3-band upward/downward compressor

### DIFF
--- a/AestraAudio/include/Plugin/AestraOTT.h
+++ b/AestraAudio/include/Plugin/AestraOTT.h
@@ -302,6 +302,13 @@ public:
         std::memcpy(&blob, state.data(), sizeof(blob));
         if (blob.version < 1 || blob.version > 1)
             return false;
+        // Validate the entire decoded set before mutating anything. setParameter
+        // silently drops non-finite values, so applying in place would leave a
+        // half-updated state while still reporting success — fail atomically.
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            if (!std::isfinite(blob.params[i]) || blob.params[i] < 0.0f || blob.params[i] > 1.0f)
+                return false;
+        }
         for (uint32_t i = 0; i < kParamCount; ++i) {
             setParameter(i, blob.params[i]);
         }
@@ -317,7 +324,13 @@ public:
 
     const PluginInfo& getInfo() const override { return m_info; }
     uint32_t getLatencySamples() const override { return 0; }
-    uint32_t getTailSamples() const override { return 4096; } // crossover + release ring-out
+    uint32_t getTailSamples() const override {
+        // Sample-rate-relative so the reported tail is constant in time, not in
+        // samples. The LR4 crossovers are Butterworth (non-resonant) so the
+        // ring-out at the lowest 60 Hz split is short (~ln(1000)/(pi·60) ≈ 40 ms);
+        // report ~150 ms to also cover the gain settle after input stops.
+        return static_cast<uint32_t>(m_sampleRate * 0.15);
+    }
     WatchdogStats getWatchdogStats() const override { return {}; }
     void resetWatchdog() override {}
     bool isBypassedByWatchdog() const override { return false; }
@@ -454,7 +467,11 @@ private:
                             uint32_t numOutputChannels, uint32_t numFrames) {
         for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
             if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
-                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+                // Skip the copy when the host renders in place (out == in):
+                // memcpy on aliased buffers is undefined and the data is already
+                // where it needs to be.
+                if (outputs[ch] != inputs[ch])
+                    std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
             } else if (outputs[ch]) {
                 std::memset(outputs[ch], 0, numFrames * sizeof(float));
             }

--- a/AestraAudio/include/Plugin/AestraOTT.h
+++ b/AestraAudio/include/Plugin/AestraOTT.h
@@ -1,0 +1,498 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraOTT V1 — 3-band upward + downward compressor ("over-the-top" style).
+//
+// The input is split into low/mid/high with 4th-order Linkwitz-Riley
+// crossovers (two cascaded Butterworth TPT-SVF stages per slope). The low
+// band passes through an LR4 allpass at the high crossover so all three
+// bands stay phase-aligned and sum flat when no gain is applied.
+//
+// Each band has a stereo-linked peak follower and a symmetric gain computer
+// that pulls the band level toward a fixed -18 dBFS target: loud bands are
+// compressed down, quiet bands are boosted up. Upward gain fades to zero
+// below -50 dB so silence and noise floors are never dragged up. Depth
+// scales the computed gain (in dB) toward unity — the wet control lives in
+// the gain domain, not a dry/wet mix, so there is no phase-cancelling
+// recombination with the allpass-rotated wet path.
+//
+// Signal path (per sample):
+//   in -> input gain -> LR4 split (low/mid/high)
+//      -> per-band gain computer (up+down toward -18 dB, scaled by Depth)
+//      -> per-band trim -> sum -> output gain
+
+#pragma once
+
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace Plugins {
+
+class AestraOTT : public IPluginInstance {
+public:
+    static constexpr uint32_t kStateMagic = 0x4F545431; // 'OTT1'
+    static constexpr float kTargetDb = -18.0f;          // band level the computer pulls toward
+    static constexpr float kRatioAmount = 0.6f;         // fraction of the distance to close
+    static constexpr float kUpGateLowDb = -50.0f;       // upward gain is zero at/below this
+    static constexpr float kUpGateHighDb = -40.0f;      // ...and fully active at/above this
+    static constexpr float kMaxUpDb = 24.0f;            // hard cap on upward gain
+
+    enum Param : uint32_t {
+        kDepth = 0, // 0% to 100% wet (gain-domain)
+        kTime,      // 0.1x to 10x time-constant scale (log)
+        kInGain,    // -24 dB to +24 dB
+        kOutGain,   // -24 dB to +24 dB
+        kLowGain,   // -12 dB to +12 dB band trim
+        kMidGain,   // -12 dB to +12 dB band trim
+        kHighGain,  // -12 dB to +12 dB band trim
+        kXoverLow,  // 60 Hz to 500 Hz (log)
+        kXoverHigh, // 1 kHz to 8 kHz (log)
+        kBypass,
+        kParamCount,
+    };
+
+    enum Band : uint32_t { kBandLow = 0, kBandMid, kBandHigh, kBandCount };
+
+    AestraOTT() = default;
+
+    bool initialize(double sampleRate, uint32_t maxBlockSize) override {
+        (void)maxBlockSize;
+        m_sampleRate = std::max(1.0, sampleRate);
+        for (const auto& param : getParameters()) {
+            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        }
+        resetRuntimeState();
+        snapSmoothedParams();
+        return true;
+    }
+
+    void shutdown() override {}
+
+    void activate() override {
+        m_active.store(true, std::memory_order_relaxed);
+        resetRuntimeState();
+        snapSmoothedParams();
+    }
+
+    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
+    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* midiInput = nullptr, MidiBuffer* midiOutput = nullptr) override {
+        (void)midiInput;
+        (void)midiOutput;
+
+        if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            return;
+        }
+
+        const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
+        const bool stereo = channels >= 2;
+        const float sr = static_cast<float>(m_sampleRate);
+
+        for (uint32_t i = 0; i < numFrames; ++i) {
+            // Smooth continuous params (2 ms one-pole)
+            m_depthSmoothed += (getParameter(kDepth) - m_depthSmoothed) * m_smoothCoeff;
+            m_timeSmoothed += (getParameter(kTime) - m_timeSmoothed) * m_smoothCoeff;
+            m_inGainSmoothed += (getParameter(kInGain) - m_inGainSmoothed) * m_smoothCoeff;
+            m_outGainSmoothed += (getParameter(kOutGain) - m_outGainSmoothed) * m_smoothCoeff;
+            m_xoverLowSmoothed += (getParameter(kXoverLow) - m_xoverLowSmoothed) * m_smoothCoeff;
+            m_xoverHighSmoothed += (getParameter(kXoverHigh) - m_xoverHighSmoothed) * m_smoothCoeff;
+            for (uint32_t b = 0; b < kBandCount; ++b) {
+                m_bandTrimSmoothed[b] += (getParameter(kLowGain + b) - m_bandTrimSmoothed[b]) * m_smoothCoeff;
+            }
+
+            // Crossover coefficients: recompute only when the smoothed target
+            // actually moved — tan() is not free and xovers are near-static.
+            if (std::abs(m_xoverLowSmoothed - m_xoverLowCached) > 1.0e-5f || m_coeffsDirty) {
+                m_xoverLowCached = m_xoverLowSmoothed;
+                m_coeffLow = makeCoeff(xoverLowHzFromNorm(m_xoverLowCached), sr);
+            }
+            if (std::abs(m_xoverHighSmoothed - m_xoverHighCached) > 1.0e-5f || m_coeffsDirty) {
+                m_xoverHighCached = m_xoverHighSmoothed;
+                m_coeffHigh = makeCoeff(xoverHighHzFromNorm(m_xoverHighCached), sr);
+            }
+            // Attack/release coefficients: same gating, driven by the Time macro.
+            if (std::abs(m_timeSmoothed - m_timeCached) > 1.0e-4f || m_coeffsDirty) {
+                m_timeCached = m_timeSmoothed;
+                updateTimeCoeffs(sr);
+            }
+            m_coeffsDirty = false;
+
+            const float inGain = dbToLinear(bipolarDbFromNorm(m_inGainSmoothed, 24.0f));
+            const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i)) * inGain;
+            const float inR = (stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL) * inGain;
+
+            // ── LR4 band split (low band allpass-corrected at the high xover) ──
+            float band[kBandCount][2];
+            for (uint32_t ch = 0; ch < 2; ++ch) {
+                const float x = (ch == 0) ? inL : inR;
+                float lowPath, highPath;
+                m_xover1[ch].split(x, m_coeffLow, lowPath, highPath);
+                float apLo, apHi;
+                m_apCorrect[ch].split(lowPath, m_coeffHigh, apLo, apHi);
+                band[kBandLow][ch] = apLo + apHi; // LR4 allpass at fHigh
+                m_xover2[ch].split(highPath, m_coeffHigh, band[kBandMid][ch], band[kBandHigh][ch]);
+            }
+
+            // ── Per-band gain computer (stereo-linked) ──
+            const float depth = m_depthSmoothed;
+            float outL = 0.0f;
+            float outR = 0.0f;
+            for (uint32_t b = 0; b < kBandCount; ++b) {
+                const float peak = std::max(std::abs(band[b][0]), std::abs(band[b][1]));
+                float& env = m_env[b];
+                const float coeff = (peak > env) ? m_attackCoeff[b] : m_releaseCoeff[b];
+                env += (peak - env) * coeff;
+                if (env != env || env < 1.0e-12f)
+                    env = 0.0f; // NaN check + denormal flush
+
+                const float envDb = linearToDb(env);
+                float compDb = (kTargetDb - envDb) * kRatioAmount;
+                if (compDb > 0.0f) {
+                    // Upward gain: gate away near the noise floor, cap the boost.
+                    const float upScale =
+                        std::clamp((envDb - kUpGateLowDb) / (kUpGateHighDb - kUpGateLowDb), 0.0f, 1.0f);
+                    compDb = std::min(compDb * upScale, kMaxUpDb);
+                }
+                const float trimDb = bipolarDbFromNorm(m_bandTrimSmoothed[b], 12.0f);
+                const float gain = dbToLinear(depth * compDb + trimDb);
+                m_bandGainDb[b].store(depth * compDb, std::memory_order_relaxed);
+
+                outL += band[b][0] * gain;
+                outR += band[b][1] * gain;
+            }
+
+            const float outGain = dbToLinear(bipolarDbFromNorm(m_outGainSmoothed, 24.0f));
+            if (outputs[0])
+                outputs[0][i] = flushDenormal(outL * outGain);
+            if (numOutputChannels > 1 && outputs[1])
+                outputs[1][i] = flushDenormal((stereo ? outR : outL) * outGain);
+            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                if (outputs[ch])
+                    outputs[ch][i] = 0.0f;
+            }
+        }
+    }
+
+    uint32_t getParameterCount() const override { return kParamCount; }
+
+    float getParameter(uint32_t id) const override {
+        if (id >= kParamCount)
+            return 0.0f;
+        return m_params[id].load(std::memory_order_relaxed);
+    }
+
+    void setParameter(uint32_t id, float value) override {
+        if (id >= kParamCount)
+            return;
+        if (!std::isfinite(value))
+            return;
+        m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    std::vector<PluginParameter> getParameters() const override {
+        return {
+            {kDepth, "Depth", "DPT", "%", 1.0f, 0.0f, 1.0f, true},
+            {kTime, "Time", "TIME", "x", 0.5f, 0.0f, 1.0f, true}, // center = 1x
+            {kInGain, "Input Gain", "IN", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kOutGain, "Output Gain", "OUT", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kLowGain, "Low Gain", "LOW", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kMidGain, "Mid Gain", "MID", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kHighGain, "High Gain", "HIGH", "dB", 0.5f, 0.0f, 1.0f, true},
+            {kXoverLow, "Low Crossover", "XLO", "Hz", 0.25f, 0.0f, 1.0f, true},   // ~102 Hz
+            {kXoverHigh, "High Crossover", "XHI", "Hz", 0.44f, 0.0f, 1.0f, true}, // ~2.5 kHz
+            {kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1},
+        };
+    }
+
+    std::string getParameterDisplay(uint32_t id) const override {
+        if (id >= kParamCount)
+            return "";
+        const float v = getParameter(id);
+        char buf[32];
+        switch (id) {
+        case kDepth:
+            return std::to_string(static_cast<int>(std::round(v * 100.0f))) + "%";
+        case kTime:
+            std::snprintf(buf, sizeof(buf), "%.2fx", timeMultFromNorm(v));
+            return buf;
+        case kInGain:
+        case kOutGain:
+            std::snprintf(buf, sizeof(buf), "%+.1f dB", bipolarDbFromNorm(v, 24.0f));
+            return buf;
+        case kLowGain:
+        case kMidGain:
+        case kHighGain:
+            std::snprintf(buf, sizeof(buf), "%+.1f dB", bipolarDbFromNorm(v, 12.0f));
+            return buf;
+        case kXoverLow:
+            std::snprintf(buf, sizeof(buf), "%.0f Hz", xoverLowHzFromNorm(v));
+            return buf;
+        case kXoverHigh: {
+            const float hz = xoverHighHzFromNorm(v);
+            std::snprintf(buf, sizeof(buf), "%.2f kHz", hz / 1000.0f);
+            return buf;
+        }
+        case kBypass:
+            return v > 0.5f ? "ON" : "OFF";
+        default:
+            return "";
+        }
+    }
+
+    std::vector<uint8_t> saveState() const override {
+        struct Blob {
+            uint32_t magic = kStateMagic;
+            uint32_t version = 1;
+            float params[kParamCount] = {};
+        } blob;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            blob.params[i] = getParameter(i);
+        }
+        const auto* data = reinterpret_cast<const uint8_t*>(&blob);
+        return {data, data + sizeof(blob)};
+    }
+
+    bool loadState(const std::vector<uint8_t>& state) override {
+        if (state.size() < sizeof(uint32_t) * 2)
+            return false;
+        uint32_t magic = 0;
+        std::memcpy(&magic, state.data(), sizeof(magic));
+        if (magic != kStateMagic)
+            return false;
+        struct Blob {
+            uint32_t magic;
+            uint32_t version;
+            float params[kParamCount];
+        };
+        if (state.size() < sizeof(Blob))
+            return false;
+        Blob blob{};
+        std::memcpy(&blob, state.data(), sizeof(blob));
+        if (blob.version < 1 || blob.version > 1)
+            return false;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            setParameter(i, blob.params[i]);
+        }
+        return true;
+    }
+
+    bool hasEditor() const override { return true; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {560, 340}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 4096; } // crossover + release ring-out
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+    void setInfo(const PluginInfo& info) { m_info = info; }
+
+    // Metering (for the editor's band gain indicators): applied comp gain in dB.
+    float getBandGainDb(uint32_t band) const {
+        if (band >= kBandCount)
+            return 0.0f;
+        return m_bandGainDb[band].load(std::memory_order_relaxed);
+    }
+
+    // ── Parameter mapping (public: shared with editor/tests) ──
+    static float timeMultFromNorm(float value) {
+        // 0.1x .. 10x, log, center = 1x
+        return 0.1f * std::pow(100.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float bipolarDbFromNorm(float value, float rangeDb) {
+        return (std::clamp(value, 0.0f, 1.0f) * 2.0f - 1.0f) * rangeDb;
+    }
+
+    static float xoverLowHzFromNorm(float value) {
+        // 60 Hz .. 500 Hz, log
+        return 60.0f * std::pow(500.0f / 60.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float xoverHighHzFromNorm(float value) {
+        // 1 kHz .. 8 kHz, log
+        return 1000.0f * std::pow(8.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+private:
+    // ── TPT (ZDF) SVF stage, Butterworth damping — building block for LR4 ──
+    struct SvfCoeff {
+        float a1 = 0.0f;
+        float a2 = 0.0f;
+        float a3 = 0.0f;
+        float k = 1.41421356f; // 1/Q for Butterworth
+    };
+
+    struct SvfStage {
+        float ic1 = 0.0f;
+        float ic2 = 0.0f;
+        void reset() { ic1 = ic2 = 0.0f; }
+        void step(float x, const SvfCoeff& c, float& lp, float& hp) {
+            const float v3 = x - ic2;
+            const float v1 = c.a1 * ic1 + c.a2 * v3;
+            const float v2 = ic2 + c.a2 * ic1 + c.a3 * v3;
+            ic1 = 2.0f * v1 - ic1;
+            ic2 = 2.0f * v2 - ic2;
+            lp = v2;
+            hp = x - c.k * v1 - v2;
+        }
+    };
+
+    // LR4 crossover: LP4 = two cascaded Butterworth LP2, HP4 = two cascaded
+    // Butterworth HP2. LP4 + HP4 sums to a 4th-order allpass (flat magnitude).
+    struct CrossoverLR4 {
+        SvfStage first;
+        SvfStage lowSecond;
+        SvfStage highSecond;
+        void reset() {
+            first.reset();
+            lowSecond.reset();
+            highSecond.reset();
+        }
+        void split(float x, const SvfCoeff& c, float& low, float& high) {
+            float lp1, hp1;
+            first.step(x, c, lp1, hp1);
+            float unusedHp, unusedLp;
+            lowSecond.step(lp1, c, low, unusedHp);
+            highSecond.step(hp1, c, unusedLp, high);
+        }
+    };
+
+    static SvfCoeff makeCoeff(float fc, float sr) {
+        SvfCoeff c;
+        const float clamped = std::clamp(fc, 20.0f, 0.45f * sr);
+        const float g = std::tan(3.14159265358979323846f * clamped / sr);
+        c.a1 = 1.0f / (1.0f + g * (g + c.k));
+        c.a2 = g * c.a1;
+        c.a3 = g * c.a2;
+        return c;
+    }
+
+    void updateTimeCoeffs(float sr) {
+        // Base times per band (ms): lows breathe slower, highs snap faster.
+        static constexpr float kAttackMs[kBandCount] = {24.0f, 10.0f, 3.0f};
+        static constexpr float kReleaseMs[kBandCount] = {240.0f, 120.0f, 60.0f};
+        const float mult = timeMultFromNorm(m_timeCached);
+        for (uint32_t b = 0; b < kBandCount; ++b) {
+            m_attackCoeff[b] = 1.0f - std::exp(-1.0f / (kAttackMs[b] * mult * 0.001f * sr));
+            m_releaseCoeff[b] = 1.0f - std::exp(-1.0f / (kReleaseMs[b] * mult * 0.001f * sr));
+        }
+    }
+
+    void resetRuntimeState() {
+        for (uint32_t ch = 0; ch < 2; ++ch) {
+            m_xover1[ch].reset();
+            m_xover2[ch].reset();
+            m_apCorrect[ch].reset();
+        }
+        for (uint32_t b = 0; b < kBandCount; ++b) {
+            m_env[b] = 0.0f;
+            m_bandGainDb[b].store(0.0f, std::memory_order_relaxed);
+        }
+        const float sr = static_cast<float>(m_sampleRate);
+        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        m_coeffsDirty = true;
+    }
+
+    void snapSmoothedParams() {
+        m_depthSmoothed = getParameter(kDepth);
+        m_timeSmoothed = getParameter(kTime);
+        m_inGainSmoothed = getParameter(kInGain);
+        m_outGainSmoothed = getParameter(kOutGain);
+        m_xoverLowSmoothed = getParameter(kXoverLow);
+        m_xoverHighSmoothed = getParameter(kXoverHigh);
+        for (uint32_t b = 0; b < kBandCount; ++b) {
+            m_bandTrimSmoothed[b] = getParameter(kLowGain + b);
+        }
+        m_coeffsDirty = true;
+    }
+
+    // ── Utility ──
+    static void copyOrClear(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                            uint32_t numOutputChannels, uint32_t numFrames) {
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
+    static float readInput(const float* const* inputs, uint32_t channels, uint32_t channel, uint32_t frame) {
+        if (channel >= channels || !inputs[channel]) {
+            return (channel == 1 && channels > 0 && inputs[0]) ? inputs[0][frame] : 0.0f;
+        }
+        return inputs[channel][frame];
+    }
+
+    static float sanitizeSample(float sample) {
+        if (!std::isfinite(sample))
+            return 0.0f;
+        return std::clamp(sample, -16.0f, 16.0f);
+    }
+
+    static float flushDenormal(float value) { return std::abs(value) < 1.0e-20f ? 0.0f : value; }
+
+    static float linearToDb(float linear) {
+        if (!std::isfinite(linear) || linear <= 1.0e-6f)
+            return -120.0f;
+        return 20.0f * std::log10(linear);
+    }
+
+    static float dbToLinear(float db) { return std::exp(db * 0.11512925464970229f); }
+
+    // ── State ──
+    PluginInfo m_info;
+    double m_sampleRate = 48000.0;
+    std::atomic<bool> m_active{false};
+    std::array<std::atomic<float>, kParamCount> m_params{};
+
+    // Crossover network, per channel
+    CrossoverLR4 m_xover1[2];    // at fLow: low path vs (mid+high) path
+    CrossoverLR4 m_xover2[2];    // at fHigh: mid vs high
+    CrossoverLR4 m_apCorrect[2]; // at fHigh: allpass correction on the low path
+
+    SvfCoeff m_coeffLow;
+    SvfCoeff m_coeffHigh;
+    bool m_coeffsDirty = true;
+    float m_xoverLowCached = -1.0f;
+    float m_xoverHighCached = -1.0f;
+    float m_timeCached = -1.0f;
+
+    float m_env[kBandCount] = {};
+    float m_attackCoeff[kBandCount] = {};
+    float m_releaseCoeff[kBandCount] = {};
+
+    float m_smoothCoeff = 0.0f;
+    float m_depthSmoothed = 1.0f;
+    float m_timeSmoothed = 0.5f;
+    float m_inGainSmoothed = 0.5f;
+    float m_outGainSmoothed = 0.5f;
+    float m_xoverLowSmoothed = 0.25f;
+    float m_xoverHighSmoothed = 0.44f;
+    float m_bandTrimSmoothed[kBandCount] = {0.5f, 0.5f, 0.5f};
+
+    std::array<std::atomic<float>, kBandCount> m_bandGainDb{};
+};
+
+} // namespace Plugins
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/AestraOTT.h
+++ b/AestraAudio/include/Plugin/AestraOTT.h
@@ -99,8 +99,14 @@ public:
         const bool stereo = channels >= 2;
         const float sr = static_cast<float>(m_sampleRate);
 
-        for (uint32_t i = 0; i < numFrames; ++i) {
-            // Smooth continuous params (2 ms one-pole)
+        // Parameters are read/smoothed and all dB<->linear transforms run once
+        // per control block; per-band gains are linearly interpolated across
+        // the block. The per-sample path is the crossover SVFs, the peak
+        // followers and multiply-adds — no atomics or transcendentals.
+        for (uint32_t blockStart = 0; blockStart < numFrames; blockStart += kCtrlBlock) {
+            const uint32_t blockEnd = std::min(blockStart + kCtrlBlock, numFrames);
+            const uint32_t blockLen = blockEnd - blockStart;
+
             m_depthSmoothed += (getParameter(kDepth) - m_depthSmoothed) * m_smoothCoeff;
             m_timeSmoothed += (getParameter(kTime) - m_timeSmoothed) * m_smoothCoeff;
             m_inGainSmoothed += (getParameter(kInGain) - m_inGainSmoothed) * m_smoothCoeff;
@@ -126,37 +132,17 @@ public:
                 m_timeCached = m_timeSmoothed;
                 updateTimeCoeffs(sr);
             }
-            m_coeffsDirty = false;
 
             const float inGain = dbToLinear(bipolarDbFromNorm(m_inGainSmoothed, 24.0f));
-            const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i)) * inGain;
-            const float inR = (stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL) * inGain;
-
-            // ── LR4 band split (low band allpass-corrected at the high xover) ──
-            float band[kBandCount][2];
-            for (uint32_t ch = 0; ch < 2; ++ch) {
-                const float x = (ch == 0) ? inL : inR;
-                float lowPath, highPath;
-                m_xover1[ch].split(x, m_coeffLow, lowPath, highPath);
-                float apLo, apHi;
-                m_apCorrect[ch].split(lowPath, m_coeffHigh, apLo, apHi);
-                band[kBandLow][ch] = apLo + apHi; // LR4 allpass at fHigh
-                m_xover2[ch].split(highPath, m_coeffHigh, band[kBandMid][ch], band[kBandHigh][ch]);
-            }
-
-            // ── Per-band gain computer (stereo-linked) ──
+            const float outGain = dbToLinear(bipolarDbFromNorm(m_outGainSmoothed, 24.0f));
             const float depth = m_depthSmoothed;
-            float outL = 0.0f;
-            float outR = 0.0f;
-            for (uint32_t b = 0; b < kBandCount; ++b) {
-                const float peak = std::max(std::abs(band[b][0]), std::abs(band[b][1]));
-                float& env = m_env[b];
-                const float coeff = (peak > env) ? m_attackCoeff[b] : m_releaseCoeff[b];
-                env += (peak - env) * coeff;
-                if (env != env || env < 1.0e-12f)
-                    env = 0.0f; // NaN check + denormal flush
 
-                const float envDb = linearToDb(env);
+            // ── Per-band gain targets from the current envelopes; the applied
+            // gain ramps linearly to the target across the block. Envelopes
+            // move over milliseconds, so a 16-sample ramp tracks them closely. ──
+            float dGain[kBandCount];
+            for (uint32_t b = 0; b < kBandCount; ++b) {
+                const float envDb = linearToDb(m_env[b]);
                 float compDb = (kTargetDb - envDb) * kRatioAmount;
                 if (compDb > 0.0f) {
                     // Upward gain: gate away near the noise floor, cap the boost.
@@ -165,21 +151,56 @@ public:
                     compDb = std::min(compDb * upScale, kMaxUpDb);
                 }
                 const float trimDb = bipolarDbFromNorm(m_bandTrimSmoothed[b], 12.0f);
-                const float gain = dbToLinear(depth * compDb + trimDb);
+                const float target = dbToLinear(depth * compDb + trimDb);
                 m_bandGainDb[b].store(depth * compDb, std::memory_order_relaxed);
-
-                outL += band[b][0] * gain;
-                outR += band[b][1] * gain;
+                if (m_coeffsDirty) {
+                    m_bandGain[b] = target;
+                    dGain[b] = 0.0f;
+                } else {
+                    dGain[b] = (target - m_bandGain[b]) / static_cast<float>(blockLen);
+                }
             }
+            m_coeffsDirty = false;
 
-            const float outGain = dbToLinear(bipolarDbFromNorm(m_outGainSmoothed, 24.0f));
-            if (outputs[0])
-                outputs[0][i] = flushDenormal(outL * outGain);
-            if (numOutputChannels > 1 && outputs[1])
-                outputs[1][i] = flushDenormal((stereo ? outR : outL) * outGain);
-            for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
-                if (outputs[ch])
-                    outputs[ch][i] = 0.0f;
+            for (uint32_t i = blockStart; i < blockEnd; ++i) {
+                const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i)) * inGain;
+                const float inR = (stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL) * inGain;
+
+                // ── LR4 band split (low band allpass-corrected at the high xover) ──
+                float band[kBandCount][2];
+                for (uint32_t ch = 0; ch < 2; ++ch) {
+                    const float x = (ch == 0) ? inL : inR;
+                    float lowPath, highPath;
+                    m_xover1[ch].split(x, m_coeffLow, lowPath, highPath);
+                    float apLo, apHi;
+                    m_apCorrect[ch].split(lowPath, m_coeffHigh, apLo, apHi);
+                    band[kBandLow][ch] = apLo + apHi; // LR4 allpass at fHigh
+                    m_xover2[ch].split(highPath, m_coeffHigh, band[kBandMid][ch], band[kBandHigh][ch]);
+                }
+
+                float outL = 0.0f;
+                float outR = 0.0f;
+                for (uint32_t b = 0; b < kBandCount; ++b) {
+                    const float peak = std::max(std::abs(band[b][0]), std::abs(band[b][1]));
+                    float& env = m_env[b];
+                    const float coeff = (peak > env) ? m_attackCoeff[b] : m_releaseCoeff[b];
+                    env += (peak - env) * coeff;
+                    if (env != env || env < 1.0e-12f)
+                        env = 0.0f; // NaN check + denormal flush
+
+                    m_bandGain[b] += dGain[b];
+                    outL += band[b][0] * m_bandGain[b];
+                    outR += band[b][1] * m_bandGain[b];
+                }
+
+                if (outputs[0])
+                    outputs[0][i] = flushDenormal(outL * outGain);
+                if (numOutputChannels > 1 && outputs[1])
+                    outputs[1][i] = flushDenormal((stereo ? outR : outL) * outGain);
+                for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                    if (outputs[ch])
+                        outputs[ch][i] = 0.0f;
+                }
             }
         }
     }
@@ -332,6 +353,8 @@ public:
     }
 
 private:
+    static constexpr uint32_t kCtrlBlock = 16; // control-rate interval for param/gain updates
+
     // ── TPT (ZDF) SVF stage, Butterworth damping — building block for LR4 ──
     struct SvfCoeff {
         float a1 = 0.0f;
@@ -407,7 +430,9 @@ private:
             m_bandGainDb[b].store(0.0f, std::memory_order_relaxed);
         }
         const float sr = static_cast<float>(m_sampleRate);
-        m_smoothCoeff = 1.0f - std::exp(-1.0f / (0.002f * sr));
+        // Smoothing runs once per control block, so the coefficient is scaled
+        // to the block interval to keep the 2 ms time constant.
+        m_smoothCoeff = 1.0f - std::exp(-static_cast<float>(kCtrlBlock) / (0.002f * sr));
         m_coeffsDirty = true;
     }
 
@@ -480,6 +505,7 @@ private:
     float m_env[kBandCount] = {};
     float m_attackCoeff[kBandCount] = {};
     float m_releaseCoeff[kBandCount] = {};
+    float m_bandGain[kBandCount] = {1.0f, 1.0f, 1.0f}; // block-interpolated applied gains
 
     float m_smoothCoeff = 0.0f;
     float m_depthSmoothed = 1.0f;

--- a/AestraAudio/include/Plugin/AestraOTT.h
+++ b/AestraAudio/include/Plugin/AestraOTT.h
@@ -66,8 +66,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // EffectChain::prepare() re-calls initialize() on the *live* instance
+        // during stream restarts / sample-rate changes, so seed defaults only on
+        // the first init — otherwise a device change would silently wipe the
+        // user's current parameter values.
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         resetRuntimeState();
         snapSmoothedParams();
@@ -413,7 +419,10 @@ private:
 
     static SvfCoeff makeCoeff(float fc, float sr) {
         SvfCoeff c;
-        const float clamped = std::clamp(fc, 20.0f, 0.45f * sr);
+        // At extremely low sample rates 0.45*sr can fall below the 20 Hz floor,
+        // which would make std::clamp's bounds invalid (lo > hi). Keep lo <= hi.
+        const float hi = 0.45f * sr;
+        const float clamped = std::clamp(fc, std::min(20.0f, hi), hi);
         const float g = std::tan(3.14159265358979323846f * clamped / sr);
         c.a1 = 1.0f / (1.0f + g * (g + c.k));
         c.a2 = g * c.a1;
@@ -491,7 +500,11 @@ private:
         return std::clamp(sample, -16.0f, 16.0f);
     }
 
-    static float flushDenormal(float value) { return std::abs(value) < 1.0e-20f ? 0.0f : value; }
+    static float flushDenormal(float value) {
+        if (!std::isfinite(value))
+            return 0.0f; // guard the output against NaN/Inf, not just denormals
+        return std::abs(value) < 1.0e-20f ? 0.0f : value;
+    }
 
     static float linearToDb(float linear) {
         if (!std::isfinite(linear) || linear <= 1.0e-6f)
@@ -505,6 +518,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
 
     // Crossover network, per channel

--- a/AestraAudio/include/Plugin/BuiltInPlugins.h
+++ b/AestraAudio/include/Plugin/BuiltInPlugins.h
@@ -18,6 +18,7 @@ const PluginInfo& driftInfo();
 const PluginInfo& limiterInfo();
 const PluginInfo& satInfo();
 const PluginInfo& filterInfo();
+const PluginInfo& ottInfo();
 void registerCoreBuiltIns();
 std::vector<PluginInfo> all();
 }

--- a/AestraAudio/src/Plugin/BuiltInPlugins.cpp
+++ b/AestraAudio/src/Plugin/BuiltInPlugins.cpp
@@ -12,6 +12,7 @@
 #include "Plugin/AestraLimit.h"
 #include "Plugin/AestraSat.h"
 #include "Plugin/AestraFilter.h"
+#include "Plugin/AestraOTT.h"
 
 #include <mutex>
 
@@ -199,6 +200,26 @@ const PluginInfo& filterInfo() {
     return info;
 }
 
+const PluginInfo& ottInfo() {
+    static const PluginInfo info = [] {
+        PluginInfo p;
+        p.id = "com.Aestrastudios.ott";
+        p.name = "Aestra OTT";
+        p.vendor = "Aestra Studios";
+        p.version = "0.1.0";
+        p.category = "Dynamics";
+        p.format = PluginFormat::Internal;
+        p.type = PluginType::Effect;
+        p.numAudioInputs = 2;
+        p.numAudioOutputs = 2;
+        p.hasMidiInput = false;
+        p.hasMidiOutput = false;
+        p.hasEditor = true;
+        return p;
+    }();
+    return info;
+}
+
 namespace {
 void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
     if (!instance) {
@@ -225,6 +246,8 @@ void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
         sat->setInfo(info);
     } else if (auto filter = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraFilter>(instance)) {
         filter->setInfo(info);
+    } else if (auto ott = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraOTT>(instance)) {
+        ott->setInfo(info);
     }
 }
 
@@ -255,6 +278,7 @@ void registerCoreBuiltIns() {
         registry.registerPlugin(makeRegistration<Plugins::AestraLimit>(limiterInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraSat>(satInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraFilter>(filterInfo()));
+        registry.registerPlugin(makeRegistration<Plugins::AestraOTT>(ottInfo()));
     });
 }
 

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -153,6 +153,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/AestraSatEditor.cpp
     Widgets/AestraFilterEditor.h
     Widgets/AestraFilterEditor.cpp
+    Widgets/AestraOTTEditor.h
+    Widgets/AestraOTTEditor.cpp
 )
 
 if(AESTRAUI_ENABLE_PREMIUM_EDITORS)

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -1,0 +1,223 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AestraOTTEditor.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "Plugin/AestraOTT.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace AestraUI {
+
+namespace {
+using Aestra::Audio::Plugins::AestraOTT;
+
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kKnobSweep = kPi * 1.5f;
+constexpr float kKnobStart = kPi * 0.75f; // pointing down-left, sweeping clockwise
+constexpr float kDragRangePx = 160.0f;    // full param range per drag distance
+
+NUIColor accent() {
+    return NUIColor(0.74f, 0.42f, 0.88f, 1.0f);
+} // OTT violet
+NUIColor panelSurface() {
+    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+}
+NUIColor insetSurface() {
+    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+}
+
+void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
+             NUIColor color) {
+    if (endAngle < startAngle)
+        std::swap(startAngle, endAngle);
+    if (endAngle - startAngle <= 0.001f)
+        return;
+    std::array<NUIPoint, 49> pts{};
+    const float div = static_cast<float>(pts.size() - 1);
+    for (size_t i = 0; i < pts.size(); ++i) {
+        const float t = static_cast<float>(i) / div;
+        const float a = startAngle + (endAngle - startAngle) * t;
+        pts[i] = {center.x + std::cos(a) * radius, center.y + std::sin(a) * radius};
+    }
+    renderer.drawPolyline(pts.data(), static_cast<int>(pts.size()), thickness, color);
+}
+} // namespace
+
+AestraOTTEditor::AestraOTTEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance)
+    : m_instance(std::move(instance)) {
+    setId("AestraOTTEditor");
+    setPanelTitle("Aestra OTT");
+    setBadgeText("Dynamics");
+    setSize(kWinW, kWinH);
+    setEnforceParentBounds(true);
+    layoutControls();
+}
+
+void AestraOTTEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
+    AestraPanelWindow::setPlatformBridge(bridge);
+}
+
+void AestraOTTEditor::layoutControls() {
+    const auto b = getBounds();
+    const float contentTop = b.y + AestraPanelWindow::TITLE_BAR_H;
+
+    constexpr float kBypassW = 88.0f;
+    constexpr float kBypassH = 26.0f;
+    m_bypassRect = NUIRect(b.right() - 44.0f - kBypassW, contentTop + 16.0f, kBypassW, kBypassH);
+
+    // Large depth knob on the left; macro row to its right, band row below.
+    const float knobTop = contentTop + 52.0f;
+    m_depthRect = NUIRect(b.x + 44.0f, knobTop + 4.0f, 108.0f, 108.0f);
+    m_timeRect = NUIRect(b.x + 208.0f, knobTop, 64.0f, 64.0f);
+    m_inRect = NUIRect(b.x + 322.0f, knobTop, 64.0f, 64.0f);
+    m_outRect = NUIRect(b.x + 436.0f, knobTop, 64.0f, 64.0f);
+
+    const float bandTop = std::min(knobTop + 150.0f, b.bottom() - 92.0f);
+    m_lowRect = NUIRect(b.x + 52.0f, bandTop, 52.0f, 52.0f);
+    m_midRect = NUIRect(b.x + 142.0f, bandTop, 52.0f, 52.0f);
+    m_highRect = NUIRect(b.x + 232.0f, bandTop, 52.0f, 52.0f);
+    m_xloRect = NUIRect(b.x + 356.0f, bandTop, 52.0f, 52.0f);
+    m_xhiRect = NUIRect(b.x + 446.0f, bandTop, 52.0f, 52.0f);
+}
+
+void AestraOTTEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    if (!m_instance)
+        return;
+
+    const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
+                           contentRect.height - 18.0f};
+    renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+
+    drawBypassPill(renderer);
+    drawKnob(renderer, m_depthRect, AestraOTT::kDepth, "Depth", true, false);
+    drawKnob(renderer, m_timeRect, AestraOTT::kTime, "Time", false, false);
+    drawKnob(renderer, m_inRect, AestraOTT::kInGain, "In", false, true);
+    drawKnob(renderer, m_outRect, AestraOTT::kOutGain, "Out", false, true);
+    drawKnob(renderer, m_lowRect, AestraOTT::kLowGain, "Low", false, true);
+    drawKnob(renderer, m_midRect, AestraOTT::kMidGain, "Mid", false, true);
+    drawKnob(renderer, m_highRect, AestraOTT::kHighGain, "High", false, true);
+    drawKnob(renderer, m_xloRect, AestraOTT::kXoverLow, "X-Low", false, false);
+    drawKnob(renderer, m_xhiRect, AestraOTT::kXoverHigh, "X-High", false, false);
+}
+
+void AestraOTTEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label,
+                               bool large, bool bipolar) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float value = m_instance ? m_instance->getParameter(paramId) : 0.0f;
+    const NUIPoint c = rect.center();
+    const float r = rect.width * 0.5f - 4.0f;
+    const float angle = kKnobStart + value * kKnobSweep;
+
+    renderer.fillCircle(c, r + 4.0f, insetSurface());
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+
+    drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
+            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+    if (bipolar) {
+        // Bipolar knobs fill from the top-center detent toward the value.
+        const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
+        drawArc(renderer, c, r - 3.0f, std::min(centerAngle, angle), std::max(centerAngle, angle), 3.0f,
+                accent().withAlpha(0.92f));
+    } else {
+        drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
+    }
+
+    const float needleLen = r - (large ? 14.0f : 9.0f);
+    const NUIPoint tip(c.x + std::cos(angle) * needleLen, c.y + std::sin(angle) * needleLen);
+    renderer.drawLine(c, tip, 2.0f, accent().withAlpha(0.85f));
+    renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
+
+    const float wellR = r * (large ? 0.34f : 0.28f);
+    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
+
+    renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
+                              theme.getColor("textPrimary").withAlpha(0.95f));
+    const std::string valStr = m_instance ? m_instance->getParameterDisplay(paramId) : "";
+    renderer.drawTextCentered(valStr, NUIRect(rect.x - 14.0f, rect.bottom() + 19.0f, rect.width + 28.0f, 13.0f),
+                              large ? 10.0f : 9.0f, accent().withAlpha(0.96f));
+}
+
+void AestraOTTEditor::drawBypassPill(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const bool bypassed = m_instance && m_instance->getParameter(AestraOTT::kBypass) > 0.5f;
+    constexpr float kRadius = 7.0f;
+    constexpr float kFont = 10.0f;
+    if (bypassed) {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 NUIColor(0.92f, 0.28f, 0.22f).withAlpha(m_bypassHovered ? 0.94f : 0.78f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, NUIColor(0.92f, 0.28f, 0.22f).withAlpha(0.50f));
+        renderer.drawTextCentered("BYPASSED", m_bypassRect, kFont, theme.getColor("textPrimary"));
+    } else {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 theme.getColor("success").withAlpha(m_bypassHovered ? 0.30f : 0.18f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, theme.getColor("success").withAlpha(0.40f));
+        renderer.drawTextCentered("ACTIVE", m_bypassRect, kFont, theme.getColor("success"));
+    }
+}
+
+bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible())
+        return false;
+    if (AestraPanelWindow::onMouseEvent(event))
+        return true;
+    if (!m_instance)
+        return false;
+
+    const float my = event.position.y;
+
+    // Bypass pill
+    if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
+        const float cur = m_instance->getParameter(AestraOTT::kBypass);
+        m_instance->setParameter(AestraOTT::kBypass, cur > 0.5f ? 0.0f : 1.0f);
+        setDirty();
+        return true;
+    }
+    m_bypassHovered = m_bypassRect.contains(event.position);
+
+    // Knob vertical drag
+    if (m_draggingParam >= 0) {
+        if (event.released) {
+            m_draggingParam = -1;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float delta = (m_dragStartY - my) / kDragRangePx;
+            m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
+                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        const struct {
+            NUIRect rect;
+            uint32_t param;
+        } knobs[] = {
+            {m_depthRect, AestraOTT::kDepth},   {m_timeRect, AestraOTT::kTime},    {m_inRect, AestraOTT::kInGain},
+            {m_outRect, AestraOTT::kOutGain},   {m_lowRect, AestraOTT::kLowGain},  {m_midRect, AestraOTT::kMidGain},
+            {m_highRect, AestraOTT::kHighGain}, {m_xloRect, AestraOTT::kXoverLow}, {m_xhiRect, AestraOTT::kXoverHigh},
+        };
+        for (const auto& k : knobs) {
+            if (k.rect.contains(event.position)) {
+                m_draggingParam = static_cast<int>(k.param);
+                m_dragStartY = my;
+                m_dragStartValue = m_instance->getParameter(k.param);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void AestraOTTEditor::onResize(int width, int height) {
+    AestraPanelWindow::onResize(width, height);
+    layoutControls();
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraOTTEditor.h
+++ b/AestraUI/Widgets/AestraOTTEditor.h
@@ -1,0 +1,53 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraPanelWindow.h"
+#include "NUITypes.h"
+#include "PluginHost.h"
+
+#include <memory>
+#include <string>
+
+namespace AestraUI {
+
+class AestraOTTEditor : public AestraPanelWindow {
+public:
+    explicit AestraOTTEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
+    void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    void onResize(int width, int height) override;
+    using AestraPanelWindow::onResize;
+    void onResize() { layoutControls(); }
+    void setPlatformBridge(NUIPlatformBridge* bridge) override;
+
+private:
+    void layoutControls();
+    void drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label, bool large,
+                  bool bipolar);
+    void drawBypassPill(NUIRenderer& renderer);
+
+    std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
+
+    NUIRect m_depthRect;
+    NUIRect m_timeRect;
+    NUIRect m_inRect;
+    NUIRect m_outRect;
+    NUIRect m_lowRect;
+    NUIRect m_midRect;
+    NUIRect m_highRect;
+    NUIRect m_xloRect;
+    NUIRect m_xhiRect;
+    NUIRect m_bypassRect;
+
+    // Vertical-drag knob state: which param is being dragged, and the value
+    // at drag start so movement is relative, not absolute.
+    int m_draggingParam = -1;
+    float m_dragStartY = 0.0f;
+    float m_dragStartValue = 0.0f;
+    bool m_bypassHovered = false;
+
+    static constexpr float kWinW = 560.0f;
+    static constexpr float kWinH = 340.0f;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -12,6 +12,7 @@
 #include "AestraLimitEditor.h"
 #include "AestraSatEditor.h"
 #include "AestraFilterEditor.h"
+#include "AestraOTTEditor.h"
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
@@ -409,6 +410,14 @@ void PluginUIController::openPluginEditor(
         });
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
+    } else if (pluginId == "com.Aestrastudios.ott") {
+        auto ed = std::make_shared<AestraOTTEditor>(instance);
+        ed->setOnClose([this, ed]() {
+            if (m_popupLayer) m_popupLayer->removeChild(ed);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
+        });
+        ed->setPlatformBridge(m_platformBridge);
+        editor = ed;
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
         ed->setOnClose([this, ed]() {
@@ -439,6 +448,8 @@ void PluginUIController::openPluginEditor(
             sat->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto filter = std::dynamic_pointer_cast<AestraFilterEditor>(editorComp)) {
             filter->onResize(static_cast<int>(width), static_cast<int>(height));
+        } else if (auto ott = std::dynamic_pointer_cast<AestraOTTEditor>(editorComp)) {
+            ott->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto generic = std::dynamic_pointer_cast<GenericPluginEditor>(editorComp)) {
             generic->onResize();
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS

--- a/Tests/AestraAudio/AestraOTTTest.cpp
+++ b/Tests/AestraAudio/AestraOTTTest.cpp
@@ -291,6 +291,73 @@ bool testParameterMapping() {
     return true;
 }
 
+// NaN/Inf must not pass the parameter ingress; a NaN-filled (magic-intact)
+// state blob must not poison processing.
+bool testSetParameterRejectsNonFinite() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.activate();
+    ott.setParameter(AestraOTT::kDepth, 0.42f);
+
+    for (float bad : {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity(),
+                      -std::numeric_limits<float>::infinity()}) {
+        ott.setParameter(AestraOTT::kDepth, bad);
+        if (std::abs(ott.getParameter(AestraOTT::kDepth) - 0.42f) > 1e-6f)
+            return false;
+    }
+
+    std::vector<uint8_t> state = ott.saveState();
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
+        std::memcpy(state.data() + off, &nan, sizeof(float));
+    }
+    ott.loadState(state);
+    for (uint32_t i = 0; i < AestraOTT::kParamCount; ++i) {
+        if (!std::isfinite(ott.getParameter(i)))
+            return false;
+    }
+
+    const auto in = makeSine(2048, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(ott, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Rapid automation of every continuous parameter, with hostile block sizes.
+bool testAutomationStress() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.activate();
+
+    uint32_t lcg = 0xBADC0DEu;
+    auto next01 = [&lcg]() {
+        lcg = lcg * 1664525u + 1013904223u;
+        return static_cast<float>(lcg >> 8) * (1.0f / 16777216.0f);
+    };
+
+    const auto in = makeSine(96000, 300.0f, 0.5f, kSampleRate); // 2 s
+    std::vector<float> outL(in.size(), 0.0f);
+    std::vector<float> outR(in.size(), 0.0f);
+    const uint32_t sizes[] = {1, 3, 17, 32, 64, 111};
+    uint32_t pos = 0;
+    uint32_t sizeIdx = 0;
+    while (pos < in.size()) {
+        for (uint32_t pIdx = 0; pIdx < AestraOTT::kParamCount; ++pIdx) {
+            if (pIdx != AestraOTT::kBypass)
+                ott.setParameter(pIdx, next01());
+        }
+        const uint32_t n = std::min<uint32_t>(sizes[sizeIdx % 6], static_cast<uint32_t>(in.size()) - pos);
+        ++sizeIdx;
+        const float* ins[] = {in.data() + pos, in.data() + pos};
+        float* outs[] = {outL.data() + pos, outR.data() + pos};
+        ott.process(ins, outs, 2, 2, n);
+        pos += n;
+    }
+
+    if (!allFinite(outL) || !allFinite(outR))
+        return false;
+    return peakAmplitude(outL) < 16.0f;
+}
+
 bool testStableAcrossSampleRates() {
     for (double sr : {44100.0, 96000.0, 192000.0}) {
         AestraOTT ott;
@@ -332,6 +399,8 @@ int main() {
         {"StateRoundTrip", testStateRoundTrip},
         {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
         {"ParameterMapping", testParameterMapping},
+        {"SetParameterRejectsNonFinite", testSetParameterRejectsNonFinite},
+        {"AutomationStress", testAutomationStress},
         {"StableAcrossSampleRates", testStableAcrossSampleRates},
     };
 

--- a/Tests/AestraAudio/AestraOTTTest.cpp
+++ b/Tests/AestraAudio/AestraOTTTest.cpp
@@ -1,0 +1,352 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraOTTTest — DSP contract tests for the 3-band upward/downward compressor.
+
+#include "Plugin/AestraOTT.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraOTT;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 512;
+
+struct StereoBuffer {
+    std::vector<float> left;
+    std::vector<float> right;
+};
+
+StereoBuffer processStereo(AestraOTT& ott, const std::vector<float>& inL, const std::vector<float>& inR) {
+    StereoBuffer out{std::vector<float>(inL.size(), 0.0f), std::vector<float>(inR.size(), 0.0f)};
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {out.left.data(), out.right.data()};
+    ott.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+    return out;
+}
+
+std::vector<float> makeSine(uint32_t numSamples, float freq, float amp, double sampleRate) {
+    std::vector<float> buf(numSamples);
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    for (uint32_t i = 0; i < numSamples; ++i)
+        buf[i] = static_cast<float>(amp * std::sin(w * static_cast<double>(i)));
+    return buf;
+}
+
+std::vector<float> makeSilence(uint32_t numSamples) {
+    return std::vector<float>(numSamples, 0.0f);
+}
+
+float peakAmplitude(const std::vector<float>& buf, size_t start = 0) {
+    float peak = 0.0f;
+    for (size_t i = start; i < buf.size(); ++i)
+        peak = std::max(peak, std::abs(buf[i]));
+    return peak;
+}
+
+bool allFinite(const std::vector<float>& buf) {
+    for (float s : buf) {
+        if (!std::isfinite(s))
+            return false;
+    }
+    return true;
+}
+
+/// Goertzel magnitude of one bin, normalized so a unit sine reads 1.0.
+float goertzelMag(const std::vector<float>& buf, size_t start, float freq, double sampleRate) {
+    const size_t n = buf.size() - start;
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (size_t i = start; i < buf.size(); ++i) {
+        s0 = buf[i] + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    return static_cast<float>(2.0 * std::sqrt(std::max(0.0, power)) / static_cast<double>(n));
+}
+
+/// Feed a sine through an OTT at the given depth, return steady-state
+/// output/input magnitude ratio at that frequency (last half of 1 second).
+float sineGain(float freq, float amp, float depth) {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kDepth, depth);
+    ott.activate();
+
+    const auto in = makeSine(48000, freq, amp, kSampleRate);
+    auto out = processStereo(ott, in, in);
+    return goertzelMag(out.left, 24000, freq, kSampleRate) / amp;
+}
+
+bool testBypassPassesAudioUnchanged() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kBypass, 1.0f);
+    ott.setParameter(AestraOTT::kInGain, 1.0f);
+    ott.activate();
+
+    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
+    auto out = processStereo(ott, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
+            return false;
+        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+// The upward gain gate: silence must never be dragged up.
+bool testSilenceStaysSilent() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kDepth, 1.0f);
+    ott.activate();
+
+    const auto silence = makeSilence(8192);
+    auto out = processStereo(ott, silence, silence);
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+}
+
+// With depth 0 and trims centered, the band split must reconstruct flat:
+// LR4 low/high sum to an allpass, so magnitude ~1 at any frequency —
+// including right at the crossover points.
+bool testDepthZeroIsSpectrallyFlat() {
+    for (float freq : {80.0f, 102.0f, 1000.0f, 2500.0f, 6000.0f}) {
+        const float mag = sineGain(freq, 0.1f, 0.0f);
+        if (mag < 0.9f || mag > 1.1f)
+            return false;
+    }
+    return true;
+}
+
+// A 0 dBFS band sits 18 dB above the target: expect ~-10.8 dB of downward
+// gain (0.6 of the distance).
+bool testDownwardCompressesLoudSignal() {
+    const float gain = sineGain(1000.0f, 1.0f, 1.0f);
+    return gain < 0.5f && gain > 0.1f;
+}
+
+// A -30 dB band sits 12 dB below the target: expect ~+7.2 dB upward gain.
+bool testUpwardBoostsQuietSignal() {
+    const float gain = sineGain(1000.0f, 0.0316f, 1.0f);
+    return gain > 1.5f && gain < 4.0f;
+}
+
+// At -70 dB the band is under the upward gate: gain must stay ~unity, not
+// the +24 dB the raw computer would ask for.
+bool testUpwardGateSparesNoiseFloor() {
+    const float gain = sineGain(1000.0f, 0.0003f, 1.0f);
+    return gain > 0.7f && gain < 1.4f;
+}
+
+// Depth is the wet control: half depth must give a noticeably smaller boost.
+bool testDepthScalesEffect() {
+    const float full = sineGain(1000.0f, 0.0316f, 1.0f);
+    const float half = sineGain(1000.0f, 0.0316f, 0.5f);
+    return half > 1.1f && full > 1.3f * half;
+}
+
+// The bands must be independent: a loud low band gets compressed while a
+// quiet high band gets boosted, in the same pass.
+bool testMultibandIndependence() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.activate();
+
+    const auto lo = makeSine(48000, 50.0f, 0.5f, kSampleRate);    // -6 dB, low band
+    const auto hi = makeSine(48000, 5000.0f, 0.02f, kSampleRate); // -34 dB, high band
+    std::vector<float> in(lo.size());
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = lo[i] + hi[i];
+
+    auto out = processStereo(ott, in, in);
+    const float loGain = goertzelMag(out.left, 24000, 50.0f, kSampleRate) / 0.5f;
+    const float hiGain = goertzelMag(out.left, 24000, 5000.0f, kSampleRate) / 0.02f;
+    return loGain < 0.7f && hiGain > 1.5f;
+}
+
+// Band trims: pulling the high trim to -12 dB must duck a high probe by
+// ~12 dB while leaving a low probe alone (depth 0 isolates the trims).
+bool testBandTrimsShapeOutput() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kDepth, 0.0f);
+    ott.setParameter(AestraOTT::kHighGain, 0.0f); // -12 dB
+    ott.activate();
+
+    const auto lo = makeSine(48000, 100.0f, 0.1f, kSampleRate);
+    const auto hi = makeSine(48000, 6000.0f, 0.1f, kSampleRate);
+    std::vector<float> in(lo.size());
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = lo[i] + hi[i];
+
+    auto out = processStereo(ott, in, in);
+    const float loMag = goertzelMag(out.left, 24000, 100.0f, kSampleRate) / 0.1f;
+    const float hiMag = goertzelMag(out.left, 24000, 6000.0f, kSampleRate) / 0.1f;
+    return loMag > 0.85f && hiMag < 0.35f;
+}
+
+bool testSurvivesHostileInput() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kDepth, 1.0f);
+    ott.setParameter(AestraOTT::kInGain, 1.0f);
+    ott.activate();
+
+    std::vector<float> in(2048, 0.0f);
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = (i % 2 == 0) ? 100.0f : -100.0f;
+    in[100] = std::numeric_limits<float>::quiet_NaN();
+    in[200] = std::numeric_limits<float>::infinity();
+    in[300] = -std::numeric_limits<float>::infinity();
+
+    auto out = processStereo(ott, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Every parameter at both extremes with hot input: output must stay finite.
+bool testStableAtParameterExtremes() {
+    for (float extreme : {0.0f, 1.0f}) {
+        AestraOTT ott;
+        ott.initialize(kSampleRate, kBlockSize);
+        for (uint32_t p = 0; p < AestraOTT::kParamCount; ++p) {
+            if (p != AestraOTT::kBypass)
+                ott.setParameter(p, extreme);
+        }
+        ott.activate();
+
+        const auto in = makeSine(8192, 700.0f, 1.0f, kSampleRate);
+        auto out = processStereo(ott, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+    }
+    return true;
+}
+
+bool testStateRoundTrip() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.activate();
+    ott.setParameter(AestraOTT::kDepth, 0.7f);
+    ott.setParameter(AestraOTT::kTime, 0.3f);
+    ott.setParameter(AestraOTT::kInGain, 0.6f);
+    ott.setParameter(AestraOTT::kOutGain, 0.4f);
+    ott.setParameter(AestraOTT::kLowGain, 0.55f);
+    ott.setParameter(AestraOTT::kMidGain, 0.45f);
+    ott.setParameter(AestraOTT::kHighGain, 0.65f);
+    ott.setParameter(AestraOTT::kXoverLow, 0.35f);
+    ott.setParameter(AestraOTT::kXoverHigh, 0.75f);
+
+    const auto state = ott.saveState();
+
+    AestraOTT restored;
+    restored.initialize(kSampleRate, kBlockSize);
+    restored.activate();
+    if (!restored.loadState(state))
+        return false;
+
+    for (uint32_t i = 0; i < AestraOTT::kParamCount; ++i) {
+        if (std::abs(restored.getParameter(i) - ott.getParameter(i)) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testLoadStateRejectsGarbage() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.activate();
+
+    std::vector<uint8_t> tooShort = {0x31, 0x54};
+    if (ott.loadState(tooShort))
+        return false;
+
+    std::vector<uint8_t> wrongMagic(64, 0);
+    if (ott.loadState(wrongMagic))
+        return false;
+    return true;
+}
+
+bool testParameterMapping() {
+    // Time center detent must be exactly 1x, gain centers exactly 0 dB.
+    if (std::abs(AestraOTT::timeMultFromNorm(0.5f) - 1.0f) > 0.01f)
+        return false;
+    if (std::abs(AestraOTT::bipolarDbFromNorm(0.5f, 24.0f)) > 0.001f)
+        return false;
+    if (std::abs(AestraOTT::xoverLowHzFromNorm(0.0f) - 60.0f) > 0.1f)
+        return false;
+    if (std::abs(AestraOTT::xoverHighHzFromNorm(1.0f) - 8000.0f) > 1.0f)
+        return false;
+    return true;
+}
+
+bool testStableAcrossSampleRates() {
+    for (double sr : {44100.0, 96000.0, 192000.0}) {
+        AestraOTT ott;
+        ott.initialize(sr, kBlockSize);
+        ott.setParameter(AestraOTT::kDepth, 1.0f);
+        ott.setParameter(AestraOTT::kXoverHigh, 1.0f); // 8 kHz
+        ott.activate();
+
+        const auto in = makeSine(static_cast<uint32_t>(sr), 1000.0f, 1.0f, sr);
+        auto out = processStereo(ott, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+        if (peakAmplitude(out.left, static_cast<size_t>(sr) / 2) > 16.0f)
+            return false;
+    }
+    return true;
+}
+
+struct TestCase {
+    const char* name;
+    bool (*fn)();
+};
+
+} // namespace
+
+int main() {
+    const TestCase tests[] = {
+        {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
+        {"SilenceStaysSilent", testSilenceStaysSilent},
+        {"DepthZeroIsSpectrallyFlat", testDepthZeroIsSpectrallyFlat},
+        {"DownwardCompressesLoudSignal", testDownwardCompressesLoudSignal},
+        {"UpwardBoostsQuietSignal", testUpwardBoostsQuietSignal},
+        {"UpwardGateSparesNoiseFloor", testUpwardGateSparesNoiseFloor},
+        {"DepthScalesEffect", testDepthScalesEffect},
+        {"MultibandIndependence", testMultibandIndependence},
+        {"BandTrimsShapeOutput", testBandTrimsShapeOutput},
+        {"SurvivesHostileInput", testSurvivesHostileInput},
+        {"StableAtParameterExtremes", testStableAtParameterExtremes},
+        {"StateRoundTrip", testStateRoundTrip},
+        {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
+        {"ParameterMapping", testParameterMapping},
+        {"StableAcrossSampleRates", testStableAcrossSampleRates},
+    };
+
+    int failures = 0;
+    for (const auto& test : tests) {
+        const bool passed = test.fn();
+        std::cout << (passed ? "[PASS] " : "[FAIL] ") << test.name << "\n";
+        if (!passed)
+            ++failures;
+    }
+
+    if (failures > 0) {
+        std::cout << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All AestraOTT tests passed\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AestraOTTTest.cpp
+++ b/Tests/AestraAudio/AestraOTTTest.cpp
@@ -311,7 +311,8 @@ bool testSetParameterRejectsNonFinite() {
     for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
         std::memcpy(state.data() + off, &nan, sizeof(float));
     }
-    ott.loadState(state);
+    if (ott.loadState(state))
+        return false; // an all-NaN blob must be rejected, not accepted as success
     for (uint32_t i = 0; i < AestraOTT::kParamCount; ++i) {
         if (!std::isfinite(ott.getParameter(i)))
             return false;

--- a/Tests/AestraAudio/AestraOTTTest.cpp
+++ b/Tests/AestraAudio/AestraOTTTest.cpp
@@ -106,6 +106,22 @@ bool testBypassPassesAudioUnchanged() {
     return true;
 }
 
+// initialize() is re-called by EffectChain::prepare() on stream/sample-rate
+// changes; after the first init it must preserve the user's parameter values,
+// not reset them to defaults.
+bool testReinitializePreservesParams() {
+    AestraOTT ott;
+    ott.initialize(kSampleRate, kBlockSize);
+    ott.setParameter(AestraOTT::kDepth, 0.33f);
+    ott.setParameter(AestraOTT::kXoverLow, 0.7f);
+    ott.setParameter(AestraOTT::kLowGain, 0.8f);
+    // Simulate a device / sample-rate change: EffectChain::prepare re-inits.
+    ott.initialize(96000, kBlockSize);
+    return std::abs(ott.getParameter(AestraOTT::kDepth) - 0.33f) < 1e-6f &&
+           std::abs(ott.getParameter(AestraOTT::kXoverLow) - 0.7f) < 1e-6f &&
+           std::abs(ott.getParameter(AestraOTT::kLowGain) - 0.8f) < 1e-6f;
+}
+
 // The upward gain gate: silence must never be dragged up.
 bool testSilenceStaysSilent() {
     AestraOTT ott;
@@ -115,7 +131,10 @@ bool testSilenceStaysSilent() {
 
     const auto silence = makeSilence(8192);
     auto out = processStereo(ott, silence, silence);
-    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+    // allFinite guards against a NaN slipping through: peakAmplitude() can
+    // return 0 for a NaN, so the peak check alone would not catch it.
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f && allFinite(out.left) &&
+           allFinite(out.right);
 }
 
 // With depth 0 and trims centered, the band split must reconstruct flat:
@@ -388,6 +407,7 @@ int main() {
     const TestCase tests[] = {
         {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
         {"SilenceStaysSilent", testSilenceStaysSilent},
+        {"ReinitializePreservesParams", testReinitializePreservesParams},
         {"DepthZeroIsSpectrallyFlat", testDepthZeroIsSpectrallyFlat},
         {"DownwardCompressesLoudSignal", testDownwardCompressesLoudSignal},
         {"UpwardBoostsQuietSignal", testUpwardBoostsQuietSignal},

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1245,6 +1245,17 @@ else()
     message(STATUS "AestraFilterBench built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
 
+# Aestra OTT Test
+add_executable(AestraOTTTest AestraAudio/AestraOTTTest.cpp)
+target_link_libraries(AestraOTTTest PRIVATE AestraAudio)
+target_include_directories(AestraOTTTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraOTTTest COMMAND AestraOTTTest)
+set_tests_properties(AestraOTTTest PROPERTIES LABELS "audio;plugins;ott")
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds **AestraOTT** (`com.Aestrastudios.ott`), the third plugin in the free-suite build-out (stacked on #473 → #472). A 3-band "over-the-top" style compressor: LR4 band split, per-band stereo-linked gain computers that simultaneously compress loud bands **down** and boost quiet bands **up** toward a fixed −18 dBFS target.

## Why

AestraOTT is on the Supporter/Advanced plugin list and didn't exist in the repo. Multiband up/down compression is the signature "glue + excitement" tool in modern electronic production, and it exercises repo-first infrastructure we'll reuse (LR4 crossover network as a pattern for AestraMulti later).

## Design

- **Crossovers**: 4th-order Linkwitz-Riley (two cascaded Butterworth TPT-SVF stages per slope) at 60–500 Hz and 1–8 kHz. The low band passes through the LR4 allpass at the high crossover, so `low + mid + high` reconstructs allpass-flat — verified by a test probing right at the crossover frequencies.
- **Gain computer** (per band, stereo-linked peak follower): `gain = (−18 − envDb) · 0.6` — symmetric upward/downward. Upward gain fades to zero between −40 and −50 dB (silence and noise floors are never dragged up) and is capped at +24 dB.
- **Depth** scales the computed gain in the dB domain — the "wet" control lives in gain space, not a dry/wet mix, so there is no phase-cancelling recombination with the allpass-rotated wet path.
- **Time macro** (0.1×–10×) scales per-band base attack/release (low 24/240 ms, mid 10/120 ms, high 3/60 ms).
- **Params** (stable IDs 0–9): Depth, Time, In ±24 dB, Out ±24 dB, Low/Mid/High trims ±12 dB, X-Low, X-High, Bypass. State blob `'OTT1'` magic + version.
- **RT safety**: no allocation/locks/IO in `process()`; `tan`/`exp` coefficient recomputation is gated on smoothed-param movement; NaN/Inf sanitized; denormal flush. Zero latency, per-band gain metering hook (`getBandGainDb`) for a future GR display.
- **Editor**: violet house-style panel (Depth large, Time/In/Out macro row, band trims + crossovers row, bypass pill).

## Testing performed

- `AestraOTTTest` — 15 headless contract tests, **all passing**: bypass parity, silence stays silent (gate), depth-0 spectral flatness at 80 Hz–6 kHz including both crossover points, downward compression of 0 dBFS signal, upward boost of −30 dB signal, gate at −70 dB, depth scaling, multiband independence (loud low band compressed while quiet high band boosted in the same pass), band trims, hostile input (NaN/Inf/±100), all-params-at-extremes stability, state round-trip, garbage-state rejection, parameter mapping, 44.1/96/192 kHz stability.
- Full `build-linux` build of all targets clean (including `Aestra` app link); `ctest -L plugins`: **11/11 passed**.
- clang-format applied.

## Docs updated?

No — `docs/` has no plugin inventory page; nothing public claims this feature yet.

## Risk / rollback

- Purely additive: new files + registration lines; no existing DSP, serialization, or plugin touched. Revert = drop the commit.
- New state format only affects projects that saved an AestraOTT instance.
- Stacked on #473 (which stacks on #472); merge those first — shared edits in `BuiltInPlugins.*`, `PluginUIController.cpp`, and the CMake lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes; adds the new `AestraOTT` built-in plugin (`com.Aestrastudios.ott`), a three-band upward/downward compressor targeting −18 dBFS.
- Implements LR4 crossover processing, stereo-linked band compression, configurable depth/timing, trims, gains, crossovers, bypass, smoothing, metering hooks, state persistence, and hostile-input handling.
- Registers the plugin with built-in metadata and adds a violet-style editor with bypass and knob controls.
- Adds comprehensive DSP contract, robustness, automation, block-size, sample-rate, and state serialization tests, wired into CTest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->