### PR TITLE
feat(verb): F8 tail dormancy — idle reverb instances sleep the wet pipeline

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -357,6 +357,16 @@ public:
             const bool wantSleep = inputSilent && !freezeHeld && m_tailEnv < kDormantThreshold &&
                                    m_silentSamples > guardSamples;
             if (wantSleep && m_sleepFaded) {
+                // Keep the smoothed control state current while asleep. The wet
+                // pipeline is skipped, so its smoothing never runs; without this
+                // an automation move during dormancy (e.g. Mix, Decay, Size) would
+                // leave stale targets and the first wake block would ramp from the
+                // pre-sleep value. Snapping is inaudible here because the output is
+                // silent, and it makes the wake start from the latest automation.
+                for (uint32_t p = 0; p < kParamCount; ++p) {
+                    m_smoothedParams[p] = m_params[p].load(std::memory_order_relaxed);
+                }
+
                 // Fully dormant: emit only the dry path (silent input -> silence),
                 // skipping the entire wet pipeline. The FDN state is untouched and
                 // near zero, so the first non-silent block resumes seamlessly.

--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -186,6 +186,15 @@ public:
     };
     static constexpr float kTwoPi = 6.28318530718f;
     static constexpr uint32_t kControlInterval = 64;
+    // F8 tail dormancy thresholds. Input samples below kSilenceThreshold count as
+    // silence; when the wet tail's tracked peak falls below kDormantThreshold
+    // (-140 dBFS, below the 24-bit noise floor and inaudible) and the input is
+    // silent, the wet pipeline sleeps. The floor is set this low deliberately:
+    // it keeps dormancy transparent to the tail-decay and modulation-purity
+    // measurements (which analyze the tail down to very low levels), so the
+    // feature can never shorten a measured T60 or splatter into the tail.
+    static constexpr float kSilenceThreshold = 1.0e-6f;
+    static constexpr float kDormantThreshold = 1.0e-7f;
     static constexpr std::array<float, kFDNLineCount> kLfoBaseRates = {
         0.158f, 0.278f, 0.398f, 0.533f, 0.668f, 0.803f, 0.923f, 1.058f
     };
@@ -318,6 +327,54 @@ public:
             return;
         }
 
+        // F8 tail dormancy: when the whole input block is silent, the wet tail
+        // has already decayed below audibility, and freeze is not holding a tail,
+        // skip the entire wet pipeline for this block and emit only the dry path
+        // (the wet contribution would be inaudible anyway). The FDN state is left
+        // untouched — it is near zero, so processing resumes seamlessly on the
+        // first non-silent block. This makes idle reverb instances nearly free,
+        // which matters most when many are inserted on a low-core target.
+        bool fadeToSleep = false;
+        {
+            bool inputSilent = true;
+            for (uint32_t ch = 0; ch < numInputChannels && inputSilent; ++ch) {
+                if (!inputs[ch]) continue;
+                for (uint32_t i = 0; i < numFrames; ++i) {
+                    if (std::abs(inputs[ch][i]) > kSilenceThreshold) { inputSilent = false; break; }
+                }
+            }
+            if (inputSilent) {
+                m_silentSamples = (m_silentSamples > 0xFFFFFFFFu - numFrames) ? 0xFFFFFFFFu
+                                                                             : m_silentSamples + numFrames;
+            } else {
+                m_silentSamples = 0;
+            }
+
+            if (!inputSilent) m_sleepFaded = false;
+
+            const bool freezeHeld = m_params[kFreeze].load(std::memory_order_relaxed) > 0.5f;
+            const uint32_t guardSamples = static_cast<uint32_t>(0.75f * static_cast<float>(m_sampleRate));
+            const bool wantSleep = inputSilent && !freezeHeld && m_tailEnv < kDormantThreshold &&
+                                   m_silentSamples > guardSamples;
+            if (wantSleep && m_sleepFaded) {
+                // Fully dormant: emit only the dry path (silent input -> silence),
+                // skipping the entire wet pipeline. The FDN state is untouched and
+                // near zero, so the first non-silent block resumes seamlessly.
+                const float mix = std::clamp(m_params[kMix].load(std::memory_order_relaxed), 0.0f, 1.0f);
+                const float dryGain = std::cos(mix * (kTwoPi * 0.25f));
+                for (uint32_t i = 0; i < numFrames; ++i) {
+                    const float inL = (numInputChannels > 0 && inputs[0]) ? inputs[0][i] : 0.0f;
+                    const float inR = (numInputChannels > 1 && inputs[1]) ? inputs[1][i] : inL;
+                    if (numOutputChannels > 0 && outputs[0]) outputs[0][i] = inL * dryGain;
+                    if (numOutputChannels > 1 && outputs[1]) outputs[1][i] = inR * dryGain;
+                }
+                return;
+            }
+            // If sleep is wanted but not yet faded, process this block normally
+            // but ramp the wet to zero across it, then sleep next block.
+            fadeToSleep = wantSleep && !m_sleepFaded;
+        }
+
         const Mode mode = currentMode();
         const ModeConstants constants = constantsForMode(mode);
         const float sampleScale = static_cast<float>(m_sampleRate) / kReferenceSampleRate;
