### PR TITLE
feat(plugins): AestraLFO — tempo-syncable audio-path LFO

### DIFF
--- a/AestraAudio/include/Plugin/AestraLFO.h
+++ b/AestraAudio/include/Plugin/AestraLFO.h
@@ -1,0 +1,632 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// AestraLFO V1 — tempo-syncable LFO that shapes the audio flowing through it
+// (LFOTool-style insert effect): rhythmic volume gating/ducking, auto-pan, or
+// filter-cutoff wobble.
+//
+// V1 deliberately modulates its own audio path instead of other plugins'
+// parameters: engine-side parameter modulation routing does not exist yet
+// (issue #467); when it lands, this LFO core can be reused as a source.
+//
+// The LFO free-runs from activate() — it locks to tempo *rate* via setBPM()
+// (same push pattern as AestraDelay) but not to transport *phase*; bar-aligned
+// restart needs a host transport hook that IPluginInstance does not have yet.
+//
+// Signal path (per sample):
+//   lfo phase -> waveform -> smoothing (slew) -> target:
+//     Volume:  gain = 1 - depth * (1 - u)          (u = unipolar LFO, 1 = open)
+//     Pan:     equal-power L/R, unity at center
+//     Cutoff:  ZDF SVF low-pass swept down up to 6 octaves from 20 kHz
+
+#pragma once
+
+#include "Plugin/PluginHost.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+namespace Plugins {
+
+class AestraLFO : public IPluginInstance {
+public:
+    static constexpr uint32_t kStateMagic = 0x4C464F31; // 'LFO1'
+    static constexpr float kCutoffTopHz = 20000.0f;
+    static constexpr float kCutoffSweepOctaves = 6.0f;
+
+    enum Param : uint32_t {
+        kTarget = 0,   // 0=Volume, 1=Pan, 2=Cutoff (stepped)
+        kWave,         // 0=Sine, 1=Triangle, 2=Saw Down, 3=Saw Up, 4=Square, 5=S&H
+        kSyncMode,     // 0=Free, 1=Sync
+        kRateHz,       // 0.02 to 20 Hz (log), free mode
+        kNoteDivision, // 0..12 division table (same table as AestraDelay), sync mode
+        kDepth,        // 0% to 100%
+        kPhase,        // 0 to 360 degrees
+        kSmooth,       // 0 to 200 ms output slew (click-free squares)
+        kBypass,
+        kParamCount,
+    };
+
+    enum Target : uint32_t { kTargetVolume = 0, kTargetPan, kTargetCutoff, kTargetCount };
+    enum Wave : uint32_t { kWaveSine = 0, kWaveTriangle, kWaveSawDown, kWaveSawUp, kWaveSquare, kWaveSH, kWaveCount };
+
+    // Same division indices/labels as AestraDelay so the two read identically.
+    enum NoteDivision : int {
+        kDiv1_1 = 0,
+        kDiv1_2,
+        kDiv1_4,
+        kDiv1_8,
+        kDiv1_16,
+        kDiv1_32,
+        kDiv1_2D,
+        kDiv1_4D,
+        kDiv1_8D,
+        kDiv1_16D,
+        kDiv1_4T,
+        kDiv1_8T,
+        kDiv1_16T,
+    };
+
+    AestraLFO() = default;
+
+    bool initialize(double sampleRate, uint32_t maxBlockSize) override {
+        (void)maxBlockSize;
+        m_sampleRate = std::max(1.0, sampleRate);
+        for (const auto& param : getParameters()) {
+            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        }
+        resetRuntimeState();
+        snapSmoothedParams();
+        return true;
+    }
+
+    void shutdown() override {}
+
+    void activate() override {
+        m_active.store(true, std::memory_order_relaxed);
+        resetRuntimeState();
+        snapSmoothedParams();
+    }
+
+    void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
+    bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
+
+    void setBPM(float bpm) { m_bpm.store(std::clamp(bpm, 20.0f, 999.0f), std::memory_order_relaxed); }
+    float getBPM() const { return m_bpm.load(std::memory_order_relaxed); }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* midiInput = nullptr, MidiBuffer* midiOutput = nullptr) override {
+        (void)midiInput;
+        (void)midiOutput;
+
+        if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+            copyOrClear(inputs, outputs, numInputChannels, numOutputChannels, numFrames);
+            return;
+        }
+
+        const uint32_t channels = std::min<uint32_t>(2, numOutputChannels);
+        const bool stereo = channels >= 2;
+        const float sr = static_cast<float>(m_sampleRate);
+        const auto target = targetFromNorm(m_params[kTarget].load(std::memory_order_relaxed));
+        const auto wave = waveFromNorm(m_params[kWave].load(std::memory_order_relaxed));
+        const bool sync = m_params[kSyncMode].load(std::memory_order_relaxed) > 0.5f;
+        const float bpm = m_bpm.load(std::memory_order_relaxed);
+        const float maxCutoff = 0.45f * sr;
+
+        // Control-block architecture: parameters, the phase increment (pow /
+        // divide) and the slew coefficient (exp) are computed once per block.
+        // The waveform, S&H and slew stay per sample (that is the LFO). Volume
+        // is a cheap linear function of the LFO so it is applied exactly per
+        // sample; the Pan (cos/sin) and Cutoff (exp2/tan) transforms are
+        // evaluated once per block from the block-boundary LFO value and their
+        // coefficients are linearly interpolated across the block, so no
+        // transcendental runs in the per-sample path.
+        for (uint32_t blockStart = 0; blockStart < numFrames; blockStart += kCtrlBlock) {
+            const uint32_t blockEnd = std::min(blockStart + kCtrlBlock, numFrames);
+            const uint32_t blockLen = blockEnd - blockStart;
+
+            m_depthSmoothed += (getParameter(kDepth) - m_depthSmoothed) * m_smoothCoeff;
+            m_phaseOffSmoothed += (getParameter(kPhase) - m_phaseOffSmoothed) * m_smoothCoeff;
+            const float depth = m_depthSmoothed;
+
+            float periodSec;
+            if (sync) {
+                const int div = noteDivisionIndexFromParam(getParameter(kNoteDivision));
+                periodSec = noteDivisionMultiplier(div) * 60.0f / bpm;
+            } else {
+                periodSec = 1.0f / rateHzFromNorm(getParameter(kRateHz));
+            }
+            const float phaseInc = 1.0f / (std::max(1.0e-3f, periodSec) * sr);
+
+            const float smoothMs = smoothMsFromNorm(getParameter(kSmooth));
+            const bool hardSlew = smoothMs < 0.01f;
+            const float slewCoeff = hardSlew ? 1.0f : 1.0f - std::exp(-1.0f / (smoothMs * 0.001f * sr));
+
+            // Pan/Cutoff coefficient targets from the block-boundary LFO value;
+            // ramp the applied coefficients toward them across the block.
+            float dPanGL = 0.0f, dPanGR = 0.0f, dca1 = 0.0f, dca2 = 0.0f, dca3 = 0.0f;
+            if (target == kTargetPan) {
+                const float pan = depth * m_lfoSlewed; // -1 .. +1
+                const float a = (pan + 1.0f) * 0.25f * 3.14159265358979323846f;
+                const float tgtGL = std::cos(a) * 1.41421356f;
+                const float tgtGR = std::sin(a) * 1.41421356f;
+                if (m_coeffsDirty) {
+                    m_panGL = tgtGL;
+                    m_panGR = tgtGR;
+                } else {
+                    dPanGL = (tgtGL - m_panGL) / static_cast<float>(blockLen);
+                    dPanGR = (tgtGR - m_panGR) / static_cast<float>(blockLen);
+                }
+            } else if (target == kTargetCutoff) {
+                const float u = 0.5f + 0.5f * m_lfoSlewed;
+                const float fc =
+                    std::clamp(kCutoffTopHz * std::exp2(-kCutoffSweepOctaves * depth * (1.0f - u)), 20.0f, maxCutoff);
+                const float g = std::tan(3.14159265358979323846f * fc / sr);
+                const float k = 1.41421356f; // Butterworth
+                const float ta1 = 1.0f / (1.0f + g * (g + k));
+                const float ta2 = g * ta1;
+                const float ta3 = g * ta2;
+                if (m_coeffsDirty) {
+                    m_ca1 = ta1;
+                    m_ca2 = ta2;
+                    m_ca3 = ta3;
+                } else {
+                    dca1 = (ta1 - m_ca1) / static_cast<float>(blockLen);
+                    dca2 = (ta2 - m_ca2) / static_cast<float>(blockLen);
+                    dca3 = (ta3 - m_ca3) / static_cast<float>(blockLen);
+                }
+            }
+            m_coeffsDirty = false;
+
+            for (uint32_t i = blockStart; i < blockEnd; ++i) {
+                // ── Advance the LFO phase ──
+                m_phase += phaseInc;
+                if (m_phase >= 1.0f)
+                    m_phase -= std::floor(m_phase);
+
+                float p = m_phase + m_phaseOffSmoothed;
+                p -= std::floor(p);
+
+                // S&H draws a fresh value each cycle (wrap of the offset phase).
+                if (p < m_prevPhase) {
+                    m_lcgState = m_lcgState * 1664525u + 1013904223u;
+                    m_shValue = static_cast<float>(m_lcgState >> 8) * (1.0f / 8388608.0f) - 1.0f;
+                }
+                m_prevPhase = p;
+
+                // ── Waveform, bipolar [-1, 1], "open" (+1) at phase 0 ──
+                float b;
+                switch (wave) {
+                case kWaveSine:
+                    b = std::cos(2.0f * 3.14159265358979323846f * p);
+                    break;
+                case kWaveTriangle:
+                    b = 4.0f * std::abs(p - 0.5f) - 1.0f;
+                    break;
+                case kWaveSawDown:
+                    b = 1.0f - 2.0f * p;
+                    break;
+                case kWaveSawUp:
+                    b = 2.0f * p - 1.0f;
+                    break;
+                case kWaveSquare:
+                    b = (p < 0.5f) ? 1.0f : -1.0f;
+                    break;
+                default:
+                    b = m_shValue;
+                    break;
+                }
+
+                // ── Output slew (one-pole toward the raw wave) ──
+                if (hardSlew) {
+                    m_lfoSlewed = b;
+                } else {
+                    m_lfoSlewed += (b - m_lfoSlewed) * slewCoeff;
+                }
+
+                const float inL = sanitizeSample(readInput(inputs, numInputChannels, 0, i));
+                const float inR = stereo ? sanitizeSample(readInput(inputs, numInputChannels, 1, i)) : inL;
+
+                float outL = inL;
+                float outR = inR;
+                switch (target) {
+                case kTargetVolume: {
+                    const float u = 0.5f + 0.5f * m_lfoSlewed; // unipolar, 1 = open
+                    const float gain = 1.0f - depth * (1.0f - u);
+                    outL = inL * gain;
+                    outR = inR * gain;
+                    break;
+                }
+                case kTargetPan: {
+                    m_panGL += dPanGL;
+                    m_panGR += dPanGR;
+                    outL = inL * m_panGL;
+                    outR = inR * m_panGR;
+                    break;
+                }
+                default: { // kTargetCutoff
+                    m_ca1 += dca1;
+                    m_ca2 += dca2;
+                    m_ca3 += dca3;
+                    for (uint32_t ch = 0; ch < 2; ++ch) {
+                        const float x = (ch == 0) ? inL : inR;
+                        float& ic1 = m_ic1[ch];
+                        float& ic2 = m_ic2[ch];
+                        const float v3 = x - ic2;
+                        const float v1 = m_ca1 * ic1 + m_ca2 * v3;
+                        const float v2 = ic2 + m_ca2 * ic1 + m_ca3 * v3;
+                        ic1 = 2.0f * v1 - ic1;
+                        ic2 = 2.0f * v2 - ic2;
+                        if (ch == 0)
+                            outL = v2;
+                        else
+                            outR = v2;
+                    }
+                    break;
+                }
+                }
+
+                if (outputs[0])
+                    outputs[0][i] = flushDenormal(outL);
+                if (numOutputChannels > 1 && outputs[1])
+                    outputs[1][i] = flushDenormal(stereo ? outR : outL);
+                for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+                    if (outputs[ch])
+                        outputs[ch][i] = 0.0f;
+                }
+            }
+        }
+
+        m_lfoLevel.store(u01(m_lfoSlewed), std::memory_order_relaxed);
+    }
+
+    uint32_t getParameterCount() const override { return kParamCount; }
+
+    float getParameter(uint32_t id) const override {
+        if (id >= kParamCount)
+            return 0.0f;
+        return m_params[id].load(std::memory_order_relaxed);
+    }
+
+    void setParameter(uint32_t id, float value) override {
+        if (id >= kParamCount)
+            return;
+        if (!std::isfinite(value))
+            return;
+        m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
+    }
+
+    std::vector<PluginParameter> getParameters() const override {
+        return {
+            {kTarget, "Target", "TGT", "", 0.0f, 0.0f, 1.0f, true, false, false, kTargetCount - 1},
+            {kWave, "Wave", "WAVE", "", 0.0f, 0.0f, 1.0f, true, false, false, kWaveCount - 1},
+            {kSyncMode, "Sync", "SYNC", "", 1.0f, 0.0f, 1.0f, true, false, false, 1},
+            {kRateHz, "Rate", "RATE", "Hz", 0.566f, 0.0f, 1.0f, true},                                // ~1 Hz
+            {kNoteDivision, "Division", "DIV", "", 2.0f / 12.0f, 0.0f, 1.0f, true, false, false, 12}, // 1/4
+            {kDepth, "Depth", "DPT", "%", 0.5f, 0.0f, 1.0f, true},
+            {kPhase, "Phase", "PHS", "deg", 0.0f, 0.0f, 1.0f, true},
+            {kSmooth, "Smooth", "SMTH", "ms", 0.05f, 0.0f, 1.0f, true}, // 10 ms
+            {kBypass, "Bypass", "BYP", "", 0.0f, 0.0f, 1.0f, true, true, false, 1},
+        };
+    }
+
+    std::string getParameterDisplay(uint32_t id) const override {
+        if (id >= kParamCount)
+            return "";
+        const float v = getParameter(id);
+        char buf[32];
+        switch (id) {
+        case kTarget:
+            switch (targetFromNorm(v)) {
+            case kTargetVolume:
+                return "Volume";
+            case kTargetPan:
+                return "Pan";
+            default:
+                return "Cutoff";
+            }
+        case kWave:
+            switch (waveFromNorm(v)) {
+            case kWaveSine:
+                return "Sine";
+            case kWaveTriangle:
+                return "Triangle";
+            case kWaveSawDown:
+                return "Saw Down";
+            case kWaveSawUp:
+                return "Saw Up";
+            case kWaveSquare:
+                return "Square";
+            default:
+                return "S&H";
+            }
+        case kSyncMode:
+            return v > 0.5f ? "Sync" : "Free";
+        case kRateHz:
+            std::snprintf(buf, sizeof(buf), "%.2f Hz", rateHzFromNorm(v));
+            return buf;
+        case kNoteDivision:
+            return noteDivisionLabel(noteDivisionIndexFromParam(v));
+        case kDepth:
+            return std::to_string(static_cast<int>(std::round(v * 100.0f))) + "%";
+        case kPhase:
+            std::snprintf(buf, sizeof(buf), "%.0f deg", v * 360.0f);
+            return buf;
+        case kSmooth:
+            std::snprintf(buf, sizeof(buf), "%.0f ms", smoothMsFromNorm(v));
+            return buf;
+        case kBypass:
+            return v > 0.5f ? "ON" : "OFF";
+        default:
+            return "";
+        }
+    }
+
+    std::vector<uint8_t> saveState() const override {
+        struct Blob {
+            uint32_t magic = kStateMagic;
+            uint32_t version = 1;
+            float params[kParamCount] = {};
+        } blob;
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            blob.params[i] = getParameter(i);
+        }
+        const auto* data = reinterpret_cast<const uint8_t*>(&blob);
+        return {data, data + sizeof(blob)};
+    }
+
+    bool loadState(const std::vector<uint8_t>& state) override {
+        if (state.size() < sizeof(uint32_t) * 2)
+            return false;
+        uint32_t magic = 0;
+        std::memcpy(&magic, state.data(), sizeof(magic));
+        if (magic != kStateMagic)
+            return false;
+        struct Blob {
+            uint32_t magic;
+            uint32_t version;
+            float params[kParamCount];
+        };
+        if (state.size() < sizeof(Blob))
+            return false;
+        Blob blob{};
+        std::memcpy(&blob, state.data(), sizeof(blob));
+        if (blob.version < 1 || blob.version > 1)
+            return false;
+        // Validate the entire decoded set before mutating anything. setParameter
+        // silently drops non-finite values, so applying in place would leave a
+        // half-updated state while still reporting success — fail atomically.
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            if (!std::isfinite(blob.params[i]) || blob.params[i] < 0.0f || blob.params[i] > 1.0f)
+                return false;
+        }
+        for (uint32_t i = 0; i < kParamCount; ++i) {
+            setParameter(i, blob.params[i]);
+        }
+        return true;
+    }
+
+    bool hasEditor() const override { return true; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {560, 320}; }
+    bool resizeEditor(int, int) override { return false; }
+
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override {
+        // Sample-rate-relative so the reported tail is constant in time, not in
+        // samples. Volume/Pan are multiplicative (silent in -> silent out); the
+        // Cutoff target's Butterworth SVF rings ~ln(1000)/(pi·20 Hz) ≈ 0.11 s at
+        // the low end, so ~120 ms covers the worst case.
+        return static_cast<uint32_t>(m_sampleRate * 0.12);
+    }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+    void setInfo(const PluginInfo& info) { m_info = info; }
+
+    // Metering (for the editor's LFO position indicator), 0..1.
+    float getLfoLevel() const { return m_lfoLevel.load(std::memory_order_relaxed); }
+
+    // ── Parameter mapping (public: shared with editor/tests) ──
+    static float rateHzFromNorm(float value) {
+        // 0.02 .. 20 Hz, log
+        return 0.02f * std::pow(1000.0f, std::clamp(value, 0.0f, 1.0f));
+    }
+
+    static float smoothMsFromNorm(float value) { return std::clamp(value, 0.0f, 1.0f) * 200.0f; }
+
+    static Target targetFromNorm(float value) {
+        return static_cast<Target>(std::min<uint32_t>(
+            kTargetCount - 1,
+            static_cast<uint32_t>(std::clamp(value, 0.0f, 1.0f) * static_cast<float>(kTargetCount - 1) + 0.5f)));
+    }
+
+    static float normFromTarget(Target target) {
+        return static_cast<float>(target) / static_cast<float>(kTargetCount - 1);
+    }
+
+    static Wave waveFromNorm(float value) {
+        return static_cast<Wave>(std::min<uint32_t>(
+            kWaveCount - 1,
+            static_cast<uint32_t>(std::clamp(value, 0.0f, 1.0f) * static_cast<float>(kWaveCount - 1) + 0.5f)));
+    }
+
+    static float normFromWave(Wave wave) { return static_cast<float>(wave) / static_cast<float>(kWaveCount - 1); }
+
+    static int noteDivisionIndexFromParam(float value) {
+        return std::clamp(static_cast<int>(std::round(std::clamp(value, 0.0f, 1.0f) * 12.0f)), 0, 12);
+    }
+
+    static float noteDivisionParamFromIndex(int index) { return static_cast<float>(std::clamp(index, 0, 12)) / 12.0f; }
+
+    /// Division length in beats (quarter notes), matching AestraDelay's table.
+    static float noteDivisionMultiplier(int index) {
+        switch (std::clamp(index, 0, 12)) {
+        case kDiv1_1:
+            return 4.0f;
+        case kDiv1_2:
+            return 2.0f;
+        case kDiv1_4:
+            return 1.0f;
+        case kDiv1_8:
+            return 0.5f;
+        case kDiv1_16:
+            return 0.25f;
+        case kDiv1_32:
+            return 0.125f;
+        case kDiv1_2D:
+            return 3.0f;
+        case kDiv1_4D:
+            return 1.5f;
+        case kDiv1_8D:
+            return 0.75f;
+        case kDiv1_16D:
+            return 0.375f;
+        case kDiv1_4T:
+            return 2.0f / 3.0f;
+        case kDiv1_8T:
+            return 1.0f / 3.0f;
+        case kDiv1_16T:
+            return 1.0f / 6.0f;
+        default:
+            return 1.0f;
+        }
+    }
+
+    static const char* noteDivisionLabel(int index) {
+        switch (std::clamp(index, 0, 12)) {
+        case kDiv1_1:
+            return "1/1";
+        case kDiv1_2:
+            return "1/2";
+        case kDiv1_4:
+            return "1/4";
+        case kDiv1_8:
+            return "1/8";
+        case kDiv1_16:
+            return "1/16";
+        case kDiv1_32:
+            return "1/32";
+        case kDiv1_2D:
+            return "1/2D";
+        case kDiv1_4D:
+            return "1/4D";
+        case kDiv1_8D:
+            return "1/8D";
+        case kDiv1_16D:
+            return "1/16D";
+        case kDiv1_4T:
+            return "1/4T";
+        case kDiv1_8T:
+            return "1/8T";
+        default:
+            return "1/16T";
+        }
+    }
+
+private:
+    static constexpr uint32_t kCtrlBlock = 16; // control-rate interval for param/coefficient updates
+
+    static float u01(float bipolar) { return std::clamp(0.5f + 0.5f * bipolar, 0.0f, 1.0f); }
+
+    void resetRuntimeState() {
+        m_phase = 0.0f;
+        m_prevPhase = 0.0f;
+        m_lfoSlewed = 1.0f; // "open" so volume target starts transparent
+        m_lcgState = 0x12345678u;
+        m_shValue = 0.0f;
+        m_ic1[0] = m_ic1[1] = 0.0f;
+        m_ic2[0] = m_ic2[1] = 0.0f;
+        m_coeffsDirty = true;
+        m_panGL = 1.0f;
+        m_panGR = 1.0f;
+        m_ca1 = m_ca2 = m_ca3 = 0.0f;
+        const float sr = static_cast<float>(m_sampleRate);
+        // Smoothing runs once per control block, so the coefficient is scaled
+        // to the block interval to keep the 2 ms time constant.
+        m_smoothCoeff = 1.0f - std::exp(-static_cast<float>(kCtrlBlock) / (0.002f * sr));
+        m_lfoLevel.store(1.0f, std::memory_order_relaxed);
+    }
+
+    void snapSmoothedParams() {
+        m_depthSmoothed = getParameter(kDepth);
+        m_phaseOffSmoothed = getParameter(kPhase);
+    }
+
+    // ── Utility ──
+    static void copyOrClear(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                            uint32_t numOutputChannels, uint32_t numFrames) {
+        for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
+            if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                // Skip the copy when the host renders in place (out == in):
+                // memcpy on aliased buffers is undefined and the data is already
+                // where it needs to be.
+                if (outputs[ch] != inputs[ch])
+                    std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+            } else if (outputs[ch]) {
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
+            }
+        }
+    }
+
+    static float readInput(const float* const* inputs, uint32_t channels, uint32_t channel, uint32_t frame) {
+        if (channel >= channels || !inputs[channel]) {
+            return (channel == 1 && channels > 0 && inputs[0]) ? inputs[0][frame] : 0.0f;
+        }
+        return inputs[channel][frame];
+    }
+
+    static float sanitizeSample(float sample) {
+        if (!std::isfinite(sample))
+            return 0.0f;
+        return std::clamp(sample, -16.0f, 16.0f);
+    }
+
+    static float flushDenormal(float value) { return std::abs(value) < 1.0e-20f ? 0.0f : value; }
+
+    // ── State ──
+    PluginInfo m_info;
+    double m_sampleRate = 48000.0;
+    std::atomic<bool> m_active{false};
+    std::atomic<float> m_bpm{120.0f};
+    std::array<std::atomic<float>, kParamCount> m_params{};
+
+    float m_phase = 0.0f;
+    float m_prevPhase = 0.0f;
+    float m_lfoSlewed = 1.0f;
+    uint32_t m_lcgState = 0x12345678u;
+    float m_shValue = 0.0f;
+
+    // ZDF SVF integrator state (cutoff target), per channel
+    float m_ic1[2] = {0.0f, 0.0f};
+    float m_ic2[2] = {0.0f, 0.0f};
+
+    float m_smoothCoeff = 0.0f;
+    float m_depthSmoothed = 0.5f;
+    float m_phaseOffSmoothed = 0.0f;
+
+    // Block-interpolated transform coefficients (Pan gains / Cutoff SVF).
+    bool m_coeffsDirty = true;
+    float m_panGL = 1.0f;
+    float m_panGR = 1.0f;
+    float m_ca1 = 0.0f;
+    float m_ca2 = 0.0f;
+    float m_ca3 = 0.0f;
+
+    std::atomic<float> m_lfoLevel{1.0f};
+};
+
+} // namespace Plugins
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/BuiltInPlugins.h
+++ b/AestraAudio/include/Plugin/BuiltInPlugins.h
@@ -19,6 +19,7 @@ const PluginInfo& limiterInfo();
 const PluginInfo& satInfo();
 const PluginInfo& filterInfo();
 const PluginInfo& ottInfo();
