### PR TITLE
feat(muse): arrange verbs — patterns onto the timeline, whole song back as audio

### DIFF
--- a/AestraAudio/include/Commands/ArrangePatternCommand.h
+++ b/AestraAudio/include/Commands/ArrangePatternCommand.h
@@ -1,0 +1,115 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to place a MIDI pattern on the timeline as a clip (undoable)
+ *
+ * Mirrors the whole pattern-drop gesture the timeline UI performs, not just
+ * the clip insert:
+ *  - creates playlist lanes up to the target track index (the app maintains
+ *    a 1:1 lane/channel mapping),
+ *  - routes every unit referenced by the pattern's notes to that timeline
+ *    lane (route authority for playback and export),
+ *  - adds a pattern-bound clip sized to the pattern length.
+ *
+ * Undo removes the clip, restores each unit's previous route, and removes
+ * any lanes this command created. Like AddChannelCommand, redo after undo
+ * mints fresh lane/clip IDs.
+ */
+class ArrangePatternCommand : public ICommand {
+public:
+    ArrangePatternCommand(TrackManager& trackManager, PatternID patternId, size_t trackIndex,
+                          double startBeat)
+        : m_trackManager(trackManager), m_patternId(patternId), m_trackIndex(trackIndex),
+          m_startBeat(startBeat) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_createdLanes.clear();
+        m_previousUnitRoutes.clear();
+
+        auto& playlist = m_trackManager.getPlaylistModel();
+        const PatternSource* pattern = m_trackManager.getPatternManager().getPattern(m_patternId);
+        if (!pattern || !pattern->isMidi()) return;
+
+        while (playlist.getLaneCount() <= m_trackIndex) {
+            PlaylistLaneID laneId =
+                playlist.createLane("Lane " + std::to_string(playlist.getLaneCount() + 1));
+            if (!laneId.isValid()) return;
+            m_createdLanes.push_back(laneId);
+        }
+        const PlaylistLaneID laneId = playlist.getLaneId(m_trackIndex);
+        if (!laneId.isValid()) return;
+
+        auto& unitManager = m_trackManager.getUnitManager();
+        std::unordered_set<UnitID> routed;
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.unitId == 0 || !routed.insert(note.unitId).second) continue;
+            if (!unitManager.getUnit(note.unitId)) continue;
+            m_previousUnitRoutes.emplace_back(note.unitId,
+                                              unitManager.getUnitTimelineLane(note.unitId));
+            unitManager.assignUnitToTimelineLane(note.unitId, static_cast<int>(m_trackIndex));
+        }
+
+        ClipInstance clip;
+        clip.id = ClipInstanceID::generate();
+        clip.name = pattern->name;
+        clip.startBeat = m_startBeat;
+        clip.durationBeats = pattern->lengthBeats;
+        clip.patternId = m_patternId;
+        clip.sourceId = m_patternId.value;
+
+        m_clipId = playlist.addClip(laneId, clip);
+        m_executed = m_clipId.isValid();
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        auto& playlist = m_trackManager.getPlaylistModel();
+        auto& unitManager = m_trackManager.getUnitManager();
+
+        playlist.removeClip(m_clipId);
+        for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend(); ++it) {
+            unitManager.assignUnitToTimelineLane(it->first, it->second);
+        }
+        for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
+            playlist.removeLane(*it);
+        }
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Arrange Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    PatternID m_patternId;
+    size_t m_trackIndex;
+    double m_startBeat;
+
+    // Recorded by execute() for undo
+    std::vector<PlaylistLaneID> m_createdLanes;
+    std::vector<std::pair<UnitID, int>> m_previousUnitRoutes;
+    ClipInstanceID m_clipId;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/ArrangePatternCommand.h
+++ b/AestraAudio/include/Commands/ArrangePatternCommand.h
@@ -40,19 +40,40 @@ public:
         m_previousUnitRoutes.clear();
 
         auto& playlist = m_trackManager.getPlaylistModel();
+        auto& unitManager = m_trackManager.getUnitManager();
         const PatternSource* pattern = m_trackManager.getPatternManager().getPattern(m_patternId);
         if (!pattern || !pattern->isMidi()) return;
