### PR TITLE
feat(workspace): dedicated Takes and History panels

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1468,7 +1468,11 @@ bool AestraApp::branchFromTake(const std::string& takeId) {
 
     auto result = switchToTake(dup.take.id);
     if (!result.ok) {
-        Log::error("[Takes] Branch created but could not switch to it: " + result.errorMessage);
+        // Don't leave a half-made branch behind: the duplicate is not active
+        // (the failed switch rolled back), so it can be deleted safely.
+        auto rollback = TakeManager::deleteTake(m_projectPath, dup.take.id);
+        Log::error("[Takes] Branch created but could not switch to it: " + result.errorMessage +
+                   (rollback.ok ? " (branch rolled back)" : " (rollback also failed: " + rollback.errorMessage + ")"));
         return false;
     }
     return true;
@@ -1559,8 +1563,14 @@ void AestraApp::wireTakesPanel() {
         auto result = loadProjectFromPath(path, m_projectPath);
         if (!result.ok) {
             Log::error("Failed to restore snapshot: " + path + " (" + result.errorMessage + ")");
+            return false;
         }
-        return result.ok;
+        // The project file still holds the pre-restore save; the restored
+        // state is unsaved work until the user commits it.
+        if (m_content && m_content->getTrackManager()) {
+            m_content->getTrackManager()->markModified();
+        }
+        return true;
     });
 }
 

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -22,6 +22,7 @@
 #include "PluginManager.h"
 #include "AudioGraphBuilder.h"
 #include "TakeManager.h"
+#include "../Panels/TakesPanel.h"
 #include "../../AestraAudio/include/Core/PlaybackGraphController.h"
 #include "../../AestraAudio/include/IO/AudioExporter.h"
 
@@ -61,10 +62,6 @@ void syncRecordingProjectPath(const std::shared_ptr<AestraContent>& content, con
     }
 }
 
-std::string takeMenuLabel(const TakeManager::TakeEntry& take) {
-    const std::string name = take.name.empty() ? take.id : take.name;
-    return take.active ? ("[current] " + name) : name;
-}
 }
 
 // =============================================================================
@@ -308,6 +305,8 @@ void AestraApp::initializeContent() {
     m_windowManager->setContent(m_content);
     m_audioController->setContent(m_content);
 
+    wireTakesPanel();
+
     // Performance HUD is created eagerly: it must exist independently of the
     // lazily built settings dialogs, or F12 / View → Performance Stats are
     // silent no-ops until the user happens to open Settings or Export first.
@@ -450,77 +449,20 @@ void AestraApp::buildMenuBar() {
             }
         });
 
-        auto takesMenu = std::make_shared<AestraUI::NUIContextMenu>();
-        const bool hasProjectContext = m_content && m_content->getTrackManager() && !m_projectPath.empty();
-        if (!hasProjectContext) {
-            auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Active Project");
-            emptyItem->setEnabled(false);
-            takesMenu->addItem(emptyItem);
-        } else {
-            takesMenu->addItem("Create Take from Current State", [this]() {
-                if (!createTakeFromCurrentProject()) {
-                    Log::error("Failed to create Take");
-                }
-            });
-            takesMenu->addItem("Save Active Take", [this]() {
-                if (!saveProject()) {
-                    Log::error("Failed to save active Take");
-                }
-            });
-            takesMenu->addSeparator();
+        menu->addSeparator();
 
-            const auto manifest = TakeManager::loadManifest(m_projectPath);
-            if (!manifest.ok) {
-                if (manifest.errorMessage == "No Takes manifest") {
-                    auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Takes Yet");
-                    emptyItem->setEnabled(false);
-                    takesMenu->addItem(emptyItem);
-                } else {
-                    Log::warning("[Takes] Could not load manifest: " + manifest.errorMessage);
-                    auto errItem = std::make_shared<AestraUI::NUIContextMenuItem>("Error loading takes");
-                    errItem->setEnabled(false);
-                    takesMenu->addItem(errItem);
-                }
-            } else {
-                size_t count = 0;
-                for (const auto& take : manifest.takes) {
-                    if (count++ >= 20)
-                        break;
-                    auto item = std::make_shared<AestraUI::NUIContextMenuItem>(takeMenuLabel(take));
-                    item->setEnabled(!take.active);
-                    item->setOnClick([this, takeId = take.id]() {
-                        auto result = switchToTake(takeId);
-                        if (!result.ok) {
-                            Log::error("Failed to switch Take: " + takeId + " (" + result.errorMessage + ")");
-                        }
-                    });
-                    takesMenu->addItem(item);
-                }
-            }
-        }
+        // Takes = "which version of the work do I want?" — opens the Takes
+        // workspace panel (create/name/open/duplicate/branch project versions).
+        menu->addItem("Takes", [this]() {
+            if (m_content) m_content->toggleTakesPanel();
+        });
 
-        menu->addSubmenu("Takes", takesMenu);
+        // History = "what actions did I perform?" — opens the command-timeline
+        // panel wired to the undo/redo system.
+        menu->addItem("History  Ctrl+H", [this]() {
+            if (m_content) m_content->toggleHistoryPanel();
+        });
 
-        auto historyMenu = std::make_shared<AestraUI::NUIContextMenu>();
-        const auto historyEntries = ProjectSerializer::listHistory(m_projectPath);
-        if (historyEntries.empty()) {
-            auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Save History");
-            emptyItem->setEnabled(false);
-            historyMenu->addItem(emptyItem);
-        } else {
-            size_t count = 0;
-            for (const auto& entry : historyEntries) {
-                if (count++ >= 10) break;
-                historyMenu->addItem(entry.label, [this, snapshotPath = entry.path]() {
-                    auto result = loadProjectFromPath(snapshotPath, m_projectPath);
-                    if (!result.ok) {
-                        Log::error("Failed to restore snapshot: " + snapshotPath + " (" + result.errorMessage + ")");
-                    }
-                });
-            }
-        }
-
-        menu->addSubmenu("Project History", historyMenu);
         menu->addSeparator();
         menu->addItem("Export Audio...", [this]() { startExport(); });
         menu->addSeparator();
@@ -615,6 +557,9 @@ void AestraApp::buildMenuBar() {
         });
         menu->addItem("Show History  Ctrl+H", [this]() {
             if (m_content) m_content->toggleHistoryPanel();
+        });
+        menu->addItem("Show Takes", [this]() {
+            if (m_content) m_content->toggleTakesPanel();
         });
 
         m_windowManager->showDropdownMenu(menu, 100.0f);
@@ -1290,6 +1235,13 @@ ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& 
     if (result.ui) {
         applyUIState(*result.ui);
     }
+    // Loading may change the project (and its takes manifest) out from under
+    // an open Takes panel — re-pull the providers.
+    if (m_content) {
+        if (auto takesPanel = m_content->getTakesPanel(); takesPanel && takesPanel->isVisible()) {
+            takesPanel->refreshTakes();
+        }
+    }
     updateWindowTitle();
     Log::info("Project loaded into app state from " + path);
     return result;
@@ -1364,6 +1316,12 @@ bool AestraApp::saveProjectToPath(const std::string& path) {
         } else {
             Log::warning("[Takes] Project saved but take snapshot failed, keeping dirty state");
             return false;
+        }
+    }
+    // A save updates the active take's timestamp — keep an open Takes panel honest.
+    if (ok) {
+        if (auto takesPanel = m_content->getTakesPanel(); takesPanel && takesPanel->isVisible()) {
+            takesPanel->refreshTakes();
         }
     }
     return ok;
@@ -1485,6 +1443,114 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
 
     Log::info("[Takes] Switched to Take: " + activeResult.take.name);
     return result;