+const PluginInfo& lfoInfo();
 void registerCoreBuiltIns();
 std::vector<PluginInfo> all();
 }

--- a/AestraAudio/src/Plugin/BuiltInPlugins.cpp
+++ b/AestraAudio/src/Plugin/BuiltInPlugins.cpp
@@ -12,6 +12,7 @@
 #include "Plugin/AestraLimit.h"
 #include "Plugin/AestraSat.h"
 #include "Plugin/AestraFilter.h"
+#include "Plugin/AestraLFO.h"
 #include "Plugin/AestraOTT.h"
 
 #include <mutex>
@@ -220,6 +221,26 @@ const PluginInfo& ottInfo() {
     return info;
 }
 
+const PluginInfo& lfoInfo() {
+    static const PluginInfo info = [] {
+        PluginInfo p;
+        p.id = "com.Aestrastudios.lfo";
+        p.name = "Aestra LFO";
+        p.vendor = "Aestra Studios";
+        p.version = "0.1.0";
+        p.category = "Modulation";
+        p.format = PluginFormat::Internal;
+        p.type = PluginType::Effect;
+        p.numAudioInputs = 2;
+        p.numAudioOutputs = 2;
+        p.hasMidiInput = false;
+        p.hasMidiOutput = false;
+        p.hasEditor = true;
+        return p;
+    }();
+    return info;
+}
+
 namespace {
 void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
     if (!instance) {
@@ -248,6 +269,8 @@ void applyInfo(const PluginInfo& info, const PluginInstancePtr& instance) {
         filter->setInfo(info);
     } else if (auto ott = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraOTT>(instance)) {
         ott->setInfo(info);
+    } else if (auto lfo = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLFO>(instance)) {
+        lfo->setInfo(info);
     }
 }
 
@@ -279,6 +302,7 @@ void registerCoreBuiltIns() {
         registry.registerPlugin(makeRegistration<Plugins::AestraSat>(satInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraFilter>(filterInfo()));
         registry.registerPlugin(makeRegistration<Plugins::AestraOTT>(ottInfo()));
+        registry.registerPlugin(makeRegistration<Plugins::AestraLFO>(lfoInfo()));
     });
 }
 

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -155,6 +155,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/AestraFilterEditor.cpp
     Widgets/AestraOTTEditor.h
     Widgets/AestraOTTEditor.cpp
