### PR TITLE
feat(muse): musical verbs — grooves in one gesture

### DIFF
--- a/AestraAudio/include/Commands/QuantizePatternCommand.h
+++ b/AestraAudio/include/Commands/QuantizePatternCommand.h
@@ -1,0 +1,93 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to quantize note starts in a pattern toward a beat grid (undoable)
+ *
+ * strength 1.0 snaps starts exactly onto the nearest grid multiple; partial
+ * strengths move them proportionally toward it. unitId 0 quantizes every
+ * note, otherwise only that unit's notes. Undo restores the exact original
+ * starts (a snapped grid position is not invertible arithmetically).
+ */
+class QuantizePatternCommand : public ICommand {
+public:
+    QuantizePatternCommand(PatternManager& patternManager, PatternID patternId, double gridBeats,
+                           double strength, uint64_t unitId)
+        : m_patternManager(patternManager), m_patternId(patternId), m_gridBeats(gridBeats),
+          m_strength(strength), m_unitId(unitId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_originalStarts.clear();
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (size_t i = 0; i < notes.size(); ++i) {
+                MidiNote& note = notes[i];
+                if (m_unitId != 0 && note.unitId != m_unitId) continue;
+                const double snapped = std::round(note.startBeat / m_gridBeats) * m_gridBeats;
+                const double moved = note.startBeat + (snapped - note.startBeat) * m_strength;
+                if (moved != note.startBeat) {
+                    m_originalStarts.emplace_back(i, note.startBeat);
+                    note.startBeat = moved;
+                }
+            }
+        });
+
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (const auto& [index, start] : m_originalStarts) {
+                if (index < notes.size()) {
+                    notes[index].startBeat = start;
+                }
+            }
+        });
+
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Quantize Pattern"; }
+    size_t getSizeInBytes() const override {
+        return sizeof(*this) + m_originalStarts.size() * sizeof(std::pair<size_t, double>);
+    }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    double m_gridBeats;
+    double m_strength;
+    uint64_t m_unitId; // 0 = all units
+
+    // Recorded by execute() for undo: (note index, original startBeat)
+    std::vector<std::pair<size_t, double>> m_originalStarts;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetStepsCommand.h
+++ b/AestraAudio/include/Commands/SetStepsCommand.h
@@ -1,0 +1,116 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to write one drum row of a pattern from a step string (undoable)
+ *
+ * Row semantics, not append semantics: the step string defines the entire
+ * row for this (unit, pitch) — every existing note of that identity is
+ * replaced, so re-issuing the verb rewrites the groove (and a shorter string
+ * cannot leave a stale tail behind). Notes of other pitches/units are
+ * untouched.
+ *
+ * If the row extends past the pattern length, the pattern grows to fit
+ * (restored on undo).
+ */
+class SetStepsCommand : public ICommand {
+public:
+    SetStepsCommand(PatternManager& patternManager, PatternID patternId,
+                    std::vector<MidiNote> rowNotes, uint64_t unitId, int pitch,
+                    double rowLengthBeats)
+        : m_patternManager(patternManager), m_patternId(patternId),
+          m_rowNotes(std::move(rowNotes)), m_unitId(unitId), m_pitch(pitch),
+          m_rowLengthBeats(rowLengthBeats) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_replacedNotes.clear();
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+
+            // Capture and remove the entire existing row for this identity.
+            for (const MidiNote& note : notes) {
+                if (note.unitId == m_unitId && note.pitch == m_pitch) {
+                    m_replacedNotes.push_back(note);
+                }
+            }
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [this](const MidiNote& n) {
+                                           return n.unitId == m_unitId && n.pitch == m_pitch;
+                                       }),
+                        notes.end());
+
+            for (const MidiNote& note : m_rowNotes) {
+                notes.push_back(note);
+            }
+
+            m_previousLengthBeats = pattern.lengthBeats;
+            if (m_rowLengthBeats > pattern.lengthBeats) {
+                pattern.lengthBeats = m_rowLengthBeats;
+            }
+        });
+
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [this](const MidiNote& n) {
+                                           return n.unitId == m_unitId && n.pitch == m_pitch;
+                                       }),
+                        notes.end());
+            for (const MidiNote& note : m_replacedNotes) {
+                notes.push_back(note);
+            }
+            pattern.lengthBeats = m_previousLengthBeats;
+        });
+
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Steps"; }
+    size_t getSizeInBytes() const override {
+        return sizeof(*this) + (m_rowNotes.size() + m_replacedNotes.size()) * sizeof(MidiNote);
+    }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    std::vector<MidiNote> m_rowNotes;
+    uint64_t m_unitId;
+    int m_pitch;
+    double m_rowLengthBeats;
+
+    // Recorded by execute() for undo
+    std::vector<MidiNote> m_replacedNotes;
+    double m_previousLengthBeats = 0.0;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/TransposePatternCommand.h
+++ b/AestraAudio/include/Commands/TransposePatternCommand.h
@@ -1,0 +1,68 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to transpose note pitches in a pattern (undoable)
+ *
+ * The factory rejects transpositions that would push any affected note
+ * outside MIDI range, so execute never clamps — undo is a clean shift back.
+ * unitId 0 transposes every note, otherwise only that unit's notes.
+ */
+class TransposePatternCommand : public ICommand {
+public:
+    TransposePatternCommand(PatternManager& patternManager, PatternID patternId, int semitones,
+                            uint64_t unitId)
+        : m_patternManager(patternManager), m_patternId(patternId), m_semitones(semitones),
+          m_unitId(unitId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        applyShift(m_semitones);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        applyShift(-m_semitones);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Transpose Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    void applyShift(int semitones) {
+        m_patternManager.applyPatch(m_patternId, [this, semitones](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            for (MidiNote& note : std::get<MidiPayload>(pattern.payload).notes) {
+                if (m_unitId != 0 && note.unitId != m_unitId) continue;
+                note.pitch += semitones;
+            }
+        });
+    }
+
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    int m_semitones;
+    uint64_t m_unitId; // 0 = all units
+
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -8,6 +8,9 @@
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/MoveNoteCommand.h"
+#include "Commands/QuantizePatternCommand.h"
+#include "Commands/SetStepsCommand.h"
+#include "Commands/TransposePatternCommand.h"
 #include "Commands/RemoveClipCommand.h"
 #include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
@@ -179,6 +182,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("move_note", noopTrack);
         reg.registerCommand("set_note", noopTrack);
         reg.registerCommand("arrange_pattern", noopTrack);
+        reg.registerCommand("set_steps", noopTrack);
+        reg.registerCommand("quantize_pattern", noopTrack);
+        reg.registerCommand("transpose_pattern", noopTrack);
         return;
     }
 
@@ -541,6 +547,135 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
                                                        static_cast<size_t>(*trackOpt),
                                                        static_cast<double>(*startOpt));
