### PR TITLE
feat(muse): effect verbs — the agentic mixing loop

### DIFF
--- a/AestraAudio/include/Commands/CommandResult.h
+++ b/AestraAudio/include/Commands/CommandResult.h
@@ -21,11 +21,13 @@ struct CommandResult {
     double executionMs = 0.0;
     bool undoable = false;
     /**
-     * Id of an object the command created (0 = none). Structured so agents
-     * never have to parse it out of the human-readable message
-     * (clone_pattern sets this to the new pattern id).
+     * Id of an object the command created, valid when hasCreatedId is true.
+     * Structured so agents never have to parse it out of the human-readable
+     * message (clone_pattern: new pattern id; add_effect: slot index, where
+     * 0 is a legitimate value — hence the explicit flag).
      */
     uint64_t createdId = 0;
+    bool hasCreatedId = false;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -50,6 +50,8 @@ public:
     bool changesProjectState() const override { return true; }
 
     size_t getSlotIndex() const { return m_slotIndex; }
+    /** True once execute() actually inserted the plugin (see CommandParser). */
+    bool wasExecuted() const { return m_executed; }
 
 private:
     TrackManager& m_trackManager;

--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -1,0 +1,186 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
+
+#include <string>
+#include <utility>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to insert an effect plugin into a track's chain (undoable)
+ *
+ * Wraps the same lifecycle the app uses: the factory creates, initializes
+ * and activates the instance; this command inserts it and requests the
+ * audio-graph rebuild the playback path needs to pick chain changes up.
+ */
+class AddEffectCommand : public ICommand {
+public:
+    AddEffectCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex,
+                     PluginInstancePtr plugin, std::string effectName)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex),
+          m_plugin(std::move(plugin)), m_effectName(std::move(effectName)) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_channel.getEffectChain().removePlugin(m_slotIndex);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Add " + m_effectName; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    size_t getSlotIndex() const { return m_slotIndex; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    PluginInstancePtr m_plugin;
+    std::string m_effectName;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to remove an effect plugin from a track's chain (undoable)
+ */
+class RemoveEffectCommand : public ICommand {
+public:
+    RemoveEffectCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_removedPlugin = m_channel.getEffectChain().removePlugin(m_slotIndex);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        if (m_removedPlugin) {
+            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin);
+        }
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Remove Effect"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    PluginInstancePtr m_removedPlugin;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to set an effect parameter (normalized 0..1, undoable)
+ */
+class SetEffectParamCommand : public ICommand {
+public:
+    SetEffectParamCommand(PluginInstancePtr plugin, uint32_t paramId, float newValue)
+        : m_plugin(std::move(plugin)), m_paramId(paramId), m_newValue(newValue) {}
+
+    void execute() override {
+        if (m_executed || !m_plugin) return;
+        m_previousValue = m_plugin->getParameter(m_paramId);
+        m_plugin->setParameter(m_paramId, m_newValue);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed || !m_plugin) return;
+        m_plugin->setParameter(m_paramId, m_previousValue);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Effect Parameter"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PluginInstancePtr m_plugin;
+    uint32_t m_paramId;
+    float m_newValue;
+    float m_previousValue = 0.0f;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to bypass/unbypass an effect slot (undoable)
+ */
+class SetEffectBypassCommand : public ICommand {
+public:
+    SetEffectBypassCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex,
+                           bool bypassed)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex),
+          m_bypassed(bypassed) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_previous = m_channel.getEffectChain().isSlotBypassed(m_slotIndex);
+        m_channel.getEffectChain().setSlotBypassed(m_slotIndex, m_bypassed);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_channel.getEffectChain().setSlotBypassed(m_slotIndex, m_previous);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return m_bypassed ? "Bypass Effect" : "Enable Effect"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    bool m_bypassed;
+    bool m_previous = false;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -173,7 +173,15 @@ CommandResult CommandParser::execute(const std::string& verb,
             return finish(result);
         }
         // add_effect: the slot is how the effect is addressed afterwards.
