### PR TITLE
Fix touchpad scrolling in file and plugin browsers

### DIFF
--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -173,16 +173,28 @@ bool PlatformWindowLinux::pollEvents() {
 
         case SDL_MOUSEWHEEL:
             if (m_mouseWheelCallback) {
-                float delta = static_cast<float>(e.wheel.y);
+                // Preserve high-resolution touchpad deltas. SDL's integer x/y
+                // fields may round a fractional gesture to zero, which leaves
+                // drag scrollbars working while two-finger scrolling appears dead.
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+                const float verticalDelta = e.wheel.preciseY;
+                const float horizontalDelta = e.wheel.preciseX;
+#else
+                const float verticalDelta = static_cast<float>(e.wheel.y);
+                const float horizontalDelta = static_cast<float>(e.wheel.x);
+#endif
+                float delta = verticalDelta;
                 // Use magnitude comparison to detect horizontal vs vertical gestures
                 // This handles touchpads that may report both axes for the same gesture
-                const bool horizontalGesture = (std::abs(e.wheel.x) > std::abs(e.wheel.y));
+                const bool horizontalGesture = (std::abs(horizontalDelta) > std::abs(verticalDelta));
                 if (horizontalGesture) {
                     // SDL wheel.x > 0 means scroll right, map to negative delta so consumers
                     // that do target -= wheelDelta move view content to the right.
-                    delta = -static_cast<float>(e.wheel.x);
+                    delta = -horizontalDelta;
                     m_syntheticShiftForHorizontalWheel = true;
                 }
+                if (e.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
+                    delta = -delta;
                 m_mouseWheelCallback(delta);
                 m_syntheticShiftForHorizontalWheel = false;
             }

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -542,10 +542,10 @@ bool PluginBrowserPanel::onMouseEvent(const NUIMouseEvent& event) {
         float listHeight = bounds.height - CONTENT_TOP_PAD - HEADER_BAR_HEIGHT - FILTER_BAR_HEIGHT - 4.0f;
         float contentHeight = m_filteredPlugins.size() * ROW_HEIGHT;
         float maxScroll = std::max(0.0f, contentHeight - listHeight);
-
         m_targetScrollOffset -= event.wheelDelta * 40.0f;
         if (m_targetScrollOffset < 0.0f) m_targetScrollOffset = 0.0f;
         if (m_targetScrollOffset > maxScroll) m_targetScrollOffset = maxScroll;
+        repaint();
         return true;
     }
 
@@ -598,8 +598,12 @@ void PluginBrowserPanel::onUpdate(double deltaTime) {
     float diff = m_targetScrollOffset - m_scrollOffset;
     if (std::abs(diff) > 0.5f) {
         m_scrollOffset += diff * std::min(1.0f, static_cast<float>(deltaTime * 15.0));
+        repaint();
     } else {
-        m_scrollOffset = m_targetScrollOffset;
+        if (m_scrollOffset != m_targetScrollOffset) {
+            m_scrollOffset = m_targetScrollOffset;
+            repaint();
+        }
     }
 }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1687,6 +1687,41 @@ bool AestraContent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         return false;
     }
 
+    // Wheel events need explicit hit routing because workspace siblings overlap
+    // the browser's screen area and the generic child dispatcher only follows
+    // z-order. Keep floating overlays first, then route the visible browser view
+    // under the pointer before the timeline can consume the gesture.
+    if (event.wheelDelta != 0.0f) {
+        if (m_overlayLayer && m_overlayLayer->onMouseEvent(event)) {
+            return true;
+        }
+
+        if (m_fileBrowser && m_fileBrowser->isVisible() && m_fileBrowser->isEnabled() &&
+            m_fileBrowser->getBounds().contains(event.position)) {
+            const auto activeView = m_fileBrowser->getActiveNavAction();
+            if (activeView == AestraUI::FileBrowser::BrowserNavAction::Plugins && m_pluginBrowser &&
+                m_pluginBrowser->isVisible() && m_pluginBrowser->isEnabled() &&
+                m_pluginBrowser->getBounds().contains(event.position) && m_pluginBrowser->onMouseEvent(event)) {
+                return true;
+            }
+            if (activeView == AestraUI::FileBrowser::BrowserNavAction::Patterns && m_patternBrowser &&
+                m_patternBrowser->isVisible() && m_patternBrowser->isEnabled() &&
+                m_patternBrowser->getBounds().contains(event.position) &&
+                static_cast<AestraUI::NUIComponent*>(m_patternBrowser.get())->onMouseEvent(event)) {
+                return true;
+            }
+            if (m_fileBrowser->onMouseEvent(event)) {
+                return true;
+            }
+
+            // Do not let a wheel gesture over browser chrome fall through to
+            // the timeline merely because the current browser pane cannot scroll.
+            return true;
+        }
+
+        return m_workspaceLayer && m_workspaceLayer->onMouseEvent(event);
+    }
+
     if (!m_browserResizing && event.pressed && m_overlayLayer && m_overlayLayer->onMouseEvent(event)) {
         return true;
     }


### PR DESCRIPTION
## Summary

- preserve SDL high-resolution touchpad wheel deltas, including flipped and horizontal gestures
- route wheel events to the active browser view before overlapping workspace siblings can consume them
- repaint the plugin browser during smooth-scroll animation

## Why

Two-finger scrolling reached SDL and the platform bridge but never reached `FileBrowser` when the pointer was over filename rows. The generic workspace dispatcher followed sibling z-order rather than the browser hit target. The plugin browser also updated its scroll target without consistently scheduling frames, making smooth scrolling appear inert.

## User impact

Laptop touchpad scrolling now works in both the Files list and Plugins list. Scrollbar dragging and timeline/transport scrolling remain available in their own hit regions, and floating overlay panels retain input priority.

## Validation

- `cmake --build build-linux --target Aestra -j2`
- `cmake --build build-linux -j2`
- `git diff --check`
- manual Linux touchpad runtime verification in Files and Plugins (confirmed working)

## Risk / rollback

Low-to-moderate UI input-routing risk. The explicit browser route is limited to wheel events inside the visible browser bounds and keeps overlay dispatch first. Revert commit `ada27d3b` to roll back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Preserve high-resolution SDL touchpad wheel deltas, including flipped and horizontal gestures.
- Route wheel input to the active file or plugin browser before workspace content, while preserving overlay and timeline behavior.
- Repaint plugin browser scrolling during smooth animation and final offset updates so touchpad scrolling remains responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->