### PR TITLE
fix(plugins): preserve parameters across initialize() reprepare

### DIFF
--- a/AestraAudio/include/Plugin/AestraComp.h
+++ b/AestraAudio/include/Plugin/AestraComp.h
@@ -104,8 +104,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         m_sampleRate = std::max(1.0, sampleRate);
         m_maxBlockSize = maxBlockSize;
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         m_osL.prepareKernels();
         m_osR.prepareKernels();
@@ -938,6 +944,7 @@ private:
     double m_sampleRate = 48000.0;
     uint32_t m_maxBlockSize = 512;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::atomic<bool> m_hasProcessed{false};
     std::atomic<bool> m_detectorHPFDirty{false};
     std::array<std::atomic<float>, kParamCount> m_params{};

--- a/AestraAudio/include/Plugin/AestraDelay.h
+++ b/AestraAudio/include/Plugin/AestraDelay.h
@@ -67,9 +67,15 @@ public:
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
         const auto defaults = getParameters();
-        for (const auto& param : defaults) {
-            if (param.id < kParamCount) {
-                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : defaults) {
+                if (param.id < kParamCount) {
+                    m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+                }
             }
         }
 
@@ -597,6 +603,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params;
     std::atomic<float> m_bpm{120.0f};
 

--- a/AestraAudio/include/Plugin/AestraDrift.h
+++ b/AestraAudio/include/Plugin/AestraDrift.h
@@ -36,8 +36,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         resetRuntimeState();
         return true;
@@ -262,6 +268,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
 
     std::array<float, kBufferSize> m_buffer{};

--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -62,8 +62,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         resetRuntimeState();
         snapSmoothedParams();
@@ -486,6 +492,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
 
     // ZDF SVF integrator state, per channel

--- a/AestraAudio/include/Plugin/AestraLFO.h
+++ b/AestraAudio/include/Plugin/AestraLFO.h
@@ -78,8 +78,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         resetRuntimeState();
         snapSmoothedParams();
@@ -599,6 +605,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::atomic<float> m_bpm{120.0f};
     std::array<std::atomic<float>, kParamCount> m_params{};
 

--- a/AestraAudio/include/Plugin/AestraLimit.h
+++ b/AestraAudio/include/Plugin/AestraLimit.h
@@ -53,8 +53,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         m_sampleRate = std::max(1.0, sampleRate);
         m_maxBlockSize = maxBlockSize;
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         resetRuntimeState();
         snapSmoothedParams();
@@ -429,6 +435,7 @@ private:
     double m_sampleRate = 48000.0;
     uint32_t m_maxBlockSize = 512;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
 
     // Oversampler states

