### PR TITLE
feat(delay): smooth transitions and overhaul editor

### DIFF
--- a/AestraAudio/include/Plugin/AestraDelay.h
+++ b/AestraAudio/include/Plugin/AestraDelay.h
@@ -106,7 +106,10 @@ public:
     void deactivate() override { m_active.store(false, std::memory_order_relaxed); }
     bool isActive() const override { return m_active.load(std::memory_order_relaxed); }
 
-    void setBPM(float bpm) { m_bpm.store(std::clamp(bpm, 20.0f, 999.0f), std::memory_order_relaxed); }
+    void setBPM(float bpm) {
+        if (std::isfinite(bpm))
+            m_bpm.store(std::clamp(bpm, 20.0f, 999.0f), std::memory_order_relaxed);
+    }
 
     float getBPM() const { return m_bpm.load(std::memory_order_relaxed); }
 
@@ -115,12 +118,14 @@ public:
         (void)midiInput;
         (void)midiOutput;
 
-        if (!m_active.load(std::memory_order_relaxed) || m_params[kBypass].load(std::memory_order_relaxed) > 0.5f) {
+        if (!m_active.load(std::memory_order_relaxed)) {
             for (uint32_t ch = 0; ch < numOutputChannels; ++ch) {
-                if (outputs[ch] && ch < numInputChannels && inputs[ch])
-                    std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
-                else if (outputs[ch])
+                if (outputs[ch] && ch < numInputChannels && inputs[ch]) {
+                    if (outputs[ch] != inputs[ch])
+                        std::memcpy(outputs[ch], inputs[ch], numFrames * sizeof(float));
+                } else if (outputs[ch]) {
                     std::memset(outputs[ch], 0, numFrames * sizeof(float));
+                }
             }
             return;
         }
@@ -145,6 +150,13 @@ public:
         float hpfPrevInR = m_hpfPrevInR;
         float hpfPrevOutL = m_hpfPrevOutL;
         float hpfPrevOutR = m_hpfPrevOutR;
+        float delaySamplesCurrentL = m_delaySamplesCurrentL;
+        float delaySamplesCurrentR = m_delaySamplesCurrentR;
+        float delaySamplesTargetL = m_delaySamplesTargetL;
+        float delaySamplesTargetR = m_delaySamplesTargetR;
+        uint32_t delayTransitionRemaining = m_delayTransitionRemaining;
+        uint32_t delayTransitionTotal = m_delayTransitionTotal;
+        bool delayTapInitialized = m_delayTapInitialized;
 
         constexpr float pi = 3.14159265358979323846f;
         constexpr float twoPi = 2.0f * pi;
@@ -167,6 +179,7 @@ public:
             const float hpfCoeff = std::exp(-twoPi * hpfCutoffHz * invSampleRate);
             const float outputTrim = std::pow(10.0f, (m_outputTrimSmoothed * 24.0f - 12.0f) / 20.0f);
             const bool pingPong = m_params[kStereoMode].load(std::memory_order_relaxed) > 0.5f;
+            const bool bypassed = m_params[kBypass].load(std::memory_order_relaxed) > 0.5f;
 
             const float maxShiftMs = std::min(delayMs * 0.5f, 500.0f * 1000.0f * invSampleRate);
             const float stereoOffsetMs = stereoShift * maxShiftMs;
@@ -176,6 +189,17 @@ public:
                                                        1.0f, static_cast<float>((bufMask + 1) - 2));
             const float delaySamplesBaseR = std::clamp(effectiveDelayMsR * static_cast<float>(m_sampleRate) / 1000.0f,
                                                        1.0f, static_cast<float>((bufMask + 1) - 2));
+            if (!delayTapInitialized) {
+                delaySamplesCurrentL = delaySamplesTargetL = delaySamplesBaseL;
+                delaySamplesCurrentR = delaySamplesTargetR = delaySamplesBaseR;
+                delayTapInitialized = true;
+            } else if (delayTransitionRemaining == 0 && (std::abs(delaySamplesBaseL - delaySamplesCurrentL) > 0.25f ||
+                                                         std::abs(delaySamplesBaseR - delaySamplesCurrentR) > 0.25f)) {
+                delaySamplesTargetL = delaySamplesBaseL;
+                delaySamplesTargetR = delaySamplesBaseR;
+                delayTransitionTotal = std::max<uint32_t>(32u, static_cast<uint32_t>(std::round(m_sampleRate * 0.020)));
+                delayTransitionRemaining = delayTransitionTotal;
+            }
             const float maxModSamples = std::min(std::min(delaySamplesBaseL, delaySamplesBaseR) * 0.25f,
                                                  static_cast<float>(m_sampleRate) * 0.0005f);
             const float pingPongPeriodBase = std::max(1.0f, std::round((delaySamplesBaseL + delaySamplesBaseR) * 0.5f));
@@ -186,17 +210,35 @@ public:
                     lfoPhase -= 1.0f;
                 const float lfo = std::sin(twoPi * lfoPhase) * modDepth * maxModSamples;
 
-                const float delaySamplesL = delaySamplesBaseL + lfo;
-                const float delaySamplesR = delaySamplesBaseR - lfo;
-
-                const float inL = (numInputChannels > 0 && inputs[0]) ? inputs[0][i] : 0.0f;
-                const float inR = (numInputChannels > 1 && inputs[1]) ? inputs[1][i] : inL;
+                const float rawInL = (numInputChannels > 0 && inputs[0]) ? inputs[0][i] : 0.0f;
+                const float rawInR = (numInputChannels > 1 && inputs[1]) ? inputs[1][i] : rawInL;
+                const float inL = sanitizeDelayValue(rawInL);
+                const float inR = sanitizeDelayValue(rawInR);
                 const float monoIn = (inL + inR) * 0.5f;
                 const bool pingPongInjectLeft =
                     ((pingPongSampleCounter / static_cast<uint64_t>(pingPongPeriodBase)) & 1ULL) == 0ULL;
 
