### PR TITLE
test(ui): fix stale NUITextInputLayoutTest single-line Y expectation (#458)

### DIFF
--- a/Tests/AestraUI/NUITextInputLayoutTest.cpp
+++ b/Tests/AestraUI/NUITextInputLayoutTest.cpp
@@ -182,7 +182,12 @@ static void test_getTextPosition_widget_space() {
     NUIPoint pos2 = input.callGetTextPosition(2);
 
     ASSERT(pos0.x == 10.0f + 8.0f + 0.0f, "char 0 x = bounds.x + padding + charX[0]");
-    ASSERT(pos0.y == 20.0f + 8.0f + 0.0f, "char 0 y = bounds.y + padding + line.y");
+    // Y must equal the line's actual render Y — the single source of truth for
+    // where the text is drawn. This input is single-line, and single-line text is
+    // vertically centered within the widget (getLineRenderY), NOT top-aligned at
+    // bounds.y + padding. Asserting against getLineRenderY keeps this a real
+    // regression guard while staying correct for the centered single-line path.
+    ASSERT(pos0.y == input.callGetLineRenderY(lines[0]), "char 0 y = line render Y (centered for single-line)");
     ASSERT(pos2.x == 10.0f + 8.0f + 10.0f, "char 2 x = bounds.x + padding + charX[2]");
     PASS("getTextPosition returns widget-space coordinates");
 }


### PR DESCRIPTION
## Summary

Fixes the long-standing `NUITextInputLayoutTest` failure (1/145 in the always-on suite).

`test_getTextPosition_widget_space` builds a **single-line** input but asserts the **multiline** Y formula `bounds.y + padding + line.y`. Single-line text is vertically *centered* within the widget — `getLineRenderY` was deliberately changed to do this in `ccd05f7d` ("use the same vertical centering as drawText") so the caret/char position tracks where the text is actually drawn. The assertion has been stale ever since.

The fix asserts `getTextPosition(0).y == getLineRenderY(lines[0])` — the actual source of truth for the draw position — so the case stays a genuine regression guard while being correct for the centered single-line path. The X assertions (widget-space offset) are unchanged.

## Why

A stale test expectation, not a layout regression. Confirmed via `git log -L` on the single-line branch of `getLineRenderY`: it originally returned the top-aligned formula (matching the old assertion) and was intentionally switched to vertical centering later.

## Testing

- `build-linux/Tests/NUITextInputLayoutTest` → **All 10 tests passed** (was 9/10).
- `ctest -R NUITextInput` → 100% pass.
- No production code touched — test-only change.

## Docs updated?

No.

## Risk / rollback

Minimal — test-only. Rollback = revert the single commit.

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `NUITextInputLayoutTest` to validate single-line text Y positions using the rendered line position.
- Corrects a stale expectation that used a multiline layout formula; X-coordinate checks remain unchanged.
- Test-only change with no public API impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->