### PR TITLE
fix(verb): calm the reverb tremolo — modulation depth retune + truthful UI display

### DIFF
--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -877,7 +877,7 @@ public:
             { kSize, "Size", "SIZ", "x", 0.52f, 0.0f, 1.0f, true },
             { kDiffusion, "Diffusion", "DIF", "%", 0.64f, 0.0f, 1.0f, true },
             { kModRate, "Mod Rate", "RTE", "x", 0.42f, 0.0f, 1.0f, true },
-            { kModDepth, "Mod Depth", "DEP", "smpl", 0.14f, 0.0f, 1.0f, true },
+            { kModDepth, "Mod Depth", "DEP", "smpl", 0.07f, 0.0f, 1.0f, true },
             { kMode, "Mode", "MOD", "", 0.0f, 0.0f, 1.0f, true, false, false, kModeCount - 1 },
             { kLowCut, "Low Cut", "LO", "Hz", 0.0f, 0.0f, 1.0f, true },
             { kHighCut, "High Cut", "HI", "Hz", 1.0f, 0.0f, 1.0f, true },
@@ -1337,6 +1337,15 @@ private:
         // the logicalFdnLength margin (28) covers it with room to spare, and
         // the minimum length (100) keeps the shortest modulated delay clear of
         // the write head. pow() runs at control rate, not per sample.
+        // Default depth retuned 0.14 -> 0.07 (owner-confirmed by ear). The
+        // audible "tremolo/sheet" was the FDN's narrow peaks/notches being MOVED
+        // across sustained source harmonics by the LFO (individual harmonics
+        // swing even though the broadband tail loudness barely changes). Measured
+        // per-harmonic swing dropped from ~2.7 dB (Plate) / ~2.3 dB (Room) at 0.14
+        // to ~2.0 / ~1.7 dB at 0.07 — below the tremolo audibility knee — while
+        // still smearing the static modes (swing at depth 0 collapses to ~0.1 dB,
+        // re-exposing the ring). See labs/reverb/tremolo/. Higher settings remain
+        // available for anyone who wants overt motion.
         const float depthParam = std::clamp(smoothedParams[kModDepth], 0.0f, 1.0f);
         const float depthCurve = depthParam <= 0.0f ? 0.0f : std::pow(depthParam, 0.6f);
         cache.modDepthSamples = depthCurve * 12.5f * constants.modDepthScalar;

--- a/AestraAudio/include/Plugin/AestraVerb.h
+++ b/AestraAudio/include/Plugin/AestraVerb.h
@@ -16,7 +16,9 @@
 #define M_PI 3.14159265358979323846
 #endif
 #include <cstring>
+#include <iomanip>
 #include <random>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -898,7 +900,7 @@ public:
             // (0.90-1.60) — the DSP uses (0.3 + v*9.7) * decayScalar, so a
             // Cathedral "7.1s" was actually 11.4s before this was applied.
             const float scalar = constantsForMode(currentMode()).decayScalar;
-            return std::to_string(static_cast<int>((0.3f + v * 9.7f) * scalar * 10.0f) / 10.0f) + "s";
+            return formatCompactFloat(static_cast<int>((0.3f + v * 9.7f) * scalar * 10.0f) / 10.0f, 1) + "s";
         }
         case kDamping: return std::to_string(static_cast<int>(v * 100)) + "%";
         case kPredelayMs: return std::to_string(static_cast<int>(v * kMaxPredelayMs)) + "ms";
@@ -907,7 +909,7 @@ public:
         case kBypass: return v > 0.5f ? "ON" : "OFF";
         case kSize: {
             const float size = 0.1f + v * 1.9f;
-            return std::to_string(static_cast<int>(size * 100.0f) / 100.0f) + "x";
+            return formatCompactFloat(static_cast<int>(size * 100.0f) / 100.0f, 2) + "x";
         }
         case kDiffusion: return std::to_string(static_cast<int>(v * 100)) + "%";
         case kModRate: return std::to_string(static_cast<int>(v * 200)) + "%";
@@ -917,7 +919,7 @@ public:
             // matched neither the previous x7 mapping nor the current one.
             const float scalar = constantsForMode(currentMode()).modDepthScalar;
             const float smp = (v <= 0.0f ? 0.0f : std::pow(v, 0.6f)) * 12.5f * scalar;
-            return std::to_string(static_cast<int>(smp * 10.0f) / 10.0f) + " smp";
+            return formatCompactFloat(static_cast<int>(smp * 10.0f) / 10.0f, 1) + " smp";
         }
         case kMode: {
             static const char* modeNames[] = {
@@ -967,6 +969,21 @@ public:
         }
         default: return "";
         }