-                const float delayOutL = readDelayLine(m_bufL, pos, delaySamplesL, bufMask);
-                const float delayOutR = readDelayLine(m_bufR, pos, delaySamplesR, bufMask);
+                float delayOutL = 0.0f;
+                float delayOutR = 0.0f;
+                if (delayTransitionRemaining > 0 && delayTransitionTotal > 0) {
+                    const float linearFade =
+                        1.0f - static_cast<float>(delayTransitionRemaining) / static_cast<float>(delayTransitionTotal);
+                    const float fade = linearFade * linearFade * (3.0f - 2.0f * linearFade);
+                    const float oldL = readDelayLine(m_bufL, pos, delaySamplesCurrentL + lfo, bufMask);
+                    const float oldR = readDelayLine(m_bufR, pos, delaySamplesCurrentR - lfo, bufMask);
+                    const float nextL = readDelayLine(m_bufL, pos, delaySamplesTargetL + lfo, bufMask);
+                    const float nextR = readDelayLine(m_bufR, pos, delaySamplesTargetR - lfo, bufMask);
+                    delayOutL = oldL + (nextL - oldL) * fade;
+                    delayOutR = oldR + (nextR - oldR) * fade;
+                    --delayTransitionRemaining;
+                    if (delayTransitionRemaining == 0) {
+                        delaySamplesCurrentL = delaySamplesTargetL;
+                        delaySamplesCurrentR = delaySamplesTargetR;
+                    }
+                } else {
+                    delayOutL = readDelayLine(m_bufL, pos, delaySamplesCurrentL + lfo, bufMask);
+                    delayOutR = readDelayLine(m_bufR, pos, delaySamplesCurrentR - lfo, bufMask);
+                }
 
                 constexpr float kPingPongBleed = 0.18f;
                 constexpr float kPingPongBleedNorm = 1.0f / (1.0f + kPingPongBleed);
@@ -231,10 +273,15 @@ public:
                 const float outR = sanitizeDelayValue((inR * (1.0f - mix) + wetR * mix) * outputTrim);
 
                 if (numOutputChannels > 0 && outputs[0])
-                    outputs[0][i] = outL;
+                    outputs[0][i] = bypassed ? rawInL : outL;
                 if (numOutputChannels > 1 && outputs[1])
-                    outputs[1][i] = outR;
+                    outputs[1][i] = bypassed ? rawInR : outR;
             }
+        }
+
+        for (uint32_t ch = 2; ch < numOutputChannels; ++ch) {
+            if (outputs[ch])
+                std::memset(outputs[ch], 0, numFrames * sizeof(float));
         }
 
         m_lfoPhase = lfoPhase;
@@ -246,6 +293,13 @@ public:
         m_hpfPrevOutR = hpfPrevOutR;
         m_pos = pos;
         m_pingPongSampleCounter = pingPongSampleCounter;
+        m_delaySamplesCurrentL = delaySamplesCurrentL;
+        m_delaySamplesCurrentR = delaySamplesCurrentR;
+        m_delaySamplesTargetL = delaySamplesTargetL;
+        m_delaySamplesTargetR = delaySamplesTargetR;
+        m_delayTransitionRemaining = delayTransitionRemaining;
+        m_delayTransitionTotal = delayTransitionTotal;
+        m_delayTapInitialized = delayTapInitialized;
     }
 
     uint32_t getParameterCount() const override { return kParamCount; }
@@ -257,7 +311,7 @@ public:
     }
 
     void setParameter(uint32_t id, float value) override {
-        if (id >= kParamCount)
+        if (id >= kParamCount || !std::isfinite(value))
             return;
         m_params[id].store(std::clamp(value, 0.0f, 1.0f), std::memory_order_relaxed);
     }
