### PR TITLE
fix(render): destination-alpha blending + stronger light-mode text lift

### DIFF
--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -495,7 +495,7 @@ bool NUIRendererGL::initialize(int width, int height) {
 
     // Set initial state
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE); // Ensure we don't write to depth buffer in 2D mode
     glDisable(GL_CULL_FACE);
@@ -609,7 +609,7 @@ void NUIRendererGL::beginFrame() {
         glDisable(GL_FRAMEBUFFER_SRGB);
     }
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
     vertices_.clear();
     indices_.clear();
@@ -2542,7 +2542,7 @@ void NUIRendererGL::renderTextWithFont(const std::string& text, const NUIPoint& 
     // instead of the standard blend which gives: result = text * coverage^2 + bg * (1 - coverage)
     glBlendFunc(GL_ONE, GL_SRC_ALPHA);
     // Actually revert — pre-multiplied bleeds edges on dark backgrounds. Use standard.
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     
     // Pre-allocate vertex buffer space (4 vertices per glyph, 6 indices per glyph)
     // This avoids repeated vector resizing for large text blocks
@@ -2708,7 +2708,7 @@ void NUIRendererGL::renderTextWithFont(const std::string& text, const NUIPoint& 
     }
 
     // Restore blend func for non-text geometry
-    // glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // Already default
+    // glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA); // Already default
 }
 
 // ============================================================================
@@ -2823,7 +2823,7 @@ void NUIRendererGL::drawTexture(const NUIRect& bounds, const unsigned char* rgba
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
     glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
-    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.35f : 1.0f);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -3054,6 +3054,12 @@ uint32_t NUIRendererGL::getGLTextureId(uint32_t textureId) const {
     return it->second.glId;
 }
 
+// NOTE on blending: all default blend sites use glBlendFuncSeparate with
+// (ONE, ONE_MINUS_SRC_ALPHA) for the alpha channel. The classic
+// (SRC_ALPHA, ...) alpha blend squares coverage: text drawn at alpha a onto
+// an opaque cache texel left it at 1-a+a^2 < 1, so composites re-blended
+// glyphs against the surface behind the panel — invisible over dark themes,
+// a gray wash over light ones (and sub-1.0 backbuffer alpha for DWM).
 void NUIRendererGL::beginOffscreen(int width, int height) {
     // Offscreen caches render into linear GL_RGBA8 textures where
     // GL_FRAMEBUFFER_SRGB does NOT re-encode on write. The shader's
@@ -3129,7 +3135,7 @@ void NUIRendererGL::flush() {
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
     glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
-    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.35f : 1.0f);
     // Note: opacity is already in vertex colors
     glUniform1i(primitiveShader_.primitiveTypeLoc, currentPrimitiveType_);
     // Default to no texturing; enable below if a texture is bound
@@ -3218,7 +3224,7 @@ bool NUIRendererGL::initializeGL() {
     
     // Enable blending for transparency
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     
     // OpenGL context should already be created by platform layer
     return true;


### PR DESCRIPTION
## Summary

Two rendering fixes found tracing the light-mode text wash (follow-up to #523):

1. **Destination-alpha corruption**: all default blend sites move to `glBlendFuncSeparate` with `(ONE, ONE_MINUS_SRC_ALPHA)` on the alpha channel. The classic `(SRC_ALPHA, …)` alpha blend squares coverage — drawing at alpha *a* onto an opaque texel left it at `1−a+a² < 1`, so offscreen-cache composites re-blended content against whatever sat behind the panel (invisible over dark themes, a wash over light), and the backbuffer could carry sub-1.0 alpha (the DWM sheet-of-glass hazard the codebase already guards against).

2. **Linear-blend polarity compensation**: `GL_FRAMEBUFFER_SRGB` blends in linear space, which shifts alpha-faded text asymmetrically — white at α 0.82 over near-black reads ~0.92 (a boost; why dark mode always looked right), while dark at α 0.82 over white reads ~0.45 (the wash). The light-theme text alpha lift strengthens from `a^0.72` to `a^0.35` to restore the perceptual fade the authored alphas were tuned against. Dark themes remain exactly neutral (`1.0`).

## Known remainder (deliberately deferred)
Some cached-surface blacks still read washed in light mode; owner deferred further tracing ("future us's problem"). The investigated/eliminated paths (cache gamma, NEAREST filtering, alpha squaring) and the remaining suspects are documented in the theme-arc notes.

## Validation
- Full app builds clean; exercised interactively in light and dark by the owner across the trace iterations (whites confirmed improved; dark mode unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated OpenGL blending to preserve destination alpha and prevent compositing artifacts in cached surfaces and backbuffers.
- Increased light-theme text alpha compensation from `0.72` to `0.35` to improve text contrast with linear-space sRGB blending; dark themes are unchanged.
- Applied the blending and text-lift behavior consistently across initialization, per-frame setup, texture uploads, and batched text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->