### PR TITLE
feat(muse): render_pattern — the beat comes back as audio

### DIFF
--- a/AestraAudio/include/Commands/MuseService.h
+++ b/AestraAudio/include/Commands/MuseService.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace Aestra {
@@ -36,6 +37,18 @@ public:
 
     /** @brief Process one JSON request line and return the JSON response. */
     std::string handleRequest(const std::string& requestJson);
+
+    /**
+     * @brief Attach an engine to a track manager the way the app does.
+     *
+     * Headless hosts (MuseRepl, tests) must wire the same five links
+     * AestraContent wires — unit manager, pattern playback engine, continuous
+     * params, channel slot map, and the transport command sink — or units
+     * render silence and transport commands never reach the engine.
+     * Both objects must outlive the wiring (the sink captures raw pointers).
+     */
+    static void wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackManager,
+                                   AudioEngine& engine);
 
 private:
     TrackManager* m_trackManager = nullptr;

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -11,11 +11,15 @@
 
 #include "AestraJSON.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <exception>
+#include <fstream>
 #include <unordered_map>
+#include <vector>
 
 namespace Aestra {
 namespace Audio {
@@ -73,12 +77,75 @@ JSON trackToJson(const MixerChannel& channel, size_t index) {
 MuseService::MuseService(TrackManager* trackManager, AudioEngine* engine)
     : m_trackManager(trackManager), m_engine(engine) {}
 
+void MuseService::wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackManager,
+                                     AudioEngine& engine) {
+    engine.setTrackManager(trackManager);
+    engine.setUnitManager(&trackManager->getUnitManager());
+    engine.setPatternPlaybackEngine(&trackManager->getPatternPlaybackEngine());
+    engine.setContinuousParams(trackManager->getContinuousParams());
+    trackManager->buildAndShareSlotMap();
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+
+    // Transport commands (play/stop/seek) travel from TrackManager to the
+    // engine through this sink — the same relay AestraContent installs.
+    TrackManager* tm = trackManager.get();
+    AudioEngine* enginePtr = &engine;
+    tm->setCommandSink([enginePtr, tm](const AudioQueueCommand& cmd) {
+        enginePtr->commandQueue().push(cmd);
+        if (cmd.type == AudioQueueCommandType::SetTransportState) {
+            const double sampleRate =
+                std::max(1.0, static_cast<double>(enginePtr->getSampleRate()));
+            tm->onTransportStateApplied(cmd.value1 != 0.0f,
+                                        static_cast<double>(cmd.samplePos) / sampleRate);
+        }
+    });
+}
+
 namespace {
 
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+}
+
+// Service actions: handled here like queries, but they do work (render a
+// file) rather than read state. Not routed through CommandHistory — a bounce
+// is not an undoable project edit.
+bool isActionVerb(const std::string& verb) {
+    return verb == "render_pattern";
+}
+
+// Interleaved stereo float32 WAV — the format the offline test renderer uses.
+bool writeFloat32Wav(const std::string& path, const std::vector<float>& samples,
+                     uint32_t sampleRate) {
+    std::ofstream file(path, std::ios::binary);
+    if (!file) return false;
+
+    const uint32_t dataBytes = static_cast<uint32_t>(samples.size() * sizeof(float));
+    const uint16_t channels = 2;
+    const uint16_t bitsPerSample = 32;
+    const uint16_t blockAlign = channels * bitsPerSample / 8;
+
+    auto u32 = [&](uint32_t v) { file.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { file.write(reinterpret_cast<const char*>(&v), 2); };
+    file.write("RIFF", 4);
+    u32(36 + dataBytes);
+    file.write("WAVE", 4);
+    file.write("fmt ", 4);
+    u32(16);
+    u16(3); // IEEE float
+    u16(channels);
+    u32(sampleRate);
+    u32(sampleRate * blockAlign);
+    u16(blockAlign);
+    u16(bitsPerSample);
+    file.write("data", 4);
+    u32(dataBytes);
+    file.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
+    return file.good();
 }
 
 const char* unitTypeName(UnitType type) {
@@ -92,7 +159,7 @@ const char* unitTypeName(UnitType type) {
 }
 
 bool isKnownVerb(const std::string& verb) {
-    if (isQueryVerb(verb)) return true;
+    if (isQueryVerb(verb) || isActionVerb(verb)) return true;
     for (const auto& cmd : MuseGrammar::allCommands()) {
         if (cmd.verb == verb) return true;
     }
@@ -352,6 +419,132 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 }
                 result.set("notes", notes);
             }
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "render_pattern") {
+            if (!m_trackManager || !m_engine) {
+                return makeError(id, "execution_error",
+                                 "render_pattern needs a track manager and an audio engine", verb)
+                    .toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(
+                           id, "validation_error",
+                           "render_pattern requires args: {\"pattern\": <id>, \"file\": <path>}",
+                           verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "pattern" && entry.first != "file" && entry.first != "tail") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for render_pattern: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("pattern") || !args["pattern"].isNumber()) {
+                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+                    .toString();
+            }
+            if (!args.has("file") || !args["file"].isString() || args["file"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'file' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+            double tailSeconds = 1.0;
+            if (args.has("tail")) {
+                if (!args["tail"].isNumber()) {
+                    return makeError(id, "validation_error", "arg 'tail' must be a number", verb)
+                        .toString();
+                }
+                tailSeconds = args["tail"].asNumber();
+                if (!(tailSeconds >= 0.0 && tailSeconds <= 30.0)) {
+                    return makeError(id, "validation_error", "arg 'tail' must be 0..30 seconds",
+                                     verb)
+                        .toString();
+                }
+            }
+
+            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternSource* pattern =
+                m_trackManager->getPatternManager().getPattern(patternId);
+            if (!pattern) {
+                return makeError(id, "execution_error",
+                                 "no such pattern: " + std::to_string(patternId.value), verb)
+                    .toString();
+            }
+            if (!pattern->isMidi()) {
+                return makeError(id, "execution_error", "pattern is not a MIDI pattern", verb)
+                    .toString();
+            }
+
+            const double bpm = std::max(1.0, static_cast<double>(m_engine->getBPM()));
+            // playPatternInArsenal resolves pattern length to at least 8 beats.
+            const double lengthBeats = std::max(8.0, pattern->lengthBeats);
+            const double durationSeconds = lengthBeats * 60.0 / bpm + tailSeconds;
+            const uint32_t sampleRate = m_engine->getSampleRate();
+            const uint64_t totalFrames =
+                static_cast<uint64_t>(durationSeconds * static_cast<double>(sampleRate));
+            constexpr uint32_t kBlockFrames = 512;
+
+            // Offline bounce through the exact live engine path, the same way
+            // the headless test renderer pumps it. Arsenal preview routing is
+            // what the user hears when a pattern plays, so it is what the
+            // agent gets back. Pattern playback needs both sides armed: the
+            // scheduler (playPatternInArsenal) and the engine's pattern mode
+            // (the app sets it wherever it starts pattern playback).
+            m_engine->setPatternPlaybackMode(true, lengthBeats);
+            m_trackManager->playPatternInArsenal(patternId, 0.0);
+
+            std::vector<float> rendered;
+            rendered.reserve(static_cast<size_t>(totalFrames) * 2u);
+            std::vector<float> block(static_cast<size_t>(kBlockFrames) * 2u, 0.0f);
+            float peak = 0.0f;
+            uint64_t framesRemaining = totalFrames;
+            while (framesRemaining > 0) {
+                const uint32_t framesThisBlock =
+                    static_cast<uint32_t>(std::min<uint64_t>(kBlockFrames, framesRemaining));
+                std::memset(block.data(), 0, block.size() * sizeof(float));
+                m_engine->processBlock(block.data(), nullptr, framesThisBlock, 0.0);
+                // The pattern scheduler's RT queue is refilled from the
+                // control thread; offline that's us (AudioExporter does the
+                // same per block).
+                m_engine->performNonRealtimeMaintenance();
+                for (uint32_t i = 0; i < framesThisBlock * 2u; ++i) {
+                    peak = std::max(peak, std::abs(block[i]));
+                }
+                rendered.insert(rendered.end(), block.begin(),
+                                block.begin() + static_cast<size_t>(framesThisBlock) * 2u);
+                framesRemaining -= framesThisBlock;
+            }
+            m_trackManager->stop();
+            // The stop command sits in the engine queue until a block drains
+            // it; pump two settle blocks (output discarded) so the transport
+            // is actually stopped when this returns.
+            for (int i = 0; i < 2; ++i) {
+                std::memset(block.data(), 0, block.size() * sizeof(float));
+                m_engine->processBlock(block.data(), nullptr, kBlockFrames, 0.0);
+                m_engine->performNonRealtimeMaintenance();
+            }
+            m_engine->setPatternPlaybackMode(false, 4.0); // app default when leaving pattern mode
+
+            if (!writeFloat32Wav(args["file"].asString(), rendered, sampleRate)) {
+                return makeError(id, "execution_error",
+                                 "cannot write output file: " + args["file"].asString(), verb)
+                    .toString();
+            }
+
+            const double peakDb = peak > 0.0f ? 20.0 * std::log10(static_cast<double>(peak))
+                                              : -144.0;
+            JSON result = JSON::object();
+            result.set("file", JSON(args["file"].asString()));
+            result.set("durationSeconds", JSON(durationSeconds));
+            result.set("frames", JSON(static_cast<double>(totalFrames)));
+            result.set("sampleRate", JSON(static_cast<double>(sampleRate)));
+            result.set("peakDb", JSON(peakDb));
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -118,6 +118,19 @@ bool isActionVerb(const std::string& verb) {
     return verb == "render_pattern";
 }
 
+// JSON numbers are doubles; an id must be a non-negative integer that a
+// double represents exactly, or the cast would silently target the wrong
+// object.
+bool numberToId(double value, uint64_t& out) {
+    constexpr double kMaxExactJsonInteger = 9007199254740991.0; // 2^53 - 1
+    if (!std::isfinite(value) || value < 0.0 || value != std::floor(value) ||
+        value > kMaxExactJsonInteger) {
+        return false;
+    }
+    out = static_cast<uint64_t>(value);
+    return true;
+}
+
 // Interleaved stereo float32 WAV — the format the offline test renderer uses.
 bool writeFloat32Wav(const std::string& path, const std::vector<float>& samples,
                      uint32_t sampleRate) {
@@ -145,7 +158,8 @@ bool writeFloat32Wav(const std::string& path, const std::vector<float>& samples,
     file.write("data", 4);
     u32(dataBytes);
     file.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
-    return file.good();
+    file.close(); // a failed flush on close must not report success
+    return !file.fail();
 }
 
 const char* unitTypeName(UnitType type) {
@@ -385,12 +399,15 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                         .toString();
                 }
             }
-            if (!args.has("pattern") || !args["pattern"].isNumber()) {
-                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+            uint64_t patternValue = 0;
+            if (!args.has("pattern") || !args["pattern"].isNumber() ||
+                !numberToId(args["pattern"].asNumber(), patternValue)) {
+                return makeError(id, "validation_error",
+                                 "arg 'pattern' must be a non-negative integer", verb)
                     .toString();
             }
 
-            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternID patternId{patternValue};
             const PatternSource* pattern =
                 m_trackManager->getPatternManager().getPattern(patternId);
             if (!pattern) {
@@ -445,8 +462,11 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                         .toString();
                 }
             }
-            if (!args.has("pattern") || !args["pattern"].isNumber()) {
-                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+            uint64_t patternValue = 0;
+            if (!args.has("pattern") || !args["pattern"].isNumber() ||
+                !numberToId(args["pattern"].asNumber(), patternValue)) {
+                return makeError(id, "validation_error",
+                                 "arg 'pattern' must be a non-negative integer", verb)
                     .toString();
             }
             if (!args.has("file") || !args["file"].isString() || args["file"].asString().empty()) {
@@ -490,46 +510,85 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 static_cast<uint64_t>(durationSeconds * static_cast<double>(sampleRate));
             constexpr uint32_t kBlockFrames = 512;
 
-            // Offline bounce through the exact live engine path, the same way
-            // the headless test renderer pumps it. Arsenal preview routing is
-            // what the user hears when a pattern plays, so it is what the
-            // agent gets back. Pattern playback needs both sides armed: the
-            // scheduler (playPatternInArsenal) and the engine's pattern mode
-            // (the app sets it wherever it starts pattern playback).
-            m_engine->setPatternPlaybackMode(true, lengthBeats);
-            m_trackManager->playPatternInArsenal(patternId, 0.0);
+            // Bound the render before touching engine state: the whole take
+            // is buffered in memory and the RIFF format caps a WAV at 4 GiB.
+            constexpr double kMaxRenderSeconds = 600.0;
+            const uint64_t dataBytes = totalFrames * 2ull * sizeof(float);
+            if (durationSeconds > kMaxRenderSeconds ||
+                36ull + dataBytes > 0xFFFFFFFFull) {
+                return makeError(id, "validation_error",
+                                 "render too long: " + std::to_string(durationSeconds) +
+                                     "s (max " + std::to_string(kMaxRenderSeconds) + "s)",
+                                 verb)
+                    .toString();
+            }
 
             std::vector<float> rendered;
             rendered.reserve(static_cast<size_t>(totalFrames) * 2u);
             std::vector<float> block(static_cast<size_t>(kBlockFrames) * 2u, 0.0f);
             float peak = 0.0f;
-            uint64_t framesRemaining = totalFrames;
-            while (framesRemaining > 0) {
-                const uint32_t framesThisBlock =
-                    static_cast<uint32_t>(std::min<uint64_t>(kBlockFrames, framesRemaining));
-                std::memset(block.data(), 0, block.size() * sizeof(float));
-                m_engine->processBlock(block.data(), nullptr, framesThisBlock, 0.0);
-                // The pattern scheduler's RT queue is refilled from the
-                // control thread; offline that's us (AudioExporter does the
-                // same per block).
-                m_engine->performNonRealtimeMaintenance();
-                for (uint32_t i = 0; i < framesThisBlock * 2u; ++i) {
-                    peak = std::max(peak, std::abs(block[i]));
+            bool nonFinite = false;
+
+            {
+                // Everything after playback starts must be undone even if the
+                // pump throws: stop the transport, drain the stop command with
+                // settle blocks, and leave pattern mode (app default length).
+                struct TransportGuard {
+                    AudioEngine& engine;
+                    TrackManager& trackManager;
+                    std::vector<float>& block;
+                    ~TransportGuard() {
+                        trackManager.stop();
+                        for (int i = 0; i < 2; ++i) {
+                            std::memset(block.data(), 0, block.size() * sizeof(float));
+                            engine.processBlock(block.data(), nullptr, kBlockFrames, 0.0);
+                            engine.performNonRealtimeMaintenance();
+                        }
+                        engine.setPatternPlaybackMode(false, 4.0);
+                    }
+                } guard{*m_engine, *m_trackManager, block};
+
+                // Offline bounce through the exact live engine path, the same
+                // way the headless test renderer pumps it. Arsenal preview
+                // routing is what the user hears when a pattern plays, so it
+                // is what the agent gets back. Pattern playback needs both
+                // sides armed: the scheduler (playPatternInArsenal) and the
+                // engine's pattern mode (the app sets it wherever it starts
+                // pattern playback).
+                m_engine->setPatternPlaybackMode(true, lengthBeats);
+                m_trackManager->playPatternInArsenal(patternId, 0.0);
+
+                uint64_t framesRemaining = totalFrames;
+                while (framesRemaining > 0 && !nonFinite) {
+                    const uint32_t framesThisBlock =
+                        static_cast<uint32_t>(std::min<uint64_t>(kBlockFrames, framesRemaining));
+                    std::memset(block.data(), 0, block.size() * sizeof(float));
+                    m_engine->processBlock(block.data(), nullptr, framesThisBlock, 0.0);
+                    // The pattern scheduler's RT queue is refilled from the
+                    // control thread; offline that's us (AudioExporter does
+                    // the same per block).
+                    m_engine->performNonRealtimeMaintenance();
+                    for (uint32_t i = 0; i < framesThisBlock * 2u; ++i) {
+                        // Plugin output is untrusted: NaN/Inf must fail the
+                        // render, not land in the file as "ok".
+                        if (!std::isfinite(block[i])) {
+                            nonFinite = true;
+                            break;
+                        }
+                        peak = std::max(peak, std::abs(block[i]));
+                    }
+                    if (nonFinite) break;
+                    rendered.insert(rendered.end(), block.begin(),
+                                    block.begin() + static_cast<size_t>(framesThisBlock) * 2u);
+                    framesRemaining -= framesThisBlock;
                 }
-                rendered.insert(rendered.end(), block.begin(),
-                                block.begin() + static_cast<size_t>(framesThisBlock) * 2u);
-                framesRemaining -= framesThisBlock;
             }
-            m_trackManager->stop();
-            // The stop command sits in the engine queue until a block drains
-            // it; pump two settle blocks (output discarded) so the transport
-            // is actually stopped when this returns.
-            for (int i = 0; i < 2; ++i) {
-                std::memset(block.data(), 0, block.size() * sizeof(float));
-                m_engine->processBlock(block.data(), nullptr, kBlockFrames, 0.0);
-                m_engine->performNonRealtimeMaintenance();
+
+            if (nonFinite) {
+                return makeError(id, "execution_error",
+                                 "engine produced non-finite audio; render aborted", verb)
+                    .toString();
             }
-            m_engine->setPatternPlaybackMode(false, 4.0); // app default when leaving pattern mode
 
             if (!writeFloat32Wav(args["file"].asString(), rendered, sampleRate)) {
                 return makeError(id, "execution_error",

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -22,6 +22,7 @@
 #include "Commands/CommandRegistry.h"
 #include "Commands/MuseGrammar.h"
 #include "Commands/MuseService.h"
+#include "Plugin/PluginManager.h"
 #include "TrackManager.h"
 
 #include <cctype>
@@ -63,6 +64,13 @@ int main(int argc, char** argv) {
 
     // Session setup mirrors the app's wiring: TrackManager owns the model and
     // history, AudioEngine owns transport/tempo, the registry binds both.
+    // Built-in plugins (the sampler load_sample instantiates) register inside
+    // PluginManager::initialize(); without it units stay silent.
+    if (!PluginManager::getInstance().initialize()) {
+        std::cerr << "failed to initialize plugin manager\n";
+        return 1;
+    }
+
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputSampleRate(static_cast<double>(sampleRate));
@@ -74,6 +82,11 @@ int main(int argc, char** argv) {
     AudioEngine engine;
     engine.setSampleRate(sampleRate);
     engine.setBufferConfig(512, 2);
+    MuseService::wireHeadlessEngine(trackManager, engine);
+    if (!engine.initialize()) {
+        std::cerr << "failed to initialize audio engine\n";
+        return 1;
+    }
 
     CommandRegistry::initialize(trackManager.get());
     CommandRegistry::setAudioEngine(&engine);

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -48,6 +48,21 @@ std::string status(JSON& response) {
     return response.has("status") ? response["status"].asString() : "<missing>";
 }
 
+// Requests carrying filesystem paths must be serialized, not interpolated —
+// Windows paths contain backslashes that are invalid JSON escapes raw.
+std::string fileRequest(double id, const std::string& verb, const std::string& idKey,
+                        double idValue, const std::string& file, double tail = -1.0) {
+    JSON req = JSON::object();
+    req.set("id", JSON(id));
+    req.set("verb", JSON(verb));
+    JSON args = JSON::object();
+    args.set(idKey, JSON(idValue));
+    args.set("file", JSON(file));
+    if (tail >= 0.0) args.set("tail", JSON(tail));
+    req.set("args", args);
+    return req.toString();
+}
+
 // Minimal valid PCM16 mono WAV for load_sample: a loud 480-frame click so a
 // rendered pattern that triggers it is measurably non-silent.
 std::string writeTestWav() {
@@ -268,16 +283,12 @@ int main() {
     // --- Beat path: sample loading ---
     {
         JSON r = call(service,
-                      "{\"id\": 55, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
-                          std::to_string(static_cast<long long>(kickUnit)) +
-                          ", \"file\": \"/nonexistent/kick.wav\"}}");
+                      fileRequest(55, "load_sample", "unit", kickUnit, "/nonexistent/kick.wav"));
         check(status(r) == "execution_error", "load_sample on missing file -> execution_error");
 
         const std::string wavPath = writeTestWav();
         check(!wavPath.empty(), "test wav written");
-        r = call(service, "{\"id\": 56, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
-                              std::to_string(static_cast<long long>(kickUnit)) +
-                              ", \"file\": \"" + wavPath + "\"}}");
+        r = call(service, fileRequest(56, "load_sample", "unit", kickUnit, wavPath));
         check(status(r) == "ok", "load_sample ok");
         r = call(service, "{\"id\": 57, \"verb\": \"list_units\"}");
         check(r["result"]["units"][0]["samplePath"].asString() == wavPath,
@@ -367,7 +378,6 @@ int main() {
 
     // --- Render: the beat comes back as a file with signal in it ---
     {
-        const std::string p = std::to_string(static_cast<long long>(kickPattern));
         const std::string outPath =
             (std::filesystem::temp_directory_path() / "muse_service_test_render.wav").string();
         std::filesystem::remove(outPath);
@@ -375,17 +385,17 @@ int main() {
         JSON r = call(service, "{\"id\": 80, \"verb\": \"render_pattern\"}");
         check(status(r) == "validation_error", "render_pattern without args -> validation_error");
 
-        r = call(service,
-                 "{\"id\": 81, \"verb\": \"render_pattern\", "
-                 "\"args\": {\"pattern\": 999999, \"file\": \"" + outPath + "\"}}");
+        r = call(service, fileRequest(81, "render_pattern", "pattern", 999999.0, outPath));
         check(status(r) == "execution_error", "render_pattern unknown pattern -> execution_error");
 
-        r = call(service, "{\"id\": 82, \"verb\": \"render_pattern\", \"args\": {\"pattern\": " +
-                              p + ", \"file\": \"" + outPath + "\", \"tail\": 0.25}}");
+        r = call(service, "{\"id\": 84, \"verb\": \"render_pattern\", "
+                          "\"args\": {\"pattern\": -3, \"file\": \"x.wav\"}}");
+        check(status(r) == "validation_error", "negative pattern id -> validation_error");
+
+        r = call(service, fileRequest(82, "render_pattern", "pattern", kickPattern, outPath, 0.25));
         check(status(r) == "ok", "render_pattern ok");
-        check(r["result"]["frames"].asNumber() > 0.0, "render reports frames");
-        check(std::filesystem::exists(outPath) && std::filesystem::file_size(outPath) > 44,
-              "rendered wav exists with data");
+        const double frames = r["result"]["frames"].asNumber();
+        check(frames > 0.0, "render reports frames");
         // The pattern triggers the loud test click through the sampler; a
         // silent render means the pattern->unit->engine path is broken.
         check(r["result"]["peakDb"].asNumber() > -90.0,
@@ -393,8 +403,51 @@ int main() {
                   std::to_string(r["result"]["peakDb"].asNumber()) + ")");
         check(!engine.isTransportPlaying(), "engine transport stopped after render");
 
-        r = call(service, "{\"id\": 83, \"verb\": \"render_pattern\", \"args\": {\"pattern\": " +
-                              p + ", \"file\": \"" + outPath + "\", \"wobble\": 1}}");
+        // The file must honor the advertised contract: IEEE-float stereo at
+        // the engine rate, with chunk sizes agreeing with reported frames.
+        {
+            std::ifstream wav(outPath, std::ios::binary);
+            check(wav.good(), "rendered wav exists");
+            char riff[4] = {}, wave[4] = {};
+            uint32_t riffSize = 0, fmtSize = 0, byteRate = 0, dataSize = 0, sampleRate = 0;
+            uint16_t format = 0, channels = 0, blockAlign = 0, bits = 0;
+            char tag[4] = {};
+            wav.read(riff, 4);
+            wav.read(reinterpret_cast<char*>(&riffSize), 4);
+            wav.read(wave, 4);
+            wav.read(tag, 4); // "fmt "
+            wav.read(reinterpret_cast<char*>(&fmtSize), 4);
+            wav.read(reinterpret_cast<char*>(&format), 2);
+            wav.read(reinterpret_cast<char*>(&channels), 2);
+            wav.read(reinterpret_cast<char*>(&sampleRate), 4);
+            wav.read(reinterpret_cast<char*>(&byteRate), 4);
+            wav.read(reinterpret_cast<char*>(&blockAlign), 2);
+            wav.read(reinterpret_cast<char*>(&bits), 2);
+            wav.read(tag, 4); // "data"
+            wav.read(reinterpret_cast<char*>(&dataSize), 4);
+            check(std::memcmp(riff, "RIFF", 4) == 0 && std::memcmp(wave, "WAVE", 4) == 0,
+                  "wav container tags");
+            check(format == 3 && channels == 2 && bits == 32,
+                  "wav is IEEE-float stereo 32-bit");
+            check(sampleRate == 48000, "wav sample rate matches engine");
+            check(dataSize == static_cast<uint32_t>(frames) * 8u,
+                  "wav data size agrees with reported frames");
+            check(std::filesystem::file_size(outPath) == 44u + dataSize,
+                  "file size agrees with header");
+            const double reported = r["result"]["durationSeconds"].asNumber();
+            check(std::abs(frames / 48000.0 - reported) < 0.001,
+                  "durationSeconds agrees with frames");
+        }
+
+        JSON bad = JSON::object();
+        bad.set("id", JSON(83.0));
+        bad.set("verb", JSON("render_pattern"));
+        JSON badArgs = JSON::object();
+        badArgs.set("pattern", JSON(kickPattern));
+        badArgs.set("file", JSON(outPath));
+        badArgs.set("wobble", JSON(1.0));
+        bad.set("args", badArgs);
+        r = call(service, bad.toString());
         check(status(r) == "validation_error", "render_pattern unknown arg -> validation_error");
         std::filesystem::remove(outPath);
     }

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -6,7 +6,9 @@
 
 #include "Commands/CommandRegistry.h"
 #include "Commands/MuseService.h"
+#include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
+#include "Plugin/PluginManager.h"
 
 #include "AestraJSON.h"
 
@@ -18,6 +20,7 @@
 #include <memory>
 #include <string>
 
+using Aestra::Audio::AudioEngine;
 using Aestra::Audio::CommandRegistry;
 using Aestra::Audio::MuseService;
 using Aestra::Audio::TrackManager;
@@ -45,14 +48,16 @@ std::string status(JSON& response) {
     return response.has("status") ? response["status"].asString() : "<missing>";
 }
 
-// Minimal valid PCM16 mono WAV (8 frames of silence) for load_sample.
+// Minimal valid PCM16 mono WAV for load_sample: a loud 480-frame click so a
+// rendered pattern that triggers it is measurably non-silent.
 std::string writeTestWav() {
     const std::string path =
         (std::filesystem::temp_directory_path() / "muse_service_test_sample.wav").string();
     const uint32_t sampleRate = 48000;
     const uint16_t channels = 1;
     const uint16_t bitsPerSample = 16;
-    const uint32_t dataBytes = 8 * sizeof(int16_t);
+    const uint32_t numFrames = 480;
+    const uint32_t dataBytes = numFrames * sizeof(int16_t);
     const uint32_t byteRate = sampleRate * channels * bitsPerSample / 8;
     const uint16_t blockAlign = channels * bitsPerSample / 8;
 
@@ -73,8 +78,10 @@ std::string writeTestWav() {
     u16(bitsPerSample);
     std::fwrite("data", 1, 4, f);
     u32(dataBytes);
-    const int16_t silence[8] = {};
-    std::fwrite(silence, sizeof(int16_t), 8, f);
+    for (uint32_t i = 0; i < numFrames; ++i) {
+        const int16_t sample = (i % 2 == 0) ? 29000 : -29000;
+        std::fwrite(&sample, sizeof(int16_t), 1, f);
+    }
     std::fclose(f);
     return path;
 }
@@ -82,12 +89,32 @@ std::string writeTestWav() {
 } // namespace
 
 int main() {
+    // Built-ins (the sampler) register inside PluginManager::initialize();
+    // without it load_sample sets the path but never instantiates a plugin,
+    // and renders come back silent.
+    if (!Aestra::Audio::PluginManager::getInstance().initialize()) {
+        std::cout << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+
     auto trackManager = std::make_shared<TrackManager>();
     // Mirror the app wiring (AestraContent): units need the pattern manager
     // to auto-create their default MIDI pattern.
     trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
+
+    // Engine wired like MuseRepl so render_pattern can pump the live path.
+    AudioEngine engine;
+    engine.setSampleRate(48000);
+    engine.setBufferConfig(512, 2);
+    MuseService::wireHeadlessEngine(trackManager, engine);
+    if (!engine.initialize()) {
+        std::cout << "FAIL: engine initialize\n";
+        return 1;
+    }
+
     CommandRegistry::initialize(trackManager.get());
-    MuseService service(trackManager.get(), nullptr);
+    CommandRegistry::setAudioEngine(&engine);
+    MuseService service(trackManager.get(), &engine);
 
     // --- Protocol: malformed input never crashes, always structured error ---
     {
@@ -336,6 +363,40 @@ int main() {
                  "{\"id\": 77, \"verb\": \"get_pattern\", "
                  "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
         check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
+    }
+
+    // --- Render: the beat comes back as a file with signal in it ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string outPath =
+            (std::filesystem::temp_directory_path() / "muse_service_test_render.wav").string();
+        std::filesystem::remove(outPath);
+
+        JSON r = call(service, "{\"id\": 80, \"verb\": \"render_pattern\"}");
+        check(status(r) == "validation_error", "render_pattern without args -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 81, \"verb\": \"render_pattern\", "
+                 "\"args\": {\"pattern\": 999999, \"file\": \"" + outPath + "\"}}");
+        check(status(r) == "execution_error", "render_pattern unknown pattern -> execution_error");
+
+        r = call(service, "{\"id\": 82, \"verb\": \"render_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"file\": \"" + outPath + "\", \"tail\": 0.25}}");
+        check(status(r) == "ok", "render_pattern ok");
+        check(r["result"]["frames"].asNumber() > 0.0, "render reports frames");
+        check(std::filesystem::exists(outPath) && std::filesystem::file_size(outPath) > 44,
+              "rendered wav exists with data");
+        // The pattern triggers the loud test click through the sampler; a
+        // silent render means the pattern->unit->engine path is broken.
+        check(r["result"]["peakDb"].asNumber() > -90.0,
+              "rendered audio is not silent (peakDb " +
+                  std::to_string(r["result"]["peakDb"].asNumber()) + ")");
+        check(!engine.isTransportPlaying(), "engine transport stopped after render");
+
+        r = call(service, "{\"id\": 83, \"verb\": \"render_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"file\": \"" + outPath + "\", \"wobble\": 1}}");
+        check(status(r) == "validation_error", "render_pattern unknown arg -> validation_error");
+        std::filesystem::remove(outPath);
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))


### PR DESCRIPTION
## What

Closes the agentic loop: an external process can now make a beat through the Muse pipe and get a **playable WAV back**, with enough metadata to know whether it actually made sound:

```
{"id":1,"verb":"render_pattern","args":{"pattern":1,"file":"beat.wav","tail":1}}
→ {"status":"ok","result":{"durationSeconds":4.43,"frames":212571,"peakDb":-21.0,"sampleRate":48000}}
```

## How

- **`render_pattern {pattern, file, tail?}`** — offline bounce through the *exact live engine path*: `playPatternInArsenal` + `processBlock` pump + `performNonRealtimeMaintenance` per block. That last call is load-bearing: the pattern scheduler's RT queue is refilled from the control thread, and offline *we* are the control thread — `AudioExporter` does the same per block. Result carries `peakDb` so an agent can distinguish silence from signal without decoding the file. Two settle blocks after stop drain the transport command so the engine is actually stopped on return. Not routed through CommandHistory — a bounce is not an undoable project edit.
- **`MuseService::wireHeadlessEngine`** — the five engine↔model links `AestraContent` wires (unit manager, pattern playback engine, continuous params, channel slot map, transport command sink), extracted so headless hosts can't silently drift from the app. Any one of them missing = silent renders with every command still returning ok.
- **MuseRepl** now initializes `PluginManager` — built-ins (the sampler) register inside `initialize()`; without it `load_sample` sets the unit's path but never instantiates a plugin.

## The debugging story (why the test asserts peakDb)

First render came back silent with every command reporting ok. Three separate missing links, found in sequence: plugin registration (PluginManager), engine↔model wiring (five links), and the control-thread maintenance tick. None of them error — they all just produce zeros. So the test's hand-rolled sample is now a loud click and the render section asserts `peakDb > -90`: a broken pattern→unit→engine link now **fails the suite** instead of passing silently.

## Validation

- `MuseServiceTest`: 69/69 assertions (render contract: no args / unknown pattern / unknown arg rejected; ok render produces a real file with signal; transport stopped after).
- Full `commands` suite 10/10.
- End-to-end through the pipe: bpm 140 → unit → real WAV into the sampler → three notes → rendered 4.4 s in 108 ms (~41× realtime), peak −21 dB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `render_pattern` to render MIDI patterns through the live engine path into playable float32 WAV files, returning duration, frame count, sample rate, and peak dB metadata.
- Added validation for invalid arguments, unknown or non-MIDI patterns, file-writing failures, silent output, and transport state.
- Extracted shared headless engine wiring and initialized plugins and the audio engine in `MuseRepl`.
- Added control-thread maintenance and transport settling during offline rendering.
- Expanded tests with non-silent sample generation and end-to-end render coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->