### PR TITLE
feat(muse): agent UX — refusal reasons, semantic schema, pattern lifecycle

### DIFF
--- a/AestraAudio/include/Commands/ClonePatternCommand.h
+++ b/AestraAudio/include/Commands/ClonePatternCommand.h
@@ -1,0 +1,54 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to clone a pattern (undoable)
+ *
+ * Undo removes the clone. Like AddChannelCommand, redo after undo mints a
+ * fresh pattern id. getClonedPatternId() is valid after execute().
+ */
+class ClonePatternCommand : public ICommand {
+public:
+    ClonePatternCommand(PatternManager& patternManager, PatternID sourceId)
+        : m_patternManager(patternManager), m_sourceId(sourceId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_clonedId = m_patternManager.clonePattern(m_sourceId);
+        m_executed = m_clonedId.isValid();
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_patternManager.removePattern(m_clonedId);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Clone Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    PatternID getClonedPatternId() const { return m_clonedId; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_sourceId;
+    PatternID m_clonedId;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/ClonePatternCommand.h
+++ b/AestraAudio/include/Commands/ClonePatternCommand.h
@@ -4,6 +4,7 @@
 #include "Commands/ICommand.h"
 #include "Models/PatternManager.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace Aestra {
@@ -23,7 +24,13 @@ public:
     void execute() override {
         if (m_executed) return;
         m_clonedId = m_patternManager.clonePattern(m_sourceId);
-        m_executed = m_clonedId.isValid();
+        if (!m_clonedId.isValid()) {
+            // Loud, not silent: a failed clone must never be recorded as an
+            // executed command or reported as success.
+            throw std::runtime_error("failed to clone pattern " +
+                                     std::to_string(m_sourceId.value));
+        }
+        m_executed = true;
     }
 
     void undo() override {

--- a/AestraAudio/include/Commands/CommandRegistry.h
+++ b/AestraAudio/include/Commands/CommandRegistry.h
@@ -26,6 +26,23 @@ public:
         const std::string& verb,
         const std::unordered_map<std::string, std::string>& flags);
 
+    /**
+     * @brief Record why a factory refused to build, then return nullptr.
+     *
+     * Factories call `return CommandRegistry::fail("no such pattern: 7");`
+     * instead of a bare `return nullptr;` so callers can surface the reason
+     * to the agent instead of a generic "failed to build command".
+     */
+    static std::unique_ptr<ICommand> fail(const std::string& reason);
+
+    /**
+     * @brief Take the reason recorded by the most recent failed build.
+     *
+     * build() clears it before invoking the factory; empty when the factory
+     * gave no reason. Thread-local, like command execution itself.
+     */
+    static std::string consumeLastBuildError();
+
     static void initialize(TrackManager* trackManager);
 
     /** Set the AudioEngine for transport commands (play/stop/set_bpm). */

--- a/AestraAudio/include/Commands/CommandResult.h
+++ b/AestraAudio/include/Commands/CommandResult.h
@@ -20,6 +20,12 @@ struct CommandResult {
     uint64_t commandId = 0;
     double executionMs = 0.0;
     bool undoable = false;
+    /**
+     * Id of an object the command created (0 = none). Structured so agents
+     * never have to parse it out of the human-readable message
+     * (clone_pattern sets this to the new pattern id).
+     */
+    uint64_t createdId = 0;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -22,11 +22,21 @@ struct CommandSchema {
     std::string verb;
     CommandCategory category;
     std::vector<FlagSchema> flags;
+    /** One-line semantics for agents; rendered into the schema manifest. */
+    std::string description;
 };
 
 namespace MuseGrammar {
     const std::vector<CommandSchema>& allCommands();
-    /** @brief The full command schema as a JSON string — the agent tool manifest. */
+    /**
+     * @brief The full agent tool manifest as a JSON string.
+     *
+     * An object with "commands" (mutations from allCommands()), "queries" and
+     * "actions" (documented here, implemented by MuseService — keep in sync
+     * with its isQueryVerb/isActionVerb), and "notes" (engine semantics an
+     * agent cannot discover through the protocol: sampler root, unit routing,
+     * step characters, id stability).
+     */
     std::string schemaToJsonString();
     void exportSchemaToJson(const std::string& outputPath);
 }

--- a/AestraAudio/include/Commands/SetPatternLengthCommand.h
+++ b/AestraAudio/include/Commands/SetPatternLengthCommand.h
@@ -1,0 +1,58 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to set a pattern's length in beats (undoable)
+ *
+ * Notes past the new length are kept (they simply stop being scheduled), so
+ * shortening then restoring the length loses nothing.
+ */
+class SetPatternLengthCommand : public ICommand {
+public:
+    SetPatternLengthCommand(PatternManager& patternManager, PatternID patternId, double beats)
+        : m_patternManager(patternManager), m_patternId(patternId), m_beats(beats) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            m_previousBeats = pattern.lengthBeats;
+            pattern.lengthBeats = m_beats;
+        });
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            pattern.lengthBeats = m_previousBeats;
+        });
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Pattern Length"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    double m_beats;
+    double m_previousBeats = 0.0;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -152,9 +152,20 @@ CommandResult CommandParser::execute(const std::string& verb,
         result.undoable = undoable;
 
         // clone_pattern creates a new object the caller needs to address;
-        // surface its id instead of making the agent diff list_patterns.
+        // surface its id (structured in createdId, and in the message for
+        // humans) instead of making the agent diff list_patterns.
         if (const auto* clone = dynamic_cast<const ClonePatternCommand*>(shared.get())) {
+            // CommandHistory::pushAndExecute swallows a throwing execute()
+            // (the command is not recorded); an invalid id here means the
+            // clone did not happen.
+            if (!clone->getClonedPatternId().isValid()) {
+                result.status = CommandStatus::ExecutionError;
+                result.message = "failed to clone pattern";
+                result.undoable = false;
+                return finish(result);
+            }
             result.status = CommandStatus::Success;
+            result.createdId = clone->getClonedPatternId().value;
             result.message = "cloned pattern -> " +
                              std::to_string(clone->getClonedPatternId().value);
             return finish(result);

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -1,4 +1,5 @@
 #include "Commands/CommandParser.h"
+#include "Commands/ClonePatternCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Commands/CommandRegistry.h"
 
@@ -109,7 +110,8 @@ std::unique_ptr<ICommand> CommandParser::buildValidated(
     auto cmd = CommandRegistry::instance().build(verb, flags);
     if (!cmd) {
         outStatus = CommandStatus::ExecutionError;
-        outMessage = "failed to build command for: " + verb;
+        const std::string reason = CommandRegistry::consumeLastBuildError();
+        outMessage = reason.empty() ? "failed to build command for: " + verb : reason;
         return nullptr;
     }
 
@@ -148,6 +150,15 @@ CommandResult CommandParser::execute(const std::string& verb,
         auto shared = std::shared_ptr<ICommand>(std::move(cmd));
         history.pushAndExecute(shared);
         result.undoable = undoable;
+
+        // clone_pattern creates a new object the caller needs to address;
+        // surface its id instead of making the agent diff list_patterns.
+        if (const auto* clone = dynamic_cast<const ClonePatternCommand*>(shared.get())) {
+            result.status = CommandStatus::Success;
+            result.message = "cloned pattern -> " +
+                             std::to_string(clone->getClonedPatternId().value);
+            return finish(result);
+        }
     } catch (const std::exception& e) {
         result.status = CommandStatus::ExecutionError;
         result.message = e.what();

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -4,6 +4,8 @@
 #include "Commands/AddNoteCommand.h"
 #include "Commands/AddUnitCommand.h"
 #include "Commands/ArrangePatternCommand.h"
+#include "Commands/ClonePatternCommand.h"
+#include "Commands/SetPatternLengthCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -103,11 +105,25 @@ std::optional<uint64_t> safeStoull(std::string_view s) {
 }
 
 AudioEngine* s_audioEngine = nullptr;
+
+// Reason recorded by the most recent factory refusal (see CommandRegistry::fail).
+thread_local std::string t_lastBuildError;
 } // namespace
 
 CommandRegistry& CommandRegistry::instance() {
     static CommandRegistry s_instance;
     return s_instance;
+}
+
+std::unique_ptr<ICommand> CommandRegistry::fail(const std::string& reason) {
+    t_lastBuildError = reason;
+    return nullptr;
+}
+
+std::string CommandRegistry::consumeLastBuildError() {
+    std::string reason = std::move(t_lastBuildError);
+    t_lastBuildError.clear();
+    return reason;
 }
 
 void CommandRegistry::registerCommand(const std::string& verb, Factory factory) {
@@ -118,6 +134,7 @@ std::unique_ptr<ICommand> CommandRegistry::build(
     const std::string& verb,
     const std::unordered_map<std::string, std::string>& flags)
 {
+    t_lastBuildError.clear();
     auto it = m_factories.find(verb);
     if (it == m_factories.end())
         return nullptr;
@@ -185,6 +202,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("set_steps", noopTrack);
         reg.registerCommand("quantize_pattern", noopTrack);
         reg.registerCommand("transpose_pattern", noopTrack);
+        reg.registerCommand("clone_pattern", noopTrack);
+        reg.registerCommand("set_pattern_length", noopTrack);
         return;
     }
 
@@ -199,6 +218,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
+        if (*trackOpt < 0 || !tm->getChannel(static_cast<size_t>(*trackOpt)))
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<DeleteTrackCommand>(*tm, *trackOpt);
     });
 
@@ -209,6 +230,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackOpt) return nullptr;
         auto nameIt = flags.find("name");
         if (nameIt == flags.end()) return nullptr;
+        if (*trackOpt < 0 || !tm->getChannel(static_cast<size_t>(*trackOpt)))
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<RenameTrackCommand>(*tm, *trackOpt, nameIt->second);
     });
 
