### PR TITLE
fix(audio): protect autosave dirty-state across concurrent edits (CR on #501)

### DIFF
--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <thread>
 #include <mutex>
@@ -194,7 +195,9 @@ private:
     std::atomic<bool> m_shouldStop{false};
     std::atomic<bool> m_initialized{false};
     
-    std::chrono::steady_clock::time_point m_lastDirtyTime;
+    // steady_clock milliseconds since epoch. Atomic so markDirty() (callable from
+    // any thread) and the autosave gate can write/read it without the mutex.
+    std::atomic<int64_t> m_lastDirtyTimeMs{0};
     std::chrono::steady_clock::time_point m_lastAutosaveTime;
     
     std::unique_ptr<std::thread> m_autosaveThread;

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -15,6 +15,16 @@ namespace fs = std::filesystem;
 namespace Aestra {
 namespace Audio {
 
+namespace {
+// Monotonic milliseconds since the steady_clock epoch. Used for the dirty-time
+// stamp so it can live in an atomic and be compared without the mutex.
+int64_t steadyNowMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+} // namespace
+
 //==============================================================================
 // RecoveryInfo
 //==============================================================================
@@ -70,7 +80,7 @@ void AutosaveManager::initialize(const std::string& projectPath, Config config) 
     m_isAutosaving = false;
     m_shouldStop = false;
     m_lastAutosaveTime = std::chrono::steady_clock::now();
-    m_lastDirtyTime = std::chrono::steady_clock::now();
+    m_lastDirtyTimeMs.store(steadyNowMs(), std::memory_order_release);
     
     // Ensure backup directory exists
     if (!m_projectPath.empty()) {
@@ -121,7 +131,7 @@ void AutosaveManager::shutdown() {
 
 void AutosaveManager::markDirty() {
     m_isDirty.store(true, std::memory_order_release);
-    m_lastDirtyTime = std::chrono::steady_clock::now();
+    m_lastDirtyTimeMs.store(steadyNowMs(), std::memory_order_release);
     m_cv.notify_all();
 }
 
@@ -160,15 +170,24 @@ bool AutosaveManager::autosaveIfDue() {
     if (!m_isDirty.load(std::memory_order_acquire)) {
         return false;
     }
-    const auto timeSinceDirty = std::chrono::steady_clock::now() - m_lastDirtyTime;
-    if (timeSinceDirty < m_config.minDirtyDelay) {
+    const int64_t sinceMs = steadyNowMs() - m_lastDirtyTimeMs.load(std::memory_order_acquire);
+    const int64_t minDelayMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(m_config.minDirtyDelay).count();
+    if (sinceMs < minDelayMs) {
         return false;
     }
-    if (performAutosave()) {
-        markClean();
-        return true;
+    // Claim the dirty state BEFORE the (slow) file I/O. A markDirty() that lands
+    // during the save then re-sets the flag and is caught next cycle, instead of
+    // being wiped by an unconditional markClean() afterward.
+    if (!m_isDirty.exchange(false, std::memory_order_acq_rel)) {
+        return false;
     }
-    return false;
+    if (!performAutosave()) {
+        m_isDirty.store(true, std::memory_order_release); // save failed; stay dirty
+        return false;
+    }
+    notifyStatus("Project saved");
+    return true;
 }
 
 std::string AutosaveManager::getAutosavePath() const {
@@ -343,20 +362,28 @@ void AutosaveManager::autosaveThreadFunc() {
         if (!m_isDirty.load(std::memory_order_acquire)) {
             continue;
         }
-        
-        auto now = std::chrono::steady_clock::now();
-        auto timeSinceDirty = now - m_lastDirtyTime;
-        if (timeSinceDirty < m_config.minDirtyDelay) {
-            auto remaining = m_config.minDirtyDelay - timeSinceDirty;
+
+        const int64_t sinceMs = steadyNowMs() - m_lastDirtyTimeMs.load(std::memory_order_acquire);
+        const int64_t minDelayMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(m_config.minDirtyDelay).count();
+        if (sinceMs < minDelayMs) {
             lock.unlock();
-            std::this_thread::sleep_for(remaining);
+            std::this_thread::sleep_for(std::chrono::milliseconds(minDelayMs - sinceMs));
             continue;
         }
-        
+
         lock.unlock();
-        
+
+        // Claim the dirty state before the save so a concurrent markDirty() during
+        // the file I/O keeps the project dirty for the next cycle rather than being
+        // cleared by an unconditional markClean().
+        if (!m_isDirty.exchange(false, std::memory_order_acq_rel)) {
+            continue;
+        }
         if (performAutosave()) {
-            markClean();
+            notifyStatus("Project saved");
+        } else {
+            m_isDirty.store(true, std::memory_order_release); // save failed; stay dirty
         }
     }
     

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -166,6 +166,38 @@ int main() {
         std::cout << "[INFO] Backup rotation passed (" << backupCount << " backups).\n";
     }
 
+    // --- Test 5: a change made during the save must not be lost ---
+    // The autosave path claims the dirty flag before the (slow) serialize. If a
+    // markDirty() lands mid-save, the project must stay dirty so the next cycle
+    // catches it — rather than being cleared by an unconditional markClean().
+    {
+        const auto concurrentPath = tempDir / "concurrent.autosave.aes";
+        AutosaveManager manager;
+        bool markedDuringSave = false;
+
+        AutosaveManager::Config config;
+        config.enabled = false; // drive synchronously; no background thread
+        config.minDirtyDelay = std::chrono::seconds(0);
+        config.autosavePathOverride = concurrentPath.string();
+        config.serializer = [&](std::string& outData) -> bool {
+            outData = "concurrent data";
+            // Simulate a user edit arriving while the save is in flight.
+            if (!markedDuringSave) {
+                markedDuringSave = true;
+                manager.markDirty();
+            }
+            return true;
+        };
+
+        manager.initialize((tempDir / "project5.aes").string(), std::move(config));
+        manager.markDirty();
+        require(manager.autosaveIfDue(), "autosave should run for a dirty project");
+        require(markedDuringSave, "serializer should have observed the save in progress");
+        require(manager.isDirty(), "a change made during the save must keep the project dirty");
+        manager.shutdown();
+        std::cout << "[INFO] concurrent-dirty preservation passed.\n";
+    }
+
     std::cout << "[PASS] AutosaveManagerTest\n";
     return 0;
 }


### PR DESCRIPTION
## Summary

Addresses the two Critical data-integrity findings CodeRabbit raised on the autosave path (during promotion PR #501). Both are fixed at the source — the background thread loop (the real production path) as well as `autosaveIfDue()`.

1. **`m_lastDirtyTime` data race** — it was written by `markDirty()` from any thread without a lock and read by the autosave gate. Replaced with an atomic `int64` millisecond timestamp (`m_lastDirtyTimeMs`), removing the race (including the pre-existing unlocked write).
2. **Concurrent edit lost during save** — both the background loop and `autosaveIfDue()` called `markClean()` unconditionally after `performAutosave()`. A `markDirty()` arriving during the slow serialize/write was wiped, silently dropping that edit. Switched both to **capture-and-clear**: atomically claim the dirty flag *before* the save and restore it if the save fails, so a concurrent `markDirty()` re-dirties and is caught next cycle.

## Why

Autosave is a data-loss-sensitive path; dropping an edit that arrives mid-save is a real (if narrow) data-integrity bug. The race and the drop both existed in the shipped background thread, not just the new method.

## Testing

- New `AutosaveManagerTest` case: a serializer that calls `markDirty()` mid-save must leave the project dirty afterward — passes with the fix, fails on the old unconditional `markClean()`.
- Existing cases (including Test 1, which exercises the real background thread) still pass.
- `AestraAudioCore` + app build clean.

## Change type

- **DSP:** no. **Serialization format:** no (behavioral dirty-state handling only). **UI:** no. **Data-integrity behavior:** yes (autosave now preserves concurrent edits).

## Docs updated?

No.

## Risk / rollback

Moderate-but-contained: touches autosave dirty-state sequencing (high-value path), but the change is a well-known capture-and-clear pattern, covered by a regression test, and does not alter the save format. Rollback = revert the single commit.

Addresses CodeRabbit review on #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)