+        // pushAndExecute swallows a throwing execute(), so confirm the insert
+        // actually happened before reporting a slot.
         if (const auto* addEffect = dynamic_cast<const AddEffectCommand*>(shared.get())) {
+            if (!addEffect->wasExecuted()) {
+                result.status = CommandStatus::ExecutionError;
+                result.message = "failed to add effect";
+                result.undoable = false;
+                return finish(result);
+            }
             result.status = CommandStatus::Success;
             result.createdId = static_cast<uint64_t>(addEffect->getSlotIndex());
             result.hasCreatedId = true;

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -2,6 +2,7 @@
 #include "Commands/ClonePatternCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Commands/CommandRegistry.h"
+#include "Commands/EffectCommands.h"
 
 #include <algorithm>
 #include <chrono>
@@ -166,8 +167,17 @@ CommandResult CommandParser::execute(const std::string& verb,
             }
             result.status = CommandStatus::Success;
             result.createdId = clone->getClonedPatternId().value;
+            result.hasCreatedId = true;
             result.message = "cloned pattern -> " +
                              std::to_string(clone->getClonedPatternId().value);
+            return finish(result);
+        }
+        // add_effect: the slot is how the effect is addressed afterwards.
+        if (const auto* addEffect = dynamic_cast<const AddEffectCommand*>(shared.get())) {
+            result.status = CommandStatus::Success;
+            result.createdId = static_cast<uint64_t>(addEffect->getSlotIndex());
+            result.hasCreatedId = true;
+            result.message = "added effect in slot " + std::to_string(addEffect->getSlotIndex());
             return finish(result);
         }
     } catch (const std::exception& e) {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -5,7 +5,9 @@
 #include "Commands/AddUnitCommand.h"
 #include "Commands/ArrangePatternCommand.h"
 #include "Commands/ClonePatternCommand.h"
+#include "Commands/EffectCommands.h"
 #include "Commands/SetPatternLengthCommand.h"
+#include "Plugin/PluginManager.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -204,6 +206,10 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("transpose_pattern", noopTrack);
         reg.registerCommand("clone_pattern", noopTrack);
         reg.registerCommand("set_pattern_length", noopTrack);
+        reg.registerCommand("add_effect", noopTrack);
+        reg.registerCommand("remove_effect", noopTrack);
+        reg.registerCommand("bypass_effect", noopTrack);
+        reg.registerCommand("set_effect_param", noopTrack);
         return;
     }
 
@@ -730,6 +736,157 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
                                                          *semitonesOpt, unitId);