@@ -222,7 +245,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         bool state = parseFlagBool(*stateRaw);
         if (!trackOpt.has_value() || *trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetMuteCommand>(*ch, state);
     });
 
@@ -236,7 +259,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         bool state = parseFlagBool(*stateRaw);
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetSoloCommand>(*ch, state);
     });
 
@@ -251,7 +274,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!valueOpt) return nullptr;
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetVolumeCommand>(*ch, *valueOpt);
     });
 
@@ -266,7 +289,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!valueOpt) return nullptr;
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetPanCommand>(*ch, *valueOpt);
     });
 
@@ -285,7 +308,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
         if (!laneId.isValid())
-            return nullptr;
+            return CommandRegistry::fail("track " + std::string(*trackRaw) + " has no playlist lane");
 
         ClipInstance clip;
         clip.startBeat = (*barOpt - 1) * 4.0;
@@ -384,7 +407,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
             if (typeIt->second == "808") {
                 type = UnitType::PitchedSampler;
             } else if (typeIt->second != "sampler") {
-                return nullptr; // schema comment advertises the accepted values
+                return CommandRegistry::fail("unknown unit type: " + typeIt->second +
+                                             " (expected sampler or 808)");
             }
         }
         return std::make_unique<AddUnitCommand>(tm->getUnitManager(), name, type);
