### PR TITLE
feat(muse): MuseRepl — JSONL stdin/stdout entry point to the agentic runtime

### DIFF
--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -26,6 +26,8 @@ struct CommandSchema {
 
 namespace MuseGrammar {
     const std::vector<CommandSchema>& allCommands();
+    /** @brief The full command schema as a JSON string — the agent tool manifest. */
+    std::string schemaToJsonString();
     void exportSchemaToJson(const std::string& outputPath);
 }
 

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <fstream>
+#include <sstream>
 
 namespace Aestra {
 namespace Audio {
@@ -77,11 +78,8 @@ const std::vector<CommandSchema>& allCommands() {
     return s_schemas;
 }
 
-void exportSchemaToJson(const std::string& outputPath) {
-    std::ofstream out(outputPath);
-    if (!out.is_open())
-        return;
-
+std::string schemaToJsonString() {
+    std::ostringstream out;
     out << "[\n";
     for (size_t i = 0; i < s_schemas.size(); ++i) {
         const auto& cmd = s_schemas[i];
@@ -127,6 +125,14 @@ void exportSchemaToJson(const std::string& outputPath) {
         out << "\n";
     }
     out << "]\n";
+    return out.str();
+}
+
+void exportSchemaToJson(const std::string& outputPath) {
+    std::ofstream out(outputPath);
+    if (!out.is_open())
+        return;
+    out << schemaToJsonString();
 }
 
 } // namespace MuseGrammar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,47 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessMain.cpp")
   message(STATUS "AestraHeadless configured")
 endif()
 
+# =============================================================================
+# MuseRepl - Agentic runtime entry point (JSONL over stdin/stdout, no UI)
+# =============================================================================
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/MuseReplMain.cpp")
+  add_executable(MuseRepl
+    Source/App/MuseReplMain.cpp
+  )
+
+  if(MSVC)
+    target_compile_options(MuseRepl PRIVATE /utf-8)
+  endif()
+
+  set_target_properties(MuseRepl PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+
+  target_link_libraries(MuseRepl PRIVATE
+    AestraAudioCore
+    AestraCore
+  )
+
+  target_include_directories(MuseRepl PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+  )
+
+  if(WIN32)
+    target_compile_definitions(MuseRepl PRIVATE
+      _CRT_SECURE_NO_WARNINGS
+      NOMINMAX
+    )
+  endif()
+
+  message(STATUS "MuseRepl configured")
+endif()
+
 if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessExportMain.cpp")
   add_executable(AestraHeadlessExport
     Source/App/HeadlessExportMain.cpp

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -1,0 +1,97 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// MuseRepl — the stdin/stdout entry point to Aestra's agentic runtime.
+//
+// One JSON request per input line, one JSON response per output line
+// (JSONL both ways). Everything goes through MuseService: the same schema
+// validation, command factories, and undo history the UI uses. This is how
+// an external agent (or a human with a pipe) drives a headless session:
+//
+//   $ MuseRepl <<'EOF'
+//   {"id": 1, "verb": "set_bpm", "args": {"value": 142}}
+//   {"id": 2, "verb": "add_track", "args": {"name": "Drums"}}
+//   {"id": 3, "verb": "list_tracks"}
+//   EOF
+//
+// Flags:
+//   --schema      print the MuseGrammar command schema as JSON and exit
+//                 (the agent's tool manifest)
+//   --sample-rate <hz>  engine sample rate (default 48000)
+
+#include "AudioEngine.h"
+#include "Commands/CommandRegistry.h"
+#include "Commands/MuseGrammar.h"
+#include "Commands/MuseService.h"
+#include "TrackManager.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace Aestra::Audio;
+
+int main(int argc, char** argv) {
+    uint32_t sampleRate = 48000;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--schema") {
+            std::cout << MuseGrammar::schemaToJsonString();
+            return 0;
+        }
+        if (arg == "--sample-rate" && i + 1 < argc) {
+            const long parsed = std::strtol(argv[++i], nullptr, 10);
+            if (parsed >= 8000 && parsed <= 192000) {
+                sampleRate = static_cast<uint32_t>(parsed);
+            } else {
+                std::cerr << "invalid --sample-rate, using 48000\n";
+            }
+            continue;
+        }
+        if (arg == "--help" || arg == "-h") {
+            std::cout << "MuseRepl: JSONL in on stdin, JSONL out on stdout.\n"
+                         "  --schema             print command schema JSON and exit\n"
+                         "  --sample-rate <hz>   engine sample rate (default 48000)\n";
+            return 0;
+        }
+        std::cerr << "unknown argument: " << arg << "\n";
+        return 2;
+    }
+
+    // Session setup mirrors the app's wiring: TrackManager owns the model and
+    // history, AudioEngine owns transport/tempo, the registry binds both.
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputChannelCount(0);
+
+    AudioEngine engine;
+    engine.setSampleRate(sampleRate);
+    engine.setBufferConfig(512, 2);
+
+    CommandRegistry::initialize(trackManager.get());
+    CommandRegistry::setAudioEngine(&engine);
+
+    MuseService service(trackManager.get(), &engine);
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        // Skip blank lines so hand-driven sessions can space things out.
+        bool blank = true;
+        for (char c : line) {
+            if (!std::isspace(static_cast<unsigned char>(c))) {
+                blank = false;
+                break;
+            }
+        }
+        if (blank) continue;
+
+        std::cout << service.handleRequest(line) << "\n";
+        std::cout.flush();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## What

The first external entry point to Muse: a headless \`MuseRepl\` executable that reads one JSON request per stdin line and writes one JSON response per stdout line, all through the \`MuseService\` surface merged in #526. This is how an external process (a script, a model harness, a human with a pipe) drives an Aestra session without the GUI.

\`\`\`
$ MuseRepl <<'REQS'
{"id": 1, "verb": "set_bpm", "args": {"value": 142}}
{"id": 2, "verb": "add_track", "args": {"name": "Drums"}}
{"id": 3, "verb": "get_session_state"}
REQS
\`\`\`

## How

- **\`Source/App/MuseReplMain.cpp\`** — session wiring mirrors the app: \`TrackManager\` (model + command history) + \`AudioEngine\` (transport/tempo) + \`CommandRegistry::initialize\` / \`setAudioEngine\`, then a \`MuseService\` on top. getline loop, blank lines skipped, response flushed per line so pipes stay interactive.
- **Flags**: \`--schema\` prints the MuseGrammar command schema as JSON and exits (the agent's tool manifest); \`--sample-rate <hz>\` (8000–192000, default 48000); \`--help\`.
- **CMake**: new \`MuseRepl\` target next to \`AestraHeadless\`, links \`AestraAudioCore\` + \`AestraCore\` only — no UI dependency.

## Why JSONL over stdin

Per the agreed Muse architecture: the structured JSON service is the contract; entry points are thin adapters over it. stdin/stdout is the smallest possible adapter — testable with a heredoc, composable with any harness, and it exercises the exact surface a future socket/in-app entry will reuse.

## Validation

- Built on Linux; smoke-tested end-to-end through a pipe: \`set_bpm 142\` → \`add_track Drums\` → invalid query args (rejected with \`validation_error\`) → \`get_session_state\` full readback, sub-millisecond per command.
- \`MuseServiceTest\` (30 assertions) covers the underlying surface; the REPL adds no logic beyond arg parsing and the line loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `MuseRepl`, a headless JSONL interface for the Muse runtime, supporting schema/help output, configurable sample rates, blank-line skipping, and flushed responses.
- Wired `MuseRepl` into CMake as an executable linked to `AestraAudioCore` and `AestraCore`.
- Added `MuseGrammar::schemaToJsonString()` to expose the command manifest and reuse it in file exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->