@@ -427,7 +481,10 @@ public:
     bool loadState(const std::vector<uint8_t>& state) override {
         if (state.size() < sizeof(uint32_t) * 2)
             return false;
-        struct Header { uint32_t magic; uint32_t version; };
+        struct Header {
+            uint32_t magic;
+            uint32_t version;
+        };
         Header header_local;
         std::memcpy(&header_local, state.data(), sizeof(header_local));
         if (header_local.magic == kStateMagicV3) {
@@ -440,6 +497,8 @@ public:
                 return false;
             StateBlobV3 blob_local;
             std::memcpy(&blob_local, state.data(), sizeof(blob_local));
+            if (blob_local.version != 3 || !allFinite(blob_local.params))
+                return false;
             for (uint32_t i = 0; i < kParamCount; ++i)
                 setParameter(i, blob_local.params[i]);
             snapSmoothedParamsToTargets();
@@ -455,6 +514,8 @@ public:
                 return false;
             LegacyStateBlobV2 blob_local;
             std::memcpy(&blob_local, state.data(), sizeof(blob_local));
+            if (blob_local.version != 2 || !allFinite(blob_local.params))
+                return false;
             for (uint32_t i = 0; i < 11; ++i)
                 setParameter(i, blob_local.params[i]);
             setParameter(kFeedbackHighpass, 0.0f);
@@ -472,6 +533,8 @@ public:
                 return false;
             StateBlobV1 blob_local;
             std::memcpy(&blob_local, state.data(), sizeof(blob_local));
+            if (blob_local.version != 1 || !allFinite(blob_local.params))
+                return false;
             {
                 const auto defaults = getParameters();
                 for (uint32_t i = 0; i < kParamCount; ++i)
@@ -489,7 +552,7 @@ public:
     bool openEditor(void*) override { return false; }
     void closeEditor() override {}
     bool isEditorOpen() const override { return false; }
-    std::pair<int, int> getEditorSize() const override { return {620, 360}; }
+    std::pair<int, int> getEditorSize() const override { return {760, 480}; }
     bool resizeEditor(int, int) override { return false; }
 
     const PluginInfo& getInfo() const override { return m_info; }
@@ -514,6 +577,14 @@ public:
     void setInfo(const PluginInfo& info) { m_info = info; }
 
 private:
+    template <size_t N> static bool allFinite(const float (&values)[N]) {
+        for (float value : values) {
+            if (!std::isfinite(value))
+                return false;
+        }
+        return true;
+    }
+
     static std::string formatTimeMs(float ms) {
         return std::to_string(static_cast<int>(std::round(std::clamp(ms, 10.0f, 2000.0f)))) + "ms";
     }
@@ -574,6 +645,13 @@ private:
         m_hpfPrevInR = 0.0f;
         m_hpfPrevOutL = 0.0f;
         m_hpfPrevOutR = 0.0f;
+        m_delaySamplesCurrentL = 0.0f;
+        m_delaySamplesCurrentR = 0.0f;
+        m_delaySamplesTargetL = 0.0f;
+        m_delaySamplesTargetR = 0.0f;
+        m_delayTransitionRemaining = 0;
+        m_delayTransitionTotal = 0;
+        m_delayTapInitialized = false;
     }
 
     void snapSmoothedParamsToTargets() {
@@ -619,6 +697,13 @@ private:
     float m_hpfPrevInR = 0.0f;
     float m_hpfPrevOutL = 0.0f;
     float m_hpfPrevOutR = 0.0f;
+    float m_delaySamplesCurrentL = 0.0f;
+    float m_delaySamplesCurrentR = 0.0f;
+    float m_delaySamplesTargetL = 0.0f;
+    float m_delaySamplesTargetR = 0.0f;
+    uint32_t m_delayTransitionRemaining = 0;
+    uint32_t m_delayTransitionTotal = 0;
+    bool m_delayTapInitialized = false;
 
     float m_timeSmoothed = 0.25f;
     float m_feedbackSmoothed = 0.3f;

--- a/AestraUI/Widgets/AestraDelayEditor.cpp
+++ b/AestraUI/Widgets/AestraDelayEditor.cpp
@@ -117,7 +117,26 @@ void AestraDelayEditor::buildControls() {
 }
 
 void AestraDelayEditor::onResize(int width, int height) {
+    (void)width;
+    (void)height;
     layoutControls();
+    AestraPanelWindow::onResize(width, height);
+}
+
+void AestraDelayEditor::onUpdate(double deltaTime) {
+    AestraPanelWindow::onUpdate(deltaTime);
+    m_controlSyncTimer += deltaTime;
+    if (!m_instance || m_controlSyncTimer < 1.0 / 30.0)
+        return;
+    m_controlSyncTimer = 0.0;
+    for (auto& knob : m_knobs) {
+        if (knob.slider)
+            knob.slider->setValue(std::clamp(m_instance->getParameter(knob.paramId), 0.0f, 1.0f));
+    }
+    using Delay = Aestra::Audio::Plugins::AestraDelay;
+    const int division = Delay::noteDivisionIndexFromParam(m_instance->getParameter(Delay::kNoteDivision));
+    divisionIndexToBaseModifier(division, m_syncBaseIndex, m_syncModifierIndex);
+    setDirty(true);
 }
 
 void AestraDelayEditor::layoutControls() {
@@ -127,63 +146,88 @@ void AestraDelayEditor::layoutControls() {
 
     const float pillY = AestraPanelWindow::TITLE_BAR_H + 42.0f;
     const float pillH = 34.0f;
-    const float groupGap = 14.0f;
+    const float groupGap = 18.0f;
     const float groupW = (contentW - groupGap) * 0.5f;
-    m_freeRect = {contentX, pillY, groupW * 0.5f, pillH};
-    m_syncRect = {contentX + groupW * 0.5f, pillY, groupW * 0.5f, pillH};
-    m_stereoRect = {contentX + groupW + groupGap, pillY, groupW * 0.5f, pillH};
-    m_pingPongRect = {contentX + groupW + groupGap + groupW * 0.5f, pillY, groupW * 0.5f, pillH};
+    constexpr float timeLabelW = 76.0f;
+    constexpr float routeLabelW = 78.0f;
+    const float timeToggleX = contentX + timeLabelW;
+    const float timeToggleW = groupW - timeLabelW;
+    const float routeGroupX = contentX + groupW + groupGap;
+    const float routeToggleX = routeGroupX + routeLabelW;
+    const float routeToggleW = groupW - routeLabelW;
+    m_freeRect = {timeToggleX, pillY, timeToggleW * 0.5f, pillH};
+    m_syncRect = {timeToggleX + timeToggleW * 0.5f, pillY, timeToggleW * 0.5f, pillH};
+    m_stereoRect = {routeToggleX, pillY, routeToggleW * 0.5f, pillH};
+    m_pingPongRect = {routeToggleX + routeToggleW * 0.5f, pillY, routeToggleW * 0.5f, pillH};
+
+    // setSize() dispatches onResize() during construction, before buildControls()
+    // has populated the fixed Delay control set.
+    if (m_knobs.size() < 8)
+        return;
 
     const bool sync = m_instance && m_instance->getParameter(Aestra::Audio::Plugins::AestraDelay::kSyncMode) > 0.5f;
-    const float gridY = pillY + pillH + 14.0f;
+    const float mainY = pillY + pillH + 14.0f;
+    const float mainBottom = b.height - 54.0f;
+    const float mainH = mainBottom - mainY;
+    const float mainGap = 12.0f;
+    const float timingW = contentW * 0.61f;
+    m_timingSectionRect = {contentX, mainY, timingW, mainH};
+    m_characterSectionRect = {contentX + timingW + mainGap, mainY, contentW - timingW - mainGap, mainH};
+    m_echoDisplayRect = {m_timingSectionRect.x + 12.0f, m_timingSectionRect.y + 31.0f,
+                         m_timingSectionRect.width - 24.0f, 112.0f};
 
-    const float knobY = gridY + 16.0f;
-    const float cellGap = 12.0f;
-    const float cellW = (contentW - cellGap * 3.0f) / 4.0f;
-    const float cellH = 84.0f;
-    for (size_t i = 0; i < m_knobs.size(); ++i) {
-        const int row = static_cast<int>(i / 4);
-        const int col = static_cast<int>(i % 4);
-        const float x = contentX + static_cast<float>(col) * (cellW + cellGap);
-        const float y = knobY + static_cast<float>(row) * (cellH + 10.0f);
-        m_knobs[i].bounds = {x, y, cellW, cellH};
-        // Slider children expect ABSOLUTE bounds (mirrors AestraCompEditor pattern).
-        const NUIRect knobAbs = {x + b.x + (cellW - kKnobSize) * 0.5f, y + b.y + 16.0f, kKnobSize, kKnobSize};
-        if (m_knobs[i].slider) {
-            m_knobs[i].slider->setBounds(knobAbs);
-        }
+    const float knobGap = 8.0f;
+    const float timingKnobY = m_echoDisplayRect.bottom() + 10.0f;
+    const float timingKnobW = (m_echoDisplayRect.width - knobGap * 3.0f) / 4.0f;
+    const float timingKnobH = m_timingSectionRect.bottom() - timingKnobY - 10.0f;
+    const int timingIndices[] = {0, 1, 3, 7};
+    for (int col = 0; col < 4; ++col) {
+        auto& knob = m_knobs[static_cast<size_t>(timingIndices[col])];
+        knob.bounds = {m_echoDisplayRect.x + static_cast<float>(col) * (timingKnobW + knobGap), timingKnobY,
+                       timingKnobW, timingKnobH};
     }
 
-    // Sync panel replaces the Time knob (index 0) in sync mode
+    const float characterX = m_characterSectionRect.x + 12.0f;
+    const float characterY = m_characterSectionRect.y + 31.0f;
+    const float characterW = m_characterSectionRect.width - 24.0f;
+    const float characterH = m_characterSectionRect.height - 41.0f;
+    const float characterCellW = (characterW - knobGap) * 0.5f;
+    const float characterCellH = (characterH - knobGap) * 0.5f;
+    const int characterIndices[] = {2, 6, 5, 4};
+    for (int index = 0; index < 4; ++index) {
+        const int row = index / 2;
+        const int col = index % 2;
+        auto& knob = m_knobs[static_cast<size_t>(characterIndices[index])];
+        knob.bounds = {characterX + static_cast<float>(col) * (characterCellW + knobGap),
+                       characterY + static_cast<float>(row) * (characterCellH + knobGap), characterCellW,
+                       characterCellH};
+    }
+
+    for (auto& knob : m_knobs) {
+        const NUIRect knobAbs = {knob.bounds.x + b.x + (knob.bounds.width - kKnobSize) * 0.5f,
+                                 knob.bounds.y + b.y + 27.0f, kKnobSize, kKnobSize};
+        if (knob.slider)
+            knob.slider->setBounds(knobAbs);
+    }
+
     if (sync && !m_baseButtons.empty() && !m_modifierButtons.empty()) {
-        const float syncPanelX = m_knobs[0].bounds.x;
-        const float syncPanelW = m_knobs[0].bounds.width;
-        const float containerH = m_knobs[0].bounds.height; // 84 px
-        const float btnGap = 6.0f;
-        const float btnH = 30.0f;
-        const float rowGap = 6.0f;
-        const float readoutGap = 4.0f;
-        const float labelH = 10.0f;
-
-        const float contentH = btnH + rowGap + btnH + readoutGap + labelH;
-        const float topPadding = (containerH - contentH) * 0.5f;
-        const float syncPanelY = m_knobs[0].bounds.y + topPadding;
-
-        const float baseBtnW = (syncPanelW - btnGap * 3.0f) / 4.0f;
-        for (int i = 0; i < 4; ++i) {
-            m_baseButtons[i].bounds = {syncPanelX + static_cast<float>(i) * (baseBtnW + btnGap), syncPanelY, baseBtnW,
-                                       btnH};
-        }
-
-        const float modBtnW = (syncPanelW - btnGap * 2.0f) / 3.0f;
-        const float modRowY = syncPanelY + btnH + rowGap;
-        for (int i = 0; i < 3; ++i) {
-            m_modifierButtons[i].bounds = {syncPanelX + static_cast<float>(i) * (modBtnW + btnGap), modRowY, modBtnW,
-                                           btnH};
-        }
-
-        const float readoutY = modRowY + btnH + readoutGap;
-        m_syncReadoutRect = {syncPanelX, readoutY, syncPanelW, labelH};
+        const float btnY = m_echoDisplayRect.bottom() - 30.0f;
+        const float btnH = 22.0f;
+        const float btnGap = 4.0f;
+        const float splitGap = 12.0f;
+        const float availableW = m_echoDisplayRect.width - 24.0f - splitGap;
+        const float baseGroupW = availableW * 0.49f;
+        const float modifierGroupW = availableW - baseGroupW;
+        const float baseX = m_echoDisplayRect.x + 12.0f;
+        const float modifierX = baseX + baseGroupW + splitGap;
+        const float baseBtnW = (baseGroupW - btnGap * 3.0f) / 4.0f;
+        for (int i = 0; i < 4; ++i)
+            m_baseButtons[i].bounds = {baseX + static_cast<float>(i) * (baseBtnW + btnGap), btnY, baseBtnW, btnH};
+        const float modifierBtnW = (modifierGroupW - btnGap * 2.0f) / 3.0f;
+        for (int i = 0; i < 3; ++i)
+            m_modifierButtons[i].bounds = {modifierX + static_cast<float>(i) * (modifierBtnW + btnGap), btnY,
+                                           modifierBtnW, btnH};
+        m_syncReadoutRect = {m_echoDisplayRect.right() - 154.0f, m_echoDisplayRect.y + 9.0f, 142.0f, 18.0f};
     }
 
     // --- bypass pill (absolute, same style as Comp/EQ) ---
@@ -199,8 +243,11 @@ void AestraDelayEditor::layoutControls() {
         using Delay = Aestra::Audio::Plugins::AestraDelay;
         const bool isSync = m_instance->getParameter(Delay::kSyncMode) > 0.5f;
         for (auto& k : m_knobs) {
-            if (k.paramId == Delay::kTime)
+            if (k.paramId == Delay::kTime) {
                 k.readOnly = isSync;
+                if (k.slider)
+                    k.slider->setVisible(!isSync);
+            }
         }
     }
 }
@@ -211,30 +258,104 @@ void AestraDelayEditor::drawPillSwitches(NUIRenderer& renderer, float wx, float 
     const bool sync = m_instance && m_instance->getParameter(Delay::kSyncMode) > 0.5f;
     const bool ping = m_instance && m_instance->getParameter(Delay::kStereoMode) > 0.5f;
 
-    auto drawGroup = [&](const NUIRect& leftLocal, const NUIRect& rightLocal, const char* l, const char* r,
-                         bool rightActive, const NUIColor& activeColor) {
+    auto drawGroup = [&](const NUIRect& leftLocal, const NUIRect& rightLocal, const char* groupLabel, const char* l,
+                         const char* r, bool rightActive, const NUIColor& activeColor) {
         NUIRect left = offsetRect(leftLocal, wx, wy);
         NUIRect right = offsetRect(rightLocal, wx, wy);
         const NUIRect outer(left.x, left.y, left.width + right.width, left.height);
-        renderer.fillRoundedRect(outer, 10.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
-        renderer.strokeRoundedRect(outer, 10.0f, 1.0f, accent().withAlpha(0.45f));
+        const float labelW = groupLabel[0] == 'T' ? 76.0f : 78.0f;
+        const NUIRect groupLabelRect(outer.x - labelW, outer.y, labelW - 8.0f, outer.height);
+        renderer.drawText(groupLabel, {groupLabelRect.x + 2.0f, groupLabelRect.y + 12.0f}, 9.0f,
+                          theme.getColor("textSecondary").withAlpha(0.70f));
+        renderer.fillRoundedRect(outer, 9.0f, NUIColor(0.018f, 0.018f, 0.022f, 0.98f));
+        renderer.strokeRoundedRect(outer, 9.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.13f));
+        renderer.drawLine({right.x, outer.y + 7.0f}, {right.x, outer.bottom() - 7.0f}, 1.0f,
+                          NUIColor(1.0f, 1.0f, 1.0f, 0.10f));
         auto seg = [&](const NUIRect& rect, const char* label, bool active) {
-            renderer.fillRoundedRect(rect, 9.0f, active ? activeColor : NUIColor(0, 0, 0, 0));
-            renderer.drawTextCentered(label, rect, 11.0f,
-                                      active ? theme.getColor("textPrimary")
-                                             : theme.getColor("textSecondary").withAlpha(0.86f));
+            const NUIRect inset(rect.x + 3.0f, rect.y + 3.0f, rect.width - 6.0f, rect.height - 6.0f);
+            if (active) {
+                renderer.fillRoundedRect(inset, 7.0f, activeColor.withAlpha(0.15f));
+                renderer.strokeRoundedRect(inset, 7.0f, 1.0f, activeColor.withAlpha(0.72f));
+                renderer.fillCircle({inset.x + 11.0f, inset.center().y}, 2.5f, activeColor);
+            }
+            renderer.drawTextCentered(label, inset, 10.0f,
+                                      active ? activeColor.withAlpha(0.98f)
+                                             : theme.getColor("textSecondary").withAlpha(0.72f));
         };
         seg(left, l, !rightActive);
         seg(right, r, rightActive);
     };
 
-    drawGroup(m_freeRect, m_syncRect, "Free", "Sync", sync, accent());
-    drawGroup(m_stereoRect, m_pingPongRect, "Stereo", "Ping-Pong", ping, accent().withAlpha(0.82f));
+    drawGroup(m_freeRect, m_syncRect, "TIME MODE", "Free", "Sync", sync, cyanAccent());
+    drawGroup(m_stereoRect, m_pingPongRect, "ROUTING", "Stereo", "Ping Pong", ping, accent());
+}
 
-    // Divider between time mode and channel mode groups
-    const float dividerX = wx + m_syncRect.x + m_syncRect.width + 7.0f;
-    renderer.drawLine({dividerX, wy + m_syncRect.y + 6.0f}, {dividerX, wy + m_syncRect.y + m_syncRect.height - 6.0f},
-                      1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.30f));
+void AestraDelayEditor::drawSectionFrame(NUIRenderer& renderer, const NUIRect& localRect, const std::string& title,
+                                         const NUIColor& color, float wx, float wy) {
+    auto& theme = NUIThemeManager::getInstance();
+    const NUIRect rect = offsetRect(localRect, wx, wy);
+    renderer.fillRoundedRect(rect, 14.0f, NUIColor(0.020f, 0.020f, 0.024f, 0.98f));
+    renderer.strokeRoundedRect(rect, 14.0f, 1.5f, color.withAlpha(0.58f));
+    renderer.fillRoundedRect({rect.x + 12.0f, rect.y + 12.0f, 4.0f, 16.0f}, 2.0f, color);
+    renderer.drawText(title, {rect.x + 24.0f, rect.y + 14.0f}, 10.5f, theme.getColor("textPrimary").withAlpha(0.92f));
+}
+
+void AestraDelayEditor::drawEchoDisplay(NUIRenderer& renderer, float wx, float wy) {
+    if (!m_instance)
+        return;
+    auto& theme = NUIThemeManager::getInstance();
+    using Delay = Aestra::Audio::Plugins::AestraDelay;
+    const NUIRect rect = offsetRect(m_echoDisplayRect, wx, wy);
+    const bool sync = m_instance->getParameter(Delay::kSyncMode) > 0.5f;
+    const bool pingPong = m_instance->getParameter(Delay::kStereoMode) > 0.5f;
+    const float feedback = std::clamp(m_instance->getParameter(Delay::kFeedback), 0.0f, 1.0f);
+    const float stereo = m_instance->getParameter(Delay::kStereoShift) * 2.0f - 1.0f;
+    const float modulation = m_instance->getParameter(Delay::kModDepth);
+
+    renderer.fillRoundedRect(rect, 10.0f, NUIColor(0.008f, 0.008f, 0.012f, 0.98f));
+    renderer.strokeRoundedRect(rect, 10.0f, 1.0f, cyanAccent().withAlpha(0.26f));
+    renderer.drawText("ECHO PATH", {rect.x + 12.0f, rect.y + 9.0f}, 9.5f,
+                      theme.getColor("textSecondary").withAlpha(0.82f));
+
+    std::string readout;
+    if (sync) {
+        readout = m_instance->getParameterDisplay(Delay::kNoteDivision) + "  /  " + syncReadoutText();
+    } else {
+        readout = formattedValue(Delay::kTime) + "  /  FREE";
+    }
+    const float readoutW = renderer.measureText(readout, 10.0f).width;
+    renderer.drawText(readout, {rect.right() - 12.0f - readoutW, rect.y + 9.0f}, 10.0f, cyanAccent().withAlpha(0.94f));
+
+    const float startX = rect.x + 27.0f;
+    const float endX = rect.right() - 20.0f;
+    const float topY = rect.y + 43.0f;
+    const float bottomY = rect.y + 66.0f;
+    renderer.drawText("L", {rect.x + 11.0f, topY - 5.0f}, 8.5f, cyanAccent().withAlpha(0.72f));
+    renderer.drawText("R", {rect.x + 11.0f, bottomY - 5.0f}, 8.5f, accent().withAlpha(0.78f));
+    renderer.drawLine({startX, topY}, {endX, topY}, 1.0f, cyanAccent().withAlpha(0.12f));
+    renderer.drawLine({startX, bottomY}, {endX, bottomY}, 1.0f, accent().withAlpha(0.12f));
+    renderer.fillCircle({startX, topY}, 3.4f, cyanAccent());
+    renderer.fillCircle({startX, bottomY}, 3.4f, accent());
+
+    NUIPoint previousL{startX, topY};
+    NUIPoint previousR{startX, bottomY};
+    constexpr int repeats = 5;
+    for (int repeat = 0; repeat < repeats; ++repeat) {
+        const float progress = static_cast<float>(repeat + 1) / static_cast<float>(repeats);
+        const float x = startX + (endX - startX) * progress;
+        const float stereoOffset = stereo * 5.0f * progress;
+        const float motion = std::sin(progress * kPi * 3.0f) * modulation * 4.0f;
+        const float decay = std::pow(std::max(feedback, 0.08f), static_cast<float>(repeat) * 0.55f);
+        const float alpha = 0.22f + decay * 0.72f;
+        NUIPoint pointL{x - stereoOffset, pingPong && (repeat & 1) ? bottomY : topY + motion};
+        NUIPoint pointR{x + stereoOffset, pingPong && !(repeat & 1) ? topY : bottomY - motion};
+        renderer.drawLine(previousL, pointL, 1.5f, cyanAccent().withAlpha(alpha * 0.72f));
+        renderer.drawLine(previousR, pointR, 1.5f, accent().withAlpha(alpha * 0.72f));
+        renderer.fillCircle(pointL, 2.2f + decay * 2.0f, cyanAccent().withAlpha(alpha));
+        renderer.fillCircle(pointR, 2.2f + decay * 2.0f, accent().withAlpha(alpha));
+        previousL = pointL;
+        previousR = pointR;
+    }
 }
 
 void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy) {
@@ -244,6 +365,16 @@ void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy)
         return;
 
     auto& theme = NUIThemeManager::getInstance();
+
+    const NUIRect timeCard = offsetRect(m_knobs[0].bounds, wx, wy);
+    renderer.fillRoundedRect(timeCard, 10.0f, cardBg());
+    renderer.strokeRoundedRect(timeCard, 10.0f, 1.0f, cyanAccent().withAlpha(0.30f));
+    renderer.drawText("DIVISION", {timeCard.x + 10.0f, timeCard.y + 9.0f}, 9.0f,
+                      theme.getColor("textSecondary").withAlpha(0.82f));
+    const std::string division = m_instance->getParameterDisplay(Aestra::Audio::Plugins::AestraDelay::kNoteDivision);
+    renderer.drawTextCentered(division, {timeCard.x, timeCard.y + 30.0f, timeCard.width, 36.0f}, 20.0f, cyanAccent());
+    renderer.drawTextCentered(syncReadoutText(), {timeCard.x, timeCard.bottom() - 27.0f, timeCard.width, 18.0f}, 10.0f,
+                              theme.getColor("textPrimary").withAlpha(0.86f));
 
     auto drawTierButton = [&](const TierButton& btn, bool active, bool hovered) {
         NUIRect r = offsetRect(btn.bounds, wx, wy);
@@ -263,13 +394,6 @@ void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy)
     }
     for (int i = 0; i < 3; ++i) {
         drawTierButton(m_modifierButtons[i], i == m_syncModifierIndex, i == m_hoveredModifierButton);
-    }
-
-    // Derived ms readout
-    NUIRect readout = offsetRect(m_syncReadoutRect, wx, wy);
-    const std::string text = syncReadoutText();
-    if (!text.empty()) {
-        renderer.drawTextCentered(text, readout, 9.5f, theme.getColor("textPrimary").withAlpha(0.92f));
     }
 }
 
@@ -298,8 +422,16 @@ std::string AestraDelayEditor::formattedValue(uint32_t paramId) const {
 
 void AestraDelayEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, float wx, float wy) {
     auto& theme = NUIThemeManager::getInstance();
+    using Delay = Aestra::Audio::Plugins::AestraDelay;
     const float value = k.slider ? static_cast<float>(k.slider->getValue()) : 0.0f;
-    const NUIColor knobAccent = k.readOnly ? cyanAccent() : accent();
+    NUIColor knobAccent = accent();
+    if (k.paramId == Delay::kTime || k.paramId == Delay::kStereoShift || k.paramId == Delay::kDamping ||
+        k.paramId == Delay::kFeedbackHighpass)
+        knobAccent = cyanAccent();
+    else if (k.paramId == Delay::kModDepth || k.paramId == Delay::kModRate)
+        knobAccent = NUIColor(0.94f, 0.34f, 0.68f, 1.0f);
+    if (k.readOnly)
+        knobAccent = cyanAccent().withAlpha(0.72f);
     NUIRect bounds = offsetRect(k.bounds, wx, wy);
     // Slider bounds are already absolute (set in layoutControls).
     NUIRect knobRect = k.slider ? k.slider->getBounds() : NUIRect();
@@ -328,7 +460,7 @@ void AestraDelayEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, fl
     renderer.drawText(k.label, {bounds.x + 10.0f, bounds.y + 6.5f}, 10.5f,
                       theme.getColor("textPrimary").withAlpha(0.90f));
     const std::string valueStr = formattedValue(k.paramId);
-    renderer.drawText(valueStr, {bounds.x + 10.0f, bounds.bottom() - 15.5f}, 10.5f, knobAccent.withAlpha(0.96f));
+    renderer.drawText(valueStr, {bounds.x + 10.0f, bounds.bottom() - 18.0f}, 10.0f, knobAccent.withAlpha(0.96f));
 }
 
 void AestraDelayEditor::drawMixSlider(NUIRenderer& renderer, float wx, float wy) {
@@ -336,7 +468,7 @@ void AestraDelayEditor::drawMixSlider(NUIRenderer& renderer, float wx, float wy)
     using Delay = Aestra::Audio::Plugins::AestraDelay;
     const float mix = m_instance ? m_instance->getParameter(Delay::kMix) : 0.0f;
     NUIRect mixRect = offsetRect(m_mixSliderRect, wx, wy);
-    const NUIRect track(mixRect.x + 38.0f, mixRect.y + 12.0f, mixRect.width - 78.0f, 8.0f);
+    const NUIRect track(mixRect.x + 58.0f, mixRect.y + 12.0f, mixRect.width - 104.0f, 8.0f);
     renderer.fillRoundedRect(mixRect, 10.0f, NUIColor(0.068f, 0.068f, 0.068f, 0.92f));
     renderer.strokeRoundedRect(mixRect, 10.0f, 1.0f, accent().withAlpha(0.35f));
     renderer.drawText("Mix", {mixRect.x + 14.0f, mixRect.y + 10.0f}, 10.5f,
@@ -367,14 +499,27 @@ void AestraDelayEditor::drawBypassPill(NUIRenderer& renderer) {
 }
 
 void AestraDelayEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
+    (void)contentRect;
     // Recompute layout each frame so cached rects (and absolute slider bounds)
     // follow window movement.
     layoutControls();
     const auto b = getBounds();
     const float wx = b.x;
     const float wy = b.y;
+    auto& theme = NUIThemeManager::getInstance();
+    const float identityY = wy + AestraPanelWindow::TITLE_BAR_H + 8.0f;
+    renderer.fillCircle({wx + kPad + 10.0f, identityY + 9.0f}, 9.0f, accent().withAlpha(0.18f));
+    renderer.strokeCircle({wx + kPad + 10.0f, identityY + 9.0f}, 9.0f, 1.5f, accent().withAlpha(0.80f));
+    renderer.fillCircle({wx + kPad + 12.5f, identityY + 6.5f}, 2.5f, cyanAccent());
+    renderer.drawText("DELAY", {wx + kPad + 28.0f, identityY + 1.0f}, 13.0f,
+                      theme.getColor("textPrimary").withAlpha(0.96f));
+    renderer.drawText("STEREO ECHO ENGINE", {wx + kPad + 28.0f, identityY + 16.0f}, 8.5f,
+                      theme.getColor("textSecondary").withAlpha(0.72f));
     drawBypassPill(renderer);
     drawPillSwitches(renderer, wx, wy);
+    drawSectionFrame(renderer, m_timingSectionRect, "TIME + FEEDBACK", cyanAccent(), wx, wy);
+    drawSectionFrame(renderer, m_characterSectionRect, "TONE + MOTION", accent(), wx, wy);
+    drawEchoDisplay(renderer, wx, wy);
     drawSyncPanel(renderer, wx, wy);
 
     using Delay = Aestra::Audio::Plugins::AestraDelay;

--- a/AestraUI/Widgets/AestraDelayEditor.h
+++ b/AestraUI/Widgets/AestraDelayEditor.h
@@ -5,6 +5,7 @@
 #include "NUISlider.h"
 #include "NUITypes.h"
 #include "PluginHost.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -17,6 +18,7 @@ public:
     void drawContent(NUIRenderer& renderer, const NUIRect& contentRect) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onResize(int width, int height) override;
+    void onUpdate(double deltaTime) override;
     using AestraPanelWindow::onResize;
     void onResize() { layoutControls(); }
     void setPlatformBridge(NUIPlatformBridge* bridge) override;
@@ -41,6 +43,9 @@ private:
     void drawBypassPill(NUIRenderer& renderer);
     void drawPillSwitches(NUIRenderer& renderer, float wx, float wy);
     void drawSyncPanel(NUIRenderer& renderer, float wx, float wy);
+    void drawEchoDisplay(NUIRenderer& renderer, float wx, float wy);
+    void drawSectionFrame(NUIRenderer& renderer, const NUIRect& localRect, const std::string& title,
+                          const NUIColor& color, float wx, float wy);
     void drawKnob(NUIRenderer& renderer, const KnobControl& k, float wx, float wy);
     void drawMixSlider(NUIRenderer& renderer, float wx, float wy);
     std::string formattedValue(uint32_t paramId) const;
@@ -64,19 +69,23 @@ private:
     NUIRect m_bypassRect;
     NUIRect m_mixSliderRect;
     NUIRect m_syncReadoutRect;
+    NUIRect m_timingSectionRect;
+    NUIRect m_echoDisplayRect;
+    NUIRect m_characterSectionRect;
     bool m_bypassHovered = false;
 
     int m_hoveredBaseButton = -1;
     int m_hoveredModifierButton = -1;
-    int m_syncBaseIndex = 1;      // default 1/8
-    int m_syncModifierIndex = 0;  // default Straight
+    int m_syncBaseIndex = 1;     // default 1/8
+    int m_syncModifierIndex = 0; // default Straight
     bool m_draggingMix = false;
+    double m_controlSyncTimer = 0.0;
 
-    static constexpr float kWinW = 620.0f;
-    static constexpr float kWinH = 400.0f;
-    static constexpr float kPad = 20.0f;
+    static constexpr float kWinW = 760.0f;
+    static constexpr float kWinH = 480.0f;
+    static constexpr float kPad = 18.0f;
     static constexpr float kRadius = 15.0f;
-    static constexpr float kKnobSize = 50.0f;
+    static constexpr float kKnobSize = 58.0f;
 };
 
 } // namespace AestraUI

--- a/Tests/AestraAudio/AestraDelayUpgradeTest.cpp
+++ b/Tests/AestraAudio/AestraDelayUpgradeTest.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 using Aestra::Audio::Plugins::AestraDelay;
@@ -236,6 +237,137 @@ bool testModulationMaxStaysFinite() {
     return true;
 }
 
+bool testDelayTimeChangesAreCrossfaded() {
+    AestraDelay delay;
+    delay.initialize(48000.0, 512);
+    delay.setParameter(AestraDelay::kSyncMode, 0.0f);
+    delay.setParameter(AestraDelay::kTime, 0.0f); // Start at 10ms.
+    delay.setParameter(AestraDelay::kFeedback, 0.0f);
+    delay.setParameter(AestraDelay::kDamping, 0.0f);
+    delay.setParameter(AestraDelay::kStereoShift, 0.5f);
+    delay.setParameter(AestraDelay::kModDepth, 0.0f);
+    delay.setParameter(AestraDelay::kMix, 1.0f);
+    delay.setParameter(AestraDelay::kBypass, 0.0f);
+    delay.activate();
+
+    constexpr size_t firstFrames = 30000;
+    constexpr size_t secondFrames = 2048;
+    constexpr float omega = 2.0f * 3.14159265358979323846f * 437.0f / 48000.0f;
+    std::vector<float> firstL(firstFrames, 0.0f);
+    std::vector<float> firstR(firstFrames, 0.0f);
+    for (size_t i = 0; i < firstFrames; ++i) {
+        firstL[i] = std::sin(omega * static_cast<float>(i));
+        firstR[i] = firstL[i];
+    }
+    const auto before = processStereo(delay, firstL, firstR);
+
+    delay.setParameter(AestraDelay::kSyncMode, 1.0f);
+    delay.setParameter(AestraDelay::kNoteDivision, AestraDelay::noteDivisionParamFromIndex(AestraDelay::kDiv1_4));
+    std::vector<float> secondL(secondFrames, 0.0f);
+    std::vector<float> secondR(secondFrames, 0.0f);
+    for (size_t i = 0; i < secondFrames; ++i) {
+        secondL[i] = std::sin(omega * static_cast<float>(firstFrames + i));
+        secondR[i] = secondL[i];
+    }
+    const auto after = processStereo(delay, secondL, secondR);
+
+    float maxDelta = std::abs(after.left.front() - before.left.back());
+    for (size_t i = 1; i < 1024; ++i)
+        maxDelta = std::max(maxDelta, std::abs(after.left[i] - after.left[i - 1]));
+    if (maxDelta > 0.12f) {
+        std::cerr << "Delay-time change produced a discontinuity. max delta=" << maxDelta << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool testBypassAdvancesDelayState() {
+    AestraDelay delay;
+    delay.initialize(48000.0, 512);
+    delay.setParameter(AestraDelay::kTime, 0.0f);
+    delay.setParameter(AestraDelay::kFeedback, 0.0f);
+    delay.setParameter(AestraDelay::kStereoShift, 0.5f);
+    delay.setParameter(AestraDelay::kModDepth, 0.0f);
+    delay.setParameter(AestraDelay::kMix, 1.0f);
+    delay.activate();
+
+    std::vector<float> impulseL(100, 0.0f);
+    std::vector<float> impulseR(100, 0.0f);
+    impulseL[0] = 1.0f;
+    impulseR[0] = 1.0f;
+    processStereo(delay, impulseL, impulseR);
+
+    delay.setParameter(AestraDelay::kBypass, 1.0f);
+    std::vector<float> bypassL(600, 0.0f);
+    std::vector<float> bypassR(600, 0.0f);
+    const auto bypassed = processStereo(delay, bypassL, bypassR);
+    if (*std::max_element(bypassed.left.begin(), bypassed.left.end()) != 0.0f) {
+        std::cerr << "Bypass did not remain sample-transparent.\n";
+        return false;
+    }
+
+    delay.setParameter(AestraDelay::kBypass, 0.0f);
+    std::vector<float> resumedL(600, 0.0f);
+    std::vector<float> resumedR(600, 0.0f);
+    const auto resumed = processStereo(delay, resumedL, resumedR);
+    float peak = 0.0f;
+    for (float sample : resumed.left)
+        peak = std::max(peak, std::abs(sample));
+    if (peak > 1.0e-6f) {
+        std::cerr << "A frozen pre-bypass repeat resurfaced after resume. peak=" << peak << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool testNonFiniteControlAndStateAreRejected() {
+    AestraDelay delay;
+    delay.initialize(48000.0, 512);
+    delay.setParameter(AestraDelay::kFeedback, 0.42f);
+    delay.setParameter(AestraDelay::kFeedback, std::nanf(""));
+    if (std::abs(delay.getParameter(AestraDelay::kFeedback) - 0.42f) > 1.0e-6f) {
+        std::cerr << "Non-finite parameter input changed the live value.\n";
+        return false;
+    }
+
+    auto state = delay.saveState();
+    const float nanValue = std::nanf("");
+    constexpr size_t feedbackOffset = sizeof(uint32_t) * 2 + sizeof(float) * AestraDelay::kFeedback;
+    std::memcpy(state.data() + feedbackOffset, &nanValue, sizeof(nanValue));
+    delay.setParameter(AestraDelay::kTime, 0.73f);
+    if (delay.loadState(state)) {
+        std::cerr << "Delay accepted a state containing NaN.\n";
+        return false;
+    }
+    if (std::abs(delay.getParameter(AestraDelay::kTime) - 0.73f) > 1.0e-6f) {
+        std::cerr << "Rejected state partially mutated parameters.\n";
+        return false;
+    }
+    return true;
+}
+
+bool testNonFiniteAudioIsContained() {
+    AestraDelay delay;
+    delay.initialize(48000.0, 512);
+    delay.setParameter(AestraDelay::kTime, 0.0f);
+    delay.setParameter(AestraDelay::kFeedback, 1.0f);
+    delay.setParameter(AestraDelay::kMix, 1.0f);
+    delay.activate();
+
+    std::vector<float> inL(1024, 0.0f);
+    std::vector<float> inR(1024, 0.0f);
+    inL[0] = std::nanf("");
+    inR[1] = std::numeric_limits<float>::infinity();
+    const auto out = processStereo(delay, inL, inR);
+    for (size_t i = 0; i < out.left.size(); ++i) {
+        if (!std::isfinite(out.left[i]) || !std::isfinite(out.right[i])) {
+            std::cerr << "Non-finite audio escaped containment at sample " << i << ".\n";
+            return false;
+        }
+    }
+    return true;
+}
+
 bool testDryPathIsNotSaturatedAtZeroMix() {
     AestraDelay delay;
     delay.initialize(48000.0, 512);
@@ -364,6 +496,14 @@ int main() {
     if (!testHotWetRepeatIsClean())
         return 1;
     if (!testModulationMaxStaysFinite())
+        return 1;
+    if (!testDelayTimeChangesAreCrossfaded())
+        return 1;
+    if (!testBypassAdvancesDelayState())
+        return 1;
+    if (!testNonFiniteControlAndStateAreRejected())
+        return 1;
+    if (!testNonFiniteAudioIsContained())
         return 1;
     if (!testDryPathIsNotSaturatedAtZeroMix())
         return 1;


### PR DESCRIPTION
## Summary
- crossfade Delay read-head changes to prevent clicks when switching free/synced timing and divisions
- keep delay state advancing through bypass and contain non-finite audio/control/state input
- overhaul the Delay editor with a live echo-path display, clearer timing/routing modes, sync controls, and grouped tone/motion controls
- fix the editor construction lifecycle crash found during manual review

## Why
Delay-time changes previously jumped directly to a new read position, producing an audible discontinuity. The editor also under-reported its intended size and presented controls as a flat grid without clearly communicating echo routing or sync state.

## Impact
Users get smoother automation and mode changes, predictable bypass tails, safer state handling, and a substantially clearer Delay workflow. Plugin and parameter IDs are unchanged, and the serialized state format remains version 3.

## Validation
- `cmake --build build-linux --target Aestra AestraDelayUpgradeTest -j2`
- `build-linux/Tests/AestraDelayUpgradeTest`
- `git diff --check`
- manual open/listening pass in Aestra, including Free/Sync, division changes, ping-pong, and bypass-tail behavior