### PR TITLE
fix(ui): plugin editors swallow clicks over empty panel space

### DIFF
--- a/AestraUI/Widgets/AestraCompEditor.cpp
+++ b/AestraUI/Widgets/AestraCompEditor.cpp
@@ -681,7 +681,7 @@ bool AestraCompEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    return NUIComponent::onMouseEvent(event);
+    return NUIComponent::onMouseEvent(event) || consumeInsideBounds(event);
 }
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/AestraDelayEditor.cpp
+++ b/AestraUI/Widgets/AestraDelayEditor.cpp
@@ -606,7 +606,7 @@ bool AestraDelayEditor::onMouseEvent(const NUIMouseEvent& event) {
     }
 
     // Let NUISlider children handle their own mouse events
-    return NUIComponent::onMouseEvent(event);
+    return NUIComponent::onMouseEvent(event) || consumeInsideBounds(event);
 }
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -248,7 +248,7 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         return true;
     }
 
-    return false;
+    return consumeInsideBounds(event);
 }
 
 void AestraDriftEditor::onResize(int width, int height) {

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -297,7 +297,7 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
         return true;
     }
 
-    return false;
+    return consumeInsideBounds(event);
 }
 
 void AestraFilterEditor::onResize(int width, int height) {

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -305,7 +305,7 @@ bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    return false;
+    return consumeInsideBounds(event);
 }
 
 void AestraLFOEditor::onResize(int width, int height) {

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -454,7 +454,7 @@ bool AestraLimitEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    return NUIComponent::onMouseEvent(event);
+    return NUIComponent::onMouseEvent(event) || consumeInsideBounds(event);
 }
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -212,7 +212,7 @@ bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    return false;
+    return consumeInsideBounds(event);
 }
 
 void AestraOTTEditor::onResize(int width, int height) {

--- a/AestraUI/Widgets/AestraPanelWindow.h
+++ b/AestraUI/Widgets/AestraPanelWindow.h
@@ -50,6 +50,14 @@ public:
     bool hitTestCloseButton(float x, float y) const;
     bool hitTestTitleBar(float x, float y) const;
 
+    // Consume any mouse event that lands inside the panel bounds. A floating
+    // editor is opaque to the mouse over its own area: a click on empty panel
+    // space (hitting no control) must NOT fall through to widgets behind it,
+    // which would otherwise both act on the click-through and dismiss the
+    // editor. Subclasses call this as their onMouseEvent fall-through, after
+    // all interactive controls have had a chance to consume the event.
+    bool consumeInsideBounds(const NUIMouseEvent& event) const { return getBounds().contains(event.position); }
+
     void setEnforceParentBounds(bool enforce) { m_enforceParentBounds = enforce; }
     void enforceBoundsInParent(float safeMargin = 14.0f);
 

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -276,7 +276,7 @@ bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
         return true;
     }
 
