### PR TITLE
feat(theme): full theme system — live switching, lights-on/lights-out across shell and editors

### DIFF
--- a/AestraDocs/design/Full_Theme_System_Audit_2026-07.md
+++ b/AestraDocs/design/Full_Theme_System_Audit_2026-07.md
@@ -1,0 +1,69 @@
+# Full Theme System Audit — July 2026
+
+## Scope and evidence
+
+This audit follows the UI consistency foundation in PR #517. It inspects the active desktop theme path, JSON loading, preference persistence, settings UI, invalidation, cached styling, and shared controls. The findings come from the current `feature/full-theme-system` tree and the runtime evidence captured by the preceding consistency pass.
+
+## Severity 1 — theme changes are not a live application contract
+
+- Aestra has two independent theme representations. `NUITheme` loads map-based JSON, while rendered application code primarily reads `NUIThemeManager` and `NUIThemeProperties`. No startup path installs a loaded JSON theme into the live manager.
+- `AestraWindowManager::initialize()` always activates `Aestra-dark`, despite `Preferences::theme` being loaded before window creation and serialized on shutdown.
+- Appearance settings always select index zero, expose a nonexistent `Midnight Blue` option, and have no selection handler. Apply and Cancel only clear a local dirty flag.
+- `NUIThemeManager` exposes one replaceable callback. A second interested surface silently disconnects the first, so application-wide invalidation and independent tooling cannot coexist.
+- `NUIThemedComponent` registration is stubbed and unused. No reliable root-to-leaf notification exists.
+- Animated `switchTheme()` interpolates only three legacy colors into a partially default-initialized theme, does not activate the target name, and completes by notifying listeners with the old active theme. This path is unsafe to expose as a theme feature.
+
+Impact: theme files can pass parser tests without affecting the real UI, saved selection is ignored, and a live switch can leave cached and uncached components showing different themes.
+
+## Severity 2 — cached theme values do not reliably refresh
+
+- Mixer widgets, routing views, panel windows, the timeline minimap, and other surfaces cache colors during construction.
+- `NUIIcon::setColorFromTheme()` resolves a token once and forgets the token name, so toolbar and transport icons cannot follow a later theme change.
+- Some shared controls refresh theme colors during render while other controls resolve once. The resulting behavior depends on component implementation rather than a common lifecycle.
+- Theme activation does not explicitly invalidate the root hierarchy. Idle frame elision can therefore leave a correctly changed manager with stale pixels until unrelated interaction occurs.
+
+Impact: switching themes is nondeterministic across major surfaces and can require mouse movement or reconstruction to become visible.
+
+## Severity 2 — JSON defaults and live defaults describe different products
+
+- `NUITheme::createDefault()` retains an older palette, 12 px default radius, 15 px body text, and 28 px title text.
+- `NUIThemeProperties` uses the compact desktop grammar established by the consistency pass: 3–7 px common radii and 9–14 px working typography.
+- Missing JSON fields correctly receive parser defaults, but those defaults are not the defaults used by live controls.
+- JSON accepts arbitrary token names for forward compatibility, but there is no documented mapping of accepted live semantic roles.
+
+Impact: a partial theme file may be internally valid yet produce unexpected geometry if connected directly to the current UI.
+
+## Severity 3 — remaining bypass paths
+
+- A repository scan finds raw color construction in both intentional domain rendering and accidental UI styling. Recording, meters, waveforms, track colors, and plugin response plots are intentional domains; generic panels, labels, borders, and interaction states should use semantic roles.
+- A few legacy widgets still query the per-component `NUITheme` object for font sizes, while the rest of the application uses `NUIThemeManager`.
+- Built-in preset families beyond Aestra and high-contrast are registered in the manager but are not product-facing choices. Exposing every internal compatibility preset would broaden the visual identity rather than complete the Aestra theme system.
+
+## Intentionally preserved distinctions
+
+- Track colors, waveform colors, meter thresholds, recording/armed state, mute, solo, bypass, warning, and error remain separate domain roles.
+- Plugin editors retain their neutral, flat direction and may use domain-specific graph colors where these communicate signal behavior.
+- Major/minor timeline grid contrast and the fractal-grid language remain distinct from ordinary dividers.
+- Dense DAW layouts keep compact metrics; this pass does not inflate rows, headers, or hit areas beyond the established minimums.
+- Existing arbitrary JSON keys remain loadable through `NUITheme` for compatibility, although only documented semantic keys affect the live manager.
+
+## Smallest reliable implementation plan
+
+1. Make `NUIThemeManager` the sole live owner while keeping `NUITheme` as the backward-compatible JSON and per-component adapter.
+2. Add deterministic theme registration/loading with a documented mapping from JSON semantic tokens to `NUIThemeProperties`; missing tokens inherit the selected base preset.
+3. Replace the single-listener limitation with explicit subscriptions while retaining the old callback API as a compatibility slot.
+4. Make theme activation atomic. Until every property has a safe interpolation rule, requested animated switches complete as one atomic change rather than emitting partial themes.
+5. Subscribe the application window once, propagate `onThemeChanged()` through the component tree, refresh cached components/icons, invalidate affected surfaces, and preserve idle rendering behavior.
+6. Wire startup and Appearance settings to `Preferences::theme`, with safe fallback for stale or unknown values and real Apply/Cancel behavior.
+7. Migrate confirmed-live generic styling bypasses, then validate dark, light, and high-contrast themes across the same main-surface runtime loop used for PR #517.
+
+## Performance and safety constraints
+
+- Parsing and registration occur only on user-driven load/reload paths, never during paint, layout, or audio processing.
+- Theme activation performs bounded UI-thread notification and one hierarchy invalidation.
+- Paint paths continue to read cached structs or manager references; no per-frame JSON parsing is introduced.
+- The theme system remains outside real-time audio paths and does not add locks, allocation, logging, or I/O to audio callbacks.
+
+## Muse handoff requirements
+
+The later Muse harness should consume public UI actions and stable observable state rather than component internals. The finalized theme contract should expose deterministic theme selection, active-theme identity, and screenshot-ready invalidation. Muse work remains a separate branch after this theming pass so automation does not become coupled to transitional UI implementation details.

--- a/AestraDocs/design/Theme_System_Contract.md
+++ b/AestraDocs/design/Theme_System_Contract.md
@@ -1,0 +1,87 @@
+# Aestra Theme System Contract
+
+## Live ownership
+
+`NUIThemeManager` is the single live theme owner. Components should read `NUIThemeProperties` or the manager's semantic accessors. `NUITheme` remains the backward-compatible JSON loader and per-component adapter; loading a file does not parse during paint or automatically mutate the application.
+
+Built-in product themes are:
+
+- `Aestra-dark`
+- `Aestra-light`
+- `high-contrast-dark`
+
+The manager retains lower-case and older internal preset names for compatibility. Product settings should expose only supported Aestra choices.
+
+## Activation and updates
+
+- `setActiveTheme(name)` returns `false` for an unknown name and leaves the current theme unchanged.
+- `switchTheme(name, duration)` currently performs the same atomic activation. A partial transition is deliberately not emitted because every semantic property would need a defined interpolation rule.
+- Use `subscribeToThemeChanges()` and retain the returned ID. Unsubscribe before the owner is destroyed.
+- `setOnThemeChanged()` is retained as one compatibility callback slot. New owners must use subscriptions so listeners cannot replace one another.
+- `AestraWindowManager` owns the application subscription and propagates `onThemeChanged()` through the component hierarchy. Theme-aware caches should refresh in their override and then call `NUIComponent::onThemeChanged(theme)`.
+- Explicit custom widget colors are preserved. Widgets using default colors refresh from the new active theme.
+
+Theme updates are UI-thread operations. Subscribers must not call audio-thread code.
+
+## JSON registration
+
+Use:
+
+```cpp
+auto& themes = AestraUI::NUIThemeManager::getInstance();
+if (themes.loadThemeFromFile("studio-custom", path, "Aestra-dark")) {
+    themes.setActiveTheme("studio-custom");
+}
+```
+
+The file is limited to 1 MiB. Missing fields inherit the requested base theme. Invalid entries are skipped according to the existing loader policy; malformed, incomplete, non-object, missing, or oversized files fail live registration and do not install a misleading fallback theme.
+
+Colors use `#RRGGBB` or `#RRGGBBAA`. Unknown token names remain available through `NUITheme` for backward and forward compatibility but do not affect the live manager until a semantic mapping is documented.
+
+### Live color roles
+
+Preferred JSON names are:
+
+- Surfaces: `appBackground`, `workspaceBackground`, `recessedPanel`, `elevatedPanel`, `surfaceRaised`
+- Controls: `controlBackground`, `controlHover`, `controlPressed`, `controlDisabled`
+- Structure: `borderSubtle`, `borderStrong`, `borderActive`, `divider`
+- Text: `textPrimary`, `textSecondary`, `textMuted`, `textDisabled`, `textLink`, `textCritical`, `textOnPrimary`
+- Accent and selection: `accent`, `accentHover`, `accentPressed`, `selection`, `focusRing`, `dragTarget`
+- Status: `success`, `warning`, `error`, `info`, `armed`, `muted`, `soloed`, `bypassed`
+- Input: `toggleDefault`, `toggleHover`, `toggleActive`, `inputBackground`, `inputBgHover`, `inputBorderFocus`, `sliderTrack`, `sliderHandle`, `sliderHandleHover`, `sliderHandlePressed`
+- Meter and grid: `meterSafe`, `meterWarn`, `meterCrit`, `meterBackground`, `meterActive`, `gridMajor`, `gridMinor`
+- Overlays: `shadow`, `overlay`, `backdrop`
+
+Legacy names such as `background`, `surface`, `primary`, `buttonBgDefault`, `buttonBgHover`, and `normal` font size remain supported.
+
+When a JSON file overrides the primary accent but omits dependent roles, hover, pressed, selection, focus, drag target, link, toggle, input-focus, and slider roles are derived deterministically. Warning, error, and info similarly feed muted, armed, meter, critical-text, and solo roles when those roles are not explicitly overridden.
+
+### Live dimensions and typography
+
+Supported dimensions include the shared spacing scale, three legacy radius keys, common control/row/header heights, icon and hit-area metrics, divider width, panel/dialog padding, file-browser width, track-controls width, track height, and transport height.
+
+Supported font keys are `micro`, `xs`, `s`, `m`, `l`, `xl`, `display-s`, and `display-l`; legacy `small`, `normal`, and `large` map to the compact live scale.
+
+Positive layout and typography values are validated. Missing values retain the base preset.
+
+## Compatibility
+
+- Existing theme files still load through `NUITheme::loadFromFile()` and still receive defaults for missing or invalid entries.
+- Preference key and serialization format are unchanged. Unknown saved theme names safely fall back to `Aestra-dark`.
+- The component-level `setTheme()` API remains available for compatibility, but application styling should use the live manager.
+- No project or plugin state format changes are involved.
+
+## Performance
+
+- JSON parsing and registration happen only on explicit load/reload paths.
+- Activation performs one bounded UI-thread notification and hierarchy invalidation.
+- Cached timeline layers are invalidated once; they are not rebuilt every frame.
+- Theme switching does not add audio-thread allocation, locking, logging, file I/O, or callbacks.
+
+## Intentional visual domains
+
+Track colors, waveform rendering, plugin response graphs, meter thresholds, recording, mute, solo, bypass, warning/error status, and major/minor timeline grids remain separate roles. The arrangement grid may retain its dark fractal-workspace language inside a light chrome theme; it is not an ordinary panel background.
+
+## Muse harness handoff
+
+Muse should automate stable public actions: open Settings, select a theme by identity, apply or cancel, wait for root invalidation, navigate major surfaces, and capture screenshots. It should observe active theme identity and visible UI state instead of reaching into component color fields. Building that harness after this contract lands avoids coupling Muse to transitional theme internals.

