### PR TITLE
test(verb): reverb consistency probe — invariants + offness diagnostics

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -117,6 +117,18 @@ public:
 
     static constexpr int kModeCount = 9;
 
+    // Canonical inverse of modeIndex(). modeIndex() decodes the kMode parameter
+    // as round(param * (kModeCount - 1)), so modeParam(i) round-trips exactly to
+    // mode i. Use this — NOT hand-picked 0.0/0.5/1.0 constants — to select a
+    // specific mode in tests, labs, and presets: param 0.5 decodes to Chamber
+    // (mode 4), not Hall, and 1.0 decodes to SmoothPlate (mode 8), not Plate.
+    static constexpr float modeParam(int index) {
+        return static_cast<float>(index) / static_cast<float>(kModeCount - 1);
+    }
+    static constexpr float modeParam(Mode mode) {
+        return modeParam(static_cast<int>(mode));
+    }
+
     enum class PredelaySync : int {
         Off = 0,
         Sixteenth = 1,   // 1/16 note
@@ -1592,6 +1604,21 @@ private:
     mutable std::array<StageProfileData, static_cast<size_t>(ProfileStage::kStageCount)> m_profileData{};
 #endif
 };
+
+// modeIndex() decodes as round(param * (kModeCount - 1)). Because i/8 is exactly
+// representable in float for i in [0, 8], modeParam(i) * 8 recovers i exactly,
+// so the round-trip is lossless. Lock the two historically mis-mapped anchors at
+// compile time: 0.5 is NOT Hall, and 1.0 is NOT Plate. (These live at namespace
+// scope because a constexpr member function cannot be evaluated inside its own
+// still-incomplete class definition.)
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Room) == 0.0f,
+              "Room must map to param 0.0");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::SmoothPlate) == 1.0f,
+              "SmoothPlate must map to param 1.0");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Hall) * static_cast<float>(AestraVerb::kModeCount - 1) == 1.0f,
+              "Hall must decode to mode index 1");
+static_assert(AestraVerb::modeParam(AestraVerb::Mode::Plate) * static_cast<float>(AestraVerb::kModeCount - 1) == 2.0f,
+              "Plate must decode to mode index 2");
 
 } // namespace Plugins
 } // namespace Audio

