### PR TITLE
feat(muse): sample discovery + expressive step strings

### DIFF
--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -667,7 +667,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                 noteVelocity = static_cast<float>(c - '0') / 9.0f;
             } else {
                 return CommandRegistry::fail(std::string("invalid step character '") + c +
-                                             "' (use x, X, 1-9, -, .)");
+                                             "' (use x, X, 1-9, -, ., or space)");
             }
             MidiNote note;
             note.pitch = *pitchOpt;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -634,6 +634,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
             if (!v) return nullptr;
             gate = *v;
         }
+        double swing = 0.0;
+        if (auto it = flags.find("swing"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            swing = static_cast<double>(*v);
+        }
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
@@ -642,8 +648,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!tm->getUnitManager().getUnit(*unitOpt))
             return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
 
-        // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
-        // typo the agent should hear about, not a silent rest.
+        // steps: 'x' hit, 'X' accent, digits '1'-'9' hit at velocity n/9,
+        // '-' '.' or ' ' rest. Anything else is a typo the agent should hear
+        // about, not a silent rest.
         const std::string steps(*stepsRaw);
         if (steps.empty() || steps.size() > 256)
             return CommandRegistry::fail("steps must be 1..256 characters");
@@ -651,14 +658,27 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         for (size_t i = 0; i < steps.size(); ++i) {
             const char c = steps[i];
             if (c == '-' || c == '.' || c == ' ') continue;
-            if (c != 'x' && c != 'X')
+            float noteVelocity;
+            if (c == 'x') {
+                noteVelocity = velocity;
+            } else if (c == 'X') {
+                noteVelocity = std::min(1.0f, velocity + 0.2f);
+            } else if (c >= '1' && c <= '9') {
+                noteVelocity = static_cast<float>(c - '0') / 9.0f;
+            } else {
                 return CommandRegistry::fail(std::string("invalid step character '") + c +
-                                             "' (use x, X, -, .)");
+                                             "' (use x, X, 1-9, -, .)");
+            }
             MidiNote note;
             note.pitch = *pitchOpt;
             note.startBeat = static_cast<double>(i) * stepBeats;
+            // Swing: every second step lands late by swing * step/2 — the
+            // classic shuffle placement.
+            if (i % 2 == 1) {
+                note.startBeat += swing * stepBeats * 0.5;
+            }
             note.durationBeats = stepBeats * static_cast<double>(gate);
