### PR TITLE
feat(muse): vertical beat path — unit, sample, and note verbs

### DIFF
--- a/AestraAudio/include/Commands/AddUnitCommand.h
+++ b/AestraAudio/include/Commands/AddUnitCommand.h
@@ -1,0 +1,57 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/UnitManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to add an Arsenal unit (undoable)
+ *
+ * Creating a non-audio unit also creates its default MIDI pattern (via
+ * UnitManager). Undo removes the unit; the default pattern is left behind,
+ * matching how the Arsenal panel removes units. Like AddChannelCommand,
+ * redo after undo mints a fresh unit ID.
+ */
+class AddUnitCommand : public ICommand {
+public:
+    AddUnitCommand(UnitManager& unitManager, const std::string& name, UnitType type)
+        : m_unitManager(unitManager), m_name(name), m_type(type) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_createdUnitId = m_unitManager.createUnit(m_name, m_type);
+        m_unitManager.setUnitEnabled(m_createdUnitId, true);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        if (m_unitManager.removeUnit(m_createdUnitId)) {
+            m_executed = false;
+        }
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Add Unit"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    UnitManager& m_unitManager;
+    std::string m_name;
+    UnitType m_type;
+    UnitID m_createdUnitId{0};
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/LoadSampleCommand.h
+++ b/AestraAudio/include/Commands/LoadSampleCommand.h
@@ -1,0 +1,57 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/UnitManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to load an audio sample into a unit (undoable)
+ *
+ * Undo restores the unit's previous sample path (possibly none) through the
+ * same UnitManager::setUnitAudioClip path, so the sampler plugin state and
+ * preview waveform stay consistent in both directions.
+ */
+class LoadSampleCommand : public ICommand {
+public:
+    LoadSampleCommand(UnitManager& unitManager, UnitID unitId, const std::string& path)
+        : m_unitManager(unitManager), m_unitId(unitId), m_path(path) {}
+
+    void execute() override {
+        if (m_executed) return;
+        const UnitInfo* unit = m_unitManager.getUnit(m_unitId);
+        if (!unit) return;
+        m_previousPath = unit->audioClipPath;
+        m_unitManager.setUnitAudioClip(m_unitId, m_path);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_unitManager.setUnitAudioClip(m_unitId, m_previousPath);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Load Sample"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    UnitManager& m_unitManager;
+    UnitID m_unitId;
+    std::string m_path;
+    std::string m_previousPath;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -8,7 +8,7 @@ namespace Aestra {
 namespace Audio {
 
 enum class FlagType { String, Int, Float, Bool };
-enum class CommandCategory { Transport, Track, Clip };
+enum class CommandCategory { Transport, Track, Clip, Unit, Pattern };
 
 struct FlagSchema {
     std::string name;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -1,14 +1,20 @@
 #include "Commands/CommandRegistry.h"
 #include "Commands/AddChannelCommand.h"
 #include "Commands/AddClipCommand.h"
+#include "Commands/AddNoteCommand.h"
+#include "Commands/AddUnitCommand.h"
 #include "Commands/DuplicateClipCommand.h"
+#include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
+#include "Commands/MoveNoteCommand.h"
 #include "Commands/RemoveClipCommand.h"
+#include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetSoloCommand.h"
 #include "Commands/SetVolumeCommand.h"
 #include "Commands/TrimClipCommand.h"
+#include "Commands/UpdateNoteCommand.h"
 #include "Commands/MuseStubs.h"
 #include "Models/ClipInstance.h"
 #include "Models/TrackManager.h"
@@ -18,9 +24,11 @@
 #include <cctype>
 #include <cmath>
 #include <exception>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 
 namespace Aestra {
 namespace Audio {
@@ -163,6 +171,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("move_clip", noopTrack);
         reg.registerCommand("duplicate_clip", noopTrack);
         reg.registerCommand("trim_clip", noopTrack);
+        reg.registerCommand("add_unit", noopTrack);
+        reg.registerCommand("load_sample", noopTrack);
+        reg.registerCommand("add_note", noopTrack);
+        reg.registerCommand("delete_note", noopTrack);
+        reg.registerCommand("move_note", noopTrack);
+        reg.registerCommand("set_note", noopTrack);
         return;
     }
 
@@ -350,6 +364,168 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         ClipInstanceID clipId;
         clipId.low = *idOpt;
         return std::make_unique<TrimClipCommand>(*pm, clipId, *startOpt, *endOpt);
+    });
+
+    // ===== Unit (2) =====
+    reg.registerCommand("add_unit", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto nameIt = flags.find("name");
+        std::string name = (nameIt != flags.end()) ? nameIt->second : "";
+        UnitType type = UnitType::Sampler;
+        auto typeIt = flags.find("type");
+        if (typeIt != flags.end()) {
+            if (typeIt->second == "808") {
+                type = UnitType::PitchedSampler;
+            } else if (typeIt->second != "sampler") {
+                return nullptr; // schema comment advertises the accepted values
+            }
+        }
+        return std::make_unique<AddUnitCommand>(tm->getUnitManager(), name, type);
+    });
+
+    reg.registerCommand("load_sample", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return nullptr;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return nullptr;
+        auto fileRaw = requireFlag(flags, "file");
+        if (!fileRaw) return nullptr;
+
+        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        std::error_code ec;
+        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec)) return nullptr;
+        return std::make_unique<LoadSampleCommand>(tm->getUnitManager(), *unitOpt, std::string(*fileRaw));
+    });
+
+    // ===== Pattern / note (4) =====
+    // Notes are addressed by (pattern, unit, pitch, start) — the same key the
+    // piano-roll note commands match on. `findNote` resolves that key against
+    // stored notes with a small tolerance on start, because the caller's beat
+    // value round-tripped through JSON text.
+    const auto findNote = [](TrackManager& tm, PatternID patternId, uint64_t unitId, int pitch,
+                             double startBeat) -> std::optional<MidiNote> {
+        const PatternSource* pattern = tm.getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return std::nullopt;
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.pitch == pitch && note.unitId == unitId &&
+                std::abs(note.startBeat - startBeat) < 1e-6) {
+                return note;
+            }
+        }
+        return std::nullopt;
+    };
+
+    // Shared front half: parse pattern/unit/pitch/start, which every note verb takes.
+    struct NoteKey {
+        PatternID patternId;
+        uint64_t unitId;
+        int pitch;
+        double startBeat;
+    };
+    const auto parseNoteKey =
+        [](const std::unordered_map<std::string, std::string>& flags) -> std::optional<NoteKey> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return std::nullopt;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return std::nullopt;
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return std::nullopt;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return std::nullopt;
+        auto pitchRaw = requireFlag(flags, "pitch");
+        if (!pitchRaw) return std::nullopt;
+        auto pitchOpt = safeStoi(*pitchRaw);
+        if (!pitchOpt) return std::nullopt;
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return std::nullopt;
+        auto startOpt = safeStof(*startRaw);
+        if (!startOpt) return std::nullopt;
+        return NoteKey{PatternID{*patternOpt}, *unitOpt, *pitchOpt, static_cast<double>(*startOpt)};
+    };
+
+    reg.registerCommand("add_note", [tm = trackManager, parseNoteKey](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto durationRaw = requireFlag(flags, "duration");
+        if (!durationRaw) return nullptr;
+        auto durationOpt = safeStof(*durationRaw);
+        if (!durationOpt) return nullptr;
+
+        float velocity = 0.8f;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float pan = 0.0f;
+        if (auto it = flags.find("pan"); it != flags.end()) {
+            auto p = safeStof(it->second);
+            if (!p) return nullptr;
+            pan = *p;
+        }
+
+        const PatternSource* pattern = tm->getPatternManager().getPattern(key->patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!tm->getUnitManager().getUnit(key->unitId)) return nullptr;
+
+        MidiNote note;
+        note.pitch = key->pitch;
+        note.startBeat = key->startBeat;
+        note.durationBeats = static_cast<double>(*durationOpt);
+        note.velocity = velocity;
+        note.pan = pan;
+        note.unitId = key->unitId;
+        return std::make_unique<AddNoteCommand>(tm->getPatternManager(), key->patternId, note);
+    });
+
+    reg.registerCommand("delete_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+        return std::make_unique<RemoveNoteCommand>(tm->getPatternManager(), key->patternId, *note);
+    });
+
+    reg.registerCommand("move_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto toStartRaw = requireFlag(flags, "to_start");
+        if (!toStartRaw) return nullptr;
+        auto toStartOpt = safeStof(*toStartRaw);
+        if (!toStartOpt) return nullptr;
+
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+
+        int toPitch = note->pitch;
+        if (auto it = flags.find("to_pitch"); it != flags.end()) {
+            auto p = safeStoi(it->second);
+            if (!p) return nullptr;
+            toPitch = *p;
+        }
+        return std::make_unique<MoveNoteCommand>(tm->getPatternManager(), key->patternId, *note,
+                                                 static_cast<double>(*toStartOpt), toPitch);
+    });
+
+    reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+
+        float velocity = note->velocity;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float pan = note->pan;
+        if (auto it = flags.find("pan"); it != flags.end()) {
+            auto p = safeStof(it->second);
+            if (!p) return nullptr;
+            pan = *p;
+        }
+        return std::make_unique<UpdateNoteCommand>(tm->getPatternManager(), key->patternId, *note,
+                                                   velocity, pan);
     });
 }
 

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -71,6 +71,53 @@ static const std::vector<CommandSchema> s_schemas = {
         {"id", FlagType::Int, true},
         {"start", FlagType::Float, true},
         {"end", FlagType::Float, true}
+    }},
+
+    // === Unit (2) ===
+    // "type" accepts: sampler (default), 808. The schema format cannot
+    // express enums yet; the factory rejects anything else.
+    {"add_unit", CommandCategory::Unit, {
+        {"name", FlagType::String, false},
+        {"type", FlagType::String, false}
+    }},
+    {"load_sample", CommandCategory::Unit, {
+        {"unit", FlagType::Int, true, 1.0},
+        {"file", FlagType::String, true}
+    }},
+
+    // === Pattern (4) ===
+    // Notes are identified by (pattern, unit, pitch, start) — the same key
+    // the piano-roll note commands match on.
+    {"add_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"duration", FlagType::Float, true, 0.001},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"pan", FlagType::Float, false, -1.0, 1.0}
+    }},
+    {"delete_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0}
+    }},
+    {"move_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"to_start", FlagType::Float, true, 0.0},
+        {"to_pitch", FlagType::Int, false, 0.0, 127.0}
+    }},
+    {"set_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"pan", FlagType::Float, false, -1.0, 1.0}
     }}
 };
 