@@ -398,9 +422,11 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         auto fileRaw = requireFlag(flags, "file");
         if (!fileRaw) return nullptr;
 
-        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        if (!tm->getUnitManager().getUnit(*unitOpt))
+            return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
         std::error_code ec;
-        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec)) return nullptr;
+        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec))
+            return CommandRegistry::fail("file not found: " + std::string(*fileRaw));
         return std::make_unique<LoadSampleCommand>(tm->getUnitManager(), *unitOpt, std::string(*fileRaw));
     });
 
@@ -472,8 +498,11 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         }
 
         const PatternSource* pattern = tm->getPatternManager().getPattern(key->patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
-        if (!tm->getUnitManager().getUnit(key->unitId)) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " +
+                                         std::to_string(key->patternId.value));
+        if (!tm->getUnitManager().getUnit(key->unitId))
+            return CommandRegistry::fail("no such unit: " + std::to_string(key->unitId));
 
         MidiNote note;
         note.pitch = key->pitch;
@@ -489,7 +518,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
         return std::make_unique<RemoveNoteCommand>(tm->getPatternManager(), key->patternId, *note);
     });
 
@@ -502,7 +536,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!toStartOpt) return nullptr;
 
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
 
         int toPitch = note->pitch;
         if (auto it = flags.find("to_pitch"); it != flags.end()) {
@@ -530,10 +569,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
         // Tracks are mixer channels; the command creates matching playlist
         // lanes, but the channel itself must already exist.
-        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount()) return nullptr;
+        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount())
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
 
         // A unit has a single timeline route: arranging it onto a different
         // track would silently reroute every earlier clip that uses it.
@@ -541,7 +582,10 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
             if (note.unitId == 0) continue;
             const int route = tm->getUnitManager().getUnitTimelineLane(note.unitId);
-            if (route >= 0 && route != *trackOpt) return nullptr;
+            if (route >= 0 && route != *trackOpt)
+                return CommandRegistry::fail(
+                    "unit " + std::to_string(note.unitId) + " is already routed to track " +
+                    std::to_string(route) + "; arrange on that track or undo the earlier arrange");
         }
 
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
@@ -586,18 +630,23 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
-        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
+        if (!tm->getUnitManager().getUnit(*unitOpt))
+            return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
 
         // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
         // typo the agent should hear about, not a silent rest.
         const std::string steps(*stepsRaw);
