### PR TITLE
Overhaul AestraFilter with a live response editor

### DIFF
--- a/AestraAudio/include/Plugin/AestraFilter.h
+++ b/AestraAudio/include/Plugin/AestraFilter.h
@@ -366,7 +366,7 @@ public:
     bool openEditor(void*) override { return false; }
     void closeEditor() override {}
     bool isEditorOpen() const override { return false; }
-    std::pair<int, int> getEditorSize() const override { return {520, 320}; }
+    std::pair<int, int> getEditorSize() const override { return {700, 420}; }
     bool resizeEditor(int, int) override { return false; }
 
     const PluginInfo& getInfo() const override { return m_info; }

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -23,10 +23,13 @@ NUIColor accent() {
     return NUIColor(0.28f, 0.72f, 0.62f, 1.0f);
 } // filter teal
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return NUIColor(0.018f, 0.021f, 0.022f, 0.98f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return NUIColor(0.028f, 0.034f, 0.035f, 0.98f);
+}
+NUIColor gridColor() {
+    return NUIColor(0.45f, 0.58f, 0.56f, 0.12f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -60,33 +63,46 @@ void AestraFilterEditor::setPlatformBridge(NUIPlatformBridge* bridge) {
     AestraPanelWindow::setPlatformBridge(bridge);
 }
 
+void AestraFilterEditor::onUpdate(double deltaTime) {
+    AestraPanelWindow::onUpdate(deltaTime);
+    if (!isVisible())
+        return;
+
+    // The response display follows the audio-thread envelope meter. Refresh at
+    // a bounded UI rate so motion is readable without forcing full-frame redraws.
+    m_visualRefreshTimer += deltaTime;
+    if (m_visualRefreshTimer >= (1.0 / 30.0)) {
+        m_visualRefreshTimer = 0.0;
+        setDirty(true);
+    }
+}
+
 void AestraFilterEditor::layoutControls() {
     const auto b = getBounds();
     const float contentTop = b.y + AestraPanelWindow::TITLE_BAR_H;
 
-    // Type selector: three segments across the top-left
-    constexpr float kSegW = 58.0f;
-    constexpr float kSegH = 26.0f;
+    constexpr float kSegW = 82.0f;
+    constexpr float kSegH = 28.0f;
     for (size_t i = 0; i < m_typeRects.size(); ++i) {
         m_typeRects[i] =
-            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kSegW + 6.0f), contentTop + 16.0f, kSegW, kSegH);
+            NUIRect(b.x + 28.0f + static_cast<float>(i) * (kSegW + 6.0f), contentTop + 20.0f, kSegW, kSegH);
     }
 
-    constexpr float kBypassW = 88.0f;
-    constexpr float kBypassH = 26.0f;
-    m_bypassRect = NUIRect(b.right() - 44.0f - kBypassW, contentTop + 16.0f, kBypassW, kBypassH);
+    constexpr float kBypassW = 96.0f;
+    constexpr float kBypassH = 28.0f;
+    m_bypassRect = NUIRect(b.right() - 28.0f - kBypassW, contentTop + 20.0f, kBypassW, kBypassH);
 
-    // Large cutoff knob on the left; two rows of small knobs to its right
-    const float knobTop = contentTop + 58.0f;
-    m_cutoffRect = NUIRect(b.x + 44.0f, knobTop + 6.0f, 118.0f, 118.0f);
-    m_resoRect = NUIRect(b.x + 208.0f, knobTop, 66.0f, 66.0f);
-    m_driveRect = NUIRect(b.x + 314.0f, knobTop, 66.0f, 66.0f);
-    m_envRect = NUIRect(b.x + 420.0f, knobTop, 66.0f, 66.0f);
-    m_attackRect = NUIRect(b.x + 261.0f, knobTop + 96.0f, 54.0f, 54.0f);
-    m_releaseRect = NUIRect(b.x + 367.0f, knobTop + 96.0f, 54.0f, 54.0f);
+    const float upperTop = contentTop + 72.0f;
+    m_responseRect = NUIRect(b.x + 28.0f, upperTop, 410.0f, 192.0f);
+    m_cutoffRect = NUIRect(b.x + 470.0f, upperTop + 5.0f, 132.0f, 132.0f);
+    m_resoRect = NUIRect(b.x + 618.0f, upperTop + 8.0f, 58.0f, 58.0f);
+    m_driveRect = NUIRect(b.x + 618.0f, upperTop + 99.0f, 58.0f, 58.0f);
 
-    const float sliderY = std::min(knobTop + 172.0f, b.bottom() - 44.0f);
-    m_mixRect = NUIRect(b.x + 58.0f, sliderY, b.width - 116.0f, 34.0f);
+    const float lowerTop = contentTop + 278.0f;
+    m_envRect = NUIRect(b.x + 44.0f, lowerTop + 8.0f, 62.0f, 62.0f);
+    m_attackRect = NUIRect(b.x + 145.0f, lowerTop + 8.0f, 62.0f, 62.0f);
+    m_releaseRect = NUIRect(b.x + 246.0f, lowerTop + 8.0f, 62.0f, 62.0f);
+    m_mixRect = NUIRect(b.x + 370.0f, lowerTop + 22.0f, b.right() - (b.x + 370.0f) - 28.0f, 38.0f);
 }
 
 void AestraFilterEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