+
+        // A failure after partial mutation must not leave lanes or routes
+        // behind: unwind everything staged so far before returning without
+        // m_executed set.
+        const auto rollbackStaged = [&]() {
+            for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend();
+                 ++it) {
+                unitManager.assignUnitToTimelineLane(it->first, it->second);
+            }
+            for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
+                playlist.removeLane(*it);
+            }
+            m_previousUnitRoutes.clear();
+            m_createdLanes.clear();
+        };
 
         while (playlist.getLaneCount() <= m_trackIndex) {
             PlaylistLaneID laneId =
                 playlist.createLane("Lane " + std::to_string(playlist.getLaneCount() + 1));
-            if (!laneId.isValid()) return;
+            if (!laneId.isValid()) {
+                rollbackStaged();
+                return;
+            }
             m_createdLanes.push_back(laneId);
         }
         const PlaylistLaneID laneId = playlist.getLaneId(m_trackIndex);
-        if (!laneId.isValid()) return;
+        if (!laneId.isValid()) {
+            rollbackStaged();
+            return;
+        }
 
-        auto& unitManager = m_trackManager.getUnitManager();
         std::unordered_set<UnitID> routed;
         for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
             if (note.unitId == 0 || !routed.insert(note.unitId).second) continue;
@@ -71,7 +92,11 @@ public:
         clip.sourceId = m_patternId.value;
 
         m_clipId = playlist.addClip(laneId, clip);
-        m_executed = m_clipId.isValid();
+        if (!m_clipId.isValid()) {
+            rollbackStaged();
+            return;
+        }
+        m_executed = true;
     }
 
     void undo() override {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -529,6 +529,15 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         // lanes, but the channel itself must already exist.
         if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount()) return nullptr;
 
+        // A unit has a single timeline route: arranging it onto a different
+        // track would silently reroute every earlier clip that uses it.
+        // Reject the conflict instead of corrupting existing arrangements.
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.unitId == 0) continue;
+            const int route = tm->getUnitManager().getUnitTimelineLane(note.unitId);
+            if (route >= 0 && route != *trackOpt) return nullptr;
+        }
+
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
                                                        static_cast<size_t>(*trackOpt),
                                                        static_cast<double>(*startOpt));

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -3,6 +3,7 @@
 #include "Commands/AddClipCommand.h"
 #include "Commands/AddNoteCommand.h"
 #include "Commands/AddUnitCommand.h"
+#include "Commands/ArrangePatternCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -177,6 +178,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("delete_note", noopTrack);
         reg.registerCommand("move_note", noopTrack);
         reg.registerCommand("set_note", noopTrack);
+        reg.registerCommand("arrange_pattern", noopTrack);
         return;
     }
 
@@ -504,6 +506,32 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         }
         return std::make_unique<MoveNoteCommand>(tm->getPatternManager(), key->patternId, *note,
                                                  static_cast<double>(*toStartOpt), toPitch);
+    });
+
+    reg.registerCommand("arrange_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return nullptr;
+        auto startOpt = safeStof(*startRaw);
+        if (!startOpt) return nullptr;
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        // Tracks are mixer channels; the command creates matching playlist
+        // lanes, but the channel itself must already exist.
+        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount()) return nullptr;
+
+        return std::make_unique<ArrangePatternCommand>(*tm, patternId,
+                                                       static_cast<size_t>(*trackOpt),
+                                                       static_cast<double>(*startOpt));
     });
 
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -111,6 +111,11 @@ static const std::vector<CommandSchema> s_schemas = {
         {"to_start", FlagType::Float, true, 0.0},
         {"to_pitch", FlagType::Int, false, 0.0, 127.0}
     }},
+    {"arrange_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"track", FlagType::Int, true, 0.0},
+        {"start", FlagType::Float, true, 0.0}
+    }},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -5,6 +5,8 @@
 #include "Commands/CommandResult.h"
 #include "Commands/CommandTransaction.h"
 #include "Core/AudioEngine.h"
+#include "Core/PlaybackGraphController.h"
+#include "IO/AudioExporter.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -117,7 +119,7 @@ bool isQueryVerb(const std::string& verb) {
 // through CommandHistory — a bounce is not an undoable project edit; batch
 // pushes one CommandTransaction so the whole group is a single undo step.
 bool isActionVerb(const std::string& verb) {
-    return verb == "render_pattern" || verb == "batch";
+    return verb == "render_pattern" || verb == "render_song" || verb == "batch";
 }
 
 // JSON args -> flag map for the schema/registry path. Returns false with
@@ -329,6 +331,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     c.set("name", JSON(clip.name));
                     c.set("startBeat", JSON(clip.startBeat));
                     c.set("durationBeats", JSON(clip.durationBeats));
+                    // 0 = not a pattern clip
+                    c.set("pattern", JSON(static_cast<double>(clip.patternId.value)));
                     clips.push(c);
                 }
                 laneJson.set("clips", clips);