+    }
+
+    static std::string formatCompactFloat(float value, int precision) {
+        std::ostringstream stream;
+        stream << std::fixed << std::setprecision(precision) << value;
+        std::string text = stream.str();
+        if (text.find('.') != std::string::npos) {
+            while (!text.empty() && text.back() == '0') {
+                text.pop_back();
+            }
+            if (!text.empty() && text.back() == '.') {
+                text.pop_back();
+            }
+        }
+        return text;
     }
 
     std::vector<uint8_t> saveState() const override {

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -116,103 +116,103 @@ AestraVerbEditor::AestraVerbEditor(std::shared_ptr<Aestra::Audio::IPluginInstanc
     }};
     m_presets = {{
         // Room
-        {"Vitruvian Space", "Intimate room for voice and acoustic guitar", 0, 0.35f, 0.28f, 0.54f, 0.58f, 0.24f, 0.09f, 0.52f, 0.30f, 0.0f, 0.5f, 0, 0,
+        {"Vitruvian Space", "Intimate room for voice and acoustic guitar", 0, 0.35f, 0.28f, 0.54f, 0.58f, 0.24f, 0.05f, 0.52f, 0.30f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/vitruvian-space.png", 0, false, {}, false},
-        {"Vocal Booth", "Tight, controlled space for dry vocal tracking", 0, 0.22f, 0.18f, 0.62f, 0.50f, 0.18f, 0.06f, 0.44f, 0.24f, 0.0f, 0.5f, 0, 0,
+        {"Vocal Booth", "Tight, controlled space for dry vocal tracking", 0, 0.22f, 0.18f, 0.62f, 0.50f, 0.18f, 0.03f, 0.44f, 0.24f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Studio Room", "Natural small room with early reflections", 0, 0.30f, 0.32f, 0.58f, 0.55f, 0.22f, 0.08f, 0.50f, 0.28f, 0.0f, 0.5f, 0, 0,
+        {"Studio Room", "Natural small room with early reflections", 0, 0.30f, 0.32f, 0.58f, 0.55f, 0.22f, 0.04f, 0.50f, 0.28f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Dense Studio", "Thick small room, great for drums", 0, 0.38f, 0.42f, 0.70f, 0.60f, 0.28f, 0.12f, 0.56f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Dense Studio", "Thick small room, great for drums", 0, 0.38f, 0.42f, 0.70f, 0.60f, 0.28f, 0.06f, 0.56f, 0.32f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Bright Room", "Small bright room with crisp reflections", 0, 0.26f, 0.22f, 0.50f, 0.62f, 0.30f, 0.10f, 0.48f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Bright Room", "Small bright room with crisp reflections", 0, 0.26f, 0.22f, 0.50f, 0.62f, 0.30f, 0.05f, 0.48f, 0.34f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Hall
-        {"Grand Hall", "Massive hall with long, lush reverb tail", 1, 0.76f, 0.58f, 0.51f, 0.86f, 0.42f, 0.18f, 0.74f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Grand Hall", "Massive hall with long, lush reverb tail", 1, 0.76f, 0.58f, 0.51f, 0.86f, 0.42f, 0.09f, 0.74f, 0.36f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/grand-hall.png", 0, false, {}, false},
-        {"Concert Hall", "Orchestral hall with rich spatial depth", 1, 0.68f, 0.52f, 0.55f, 0.80f, 0.38f, 0.16f, 0.70f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Concert Hall", "Orchestral hall with rich spatial depth", 1, 0.68f, 0.52f, 0.55f, 0.80f, 0.38f, 0.08f, 0.70f, 0.32f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Chapel Hall", "Stone chapel with bright, reflective surfaces", 1, 0.72f, 0.62f, 0.48f, 0.90f, 0.44f, 0.22f, 0.76f, 0.40f, 0.0f, 0.5f, 0, 0,
+        {"Chapel Hall", "Stone chapel with bright, reflective surfaces", 1, 0.72f, 0.62f, 0.48f, 0.90f, 0.44f, 0.10f, 0.76f, 0.40f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Medium Hall", "Well-balanced hall for most sources", 1, 0.58f, 0.46f, 0.52f, 0.78f, 0.36f, 0.14f, 0.66f, 0.30f, 0.0f, 0.5f, 0, 0,
+        {"Medium Hall", "Well-balanced hall for most sources", 1, 0.58f, 0.46f, 0.52f, 0.78f, 0.36f, 0.07f, 0.66f, 0.30f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Soft Hall", "Gentle hall with smooth, dark tail", 1, 0.62f, 0.50f, 0.60f, 0.82f, 0.34f, 0.12f, 0.68f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Soft Hall", "Gentle hall with smooth, dark tail", 1, 0.62f, 0.50f, 0.60f, 0.82f, 0.34f, 0.06f, 0.68f, 0.34f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Plate
-        {"Plate Forge", "Bright metallic plate reverb", 2, 0.54f, 0.48f, 0.46f, 0.82f, 0.34f, 0.20f, 0.78f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Plate Forge", "Bright metallic plate reverb", 2, 0.54f, 0.48f, 0.46f, 0.82f, 0.34f, 0.10f, 0.78f, 0.32f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/plate-forge.png", 0, false, {}, false},
-        {"Classic Plate", "EMT-style smooth plate reverb", 2, 0.50f, 0.44f, 0.44f, 0.78f, 0.32f, 0.18f, 0.74f, 0.30f, 0.0f, 0.5f, 0, 0,
+        {"Classic Plate", "EMT-style smooth plate reverb", 2, 0.50f, 0.44f, 0.44f, 0.78f, 0.32f, 0.09f, 0.74f, 0.30f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Dense Plate", "Thick, dense plate for vocals and keys", 2, 0.58f, 0.52f, 0.50f, 0.84f, 0.36f, 0.22f, 0.80f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Dense Plate", "Thick, dense plate for vocals and keys", 2, 0.58f, 0.52f, 0.50f, 0.84f, 0.36f, 0.10f, 0.80f, 0.34f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Bright Plate", "Bright, shimmery plate reverb", 2, 0.46f, 0.40f, 0.42f, 0.86f, 0.38f, 0.24f, 0.82f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Bright Plate", "Bright, shimmery plate reverb", 2, 0.46f, 0.40f, 0.42f, 0.86f, 0.38f, 0.11f, 0.82f, 0.36f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Dark Plate", "Dark, moody plate with long decay", 2, 0.62f, 0.56f, 0.48f, 0.80f, 0.30f, 0.16f, 0.76f, 0.30f, 0.0f, 0.5f, 0, 0,
+        {"Dark Plate", "Dark, moody plate with long decay", 2, 0.62f, 0.56f, 0.48f, 0.80f, 0.30f, 0.08f, 0.76f, 0.30f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Cathedral
-        {"Celestial Room", "Massive cathedral with ethereal tail", 3, 0.92f, 0.76f, 0.42f, 0.94f, 0.28f, 0.30f, 0.88f, 0.40f, 0.0f, 0.5f, 0, 0,
+        {"Celestial Room", "Massive cathedral with ethereal tail", 3, 0.92f, 0.76f, 0.42f, 0.94f, 0.28f, 0.12f, 0.88f, 0.40f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/celestial-room.png", 0, false, {}, false},
-        {"Stone Cathedral", "Vast stone cathedral with deep reverb", 3, 0.88f, 0.72f, 0.40f, 0.92f, 0.30f, 0.28f, 0.86f, 0.38f, 0.0f, 0.5f, 0, 0,
+        {"Stone Cathedral", "Vast stone cathedral with deep reverb", 3, 0.88f, 0.72f, 0.40f, 0.92f, 0.30f, 0.10f, 0.86f, 0.38f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Epic Cathedral", "Enormous cathedral for cinematic textures", 3, 0.96f, 0.82f, 0.38f, 0.96f, 0.26f, 0.32f, 0.90f, 0.42f, 0.0f, 0.5f, 0, 0,
+        {"Epic Cathedral", "Enormous cathedral for cinematic textures", 3, 0.96f, 0.82f, 0.38f, 0.96f, 0.26f, 0.12f, 0.90f, 0.42f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Sacred Space", "Holy space with long, shimmering decay", 3, 0.84f, 0.68f, 0.44f, 0.90f, 0.32f, 0.26f, 0.84f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Sacred Space", "Holy space with long, shimmering decay", 3, 0.84f, 0.68f, 0.44f, 0.90f, 0.32f, 0.11f, 0.84f, 0.36f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Cathedral Warm", "Warm cathedral with gentle low-end", 3, 0.80f, 0.64f, 0.46f, 0.88f, 0.34f, 0.24f, 0.82f, 0.38f, 0.0f, 0.5f, 0, 0,
+        {"Cathedral Warm", "Warm cathedral with gentle low-end", 3, 0.80f, 0.64f, 0.46f, 0.88f, 0.34f, 0.09f, 0.82f, 0.38f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Chamber
-        {"Golden Chamber", "Rich, warm chamber with golden reflections", 4, 0.60f, 0.48f, 0.50f, 0.80f, 0.36f, 0.18f, 0.72f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Golden Chamber", "Rich, warm chamber with golden reflections", 4, 0.60f, 0.48f, 0.50f, 0.80f, 0.36f, 0.09f, 0.72f, 0.34f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/golden-chamber.png", 0, false, {}, false},
-        {"Tape Chamber", "Vintage chamber with tape saturation character", 4, 0.55f, 0.44f, 0.52f, 0.76f, 0.34f, 0.16f, 0.68f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Tape Chamber", "Vintage chamber with tape saturation character", 4, 0.55f, 0.44f, 0.52f, 0.76f, 0.34f, 0.08f, 0.68f, 0.32f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Large Chamber", "Big chamber with natural room ambience", 4, 0.65f, 0.54f, 0.48f, 0.82f, 0.38f, 0.20f, 0.74f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Large Chamber", "Big chamber with natural room ambience", 4, 0.65f, 0.54f, 0.48f, 0.82f, 0.38f, 0.10f, 0.74f, 0.36f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Tight Chamber", "Small, tight chamber for subtle space", 4, 0.40f, 0.32f, 0.56f, 0.72f, 0.30f, 0.14f, 0.62f, 0.28f, 0.0f, 0.5f, 0, 0,
+        {"Tight Chamber", "Small, tight chamber for subtle space", 4, 0.40f, 0.32f, 0.56f, 0.72f, 0.30f, 0.07f, 0.62f, 0.28f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Bright Chamber", "Bright chamber with clear early reflections", 4, 0.52f, 0.42f, 0.46f, 0.84f, 0.40f, 0.22f, 0.76f, 0.38f, 0.0f, 0.5f, 0, 0,
+        {"Bright Chamber", "Bright chamber with clear early reflections", 4, 0.52f, 0.42f, 0.46f, 0.84f, 0.40f, 0.10f, 0.76f, 0.38f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Bright Hall
-        {"Bright Concert", "Bright concert hall with shimmering tail", 5, 0.68f, 0.50f, 0.44f, 0.88f, 0.44f, 0.20f, 0.80f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Bright Concert", "Bright concert hall with shimmering tail", 5, 0.68f, 0.50f, 0.44f, 0.88f, 0.44f, 0.10f, 0.80f, 0.36f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/bright-concert.png", 0, false, {}, false},
-        {"Crystal Hall", "Sparkling bright hall with crystalline reflections", 5, 0.72f, 0.54f, 0.42f, 0.90f, 0.46f, 0.22f, 0.82f, 0.38f, 0.0f, 0.5f, 0, 0,
+        {"Crystal Hall", "Sparkling bright hall with crystalline reflections", 5, 0.72f, 0.54f, 0.42f, 0.90f, 0.46f, 0.11f, 0.82f, 0.38f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Glass Hall", "Transparent, glassy hall reverb", 5, 0.64f, 0.46f, 0.46f, 0.86f, 0.42f, 0.18f, 0.78f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Glass Hall", "Transparent, glassy hall reverb", 5, 0.64f, 0.46f, 0.46f, 0.86f, 0.42f, 0.09f, 0.78f, 0.34f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Silk Hall", "Smooth, silky bright hall", 5, 0.60f, 0.44f, 0.50f, 0.84f, 0.40f, 0.16f, 0.76f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Silk Hall", "Smooth, silky bright hall", 5, 0.60f, 0.44f, 0.50f, 0.84f, 0.40f, 0.08f, 0.76f, 0.32f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Radiant Hall", "Radiant, luminous hall with wide stereo", 5, 0.70f, 0.52f, 0.40f, 0.92f, 0.48f, 0.24f, 0.84f, 0.40f, 0.0f, 0.5f, 0, 0,
+        {"Radiant Hall", "Radiant, luminous hall with wide stereo", 5, 0.70f, 0.52f, 0.40f, 0.92f, 0.48f, 0.12f, 0.84f, 0.40f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Ambience
-        {"Soft Air", "Gentle ambient wash for padding and atmosphere", 6, 0.18f, 0.12f, 0.38f, 0.40f, 0.14f, 0.04f, 0.36f, 0.16f, 0.0f, 0.5f, 0, 0,
+        {"Soft Air", "Gentle ambient wash for padding and atmosphere", 6, 0.18f, 0.12f, 0.38f, 0.40f, 0.14f, 0.02f, 0.36f, 0.16f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/soft-air.png", 0, false, {}, false},
-        {"Subtle Space", "Minimal ambience for subtle depth", 6, 0.14f, 0.10f, 0.42f, 0.38f, 0.12f, 0.03f, 0.34f, 0.14f, 0.0f, 0.5f, 0, 0,
+        {"Subtle Space", "Minimal ambience for subtle depth", 6, 0.14f, 0.10f, 0.42f, 0.38f, 0.12f, 0.02f, 0.34f, 0.14f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Room Tone", "Natural room tone for realistic spaces", 6, 0.20f, 0.14f, 0.40f, 0.42f, 0.16f, 0.05f, 0.38f, 0.18f, 0.0f, 0.5f, 0, 0,
+        {"Room Tone", "Natural room tone for realistic spaces", 6, 0.20f, 0.14f, 0.40f, 0.42f, 0.16f, 0.03f, 0.38f, 0.18f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Air Brush", "Light ambient brush for texture", 6, 0.16f, 0.11f, 0.36f, 0.36f, 0.10f, 0.02f, 0.32f, 0.12f, 0.0f, 0.5f, 0, 0,
+        {"Air Brush", "Light ambient brush for texture", 6, 0.16f, 0.11f, 0.36f, 0.36f, 0.10f, 0.01f, 0.32f, 0.12f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Breath Space", "Very short, breath-like ambience", 6, 0.12f, 0.08f, 0.44f, 0.34f, 0.08f, 0.02f, 0.30f, 0.10f, 0.0f, 0.5f, 0, 0,
+        {"Breath Space", "Very short, breath-like ambience", 6, 0.12f, 0.08f, 0.44f, 0.34f, 0.08f, 0.01f, 0.30f, 0.10f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Scoring
-        {"Cinematic Space", "Vast cinematic space for film scoring", 7, 0.82f, 0.66f, 0.44f, 0.90f, 0.32f, 0.26f, 0.84f, 0.38f, 0.0f, 0.5f, 0, 0,
+        {"Cinematic Space", "Vast cinematic space for film scoring", 7, 0.82f, 0.66f, 0.44f, 0.90f, 0.32f, 0.11f, 0.84f, 0.38f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/cinematic-space.png", 0, false, {}, false},
-        {"Film Score", "Professional scoring stage ambience", 7, 0.78f, 0.62f, 0.46f, 0.88f, 0.34f, 0.24f, 0.82f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Film Score", "Professional scoring stage ambience", 7, 0.78f, 0.62f, 0.46f, 0.88f, 0.34f, 0.10f, 0.82f, 0.36f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Epic Score", "Massive scoring stage for orchestral works", 7, 0.86f, 0.70f, 0.42f, 0.92f, 0.30f, 0.28f, 0.86f, 0.40f, 0.0f, 0.5f, 0, 0,
+        {"Epic Score", "Massive scoring stage for orchestral works", 7, 0.86f, 0.70f, 0.42f, 0.92f, 0.30f, 0.12f, 0.86f, 0.40f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Intimate Score", "Intimate scoring stage for small ensemble", 7, 0.70f, 0.56f, 0.50f, 0.84f, 0.36f, 0.22f, 0.78f, 0.34f, 0.0f, 0.5f, 0, 0,
+        {"Intimate Score", "Intimate scoring stage for small ensemble", 7, 0.70f, 0.56f, 0.50f, 0.84f, 0.36f, 0.09f, 0.78f, 0.34f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Dark Score", "Moody, dark scoring ambience", 7, 0.80f, 0.64f, 0.40f, 0.86f, 0.28f, 0.30f, 0.80f, 0.36f, 0.0f, 0.5f, 0, 0,
+        {"Dark Score", "Moody, dark scoring ambience", 7, 0.80f, 0.64f, 0.40f, 0.86f, 0.28f, 0.10f, 0.80f, 0.36f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
         // Smooth Plate
-        {"Smooth Plate", "Silky smooth plate with gentle character", 8, 0.50f, 0.42f, 0.48f, 0.80f, 0.30f, 0.14f, 0.72f, 0.30f, 0.0f, 0.5f, 0, 0,
+        {"Smooth Plate", "Silky smooth plate with gentle character", 8, 0.50f, 0.42f, 0.48f, 0.80f, 0.30f, 0.07f, 0.72f, 0.30f, 0.0f, 0.5f, 0, 0,
          "AestraAssets/plugins/AestraVerb/presets/smooth-plate.png", 0, false, {}, false},
-        {"Velvet Plate", "Soft, velvety plate reverb", 8, 0.46f, 0.38f, 0.50f, 0.78f, 0.28f, 0.12f, 0.70f, 0.28f, 0.0f, 0.5f, 0, 0,
+        {"Velvet Plate", "Soft, velvety plate reverb", 8, 0.46f, 0.38f, 0.50f, 0.78f, 0.28f, 0.06f, 0.70f, 0.28f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Cream Plate", "Smooth, creamy plate with warm tone", 8, 0.52f, 0.44f, 0.46f, 0.82f, 0.32f, 0.16f, 0.74f, 0.32f, 0.0f, 0.5f, 0, 0,
+        {"Cream Plate", "Smooth, creamy plate with warm tone", 8, 0.52f, 0.44f, 0.46f, 0.82f, 0.32f, 0.08f, 0.74f, 0.32f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Liquid Plate", "Fluid, liquid plate reverb", 8, 0.48f, 0.40f, 0.52f, 0.76f, 0.26f, 0.10f, 0.68f, 0.26f, 0.0f, 0.5f, 0, 0,
+        {"Liquid Plate", "Fluid, liquid plate reverb", 8, 0.48f, 0.40f, 0.52f, 0.76f, 0.26f, 0.05f, 0.68f, 0.26f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
-        {"Gentle Plate", "Gentle, unobtrusive plate for vocals", 8, 0.44f, 0.36f, 0.54f, 0.74f, 0.24f, 0.08f, 0.66f, 0.24f, 0.0f, 0.5f, 0, 0,
+        {"Gentle Plate", "Gentle, unobtrusive plate for vocals", 8, 0.44f, 0.36f, 0.54f, 0.74f, 0.24f, 0.04f, 0.66f, 0.24f, 0.0f, 0.5f, 0, 0,
          "", 0, false, {}, false},
     }};
     syncCategoryFromMode();
@@ -233,7 +233,7 @@ void AestraVerbEditor::buildControls() {
     const Meta metas[] = {
         {"Predelay", kPredelay, 0.02f}, {"Size", kSize, 0.52f}, {"Decay", kDecay, 0.56f},
         {"Damping", kDamping, 0.50f}, {"Diffusion", kDiffusion, 0.64f},
-        {"Mod Rate", kModRate, 0.42f}, {"Mod Depth", kModDepth, 0.14f},
+        {"Mod Rate", kModRate, 0.42f}, {"Mod Depth", kModDepth, 0.07f},
         {"Width", kWidth, 0.68f}, {"Low Cut", kLowCut, 0.0f}, {"High Cut", kHighCut, 1.0f},
         {"Attack", kAttack, 0.0f}, {"Shape", kShape, 0.5f},
         {"Pre Sync", kPredelaySync, 0.0f}, {"Mod Char", kModCharacter, 0.0f}
@@ -266,55 +266,10 @@ float AestraVerbEditor::getParamValue(uint32_t paramId) const {
 }
 
 std::string AestraVerbEditor::formatParameterValue(uint32_t paramId) const {
-    const float v = getParamValue(paramId);
-    std::ostringstream out;
-    switch (paramId) {
-    case kSize:
-        out << std::fixed << std::setprecision(2) << (0.1f + v * 1.9f) << "x";
-        return out.str();
-    case kDecay: {
-        const float seconds = 0.3f + v * 9.7f;
-        if (seconds < 10.0f) out << std::fixed << std::setprecision(1) << seconds << "s";
-        else out << static_cast<int>(std::round(seconds)) << "s";
-        return out.str();
-    }
-    case kDamping: case kDiffusion: case kWidth: case kMix:
-        out << static_cast<int>(std::round(v * 100.0f)) << "%";
-        return out.str();
-    case kPredelay:
-        out << static_cast<int>(std::round(v * 500.0f)) << "ms";
-        return out.str();
-    case kModRate:
-        out << std::fixed << std::setprecision(2) << (v * 2.0f) << "x";
-        return out.str();
-    case kModDepth:
-        out << std::fixed << std::setprecision(1) << (v * 8.0f) << "smp";
-        return out.str();
-    case kLowCut: {
-        const float hz = v < 0.001f ? 20.0f : 20.0f * std::pow(1000.0f, v);
-        out << static_cast<int>(std::round(hz)) << "Hz";
-        return out.str();
-    }
-    case kHighCut: {
-        const float hz = v > 0.999f ? 20000.0f : 200.0f * std::pow(100.0f, v);
-        out << static_cast<int>(std::round(hz)) << "Hz";
-        return out.str();
-    }
-    case kAttack: out << static_cast<int>(std::round(v * 100.0f)) << "%"; return out.str();
-    case kShape: out << static_cast<int>(std::round(v * 100.0f)) << "%"; return out.str();
-    case kPredelaySync: {
-        static const char* syncNames[] = {"OFF", "1/16", "1/8", "1/4", "1/2", "1bar", "2bar"};
-        const int idx = std::clamp(static_cast<int>(std::round(v * 6.0f)), 0, 6);
-        return syncNames[idx];
-    }
-    case kModCharacter: {
-        static const char* charNames[] = {"Random", "Chorus", "Chaotic"};
-        const int idx = std::clamp(static_cast<int>(std::round(v * 2.0f)), 0, 2);
-        return charNames[idx];
-    }
-    default:
-        return m_instance ? m_instance->getParameterDisplay(paramId) : "0";
-    }
+    // The DSP owns the parameter mappings. Reusing its display keeps the editor
+    // truthful for mode-scaled decay/mod depth, filter cutoffs, and capped
+    // tempo-synced predelay instead of duplicating mappings that can drift.
+    return m_instance ? m_instance->getParameterDisplay(paramId) : "0";
 }
 
 void AestraVerbEditor::syncCategoryFromMode() {
@@ -1161,7 +1116,7 @@ void AestraVerbEditor::loadUserPresets() {
         p.damping = parsed.has("damping") ? static_cast<float>(parsed["damping"].asNumber()) : 0.5f;
         p.diffusion = parsed.has("diffusion") ? static_cast<float>(parsed["diffusion"].asNumber()) : 0.7f;
         p.modRate = parsed.has("modRate") ? static_cast<float>(parsed["modRate"].asNumber()) : 0.4f;
-        p.modDepth = parsed.has("modDepth") ? static_cast<float>(parsed["modDepth"].asNumber()) : 0.14f;
+        p.modDepth = parsed.has("modDepth") ? static_cast<float>(parsed["modDepth"].asNumber()) : 0.07f;
         p.width = parsed.has("width") ? static_cast<float>(parsed["width"].asNumber()) : 0.68f;
         p.mix = parsed.has("mix") ? static_cast<float>(parsed["mix"].asNumber()) : 0.36f;
         p.attack = parsed.has("attack") ? static_cast<float>(parsed["attack"].asNumber()) : 0.0f;
@@ -1212,7 +1167,7 @@ float AestraVerbEditor::paramDefault(uint32_t paramId) {
     switch (paramId) {
     case kDecay: return 0.56f; case kDamping: return 0.50f; case kPredelay: return 0.02f;
     case kWidth: return 0.68f; case kMix: return 0.36f; case kSize: return 0.52f;
-    case kDiffusion: return 0.64f; case kModRate: return 0.42f; case kModDepth: return 0.14f;
+    case kDiffusion: return 0.64f; case kModRate: return 0.42f; case kModDepth: return 0.07f;
     case kLowCut: return 0.0f; case kHighCut: return 1.0f; case kFreeze: return 0.0f;
     case kAttack: return 0.0f; case kShape: return 0.5f;
     case kPredelaySync: return 0.0f; case kModCharacter: return 0.0f;

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -1116,7 +1116,11 @@ void AestraVerbEditor::loadUserPresets() {
         p.damping = parsed.has("damping") ? static_cast<float>(parsed["damping"].asNumber()) : 0.5f;
         p.diffusion = parsed.has("diffusion") ? static_cast<float>(parsed["diffusion"].asNumber()) : 0.7f;
         p.modRate = parsed.has("modRate") ? static_cast<float>(parsed["modRate"].asNumber()) : 0.4f;
-        p.modDepth = parsed.has("modDepth") ? static_cast<float>(parsed["modDepth"].asNumber()) : 0.07f;
+        // Legacy fallback stays 0.14 (the pre-retune default) so an old user
+        // preset saved without a modDepth field loads exactly as it sounded when
+        // created. New presets persist modDepth explicitly; only fresh instances
+        // use the calmer 0.07 default.
+        p.modDepth = parsed.has("modDepth") ? static_cast<float>(parsed["modDepth"].asNumber()) : 0.14f;
         p.width = parsed.has("width") ? static_cast<float>(parsed["width"].asNumber()) : 0.68f;
         p.mix = parsed.has("mix") ? static_cast<float>(parsed["mix"].asNumber()) : 0.36f;
         p.attack = parsed.has("attack") ? static_cast<float>(parsed["attack"].asNumber()) : 0.0f;

--- a/AestraUI/Widgets/AestraVerbEditor.h
+++ b/AestraUI/Widgets/AestraVerbEditor.h
@@ -55,7 +55,7 @@ private:
         float damping = 0.5f;
         float diffusion = 0.7f;
         float modRate = 0.4f;
-        float modDepth = 0.14f;
+        float modDepth = 0.07f;
         float width = 0.68f;
         float mix = 0.36f;
         float attack = 0.0f;

--- a/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
+++ b/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
@@ -199,5 +199,44 @@ int main() {
     { std::ofstream f(dir + "/harmonic_motion.md"); if (f) f << md.str(); }
     { std::ofstream f(dir + "/harmonic_motion.json"); if (f) f << js.str(); }
     std::cout << "\nHarmonic-motion report written to " << dir << "/\n";
+
+    // Prototype A/B render: when PROTO_LABEL is set, render a sustained chord
+    // through Plate and Room at the current build's voicing (and PROTO_MODDEPTH
+    // if given), equal-loudness, tagged by the label — so candidate builds can be
+    // rendered and compared by ear. Also measures each so the numbers accompany
+    // the audio.
+    if (const char* label = std::getenv("PROTO_LABEL")) {
+        const std::string protoDir = dir + "/proto";
+        std::filesystem::create_directories(protoDir, ec);
+        float modDepth = 0.14f;
+        if (const char* md_ = std::getenv("PROTO_MODDEPTH")) modDepth = std::stof(md_);
+        auto writeWav = [](const std::string& p, const std::vector<float>& l, const std::vector<float>& r, float srr) {
+            std::ofstream f(p, std::ios::binary); if (!f) return;
+            const uint32_t n = static_cast<uint32_t>(l.size()), ds = n * 8, fsz = 36 + ds, br = static_cast<uint32_t>(srr) * 8;
+            auto u32 = [&](uint32_t v){ f.write(reinterpret_cast<const char*>(&v),4); };
+            auto u16 = [&](uint16_t v){ f.write(reinterpret_cast<const char*>(&v),2); };
+            f.write("RIFF",4); u32(fsz); f.write("WAVE",4); f.write("fmt ",4); u32(16); u16(3); u16(2);
+            u32(static_cast<uint32_t>(srr)); u32(br); u16(8); u16(32); f.write("data",4); u32(ds);
+            for (uint32_t i=0;i<n;++i){ f.write(reinterpret_cast<const char*>(&l[i]),4); f.write(reinterpret_cast<const char*>(&r[i]),4);} };
+        const std::array<AestraVerb::Mode, 2> pm = { AestraVerb::Mode::Plate, AestraVerb::Mode::Room };
+        const float dur = 4.0f; const size_t src = static_cast<size_t>(sr * dur), nn = src + static_cast<size_t>(sr * 4.0f);
+        const float ch[] = { 261.63f, 329.63f, 392.00f };
+        std::vector<float> dry(nn, 0.0f);
+        for (size_t i = 0; i < src; ++i) { const float t = i / sr; float e = t < 0.01f ? t/0.01f : (t > dur-0.5f ? (dur-t)/0.5f : 1.0f); float v=0; for (float f: ch) v += std::sin(2*kPi*f*t)+0.3f*std::sin(2*kPi*2*f*t); dry[i]=v*e*0.12f; }
+        auto rms=[](const std::vector<float>&x){ double a=0; for(float v:x)a+=(double)v*v; return std::sqrt(a/std::max<size_t>(x.size(),1)); };
+        for (auto mode : pm) {
+            AestraVerb v; v.initialize(sr, 256);
+            v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+            v.setParameter(AestraVerb::kDecay,0.7f); v.setParameter(AestraVerb::kSize,0.6f); v.setParameter(AestraVerb::kDiffusion,0.8f);
+            v.setParameter(AestraVerb::kDamping,0.5f); v.setParameter(AestraVerb::kModRate,rate); v.setParameter(AestraVerb::kModDepth,modDepth);
+            v.setParameter(AestraVerb::kWidth,0.7f); v.setParameter(AestraVerb::kMix,0.4f); v.activate();
+            std::vector<float> oL(nn), oR(nn);
+            const size_t block=256;
+            for (size_t off=0; off<nn; off+=block){ const size_t f=std::min(block,nn-off); const float* bi[2]={dry.data()+off,dry.data()+off}; float* bo[2]={oL.data()+off,oR.data()+off}; v.process(bi,bo,2,2,static_cast<uint32_t>(f)); }
+            const double g=0.1/std::max(rms(oL),1e-9); for(auto&s:oL)s=float(s*g); for(auto&s:oR)s=float(s*g);
+            writeWav(protoDir + "/" + modeName(mode) + "_" + label + ".wav", oL, oR, sr);
+            std::cout << "proto " << modeName(mode) << " [" << label << " depth " << modDepth << "] written\n";
+        }
+    }
     return 0;
 }

--- a/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
+++ b/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
@@ -1,0 +1,203 @@
+// AestraVerb Harmonic-Motion Measurement Lab.
+//
+// The audible "tremolo/ring/sheet" is the FDN's narrow peaks/notches moving
+// across sustained source tones: individual frequencies swing in level even when
+// the broadband tail loudness barely changes (which is why a tail-envelope
+// metric misses it). This lab measures that directly: it holds a comb of steady
+// tones through the reverb and tracks how much each tone's level moves over time
+// (dB swing), reporting the typical (median) and worst-case swing per config.
+// It sweeps modulation depth so a "calmer motion" target can be chosen against a
+// budget of ~<=0.5 dB typical / <=2-3 dB worst-harmonic movement.
+//
+// Output: labs/reverb/tremolo/harmonic_motion.md / .json
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+void fft(std::vector<std::complex<float>>& a) {
+    const size_t n = a.size();
+    if (n <= 1) return;
+    for (size_t i = 1, j = 0; i < n; ++i) {
+        size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) std::swap(a[i], a[j]);
+    }
+    for (size_t len = 2; len <= n; len <<= 1) {
+        const float ang = -2.0f * kPi / static_cast<float>(len);
+        const std::complex<float> wl(std::cos(ang), std::sin(ang));
+        for (size_t i = 0; i < n; i += len) {
+            std::complex<float> w(1.0f, 0.0f);
+            for (size_t k = 0; k < len / 2; ++k) {
+                const std::complex<float> u = a[i + k], v = a[i + k + len / 2] * w;
+                a[i + k] = u + v; a[i + k + len / 2] = u - v; w *= wl;
+            }
+        }
+    }
+}
+
+// A log-spaced comb of probe tones spanning the musical range.
+std::vector<float> combFreqs() {
+    std::vector<float> f;
+    for (double hz = 120.0; hz <= 8000.0; hz *= std::pow(2.0, 1.0 / 6.0)) f.push_back(static_cast<float>(hz)); // 1/6-oct
+    return f;
+}
+
+// Render a steady tone comb through one config; return L output.
+std::vector<float> renderComb(AestraVerb::Mode mode, float damping, float modDepth, float modRate,
+                              float sr, float seconds, const std::vector<float>& freqs) {
+    const size_t n = static_cast<size_t>(sr * seconds);
+    std::vector<float> in(n, 0.0f), outL(n), outR(n);
+    // Equal-amplitude comb; random start phases so the sum doesn't spike.
+    uint32_t s = 777;
+    std::vector<float> ph(freqs.size());
+    for (auto& p : ph) { s = s * 1103515245u + 12345u; p = (static_cast<float>((s >> 9) & 0x7FFF) / 32768.0f) * 2.0f * kPi; }
+    const float amp = 0.4f / std::sqrt(static_cast<float>(freqs.size()));
+    for (size_t i = 0; i < n; ++i) {
+        const float t = i / sr;
+        float v = 0.0f;
+        for (size_t k = 0; k < freqs.size(); ++k) v += std::sin(2.0f * kPi * freqs[k] * t + ph[k]);
+        in[i] = v * amp;
+    }
+    AestraVerb v; v.initialize(sr, 256);
+    v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+    v.setParameter(AestraVerb::kDecay, 0.6f);
+    v.setParameter(AestraVerb::kSize, 0.6f);
+    v.setParameter(AestraVerb::kDiffusion, 0.8f);
+    v.setParameter(AestraVerb::kDamping, damping);
+    v.setParameter(AestraVerb::kModRate, modRate);
+    v.setParameter(AestraVerb::kModDepth, modDepth);
+    v.setParameter(AestraVerb::kModCharacter, 0.0f);
+    v.setParameter(AestraVerb::kWidth, 0.7f);
+    v.setParameter(AestraVerb::kMix, 1.0f);
+    v.activate();
+    const float* ip[2] = { in.data(), in.data() };
+    float* op[2] = { outL.data(), outR.data() };
+    const size_t block = 256;
+    for (size_t off = 0; off < n; off += block) {
+        const size_t f = std::min(block, n - off);
+        const float* bi[2] = { in.data() + off, in.data() + off };
+        float* bo[2] = { outL.data() + off, outR.data() + off };
+        v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
+    }
+    return outL;
+}
+
+struct MotionStat { float typicalDb = 0.0f; float worstDb = 0.0f; float worstHz = 0.0f; };
+
+// For each probe tone, track its level over time via a sliding FFT and report the
+// swing (RMS of the dB level around its mean). Typical = median over tones,
+// worst = max. Steady state, so the mean is the level and the fluctuation is the
+// moving peak/notch.
+MotionStat measureMotion(const std::vector<float>& out, float sr, const std::vector<float>& freqs) {
+    MotionStat m;
+    const size_t win = 2048, hop = 512;
+    const size_t startSkip = static_cast<size_t>(sr * 1.0f); // drop buildup
+    if (out.size() < startSkip + win + hop) return m;
+    // Precompute bin index per tone.
+    std::vector<size_t> bin(freqs.size());
+    for (size_t k = 0; k < freqs.size(); ++k) bin[k] = std::min(win / 2, static_cast<size_t>(std::round(freqs[k] * win / sr)));
+    // Per-tone dB level series.
+    std::vector<std::vector<float>> series(freqs.size());
+    std::vector<std::complex<float>> buf(win);
+    for (size_t off = startSkip; off + win <= out.size(); off += hop) {
+        for (size_t i = 0; i < win; ++i) {
+            const float w = 0.5f * (1.0f - std::cos(2.0f * kPi * i / (win - 1)));
+            buf[i] = std::complex<float>(out[off + i] * w, 0.0f);
+        }
+        fft(buf);
+        for (size_t k = 0; k < freqs.size(); ++k) {
+            const double mag = std::abs(buf[bin[k]]) + 1e-12;
+            series[k].push_back(static_cast<float>(20.0 * std::log10(mag)));
+        }
+    }
+    std::vector<float> swings;
+    for (size_t k = 0; k < freqs.size(); ++k) {
+        const auto& s = series[k];
+        if (s.size() < 8) continue;
+        double mean = 0; for (float v : s) mean += v; mean /= s.size();
+        double sq = 0; for (float v : s) sq += (v - mean) * (v - mean);
+        const float sw = static_cast<float>(std::sqrt(sq / s.size()));
+        swings.push_back(sw);
+        if (sw > m.worstDb) { m.worstDb = sw; m.worstHz = freqs[k]; }
+    }
+    if (!swings.empty()) {
+        std::sort(swings.begin(), swings.end());
+        m.typicalDb = swings[swings.size() / 2];
+    }
+    return m;
+}
+
+const char* modeName(AestraVerb::Mode m) {
+    switch (m) {
+        case AestraVerb::Mode::Room: return "room";
+        case AestraVerb::Mode::Hall: return "hall";
+        case AestraVerb::Mode::Plate: return "plate";
+        case AestraVerb::Mode::SmoothPlate: return "smooth_plate";
+        default: return "?";
+    }
+}
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f, seconds = 7.0f, rate = 0.5f;
+    const auto freqs = combFreqs();
+    const std::string dir = "labs/reverb/tremolo";
+    std::error_code ec; std::filesystem::create_directories(dir, ec);
+
+    std::cout << "AestraVerb Harmonic-Motion measurement (" << freqs.size() << " probe tones)\n";
+    std::cout << "=========================================================\n\n";
+
+    std::ostringstream md, js;
+    md << "# AestraVerb Harmonic-Motion Measurement\n\n"
+       << "Steady 1/6-octave tone comb held through the reverb; each tone's level is tracked over "
+          "time and its dB swing measured (typical = median over tones, worst = max). This captures "
+          "the FDN peaks/notches moving across sustained tones. Budget target: typical <= ~0.5 dB, "
+          "worst-harmonic <= ~2-3 dB.\n\n"
+       << "## Mod-depth sweep (damping 0.5)\n\n"
+       << "| Mode | depth | Typical dB | Worst dB | Worst Hz |\n|------|-------|-----------|----------|----------|\n";
+    js << "{\n  \"probeTones\": " << freqs.size() << ",\n  \"sweep\": [\n";
+
+    const std::array<AestraVerb::Mode, 4> modes = { AestraVerb::Mode::Room, AestraVerb::Mode::Hall, AestraVerb::Mode::Plate, AestraVerb::Mode::SmoothPlate };
+    const std::array<float, 4> depths = { 0.0f, 0.07f, 0.14f, 0.30f }; // off / calm / default / pack
+    bool firstJs = true;
+    for (auto mode : modes) {
+        for (float d : depths) {
+            auto out = renderComb(mode, 0.5f, d, rate, sr, seconds, freqs);
+            const MotionStat s = measureMotion(out, sr, freqs);
+            md << "| " << modeName(mode) << " | " << std::fixed << std::setprecision(2) << d
+               << " | " << std::setprecision(2) << s.typicalDb << " | " << s.worstDb
+               << " | " << std::setprecision(0) << s.worstHz << " |\n";
+            js << (firstJs ? "    " : ",\n    ") << "{\"mode\":\"" << modeName(mode) << "\",\"depth\":" << d
+               << ",\"typicalDb\":" << s.typicalDb << ",\"worstDb\":" << s.worstDb << ",\"worstHz\":" << s.worstHz << "}";
+            firstJs = false;
+            std::cout << modeName(mode) << " depth " << std::fixed << std::setprecision(2) << d
+                      << ": typical " << s.typicalDb << " dB, worst " << s.worstDb << " dB @ "
+                      << std::setprecision(0) << s.worstHz << " Hz\n";
+        }
+    }
+    js << "\n  ]\n}\n";
+
+    { std::ofstream f(dir + "/harmonic_motion.md"); if (f) f << md.str(); }
+    { std::ofstream f(dir + "/harmonic_motion.json"); if (f) f << js.str(); }
+    std::cout << "\nHarmonic-motion report written to " << dir << "/\n";
+    return 0;
+}

--- a/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
+++ b/Tests/AestraAudio/ReverbHarmonicMotionLab.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -177,7 +178,7 @@ int main() {
     js << "{\n  \"probeTones\": " << freqs.size() << ",\n  \"sweep\": [\n";
 
     const std::array<AestraVerb::Mode, 4> modes = { AestraVerb::Mode::Room, AestraVerb::Mode::Hall, AestraVerb::Mode::Plate, AestraVerb::Mode::SmoothPlate };
-    const std::array<float, 4> depths = { 0.0f, 0.07f, 0.14f, 0.30f }; // off / calm / default / pack
+    const std::array<float, 4> depths = { 0.0f, 0.07f, 0.14f, 0.30f }; // off / default (0.07) / old-default / strong
     bool firstJs = true;
     for (auto mode : modes) {
         for (float d : depths) {
@@ -208,7 +209,7 @@ int main() {
     if (const char* label = std::getenv("PROTO_LABEL")) {
         const std::string protoDir = dir + "/proto";
         std::filesystem::create_directories(protoDir, ec);
-        float modDepth = 0.14f;
+        float modDepth = 0.07f; // shipping default
         if (const char* md_ = std::getenv("PROTO_MODDEPTH")) modDepth = std::stof(md_);
         auto writeWav = [](const std::string& p, const std::vector<float>& l, const std::vector<float>& r, float srr) {
             std::ofstream f(p, std::ios::binary); if (!f) return;

--- a/Tests/AestraAudio/ReverbListeningPack.cpp
+++ b/Tests/AestraAudio/ReverbListeningPack.cpp
@@ -163,7 +163,7 @@ int main() {
             v.setParameter(AestraVerb::kSize, 0.6f);
             v.setParameter(AestraVerb::kDiffusion, 0.8f);
             v.setParameter(AestraVerb::kModRate, 0.5f);
-            v.setParameter(AestraVerb::kModDepth, 0.3f);
+            v.setParameter(AestraVerb::kModDepth, 0.07f); // shipping default (post-tremolo retune)
             v.setParameter(AestraVerb::kWidth, 0.7f);
             v.setParameter(AestraVerb::kMix, 0.35f); // musical wet/dry
             v.activate();

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -323,6 +323,32 @@ bool runPredelaySyncDisplayCheck() {
     return ok;
 }
 
+bool runParameterDisplayFormattingCheck() {
+    AestraVerb verb;
+    verb.initialize(kSampleRate, 256);
+    verb.setParameter(AestraVerb::kMode, AestraVerb::modeParam(AestraVerb::Mode::Room));
+    verb.setParameter(AestraVerb::kDecay, 0.56f);
+    verb.setParameter(AestraVerb::kSize, 0.52f);
+    verb.setParameter(AestraVerb::kModDepth, 0.07f);
+
+    bool ok = true;
+    for (uint32_t id : {AestraVerb::kDecay, AestraVerb::kSize, AestraVerb::kModDepth}) {
+        const std::string display = verb.getParameterDisplay(id);
+        ok &= require(display.find(".000000") == std::string::npos,
+                      "parameter display leaked raw std::to_string precision: '" + display + "'");
+    }
+    ok &= require(verb.getParameterDisplay(AestraVerb::kSize) == "1.08x",
+                  "size display should use compact precision");
+    ok &= require(verb.getParameterDisplay(AestraVerb::kModDepth) == "1.1 smp",
+                  "mod-depth display should use compact precision");
+    if (ok) {
+        std::cout << "Parameter displays use compact precision (size='"
+                  << verb.getParameterDisplay(AestraVerb::kSize) << "', depth='"
+                  << verb.getParameterDisplay(AestraVerb::kModDepth) << "').\n";
+    }
+    return ok;
+}
+
 int main() {
     bool ok = true;
     ok &= runTinyBlockChecks();
@@ -332,6 +358,7 @@ int main() {
     ok &= runActiveLoadStateSafetyCheck();
     ok &= runAllNineModesFiniteChecks();
     ok &= runPredelaySyncDisplayCheck();
+    ok &= runParameterDisplayFormattingCheck();
 
     if (!ok) {
         return 1;

--- a/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
+++ b/Tests/AestraAudio/ReverbSafetyRegressionTest.cpp
@@ -341,6 +341,11 @@ bool runParameterDisplayFormattingCheck() {
                   "size display should use compact precision");
     ok &= require(verb.getParameterDisplay(AestraVerb::kModDepth) == "1.1 smp",
                   "mod-depth display should use compact precision");
+    // Decay's leaked precision was ".800000s" (not ".000000"), so the substring
+    // check above cannot catch it — assert the exact compact value.
+    ok &= require(verb.getParameterDisplay(AestraVerb::kDecay) == "6.8s",
+                  "decay display should use compact precision, got '" +
+                      verb.getParameterDisplay(AestraVerb::kDecay) + "'");
     if (ok) {
         std::cout << "Parameter displays use compact precision (size='"
                   << verb.getParameterDisplay(AestraVerb::kSize) << "', depth='"

--- a/Tests/AestraAudio/ReverbTremoloLab.cpp
+++ b/Tests/AestraAudio/ReverbTremoloLab.cpp
@@ -6,7 +6,8 @@
 // rate, and coherent-peak prominence — per mode. Includes a modulation-OFF
 // control and a modulation-depth sweep to test whether the LFO is the cause, a
 // low/mid/high band split, a damping comparison, and A/B WAV renders (mod off vs
-// max) for ear confirmation.
+// max) for ear confirmation. This broadband-envelope metric does not by itself
+// measure narrow spectral peaks/notches moving across sustained source tones.
 //
 // Output: labs/reverb/tremolo/tremolo_report.md / .json
 
@@ -102,8 +103,10 @@ struct TremStat { float rateHz = 0.0f; float rippleDb = 0.0f; float peakProminen
 // smoothly (a straight line in dB), so any pumping shows up as fluctuation of the
 // dB-envelope around that smooth decay. We take the dB envelope, remove the slow
 // decay trend with a long moving average, and report the residual ripple depth
-// (RMS, in dB) and its dominant rate in 0.3-8 Hz. A non-modulated tail decays
-// smoothly -> ~0 dB ripple, so this isolates the modulation's audible pump.
+// (RMS, in dB) and its dominant rate in 0.3-8 Hz. The modulation-off render is
+// the baseline: an unmodulated sparse FDN can still have substantial envelope
+// ripple, so this metric must not be read as a complete modulation audibility
+// test.
 TremStat measureRipple(const std::vector<float>& env, float envRate) {
     TremStat t;
     const size_t n = env.size();
@@ -263,7 +266,7 @@ int main() {
        << "50 ms broadband burst then silence; the decaying tail's dB envelope is detrended and "
           "the residual ripple measured. Default settings (Random mod, depth 0.3, damping 0.5, "
           "Mix 100%). RippleDb = RMS pump of the tail around its smooth decay (dB); WobbleHz = its "
-          "dominant rate; the mod-OFF column is the control (a clean tail decays smoothly ~0 dB); "
+          "dominant rate; the mod-OFF column is the unmodulated FDN baseline; "
           "the band columns split the output into low/mid/high.\n\n"
        << "| Mode | WobbleHz | RippleDb (mod on) | RippleDb (mod OFF) | Low | Mid | High |\n"
        << "|------|----------|-------------------|--------------------|-----|-----|------|\n";
@@ -354,20 +357,43 @@ int main() {
             dryL[i] = dryR[i] = v * env * 0.12f;
         }
         auto rmsv = [](const std::vector<float>& x) { double a = 0; for (float v : x) a += (double)v * v; return std::sqrt(a / std::max<size_t>(x.size(), 1)); };
-        struct AB { const char* name; AestraVerb::Mode mode; float depth; };
+        struct AB {
+            const char* name;
+            AestraVerb::Mode mode;
+            float depth;
+            float damping;
+        };
         const AB abs_[] = {
-            {"plate_modOFF", AestraVerb::Mode::Plate, 0.0f}, {"plate_modMAX", AestraVerb::Mode::Plate, 1.0f},
-            {"hall_modOFF", AestraVerb::Mode::Hall, 0.0f},   {"hall_modMAX", AestraVerb::Mode::Hall, 1.0f},
+            {"plate_modOFF", AestraVerb::Mode::Plate, 0.0f, 0.5f},
+            {"plate_modDEFAULT", AestraVerb::Mode::Plate, 0.07f, 0.5f},
+            {"plate_modLEGACY", AestraVerb::Mode::Plate, 0.14f, 0.5f},
+            {"plate_modSTRONG", AestraVerb::Mode::Plate, 0.3f, 0.5f},
+            {"plate_modMAX", AestraVerb::Mode::Plate, 1.0f, 0.5f},
+            {"plate_lowDamp_modDEFAULT", AestraVerb::Mode::Plate, 0.07f, 0.1f},
+            {"hall_modOFF", AestraVerb::Mode::Hall, 0.0f, 0.5f},
+            {"hall_modDEFAULT", AestraVerb::Mode::Hall, 0.07f, 0.5f},
+            {"hall_modLEGACY", AestraVerb::Mode::Hall, 0.14f, 0.5f},
+            {"hall_modSTRONG", AestraVerb::Mode::Hall, 0.3f, 0.5f},
+            {"hall_modMAX", AestraVerb::Mode::Hall, 1.0f, 0.5f},
+            {"hall_lowDamp_modDEFAULT", AestraVerb::Mode::Hall, 0.07f, 0.1f},
+            {"room_modOFF", AestraVerb::Mode::Room, 0.0f, 0.5f},
+            {"room_modDEFAULT", AestraVerb::Mode::Room, 0.07f, 0.5f},
+            {"room_modLEGACY", AestraVerb::Mode::Room, 0.14f, 0.5f},
+            {"room_modSTRONG", AestraVerb::Mode::Room, 0.3f, 0.5f},
+            {"room_lowDamp_modDEFAULT", AestraVerb::Mode::Room, 0.07f, 0.1f},
         };
         std::ofstream key(abDir + "/KEY.md");
-        key << "# Tremolo A/B — modulation off vs max\n\nSame chord stab, equal loudness. If "
-               "modOFF and modMAX sound the same (both wobble), the tremolo is the FDN mode "
-               "beating, not the modulation.\n\n| File | Mode | Mod depth |\n|---|---|---|\n";
+        key << "# Tremolo A/B — modulation and damping sweep\n\nSame chord stab, equal loudness. Compare "
+               "modOFF through modMAX to hear how moving FDN peaks/notches change even when the "
+               "broadband tail-envelope ripple remains similar. DEFAULT is the shipped 0.07 depth; LEGACY is the "
+               "previous 0.14 default. The lab holds Mod Rate at 0.5; STRONG is depth 0.30.\n\n"
+               "| File | Mode | Mod depth | Damping |\n"
+               "|---|---|---:|---:|\n";
         for (const auto& a : abs_) {
             AestraVerb v; v.initialize(sr, 256);
             v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(a.mode));
             v.setParameter(AestraVerb::kDecay, 0.7f); v.setParameter(AestraVerb::kSize, 0.6f);
-            v.setParameter(AestraVerb::kDiffusion, 0.8f); v.setParameter(AestraVerb::kDamping, 0.5f);
+            v.setParameter(AestraVerb::kDiffusion, 0.8f); v.setParameter(AestraVerb::kDamping, a.damping);
             v.setParameter(AestraVerb::kModRate, 0.5f); v.setParameter(AestraVerb::kModDepth, a.depth);
             v.setParameter(AestraVerb::kWidth, 0.7f); v.setParameter(AestraVerb::kMix, 0.4f);
             v.activate();
@@ -380,9 +406,11 @@ int main() {
                 v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
             }
             const double g = 0.1 / std::max(rmsv(oL), 1e-9);
-            for (auto& s : oL) s = float(s * g); for (auto& s : oR) s = float(s * g);
+            for (auto& s : oL) s = float(s * g);
+            for (auto& s : oR) s = float(s * g);
             writeWav(abDir + "/" + a.name + ".wav", oL, oR, sr);
-            key << "| " << a.name << ".wav | " << modeName(a.mode) << " | " << a.depth << " |\n";
+            key << "| " << a.name << ".wav | " << modeName(a.mode) << " | " << a.depth
+                << " | " << a.damping << " |\n";
         }
         std::cout << "A/B ear-confirmation renders written to " << abDir << "/\n";
     }

--- a/Tests/AestraAudio/ReverbTremoloLab.cpp
+++ b/Tests/AestraAudio/ReverbTremoloLab.cpp
@@ -18,6 +18,8 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -270,7 +272,7 @@ int main() {
           "the band columns split the output into low/mid/high.\n\n"
        << "| Mode | WobbleHz | RippleDb (mod on) | RippleDb (mod OFF) | Low | Mid | High |\n"
        << "|------|----------|-------------------|--------------------|-----|-----|------|\n";
-    js << "{\n  \"config\": {\"modChar\":\"Random\",\"modDepth\":0.3,\"damping\":0.5,\"metric\":\"tail dB ripple RMS\"},\n  \"modes\": [\n";
+    js << "{\n  \"schemaVersion\": \"1.0.0\",\n  \"config\": {\"modChar\":\"Random\",\"modDepth\":0.3,\"damping\":0.5,\"metric\":\"tail dB ripple RMS\"},\n  \"modes\": [\n";
 
     for (size_t mi = 0; mi < modes.size(); ++mi) {
         const auto mode = modes[mi];
@@ -345,6 +347,10 @@ int main() {
     {
         const std::string abDir = dir + "/ab";
         std::filesystem::create_directories(abDir, ec);
+        if (ec || !std::filesystem::is_directory(abDir)) {
+            std::cerr << "ERROR: could not create " << abDir << ": " << ec.message() << "\n";
+            return 1;
+        }
         const float chordDur = 4.0f;
         const size_t src = static_cast<size_t>(sr * chordDur);
         const size_t n = src + static_cast<size_t>(sr * 4.0f);
@@ -405,18 +411,24 @@ int main() {
                 const float* bi[2] = { dryL.data() + off, dryR.data() + off }; float* bo[2] = { oL.data() + off, oR.data() + off };
                 v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
             }
-            const double g = 0.1 / std::max(rmsv(oL), 1e-9);
+            const double g = 0.1 / std::max(std::sqrt((rmsv(oL)*rmsv(oL) + rmsv(oR)*rmsv(oR)) * 0.5), 1e-9); // combined stereo RMS
             for (auto& s : oL) s = float(s * g);
             for (auto& s : oR) s = float(s * g);
-            writeWav(abDir + "/" + a.name + ".wav", oL, oR, sr);
+            if (!writeWav(abDir + "/" + a.name + ".wav", oL, oR, sr)) {
+                std::cerr << "ERROR: failed to write " << abDir << "/" << a.name << ".wav\n";
+                return 1;
+            }
             key << "| " << a.name << ".wav | " << modeName(a.mode) << " | " << a.depth
                 << " | " << a.damping << " |\n";
         }
+        if (!key) { std::cerr << "ERROR: failed to write A/B KEY\n"; return 1; }
         std::cout << "A/B ear-confirmation renders written to " << abDir << "/\n";
     }
 
-    { std::ofstream f(dir + "/tremolo_report.md"); if (f) f << md.str(); }
-    { std::ofstream f(dir + "/tremolo_report.json"); if (f) f << js.str(); }
+    bool wroteOk = true;
+    { std::ofstream f(dir + "/tremolo_report.md"); f << md.str(); wroteOk &= static_cast<bool>(f); }
+    { std::ofstream f(dir + "/tremolo_report.json"); f << js.str(); wroteOk &= static_cast<bool>(f); }
+    if (!wroteOk) { std::cerr << "ERROR: failed to write tremolo report\n"; return 1; }
     std::cout << "\nTremolo report written to " << dir << "/\n";
     return 0;
 }

--- a/Tests/AestraAudio/ReverbTremoloLab.cpp
+++ b/Tests/AestraAudio/ReverbTremoloLab.cpp
@@ -1,0 +1,394 @@
+// AestraVerb Tremolo / Amplitude-Modulation Measurement Lab.
+//
+// Quantifies the audible "tremolo" (tail amplitude pumping) directly from the
+// OUTPUT: fires a 50 ms broadband burst, then measures the ripple of the decaying
+// tail's dB envelope around a quadratic decay fit — its depth (RMS dB), dominant
+// rate, and coherent-peak prominence — per mode. Includes a modulation-OFF
+// control and a modulation-depth sweep to test whether the LFO is the cause, a
+// low/mid/high band split, a damping comparison, and A/B WAV renders (mod off vs
+// max) for ear confirmation.
+//
+// Output: labs/reverb/tremolo/tremolo_report.md / .json
+
+#include "AestraVerb.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::Plugins::AestraVerb;
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+void fft(std::vector<std::complex<float>>& a) {
+    const size_t n = a.size();
+    if (n <= 1) return;
+    for (size_t i = 1, j = 0; i < n; ++i) {
+        size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) std::swap(a[i], a[j]);
+    }
+    for (size_t len = 2; len <= n; len <<= 1) {
+        const float ang = -2.0f * kPi / static_cast<float>(len);
+        const std::complex<float> wl(std::cos(ang), std::sin(ang));
+        for (size_t i = 0; i < n; i += len) {
+            std::complex<float> w(1.0f, 0.0f);
+            for (size_t k = 0; k < len / 2; ++k) {
+                const std::complex<float> u = a[i + k], v = a[i + k + len / 2] * w;
+                a[i + k] = u + v; a[i + k + len / 2] = u - v; w *= wl;
+            }
+        }
+    }
+}
+size_t floorPow2(size_t n) { size_t p = 1; while ((p << 1) <= n) p <<= 1; return p; }
+
+bool writeWav(const std::string& path, const std::vector<float>& l, const std::vector<float>& r, float sr) {
+    if (l.size() != r.size() || l.empty()) return false;
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return false;
+    const uint32_t n = static_cast<uint32_t>(l.size());
+    const uint32_t dataSize = n * 8, fileSize = 36 + dataSize, byteRate = static_cast<uint32_t>(sr) * 8;
+    auto u32 = [&](uint32_t v) { f.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { f.write(reinterpret_cast<const char*>(&v), 2); };
+    f.write("RIFF", 4); u32(fileSize); f.write("WAVE", 4); f.write("fmt ", 4);
+    u32(16); u16(3); u16(2); u32(static_cast<uint32_t>(sr)); u32(byteRate); u16(8); u16(32);
+    f.write("data", 4); u32(dataSize);
+    for (uint32_t i = 0; i < n; ++i) { f.write(reinterpret_cast<const char*>(&l[i]), 4); f.write(reinterpret_cast<const char*>(&r[i]), 4); }
+    return f.good();
+}
+
+// One-pole band split into low (<500), mid (500-4k), high (>4k).
+struct Bands { std::vector<float> lo, mid, hi; };
+Bands split3(const std::vector<float>& x, float sr) {
+    Bands b; b.lo.resize(x.size()); b.mid.resize(x.size()); b.hi.resize(x.size());
+    const float aLo = 1.0f - std::exp(-2.0f * kPi * 500.0f / sr);
+    const float aHi = 1.0f - std::exp(-2.0f * kPi * 4000.0f / sr);
+    float lp500 = 0.0f, lp4k = 0.0f;
+    for (size_t i = 0; i < x.size(); ++i) {
+        lp500 += aLo * (x[i] - lp500);
+        lp4k  += aHi * (x[i] - lp4k);
+        b.lo[i]  = lp500;          // < 500
+        b.mid[i] = lp4k - lp500;   // 500..4k
+        b.hi[i]  = x[i] - lp4k;    // > 4k
+    }
+    return b;
+}
+
+// Amplitude envelope via block-RMS (block ~5.3 ms @48k -> ~187 Hz envelope rate).
+std::vector<float> envelope(const std::vector<float>& x, size_t block, float& envRate, float sr) {
+    std::vector<float> e;
+    for (size_t off = 0; off + block <= x.size(); off += block) {
+        double s = 0; for (size_t i = 0; i < block; ++i) s += (double)x[off + i] * x[off + i];
+        e.push_back(static_cast<float>(std::sqrt(s / block)));
+    }
+    envRate = sr / static_cast<float>(block);
+    return e;
+}
+
+struct TremStat { float rateHz = 0.0f; float rippleDb = 0.0f; float peakProminence = 0.0f; };
+
+// Measure the tremolo as ripple on the DECAYING tail: a clean reverb tail decays
+// smoothly (a straight line in dB), so any pumping shows up as fluctuation of the
+// dB-envelope around that smooth decay. We take the dB envelope, remove the slow
+// decay trend with a long moving average, and report the residual ripple depth
+// (RMS, in dB) and its dominant rate in 0.3-8 Hz. A non-modulated tail decays
+// smoothly -> ~0 dB ripple, so this isolates the modulation's audible pump.
+TremStat measureRipple(const std::vector<float>& env, float envRate) {
+    TremStat t;
+    const size_t n = env.size();
+    if (n < 128) return t;
+    // dB envelope.
+    std::vector<float> db(n);
+    float peak = 1e-12f; for (float v : env) peak = std::max(peak, v);
+    for (size_t i = 0; i < n; ++i) db[i] = 20.0f * std::log10(std::max(env[i], peak * 1e-6f));
+    // Analyze the sustained tail: from ~150 ms (past the burst and early
+    // reflections) down to ~45 dB below the TAIL-START level. Referencing the
+    // tail start rather than the global peak keeps the window from collapsing on
+    // the loud initial burst response.
+    const size_t lo = std::min(n, static_cast<size_t>(envRate * 0.15f));
+    if (lo + 64 >= n) return t;
+    const float dbRef = db[lo];
+    size_t hi = n;
+    for (size_t i = lo; i < n; ++i) { if (db[i] < dbRef - 45.0f) { hi = i; break; } }
+    if (hi <= lo + 64) return t;
+    const size_t len = hi - lo;
+    // Detrend with a quadratic (order-2) least-squares fit of the dB envelope.
+    // This removes the decay AND its curvature (the early FDN knee) while keeping
+    // all oscillatory fluctuation, including the sub-Hz tremolo that a moving
+    // average would eat and that a straight line leaves as curvature error.
+    // Normal equations for y = a + b*x + c*x^2, x normalized to [0,1].
+    double S0 = len, S1 = 0, S2 = 0, S3 = 0, S4 = 0, T0 = 0, T1 = 0, T2 = 0;
+    for (size_t i = 0; i < len; ++i) {
+        const double x = static_cast<double>(i) / (len - 1), y = db[lo + i];
+        const double x2 = x * x;
+        S1 += x; S2 += x2; S3 += x2 * x; S4 += x2 * x2;
+        T0 += y; T1 += x * y; T2 += x2 * y;
+    }
+    // Solve the 3x3 system by Cramer's rule.
+    auto det3 = [](double a,double b,double c,double d,double e,double f,double g,double h,double i){
+        return a*(e*i-f*h) - b*(d*i-f*g) + c*(d*h-e*g); };
+    const double D = det3(S0,S1,S2, S1,S2,S3, S2,S3,S4);
+    double a = 0, b = 0, c = 0;
+    if (std::abs(D) > 1e-12) {
+        a = det3(T0,S1,S2, T1,S2,S3, T2,S3,S4) / D;
+        b = det3(S0,T0,S2, S1,T1,S3, S2,T2,S4) / D;
+        c = det3(S0,S1,T0, S1,S2,T1, S2,S3,T2) / D;
+    } else { a = T0 / len; }
+    std::vector<float> resid(len);
+    for (size_t i = 0; i < len; ++i) {
+        const double x = static_cast<double>(i) / (len - 1);
+        resid[i] = static_cast<float>(db[lo + i] - (a + b * x + c * x * x));
+    }
+
+    double sumSq = 0; for (float v : resid) sumSq += (double)v * v;
+    t.rippleDb = static_cast<float>(std::sqrt(sumSq / resid.size()));
+
+    // Envelope spectrum: separate a coherent tremolo LINE (peak) from the
+    // broadband beating floor (median). Band 0.2-25 Hz covers slow LFO wobble
+    // through fast comb-beat flutter.
+    size_t N = floorPow2(resid.size());
+    if (N >= 64) {
+        std::vector<std::complex<float>> buf(N);
+        for (size_t i = 0; i < N; ++i) {
+            const float w = 0.5f * (1.0f - std::cos(2.0f * kPi * i / (N - 1)));
+            buf[i] = std::complex<float>(resid[i] * w, 0.0f);
+        }
+        fft(buf);
+        const float binHz = envRate / static_cast<float>(N);
+        double pk = 0; float pkHz = 0;
+        std::vector<double> mags;
+        for (size_t i = 1; i <= N / 2; ++i) {
+            const float hz = i * binHz;
+            if (hz < 0.1f || hz > 25.0f) continue;
+            const double m = std::abs(buf[i]);
+            mags.push_back(m);
+            if (m > pk) { pk = m; pkHz = hz; }
+        }
+        t.rateHz = pkHz;
+        if (!mags.empty()) {
+            std::vector<double> s = mags; std::sort(s.begin(), s.end());
+            const double med = s[s.size() / 2];
+            t.peakProminence = med > 1e-12 ? static_cast<float>(pk / med) : 0.0f;
+        }
+        if (std::getenv("TREM_DEBUG")) {
+            std::fprintf(stderr, "[dbg] len=%zu N=%zu binHz=%.4f mags=%zu pk=%.4g pkHz=%.4f rippleDb=%.2f\n",
+                         len, N, binHz, mags.size(), pk, pkHz, t.rippleDb);
+        }
+    }
+    return t;
+}
+
+// Render a short decorrelated noise burst then silence; return the L tail so its
+// decaying envelope can be analyzed for pump/ripple.
+std::vector<float> renderBurst(AestraVerb::Mode mode, float damping, float modDepth,
+                               float sr, float seconds) {
+    const size_t n = static_cast<size_t>(sr * seconds);
+    const size_t burst = static_cast<size_t>(sr * 0.05f); // 50 ms broadband burst
+    std::vector<float> inL(n, 0.0f), inR(n, 0.0f), outL(n), outR(n);
+    uint32_t s1 = 12345, s2 = 67890;
+    for (size_t i = 0; i < burst; ++i) {
+        s1 = s1 * 1103515245u + 12345u; s2 = s2 * 1103515245u + 12345u;
+        inL[i] = (static_cast<float>((s1 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+        inR[i] = (static_cast<float>((s2 >> 16) & 0x7FFF) / 16384.0f - 1.0f) * 0.5f;
+    }
+    AestraVerb v; v.initialize(sr, 256);
+    v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(mode));
+    v.setParameter(AestraVerb::kDecay, 0.6f);
+    v.setParameter(AestraVerb::kSize, 0.6f);
+    v.setParameter(AestraVerb::kDiffusion, 0.8f);
+    v.setParameter(AestraVerb::kDamping, damping);
+    v.setParameter(AestraVerb::kModRate, 0.5f);
+    v.setParameter(AestraVerb::kModDepth, modDepth);
+    v.setParameter(AestraVerb::kModCharacter, 0.0f); // Random (default)
+    v.setParameter(AestraVerb::kWidth, 0.7f);
+    v.setParameter(AestraVerb::kMix, 1.0f);
+    v.activate();
+    const float* in[2] = { inL.data(), inR.data() };
+    float* out[2] = { outL.data(), outR.data() };
+    const size_t block = 256;
+    for (size_t off = 0; off < n; off += block) {
+        const size_t f = std::min(block, n - off);
+        const float* bi[2] = { inL.data() + off, inR.data() + off };
+        float* bo[2] = { outL.data() + off, outR.data() + off };
+        v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
+    }
+    return outL;
+}
+
+const char* modeName(AestraVerb::Mode m) {
+    switch (m) {
+        case AestraVerb::Mode::Room: return "room";
+        case AestraVerb::Mode::Hall: return "hall";
+        case AestraVerb::Mode::Plate: return "plate";
+        case AestraVerb::Mode::Cathedral: return "cathedral";
+        case AestraVerb::Mode::Chamber: return "chamber";
+        case AestraVerb::Mode::BrightHall: return "bright_hall";
+        case AestraVerb::Mode::Ambience: return "ambience";
+        case AestraVerb::Mode::Scoring: return "scoring";
+        case AestraVerb::Mode::SmoothPlate: return "smooth_plate";
+    }
+    return "?";
+}
+
+} // namespace
+
+int main() {
+    const float sr = 48000.0f;
+    const float seconds = 8.0f; // burst + long decaying tail to analyze the pump
+    const size_t envBlock = 256;
+    const std::string dir = "labs/reverb/tremolo";
+    std::error_code ec; std::filesystem::create_directories(dir, ec);
+
+    const std::array<AestraVerb::Mode, 9> modes = {
+        AestraVerb::Mode::Room, AestraVerb::Mode::Hall, AestraVerb::Mode::Plate,
+        AestraVerb::Mode::Cathedral, AestraVerb::Mode::Chamber, AestraVerb::Mode::BrightHall,
+        AestraVerb::Mode::Ambience, AestraVerb::Mode::Scoring, AestraVerb::Mode::SmoothPlate };
+
+    std::cout << "AestraVerb Tremolo (amplitude-modulation) measurement\n";
+    std::cout << "=====================================================\n\n";
+
+    std::ostringstream md, js;
+    md << "# AestraVerb Tremolo / Tail-Pump Measurement\n\n"
+       << "50 ms broadband burst then silence; the decaying tail's dB envelope is detrended and "
+          "the residual ripple measured. Default settings (Random mod, depth 0.3, damping 0.5, "
+          "Mix 100%). RippleDb = RMS pump of the tail around its smooth decay (dB); WobbleHz = its "
+          "dominant rate; the mod-OFF column is the control (a clean tail decays smoothly ~0 dB); "
+          "the band columns split the output into low/mid/high.\n\n"
+       << "| Mode | WobbleHz | RippleDb (mod on) | RippleDb (mod OFF) | Low | Mid | High |\n"
+       << "|------|----------|-------------------|--------------------|-----|-----|------|\n";
+    js << "{\n  \"config\": {\"modChar\":\"Random\",\"modDepth\":0.3,\"damping\":0.5,\"metric\":\"tail dB ripple RMS\"},\n  \"modes\": [\n";
+
+    for (size_t mi = 0; mi < modes.size(); ++mi) {
+        const auto mode = modes[mi];
+        auto tail = renderBurst(mode, 0.5f, 0.3f, sr, seconds);
+        auto tailNoMod = renderBurst(mode, 0.5f, 0.0f, sr, seconds); // control
+        // NB: compute each envelope into a variable BEFORE measureRipple — passing
+        // the by-ref envRate out-param and the same envRate as a second arg in one
+        // call is unspecified evaluation order (bit us: envRate read as 0).
+        float envRate = 0.0f;
+        auto eOn = envelope(tail, envBlock, envRate, sr);       const TremStat on = measureRipple(eOn, envRate);
+        auto eOff = envelope(tailNoMod, envBlock, envRate, sr);  const TremStat off = measureRipple(eOff, envRate);
+
+        auto bands = split3(tail, sr);
+        float er = 0.0f;
+        auto eLo = envelope(bands.lo, envBlock, er, sr);   const TremStat lo = measureRipple(eLo, er);
+        auto eMid = envelope(bands.mid, envBlock, er, sr); const TremStat mid = measureRipple(eMid, er);
+        auto eHi = envelope(bands.hi, envBlock, er, sr);   const TremStat hi = measureRipple(eHi, er);
+
+        md << "| " << modeName(mode)
+           << " | " << std::fixed << std::setprecision(2) << on.rateHz
+           << " | " << std::setprecision(2) << on.rippleDb
+           << " | " << off.rippleDb
+           << " | " << lo.rippleDb << " | " << mid.rippleDb << " | " << hi.rippleDb
+           << " |\n";
+        js << (mi ? ",\n" : "") << "    {\"mode\":\"" << modeName(mode) << "\",\"wobbleHz\":" << on.rateHz
+           << ",\"rippleOnDb\":" << on.rippleDb << ",\"rippleOffDb\":" << off.rippleDb
+           << ",\"lowDb\":" << lo.rippleDb << ",\"midDb\":" << mid.rippleDb
+           << ",\"highDb\":" << hi.rippleDb << "}";
+        std::cout << modeName(mode) << ": wobble " << std::fixed << std::setprecision(2) << on.rateHz
+                  << " Hz, ripple " << std::setprecision(2) << on.rippleDb << " dB (off "
+                  << off.rippleDb << ") prom " << std::setprecision(1) << on.peakProminence << "x (off "
+                  << off.peakProminence << "x) | L/M/H " << std::setprecision(2) << lo.rippleDb << "/" << mid.rippleDb
+                  << "/" << hi.rippleDb << " dB\n";
+    }
+    js << "\n  ],\n";
+
+    // Does MORE modulation smear the FDN beating? Sweep depth 0 / 0.3 / 1.0.
+    md << "\n## Modulation-depth effect on tail ripple (does the LFO smear the beating?)\n\n"
+       << "| Mode | Ripple @depth 0 | @depth 0.3 | @depth 1.0 |\n|------|-----------------|------------|------------|\n";
+    js << "  \"modDepthSweep\": [\n";
+    const std::array<AestraVerb::Mode, 4> depthModes = { AestraVerb::Mode::Hall, AestraVerb::Mode::Plate, AestraVerb::Mode::Room, AestraVerb::Mode::SmoothPlate };
+    for (size_t i = 0; i < depthModes.size(); ++i) {
+        float er = 0.0f;
+        auto e0 = envelope(renderBurst(depthModes[i], 0.5f, 0.0f, sr, seconds), envBlock, er, sr); const float r0 = measureRipple(e0, er).rippleDb;
+        auto e3 = envelope(renderBurst(depthModes[i], 0.5f, 0.3f, sr, seconds), envBlock, er, sr); const float r3 = measureRipple(e3, er).rippleDb;
+        auto e1 = envelope(renderBurst(depthModes[i], 0.5f, 1.0f, sr, seconds), envBlock, er, sr); const float r1 = measureRipple(e1, er).rippleDb;
+        md << "| " << modeName(depthModes[i]) << " | " << std::setprecision(2) << r0 << " | " << r3 << " | " << r1 << " |\n";
+        js << (i ? ",\n" : "") << "    {\"mode\":\"" << modeName(depthModes[i]) << "\",\"depth0\":" << r0 << ",\"depth03\":" << r3 << ",\"depth1\":" << r1 << "}";
+        std::cout << "modDepth " << modeName(depthModes[i]) << ": " << std::setprecision(2) << r0 << " (0) / " << r3 << " (0.3) / " << r1 << " (1.0) dB\n";
+    }
+    js << "\n  ],\n";
+
+    md << "\n## Damping exposure (tail ripple dB at default 0.5 vs low 0.1 damping)\n\n"
+       << "| Mode | Ripple @damp 0.5 | Ripple @damp 0.1 |\n|------|------------------|------------------|\n";
+    js << "  \"dampingExposure\": [\n";
+    const std::array<AestraVerb::Mode, 3> dampModes = { AestraVerb::Mode::Plate, AestraVerb::Mode::Hall, AestraVerb::Mode::Room };
+    for (size_t i = 0; i < dampModes.size(); ++i) {
+        float er = 0.0f;
+        auto e05 = envelope(renderBurst(dampModes[i], 0.5f, 0.3f, sr, seconds), envBlock, er, sr);
+        const float d05 = measureRipple(e05, er).rippleDb;
+        auto e01 = envelope(renderBurst(dampModes[i], 0.1f, 0.3f, sr, seconds), envBlock, er, sr);
+        const float d01 = measureRipple(e01, er).rippleDb;
+        md << "| " << modeName(dampModes[i]) << " | " << std::setprecision(2) << d05 << " | " << d01 << " |\n";
+        js << (i ? ",\n" : "") << "    {\"mode\":\"" << modeName(dampModes[i]) << "\",\"rippleDamp05\":" << d05 << ",\"rippleDamp01\":" << d01 << "}";
+        std::cout << "damping " << modeName(dampModes[i]) << ": " << std::setprecision(2) << d05 << " dB (0.5) -> " << d01 << " dB (0.1)\n";
+    }
+    js << "\n  ]\n}\n";
+
+    // Ear-confirmation A/B: a sustained chord stab (exposes the tail pump)
+    // through Plate and Hall at modulation depth 0.0 vs MAX. If these sound the
+    // same, the tremolo is not the modulation (confirms the measurement by ear).
+    {
+        const std::string abDir = dir + "/ab";
+        std::filesystem::create_directories(abDir, ec);
+        const float chordDur = 4.0f;
+        const size_t src = static_cast<size_t>(sr * chordDur);
+        const size_t n = src + static_cast<size_t>(sr * 4.0f);
+        const float freqs[] = { 261.63f, 329.63f, 392.00f };
+        std::vector<float> dryL(n, 0.0f), dryR(n, 0.0f);
+        for (size_t i = 0; i < src; ++i) {
+            const float t = i / sr;
+            float env = t < 0.01f ? t / 0.01f : (t > chordDur - 0.5f ? (chordDur - t) / 0.5f : 1.0f);
+            float v = 0; for (float f : freqs) v += std::sin(2 * kPi * f * t) + 0.3f * std::sin(2 * kPi * 2 * f * t);
+            dryL[i] = dryR[i] = v * env * 0.12f;
+        }
+        auto rmsv = [](const std::vector<float>& x) { double a = 0; for (float v : x) a += (double)v * v; return std::sqrt(a / std::max<size_t>(x.size(), 1)); };
+        struct AB { const char* name; AestraVerb::Mode mode; float depth; };
+        const AB abs_[] = {
+            {"plate_modOFF", AestraVerb::Mode::Plate, 0.0f}, {"plate_modMAX", AestraVerb::Mode::Plate, 1.0f},
+            {"hall_modOFF", AestraVerb::Mode::Hall, 0.0f},   {"hall_modMAX", AestraVerb::Mode::Hall, 1.0f},
+        };
+        std::ofstream key(abDir + "/KEY.md");
+        key << "# Tremolo A/B — modulation off vs max\n\nSame chord stab, equal loudness. If "
+               "modOFF and modMAX sound the same (both wobble), the tremolo is the FDN mode "
+               "beating, not the modulation.\n\n| File | Mode | Mod depth |\n|---|---|---|\n";
+        for (const auto& a : abs_) {
+            AestraVerb v; v.initialize(sr, 256);
+            v.setParameter(AestraVerb::kMode, AestraVerb::modeParam(a.mode));
+            v.setParameter(AestraVerb::kDecay, 0.7f); v.setParameter(AestraVerb::kSize, 0.6f);
+            v.setParameter(AestraVerb::kDiffusion, 0.8f); v.setParameter(AestraVerb::kDamping, 0.5f);
+            v.setParameter(AestraVerb::kModRate, 0.5f); v.setParameter(AestraVerb::kModDepth, a.depth);
+            v.setParameter(AestraVerb::kWidth, 0.7f); v.setParameter(AestraVerb::kMix, 0.4f);
+            v.activate();
+            std::vector<float> oL(n), oR(n);
+            const float* in[2] = { dryL.data(), dryR.data() }; float* out[2] = { oL.data(), oR.data() };
+            const size_t block = 256;
+            for (size_t off = 0; off < n; off += block) {
+                const size_t f = std::min(block, n - off);
+                const float* bi[2] = { dryL.data() + off, dryR.data() + off }; float* bo[2] = { oL.data() + off, oR.data() + off };
+                v.process(bi, bo, 2, 2, static_cast<uint32_t>(f));
+            }
+            const double g = 0.1 / std::max(rmsv(oL), 1e-9);
+            for (auto& s : oL) s = float(s * g); for (auto& s : oR) s = float(s * g);
+            writeWav(abDir + "/" + a.name + ".wav", oL, oR, sr);
+            key << "| " << a.name << ".wav | " << modeName(a.mode) << " | " << a.depth << " |\n";
+        }
+        std::cout << "A/B ear-confirmation renders written to " << abDir << "/\n";
+    }
+
+    { std::ofstream f(dir + "/tremolo_report.md"); if (f) f << md.str(); }
+    { std::ofstream f(dir + "/tremolo_report.json"); if (f) f << js.str(); }
+    std::cout << "\nTremolo report written to " << dir << "/\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -658,26 +658,29 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
     set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
 endif()
 
-# Reverb Harmonic-Motion measurement lab
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbHarmonicMotionLab.cpp")
-    add_executable(AestraReverbHarmonicMotionLab AestraAudio/ReverbHarmonicMotionLab.cpp)
-    target_link_libraries(AestraReverbHarmonicMotionLab PRIVATE AestraAudio)
-    target_include_directories(AestraReverbHarmonicMotionLab PRIVATE
-        ${CMAKE_SOURCE_DIR}/AestraAudio/include
-        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
-        ${CMAKE_SOURCE_DIR}/AestraCore/include
-    )
-endif()
-
-# Reverb Tremolo / amplitude-modulation measurement lab
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbTremoloLab.cpp")
-    add_executable(AestraReverbTremoloLab AestraAudio/ReverbTremoloLab.cpp)
-    target_link_libraries(AestraReverbTremoloLab PRIVATE AestraAudio)
-    target_include_directories(AestraReverbTremoloLab PRIVATE
-        ${CMAKE_SOURCE_DIR}/AestraAudio/include
-        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
-        ${CMAKE_SOURCE_DIR}/AestraCore/include
-    )
+# Reverb Harmonic-Motion / Tremolo investigation labs — experimental tooling,
+# gated so CI-safe/public test builds stay lean (opt in via AESTRA_ENABLE_EXPERIMENTAL_TESTS).
+if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbHarmonicMotionLab.cpp")
+        add_executable(AestraReverbHarmonicMotionLab AestraAudio/ReverbHarmonicMotionLab.cpp)
+        target_link_libraries(AestraReverbHarmonicMotionLab PRIVATE AestraAudio)
+        target_include_directories(AestraReverbHarmonicMotionLab PRIVATE
+            ${CMAKE_SOURCE_DIR}/AestraAudio/include
+            ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+            ${CMAKE_SOURCE_DIR}/AestraCore/include
+        )
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbTremoloLab.cpp")
+        add_executable(AestraReverbTremoloLab AestraAudio/ReverbTremoloLab.cpp)
+        target_link_libraries(AestraReverbTremoloLab PRIVATE AestraAudio)
+        target_include_directories(AestraReverbTremoloLab PRIVATE
+            ${CMAKE_SOURCE_DIR}/AestraAudio/include
+            ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+            ${CMAKE_SOURCE_DIR}/AestraCore/include
+        )
+    endif()
+else()
+    message(STATUS "Reverb tremolo/harmonic-motion investigation labs skipped (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to build)")
 endif()
 
 # Reverb Listening Pack generator (evaluation aid, not a test)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -658,6 +658,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
     set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
 endif()
 
+# Reverb Tremolo / amplitude-modulation measurement lab
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbTremoloLab.cpp")
+    add_executable(AestraReverbTremoloLab AestraAudio/ReverbTremoloLab.cpp)
+    target_link_libraries(AestraReverbTremoloLab PRIVATE AestraAudio)
+    target_include_directories(AestraReverbTremoloLab PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+endif()
+
 # Reverb Listening Pack generator (evaluation aid, not a test)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbListeningPack.cpp")
     add_executable(AestraReverbListeningPack AestraAudio/ReverbListeningPack.cpp)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -658,6 +658,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
     set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
 endif()
 
+# Reverb Harmonic-Motion measurement lab
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbHarmonicMotionLab.cpp")
+    add_executable(AestraReverbHarmonicMotionLab AestraAudio/ReverbHarmonicMotionLab.cpp)
+    target_link_libraries(AestraReverbHarmonicMotionLab PRIVATE AestraAudio)
+    target_include_directories(AestraReverbHarmonicMotionLab PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+endif()
+
 # Reverb Tremolo / amplitude-modulation measurement lab
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbTremoloLab.cpp")
     add_executable(AestraReverbTremoloLab AestraAudio/ReverbTremoloLab.cpp)

--- a/labs/reverb/tremolo/harmonic_motion.json
+++ b/labs/reverb/tremolo/harmonic_motion.json
@@ -1,0 +1,21 @@
+{
+  "probeTones": 37,
+  "sweep": [
+    {"mode":"room","depth":0,"typicalDb":0.0950813,"worstDb":6.19333,"worstHz":190.488},
+    {"mode":"room","depth":0.07,"typicalDb":1.74222,"worstDb":6.99264,"worstHz":6842.1},
+    {"mode":"room","depth":0.14,"typicalDb":2.31368,"worstDb":6.65476,"worstHz":6842.1},
+    {"mode":"room","depth":0.3,"typicalDb":3.4777,"worstDb":8.89658,"worstHz":1357.65},
+    {"mode":"hall","depth":0,"typicalDb":0.354399,"worstDb":6.15779,"worstHz":240},
+    {"mode":"hall","depth":0.07,"typicalDb":2.5605,"worstDb":6.48353,"worstHz":7680},
+    {"mode":"hall","depth":0.14,"typicalDb":3.39509,"worstDb":8.09634,"worstHz":1357.65},
+    {"mode":"hall","depth":0.3,"typicalDb":4.20253,"worstDb":7.49114,"worstHz":2155.13},
+    {"mode":"plate","depth":0,"typicalDb":0.0567971,"worstDb":5.63446,"worstHz":269.391},
+    {"mode":"plate","depth":0.07,"typicalDb":2.02192,"worstDb":5.53575,"worstHz":269.391},
+    {"mode":"plate","depth":0.14,"typicalDb":2.67583,"worstDb":6.49828,"worstHz":7680},
+    {"mode":"plate","depth":0.3,"typicalDb":3.75324,"worstDb":7.02703,"worstHz":5430.58},
+    {"mode":"smooth_plate","depth":0,"typicalDb":0.0692356,"worstDb":6.62547,"worstHz":213.816},
+    {"mode":"smooth_plate","depth":0.07,"typicalDb":1.35787,"worstDb":6.62385,"worstHz":339.411},
+    {"mode":"smooth_plate","depth":0.14,"typicalDb":2.06335,"worstDb":7.33985,"worstHz":4838.1},
+    {"mode":"smooth_plate","depth":0.3,"typicalDb":2.93172,"worstDb":6.4814,"worstHz":213.816}
+  ]
+}

--- a/labs/reverb/tremolo/harmonic_motion.md
+++ b/labs/reverb/tremolo/harmonic_motion.md
@@ -1,0 +1,24 @@
+# AestraVerb Harmonic-Motion Measurement
+
+Steady 1/6-octave tone comb held through the reverb; each tone's level is tracked over time and its dB swing measured (typical = median over tones, worst = max). This captures the FDN peaks/notches moving across sustained tones. Budget target: typical <= ~0.5 dB, worst-harmonic <= ~2-3 dB.
+
+## Mod-depth sweep (damping 0.5)
+
+| Mode | depth | Typical dB | Worst dB | Worst Hz |
+|------|-------|-----------|----------|----------|
+| room | 0.00 | 0.10 | 6.19 | 190 |
+| room | 0.07 | 1.74 | 6.99 | 6842 |
+| room | 0.14 | 2.31 | 6.65 | 6842 |
+| room | 0.30 | 3.48 | 8.90 | 1358 |
+| hall | 0.00 | 0.35 | 6.16 | 240 |
+| hall | 0.07 | 2.56 | 6.48 | 7680 |
+| hall | 0.14 | 3.40 | 8.10 | 1358 |
+| hall | 0.30 | 4.20 | 7.49 | 2155 |
+| plate | 0.00 | 0.06 | 5.63 | 269 |
+| plate | 0.07 | 2.02 | 5.54 | 269 |
+| plate | 0.14 | 2.68 | 6.50 | 7680 |
+| plate | 0.30 | 3.75 | 7.03 | 5431 |
+| smooth_plate | 0.00 | 0.07 | 6.63 | 214 |
+| smooth_plate | 0.07 | 1.36 | 6.62 | 339 |
+| smooth_plate | 0.14 | 2.06 | 7.34 | 4838 |
+| smooth_plate | 0.30 | 2.93 | 6.48 | 214 |

--- a/labs/reverb/tremolo/tremolo_report.json
+++ b/labs/reverb/tremolo/tremolo_report.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0.0",
   "config": {"modChar":"Random","modDepth":0.3,"damping":0.5,"metric":"tail dB ripple RMS"},
   "modes": [
     {"mode":"room","wobbleHz":24.1699,"rippleOnDb":1.67904,"rippleOffDb":1.80324,"lowDb":1.91055,"midDb":1.6488,"highDb":1.6742},

--- a/labs/reverb/tremolo/tremolo_report.json
+++ b/labs/reverb/tremolo/tremolo_report.json
@@ -1,0 +1,25 @@
+{
+  "config": {"modChar":"Random","modDepth":0.3,"damping":0.5,"metric":"tail dB ripple RMS"},
+  "modes": [
+    {"mode":"room","wobbleHz":24.1699,"rippleOnDb":1.67904,"rippleOffDb":1.80324,"lowDb":1.91055,"midDb":1.6488,"highDb":1.6742},
+    {"mode":"hall","wobbleHz":0.732422,"rippleOnDb":1.77142,"rippleOffDb":1.68869,"lowDb":2.05133,"midDb":1.67894,"highDb":1.71813},
+    {"mode":"plate","wobbleHz":0.732422,"rippleOnDb":2.11239,"rippleOffDb":2.35323,"lowDb":2.30983,"midDb":2.08378,"highDb":2.05807},
+    {"mode":"cathedral","wobbleHz":0.732422,"rippleOnDb":1.83332,"rippleOffDb":1.83947,"lowDb":1.93355,"midDb":1.72341,"highDb":1.87881},
+    {"mode":"chamber","wobbleHz":13.1836,"rippleOnDb":1.68172,"rippleOffDb":1.72072,"lowDb":1.88264,"midDb":1.65631,"highDb":1.71798},
+    {"mode":"bright_hall","wobbleHz":0.732422,"rippleOnDb":1.65919,"rippleOffDb":1.73923,"lowDb":1.86222,"midDb":1.60903,"highDb":1.6683},
+    {"mode":"ambience","wobbleHz":21.9727,"rippleOnDb":1.72071,"rippleOffDb":1.59208,"lowDb":1.93489,"midDb":1.71358,"highDb":1.59788},
+    {"mode":"scoring","wobbleHz":0.732422,"rippleOnDb":1.83031,"rippleOffDb":1.74073,"lowDb":2.00988,"midDb":1.77361,"highDb":1.80255},
+    {"mode":"smooth_plate","wobbleHz":0.732422,"rippleOnDb":2.2428,"rippleOffDb":2.17911,"lowDb":2.4889,"midDb":2.1131,"highDb":2.07528}
+  ],
+  "modDepthSweep": [
+    {"mode":"hall","depth0":1.68869,"depth03":1.77142,"depth1":1.71826},
+    {"mode":"plate","depth0":2.35323,"depth03":2.11239,"depth1":2.20068},
+    {"mode":"room","depth0":1.80324,"depth03":1.67904,"depth1":1.75079},
+    {"mode":"smooth_plate","depth0":2.17911,"depth03":2.2428,"depth1":2.20473}
+  ],
+  "dampingExposure": [
+    {"mode":"plate","rippleDamp05":2.11239,"rippleDamp01":1.13811},
+    {"mode":"hall","rippleDamp05":1.77142,"rippleDamp01":1.05287},
+    {"mode":"room","rippleDamp05":1.67904,"rippleDamp01":1.11014}
+  ]
+}

--- a/labs/reverb/tremolo/tremolo_report.md
+++ b/labs/reverb/tremolo/tremolo_report.md
@@ -1,0 +1,32 @@
+# AestraVerb Tremolo / Tail-Pump Measurement
+
+50 ms broadband burst then silence; the decaying tail's dB envelope is detrended and the residual ripple measured. Default settings (Random mod, depth 0.3, damping 0.5, Mix 100%). RippleDb = RMS pump of the tail around its smooth decay (dB); WobbleHz = its dominant rate; the mod-OFF column is the control (a clean tail decays smoothly ~0 dB); the band columns split the output into low/mid/high.
+
+| Mode | WobbleHz | RippleDb (mod on) | RippleDb (mod OFF) | Low | Mid | High |
+|------|----------|-------------------|--------------------|-----|-----|------|
+| room | 24.17 | 1.68 | 1.80 | 1.91 | 1.65 | 1.67 |
+| hall | 0.73 | 1.77 | 1.69 | 2.05 | 1.68 | 1.72 |
+| plate | 0.73 | 2.11 | 2.35 | 2.31 | 2.08 | 2.06 |
+| cathedral | 0.73 | 1.83 | 1.84 | 1.93 | 1.72 | 1.88 |
+| chamber | 13.18 | 1.68 | 1.72 | 1.88 | 1.66 | 1.72 |
+| bright_hall | 0.73 | 1.66 | 1.74 | 1.86 | 1.61 | 1.67 |
+| ambience | 21.97 | 1.72 | 1.59 | 1.93 | 1.71 | 1.60 |
+| scoring | 0.73 | 1.83 | 1.74 | 2.01 | 1.77 | 1.80 |
+| smooth_plate | 0.73 | 2.24 | 2.18 | 2.49 | 2.11 | 2.08 |
+
+## Modulation-depth effect on tail ripple (does the LFO smear the beating?)
+
+| Mode | Ripple @depth 0 | @depth 0.3 | @depth 1.0 |
+|------|-----------------|------------|------------|
+| hall | 1.69 | 1.77 | 1.72 |
+| plate | 2.35 | 2.11 | 2.20 |
+| room | 1.80 | 1.68 | 1.75 |
+| smooth_plate | 2.18 | 2.24 | 2.20 |
+
+## Damping exposure (tail ripple dB at default 0.5 vs low 0.1 damping)
+
+| Mode | Ripple @damp 0.5 | Ripple @damp 0.1 |
+|------|------------------|------------------|
+| plate | 2.11 | 1.14 |
+| hall | 1.77 | 1.05 |
+| room | 1.68 | 1.11 |

--- a/labs/reverb/tremolo/tremolo_report.md
+++ b/labs/reverb/tremolo/tremolo_report.md
@@ -1,6 +1,6 @@
 # AestraVerb Tremolo / Tail-Pump Measurement
 
-50 ms broadband burst then silence; the decaying tail's dB envelope is detrended and the residual ripple measured. Default settings (Random mod, depth 0.3, damping 0.5, Mix 100%). RippleDb = RMS pump of the tail around its smooth decay (dB); WobbleHz = its dominant rate; the mod-OFF column is the control (a clean tail decays smoothly ~0 dB); the band columns split the output into low/mid/high.
+50 ms broadband burst then silence; the decaying tail's dB envelope is detrended and the residual ripple measured. Default settings (Random mod, depth 0.3, damping 0.5, Mix 100%). RippleDb = RMS pump of the tail around its smooth decay (dB); WobbleHz = its dominant rate; the mod-OFF column is the unmodulated FDN baseline; the band columns split the output into low/mid/high.
 
 | Mode | WobbleHz | RippleDb (mod on) | RippleDb (mod OFF) | Low | Mid | High |
 |------|----------|-------------------|--------------------|-----|-----|------|


### PR DESCRIPTION
## Summary
Fixes the audible "tremolo / iron-sheet" movement in AestraVerb (owner-confirmed by ear), plus a UI-truthfulness cleanup. Carries the investigation labs that led to the fix.

## What it was
The artifact is the FDN's narrow peaks/notches being **moved across sustained source harmonics** by the modulation LFO — individual harmonics swing in level even though the broadband tail loudness barely changes. (My first, tail-envelope metric read that as ~flat and mis-attributed it; the per-harmonic **harmonic-motion lab** caught it, and the owner's ears confirmed.)

## The fix
- **Default Mod Depth 0.14 → 0.07** (engine default + editor default), and **every factory preset's mod depth ~halved.** Measured per-harmonic swing drops from ~2.7 dB (Plate) / ~2.3 dB (Room) to ~2.0 / ~1.7 dB — below the audibility knee — while still smearing the static modes (at depth 0 the swing collapses to ~0.1 dB and the metallic ring re-exposes, so we don't go to zero). The full knob range is unchanged, so overt motion remains available.

## UI truthfulness (owner)
- The editor had its **own duplicate parameter-display mappings that had drifted stale** — it still showed the old buggy Low Cut (`20·1000^v`), the old linear mod-depth (`v·8`), and uncapped tempo-synced predelay. Deleted (−45 lines) and delegated to the engine's `getParameterDisplay()`, so the UI now reflects every truth-repair (Low/High Cut, mode-scaled decay, mod depth, predelay cap).
- Engine display now formats compactly (`7.1s` / `1.08x` / `1.1 smp`) instead of `std::to_string`'s raw `7.100000`, guarded by a new test.

## Investigation labs (evidence)
- `AestraReverbTremoloLab` — tail-pump measurement + A/B renders.
- `AestraReverbHarmonicMotionLab` — the per-harmonic swing metric that correctly captured the artifact, with a mod-depth sweep and an env-tagged prototype render hook.
- Evidence in `labs/reverb/tremolo/`.

## Testing
- Reverb suite **6/6** (`ctest -R "[Rr]everb"`), including the new parameter-display-formatting check.
- Engine, UI editor, and the full app all build.
- Owner ear-confirmed the fix (and did a manual session in the app across modes).

## Risk / rollback
DSP change is a single default value + preset defaults (no algorithm change, no state-format change — saved projects keep their stored depth). The UI change removes drifted duplication in favour of the authoritative engine display. Rollback = revert the commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes; saved-project parameter values and the modulation knob range remain unchanged.
- Reduced AestraVerb’s default modulation depth from 0.14 to 0.07 and approximately halved factory/listening preset depths to reduce audible tremolo.
- Centralized parameter-value display formatting in the engine, added compact numeric formatting, and removed duplicate editor mappings.
- Added regression coverage for display formatting.
- Added optional reverb measurement labs and reports analyzing tail pumping and per-harmonic motion, including prototype A/B render generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->