+    });
+
+    reg.registerCommand("set_steps", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return nullptr;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return nullptr;
+        auto pitchRaw = requireFlag(flags, "pitch");
+        if (!pitchRaw) return nullptr;
+        auto pitchOpt = safeStoi(*pitchRaw);
+        if (!pitchOpt) return nullptr;
+        auto stepsRaw = requireFlag(flags, "steps");
+        if (!stepsRaw) return nullptr;
+
+        double stepBeats = 0.25; // 16th notes
+        if (auto it = flags.find("step"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            stepBeats = static_cast<double>(*v);
+        }
+        float velocity = 0.8f;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float gate = 0.9f;
+        if (auto it = flags.find("gate"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            gate = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+
+        // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
+        // typo the agent should hear about, not a silent rest.
+        const std::string steps(*stepsRaw);
+        if (steps.empty() || steps.size() > 256) return nullptr;
+        std::vector<MidiNote> rowNotes;
+        for (size_t i = 0; i < steps.size(); ++i) {
+            const char c = steps[i];
+            if (c == '-' || c == '.' || c == ' ') continue;
+            if (c != 'x' && c != 'X') return nullptr;
+            MidiNote note;
+            note.pitch = *pitchOpt;
+            note.startBeat = static_cast<double>(i) * stepBeats;
+            note.durationBeats = stepBeats * static_cast<double>(gate);
+            note.velocity = (c == 'X') ? std::min(1.0f, velocity + 0.2f) : velocity;
+            note.unitId = *unitOpt;
+            rowNotes.push_back(note);
+        }
+
+        const double rowLengthBeats = static_cast<double>(steps.size()) * stepBeats;
+        return std::make_unique<SetStepsCommand>(tm->getPatternManager(), patternId,
+                                                 std::move(rowNotes), *unitOpt, *pitchOpt,
+                                                 rowLengthBeats);
+    });
+
+    reg.registerCommand("quantize_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto gridRaw = requireFlag(flags, "grid");
+        if (!gridRaw) return nullptr;
+        auto gridOpt = safeStof(*gridRaw);
+        if (!gridOpt) return nullptr;
+
+        double strength = 1.0;
+        if (auto it = flags.find("strength"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            strength = static_cast<double>(*v);
+        }
+        uint64_t unitId = 0; // all units
+        if (auto it = flags.find("unit"); it != flags.end()) {
+            auto v = safeStoull(it->second);
+            if (!v) return nullptr;
+            unitId = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+
+        return std::make_unique<QuantizePatternCommand>(tm->getPatternManager(), patternId,
+                                                        static_cast<double>(*gridOpt), strength,
+                                                        unitId);
+    });
+
+    reg.registerCommand("transpose_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto semitonesRaw = requireFlag(flags, "semitones");
+        if (!semitonesRaw) return nullptr;
+        auto semitonesOpt = safeStoi(*semitonesRaw);
+        if (!semitonesOpt) return nullptr;
+
+        uint64_t unitId = 0; // all units
+        if (auto it = flags.find("unit"); it != flags.end()) {
+            auto v = safeStoull(it->second);
+            if (!v) return nullptr;
+            unitId = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+
+        // Reject rather than clamp: a clamped transpose is not invertible,
+        // which would corrupt undo.
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (unitId != 0 && note.unitId != unitId) continue;
+            const int shifted = note.pitch + *semitonesOpt;
+            if (shifted < 0 || shifted > 127) return nullptr;
+        }
+
+        return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
+                                                         *semitonesOpt, unitId);
     });
 
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -116,6 +116,29 @@ static const std::vector<CommandSchema> s_schemas = {
         {"track", FlagType::Int, true, 0.0},
         {"start", FlagType::Float, true, 0.0}
     }},