@@ -91,6 +138,8 @@ std::string schemaToJsonString() {
         case CommandCategory::Transport: catStr = "transport"; break;
         case CommandCategory::Track: catStr = "track"; break;
         case CommandCategory::Clip: catStr = "clip"; break;
+        case CommandCategory::Unit: catStr = "unit"; break;
+        case CommandCategory::Pattern: catStr = "pattern"; break;
         }
         out << "    \"category\": \"" << catStr << "\",\n";
         out << "    \"flags\": [\n";

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -5,6 +5,9 @@
 #include "Commands/CommandResult.h"
 #include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
+#include "Models/UnitManager.h"
+
+#include <variant>
 
 #include "AestraJSON.h"
 
@@ -75,7 +78,17 @@ namespace {
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
-           verb == "get_session_state";
+           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+}
+
+const char* unitTypeName(UnitType type) {
+    switch (type) {
+    case UnitType::Sampler: return "sampler";
+    case UnitType::PitchedSampler: return "808";
+    case UnitType::Instrument: return "instrument";
+    case UnitType::Audio: return "audio";
+    }
+    return "unknown";
 }
 
 bool isKnownVerb(const std::string& verb) {
@@ -127,9 +140,10 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return makeError(id, "parse_error", "unknown command: " + verb).toString();
         }
 
