### PR TITLE
fix(vst3): own module handle with typed RAII

### DIFF
--- a/AestraAudio/include/Plugin/VST3Host.h
+++ b/AestraAudio/include/Plugin/VST3Host.h
@@ -102,6 +102,8 @@ public:
     bool isCrashed() const override;
 
 private:
+    struct ModuleHolder;
+
     bool m_loaded = false;
     bool m_active = false;
     bool m_editorOpen = false;
@@ -119,8 +121,9 @@ private:
     double m_sampleRate = 44100.0;
     uint32_t m_maxBlockSize = 512;
 
-    // VST3 SDK objects (using void* to avoid header pollution, cast in .cpp)
-    void* m_module = nullptr;          // VST3::Hosting::Module
+    // VST3 SDK objects. ModuleHolder keeps the SDK module type out of this
+    // public header while retaining typed RAII ownership in VST3Host.cpp.
+    std::unique_ptr<ModuleHolder> m_module;
     void* m_factory = nullptr;         // IPluginFactory*
     void* m_hostApplication = nullptr; // VST3::HostApplication
     void* m_component = nullptr;       // IComponent*

--- a/AestraAudio/src/Plugin/VST3Host.cpp
+++ b/AestraAudio/src/Plugin/VST3Host.cpp
@@ -35,6 +35,12 @@ using namespace Steinberg::Vst;
 namespace Aestra {
 namespace Audio {
 
+struct VST3PluginInstance::ModuleHolder {
+    explicit ModuleHolder(VST3::Hosting::Module::Ptr moduleIn) : module(std::move(moduleIn)) {}
+
+    VST3::Hosting::Module::Ptr module;
+};
+
 // Helper for UTF-16 (VST3) to UTF-8 (Aestra) conversion
 static std::string utf16_to_utf8(const Steinberg::Vst::TChar* str) {
     if (!str)
@@ -117,8 +123,8 @@ bool VST3PluginInstance::load(const std::filesystem::path& path, int classIndex)
             return false;
         }
 
-        m_module = new VST3::Hosting::Module::Ptr(std::move(module));
-        auto& mod = *static_cast<VST3::Hosting::Module::Ptr*>(m_module);
+        m_module = std::make_unique<ModuleHolder>(std::move(module));
+        auto& mod = m_module->module;
         m_hostApplication = new HostApplication();
         auto hostApplication = static_cast<HostApplication*>(m_hostApplication);
 
@@ -263,10 +269,7 @@ void VST3PluginInstance::unload() {
         m_component = nullptr;
     }
 
-    if (m_module) {
-        delete static_cast<VST3::Hosting::Module::Ptr*>(m_module);
-        m_module = nullptr;
-    }
+    m_module.reset();
 
     if (m_hostApplication) {
         delete static_cast<HostApplication*>(m_hostApplication);


### PR DESCRIPTION
## Summary

- replace the type-erased, manually allocated VST3 `Module::Ptr` wrapper with a private RAII holder
- keep Steinberg SDK types out of the public header
- release module ownership through `std::unique_ptr::reset()` during unload

## Why

The existing `void*` storage required allocation, casting, and deletion to stay perfectly paired. Typed RAII makes ownership and exception cleanup explicit without making public/core builds depend on VST3 SDK types.

Closes #200.

## Testing performed

- `cmake -S . -B build-linux`
- `cmake --build build-linux --target AestraAudioCore -j2`
- built and ran `AestraWatchdogTest` and `AestraCrashTest`
- ran the existing `VST3PluginTest` smoke executable
- repeated real-module load, initialize/shutdown, reload, unload, and destruction for 25 cycles against LSP VST3
- rebuilt the affected target and lifecycle tests with ASan + UBSan
- isolated `Module::Ptr` ownership passed 25 LeakSanitizer cycles with no leaks
- `clang-format --dry-run --Werror`
- `git diff --check`

## Docs updated?

No. This is an internal ownership correction with no user-facing or public API change.

## Risk / rollback

- no DSP, audio output, latency, realtime-path, or state-format behavior changed
- the public header still hides Steinberg SDK implementation types
- rollback is the single commit in this PR
- a separate LSP component-initialization retention finding was observed during extended diagnostics; it originates beyond the module-holder path and is not attributed to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes or public API changes.
- Replaced the untyped `void*` VST3 module storage with a private typed RAII holder using `std::unique_ptr`.
- Ensured module ownership is released safely via `reset()`, including exception and unload paths.
- Kept Steinberg SDK types out of public headers while preserving existing DSP, audio, latency, realtime, and state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->