### PR TITLE
feat(audio): wire master-bus DC removal to the settings toggle (#376)

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -9,6 +9,7 @@
 #include "AudioTelemetry.h"
 #include "ChannelSlotMap.h"
 #include "ContinuousParamBuffer.h"
+#include "DSP/DCBlocker.h"
 #include "DSP/TruePeakMeter.h"
 #include "EngineState.h"
 #include "GarbageCollector.h"
@@ -305,6 +306,11 @@ public:
     void setSafetyLimiterEnabled(bool enabled) { m_safetyLimiterEnabled.store(enabled, std::memory_order_relaxed); }
     /** @brief Check whether the master safety limiter is enabled. */
     bool isSafetyLimiterEnabled() const { return m_safetyLimiterEnabled.load(std::memory_order_relaxed); }
+
+    /** @brief Enable or disable master-bus DC removal (one-pole DC blocker). Default: off. */
+    void setDCRemovalEnabled(bool enabled) { m_dcRemovalEnabled.store(enabled, std::memory_order_relaxed); }
+    /** @brief Check whether master-bus DC removal is enabled. */
+    bool isDCRemovalEnabled() const { return m_dcRemovalEnabled.load(std::memory_order_relaxed); }
 
     /** @brief Enable or disable the metronome. */
     void setMetronomeEnabled(bool enabled) { m_metronomeEngine.setEnabled(enabled); }
@@ -698,19 +704,8 @@ private:
         return x * (27.0 + x2) / (27.0 + 9.0 * x2);
     }
 
-    // DC blocker (double precision)
-    struct DCBlockerD {
-        double x1{0.0};
-        double y1{0.0};
-        static constexpr double R = 0.9997; // Slightly more aggressive
-
-        inline double process(double x) {
-            double y = x - x1 + R * y1;
-            x1 = x;
-            y1 = y;
-            return y;
-        }
-    };
+    // DC blocker (double precision) — shared one-pole, see DSP/DCBlocker.h
+    using DCBlockerD = DCBlocker;
 
     AudioCommandQueue m_commandQueue;
     AudioTelemetry m_telemetry;
@@ -899,6 +894,14 @@ private:
     SmoothedParamD m_smoothedMasterGain;
     MasterSafetyLimiter m_safetyLimiter;
     std::atomic<bool> m_safetyLimiterEnabled{true};
+
+    // Master-bus DC removal (off by default; see setDCRemovalEnabled).
+    // m_dcRemovalPrevOn is RT-thread-only bookkeeping used to clear the blocker
+    // state on the off->on transition so enabling never injects a stale-state step.
+    std::atomic<bool> m_dcRemovalEnabled{false};
+    DCBlockerD m_dcBlockerL;
+    DCBlockerD m_dcBlockerR;
+    bool m_dcRemovalPrevOn{false};
 
     // Peak detection
     std::atomic<float> m_peakL{0.0f};