@@ -96,17 +112,128 @@ void AestraFilterEditor::drawContent(NUIRenderer& renderer, const NUIRect& conte
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, accent().withAlpha(0.16f));
 
     drawTypeSelector(renderer);
     drawBypassPill(renderer);
+    drawResponseDisplay(renderer);
     drawKnob(renderer, m_cutoffRect, AestraFilter::kCutoff, "Cutoff", true, false);
-    drawKnob(renderer, m_resoRect, AestraFilter::kReso, "Reso", false, false);
+    drawKnob(renderer, m_resoRect, AestraFilter::kReso, "Resonance", false, false);
     drawKnob(renderer, m_driveRect, AestraFilter::kDrive, "Drive", false, false);
-    drawKnob(renderer, m_envRect, AestraFilter::kEnvAmount, "Env", false, true);
-    drawKnob(renderer, m_attackRect, AestraFilter::kEnvAttack, "Atk", false, false);
-    drawKnob(renderer, m_releaseRect, AestraFilter::kEnvRelease, "Rel", false, false);
+    drawSectionLabel(renderer, "ENVELOPE MOTION", NUIRect(m_envRect.x, m_envRect.y - 22.0f, 266.0f, 14.0f));
+    drawKnob(renderer, m_envRect, AestraFilter::kEnvAmount, "Amount", false, true);
+    drawKnob(renderer, m_attackRect, AestraFilter::kEnvAttack, "Attack", false, false);
+    drawKnob(renderer, m_releaseRect, AestraFilter::kEnvRelease, "Release", false, false);
+    drawSectionLabel(renderer, "BLEND", NUIRect(m_mixRect.x, m_mixRect.y - 22.0f, m_mixRect.width, 14.0f));
     drawMixSlider(renderer);