+}
+
+bool AestraApp::branchFromTake(const std::string& takeId) {
+    if (m_projectPath.empty() || takeId.empty()) {
+        return false;
+    }
+
+    // Preserve the working state before anything else touches the manifest.
+    if (!saveProject()) {
+        Log::warning("[Takes] Could not save the current Take before branching");
+        return false;
+    }
+
+    const auto manifest = TakeManager::loadManifest(m_projectPath);
+    const auto* source = manifest.ok ? manifest.findTake(takeId) : nullptr;
+    const std::string branchName = source ? (source->name + " Branch") : "";
+
+    auto dup = TakeManager::duplicateTake(m_projectPath, takeId, branchName);
+    if (!dup.ok) {
+        Log::warning("[Takes] Could not branch from Take: " + dup.errorMessage);
+        return false;
+    }
+
+    auto result = switchToTake(dup.take.id);
+    if (!result.ok) {
+        Log::error("[Takes] Branch created but could not switch to it: " + result.errorMessage);
+        return false;
+    }
+    return true;
+}
+
+void AestraApp::wireTakesPanel() {
+    if (!m_content) {
+        return;
+    }
+    auto takesPanel = m_content->getTakesPanel();
+    if (!takesPanel) {
+        return;
+    }
+
+    takesPanel->setTakesProvider([this]() -> TakeManager::Manifest {
+        if (m_projectPath.empty()) {
+            TakeManager::Manifest manifest;
+            manifest.errorMessage = "No Takes manifest";
+            return manifest;
+        }
+        return TakeManager::loadManifest(m_projectPath);
+    });
+
+    takesPanel->setSnapshotsProvider([this]() {
+        std::vector<Aestra::Audio::TakesPanel::SnapshotEntry> entries;
+        if (m_projectPath.empty()) {
+            return entries;
+        }
+        for (const auto& entry : ProjectSerializer::listHistory(m_projectPath)) {
+            entries.push_back({entry.path, entry.label});
+        }
+        return entries;
+    });
+
+    takesPanel->setOnCreateTake([this]() { return createTakeFromCurrentProject(); });
+    takesPanel->setOnSaveActiveTake([this]() { return saveProject(); });
+
+    takesPanel->setOnOpenTake([this](const std::string& takeId) {
+        auto result = switchToTake(takeId);
+        if (!result.ok) {
+            Log::error("[Takes] Failed to open Take: " + takeId + " (" + result.errorMessage + ")");
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnRenameTake([this](const std::string& takeId, const std::string& name) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::renameTake(m_projectPath, takeId, name);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not rename Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnDuplicateTake([this](const std::string& takeId) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::duplicateTake(m_projectPath, takeId);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not duplicate Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnBranchTake([this](const std::string& takeId) { return branchFromTake(takeId); });
+
+    takesPanel->setOnRestoreSnapshot([this](const std::string& path) {
+        // Save the current take first so a snapshot restore never silently
+        // destroys the working state.
+        if (!saveProject()) {
+            Log::warning("[Takes] Could not save the current Take before restoring a snapshot");
+            return false;
+        }
+        auto result = loadProjectFromPath(path, m_projectPath);
+        if (!result.ok) {
+            Log::error("Failed to restore snapshot: " + path + " (" + result.errorMessage + ")");
+        }
+        return result.ok;
+    });
 }
 
 void AestraApp::reinitAutosaveManager() {

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1536,6 +1536,17 @@ void AestraApp::wireTakesPanel() {
         return result.ok;
     });
 
+    takesPanel->setOnDeleteTake([this](const std::string& takeId) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::deleteTake(m_projectPath, takeId);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not delete Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
     takesPanel->setOnBranchTake([this](const std::string& takeId) { return branchFromTake(takeId); });
 
     takesPanel->setOnRestoreSnapshot([this](const std::string& path) {

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -93,6 +93,8 @@ private:
     bool saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState = nullptr);
     bool createTakeFromCurrentProject();
     ProjectSerializer::LoadResult switchToTake(const std::string& takeId);
+    bool branchFromTake(const std::string& takeId);
+    void wireTakesPanel();
     void reinitAutosaveManager();
     ProjectSerializer::UIState captureUIState() const;
     void applyUIState(const ProjectSerializer::UIState& state);

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -50,6 +50,8 @@ set(Aestra_SOURCES
 	Panels/AuditionPanel.cpp
 	Panels/AestraHistoryPanel.h
 	Panels/AestraHistoryPanel.cpp
+	Panels/TakesPanel.h
+	Panels/TakesPanel.cpp
 	Panels/SampleEditorPanel.h
 	Panels/SampleEditorPanel.cpp
 	

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3852,6 +3852,7 @@ void AestraContent::toggleHistoryPanel() {
         float y = 80.0f;
         m_viewState.historyRect = AestraUI::NUIRect(x, y, w, h);
         m_historyPanel->setBounds(m_viewState.historyRect);
+        m_historyPanel->bringToFront();
         m_historyPanel->refreshHistory();
     }
     onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
@@ -3863,14 +3864,20 @@ void AestraContent::toggleTakesPanel() {
     bool show = !m_takesPanel->isVisible();
     m_takesPanel->setVisible(show);
     if (show) {
-        // Position below transport bar, offset from the History panel spot
-        auto root = getBounds();
-        float w = 320.0f;
-        float h = std::min(520.0f, root.height * 0.7f);
-        float x = std::max(0.0f, root.width * 0.5f - w - 12.0f);
-        float y = 80.0f;
-        m_viewState.takesRect = AestraUI::NUIRect(x, y, w, h);
+        // Default position below the transport bar on first open only —
+        // later opens keep the user's dragged/resized bounds (clamped by
+        // the onResize below).
+        if (!m_takesRectInitialized) {
+            auto root = getBounds();
+            float w = 320.0f;
+            float h = std::min(520.0f, root.height * 0.7f);
+            float x = std::max(0.0f, root.width * 0.5f - w - 12.0f);
+            float y = 80.0f;
+            m_viewState.takesRect = AestraUI::NUIRect(x, y, w, h);
+            m_takesRectInitialized = true;
+        }
         m_takesPanel->setBounds(m_viewState.takesRect);
+        m_takesPanel->bringToFront();
         m_takesPanel->refreshTakes();
     }
     onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -12,6 +12,7 @@
 #include "../AestraUI/Widgets/UIMixerInspector.h"
 #include "../AestraUI/Widgets/UIMixerPanel.h"
 #include "AestraHistoryPanel.h"
+#include "TakesPanel.h"
 #include "ArsenalPanel.h"
 #include "AudioGraphBuilder.h"
 #include "AuditionEngine.h" // Audition Mode backend
@@ -1088,6 +1089,26 @@ AestraContent::AestraContent()
             m_sequencerPanel->refreshUnits();
         m_trackManager->markModified();
     });
+    // Create Takes panel — data providers and action callbacks are wired by the
+    // app layer (AestraApp) because take operations need the project path and
+    // the save/load safety rules that live there.
+    m_takesPanel = std::make_shared<Aestra::Audio::TakesPanel>();
+    m_takesPanel->setVisible(false);
+    m_takesPanel->setOnClose([this]() { toggleTakesPanel(); });
+    m_takesPanel->setOnDragStart([this](const AestraUI::NUIPoint& pos) { beginPanelDrag(ViewType::Takes, pos); });
+    m_takesPanel->setOnDragMove([this](const AestraUI::NUIPoint& pos) { updatePanelDrag(ViewType::Takes, pos); });
+    m_takesPanel->setOnDragEnd([this]() { endPanelDrag(ViewType::Takes); });
+    m_takesPanel->setOnResizeMove([this](const AestraUI::NUIRect& proposed) {
+        const auto allowed = computeAllowedRectForPanels();
+        m_viewState.takesRect = clampRectToAllowed(proposed, allowed);
+        if (m_takesPanel)
+            m_takesPanel->setBounds(m_viewState.takesRect);
+        setDirty(true);
+    });
+    m_takesPanel->setMaximized(false);
+    m_takesPanel->setOnMaximizeToggle(
+        [this](bool) { onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height)); });
+
     // NOTE: History panel is added LAST so it's on top and receives mouse events first.
 
     // Wire CommandHistory state-changed callback to refresh the history panel
@@ -1154,7 +1175,8 @@ AestraContent::AestraContent()
     m_audioVisualizer->setShowStereo(true);
     m_overlayLayer->addChild(m_audioVisualizer);
 
-    // Add History panel LAST to overlay so it's on top and receives mouse events first
+    // Add Takes + History panels LAST to overlay so they're on top and receive mouse events first
+    m_overlayLayer->addChild(m_takesPanel);
     m_overlayLayer->addChild(m_historyPanel);
 
     // Initialize preview engine
@@ -1658,6 +1680,15 @@ void AestraContent::onResize(int width, int height) {
         } else {
             m_viewState.historyRect = clampRectToAllowed(m_viewState.historyRect, allowed);
             m_historyPanel->setBounds(m_viewState.historyRect);
+        }
+    }
+
+    if (m_takesPanel && m_takesPanel->isVisible()) {
+        if (m_takesPanel->isMaximized()) {
+            m_takesPanel->setBounds(maxRect);
+        } else {
+            m_viewState.takesRect = clampRectToAllowed(m_viewState.takesRect, allowed);
+            m_takesPanel->setBounds(m_viewState.takesRect);
         }
     }
 
@@ -2488,6 +2519,9 @@ void AestraContent::beginPanelDrag(Audio::ViewType view, const AestraUI::NUIPoin
     case Audio::ViewType::History:
         m_viewState.dragStartRect = m_viewState.historyRect;
         break;
+    case Audio::ViewType::Takes:
+        m_viewState.dragStartRect = m_viewState.takesRect;
+        break;
     default:
         break;
     }
@@ -2529,6 +2563,11 @@ void AestraContent::updatePanelDrag(Audio::ViewType view, const AestraUI::NUIPoi
         m_viewState.historyRect = finalRect;
         if (m_historyPanel)
             m_historyPanel->setBounds(finalRect);
+        break;
+    case Audio::ViewType::Takes:
+        m_viewState.takesRect = finalRect;
+        if (m_takesPanel)
+            m_takesPanel->setBounds(finalRect);
         break;
     default:
         break;
@@ -3818,6 +3857,25 @@ void AestraContent::toggleHistoryPanel() {
     onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
 }
 
+void AestraContent::toggleTakesPanel() {
+    if (!m_takesPanel)
+        return;
+    bool show = !m_takesPanel->isVisible();
+    m_takesPanel->setVisible(show);
+    if (show) {
+        // Position below transport bar, offset from the History panel spot
+        auto root = getBounds();
+        float w = 320.0f;
+        float h = std::min(520.0f, root.height * 0.7f);
+        float x = std::max(0.0f, root.width * 0.5f - w - 12.0f);
+        float y = 80.0f;
+        m_viewState.takesRect = AestraUI::NUIRect(x, y, w, h);
+        m_takesPanel->setBounds(m_viewState.takesRect);
+        m_takesPanel->refreshTakes();
+    }
+    onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
+}
+
 // Global Shortcuts
 bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
     // A note release must win even if focus moved after its note-on; otherwise
@@ -3841,6 +3899,11 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
 
     if (!event.pressed)
         return false;
+
+    // Takes panel inline rename captures typing while active — it must win
+    // over global shortcuts so Ctrl+Z etc. don't fire mid-edit.
+    if (m_takesPanel && m_takesPanel->isVisible() && m_takesPanel->handleKeyEvent(event))
+        return true;
 
     // Forward to piano roll when visible — its local undo/redo
     // and note shortcuts must take priority over global handlers

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -362,6 +362,9 @@ private:
     std::shared_ptr<Aestra::Audio::ArsenalPanel> m_sequencerPanel;
     std::shared_ptr<Aestra::Audio::AestraHistoryPanel> m_historyPanel;
     std::shared_ptr<Aestra::Audio::TakesPanel> m_takesPanel;
+    // First-open flag: the Takes panel gets a default rect once, then keeps
+    // whatever bounds the user dragged/resized across close/reopen.
+    bool m_takesRectInitialized{false};
     std::shared_ptr<AestraUI::PluginUIController> m_pluginController;
     std::shared_ptr<AestraUI::UIRoutingMap> m_routingMapPanel;
 

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -64,6 +64,7 @@ namespace Aestra::Audio {
     class PatternBrowserPanel;
     class WindowPanel;
     class AestraHistoryPanel;
+    class TakesPanel;
     class AuditionEngine;  // For Audition Mode
     class PlaybackGraphController;
 }
@@ -128,6 +129,7 @@ public:
         /** @brief Arsenal overlay bounds in overlay-local coordinates. */
         AestraUI::NUIRect sequencerRect = {0, 0, 600, 300};
         AestraUI::NUIRect historyRect = {0, 80, 280, 460};
+        AestraUI::NUIRect takesRect = {0, 80, 320, 480};
 
         /** @brief True while an overlay panel is being dragged. */
         bool isDragging = false;
@@ -184,6 +186,10 @@ public:
     void toggleArsenalPanel();
     /** @brief Toggle the History panel visibility. */
     void toggleHistoryPanel();
+    /** @brief Toggle the Takes panel visibility. */
+    void toggleTakesPanel();
+    /** @brief Get the Takes panel (for app-level action wiring). */
+    std::shared_ptr<Aestra::Audio::TakesPanel> getTakesPanel() const { return m_takesPanel; }
 
     /** @brief Compute the safe workspace rectangle after chrome and sidebars. */
     AestraUI::NUIRect computeSafeRect() const;
@@ -355,6 +361,7 @@ private:
     Aestra::KeyboardNoteInput m_keyboardNoteInput;
     std::shared_ptr<Aestra::Audio::ArsenalPanel> m_sequencerPanel;
     std::shared_ptr<Aestra::Audio::AestraHistoryPanel> m_historyPanel;
+    std::shared_ptr<Aestra::Audio::TakesPanel> m_takesPanel;
     std::shared_ptr<AestraUI::PluginUIController> m_pluginController;
     std::shared_ptr<AestraUI::UIRoutingMap> m_routingMapPanel;
 

--- a/Source/Core/TakeManager.cpp
+++ b/Source/Core/TakeManager.cpp
@@ -500,3 +500,95 @@ TakeManager::Result TakeManager::setActiveTake(const std::string& projectPath, c
 
     return makeResult(true, "", manifest, selectedCopy);
 }
+
+TakeManager::Result TakeManager::renameTake(const std::string& projectPath, const std::string& takeId,
+                                            const std::string& newName) {
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+
+    std::string trimmedName = newName;
+    trimmedName.erase(0, trimmedName.find_first_not_of(" \t\r\n"));
+    trimmedName.erase(trimmedName.find_last_not_of(" \t\r\n") + 1);
+    if (trimmedName.empty()) {
+        return makeResult(false, "Take name cannot be empty", manifest);
+    }
+    if (trimmedName.size() > TAKE_MAX_STRING_BYTES) {
+        trimmedName.resize(TAKE_MAX_STRING_BYTES);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    TakeEntry* target = nullptr;
+    for (auto& take : manifest.takes) {
+        if (take.id == sanitizedId) {
+            target = &take;
+            break;
+        }
+    }
+    if (!target) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+
+    target->name = trimmedName;
+    target->updatedAtMs = nowMs();
+
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        return makeResult(false, error, manifest, *target);
+    }
+    return makeResult(true, "", manifest, *target);
+}
+
+TakeManager::Result TakeManager::duplicateTake(const std::string& projectPath, const std::string& takeId,
+                                               const std::string& newName) {
+    namespace fs = std::filesystem;
+
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+    if (manifest.takes.size() >= TAKE_MAX_ENTRIES) {
+        return makeResult(false, "Maximum number of takes reached (" + std::to_string(TAKE_MAX_ENTRIES) + ")", manifest);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    const TakeEntry* source = manifest.findTake(sanitizedId);
+    if (!source) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+
+    const std::string sourceSnapshot = resolveSnapshotPath(projectPath, *source);
+    std::error_code ec;
+    if (sourceSnapshot.empty() || !fs::exists(sourceSnapshot, ec) || ec) {
+        return makeResult(false, "Source take snapshot is missing: " + source->id, manifest);
+    }
+
+    TakeEntry copy;
+    copy.id = makeTakeId();
+    copy.name = newName.empty() ? (source->name + " Copy") : newName;
+    copy.parentId = source->id;
+    copy.snapshotPath = makeSnapshotFilename(copy.id);
+    copy.createdAtMs = nowMs();
+    copy.updatedAtMs = copy.createdAtMs;
+    copy.active = false;
+
+    const std::string copySnapshot = resolveSnapshotPath(projectPath, copy);
+    if (copySnapshot.empty()) {
+        return makeResult(false, "Could not resolve duplicate snapshot path", manifest);
+    }
+    fs::copy_file(sourceSnapshot, copySnapshot, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        return makeResult(false, "Could not copy take snapshot: " + ec.message(), manifest);
+    }
+
+    manifest.takes.push_back(copy);
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        fs::remove(copySnapshot, ec); // best effort: don't leave an orphan snapshot
+        return makeResult(false, error, manifest, copy);
+    }
+
+    Aestra::Log::info("[Takes] Duplicated take '" + source->name + "' as '" + copy.name + "'");
+    return makeResult(true, "", manifest, copy);
+}

--- a/Source/Core/TakeManager.cpp
+++ b/Source/Core/TakeManager.cpp
@@ -582,6 +582,7 @@ TakeManager::Result TakeManager::duplicateTake(const std::string& projectPath, c
         return makeResult(false, "Could not copy take snapshot: " + ec.message(), manifest);
     }
 
+    const std::string sourceName = source->name; // push_back below may reallocate and dangle `source`
     manifest.takes.push_back(copy);
     std::string error;
     if (!saveManifest(manifest, error)) {
@@ -589,7 +590,7 @@ TakeManager::Result TakeManager::duplicateTake(const std::string& projectPath, c
         return makeResult(false, error, manifest, copy);
     }
 
-    Aestra::Log::info("[Takes] Duplicated take '" + source->name + "' as '" + copy.name + "'");
+    Aestra::Log::info("[Takes] Duplicated take '" + sourceName + "' as '" + copy.name + "'");
     return makeResult(true, "", manifest, copy);
 }
 

--- a/Source/Core/TakeManager.cpp
+++ b/Source/Core/TakeManager.cpp
@@ -592,3 +592,49 @@ TakeManager::Result TakeManager::duplicateTake(const std::string& projectPath, c
     Aestra::Log::info("[Takes] Duplicated take '" + source->name + "' as '" + copy.name + "'");
     return makeResult(true, "", manifest, copy);
 }
+
+TakeManager::Result TakeManager::deleteTake(const std::string& projectPath, const std::string& takeId) {
+    namespace fs = std::filesystem;
+
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    const TakeEntry* target = manifest.findTake(sanitizedId);
+    if (!target) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+    if (sanitizedId == manifest.activeTakeId) {
+        return makeResult(false, "Cannot delete the active take — switch to another take first", manifest, *target);
+    }
+
+    TakeEntry deleted = *target;
+    const std::string snapshotPath = resolveSnapshotPath(projectPath, deleted);
+
+    // Children keep their history by moving up to the deleted take's parent.
+    for (auto& take : manifest.takes) {
+        if (take.parentId == deleted.id) {
+            take.parentId = deleted.parentId;
+        }
+    }
+    manifest.takes.erase(std::remove_if(manifest.takes.begin(), manifest.takes.end(),
+                                        [&deleted](const TakeEntry& take) { return take.id == deleted.id; }),
+                         manifest.takes.end());
+
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        return makeResult(false, error, manifest, deleted);
+    }
+
+    // Snapshot removal is best-effort: an orphan file is harmless, a manifest
+    // pointing at a deleted file is not — so the manifest write comes first.
+    if (!snapshotPath.empty()) {
+        std::error_code ec;
+        fs::remove(snapshotPath, ec);
+    }
+
+    Aestra::Log::info("[Takes] Deleted take '" + deleted.name + "'");
+    return makeResult(true, "", manifest, deleted);
+}

--- a/Source/Core/TakeManager.h
+++ b/Source/Core/TakeManager.h
@@ -89,4 +89,24 @@ public:
      * @param takeId       ID of the take to activate.
      */
     static Result setActiveTake(const std::string& projectPath, const std::string& takeId);
+
+    /**
+     * @brief Renames an existing take. Snapshot contents are untouched.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to rename.
+     * @param newName      New human-readable name (must be non-empty).
+     */
+    static Result renameTake(const std::string& projectPath, const std::string& takeId, const std::string& newName);
+
+    /**
+     * @brief Duplicates a take by copying its snapshot into a new take entry.
+     *
+     * The duplicate records the source take as its parent and does NOT become
+     * active — the caller's working state is never touched.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to duplicate.
+     * @param newName      Name for the duplicate (empty derives "<source> Copy").
+     */
+    static Result duplicateTake(const std::string& projectPath, const std::string& takeId,
+                                const std::string& newName = "");
 };

--- a/Source/Core/TakeManager.h
+++ b/Source/Core/TakeManager.h
@@ -111,11 +111,13 @@ public:
                                 const std::string& newName = "");
 
     /**
-     * @brief Deletes a take and its snapshot.
+     * @brief Deletes a take from the manifest and removes its snapshot.
      *
      * The active take can never be deleted (switch away first), so the working
      * state is always safe. Children of the deleted take are re-parented to
-     * its parent to keep lineage intact.
+     * its parent to keep lineage intact. Success means the manifest was
+     * updated; snapshot-file removal is best-effort and may leave an orphaned
+     * (harmless, unreferenced) file behind.
      * @param projectPath  Path to the project directory.
      * @param takeId       ID of the take to delete.
      */

--- a/Source/Core/TakeManager.h
+++ b/Source/Core/TakeManager.h
@@ -109,4 +109,15 @@ public:
      */
     static Result duplicateTake(const std::string& projectPath, const std::string& takeId,
                                 const std::string& newName = "");
+
+    /**
+     * @brief Deletes a take and its snapshot.
+     *
+     * The active take can never be deleted (switch away first), so the working
+     * state is always safe. Children of the deleted take are re-parented to
+     * its parent to keep lineage intact.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to delete.
+     */
+    static Result deleteTake(const std::string& projectPath, const std::string& takeId);
 };

--- a/Source/Panels/AestraHistoryPanel.cpp
+++ b/Source/Panels/AestraHistoryPanel.cpp
@@ -103,8 +103,10 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
 
         bool hovered = (i == m_hoveredEntry);
         if (hovered) {
+            // Keep the lift subtle — the hover token is light, and a strong
+            // fill washes out light row text.
             renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
-                theme.getColor("hover").withAlpha(entry.isRedo ? 0.42f : 0.92f));
+                theme.getColor("hover").withAlpha(entry.isRedo ? 0.08f : 0.14f));
         }
 
         // Category dot