+    Widgets/AestraLFOEditor.h
+    Widgets/AestraLFOEditor.cpp
 )
 
 if(AESTRAUI_ENABLE_PREMIUM_EDITORS)

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -1,0 +1,316 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AestraLFOEditor.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "Plugin/AestraLFO.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace AestraUI {
+
+namespace {
+using Aestra::Audio::Plugins::AestraLFO;
+
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kKnobSweep = kPi * 1.5f;
+constexpr float kKnobStart = kPi * 0.75f; // pointing down-left, sweeping clockwise
+constexpr float kDragRangePx = 160.0f;    // full param range per drag distance
+
+NUIColor accent() {
+    return NUIColor(0.36f, 0.62f, 0.92f, 1.0f);
+} // LFO blue
+NUIColor panelSurface() {
+    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+}
+NUIColor insetSurface() {
+    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+}
+
+void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
+             NUIColor color) {
+    if (endAngle < startAngle)
+        std::swap(startAngle, endAngle);
+    if (endAngle - startAngle <= 0.001f)
+        return;
+    std::array<NUIPoint, 49> pts{};
+    const float div = static_cast<float>(pts.size() - 1);
+    for (size_t i = 0; i < pts.size(); ++i) {
+        const float t = static_cast<float>(i) / div;
+        const float a = startAngle + (endAngle - startAngle) * t;
+        pts[i] = {center.x + std::cos(a) * radius, center.y + std::sin(a) * radius};
+    }
+    renderer.drawPolyline(pts.data(), static_cast<int>(pts.size()), thickness, color);
+}
+} // namespace
+
+AestraLFOEditor::AestraLFOEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance)
+    : m_instance(std::move(instance)) {
+    setId("AestraLFOEditor");
+    setPanelTitle("Aestra LFO");
+    setBadgeText("Modulation");
+    setSize(kWinW, kWinH);
+    setEnforceParentBounds(true);
+    layoutControls();
+}
+
+void AestraLFOEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
+    AestraPanelWindow::setPlatformBridge(bridge);
+}
+
+void AestraLFOEditor::layoutControls() {
+    const auto b = getBounds();
+    const float contentTop = b.y + AestraPanelWindow::TITLE_BAR_H;
+
+    // Target selector: three segments across the top-left
+    constexpr float kSegW = 62.0f;
+    constexpr float kSegH = 26.0f;
+    for (size_t i = 0; i < m_targetRects.size(); ++i) {
+        m_targetRects[i] =
+            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kSegW + 6.0f), contentTop + 14.0f, kSegW, kSegH);
+    }
+
+    constexpr float kBypassW = 88.0f;
+    constexpr float kBypassH = 26.0f;
+    m_bypassRect = NUIRect(b.right() - 44.0f - kBypassW, contentTop + 14.0f, kBypassW, kBypassH);
+    m_syncRect = NUIRect(m_bypassRect.x - 70.0f - 12.0f, contentTop + 14.0f, 70.0f, kBypassH);
+
+    // Wave selector: six segments on the second row
+    constexpr float kWaveW = 52.0f;
+    constexpr float kWaveH = 24.0f;
+    for (size_t i = 0; i < m_waveRects.size(); ++i) {
+        m_waveRects[i] =
+            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kWaveW + 6.0f), contentTop + 52.0f, kWaveW, kWaveH);
+    }
+
+    // Large rate knob on the left; small knobs to its right
+    const float knobTop = contentTop + 96.0f;
+    m_rateRect = NUIRect(b.x + 44.0f, knobTop, 104.0f, 104.0f);
+    m_depthRect = NUIRect(b.x + 216.0f, knobTop + 16.0f, 64.0f, 64.0f);
+    m_phaseRect = NUIRect(b.x + 330.0f, knobTop + 16.0f, 64.0f, 64.0f);
+    m_smoothRect = NUIRect(b.x + 444.0f, knobTop + 16.0f, 64.0f, 64.0f);
+}
+
+void AestraLFOEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    if (!m_instance)
+        return;
+
+    const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
+                           contentRect.height - 18.0f};
+    renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+
+    drawTargetSelector(renderer);
+    drawWaveSelector(renderer);
+    drawSyncPill(renderer);
+    drawBypassPill(renderer);
+    drawRateKnob(renderer);
+    drawKnob(renderer, m_depthRect, AestraLFO::kDepth, "Depth", false);
+    drawKnob(renderer, m_phaseRect, AestraLFO::kPhase, "Phase", false);
+    drawKnob(renderer, m_smoothRect, AestraLFO::kSmooth, "Smooth", false);
+}
+
+void AestraLFOEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label,
+                               bool large) {
+    auto& theme = NUIThemeManager::getInstance();
+    const float value = m_instance ? m_instance->getParameter(paramId) : 0.0f;
+    const NUIPoint c = rect.center();
+    const float r = rect.width * 0.5f - 4.0f;
+    const float angle = kKnobStart + value * kKnobSweep;
+
+    renderer.fillCircle(c, r + 4.0f, insetSurface());
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+
+    drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
+            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+    drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
+
+    const float needleLen = r - (large ? 14.0f : 9.0f);
+    const NUIPoint tip(c.x + std::cos(angle) * needleLen, c.y + std::sin(angle) * needleLen);
+    renderer.drawLine(c, tip, 2.0f, accent().withAlpha(0.85f));
+    renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
+
+    const float wellR = r * (large ? 0.34f : 0.28f);
+    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
+
+    renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
+                              theme.getColor("textPrimary").withAlpha(0.95f));
+    const std::string valStr = m_instance ? m_instance->getParameterDisplay(paramId) : "";
+    renderer.drawTextCentered(valStr, NUIRect(rect.x - 14.0f, rect.bottom() + 19.0f, rect.width + 28.0f, 13.0f),
+                              large ? 10.0f : 9.0f, accent().withAlpha(0.96f));
+}
+
+void AestraLFOEditor::drawRateKnob(NUIRenderer& renderer) {
+    // The rate knob edits Hz in free mode and the note division when synced.
+    const bool sync = m_instance && m_instance->getParameter(AestraLFO::kSyncMode) > 0.5f;
+    drawKnob(renderer, m_rateRect, sync ? AestraLFO::kNoteDivision : AestraLFO::kRateHz, sync ? "Rate (Sync)" : "Rate",
+             true);
+}
+
+void AestraLFOEditor::drawTargetSelector(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const auto target =
+        m_instance ? AestraLFO::targetFromNorm(m_instance->getParameter(AestraLFO::kTarget)) : AestraLFO::kTargetVolume;
+    static constexpr const char* kLabels[] = {"VOL", "PAN", "CUT"};
+    for (size_t i = 0; i < m_targetRects.size(); ++i) {
+        const bool selected = static_cast<uint32_t>(target) == i;
+        if (selected) {
+            renderer.fillRoundedRect(m_targetRects[i], 7.0f, accent().withAlpha(0.26f));
+            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, accent().withAlpha(0.62f));
+            renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f, accent().withAlpha(0.98f));
+        } else {
+            renderer.fillRoundedRect(m_targetRects[i], 7.0f, insetSurface());
+            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f,
+                                      theme.getColor("textPrimary").withAlpha(0.62f));
+        }
+    }
+}
+
+void AestraLFOEditor::drawWaveSelector(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const auto wave =
+        m_instance ? AestraLFO::waveFromNorm(m_instance->getParameter(AestraLFO::kWave)) : AestraLFO::kWaveSine;
+    static constexpr const char* kLabels[] = {"SIN", "TRI", "SAW", "RMP", "SQR", "S&H"};
+    for (size_t i = 0; i < m_waveRects.size(); ++i) {
+        const bool selected = static_cast<uint32_t>(wave) == i;
+        if (selected) {
+            renderer.fillRoundedRect(m_waveRects[i], 7.0f, accent().withAlpha(0.26f));
+            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, accent().withAlpha(0.62f));
+            renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f, accent().withAlpha(0.98f));
+        } else {
+            renderer.fillRoundedRect(m_waveRects[i], 7.0f, insetSurface());
+            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f,
+                                      theme.getColor("textPrimary").withAlpha(0.62f));
+        }
+    }
+}
+
+void AestraLFOEditor::drawSyncPill(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const bool sync = m_instance && m_instance->getParameter(AestraLFO::kSyncMode) > 0.5f;
+    constexpr float kRadius = 7.0f;
+    if (sync) {
+        renderer.fillRoundedRect(m_syncRect, kRadius, accent().withAlpha(0.26f));
+        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, accent().withAlpha(0.62f));
+        renderer.drawTextCentered("SYNC", m_syncRect, 10.0f, accent().withAlpha(0.98f));
+    } else {
+        renderer.fillRoundedRect(m_syncRect, kRadius, insetSurface());
+        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+        renderer.drawTextCentered("FREE", m_syncRect, 10.0f, theme.getColor("textPrimary").withAlpha(0.62f));
+    }
+}
+
+void AestraLFOEditor::drawBypassPill(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const bool bypassed = m_instance && m_instance->getParameter(AestraLFO::kBypass) > 0.5f;
+    constexpr float kRadius = 7.0f;
+    constexpr float kFont = 10.0f;
+    if (bypassed) {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 NUIColor(0.92f, 0.28f, 0.22f).withAlpha(m_bypassHovered ? 0.94f : 0.78f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, NUIColor(0.92f, 0.28f, 0.22f).withAlpha(0.50f));
+        renderer.drawTextCentered("BYPASSED", m_bypassRect, kFont, theme.getColor("textPrimary"));
+    } else {
+        renderer.fillRoundedRect(m_bypassRect, kRadius,
+                                 theme.getColor("success").withAlpha(m_bypassHovered ? 0.30f : 0.18f));
+        renderer.strokeRoundedRect(m_bypassRect, kRadius, 1.0f, theme.getColor("success").withAlpha(0.40f));
+        renderer.drawTextCentered("ACTIVE", m_bypassRect, kFont, theme.getColor("success"));
+    }
+}
+
+bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible())
+        return false;
+    if (AestraPanelWindow::onMouseEvent(event))
+        return true;
+    if (!m_instance)
+        return false;
+
+    const float my = event.position.y;
+
+    // Bypass pill
+    if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
+        const float cur = m_instance->getParameter(AestraLFO::kBypass);
+        m_instance->setParameter(AestraLFO::kBypass, cur > 0.5f ? 0.0f : 1.0f);
+        setDirty();
+        return true;
+    }
+    m_bypassHovered = m_bypassRect.contains(event.position);
+
+    // Sync pill
+    if (m_syncRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
+        const float cur = m_instance->getParameter(AestraLFO::kSyncMode);
+        m_instance->setParameter(AestraLFO::kSyncMode, cur > 0.5f ? 0.0f : 1.0f);
+        setDirty();
+        return true;
+    }
+
+    // Target / wave segments
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        for (size_t i = 0; i < m_targetRects.size(); ++i) {
+            if (m_targetRects[i].contains(event.position)) {
+                m_instance->setParameter(AestraLFO::kTarget,
+                                         AestraLFO::normFromTarget(static_cast<AestraLFO::Target>(i)));
+                setDirty();
+                return true;
+            }
+        }
+        for (size_t i = 0; i < m_waveRects.size(); ++i) {
+            if (m_waveRects[i].contains(event.position)) {
+                m_instance->setParameter(AestraLFO::kWave, AestraLFO::normFromWave(static_cast<AestraLFO::Wave>(i)));
+                setDirty();
+                return true;
+            }
+        }
+    }
+
+    // Knob vertical drag
+    if (m_draggingParam >= 0) {
+        if (event.released) {
+            m_draggingParam = -1;
+            return true;
+        }
+        if (event.button == NUIMouseButton::None) {
+            const float delta = (m_dragStartY - my) / kDragRangePx;
+            m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
+                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+            setDirty();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        const bool sync = m_instance->getParameter(AestraLFO::kSyncMode) > 0.5f;
+        const uint32_t rateParam = sync ? AestraLFO::kNoteDivision : AestraLFO::kRateHz;
+        const struct {
+            NUIRect rect;
+            uint32_t param;
+        } knobs[] = {
+            {m_rateRect, rateParam},
+            {m_depthRect, AestraLFO::kDepth},
+            {m_phaseRect, AestraLFO::kPhase},
+            {m_smoothRect, AestraLFO::kSmooth},
+        };
+        for (const auto& k : knobs) {
+            if (k.rect.contains(event.position)) {
+                m_draggingParam = static_cast<int>(k.param);
+                m_dragStartY = my;
+                m_dragStartValue = m_instance->getParameter(k.param);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void AestraLFOEditor::onResize(int width, int height) {
+    AestraPanelWindow::onResize(width, height);
+    layoutControls();
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/AestraLFOEditor.h
+++ b/AestraUI/Widgets/AestraLFOEditor.h
@@ -1,0 +1,55 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraPanelWindow.h"
+#include "NUITypes.h"
+#include "PluginHost.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+namespace AestraUI {
+
+class AestraLFOEditor : public AestraPanelWindow {
+public:
+    explicit AestraLFOEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
+    void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    void onResize(int width, int height) override;
+    using AestraPanelWindow::onResize;
+    void onResize() { layoutControls(); }
+    void setPlatformBridge(NUIPlatformBridge* bridge) override;
+
+private:
+    void layoutControls();
+    void drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label, bool large);
+    void drawRateKnob(NUIRenderer& renderer);
+    void drawTargetSelector(NUIRenderer& renderer);
+    void drawWaveSelector(NUIRenderer& renderer);
+    void drawSyncPill(NUIRenderer& renderer);
+    void drawBypassPill(NUIRenderer& renderer);
+
+    std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
+
+    std::array<NUIRect, 3> m_targetRects{};
+    std::array<NUIRect, 6> m_waveRects{};
+    NUIRect m_syncRect;
+    NUIRect m_rateRect;
+    NUIRect m_depthRect;
+    NUIRect m_phaseRect;
+    NUIRect m_smoothRect;
+    NUIRect m_bypassRect;
+
+    // Vertical-drag knob state: which param is being dragged, and the value
+    // at drag start so movement is relative, not absolute.
+    int m_draggingParam = -1;
+    float m_dragStartY = 0.0f;
+    float m_dragStartValue = 0.0f;
+    bool m_bypassHovered = false;
+
+    static constexpr float kWinW = 560.0f;
+    static constexpr float kWinH = 320.0f;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -12,6 +12,7 @@
 #include "AestraLimitEditor.h"
 #include "AestraSatEditor.h"
 #include "AestraFilterEditor.h"
+#include "AestraLFOEditor.h"
 #include "AestraOTTEditor.h"
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
@@ -418,6 +419,14 @@ void PluginUIController::openPluginEditor(
         });
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
+    } else if (pluginId == "com.Aestrastudios.lfo") {
+        auto ed = std::make_shared<AestraLFOEditor>(instance);
+        ed->setOnClose([this, ed]() {
+            if (m_popupLayer) m_popupLayer->removeChild(ed);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
+        });
+        ed->setPlatformBridge(m_platformBridge);
+        editor = ed;
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
         ed->setOnClose([this, ed]() {
@@ -450,6 +459,8 @@ void PluginUIController::openPluginEditor(
             filter->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto ott = std::dynamic_pointer_cast<AestraOTTEditor>(editorComp)) {
             ott->onResize(static_cast<int>(width), static_cast<int>(height));
+        } else if (auto lfoEd = std::dynamic_pointer_cast<AestraLFOEditor>(editorComp)) {
+            lfoEd->onResize(static_cast<int>(width), static_cast<int>(height));
         } else if (auto generic = std::dynamic_pointer_cast<GenericPluginEditor>(editorComp)) {
             generic->onResize();
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -23,6 +23,7 @@
 #include "PatternBrowserPanel.h"
 #include "PianoRollPanel.h"
 #include "Plugin/AestraDelay.h"
+#include "Plugin/AestraLFO.h"
 #include "PluginManager.h"
 #include "SampleEditorPanel.h"
 
@@ -3557,6 +3558,10 @@ void AestraContent::loadEffectToSelectedTrack(const std::string& pluginId) {
         const float bpm = m_audioEngine ? m_audioEngine->getBPM() : 120.0f;
         delay->setBPM(bpm);
     }
+    if (auto lfo = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLFO>(instance)) {
+        const float bpm = m_audioEngine ? m_audioEngine->getBPM() : 120.0f;
+        lfo->setBPM(bpm);
+    }
     instance->activate();
 
     // 4. Insert into first available effect chain slot (via CommandHistory for undo)
@@ -3581,6 +3586,9 @@ void AestraContent::setPluginTempo(float bpm) {
     for (const auto& instance : pluginManager.getActiveInstances()) {
         if (auto delay = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraDelay>(instance)) {
             delay->setBPM(bpm);
+        }
+        if (auto lfo = std::dynamic_pointer_cast<Aestra::Audio::Plugins::AestraLFO>(instance)) {
+            lfo->setBPM(bpm);
         }
     }
 }

--- a/Tests/AestraAudio/AestraLFOTest.cpp
+++ b/Tests/AestraAudio/AestraLFOTest.cpp
@@ -1,0 +1,483 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// AestraLFOTest — DSP contract tests for the tempo-syncable audio-path LFO.
+
+#include "Plugin/AestraLFO.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraLFO;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 512;
+
+struct StereoBuffer {
+    std::vector<float> left;
+    std::vector<float> right;
+};
+
+StereoBuffer processStereo(AestraLFO& lfo, const std::vector<float>& inL, const std::vector<float>& inR) {
+    StereoBuffer out{std::vector<float>(inL.size(), 0.0f), std::vector<float>(inR.size(), 0.0f)};
+    const float* inputs[] = {inL.data(), inR.data()};
+    float* outputs[] = {out.left.data(), out.right.data()};
+    lfo.process(inputs, outputs, 2, 2, static_cast<uint32_t>(inL.size()));
+    return out;
+}
+
+std::vector<float> makeSine(uint32_t numSamples, float freq, float amp, double sampleRate) {
+    std::vector<float> buf(numSamples);
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    for (uint32_t i = 0; i < numSamples; ++i)
+        buf[i] = static_cast<float>(amp * std::sin(w * static_cast<double>(i)));
+    return buf;
+}
+
+float peakAmplitude(const std::vector<float>& buf, size_t start = 0) {
+    float peak = 0.0f;
+    for (size_t i = start; i < buf.size(); ++i)
+        peak = std::max(peak, std::abs(buf[i]));
+    return peak;
+}
+
+bool allFinite(const std::vector<float>& buf) {
+    for (float s : buf) {
+        if (!std::isfinite(s))
+            return false;
+    }
+    return true;
+}
+
+/// Peak amplitude per fixed-size window — the modulation envelope.
+std::vector<float> windowPeaks(const std::vector<float>& buf, size_t window, size_t start = 0) {
+    std::vector<float> peaks;
+    for (size_t w = start; w + window <= buf.size(); w += window) {
+        float p = 0.0f;
+        for (size_t i = w; i < w + window; ++i)
+            p = std::max(p, std::abs(buf[i]));
+        peaks.push_back(p);
+    }
+    return peaks;
+}
+
+/// Goertzel magnitude of one bin, normalized so a unit sine reads 1.0.
+float goertzelMag(const std::vector<float>& buf, size_t start, float freq, double sampleRate) {
+    const size_t n = buf.size() - start;
+    const double w = 2.0 * 3.14159265358979323846 * freq / sampleRate;
+    const double coeff = 2.0 * std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (size_t i = start; i < buf.size(); ++i) {
+        s0 = buf[i] + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    const double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    return static_cast<float>(2.0 * std::sqrt(std::max(0.0, power)) / static_cast<double>(n));
+}
+
+constexpr float kRate2HzNorm = 2.0f / 3.0f; // 0.02 * 1000^(2/3) = 2 Hz
+
+void setupFreeRunning(AestraLFO& lfo, AestraLFO::Target target, AestraLFO::Wave wave, float depth) {
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.setParameter(AestraLFO::kTarget, AestraLFO::normFromTarget(target));
+    lfo.setParameter(AestraLFO::kWave, AestraLFO::normFromWave(wave));
+    lfo.setParameter(AestraLFO::kSyncMode, 0.0f);
+    lfo.setParameter(AestraLFO::kRateHz, kRate2HzNorm);
+    lfo.setParameter(AestraLFO::kDepth, depth);
+    lfo.setParameter(AestraLFO::kSmooth, 0.0f);
+}
+
+bool testBypassPassesAudioUnchanged() {
+    AestraLFO lfo;
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.setParameter(AestraLFO::kBypass, 1.0f);
+    lfo.setParameter(AestraLFO::kDepth, 1.0f);
+    lfo.activate();
+
+    const auto inL = makeSine(1024, 1000.0f, 0.5f, kSampleRate);
+    const auto inR = makeSine(1024, 500.0f, 0.3f, kSampleRate);
+    auto out = processStereo(lfo, inL, inR);
+
+    for (uint32_t i = 0; i < inL.size(); ++i) {
+        if (std::abs(out.left[i] - inL[i]) > 1e-6f)
+            return false;
+        if (std::abs(out.right[i] - inR[i]) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testSilenceStaysSilent() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetVolume, AestraLFO::kWaveSine, 1.0f);
+    lfo.activate();
+    const std::vector<float> silence(8192, 0.0f);
+    auto out = processStereo(lfo, silence, silence);
+    return peakAmplitude(out.left) < 1e-8f && peakAmplitude(out.right) < 1e-8f;
+}
+
+// Depth 0 must be transparent on every target.
+bool testDepthZeroIsTransparent() {
+    for (auto target : {AestraLFO::kTargetVolume, AestraLFO::kTargetPan, AestraLFO::kTargetCutoff}) {
+        AestraLFO lfo;
+        setupFreeRunning(lfo, target, AestraLFO::kWaveSine, 0.0f);
+        lfo.activate();
+        const float freq = 1000.0f;
+        const auto in = makeSine(16384, freq, 0.5f, kSampleRate);
+        auto out = processStereo(lfo, in, in);
+        const float mag = goertzelMag(out.left, 8192, freq, kSampleRate) / 0.5f;
+        if (mag < 0.98f || mag > 1.02f)
+            return false;
+    }
+    return true;
+}
+
+// Volume target at full depth: the envelope must swing from ~full to ~zero.
+bool testVolumeTargetTremolo() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetVolume, AestraLFO::kWaveSine, 1.0f);
+    lfo.activate();
+
+    const auto in = makeSine(48000, 1000.0f, 0.5f, kSampleRate); // 2 LFO periods
+    auto out = processStereo(lfo, in, in);
+    const auto peaks = windowPeaks(out.left, 2400); // 50 ms windows
+    const float maxP = *std::max_element(peaks.begin(), peaks.end());
+    const float minP = *std::min_element(peaks.begin(), peaks.end());
+    return maxP > 0.4f && minP < 0.06f;
+}
+
+// Pan target at full depth: energy must alternate between channels.
+bool testPanTargetAlternatesChannels() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetPan, AestraLFO::kWaveSine, 1.0f);
+    lfo.activate();
+
+    const auto in = makeSine(48000, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(lfo, in, in);
+    const auto peaksL = windowPeaks(out.left, 2400);
+    const auto peaksR = windowPeaks(out.right, 2400);
+    bool leftDominates = false;
+    bool rightDominates = false;
+    for (size_t i = 0; i < peaksL.size(); ++i) {
+        if (peaksL[i] > 3.0f * std::max(1e-6f, peaksR[i]))
+            leftDominates = true;
+        if (peaksR[i] > 3.0f * std::max(1e-6f, peaksL[i]))
+            rightDominates = true;
+    }
+    return leftDominates && rightDominates;
+}
+
+// Cutoff target at full depth: a high probe must fade as the filter sweeps
+// down (6 octaves from 20 kHz reaches ~312 Hz) and return as it reopens.
+bool testCutoffTargetSweeps() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetCutoff, AestraLFO::kWaveSine, 1.0f);
+    lfo.activate();
+
+    const auto in = makeSine(48000, 8000.0f, 0.3f, kSampleRate);
+    auto out = processStereo(lfo, in, in);
+    const auto peaks = windowPeaks(out.left, 2400);
+    const float maxP = *std::max_element(peaks.begin(), peaks.end());
+    const float minP = *std::min_element(peaks.begin(), peaks.end());
+    return maxP > 0.25f && minP < 0.3f * maxP;
+}
+
+// Sync mode: the tremolo rate must follow the pushed BPM (1/4 note at
+// 120 BPM = 2 Hz, at 240 BPM = 4 Hz). Detected on the rectified envelope.
+bool testSyncFollowsBpm() {
+    auto envMagAt = [](float bpm, float probeHz) {
+        AestraLFO lfo;
+        lfo.initialize(kSampleRate, kBlockSize);
+        lfo.setParameter(AestraLFO::kTarget, AestraLFO::normFromTarget(AestraLFO::kTargetVolume));
+        lfo.setParameter(AestraLFO::kWave, AestraLFO::normFromWave(AestraLFO::kWaveSine));
+        lfo.setParameter(AestraLFO::kSyncMode, 1.0f);
+        lfo.setParameter(AestraLFO::kNoteDivision, AestraLFO::noteDivisionParamFromIndex(AestraLFO::kDiv1_4));
+        lfo.setParameter(AestraLFO::kDepth, 1.0f);
+        lfo.setParameter(AestraLFO::kSmooth, 0.0f);
+        lfo.setBPM(bpm);
+        lfo.activate();
+
+        const auto in = makeSine(4 * kSampleRate, 1000.0f, 0.5f, kSampleRate);
+        auto out = processStereo(lfo, in, in);
+        std::vector<float> env(out.left.size());
+        for (size_t i = 0; i < env.size(); ++i)
+            env[i] = std::abs(out.left[i]);
+        return goertzelMag(env, 2 * kSampleRate, probeHz, kSampleRate);
+    };
+
+    const float at120 = envMagAt(120.0f, 2.0f);
+    const float at120Wrong = envMagAt(120.0f, 4.0f);
+    const float at240 = envMagAt(240.0f, 4.0f);
+    const float at240Wrong = envMagAt(240.0f, 2.0f);
+    return at120 > 3.0f * at120Wrong && at240 > 3.0f * at240Wrong;
+}
+
+// Smoothing must remove the hard edges of a square LFO (click-free gating).
+bool testSmoothingLimitsSlew() {
+    auto maxDelta = [](float smoothNorm) {
+        AestraLFO lfo;
+        setupFreeRunning(lfo, AestraLFO::kTargetVolume, AestraLFO::kWaveSquare, 1.0f);
+        lfo.setParameter(AestraLFO::kSmooth, smoothNorm);
+        lfo.activate();
+
+        const std::vector<float> in(48000, 0.5f); // DC probe isolates gain slew
+        auto out = processStereo(lfo, in, in);
+        float d = 0.0f;
+        for (size_t i = 1; i < out.left.size(); ++i)
+            d = std::max(d, std::abs(out.left[i] - out.left[i - 1]));
+        return d;
+    };
+
+    const float hard = maxDelta(0.0f);
+    const float soft = maxDelta(1.0f); // 200 ms
+    return hard > 0.1f && soft < 0.02f;
+}
+
+// S&H must stay bounded: volume gain never exceeds unity.
+bool testSampleHoldIsBounded() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetVolume, AestraLFO::kWaveSH, 1.0f);
+    lfo.setParameter(AestraLFO::kRateHz, 1.0f); // 20 Hz, many cycles
+    lfo.activate();
+
+    const auto in = makeSine(48000, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(lfo, in, in);
+    return allFinite(out.left) && peakAmplitude(out.left) <= 0.5f + 1e-4f;
+}
+
+bool testSurvivesHostileInput() {
+    AestraLFO lfo;
+    setupFreeRunning(lfo, AestraLFO::kTargetCutoff, AestraLFO::kWaveSquare, 1.0f);
+    lfo.activate();
+
+    std::vector<float> in(2048, 0.0f);
+    for (size_t i = 0; i < in.size(); ++i)
+        in[i] = (i % 2 == 0) ? 100.0f : -100.0f;
+    in[100] = std::numeric_limits<float>::quiet_NaN();
+    in[200] = std::numeric_limits<float>::infinity();
+    in[300] = -std::numeric_limits<float>::infinity();
+
+    auto out = processStereo(lfo, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Every parameter at both extremes with hot input: output must stay finite.
+bool testStableAtParameterExtremes() {
+    for (float extreme : {0.0f, 1.0f}) {
+        AestraLFO lfo;
+        lfo.initialize(kSampleRate, kBlockSize);
+        for (uint32_t p = 0; p < AestraLFO::kParamCount; ++p) {
+            if (p != AestraLFO::kBypass)
+                lfo.setParameter(p, extreme);
+        }
+        lfo.activate();
+
+        const auto in = makeSine(8192, 700.0f, 1.0f, kSampleRate);
+        auto out = processStereo(lfo, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+    }
+    return true;
+}
+
+bool testStateRoundTrip() {
+    AestraLFO lfo;
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.activate();
+    lfo.setParameter(AestraLFO::kTarget, AestraLFO::normFromTarget(AestraLFO::kTargetPan));
+    lfo.setParameter(AestraLFO::kWave, AestraLFO::normFromWave(AestraLFO::kWaveTriangle));
+    lfo.setParameter(AestraLFO::kSyncMode, 0.0f);
+    lfo.setParameter(AestraLFO::kRateHz, 0.42f);
+    lfo.setParameter(AestraLFO::kNoteDivision, AestraLFO::noteDivisionParamFromIndex(AestraLFO::kDiv1_8T));
+    lfo.setParameter(AestraLFO::kDepth, 0.8f);
+    lfo.setParameter(AestraLFO::kPhase, 0.25f);
+    lfo.setParameter(AestraLFO::kSmooth, 0.6f);
+
+    const auto state = lfo.saveState();
+
+    AestraLFO restored;
+    restored.initialize(kSampleRate, kBlockSize);
+    restored.activate();
+    if (!restored.loadState(state))
+        return false;
+
+    for (uint32_t i = 0; i < AestraLFO::kParamCount; ++i) {
+        if (std::abs(restored.getParameter(i) - lfo.getParameter(i)) > 1e-6f)
+            return false;
+    }
+    return true;
+}
+
+bool testLoadStateRejectsGarbage() {
+    AestraLFO lfo;
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.activate();
+
+    std::vector<uint8_t> tooShort = {0x31, 0x4F};
+    if (lfo.loadState(tooShort))
+        return false;
+
+    std::vector<uint8_t> wrongMagic(64, 0);
+    if (lfo.loadState(wrongMagic))
+        return false;
+    return true;
+}
+
+bool testEnumAndDivisionMapping() {
+    if (AestraLFO::targetFromNorm(0.0f) != AestraLFO::kTargetVolume)
+        return false;
+    if (AestraLFO::targetFromNorm(0.5f) != AestraLFO::kTargetPan)
+        return false;
+    if (AestraLFO::targetFromNorm(1.0f) != AestraLFO::kTargetCutoff)
+        return false;
+    if (AestraLFO::waveFromNorm(0.0f) != AestraLFO::kWaveSine)
+        return false;
+    if (AestraLFO::waveFromNorm(1.0f) != AestraLFO::kWaveSH)
+        return false;
+    for (int i = 0; i <= 12; ++i) {
+        if (AestraLFO::noteDivisionIndexFromParam(AestraLFO::noteDivisionParamFromIndex(i)) != i)
+            return false;
+    }
+    // 1/4 = one beat; the table matches AestraDelay's.
+    return std::abs(AestraLFO::noteDivisionMultiplier(AestraLFO::kDiv1_4) - 1.0f) < 1e-6f &&
+           std::abs(AestraLFO::noteDivisionMultiplier(AestraLFO::kDiv1_1) - 4.0f) < 1e-6f;
+}
+
+// NaN/Inf must not pass the parameter ingress; a NaN-filled (magic-intact)
+// state blob must not poison processing.
+bool testSetParameterRejectsNonFinite() {
+    AestraLFO lfo;
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.activate();
+    lfo.setParameter(AestraLFO::kDepth, 0.42f);
+
+    for (float bad : {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity(),
+                      -std::numeric_limits<float>::infinity()}) {
+        lfo.setParameter(AestraLFO::kDepth, bad);
+        if (std::abs(lfo.getParameter(AestraLFO::kDepth) - 0.42f) > 1e-6f)
+            return false;
+    }
+
+    std::vector<uint8_t> state = lfo.saveState();
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    for (size_t off = 8; off + sizeof(float) <= state.size(); off += sizeof(float)) {
+        std::memcpy(state.data() + off, &nan, sizeof(float));
+    }
+    if (lfo.loadState(state))
+        return false; // an all-NaN blob must be rejected, not accepted as success
+    for (uint32_t i = 0; i < AestraLFO::kParamCount; ++i) {
+        if (!std::isfinite(lfo.getParameter(i)))
+            return false;
+    }
+
+    const auto in = makeSine(2048, 1000.0f, 0.5f, kSampleRate);
+    auto out = processStereo(lfo, in, in);
+    return allFinite(out.left) && allFinite(out.right);
+}
+
+// Rapid automation of every continuous parameter (incl. target/wave/sync
+// switching), with hostile block sizes.
+bool testAutomationStress() {
+    AestraLFO lfo;
+    lfo.initialize(kSampleRate, kBlockSize);
+    lfo.activate();
+    lfo.setBPM(128.0f);
+
+    uint32_t lcg = 0x5EED1234u;
+    auto next01 = [&lcg]() {
+        lcg = lcg * 1664525u + 1013904223u;
+        return static_cast<float>(lcg >> 8) * (1.0f / 16777216.0f);
+    };
+
+    const auto in = makeSine(96000, 400.0f, 0.5f, kSampleRate); // 2 s
+    std::vector<float> outL(in.size(), 0.0f);
+    std::vector<float> outR(in.size(), 0.0f);
+    const uint32_t sizes[] = {1, 3, 17, 32, 64, 111};
+    uint32_t pos = 0;
+    uint32_t sizeIdx = 0;
+    while (pos < in.size()) {
+        for (uint32_t pIdx = 0; pIdx < AestraLFO::kParamCount; ++pIdx) {
+            if (pIdx != AestraLFO::kBypass)
+                lfo.setParameter(pIdx, next01());
+        }
+        const uint32_t n = std::min<uint32_t>(sizes[sizeIdx % 6], static_cast<uint32_t>(in.size()) - pos);
+        ++sizeIdx;
+        const float* ins[] = {in.data() + pos, in.data() + pos};
+        float* outs[] = {outL.data() + pos, outR.data() + pos};
+        lfo.process(ins, outs, 2, 2, n);
+        pos += n;
+    }
+
+    if (!allFinite(outL) || !allFinite(outR))
+        return false;
+    return peakAmplitude(outL) < 4.0f; // gain/pan/cutoff never boost above unity
+}
+
+bool testStableAcrossSampleRates() {
+    for (double sr : {44100.0, 96000.0, 192000.0}) {
+        AestraLFO lfo;
+        lfo.initialize(sr, kBlockSize);
+        lfo.setParameter(AestraLFO::kTarget, AestraLFO::normFromTarget(AestraLFO::kTargetCutoff));
+        lfo.setParameter(AestraLFO::kDepth, 1.0f);
+        lfo.setParameter(AestraLFO::kRateHz, 1.0f); // 20 Hz
+        lfo.activate();
+
+        const auto in = makeSine(8192, 1000.0f, 0.5f, sr);
+        auto out = processStereo(lfo, in, in);
+        if (!allFinite(out.left) || !allFinite(out.right))
+            return false;
+        if (peakAmplitude(out.left) > 16.0f)
+            return false;
+    }
+    return true;
+}
+
+struct TestCase {
+    const char* name;
+    bool (*fn)();
+};
+
+} // namespace
+
+int main() {
+    const TestCase tests[] = {
+        {"BypassPassesAudioUnchanged", testBypassPassesAudioUnchanged},
+        {"SilenceStaysSilent", testSilenceStaysSilent},
+        {"DepthZeroIsTransparent", testDepthZeroIsTransparent},
+        {"VolumeTargetTremolo", testVolumeTargetTremolo},
+        {"PanTargetAlternatesChannels", testPanTargetAlternatesChannels},
+        {"CutoffTargetSweeps", testCutoffTargetSweeps},
+        {"SyncFollowsBpm", testSyncFollowsBpm},
+        {"SmoothingLimitsSlew", testSmoothingLimitsSlew},
+        {"SampleHoldIsBounded", testSampleHoldIsBounded},
+        {"SurvivesHostileInput", testSurvivesHostileInput},
+        {"StableAtParameterExtremes", testStableAtParameterExtremes},
+        {"StateRoundTrip", testStateRoundTrip},
+        {"LoadStateRejectsGarbage", testLoadStateRejectsGarbage},
+        {"EnumAndDivisionMapping", testEnumAndDivisionMapping},
+        {"SetParameterRejectsNonFinite", testSetParameterRejectsNonFinite},
+        {"AutomationStress", testAutomationStress},
+        {"StableAcrossSampleRates", testStableAcrossSampleRates},
+    };
+
+    int failures = 0;
+    for (const auto& test : tests) {
+        const bool passed = test.fn();
+        std::cout << (passed ? "[PASS] " : "[FAIL] ") << test.name << "\n";
+        if (!passed)
+            ++failures;
+    }
+
+    if (failures > 0) {
+        std::cout << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All AestraLFO tests passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1256,6 +1256,17 @@ target_include_directories(AestraOTTTest PRIVATE
 add_test(NAME AestraOTTTest COMMAND AestraOTTTest)
 set_tests_properties(AestraOTTTest PROPERTIES LABELS "audio;plugins;ott")
 
+# Aestra LFO Test
+add_executable(AestraLFOTest AestraAudio/AestraLFOTest.cpp)
+target_link_libraries(AestraLFOTest PRIVATE AestraAudio)
+target_include_directories(AestraLFOTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AestraLFOTest COMMAND AestraLFOTest)
+set_tests_properties(AestraLFOTest PROPERTIES LABELS "audio;plugins;lfo")
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds **AestraLFO** (`com.Aestrastudios.lfo`), the fourth plugin in the free-suite build-out, stacked on #474 (OTT). An LFOTool-style insert effect: a tempo-syncable LFO that shapes the audio flowing through it — rhythmic volume gating/ducking, auto-pan, or filter-cutoff wobble.

## Why

AestraLFO is on the Free Core Suite list. V1 deliberately modulates its **own** audio path rather than other plugins' parameters, because engine-side parameter-modulation routing does not exist yet (#467); when it lands, this LFO core is reusable as a source.

## Design

- **Targets**: Volume (gate/duck), Pan (equal-power, unity at center), Cutoff (ZDF SVF low-pass swept up to 6 octaves from 20 kHz).
- **Waves**: sine / triangle / saw down / saw up / square / S&H (deterministic LCG).
- **Rate**: free 0.02–20 Hz (log) or tempo-synced via AestraDelay's 13-division table; BPM pushed through the existing `setPluginTempo` path.
- **Controls**: phase offset, 0–200 ms output slew (click-free square gating), depth, bypass.
- **Control-rate architecture** (house standard): parameters, phase increment (pow/divide), and slew coefficient (exp) computed once per 16-sample block; Pan (cos/sin) and Cutoff (exp2/tan) transforms computed per block from the block-boundary LFO value and their coefficients interpolated across the block. Volume stays exact per-sample (a cheap linear function of the LFO). No atomics or transcendentals in the per-sample path beyond the waveform generator.
- **Review-standard fixes** already applied: atomic `loadState` (validate all params before mutating), in-place `memcpy` guard, sample-rate-relative tail, `isfinite` `setParameter` guard.
- **State** blob `'LFO1'`; blue house-style editor (target/wave selectors, sync pill, rate knob edits Hz or division by mode).

## Testing performed

- `AestraLFOTest` — 17 headless contract tests: tremolo depth, channel alternation, BPM-follow (envelope Goertzel at 120 vs 240 BPM), slew limiting, S&H bounds, depth-zero transparency, NaN/Inf param ingress + NaN-blob rejection, randomized automation stress at hostile block sizes, hostile audio, param extremes, 44.1/96/192 kHz stability.
- Full `build-linux` build clean (0 errors) on the current develop base; `ctest -L plugins` 12/12.

## Docs updated?

No — `docs/` has no plugin inventory page.

## Risk / rollback

- Purely additive: new plugin + registration + editor + the `setPluginTempo` LFO hook. No existing DSP/serialization touched. Revert = drop the commit.
- RT-safe: no allocation/locks/IO in `process()`. Zero latency. Free-running phase; bar-locked restart needs a transport hook (follow-up).
- Stacked on #474 (OTT); merge that first — shared edits in `BuiltInPlugins.*`, `PluginUIController.cpp`, CMake lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)