--- a/AestraAudio/include/DSP/DCBlocker.h
+++ b/AestraAudio/include/DSP/DCBlocker.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// DCBlocker — one-pole DC-blocking high-pass filter (double precision).
+//
+//   y[n] = x[n] - x[n-1] + R * y[n-1]
+//
+// R sits just below 1.0, giving a very low corner frequency: the filter removes
+// a constant (DC) offset and sub-sonic drift while leaving the audible band
+// essentially untouched. State is per-instance, so use one per channel.
+//
+// Real-time safe: no allocation, no locks, no branches in process().
+
+namespace Aestra {
+namespace Audio {
+
+struct DCBlocker {
+    double x1{0.0};
+    double y1{0.0};
+    static constexpr double R = 0.9997;
+
+    inline double process(double x) {
+        double y = x - x1 + (R * y1);
+        x1 = x;
+        y1 = y;
+        return y;
+    }
+
+    inline void reset() {
+        x1 = 0.0;
+        y1 = 0.0;
+    }
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1049,6 +1049,15 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
 
     const bool limiterOn = m_safetyLimiterEnabled.load(std::memory_order_relaxed);
 
+    // Master-bus DC removal. Clear the blocker state on the off->on transition so
+    // enabling never plays back a stale-state step from a previous engagement.
+    const bool dcRemovalOn = m_dcRemovalEnabled.load(std::memory_order_relaxed);
+    if (dcRemovalOn && !m_dcRemovalPrevOn) {
+        m_dcBlockerL.reset();
+        m_dcBlockerR.reset();
+    }
+    m_dcRemovalPrevOn = dcRemovalOn;
+
     // Signal integrity counters (local, then atomic update at end)
     uint32_t nanCount = 0;
     uint32_t clipCount = 0;
@@ -1073,6 +1082,13 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
 #ifdef AESTRA_DEBUG
             assert(false && "NaN/Inf detected in right channel output");
 #endif
+        }
+
+        // DC removal runs before the limiter and metering so the offset is gone
+        // from peak/RMS/LUFS and the limiter acts on the corrected signal.
+        if (dcRemovalOn) {
+            L = m_dcBlockerL.process(L);
+            R = m_dcBlockerR.process(R);
         }
 
         if (limiterOn) {

--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -506,9 +506,8 @@ void AudioSettingsPage::applyChanges() {
     
     // Toggles
     if (m_audioEngine) {
-        // DC Removal (Mock - Engine doesn't have explicit param exposed yet, assume enabled by default or add later)
-        // m_audioEngine->setDCRemovalEnabled(m_dcRemovalToggle->isOn());
-        
+        m_audioEngine->setDCRemovalEnabled(m_dcRemovalToggle->isOn());
+
         m_audioEngine->setSafetyLimiterEnabled(m_softClippingToggle->isOn());
         m_audioEngine->setPreviewDuckingAttenuationDb(static_cast<float>(m_previewDuckingDropdown->getSelectedValue()));
     }

--- a/Tests/AestraAudio/DCBlockerTest.cpp
+++ b/Tests/AestraAudio/DCBlockerTest.cpp
@@ -15,6 +15,10 @@ using Aestra::Audio::DCBlocker;
 
 namespace {
 
+// M_PI is not defined by MSVC without _USE_MATH_DEFINES; use a local constant so
+// the test builds identically across GCC/Clang/MSVC.
+constexpr double kPi = 3.14159265358979323846;
+
 int g_failures = 0;
 
 void check(bool cond, const char* msg) {
@@ -57,7 +61,7 @@ void test_preserves_audio_band() {
     // Skip the first 100 ms so the filter transient settles before measuring.
     const int settle = 4800;
     for (int i = 0; i < n; ++i) {
-        const double x = std::sin(2.0 * M_PI * freq * static_cast<double>(i) / sr);
+        const double x = std::sin(2.0 * kPi * freq * static_cast<double>(i) / sr);
         const double y = b.process(x);
         if (i >= settle) {
             peakIn = std::max(peakIn, std::fabs(x));
@@ -82,7 +86,7 @@ void test_dc_plus_sine_recenters() {
     double sum = 0.0;
     int counted = 0;
     for (int i = 0; i < n; ++i) {
-        const double x = dc + 0.4 * std::sin(2.0 * M_PI * freq * static_cast<double>(i) / sr);
+        const double x = dc + 0.4 * std::sin(2.0 * kPi * freq * static_cast<double>(i) / sr);
         const double y = b.process(x);
         if (i >= settle) {
             sum += y;

--- a/Tests/AestraAudio/DCBlockerTest.cpp
+++ b/Tests/AestraAudio/DCBlockerTest.cpp
@@ -1,0 +1,135 @@
+// DCBlockerTest.cpp — unit tests for the master-bus DC blocker (DSP/DCBlocker.h).
+//
+// Verifies the one-pole DC blocker actually removes a DC offset, leaves the
+// audible band essentially untouched, keeps silence silent, and clears its
+// state on reset(). This is the DSP that backs the Audio Settings "DC Removal"
+// toggle (#376).
+
+#include "DSP/DCBlocker.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+using Aestra::Audio::DCBlocker;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::printf("[PASS] %s\n", msg);
+    } else {
+        std::printf("[FAIL] %s\n", msg);
+        ++g_failures;
+    }
+}
+
+// Feed a constant offset for `n` samples; return the last output sample.
+double lastOutForDC(DCBlocker& b, double dc, int n) {
+    double y = 0.0;
+    for (int i = 0; i < n; ++i)
+        y = b.process(dc);
+    return y;
+}
+
+// Removes a steady DC offset: output converges toward zero.
+void test_removes_dc() {
+    DCBlocker b;
+    const double dc = 0.5;
+    const double y = lastOutForDC(b, dc, 48000); // ~1s at 48k
+    check(std::fabs(y) < 1e-3, "steady 0.5 DC is driven below 1e-3 after ~1s");
+
+    DCBlocker b2;
+    const double yNeg = lastOutForDC(b2, -0.25, 48000);
+    check(std::fabs(yNeg) < 1e-3, "steady -0.25 DC is driven below 1e-3 after ~1s");
+}
+
+// A pure sine (well above the corner) passes with negligible amplitude loss.
+void test_preserves_audio_band() {
+    DCBlocker b;
+    const double sr = 48000.0;
+    const double freq = 1000.0;
+    const int n = static_cast<int>(sr); // 1s, whole number of cycles-ish
+    double peakIn = 0.0;
+    double peakOut = 0.0;
+    // Skip the first 100 ms so the filter transient settles before measuring.
+    const int settle = 4800;
+    for (int i = 0; i < n; ++i) {
+        const double x = std::sin(2.0 * M_PI * freq * static_cast<double>(i) / sr);
+        const double y = b.process(x);
+        if (i >= settle) {
+            peakIn = std::max(peakIn, std::fabs(x));
+            peakOut = std::max(peakOut, std::fabs(y));
+        }
+    }
+    const double loss = std::fabs(peakOut - peakIn) / peakIn;
+    check(loss < 0.01, "1 kHz sine passes with <1% peak change");
+}
+
+// DC + audio: the DC is removed while the AC content remains centered on zero.
+void test_dc_plus_sine_recenters() {
+    DCBlocker b;
+    const double sr = 48000.0;
+    const double freq = 500.0;
+    const double dc = 0.3;
+    const int n = 2 * static_cast<int>(sr); // 2 s
+    // Settle a full second so the DC residual has fully decayed (corner is only a
+    // few Hz), then measure over exactly 500 cycles of the 500 Hz tone so the AC
+    // content sums to zero and only a leftover DC offset could move the mean.
+    const int settle = static_cast<int>(sr);
+    double sum = 0.0;
+    int counted = 0;
+    for (int i = 0; i < n; ++i) {
+        const double x = dc + 0.4 * std::sin(2.0 * M_PI * freq * static_cast<double>(i) / sr);
+        const double y = b.process(x);
+        if (i >= settle) {
+            sum += y;
+            ++counted;
+        }
+    }
+    const double mean = sum / static_cast<double>(counted);
+    check(std::fabs(mean) < 1e-3, "DC+sine output mean is ~0 (offset removed, AC kept)");
+}
+
+// Silence in, silence out — never generates energy from nothing.
+void test_silence_stays_silent() {
+    DCBlocker b;
+    double maxAbs = 0.0;
+    for (int i = 0; i < 4800; ++i)
+        maxAbs = std::max(maxAbs, std::fabs(b.process(0.0)));
+    check(maxAbs == 0.0, "silence in -> exact silence out");
+}
+
+// reset() clears state so a re-enabled blocker starts from a known-zero point.
+void test_reset_clears_state() {
+    DCBlocker b;
+    lastOutForDC(b, 0.8, 1000); // build up state
+    b.reset();
+    // First sample after reset with a fresh DC step equals the input (x - 0 + 0).
+    const double first = b.process(0.2);
+    check(std::fabs(first - 0.2) < 1e-12, "after reset(), first output equals first input");
+}
+
+} // namespace
+
+int main() {
+    std::printf("========================================\n");
+    std::printf("  DCBlocker DSP Tests\n");
+    std::printf("========================================\n\n");
+
+    test_removes_dc();
+    test_preserves_audio_band();
+    test_dc_plus_sine_recenters();
+    test_silence_stays_silent();
+    test_reset_clears_state();
+
+    std::printf("\n========================================\n");
+    if (g_failures == 0)
+        std::printf("  All DCBlocker tests passed.\n");
+    else
+        std::printf("  %d DCBlocker test(s) failed.\n", g_failures);
+    std::printf("========================================\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1966,6 +1966,16 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Audio/DelayLineTest.cpp")
     set_tests_properties(DelayLineTest PROPERTIES LABELS "audio;dsp;delay")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DCBlockerTest.cpp")
+    add_executable(DCBlockerTest AestraAudio/DCBlockerTest.cpp)
+    target_include_directories(DCBlockerTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME DCBlockerTest COMMAND DCBlockerTest)
+    set_tests_properties(DCBlockerTest PROPERTIES LABELS "audio;dsp;dc-removal")
+endif()
+
 # AudioEngine Diagnostics Test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineDiagnosticsTest.cpp")
     add_executable(AudioEngineDiagnosticsTest AestraAudio/AudioEngineDiagnosticsTest.cpp)


### PR DESCRIPTION
## Summary

Makes the Audio Settings **DC Removal** toggle actually do something. It persisted and reflected its state, but the engine call was commented out (`AudioSettingsPage.cpp:510`) and both candidate implementations behind it were dead code — the UI was claiming a feature that didn't exist.

- **Extract** the one-pole DC blocker into `DSP/DCBlocker.h` (it was a dead nested struct in `AudioEngine`) so it's shared and unit-testable.
- **Add** `setDCRemovalEnabled` / `isDCRemovalEnabled` (atomic, RT-safe per-block read, mirroring `setSafetyLimiterEnabled`). Two blockers (L/R) run on the master output **before** the limiter and metering, so the offset is gone from peak/RMS/LUFS and the limiter acts on the corrected signal. State clears on the off→on transition so enabling never plays back a stale step.
- **Wire** `AudioSettingsPage::applyChanges()` to the setter (the config-load path already funnels through `applyChanges`, so persisted state takes effect on startup).
- **Default OFF** — existing projects sound identical until the user opts in.
- **Test** `DCBlockerTest` (pure DSP, always-on): removes steady DC, preserves the audio band (<1% peak change at 1 kHz), recenters DC+sine, silence stays silent, `reset()` clears state.

## Why

Trust bug: the toggle told the user DC removal was active when it wasn't (#376).

## Testing

- `DCBlockerTest` → all 6 cases pass.
- `ctest -R "DCBlocker|AudioEngineOutputChannel|PlaybackPathSignalIntegrity|SummingEngine"` → 4/4 pass (confirms the header extraction didn't disturb the master path).
- `Aestra` app builds clean.

## Change type

- **DSP changed:** yes — but audio output changes **only when the toggle is enabled** (default off); bypass/existing behavior is bit-unchanged.
- **Latency:** unchanged.
- **State/serialization format:** unchanged (`audio_settings.conf` key `dc_removal` already existed).
- **UI:** no layout change (existing toggle now functional).

## Docs updated?

No.

## Risk / rollback

Low. Default-off means no surprise to existing sessions. The DSP is a standard one-pole DC blocker with per-channel state and RT-safe toggling. Rollback = revert the single commit.

Closes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)