### PR TITLE
feat(piano-roll): editing overhaul — smoother, more musical draw workflow

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -245,6 +245,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/RemoveNoteCommand.cpp
     src/Commands/MoveNoteCommand.cpp
     src/Commands/ResizeNoteCommand.cpp
+    src/Commands/UpdateNoteCommand.cpp
     src/Commands/NoteDiff.cpp
     src/Commands/MuseGrammar.cpp
     src/Commands/CommandParser.cpp

--- a/AestraAudio/include/Commands/NoteDiff.h
+++ b/AestraAudio/include/Commands/NoteDiff.h
@@ -24,9 +24,12 @@ struct NoteDiffResult {
     std::vector<std::pair<MidiNote, MidiNote>> moved;
     /** @brief Pairs of (before, after) for notes that changed duration. */
     std::vector<std::pair<MidiNote, MidiNote>> resized;
+    /** @brief Pairs of (before, after) for in-place expression changes (velocity/pan). */
+    std::vector<std::pair<MidiNote, MidiNote>> modified;
 
     bool empty() const {
-        return added.empty() && removed.empty() && moved.empty() && resized.empty();
+        return added.empty() && removed.empty() && moved.empty() && resized.empty() &&
+               modified.empty();
     }
 };
 

--- a/AestraAudio/include/Commands/UpdateNoteCommand.h
+++ b/AestraAudio/include/Commands/UpdateNoteCommand.h
@@ -1,0 +1,47 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to update a MIDI note's expression (velocity/pan) in place (undoable)
+ *
+ * Identifies the target note by pitch + startBeat + unitId, like
+ * ResizeNoteCommand — position and duration are unchanged by this command.
+ */
+class UpdateNoteCommand : public ICommand {
+public:
+    UpdateNoteCommand(PatternManager& patternManager, PatternID patternId,
+                      const MidiNote& originalNote, float newVelocity, float newPan);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    std::string getName() const override { return "Update Note"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+
+    // Original note state for identification and undo
+    MidiNote m_originalNote;
+
+    // New expression values
+    float m_newVelocity;
+    float m_newPan;
+
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -757,7 +757,11 @@ private:
         bool noteOnPending{false};
         bool active{false};
     };
-    UnitAuditionState m_unitAuditionState;
+    // Small slot pool so a chord stamp auditions every pitch, not just the
+    // root. Slots are claimed per AuditionUnit command (free-first, else the
+    // one closest to its note-off) — all touched on the RT thread only.
+    static constexpr size_t kUnitAuditionSlots = 4;
+    std::array<UnitAuditionState, kUnitAuditionSlots> m_unitAuditionStates;
     // std::vector<TrackRTState> m_trackState; <-- Moved to m_rtGraphState (actually m_graphStates)
     // But we need persistent state across swaps?
     // TrackRTState contains current Volume/Pan/SmoothedParams.

--- a/AestraAudio/include/Models/PatternSource.h
+++ b/AestraAudio/include/Models/PatternSource.h
@@ -37,6 +37,7 @@ struct MidiNote {
     double startBeat{0.0};     // Start position in beats
     double durationBeats{0.0}; // Duration in beats
     float velocity{0.0f};      // 0..1
+    float pan{0.0f};           // -1 (left) .. 1 (right), 0 = centre
     uint64_t unitId{0};        // Unit ID for routing
     int8_t pitchOffset{0};     // Semitone offset from root for step-based pitched samplers
     float gate{1.0f};          // Note length as a fraction of one step

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -944,12 +944,17 @@ public:
     /**
      * @brief Start Arsenal playback for the supplied pattern.
      * @param pid Pattern identifier to schedule for playback.
-     * @param startSeconds Transport position to start from (e.g. a scrubbed
-     *        piano-roll playhead). Defaults to beat zero; the engine wraps
-     *        positions past the pattern length, so any cue point is safe.
+     * @param startSeconds Transport position to start from. Negative (the
+     *        default) resumes from the current position — e.g. a scrubbed
+     *        piano-roll playhead — matching how timeline play() cues. Pass an
+     *        explicit value (e.g. 0.0 for a from-the-top preview) to override.
+     *        The engine wraps positions past the pattern length, so any cue
+     *        point is safe.
      */
-    void playPatternInArsenal(PatternID pid, double startSeconds = 0.0) {
-        startSeconds = std::max(0.0, startSeconds);
+    void playPatternInArsenal(PatternID pid, double startSeconds = -1.0) {
+        if (startSeconds < 0.0) {
+            startSeconds = std::max(0.0, m_position.load(std::memory_order_relaxed));
+        }
         m_patternMode.store(true, std::memory_order_relaxed);
         m_isPlaying.store(true, std::memory_order_relaxed);
         m_isPaused.store(false, std::memory_order_relaxed);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -942,15 +942,19 @@ public:
     const PatternPlaybackEngine& getPatternPlaybackEngine() const { return m_patternPlaybackEngine; }
 
     /**
-     * @brief Start Arsenal playback from beat zero for the supplied pattern.
+     * @brief Start Arsenal playback for the supplied pattern.
      * @param pid Pattern identifier to schedule for playback.
+     * @param startSeconds Transport position to start from (e.g. a scrubbed
+     *        piano-roll playhead). Defaults to beat zero; the engine wraps
+     *        positions past the pattern length, so any cue point is safe.
      */
-    void playPatternInArsenal(PatternID pid) {
+    void playPatternInArsenal(PatternID pid, double startSeconds = 0.0) {
+        startSeconds = std::max(0.0, startSeconds);
         m_patternMode.store(true, std::memory_order_relaxed);
         m_isPlaying.store(true, std::memory_order_relaxed);
         m_isPaused.store(false, std::memory_order_relaxed);
-        m_position.store(0.0, std::memory_order_relaxed);
-        m_playStartPosition.store(0.0, std::memory_order_relaxed);
+        m_position.store(startSeconds, std::memory_order_relaxed);
+        m_playStartPosition.store(startSeconds, std::memory_order_relaxed);
         m_patternPlaybackEngine.flush();
 
         {
@@ -964,7 +968,7 @@ public:
             }
         }
 
-        pushTransportCommand(1.0f, 0.0);
+        pushTransportCommand(1.0f, startSeconds);
         m_patternPlaybackEngine.schedulePatternInstance(pid, 0.0, 1);
     }
 

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -39,7 +39,7 @@ struct ScheduledEvent {
     /** @brief Second MIDI data byte, usually velocity. */
     uint8_t data2;        // 1 byte (velocity)
     /** @brief Event priority inside a frame. */
-    uint8_t priority;     // 1 byte (0=note-off first, 1=note-on second)
+    uint8_t priority;     // 1 byte (0=note-off, 1=per-note pan, 2=note-on)
     uint8_t _padding[6];  // 6 bytes -> Total 32.
 };
 static_assert(sizeof(ScheduledEvent) == 32, "ScheduledEvent must be 32 bytes");

--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -124,6 +124,8 @@ private:
         bool active = false;
         int note = 0;
         float velocity = 0.0f;
+        float gainL = 1.0f; // Per-note pan, latched at note-on (unity centre)
+        float gainR = 1.0f;
         double position = 0.0; // Sample index
         double playbackRate = 1.0; // sample index increment/frame
         double targetPlaybackRate = 1.0;
@@ -136,6 +138,11 @@ private:
 
     static constexpr int kMaxVoices = 32;
     std::array<Voice, kMaxVoices> m_voices;
+
+    // Per-note pan latch: the pattern scheduler sends pan as polyphonic
+    // aftertouch (0xA0, note, 0..127) just before the matching note-on, which
+    // consumes and re-centres its slot. Audio-thread only — no atomics needed.
+    std::array<uint8_t, 128> m_pendingNotePan{};
 
     // Helpers
     void handleMidiEvent(const MidiBuffer::Event& event, double baseRate,

--- a/AestraAudio/src/Commands/NoteDiff.cpp
+++ b/AestraAudio/src/Commands/NoteDiff.cpp
@@ -29,6 +29,13 @@ bool notesEqualPosition(const Aestra::Audio::MidiNote& a, const Aestra::Audio::M
            a.unitId == b.unitId;
 }
 
+/**
+ * Expression inequality: velocity or pan changed on an otherwise-identical note.
+ */
+bool notesExpressionDiffers(const Aestra::Audio::MidiNote& a, const Aestra::Audio::MidiNote& b) {
+    return std::abs(a.velocity - b.velocity) > 1e-4f || std::abs(a.pan - b.pan) > 1e-4f;
+}
+
 } // anonymous namespace
 
 namespace Aestra {
@@ -54,6 +61,11 @@ NoteDiffResult diffNotes(const std::vector<MidiNote>& before,
             if (notesEqualFull(bnote, after[ai])) {
                 matchedBefore.insert(bi);
                 matchedAfter.insert(ai);
+                // Full-field equality ignores expression, so a velocity/pan
+                // change on an otherwise-untouched note surfaces here.
+                if (notesExpressionDiffers(bnote, after[ai])) {
+                    result.modified.push_back({bnote, after[ai]});
+                }
                 break;
             }
         }
@@ -132,11 +144,14 @@ NoteDiffResult diffNotes(const std::vector<MidiNote>& before,
             if (beforeUsed[bi] || afterUsed[ai]) continue;
             beforeUsed[bi] = true;
             afterUsed[ai] = true;
+            const auto& bnote = beforeVec[bi].second;
+            const auto& anote = afterVec[ai].second;
             if (dist >= 1e-6) {
                 // Non-exact match = resize
-                const auto& bnote = beforeVec[bi].second;
-                const auto& anote = afterVec[ai].second;
                 result.resized.push_back({bnote, anote});
+            } else if (notesExpressionDiffers(bnote, anote)) {
+                // Same position and duration but new velocity/pan.
+                result.modified.push_back({bnote, anote});
             }
         }
 
@@ -240,6 +255,7 @@ NoteDiffResult diffNotes(const std::vector<MidiNote>& before,
     sortNotes(result.added);
     sortPairs(result.resized);
     sortPairs(result.moved);
+    sortPairs(result.modified);
 
     return result;
 }

--- a/AestraAudio/src/Commands/UpdateNoteCommand.cpp
+++ b/AestraAudio/src/Commands/UpdateNoteCommand.cpp
@@ -1,0 +1,64 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/UpdateNoteCommand.h"
+
+namespace Aestra {
+namespace Audio {
+
+UpdateNoteCommand::UpdateNoteCommand(PatternManager& patternManager, PatternID patternId,
+                                     const MidiNote& originalNote, float newVelocity, float newPan)
+    : m_patternManager(patternManager), m_patternId(patternId),
+      m_originalNote(originalNote), m_newVelocity(newVelocity), m_newPan(newPan) {}
+
+void UpdateNoteCommand::execute() {
+    if (m_executed)
+        return;
+
+    m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+        if (pattern.isMidi()) {
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (auto& note : notes) {
+                if (note.pitch == m_originalNote.pitch &&
+                    note.startBeat == m_originalNote.startBeat &&
+                    note.unitId == m_originalNote.unitId) {
+                    note.velocity = m_newVelocity;
+                    note.pan = m_newPan;
+                    break;
+                }
+            }
+        }
+    });
+
+    m_executed = true;
+}
+
+void UpdateNoteCommand::undo() {
+    if (!m_executed)
+        return;
+
+    m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+        if (pattern.isMidi()) {
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (auto& note : notes) {
+                if (note.pitch == m_originalNote.pitch &&
+                    note.startBeat == m_originalNote.startBeat &&
+                    note.unitId == m_originalNote.unitId) {
+                    note.velocity = m_originalNote.velocity;
+                    note.pan = m_originalNote.pan;
+                    break;
+                }
+            }
+        }
+    });
+
+    m_executed = false;
+}
+
+void UpdateNoteCommand::redo() {
+    if (m_executed)
+        return;
+
+    execute();
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -294,6 +294,14 @@ void AudioEngine::applyPendingCommands() {
                 std::max<uint32_t>(1, m_sampleRate.load(std::memory_order_relaxed) / 8);
             m_unitAuditionState.noteOnPending = true;
             m_unitAuditionState.active = true;
+            // Wake the master out of the post-stop Silent fast path so the
+            // audition is actually rendered. After the transport stops the fade
+            // settles to Silent, whose early-return drops everything before the
+            // unit-audition MIDI is injected — mirrors the metronome count-in
+            // recovery, and matches the pre-first-play (None) state.
+            if (m_fadeState.load(std::memory_order_relaxed) == FadeState::Silent) {
+                m_fadeState.store(FadeState::None, std::memory_order_relaxed);
+            }
             break;
         }
         // MUSE-WIRING: LoadProjectState / UpdateClipState / StartPreview / StopPreview

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -286,14 +286,32 @@ void AudioEngine::applyPendingCommands() {
             break;
         }
         case AudioQueueCommandType::AuditionUnit: {
-            m_unitAuditionState.unitId = static_cast<UnitID>(cmd.trackIndex);
-            m_unitAuditionState.note = static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value1), 0, 127));
-            m_unitAuditionState.velocity =
+            // Claim a slot from the pool: a free one when possible, otherwise
+            // the one closest to its note-off. A chord stamp sends one command
+            // per pitch, so simultaneous triad tones each get their own slot.
+            UnitAuditionState* slot = nullptr;
+            for (auto& s : m_unitAuditionStates) {
+                if (!s.active) {
+                    slot = &s;
+                    break;
+                }
+            }
+            if (!slot) {
+                slot = &m_unitAuditionStates[0];
+                for (auto& s : m_unitAuditionStates) {
+                    if (s.noteOffSamplesRemaining < slot->noteOffSamplesRemaining) {
+                        slot = &s;
+                    }
+                }
+            }
+            slot->unitId = static_cast<UnitID>(cmd.trackIndex);
+            slot->note = static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value1), 0, 127));
+            slot->velocity =
                 static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value2 * 127.0f), 1, 127));
-            m_unitAuditionState.noteOffSamplesRemaining =
+            slot->noteOffSamplesRemaining =
                 std::max<uint32_t>(1, m_sampleRate.load(std::memory_order_relaxed) / 8);
-            m_unitAuditionState.noteOnPending = true;
-            m_unitAuditionState.active = true;
+            slot->noteOnPending = true;
+            slot->active = true;
             // Wake the master out of the post-stop Silent fast path so the
             // audition is actually rendered. After the transport stops the fade
             // settles to Silent, whose early-return drops everything before the