--- a/Source/Panels/AestraHistoryPanel.cpp
+++ b/Source/Panels/AestraHistoryPanel.cpp
@@ -60,7 +60,9 @@ void AestraHistoryPanel::rebuildEntries()
         m_entries.push_back({name.empty() ? "(unnamed)" : name, false, i});
     }
     m_contentHeight = m_entries.size() * ROW_HEIGHT + ROW_HEIGHT;
-    m_scrollY = std::min(m_scrollY, std::max(0.0f, m_contentHeight - ROW_HEIGHT));
+    // Clamp against the visible height so a shrunken list snaps back fully.
+    const float visibleH = std::max(0.0f, getBounds().height - HEADER_HEIGHT);
+    m_scrollY = std::min(m_scrollY, std::max(0.0f, m_contentHeight - visibleH));
 }
 
 void AestraHistoryPanel::onResize(int width, int height) {
@@ -77,9 +79,8 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     if (bounds.width <= 0 || bounds.height <= 0) return;
 
     // Content area starts below WindowPanel's title bar + padding
-    float headerH = 36.0f; // WindowPanel title bar height
-    float contentY = bounds.y + headerH;
-    float contentH = bounds.height - headerH;
+    float contentY = bounds.y + HEADER_HEIGHT;
+    float contentH = bounds.height - HEADER_HEIGHT;
 
     // Empty state
     if (m_entries.empty()) {
@@ -140,9 +141,8 @@ bool AestraHistoryPanel::onMouseEvent(const NUIMouseEvent& event)
     if (!isVisible()) return false;
 
     auto bounds = getBounds();
-    float headerH = 32.0f;
-    float contentY = bounds.y + headerH;
-    float contentH = bounds.height - headerH;
+    float contentY = bounds.y + HEADER_HEIGHT;
+    float contentH = bounds.height - HEADER_HEIGHT;
     const bool inContent = bounds.contains(event.position) && event.position.y >= contentY;
 
     // Handle click on entries (scroll-aware)

--- a/Source/Panels/AestraHistoryPanel.cpp
+++ b/Source/Panels/AestraHistoryPanel.cpp
@@ -35,6 +35,16 @@ AestraHistoryPanel::AestraHistoryPanel(std::shared_ptr<TrackManager> trackManage
 
 void AestraHistoryPanel::refreshHistory() { rebuildEntries(); }
 
+void AestraHistoryPanel::activateEntry(int index)
+{
+    if (!m_trackManager || index < 0 || index >= static_cast<int>(m_entries.size())) return;
+    auto& history = m_trackManager->getCommandHistory();
+    if (m_entries[index].isRedo) history.redoTo(m_entries[index].stackIndex);
+    else history.undoTo(m_entries[index].stackIndex);
+    refreshHistory();
+    if (m_onHistoryChanged) m_onHistoryChanged();
+}
+
 void AestraHistoryPanel::rebuildEntries()
 {
     m_entries.clear();
@@ -50,6 +60,7 @@ void AestraHistoryPanel::rebuildEntries()
         m_entries.push_back({name.empty() ? "(unnamed)" : name, false, i});
     }
     m_contentHeight = m_entries.size() * ROW_HEIGHT + ROW_HEIGHT;
+    m_scrollY = std::min(m_scrollY, std::max(0.0f, m_contentHeight - ROW_HEIGHT));
 }
 
 void AestraHistoryPanel::onResize(int width, int height) {
@@ -82,12 +93,12 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     int headRedo = 0;
     for (const auto& e : m_entries) { if (e.isRedo) ++headRedo; else break; }
 
-    // Draw entries top-down from header
+    // Draw entries top-down from header, offset by the scroll position
     for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
         const auto& entry = m_entries[i];
-        float rowY = contentY + i * ROW_HEIGHT;
+        float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
 
-                // Skip entries outside visible area
+        // Skip entries outside visible area
         if (rowY + ROW_HEIGHT < contentY || rowY > contentY + contentH) continue;
 
         bool hovered = (i == m_hoveredEntry);
@@ -111,7 +122,7 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     }
 
     // HEAD marker
-    float headY = contentY + headRedo * ROW_HEIGHT;
+    float headY = contentY + headRedo * ROW_HEIGHT - m_scrollY;
     if (headY >= contentY && headY < contentY + contentH) {
         renderer.fillRect(NUIRect(bounds.x, headY, 3.0f, ROW_HEIGHT), theme.getColor("secondary").withAlpha(0.92f));
         renderer.drawText("HEAD", NUIPoint(bounds.x + 6.0f, headY + 7.0f), 9.0f,
@@ -124,24 +135,21 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
 
 bool AestraHistoryPanel::onMouseEvent(const NUIMouseEvent& event)
 {
-    if (event.pressed && isVisible()) {    }
-
     if (!isVisible()) return false;
 
     auto bounds = getBounds();
     float headerH = 32.0f;
     float contentY = bounds.y + headerH;
     float contentH = bounds.height - headerH;
+    const bool inContent = bounds.contains(event.position) && event.position.y >= contentY;
 
-    // Handle click on entries
-    if (event.pressed && event.button == NUIMouseButton::Left && m_trackManager) {        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
-            float rowY = contentY + i * ROW_HEIGHT;
-            bool match = (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT);            if (match) {
-                auto& history = m_trackManager->getCommandHistory();
-                if (m_entries[i].isRedo) history.redoTo(m_entries[i].stackIndex);
-                else history.undoTo(m_entries[i].stackIndex);
-                refreshHistory();
-                if (m_onHistoryChanged) m_onHistoryChanged();
+    // Handle click on entries (scroll-aware)
+    if (event.pressed && event.button == NUIMouseButton::Left && m_trackManager && inContent) {
+        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
+            float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
+            if (rowY + ROW_HEIGHT < contentY) continue;
+            if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) {
+                activateEntry(i);
                 return true;
             }
         }
@@ -150,9 +158,12 @@ bool AestraHistoryPanel::onMouseEvent(const NUIMouseEvent& event)
     // Handle hover
     if (event.type == NUIMouseEventType::Move) {
         m_hoveredEntry = -1;
-        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
-            float rowY = contentY + i * ROW_HEIGHT;
-            if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) { m_hoveredEntry = i; break; }
+        if (inContent) {
+            for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
+                float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
+                if (rowY + ROW_HEIGHT < contentY) continue;
+                if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) { m_hoveredEntry = i; break; }
+            }
         }
     }
 

--- a/Source/Panels/AestraHistoryPanel.h
+++ b/Source/Panels/AestraHistoryPanel.h
@@ -43,6 +43,7 @@ public:
 
 private:
     static constexpr float ROW_HEIGHT = 26.0f;
+    static constexpr float HEADER_HEIGHT = 36.0f; // content offset below the WindowPanel title bar
     static constexpr float INDICATOR_SIZE = 6.0f;
     static constexpr float LEFT_PAD = 12.0f;
     static constexpr float TEXT_LEFT_PAD = 28.0f;

--- a/Source/Panels/AestraHistoryPanel.h
+++ b/Source/Panels/AestraHistoryPanel.h
@@ -31,6 +31,16 @@ public:
     /** @brief Set callback for when user clicks to undo/redo (so UI panels refresh). */
     void setOnHistoryChanged(std::function<void()> cb) { m_onHistoryChanged = std::move(cb); }
 
+    // --- Introspection (used by tests and tooling) ---------------------------
+    /** @brief Number of displayed history entries (redo + undo). */
+    int getEntryCount() const { return static_cast<int>(m_entries.size()); }
+    /** @brief Display name of an entry (top row first). */
+    const std::string& getEntryName(int index) const { return m_entries[static_cast<size_t>(index)].name; }
+    /** @brief True if the entry sits on the redo stack (above HEAD). */
+    bool isEntryRedo(int index) const { return m_entries[static_cast<size_t>(index)].isRedo; }
+    /** @brief Navigate to an entry exactly like a mouse click on its row. */
+    void activateEntry(int index);
+
 private:
     static constexpr float ROW_HEIGHT = 26.0f;
     static constexpr float INDICATOR_SIZE = 6.0f;

--- a/Source/Panels/TakesPanel.cpp
+++ b/Source/Panels/TakesPanel.cpp
@@ -1,0 +1,601 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "TakesPanel.h"
+
+#include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../AestraUI/Graphics/NUIRenderer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <unordered_map>
+
+using namespace AestraUI;
+
+namespace Aestra {
+namespace Audio {
+
+namespace {
+constexpr float ACTION_BUTTON_PAD = 8.0f;
+constexpr float TOOLBAR_BUTTON_HEIGHT = 22.0f;
+} // namespace
+
+TakesPanel::TakesPanel() : WindowPanel("TAKES") {
+    setMinimumPanelSize(280.0f, 260.0f);
+}
+
+void TakesPanel::refreshTakes() {
+    rebuildRows();
+    setDirty(true);
+}
+
+void TakesPanel::rebuildRows() {
+    std::string previousSelectedId;
+    if (m_selectedTake >= 0 && m_selectedTake < static_cast<int>(m_takeRows.size())) {
+        previousSelectedId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    }
+
+    m_takeRows.clear();
+    m_snapshotRows.clear();
+    m_manifestError.clear();
+
+    if (m_takesProvider) {
+        TakeManager::Manifest manifest = m_takesProvider();
+        if (manifest.ok) {
+            // Depth = length of the parent chain; guards against cycles/orphans.
+            std::unordered_map<std::string, std::string> parentOf;
+            for (const auto& take : manifest.takes) {
+                parentOf[take.id] = take.parentId;
+            }
+            for (const auto& take : manifest.takes) {
+                int depth = 0;
+                std::string cursor = take.parentId;
+                while (!cursor.empty() && depth < 8) {
+                    auto it = parentOf.find(cursor);
+                    if (it == parentOf.end()) {
+                        break;
+                    }
+                    ++depth;
+                    cursor = it->second;
+                }
+                m_takeRows.push_back({take, depth});
+            }
+        } else if (manifest.errorMessage != "No Takes manifest") {
+            m_manifestError = manifest.errorMessage;
+        }
+    }
+
+    if (m_snapshotsProvider) {
+        auto snapshots = m_snapshotsProvider();
+        if (snapshots.size() > MAX_SNAPSHOT_ROWS) {
+            snapshots.resize(MAX_SNAPSHOT_ROWS);
+        }
+        m_snapshotRows = std::move(snapshots);
+    }
+
+    // Selection follows the take's identity, not its row index.
+    m_selectedTake = -1;
+    if (!previousSelectedId.empty()) {
+        for (int i = 0; i < static_cast<int>(m_takeRows.size()); ++i) {
+            if (m_takeRows[static_cast<size_t>(i)].take.id == previousSelectedId) {
+                m_selectedTake = i;
+                break;
+            }
+        }
+    }
+    if (m_selectedSnapshot >= static_cast<int>(m_snapshotRows.size())) {
+        m_selectedSnapshot = -1;
+    }
+    if (m_renameActive) {
+        // The renamed take may have vanished (external change) — drop the edit.
+        bool stillPresent = false;
+        for (const auto& row : m_takeRows) {
+            if (row.take.id == m_renameTakeId) {
+                stillPresent = true;
+                break;
+            }
+        }
+        if (!stillPresent) {
+            cancelRename();
+        }
+    }
+}
+
+TakesPanel::Layout TakesPanel::computeLayout() const {
+    Layout layout;
+    const auto bounds = getBounds();
+    const float x = bounds.x;
+    const float w = bounds.width;
+    float top = bounds.y + HEADER_HEIGHT;
+    float bottom = bounds.y + bounds.height;
+
+    if (!m_statusText.empty()) {
+        bottom -= STATUS_HEIGHT;
+        layout.statusLine = NUIRect(x, bottom, w, STATUS_HEIGHT);
+    }
+
+    if (!m_snapshotRows.empty()) {
+        const float snapshotListH = static_cast<float>(m_snapshotRows.size()) * ROW_HEIGHT;
+        bottom -= snapshotListH;
+        layout.snapshotList = NUIRect(x, bottom, w, snapshotListH);
+        bottom -= SECTION_HEADER_HEIGHT;
+        layout.snapshotHeader = NUIRect(x, bottom, w, SECTION_HEADER_HEIGHT);
+    }
+
+    layout.actionBarVisible = (m_selectedTake >= 0 || m_selectedSnapshot >= 0);
+    if (layout.actionBarVisible) {
+        bottom -= ACTION_BAR_HEIGHT;
+        layout.actionBar = NUIRect(x, bottom, w, ACTION_BAR_HEIGHT);
+    }
+
+    layout.toolbar = NUIRect(x, top, w, TOOLBAR_HEIGHT);
+    const float buttonY = top + (TOOLBAR_HEIGHT - TOOLBAR_BUTTON_HEIGHT) * 0.5f;
+    const float buttonW = (w - LEFT_PAD * 3.0f) * 0.5f;
+    layout.newTakeButton = NUIRect(x + LEFT_PAD, buttonY, buttonW, TOOLBAR_BUTTON_HEIGHT);
+    layout.saveActiveButton = NUIRect(x + LEFT_PAD * 2.0f + buttonW, buttonY, buttonW, TOOLBAR_BUTTON_HEIGHT);
+
+    top += TOOLBAR_HEIGHT;
+    layout.takesList = NUIRect(x, top, w, std::max(0.0f, bottom - top));
+    return layout;
+}
+
+int TakesPanel::takeRowAt(const NUIPoint& point, const Layout& layout) const {
+    if (!layout.takesList.contains(point)) {
+        return -1;
+    }
+    const int index = static_cast<int>((point.y - layout.takesList.y + m_scrollY) / ROW_HEIGHT);
+    if (index < 0 || index >= static_cast<int>(m_takeRows.size())) {
+        return -1;
+    }
+    return index;
+}
+
+int TakesPanel::snapshotRowAt(const NUIPoint& point, const Layout& layout) const {
+    if (m_snapshotRows.empty() || !layout.snapshotList.contains(point)) {
+        return -1;
+    }
+    const int index = static_cast<int>((point.y - layout.snapshotList.y) / ROW_HEIGHT);
+    if (index < 0 || index >= static_cast<int>(m_snapshotRows.size())) {
+        return -1;
+    }
+    return index;
+}
+
+std::vector<std::string> TakesPanel::actionButtonLabels() const {
+    if (m_selectedSnapshot >= 0) {
+        return {"RESTORE"};
+    }
+    if (m_selectedTake >= 0) {
+        const bool active = m_takeRows[static_cast<size_t>(m_selectedTake)].take.active;
+        if (active) {
+            return {"RENAME", "DUPLICATE", "BRANCH"};
+        }
+        return {"OPEN", "RENAME", "DUPLICATE", "BRANCH"};
+    }
+    return {};
+}
+
+std::vector<NUIRect> TakesPanel::actionButtonRects(const Layout& layout) const {
+    std::vector<NUIRect> rects;
+    if (!layout.actionBarVisible) {
+        return rects;
+    }
+    const auto labels = actionButtonLabels();
+    if (labels.empty()) {
+        return rects;
+    }
+    const float buttonH = ACTION_BAR_HEIGHT - 8.0f;
+    const float totalPad = LEFT_PAD * 2.0f + ACTION_BUTTON_PAD * static_cast<float>(labels.size() - 1);
+    const float buttonW = (layout.actionBar.width - totalPad) / static_cast<float>(labels.size());
+    float bx = layout.actionBar.x + LEFT_PAD;
+    for (size_t i = 0; i < labels.size(); ++i) {
+        rects.emplace_back(bx, layout.actionBar.y + 4.0f, buttonW, buttonH);
+        bx += buttonW + ACTION_BUTTON_PAD;
+    }
+    return rects;
+}
+
+void TakesPanel::selectTake(int index) {
+    if (index < -1 || index >= static_cast<int>(m_takeRows.size())) {
+        index = -1;
+    }
+    if (m_renameActive && index != m_selectedTake) {
+        cancelRename();
+    }
+    m_selectedTake = index;
+    if (index >= 0) {
+        m_selectedSnapshot = -1;
+    }
+    setDirty(true);
+}
+
+void TakesPanel::selectSnapshot(int index) {
+    if (index < -1 || index >= static_cast<int>(m_snapshotRows.size())) {
+        index = -1;
+    }
+    if (m_renameActive) {
+        cancelRename();
+    }
+    m_selectedSnapshot = index;
+    if (index >= 0) {
+        m_selectedTake = -1;
+    }
+    setDirty(true);
+}
+
+void TakesPanel::setStatus(const std::string& text) {
+    m_statusText = text;
+    setDirty(true);
+}
+
+bool TakesPanel::invokeAction(const std::function<bool()>& action, const char* failureMessage) {
+    if (!action) {
+        return false;
+    }
+    setStatus("");
+    const bool ok = action();
+    if (!ok) {
+        setStatus(failureMessage);
+    }
+    refreshTakes();
+    return ok;
+}
+
+bool TakesPanel::requestCreateTake() {
+    return invokeAction([this]() { return m_onCreateTake && m_onCreateTake(); }, "Could not create take");
+}
+
+bool TakesPanel::requestSaveActiveTake() {
+    return invokeAction([this]() { return m_onSaveActiveTake && m_onSaveActiveTake(); },
+                        "Could not save the active take");
+}
+
+bool TakesPanel::requestOpenSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onOpenTake && m_onOpenTake(takeId); }, "Could not open take");
+}
+
+bool TakesPanel::requestDuplicateSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onDuplicateTake && m_onDuplicateTake(takeId); },
+                        "Could not duplicate take");
+}
+
+bool TakesPanel::requestBranchSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onBranchTake && m_onBranchTake(takeId); },
+                        "Could not branch from take");
+}
+
+bool TakesPanel::requestRestoreSelectedSnapshot() {
+    if (m_selectedSnapshot < 0) {
+        return false;
+    }
+    const std::string path = m_snapshotRows[static_cast<size_t>(m_selectedSnapshot)].path;
+    return invokeAction([this, path]() { return m_onRestoreSnapshot && m_onRestoreSnapshot(path); },
+                        "Could not restore snapshot");
+}
+
+void TakesPanel::beginRenameSelected() {
+    if (m_selectedTake < 0) {
+        return;
+    }
+    const auto& take = m_takeRows[static_cast<size_t>(m_selectedTake)].take;
+    m_renameActive = true;
+    m_renameTakeId = take.id;
+    m_renameBuffer = take.name;
+    setStatus("");
+    setDirty(true);
+}
+
+bool TakesPanel::commitRename() {
+    if (!m_renameActive) {
+        return false;
+    }
+    const std::string takeId = m_renameTakeId;
+    const std::string name = m_renameBuffer;
+    m_renameActive = false;
+    m_renameTakeId.clear();
+    m_renameBuffer.clear();
+    if (name.empty()) {
+        setStatus("Take name cannot be empty");
+        return false;
+    }
+    return invokeAction([this, takeId, name]() { return m_onRenameTake && m_onRenameTake(takeId, name); },
+                        "Could not rename take");
+}
+
+void TakesPanel::cancelRename() {
+    m_renameActive = false;
+    m_renameTakeId.clear();
+    m_renameBuffer.clear();
+    setDirty(true);
+}
+
+bool TakesPanel::handleKeyEvent(const NUIKeyEvent& event) {
+    if (!m_renameActive || !isVisible() || !event.pressed) {
+        return false;
+    }
+
+    if (event.keyCode == NUIKeyCode::Enter) {
+        commitRename();
+        return true;
+    }
+    if (event.keyCode == NUIKeyCode::Escape) {
+        cancelRename();
+        return true;
+    }
+    if (event.keyCode == NUIKeyCode::Backspace) {
+        if (!m_renameBuffer.empty()) {
+            m_renameBuffer.pop_back();
+            setDirty(true);
+        }
+        return true;
+    }
+    if (event.character >= 32 && event.character != 127) {
+        if (m_renameBuffer.size() < 128) {
+            m_renameBuffer.push_back(event.character);
+            setDirty(true);
+        }
+        return true;
+    }
+    // While editing, swallow other presses so global shortcuts don't fire.
+    return true;
+}
+
+bool TakesPanel::runRowAction(int actionIndex) {
+    const auto labels = actionButtonLabels();
+    if (actionIndex < 0 || actionIndex >= static_cast<int>(labels.size())) {
+        return false;
+    }
+    const std::string& label = labels[static_cast<size_t>(actionIndex)];
+    if (label == "OPEN") {
+        return requestOpenSelected();
+    }
+    if (label == "RENAME") {
+        beginRenameSelected();
+        return true;
+    }
+    if (label == "DUPLICATE") {
+        return requestDuplicateSelected();
+    }
+    if (label == "BRANCH") {
+        return requestBranchSelected();
+    }
+    if (label == "RESTORE") {
+        return requestRestoreSelectedSnapshot();
+    }
+    return false;
+}
+
+std::string TakesPanel::relativeTimeLabel(uint64_t epochMs) {
+    if (epochMs == 0) {
+        return {};
+    }
+    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+    const int64_t deltaSec = std::max<int64_t>(0, (static_cast<int64_t>(now) - static_cast<int64_t>(epochMs)) / 1000);
+    if (deltaSec < 60) {
+        return "now";
+    }
+    if (deltaSec < 3600) {
+        return std::to_string(deltaSec / 60) + "m";
+    }
+    if (deltaSec < 86400) {
+        return std::to_string(deltaSec / 3600) + "h";
+    }
+    return std::to_string(deltaSec / 86400) + "d";
+}
+
+void TakesPanel::onRender(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    WindowPanel::onRender(renderer);
+
+    const auto bounds = getBounds();
+    if (bounds.width <= 0 || bounds.height <= 0 || isMinimized()) {
+        return;
+    }
+
+    const Layout layout = computeLayout();
+
+    // Toolbar buttons
+    const auto drawButton = [&](const NUIRect& rect, const std::string& label, bool accent) {
+        renderer.fillRoundedRect(rect, 4.0f,
+                                 (accent ? theme.getColor("accentPrimary") : theme.getColor("backgroundSecondary"))
+                                     .withAlpha(accent ? 0.28f : 0.9f));
+        const NUISize textSize = renderer.measureText(label, 11.0f);
+        renderer.drawText(label,
+                          NUIPoint(rect.x + (rect.width - textSize.width) * 0.5f,
+                                   rect.y + (rect.height - textSize.height) * 0.5f),
+                          11.0f, theme.getColor(accent ? "textPrimary" : "textSecondary"));
+    };
+    drawButton(layout.newTakeButton, "+ NEW TAKE", true);
+    drawButton(layout.saveActiveButton, "SAVE ACTIVE", false);
+    renderer.drawLine(NUIPoint(bounds.x, layout.toolbar.y + layout.toolbar.height),
+                      NUIPoint(bounds.x + bounds.width, layout.toolbar.y + layout.toolbar.height), 0.5f,
+                      theme.getColor("divider").withAlpha(0.86f));
+
+    // Takes list
+    if (m_takeRows.empty()) {
+        const std::string hint = !m_manifestError.empty()
+                                     ? ("Takes unavailable: " + m_manifestError)
+                                     : "No takes yet — save a version with + NEW TAKE";
+        renderer.drawText(hint, NUIPoint(bounds.x + LEFT_PAD, layout.takesList.y + ROW_HEIGHT * 0.6f), 12.0f,
+                          theme.getColor("textSecondary").withAlpha(0.72f));
+    }
+    for (int i = 0; i < static_cast<int>(m_takeRows.size()); ++i) {
+        const auto& row = m_takeRows[static_cast<size_t>(i)];
+        const float rowY = layout.takesList.y + static_cast<float>(i) * ROW_HEIGHT - m_scrollY;
+        if (rowY + ROW_HEIGHT < layout.takesList.y || rowY > layout.takesList.y + layout.takesList.height) {
+            continue;
+        }
+
+        if (i == m_selectedTake) {
+            renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                              theme.getColor("accentPrimary").withAlpha(0.18f));
+        } else if (i == m_hoveredTake) {
+            renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                              theme.getColor("hover").withAlpha(0.8f));
+        }
+
+        const float indent = static_cast<float>(row.depth) * DEPTH_INDENT;
+        const NUIColor dotColor =
+            row.take.active ? theme.getColor("accentPrimary") : theme.getColor("textDisabled").withAlpha(0.7f);
+        renderer.fillCircle(NUIPoint(bounds.x + LEFT_PAD + indent, rowY + ROW_HEIGHT * 0.5f), 3.0f, dotColor);
+
+        const bool editingThisRow = m_renameActive && row.take.id == m_renameTakeId;
+        if (editingThisRow) {
+            renderer.fillRect(NUIRect(bounds.x + TEXT_LEFT_PAD + indent - 4.0f, rowY + 3.0f,
+                                      bounds.width - TEXT_LEFT_PAD - indent - LEFT_PAD, ROW_HEIGHT - 6.0f),
+                              theme.getColor("backgroundSecondary").withAlpha(0.95f));
+            renderer.drawText(m_renameBuffer + "|", NUIPoint(bounds.x + TEXT_LEFT_PAD + indent, rowY + 7.0f), 12.0f,
+                              theme.getColor("textPrimary"));
+        } else {
+            const NUIColor textColor = row.take.active ? theme.getColor("textPrimary")
+                                                       : theme.getColor("textPrimary").withAlpha(0.82f);
+            renderer.drawText(row.take.name, NUIPoint(bounds.x + TEXT_LEFT_PAD + indent, rowY + 7.0f), 12.0f,
+                              textColor);
+            const std::string timeLabel = relativeTimeLabel(row.take.updatedAtMs);
+            if (!timeLabel.empty()) {
+                const NUISize timeSize = renderer.measureText(timeLabel, 10.0f);
+                renderer.drawText(timeLabel,
+                                  NUIPoint(bounds.x + bounds.width - LEFT_PAD - timeSize.width, rowY + 8.0f), 10.0f,
+                                  theme.getColor("textSecondary").withAlpha(0.7f));
+            }
+        }
+
+        renderer.drawLine(NUIPoint(bounds.x + TEXT_LEFT_PAD, rowY + ROW_HEIGHT),
+                          NUIPoint(bounds.x + bounds.width, rowY + ROW_HEIGHT), 0.5f,
+                          theme.getColor("divider").withAlpha(0.7f));
+    }
+
+    // Action bar for the current selection
+    if (layout.actionBarVisible) {
+        renderer.fillRect(layout.actionBar, theme.getColor("backgroundSecondary").withAlpha(0.55f));
+        const auto labels = actionButtonLabels();
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < labels.size() && i < rects.size(); ++i) {
+            const bool hovered = static_cast<int>(i) == m_hoveredAction;
+            renderer.fillRoundedRect(rects[i], 4.0f,
+                                     theme.getColor(hovered ? "accentPrimary" : "borderSubtle")
+                                         .withAlpha(hovered ? 0.32f : 0.5f));
+            const NUISize textSize = renderer.measureText(labels[i], 10.0f);
+            renderer.drawText(labels[i],
+                              NUIPoint(rects[i].x + (rects[i].width - textSize.width) * 0.5f,
+                                       rects[i].y + (rects[i].height - textSize.height) * 0.5f),
+                              10.0f, theme.getColor("textPrimary").withAlpha(0.92f));
+        }
+    }
+
+    // Recovery snapshot section — automatic save history, restore-only.
+    if (!m_snapshotRows.empty()) {
+        renderer.fillRect(layout.snapshotHeader, theme.getColor("backgroundSecondary").withAlpha(0.4f));
+        renderer.drawText("RECOVERY SNAPSHOTS", NUIPoint(bounds.x + LEFT_PAD, layout.snapshotHeader.y + 5.0f), 9.0f,
+                          theme.getColor("textSecondary").withAlpha(0.8f));
+        for (int i = 0; i < static_cast<int>(m_snapshotRows.size()); ++i) {
+            const float rowY = layout.snapshotList.y + static_cast<float>(i) * ROW_HEIGHT;
+            if (i == m_selectedSnapshot) {
+                renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                                  theme.getColor("accentPrimary").withAlpha(0.18f));
+            } else if (i == m_hoveredSnapshot) {
+                renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                                  theme.getColor("hover").withAlpha(0.8f));
+            }
+            renderer.fillCircle(NUIPoint(bounds.x + LEFT_PAD, rowY + ROW_HEIGHT * 0.5f), 3.0f,
+                                theme.getColor("warning").withAlpha(0.75f));
+            renderer.drawText(m_snapshotRows[static_cast<size_t>(i)].label,
+                              NUIPoint(bounds.x + TEXT_LEFT_PAD, rowY + 7.0f), 11.0f,
+                              theme.getColor("textSecondary").withAlpha(0.95f));
+        }
+    }
+
+    if (!m_statusText.empty()) {
+        renderer.fillRect(layout.statusLine, theme.getColor("warning").withAlpha(0.14f));
+        renderer.drawText(m_statusText, NUIPoint(bounds.x + LEFT_PAD, layout.statusLine.y + 3.0f), 10.0f,
+                          theme.getColor("warning").withAlpha(0.95f));
+    }
+}
+
+bool TakesPanel::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible()) {
+        return false;
+    }
+    if (isMinimized()) {
+        return WindowPanel::onMouseEvent(event);
+    }
+
+    const Layout layout = computeLayout();
+
+    if (event.type == NUIMouseEventType::Move) {
+        m_hoveredTake = takeRowAt(event.position, layout);
+        m_hoveredSnapshot = snapshotRowAt(event.position, layout);
+        m_hoveredAction = -1;
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < rects.size(); ++i) {
+            if (rects[i].contains(event.position)) {
+                m_hoveredAction = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+
+    if (event.type == NUIMouseEventType::Scroll && layout.takesList.contains(event.position)) {
+        const float contentHeight = static_cast<float>(m_takeRows.size()) * ROW_HEIGHT;
+        const float maxScroll = std::max(0.0f, contentHeight - layout.takesList.height);
+        m_scrollY = std::clamp(m_scrollY - event.wheelDelta * 30.0f, 0.0f, maxScroll);
+        setDirty(true);
+        return true;
+    }
+
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        if (layout.newTakeButton.contains(event.position)) {
+            requestCreateTake();
+            return true;
+        }
+        if (layout.saveActiveButton.contains(event.position)) {
+            requestSaveActiveTake();
+            return true;
+        }
+
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < rects.size(); ++i) {
+            if (rects[i].contains(event.position)) {
+                runRowAction(static_cast<int>(i));
+                return true;
+            }
+        }
+
+        const int takeRow = takeRowAt(event.position, layout);
+        if (takeRow >= 0) {
+            if (event.type == NUIMouseEventType::DoubleClick) {
+                selectTake(takeRow);
+                if (!m_takeRows[static_cast<size_t>(takeRow)].take.active) {
+                    requestOpenSelected();
+                }
+            } else {
+                selectTake(takeRow);
+            }
+            return true;
+        }
+
+        const int snapshotRow = snapshotRowAt(event.position, layout);
+        if (snapshotRow >= 0) {
+            selectSnapshot(snapshotRow);
+            return true;
+        }
+    }
+
+    // Title bar, drag, resize, close, click-swallow inside panel bounds.
+    return WindowPanel::onMouseEvent(event);
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/TakesPanel.cpp
+++ b/Source/Panels/TakesPanel.cpp
@@ -32,6 +32,10 @@ void TakesPanel::rebuildRows() {
     if (m_selectedTake >= 0 && m_selectedTake < static_cast<int>(m_takeRows.size())) {
         previousSelectedId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
     }
+    std::string previousSelectedSnapshotPath;
+    if (m_selectedSnapshot >= 0 && m_selectedSnapshot < static_cast<int>(m_snapshotRows.size())) {
+        previousSelectedSnapshotPath = m_snapshotRows[static_cast<size_t>(m_selectedSnapshot)].path;
+    }
 
     m_takeRows.clear();
     m_snapshotRows.clear();
@@ -81,8 +85,14 @@ void TakesPanel::rebuildRows() {
             }
         }
     }
