### PR TITLE
fix(serialization): stable identities — save→load→save is byte-identical

### DIFF
--- a/AestraAudio/include/AestraUUID.h
+++ b/AestraAudio/include/AestraUUID.h
@@ -57,6 +57,41 @@ struct AestraUUID {
         snprintf(buf, sizeof(buf), "%016" PRIx64 "%016" PRIx64, high, low);
         return std::string(buf);
     }
+
+    /**
+     * @brief Parse the toString() representation (32 lowercase/uppercase hex chars).
+     * @param str Candidate string.
+     * @param out Receives the parsed UUID on success (untouched on failure).
+     * @return true when the string is exactly 32 hex characters.
+     */
+    static bool tryParse(const std::string& str, AestraUUID& out) {
+        if (str.size() != 32) {
+            return false;
+        }
+        uint64_t parsedHigh = 0;
+        uint64_t parsedLow = 0;
+        for (size_t i = 0; i < 32; ++i) {
+            const char c = str[i];
+            uint64_t digit;
+            if (c >= '0' && c <= '9') {
+                digit = static_cast<uint64_t>(c - '0');
+            } else if (c >= 'a' && c <= 'f') {
+                digit = static_cast<uint64_t>(c - 'a') + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                digit = static_cast<uint64_t>(c - 'A') + 10;
+            } else {
+                return false;
+            }
+            if (i < 16) {
+                parsedHigh = (parsedHigh << 4) | digit;
+            } else {
+                parsedLow = (parsedLow << 4) | digit;
+            }
+        }
+        out.high = parsedHigh;
+        out.low = parsedLow;
+        return true;
+    }
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -23,12 +23,18 @@ struct ClipInstanceID : public AestraUUID {
     bool isValid() const { return low != 0 || high != 0; }
 
     /**
-     * @brief Parse from string (stub - just returns generate())
+     * @brief Parse the toString() representation.
+     * @return The parsed ID, or an invalid (zero) ID when the string doesn't
+     *         parse — callers mint a fresh ID for invalid ones, which keeps
+     *         old project files (without clip ids) loading fine while saved
+     *         ids stay stable across load cycles (#446).
      */
     static ClipInstanceID fromString(const std::string& str) {
-        // Stub implementation - in real code would parse UUID string
-        (void)str;
-        return generate();
+        AestraUUID parsed;
+        if (AestraUUID::tryParse(str, parsed)) {
+            return ClipInstanceID(parsed);
+        }
+        return ClipInstanceID();
     }
 };
 

--- a/AestraAudio/include/Models/PatternManager.h
+++ b/AestraAudio/include/Models/PatternManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "PatternSource.h"
 
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -195,9 +196,12 @@ private:
      *
      * Valid + unused requested IDs are restored verbatim and the mint counter
      * jumps past them so later mints can never collide with restored IDs.