@@ -348,6 +405,9 @@ public:
         float chaoticPhaseA = m_chaoticPhaseA;
         float chaoticPhaseB = m_chaoticPhaseB;
         float chaoticPhaseC = m_chaoticPhaseC;
+
+        // F8: track the loudest wet sample this block to decide dormancy next block.
+        float blockWetPeak = 0.0f;
 
         predelayPos &= m_predelayMask;
         earlyPos &= m_earlyMask;
@@ -725,6 +785,18 @@ public:
             wetL = sanitize(wetL);
             wetR = sanitize(wetR);
 
+            // F8: on the transition-to-dormant block, ramp the wet linearly to
+            // zero across the block so the ~-100 dBFS residual reaches exactly
+            // zero with no step before the pipeline is skipped next block.
+            if (fadeToSleep) {
+                const float g = 1.0f - static_cast<float>(i) / static_cast<float>(numFrames);
+                wetL *= g;
+                wetR *= g;
+            }
+
+            // F8: the post-EQ, pre-mix wet is the tail's actual contribution.
+            blockWetPeak = std::max(blockWetPeak, std::max(std::abs(wetL), std::abs(wetR)));
+
             AESTRA_DIAG_WETPRE(wetL, wetR);
 
             const float sumL = dryL * control.dryGain + wetL * control.wetGain;
@@ -765,6 +837,10 @@ public:
         m_chaoticPhaseA = chaoticPhaseA;
         m_chaoticPhaseB = chaoticPhaseB;
         m_chaoticPhaseC = chaoticPhaseC;
+        // F8: remember this block's wet peak; the next block sleeps if this
+        // decayed below the dormant floor (and the input is silent).
+        m_tailEnv = blockWetPeak;
+        if (fadeToSleep) m_sleepFaded = true;
     }
 
     uint32_t getParameterCount() const override { return kParamCount; }
@@ -1454,6 +1530,11 @@ private:
         m_chaoticPhaseA = 0.0f;
         m_chaoticPhaseB = 0.0f;
         m_chaoticPhaseC = 0.0f;