+    // steps: one char per step — 'x' hit, 'X' accented hit, '-' or '.' rest.
+    // The string defines the ENTIRE row for that (unit, pitch): re-issuing
+    // the verb rewrites the groove, an all-rest string clears it.
+    {"set_steps", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"steps", FlagType::String, true},
+        {"step", FlagType::Float, false, 0.015625, 4.0},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"gate", FlagType::Float, false, 0.05, 1.0}
+    }},
+    {"quantize_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"grid", FlagType::Float, true, 0.015625, 16.0},
+        {"strength", FlagType::Float, false, 0.0, 1.0},
+        {"unit", FlagType::Int, false, 1.0}
+    }},
+    {"transpose_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"semitones", FlagType::Int, true, -48.0, 48.0},
+        {"unit", FlagType::Int, false, 1.0}
+    }},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
@@ -376,6 +377,123 @@ int main() {
                  "{\"id\": 77, \"verb\": \"get_pattern\", "
                  "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
         check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
+    }
+
+    // --- Musical verbs: whole grooves in one gesture ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        JSON r = call(service,
+                      "{\"id\": 140, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                          ", \"unit\": " + u +
+                          ", \"pitch\": 40, \"steps\": \"x---X---x---X-x-\"}}");
+        check(status(r) == "ok", "set_steps writes a 16-step row");
+
+        r = call(service,
+                 "{\"id\": 141, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        size_t rowNotes = 0;
+        double accentVelocity = 0.0;
+        double plainVelocity = 0.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() == 40.0) {
+                ++rowNotes;
+                if (note["start"].asNumber() == 1.0) accentVelocity = note["velocity"].asNumber();
+                if (note["start"].asNumber() == 0.0) plainVelocity = note["velocity"].asNumber();
+            }
+        }
+        check(rowNotes == 5, "step string with 5 hits lands 5 notes");
+        check(accentVelocity > plainVelocity, "accented step is louder than plain step");
+
+        // Rewriting the row replaces it — the revision gesture.
+        r = call(service, "{\"id\": 142, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x-------\"}}");
+        check(status(r) == "ok", "rewriting the row ok");
+        r = call(service,
+                 "{\"id\": 143, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        rowNotes = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 40.0) ++rowNotes;
+        }
+        check(rowNotes == 1, "rewritten row replaced the old one");
+
+        // Undo restores the previous groove, not an empty row.
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 144, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        rowNotes = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 40.0) ++rowNotes;
+        }
+        check(rowNotes == 5, "undoing the rewrite restores the previous row");
+
+        // Garbage in the step string is an error, not a silent rest.
+        r = call(service, "{\"id\": 145, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x--q\"}}");
+        check(status(r) == "execution_error", "invalid step character rejected");
+
+        // Quantize: drag an off-grid note onto the grid.
+        r = call(service, "{\"id\": 146, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 41, \"start\": 1.13, \"duration\": 0.5}}");
+        check(status(r) == "ok", "off-grid note added");
+        r = call(service, "{\"id\": 147, \"verb\": \"quantize_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"grid\": 0.25}}");
+        check(status(r) == "ok", "quantize_pattern ok");
+        r = call(service,
+                 "{\"id\": 148, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        double quantizedStart = -1.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 41.0) {
+                quantizedStart = r["result"]["notes"][i]["start"].asNumber();
+            }
+        }
+        check(std::abs(quantizedStart - 1.25) < 1e-9, "off-grid note snapped to 1.25");
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 149, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 41.0) {
+                quantizedStart = r["result"]["notes"][i]["start"].asNumber();
+            }
+        }
+        // 1.13 crossed the JSON->flag->float boundary, so compare at float
+        // precision.
+        check(std::abs(quantizedStart - 1.13) < 1e-6, "undo restores the exact off-grid start");
+
+        // Transpose: shift the whole pattern up an octave and back.
+        r = call(service,
+                 "{\"id\": 150, \"verb\": \"transpose_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"semitones\": 12}}");
+        check(status(r) == "ok", "transpose up an octave ok");
+        r = call(service,
+                 "{\"id\": 151, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool sawShifted = false;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 52.0) sawShifted = true;
+        }
+        check(sawShifted, "row pitch 40 reads back at 52 after transpose");
+        trackManager->getCommandHistory().undo();
+
+        // Out-of-range transpose is rejected, state untouched.
+        r = call(service,
+                 "{\"id\": 152, \"verb\": \"transpose_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"semitones\": -48}}");
+        check(status(r) == "execution_error", "transpose past MIDI range rejected");
+
+        // Cleanup: drop the scratch notes so later sections see the original
+        // two-note pattern.
+        r = call(service, "{\"id\": 153, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 41, \"start\": 1.13}}");
+        check(status(r) == "ok", "scratch quantize note removed");
+        r = call(service, "{\"id\": 154, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 40, \"steps\": \"----------------\"}}");
+        check(status(r) == "ok", "row cleared with an all-rest step string");
+        r = call(service,
+                 "{\"id\": 155, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2, "pattern back to its two original notes");
     }
 
     // --- Render: the beat comes back as a file with signal in it ---

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -476,11 +476,30 @@ int main() {
         check(sawShifted, "row pitch 40 reads back at 52 after transpose");
         trackManager->getCommandHistory().undo();
 
+        // Undo must land every note back on its original pitch.
+        r = call(service,
+                 "{\"id\": 156, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        size_t at40 = 0, at52 = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            const double pitch = r["result"]["notes"][i]["pitch"].asNumber();
+            if (pitch == 40.0) ++at40;
+            if (pitch == 52.0) ++at52;
+        }
+        check(at40 == 5 && at52 == 0, "undo returns all row notes to pitch 40");
+
         // Out-of-range transpose is rejected, state untouched.
         r = call(service,
                  "{\"id\": 152, \"verb\": \"transpose_pattern\", \"args\": {\"pattern\": " + p +
                      ", \"semitones\": -48}}");
         check(status(r) == "execution_error", "transpose past MIDI range rejected");
+        r = call(service,
+                 "{\"id\": 157, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool pitchesIntact = true;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            const double pitch = r["result"]["notes"][i]["pitch"].asNumber();
+            if (pitch != 36.0 && pitch != 40.0 && pitch != 41.0) pitchesIntact = false;
+        }
+        check(pitchesIntact, "rejected transpose left no partially shifted pitches");
 
         // Cleanup: drop the scratch notes so later sections see the original
         // two-note pattern.
@@ -494,6 +513,25 @@ int main() {
         r = call(service,
                  "{\"id\": 155, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
         check(r["result"]["notes"].size() == 2, "pattern back to its two original notes");
+
+        // Batch composition: a whole groove in one gesture, one undo step.
+        r = call(service,
+                 "{\"id\": 158, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                     ", \"unit\": " + u + ", \"pitch\": 45, \"steps\": \"x---x---\"}},"
+                 "{\"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                     ", \"unit\": " + u + ", \"pitch\": 47, \"steps\": \"--x---x-\"}},"
+                 "{\"verb\": \"quantize_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"grid\": 0.25}}]}}");
+        check(status(r) == "ok", "batch of musical verbs ok");
+        r = call(service,
+                 "{\"id\": 159, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 6, "batch groove landed both rows");
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 160, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2,
+              "single undo reverts the whole musical batch");
     }
 
     // --- Render: the beat comes back as a file with signal in it ---


### PR DESCRIPTION
## What

Three verbs that lift Muse from note-level plumbing to musical gestures. A complete kick/snare/hat groove is now **one batch**:

```json
{"verb":"batch","args":{"commands":[
  {"verb":"set_steps","args":{"pattern":1,"unit":1,"pitch":36,"steps":"x---x---x---x---","velocity":0.9}},
  {"verb":"set_steps","args":{"pattern":1,"unit":1,"pitch":38,"steps":"----X-------X---"}},
  {"verb":"set_steps","args":{"pattern":1,"unit":1,"pitch":42,"steps":"x-x-x-x-x-x-x-xX","velocity":0.5,"gate":0.4}}
]}}
```

All three are plain mutation verbs: schema-validated, undoable through the shared history, and batch-composable with everything that already exists.

## The verbs

- **`set_steps {pattern, unit, pitch, steps, step?, velocity?, gate?}`** — write a drum row from a step string (`x` hit, `X` accent, `-`/`.` rest; default 16th-note steps). The string defines the **entire row** for that (unit, pitch): re-issuing rewrites the groove, an all-rest string clears it, and a shorter string can't leave a stale tail behind. Rows longer than the pattern grow it (restored on undo). Invalid characters are an error, not a silent rest. New `SetStepsCommand` captures the replaced row for undo — undoing a rewrite restores the *previous groove*, not an empty row.
- **`quantize_pattern {pattern, grid, strength?, unit?}`** — move note starts toward the grid (strength 1.0 = snap, partial = proportional). Undo restores the **exact** original starts, since snapping isn't invertible arithmetically. New `QuantizePatternCommand`.
- **`transpose_pattern {pattern, semitones, unit?}`** — shift pitches. The factory **rejects** any transpose that would leave MIDI range instead of clamping — a clamped transpose isn't invertible, which would corrupt undo. New `TransposePatternCommand`.

## Validation

- `MuseServiceTest` musical-verbs section: 16-step row lands 5 hits with accent louder than plain; rewrite replaces; **undo restores the previous groove**; invalid step char rejected; off-grid 1.13 snaps to 1.25 and undoes back to the exact float-precision original; octave transpose reads back; out-of-range transpose rejected with state untouched. All assertions pass, commands suite 10/10.
- Through the MuseRepl pipe: 15-note three-row groove written in one batch, verified via `get_pattern`, rendered at −22.8 dB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added three schema-validated, undoable Muse pattern verbs:
  - `set_steps` writes or replaces complete drum rows, supporting hits, accents, rests, velocity, and gate settings.
  - `quantize_pattern` moves note starts toward a configurable grid while preserving exact undo state.
  - `transpose_pattern` shifts pitches with MIDI range validation.
- Registered the commands and exposed their schemas, including validation for required arguments and invalid values.
- Added command implementations with execute, undo, and redo support, including pattern-length expansion for longer step rows.
- Added coverage for row writing and rewriting, undo behavior, quantization, transposition, validation errors, and batch groove workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->