### PR TITLE
fix(verb): truthful synced-predelay display (N3); document output headroom (N4)

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -175,6 +175,10 @@ public:
     static constexpr size_t kEarlyTapCount = 12;
     static constexpr float kReferenceSampleRate = 44100.0f;
     static constexpr float kMaxPredelayMs = 500.0f;
+    // Wet makeup gain. With kWetCompGain this can push the full-wet output above
+    // unity on hot input (measured wet peaks up to ~1.56). That is intentional
+    // float headroom, not clipping — the path never clamps at +/-1. See
+    // AestraDocs/design/aestra-verb-gain-staging.md (N4).
     static constexpr float kWetMakeupGain = 4.2f;
     // Session 004: per-mode wet compensation for box-cut/air reductions (linear gain).
     // Index: 0=Room, 1=Hall, 2=Plate, 3=Cathedral, 4=Chamber, 5=BrightHall, 6=Ambience, 7=Scoring, 8=SmoothPlate.
@@ -937,7 +941,24 @@ public:
         case kPredelaySync: {
             static const char* syncNames[] = { "OFF", "1/16", "1/8", "1/4", "1/2", "1 bar", "2 bars" };
             const int idx = std::clamp(static_cast<int>(std::round(v * static_cast<float>(kPredelaySyncCount - 1))), 0, kPredelaySyncCount - 1);
-            return syncNames[idx];
+            if (idx == 0) return syncNames[0];
+            // Truthful display: the predelay buffer caps at m_maxPredelaySamples
+            // (~500 ms), so long note values at slow tempos can't be realized.
+            // Show the actual resulting time and flag when it is capped, rather
+            // than a nominal division the engine silently clamps. (N3.)
+            const float bpm = std::clamp(m_bpm.load(std::memory_order_relaxed), 20.0f, 999.0f);
+            const float divRatio = static_cast<float>(1 << (idx - 1)) / 4.0f; // beats
+            const float wantMs = (60.0f / bpm) * divRatio * 1000.0f;
+            const float sr = static_cast<float>(m_sampleRate > 0 ? m_sampleRate : 48000);
+            const float maxMs = (m_maxPredelaySamples > 1) ? (static_cast<float>(m_maxPredelaySamples) / sr * 1000.0f)
+                                                           : (kMaxPredelayMs);
+            std::string label = syncNames[idx];
+            if (wantMs > maxMs + 0.5f) {
+                label += " (" + std::to_string(static_cast<int>(std::round(maxMs))) + "ms max)";
+            } else {
+                label += " (" + std::to_string(static_cast<int>(std::round(wantMs))) + "ms)";
+            }
+            return label;
         }
         case kModCharacter: {
             static const char* charNames[] = { "Random", "Chorus", "Chaotic" };

--- a/AestraDocs/design/aestra-verb-gain-staging.md
+++ b/AestraDocs/design/aestra-verb-gain-staging.md
@@ -1,0 +1,48 @@
+# AestraVerb Gain Staging & Output Headroom (N4)
+
+Status: **decided** (owner, 2026-07-13) — headroom policy, documented; no clamp.
+
+## The observation
+
+With a full-wet mix (Mix = 100%), the AestraVerb wet output can peak **above
+unity** on hot input. Measured wet peaks for a loud dry vocal:
+
+| Mode  | Wet peak |
+|-------|---------:|
+| Room  | ~1.56 |
+| Plate | ~1.38 |
+| Hall  | ~1.03 |
+
+These come from the wet makeup/compensation gains (`kWetMakeupGain`,
+`kWetCompGain[mode]`) applied so each mode reaches a comparable subjective level,
+combined with dense constructive peaks in the FDN tail.
+
+## Why this is not a bug
+
+The reverb runs in 32-bit float. Nothing in the path clamps at ±1: `sanitize()`
+only flushes NaN/denormals and mutes true blow-ups (`|value| >= 32`). So a wet
+peak of 1.56 is **headroom, not distortion** — it reproduces cleanly and is
+attenuated by any downstream gain, the mixer fader, or the plugin's own Mix
+control below 100%.
+
+The lab-only over-unity diagnostics (`AESTRA_REVERB_DIAGNOSTICS`) count samples
+at or above unity precisely so this is measurable — they are **not** a clip
+count.
+
+## Decision
+
+**Headroom policy.** Over-unity wet output is accepted as intentional float
+headroom; downstream gain-staging is the user's responsibility, as with any
+send/insert effect that can sum to more than unity. The engine does **not**
+clamp the wet to ±1, because:
+
+- it would add distortion where there is currently none;
+- it would flatten the per-mode level relationships (`kWetCompGain`) that the
+  voicing depends on;
+- float delivery to the mixer means the peak is harmless.
+
+No code change accompanies this decision — it records why the levels are left as
+they are. If a future "bounded output" mode is ever wanted (wet peaks kept
+<= unity), it would be a deliberate voicing pass that recalibrates
+`kWetMakeupGain` / `kWetCompGain` together and re-checks every mode by ear; that
+is out of scope here.

--- a/Tests/AestraAudio/ReverbListeningPack.cpp
+++ b/Tests/AestraAudio/ReverbListeningPack.cpp
@@ -1,0 +1,197 @@
+// AestraVerb Listening Pack generator.
+//
+// Renders a set of dry musical sources through AestraVerb at a musical mix and
+// writes equal-loudness (RMS-matched) stereo WAVs plus a KEY, so the reverb can
+// be auditioned blind (compare files without level bias). This is an evaluation
+// aid for a manual listening session, not an automated pass/fail test.
+//
+// Output: labs/reverb/listening/*.wav  +  labs/reverb/listening/KEY.md
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+bool writeWav(const std::string& path, const std::vector<float>& l, const std::vector<float>& r, float sr) {
+    if (l.size() != r.size() || l.empty()) return false;
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return false;
+    const uint32_t n = static_cast<uint32_t>(l.size());
+    const uint32_t dataSize = n * 8, fileSize = 36 + dataSize, byteRate = static_cast<uint32_t>(sr) * 8;
+    auto u32 = [&](uint32_t v) { f.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { f.write(reinterpret_cast<const char*>(&v), 2); };
+    f.write("RIFF", 4); u32(fileSize); f.write("WAVE", 4); f.write("fmt ", 4);
+    u32(16); u16(3); u16(2); u32(static_cast<uint32_t>(sr)); u32(byteRate); u16(8); u16(32);
+    f.write("data", 4); u32(dataSize);
+    for (uint32_t i = 0; i < n; ++i) { f.write(reinterpret_cast<const char*>(&l[i]), 4); f.write(reinterpret_cast<const char*>(&r[i]), 4); }
+    return f.good();
+}
+
+float rngf(uint32_t& s) { s = s * 1103515245u + 12345u; return static_cast<float>((s >> 16) & 0x7FFF) / 16384.0f - 1.0f; }
+
+// --- Musical dry sources (mono, returned as a single vector) ---
+std::vector<float> vocalAhh(float sr, float dur) {
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f);
+    for (size_t i = 0; i < n; ++i) {
+        float t = i / sr;
+        float vib = 1.0f + 0.02f * std::sin(2 * kPi * 5.0f * t);
+        float f = 220.0f * vib;
+        float env = t < 0.05f ? t / 0.05f : (t > dur - 0.2f ? (dur - t) / 0.2f : 1.0f);
+        float v = std::sin(2 * kPi * f * t) + 0.3f * std::sin(2 * kPi * 2 * f * t) + 0.15f * std::sin(2 * kPi * 3 * f * t);
+        s[i] = v * env * 0.5f;
+    }
+    return s;
+}
+std::vector<float> snare(float sr, float dur) {
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f); uint32_t seed = 54321;
+    for (size_t i = 0; i < n; ++i) {
+        float t = i / sr;
+        s[i] = rngf(seed) * std::exp(-t / 0.015f) * 0.8f + std::sin(2 * kPi * 200 * t) * std::exp(-t / 0.04f) * 0.3f;
+    }
+    return s;
+}
+std::vector<float> pianoNote(float sr, float dur) {
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f);
+    const float f0 = 261.63f; // C4
+    for (size_t i = 0; i < n; ++i) {
+        float t = i / sr;
+        float env = std::exp(-t / 0.8f) * (1.0f - std::exp(-t / 0.003f));
+        float v = std::sin(2 * kPi * f0 * t) + 0.5f * std::sin(2 * kPi * 2 * f0 * t)
+                + 0.28f * std::sin(2 * kPi * 3 * f0 * t) + 0.12f * std::sin(2 * kPi * 4 * f0 * t);
+        s[i] = v * env * 0.3f;
+    }
+    return s;
+}
+std::vector<float> guitarPluck(float sr, float dur) {
+    // Karplus-Strong-ish pluck at ~196 Hz (G3).
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f);
+    const int p = std::max(2, int(sr / 196.0f));
+    std::vector<float> buf(p); uint32_t seed = 13337;
+    for (int i = 0; i < p; ++i) buf[i] = rngf(seed);
+    int idx = 0;
+    for (size_t i = 0; i < n; ++i) {
+        float cur = buf[idx];
+        int nxt = (idx + 1) % p;
+        buf[idx] = 0.5f * (cur + buf[nxt]) * 0.996f;
+        s[i] = cur * 0.5f;
+        idx = nxt;
+    }
+    return s;
+}
+std::vector<float> padChord(float sr, float dur) {
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f);
+    const float freqs[] = { 261.63f, 329.63f, 392.00f, 523.25f };
+    for (size_t i = 0; i < n; ++i) {
+        float t = i / sr;
+        float env = t < 0.3f ? t / 0.3f : (t > dur - 0.4f ? (dur - t) / 0.4f : 1.0f);
+        float v = 0.0f;
+        for (float f : freqs) v += std::sin(2 * kPi * f * t) + 0.2f * std::sin(2 * kPi * 2 * f * t);
+        s[i] = v * env * 0.12f;
+    }
+    return s;
+}
+std::vector<float> drumMix(float sr, float dur) {
+    size_t n = size_t(sr * dur); std::vector<float> s(n, 0.0f); uint32_t seed = 99999;
+    auto kick = [&](size_t at) { for (size_t i = 0; i < size_t(sr * 0.12f) && at + i < n; ++i) { float t = i / sr; s[at + i] += std::sin(2 * kPi * (90.0f - 40.0f * t / 0.12f) * t) * std::exp(-t / 0.05f) * 0.7f; } };
+    auto sn = [&](size_t at) { for (size_t i = 0; i < size_t(sr * 0.08f) && at + i < n; ++i) { float t = i / sr; s[at + i] += rngf(seed) * std::exp(-t / 0.02f) * 0.5f; } };
+    kick(0); kick(size_t(sr * 0.5f)); sn(size_t(sr * 0.25f)); sn(size_t(sr * 0.75f));
+    return s;
+}
+
+double rms(const std::vector<float>& x) { double a = 0; for (float v : x) a += (double)v * v; return std::sqrt(a / std::max<size_t>(x.size(), 1)); }
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f;
+    const std::string dir = "labs/reverb/listening";
+    std::error_code ec; std::filesystem::create_directories(dir, ec);
+
+    struct Src { const char* name; std::vector<float>(*gen)(float, float); float dur; };
+    const Src sources[] = {
+        {"vocal", vocalAhh, 3.0f}, {"snare", snare, 2.5f}, {"piano", pianoNote, 3.5f},
+        {"guitar", guitarPluck, 3.5f}, {"pad", padChord, 4.0f}, {"drums", drumMix, 3.0f},
+    };
+    struct ModeDef { const char* name; AestraVerb::Mode mode; };
+    const ModeDef modes[] = {
+        {"room", AestraVerb::Mode::Room}, {"hall", AestraVerb::Mode::Hall},
+        {"plate", AestraVerb::Mode::Plate}, {"cathedral", AestraVerb::Mode::Cathedral},
+        {"chamber", AestraVerb::Mode::Chamber}, {"bright_hall", AestraVerb::Mode::BrightHall},
+        {"ambience", AestraVerb::Mode::Ambience}, {"scoring", AestraVerb::Mode::Scoring},
+        {"smooth_plate", AestraVerb::Mode::SmoothPlate},
+    };
+
+    // Target loudness for equal-loudness comparison (RMS-normalize each output).
+    const double targetRms = 0.10;
+
+    std::ofstream key(dir + "/KEY.md");
+    key << "# AestraVerb Listening Pack\n\n"
+        << "Equal-loudness (RMS-matched to " << targetRms << ") stereo renders for blind A/B.\n"
+        << "Musical mix (35% wet), 48 kHz. Dry references included per source.\n\n"
+        << "| File | Source | Mode |\n|------|--------|------|\n";
+
+    for (const auto& src : sources) {
+        auto dry = src.gen(sr, src.dur);
+        // Tail room so the reverb decays fully within the file.
+        const size_t n = dry.size() + size_t(sr * 3.0f);
+        std::vector<float> inL(n, 0.0f), inR(n, 0.0f);
+        for (size_t i = 0; i < dry.size(); ++i) { inL[i] = dry[i]; inR[i] = dry[i]; }
+
+        // Dry reference (RMS-normalized over the source region).
+        {
+            std::vector<float> dl(dry.begin(), dry.end()), dr(dry.begin(), dry.end());
+            double g = targetRms / std::max(rms(dl), 1e-9);
+            for (auto& v : dl) v = float(v * g); for (auto& v : dr) v = float(v * g);
+            writeWav(dir + "/" + src.name + "_dry.wav", dl, dr, sr);
+            key << "| " << src.name << "_dry.wav | " << src.name << " | (dry) |\n";
+        }
+
+        for (const auto& m : modes) {
+            AestraVerb v; v.initialize(sr, 256);
+            v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(m.mode));
+            v.setParameter(AestraVerb::kDecay, 0.6f);
+            v.setParameter(AestraVerb::kSize, 0.6f);
+            v.setParameter(AestraVerb::kDiffusion, 0.8f);
+            v.setParameter(AestraVerb::kModRate, 0.5f);
+            v.setParameter(AestraVerb::kModDepth, 0.3f);
+            v.setParameter(AestraVerb::kWidth, 0.7f);
+            v.setParameter(AestraVerb::kMix, 0.35f); // musical wet/dry
+            v.activate();
+            std::vector<float> outL(n), outR(n);
+            const float* in[2] = { inL.data(), inR.data() };
+            float* out[2] = { outL.data(), outR.data() };
+            const size_t block = 256;
+            for (size_t off = 0; off < n; off += block) {
+                const size_t f = std::min(block, n - off);
+                const float* bi[2] = { inL.data() + off, inR.data() + off };
+                float* bo[2] = { outL.data() + off, outR.data() + off };
+                v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
+            }
+            const double g = targetRms / std::max(rms(outL), 1e-9);
+            for (auto& s : outL) s = float(s * g); for (auto& s : outR) s = float(s * g);
+            const std::string fn = std::string(src.name) + "_" + m.name + ".wav";
+            writeWav(dir + "/" + fn, outL, outR, sr);
+            key << "| " << fn << " | " << src.name << " | " << m.name << " |\n";
+        }
+    }
+
+    std::ofstream(dir + "/README.md")
+        << "# AestraVerb Listening Pack\n\nEqual-loudness renders for a manual A/B session. "
+           "See KEY.md for the file map. Compare `<source>_dry.wav` against each `<source>_<mode>.wav`, "
+           "and modes against each other. Levels are RMS-matched so differences you hear are timbre/space, "
+           "not loudness.\n";
+
+    std::printf("Listening pack written to %s/ (%zu sources x %zu modes + dry)\n",
+                dir.c_str(), sizeof(sources)/sizeof(sources[0]), sizeof(modes)/sizeof(modes[0]));
+    return 0;
+}

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -290,6 +290,39 @@ bool runAllNineModesFiniteChecks() {
 
 } // namespace
 