--- a/AestraUI/Base/NUICheckbox.cpp
+++ b/AestraUI/Base/NUICheckbox.cpp
@@ -63,6 +63,25 @@ void NUICheckbox::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUICheckbox::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        textColor_ = theme.textPrimary;
+        backgroundColor_ = theme.buttonBgDefault;
+        borderColor_ = theme.borderSubtle;
+        checkColor_ = theme.primary;
+        hoverColor_ = theme.buttonBgHover;
+        pressedColor_ = theme.buttonBgActive;
+        toggleThumbColor_ = theme.textOnPrimary;
+        toggleTrackColor_ = theme.toggleDefault;
+        toggleTrackCheckedColor_ = theme.toggleActive;
+        checkboxRadius_ = theme.radiusXS;
+    }
+    if (checkIcon_)
+        checkIcon_->setColor(checkColor_);
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUICheckbox::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isEnabled() || !isVisible()) return false;
@@ -174,54 +193,63 @@ void NUICheckbox::setCheckboxRadius(float radius)
 void NUICheckbox::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setCheckColor(const NUIColor& color)
 {
     checkColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setHoverColor(const NUIColor& color)
 {
     hoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setPressedColor(const NUIColor& color)
 {
     pressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleThumbColor(const NUIColor& color)
 {
     toggleThumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleTrackColor(const NUIColor& color)
 {
     toggleTrackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleTrackCheckedColor(const NUIColor& color)
 {
     toggleTrackCheckedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -538,8 +566,8 @@ void NUICheckbox::drawCheckmark(NUIRenderer& renderer, const NUIRect& rect)
     // Position the checkmark icon
     checkIcon_->setIconSize(iconSize, iconSize);
     checkIcon_->setPosition(centerX - iconSize * 0.5f, centerY - iconSize * 0.5f);
-    // Use white/primary color for checkmark to contrast with accent background
-    checkIcon_->setColor(NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+    // Contrast against the accent fill via the theme's on-primary token.
+    checkIcon_->setColor(NUIThemeManager::getInstance().getCurrentTheme().textOnPrimary);
     
     // Render the checkmark
     checkIcon_->onRender(renderer);

--- a/AestraUI/Base/NUICheckbox.h
+++ b/AestraUI/Base/NUICheckbox.h
@@ -39,6 +39,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseEnter() override;
     void onMouseLeave() override;
@@ -169,6 +170,7 @@ private:
     NUIColor toggleThumbColor_ = NUIColor::fromHex(0xffffffff);
     NUIColor toggleTrackColor_ = NUIColor::fromHex(0xff2a2d32);
     NUIColor toggleTrackCheckedColor_ = NUIColor::fromHex(0xffa855f7);
+    bool customColors_ = false;
 
     // Text properties
     NUITextAlignment textAlignment_ = NUITextAlignment::Left;

--- a/AestraUI/Base/NUIContextMenu.cpp
+++ b/AestraUI/Base/NUIContextMenu.cpp
@@ -126,6 +126,23 @@ void NUIContextMenu::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUIContextMenu::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        backgroundColor_ = theme.surfaceTertiary;
+        borderColor_ = theme.borderStrong;
+        textColor_ = theme.textPrimary;
+        hoverColor_ = theme.buttonBgHover;
+        separatorColor_ = theme.borderSubtle;
+        shortcutColor_ = theme.textSecondary;
+        borderRadius_ = theme.radiusM;
+        itemHeight_ = theme.layout.standardMenuRowHeight;
+        iconSize_ = theme.layout.standardIconSize;
+        updateSize();
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUIContextMenu::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isVisible() || !isEnabled()) return false;
@@ -359,36 +376,42 @@ void NUIContextMenu::hide()
 void NUIContextMenu::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setHoverColor(const NUIColor& color)
 {
     hoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setSeparatorColor(const NUIColor& color)
 {
     separatorColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setShortcutColor(const NUIColor& color)
 {
     shortcutColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUIContextMenu.h
+++ b/AestraUI/Base/NUIContextMenu.h
@@ -96,6 +96,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
     void onMouseEnter() override;
@@ -213,6 +214,7 @@ private:
     NUIColor hoverColor_ = NUIColor::fromHex(0xff3a3d42);
     NUIColor separatorColor_ = NUIColor::fromHex(0xff666666);
     NUIColor shortcutColor_ = NUIColor::fromHex(0xff888888);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 7.0f;
     float itemHeight_ = 28.0f;

--- a/AestraUI/Base/NUIDropdown.cpp
+++ b/AestraUI/Base/NUIDropdown.cpp
@@ -29,7 +29,7 @@ NUIDropdown::NUIDropdown()
     try {
         auto& mgr = NUIThemeManager::getInstance();
         const auto& props = mgr.getCurrentTheme();
-        backgroundColor_ = props.surfaceRaised;
+        backgroundColor_ = props.surfaceTertiary; // keep in sync with refreshThemeColors()
         hoverColor_ = props.buttonBgHover;
         selectedColor_ = props.selected;
         borderColor_ = props.border;

--- a/AestraUI/Base/NUIIcon.cpp
+++ b/AestraUI/Base/NUIIcon.cpp
@@ -61,17 +61,29 @@ void NUIIcon::setIconSize(float width, float height) {
 void NUIIcon::setColor(const NUIColor& color) {
     color_ = color;
     hasCustomColor_ = true;
+    themeColorName_.clear();
     setDirty(true);
 }
 
 void NUIIcon::setColorFromTheme(const std::string& colorName) {
     auto& themeManager = NUIThemeManager::getInstance();
-    setColor(themeManager.getColor(colorName));
+    color_ = themeManager.getColor(colorName);
+    hasCustomColor_ = true;
+    themeColorName_ = colorName;
+    setDirty(true);
 }
 
 void NUIIcon::clearColor() {
     hasCustomColor_ = false;
+    themeColorName_.clear();
     setDirty(true);
+}
+
+void NUIIcon::onThemeChanged(const NUIThemeProperties& theme) {
+    (void)theme;
+    if (!themeColorName_.empty())
+        color_ = NUIThemeManager::getInstance().getColor(themeColorName_);
+    NUIComponent::onThemeChanged(theme);
 }
 
 void NUIIcon::updateBounds() {

--- a/AestraUI/Base/NUIIcon.h
+++ b/AestraUI/Base/NUIIcon.h
@@ -31,6 +31,7 @@ public:
     
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     
     // Icon management
     void loadSVG(const std::string& svgContent);
@@ -68,6 +69,7 @@ private:
     std::shared_ptr<NUISVGDocument> svgDoc_;
     NUIColor color_ = NUIColor::white();
     bool hasCustomColor_ = false;
+    std::string themeColorName_;
     float iconWidth_ = 24.0f;
     float iconHeight_ = 24.0f;
 };

--- a/AestraUI/Base/NUILabel.cpp
+++ b/AestraUI/Base/NUILabel.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUILabel.h"
 #include "NUITheme.h"
+#include "NUIThemeSystem.h"
 #include "Graphics/NUIRenderer.h"
 #include <algorithm>
 #include <cmath>
@@ -10,7 +11,12 @@ namespace AestraUI {
 NUILabel::NUILabel(const std::string& text)
     : text_(text)
 {
-    setSize(100, 20); // Default size
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    textColor_ = theme.textPrimary;
+    backgroundColor_ = NUIColor::transparent();
+    borderColor_ = theme.borderSubtle;
+    fontSize_ = theme.fontSizeM;
+    setSize(100, theme.layout.compactControlHeight);
 }
 
 void NUILabel::onRender(NUIRenderer& renderer)
@@ -103,6 +109,18 @@ void NUILabel::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUILabel::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customTextColor_)
+        textColor_ = theme.textPrimary;
+    if (!customBackgroundColor_)
+        backgroundColor_ = NUIColor::transparent();
+    if (!customBorderColor_)
+        borderColor_ = theme.borderSubtle;
+    textSizeValid_ = false;
+    NUIComponent::onThemeChanged(theme);
+}
+
 void NUILabel::setText(const std::string& text)
 {
     if (text_ != text) {
@@ -121,6 +139,7 @@ void NUILabel::setFont(std::shared_ptr<NUIFont> font)
 void NUILabel::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customTextColor_ = true;
     repaint();
 }
 
@@ -160,6 +179,7 @@ void NUILabel::setEllipsize(bool ellipsize)
 void NUILabel::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customBackgroundColor_ = true;
     repaint();
 }
 
@@ -172,6 +192,7 @@ void NUILabel::setBackgroundVisible(bool visible)
 void NUILabel::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customBorderColor_ = true;
     repaint();
 }
 

--- a/AestraUI/Base/NUILabel.h
+++ b/AestraUI/Base/NUILabel.h
@@ -31,6 +31,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
 
     // Text properties
     void setText(const std::string& text);
@@ -99,6 +100,9 @@ private:
     
     // Editable state
     bool editable_ = false;
+    bool customTextColor_ = false;
+    bool customBackgroundColor_ = false;
+    bool customBorderColor_ = false;
     
     // OPTIMIZATION: Cache text measurements
     mutable NUISize cachedTextSize_{0, 0};

--- a/AestraUI/Base/NUIProgressBar.cpp
+++ b/AestraUI/Base/NUIProgressBar.cpp
@@ -2,6 +2,7 @@
 #include "NUIProgressBar.h"
 #include "NUIRenderer.h"
 #include "NUITheme.h"
+#include "NUIThemeSystem.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -12,7 +13,13 @@ namespace AestraUI {
 NUIProgressBar::NUIProgressBar()
     : NUIComponent()
 {
-    setSize(200, 20); // Default size
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    backgroundColor_ = theme.meterBackground;
+    progressColor_ = theme.meterActive;
+    borderColor_ = theme.borderSubtle;
+    textColor_ = theme.textPrimary;
+    borderRadius_ = theme.radiusS;
+    setSize(200, theme.layout.compactControlHeight);
 }
 
 void NUIProgressBar::onRender(NUIRenderer& renderer)
@@ -38,6 +45,18 @@ void NUIProgressBar::onRender(NUIRenderer& renderer)
     {
         drawText(renderer);
     }
+}
+
+void NUIProgressBar::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        backgroundColor_ = theme.meterBackground;
+        progressColor_ = theme.meterActive;
+        borderColor_ = theme.borderSubtle;
+        textColor_ = theme.textPrimary;
+        borderRadius_ = theme.radiusS;
+    }
+    NUIComponent::onThemeChanged(theme);
 }
 
 void NUIProgressBar::onUpdate(double deltaTime)
@@ -112,24 +131,28 @@ void NUIProgressBar::setOrientation(Orientation orientation)
 void NUIProgressBar::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setProgressColor(const NUIColor& color)
 {
     progressColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUIProgressBar.h
+++ b/AestraUI/Base/NUIProgressBar.h
@@ -36,6 +36,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     void onUpdate(double deltaTime) override;
 
     // Progress properties
@@ -154,6 +155,7 @@ private:
     NUIColor progressColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor borderColor_ = NUIColor::fromHex(0xff666666);
     NUIColor textColor_ = NUIColor::fromHex(0xffffffff);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float thickness_ = 8.0f;

--- a/AestraUI/Base/NUIScrollbar.cpp
+++ b/AestraUI/Base/NUIScrollbar.cpp
@@ -85,6 +85,27 @@ void NUIScrollbar::onRender(NUIRenderer& renderer)
     drawArrows(renderer);
 }
 
+void NUIScrollbar::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        trackColor_ = theme.backgroundSecondary.withAlpha(0.72f);
+        thumbColor_ = theme.textMuted.withAlpha(0.42f);
+        thumbHoverColor_ = theme.textSecondary.withAlpha(0.62f);
+        thumbPressedColor_ = theme.textPrimary.withAlpha(0.76f);
+        arrowColor_ = theme.textMuted;
+        arrowHoverColor_ = theme.textSecondary;
+        arrowPressedColor_ = theme.textPrimary;
+        borderColor_ = theme.borderSubtle;
+        borderRadius_ = theme.radiusXS;
+        arrowSize_ = theme.fontSizeM;
+        if (upArrowIcon_)
+            upArrowIcon_->setColor(arrowColor_);
+        if (downArrowIcon_)
+            downArrowIcon_->setColor(arrowColor_);
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 void NUIScrollbar::onUpdate(double deltaTime)
 {
     if (isAnimating_ && !isDragging_) {
@@ -426,48 +447,56 @@ void NUIScrollbar::setMinimumThumbSize(double size)
 void NUIScrollbar::setTrackColor(const NUIColor& color)
 {
     trackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbColor(const NUIColor& color)
 {
     thumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbHoverColor(const NUIColor& color)
 {
     thumbHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbPressedColor(const NUIColor& color)
 {
     thumbPressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowColor(const NUIColor& color)
 {
     arrowColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowHoverColor(const NUIColor& color)
 {
     arrowHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowPressedColor(const NUIColor& color)
 {
     arrowPressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -1129,12 +1158,12 @@ void NUIScrollbar::drawEnhancedThumb(NUIRenderer& renderer, const NUIRect& thumb
         // Top horizontal white marker
         NUIRect topMarker(visualThumb.x + 2.0f, markerY, visualThumb.width - 4.0f, markerHeight);
         const float markerAlpha = thumbHot ? 0.24f : 0.12f;
-        renderer.fillRoundedRect(topMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(topMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
         
         // Bottom horizontal white marker
         NUIRect bottomMarker(visualThumb.x + 2.0f, markerY + markerHeight + markerSpacing, 
                              visualThumb.width - 4.0f, markerHeight);
-        renderer.fillRoundedRect(bottomMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(bottomMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
     }
     else
     {
@@ -1149,12 +1178,12 @@ void NUIScrollbar::drawEnhancedThumb(NUIRenderer& renderer, const NUIRect& thumb
         // Left vertical white marker
         NUIRect leftMarker(markerX, visualThumb.y + 2.0f, markerWidth, visualThumb.height - 4.0f);
         const float markerAlpha = thumbHot ? 0.24f : 0.12f;
-        renderer.fillRoundedRect(leftMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(leftMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
         
         // Right vertical white marker
         NUIRect rightMarker(markerX + markerWidth + markerSpacing, visualThumb.y + 2.0f, 
                             markerWidth, visualThumb.height - 4.0f);
-        renderer.fillRoundedRect(rightMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(rightMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
     }
     
     // Subtle inner highlight

--- a/AestraUI/Base/NUIScrollbar.h
+++ b/AestraUI/Base/NUIScrollbar.h
@@ -49,6 +49,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onUpdate(double deltaTime) override;
     void onMouseEnter() override;
@@ -198,6 +199,7 @@ private:
     NUIColor arrowHoverColor_ = NUIColor(0.95f, 0.95f, 0.95f, 0.45f);    // Brighter on hover
     NUIColor arrowPressedColor_ = NUIColor(0.70f, 0.70f, 0.70f, 0.65f);  // Stronger on press
     NUIColor borderColor_ = NUIColor(0.30f, 0.30f, 0.30f, 0.35f);        // Subtle border
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float arrowSize_ = 12.0f;

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -61,6 +61,18 @@ void NUISlider::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUISlider::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        trackColor_ = theme.sliderTrack;
+        fillColor_ = theme.sliderHandle;
+        thumbColor_ = theme.textPrimary;
+        thumbHoverColor_ = theme.sliderHandleHover;
+        sliderRadius_ = theme.radiusM;
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isEnabled() || !isVisible()) return false;
@@ -284,24 +296,28 @@ void NUISlider::setSliderRadius(float radius)
 void NUISlider::setTrackColor(const NUIColor& color)
 {
     trackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setFillColor(const NUIColor& color)
 {
     fillColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setThumbColor(const NUIColor& color)
 {
     thumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setThumbHoverColor(const NUIColor& color)
 {
     thumbHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUISlider.h
+++ b/AestraUI/Base/NUISlider.h
@@ -45,6 +45,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseEnter() override;
     void onMouseLeave() override;
@@ -191,6 +192,7 @@ private:
     NUIColor fillColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor thumbColor_ = NUIColor::fromHex(0xffffffff);
     NUIColor thumbHoverColor_ = NUIColor::fromHex(0xffe5e7eb);
+    bool customColors_ = false;
 
     // Interaction state
     bool isDragging_ = false;

--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -125,6 +125,23 @@ void NUITextInput::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUITextInput::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        textColor_ = theme.textPrimary;
+        backgroundColor_ = theme.inputBgDefault;
+        borderColor_ = theme.borderSubtle;
+        focusedBorderColor_ = theme.focusRing;
+        placeholderColor_ = theme.textMuted;
+        selectionColor_ = theme.selected;
+        caretColor_ = theme.textPrimary;
+        borderRadius_ = theme.radiusM;
+        padding_ = theme.spacingS;
+    }
+    invalidateLayout();
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUITextInput::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isVisible() || !isEnabled()) return false;
@@ -352,12 +369,14 @@ void NUITextInput::setMinLength(int minLength)
 void NUITextInput::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -370,30 +389,35 @@ void NUITextInput::setBackgroundVisible(bool visible)
 void NUITextInput::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setFocusedBorderColor(const NUIColor& color)
 {
     focusedBorderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setPlaceholderColor(const NUIColor& color)
 {
     placeholderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setSelectionColor(const NUIColor& color)
 {
     selectionColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setCaretColor(const NUIColor& color)
 {
     caretColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUITextInput.h
+++ b/AestraUI/Base/NUITextInput.h
@@ -53,6 +53,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
     void onFocusGained() override;
@@ -245,6 +246,7 @@ private:
     NUIColor placeholderColor_ = NUIColor::fromHex(0xff888888);
     NUIColor selectionColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor caretColor_ = NUIColor::fromHex(0xffffffff);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float padding_ = 8.0f;

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -488,6 +488,13 @@ std::shared_ptr<NUITheme> NUIComponent::getTheme() const {
     return nullptr;
 }
 
+void NUIComponent::onThemeChanged(const NUIThemeProperties& theme) {
+    (void)theme;
+    setDirty(true);
+    for (auto& child : children_)
+        child->onThemeChanged(theme);
+}
+
 // ============================================================================
 // Protected Methods
 // ============================================================================

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -10,6 +10,7 @@ namespace AestraUI {
 
 class NUIRenderer;
 class NUITheme;
+struct NUIThemeProperties;
 class NUIFont;
 
 /**
@@ -137,6 +138,8 @@ public:
     // Theme
     void setTheme(std::shared_ptr<NUITheme> theme);
     std::shared_ptr<NUITheme> getTheme() const;
+    /** Refresh cached theme state, then propagate the change to descendants. */
+    virtual void onThemeChanged(const NUIThemeProperties& theme);
     
     // Callbacks
     NUIMouseCallback onMouseDown;

--- a/AestraUI/Core/NUITheme.cpp
+++ b/AestraUI/Core/NUITheme.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <functional>
 #include <unordered_set>
+#include <vector>
 
 namespace AestraUI {
 
@@ -44,8 +45,37 @@ bool requiresPositiveDimension(const std::string& name) {
         "margin", "borderWidth", "compactControlHeight", "standardControlHeight", "dialogActionHeight",
         "standardRowHeight", "compactMenuRowHeight", "standardMenuRowHeight", "panelHeaderHeight",
         "sectionHeaderHeight", "standardIconSize", "minimumHitArea", "dividerWidth", "panelPadding",
-        "dialogPadding"};
+        "dialogPadding", "spacingXS", "spacingS", "spacingM", "spacingL", "spacingXL", "spacingXXL",
+        "fileBrowserWidth", "trackControlsWidth", "trackHeight", "transportBarHeight"};
     return positiveDimensions.find(name) != positiveDimensions.end();
+}
+
+bool hasCompleteJSONStructure(const std::string& content) {
+    std::vector<char> stack;
+    bool inString = false;
+    bool escaped = false;
+    for (char c : content) {
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                inString = false;
+            }
+            continue;
+        }
+        if (c == '"') {
+            inString = true;
+        } else if (c == '{' || c == '[') {
+            stack.push_back(c);
+        } else if (c == '}' || c == ']') {
+            if (stack.empty() || (c == '}' && stack.back() != '{') || (c == ']' && stack.back() != '['))
+                return false;
+            stack.pop_back();
+        }
+    }
+    return !inString && !escaped && stack.empty();
 }
 
 } // namespace
@@ -131,6 +161,8 @@ std::shared_ptr<NUITheme> NUITheme::createDefault() {
     theme->setFontSize("large", 20.0f);
     theme->setFontSize("title", 28.0f);
     theme->setFontSize("huge", 48.0f);
+
+    theme->loadedSuccessfully_ = true;
     
     return theme;
 }
@@ -140,6 +172,8 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
     // its default value. On any failure this default theme is returned (never
     // nullptr) and the failure is logged.
     auto theme = createDefault();
+    theme->loadedSuccessfully_ = false;
+    theme->clearOverrideTracking();
 
     std::ifstream file(filepath, std::ios::binary);
     if (!file.is_open()) {
@@ -161,11 +195,19 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
     std::string content(static_cast<size_t>(fileSize), '\0');
     file.read(content.data(), fileSize);
 
+    if (!hasCompleteJSONStructure(content)) {
+        Aestra::Log::error("[NUITheme] Theme file '" + filepath +
+                           "' has incomplete JSON structure — using default theme");
+        return theme;
+    }
+
     Aestra::JSON root = Aestra::JSON::parse(content);
     if (!root.isObject()) {
         Aestra::Log::error("[NUITheme] Theme file '" + filepath + "' is not a valid JSON object — using default theme");
         return theme;
     }
+
+    theme->loadedSuccessfully_ = true;
 
     int applied = 0;
     int skipped = 0;
@@ -251,6 +293,11 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
 
 void NUITheme::setColor(const std::string& name, const NUIColor& color) {
     colors_[name] = color;
+    colorOverrides_.insert(name);
+}
+
+bool NUITheme::hasColorOverride(const std::string& name) const {
+    return colorOverrides_.find(name) != colorOverrides_.end();
 }
 
 NUIColor NUITheme::getColor(const std::string& name, const NUIColor& defaultColor) const {
@@ -267,6 +314,11 @@ NUIColor NUITheme::getColor(const std::string& name, const NUIColor& defaultColo
 
 void NUITheme::setDimension(const std::string& name, float value) {
     dimensions_[name] = value;
+    dimensionOverrides_.insert(name);
+}
+
+bool NUITheme::hasDimensionOverride(const std::string& name) const {
+    return dimensionOverrides_.find(name) != dimensionOverrides_.end();
 }
 
 float NUITheme::getDimension(const std::string& name, float defaultValue) const {
@@ -283,6 +335,11 @@ float NUITheme::getDimension(const std::string& name, float defaultValue) const 
 
 void NUITheme::setEffect(const std::string& name, float value) {
     effects_[name] = value;
+    effectOverrides_.insert(name);
+}
+
+bool NUITheme::hasEffectOverride(const std::string& name) const {
+    return effectOverrides_.find(name) != effectOverrides_.end();
 }
 
 float NUITheme::getEffect(const std::string& name, float defaultValue) const {
@@ -299,6 +356,11 @@ float NUITheme::getEffect(const std::string& name, float defaultValue) const {
 
 void NUITheme::setFontSize(const std::string& name, float size) {
     fontSizes_[name] = size;
+    fontSizeOverrides_.insert(name);
+}
+
+bool NUITheme::hasFontSizeOverride(const std::string& name) const {
+    return fontSizeOverrides_.find(name) != fontSizeOverrides_.end();
 }
 
 float NUITheme::getFontSize(const std::string& name, float defaultSize) const {
@@ -307,6 +369,13 @@ float NUITheme::getFontSize(const std::string& name, float defaultSize) const {
         return it->second;
     }
     return defaultSize;
+}
+
+void NUITheme::clearOverrideTracking() {
+    colorOverrides_.clear();
+    dimensionOverrides_.clear();
+    effectOverrides_.clear();
+    fontSizeOverrides_.clear();
 }
 
 // TODO: Implement font creation when NUIFont supports copying

--- a/AestraUI/Core/NUITheme.h
+++ b/AestraUI/Core/NUITheme.h
@@ -4,6 +4,7 @@
 #include "NUITypes.h"
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <memory>
 
 namespace AestraUI {
@@ -32,6 +33,13 @@ public:
      * Load a theme from a JSON file.
      */
     static std::shared_ptr<NUITheme> loadFromFile(const std::string& filepath);
+
+    /** True when this instance was created from a valid JSON object. */
+    bool loadedSuccessfully() const { return loadedSuccessfully_; }
+    bool hasColorOverride(const std::string& name) const;
+    bool hasDimensionOverride(const std::string& name) const;
+    bool hasEffectOverride(const std::string& name) const;
+    bool hasFontSizeOverride(const std::string& name) const;
     
     // ========================================================================
     // Colors
@@ -95,10 +103,17 @@ public:
     // NUIFont getDefaultFont() const;
     
 private:
+    void clearOverrideTracking();
+
     std::unordered_map<std::string, NUIColor> colors_;
     std::unordered_map<std::string, float> dimensions_;
     std::unordered_map<std::string, float> effects_;
     std::unordered_map<std::string, float> fontSizes_;
+    std::unordered_set<std::string> colorOverrides_;
+    std::unordered_set<std::string> dimensionOverrides_;
+    std::unordered_set<std::string> effectOverrides_;
+    std::unordered_set<std::string> fontSizeOverrides_;
+    bool loadedSuccessfully_ = false;
 };
 
 } // namespace AestraUI

--- a/AestraUI/Core/NUIThemeSystem.cpp
+++ b/AestraUI/Core/NUIThemeSystem.cpp
@@ -1,9 +1,191 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUIThemeSystem.h"
+#include "NUITheme.h"
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 namespace AestraUI {
+
+namespace {
+
+void applyJSONThemeOverrides(const NUITheme& source, NUIThemeProperties& target) {
+    const auto color = [&](const char* name, NUIColor& value) {
+        if (source.hasColorOverride(name))
+            value = source.getColor(name, value);
+    };
+
+    color("appBackground", target.backgroundPrimary);
+    color("workspaceBackground", target.backgroundPrimary);
+    color("backgroundPrimary", target.backgroundPrimary);
+    color("recessedPanel", target.backgroundSecondary);
+    color("backgroundSecondary", target.backgroundSecondary);
+    color("elevatedPanel", target.surfaceTertiary);
+    color("surfaceTertiary", target.surfaceTertiary);
+    color("surfaceRaised", target.surfaceRaised);
+    color("background", target.background);
+    color("surface", target.surface);
+    color("surfaceVariant", target.surfaceVariant);
+
+    color("primary", target.primary);
+    color("accent", target.primary);
+    color("primaryHover", target.primaryHover);
+    color("accentHover", target.primaryHover);
+    color("primaryPressed", target.primaryPressed);
+    color("accentPressed", target.primaryPressed);
+    color("secondary", target.secondary);
+    color("accentCyan", target.accentCyan);
+    color("accentMagenta", target.accentMagenta);
+    color("accentLime", target.accentLime);
+    color("accentPrimary", target.accentPrimary);
+    color("accentSecondary", target.accentSecondary);
+
+    color("success", target.success);
+    color("warning", target.warning);
+    color("error", target.error);
+    color("info", target.info);
+    color("text", target.textPrimary);
+    color("textPrimary", target.textPrimary);
+    color("textSecondary", target.textSecondary);
+    color("textMuted", target.textMuted);
+    color("textDisabled", target.textDisabled);
+    color("textLink", target.textLink);
+    color("textCritical", target.textCritical);
+    color("textOnPrimary", target.textOnPrimary);
+    color("textOnSecondary", target.textOnSecondary);
+
+    color("border", target.border);
+    color("borderSubtle", target.borderSubtle);
+    color("borderStrong", target.borderStrong);
+    color("borderActive", target.borderActive);
+    color("divider", target.divider);
+    color("selection", target.selected);
+    color("selected", target.selected);
+    color("hover", target.hover);
+    color("pressed", target.pressed);
+    color("focused", target.focused);
+    color("disabled", target.disabled);
+    color("focusRing", target.focusRing);
+    color("armed", target.armed);
+    color("muted", target.muted);
+    color("soloed", target.soloed);
+    color("bypassed", target.bypassed);
+    color("dragTarget", target.dragTarget);
+
+    color("controlBackground", target.buttonBgDefault);
+    color("buttonBgDefault", target.buttonBgDefault);
+    color("controlHover", target.buttonBgHover);
+    color("buttonBgHover", target.buttonBgHover);
+    color("controlPressed", target.buttonBgActive);
+    color("buttonBgActive", target.buttonBgActive);
+    color("buttonTextDefault", target.buttonTextDefault);
+    color("buttonTextActive", target.buttonTextActive);
+    color("toggleDefault", target.toggleDefault);
+    color("toggleHover", target.toggleHover);
+    color("toggleActive", target.toggleActive);
+    color("inputBackground", target.inputBgDefault);
+    color("inputBgDefault", target.inputBgDefault);
+    color("inputBgHover", target.inputBgHover);
+    color("inputBorderFocus", target.inputBorderFocus);
+    color("sliderTrack", target.sliderTrack);
+    color("sliderHandle", target.sliderHandle);
+    color("sliderHandleHover", target.sliderHandleHover);
+    color("sliderHandlePressed", target.sliderHandlePressed);
+
+    color("shadow", target.shadow);
+    color("overlay", target.overlay);
+    color("backdrop", target.backdrop);
+    color("meterSafe", target.meterSafe);
+    color("meterWarn", target.meterWarn);
+    color("meterCrit", target.meterCrit);
+    color("meterBackground", target.meterBackground);
+    color("meterActive", target.meterActive);
+    color("gridMajor", target.gridMajor);
+    color("gridMinor", target.gridMinor);
+    color("mixerStripBg", target.mixerStripBg);
+    color("mixerMasterBorder", target.mixerMasterBorder);
+
+    const auto hasColor = [&](const char* primaryName, const char* alias = nullptr) {
+        return source.hasColorOverride(primaryName) || (alias && source.hasColorOverride(alias));
+    };
+    if (hasColor("primary", "accent")) {
+        if (!hasColor("primaryHover", "accentHover"))
+            target.primaryHover = target.primary.lightened(0.10f);
+        if (!hasColor("primaryPressed", "accentPressed"))
+            target.primaryPressed = target.primary.darkened(0.10f);
+        if (!hasColor("accentPrimary")) target.accentPrimary = target.primary;
+        if (!hasColor("borderActive")) target.borderActive = target.primary;
+        if (!hasColor("focusRing")) target.focusRing = target.primary.withAlpha(0.86f);
+        if (!hasColor("selection", "selected")) target.selected = target.primary.withAlpha(0.18f);
+        if (!hasColor("dragTarget")) target.dragTarget = target.primary.withAlpha(0.28f);
+        if (!hasColor("textLink")) target.textLink = target.primary;
+        if (!hasColor("toggleActive")) target.toggleActive = target.primary.withAlpha(0.85f);
+        if (!hasColor("inputBorderFocus")) target.inputBorderFocus = target.focusRing;
+        if (!hasColor("sliderHandle")) target.sliderHandle = target.primary;
+        if (!hasColor("sliderHandleHover")) target.sliderHandleHover = target.primaryHover;
+        if (!hasColor("sliderHandlePressed")) target.sliderHandlePressed = target.primaryPressed;
+    }
+    if (hasColor("warning")) {
+        if (!hasColor("muted")) target.muted = target.warning;
+        if (!hasColor("meterWarn")) target.meterWarn = target.warning;
+    }
+    if (hasColor("error")) {
+        if (!hasColor("armed")) target.armed = target.error;
+        if (!hasColor("meterCrit")) target.meterCrit = target.error;
+        if (!hasColor("textCritical")) target.textCritical = target.error;
+    }
+    if (hasColor("info") && !hasColor("soloed"))
+        target.soloed = target.info;
+
+    const auto dimension = [&](const char* name, float& value) {
+        if (source.hasDimensionOverride(name))
+            value = source.getDimension(name, value);
+    };
+    dimension("spacingXS", target.spacingXS);
+    dimension("spacingS", target.spacingS);
+    dimension("spacingM", target.spacingM);
+    dimension("spacingL", target.spacingL);
+    dimension("spacingXL", target.spacingXL);
+    dimension("spacingXXL", target.spacingXXL);
+    dimension("borderRadiusSmall", target.radiusS);
+    dimension("borderRadius", target.radiusM);
+    dimension("borderRadiusLarge", target.radiusL);
+    dimension("compactControlHeight", target.layout.compactControlHeight);
+    dimension("standardControlHeight", target.layout.standardControlHeight);
+    dimension("dialogActionHeight", target.layout.dialogActionHeight);
+    dimension("standardRowHeight", target.layout.standardRowHeight);
+    dimension("compactMenuRowHeight", target.layout.compactMenuRowHeight);
+    dimension("standardMenuRowHeight", target.layout.standardMenuRowHeight);
+    dimension("panelHeaderHeight", target.layout.panelHeaderHeight);
+    dimension("sectionHeaderHeight", target.layout.sectionHeaderHeight);
+    dimension("standardIconSize", target.layout.standardIconSize);
+    dimension("minimumHitArea", target.layout.minimumHitArea);
+    dimension("dividerWidth", target.layout.dividerWidth);
+    dimension("panelPadding", target.layout.panelPadding);
+    dimension("dialogPadding", target.layout.dialogPadding);
+    dimension("fileBrowserWidth", target.layout.fileBrowserWidth);
+    dimension("trackControlsWidth", target.layout.trackControlsWidth);
+    dimension("trackHeight", target.layout.trackHeight);
+    dimension("transportBarHeight", target.layout.transportBarHeight);
+
+    const auto fontSize = [&](const char* name, float& value) {
+        if (source.hasFontSizeOverride(name))
+            value = source.getFontSize(name, value);
+    };
+    fontSize("micro", target.fontSizeMicro);
+    fontSize("xs", target.fontSizeXS);
+    fontSize("small", target.fontSizeS);
+    fontSize("s", target.fontSizeS);
+    fontSize("normal", target.fontSizeM);
+    fontSize("m", target.fontSizeM);
+    fontSize("large", target.fontSizeL);
+    fontSize("l", target.fontSizeL);
+    fontSize("xl", target.fontSizeXL);
+    fontSize("display-s", target.fontSizeDisplayS);
+    fontSize("display-l", target.fontSizeDisplayL);
+}
+
+} // namespace
 
 NUIResolvedControlColors resolveControlColors(const NUIThemeProperties& theme,
                                               const NUIControlVisualState& state) {
@@ -81,15 +263,39 @@ void NUIThemeManager::setThemeVariant(NUIThemeVariant variant) {
 
 void NUIThemeManager::setCustomTheme(const std::string& name, const NUIThemeProperties& properties) {
     themes_[name] = properties;
+    if (activeTheme_ == name)
+        notifyThemeChanged();
 }
 
-void NUIThemeManager::setActiveTheme(const std::string& name) {
-    if (themes_.find(name) != themes_.end()) {
-        activeTheme_ = name;
-        if (onThemeChanged_) {
-            onThemeChanged_(getCurrentTheme());
-        }
-    }
+bool NUIThemeManager::loadThemeFromFile(const std::string& name, const std::string& filepath,
+                                        const std::string& baseTheme) {
+    const auto base = themes_.find(baseTheme);
+    if (name.empty() || base == themes_.end())
+        return false;
+
+    auto loaded = NUITheme::loadFromFile(filepath);
+    if (!loaded || !loaded->loadedSuccessfully())
+        return false;
+
+    NUIThemeProperties properties = base->second;
+    applyJSONThemeOverrides(*loaded, properties);
+    setCustomTheme(name, properties);
+    return true;
+}
+
+bool NUIThemeManager::setActiveTheme(const std::string& name) {
+    if (!hasTheme(name))
+        return false;
+    if (activeTheme_ == name)
+        return true;
+
+    activeTheme_ = name;
+    notifyThemeChanged();
+    return true;
+}
+
+bool NUIThemeManager::hasTheme(const std::string& name) const {
+    return themes_.find(name) != themes_.end();
 }
 
 const NUIThemeProperties& NUIThemeManager::getCurrentTheme() const {
@@ -105,46 +311,11 @@ NUIThemeProperties& NUIThemeManager::getCurrentThemeMutable() {
 }
 
 void NUIThemeManager::switchTheme(const std::string& name, float durationMs) {
-    if (themes_.find(name) == themes_.end()) return;
-    
-    if (durationMs <= 0.0f) {
-        setActiveTheme(name);
-        return;
-    }
-    
-    isTransitioning_ = true;
-    transitionFromTheme_ = getCurrentTheme();
-    transitionToTheme_ = themes_[name];
-    
-    themeTransitionAnimation_ = std::make_shared<NUIAnimation>();
-    themeTransitionAnimation_->setDuration(durationMs);
-    themeTransitionAnimation_->setEasing(NUIEasingType::EaseOutCubic);
-    themeTransitionAnimation_->setStartValue(0.0f);
-    themeTransitionAnimation_->setEndValue(1.0f);
-    
-    themeTransitionAnimation_->setOnUpdate([this](float progress) {
-        // Interpolate between themes
-        NUIThemeProperties currentTheme;
-        currentTheme.background = NUIColor::lerpHSL(transitionFromTheme_.background, transitionToTheme_.background, progress);
-        currentTheme.surface = NUIColor::lerpHSL(transitionFromTheme_.surface, transitionToTheme_.surface, progress);
-        currentTheme.primary = NUIColor::lerpHSL(transitionFromTheme_.primary, transitionToTheme_.primary, progress);
-        // ... interpolate other properties as needed
-        
-        if (onThemeChanged_) {
-            onThemeChanged_(currentTheme);
-        }
-    });
-    
-    themeTransitionAnimation_->setOnComplete([this]() {
-        isTransitioning_ = false;
-        // Note: activeTheme_ should be set before calling switchTheme
-        if (onThemeChanged_) {
-            onThemeChanged_(getCurrentTheme());
-        }
-    });
-    
-    themeTransitionAnimation_->start();
-    NUIAnimationManager::getInstance().addAnimation(themeTransitionAnimation_);
+    (void)durationMs;
+    // A partial interpolated theme is visually and semantically unsafe. Theme
+    // activation stays atomic until every semantic property has a defined
+    // transition rule.
+    setActiveTheme(name);
 }
 
 void NUIThemeManager::switchThemeVariant(NUIThemeVariant variant, float durationMs) {
@@ -167,6 +338,37 @@ void NUIThemeManager::switchThemeVariant(NUIThemeVariant variant, float duration
 
 void NUIThemeManager::setOnThemeChanged(std::function<void(const NUIThemeProperties&)> callback) {
     onThemeChanged_ = callback;
+}
+
+NUIThemeManager::ThemeSubscriptionId NUIThemeManager::subscribeToThemeChanges(
+    std::function<void(const NUIThemeProperties&)> callback) {
+    if (!callback)
+        return 0;
+    const ThemeSubscriptionId id = nextSubscriptionId_++;
+    themeSubscribers_.emplace(id, std::move(callback));
+    return id;
+}
+
+void NUIThemeManager::unsubscribeFromThemeChanges(ThemeSubscriptionId subscriptionId) {
+    if (subscriptionId != 0)
+        themeSubscribers_.erase(subscriptionId);
+}
+
+void NUIThemeManager::notifyThemeChanged() {
+    const auto& theme = getCurrentTheme();
+    if (onThemeChanged_)
+        onThemeChanged_(theme);
+
+    // Listeners may unsubscribe while handling a change. Copying callbacks is
+    // bounded, user-driven UI work and keeps notification lifetime-safe.
+    std::vector<std::function<void(const NUIThemeProperties&)>> callbacks;
+    callbacks.reserve(themeSubscribers_.size());
+    for (const auto& [id, callback] : themeSubscribers_) {
+        (void)id;
+        callbacks.push_back(callback);
+    }
+    for (const auto& callback : callbacks)
+        callback(theme);
 }
 
 NUIColor NUIThemeManager::getColor(const std::string& colorName) const {
@@ -310,6 +512,41 @@ NUIColor NUIThemeManager::getColor(const std::string& colorName) const {
     if (colorName == "mixerMasterBorder") return theme.mixerMasterBorder;
     
     // === Arsenal / Step Sequencer Tokens ===
+    // Timeline work bed + track chrome: derived per theme polarity. Dark
+    // themes keep the owner-directed pure-black grid and near-black chrome;
+    // light themes get a recessed light bed and clean white chrome instead.
+    if (colorName == "timelineBed" || colorName == "trackChrome") {
+        const float bgLuma = 0.2126f * theme.backgroundPrimary.r +
+                             0.7152f * theme.backgroundPrimary.g +
+                             0.0722f * theme.backgroundPrimary.b;
+        const bool darkTheme = bgLuma < 0.5f;
+        if (colorName == "timelineBed") {
+            return darkTheme ? NUIColor::black()
+                             : NUIColor(0.936f, 0.938f, 0.942f, 1.0f);
+        }
+        return darkTheme ? NUIColor(0.038f, 0.039f, 0.045f, 1.0f)
+                         : theme.backgroundSecondary;
+    }
+    // Plugin-editor internals share one polarity-aware language: cards,
+    // display wells, and control fills that are near-black on dark themes
+    // and clean light surfaces on light ones. Identity accents stay per-editor.
+    if (colorName == "editorCard" || colorName == "editorWell" || colorName == "editorControl") {
+        const float bgLuma = 0.2126f * theme.backgroundPrimary.r +
+                             0.7152f * theme.backgroundPrimary.g +
+                             0.0722f * theme.backgroundPrimary.b;
+        const bool darkTheme = bgLuma < 0.5f;
+        if (colorName == "editorCard") {
+            return darkTheme ? NUIColor(0.084f, 0.084f, 0.084f, 0.95f)
+                             : NUIColor(0.962f, 0.963f, 0.968f, 0.97f);
+        }
+        if (colorName == "editorWell") {
+            return darkTheme ? NUIColor(0.010f, 0.010f, 0.014f, 0.98f)
+                             : NUIColor(0.915f, 0.918f, 0.925f, 0.98f);
+        }
+        return darkTheme ? NUIColor(0.068f, 0.068f, 0.068f, 0.90f)
+                         : NUIColor(0.935f, 0.937f, 0.943f, 0.92f);
+    }
+
     // Step Grid Colors
     if (colorName == "stepActive") return theme.primary;                              // Active step (on)
     if (colorName == "stepInactive") return theme.surfaceRaised;                      // Inactive step (off)
@@ -536,16 +773,25 @@ void NUIThemeManager::updateSystemTheme() {
 }
 
 // NUIThemedComponent Implementation
+NUIThemedComponent::~NUIThemedComponent() {
+    unregisterFromThemeUpdates();
+}
+
 void NUIThemedComponent::registerForThemeUpdates() {
     if (!isThemeRegistered_) {
-        // TODO: Register with theme manager
+        themeSubscriptionId_ = NUIThemeManager::getInstance().subscribeToThemeChanges(
+            [this](const NUIThemeProperties& theme) {
+                applyTheme(theme);
+                onThemeChanged(theme);
+            });
         isThemeRegistered_ = true;
     }
 }
 
 void NUIThemedComponent::unregisterFromThemeUpdates() {
     if (isThemeRegistered_) {
-        // TODO: Unregister from theme manager
+        NUIThemeManager::getInstance().unsubscribeFromThemeChanges(themeSubscriptionId_);
+        themeSubscriptionId_ = 0;
         isThemeRegistered_ = false;
     }
 }
@@ -722,7 +968,7 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.backgroundPrimary = theme.background;
     theme.backgroundSecondary = theme.surface;
     theme.surfaceTertiary = theme.surfaceVariant;
-    theme.surfaceRaised = NUIColor(0.92f, 0.92f, 0.93f, 1.0f);
+    theme.surfaceRaised = NUIColor(0.955f, 0.957f, 0.962f, 1.0f);
     theme.primary = NUIColor(0.2f, 0.4f, 0.8f, 1.0f);
     theme.primaryVariant = NUIColor(0.1f, 0.3f, 0.7f, 1.0f);
     theme.primaryHover = NUIColor(0.26f, 0.46f, 0.86f, 1.0f);
@@ -740,10 +986,10 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.accentSecondary = theme.secondary;
     
     // Text colors
-    theme.textPrimary = NUIColor(0.1f, 0.1f, 0.1f, 1.0f);
-    theme.textSecondary = NUIColor(0.4f, 0.4f, 0.4f, 1.0f);
-    theme.textMuted = NUIColor(0.48f, 0.48f, 0.48f, 1.0f);
-    theme.textDisabled = NUIColor(0.6f, 0.6f, 0.6f, 1.0f);
+    theme.textPrimary = NUIColor(0.08f, 0.08f, 0.09f, 1.0f);
+    theme.textSecondary = NUIColor(0.26f, 0.26f, 0.28f, 1.0f);
+    theme.textMuted = NUIColor(0.38f, 0.38f, 0.40f, 1.0f);
+    theme.textDisabled = NUIColor(0.55f, 0.55f, 0.57f, 1.0f);
     theme.textLink = theme.primary;
     theme.textCritical = theme.error;
     theme.textOnPrimary = NUIColor::white();
@@ -772,9 +1018,9 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.highlightGlow = theme.primary.withAlpha(0.14f);
     
     // Borders
-    theme.border = NUIColor(0.8f, 0.8f, 0.8f, 1.0f);
+    theme.border = NUIColor(0.78f, 0.78f, 0.80f, 1.0f);
     theme.borderSubtle = theme.border.withAlpha(0.72f);
-    theme.borderStrong = NUIColor(0.68f, 0.68f, 0.70f, 1.0f);
+    theme.borderStrong = NUIColor(0.62f, 0.62f, 0.65f, 1.0f);
     theme.borderActive = theme.primary;
     theme.divider = NUIColor(0.9f, 0.9f, 0.9f, 1.0f);
     theme.outline = NUIColor(0.7f, 0.7f, 0.7f, 1.0f);
@@ -833,7 +1079,67 @@ NUIThemeProperties NUIThemePresets::createFluentLight() { return createAestraLig
 NUIThemeProperties NUIThemePresets::createFluentDark() { return createAestraDark(); }
 NUIThemeProperties NUIThemePresets::createCupertinoLight() { return createAestraLight(); }
 NUIThemeProperties NUIThemePresets::createCupertinoDark() { return createAestraDark(); }
-NUIThemeProperties NUIThemePresets::createHighContrastLight() { return createAestraLight(); }
-NUIThemeProperties NUIThemePresets::createHighContrastDark() { return createAestraDark(); }
+NUIThemeProperties NUIThemePresets::createHighContrastLight() {
+    auto theme = createAestraLight();
+    theme.backgroundPrimary = NUIColor::white();
+    theme.backgroundSecondary = NUIColor::fromHex(0xf5f5f5);
+    theme.surfaceTertiary = NUIColor::fromHex(0xebebeb);
+    theme.surfaceRaised = NUIColor::fromHex(0xdedede);
+    theme.background = theme.backgroundPrimary;
+    theme.surface = theme.backgroundSecondary;
+    theme.surfaceVariant = theme.surfaceTertiary;
+    theme.textPrimary = NUIColor::black();
+    theme.textSecondary = NUIColor::fromHex(0x303030);
+    theme.textMuted = NUIColor::fromHex(0x4a4a4a);
+    theme.borderSubtle = NUIColor::fromHex(0x777777);
+    theme.borderStrong = NUIColor::black();
+    theme.border = theme.borderStrong;
+    theme.divider = theme.borderSubtle;
+    theme.focusRing = theme.primary;
+    return theme;
+}
+
+NUIThemeProperties NUIThemePresets::createHighContrastDark() {
+    auto theme = createAestraDark();
+    theme.backgroundPrimary = NUIColor::black();
+    theme.backgroundSecondary = NUIColor::fromHex(0x0b0b0b);
+    theme.surfaceTertiary = NUIColor::fromHex(0x151515);
+    theme.surfaceRaised = NUIColor::fromHex(0x202020);
+    theme.background = theme.backgroundPrimary;
+    theme.surface = theme.backgroundSecondary;
+    theme.surfaceVariant = theme.surfaceTertiary;
+    theme.primary = NUIColor::fromHex(0xa78bfa);
+    theme.primaryHover = NUIColor::fromHex(0xc4b5fd);
+    theme.primaryPressed = NUIColor::fromHex(0x8b5cf6);
+    theme.accentPrimary = theme.primary;
+    theme.textOnPrimary = NUIColor::black();
+    theme.onPrimary = theme.textOnPrimary;
+    theme.textPrimary = NUIColor::white();
+    theme.textSecondary = NUIColor::white().withAlpha(0.78f);
+    theme.textMuted = NUIColor::white().withAlpha(0.62f);
+    theme.textDisabled = NUIColor::white().withAlpha(0.42f);
+    theme.borderSubtle = NUIColor::fromHex(0x666666);
+    theme.borderStrong = NUIColor::fromHex(0xb0b0b0);
+    theme.border = theme.borderStrong;
+    theme.divider = theme.borderSubtle;
+    theme.borderActive = theme.primary;
+    theme.focusRing = theme.primary;
+    theme.selected = theme.primary.withAlpha(0.34f);
+    theme.hover = NUIColor::white().withAlpha(0.13f);
+    theme.pressed = NUIColor::white().withAlpha(0.20f);
+    theme.buttonBgDefault = theme.surfaceTertiary;
+    theme.buttonBgHover = theme.surfaceRaised;
+    theme.buttonBgActive = theme.selected;
+    theme.inputBgDefault = theme.backgroundSecondary;
+    theme.inputBgHover = theme.surfaceTertiary;
+    theme.inputBorderFocus = theme.focusRing;
+    theme.sliderTrack = theme.borderSubtle;
+    theme.sliderHandle = theme.primary;
+    theme.sliderHandleHover = theme.primaryHover;
+    theme.sliderHandlePressed = theme.primaryPressed;
+    theme.gridMajor = NUIColor::white().withAlpha(0.24f);
+    theme.gridMinor = NUIColor::white().withAlpha(0.12f);
+    return theme;
+}
 
 } // namespace AestraUI

--- a/AestraUI/Core/NUIThemeSystem.h
+++ b/AestraUI/Core/NUIThemeSystem.h
@@ -5,7 +5,11 @@
 #include "NUIAnimation.h"
 #include <unordered_map>
 #include <string>
+#include <algorithm>
 #include <memory>
+#include <cstdint>
+#include <functional>
+#include <map>
 
 namespace AestraUI {
 
@@ -298,6 +302,8 @@ NUIResolvedControlColors resolveControlColors(const NUIThemeProperties& theme,
 // Theme manager
 class NUIThemeManager {
 public:
+    using ThemeSubscriptionId = std::uint64_t;
+
     static NUIThemeManager& getInstance();
     
     // Theme management
@@ -305,7 +311,10 @@ public:
     NUIThemeVariant getThemeVariant() const { return currentVariant_; }
     
     void setCustomTheme(const std::string& name, const NUIThemeProperties& properties);
-    void setActiveTheme(const std::string& name);
+    bool loadThemeFromFile(const std::string& name, const std::string& filepath,
+                           const std::string& baseTheme = "Aestra-dark");
+    bool setActiveTheme(const std::string& name);
+    bool hasTheme(const std::string& name) const;
     std::string getActiveTheme() const { return activeTheme_; }
     
     // Theme access
@@ -317,6 +326,10 @@ public:
     void switchThemeVariant(NUIThemeVariant variant, float durationMs = 300.0f);
     
     // Theme callbacks
+    ThemeSubscriptionId subscribeToThemeChanges(std::function<void(const NUIThemeProperties&)> callback);
+    void unsubscribeFromThemeChanges(ThemeSubscriptionId subscriptionId);
+    // Compatibility callback slot. New owners should use subscriptions so they
+    // do not replace one another.
     void setOnThemeChanged(std::function<void(const NUIThemeProperties&)> callback);
     
     // Utility methods
@@ -347,11 +360,14 @@ private:
     NUIThemeManager();
     void initializeDefaultThemes();
     void updateSystemTheme();
+    void notifyThemeChanged();
     
     NUIThemeVariant currentVariant_;
     std::string activeTheme_;
     std::unordered_map<std::string, NUIThemeProperties> themes_;
     std::function<void(const NUIThemeProperties&)> onThemeChanged_;
+    std::map<ThemeSubscriptionId, std::function<void(const NUIThemeProperties&)>> themeSubscribers_;
+    ThemeSubscriptionId nextSubscriptionId_ = 1;
     
     // Animation for theme switching
     std::shared_ptr<NUIAnimation> themeTransitionAnimation_;
@@ -363,7 +379,7 @@ private:
 // Theme-aware component base
 class NUIThemedComponent {
 public:
-    virtual ~NUIThemedComponent() = default;
+    virtual ~NUIThemedComponent();
     
     // Theme integration
     virtual void onThemeChanged(const NUIThemeProperties& theme) {}
@@ -383,6 +399,7 @@ protected:
     
 private:
     bool isThemeRegistered_ = false;
+    NUIThemeManager::ThemeSubscriptionId themeSubscriptionId_ = 0;
 };
 
 // Predefined theme presets
@@ -399,5 +416,41 @@ public:
     static NUIThemeProperties createHighContrastLight();
     static NUIThemeProperties createHighContrastDark();
 };
+
+// ---------------------------------------------------------------------------
+// Plugin-editor chrome helpers (polarity-aware neutrals)
+// ---------------------------------------------------------------------------
+
+/** True when the active theme is light (lights-on). */
+inline bool editorLightUi() {
+    const auto& bg = NUIThemeManager::getInstance().getCurrentTheme().backgroundPrimary;
+    return (0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b) >= 0.5f;
+}
+
+/**
+ * Map a plugin editor's dark neutral gray onto the active theme's polarity.
+ * Dark themes return the given gray untouched (editors keep their tuned
+ * near-blacks bit-for-bit); light themes mirror it onto the light-surface
+ * ramp, preserving the raised/recessed ordering (lighter = more raised).
+ */
+inline NUIColor editorNeutral(float darkGray, float alpha = 1.0f) {
+    if (!editorLightUi()) return NUIColor(darkGray, darkGray, darkGray, alpha);
+    const float g = std::min(0.905f + darkGray * 0.38f, 0.985f);
+    return NUIColor(g, g, g, alpha);
+}
+
+/** Tinted variant: dark themes keep the tuned color; light themes map its
+    luma onto the light ramp (the subtle tint reads as gray up there anyway). */
+inline NUIColor editorNeutral(const NUIColor& dark) {
+    if (!editorLightUi()) return dark;
+    const float luma = 0.2126f * dark.r + 0.7152f * dark.g + 0.0722f * dark.b;
+    const float g = std::min(0.905f + luma * 0.38f, 0.985f);
+    return NUIColor(g, g, g, dark.a);
+}
+
+/** The active theme's text ink — replaces hardcoded white overlays/labels. */
+inline NUIColor editorInk(float alpha = 1.0f) {
+    return NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(alpha);
+}
 
 } // namespace AestraUI

--- a/AestraUI/Graphics/NUIRenderer.h
+++ b/AestraUI/Graphics/NUIRenderer.h
@@ -85,6 +85,14 @@ public:
     /**
      * Set the current clip rectangle (scissor test).
      */
+    /**
+     * Compensate text weight for background polarity. Light glyphs on dark
+     * bloom (irradiation); dark glyphs on light do not, so text tuned on a
+     * dark theme reads thin in light mode. 1.0 = dark-theme tuning; values
+     * below 1.0 thicken strokes (light themes want ~0.86-0.92).
+     */
+    virtual void setTextContrast(float contrast) { (void)contrast; }
+
     virtual void setClipRect(const NUIRect& rect) = 0;
     
     /**

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -195,6 +195,8 @@ uniform bool uUseTexture;
 uniform vec2 uTextTexelSize;
 uniform float uTextSharpen;
 uniform float uTextGamma;
+uniform float uTextBold; // SDF edge-center shift; 0 = neutral, positive = bolder
+uniform float uTextAlphaLift; // exponent on text alpha; 1 = neutral, <1 lifts faded text
 uniform bool uOutputLinear;
 
 // Squircle SDF Implementation
@@ -256,13 +258,13 @@ void main() {
              float dist = texColor.r;
              float ddist = fwidth(dist);
              float edgeWidth = ddist * 0.7;
-             float center = 0.5 - smoothstep(0.1, 0.5, ddist) * 0.08; 
+             float center = 0.5 - smoothstep(0.1, 0.5, ddist) * 0.08 - uTextBold; 
              float alpha = smoothstep(center - edgeWidth, center + edgeWidth, dist);
-             color.a *= alpha;
+             color.a = pow(color.a, uTextAlphaLift) * alpha;
         } else if (primitiveID == 4) {
                // Bitmap text — atlas stores coverage in alpha channel.
                float coverage = pow(sampleTextCoverage(vTexCoord), uTextGamma);
-               color.a *= coverage;
+               color.a = pow(color.a, uTextAlphaLift) * coverage;
         } else {
              // Regular textured primitive
              color *= texColor;
@@ -2820,6 +2822,8 @@ void NUIRendererGL::drawTexture(const NUIRect& bounds, const unsigned char* rgba
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
+    glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -3124,6 +3128,8 @@ void NUIRendererGL::flush() {
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
+    glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
     // Note: opacity is already in vertex colors
     glUniform1i(primitiveShader_.primitiveTypeLoc, currentPrimitiveType_);
     // Default to no texturing; enable below if a texture is bound
@@ -3160,7 +3166,7 @@ void NUIRendererGL::flush() {
             const bool tinyAtlas = (currentTextureId_ == fontAtlasTextureIdXSmall_
                                     || currentTextureId_ == fontAtlasTextureIdSmall_);
             glUniform1f(primitiveShader_.textSharpenLoc, tinyAtlas ? 0.20f : 0.28f);
-            glUniform1f(primitiveShader_.textGammaLoc, tinyAtlas ? 0.74f : 0.93f);
+            glUniform1f(primitiveShader_.textGammaLoc, (tinyAtlas ? 0.74f : 0.93f) * textContrast_);
         }
     }
     
@@ -3245,6 +3251,8 @@ bool NUIRendererGL::loadShaders() {
     primitiveShader_.textTexelSizeLoc = glGetUniformLocation(primitiveShader_.id, "uTextTexelSize");
     primitiveShader_.textSharpenLoc = glGetUniformLocation(primitiveShader_.id, "uTextSharpen");
     primitiveShader_.textGammaLoc = glGetUniformLocation(primitiveShader_.id, "uTextGamma");
+    primitiveShader_.textBoldLoc = glGetUniformLocation(primitiveShader_.id, "uTextBold");
+    primitiveShader_.textAlphaLiftLoc = glGetUniformLocation(primitiveShader_.id, "uTextAlphaLift");
     primitiveShader_.outputLinearLoc = glGetUniformLocation(primitiveShader_.id, "uOutputLinear");
 
     

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.h
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.h
@@ -49,6 +49,7 @@ public:
     // ========================================================================
     
     void beginFrame() override;
+    void setTextContrast(float contrast) override { textContrast_ = contrast; }
     void endFrame() override;
     void clear(const NUIColor& color) override;
     
@@ -204,6 +205,8 @@ private:
         int32_t textTexelSizeLoc = -1;
         int32_t textSharpenLoc = -1;
         int32_t textGammaLoc = -1;
+        int32_t textBoldLoc = -1;
+        int32_t textAlphaLiftLoc = -1;
         int32_t outputLinearLoc = -1;
     };
     
@@ -312,6 +315,7 @@ private:
     bool scissorEnabled_ = false;
     bool debugTextBounds_ = false;
     bool framebufferSRGBEnabled_ = false;
+    float textContrast_ = 1.0f;
 
     
     // OpenGL objects

--- a/AestraUI/Helpers/TimelineGridRenderer.h
+++ b/AestraUI/Helpers/TimelineGridRenderer.h
@@ -36,7 +36,8 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
                                float gridEndX,
                                float scrollX,
                                float pixelsPerBeat,
-                               int beatsPerBar) {
+                               int beatsPerBar,
+                               const NUIColor& ink = NUIColor::white()) {
     const float gridWidth = std::max(0.0f, gridEndX - gridStartX);
     beatsPerBar = std::max(1, beatsPerBar);
     const float pixelsPerBar = pixelsPerBeat * static_cast<float>(beatsPerBar);
@@ -73,7 +74,7 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
             }
             if (rectWidth > 0.0f) {
                 renderer.fillRect(NUIRect(rectX, bounds.y, rectWidth, bounds.height),
-                                  NUIColor::white().withAlpha(alpha));
+                                  ink.withAlpha(alpha));
             }
         }
     };
@@ -91,7 +92,7 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
         renderer.drawLine(NUIPoint(x, bounds.y),
                           NUIPoint(x, bounds.bottom()),
                           1.0f,
-                          NUIColor::white().withAlpha(alpha));
+                          ink.withAlpha(alpha));
     };
     const float beatLineAlpha = lineAlpha(pixelsPerBeat);
     const float halfBeatLineAlpha = lineAlpha(pixelsPerBeat * 0.5f);

--- a/AestraUI/Widgets/AestraCompEditor.cpp
+++ b/AestraUI/Widgets/AestraCompEditor.cpp
@@ -16,11 +16,11 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 
-NUIColor insetBg() { return NUIColor(0.02f, 0.02f, 0.02f, 0.960f); }
-NUIColor curveBg() { return NUIColor(0.037f, 0.037f, 0.037f, 1.0f); }
+NUIColor insetBg() { return editorNeutral(0.02f, 0.960f); }
+NUIColor curveBg() { return editorNeutral(0.037f, 1.0f); }
 NUIColor amber() { return NUIColor(0.88f, 0.63f, 0.14f, 1.0f); }
 NUIColor purple() { return NUIColor(0.50f, 0.35f, 0.94f, 1.0f); }
-NUIColor dimText() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
+NUIColor dimText() { return editorInk(0.30f); }
 
 float levelToNorm(float linear) {
     const float db = linear > 1.0e-8f ? 20.0f * std::log10(linear) : -60.0f;
@@ -266,7 +266,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     // Zone backgrounds — curve gets its own bg, stats + modes get a slightly darker treatment
     renderer.fillRoundedRect({curveLeft - 4.0f, b.y, curveW + 8.0f, b.height}, 6.0f, curveBg());
     renderer.fillRoundedRect({statsX - 4.0f, b.y, kStatsW + kModesW + kDividerW + kRightMargin + 8.0f, b.height},
-                             6.0f, NUIColor(0.014f, 0.014f, 0.014f, 0.92f));
+                             6.0f, editorNeutral(0.014f, 0.92f));
 
     renderer.strokeRoundedRect(b, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.05f));
     // Subtle top highlight
@@ -424,7 +424,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
             renderer.drawTextCentered(pillLabels[i], r, 9.5f, NUIColor(1, 1, 1, 0.98f));
         } else {
             // Body — deep dark inset
-            renderer.fillRoundedRect(r, 5.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.90f));
+            renderer.fillRoundedRect(r, 5.0f, editorNeutral(0.018f, 0.90f));
             // Top inner shadow
             renderer.drawLine({r.x + 5.0f, r.y + 1.0f}, {r.x + r.width - 5.0f, r.y + 1.0f},
                               0.5f, NUIColor(0, 0, 0, 0.30f));
@@ -443,7 +443,7 @@ void AestraCompEditor::drawMeters(NUIRenderer& renderer, NUIColor accent) {
 
     auto drawMeter = [&](float x, const char* label, float norm, NUIColor color) {
         const NUIRect meterBounds(x, b.y, thirdW, b.height);
-        renderer.fillRoundedRect(meterBounds, 5.0f, NUIColor(0.008f, 0.008f, 0.008f, 1.0f));
+        renderer.fillRoundedRect(meterBounds, 5.0f, editorNeutral(0.008f, 1.0f));
         renderer.strokeRoundedRect(meterBounds, 5.0f, 1.0f, NUIColor(1, 1, 1, 0.055f));
 
         // Fill
@@ -478,7 +478,7 @@ void AestraCompEditor::drawControl(NUIRenderer& renderer, const KnobControl& con
 
     // Knob cell background + border
     const NUIColor cellBg(0.035f, 0.035f, 0.040f, 0.96f);
-    const NUIColor cellBorder = prim ? NUIColor(0.18f, 0.13f, 0.28f, 1.0f) : NUIColor(0.118f, 0.118f, 0.133f, 1.0f);
+    const NUIColor cellBorder = prim ? NUIColor(0.18f, 0.13f, 0.28f, 1.0f) : editorNeutral(NUIColor(0.118f, 0.118f, 0.133f, 1.0f));
     renderer.fillRoundedRect(control.bounds, 8.0f, cellBg);
     renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f, cellBorder);
     // Subtle top highlight on primary cells
@@ -517,14 +517,14 @@ void AestraCompEditor::drawControl(NUIRenderer& renderer, const KnobControl& con
 
     // Label (top of cell) — spec: rgba(255,255,255,0.5), 9px
     renderer.drawTextCentered(control.label, {control.bounds.x, control.bounds.y + 2.0f, control.bounds.width, 12.0f},
-                              9.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.50f));
+                              9.0f, editorInk(0.50f));
 
     // Value (bottom of cell) — primary: muted lavender #9b8fcc, utility: spec rgba(255,255,255,0.85)
     const float valueY = prim ? control.bounds.bottom() - 18.0f
                               : knobRect.bottom() + 4.0f;
     const NUIColor valueColor = prim
         ? NUIColor(0.608f, 0.561f, 0.800f, 1.0f)   // #9b8fcc
-        : NUIColor(1.0f, 1.0f, 1.0f, 0.85f);        // rgba(255,255,255,0.85)
+        : editorInk(0.85f);        // rgba(255,255,255,0.85)
     renderer.drawTextCentered(valueText(control.paramId),
                               {control.bounds.x, valueY, control.bounds.width, 14.0f},
                               11.0f, valueColor);
@@ -562,8 +562,8 @@ void AestraCompEditor::drawUtilityButtons(NUIRenderer& renderer, NUIColor accent
             renderer.strokeRoundedRect(btn.bounds, 5.0f, 1.0f, activeAccent.withAlpha(0.80f));
             renderer.drawTextCentered(btn.label, btn.bounds, 9.0f, NUIColor(1, 1, 1, 0.95f));
         } else {
-            const NUIColor bg = btn.hov ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
-                                        : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
+            const NUIColor bg = btn.hov ? editorNeutral(0.041f, 0.90f)
+                                        : editorNeutral(0.022f, 0.90f);
             renderer.fillRoundedRect(btn.bounds, 5.0f, bg);
             renderer.drawLine({btn.bounds.x + 5.0f, btn.bounds.y + 1.0f},
                               {btn.bounds.x + btn.bounds.width - 5.0f, btn.bounds.y + 1.0f},

--- a/AestraUI/Widgets/AestraDelayEditor.cpp
+++ b/AestraUI/Widgets/AestraDelayEditor.cpp
@@ -20,7 +20,7 @@ NUIColor cyanAccent() {
     return NUIColor(0.0f, 0.90f, 0.80f, 1.0f);
 }
 NUIColor cardBg() {
-    return NUIColor(0.084f, 0.084f, 0.084f, 0.95f);
+    return NUIThemeManager::getInstance().getColor("editorCard");
 }
 NUIRect offsetRect(const NUIRect& r, float dx, float dy) {
     return NUIRect(r.x + dx, r.y + dy, r.width, r.height);
@@ -267,10 +267,10 @@ void AestraDelayEditor::drawPillSwitches(NUIRenderer& renderer, float wx, float 
         const NUIRect groupLabelRect(outer.x - labelW, outer.y, labelW - 8.0f, outer.height);
         renderer.drawText(groupLabel, {groupLabelRect.x + 2.0f, groupLabelRect.y + 12.0f}, 9.0f,
                           theme.getColor("textSecondary").withAlpha(0.70f));
-        renderer.fillRoundedRect(outer, 9.0f, NUIColor(0.018f, 0.018f, 0.022f, 0.98f));
-        renderer.strokeRoundedRect(outer, 9.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.13f));
+        renderer.fillRoundedRect(outer, 9.0f, NUIThemeManager::getInstance().getColor("editorWell"));
+        renderer.strokeRoundedRect(outer, 9.0f, 1.0f, editorInk().withAlpha(0.13f));
         renderer.drawLine({right.x, outer.y + 7.0f}, {right.x, outer.bottom() - 7.0f}, 1.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, 0.10f));
+                          editorInk().withAlpha(0.10f));
         auto seg = [&](const NUIRect& rect, const char* label, bool active) {
             const NUIRect inset(rect.x + 3.0f, rect.y + 3.0f, rect.width - 6.0f, rect.height - 6.0f);
             if (active) {
@@ -294,7 +294,7 @@ void AestraDelayEditor::drawSectionFrame(NUIRenderer& renderer, const NUIRect& l
                                          const NUIColor& color, float wx, float wy) {
     auto& theme = NUIThemeManager::getInstance();
     const NUIRect rect = offsetRect(localRect, wx, wy);
-    renderer.fillRoundedRect(rect, 14.0f, NUIColor(0.020f, 0.020f, 0.024f, 0.98f));
+    renderer.fillRoundedRect(rect, 14.0f, NUIThemeManager::getInstance().getColor("editorWell"));
     renderer.strokeRoundedRect(rect, 14.0f, 1.5f, color.withAlpha(0.58f));
     renderer.fillRoundedRect({rect.x + 12.0f, rect.y + 12.0f, 4.0f, 16.0f}, 2.0f, color);
     renderer.drawText(title, {rect.x + 24.0f, rect.y + 14.0f}, 10.5f, theme.getColor("textPrimary").withAlpha(0.92f));
@@ -312,7 +312,7 @@ void AestraDelayEditor::drawEchoDisplay(NUIRenderer& renderer, float wx, float w
     const float stereo = m_instance->getParameter(Delay::kStereoShift) * 2.0f - 1.0f;
     const float modulation = m_instance->getParameter(Delay::kModDepth);
 
-    renderer.fillRoundedRect(rect, 10.0f, NUIColor(0.008f, 0.008f, 0.012f, 0.98f));
+    renderer.fillRoundedRect(rect, 10.0f, NUIThemeManager::getInstance().getColor("editorWell"));
     renderer.strokeRoundedRect(rect, 10.0f, 1.0f, cyanAccent().withAlpha(0.26f));
     renderer.drawText("ECHO PATH", {rect.x + 12.0f, rect.y + 9.0f}, 9.5f,
                       theme.getColor("textSecondary").withAlpha(0.82f));
@@ -382,7 +382,8 @@ void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy)
             renderer.fillRoundedRect(r, 6.0f, accent());
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textPrimary"));
         } else {
-            NUIColor fill = hovered ? NUIColor(0.099f, 0.099f, 0.099f, 0.92f) : NUIColor(0.068f, 0.068f, 0.068f, 0.90f);
+            NUIColor fill = NUIThemeManager::getInstance().getColor("editorControl");
+            if (hovered) fill = fill.lightened(0.03f);
             renderer.fillRoundedRect(r, 6.0f, fill);
             renderer.strokeRoundedRect(r, 6.0f, 1.0f, accent().withAlpha(0.32f));
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textSecondary").withAlpha(0.88f));
@@ -442,7 +443,7 @@ void AestraDelayEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, fl
     const float cy = knobRect.center().y;
     const float r = kKnobSize * 0.40f;
     renderer.fillCircle({cx, cy}, r + 7.0f, knobAccent.withAlpha(0.07f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, NUIThemeManager::getInstance().getColor("editorWell").withAlpha(0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, knobAccent.withAlpha(0.32f));
 
     const float sa = kPi * 0.75f;
@@ -469,7 +470,7 @@ void AestraDelayEditor::drawMixSlider(NUIRenderer& renderer, float wx, float wy)
     const float mix = m_instance ? m_instance->getParameter(Delay::kMix) : 0.0f;
     NUIRect mixRect = offsetRect(m_mixSliderRect, wx, wy);
     const NUIRect track(mixRect.x + 58.0f, mixRect.y + 12.0f, mixRect.width - 104.0f, 8.0f);
-    renderer.fillRoundedRect(mixRect, 10.0f, NUIColor(0.068f, 0.068f, 0.068f, 0.92f));
+    renderer.fillRoundedRect(mixRect, 10.0f, NUIThemeManager::getInstance().getColor("editorControl"));
     renderer.strokeRoundedRect(mixRect, 10.0f, 1.0f, accent().withAlpha(0.35f));
     renderer.drawText("Mix", {mixRect.x + 14.0f, mixRect.y + 10.0f}, 10.5f,
                       theme.getColor("textPrimary").withAlpha(0.95f));

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -29,13 +29,13 @@ NUIColor motionAccent() {
     return NUIColor(1.0f, 0.45f, 0.64f, 1.0f);
 }
 NUIColor shellSurface() {
-    return NUIColor(0.024f, 0.023f, 0.031f, 0.99f);
+    return editorNeutral(NUIColor(0.024f, 0.023f, 0.031f, 0.99f));
 }
 NUIColor panelSurface() {
-    return NUIColor(0.040f, 0.038f, 0.050f, 0.99f);
+    return editorNeutral(NUIColor(0.040f, 0.038f, 0.050f, 0.99f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.018f, 0.017f, 0.024f, 0.99f);
+    return editorNeutral(NUIColor(0.018f, 0.017f, 0.024f, 0.99f));
 }
 
 NUIColor parameterAccent(uint32_t parameterId) {
@@ -193,7 +193,7 @@ void AestraDriftEditor::drawPitchPanel(NUIRenderer& renderer) {
                                            : insetSurface());
         renderer.strokeRoundedRect(m_intervalBounds[i], 7.0f, 1.0f,
                                    active || hovered ? pitchAccent().withAlpha(0.56f)
-                                                     : NUIColor(1.0f, 1.0f, 1.0f, 0.05f));
+                                                     : editorInk(0.05f));
         const std::string label =
             kIntervals[i] > 0 ? "+" + std::to_string(kIntervals[i]) : std::to_string(kIntervals[i]);
         renderer.drawTextCentered(label, m_intervalBounds[i], 9.0f,
@@ -211,9 +211,9 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer) {
     renderer.fillCircle(center, radius, insetSurface());
     renderer.strokeCircle(center, radius, 1.0f,
                           m_pitchHovered || m_draggingPitch ? pitchAccent().withAlpha(0.54f)
-                                                            : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                                                            : editorInk(0.08f));
     drawArc(renderer, center, radius - 11.0f, kWheelStart, kWheelStart + kWheelSweep, 6.0f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+            editorInk(0.09f));
     drawArc(renderer, center, radius - 11.0f, kWheelStart, angle, 6.0f, pitchAccent().withAlpha(0.94f));
     for (int semitones : kIntervals) {
         const float t = (static_cast<float>(semitones) + 12.0f) / 24.0f;
@@ -228,7 +228,7 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer) {
     }
     const NUIPoint needle{center.x + std::cos(angle) * (radius - 35.0f), center.y + std::sin(angle) * (radius - 35.0f)};
     renderer.drawLine(center, needle, 2.3f, pitchAccent().withAlpha(0.88f));
-    renderer.fillCircle(center, 28.0f, NUIColor(0.048f, 0.045f, 0.060f, 1.0f));
+    renderer.fillCircle(center, 28.0f, editorNeutral(NUIColor(0.048f, 0.045f, 0.060f, 1.0f)));
     renderer.strokeCircle(center, 28.0f, 1.0f, pitchAccent().withAlpha(0.30f));
     renderer.drawTextCentered(pitchValueString(), {center.x - 34.0f, center.y - 11.0f, 68.0f, 22.0f}, 18.0f,
                               pitchAccent());
@@ -263,21 +263,21 @@ void AestraDriftEditor::drawKnob(NUIRenderer& renderer, const KnobControl& contr
         control.parameterId == Drift::kMotionRate && m_instance->getParameter(Drift::kMotion) < 0.001f;
     const NUIColor color = parameterAccent(control.parameterId);
     renderer.fillRoundedRect(control.bounds, 10.0f,
-                             hovered || dragging ? NUIColor(0.070f, 0.064f, 0.086f, 0.98f) : insetSurface());
+                             hovered || dragging ? editorNeutral(NUIColor(0.070f, 0.064f, 0.086f, 0.98f)) : insetSurface());
     renderer.strokeRoundedRect(control.bounds, 10.0f, 1.0f,
-                               hovered || dragging ? color.withAlpha(0.48f) : NUIColor(1.0f, 1.0f, 1.0f, 0.045f));
+                               hovered || dragging ? color.withAlpha(0.48f) : editorInk(0.045f));
     const float value = m_instance->getParameter(control.parameterId);
     const NUIPoint center = control.knobBounds.center();
     const float radius = control.knobBounds.width * 0.5f;
     const float angle = kWheelStart + value * kWheelSweep;
-    renderer.fillCircle(center, radius, NUIColor(0.030f, 0.029f, 0.039f, 1.0f));
-    renderer.strokeCircle(center, radius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+    renderer.fillCircle(center, radius, editorNeutral(NUIColor(0.030f, 0.029f, 0.039f, 1.0f)));
+    renderer.strokeCircle(center, radius, 1.0f, editorInk(0.07f));
     drawArc(renderer, center, radius - 6.0f, kWheelStart, kWheelStart + kWheelSweep, 3.5f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            editorInk(0.08f));
     drawArc(renderer, center, radius - 6.0f, kWheelStart, angle, 3.5f, color.withAlpha(rateInactive ? 0.30f : 0.92f));
     const NUIPoint needle{center.x + std::cos(angle) * (radius - 14.0f), center.y + std::sin(angle) * (radius - 14.0f)};
     renderer.drawLine(center, needle, 1.8f, color.withAlpha(rateInactive ? 0.28f : 0.86f));
-    renderer.fillCircle(center, 4.5f, NUIColor(0.070f, 0.066f, 0.086f, 1.0f));
+    renderer.fillCircle(center, 4.5f, editorNeutral(NUIColor(0.070f, 0.066f, 0.086f, 1.0f)));
     renderer.fillCircle(center, 1.8f, color.withAlpha(rateInactive ? 0.30f : 0.90f));
 
     const float labelY = control.knobBounds.bottom() + 5.0f;
@@ -297,7 +297,7 @@ void AestraDriftEditor::drawMixBar(NUIRenderer& renderer) {
     renderer.strokeRoundedRect(m_mixBounds, 11.0f, 1.0f, pitchAccent().withAlpha(m_draggingMix ? 0.56f : 0.18f));
     renderer.drawText("BLEND", {m_mixBounds.x + 14.0f, m_mixBounds.y + 15.0f}, 9.0f, theme.getColor("textPrimary"));
     const NUIRect track(m_mixBounds.x + 70.0f, m_mixBounds.y + 17.0f, m_mixBounds.width - 132.0f, 8.0f);
-    renderer.fillRoundedRect(track, 4.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+    renderer.fillRoundedRect(track, 4.0f, editorInk(0.09f));
     renderer.fillRoundedRect({track.x, track.y, track.width * mix, track.height}, 4.0f, pitchAccent().withAlpha(0.90f));
     const NUIPoint thumb{track.x + track.width * mix, track.center().y};
     renderer.fillCircle(thumb, 8.0f, pitchAccent().withAlpha(0.20f));

--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -23,7 +23,7 @@ constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accent() { return NUIColor(0.55f, 0.40f, 0.92f, 1.0f); }
 NUIColor accentSoft() { return NUIColor(0.55f, 0.40f, 0.92f, 0.35f); }
-NUIColor graphBg() { return NUIColor(0.045f, 0.045f, 0.045f, 0.96f); }
+NUIColor graphBg() { return editorNeutral(0.045f, 0.96f); }
 
 std::shared_ptr<NUIIcon> makeSvgIcon(const char* svg) {
     return std::make_shared<NUIIcon>(svg);
@@ -1398,7 +1398,7 @@ void AestraEQEditor::drawOutputGainPill(NUIRenderer& renderer) {
     const NUIColor outline =
         m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.44f) : NUIColor(1, 1, 1, 0.14f);
     const NUIColor fill = m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.11f)
-                                                                      : NUIColor(0.035f, 0.035f, 0.035f, 0.88f);
+                                                                      : editorNeutral(0.035f, 0.88f);
     renderer.fillRoundedRect(m_outputGainRect, 7.0f, fill);
     renderer.strokeRoundedRect(m_outputGainRect, 7.0f, 1.0f, outline);
     std::string gainText = formatGain(gain);
@@ -1452,7 +1452,7 @@ void AestraEQEditor::drawComparePills(NUIRenderer& renderer) {
     const char* label = m_compareActiveSlot == 0 ? "A>B" : "B>A";
     renderer.fillRoundedRect(m_compareCopyRect, 7.0f,
                              m_compareCopyHovered ? accent().withAlpha(0.11f)
-                                                  : NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
+                                                  : editorNeutral(0.035f, 0.88f));
     renderer.strokeRoundedRect(m_compareCopyRect, 7.0f, 1.0f,
                                m_compareCopyHovered ? accent().withAlpha(0.42f) : NUIColor(1, 1, 1, 0.13f));
     drawSvgIcon(renderer, compareCopyIcon(), {m_compareCopyRect.x + 7.0f, m_compareCopyRect.y + 5.0f, 14.0f, 14.0f},
@@ -1492,7 +1492,7 @@ void AestraEQEditor::drawAnalyzerSettingsPanel(NUIRenderer& renderer) {
         return;
 
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
+    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, editorNeutral(0.031f, 0.94f));
     renderer.strokeRoundedRect(m_analyzerPanelRect, 8.0f, 1.0f, accent().withAlpha(0.34f));
     renderer.drawText("Analyzer", {m_analyzerPanelRect.x + 10.0f, m_analyzerPanelRect.y + 9.0f}, 9.5f,
                       theme.getColor("textPrimary").withAlpha(0.92f));
@@ -1632,7 +1632,7 @@ void AestraEQEditor::drawKnob(NUIRenderer& renderer, const NUIRect& bounds, floa
     const float r = bounds.width * 0.42f;
     const NUIColor col = active ? a : NUIColor(a.r, a.g, a.b, 0.30f);
     renderer.fillCircle({cx, cy}, r + 5.0f, col.withAlpha(active ? 0.08f : 0.04f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, col.withAlpha(active ? 0.34f : 0.18f));
 
     const float sa = kPi * 0.75f;
@@ -1665,7 +1665,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         return;
 
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, NUIColor(0.046f, 0.046f, 0.046f, 0.97f));
+    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, editorNeutral(0.046f, 0.97f));
     renderer.strokeRoundedRect(m_bandInspectorRect, 7.0f, 1.0f, band.withAlpha(0.16f));
     renderer.fillRect({m_bandInspectorRect.x, m_bandInspectorRect.y, m_bandInspectorRect.width, 2.0f},
                       band.withAlpha(0.72f));
@@ -1746,7 +1746,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
                                                m_bandInspectorRect.right() - chipW - 10.0f);
                 const NUIRect hoverChip{chipX, slotRail.bottom() + 7.0f, chipW, 19.0f};
                 const NUIColor hoverColor = bandColor(hoverBand.slotIndex);
-                renderer.fillRoundedRect(hoverChip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+                renderer.fillRoundedRect(hoverChip, 5.0f, editorNeutral(0.026f, 0.96f));
                 renderer.strokeRoundedRect(hoverChip, 5.0f, 1.0f, hoverColor.withAlpha(0.34f));
                 renderer.drawTextCentered(hoverText, hoverChip, 7.8f, theme.getColor("textSecondary").withAlpha(0.88f));
             }
@@ -1818,7 +1818,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(bd.stereoButton.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           bd.stereoButton.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(modeHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1828,7 +1828,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(m_selectedCollapseRect.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           m_selectedCollapseRect.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(collapseHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1854,7 +1854,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const float trackY = lane.center().y;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(lane, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.95f));
+        renderer.fillRoundedRect(lane, 5.0f, editorNeutral(0.026f, 0.95f));
         renderer.fillRoundedRect({lane.x, lane.y, labelW, lane.height}, 5.0f,
                                  bd.enabled ? band.withAlpha(0.050f) : band.withAlpha(0.018f));
         renderer.fillRoundedRect({trackX, trackY - 1.5f, trackW, 3.0f}, 1.5f, NUIColor(1, 1, 1, 0.080f));
@@ -2114,7 +2114,7 @@ void AestraEQEditor::drawAnalyzerCollisionOverlay(NUIRenderer& renderer, const N
             std::clamp(inner.x + peakNorm * inner.width - chipW * 0.5f, inner.x + 8.0f, inner.right() - chipW - 8.0f);
         const NUIRect chip{chipX, inner.y + 28.0f, chipW, 22.0f};
         const NUIColor heat(1.0f, 0.40f, 0.18f, 1.0f);
-        renderer.fillRoundedRect(chip, 6.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
+        renderer.fillRoundedRect(chip, 6.0f, editorNeutral(0.035f, 0.88f));
         renderer.strokeRoundedRect(chip, 6.0f, 1.0f, heat.withAlpha(0.34f + peakMask * 0.22f));
         renderer.drawText(maskBuf, {chip.x + 8.0f, chip.y + 6.0f}, 8.3f, heat.withAlpha(0.92f));
         renderer.drawText(freqBuf, {chip.right() - 38.0f, chip.y + 6.0f}, 8.3f,
@@ -2208,11 +2208,11 @@ void AestraEQEditor::drawGraphCursorReadout(NUIRenderer& renderer, const NUIRect
     const NUIColor preview = canAddBand ? accent() : theme.getColor("textSecondary");
 
     renderer.drawLine({m_graphCursorPoint.x, inner.y}, {m_graphCursorPoint.x, inner.bottom()}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, canAddBand ? 0.085f : 0.040f));
+                      editorInk(canAddBand ? 0.085f : 0.040f));
     renderer.drawLine({inner.x, m_graphCursorPoint.y}, {inner.right(), m_graphCursorPoint.y}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, canAddBand ? 0.070f : 0.035f));
+                      editorInk(canAddBand ? 0.070f : 0.035f));
     renderer.fillCircle(m_graphCursorPoint, 10.0f, preview.withAlpha(canAddBand ? 0.050f : 0.025f));
-    renderer.fillCircle(m_graphCursorPoint, 4.0f, NUIColor(0.045f, 0.045f, 0.045f, 0.64f));
+    renderer.fillCircle(m_graphCursorPoint, 4.0f, editorNeutral(0.045f, 0.64f));
     renderer.strokeCircle(m_graphCursorPoint, 7.0f, 1.1f, preview.withAlpha(canAddBand ? 0.34f : 0.16f));
     renderer.drawLine({m_graphCursorPoint.x - 3.0f, m_graphCursorPoint.y},
                       {m_graphCursorPoint.x + 3.0f, m_graphCursorPoint.y}, 1.2f,
@@ -2314,7 +2314,7 @@ void AestraEQEditor::drawNodeHoverTooltip(NUIRenderer& renderer, const NUIRect& 
     y = std::clamp(y, inner.y + 6.0f, inner.bottom() - h - 6.0f);
     const NUIRect r{x, y, w, h};
 
-    renderer.fillRoundedRect(r, 5.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.90f));
+    renderer.fillRoundedRect(r, 5.0f, editorNeutral(0.031f, 0.90f));
     renderer.strokeRoundedRect(r, 5.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, r.x + 8.0f, r.right() - 8.0f);
     const float stemY = r.y > node.y ? r.y : r.bottom();
@@ -2344,7 +2344,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
     const bool canType = bd.typeId != 0 || !bd.legacySlot;
     const bool canDelete = !bd.legacySlot;
 
-    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, NUIColor(0.028f, 0.028f, 0.028f, 0.94f));
+    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, editorNeutral(0.028f, 0.94f));
     renderer.strokeRoundedRect(m_nodeQuickActionRect, 7.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, m_nodeQuickActionRect.x + 10.0f, m_nodeQuickActionRect.right() - 10.0f);
     const float stemY = m_nodeQuickActionRect.y > node.y ? m_nodeQuickActionRect.y : m_nodeQuickActionRect.bottom();
@@ -2359,11 +2359,11 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
         const NUIColor base = destructive ? red : band;
         const NUIColor fill = soloAction ? base.withAlpha(hovered ? 0.24f : 0.17f)
                                          : (enabled && hovered ? base.withAlpha(destructive ? 0.12f : 0.15f)
-                                                               : NUIColor(1.0f, 1.0f, 1.0f, enabled ? 0.026f : 0.010f));
+                                                               : editorInk(enabled ? 0.026f : 0.010f));
         const NUIColor edge = soloAction ? base.withAlpha(hovered ? 0.72f : 0.54f)
                               : enabled  ? (hovered ? base.withAlpha(destructive ? 0.48f : 0.44f)
                                                     : base.withAlpha(destructive ? 0.24f : 0.20f))
-                                         : NUIColor(1.0f, 1.0f, 1.0f, 0.040f);
+                                         : editorInk(0.040f);
         if (soloAction) {
             renderer.fillRoundedRect({r.x - 3.0f, r.y - 3.0f, r.width + 6.0f, r.height + 6.0f}, 7.0f,
                                      base.withAlpha(0.075f));
@@ -2440,7 +2440,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
             }
             tipY = std::clamp(tipY, inner.y + 4.0f, inner.bottom() - 22.0f);
             const NUIRect tip{tipX, tipY, tipW, 18.0f};
-            renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.94f));
+            renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.94f));
             renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.26f));
             renderer.drawTextCentered(label, tip, 7.7f, theme.getColor("textSecondary").withAlpha(0.86f));
         }
@@ -2462,7 +2462,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
     for (int db = -gridMax; db <= gridMax; db += gridStep) {
         const float y = inner.bottom() - (static_cast<float>(db) + dbRange) / (dbRange * 2.0f) * inner.height;
         const float alpha = (db == 0) ? 0.28f : 0.10f;
-        renderer.drawLine({inner.x, y}, {inner.right(), y}, db == 0 ? 1.2f : 1.0f, NUIColor(1.0f, 1.0f, 1.0f, alpha));
+        renderer.drawLine({inner.x, y}, {inner.right(), y}, db == 0 ? 1.2f : 1.0f, editorInk(alpha));
         const std::string lbl = (db > 0 ? "+" : "") + std::to_string(db);
         renderer.drawTextCentered(lbl, {bounds.x + 3.0f, y - 7.0f, 26.0f, 14.0f}, 8.6f,
                                   theme.getColor("textSecondary").withAlpha(0.66f));
@@ -2474,7 +2474,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
     for (int i = 0; i < 6; ++i) {
         const float norm = (std::log10(freqs[i]) - logMin) / (logMax - logMin);
         const float x = inner.x + norm * inner.width;
-        renderer.drawLine({x, inner.y}, {x, inner.bottom()}, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+        renderer.drawLine({x, inner.y}, {x, inner.bottom()}, 1.0f, editorInk(0.07f));
         renderer.drawTextCentered(freqLabels[i], {x - 14.0f, inner.bottom() + 1.0f, 28.0f, 14.0f}, 8.6f,
                                   theme.getColor("textSecondary").withAlpha(0.70f));
     }
@@ -2560,7 +2560,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
         renderer.fillCircle(
             node, radius + (quietDynamicNode ? 2.4f : 4.0f),
             c.withAlpha((selected || dragging || soloed ? 0.18f : (quietDynamicNode ? 0.050f : 0.10f)) * activeAlpha));
-        renderer.fillCircle(node, radius, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+        renderer.fillCircle(node, radius, editorNeutral(0.045f, 0.96f));
         renderer.strokeCircle(node, radius, bd.enabled ? (quietDynamicNode ? 1.1f : 1.6f) : 1.1f,
                               c.withAlpha(bd.enabled ? (quietDynamicNode ? 0.58f : 1.0f) : 0.42f));
         if (bd.enabled) {
@@ -2631,7 +2631,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     const NUIRect handle{x - 6.0f, y - 6.0f, 12.0f, 12.0f};
     renderer.fillRoundedRect({handle.x - 4.0f, handle.y - 4.0f, handle.width + 8.0f, handle.height + 8.0f}, 5.0f,
                              c.withAlpha(dragging ? 0.12f : 0.06f));
-    renderer.fillRoundedRect(handle, 3.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
+    renderer.fillRoundedRect(handle, 3.0f, editorNeutral(0.031f, 0.94f));
     renderer.strokeRoundedRect(handle, 3.0f, dragging ? 1.6f : 1.1f, c.withAlpha(dragging ? 0.95f : 0.72f));
 
     char freqBuf[24];
@@ -2641,7 +2641,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     else
         std::snprintf(freqBuf, sizeof(freqBuf), "%.0f", hz);
     const NUIRect chip{std::clamp(x - 42.0f, inner.x + 6.0f, inner.right() - 84.0f), y + 11.0f, 84.0f, 19.0f};
-    renderer.fillRoundedRect(chip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.86f));
+    renderer.fillRoundedRect(chip, 5.0f, editorNeutral(0.026f, 0.86f));
     renderer.strokeRoundedRect(chip, 5.0f, 1.0f, c.withAlpha(0.24f));
     renderer.drawText("DET", {chip.x + 7.0f, std::round(renderer.calculateTextY(chip, 7.4f))}, 7.4f,
                       c.withAlpha(0.76f));
@@ -2665,7 +2665,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
     const NUIRect r = layout.panel;
     const NUIColor c = bandColor(bd.slotIndex);
 
-    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.052f, 0.052f, 0.052f, 0.96f));
+    renderer.fillRoundedRect(r, 6.0f, editorNeutral(0.052f, 0.96f));
     renderer.strokeRoundedRect(r, 6.0f, 1.0f, c.withAlpha(bd.enabled ? 0.35f : 0.16f));
     const float connectorX = std::clamp(node.x, r.x + 12.0f, r.right() - 12.0f);
     const float connectorY = node.y < r.y ? r.y + 8.0f : r.bottom() - 8.0f;
@@ -2679,7 +2679,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
     renderer.drawText(bandId, {r.x + 8.0f, tooltipHeaderY}, kTooltipHeaderFont,
                       c.withAlpha(bd.enabled ? 0.98f : 0.44f));
     renderer.fillRoundedRect(layout.typeRect, 4.0f,
-                             bd.enabled ? c.withAlpha(0.055f) : NUIColor(1.0f, 1.0f, 1.0f, 0.010f));
+                             bd.enabled ? c.withAlpha(0.055f) : editorInk(0.010f));
     if (bd.typeId != 0 || !bd.legacySlot)
         renderer.strokeRoundedRect(layout.typeRect, 4.0f, 1.0f, c.withAlpha(0.16f));
     renderer.drawTextCentered(typeLabel, layout.typeRect, 8.0f,
@@ -2688,9 +2688,9 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
         (bd.legacySlot && m_instance && bd.stereoId != 0) ? m_instance->getParameter(bd.stereoId) : bd.stereoNorm;
     const bool stereoScoped = quantizeStereoNorm(stereoNorm) > 0.0f;
     renderer.fillRoundedRect(layout.stereoRect, 4.0f,
-                             stereoScoped ? c.withAlpha(0.18f) : NUIColor(1.0f, 1.0f, 1.0f, 0.028f));
+                             stereoScoped ? c.withAlpha(0.18f) : editorInk(0.028f));
     renderer.strokeRoundedRect(layout.stereoRect, 4.0f, 1.0f,
-                               stereoScoped ? c.withAlpha(0.40f) : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                               stereoScoped ? c.withAlpha(0.40f) : editorInk(0.08f));
     renderer.drawTextCentered(stereoModeShortName(stereoNorm), layout.stereoRect, 7.4f,
                               stereoScoped ? c.withAlpha(0.96f) : theme.getColor("textSecondary").withAlpha(0.58f));
     renderer.fillCircle(layout.enableRect.center(), 3.0f,
@@ -2709,7 +2709,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
         const float trackY = row.center().y + 5.0f;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(row, 4.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.86f));
+        renderer.fillRoundedRect(row, 4.0f, editorNeutral(0.018f, 0.86f));
         renderer.fillRoundedRect({row.x, row.y, labelW, row.height}, 4.0f,
                                  bd.enabled ? c.withAlpha(draggingThis ? 0.16f : 0.075f) : c.withAlpha(0.025f));
         renderer.fillRoundedRect({trackX, trackY - 1.0f, trackW, 2.0f}, 1.0f, NUIColor(1, 1, 1, 0.055f));
@@ -2797,7 +2797,7 @@ void AestraEQEditor::drawBandTypeMenu(NUIRenderer& renderer) {
                              quantizeTypeNorm(m_instance ? m_instance->getParameter(bd.typeId) : bd.typeNorm) * 3.0f)),
                          0, 3)
             : std::clamp(static_cast<int>(std::round(std::clamp(bd.typeNorm, 0.0f, 1.0f) * 7.0f)), 0, 7);
-    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_typeMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     for (size_t i = 0; i < optionCount; ++i) {
@@ -2824,7 +2824,7 @@ void AestraEQEditor::drawBandStereoMenu(NUIRenderer& renderer) {
         (bd.legacySlot && bd.stereoId != 0 && m_instance) ? m_instance->getParameter(bd.stereoId) : bd.stereoNorm;
     const int current = std::clamp(static_cast<int>(std::round(quantizeStereoNorm(stereoNorm) * 4.0f)), 0, 4);
 
-    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_stereoMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     static constexpr const char* kLabels[] = {"Stereo", "Left", "Right", "Mid", "Side"};
@@ -2855,7 +2855,7 @@ void AestraEQEditor::drawBandContextMenu(NUIRenderer& renderer) {
     const NUIColor band = bandColor(bd.slotIndex);
     const std::string bandId = bd.name.empty() ? bandIdLabel(static_cast<size_t>(m_bandContextMenuBand)) : bd.name;
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_bandContextMenuRect, 8.0f, 1.0f, band.withAlpha(0.34f));
     renderer.drawText(bandId, {m_bandContextMenuRect.x + 10.0f, m_bandContextMenuRect.y + 10.0f}, 9.5f,
                       band.withAlpha(0.96f));
@@ -2948,7 +2948,7 @@ void AestraEQEditor::drawNumericEditBox(NUIRenderer& renderer) {
     const NUIColor band = m_numericEditBand >= 0 && m_numericEditBand < static_cast<int>(m_bands.size())
                               ? bandColor(m_bands[static_cast<size_t>(m_numericEditBand)].slotIndex)
                               : accent();
-    renderer.fillRoundedRect(r, 7.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(r, 7.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(r, 7.0f, 1.2f, band.withAlpha(0.62f));
     const char* label = "VALUE";
     switch (m_numericEditTarget) {

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -23,12 +23,14 @@ NUIColor accent() {
     return NUIColor(0.28f, 0.72f, 0.62f, 1.0f);
 } // filter teal
 NUIColor panelSurface() {
-    return NUIColor(0.018f, 0.021f, 0.022f, 0.98f);
+    return editorNeutral(NUIColor(0.018f, 0.021f, 0.022f, 0.98f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.028f, 0.034f, 0.035f, 0.98f);
+    return editorNeutral(NUIColor(0.028f, 0.034f, 0.035f, 0.98f));
 }
 NUIColor gridColor() {
+    // Teal-tinted grid ink over the response well; darkened on light themes.
+    if (editorLightUi()) return NUIColor(0.16f, 0.26f, 0.24f, 0.16f);
     return NUIColor(0.45f, 0.58f, 0.56f, 0.12f);
 }
 
@@ -164,7 +166,7 @@ void AestraFilterEditor::drawResponseDisplay(NUIRenderer& renderer) {
     // sit on the response border or compete with the live envelope meter.
     const NUIRect graph{m_responseRect.x + 14.0f, m_responseRect.y + 31.0f, m_responseRect.width - 28.0f,
                         m_responseRect.height - 65.0f};
-    renderer.fillRoundedRect(graph, 7.0f, NUIColor(0.006f, 0.010f, 0.011f, 0.98f));
+    renderer.fillRoundedRect(graph, 7.0f, editorNeutral(NUIColor(0.006f, 0.010f, 0.011f, 0.98f)));
 
     auto xForHz = [&graph](float hz) {
         const float norm = std::log10(std::clamp(hz, 20.0f, 20000.0f) / 20.0f) / 3.0f;
@@ -231,7 +233,7 @@ void AestraFilterEditor::drawResponseDisplay(NUIRenderer& renderer) {
     renderer.clearClipRect();
 
     const NUIRect envTrack{graph.x, m_responseRect.bottom() - 8.0f, graph.width, 3.0f};
-    renderer.fillRoundedRect(envTrack, 1.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.06f));
+    renderer.fillRoundedRect(envTrack, 1.5f, editorInk(0.06f));
     renderer.fillRoundedRect({envTrack.x, envTrack.y, envTrack.width * envelope, envTrack.height}, 1.5f,
                              accent().withAlpha(0.72f));
 }
@@ -245,10 +247,10 @@ void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, ui
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     if (bipolar) {
         // Bipolar knobs fill from the top-center detent toward the value.
         const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
@@ -264,7 +266,7 @@ void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, ui
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -287,7 +289,7 @@ void AestraFilterEditor::drawTypeSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_typeRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.36f, 0.62f, 0.92f, 1.0f);
 } // LFO blue
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -100,7 +100,7 @@ void AestraLFOEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawTargetSelector(renderer);
     drawWaveSelector(renderer);
@@ -121,10 +121,10 @@ void AestraLFOEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
 
     const float needleLen = r - (large ? 14.0f : 9.0f);
@@ -133,7 +133,7 @@ void AestraLFOEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -163,7 +163,7 @@ void AestraLFOEditor::drawTargetSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_targetRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }
@@ -183,7 +183,7 @@ void AestraLFOEditor::drawWaveSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_waveRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }
@@ -200,7 +200,7 @@ void AestraLFOEditor::drawSyncPill(NUIRenderer& renderer) {
         renderer.drawTextCentered("SYNC", m_syncRect, 10.0f, accent().withAlpha(0.98f));
     } else {
         renderer.fillRoundedRect(m_syncRect, kRadius, insetSurface());
-        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, editorInk(0.08f));
         renderer.drawTextCentered("FREE", m_syncRect, 10.0f, theme.getColor("textPrimary").withAlpha(0.62f));
     }
 }

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -17,10 +17,10 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accentColor() { return NUIColor(0.95f, 0.60f, 0.12f, 1.0f); }
-NUIColor bgDark() { return NUIColor(0.02f, 0.02f, 0.02f, 0.96f); }
-NUIColor textDim() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
-NUIColor textBright() { return NUIColor(1.0f, 1.0f, 1.0f, 0.88f); }
-NUIColor meterBg() { return NUIColor(0.008f, 0.008f, 0.008f, 1.0f); }
+NUIColor bgDark() { return editorNeutral(0.02f, 0.96f); }
+NUIColor textDim() { return editorInk(0.30f); }
+NUIColor textBright() { return editorInk(0.88f); }
+NUIColor meterBg() { return editorNeutral(0.008f, 1.0f); }
 
 float smoothMeter(float current, float target, float attack, float release) {
     const float coeff = target > current ? attack : release;
@@ -250,10 +250,10 @@ void AestraLimitEditor::drawKnob(NUIRenderer& renderer, const KnobControl& contr
     const NUIColor knobAccent = control.isPrimary ? accent : accent.withAlpha(0.72f);
 
     // Cell background
-    renderer.fillRoundedRect(control.bounds, 8.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.96f));
+    renderer.fillRoundedRect(control.bounds, 8.0f, editorNeutral(0.035f, 0.96f));
     renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f,
                                control.isPrimary ? NUIColor(0.28f, 0.18f, 0.06f, 1.0f)
-                                                 : NUIColor(0.119f, 0.119f, 0.119f, 1.0f));
+                                                 : editorNeutral(0.119f, 1.0f));
 
     const NUIRect knobRect = control.slider ? control.slider->getBounds() : NUIRect();
     const float cx = knobRect.center().x;
@@ -315,8 +315,8 @@ void AestraLimitEditor::drawPill(NUIRenderer& renderer, NUIRect rect,
         renderer.strokeRoundedRect(rect, 5.0f, 1.0f, accent);
         renderer.drawTextCentered(label, rect, 9.5f, NUIColor(1, 1, 1, 0.97f));
     } else {
-        const NUIColor bg = hovered ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
-                                    : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
+        const NUIColor bg = hovered ? editorNeutral(0.041f, 0.90f)
+                                    : editorNeutral(0.022f, 0.90f);
         renderer.fillRoundedRect(rect, 5.0f, bg);
         renderer.drawLine({rect.x + 5.0f, rect.y + 1.0f},
                           {rect.x + rect.width - 5.0f, rect.y + 1.0f},

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.74f, 0.42f, 0.88f, 1.0f);
 } // OTT violet
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -90,7 +90,7 @@ void AestraOTTEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawBypassPill(renderer);
     drawKnob(renderer, m_depthRect, AestraOTT::kDepth, "Depth", true, false);
@@ -113,10 +113,10 @@ void AestraOTTEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     if (bipolar) {
         // Bipolar knobs fill from the top-center detent toward the value.
         const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
@@ -132,7 +132,7 @@ void AestraOTTEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,

--- a/AestraUI/Widgets/AestraPanelWindow.cpp
+++ b/AestraUI/Widgets/AestraPanelWindow.cpp
@@ -20,8 +20,8 @@ void AestraPanelWindow::cacheThemeColors()
     m_border = theme.getColor("borderSubtle");
     m_textSecondary = theme.getColor("textSecondary");
     m_textTertiary = theme.getColor("textDisabled");
-    m_closeHover = NUIColor::fromHex(0xffd95f5f);
-    m_closeActive = NUIColor::fromHex(0xffe57373);
+    m_closeHover = theme.getColor("error").withAlpha(0.78f);
+    m_closeActive = theme.getColor("error");
 }
 
 void AestraPanelWindow::setPanelTitle(const std::string& title)

--- a/AestraUI/Widgets/AestraPanelWindow.h
+++ b/AestraUI/Widgets/AestraPanelWindow.h
@@ -29,6 +29,7 @@ public:
     ~AestraPanelWindow() override = default;
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setPanelTitle(const std::string& title);

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.94f, 0.52f, 0.22f, 1.0f);
 } // heat orange
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -91,7 +91,7 @@ void AestraSatEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawModeSelector(renderer);
     drawBypassPill(renderer);
@@ -110,10 +110,10 @@ void AestraSatEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
 
     const float needleLen = r - (large ? 14.0f : 10.0f);
@@ -122,7 +122,7 @@ void AestraSatEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.30f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -145,7 +145,7 @@ void AestraSatEditor::drawModeSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_modeRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -41,8 +41,8 @@ constexpr float kPresetListBottomPadding = 24.0f;
 constexpr float kPresetArtworkSize = 44.0f;
 constexpr float kPresetArtworkPixels = 256.0f; // matches the committed 256x256 preset artwork
 
-NUIColor verbSurfaceBg() { return NUIColor(0.044f, 0.044f, 0.044f, 0.985f); }
-NUIColor verbInsetBg() { return NUIColor(0.025f, 0.025f, 0.025f, 0.965f); }
+NUIColor verbSurfaceBg() { return editorNeutral(0.044f, 0.985f); }
+NUIColor verbInsetBg() { return editorNeutral(0.025f, 0.965f); }
 NUIColor verbGold() { return NUIColor(0.88f, 0.63f, 0.13f, 1.0f); }
 NUIColor verbAccent() { return NUIColor(0.498f, 0.353f, 0.941f, 1.0f); }
 float presetColumnWidth(float editorWidth) { return std::clamp(editorWidth * 0.235f, 168.0f, 210.0f); }
@@ -573,7 +573,7 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
     const float stripBottomY = b.y + b.height - 14.0f;
     const float stripH = stripBottomY - stripTopY;
     renderer.fillRoundedRect({stripX - 5.0f, stripTopY, stripW + 10.0f, stripH}, 8.0f,
-                             NUIColor(0.022f, 0.022f, 0.027f, 0.98f));
+                             editorNeutral(NUIColor(0.022f, 0.022f, 0.027f, 0.98f)));
     renderer.strokeRoundedRect({stripX - 5.0f, stripTopY, stripW + 10.0f, stripH}, 8.0f, 1.0f, NUIColor(1, 1, 1, 0.085f));
     const NUIRect libraryRow(stripX + 7.0f, stripTopY + 5.0f, stripW - 23.0f, 16.0f);
     renderer.drawText("PRESET LIBRARY", {libraryRow.x, std::round(renderer.calculateTextY(libraryRow, 8.5f))}, 8.5f,
@@ -619,8 +619,8 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
         const bool focused = static_cast<int>(i) == m_focusedPreset;
         const bool pressed = static_cast<int>(i) == m_pressedPreset;
         const NUIColor presetFill = active ? accent.withAlpha(pressed ? 0.17f : 0.125f)
-            : (pressed ? NUIColor(0.060f, 0.052f, 0.078f, 0.99f)
-                       : (p.hovered ? NUIColor(0.061f, 0.057f, 0.074f, 0.98f) : verbInsetBg().withAlpha(0.92f)));
+            : (pressed ? editorNeutral(NUIColor(0.060f, 0.052f, 0.078f, 0.99f))
+                       : (p.hovered ? editorNeutral(NUIColor(0.061f, 0.057f, 0.074f, 0.98f)) : verbInsetBg().withAlpha(0.92f)));
         renderer.fillRoundedRect(p.bounds, 6.0f, presetFill);
         renderer.strokeRoundedRect(p.bounds, 5.0f, 1.0f,
                                    active ? accent.withAlpha(0.42f)
@@ -644,7 +644,7 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
             const float hue = modeHues[modeIdx];
             renderer.fillRectGradient(art,
                 NUIColor(hue * 0.8f + 0.15f, hue * 0.4f + 0.08f, 0.20f, 1.0f),
-                NUIColor(0.029f, 0.029f, 0.029f, 1.0f), true);
+                editorNeutral(0.029f, 1.0f), true);
             static const char* modeInitials[] = {"R", "H", "P", "C", "Ch", "B", "A", "S", "Sp"};
             const char* initial = (modeIdx >= 0 && modeIdx < kModeCount) ? modeInitials[modeIdx] : "R";
             renderer.drawTextCentered(initial, art, 14.0f, accent.withAlpha(0.65f));
@@ -705,7 +705,7 @@ void AestraVerbEditor::drawCategoryPills(NUIRenderer& renderer, NUIColor accent)
     const auto outer = NUIRect(m_categoryPills.front().bounds.x, m_categoryPills.front().bounds.y,
                                m_categoryPills.back().bounds.right() - m_categoryPills.front().bounds.x,
                                m_categoryPills.front().bounds.height);
-    renderer.fillRoundedRect(outer, 13.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
+    renderer.fillRoundedRect(outer, 13.0f, editorNeutral(0.027f, 0.985f));
     renderer.strokeRoundedRect(outer, 13.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
     const float pad = 2.0f;
     for (const auto& pill : m_categoryPills) {
@@ -799,7 +799,7 @@ void AestraVerbEditor::drawModeDropdown(NUIRenderer& renderer, NUIColor accent) 
     chevronIcon->onRender(renderer);
 
     if (m_dropdownOpen && !m_dropdownItems.empty()) {
-        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
+        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, editorNeutral(0.027f, 0.985f));
         renderer.strokeRoundedRect(m_dropdownListBounds, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
         for (const auto& item : m_dropdownItems) {
             const bool isCurrent = item.mode == modeIdx;
@@ -834,9 +834,9 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
         const float ringThickness = 11.0f;
         renderer.drawShadow(NUIRect{cx - macroR * 0.82f, cy - macroR * 0.82f, macroR * 1.64f, macroR * 1.64f}, 0.0f, 3.0f, 6.0f,
                             NUIColor(0, 0, 0, 0.52f));
-        renderer.fillCircle({cx, cy}, macroR - 10.0f, NUIColor(0.012f, 0.012f, 0.016f, 0.98f));
+        renderer.fillCircle({cx, cy}, macroR - 10.0f, editorNeutral(NUIColor(0.012f, 0.012f, 0.016f, 0.98f)));
         renderer.strokeCircle({cx, cy}, macroR - 15.0f, 1.0f, NUIColor(1, 1, 1, 0.045f));
-        renderer.strokeCircle({cx, cy}, macroR, ringThickness, NUIColor(0.091f, 0.091f, 0.091f, 1.0f));
+        renderer.strokeCircle({cx, cy}, macroR, ringThickness, editorNeutral(0.091f, 1.0f));
         const float dStartAngle = -kPi * 0.5f;
         const float dSweep = kTwoPi * 0.80f;
         const float dValue = k.slider ? k.slider->getValue() : 0.0f;
@@ -868,8 +868,8 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     if (k.verticalLayout) {
         renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                             NUIColor(0, 0, 0, 0.48f));
-        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
-        renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
+        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : editorNeutral(0.039f, 1.0f));
+        renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, editorInk(0.09f + stateLift * 0.045f));
         renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
         const float startAngle = kPi * 0.75f;
         const float sweep = kPi * 1.5f;
@@ -879,7 +879,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
         drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
         const float pa = startAngle + value * kPi * 1.5f;
         renderer.drawLine({cx, cy}, {cx + std::cos(pa) * (r * 0.56f), cy + std::sin(pa) * (r * 0.56f)}, 2.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, active ? 0.98f : (hover ? 0.92f : 0.84f)));
+                          editorInk(active ? 0.98f : (hover ? 0.92f : 0.84f)));
         const float labelY = k.bounds.y + knobRect.height + 6.0f;
         renderer.drawTextCentered(k.label, {k.bounds.x, labelY, k.bounds.width, 14.0f}, 10.0f,
                                   theme.getColor("textPrimary").withAlpha(0.74f + stateLift * 0.12f));
@@ -891,8 +891,8 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                         NUIColor(0, 0, 0, 0.48f));
     if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.25f));
-    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
-    renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
+    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : editorNeutral(0.039f, 1.0f));
+    renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, editorInk(0.09f + stateLift * 0.045f));
     renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
     const float startAngle = kPi * 0.75f;
     const float sweep = kPi * 1.5f;
@@ -902,7 +902,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
     const float pa = startAngle + value * kPi * 1.5f;
     renderer.drawLine({cx, cy}, {cx + std::cos(pa) * (r * 0.56f), cy + std::sin(pa) * (r * 0.56f)}, 2.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, active ? 0.98f : (hover ? 0.92f : 0.84f)));
+                      editorInk(active ? 0.98f : (hover ? 0.92f : 0.84f)));
     const float textX = knobRect.right() + 9.0f;
     // Optically centre the label + value on the knob's centre (see opticalTextY).
     const float labelTextY = std::round(opticalTextY(renderer, cy, 9.5f));
@@ -1013,7 +1013,7 @@ void AestraVerbEditor::drawSectionLabels(NUIRenderer& renderer) {
 
     auto drawSection = [&](const char* label, const char* hint, float y, float height, int rows) {
         const NUIRect card(rightX, y, rightW, height);
-        renderer.fillRoundedRect(card, 9.0f, NUIColor(0.030f, 0.030f, 0.035f, 0.97f));
+        renderer.fillRoundedRect(card, 9.0f, editorNeutral(NUIColor(0.030f, 0.030f, 0.035f, 0.97f)));
         renderer.strokeRoundedRect(card, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.075f));
         renderer.fillCircle({rightX + 13.0f, y + 13.0f}, 2.0f, verbAccent().withAlpha(0.72f));
         const NUIRect headerRow(rightX + 21.0f, y, rightW - 33.0f, headerH);
@@ -1051,19 +1051,19 @@ void AestraVerbEditor::drawParamRow(NUIRenderer& renderer, NUIColor accent) {
         const bool hover = temp.slider ? temp.slider->isHovered() : false;
         const float stateLift = active ? 1.0f : (hover ? 0.55f : 0.0f);
         renderer.fillRoundedRect(rect, 7.0f,
-                                 hover ? NUIColor(0.034f, 0.031f, 0.044f, 0.98f)
-                                       : NUIColor(0.020f, 0.020f, 0.024f, 0.92f));
+                                 hover ? editorNeutral(NUIColor(0.034f, 0.031f, 0.044f, 0.98f))
+                                       : editorNeutral(NUIColor(0.020f, 0.020f, 0.024f, 0.92f)));
         renderer.strokeRoundedRect(rect, 7.0f, 1.0f,
                                    active ? accent.withAlpha(0.46f)
                                           : (hover ? accent.withAlpha(0.24f) : NUIColor(1, 1, 1, 0.065f)));
-        renderer.fillCircle({cx, cy}, r, NUIColor(0.01f, 0.01f, 0.01f, 1.0f));
+        renderer.fillCircle({cx, cy}, r, editorNeutral(0.01f, 1.0f));
         renderer.strokeCircle({cx, cy}, r, 1.0f, NUIColor(1, 1, 1, 0.10f + stateLift * 0.045f));
         if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.20f));
         const float startAngle = kPi * 0.75f;
         const float sweep = kPi * 1.5f;
         const float value = temp.slider ? temp.slider->getValue() : 0.0f;
         const float endAngle = startAngle + value * sweep;
-        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, NUIColor(0.166f, 0.166f, 0.166f, 1.0f));
+        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, editorNeutral(0.166f, 1.0f));
         drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
         const float pa = startAngle + value * kPi * 1.5f;
         renderer.fillCircle({cx + std::cos(pa) * (r - 2.0f), cy + std::sin(pa) * (r - 2.0f)}, 2.5f,
@@ -1093,18 +1093,18 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
     const float heroHeight = std::clamp(bodyH - 180.0f, 230.0f, 290.0f);
 
     renderer.fillRectGradient({b.x + 8.0f, b.y + 48.0f, b.width - 16.0f, b.height - 58.0f},
-                              NUIColor(0.024f, 0.022f, 0.030f, 0.98f),
-                              NUIColor(0.012f, 0.013f, 0.017f, 0.99f), true);
+                              editorNeutral(NUIColor(0.024f, 0.022f, 0.030f, 0.98f)),
+                              editorNeutral(NUIColor(0.012f, 0.013f, 0.017f, 0.99f)), true);
     drawPresetStrip(renderer, accent);
     drawCategoryPills(renderer, accent);
 
     renderer.fillRoundedRect({mainX - 8.0f, mainY - 6.0f, contentW + 16.0f, bodyH + 12.0f}, 11.0f,
-                             NUIColor(0.018f, 0.018f, 0.022f, 0.94f));
+                             editorNeutral(NUIColor(0.018f, 0.018f, 0.022f, 0.94f)));
     renderer.strokeRoundedRect({mainX - 8.0f, mainY - 6.0f, contentW + 16.0f, bodyH + 12.0f}, 11.0f, 1.0f,
                                NUIColor(1, 1, 1, 0.055f));
 
     const NUIRect heroCard(mainX, mainY, centerW, heroHeight);
-    renderer.fillRoundedRect(heroCard, 10.0f, NUIColor(0.026f, 0.025f, 0.033f, 0.98f));
+    renderer.fillRoundedRect(heroCard, 10.0f, editorNeutral(NUIColor(0.026f, 0.025f, 0.033f, 0.98f)));
     renderer.strokeRoundedRect(heroCard, 10.0f, 1.0f, accent.withAlpha(0.16f));
     renderer.fillCircle({heroCard.x + 15.0f, heroCard.y + 15.0f}, 2.0f, accent.withAlpha(0.82f));
     const NUIRect heroHeader(heroCard.x + 23.0f, heroCard.y + 2.0f, heroCard.width - 37.0f, 26.0f);
@@ -1118,13 +1118,13 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
 
     const NUIRect mixCard(m_mixBounds.x - 10.0f, m_mixBounds.y - 5.0f,
                           m_mixBounds.width + 20.0f, m_mixBounds.height + 10.0f);
-    renderer.fillRoundedRect(mixCard, 9.0f, NUIColor(0.026f, 0.025f, 0.033f, 0.96f));
+    renderer.fillRoundedRect(mixCard, 9.0f, editorNeutral(NUIColor(0.026f, 0.025f, 0.033f, 0.96f)));
     renderer.strokeRoundedRect(mixCard, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.06f));
 
     const NUIRect utilityCard(m_bypassBounds.x - 10.0f, m_bypassBounds.y - 10.0f,
                               m_mixLockBounds.right() - m_bypassBounds.x + 20.0f,
                               m_abBoundsB.bottom() - m_bypassBounds.y + 20.0f);
-    renderer.fillRoundedRect(utilityCard, 9.0f, NUIColor(0.023f, 0.023f, 0.029f, 0.94f));
+    renderer.fillRoundedRect(utilityCard, 9.0f, editorNeutral(NUIColor(0.023f, 0.023f, 0.029f, 0.94f)));
     renderer.strokeRoundedRect(utilityCard, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.055f));
 
     drawSectionLabels(renderer);
@@ -1218,7 +1218,7 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
         for (auto& btn : btns) {
             if (btn.hov && btn.tip) {
                 const NUIRect tipBounds(btn.bounds.x, btn.bounds.y - 18.0f, btn.bounds.width, 16.0f);
-                renderer.fillRoundedRect(tipBounds, 3.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.92f));
+                renderer.fillRoundedRect(tipBounds, 3.0f, editorNeutral(0.0f, 0.92f));
                 renderer.drawTextCentered(btn.tip, tipBounds, 8.0f, NUIColor(1, 1, 1, 0.78f));
             }
         }
@@ -1227,7 +1227,7 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
         const auto& tip = m_presets[static_cast<size_t>(m_hoveredPreset)];
         if (!tip.tooltip.empty()) {
             const NUIRect tipBounds(tip.bounds.x, tip.bounds.bottom() + 4.0f, tip.bounds.width, 20.0f);
-            renderer.fillRoundedRect(tipBounds, 4.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.92f));
+            renderer.fillRoundedRect(tipBounds, 4.0f, editorNeutral(0.0f, 0.92f));
             renderer.drawText(tip.tooltip, {tip.bounds.x + 6.0f, tip.bounds.bottom() + 8.0f}, 8.5f,
                               NUIColor(1, 1, 1, 0.78f));
         }

--- a/AestraUI/Widgets/GenericPluginEditor.cpp
+++ b/AestraUI/Widgets/GenericPluginEditor.cpp
@@ -119,11 +119,11 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
                     LABEL_WIDTH + SLIDER_WIDTH + VALUE_WIDTH + PADDING * 3.0f + 12.0f,
                     PARAMETER_HEIGHT - 2.0f);
     renderer.fillRoundedRect(rowRect, 9.0f,
-        hovered || p.isDragging ? NUIColor(0.181f, 0.181f, 0.181f, 0.92f)
-                                : NUIColor(0.111f, 0.111f, 0.111f, 0.74f));
+        hovered || p.isDragging ? editorNeutral(0.181f, 0.92f)
+                                : editorNeutral(0.111f, 0.74f));
     renderer.strokeRoundedRect(rowRect, 9.0f, 1.0f,
         hovered || p.isDragging ? theme.getColor("accentPrimary").withAlpha(0.30f)
-                                : NUIColor(1.0f, 1.0f, 1.0f, 0.05f));
+                                : editorInk(0.05f));
 
     float labelY = offsetY + p.sliderBounds.y + (p.sliderBounds.height * 0.5f) - 5.0f; 
     renderer.drawText(p.shortName, 
@@ -135,7 +135,7 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
     NUIRect track(offsetX + p.sliderBounds.x, trackY, 
                   p.sliderBounds.width, trackH);
 
-    renderer.fillRoundedRect(track, 3.0f, NUIColor(0.039f, 0.039f, 0.039f, 0.78f));
+    renderer.fillRoundedRect(track, 3.0f, editorNeutral(0.039f, 0.78f));
 
     float fillWidth = track.width * p.normalizedValue;
     if (fillWidth > 0) {
@@ -158,7 +158,7 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
     NUIRect thumbRect(thumbX, thumbY, thumbSize, thumbSize);
 
     if (hovered || p.isDragging) {
-         renderer.fillRoundedRect(thumbRect, thumbSize * 0.5f, NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+         renderer.fillRoundedRect(thumbRect, thumbSize * 0.5f, editorInk(1.0f));
          renderer.strokeRoundedRect(thumbRect, thumbSize * 0.5f, 1.5f, theme.getColor("accentPrimary"));
     } else {
          float idleSize = 8.0f;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -505,7 +505,7 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
     const auto bounds = getBounds();
     auto& theme = NUIThemeManager::getInstance();
 
-    const auto rulerBackground = NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
+    const auto rulerBackground = NUIThemeManager::getInstance().getColor("backgroundPrimary");
     const auto border = NUIColor::white().withAlpha(0.075f);
     const auto highlight = NUIColor::white().withAlpha(0.014f);
     const auto text = theme.getColor("textPrimary").withAlpha(0.86f);
@@ -1010,12 +1010,14 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
 
     renderer.setClipRect(bounds);
-    renderer.fillRect(bounds, NUIColor::black());
+    renderer.fillRect(bounds, theme.getColor("timelineBed"));
 
-    const auto accidentalRow = NUIColor::white().withAlpha(0.022f);
+    const auto gridInk = theme.getCurrentTheme().textPrimary;
+    const auto accidentalRow = gridInk.withAlpha(0.032f);
     const auto rootRow = theme.getColor("accentPrimary").withAlpha(0.055f);
-    const auto outOfScaleRow = NUIColor::black().withAlpha(0.24f);
-    const auto rowLine = NUIColor::white().withAlpha(0.045f);
+    // Out-of-scale rows recede toward the bed's own polarity, not toward black.
+    const auto outOfScaleRow = gridInk.withAlpha(0.10f);
+    const auto rowLine = gridInk.withAlpha(0.045f);
 
     int startPitch = 127 - static_cast<int>(scrollY_ / keyHeight_);
     int endPitch = 127 - static_cast<int>((scrollY_ + bounds.height) / keyHeight_);
@@ -1040,7 +1042,7 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     }
 
     renderTimelineGrid(
-        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
+        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk);
 
     if (hoveredPitch_ >= 0 && hoveredPitch_ <= 127) {
         const float hoverY = bounds.y + (127 - hoveredPitch_) * keyHeight_ - scrollY_;
@@ -1062,7 +1064,7 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     if (patternEndX < bounds.right()) {
         const float shadeX = std::max(bounds.x, patternEndX);
         renderer.fillRect(NUIRect(shadeX, bounds.y, bounds.right() - shadeX, bounds.height),
-                          NUIColor::black().withAlpha(0.58f));
+                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
     }
     if (patternEndX >= bounds.x && patternEndX <= bounds.right()) {
         renderer.drawLine(NUIPoint(patternEndX, bounds.y),
@@ -1811,8 +1813,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
 
     // Rubber-band selection rectangle (already normalized during drag)
     if (state_ == State::SelectingBox && selectionRect_.width > 0 && selectionRect_.height > 0) {
-        renderer.fillRoundedRect(selectionRect_, 2.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.15f));
-        renderer.strokeRoundedRect(selectionRect_, 2.0f, 1.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.55f));
+        renderer.fillRoundedRect(selectionRect_, 2.0f, NUIThemeManager::getInstance().getColor("accentPrimary").withAlpha(0.15f));
+        renderer.strokeRoundedRect(selectionRect_, 2.0f, 1.0f, NUIThemeManager::getInstance().getColor("accentPrimary").withAlpha(0.55f));
     }
 
     renderNoteProperties(renderer);
@@ -3111,7 +3113,8 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(contentRect);
 
     const float startX = contentRect.x;
-    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
+    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_,
+                       themeManager.getCurrentTheme().textPrimary);
 
     const float availH = std::max(1.0f, b.height - 28.0f);
     const float bottomY = b.bottom() - 8.0f;
@@ -3128,7 +3131,7 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     if (patternEndX < contentRect.right()) {
         const float shadeX = std::max(contentRect.x, patternEndX);
         renderer.fillRect(NUIRect(shadeX, contentRect.y, contentRect.right() - shadeX, contentRect.height),
-                          NUIColor::black().withAlpha(0.58f));
+                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
     }
     if (patternEndX >= contentRect.x && patternEndX <= contentRect.right()) {
         renderer.drawLine(NUIPoint(patternEndX, contentRect.y),

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -45,8 +45,6 @@ namespace Colors {
     static const NUIColor badgeVst3Text = NUIColor(0.655f, 0.545f, 0.980f, 1.0f);
     static const NUIColor badgeClapBg   = NUIColor(0.204f, 0.835f, 0.600f, 0.20f);
     static const NUIColor badgeClapText = NUIColor(0.204f, 0.835f, 0.600f, 1.0f);
-    static const NUIColor badgeIntBg    = NUIColor(1.0f, 1.0f, 1.0f, 0.08f);
-    static const NUIColor badgeIntText  = NUIColor(1.0f, 1.0f, 1.0f, 0.40f);
 
     // Active pill
     NUIColor pillActiveBg() { return NUIThemeManager::getInstance().getColor("selection"); }
@@ -877,7 +875,7 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
 
     // DEBUG: Visual indicator for pending removal
     if (slot.pendingRemoval) {
-        renderer.strokeRoundedRect(slotRect, 4.0f, 2.0f, NUIColor(1.0f, 0.0f, 0.0f, 0.8f));
+        renderer.strokeRoundedRect(slotRect, 4.0f, 2.0f, NUIThemeManager::getInstance().getColor("error").withAlpha(0.8f));
     }
 
     // Shared vertical midline for the slot row — center everything around it

--- a/AestraUI/Widgets/RumblePluginEditor.cpp
+++ b/AestraUI/Widgets/RumblePluginEditor.cpp
@@ -33,13 +33,13 @@ NUIColor cleanAccent() {
     return NUIColor(0.35f, 0.72f, 1.0f, 1.0f);
 }
 NUIColor shellSurface() {
-    return NUIColor(0.026f, 0.025f, 0.032f, 0.985f);
+    return editorNeutral(NUIColor(0.026f, 0.025f, 0.032f, 0.985f));
 }
 NUIColor panelSurface() {
-    return NUIColor(0.043f, 0.041f, 0.052f, 0.98f);
+    return editorNeutral(NUIColor(0.043f, 0.041f, 0.052f, 0.98f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.022f, 0.021f, 0.027f, 0.98f);
+    return editorNeutral(NUIColor(0.022f, 0.021f, 0.027f, 0.98f));
 }
 
 std::shared_ptr<NUIIcon> chevronLeftIcon() {
@@ -289,7 +289,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
     const auto drawArrowButton = [&](const NUIRect& rect, const std::shared_ptr<NUIIcon>& icon, bool hovered) {
         renderer.fillRoundedRect(rect, 9.0f, hovered ? bodyAccent().withAlpha(0.26f) : insetSurface());
         renderer.strokeRoundedRect(rect, 9.0f, 1.0f,
-                                   hovered ? bodyAccent().withAlpha(0.62f) : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                                   hovered ? bodyAccent().withAlpha(0.62f) : editorInk(0.08f));
         drawSvgIcon(renderer, icon, rect, hovered ? bodyAccent() : theme.getColor("textPrimary").withAlpha(0.72f),
                     15.0f);
     };
@@ -307,7 +307,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
                                                                        : insetSurface());
     renderer.strokeRoundedRect(m_presetButtonBounds, 9.0f, 1.0f,
                                m_presetButtonHovered || m_presetMenuOpen ? bodyAccent().withAlpha(0.65f)
-                                                                         : NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+                                                                         : editorInk(0.09f));
     renderer.fillRoundedRect({m_presetButtonBounds.x + 9.0f, m_presetButtonBounds.y + 10.0f, 3.0f, 28.0f}, 1.5f,
                              (factory ? presetAccent(m_activePreset) : bodyAccent()).withAlpha(0.88f));
     renderer.drawText(factory ? std::string(preset.category) : "CUSTOM",
@@ -318,7 +318,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
                       factory ? presetAccent(m_activePreset) : theme.getColor("textPrimary"));
     renderer.drawLine({m_presetButtonBounds.right() - 32.0f, m_presetButtonBounds.y + 8.0f},
                       {m_presetButtonBounds.right() - 32.0f, m_presetButtonBounds.bottom() - 8.0f}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+                      editorInk(0.07f));
     const NUIRect chevronBounds(m_presetButtonBounds.right() - 30.0f, m_presetButtonBounds.y, 28.0f,
                                 m_presetButtonBounds.height);
     drawSvgIcon(renderer, m_presetMenuOpen ? chevronUpIcon() : chevronDownIcon(), chevronBounds,
@@ -361,7 +361,7 @@ void RumblePluginEditor::drawImpactShape(NUIRenderer& renderer) {
     for (int i = 1; i < 4; ++i) {
         const float x = m_impactShapeBounds.x + m_impactShapeBounds.width * static_cast<float>(i) / 4.0f;
         renderer.drawLine({x, m_impactShapeBounds.y + 12.0f}, {x, m_impactShapeBounds.bottom() - 12.0f}, 1.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, 0.035f));
+                          editorInk(0.035f));
     }
     const float punch = m_controls.size() > 0 ? m_controls[0].normalizedValue : 0.0f;
     const float sweep = m_controls.size() > 1 ? m_controls[1].normalizedValue : 0.0f;
@@ -389,23 +389,23 @@ void RumblePluginEditor::drawKnob(NUIRenderer& renderer, const MacroControl& con
     const bool dragging = m_draggingControl == controlIndex;
     const NUIColor accent = controlAccent(control.parameterId);
     renderer.fillRoundedRect(control.bounds, 11.0f,
-                             hovered || dragging ? NUIColor(0.068f, 0.064f, 0.080f, 0.98f)
-                                                 : NUIColor(0.036f, 0.034f, 0.043f, 0.82f));
+                             hovered || dragging ? editorNeutral(NUIColor(0.068f, 0.064f, 0.080f, 0.98f))
+                                                 : editorNeutral(NUIColor(0.036f, 0.034f, 0.043f, 0.82f)));
     renderer.strokeRoundedRect(control.bounds, 11.0f, 1.0f,
-                               hovered || dragging ? accent.withAlpha(0.50f) : NUIColor(1.0f, 1.0f, 1.0f, 0.045f));
+                               hovered || dragging ? accent.withAlpha(0.50f) : editorInk(0.045f));
 
     const NUIPoint center = control.knobBounds.center();
     const float radius = control.knobBounds.width * 0.5f;
     const float valueAngle = kKnobStart + control.normalizedValue * kKnobSweep;
     renderer.fillCircle(center, radius, insetSurface());
-    renderer.strokeCircle(center, radius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+    renderer.strokeCircle(center, radius, 1.0f, editorInk(0.07f));
     drawArc(renderer, center, radius - 6.0f, kKnobStart, kKnobStart + kKnobSweep, primary ? 4.0f : 3.2f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+            editorInk(0.09f));
     drawArc(renderer, center, radius - 6.0f, kKnobStart, valueAngle, primary ? 4.0f : 3.2f, accent.withAlpha(0.94f));
     const float needleLength = radius - (primary ? 16.0f : 13.0f);
     const NUIPoint tip{center.x + std::cos(valueAngle) * needleLength, center.y + std::sin(valueAngle) * needleLength};
     renderer.drawLine(center, tip, 2.0f, accent.withAlpha(0.86f));
-    renderer.fillCircle(center, primary ? 7.0f : 5.5f, NUIColor(0.075f, 0.071f, 0.088f, 1.0f));
+    renderer.fillCircle(center, primary ? 7.0f : 5.5f, editorNeutral(NUIColor(0.075f, 0.071f, 0.088f, 1.0f)));
     renderer.fillCircle(center, primary ? 2.8f : 2.2f, accent.withAlpha(0.90f));
 
     const float labelY = control.knobBounds.bottom() + (primary ? 8.0f : 5.0f);
@@ -423,7 +423,7 @@ void RumblePluginEditor::drawKnob(NUIRenderer& renderer, const MacroControl& con
 
 void RumblePluginEditor::drawPresetBrowser(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(m_presetMenuBounds, 16.0f, NUIColor(0.018f, 0.017f, 0.023f, 1.0f));
+    renderer.fillRoundedRect(m_presetMenuBounds, 16.0f, editorNeutral(NUIColor(0.018f, 0.017f, 0.023f, 1.0f)));
     renderer.strokeRoundedRect(m_presetMenuBounds, 16.0f, 1.2f, bodyAccent().withAlpha(0.58f));
     renderer.drawText("FACTORY SOUNDS", {m_presetMenuBounds.x + 18.0f, m_presetMenuBounds.y + 17.0f}, 11.0f,
                       theme.getColor("textPrimary"));
@@ -444,10 +444,10 @@ void RumblePluginEditor::drawPresetBrowser(NUIRenderer& renderer) {
         const NUIColor accent = presetAccent(i);
         renderer.fillRoundedRect(m_presetItemBounds[i], 8.0f,
                                  active    ? accent.withAlpha(0.22f)
-                                 : hovered ? NUIColor(0.095f, 0.088f, 0.115f, 0.96f)
+                                 : hovered ? editorNeutral(NUIColor(0.095f, 0.088f, 0.115f, 0.96f))
                                            : panelSurface());
         renderer.strokeRoundedRect(m_presetItemBounds[i], 8.0f, 1.0f,
-                                   active || hovered ? accent.withAlpha(0.58f) : NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+                                   active || hovered ? accent.withAlpha(0.58f) : editorInk(0.055f));
         renderer.drawText(std::string(Aestra::Plugins::kRumbleFactoryPresets[i].name),
                           {m_presetItemBounds[i].x + 10.0f, m_presetItemBounds[i].y + 13.0f}, 9.5f,
                           active ? accent : theme.getColor("textPrimary").withAlpha(0.88f));

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -54,10 +54,9 @@ void UIMixerButtonRow::cacheThemeColors()
     m_textOnBright = theme.getColor("textPrimary");
     m_textOnRed = theme.getColor("textPrimary");
 
-    // Active glow colors (amber mute, yellow solo, red arm)
-    m_muteOn = NUIColor(1.0f, 0.75f, 0.2f, 1.0f);   // amber
-    m_soloOn = NUIColor(1.0f, 0.92f, 0.3f, 1.0f);   // yellow
-    m_armOn  = NUIColor(1.0f, 0.25f, 0.25f, 1.0f);  // red
+    m_muteOn = theme.getColor("muted");
+    m_soloOn = theme.getColor("soloed");
+    m_armOn = theme.getColor("armed");
 }
 
 void UIMixerButtonRow::layoutButtons()

--- a/AestraUI/Widgets/UIMixerButtonRow.h
+++ b/AestraUI/Widgets/UIMixerButtonRow.h
@@ -19,6 +19,7 @@ public:
     UIMixerButtonRow();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseLeave() override;
@@ -72,4 +73,3 @@ private:
 };
 
 } // namespace AestraUI
-

--- a/AestraUI/Widgets/UIMixerFXSummary.h
+++ b/AestraUI/Widgets/UIMixerFXSummary.h
@@ -16,6 +16,7 @@ public:
     UIMixerFXSummary();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setFxCount(int count);

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -31,13 +31,15 @@ void UIMixerFader::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();
     // Track: Deep Glass Slot
-    m_trackBg = AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.6f);
+    m_trackBg = theme.getColor("meterBackground").withAlpha(0.72f);
     // Fill: Gradient handled in render
     m_trackFg = theme.getColor("accentPrimary"); 
     m_handle = theme.getColor("backgroundSecondary"); // Handle Core
     m_handleHover = theme.getColor("textPrimary");    // Handle Active
     m_text = theme.getColor("textPrimary");
     m_textSecondary = theme.getColor("textSecondary");
+    m_border = theme.getColor("borderStrong");
+    m_tooltipBg = theme.getColor("elevatedPanel").withAlpha(0.98f);
 }
 
 float UIMixerFader::clampDb(float db) const
@@ -102,7 +104,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
 
     // 1. Track Background (deep recessed slot)
     renderer.fillRoundedRect(trackRect, 2.0f, m_trackBg);
-    renderer.strokeRoundedRect(trackRect, 2.0f, 1.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.6f));
+    renderer.strokeRoundedRect(trackRect, 2.0f, 1.0f, m_border.withAlpha(0.60f));
 
     // 2. Filled Portion (subtle, no wide glow)
     const float norm = (m_valueDb - m_minDb) / std::max(1e-3f, (m_maxDb - m_minDb));
@@ -135,11 +137,11 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
 
     // Handle Body (dark surface) — flat, no drop shadow; the border + slit
     // give it enough definition.
-    renderer.fillRoundedRect(handleRect, handleRad, NUIColor(0.18f, 0.18f, 0.18f, 0.98f));
+    renderer.fillRoundedRect(handleRect, handleRad, m_handle.withAlpha(0.98f));
 
     // Handle Border (accent when active/hovered, subtle white otherwise)
     bool handleActive = isHovered() || m_dragging;
-    NUIColor handleBorder = handleActive ? m_trackFg : NUIColor(1.0f, 1.0f, 1.0f, 0.25f);
+    NUIColor handleBorder = handleActive ? m_trackFg : m_border;
     renderer.strokeRoundedRect(handleRect, handleRad, 1.0f, handleBorder);
 
     // Center accent line (the "light slit")
@@ -148,7 +150,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
     renderer.fillRoundedRect(
         NUIRect{handleX + (handleW - slitW)*0.5f, handleY + (handleH - slitH)*0.5f, slitW, slitH},
         1.5f,
-        handleActive ? m_trackFg : NUIColor(1.0f, 1.0f, 1.0f, 0.5f)
+        handleActive ? m_trackFg : m_textSecondary
     );
 
     // 4. Fixed dB readout at top of fader area (not attached to handle)
@@ -168,7 +170,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
             tipY = handleY + handleH + 4.0f;
         }
 
-        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, NUIColor(0.05f, 0.05f, 0.05f, 0.95f));
+        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, m_tooltipBg);
         renderer.strokeRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, 1.0f, m_trackFg.withAlpha(0.5f));
         renderer.drawTextCentered(m_cachedText, {tipX, tipY, tipW, tipH}, 10.5f, m_text);
     }

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -24,6 +24,7 @@ public:
     UIMixerFader();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setRangeDb(float minDb, float maxDb);
@@ -69,6 +70,8 @@ private:
     NUIColor m_handleHover;
     NUIColor m_text;
     NUIColor m_textSecondary;
+    NUIColor m_border;
+    NUIColor m_tooltipBg;
 
     static constexpr float FADER_FLOOR_THRESHOLD = -60.0f;
 

--- a/AestraUI/Widgets/UIMixerFooter.h
+++ b/AestraUI/Widgets/UIMixerFooter.h
@@ -15,6 +15,7 @@ public:
     UIMixerFooter();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
 
     void setTrackNumber(int number);
 

--- a/AestraUI/Widgets/UIMixerHeader.h
+++ b/AestraUI/Widgets/UIMixerHeader.h
@@ -17,6 +17,7 @@ public:
     UIMixerHeader();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setTrackName(std::string name);

--- a/AestraUI/Widgets/UIMixerInspector.h
+++ b/AestraUI/Widgets/UIMixerInspector.h
@@ -31,6 +31,7 @@ public:
     explicit UIMixerInspector(Aestra::MixerViewModel* viewModel);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIMixerKnob.h
+++ b/AestraUI/Widgets/UIMixerKnob.h
@@ -27,6 +27,7 @@ public:
     explicit UIMixerKnob(UIMixerKnobType type);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setValue(float value);

--- a/AestraUI/Widgets/UIMixerMeter.cpp
+++ b/AestraUI/Widgets/UIMixerMeter.cpp
@@ -29,7 +29,7 @@ void UIMixerMeter::cacheThemeColors()
     m_colorYellowDim = m_colorYellow.withSaturation(0.0f).withAlpha(0.55f);
     m_colorRedDim = m_colorRed.withSaturation(0.0f).withAlpha(0.55f);
     // Match fader track background (Dark Glass)
-    m_colorBackground = AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.3f);
+    m_colorBackground = theme.getColor("meterBackground").withAlpha(0.3f);
     m_colorPeakHold = theme.getColor("textPrimary"); // #E5E5E8
     m_colorPeakOverlay = m_colorPeakHold.withAlpha(0.8f);
     m_colorPeakOverlayDim = m_colorPeakOverlay.withSaturation(0.0f).withAlpha(0.6f);
@@ -250,7 +250,7 @@ void UIMixerMeter::renderMeterBar(NUIRenderer& renderer, const NUIRect& bounds,
         // Draw hold line (white 0.85 alpha, 1px thick)
         const NUIColor holdColor = m_dimmed
             ? m_colorPeakOverlayDim
-            : NUIColor(1.0f, 1.0f, 1.0f, 0.85f);
+            : m_colorPeakHold.withAlpha(0.85f);
         renderer.fillRect(NUIRect{meterArea.x, peakY, meterArea.width, PEAK_HOLD_HEIGHT}, holdColor);
     }
 
@@ -310,7 +310,7 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
         
         // Background (distinct from main meter)
         // Use a visible gray track (0.25f)
-        renderer.fillRect(corrBounds, NUIColor(0.25f, 0.25f, 0.25f, 1.0f));
+        renderer.fillRect(corrBounds, NUIThemeManager::getInstance().getColor("controlBackground"));
         
         // Center line (white/bright) - 2px width
         float centerX = corrBounds.x + corrBounds.width * 0.5f;
@@ -392,7 +392,7 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
             lineHeight
         };
         std::string lufsLabel = "LUFS " + m_cachedLufsStr;
-        renderer.drawTextCentered(lufsLabel, lufsRect, 7.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.45f));
+        renderer.drawTextCentered(lufsLabel, lufsRect, 7.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.45f));
         
     } else if (hasPeak) {
         // Regular tracks: Show Peak dB or −∞ at silence floor

--- a/AestraUI/Widgets/UIMixerMeter.h
+++ b/AestraUI/Widgets/UIMixerMeter.h
@@ -23,6 +23,7 @@ public:
     UIMixerMeter();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     /**

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -50,6 +50,7 @@ public:
     ~UIMixerPanel() override;
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIMixerPluginDropdown.h
+++ b/AestraUI/Widgets/UIMixerPluginDropdown.h
@@ -22,6 +22,7 @@ public:
     UIMixerPluginDropdown();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -39,6 +39,7 @@ public:
                  std::shared_ptr<Aestra::Audio::ContinuousParamBuffer> continuousParams);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -87,6 +87,7 @@ void UIRoutingMap::cacheThemeColors() {
     m_textInfo = tm.getColor("info");
     m_accent = tm.getColor("accentPrimary");
     m_warning = tm.getColor("warning");
+    m_error = tm.getColor("error");
 }
 
 void UIRoutingMap::rebuildGraph() {
@@ -730,7 +731,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
     // === Chrome: flat rounded card ===
     // Solid dark card so the workspace doesn't bleed through. Flat — no fake
     // drop shadow, no depth gradient (matches the app's flat surface language).
-    renderer.fillRoundedRect(bounds, kCornerRadius, NUIColor(0.046f, 0.046f, 0.046f, 1.0f));
+    renderer.fillRoundedRect(bounds, kCornerRadius, m_bg);
 
     // === Title bar === charcoal (backgroundSecondary), matching the transport
     // bar and every docked panel's chrome — rounded top, squared flush bottom.
@@ -822,7 +823,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
             float itemH = 22.0f;
             float dropH = static_cast<float>(m_searchMatches.size()) * itemH + 4.0f;
             NUIRect dropRect{searchX, dropY, searchW, dropH};
-            renderer.fillRoundedRect(dropRect, 5.0f, NUIColor(0.085f, 0.085f, 0.085f, 0.98f));
+            renderer.fillRoundedRect(dropRect, 5.0f, m_bgTertiary.withAlpha(0.98f));
             renderer.strokeRoundedRect(dropRect, 5.0f, 1.0f, m_border.withAlpha(0.35f));
             for (size_t i = 0; i < m_searchMatches.size() && i < 5; ++i) {
                 int nodeIdx = m_searchMatches[i];
@@ -1106,7 +1107,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
         const float pillH = kLegFont + kPadY * 2.0f + 2.0f;
         NUIRect legendBg{bounds.x + 14.0f, bounds.bottom() - pillH - 12.0f,
                          contentW + kPadX * 2.0f, pillH};
-        renderer.fillRoundedRect(legendBg, 5.0f, NUIColor(0.046f, 0.046f, 0.046f, 0.85f));
+        renderer.fillRoundedRect(legendBg, 5.0f, m_bgTertiary.withAlpha(0.85f));
         renderer.strokeRoundedRect(legendBg, 5.0f, 1.0f, m_border.withAlpha(0.14f));
 
         const float textY = legendBg.y + kPadY;
@@ -1168,11 +1169,9 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
         // the destination stays visually distinct.
         NUIColor bg;
         if (node.type == Node::Master) {
-            bg = node.hovered ? NUIColor(0.22f, 0.16f, 0.32f, 1.0f)
-                              : NUIColor(0.18f, 0.13f, 0.27f, 1.0f);
+            bg = node.hovered ? m_accent.withAlpha(0.28f) : m_accent.withAlpha(0.20f);
         } else {
-            bg = node.hovered ? NUIColor(0.137f, 0.137f, 0.137f, 1.0f)
-                              : NUIColor(0.097f, 0.097f, 0.097f, 1.0f);
+            bg = node.hovered ? m_bgTertiary : m_bgSecondary;
         }
         renderer.fillRoundedRect(nodeRect, radius, bg);
 
@@ -1195,8 +1194,7 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
 
         // Muted overlay: dim the entire node
         if (node.muted) {
-            renderer.fillRoundedRect(nodeRect, radius,
-                                      NUIColor(0.0f, 0.0f, 0.0f, 0.55f));
+            renderer.fillRoundedRect(nodeRect, radius, m_bg.withAlpha(0.72f));
         }
 
         if (node.type == Node::Master) {
@@ -1260,14 +1258,14 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
             }
             if (node.muted) {
                 NUIRect bRect{badgeX - 16.0f, ny + 6.0f, 16.0f, 16.0f};
-                renderer.fillRoundedRect(bRect, 4.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.85f));
+                renderer.fillRoundedRect(bRect, 4.0f, m_error.withAlpha(0.85f));
                 renderer.drawTextCentered("M", bRect, 10.0f, NUIColor::white());
             }
 
             // Routing warning badge (top-left, overlapping the color strip)
             if (node.hasRoutingWarning) {
                 NUIRect wRect{nx + 6.0f, ny + 6.0f, 16.0f, 16.0f};
-                renderer.fillRoundedRect(wRect, 4.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.9f));
+                renderer.fillRoundedRect(wRect, 4.0f, m_warning.withAlpha(0.9f));
                 renderer.drawTextCentered("!", wRect, 11.0f, NUIColor::white());
             }
 
@@ -1281,7 +1279,7 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
                 float trackH_meter = 3.0f;
                 float meterY = ny + nh - trackH_meter - 4.0f;
                 NUIRect track{nx + 14.0f, meterY, nw - 24.0f, trackH_meter};
-                renderer.fillRoundedRect(track, 1.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                renderer.fillRoundedRect(track, 1.5f, m_text.withAlpha(0.08f));
 
                 // Map dB to 0..1: -60dB → 0, 0dB → 1
                 float normalized = std::clamp((node.peakDb + 60.0f) / 60.0f, 0.0f, 1.0f);
@@ -1326,13 +1324,13 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
     } else {
         // === Minimap mode ===
         // Brighter overlay so nodes contrast against the dark card.
-        NUIColor nodeFill = NUIColor(1.0f, 1.0f, 1.0f, node.hovered ? 0.18f : 0.12f);
+        NUIColor nodeFill = m_text.withAlpha(node.hovered ? 0.18f : 0.12f);
         renderer.fillRoundedRect(nodeRect, radius, nodeFill);
 
         // Border picks up solo/selection state too
         bool isSelected = (m_viewModel &&
                            static_cast<int32_t>(node.id) == m_viewModel->getSelectedChannelId());
-        NUIColor strokeColor = NUIColor(1.0f, 1.0f, 1.0f, 0.22f);
+        NUIColor strokeColor = m_text.withAlpha(0.22f);
         if (node.soloed) strokeColor = m_warning.withAlpha(0.95f);
         else if (isSelected) strokeColor = m_accent.withAlpha(0.85f);
         else if (node.hovered) strokeColor = m_accent.withAlpha(0.7f);
@@ -2351,29 +2349,30 @@ void UIRoutingMap::drawSendLevelLabel(NUIRenderer& renderer, const NUIPoint& a, 
     float textW = renderer.measureText(buf, fontSize).width;
     float textH = fontSize + 2.0f;
     NUIRect bg{mx - textW * 0.5f - 3.0f, my - textH * 0.5f, textW + 6.0f, textH};
-    renderer.fillRoundedRect(bg, 3.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.85f));
+    renderer.fillRoundedRect(bg, 3.0f, m_bgSecondary.withAlpha(0.85f));
     renderer.strokeRoundedRect(bg, 3.0f, 0.5f, m_borderSecondary.withAlpha(0.4f));
     renderer.drawTextCentered(buf, bg, fontSize, m_textSecondary.withAlpha(0.85f));
 }
 
 NUIColor UIRoutingMap::resolveInsertColor(const std::string& name) const {
+    auto& tm = NUIThemeManager::getInstance();
     std::string low;
     low.reserve(name.size());
     for (char c : name) low.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
 
     if (low.find("eq") != std::string::npos || low.find("filter") != std::string::npos)
-        return NUIColor(0.46f, 0.92f, 0.92f, 0.92f); // cyan
+        return tm.getColor("accentCyan").withAlpha(0.92f);
     if (low.find("comp") != std::string::npos || low.find("limit") != std::string::npos)
-        return NUIColor(0.96f, 0.60f, 0.26f, 0.92f); // orange
+        return tm.getColor("accentAmber").withAlpha(0.92f);
     if (low.find("reverb") != std::string::npos || low.find("delay") != std::string::npos)
-        return NUIColor(0.36f, 0.58f, 0.96f, 0.92f); // blue
+        return tm.getColor("info").withAlpha(0.92f);
     if (low.find("dist") != std::string::npos || low.find("sat") != std::string::npos || low.find("drive") != std::string::npos)
-        return NUIColor(0.96f, 0.36f, 0.36f, 0.92f); // red
+        return tm.getColor("accentRed").withAlpha(0.92f);
     if (low.find("chorus") != std::string::npos || low.find("flang") != std::string::npos || low.find("phaser") != std::string::npos)
-        return NUIColor(0.46f, 0.86f, 0.46f, 0.92f); // green
+        return tm.getColor("accentLime").withAlpha(0.92f);
     if (low.find("sampler") != std::string::npos || low.find("sample") != std::string::npos)
-        return NUIColor(0.96f, 0.86f, 0.36f, 0.92f); // yellow
-    return NUIColor(0.72f, 0.52f, 0.96f, 0.92f); // purple default
+        return tm.getColor("warning").withAlpha(0.92f);
+    return tm.getColor("accentPrimary").withAlpha(0.92f);
 }
 
 void UIRoutingMap::drawInsertDots(NUIRenderer& renderer, const Node& node, float nx, float ny, float nw, float nh) {
@@ -2385,7 +2384,7 @@ void UIRoutingMap::drawInsertDots(NUIRenderer& renderer, const Node& node, float
     for (size_t i = 0; i < node.insertNames.size(); ++i) {
         NUIColor col = resolveInsertColor(node.insertNames[i]);
         renderer.fillCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, col);
-        renderer.strokeCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, 0.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.25f));
+        renderer.strokeCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, 0.5f, m_text.withAlpha(0.25f));
     }
 }
 
@@ -2447,7 +2446,7 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
     float offsetY = insetY + insetH * 0.5f - (m_worldMinY + worldH * 0.5f) * scale;
 
     // Background
-    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, NUIColor(0.055f, 0.055f, 0.055f, 0.92f));
+    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, m_bgSecondary.withAlpha(0.92f));
     renderer.strokeRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, 1.0f, m_border.withAlpha(0.35f));
 
     // Draw all edges as thin faint lines
@@ -2475,8 +2474,8 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
         float ny = offsetY + node.y * scale;
         float nw = node.w * scale;
         float nh = node.h * scale;
-        NUIColor fill = NUIColor(0.169f, 0.169f, 0.169f, 0.85f);
-        if (node.type == Node::Master) fill = NUIColor(0.25f, 0.18f, 0.36f, 0.85f);
+        NUIColor fill = m_bgTertiary.withAlpha(0.85f);
+        if (node.type == Node::Master) fill = m_accent.withAlpha(0.24f);
         renderer.fillRoundedRect({nx, ny, nw, nh}, 2.0f, fill);
         renderer.strokeRoundedRect({nx, ny, nw, nh}, 2.0f, 0.5f, m_border.withAlpha(0.4f));
     }
@@ -2535,7 +2534,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     m_inspectorPanelRect = NUIRect{insetX, insetY, kInspectorW, insetH};
 
     // Background
-    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.96f));
+    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, m_bgSecondary.withAlpha(0.96f));
     renderer.strokeRoundedRect(m_inspectorPanelRect, 8.0f, 1.0f, m_border.withAlpha(0.45f));
 
     // Clip content to panel interior (scrollable area)
@@ -2574,7 +2573,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
         }
         if (ch->muted) {
             NUIRect bRect{badgeX, y, 20.0f, 18.0f};
-            renderer.fillRoundedRect(bRect, 4.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.85f));
+            renderer.fillRoundedRect(bRect, 4.0f, m_error.withAlpha(0.85f));
             renderer.drawTextCentered("M", bRect, 10.0f, NUIColor::white());
         }
         y += 24.0f;
@@ -2583,10 +2582,10 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     // Routing warning
     if (node.hasRoutingWarning) {
         std::string warn = m_viewModel->getRoutingWarning(node.id);
-        renderer.fillRoundedRect({left, y, textW, 20.0f}, 4.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.18f));
-        renderer.strokeRoundedRect({left, y, textW, 20.0f}, 4.0f, 1.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.5f));
+        renderer.fillRoundedRect({left, y, textW, 20.0f}, 4.0f, m_warning.withAlpha(0.18f));
+        renderer.strokeRoundedRect({left, y, textW, 20.0f}, 4.0f, 1.0f, m_warning.withAlpha(0.5f));
         std::string wtext = fitLabel(renderer, warn, 10.0f, textW - 8.0f);
-        renderer.drawText(wtext, {left + 6.0f, y + 3.0f}, 10.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.9f));
+        renderer.drawText(wtext, {left + 6.0f, y + 3.0f}, 10.0f, m_warning.withAlpha(0.9f));
         y += 28.0f;
     }
 
@@ -2684,7 +2683,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
                 metaX += renderer.measureText("pre", 9.0f).width + 8.0f;
             }
             if (send.muted) {
-                renderer.drawText("muted", {metaX, metaY}, 9.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.75f));
+                renderer.drawText("muted", {metaX, metaY}, 9.0f, m_error.withAlpha(0.75f));
             }
 
             y += 28.0f;
@@ -2697,8 +2696,8 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     // Close button (top-right of panel)
     m_inspectorCloseRect = NUIRect{insetX + kInspectorW - 26.0f, insetY + 8.0f, 18.0f, 18.0f};
     renderer.fillRoundedRect(m_inspectorCloseRect, 5.0f,
-                             m_inspectorCloseHovered ? NUIColor(0.9f, 0.3f, 0.3f, 0.45f)
-                                                      : NUIColor(0.2f, 0.2f, 0.2f, 0.4f));
+                             m_inspectorCloseHovered ? m_warning.withAlpha(0.45f)
+                                                      : m_bgTertiary.withAlpha(0.4f));
     renderer.drawTextCentered("x", m_inspectorCloseRect, 12.0f, m_textSecondary.withAlpha(0.85f));
 }
 

--- a/AestraUI/Widgets/UIRoutingMap.h
+++ b/AestraUI/Widgets/UIRoutingMap.h
@@ -29,6 +29,7 @@ public:
     explicit UIRoutingMap(Mode mode = Mode::Minimap);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
@@ -244,6 +245,7 @@ private:
     NUIColor m_textInfo;
     NUIColor m_accent;
     NUIColor m_warning;
+    NUIColor m_error;
 
     void cacheThemeColors();
     void rebuildGraph();

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -259,7 +259,7 @@ void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     auto& theme = NUIThemeManager::getInstance();
     
     NUIColor bgColor = active ? theme.getColor("warning") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? NUIColor(0.0f, 0.0f, 0.0f, 1.0f) : theme.getColor("textSecondary");
+    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
     NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
 
     // Circular Button
@@ -280,7 +280,7 @@ void UnitRow::drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     auto& theme = NUIThemeManager::getInstance();
 
     NUIColor bgColor = active ? theme.getColor("success") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? NUIColor(0.0f, 0.0f, 0.0f, 1.0f) : theme.getColor("textSecondary");
+    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
     NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
 
     // Circular Button

--- a/Source/Components/AudioVisualizer.cpp
+++ b/Source/Components/AudioVisualizer.cpp
@@ -197,6 +197,17 @@ void AudioVisualizer::onResize(int width, int height) {
     currentSample_ = 0;
 }
 
+void AudioVisualizer::onThemeChanged(const NUIThemeProperties& theme) {
+    backgroundColor_ = theme.backgroundPrimary;
+    gridColor_ = theme.border;
+    textColor_ = theme.textPrimary;
+    if (!customColorScheme_) {
+        primaryColor_ = theme.accentCyan;
+        secondaryColor_ = theme.accentMagenta;
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 // =============================================================================
 // SECTION: Audio Data Input
 // =============================================================================
@@ -303,6 +314,7 @@ void AudioVisualizer::setDecayRate(float decayRate) {
 void AudioVisualizer::setColorScheme(const NUIColor& primary, const NUIColor& secondary) {
     primaryColor_ = primary;
     secondaryColor_ = secondary;
+    customColorScheme_ = true;
     setDirty(true);
 }
 
@@ -378,7 +390,7 @@ void AudioVisualizer::renderWaveform(NUIRenderer& renderer) {
     
     // Liminal Dark v2.0 background gradient - top: #121214 â†’ bottom: #18181b
     NUIColor topColor = backgroundColor_;  // #121214 - Deep charcoal
-    NUIColor bottomColor = NUIColor(0.094f, 0.094f, 0.094f, 1.0f);  // #181818 - Slightly lighter
+    NUIColor bottomColor = AestraUI::NUIThemeManager::getInstance().getColor("backgroundSecondary");
     
     // Draw gradient background
     for (int i = 0; i < static_cast<int>(bounds.height); ++i) {
@@ -521,7 +533,7 @@ void AudioVisualizer::renderWaveform(NUIRenderer& renderer) {
     
     // Audio active pulse indicator - Liminal Dark v2.0
     float pulse = 0.5f + 0.5f * std::sin(animationTime_ * 3.5f);
-    NUIColor pulseColor = NUIColor(0.620f, 1.0f, 0.380f, pulse * glowIntensity);  // #9eff61 - Accent lime
+    NUIColor pulseColor = AestraUI::NUIThemeManager::getInstance().getColor("accentLime").withAlpha(pulse * glowIntensity);
     float pulseRadius = 5.0f + (glowIntensity * 2.0f);
     renderer.fillCircle(NUIPoint(bounds.x + bounds.width - 15, bounds.y + bounds.height - 15), 
                        pulseRadius, pulseColor);
@@ -718,7 +730,7 @@ void AudioVisualizer::renderOscilloscope(NUIRenderer& renderer) {
     // Add trigger level indicator
     float triggerLevel = 0.3f; // Fixed trigger level for demo
     float triggerY = centerY - triggerLevel * bounds.height / 2.0f;
-    renderer.drawLine(NUIPoint(bounds.x, triggerY), NUIPoint(bounds.x + bounds.width, triggerY), 1, NUIColor(1.0f, 1.0f, 0.0f, 0.6f));
+    renderer.drawLine(NUIPoint(bounds.x, triggerY), NUIPoint(bounds.x + bounds.width, triggerY), 1, AestraUI::NUIThemeManager::getInstance().getColor("warning").withAlpha(0.6f));
     
     // Add timebase indicator
     std::string timebaseText = "1ms/div";

--- a/Source/Components/AudioVisualizer.h
+++ b/Source/Components/AudioVisualizer.h
@@ -40,6 +40,7 @@ public:
     void onRender(NUIRenderer& renderer) override;
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     
     // Audio data input
     void setAudioData(const float* leftChannel, const float* rightChannel, size_t numSamples, double sampleRate);
@@ -115,6 +116,7 @@ private:
     float decayRate_;
     NUIColor primaryColor_;
     NUIColor secondaryColor_;
+    bool customColorScheme_{false};
     bool showStereo_;
     bool showPeakHold_;
     

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -172,7 +172,7 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
         
         // Meter background (Dark Slot)
         AestraUI::NUIRect meterBg(meterX, meterY, meterW, meterH);
-        renderer.fillRoundedRect(meterBg, 2.0f, AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.8f));
+        renderer.fillRoundedRect(meterBg, 2.0f, theme.getColor("meterBackground"));
         
         // Get current level (Mock/Placeholder)
         float level = m_track->getVolume(); // Simple mapping
@@ -193,12 +193,12 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
             
             if (isActive) {
                 float n = static_cast<float>(i) / numSegments;
-                if (n < 0.7f) segColor = AestraUI::NUIColor::fromHex(0x00ffaa); // Cyan
-                else if (n < 0.9f) segColor = AestraUI::NUIColor::fromHex(0xffaa00); // Amber
-                else segColor = AestraUI::NUIColor::fromHex(0xff3333); // Red
+                if (n < 0.7f) segColor = theme.getColor("meterSafe");
+                else if (n < 0.9f) segColor = theme.getColor("meterWarn");
+                else segColor = theme.getColor("meterCrit");
                 segColor = segColor.withAlpha(0.9f);
             } else {
-                segColor = AestraUI::NUIColor(0.2f, 0.2f, 0.2f, 0.3f);
+                segColor = theme.getColor("meterBackground").withAlpha(0.55f);
             }
             
             renderer.fillRect(AestraUI::NUIRect(meterX + 1.0f, y + segGap, meterW - 2.0f, segH - segGap), segColor);
@@ -273,15 +273,13 @@ void MixerView::onRender(AestraUI::NUIRenderer& renderer) {
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     auto bounds = getBounds();
     
-    // Deep Void Background
-    auto bgColor = AestraUI::NUIColor::fromHex(0x050505); // Matches Playlist
-    renderer.fillRect(bounds, bgColor);
+    renderer.fillRect(bounds, theme.getColor("workspaceBackground"));
     
     // Subtle Top Gradient (Header Shadow)
     renderer.fillRectGradient(
         AestraUI::NUIRect(bounds.x, bounds.y, bounds.width, 20.0f),
-        AestraUI::NUIColor(0,0,0,0.4f),
-        AestraUI::NUIColor(0,0,0,0.0f),
+        theme.getColor("shadow").withAlpha(0.40f),
+        theme.getColor("shadow").withAlpha(0.0f),
         true
     );
     

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -180,9 +180,9 @@ void TimelineMinimapBar::endDrag_()
 void TimelineMinimapBar::cacheThemeColors_()
 {
     auto& theme = NUIThemeManager::getInstance();
-    // Near-black shell matching the ruler material exactly (one continuous
-    // band; the old surfaceRaised tint read blue against neighboring rows).
-    colors_.glassFill = NUIColor(0.012f, 0.012f, 0.012f, 0.98f);
+    // Match the ruler's recessed material so the band remains continuous in
+    // every theme.
+    colors_.glassFill = theme.getColor("recessedPanel");
     colors_.glassBorder = theme.getColor("border").withAlpha(0.28f);
     colors_.cornerSeparator = theme.getColor("border").withAlpha(0.28f);
 
@@ -196,8 +196,8 @@ void TimelineMinimapBar::cacheThemeColors_()
     colors_.selectionFill = theme.getColor("accentCyan").withAlpha(0.10f);
     colors_.loopFill = theme.getColor("accentPrimary").withAlpha(0.08f);
 
-    colors_.playheadDark = NUIColor(0.0f, 0.0f, 0.0f, 0.75f);
-    colors_.playheadBright = NUIColor(1.0f, 1.0f, 1.0f, 0.85f);
+    colors_.playheadDark = theme.getColor("shadow").withAlpha(0.75f);
+    colors_.playheadBright = theme.getColor("textPrimary").withAlpha(0.85f);
 
     colors_.text = theme.getColor("textPrimary");
 }

--- a/Source/Components/TimelineMinimapBar.h
+++ b/Source/Components/TimelineMinimapBar.h
@@ -29,6 +29,7 @@ public:
     TimelineMinimapBar();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors_(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseLeave() override;

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1785,12 +1785,12 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
     // Draw background (control area + full grid area - no bounds restriction)
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor::black(); // pure black grid (owner direction)
+    const AestraUI::NUIColor gridBgColor = themeManager.getColor("timelineBed"); // pure black on dark (owner direction), recessed on light
 
     if (m_playlistVisible) {
         // Background for control area (always visible)
         AestraUI::NUIRect controlBg(bounds.x, bounds.y, controlAreaWidth, bounds.height);
-        renderer.fillRect(controlBg, AestraUI::NUIColor(0.035f, 0.035f, 0.035f, 1.0f));
+        renderer.fillRect(controlBg, themeManager.getColor("recessedPanel"));
 
         // Background for grid area (match track background; zebra grid provides contrast)
         float scrollbarWidth = kTimelineScrollbarWidth;
@@ -1870,9 +1870,10 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         if (trackBounds.bottom() < viewportTop || trackBounds.y > viewportBottom)
             continue;
 
-        // Uniform pure-black row base (owner direction: no row zebra; the bar
-        // zebra inside drawPlaylistGrid provides the only alternation).
-        renderer.fillRect(trackBounds, AestraUI::NUIColor::black());
+        // Uniform row base (owner direction: no row zebra; the bar zebra
+        // inside drawPlaylistGrid provides the only alternation). Pure black
+        // on dark themes, recessed light bed on light themes.
+        renderer.fillRect(trackBounds, themeManager.getColor("timelineBed"));
 
         track->renderStatic(renderer);
 
@@ -1883,7 +1884,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         const AestraUI::NUIRect gapRect(bounds.x + gridStartX, trackBounds.bottom(),
                                         std::max(0.0f, trackWidth - gridStartX),
                                         static_cast<float>(m_trackSpacing));
-        renderer.fillRect(gapRect, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.30f));
+        renderer.fillRect(gapRect, AestraUI::NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.30f));
     }
 
     // Clear clip rect before drawing header/ruler (they should draw fully)
@@ -1901,7 +1902,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         AestraUI::NUIRect headerRect(bounds.x, bounds.y, headerWidth, headerHeight);
         // Elevated header: base fill + soft vertical gradient + glass top edge.
         // Rendered into the playlist FBO cache, so the richness is free per frame.
-        renderer.fillRect(headerRect, AestraUI::NUIColor(0.031f, 0.031f, 0.031f, 1.0f));
+        renderer.fillRect(headerRect, themeManager.getColor("recessedPanel"));
         // Shade-only elevation — any white component reads as a sheen on this
         // near-black chrome (owner direction: no light gradients anywhere).
         renderer.fillRectGradient(headerRect, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
@@ -3738,8 +3739,8 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
 
     // Opaque near-black ruler material — identical across the full row and the
     // grid shell so the corner over the track controls is flush by construction.
-    auto glassBg = AestraUI::NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
-    auto glassHighlight = AestraUI::NUIColor::white().withAlpha(0.014f);
+    auto glassBg = themeManager.getColor("recessedPanel");
+    auto glassHighlight = themeManager.getColor("textPrimary").withAlpha(0.014f);
 
     auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
     auto majorTickCol = themeManager.getColor("gridMajor");
@@ -4158,7 +4159,7 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
 
     AestraUI::NUIRect textureBounds(0, 0, static_cast<float>(width), static_cast<float>(height));
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor(0.08235f, 0.08235f, 0.08235f, 1.0f); // #151515
+    const AestraUI::NUIColor gridBgColor = themeManager.getColor("workspaceBackground");
     AestraUI::NUIColor borderColor = themeManager.getColor("border");
 
     // Draw background panels
@@ -4196,9 +4197,9 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
     double maxExtentInBeats = maxExtent / secondsPerBeat;
 
     // Ruler Render: "Mature" Playlist Style
-    auto bg = AestraUI::NUIColor(0.08f, 0.08f, 0.08f, 1.0f);
-    auto textCol = AestraUI::NUIColor(0.82f, 0.82f, 0.82f, 1.0f); // bright gray for ruler labels
-    auto tickCol = AestraUI::NUIColor(0.45f, 0.45f, 0.45f, 1.0f); // visible tick marks
+    auto bg = themeManager.getColor("recessedPanel");
+    auto textCol = themeManager.getColor("textPrimary");
+    auto tickCol = themeManager.getColor("gridMajor");
 
     // Draw ruler background
     renderer.fillRect(rulerRect, bg);
@@ -5166,7 +5167,7 @@ void TrackManagerUI::renderDropPreview(AestraUI::NUIRenderer& renderer) {
             const float clipLabelFont = themeManager.getFontSize("xs");
             const float labelTextY = headerRect.y + std::max(0.0f, (headerRect.height - clipLabelFont) * 0.5f);
             AestraUI::NUIPoint textPos(clipPreview.x + 6.0f, labelTextY);
-            renderer.drawText(displayName, textPos, clipLabelFont, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+            renderer.drawText(displayName, textPos, clipLabelFont, AestraUI::NUIThemeManager::getInstance().getCurrentTheme().textPrimary);
         }
     }
 }

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -64,6 +64,10 @@ class TrackManagerUI : public ::AestraUI::NUIComponent, public ::AestraUI::IDrop
 public:
     TrackManagerUI(std::shared_ptr<TrackManager> trackManager);
     ~TrackManagerUI() override;
+    void onThemeChanged(const ::AestraUI::NUIThemeProperties& theme) override {
+        invalidateAllCaches();
+        ::AestraUI::NUIComponent::onThemeChanged(theme);
+    }
 
     void setPlatformWindow(::AestraUI::NUIPlatformBridge* window);
     ::AestraUI::NUIPlatformBridge* getPlatformWindow() const { return m_window; }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -888,7 +888,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
             AestraUI::NUIPoint(clipBounds.x + 4.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
             AestraUI::NUIPoint(clipBounds.right() - 4.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
             1.0f,
-            AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.09f)
+            themeManager.getCurrentTheme().textPrimary.withAlpha(0.09f)
         );
 
         const std::string displayName = truncateClipLabel(sampleName, clipBounds.width - 16.0f, 6.0f);
@@ -904,7 +904,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
             renderer.drawText(displayName,
                               AestraUI::NUIPoint(clipBounds.x + 6.0f, textY),
                               kClipLabelFontSize,
-                              AestraUI::NUIColor(1.0f, 1.0f, 1.0f, clipSelected ? 0.92f : 0.78f));
+                              themeManager.getCurrentTheme().textPrimary.withAlpha(clipSelected ? 0.92f : 0.78f));
         }
     }
 }
@@ -1026,7 +1026,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
     }
 
     const float clipRadius = themeManager.getRadius("s");
-    renderer.fillRoundedRect(clipBounds, clipRadius, AestraUI::NUIColor(0.071f, 0.071f, 0.071f, 0.96f));
+    renderer.fillRoundedRect(clipBounds, clipRadius, themeManager.getColor("elevatedPanel").withAlpha(0.96f));
     renderer.fillRoundedRect(clipBounds, clipRadius, baseColor.withAlpha(isSelected ? 0.38f : 0.28f));
     renderer.strokeRoundedRect(
         clipBounds,
@@ -1051,7 +1051,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
         AestraUI::NUIPoint(clipBounds.x + 6.0f, clipBounds.y + headerHeight + 1.0f),
         AestraUI::NUIPoint(clipBounds.right() - 6.0f, clipBounds.y + headerHeight + 1.0f),
         1.0f,
-        AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.08f)
+        themeManager.getCurrentTheme().textPrimary.withAlpha(0.08f)
     );
 
     std::string clipName = clip.name;
@@ -1065,7 +1065,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
     const std::string displayName = truncateClipLabel(clipName, clipBounds.width - 46.0f, 5.9f);
     if (!displayName.empty()) {
         renderer.drawText(displayName, AestraUI::NUIPoint(clipBounds.x + 10.0f, clipBounds.y + 4.0f),
-                          9.5f, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+                          9.5f, themeManager.getCurrentTheme().textPrimary);
     }
 
     if (m_trackManager && clip.patternId.isValid()) {
@@ -1099,7 +1099,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     AestraUI::NUIPoint(clipBounds.x + 7.0f, y),
                     AestraUI::NUIPoint(clipBounds.right() - 4.0f, y),
                     1.0f,
-                    AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.06f)
+                    themeManager.getCurrentTheme().textPrimary.withAlpha(0.06f)
                 );
             }
 
@@ -1113,7 +1113,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     AestraUI::NUIPoint(stepX, noteAreaY + 1.0f),
                     AestraUI::NUIPoint(stepX, clipBounds.bottom() - 4.0f),
                     1.0f,
-                    AestraUI::NUIColor(1.0f, 1.0f, 1.0f, major ? 0.08f : 0.04f)
+                    themeManager.getCurrentTheme().textPrimary.withAlpha(major ? 0.08f : 0.04f)
                 );
             }
             
@@ -1136,7 +1136,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     if (noteRect.x + noteRect.width > clipBounds.x + clipBounds.width) {
                         noteRect.width = (clipBounds.x + clipBounds.width) - noteRect.x;
                     }
-                    renderer.fillRoundedRect(noteRect, themeProps.radiusXS, AestraUI::NUIColor(1.0f, 0.985f, 0.93f, isSelected ? 0.88f : 0.78f));
+                    renderer.fillRoundedRect(noteRect, themeProps.radiusXS, themeManager.getCurrentTheme().textPrimary.withAlpha(isSelected ? 0.88f : 0.78f));
                     if (noteRect.width > 6.0f && noteRect.height > 2.5f) {
                         renderer.fillRoundedRect(
                             {noteRect.x + 1.0f, noteRect.y + 1.0f, std::max(0.0f, noteRect.width - 2.0f), std::max(0.0f, noteRect.height - 2.0f)},
@@ -1178,7 +1178,7 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
          AestraUI::NUIColor selectedColor = themeManager.getColor("accentPrimary").withAlpha(0.075f);
          trackBgColor = selectedColor; 
     } else if (isHovered()) {
-         trackBgColor = AestraUI::NUIColor::white().withAlpha(0.026f);
+         trackBgColor = themeManager.getCurrentTheme().textPrimary.withAlpha(0.026f);
     }
     
     // Apply background
@@ -1193,9 +1193,9 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
     if (m_isPrimaryForLane) {
         AestraUI::NUIRect controlBounds(bounds.x, bounds.y, controlAreaWidth, bounds.height);
 
-        // Control Area base: elevated surface from palette.
-        // Near-black chrome per owner direction (was surfaceTertiary, read bluish-grey).
-        AestraUI::NUIColor baseControlColor(0.038f, 0.039f, 0.045f, 1.0f);
+        // Control Area base: near-black chrome on dark themes (owner
+        // direction — surfaceTertiary read bluish-grey), clean surface on light.
+        AestraUI::NUIColor baseControlColor = themeManager.getColor("trackChrome");
 
         // Static Control Area State
         if (m_channel) {
@@ -1592,7 +1592,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                     trackPoints.push_back({cx + std::cos(theta) * r, cy + std::sin(theta) * r});
                 }
                 renderer.drawPolyline(trackPoints.data(), static_cast<int>(trackPoints.size()), 2.0f,
-                                      AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.13f));
+                                      themeManager.getCurrentTheme().textPrimary.withAlpha(0.13f));
 
                 // Active value arc
                 if (t > 0.0f) {
@@ -1612,7 +1612,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                 // Pointer dot at current value
                 const float ptrX = cx + std::cos(currentAng) * (r * 0.72f);
                 const float ptrY = cy + std::sin(currentAng) * (r * 0.72f);
-                renderer.fillCircle({ptrX, ptrY}, 1.8f, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.9f));
+                renderer.fillCircle({ptrX, ptrY}, 1.8f, themeManager.getCurrentTheme().textPrimary.withAlpha(0.9f));
             }
         }
 
@@ -1654,7 +1654,8 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     const float gridEndX = bounds.right();
 
     AestraUI::renderTimelineGrid(
-        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar);
+        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar,
+        themeManager.getCurrentTheme().textPrimary);
 }
 
 void TrackUIComponent::onMouseEnter() {

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -11,6 +11,7 @@
 #include "TrackManagerUI.h"
 #include "FileBrowser.h"
 #include "TransportBar.h"
+#include "Preferences.h"
 
 #include "../AestraUI/Graphics/OpenGL/NUIRendererGL.h"
 #include "../AestraUI/Core/NUIDragDrop.h"
@@ -150,15 +151,27 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
         return false;
     }
 
-    // Initialize Aestra theme
+    // Initialize the persisted theme before constructing theme-aware widgets.
     auto& themeManager = NUIThemeManager::getInstance();
-    themeManager.setActiveTheme("Aestra-dark");
+    auto& preferences = Preferences::instance();
+    if (!themeManager.setActiveTheme(preferences.theme)) {
+        preferences.theme = "Aestra-dark";
+        themeManager.setActiveTheme(preferences.theme);
+        Log::warning("Unknown saved theme; using Aestra-dark");
+    }
     Log::info("Theme system initialized");
 
     // Create root component
     m_rootComponent = std::make_shared<AestraRootComponent>();
     m_rootComponent->setBounds(NUIRect(0, 0, desc.width, desc.height));
     m_window->setRootComponent(m_rootComponent.get()); // WIRED: Events flow to this root
+    m_themeSubscriptionId = themeManager.subscribeToThemeChanges(
+        [this](const NUIThemeProperties& theme) {
+            if (m_rootComponent)
+                m_rootComponent->onThemeChanged(theme);
+            if (m_adaptiveFPS)
+                m_adaptiveFPS->signalActivity(AestraUI::NUIAdaptiveFPS::ActivityType::Animation);
+        });
 
     // Create custom window with title bar
     m_customWindow = std::make_shared<NUICustomWindow>();
@@ -431,6 +444,10 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
 }
 
 void AestraWindowManager::shutdown() {
+    if (m_themeSubscriptionId != 0) {
+        NUIThemeManager::getInstance().unsubscribeFromThemeChanges(m_themeSubscriptionId);
+        m_themeSubscriptionId = 0;
+    }
     if (m_window) {
         m_window->destroy();
     }
@@ -707,6 +724,13 @@ void AestraWindowManager::render() {
     NUIColor bgColor = themeManager.getColor("background").withAlpha(1.0f);
 
     m_renderer->clear(bgColor);
+    // Dark-on-light text lacks the bloom light-on-dark gets; thicken strokes
+    // on light themes so labels keep the same perceived weight in both modes.
+    {
+        const auto& themeBg = themeManager.getCurrentTheme().backgroundPrimary;
+        const float bgLuma = 0.2126f * themeBg.r + 0.7152f * themeBg.g + 0.0722f * themeBg.b;
+        m_renderer->setTextContrast(bgLuma < 0.5f ? 1.0f : 0.88f);
+    }
     m_renderer->beginFrame();
     if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
         m_confirmationDialog->setBounds(m_rootComponent->getBounds());

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -194,6 +194,7 @@ private:
     std::shared_ptr<class ExportDialog> m_exportDialog;
 
     std::unique_ptr<AestraUI::NUIAdaptiveFPS> m_adaptiveFPS;
+    AestraUI::NUIThemeManager::ThemeSubscriptionId m_themeSubscriptionId{0};
 
     // Menus
     std::shared_ptr<AestraUI::NUIMenuBar> m_menuBar;

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -101,7 +101,7 @@ public:
         auto b = getBounds();
         auto& theme = NUIThemeManager::getInstance();
 
-        renderer.fillRect(b, NUIColor(0.045f, 0.045f, 0.045f, 1.0f));
+        renderer.fillRect(b, theme.getColor("workspaceBackground"));
 
         const float pad = 8.0f;
         const float gutter = 6.0f;
@@ -150,8 +150,9 @@ void ADSRDisplayComponent::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.055f, 0.055f, 0.055f, 1.0f));
-    renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.22f));
+    const float radius = theme.getRadius("s");
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), radius, theme.getColor("recessedPanel"));
+    renderer.strokeRoundedRect(b, radius, 1.0f, theme.getColor("borderSubtle"));
 
     const auto g = calculateADSRGeometry(b, m_attack, m_decay, m_sustain, m_release);
     const std::vector<NUIPoint> pts{g.start, g.attack, g.decay, g.releaseStart, g.end};
@@ -401,8 +402,9 @@ void WaveformDisplayComponent::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(b);
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.05f, 0.05f, 0.05f, 1.0f));
-    renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.24f));
+    const float radius = theme.getRadius("s");
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), radius, theme.getColor("recessedPanel"));
+    renderer.strokeRoundedRect(b, radius, 1.0f, theme.getColor("borderSubtle"));
 
     // Center line
     float centerY = b.y + b.height * 0.5f;

--- a/Source/Settings/AppearanceSettingsPage.cpp
+++ b/Source/Settings/AppearanceSettingsPage.cpp
@@ -1,8 +1,15 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "AppearanceSettingsPage.h"
 #include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../Core/Preferences.h"
+
+#include <array>
 
 namespace Aestra {
+
+namespace {
+constexpr std::array<const char*, 3> kThemeNames{"Aestra-dark", "Aestra-light", "high-contrast-dark"};
+}
 
 AppearanceSettingsPage::AppearanceSettingsPage() {
     createUI();
@@ -17,10 +24,57 @@ void AppearanceSettingsPage::createUI() {
     m_themeDropdown = std::make_shared<AestraUI::NUIDropdown>();
     m_themeDropdown->addItem("Aestra Dark (Default)", 0);
     m_themeDropdown->addItem("Aestra Light", 1);
-    m_themeDropdown->addItem("Midnight Blue", 2);
-    m_themeDropdown->addItem("High Contrast", 3);
-    m_themeDropdown->setSelectedIndex(0);
+    m_themeDropdown->addItem("High Contrast Dark", 2);
+    m_themeDropdown->setOnSelectionChanged([this](int index) {
+        if (!m_syncingSelection && index >= 0 && index < static_cast<int>(kThemeNames.size()))
+            selectTheme(kThemeNames[static_cast<size_t>(index)]);
+    });
     addChild(m_themeDropdown);
+
+    onShow();
+}
+
+void AppearanceSettingsPage::onShow() {
+    auto& manager = AestraUI::NUIThemeManager::getInstance();
+    m_originalTheme = manager.getActiveTheme();
+    m_pendingTheme = m_originalTheme;
+    m_dirty = false;
+    m_syncingSelection = true;
+    m_themeDropdown->setSelectedIndex(indexForTheme(m_pendingTheme));
+    m_syncingSelection = false;
+}
+
+void AppearanceSettingsPage::selectTheme(const std::string& themeName) {
+    auto& manager = AestraUI::NUIThemeManager::getInstance();
+    if (!manager.setActiveTheme(themeName))
+        return;
+    m_pendingTheme = themeName;
+    m_dirty = m_pendingTheme != m_originalTheme;
+}
+
+void AppearanceSettingsPage::applyChanges() {
+    auto& preferences = Preferences::instance();
+    preferences.theme = m_pendingTheme;
+    preferences.save();
+    m_originalTheme = m_pendingTheme;
+    m_dirty = false;
+}
+
+void AppearanceSettingsPage::cancelChanges() {
+    AestraUI::NUIThemeManager::getInstance().setActiveTheme(m_originalTheme);
+    m_pendingTheme = m_originalTheme;
+    m_syncingSelection = true;
+    m_themeDropdown->setSelectedIndex(indexForTheme(m_pendingTheme));
+    m_syncingSelection = false;
+    m_dirty = false;
+}
+
+int AppearanceSettingsPage::indexForTheme(const std::string& themeName) const {
+    for (size_t i = 0; i < kThemeNames.size(); ++i) {
+        if (themeName == kThemeNames[i])
+            return static_cast<int>(i);
+    }
+    return 0;
 }
 
 void AppearanceSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {

--- a/Source/Settings/AppearanceSettingsPage.h
+++ b/Source/Settings/AppearanceSettingsPage.h
@@ -15,9 +15,10 @@ public:
     std::string getPageID() const override { return "appearance"; }
     std::string getTitle() const override { return "Appearance"; }
 
-    void applyChanges() override { m_dirty = false; }
-    void cancelChanges() override { m_dirty = false; }
+    void applyChanges() override;
+    void cancelChanges() override;
     bool hasUnsavedChanges() const override { return m_dirty; }
+    void onShow() override;
 
     void onRender(AestraUI::NUIRenderer& renderer) override;
     void onResize(int width, int height) override;
@@ -25,8 +26,13 @@ public:
 private:
     void createUI();
     void layoutComponents();
+    void selectTheme(const std::string& themeName);
+    int indexForTheme(const std::string& themeName) const;
 
     bool m_dirty = false;
+    bool m_syncingSelection = false;
+    std::string m_originalTheme;
+    std::string m_pendingTheme;
     
     std::shared_ptr<AestraUI::NUILabel> m_themeLabel;
     std::shared_ptr<AestraUI::NUIDropdown> m_themeDropdown;

--- a/Source/Settings/SettingsDialog.cpp
+++ b/Source/Settings/SettingsDialog.cpp
@@ -3,6 +3,8 @@
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraCore/include/AestraLog.h"
 
+#include <algorithm>
+
 namespace Aestra {
 
 SettingsDialog::SettingsDialog() 
@@ -51,14 +53,8 @@ void SettingsDialog::show() {
         auto parentBounds = getParent()->getBounds();
         if (parentBounds.width > 0 && parentBounds.height > 0) {
             setBounds(parentBounds); // Force resize to parent
+            updateDialogBounds(parentBounds);
         }
-    }
-
-    // Center on screen
-    auto componentBounds = getBounds();
-    if (componentBounds.width > 0 && componentBounds.height > 0) {
-        m_dialogBounds.x = componentBounds.x + (componentBounds.width - m_dialogBounds.width) / 2;
-        m_dialogBounds.y = componentBounds.y + (componentBounds.height - m_dialogBounds.height) / 2;
     }
     
     layoutComponents();
@@ -113,11 +109,12 @@ void SettingsDialog::setActivePage(const std::string& pageID) {
 
 void SettingsDialog::layoutComponents() {
     if (!m_visible) return;
-    
-    float padding = 20.0f;
-    float sidebarWidth = 220.0f;
-    float footerHeight = 60.0f;
-    float titleHeight = 32.0f;
+
+    const auto& props = AestraUI::NUIThemeManager::getInstance().getCurrentTheme();
+    const float padding = props.layout.dialogPadding;
+    const float sidebarWidth = std::clamp(m_dialogBounds.width * 0.23f, 150.0f, 220.0f);
+    const float footerHeight = props.layout.dialogActionHeight + padding * 2.0f;
+    const float titleHeight = props.layout.panelHeaderHeight;
 
     // Sidebar
     m_sidebarBounds = AestraUI::NUIRect(
@@ -144,16 +141,16 @@ void SettingsDialog::layoutComponents() {
 
     // Sidebar items layout
     float itemY = m_sidebarBounds.y + padding;
-    float itemHeight = 36.0f;
+    const float itemHeight = std::max(props.layout.standardRowHeight, 32.0f);
     for (auto& item : m_sidebarItems) {
         item.bounds = AestraUI::NUIRect(m_dialogBounds.x, itemY, sidebarWidth, itemHeight);
         itemY += itemHeight;
     }
     
     // Footer buttons
-    float buttonWidth = 100.0f;
-    float buttonHeight = 32.0f;
-    float buttonY = m_dialogBounds.y + m_dialogBounds.height - 46.0f;
+    const float buttonWidth = m_dialogBounds.width < 560.0f ? 84.0f : 98.0f;
+    const float buttonHeight = props.layout.dialogActionHeight;
+    const float buttonY = m_dialogBounds.bottom() - padding - buttonHeight;
     float rightX = m_dialogBounds.x + m_dialogBounds.width - padding;
     
     m_okButton->setBounds(AestraUI::NUIRect(rightX - buttonWidth, buttonY, buttonWidth, buttonHeight));
@@ -168,13 +165,26 @@ void SettingsDialog::layoutComponents() {
     }
 }
 
+void SettingsDialog::updateDialogBounds(const AestraUI::NUIRect& parentBounds) {
+    constexpr float kPreferredWidth = 950.0f;
+    constexpr float kPreferredHeight = 600.0f;
+    constexpr float kWindowMargin = 16.0f;
+    constexpr float kMinimumWidth = 360.0f;
+    constexpr float kMinimumHeight = 320.0f;
+
+    const float availableWidth = std::max(kMinimumWidth, parentBounds.width - kWindowMargin * 2.0f);
+    const float availableHeight = std::max(kMinimumHeight, parentBounds.height - kWindowMargin * 2.0f);
+    m_dialogBounds.width = std::min(kPreferredWidth, availableWidth);
+    m_dialogBounds.height = std::min(kPreferredHeight, availableHeight);
+    m_dialogBounds.x = parentBounds.x + (parentBounds.width - m_dialogBounds.width) * 0.5f;
+    m_dialogBounds.y = parentBounds.y + (parentBounds.height - m_dialogBounds.height) * 0.5f;
+}
+
 void SettingsDialog::onResize(int width, int height) {
     // Parent bounds (window size)
     setBounds(AestraUI::NUIRect(0, 0, (float)width, (float)height));
     
-    // Center dialog
-    m_dialogBounds.x = (width - m_dialogBounds.width) / 2;
-    m_dialogBounds.y = (height - m_dialogBounds.height) / 2;
+    updateDialogBounds(getBounds());
     
     layoutComponents();
 }

--- a/Source/Settings/SettingsDialog.h
+++ b/Source/Settings/SettingsDialog.h
@@ -41,6 +41,7 @@ public:
 private:
     void createUI();
     void layoutComponents();
+    void updateDialogBounds(const AestraUI::NUIRect& parentBounds);
     void updateSidebar();
 
     bool m_visible;

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -1,9 +1,12 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "NUIThemeSystem.h"
+#include "NUIComponent.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -12,6 +15,18 @@ using namespace AestraUI;
 namespace {
 
 int gFailures = 0;
+
+class ThemeProbe final : public NUIComponent {
+public:
+    void onThemeChanged(const NUIThemeProperties& theme) override {
+        ++changeCount;
+        observedPrimary = theme.primary;
+        NUIComponent::onThemeChanged(theme);
+    }
+
+    int changeCount = 0;
+    NUIColor observedPrimary;
+};
 
 void check(bool condition, const std::string& label) {
     std::cout << "  " << (condition ? "PASS " : "FAIL ") << label << '\n';
@@ -126,6 +141,95 @@ void testThemeChangeResolution() {
     manager.setOnThemeChanged({});
 }
 
+void testIndependentSubscriptionsAndAtomicSwitching() {
+    std::cout << "[Test] independent subscribers and atomic switching\n";
+    auto& manager = NUIThemeManager::getInstance();
+    manager.setActiveTheme("Aestra-dark");
+
+    auto target = NUIThemePresets::createAestraLight();
+    target.primary = NUIColor::fromHex(0x13579b);
+    target.layout.standardControlHeight = 31.0f;
+    manager.setCustomTheme("subscription-test", target);
+
+    int firstCount = 0;
+    int secondCount = 0;
+    bool observedCompleteTheme = false;
+    const auto first = manager.subscribeToThemeChanges([&](const NUIThemeProperties&) { ++firstCount; });
+    const auto second = manager.subscribeToThemeChanges([&](const NUIThemeProperties& theme) {
+        ++secondCount;
+        observedCompleteTheme = colorsEqual(theme.primary, target.primary) &&
+                                nearlyEqual(theme.layout.standardControlHeight, 31.0f);
+    });
+
+    manager.switchTheme("subscription-test", 300.0f);
+    check(manager.getActiveTheme() == "subscription-test", "animated API activates the requested theme atomically");
+    check(firstCount == 1 && secondCount == 1, "independent subscribers each receive one notification");
+    check(observedCompleteTheme, "subscriber receives a complete target theme, not a partial interpolation");
+
+    manager.unsubscribeFromThemeChanges(first);
+    manager.setActiveTheme("Aestra-dark");
+    check(firstCount == 1 && secondCount == 2, "unsubscribing one listener does not disconnect another");
+    manager.unsubscribeFromThemeChanges(second);
+}
+
+void testLiveJSONThemeRegistration() {
+    std::cout << "[Test] JSON overrides register into the live manager\n";
+    const std::string path = "live_theme_registration_test.json";
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out << R"({
+            "colors": { "accent": "#2468ac", "focusRing": "#abcdef" },
+            "dimensions": { "standardControlHeight": 30.0 },
+            "fontSizes": { "normal": 13.0 }
+        })";
+    }
+
+    auto& manager = NUIThemeManager::getInstance();
+    const auto base = NUIThemePresets::createAestraDark();
+    check(manager.loadThemeFromFile("live-json-test", path), "valid JSON theme registers successfully");
+    check(manager.setActiveTheme("live-json-test"), "registered JSON theme can become active");
+    const auto& loaded = manager.getCurrentTheme();
+    check(colorsEqual(loaded.primary, NUIColor::fromHex(0x2468ac)), "legacy accent key maps to live primary role");
+    check(colorsEqual(loaded.focusRing, NUIColor::fromHex(0xabcdef)), "semantic focus ring maps into live state");
+    check(colorsEqual(loaded.backgroundPrimary, base.backgroundPrimary), "missing live token inherits the base preset");
+    check(nearlyEqual(loaded.layout.standardControlHeight, 30.0f), "live control dimension is overridden");
+    check(nearlyEqual(loaded.fontSizeM, 13.0f), "legacy normal font size maps to live body text");
+
+    int reloadCount = 0;
+    const auto reloadSubscription = manager.subscribeToThemeChanges(
+        [&](const NUIThemeProperties&) { ++reloadCount; });
+    check(manager.loadThemeFromFile("live-json-test", path), "active JSON theme can be reloaded");
+    check(reloadCount == 1, "reloading the active theme emits one update");
+    manager.unsubscribeFromThemeChanges(reloadSubscription);
+    std::remove(path.c_str());
+
+    const std::string invalidPath = "invalid_live_theme_registration_test.json";
+    {
+        std::ofstream out(invalidPath, std::ios::binary | std::ios::trunc);
+        out << "{ invalid";
+    }
+    check(!manager.loadThemeFromFile("invalid-live-json-test", invalidPath),
+          "malformed JSON is rejected by live registration");
+    check(!manager.hasTheme("invalid-live-json-test"), "failed registration does not install a misleading fallback");
+    std::remove(invalidPath.c_str());
+    manager.setActiveTheme("Aestra-dark");
+}
+
+void testHierarchyInvalidation() {
+    std::cout << "[Test] component hierarchy theme propagation\n";
+    auto root = std::make_shared<ThemeProbe>();
+    auto child = std::make_shared<ThemeProbe>();
+    root->addChild(child);
+    root->setDirty(false);
+    child->setDirty(false);
+
+    const auto theme = NUIThemePresets::createAestraLight();
+    root->onThemeChanged(theme);
+    check(root->changeCount == 1 && child->changeCount == 1, "theme change reaches each hierarchy node once");
+    check(root->isDirty() && child->isDirty(), "theme change invalidates root and descendants");
+    check(colorsEqual(child->observedPrimary, theme.primary), "descendant observes the complete active theme");
+}
+
 void testCompatibilityAliases() {
     std::cout << "[Test] live component token aliases\n";
     auto& manager = NUIThemeManager::getInstance();
@@ -164,6 +268,23 @@ void testLightPresetCompleteness() {
           "light primary action text remains readable");
 }
 
+void testHighContrastPreset() {
+    std::cout << "[Test] high-contrast preset is distinct and readable\n";
+    const auto ordinary = NUIThemePresets::createAestraDark();
+    const auto highContrast = NUIThemePresets::createHighContrastDark();
+
+    check(!colorsEqual(highContrast.borderStrong, ordinary.borderStrong),
+          "high contrast is not an alias of ordinary dark");
+    check(contrastRatio(highContrast.textPrimary, highContrast.backgroundPrimary) >= 7.0f,
+          "high-contrast primary text exceeds enhanced contrast");
+    check(contrastRatio(highContrast.textSecondary, highContrast.backgroundSecondary) >= 4.5f,
+          "high-contrast secondary text remains readable");
+    check(contrastRatio(highContrast.textOnPrimary, highContrast.primary) >= 4.5f,
+          "high-contrast accent action text remains readable");
+    check(highContrast.gridMajor.a > ordinary.gridMajor.a && highContrast.gridMinor.a > ordinary.gridMinor.a,
+          "high-contrast grid hierarchy is stronger without flattening major/minor distinction");
+}
+
 } // namespace
 
 int main() {
@@ -171,8 +292,12 @@ int main() {
     testStatePriorityAndGeometry();
     testDefaultContrast();
     testThemeChangeResolution();
+    testIndependentSubscriptionsAndAtomicSwitching();
+    testLiveJSONThemeRegistration();
+    testHierarchyInvalidation();
     testCompatibilityAliases();
     testLightPresetCompleteness();
+    testHighContrastPreset();
 
     if (gFailures == 0) {
         std::cout << "All UI theme consistency checks passed\n";

--- a/Tests/AestraUI/NUIThemeJSONTest.cpp
+++ b/Tests/AestraUI/NUIThemeJSONTest.cpp
@@ -65,6 +65,9 @@ void testValidThemeApplies() {
 
     auto theme = NUITheme::loadFromFile(path);
     check(theme != nullptr, "theme is not null");
+    check(theme->loadedSuccessfully(), "valid JSON reports a successful load");
+    check(theme->hasColorOverride("primary") && !theme->hasColorOverride("textMuted"),
+          "explicit color overrides are distinguished from defaults");
     check(colorsEqual(theme->getColor("primary"), NUIColor::fromHex(0xff0000)), "primary = #ff0000");
     check(colorsEqual(theme->getColor("background"), NUIColor::fromHex(0x00ff00)), "background = #00ff00");
     check(colorsEqual(theme->getColor("surface"), NUIColor::fromHex(0x0000ff, 128.0f / 255.0f)),
@@ -108,6 +111,7 @@ void testNonexistentFileReturnsDefault() {
     auto theme = NUITheme::loadFromFile("theme_does_not_exist_test.json");
     auto defaults = NUITheme::createDefault();
     check(theme != nullptr, "theme is not null");
+    check(!theme->loadedSuccessfully(), "missing file reports a failed load");
     check(colorsEqual(theme->getColor("primary"), defaults->getColor("primary")), "matches default theme");
 }
 
@@ -117,6 +121,7 @@ void testMalformedJSONReturnsDefault() {
     auto theme = NUITheme::loadFromFile(path);
     auto defaults = NUITheme::createDefault();
     check(theme != nullptr, "theme is not null");
+    check(!theme->loadedSuccessfully(), "malformed JSON reports a failed load");
     check(colorsEqual(theme->getColor("primary"), defaults->getColor("primary")), "matches default theme");
     std::remove(path.c_str());
 
@@ -138,7 +143,7 @@ void testInvalidEntriesKeepDefaults() {
             "textSecondary": "#abc",
             "error": "#ff00ff"
         },
-        "dimensions": { "borderRadius": "twelve", "compactControlHeight": -1.0 },
+        "dimensions": { "borderRadius": "twelve", "compactControlHeight": -1.0, "spacingM": -8.0 },
         "fontSizes": { "normal": -5, "small": 11.0 }
     })");
 
@@ -155,6 +160,8 @@ void testInvalidEntriesKeepDefaults() {
           "string-as-dimension rejected");
     check(nearlyEqual(theme->getDimension("compactControlHeight"), defaults->getDimension("compactControlHeight")),
           "non-positive semantic dimension rejected");
+    check(nearlyEqual(theme->getDimension("spacingM"), defaults->getDimension("spacingM")),
+          "non-positive spacing token rejected");
     check(nearlyEqual(theme->getFontSize("normal"), defaults->getFontSize("normal")),
           "non-positive font size rejected");
     check(nearlyEqual(theme->getFontSize("small"), 11.0f), "valid sibling font size applied");


### PR DESCRIPTION
## Summary

Makes the theme system real: live theme switching via subscriptions, JSON theme loading, and a complete lights-on (light) / lights-out (dark) switch across the app shell and all 12 plugin editors. Dark mode is preserved bit-for-bit — every polarity mapping returns the original tuned values on dark themes.

## Foundation (`150a3a82`)
- `NUIThemeManager` gains independent change **subscriptions** (`subscribeToThemeChanges`/`unsubscribeFromThemeChanges`; the single `setOnThemeChanged` slot survives as a compatibility shim), fallible `setActiveTheme`, `hasTheme`, and **`loadThemeFromFile`** (JSON theme layered over a base preset)
- Base widgets adopt per-widget `onThemeChanged` refresh with `customColors_` guards → live switches restyle everything without a restart
- New polarity-derived tokens: `timelineBed`/`trackChrome` (pure-black grid + near-black chrome kept exactly on dark; recessed bed + clean chrome on light), `editorCard`/`editorWell`/`editorControl` + `editorNeutral()`/`editorInk()` helpers
- Light preset de-washed: near-white raised surfaces, defined borders, darker secondary-text ramp
- Tests: `NUIThemeConsistencyTest` (subscriptions, atomic switching, live JSON registration, hierarchy invalidation, high-contrast preset) + `NUIThemeJSONTest`
- Design docs: `Theme_System_Contract.md`, `Full_Theme_System_Audit_2026-07.md`

## Text rendering (`b1f6535f`)
Text tuning was calibrated on dark themes (light-on-dark glyphs bloom; dark-on-light doesn't), so light mode read thin. The renderer gains `setTextContrast()`, driven per frame from theme polarity: bitmap-atlas coverage gamma scales down (thicker strokes), the SDF edge center shifts bolder (`uTextBold`), and text alpha passes through an exponent lift (`a^0.72`) so the ubiquitous `withAlpha(0.45–0.85)` label fades keep hierarchy but stay legible. Dark themes run at exactly neutral.

## Shell + editors (`b5a5243f`)
- The white-alpha "ink" language (assumed dark canvas) becomes theme ink: routing map, playlist clips/grid, mixer meters, scrollbar grips, checkbox check, dropdowns, browsers, piano roll
- Shared `TimelineGridRenderer` takes an ink parameter — bar/beat lines and zebra visible on both polarities
- Routing map's categorical insert palette maps to theme accent tokens
- **All 12 plugin editors**: tuned near-black chrome routes through `editorNeutral()` — bit-identical on dark, mirrored onto the light ramp on light (raised/recessed ordering preserved); identity accents (EQ band colors, Verb gold, OTT violet, Filter teal) untouched. Interim behavior until per-surface thematic opt-in ships.

## Known issue (deferred by owner)
Some text still washes in light mode (browser file rows, playlist labels) after fixes at three layers — prime suspect is an FBO-cache composite path that bypasses the per-draw text uniforms. Documented in the text-rendering commit; will be traced in a follow-up.

## Validation
- Full app + `NUIThemeConsistencyTest` + `NUIThemeJSONTest` + `PianoRollInteractionTest` green locally
- Owner exercised light and dark interactively through several iterations (screenshots drove the fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)