+     * UINT64_MAX is never restored: bumping the counter past it would wrap
+     * to zero and poison every later mint.
      */
     PatternID claimId(PatternID requestedId) {
-        if (requestedId.isValid() && m_patterns.find(requestedId.value) == m_patterns.end()) {
+        if (requestedId.isValid() && requestedId.value != std::numeric_limits<uint64_t>::max()
+            && m_patterns.find(requestedId.value) == m_patterns.end()) {
             if (requestedId.value >= nextId) {
                 nextId = requestedId.value + 1;
             }

--- a/AestraAudio/include/Models/PatternManager.h
+++ b/AestraAudio/include/Models/PatternManager.h
@@ -56,7 +56,23 @@ public:
      * @return Identifier of the created audio pattern.
      */
     PatternID createAudioPattern(const std::string& name, double lengthBeats, const AudioSlicePayload& payload) {
-        PatternID id{nextId++};
+        return createAudioPatternWithId(PatternID{}, name, lengthBeats, payload);
+    }
+
+    /**
+     * @brief Create an audio pattern restoring a serialized identity (#446).
+     *
+     * When @p requestedId is valid and unused it becomes the pattern's ID and
+     * the mint counter advances past it; otherwise a fresh ID is minted.
+     * @param requestedId Serialized pattern ID to restore (invalid = mint).
+     * @param name Pattern display name.
+     * @param lengthBeats Pattern duration in beats.
+     * @param payload Audio pattern payload.
+     * @return Identifier of the created audio pattern.
+     */
+    PatternID createAudioPatternWithId(PatternID requestedId, const std::string& name, double lengthBeats,
+                                       const AudioSlicePayload& payload) {
+        const PatternID id = claimId(requestedId);
         auto pattern = std::make_unique<PatternSource>();
         pattern->id = id;
         pattern->name = name;
@@ -75,7 +91,23 @@ public:
      * @return Identifier of the created MIDI pattern.
      */
     PatternID createMidiPattern(const std::string& name, double lengthBeats, const MidiPayload& payload) {
-        PatternID id{nextId++};
+        return createMidiPatternWithId(PatternID{}, name, lengthBeats, payload);
+    }
+
+    /**
+     * @brief Create a MIDI pattern restoring a serialized identity (#446).
+     *
+     * When @p requestedId is valid and unused it becomes the pattern's ID and
+     * the mint counter advances past it; otherwise a fresh ID is minted.
+     * @param requestedId Serialized pattern ID to restore (invalid = mint).
+     * @param name Pattern display name.
+     * @param lengthBeats Pattern duration in beats.
+     * @param payload MIDI pattern payload.
+     * @return Identifier of the created MIDI pattern.
+     */
+    PatternID createMidiPatternWithId(PatternID requestedId, const std::string& name, double lengthBeats,
+                                      const MidiPayload& payload) {
+        const PatternID id = claimId(requestedId);
         auto pattern = std::make_unique<PatternSource>();
         pattern->id = id;
         pattern->name = name;
@@ -158,6 +190,22 @@ public:
     }
 
 private:
+    /**
+     * @brief Resolve the ID a new pattern should use.
+     *
+     * Valid + unused requested IDs are restored verbatim and the mint counter
+     * jumps past them so later mints can never collide with restored IDs.
+     */
+    PatternID claimId(PatternID requestedId) {
+        if (requestedId.isValid() && m_patterns.find(requestedId.value) == m_patterns.end()) {
+            if (requestedId.value >= nextId) {
+                nextId = requestedId.value + 1;
+            }
+            return requestedId;
+        }
+        return PatternID{nextId++};
+    }
+
     uint64_t nextId{1};
     std::unordered_map<uint64_t, std::unique_ptr<PatternSource>> m_patterns;
 };

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -81,10 +81,26 @@ public:
      * @return Identifier of the created lane.
      */
     PlaylistLaneID createLane(const std::string& name = "") {
+        return createLaneWithId(PlaylistLaneID{}, name);
+    }
+
+    /**
+     * @brief Create a lane restoring a serialized identity (#446).
+     *
+     * A valid, unused requested ID becomes the lane's ID; an invalid or taken
+     * one falls back to the generated ID so old files keep loading.
+     * @param requestedId Serialized lane ID to restore (invalid = generate).
+     * @param name Lane display name.
+     * @return The created lane's ID.
+     */
+    PlaylistLaneID createLaneWithId(const PlaylistLaneID& requestedId, const std::string& name = "") {
         std::unique_lock<std::shared_mutex> lock(m_mutex);
 
         PlaylistLane lane(static_cast<int>(m_lanes.size()));
         lane.name = name.empty() ? "Track " + std::to_string(lane.index + 1) : name;
+        if (requestedId.isValid() && m_laneMap.find(requestedId) == m_laneMap.end()) {
+            lane.id = requestedId;
+        }
 
         PlaylistLaneID id = lane.id;
         m_lanes.push_back(std::move(lane));

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -2,6 +2,7 @@
 #include "ClipSource.h"
 
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -44,7 +45,9 @@ public:
      * Path is still the dedupe key: an existing source for @p filePath wins
      * regardless of the requested ID. Otherwise a valid, unused requested ID
      * is restored verbatim (advancing the mint counter past it) and an
-     * invalid or taken ID falls back to a fresh mint.
+     * invalid or taken ID falls back to a fresh mint. UINT64_MAX is never
+     * restored: bumping the counter past it would wrap to zero and poison
+     * every later mint.
      * @param requestedId Serialized source ID to restore (invalid = mint).
      * @param filePath Source file path (dedupe key).
      * @param displayName Optional user-facing name.
@@ -58,7 +61,8 @@ public:
         }
 
         ClipSourceID id{};
-        if (requestedId.isValid() && m_sources.find(requestedId.value) == m_sources.end()) {
+        if (requestedId.isValid() && requestedId.value != std::numeric_limits<uint64_t>::max()
+            && m_sources.find(requestedId.value) == m_sources.end()) {
             id = requestedId;
             if (requestedId.value >= nextId) {
                 nextId = requestedId.value + 1;

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -39,6 +39,44 @@ public:
     }
 
     /**
+     * @brief Get or create a source restoring a serialized identity (#446).
+     *
+     * Path is still the dedupe key: an existing source for @p filePath wins
+     * regardless of the requested ID. Otherwise a valid, unused requested ID
+     * is restored verbatim (advancing the mint counter past it) and an
+     * invalid or taken ID falls back to a fresh mint.
+     * @param requestedId Serialized source ID to restore (invalid = mint).
+     * @param filePath Source file path (dedupe key).
+     * @param displayName Optional user-facing name.
+     * @return Source ID (returns ClipSourceID{0} on failure)
+     */
+    ClipSourceID getOrCreateSourceWithId(ClipSourceID requestedId, const std::string& filePath,
+                                         const std::string& displayName = {}) {
+        auto it = m_pathToId.find(filePath);
+        if (it != m_pathToId.end()) {
+            return it->second;
+        }
+
+        ClipSourceID id{};
+        if (requestedId.isValid() && m_sources.find(requestedId.value) == m_sources.end()) {
+            id = requestedId;
+            if (requestedId.value >= nextId) {
+                nextId = requestedId.value + 1;
+            }
+        } else {
+            id = ClipSourceID{nextId++};
+        }
+
+        auto source = std::make_unique<ClipSource>(id, displayName.empty() ? makeDisplayName(filePath) : displayName);
+        source->setFilePath(filePath);
+
+        m_sources[id.value] = std::move(source);
+        m_pathToId[filePath] = id;
+
+        return id;
+    }
+
+    /**
      * @brief Create or replace a source for a recorded take.
      * @param filePath Stable file path written for the take.
      * @param displayName User-facing clip name.

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -697,6 +697,10 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
     // 1. Save Sources
     JSON sourcesJson = JSON::array();
     std::vector<ClipSourceID> sourceIds = sourceManager.getAllSourceIDs();
+    // Deterministic order: the store is an unordered_map, and byte-stable
+    // save→load→save (#446) needs identical array order every time.
+    std::sort(sourceIds.begin(), sourceIds.end(),
+              [](const ClipSourceID& a, const ClipSourceID& b) { return a.value < b.value; });
     for (const auto& id : sourceIds) {
         if (const auto* source = sourceManager.getSource(id)) {
             JSON s = JSON::object();
@@ -712,6 +716,11 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
     // 2. Save Patterns
     JSON patternsJson = JSON::array();
     std::vector<std::shared_ptr<PatternSource>> patterns = patternManager.getAllPatterns();
+    // Deterministic order (see sources note above / #446).
+    std::sort(patterns.begin(), patterns.end(),
+              [](const std::shared_ptr<PatternSource>& a, const std::shared_ptr<PatternSource>& b) {
+                  return a->id.value < b->id.value;
+              });
     for (const auto& p : patterns) {
         JSON pjs = JSON::object();
         pjs.set("id", JSON(static_cast<double>(p->id.value)));
@@ -1371,7 +1380,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 std::filesystem::path resolvedPath = resolveProjectAssetPath(assetRoot, storedPath);
                 const std::string sourcePath = storedPath; // Use original storedPath for serialization
                 const std::string filePath = resolvedPath.string(); // Use resolvedPath only for file I/O
-                ClipSourceID newId = sourceManager.getOrCreateSource(sourcePath);
+                // Restore the serialized source identity (#446); the idMap
+                // remains for files whose ids collide or fail to restore.
+                ClipSourceID newId = sourceManager.getOrCreateSourceWithId(ClipSourceID{oldId}, sourcePath);
                 idMap[oldId] = newId;
                 const bool assetReadable =
                     std::filesystem::exists(resolvedPath) && std::filesystem::is_regular_file(resolvedPath);
@@ -1463,7 +1474,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                 payload.slices.push_back(slice);
                             }
                         }
-                        PatternID newId = patternManager.createAudioPattern(name, length, payload);
+                        // Restore serialized pattern identity (#446); the map
+                        // still covers collision/mint fallbacks.
+                        PatternID newId = patternManager.createAudioPatternWithId(PatternID{oldId}, name, length, payload);
                         patternMap[oldId] = newId;
                     }
                 } else {
@@ -1487,7 +1500,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             payload.notes.push_back(note);
                         }
                     }
-                    PatternID newId = patternManager.createMidiPattern(name, length, payload);
+                    // Restore serialized pattern identity (#446), as above.
+                    PatternID newId = patternManager.createMidiPatternWithId(PatternID{oldId}, name, length, payload);
                     patternMap[oldId] = newId;
     
                     // Deserialize scale context if present
@@ -1539,6 +1553,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         }
     
         // 4. Load Lanes and Clips
+        // Clip ids restored from the file must stay unique — a hand-edited or
+        // corrupted file with duplicates would silently break id lookups.
+        std::unordered_set<AestraUUID> seenClipIds;
         if (root.has("lanes")) {
             const JSON& lj = root["lanes"];
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
@@ -1549,7 +1566,17 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 Log::info("[ProjectLoad] Lane[" + std::to_string(i) + "] name='" + lj[i]["name"].asString() + "'");
         #endif
                 const std::string laneName = boundedStringOr(lj[i], "name", "Track", PROJECT_MAX_STRING_BYTES);
-                PlaylistLaneID laneId = playlist.createLane(laneName);
+                // Restore the serialized lane identity so save→load→save is
+                // id-stable (#446); invalid/missing ids fall back to minting.
+                PlaylistLaneID storedLaneId;
+                {
+                    AestraUUID parsedLaneId;
+                    if (AestraUUID::tryParse(boundedStringOr(lj[i], "id", "", PROJECT_MAX_STRING_BYTES),
+                                             parsedLaneId)) {
+                        storedLaneId = PlaylistLaneID(parsedLaneId);
+                    }
+                }
+                PlaylistLaneID laneId = playlist.createLaneWithId(storedLaneId, laneName);
                 if (!laneId.isValid()) {
                     warningLimiter.warning(
                         ProjectLoadWarningCategory::LaneCreate,
@@ -1722,6 +1749,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             if (patternMap.count(oldPatId)) {
                                 ClipInstance clip;
                                 clip.id = ClipInstanceID::fromString(boundedStringOr(cj[c], "id", "", PROJECT_MAX_STRING_BYTES));
+                                if (clip.id.isValid() && !seenClipIds.insert(clip.id).second) {
+                                    clip.id = ClipInstanceID(); // duplicate in file — mint below
+                                }
                                 clip.patternId = patternMap[oldPatId];
                                 clip.sourceId = clip.patternId.value;
                                 clip.startBeat = finiteNumberOr(cj[c], "start", 0.0, 0.0, 1000000.0);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -259,6 +259,33 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectValueFidelityTest.cpp"
     set_tests_properties(ProjectValueFidelityTest PROPERTIES LABELS "integration;serialization")
 endif()
 
+# Identity stability (#446): serialized clip/lane/pattern/source IDs survive
+# load, save->load->save is a byte-identical fixed point, post-load mints
+# never collide with restored IDs.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectIdentityStabilityTest.cpp")
+    add_executable(ProjectIdentityStabilityTest
+        Integration/ProjectIdentityStabilityTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(ProjectIdentityStabilityTest PRIVATE AestraAudio)
+    target_include_directories(ProjectIdentityStabilityTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    add_test(NAME ProjectIdentityStabilityTest COMMAND ProjectIdentityStabilityTest)
+    set_tests_properties(ProjectIdentityStabilityTest PROPERTIES LABELS "integration;serialization;identity")
+endif()
+
 # Project Load Regression Tests (routing safety, missing references, non-destructive load)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectLoadRegressionTest.cpp")
     add_executable(ProjectLoadRegressionTest

--- a/Tests/Integration/ProjectIdentityStabilityTest.cpp
+++ b/Tests/Integration/ProjectIdentityStabilityTest.cpp
@@ -17,6 +17,8 @@
 //   - AestraUUID::tryParse round-trips toString() and rejects garbage
 //     (invalid/absent ids keep minting, so legacy files still load)
 //   - duplicate clip ids in a hand-edited file are re-minted, not aliased
+//   - UINT64_MAX pattern/source ids are re-minted (restoring would wrap the
+//     mint counter to zero and poison every later mint)
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../Support/TestTempDirectory.h"
@@ -29,6 +31,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -254,6 +257,27 @@ int main() {
         auto dupClipIds = collectClipIds(*tmDup);
         require(dupClipIds.size() == 2, "both clips must survive a duplicate-id file");
         require(dupClipIds[0] != dupClipIds[1], "duplicate clip ids must be re-minted, not aliased");
+    }
+
+    // ---------------- UINT64_MAX ids are re-minted (restoring would wrap the counter)
+    {
+        constexpr uint64_t maxId = std::numeric_limits<uint64_t>::max();
+
+        PatternManager pm;
+        const PatternID cappedPat = pm.createAudioPatternWithId(PatternID{maxId}, "max", 4.0, AudioSlicePayload{});
+        require(cappedPat.isValid() && cappedPat.value != maxId,
+                "UINT64_MAX pattern id must be re-minted, not restored");
+        const PatternID afterCapPat = pm.createAudioPattern("next", 4.0, AudioSlicePayload{});
+        require(afterCapPat.isValid() && afterCapPat.value != cappedPat.value,
+                "pattern mint after a UINT64_MAX request must stay valid and unique");
+
+        SourceManager sm;
+        const ClipSourceID cappedSrc = sm.getOrCreateSourceWithId(ClipSourceID{maxId}, (tempDir / "max_a.wav").string());
+        require(cappedSrc.isValid() && cappedSrc.value != maxId,
+                "UINT64_MAX source id must be re-minted, not restored");
+        const ClipSourceID afterCapSrc = sm.getOrCreateSourceWithId(ClipSourceID{}, (tempDir / "max_b.wav").string());
+        require(afterCapSrc.isValid() && afterCapSrc.value != cappedSrc.value,
+                "source mint after a UINT64_MAX request must stay valid and unique");
     }
 
     std::cout << "[PASS] ProjectIdentityStabilityTest\n";

--- a/Tests/Integration/ProjectIdentityStabilityTest.cpp
+++ b/Tests/Integration/ProjectIdentityStabilityTest.cpp
@@ -1,0 +1,261 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// ProjectIdentityStabilityTest (#446) — serialized identities must survive
+// load, and save→load→save must be a byte-identical fixed point.
+//
+// Before this fix the loader re-minted clip UUIDs, pattern IDs, lane IDs and
+// source IDs on every load (remapping references so semantics survived but
+// identity didn't), and the writer emitted patterns/sources in unordered_map
+// order. Consequences: no whole-file fixed-point regression gate, and no
+// stable identity for Takes across sessions, diffing, or external references.
+//
+// Asserted here:
+//   - clip / pattern / lane / source IDs are identical after a load cycle
+//   - save→load→save produces byte-identical project contents (fixed point),
+//     and stays identical over a further generation (idempotence)
+//   - IDs minted AFTER a load never collide with restored IDs
+//   - AestraUUID::tryParse round-trips toString() and rejects garbage
+//     (invalid/absent ids keep minting, so legacy files still load)
+//   - duplicate clip ids in a hand-edited file are re-minted, not aliased
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
+#include "Models/ClipSource.h"
+#include "Models/PatternSource.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager loading).
+bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
+    if (sampleRate <= 0 || numSamples <= 0)
+        return false;
+    const int numChannels = 1;
+    const int bitsPerSample = 16;
+    const int bytesPerSample = bitsPerSample / 8;
+    const int blockAlign = numChannels * bytesPerSample;
+    const int byteRate = sampleRate * blockAlign;
+    const std::uint32_t dataSize = static_cast<std::uint32_t>(numSamples * blockAlign);
+
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out)
+        return false;
+    auto writeU32 = [&](std::uint32_t v) { out.write(reinterpret_cast<const char*>(&v), 4); };
+    auto writeU16 = [&](std::uint16_t v) { out.write(reinterpret_cast<const char*>(&v), 2); };
+    out.write("RIFF", 4);
+    writeU32(36u + dataSize);
+    out.write("WAVE", 4);
+    out.write("fmt ", 4);
+    writeU32(16u);
+    writeU16(1u); // PCM
+    writeU16(static_cast<std::uint16_t>(numChannels));
+    writeU32(static_cast<std::uint32_t>(sampleRate));
+    writeU32(static_cast<std::uint32_t>(byteRate));
+    writeU16(static_cast<std::uint16_t>(blockAlign));
+    writeU16(static_cast<std::uint16_t>(bitsPerSample));
+    out.write("data", 4);
+    writeU32(dataSize);
+    std::vector<char> silence(dataSize, 0);
+    out.write(silence.data(), static_cast<std::streamsize>(silence.size()));
+    return static_cast<bool>(out);
+}
+
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+std::vector<std::string> collectClipIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<std::string> ids;
+    auto& playlist = tm.getPlaylistModel();
+    for (const auto& laneId : playlist.getLaneIDs()) {
+        if (const auto* lane = playlist.getLane(laneId)) {
+            for (const auto& clip : lane->clips) {
+                ids.push_back(clip.id.toString());
+            }
+        }
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<std::string> collectLaneIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<std::string> ids;
+    for (const auto& laneId : tm.getPlaylistModel().getLaneIDs()) {
+        ids.push_back(laneId.toString());
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<uint64_t> collectPatternIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<uint64_t> ids;
+    for (const auto& p : tm.getPatternManager().getAllPatterns()) {
+        ids.push_back(p->id.value);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<uint64_t> collectSourceIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<uint64_t> ids;
+    for (const auto& id : tm.getSourceManager().getAllSourceIDs()) {
+        ids.push_back(id.value);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectIdentityStability"};
+    const auto& tempDir = tempDirScope.path();
+    const auto wavPath = tempDir / "identity.wav";
+    const auto projectPath = tempDir / "identity.aes";
+    require(writeMinimalWavMono16(wavPath, 48000, 4800), "could not write test WAV");
+
+    constexpr double kTempo = 120.0;
+    constexpr double kPlayhead = 0.0;
+
+    // ---------------- AestraUUID parsing contract
+    {
+        const AestraUUID original = AestraUUID::generate();
+        AestraUUID parsed;
+        require(AestraUUID::tryParse(original.toString(), parsed), "tryParse must accept toString output");
+        require(parsed == original, "tryParse(toString()) must round-trip exactly");
+        require(!AestraUUID::tryParse("", parsed), "empty string must not parse");
+        require(!AestraUUID::tryParse("not-a-uuid", parsed), "garbage must not parse");
+        require(!AestraUUID::tryParse(std::string(31, 'a'), parsed), "short string must not parse");
+        require(!AestraUUID::tryParse(std::string(31, 'a') + "g", parsed), "non-hex chars must not parse");
+        require(!ClipInstanceID::fromString("").isValid(), "legacy empty clip id must stay invalid (mint on add)");
+    }
+
+    // ---------------- Arrange: lanes, MIDI + audio patterns, clips
+    auto tm1 = std::make_shared<TrackManager>();
+    tm1->getPlaylistModel().setPatternManager(&tm1->getPatternManager());
+    auto& playlist1 = tm1->getPlaylistModel();
+    playlist1.setBPM(kTempo);
+
+    PlaylistLaneID laneAId = playlist1.createLane("Identity A");
+    auto* chanA = tm1->addChannel("Identity A");
+    PlaylistLaneID laneBId = playlist1.createLane("Identity B");
+    auto* chanB = tm1->addChannel("Identity B");
+    require(laneAId.isValid() && laneBId.isValid() && chanA && chanB, "setup: lanes/channels");
+
+    MidiPayload midi;
+    MidiNote note;
+    note.pitch = 64;
+    note.startBeat = 1.5;
+    note.durationBeats = 0.5;
+    note.velocity = 0.8f;
+    midi.notes.push_back(note);
+    PatternID midiPatId = tm1->getPatternManager().createMidiPattern("IdentityMelody", 8.0, midi);
+
+    ClipSourceID srcId = tm1->getSourceManager().getOrCreateSource(wavPath.string());
+    AudioSlicePayload slicePayload;
+    slicePayload.audioSourceId = srcId;
+    PatternID audioPatId = tm1->getPatternManager().createAudioPattern("IdentityAudio", 4.0, slicePayload);
+    require(midiPatId.isValid() && srcId.isValid() && audioPatId.isValid(), "setup: patterns/source");
+
+    ClipInstanceID midiClipId = playlist1.addClipFromPattern(laneAId, midiPatId, 0.0, 8.0);
+    ClipInstanceID audioClipId = playlist1.addClipFromPattern(laneBId, audioPatId, 4.0, 4.0);
+    require(midiClipId.isValid() && audioClipId.isValid(), "setup: clips");
+
+    const auto clipIds1 = collectClipIds(*tm1);
+    const auto laneIds1 = collectLaneIds(*tm1);
+    const auto patternIds1 = collectPatternIds(*tm1);
+    const auto sourceIds1 = collectSourceIds(*tm1);
+
+    // ---------------- Generation 2: identities must survive the load
+    auto ser1 = ProjectSerializer::serialize(tm1, kTempo, kPlayhead, 2);
+    require(ser1.ok && !ser1.contents.empty(), "generation-1 serialize failed");
+    require(ProjectSerializer::writeAtomically(projectPath.string(), ser1.contents), "generation-1 write failed");
+
+    auto tm2 = std::make_shared<TrackManager>();
+    tm2->getPlaylistModel().setPatternManager(&tm2->getPatternManager());
+    ProjectSerializer::LoadResult load1 = ProjectSerializer::load(projectPath.string(), tm2);
+    require(load1.ok, "generation-2 load failed");
+
+    require(collectClipIds(*tm2) == clipIds1, "clip UUIDs must survive load unchanged");
+    require(collectLaneIds(*tm2) == laneIds1, "lane UUIDs must survive load unchanged");
+    require(collectPatternIds(*tm2) == patternIds1, "pattern IDs must survive load unchanged");
+    require(collectSourceIds(*tm2) == sourceIds1, "source IDs must survive load unchanged");
+
+    // ---------------- Byte-stable fixed point + idempotence
+    auto ser2 = ProjectSerializer::serialize(tm2, load1.tempo, load1.playhead, 2);
+    require(ser2.ok, "generation-2 serialize failed");
+    require(ser2.contents == ser1.contents, "save->load->save must be byte-identical (fixed point)");
+
+    const auto gen3Path = tempDir / "identity_gen3.aes";
+    require(ProjectSerializer::writeAtomically(gen3Path.string(), ser2.contents), "generation-3 write failed");
+    auto tm3 = std::make_shared<TrackManager>();
+    tm3->getPlaylistModel().setPatternManager(&tm3->getPatternManager());
+    ProjectSerializer::LoadResult load2 = ProjectSerializer::load(gen3Path.string(), tm3);
+    require(load2.ok, "generation-3 load failed");
+    auto ser3 = ProjectSerializer::serialize(tm3, load2.tempo, load2.playhead, 2);
+    require(ser3.ok, "generation-3 serialize failed");
+    require(ser3.contents == ser2.contents, "fixed point must hold across further generations");
+
+    // ---------------- Collision safety: post-load mints never reuse restored IDs
+    {
+        const uint64_t maxPattern = patternIds1.back();
+        PatternID freshPattern = tm2->getPatternManager().createMidiPattern("PostLoad", 4.0, MidiPayload{});
+        require(freshPattern.value > maxPattern, "post-load pattern mint must exceed restored pattern IDs");
+
+        const uint64_t maxSource = sourceIds1.back();
+        const auto wav2 = tempDir / "identity2.wav";
+        require(writeMinimalWavMono16(wav2, 48000, 480), "could not write second WAV");
+        ClipSourceID freshSource = tm2->getSourceManager().getOrCreateSource(wav2.string());
+        require(freshSource.value > maxSource, "post-load source mint must exceed restored source IDs");
+
+        PlaylistLaneID freshLane = tm2->getPlaylistModel().createLane("PostLoad");
+        require(freshLane.isValid(), "post-load lane create failed");
+        auto laneIds2 = collectLaneIds(*tm2);
+        require(std::count(laneIds2.begin(), laneIds2.end(), freshLane.toString()) == 1,
+                "post-load lane ID must be unique");
+
+        ClipInstanceID freshClip =
+            tm2->getPlaylistModel().addClipFromPattern(freshLane, freshPattern, 0.0, 4.0);
+        require(freshClip.isValid(), "post-load clip create failed");
+        require(std::count(clipIds1.begin(), clipIds1.end(), freshClip.toString()) == 0,
+                "post-load clip UUID must not collide with restored clips");
+    }
+
+    // ---------------- Duplicate clip ids in a hand-edited file get re-minted
+    {
+        std::string mangled = ser1.contents;
+        const std::string fromId = audioClipId.toString();
+        const std::string toId = midiClipId.toString();
+        const size_t pos = mangled.find(fromId);
+        require(pos != std::string::npos, "mangle setup: audio clip id not found in contents");
+        mangled.replace(pos, fromId.size(), toId);
+
+        const auto dupPath = tempDir / "identity_dup.aes";
+        require(ProjectSerializer::writeAtomically(dupPath.string(), mangled), "duplicate-id write failed");
+        auto tmDup = std::make_shared<TrackManager>();
+        tmDup->getPlaylistModel().setPatternManager(&tmDup->getPatternManager());
+        ProjectSerializer::LoadResult loadDup = ProjectSerializer::load(dupPath.string(), tmDup);
+        require(loadDup.ok, "duplicate-id load failed");
+
+        auto dupClipIds = collectClipIds(*tmDup);
+        require(dupClipIds.size() == 2, "both clips must survive a duplicate-id file");
+        require(dupClipIds[0] != dupClipIds[1], "duplicate clip ids must be re-minted, not aliased");
+    }
+
+    std::cout << "[PASS] ProjectIdentityStabilityTest\n";
+    return 0;
+}

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -310,7 +310,10 @@ void testArsenalDefaultPatternRebindsAfterLoad() {
     const auto* unit = tm->getUnitManager().getUnit(7);
     assert(unit);
     assert(unit->defaultPatternId.isValid());
-    assert(unit->defaultPatternId.value != 42);
+    // Serialized pattern identity is restored on load since #446, so the
+    // rebind map resolves 42 -> 42. The binding itself (unit points at the
+    // pattern that carries its notes) is what this test guards.
+    assert(unit->defaultPatternId.value == 42);
 
     const auto* pattern = tm->getPatternManager().getPattern(unit->defaultPatternId);
     assert(pattern);

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -23,10 +23,10 @@
 // at beat 0; and the slice loader filling startOffset/duration instead of the
 // startSamples/lengthSamples fields the writer persists.
 //
-// NOT asserted here: byte-identical save->load->save output. Clip UUIDs and
-// pattern numeric IDs are re-minted by the loader (identity is session-scoped
-// today), which also reorders the patterns array between generations. Stable
-// persisted identity is tracked as its own serialization-cluster issue.
+// NOT asserted here: byte-identical save->load->save output and identity
+// stability — ProjectIdentityStabilityTest owns those (#446: the loader now
+// restores clip/lane UUIDs and pattern/source numeric IDs, and the writer
+// emits patterns/sources in sorted order).
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../Support/TestTempDirectory.h"


### PR DESCRIPTION
Closes #446.

## Problem

The loader re-minted every serialized identity: clip UUIDs (`ClipInstanceID::fromString` was a stub that ignored its input and called `generate()`), lane UUIDs (`createLane` always generates), and pattern/source numeric IDs (counter mints with old→new remaps). The writer also emitted the patterns and sources arrays in `unordered_map` order. References were remapped so *semantics* survived — but identity didn't:

- save→load→save could never be byte-identical → no cheap whole-file fixed-point regression gate
- nothing stable for Takes across sessions, collaborative diffing, or external references into a project

## Fix

- **`AestraUUID::tryParse`** parses the `toString()` form exactly; garbage/absent ids stay invalid, and invalid ids still mint on add — so legacy files (no clip/lane ids) keep loading unchanged.
- **Restore-with-id creators**: `PatternManager::create{Midi,Audio}PatternWithId`, `SourceManager::getOrCreateSourceWithId`, `PlaylistModel::createLaneWithId`. A valid, unused requested ID is restored verbatim and the mint counter jumps past it — post-load mints can never collide with restored IDs. Invalid/taken IDs fall back to minting, and the loader's existing remap maps cover that path.
- **Loader** restores all four identity families; duplicate clip ids in a hand-edited/corrupt file are re-minted rather than aliased.
- **Writer** sorts patterns and sources by ID for deterministic output.

## Side effect (pre-existing bug)

The `fromString` stub was silently breaking the clip drag-move drop path: it constructed `MoveClipCommand` against a freshly minted (nonexistent) ID while reporting "Clip moved" success. That path now fails honestly on an unparseable reference. (It turns out nothing populates `sourceClipIdString` for AudioClip drags today, so the path was doubly dead — worth its own look later.)

## Tests

- **New `ProjectIdentityStabilityTest`**: identity survival across load; byte-identical save→load→save fixed point held across two further generations; post-load mints exceed all restored IDs; UUID parse contract (round-trip + rejection); duplicate-clip-id re-minting.
- `ProjectRoundTripIntegrityTest`'s Arsenal-rebind assertion updated: it encoded the old re-minting contract (`defaultPatternId != 42`); identity is now restored so the rebind resolves 42→42 — the binding itself is still asserted.
- `ProjectValueFidelityTest` header note updated (byte-stability is now owned by the new test).
- Full local suite: 168/168 pass (excluding env-dependent `SecAccountApiClient`, which needs an account-API base URL and is already CI-excluded).

Part of the beta-gameplan serialization trust cluster ("sessions never lie") with #263/#249/#273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Restores serialized UUIDs and numeric IDs for clips, lanes, patterns, and sources during project loading.
- Adds collision-safe ID allocation, including fallback handling for invalid, missing, duplicate, or already-used IDs.
- Sorts patterns and sources deterministically during serialization, enabling byte-identical save→load→save cycles.
- Adds UUID parsing support and comprehensive identity-stability, collision, and fixed-point serialization tests.
- Updates existing round-trip tests to reflect restored identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->