-    if (m_selectedSnapshot >= static_cast<int>(m_snapshotRows.size())) {
-        m_selectedSnapshot = -1;
+    m_selectedSnapshot = -1;
+    if (!previousSelectedSnapshotPath.empty()) {
+        for (int i = 0; i < static_cast<int>(m_snapshotRows.size()); ++i) {
+            if (m_snapshotRows[static_cast<size_t>(i)].path == previousSelectedSnapshotPath) {
+                m_selectedSnapshot = i;
+                break;
+            }
+        }
     }
     if (m_renameActive) {
         // The renamed take may have vanished (external change) — drop the edit.

--- a/Source/Panels/TakesPanel.cpp
+++ b/Source/Panels/TakesPanel.cpp
@@ -166,9 +166,11 @@ std::vector<std::string> TakesPanel::actionButtonLabels() const {
     if (m_selectedTake >= 0) {
         const bool active = m_takeRows[static_cast<size_t>(m_selectedTake)].take.active;
         if (active) {
-            return {"RENAME", "DUPLICATE", "BRANCH"};
+            // The active take can't be opened (it already is) or deleted
+            // (the working state must never be pulled out from under itself).
+            return {"RENAME", "DUP", "BRANCH"};
         }
-        return {"OPEN", "RENAME", "DUPLICATE", "BRANCH"};
+        return {"OPEN", "RENAME", "DUP", "BRANCH", "DELETE"};
     }
     return {};
 }
@@ -274,6 +276,20 @@ bool TakesPanel::requestBranchSelected() {
                         "Could not branch from take");
 }
 
+bool TakesPanel::requestDeleteSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const auto& take = m_takeRows[static_cast<size_t>(m_selectedTake)].take;
+    if (take.active) {
+        setStatus("Switch to another take before deleting this one");
+        return false;
+    }
+    const std::string takeId = take.id;
+    return invokeAction([this, takeId]() { return m_onDeleteTake && m_onDeleteTake(takeId); },
+                        "Could not delete take");
+}
+
 bool TakesPanel::requestRestoreSelectedSnapshot() {
     if (m_selectedSnapshot < 0) {
         return false;
@@ -372,11 +388,14 @@ bool TakesPanel::runRowAction(int actionIndex) {
         beginRenameSelected();
         return true;
     }
-    if (label == "DUPLICATE") {
+    if (label == "DUP") {
         return requestDuplicateSelected();
     }
     if (label == "BRANCH") {
         return requestBranchSelected();
+    }
+    if (label == "DELETE") {
+        return requestDeleteSelected();
     }
     if (label == "RESTORE") {
         return requestRestoreSelectedSnapshot();
@@ -452,7 +471,7 @@ void TakesPanel::onRender(NUIRenderer& renderer) {
                               theme.getColor("accentPrimary").withAlpha(0.18f));
         } else if (i == m_hoveredTake) {
             renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
-                              theme.getColor("hover").withAlpha(0.8f));
+                              theme.getColor("hover").withAlpha(0.12f));
         }
 
         const float indent = static_cast<float>(row.depth) * DEPTH_INDENT;
@@ -493,9 +512,10 @@ void TakesPanel::onRender(NUIRenderer& renderer) {
         const auto rects = actionButtonRects(layout);
         for (size_t i = 0; i < labels.size() && i < rects.size(); ++i) {
             const bool hovered = static_cast<int>(i) == m_hoveredAction;
+            const bool destructive = labels[i] == "DELETE";
+            const char* fillToken = destructive ? "warning" : (hovered ? "accentPrimary" : "borderSubtle");
             renderer.fillRoundedRect(rects[i], 4.0f,
-                                     theme.getColor(hovered ? "accentPrimary" : "borderSubtle")
-                                         .withAlpha(hovered ? 0.32f : 0.5f));
+                                     theme.getColor(fillToken).withAlpha(hovered ? 0.32f : (destructive ? 0.2f : 0.5f)));
             const NUISize textSize = renderer.measureText(labels[i], 10.0f);
             renderer.drawText(labels[i],
                               NUIPoint(rects[i].x + (rects[i].width - textSize.width) * 0.5f,
@@ -516,7 +536,7 @@ void TakesPanel::onRender(NUIRenderer& renderer) {
                                   theme.getColor("accentPrimary").withAlpha(0.18f));
             } else if (i == m_hoveredSnapshot) {
                 renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
-                                  theme.getColor("hover").withAlpha(0.8f));
+                                  theme.getColor("hover").withAlpha(0.12f));
             }
             renderer.fillCircle(NUIPoint(bounds.x + LEFT_PAD, rowY + ROW_HEIGHT * 0.5f), 3.0f,
                                 theme.getColor("warning").withAlpha(0.75f));

--- a/Source/Panels/TakesPanel.cpp
+++ b/Source/Panels/TakesPanel.cpp
@@ -291,6 +291,9 @@ void TakesPanel::beginRenameSelected() {
     m_renameActive = true;
     m_renameTakeId = take.id;
     m_renameBuffer = take.name;
+    // Printable characters are delivered through the focused-component text
+    // path (see AestraWindowManager charCallback), so claim focus for the edit.
+    setFocused(true);
     setStatus("");
     setDirty(true);
 }
@@ -304,6 +307,7 @@ bool TakesPanel::commitRename() {
     m_renameActive = false;
     m_renameTakeId.clear();
     m_renameBuffer.clear();
+    setFocused(false);
     if (name.empty()) {
         setStatus("Take name cannot be empty");
         return false;
@@ -316,7 +320,12 @@ void TakesPanel::cancelRename() {
     m_renameActive = false;
     m_renameTakeId.clear();
     m_renameBuffer.clear();
+    setFocused(false);
     setDirty(true);
+}
+
+bool TakesPanel::onKeyEvent(const NUIKeyEvent& event) {
+    return handleKeyEvent(event);
 }
 
 bool TakesPanel::handleKeyEvent(const NUIKeyEvent& event) {

--- a/Source/Panels/TakesPanel.h
+++ b/Source/Panels/TakesPanel.h
@@ -42,6 +42,8 @@ public:
 
     void onRender(AestraUI::NUIRenderer& renderer) override;
     bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
+    /** @brief Focused key delivery (text input arrives here while renaming). */
+    bool onKeyEvent(const AestraUI::NUIKeyEvent& event) override;
 
     /** @brief Handle keys while an inline rename is active. Returns true if consumed. */
     bool handleKeyEvent(const AestraUI::NUIKeyEvent& event);

--- a/Source/Panels/TakesPanel.h
+++ b/Source/Panels/TakesPanel.h
@@ -1,0 +1,191 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "WindowPanel.h"
+#include "../Core/TakeManager.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Workspace panel for project Takes — named, versioned project states.
+ *
+ * Answers "which version of the work do I want?" (the History panel answers
+ * "what actions did I perform?"). Lists the takes manifest with lineage
+ * indentation, lets the user create, open, rename, duplicate and branch takes,
+ * and exposes recent automatic save snapshots as a recovery section.
+ *
+ * The panel owns no project logic: data arrives through providers and every
+ * action is delegated through a callback so the app layer keeps its
+ * save-before-switch safety rules in one place. Callbacks return false on
+ * failure and the panel surfaces a status line.
+ */
+class TakesPanel : public WindowPanel {
+public:
+    /** @brief A recovery snapshot row (from the automatic save history). */
+    struct SnapshotEntry {
+        std::string path;   ///< Absolute snapshot file path.
+        std::string label;  ///< Human-readable label (timestamp).
+    };
+
+    using TakesProvider = std::function<TakeManager::Manifest()>;
+    using SnapshotsProvider = std::function<std::vector<SnapshotEntry>()>;
+
+    TakesPanel();
+    ~TakesPanel() override = default;
+
+    void onRender(AestraUI::NUIRenderer& renderer) override;
+    bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
+
+    /** @brief Handle keys while an inline rename is active. Returns true if consumed. */
+    bool handleKeyEvent(const AestraUI::NUIKeyEvent& event);
+
+    /** @brief Bind the manifest source (typically TakeManager::loadManifest). */
+    void setTakesProvider(TakesProvider provider) { m_takesProvider = std::move(provider); }
+    /** @brief Bind the recovery-snapshot source (automatic save history). */
+    void setSnapshotsProvider(SnapshotsProvider provider) { m_snapshotsProvider = std::move(provider); }
+
+    /** @brief Capture the current project state as a new take. */
+    void setOnCreateTake(std::function<bool()> cb) { m_onCreateTake = std::move(cb); }
+    /** @brief Save the current state into the active take's snapshot. */
+    void setOnSaveActiveTake(std::function<bool()> cb) { m_onSaveActiveTake = std::move(cb); }
+    /** @brief Open (restore) a take after safely saving the current one. */
+    void setOnOpenTake(std::function<bool(const std::string& takeId)> cb) { m_onOpenTake = std::move(cb); }
+    /** @brief Rename a take. */
+    void setOnRenameTake(std::function<bool(const std::string& takeId, const std::string& name)> cb) {
+        m_onRenameTake = std::move(cb);
+    }
+    /** @brief Duplicate a take without activating it. */
+    void setOnDuplicateTake(std::function<bool(const std::string& takeId)> cb) { m_onDuplicateTake = std::move(cb); }
+    /** @brief Branch: duplicate a take and continue working on the branch. */
+    void setOnBranchTake(std::function<bool(const std::string& takeId)> cb) { m_onBranchTake = std::move(cb); }
+    /** @brief Restore a recovery snapshot after safely saving the current take. */
+    void setOnRestoreSnapshot(std::function<bool(const std::string& path)> cb) {
+        m_onRestoreSnapshot = std::move(cb);
+    }
+
+    /** @brief Rebuild rows from the providers. Call after any take operation. */
+    void refreshTakes();
+
+    // --- Introspection + programmatic actions -------------------------------
+    // The mouse handlers route through these; tests drive them directly.
+
+    /** @brief Number of take rows currently displayed. */
+    int getTakeCount() const { return static_cast<int>(m_takeRows.size()); }
+    /** @brief Take entry for a displayed row (row order = manifest order). */
+    const TakeManager::TakeEntry& getTakeAt(int index) const { return m_takeRows[static_cast<size_t>(index)].take; }
+    /** @brief Lineage depth used for row indentation. */
+    int getTakeDepthAt(int index) const { return m_takeRows[static_cast<size_t>(index)].depth; }
+    /** @brief Number of recovery snapshot rows currently displayed. */
+    int getSnapshotCount() const { return static_cast<int>(m_snapshotRows.size()); }
+    /** @brief Selected take row index, or -1. */
+    int getSelectedTake() const { return m_selectedTake; }
+    /** @brief Selected snapshot row index, or -1. */
+    int getSelectedSnapshot() const { return m_selectedSnapshot; }
+    /** @brief Status line shown at the bottom of the panel (empty when clear). */
+    const std::string& getStatusText() const { return m_statusText; }
+    /** @brief True while an inline rename edit is active. */
+    bool isRenameActive() const { return m_renameActive; }
+    /** @brief Current rename edit buffer. */
+    const std::string& getRenameBuffer() const { return m_renameBuffer; }
+
+    /** @brief Select a take row (clears any snapshot selection). -1 clears. */
+    void selectTake(int index);
+    /** @brief Select a snapshot row (clears any take selection). -1 clears. */
+    void selectSnapshot(int index);
+
+    /** @brief Create a new take from the current state. */
+    bool requestCreateTake();
+    /** @brief Save the current state into the active take. */
+    bool requestSaveActiveTake();
+    /** @brief Open the selected take. */
+    bool requestOpenSelected();
+    /** @brief Duplicate the selected take (stays on the current take). */
+    bool requestDuplicateSelected();
+    /** @brief Branch from the selected take and switch to the branch. */
+    bool requestBranchSelected();
+    /** @brief Restore the selected recovery snapshot. */
+    bool requestRestoreSelectedSnapshot();
+    /** @brief Start inline rename for the selected take. */
+    void beginRenameSelected();
+    /** @brief Commit the inline rename buffer. */
+    bool commitRename();
+    /** @brief Abandon the inline rename. */
+    void cancelRename();
+
+private:
+    static constexpr float ROW_HEIGHT = 26.0f;
+    static constexpr float HEADER_HEIGHT = 36.0f;   // WindowPanel title bar area
+    static constexpr float TOOLBAR_HEIGHT = 30.0f;
+    static constexpr float ACTION_BAR_HEIGHT = 28.0f;
+    static constexpr float SECTION_HEADER_HEIGHT = 22.0f;
+    static constexpr float STATUS_HEIGHT = 18.0f;
+    static constexpr float LEFT_PAD = 12.0f;
+    static constexpr float TEXT_LEFT_PAD = 28.0f;
+    static constexpr float DEPTH_INDENT = 12.0f;
+    static constexpr size_t MAX_SNAPSHOT_ROWS = 4;
+
+    struct TakeRow {
+        TakeManager::TakeEntry take;
+        int depth{0};
+    };
+
+    struct Layout {
+        AestraUI::NUIRect toolbar;
+        AestraUI::NUIRect newTakeButton;
+        AestraUI::NUIRect saveActiveButton;
+        AestraUI::NUIRect takesList;
+        AestraUI::NUIRect actionBar;
+        AestraUI::NUIRect snapshotHeader;
+        AestraUI::NUIRect snapshotList;
+        AestraUI::NUIRect statusLine;
+        bool actionBarVisible{false};
+    };
+
+    Layout computeLayout() const;
+    void rebuildRows();
+    int takeRowAt(const AestraUI::NUIPoint& point, const Layout& layout) const;
+    int snapshotRowAt(const AestraUI::NUIPoint& point, const Layout& layout) const;
+    std::vector<AestraUI::NUIRect> actionButtonRects(const Layout& layout) const;
+    std::vector<std::string> actionButtonLabels() const;
+    bool runRowAction(int actionIndex);
+    void setStatus(const std::string& text);
+    bool invokeAction(const std::function<bool()>& action, const char* failureMessage);
+    static std::string relativeTimeLabel(uint64_t epochMs);
+
+    TakesProvider m_takesProvider;
+    SnapshotsProvider m_snapshotsProvider;
+
+    std::function<bool()> m_onCreateTake;
+    std::function<bool()> m_onSaveActiveTake;
+    std::function<bool(const std::string&)> m_onOpenTake;
+    std::function<bool(const std::string&, const std::string&)> m_onRenameTake;
+    std::function<bool(const std::string&)> m_onDuplicateTake;
+    std::function<bool(const std::string&)> m_onBranchTake;
+    std::function<bool(const std::string&)> m_onRestoreSnapshot;
+
+    std::vector<TakeRow> m_takeRows;
+    std::vector<SnapshotEntry> m_snapshotRows;
+    std::string m_manifestError;
+
+    int m_selectedTake{-1};
+    int m_selectedSnapshot{-1};
+    int m_hoveredTake{-1};
+    int m_hoveredSnapshot{-1};
+    int m_hoveredAction{-1};
+    float m_scrollY{0.0f};
+    std::string m_statusText;
+
+    bool m_renameActive{false};
+    std::string m_renameBuffer;
+    std::string m_renameTakeId;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/TakesPanel.h
+++ b/Source/Panels/TakesPanel.h
@@ -65,6 +65,8 @@ public:
     }
     /** @brief Duplicate a take without activating it. */
     void setOnDuplicateTake(std::function<bool(const std::string& takeId)> cb) { m_onDuplicateTake = std::move(cb); }
+    /** @brief Delete a non-active take. */
+    void setOnDeleteTake(std::function<bool(const std::string& takeId)> cb) { m_onDeleteTake = std::move(cb); }
     /** @brief Branch: duplicate a take and continue working on the branch. */
     void setOnBranchTake(std::function<bool(const std::string& takeId)> cb) { m_onBranchTake = std::move(cb); }
     /** @brief Restore a recovery snapshot after safely saving the current take. */
@@ -112,6 +114,8 @@ public:
     bool requestDuplicateSelected();
     /** @brief Branch from the selected take and switch to the branch. */
     bool requestBranchSelected();
+    /** @brief Delete the selected take (refused for the active take). */
+    bool requestDeleteSelected();
     /** @brief Restore the selected recovery snapshot. */
     bool requestRestoreSelectedSnapshot();
     /** @brief Start inline rename for the selected take. */
@@ -169,6 +173,7 @@ private:
     std::function<bool(const std::string&)> m_onOpenTake;
     std::function<bool(const std::string&, const std::string&)> m_onRenameTake;
     std::function<bool(const std::string&)> m_onDuplicateTake;
+    std::function<bool(const std::string&)> m_onDeleteTake;
     std::function<bool(const std::string&)> m_onBranchTake;
     std::function<bool(const std::string&)> m_onRestoreSnapshot;
 

--- a/Source/ViewTypes.h
+++ b/Source/ViewTypes.h
@@ -12,7 +12,8 @@ enum class ViewType {
     Sequencer,
     PianoRoll,
     Playlist,
-    History
+    History,
+    Takes
 };
 
 } // namespace Audio

--- a/Tests/AestraUI/TakesHistoryPanelTest.cpp
+++ b/Tests/AestraUI/TakesHistoryPanelTest.cpp
@@ -223,6 +223,9 @@ void testTakesPanel() {
     }
     panel.beginRenameSelected();
     require(panel.isRenameActive(), "Rename edit should be active");
+    // Text input is delivered via the focused-component path — the panel must
+    // hold focus for the duration of the edit and release it afterwards.
+    require(panel.isFocused(), "Rename edit must claim keyboard focus");
     // Clear the prefilled name, type a new one, commit with Enter.
     while (!panel.getRenameBuffer().empty()) {
         require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Backspace)), "Backspace should be consumed");
@@ -233,6 +236,7 @@ void testTakesPanel() {
     require(panel.getRenameBuffer() == "Chorus V2", "Rename buffer should reflect typed name");
     require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Enter)), "Enter should commit rename");
     require(!panel.isRenameActive(), "Rename edit should end on commit");
