### PR TITLE
fix(verb): correct mode-index test mapping; measure all nine modes

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -117,6 +117,18 @@ public:
 
     static constexpr int kModeCount = 9;
 
+    // Canonical inverse of modeIndex(). modeIndex() decodes the kMode parameter
+    // as round(param * (kModeCount - 1)), so modeParam(i) round-trips exactly to
+    // mode i. Use this — NOT hand-picked 0.0/0.5/1.0 constants — to select a
+    // specific mode in tests, labs, and presets: param 0.5 decodes to Chamber
+    // (mode 4), not Hall, and 1.0 decodes to SmoothPlate (mode 8), not Plate.
+    static constexpr float modeParam(int index) {
+        return static_cast<float>(index) / static_cast<float>(kModeCount - 1);
+    }
+    static constexpr float modeParam(Mode mode) {
+        return modeParam(static_cast<int>(mode));
+    }
+
     enum class PredelaySync : int {
         Off = 0,
         Sixteenth = 1,   // 1/16 note
@@ -1592,6 +1604,21 @@ private:
     mutable std::array<StageProfileData, static_cast<size_t>(ProfileStage::kStageCount)> m_profileData{};
 #endif
 };
+
+// modeIndex() decodes as round(param * (kModeCount - 1)). Because i/8 is exactly
+// representable in float for i in [0, 8], modeParam(i) * 8 recovers i exactly,
+// so the round-trip is lossless. Lock the two historically mis-mapped anchors at
+// compile time: 0.5 is NOT Hall, and 1.0 is NOT Plate. (These live at namespace
+// scope because a constexpr member function cannot be evaluated inside its own
+// still-incomplete class definition.)
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Room) == 0.0f,
+              "Room must map to param 0.0");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::SmoothPlate) == 1.0f,
+              "SmoothPlate must map to param 1.0");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Hall) * static_cast<float>(AestraVerb::kModeCount - 1) == 1.0f,
+              "Hall must decode to mode index 1");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Plate) * static_cast<float>(AestraVerb::kModeCount - 1) == 2.0f,
+              "Plate must decode to mode index 2");
 
 } // namespace Plugins
 } // namespace Audio

--- a/Tests/AestraAudio/ReverbMaterialLab.cpp
+++ b/Tests/AestraAudio/ReverbMaterialLab.cpp
@@ -494,10 +494,13 @@ int main() {
         std::string name;
         float param;
     };
+    // Select each mode via the canonical AestraVerb::modeParam() so the labeled
+    // mode is the mode actually rendered. Hardcoded 0.5/1.0 previously decoded
+    // to Chamber (mode 4) and SmoothPlate (mode 8), not Hall and Plate.
     std::vector<ModeDef> modes = {
-        {"room", 0.0f},
-        {"hall", 0.5f},
-        {"plate", 1.0f},
+        {"room", AestraVerb::modeParam(AestraVerb::Mode::Room)},
+        {"hall", AestraVerb::modeParam(AestraVerb::Mode::Hall)},
+        {"plate", AestraVerb::modeParam(AestraVerb::Mode::Plate)},
     };
 
     std::vector<MaterialResult> results;