-            note.velocity = (c == 'X') ? std::min(1.0f, velocity + 0.2f) : velocity;
+            note.velocity = noteVelocity;
             note.unitId = *unitOpt;
             rowNotes.push_back(note);
         }

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -147,9 +147,10 @@ static const std::vector<CommandSchema> s_schemas = {
         {"steps", FlagType::String, true},
         {"step", FlagType::Float, false, 0.015625, 4.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
-        {"gate", FlagType::Float, false, 0.05, 1.0}
+        {"gate", FlagType::Float, false, 0.05, 1.0},
+        {"swing", FlagType::Float, false, 0.0, 0.9}
     },
-     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it."},
+     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it. Digits 1-9 are hits at velocity n/9; swing delays every second step."},
     {"quantize_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"grid", FlagType::Float, true, 0.015625, 16.0},
@@ -275,6 +276,7 @@ std::string schemaToJsonString() {
   {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
   {"verb": "list_plugins", "args": "none", "description": "available effect plugins: id, name, category. Use id or name with add_effect."},
   {"verb": "get_effects", "args": "{\"track\": <index>}", "description": "a track's effect chain: slot, id, name, bypassed, and every parameter (id, name, value 0..1, display, unit)."},
+  {"verb": "list_samples", "args": "{\"dir\": <path>}", "description": "audio files under a directory (recursive, depth 3, max 500): path, name, sizeBytes. Feed paths to load_sample."},
   {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
   {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
 ],
@@ -288,7 +290,7 @@ std::string schemaToJsonString() {
   "unitTypes": "sampler = polyphonic sampler; 808 = mono pitched sampler with glide.",
   "patterns": "Every non-audio unit gets a default MIDI pattern at creation (list_units.defaultPatternId). A pattern is just a container: notes carry their unit, so one pattern can hold a whole multi-unit groove.",
   "routing": "A unit routes to at most one timeline track. arrange_pattern routes the pattern's units to its track and rejects conflicting arrangements.",
-  "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
+  "steps": "Step strings: 'x' hit at the row velocity, 'X' accented hit (+0.2), digits '1'-'9' hit at velocity n/9, '-', '.', ' ' rest. Default step is 0.25 beats (16ths). swing (0..0.9) delays every second step by swing * step/2 for shuffle feels.",
   "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
   "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
   "effects": "Effect parameters are normalized 0..1; get_effects shows the human display value after a set. A track chain has 10 slots.",

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -7,8 +7,11 @@
 #include "Core/AudioEngine.h"
 #include "Core/PlaybackGraphController.h"
 #include "IO/AudioExporter.h"
+#include "IO/AudioFileValidator.h"
 #include "Plugin/EffectChain.h"
 #include "Plugin/PluginManager.h"
+
+#include <filesystem>
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -114,12 +117,13 @@ namespace {
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
-           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects";
+           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects" ||
+           verb == "list_samples";
 }
 
 // The few queries that take arguments; every other query rejects them.
 bool queryTakesArgs(const std::string& verb) {
-    return verb == "get_pattern" || verb == "get_effects";
+    return verb == "get_pattern" || verb == "get_effects" || verb == "list_samples";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -415,6 +419,76 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_samples") {
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "list_samples requires args: {\"dir\": <path>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "dir") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for list_samples: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("dir") || !args["dir"].isString() || args["dir"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'dir' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+
+            const std::filesystem::path root(args["dir"].asString());
+            std::error_code ec;
+            if (!std::filesystem::is_directory(root, ec)) {
+                return makeError(id, "execution_error",
+                                 "not a directory: " + args["dir"].asString(), verb)
+                    .toString();
+            }
+
+            constexpr size_t kMaxEntries = 500;
+            constexpr int kMaxDepth = 3;
+            bool truncated = false;
+            std::vector<std::filesystem::path> found;
+            std::filesystem::recursive_directory_iterator it(
+                root, std::filesystem::directory_options::skip_permission_denied, ec);
+            const std::filesystem::recursive_directory_iterator end;
+            for (; !ec && it != end; it.increment(ec)) {
+                if (it.depth() >= kMaxDepth) {
+                    it.disable_recursion_pending();
+                    continue;
+                }
+                if (!it->is_regular_file(ec)) continue;
+                const std::string path = it->path().string();
+                if (!AudioFileValidator::isValidAudioFile(path)) continue;
+                if (found.size() >= kMaxEntries) {
+                    truncated = true;
+                    break;
+                }
+                found.push_back(it->path());
+            }
+            // Deterministic order for agents diffing across calls.
+            std::sort(found.begin(), found.end());
+
+            JSON samples = JSON::array();
+            for (const auto& path : found) {
+                JSON entry = JSON::object();
+                entry.set("path", JSON(path.string()));
+                entry.set("name", JSON(path.filename().string()));
+                std::error_code sizeEc;
+                const auto size = std::filesystem::file_size(path, sizeEc);
+                entry.set("sizeBytes", JSON(sizeEc ? 0.0 : static_cast<double>(size)));
+                samples.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("samples", samples);
+            result.set("truncated", JSON(truncated));
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -453,27 +453,66 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
 
             constexpr size_t kMaxEntries = 500;
-            constexpr int kMaxDepth = 3;
+            constexpr int kMaxDepth = 3;   // subdirectory nesting below root
+            constexpr size_t kScanBudget = 20000; // entries examined, audio or not
             bool truncated = false;
             std::vector<std::filesystem::path> found;
-            std::filesystem::recursive_directory_iterator it(
-                root, std::filesystem::directory_options::skip_permission_denied, ec);
-            const std::filesystem::recursive_directory_iterator end;
-            for (; !ec && it != end; it.increment(ec)) {
-                if (it.depth() >= kMaxDepth) {
-                    it.disable_recursion_pending();
-                    continue;
+            size_t scanned = 0;
+
+            // Deterministic bounded traversal: depth-first with per-directory
+            // sorted entries, so a truncated listing is always the same
+            // stable prefix across calls and platforms. Directory read
+            // failures are errors, not silently partial results.
+            std::vector<std::pair<std::filesystem::path, int>> pending;
+            pending.emplace_back(root, 0);
+            while (!pending.empty() && !truncated) {
+                const auto [dir, depth] = pending.back();
+                pending.pop_back();
+
+                std::vector<std::filesystem::directory_entry> entries;
+                std::error_code dirEc;
+                std::filesystem::directory_iterator dirIt(
+                    dir, std::filesystem::directory_options::skip_permission_denied, dirEc);
+                const std::filesystem::directory_iterator dirEnd;
+                for (; !dirEc && dirIt != dirEnd; dirIt.increment(dirEc)) {
+                    entries.push_back(*dirIt);
                 }
-                if (!it->is_regular_file(ec)) continue;
-                const std::string path = it->path().string();
-                if (!AudioFileValidator::isValidAudioFile(path)) continue;
-                if (found.size() >= kMaxEntries) {
-                    truncated = true;
-                    break;
+                if (dirEc) {
+                    return makeError(id, "execution_error",
+                                     "error reading directory " + dir.string() + ": " +
+                                         dirEc.message(),
+                                     verb)
+                        .toString();
                 }
-                found.push_back(it->path());
+                std::sort(entries.begin(), entries.end(),
+                          [](const auto& a, const auto& b) { return a.path() < b.path(); });
+
+                std::vector<std::filesystem::path> subdirs;
+                for (const auto& entry : entries) {
+                    if (++scanned > kScanBudget) {
+                        truncated = true;
+                        break;
+                    }
+                    std::error_code typeEc;
+                    if (entry.is_directory(typeEc)) {
+                        if (depth < kMaxDepth) subdirs.push_back(entry.path());
+                        continue;
+                    }
+                    if (typeEc) continue;
+                    std::error_code fileEc;
+                    if (!entry.is_regular_file(fileEc) || fileEc) continue;
+                    if (!AudioFileValidator::isValidAudioFile(entry.path().string())) continue;
+                    if (found.size() >= kMaxEntries) {
+                        truncated = true;
+                        break;
+                    }
+                    found.push_back(entry.path());
+                }
+                // Reverse push so the stack pops subdirectories in sorted order.
+                for (auto it = subdirs.rbegin(); it != subdirs.rend(); ++it) {
+                    pending.emplace_back(*it, depth + 1);
+                }
             }
-            // Deterministic order for agents diffing across calls.
             std::sort(found.begin(), found.end());
 
             JSON samples = JSON::array();
@@ -483,7 +522,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 entry.set("name", JSON(path.filename().string()));
                 std::error_code sizeEc;
                 const auto size = std::filesystem::file_size(path, sizeEc);
-                entry.set("sizeBytes", JSON(sizeEc ? 0.0 : static_cast<double>(size)));
+                // Absent field = size unknown; never a fake zero.
+                if (!sizeEc) entry.set("sizeBytes", JSON(static_cast<double>(size)));
                 samples.push(entry);
             }
             JSON result = JSON::object();

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -12,6 +12,7 @@
 
 #include "AestraJSON.h"
 
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cmath>
@@ -712,7 +713,12 @@ int main() {
     // --- Sample discovery + expressive step strings ---
     {
         // A tiny library: one wav, one decoy, one nested wav.
-        const auto libDir = std::filesystem::temp_directory_path() / "muse_service_test_lib";
+        // Unique per run so stale files or parallel runs cannot change counts.
+        const auto uniqueSuffix = std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count());
+        const auto libDir = std::filesystem::temp_directory_path() /
+                            ("muse_service_test_lib_" + uniqueSuffix);
+        std::filesystem::remove_all(libDir);
         std::filesystem::create_directories(libDir / "kicks");
         {
             // Real WAVs (the validator checks magic bytes, not just extension).
@@ -722,8 +728,11 @@ int main() {
             std::filesystem::copy_file(source, libDir / "kicks" / "deep.wav",
                                        std::filesystem::copy_options::overwrite_existing);
             std::FILE* f = std::fopen((libDir / "notes.txt").string().c_str(), "wb");
-            std::fputs("not audio", f);
-            std::fclose(f);
+            check(f != nullptr, "decoy file created");
+            if (f) {
+                std::fputs("not audio", f);
+                std::fclose(f);
+            }
         }
 
         JSON req = JSON::object();

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -709,6 +709,90 @@ int main() {
         check(r["result"]["effects"].size() == 0, "full undo chain leaves a clean track");
     }
 
+    // --- Sample discovery + expressive step strings ---
+    {
+        // A tiny library: one wav, one decoy, one nested wav.
+        const auto libDir = std::filesystem::temp_directory_path() / "muse_service_test_lib";
+        std::filesystem::create_directories(libDir / "kicks");
+        {
+            // Real WAVs (the validator checks magic bytes, not just extension).
+            const std::string source = writeTestWav();
+            std::filesystem::copy_file(source, libDir / "top.wav",
+                                       std::filesystem::copy_options::overwrite_existing);
+            std::filesystem::copy_file(source, libDir / "kicks" / "deep.wav",
+                                       std::filesystem::copy_options::overwrite_existing);
+            std::FILE* f = std::fopen((libDir / "notes.txt").string().c_str(), "wb");
+            std::fputs("not audio", f);
+            std::fclose(f);
+        }
+
+        JSON req = JSON::object();
+        req.set("id", JSON(210.0));
+        req.set("verb", JSON("list_samples"));
+        JSON dirArgs = JSON::object();
+        dirArgs.set("dir", JSON(libDir.string()));
+        req.set("args", dirArgs);
+        JSON r = call(service, req.toString());
+        check(status(r) == "ok", "list_samples ok");
+        check(r["result"]["samples"].size() == 2, "only audio files listed (txt skipped)");
+        check(!r["result"]["truncated"].asBool(), "listing not truncated");
+        bool sawNested = false;
+        for (size_t i = 0; i < r["result"]["samples"].size(); ++i) {
+            if (r["result"]["samples"][i]["name"].asString() == "deep.wav") sawNested = true;
+        }
+        check(sawNested, "nested sample found");
+
+        r = call(service,
+                 "{\"id\": 211, \"verb\": \"list_samples\", \"args\": {\"dir\": \"/nonexistent_muse_lib\"}}");
+        check(status(r) == "execution_error", "missing dir -> execution_error");
+        r = call(service, "{\"id\": 212, \"verb\": \"list_samples\"}");
+        check(status(r) == "validation_error", "missing dir arg -> validation_error");
+        std::filesystem::remove_all(libDir);
+
+        // Velocity digits: '9' is full velocity, '3' is a third.
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+        r = call(service, "{\"id\": 213, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 44, \"steps\": \"9-3-\"}}");
+        check(status(r) == "ok", "digit steps ok");
+        r = call(service,
+                 "{\"id\": 214, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        double v9 = -1.0, v3 = -1.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() == 44.0) {
+                if (note["start"].asNumber() == 0.0) v9 = note["velocity"].asNumber();
+                if (note["start"].asNumber() == 0.5) v3 = note["velocity"].asNumber();
+            }
+        }
+        check(std::abs(v9 - 1.0) < 1e-6, "digit 9 lands at full velocity");
+        check(std::abs(v3 - 3.0 / 9.0) < 1e-6, "digit 3 lands at a third velocity");
+
+        // Swing: odd steps land late by swing * step / 2.
+        r = call(service, "{\"id\": 215, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 44, \"steps\": \"x-x-xx\", \"swing\": 0.6}}");
+        check(status(r) == "ok", "swing steps ok");
+        r = call(service,
+                 "{\"id\": 216, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool sawSwung = false, sawStraight = false;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() != 44.0) continue;
+            const double start = note["start"].asNumber();
+            // step 5 (odd) at 1.25 + 0.6*0.125 = 1.325
+            if (std::abs(start - 1.325) < 1e-6) sawSwung = true;
+            if (std::abs(start - 1.0) < 1e-6) sawStraight = true;
+        }
+        check(sawSwung, "odd step swung late");
+        check(sawStraight, "even step stays on the grid");
+
+        // Cleanup: clear the scratch row.
+        r = call(service, "{\"id\": 217, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 44, \"steps\": \"-\"}}");
+        check(status(r) == "ok", "scratch row cleared");
+    }
+
     // --- Render: the beat comes back as a file with signal in it ---
     {
         const std::string outPath =


### PR DESCRIPTION
## What

The last two items on the agent-capability improvement list:

**`list_samples {dir}`** — the sample-provenance gap from the first agent production run (the agent had to synthesize WAVs blind). Recursive audio-file listing (depth 3, 500-entry cap with a `truncated` flag, deterministic sort), validated by `AudioFileValidator` magic bytes — not just extensions — returning `path`/`name`/`sizeBytes` ready to feed `load_sample`. Missing dirs and non-dirs are reasoned errors.

**`set_steps` grows two expressive dimensions:**
- digits `1`–`9` are hits at velocity n/9, mixed freely with `x`/`X`: `"9-3-x-X-"` is a groove with dynamics in one string;
- `swing` (0..0.9) delays every second step by `swing × step/2` — the classic shuffle placement.

Invalid-character refusals now name the accepted set (`x, X, 1-9, -, .`); the schema manifest documents both.

## Validation

- `MuseServiceTest`: nested library with a decoy `.txt` (only real WAVs listed, nested file found, not truncated), missing-dir → `execution_error`, missing-arg → `validation_error`; digit velocities exact (9 → 1.0, 3 → 0.333); swung odd step lands at 1.325 while the even step stays on 1.0. All pass; commands suite 10/10.
- Rebased on #539; the FX review fixes are included beneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `list_samples {dir}` to recursively discover valid audio files up to depth 3 and 500 results, with deterministic sorting, truncation reporting, file metadata, and clear validation errors.
- Extended `set_steps` with velocity digits (`1`–`9`) and configurable swing timing from `0` to `0.9`; updated parsing errors and schema documentation.
- Added tests covering nested sample discovery, audio filtering, velocity scaling, and swing timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->