+    require(!panel.isFocused(), "Committing a rename must release keyboard focus");
     auto renamedManifest = TakeManager::loadManifest(projectPath);
     require(renamedManifest.ok, "Manifest should reload after rename");
     bool foundRenamed = false;
@@ -245,6 +249,7 @@ void testTakesPanel() {
     panel.beginRenameSelected();
     require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Escape)), "Escape should be consumed");
     require(!panel.isRenameActive(), "Escape should cancel rename");
+    require(!panel.isFocused(), "Cancelling a rename must release keyboard focus");
 
     // Branch: duplicate + activate, source take untouched (non-destructive).
     const auto beforeBranch = TakeManager::loadManifest(projectPath);

--- a/Tests/AestraUI/TakesHistoryPanelTest.cpp
+++ b/Tests/AestraUI/TakesHistoryPanelTest.cpp
@@ -281,6 +281,25 @@ void testTakesPanel() {
     require(readFileContents(TakeManager::resolveSnapshotPath(projectPath, *branch)) == sourceContentsBefore,
             "Branch snapshot should start as a copy of its source");
 
+    // Delete: refused for the active take, works for others, row disappears.
+    panel.setOnDeleteTake([&](const std::string& takeId) { return TakeManager::deleteTake(projectPath, takeId).ok; });
+    int activeRow = -1, chorusRow = -1;
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).active) activeRow = i;
+        if (panel.getTakeAt(i).name == "Chorus V2") chorusRow = i;
+    }
+    require(activeRow >= 0 && chorusRow >= 0, "Active and Chorus V2 takes should exist before delete");
+    panel.selectTake(activeRow);
+    require(!panel.requestDeleteSelected(), "Deleting the active take must be refused by the panel");
+    require(!panel.getStatusText().empty(), "Refused delete should explain itself");
+    const int countBeforeDelete = panel.getTakeCount();
+    panel.selectTake(chorusRow);
+    require(panel.requestDeleteSelected(), "Deleting a non-active take should succeed");
+    require(panel.getTakeCount() == countBeforeDelete - 1, "Deleted take row should disappear");
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        require(panel.getTakeAt(i).name != "Chorus V2", "Deleted take must not reappear");
+    }
+
     // A failing action surfaces a status message instead of silently dropping.
     panel.setOnDuplicateTake([](const std::string&) { return false; });
     panel.selectTake(0);