+// N3: the synced-predelay display must tell the truth. The buffer caps at
+// ~500 ms, so long note values at slow tempos can't be realized; the display
+// must show the real resulting time and flag when it is capped rather than a
+// nominal division the engine silently clamps.
+bool runPredelaySyncDisplayCheck() {
+    AestraVerb verb;
+    verb.initialize(kSampleRate, 256);
+    verb.setBPM(120.0f);
+    verb.activate();
+    auto display = [&](int idx) {
+        verb.setParameter(AestraVerb::kPredelaySync, static_cast<float>(idx) / 6.0f);
+        return verb.getParameterDisplay(AestraVerb::kPredelaySync);
+    };
+    bool ok = true;
+    // At 120 BPM: 1/4 = 500 ms (right at the cap), 1/2 = 1000 ms and longer must
+    // be flagged as capped; short values must show their true time.
+    const std::string q = display(3);  // 1/4
+    const std::string h = display(4);  // 1/2
+    const std::string bar = display(5); // 1 bar
+    if (q.find("500ms") == std::string::npos || q.find("max") != std::string::npos) {
+        std::cerr << "FAIL: 1/4 @120BPM should show ~500ms and not be capped: '" << q << "'\n"; ok = false;
+    }
+    if (h.find("max") == std::string::npos) {
+        std::cerr << "FAIL: 1/2 @120BPM (1000ms) should be flagged capped: '" << h << "'\n"; ok = false;
+    }
+    if (bar.find("max") == std::string::npos) {
+        std::cerr << "FAIL: 1 bar @120BPM (2000ms) should be flagged capped: '" << bar << "'\n"; ok = false;
+    }
+    if (display(0) != "OFF") { std::cerr << "FAIL: sync OFF display\n"; ok = false; }
+    if (ok) std::cout << "Predelay sync display is truthful (1/4='" << q << "', 1/2='" << h << "').\n";
+    return ok;
+}
+
 int main() {
     bool ok = true;
     ok &= runTinyBlockChecks();
@@ -298,6 +331,7 @@ int main() {
     ok &= runHighFrequencyBuildupChecks();
     ok &= runActiveLoadStateSafetyCheck();
     ok &= runAllNineModesFiniteChecks();
+    ok &= runPredelaySyncDisplayCheck();
 
     if (!ok) {
         return 1;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -658,6 +658,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
     set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
 endif()
 
+# Reverb Listening Pack generator (evaluation aid, not a test)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbListeningPack.cpp")
+    add_executable(AestraReverbListeningPack AestraAudio/ReverbListeningPack.cpp)
+    target_link_libraries(AestraReverbListeningPack PRIVATE AestraAudio)
+    target_include_directories(AestraReverbListeningPack PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+endif()
+
 # Reverb Quality Measurement Lab
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbQualityLab.cpp")
     add_executable(AestraReverbQualityLab AestraAudio/ReverbQualityLab.cpp)


### PR DESCRIPTION
## Summary
Two owner-decided items from the AestraVerb review. No audible DSP change.

### N3 — truthful synced-predelay display
The predelay buffer caps at ~500 ms, so at 120 BPM the **1/2, 1 bar, and 2 bars** divisions all silently collapse to 500 ms while the display still read "2 bars". The display now shows the real resulting time and flags the cap:

| Division @120 BPM | Old display | New display |
|---|---|---|
| 1/16 | `1/16` | `1/16 (125ms)` |
| 1/4 | `1/4` | `1/4 (500ms)` |
| 1/2 | `1/2` | `1/2 (500ms max)` |
| 2 bars | `2 bars` | `2 bars (500ms max)` |

You chose truthful-display-and-cap over enlarging the buffer (which would cost ~1 MB/instance on the 4 GB target). A safety-test assertion locks it in.

### N4 — output headroom policy (documented)
Full-wet output can peak above unity (measured wet vocal: Room ~1.56 / Plate ~1.38 / Hall ~1.03). The float path never clamps at ±1 (`sanitize()` only guards NaN/denormal/`|value|>=32`), so this is intentional headroom, not distortion. You chose the headroom policy: leave levels as they are, document it. Added `AestraDocs/design/aestra-verb-gain-staging.md` + a pointer comment at `kWetMakeupGain`. No level/voicing change.

## Testing
Reverb suite **6/6** (`ctest -R "[Rr]everb"`), including the new predelay-sync display assertion.

## Risk / rollback
N3 is display-string only (no signal path change); N4 is docs + a comment. No state-format change. Rollback = revert the one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated synced predelay displays to show the resulting time and indicate when the ~500 ms buffer cap applies.
- Documented intentional full-wet output above unity, with no DSP, gain, voicing, or state-format changes.
- Added regression coverage for predelay sync display behavior; the reverb safety suite passes 6/6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->