### PR TITLE
test(infra): race-free shared temp-directory helper; fix ctest -j collision

### DIFF
--- a/Tests/AestraAudio/ArsenalRouteModeRoundTripTest.cpp
+++ b/Tests/AestraAudio/ArsenalRouteModeRoundTripTest.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 void require(bool cond, const char* msg) {
@@ -24,19 +25,7 @@ void require(bool cond, const char* msg) {
 }
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("ArsenalRouteModeRoundTrip_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-    auto fallback = base / "ArsenalRouteModeRoundTrip_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ArsenalRouteModeRoundTrip");
 }
 
 struct TempDir {

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -9,22 +9,12 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("AutosaveManager_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-    auto fallback = base / "AutosaveManager_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("AutosaveManager");
 }
 
 void require(bool cond, const char* msg) {

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -1,21 +1,18 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "Core/AutosaveManager.h"
+
+#include "../Support/TestTempDirectory.h"
 #include "AestraLog.h"
 
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>
-#include <chrono>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("AutosaveManager");
-}
 
 void require(bool cond, const char* msg) {
     if (!cond) {
@@ -29,7 +26,8 @@ void require(bool cond, const char* msg) {
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"AutosaveManager"};
+    const auto& tempDir = tempDirScope.path();
     const auto autosavePath = tempDir / "override.autosave.aes";
 
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
@@ -51,8 +49,7 @@ int main() {
         };
 
         manager.initialize("some_project.aes", std::move(config));
-        require(manager.getAutosavePath() == autosavePath.string(),
-                "autosavePathOverride should be respected");
+        require(manager.getAutosavePath() == autosavePath.string(), "autosavePathOverride should be respected");
 
         manager.markDirty();
         std::this_thread::sleep_for(std::chrono::seconds(2));

--- a/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
+++ b/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
@@ -9,6 +9,7 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+#include "../Support/TestTempDirectory.h"
 #endif
 
 namespace {
@@ -20,19 +21,7 @@ void require(bool cond, const char* msg) {
 }
 
 std::filesystem::path makeTempDir() {
-    const auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-    for (int i = 0; i < 1000; ++i) {
-        const auto candidate = base / ("PluginScannerSigpipe_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-
-    const auto fallback = base / "PluginScannerSigpipe_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("PluginScannerSigpipe");
 }
 
 #ifndef _WIN32

--- a/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
+++ b/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
@@ -8,8 +8,9 @@
 #include <iostream>
 
 #ifndef _WIN32
-#include <unistd.h>
 #include "../Support/TestTempDirectory.h"
+
+#include <unistd.h>
 #endif
 
 namespace {
@@ -18,10 +19,6 @@ void require(bool cond, const char* msg) {
         std::cerr << "[FAIL] " << msg << "\n";
         std::exit(1);
     }
-}
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("PluginScannerSigpipe");
 }
 
 #ifndef _WIN32
@@ -42,7 +39,8 @@ int main() {
     std::cout << "[SKIP] PluginScannerSigpipeTest is Unix-only\n";
     return 0;
 #else
-    const auto dir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory dirScope{"PluginScannerSigpipe"};
+    const auto& dir = dirScope.path();
     const auto clapPath = dir / "broken.clap";
     {
         std::ofstream out(clapPath, std::ios::binary);

--- a/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
+++ b/Tests/AestraAudio/PluginScannerSigpipeTest.cpp
@@ -50,7 +50,6 @@ int main() {
     const std::string falseExecutable = findFalseExecutable();
     if (falseExecutable.empty()) {
         std::cout << "[SKIP] PluginScannerSigpipeTest: no false executable found\n";
-        std::filesystem::remove_all(dir);
         return 0;
     }
 
@@ -66,8 +65,6 @@ int main() {
     } else {
         unsetenv("AESTRA_PLUGIN_HOST_PATH");
     }
-
-    std::filesystem::remove_all(dir);
 
 #ifdef AESTRA_TEST_HAS_CLAP
     require(plugins.empty(), "Broken out-of-process CLAP scan should not return plugin metadata");

--- a/Tests/AestraLicense/LocalAccountCacheTest.cpp
+++ b/Tests/AestraLicense/LocalAccountCacheTest.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 using Aestra::License::AccountSessionState;
 using Aestra::License::LocalAccountCache;
@@ -16,9 +17,7 @@ using Aestra::License::LocalAccountRecord;
 namespace {
 
 std::filesystem::path testCachePath() {
-    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-    return std::filesystem::temp_directory_path() /
-           ("aestra_local_account_cache_test_" + std::to_string(stamp) + ".json");
+    return Aestra::Tests::makeUniqueTempDirectory("LocalAccountCache") / "account_cache.json";
 }
 
 LocalAccountRecord validRecord() {

--- a/Tests/AestraLicense/LocalAccountCacheTest.cpp
+++ b/Tests/AestraLicense/LocalAccountCacheTest.cpp
@@ -2,12 +2,12 @@
 
 #include "LocalAccountCache.h"
 
+#include "../Support/TestTempDirectory.h"
+
 #include <cassert>
-#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 using Aestra::License::AccountSessionState;
 using Aestra::License::LocalAccountCache;
@@ -15,10 +15,6 @@ using Aestra::License::LocalAccountCacheLoadStatus;
 using Aestra::License::LocalAccountRecord;
 
 namespace {
-
-std::filesystem::path testCachePath() {
-    return Aestra::Tests::makeUniqueTempDirectory("LocalAccountCache") / "account_cache.json";
-}
 
 LocalAccountRecord validRecord() {
     LocalAccountRecord record;
@@ -34,7 +30,8 @@ LocalAccountRecord validRecord() {
 }
 
 void testRoundTrip() {
-    const std::filesystem::path path = testCachePath();
+    const Aestra::Tests::ScopedTempDirectory cacheDir{"LocalAccountCache"};
+    const std::filesystem::path path = cacheDir.path() / "account_cache.json";
     LocalAccountCache cache(path);
     assert(cache.save(validRecord()));
 
@@ -45,7 +42,8 @@ void testRoundTrip() {
 }
 
 void testOversizedCacheLoadIsMalformed() {
-    const std::filesystem::path path = testCachePath();
+    const Aestra::Tests::ScopedTempDirectory cacheDir{"LocalAccountCache"};
+    const std::filesystem::path path = cacheDir.path() / "account_cache.json";
     {
         std::ofstream file(path, std::ios::binary | std::ios::trunc);
         file << std::string(64u * 1024u + 1u, 'x');
@@ -58,7 +56,8 @@ void testOversizedCacheLoadIsMalformed() {
 }
 
 void testOversizedCacheSaveIsRejected() {
-    const std::filesystem::path path = testCachePath();
+    const Aestra::Tests::ScopedTempDirectory cacheDir{"LocalAccountCache"};
+    const std::filesystem::path path = cacheDir.path() / "account_cache.json";
     LocalAccountCache cache(path);
     LocalAccountRecord record = validRecord();
     record.sessionToken = std::string(64u * 1024u, 'x');

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -64,6 +64,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/VST3PluginTest.cpp")
     endif()
 endif()
 
+# Test temp-directory reliability stress test — proves makeUniqueTempDirectory
+# never hands two callers the same path under heavy concurrency (regression
+# guard for the ctest -j temp-dir collision).
+add_executable(TestTempDirectoryStressTest Support/TestTempDirectoryStressTest.cpp)
+find_package(Threads REQUIRED)
+target_link_libraries(TestTempDirectoryStressTest PRIVATE Threads::Threads)
+add_test(NAME TestTempDirectoryStressTest COMMAND TestTempDirectoryStressTest)
+set_tests_properties(TestTempDirectoryStressTest PROPERTIES LABELS "support;infrastructure")
+
 # Project RoundTrip Test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripTest.cpp")
     add_executable(ProjectRoundTripTest

--- a/Tests/Integration/InternalPluginProjectRoundTripTest.cpp
+++ b/Tests/Integration/InternalPluginProjectRoundTripTest.cpp
@@ -1,19 +1,15 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/TrackManager.h"
 #include "Plugin/PluginManager.h"
 
 #include <cmath>
 #include <filesystem>
 #include <iostream>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("InternalPluginRoundTrip");
-}
-
 void require(bool cond, const char* msg) {
     if (!cond) {
         std::cerr << "[FAIL] " << msg << "\n";
@@ -29,7 +25,8 @@ bool nearlyEqual(float a, float b, float epsilon = 1.0e-6f) {
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"InternalPluginRoundTrip"};
+    const auto& tempDir = tempDirScope.path();
     const auto projectPath = tempDir / "internal-plugin-project.aes";
 
     auto& pluginManager = PluginManager::getInstance();

--- a/Tests/Integration/InternalPluginProjectRoundTripTest.cpp
+++ b/Tests/Integration/InternalPluginProjectRoundTripTest.cpp
@@ -7,23 +7,11 @@
 #include <cmath>
 #include <filesystem>
 #include <iostream>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("InternalPluginProjectRoundTrip_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-
-    auto fallback = base / "InternalPluginProjectRoundTrip_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("InternalPluginRoundTrip");
 }
 
 void require(bool cond, const char* msg) {

--- a/Tests/Integration/ProjectFixtureCorpusTest.cpp
+++ b/Tests/Integration/ProjectFixtureCorpusTest.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
@@ -231,8 +232,7 @@ int main() {
             "re-save not stamped with current version (migration did not run)");
 
     // ---------------- The re-save must load with every value intact.
-    const auto tempDir = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(tempDir);
+    const auto tempDir = Aestra::Tests::makeUniqueTempDirectory("ProjectFixtureCorpus");
     const auto resavePath = tempDir / "v1_rich_resaved.aes";
     require(ProjectSerializer::writeAtomically(resavePath.string(), resave.contents), "re-save write failed");
 

--- a/Tests/Integration/ProjectFixtureCorpusTest.cpp
+++ b/Tests/Integration/ProjectFixtureCorpusTest.cpp
@@ -15,6 +15,7 @@
 // smoke) and ProjectValueFidelityTest (current-version roundtrip fidelity).
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -25,7 +26,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
 
@@ -68,8 +68,7 @@ constexpr float kSendPan = 0.111111f;
 // The full expected-value set for v1_rich.aes. Runs against the direct fixture
 // load AND against a load of its re-save, so values must survive migration and
 // a full write cycle.
-void assertRichFixture(Aestra::Audio::TrackManager& tm,
-                       const ProjectSerializer::LoadResult& load,
+void assertRichFixture(Aestra::Audio::TrackManager& tm, const ProjectSerializer::LoadResult& load,
                        const std::string& gen) {
     using namespace Aestra::Audio;
     auto tag = [&gen](const char* what) { return gen + ": " + what; };
@@ -232,7 +231,8 @@ int main() {
             "re-save not stamped with current version (migration did not run)");
 
     // ---------------- The re-save must load with every value intact.
-    const auto tempDir = Aestra::Tests::makeUniqueTempDirectory("ProjectFixtureCorpus");
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectFixtureCorpus"};
+    const auto& tempDir = tempDirScope.path();
     const auto resavePath = tempDir / "v1_rich_resaved.aes";
     require(ProjectSerializer::writeAtomically(resavePath.string(), resave.contents), "re-save write failed");
 

--- a/Tests/Integration/ProjectIntegrityCheckTest.cpp
+++ b/Tests/Integration/ProjectIntegrityCheckTest.cpp
@@ -12,6 +12,7 @@
 //   4. the autosave path (serialize + writeAtomically) carries the checksum too.
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/TrackManager.h"
 
 #include <filesystem>
@@ -19,7 +20,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
 
@@ -30,10 +30,6 @@ void require(bool cond, const std::string& msg) {
         std::cerr << "[FAIL] " << msg << "\n";
         ++g_failures;
     }
-}
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("ProjectIntegrityCheck");
 }
 
 std::shared_ptr<Aestra::Audio::TrackManager> makeFreshManager() {
@@ -57,7 +53,8 @@ bool reportHasIntegrityIssue(const ProjectSerializer::LoadResult& load) {
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectIntegrityCheck"};
+    const auto& tempDir = tempDirScope.path();
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
 
     // Build a small project.
@@ -94,8 +91,7 @@ int main() {
         auto tm3 = makeFreshManager();
         auto load = ProjectSerializer::load(corruptPath.string(), tm3);
         require(load.ok, "corrupted-value file must still load non-destructively");
-        require(load.integrity == ProjectSerializer::LoadIntegrity::Mismatch,
-                "corrupted file did not report Mismatch");
+        require(load.integrity == ProjectSerializer::LoadIntegrity::Mismatch, "corrupted file did not report Mismatch");
         require(reportHasIntegrityIssue(load), "mismatch missing from the structured load report");
     }
 

--- a/Tests/Integration/ProjectIntegrityCheckTest.cpp
+++ b/Tests/Integration/ProjectIntegrityCheckTest.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
@@ -32,18 +33,7 @@ void require(bool cond, const std::string& msg) {
 }
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("IntegrityCheck_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-    auto fallback = base / "IntegrityCheck_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ProjectIntegrityCheck");
 }
 
 std::shared_ptr<Aestra::Audio::TrackManager> makeFreshManager() {

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "../Support/TestTempDirectory.h"
 
 using namespace Aestra;
 using namespace Aestra::Audio;
@@ -86,20 +87,7 @@ bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, in
 }
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("ProjectLoadTests_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-
-    auto fallback = base / "ProjectLoadTests_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ProjectLoadRegression");
 }
 
 void testValidProjectLoad() {

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -3,6 +3,7 @@
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -17,7 +18,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "../Support/TestTempDirectory.h"
 
 using namespace Aestra;
 using namespace Aestra::Audio;
@@ -86,14 +86,11 @@ bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, in
     return out.good();
 }
 
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("ProjectLoadRegression");
-}
-
 void testValidProjectLoad() {
     std::cout << "[TEST] Valid project load..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testWav = testDir / "audio.wav";
     std::filesystem::path testProject = testDir / "project.aes";
 
@@ -103,7 +100,8 @@ void testValidProjectLoad() {
         "version": 1,
         "tempo": 120.0,
         "playhead": 0.0,
-        "sources": [{"id": 1, "path": ")" + testWav.generic_string() + R"(", "name": "Test Audio"}],
+        "sources": [{"id": 1, "path": ")" +
+                              testWav.generic_string() + R"(", "name": "Test Audio"}],
         "patterns": [
             {"id": 1, "name": "Test Pattern", "type": "midi", "length": 4.0, "notes": []}
         ],
@@ -141,7 +139,8 @@ void testValidProjectLoad() {
 void testMissingPatternReference() {
     std::cout << "[TEST] Missing pattern reference preserves placeholder..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // Project references pattern ID 999 which does NOT exist in patterns array
@@ -196,7 +195,8 @@ void testMissingPatternReference() {
 void testMissingArsenalUnitReference() {
     std::cout << "[TEST] Missing Arsenal unit reference preserves note..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // MIDI note references unit ID 888 which does NOT exist in arsenal
@@ -243,7 +243,8 @@ void testMissingArsenalUnitReference() {
 void testFailedValidationDoesNotClear() {
     std::cout << "[TEST] Failed validation does not clear existing state..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // Invalid project - missing required "lanes" field
@@ -281,7 +282,8 @@ void testFailedValidationDoesNotClear() {
 void testUnitManagerSurvivesFailedLoad() {
     std::cout << "[TEST] UnitManager survives failed PHASE 3 validation..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // Invalid project - missing required "lanes" field
@@ -321,7 +323,8 @@ void testUnitManagerSurvivesFailedLoad() {
 void testMissingAudioFileNonDestructive() {
     std::cout << "[TEST] Missing audio file is non-destructive..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // References a file that does NOT exist
@@ -329,7 +332,8 @@ void testMissingAudioFileNonDestructive() {
         "version": 1,
         "tempo": 120.0,
         "playhead": 0.0,
-        "sources": [{"id": 1, "path": ")" + (testDir / "nonexistent.wav").generic_string() + R"(", "name": "Missing Audio"}],
+        "sources": [{"id": 1, "path": ")" +
+                              (testDir / "nonexistent.wav").generic_string() + R"(", "name": "Missing Audio"}],
         "patterns": [],
         "lanes": [],
         "arsenal": {"nextId": 1, "units": []}
@@ -354,7 +358,8 @@ void testMissingAudioFileNonDestructive() {
 void testUnresolvedRouteTargetNonFatal() {
     std::cout << "[TEST] Unresolved send routing targets are non-fatal..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // Project with routing sends to a channel ID that doesn't exist.
@@ -437,8 +442,7 @@ void testUnresolvedRouteTargetNonFatal() {
     // Verify that saving and reloading preserves the routing (no data loss).
     std::string saved = ProjectSerializer::serialize(trackManager, 120.0, 0.0, 0).contents;
     assert(!saved.empty());
-    assert(saved.find("\"targetId\": 99") != std::string::npos ||
-           saved.find("\"targetId\":99") != std::string::npos);
+    assert(saved.find("\"targetId\": 99") != std::string::npos || saved.find("\"targetId\":99") != std::string::npos);
 
     // Load the re-saved project and verify routing is still preserved.
     std::filesystem::path testProject2 = testDir / "project2.aes";
@@ -504,10 +508,10 @@ void testV1FixtureMigratesToCurrentVersion() {
     assert(std::abs(patterns[0]->getMidiNotes()[0].velocity - 0.75f) < 1e-6f);
 
     std::string saved = ProjectSerializer::serialize(trackManager, result.tempo, result.playhead, 0).contents;
-    assert(saved.find("\"version\": 2") != std::string::npos ||
-           saved.find("\"version\":2") != std::string::npos);
+    assert(saved.find("\"version\": 2") != std::string::npos || saved.find("\"version\":2") != std::string::npos);
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     auto migratedPath = testDir / "v1_migrated_roundtrip.aes";
     std::ofstream migratedOut(migratedPath);
     migratedOut << saved;
@@ -550,7 +554,8 @@ void testV1FixtureMigratesToCurrentVersion() {
 void testAutomationTarget256DoesNotWrapToVolume() {
     std::cout << "[TEST] AutomationTarget 256 does not wrap to Volume..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     // AutomationTarget is uint8_t. Raw static_cast wraps 256→0 (Volume).
@@ -637,7 +642,8 @@ void testAutomationTarget256DoesNotWrapToVolume() {
 void testMixerLaneStateNumbersClampBeforeCast() {
     std::cout << "[TEST] Mixer lane state numbers clamp before cast..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     std::string projectJson = R"({
@@ -698,7 +704,8 @@ void testMixerLaneStateNumbersClampBeforeCast() {
 void testTrackColorIndexRoundtrip() {
     std::cout << "[TEST] trackColorIndex survives save/load roundtrip..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     std::string projectJson = R"({
@@ -774,18 +781,22 @@ void testTrackColorIndexRoundtrip() {
 void testProjectLoadWarningsAreBounded() {
     std::cout << "[TEST] Project load warnings are bounded..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     std::ostringstream lanes;
     for (int i = 0; i < 100; ++i) {
-        if (i > 0) lanes << ",";
+        if (i > 0)
+            lanes << ",";
         lanes << R"({
-                "name": "Track )" << i << R"(",
+                "name": "Track )"
+              << i << R"(",
                 "color": "4294967295",
                 "volume": 1.0,
                 "pan": 0.0,
-                "routing": {"sends": [{"targetId": )" << (100000 + i) << R"(, "gain": 1.0}]},
+                "routing": {"sends": [{"targetId": )"
+              << (100000 + i) << R"(, "gain": 1.0}]},
                 "clips": []
             })";
     }
@@ -796,7 +807,8 @@ void testProjectLoadWarningsAreBounded() {
         "playhead": 0.0,
         "sources": [],
         "patterns": [],
-        "lanes": [)" + lanes.str() + R"(],
+        "lanes": [)" + lanes.str() +
+                              R"(],
         "arsenal": {"nextId": 1, "units": []}
     })";
 
@@ -836,7 +848,7 @@ void testProjectLoadWarningsAreBounded() {
     std::filesystem::remove_all(testDir);
 }
 
-}
+} // namespace
 
 int main() {
     std::cout << "=== Project Load Regression Tests ===" << std::endl;

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -132,8 +132,6 @@ void testValidProjectLoad() {
     assert(!result.report || !result.report->hasErrors());
 
     std::cout << "[PASS] Valid project load" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testMissingPatternReference() {
@@ -188,8 +186,6 @@ void testMissingPatternReference() {
     }
 
     std::cout << "[PASS] Missing pattern reference preserves placeholder" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testMissingArsenalUnitReference() {
@@ -236,8 +232,6 @@ void testMissingArsenalUnitReference() {
     }
 
     std::cout << "[PASS] Missing Arsenal unit reference preserves note" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testFailedValidationDoesNotClear() {
@@ -275,8 +269,6 @@ void testFailedValidationDoesNotClear() {
     assert(!laneIds.empty());
 
     std::cout << "[PASS] Failed validation does not clear existing state" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testUnitManagerSurvivesFailedLoad() {
@@ -316,8 +308,6 @@ void testUnitManagerSurvivesFailedLoad() {
 
     // If we got here, no state was cleared (early return preserved everything)
     std::cout << "[PASS] UnitManager survives failed PHASE 3 validation" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testMissingAudioFileNonDestructive() {
@@ -351,8 +341,6 @@ void testMissingAudioFileNonDestructive() {
     assert(!result.missingAssets.empty());
 
     std::cout << "[PASS] Missing audio file is non-destructive" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testUnresolvedRouteTargetNonFatal() {
@@ -463,8 +451,6 @@ void testUnresolvedRouteTargetNonFatal() {
     assert(channel2->getMainOutputId() == channel->getMainOutputId());
 
     std::cout << "[PASS] Unresolved send routing targets are non-fatal" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testV1FixtureMigratesToCurrentVersion() {
@@ -545,8 +531,6 @@ void testV1FixtureMigratesToCurrentVersion() {
     assert(std::abs(roundTripPatterns[0]->getMidiNotes()[0].velocity - 0.75f) < 1e-6f);
     assert(roundTripPatterns[0]->getMidiNotes()[1].pitch == 64);
     assert(std::abs(roundTripPatterns[0]->getMidiNotes()[1].velocity - 0.5f) < 1e-6f);
-
-    std::filesystem::remove_all(testDir);
 
     std::cout << "[PASS] v1 fixture migrates to current project version" << std::endl;
 }
@@ -635,8 +619,6 @@ void testAutomationTarget256DoesNotWrapToVolume() {
     assert(lane2->automationCurves[0].getPoints().size() == 2);
 
     std::cout << "[PASS] AutomationTarget 256 does not wrap to Volume" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testMixerLaneStateNumbersClampBeforeCast() {
@@ -697,8 +679,6 @@ void testMixerLaneStateNumbersClampBeforeCast() {
     assert(negativeChannel->getTrackColorIndex() == -1);
 
     std::cout << "[PASS] Mixer lane state numbers clamp before cast" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testTrackColorIndexRoundtrip() {
@@ -774,8 +754,6 @@ void testTrackColorIndexRoundtrip() {
     assert(trackManager2->getChannel(2)->getTrackColorIndex() == -1);
 
     std::cout << "[PASS] trackColorIndex survives save/load roundtrip" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testProjectLoadWarningsAreBounded() {
@@ -844,8 +822,6 @@ void testProjectLoadWarningsAreBounded() {
     assert(suppressedWarnings == 1);
 
     std::cout << "[PASS] Project load warnings are bounded" << std::endl;
-
-    std::filesystem::remove_all(testDir);
 }
 
 } // namespace

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -19,22 +19,12 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("RoundTrip_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-    auto fallback = base / "RoundTrip_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ProjectRoundTripIntegrity");
 }
 
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -3,6 +3,7 @@
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -19,16 +20,12 @@
 #include <string>
 #include <variant>
 #include <vector>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
 
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("ProjectRoundTripIntegrity");
-}
-
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
-    if (sampleRate <= 0 || numSamples <= 0) return false;
+    if (sampleRate <= 0 || numSamples <= 0)
+        return false;
     const int numChannels = 1;
     const int bitsPerSample = 16;
     const int bytesPerSample = bitsPerSample / 8;
@@ -37,7 +34,8 @@ bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, in
     const std::uint32_t dataSize = static_cast<std::uint32_t>(numSamples * blockAlign);
 
     std::ofstream out(path, std::ios::binary | std::ios::trunc);
-    if (!out) return false;
+    if (!out)
+        return false;
 
     auto writeU32 = [&](std::uint32_t v) { out.write(reinterpret_cast<const char*>(&v), 4); };
     auto writeU16 = [&](std::uint16_t v) { out.write(reinterpret_cast<const char*>(&v), 2); };
@@ -79,8 +77,8 @@ std::string normalizeJson(const std::string& json) {
 }
 
 std::string serializeProject(Aestra::Audio::TrackManager& tm, double tempo, double playhead) {
-    auto ser = ProjectSerializer::serialize(std::shared_ptr<Aestra::Audio::TrackManager>(&tm, [](Aestra::Audio::TrackManager*) {}),
-                                tempo, playhead, 0);
+    auto ser = ProjectSerializer::serialize(
+        std::shared_ptr<Aestra::Audio::TrackManager>(&tm, [](Aestra::Audio::TrackManager*) {}), tempo, playhead, 0);
     return ser.contents;
 }
 
@@ -93,11 +91,13 @@ void compareProjectSemantic(const std::string& json1, const std::string& json2, 
     auto countField = [](const std::string& json, const char* field) -> int {
         std::string pattern = "\"" + std::string(field) + "\":[";
         size_t pos = json.find(pattern);
-        if (pos == std::string::npos) return 0;
+        if (pos == std::string::npos)
+            return 0;
         int count = 0;
         size_t start = pos + pattern.size();
         for (size_t i = start; i < json.size() && json[i] != '}'; ++i) {
-            if (json[i] == '{') ++count;
+            if (json[i] == '{')
+                ++count;
         }
         return count;
     };
@@ -137,9 +137,8 @@ void compareProjectSemantic(const std::string& json1, const std::string& json2, 
 
     if (lanes1 != lanes2 || clips1 != clips2 || notes1 != notes2 || units1 != units2) {
         std::cout << "[FAIL] " << testName << " - count mismatch (lanes:" << lanes1 << "vs" << lanes2
-                 << " clips:" << clips1 << "vs" << clips2
-                 << " notes:" << notes1 << "vs" << notes2
-                 << " units:" << units1 << "vs" << units2 << ")" << std::endl;
+                  << " clips:" << clips1 << "vs" << clips2 << " notes:" << notes1 << "vs" << notes2
+                  << " units:" << units1 << "vs" << units2 << ")" << std::endl;
         assert(false);
     }
 
@@ -154,7 +153,8 @@ void compareProjectSemantic(const std::string& json1, const std::string& json2, 
 void testEmptyProjectRoundTrip() {
     std::cout << "[TEST] Empty project round-trip..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
@@ -177,7 +177,8 @@ void testEmptyProjectRoundTrip() {
 void testSourcesLanesClipsPatternsRoundTrip() {
     std::cout << "[TEST] Sources/lanes/clips/patterns round-trip..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testWav = testDir / "audio.wav";
     std::filesystem::path testProject = testDir / "project.aes";
 
@@ -238,7 +239,8 @@ void testSourcesLanesClipsPatternsRoundTrip() {
 void testArsenalUnitsRoundTrip() {
     std::cout << "[TEST] Arsenal units round-trip..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
@@ -263,7 +265,8 @@ void testArsenalUnitsRoundTrip() {
 void testArsenalDefaultPatternRebindsAfterLoad() {
     std::cout << "[TEST] Arsenal default pattern rebinds after load..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     std::string projectJson = R"({
@@ -329,7 +332,8 @@ void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
     auto& pluginManager = Aestra::Audio::PluginManager::getInstance();
     assert(pluginManager.initialize());
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testWav = testDir / "sampler.wav";
     std::filesystem::path testProject = testDir / "project.aes";
     assert(writeMinimalWavMono16(testWav, 48000, 4800));
@@ -358,7 +362,8 @@ void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
                 "muted": false,
                 "solo": false,
                 "armed": false,
-                "audioClipPath": ")" + wavPath + R"(",
+                "audioClipPath": ")" +
+                              wavPath + R"(",
                 "audioDurationSeconds": 0.1,
                 "defaultPatternId": 1,
                 "pluginId": "com.Aestrastudios.sampler",
@@ -405,7 +410,8 @@ void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
 void testMissingPatternReferenceDoesNotCompound() {
     std::cout << "[TEST] Missing pattern reference does not compound..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     std::string projectJson = R"({
@@ -465,7 +471,8 @@ void testMissingPatternReferenceDoesNotCompound() {
 void testMultipleRoundTripCycles() {
     std::cout << "[TEST] Multiple round-trip cycles..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
@@ -497,7 +504,8 @@ void testMultipleRoundTripCycles() {
 void testAutomationRoundTrip() {
     std::cout << "[TEST] Automation round-trip..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project.aes";
 
     auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
@@ -576,10 +584,16 @@ void testAutomationRoundTrip() {
             // Count objects until end of array
             int braceDepth = 1;
             for (size_t i = start; i < json.size(); ++i) {
-                if (json[i] == '{') ++braceDepth;
-                else if (json[i] == '}') --braceDepth;
-                if (braceDepth == 0) { ++count; break; }
-                else if (json[i] == ',') { std::cerr << ""; } // continue
+                if (json[i] == '{')
+                    ++braceDepth;
+                else if (json[i] == '}')
+                    --braceDepth;
+                if (braceDepth == 0) {
+                    ++count;
+                    break;
+                } else if (json[i] == ',') {
+                    std::cerr << "";
+                } // continue
             }
             pos = start;
         }
@@ -613,14 +627,16 @@ void testAutomationRoundTrip() {
     assert(points1 == points2 && "Automation point count changed across round-trip cycle 1→2");
     assert(points2 == points3 && "Automation point count changed across round-trip cycle 2→3");
 
-    std::cout << "[PASS] Automation round-trip (3 cycles, " << autoCurves3 << " curves, " << points3 << " points)" << std::endl;
+    std::cout << "[PASS] Automation round-trip (3 cycles, " << autoCurves3 << " curves, " << points3 << " points)"
+              << std::endl;
     std::filesystem::remove_all(testDir);
 }
 
 void testLegacyProjectWithoutAutomation() {
     std::cout << "[TEST] Legacy project without automation key..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project_legacy.aes";
 
     // Old-format project: lanes have no "automation" key
@@ -678,7 +694,8 @@ void testLegacyProjectWithoutAutomation() {
 void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
     std::cout << "[TEST] Audio clip duration seconds migration and tempo recompute..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testProject = testDir / "project_audio_duration_migration.aes";
 
     const std::string legacyJson = R"({
@@ -742,7 +759,8 @@ void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
 void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     std::cout << "[TEST] Audio clip placement helper persists clip and duration seconds..." << std::endl;
 
-    auto testDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectRoundTripIntegrity"};
+    const auto& testDir = testDirScope.path();
     std::filesystem::path testWav = testDir / "placed_audio.wav";
     std::filesystem::path testProject = testDir / "project_audio_placement.aes";
     assert(writeMinimalWavMono16(testWav, 48000, 48000));
@@ -792,7 +810,7 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     std::filesystem::remove_all(testDir);
 }
 
-}
+} // namespace
 
 int main() {
     std::cout << "=== Project Round-Trip Integrity Tests ===" << std::endl;

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -171,7 +171,6 @@ void testEmptyProjectRoundTrip() {
     std::string secondSave = serializeProject(*tm2, result.tempo, result.playhead);
 
     compareProjectSemantic(firstSave, secondSave, "empty_project");
-    std::filesystem::remove_all(testDir);
 }
 
 void testSourcesLanesClipsPatternsRoundTrip() {
@@ -233,7 +232,6 @@ void testSourcesLanesClipsPatternsRoundTrip() {
 
     compareProjectSemantic(firstSave, secondSave, "sources_lanes_clips_patterns");
     compareProjectSemantic(secondSave, thirdSave, "sources_lanes_clips_patterns_2nd_cycle");
-    std::filesystem::remove_all(testDir);
 }
 
 void testArsenalUnitsRoundTrip() {
@@ -259,7 +257,6 @@ void testArsenalUnitsRoundTrip() {
     std::string secondSave = serializeProject(*tm2, result.tempo, result.playhead);
 
     compareProjectSemantic(firstSave, secondSave, "arsenal_units");
-    std::filesystem::remove_all(testDir);
 }
 
 void testArsenalDefaultPatternRebindsAfterLoad() {
@@ -322,8 +319,6 @@ void testArsenalDefaultPatternRebindsAfterLoad() {
     const auto& payload = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
     assert(payload.notes.size() == 1);
     assert(payload.notes[0].unitId == 7);
-
-    std::filesystem::remove_all(testDir);
 }
 
 void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
@@ -403,7 +398,6 @@ void testArsenalSamplerAudioClipPathRehydratesPluginAfterLoad() {
     }
     assert(peak > 1.0e-5f);
 
-    std::filesystem::remove_all(testDir);
     std::cout << "[PASS] Arsenal sampler audioClipPath rehydrates plugin after load" << std::endl;
 }
 
@@ -465,7 +459,6 @@ void testMissingPatternReferenceDoesNotCompound() {
 
     compareProjectSemantic(save1, save2, "missing_pattern_round_1");
     compareProjectSemantic(save2, save3, "missing_pattern_round_2");
-    std::filesystem::remove_all(testDir);
 }
 
 void testMultipleRoundTripCycles() {
@@ -498,7 +491,6 @@ void testMultipleRoundTripCycles() {
     }
 
     std::cout << "[PASS] Multiple round-trip cycles (5 cycles)" << std::endl;
-    std::filesystem::remove_all(testDir);
 }
 
 void testAutomationRoundTrip() {
@@ -629,7 +621,6 @@ void testAutomationRoundTrip() {
 
     std::cout << "[PASS] Automation round-trip (3 cycles, " << autoCurves3 << " curves, " << points3 << " points)"
               << std::endl;
-    std::filesystem::remove_all(testDir);
 }
 
 void testLegacyProjectWithoutAutomation() {
@@ -688,7 +679,6 @@ void testLegacyProjectWithoutAutomation() {
     assert(lane2->automationCurves.empty());
 
     std::cout << "[PASS] Legacy project without automation key loads and round-trips" << std::endl;
-    std::filesystem::remove_all(testDir);
 }
 
 void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
@@ -753,7 +743,6 @@ void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
     assert(saved.find("\"durationSeconds\"") != std::string::npos);
 
     std::cout << "[PASS] Audio clip duration seconds migration and tempo recompute" << std::endl;
-    std::filesystem::remove_all(testDir);
 }
 
 void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
@@ -807,7 +796,6 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     assert(std::abs(loadedLane->clips[0].durationBeats - 2.0) < 1.0e-9);
 
     std::cout << "[PASS] Audio clip placement helper persists clip and duration seconds" << std::endl;
-    std::filesystem::remove_all(testDir);
 }
 
 } // namespace

--- a/Tests/Integration/ProjectRoundTripTest.cpp
+++ b/Tests/Integration/ProjectRoundTripTest.cpp
@@ -12,26 +12,12 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    // Ensure uniqueness without relying on high-resolution clocks.
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("ProjectRoundTrip_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-
-    // Fallback (should not happen).
-    auto fallback = base / "ProjectRoundTrip_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ProjectRoundTrip");
 }
 
 // Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager file loading).

--- a/Tests/Integration/ProjectRoundTripTest.cpp
+++ b/Tests/Integration/ProjectRoundTripTest.cpp
@@ -2,6 +2,7 @@
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -12,13 +13,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("ProjectRoundTrip");
-}
 
 // Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager file loading).
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
@@ -79,7 +75,8 @@ void require(bool cond, const char* msg) {
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectRoundTrip"};
+    const auto& tempDir = tempDirScope.path();
     const auto wavPath = tempDir / "test.wav";
     const auto projectPath = tempDir / "project.aes";
     const auto autosavePath = tempDir / "autosave.aes";

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -29,6 +29,7 @@
 // persisted identity is tracked as its own serialization-cluster issue.
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Core/AutomationCurve.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
@@ -41,13 +42,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("ProjectValueFidelity");
-}
 
 // Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager loading).
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
@@ -132,8 +128,7 @@ constexpr float kSendPan = 0.111111f;
 // values that survive one save/load cycle but not two still fail.
 // Note: ProjectSerializer currently lives in the global namespace (its header
 // closes `namespace Aestra` before declaring the class) — see the #266 move.
-void assertAllValues(Aestra::Audio::TrackManager& tm,
-                     const ProjectSerializer::LoadResult& load,
+void assertAllValues(Aestra::Audio::TrackManager& tm, const ProjectSerializer::LoadResult& load,
                      const std::string& gen) {
     using namespace Aestra::Audio;
     auto tag = [&gen](const char* what) { return gen + ": " + what; };
@@ -261,7 +256,8 @@ void assertAllValues(Aestra::Audio::TrackManager& tm,
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectValueFidelity"};
+    const auto& tempDir = tempDirScope.path();
     const auto wavPath = tempDir / "fidelity.wav";
     const auto projectPath = tempDir / "fidelity.aes";
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -41,22 +41,12 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("ValueFidelity_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-    auto fallback = base / "ValueFidelity_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("ProjectValueFidelity");
 }
 
 // Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager loading).

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -12,24 +12,12 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    for (int i = 0; i < 1000; ++i) {
-        auto candidate = base / ("SessionRecovery_" + std::to_string(i));
-        if (!std::filesystem::exists(candidate)) {
-            std::filesystem::create_directories(candidate);
-            return candidate;
-        }
-    }
-
-    auto fallback = base / "SessionRecovery_fallback";
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("SessionRecovery");
 }
 
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -2,6 +2,7 @@
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -12,13 +13,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("SessionRecovery");
-}
 
 bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
     if (sampleRate <= 0 || numSamples <= 0)
@@ -94,10 +90,8 @@ bool isCrashedSession(const std::filesystem::path& path) {
 }
 
 // Mimics RecoveryDialog::detectAutosave — just checks file existence
-bool detectAutosave(const std::filesystem::path& autosavePath,
-                    const std::filesystem::path& recoveryMarkerPath,
-                    const std::string& expectedSessionToken,
-                    std::string& outTimestamp) {
+bool detectAutosave(const std::filesystem::path& autosavePath, const std::filesystem::path& recoveryMarkerPath,
+                    const std::string& expectedSessionToken, std::string& outTimestamp) {
     std::error_code ec;
     if (!std::filesystem::exists(autosavePath, ec) || ec) {
         return false;
@@ -121,7 +115,8 @@ bool detectAutosave(const std::filesystem::path& autosavePath,
 int main() {
     using namespace Aestra::Audio;
 
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"SessionRecovery"};
+    const auto& tempDir = tempDirScope.path();
     const auto wavPath = tempDir / "test.wav";
     const auto autosavePath = tempDir / "autosave.aes";
     const auto recoveryMarkerPath = tempDir / "autosave.aes.recovery";
@@ -232,10 +227,8 @@ int main() {
     require(recoveredChannel1 != nullptr && recoveredChannel2 != nullptr, "Recovered channels missing");
     require(recoveredChannel1->getMainOutputId() == recoveredChannel2->getChannelId(),
             "Recovered main output destination mismatch");
-    require(std::abs(recoveredChannel1->getVolume() - 0.75f) < 1e-6f,
-            "Recovered channel 1 volume mismatch");
-    require(std::abs(recoveredChannel1->getPan() - (-0.25f)) < 1e-6f,
-            "Recovered channel 1 pan mismatch");
+    require(std::abs(recoveredChannel1->getVolume() - 0.75f) < 1e-6f, "Recovered channel 1 volume mismatch");
+    require(std::abs(recoveredChannel1->getPan() - (-0.25f)) < 1e-6f, "Recovered channel 1 pan mismatch");
 
     // --- Clean up
     clearCrashFlag(crashFlagPath);

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -141,7 +141,6 @@ int main() {
     require(switchedManifest.activeTake() && switchedManifest.activeTake()->active,
             "Active take marker was not restored");
 
-    std::filesystem::remove_all(tempDir);
     std::cout << "[PASS] TakeManagerTest\n";
     return 0;
 }

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -3,6 +3,7 @@
 #include "../../Source/Core/TakeManager.h"
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Models/TrackManager.h"
 
 #include <atomic>
@@ -11,13 +12,8 @@
 #include <iostream>
 #include <string>
 #include <thread>
-#include "../Support/TestTempDirectory.h"
 
 namespace {
-
-std::filesystem::path makeTempDir() {
-    return Aestra::Tests::makeUniqueTempDirectory("TakeManager");
-}
 
 void require(bool cond, const char* msg) {
     if (!cond) {
@@ -76,7 +72,8 @@ std::string loadFirstLaneName(const std::string& projectPath) {
 } // namespace
 
 int main() {
-    const auto tempDir = makeTempDir();
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"TakeManager"};
+    const auto& tempDir = tempDirScope.path();
     const auto projectPath = tempDir / "takes_project.aes";
 
     auto trackManager = makeProject("Main Lane");

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -11,26 +11,12 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include "../Support/TestTempDirectory.h"
 
 namespace {
 
 std::filesystem::path makeTempDir() {
-    static std::atomic<uint64_t> counter{0};
-    auto base = std::filesystem::temp_directory_path() / "Aestra_tests";
-    std::filesystem::create_directories(base);
-
-    const auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
-    for (int attempt = 0; attempt < 100; ++attempt) {
-        auto candidate = base / ("TakeManager_" + std::to_string(tid) + "_" + std::to_string(counter.fetch_add(1)));
-        std::error_code ec;
-        if (std::filesystem::create_directories(candidate, ec)) {
-            return candidate;
-        }
-    }
-
-    auto fallback = base / ("TakeManager_fallback_" + std::to_string(counter.fetch_add(1)));
-    std::filesystem::create_directories(fallback);
-    return fallback;
+    return Aestra::Tests::makeUniqueTempDirectory("TakeManager");
 }
 
 void require(bool cond, const char* msg) {

--- a/Tests/Support/TestTempDirectory.h
+++ b/Tests/Support/TestTempDirectory.h
@@ -35,7 +35,7 @@ namespace Aestra::Tests {
 
 // Upper bound on create_directory retries; with the per-call token a single
 // attempt essentially always wins, so this is only a safety net.
-inline constexpr int kMaxTempDirAttempts = 4096;
+inline constexpr int MAX_TEMP_DIR_ATTEMPTS = 4096;
 
 // Root under the system temp dir shared by all Aestra tests. Unique per-call
 // subdirectories live beneath it.
@@ -70,7 +70,7 @@ inline std::filesystem::path makeUniqueTempDirectory(const std::string& prefix) 
     fs::create_directories(base, ec); // idempotent; only the leaf below must be exclusive
 
     const std::string token = uniqueTempToken();
-    for (int attempt = 0; attempt < kMaxTempDirAttempts; ++attempt) {
+    for (int attempt = 0; attempt < MAX_TEMP_DIR_ATTEMPTS; ++attempt) {
         std::string name = prefix;
         name += '_';
         name += token;

--- a/Tests/Support/TestTempDirectory.h
+++ b/Tests/Support/TestTempDirectory.h
@@ -1,0 +1,119 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Race-free temporary-directory allocation for tests.
+//
+// Several test binaries are registered more than once in CTest (e.g.
+// ProjectRoundTripTest / AutosaveRoundTripTest run the same executable), and
+// many tests run in parallel under `ctest -j`. The historical per-test
+// allocator did `exists(candidate)` then `create_directories(candidate)` on a
+// fixed, entropy-free name, so two concurrent processes could select the same
+// directory and clobber each other mid atomic-write (surfacing as an LSan/CI
+// failure). This helper removes that whole class of failure:
+//
+//   * The ownership decision is the atomic result of create_directory() —
+//     mkdir(2)/CreateDirectory succeeds for exactly one caller; the loser
+//     retries the next candidate. No exists()-before-create TOCTOU window.
+//   * A per-call token (steady_clock timestamp + random_device + an in-process
+//     atomic counter) makes collisions vanishingly unlikely across processes
+//     and threads, so the atomic create almost never has to retry. The token
+//     only reduces contention; create_directory is the correctness guarantee.
+//   * Failure is reported explicitly (throw) rather than silently reusing a
+//     shared fallback directory that could reintroduce sharing.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+namespace Aestra::Tests {
+
+// Upper bound on create_directory retries; with the per-call token a single
+// attempt essentially always wins, so this is only a safety net.
+inline constexpr int kMaxTempDirAttempts = 4096;
+
+// Root under the system temp dir shared by all Aestra tests. Unique per-call
+// subdirectories live beneath it.
+inline std::filesystem::path testTempRoot() {
+    return std::filesystem::temp_directory_path() / "Aestra_tests";
+}
+
+// Process/thread-unique token: monotonic clock + non-deterministic entropy +
+// an in-process counter. Never relied on alone — the atomic create below is
+// the actual guard — but it keeps the create loop from ever contending.
+inline std::string uniqueTempToken() {
+    static std::atomic<std::uint64_t> counter{0};
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    std::random_device rd;
+    const std::uint64_t entropy = (static_cast<std::uint64_t>(rd()) << 32) ^ static_cast<std::uint64_t>(rd());
+    const std::uint64_t seq = counter.fetch_add(1, std::memory_order_relaxed);
+    std::string token = std::to_string(static_cast<std::uint64_t>(now));
+    token += '_';
+    token += std::to_string(entropy);
+    token += '_';
+    token += std::to_string(seq);
+    return token;
+}
+
+// Create and return a unique temporary directory named "<prefix>_<token>_<n>".
+// Throws std::runtime_error if a fresh directory cannot be created (should be
+// unreachable given the token, but never silently shares a directory).
+inline std::filesystem::path makeUniqueTempDirectory(const std::string& prefix) {
+    namespace fs = std::filesystem;
+    const fs::path base = testTempRoot();
+    std::error_code ec;
+    fs::create_directories(base, ec); // idempotent; only the leaf below must be exclusive
+
+    const std::string token = uniqueTempToken();
+    for (int attempt = 0; attempt < kMaxTempDirAttempts; ++attempt) {
+        std::string name = prefix;
+        name += '_';
+        name += token;
+        name += '_';
+        name += std::to_string(attempt);
+        fs::path candidate = base / name;
+        std::error_code createEc;
+        // create_directory returns true only if *this* call created it; a
+        // concurrent creator gets false (already exists) and we try the next.
+        if (fs::create_directory(candidate, createEc) && !createEc) {
+            return candidate;
+        }
+    }
+    throw std::runtime_error("makeUniqueTempDirectory: could not create a unique directory for prefix '" + prefix +
+                             "'");
+}
+
+// RAII wrapper that removes its directory on destruction, unless the
+// AESTRA_KEEP_TEST_ARTIFACTS environment variable is set (to anything other
+// than "0"/empty) so a failing test's files can be inspected.
+class ScopedTempDirectory {
+public:
+    explicit ScopedTempDirectory(const std::string& prefix) : m_path(makeUniqueTempDirectory(prefix)) {}
+    ~ScopedTempDirectory() {
+        if (keepArtifacts()) {
+            return;
+        }
+        std::error_code ec;
+        std::filesystem::remove_all(m_path, ec);
+    }
+
+    ScopedTempDirectory(const ScopedTempDirectory&) = delete;
+    ScopedTempDirectory& operator=(const ScopedTempDirectory&) = delete;
+
+    [[nodiscard]] const std::filesystem::path& path() const { return m_path; }
+    operator const std::filesystem::path&() const { return m_path; }
+
+private:
+    static bool keepArtifacts() {
+        const char* v = std::getenv("AESTRA_KEEP_TEST_ARTIFACTS");
+        return v != nullptr && v[0] != '\0' && std::string(v) != "0";
+    }
+    std::filesystem::path m_path;
+};
+
+} // namespace Aestra::Tests

--- a/Tests/Support/TestTempDirectoryStressTest.cpp
+++ b/Tests/Support/TestTempDirectoryStressTest.cpp
@@ -16,18 +16,18 @@
 int main() {
     namespace fs = std::filesystem;
 
-    constexpr int kThreads = 16;
-    constexpr int kPerThread = 250; // 4000 directories total
+    constexpr int THREAD_COUNT = 16;
+    constexpr int DIRS_PER_THREAD = 250; // 4000 directories total
 
-    std::vector<std::vector<fs::path>> perThread(kThreads);
+    std::vector<std::vector<fs::path>> perThread(THREAD_COUNT);
     std::atomic<int> createFailures{0};
 
     std::vector<std::thread> workers;
-    workers.reserve(kThreads);
-    for (int t = 0; t < kThreads; ++t) {
+    workers.reserve(THREAD_COUNT);
+    for (int t = 0; t < THREAD_COUNT; ++t) {
         workers.emplace_back([&, t]() {
-            perThread[t].reserve(kPerThread);
-            for (int i = 0; i < kPerThread; ++i) {
+            perThread[t].reserve(DIRS_PER_THREAD);
+            for (int i = 0; i < DIRS_PER_THREAD; ++i) {
                 try {
                     fs::path p = Aestra::Tests::makeUniqueTempDirectory("Stress");
                     // Must be a real, freshly created directory.
@@ -74,7 +74,7 @@ int main() {
     if (!ok) {
         return 1;
     }
-    std::cout << "[PASS] " << total << " unique temp directories created across " << kThreads << " threads\n";
+    std::cout << "[PASS] " << total << " unique temp directories created across " << THREAD_COUNT << " threads\n";
     std::cout << "All TestTempDirectory stress checks passed\n";
     return 0;
 }

--- a/Tests/Support/TestTempDirectoryStressTest.cpp
+++ b/Tests/Support/TestTempDirectoryStressTest.cpp
@@ -1,0 +1,80 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// TestTempDirectoryStressTest — proves makeUniqueTempDirectory hands out a
+// distinct, freshly-created directory to every caller, even under heavy
+// concurrency. This is the regression guard for the temp-dir collision that
+// previously failed ProjectRoundTripTest under `ctest -j`.
+
+#include "TestTempDirectory.h"
+
+#include <atomic>
+#include <filesystem>
+#include <iostream>
+#include <set>
+#include <thread>
+#include <vector>
+
+int main() {
+    namespace fs = std::filesystem;
+
+    constexpr int kThreads = 16;
+    constexpr int kPerThread = 250; // 4000 directories total
+
+    std::vector<std::vector<fs::path>> perThread(kThreads);
+    std::atomic<int> createFailures{0};
+
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        workers.emplace_back([&, t]() {
+            perThread[t].reserve(kPerThread);
+            for (int i = 0; i < kPerThread; ++i) {
+                try {
+                    fs::path p = Aestra::Tests::makeUniqueTempDirectory("Stress");
+                    // Must be a real, freshly created directory.
+                    if (!fs::exists(p) || !fs::is_directory(p)) {
+                        createFailures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    perThread[t].push_back(std::move(p));
+                } catch (const std::exception&) {
+                    createFailures.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    // Every path returned across all threads must be unique.
+    std::set<fs::path> unique;
+    size_t total = 0;
+    for (const auto& v : perThread) {
+        for (const auto& p : v) {
+            unique.insert(p);
+            ++total;
+        }
+    }
+
+    bool ok = true;
+    if (createFailures.load() != 0) {
+        std::cout << "[FAIL] " << createFailures.load() << " directories were not created / threw\n";
+        ok = false;
+    }
+    if (unique.size() != total) {
+        std::cout << "[FAIL] collision: " << total << " created but only " << unique.size() << " distinct paths\n";
+        ok = false;
+    }
+
+    // Cleanup (best effort — this test intentionally does not keep artifacts).
+    for (const auto& p : unique) {
+        std::error_code ec;
+        fs::remove_all(p, ec);
+    }
+
+    if (!ok) {
+        return 1;
+    }
+    std::cout << "[PASS] " << total << " unique temp directories created across " << kThreads << " threads\n";
+    std::cout << "All TestTempDirectory stress checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes the systemic test temp-directory race that surfaced as the **LSan-lane failure on #473's CI**. Introduces a shared, race-free `Aestra::Tests::makeUniqueTempDirectory` and migrates all 13 racy call sites to it.

## Why

The historical per-test allocator did `exists(candidate)` → `create_directories(candidate)` on a fixed, entropy-free name (`ProjectRoundTrip_<i>`). `ProjectRoundTripTest.cpp` is registered **twice** in CTest (`ProjectRoundTripTest` + `AutosaveRoundTripTest` run the same binary, `Tests/CMakeLists.txt`), so under `ctest -j` both processes selected `/tmp/Aestra_tests/ProjectRoundTrip_0` and then collided on the fixed `autosave.aes.tmp` intermediate during `ProjectSerializer::writeAtomically` → `rename` ENOENT → `ProjectRoundTripTest` failed. It ran under the LSan build, so it showed up red on the LSan advisory lane, but it's a **functional collision, not a memory leak**. The same racy pattern was copy-pasted across ~13 test files, so any two sharing a prefix under `-j` was a latent flake.

## What changed

**New `Tests/Support/TestTempDirectory.h`:**
- `makeUniqueTempDirectory(prefix)` — the ownership decision is the **atomic** result of `std::filesystem::create_directory()` (mkdir/CreateDirectory succeeds for exactly one caller; the loser retries the next candidate). **No `exists()`-before-create TOCTOU window.**
- Per-call token = `steady_clock` timestamp + `random_device` + an in-process atomic counter. This only reduces contention so the atomic create essentially never retries — `create_directory` is the correctness guarantee, not the token (so a weak/deterministic `random_device` can't reintroduce sharing).
- **Explicit failure** (throw) instead of silently reusing a shared fallback directory.
- `ScopedTempDirectory` RAII helper that removes its directory on destruction unless `AESTRA_KEEP_TEST_ARTIFACTS` is set (preserve artifacts for debugging).

**Migrated all 13 sites** — Integration: `ProjectRoundTrip`, `InternalPluginProjectRoundTrip`, `ProjectLoadRegression`, `SessionRecovery`, `ProjectIntegrityCheck`, `ProjectRoundTripIntegrity`, `ProjectValueFidelity`, `TakeManager`, `ProjectFixtureCorpus`; AestraAudio: `ArsenalRouteModeRoundTrip`, `AutosaveManager`, `PluginScannerSigpipe`; AestraLicense: `LocalAccountCache`.

**New `TestTempDirectoryStressTest`** — 16 threads × 250 creations, asserts all 4000 paths are distinct and freshly created.

## Testing performed

- Full `build-linux` build clean (0 errors) with all 13 migrated files.
- `TestTempDirectoryStressTest`: 4000 unique dirs across 16 threads, passes.
- The once-colliding `ProjectRoundTripTest`/`AutosaveRoundTripTest` pair: **5/5 passes** under repeated `ctest -j4`.
- Full `ctest -j4` suite: green except `NUITextInputLayoutTest`, which is a **pre-existing, unrelated** UI-layout failure (issue #458) not touched by this PR (no temp-dir or UI code changed here).

## Docs updated?

No.

## Risk / rollback

- Test-infrastructure only — **no production code, no plugin/DSP changes**, no `RUN_SERIAL`, no suppressions, no test serialization.
- Revert = drop the commit. Each migrated site is a one-line delegation, so behavior is unchanged except that each test now gets a private directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added a shared, race-free test temp-directory helper (`Aestra::Tests::makeUniqueTempDirectory`) using atomic `std::filesystem::create_directory`, unique per-call tokens, explicit failure handling, and an RAII wrapper (`ScopedTempDirectory`) for automatic cleanup (kept only when `AESTRA_KEEP_TEST_ARTIFACTS` is set).
- Migrated 13 tests across Integration, AestraAudio, and AestraLicense to use `ScopedTempDirectory` instead of bespoke temp-dir creation code, eliminating parallel CTest collisions.
- Introduced `TestTempDirectoryStressTest` (16 threads / 4,000 directories) to verify concurrent uniqueness, and registered it in CTest with appropriate labels.
- Aligned new constants to UPPER_SNAKE_CASE style (e.g., `MAX_TEMP_DIR_ATTEMPTS`, `THREAD_COUNT`, `DIRS_PER_THREAD`) and updated tests accordingly (mostly temp-dir wiring/formatting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->