-        // Queries take no arguments; accepting them would silently drop
-        // caller intent.
-        if (isQueryVerb(verb) && request.has("args") && request["args"].size() > 0) {
+        // Queries take no arguments — except get_pattern, which takes exactly
+        // one. Accepting anything else would silently drop caller intent.
+        if (isQueryVerb(verb) && verb != "get_pattern" && request.has("args") &&
+            request["args"].size() > 0) {
             return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
         }
 
@@ -247,8 +261,97 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             result.set("tracks", tracks);
             result.set("laneCount",
                        JSON(static_cast<double>(m_trackManager->getPlaylistModel().getLaneCount())));
+            result.set("unitCount",
+                       JSON(static_cast<double>(m_trackManager->getUnitManager().getUnitCount())));
             result.set("canUndo", JSON(m_trackManager->getCommandHistory().canUndo()));
 
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_units") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            auto& unitManager = m_trackManager->getUnitManager();
+            JSON units = JSON::array();
+            for (UnitID unitId : unitManager.getAllUnitIDs()) {
+                const UnitInfo* unit = unitManager.getUnit(unitId);
+                if (!unit) continue;
+                JSON u = JSON::object();
+                u.set("id", JSON(static_cast<double>(unit->id)));
+                u.set("name", JSON(unit->name));
+                u.set("type", JSON(unitTypeName(unit->type)));
+                u.set("enabled", JSON(unit->isEnabled));
+                u.set("muted", JSON(unit->isMuted));
+                u.set("soloed", JSON(unit->isSolo));
+                u.set("defaultPatternId",
+                      JSON(static_cast<double>(unit->defaultPatternId.value)));
+                u.set("samplePath", JSON(unit->audioClipPath));
+                u.set("sampleDurationSeconds", JSON(unit->audioDurationSeconds));
+                units.push(u);
+            }
+            JSON result = JSON::object();
+            result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "get_pattern") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            // The one parameterized query: args must be exactly
+            // {"pattern": <number>}.
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "get_pattern requires args: {\"pattern\": <id>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "pattern") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for get_pattern: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("pattern") || !args["pattern"].isNumber()) {
+                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+                    .toString();
+            }
+
+            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternSource* pattern =
+                m_trackManager->getPatternManager().getPattern(patternId);
+            if (!pattern) {
+                return makeError(id, "execution_error",
+                                 "no such pattern: " + std::to_string(patternId.value), verb)
+                    .toString();
+            }
+
+            JSON result = JSON::object();
+            result.set("id", JSON(static_cast<double>(pattern->id.value)));
+            result.set("name", JSON(pattern->name));
+            result.set("lengthBeats", JSON(pattern->lengthBeats));
+            const bool isMidi = pattern->isMidi();
+            result.set("type", JSON(isMidi ? "midi" : "other"));
+            if (isMidi) {
+                JSON notes = JSON::array();
+                for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+                    JSON n = JSON::object();
+                    n.set("pitch", JSON(static_cast<double>(note.pitch)));
+                    n.set("start", JSON(note.startBeat));
+                    n.set("duration", JSON(note.durationBeats));
+                    n.set("velocity", JSON(static_cast<double>(note.velocity)));
+                    n.set("pan", JSON(static_cast<double>(note.pan)));
+                    n.set("unit", JSON(static_cast<double>(note.unitId)));
+                    notes.push(n);
+                }
+                result.set("notes", notes);
+            }
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -67,6 +67,9 @@ int main(int argc, char** argv) {
     trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputChannelCount(0);
+    // The app wires this in AestraContent; without it, creating a unit does
+    // not create its default MIDI pattern.
+    trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
 
     AudioEngine engine;
     engine.setSampleRate(sampleRate);

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -10,6 +10,10 @@
 
 #include "AestraJSON.h"
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -41,10 +45,47 @@ std::string status(JSON& response) {
     return response.has("status") ? response["status"].asString() : "<missing>";
 }
 
+// Minimal valid PCM16 mono WAV (8 frames of silence) for load_sample.
+std::string writeTestWav() {
+    const std::string path =
+        (std::filesystem::temp_directory_path() / "muse_service_test_sample.wav").string();
+    const uint32_t sampleRate = 48000;
+    const uint16_t channels = 1;
+    const uint16_t bitsPerSample = 16;
+    const uint32_t dataBytes = 8 * sizeof(int16_t);
+    const uint32_t byteRate = sampleRate * channels * bitsPerSample / 8;
+    const uint16_t blockAlign = channels * bitsPerSample / 8;
+
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return "";
+    auto u32 = [&](uint32_t v) { std::fwrite(&v, 4, 1, f); };
+    auto u16 = [&](uint16_t v) { std::fwrite(&v, 2, 1, f); };
+    std::fwrite("RIFF", 1, 4, f);
+    u32(36 + dataBytes);
+    std::fwrite("WAVE", 1, 4, f);
+    std::fwrite("fmt ", 1, 4, f);
+    u32(16);
+    u16(1); // PCM
+    u16(channels);
+    u32(sampleRate);
+    u32(byteRate);
+    u16(blockAlign);
+    u16(bitsPerSample);
+    std::fwrite("data", 1, 4, f);
+    u32(dataBytes);
+    const int16_t silence[8] = {};
+    std::fwrite(silence, sizeof(int16_t), 8, f);
+    std::fclose(f);
+    return path;
+}
+
 } // namespace
 
 int main() {
     auto trackManager = std::make_shared<TrackManager>();
+    // Mirror the app wiring (AestraContent): units need the pattern manager
+    // to auto-create their default MIDI pattern.
+    trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
     CommandRegistry::initialize(trackManager.get());
     MuseService service(trackManager.get(), nullptr);
 
@@ -167,6 +208,134 @@ int main() {
         history.undo(); // restore the deleted Drums track
         JSON r = call(service, "{\"id\": 41, \"verb\": \"list_tracks\"}");
         check(r["result"]["tracks"].size() == 2, "undo restores the deleted track");
+    }
+
+    // --- Beat path: units ---
+    double kickUnit = 0.0;
+    double kickPattern = 0.0;
+    {
+        JSON r = call(service,
+                      "{\"id\": 50, \"verb\": \"add_unit\", \"args\": {\"name\": \"Kick\"}}");
+        check(status(r) == "ok", "add_unit Kick ok");
+
+        r = call(service,
+                 "{\"id\": 51, \"verb\": \"add_unit\", "
+                 "\"args\": {\"name\": \"Sub\", \"type\": \"808\"}}");
+        check(status(r) == "ok", "add_unit 808 ok");
+
+        r = call(service,
+                 "{\"id\": 52, \"verb\": \"add_unit\", "
+                 "\"args\": {\"name\": \"X\", \"type\": \"theremin\"}}");
+        check(status(r) == "execution_error", "unknown unit type rejected");
+
+        r = call(service, "{\"id\": 53, \"verb\": \"list_units\"}");
+        check(status(r) == "ok", "list_units ok");
+        check(r["result"]["units"].size() == 2, "two units listed");
+        check(r["result"]["units"][0]["name"].asString() == "Kick", "unit 0 named Kick");
+        check(r["result"]["units"][1]["type"].asString() == "808", "unit 1 typed 808");
+        kickUnit = r["result"]["units"][0]["id"].asNumber();
+        kickPattern = r["result"]["units"][0]["defaultPatternId"].asNumber();
+        check(kickPattern > 0.0, "unit creation minted a default pattern");
+    }
+
+    // --- Beat path: sample loading ---
+    {
+        JSON r = call(service,
+                      "{\"id\": 55, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
+                          std::to_string(static_cast<long long>(kickUnit)) +
+                          ", \"file\": \"/nonexistent/kick.wav\"}}");
+        check(status(r) == "execution_error", "load_sample on missing file -> execution_error");
+
+        const std::string wavPath = writeTestWav();
+        check(!wavPath.empty(), "test wav written");
+        r = call(service, "{\"id\": 56, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
+                              std::to_string(static_cast<long long>(kickUnit)) +
+                              ", \"file\": \"" + wavPath + "\"}}");
+        check(status(r) == "ok", "load_sample ok");
+        r = call(service, "{\"id\": 57, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["samplePath"].asString() == wavPath,
+              "unit readback carries sample path");
+    }
+
+    // --- Beat path: notes in the unit's default pattern ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        JSON r = call(service, "{\"id\": 60, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                                   ", \"unit\": " + u +
+                                   ", \"pitch\": 36, \"start\": 0, \"duration\": 1}}");
+        check(status(r) == "ok", "add_note ok");
+
+        r = call(service, "{\"id\": 61, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 2.5, \"duration\": 0.5, "
+                              "\"velocity\": 0.6, \"pan\": -0.25}}");
+        check(status(r) == "ok", "add_note with expression ok");
+
+        r = call(service, "{\"id\": 62, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 200, \"start\": 0, \"duration\": 1}}");
+        check(status(r) == "validation_error", "out-of-range pitch -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 63, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(status(r) == "ok", "get_pattern ok");
+        check(r["result"]["notes"].size() == 2, "pattern readback lists both notes");
+        check(r["result"]["notes"][1]["velocity"].asNumber() > 0.59 &&
+                  r["result"]["notes"][1]["velocity"].asNumber() < 0.61,
+              "note expression round-trips");
+
+        // Revision loop: move the second hit, then soften it, then delete it.
+        r = call(service, "{\"id\": 64, \"verb\": \"move_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 2.5, \"to_start\": 3}}");
+        check(status(r) == "ok", "move_note ok");
+
+        r = call(service, "{\"id\": 65, \"verb\": \"set_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 3, \"velocity\": 0.3}}");
+        check(status(r) == "ok", "set_note ok");
+
+        r = call(service,
+                 "{\"id\": 66, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"][1]["start"].asNumber() == 3.0, "moved note reads back at 3");
+        check(r["result"]["notes"][1]["velocity"].asNumber() < 0.31,
+              "softened velocity reads back");
+        check(r["result"]["notes"][1]["pan"].asNumber() < -0.24,
+              "set_note leaves untouched expression alone");
+
+        r = call(service, "{\"id\": 67, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 36, \"start\": 3}}");
+        check(status(r) == "ok", "delete_note ok");
+
+        r = call(service, "{\"id\": 68, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 36, \"start\": 3}}");
+        check(status(r) == "execution_error", "deleting a missing note -> execution_error");
+
+        r = call(service,
+                 "{\"id\": 69, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 1, "one note remains after delete");
+
+        trackManager->getCommandHistory().undo(); // restore the deleted note
+        r = call(service,
+                 "{\"id\": 70, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2, "undo restores the deleted note");
+    }
+
+    // --- get_pattern arg contract ---
+    {
+        JSON r = call(service, "{\"id\": 75, \"verb\": \"get_pattern\"}");
+        check(status(r) == "validation_error", "get_pattern without args -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 76, \"verb\": \"get_pattern\", \"args\": {\"pattern\": 999999}}");
+        check(status(r) == "execution_error", "get_pattern unknown id -> execution_error");
+
+        r = call(service,
+                 "{\"id\": 77, \"verb\": \"get_pattern\", "
+                 "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
+        check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))


### PR DESCRIPTION
> Stacked on #527 (MuseRepl). Reviews here should see only the beat-path commit; retargets to `develop` automatically when #527 merges.

## What

The slice that lets an agent actually make a beat through Muse — units, samples, and notes, with the eyes to verify every step:

```
{"id":1,"verb":"add_unit","args":{"name":"Kick"}}
{"id":2,"verb":"load_sample","args":{"unit":1,"file":"kick.wav"}}
{"id":3,"verb":"add_note","args":{"pattern":1,"unit":1,"pitch":36,"start":0,"duration":1}}
{"id":4,"verb":"get_pattern","args":{"pattern":1}}
```

## New verbs

**Mutations** (all undoable through the shared `CommandHistory`):
- `add_unit` — name + type (`sampler` default, `808` for the built-in melodic unit). New `AddUnitCommand`, mirrors `AddChannelCommand` (undo removes; redo mints a fresh ID). Unit creation auto-mints its default MIDI pattern.
- `load_sample` — new `LoadSampleCommand`; undo restores the previous sample path through the same `UnitManager::setUnitAudioClip` path so plugin state and preview stay consistent both ways. Factory rejects missing units/files.
- `add_note` / `delete_note` / `move_note` / `set_note` — thin registry factories over the **existing piano-roll note commands** (`AddNoteCommand`, `RemoveNoteCommand`, `MoveNoteCommand`, `UpdateNoteCommand`). Notes are addressed by `(pattern, unit, pitch, start)` — the same key those commands already match on — with a 1e-6 start tolerance since the caller's beat value round-tripped through JSON text. `set_note` leaves unspecified expression fields untouched.

**Queries**:
- `list_units` — id, type, enabled/muted/soloed, `defaultPatternId`, `samplePath`, duration.
- `get_pattern` — the first parameterized query; args must be exactly `{"pattern": <id>}`, unknown args rejected. Returns notes with full expression.
- `get_session_state` gains `unitCount`.

## Wiring note

Only the app wired `UnitManager → PatternManager` (AestraContent). MuseRepl and the test now mirror that wiring; without it, unit creation silently skips minting the default pattern.

## Validation

- `MuseServiceTest` grows a beat-path section (unit creation + type rejection, sample load success with a hand-rolled WAV and failure on a missing file, note CRUD with expression readback, the revision loop move → soften → delete → undo, `get_pattern` arg contract). All pass; full `commands` suite 10/10.
- End-to-end through the MuseRepl pipe: bpm → two units (sampler + 808) → real WAV decoded into the sampler (3.5 s, 5.8 ms) → notes placed/moved → `get_pattern` readback correct → session state shows it all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)