--- a/Tests/AestraUI/TakesHistoryPanelTest.cpp
+++ b/Tests/AestraUI/TakesHistoryPanelTest.cpp
@@ -1,0 +1,300 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Takes/History workspace panel behavior:
+//   * History panel presents the session command timeline (undo + redo stacks),
+//     refreshes on state change, and navigates safely through activateEntry.
+//   * Takes panel lists the takes manifest with lineage depth, routes every
+//     action through app-layer callbacks, supports inline rename via key
+//     events, and never mutates project state itself.
+//   * Panel opening: hidden panels ignore input; showing + refresh presents
+//     current data.
+
+#include "../../Source/Panels/AestraHistoryPanel.h"
+#include "../../Source/Panels/TakesPanel.h"
+
+#include "../../Source/Core/TakeManager.h"
+#include "../Support/TestTempDirectory.h"
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Aestra::Audio::AestraHistoryPanel;
+using Aestra::Audio::TakesPanel;
+using Aestra::Audio::TrackManager;
+
+namespace {
+
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+/** Minimal named command so the history panel has real timeline entries. */
+class NamedTestCommand : public Aestra::Audio::ICommand {
+public:
+    NamedTestCommand(std::string name, int& counter) : m_name(std::move(name)), m_counter(counter) {}
+    void execute() override { ++m_counter; }
+    void undo() override { --m_counter; }
+    void redo() override { ++m_counter; }
+    std::string getName() const override { return m_name; }
+
+private:
+    std::string m_name;
+    int& m_counter;
+};
+
+std::string readFileContents(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+AestraUI::NUIKeyEvent keyPress(AestraUI::NUIKeyCode code, char character = 0) {
+    AestraUI::NUIKeyEvent e;
+    e.keyCode = code;
+    e.character = character;
+    e.pressed = true;
+    return e;
+}
+
+AestraUI::NUIMouseEvent leftPress(float x, float y) {
+    AestraUI::NUIMouseEvent e;
+    e.type = AestraUI::NUIMouseEventType::Down;
+    e.pressed = true;
+    e.button = AestraUI::NUIMouseButton::Left;
+    e.position = {x, y};
+    return e;
+}
+
+// =============================================================================
+// History panel — command timeline presentation and navigation
+// =============================================================================
+
+void testHistoryPanel() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& history = trackManager->getCommandHistory();
+
+    AestraHistoryPanel panel(trackManager);
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 280.0f, 460.0f));
+    panel.setVisible(true);
+
+    require(panel.getEntryCount() == 0, "History panel should start empty");
+
+    int counter = 0;
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Move Clip", counter));
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Add Track", counter));
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Change Volume", counter));
+    require(counter == 3, "Commands should have executed");
+
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 3, "Panel should present all executed commands");
+    for (int i = 0; i < 3; ++i) {
+        require(!panel.isEntryRedo(i), "No redo entries expected before undo");
+    }
+    bool sawMove = false, sawAdd = false, sawVolume = false;
+    for (int i = 0; i < 3; ++i) {
+        const auto& name = panel.getEntryName(i);
+        sawMove = sawMove || name == "Move Clip";
+        sawAdd = sawAdd || name == "Add Track";
+        sawVolume = sawVolume || name == "Change Volume";
+    }
+    require(sawMove && sawAdd && sawVolume, "Panel entries should carry command names");
+
+    // Undo → most recent command moves to the redo (greyed) region.
+    require(history.undo(), "Undo should succeed");
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 3, "Undone commands stay visible in the timeline");
+    int redoCount = 0;
+    for (int i = 0; i < panel.getEntryCount(); ++i) {
+        if (panel.isEntryRedo(i)) {
+            ++redoCount;
+            require(panel.getEntryName(i) == "Change Volume", "Undone command should appear as redo entry");
+        }
+    }
+    require(redoCount == 1, "Exactly one redo entry expected after a single undo");
+    require(counter == 2, "Undo should have reverted the command");
+
+    // Navigate by clicking the redo entry — redoes it and fires the callback.
+    int historyChangedCalls = 0;
+    panel.setOnHistoryChanged([&historyChangedCalls]() { ++historyChangedCalls; });
+    int redoIndex = -1;
+    for (int i = 0; i < panel.getEntryCount(); ++i) {
+        if (panel.isEntryRedo(i)) {
+            redoIndex = i;
+            break;
+        }
+    }
+    require(redoIndex >= 0, "Redo entry should exist");
+    panel.activateEntry(redoIndex);
+    require(counter == 3, "Activating a redo entry should re-apply the command");
+    require(!history.canRedo(), "Redo stack should be drained");
+    require(historyChangedCalls == 1, "History navigation should notify listeners");
+
+    // Jump back to the beginning of the session through the timeline.
+    panel.activateEntry(panel.getEntryCount() - 1); // deepest undo row keeps that stackIndex
+    require(history.canRedo(), "Timeline jump should produce redoable commands");
+    require(counter < 3, "Timeline jump should have undone commands");
+
+    // Hidden panel must ignore input entirely.
+    panel.setVisible(false);
+    require(!panel.onMouseEvent(leftPress(10.0f, 50.0f)), "Hidden history panel must not consume events");
+
+    std::cout << "[PASS] History panel timeline\n";
+}
+
+// =============================================================================
+// Takes panel — manifest presentation, actions, rename, non-destructive branch
+// =============================================================================
+
+void testTakesPanel() {
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"TakesPanel"};
+    const auto projectPath = (tempDirScope.path() / "panel_project.aes").string();
+
+    auto init = TakeManager::ensureManifest(projectPath, "state-main", "Main");
+    require(init.ok, "Failed to initialize takes manifest");
+    auto created = TakeManager::createTake(projectPath, "state-idea-b", "Idea B");
+    require(created.ok, "Failed to create second take");
+
+    TakesPanel panel;
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 320.0f, 480.0f));
+    panel.setVisible(true);
+    panel.setTakesProvider([&projectPath]() { return TakeManager::loadManifest(projectPath); });
+    panel.setSnapshotsProvider([]() {
+        return std::vector<TakesPanel::SnapshotEntry>{{"/nonexistent/snapshot.aes", "Jul 16 10:00"}};
+    });
+
+    // Opening semantics: refresh presents current manifest + snapshots.
+    panel.refreshTakes();
+    require(panel.getTakeCount() == 2, "Panel should list both takes");
+    require(panel.getSnapshotCount() == 1, "Panel should list recovery snapshots");
+
+    int mainRow = -1, ideaRow = -1;
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") mainRow = i;
+        if (panel.getTakeAt(i).name == "Idea B") ideaRow = i;
+    }
+    require(mainRow >= 0 && ideaRow >= 0, "Both takes should be present");
+    require(panel.getTakeDepthAt(mainRow) == 0, "Root take should have depth 0");
+    require(panel.getTakeDepthAt(ideaRow) == 1, "Child take should be indented under its parent");
+    require(panel.getTakeAt(ideaRow).active, "Newly created take should be marked active");
+
+    // Open action routes through the callback with the selected take's id.
+    std::string openedId;
+    panel.setOnOpenTake([&](const std::string& takeId) {
+        openedId = takeId;
+        // Mimic the app: activate the take in the manifest (snapshot load is app-side).
+        return TakeManager::setActiveTake(projectPath, takeId).ok;
+    });
+    panel.selectTake(mainRow);
+    require(panel.getSelectedTake() == mainRow, "Selection should stick");
+    require(panel.requestOpenSelected(), "Open action should succeed");
+    require(openedId == "main", "Open action should receive the selected take id");
+    // The refresh after the action must reflect the new active take.
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") {
+            require(panel.getTakeAt(i).active, "Manifest refresh should show the opened take as active");
+        }
+    }
+
+    // Create action → new take appears after the built-in refresh.
+    panel.setOnCreateTake([&]() { return TakeManager::createTake(projectPath, "state-c", "Idea C").ok; });
+    require(panel.requestCreateTake(), "Create action should succeed");
+    require(panel.getTakeCount() == 3, "New take should appear in the panel");
+
+    // Mouse selection: click on the first take row.
+    panel.selectTake(-1);
+    const float rowCenterY = 36.0f + 30.0f + 13.0f; // header + toolbar + half row
+    require(panel.onMouseEvent(leftPress(160.0f, rowCenterY)), "Row click should be consumed");
+    require(panel.getSelectedTake() == 0, "Click should select the first take row");
+
+    // Inline rename: keyboard-driven edit, committed through the callback.
+    panel.setOnRenameTake([&](const std::string& takeId, const std::string& name) {
+        return TakeManager::renameTake(projectPath, takeId, name).ok;
+    });
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).name == "Idea C") panel.selectTake(i);
+    }
+    panel.beginRenameSelected();
+    require(panel.isRenameActive(), "Rename edit should be active");
+    // Clear the prefilled name, type a new one, commit with Enter.
+    while (!panel.getRenameBuffer().empty()) {
+        require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Backspace)), "Backspace should be consumed");
+    }
+    for (char c : std::string("Chorus V2")) {
+        require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Unknown, c)), "Typing should be consumed");
+    }
+    require(panel.getRenameBuffer() == "Chorus V2", "Rename buffer should reflect typed name");
+    require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Enter)), "Enter should commit rename");
+    require(!panel.isRenameActive(), "Rename edit should end on commit");
+    auto renamedManifest = TakeManager::loadManifest(projectPath);
+    require(renamedManifest.ok, "Manifest should reload after rename");
+    bool foundRenamed = false;
+    for (const auto& take : renamedManifest.takes) {
+        foundRenamed = foundRenamed || take.name == "Chorus V2";
+    }
+    require(foundRenamed, "Rename should persist to the manifest");
+
+    // Escape cancels a rename without touching the manifest.
+    panel.beginRenameSelected();
+    require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Escape)), "Escape should be consumed");
+    require(!panel.isRenameActive(), "Escape should cancel rename");
+
+    // Branch: duplicate + activate, source take untouched (non-destructive).
+    const auto beforeBranch = TakeManager::loadManifest(projectPath);
+    require(beforeBranch.ok, "Manifest should load before branch");
+    const auto* branchSource = beforeBranch.findTake("main");
+    require(branchSource != nullptr, "Branch source should exist");
+    const std::string sourceSnapshotPath = TakeManager::resolveSnapshotPath(projectPath, *branchSource);
+    const std::string sourceContentsBefore = readFileContents(sourceSnapshotPath);
+    require(!sourceContentsBefore.empty(), "Branch source snapshot should exist");
+
+    panel.setOnBranchTake([&](const std::string& takeId) {
+        auto dup = TakeManager::duplicateTake(projectPath, takeId, "Main Branch");
+        if (!dup.ok) return false;
+        return TakeManager::setActiveTake(projectPath, dup.take.id).ok;
+    });
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") panel.selectTake(i);
+    }
+    require(panel.requestBranchSelected(), "Branch action should succeed");
+
+    const auto afterBranch = TakeManager::loadManifest(projectPath);
+    require(afterBranch.ok, "Manifest should load after branch");
+    require(afterBranch.takes.size() == beforeBranch.takes.size() + 1, "Branch should add a take");
+    const auto* branch = afterBranch.activeTake();
+    require(branch != nullptr && branch->name == "Main Branch", "Branch should be active");
+    require(branch->parentId == "main", "Branch should record its source as parent");
+    require(readFileContents(sourceSnapshotPath) == sourceContentsBefore,
+            "Branching must not modify the source take snapshot");
+    require(readFileContents(TakeManager::resolveSnapshotPath(projectPath, *branch)) == sourceContentsBefore,
+            "Branch snapshot should start as a copy of its source");
+
+    // A failing action surfaces a status message instead of silently dropping.
+    panel.setOnDuplicateTake([](const std::string&) { return false; });
+    panel.selectTake(0);
+    require(!panel.requestDuplicateSelected(), "Failing duplicate should report false");
+    require(!panel.getStatusText().empty(), "Failing action should surface a status message");
+
+    // Hidden panel ignores input.
+    panel.setVisible(false);
+    require(!panel.onMouseEvent(leftPress(160.0f, rowCenterY)), "Hidden takes panel must not consume events");
+    require(!panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Enter)), "Hidden takes panel must not consume keys");
+
+    std::cout << "[PASS] Takes panel actions\n";
+}
+
+} // namespace
+
+int main() {
+    testHistoryPanel();
+    testTakesPanel();
+    std::cout << "[PASS] TakesHistoryPanelTest\n";
+    return 0;
+}

