### PR TITLE
fix(serialization): populate the persisted AudioSlice fields at creation (#447)

### DIFF
--- a/AestraAudio/include/Models/PatternSource.h
+++ b/AestraAudio/include/Models/PatternSource.h
@@ -54,10 +54,15 @@ struct MidiPayload {
  * @brief Audio slice definition
  */
 struct AudioSlice {
-    double startOffset{0.0};
-    double duration{0.0};
-    double startSamples{0.0};  // Alternative representation in samples (as double for JSON)
-    double lengthSamples{0.0}; // Alternative representation in samples (as double for JSON)
+    // NOTE: only startSamples/lengthSamples are persisted (ProjectSerializer writes
+    // and reads these). startOffset/duration are legacy and are not serialized —
+    // do NOT rely on positional aggregate init like {0.0, numFrames}, which fills
+    // startOffset/duration and leaves the persisted fields empty. Set the sample
+    // fields explicitly. See #447.
+    double startOffset{0.0};    // legacy, not persisted
+    double duration{0.0};       // legacy, not persisted
+    double startSamples{0.0};   // persisted "start" (samples, as double for JSON)
+    double lengthSamples{0.0};  // persisted "length" (samples, as double for JSON)
 };
 
 /**

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1251,7 +1251,13 @@ private:
         AudioSlicePayload payload;
         payload.audioSourceId = sourceId;
         payload.durationSeconds = durationSeconds;
-        payload.slices.push_back({0.0, static_cast<double>(buffer->numFrames)});
+        // Populate the sample-domain fields the serializer persists
+        // (startSamples/lengthSamples). The old {0.0, numFrames} form set
+        // startOffset/duration instead, so the slice saved as start:0 length:0.
+        AudioSlice fullSlice;
+        fullSlice.startSamples = 0.0;
+        fullSlice.lengthSamples = static_cast<double>(buffer->numFrames);
+        payload.slices.push_back(fullSlice);
 
         PatternID patternId = m_patternManager.createAudioPattern(takeName, durationBeats, payload);
         if (!patternId.isValid()) {

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4697,7 +4697,13 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 AudioSlicePayload payload;
                 payload.audioSourceId = sourceId;
                 payload.durationSeconds = durationSeconds;
-                payload.slices.push_back({0.0, static_cast<double>(source->getNumFrames())});
+                // Populate the sample-domain fields the serializer persists
+                // (startSamples/lengthSamples). The old {0.0, numFrames} form set
+                // startOffset/duration instead, so the slice saved as start:0 length:0.
+                AudioSlice fullSlice;
+                fullSlice.startSamples = 0.0;
+                fullSlice.lengthSamples = static_cast<double>(source->getNumFrames());
+                payload.slices.push_back(fullSlice);
 
                 auto& patternManager = self->m_trackManager->getPatternManager();
                 PatternID patternId = patternManager.createAudioPattern(displayName, durationBeats, payload);


### PR DESCRIPTION
## Summary

Two production audio-slice creation sites populated the wrong `AudioSlice` fields, so freshly created slices persisted as empty.

`AudioSlice` carries two representations: `startOffset`/`duration` (fields 1-2) and `startSamples`/`lengthSamples` (fields 3-4). The serializer persists **only fields 3-4**. But both production sites used positional aggregate init `{0.0, numFrames}`, which fills fields 1-2 and leaves the persisted fields at 0 → the slice saved as `start:0, length:0`.

- `AestraAudio/include/Models/TrackManager.h` (recorded take) and `Source/Components/TrackManagerUI.cpp` (audio drop): now set `startSamples`/`lengthSamples` explicitly.
- `AudioSlice`: documented that only `startSamples`/`lengthSamples` are persisted, with a warning against the positional-init footgun that caused this.

## Why

`#447` — creation sites populated fields that are never persisted, silently dropping slice data. No runtime consumer reads slices yet, so nothing audible breaks today, but the future slicer/sampler feature would inherit empty persisted slices.

## Scope note

`startOffset`/`duration` are write-only legacy fields (verified never read anywhere). Collapsing the struct to one representation was considered, but ~11 test fixtures use the 4-arg positional form; correcting the two **production** sites is the right-sized fix and changes **no serialization format**.

## Testing

- Serialization roundtrip suite — `ProjectValueFidelityTest`, `ProjectFixtureCorpusTest`, `ProjectRoundTripTest`, `ProjectRoundTripIntegrityTest`, `SessionRecoveryTest` — all pass.
- `Aestra` app builds clean.

## Change type

- **Serialization format:** no change (writer/loader already used fields 3-4). **DSP:** no. **UI:** no. **Data correctness:** yes (slices now persist their real bounds).

## Docs updated?

No.

## Risk / rollback

Low — two explicit-field assignments + a doc comment; no format or runtime-behavior change. Rollback = revert the single commit.

Closes #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated recorded-take and imported-audio slice creation to explicitly populate the persisted `startSamples` and `lengthSamples` fields, preventing newly created slices from saving zero start/length values.
- Documented that `startOffset` and `duration` are legacy, non-serialized fields and warned against positional aggregate initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->