-        if (steps.empty() || steps.size() > 256) return nullptr;
+        if (steps.empty() || steps.size() > 256)
+            return CommandRegistry::fail("steps must be 1..256 characters");
         std::vector<MidiNote> rowNotes;
         for (size_t i = 0; i < steps.size(); ++i) {
             const char c = steps[i];
             if (c == '-' || c == '.' || c == ' ') continue;
-            if (c != 'x' && c != 'X') return nullptr;
+            if (c != 'x' && c != 'X')
+                return CommandRegistry::fail(std::string("invalid step character '") + c +
+                                             "' (use x, X, -, .)");
             MidiNote note;
             note.pitch = *pitchOpt;
             note.startBeat = static_cast<double>(i) * stepBeats;
@@ -638,7 +687,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
 
         return std::make_unique<QuantizePatternCommand>(tm->getPatternManager(), patternId,
                                                         static_cast<double>(*gridOpt), strength,
@@ -664,25 +714,61 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
 
         // Reject rather than clamp: a clamped transpose is not invertible,
         // which would corrupt undo.
         for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
             if (unitId != 0 && note.unitId != unitId) continue;
             const int shifted = note.pitch + *semitonesOpt;
-            if (shifted < 0 || shifted > 127) return nullptr;
+            if (shifted < 0 || shifted > 127)
+                return CommandRegistry::fail(
+                    "transpose would move pitch " + std::to_string(note.pitch) + " to " +
+                    std::to_string(shifted) + " (outside MIDI range 0..127)");
         }
 
         return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
                                                          *semitonesOpt, unitId);
     });
 
+    reg.registerCommand("clone_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        const PatternID patternId{*patternOpt};
+        if (!tm->getPatternManager().getPattern(patternId))
+            return CommandRegistry::fail("no such pattern: " + std::string(*patternRaw));
+        return std::make_unique<ClonePatternCommand>(tm->getPatternManager(), patternId);
+    });
+
+    reg.registerCommand("set_pattern_length", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto beatsRaw = requireFlag(flags, "beats");
+        if (!beatsRaw) return nullptr;
+        auto beatsOpt = safeStof(*beatsRaw);
+        if (!beatsOpt) return nullptr;
+        const PatternID patternId{*patternOpt};
+        if (!tm->getPatternManager().getPattern(patternId))
+            return CommandRegistry::fail("no such pattern: " + std::string(*patternRaw));
+        return std::make_unique<SetPatternLengthCommand>(tm->getPatternManager(), patternId,
+                                                         static_cast<double>(*beatsOpt));
+    });
+
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
 
         float velocity = note->velocity;
         if (auto it = flags.find("velocity"); it != flags.end()) {

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -13,65 +13,80 @@ static const std::vector<CommandSchema> s_schemas = {
     // === Transport (3) ===
     {"set_bpm", CommandCategory::Transport, {
         {"value", FlagType::Float, true, 1.0, 999.0}
-    }},
+    },
+     "Set the session tempo in BPM."},
     {"play", CommandCategory::Transport, {
-    }},
+    },
+     "Start transport playback."},
     {"stop", CommandCategory::Transport, {
-    }},
+    },
+     "Stop transport playback."},
 
     // === Track (8) ===
     // NOTE: no "type" flag until the factory consumes one — advertising a
     // flag the registry ignores would make the schema lie to agents.
     {"add_track", CommandCategory::Track, {
         {"name", FlagType::String, false}
-    }},
+    },
+     "Add a mixer track (channel). Tracks are addressed by index in later commands."},
     {"delete_track", CommandCategory::Track, {
         {"track", FlagType::Int, true}
-    }},
+    },
+     "Delete the track at this index. Later indexes shift down; ids stay stable."},
     {"rename_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"name", FlagType::String, true}
-    }},
+    },
+     "Rename the track at this index."},
     {"mute_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"state", FlagType::Bool, true}
-    }},
+    },
+     "Set the mute state of a track."},
     {"solo_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"state", FlagType::Bool, true}
-    }},
+    },
+     "Set the solo state of a track."},
     {"set_volume", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"value", FlagType::Float, true, 0.0, 1.0}
