### PR TITLE
fix(license): follow redirects in account HTTP transport; default to www host

### DIFF
--- a/AestraLicense/src/AccountApiClient.cpp
+++ b/AestraLicense/src/AccountApiClient.cpp
@@ -236,9 +236,10 @@ LicenseRefreshResult AccountApiClient::refreshEntitlements(const std::string& se
 
 AccountApiConfig accountApiConfigFromEnvironment() {
     AccountApiConfig config;
-    // Default to Aestra's home. AESTRA_ACCOUNT_API_BASE_URL overrides it (e.g. a
-    // staging server or a local mock during development).
-    config.baseUrl = "https://aestra.studio";
+    // Default to Aestra's home. Use the canonical www host directly: the apex
+    // (aestra.studio) 307-redirects to www, and pointing here avoids that hop.
+    // AESTRA_ACCOUNT_API_BASE_URL overrides it (staging / local mock).
+    config.baseUrl = "https://www.aestra.studio";
     if (const char* envUrl = std::getenv("AESTRA_ACCOUNT_API_BASE_URL")) {
         config.baseUrl = envUrl;
     }

--- a/AestraLicense/src/HttpTransport.cpp
+++ b/AestraLicense/src/HttpTransport.cpp
@@ -82,7 +82,13 @@ HttpResponse CurlHttpTransport::send(const HttpRequest& request) {
     curl_easy_setopt(curl, CURLOPT_URL, request.url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeBody);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+    // Follow redirects (bounded). The account host may 3xx apex -> www (e.g.
+    // Vercel), and without this the request dies on the redirect instead of
+    // reaching the API. CURL_REDIR_POST_ALL keeps POST bodies across 301/302/307/308
+    // so login/verify calls aren't silently downgraded to GET.
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    curl_easy_setopt(curl, CURLOPT_POSTREDIR, static_cast<long>(CURL_REDIR_POST_ALL));
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(request.timeoutMs));
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(request.timeoutMs));


### PR DESCRIPTION
## Summary

Two client-side robustness fixes surfaced while tracing why sign-in fails.

The account host (Vercel) 307-redirects apex → www, but the curl transport had `CURLOPT_FOLLOWLOCATION=0`, so the request died on the redirect before reaching any API.

- **Follow redirects** (bounded): `FOLLOWLOCATION=1`, `MAXREDIRS=5`, and `CURL_REDIR_POST_ALL` so POST bodies (login/verify) survive 301/302/307/308 instead of being downgraded to GET.
- **Default to the canonical `https://www.aestra.studio`**, skipping the apex→www hop entirely. `AESTRA_ACCOUNT_API_BASE_URL` still overrides.

## Why

Login trace: `aestra.studio` → 307 → `www.aestra.studio`, and the transport didn't follow it. Even at www, `/v1/account/*` currently returns the site HTML (SPA catch-all), so **this does not by itself make sign-in work** — the account API backend still needs to be deployed. This removes the *client* reasons login would fail once that backend exists.

## Testing

- `Aestra` app builds and links clean (libcurl present, `AESTRA_LICENSE_HAS_CURL=1`).
- Redirect behavior verified out-of-band: `aestra.studio` 307→www confirmed via curl.

## Change type

- License/networking client config. No auth/verification logic change; only redirect handling + default host.

## Risk / rollback

Low — bounded redirect following is standard for an API client; env override preserved. Rollback = revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Enables libcurl to follow up to five redirects while preserving POST bodies across 301, 302, 307, and 308 responses.
- Changes the default account API host to `https://www.aestra.studio` to avoid the apex-domain redirect.
- Retains `AESTRA_ACCOUNT_API_BASE_URL` as an override.
- Authentication and verification logic are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->