+}
+
+void AestraFilterEditor::drawSectionLabel(NUIRenderer& renderer, const char* label, const NUIRect& bounds) {
+    auto& theme = NUIThemeManager::getInstance();
+    renderer.drawText(label, {bounds.x, bounds.y}, 9.0f, theme.getColor("textSecondary").withAlpha(0.62f));
+    const float labelWidth = renderer.measureText(label, 9.0f).width;
+    renderer.drawLine({bounds.x + labelWidth + 9.0f, bounds.y + 6.0f}, {bounds.right(), bounds.y + 6.0f}, 1.0f,
+                      accent().withAlpha(0.16f));
+}
+
+void AestraFilterEditor::drawResponseDisplay(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    renderer.fillRoundedRect(m_responseRect, 12.0f, insetSurface());
+    renderer.strokeRoundedRect(m_responseRect, 12.0f, 1.0f, accent().withAlpha(0.22f));
+
+    renderer.drawText("FILTER RESPONSE", {m_responseRect.x + 14.0f, m_responseRect.y + 10.0f}, 9.0f,
+                      theme.getColor("textSecondary").withAlpha(0.68f));
+
+    const auto filter = std::dynamic_pointer_cast<AestraFilter>(m_instance);
+    const float envelope = filter ? std::clamp(filter->getEnvelopeLevel(), 0.0f, 1.0f) : 0.0f;
+    const float cutoffNorm = m_instance->getParameter(AestraFilter::kCutoff);
+    const float baseCutoff = AestraFilter::cutoffHzFromNorm(cutoffNorm);
+    const float envAmount = 2.0f * m_instance->getParameter(AestraFilter::kEnvAmount) - 1.0f;
+    const float modCutoff =
+        std::clamp(baseCutoff * std::exp2(envAmount * AestraFilter::kEnvModOctaves * envelope), 20.0f, 20000.0f);
+    const float q = AestraFilter::qFromNorm(m_instance->getParameter(AestraFilter::kReso));
+    const auto type = AestraFilter::typeFromNorm(m_instance->getParameter(AestraFilter::kType));
+
+    const int envPct = static_cast<int>(std::round(envelope * 100.0f));
+    const std::string envLabel = "ENV " + std::to_string(envPct) + "%";
+    const float envLabelW = renderer.measureText(envLabel, 9.0f).width;
+    renderer.drawText(envLabel, {m_responseRect.right() - envLabelW - 14.0f, m_responseRect.y + 10.0f}, 9.0f,
+                      accent().withAlpha(0.82f));
+
+    // Keep a dedicated scale gutter below the plot so frequency labels never
+    // sit on the response border or compete with the live envelope meter.
+    const NUIRect graph{m_responseRect.x + 14.0f, m_responseRect.y + 31.0f, m_responseRect.width - 28.0f,
+                        m_responseRect.height - 65.0f};
+    renderer.fillRoundedRect(graph, 7.0f, NUIColor(0.006f, 0.010f, 0.011f, 0.98f));
+
+    auto xForHz = [&graph](float hz) {
+        const float norm = std::log10(std::clamp(hz, 20.0f, 20000.0f) / 20.0f) / 3.0f;
+        return graph.x + norm * graph.width;
+    };
+    auto yForDb = [&graph](float db) {
+        constexpr float kTopDb = 18.0f;
+        constexpr float kBottomDb = -36.0f;
+        return graph.y + (kTopDb - std::clamp(db, kBottomDb, kTopDb)) / (kTopDb - kBottomDb) * graph.height;
+    };
+
+    for (float db : {-24.0f, -12.0f, 0.0f, 12.0f}) {
+        const float y = yForDb(db);
+        renderer.drawLine({graph.x, y}, {graph.right(), y}, db == 0.0f ? 1.2f : 1.0f,
+                          gridColor().withAlpha(db == 0.0f ? 0.22f : 0.12f));
+    }
+
+    struct FrequencyGuide {
+        float hz;
+        const char* label;
+    };
+    static constexpr FrequencyGuide kGuides[] = {
+        {20.0f, "20"}, {100.0f, "100"}, {1000.0f, "1k"}, {10000.0f, "10k"}, {20000.0f, "20k"},
+    };
+    for (const auto& guide : kGuides) {
+        const float x = xForHz(guide.hz);
+        renderer.drawLine({x, graph.y}, {x, graph.bottom()}, 1.0f, gridColor());
+        const float labelW = renderer.measureText(guide.label, 8.0f).width;
+        renderer.drawText(guide.label,
+                          {std::clamp(x - labelW * 0.5f, graph.x, graph.right() - labelW), graph.bottom() + 5.0f},
+                          8.0f, theme.getColor("textSecondary").withAlpha(0.58f));
+    }
+
+    auto drawResponse = [&](float cutoff, NUIColor color, float thickness) {
+        std::array<NUIPoint, 129> points{};
+        for (size_t i = 0; i < points.size(); ++i) {
+            const float t = static_cast<float>(i) / static_cast<float>(points.size() - 1);
+            const float freq = 20.0f * std::pow(1000.0f, t);
+            const float ratio = freq / std::max(20.0f, cutoff);
+            const float ratio2 = ratio * ratio;
+            const float damping = ratio / q;
+            const float denominator = std::sqrt((1.0f - ratio2) * (1.0f - ratio2) + damping * damping);
+            float magnitude = 1.0f / std::max(1.0e-5f, denominator);
+            if (type == AestraFilter::kTypeBandPass)
+                magnitude *= ratio;
+            else if (type == AestraFilter::kTypeHighPass)
+                magnitude *= ratio2;
+            const float db = 20.0f * std::log10(std::max(1.0e-5f, magnitude));
+            points[i] = {graph.x + t * graph.width, yForDb(db)};
+        }
+        renderer.drawPolyline(points.data(), static_cast<int>(points.size()), thickness, color);
+    };
+
+    renderer.setClipRect(graph);
+    const bool modulationActive = std::abs(envAmount) > 0.005f;
+    if (modulationActive) {
+        drawResponse(baseCutoff, theme.getColor("textSecondary").withAlpha(0.28f), 1.5f);
+        renderer.drawLine({xForHz(baseCutoff), graph.y}, {xForHz(baseCutoff), graph.bottom()}, 1.0f,
+                          theme.getColor("textSecondary").withAlpha(0.20f));
+    }
+    drawResponse(modCutoff, accent().withAlpha(0.96f), 2.4f);
+    renderer.drawLine({xForHz(modCutoff), graph.y}, {xForHz(modCutoff), graph.bottom()}, 1.2f,
+                      accent().withAlpha(0.34f));
+    renderer.clearClipRect();
+
+    const NUIRect envTrack{graph.x, m_responseRect.bottom() - 8.0f, graph.width, 3.0f};
+    renderer.fillRoundedRect(envTrack, 1.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.06f));
+    renderer.fillRoundedRect({envTrack.x, envTrack.y, envTrack.width * envelope, envTrack.height}, 1.5f,
+                             accent().withAlpha(0.72f));
 }
 
 void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label,