+    });
+
+    // Shared by the effect factories: case-insensitive string equality.
+    const auto equalsIgnoreCase = [](std::string_view a, std::string_view b) {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); ++i) {
+            if (std::tolower(static_cast<unsigned char>(a[i])) !=
+                std::tolower(static_cast<unsigned char>(b[i])))
+                return false;
+        }
+        return true;
+    };
+
+    reg.registerCommand("add_effect", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto effectRaw = requireFlag(flags, "effect");
+        if (!effectRaw) return nullptr;
+
+        auto& pluginManager = PluginManager::getInstance();
+        const PluginInfo* match = nullptr;
+        const auto effects = pluginManager.getEffectPlugins();
+        for (const auto& info : effects) {
+            if (info.id == *effectRaw || equalsIgnoreCase(info.name, *effectRaw)) {
+                match = &info;
+                break;
+            }
+        }
+        if (!match)
+            return CommandRegistry::fail("unknown effect: " + std::string(*effectRaw) +
+                                         " (list_plugins shows what is available)");
+
+        auto& chain = ch->getEffectChain();
+        size_t slot = chain.getFirstEmptySlot();
+        if (auto it = flags.find("slot"); it != flags.end()) {
+            auto s = safeStoi(it->second);
+            if (!s) return nullptr;
+            slot = static_cast<size_t>(*s);
+            if (chain.getPlugin(slot))
+                return CommandRegistry::fail("slot " + it->second + " on track " +
+                                             std::string(*trackRaw) + " is occupied");
+        }
+        if (slot >= EffectChain::MAX_SLOTS)
+            return CommandRegistry::fail("no empty effect slots on track " +
+                                         std::string(*trackRaw));
+
+        // Same lifecycle the app runs before inserting an effect.
+        auto instance = pluginManager.createInstanceById(match->id);
+        if (!instance)
+            return CommandRegistry::fail("failed to create effect: " + match->id);
+        if (!instance->initialize(pluginManager.getDefaultSampleRate(),
+                                  pluginManager.getDefaultBlockSize()))
+            return CommandRegistry::fail("failed to initialize effect: " + match->id);
+        instance->activate();
+        chain.prepare(pluginManager.getDefaultSampleRate(), pluginManager.getDefaultBlockSize());
+
+        return std::make_unique<AddEffectCommand>(*tm, *ch, slot, std::move(instance),
+                                                  match->name);
+    });
+
+    reg.registerCommand("remove_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        if (!ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt)))
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        return std::make_unique<RemoveEffectCommand>(*tm, *ch, static_cast<size_t>(*slotOpt));
+    });
+
+    reg.registerCommand("bypass_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        auto stateRaw = requireFlag(flags, "state");
+        if (!stateRaw) return nullptr;
+        if (!ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt)))
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        return std::make_unique<SetEffectBypassCommand>(*tm, *ch, static_cast<size_t>(*slotOpt),
+                                                        parseFlagBool(*stateRaw));
+    });
+
+    reg.registerCommand("set_effect_param", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        auto plugin = ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt));
+        if (!plugin)
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        auto paramRaw = requireFlag(flags, "param");
+        if (!paramRaw) return nullptr;
+        auto valueRaw = requireFlag(flags, "value");
+        if (!valueRaw) return nullptr;
+        auto valueOpt = safeStof(*valueRaw);
+        if (!valueOpt) return nullptr;
+
+        // param is a name (case-insensitive) or a numeric id from get_effects.
+        const auto params = plugin->getParameters();
+        const PluginParameter* target = nullptr;
+        if (auto numeric = safeStoi(*paramRaw)) {
+            for (const auto& param : params) {
+                if (param.id == static_cast<uint32_t>(*numeric)) {
+                    target = &param;
+                    break;
+                }
+            }
+        }
+        if (!target) {
+            for (const auto& param : params) {
+                if (equalsIgnoreCase(param.name, *paramRaw) ||
+                    equalsIgnoreCase(param.shortName, *paramRaw)) {
+                    target = &param;
+                    break;
+                }
+            }
+        }
+        if (!target)
+            return CommandRegistry::fail("no parameter '" + std::string(*paramRaw) + "' on " +
+                                         plugin->getInfo().name +
+                                         " (get_effects lists parameters)");
+        if (target->isReadOnly)
+            return CommandRegistry::fail("parameter '" + target->name + "' is read-only");
+
+        return std::make_unique<SetEffectParamCommand>(plugin, target->id, *valueOpt);
     });
 
     reg.registerCommand("clone_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -33,6 +33,7 @@
 #include <cmath>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -862,7 +863,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         // param is a name (case-insensitive) or a numeric id from get_effects.
         const auto params = plugin->getParameters();
         const PluginParameter* target = nullptr;
-        if (auto numeric = safeStoi(*paramRaw)) {
+        if (auto numeric = safeStoull(*paramRaw);
+            numeric && *numeric <= std::numeric_limits<uint32_t>::max()) {
             for (const auto& param : params) {
                 if (param.id == static_cast<uint32_t>(*numeric)) {
                     target = &param;

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -172,6 +172,32 @@ static const std::vector<CommandSchema> s_schemas = {
         {"beats", FlagType::Float, true, 1.0, 512.0}
     },
      "Set the length of a pattern in beats. Playback and arranged clip scheduling use this length."},
+
+    // === Effects (4) ===
+    {"add_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"effect", FlagType::String, true},
+        {"slot", FlagType::Int, false, 0.0, 9.0}
+    },
+     "Insert an effect on a track (first empty slot unless given). effect = id or name from list_plugins. result.createdId carries the slot."},
+    {"remove_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0}
+    },
+     "Remove the effect in a slot of a track's chain."},
+    {"bypass_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0},
+        {"state", FlagType::Bool, true}
+    },
+     "Bypass (true) or re-enable (false) an effect slot."},
+    {"set_effect_param", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0},
+        {"param", FlagType::String, true},
+        {"value", FlagType::Float, true, 0.0, 1.0}
+    },
+     "Set an effect parameter, normalized 0..1. param = name (case-insensitive) or numeric id from get_effects; get_effects shows the resulting display value."},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -247,6 +273,8 @@ std::string schemaToJsonString() {
   {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, timelineLane (-1 = preview), samplePath per unit."},
   {"verb": "list_clips", "args": "none", "description": "playlist lanes with clips (id, name, startBeat, durationBeats, pattern; pattern 0 = not a pattern clip)."},
   {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
+  {"verb": "list_plugins", "args": "none", "description": "available effect plugins: id, name, category. Use id or name with add_effect."},
+  {"verb": "get_effects", "args": "{\"track\": <index>}", "description": "a track's effect chain: slot, id, name, bypassed, and every parameter (id, name, value 0..1, display, unit)."},
   {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
   {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
 ],
@@ -263,6 +291,7 @@ std::string schemaToJsonString() {
   "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
   "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
   "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
+  "effects": "Effect parameters are normalized 0..1; get_effects shows the human display value after a set. A track chain has 10 slots.",
   "undo": "Every mutation and every batch is one step in the same undo history the UI uses."
 }
 }

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -482,8 +482,18 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     JSON paramJson = JSON::object();
                     paramJson.set("id", JSON(static_cast<double>(param.id)));
                     paramJson.set("name", JSON(param.name));
-                    paramJson.set("value",
-                                  JSON(static_cast<double>(plugin->getParameter(param.id))));
+                    // Plugin output is untrusted: a NaN/Inf value would break
+                    // the JSON contract — fail loudly instead.
+                    const float value = plugin->getParameter(param.id);
+                    if (!std::isfinite(value)) {
+                        return makeError(id, "execution_error",
+                                         "plugin " + plugin->getInfo().name +
+                                             " returned a non-finite value for parameter '" +
+                                             param.name + "'",
+                                         verb)
+                            .toString();
+                    }
+                    paramJson.set("value", JSON(static_cast<double>(value)));
                     paramJson.set("display", JSON(plugin->getParameterDisplay(param.id)));
                     if (!param.unit.empty()) paramJson.set("unit", JSON(param.unit));
                     params.push(paramJson);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -7,6 +7,8 @@
 #include "Core/AudioEngine.h"
 #include "Core/PlaybackGraphController.h"
 #include "IO/AudioExporter.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginManager.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -112,7 +114,12 @@ namespace {
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
-           verb == "list_patterns";
+           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects";
+}
+
+// The few queries that take arguments; every other query rejects them.
+bool queryTakesArgs(const std::string& verb) {
+    return verb == "get_pattern" || verb == "get_effects";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -249,9 +256,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return makeError(id, "parse_error", "unknown command: " + verb).toString();
         }
 
-        // Queries take no arguments — except get_pattern, which takes exactly
-        // one. Accepting anything else would silently drop caller intent.
-        if (isQueryVerb(verb) && verb != "get_pattern" && request.has("args") &&
+        // Most queries take no arguments; accepting any would silently drop
+        // caller intent.
+        if (isQueryVerb(verb) && !queryTakesArgs(verb) && request.has("args") &&
             request["args"].size() > 0) {
             return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
         }
@@ -408,6 +415,84 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_plugins") {
+            JSON plugins = JSON::array();
+            for (const auto& info : PluginManager::getInstance().getEffectPlugins()) {
+                JSON entry = JSON::object();
+                entry.set("id", JSON(info.id));
+                entry.set("name", JSON(info.name));
+                entry.set("category", JSON(info.category));
+                plugins.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("effects", plugins);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "get_effects") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "get_effects requires args: {\"track\": <index>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "track") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for get_effects: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            uint64_t trackIndex = 0;
+            if (!args.has("track") || !args["track"].isNumber() ||
+                !numberToId(args["track"].asNumber(), trackIndex)) {
+                return makeError(id, "validation_error",
+                                 "arg 'track' must be a non-negative integer", verb)
+                    .toString();
+            }
+            MixerChannel* channel = m_trackManager->getChannel(static_cast<size_t>(trackIndex));
+            if (!channel) {
+                return makeError(id, "execution_error",
+                                 "no such track: " + std::to_string(trackIndex), verb)
+                    .toString();
+            }
+
+            auto& chain = channel->getEffectChain();
+            JSON slots = JSON::array();
+            for (size_t slot = 0; slot < EffectChain::MAX_SLOTS; ++slot) {
+                auto plugin = chain.getPlugin(slot);
+                if (!plugin) continue;
+                JSON entry = JSON::object();
+                entry.set("slot", JSON(static_cast<double>(slot)));
+                entry.set("id", JSON(plugin->getInfo().id));
+                entry.set("name", JSON(plugin->getInfo().name));
+                entry.set("bypassed", JSON(chain.isSlotBypassed(slot)));
+                JSON params = JSON::array();
+                for (const auto& param : plugin->getParameters()) {
+                    JSON paramJson = JSON::object();
+                    paramJson.set("id", JSON(static_cast<double>(param.id)));
+                    paramJson.set("name", JSON(param.name));
+                    paramJson.set("value",
+                                  JSON(static_cast<double>(plugin->getParameter(param.id))));
+                    paramJson.set("display", JSON(plugin->getParameterDisplay(param.id)));
+                    if (!param.unit.empty()) paramJson.set("unit", JSON(param.unit));
+                    params.push(paramJson);
+                }
+                entry.set("params", params);
+                slots.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("effects", slots);
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);
@@ -946,7 +1031,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         response.set("verb", JSON(verb));
         response.set("message", JSON(cmdResult.message));
         response.set("undoable", JSON(cmdResult.undoable));
-        if (cmdResult.createdId != 0) {
+        if (cmdResult.hasCreatedId) {
             // Structured id of the object the command created (e.g. the new
             // pattern from clone_pattern) — agents must not parse the message.
             JSON result = JSON::object();

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -620,6 +620,95 @@ int main() {
         check(status(r) == "execution_error", "undo removes the cloned pattern");
     }
 
+    // --- Effects: the mixing loop (discover, insert, tweak, read back) ---
+    {
+        JSON r = call(service, "{\"id\": 190, \"verb\": \"list_plugins\"}");
+        check(status(r) == "ok", "list_plugins ok");
+        check(r["result"]["effects"].size() > 0, "effects are discoverable");
+        bool sawEq = false;
+        std::string eqName;
+        for (size_t i = 0; i < r["result"]["effects"].size(); ++i) {
+            if (r["result"]["effects"][i]["id"].asString() == "com.Aestrastudios.eq") {
+                sawEq = true;
+                eqName = r["result"]["effects"][i]["name"].asString();
+            }
+        }
+        check(sawEq, "built-in EQ listed");
+
+        // Insert by id; the response carries the slot as structured data.
+        r = call(service,
+                 "{\"id\": 191, \"verb\": \"add_effect\", "
+                 "\"args\": {\"track\": 0, \"effect\": \"com.Aestrastudios.eq\"}}");
+        check(status(r) == "ok", "add_effect by id ok");
+        check(r.has("result") && r["result"]["createdId"].isNumber(),
+              "add_effect returns the slot as structured data");
+        const int slot = static_cast<int>(r["result"]["createdId"].asNumber());
+
+        // Read the chain, pick a writable parameter, set it by name.
+        r = call(service, "{\"id\": 192, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(status(r) == "ok", "get_effects ok");
+        check(r["result"]["effects"].size() == 1, "chain shows one effect");
+        JSON effect = r["result"]["effects"][0];
+        check(effect["name"].asString() == eqName, "chain entry matches list_plugins name");
+        check(effect["params"].size() > 0, "effect exposes parameters");
+        const std::string paramName = effect["params"][0]["name"].asString();
+        const double originalValue = effect["params"][0]["value"].asNumber();
+
+        r = call(service, "{\"id\": 193, \"verb\": \"set_effect_param\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + ", \"param\": \"" + paramName +
+                          "\", \"value\": 0.8}}");
+        check(status(r) == "ok", "set_effect_param by name ok");
+        r = call(service, "{\"id\": 194, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        const double paramValue = r["result"]["effects"][0]["params"][0]["value"].asNumber();
+        check(paramValue > 0.79 && paramValue < 0.81, "parameter readback reflects the set");
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 195, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(std::abs(r["result"]["effects"][0]["params"][0]["value"].asNumber() -
+                       originalValue) < 1e-6,
+              "param undo restores the original value");
+        trackManager->getCommandHistory().redo();
+
+        // Bypass round-trip.
+        r = call(service, "{\"id\": 196, \"verb\": \"bypass_effect\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + ", \"state\": true}}");
+        check(status(r) == "ok", "bypass_effect ok");
+        r = call(service, "{\"id\": 197, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"][0]["bypassed"].asBool(), "bypass readback true");
+
+        // Refusals carry reasons.
+        r = call(service,
+                 "{\"id\": 198, \"verb\": \"add_effect\", "
+                 "\"args\": {\"track\": 0, \"effect\": \"MegaVerb 9000\"}}");
+        check(status(r) == "execution_error" &&
+                  r["message"].asString().find("unknown effect: MegaVerb 9000") !=
+                      std::string::npos,
+              "unknown effect refusal names it");
+        r = call(service, "{\"id\": 199, \"verb\": \"set_effect_param\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) +
+                          ", \"param\": \"wobble\", \"value\": 0.5}}");
+        check(r["message"].asString().find("no parameter 'wobble'") != std::string::npos,
+              "unknown param refusal names it");
+        r = call(service,
+                 "{\"id\": 200, \"verb\": \"remove_effect\", \"args\": {\"track\": 0, \"slot\": 7}}");
+        check(r["message"].asString().find("no effect in slot 7") != std::string::npos,
+              "empty slot refusal names it");
+
+        // Remove and verify the chain is empty again.
+        r = call(service, "{\"id\": 201, \"verb\": \"remove_effect\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + "}}");
+        check(status(r) == "ok", "remove_effect ok");
+        r = call(service, "{\"id\": 202, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 0, "chain empty after remove");
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 203, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 1, "undo restores the removed effect");
+        trackManager->getCommandHistory().undo(); // bypass
+        trackManager->getCommandHistory().undo(); // param
+        trackManager->getCommandHistory().undo(); // add_effect
+        r = call(service, "{\"id\": 204, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 0, "full undo chain leaves a clean track");
+    }
+
     // --- Render: the beat comes back as a file with signal in it ---
     {
         const std::string outPath =


### PR DESCRIPTION
## What

The "mix this track" prerequisite from the improvement list: agents can now **discover, insert, tweak, bypass and remove** the house effects with full readback — closing the loop `get_effects → set_effect_param → render → measure → repeat`.

```json
{"verb":"list_plugins"}                                  → 10 house effects (id, name, category)
{"verb":"add_effect","args":{"track":0,"effect":"Aestra EQ"}}  → {"result":{"createdId":0}}  (the slot)
{"verb":"set_effect_param","args":{"track":0,"slot":0,"param":"Low Gain","value":0.8}}
{"verb":"get_effects","args":{"track":0}}                → params with value, display string, unit
```

## The verbs

**Mutations** (all undoable, batch-composable):
- `add_effect {track, effect, slot?}` — effect by **id or case-insensitive name** from `list_plugins`; runs the same lifecycle the app runs (create → initialize → activate → chain prepare); first empty slot unless given; occupied/full slots refused with reasons. Response carries the slot in `result.createdId`.
- `remove_effect {track, slot}` / `bypass_effect {track, slot, state}` / `set_effect_param {track, slot, param, value 0..1}` — param by name (short names too) or numeric id; read-only params rejected.
- New `EffectCommands.h` (Add/Remove/SetParam/SetBypass): chain mutations and their undos request the **audio-graph rebuild** the playback path needs — without it a new effect never processes (the same lesson AestraContent encodes).

**Eyes**: `list_plugins`, and `get_effects {track}` — the second parameterized query — returning every slot with its full parameter set (id, name, normalized value, display, unit).

**Contract detail**: `CommandResult.hasCreatedId` replaces the zero-sentinel — slot 0 is a legitimate created id.

## Validation

- `MuseServiceTest` effects section: discovery, insert by id with structured slot, param set by name with readback, **undo restoring the original value** (then redo), bypass round-trip, three refusal messages asserted verbatim (unknown effect / unknown param / empty slot), remove + undo restore, and a full undo chain leaving the track clean. All pass; commands suite 10/10.
- Pipe smoke: discovery lists all 10 built-ins; a wrong name gets `unknown effect: eq (list_plugins shows what is available)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added Muse effect-management commands for listing plugins, reading effect chains, adding/removing effects, bypassing slots, and setting parameters.
- Added undo/redo support for all effect mutations, with audio-graph rebuilds following changes.
- Added case-insensitive effect and parameter lookup, normalized parameter values, and detailed readback metadata.
- Fixed created-ID handling so slot `0` is reported correctly.
- Documented the new command schemas and effect parameter semantics.
- Added end-to-end coverage for discovery, mutation, validation, bypass, removal, and undo/redo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->