-    }},
+    },
+     "Set track volume (0..1 linear)."},
     {"set_pan", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"value", FlagType::Float, true, -1.0, 1.0}
-    }},
+    },
+     "Set track pan (-1 left .. 1 right)."},
 
     // === Clip (5) ===
     {"add_clip", CommandCategory::Clip, {
         {"track", FlagType::Int, true},
         {"file", FlagType::String, true},
         {"bar", FlagType::Int, true}
-    }},
+    },
+     "Add a file-based clip on a track at a bar position."},
     {"delete_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true}
-    }},
+    },
+     "Delete a clip by id."},
     {"move_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"track", FlagType::Int, true},
         {"start", FlagType::Float, true}
-    }},
+    },
+     "Move a clip to a track and start beat."},
     {"duplicate_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"bar", FlagType::Int, true}
-    }},
+    },
+     "Duplicate a clip to a bar position."},
     {"trim_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"start", FlagType::Float, true},
         {"end", FlagType::Float, true}
-    }},
+    },
+     "Trim a clip to a start/end beat range."},
 
     // === Unit (2) ===
     // "type" accepts: sampler (default), 808. The schema format cannot
@@ -79,11 +94,13 @@ static const std::vector<CommandSchema> s_schemas = {
     {"add_unit", CommandCategory::Unit, {
         {"name", FlagType::String, false},
         {"type", FlagType::String, false}
-    }},
+    },
+     "Add an Arsenal unit: sampler (polyphonic, default) or 808 (mono with glide). Also creates the unit default MIDI pattern (see list_units.defaultPatternId)."},
     {"load_sample", CommandCategory::Unit, {
         {"unit", FlagType::Int, true, 1.0},
         {"file", FlagType::String, true}
-    }},
+    },
+     "Load an audio file into a unit sampler. MIDI pitch 60 plays it unshifted."},
 
     // === Pattern (4) ===
     // Notes are identified by (pattern, unit, pitch, start) — the same key
@@ -96,13 +113,15 @@ static const std::vector<CommandSchema> s_schemas = {
         {"duration", FlagType::Float, true, 0.001},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"pan", FlagType::Float, false, -1.0, 1.0}
-    }},
+    },
+     "Add one note. Notes carry the unit they play through; one pattern may hold notes from many units."},
     {"delete_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
         {"pitch", FlagType::Int, true, 0.0, 127.0},
         {"start", FlagType::Float, true, 0.0}
-    }},
+    },
+     "Delete the note identified by (pattern, unit, pitch, start)."},
     {"move_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -110,12 +129,14 @@ static const std::vector<CommandSchema> s_schemas = {
         {"start", FlagType::Float, true, 0.0},
         {"to_start", FlagType::Float, true, 0.0},
         {"to_pitch", FlagType::Int, false, 0.0, 127.0}
-    }},
+    },
+     "Move a note to a new start and optionally a new pitch."},
     {"arrange_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"track", FlagType::Int, true, 0.0},
         {"start", FlagType::Float, true, 0.0}
-    }},
+    },
+     "Place a pattern on the timeline as a clip, routing its units to that track. A unit routes to at most one track; conflicts are rejected."},
     // steps: one char per step — 'x' hit, 'X' accented hit, '-' or '.' rest.
     // The string defines the ENTIRE row for that (unit, pitch): re-issuing
     // the verb rewrites the groove, an all-rest string clears it.
