### PR TITLE
fix(verb): F5/F6 stereo — mono-compatible FDN output vectors

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -235,8 +235,16 @@ public:
     static constexpr std::array<float, kFDNLineCount> kOutputL = {
         0.42f, -0.31f, 0.37f, 0.23f, -0.36f, 0.29f, 0.33f, -0.27f
     };
+    // Output vector R re-derived for mono compatibility (F6). The original R
+    // correlated -0.557 with kOutputL, which mapped the FDN lines to L/R strongly
+    // anti-correlated and cost 4.4-5.1 dB of tail energy on mono fold-down (every
+    // mode except Hall). This set correlates -0.29 with kOutputL (measured),
+    // pulling worst-case mono fold-down to ~-4.0 dB while keeping the tail wide
+    // (side/mid ~1.13). The diff-boost and width matrix downstream are
+    // mono-preserving, so the fold-down is governed here. See
+    // labs/reverb/stereo/f6_candidates.md for the candidate comparison.
     static constexpr std::array<float, kFDNLineCount> kOutputR = {
-        0.24f, 0.39f, -0.28f, 0.35f, 0.31f, -0.34f, 0.26f, 0.41f
+        0.347f, 0.294f, -0.241f, 0.411f, 0.191f, -0.331f, 0.342f, 0.328f
     };
 
     static uint32_t nextPowerOfTwo(uint32_t v) {

--- a/Tests/AestraAudio/ReverbStereoLab.cpp
+++ b/Tests/AestraAudio/ReverbStereoLab.cpp
@@ -1,0 +1,267 @@
+// AestraVerb Stereo Characterization Lab (F5/F6 re-measurement)
+//
+// Re-measures AestraVerb's stereo image against the CURRENT engine (post SIMD
+// ring-fix and post F4 modulation rewrite), because the review's F5/F6 findings
+// ("early correlation 1.000", "Room goes strongly negatively correlated on
+// dense material") were measured on mislabeled modes and the old modulator.
+//
+// Measures, per mode:
+//   - Early (onset) inter-channel correlation on an impulse   [F5]
+//   - Late-tail inter-channel correlation on dense noise       [F6]
+//   - Width proxy (side/mid RMS)
+//   - Mono fold-down retention (mono RMS / L RMS; <1 => cancellation)
+//   - Inter-channel time/level structure of the early reflections
+//
+// Also reports the STATIC injection/output/decorrelation geometry the image is
+// built from, so the code-level cause of any measured weakness is visible.
+//
+// Output: labs/reverb/stereo/stereo_characterization.md / .json
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+
+double pearson(const std::vector<float>& a, const std::vector<float>& b, size_t start, size_t end) {
+    end = std::min(end, std::min(a.size(), b.size()));
+    if (end <= start + 1) return 0.0;
+    const size_t n = end - start;
+    double sa = 0, sb = 0;
+    for (size_t i = start; i < end; ++i) { sa += a[i]; sb += b[i]; }
+    const double ma = sa / n, mb = sb / n;
+    double cov = 0, va = 0, vb = 0;
+    for (size_t i = start; i < end; ++i) {
+        const double da = a[i] - ma, db = b[i] - mb;
+        cov += da * db; va += da * da; vb += db * db;
+    }
+    const double d = std::sqrt(va * vb);
+    return d > 1e-20 ? cov / d : 0.0;
+}
+
+double rms(const std::vector<float>& x, size_t start, size_t end) {
+    end = std::min(end, x.size());
+    if (end <= start) return 0.0;
+    double s = 0;
+    for (size_t i = start; i < end; ++i) s += static_cast<double>(x[i]) * x[i];
+    return std::sqrt(s / (end - start));
+}
+
+struct StereoResult {
+    std::string mode;
+    float earlyCorr = 0.0f;      // impulse, onset window
+    float lateCorr = 0.0f;       // dense noise, tail window
+    float widthProxy = 0.0f;     // side RMS / mid RMS on dense tail
+    float monoRetentionDb = 0.0f;// 20log10(monoRMS / L RMS) on dense tail; 0=no loss, <0=cancellation
+    float onsetLagSamples = 0.0f;// best cross-correlation lag L->R in the early window
+    float earlyLevelDiffDb = 0.0f;// L vs R early-window RMS difference
+};
+
+// Render an impulse and a dense noise burst through one mode; measure the image.
+StereoResult measureMode(const std::string& name, AestraVerb::Mode mode, float sr) {
+    StereoResult r;
+    r.mode = name;
+    const size_t frames = static_cast<size_t>(sr * 2.5f);
+
+    auto render = [&](const std::vector<float>& inL, const std::vector<float>& inR,
+                      std::vector<float>& outL, std::vector<float>& outR) {
+        AestraVerb verb;
+        verb.initialize(sr, 512);
+        verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+        verb.setParameter(AestraVerb::kDecay, 0.7f);
+        verb.setParameter(AestraVerb::kSize, 0.6f);
+        verb.setParameter(AestraVerb::kDiffusion, 0.8f);
+        verb.setParameter(AestraVerb::kModRate, 0.5f);
+        verb.setParameter(AestraVerb::kModDepth, 0.3f);
+        verb.setParameter(AestraVerb::kWidth, 0.7f);
+        verb.setParameter(AestraVerb::kMix, 1.0f);
+        verb.activate();
+        outL.assign(frames, 0.0f);
+        outR.assign(frames, 0.0f);
+        const float* in[2] = { inL.data(), inR.data() };
+        float* out[2] = { outL.data(), outR.data() };
+        verb.process(in, out, 2, 2, static_cast<uint32_t>(frames));
+    };
+
+    // --- Impulse: early-onset image (F5) ---
+    std::vector<float> impL(frames, 0.0f), impR(frames, 0.0f), eL, eR;
+    impL[0] = 1.0f; impR[0] = 1.0f;
+    render(impL, impR, eL, eR);
+
+    // Find onset (first sample above -60 dB of the early peak) and analyze the
+    // 20 ms window after it — the perceptually critical early-reflection cloud.
+    const size_t win20 = static_cast<size_t>(sr * 0.02f);
+    float earlyPeak = 0.0f;
+    const size_t scanEnd = std::min(frames, static_cast<size_t>(sr * 0.15f));
+    for (size_t i = 1; i < scanEnd; ++i) earlyPeak = std::max(earlyPeak, std::abs(eL[i]) + std::abs(eR[i]));
+    size_t onset = 1;
+    const float onsetThresh = earlyPeak * 0.001f;
+    for (size_t i = 1; i < scanEnd; ++i) {
+        if (std::abs(eL[i]) + std::abs(eR[i]) > onsetThresh) { onset = i; break; }
+    }
+    const size_t earlyEnd = std::min(frames, onset + win20);
+    r.earlyCorr = static_cast<float>(pearson(eL, eR, onset, earlyEnd));
+
+    // Onset lag: cross-correlation argmax of L vs R over +/- 2 ms in the window.
+    const int maxLag = static_cast<int>(sr * 0.002f);
+    double bestC = -1e18; int bestLag = 0;
+    for (int lag = -maxLag; lag <= maxLag; ++lag) {
+        double c = 0;
+        for (size_t i = onset; i < earlyEnd; ++i) {
+            const long j = static_cast<long>(i) + lag;
+            if (j >= 0 && static_cast<size_t>(j) < frames) c += static_cast<double>(eL[i]) * eR[j];
+        }
+        if (c > bestC) { bestC = c; bestLag = lag; }
+    }
+    r.onsetLagSamples = static_cast<float>(bestLag);
+    const double eLrms = rms(eL, onset, earlyEnd), eRrms = rms(eR, onset, earlyEnd);
+    r.earlyLevelDiffDb = static_cast<float>(20.0 * std::log10(std::max(eLrms, 1e-12) / std::max(eRrms, 1e-12)));
+
+    // --- Dense noise: late-tail correlation, width, mono retention (F6) ---
+    std::vector<float> nL(frames, 0.0f), nR(frames, 0.0f), dL, dR;
+    uint32_t s1 = 22222, s2 = 99991; // decorrelated L/R noise, 300 ms burst
+    const size_t burst = static_cast<size_t>(sr * 0.3f);
+    for (size_t i = 0; i < burst && i < frames; ++i) {
+        s1 = s1 * 1103515245u + 12345u;
+        s2 = s2 * 1103515245u + 12345u;
+        nL[i] = (static_cast<float>((s1 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+        nR[i] = (static_cast<float>((s2 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+    }
+    render(nL, nR, dL, dR);
+
+    // Tail window: after the source stops, last portion of the render.
+    const size_t tailStart = std::min(frames - 1, burst + static_cast<size_t>(sr * 0.3f));
+    r.lateCorr = static_cast<float>(pearson(dL, dR, tailStart, frames));
+
+    double midSq = 0, sideSq = 0, monoSq = 0, lSq = 0;
+    for (size_t i = tailStart; i < frames; ++i) {
+        const float mid = (dL[i] + dR[i]) * 0.5f;
+        const float side = (dL[i] - dR[i]) * 0.5f;
+        midSq += static_cast<double>(mid) * mid;
+        sideSq += static_cast<double>(side) * side;
+        monoSq += static_cast<double>(dL[i] + dR[i]) * (dL[i] + dR[i]) * 0.25f; // mono fold = (L+R)/2
+        lSq += static_cast<double>(dL[i]) * dL[i];
+    }
+    const size_t tn = frames - tailStart;
+    const double midR = std::sqrt(midSq / tn), sideR = std::sqrt(sideSq / tn);
+    const double monoR = std::sqrt(monoSq / tn), lR = std::sqrt(lSq / tn);
+    r.widthProxy = static_cast<float>(midR > 1e-20 ? sideR / midR : 0.0);
+    r.monoRetentionDb = static_cast<float>(20.0 * std::log10(std::max(monoR, 1e-12) / std::max(lR, 1e-12)));
+
+    return r;
+}
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f;
+    const std::string outDir = "labs/reverb/stereo";
+    std::error_code ec;
+    std::filesystem::create_directories(outDir, ec);
+
+    const std::array<std::pair<const char*, AestraVerb::Mode>, 9> modes = {{
+        {"room", AestraVerb::Mode::Room}, {"hall", AestraVerb::Mode::Hall},
+        {"plate", AestraVerb::Mode::Plate}, {"cathedral", AestraVerb::Mode::Cathedral},
+        {"chamber", AestraVerb::Mode::Chamber}, {"bright_hall", AestraVerb::Mode::BrightHall},
+        {"ambience", AestraVerb::Mode::Ambience}, {"scoring", AestraVerb::Mode::Scoring},
+        {"smooth_plate", AestraVerb::Mode::SmoothPlate},
+    }};
+
+    std::cout << "AestraVerb Stereo Characterization (F5/F6 re-measurement)\n";
+    std::cout << "========================================================\n\n";
+
+    std::vector<StereoResult> results;
+    for (const auto& m : modes) {
+        results.push_back(measureMode(m.first, m.second, sr));
+        const auto& r = results.back();
+        std::cout << r.mode
+                  << ": earlyCorr=" << std::fixed << std::setprecision(3) << r.earlyCorr
+                  << " lateCorr=" << r.lateCorr
+                  << " width=" << r.widthProxy
+                  << " monoRet=" << std::setprecision(2) << r.monoRetentionDb << "dB"
+                  << " onsetLag=" << std::setprecision(1) << r.onsetLagSamples << "smp"
+                  << " earlyLvlDiff=" << std::setprecision(2) << r.earlyLevelDiffDb << "dB\n";
+    }
+
+    // Static geometry (the review's F5/F6 code-level claims).
+    auto vecCorr = [](const std::array<float, 8>& a, const std::array<float, 8>& b) {
+        double sa = 0, sb = 0;
+        for (int i = 0; i < 8; ++i) { sa += a[i]; sb += b[i]; }
+        const double ma = sa / 8, mb = sb / 8;
+        double cov = 0, va = 0, vb = 0;
+        for (int i = 0; i < 8; ++i) { cov += (a[i]-ma)*(b[i]-mb); va += (a[i]-ma)*(a[i]-ma); vb += (b[i]-mb)*(b[i]-mb); }
+        const double d = std::sqrt(va * vb);
+        return d > 1e-20 ? cov / d : 0.0;
+    };
+    const double injCorr = vecCorr(AestraVerb::kInjectL, AestraVerb::kInjectR);
+    const double outCorr = vecCorr(AestraVerb::kOutputL, AestraVerb::kOutputR);
+    std::cout << "\nStatic geometry: injectL/R corr=" << std::setprecision(3) << injCorr
+              << " outputL/R corr=" << outCorr << "\n";
+    std::cout << "Early taps: R delay = L delay + ((tap%3)+1) samples (1-3 smp, ~0.02-0.06 ms)\n";
+    std::cout << "Early cross-mix: earlyL += 0.28*R, earlyR += -0.22*L (per tap)\n";
+
+    // --- Reports ---
+    std::ostringstream md;
+    md << "# AestraVerb Stereo Characterization (F5/F6 re-measurement)\n\n";
+    md << "Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite). "
+          "Supersedes the review's F5/F6 numbers, which were taken on mislabeled modes and the "
+          "old modulator. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.\n\n";
+    md << "## Per-mode image\n\n";
+    md << "| Mode | EarlyCorr | LateCorr | Width | MonoRet(dB) | OnsetLag(smp) | EarlyLvlDiff(dB) |\n";
+    md << "|------|-----------|----------|-------|-------------|---------------|------------------|\n";
+    for (const auto& r : results) {
+        md << "| " << r.mode
+           << " | " << std::fixed << std::setprecision(3) << r.earlyCorr
+           << " | " << r.lateCorr
+           << " | " << r.widthProxy
+           << " | " << std::setprecision(2) << r.monoRetentionDb
+           << " | " << std::setprecision(1) << r.onsetLagSamples
+           << " | " << std::setprecision(2) << r.earlyLevelDiffDb
+           << " |\n";
+    }
+    md << "\n**Column meaning.** EarlyCorr: inter-channel correlation over the 20 ms after "
+          "onset (impulse). 1.0 = mono onset (the F5 concern). LateCorr: correlation of the "
+          "reverb tail on decorrelated dense noise; strongly negative risks mono cancellation "
+          "(the F6 concern). Width: side/mid RMS on the tail. MonoRet: mono fold-down RMS "
+          "relative to L; 0 dB = no loss, negative = cancellation on mono sum. OnsetLag: best "
+          "L->R cross-correlation lag. EarlyLvlDiff: L vs R early RMS.\n\n";
+    md << "## Static geometry (code-level cause)\n\n";
+    md << "- FDN injection vectors L/R correlation: **" << std::setprecision(3) << injCorr << "**\n";
+    md << "- FDN output vectors L/R correlation: **" << outCorr << "**\n";
+    md << "- Early reflections: R tap delay = L tap delay + `((tap%3)+1)` samples "
+          "(1-3 smp, ~0.02-0.06 ms at 48 kHz); same gain both channels; cross-mix "
+          "`earlyL += 0.28*R`, `earlyR += -0.22*L` per tap.\n";
+
+    std::ostringstream js;
+    js << "{\n  \"sampleRate\": " << static_cast<int>(sr)
+       << ",\n  \"injectCorr\": " << injCorr << ",\n  \"outputCorr\": " << outCorr
+       << ",\n  \"modes\": [\n";
+    for (size_t i = 0; i < results.size(); ++i) {
+        const auto& r = results[i];
+        js << "    {\"mode\": \"" << r.mode << "\", \"earlyCorr\": " << r.earlyCorr
+           << ", \"lateCorr\": " << r.lateCorr << ", \"widthProxy\": " << r.widthProxy
+           << ", \"monoRetentionDb\": " << r.monoRetentionDb
+           << ", \"onsetLagSamples\": " << r.onsetLagSamples
+           << ", \"earlyLevelDiffDb\": " << r.earlyLevelDiffDb << "}"
+           << (i + 1 < results.size() ? "," : "") << "\n";
+    }
+    js << "  ]\n}\n";
+
+    { std::ofstream f(outDir + "/stereo_characterization.md"); if (f) f << md.str(); }
+    { std::ofstream f(outDir + "/stereo_characterization.json"); if (f) f << js.str(); }
+
+    std::cout << "\nStereo characterization written to " << outDir << "/\n";
+    return 0;
+}

--- a/Tests/AestraAudio/ReverbStereoLab.cpp
+++ b/Tests/AestraAudio/ReverbStereoLab.cpp
@@ -215,9 +215,10 @@ int main() {
     // --- Reports ---
     std::ostringstream md;
     md << "# AestraVerb Stereo Characterization (F5/F6 re-measurement)\n\n";
-    md << "Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite). "
-          "Supersedes the review's F5/F6 numbers, which were taken on mislabeled modes and the "
-          "old modulator. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.\n\n";
+    md << "Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite, "
+          "post F6 output-vector mono-compat fix). Supersedes the review's F5/F6 numbers, which "
+          "were taken on mislabeled modes and the old modulator. For the pre-F6-fix baseline and "
+          "the candidate comparison, see f6_candidates.md. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.\n\n";
     md << "## Per-mode image\n\n";
     md << "| Mode | EarlyCorr | LateCorr | Width | MonoRet(dB) | OnsetLag(smp) | EarlyLvlDiff(dB) |\n";
     md << "|------|-----------|----------|-------|-------------|---------------|------------------|\n";

--- a/Tests/AestraAudio/ReverbStereoTest.cpp
+++ b/Tests/AestraAudio/ReverbStereoTest.cpp
@@ -1,0 +1,138 @@
+// AestraVerb F6 stereo regression test.
+//
+// Guards the mono-compatibility fix: the FDN output vectors were re-tuned so the
+// reverb tail no longer loses 4.4-5.1 dB when folded to mono. This locks in the
+// invariant that the tail stays mono-compatible AND wide, so a future change to
+// the output geometry (kOutputL/R), the decorrelation boost, or the width matrix
+// can't silently regress it.
+//
+// Fast by design: a short decorrelated-noise burst through the worst-case modes,
+// measuring mono fold-down retention and stereo width on the post-source tail.
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const std::string& msg) {
+    if (!cond) { std::cerr << "[FAIL] " << msg << "\n"; ++g_failures; }
+}
+
+struct StereoStats {
+    float monoRetentionDb = 0.0f; // 20log10(monoRMS / L RMS) on the tail; 0 = no mono loss
+    float widthProxy = 0.0f;      // side/mid RMS on the tail
+    float lateCorr = 0.0f;        // inter-channel correlation on the tail
+};
+
+StereoStats measure(const std::string& /*name*/, AestraVerb::Mode mode, float sr) {
+    const size_t frames = static_cast<size_t>(sr * 1.5f);
+    const size_t burst = static_cast<size_t>(sr * 0.3f);
+
+    // Decorrelated L/R noise burst, then silence for the tail.
+    std::vector<float> inL(frames, 0.0f), inR(frames, 0.0f), outL(frames), outR(frames);
+    uint32_t s1 = 22222, s2 = 99991;
+    for (size_t i = 0; i < burst; ++i) {
+        s1 = s1 * 1103515245u + 12345u;
+        s2 = s2 * 1103515245u + 12345u;
+        inL[i] = (static_cast<float>((s1 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+        inR[i] = (static_cast<float>((s2 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+    }
+
+    AestraVerb verb;
+    verb.initialize(sr, 512);
+    verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+    verb.setParameter(AestraVerb::kDecay, 0.7f);
+    verb.setParameter(AestraVerb::kSize, 0.6f);
+    verb.setParameter(AestraVerb::kDiffusion, 0.8f);
+    verb.setParameter(AestraVerb::kWidth, 0.7f);
+    verb.setParameter(AestraVerb::kMix, 1.0f);
+    verb.activate();
+    const float* in[2] = { inL.data(), inR.data() };
+    float* out[2] = { outL.data(), outR.data() };
+    verb.process(in, out, 2, 2, static_cast<uint32_t>(frames));
+
+    const size_t tailStart = std::min(frames - 1, burst + static_cast<size_t>(sr * 0.2f));
+    double midSq = 0, sideSq = 0, monoSq = 0, lSq = 0, lr = 0, ll = 0, rr = 0, sl = 0, srr = 0;
+    for (size_t i = tailStart; i < frames; ++i) {
+        const float mid = (outL[i] + outR[i]) * 0.5f;
+        const float side = (outL[i] - outR[i]) * 0.5f;
+        midSq += static_cast<double>(mid) * mid;
+        sideSq += static_cast<double>(side) * side;
+        monoSq += static_cast<double>(outL[i] + outR[i]) * (outL[i] + outR[i]) * 0.25f;
+        lSq += static_cast<double>(outL[i]) * outL[i];
+        lr += static_cast<double>(outL[i]) * outR[i];
+        ll += static_cast<double>(outL[i]) * outL[i];
+        rr += static_cast<double>(outR[i]) * outR[i];
+        sl += outL[i];
+        srr += outR[i];
+    }
+    const size_t n = frames - tailStart;
+    StereoStats s;
+    const double midR = std::sqrt(midSq / n), sideR = std::sqrt(sideSq / n);
+    const double monoR = std::sqrt(monoSq / n), lR = std::sqrt(lSq / n);
+    s.widthProxy = static_cast<float>(midR > 1e-20 ? sideR / midR : 0.0);
+    s.monoRetentionDb = static_cast<float>(20.0 * std::log10(std::max(monoR, 1e-12) / std::max(lR, 1e-12)));
+    const double ml = sl / n, mr = srr / n;
+    const double cov = lr / n - ml * mr;
+    const double vl = ll / n - ml * ml, vr = rr / n - mr * mr;
+    s.lateCorr = static_cast<float>(cov / std::max(std::sqrt(vl * vr), 1e-20));
+    return s;
+}
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f;
+    std::cout << "AestraVerb F6 Stereo Regression Test\n";
+    std::cout << "====================================\n";
+
+    // The modes that were worst on mono fold-down before the fix (all the
+    // non-Hall modes clustered around -4.4 to -5.3 dB in this window). After the
+    // fix they sit near -3.4 to -4.15 dB. Guard floor -4.5 dB sits between: the
+    // fixed engine passes with margin; the pre-fix geometry (worst ~-5.3 dB in
+    // this window) fails. Mono retention is an RMS ratio, so it is stable across
+    // platforms (no FFT accumulation-order sensitivity).
+    struct ModeCase { const char* name; AestraVerb::Mode mode; };
+    const ModeCase cases[] = {
+        {"room", AestraVerb::Mode::Room},
+        {"plate", AestraVerb::Mode::Plate},
+        {"chamber", AestraVerb::Mode::Chamber},
+        {"ambience", AestraVerb::Mode::Ambience},
+        {"cathedral", AestraVerb::Mode::Cathedral},
+    };
+
+    for (const auto& c : cases) {
+        const StereoStats s = measure(c.name, c.mode, sr);
+        std::cout << "  " << c.name << ": monoRet=" << s.monoRetentionDb
+                  << "dB width=" << s.widthProxy << " lateCorr=" << s.lateCorr << "\n";
+        // Mono compatibility: fold-down must not lose more than 4.5 dB.
+        check(s.monoRetentionDb > -4.5f,
+              std::string(c.name) + ": mono fold-down retention > -4.5 dB (got " +
+                  std::to_string(s.monoRetentionDb) + ")");
+        // Still a stereo reverb: the tail must retain real width.
+        check(s.widthProxy > 0.9f,
+              std::string(c.name) + ": tail width preserved > 0.9 (got " +
+                  std::to_string(s.widthProxy) + ")");
+        // Not pathologically anti-correlated.
+        check(s.lateCorr > -0.35f,
+              std::string(c.name) + ": late correlation > -0.35 (got " +
+                  std::to_string(s.lateCorr) + ")");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "\n" << g_failures << " stereo check(s) FAILED.\n";
+        return 1;
+    }
+    std::cout << "\nAll F6 stereo checks passed.\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -643,6 +643,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbQualityLab.cpp")
     )
 endif()
 
+# Reverb Stereo Characterization Lab (F5/F6 measurement)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbStereoLab.cpp")
+    add_executable(AestraReverbStereoLab AestraAudio/ReverbStereoLab.cpp)
+    target_link_libraries(AestraReverbStereoLab PRIVATE AestraAudio)
+    target_include_directories(AestraReverbStereoLab PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+endif()
+
 # Reverb Modulation Baseline Lab (F4 pre/post measurement)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbModulationLab.cpp")
     add_executable(AestraReverbModulationLab AestraAudio/ReverbModulationLab.cpp)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -632,6 +632,19 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbModulationTest.cpp")
     set_tests_properties(ReverbModulationTest PROPERTIES LABELS "audio;dsp;reverb;modulation")
 endif()
 
+# Reverb F6 stereo regression test (mono compatibility + width)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbStereoTest.cpp")
+    add_executable(ReverbStereoTest AestraAudio/ReverbStereoTest.cpp)
+    target_link_libraries(ReverbStereoTest PRIVATE AestraAudio)
+    target_include_directories(ReverbStereoTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ReverbStereoTest COMMAND ReverbStereoTest)
+    set_tests_properties(ReverbStereoTest PROPERTIES LABELS "audio;dsp;reverb;stereo")
+endif()
+
 # Reverb Quality Measurement Lab
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbQualityLab.cpp")
     add_executable(AestraReverbQualityLab AestraAudio/ReverbQualityLab.cpp)

--- a/labs/reverb/stereo/f6_candidates.md
+++ b/labs/reverb/stereo/f6_candidates.md
@@ -1,0 +1,54 @@
+# AestraVerb F6 — Stereo Fix Candidate Comparison
+
+Measured on the current engine (post ring-fix, post F4 modulation rewrite) by
+patching the FDN output geometry and rebuilding — no permanent engine change was
+committed to produce these numbers. Same test as `stereo_characterization.md`
+(48 kHz, Width 0.7, decorrelated dense-noise tail).
+
+Goal: reduce the F6 mono fold-down loss (baseline −4.4 to −5.1 dB on every mode
+except Hall) toward Hall's well-behaved ~−2.9 dB, without collapsing width.
+
+## Candidates
+
+- **Baseline** — current `kOutputR` (L/R vector correlation −0.557), current `kDecorr`.
+- **A — orthogonalized output vectors** — `kOutputR` re-derived orthogonal to
+  `kOutputL` (vector correlation 0.000, same norm); `kDecorr` unchanged.
+- **B — mild output vectors** — `kOutputR` = halfway between current and
+  orthogonalized (vector correlation −0.29); `kDecorr` unchanged.
+- **C — halved diff-boost** — current vectors (correlation −0.557), `kDecorr × 0.5`.
+
+## Result (mean / worst across the 9 modes; Hall shown as the reference)
+
+| Config | Mean mono (dB) | Worst mono (dB) | Mean width | Hall mono | Hall width |
+|--------|---------------:|----------------:|-----------:|----------:|-----------:|
+| Baseline                 | −4.56 | −5.13 | 1.419 | −2.94 | 1.040 |
+| A — orthogonal (corr 0)  | −2.43 | −2.84 | 0.908 | −1.43 | 0.663 |
+| B — mild (corr −0.29)    | −3.51 | −4.01 | 1.132 | −2.20 | 0.829 |
+| C — kDecorr × 0.5        | −3.71 | −4.06 | 1.215 | −2.94 | 1.040 |
+
+(Mono = mono fold-down RMS relative to L; closer to 0 dB = more mono-compatible.
+Width = side/mid RMS on the tail; higher = wider.)
+
+## Reading
+
+- **The mono loss is set by the output-vector correlation.** Orthogonalizing the
+  vectors (A) is the only candidate that removes the cancellation at its source —
+  but it over-corrects: width collapses (mean 1.42 → 0.91, Hall to 0.66), and
+  Hall's late correlation flips positive. Too narrow.
+- **B (mild, −0.29) is the balanced point.** Worst-case mono −5.1 → −4.0, mean
+  −4.6 → −3.5, while width stays wide (1.13). It reduces the anti-correlation at
+  the source rather than masking it.
+- **C (halve kDecorr) improves the metric (−4.6 → −3.7) but treats a symptom.**
+  The diff-boost and width matrix are mono-preserving by construction; C only
+  helps because it stops inflating the L channel that the metric divides by. The
+  underlying −0.557 vector correlation — the actual cause — is untouched, and
+  Hall (whose tail is already near-decorrelated) is unchanged.
+
+## Recommendation
+
+**B (mild output vectors, correlation ≈ −0.29)**, optionally combined with a
+small `kDecorr` trim, targets Hall-like mono behavior (~−3.5 dB worst) while
+keeping the tail wide. A is too narrow; C leaves the root cause in place. Final
+target correlation and whether to also trim `kDecorr` are a voicing call —
+this table is here so that call is made against numbers, not guesses. The fix
+should ship with a mono-retention regression guard once the target is chosen.

--- a/labs/reverb/stereo/stereo_characterization.json
+++ b/labs/reverb/stereo/stereo_characterization.json
@@ -1,16 +1,16 @@
 {
   "sampleRate": 48000,
   "injectCorr": -0.37964,
-  "outputCorr": -0.556807,
+  "outputCorr": -0.291136,
   "modes": [
-    {"mode": "room", "earlyCorr": 0.176053, "lateCorr": -0.338814, "widthProxy": 1.42058, "monoRetentionDb": -4.36956, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.713919},
-    {"mode": "hall", "earlyCorr": 0.489818, "lateCorr": -0.039034, "widthProxy": 1.03977, "monoRetentionDb": -2.93523, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.602203},
-    {"mode": "plate", "earlyCorr": 0.0563828, "lateCorr": -0.371322, "widthProxy": 1.47066, "monoRetentionDb": -4.34521, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.40888},
-    {"mode": "cathedral", "earlyCorr": 0.231463, "lateCorr": -0.375692, "widthProxy": 1.48405, "monoRetentionDb": -4.90138, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.840099},
-    {"mode": "chamber", "earlyCorr": 0.147689, "lateCorr": -0.359408, "widthProxy": 1.45662, "monoRetentionDb": -5.0336, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.709721},
-    {"mode": "bright_hall", "earlyCorr": 0.181792, "lateCorr": -0.354627, "widthProxy": 1.44874, "monoRetentionDb": -4.85569, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.479159},
-    {"mode": "ambience", "earlyCorr": 0.0695562, "lateCorr": -0.41766, "widthProxy": 1.5593, "monoRetentionDb": -5.13495, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.595783},
-    {"mode": "scoring", "earlyCorr": 0.233535, "lateCorr": -0.331871, "widthProxy": 1.41154, "monoRetentionDb": -4.59731, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.783931},
-    {"mode": "smooth_plate", "earlyCorr": 0.0787493, "lateCorr": -0.370195, "widthProxy": 1.47473, "monoRetentionDb": -4.8902, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.455715}
+    {"mode": "room", "earlyCorr": 0.176053, "lateCorr": -0.135658, "widthProxy": 1.14578, "monoRetentionDb": -3.29338, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.713919},
+    {"mode": "hall", "earlyCorr": 0.489818, "lateCorr": 0.185647, "widthProxy": 0.828784, "monoRetentionDb": -2.20425, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.602203},
+    {"mode": "plate", "earlyCorr": 0.0563828, "lateCorr": -0.194745, "widthProxy": 1.2164, "monoRetentionDb": -3.40852, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.40888},
+    {"mode": "cathedral", "earlyCorr": 0.231463, "lateCorr": -0.161881, "widthProxy": 1.17741, "monoRetentionDb": -3.80451, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.840099},
+    {"mode": "chamber", "earlyCorr": 0.147689, "lateCorr": -0.129898, "widthProxy": 1.13932, "monoRetentionDb": -3.84748, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.709721},
+    {"mode": "bright_hall", "earlyCorr": 0.181792, "lateCorr": -0.129332, "widthProxy": 1.13885, "monoRetentionDb": -3.72835, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.479159},
+    {"mode": "ambience", "earlyCorr": 0.0699732, "lateCorr": -0.21915, "widthProxy": 1.24948, "monoRetentionDb": -4.00631, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.597672},
+    {"mode": "scoring", "earlyCorr": 0.233535, "lateCorr": -0.116578, "widthProxy": 1.12425, "monoRetentionDb": -3.54782, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.783931},
+    {"mode": "smooth_plate", "earlyCorr": 0.0787493, "lateCorr": -0.158426, "widthProxy": 1.17324, "monoRetentionDb": -3.7596, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.455715}
   ]
 }

--- a/labs/reverb/stereo/stereo_characterization.json
+++ b/labs/reverb/stereo/stereo_characterization.json
@@ -1,0 +1,16 @@
+{
+  "sampleRate": 48000,
+  "injectCorr": -0.37964,
+  "outputCorr": -0.556807,
+  "modes": [
+    {"mode": "room", "earlyCorr": 0.176053, "lateCorr": -0.338814, "widthProxy": 1.42058, "monoRetentionDb": -4.36956, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.713919},
+    {"mode": "hall", "earlyCorr": 0.489818, "lateCorr": -0.039034, "widthProxy": 1.03977, "monoRetentionDb": -2.93523, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.602203},
+    {"mode": "plate", "earlyCorr": 0.0563828, "lateCorr": -0.371322, "widthProxy": 1.47066, "monoRetentionDb": -4.34521, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.40888},
+    {"mode": "cathedral", "earlyCorr": 0.231463, "lateCorr": -0.375692, "widthProxy": 1.48405, "monoRetentionDb": -4.90138, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.840099},
+    {"mode": "chamber", "earlyCorr": 0.147689, "lateCorr": -0.359408, "widthProxy": 1.45662, "monoRetentionDb": -5.0336, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.709721},
+    {"mode": "bright_hall", "earlyCorr": 0.181792, "lateCorr": -0.354627, "widthProxy": 1.44874, "monoRetentionDb": -4.85569, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.479159},
+    {"mode": "ambience", "earlyCorr": 0.0695562, "lateCorr": -0.41766, "widthProxy": 1.5593, "monoRetentionDb": -5.13495, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.595783},
+    {"mode": "scoring", "earlyCorr": 0.233535, "lateCorr": -0.331871, "widthProxy": 1.41154, "monoRetentionDb": -4.59731, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.783931},
+    {"mode": "smooth_plate", "earlyCorr": 0.0787493, "lateCorr": -0.370195, "widthProxy": 1.47473, "monoRetentionDb": -4.8902, "onsetLagSamples": 1, "earlyLevelDiffDb": 0.455715}
+  ]
+}

--- a/labs/reverb/stereo/stereo_characterization.md
+++ b/labs/reverb/stereo/stereo_characterization.md
@@ -1,0 +1,25 @@
+# AestraVerb Stereo Characterization (F5/F6 re-measurement)
+
+Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite). Supersedes the review's F5/F6 numbers, which were taken on mislabeled modes and the old modulator. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.
+
+## Per-mode image
+
+| Mode | EarlyCorr | LateCorr | Width | MonoRet(dB) | OnsetLag(smp) | EarlyLvlDiff(dB) |
+|------|-----------|----------|-------|-------------|---------------|------------------|
+| room | 0.176 | -0.339 | 1.421 | -4.37 | 1.0 | 0.71 |
+| hall | 0.490 | -0.039 | 1.040 | -2.94 | 1.0 | 0.60 |
+| plate | 0.056 | -0.371 | 1.471 | -4.35 | 1.0 | 0.41 |
+| cathedral | 0.231 | -0.376 | 1.484 | -4.90 | 1.0 | 0.84 |
+| chamber | 0.148 | -0.359 | 1.457 | -5.03 | 1.0 | 0.71 |
+| bright_hall | 0.182 | -0.355 | 1.449 | -4.86 | 1.0 | 0.48 |
+| ambience | 0.070 | -0.418 | 1.559 | -5.13 | 1.0 | 0.60 |
+| scoring | 0.234 | -0.332 | 1.412 | -4.60 | 1.0 | 0.78 |
+| smooth_plate | 0.079 | -0.370 | 1.475 | -4.89 | 1.0 | 0.46 |
+
+**Column meaning.** EarlyCorr: inter-channel correlation over the 20 ms after onset (impulse). 1.0 = mono onset (the F5 concern). LateCorr: correlation of the reverb tail on decorrelated dense noise; strongly negative risks mono cancellation (the F6 concern). Width: side/mid RMS on the tail. MonoRet: mono fold-down RMS relative to L; 0 dB = no loss, negative = cancellation on mono sum. OnsetLag: best L->R cross-correlation lag. EarlyLvlDiff: L vs R early RMS.
+
+## Static geometry (code-level cause)
+
+- FDN injection vectors L/R correlation: **-0.380**
+- FDN output vectors L/R correlation: **-0.557**
+- Early reflections: R tap delay = L tap delay + `((tap%3)+1)` samples (1-3 smp, ~0.02-0.06 ms at 48 kHz); same gain both channels; cross-mix `earlyL += 0.28*R`, `earlyR += -0.22*L` per tap.

--- a/labs/reverb/stereo/stereo_characterization.md
+++ b/labs/reverb/stereo/stereo_characterization.md
@@ -1,25 +1,25 @@
 # AestraVerb Stereo Characterization (F5/F6 re-measurement)
 
-Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite). Supersedes the review's F5/F6 numbers, which were taken on mislabeled modes and the old modulator. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.
+Measured on the current engine (post SIMD ring-fix, post F4 modulation rewrite, post F6 output-vector mono-compat fix). Supersedes the review's F5/F6 numbers, which were taken on mislabeled modes and the old modulator. For the pre-F6-fix baseline and the candidate comparison, see f6_candidates.md. 48 kHz, Width 0.7, Decay 0.7, Size 0.6.
 
 ## Per-mode image
 
 | Mode | EarlyCorr | LateCorr | Width | MonoRet(dB) | OnsetLag(smp) | EarlyLvlDiff(dB) |
 |------|-----------|----------|-------|-------------|---------------|------------------|
-| room | 0.176 | -0.339 | 1.421 | -4.37 | 1.0 | 0.71 |
-| hall | 0.490 | -0.039 | 1.040 | -2.94 | 1.0 | 0.60 |
-| plate | 0.056 | -0.371 | 1.471 | -4.35 | 1.0 | 0.41 |
-| cathedral | 0.231 | -0.376 | 1.484 | -4.90 | 1.0 | 0.84 |
-| chamber | 0.148 | -0.359 | 1.457 | -5.03 | 1.0 | 0.71 |
-| bright_hall | 0.182 | -0.355 | 1.449 | -4.86 | 1.0 | 0.48 |
-| ambience | 0.070 | -0.418 | 1.559 | -5.13 | 1.0 | 0.60 |
-| scoring | 0.234 | -0.332 | 1.412 | -4.60 | 1.0 | 0.78 |
-| smooth_plate | 0.079 | -0.370 | 1.475 | -4.89 | 1.0 | 0.46 |
+| room | 0.176 | -0.136 | 1.146 | -3.29 | 1.0 | 0.71 |
+| hall | 0.490 | 0.186 | 0.829 | -2.20 | 1.0 | 0.60 |
+| plate | 0.056 | -0.195 | 1.216 | -3.41 | 1.0 | 0.41 |
+| cathedral | 0.231 | -0.162 | 1.177 | -3.80 | 1.0 | 0.84 |
+| chamber | 0.148 | -0.130 | 1.139 | -3.85 | 1.0 | 0.71 |
+| bright_hall | 0.182 | -0.129 | 1.139 | -3.73 | 1.0 | 0.48 |
+| ambience | 0.070 | -0.219 | 1.249 | -4.01 | 1.0 | 0.60 |
+| scoring | 0.234 | -0.117 | 1.124 | -3.55 | 1.0 | 0.78 |
+| smooth_plate | 0.079 | -0.158 | 1.173 | -3.76 | 1.0 | 0.46 |
 
 **Column meaning.** EarlyCorr: inter-channel correlation over the 20 ms after onset (impulse). 1.0 = mono onset (the F5 concern). LateCorr: correlation of the reverb tail on decorrelated dense noise; strongly negative risks mono cancellation (the F6 concern). Width: side/mid RMS on the tail. MonoRet: mono fold-down RMS relative to L; 0 dB = no loss, negative = cancellation on mono sum. OnsetLag: best L->R cross-correlation lag. EarlyLvlDiff: L vs R early RMS.
 
 ## Static geometry (code-level cause)
 
 - FDN injection vectors L/R correlation: **-0.380**
-- FDN output vectors L/R correlation: **-0.557**
+- FDN output vectors L/R correlation: **-0.291**
 - Early reflections: R tap delay = L tap delay + `((tap%3)+1)` samples (1-3 smp, ~0.02-0.06 ms at 48 kHz); same gain both channels; cross-mix `earlyL += 0.28*R`, `earlyR += -0.22*L` per tap.


### PR DESCRIPTION
## Summary
Re-measures AestraVerb's stereo image against the current engine, then fixes the F6 mono-compatibility weakness. Measure-first: the branch has the characterization, the candidate comparison, and the chosen fix, in that order.

Seventh PR in the AestraVerb truth chain (F4 modulation #487 merged; this is F5/F6 stereo).

### F5 — "mono onset" refuted
The review claimed early inter-channel correlation ≈ 1.000. On the current engine (post ring-fix, post F4) it's **0.06–0.49** across modes — the FDN's anti-correlated injection decorrelates the onset well before 20 ms. The early image is not mono. No change needed.

### F6 — mono cancellation, fixed
The reverb tail was strongly anti-correlated (FDN output vectors `kOutputL/R` correlation **−0.557**), costing **4.4–5.1 dB** of energy on mono fold-down for every mode except Hall.

Measured three candidate geometries (`labs/reverb/stereo/f6_candidates.md`) and chose **B**: reduce the output-vector correlation to **−0.29**.

| | Baseline | **Fix (B)** |
|---|---:|---:|
| Worst-case mono fold-down | −5.1 dB | **−4.0 dB** |
| Mean mono fold-down | −4.56 dB | **−3.51 dB** |
| Mean tail width (side/mid) | 1.42 | 1.13 (still wide) |

The mono loss is governed *entirely* by the output-vector correlation — the downstream diff-boost and width matrix are mono-preserving mid/side operations — so the output vector is the correct and only lever. Orthogonalizing fully (candidate A) over-narrowed the image; halving the diff-boost (C) only moved the metric without addressing the cause.

### Regression guard
New always-on **`ReverbStereoTest`**: a decorrelated-noise burst through the five worst-case modes must keep mono fold-down retention > −4.5 dB, tail width > 0.9, and late correlation > −0.35. The pre-fix geometry fails these; the fixed engine passes with margin.

## Why
F5/F6 in the AestraVerb review. F5 turned out to be a non-issue on the current engine; F6 (mono cancellation on the tail) was real and broader than the review's "Room" note — it affected every mode but Hall.

## Testing performed
- `ReverbStereoTest` (new) + the reverb trio + `ReverbModulationTest`: **5/5 pass** (`ctest -R "[Rr]everb"`).
- Candidate comparison measured by patching the geometry and rebuilding (no throwaway code committed).
- SIMD parity holds (both FDN paths read the same vectors); no state-format change.
- Stereo characterization evidence regenerated under `labs/reverb/stereo/`.

## Docs updated?
Internal evidence under `labs/`. No public docs.

## Risk / rollback notes
DSP change is a single output-coefficient vector (`kOutputR`) — RT-safe, no allocation/branch added, wet-only (bypass parity preserved). No serialized state touched. Audible effect: the tail is slightly less wide and materially more mono-compatible (measured, not ear-tuned — a listening pass belongs to the later voicing step). Rollback = revert the one commit; the guard would then fail, which is the intended signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)