### PR TITLE
feat(worker): route the account API to www.aestra.studio/v1/account/*

### DIFF
--- a/workers/license-signing/wrangler.toml
+++ b/workers/license-signing/wrangler.toml
@@ -17,3 +17,10 @@ binding = "AESTRA_LICENSE_DB"
 database_name = "aestra-license"
 database_id = "4c09044c-95fc-4896-87ac-51cac5b99b91"
 migrations_dir = "migrations"
+
+# Bind the account API to the production host so the DAW client (which defaults to
+# https://www.aestra.studio) reaches the worker instead of the static site. Scoped
+# to /v1/account/* — all other paths still serve the website.
+[[routes]]
+pattern = "www.aestra.studio/v1/account/*"
+zone_name = "aestra.studio"


### PR DESCRIPTION
## Summary

Binds the (already-built, already-deployed) `aestra-license-signing` Worker to `www.aestra.studio/v1/account/*`.

The Worker had D1, Resend/SMTP mail, and Ed25519 lease signing all configured — but **no production route**, so the DAW client's requests to `www.aestra.studio/v1/account/*` hit the Vercel static site (HTML) instead of the Worker. That was the entire reason sign-in never worked.

## Verified end-to-end (through production)

`www.aestra.studio` → Worker: `login/start` → `login/verify` → `me` → `entitlements/refresh`, and the returned `aestra-license-v1` Ed25519 lease **verifies against the client's embedded public key** (`bf30bfb9…`, the current dev key). Route is scoped to `/v1/account/*`; all other paths still serve the website.

## Change

One `[[routes]]` block in `workers/license-signing/wrangler.toml`. Deploy with `wrangler deploy` from that dir (already deployed live).

## Change type

- Infra/worker config only. No DAW source, DSP, or serialization change.

## Risk / rollback

Low and scoped — only `/v1/account/*` on `www` is intercepted. Rollback = remove the route block + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)