--- a/Tests/AestraAudio/ReverbConsistencyProbe.cpp
+++ b/Tests/AestraAudio/ReverbConsistencyProbe.cpp
@@ -1,0 +1,326 @@
+// AestraVerb consistency probe — hunts for inconsistency/offness beyond the
+// existing safety checks. Hard invariants (bypass parity, NaN rejection,
+// silence tail, state roundtrip) assert and fail the process; the remaining
+// measurements print diagnostics for review (Low Cut mapping, freeze stability,
+// sample-rate consistency, mode-switch clicks, early stereo correlation, mono
+// L/R balance).
+
+#include "AestraVerb.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+
+int g_failures = 0;
+void check(bool cond, const std::string& what) {
+    std::cout << (cond ? "[ ok ] " : "[FAIL] ") << what << "\n";
+    if (!cond) ++g_failures;
+}
+
+struct Stereo {
+    std::vector<float> l, r;
+};
+
+// Render a stereo input through the verb in fixed blocks.
+Stereo render(AestraVerb& v, const std::vector<float>& inL, const std::vector<float>& inR, uint32_t block) {
+    const size_t n = inL.size();
+    Stereo out{std::vector<float>(n, 0.0f), std::vector<float>(n, 0.0f)};
+    for (size_t off = 0; off < n; off += block) {
+        const uint32_t frames = static_cast<uint32_t>(std::min<size_t>(block, n - off));
+        const float* ins[2] = {inL.data() + off, inR.data() + off};
+        float* outs[2] = {out.l.data() + off, out.r.data() + off};
+        v.process(ins, outs, 2, 2, frames);
+    }
+    return out;
+}
+
+Stereo impulseIn(size_t n) {
+    Stereo s{std::vector<float>(n, 0.0f), std::vector<float>(n, 0.0f)};
+    s.l[0] = 1.0f;
+    s.r[0] = 1.0f;
+    return s;
+}
+
+std::vector<float> whiteNoise(size_t n, uint32_t seed, float amp = 0.25f) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> d(-amp, amp);
+    std::vector<float> v(n);
+    for (auto& x : v) x = d(rng);
+    return v;
+}
+
+double rms(const std::vector<float>& v, size_t from, size_t to) {
+    double acc = 0.0;
+    size_t cnt = 0;
+    for (size_t i = from; i < to && i < v.size(); ++i) { acc += double(v[i]) * v[i]; ++cnt; }
+    return cnt ? std::sqrt(acc / double(cnt)) : 0.0;
+}
+
+double toDb(double lin) { return 20.0 * std::log10(std::max(lin, 1e-12)); }
+
+void configureHall(AestraVerb& v) {
+    v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(AestraVerb::Mode::Hall));
+    v.setParameter(AestraVerb::kDecay, 0.7f);
+    v.setParameter(AestraVerb::kSize, 0.7f);
+    v.setParameter(AestraVerb::kDiffusion, 0.7f);
+    v.setParameter(AestraVerb::kModRate, 0.4f);
+    v.setParameter(AestraVerb::kModDepth, 0.15f);
+    v.setParameter(AestraVerb::kMix, 1.0f);
+    v.setParameter(AestraVerb::kWidth, 0.7f);
+    v.setParameter(AestraVerb::kLowCut, 0.0f);
+    v.setParameter(AestraVerb::kHighCut, 1.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Hard invariants
+// ---------------------------------------------------------------------------
+
+void probeBypassParity() {
+    AestraVerb v;
+    v.initialize(48000.0, 256);
+    configureHall(v);
+    v.setParameter(AestraVerb::kBypass, 1.0f);
+    v.activate();
+    auto nL = whiteNoise(2048, 1), nR = whiteNoise(2048, 2);
+    auto out = render(v, nL, nR, 128);
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < nL.size(); ++i) {
+        maxDiff = std::max(maxDiff, std::abs(out.l[i] - nL[i]));
+        maxDiff = std::max(maxDiff, std::abs(out.r[i] - nR[i]));
+    }
+    check(maxDiff == 0.0f, "bypass is a bit-exact dry passthrough (maxDiff=" + std::to_string(maxDiff) + ")");
+}
+
+void probeNaNRejection() {
+    AestraVerb v;
+    v.initialize(48000.0, 256);
+    configureHall(v);
+    v.activate();
+    std::vector<float> inL(512, 0.0f), inR(512, 0.0f);
+    inL[10] = std::numeric_limits<float>::quiet_NaN();
+    inR[20] = std::numeric_limits<float>::infinity();
+    inL[30] = -std::numeric_limits<float>::infinity();
+    auto out = render(v, inL, inR, 64);
+    bool allFinite = true;
+    for (size_t i = 0; i < out.l.size(); ++i)
+        allFinite &= std::isfinite(out.l[i]) && std::isfinite(out.r[i]);
+    check(allFinite, "NaN/Inf input produces only finite output");
+}
+
+void probeSilenceTail() {
+    AestraVerb v;
+    v.initialize(48000.0, 256);
+    configureHall(v);
+    v.activate();
+    // 0.5 s excitation, then 6 s of silence.
+    const size_t exc = 24000, sil = 288000;
+    std::vector<float> inL(exc + sil, 0.0f), inR(exc + sil, 0.0f);
+    auto nL = whiteNoise(exc, 7), nR = whiteNoise(exc, 8);
+    for (size_t i = 0; i < exc; ++i) { inL[i] = nL[i]; inR[i] = nR[i]; }
+    auto out = render(v, inL, inR, 128);
+    const double tailDb = toDb(rms(out.l, out.l.size() - 24000, out.l.size()));
+    std::cout << "       silence-tail residual (last 0.5s): " << tailDb << " dBFS\n";
+    check(tailDb < -80.0, "output decays into silence (no self-oscillation/denormal buzz)");
+}
+
+void probeStateRoundtrip() {
+    AestraVerb a;
+    a.initialize(48000.0, 256);
+    configureHall(a);
+    a.setParameter(AestraVerb::kLowCut, 0.4f);
+    a.setParameter(AestraVerb::kHighCut, 0.6f);
+    a.setParameter(AestraVerb::kMode, AestraVerb::modeParam(AestraVerb::Mode::Plate));
+    const auto blob = a.saveState();
+
+    AestraVerb b;
+    b.initialize(48000.0, 256);
+    check(b.loadState(blob), "loadState accepts a saved blob");
+    a.activate();
+    b.activate();
+    auto imp = impulseIn(48000);
+    auto oa = render(a, imp.l, imp.r, 128);
+    auto ob = render(b, imp.l, imp.r, 128);
+    float maxDiff = 0.0f;
+    for (size_t i = 0; i < oa.l.size(); ++i) {
+        maxDiff = std::max(maxDiff, std::abs(oa.l[i] - ob.l[i]));
+        maxDiff = std::max(maxDiff, std::abs(oa.r[i] - ob.r[i]));
+    }
+    check(maxDiff == 0.0f, "save/load reproduces identical output (maxDiff=" + std::to_string(maxDiff) + ")");
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics (printed; do not fail the build)
+// ---------------------------------------------------------------------------
+
+void diagLowCutMapping() {
+    std::cout << "\n--- Low Cut: displayed vs actual cutoff, and measured attenuation ---\n";
+    std::cout << "  knob   displayHz   dspHz   100Hz-atten   500Hz-atten\n";
+    for (float v : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
+        const double displayHz = v < 0.001f ? 20.0 : 20.0 * std::pow(100.0, v);
+        const double dspHz = v < 0.001f ? 20.0 : std::min(2000.0, 20.0 * std::pow(1000.0, v));
+        // Measure attenuation of steady 100 Hz and 500 Hz tones vs Low Cut = 0.
+        auto measureTone = [&](float hz) -> double {
+            auto tone = [&](AestraVerb& verb) {
+                std::vector<float> in(48000);
+                for (size_t i = 0; i < in.size(); ++i)
+                    in[i] = 0.5f * std::sin(2.0 * M_PI * hz * double(i) / 48000.0);
+                auto out = render(verb, in, in, 128);
+                return rms(out.l, 24000, 48000); // steady-state second half
+            };
+            AestraVerb ref;  ref.initialize(48000.0, 256); configureHall(ref);
+            ref.setParameter(AestraVerb::kMix, 1.0f); ref.setParameter(AestraVerb::kLowCut, 0.0f); ref.activate();
+            AestraVerb cut;  cut.initialize(48000.0, 256); configureHall(cut);
+            cut.setParameter(AestraVerb::kMix, 1.0f); cut.setParameter(AestraVerb::kLowCut, v); cut.activate();
+            return toDb(tone(cut) / std::max(tone(ref), 1e-9));
+        };
+        char buf[160];
+        std::snprintf(buf, sizeof(buf), "  %.2f   %8.1f   %6.1f    %+7.1f dB    %+7.1f dB\n",
+                      v, displayHz, dspHz, measureTone(100.0f), measureTone(500.0f));
+        std::cout << buf;
+    }
+    std::cout << "  (displayHz uses 20*100^v; dspHz uses 20*1000^v clamped to 2000 — they diverge)\n";
+}
+
+void diagFreezeStability() {
+    std::cout << "\n--- Freeze stability: tail RMS over time (want ~flat) ---\n";
+    AestraVerb v;
+    v.initialize(48000.0, 256);
+    configureHall(v);
+    v.setParameter(AestraVerb::kFreeze, 1.0f);
+    v.activate();
+    const size_t exc = 12000, total = 48000 * 8;
+    std::vector<float> inL(total, 0.0f), inR(total, 0.0f);
+    auto nL = whiteNoise(exc, 11), nR = whiteNoise(exc, 12);
+    for (size_t i = 0; i < exc; ++i) { inL[i] = nL[i]; inR[i] = nR[i]; }
+    auto out = render(v, inL, inR, 128);
+    const double r1 = rms(out.l, 48000 * 1, 48000 * 1 + 24000);
+    const double r3 = rms(out.l, 48000 * 3, 48000 * 3 + 24000);
+    const double r7 = rms(out.l, 48000 * 7, 48000 * 7 + 24000);
+    char buf[160];
+    std::snprintf(buf, sizeof(buf), "  t=1s: %.1f dB   t=3s: %.1f dB   t=7s: %.1f dB   (7s-1s drift: %+.1f dB)\n",
+                  toDb(r1), toDb(r3), toDb(r7), toDb(r7) - toDb(r1));
+    std::cout << buf;
+}
+
+double measureT60(double sr) {
+    AestraVerb v;
+    v.initialize(sr, 256);
+    configureHall(v);
+    v.setParameter(AestraVerb::kDecay, 0.7f);
+    v.activate();
+    const size_t n = size_t(sr * 6.0);
+    std::vector<float> inL(n, 0.0f), inR(n, 0.0f);
+    inL[0] = 1.0f; inR[0] = 1.0f;
+    auto out = render(v, inL, inR, 128);
+    // Peak windowed RMS then time to fall 60 dB below it.
+    const size_t win = size_t(sr * 0.05);
+    double peak = 0.0;
+    for (size_t i = 0; i + win < n; i += win) peak = std::max(peak, rms(out.l, i, i + win));
+    const double thresh = peak * std::pow(10.0, -60.0 / 20.0);
+    double t60 = 0.0;
+    for (size_t i = 0; i + win < n; i += win)
+        if (rms(out.l, i, i + win) > thresh) t60 = double(i) / sr;
+    return t60;
+}
+
+void diagSampleRateConsistency() {
+    std::cout << "\n--- Sample-rate consistency: T60 at fixed params (want ~equal) ---\n";
+    const double t441 = measureT60(44100.0);
+    const double t48 = measureT60(48000.0);
+    const double t96 = measureT60(96000.0);
+    char buf[160];
+    std::snprintf(buf, sizeof(buf), "  44.1k: %.3fs   48k: %.3fs   96k: %.3fs   (spread: %.1f%%)\n",
+                  t441, t48, t96, 100.0 * (std::max({t441, t48, t96}) - std::min({t441, t48, t96})) / std::max(t48, 1e-6));
+    std::cout << buf;
+}
+
+void diagModeSwitchClick() {
+    std::cout << "\n--- Mode-switch discontinuity (max |sample delta| around switch) ---\n";
+    AestraVerb v;
+    v.initialize(48000.0, 64);
+    configureHall(v);
+    v.activate();
+    // Build a steady tail, then switch mode mid-render and watch the seam.
+    auto noise = whiteNoise(48000, 21);
+    auto baselineMaxDelta = [](const std::vector<float>& x, size_t from, size_t to) {
+        float m = 0.0f;
+        for (size_t i = from + 1; i < to && i < x.size(); ++i) m = std::max(m, std::abs(x[i] - x[i - 1]));
+        return m;
+    };
+    std::vector<float> outL(96000, 0.0f), outR(96000, 0.0f);
+    std::vector<float> inL(96000, 0.0f), inR(96000, 0.0f);
+    for (size_t i = 0; i < 48000; ++i) { inL[i] = noise[i] * 0.3f; inR[i] = noise[i] * 0.3f; }
+    size_t switchAt = 60000;
+    for (size_t off = 0; off < 96000; off += 64) {
+        if (off == switchAt) v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(AestraVerb::Mode::Plate));
+        const uint32_t frames = 64;
+        const float* ins[2] = {inL.data() + off, inR.data() + off};
+        float* outs[2] = {outL.data() + off, outR.data() + off};
+        v.process(ins, outs, 2, 2, frames);
+    }
+    const float preDelta = baselineMaxDelta(outL, switchAt - 4096, switchAt - 64);
+    const float atDelta = baselineMaxDelta(outL, switchAt - 64, switchAt + 512);
+    char buf[160];
+    std::snprintf(buf, sizeof(buf), "  pre-switch max delta: %.5f   at-switch max delta: %.5f   (ratio: %.2fx)\n",
+                  preDelta, atDelta, atDelta / std::max(preDelta, 1e-9f));
+    std::cout << buf;
+}
+
+double pearson(const std::vector<float>& a, const std::vector<float>& b, size_t from, size_t to) {
+    double ma = 0, mb = 0; size_t n = 0;
+    for (size_t i = from; i < to && i < a.size(); ++i) { ma += a[i]; mb += b[i]; ++n; }
+    if (!n) return 0; ma /= n; mb /= n;
+    double num = 0, da = 0, db = 0;
+    for (size_t i = from; i < to && i < a.size(); ++i) {
+        num += (a[i] - ma) * (b[i] - mb); da += (a[i] - ma) * (a[i] - ma); db += (b[i] - mb) * (b[i] - mb);
+    }
+    return num / std::sqrt(std::max(da * db, 1e-18));
+}
+
+void diagStereoCorrelationAndBalance() {
+    std::cout << "\n--- Early stereo correlation + mono-in L/R balance ---\n";
+    AestraVerb v;
+    v.initialize(48000.0, 256);
+    configureHall(v);
+    v.activate();
+    auto imp = impulseIn(96000);
+    auto out = render(v, imp.l, imp.r, 128);
+    const double earlyCorr = pearson(out.l, out.r, 0, 960);   // first 20 ms
+    const double lateCorr = pearson(out.l, out.r, 24000, 48000);
+    const double balL = toDb(rms(out.l, 0, out.l.size()));
+    const double balR = toDb(rms(out.r, 0, out.r.size()));
+    char buf[200];
+    std::snprintf(buf, sizeof(buf),
+                  "  early (0-20ms) L/R corr: %.3f   late (0.5-1s) corr: %.3f   mono-in L/R RMS: %+.2f/%+.2f dB (imbalance %.2f dB)\n",
+                  earlyCorr, lateCorr, balL, balR, balL - balR);
+    std::cout << buf;
+    std::cout << "  (early corr near 1.0 = mono onset; nonzero L/R imbalance = asymmetric injection/output)\n";
+}
+
+} // namespace
+
+int main() {
+    std::cout << "AestraVerb Consistency Probe\n============================\n";
+    probeBypassParity();
+    probeNaNRejection();
+    probeSilenceTail();
+    probeStateRoundtrip();
+
+    diagLowCutMapping();
+    diagFreezeStability();
+    diagSampleRateConsistency();
+    diagModeSwitchClick();
+    diagStereoCorrelationAndBalance();
+
+    std::cout << "\n" << (g_failures ? std::to_string(g_failures) + " hard invariant(s) FAILED\n"
+                                     : "All hard invariants held\n");
+    return g_failures ? 1 : 0;
+}