-    return false;
+    return consumeInsideBounds(event);
 }
 
 void AestraSatEditor::onResize(int width, int height) {

--- a/Tests/AestraUI/PanelWindowClickSwallowTest.cpp
+++ b/Tests/AestraUI/PanelWindowClickSwallowTest.cpp
@@ -1,0 +1,125 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// PanelWindowClickSwallowTest — regression for the global plugin-editor
+// click-through bug.
+//
+// A floating plugin editor (AestraPanelWindow subclass) must be OPAQUE to the
+// mouse over its own area: a left-click on empty panel space — hitting no
+// control, close button, or title bar — must be consumed (return true) so it
+// does not fall through to the widgets behind the editor. Before the fix, most
+// editors fell through to `return false` on such clicks, so the click both hit
+// the widget behind (click-through) and dismissed the editor. The fix routes
+// every editor's fall-through through AestraPanelWindow::consumeInsideBounds().
+//
+// This exercises the base-class contract with a minimal subclass that follows
+// the exact editor dispatch shape (chrome first, controls, then swallow).
+
+#include "AestraPanelWindow.h"
+#include "NUITypes.h"
+
+#include <iostream>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+void check(bool cond, const char* what) {
+    if (!cond) {
+        std::cout << "[FAIL] " << what << "\n";
+        ++g_failures;
+    }
+}
+
+// Mimics the canonical editor onMouseEvent: base chrome first, then a single
+// interactive control, then the inside-bounds swallow as the fall-through.
+class FakePanelEditor : public AestraPanelWindow {
+public:
+    NUIRect controlRect;
+    bool controlHit = false;
+
+    bool onMouseEvent(const NUIMouseEvent& event) override {
+        if (AestraPanelWindow::onMouseEvent(event))
+            return true;
+        if (event.pressed && event.button == NUIMouseButton::Left && controlRect.contains(event.position)) {
+            controlHit = true;
+            return true;
+        }
+        return consumeInsideBounds(event);
+    }
+};
+
+NUIMouseEvent leftPress(float x, float y) {
+    NUIMouseEvent e;
+    e.type = NUIMouseEventType::Down;
+    e.pressed = true;
+    e.button = NUIMouseButton::Left;
+    e.position = {x, y};
+    return e;
+}
+
+FakePanelEditor makeEditor(int& closeCount) {
+    // Bounds well away from the origin; title bar is the top TITLE_BAR_H px.
+    // Body: y in [132, 300). Close button: right()-28 .. right()-4, y 104..128.
+    FakePanelEditor ed;
+    ed.setBounds(NUIRect(100.0f, 100.0f, 300.0f, 200.0f)); // x100..400 y100..300
+    ed.controlRect = NUIRect(140.0f, 160.0f, 60.0f, 60.0f); // a control inside the body
+    ed.setOnClose([&closeCount] { ++closeCount; });
+    return ed;
+}
+
+// Empty body click (no control, no chrome) must be consumed and must NOT close.
+void testEmptyBodyClickIsSwallowed() {
+    int closed = 0;
+    auto ed = makeEditor(closed);
+    bool handled = ed.onMouseEvent(leftPress(350.0f, 280.0f)); // inside body, outside control
+    check(handled, "empty-body click consumed (no fall-through)");
+    check(closed == 0, "empty-body click did not close the editor");
+    check(!ed.controlHit, "empty-body click did not hit the control");
+}
+
+// A click on an actual control is consumed by the control, not the swallow.
+void testControlClickStillWorks() {
+    int closed = 0;
+    auto ed = makeEditor(closed);
+    bool handled = ed.onMouseEvent(leftPress(170.0f, 190.0f)); // inside controlRect
+    check(handled, "control click consumed");
+    check(ed.controlHit, "control click reached the control");
+    check(closed == 0, "control click did not close the editor");
+}
+
+// A genuine outside click is NOT swallowed (propagates) and closes the editor.
+void testOutsideClickPropagatesAndCloses() {
+    int closed = 0;
+    auto ed = makeEditor(closed);
+    bool handled = ed.onMouseEvent(leftPress(600.0f, 600.0f)); // far outside bounds
+    check(!handled, "outside click not swallowed (propagates for dismiss/passthrough)");
+    check(closed == 1, "outside click closed the editor exactly once");
+    check(!ed.controlHit, "outside click did not hit the control");
+}
+
+// A click on the title bar is consumed by chrome (drag), not the swallow, and
+// does not close.
+void testTitleBarClickConsumedByChrome() {
+    int closed = 0;
+    auto ed = makeEditor(closed);
+    bool handled = ed.onMouseEvent(leftPress(200.0f, 110.0f)); // title bar strip
+    check(handled, "title-bar click consumed by chrome");
+    check(closed == 0, "title-bar click did not close the editor");
+    check(ed.isDraggingWindow(), "title-bar press started a window drag");
+}
+
+} // namespace
+
+int main() {
+    testEmptyBodyClickIsSwallowed();
+    testControlClickStillWorks();
+    testOutsideClickPropagatesAndCloses();
+    testTitleBarClickConsumedByChrome();
+
+    if (g_failures > 0) {
+        std::cout << g_failures << " check(s) failed\n";
+        return 1;
+    }
+    std::cout << "All panel-window click-swallow checks passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1606,6 +1606,23 @@ else()
     message(STATUS "EditorCloseDeferredTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Panel-window click-swallow regression: a floating plugin editor must consume
+# clicks over its own empty area so they don't fall through to widgets behind it
+# (click-through + spurious dismiss).
+if(TARGET AestraUI_Core)
+    add_executable(PanelWindowClickSwallowTest AestraUI/PanelWindowClickSwallowTest.cpp)
+    target_link_libraries(PanelWindowClickSwallowTest PRIVATE AestraUI_Core)
+    target_include_directories(PanelWindowClickSwallowTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+    )
+    add_test(NAME PanelWindowClickSwallowTest COMMAND PanelWindowClickSwallowTest)
+    set_tests_properties(PanelWindowClickSwallowTest PROPERTIES LABELS "ui;input;regression")
+else()
+    message(STATUS "PanelWindowClickSwallowTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # NUITextInput Layout / Caret / Selection regression tests
 # Guard on target presence because headless/CI disables AestraUI targets.
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUITextInputLayoutTest.cpp")


### PR DESCRIPTION
## Summary
Fixes a global plugin-editor bug: clicking inside a plugin editor where there are no controls (empty panel space) closed the editor **and** clicked through to the widget behind it.

## Why
Every plugin editor derives from `AestraPanelWindow` and dispatches: base chrome first (close button / title drag / outside-click close), then its own controls. When a left-click hit none of those, 8 of 10 editors fell through to `return false`. A non-consumed click propagates behind the floating editor, so the widget behind both acted on it (click-through) and a dismiss fired.

`AestraEQEditor` and `AestraVerbEditor` already guarded this by returning `getBounds().contains(pos)`. This makes that behavior canonical and applies it everywhere.

## What changed
- **`AestraPanelWindow::consumeInsideBounds(event)`** — new base helper: consume any event landing inside the panel bounds (matches EQ/Verb's existing behavior). A floating editor is opaque to the mouse over its own area.
- Routed the 8 leaky editors' fall-through through it:
  - `Drift/Filter/LFO/OTT/Sat` — were `return false;`
  - `Comp/Delay/Limit` — forwarded to slider children; now `NUIComponent::onMouseEvent(event) || consumeInsideBounds(event)` so child drags still work.
- Outside-the-panel clicks still return `false` → close-on-outside-click and passthrough unchanged.

## Testing
- New headless regression `Tests/AestraUI/PanelWindowClickSwallowTest` (links `AestraUI_Core`): empty-body click swallowed + not closed, control click still consumed, outside click propagates + closes exactly once, title-bar press starts a drag. **Passes.**
- `EditorCloseDeferredTest` still passes (no regression to close/removeChild).
- Full `Aestra` app target builds clean (`-j2`, Release, core mode).

## Docs updated?
No.

## Risk / rollback
Low, UI-only, no DSP/serialization change. Behavior change is limited to previously-unhandled clicks inside a panel now being consumed instead of falling through. Rollback = revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)