@@ -351,34 +369,40 @@ void AudioEngine::applyPendingCommands() {
 
 void AudioEngine::injectPendingUnitAudition(PatternPlaybackEngine::UnitMidiRoute* routes, size_t routeCount,
                                             uint32_t numFrames) noexcept {
-    if (!m_unitAuditionState.active || !routes || routeCount == 0 || numFrames == 0) {
+    if (!routes || routeCount == 0 || numFrames == 0) {
         return;
     }
 
-    MidiBuffer* target = nullptr;
-    for (size_t i = 0; i < routeCount; ++i) {
-        if (routes[i].unitId == m_unitAuditionState.unitId) {
-            target = routes[i].midiBuffer;
-            break;
+    for (auto& slot : m_unitAuditionStates) {
+        if (!slot.active) {
+            continue;
         }
-    }
 
-    if (!target) {
-        return;
-    }
+        MidiBuffer* target = nullptr;
+        for (size_t i = 0; i < routeCount; ++i) {
+            if (routes[i].unitId == slot.unitId) {
+                target = routes[i].midiBuffer;
+                break;
+            }
+        }
 
-    if (m_unitAuditionState.noteOnPending) {
-        target->addNoteOn(1, m_unitAuditionState.note, m_unitAuditionState.velocity, 0);
-        m_unitAuditionState.noteOnPending = false;
-    }
+        if (!target) {
+            continue;
+        }
 
-    if (m_unitAuditionState.noteOffSamplesRemaining <= numFrames) {
-        const uint32_t noteOffOffset = std::min(numFrames - 1, m_unitAuditionState.noteOffSamplesRemaining - 1);
-        target->addNoteOff(1, m_unitAuditionState.note, 0, noteOffOffset);
-        m_unitAuditionState.noteOffSamplesRemaining = 0;
-        m_unitAuditionState.active = false;
-    } else {
-        m_unitAuditionState.noteOffSamplesRemaining -= numFrames;
+        if (slot.noteOnPending) {
+            target->addNoteOn(1, slot.note, slot.velocity, 0);
+            slot.noteOnPending = false;
+        }
+
+        if (slot.noteOffSamplesRemaining <= numFrames) {
+            const uint32_t noteOffOffset = std::min(numFrames - 1, slot.noteOffSamplesRemaining - 1);
+            target->addNoteOff(1, slot.note, 0, noteOffOffset);
+            slot.noteOffSamplesRemaining = 0;
+            slot.active = false;
+        } else {
+            slot.noteOffSamplesRemaining -= numFrames;
+        }
     }
 }
 

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -225,7 +225,29 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
 
             uint16_t channelIdx = getChannelForUnit(note.unitId);
 
+            // Off-centre notes ship their pan as a polyphonic-aftertouch event
+            // (0xA0, note, pan) at the same frame with priority 1, so it lands
+            // after note-offs but before every note-on of that frame. Keyed by
+            // note number, simultaneous chord notes each latch their own pan.
+            // Centred notes emit nothing — the sampler defaults to centre.
+            // Encoded 1..127 (64 = centre); 0 is the sampler's "no pan" slot.
+            const bool hasPan = std::abs(note.pan) > 0.004f;
+            const uint8_t panByte =
+                static_cast<uint8_t>(std::clamp<long>(64 + std::lround(note.pan * 64.0f), 1, 127));
+
             if (noteFrame >= scheduleFromFrame && noteFrame < windowEnd) {
+                if (hasPan) {
+                    ScheduledEvent panEvent{};
+                    panEvent.sampleFrame = noteFrame;
+                    panEvent.instanceId = inst.instanceId;
+                    panEvent.unitId = note.unitId;
+                    panEvent.channelIdx = channelIdx;
+                    panEvent.statusByte = 0xA0;
+                    panEvent.data1 = static_cast<uint8_t>(resolvedMidiNote);
+                    panEvent.data2 = panByte;
+                    panEvent.priority = 1;
+                    m_scratchEvents.push_back(panEvent);
+                }
                 ScheduledEvent onEvent{};
                 onEvent.sampleFrame = noteFrame;
                 onEvent.instanceId = inst.instanceId;
@@ -234,11 +256,23 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 onEvent.statusByte = 0x90;
                 onEvent.data1 = static_cast<uint8_t>(resolvedMidiNote);
                 onEvent.data2 = toMidiVelocity(note.velocity);
-                onEvent.priority = 1;
+                onEvent.priority = 2;
                 m_scratchEvents.push_back(onEvent);
             } else if (noteFrame < scheduleFromFrame && offFrame > scheduleFromFrame &&
                        noteFrame >= previousScheduledThroughFrame) {
                 // Playback entered while this note was already active; start it immediately at the buffer edge once.
+                if (hasPan) {
+                    ScheduledEvent panEvent{};
+                    panEvent.sampleFrame = scheduleFromFrame;
+                    panEvent.instanceId = inst.instanceId;
+                    panEvent.unitId = note.unitId;
+                    panEvent.channelIdx = channelIdx;
+                    panEvent.statusByte = 0xA0;
+                    panEvent.data1 = static_cast<uint8_t>(resolvedMidiNote);
+                    panEvent.data2 = panByte;
+                    panEvent.priority = 1;
+                    m_scratchEvents.push_back(panEvent);
+                }
                 ScheduledEvent resumeOnEvent{};
                 resumeOnEvent.sampleFrame = scheduleFromFrame;
                 resumeOnEvent.instanceId = inst.instanceId;
@@ -247,7 +281,7 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 resumeOnEvent.statusByte = 0x90;
                 resumeOnEvent.data1 = static_cast<uint8_t>(resolvedMidiNote);
                 resumeOnEvent.data2 = toMidiVelocity(note.velocity);
-                resumeOnEvent.priority = 1;
+                resumeOnEvent.priority = 2;
                 m_scratchEvents.push_back(resumeOnEvent);
             }
 

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -421,8 +421,8 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
             }
 
             float gain = (v.velocity * v.velocity) * env * kSamplerOutputHeadroom * voiceComp;
-            L += outL * gain;
-            R += outR * gain;
+            L += outL * gain * v.gainL;
+            R += outR * gain * v.gainR;
 
             // Advance
             v.position += v.playbackRate;
@@ -439,7 +439,26 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
     uint8_t note = event.data[1];
     uint8_t velocity = event.data[2];
 
+    if (status == 0xA0) { // Per-note pan, sent just before the matching note-on
+        m_pendingNotePan[note & 0x7F] = velocity; // 1..127, 64 = centre
+        return;
+    }
+
     if (status == 0x90 && velocity > 0) { // Note On
+        // Consume the pending pan for this note (0 = none → centre) and
+        // re-arm the slot so later notes without pan stay centred. Unity at
+        // centre keeps unpanned projects bit-identical to before.
+        float noteGainL = 1.0f;
+        float noteGainR = 1.0f;
+        {
+            const uint8_t panByte = m_pendingNotePan[note & 0x7F];
+            m_pendingNotePan[note & 0x7F] = 0;
+            if (panByte != 0 && panByte != 64) {
+                const float pan = std::clamp((static_cast<float>(panByte) - 64.0f) / 63.0f, -1.0f, 1.0f);
+                noteGainL = std::min(1.0f, 1.0f - pan);
+                noteGainR = std::min(1.0f, 1.0f + pan);
+            }
+        }
         const float pitchParam = m_params[kParamPitch].load(std::memory_order_relaxed);
         const float globalSemitones = (pitchParam - 0.5f) * 24.0f + (m_fineTuneCents.load(std::memory_order_relaxed) / 100.0f);
         const int rootMidiNote = m_rootMidiNote.load(std::memory_order_relaxed);
@@ -461,6 +480,8 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
             voice.active = true;
             voice.note = note;
             voice.velocity = velocity / 127.0f;
+            voice.gainL = noteGainL;
+            voice.gainR = noteGainR;
 
             if (legato) {
                 voice.targetPlaybackRate = targetRate;
@@ -526,6 +547,8 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
         freeVoice->active = true;
         freeVoice->note = note;
         freeVoice->velocity = velocity / 127.0f;
+        freeVoice->gainL = noteGainL;
+        freeVoice->gainR = noteGainR;
         freeVoice->position = noteStartFrame;
         freeVoice->playbackRate = targetRate;
         freeVoice->targetPlaybackRate = targetRate;

--- a/AestraUI/Common/MusicHelpers.h
+++ b/AestraUI/Common/MusicHelpers.h
@@ -11,6 +11,7 @@ struct MidiNote {
     double startBeat;    // Start position in beats
     double durationBeats;// Duration in beats
     float velocity;      // 0..1
+    float pan = 0.0f;    // -1 (left) .. 1 (right), 0 = centre
     uint64_t unitId = 0; // Arsenal unit routing
     bool selected = false;
     bool isDeleted = false; // For delete animation

--- a/AestraUI/Helpers/PianoRollInteraction.cpp
+++ b/AestraUI/Helpers/PianoRollInteraction.cpp
@@ -15,7 +15,9 @@ int findNoteAtLocal(const std::vector<MidiNote>& notes,
 
         float nx = static_cast<float>(n.startBeat * pixelsPerBeat);
         float ny = (127 - n.pitch) * keyHeight;
-        float nw = static_cast<float>(n.durationBeats * pixelsPerBeat);
+        // Zoomed far out a short note renders ~1px wide; keep a few pixels of
+        // click target so it stays selectable.
+        float nw = std::max(4.0f, static_cast<float>(n.durationBeats * pixelsPerBeat));
         float nh = keyHeight;
 
         if (localX >= nx && localX < nx + nw &&

--- a/AestraUI/Helpers/PianoRollInteraction.cpp
+++ b/AestraUI/Helpers/PianoRollInteraction.cpp
@@ -1,5 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "PianoRollInteraction.h"
+#include <algorithm>
+#include <cmath>
 
 namespace AestraUI {
 
@@ -41,6 +43,21 @@ bool isNoteInSelectionBox(const MidiNote& note,
 
     return !(nx + nw <= normX || nx >= normX + normW ||
              ny + nh <= normY || ny >= normY + normH);
+}
+
+float velocityFromPanelPosition(float pointerY, float bottomY, float availableHeight) {
+    if (!std::isfinite(pointerY) || !std::isfinite(bottomY) ||
+        !std::isfinite(availableHeight) || availableHeight <= 0.0f) {
+        return 0.0f;
+    }
+    return std::clamp((bottomY - pointerY) / availableHeight, 0.0f, 1.0f);
+}
+
+float velocityToPanelHeight(float velocity, float availableHeight) {
+    if (!std::isfinite(velocity) || !std::isfinite(availableHeight) || availableHeight <= 0.0f) {
+        return 0.0f;
+    }
+    return std::clamp(velocity, 0.0f, 1.0f) * availableHeight;
 }
 
 } // namespace AestraUI

--- a/AestraUI/Helpers/PianoRollInteraction.h
+++ b/AestraUI/Helpers/PianoRollInteraction.h
@@ -10,6 +10,15 @@
 namespace AestraUI {
 
 /**
+ * Snap a beat position to the nearest @p snapDur grid line, clamped to >= 0.
+ * A non-positive grid returns the position unchanged (nothing to quantize to).
+ */
+inline double quantizeBeatToGrid(double beat, double snapDur) {
+    if (snapDur <= 0.0001) return beat;
+    return std::max(0.0, std::round(beat / snapDur) * snapDur);
+}
+
+/**
  * Compute the elongated end for a note being "connected" (legato) to the next
  * note in time. The note's end extends forward to the nearest start greater than
  * its own; when nothing follows, it extends to the next @p snapDur boundary. The

--- a/AestraUI/Helpers/PianoRollInteraction.h
+++ b/AestraUI/Helpers/PianoRollInteraction.h
@@ -2,9 +2,38 @@
 #pragma once
 
 #include "MusicHelpers.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <vector>
 
 namespace AestraUI {
+
+/**
+ * Compute the elongated end for a note being "connected" (legato) to the next
+ * note in time. The note's end extends forward to the nearest start greater than
+ * its own; when nothing follows, it extends to the next @p snapDur boundary. The
+ * result never precedes the current end — the operation only ever lengthens.
+ *
+ * @param start      Note start in beats.
+ * @param end        Note end in beats (start + duration).
+ * @param otherStarts Start beats of the other candidate notes.
+ * @param snapDur    Grid used for the no-follower fallback (<=0 falls back to 1 beat).
+ * @return The new end beat (>= end).
+ */
+inline double computeConnectedNoteEnd(double start, double end,
+                                      const std::vector<double>& otherStarts,
+                                      double snapDur) {
+    double nextStart = std::numeric_limits<double>::max();
+    for (double s : otherStarts) {
+        if (s > start + 0.0001 && s < nextStart) nextStart = s;
+    }
+    if (nextStart < std::numeric_limits<double>::max()) {
+        return nextStart > end ? nextStart : end; // fill the gap, but never shorten
+    }
+    if (snapDur <= 0.0001) snapDur = 1.0;
+    return std::ceil((end + 0.0001) / snapDur) * snapDur; // out to the next grid line
+}
 
 /**
  * Find the topmost non-deleted note at a given local coordinate.

--- a/AestraUI/Helpers/PianoRollInteraction.h
+++ b/AestraUI/Helpers/PianoRollInteraction.h
@@ -40,6 +40,17 @@ bool isNoteInSelectionBox(const MidiNote& note,
                           float scrollX = 0.0f, float scrollY = 0.0f);
 
 /**
+ * Convert a pointer Y coordinate in the velocity lane to the normalized
+ * velocity representation used by MidiNote (0.0f to 1.0f).
+ */
+float velocityFromPanelPosition(float pointerY, float bottomY, float availableHeight);
+
+/**
+ * Convert a normalized MidiNote velocity to a rendered lane height.
+ */
+float velocityToPanelHeight(float velocity, float availableHeight);
+
+/**
  * Check if a note should be considered for interaction (not deleted).
  */
 inline bool isNoteActive(const MidiNote& note) {

--- a/AestraUI/Helpers/TimelineGridRenderer.h
+++ b/AestraUI/Helpers/TimelineGridRenderer.h
@@ -1,0 +1,135 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "../Core/NUITypes.h"
+#include "../Graphics/NUIRenderer.h"
+#include <algorithm>
+#include <cmath>
+
+namespace AestraUI {
+
+inline float timelineGridLevelFade(float spacingPixels) {
+    constexpr float kLevelHidePixels = 14.0f;
+    constexpr float kLevelFullPixels = 28.0f;
+    return std::clamp((spacingPixels - kLevelHidePixels) / (kLevelFullPixels - kLevelHidePixels), 0.0f, 1.0f);
+}
+
+inline int timelineGridBarStride(float pixelsPerBeat, int beatsPerBar) {
+    constexpr float kLevelFullPixels = 28.0f;
+    const float pixelsPerBar = pixelsPerBeat * static_cast<float>(std::max(1, beatsPerBar));
+    int stride = 1;
+    while ((pixelsPerBar * static_cast<float>(stride)) < kLevelFullPixels && stride < (1 << 20)) {
+        stride *= 2;
+    }
+    return stride;
+}
+
+/**
+ * Draw the canonical Track Manager timeline grid inside an arbitrary grid span.
+ *
+ * The power-of-two hierarchy and zebra crossfade stay stable at every zoom,
+ * allowing timeline-derived editors to share one visual rhythm.
+ */
+inline void renderTimelineGrid(NUIRenderer& renderer,
+                               const NUIRect& bounds,
+                               float gridStartX,
+                               float gridEndX,
+                               float scrollX,
+                               float pixelsPerBeat,
+                               int beatsPerBar) {
+    const float gridWidth = std::max(0.0f, gridEndX - gridStartX);
+    beatsPerBar = std::max(1, beatsPerBar);
+    const float pixelsPerBar = pixelsPerBeat * static_cast<float>(beatsPerBar);
+    if (gridWidth <= 0.0f || pixelsPerBeat <= 0.0f || pixelsPerBar <= 0.0f) {
+        return;
+    }
+
+    constexpr float kLevelFullPx = 28.0f;
+    const auto lineAlpha = [&](float spacingPx) {
+        const float strength =
+            0.028f + (0.105f - 0.028f) *
+                         std::clamp((spacingPx - kLevelFullPx) / (kLevelFullPx * 3.0f), 0.0f, 1.0f);
+        return strength * timelineGridLevelFade(spacingPx);
+    };
+
+    const int barStride = timelineGridBarStride(pixelsPerBeat, beatsPerBar);
+
+    constexpr float kZebraAlpha = 0.030f;
+    const auto drawZebraLevel = [&](int strideBars, float alpha) {
+        if (alpha <= 0.001f) return;
+        const float blockWidth = pixelsPerBar * static_cast<float>(strideBars);
+        const int startBlock = static_cast<int>(std::floor(scrollX / blockWidth));
+        const int endBlock = static_cast<int>(std::floor((scrollX + gridWidth) / blockWidth)) + 1;
+        for (int block = startBlock; block <= endBlock; ++block) {
+            if ((block & 1) == 0) continue;
+            float rectX = gridStartX + (block * blockWidth) - scrollX;
+            float rectWidth = blockWidth;
+            if (rectX < gridStartX) {
+                rectWidth -= gridStartX - rectX;
+                rectX = gridStartX;
+            }
+            if (rectX + rectWidth > gridEndX) {
+                rectWidth = gridEndX - rectX;
+            }
+            if (rectWidth > 0.0f) {
+                renderer.fillRect(NUIRect(rectX, bounds.y, rectWidth, bounds.height),
+                                  NUIColor::white().withAlpha(alpha));
+            }
+        }
+    };
+
+    const float pixelsPerBlock = pixelsPerBar * static_cast<float>(barStride);
+    const float fineT = std::clamp((pixelsPerBlock - kLevelFullPx) / kLevelFullPx, 0.0f, 1.0f);
+    drawZebraLevel(barStride, kZebraAlpha * fineT);
+    drawZebraLevel(barStride * 2, kZebraAlpha * (1.0f - fineT));
+
+    const double startBeat = static_cast<double>(scrollX) / pixelsPerBeat;
+    const double endBeat = startBeat + static_cast<double>(gridWidth / pixelsPerBeat);
+    const int firstVisibleBar = static_cast<int>(std::floor(startBeat / beatsPerBar)) - 1;
+    const int lastVisibleBar = static_cast<int>(std::ceil(endBeat / beatsPerBar)) + 1;
+    const auto drawGridLine = [&](float x, float alpha) {
+        renderer.drawLine(NUIPoint(x, bounds.y),
+                          NUIPoint(x, bounds.bottom()),
+                          1.0f,
+                          NUIColor::white().withAlpha(alpha));
+    };
+    const float beatLineAlpha = lineAlpha(pixelsPerBeat);
+    const float halfBeatLineAlpha = lineAlpha(pixelsPerBeat * 0.5f);
+
+    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
+        const float barX = gridStartX + (bar * pixelsPerBar) - scrollX;
+        if (barX >= gridStartX && barX <= gridEndX) {
+            int level = 20;
+            if (bar != 0) {
+                level = 0;
+                int barMagnitude = std::abs(bar);
+                while ((barMagnitude & 1) == 0 && level < 20) {
+                    barMagnitude >>= 1;
+                    ++level;
+                }
+            }
+            const float levelSpacing = pixelsPerBar * static_cast<float>(1u << level);
+            const float alpha = lineAlpha(levelSpacing);
+            if (alpha > 0.001f) drawGridLine(barX, alpha);
+        }
+
+        if (beatLineAlpha > 0.001f) {
+            for (int beat = 1; beat < beatsPerBar; ++beat) {
+                const float beatX = barX + beat * pixelsPerBeat;
+                if (beatX >= gridStartX && beatX <= gridEndX) drawGridLine(beatX, beatLineAlpha);
+            }
+        }
+
+        if (halfBeatLineAlpha > 0.001f) {
+            const float halfBeatOffset = pixelsPerBeat * 0.5f;
+            for (int beat = 0; beat < beatsPerBar; ++beat) {
+                const float subBeatX = barX + beat * pixelsPerBeat + halfBeatOffset;
+                if (subBeatX >= gridStartX && subBeatX <= gridEndX) {
+                    drawGridLine(subBeatX, halfBeatLineAlpha);
+                }
+            }
+        }
+    }
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1068,6 +1068,26 @@ int PianoRollNoteLayer::snapPitchToScale(int pitch) {
     return bestPitch;
 }
 
+void PianoRollNoteLayer::auditionPitch(int pitch) {
+    // Never talk over the transport — playback owns the audio focus.
+    if (isPlayingCallback_ && isPlayingCallback_()) {
+        auditionStop();
+        return;
+    }
+    pitch = std::clamp(pitch, 0, 127);
+    if (pitch == auditionPitch_) return;
+    if (!onPreviewNote_) { auditionPitch_ = pitch; return; }
+    if (auditionPitch_ != -1) onPreviewNote_(auditionPitch_, 0); // release previous
+    onPreviewNote_(pitch, static_cast<int>(std::lround(lastNoteVelocity_ * 127.0f)));
+    auditionPitch_ = pitch;
+}
+
+void PianoRollNoteLayer::auditionStop() {
+    if (auditionPitch_ == -1) return;
+    if (onPreviewNote_) onPreviewNote_(auditionPitch_, 0);
+    auditionPitch_ = -1;
+}
+
 void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
     if (!isVisible()) return;
     auto b = getBounds();
@@ -1196,6 +1216,30 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
             renderer.fillRoundedRect(pr, 3.0f, noteColor.withAlpha(0.20f));
             renderer.strokeRoundedRect(pr, 3.0f, 1.0f, noteColor.lightened(0.16f).withAlpha(0.48f));
         }
+    }
+
+    // Floating pitch label while placing or moving a note — read the pitch you
+    // hear, tracking the note and flipping below if it would clip at the top.
+    if ((state_ == State::Painting || state_ == State::Moving) && dragAnchorIndex_ >= 0 &&
+        dragAnchorIndex_ < static_cast<int>(notes_.size()) && !notes_[dragAnchorIndex_].isDeleted) {
+        const auto& an = notes_[dragAnchorIndex_];
+        const float ax = snapRectX(beatToScreenX(an.startBeat, pixelsPerBeat_, scrollX_, b.x));
+        const float ay = b.y + (127 - an.pitch) * keyHeight_ - scrollY_;
+        const std::string label = MusicTheory::getPitchName(an.pitch);
+        constexpr float kFontSize = 10.0f;
+        const auto measured = renderer.measureText(label, kFontSize);
+        const float bubbleW = measured.width + 12.0f;
+        const float bubbleH = 17.0f;
+        float bubbleY = ay - bubbleH - 3.0f;
+        if (bubbleY < b.y) bubbleY = ay + keyHeight_ + 3.0f;
+        const float bubbleX = std::clamp(ax, b.x + 2.0f, b.right() - bubbleW - 2.0f);
+        const NUIRect bubble(bubbleX, bubbleY, bubbleW, bubbleH);
+        renderer.fillRoundedRect(bubble, 4.0f, NUIColor::black().withAlpha(0.92f));
+        renderer.strokeRoundedRect(bubble, 4.0f, 1.0f, themeManager.getColor("accentPrimary").withAlpha(0.80f));
+        renderer.drawText(label,
+                          NUIPoint(bubble.x + 6.0f, bubble.y + (bubble.height - measured.height) * 0.5f),
+                          kFontSize,
+                          NUIColor::white().withAlpha(0.95f));
     }
 
     // Rubber-band selection rectangle (already normalized during drag)
@@ -1425,7 +1469,10 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             
             notes_.push_back(newNote);
             paintingNoteIndex_ = static_cast<int>(notes_.size()) - 1;
-            
+            dragAnchorIndex_ = paintingNoteIndex_;
+
+            auditionPitch(paintPitch_); // sound the note as it's laid down
+
             dragStartPos_ = event.position;
             dragStartScrollX_ = scrollX_;
             dragStartScrollY_ = scrollY_;
@@ -1510,6 +1557,14 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             dragStartScrollX_ = scrollX_;
             dragStartScrollY_ = scrollY_;
             dragStartNotes_ = notes_;
+
+            // Grabbing a note to move it sounds its pitch, and keeps sounding
+            // the new pitch as you drag it up/down.
+            if (state_ == State::Moving) {
+                moveAnchorPitch_ = notes_[clickedIndex].pitch;
+                dragAnchorIndex_ = clickedIndex;
+                auditionPitch(moveAnchorPitch_);
+            }
 
             // Spec 2: adopt clicked note's length for subsequent placement
             lastNoteDuration_ = notes_[clickedIndex].durationBeats;
@@ -1615,6 +1670,8 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
                     notes_[i].pitch = snapPitchToScale(newPitch);
                 }
             }
+            // Re-audition when the grabbed note lands on a new pitch.
+            auditionPitch(snapPitchToScale(std::clamp(moveAnchorPitch_ + pitchDelta, 0, 127)));
             repaint();
             return true;
         }
@@ -1686,6 +1743,8 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     
     // --- RELEASE ---
     if (event.released && event.button == NUIMouseButton::Left) {
+        auditionStop(); // release any note sounded while painting/dragging
+        dragAnchorIndex_ = -1;
         if (state_ == State::SelectingBox) {
             // Marquee selection done. Selection was cleared on click (without Shift),
             // and notes inside the box were selected during drag.
@@ -2830,8 +2889,14 @@ void PianoRollView::setIsPlayingCallback(std::function<bool()> cb) {
 
 void PianoRollView::setOnPreviewNote(std::function<void(int pitch, int velocity)> cb) {
     if (m_keys) {
-        m_keys->setOnPreviewNote(std::move(cb));
+        m_keys->setOnPreviewNote(cb);
         m_keys->setIsPlayingFromParent(m_isPlayingCallback);
+    }
+    if (m_notes) {
+        // The note layer auditions pitches while notes are placed and dragged,
+        // through the same synth path the key lane uses.
+        m_notes->setOnPreviewNote(std::move(cb));
+        m_notes->setIsPlayingCallback(m_isPlayingCallback);
     }
 }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -170,6 +170,11 @@ bool PianoRollKeyLane::onMouseEvent(const NUIMouseEvent& event) {
             if (onHoveredKeyChanged_) onHoveredKeyChanged_(-1);
             repaint();
         }
+        // A press that started on a key can be released outside the lane —
+        // still end the preview so the next press re-fires cleanly.
+        if (event.released && event.button == NUIMouseButton::Left) {
+            previewPitch_ = -1;
+        }
         return false;
     }
 
@@ -195,12 +200,12 @@ bool PianoRollKeyLane::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
     else if (event.released && event.button == NUIMouseButton::Left && previewPitch_ != -1) {
-        if (onPreviewNote_) {
-            onPreviewNote_(previewPitch_, 0);
-        }
+        // The engine audition voice is one-shot (auto note-off, velocity
+        // clamped to >=1) — sending a velocity-0 "note-off" would retrigger a
+        // near-silent voice on top of it, so just clear the preview state.
         previewPitch_ = -1;
     }
-    
+
     return NUIComponent::onMouseEvent(event);
 }
 
@@ -1878,6 +1883,10 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     if (hoveredPitch_ != cursorPitch) {
         hoveredPitch_ = cursorPitch;
         if (onHoveredPitchChanged_) onHoveredPitchChanged_(cursorPitch);
+        // Vertical moves within the same snapped beat leave hoverBeat_
+        // unchanged, so without this the pencil's phantom note would linger
+        // on the previous pitch row.
+        repaint();
     }
 
     // --- HOVER / SMART CURSOR (no button activity) ---
@@ -3100,9 +3109,8 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     NUIRect contentRect(b.x + sidebarW, b.y, b.width - sidebarW, b.height);
     renderer.setClipRect(contentRect);
 
-    constexpr int beatsPerBar = 4;
     const float startX = contentRect.x;
-    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar);
+    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
 
     const float availH = std::max(1.0f, b.height - 28.0f);
     const float bottomY = b.bottom() - 8.0f;
@@ -3831,6 +3839,7 @@ void PianoRollView::setBeatsPerBar(int bpb) {
     if (m_grid) m_grid->setBeatsPerBar(bpb);
     if (m_ruler) m_ruler->setBeatsPerBar(bpb);
     if (m_notes) m_notes->setBeatsPerBar(bpb);
+    if (m_controls) m_controls->setBeatsPerBar(bpb);
 }
 
 void PianoRollView::setTool(GlobalTool tool) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -3,6 +3,7 @@
 #include "../Platform/NUIPlatformBridge.h"
 #include "../Common/MusicHelpers.h"
 #include "../Helpers/PianoRollInteraction.h"
+#include "../Helpers/TimelineGridRenderer.h"
 #include "NUIDropdown.h"
 #include "NUIButton.h"
 #include "NUIContextMenu.h"
@@ -164,6 +165,7 @@ bool PianoRollKeyLane::onMouseEvent(const NUIMouseEvent& event) {
     if (!getBounds().contains(event.position)) {
         if (hoveredKey_ != -1) {
             hoveredKey_ = -1;
+            if (onHoveredKeyChanged_) onHoveredKeyChanged_(-1);
             repaint();
         }
         return false;
@@ -176,6 +178,7 @@ bool PianoRollKeyLane::onMouseEvent(const NUIMouseEvent& event) {
 
     if (hoveredKey_ != pitch) {
         hoveredKey_ = pitch;
+        if (onHoveredKeyChanged_) onHoveredKeyChanged_(pitch);
         repaint();
     }
 
@@ -492,74 +495,85 @@ bool PianoRollRuler::onMouseEvent(const NUIMouseEvent& event) {
 // Ruler Render: "Mature" Playlist Style
 void PianoRollRuler::onRender(NUIRenderer& renderer) {
     if (!isVisible()) return;
-    auto b = getBounds();
-    auto& themeManager = NUIThemeManager::getInstance();
-    
-    // CLIP: Prevent left bleeding
-    renderer.setClipRect(b);
-    
-    auto bg = themeManager.getColor("backgroundSecondary").darkened(0.025f);
-    auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
-    auto tickCol = themeManager.getColor("textSecondary").withAlpha(0.52f);
-    auto borderCol = themeManager.getColor("border").withAlpha(0.66f);
-    
-    renderer.fillRect(b, bg);
-    
-    // Bottom border
-    renderer.drawLine(NUIPoint(b.x, b.y + b.height), NUIPoint(b.x + b.width, b.y + b.height), 1.0f, borderCol);
+    const auto bounds = getBounds();
+    auto& theme = NUIThemeManager::getInstance();
 
-    float startBeat = scrollX_ / pixelsPerBeat_;
-    float endBeat = (scrollX_ + b.width) / pixelsPerBeat_;
-    
-    int iStart = static_cast<int>(startBeat);
-    int iEnd = static_cast<int>(endBeat) + 1;
+    const auto rulerBackground = NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
+    const auto border = NUIColor::white().withAlpha(0.075f);
+    const auto highlight = NUIColor::white().withAlpha(0.014f);
+    const auto text = theme.getColor("textPrimary").withAlpha(0.86f);
+    const auto tick = NUIColor::fromHex(0x2e2e2e).withAlpha(0.82f);
 
-    for (int i = iStart; i <= iEnd; ++i) {
-        float x = snapVerticalLineX(beatToScreenX(static_cast<double>(i), pixelsPerBeat_, scrollX_, b.x));
-        
-        // Prevent drawing text partially off-screen left if we can help it, 
-        // but setClipRect handles the actual pixels.
-        
-        bool isBar = (beatsPerBar_ > 0 && i % beatsPerBar_ == 0);
-        
-        if (isBar) {
-            // Bar: Taller tick, Label
-            int barNum = (i / beatsPerBar_) + 1;
-            
-            // Modern Look: Line doesn't go all the way, just top portion or bottom tick
-            // Playlist usually has numbers at the start of the bar.
-            
-            // Major Tick (Bottom up)
-            renderer.fillRect(NUIRect(x, b.y, 1.0f, b.height), borderCol.withAlpha(0.48f));
-            renderer.drawLine(NUIPoint(x, b.y + b.height * 0.45f), NUIPoint(x, b.y + b.height), 1.0f, tickCol);
-            
-            // Label
-            renderer.drawText(std::to_string(barNum), NUIPoint(x + 6, b.y + 5), 11.0f, textCol);
-        } else {
-            // Beat: Short Tick
-            renderer.drawLine(NUIPoint(x, b.y + b.height * 0.75f), NUIPoint(x, b.y + b.height), 1.0f, tickCol.withAlpha(0.6f));
+    renderer.fillRoundedRect(bounds, 3.0f, rulerBackground);
+    renderer.fillRect(NUIRect(bounds.x, bounds.y, bounds.width, 1.0f), highlight);
+    renderer.strokeRoundedRect(bounds, 3.0f, 1.0f, border);
+    renderer.drawLine(NUIPoint(bounds.x, bounds.bottom() - 1.0f),
+                      NUIPoint(bounds.right(), bounds.bottom() - 1.0f),
+                      1.0f,
+                      border);
+
+    renderer.setClipRect(bounds);
+
+    const int beatsPerBar = std::max(1, beatsPerBar_);
+    const float pixelsPerBar = pixelsPerBeat_ * beatsPerBar;
+    int barStride = 1;
+    while ((pixelsPerBar * static_cast<float>(barStride)) < 28.0f && barStride < 128) {
+        barStride *= 2;
+    }
+
+    int startBar = static_cast<int>(std::floor(scrollX_ / pixelsPerBar));
+    startBar = static_cast<int>(std::floor(static_cast<double>(startBar) / barStride)) * barStride;
+    const int visibleBars = static_cast<int>(std::ceil((scrollX_ + bounds.width) / pixelsPerBar)) - startBar;
+    const int endBar = startBar + visibleBars + barStride;
+
+    for (int bar = startBar; bar <= endBar; bar += barStride) {
+        const float x = snapVerticalLineX(bounds.x + bar * pixelsPerBar - scrollX_);
+        const int barNumber = bar + 1;
+        const bool isMajorBar = barStride > 1 || barNumber == 1 || ((barNumber - 1) % 4 == 0);
+        const float fontSize = isMajorBar ? 11.0f : 10.0f;
+        const float textY = std::round(renderer.calculateTextY(bounds, fontSize));
+        renderer.drawText(std::to_string(barNumber),
+                          NUIPoint(x + 4.0f, textY),
+                          fontSize,
+                          isMajorBar ? text : text.withAlpha(0.76f));
+
+        const float tickHeight = isMajorBar ? bounds.height * 0.58f : bounds.height * 0.24f;
+        renderer.drawLine(NUIPoint(x, bounds.bottom() - tickHeight),
+                          NUIPoint(x, bounds.bottom()),
+                          isMajorBar ? 1.15f : 1.0f,
+                          isMajorBar ? tick : tick.withAlpha(0.58f));
+
+        if (pixelsPerBeat_ >= 10.0f && barStride == 1) {
+            for (int beat = 1; beat < beatsPerBar; ++beat) {
+                const float beatX = x + beat * pixelsPerBeat_;
+                renderer.drawLine(NUIPoint(beatX, bounds.bottom() - bounds.height * 0.22f),
+                                  NUIPoint(beatX, bounds.bottom()),
+                                  1.0f,
+                                  NUIColor::fromHex(0x262626).withAlpha(0.36f));
+            }
         }
     }
 
-    const float playheadX = snapVerticalLineX(
-        beatToScreenX(playheadBeat_, pixelsPerBeat_, scrollX_, b.x));
-    if (playheadX >= b.x && playheadX <= b.right()) {
-        const auto accent = themeManager.getColor("accentPrimary");
-        const NUIRect handle(playheadX - 5.0f, b.y + 3.0f, 10.0f, 16.0f);
-        renderer.fillRoundedRect(handle, 4.0f, accent.withAlpha(isScrubbing_ ? 1.0f : 0.90f));
-        renderer.strokeRoundedRect(handle, 4.0f, 1.0f, NUIColor::white().withAlpha(0.46f));
-        renderer.fillRoundedRect(NUIRect(playheadX - 1.0f, handle.y + 4.0f, 2.0f, 8.0f),
-                                 1.0f,
-                                 NUIColor::white().withAlpha(0.72f));
-        renderer.drawLine(NUIPoint(playheadX, handle.bottom()),
-                          NUIPoint(playheadX, b.bottom()),
-                          2.0f,
-                          accent.withAlpha(0.92f));
+    const float playheadX =
+        snapVerticalLineX(beatToScreenX(playheadBeat_, pixelsPerBeat_, scrollX_, bounds.x));
+    if (playheadX >= bounds.x && playheadX <= bounds.right()) {
+        const auto accent = theme.getColor("accentPrimary");
+        const float markerRadius = isScrubbing_ ? 6.5f : 6.0f;
+        const NUIPoint markerCenter(playheadX, bounds.bottom() - markerRadius);
+        renderer.fillCircle(markerCenter,
+                            markerRadius + 2.0f,
+                            theme.getColor("backgroundPrimary").withAlpha(0.94f));
+        renderer.fillCircle(markerCenter, markerRadius, accent.withAlpha(isScrubbing_ ? 0.34f : 0.20f));
+        renderer.strokeCircle(markerCenter, markerRadius, 1.3f, accent.withAlpha(0.98f));
+        renderer.fillCircle(markerCenter, 1.7f, accent);
+        renderer.drawLine(NUIPoint(playheadX, markerCenter.y + markerRadius),
+                          NUIPoint(playheadX, bounds.bottom()),
+                          1.0f,
+                          accent.withAlpha(0.88f));
     }
 
     renderer.clearClipRect();
 }
-
 void PianoRollRuler::setPixelsPerBeat(float ppb) { pixelsPerBeat_ = std::max(10.0f, ppb); repaint(); }
 void PianoRollRuler::setScrollX(float scrollX) { scrollX_ = scrollX; repaint(); }
 
@@ -611,13 +625,11 @@ void PianoRollToolbar::setupUI() {
         auto snapMenu = std::make_shared<NUIContextMenu>();
         auto snaps = MusicTheory::getSnapOptions();
         for (auto snap : snaps) {
-            bool isSelected = false; // Need to track this
-            if (auto g = grid_.lock()) {
-                // We'll need a getter for snap in PianoRollGrid or track it here
-            }
             snapMenu->addItem(MusicTheory::getSnapName(snap), [this, snap]() {
+                m_currentSnap = snap;
                 if (auto g = grid_.lock()) g->setSnap(snap);
                 if (auto n = notes_.lock()) n->setSnap(snap);
+                repaint();
             });
         }
         menu->addSubmenu("Snap", snapMenu);
@@ -625,10 +637,10 @@ void PianoRollToolbar::setupUI() {
         // --- ROOT KEY SUBMENU ---
         auto rootMenu = std::make_shared<NUIContextMenu>();
         auto roots = MusicTheory::getRootNames();
-        for (int i = 0; i < roots.size(); ++i) {
+        for (size_t i = 0; i < roots.size(); ++i) {
             rootMenu->addItem(roots[i], [this, i]() {
-                if (auto g = grid_.lock()) g->setRootKey(i);
-                if (auto n = notes_.lock()) n->setRootKey(i);
+                if (auto g = grid_.lock()) g->setRootKey(static_cast<int>(i));
+                if (auto n = notes_.lock()) n->setRootKey(static_cast<int>(i));
             });
         }
         menu->addSubmenu("Root Key", rootMenu);
@@ -636,7 +648,7 @@ void PianoRollToolbar::setupUI() {
         // --- SCALE SUBMENU ---
         auto scaleMenu = std::make_shared<NUIContextMenu>();
         auto scales = MusicTheory::getScales();
-        for (int i = 0; i < scales.size(); ++i) {
+        for (size_t i = 0; i < scales.size(); ++i) {
             scaleMenu->addItem(scales[i].name, [this, i]() {
                 if (auto g = grid_.lock()) g->setScaleType(static_cast<ScaleType>(i));
                 if (auto n = notes_.lock()) n->setScaleType(static_cast<ScaleType>(i));
@@ -865,6 +877,21 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
 
     renderButton(m_lengthUpBtn, m_lengthUpIcon, false);
 
+    currentX += 8.0f;
+    const std::string snapLabel = "SNAP  " + MusicTheory::getSnapName(m_currentSnap);
+    const float snapFontSize = 9.0f;
+    const auto snapTextSize = renderer.measureText(snapLabel, snapFontSize);
+    const float snapWidth = std::max(78.0f, snapTextSize.width + 18.0f);
+    const NUIRect snapRect(currentX, currentY, snapWidth, buttonSize);
+    renderer.fillRoundedRect(snapRect, radius, groupBg);
+    renderer.strokeRoundedRect(snapRect, radius, 1.0f, groupBorder);
+    renderer.drawText(snapLabel,
+                      NUIPoint(snapRect.x + (snapRect.width - snapTextSize.width) * 0.5f,
+                               snapRect.y + (snapRect.height - snapTextSize.height) * 0.5f + 1.0f),
+                      snapFontSize,
+                      themeManager.getColor("textSecondary").withAlpha(0.76f));
+    currentX += snapWidth;
+
     // Editing Pattern Label (Right Side)
     if (!m_patternName.empty()) {
         const float labelLeft = std::max(patternDropdownRight + 10.0f, currentX + 12.0f);
@@ -936,92 +963,73 @@ PianoRollGrid::PianoRollGrid()
 
 void PianoRollGrid::onRender(NUIRenderer& renderer) {
     if (!isVisible()) return;
-    auto b = getBounds();
-    auto& themeManager = NUIThemeManager::getInstance();
-    
-    // CLIP TO BOUNDS to prevent bleeding
-    renderer.setClipRect(b);
+    const auto bounds = getBounds();
+    auto& theme = NUIThemeManager::getInstance();
 
-    renderer.fillRect(b, themeManager.getColor("backgroundPrimary").darkened(0.01f));
+    renderer.setClipRect(bounds);
+    renderer.fillRect(bounds, NUIColor::black());
 
-    const auto rowAccidental = themeManager.getColor("surfaceRaised").withAlpha(0.11f);
-    const auto rowRoot = themeManager.getColor("accentPrimary").withAlpha(0.075f);
-    const auto rowOutOfScale = themeManager.getColor("backgroundPrimary").darkened(0.05f).withAlpha(0.45f);
-    const auto rowLine = themeManager.getColor("border").withAlpha(0.075f);
-    const auto gridSubdivision = themeManager.getColor("border").withAlpha(0.065f);
-    const auto gridBeat = themeManager.getColor("border").withAlpha(0.15f);
-    const auto gridBar = themeManager.getColor("textSecondary").withAlpha(0.24f);
+    const auto accidentalRow = NUIColor::white().withAlpha(0.022f);
+    const auto rootRow = theme.getColor("accentPrimary").withAlpha(0.055f);
+    const auto outOfScaleRow = NUIColor::black().withAlpha(0.24f);
+    const auto rowLine = NUIColor::white().withAlpha(0.045f);
 
-    const double visibleStartBeat = static_cast<double>(scrollX_) / pixelsPerBeat_;
-    const double visibleEndBeat = static_cast<double>(scrollX_ + b.width) / pixelsPerBeat_;
-    const int firstVisibleBar = static_cast<int>(std::floor(visibleStartBeat / beatsPerBar_));
-    const int lastVisibleBar = static_cast<int>(std::ceil(visibleEndBeat / beatsPerBar_));
-    const auto zebraColor = themeManager.getColor("surfaceRaised").withAlpha(0.035f);
-    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
-        if ((bar & 1) == 0) continue;
-        const double barStartBeat = static_cast<double>(bar * beatsPerBar_);
-        const float barX = beatToScreenX(barStartBeat, pixelsPerBeat_, scrollX_, b.x);
-        const float barWidth = pixelsPerBeat_ * static_cast<float>(beatsPerBar_);
-        renderer.fillRect(NUIRect(barX, b.y, barWidth, b.height), zebraColor);
-    }
-
-    // 1. Draw Rows (Matching Keys)
-    int startPitch = 127 - static_cast<int>((scrollY_) / keyHeight_);
-    int endPitch = 127 - static_cast<int>((scrollY_ + b.height) / keyHeight_);
-    
-    // Expand range for safety margin (2 extra rows on each end)
+    int startPitch = 127 - static_cast<int>(scrollY_ / keyHeight_);
+    int endPitch = 127 - static_cast<int>((scrollY_ + bounds.height) / keyHeight_);
     startPitch = std::clamp(startPitch + 2, 0, 127);
     endPitch = std::clamp(endPitch - 2, 0, 127);
-    
-    for (int p = startPitch; p >= endPitch; --p) {
-        // Calculate screen Y position
-        float worldY = (127 - p) * keyHeight_;
-        float y = b.y + worldY - scrollY_;
-        
-        NUIRect rowRect(b.x, y, b.width, keyHeight_);
-        
-        const int pitchClass = ((p % 12) + 12) % 12;
+
+    for (int pitch = startPitch; pitch >= endPitch; --pitch) {
+        const float y = bounds.y + (127 - pitch) * keyHeight_ - scrollY_;
+        const NUIRect row(bounds.x, y, bounds.width, keyHeight_);
+        const int pitchClass = ((pitch % 12) + 12) % 12;
         const bool isRoot = pitchClass == rootKey_;
-        const bool isInScale = scaleType_ == ScaleType::Chromatic || MusicTheory::isNoteInScale(p, rootKey_, scaleType_);
+        const bool isInScale =
+            scaleType_ == ScaleType::Chromatic || MusicTheory::isNoteInScale(pitch, rootKey_, scaleType_);
 
         if (isRoot) {
-            renderer.fillRect(rowRect, rowRoot);
-        } else if (isBlackKey(p)) {
-            renderer.fillRect(rowRect, rowAccidental);
+            renderer.fillRect(row, rootRow);
+        } else if (isBlackKey(pitch)) {
+            renderer.fillRect(row, accidentalRow);
         }
-        if (!isInScale) {
-            renderer.fillRect(rowRect, rowOutOfScale);
-        }
-
-        renderer.drawLine(NUIPoint(b.x, y), NUIPoint(b.right(), y), 1.0f, rowLine);
+        if (!isInScale) renderer.fillRect(row, outOfScaleRow);
+        renderer.drawLine(NUIPoint(bounds.x, y), NUIPoint(bounds.right(), y), 1.0f, rowLine);
     }
 
-    // Vertical Lines (Snap Grid)
-    double snapDur = MusicTheory::getSnapDuration(snap_);
-    if (snapDur <= 0.0001) snapDur = 1.0;
-    if (snap_ == SnapGrid::None) snapDur = 1.0; 
-    
-    // Dynamic Density: If too dense, double interval
-    while ((pixelsPerBeat_ * snapDur) < 12.0f) {
-        snapDur *= 2.0;
+    renderTimelineGrid(
+        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
+
+    if (hoveredPitch_ >= 0 && hoveredPitch_ <= 127) {
+        const float hoverY = bounds.y + (127 - hoveredPitch_) * keyHeight_ - scrollY_;
+        const NUIRect hoverRow(bounds.x, hoverY, bounds.width, keyHeight_);
+        const auto hoverColor = theme.getColor("accentPrimary").withAlpha(0.075f);
+        renderer.fillRect(hoverRow, hoverColor);
+        renderer.drawLine(NUIPoint(bounds.x, hoverRow.y),
+                          NUIPoint(bounds.right(), hoverRow.y),
+                          1.0f,
+                          theme.getColor("accentPrimary").withAlpha(0.28f));
+        renderer.drawLine(NUIPoint(bounds.x, hoverRow.bottom()),
+                          NUIPoint(bounds.right(), hoverRow.bottom()),
+                          1.0f,
+                          theme.getColor("accentPrimary").withAlpha(0.18f));
     }
 
-    double current = std::floor(visibleStartBeat / snapDur) * snapDur;
-    
-    for (; current <= visibleEndBeat + snapDur; current += snapDur) {
-        // Calculate X in double precision relative to scrollX_ BEFORE casting to float
-        float x = snapVerticalLineX(beatToScreenX(current, pixelsPerBeat_, scrollX_, b.x));
-        
-        const bool isBar = std::fmod(std::abs(current), static_cast<double>(beatsPerBar_)) < 0.001;
-        const bool isBeat = std::fmod(std::abs(current), 1.0) < 0.001;
-        const float lineWidth = isBar ? 1.5f : 1.0f;
-        const NUIColor col = isBar ? gridBar : (isBeat ? gridBeat : gridSubdivision);
-        renderer.drawLine(NUIPoint(x, b.y), NUIPoint(x, b.y + b.height), lineWidth, col);
+    const float patternEndX =
+        beatToScreenX(totalDurationBeats_, pixelsPerBeat_, scrollX_, bounds.x);
+    if (patternEndX < bounds.right()) {
+        const float shadeX = std::max(bounds.x, patternEndX);
+        renderer.fillRect(NUIRect(shadeX, bounds.y, bounds.right() - shadeX, bounds.height),
+                          NUIColor::black().withAlpha(0.58f));
+    }
+    if (patternEndX >= bounds.x && patternEndX <= bounds.right()) {
+        renderer.drawLine(NUIPoint(patternEndX, bounds.y),
+                          NUIPoint(patternEndX, bounds.bottom()),
+                          2.0f,
+                          theme.getColor("accentPrimary").withAlpha(0.58f));
     }
 
     renderer.clearClipRect();
 }
-
 void PianoRollGrid::setPixelsPerBeat(float ppb) { pixelsPerBeat_ = std::max(10.0f, ppb); repaint(); }
 void PianoRollGrid::setKeyHeight(float height) { keyHeight_ = std::max(8.0f, height); repaint(); }
 void PianoRollGrid::setScrollOffsetX(float offset) { scrollX_ = offset; repaint(); }
@@ -1109,11 +1117,12 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         NUIRect r(x + 1.0f, y + 2.0f, std::max(6.0f, w - 2.0f), std::max(5.0f, h - 4.0f));
 
         const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
+        const bool isHovered = static_cast<int>(noteIndex) == hoveredNoteIndex_;
         const NUIColor baseColor = n.selected ? noteColorSelected : noteColor;
         const NUIColor coreColor = baseColor.withAlpha(0.68f + normalizedVelocity * 0.28f);
-        const NUIColor edgeColor = n.selected
-                                       ? NUIColor::white().withAlpha(0.72f)
-                                       : baseColor.lightened(0.16f).withAlpha(0.74f);
+        const NUIColor edgeColor = n.selected ? NUIColor::white().withAlpha(0.78f)
+                                              : (isHovered ? NUIColor::white().withAlpha(0.38f)
+                                                           : baseColor.lightened(0.16f).withAlpha(0.74f));
 
         renderer.drawShadow(NUIRect(r.x, r.y + 1.0f, r.width, r.height),
                             0.0f,
@@ -1121,18 +1130,24 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
                             5.0f,
                             NUIColor(0, 0, 0, n.selected ? 0.22f : 0.14f));
         renderer.fillRoundedRect(r, 3.0f, coreColor);
-        renderer.strokeRoundedRect(r, 3.0f, n.selected ? 1.5f : 1.0f, edgeColor);
+        renderer.strokeRoundedRect(r, 3.0f, n.selected ? 1.5f : (isHovered ? 1.25f : 1.0f), edgeColor);
         renderer.fillRoundedRect(NUIRect(r.x + 1.0f, r.y + 2.0f, 2.5f, std::max(2.0f, r.height - 4.0f)),
                                  1.0f,
                                  NUIColor::white().withAlpha(n.selected ? 0.68f : 0.42f));
 
-        // Edge resize affordance on hover
-        if (static_cast<int>(noteIndex) == hoveredNoteIndex_ && (hoverOnRightEdge_ || hoverOnLeftEdge_)) {
+        if (isHovered && !hoverOnRightEdge_ && !hoverOnLeftEdge_) {
+            renderer.fillRoundedRect(NUIRect(r.x + 4.0f, r.y + 1.0f, std::max(2.0f, r.width - 8.0f), 1.0f),
+                                     0.5f,
+                                     NUIColor::white().withAlpha(0.24f));
+        }
+
+        // Selected notes retain subtle resize handles; hovered edges intensify them.
+        if (n.selected || (isHovered && (hoverOnRightEdge_ || hoverOnLeftEdge_))) {
             const NUIColor affordanceColor = NUIColor::white().withAlpha(0.72f);
-            if (hoverOnRightEdge_) {
+            if (n.selected || hoverOnRightEdge_) {
                 renderer.fillRoundedRect(NUIRect(r.right() - 3.0f, r.y + 3.0f, 2.0f, r.height - 6.0f), 1.0f, affordanceColor);
             }
-            if (hoverOnLeftEdge_) {
+            if (n.selected || hoverOnLeftEdge_) {
                 renderer.fillRoundedRect(NUIRect(r.x + 1.0f, r.y + 3.0f, 2.0f, r.height - 6.0f), 1.0f, affordanceColor);
             }
         }
@@ -1152,6 +1167,23 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
                 NUIColor labelColor = NUIColor::white().withAlpha(0.88f);
                 renderer.drawText(pitchLabel, NUIPoint(labelX, labelY), kFontSize, labelColor);
             }
+        }
+    }
+
+    // Draw-mode preview: a translucent phantom of the note a click would place,
+    // tracking the snapped cursor cell so placement reads before you commit it.
+    // Only while the pencil hovers empty space — never over an existing note.
+    if (tool_ == GlobalTool::Pencil && state_ == State::None && hoveredNoteIndex_ == -1 &&
+        hoveredPitch_ >= 0 && hoverBeat_ >= 0.0) {
+        const int previewPitch = snapPitchToScale(hoveredPitch_);
+        const float px = snapRectX(beatToScreenX(hoverBeat_, pixelsPerBeat_, scrollX_, b.x));
+        const float py = b.y + (127 - previewPitch) * keyHeight_ - scrollY_;
+        const float pw = std::max(6.0f, std::round(static_cast<float>(lastNoteDuration_ * pixelsPerBeat_)) - 2.0f);
+        const float ph = std::max(5.0f, keyHeight_ - 4.0f);
+        if (px + pw >= b.x && px <= b.right() && py + ph >= b.y && py <= b.bottom()) {
+            const NUIRect pr(px + 1.0f, py + 2.0f, pw, ph);
+            renderer.fillRoundedRect(pr, 3.0f, noteColor.withAlpha(0.20f));
+            renderer.strokeRoundedRect(pr, 3.0f, 1.0f, noteColor.lightened(0.16f).withAlpha(0.48f));
         }
     }
 
@@ -1196,16 +1228,40 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             hoverOnLeftEdge_ = false;
             if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
         }
+        if (hoveredPitch_ != -1) {
+            hoveredPitch_ = -1;
+            if (onHoveredPitchChanged_) onHoveredPitchChanged_(-1);
+        }
+        if (hoverBeat_ >= 0.0) {
+            hoverBeat_ = -1.0;
+            repaint();
+        }
         return false;
     }
 
     auto b = getBounds();
     float localX = event.position.x - b.x + scrollX_;
     float localY = event.position.y - b.y + scrollY_;
+    const int cursorPitch = std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127);
+    if (hoveredPitch_ != cursorPitch) {
+        hoveredPitch_ = cursorPitch;
+        if (onHoveredPitchChanged_) onHoveredPitchChanged_(cursorPitch);
+    }
 
     // --- HOVER / SMART CURSOR (no button activity) ---
     if (state_ == State::None && !event.pressed && !event.released) {
         int hitIdx = findNoteAt(localX, localY);
+        // Track the snapped beat the cursor sits on so the pencil can render a
+        // phantom of the note a click would place. Only meaningful over empty
+        // space with the pencil active; suppressed elsewhere so it never lingers.
+        const double snappedHoverBeat =
+            (tool_ == GlobalTool::Pencil && hitIdx == -1)
+                ? snapToGrid(std::max(0.0, static_cast<double>(localX) / pixelsPerBeat_))
+                : -1.0;
+        if (hoverBeat_ != snappedHoverBeat) {
+            hoverBeat_ = snappedHoverBeat;
+            repaint();
+        }
         if (hitIdx == -1) {
             if (hoveredNoteIndex_ != -1) {
                 hoveredNoteIndex_ = -1;
@@ -2209,16 +2265,8 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(contentRect);
 
     constexpr int beatsPerBar = 4;
-    const double visibleStartBeat = scrollX_ / pixelsPerBeat_;
-    const double visibleEndBeat = (scrollX_ + contentRect.width) / pixelsPerBeat_;
-    const int firstVisibleBar = static_cast<int>(std::floor(visibleStartBeat / beatsPerBar));
-    const int lastVisibleBar = static_cast<int>(std::ceil(visibleEndBeat / beatsPerBar));
-    const auto zebraColor = themeManager.getColor("surfaceRaised").withAlpha(0.035f);
-    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
-        if ((bar & 1) == 0) continue;
-        const float x = contentRect.x + static_cast<float>(bar * beatsPerBar) * pixelsPerBeat_ - scrollX_;
-        renderer.fillRect(NUIRect(x, contentRect.y, pixelsPerBeat_ * beatsPerBar, contentRect.height), zebraColor);
-    }
+    const float startX = contentRect.x;
+    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar);
 
     const float availH = std::max(1.0f, b.height - 28.0f);
     const float bottomY = b.bottom() - 8.0f;
@@ -2231,39 +2279,25 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
                       guideColor.withAlpha(0.72f));
     renderer.drawLine(NUIPoint(contentRect.x, bottomY), NUIPoint(contentRect.right(), bottomY), 1.0f, guideColor);
 
-    // 1. Draw Grid Background (Sync with PianoRollGrid)
-    auto snap = layer->getSnap();
-    double snapDur = MusicTheory::getSnapDuration(snap);
-    if (snapDur <= 0.0001) snapDur = 1.0;
-    if (snap == SnapGrid::None) snapDur = 1.0; 
-
-    // Dynamic Density
-    while ((pixelsPerBeat_ * snapDur) < 12.0f) {
-        snapDur *= 2.0;
+    const float patternEndX = startX + static_cast<float>(layer->getTotalDurationBeats() * pixelsPerBeat_) - scrollX_;
+    if (patternEndX < contentRect.right()) {
+        const float shadeX = std::max(contentRect.x, patternEndX);
+        renderer.fillRect(NUIRect(shadeX, contentRect.y, contentRect.right() - shadeX, contentRect.height),
+                          NUIColor::black().withAlpha(0.58f));
     }
-
-    float startX = b.x + sidebarW;
-    // Align to snap
-    double current = std::floor(visibleStartBeat / snapDur) * snapDur;
-
-    auto gridCol = themeManager.getColor("border").withAlpha(0.07f);
-    auto barCol = themeManager.getColor("border").withAlpha(0.14f);
-    for (; current <= visibleEndBeat + snapDur; current += snapDur) {
-        // Double precision relative subtraction
-        double relX = (current * pixelsPerBeat_) - static_cast<double>(scrollX_);
-        float x = startX + static_cast<float>(relX);
-        
-        bool isBar = (std::fmod(std::abs(current), (double)beatsPerBar) < 0.001);
-        
-        // Draw line
-        renderer.drawLine(NUIPoint(x, b.y), NUIPoint(x, b.y + b.height), 1.0f, isBar ? barCol : gridCol);
+    if (patternEndX >= contentRect.x && patternEndX <= contentRect.right()) {
+        renderer.drawLine(NUIPoint(patternEndX, contentRect.y),
+                          NUIPoint(patternEndX, contentRect.bottom()),
+                          2.0f,
+                          themeManager.getColor("accentPrimary").withAlpha(0.58f));
     }
     
     // 2. Render velocity stems using MidiNote's normalized 0..1 representation.
     const auto& notes = layer->getNotes();
     auto velColorBase = themeManager.getColor("accentPrimary").lightened(0.05f);
 
-    for (const auto& n : notes) {
+    for (size_t noteIndex = 0; noteIndex < notes.size(); ++noteIndex) {
+        const auto& n = notes[noteIndex];
         if (n.isDeleted && n.animationScale < 0.01f) continue;
         
         float x = startX + static_cast<float>(n.startBeat * pixelsPerBeat_) - scrollX_;
@@ -2293,6 +2327,21 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
         if (w > 4.0f) {
             renderer.drawLine(NUIPoint(x, y), NUIPoint(x + w, y), n.selected ? 2.0f : 1.0f, col.withAlpha(0.64f));
         }
+
+        if (isDragging_ && static_cast<int>(noteIndex) == hoveringNoteIndex_) {
+            const std::string value = std::to_string(static_cast<int>(std::lround(normalizedVelocity * 127.0f)));
+            const float fontSize = 9.0f;
+            const auto textSize = renderer.measureText(value, fontSize);
+            const float bubbleWidth = textSize.width + 10.0f;
+            const float bubbleY = y - 18.0f >= contentRect.y ? y - 18.0f : y + 8.0f;
+            const NUIRect bubble(x + 7.0f, bubbleY, bubbleWidth, 16.0f);
+            renderer.fillRoundedRect(bubble, 4.0f, NUIColor::black().withAlpha(0.92f));
+            renderer.strokeRoundedRect(bubble, 4.0f, 1.0f, col.withAlpha(0.82f));
+            renderer.drawText(value,
+                              NUIPoint(bubble.x + 5.0f, bubble.y + (bubble.height - textSize.height) * 0.5f),
+                              fontSize,
+                              NUIColor::white().withAlpha(0.92f));
+        }
     }
     
     renderer.clearClipRect();
@@ -2320,6 +2369,14 @@ PianoRollView::PianoRollView()
     m_grid = std::make_shared<PianoRollGrid>();
     m_notes = std::make_shared<PianoRollNoteLayer>();
     m_controls = std::make_shared<PianoRollControlPanel>();
+
+    m_notes->setOnHoveredPitchChanged([this](int pitch) {
+        if (m_grid) m_grid->setHoveredPitch(pitch);
+        if (m_keys) m_keys->setHoveredKey(pitch);
+    });
+    m_keys->setOnHoveredKeyChanged([this](int pitch) {
+        if (m_grid) m_grid->setHoveredPitch(pitch);
+    });
     
     // Toolbar
     m_toolbar = std::make_shared<PianoRollToolbar>();
@@ -2454,30 +2511,36 @@ void PianoRollView::onRender(NUIRenderer& renderer) {
             playheadX >= gridBounds.x && playheadX <= gridBounds.right()) {
             const float playheadStartY = rulerBounds.bottom();
             const float playheadEndY = m_controls ? m_controls->getBounds().bottom() : gridBounds.bottom();
-            renderer.drawLine(NUIPoint(playheadX, playheadStartY),
-                              NUIPoint(playheadX, playheadEndY),
-                              5.0f,
-                              accent.withAlpha(0.10f));
-            renderer.drawLine(NUIPoint(playheadX, playheadStartY),
-                              NUIPoint(playheadX, playheadEndY),
-                              2.0f,
-                              accent.withAlpha(0.92f));
-
-            const float triangleH = 8.0f;
-            const float triangleW = 5.0f;
-            for (float dx = 0.0f; dx <= triangleW; dx += 1.0f) {
-                renderer.drawLine(NUIPoint(playheadX + dx, playheadStartY),
-                                  NUIPoint(playheadX + dx,
-                                           playheadStartY + triangleH - dx * (triangleH / triangleW)),
-                                  1.0f,
-                                  accent);
-                renderer.drawLine(NUIPoint(playheadX - dx, playheadStartY),
-                                  NUIPoint(playheadX - dx,
-                                           playheadStartY + triangleH - dx * (triangleH / triangleW)),
-                                  1.0f,
-                                  accent);
+            if (m_isPlayingCallback && m_isPlayingCallback()) {
+                const float glowWidth = 4.0f;
+                const float lineHeight = playheadEndY - playheadStartY;
+                renderer.fillRectGradient(NUIRect(playheadX - glowWidth, playheadStartY, glowWidth, lineHeight),
+                                          accent.withAlpha(0.0f),
+                                          accent.withAlpha(0.14f),
+                                          false);
+                renderer.fillRectGradient(NUIRect(playheadX, playheadStartY, glowWidth, lineHeight),
+                                          accent.withAlpha(0.14f),
+                                          accent.withAlpha(0.0f),
+                                          false);
             }
+            renderer.drawLine(NUIPoint(playheadX, playheadStartY),
+                              NUIPoint(playheadX, playheadEndY),
+                              1.0f,
+                              accent.withAlpha(0.55f));
         }
+    }
+
+    if (m_controls) {
+        const auto controlBounds = m_controls->getBounds();
+        const float gripWidth = 34.0f;
+        const NUIRect splitterGrip(controlBounds.x + (controlBounds.width - gripWidth) * 0.5f,
+                                   controlBounds.y - 2.0f,
+                                   gripWidth,
+                                   4.0f);
+        renderer.fillRoundedRect(splitterGrip,
+                                 2.0f,
+                                 theme.getColor("accentPrimary").withAlpha(
+                                     m_isResizingPanel ? 0.92f : (m_splitterHovered ? 0.52f : 0.22f)));
     }
 
     if (m_toolbar) {
@@ -2614,12 +2677,14 @@ void PianoRollView::syncChildren() {
     m_grid->setScrollOffsetX(x);
     m_grid->setScrollOffsetY(y);
     m_grid->setPlayheadBeat(m_playheadBeat);
+    m_grid->setTotalDurationBeats(m_totalDurationBeats);
     
     m_notes->setPixelsPerBeat(m_pixelsPerBeat);
     m_notes->setKeyHeight(m_keyHeight);
     m_notes->setScrollOffsetX(m_scrollX);
     m_notes->setScrollOffsetY(m_scrollY);
     m_notes->setPlayheadBeat(m_playheadBeat);
+    m_notes->setTotalDurationBeats(m_totalDurationBeats);
     
     if (m_controls) {
         m_controls->setPixelsPerBeat(m_pixelsPerBeat);
@@ -2653,7 +2718,12 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
 
     auto b = getBounds();
     float splitterY = b.y + b.height - m_controlPanelHeight;
-    float splitterZone = 5.0f;
+    float splitterZone = 7.0f;
+    const bool splitterHovered = std::abs(event.position.y - splitterY) < splitterZone;
+    if (m_splitterHovered != splitterHovered) {
+        m_splitterHovered = splitterHovered;
+        repaint();
+    }
     
     if (event.pressed && event.button == NUIMouseButton::Left) {
         if (std::abs(event.position.y - splitterY) < splitterZone) {
@@ -2663,7 +2733,7 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
     }
-    else if (m_isResizingPanel && event.pressed) {
+    else if (m_isResizingPanel && !event.released) {
         float dy = event.position.y - m_dragStartPos.y;
         // Dragging UP increases height
         float newH = m_dragStartPanelHeight - dy;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1248,6 +1248,30 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
                           NUIColor::white().withAlpha(0.95f));
     }
 
+    // Velocity value bubble after an Alt+wheel nudge, while the cursor stays on
+    // the note it edited (guarded so a -1/-1 match can't show a phantom bubble).
+    if (velocityBubbleIndex_ >= 0 && velocityBubbleIndex_ == hoveredNoteIndex_ &&
+        velocityBubbleIndex_ < static_cast<int>(notes_.size()) && !notes_[velocityBubbleIndex_].isDeleted) {
+        const auto& vn = notes_[velocityBubbleIndex_];
+        const float vx = snapRectX(beatToScreenX(vn.startBeat, pixelsPerBeat_, scrollX_, b.x));
+        const float vy = b.y + (127 - vn.pitch) * keyHeight_ - scrollY_;
+        const std::string label = "V " + std::to_string(static_cast<int>(std::lround(vn.velocity * 127.0f)));
+        constexpr float kFontSize = 10.0f;
+        const auto measured = renderer.measureText(label, kFontSize);
+        const float bubbleW = measured.width + 12.0f;
+        const float bubbleH = 17.0f;
+        float bubbleY = vy - bubbleH - 3.0f;
+        if (bubbleY < b.y) bubbleY = vy + keyHeight_ + 3.0f;
+        const float bubbleX = std::clamp(vx, b.x + 2.0f, b.right() - bubbleW - 2.0f);
+        const NUIRect bubble(bubbleX, bubbleY, bubbleW, bubbleH);
+        renderer.fillRoundedRect(bubble, 4.0f, NUIColor::black().withAlpha(0.92f));
+        renderer.strokeRoundedRect(bubble, 4.0f, 1.0f, themeManager.getColor("accentPrimary").withAlpha(0.80f));
+        renderer.drawText(label,
+                          NUIPoint(bubble.x + 6.0f, bubble.y + (bubble.height - measured.height) * 0.5f),
+                          kFontSize,
+                          NUIColor::white().withAlpha(0.95f));
+    }
+
     // Rubber-band selection rectangle (already normalized during drag)
     if (state_ == State::SelectingBox && selectionRect_.width > 0 && selectionRect_.height > 0) {
         renderer.fillRoundedRect(selectionRect_, 2.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.15f));
@@ -1355,6 +1379,34 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
                     platformBridge_->setCursorStyle(NUICursorStyle::Grab);
             }
         }
+    }
+
+    // --- ALT + WHEEL OVER A NOTE = VELOCITY ---
+    // Plain / Shift / Ctrl wheel stay bound to scroll+zoom; Alt shapes the
+    // velocity of the note under the cursor (and the whole selection if that
+    // note is part of it), so dynamics can be dialled in without leaving the grid.
+    if (event.wheelDelta != 0.0f && (event.modifiers & NUIModifiers::Alt) && hoveredNoteIndex_ >= 0 &&
+        hoveredNoteIndex_ < static_cast<int>(notes_.size()) && !notes_[hoveredNoteIndex_].isDeleted) {
+        auto oldNotes = notes_;
+        const float delta = event.wheelDelta * 0.04f; // ~5 MIDI steps per notch
+        const bool editSelection = notes_[hoveredNoteIndex_].selected;
+        for (auto& n : notes_) {
+            if (n.isDeleted) continue;
+            if (editSelection ? n.selected : (&n == &notes_[hoveredNoteIndex_])) {
+                n.velocity = std::clamp(n.velocity + delta, 0.0f, 1.0f);
+            }
+        }
+        lastNoteVelocity_ = notes_[hoveredNoteIndex_].velocity; // adopt for new notes
+        velocityBubbleIndex_ = hoveredNoteIndex_;
+        // Coalesce a continuous scrub into one undo step instead of one per notch.
+        if (!undoStack_.empty() && undoStack_.back().description == "Velocity") {
+            undoStack_.back().notesAfter = notes_;
+        } else {
+            pushUndo("Velocity", oldNotes, notes_);
+        }
+        commitNotes();
+        repaint();
+        return true;
     }
 
     // --- RIGHT CLICK / ERASER (FAST ERASE) ---

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -11,6 +11,7 @@
 #include "NUIRenderer.h"
 #include "NUIThemeSystem.h"
 #include <algorithm>
+#include <chrono>  // Manual double-click timing
 #include <cmath>
 #include <iomanip> // For string formatting
 #include <random>  // Humanize velocity jitter
@@ -1927,13 +1928,12 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    // --- WHEEL OVER A NOTE = VELOCITY ---
-    // Scrolling over a note shapes its velocity (and the whole selection if
-    // that note is part of it) — no modifier needed, though Alt still works.
-    // Ctrl (zoom) and Shift (h-scroll) keep their bindings, and over empty
-    // space the wheel scrolls the grid as usual.
-    if (event.wheelDelta != 0.0f && !(event.modifiers & NUIModifiers::Ctrl) &&
-        !(event.modifiers & NUIModifiers::Shift) && hoveredNoteIndex_ >= 0 &&
+    // --- ALT + WHEEL OVER A NOTE = VELOCITY ---
+    // Alt shapes the velocity of the note under the cursor (and the whole
+    // selection if that note is part of it). Kept behind a modifier so plain
+    // wheel always scrolls — mixing "scroll the grid" and "edit the note" on
+    // the same gesture made scrolling feel unpredictable.
+    if (event.wheelDelta != 0.0f && (event.modifiers & NUIModifiers::Alt) && hoveredNoteIndex_ >= 0 &&
         hoveredNoteIndex_ < static_cast<int>(notes_.size()) && !notes_[hoveredNoteIndex_].isDeleted) {
         auto oldNotes = notes_;
         const float delta = event.wheelDelta * 0.04f; // ~5 MIDI steps per notch
@@ -1990,10 +1990,24 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     if (event.pressed && event.button == NUIMouseButton::Left) {
         setFocused(true); // Gain keyboard focus for shortcuts
         int clickedIndex = findNoteAt(localX, localY);
-        
+
+        // The platform never sets event.doubleClick, so detect it here: a
+        // second left press within 400ms landing within a few pixels.
+        const long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now().time_since_epoch())
+                                    .count();
+        const bool isDoubleClick =
+            event.doubleClick ||
+            ((nowMs - lastClickTimeMs_) < 400 &&
+             std::abs(event.position.x - lastClickPos_.x) < 5.0f &&
+             std::abs(event.position.y - lastClickPos_.y) < 5.0f);
+        // Consume the pair so a triple-click can't read as two doubles.
+        lastClickTimeMs_ = isDoubleClick ? 0 : nowMs;
+        lastClickPos_ = event.position;
+
         // DOUBLE CLICK: note → precision properties popup; empty space → add.
         // (Deletion stays on right-click / eraser / Delete.)
-        if (event.doubleClick) {
+        if (isDoubleClick) {
             if (clickedIndex != -1) {
                  openNoteProperties(clickedIndex);
             } else {
@@ -3420,7 +3434,7 @@ void PianoRollView::renderShortcutHelp(NUIRenderer& renderer) {
         {"Ctrl+Drag", "marquee select (any tool)"},
         {"Alt+Drag", "clone the selection"},
         {"Alt mid-drag", "bypass snap for fine moves"},
-        {"Wheel on note", "adjust velocity"},
+        {"Alt+Wheel", "adjust velocity under cursor"},
         {"Right-Click", "erase"},
         {"Double-Click", "add note / note properties"},
         {"Lane sidebar", "switch velocity / pan lane"},

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1069,22 +1069,28 @@ int PianoRollNoteLayer::snapPitchToScale(int pitch) {
 }
 
 void PianoRollNoteLayer::auditionPitch(int pitch) {
-    // Never talk over the transport — playback owns the audio focus.
+    // Never talk over the transport — playback owns the audio focus. Clear the
+    // sounding pitch while suppressed so the very next idle placement re-fires
+    // (otherwise the same-pitch guard below would swallow it after playback stops).
     if (isPlayingCallback_ && isPlayingCallback_()) {
-        auditionStop();
+        auditionPitch_ = -1;
         return;
     }
     pitch = std::clamp(pitch, 0, 127);
+    // The audition path is a one-shot voice that auto-releases (~125 ms), so a
+    // fresh press must always fire. auditionStop() resets the guard on release;
+    // the guard's only job is to avoid machine-gunning one pitch while a drag
+    // jitters within the same row.
     if (pitch == auditionPitch_) return;
-    if (!onPreviewNote_) { auditionPitch_ = pitch; return; }
-    if (auditionPitch_ != -1) onPreviewNote_(auditionPitch_, 0); // release previous
-    onPreviewNote_(pitch, static_cast<int>(std::lround(lastNoteVelocity_ * 127.0f)));
+    if (onPreviewNote_) {
+        onPreviewNote_(pitch, static_cast<int>(std::lround(lastNoteVelocity_ * 127.0f)));
+    }
     auditionPitch_ = pitch;
 }
 
 void PianoRollNoteLayer::auditionStop() {
-    if (auditionPitch_ == -1) return;
-    if (onPreviewNote_) onPreviewNote_(auditionPitch_, 0);
+    // The one-shot voice releases itself; just clear the guard so the next
+    // placement or pitch-drag can audition again, even on the same pitch.
     auditionPitch_ = -1;
 }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -87,18 +87,17 @@ void PianoRollKeyLane::onRender(NUIRenderer& renderer) {
     if (!isVisible()) return;
     auto b = getBounds();
     auto& themeManager = NUIThemeManager::getInstance();
-    
+
     renderer.setClipRect(b);
-    
-    const auto laneBg = themeManager.getColor("backgroundSecondary");
-    const auto whiteKey = themeManager.getColor("surfaceRaised").withAlpha(0.50f);
-    const auto blackKey = themeManager.getColor("backgroundPrimary").darkened(0.04f);
-    const auto whiteBorder = themeManager.getColor("border").withAlpha(0.2f);
-    const auto blackBorder = themeManager.getColor("border").withAlpha(0.4f);
-    const auto keySeparator = themeManager.getColor("border").withAlpha(0.1f);
-    const auto rootAccent = themeManager.getColor("accentPrimary").withAlpha(0.45f);
-    const auto whiteText = themeManager.getColor("textSecondary");
-    const auto blackText = themeManager.getColor("textSecondary").withAlpha(0.7f);
+
+    const auto laneBg = themeManager.getColor("backgroundSecondary").darkened(0.02f);
+    const auto naturalKey = themeManager.getColor("surfaceRaised").withAlpha(0.72f);
+    const auto naturalHover = themeManager.getColor("surfaceRaised").lightened(0.08f).withAlpha(0.92f);
+    const auto accidentalKey = themeManager.getColor("backgroundPrimary").darkened(0.08f);
+    const auto accidentalHover = themeManager.getColor("accentPrimary").darkened(0.35f).withAlpha(0.92f);
+    const auto separator = themeManager.getColor("border").withAlpha(0.34f);
+    const auto rootAccent = themeManager.getColor("accentPrimary").withAlpha(0.86f);
+    const auto naturalText = themeManager.getColor("textPrimary").withAlpha(0.72f);
     
     int startPitch = 127 - static_cast<int>((scrollY_) / keyHeight_);
     int endPitch = 127 - static_cast<int>((scrollY_ + b.height) / keyHeight_);
@@ -112,47 +111,73 @@ void PianoRollKeyLane::onRender(NUIRenderer& renderer) {
     for (int p = startPitch; p >= endPitch; --p) {
         float worldY = (127 - p) * keyHeight_;
         float y = b.y + worldY - scrollY_;
-        NUIRect keyRect(b.x, y, b.width, keyHeight_);
+        const bool accidental = isBlackKey(p);
+        const bool hovered = p == hoveredKey_ || p == previewPitch_;
+        const float rightPad = 3.0f;
+        const float accidentalW = std::round(b.width * 0.68f);
+        NUIRect keyRect(b.x + 3.0f,
+                        y + 1.0f,
+                        accidental ? accidentalW : b.width - 3.0f - rightPad,
+                        std::max(4.0f, keyHeight_ - 2.0f));
 
-        bool isBlack = isBlackKey(p);
+        renderer.fillRoundedRect(keyRect,
+                                 accidental ? 2.0f : 3.0f,
+                                 hovered ? (accidental ? accidentalHover : naturalHover)
+                                         : (accidental ? accidentalKey : naturalKey));
+        renderer.strokeRoundedRect(keyRect, accidental ? 2.0f : 3.0f, 1.0f, separator);
 
-        if (isBlack) {
-            renderer.fillRect(keyRect, blackKey);
-            renderer.strokeRect(keyRect, 1.0f, blackBorder);
-        } else {
-            renderer.fillRect(keyRect, whiteKey);
-            renderer.strokeRect(keyRect, 1.0f, whiteBorder);
+        if (!accidental) {
+            renderer.drawLine(NUIPoint(keyRect.x, keyRect.bottom()),
+                              NUIPoint(keyRect.right(), keyRect.bottom()),
+                              1.0f,
+                              separator.withAlpha(0.52f));
         }
 
-        renderer.drawLine(NUIPoint(b.x, y + keyHeight_), NUIPoint(b.x + b.width, y + keyHeight_), 1.0f, keySeparator);
-
-        if (keyHeight_ >= 14.0f) {
-            std::string lbl = getNoteLabel(p);
-            float fontSize = (keyHeight_ >= 20.0f) ? 10.0f : 8.0f;
-            auto dim = renderer.measureText(lbl, fontSize);
-            float txtY = y + (keyHeight_ - dim.height) * 0.5f;
-            float txtX = isBlack ? (b.x + 6.0f) : (b.x + 8.0f);
-            renderer.drawText(lbl, NUIPoint(txtX, txtY), fontSize, isBlack ? blackText : whiteText);
+        if (keyHeight_ >= 15.0f && p % 12 == 0) {
+            const std::string label = getNoteLabel(p);
+            const float fontSize = 10.0f;
+            const auto textSize = renderer.measureText(label, fontSize);
+            const float textX = keyRect.right() - textSize.width - 8.0f;
+            const float textY = keyRect.y + (keyRect.height - textSize.height) * 0.5f;
+            renderer.drawText(label,
+                              NUIPoint(textX, textY),
+                              fontSize,
+                              naturalText.lightened(0.12f));
         }
 
-        // Accent bar for C notes (root keys)
         if (p % 12 == 0) {
-            renderer.fillRoundedRect(NUIRect(b.x + b.width - 4.0f, y + 4.0f, 2.0f, keyHeight_ - 8.0f), 1.0f, rootAccent);
+            renderer.fillRoundedRect(NUIRect(b.x + 3.0f, y + 4.0f, 2.0f, std::max(2.0f, keyHeight_ - 8.0f)),
+                                     1.0f,
+                                     rootAccent);
         }
     }
-    
-    renderer.drawLine(NUIPoint(b.x + b.width, b.y), NUIPoint(b.x + b.width, b.y + b.height), 1.0f, whiteBorder.withAlpha(0.7f));
-    
+
+    renderer.drawLine(NUIPoint(b.right() - 0.5f, b.y),
+                      NUIPoint(b.right() - 0.5f, b.bottom()),
+                      1.0f,
+                      separator.withAlpha(0.9f));
+
     renderer.clearClipRect();
 }
 
 bool PianoRollKeyLane::onMouseEvent(const NUIMouseEvent& event) {
-    if (!getBounds().contains(event.position)) return false;
+    if (!getBounds().contains(event.position)) {
+        if (hoveredKey_ != -1) {
+            hoveredKey_ = -1;
+            repaint();
+        }
+        return false;
+    }
 
     auto b = getBounds();
     float localY = event.position.y - b.y + scrollY_;
     int pitch = 127 - static_cast<int>(localY / keyHeight_);
     pitch = std::clamp(pitch, 0, 127);
+
+    if (hoveredKey_ != pitch) {
+        hoveredKey_ = pitch;
+        repaint();
+    }
 
     if (m_isPlayingCallback && m_isPlayingCallback()) {
         return NUIComponent::onMouseEvent(event);
@@ -257,18 +282,18 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
     auto b = getBounds();
     auto& theme = NUIThemeManager::getInstance();
     
-    const auto panelBg = theme.getColor("backgroundSecondary").withAlpha(0.95f);
-    const auto border = theme.getColor("border").withAlpha(0.28f);
-    renderer.fillRoundedRect(b, 7.0f, panelBg);
-    renderer.strokeRoundedRect(b, 7.0f, 1.0f, border);
+    const auto panelBg = theme.getColor("backgroundPrimary").darkened(0.03f);
+    const auto border = theme.getColor("border").withAlpha(0.48f);
+    renderer.fillRoundedRect(NUIRect(b.x + 4.0f, b.y + 3.0f, b.width - 8.0f, b.height - 6.0f), 5.0f, panelBg);
+    renderer.strokeRoundedRect(NUIRect(b.x + 4.0f, b.y + 3.0f, b.width - 8.0f, b.height - 6.0f), 5.0f, 1.0f, border);
     
     // View Rect
     float x1 = b.x + beatToX(startBeat_);
     float w = beatToX(viewDuration_);
     NUIRect viewRect(x1, b.y + 2, w, b.height - 4);
     
-    auto thumbCol = theme.getColor("accentPrimary").withAlpha(0.06f);
-    auto borderCol = theme.getColor("accentPrimary").withAlpha(0.42f);
+    auto thumbCol = theme.getColor("accentPrimary").withAlpha(0.13f);
+    auto borderCol = theme.getColor("accentPrimary").withAlpha(0.72f);
     
     renderer.fillRoundedRect(viewRect, 5.0f, thumbCol);
     renderer.strokeRoundedRect(viewRect, 5.0f, 1.0f, borderCol);
@@ -426,15 +451,40 @@ PianoRollRuler::PianoRollRuler()
 }
 
 bool PianoRollRuler::onMouseEvent(const NUIMouseEvent& event) {
-    if (!getBounds().contains(event.position)) return false;
+    const auto bounds = getBounds();
+    if (!bounds.contains(event.position) && !isScrubbing_) return false;
 
     // Zoom on Wheel
     if (event.wheelDelta != 0.0f) {
         if (onZoomRequested) {
-            float localX = event.position.x - getBounds().x;
+            float localX = event.position.x - bounds.x;
             onZoomRequested(event.wheelDelta, localX);
             return true;
         }
+    }
+
+    auto scrubToPointer = [&]() {
+        const double localX = static_cast<double>(event.position.x - bounds.x + scrollX_);
+        const double beat = std::max(0.0, localX / static_cast<double>(pixelsPerBeat_));
+        playheadBeat_ = beat;
+        if (onPlayheadScrubbed) onPlayheadScrubbed(beat, true);
+        repaint();
+    };
+
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        isScrubbing_ = true;
+        scrubToPointer();
+        return true;
+    }
+    if (isScrubbing_) {
+        if (event.released && event.button == NUIMouseButton::Left) {
+            scrubToPointer();
+            isScrubbing_ = false;
+            if (onPlayheadScrubbed) onPlayheadScrubbed(playheadBeat_, false);
+            return true;
+        }
+        scrubToPointer();
+        return true;
     }
     return NUIComponent::onMouseEvent(event);
 }
@@ -448,10 +498,10 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
     // CLIP: Prevent left bleeding
     renderer.setClipRect(b);
     
-    auto bg = themeManager.getColor("backgroundSecondary");
-    auto textCol = themeManager.getColor("textPrimary").withAlpha(0.78f);
-    auto tickCol = themeManager.getColor("textSecondary").withAlpha(0.42f);
-    auto borderCol = themeManager.getColor("border").withAlpha(0.50f);
+    auto bg = themeManager.getColor("backgroundSecondary").darkened(0.025f);
+    auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
+    auto tickCol = themeManager.getColor("textSecondary").withAlpha(0.52f);
+    auto borderCol = themeManager.getColor("border").withAlpha(0.66f);
     
     renderer.fillRect(b, bg);
     
@@ -480,14 +530,31 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
             // Playlist usually has numbers at the start of the bar.
             
             // Major Tick (Bottom up)
-            renderer.drawLine(NUIPoint(x, b.y + b.height * 0.5f), NUIPoint(x, b.y + b.height), 1.0f, tickCol);
+            renderer.fillRect(NUIRect(x, b.y, 1.0f, b.height), borderCol.withAlpha(0.48f));
+            renderer.drawLine(NUIPoint(x, b.y + b.height * 0.45f), NUIPoint(x, b.y + b.height), 1.0f, tickCol);
             
             // Label
-            renderer.drawText(std::to_string(barNum), NUIPoint(x + 4, b.y + 4), 11.5f, textCol);
+            renderer.drawText(std::to_string(barNum), NUIPoint(x + 6, b.y + 5), 11.0f, textCol);
         } else {
             // Beat: Short Tick
             renderer.drawLine(NUIPoint(x, b.y + b.height * 0.75f), NUIPoint(x, b.y + b.height), 1.0f, tickCol.withAlpha(0.6f));
         }
+    }
+
+    const float playheadX = snapVerticalLineX(
+        beatToScreenX(playheadBeat_, pixelsPerBeat_, scrollX_, b.x));
+    if (playheadX >= b.x && playheadX <= b.right()) {
+        const auto accent = themeManager.getColor("accentPrimary");
+        const NUIRect handle(playheadX - 5.0f, b.y + 3.0f, 10.0f, 16.0f);
+        renderer.fillRoundedRect(handle, 4.0f, accent.withAlpha(isScrubbing_ ? 1.0f : 0.90f));
+        renderer.strokeRoundedRect(handle, 4.0f, 1.0f, NUIColor::white().withAlpha(0.46f));
+        renderer.fillRoundedRect(NUIRect(playheadX - 1.0f, handle.y + 4.0f, 2.0f, 8.0f),
+                                 1.0f,
+                                 NUIColor::white().withAlpha(0.72f));
+        renderer.drawLine(NUIPoint(playheadX, handle.bottom()),
+                          NUIPoint(playheadX, b.bottom()),
+                          2.0f,
+                          accent.withAlpha(0.92f));
     }
 
     renderer.clearClipRect();
@@ -633,7 +700,7 @@ void PianoRollToolbar::setupUI() {
     });
     
     // Icons
-    const char* ptrSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 2l12 11.2-5.8.5 3.3 7.3-2.2.9-3.2-7.4-4.4 4V2z"/></svg>)";
+    const char* ptrSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M5.4 2.5v15.9l4.2-3.9 3.1 6.7 2.6-1.2-3.1-6.5 5.7-.6L5.4 2.5zm2.1 4.4 5.6 4.6-3.9.4 3 6.4-.7.3-3-6.5-1 1V6.9z"/></svg>)";
     m_ptrIcon = std::make_shared<NUIIcon>(ptrSvg);
     
     const char* penSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>)";
@@ -685,51 +752,59 @@ void PianoRollToolbar::setPatternChoices(const std::vector<PatternChoice>& choic
 void PianoRollToolbar::onRender(NUIRenderer& renderer) {
     auto b = getBounds();
     auto& themeManager = NUIThemeManager::getInstance();
-    
-    renderer.fillRect(b, themeManager.getColor("backgroundSecondary"));
-    renderer.drawLine(NUIPoint(b.x, b.y + b.height), NUIPoint(b.x + b.width, b.y + b.height), 1.0f, themeManager.getColor("border").withAlpha(0.35f));
+
+    const auto toolbarBg = themeManager.getColor("backgroundSecondary").darkened(0.015f);
+    const auto groupBg = themeManager.getColor("backgroundPrimary").withAlpha(0.72f);
+    const auto groupBorder = themeManager.getColor("border").withAlpha(0.52f);
+    renderer.fillRect(b, toolbarBg);
+    renderer.drawLine(NUIPoint(b.x, b.bottom() - 0.5f),
+                      NUIPoint(b.right(), b.bottom() - 0.5f),
+                      1.0f,
+                      groupBorder);
 
     // Let child buttons keep input/hit-testing, but draw our custom toolbar chrome and glyphs after them.
     renderChildren(renderer);
 
-    // Common layout constants
-    const float buttonSize = 26.0f;
-    const float buttonSpacing = 6.0f;
-    const float innerPad = 8.0f;
-    const float radius = 8.0f;
-    
+    const float buttonSize = 30.0f;
+    const float buttonSpacing = 4.0f;
+    const float innerPad = 10.0f;
+    const float radius = 6.0f;
+
     float currentX = b.x + innerPad;
     float currentY = b.y + (b.height - buttonSize) * 0.5f;
 
-    auto idleBg = themeManager.getColor("buttonBgDefault").withAlpha(0.94f);
+    auto idleBg = themeManager.getColor("surfaceSecondary").withAlpha(0.76f);
     auto hoverBg = themeManager.getColor("buttonBgHover").withAlpha(0.98f);
-    auto activeBg = themeManager.getColor("buttonBgActive");
-    auto borderCol = themeManager.getColor("border").withAlpha(0.24f);
-    auto iconIdle = themeManager.getColor("textPrimary").withAlpha(0.86f);
+    auto activeBg = themeManager.getColor("accentPrimary").withAlpha(0.84f);
+    auto borderCol = themeManager.getColor("border").withAlpha(0.42f);
+    auto iconIdle = themeManager.getColor("textPrimary").withAlpha(0.78f);
     auto iconActive = themeManager.getColor("textPrimary");
 
-    // Helper to render standardized buttons
+    auto drawGroup = [&](float x, float width) {
+        NUIRect groupRect(x, currentY - 3.0f, width, buttonSize + 6.0f);
+        renderer.fillRoundedRect(groupRect, 8.0f, groupBg);
+        renderer.strokeRoundedRect(groupRect, 8.0f, 1.0f, groupBorder);
+    };
+
     auto renderButton = [&](std::shared_ptr<NUIButton> btn, std::shared_ptr<NUIIcon> icon, bool isActive) {
         btn->setBounds(NUIRect(currentX, currentY, buttonSize, buttonSize));
-        btn->setText(""); // No text, just icon
-        
+        btn->setText("");
+
         AestraUI::NUIColor bg = idleBg;
         AestraUI::NUIColor border = borderCol;
-        
+
         if (isActive) {
             bg = activeBg;
-            border = themeManager.getColor("accentPrimary").withAlpha(0.34f);
+            border = themeManager.getColor("accentPrimary").lightened(0.18f).withAlpha(0.88f);
         } else if (btn->isHovered()) {
             bg = hoverBg;
         }
 
-        if (isActive || btn->isHovered()) {
-            renderer.fillRoundedRect(btn->getBounds(), radius, bg);
-            renderer.strokeRoundedRect(btn->getBounds(), radius, 1.0f, border);
-        }
+        renderer.fillRoundedRect(btn->getBounds(), radius, bg);
+        renderer.strokeRoundedRect(btn->getBounds(), radius, 1.0f, border);
 
         if (icon) {
-            const float iconSz = 16.0f;
+            const float iconSz = 15.0f;
             NUIRect iconRect(
                 std::round(currentX + (buttonSize - iconSz) * 0.5f),
                 std::round(currentY + (buttonSize - iconSz) * 0.5f),
@@ -743,47 +818,44 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
         currentX += buttonSize + buttonSpacing;
     };
 
-    // 1. Menu Button
+    drawGroup(currentX - 3.0f, buttonSize + 6.0f);
     renderButton(m_menuBtn, m_menuIcon, false);
-    
-    // Separator after Menu
-    currentX += 4.0f;
-    renderer.drawLine(NUIPoint(currentX, currentY + 4), NUIPoint(currentX, currentY + buttonSize - 4), 1.0f, borderCol.withAlpha(0.45f));
-    currentX += 10.0f;
 
-    // 2. Tools
+    currentX += 8.0f;
+
+    drawGroup(currentX - 3.0f, buttonSize * 3.0f + buttonSpacing * 2.0f + 6.0f);
     renderButton(m_ptrBtn, m_ptrIcon, activeTool_ == GlobalTool::Pointer);
     renderButton(m_pencilBtn, m_pencilIcon, activeTool_ == GlobalTool::Pencil);
     renderButton(m_eraserBtn, m_eraserIcon, activeTool_ == GlobalTool::Eraser);
 
     float patternDropdownRight = currentX;
     if (m_patternDropdown) {
-        currentX += 4.0f;
-        renderer.drawLine(NUIPoint(currentX, currentY + 4), NUIPoint(currentX, currentY + buttonSize - 4), 1.0f, borderCol.withAlpha(0.45f));
-        currentX += 10.0f;
+        currentX += 8.0f;
 
-        const float dropdownW = 190.0f;
+        const float dropdownW = std::clamp(b.width * 0.24f, 180.0f, 250.0f);
+        drawGroup(currentX - 3.0f, dropdownW + 6.0f);
         m_patternDropdown->setBounds(NUIRect(currentX, currentY, dropdownW, buttonSize));
         m_patternDropdown->onRender(renderer);
         patternDropdownRight = currentX + dropdownW;
         currentX += dropdownW + buttonSpacing;
     }
 
-    currentX += 4.0f;
-    renderer.drawLine(NUIPoint(currentX, currentY + 4), NUIPoint(currentX, currentY + buttonSize - 4), 1.0f, borderCol.withAlpha(0.45f));
-    currentX += 10.0f;
-
-    renderButton(m_lengthDownBtn, m_lengthDownIcon, false);
+    currentX += 8.0f;
 
     const int patternBars = std::max(1, static_cast<int>(std::lround(m_patternLengthBeats / 4.0)));
     const std::string lengthLabel = std::to_string(patternBars) + " Bars";
     const float lengthFontSize = 10.0f;
     const auto lengthSize = renderer.measureText(lengthLabel, lengthFontSize);
-    const float pillPadX = 10.0f;
-    const float pillW = std::max(56.0f, lengthSize.width + pillPadX * 2.0f);
+    const float pillPadX = 12.0f;
+    const float pillW = std::max(64.0f, lengthSize.width + pillPadX * 2.0f);
+    const float lengthGroupX = currentX - 3.0f;
+    const float lengthGroupW = buttonSize * 2.0f + pillW + buttonSpacing * 2.0f + 6.0f;
+    drawGroup(lengthGroupX, lengthGroupW);
+
+    renderButton(m_lengthDownBtn, m_lengthDownIcon, false);
     const NUIRect pillRect(currentX, currentY, pillW, buttonSize);
-    renderer.fillRoundedRect(pillRect, radius, themeManager.getColor("surfaceSecondary").withAlpha(0.92f));
-    renderer.strokeRoundedRect(pillRect, radius, 1.0f, borderCol.withAlpha(0.35f));
+    renderer.fillRoundedRect(pillRect, radius, themeManager.getColor("surfaceRaised").withAlpha(0.80f));
+    renderer.strokeRoundedRect(pillRect, radius, 1.0f, borderCol);
     renderer.drawText(lengthLabel,
                       NUIPoint(pillRect.x + (pillRect.width - lengthSize.width) * 0.5f,
                                pillRect.y + (pillRect.height - lengthSize.height) * 0.5f + 1.0f),
@@ -795,7 +867,7 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
 
     // Editing Pattern Label (Right Side)
     if (!m_patternName.empty()) {
-        const float labelLeft = std::max(patternDropdownRight + 10.0f, currentX + 6.0f);
+        const float labelLeft = std::max(patternDropdownRight + 10.0f, currentX + 12.0f);
         const float labelRight = b.right() - innerPad - 4.0f;
         const float maxLabelWidth = labelRight - labelLeft;
         if (maxLabelWidth < 24.0f) {
@@ -816,7 +888,10 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
         }
         auto size = renderer.measureText(labelStr, fontSize);
         float lx = std::max(labelLeft, labelRight - size.width);
-        renderer.drawText(labelStr, NUIPoint(lx, currentY + (buttonSize - size.height) * 0.5f + 2.0f), fontSize, themeManager.getColor("textSecondary").withAlpha(0.72f));
+        renderer.drawText(labelStr,
+                          NUIPoint(lx, currentY + (buttonSize - size.height) * 0.5f + 2.0f),
+                          fontSize,
+                          themeManager.getColor("textSecondary").withAlpha(0.68f));
     }
 
 }
@@ -867,13 +942,28 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     // CLIP TO BOUNDS to prevent bleeding
     renderer.setClipRect(b);
 
-    renderer.fillRect(b, themeManager.getColor("backgroundPrimary"));
+    renderer.fillRect(b, themeManager.getColor("backgroundPrimary").darkened(0.01f));
 
-    auto rowBlackKey = themeManager.getColor("surfaceRaised").withAlpha(0.08f);
-    auto rowRootKey = themeManager.getColor("accentPrimary").withAlpha(0.04f);
-    
-    auto gridBeat = themeManager.getColor("border").withAlpha(0.06f);
-    auto gridBar = themeManager.getColor("border").withAlpha(0.14f);
+    const auto rowAccidental = themeManager.getColor("surfaceRaised").withAlpha(0.11f);
+    const auto rowRoot = themeManager.getColor("accentPrimary").withAlpha(0.075f);
+    const auto rowOutOfScale = themeManager.getColor("backgroundPrimary").darkened(0.05f).withAlpha(0.45f);
+    const auto rowLine = themeManager.getColor("border").withAlpha(0.075f);
+    const auto gridSubdivision = themeManager.getColor("border").withAlpha(0.065f);
+    const auto gridBeat = themeManager.getColor("border").withAlpha(0.15f);
+    const auto gridBar = themeManager.getColor("textSecondary").withAlpha(0.24f);
+
+    const double visibleStartBeat = static_cast<double>(scrollX_) / pixelsPerBeat_;
+    const double visibleEndBeat = static_cast<double>(scrollX_ + b.width) / pixelsPerBeat_;
+    const int firstVisibleBar = static_cast<int>(std::floor(visibleStartBeat / beatsPerBar_));
+    const int lastVisibleBar = static_cast<int>(std::ceil(visibleEndBeat / beatsPerBar_));
+    const auto zebraColor = themeManager.getColor("surfaceRaised").withAlpha(0.035f);
+    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
+        if ((bar & 1) == 0) continue;
+        const double barStartBeat = static_cast<double>(bar * beatsPerBar_);
+        const float barX = beatToScreenX(barStartBeat, pixelsPerBeat_, scrollX_, b.x);
+        const float barWidth = pixelsPerBeat_ * static_cast<float>(beatsPerBar_);
+        renderer.fillRect(NUIRect(barX, b.y, barWidth, b.height), zebraColor);
+    }
 
     // 1. Draw Rows (Matching Keys)
     int startPitch = 127 - static_cast<int>((scrollY_) / keyHeight_);
@@ -890,16 +980,20 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
         
         NUIRect rowRect(b.x, y, b.width, keyHeight_);
         
-        // Row Coloring
-        if ((p % 12) == 0) {
-            // Root Key (C)
-            renderer.fillRect(rowRect, rowRootKey);
+        const int pitchClass = ((p % 12) + 12) % 12;
+        const bool isRoot = pitchClass == rootKey_;
+        const bool isInScale = scaleType_ == ScaleType::Chromatic || MusicTheory::isNoteInScale(p, rootKey_, scaleType_);
+
+        if (isRoot) {
+            renderer.fillRect(rowRect, rowRoot);
         } else if (isBlackKey(p)) {
-            // Black Key
-            renderer.fillRect(rowRect, rowBlackKey);
+            renderer.fillRect(rowRect, rowAccidental);
         }
-        
-        renderer.drawLine(NUIPoint(b.x, y), NUIPoint(b.x + b.width, y), 1.0f, gridBeat.withAlpha(0.55f));
+        if (!isInScale) {
+            renderer.fillRect(rowRect, rowOutOfScale);
+        }
+
+        renderer.drawLine(NUIPoint(b.x, y), NUIPoint(b.right(), y), 1.0f, rowLine);
     }
 
     // Vertical Lines (Snap Grid)
@@ -912,21 +1006,16 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
         snapDur *= 2.0;
     }
 
-    double startBeat = static_cast<double>(scrollX_) / pixelsPerBeat_;
-    double endBeat = static_cast<double>(scrollX_ + b.width) / pixelsPerBeat_;
+    double current = std::floor(visibleStartBeat / snapDur) * snapDur;
     
-    double current = std::floor(startBeat / snapDur) * snapDur;
-    
-    for (; current <= endBeat + snapDur; current += snapDur) {
+    for (; current <= visibleEndBeat + snapDur; current += snapDur) {
         // Calculate X in double precision relative to scrollX_ BEFORE casting to float
         float x = snapVerticalLineX(beatToScreenX(current, pixelsPerBeat_, scrollX_, b.x));
         
-        // Check hierarchy
-        bool isBar = (std::fmod(std::abs(current), (double)beatsPerBar_) < 0.001);
-        
-        // Draw
-        float lineWidth = isBar ? 1.0f : 1.0f;
-        NUIColor col = isBar ? gridBar : gridBeat;
+        const bool isBar = std::fmod(std::abs(current), static_cast<double>(beatsPerBar_)) < 0.001;
+        const bool isBeat = std::fmod(std::abs(current), 1.0) < 0.001;
+        const float lineWidth = isBar ? 1.5f : 1.0f;
+        const NUIColor col = isBar ? gridBar : (isBeat ? gridBeat : gridSubdivision);
         renderer.drawLine(NUIPoint(x, b.y), NUIPoint(x, b.y + b.height), lineWidth, col);
     }
 
@@ -979,9 +1068,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
     // CLIP TO BOUNDS
     renderer.setClipRect(b);
     
-    // Note colors — purple base (theme.primary), lighter purple for selected
-    auto noteColor = NUIColor(0.545f, 0.498f, 1.0f, 0.88f);         // #8B7FFF
-    auto noteColorSelected = NUIColor(0.72f, 0.66f, 1.0f, 0.97f);   // lighter purple
+    const auto noteColor = themeManager.getColor("accentPrimary").lightened(0.04f);
+    const auto noteColorSelected = themeManager.getColor("accentSecondary").lightened(0.12f);
     
     // 1. GHOST NOTES (Read-only backgrounds)
     for (const auto& ghost : ghostPatterns_) {
@@ -996,15 +1084,16 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
             
             if (x + w < b.x || x > b.x + b.width || y + h < b.y || y > b.y + b.height) continue;
             
-            NUIRect r(x, y + 1, std::max(4.0f, w), h - 2);
-            renderer.fillRoundedRect(r, 4.0f, gCol); // More rounded
-            renderer.strokeRoundedRect(r, 4.0f, 1.0f, gBorder);
+            NUIRect r(x, y + 2, std::max(4.0f, w), h - 4);
+            renderer.fillRoundedRect(r, 2.0f, gCol);
+            renderer.strokeRoundedRect(r, 2.0f, 1.0f, gBorder);
         }
     }
     
     const double visibleEndBeat = (scrollX_ + b.width) / pixelsPerBeat_;
 
-    for (const auto& n : notes_) {
+    for (size_t noteIndex = 0; noteIndex < notes_.size(); ++noteIndex) {
+        const auto& n = notes_[noteIndex];
         if (n.startBeat > visibleEndBeat) break;
         
         float x = snapRectX(beatToScreenX(n.startBeat, pixelsPerBeat_, scrollX_, b.x));
@@ -1017,39 +1106,34 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         // Skip deleted notes
         if (n.isDeleted) continue;
         
-        NUIRect r(x, y + 1, std::max(6.0f, w), h - 2);
-        
-        NUIColor baseColor = n.selected ? noteColorSelected : noteColor;
-        NUIColor coreColor = baseColor.withAlpha(0.92f);
-        NUIColor edgeColor = n.selected
-                                 ? NUIColor::white().withAlpha(0.55f)
-                                 : themeManager.getColor("border").withAlpha(0.40f);
-        NUIColor glowColor = n.selected
-                                 ? noteColorSelected.withAlpha(0.65f)
-                                 : baseColor.withAlpha(0.18f);
+        NUIRect r(x + 1.0f, y + 2.0f, std::max(6.0f, w - 2.0f), std::max(5.0f, h - 4.0f));
 
-        // Spec 6: compressed velocity range — quiet notes still read clearly
-        float velFactor = 0.85f + n.velocity * 0.15f;
-        coreColor = coreColor.withAlpha(coreColor.a * velFactor);
+        const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
+        const NUIColor baseColor = n.selected ? noteColorSelected : noteColor;
+        const NUIColor coreColor = baseColor.withAlpha(0.68f + normalizedVelocity * 0.28f);
+        const NUIColor edgeColor = n.selected
+                                       ? NUIColor::white().withAlpha(0.72f)
+                                       : baseColor.lightened(0.16f).withAlpha(0.74f);
 
-        renderer.drawShadow(NUIRect(r.x, r.y + 1.0f, r.width, r.height), 0.0f, 3.0f, 8.0f, NUIColor(0, 0, 0, 0.10f));
-        renderer.fillRoundedRect(NUIRect(r.x, r.y, r.width, r.height), 6.0f, coreColor);
-        // Spec 6: thinner specular — top 20%, 7-9% alpha
-        renderer.fillRoundedRect(NUIRect(r.x + 1.0f, r.y + 1.0f, r.width - 2.0f, r.height * 0.20f), 5.0f, NUIColor::white().withAlpha(n.selected ? 0.09f : 0.07f));
-        renderer.strokeRoundedRect(r, 6.0f, 1.0f, edgeColor);
-        renderer.fillRoundedRect(NUIRect(r.x + 2.0f, r.bottom() - 3.0f, std::max(8.0f, r.width - 4.0f), 1.5f), 0.75f, glowColor);
+        renderer.drawShadow(NUIRect(r.x, r.y + 1.0f, r.width, r.height),
+                            0.0f,
+                            2.0f,
+                            5.0f,
+                            NUIColor(0, 0, 0, n.selected ? 0.22f : 0.14f));
+        renderer.fillRoundedRect(r, 3.0f, coreColor);
+        renderer.strokeRoundedRect(r, 3.0f, n.selected ? 1.5f : 1.0f, edgeColor);
+        renderer.fillRoundedRect(NUIRect(r.x + 1.0f, r.y + 2.0f, 2.5f, std::max(2.0f, r.height - 4.0f)),
+                                 1.0f,
+                                 NUIColor::white().withAlpha(n.selected ? 0.68f : 0.42f));
 
         // Edge resize affordance on hover
-        if (static_cast<int>(&n - &notes_[0]) == hoveredNoteIndex_ && (hoverOnRightEdge_ || hoverOnLeftEdge_)) {
-            NUIColor affordanceColor = coreColor;
-            affordanceColor.r *= 0.68f;
-            affordanceColor.g *= 0.68f;
-            affordanceColor.b *= 0.68f;
+        if (static_cast<int>(noteIndex) == hoveredNoteIndex_ && (hoverOnRightEdge_ || hoverOnLeftEdge_)) {
+            const NUIColor affordanceColor = NUIColor::white().withAlpha(0.72f);
             if (hoverOnRightEdge_) {
-                renderer.fillRoundedRect(NUIRect(r.right() - 3.0f, r.y, 3.0f, r.height), 1.5f, affordanceColor);
+                renderer.fillRoundedRect(NUIRect(r.right() - 3.0f, r.y + 3.0f, 2.0f, r.height - 6.0f), 1.0f, affordanceColor);
             }
             if (hoverOnLeftEdge_) {
-                renderer.fillRoundedRect(NUIRect(r.x, r.y, 3.0f, r.height), 1.5f, affordanceColor);
+                renderer.fillRoundedRect(NUIRect(r.x + 1.0f, r.y + 3.0f, 2.0f, r.height - 6.0f), 1.0f, affordanceColor);
             }
         }
 
@@ -1061,11 +1145,11 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
             constexpr float kFontSize = 10.0f;
             auto measured = renderer.measureText(pitchLabel, kFontSize);
             // Left-align with padding, vertically centered
-            float labelX = r.x + 5.0f;
+            float labelX = r.x + 7.0f;
             float labelY = r.y + (r.height - measured.height) * 0.5f;
             // Clip label to note bounds (renderer should handle this, but extra safety)
             if (labelX + measured.width < r.x + r.width) {
-                NUIColor labelColor = NUIColor::white().withAlpha(0.85f);
+                NUIColor labelColor = NUIColor::white().withAlpha(0.88f);
                 renderer.drawText(pitchLabel, NUIPoint(labelX, labelY), kFontSize, labelColor);
             }
         }
@@ -1987,7 +2071,7 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
     // CRITICAL FIX: Ignore events outside bounds unless we are already dragging
     if (!b.contains(event.position) && !isDragging_) return false;
 
-    float sidebarW = 60.0f; // Defined here
+    constexpr float sidebarW = 76.0f;
     // Note Layer Interaction (Velocity)
     // We assume clicks in content area are for velocity
     // COPIED FROM OLD LOGIC
@@ -2045,13 +2129,12 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
                 dragStartPos_ = event.position;
                 
                 // Set velocity immediately based on click Y (Global)
-                float availH = b.height - 15.0f;
-                float h = (b.y + b.height - 5.0f) - event.position.y;
-                int newVel = static_cast<int>((h / availH) * 127.0f);
-                newVel = std::clamp(newVel, 0, 127);
+                const float availH = std::max(1.0f, b.height - 28.0f);
+                const float bottomY = b.bottom() - 8.0f;
+                const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
                 
                 auto modNotes = notes;
-                modNotes[foundIdx].velocity = newVel;
+                modNotes[foundIdx].velocity = newVelocity;
                 
                 // Single Edit Only (Batch removed)
                 
@@ -2069,14 +2152,13 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
             }
 
             // Move
-            float availH = b.height - 15.0f;
-            float h = (b.y + b.height - 5.0f) - event.position.y;
-            int newVel = static_cast<int>((h / availH) * 127.0f);
-            newVel = std::clamp(newVel, 0, 127);
+            const float availH = std::max(1.0f, b.height - 28.0f);
+            const float bottomY = b.bottom() - 8.0f;
+            const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
             
             auto modNotes = layer->getNotes();
-            if (hoveringNoteIndex_ >= 0 && hoveringNoteIndex_ < modNotes.size()) {
-                 modNotes[hoveringNoteIndex_].velocity = newVel;
+            if (hoveringNoteIndex_ >= 0 && static_cast<size_t>(hoveringNoteIndex_) < modNotes.size()) {
+                 modNotes[hoveringNoteIndex_].velocity = newVelocity;
                  // Single Edit Only (Batch removed)
                  layer->setNotes(modNotes);
                  repaint();
@@ -2092,19 +2174,32 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     auto b = getBounds();
     auto& themeManager = NUIThemeManager::getInstance();
     
-    renderer.fillRect(b, themeManager.getColor("backgroundSecondary"));
-    // Top border to separate from grid
-    renderer.drawLine(NUIPoint(b.x, b.y), NUIPoint(b.x + b.width, b.y), 1.0f, themeManager.getColor("border").withAlpha(0.35f));
+    const auto panelBg = themeManager.getColor("backgroundSecondary").darkened(0.025f);
+    const auto border = themeManager.getColor("border").withAlpha(0.52f);
+    renderer.fillRect(b, panelBg);
+    renderer.drawLine(NUIPoint(b.x, b.y), NUIPoint(b.right(), b.y), 1.0f, border);
     
     // Sidebar Area (Left)
-    float sidebarW = 60.0f; 
+    constexpr float sidebarW = 76.0f;
     NUIRect sidebarRect(b.x, b.y, sidebarW, b.height);
     
-    renderer.fillRect(sidebarRect, themeManager.getColor("backgroundPrimary").withAlpha(0.60f));
-    renderer.drawLine(NUIPoint(sidebarRect.right(), sidebarRect.y), NUIPoint(sidebarRect.right(), sidebarRect.bottom()), 1.0f, themeManager.getColor("border").withAlpha(0.22f));
-    
-    auto textDim = renderer.measureText("VELOCITY", themeManager.getFontSize("xs"));
-    renderer.drawText("VELOCITY", NUIPoint(b.x + (sidebarW - textDim.width) * 0.5f, b.y + (b.height - textDim.height) * 0.5f), themeManager.getFontSize("xs"), themeManager.getColor("textSecondary").withAlpha(0.68f));
+    renderer.fillRect(sidebarRect, themeManager.getColor("backgroundPrimary").withAlpha(0.72f));
+    renderer.drawLine(NUIPoint(sidebarRect.right(), sidebarRect.y),
+                      NUIPoint(sidebarRect.right(), sidebarRect.bottom()),
+                      1.0f,
+                      border);
+
+    const float labelSize = themeManager.getFontSize("xs");
+    const auto textDim = renderer.measureText("VELOCITY", labelSize);
+    renderer.drawText("VELOCITY",
+                      NUIPoint(b.x + (sidebarW - textDim.width) * 0.5f, b.y + 13.0f),
+                      labelSize,
+                      themeManager.getColor("textPrimary").withAlpha(0.78f));
+    const auto rangeDim = renderer.measureText("MIDI 0 - 127", 8.0f);
+    renderer.drawText("MIDI 0 - 127",
+                      NUIPoint(b.x + (sidebarW - rangeDim.width) * 0.5f, b.y + 31.0f),
+                      8.0f,
+                      themeManager.getColor("textSecondary").withAlpha(0.48f));
     
     auto layer = noteLayer_.lock();
     if (!layer || !isVisible()) return;
@@ -2112,6 +2207,29 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     // Content Area Clip
     NUIRect contentRect(b.x + sidebarW, b.y, b.width - sidebarW, b.height);
     renderer.setClipRect(contentRect);
+
+    constexpr int beatsPerBar = 4;
+    const double visibleStartBeat = scrollX_ / pixelsPerBeat_;
+    const double visibleEndBeat = (scrollX_ + contentRect.width) / pixelsPerBeat_;
+    const int firstVisibleBar = static_cast<int>(std::floor(visibleStartBeat / beatsPerBar));
+    const int lastVisibleBar = static_cast<int>(std::ceil(visibleEndBeat / beatsPerBar));
+    const auto zebraColor = themeManager.getColor("surfaceRaised").withAlpha(0.035f);
+    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
+        if ((bar & 1) == 0) continue;
+        const float x = contentRect.x + static_cast<float>(bar * beatsPerBar) * pixelsPerBeat_ - scrollX_;
+        renderer.fillRect(NUIRect(x, contentRect.y, pixelsPerBeat_ * beatsPerBar, contentRect.height), zebraColor);
+    }
+
+    const float availH = std::max(1.0f, b.height - 28.0f);
+    const float bottomY = b.bottom() - 8.0f;
+    const float topY = bottomY - availH;
+    const auto guideColor = themeManager.getColor("border").withAlpha(0.11f);
+    renderer.drawLine(NUIPoint(contentRect.x, topY), NUIPoint(contentRect.right(), topY), 1.0f, guideColor);
+    renderer.drawLine(NUIPoint(contentRect.x, topY + availH * 0.5f),
+                      NUIPoint(contentRect.right(), topY + availH * 0.5f),
+                      1.0f,
+                      guideColor.withAlpha(0.72f));
+    renderer.drawLine(NUIPoint(contentRect.x, bottomY), NUIPoint(contentRect.right(), bottomY), 1.0f, guideColor);
 
     // 1. Draw Grid Background (Sync with PianoRollGrid)
     auto snap = layer->getSnap();
@@ -2125,17 +2243,12 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     }
 
     float startX = b.x + sidebarW;
-    double startBeat = scrollX_ / pixelsPerBeat_;
-    double endBeat = (scrollX_ + contentRect.width) / pixelsPerBeat_;
-    
     // Align to snap
-    double current = std::floor(startBeat / snapDur) * snapDur;
+    double current = std::floor(visibleStartBeat / snapDur) * snapDur;
 
     auto gridCol = themeManager.getColor("border").withAlpha(0.07f);
     auto barCol = themeManager.getColor("border").withAlpha(0.14f);
-    int beatsPerBar = 4;
-    
-    for (; current <= endBeat + snapDur; current += snapDur) {
+    for (; current <= visibleEndBeat + snapDur; current += snapDur) {
         // Double precision relative subtraction
         double relX = (current * pixelsPerBeat_) - static_cast<double>(scrollX_);
         float x = startX + static_cast<float>(relX);
@@ -2146,12 +2259,9 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
         renderer.drawLine(NUIPoint(x, b.y), NUIPoint(x, b.y + b.height), 1.0f, isBar ? barCol : gridCol);
     }
     
-    // 2. Render Velocity Bars (Lollipop Style + Note Width)
+    // 2. Render velocity stems using MidiNote's normalized 0..1 representation.
     const auto& notes = layer->getNotes();
     auto velColorBase = themeManager.getColor("accentPrimary").lightened(0.05f);
-    
-    float availH = b.height - 15.0f; // Leave room at top
-    float bottomY = b.y + b.height - 5.0f; // Floor (Global Y)
 
     for (const auto& n : notes) {
         if (n.isDeleted && n.animationScale < 0.01f) continue;
@@ -2161,27 +2271,27 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
         // Skip if out of view
         if (x > b.x + b.width) continue;
         
-        float h = (n.velocity / 127.0f) * availH;
+        const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
+        float h = velocityToPanelHeight(normalizedVelocity, availH);
         float y = bottomY - h;
-        
-        // Alpha based on velocity logic for bars too?
-        float alpha = 0.5f + (n.velocity / 127.0f) * 0.5f;
+
+        float alpha = 0.48f + normalizedVelocity * 0.48f;
         auto col = velColorBase.withAlpha(alpha);
         if (n.selected) col = themeManager.getColor("accentSecondary").withAlpha(0.92f);
-        
-        // STEM (Thicker)
-        renderer.drawLine(NUIPoint(x, bottomY), NUIPoint(x, y), 2.0f, col);
-        
-        // POP / CIRCLE HEAD
-        float circleSize = 6.0f;
-        NUIRect circleRect(x - circleSize/2, y - circleSize/2, circleSize, circleSize);
-        renderer.fillRoundedRect(circleRect, circleSize/2, col);
-        renderer.strokeRoundedRect(circleRect, circleSize/2, 1.0f, NUIColor::white().withAlpha(0.18f));
-        
-        // Note Length Line
+
+        renderer.fillRoundedRect(NUIRect(x - 2.0f, y, 4.0f, std::max(2.0f, h)), 2.0f, col.withAlpha(alpha * 0.78f));
+
+        const float handleSize = n.selected ? 7.0f : 6.0f;
+        NUIRect handleRect(x - handleSize * 0.5f, y - handleSize * 0.5f, handleSize, handleSize);
+        renderer.fillRoundedRect(handleRect, 2.0f, col);
+        renderer.strokeRoundedRect(handleRect,
+                                   2.0f,
+                                   1.0f,
+                                   NUIColor::white().withAlpha(n.selected ? 0.48f : 0.20f));
+
         float w = static_cast<float>(n.durationBeats * pixelsPerBeat_);
         if (w > 4.0f) {
-            renderer.drawLine(NUIPoint(x, y), NUIPoint(x + w, y), 1.0f, col.withAlpha(0.6f));
+            renderer.drawLine(NUIPoint(x, y), NUIPoint(x + w, y), n.selected ? 2.0f : 1.0f, col.withAlpha(0.64f));
         }
     }
     
@@ -2198,7 +2308,7 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
 // PianoRollView
 // =============================================================================
 PianoRollView::PianoRollView()
-    : m_keyLaneWidth(60.0f), m_rulerHeight(30.0f), m_pixelsPerBeat(80.0f), m_keyHeight(24.0f),
+    : m_keyLaneWidth(76.0f), m_rulerHeight(28.0f), m_pixelsPerBeat(80.0f), m_keyHeight(24.0f),
       m_scrollX(0.0f), m_targetScrollX(0.0f)
 {
     // [FIX] Canonical default octave: C3 (MIDI 48).
@@ -2260,6 +2370,14 @@ PianoRollView::PianoRollView()
         syncChildren();
     };
 
+    m_ruler->onPlayheadScrubbed = [this](double beat, bool active) {
+        const double clampedBeat = std::clamp(beat, 0.0, m_totalDurationBeats);
+        setPlayheadBeat(clampedBeat, false);
+        if (m_onPlayheadScrubbed) {
+            m_onPlayheadScrubbed(clampedBeat, active);
+        }
+    };
+
     m_minimap->onViewChanged = [this](double start, double duration) {
         m_scrollX = static_cast<float>(start * m_pixelsPerBeat);
         m_targetScrollX = m_scrollX;
@@ -2294,41 +2412,72 @@ PianoRollView::PianoRollView()
 
 void PianoRollView::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRect(getBounds(), theme.getColor("backgroundPrimary"));
+    const auto bounds = getBounds();
+    renderer.fillRect(bounds, theme.getColor("backgroundPrimary"));
+
+    const float toolbarH = 50.0f;
+    const float minimapH = m_showLocalMinimap ? 28.0f : 0.0f;
+    const float rulerH = 28.0f;
+    const NUIRect pitchHeader(bounds.x,
+                              bounds.y + toolbarH,
+                              m_keyLaneWidth,
+                              minimapH + rulerH);
+    renderer.fillRect(pitchHeader, theme.getColor("backgroundSecondary").darkened(0.025f));
+    renderer.drawLine(NUIPoint(pitchHeader.right() - 0.5f, pitchHeader.y),
+                      NUIPoint(pitchHeader.right() - 0.5f, pitchHeader.bottom()),
+                      1.0f,
+                      theme.getColor("border").withAlpha(0.54f));
+    renderer.drawLine(NUIPoint(pitchHeader.x, pitchHeader.bottom() - 0.5f),
+                      NUIPoint(pitchHeader.right(), pitchHeader.bottom() - 0.5f),
+                      1.0f,
+                      theme.getColor("border").withAlpha(0.54f));
+    const auto pitchLabelSize = renderer.measureText("PITCH", 9.0f);
+    renderer.drawText("PITCH",
+                      NUIPoint(pitchHeader.x + (pitchHeader.width - pitchLabelSize.width) * 0.5f,
+                               pitchHeader.bottom() - rulerH + (rulerH - pitchLabelSize.height) * 0.5f),
+                      9.0f,
+                      theme.getColor("textSecondary").withAlpha(0.62f));
+
     NUIComponent::onRender(renderer);
 
     // Draw playhead
-    if (!m_grid || !m_ruler) return;
+    if (m_grid && m_ruler) {
+        const auto gridBounds = m_grid->getBounds();
+        const auto rulerBounds = m_ruler->getBounds();
+        const auto accent = theme.getColor("accentPrimary");
+        const double visibleStartBeat = getViewStartBeat();
+        const double visibleEndBeat = visibleStartBeat + getViewDurationBeats();
+        const float playheadX = snapVerticalLineX(
+            beatToScreenX(m_playheadBeat, m_pixelsPerBeat, m_scrollX, gridBounds.x));
 
-    const auto gridBounds = m_grid->getBounds();
-    const auto rulerBounds = m_ruler->getBounds();
-    const auto accent = NUIThemeManager::getInstance().getColor("accentPrimary");
-    const double visibleStartBeat = getViewStartBeat();
-    const double visibleEndBeat = visibleStartBeat + getViewDurationBeats();
-    if (m_playheadBeat < visibleStartBeat || m_playheadBeat > visibleEndBeat) return;
+        if (m_playheadBeat >= visibleStartBeat && m_playheadBeat <= visibleEndBeat &&
+            playheadX >= gridBounds.x && playheadX <= gridBounds.right()) {
+            const float playheadStartY = rulerBounds.bottom();
+            const float playheadEndY = m_controls ? m_controls->getBounds().bottom() : gridBounds.bottom();
+            renderer.drawLine(NUIPoint(playheadX, playheadStartY),
+                              NUIPoint(playheadX, playheadEndY),
+                              5.0f,
+                              accent.withAlpha(0.10f));
+            renderer.drawLine(NUIPoint(playheadX, playheadStartY),
+                              NUIPoint(playheadX, playheadEndY),
+                              2.0f,
+                              accent.withAlpha(0.92f));
 
-    const float playheadX = snapVerticalLineX(beatToScreenX(m_playheadBeat, m_pixelsPerBeat, m_scrollX, gridBounds.x));
-    const float playheadStartY = rulerBounds.bottom();
-    const float playheadEndY = gridBounds.bottom();
-
-    if (playheadX < gridBounds.x || playheadX > gridBounds.right()) return;
-
-    renderer.drawLine(NUIPoint(playheadX, playheadStartY),
-                      NUIPoint(playheadX, playheadEndY),
-                      1.5f,
-                      accent);
-
-    const float triangleH = 8.0f;
-    const float triangleW = 5.0f;
-    for (float dx = 0.0f; dx <= triangleW; dx += 1.0f) {
-        renderer.drawLine(NUIPoint(playheadX + dx, playheadStartY),
-                          NUIPoint(playheadX + dx, playheadStartY + triangleH - dx * (triangleH / triangleW)),
-                          1.0f,
-                          accent);
-        renderer.drawLine(NUIPoint(playheadX - dx, playheadStartY),
-                          NUIPoint(playheadX - dx, playheadStartY + triangleH - dx * (triangleH / triangleW)),
-                          1.0f,
-                          accent);
+            const float triangleH = 8.0f;
+            const float triangleW = 5.0f;
+            for (float dx = 0.0f; dx <= triangleW; dx += 1.0f) {
+                renderer.drawLine(NUIPoint(playheadX + dx, playheadStartY),
+                                  NUIPoint(playheadX + dx,
+                                           playheadStartY + triangleH - dx * (triangleH / triangleW)),
+                                  1.0f,
+                                  accent);
+                renderer.drawLine(NUIPoint(playheadX - dx, playheadStartY),
+                                  NUIPoint(playheadX - dx,
+                                           playheadStartY + triangleH - dx * (triangleH / triangleW)),
+                                  1.0f,
+                                  accent);
+            }
+        }
     }
 
     if (m_toolbar) {
@@ -2385,14 +2534,14 @@ void PianoRollView::layoutChildren() {
     float sbSize = 14.0f; 
     
     // 0. Toolbar (Standardized Aestra UI Height)
-    float toolbarH = 40.0f;
+    float toolbarH = 50.0f;
     if (m_toolbar) m_toolbar->setBounds(NUIRect(b.x, b.y, b.width, toolbarH));
     
     // 1. Scrollbar/Minimap Section (Below Toolbar)
-    float miniMapH = 24.0f;
+    float miniMapH = m_showLocalMinimap ? 28.0f : 0.0f;
     
     // 2. Ruler Section (Below Minimap if present)
-    float rulerH = 24.0f;
+    float rulerH = 28.0f;
     
     float topTotalH = toolbarH + miniMapH + rulerH;
     
@@ -2709,6 +2858,10 @@ void PianoRollView::setOnPatternChoiceSelected(std::function<void(int patternVal
     if (m_toolbar) {
         m_toolbar->setOnPatternChoiceSelected(std::move(cb));
     }
+}
+
+void PianoRollView::setOnPlayheadScrubbed(std::function<void(double beat, bool active)> cb) {
+    m_onPlayheadScrubbed = std::move(cb);
 }
 
 void PianoRollView::setLocalMinimapVisible(bool visible) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1207,6 +1207,80 @@ void PianoRollNoteLayer::connectSelectedNotes() {
     }
 }
 
+void PianoRollNoteLayer::quantizeSelectedNotes() {
+    double snapDur = MusicTheory::getSnapDuration(snap_);
+    if (snap_ == SnapGrid::None || snapDur <= 0.0001) snapDur = 0.25; // sensible 1/16 default
+
+    auto oldNotes = notes_;
+    bool changed = false;
+    for (auto& n : notes_) {
+        if (!n.selected || n.isDeleted) continue;
+        const double q = quantizeBeatToGrid(n.startBeat, snapDur);
+        if (std::abs(q - n.startBeat) > 0.0001) {
+            n.startBeat = q;
+            changed = true;
+        }
+    }
+    if (changed) {
+        pushUndo("Quantize", oldNotes, notes_);
+        commitNotes();
+        repaint();
+    }
+}
+
+void PianoRollNoteLayer::glueSelectedNotes() {
+    // Collect selected note indices grouped by pitch.
+    std::vector<int> selected;
+    for (size_t i = 0; i < notes_.size(); ++i) {
+        if (notes_[i].selected && !notes_[i].isDeleted) selected.push_back(static_cast<int>(i));
+    }
+    if (selected.size() < 2) return;
+
+    auto oldNotes = notes_;
+    std::vector<MidiNote> merged;      // rebuilt selected notes
+    std::vector<bool> consumed(notes_.size(), false);
+
+    // For each pitch, sweep left→right and coalesce runs that overlap or touch.
+    std::sort(selected.begin(), selected.end(), [&](int a, int b) {
+        if (notes_[a].pitch != notes_[b].pitch) return notes_[a].pitch < notes_[b].pitch;
+        return notes_[a].startBeat < notes_[b].startBeat;
+    });
+
+    bool changed = false;
+    size_t k = 0;
+    while (k < selected.size()) {
+        MidiNote run = notes_[selected[k]];
+        double runEnd = run.startBeat + run.durationBeats;
+        size_t j = k + 1;
+        while (j < selected.size() && notes_[selected[j]].pitch == run.pitch &&
+               notes_[selected[j]].startBeat <= runEnd + 0.0001) {
+            runEnd = std::max(runEnd, notes_[selected[j]].startBeat + notes_[selected[j]].durationBeats);
+            changed = true; // at least two notes folded together
+            ++j;
+        }
+        run.durationBeats = runEnd - run.startBeat;
+        run.selected = true;
+        merged.push_back(run);
+        for (size_t m = k; m < j; ++m) consumed[selected[m]] = true;
+        k = j;
+    }
+
+    if (!changed) return;
+
+    // Keep everything that wasn't glued, then append the merged notes.
+    std::vector<MidiNote> rebuilt;
+    rebuilt.reserve(notes_.size());
+    for (size_t i = 0; i < notes_.size(); ++i) {
+        if (!consumed[i]) rebuilt.push_back(notes_[i]);
+    }
+    for (auto& m : merged) rebuilt.push_back(m);
+    notes_ = std::move(rebuilt);
+
+    pushUndo("Glue", oldNotes, notes_);
+    commitNotes();
+    repaint();
+}
+
 void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
     std::vector<int> selected;
     for (size_t i = 0; i < notes_.size(); ++i) {
@@ -2100,6 +2174,17 @@ bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
         // or out to the next snap/beat boundary when nothing follows.
         if (ctrl && event.keyCode == NUIKeyCode::L) {
             connectSelectedNotes();
+            return true;
+        }
+
+        // Q: quantize selected note starts to the grid. Ctrl+G: glue selected
+        // notes on the same pitch into one. Both are no-ops without a selection.
+        if (!ctrl && event.keyCode == NUIKeyCode::Q) {
+            quantizeSelectedNotes();
+            return true;
+        }
+        if (ctrl && event.keyCode == NUIKeyCode::G) {
+            glueSelectedNotes();
             return true;
         }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1484,10 +1484,10 @@ bool PianoRollNoteLayer::handleNotePropertiesMouse(const NUIMouseEvent& event) {
     }
 
     if (event.released) {
-        if (propDragField_ != -1) {
-            propDragField_ = -1;
-            commitNotes();
-        }
+        // No commitNotes() while the popup is open: it sorts notes_ by start
+        // beat, which would silently retarget propNoteIndex_ after a Start
+        // edit. closeNoteProperties() commits once, on Accept/cancel.
+        propDragField_ = -1;
         return true;
     }
 
@@ -1507,7 +1507,6 @@ bool PianoRollNoteLayer::handleNotePropertiesMouse(const NUIMouseEvent& event) {
             applyNotePropertyDelta(field,
                                    (event.wheelDelta > 0.0f ? 1.0f : -1.0f) * kStepPixels[field],
                                    !(event.modifiers & NUIModifiers::Alt));
-            commitNotes();
         }
         return true;
     }

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1224,14 +1224,43 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         }
     }
 
-    // Floating pitch label while placing or moving a note — read the pitch you
-    // hear, tracking the note and flipping below if it would clip at the top.
-    if ((state_ == State::Painting || state_ == State::Moving) && dragAnchorIndex_ >= 0 &&
-        dragAnchorIndex_ < static_cast<int>(notes_.size()) && !notes_[dragAnchorIndex_].isDeleted) {
+    // Floating edit HUD while placing/moving/resizing a note: read what you're
+    // doing — pitch + bar:beat when moving, length while resizing, pitch + length
+    // while drawing. Tracks the grabbed note and flips below if it clips the top.
+    const bool isEditingNote = (state_ == State::Painting || state_ == State::Moving ||
+                                state_ == State::Resizing || state_ == State::ResizingLeft);
+    if (isEditingNote && dragAnchorIndex_ >= 0 && dragAnchorIndex_ < static_cast<int>(notes_.size()) &&
+        !notes_[dragAnchorIndex_].isDeleted) {
         const auto& an = notes_[dragAnchorIndex_];
+
+        const auto formatLength = [](double beats) {
+            char buf[24];
+            if (std::abs(beats - std::round(beats)) < 0.01)
+                std::snprintf(buf, sizeof(buf), "%d beat%s", static_cast<int>(std::round(beats)),
+                              std::abs(beats - 1.0) < 0.01 ? "" : "s");
+            else
+                std::snprintf(buf, sizeof(buf), "%.2f beats", beats);
+            return std::string(buf);
+        };
+        const auto formatBarBeat = [this](double startBeat) {
+            const int bpb = std::max(1, beatsPerBar_);
+            const double barIndex = std::floor(startBeat / bpb);
+            const double beatInBar = startBeat - barIndex * bpb;
+            char buf[24];
+            std::snprintf(buf, sizeof(buf), "%d:%.2f", static_cast<int>(barIndex) + 1, beatInBar + 1.0);
+            return std::string(buf);
+        };
+
+        std::string label;
+        if (state_ == State::Resizing || state_ == State::ResizingLeft)
+            label = formatLength(an.durationBeats);
+        else if (state_ == State::Moving)
+            label = MusicTheory::getPitchName(an.pitch) + "  " + formatBarBeat(an.startBeat);
+        else // Painting: pitch + the length being dragged out
+            label = MusicTheory::getPitchName(an.pitch) + "  " + formatLength(an.durationBeats);
+
         const float ax = snapRectX(beatToScreenX(an.startBeat, pixelsPerBeat_, scrollX_, b.x));
         const float ay = b.y + (127 - an.pitch) * keyHeight_ - scrollY_;
-        const std::string label = MusicTheory::getPitchName(an.pitch);
         constexpr float kFontSize = 10.0f;
         const auto measured = renderer.measureText(label, kFontSize);
         const float bubbleW = measured.width + 12.0f;
@@ -1616,11 +1645,12 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             dragStartScrollY_ = scrollY_;
             dragStartNotes_ = notes_;
 
+            // Anchor the edit HUD to the grabbed note for move/resize.
+            dragAnchorIndex_ = clickedIndex;
             // Grabbing a note to move it sounds its pitch, and keeps sounding
             // the new pitch as you drag it up/down.
             if (state_ == State::Moving) {
                 moveAnchorPitch_ = notes_[clickedIndex].pitch;
-                dragAnchorIndex_ = clickedIndex;
                 auditionPitch(moveAnchorPitch_);
             }
 
@@ -2971,6 +3001,7 @@ void PianoRollView::setPixelsPerBeat(float ppb) {
 void PianoRollView::setBeatsPerBar(int bpb) {
     if (m_grid) m_grid->setBeatsPerBar(bpb);
     if (m_ruler) m_ruler->setBeatsPerBar(bpb);
+    if (m_notes) m_notes->setBeatsPerBar(bpb);
 }
 
 void PianoRollView::setTool(GlobalTool tool) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1118,12 +1118,23 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
 
         const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
         const bool isHovered = static_cast<int>(noteIndex) == hoveredNoteIndex_;
+        // A note "sounds" while the playhead sits within its span during
+        // playback — it briefly lifts so the ear and eye stay in sync.
+        const bool isSounding = isPlaying_ && playheadBeat_ >= n.startBeat &&
+                                playheadBeat_ < n.startBeat + n.durationBeats;
         const NUIColor baseColor = n.selected ? noteColorSelected : noteColor;
-        const NUIColor coreColor = baseColor.withAlpha(0.68f + normalizedVelocity * 0.28f);
-        const NUIColor edgeColor = n.selected ? NUIColor::white().withAlpha(0.78f)
-                                              : (isHovered ? NUIColor::white().withAlpha(0.38f)
-                                                           : baseColor.lightened(0.16f).withAlpha(0.74f));
+        NUIColor coreColor = baseColor.withAlpha(0.68f + normalizedVelocity * 0.28f);
+        NUIColor edgeColor = n.selected ? NUIColor::white().withAlpha(0.78f)
+                                        : (isHovered ? NUIColor::white().withAlpha(0.38f)
+                                                     : baseColor.lightened(0.16f).withAlpha(0.74f));
+        if (isSounding) {
+            coreColor = baseColor.lightened(0.30f).withAlpha(1.0f);
+            edgeColor = NUIColor::white().withAlpha(0.88f);
+        }
 
+        if (isSounding) {
+            renderer.drawShadow(r, 0.0f, 0.0f, 9.0f, baseColor.withAlpha(0.55f));
+        }
         renderer.drawShadow(NUIRect(r.x, r.y + 1.0f, r.width, r.height),
                             0.0f,
                             2.0f,
@@ -2685,7 +2696,8 @@ void PianoRollView::syncChildren() {
     m_notes->setScrollOffsetY(m_scrollY);
     m_notes->setPlayheadBeat(m_playheadBeat);
     m_notes->setTotalDurationBeats(m_totalDurationBeats);
-    
+    m_notes->setPlaying(m_isPlayingCallback && m_isPlayingCallback());
+
     if (m_controls) {
         m_controls->setPixelsPerBeat(m_pixelsPerBeat);
         m_controls->setScrollX(m_scrollX);

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -691,6 +691,11 @@ void PianoRollToolbar::setupUI() {
         }
         menu->addSubmenu("Strum Selection", strumMenu);
 
+        // --- SHORTCUT CHEAT SHEET ---
+        menu->addItem("Keyboard Shortcuts", [this]() {
+            if (onShowShortcutHelp_) onShowShortcutHelp_();
+        });
+
         auto b = m_menuBtn->getBounds();
         if (auto* parent = getParent()) {
             parent->addChild(m_activeContextMenu);
@@ -2846,6 +2851,10 @@ PianoRollView::PianoRollView()
     m_toolbar->setGrid(m_grid);
     m_toolbar->setNoteLayer(m_notes);
     m_toolbar->setPatternLengthBeats(m_patternLengthBeats);
+    m_toolbar->setOnShowShortcutHelp([this]() {
+        m_showShortcutHelp = !m_showShortcutHelp;
+        repaint();
+    });
 
     m_controls->setNoteLayer(m_notes);
     
@@ -3012,6 +3021,106 @@ void PianoRollView::onRender(NUIRenderer& renderer) {
         }
     }
 
+    if (m_showShortcutHelp) {
+        renderShortcutHelp(renderer);
+    }
+}
+
+void PianoRollView::renderShortcutHelp(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    const auto bounds = getBounds();
+    const float toolbarH = 50.0f;
+    const NUIRect area(bounds.x, bounds.y + toolbarH, bounds.width, bounds.height - toolbarH);
+
+    // Dim the editors underneath so the sheet reads as modal.
+    renderer.fillRect(area, theme.getColor("backgroundPrimary").withAlpha(0.62f));
+
+    struct Entry { const char* keys; const char* action; };
+    static constexpr Entry kMouse[] = {
+        {"Drag", "draw a note, keep dragging for length"},
+        {"Shift+Drag", "paint a run of notes"},
+        {"Ctrl+Drag", "marquee select (any tool)"},
+        {"Alt+Drag", "clone the selection"},
+        {"Alt+Wheel", "adjust velocity under cursor"},
+        {"Right-Click", "erase"},
+        {"Double-Click", "add or remove a note"},
+        {"Velocity Lane", "sweep across to shape levels"},
+    };
+    static constexpr Entry kKeys[] = {
+        {"Q", "quantize note starts"},
+        {"Ctrl+G", "glue same-pitch runs"},
+        {"Ctrl+L", "connect notes (legato)"},
+        {"Ctrl+Z / Y", "undo / redo"},
+        {"Ctrl+C / V / D", "copy / paste / duplicate"},
+        {"Ctrl+A", "select all"},
+        {"Arrows", "nudge / transpose"},
+        {"Shift+Left/Right", "resize by grid"},
+        {"Shift+Up/Down", "octave jump"},
+        {"Delete", "remove selection"},
+    };
+    constexpr size_t kMouseCount = sizeof(kMouse) / sizeof(kMouse[0]);
+    constexpr size_t kKeysCount = sizeof(kKeys) / sizeof(kKeys[0]);
+    constexpr size_t kRows = kMouseCount > kKeysCount ? kMouseCount : kKeysCount;
+
+    const float rowH = 19.0f;
+    const float padX = 24.0f;
+    const float padY = 18.0f;
+    const float titleH = 18.0f;
+    const float sectionH = 16.0f;
+    const float footerH = 14.0f;
+    const float colGap = 28.0f;
+    const float keyColW = 118.0f;
+    const float panelW = std::min(660.0f, area.width - 32.0f);
+    const float panelH = padY + titleH + 12.0f + sectionH + kRows * rowH + 14.0f + footerH + padY;
+    const NUIRect panel(area.x + (area.width - panelW) * 0.5f,
+                        area.y + std::max(8.0f, (area.height - panelH) * 0.5f),
+                        panelW,
+                        panelH);
+
+    renderer.drawShadow(panel, 0.0f, 6.0f, 26.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.45f));
+    renderer.fillRoundedRect(panel, 10.0f, theme.getColor("backgroundSecondary").withAlpha(0.98f));
+    renderer.strokeRoundedRect(panel, 10.0f, 1.0f, theme.getColor("border").withAlpha(0.7f));
+
+    const auto accent = theme.getColor("accentPrimary");
+    const auto keyColor = theme.getColor("textPrimary").withAlpha(0.95f);
+    const auto actionColor = theme.getColor("textSecondary").withAlpha(0.92f);
+
+    float y = panel.y + padY;
+    const char* title = "PIANO ROLL SHORTCUTS";
+    const auto titleSize = renderer.measureText(title, 11.0f);
+    renderer.drawText(title,
+                      NUIPoint(panel.x + (panel.width - titleSize.width) * 0.5f, y),
+                      11.0f,
+                      accent.withAlpha(0.95f));
+    y += titleH + 12.0f;
+
+    const float colW = (panelW - padX * 2.0f - colGap) * 0.5f;
+    const float leftX = panel.x + padX;
+    const float rightX = leftX + colW + colGap;
+
+    renderer.drawText("MOUSE", NUIPoint(leftX, y), 9.0f, actionColor.withAlpha(0.6f));
+    renderer.drawText("KEYS", NUIPoint(rightX, y), 9.0f, actionColor.withAlpha(0.6f));
+    y += sectionH;
+
+    for (size_t i = 0; i < kRows; ++i) {
+        const float rowY = y + i * rowH;
+        if (i < kMouseCount) {
+            renderer.drawText(kMouse[i].keys, NUIPoint(leftX, rowY), 10.5f, keyColor);
+            renderer.drawText(kMouse[i].action, NUIPoint(leftX + keyColW, rowY), 10.5f, actionColor);
+        }
+        if (i < kKeysCount) {
+            renderer.drawText(kKeys[i].keys, NUIPoint(rightX, rowY), 10.5f, keyColor);
+            renderer.drawText(kKeys[i].action, NUIPoint(rightX + keyColW, rowY), 10.5f, actionColor);
+        }
+    }
+    y += kRows * rowH + 14.0f;
+
+    const char* footer = "Chord & Strum live in the toolbar menu. F1 toggles this sheet; any key or click closes it.";
+    const auto footerSize = renderer.measureText(footer, 9.5f);
+    renderer.drawText(footer,
+                      NUIPoint(panel.x + (panel.width - footerSize.width) * 0.5f, y),
+                      9.5f,
+                      actionColor.withAlpha(0.7f));
 }
 
 void PianoRollView::onResize(int width, int height) {
@@ -3164,6 +3273,16 @@ void PianoRollView::syncChildren() {
 bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
     if (!getBounds().contains(event.position) && !m_isResizingPanel) return false;
 
+    // The shortcut sheet captures the pointer: any click or scroll dismisses it
+    // instead of reaching the editors underneath.
+    if (m_showShortcutHelp) {
+        if (event.pressed || event.wheelDelta != 0.0f) {
+            m_showShortcutHelp = false;
+            repaint();
+        }
+        return true;
+    }
+
     if (m_toolbar) {
         if (auto menu = m_toolbar->getActiveContextMenu(); menu && menu->isVisible()) {
             if (menu->onMouseEvent(event)) return true;
@@ -3248,6 +3367,18 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
 }
 
 bool PianoRollView::onKeyEvent(const NUIKeyEvent& event) {
+    if (event.pressed && event.keyCode == NUIKeyCode::F1) {
+        m_showShortcutHelp = !m_showShortcutHelp;
+        repaint();
+        return true;
+    }
+    if (m_showShortcutHelp && event.pressed) {
+        // While the sheet is up, any key dismisses it rather than editing the
+        // notes it covers.
+        m_showShortcutHelp = false;
+        repaint();
+        return true;
+    }
     if (m_notes->onKeyEvent(event)) return true;
     return NUIComponent::onKeyEvent(event);
 }

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -667,6 +667,19 @@ void PianoRollToolbar::setupUI() {
             }
         });
 
+        // --- STRUM SUBMENU (staggers the selected chord low → high) ---
+        auto strumMenu = std::make_shared<NUIContextMenu>();
+        const struct { const char* name; double beats; } kStrumSpreads[] = {
+            {"Tight (1/64)", 0.0625}, {"1/32", 0.125}, {"1/16", 0.25}, {"Wide (1/8)", 0.5},
+        };
+        for (const auto& spread : kStrumSpreads) {
+            const double beats = spread.beats;
+            strumMenu->addItem(spread.name, [this, beats]() {
+                if (auto n = notes_.lock()) n->strumSelectedNotes(beats);
+            });
+        }
+        menu->addSubmenu("Strum Selection", strumMenu);
+
         auto b = m_menuBtn->getBounds();
         if (auto* parent = getParent()) {
             parent->addChild(m_activeContextMenu);
@@ -1092,6 +1105,29 @@ void PianoRollNoteLayer::auditionStop() {
     // The one-shot voice releases itself; just clear the guard so the next
     // placement or pitch-drag can audition again, even on the same pitch.
     auditionPitch_ = -1;
+}
+
+void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
+    std::vector<int> selected;
+    for (size_t i = 0; i < notes_.size(); ++i) {
+        if (notes_[i].selected && !notes_[i].isDeleted) selected.push_back(static_cast<int>(i));
+    }
+    if (selected.size() < 2) return;
+
+    // Anchor at the earliest selected start so the strum begins where the chord
+    // sits, then cascade low pitch → high pitch.
+    double baseStart = std::numeric_limits<double>::max();
+    for (int i : selected) baseStart = std::min(baseStart, notes_[i].startBeat);
+    std::sort(selected.begin(), selected.end(),
+              [&](int a, int b) { return notes_[a].pitch < notes_[b].pitch; });
+
+    auto oldNotes = notes_;
+    for (size_t k = 0; k < selected.size(); ++k) {
+        notes_[selected[k]].startBeat = std::max(0.0, baseStart + static_cast<double>(k) * spreadBeats);
+    }
+    pushUndo("Strum", oldNotes, notes_);
+    commitNotes();
+    repaint();
 }
 
 void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip> // For string formatting
+#include <random>  // Humanize velocity jitter
 
 namespace AestraUI {
 
@@ -691,6 +692,11 @@ void PianoRollToolbar::setupUI() {
         }
         menu->addSubmenu("Strum Selection", strumMenu);
 
+        // --- HUMANIZE ---
+        menu->addItem("Humanize Velocity", [this]() {
+            if (auto n = notes_.lock()) n->humanizeSelectedVelocities();
+        });
+
         // --- SHORTCUT CHEAT SHEET ---
         menu->addItem("Keyboard Shortcuts", [this]() {
             if (onShowShortcutHelp_) onShowShortcutHelp_();
@@ -1073,6 +1079,7 @@ PianoRollNoteLayer::PianoRollNoteLayer()
 }
 
 double PianoRollNoteLayer::snapToGrid(double beat) {
+    if (fineDrag_) return beat; // Alt held mid-drag: free positioning
     if (snap_ == SnapGrid::None) return beat;
     double grid = MusicTheory::getSnapDuration(snap_);
     if (grid <= 0.00001) return beat;
@@ -1309,6 +1316,280 @@ void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
     repaint();
 }
 
+void PianoRollNoteLayer::humanizeSelectedVelocities() {
+    // A gentle ±10 MIDI steps of jitter — enough to break the machine-gun
+    // feel of identical velocities without mangling drawn dynamics.
+    static std::mt19937 rng{std::random_device{}()};
+    std::uniform_real_distribution<float> jitter(-0.08f, 0.08f);
+
+    auto oldNotes = notes_;
+    bool changed = false;
+    for (auto& n : notes_) {
+        if (n.selected && !n.isDeleted) {
+            n.velocity = std::clamp(n.velocity + jitter(rng), 0.05f, 1.0f);
+            changed = true;
+        }
+    }
+    if (!changed) return;
+    pushUndo("Humanize", oldNotes, notes_);
+    commitNotes();
+    repaint();
+}
+
+// --- Note Properties popup -------------------------------------------------
+// Fixed layout shared by the renderer and the hit tests below.
+namespace {
+constexpr float kPropW = 208.0f;
+constexpr float kPropPad = 10.0f;
+constexpr float kPropTitleH = 24.0f;
+constexpr float kPropRowH = 22.0f;
+constexpr int kPropRowCount = 5; // Pitch, Velocity, Pan, Start, Length
+constexpr float kPropFooterH = 28.0f;
+constexpr float kPropH =
+    kPropPad + kPropTitleH + kPropRowCount * kPropRowH + 8.0f + kPropFooterH + kPropPad;
+} // namespace
+
+void PianoRollNoteLayer::openNoteProperties(int noteIndex) {
+    if (noteIndex < 0 || noteIndex >= static_cast<int>(notes_.size()) ||
+        notes_[noteIndex].isDeleted) {
+        return;
+    }
+    propNoteIndex_ = noteIndex;
+    propUndoSnapshot_ = notes_;
+    propOriginalNote_ = notes_[noteIndex];
+    propDragField_ = -1;
+
+    // Sit beside the note, flipped/clamped to stay inside the layer.
+    const auto b = getBounds();
+    const auto& n = notes_[noteIndex];
+    const float nx = b.x + static_cast<float>(n.startBeat * pixelsPerBeat_) - scrollX_;
+    const float ny = b.y + (127 - n.pitch) * keyHeight_ - scrollY_;
+    float px = nx + 26.0f;
+    float py = ny - kPropH - 8.0f;
+    if (py < b.y + 4.0f) py = ny + keyHeight_ + 8.0f;
+    px = std::clamp(px, b.x + 4.0f, std::max(b.x + 4.0f, b.right() - kPropW - 4.0f));
+    py = std::clamp(py, b.y + 4.0f, std::max(b.y + 4.0f, b.bottom() - kPropH - 4.0f));
+    propPanelRect_ = NUIRect(px, py, kPropW, kPropH);
+    repaint();
+}
+
+void PianoRollNoteLayer::closeNoteProperties(bool accept) {
+    if (propNoteIndex_ < 0) return;
+    if (!accept) {
+        notes_ = propUndoSnapshot_;
+    } else if (propNoteIndex_ < static_cast<int>(notes_.size())) {
+        const auto& n = notes_[propNoteIndex_];
+        const auto& o = propOriginalNote_;
+        const bool changed = n.pitch != o.pitch ||
+                             std::abs(n.startBeat - o.startBeat) > 1e-9 ||
+                             std::abs(n.durationBeats - o.durationBeats) > 1e-9 ||
+                             std::abs(n.velocity - o.velocity) > 1e-6f ||
+                             std::abs(n.pan - o.pan) > 1e-6f;
+        if (changed) {
+            pushUndo("Note Properties", propUndoSnapshot_, notes_);
+        }
+    }
+    propNoteIndex_ = -1;
+    propDragField_ = -1;
+    propUndoSnapshot_.clear();
+    commitNotes();
+    repaint();
+}
+
+void PianoRollNoteLayer::applyNotePropertyDelta(int field, float dy, bool coarseStep) {
+    if (propNoteIndex_ < 0 || propNoteIndex_ >= static_cast<int>(notes_.size())) return;
+    auto& n = notes_[propNoteIndex_];
+    const MidiNote& s = propDragStartNote_;
+
+    double timeStep = MusicTheory::getSnapDuration(snap_);
+    if (timeStep <= 0.0) timeStep = 0.25; // SnapGrid::None still steps musically
+    if (!coarseStep) timeStep = 0.01;     // Alt: fine time adjustment
+
+    switch (field) {
+        case 0: { // Pitch — one semitone per few pixels, auditioned as it moves
+            const int np = std::clamp(s.pitch + static_cast<int>(std::lround(dy / 6.0f)), 0, 127);
+            if (np != n.pitch) {
+                n.pitch = np;
+                auditionPitch(np);
+            }
+            break;
+        }
+        case 1: // Velocity
+            n.velocity = std::clamp(s.velocity + dy / 160.0f, 0.0f, 1.0f);
+            break;
+        case 2: // Pan
+            n.pan = std::clamp(s.pan + dy / 90.0f, -1.0f, 1.0f);
+            break;
+        case 3: { // Start time
+            const double steps = std::trunc(dy / 8.0f);
+            n.startBeat = std::max(0.0, s.startBeat + steps * timeStep);
+            break;
+        }
+        case 4: { // Length
+            const double steps = std::trunc(dy / 8.0f);
+            n.durationBeats = std::max(0.125, s.durationBeats + steps * timeStep);
+            break;
+        }
+        default:
+            break;
+    }
+    repaint();
+}
+
+bool PianoRollNoteLayer::handleNotePropertiesMouse(const NUIMouseEvent& event) {
+    if (propNoteIndex_ < 0) return false;
+    if (propNoteIndex_ >= static_cast<int>(notes_.size())) {
+        propNoteIndex_ = -1;
+        return false;
+    }
+
+    const NUIRect& r = propPanelRect_;
+    const float rowsTop = r.y + kPropPad + kPropTitleH;
+    const auto fieldAt = [&](const NUIPoint& p) -> int {
+        if (p.x < r.x + 4.0f || p.x > r.right() - 4.0f) return -1;
+        const int row = static_cast<int>(std::floor((p.y - rowsTop) / kPropRowH));
+        return (row >= 0 && row < kPropRowCount) ? row : -1;
+    };
+
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        if (!r.contains(event.position)) {
+            closeNoteProperties(true); // click-away accepts, like Accept
+            return true;
+        }
+        const float btnY = r.bottom() - kPropPad - 22.0f;
+        const NUIRect resetRect(r.x + kPropPad, btnY, 88.0f, 22.0f);
+        const NUIRect acceptRect(r.right() - kPropPad - 88.0f, btnY, 88.0f, 22.0f);
+        if (resetRect.contains(event.position)) {
+            notes_[propNoteIndex_] = propOriginalNote_;
+            repaint();
+            return true;
+        }
+        if (acceptRect.contains(event.position)) {
+            closeNoteProperties(true);
+            return true;
+        }
+        const int field = fieldAt(event.position);
+        if (field != -1) {
+            propDragField_ = field;
+            propDragStartPos_ = event.position;
+            propDragStartNote_ = notes_[propNoteIndex_];
+        }
+        return true;
+    }
+
+    if (event.released) {
+        if (propDragField_ != -1) {
+            propDragField_ = -1;
+            commitNotes();
+        }
+        return true;
+    }
+
+    if (propDragField_ != -1) {
+        // Row drag: up increases. Alt refines the time fields.
+        const float dy = propDragStartPos_.y - event.position.y;
+        applyNotePropertyDelta(propDragField_, dy, !(event.modifiers & NUIModifiers::Alt));
+        return true;
+    }
+
+    if (event.wheelDelta != 0.0f) {
+        const int field = fieldAt(event.position);
+        if (field != -1) {
+            // One step per notch, expressed as the drag distance of one step.
+            static constexpr float kStepPixels[kPropRowCount] = {6.0f, 4.0f, 4.0f, 8.0f, 8.0f};
+            propDragStartNote_ = notes_[propNoteIndex_];
+            applyNotePropertyDelta(field,
+                                   (event.wheelDelta > 0.0f ? 1.0f : -1.0f) * kStepPixels[field],
+                                   !(event.modifiers & NUIModifiers::Alt));
+            commitNotes();
+        }
+        return true;
+    }
+
+    return true; // modal: swallow hover/motion so nothing edits underneath
+}
+
+void PianoRollNoteLayer::renderNoteProperties(NUIRenderer& renderer) {
+    if (propNoteIndex_ < 0 || propNoteIndex_ >= static_cast<int>(notes_.size())) return;
+    const auto& n = notes_[propNoteIndex_];
+    auto& theme = NUIThemeManager::getInstance();
+    const NUIRect& r = propPanelRect_;
+
+    renderer.drawShadow(r, 0.0f, 5.0f, 18.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.5f));
+    renderer.fillRoundedRect(r, 8.0f, theme.getColor("backgroundSecondary").withAlpha(0.98f));
+    renderer.strokeRoundedRect(r, 8.0f, 1.0f, theme.getColor("border").withAlpha(0.85f));
+
+    const auto accent = theme.getColor("accentPrimary");
+    const auto labelColor = theme.getColor("textSecondary").withAlpha(0.85f);
+    const auto valueColor = theme.getColor("textPrimary").withAlpha(0.96f);
+
+    const std::string title = "Note Properties - " + MusicTheory::getPitchName(n.pitch);
+    renderer.drawText(title, NUIPoint(r.x + kPropPad + 2.0f, r.y + kPropPad + 2.0f), 10.5f,
+                      accent.withAlpha(0.95f));
+
+    // Row values
+    const int velMidi = static_cast<int>(std::lround(std::clamp(n.velocity, 0.0f, 1.0f) * 127.0f));
+    const int panPct = static_cast<int>(std::lround(std::abs(n.pan) * 100.0f));
+    const std::string panText =
+        panPct == 0 ? "C" : ((n.pan < 0.0f ? "L " : "R ") + std::to_string(panPct));
+    char startBuf[32];
+    {
+        const int bpb = std::max(1, beatsPerBar_);
+        const int bar = static_cast<int>(n.startBeat / bpb) + 1;
+        const double rem = n.startBeat - static_cast<double>((bar - 1) * bpb);
+        const int beat = static_cast<int>(rem) + 1;
+        const int pct = static_cast<int>(std::lround((rem - (beat - 1)) * 100.0));
+        std::snprintf(startBuf, sizeof(startBuf), "%d:%d +%02d", bar, beat, pct);
+    }
+    char lenBuf[24];
+    std::snprintf(lenBuf, sizeof(lenBuf), "%.2f beats", n.durationBeats);
+
+    struct Row {
+        const char* label;
+        std::string value;
+    };
+    const Row rows[kPropRowCount] = {
+        {"Pitch", MusicTheory::getPitchName(n.pitch)},
+        {"Velocity", std::to_string(velMidi)},
+        {"Pan", panText},
+        {"Start", startBuf},
+        {"Length", lenBuf},
+    };
+
+    const float rowsTop = r.y + kPropPad + kPropTitleH;
+    for (int i = 0; i < kPropRowCount; ++i) {
+        const NUIRect rowRect(r.x + 4.0f, rowsTop + i * kPropRowH, r.width - 8.0f, kPropRowH);
+        if (i == propDragField_) {
+            renderer.fillRoundedRect(rowRect, 4.0f, accent.withAlpha(0.16f));
+        }
+        const float textY = rowRect.y + 5.0f;
+        renderer.drawText(rows[i].label, NUIPoint(r.x + kPropPad + 2.0f, textY), 10.0f, labelColor);
+        const auto valDim = renderer.measureText(rows[i].value, 10.0f);
+        renderer.drawText(rows[i].value,
+                          NUIPoint(r.right() - kPropPad - 2.0f - valDim.width, textY), 10.0f,
+                          i == propDragField_ ? accent.withAlpha(0.98f) : valueColor);
+    }
+
+    // Footer buttons
+    const float btnY = r.bottom() - kPropPad - 22.0f;
+    const NUIRect resetRect(r.x + kPropPad, btnY, 88.0f, 22.0f);
+    const NUIRect acceptRect(r.right() - kPropPad - 88.0f, btnY, 88.0f, 22.0f);
+    renderer.fillRoundedRect(resetRect, 5.0f, theme.getColor("surfaceRaised").withAlpha(0.9f));
+    renderer.strokeRoundedRect(resetRect, 5.0f, 1.0f, theme.getColor("border").withAlpha(0.7f));
+    renderer.fillRoundedRect(acceptRect, 5.0f, accent.withAlpha(0.28f));
+    renderer.strokeRoundedRect(acceptRect, 5.0f, 1.0f, accent.withAlpha(0.8f));
+    const auto resetDim = renderer.measureText("Reset", 10.0f);
+    renderer.drawText("Reset",
+                      NUIPoint(resetRect.x + (resetRect.width - resetDim.width) * 0.5f,
+                               resetRect.y + 5.0f),
+                      10.0f, labelColor);
+    const auto acceptDim = renderer.measureText("Accept", 10.0f);
+    renderer.drawText("Accept",
+                      NUIPoint(acceptRect.x + (acceptRect.width - acceptDim.width) * 0.5f,
+                               acceptRect.y + 5.0f),
+                      10.0f, valueColor);
+}
+
 void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
     if (!isVisible()) return;
     auto b = getBounds();
@@ -1527,6 +1808,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         renderer.strokeRoundedRect(selectionRect_, 2.0f, 1.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.55f));
     }
 
+    renderNoteProperties(renderer);
+
     renderer.clearClipRect();
 
     // Cleanup Deleted Notes
@@ -1576,6 +1859,20 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     auto b = getBounds();
     float localX = event.position.x - b.x + scrollX_;
     float localY = event.position.y - b.y + scrollY_;
+
+    // Holding Alt mid-drag bypasses the grid for fine placement. Clone drags
+    // (CopyDragging) are excluded — Alt is what starts them, so it can't
+    // double as the fine toggle there. Recomputed every event so it can never
+    // go stale between gestures.
+    fineDrag_ = (event.modifiers & NUIModifiers::Alt) &&
+                (state_ == State::Painting || state_ == State::Moving ||
+                 state_ == State::Resizing || state_ == State::ResizingLeft);
+
+    // The Note Properties popup is modal within the layer while open.
+    if (propNoteIndex_ >= 0) {
+        return handleNotePropertiesMouse(event);
+    }
+
     const int cursorPitch = std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127);
     if (hoveredPitch_ != cursorPitch) {
         hoveredPitch_ = cursorPitch;
@@ -1630,11 +1927,13 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    // --- ALT + WHEEL OVER A NOTE = VELOCITY ---
-    // Plain / Shift / Ctrl wheel stay bound to scroll+zoom; Alt shapes the
-    // velocity of the note under the cursor (and the whole selection if that
-    // note is part of it), so dynamics can be dialled in without leaving the grid.
-    if (event.wheelDelta != 0.0f && (event.modifiers & NUIModifiers::Alt) && hoveredNoteIndex_ >= 0 &&
+    // --- WHEEL OVER A NOTE = VELOCITY ---
+    // Scrolling over a note shapes its velocity (and the whole selection if
+    // that note is part of it) — no modifier needed, though Alt still works.
+    // Ctrl (zoom) and Shift (h-scroll) keep their bindings, and over empty
+    // space the wheel scrolls the grid as usual.
+    if (event.wheelDelta != 0.0f && !(event.modifiers & NUIModifiers::Ctrl) &&
+        !(event.modifiers & NUIModifiers::Shift) && hoveredNoteIndex_ >= 0 &&
         hoveredNoteIndex_ < static_cast<int>(notes_.size()) && !notes_[hoveredNoteIndex_].isDeleted) {
         auto oldNotes = notes_;
         const float delta = event.wheelDelta * 0.04f; // ~5 MIDI steps per notch
@@ -1692,16 +1991,13 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         setFocused(true); // Gain keyboard focus for shortcuts
         int clickedIndex = findNoteAt(localX, localY);
         
-        // DOUBLE CLICK: Add / Delete
+        // DOUBLE CLICK: note → precision properties popup; empty space → add.
+        // (Deletion stays on right-click / eraser / Delete.)
         if (event.doubleClick) {
-            auto oldNotes = notes_;
             if (clickedIndex != -1) {
-                 // Delete existing note
-                 notes_.erase(notes_.begin() + clickedIndex);
-                 pushUndo("Delete Note", oldNotes, notes_);
-                 commitNotes();
-                 repaint();
+                 openNoteProperties(clickedIndex);
             } else {
+                 auto oldNotes = notes_;
                  // Create New Note
                  double beat = std::max(0.0, static_cast<double>(localX / pixelsPerBeat_));
                  beat = snapToGrid(beat);
@@ -1807,7 +2103,15 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
                 note.animationScale = 1.0f;
                 notes_.push_back(note);
             }
-            auditionPitch(rootPitch);
+            // Sound the whole triad — the engine keeps a small pool of
+            // audition voices, one command per pitch.
+            if (!(isPlayingCallback_ && isPlayingCallback_()) && onPreviewNote_) {
+                const int velocity = static_cast<int>(std::lround(lastNoteVelocity_ * 127.0f));
+                for (int p : buildTriad(rootPitch)) {
+                    onPreviewNote_(p, velocity);
+                }
+                auditionPitch_ = rootPitch;
+            }
             pushUndo("Add Chord", oldNotes, notes_);
             commitNotes();
             repaint();
@@ -2162,7 +2466,21 @@ static std::vector<MidiNote> s_noteClipboard;
 
 bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
     bool ctrl = (event.modifiers & NUIModifiers::Ctrl);
-    
+
+    // Note Properties popup is modal: Enter accepts, Escape cancels, and
+    // everything else is swallowed so shortcuts can't edit the note beneath.
+    if (propNoteIndex_ >= 0 && event.pressed) {
+        if (event.keyCode == NUIKeyCode::Escape) {
+            closeNoteProperties(false);
+            return true;
+        }
+        if (event.keyCode == NUIKeyCode::Enter) {
+            closeNoteProperties(true);
+            return true;
+        }
+        return true;
+    }
+
     if (event.pressed) {
         // Undo / Redo
         if (ctrl && event.keyCode == NUIKeyCode::Z) {
@@ -2605,12 +2923,17 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
     auto layer = noteLayer_.lock();
     if (layer) {
         auto b = getBounds();
-        // Ignore sidebar clicks for velocity (except dragging started inside)
-        // If not dragging and in sidebar, let base handle it (or return true if we want to block)
+        // Sidebar: clicking it flips the lane between velocity and pan.
         if (!isDragging_ && event.position.x < b.x + sidebarW) {
+             if (event.pressed && event.button == NUIMouseButton::Left) {
+                 laneMode_ = (laneMode_ == LaneMode::Velocity) ? LaneMode::Pan : LaneMode::Velocity;
+                 repaint();
+                 return true;
+             }
              return NUIComponent::onMouseEvent(event);
         }
 
+        const bool panMode = laneMode_ == LaneMode::Pan;
         float localX = event.position.x - b.x + scrollX_ - sidebarW;
 
         // Find the note whose velocity stem sits under a given lane-x, preferring
@@ -2636,19 +2959,31 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
         if (event.pressed && event.button == NUIMouseButton::Left) {
             int foundIdx = noteUnderX(localX);
 
+            // Map the cursor height to the lane's value: velocity is unipolar
+            // from the lane floor; pan is bipolar around the centre line
+            // (top = right, bottom = left).
+            const auto laneValueAtY = [&](float y) -> float {
+                const float availH = std::max(1.0f, b.height - 28.0f);
+                const float bottomY = b.bottom() - 8.0f;
+                if (panMode) {
+                    const float centerY = bottomY - availH * 0.5f;
+                    return std::clamp((centerY - y) / std::max(1.0f, availH * 0.5f), -1.0f, 1.0f);
+                }
+                return velocityFromPanelPosition(y, bottomY, availH);
+            };
+
             if (foundIdx != -1) {
                 isDragging_ = true;
                 hoveringNoteIndex_ = foundIdx;
                 dragStartPos_ = event.position;
                 dragUndoSnapshot_ = layer->getNotes(); // baseline for one undo step
 
-                // Set velocity immediately based on click Y (Global)
-                const float availH = std::max(1.0f, b.height - 28.0f);
-                const float bottomY = b.bottom() - 8.0f;
-                const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
+                // Set the value immediately based on click Y (Global)
+                const float newValue = laneValueAtY(event.position.y);
 
                 auto modNotes = layer->getNotes();
-                modNotes[foundIdx].velocity = newVelocity;
+                if (panMode) modNotes[foundIdx].pan = newValue;
+                else modNotes[foundIdx].velocity = newValue;
 
                 // Single Edit Only (Batch removed)
 
@@ -2662,28 +2997,36 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
             if (event.released) {
                  isDragging_ = false;
                  hoveringNoteIndex_ = -1;
-                 // Fold the whole velocity drag into a single undo step.
+                 // Fold the whole lane drag into a single undo step.
                  if (!dragUndoSnapshot_.empty()) {
-                     layer->pushExternalEdit(dragUndoSnapshot_, "Velocity");
+                     layer->pushExternalEdit(dragUndoSnapshot_, panMode ? "Pan" : "Velocity");
                      dragUndoSnapshot_.clear();
                  }
                  return true;
             }
 
             // Sweep-paint: as the cursor moves across the lane, the note under it
-            // takes the cursor's height, so dragging draws a velocity ramp/curve.
+            // takes the cursor's height, so dragging draws a ramp/curve.
             // When between stems, keep painting the last note so quick sweeps
             // don't drop out.
             const float availH = std::max(1.0f, b.height - 28.0f);
             const float bottomY = b.bottom() - 8.0f;
-            const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
+            float newValue;
+            if (panMode) {
+                const float centerY = bottomY - availH * 0.5f;
+                newValue = std::clamp((centerY - event.position.y) / std::max(1.0f, availH * 0.5f),
+                                      -1.0f, 1.0f);
+            } else {
+                newValue = velocityFromPanelPosition(event.position.y, bottomY, availH);
+            }
 
             const int swept = noteUnderX(localX);
             if (swept != -1) hoveringNoteIndex_ = swept;
 
             auto modNotes = layer->getNotes();
             if (hoveringNoteIndex_ >= 0 && static_cast<size_t>(hoveringNoteIndex_) < modNotes.size()) {
-                 modNotes[hoveringNoteIndex_].velocity = newVelocity;
+                 if (panMode) modNotes[hoveringNoteIndex_].pan = newValue;
+                 else modNotes[hoveringNoteIndex_].velocity = newValue;
                  layer->setNotes(modNotes);
                  repaint();
             }
@@ -2713,15 +3056,26 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
                       1.0f,
                       border);
 
+    // Stacked mode tabs — the active lane reads accent, the other dim; a click
+    // anywhere on the sidebar swaps them (handled in onMouseEvent).
+    const bool panMode = laneMode_ == LaneMode::Pan;
     const float labelSize = themeManager.getFontSize("xs");
-    const auto textDim = renderer.measureText("VELOCITY", labelSize);
+    const auto activeColor = themeManager.getColor("accentPrimary").withAlpha(0.95f);
+    const auto inactiveColor = themeManager.getColor("textSecondary").withAlpha(0.42f);
+    const auto velDim = renderer.measureText("VELOCITY", labelSize);
     renderer.drawText("VELOCITY",
-                      NUIPoint(b.x + (sidebarW - textDim.width) * 0.5f, b.y + 13.0f),
+                      NUIPoint(b.x + (sidebarW - velDim.width) * 0.5f, b.y + 13.0f),
                       labelSize,
-                      themeManager.getColor("textPrimary").withAlpha(0.78f));
-    const auto rangeDim = renderer.measureText("MIDI 0 - 127", 8.0f);
-    renderer.drawText("MIDI 0 - 127",
-                      NUIPoint(b.x + (sidebarW - rangeDim.width) * 0.5f, b.y + 31.0f),
+                      panMode ? inactiveColor : activeColor);
+    const auto panDim = renderer.measureText("PAN", labelSize);
+    renderer.drawText("PAN",
+                      NUIPoint(b.x + (sidebarW - panDim.width) * 0.5f, b.y + 31.0f),
+                      labelSize,
+                      panMode ? activeColor : inactiveColor);
+    const char* rangeText = panMode ? "L - C - R" : "MIDI 0 - 127";
+    const auto rangeDim = renderer.measureText(rangeText, 8.0f);
+    renderer.drawText(rangeText,
+                      NUIPoint(b.x + (sidebarW - rangeDim.width) * 0.5f, b.y + 49.0f),
                       8.0f,
                       themeManager.getColor("textSecondary").withAlpha(0.48f));
     
@@ -2760,28 +3114,45 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
                           themeManager.getColor("accentPrimary").withAlpha(0.58f));
     }
     
-    // 2. Render velocity stems using MidiNote's normalized 0..1 representation.
+    // 2. Render the lane stems: velocity rises from the floor; pan hangs off
+    //    the centre line (up = right, down = left).
     const auto& notes = layer->getNotes();
     auto velColorBase = themeManager.getColor("accentPrimary").lightened(0.05f);
+    const float centerY = bottomY - availH * 0.5f;
 
     for (size_t noteIndex = 0; noteIndex < notes.size(); ++noteIndex) {
         const auto& n = notes[noteIndex];
         if (n.isDeleted && n.animationScale < 0.01f) continue;
-        
+
         float x = startX + static_cast<float>(n.startBeat * pixelsPerBeat_) - scrollX_;
-        
+
         // Skip if out of view
         if (x > b.x + b.width) continue;
-        
-        const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
-        float h = velocityToPanelHeight(normalizedVelocity, availH);
-        float y = bottomY - h;
 
-        float alpha = 0.48f + normalizedVelocity * 0.48f;
+        const float normalizedVelocity = std::clamp(n.velocity, 0.0f, 1.0f);
+        float y;
+        float stemTop;
+        float stemH;
+        float intensity; // drives the stem alpha
+        if (panMode) {
+            const float pv = std::clamp(n.pan, -1.0f, 1.0f);
+            y = centerY - pv * availH * 0.5f;
+            stemTop = std::min(y, centerY);
+            stemH = std::max(2.0f, std::abs(y - centerY));
+            intensity = std::abs(pv);
+        } else {
+            const float h = velocityToPanelHeight(normalizedVelocity, availH);
+            y = bottomY - h;
+            stemTop = y;
+            stemH = std::max(2.0f, h);
+            intensity = normalizedVelocity;
+        }
+
+        float alpha = 0.48f + intensity * 0.48f;
         auto col = velColorBase.withAlpha(alpha);
         if (n.selected) col = themeManager.getColor("accentSecondary").withAlpha(0.92f);
 
-        renderer.fillRoundedRect(NUIRect(x - 2.0f, y, 4.0f, std::max(2.0f, h)), 2.0f, col.withAlpha(alpha * 0.78f));
+        renderer.fillRoundedRect(NUIRect(x - 2.0f, stemTop, 4.0f, stemH), 2.0f, col.withAlpha(alpha * 0.78f));
 
         const float handleSize = n.selected ? 7.0f : 6.0f;
         NUIRect handleRect(x - handleSize * 0.5f, y - handleSize * 0.5f, handleSize, handleSize);
@@ -2797,7 +3168,14 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
         }
 
         if (isDragging_ && static_cast<int>(noteIndex) == hoveringNoteIndex_) {
-            const std::string value = std::to_string(static_cast<int>(std::lround(normalizedVelocity * 127.0f)));
+            std::string value;
+            if (panMode) {
+                const int panSteps = static_cast<int>(std::lround(std::abs(n.pan) * 100.0f));
+                if (panSteps == 0) value = "C";
+                else value = (n.pan < 0.0f ? "L " : "R ") + std::to_string(panSteps);
+            } else {
+                value = std::to_string(static_cast<int>(std::lround(normalizedVelocity * 127.0f)));
+            }
             const float fontSize = 9.0f;
             const auto textSize = renderer.measureText(value, fontSize);
             const float bubbleWidth = textSize.width + 10.0f;
@@ -3041,10 +3419,11 @@ void PianoRollView::renderShortcutHelp(NUIRenderer& renderer) {
         {"Shift+Drag", "paint a run of notes"},
         {"Ctrl+Drag", "marquee select (any tool)"},
         {"Alt+Drag", "clone the selection"},
-        {"Alt+Wheel", "adjust velocity under cursor"},
+        {"Alt mid-drag", "bypass snap for fine moves"},
+        {"Wheel on note", "adjust velocity"},
         {"Right-Click", "erase"},
-        {"Double-Click", "add or remove a note"},
-        {"Velocity Lane", "sweep across to shape levels"},
+        {"Double-Click", "add note / note properties"},
+        {"Lane sidebar", "switch velocity / pan lane"},
     };
     static constexpr Entry kKeys[] = {
         {"Q", "quantize note starts"},

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -667,6 +667,17 @@ void PianoRollToolbar::setupUI() {
             }
         });
 
+        // --- CHORD MODE TOGGLE (pencil stamps a diatonic triad) ---
+        bool chordModeActive = false;
+        if (auto n = notes_.lock()) {
+            chordModeActive = n->getChordMode();
+        }
+        menu->addCheckbox("Chord (Triad)", chordModeActive, [this](bool) {
+            if (auto n = notes_.lock()) {
+                n->setChordMode(!n->getChordMode());
+            }
+        });
+
         // --- STRUM SUBMENU (staggers the selected chord low → high) ---
         auto strumMenu = std::make_shared<NUIContextMenu>();
         const struct { const char* name; double beats; } kStrumSpreads[] = {
@@ -1107,6 +1118,33 @@ void PianoRollNoteLayer::auditionStop() {
     auditionPitch_ = -1;
 }
 
+std::vector<int> PianoRollNoteLayer::buildTriad(int rootPitch) const {
+    rootPitch = std::clamp(rootPitch, 0, 127);
+    // No scale context → a plain major triad is the sensible default.
+    if (scaleType_ == ScaleType::Chromatic) {
+        std::vector<int> chord = {rootPitch};
+        if (rootPitch + 4 <= 127) chord.push_back(rootPitch + 4);
+        if (rootPitch + 7 <= 127) chord.push_back(rootPitch + 7);
+        return chord;
+    }
+
+    // Diatonic triad = root + the 2nd and 4th scale tones above it (the third and
+    // fifth), so the chord quality follows the degree the root sits on.
+    std::vector<int> chord = {rootPitch};
+    const int wantDegrees[] = {2, 4};
+    int found = 0;
+    int scaleStepsUp = 0;
+    for (int p = rootPitch + 1; p <= 127 && found < 2; ++p) {
+        if (!MusicTheory::isNoteInScale(p, rootKey_, scaleType_)) continue;
+        ++scaleStepsUp;
+        if (scaleStepsUp == wantDegrees[found]) {
+            chord.push_back(p);
+            ++found;
+        }
+    }
+    return chord;
+}
+
 bool PianoRollNoteLayer::paintBrushAt(float localX, float localY) {
     const double snappedBeat = snapToGrid(std::max(0.0, static_cast<double>(localX) / pixelsPerBeat_));
     const int pitch = snapPitchToScale(std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127));
@@ -1272,15 +1310,20 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
     // Only while the pencil hovers empty space — never over an existing note.
     if (tool_ == GlobalTool::Pencil && state_ == State::None && hoveredNoteIndex_ == -1 &&
         hoveredPitch_ >= 0 && hoverBeat_ >= 0.0) {
-        const int previewPitch = snapPitchToScale(hoveredPitch_);
+        // In chord mode the phantom shows the whole diatonic triad a click stamps.
+        const std::vector<int> previewPitches =
+            chordMode_ ? buildTriad(snapPitchToScale(hoveredPitch_))
+                       : std::vector<int>{snapPitchToScale(hoveredPitch_)};
         const float px = snapRectX(beatToScreenX(hoverBeat_, pixelsPerBeat_, scrollX_, b.x));
-        const float py = b.y + (127 - previewPitch) * keyHeight_ - scrollY_;
         const float pw = std::max(6.0f, std::round(static_cast<float>(lastNoteDuration_ * pixelsPerBeat_)) - 2.0f);
         const float ph = std::max(5.0f, keyHeight_ - 4.0f);
-        if (px + pw >= b.x && px <= b.right() && py + ph >= b.y && py <= b.bottom()) {
-            const NUIRect pr(px + 1.0f, py + 2.0f, pw, ph);
-            renderer.fillRoundedRect(pr, 3.0f, noteColor.withAlpha(0.20f));
-            renderer.strokeRoundedRect(pr, 3.0f, 1.0f, noteColor.lightened(0.16f).withAlpha(0.48f));
+        for (int previewPitch : previewPitches) {
+            const float py = b.y + (127 - previewPitch) * keyHeight_ - scrollY_;
+            if (px + pw >= b.x && px <= b.right() && py + ph >= b.y && py <= b.bottom()) {
+                const NUIRect pr(px + 1.0f, py + 2.0f, pw, ph);
+                renderer.fillRoundedRect(pr, 3.0f, noteColor.withAlpha(0.20f));
+                renderer.strokeRoundedRect(pr, 3.0f, 1.0f, noteColor.lightened(0.16f).withAlpha(0.48f));
+            }
         }
     }
 
@@ -1603,12 +1646,48 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
 
+        // Chord mode: a click stamps the diatonic triad rooted at the cell
+        // (discrete — no drag-to-lengthen; the stamped chord lands selected so
+        // it can be resized or strummed as a unit right after).
+        if (intentToPaint && chordMode_) {
+            auto oldNotes = notes_;
+            if (!(event.modifiers & NUIModifiers::Shift)) {
+                for (auto& note : notes_) note.selected = false;
+            }
+            const double startBeat = snapToGrid(std::max(0.0, static_cast<double>(localX) / pixelsPerBeat_));
+            const int rootPitch = snapPitchToScale(std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127));
+            for (int p : buildTriad(rootPitch)) {
+                bool occupied = false;
+                for (const auto& n : notes_) {
+                    if (!n.isDeleted && n.pitch == p && std::abs(n.startBeat - startBeat) < 0.001) {
+                        occupied = true;
+                        break;
+                    }
+                }
+                if (occupied) continue;
+                MidiNote note;
+                note.pitch = p;
+                note.startBeat = startBeat;
+                note.durationBeats = lastNoteDuration_;
+                note.velocity = lastNoteVelocity_;
+                note.unitId = defaultUnitId_;
+                note.selected = true;
+                note.animationScale = 1.0f;
+                notes_.push_back(note);
+            }
+            auditionPitch(rootPitch);
+            pushUndo("Add Chord", oldNotes, notes_);
+            commitNotes();
+            repaint();
+            return true;
+        }
+
         if (intentToPaint) {
             // --- PAINT NEW NOTE ---
             if (!(event.modifiers & NUIModifiers::Shift)) {
                 for (auto& note : notes_) note.selected = false;
             }
-            
+
             state_ = State::Painting;
             dragStartNotes_ = notes_; 
             

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1169,6 +1169,44 @@ bool PianoRollNoteLayer::paintBrushAt(float localX, float localY) {
     return true;
 }
 
+void PianoRollNoteLayer::connectSelectedNotes() {
+    std::vector<int> selected;
+    for (size_t i = 0; i < notes_.size(); ++i) {
+        if (notes_[i].selected && !notes_[i].isDeleted) selected.push_back(static_cast<int>(i));
+    }
+    if (selected.empty()) return;
+
+    // Grid used for the "nothing follows" fallback.
+    double snapDur = MusicTheory::getSnapDuration(snap_);
+    if (snap_ == SnapGrid::None || snapDur <= 0.0001) snapDur = 1.0; // fall back to one beat
+
+    // Candidate starts to connect against (own start is excluded by the helper's
+    // strict "> start" test, so passing all of them is fine).
+    std::vector<double> starts;
+    starts.reserve(notes_.size());
+    for (const auto& n : notes_) {
+        if (!n.isDeleted) starts.push_back(n.startBeat);
+    }
+
+    auto oldNotes = notes_;
+    bool changed = false;
+    for (int idx : selected) {
+        const double start = notes_[idx].startBeat;
+        const double end = start + notes_[idx].durationBeats;
+        const double newEnd = computeConnectedNoteEnd(start, end, starts, snapDur);
+        if (newEnd > end + 0.0001) {
+            notes_[idx].durationBeats = newEnd - start;
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        pushUndo("Connect", oldNotes, notes_);
+        commitNotes();
+        repaint();
+    }
+}
+
 void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
     std::vector<int> selected;
     for (size_t i = 0; i < notes_.size(); ++i) {
@@ -2040,6 +2078,13 @@ bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
         }
         else if (ctrl && event.keyCode == NUIKeyCode::Y) {
             redo();
+            return true;
+        }
+
+        // Ctrl+L: elongate selected notes to connect to the next note (legato),
+        // or out to the next snap/beat boundary when nothing follows.
+        if (ctrl && event.keyCode == NUIKeyCode::L) {
+            connectSelectedNotes();
             return true;
         }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1651,7 +1651,21 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             }
             return true;
         }
-        
+
+        // Ctrl+drag on empty space = marquee select, in any tool. This is how a
+        // lasso coexists with the pencil (whose plain drag places notes): the
+        // pencil keeps drawing, and Ctrl temporarily borrows a selection box.
+        if (clickedIndex == -1 && (event.modifiers & NUIModifiers::Ctrl)) {
+            state_ = State::SelectingBox;
+            dragStartPos_ = event.position;
+            selectionRect_ = NUIRect(event.position.x, event.position.y, 0, 0);
+            if (!(event.modifiers & NUIModifiers::Shift)) {
+                for (auto& n : notes_) n.selected = false;
+            }
+            repaint();
+            return true;
+        }
+
         // 1. Eraser Tool
         if (tool_ == GlobalTool::Eraser) {
             if (clickedIndex != -1) {
@@ -1670,9 +1684,10 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         
         bool intentToPaint = (tool_ == GlobalTool::Pencil && clickedIndex == -1);
 
-        // Ctrl+pencil on empty space starts a paint-brush stroke: notes are
+        // Shift+pencil on empty space starts a paint-brush stroke: notes are
         // stamped into each snap cell the cursor crosses (see drag handling).
-        if (intentToPaint && (event.modifiers & NUIModifiers::Ctrl)) {
+        // (Ctrl is reserved for the marquee, so the brush lives on Shift.)
+        if (intentToPaint && (event.modifiers & NUIModifiers::Shift)) {
             for (auto& note : notes_) note.selected = false;
             state_ = State::BrushPainting;
             dragStartNotes_ = notes_; // snapshot for a single-stroke undo
@@ -2254,14 +2269,16 @@ bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
                     auto oldNotes = notes_;
                     for (auto& n : notes_) {
                         if (n.selected && !n.isDeleted) {
-                            if (snapToScale_ && scaleType_ != ScaleType::Chromatic) {
+                            if (shift) {
+                                n.pitch = std::min(127, n.pitch + 12); // whole octave
+                            } else if (snapToScale_ && scaleType_ != ScaleType::Chromatic) {
                                 n.pitch = MusicTheory::nextPitchInScale(n.pitch, rootKey_, scaleType_);
                             } else {
                                 n.pitch = std::min(127, n.pitch + 1);
                             }
                         }
                     }
-                    pushUndo("Transpose Up", oldNotes, notes_);
+                    pushUndo(shift ? "Octave Up" : "Transpose Up", oldNotes, notes_);
                     commitNotes();
                     repaint();
                     return true;
@@ -2270,14 +2287,16 @@ bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
                     auto oldNotes = notes_;
                     for (auto& n : notes_) {
                         if (n.selected && !n.isDeleted) {
-                            if (snapToScale_ && scaleType_ != ScaleType::Chromatic) {
+                            if (shift) {
+                                n.pitch = std::max(0, n.pitch - 12); // whole octave
+                            } else if (snapToScale_ && scaleType_ != ScaleType::Chromatic) {
                                 n.pitch = MusicTheory::previousPitchInScale(n.pitch, rootKey_, scaleType_);
                             } else {
                                 n.pitch = std::max(0, n.pitch - 1);
                             }
                         }
                     }
-                    pushUndo("Transpose Down", oldNotes, notes_);
+                    pushUndo(shift ? "Octave Down" : "Transpose Down", oldNotes, notes_);
                     commitNotes();
                     repaint();
                     return true;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -1107,6 +1107,30 @@ void PianoRollNoteLayer::auditionStop() {
     auditionPitch_ = -1;
 }
 
+bool PianoRollNoteLayer::paintBrushAt(float localX, float localY) {
+    const double snappedBeat = snapToGrid(std::max(0.0, static_cast<double>(localX) / pixelsPerBeat_));
+    const int pitch = snapPitchToScale(std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127));
+
+    // One note per cell: skip if a note already starts on this pitch+beat so a
+    // jittery drag doesn't stack duplicates.
+    for (const auto& n : notes_) {
+        if (n.isDeleted) continue;
+        if (n.pitch == pitch && std::abs(n.startBeat - snappedBeat) < 0.001) return false;
+    }
+
+    MidiNote note;
+    note.pitch = pitch;
+    note.startBeat = snappedBeat;
+    note.durationBeats = lastNoteDuration_;
+    note.velocity = lastNoteVelocity_;
+    note.unitId = defaultUnitId_;
+    note.selected = true; // the whole stroke ends up selected
+    note.animationScale = 1.0f;
+    notes_.push_back(note);
+    auditionPitch(pitch);
+    return true;
+}
+
 void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
     std::vector<int> selected;
     for (size_t i = 0; i < notes_.size(); ++i) {
@@ -1564,7 +1588,21 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         // User Request: "Pen... placing notes moving notes... place but not extend or move" -> Enable Move/Resize in Pen mode.
         
         bool intentToPaint = (tool_ == GlobalTool::Pencil && clickedIndex == -1);
-        
+
+        // Ctrl+pencil on empty space starts a paint-brush stroke: notes are
+        // stamped into each snap cell the cursor crosses (see drag handling).
+        if (intentToPaint && (event.modifiers & NUIModifiers::Ctrl)) {
+            for (auto& note : notes_) note.selected = false;
+            state_ = State::BrushPainting;
+            dragStartNotes_ = notes_; // snapshot for a single-stroke undo
+            dragStartPos_ = event.position;
+            dragStartScrollX_ = scrollX_;
+            dragStartScrollY_ = scrollY_;
+            paintBrushAt(localX, localY);
+            repaint();
+            return true;
+        }
+
         if (intentToPaint) {
             // --- PAINT NEW NOTE ---
             if (!(event.modifiers & NUIModifiers::Shift)) {
@@ -1759,11 +1797,17 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
         
+        if (state_ == State::BrushPainting) {
+            // Stamp a note in whatever snap cell the cursor is over now.
+            if (paintBrushAt(localX, localY)) repaint();
+            return true;
+        }
+
         if (state_ == State::Painting && paintingNoteIndex_ != -1) {
             float dx = (event.position.x - dragStartPos_.x) + (scrollX_ - dragStartScrollX_);
             double beatDelta = dx / pixelsPerBeat_;
-            
-            double newDur = lastNoteDuration_ + beatDelta; 
+
+            double newDur = lastNoteDuration_ + beatDelta;
             newDur = std::max(0.125, snapToGrid(newDur));
             
             notes_[paintingNoteIndex_].durationBeats = newDur;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -2607,59 +2607,45 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
         }
 
         float localX = event.position.x - b.x + scrollX_ - sidebarW;
-        
-        if (event.pressed && event.button == NUIMouseButton::Left) {
-            float minDist = 10.0f; // Pixel threshold
-            int foundIdx = -1;
-            
+
+        // Find the note whose velocity stem sits under a given lane-x, preferring
+        // a selected one. Shared by the initial press and the sweep-drag below.
+        auto noteUnderX = [&](float lx) -> int {
             const auto& notes = layer->getNotes();
-            std::vector<int> candidates;
+            int found = -1;
             for (int i = 0; i < static_cast<int>(notes.size()); ++i) {
                 if (notes[i].isDeleted) continue;
-                
                 float nStart = static_cast<float>(notes[i].startBeat * pixelsPerBeat_);
                 float nEnd = static_cast<float>((notes[i].startBeat + notes[i].durationBeats) * pixelsPerBeat_);
-                float minW = 6.0f; // Lollipop head radius
-                if (nEnd < nStart + minW) nEnd = nStart + minW; 
-                
-                // Hit Test: Head (Start) OR Body (Length Line)
-                // Relaxed tolerance for Head
-                bool hitHead = std::abs(nStart - localX) < 10.0f;
-                bool hitBody = (localX >= nStart - 2.0f && localX <= nEnd + 2.0f);
-                
+                if (nEnd < nStart + 6.0f) nEnd = nStart + 6.0f; // lollipop head radius
+                const bool hitHead = std::abs(nStart - lx) < 10.0f;
+                const bool hitBody = (lx >= nStart - 2.0f && lx <= nEnd + 2.0f);
                 if (hitHead || hitBody) {
-                    candidates.push_back(i);
+                    found = i; // last (topmost) wins by default
+                    if (notes[i].selected) return i; // but a selected note takes priority
                 }
             }
-            
-            if (!candidates.empty()) {
-                // Default heuristic: Last one (usually rendered last = on top)
-                foundIdx = candidates.back();
-                
-                // Priority: Selected Note
-                for (int idx : candidates) {
-                    if (notes[idx].selected) {
-                        foundIdx = idx;
-                        break;
-                    }
-                }
-            }
-            
+            return found;
+        };
+
+        if (event.pressed && event.button == NUIMouseButton::Left) {
+            int foundIdx = noteUnderX(localX);
+
             if (foundIdx != -1) {
                 isDragging_ = true;
                 hoveringNoteIndex_ = foundIdx;
                 dragStartPos_ = event.position;
-                
+
                 // Set velocity immediately based on click Y (Global)
                 const float availH = std::max(1.0f, b.height - 28.0f);
                 const float bottomY = b.bottom() - 8.0f;
                 const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
-                
-                auto modNotes = notes;
+
+                auto modNotes = layer->getNotes();
                 modNotes[foundIdx].velocity = newVelocity;
-                
+
                 // Single Edit Only (Batch removed)
-                
+
                 layer->setNotes(modNotes);
                 repaint();
                 return true;
@@ -2673,15 +2659,20 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
                  return true;
             }
 
-            // Move
+            // Sweep-paint: as the cursor moves across the lane, the note under it
+            // takes the cursor's height, so dragging draws a velocity ramp/curve.
+            // When between stems, keep painting the last note so quick sweeps
+            // don't drop out.
             const float availH = std::max(1.0f, b.height - 28.0f);
             const float bottomY = b.bottom() - 8.0f;
             const float newVelocity = velocityFromPanelPosition(event.position.y, bottomY, availH);
-            
+
+            const int swept = noteUnderX(localX);
+            if (swept != -1) hoveringNoteIndex_ = swept;
+
             auto modNotes = layer->getNotes();
             if (hoveringNoteIndex_ >= 0 && static_cast<size_t>(hoveringNoteIndex_) < modNotes.size()) {
                  modNotes[hoveringNoteIndex_].velocity = newVelocity;
-                 // Single Edit Only (Batch removed)
                  layer->setNotes(modNotes);
                  repaint();
             }

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -2635,6 +2635,7 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
                 isDragging_ = true;
                 hoveringNoteIndex_ = foundIdx;
                 dragStartPos_ = event.position;
+                dragUndoSnapshot_ = layer->getNotes(); // baseline for one undo step
 
                 // Set velocity immediately based on click Y (Global)
                 const float availH = std::max(1.0f, b.height - 28.0f);
@@ -2656,6 +2657,11 @@ bool PianoRollControlPanel::onMouseEvent(const NUIMouseEvent& event) {
             if (event.released) {
                  isDragging_ = false;
                  hoveringNoteIndex_ = -1;
+                 // Fold the whole velocity drag into a single undo step.
+                 if (!dragUndoSnapshot_.empty()) {
+                     layer->pushExternalEdit(dragUndoSnapshot_, "Velocity");
+                     dragUndoSnapshot_.clear();
+                 }
                  return true;
             }
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -479,6 +479,12 @@ private:
     // Alt+drag copy state
     std::vector<int> copyDragIndices_;
     NUIPlatformBridge* platformBridge_ = nullptr;
+
+    // Manual double-click detection: the platform layer never populates
+    // NUIMouseEvent::doubleClick, so pair up quick same-spot left presses
+    // ourselves (same approach as UnitRow / UnitNameLabel).
+    long long lastClickTimeMs_ = 0;
+    NUIPoint lastClickPos_;
     
     NUIPoint dragStartPos_;
     float dragStartScrollX_ = 0.0f;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -32,9 +32,13 @@ public:
 
     /** @brief Set the vertical scroll offset applied to the lane. */
     void setScrollOffsetY(float offset);
+    void setHoveredKey(int pitch) { hoveredKey_ = pitch; repaint(); }
 
     /** @brief Set callback for note preview (pitch, velocity). Called when user clicks a key. */
     void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb);
+    void setOnHoveredKeyChanged(std::function<void(int pitch)> cb) {
+        onHoveredKeyChanged_ = std::move(cb);
+    }
 
     /** @brief Set callback to check if transport is playing (suppress preview when playing). */
     void setIsPlayingCallback(std::function<bool()> cb);
@@ -48,6 +52,7 @@ private:
     int hoveredKey_; // -1 if none
     int previewPitch_; // Currently playing preview note (-1 if none)
     std::function<void(int pitch, int velocity)> onPreviewNote_;
+    std::function<void(int pitch)> onHoveredKeyChanged_;
     std::function<bool()> m_isPlayingCallback;
 };
 
@@ -204,6 +209,7 @@ private:
     std::function<void(int barsDelta)> onAdjustPatternLength_;
     std::function<void(int patternValue)> onPatternChoiceSelected_;
     bool m_updatingPatternDropdown = false;
+    SnapGrid m_currentSnap = SnapGrid::Beat;
 
     void closeActiveContextMenu();
     
@@ -235,6 +241,8 @@ public:
     void setScrollOffsetY(float offset);
     /** @brief Set the playhead beat rendered on the grid. */
     void setPlayheadBeat(double beat) { playheadBeat_ = beat; repaint(); }
+    void setTotalDurationBeats(double beats) { totalDurationBeats_ = std::max(0.0, beats); repaint(); }
+    void setHoveredPitch(int pitch) { hoveredPitch_ = pitch; repaint(); }
     
     /** @brief Set the bar signature in beats per bar. */
     void setBeatsPerBar(int bpb) { beatsPerBar_ = bpb; repaint(); }
@@ -254,6 +262,8 @@ private:
     float scrollY_; // Added implementation
     int beatsPerBar_ = 4;
     double playheadBeat_ = 0.0;
+    double totalDurationBeats_ = 8.0;
+    int hoveredPitch_ = -1;
     
     // Scale State
     int rootKey_ = 0; // 0=C, 1=C#, etc.
@@ -351,6 +361,9 @@ public:
 
     /** @brief Set the callback fired whenever notes change. */
     void setOnNotesChanged(std::function<void(const std::vector<MidiNote>&)> cb);
+    void setOnHoveredPitchChanged(std::function<void(int pitch)> cb) {
+        onHoveredPitchChanged_ = std::move(cb);
+    }
     /** @brief Set the default unit assigned to newly created notes. */
     void setDefaultUnitId(uint64_t unitId) { defaultUnitId_ = unitId; }
 
@@ -369,6 +382,7 @@ private:
     double totalDurationBeats_ = 400.0;
     
     std::function<void(const std::vector<MidiNote>&)> onNotesChanged_;
+    std::function<void(int pitch)> onHoveredPitchChanged_;
     uint64_t defaultUnitId_ = 0;
 
     // Tool
@@ -397,6 +411,8 @@ private:
 
     // Smart Cursor hover state
     int hoveredNoteIndex_ = -1;
+    int hoveredPitch_ = -1;
+    double hoverBeat_ = -1.0; // Snapped cursor beat for the draw-mode preview; <0 when idle
     bool hoverOnRightEdge_ = false;
     bool hoverOnLeftEdge_ = false;
 
@@ -550,6 +566,7 @@ private:
     std::function<void(double beat, bool active)> m_onPlayheadScrubbed;
 
     bool m_isResizingPanel = false; // Added for splitter dragging
+    bool m_splitterHovered = false;
     float m_dragStartPanelHeight = 0.0f;
     NUIPoint m_dragStartPos;
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -578,6 +578,8 @@ public:
 
     void setPixelsPerBeat(float ppb);
     void setScrollX(float scrollX);
+    /** @brief Set the bar signature so the lane grid matches the ruler/note grid. */
+    void setBeatsPerBar(int bpb) { beatsPerBar_ = std::max(1, bpb); repaint(); }
 
 private:
     std::weak_ptr<PianoRollNoteLayer> noteLayer_;
@@ -585,6 +587,7 @@ private:
 
     float pixelsPerBeat_;
     float scrollX_;
+    int beatsPerBar_ = 4;
     LaneMode laneMode_ = LaneMode::Velocity; // Toggled by clicking the lane's sidebar
 
     // Interaction

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -415,6 +415,9 @@ public:
     /** @brief Merge overlapping/touching selected notes on the same pitch into one. */
     void glueSelectedNotes();
 
+    /** @brief Add slight random velocity variation to the selected notes. */
+    void humanizeSelectedVelocities();
+
     /** @brief Set the platform bridge for cursor style changes. */
     void setPlatformBridge(NUIPlatformBridge* bridge);
 
@@ -462,6 +465,9 @@ private:
         CopyDragging    // Alt+drag copy of selection
     };
     State state_ = State::None;
+    // Alt held during a move/resize/paint drag: snapToGrid passes through
+    // untouched for fine positioning. Recomputed on every mouse event.
+    bool fineDrag_ = false;
 
     // Smart Cursor hover state
     int hoveredNoteIndex_ = -1;
@@ -492,6 +498,23 @@ private:
     // Note whose velocity was last nudged by Alt+wheel — shows a value bubble
     // while the cursor stays on it, cleared when the hover moves away.
     int velocityBubbleIndex_ = -1;
+
+    // Note Properties popup (double-click a note). While open it captures
+    // pointer + keys; rows drag (or wheel) to adjust, Reset restores the
+    // opening values, Accept/outside-click commits one undo step, Escape cancels.
+    int propNoteIndex_ = -1;        // notes_ index being edited; -1 = closed
+    NUIRect propPanelRect_;         // fixed at open, screen coords
+    std::vector<MidiNote> propUndoSnapshot_; // full notes_ at open (undo baseline)
+    MidiNote propOriginalNote_{};   // target note at open (Reset target)
+    MidiNote propDragStartNote_{};  // target note at row-drag start
+    int propDragField_ = -1;        // row being dragged; -1 = none
+    NUIPoint propDragStartPos_;
+
+    void openNoteProperties(int noteIndex);
+    void closeNoteProperties(bool accept);
+    bool handleNotePropertiesMouse(const NUIMouseEvent& event);
+    void renderNoteProperties(NUIRenderer& renderer);
+    void applyNotePropertyDelta(int field, float dy, bool coarseStep);
     
     // For Select Box
     NUIRect selectionRect_;
@@ -536,29 +559,33 @@ private:
 // -----------------------------------------------------------------------------
 class PianoRollControlPanel : public NUIComponent {
 public:
+    /** @brief Which per-note property the lane draws and edits. */
+    enum class LaneMode : uint8_t { Velocity, Pan };
+
     PianoRollControlPanel();
-    
+
     void onRender(NUIRenderer& renderer) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
-    
+
     void setNoteLayer(std::shared_ptr<PianoRollNoteLayer> layer);
     void setGrid(std::shared_ptr<PianoRollGrid> grid); // Added logic to link Grid
-    
+
     void setPixelsPerBeat(float ppb);
     void setScrollX(float scrollX);
 
 private:
     std::weak_ptr<PianoRollNoteLayer> noteLayer_;
     std::weak_ptr<PianoRollGrid> grid_; // Grid link
-    
+
     float pixelsPerBeat_;
     float scrollX_;
-    
+    LaneMode laneMode_ = LaneMode::Velocity; // Toggled by clicking the lane's sidebar
+
     // Interaction
     int hoveringNoteIndex_ = -1;
     bool isDragging_ = false;
     NUIPoint dragStartPos_;
-    std::vector<MidiNote> dragUndoSnapshot_; // notes at velocity-drag start, for one undo step
+    std::vector<MidiNote> dragUndoSnapshot_; // notes at lane-drag start, for one undo step
 };
 
 // -----------------------------------------------------------------------------

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -426,6 +426,7 @@ private:
     enum class State : uint8_t {
         None,
         Painting,       // Creating a new note (Drag extends duration)
+        BrushPainting,  // Ctrl+pencil drag: lay one note per snap cell crossed
         Moving,         // Moving existing note(s)
         Resizing,       // Resizing existing note(s) (Right edge)
         ResizingLeft,   // Resizing from left edge (moves start, keeps end)
@@ -492,6 +493,10 @@ private:
     // so pitch is audible before commit. Suppressed while the transport plays.
     void auditionPitch(int pitch);
     void auditionStop();
+
+    // Paint-brush: stamp one snapped note at the cursor cell if empty, used for
+    // Ctrl+pencil drag strokes. Returns true if a note was added.
+    bool paintBrushAt(float localX, float localY);
 };
 
 // -----------------------------------------------------------------------------

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -118,12 +118,15 @@ public:
 
     // Callback: delta (wheel), mouseX (local)
     std::function<void(float delta, float mouseX)> onZoomRequested; // ADDED
+    /** @brief Called while the user clicks or drags the ruler playhead. */
+    std::function<void(double beat, bool active)> onPlayheadScrubbed;
 
 private:
     float scrollX_; // REORDERED
     float pixelsPerBeat_; // REORDERED
     int beatsPerBar_;
     double playheadBeat_ = 0.0;
+    bool isScrubbing_ = false;
 };
 
 // -----------------------------------------------------------------------------
@@ -503,6 +506,7 @@ public:
     void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb);
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb);
     void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb);
+    void setOnPlayheadScrubbed(std::function<void(double beat, bool active)> cb);
 
     void setPixelsPerBeat(float ppb);
     void setBeatsPerBar(int bpb);
@@ -528,7 +532,7 @@ private:
 
     float m_keyLaneWidth;
     float m_rulerHeight;
-    float m_controlPanelHeight = 100.0f;
+    float m_controlPanelHeight = 116.0f;
     
     float m_pixelsPerBeat;
     float m_keyHeight;
@@ -543,6 +547,7 @@ private:
     bool m_showLocalMinimap = true;
 
     std::function<bool()> m_isPlayingCallback;
+    std::function<void(double beat, bool active)> m_onPlayheadScrubbed;
 
     bool m_isResizingPanel = false; // Added for splitter dragging
     float m_dragStartPanelHeight = 0.0f;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -401,6 +401,12 @@ public:
      */
     void connectSelectedNotes();
 
+    /** @brief Snap the starts of the selected notes to the current snap grid. */
+    void quantizeSelectedNotes();
+
+    /** @brief Merge overlapping/touching selected notes on the same pitch into one. */
+    void glueSelectedNotes();
+
     /** @brief Set the platform bridge for cursor style changes. */
     void setPlatformBridge(NUIPlatformBridge* bridge);
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -173,6 +173,8 @@ public:
     void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb) {
         onPatternChoiceSelected_ = std::move(cb);
     }
+    /** @brief Set callback fired by the menu's "Keyboard Shortcuts" item. */
+    void setOnShowShortcutHelp(std::function<void()> cb) { onShowShortcutHelp_ = std::move(cb); }
     /** @brief Get the currently open context menu, if any. */
     std::shared_ptr<NUIComponent> getActiveContextMenu() const { return m_activeContextMenu; }
     /** @brief Close and remove the currently open context menu, if any. */
@@ -208,6 +210,7 @@ private:
     std::shared_ptr<NUIComponent> m_activeContextMenu;
     std::function<void(int barsDelta)> onAdjustPatternLength_;
     std::function<void(int patternValue)> onPatternChoiceSelected_;
+    std::function<void()> onShowShortcutHelp_;
     bool m_updatingPatternDropdown = false;
     SnapGrid m_currentSnap = SnapGrid::Beat;
 
@@ -636,6 +639,7 @@ private:
     double m_totalDurationBeats = 400.0;
     double m_patternLengthBeats = 8.0;
     bool m_showLocalMinimap = true;
+    bool m_showShortcutHelp = false;
 
     std::function<bool()> m_isPlayingCallback;
     std::function<void(double beat, bool active)> m_onPlayheadScrubbed;
@@ -648,6 +652,7 @@ private:
     void syncChildren();
     void layoutChildren();
     void updateScrollbars(); // Renamed to updateNavigation?
+    void renderShortcutHelp(NUIRenderer& renderer);
 };
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -359,6 +359,9 @@ public:
     /** @brief Set the current playhead beat used for rendering. */
     void setPlayheadBeat(double beat) { playheadBeat_ = beat; repaint(); }
 
+    /** @brief Set whether transport is playing, so sounding notes can light up. */
+    void setPlaying(bool playing) { isPlaying_ = playing; }
+
     /** @brief Set the callback fired whenever notes change. */
     void setOnNotesChanged(std::function<void(const std::vector<MidiNote>&)> cb);
     void setOnHoveredPitchChanged(std::function<void(int pitch)> cb) {
@@ -380,7 +383,8 @@ private:
     float scrollY_;
     double playheadBeat_ = 0.0;
     double totalDurationBeats_ = 400.0;
-    
+    bool isPlaying_ = false;
+
     std::function<void(const std::vector<MidiNote>&)> onNotesChanged_;
     std::function<void(int pitch)> onHoveredPitchChanged_;
     uint64_t defaultUnitId_ = 0;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -362,6 +362,9 @@ public:
     /** @brief Set whether transport is playing, so sounding notes can light up. */
     void setPlaying(bool playing) { isPlaying_ = playing; }
 
+    /** @brief Set beats-per-bar, used for the bar:beat readout while editing. */
+    void setBeatsPerBar(int bpb) { beatsPerBar_ = std::max(1, bpb); }
+
     /** @brief Set callback used to audition a pitch (velocity 0 = note-off). */
     void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb) {
         onPreviewNote_ = std::move(cb);
@@ -391,6 +394,7 @@ private:
     double playheadBeat_ = 0.0;
     double totalDurationBeats_ = 400.0;
     bool isPlaying_ = false;
+    int beatsPerBar_ = 4;
 
     std::function<void(const std::vector<MidiNote>&)> onNotesChanged_;
     std::function<void(int pitch)> onHoveredPitchChanged_;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -380,6 +380,10 @@ public:
     /** @brief Set the default unit assigned to newly created notes. */
     void setDefaultUnitId(uint64_t unitId) { defaultUnitId_ = unitId; }
 
+    /** @brief Toggle chord mode: the pencil stamps a diatonic triad, not one note. */
+    void setChordMode(bool enabled) { chordMode_ = enabled; }
+    bool getChordMode() const { return chordMode_; }
+
     /**
      * @brief Stagger the selected notes into an upward strum.
      *
@@ -476,6 +480,11 @@ private:
     int rootKey_ = 0;
     ScaleType scaleType_ = ScaleType::Chromatic;
     bool snapToScale_ = false;
+
+    // Chord mode: stamp a diatonic triad (root + scale third + scale fifth).
+    bool chordMode_ = false;
+    /** @brief Build the diatonic triad rooted at @p rootPitch under the current scale. */
+    std::vector<int> buildTriad(int rootPitch) const;
 
     // Edge Scrolling During Drag
     static constexpr float kEdgeThreshold = 50.0f;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -392,6 +392,15 @@ public:
      */
     void strumSelectedNotes(double spreadBeats);
 
+    /**
+     * @brief Elongate selected notes to connect to the following note (legato).
+     *
+     * Each selected note's end is extended forward to meet the start of the next
+     * note in time; when nothing follows, it extends to the next snap/beat
+     * boundary instead. Only ever lengthens — never shortens.
+     */
+    void connectSelectedNotes();
+
     /** @brief Set the platform bridge for cursor style changes. */
     void setPlatformBridge(NUIPlatformBridge* bridge);
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -404,6 +404,11 @@ public:
     /** @brief Snap the starts of the selected notes to the current snap grid. */
     void quantizeSelectedNotes();
 
+    /** @brief Record an undo step for an edit applied externally (e.g. velocity lane). */
+    void pushExternalEdit(const std::vector<MidiNote>& before, const std::string& description) {
+        pushUndo(description, before, notes_);
+    }
+
     /** @brief Merge overlapping/touching selected notes on the same pitch into one. */
     void glueSelectedNotes();
 
@@ -550,6 +555,7 @@ private:
     int hoveringNoteIndex_ = -1;
     bool isDragging_ = false;
     NUIPoint dragStartPos_;
+    std::vector<MidiNote> dragUndoSnapshot_; // notes at velocity-drag start, for one undo step
 };
 
 // -----------------------------------------------------------------------------

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -449,6 +449,9 @@ private:
     int moveAnchorPitch_ = 0;
     // Note being placed/dragged, so a floating pitch label can track it.
     int dragAnchorIndex_ = -1;
+    // Note whose velocity was last nudged by Alt+wheel — shows a value bubble
+    // while the cursor stays on it, cleared when the hover moves away.
+    int velocityBubbleIndex_ = -1;
     
     // For Select Box
     NUIRect selectionRect_;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -380,6 +380,14 @@ public:
     /** @brief Set the default unit assigned to newly created notes. */
     void setDefaultUnitId(uint64_t unitId) { defaultUnitId_ = unitId; }
 
+    /**
+     * @brief Stagger the selected notes into an upward strum.
+     *
+     * Notes are anchored at the earliest selected start and cascaded low-to-high
+     * pitch by @p spreadBeats each. No-op for fewer than two selected notes.
+     */
+    void strumSelectedNotes(double spreadBeats);
+
     /** @brief Set the platform bridge for cursor style changes. */
     void setPlatformBridge(NUIPlatformBridge* bridge);
 

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -362,6 +362,13 @@ public:
     /** @brief Set whether transport is playing, so sounding notes can light up. */
     void setPlaying(bool playing) { isPlaying_ = playing; }
 
+    /** @brief Set callback used to audition a pitch (velocity 0 = note-off). */
+    void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb) {
+        onPreviewNote_ = std::move(cb);
+    }
+    /** @brief Set callback to check if transport is playing (suppresses audition). */
+    void setIsPlayingCallback(std::function<bool()> cb) { isPlayingCallback_ = std::move(cb); }
+
     /** @brief Set the callback fired whenever notes change. */
     void setOnNotesChanged(std::function<void(const std::vector<MidiNote>&)> cb);
     void setOnHoveredPitchChanged(std::function<void(int pitch)> cb) {
@@ -387,6 +394,9 @@ private:
 
     std::function<void(const std::vector<MidiNote>&)> onNotesChanged_;
     std::function<void(int pitch)> onHoveredPitchChanged_;
+    std::function<void(int pitch, int velocity)> onPreviewNote_;
+    std::function<bool()> isPlayingCallback_;
+    int auditionPitch_ = -1; // Pitch currently sounding from edit audition; -1 if none
     uint64_t defaultUnitId_ = 0;
 
     // Tool
@@ -433,6 +443,12 @@ private:
     int paintingNoteIndex_ = -1; // Index in notes_ of the note being painted
     double paintStartBeat_ = 0.0;
     int paintPitch_ = 0;
+
+    // For Moving: pitch of the grabbed note at drag start, so audition can
+    // follow the note under the cursor as it's dragged up and down.
+    int moveAnchorPitch_ = 0;
+    // Note being placed/dragged, so a floating pitch label can track it.
+    int dragAnchorIndex_ = -1;
     
     // For Select Box
     NUIRect selectionRect_;
@@ -456,6 +472,11 @@ private:
     void commitNotes();
     double snapToGrid(double beat);
     int snapPitchToScale(int pitch);
+
+    // Edit audition — play the note under the cursor while placing/dragging it,
+    // so pitch is audible before commit. Suppressed while the transport plays.
+    void auditionPitch(int pitch);
+    void auditionStop();
 };
 
 // -----------------------------------------------------------------------------

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -18,6 +18,7 @@
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Graphics/NUISVGParser.h"
+#include "../AestraUI/Helpers/TimelineGridRenderer.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraUI/Widgets/TrackColorPalette.h"
@@ -1678,155 +1679,16 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 // Draw playlist grid (beat/bar grid)
 void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds) {
     AESTRA_ZONE("TrackUI_Grid");
-    // Get layout dimensions from theme
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const auto& layout = themeManager.getLayoutDimensions();
     const float controlAreaWidth = std::min(layout.trackControlsWidth, bounds.width);
-    
-    // Grid settings - start after control area (robust to narrow widths)
     const float desiredGap = 5.0f;
     const float gridGap = std::min(desiredGap, std::max(0.0f, bounds.width - controlAreaWidth));
     const float gridStartX = bounds.x + controlAreaWidth + gridGap;
-    const float gridWidth = std::max(0.0f, bounds.width - controlAreaWidth - gridGap);
-    const float gridEndX = gridStartX + gridWidth;
+    const float gridEndX = bounds.right();
 
-    if (gridWidth <= 0.0f) {
-        return;
-    }
-
-    // 1. BAR ZEBRA on pure black: odd bars lift to a whisper of grey. With the
-    // gamma-correct cache pipeline this renders at its authored subtlety
-    // (the old "frost" was the double-linearization amplifying it).
-    const float pixelsPerBar = m_pixelsPerBeat * m_beatsPerBar;
-    if (pixelsPerBar <= 0.0f) {
-        return; // degenerate zoom — no grid, and guards the divisions below
-    }
-
-    // ==== FRACTAL GRID (owner direction: self-similar at every zoom) ====
-    // Every level of the hierarchy — half-beats, beats, bars, bars×2^k —
-    // fades purely as a function of its own pixel spacing. Zooming out
-    // dissolves the finest visible level while the next-coarser level takes
-    // its place, so the grid never pops and never collapses into a barcode;
-    // the same pattern just re-emerges one scale up, indefinitely.
-    constexpr float kLevelHidePx = 14.0f; // spacing below this: level invisible
-    constexpr float kLevelFullPx = 28.0f; // spacing at/above this: fully faded in
-    const auto levelFade = [](float spacingPx) {
-        return std::clamp((spacingPx - kLevelHidePx) / (kLevelFullPx - kLevelHidePx), 0.0f, 1.0f);
-    };
-    // One brightness law for every line: a newly-visible level starts at the
-    // sub-line strength and grows toward major strength as it widens.
-    const auto lineAlpha = [&](float spacingPx) {
-        const float strength =
-            0.028f + (0.105f - 0.028f) * std::clamp((spacingPx - kLevelFullPx) / (kLevelFullPx * 3.0f), 0.0f, 1.0f);
-        return strength * levelFade(spacingPx);
-    };
-
-    const int beatsPerBar = std::max(1, m_beatsPerBar);
-    // Coarsest power-of-two bar stride with blocks >= kLevelFullPx. Labeled
-    // ruler bars are always a multiple of this stride (same power-of-two
-    // ladder as TrackManagerUI::renderTimeRuler). The cap is not a zoom
-    // assumption — it only bounds the loop; 2^20 bars per block is far past
-    // any zoom the timeline can reach, so the zebra keeps handing off
-    // upward instead of densifying at extreme zoom-out.
-    int barStride = 1;
-    while ((pixelsPerBar * static_cast<float>(barStride)) < kLevelFullPx && barStride < (1 << 20)) {
-        barStride *= 2;
-    }
-
-    // Zebra: crossfade two adjacent block levels so the coarse alternation
-    // continuously becomes the fine alternation while zooming (and vice
-    // versa) — the big strips turn into the small strips, never snapping.
-    {
-        constexpr float kZebraAlpha = 0.030f;
-        const auto drawZebraLevel = [&](int strideBars, float alpha) {
-            if (alpha <= 0.001f) {
-                return;
-            }
-            const float blockW = pixelsPerBar * static_cast<float>(strideBars);
-            const int startBlock = static_cast<int>(m_timelineScrollOffset / blockW);
-            const int endBlock = static_cast<int>((m_timelineScrollOffset + gridWidth) / blockW) + 1;
-            for (int block = startBlock; block <= endBlock; ++block) {
-                if (block % 2 == 0)
-                    continue;
-                float rectX = gridStartX + (block * blockW) - m_timelineScrollOffset;
-                float rectW = blockW;
-                if (rectX < gridStartX) {
-                    rectW -= (gridStartX - rectX);
-                    rectX = gridStartX;
-                }
-                if (rectX + rectW > gridEndX) {
-                    rectW = gridEndX - rectX;
-                }
-                if (rectW > 0.0f) {
-                    renderer.fillRect(AestraUI::NUIRect(rectX, bounds.y, rectW, bounds.height),
-                                      AestraUI::NUIColor(1.0f, 1.0f, 1.0f, alpha));
-                }
-            }
-        };
-        // fineT: 1 when the fine level is comfortably wide (56px blocks),
-        // 0 just as it would shrink past kLevelFullPx and hand off upward.
-        const float pixelsPerBlock = pixelsPerBar * static_cast<float>(barStride); // in [28, 56)
-        const float fineT = std::clamp((pixelsPerBlock - kLevelFullPx) / kLevelFullPx, 0.0f, 1.0f);
-        drawZebraLevel(barStride, kZebraAlpha * fineT);
-        drawZebraLevel(barStride * 2, kZebraAlpha * (1.0f - fineT));
-    }
-
-    const double startBeat = m_timelineScrollOffset / m_pixelsPerBeat;
-    const double endBeat = startBeat + (gridWidth / m_pixelsPerBeat);
-    const int firstVisibleBar = static_cast<int>(std::floor(startBeat / static_cast<double>(beatsPerBar))) - 1;
-    const int lastVisibleBar = static_cast<int>(std::ceil(endBeat / static_cast<double>(beatsPerBar))) + 1;
-
-    // Inverted grid (owner direction): near-black lanes with grey lines, so
-    // the grid reads as light structure on dark. Line brightness comes from
-    // lineAlpha() so every level obeys the same fractal fade law: a bar line
-    // whose own level (largest power of two dividing its index) is too dense
-    // simply fades out instead of stacking into a barcode.
-    const auto drawGridLine = [&](float x, float alpha) {
-        renderer.drawLine(AestraUI::NUIPoint(x, bounds.y), AestraUI::NUIPoint(x, bounds.y + bounds.height), 1.0f,
-                          AestraUI::NUIColor(1.0f, 1.0f, 1.0f, alpha));
-    };
-    const float beatLineAlpha = lineAlpha(m_pixelsPerBeat);
-    const float halfBeatLineAlpha = lineAlpha(m_pixelsPerBeat * 0.5f);
-
-    for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
-        const float barX = gridStartX + (bar * pixelsPerBar) - m_timelineScrollOffset;
-        if (barX >= gridStartX && barX <= gridEndX) {
-            // Level = largest power of two dividing the bar index (bar 0 is
-            // effectively the coarsest — the timeline origin never fades).
-            int level = 20;
-            if (bar != 0) {
-                level = 0;
-                int b = std::abs(bar);
-                while ((b & 1) == 0 && level < 20) {
-                    b >>= 1;
-                    ++level;
-                }
-            }
-            const float levelSpacing = pixelsPerBar * static_cast<float>(1u << level);
-            const float alpha = lineAlpha(levelSpacing);
-            if (alpha > 0.001f) {
-                drawGridLine(barX, alpha);
-            }
-        }
-
-        // Beats and half-beats are just the next levels down the same law.
-        if (beatLineAlpha > 0.001f) {
-            for (int beat = 1; beat < beatsPerBar; ++beat) {
-                const float beatX = barX + (beat * m_pixelsPerBeat);
-                if (beatX < gridStartX || beatX > gridEndX) continue;
-                drawGridLine(beatX, beatLineAlpha);
-            }
-        }
-
-        if (halfBeatLineAlpha > 0.001f) {
-            const float halfBeatOffset = m_pixelsPerBeat * 0.5f;
-            for (int beat = 0; beat < beatsPerBar; ++beat) {
-                const float subBeatX = barX + (beat * m_pixelsPerBeat) + halfBeatOffset;
-                if (subBeatX < gridStartX || subBeatX > gridEndX) continue;
-                drawGridLine(subBeatX, halfBeatLineAlpha);
-            }
-        }
-    }
+    AestraUI::renderTimelineGrid(
+        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar);
 }
 
 void TrackUIComponent::onMouseEnter() {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2619,7 +2619,9 @@ void AestraContent::startPatternClipPreview(PatternID patternId) {
     }
 
     m_trackManager->preparePatternForArsenal(patternId);
-    m_trackManager->playPatternInArsenal(patternId);
+    // Clip preview intentionally starts from the top; every other play path
+    // resumes from the cued transport position (playPatternInArsenal default).
+    m_trackManager->playPatternInArsenal(patternId, 0.0);
 }
 
 void AestraContent::stopPatternClipPreview(bool restoreTimelineUi) {
@@ -2816,9 +2818,9 @@ void AestraContent::playFromCurrentFocus() {
         }
 
         AESTRA_LOG_DEBUG("[Arsenal] Focus-aware play scheduling pattern " + std::to_string(activePattern.value));
-        // Resume from the cued transport position (e.g. a scrubbed piano-roll
-        // playhead) instead of always rewinding to beat zero.
-        m_trackManager->playPatternInArsenal(activePattern, m_trackManager->getPosition());
+        // Resumes from the cued transport position (e.g. a scrubbed piano-roll
+        // playhead) — playPatternInArsenal's default — not from beat zero.
+        m_trackManager->playPatternInArsenal(activePattern);
         return;
     }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2816,7 +2816,9 @@ void AestraContent::playFromCurrentFocus() {
         }
 
         AESTRA_LOG_DEBUG("[Arsenal] Focus-aware play scheduling pattern " + std::to_string(activePattern.value));
-        m_trackManager->playPatternInArsenal(activePattern);
+        // Resume from the cued transport position (e.g. a scrubbed piano-roll
+        // playhead) instead of always rewinding to beat zero.
+        m_trackManager->playPatternInArsenal(activePattern, m_trackManager->getPosition());
         return;
     }
 

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -744,6 +744,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 nj.set("startBeat", JSON(note.startBeat));
                 nj.set("durationBeats", JSON(note.durationBeats));
                 nj.set("velocity", JSON(static_cast<double>(note.velocity)));
+                nj.set("pan", JSON(static_cast<double>(note.pan)));
                 nj.set("unitId", JSON(static_cast<double>(note.unitId)));
                 nj.set("pitchOffset", JSON(static_cast<double>(note.pitchOffset)));
                 nj.set("gate", JSON(static_cast<double>(note.gate)));
@@ -1477,6 +1478,7 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             note.startBeat = finiteNumberOr(notes[n], "startBeat", 0.0, 0.0, 1000000.0);
                             note.durationBeats = finiteNumberOr(notes[n], "durationBeats", 0.25, 0.0, 1000000.0);
                             note.velocity = static_cast<float>(finiteNumberOr(notes[n], "velocity", 1.0, 0.0, 1.0));
+                            note.pan = static_cast<float>(finiteNumberOr(notes[n], "pan", 0.0, -1.0, 1.0));
                             note.unitId = static_cast<uint64_t>(
                                 finiteNumberOr(notes[n], "unitId", 0.0, 0.0, static_cast<double>(UINT64_MAX)));
                             note.pitchOffset = static_cast<int8_t>(finiteNumberOr(notes[n], "pitchOffset", 0.0, -128.0, 127.0));

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -8,6 +8,7 @@
 #include "Commands/RemoveNoteCommand.h"
 #include "Commands/MoveNoteCommand.h"
 #include "Commands/ResizeNoteCommand.h"
+#include "Commands/UpdateNoteCommand.h"
 #include "Commands/NoteDiff.h"
 #include "Commands/CommandHistory.h"
 #include "../AestraCore/include/AestraLog.h"
@@ -192,6 +193,7 @@ void PianoRollPanel::loadPattern(PatternID patternId) {
             uiNote.startBeat = vn.startBeat;
             uiNote.durationBeats = vn.durationBeats;
             uiNote.velocity = vn.velocity;
+            uiNote.pan = vn.pan;
             uiNote.unitId = vn.unitId;
             uiNote.selected = false;
             uiNote.isDeleted = false;
@@ -256,6 +258,7 @@ void PianoRollPanel::savePattern() {
         backendNote.startBeat = uiNote.startBeat;
         backendNote.durationBeats = uiNote.durationBeats;
         backendNote.velocity = uiNote.velocity;
+        backendNote.pan = uiNote.pan;
         backendNote.unitId = uiNote.unitId != 0 ? uiNote.unitId : m_editingUnitId;
         currentNotes.push_back(backendNote);
     }
@@ -298,6 +301,11 @@ void PianoRollPanel::savePattern() {
                 pm, m_currentPatternId, oldNote, newNote.durationBeats);
             history.pushAndExecute(cmd);
         }
+        for (const auto& [oldNote, newNote] : diff.modified) {
+            auto cmd = std::make_shared<UpdateNoteCommand>(
+                pm, m_currentPatternId, oldNote, newNote.velocity, newNote.pan);
+            history.pushAndExecute(cmd);
+        }
         for (const auto& note : diff.added) {
             auto cmd = std::make_shared<AddNoteCommand>(pm, m_currentPatternId, note);
             history.pushAndExecute(cmd);
@@ -308,7 +316,8 @@ void PianoRollPanel::savePattern() {
                   " (added:" + std::to_string(diff.added.size()) +
                   " removed:" + std::to_string(diff.removed.size()) +
                   " moved:" + std::to_string(diff.moved.size()) +
-                  " resized:" + std::to_string(diff.resized.size()) + ")");
+                  " resized:" + std::to_string(diff.resized.size()) +
+                  " modified:" + std::to_string(diff.modified.size()) + ")");
 
         m_applyingUndoRedo = false;
     }

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -102,6 +102,27 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
             m_audioEngine->commandQueue().push(cmd);
         }
     });
+    m_pianoRoll->setOnPlayheadScrubbed([this](double beat, bool active) {
+        if (!m_trackManager) return;
+
+        m_trackManager->setUserScrubbing(active);
+        double positionSeconds = 0.0;
+        if (m_trackManager->isPatternMode()) {
+            const double bpm = std::max(1.0, m_trackManager->getTimelineClock().getCurrentTempo());
+            positionSeconds = beat * (60.0 / bpm);
+        } else {
+            positionSeconds = m_trackManager->getPlaylistModel().beatToSeconds(beat);
+        }
+        positionSeconds = std::max(0.0, positionSeconds);
+
+        m_trackManager->setPosition(positionSeconds);
+        m_trackManager->setPlayStartPosition(positionSeconds);
+        if (m_audioEngine) {
+            const uint32_t sampleRate = m_audioEngine->getSampleRate();
+            const uint64_t samplePosition = static_cast<uint64_t>(positionSeconds * sampleRate);
+            m_audioEngine->setGlobalSamplePos(samplePosition);
+        }
+    });
 
     // Wire CommandHistory state-changed callback to reload pattern into UI on undo/redo
     if (m_trackManager) {

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -98,7 +98,10 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
             cmd.type = AudioQueueCommandType::AuditionUnit;
             cmd.trackIndex = static_cast<uint32_t>(m_editingUnitId);
             cmd.value1 = static_cast<float>(pitch);
-            cmd.value2 = static_cast<float>(velocity);
+            // The engine expects value2 normalized 0..1 (it scales by 127 and
+            // clamps to [1,127]); raw MIDI velocity here pinned every audition
+            // to full velocity.
+            cmd.value2 = static_cast<float>(velocity) / 127.0f;
             cmd.samplePos = 0;
             m_audioEngine->commandQueue().push(cmd);
         }

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -135,8 +135,8 @@ ScenarioResult runScenario(const std::filesystem::path& tempRoot,
     pattern->lengthBeats = kRenderBeats;
     pattern->payload = MidiPayload{};
     auto& notes = std::get<MidiPayload>(pattern->payload).notes;
-    notes.push_back(MidiNote{60, 0.0, 0.75, 120.0f, unitId});
-    notes.push_back(MidiNote{64, 1.0, 0.75, 110.0f, unitId});
+    notes.push_back(MidiNote{60, 0.0, 0.75, 120.0f, 0.0f, unitId});
+    notes.push_back(MidiNote{64, 1.0, 0.75, 110.0f, 0.0f, unitId});
 
     AudioEngine engine;
     require(engine.initialize(), "AudioEngine initialize failed");
@@ -249,8 +249,8 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     previewPattern->lengthBeats = kRenderBeats;
     previewPattern->payload = MidiPayload{};
     auto& previewNotes = std::get<MidiPayload>(previewPattern->payload).notes;
-    previewNotes.push_back(MidiNote{72, 0.0, 0.75, 120.0f, previewUnitId});
-    previewNotes.push_back(MidiNote{76, 1.0, 0.75, 110.0f, previewUnitId});
+    previewNotes.push_back(MidiNote{72, 0.0, 0.75, 120.0f, 0.0f, previewUnitId});
+    previewNotes.push_back(MidiNote{76, 1.0, 0.75, 110.0f, 0.0f, previewUnitId});
 
     PatternID trackPatternId = patternManager.createPattern();
     auto* trackPattern = patternManager.getPattern(trackPatternId);
@@ -260,8 +260,8 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     trackPattern->lengthBeats = kRenderBeats;
     trackPattern->payload = MidiPayload{};
     auto& trackNotes = std::get<MidiPayload>(trackPattern->payload).notes;
-    trackNotes.push_back(MidiNote{60, 0.0, 0.75, 120.0f, trackUnitId});
-    trackNotes.push_back(MidiNote{64, 1.0, 0.75, 110.0f, trackUnitId});
+    trackNotes.push_back(MidiNote{60, 0.0, 0.75, 120.0f, 0.0f, trackUnitId});
+    trackNotes.push_back(MidiNote{64, 1.0, 0.75, 110.0f, 0.0f, trackUnitId});
 
     AudioEngine engine;
     require(engine.initialize(), "AudioEngine initialize failed in mixed scenario");
@@ -387,7 +387,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
     track0Pat->lengthBeats = kRenderBeats;
     track0Pat->payload = MidiPayload{};
     auto& tn0 = std::get<MidiPayload>(track0Pat->payload).notes;
-    tn0.push_back(MidiNote{72, 0.0, 0.75, 120.0f, track0Unit});
+    tn0.push_back(MidiNote{72, 0.0, 0.75, 120.0f, 0.0f, track0Unit});
 
     AudioEngine engine;
     require(engine.initialize(), "AudioEngine initialize failed in bounce scenario");

--- a/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
+++ b/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
@@ -49,7 +49,7 @@ int main() {
     pattern->lengthBeats = 4.0;
     pattern->payload = MidiPayload{};
     auto& notes = std::get<MidiPayload>(pattern->payload).notes;
-    notes.push_back(MidiNote{pitch, 2.0, 0.5, 1.0f, unitId});
+    notes.push_back(MidiNote{pitch, 2.0, 0.5, 1.0f, 0.0f, unitId});
 
     PatternPlaybackEngine playback(&clock, &patternManager, &unitManager);
     playback.schedulePatternInstance(patternId, 0.0, 1);

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -122,6 +122,32 @@ static void test_negative_box_dimensions() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: velocity editor preserves MidiNote's normalized 0..1 representation
+// ---------------------------------------------------------------------------
+static void test_velocity_panel_normalization() {
+    ASSERT(velocityFromPanelPosition(100.0f, 100.0f, 80.0f) == 0.0f,
+           "velocity at panel floor should be zero");
+    ASSERT(velocityFromPanelPosition(60.0f, 100.0f, 80.0f) == 0.5f,
+           "velocity at panel midpoint should be normalized to 0.5");
+    ASSERT(velocityFromPanelPosition(20.0f, 100.0f, 80.0f) == 1.0f,
+           "velocity at panel ceiling should be one");
+    ASSERT(velocityFromPanelPosition(0.0f, 100.0f, 80.0f) == 1.0f,
+           "velocity above panel should clamp to one");
+    ASSERT(velocityFromPanelPosition(120.0f, 100.0f, 80.0f) == 0.0f,
+           "velocity below panel should clamp to zero");
+
+    ASSERT(velocityToPanelHeight(0.0f, 80.0f) == 0.0f,
+           "zero velocity should render at zero height");
+    ASSERT(velocityToPanelHeight(0.5f, 80.0f) == 40.0f,
+           "normalized midpoint should render at half height");
+    ASSERT(velocityToPanelHeight(1.0f, 80.0f) == 80.0f,
+           "full velocity should render at full height");
+    ASSERT(velocityToPanelHeight(127.0f, 80.0f) == 80.0f,
+           "legacy out-of-range velocity should render safely");
+    PASS("velocity panel uses normalized MidiNote velocities");
+}
+
+// ---------------------------------------------------------------------------
 // Scale Pitch Movement Tests
 // ---------------------------------------------------------------------------
 
@@ -203,6 +229,7 @@ int main() {
     test_marquee_detects_note_inside();
     test_marquee_ignores_deleted();
     test_negative_box_dimensions();
+    test_velocity_panel_normalization();
     test_c_major_in_scale_detection();
     test_a_natural_minor_detection();
     test_chromatic_returns_original();

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -174,6 +174,14 @@ static void test_connect_note_legato() {
     PASS("Ctrl+L connect elongates to the next note or the next grid line");
 }
 
+static void test_quantize_to_grid() {
+    ASSERT(quantizeBeatToGrid(0.24, 0.25) == 0.25, "quantize should snap up to the nearest grid line");
+    ASSERT(quantizeBeatToGrid(0.10, 0.25) == 0.0, "quantize should snap down to the nearest grid line");
+    ASSERT(quantizeBeatToGrid(1.0, 0.5) == 1.0, "quantize should leave on-grid positions untouched");
+    ASSERT(quantizeBeatToGrid(0.30, 0.0) == 0.30, "a zero grid leaves the position unchanged");
+    PASS("Q quantizes note starts to the nearest grid line");
+}
+
 // ---------------------------------------------------------------------------
 // Scale Pitch Movement Tests
 // ---------------------------------------------------------------------------
@@ -259,6 +267,7 @@ int main() {
     test_velocity_panel_normalization();
     test_shared_timeline_grid_density();
     test_connect_note_legato();
+    test_quantize_to_grid();
     test_c_major_in_scale_detection();
     test_a_natural_minor_detection();
     test_chromatic_returns_original();

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -16,14 +16,14 @@ static int testsFailed = 0;
 
 // ---------------------------------------------------------------------------
 // Test: deleted notes are ignored in hit testing
-// MidiNote: pitch, startBeat, durationBeats, velocity, unitId, selected, isDeleted, animationScale
+// MidiNote: pitch, startBeat, durationBeats, velocity, pan, unitId, selected, isDeleted, animationScale
 // ---------------------------------------------------------------------------
 static void test_deleted_notes_ignored() {
     std::vector<MidiNote> notes;
     // Note at pitch 60, beat 0, duration 1 beat
     // Screen position: nx = startBeat * pixelsPerBeat = 0, ny = (127 - pitch) * keyHeight = 67*24 = 1608
-    notes.push_back({60, 0.0, 1.0, 0.8f, 0, false, false, 1.0f}); // active note (selected=false, isDeleted=false)
-    notes.push_back({60, 0.0, 1.0, 0.8f, 0, false, true, 1.0f});  // deleted note (selected=false, isDeleted=true)
+    notes.push_back({60, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f}); // active note (selected=false, isDeleted=false)
+    notes.push_back({60, 0.0, 1.0, 0.8f, 0.0f, 0, false, true, 1.0f});  // deleted note (selected=false, isDeleted=true)
 
     // Search at the position of the active note (nx=0, ny=1608) - should return index 0
     int idx = findNoteAtLocal(notes, 0.0f, 1608.0f, 80.0f, 24.0f);
@@ -36,8 +36,8 @@ static void test_deleted_notes_ignored() {
 // ---------------------------------------------------------------------------
 static void test_topmost_note_returned() {
     std::vector<MidiNote> notes;
-    notes.push_back({60, 0.0, 1.0, 0.8f, 0, false, false, 1.0f}); // bottom note
-    notes.push_back({62, 0.0, 1.0, 0.8f, 0, false, false, 1.0f}); // top note (higher pitch = rendered on top)
+    notes.push_back({60, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f}); // bottom note
+    notes.push_back({62, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f}); // top note (higher pitch = rendered on top)
 
     // Search for note at pitch 62 position - should return index 1
     int idx = findNoteAtLocal(notes, 0.0f, (127 - 62) * 24.0f, 80.0f, 24.0f);
@@ -54,7 +54,7 @@ static void test_topmost_note_returned() {
 // ---------------------------------------------------------------------------
 static void test_no_note_found_outside() {
     std::vector<MidiNote> notes;
-    notes.push_back({60, 0.0, 1.0, 0.8f, 0, false, false, 1.0f});
+    notes.push_back({60, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f});
 
     // Search far to the right (beat 10)
     int idx = findNoteAtLocal(notes, 800.0f, 0.0f, 80.0f, 24.0f);
@@ -70,7 +70,7 @@ static void test_no_note_found_outside() {
 // Test: marquee selection detects note inside box
 // ---------------------------------------------------------------------------
 static void test_marquee_detects_note_inside() {
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, false, false, 1.0f}; // at beat 0, pitch 60
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f}; // at beat 0, pitch 60
 
     // Note screen position: nx=(127-60)*24=1608, ny=0 (startBeat=0)
     // Box from x=0 to x=2000, y=1500 to y=1800 should contain the note
@@ -81,10 +81,10 @@ static void test_marquee_detects_note_inside() {
 
 // ---------------------------------------------------------------------------
 // Test: marquee selection ignores deleted notes
-// MidiNote: pitch, startBeat, durationBeats, velocity, unitId, selected, isDeleted, animationScale
+// MidiNote: pitch, startBeat, durationBeats, velocity, pan, unitId, selected, isDeleted, animationScale
 // ---------------------------------------------------------------------------
 static void test_marquee_ignores_deleted() {
-    MidiNote deletedNote{60, 0.0, 1.0, 0.8f, 0, false, true, 1.0f}; // selected=false, isDeleted=true
+    MidiNote deletedNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, false, true, 1.0f}; // selected=false, isDeleted=true
 
     // The helper function isNoteInSelectionBox doesn't check isDeleted directly,
     // but this test documents expected caller behavior: deleted notes should
@@ -101,7 +101,7 @@ static void test_marquee_ignores_deleted() {
 // Test: negative box dimensions handled
 // ---------------------------------------------------------------------------
 static void test_negative_box_dimensions() {
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, false, false, 1.0f};
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, false, false, 1.0f};
     // Note screen position: nx=0 (startBeat=0, pixelsPerBeat=80), ny=1608 ((127-60)*24), width=80, height=24
 
     // Box clearly outside note's position (note at x=0, box at x=0-100)

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -158,6 +158,22 @@ static void test_shared_timeline_grid_density() {
     PASS("Piano Roll and Track Manager share adaptive grid density");
 }
 
+static void test_connect_note_legato() {
+    // Note at [0,1) with a follower starting at 2 → elongate end to 2 (gap filled).
+    ASSERT(computeConnectedNoteEnd(0.0, 1.0, {0.0, 2.0}, 0.25) == 2.0,
+           "connect should extend the note up to the next note's start");
+    // Already overlapping the next note (next starts before end) → never shorten.
+    ASSERT(computeConnectedNoteEnd(0.0, 3.0, {0.0, 2.0}, 0.25) == 3.0,
+           "connect must never shorten a note that already reaches past the next");
+    // No follower → extend to the next snap boundary beyond the end.
+    ASSERT(computeConnectedNoteEnd(0.0, 1.3, {0.0}, 0.5) == 1.5,
+           "connect should fill out to the next snap line when nothing follows");
+    // No follower, end already on a boundary → advance to the next boundary.
+    ASSERT(computeConnectedNoteEnd(0.0, 2.0, {0.0}, 1.0) == 3.0,
+           "connect should reach the next beat when the end sits on one");
+    PASS("Ctrl+L connect elongates to the next note or the next grid line");
+}
+
 // ---------------------------------------------------------------------------
 // Scale Pitch Movement Tests
 // ---------------------------------------------------------------------------
@@ -242,6 +258,7 @@ int main() {
     test_negative_box_dimensions();
     test_velocity_panel_normalization();
     test_shared_timeline_grid_density();
+    test_connect_note_legato();
     test_c_major_in_scale_detection();
     test_a_natural_minor_detection();
     test_chromatic_returns_original();

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "Helpers/PianoRollInteraction.h"
+#include "Helpers/TimelineGridRenderer.h"
 #include "Common/MusicHelpers.h"
 #include <cassert>
 #include <iostream>
@@ -147,6 +148,16 @@ static void test_velocity_panel_normalization() {
     PASS("velocity panel uses normalized MidiNote velocities");
 }
 
+static void test_shared_timeline_grid_density() {
+    ASSERT(timelineGridLevelFade(10.0f) == 0.0f, "dense grid levels should be hidden");
+    ASSERT(timelineGridLevelFade(21.0f) == 0.5f, "grid levels should crossfade at midpoint");
+    ASSERT(timelineGridLevelFade(32.0f) == 1.0f, "wide grid levels should be fully visible");
+    ASSERT(timelineGridBarStride(80.0f, 4) == 1, "normal zoom should show every bar");
+    ASSERT(timelineGridBarStride(5.0f, 4) == 2, "zoomed-out grid should promote to two-bar blocks");
+    ASSERT(timelineGridBarStride(1.0f, 4) == 8, "extreme zoom should preserve power-of-two hierarchy");
+    PASS("Piano Roll and Track Manager share adaptive grid density");
+}
+
 // ---------------------------------------------------------------------------
 // Scale Pitch Movement Tests
 // ---------------------------------------------------------------------------
@@ -230,6 +241,7 @@ int main() {
     test_marquee_ignores_deleted();
     test_negative_box_dimensions();
     test_velocity_panel_normalization();
+    test_shared_timeline_grid_density();
     test_c_major_in_scale_detection();
     test_a_natural_minor_detection();
     test_chromatic_returns_original();

--- a/Tests/Commands/NoteCommandsTest.cpp
+++ b/Tests/Commands/NoteCommandsTest.cpp
@@ -30,7 +30,7 @@ static int testsFailed = 0;
 void test_add_note_command_execute() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     AddNoteCommand cmd(pm, pid, note);
     cmd.execute();
@@ -44,7 +44,7 @@ void test_add_note_command_execute() {
 void test_add_note_command_undo() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     AddNoteCommand cmd(pm, pid, note);
     cmd.execute();
@@ -60,8 +60,8 @@ void test_add_note_command_undo_disambiguation() {
     // must be independent: adding+removing note2 must NOT accidentally remove note1.
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    MidiNote note1{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
-    MidiNote note2{60, 0.0, 2.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote note1{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
+    MidiNote note2{60, 0.0, 2.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     // Add both notes
     AddNoteCommand cmd1(pm, pid, note1);
@@ -92,7 +92,7 @@ void test_add_note_command_undo_disambiguation() {
 void test_add_note_command_redo() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     AddNoteCommand cmd(pm, pid, note);
     cmd.execute();
@@ -107,7 +107,7 @@ void test_add_note_command_redo() {
 void test_add_note_command_double_execute_noop() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    MidiNote note{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote note{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     AddNoteCommand cmd(pm, pid, note);
     cmd.execute();
@@ -124,7 +124,7 @@ void test_add_note_command_double_execute_noop() {
 void test_remove_note_command_execute() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote toRemove = pat->getMidiNotes()[0];
@@ -139,7 +139,7 @@ void test_remove_note_command_execute() {
 void test_remove_note_command_undo() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote toRemove = pat->getMidiNotes()[0];
@@ -158,7 +158,7 @@ void test_remove_note_command_undo() {
 void test_move_note_command_execute() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote original = pat->getMidiNotes()[0];
@@ -175,7 +175,7 @@ void test_move_note_command_execute() {
 void test_move_note_command_undo() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote original = pat->getMidiNotes()[0];
@@ -196,7 +196,7 @@ void test_move_note_command_undo() {
 void test_resize_note_command_execute() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote original = pat->getMidiNotes()[0];
@@ -212,7 +212,7 @@ void test_resize_note_command_execute() {
 void test_resize_note_command_undo() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
-    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false}).execute();
+    AddNoteCommand(pm, pid, MidiNote{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false}).execute();
 
     auto* pat = pm.getPattern(pid);
     MidiNote original = pat->getMidiNotes()[0];
@@ -291,9 +291,9 @@ void test_overlapping_notes_preserved() {
     PatternManager pm;
     PatternID pid = pm.createMidiPattern("test", 16.0, MidiPayload{});
 
-    MidiNote n1{60, 0.0, 1.0, 0.8f, 0, 0, 1.0f, false};
-    MidiNote n2{60, 2.0, 1.0, 0.8f, 0, 0, 1.0f, false};
-    MidiNote n3{60, 4.0, 1.0, 0.8f, 0, 0, 1.0f, false};
+    MidiNote n1{60, 0.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
+    MidiNote n2{60, 2.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
+    MidiNote n3{60, 4.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false};
 
     AddNoteCommand(pm, pid, n1).execute();
     AddNoteCommand(pm, pid, n2).execute();

--- a/Tests/Commands/NoteDiffTest.cpp
+++ b/Tests/Commands/NoteDiffTest.cpp
@@ -25,7 +25,7 @@ static int testsFailed = 0;
 // ---------------------------------------------------------------------------
 static MidiNote make(int pitch, double start, double dur, float vel = 0.8f,
                      uint64_t unitId = 0) {
-    return MidiNote{pitch, start, dur, vel, unitId, 0, 1.0f, false};
+    return MidiNote{pitch, start, dur, vel, 0.0f, unitId, 0, 1.0f, false};
 }
 
 

--- a/Tests/Headless/RumbleArsenalAudibleTest.cpp
+++ b/Tests/Headless/RumbleArsenalAudibleTest.cpp
@@ -86,8 +86,8 @@ int main() {
     pattern->payload = MidiPayload{};
 
     auto& notes = std::get<MidiPayload>(pattern->payload).notes;
-    notes.push_back(MidiNote{36, 0.0, 0.5, 110.0f, unitId});
-    notes.push_back(MidiNote{38, 1.0, 0.4, 100.0f, unitId});
+    notes.push_back(MidiNote{36, 0.0, 0.5, 110.0f, 0.0f, unitId});
+    notes.push_back(MidiNote{38, 1.0, 0.4, 100.0f, 0.0f, unitId});
 
     AudioEngine engine;
     require(engine.initialize(), "AudioEngine failed to initialize");

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -194,8 +194,8 @@ void testSourcesLanesClipsPatternsRoundTrip() {
 
     auto& patternManager = tm1->getPatternManager();
     Aestra::Audio::MidiPayload payload;
-    payload.notes.push_back({60, 0.0, 1.0, 1.0f, 0, 0, 1.0f, false});
-    payload.notes.push_back({64, 1.0, 1.0, 0.8f, 0, 0, 1.0f, false});
+    payload.notes.push_back({60, 0.0, 1.0, 1.0f, 0.0f, 0, 0, 1.0f, false});
+    payload.notes.push_back({64, 1.0, 1.0, 0.8f, 0.0f, 0, 0, 1.0f, false});
     auto patternId = patternManager.createMidiPattern("Test Pattern", 4.0, payload);
 
     Aestra::Audio::ClipInstance clip;


### PR DESCRIPTION
## Summary

Overhauls the Piano Roll editing experience with a focus on a smooth, predictable draw workflow and a grid that stays legible at any zoom. Builds on the existing tool/undo/snap model — no behavioural regressions to selection, move/resize, eraser, alt-drag copy, or scale snapping.

## What's new

**Placement reads before you commit it**
- **Draw-mode ghost preview** — a translucent phantom of the note a click would create tracks the snapped cursor cell (pitch + last-drawn length). It only shows over empty space with the pencil active and never over an existing note.
- **Cursor crosshair** — hovering a row lights up the matching piano key and the grid lane across the keys, grid, and note layers, so pitch is unambiguous.
- **Live velocity readout** — a `0–127` value bubble follows the cursor while dragging velocity stems.
- **Playback note highlight** — each note briefly lifts (brighter fill, white edge, soft accent glow) while the playhead sits within its span, so the eye tracks what the ear hears. Gated on transport state so a parked playhead never highlights notes at rest.
- **Note audition on edit** — placing a note plays it, and dragging it up/down re-triggers the new pitch, through the same synth path the key lane auditions with. Suppressed while the transport plays (playback owns the audio focus; the note-highlight carries the visual cue). The audition path is a one-shot voice, so it fires once per placement / pitch-step and always re-fires after the transport stops.
- **Edit HUD** — a floating readout tracks the note you're editing: pitch while drawing, pitch + bar:beat while moving, length while resizing (either edge).
- **Alt+wheel velocity** — hold Alt and scroll over a note to shape its velocity (the whole selection if that note is selected), with a `V nn` bubble and a single coalesced undo. Plain / Shift / Ctrl wheel stay bound to scroll + zoom.
- **Strum selection** — a toolbar-menu submenu (Tight 1/64 · 1/32 · 1/16 · Wide 1/8) cascades the selected chord low → high from its earliest start.
- **Ctrl+L connect (legato)** — elongates selected notes to meet the next note in time; with nothing ahead, fills out to the next snap/beat line. Only ever lengthens. Covered by unit tests.
- **Marquee in any tool (Ctrl+drag)** — Ctrl+drag on empty space lassos a selection even while the pencil is active (plain pencil drag still places notes); Ctrl+click on a note still toggles it.
- **Octave transpose (Shift+Up/Down)** — jumps the selection a full octave; plain Up/Down still steps a semitone / scale step.
- **Paint-brush (Shift+pencil drag)** — lays one note per snap cell the cursor crosses; plain pencil drag still extends a single note's length.
- **Chord mode (triad)** — a toolbar-menu toggle; the pencil's ghost preview shows a diatonic triad and a click stamps it (root + scale third/fifth), landing selected so it can be strummed/resized as a unit.
- **Quantize (Q)** — snaps selected note starts to the grid (`quantizeBeatToGrid`, unit-tested).
- **Glue (Ctrl+G)** — merges overlapping/touching selected notes on the same pitch into one — tidies a paint-brush run into held notes.
- **Draw velocities** — dragging across the velocity lane now sweep-paints each note under the cursor, so you can draw a ramp/curve; folded into a single undo step (velocity-lane edits are now undoable at all).
- **Shortcut cheat sheet (F1 / menu)** — all of the above is discoverable in-app: a "Keyboard Shortcuts" item in the toolbar menu (or F1) opens a modal sheet listing the full mouse + key map in two columns. While it's up it captures pointer and keyboard so stray input can't edit the notes underneath; any key, click, or scroll dismisses it.
- **Note Properties popup (double-click a note)** — precision control over one note: Pitch, Velocity, Pan, Start, Length as drag- or wheel-to-adjust rows (Alt refines the time fields), with Reset/Accept, Enter/click-away to accept and Escape to cancel — all folded into one undo step. Deletion moves fully to right-click / eraser / Delete; double-click on empty space still adds a note.
- **Per-note pan, wired end-to-end** — notes carry a pan value that actually reaches the speakers (scheduler → sampler voice, latched at note-on with a unity-centre balance law) and the project file (serialized round-trip). Simultaneous chord tones each keep their own pan.
- **Switchable control lane (velocity / pan)** — clicking the lane's sidebar flips it between VELOCITY (unipolar stems) and PAN (bipolar stems off the centre line, up = right). Sweep-painting, value bubbles and one-step undo work in both modes.
- **Alt+wheel over a note = velocity** (whole selection if that note is selected). Kept behind a modifier so plain wheel always scrolls; Ctrl zooms, Shift h-scrolls.
- **Alt mid-drag = fine positioning** — holding Alt during a move/resize/paint drag bypasses the snap grid (clone drags excluded, since Alt starts those).
- **Humanize Velocity** — menu action that jitters the selection's velocities by ±10 MIDI steps in one undo step, to break machine-gun dynamics.
- **Polyphonic audition** — the engine's edit-audition voice is now a 4-slot pool, so stamping a chord sounds the whole triad instead of just the root.

### More audio fixes
- **Pattern-mode play resumes from the scrubbed playhead.** Scrubbing stored a cue point but every pattern-play path restarted at beat zero (`playPatternInArsenal` hardcoded position 0). The default is now flipped: it resumes from the current transport position like timeline play, across all callers (transport, Arsenal play button, pattern activation); only the clip preview still starts from the top, explicitly. Stop returns to the cue — scrub → play → stop → play repeats from the same spot.
- **Double-clicks now actually exist.** The platform layer never populates `doubleClick` on mouse events (permanently false), so double-click gestures silently never fired. The note layer detects them manually (two left presses within 400ms / 5px, pair consumed) — the same pattern other widgets already use.
- **Velocity-lane edits now actually persist.** `diffNotes` never compared velocity, so velocity-only edits produced an empty diff and were never written to the pattern payload or the project file — audible in the session, silently lost on reload. The diff now emits in-place expression changes and a new `UpdateNoteCommand` applies velocity+pan undoably.

### Audio fix
- **Unit audition survives the global stop.** After the transport stops the master fade settles to `Silent`, whose fast-path early-return zeroed the callback before the piano-roll audition MIDI was injected — so place/drag audition went dead after any stop. The master now wakes out of `Silent` when a unit-audition arrives (mirroring the metronome count-in recovery).

**A grid that holds up at every zoom**
- Extracted a shared `TimelineGridRenderer` so the piano roll grid, velocity lane, and playlist all draw the same power-of-two density + zebra rhythm. Zooming out dissolves the finest visible level as the next-coarser one takes over — it never collapses into a barcode.
- **Redesigned ruler** — adaptive bar stride with labels, a circular playhead marker, and a subtle glow on the playhead during playback.
- **Pattern-end shading** + accent boundary line so out-of-pattern space reads clearly.

**Small workflow niceties**
- Visible velocity-panel **splitter grip** with hover/drag feedback.
- **Snap value indicator** in the toolbar.
- Resize affordances now persist on selected notes; hover intensifies them.

## Tests
- New unit test covers the shared grid's adaptive density (`timelineGridLevelFade` / `timelineGridBarStride`), so the piano roll and Track Manager stay in visual lockstep.
- `PianoRollInteractionTest` green; `AestraUI_Core` compiles clean.

## Notes
Rendering-heavy changes; the ghost preview / crosshair / velocity bubble are visual and best evaluated interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Reworked piano-roll interaction into a smoother, more predictable draw/edit workflow with ghost previews, crosshair highlighting, live velocity/pan feedback, improved snapping/sweep painting, and persistent resize affordances.
- Unified adaptive grid rendering via a shared `TimelineGridRenderer`, keeping zebra rhythm and density consistent across the piano roll, velocity lane, and playlist at all zoom levels.
- Updated ruler/playhead behavior with scrub callbacks, improved playhead presentation/shading (including pattern-end), and tighter synchronization between UI transport and the track timeline.
- Expanded note editing capabilities: chord/triad mode stamping, auditioning during edits (including polyphonic voices), chord placement support, legato/glue/quantize workflows, and an edit HUD with note properties editing.
- Added wheel-based velocity editing and fine Alt-drag positioning, while preserving existing selection/move/resize/eraser/copy/undo/scale-snapping semantics.
- Implemented undoable, persisted expression edits by introducing per-note `pan` across project save/load and handling expression-only diffs as `modified`, backed by a new `UpdateNoteCommand` for velocity/pan changes.
- Fixed playback/audition correctness: Arsenal/unit audition now supports multiple concurrent slots, and pattern playback resumes from the scrubbed cue point across playback paths.
- Refreshed the velocity/pan control lane UI and mapping (normalized conversions with clamping) and updated sampler/polyphonic aftertouch handling to deliver per-note pan to the audio engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