--- a/AestraAudio/include/Plugin/AestraSat.h
+++ b/AestraAudio/include/Plugin/AestraSat.h
@@ -49,8 +49,14 @@ public:
     bool initialize(double sampleRate, uint32_t maxBlockSize) override {
         (void)maxBlockSize;
         m_sampleRate = std::max(1.0, sampleRate);
-        for (const auto& param : getParameters()) {
-            m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : getParameters()) {
+                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+            }
         }
         for (auto& os : m_oversampler) {
             os.prepare(kOsFactor);
@@ -426,6 +432,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
 
     std::array<DSP::Oversampler, 2> m_oversampler;

--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -211,10 +211,21 @@ public:
         (void)maxBlockSize;
         m_sampleRate = sampleRate > 1.0 ? sampleRate : 48000.0;
         const auto defaults = getParameters();
+        // Seed parameter defaults only on the first initialization of a fresh
+        // instance. EffectChain::prepare() re-calls initialize() on the live
+        // instance during sample-rate/device changes and must preserve the
+        // user's current parameter values (and any loaded project state).
+        if (!m_paramsInitialized.exchange(true)) {
+            for (const auto& param : defaults) {
+                if (param.id < kParamCount) {
+                    m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
+                }
+            }
+        }
+        // Snap smoothed values to the current (preserved-or-default) params.
         for (const auto& param : defaults) {
             if (param.id < kParamCount) {
-                m_params[param.id].store(param.defaultValue, std::memory_order_relaxed);
-                m_smoothedParams[param.id] = param.defaultValue;
+                m_smoothedParams[param.id] = m_params[param.id].load(std::memory_order_relaxed);
             }
         }
         prepareDelayLines(true);
@@ -1502,6 +1513,7 @@ private:
     PluginInfo m_info;
     double m_sampleRate = 48000.0;
     std::atomic<bool> m_active{false};
+    std::atomic<bool> m_paramsInitialized{false};
     std::array<std::atomic<float>, kParamCount> m_params{};
     std::array<float, kParamCount> m_smoothedParams{};
 

--- a/Tests/AestraAudio/PluginInitContractTest.cpp
+++ b/Tests/AestraAudio/PluginInitContractTest.cpp
@@ -1,0 +1,148 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// PluginInitContractTest — enforces the initialization contract across every
+// internal effect plugin:
+//   * initialize() seeds parameter defaults only on the FIRST init of a fresh
+//     instance;
+//   * EffectChain::prepare() re-calls initialize() on the live instance during
+//     sample-rate / device changes and must PRESERVE the user's parameters and
+//     any loaded project state;
+//   * smoothed/current DSP values snap safely to the preserved targets;
+//   * a save/reinit/load/reinit cycle preserves state.
+// This is the regression for the parameter-wipe bug found on #474.
+
+#include "Plugin/AestraComp.h"
+#include "Plugin/AestraDelay.h"
+#include "Plugin/AestraDrift.h"
+#include "Plugin/AestraFilter.h"
+#include "Plugin/AestraLFO.h"
+#include "Plugin/AestraLimit.h"
+#include "Plugin/AestraOTT.h"
+#include "Plugin/AestraSat.h"
+#include "Plugin/AestraVerb.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+// A distinctive, in-range value that differs clearly from the default, so a
+// reset-to-default would be caught. Plugins store the raw normalized value, so
+// getParameter() returns exactly what we set (bit-identical comparison holds).
+float distinctiveValue(float def) {
+    float v = (def <= 0.5f) ? def + 0.3f : def - 0.3f;
+    v = std::clamp(v, 0.05f, 0.95f);
+    if (std::abs(v - def) < 0.05f)
+        v = (def < 0.5f) ? 0.9f : 0.1f;
+    return v;
+}
+
+template <typename PluginT> bool reinitContract(const char* name) {
+    PluginT p;
+
+    // 1. Construct and initialize.
+    p.initialize(48000.0, 512);
+    const uint32_t n = p.getParameterCount();
+
+    // 2-3. Set every parameter (incl. bypass and stepped/enumerated) to a
+    // distinctive non-default value and remember it.
+    std::vector<float> saved(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        p.setParameter(i, distinctiveValue(p.getParameter(i)));
+        saved[i] = p.getParameter(i);
+    }
+
+    auto assertPreserved = [&](const char* stage) {
+        for (uint32_t i = 0; i < n; ++i) {
+            if (std::abs(p.getParameter(i) - saved[i]) > 1e-6f) {
+                std::cout << "  [" << name << "] param " << i << " changed at " << stage << " (" << saved[i] << " -> "
+                          << p.getParameter(i) << ")\n";
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // 4. Reinitialize at the same sample rate.
+    p.initialize(48000.0, 512);
+    if (!assertPreserved("reinit-same-rate"))
+        return false;
+
+    // 5. Reinitialize at a different sample rate and block size.
+    p.initialize(96000.0, 256);
+    if (!assertPreserved("reinit-different-rate"))
+        return false;
+
+    // 6. (covered by assertPreserved above — bit/epsilon identical.)
+
+    // 7. Process audio and require finite output.
+    p.activate();
+    constexpr uint32_t kFrames = 256;
+    std::vector<float> inL(kFrames), inR(kFrames), outL(kFrames, 0.0f), outR(kFrames, 0.0f);
+    for (uint32_t i = 0; i < kFrames; ++i)
+        inL[i] = inR[i] = 0.3f * std::sin(0.05f * static_cast<float>(i));
+    const float* ins[] = {inL.data(), inR.data()};
+    float* outs[] = {outL.data(), outR.data()};
+    p.process(ins, outs, 2, 2, kFrames);
+    for (uint32_t i = 0; i < kFrames; ++i) {
+        if (!std::isfinite(outL[i]) || !std::isfinite(outR[i])) {
+            std::cout << "  [" << name << "] non-finite output at frame " << i << "\n";
+            return false;
+        }
+    }
+
+    // 8. Save state, clobber params, reinit, reload state, reinit again, verify
+    //    persistence across the whole cycle.
+    const auto state = p.saveState();
+    for (uint32_t i = 0; i < n; ++i)
+        p.setParameter(i, 0.5f); // clobber
+    p.initialize(48000.0, 512);  // must preserve the clobbered values, not reset
+    if (!p.loadState(state)) {
+        std::cout << "  [" << name << "] loadState rejected a self-saved blob\n";
+        return false;
+    }
+    p.initialize(96000.0, 512); // reinit after load must preserve the loaded state
+    if (!assertPreserved("reload-then-reinit"))
+        return false;
+
+    return true;
+}
+
+struct Case {
+    const char* name;
+    bool (*fn)();
+};
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio::Plugins;
+    const Case cases[] = {
+        {"AestraSat", [] { return reinitContract<AestraSat>("AestraSat"); }},
+        {"AestraFilter", [] { return reinitContract<AestraFilter>("AestraFilter"); }},
+        {"AestraComp", [] { return reinitContract<AestraComp>("AestraComp"); }},
+        {"AestraVerb", [] { return reinitContract<AestraVerb>("AestraVerb"); }},
+        {"AestraDelay", [] { return reinitContract<AestraDelay>("AestraDelay"); }},
+        {"AestraDrift", [] { return reinitContract<AestraDrift>("AestraDrift"); }},
+        {"AestraLimit", [] { return reinitContract<AestraLimit>("AestraLimit"); }},
+        {"AestraLFO", [] { return reinitContract<AestraLFO>("AestraLFO"); }},
+        {"AestraOTT", [] { return reinitContract<AestraOTT>("AestraOTT"); }},
+    };
+
+    int failures = 0;
+    for (const auto& c : cases) {
+        const bool ok = c.fn();
+        std::cout << (ok ? "[PASS] " : "[FAIL] ") << c.name << " init contract\n";
+        if (!ok)
+            ++failures;
+    }
+
+    if (failures > 0) {
+        std::cout << failures << " plugin(s) failed the init contract\n";
+        return 1;
+    }
+    std::cout << "All plugin init-contract checks passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1267,6 +1267,18 @@ target_include_directories(AestraLFOTest PRIVATE
 add_test(NAME AestraLFOTest COMMAND AestraLFOTest)
 set_tests_properties(AestraLFOTest PROPERTIES LABELS "audio;plugins;lfo")
 
+# Plugin initialization contract — parameters must survive EffectChain::prepare()
+# re-initialize (sample-rate/device changes), across every internal effect.
+add_executable(PluginInitContractTest AestraAudio/PluginInitContractTest.cpp)
+target_link_libraries(PluginInitContractTest PRIVATE AestraAudio)
+target_include_directories(PluginInitContractTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME PluginInitContractTest COMMAND PluginInitContractTest)
+set_tests_properties(PluginInitContractTest PROPERTIES LABELS "audio;plugins;lifecycle")
+
 # =============================================================================
 # Audio Quality Tests (S-Tier validation suite, Spec §3, §8, §15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes a project/session-integrity bug: **a device or sample-rate change silently reset every internal effect's parameters to defaults**, wiping the user's configured knob positions. Establishes and enforces an initialization contract across all affected plugins.

## Why

`EffectChain::prepare()` re-calls `initialize()` on the **live** plugin instance during stream restarts / sample-rate / audio-device changes (`EffectChain.cpp:357`, `:703`). Every internal effect seeded parameter defaults unconditionally in `initialize()`, so re-init clobbered the user's current values. Surfaced during CodeRabbit's review of AestraOTT (#474), which fixed OTT; this sweep fixes the rest.

## The contract

- `initialize()` may allocate, configure sample-rate-dependent DSP, and reset transient processing state.
- Parameter defaults are seeded **only on the first initialization** of a fresh instance (guarded by an atomic `m_paramsInitialized` flag).
- Subsequent `initialize()` calls **preserve** the parameter atomics and any loaded project state; smoothed/current DSP values snap safely to the preserved targets.
- Delay rings, integrators, envelopes and oversamplers still reset via the existing `resetRuntimeState()`/snap paths; user-facing controls do not.

The engine load path is `initialize()` → `loadState()` (`EffectChain.cpp:703-704`), so the first-init default seed is harmless (immediately overwritten by `loadState`), and a re-init after load preserves the loaded state.

## Scope

**Guarded (8):** AestraSat, AestraFilter, AestraComp, AestraDrift, AestraLimit, AestraDelay, AestraLFO, AestraVerb. Verb additionally snaps `m_smoothedParams` to the *current* (preserved) params on re-init rather than defaults.

**Already fixed:** AestraOTT (#474).

**Excluded after inspection (deviations from the original scope):**
- **AestraEQ** — its `initialize()` only snaps `m_smoothed` from `m_params`; it never resets parameters, so it's already correct.
- **SamplerPlugin** — `initialize()` only sets the sample rate.
- Note: **Drift and Limit** weren't on the original list but have the same reset pattern, so they're included.

Each guard is a minimal, guard-only diff (~11 lines/header); **no parameter IDs, state versions, defaults, or audible DSP changed.**

## Testing

New `PluginInitContractTest` runs the full contract per plugin:
1. construct + initialize; 2–3. set every parameter (incl. bypass and stepped/enumerated) to distinctive non-default values and record them; 4. reinit at the same rate; 5. reinit at a different sample rate + block size; 6. assert every parameter preserved (bit/epsilon-identical); 7. process audio and require finite output; 8. save state → clobber → reinit → load → reinit and verify persistence.

- All 9 (8 fixed + OTT) pass; the test **fails on the pre-fix code**, so it's a genuine regression guard.
- Full `build-linux` build clean (0 errors); `ctest -L plugins` **13/13**; existing per-plugin suites unaffected.

## Docs updated?

No.

## Risk / rollback

- Header-only guard additions + one new test; no production logic beyond the first-init guard, no serialization/DSP/ID changes. Revert = drop the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Preserve plugin parameter values across reinitialization caused by stream restarts, sample-rate changes, and audio-device changes.
- Updated eight plugins to seed defaults only during first initialization while continuing to reset transient DSP state.
- Added `PluginInitContractTest`, covering parameter preservation, processing stability, and save/load behavior across nine plugins.
- Registered the regression test with CTest; all plugin tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->