+        // Start non-dormant: the first block always processes so a just-prepared
+        // instance can build a tail even if its opening samples are quiet.
+        m_tailEnv = 1.0f;
+        m_silentSamples = 0;
+        m_sleepFaded = false;
 
         if (randomizeLfos) {
             std::mt19937 rng{0xAE57A000u}; // deterministic seed for reproducible tests
@@ -1785,6 +1866,23 @@ private:
     float m_chaoticPhaseA = 0.0f;
     float m_chaoticPhaseB = 0.0f;
     float m_chaoticPhaseC = 0.0f;
+
+    // F8 tail dormancy: peak of the wet signal seen in the last processed block.
+    // When the input goes silent and this decays below the dormant floor, the
+    // whole wet pipeline (FDN, diffusers, early reflections, modulation, EQ) is
+    // skipped and only the dry path is emitted. Reset high on clearBuffers so a
+    // freshly prepared instance never starts falsely dormant.
+    float m_tailEnv = 1.0f;
+    // Consecutive silent-input samples. Dormancy is only allowed once this
+    // exceeds the guard (max predelay + buildup margin), so we never sleep while
+    // freshly injected energy is still traversing the predelay line and building
+    // in the FDN — the wet peak can momentarily read ~0 during that window.
+    uint32_t m_silentSamples = 0;
+    // Set once the wet has been faded to zero over a transition block, after
+    // which the wet pipeline is fully skipped. Fading (rather than hard-cutting)
+    // the ~-100 dBFS residual keeps the sleep transition free of a broadband
+    // step, so it can't splatter into the tail or the decay measurement.
+    bool m_sleepFaded = false;
 
 #ifdef AESTRA_REVERB_PROFILE
     mutable std::array<StageProfileData, static_cast<size_t>(ProfileStage::kStageCount)> m_profileData{};

--- a/Tests/AestraAudio/ReverbDormancyTest.cpp
+++ b/Tests/AestraAudio/ReverbDormancyTest.cpp
@@ -174,6 +174,62 @@ int main() {
         std::cout << "  wake transparency: earlyCorr=" << earlyCorr << " worstEnvDiff=" << worstDb << " dB\n";
     }
 
+    // --- 3b. Dormant automation: controls stay current while asleep ---
+    // Prime wet, sleep, then automate Mix fully dry during dormancy. On wake the
+    // dry path must take effect immediately; if the smoothed Mix were left stale
+    // at its wet value, the first wake block would ramp up from ~0 dry gain and
+    // the early output would not track the input.
+    {
+        AestraVerb v; configure(v, sr); // Mix = 1.0 (fully wet)
+        const size_t pre = static_cast<size_t>(sr * 0.1f);
+        const size_t gap = static_cast<size_t>(sr * 13.0f);
+        const size_t wake = static_cast<size_t>(sr * 0.05f);
+
+        auto prime = noiseBurst(pre, pre, 111);
+        std::vector<float> pO(pre);
+        const float* pin[2] = { prime.data(), prime.data() };
+        float* pout[2] = { pO.data(), pO.data() };
+        v.process(pin, pout, 2, 2, static_cast<uint32_t>(pre));
+
+        std::vector<float> s(gap, 0.0f), sO(gap);
+        const size_t block = 256;
+        for (size_t off = 0; off < gap; off += block) {
+            const size_t f = std::min(block, gap - off);
+            const float* in[2] = { s.data() + off, s.data() + off };
+            float* out[2] = { sO.data() + off, sO.data() + off };
+            v.process(in, out, 2, 2, static_cast<uint32_t>(f));
+        }
+
+        // Automate Mix to fully dry while dormant, then let one more silent
+        // (dormant) block run so the snap picks up the new value — this models
+        // continuous host automation writing between process blocks while idle.
+        v.setParameter(AestraVerb::kMix, 0.0f);
+        {
+            std::vector<float> s2(block, 0.0f), s2O(block);
+            const float* in[2] = { s2.data(), s2.data() };
+            float* out[2] = { s2O.data(), s2O.data() };
+            v.process(in, out, 2, 2, static_cast<uint32_t>(block));
+        }
+
+        auto wk = noiseBurst(wake, wake, 222);
+        std::vector<float> wOutL(wake), wOutR(wake);
+        const float* win[2] = { wk.data(), wk.data() };
+        float* wout[2] = { wOutL.data(), wOutR.data() };
+        v.process(win, wout, 2, 2, static_cast<uint32_t>(wake));
+
+        // With Mix snapped to dry, the wake output tracks the dry input closely
+        // from the first samples (dry gain ~1, wet gain ~0). Measure early-window
+        // correlation of output vs input.
+        const size_t earlyN = static_cast<size_t>(sr * 0.01f);
+        double num = 0.0, do_ = 0.0, di = 0.0;
+        for (size_t i = 0; i < earlyN; ++i) {
+            num += (double)wOutL[i] * wk[i]; do_ += (double)wOutL[i] * wOutL[i]; di += (double)wk[i] * wk[i];
+        }
+        const double dryCorr = (do_ > 1e-20 && di > 1e-20) ? num / std::sqrt(do_ * di) : 0.0;
+        check(dryCorr > 0.99, "wake after dormant Mix->dry tracks dry input (corr " + std::to_string(dryCorr) + ")");
+        std::cout << "  dormant automation: dry-track corr=" << dryCorr << "\n";
+    }
+
     // --- 4. CPU benefit: a dormant span is much cheaper than an active span ---
     {
         const size_t n = static_cast<size_t>(sr * 4.0f);

--- a/Tests/AestraAudio/ReverbDormancyTest.cpp
+++ b/Tests/AestraAudio/ReverbDormancyTest.cpp
@@ -1,0 +1,238 @@
+// AestraVerb F8 tail-dormancy regression test.
+//
+// Verifies the idle-instance optimization is correct and transparent:
+//   1. Silence transparency  — silent input yields silent output (dormant path).
+//   2. No early truncation    — the audible tail after a burst is not cut short.
+//   3. Wake transparency      — after going dormant then receiving new input, the
+//                               response matches a fresh instance (the FDN state
+//                               decayed to ~0 during sleep, exactly like fresh).
+//   4. CPU benefit            — processing a dormant (silent) span is much cheaper
+//                               than processing an active (noisy) span.
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+
+int g_failures = 0;
+void check(bool cond, const std::string& msg) {
+    if (!cond) { std::cerr << "[FAIL] " << msg << "\n"; ++g_failures; }
+}
+
+void configure(AestraVerb& v, float sr) {
+    v.initialize(sr, 256);
+    v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(AestraVerb::Mode::Hall));
+    v.setParameter(AestraVerb::kDecay, 0.7f);
+    v.setParameter(AestraVerb::kSize, 0.6f);
+    v.setParameter(AestraVerb::kDiffusion, 0.8f);
+    v.setParameter(AestraVerb::kModRate, 0.5f);
+    v.setParameter(AestraVerb::kModDepth, 0.3f);
+    v.setParameter(AestraVerb::kMix, 1.0f);
+    v.setParameter(AestraVerb::kWidth, 0.7f);
+    v.activate();
+}
+
+// Process a buffer in 256-frame blocks.
+void run(AestraVerb& v, const std::vector<float>& inL, const std::vector<float>& inR,
+         std::vector<float>& outL, std::vector<float>& outR) {
+    const size_t n = inL.size();
+    outL.assign(n, 0.0f);
+    outR.assign(n, 0.0f);
+    const size_t block = 256;
+    for (size_t off = 0; off < n; off += block) {
+        const size_t f = std::min(block, n - off);
+        const float* in[2] = { inL.data() + off, inR.data() + off };
+        float* out[2] = { outL.data() + off, outR.data() + off };
+        v.process(in, out, 2, 2, static_cast<uint32_t>(f));
+    }
+}
+
+double peak(const std::vector<float>& x, size_t a, size_t b) {
+    double p = 0.0;
+    for (size_t i = a; i < b && i < x.size(); ++i) p = std::max(p, std::abs((double)x[i]));
+    return p;
+}
+
+double rms(const std::vector<float>& x, size_t a, size_t b) {
+    double s = 0.0; size_t n = 0;
+    for (size_t i = a; i < b && i < x.size(); ++i) { s += (double)x[i] * x[i]; ++n; }
+    return n ? std::sqrt(s / n) : 0.0;
+}
+
+std::vector<float> noiseBurst(size_t n, size_t burstLen, uint32_t seed) {
+    std::vector<float> v(n, 0.0f);
+    for (size_t i = 0; i < burstLen && i < n; ++i) {
+        seed = seed * 1103515245u + 12345u;
+        v[i] = (static_cast<float>((seed >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+    }
+    return v;
+}
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f;
+    std::cout << "AestraVerb F8 Tail-Dormancy Test\n";
+    std::cout << "================================\n";
+
+    // --- 1. Silence transparency: silent input -> silent output ---
+    {
+        AestraVerb v; configure(v, sr);
+        const size_t n = static_cast<size_t>(sr * 2.0f);
+        std::vector<float> zero(n, 0.0f), oL, oR;
+        run(v, zero, zero, oL, oR);
+        const double p = std::max(peak(oL, 0, n), peak(oR, 0, n));
+        check(p < 1e-9, "silent input produces silent output (peak " + std::to_string(p) + ")");
+        std::cout << "  silence transparency: output peak " << p << "\n";
+    }
+
+    // --- 2. No early truncation: audible tail survives well past the burst ---
+    {
+        AestraVerb v; configure(v, sr);
+        const size_t n = static_cast<size_t>(sr * 5.0f);
+        const size_t burst = static_cast<size_t>(sr * 0.1f);
+        auto inL = noiseBurst(n, burst, 12345);
+        auto inR = noiseBurst(n, burst, 99991);
+        std::vector<float> oL, oR;
+        run(v, inL, inR, oL, oR);
+        // Tail at 1 s and 2 s must be far above the dormant floor (-140 dBFS).
+        const double t1 = rms(oL, size_t(sr * 1.0f), size_t(sr * 1.1f));
+        const double t2 = rms(oL, size_t(sr * 2.0f), size_t(sr * 2.1f));
+        check(t1 > 1e-4, "tail present at 1 s (rms " + std::to_string(t1) + ")");
+        check(t2 > 1e-5, "tail present at 2 s (rms " + std::to_string(t2) + ")");
+        std::cout << "  tail rms @1s=" << t1 << " @2s=" << t2 << "\n";
+    }
+
+    // --- 3. Wake transparency: dormant-then-woken behaves like a fresh instance ---
+    // The FDN decays to ~0 during a long sleep, so a woken instance responds to
+    // new input like a fresh one. Two caveats shape the assertions:
+    //  * The sub-Hz modulation LFOs advance while the woken instance is still
+    //    actively decaying (before it sleeps), so at wake its modulation phase
+    //    differs from a fresh instance. That decorrelates the *modulated* late
+    //    tail's micro-structure but not its energy. So we check the energy
+    //    envelope (phase-insensitive) over the whole response, and sample-level
+    //    correlation only in the early, unmodulated reflection window.
+    {
+        const size_t pre = static_cast<size_t>(sr * 0.1f);
+        const size_t gap = static_cast<size_t>(sr * 12.0f);
+        const size_t tail = static_cast<size_t>(sr * 2.0f);
+        const size_t wake = static_cast<size_t>(sr * 0.1f);
+
+        AestraVerb vw; configure(vw, sr);
+        const size_t nW = pre + gap + wake + tail;
+        std::vector<float> wInL(nW, 0.0f), wInR(nW, 0.0f);
+        auto primeL = noiseBurst(pre, pre, 54321);
+        auto wakeL = noiseBurst(wake, wake, 24680);
+        auto wakeR = noiseBurst(wake, wake, 13579);
+        for (size_t i = 0; i < pre; ++i) { wInL[i] = primeL[i]; wInR[i] = primeL[i]; }
+        const size_t wakeStart = pre + gap;
+        for (size_t i = 0; i < wake; ++i) { wInL[wakeStart + i] = wakeL[i]; wInR[wakeStart + i] = wakeR[i]; }
+        std::vector<float> wOutL, wOutR;
+        run(vw, wInL, wInR, wOutL, wOutR);
+
+        AestraVerb vf; configure(vf, sr);
+        const size_t nF = wake + tail;
+        std::vector<float> fInL(nF, 0.0f), fInR(nF, 0.0f);
+        for (size_t i = 0; i < wake; ++i) { fInL[i] = wakeL[i]; fInR[i] = wakeR[i]; }
+        std::vector<float> fOutL, fOutR;
+        run(vf, fInL, fInR, fOutL, fOutR);
+
+        // Early, unmodulated window (first 30 ms): should match closely.
+        const size_t earlyN = static_cast<size_t>(sr * 0.03f);
+        double num = 0.0, dw = 0.0, df = 0.0;
+        for (size_t i = 0; i < earlyN; ++i) {
+            const float a = wOutL[wakeStart + i], b = fOutL[i];
+            num += (double)a * b; dw += (double)a * a; df += (double)b * b;
+        }
+        const double earlyCorr = (dw > 1e-20 && df > 1e-20) ? num / std::sqrt(dw * df) : 0.0;
+        check(earlyCorr > 0.98, "woken early reflections match fresh (corr " + std::to_string(earlyCorr) + ")");
+
+        // Energy envelope match over 0-500 ms (phase-insensitive), within 1.5 dB.
+        bool envOk = true;
+        double worstDb = 0.0;
+        for (int w = 0; w < 10; ++w) {
+            const size_t a = static_cast<size_t>(sr * 0.05f) * w;
+            const size_t b = a + static_cast<size_t>(sr * 0.05f);
+            const double rw = rms(wOutL, wakeStart + a, wakeStart + b);
+            const double rf = rms(fOutL, a, b);
+            if (rf > 1e-6) {
+                const double db = std::abs(20.0 * std::log10(std::max(rw, 1e-9) / rf));
+                worstDb = std::max(worstDb, db);
+                if (db > 1.5) envOk = false;
+            }
+        }
+        check(envOk, "woken energy envelope matches fresh within 1.5 dB (worst " + std::to_string(worstDb) + " dB)");
+        std::cout << "  wake transparency: earlyCorr=" << earlyCorr << " worstEnvDiff=" << worstDb << " dB\n";
+    }
+
+    // --- 4. CPU benefit: a dormant span is much cheaper than an active span ---
+    {
+        const size_t n = static_cast<size_t>(sr * 4.0f);
+        const size_t block = 256;
+
+        // Active: continuous noise.
+        AestraVerb va; configure(va, sr);
+        auto nz = noiseBurst(n, n, 4242);
+        std::vector<float> aOutL(n), aOutR(n);
+        auto ta0 = std::chrono::high_resolution_clock::now();
+        for (size_t off = 0; off < n; off += block) {
+            const size_t f = std::min(block, n - off);
+            const float* in[2] = { nz.data() + off, nz.data() + off };
+            float* out[2] = { aOutL.data() + off, aOutR.data() + off };
+            va.process(in, out, 2, 2, static_cast<uint32_t>(f));
+        }
+        auto ta1 = std::chrono::high_resolution_clock::now();
+        const double activeUs = std::chrono::duration<double, std::micro>(ta1 - ta0).count();
+
+        // Dormant: prime briefly, then time a long silent span (instance asleep).
+        AestraVerb vd; configure(vd, sr);
+        auto prime = noiseBurst(static_cast<size_t>(sr * 0.1f), static_cast<size_t>(sr * 0.1f), 7);
+        std::vector<float> pO(prime.size());
+        // Prime + let it fall asleep over ~15 s of silence (not timed).
+        {
+            const size_t settle = static_cast<size_t>(sr * 15.0f);
+            std::vector<float> s(settle, 0.0f), sO(settle);
+            const float* pin[2] = { prime.data(), prime.data() };
+            float* pout[2] = { pO.data(), pO.data() };
+            vd.process(pin, pout, 2, 2, static_cast<uint32_t>(prime.size()));
+            for (size_t off = 0; off < settle; off += block) {
+                const size_t f = std::min(block, settle - off);
+                const float* in[2] = { s.data() + off, s.data() + off };
+                float* out[2] = { sO.data() + off, sO.data() + off };
+                vd.process(in, out, 2, 2, static_cast<uint32_t>(f));
+            }
+        }
+        std::vector<float> z(n, 0.0f), dOutL(n), dOutR(n);
+        auto td0 = std::chrono::high_resolution_clock::now();
+        for (size_t off = 0; off < n; off += block) {
+            const size_t f = std::min(block, n - off);
+            const float* in[2] = { z.data() + off, z.data() + off };
+            float* out[2] = { dOutL.data() + off, dOutR.data() + off };
+            vd.process(in, out, 2, 2, static_cast<uint32_t>(f));
+        }
+        auto td1 = std::chrono::high_resolution_clock::now();
+        const double dormantUs = std::chrono::duration<double, std::micro>(td1 - td0).count();
+
+        std::cout << "  cpu: active=" << activeUs << "us dormant=" << dormantUs
+                  << "us (" << (activeUs / std::max(dormantUs, 1e-9)) << "x cheaper)\n";
+        // Generous bound: the real ratio is tens of x; require at least 2x so the
+        // check is robust on a loaded CI runner but still fails if dormancy breaks.
+        check(dormantUs < 0.5 * activeUs, "dormant span is materially cheaper than active");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "\n" << g_failures << " dormancy check(s) FAILED.\n";
+        return 1;
+    }
+    std::cout << "\nAll F8 dormancy checks passed.\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -645,6 +645,19 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbStereoTest.cpp")
     set_tests_properties(ReverbStereoTest PROPERTIES LABELS "audio;dsp;reverb;stereo")
 endif()
 
+# Reverb F8 tail-dormancy test (idle-instance optimization correctness)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
+    add_executable(ReverbDormancyTest AestraAudio/ReverbDormancyTest.cpp)
+    target_link_libraries(ReverbDormancyTest PRIVATE AestraAudio)
+    target_include_directories(ReverbDormancyTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ReverbDormancyTest COMMAND ReverbDormancyTest)
+    set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
+endif()
+
 # Reverb Quality Measurement Lab
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbQualityLab.cpp")
     add_executable(AestraReverbQualityLab AestraAudio/ReverbQualityLab.cpp)

--- a/labs/reverb/efficiency/f7_f8_measurement.md
+++ b/labs/reverb/efficiency/f7_f8_measurement.md
@@ -45,14 +45,24 @@ items remain candidates for a later pass (synced-predelay per-sample BPM reload
 ## Decision: do F8 tail dormancy
 
 An **idle** instance (silent input, tail decayed) still runs that entire ~78%
-FDN pipeline every sample. Dormancy skips it. Measured with the dormancy test:
+FDN pipeline every sample. Dormancy skips it.
 
-- Dormant span vs active span: **~68x cheaper** (silent input, instance asleep).
-- Transparent: silent input -> silent output; woken early reflections identical
-  to a fresh instance (corr 1.000); energy envelope within ~0.8 dB.
-- Measurement-safe: the dormant floor is -140 dBFS, below the tail-decay and
-  modulation-purity probes' analysis range, so it never shortens a measured T60
-  or splatters into the tail.
+Measured configuration (single instance, ReverbDormancyTest): Hall, 48 kHz,
+one dormant instance vs one active instance.
 
-This is the high-value efficiency win for multi-instance sessions on the 4 GB /
-low-core target: N idle reverb sends cost almost nothing.
+- Dormant span vs active span: **~68x cheaper** on this dev machine (silent
+  input, instance asleep). The absolute ratio depends on the target CPU and
+  mode, but the effect is structural: dormant processing skips the ~78% FDN
+  pipeline entirely.
+- Transparent (this config): silent input -> silent output; woken early
+  reflections identical to a fresh instance (corr 1.000); energy envelope within
+  ~0.8 dB; controls stay current under automation while asleep.
+- Measurement-safe: the dormant floor is -140 dBFS. The consistency probe's T60
+  check (44.1 / 48 / 96 kHz) and modulation-purity check pass unchanged with
+  dormancy on, so the floor sits below their analysis range — it does not
+  shorten those measured T60s or splatter into the tail.
+
+Because instances are independent, the per-instance saving compounds across the
+idle sends in a session, which is the point on the 4 GB / low-core target.
+Broader coverage (all modes, more sample rates, many-instance sessions) is left
+to a follow-up; the numbers above are the tested setup.

--- a/labs/reverb/efficiency/f7_f8_measurement.md
+++ b/labs/reverb/efficiency/f7_f8_measurement.md
@@ -1,0 +1,58 @@
+# AestraVerb F7/F8 Efficiency Measurement
+
+Measured on develop (post F4/F5/F6) with AestraReverbBenchmark. This is the
+evidence behind two decisions: **do F8 (tail dormancy)**, and **skip the F7
+dirty-domain control-cache refactor**.
+
+## Baseline cost (active, profiling off)
+
+| Mode  | CPU budget / 256-frame callback | Realtime |
+|-------|--------------------------------:|---------:|
+| Room  | 2.32% | 43x |
+| Hall  | 3.07% | 33x |
+| Plate | 3.26% | 31x |
+
+Already fast — one active instance is ~3% of a callback on this dev machine.
+
+## Stage profile (proportions; AESTRA_REVERB_PROFILE, Room)
+
+| Stage | % of total |
+|-------|-----------:|
+| FDN Delay Read | 27.3 |
+| FDN Feedback/Matrix | 15.7 |
+| Early Reflections | 12.7 |
+| Output/Mix | 12.5 |
+| Diffuser | 8.9 |
+| **LFO Normalize + Control** | **6.9** |
+| Input/Predelay | 5.5 |
+| Modulation/LFO | 5.3 |
+| Parameter Smoothing | 5.3 |
+
+The per-sample FDN pipeline (delay read + feedback + early + output + diffuser)
+is ~78% of the cost. The control cache lives inside the 6.9% "LFO Normalize +
+Control" stage and runs only once per 64 samples, so `updateControlCache` is a
+small fraction of that 6.9%.
+
+## Decision: skip the F7 dirty-domain control-cache refactor
+
+Splitting `updateControlCache` into per-domain dirty recomputation targets a
+sub-fraction of a 6.9% stage on a plugin already at ~3% budget. The realizable
+saving is a fraction of a percent of a callback, against real regression risk
+(coefficients not updating when they should). Not worth it. The cheap, safe F7
+items remain candidates for a later pass (synced-predelay per-sample BPM reload
+-> control rate; SIMD dispatch is already hoisted to a `static` check).
+
+## Decision: do F8 tail dormancy
+
+An **idle** instance (silent input, tail decayed) still runs that entire ~78%
+FDN pipeline every sample. Dormancy skips it. Measured with the dormancy test:
+
+- Dormant span vs active span: **~68x cheaper** (silent input, instance asleep).
+- Transparent: silent input -> silent output; woken early reflections identical
+  to a fresh instance (corr 1.000); energy envelope within ~0.8 dB.
+- Measurement-safe: the dormant floor is -140 dBFS, below the tail-decay and
+  modulation-purity probes' analysis range, so it never shortens a measured T60
+  or splatters into the tail.
+
+This is the high-value efficiency win for multi-instance sessions on the 4 GB /
+low-core target: N idle reverb sends cost almost nothing.


### PR DESCRIPTION
## Summary
Idle AestraVerb instances now sleep the wet pipeline. Part of the F7/F8 efficiency step — measure-first, so it also records why the risky F7 refactor is skipped.

Follows the merged F4 (#487) and F5/F6 (#488) work.

## Measurement (why F8, not the F7 refactor)
Stage profile (`labs/reverb/efficiency/f7_f8_measurement.md`): the per-sample FDN pipeline (delay read + feedback + early + output + diffuser) is **~78%** of the cost; the control cache lives in a **6.9%** stage and runs 1/64 samples. One active instance is already only ~3% of a callback.

- **F8 (do it):** an *idle* instance still ran that entire ~78% pipeline every sample. Skipping it makes a dormant span **~68× cheaper** — the real win when many reverb sends sit idle on a low-core target.
- **F7 dirty-domain cache refactor (skip):** targets a fraction of a 6.9% stage on a 3%-budget plugin; the realizable saving doesn't justify the regression risk. Documented, not done. The cheap F7 items (synced-predelay → control rate) remain for a later pass.

## How it works
- Sleep only when: the input block is silent, freeze is off, the tracked wet peak has fallen below the dormant floor, **and** the input has been silent longer than a 0.75 s guard (> max predelay) — so we never sleep while freshly injected energy is still traversing the predelay line or building in the FDN.
- Dormant floor is **−140 dBFS** (below the 24-bit noise floor). Deliberately far below audibility so dormancy is transparent to the tail-decay (T60) and modulation-purity probes, which analyse the tail down to very low levels. (A higher floor measurably shortened T60 at 96 kHz — caught by the consistency probe.)
- The transition to sleep ramps the wet to zero over one block, so the residual is faded, not hard-cut — no broadband step splatters into the tail.
- RT-safe: bounded silence scan + a few scalar ops per block; no allocation/locks/unbounded work. FDN state is left intact, so waking resumes seamlessly.

## Testing
- New always-on **ReverbDormancyTest**: silence transparency (silent in → silent out), no early tail truncation, wake transparency (woken early reflections identical to fresh, corr 1.000; energy envelope within 0.8 dB), and the CPU benefit (~68× cheaper dormant).
- Full reverb suite **6/6** (`ctest -R "[Rr]everb"`): SIMD parity, safety, consistency probe, modulation, stereo, dormancy.
- Production lib builds clean (dormancy is always-on engine logic, no new build flag).

## Docs updated?
Internal evidence under `labs/reverb/efficiency/`. No public docs.

## Risk / rollback notes
Adds a fast-path early-out to `process()`; the active path is unchanged except for a cheap per-block wet-peak track and a one-block fade on sleep entry. Wet-only, no state-format change, bypass path untouched. The main risk (premature sleep during predelay/buildup) is handled by the silence guard and covered by the "no early truncation" and probe tests. Rollback = revert the one commit; the dormancy test would then fail to build (its target is removed with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added F8 tail dormancy to AestraVerb, skipping wet reverb processing after prolonged silence while preserving FDN state for seamless wake-up.
- Added block-level fade-out, tail tracking, freeze checks, and reset-safe dormancy state to prevent artifacts and premature truncation.
- Added `ReverbDormancyTest` covering silence transparency, tail preservation, wake behavior, and CPU savings.
- Registered the test with CTest and documented F7/F8 efficiency measurements, including the decision not to pursue the higher-risk F7 cache refactor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->