--- a/Tests/AestraUI/TakesHistoryPanelTest.cpp
+++ b/Tests/AestraUI/TakesHistoryPanelTest.cpp
@@ -21,8 +21,10 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <utility>
 
 using Aestra::Audio::AestraHistoryPanel;
 using Aestra::Audio::TakesPanel;
@@ -69,6 +71,14 @@ AestraUI::NUIMouseEvent leftPress(float x, float y) {
     e.type = AestraUI::NUIMouseEventType::Down;
     e.pressed = true;
     e.button = AestraUI::NUIMouseButton::Left;
+    e.position = {x, y};
+    return e;
+}
+
+AestraUI::NUIMouseEvent scrollBy(float x, float y, float wheelDelta) {
+    AestraUI::NUIMouseEvent e;
+    e.type = AestraUI::NUIMouseEventType::Scroll;
+    e.wheelDelta = wheelDelta;
     e.position = {x, y};
     return e;
 }
@@ -147,6 +157,38 @@ void testHistoryPanel() {
     require(!panel.onMouseEvent(leftPress(10.0f, 50.0f)), "Hidden history panel must not consume events");
 
     std::cout << "[PASS] History panel timeline\n";
+}
+
+// Clicking rows after scrolling must hit the visually shifted entries —
+// regression for the scroll offset being tracked but never applied.
+void testHistoryPanelScrolledClick() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& history = trackManager->getCommandHistory();
+
+    AestraHistoryPanel panel(trackManager);
+    // 36px header + room for ~3 of the 26px rows: most entries start clipped.
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 280.0f, 114.0f));
+    panel.setVisible(true);
+
+    int counter = 0;
+    for (int i = 0; i < 10; ++i) {
+        history.pushAndExecute(std::make_shared<NamedTestCommand>("Cmd " + std::to_string(i), counter));
+    }
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 10, "All commands should be listed");
+    require(counter == 10, "All commands should have executed");
+
+    // Two wheel notches = 60px of scroll (30px per notch).
+    require(panel.onMouseEvent(scrollBy(100.0f, 60.0f, -1.0f)), "Scroll should be consumed");
+    require(panel.onMouseEvent(scrollBy(100.0f, 60.0f, -1.0f)), "Scroll should be consumed");
+
+    // With scrollY=60, row i spans y = [36 + 26*i - 60, +26) → y=40 hits row 2.
+    // Entry 2 = undoStack[2], so undoTo(2) keeps exactly 2 commands applied.
+    require(panel.onMouseEvent(leftPress(100.0f, 40.0f)), "Row click should be consumed");
+    require(counter == 2, "Scrolled click should activate the visually shifted entry");
+    require(history.canRedo(), "Timeline jump should leave redoable commands");
+
+    std::cout << "[PASS] History panel scrolled click\n";
 }
 
 // =============================================================================
