### PR TITLE
fix(ui): safe deferred editor close — break setOnClose retain cycle (#475)

### DIFF
--- a/AestraUI/Core/NUIApp.cpp
+++ b/AestraUI/Core/NUIApp.cpp
@@ -235,7 +235,9 @@ void NUIApp::handleMouseEvent(const NUIMouseEvent& event) {
     // The component will handle hover state internally
     // Dispatch event to root component
     // The component will handle hover state internally
+    NUIComponent::beginEventDispatch();
     bool handled = rootComponent_->onMouseEvent(event);
+    NUIComponent::endEventDispatch();
     
     // Handle focus on click
     if (event.pressed && !handled) {

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -5,6 +5,8 @@
 #include "NUIRenderer.h"
 #include <algorithm>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 // Forward declare NUIRenderer to avoid dependency
 namespace AestraUI {
@@ -245,7 +247,46 @@ void NUIComponent::addChild(std::shared_ptr<NUIComponent> child) {
     setDirty();
 }
 
+namespace {
+// The dispatch guard is a per-thread context: begin/endEventDispatch and the
+// removeChild()s they bracket all run on the same (UI) thread. Making the state
+// thread_local keeps it correct while avoiding any data race with a removeChild
+// issued from another thread (which simply sees depth 0 and removes at once).
+// Depth counts nested dispatches; the deferred list holds strong refs so queued
+// children stay alive until the dispatch unwinds.
+thread_local int g_eventDispatchDepth = 0;
+thread_local std::vector<std::pair<NUIComponent*, std::shared_ptr<NUIComponent>>> g_deferredRemovals;
+} // namespace
+
+void NUIComponent::beginEventDispatch() {
+    ++g_eventDispatchDepth;
+}
+
+void NUIComponent::endEventDispatch() {
+    if (g_eventDispatchDepth > 0) {
+        --g_eventDispatchDepth;
+    }
+    if (g_eventDispatchDepth == 0 && !g_deferredRemovals.empty()) {
+        auto pending = std::move(g_deferredRemovals);
+        g_deferredRemovals.clear();
+        for (auto& entry : pending) {
+            if (entry.first) {
+                entry.first->removeChild(entry.second); // depth == 0 now -> immediate
+            }
+        }
+    }
+}
+
 void NUIComponent::removeChild(std::shared_ptr<NUIComponent> child) {
+    if (!child) {
+        return;
+    }
+    if (g_eventDispatchDepth > 0) {
+        // Defer until the dispatch unwinds; the strong ref keeps the child alive
+        // through the rest of the current event.
+        g_deferredRemovals.emplace_back(this, std::move(child));
+        return;
+    }
     auto it = std::find(children_.begin(), children_.end(), child);
     if (it != children_.end()) {
         (*it)->parent_ = nullptr;

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -80,6 +80,15 @@ public:
     void removeChild(std::shared_ptr<NUIComponent> child);
     void removeAllChildren();
 
+    // Event-dispatch guard. While a mouse-event dispatch is in flight (bracketed
+    // by NUIApp around the root onMouseEvent), removeChild() defers the actual
+    // removal until the dispatch unwinds. This prevents a handler that
+    // closes/removes a component from mutating a parent's children_ mid-iteration
+    // (iterator invalidation) or freeing a component still on the call stack
+    // (use-after-free). Nestable via an internal depth counter.
+    static void beginEventDispatch();
+    static void endEventDispatch();
+
     /**
      * @brief Moves this component to the top of its parent's children list (rendered last, receives events first)
      */

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -341,98 +341,62 @@ void PluginUIController::openPluginEditor(
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
     } else if (pluginId == "com.Aestrastudios.rumble") {
         auto ed = std::make_shared<RumblePluginEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         editor = ed;
 #endif
     } else if (pluginId == "com.Aestrastudios.eq") {
         auto ed = std::make_shared<AestraEQEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.comp") {
         auto ed = std::make_shared<AestraCompEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.verb") {
         auto ed = std::make_shared<AestraVerbEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.delay") {
         auto ed = std::make_shared<AestraDelayEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.drift") {
         auto ed = std::make_shared<AestraDriftEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.limiter") {
         auto ed = std::make_shared<AestraLimitEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.sat") {
         auto ed = std::make_shared<AestraSatEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.filter") {
         auto ed = std::make_shared<AestraFilterEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.ott") {
         auto ed = std::make_shared<AestraOTTEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else if (pluginId == "com.Aestrastudios.lfo") {
         auto ed = std::make_shared<AestraLFOEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
-        ed->setOnClose([this, ed]() {
-            if (m_popupLayer) m_popupLayer->removeChild(ed);
-            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), ed), m_activeEditors.end());
-        });
+        wireEditorClose(ed);
         editor = ed;
     }
     

--- a/AestraUI/Widgets/PluginUIController.h
+++ b/AestraUI/Widgets/PluginUIController.h
@@ -194,7 +194,25 @@ public:
     PluginListItem convertToListItem(const Aestra::Audio::PluginInfo& info) const;
 
 private:
-    
+
+    // Wire an editor's close callback. Captures the editor by weak_ptr (so the
+    // callback does not form a retain cycle that leaks the editor), and removes
+    // it from the popup layer and the active-editor list on close. removeChild()
+    // is deferred while an event dispatch is in flight, so the removal is safe
+    // even though close fires from within the editor's own onMouseEvent.
+    template <typename EditorT>
+    void wireEditorClose(const std::shared_ptr<EditorT>& editor) {
+        std::weak_ptr<EditorT> weak = editor;
+        editor->setOnClose([this, weak]() {
+            auto ed = weak.lock();
+            if (!ed) return;
+            std::shared_ptr<NUIComponent> comp = ed;
+            if (m_popupLayer) m_popupLayer->removeChild(comp);
+            m_activeEditors.erase(std::remove(m_activeEditors.begin(), m_activeEditors.end(), comp),
+                                  m_activeEditors.end());
+        });
+    }
+
     // Backend references
     Aestra::Audio::PluginScanner* m_scanner = nullptr;
     Aestra::Audio::PluginManager* m_manager = nullptr;

--- a/Tests/AestraUI/EditorCloseDeferredTest.cpp
+++ b/Tests/AestraUI/EditorCloseDeferredTest.cpp
@@ -1,0 +1,126 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// EditorCloseDeferredTest — regression for the plugin-editor close cycle (#475).
+//
+// A plugin editor closes itself from inside its own onMouseEvent by calling
+// m_popupLayer->removeChild(self). Before the fix, that erased the parent's
+// children_ mid-iteration (iterator invalidation) and, with a weak_ptr close
+// capture, freed the editor while it was still on the call stack (use-after-
+// free). The fix defers removeChild() while an event dispatch is in flight
+// (NUIComponent::begin/endEventDispatch) and flushes it when the dispatch
+// unwinds. These tests exercise that directly at the NUIComponent level.
+
+#include "NUIComponent.h"
+#include "NUITypes.h"
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace AestraUI;
+
+namespace {
+
+// Removes itself from its parent during onMouseEvent, then lets the parent's
+// dispatch loop continue to the next sibling (returns false).
+class SelfCloser : public NUIComponent {
+public:
+    bool sawEvent = false;
+    bool onMouseEvent(const NUIMouseEvent&) override {
+        sawEvent = true;
+        if (auto* parent = getParent()) {
+            for (const auto& child : parent->getChildren()) {
+                if (child.get() == this) {
+                    parent->removeChild(child);
+                    break;
+                }
+            }
+        }
+        return false; // don't consume — force the parent loop to continue past a removed child
+    }
+};
+
+int g_failures = 0;
+void check(bool cond, const char* what) {
+    if (!cond) {
+        std::cout << "[FAIL] " << what << "\n";
+        ++g_failures;
+    }
+}
+
+// Two children remove themselves during a single dispatch; a plain child stays.
+void testSelfRemovalDuringDispatchIsSafe() {
+    auto root = std::make_shared<NUIComponent>();
+    auto a = std::make_shared<SelfCloser>();
+    auto b = std::make_shared<SelfCloser>();
+    auto keep = std::make_shared<NUIComponent>();
+    root->addChild(a);
+    root->addChild(b);
+    root->addChild(keep);
+
+    std::weak_ptr<NUIComponent> wa = a, wb = b;
+    SelfCloser* ap = a.get();
+    SelfCloser* bp = b.get();
+    a.reset();
+    b.reset(); // only root holds a and b now
+
+    NUIMouseEvent ev;
+    ev.pressed = true;
+    ev.button = NUIMouseButton::Left;
+
+    NUIComponent::beginEventDispatch();
+    root->onMouseEvent(ev); // iterates children; a and b remove themselves mid-loop
+    // Removal is deferred: still present, still alive during dispatch.
+    check(root->getChildren().size() == 3, "children preserved during dispatch");
+    check(!wa.expired() && !wb.expired(), "self-closers alive during dispatch");
+    check(ap->sawEvent && bp->sawEvent, "both self-closers received the event");
+    NUIComponent::endEventDispatch(); // flush deferred removals
+
+    check(root->getChildren().size() == 1, "self-closers removed after dispatch");
+    check(root->getChildren().front() == keep, "the kept child remains");
+    check(wa.expired() && wb.expired(), "removed editors freed (no retain cycle)");
+}
+
+// removeChild outside any dispatch removes immediately (unchanged behavior).
+void testRemoveOutsideDispatchIsImmediate() {
+    auto root = std::make_shared<NUIComponent>();
+    auto child = std::make_shared<NUIComponent>();
+    root->addChild(child);
+    std::weak_ptr<NUIComponent> w = child;
+    child.reset();
+
+    root->removeChild(root->getChildren().front());
+    check(root->getChildren().empty(), "immediate removal outside dispatch");
+    check(w.expired(), "child freed immediately outside dispatch");
+}
+
+// Nested begin/end: removal only flushes when the outermost dispatch unwinds.
+void testNestedDispatchDepth() {
+    auto root = std::make_shared<NUIComponent>();
+    auto child = std::make_shared<NUIComponent>();
+    root->addChild(child);
+    auto childRef = root->getChildren().front();
+
+    NUIComponent::beginEventDispatch();
+    NUIComponent::beginEventDispatch();
+    root->removeChild(childRef);
+    check(root->getChildren().size() == 1, "deferred while nested dispatch active");
+    NUIComponent::endEventDispatch();
+    check(root->getChildren().size() == 1, "still deferred at inner unwind");
+    NUIComponent::endEventDispatch();
+    check(root->getChildren().empty(), "flushed at outer unwind");
+}
+
+} // namespace
+
+int main() {
+    testSelfRemovalDuringDispatchIsSafe();
+    testRemoveOutsideDispatchIsImmediate();
+    testNestedDispatchDepth();
+
+    if (g_failures > 0) {
+        std::cout << g_failures << " check(s) failed\n";
+        return 1;
+    }
+    std::cout << "All editor-close deferred-destruction checks passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1591,6 +1591,21 @@ else()
     message(STATUS "PianoRollInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Editor-close deferred-destruction regression (#475): removeChild() during
+# event dispatch must defer and free safely (no iterator invalidation / UAF).
+if(TARGET AestraUI_Core)
+    add_executable(EditorCloseDeferredTest AestraUI/EditorCloseDeferredTest.cpp)
+    target_link_libraries(EditorCloseDeferredTest PRIVATE AestraUI_Core)
+    target_include_directories(EditorCloseDeferredTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+    )
+    add_test(NAME EditorCloseDeferredTest COMMAND EditorCloseDeferredTest)
+    set_tests_properties(EditorCloseDeferredTest PROPERTIES LABELS "ui;lifecycle;regression")
+else()
+    message(STATUS "EditorCloseDeferredTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # NUITextInput Layout / Caret / Selection regression tests
 # Guard on target presence because headless/CI disables AestraUI targets.
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUITextInputLayoutTest.cpp")


### PR DESCRIPTION
Closes #475.

## Summary

Fixes the plugin-editor `setOnClose` `shared_ptr` retain cycle (editors leak on close) **safely** — with framework-level deferred destruction, so it doesn't trade the leak for a use-after-free.

## Why the obvious fix is unsafe

Editors close themselves from inside their own `onMouseEvent` (`AestraPanelWindow.cpp:138` outside-click, `:153` close-button) by calling `m_popupLayer->removeChild(self)`. `NUIComponent::removeChild` erases from `children_` immediately, while `NUIComponent::onMouseEvent` is reverse-iterating that same `children_`. With the current **strong** capture the editor leaks but stays allocated, so the mid-dispatch removal is benign. A plain `weak_ptr` swap would let the editor be **freed at callback end** → dangling iterator over freed memory during the parent's iteration (intermittent UAF). `m_closeOnOutsideClick` defaults `true`, so this path is live.

## The fix (two parts)

**1. Framework-level deferred removal.** `NUIComponent` gains `beginEventDispatch()`/`endEventDispatch()` — a depth counter plus a strong-ref pending-removal list. While an event dispatch is in flight, `removeChild()` **defers** the removal (keeping the child alive) and **flushes** it when the dispatch unwinds. So a handler that closes a component can never invalidate a parent's iteration or free a component still on the call stack. `NUIApp::handleMouseEvent` brackets the root dispatch with `begin`/`endEventDispatch`. This fixes the whole class of "remove-during-dispatch" hazard, not just editors.

**2. Shared `weak_ptr` helper.** `PluginUIController::wireEditorClose<EditorT>()` captures the editor by `weak_ptr` (no retain cycle) and performs the now-deferred `removeChild` + active-list erase. All **12** `setOnClose` branches use it (EQ, Comp, Verb, Delay, Drift, Limit, Sat, Filter, OTT, LFO, Generic, Rumble).

Editors close only via mouse; there is no key-triggered close (`AestraPanelWindow` invokes `m_onClose` only from `onMouseEvent`), so only the mouse dispatch is bracketed. If a key-triggered removal is added later, the same `begin`/`end` wrap applies to `handleKeyEvent`.

## Testing

New `EditorCloseDeferredTest` (links `AestraUI_Core`):
- **Self-removal during dispatch is safe**: two components remove themselves mid-iteration; nothing crashes, the removals are deferred (children preserved + alive during dispatch), then flushed and **freed** after the dispatch unwinds (proving no retain cycle).
- **Removal outside dispatch stays immediate** (unchanged behavior + immediate free).
- **Nested dispatch depth**: removal flushes only at the outermost unwind.

All pass. Full `build-linux` build clean (0 errors); UI test suite green except the pre-existing `NUITextInputLayoutTest` (#458), which this PR doesn't touch.

## Docs updated?

No.

## Risk / rollback

- Touches the UI framework's child-removal path (now defers during event dispatch) — behavior is unchanged outside dispatch, and the deferral window is a single event's unwind. No DSP/plugin/serialization changes. Revert = drop the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added dispatch-depth tracking to defer `NUIComponent::removeChild()` until mouse-event handling fully unwinds, preventing iterator invalidation and use-after-free during editor closure.
- Updated `NUIApp` to bracket root mouse-event dispatch with the new lifecycle guard.
- Centralized plugin-editor close handling with a `weak_ptr`-based helper across all editor types, eliminating retain cycles and consistently cleaning up popup and active-editor state.
- Added regression coverage for self-removal, immediate removal outside dispatch, and nested dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->