@@ -394,6 +398,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 u.set("soloed", JSON(unit->isSolo));
                 u.set("defaultPatternId",
                       JSON(static_cast<double>(unit->defaultPatternId.value)));
+                // -1 = preview-to-master; >= 0 routes into that timeline track.
+                u.set("timelineLane",
+                      JSON(static_cast<double>(unitManager.getUnitTimelineLane(unitId))));
                 u.set("samplePath", JSON(unit->audioClipPath));
                 u.set("sampleDurationSeconds", JSON(unit->audioDurationSeconds));
                 units.push(u);
@@ -601,6 +608,114 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return finish(response);
         }
 
+        if (verb == "render_song") {
+            if (!m_trackManager || !m_engine) {
+                return makeError(id, "execution_error",
+                                 "render_song needs a track manager and an audio engine", verb)
+                    .toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "render_song requires args: {\"file\": <path>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "file" && entry.first != "tail") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for render_song: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("file") || !args["file"].isString() || args["file"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'file' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+            double tailSeconds = 1.0;
+            if (args.has("tail")) {
+                if (!args["tail"].isNumber()) {
+                    return makeError(id, "validation_error", "arg 'tail' must be a number", verb)
+                        .toString();
+                }
+                tailSeconds = args["tail"].asNumber();
+                if (!(tailSeconds >= 0.0 && tailSeconds <= 30.0)) {
+                    return makeError(id, "validation_error", "arg 'tail' must be 0..30 seconds",
+                                     verb)
+                        .toString();
+                }
+            }
+
+            // Channels may have been added since the engine was wired; the
+            // exporter render path resolves tracks through the slot map.
+            m_trackManager->buildAndShareSlotMap();
+            if (auto slotMap = m_trackManager->getChannelSlotMapShared()) {
+                m_engine->setChannelSlotMap(slotMap);
+            }
+
+            // The timeline render path routes tracks to master through the
+            // published audio graph; in the app AestraApp::run() drains
+            // rebuilds continuously, headless we drain here.
+            PlaybackGraphController graphController;
+            graphController.setTrackManager(m_trackManager);
+            graphController.setAudioEngine(m_engine);
+            graphController.requestRebuild(GraphDirtyReason::TimelineChanged);
+            graphController.drainIfDirty(static_cast<double>(m_engine->getSampleRate()));
+
+            AudioExporter::Result exportResult;
+            {
+                // TrackManager::play() is what schedules timeline MIDI clip
+                // instances into the pattern engine — the exporter only
+                // drives the engine transport. Guarantee stop + pattern-mode
+                // restore on every exit.
+                struct TimelineGuard {
+                    TrackManager& trackManager;
+                    AudioEngine& engine;
+                    ~TimelineGuard() {
+                        trackManager.stop();
+                        std::vector<float> settle(1024, 0.0f);
+                        for (int i = 0; i < 2; ++i) {
+                            engine.processBlock(settle.data(), nullptr, 512, 0.0);
+                            engine.performNonRealtimeMaintenance();
+                        }
+                    }
+                } guard{*m_trackManager, *m_engine};
+
+                // Leave any Arsenal pattern-mode state behind: TrackManager's
+                // play() only schedules timeline MIDI clip instances when its
+                // own pattern-mode flag is clear.
+                m_trackManager->stopArsenalPlayback(false);
+                m_engine->setPatternPlaybackMode(false, 4.0);
+                m_trackManager->setPosition(0.0);
+                m_trackManager->play();
+
+                AudioExporter exporter(*m_engine, *m_trackManager);
+                AudioExporter::Config config;
+                config.outputPath = args["file"].asString();
+                config.scope = AudioExporter::RenderScope::FullSong;
+                config.sampleRate = m_engine->getSampleRate();
+                config.bitDepth = AudioExporter::BitDepth::Float_32;
+                config.numChannels = 2;
+                config.tailSeconds = tailSeconds;
+                exportResult = exporter.render(config);
+            }
+
+            if (!exportResult.success) {
+                return makeError(id, "execution_error", exportResult.errorMessage, verb)
+                    .toString();
+            }
+
+            JSON result = JSON::object();
+            result.set("file", JSON(exportResult.outputPath));
+            result.set("durationSeconds", JSON(exportResult.durationSeconds));
+            result.set("frames", JSON(static_cast<double>(exportResult.framesRendered)));
+            result.set("sampleRate", JSON(static_cast<double>(m_engine->getSampleRate())));
+            result.set("peakDb", JSON(exportResult.peakDb));
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
         if (verb == "render_pattern") {
             if (!m_trackManager || !m_engine) {
                 return makeError(id, "execution_error",
@@ -698,7 +813,11 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     TrackManager& trackManager;
                     std::vector<float>& block;
                     ~TransportGuard() {
-                        trackManager.stop();
+                        // Full Arsenal teardown: stop, flush the scheduled
+                        // instance, and leave pattern mode — a lingering
+                        // pattern-mode flag or instance would bleed into the
+                        // next timeline play/render.
+                        trackManager.stopArsenalPlayback(false);
                         for (int i = 0; i < 2; ++i) {
                             std::memset(block.data(), 0, block.size() * sizeof(float));
                             engine.processBlock(block.data(), nullptr, kBlockFrames, 0.0);

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -81,7 +81,9 @@ int main(int argc, char** argv) {
 
     AudioEngine engine;
     engine.setSampleRate(sampleRate);
-    engine.setBufferConfig(512, 2);
+    // Must cover AudioExporter's 4096-frame render blocks (render_song):
+    // processBlock does not split blocks larger than the configured maximum.
+    engine.setBufferConfig(4096, 2);
     MuseService::wireHeadlessEngine(trackManager, engine);
     if (!engine.initialize()) {
         std::cerr << "failed to initialize audio engine\n";

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -120,7 +120,9 @@ int main() {
     // Engine wired like MuseRepl so render_pattern can pump the live path.
     AudioEngine engine;
     engine.setSampleRate(48000);
-    engine.setBufferConfig(512, 2);
+    // Must cover AudioExporter's 4096-frame render blocks: processBlock does
+    // not split blocks larger than the configured maximum, it overruns.
+    engine.setBufferConfig(4096, 2);
     MuseService::wireHeadlessEngine(trackManager, engine);
     if (!engine.initialize()) {
         std::cout << "FAIL: engine initialize\n";
@@ -535,6 +537,101 @@ int main() {
         check(status(r) == "parse_error" &&
                   r["message"].asString().find("commands[0]") != std::string::npos,
               "unknown verb inside batch -> parse_error naming the index");
+    }
+
+    // --- Arrange: pattern onto the timeline as a clip ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+
+        // Earlier sections leave track 0 muted (the typed-args mute survived
+        // the delete/undo reorder); the arranged pattern routes here, so an
+        // accidentally muted target would make the song render silent for
+        // reasons unrelated to the arrange path.
+        JSON unmute = call(service,
+                           "{\"id\": 109, \"verb\": \"mute_track\", "
+                           "\"args\": {\"track\": 0, \"state\": false}}");
+        check(status(unmute) == "ok", "unmute render target track");
+
+        JSON r = call(service, "{\"id\": 110, \"verb\": \"list_clips\"}");
+        const size_t lanesBefore = r["result"]["lanes"].size();
+
+        r = call(service, "{\"id\": 111, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 0}}");
+        check(status(r) == "ok", "arrange_pattern ok");
+
+        r = call(service, "{\"id\": 112, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"].size() > lanesBefore, "arrange created the missing lane");
+        check(r["result"]["lanes"][0]["clips"].size() == 1, "lane carries one clip");
+        check(r["result"]["lanes"][0]["clips"][0]["pattern"].asNumber() == kickPattern,
+              "clip is bound to the pattern");
+        check(r["result"]["lanes"][0]["clips"][0]["durationBeats"].asNumber() > 0.0,
+              "clip sized from pattern length");
+
+        r = call(service, "{\"id\": 113, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["timelineLane"].asNumber() == 0.0,
+              "pattern's unit routed to timeline lane 0");
+
+        r = call(service, "{\"id\": 114, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 8}}");
+        check(status(r) == "ok", "second arrange at beat 8 ok");
+        r = call(service, "{\"id\": 115, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"][0]["clips"].size() == 2, "two clips on the lane");
+
+        // Undo unwinds the whole gesture: clip, unit routing, created lane.
+        trackManager->getCommandHistory().undo();
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 116, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"].size() == lanesBefore, "undo removes the created lane");
+        r = call(service, "{\"id\": 117, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["timelineLane"].asNumber() == -1.0,
+              "undo restores the unit's preview routing");
+
+        // Contract: bad targets never build.
+        r = call(service,
+                 "{\"id\": 118, \"verb\": \"arrange_pattern\", "
+                 "\"args\": {\"pattern\": 999999, \"track\": 0, \"start\": 0}}");
+        check(status(r) == "execution_error", "arrange unknown pattern -> execution_error");
+        r = call(service, "{\"id\": 119, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 99, \"start\": 0}}");
+        check(status(r) == "execution_error", "arrange onto missing channel -> execution_error");
+    }
+
+    // --- Render the arrangement: the song comes back as audio ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string outPath =
+            (std::filesystem::temp_directory_path() / "muse_service_test_song.wav").string();
+        std::filesystem::remove(outPath);
+
+        JSON r = call(service, "{\"id\": 120, \"verb\": \"render_song\"}");
+        check(status(r) == "validation_error", "render_song without args -> validation_error");
+
+        r = call(service, fileRequest(121, "render_song", "pattern", 1.0, outPath));
+        check(status(r) == "validation_error", "render_song unknown arg -> validation_error");
+
+        r = call(service, "{\"id\": 122, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 0}}");
+        check(status(r) == "ok", "re-arrange for render ok");
+
+        JSON req = JSON::object();
+        req.set("id", JSON(123.0));
+        req.set("verb", JSON("render_song"));
+        JSON reqArgs = JSON::object();
+        reqArgs.set("file", JSON(outPath));
+        reqArgs.set("tail", JSON(0.25));
+        req.set("args", reqArgs);
+        r = call(service, req.toString());
+        check(status(r) == "ok", "render_song ok");
+        check(r["result"]["frames"].asNumber() > 0.0, "song render reports frames");
+        check(std::filesystem::exists(outPath) && std::filesystem::file_size(outPath) > 44,
+              "song wav exists with data");
+        // The timeline clip triggers the loud test click through the routed
+        // unit; silence means the clip->schedule->unit->track path is broken.
+        check(r["result"]["peakDb"].asNumber() > -90.0,
+              "song render is not silent (peakDb " +
+                  std::to_string(r["result"]["peakDb"].asNumber()) + ")");
+        check(!engine.isTransportPlaying(), "engine transport stopped after song render");
+        std::filesystem::remove(outPath);
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -576,6 +576,15 @@ int main() {
         check(status(r) == "ok", "second arrange at beat 8 ok");
         r = call(service, "{\"id\": 115, \"verb\": \"list_clips\"}");
         check(r["result"]["lanes"][0]["clips"].size() == 2, "two clips on the lane");
+        check(r["result"]["lanes"][0]["clips"][1]["startBeat"].asNumber() == 8.0,
+              "second clip starts at the requested beat");
+
+        // Conflict: the pattern's unit is routed to lane 0; arranging it on
+        // another track would silently reroute the clips already placed.
+        r = call(service, "{\"id\": 130, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 1, \"start\": 0}}");
+        check(status(r) == "execution_error",
+              "arrange onto a conflicting track -> execution_error");
 
         // Undo unwinds the whole gesture: clip, unit routing, created lane.
         trackManager->getCommandHistory().undo();
@@ -609,9 +618,33 @@ int main() {
         r = call(service, fileRequest(121, "render_song", "pattern", 1.0, outPath));
         check(status(r) == "validation_error", "render_song unknown arg -> validation_error");
 
+        // The arrange section undid its clips: the timeline is empty here.
+        JSON emptyReq = JSON::object();
+        emptyReq.set("id", JSON(124.0));
+        emptyReq.set("verb", JSON("render_song"));
+        JSON emptyArgs = JSON::object();
+        emptyArgs.set("file", JSON(outPath));
+        emptyReq.set("args", emptyArgs);
+        r = call(service, emptyReq.toString());
+        check(status(r) == "execution_error", "empty timeline -> execution_error");
+        check(!std::filesystem::exists(outPath), "empty timeline writes no file");
+
         r = call(service, "{\"id\": 122, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
                               p + ", \"track\": 0, \"start\": 0}}");
         check(status(r) == "ok", "re-arrange for render ok");
+        r = call(service, "{\"id\": 125, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 8}}");
+        check(status(r) == "ok", "late clip at beat 8 for render ok");
+
+        // Unwritable destination must fail loudly, not report a phantom file.
+        JSON badDest = JSON::object();
+        badDest.set("id", JSON(126.0));
+        badDest.set("verb", JSON("render_song"));
+        JSON badDestArgs = JSON::object();
+        badDestArgs.set("file", JSON("/nonexistent_muse_dir/song.wav"));
+        badDest.set("args", badDestArgs);
+        r = call(service, badDest.toString());
+        check(status(r) == "execution_error", "unwritable destination -> execution_error");
 
         JSON req = JSON::object();
         req.set("id", JSON(123.0));
@@ -623,6 +656,10 @@ int main() {
         r = call(service, req.toString());
         check(status(r) == "ok", "render_song ok");
         check(r["result"]["frames"].asNumber() > 0.0, "song render reports frames");
+        // Two 8-beat clips at 0 and 8 = 16 beats; at 120 BPM that's 8 s. A
+        // render that ignored the late clip would come back shorter.
+        check(r["result"]["durationSeconds"].asNumber() >= 8.0,
+              "render duration reaches the late clip");
         check(std::filesystem::exists(outPath) && std::filesystem::file_size(outPath) > 44,
               "song wav exists with data");
         // The timeline clip triggers the loud test click through the routed


### PR DESCRIPTION
## What

The last structural slice of the Muse beat path: an agent can now **arrange** patterns onto the playlist and bounce the **whole song**:

```json
{"id":5,"verb":"arrange_pattern","args":{"pattern":1,"track":0,"start":0}}
{"id":6,"verb":"arrange_pattern","args":{"pattern":1,"track":0,"start":8}}
{"id":8,"verb":"render_song","args":{"file":"song.wav","tail":1}}
→ {"status":"ok","result":{"durationSeconds":7.86,"frames":377142,"peakDb":-24.0}}
```

## How

- **`arrange_pattern {pattern, track, start}`** — new `ArrangePatternCommand` mirroring the *whole* timeline pattern-drop gesture, not just the clip insert: creates lanes up to the track index (the app maintains a 1:1 lane/channel mapping), routes the pattern's note units to that timeline lane (route authority for playback **and** export), and adds a pattern-bound clip sized to the pattern length. Undo unwinds all three (clip, routes, created lanes).
- **`render_song {file, tail?}`** — bounces the timeline through the house `AudioExporter` (FullSong, float32). Headless, the service performs what the app runtime does around an export:
  - rebuild + share the channel slot map,
  - drain the audio graph via `PlaybackGraphController` (in-app `AestraApp::run()` drains continuously; without it tracks never route to master),
  - arm timeline MIDI clip scheduling via `TrackManager::play()` — the exporter only drives the engine transport and never schedules clips itself.
  All wrapped in an RAII guard that stops and restores on any exit.
- **Eyes**: `list_units` gains `timelineLane` (−1 = preview-to-master), `list_clips` clips gain `pattern` (0 = not a pattern clip).

## Two real bugs found on the way

1. **`render_pattern` left TrackManager's pattern-mode flag set** (`stop()` doesn't clear it) — which silently disables timeline clip scheduling for every later `play()`/render. Teardown now uses `stopArsenalPlayback(false)` (stop + scheduler flush + leave pattern mode).
2. **Headless buffer config**: `processBlock` does not split blocks larger than the configured maximum, and `AudioExporter` pumps 4096-frame blocks. Hosts configured at 512 overran/misrouted — MuseRepl and the test now configure 4096.

## Validation

- `MuseServiceTest`: arrange contract (lane creation, unit routing readback, undo restoring lane count and preview routing, unknown pattern/missing channel rejected), `render_song` contract, and the song render **asserted non-silent** (−19 dB) — the muted-track pitfall the suite itself hit is now guarded in the test.
- Full `commands` suite 10/10.
- Through the MuseRepl pipe: batch setup → sample → notes → two clips arranged back-to-back → 16-beat song (7.9 s) rendered in 127 ms (~62× realtime), peak −24 dB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added `arrange_pattern` to place a MIDI pattern onto the timeline (creating needed lanes, routing referenced units, and adding a pattern-bound clip) with full undo/redo and rollback on any mid-execution failure.
- Hardened `arrange_pattern` validation by rejecting routing conflicts (instead of silently rerouting) and ensuring correct timing for subsequent clips (e.g., second-clip start beat).
- Added `render_song` to export the entire rendered timeline via headless `AudioExporter`, including playback-graph draining and MIDI clip scheduling, returning render metadata (and supporting optional tail rendering).
- Extended `list_clips`/`list_units` responses to include timeline-lane/pattern bindings so arranged content is observable post-operation.
- Fixed pattern-mode teardown after `render_pattern` and updated headless rendering buffers to 4096 frames for correct `render_song` block processing.
- Expanded command integration coverage for arrangement error cases, undo behavior, empty timelines, unwritable destinations, and “late” clip rendering; the commands suite passes 10/10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->