### PR TITLE
test(audio): make AutosaveManagerTest deterministic under TSan (#437)

### DIFF
--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -139,6 +139,17 @@ public:
      * @return true if successful
      */
     bool forceAutosave();
+
+    /**
+     * @brief Run one autosave decision synchronously: save only if the project is
+     * dirty and the debounce (minDirtyDelay) has elapsed. Applies the same
+     * dirty/debounce gate the background thread uses, so an explicit caller (or a
+     * deterministic test) can drive an autosave-if-needed without waiting on the
+     * scheduler. Like forceAutosave(), it is independent of the background
+     * `enabled` flag — that flag governs only the automatic timer.
+     * @return true if an autosave was performed.
+     */
+    bool autosaveIfDue();
     
     std::string getAutosavePath() const;
     std::string getBackupDirectory() const;

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -153,6 +153,24 @@ bool AutosaveManager::forceAutosave() {
     return performAutosave();
 }
 
+bool AutosaveManager::autosaveIfDue() {
+    // Same gate as autosaveThreadFunc(): only save when there are pending changes
+    // that have survived the debounce window. markClean() clearing m_isDirty is
+    // exactly what suppresses a would-be autosave here.
+    if (!m_isDirty.load(std::memory_order_acquire)) {
+        return false;
+    }
+    const auto timeSinceDirty = std::chrono::steady_clock::now() - m_lastDirtyTime;
+    if (timeSinceDirty < m_config.minDirtyDelay) {
+        return false;
+    }
+    if (performAutosave()) {
+        markClean();
+        return true;
+    }
+    return false;
+}
+
 std::string AutosaveManager::getAutosavePath() const {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_config.autosavePathOverride.empty()) return m_config.autosavePathOverride;

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -48,7 +48,7 @@ int main() {
             return true;
         };
 
-        manager.initialize("some_project.aes", std::move(config));
+        manager.initialize((tempDir / "some_project.aes").string(), std::move(config));
         require(manager.getAutosavePath() == autosavePath.string(), "autosavePathOverride should be respected");
 
         manager.markDirty();
@@ -62,33 +62,48 @@ int main() {
         std::cout << "[INFO] Autosave with override passed.\n";
     }
 
-    // --- Test 2: markClean suppresses further autosaves ---
+    // --- Test 2: markClean suppresses a due autosave ---
+    // Driven synchronously via autosaveIfDue() rather than sleeping against the
+    // background thread: the previous version raced markClean() vs. the 1s autosave
+    // timer, which flaked under ThreadSanitizer's 5-15x slowdown (issue #437). Here
+    // there is no timing dependency at all. A dedicated path keeps Test 1's file
+    // untouched.
     {
+        const auto suppressPath = tempDir / "suppress.autosave.aes";
         AutosaveManager manager;
         int serializeCount = 0;
 
         AutosaveManager::Config config;
-        config.enabled = true;
+        config.enabled = false; // no background thread; we drive the gate explicitly
         config.autosaveInterval = std::chrono::seconds(1);
         config.minDirtyDelay = std::chrono::seconds(0);
-        config.autosavePathOverride = autosavePath.string();
+        config.autosavePathOverride = suppressPath.string();
         config.serializer = [&](std::string& outData) -> bool {
             outData = "updated data";
             ++serializeCount;
             return true;
         };
 
-        manager.initialize("project2.aes", std::move(config));
+        manager.initialize((tempDir / "project2.aes").string(), std::move(config));
+
+        // markClean() after markDirty() must clear the pending-change state so a
+        // due autosave is suppressed.
         manager.markDirty();
         manager.markClean();
-        std::this_thread::sleep_for(std::chrono::seconds(2));
-        manager.shutdown();
+        require(!manager.autosaveIfDue(), "markClean should have suppressed autosave");
+        require(serializeCount == 0, "suppressed autosave must not serialize");
+        require(!std::filesystem::exists(suppressPath), "suppressed autosave must not write a file");
 
-        // The existing file from test 1 should still be there; test 2 should NOT have
-        // overwritten it because markClean() was called before the thread woke.
-        std::ifstream in(autosavePath, std::ios::binary);
+        // Sanity: with changes genuinely pending, the same gate does autosave —
+        // proving the suppression above was due to markClean(), not a dead path.
+        manager.markDirty();
+        require(manager.autosaveIfDue(), "a dirty project should autosave when due");
+        require(serializeCount == 1, "exactly one serialize after the due autosave");
+        std::ifstream in(suppressPath, std::ios::binary);
         std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-        require(contents == "test autosave data", "markClean should have suppressed autosave");
+        require(contents == "updated data", "due autosave should write serialized data");
+
+        manager.shutdown();
         std::cout << "[INFO] markClean suppression passed.\n";
     }
 
@@ -106,7 +121,7 @@ int main() {
             return true;
         };
 
-        manager.initialize("project3.aes", std::move(config));
+        manager.initialize((tempDir / "project3.aes").string(), std::move(config));
         bool ok = manager.forceAutosave();
         require(ok, "forceAutosave should succeed");
         manager.shutdown();
@@ -132,7 +147,7 @@ int main() {
             return true;
         };
 
-        manager.initialize("project4.aes", std::move(config));
+        manager.initialize((tempDir / "project4.aes").string(), std::move(config));
         manager.forceAutosave();
         manager.forceAutosave();
         manager.forceAutosave();


### PR DESCRIPTION
## Summary

Fixes the flaky `AutosaveManagerTest` under the advisory ThreadSanitizer lane (#437). Test 2 raced `markClean()` against the 1s background autosave timer via a `sleep_for(2s)`; under TSan's 5–15× slowdown the autosave thread could pass its dirty-gate before `markClean()` landed, overwrite the file, and fail the assertion. It was never a data race — just a wall-clock race in the test.

- **Add `AutosaveManager::autosaveIfDue()`** — runs one autosave decision synchronously using the same dirty + debounce gate as the background thread. Like the existing `forceAutosave()`, it's independent of the background `enabled` timer flag. Also useful as a real "commit now if there are pending changes" entry point.
- **Rewrite Test 2** to drive that gate directly with `enabled=false` (no background thread, no sleeps): `markDirty()`+`markClean()` → `autosaveIfDue()` is suppressed and writes nothing; a fresh `markDirty()` → `autosaveIfDue()` does save. That proves the suppression is `markClean()`'s doing (not a dead path) and is fully deterministic regardless of sanitizer slowdown.
- **Absolute temp-dir project paths** in all four cases, so `initialize()` no longer scatters stray `*.autosave` backup dirs into the working directory.

The test still exercises the real suppression behavior — it is not skipped or weakened.

## Why

An advisory-lane flake that adds noise to every sanitizer run (#437). The issue explicitly asked to drive the clock explicitly rather than sleep, and to not delete/skip the test.

## Testing

- `AutosaveManagerTest` → all cases pass; no `*.autosave` litter in CWD afterward.
- `AestraAudioCore` + app build clean.

## Change type

- **DSP:** no. **Serialization format:** no (behavioral autosave logic unchanged; `autosaveIfDue()` is additive with no existing callers). **UI:** no. **Test:** yes.

## Docs updated?

No.

## Risk / rollback

Low. The new method has no callers outside the test and reuses `performAutosave()`; the background thread path is untouched. Rollback = revert the single commit.

Closes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)