### PR TITLE
feat(browser): unify adaptive browser content views

### DIFF
--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -364,7 +364,9 @@ FileBrowser::FileBrowser()
         if (onSearchTextChanged_) {
             onSearchTextChanged_(text);
         }
-        applyFilter();
+        if (activeNavAction_ != BrowserNavAction::Plugins && activeNavAction_ != BrowserNavAction::Patterns) {
+            applyFilter();
+        }
     });
     searchInput_->setOnEscapeKey([this]() {
         searchInput_->clear();
@@ -822,9 +824,8 @@ bool FileBrowser::usesCompactNavigation() const {
 
 NUIRect FileBrowser::getContentViewBounds() const {
     const BrowserLayout layout = computeBrowserLayout();
-    const NUIRect bounds = getBounds();
     return NUIRect(layout.listHeader.x, layout.searchBar.bottom(), layout.listHeader.width,
-                   std::max(0.0f, bounds.bottom() - layout.searchBar.bottom()));
+                   std::max(0.0f, layout.list.bottom() - layout.searchBar.bottom()));
 }
 
 void FileBrowser::registerContentView(BrowserNavAction action, const std::shared_ptr<NUIComponent>& component) {

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -35,7 +35,10 @@ namespace AestraUI {
 
 namespace {
 
-constexpr float kPreviewPanelHeight = 90.0f;
+constexpr float kPreviewPanelHeight = 68.0f;
+constexpr float kCompactNavWidth = 52.0f;
+constexpr float kCompactNavStartWidth = 320.0f;
+constexpr float kExpandedNavStartWidth = 440.0f;
 constexpr float BROWSER_SEARCH_ROW_H = 34.0f;
 constexpr float BROWSER_TOP_PAD = 7.0f;
 constexpr float BROWSER_CONTENT_GAP = 8.0f;
@@ -58,6 +61,21 @@ AestraUI::NUIComponent* getRootComponent(AestraUI::NUIComponent* component) {
         root = root->getParent();
     }
     return root;
+}
+
+float computeNavigationWidth(float browserWidth) {
+    if (browserWidth <= kCompactNavStartWidth) {
+        return std::min(browserWidth, kCompactNavWidth);
+    }
+
+    const float expandedWidth = std::clamp(browserWidth * 0.34f, 118.0f, 188.0f);
+    if (browserWidth >= kExpandedNavStartWidth) {
+        return expandedWidth;
+    }
+
+    const float expandedAtBreakpoint = kExpandedNavStartWidth * 0.34f;
+    const float progress = (browserWidth - kCompactNavStartWidth) / (kExpandedNavStartWidth - kCompactNavStartWidth);
+    return kCompactNavWidth + progress * (expandedAtBreakpoint - kCompactNavWidth);
 }
 
 void detachPopupMenu(const std::shared_ptr<AestraUI::NUIContextMenu>& menu) {
@@ -761,12 +779,12 @@ void FileBrowser::processScanResults() {
 
 FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
     NUIRect bounds = getBounds();
-    const float effectiveW = effectiveWidth_ > 0.0f ? effectiveWidth_ : bounds.width;
+    const float effectiveW = bounds.width;
     const float searchH = BROWSER_SEARCH_ROW_H;
     const float headerH = searchH;
     const float contentY = bounds.y + headerH;
     const float contentH = std::max(0.0f, bounds.height - headerH);
-    const float navW = std::clamp(effectiveW * 0.34f, 118.0f, 188.0f);
+    const float navW = computeNavigationWidth(effectiveW);
     const float listX = bounds.x + navW;
     const float listW = std::max(0.0f, effectiveW - navW);
 
@@ -776,8 +794,9 @@ FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
                             std::max(0.0f, effectiveW - 64.0f), searchH - 8.0f);
     layout.navPane = NUIRect(bounds.x, contentY, navW, contentH);
     layout.listHeader = NUIRect(listX, contentY, listW, BROWSER_LIST_HEADER_H);
-    layout.list = NUIRect(listX, contentY + BROWSER_LIST_HEADER_H,
-                         listW, std::max(0.0f, contentH - BROWSER_LIST_HEADER_H));
+    const float previewH = previewPanelVisible_ ? std::min(kPreviewPanelHeight, contentH) : 0.0f;
+    layout.list = NUIRect(listX, contentY + BROWSER_LIST_HEADER_H, listW,
+                          std::max(0.0f, contentH - BROWSER_LIST_HEADER_H - previewH));
     const float chromeY = layout.listHeader.y + 3.0f;
     layout.backButton = NUIRect(layout.listHeader.x + 5.0f, chromeY, 22.0f, 24.0f);
     layout.forwardButton = NUIRect(layout.backButton.right() + 2.0f, chromeY, 22.0f, 24.0f);
@@ -793,8 +812,56 @@ FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
 
 float FileBrowser::getNavPaneWidth() const {
     NUIRect bounds = getBounds();
-    const float effectiveW = effectiveWidth_ > 0.0f ? effectiveWidth_ : bounds.width;
-    return std::clamp(effectiveW * 0.34f, 118.0f, 188.0f);
+    const float effectiveW = bounds.width;
+    return computeNavigationWidth(effectiveW);
+}
+
+bool FileBrowser::usesCompactNavigation() const {
+    return getNavPaneWidth() < 112.0f;
+}
+
+NUIRect FileBrowser::getContentViewBounds() const {
+    const BrowserLayout layout = computeBrowserLayout();
+    const NUIRect bounds = getBounds();
+    return NUIRect(layout.listHeader.x, layout.searchBar.bottom(), layout.listHeader.width,
+                   std::max(0.0f, bounds.bottom() - layout.searchBar.bottom()));
+}
+
+void FileBrowser::registerContentView(BrowserNavAction action, const std::shared_ptr<NUIComponent>& component) {
+    if (!component) {
+        return;
+    }
+
+    for (auto& view : contentViews_) {
+        if (view.action == action) {
+            view.component = component;
+            updateContentViews();
+            return;
+        }
+    }
+
+    contentViews_.push_back({action, component});
+    updateContentViews();
+}
+
+void FileBrowser::setContentViewsEnabled(bool enabled) {
+    if (contentViewsEnabled_ == enabled) {
+        return;
+    }
+    contentViewsEnabled_ = enabled;
+    updateContentViews();
+}
+
+void FileBrowser::updateContentViews() {
+    const NUIRect contentBounds = getContentViewBounds();
+    for (auto& view : contentViews_) {
+        if (auto component = view.component.lock()) {
+            const bool active = contentViewsEnabled_ && isVisible() && view.action == activeNavAction_;
+            component->setBounds(contentBounds);
+            component->setEnabled(active);
+            component->setVisible(active);
+        }
+    }
 }
 
 void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayout& layout) {
@@ -807,6 +874,7 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     const NUIColor muted = themeManager.getColor("textSecondary").withAlpha(0.48f);
     const NUIColor selectedBg = themeManager.getColor("primary").withAlpha(0.16f); // More prominent selection
     const NUIColor divider = themeManager.getColor("border").withAlpha(0.48f);  // Sharper panel edge
+    const bool compact = layout.navWidth < 112.0f;
 
     renderer.fillRect(layout.navPane, paneBg);
     renderer.setClipRect(layout.navPane);
@@ -829,19 +897,30 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
         folderName = p.filename().string();
         if (folderName.empty()) folderName = currentPath_;
     }
-    renderer.drawText(folderName,
-                      {navHeader.x + themeProps.spacingM, std::round(renderer.calculateTextY(
-                          NUIRect(navHeader.x, navHeader.y + 5.0f, navHeader.width, 20.0f), themeProps.fontSizeXS))},
-                      themeProps.fontSizeXS, themeManager.getColor("textPrimary").withAlpha(0.76f));
+    if (!compact) {
+        renderer.drawText(
+            folderName,
+            {navHeader.x + themeProps.spacingM,
+             std::round(renderer.calculateTextY(NUIRect(navHeader.x, navHeader.y + 5.0f, navHeader.width, 20.0f),
+                                                themeProps.fontSizeXS))},
+            themeProps.fontSizeXS, themeManager.getColor("textPrimary").withAlpha(0.76f));
+    } else {
+        const std::string compactLabel = "LIB";
+        const auto labelSize = renderer.measureText(compactLabel, 9.0f);
+        renderer.drawText(compactLabel,
+                          {navHeader.x + (navHeader.width - labelSize.width) * 0.5f,
+                           std::round(renderer.calculateTextY(
+                               NUIRect(navHeader.x, navHeader.y + 5.0f, navHeader.width, 20.0f), 9.0f))},
+                          9.0f, themeManager.getColor("textSecondary").withAlpha(0.58f));
+    }
 
     // Inner divider (like right header)
     renderer.drawLine({navHeader.x, navHeader.y + 27.0f},
                       {navHeader.right(), navHeader.y + 27.0f},
                       1.0f, themeManager.getColor("border").withAlpha(0.65f));
 
-    // Scrollable content region below the fixed folder-name header. When the
-    // preview dock steals height the tail rows would clip; instead the content
-    // scrolls under the header exactly like the file list below it.
+    // Scrollable content region below the fixed folder-name header. Short
+    // windows keep the tail rows reachable without moving the header.
     const float navContentTop = layout.navPane.y + 28.0f;
     navViewportHeight_ = std::max(0.0f, layout.navPane.bottom() - navContentTop);
     const float navMaxScroll = std::max(0.0f, navContentHeight_ - navViewportHeight_);
@@ -863,6 +942,13 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     };
 
     auto drawSection = [&](const std::string& label) {
+        if (compact) {
+            y += 5.0f;
+            renderer.drawLine({layout.navPane.x + 15.0f, y}, {layout.navPane.right() - 15.0f, y}, 1.0f,
+                              divider.withAlpha(0.38f));
+            y += 6.0f;
+            return;
+        }
         std::string upper = label;
         std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
         NUIRect labelRect(layout.navPane.x + themeProps.spacingM, y, layout.navPane.width - themeProps.spacingM * 2.0f, 22.0f);
@@ -880,7 +966,7 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
 
     auto drawIcon = [&](const NUIRect& rect, BrowserNavAction action, bool selected) {
         const NUIColor iconColor = selected ? themeManager.getColor("textPrimary").withAlpha(0.86f) : muted.withAlpha(0.70f);
-        const float cx = rect.x + 13.0f;
+        const float cx = compact ? rect.x + rect.width * 0.5f : rect.x + 13.0f;
         const float cy = rect.y + rect.height * 0.5f;
 
         auto drawSvgIcon = [&](const char* svg) {
@@ -971,9 +1057,12 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
         }
         // Nav hover wash also lives in renderHoverOverlays(), outside the cache.
         drawIcon(row, action, selected);
-        renderer.drawText(label, {row.x + 33.0f, std::round(renderer.calculateTextY(row, themeProps.fontSizeS))},
-                          themeProps.fontSizeS, selected ? themeManager.getColor("textPrimary").withAlpha(0.90f) : rowText);
-        if (count > 0) {
+        if (!compact) {
+            renderer.drawText(label, {row.x + 33.0f, std::round(renderer.calculateTextY(row, themeProps.fontSizeS))},
+                              themeProps.fontSizeS,
+                              selected ? themeManager.getColor("textPrimary").withAlpha(0.90f) : rowText);
+        }
+        if (!compact && count > 0) {
             const std::string countText = std::to_string(count);
             const auto countSize = renderer.measureText(countText, themeManager.getFontSize("s"));
             renderer.drawText(countText,
@@ -981,17 +1070,17 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
                               11.0f,
                               muted.withAlpha(selected ? 0.82f : 0.54f));
         }
-        navHits_.push_back({action, row, std::move(path)});
+        navHits_.push_back({action, row, label, std::move(path)});
         y += BROWSER_NAV_ROW_H;
         ++hitIndex;
     };
 
     auto drawDivider = [&]() {
-        y += 5.0f;
+        y += compact ? 3.0f : 5.0f;
         renderer.drawLine({layout.navPane.x + 14.0f, y},
                           {layout.navPane.right() - 14.0f, y},
                           1.0f, divider.withAlpha(0.45f));
-        y += 8.0f;
+        y += compact ? 4.0f : 8.0f;
     };
 
     drawSection("Collections");
@@ -1046,7 +1135,7 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     navContentHeight_ = (y + navScrollOffset_) - navContentTop;
 
     // Restore the full-pane clip and draw a thin scroll thumb when content
-    // overflows the (preview-shortened) viewport.
+    // overflows the available viewport.
     renderer.setClipRect(layout.navPane);
     const float navOverflow = navContentHeight_ - navViewportHeight_;
     if (navOverflow > 0.5f && navViewportHeight_ > 0.0f) {
@@ -1264,6 +1353,10 @@ void FileBrowser::onRender(NUIRenderer& renderer) {
     NUIRect bounds = getBounds();
     if (bounds.isEmpty()) return;
 
+    // Specialized views (Plugins, Patterns, future browser modes) share this
+    // geometry even when the File Browser's static FBO cache is reused.
+    updateContentViews();
+
     // FBO Caching Logic
     auto* renderCache = renderer.getRenderCache();
     if (!renderCache || !renderCache->isEnabled()) {
@@ -1464,6 +1557,7 @@ void FileBrowser::onResize(int width, int height) {
     updateScrollbarVisibility();
     invalidateAllItemCaches(); // Force text re-layout on resize
     invalidateCache();
+    updateContentViews();
 }
 
 void FileBrowser::invalidateAllItemCaches() {
@@ -1652,8 +1746,7 @@ bool FileBrowser::onMouseEvent(const NUIMouseEvent& event) {
     }
 
     // === NAV PANE WHEEL (independent of the file list) ===
-    // Scroll the collections/categories/places column when it overflows —
-    // e.g. the preview dock is open and shortened the pane.
+    // Scroll the collections/categories/places column when it overflows.
     if (event.wheelDelta != 0 && browserLayout.navPane.contains(event.position)) {
         const float navOverflow = std::max(0.0f, navContentHeight_ - navViewportHeight_);
         if (navOverflow > 0.0f) {
@@ -1749,7 +1842,9 @@ bool FileBrowser::onMouseEvent(const NUIMouseEvent& event) {
                 hoveredIndex_ = -1;
                 setDirty(true); // hover overlay only — no cache rebuild
             }
-            AestraUI::NUIComponent::hideRemoteTooltip(this);
+            if (!browserLayout.navPane.contains(event.position)) {
+                AestraUI::NUIComponent::hideRemoteTooltip(this);
+            }
         }
 
         if (!event.cursorCaptured && isInsideList) {
@@ -2177,6 +2272,7 @@ void FileBrowser::onMouseLeave() {
         hoveredChromeAction_ = ChromeAction::None;
         setDirty(true); // hover overlay only — no cache rebuild
     }
+    NUIComponent::hideRemoteTooltip(this);
     NUIComponent::onMouseLeave();
 }
 
@@ -3564,6 +3660,14 @@ bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const B
         setDirty(true); // hover overlay only — no cache rebuild
     }
 
+    if (usesCompactNavigation() && newHovered >= 0 && newHovered < static_cast<int>(navHits_.size())) {
+        NUIPoint tooltipPosition = event.position;
+        tooltipPosition.x = layout.navPane.right() + 8.0f;
+        NUIComponent::showRemoteTooltip(navHits_[newHovered].label, tooltipPosition, this);
+    } else if (newHovered < 0 || !usesCompactNavigation()) {
+        NUIComponent::hideRemoteTooltip(this);
+    }
+
     if (!event.pressed || event.button != NUIMouseButton::Left || newHovered < 0 ||
         newHovered >= static_cast<int>(navHits_.size())) {
         return false;
@@ -3572,6 +3676,7 @@ bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const B
     const BrowserNavAction action = navHits_[newHovered].action;
     activeNavAction_ = action;
     activeNavPath_ = navHits_[newHovered].path;
+    updateContentViews();
     auto setFilter = [this](QuickFilter filter) {
         if (activeQuickFilter_ != filter) {
             activeQuickFilter_ = filter;
@@ -3818,6 +3923,17 @@ void FileBrowser::setSearchPlaceholder(const std::string& placeholder) {
     if (searchInput_ && searchInput_->getPlaceholderText() != placeholder) {
         searchInput_->setPlaceholderText(placeholder);
     }
+}
+
+void FileBrowser::setPreviewPanelVisible(bool visible) {
+    if (previewPanelVisible_ == visible) {
+        return;
+    }
+
+    previewPanelVisible_ = visible;
+    const auto bounds = getBounds();
+    onResize(static_cast<int>(bounds.width), static_cast<int>(bounds.height));
+    invalidateCache();
 }
 
 void FileBrowser::applyFilter() {

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -213,6 +213,7 @@ public:
     struct BrowserNavHit {
         BrowserNavAction action;
         NUIRect bounds;
+        std::string label;
         std::string path;
     };
 
@@ -238,7 +239,15 @@ public:
     /// never force a cache rebuild (see renderFileList / nav drawRow).
     void renderHoverOverlays(NUIRenderer& renderer);
     float getNavPaneWidth() const;
+    bool usesCompactNavigation() const;
     BrowserNavAction getActiveNavAction() const { return activeNavAction_; }
+
+    // Shared results-pane host for specialized browser views. FileBrowser owns
+    // their geometry and active-state visibility; the application retains the
+    // component lifetime and workspace z-order.
+    void registerContentView(BrowserNavAction action, const std::shared_ptr<NUIComponent>& component);
+    void setContentViewsEnabled(bool enabled);
+    NUIRect getContentViewBounds() const;
 
     void setOnNavActionSelected(std::function<void(BrowserNavAction)> callback) { onNavActionSelected_ = callback; }
 
@@ -412,7 +421,14 @@ public:
         };
         ChromeAction hoveredChromeAction_ = ChromeAction::None;
         std::vector<BrowserNavHit> navHits_;
-        // Nav pane vertical scroll (engages when the preview dock steals height).
+        struct BrowserContentView {
+            BrowserNavAction action;
+            std::weak_ptr<NUIComponent> component;
+        };
+        std::vector<BrowserContentView> contentViews_;
+        bool contentViewsEnabled_ = true;
+        void updateContentViews();
+        // Nav pane vertical scroll for short browser viewports.
         float navScrollOffset_ = 0.0f;   // current offset, clamped in render
         float navContentHeight_ = 0.0f;  // measured content height below the header
         float navViewportHeight_ = 0.0f; // visible content height below the header
@@ -428,22 +444,22 @@ public:
 	    std::vector<std::string> customPlacePaths_;
     
     // Preview panel state
-    bool previewPanelVisible_;
-    float previewPanelWidth_;
-    std::vector<float> waveformData_;      // Cached waveform amplitude data
-    bool isLoadingPreview_;                // True while loading waveform/preview
-    float loadingAnimationTime_;           // Animation timer for loading spinner
-    bool isLoadingPlayback_;               // True while loading audio for playback
-    bool wasLoadingPlayback_;              // Previous frame's playback loading state
-    
-    // Breadcrumb state
-    struct Breadcrumb {
-        std::string name;
-        std::string path;
-        std::vector<std::string> hiddenPaths; // For ellipsis menu
-        float x;
-        float width;
-    };
+        bool previewPanelVisible_{false};
+        float previewPanelWidth_{0.0f};
+        std::vector<float> waveformData_;  // Cached waveform amplitude data
+        bool isLoadingPreview_{false};     // True while loading waveform/preview
+        float loadingAnimationTime_{0.0f}; // Animation timer for loading spinner
+        bool isLoadingPlayback_;           // True while loading audio for playback
+        bool wasLoadingPlayback_;          // Previous frame's playback loading state
+
+        // Breadcrumb state
+        struct Breadcrumb {
+            std::string name;
+            std::string path;
+            std::vector<std::string> hiddenPaths; // For ellipsis menu
+            float x;
+            float width;
+        };
     std::vector<Breadcrumb> breadcrumbs_;
     int hoveredBreadcrumbIndex_;
     NUIRect breadcrumbBounds_;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1471,12 +1471,7 @@ void AestraContent::onResize(int width, int height) {
     const size_t browserTab = m_browserToggle ? m_browserToggle->getSelectedIndex() : 0;
     const auto activeNavAction =
         m_fileBrowser ? m_fileBrowser->getActiveNavAction() : AestraUI::FileBrowser::BrowserNavAction::Sounds;
-    float* activeBrowserWidthPref = &m_fileBrowserWidthPref;
-    if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
-        activeBrowserWidthPref = &m_pluginBrowserWidthPref;
-    } else if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
-        activeBrowserWidthPref = &m_patternNavBrowserWidthPref;
-    }
+    float* activeBrowserWidthPref = getActiveBrowserWidthPrefPtr();
     if (*activeBrowserWidthPref <= 0.0f) {
         *activeBrowserWidthPref = computedFileBrowserWidth;
     }
@@ -1865,16 +1860,25 @@ void AestraContent::syncViewState() {
 // SECTION: Panel State Persistence (Issue #120)
 // =============================================================================
 
-float AestraContent::getBrowserWidth() const {
-    float preferredWidth = m_fileBrowserWidthPref;
+float* AestraContent::getActiveBrowserWidthPrefPtr() {
+    return const_cast<float*>(static_cast<const AestraContent*>(this)->getActiveBrowserWidthPrefPtr());
+}
+
+const float* AestraContent::getActiveBrowserWidthPrefPtr() const {
     if (m_fileBrowser) {
         const auto action = m_fileBrowser->getActiveNavAction();
         if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
-            preferredWidth = m_pluginBrowserWidthPref;
-        } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
-            preferredWidth = m_patternNavBrowserWidthPref;
+            return &m_pluginBrowserWidthPref;
+        }
+        if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+            return &m_patternNavBrowserWidthPref;
         }
     }
+    return &m_fileBrowserWidthPref;
+}
+
+float AestraContent::getBrowserWidth() const {
+    const float preferredWidth = *getActiveBrowserWidthPrefPtr();
     if (preferredWidth > 0.0f) {
         return preferredWidth;
     }
@@ -1886,16 +1890,7 @@ float AestraContent::getBrowserWidth() const {
 
 void AestraContent::setBrowserWidth(float width) {
     if (width > 0.0f) {
-        float* preferredWidth = &m_fileBrowserWidthPref;
-        if (m_fileBrowser) {
-            const auto action = m_fileBrowser->getActiveNavAction();
-            if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
-                preferredWidth = &m_pluginBrowserWidthPref;
-            } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
-                preferredWidth = &m_patternNavBrowserWidthPref;
-            }
-        }
-        *preferredWidth = width;
+        *getActiveBrowserWidthPrefPtr() = width;
         onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
     }
 }
@@ -2392,16 +2387,7 @@ void AestraContent::updateBrowserResizeDrag(const AestraUI::NUIPoint& mouseScree
     const float deltaX = mouseScreen.x - m_browserResizeStartX;
 
     if (m_browserResizeTarget == BrowserResizeTarget::FileRail) {
-        float* preferredWidth = &m_fileBrowserWidthPref;
-        if (m_fileBrowser) {
-            const auto action = m_fileBrowser->getActiveNavAction();
-            if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
-                preferredWidth = &m_pluginBrowserWidthPref;
-            } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
-                preferredWidth = &m_patternNavBrowserWidthPref;
-            }
-        }
-        *preferredWidth = std::max(kMinFileBrowserWidth, m_browserResizeStartFileWidth + deltaX);
+        *getActiveBrowserWidthPrefPtr() = std::max(kMinFileBrowserWidth, m_browserResizeStartFileWidth + deltaX);
     } else if (m_browserResizeTarget == BrowserResizeTarget::PatternRail) {
         m_patternBrowserWidthPref = std::max(kMinPatternBrowserWidth, m_browserResizeStartPatternWidth + deltaX);
     }

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -70,7 +70,7 @@ using namespace AestraUI;
 using namespace Aestra::Audio;
 
 namespace {
-constexpr float kMinFileBrowserWidth = 300.0f;
+constexpr float kMinFileBrowserWidth = 260.0f;
 constexpr float kMinPatternBrowserWidth = 96.0f;
 constexpr float kMinTrackAreaWidth = 420.0f;
 constexpr float kResizeHitWidth = 6.0f;
@@ -399,36 +399,30 @@ AestraContent::AestraContent()
     m_fileBrowser->setOnNavActionSelected([this](AestraUI::FileBrowser::BrowserNavAction action) {
         const bool isPlugins = (action == AestraUI::FileBrowser::BrowserNavAction::Plugins);
         const bool isPatterns = (action == AestraUI::FileBrowser::BrowserNavAction::Patterns);
-        m_fileBrowser->setSearchPlaceholder(isPlugins ? "Search plugins..." : "Search library...");
-        if (m_pluginBrowser) {
-            m_pluginBrowser->setVisible(isPlugins);
-        }
+        m_fileBrowser->setSearchPlaceholder(isPlugins ? "Search plugins..."
+                                                      : (isPatterns ? "Search patterns..." : "Search library..."));
         if (m_patternBrowser) {
             if (isPatterns) {
                 m_patternBrowser->showPatternsTab();
                 m_patternBrowser->refreshPatterns();
-                m_patternBrowser->setVisible(true);
-            } else {
-                m_patternBrowser->setVisible(false);
             }
         }
-        if (isPlugins && m_fileBrowser && m_pluginBrowser) {
-            float navW = m_fileBrowser->getNavPaneWidth();
-            auto fbBounds = m_fileBrowser->getBounds();
-            float pbWidth = std::max(0.0f, fbBounds.width - navW);
-            // Cover from just below the search bar to the bottom (the "Plugins"
-            // header is offset internally via CONTENT_TOP_PAD, not by moving bounds).
-            constexpr float searchH = 28.0f;
-            m_pluginBrowser->setBounds(
-                AestraUI::NUIRect(fbBounds.x + navW, fbBounds.y + searchH, pbWidth,
-                                  std::max(0.0f, fbBounds.height - searchH)));
+        const std::string searchQuery = m_fileBrowser->getSearchQuery();
+        if (isPlugins && m_pluginBrowser) {
+            m_pluginBrowser->setSearchQuery(searchQuery);
+        } else if (isPatterns && m_patternBrowser) {
+            m_patternBrowser->setSearchQuery(searchQuery);
         }
         onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
     });
 
     m_fileBrowser->setOnSearchTextChanged([this](const std::string& text) {
-        if (m_pluginBrowser) {
+        const auto action =
+            m_fileBrowser ? m_fileBrowser->getActiveNavAction() : AestraUI::FileBrowser::BrowserNavAction::Sounds;
+        if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins && m_pluginBrowser) {
             m_pluginBrowser->setSearchQuery(text);
+        } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns && m_patternBrowser) {
+            m_patternBrowser->setSearchQuery(text);
         }
     });
 
@@ -506,6 +500,7 @@ AestraContent::AestraContent()
     m_pluginController->bindBrowser(m_pluginBrowser.get());
 
     m_workspaceLayer->addChild(m_pluginBrowser);
+    m_fileBrowser->registerContentView(AestraUI::FileBrowser::BrowserNavAction::Plugins, m_pluginBrowser);
 
     // Create file preview panel (add to workspace, below browser)
     m_previewPanel = std::make_shared<AestraUI::FilePreviewPanel>();
@@ -601,6 +596,7 @@ AestraContent::AestraContent()
         m_fileBrowser->selectFile(filePath);
     });
     m_workspaceLayer->addChild(m_patternBrowser);
+    m_fileBrowser->registerContentView(AestraUI::FileBrowser::BrowserNavAction::Patterns, m_patternBrowser);
 
     // Create panels (add to overlay)
     m_mixerPanel = std::make_shared<MixerPanel>(m_trackManager);
@@ -1394,7 +1390,10 @@ void AestraContent::onRender(AestraUI::NUIRenderer& renderer) {
     } else if (m_pluginBrowser && m_pluginBrowser->isVisible()) {
         drawDividerRail(m_pluginBrowser);
     }
-    if (m_patternBrowser && m_patternBrowser->isVisible()) {
+    const bool embeddedPatternVisible =
+        m_fileBrowser && m_fileBrowser->isVisible() &&
+        m_fileBrowser->getActiveNavAction() == AestraUI::FileBrowser::BrowserNavAction::Patterns;
+    if (m_patternBrowser && m_patternBrowser->isVisible() && !embeddedPatternVisible) {
         drawDividerRail(m_patternBrowser);
     }
 
@@ -1472,10 +1471,23 @@ void AestraContent::onResize(int width, int height) {
     const size_t browserTab = m_browserToggle ? m_browserToggle->getSelectedIndex() : 0;
     const auto activeNavAction =
         m_fileBrowser ? m_fileBrowser->getActiveNavAction() : AestraUI::FileBrowser::BrowserNavAction::Sounds;
+    float* activeBrowserWidthPref = &m_fileBrowserWidthPref;
+    if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
+        activeBrowserWidthPref = &m_pluginBrowserWidthPref;
+    } else if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+        activeBrowserWidthPref = &m_patternNavBrowserWidthPref;
+    }
+    if (*activeBrowserWidthPref <= 0.0f) {
+        *activeBrowserWidthPref = computedFileBrowserWidth;
+    }
     if (m_fileBrowser) {
-        m_fileBrowser->setSearchPlaceholder(
-            activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Plugins ? "Search plugins..."
-                                                                                : "Search library...");
+        if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
+            m_fileBrowser->setSearchPlaceholder("Search plugins...");
+        } else if (activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+            m_fileBrowser->setSearchPlaceholder("Search patterns...");
+        } else {
+            m_fileBrowser->setSearchPlaceholder("Search library...");
+        }
     }
     const bool legacyPatternTabActive = browserTab == 2;
     const bool patternNavActive = activeNavAction == AestraUI::FileBrowser::BrowserNavAction::Patterns;
@@ -1497,13 +1509,13 @@ void AestraContent::onResize(int width, int height) {
         patternRailVisible ? std::max(minPatternWidth, std::min(width * 0.24f, 280.0f)) : 0.0f;
     const float maxFileByTrack = std::max(kMinFileBrowserWidth, width - kMinTrackAreaWidth - minPatternWidth);
     const float fileBrowserWidth =
-        std::clamp(m_fileBrowserWidthPref, kMinFileBrowserWidth, std::min(maxFileBrowserWidth, maxFileByTrack));
+        std::clamp(*activeBrowserWidthPref, kMinFileBrowserWidth, std::min(maxFileBrowserWidth, maxFileByTrack));
     const float maxPatternByTrack = std::max(minPatternWidth, width - kMinTrackAreaWidth - fileBrowserWidth);
     const float patternBrowserWidth = patternRailVisible ? std::clamp(m_patternBrowserWidthPref, minPatternWidth,
                                                                       std::min(maxPatternWidth, maxPatternByTrack))
                                                          : 0.0f;
 
-    m_fileBrowserWidthPref = fileBrowserWidth;
+    *activeBrowserWidthPref = fileBrowserWidth;
     if (patternRailVisible) {
         m_patternBrowserWidthPref = patternBrowserWidth;
     }
@@ -1515,49 +1527,24 @@ void AestraContent::onResize(int width, int height) {
     if (m_previewPanel) {
         m_previewPanel->setVisible(showPreviewDock);
     }
+    if (m_fileBrowser) {
+        m_fileBrowser->setPreviewPanelVisible(showPreviewDock);
+    }
 
     // Browser toggle removed - browser panes now start directly at sidebarTopY without toggle offset
 
     if (m_fileBrowser) {
-        float fbTop = sidebarTopY;
-        float fbHeight = height - fbTop;
-
-        if (showPreviewDock) {
-            // Full browser width: the dock previously started at the nav-pane
-            // edge, leaving an unpainted (black) strip under the nav pane.
-            const float previewHeight = 68.0f;
-            fbHeight -= previewHeight;
-            m_previewPanel->setBounds(
-                AestraUI::NUIAbsolute(contentBounds, 0, fbTop + fbHeight, fileBrowserWidth, previewHeight));
-        }
-
+        const float fbTop = sidebarTopY;
+        const float fbHeight = height - fbTop;
         m_fileBrowser->setBounds(AestraUI::NUIAbsolute(contentBounds, 0, fbTop, fileBrowserWidth, fbHeight));
-    }
+        m_fileBrowser->setContentViewsEnabled(!isAuditionMode && m_fileBrowser->isVisible());
 
-    if (m_pluginBrowser) {
-        bool isPlugins = m_fileBrowser && m_fileBrowser->getActiveNavAction() == AestraUI::FileBrowser::BrowserNavAction::Plugins;
-        if (isPlugins && m_fileBrowser->isVisible()) {
-            // Overlay the file browser's actual bounds (which span full height),
-            // offset below its search bar, so the panel reaches the bottom and
-            // never leaks the file list behind it. Uses the same absolute bounds
-            // as the nav-action callback to avoid coordinate-convention drift.
-            // Cover the file browser from just below its search bar to the bottom,
-            // so nothing behind it (breadcrumb / Name header / file list) leaks. The
-            // "Plugins" header is offset DOWN inside the panel (CONTENT_TOP_PAD), not
-            // by moving the panel, so the placement stays without exposing the gap.
-            const auto fbB = m_fileBrowser->getBounds();
-            const float navW = m_fileBrowser->getNavPaneWidth();
-            constexpr float searchH = 28.0f;
-            const float pbTop = fbB.y + searchH;
-            m_pluginBrowser->setBounds(AestraUI::NUIRect(fbB.x + navW, pbTop,
-                                                         std::max(0.0f, fbB.width - navW),
-                                                         std::max(0.0f, fbB.bottom() - pbTop)));
-            m_pluginBrowser->setVisible(true);
-        } else {
-            float pbTop = sidebarTopY;
-            float pbHeight = height - pbTop;
-            m_pluginBrowser->setBounds(AestraUI::NUIAbsolute(contentBounds, 0, pbTop - contentBounds.y, fileBrowserWidth, pbHeight));
-            m_pluginBrowser->setVisible(false);
+        if (showPreviewDock && m_previewPanel) {
+            const auto browserLayout = m_fileBrowser->computeBrowserLayout();
+            const auto fbBounds = m_fileBrowser->getBounds();
+            m_previewPanel->setBounds(
+                AestraUI::NUIRect(browserLayout.list.x, browserLayout.list.bottom(), browserLayout.list.width,
+                                  std::max(0.0f, fbBounds.bottom() - browserLayout.list.bottom())));
         }
     }
 
@@ -1567,12 +1554,7 @@ void AestraContent::onResize(int width, int height) {
             m_patternBrowser->setBounds(
                 AestraUI::NUIAbsolute(contentBounds, 0.0f, clipTop, fileBrowserWidth, height - clipTop));
         } else if (patternNavActive && m_fileBrowser) {
-            const float navW = m_fileBrowser->getNavPaneWidth();
-            constexpr float searchH = 28.0f;
-            const float patternTop = sidebarTopY + searchH;
-            const float patternWidth = std::max(0.0f, fileBrowserWidth - navW);
-            m_patternBrowser->setBounds(
-                AestraUI::NUIAbsolute(contentBounds, navW, patternTop, patternWidth, height - patternTop));
+            // FileBrowser owns embedded Patterns geometry and visibility.
         } else {
             float patternBrowserX = fileBrowserWidth;
             float pbY = isAuditionMode ? 0.0f : transportHeight;
@@ -1735,7 +1717,7 @@ bool AestraContent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             m_browserResizing = true;
             m_browserResizeTarget = target;
             m_browserResizeStartX = event.position.x;
-            m_browserResizeStartFileWidth = std::max(kMinFileBrowserWidth, m_fileBrowserWidthPref);
+            m_browserResizeStartFileWidth = std::max(kMinFileBrowserWidth, getBrowserWidth());
             m_browserResizeStartPatternWidth = std::max(kMinPatternBrowserWidth, m_patternBrowserWidthPref);
             return true;
         }
@@ -1884,8 +1866,17 @@ void AestraContent::syncViewState() {
 // =============================================================================
 
 float AestraContent::getBrowserWidth() const {
-    if (m_fileBrowserWidthPref > 0.0f) {
-        return m_fileBrowserWidthPref;
+    float preferredWidth = m_fileBrowserWidthPref;
+    if (m_fileBrowser) {
+        const auto action = m_fileBrowser->getActiveNavAction();
+        if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
+            preferredWidth = m_pluginBrowserWidthPref;
+        } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+            preferredWidth = m_patternNavBrowserWidthPref;
+        }
+    }
+    if (preferredWidth > 0.0f) {
+        return preferredWidth;
     }
     if (m_fileBrowser) {
         return m_fileBrowser->getBounds().width;
@@ -1895,7 +1886,16 @@ float AestraContent::getBrowserWidth() const {
 
 void AestraContent::setBrowserWidth(float width) {
     if (width > 0.0f) {
-        m_fileBrowserWidthPref = width;
+        float* preferredWidth = &m_fileBrowserWidthPref;
+        if (m_fileBrowser) {
+            const auto action = m_fileBrowser->getActiveNavAction();
+            if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
+                preferredWidth = &m_pluginBrowserWidthPref;
+            } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+                preferredWidth = &m_patternNavBrowserWidthPref;
+            }
+        }
+        *preferredWidth = width;
         onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
     }
 }
@@ -2376,7 +2376,10 @@ AestraContent::hitTestBrowserResizeTarget(const AestraUI::NUIPoint& mouseScreen)
         return std::abs(mouseScreen.x - global.right()) <= kResizeHitWidth;
     };
 
-    if (isNearRightEdge(m_patternBrowser)) {
+    const bool embeddedPatternVisible =
+        m_fileBrowser && m_fileBrowser->isVisible() &&
+        m_fileBrowser->getActiveNavAction() == AestraUI::FileBrowser::BrowserNavAction::Patterns;
+    if (!embeddedPatternVisible && isNearRightEdge(m_patternBrowser)) {
         return BrowserResizeTarget::PatternRail;
     }
     if (isNearRightEdge(m_fileBrowser) || isNearRightEdge(m_pluginBrowser) || isNearRightEdge(m_previewPanel)) {
@@ -2389,7 +2392,16 @@ void AestraContent::updateBrowserResizeDrag(const AestraUI::NUIPoint& mouseScree
     const float deltaX = mouseScreen.x - m_browserResizeStartX;
 
     if (m_browserResizeTarget == BrowserResizeTarget::FileRail) {
-        m_fileBrowserWidthPref = std::max(kMinFileBrowserWidth, m_browserResizeStartFileWidth + deltaX);
+        float* preferredWidth = &m_fileBrowserWidthPref;
+        if (m_fileBrowser) {
+            const auto action = m_fileBrowser->getActiveNavAction();
+            if (action == AestraUI::FileBrowser::BrowserNavAction::Plugins) {
+                preferredWidth = &m_pluginBrowserWidthPref;
+            } else if (action == AestraUI::FileBrowser::BrowserNavAction::Patterns) {
+                preferredWidth = &m_patternNavBrowserWidthPref;
+            }
+        }
+        *preferredWidth = std::max(kMinFileBrowserWidth, m_browserResizeStartFileWidth + deltaX);
     } else if (m_browserResizeTarget == BrowserResizeTarget::PatternRail) {
         m_patternBrowserWidthPref = std::max(kMinPatternBrowserWidth, m_browserResizeStartPatternWidth + deltaX);
     }

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -309,6 +309,8 @@ private:
     };
     BrowserResizeTarget hitTestBrowserResizeTarget(const AestraUI::NUIPoint& mouseScreen) const;
     void updateBrowserResizeDrag(const AestraUI::NUIPoint& mouseScreen);
+    float* getActiveBrowserWidthPrefPtr();
+    const float* getActiveBrowserWidthPrefPtr() const;
 
     // Pattern loop length helpers
     double getActivePatternLengthBeats() const;

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -333,6 +333,8 @@ private:
     std::shared_ptr<Aestra::Audio::PatternBrowserPanel> m_patternBrowser;
     bool m_pluginScanWasRunning{false};
     float m_fileBrowserWidthPref{-1.0f};
+    float m_pluginBrowserWidthPref{-1.0f};
+    float m_patternNavBrowserWidthPref{-1.0f};
     float m_patternBrowserWidthPref{-1.0f};
     bool m_browserResizing{false};
     BrowserResizeTarget m_browserResizeTarget{BrowserResizeTarget::None};

--- a/Source/Panels/PatternBrowserPanel.cpp
+++ b/Source/Panels/PatternBrowserPanel.cpp
@@ -534,6 +534,23 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
         const bool dropActive = m_isDragOver;
         const bool noSearchResults = !m_searchQuery.empty();
         const bool compactRail = bounds.width < 170.0f;
+        struct EmptyStateCopy {
+            std::string chipLabel;
+            std::string chipDetail;
+            std::string title;
+            std::string detailLine1;
+            std::string detailLine2;
+        } copy;
+        if (dropActive) {
+            copy = {"Drop", "release", "Release To Import", "Release audio files here", "to add them to Clips"};
+        } else if (noSearchResults) {
+            copy = {"No matches", "ready", "No Matching Results", "Try a different name", ""};
+        } else if (m_mode == BrowserMode::Patterns) {
+            copy = {"Patterns", "ready", "No Patterns Yet", "Create a pattern, or drop files", "to switch into Clips"};
+        } else {
+            copy = {"Clips", "ready", "Clip Bin Ready", "Clip Bin stages files for fast timeline placement",
+                    "Use Clips as an optional bin"};
+        }
         if (compactRail) {
             renderer.fillRect(listRect, theme.getColor("backgroundSecondary"));
             const AestraUI::NUIRect chip{
@@ -548,14 +565,9 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
             renderer.strokeRoundedRect(chip, themeProps.radiusS + 1.0f, 1.0f,
                                        dropActive ? theme.getColor("accentPrimary").withAlpha(0.38f)
                                                   : theme.getColor("borderSubtle").withAlpha(0.070f));
-            renderer.drawTextCentered(
-                dropActive
-                    ? "Drop"
-                    : (noSearchResults ? "No matches" : (m_mode == BrowserMode::Patterns ? "Patterns" : "Clips")),
-                chip, 10.5f, theme.getColor("textPrimary").withAlpha(dropActive ? 0.92f : 0.70f));
-            renderer.drawTextCentered(dropActive ? "release" : "ready",
-                                      {chip.x, chip.bottom() + 7.0f, chip.width, 14.0f},
-                                      9.0f,
+            renderer.drawTextCentered(copy.chipLabel, chip, 10.5f,
+                                      theme.getColor("textPrimary").withAlpha(dropActive ? 0.92f : 0.70f));
+            renderer.drawTextCentered(copy.chipDetail, {chip.x, chip.bottom() + 7.0f, chip.width, 14.0f}, 9.0f,
                                       theme.getColor("textSecondary").withAlpha(0.56f));
             return;
         }
@@ -574,30 +586,6 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
                                    dropActive ? accent.withAlpha(0.26f)
                                               : theme.getColor("borderSubtle").withAlpha(0.24f));
 
-        const std::string title =
-            dropActive ? "Release To Import"
-                       : (noSearchResults ? "No Matching Results"
-                                          : (m_mode == BrowserMode::Patterns ? "No Patterns Yet" : "Clip Bin Ready"));
-        const std::string detailLine1 =
-            compactRail
-                ? (dropActive
-                       ? "Release to import"
-                       : (noSearchResults ? "Try another search"
-                                          : (m_mode == BrowserMode::Patterns ? "Create or drop MIDI"
-                                                                             : "Drop files, then paint or drag")))
-                : (dropActive ? "Release audio files here"
-                              : (noSearchResults ? "Try a different name"
-                                                 : (m_mode == BrowserMode::Patterns
-                                                        ? "Create a pattern, or drop files"
-                                                        : "Clip Bin stages files for fast timeline placement")));
-        const std::string detailLine2 =
-            compactRail
-                ? ""
-                : (dropActive ? "to add them to Clips"
-                              : (noSearchResults ? ""
-                                                 : (m_mode == BrowserMode::Patterns ? "to switch into Clips"
-                                                                                    : "Use Clips as an optional bin")));
-
         const AestraUI::NUIRect iconChip{
             stateCard.center().x - (compactRail ? 20.0f : 26.0f),
             stateCard.y + (compactRail ? 12.0f : 20.0f),
@@ -614,19 +602,18 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
                                   iconChip,
                                   compactRail ? 8.0f : 9.0f,
                                   dropActive ? theme.getColor("textPrimary") : theme.getColor("textSecondary").withAlpha(0.92f));
-        renderer.drawTextCentered(title,
-                                  {stateCard.x + 14.0f, iconChip.bottom() + (compactRail ? 8.0f : 12.0f), stateCard.width - 28.0f, 18.0f},
-                                  compactRail ? 11.0f : 13.0f,
-                                  theme.getColor("textPrimary").withAlpha(0.94f));
-        renderer.drawTextCentered(detailLine1,
-                                  {stateCard.x + 14.0f, iconChip.bottom() + (compactRail ? 24.0f : 34.0f), stateCard.width - 28.0f, 14.0f},
-                                  compactRail ? 9.0f : 10.5f,
-                                  theme.getColor("textSecondary").withAlpha(0.86f));
-        if (!detailLine2.empty()) {
-            renderer.drawTextCentered(detailLine2,
+        renderer.drawTextCentered(
+            copy.title,
+            {stateCard.x + 14.0f, iconChip.bottom() + (compactRail ? 8.0f : 12.0f), stateCard.width - 28.0f, 18.0f},
+            compactRail ? 11.0f : 13.0f, theme.getColor("textPrimary").withAlpha(0.94f));
+        renderer.drawTextCentered(
+            copy.detailLine1,
+            {stateCard.x + 14.0f, iconChip.bottom() + (compactRail ? 24.0f : 34.0f), stateCard.width - 28.0f, 14.0f},
+            compactRail ? 9.0f : 10.5f, theme.getColor("textSecondary").withAlpha(0.86f));
+        if (!copy.detailLine2.empty()) {
+            renderer.drawTextCentered(copy.detailLine2,
                                       {stateCard.x + 24.0f, iconChip.bottom() + 48.0f, stateCard.width - 48.0f, 14.0f},
-                                      10.5f,
-                                      theme.getColor("textSecondary").withAlpha(0.86f));
+                                      10.5f, theme.getColor("textSecondary").withAlpha(0.86f));
         }
 
         if (!compactRail) {

--- a/Source/Panels/PatternBrowserPanel.cpp
+++ b/Source/Panels/PatternBrowserPanel.cpp
@@ -122,10 +122,7 @@ AestraUI::NUIRect computePlayButtonRect(const AestraUI::NUIRect& cardRect) {
 } // namespace
 
 PatternBrowserPanel::PatternBrowserPanel(TrackManager* trackManager)
-    : m_trackManager(trackManager)
-    , m_headerHeight(40.0f) 
-    , m_itemHeight(44.0f)
-{
+    : m_trackManager(trackManager), m_headerHeight(40.0f), m_itemHeight(38.0f) {
     setId("PatternBrowserPanel");
     
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
@@ -260,8 +257,12 @@ PatternBrowserPanel::~PatternBrowserPanel() {
 
 void PatternBrowserPanel::refreshPatterns() {
     m_patterns.clear();
-    if (!m_trackManager) return;
-    
+    if (!m_trackManager) {
+        rebuildFilteredItems();
+        setDirty(true);
+        return;
+    }
+
     auto& playlistModel = m_trackManager->getPlaylistModel();
     auto allPatterns = m_trackManager->getPatternManager().getAllPatterns();
     for (const auto& p : allPatterns) {
@@ -289,6 +290,7 @@ void PatternBrowserPanel::refreshPatterns() {
         return lhs.id.value < rhs.id.value;
     });
 
+    rebuildFilteredItems();
     setDirty(true);
 }
 
@@ -316,9 +318,44 @@ void PatternBrowserPanel::showClipsTab() {
     switchMode(BrowserMode::Clips);
 }
 
+void PatternBrowserPanel::setSearchQuery(const std::string& query) {
+    if (m_searchQuery == query) {
+        return;
+    }
+    m_searchQuery = query;
+    m_scrollOffset = 0.0f;
+    m_targetScrollOffset = 0.0f;
+    rebuildFilteredItems();
+    setDirty(true);
+}
+
+void PatternBrowserPanel::rebuildFilteredItems() {
+    m_filteredPatternIndices.clear();
+    m_filteredClipIndices.clear();
+    m_filteredPatternIndices.reserve(m_patterns.size());
+    m_filteredClipIndices.reserve(m_clips.size());
+    const std::string query = toLowerASCII(m_searchQuery);
+    for (size_t i = 0; i < m_patterns.size(); ++i) {
+        if (query.empty() || toLowerASCII(m_patterns[i].name).find(query) != std::string::npos) {
+            m_filteredPatternIndices.push_back(i);
+        }
+    }
+    for (size_t i = 0; i < m_clips.size(); ++i) {
+        const auto& clip = m_clips[i];
+        if (query.empty() || toLowerASCII(clip.name).find(query) != std::string::npos ||
+            toLowerASCII(clip.filename).find(query) != std::string::npos) {
+            m_filteredClipIndices.push_back(i);
+        }
+    }
+}
+
 void PatternBrowserPanel::refreshClips() {
     m_clips.clear();
-    if (!m_trackManager) return;
+    if (!m_trackManager) {
+        rebuildFilteredItems();
+        setDirty(true);
+        return;
+    }
 
     std::unordered_set<uint64_t> placedSourceIds;
     auto& playlistModel = m_trackManager->getPlaylistModel();
@@ -370,6 +407,7 @@ void PatternBrowserPanel::refreshClips() {
         return lhs.id.value < rhs.id.value;
     });
 
+    rebuildFilteredItems();
     setDirty(true);
 }
 
@@ -446,13 +484,18 @@ void PatternBrowserPanel::renderHeader(AestraUI::NUIRenderer& renderer) {
         );
     }
 
-    const size_t itemCount = (m_mode == BrowserMode::Clips) ? m_clips.size() : m_patterns.size();
-    const std::string title = (m_mode == BrowserMode::Clips ? "Clips (" : "Patterns (") + std::to_string(itemCount) + ")";
-    renderer.drawText(title,
-                      AestraUI::NUIPoint(bounds.x + 10.0f, bounds.y + 12.0f),
-                      themeProps.fontSizeXS,
-                      theme.getColor("textPrimary").withAlpha(0.78f));
-    
+    const size_t itemCount =
+        (m_mode == BrowserMode::Clips) ? getFilteredClipIndices().size() : getFilteredPatternIndices().size();
+    const size_t totalCount = (m_mode == BrowserMode::Clips) ? m_clips.size() : m_patterns.size();
+    const std::string title = m_mode == BrowserMode::Clips ? "Clips" : "Patterns";
+    renderer.drawText(title, AestraUI::NUIPoint(bounds.x + 12.0f, bounds.y + 12.0f), themeProps.fontSizeXS,
+                      theme.getColor("textPrimary").withAlpha(0.88f));
+    const float titleWidth = renderer.measureText(title, themeProps.fontSizeXS).width;
+    const std::string count = m_searchQuery.empty() ? std::to_string(totalCount)
+                                                    : std::to_string(itemCount) + " / " + std::to_string(totalCount);
+    renderer.drawText(count, AestraUI::NUIPoint(bounds.x + 18.0f + titleWidth, bounds.y + 13.0f), 10.0f,
+                      theme.getColor("textSecondary").withAlpha(0.48f));
+
     // Mode toggle is rendered by addChild mechanism automatically
     // The buttons are also rendered by addChild mechanism
     
@@ -482,12 +525,14 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
     AestraUI::NUIRect listRect(bounds.x, bounds.y + m_headerHeight, bounds.width, bounds.height - m_headerHeight - m_footerHeight);
     
     // Check if empty
-    bool isEmpty = (m_mode == BrowserMode::Patterns) ? m_patterns.empty() : m_clips.empty();
-    
+    const bool isEmpty =
+        (m_mode == BrowserMode::Patterns) ? getFilteredPatternIndices().empty() : getFilteredClipIndices().empty();
+
     if (isEmpty) {
         auto& theme = AestraUI::NUIThemeManager::getInstance();
         const auto& themeProps = theme.getCurrentTheme();
         const bool dropActive = m_isDragOver;
+        const bool noSearchResults = !m_searchQuery.empty();
         const bool compactRail = bounds.width < 170.0f;
         if (compactRail) {
             renderer.fillRect(listRect, theme.getColor("backgroundSecondary"));
@@ -503,10 +548,11 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
             renderer.strokeRoundedRect(chip, themeProps.radiusS + 1.0f, 1.0f,
                                        dropActive ? theme.getColor("accentPrimary").withAlpha(0.38f)
                                                   : theme.getColor("borderSubtle").withAlpha(0.070f));
-            renderer.drawTextCentered(dropActive ? "Drop" : (m_mode == BrowserMode::Patterns ? "Patterns" : "Clips"),
-                                      chip,
-                                      10.5f,
-                                      theme.getColor("textPrimary").withAlpha(dropActive ? 0.92f : 0.70f));
+            renderer.drawTextCentered(
+                dropActive
+                    ? "Drop"
+                    : (noSearchResults ? "No matches" : (m_mode == BrowserMode::Patterns ? "Patterns" : "Clips")),
+                chip, 10.5f, theme.getColor("textPrimary").withAlpha(dropActive ? 0.92f : 0.70f));
             renderer.drawTextCentered(dropActive ? "release" : "ready",
                                       {chip.x, chip.bottom() + 7.0f, chip.width, 14.0f},
                                       9.0f,
@@ -528,23 +574,29 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
                                    dropActive ? accent.withAlpha(0.26f)
                                               : theme.getColor("borderSubtle").withAlpha(0.24f));
 
-        const std::string title = dropActive
-            ? "Release To Import"
-            : (m_mode == BrowserMode::Patterns ? "No Patterns Yet" : "Clip Bin Ready");
-        const std::string detailLine1 = compactRail
-            ? (dropActive ? "Release to import" : (m_mode == BrowserMode::Patterns ? "Create or drop MIDI" : "Drop files, then paint or drag"))
-            : (dropActive
-            ? "Release audio files here"
-            : (m_mode == BrowserMode::Patterns
-                ? "Create a pattern, or drop files"
-                : "Clip Bin stages files for fast timeline placement"));
-        const std::string detailLine2 = compactRail
-            ? ""
-            : (dropActive
-            ? "to add them to Clips"
-            : (m_mode == BrowserMode::Patterns
-                ? "to switch into Clips"
-                : "Use Clips as an optional bin"));
+        const std::string title =
+            dropActive ? "Release To Import"
+                       : (noSearchResults ? "No Matching Results"
+                                          : (m_mode == BrowserMode::Patterns ? "No Patterns Yet" : "Clip Bin Ready"));
+        const std::string detailLine1 =
+            compactRail
+                ? (dropActive
+                       ? "Release to import"
+                       : (noSearchResults ? "Try another search"
+                                          : (m_mode == BrowserMode::Patterns ? "Create or drop MIDI"
+                                                                             : "Drop files, then paint or drag")))
+                : (dropActive ? "Release audio files here"
+                              : (noSearchResults ? "Try a different name"
+                                                 : (m_mode == BrowserMode::Patterns
+                                                        ? "Create a pattern, or drop files"
+                                                        : "Clip Bin stages files for fast timeline placement")));
+        const std::string detailLine2 =
+            compactRail
+                ? ""
+                : (dropActive ? "to add them to Clips"
+                              : (noSearchResults ? ""
+                                                 : (m_mode == BrowserMode::Patterns ? "to switch into Clips"
+                                                                                    : "Use Clips as an optional bin")));
 
         const AestraUI::NUIRect iconChip{
             stateCard.center().x - (compactRail ? 20.0f : 26.0f),
@@ -606,8 +658,9 @@ void PatternBrowserPanel::renderContent(AestraUI::NUIRenderer& renderer) {
 void PatternBrowserPanel::renderPatternList(AestraUI::NUIRenderer& renderer) {
     auto bounds = getBounds();
     float y = bounds.y + m_headerHeight - m_scrollOffset;
-    
-    for (const auto& entry : m_patterns) {
+
+    for (const size_t index : getFilteredPatternIndices()) {
+        const auto& entry = m_patterns[index];
         if (y + m_itemHeight < bounds.y + m_headerHeight) { y += m_itemHeight; continue; } 
         if (y > bounds.y + bounds.height) break;
         
@@ -622,8 +675,9 @@ void PatternBrowserPanel::renderPatternList(AestraUI::NUIRenderer& renderer) {
 void PatternBrowserPanel::renderClipList(AestraUI::NUIRenderer& renderer) {
     auto bounds = getBounds();
     float y = bounds.y + m_headerHeight - m_scrollOffset;
-    
-    for (const auto& entry : m_clips) {
+
+    for (const size_t index : getFilteredClipIndices()) {
+        const auto& entry = m_clips[index];
         if (y + m_itemHeight < bounds.y + m_headerHeight) { y += m_itemHeight; continue; }
         if (y > bounds.y + bounds.height) break;
         
@@ -700,6 +754,8 @@ void PatternBrowserPanel::renderPatternItem(AestraUI::NUIRenderer& renderer, con
 bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     auto b = getBounds();
     auto& dragManager = AestraUI::NUIDragDropManager::getInstance();
+    const auto filteredPatterns = getFilteredPatternIndices();
+    const auto filteredClips = getFilteredClipIndices();
 
     if (!b.contains(event.position) && !m_dragPotential) {
         return NUIComponent::onMouseEvent(event);
@@ -727,8 +783,8 @@ bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         float listScrollY = relativeY - m_headerHeight + m_scrollOffset;
         int itemIndex = static_cast<int>(listScrollY / m_itemHeight);
         if (m_mode == BrowserMode::Patterns) {
-            if (itemIndex >= 0 && itemIndex < static_cast<int>(m_patterns.size())) {
-                const auto& pattern = m_patterns[itemIndex];
+            if (itemIndex >= 0 && itemIndex < static_cast<int>(filteredPatterns.size())) {
+                const auto& pattern = m_patterns[filteredPatterns[static_cast<size_t>(itemIndex)]];
                 m_hoveredPatternId = pattern.id;
                 const AestraUI::NUIRect cardRect = computeBinCardRect(b, b.y + m_headerHeight + (itemIndex * m_itemHeight) - m_scrollOffset, m_itemHeight);
                 const AestraUI::NUIRect playButtonRect = computePlayButtonRect(cardRect);
@@ -777,7 +833,7 @@ bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_hoveredPatternId = PatternID();
             }
 
-            if (m_dragPotential && itemIndex >= 0 && itemIndex < static_cast<int>(m_patterns.size())) {
+            if (m_dragPotential && itemIndex >= 0 && itemIndex < static_cast<int>(filteredPatterns.size())) {
                 float dx = event.position.x - m_dragStartPos.x;
                 float dy = event.position.y - m_dragStartPos.y;
                 float dist = std::sqrt(dx * dx + dy * dy);
@@ -808,8 +864,8 @@ bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 }
             }
         } else {
-            if (itemIndex >= 0 && itemIndex < static_cast<int>(m_clips.size())) {
-                const auto& clip = m_clips[itemIndex];
+            if (itemIndex >= 0 && itemIndex < static_cast<int>(filteredClips.size())) {
+                const auto& clip = m_clips[filteredClips[static_cast<size_t>(itemIndex)]];
                 m_hoveredClipId = clip.id;
                 const AestraUI::NUIRect cardRect = computeBinCardRect(b, b.y + m_headerHeight + (itemIndex * m_itemHeight) - m_scrollOffset, m_itemHeight);
                 const AestraUI::NUIRect playButtonRect = computePlayButtonRect(cardRect);
@@ -849,13 +905,13 @@ bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_hoveredClipId = ClipSourceID{};
             }
 
-            if (m_dragPotential && itemIndex >= 0 && itemIndex < static_cast<int>(m_clips.size())) {
+            if (m_dragPotential && itemIndex >= 0 && itemIndex < static_cast<int>(filteredClips.size())) {
                 float dx = event.position.x - m_dragStartPos.x;
                 float dy = event.position.y - m_dragStartPos.y;
                 float dist = std::sqrt(dx * dx + dy * dy);
 
                 if (dist >= dragManager.getDragThreshold()) {
-                    const auto& clip = m_clips[itemIndex];
+                    const auto& clip = m_clips[filteredClips[static_cast<size_t>(itemIndex)]];
                     AestraUI::DragData dragData;
                     dragData.type = AestraUI::DragDataType::File;
                     dragData.filePath = clip.filename;
@@ -885,7 +941,9 @@ bool PatternBrowserPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     
     // Mouse Wheel - Scroll Handling
     if (std::abs(event.wheelDelta) > 0.001f && getBounds().contains(event.position)) {
-        float listHeight = (m_mode == BrowserMode::Patterns) ? m_patterns.size() * m_itemHeight : m_clips.size() * m_itemHeight;
+        const float itemCount =
+            static_cast<float>((m_mode == BrowserMode::Patterns) ? filteredPatterns.size() : filteredClips.size());
+        float listHeight = itemCount * m_itemHeight;
         float viewportHeight = b.height - m_headerHeight - m_footerHeight;
         float maxScroll = std::max(0.0f, listHeight - viewportHeight);
         
@@ -995,9 +1053,9 @@ void PatternBrowserPanel::onUpdate(double deltaTime) {
     if (m_modeToggle) m_modeToggle->onUpdate(deltaTime);
     ensureDropTargetRegistration();
     const float viewportHeight = std::max(0.0f, getBounds().height - m_headerHeight - m_footerHeight);
-    const float listHeight = ((m_mode == BrowserMode::Patterns)
-        ? static_cast<float>(m_patterns.size())
-        : static_cast<float>(m_clips.size())) * m_itemHeight;
+    const float itemCount = static_cast<float>((m_mode == BrowserMode::Patterns) ? getFilteredPatternIndices().size()
+                                                                                 : getFilteredClipIndices().size());
+    const float listHeight = itemCount * m_itemHeight;
     const float maxScroll = std::max(0.0f, listHeight - viewportHeight);
     m_targetScrollOffset = safeClampBrowserScroll(m_targetScrollOffset, maxScroll);
     m_scrollOffset = safeClampBrowserScroll(m_scrollOffset, maxScroll);

--- a/Source/Panels/PatternBrowserPanel.h
+++ b/Source/Panels/PatternBrowserPanel.h
@@ -54,6 +54,7 @@ public:
     bool usesCompactRail() const;
     void showPatternsTab();
     void showClipsTab();
+    void setSearchQuery(const std::string& query);
 
     // IDropTarget Implementation
     AestraUI::DropFeedback onDragEnter(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) override;
@@ -101,7 +102,10 @@ private:
         bool isPlacedOnTimeline = false;
     };
     std::vector<ClipEntry> m_clips;
-    
+    std::string m_searchQuery;
+    std::vector<size_t> m_filteredPatternIndices;
+    std::vector<size_t> m_filteredClipIndices;
+
     Aestra::Audio::PatternID m_selectedPatternId;
     Aestra::Audio::PatternID m_hoveredPatternId;
     Aestra::Audio::ClipSourceID m_selectedClipId;
@@ -110,7 +114,7 @@ private:
     // UI Layout
     float m_headerHeight = 40.0f; // Header now contains Buttons
     float m_footerHeight = 0.0f;
-    float m_itemHeight = 32.0f;
+    float m_itemHeight = 38.0f;
     float m_scrollOffset = 0.0f;
     float m_targetScrollOffset = 0.0f;
     
@@ -170,7 +174,10 @@ private:
     void renderContent(AestraUI::NUIRenderer& renderer);
     void renderPatternList(AestraUI::NUIRenderer& renderer);
     void renderClipList(AestraUI::NUIRenderer& renderer);
-    
+    void rebuildFilteredItems();
+    const std::vector<size_t>& getFilteredPatternIndices() const { return m_filteredPatternIndices; }
+    const std::vector<size_t>& getFilteredClipIndices() const { return m_filteredClipIndices; }
+
     void renderPatternItem(AestraUI::NUIRenderer& renderer, const PatternEntry& entry, float y, bool selected, bool hovered);
     void renderClipItem(AestraUI::NUIRenderer& renderer, const ClipEntry& entry, float y, bool selected, bool hovered);
     


### PR DESCRIPTION
## Summary

- make the File Browser navigation adapt into a compact icon rail at narrow widths
- host Plugins and Patterns in one shared results-pane layout with centralized geometry, visibility, and input ownership
- route the shared search field into plugin and pattern filtering, with responsive per-mode widths and clearer empty states
- keep preview controls confined to the file-results column and prevent inactive browser views from receiving pointer events

## Why

The browser modes had separate layout assumptions, so UI polish required repeated mode-specific offsets and could produce overlap or click-through regressions. This follow-up gives File Browser one host contract for specialized content views and builds directly on #510.

## Testing performed

- `cmake --build build-linux --target Aestra -j2`
- `build/headless/Tests/FileBrowserStressTest` (9 passed)
- `build-linux/Tests/NUITextInputLayoutTest` (10 passed)
- `build-linux/Tests/PluginBrowserSelectionTest`
- `git clang-format --staged --diff`
- manual Linux UI verification: Plugins and Patterns share the adaptive browser layout; Scan no longer selects or opens a hidden pattern in Piano Roll

## Docs updated?

No public behavior or documentation contract changed.

## Risk / rollback

Risk is limited to browser layout, filtering, resizing, and input routing. No DSP, audio-thread, serialization, or project-format behavior changed. Roll back this commit to restore the prior panel-specific layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Unified File Browser, Plugins, and Patterns into a responsive shared layout, including compact navigation at narrow widths and mode-specific resizing.
- Centralized browser geometry, preview visibility, content-view ownership, and input routing.
- Connected shared search to plugin and pattern filtering, with filtered counts, scrolling, selection, and clearer empty states.
- Improved tooltip and pointer-event handling so inactive views do not intercept interaction.
- Added separate remembered widths for library, plugin, and pattern views.
- Validated with Linux builds, browser/text-input tests, formatting checks, and manual responsive-layout verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->