@@ -151,17 +278,17 @@ void AestraFilterEditor::drawTypeSelector(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
     const auto type = m_instance ? AestraFilter::typeFromNorm(m_instance->getParameter(AestraFilter::kType))
                                  : AestraFilter::kTypeLowPass;
-    static constexpr const char* kLabels[] = {"LP", "BP", "HP"};
+    static constexpr const char* kLabels[] = {"LOW PASS", "BAND PASS", "HIGH PASS"};
     for (size_t i = 0; i < m_typeRects.size(); ++i) {
         const bool selected = static_cast<uint32_t>(type) == i;
         if (selected) {
             renderer.fillRoundedRect(m_typeRects[i], 7.0f, accent().withAlpha(0.26f));
             renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, accent().withAlpha(0.62f));
-            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 10.5f, accent().withAlpha(0.98f));
+            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_typeRects[i], 7.0f, insetSurface());
             renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
-            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 10.5f,
+            renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }
     }

--- a/AestraUI/Widgets/AestraFilterEditor.h
+++ b/AestraUI/Widgets/AestraFilterEditor.h
@@ -15,6 +15,7 @@ class AestraFilterEditor : public AestraPanelWindow {
 public:
     explicit AestraFilterEditor(std::shared_ptr<Aestra::Audio::IPluginInstance> instance);
     void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
+    void onUpdate(double deltaTime) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onResize(int width, int height) override;
     using AestraPanelWindow::onResize;
@@ -23,6 +24,8 @@ public:
 
 private:
     void layoutControls();
+    void drawResponseDisplay(NUIRenderer& renderer);
+    void drawSectionLabel(NUIRenderer& renderer, const char* label, const NUIRect& bounds);
     void drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint32_t paramId, const char* label, bool large,
                   bool bipolar);
     void drawTypeSelector(NUIRenderer& renderer);
@@ -35,6 +38,7 @@ private:
     std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
 
     NUIRect m_cutoffRect;
+    NUIRect m_responseRect;
     NUIRect m_resoRect;
     NUIRect m_driveRect;
     NUIRect m_envRect;
@@ -51,9 +55,10 @@ private:
     float m_dragStartValue = 0.0f;
     bool m_draggingMix = false;
     bool m_bypassHovered = false;
+    double m_visualRefreshTimer = 0.0;
 
-    static constexpr float kWinW = 520.0f;
-    static constexpr float kWinH = 320.0f;
+    static constexpr float kWinW = 700.0f;
+    static constexpr float kWinH = 420.0f;
 };
 
 } // namespace AestraUI


### PR DESCRIPTION
## Summary

- redesign AestraFilter as a larger, sectioned 700×420 editor
- add a live log-frequency response display for LP/BP/HP modes
- show the base response and envelope-modulated response together, including live cutoff motion and envelope activity
- clarify filter type, motion, color, and blend controls with full labels and improved spacing
- reserve a dedicated frequency-label gutter so scale labels stay clear of the plot edge

## Why

The filter DSP already had a strong ZDF core and extensive regression coverage, but the original compact knob grid did not explain what the filter or its bipolar envelope modulation was doing. The new editor makes the sonic result and modulation range visible without changing the DSP or parameter/state contract.

## User impact

AestraFilter is faster to understand and tune, especially for envelope-driven sweeps. Users can see the static cutoff, the currently modulated cutoff, the response shape, resonance, and live envelope level in one view.

## Validation

- `cmake --build build-linux --target Aestra AestraFilterPluginTest -j2`
- `build-linux/Tests/AestraFilterPluginTest` — all 22 tests passed
- `build-linux/Tests/AestraFilterBench` — baseline captured before UI work; 16 instances at 48 kHz/256 samples used 8.5% of callback budget on this machine
- `git diff --check`
- manual Linux visual review approved

## Risk / rollback

Low UI risk. Audio processing, latency, parameter IDs, defaults, and serialized state format are unchanged. The only plugin metadata change is the preferred editor size. Revert commit `518e54e1` to roll back.