@@ -127,18 +148,30 @@ static const std::vector<CommandSchema> s_schemas = {
         {"step", FlagType::Float, false, 0.015625, 4.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"gate", FlagType::Float, false, 0.05, 1.0}
-    }},
+    },
+     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it."},
     {"quantize_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"grid", FlagType::Float, true, 0.015625, 16.0},
         {"strength", FlagType::Float, false, 0.0, 1.0},
         {"unit", FlagType::Int, false, 1.0}
-    }},
+    },
+     "Move note starts toward the grid (in beats). strength 1 = snap; omit unit to affect all units."},
     {"transpose_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"semitones", FlagType::Int, true, -48.0, 48.0},
         {"unit", FlagType::Int, false, 1.0}
-    }},
+    },
+     "Shift note pitches by semitones. Rejected if any note would leave MIDI range 0..127."},
+    {"clone_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0}
+    },
+     "Duplicate a pattern (notes, name, length). The response message carries the new pattern id; list_patterns shows it."},
+    {"set_pattern_length", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"beats", FlagType::Float, true, 1.0, 512.0}
+    },
+     "Set the length of a pattern in beats. Playback and arranged clip scheduling use this length."},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -146,7 +179,8 @@ static const std::vector<CommandSchema> s_schemas = {
         {"start", FlagType::Float, true, 0.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"pan", FlagType::Float, false, -1.0, 1.0}
-    }}
+    },
+     "Update velocity and/or pan of the note identified by (pattern, unit, pitch, start)."}
 };
 
 const std::vector<CommandSchema>& allCommands() {
@@ -155,11 +189,13 @@ const std::vector<CommandSchema>& allCommands() {
 
 std::string schemaToJsonString() {
     std::ostringstream out;
-    out << "[\n";
+    out << "{\n\"commands\": [\n";
     for (size_t i = 0; i < s_schemas.size(); ++i) {
         const auto& cmd = s_schemas[i];
         out << "  {\n";
         out << "    \"verb\": \"" << cmd.verb << "\",\n";
+        if (!cmd.description.empty())
+            out << "    \"description\": \"" << cmd.description << "\",\n";
 
         const char* catStr = "unknown";
         switch (cmd.category) {
@@ -201,7 +237,36 @@ std::string schemaToJsonString() {
             out << ",";
         out << "\n";
     }
-    out << "]\n";
+    out << "],\n";
+
+    // Queries and actions are implemented by MuseService; keep this list in
+    // sync with its isQueryVerb()/isActionVerb().
+    out << R"("queries": [
+  {"verb": "get_transport", "args": "none", "description": "bpm, playing, positionSeconds."},
+  {"verb": "list_tracks", "args": "none", "description": "index, stable id, name, volume, pan, muted, soloed per track."},
+  {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, timelineLane (-1 = preview), samplePath per unit."},
+  {"verb": "list_clips", "args": "none", "description": "playlist lanes with clips (id, name, startBeat, durationBeats, pattern; pattern 0 = not a pattern clip)."},
+  {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
+  {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
+  {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
+],
+"actions": [
+  {"verb": "render_pattern", "args": "{\"pattern\": <id>, \"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce one pattern (Arsenal preview routing) to a float32 WAV. Result carries durationSeconds, frames, sampleRate, peakDb."},
+  {"verb": "render_song", "args": "{\"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce the arranged timeline to a float32 WAV. Errors on an empty timeline. Result carries durationSeconds, frames, sampleRate, peakDb."},
+  {"verb": "batch", "args": "{\"commands\": [{\"verb\": ..., \"args\": ...}, ...]}", "description": "Run 1..64 mutation verbs all-or-nothing as a single undo step. Members execute against the state their predecessors produced."}
+],
+"notes": {
+  "samplerPitch": "The sampler root is MIDI pitch 60: notes at 60 play the loaded sample unshifted, other pitches resample relative to 60. Put drum hits at pitch 60; write melodies around 60.",
+  "unitTypes": "sampler = polyphonic sampler; 808 = mono pitched sampler with glide.",
+  "patterns": "Every non-audio unit gets a default MIDI pattern at creation (list_units.defaultPatternId). A pattern is just a container: notes carry their unit, so one pattern can hold a whole multi-unit groove.",
+  "routing": "A unit routes to at most one timeline track. arrange_pattern routes the pattern's units to its track and rejects conflicting arrangements.",
+  "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
+  "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
+  "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
+  "undo": "Every mutation and every batch is one step in the same undo history the UI uses."
+}
+}
+)";
     return out.str();
 }
 

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -166,7 +166,7 @@ static const std::vector<CommandSchema> s_schemas = {
     {"clone_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0}
     },
-     "Duplicate a pattern (notes, name, length). The response message carries the new pattern id; list_patterns shows it."},
+     "Duplicate a pattern (notes, name, length). The new pattern id is returned in result.createdId; list_patterns shows it."},
     {"set_pattern_length", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"beats", FlagType::Float, true, 1.0, 512.0}

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -946,6 +946,13 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         response.set("verb", JSON(verb));
         response.set("message", JSON(cmdResult.message));
         response.set("undoable", JSON(cmdResult.undoable));
+        if (cmdResult.createdId != 0) {
+            // Structured id of the object the command created (e.g. the new
+            // pattern from clone_pattern) — agents must not parse the message.
+            JSON result = JSON::object();
+            result.set("createdId", JSON(static_cast<double>(cmdResult.createdId)));
+            response.set("result", result);
+        }
         response.set("executionMs", JSON(cmdResult.executionMs));
         return response.toString();
     } catch (const std::exception& e) {

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -111,7 +111,8 @@ namespace {
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
-           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
+           verb == "list_patterns";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -407,6 +408,32 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_patterns") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            JSON patterns = JSON::array();
+            for (const auto& pattern : m_trackManager->getPatternManager().getAllPatterns()) {
+                if (!pattern) continue;
+                JSON entry = JSON::object();
+                entry.set("id", JSON(static_cast<double>(pattern->id.value)));
+                entry.set("name", JSON(pattern->name));
+                entry.set("lengthBeats", JSON(pattern->lengthBeats));
+                const bool isMidi = pattern->isMidi();
+                entry.set("type", JSON(isMidi ? "midi" : "other"));
+                entry.set("noteCount",
+                          JSON(isMidi ? static_cast<double>(
+                                            std::get<MidiPayload>(pattern->payload).notes.size())
+                                      : 0.0));
+                patterns.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("patterns", patterns);
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -583,11 +583,11 @@ int main() {
                       "{\"id\": 180, \"verb\": \"clone_pattern\", \"args\": {\"pattern\": " + p +
                           "}}");
         check(status(r) == "ok", "clone_pattern ok");
-        const std::string msg = r["message"].asString();
-        check(msg.find("cloned pattern -> ") != std::string::npos,
-              "clone response carries the new pattern id");
-        const uint64_t clonedId =
-            std::stoull(msg.substr(msg.find("-> ") + 3));
+        check(r["message"].asString().find("cloned pattern -> ") != std::string::npos,
+              "clone message is human-readable");
+        check(r.has("result") && r["result"]["createdId"].isNumber(),
+              "clone response carries the new id as structured data");
+        const uint64_t clonedId = static_cast<uint64_t>(r["result"]["createdId"].asNumber());
 
         r = call(service, "{\"id\": 181, \"verb\": \"list_patterns\"}");
         check(status(r) == "ok", "list_patterns ok");

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -534,6 +534,92 @@ int main() {
               "single undo reverts the whole musical batch");
     }
 
+    // --- Agent UX: refusals carry reasons, schema carries semantics ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        // Factory refusals name the object and the rule, not just the verb.
+        JSON r = call(service,
+                      "{\"id\": 170, \"verb\": \"set_steps\", \"args\": {\"pattern\": 999999, "
+                      "\"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x---\"}}");
+        check(status(r) == "execution_error" &&
+                  r["message"].asString().find("no such MIDI pattern: 999999") != std::string::npos,
+              "unknown pattern refusal names the pattern");
+
+        r = call(service, "{\"id\": 171, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x--q\"}}");
+        check(r["message"].asString().find("invalid step character 'q'") != std::string::npos,
+              "bad step char refusal names the character");
+
+        r = call(service,
+                 "{\"id\": 172, \"verb\": \"set_volume\", \"args\": {\"track\": 97, \"value\": 0.5}}");
+        check(r["message"].asString().find("no such track: 97") != std::string::npos,
+              "unknown track refusal names the index");
+
+        r = call(service,
+                 "{\"id\": 173, \"verb\": \"add_unit\", \"args\": {\"name\": \"X\", \"type\": "
+                 "\"theremin\"}}");
+        check(r["message"].asString().find("unknown unit type: theremin") != std::string::npos,
+              "unknown unit type refusal names the type");
+
+        // The schema manifest documents queries, actions, and semantics.
+        const std::string schema = Aestra::Audio::MuseGrammar::schemaToJsonString();
+        JSON manifest = JSON::parse(schema);
+        check(manifest.has("commands") && manifest.has("queries") && manifest.has("actions") &&
+                  manifest.has("notes"),
+              "schema manifest has commands, queries, actions, notes");
+        check(manifest["notes"]["samplerPitch"].asString().find("60") != std::string::npos,
+              "schema notes document the sampler root");
+        check(manifest["commands"][0].has("description"),
+              "mutation entries carry descriptions");
+    }
+
+    // --- Pattern lifecycle: clone and length ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+
+        JSON r = call(service,
+                      "{\"id\": 180, \"verb\": \"clone_pattern\", \"args\": {\"pattern\": " + p +
+                          "}}");
+        check(status(r) == "ok", "clone_pattern ok");
+        const std::string msg = r["message"].asString();
+        check(msg.find("cloned pattern -> ") != std::string::npos,
+              "clone response carries the new pattern id");
+        const uint64_t clonedId =
+            std::stoull(msg.substr(msg.find("-> ") + 3));
+
+        r = call(service, "{\"id\": 181, \"verb\": \"list_patterns\"}");
+        check(status(r) == "ok", "list_patterns ok");
+        bool sawClone = false;
+        size_t patternCount = r["result"]["patterns"].size();
+        double sourceNotes = -1.0, cloneNotes = -2.0;
+        for (size_t i = 0; i < patternCount; ++i) {
+            JSON entry = r["result"]["patterns"][i];
+            if (entry["id"].asNumber() == static_cast<double>(clonedId)) {
+                sawClone = true;
+                cloneNotes = entry["noteCount"].asNumber();
+            }
+            if (entry["id"].asNumber() == kickPattern) sourceNotes = entry["noteCount"].asNumber();
+        }
+        check(sawClone, "clone appears in list_patterns");
+        check(cloneNotes == sourceNotes, "clone carries the source notes");
+
+        r = call(service, "{\"id\": 182, \"verb\": \"set_pattern_length\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + ", \"beats\": 16}}");
+        check(status(r) == "ok", "set_pattern_length ok");
+        r = call(service, "{\"id\": 183, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + "}}");
+        check(r["result"]["lengthBeats"].asNumber() == 16.0, "length readback is 16 beats");
+
+        // Undo unwinds length then the clone itself.
+        trackManager->getCommandHistory().undo();
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 184, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + "}}");
+        check(status(r) == "execution_error", "undo removes the cloned pattern");
+    }
+
     // --- Render: the beat comes back as a file with signal in it ---
     {
         const std::string outPath =


### PR DESCRIPTION
## What

The first full agent-driven production run (a complete beat produced through the MuseRepl pipe) surfaced exactly three classes of friction — everything an outside agent could not know or diagnose. This PR fixes all three.

## 1. Refusal reasons

Registry factories used to return bare `nullptr`, and every semantic refusal collapsed into `failed to build command for: X`. New `CommandRegistry::fail(reason)` + `consumeLastBuildError()` (thread-local, cleared per build) let the reason reach the response:

```
{"id":1,"verb":"set_volume","args":{"track":42,"value":0.5}}
→ {"status":"execution_error","message":"no such track: 42"}
```

26 semantic refusal sites converted — unknown tracks/units/patterns, arrange routing conflicts (now telling the agent *which* unit is routed *where* and what to do), invalid step characters (naming the character), out-of-range transposes (naming the pitch and where it would land). `delete_track`/`rename_track` also now validate their target exists instead of building a silent no-op.

## 2. Semantic schema manifest

`--schema` output goes from a bare mutations array to `{commands, queries, actions, notes}`:
- every mutation carries a one-line `description`;
- queries and actions (implemented by MuseService, documented here with a keep-in-sync note) are listed with arg shapes;
- `notes` captures the semantics an agent cannot discover through the protocol: **sampler root is pitch 60**, unit types, one pattern holds many units' notes, one-route-per-unit, step characters, id stability, units of measure, undo granularity.

The production run needed engine source access to learn the root-note fact; the manifest now carries it.

## 3. Pattern lifecycle

Variations previously meant retyping every note. Now:
- **`clone_pattern {pattern}`** — new `ClonePatternCommand` over the existing `PatternManager::clonePattern`; undo removes the clone; the response message carries the new id (`"cloned pattern -> 9"`) so the agent doesn't diff pattern lists;
- **`set_pattern_length {pattern, beats}`** — notes past the new length are kept, so shorten-then-restore loses nothing;
- **`list_patterns`** query (id, name, lengthBeats, noteCount, type) — clones and default patterns are now discoverable.

## Validation

- `MuseServiceTest`: refusal messages asserted verbatim (pattern/step-char/track/unit-type), manifest parsed as JSON and probed (sections present, sampler-root note, descriptions), clone id round-trip through the response message, clone contents match source, length set/readback, undo unwinds length then clone. All pass; commands suite 10/10.
- Pipe smoke: reasons, `cloned pattern -> 2`, `list_patterns`, and `--schema` parsing clean (27 commands / 7 queries / 3 actions / 8 notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Propagate specific semantic refusal reasons instead of generic command-build errors.
- Expand `--schema` with command descriptions, queries, actions, and agent-focused notes.
- Add pattern lifecycle support: clone, resize, and list patterns.
- Validate track targets for delete and rename operations.
- Make clone and resize commands undoable/redoable.
- Add coverage for refusal messages, schema content, pattern operations, undo behavior, and pipe flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->