--- a/Tests/AestraAudio/ReverbMaterialLab.cpp
+++ b/Tests/AestraAudio/ReverbMaterialLab.cpp
@@ -494,10 +494,13 @@ int main() {
         std::string name;
         float param;
     };
+    // Select each mode via the canonical AestraVerb::modeParam() so the labeled
+    // mode is the mode actually rendered. Hardcoded 0.5/1.0 previously decoded
+    // to Chamber (mode 4) and SmoothPlate (mode 8), not Hall and Plate.
     std::vector<ModeDef> modes = {
-        {"room", 0.0f},
-        {"hall", 0.5f},
-        {"plate", 1.0f},
+        {"room", AestraVerb::modeParam(AestraVerb::Mode::Room)},
+        {"hall", AestraVerb::modeParam(AestraVerb::Mode::Hall)},
+        {"plate", AestraVerb::modeParam(AestraVerb::Mode::Plate)},
     };
 
     std::vector<MaterialResult> results;

--- a/Tests/AestraAudio/ReverbQualityLab.cpp
+++ b/Tests/AestraAudio/ReverbQualityLab.cpp
@@ -881,9 +881,31 @@ int main() {
     std::cout << "==================================\n\n";
 
     std::vector<ModeQuality> modes;
-    modes.push_back(measureMode("room", 0.0f, 0.6f, 0.5f, 0.7f, sampleRate, numFrames, qualityDir));
-    modes.push_back(measureMode("hall", 0.5f, 0.9f, 0.9f, 0.85f, sampleRate, numFrames, qualityDir));
-    modes.push_back(measureMode("plate", 1.0f, 0.7f, 0.6f, 0.8f, sampleRate, numFrames, qualityDir));
+    // Measure all nine modes. Each mode is selected via the canonical
+    // AestraVerb::modeParam() so its measured evidence matches the mode it is
+    // labeled with. (Previously "hall" passed 0.5, which decodes to Chamber
+    // (mode 4), and "plate" passed 1.0, which decodes to SmoothPlate (mode 8) —
+    // so the published Hall/Plate measurements were mislabeled.)
+    struct ModeSetting {
+        AestraVerb::Mode mode;
+        const char* name;
+        float decay, size, diffusion;
+    };
+    static const ModeSetting kModeSettings[] = {
+        {AestraVerb::Mode::Room,        "room",         0.60f, 0.50f, 0.70f},
+        {AestraVerb::Mode::Hall,        "hall",         0.90f, 0.90f, 0.85f},
+        {AestraVerb::Mode::Plate,       "plate",        0.70f, 0.60f, 0.80f},
+        {AestraVerb::Mode::Cathedral,   "cathedral",    0.95f, 0.95f, 0.80f},
+        {AestraVerb::Mode::Chamber,     "chamber",      0.70f, 0.60f, 0.75f},
+        {AestraVerb::Mode::BrightHall,  "bright_hall",  0.88f, 0.85f, 0.85f},
+        {AestraVerb::Mode::Ambience,    "ambience",     0.40f, 0.40f, 0.60f},
+        {AestraVerb::Mode::Scoring,     "scoring",      0.90f, 0.85f, 0.85f},
+        {AestraVerb::Mode::SmoothPlate, "smooth_plate", 0.72f, 0.60f, 0.85f},
+    };
+    for (const auto& s : kModeSettings) {
+        modes.push_back(measureMode(s.name, AestraVerb::modeParam(s.mode),
+                                    s.decay, s.size, s.diffusion, sampleRate, numFrames, qualityDir));
+    }
 
     // Write JSON report
     {
@@ -906,12 +928,12 @@ int main() {
             f << "## Files\n\n";
             f << "- `reverb_quality_baseline.json` — Machine-readable quality metrics\n";
             f << "- `reverb_quality_baseline.md` — Human-readable quality report\n";
-            f << "- `impulse_room.wav` — Room mode impulse response\n";
-            f << "- `impulse_hall.wav` — Hall mode impulse response\n";
-            f << "- `impulse_plate.wav` — Plate mode impulse response\n";
-            f << "- `noiseburst_room.wav` — Room mode noise burst response\n";
-            f << "- `noiseburst_hall.wav` — Hall mode noise burst response\n";
-            f << "- `noiseburst_plate.wav` — Plate mode noise burst response\n";
+            for (const auto& q : modes) {
+                f << "- `impulse_" << q.name << ".wav` — " << q.name << " mode impulse response\n";
+            }
+            for (const auto& q : modes) {
+                f << "- `noiseburst_" << q.name << ".wav` — " << q.name << " mode noise burst response\n";
+            }
         }
     }
 

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -26,8 +26,13 @@ struct RenderStats {
     bool finite = true;
 };
 
+// mode: 0 = Room, 1 = Hall, 2 = Plate. Select via the canonical modeParam() so
+// these actually land on Room/Hall/Plate; the old 0.0/0.5/1.0 constants decoded
+// to Room/Chamber/SmoothPlate.
 void setMode(AestraVerb& verb, int mode) {
-    verb.setParameter(AestraVerb::kMode, mode == 0 ? 0.0f : (mode == 1 ? 0.5f : 1.0f));
+    const AestraVerb::Mode m =
+        mode == 0 ? AestraVerb::Mode::Room : (mode == 1 ? AestraVerb::Mode::Hall : AestraVerb::Mode::Plate);
+    verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(m));
 }
 
 void setUsableDefaults(AestraVerb& verb, int mode) {
@@ -258,6 +263,31 @@ bool runActiveLoadStateSafetyCheck() {
     return ok;
 }
 
+// Every one of the nine modes, selected via the canonical modeParam(), must
+// render finite, bounded audio. Guards against a mode index that aliases or
+// clamps to a neighbor and against any single mode blowing up.
+bool runAllNineModesFiniteChecks() {
+    bool ok = true;
+    std::vector<float> input = makeBrightTransient(48000, 4000.0f);
+    for (int mode = 0; mode < AestraVerb::kModeCount; ++mode) {
+        AestraVerb verb;
+        verb.initialize(kSampleRate, 256);
+        verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+        verb.setParameter(AestraVerb::kDecay, 0.7f);
+        verb.setParameter(AestraVerb::kSize, 0.6f);
+        verb.setParameter(AestraVerb::kDiffusion, 0.7f);
+        verb.setParameter(AestraVerb::kModRate, 0.42f);
+        verb.setParameter(AestraVerb::kModDepth, 0.2f);
+        verb.setParameter(AestraVerb::kMix, 1.0f);
+        verb.setParameter(AestraVerb::kWidth, 0.7f);
+        verb.activate();
+        auto stats = render(verb, input, 128);
+        ok &= require(stats.finite, "nine-mode sweep produced NaN/Inf");
+        ok &= require(stats.peak < 8.0f, "nine-mode sweep exceeded sane bounds");
+    }
+    return ok;
+}
+
 } // namespace
 
 int main() {
@@ -267,6 +297,7 @@ int main() {
     ok &= runModeSwitchAndDeterminismChecks();
     ok &= runHighFrequencyBuildupChecks();
     ok &= runActiveLoadStateSafetyCheck();
+    ok &= runAllNineModesFiniteChecks();
 
     if (!ok) {
         return 1;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -597,6 +597,22 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbSafetyRegressionTest.cp
     set_tests_properties(ReverbSafetyRegressionTest PROPERTIES LABELS "audio;dsp;reverb;safety")
 endif()
 
+# Reverb Consistency Probe — hunts for inconsistency/offness (bypass parity,
+# NaN rejection, silence tail, state roundtrip are hard invariants; Low Cut
+# mapping, freeze stability, sample-rate consistency, mode-switch clicks, and
+# stereo correlation are printed diagnostics).
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbConsistencyProbe.cpp")
+    add_executable(ReverbConsistencyProbe AestraAudio/ReverbConsistencyProbe.cpp)
+    target_link_libraries(ReverbConsistencyProbe PRIVATE AestraAudio)
+    target_include_directories(ReverbConsistencyProbe PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ReverbConsistencyProbe COMMAND ReverbConsistencyProbe)
+    set_tests_properties(ReverbConsistencyProbe PROPERTIES LABELS "audio;dsp;reverb;probe")
+endif()
+
 # Reverb Quality Measurement Lab
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbQualityLab.cpp")
     add_executable(AestraReverbQualityLab AestraAudio/ReverbQualityLab.cpp)


### PR DESCRIPTION
## Summary
Stacked on #482 (needs `AestraVerb::modeParam`). Adds `ReverbConsistencyProbe` — a hunt for inconsistency/offness beyond the existing safety checks. **Test-only.**

## What it checks
Hard invariants (fail the test):
- Bypass is a bit-exact dry passthrough
- NaN/Inf input → only finite output
- Output decays to silence (−91 dB tail; no self-oscillation/denormal buzz)
- `saveState`/`loadState` reproduces bit-identical output

Diagnostics (printed; assertions arrive with the fixes in the follow-up PR):
- Low Cut displayed-vs-DSP cutoff and measured attenuation
- Freeze tail stability over 8 s
- T60 across 44.1k/48k/96k
- Mode-switch discontinuity (Hall→Plate seam)
- Early/late stereo correlation + mono-in L/R balance

## What it found (measured on develop + #482)
- **Low Cut**: knob@0.5 displays 200 Hz, DSP uses 632 Hz; top third of knob is a clamped dead zone; response is not a clean HP shape.
- **Freeze**: tail decayed ~22 dB over 6 s instead of sustaining.
- **T60**: ~25% longer at 96k than 48k at identical params.
- **Mode switch**: no click detected (seam delta 0.5× of steady tail).
- **Early stereo corr 0.54** for a true Hall — the prior "1.000" evidence was measured on mislabeled modes.

## Testing
Probe passes (hard invariants); registered in ctest with labels `audio;dsp;reverb;probe`.

## Docs updated?
No.

## Risk / rollback
None — test-only. Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)