@@ -318,6 +360,7 @@ void testTakesPanel() {
 
 int main() {
     testHistoryPanel();
+    testHistoryPanelScrolledClick();
     testTakesPanel();
     std::cout << "[PASS] TakesHistoryPanelTest\n";
     return 0;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1777,6 +1777,45 @@ else()
     message(STATUS "PanelWindowClickSwallowTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Takes/History workspace panels: command-timeline presentation + navigation,
+# takes manifest listing, actions, inline rename, non-destructive branching.
+if(TARGET AestraUI_Core)
+    add_executable(TakesHistoryPanelTest
+        AestraUI/TakesHistoryPanelTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/WindowPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/AestraHistoryPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/TakesPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/TakeManager.cpp
+    )
+    target_link_libraries(TakesHistoryPanelTest PRIVATE AestraUI_Core AestraAudio)
+    target_include_directories(TakesHistoryPanelTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+        ${CMAKE_SOURCE_DIR}/AestraUI/Graphics
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/Source/Panels
+    )
+    add_test(NAME TakesHistoryPanelTest COMMAND TakesHistoryPanelTest)
+    set_tests_properties(TakesHistoryPanelTest PROPERTIES LABELS "ui;takes;history;regression")
+else()
+    message(STATUS "TakesHistoryPanelTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # Plugin-browser filtering must preserve selection by stable plugin ID rather
 # than silently selecting whichever row inherits the old numeric index.
 if(TARGET AestraUI_Core)

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -191,6 +191,35 @@ int main() {
     require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *branchEntry)) == "Main Lane",
             "Branch snapshot should start from its source state");
 
+    // --- Delete: refuses the active take, reparents children, removes files --
+    require(!TakeManager::deleteTake(projectPath.string(), branch.take.id).ok,
+            "Deleting the active take must be refused");
+    require(!TakeManager::deleteTake(projectPath.string(), "no_such_take").ok,
+            "Deleting a missing take must fail");
+
+    // duplicated (parent = renamed variation) must survive its parent's
+    // deletion by moving up to the variation's parent ("main").
+    const std::string dupSnapshotPath = TakeManager::resolveSnapshotPath(projectPath.string(), duplicated.take);
+    const auto beforeDeleteManifest = TakeManager::loadManifest(projectPath.string());
+    require(beforeDeleteManifest.ok, "Manifest should load before deletion");
+    const auto* renamedBeforeDelete = beforeDeleteManifest.findTake(created.take.id);
+    require(renamedBeforeDelete != nullptr, "Renamed take should exist before deletion");
+    const std::string renamedSnapshotPath =
+        TakeManager::resolveSnapshotPath(projectPath.string(), *renamedBeforeDelete);
+    require(std::filesystem::exists(renamedSnapshotPath), "Renamed take snapshot should exist before deletion");
+
+    auto deleted = TakeManager::deleteTake(projectPath.string(), created.take.id);
+    require(deleted.ok, "Failed to delete a non-active take");
+    auto afterDelete = TakeManager::loadManifest(projectPath.string());
+    require(afterDelete.ok, "Manifest should reload after deletion");
+    require(afterDelete.findTake(created.take.id) == nullptr, "Deleted take must leave the manifest");
+    require(!std::filesystem::exists(renamedSnapshotPath), "Deleted take snapshot must be removed from disk");
+    const auto* orphan = afterDelete.findTake(duplicated.take.id);
+    require(orphan != nullptr, "Child of a deleted take must survive");
+    require(orphan->parentId == "main", "Child of a deleted take must reparent to its grandparent");
+    require(std::filesystem::exists(dupSnapshotPath), "Deleting a take must not touch other snapshots");
+    require(afterDelete.activeTakeId == branch.take.id, "Deletion must not change the active take");
+
     std::cout << "[PASS] TakeManagerTest\n";
     return 0;
 }

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -141,6 +141,56 @@ int main() {
     require(switchedManifest.activeTake() && switchedManifest.activeTake()->active,
             "Active take marker was not restored");
 
+    // --- Rename: name changes persist, snapshot contents stay untouched ------
+    auto renamed = TakeManager::renameTake(projectPath.string(), created.take.id, "  Drum Bus V2  ");
+    require(renamed.ok, "Failed to rename Take");
+    require(renamed.take.name == "Drum Bus V2", "Rename should trim whitespace");
+    auto renamedManifest = TakeManager::loadManifest(projectPath.string());
+    require(renamedManifest.ok, "Failed to reload manifest after rename");
+    const auto* renamedTake = renamedManifest.findTake(created.take.id);
+    require(renamedTake != nullptr && renamedTake->name == "Drum Bus V2", "Rename did not persist");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *renamedTake)) ==
+                "Variation Saved Lane",
+            "Rename must not modify the take snapshot");
+    require(!TakeManager::renameTake(projectPath.string(), created.take.id, "   ").ok,
+            "Blank take names must be rejected");
+    require(!TakeManager::renameTake(projectPath.string(), "no_such_take", "X").ok,
+            "Renaming a missing take must fail");
+
+    // --- Duplicate: non-destructive copy, records lineage, stays inactive ----
+    auto duplicated = TakeManager::duplicateTake(projectPath.string(), created.take.id);
+    require(duplicated.ok, "Failed to duplicate Take");
+    require(duplicated.take.parentId == created.take.id, "Duplicate should record its source as parent");
+    require(duplicated.take.name == "Drum Bus V2 Copy", "Duplicate should derive a Copy name");
+    require(duplicated.manifest.activeTakeId == "main", "Duplicating must not change the active take");
+    require(duplicated.manifest.takes.size() == 3, "Duplicate should add a manifest entry");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), duplicated.take)) ==
+                "Variation Saved Lane",
+            "Duplicate snapshot should be a copy of its source");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *renamedTake)) ==
+                "Variation Saved Lane",
+            "Duplicating must not modify the source snapshot");
+    require(!TakeManager::duplicateTake(projectPath.string(), "no_such_take").ok,
+            "Duplicating a missing take must fail");
+
+    // --- Branch flow: duplicate + activate leaves every prior take intact ----
+    auto branch = TakeManager::duplicateTake(projectPath.string(), "main", "Main Branch");
+    require(branch.ok, "Failed to create branch duplicate");
+    auto branchActive = TakeManager::setActiveTake(projectPath.string(), branch.take.id);
+    require(branchActive.ok, "Failed to activate branch take");
+    auto branchedManifest = TakeManager::loadManifest(projectPath.string());
+    require(branchedManifest.ok, "Failed to reload manifest after branching");
+    require(branchedManifest.activeTakeId == branch.take.id, "Branch take should be active");
+    const auto* branchEntry = branchedManifest.findTake(branch.take.id);
+    require(branchEntry != nullptr && branchEntry->parentId == "main", "Branch should descend from Main");
+    const auto* mainAfterBranch = branchedManifest.findTake("main");
+    require(mainAfterBranch != nullptr, "Main take must survive branching");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *mainAfterBranch)) ==
+                "Main Lane",
+            "Branching must not modify the Main snapshot");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *branchEntry)) == "Main Lane",
+            "Branch snapshot should start from its source state");
+
     std::cout << "[PASS] TakeManagerTest\n";
     return 0;
 }


### PR DESCRIPTION
## Summary

Replaces the File-menu **Takes** / **Project History** submenus with proper workspace panels, keeping a strict conceptual boundary:

- **History panel** — *"what actions did I perform?"* The session command timeline (undo/redo stacks) with clickable navigation and a HEAD marker. `File → History` opens it (Ctrl+H unchanged). Also fixes a pre-existing bug where the panel tracked scroll but never applied it to rendering or hit-testing, so long timelines were unreachable.
- **Takes panel** (new) — *"which version of the work do I want?"* Lists the `TakeManager` manifest with lineage indentation and the active-take marker; toolbar (`+ NEW TAKE` / `SAVE ACTIVE`) plus per-selection actions: OPEN / RENAME (inline, keyboard-driven) / DUP / BRANCH / DELETE. The automatic save history surfaces as a restore-only **Recovery snapshots** section.

## Safety model

- The panel owns no project logic: data comes from providers, every action goes through bool-returning callbacks wired in `AestraApp::wireTakesPanel()`, so the save-before-switch rules stay in one place.
- Restores and branches always save the current state first; branch = save → duplicate → switch, so no prior take is ever modified.
- `TakeManager` gains `renameTake`, `duplicateTake` (snapshot copy, parent = source, never activates) and `deleteTake` (refuses the active take, reparents children, manifest write before snapshot removal).

## Integration

Follows the existing overlay-panel conventions end to end: `ViewType::Takes`, `ViewState` rect, drag/resize/clamp/maximize wiring, theme tokens, z-order via last-added overlay children. Inline rename claims component focus for the duration of the edit (printable characters arrive via the focused-component text path) and swallows keys so global shortcuts can't fire mid-edit.

## Verified in the live app

Driven end-to-end on desktop (menu → panel open → create → restart-persistence → rename → branch → delete → history undo navigation via row clicks). The live drive caught the rename focus bug and the washed-out hover, both fixed here.

## Tests

- `TakeManagerTest` (extended): rename trim/validation/persistence; duplicate lineage + source-snapshot immutability; branch flow; delete refusal for active take, child reparenting, snapshot removal.
- `TakesHistoryPanelTest` (new): panel opening semantics (hidden panels ignore input), history presentation + navigation + listener notification, take listing/depth, create/open/rename/branch/delete actions, keyboard rename incl. focus contract, non-destructive branching, failure-status surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added dedicated Takes and History workspace panels, replacing their File-menu submenus while preserving Ctrl+H behavior.
- Added take management UI for lineage, snapshots, creation, saving, opening, renaming, duplicating, branching, restoring, and deletion.
- Routed panel actions through app callbacks with save-before-switch and save-before-restore safeguards.
- Extended TakeManager with rename, duplicate, and delete operations, including child reparenting and snapshot cleanup.
- Improved History panel scrolling, hit-testing, navigation, hover styling, and HEAD positioning.
- Integrated both panels with workspace overlays, focus handling, resizing, theming, dragging, and keyboard input.
- Added regression coverage for panel workflows and expanded TakeManager lifecycle tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->