--- a/Tests/AestraAudio/ReverbQualityLab.cpp
+++ b/Tests/AestraAudio/ReverbQualityLab.cpp
@@ -881,9 +881,31 @@ int main() {
     std::cout << "==================================\n\n";
 
     std::vector<ModeQuality> modes;
-    modes.push_back(measureMode("room", 0.0f, 0.6f, 0.5f, 0.7f, sampleRate, numFrames, qualityDir));
-    modes.push_back(measureMode("hall", 0.5f, 0.9f, 0.9f, 0.85f, sampleRate, numFrames, qualityDir));
-    modes.push_back(measureMode("plate", 1.0f, 0.7f, 0.6f, 0.8f, sampleRate, numFrames, qualityDir));
+    // Measure all nine modes. Each mode is selected via the canonical
+    // AestraVerb::modeParam() so its measured evidence matches the mode it is
+    // labeled with. (Previously "hall" passed 0.5, which decodes to Chamber
+    // (mode 4), and "plate" passed 1.0, which decodes to SmoothPlate (mode 8) —
+    // so the published Hall/Plate measurements were mislabeled.)
+    struct ModeSetting {
+        AestraVerb::Mode mode;
+        const char* name;
+        float decay, size, diffusion;
+    };
+    static const ModeSetting kModeSettings[] = {
+        {AestraVerb::Mode::Room,        "room",         0.60f, 0.50f, 0.70f},
+        {AestraVerb::Mode::Hall,        "hall",         0.90f, 0.90f, 0.85f},
+        {AestraVerb::Mode::Plate,       "plate",        0.70f, 0.60f, 0.80f},
+        {AestraVerb::Mode::Cathedral,   "cathedral",    0.95f, 0.95f, 0.80f},
+        {AestraVerb::Mode::Chamber,     "chamber",      0.70f, 0.60f, 0.75f},
+        {AestraVerb::Mode::BrightHall,  "bright_hall",  0.88f, 0.85f, 0.85f},
+        {AestraVerb::Mode::Ambience,    "ambience",     0.40f, 0.40f, 0.60f},
+        {AestraVerb::Mode::Scoring,     "scoring",      0.90f, 0.85f, 0.85f},
+        {AestraVerb::Mode::SmoothPlate, "smooth_plate", 0.72f, 0.60f, 0.85f},
+    };
+    for (const auto& s : kModeSettings) {
+        modes.push_back(measureMode(s.name, AestraVerb::modeParam(s.mode),
+                                    s.decay, s.size, s.diffusion, sampleRate, numFrames, qualityDir));
+    }
 
     // Write JSON report
     {
@@ -906,12 +928,12 @@ int main() {
             f << "## Files\n\n";
             f << "- `reverb_quality_baseline.json` — Machine-readable quality metrics\n";
             f << "- `reverb_quality_baseline.md` — Human-readable quality report\n";
-            f << "- `impulse_room.wav` — Room mode impulse response\n";
-            f << "- `impulse_hall.wav` — Hall mode impulse response\n";
-            f << "- `impulse_plate.wav` — Plate mode impulse response\n";
-            f << "- `noiseburst_room.wav` — Room mode noise burst response\n";
-            f << "- `noiseburst_hall.wav` — Hall mode noise burst response\n";
-            f << "- `noiseburst_plate.wav` — Plate mode noise burst response\n";
+            for (const auto& q : modes) {
+                f << "- `impulse_" << q.name << ".wav` — " << q.name << " mode impulse response\n";
+            }
+            for (const auto& q : modes) {
+                f << "- `noiseburst_" << q.name << ".wav` — " << q.name << " mode noise burst response\n";
+            }
         }
     }
 

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -26,8 +26,13 @@ struct RenderStats {
     bool finite = true;
 };
 
+// mode: 0 = Room, 1 = Hall, 2 = Plate. Select via the canonical modeParam() so
+// these actually land on Room/Hall/Plate; the old 0.0/0.5/1.0 constants decoded
+// to Room/Chamber/SmoothPlate.
 void setMode(AestraVerb& verb, int mode) {
-    verb.setParameter(AestraVerb::kMode, mode == 0 ? 0.0f : (mode == 1 ? 0.5f : 1.0f));
+    const AestraVerb::Mode m =
+        mode == 0 ? AestraVerb::Mode::Room : (mode == 1 ? AestraVerb::Mode::Hall : AestraVerb::Mode::Plate);
+    verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(m));
 }
 
 void setUsableDefaults(AestraVerb& verb, int mode) {
@@ -258,6 +263,31 @@ bool runActiveLoadStateSafetyCheck() {
     return ok;
 }
 
+// Every one of the nine modes, selected via the canonical modeParam(), must
+// render finite, bounded audio. Guards against a mode index that aliases or
+// clamps to a neighbor and against any single mode blowing up.
+bool runAllNineModesFiniteChecks() {
+    bool ok = true;
+    std::vector<float> input = makeBrightTransient(48000, 4000.0f);
+    for (int mode = 0; mode < AestraVerb::kModeCount; ++mode) {
+        AestraVerb verb;
+        verb.initialize(kSampleRate, 256);
+        verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+        verb.setParameter(AestraVerb::kDecay, 0.7f);
+        verb.setParameter(AestraVerb::kSize, 0.6f);
+        verb.setParameter(AestraVerb::kDiffusion, 0.7f);
+        verb.setParameter(AestraVerb::kModRate, 0.42f);
+        verb.setParameter(AestraVerb::kModDepth, 0.2f);
+        verb.setParameter(AestraVerb::kMix, 1.0f);
+        verb.setParameter(AestraVerb::kWidth, 0.7f);
+        verb.activate();
+        auto stats = render(verb, input, 128);
+        ok &= require(stats.finite, "nine-mode sweep produced NaN/Inf");
+        ok &= require(stats.peak < 8.0f, "nine-mode sweep exceeded sane bounds");
+    }
+    return ok;
+}
+
 } // namespace
 
 int main() {
@@ -267,6 +297,7 @@ int main() {
     ok &= runModeSwitchAndDeterminismChecks();
     ok &= runHighFrequencyBuildupChecks();
     ok &= runActiveLoadStateSafetyCheck();
+    ok &= runAllNineModesFiniteChecks();
 
     if (!ok) {
         return 1;


### PR DESCRIPTION
## Summary
First step of the AestraVerb truth-repair: fix the mode-index mapping error in the reverb labs/tests so measurements are labeled with the mode they actually render. **No DSP change.**

## Why
`AestraVerb` decodes the `kMode` parameter as `round(param * (kModeCount - 1))` across 9 modes (`Room=0.0` … `SmoothPlate=1.0`). The quality/material/safety labs selected modes with hand-picked constants:

| Label | Param used | Actually selected |
|-------|-----------|-------------------|
| Room  | 0.0 | Room ✓ |
| Hall  | **0.5** | **Chamber (mode 4)** ✗ |
| Plate | **1.0** | **SmoothPlate (mode 8)** ✗ |

So every published "Hall" and "Plate" measurement was mislabeled — and tuning the real Hall against Chamber evidence would have been wrong. Fixing this is the prerequisite for all later reverb work.

## What changed
- **`AestraVerb::modeParam(int)` / `modeParam(Mode)`** — canonical exact inverse of `modeIndex()`. Namespace-scope `static_assert`s lock the mapping (Room=0.0, SmoothPlate=1.0, Hall→idx 1, Plate→idx 2); `i/8` is exactly representable in float so the round-trip is lossless.
- **ReverbQualityLab** — measures **all nine modes** via `modeParam()` (was 3, two mislabeled); README wav listing generated from the measured set.
- **ReverbMaterialLab** — selects Room/Hall/Plate via `modeParam()`.
- **ReverbSafetyRegressionTest** — `setMode()` now selects Room/Hall/Plate correctly; new `runAllNineModesFiniteChecks()` asserts every mode renders finite + bounded.

## Testing
- `ReverbSafetyRegressionTest` **passes**, including the new nine-mode sweep.
- Both labs build and run; `AestraReverbQualityLab` now reports **nine distinct modes** — "hall" measures a true diffuse hall (centroid ~2280 Hz, crest ~10) instead of the dense Chamber it measured before.
- Full `AestraAudioCore` compiles (static_asserts pass → mapping proven at compile time).

## Docs updated?
No. Evidence regeneration is **deliberately deferred** to the measurement (T60) fix — several modes currently show a `T20=T40=T60` collapse (the known render-too-short estimator bug), so committing a regenerated baseline now would bake in untrustworthy decay numbers.

## Risk / rollback
Very low — test/lab-only, no DSP/serialization/latency change. Rollback = revert the commit.

Follow-ups (this review's remaining items): corrected T60 measurement + diagnostic renaming, Low Cut fix, transition system, chaotic-mod rewrite, stereo geometry, control-cache dirtying + tail dormancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)