### PR TITLE
Promote develop → main

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -252,6 +252,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/CommandRegistry.cpp
     src/Commands/SessionLog.cpp
     src/Commands/MuseStubs.cpp
+    src/Commands/MuseService.cpp
     
     # Headless / batch processing
     src/Headless/HeadlessMusicGenerator.cpp

--- a/AestraAudio/include/AestraUUID.h
+++ b/AestraAudio/include/AestraUUID.h
@@ -57,6 +57,41 @@ struct AestraUUID {
         snprintf(buf, sizeof(buf), "%016" PRIx64 "%016" PRIx64, high, low);
         return std::string(buf);
     }
+
+    /**
+     * @brief Parse the toString() representation (32 lowercase/uppercase hex chars).
+     * @param str Candidate string.
+     * @param out Receives the parsed UUID on success (untouched on failure).
+     * @return true when the string is exactly 32 hex characters.
+     */
+    static bool tryParse(const std::string& str, AestraUUID& out) {
+        if (str.size() != 32) {
+            return false;
+        }
+        uint64_t parsedHigh = 0;
+        uint64_t parsedLow = 0;
+        for (size_t i = 0; i < 32; ++i) {
+            const char c = str[i];
+            uint64_t digit;
+            if (c >= '0' && c <= '9') {
+                digit = static_cast<uint64_t>(c - '0');
+            } else if (c >= 'a' && c <= 'f') {
+                digit = static_cast<uint64_t>(c - 'a') + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                digit = static_cast<uint64_t>(c - 'A') + 10;
+            } else {
+                return false;
+            }
+            if (i < 16) {
+                parsedHigh = (parsedHigh << 4) | digit;
+            } else {
+                parsedLow = (parsedLow << 4) | digit;
+            }
+        }
+        out.high = parsedHigh;
+        out.low = parsedLow;
+        return true;
+    }
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/AddUnitCommand.h
+++ b/AestraAudio/include/Commands/AddUnitCommand.h
@@ -1,0 +1,57 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/UnitManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to add an Arsenal unit (undoable)
+ *
+ * Creating a non-audio unit also creates its default MIDI pattern (via
+ * UnitManager). Undo removes the unit; the default pattern is left behind,
+ * matching how the Arsenal panel removes units. Like AddChannelCommand,
+ * redo after undo mints a fresh unit ID.
+ */
+class AddUnitCommand : public ICommand {
+public:
+    AddUnitCommand(UnitManager& unitManager, const std::string& name, UnitType type)
+        : m_unitManager(unitManager), m_name(name), m_type(type) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_createdUnitId = m_unitManager.createUnit(m_name, m_type);
+        m_unitManager.setUnitEnabled(m_createdUnitId, true);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        if (m_unitManager.removeUnit(m_createdUnitId)) {
+            m_executed = false;
+        }
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Add Unit"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    UnitManager& m_unitManager;
+    std::string m_name;
+    UnitType m_type;
+    UnitID m_createdUnitId{0};
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/ArrangePatternCommand.h
+++ b/AestraAudio/include/Commands/ArrangePatternCommand.h
@@ -1,0 +1,140 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to place a MIDI pattern on the timeline as a clip (undoable)
+ *
+ * Mirrors the whole pattern-drop gesture the timeline UI performs, not just
+ * the clip insert:
+ *  - creates playlist lanes up to the target track index (the app maintains
+ *    a 1:1 lane/channel mapping),
+ *  - routes every unit referenced by the pattern's notes to that timeline
+ *    lane (route authority for playback and export),
+ *  - adds a pattern-bound clip sized to the pattern length.
+ *
+ * Undo removes the clip, restores each unit's previous route, and removes
+ * any lanes this command created. Like AddChannelCommand, redo after undo
+ * mints fresh lane/clip IDs.
+ */
+class ArrangePatternCommand : public ICommand {
+public:
+    ArrangePatternCommand(TrackManager& trackManager, PatternID patternId, size_t trackIndex,
+                          double startBeat)
+        : m_trackManager(trackManager), m_patternId(patternId), m_trackIndex(trackIndex),
+          m_startBeat(startBeat) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_createdLanes.clear();
+        m_previousUnitRoutes.clear();
+
+        auto& playlist = m_trackManager.getPlaylistModel();
+        auto& unitManager = m_trackManager.getUnitManager();
+        const PatternSource* pattern = m_trackManager.getPatternManager().getPattern(m_patternId);
+        if (!pattern || !pattern->isMidi()) return;
+
+        // A failure after partial mutation must not leave lanes or routes
+        // behind: unwind everything staged so far before returning without
+        // m_executed set.
+        const auto rollbackStaged = [&]() {
+            for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend();
+                 ++it) {
+                unitManager.assignUnitToTimelineLane(it->first, it->second);
+            }
+            for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
+                playlist.removeLane(*it);
+            }
+            m_previousUnitRoutes.clear();
+            m_createdLanes.clear();
+        };
+
+        while (playlist.getLaneCount() <= m_trackIndex) {
+            PlaylistLaneID laneId =
+                playlist.createLane("Lane " + std::to_string(playlist.getLaneCount() + 1));
+            if (!laneId.isValid()) {
+                rollbackStaged();
+                return;
+            }
+            m_createdLanes.push_back(laneId);
+        }
+        const PlaylistLaneID laneId = playlist.getLaneId(m_trackIndex);
+        if (!laneId.isValid()) {
+            rollbackStaged();
+            return;
+        }
+
+        std::unordered_set<UnitID> routed;
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.unitId == 0 || !routed.insert(note.unitId).second) continue;
+            if (!unitManager.getUnit(note.unitId)) continue;
+            m_previousUnitRoutes.emplace_back(note.unitId,
+                                              unitManager.getUnitTimelineLane(note.unitId));
+            unitManager.assignUnitToTimelineLane(note.unitId, static_cast<int>(m_trackIndex));
+        }
+
+        ClipInstance clip;
+        clip.id = ClipInstanceID::generate();
+        clip.name = pattern->name;
+        clip.startBeat = m_startBeat;
+        clip.durationBeats = pattern->lengthBeats;
+        clip.patternId = m_patternId;
+        clip.sourceId = m_patternId.value;
+
+        m_clipId = playlist.addClip(laneId, clip);
+        if (!m_clipId.isValid()) {
+            rollbackStaged();
+            return;
+        }
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        auto& playlist = m_trackManager.getPlaylistModel();
+        auto& unitManager = m_trackManager.getUnitManager();
+
+        playlist.removeClip(m_clipId);
+        for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend(); ++it) {
+            unitManager.assignUnitToTimelineLane(it->first, it->second);
+        }
+        for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
+            playlist.removeLane(*it);
+        }
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Arrange Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    PatternID m_patternId;
+    size_t m_trackIndex;
+    double m_startBeat;
+
+    // Recorded by execute() for undo
+    std::vector<PlaylistLaneID> m_createdLanes;
+    std::vector<std::pair<UnitID, int>> m_previousUnitRoutes;
+    ClipInstanceID m_clipId;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/ClonePatternCommand.h
+++ b/AestraAudio/include/Commands/ClonePatternCommand.h
@@ -1,0 +1,61 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to clone a pattern (undoable)
+ *
+ * Undo removes the clone. Like AddChannelCommand, redo after undo mints a
+ * fresh pattern id. getClonedPatternId() is valid after execute().
+ */
+class ClonePatternCommand : public ICommand {
+public:
+    ClonePatternCommand(PatternManager& patternManager, PatternID sourceId)
+        : m_patternManager(patternManager), m_sourceId(sourceId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_clonedId = m_patternManager.clonePattern(m_sourceId);
+        if (!m_clonedId.isValid()) {
+            // Loud, not silent: a failed clone must never be recorded as an
+            // executed command or reported as success.
+            throw std::runtime_error("failed to clone pattern " +
+                                     std::to_string(m_sourceId.value));
+        }
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_patternManager.removePattern(m_clonedId);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Clone Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    PatternID getClonedPatternId() const { return m_clonedId; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_sourceId;
+    PatternID m_clonedId;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/CommandHistory.h
+++ b/AestraAudio/include/Commands/CommandHistory.h
@@ -41,6 +41,21 @@ public:
     void pushAndExecute(std::shared_ptr<ICommand> cmd);
 
     /**
+     * @brief Push a command that the caller already executed.
+     *
+     * Same undo/redo bookkeeping as pushAndExecute, without running
+     * execute(). For stepwise batches where members were applied one-by-one
+     * (see CommandTransaction::markExecuted). Not valid inside an active
+     * transaction.
+     * @param cmd Already-executed command to track
+     * @return true when the command was recorded on the undo stack; false
+     *         when it was refused (null, not undoable, or a deferred
+     *         transaction is active). Callers must not report the operation
+     *         as undoable unless this returns true.
+     */
+    bool pushExecuted(std::shared_ptr<ICommand> cmd);
+
+    /**
      * @brief Begin a transaction. All pushAndExecute calls until commitTransaction
      * will be batched into the transaction.
      * @param transaction The transaction to populate

--- a/AestraAudio/include/Commands/CommandParser.h
+++ b/AestraAudio/include/Commands/CommandParser.h
@@ -16,6 +16,18 @@ class CommandParser {
 public:
     CommandResult parse(const std::string& input, CommandHistory& history);
 
+    /**
+     * @brief Execute a verb from an already-tokenised flag map.
+     *
+     * The shared back half of parse(): schema lookup, flag validation,
+     * registry build, and execution through CommandHistory. MuseService's
+     * JSON surface enters here so text and structured requests can never
+     * diverge in behaviour.
+     */
+    CommandResult execute(const std::string& verb,
+                          const std::unordered_map<std::string, std::string>& flags,
+                          CommandHistory& history);
+
 private:
     std::unordered_map<std::string, std::string> tokeniseFlags(
         const std::vector<std::string>& tokens,

--- a/AestraAudio/include/Commands/CommandParser.h
+++ b/AestraAudio/include/Commands/CommandParser.h
@@ -3,6 +3,7 @@
 #include "Commands/CommandResult.h"
 #include "Commands/MuseGrammar.h"
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -11,6 +12,7 @@ namespace Aestra {
 namespace Audio {
 
 class CommandHistory;
+class ICommand;
 
 class CommandParser {
 public:
@@ -27,6 +29,20 @@ public:
     CommandResult execute(const std::string& verb,
                           const std::unordered_map<std::string, std::string>& flags,
                           CommandHistory& history);
+
+    /**
+     * @brief Validate and build a command without executing it.
+     *
+     * The front half of execute(): schema lookup, unknown-flag rejection,
+     * flag validation, and registry build. Batch execution uses this to
+     * validate each member against the current state immediately before
+     * executing it. Returns nullptr with outStatus/outMessage set on failure.
+     */
+    std::unique_ptr<ICommand> buildValidated(
+        const std::string& verb,
+        const std::unordered_map<std::string, std::string>& flags,
+        CommandStatus& outStatus,
+        std::string& outMessage);
 
 private:
     std::unordered_map<std::string, std::string> tokeniseFlags(

--- a/AestraAudio/include/Commands/CommandRegistry.h
+++ b/AestraAudio/include/Commands/CommandRegistry.h
@@ -26,6 +26,23 @@ public:
         const std::string& verb,
         const std::unordered_map<std::string, std::string>& flags);
 
+    /**
+     * @brief Record why a factory refused to build, then return nullptr.
+     *
+     * Factories call `return CommandRegistry::fail("no such pattern: 7");`
+     * instead of a bare `return nullptr;` so callers can surface the reason
+     * to the agent instead of a generic "failed to build command".
+     */
+    static std::unique_ptr<ICommand> fail(const std::string& reason);
+
+    /**
+     * @brief Take the reason recorded by the most recent failed build.
+     *
+     * build() clears it before invoking the factory; empty when the factory
+     * gave no reason. Thread-local, like command execution itself.
+     */
+    static std::string consumeLastBuildError();
+
     static void initialize(TrackManager* trackManager);
 
     /** Set the AudioEngine for transport commands (play/stop/set_bpm). */

--- a/AestraAudio/include/Commands/CommandResult.h
+++ b/AestraAudio/include/Commands/CommandResult.h
@@ -21,11 +21,13 @@ struct CommandResult {
     double executionMs = 0.0;
     bool undoable = false;
     /**
-     * Id of an object the command created (0 = none). Structured so agents
-     * never have to parse it out of the human-readable message
-     * (clone_pattern sets this to the new pattern id).
+     * Id of an object the command created, valid when hasCreatedId is true.
+     * Structured so agents never have to parse it out of the human-readable
+     * message (clone_pattern: new pattern id; add_effect: slot index, where
+     * 0 is a legitimate value — hence the explicit flag).
      */
     uint64_t createdId = 0;
+    bool hasCreatedId = false;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/CommandResult.h
+++ b/AestraAudio/include/Commands/CommandResult.h
@@ -20,6 +20,12 @@ struct CommandResult {
     uint64_t commandId = 0;
     double executionMs = 0.0;
     bool undoable = false;
+    /**
+     * Id of an object the command created (0 = none). Structured so agents
+     * never have to parse it out of the human-readable message
+     * (clone_pattern sets this to the new pattern id).
+     */
+    uint64_t createdId = 0;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/CommandTransaction.h
+++ b/AestraAudio/include/Commands/CommandTransaction.h
@@ -38,6 +38,17 @@ public:
     
     // Transaction interface
     void add(std::shared_ptr<ICommand> cmd);
+
+    /**
+     * @brief Adopt members that were already executed one-by-one.
+     *
+     * For stepwise batch execution (each member validated against the state
+     * its predecessors produced): the caller executes members itself, then
+     * marks the transaction executed so undo/redo treat it as one applied
+     * step. Pair with CommandHistory::pushExecuted().
+     */
+    void markExecuted() { m_executed = true; }
+
     size_t size() const { return m_commands.size(); }
     bool isEmpty() const { return m_commands.empty(); }
     void clear() { m_commands.clear(); }

--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -1,0 +1,188 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
+
+#include <string>
+#include <utility>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to insert an effect plugin into a track's chain (undoable)
+ *
+ * Wraps the same lifecycle the app uses: the factory creates, initializes
+ * and activates the instance; this command inserts it and requests the
+ * audio-graph rebuild the playback path needs to pick chain changes up.
+ */
+class AddEffectCommand : public ICommand {
+public:
+    AddEffectCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex,
+                     PluginInstancePtr plugin, std::string effectName)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex),
+          m_plugin(std::move(plugin)), m_effectName(std::move(effectName)) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_channel.getEffectChain().removePlugin(m_slotIndex);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Add " + m_effectName; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    size_t getSlotIndex() const { return m_slotIndex; }
+    /** True once execute() actually inserted the plugin (see CommandParser). */
+    bool wasExecuted() const { return m_executed; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    PluginInstancePtr m_plugin;
+    std::string m_effectName;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to remove an effect plugin from a track's chain (undoable)
+ */
+class RemoveEffectCommand : public ICommand {
+public:
+    RemoveEffectCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_removedPlugin = m_channel.getEffectChain().removePlugin(m_slotIndex);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        if (m_removedPlugin) {
+            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin);
+        }
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Remove Effect"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    PluginInstancePtr m_removedPlugin;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to set an effect parameter (normalized 0..1, undoable)
+ */
+class SetEffectParamCommand : public ICommand {
+public:
+    SetEffectParamCommand(PluginInstancePtr plugin, uint32_t paramId, float newValue)
+        : m_plugin(std::move(plugin)), m_paramId(paramId), m_newValue(newValue) {}
+
+    void execute() override {
+        if (m_executed || !m_plugin) return;
+        m_previousValue = m_plugin->getParameter(m_paramId);
+        m_plugin->setParameter(m_paramId, m_newValue);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed || !m_plugin) return;
+        m_plugin->setParameter(m_paramId, m_previousValue);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Effect Parameter"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PluginInstancePtr m_plugin;
+    uint32_t m_paramId;
+    float m_newValue;
+    float m_previousValue = 0.0f;
+    bool m_executed = false;
+};
+
+/**
+ * @brief Command to bypass/unbypass an effect slot (undoable)
+ */
+class SetEffectBypassCommand : public ICommand {
+public:
+    SetEffectBypassCommand(TrackManager& trackManager, MixerChannel& channel, size_t slotIndex,
+                           bool bypassed)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex),
+          m_bypassed(bypassed) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_previous = m_channel.getEffectChain().isSlotBypassed(m_slotIndex);
+        m_channel.getEffectChain().setSlotBypassed(m_slotIndex, m_bypassed);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_channel.getEffectChain().setSlotBypassed(m_slotIndex, m_previous);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return m_bypassed ? "Bypass Effect" : "Enable Effect"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_slotIndex;
+    bool m_bypassed;
+    bool m_previous = false;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/LoadSampleCommand.h
+++ b/AestraAudio/include/Commands/LoadSampleCommand.h
@@ -1,0 +1,57 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/UnitManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to load an audio sample into a unit (undoable)
+ *
+ * Undo restores the unit's previous sample path (possibly none) through the
+ * same UnitManager::setUnitAudioClip path, so the sampler plugin state and
+ * preview waveform stay consistent in both directions.
+ */
+class LoadSampleCommand : public ICommand {
+public:
+    LoadSampleCommand(UnitManager& unitManager, UnitID unitId, const std::string& path)
+        : m_unitManager(unitManager), m_unitId(unitId), m_path(path) {}
+
+    void execute() override {
+        if (m_executed) return;
+        const UnitInfo* unit = m_unitManager.getUnit(m_unitId);
+        if (!unit) return;
+        m_previousPath = unit->audioClipPath;
+        m_unitManager.setUnitAudioClip(m_unitId, m_path);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_unitManager.setUnitAudioClip(m_unitId, m_previousPath);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Load Sample"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    UnitManager& m_unitManager;
+    UnitID m_unitId;
+    std::string m_path;
+    std::string m_previousPath;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -8,7 +8,7 @@ namespace Aestra {
 namespace Audio {
 
 enum class FlagType { String, Int, Float, Bool };
-enum class CommandCategory { Transport, Track, Clip };
+enum class CommandCategory { Transport, Track, Clip, Unit, Pattern };
 
 struct FlagSchema {
     std::string name;

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -22,11 +22,21 @@ struct CommandSchema {
     std::string verb;
     CommandCategory category;
     std::vector<FlagSchema> flags;
+    /** One-line semantics for agents; rendered into the schema manifest. */
+    std::string description;
 };
 
 namespace MuseGrammar {
     const std::vector<CommandSchema>& allCommands();
-    /** @brief The full command schema as a JSON string — the agent tool manifest. */
+    /**
+     * @brief The full agent tool manifest as a JSON string.
+     *
+     * An object with "commands" (mutations from allCommands()), "queries" and
+     * "actions" (documented here, implemented by MuseService — keep in sync
+     * with its isQueryVerb/isActionVerb), and "notes" (engine semantics an
+     * agent cannot discover through the protocol: sampler root, unit routing,
+     * step characters, id stability).
+     */
     std::string schemaToJsonString();
     void exportSchemaToJson(const std::string& outputPath);
 }

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -26,6 +26,8 @@ struct CommandSchema {
 
 namespace MuseGrammar {
     const std::vector<CommandSchema>& allCommands();
+    /** @brief The full command schema as a JSON string — the agent tool manifest. */
+    std::string schemaToJsonString();
     void exportSchemaToJson(const std::string& outputPath);
 }
 

--- a/AestraAudio/include/Commands/MuseService.h
+++ b/AestraAudio/include/Commands/MuseService.h
@@ -1,0 +1,46 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+class AudioEngine;
+class TrackManager;
+
+/**
+ * @brief Muse's structured machine interface: one JSON request in, one JSON
+ *        response out.
+ *
+ * This is the single surface every external driver (CLI, socket, local model,
+ * tests, future in-app chat) talks through — nothing should reach past it to
+ * command objects or engine internals.
+ *
+ * Request:  {"id": 42, "verb": "set_bpm", "args": {"value": 142}}
+ * Response: {"id": 42, "status": "ok", "verb": "set_bpm",
+ *            "result": {...}, "executionMs": 0.18}
+ *
+ * - Mutation verbs run through the MuseGrammar schema validation, the
+ *   CommandRegistry factories, and CommandHistory — every mutation is
+ *   undoable and identical to the equivalent UI edit.
+ * - Query verbs (get_transport, list_tracks, list_clips, get_session_state)
+ *   are read-only, never touch history, and return stable IDs so an agent
+ *   never has to infer object identity across edits.
+ * - handleRequest never throws; malformed input comes back as a
+ *   status:"parse_error" response.
+ */
+class MuseService {
+public:
+    MuseService(TrackManager* trackManager, AudioEngine* engine);
+
+    /** @brief Process one JSON request line and return the JSON response. */
+    std::string handleRequest(const std::string& requestJson);
+
+private:
+    TrackManager* m_trackManager = nullptr;
+    AudioEngine* m_engine = nullptr;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MuseService.h
+++ b/AestraAudio/include/Commands/MuseService.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace Aestra {
@@ -36,6 +37,18 @@ public:
 
     /** @brief Process one JSON request line and return the JSON response. */
     std::string handleRequest(const std::string& requestJson);
+
+    /**
+     * @brief Attach an engine to a track manager the way the app does.
+     *
+     * Headless hosts (MuseRepl, tests) must wire the same five links
+     * AestraContent wires — unit manager, pattern playback engine, continuous
+     * params, channel slot map, and the transport command sink — or units
+     * render silence and transport commands never reach the engine.
+     * Both objects must outlive the wiring (the sink captures raw pointers).
+     */
+    static void wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackManager,
+                                   AudioEngine& engine);
 
 private:
     TrackManager* m_trackManager = nullptr;

--- a/AestraAudio/include/Commands/QuantizePatternCommand.h
+++ b/AestraAudio/include/Commands/QuantizePatternCommand.h
@@ -1,0 +1,93 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to quantize note starts in a pattern toward a beat grid (undoable)
+ *
+ * strength 1.0 snaps starts exactly onto the nearest grid multiple; partial
+ * strengths move them proportionally toward it. unitId 0 quantizes every
+ * note, otherwise only that unit's notes. Undo restores the exact original
+ * starts (a snapped grid position is not invertible arithmetically).
+ */
+class QuantizePatternCommand : public ICommand {
+public:
+    QuantizePatternCommand(PatternManager& patternManager, PatternID patternId, double gridBeats,
+                           double strength, uint64_t unitId)
+        : m_patternManager(patternManager), m_patternId(patternId), m_gridBeats(gridBeats),
+          m_strength(strength), m_unitId(unitId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_originalStarts.clear();
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (size_t i = 0; i < notes.size(); ++i) {
+                MidiNote& note = notes[i];
+                if (m_unitId != 0 && note.unitId != m_unitId) continue;
+                const double snapped = std::round(note.startBeat / m_gridBeats) * m_gridBeats;
+                const double moved = note.startBeat + (snapped - note.startBeat) * m_strength;
+                if (moved != note.startBeat) {
+                    m_originalStarts.emplace_back(i, note.startBeat);
+                    note.startBeat = moved;
+                }
+            }
+        });
+
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+            for (const auto& [index, start] : m_originalStarts) {
+                if (index < notes.size()) {
+                    notes[index].startBeat = start;
+                }
+            }
+        });
+
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Quantize Pattern"; }
+    size_t getSizeInBytes() const override {
+        return sizeof(*this) + m_originalStarts.size() * sizeof(std::pair<size_t, double>);
+    }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    double m_gridBeats;
+    double m_strength;
+    uint64_t m_unitId; // 0 = all units
+
+    // Recorded by execute() for undo: (note index, original startBeat)
+    std::vector<std::pair<size_t, double>> m_originalStarts;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetPatternLengthCommand.h
+++ b/AestraAudio/include/Commands/SetPatternLengthCommand.h
@@ -1,0 +1,58 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to set a pattern's length in beats (undoable)
+ *
+ * Notes past the new length are kept (they simply stop being scheduled), so
+ * shortening then restoring the length loses nothing.
+ */
+class SetPatternLengthCommand : public ICommand {
+public:
+    SetPatternLengthCommand(PatternManager& patternManager, PatternID patternId, double beats)
+        : m_patternManager(patternManager), m_patternId(patternId), m_beats(beats) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            m_previousBeats = pattern.lengthBeats;
+            pattern.lengthBeats = m_beats;
+        });
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            pattern.lengthBeats = m_previousBeats;
+        });
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Pattern Length"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    double m_beats;
+    double m_previousBeats = 0.0;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetStepsCommand.h
+++ b/AestraAudio/include/Commands/SetStepsCommand.h
@@ -1,0 +1,116 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to write one drum row of a pattern from a step string (undoable)
+ *
+ * Row semantics, not append semantics: the step string defines the entire
+ * row for this (unit, pitch) — every existing note of that identity is
+ * replaced, so re-issuing the verb rewrites the groove (and a shorter string
+ * cannot leave a stale tail behind). Notes of other pitches/units are
+ * untouched.
+ *
+ * If the row extends past the pattern length, the pattern grows to fit
+ * (restored on undo).
+ */
+class SetStepsCommand : public ICommand {
+public:
+    SetStepsCommand(PatternManager& patternManager, PatternID patternId,
+                    std::vector<MidiNote> rowNotes, uint64_t unitId, int pitch,
+                    double rowLengthBeats)
+        : m_patternManager(patternManager), m_patternId(patternId),
+          m_rowNotes(std::move(rowNotes)), m_unitId(unitId), m_pitch(pitch),
+          m_rowLengthBeats(rowLengthBeats) {}
+
+    void execute() override {
+        if (m_executed) return;
+        m_replacedNotes.clear();
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+
+            // Capture and remove the entire existing row for this identity.
+            for (const MidiNote& note : notes) {
+                if (note.unitId == m_unitId && note.pitch == m_pitch) {
+                    m_replacedNotes.push_back(note);
+                }
+            }
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [this](const MidiNote& n) {
+                                           return n.unitId == m_unitId && n.pitch == m_pitch;
+                                       }),
+                        notes.end());
+
+            for (const MidiNote& note : m_rowNotes) {
+                notes.push_back(note);
+            }
+
+            m_previousLengthBeats = pattern.lengthBeats;
+            if (m_rowLengthBeats > pattern.lengthBeats) {
+                pattern.lengthBeats = m_rowLengthBeats;
+            }
+        });
+
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+
+        m_patternManager.applyPatch(m_patternId, [this](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            auto& notes = std::get<MidiPayload>(pattern.payload).notes;
+
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [this](const MidiNote& n) {
+                                           return n.unitId == m_unitId && n.pitch == m_pitch;
+                                       }),
+                        notes.end());
+            for (const MidiNote& note : m_replacedNotes) {
+                notes.push_back(note);
+            }
+            pattern.lengthBeats = m_previousLengthBeats;
+        });
+
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Set Steps"; }
+    size_t getSizeInBytes() const override {
+        return sizeof(*this) + (m_rowNotes.size() + m_replacedNotes.size()) * sizeof(MidiNote);
+    }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    std::vector<MidiNote> m_rowNotes;
+    uint64_t m_unitId;
+    int m_pitch;
+    double m_rowLengthBeats;
+
+    // Recorded by execute() for undo
+    std::vector<MidiNote> m_replacedNotes;
+    double m_previousLengthBeats = 0.0;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/TransposePatternCommand.h
+++ b/AestraAudio/include/Commands/TransposePatternCommand.h
@@ -1,0 +1,68 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to transpose note pitches in a pattern (undoable)
+ *
+ * The factory rejects transpositions that would push any affected note
+ * outside MIDI range, so execute never clamps — undo is a clean shift back.
+ * unitId 0 transposes every note, otherwise only that unit's notes.
+ */
+class TransposePatternCommand : public ICommand {
+public:
+    TransposePatternCommand(PatternManager& patternManager, PatternID patternId, int semitones,
+                            uint64_t unitId)
+        : m_patternManager(patternManager), m_patternId(patternId), m_semitones(semitones),
+          m_unitId(unitId) {}
+
+    void execute() override {
+        if (m_executed) return;
+        applyShift(m_semitones);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed) return;
+        applyShift(-m_semitones);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed) return;
+        execute();
+    }
+
+    std::string getName() const override { return "Transpose Pattern"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    void applyShift(int semitones) {
+        m_patternManager.applyPatch(m_patternId, [this, semitones](PatternSource& pattern) {
+            if (!pattern.isMidi()) return;
+            for (MidiNote& note : std::get<MidiPayload>(pattern.payload).notes) {
+                if (m_unitId != 0 && note.unitId != m_unitId) continue;
+                note.pitch += semitones;
+            }
+        });
+    }
+
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    int m_semitones;
+    uint64_t m_unitId; // 0 = all units
+
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -23,12 +23,18 @@ struct ClipInstanceID : public AestraUUID {
     bool isValid() const { return low != 0 || high != 0; }
 
     /**
-     * @brief Parse from string (stub - just returns generate())
+     * @brief Parse the toString() representation.
+     * @return The parsed ID, or an invalid (zero) ID when the string doesn't
+     *         parse — callers mint a fresh ID for invalid ones, which keeps
+     *         old project files (without clip ids) loading fine while saved
+     *         ids stay stable across load cycles (#446).
      */
     static ClipInstanceID fromString(const std::string& str) {
-        // Stub implementation - in real code would parse UUID string
-        (void)str;
-        return generate();
+        AestraUUID parsed;
+        if (AestraUUID::tryParse(str, parsed)) {
+            return ClipInstanceID(parsed);
+        }
+        return ClipInstanceID();
     }
 };
 

--- a/AestraAudio/include/Models/PatternManager.h
+++ b/AestraAudio/include/Models/PatternManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "PatternSource.h"
 
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -56,7 +57,23 @@ public:
      * @return Identifier of the created audio pattern.
      */
     PatternID createAudioPattern(const std::string& name, double lengthBeats, const AudioSlicePayload& payload) {
-        PatternID id{nextId++};
+        return createAudioPatternWithId(PatternID{}, name, lengthBeats, payload);
+    }
+
+    /**
+     * @brief Create an audio pattern restoring a serialized identity (#446).
+     *
+     * When @p requestedId is valid and unused it becomes the pattern's ID and
+     * the mint counter advances past it; otherwise a fresh ID is minted.
+     * @param requestedId Serialized pattern ID to restore (invalid = mint).
+     * @param name Pattern display name.
+     * @param lengthBeats Pattern duration in beats.
+     * @param payload Audio pattern payload.
+     * @return Identifier of the created audio pattern.
+     */
+    PatternID createAudioPatternWithId(PatternID requestedId, const std::string& name, double lengthBeats,
+                                       const AudioSlicePayload& payload) {
+        const PatternID id = claimId(requestedId);
         auto pattern = std::make_unique<PatternSource>();
         pattern->id = id;
         pattern->name = name;
@@ -75,7 +92,23 @@ public:
      * @return Identifier of the created MIDI pattern.
      */
     PatternID createMidiPattern(const std::string& name, double lengthBeats, const MidiPayload& payload) {
-        PatternID id{nextId++};
+        return createMidiPatternWithId(PatternID{}, name, lengthBeats, payload);
+    }
+
+    /**
+     * @brief Create a MIDI pattern restoring a serialized identity (#446).
+     *
+     * When @p requestedId is valid and unused it becomes the pattern's ID and
+     * the mint counter advances past it; otherwise a fresh ID is minted.
+     * @param requestedId Serialized pattern ID to restore (invalid = mint).
+     * @param name Pattern display name.
+     * @param lengthBeats Pattern duration in beats.
+     * @param payload MIDI pattern payload.
+     * @return Identifier of the created MIDI pattern.
+     */
+    PatternID createMidiPatternWithId(PatternID requestedId, const std::string& name, double lengthBeats,
+                                      const MidiPayload& payload) {
+        const PatternID id = claimId(requestedId);
         auto pattern = std::make_unique<PatternSource>();
         pattern->id = id;
         pattern->name = name;
@@ -158,6 +191,25 @@ public:
     }
 
 private:
+    /**
+     * @brief Resolve the ID a new pattern should use.
+     *
+     * Valid + unused requested IDs are restored verbatim and the mint counter
+     * jumps past them so later mints can never collide with restored IDs.
+     * UINT64_MAX is never restored: bumping the counter past it would wrap
+     * to zero and poison every later mint.
+     */
+    PatternID claimId(PatternID requestedId) {
+        if (requestedId.isValid() && requestedId.value != std::numeric_limits<uint64_t>::max()
+            && m_patterns.find(requestedId.value) == m_patterns.end()) {
+            if (requestedId.value >= nextId) {
+                nextId = requestedId.value + 1;
+            }
+            return requestedId;
+        }
+        return PatternID{nextId++};
+    }
+
     uint64_t nextId{1};
     std::unordered_map<uint64_t, std::unique_ptr<PatternSource>> m_patterns;
 };

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -81,10 +81,26 @@ public:
      * @return Identifier of the created lane.
      */
     PlaylistLaneID createLane(const std::string& name = "") {
+        return createLaneWithId(PlaylistLaneID{}, name);
+    }
+
+    /**
+     * @brief Create a lane restoring a serialized identity (#446).
+     *
+     * A valid, unused requested ID becomes the lane's ID; an invalid or taken
+     * one falls back to the generated ID so old files keep loading.
+     * @param requestedId Serialized lane ID to restore (invalid = generate).
+     * @param name Lane display name.
+     * @return The created lane's ID.
+     */
+    PlaylistLaneID createLaneWithId(const PlaylistLaneID& requestedId, const std::string& name = "") {
         std::unique_lock<std::shared_mutex> lock(m_mutex);
 
         PlaylistLane lane(static_cast<int>(m_lanes.size()));
         lane.name = name.empty() ? "Track " + std::to_string(lane.index + 1) : name;
+        if (requestedId.isValid() && m_laneMap.find(requestedId) == m_laneMap.end()) {
+            lane.id = requestedId;
+        }
 
         PlaylistLaneID id = lane.id;
         m_lanes.push_back(std::move(lane));

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -2,6 +2,7 @@
 #include "ClipSource.h"
 
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -29,6 +30,47 @@ public:
 
         // Create new source
         ClipSourceID id{nextId++};
+        auto source = std::make_unique<ClipSource>(id, displayName.empty() ? makeDisplayName(filePath) : displayName);
+        source->setFilePath(filePath);
+
+        m_sources[id.value] = std::move(source);
+        m_pathToId[filePath] = id;
+
+        return id;
+    }
+
+    /**
+     * @brief Get or create a source restoring a serialized identity (#446).
+     *
+     * Path is still the dedupe key: an existing source for @p filePath wins
+     * regardless of the requested ID. Otherwise a valid, unused requested ID
+     * is restored verbatim (advancing the mint counter past it) and an
+     * invalid or taken ID falls back to a fresh mint. UINT64_MAX is never
+     * restored: bumping the counter past it would wrap to zero and poison
+     * every later mint.
+     * @param requestedId Serialized source ID to restore (invalid = mint).
+     * @param filePath Source file path (dedupe key).
+     * @param displayName Optional user-facing name.
+     * @return Source ID (returns ClipSourceID{0} on failure)
+     */
+    ClipSourceID getOrCreateSourceWithId(ClipSourceID requestedId, const std::string& filePath,
+                                         const std::string& displayName = {}) {
+        auto it = m_pathToId.find(filePath);
+        if (it != m_pathToId.end()) {
+            return it->second;
+        }
+
+        ClipSourceID id{};
+        if (requestedId.isValid() && requestedId.value != std::numeric_limits<uint64_t>::max()
+            && m_sources.find(requestedId.value) == m_sources.end()) {
+            id = requestedId;
+            if (requestedId.value >= nextId) {
+                nextId = requestedId.value + 1;
+            }
+        } else {
+            id = ClipSourceID{nextId++};
+        }
+
         auto source = std::make_unique<ClipSource>(id, displayName.empty() ? makeDisplayName(filePath) : displayName);
         source->setFilePath(filePath);
 

--- a/AestraAudio/src/Commands/CommandHistory.cpp
+++ b/AestraAudio/src/Commands/CommandHistory.cpp
@@ -59,6 +59,34 @@ void CommandHistory::pushAndExecute(std::shared_ptr<ICommand> cmd) {
     }
 }
 
+bool CommandHistory::pushExecuted(std::shared_ptr<ICommand> cmd) {
+    if (!cmd || !cmd->isUndoable())
+        return false;
+
+    bool recorded = false;
+    {
+        // Transaction check and stack insertion under one lock so a
+        // transaction beginning on another thread cannot slip between them.
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_activeTransaction && m_transactionNestingLevel > 0) {
+            // Deferred-execution transactions would re-run this command at
+            // commit; refuse rather than execute it twice.
+            std::cerr << "CommandHistory::pushExecuted: not valid inside an active transaction"
+                      << std::endl;
+        } else {
+            m_undoStack.push_back(cmd);
+            m_redoStack.clear();
+            trimHistory();
+            recorded = true;
+        }
+    }
+
+    if (recorded) {
+        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+    }
+    return recorded;
+}
+
 void CommandHistory::beginTransaction(std::shared_ptr<CommandTransaction> transaction) {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_transactionNestingLevel == 0) {

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -41,25 +41,7 @@ CommandResult CommandParser::parse(const std::string& input, CommandHistory& his
     result.verb = tokens[0];
     tokens.erase(tokens.begin());
 
-    // 2. Look up verb in MuseGrammar::allCommands()
-    const auto& allCmds = MuseGrammar::allCommands();
-    const CommandSchema* schema = nullptr;
-    for (const auto& cmd : allCmds) {
-        if (cmd.verb == result.verb) {
-            schema = &cmd;
-            break;
-        }
-    }
-
-    if (!schema) {
-        result.status = CommandStatus::ParseError;
-        result.message = "unknown command: " + result.verb;
-        auto endTime = std::chrono::steady_clock::now();
-        result.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
-        return result;
-    }
-
-    // 3. Tokenise remaining tokens into {"flag": "value"} map
+    // 2. Tokenise remaining tokens into {"flag": "value"} map
     std::string tokeniseError;
     auto parsedFlags = tokeniseFlags(tokens, tokeniseError);
     if (!tokeniseError.empty()) {
@@ -70,46 +52,92 @@ CommandResult CommandParser::parse(const std::string& input, CommandHistory& his
         return result;
     }
 
-    // 4. Validate required flags present and values within type + range
+    // 3. Shared back half: schema lookup, validation, build, execute
+    CommandResult executed = execute(result.verb, parsedFlags, history);
+    auto endTime = std::chrono::steady_clock::now();
+    executed.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
+    return executed;
+}
+
+CommandResult CommandParser::execute(const std::string& verb,
+                                     const std::unordered_map<std::string, std::string>& flags,
+                                     CommandHistory& history) {
+    CommandResult result;
+    result.commandId = 0;
+    result.verb = verb;
+
+    auto startTime = std::chrono::steady_clock::now();
+    const auto finish = [&](CommandResult& r) -> CommandResult& {
+        auto endTime = std::chrono::steady_clock::now();
+        r.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
+        return r;
+    };
+
+    // Look up verb in MuseGrammar::allCommands()
+    const auto& allCmds = MuseGrammar::allCommands();
+    const CommandSchema* schema = nullptr;
+    for (const auto& cmd : allCmds) {
+        if (cmd.verb == verb) {
+            schema = &cmd;
+            break;
+        }
+    }
+
+    if (!schema) {
+        result.status = CommandStatus::ParseError;
+        result.message = "unknown command: " + verb;
+        return finish(result);
+    }
+
+    // Reject flags the schema does not define — accepting them would let a
+    // caller believe intent was honoured when it was silently dropped.
+    for (const auto& entry : flags) {
+        bool known = false;
+        for (const auto& flagSchema : schema->flags) {
+            if (flagSchema.name == entry.first) {
+                known = true;
+                break;
+            }
+        }
+        if (!known) {
+            result.status = CommandStatus::ValidationError;
+            result.message = "unknown flag for " + verb + ": --" + entry.first;
+            return finish(result);
+        }
+    }
+
+    // Validate required flags present and values within type + range
     std::string validationError;
-    if (!validateFlags(*schema, parsedFlags, validationError)) {
+    if (!validateFlags(*schema, flags, validationError)) {
         result.status = CommandStatus::ValidationError;
         result.message = std::move(validationError);
-        auto endTime = std::chrono::steady_clock::now();
-        result.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
-        return result;
+        return finish(result);
     }
 
-    // 5. Build ICommand via registry
-    auto cmd = CommandRegistry::instance().build(result.verb, parsedFlags);
+    // Build ICommand via registry
+    auto cmd = CommandRegistry::instance().build(verb, flags);
     if (!cmd) {
         result.status = CommandStatus::ExecutionError;
-        result.message = "failed to build command for: " + result.verb;
-        auto endTime = std::chrono::steady_clock::now();
-        result.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
-        return result;
+        result.message = "failed to build command for: " + verb;
+        return finish(result);
     }
 
-    result.undoable = cmd->changesProjectState();
+    const bool undoable = cmd->changesProjectState();
 
-    // 6. Execute through CommandHistory
+    // Execute through CommandHistory; only a successful execution is undoable.
     try {
         auto shared = std::shared_ptr<ICommand>(std::move(cmd));
         history.pushAndExecute(shared);
+        result.undoable = undoable;
     } catch (const std::exception& e) {
         result.status = CommandStatus::ExecutionError;
         result.message = e.what();
-        auto endTime = std::chrono::steady_clock::now();
-        result.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
-        return result;
+        return finish(result);
     }
 
-    // 7. Success
     result.status = CommandStatus::Success;
     result.message = "ok";
-    auto endTime = std::chrono::steady_clock::now();
-    result.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
-    return result;
+    return finish(result);
 }
 
 std::unordered_map<std::string, std::string> CommandParser::tokeniseFlags(

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -1,4 +1,5 @@
 #include "Commands/CommandParser.h"
+#include "Commands/ClonePatternCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Commands/CommandRegistry.h"
 
@@ -109,7 +110,8 @@ std::unique_ptr<ICommand> CommandParser::buildValidated(
     auto cmd = CommandRegistry::instance().build(verb, flags);
     if (!cmd) {
         outStatus = CommandStatus::ExecutionError;
-        outMessage = "failed to build command for: " + verb;
+        const std::string reason = CommandRegistry::consumeLastBuildError();
+        outMessage = reason.empty() ? "failed to build command for: " + verb : reason;
         return nullptr;
     }
 
@@ -148,6 +150,26 @@ CommandResult CommandParser::execute(const std::string& verb,
         auto shared = std::shared_ptr<ICommand>(std::move(cmd));
         history.pushAndExecute(shared);
         result.undoable = undoable;
+
+        // clone_pattern creates a new object the caller needs to address;
+        // surface its id (structured in createdId, and in the message for
+        // humans) instead of making the agent diff list_patterns.
+        if (const auto* clone = dynamic_cast<const ClonePatternCommand*>(shared.get())) {
+            // CommandHistory::pushAndExecute swallows a throwing execute()
+            // (the command is not recorded); an invalid id here means the
+            // clone did not happen.
+            if (!clone->getClonedPatternId().isValid()) {
+                result.status = CommandStatus::ExecutionError;
+                result.message = "failed to clone pattern";
+                result.undoable = false;
+                return finish(result);
+            }
+            result.status = CommandStatus::Success;
+            result.createdId = clone->getClonedPatternId().value;
+            result.message = "cloned pattern -> " +
+                             std::to_string(clone->getClonedPatternId().value);
+            return finish(result);
+        }
     } catch (const std::exception& e) {
         result.status = CommandStatus::ExecutionError;
         result.message = e.what();

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -2,6 +2,7 @@
 #include "Commands/ClonePatternCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Commands/CommandRegistry.h"
+#include "Commands/EffectCommands.h"
 
 #include <algorithm>
 #include <chrono>
@@ -166,8 +167,25 @@ CommandResult CommandParser::execute(const std::string& verb,
             }
             result.status = CommandStatus::Success;
             result.createdId = clone->getClonedPatternId().value;
+            result.hasCreatedId = true;
             result.message = "cloned pattern -> " +
                              std::to_string(clone->getClonedPatternId().value);
+            return finish(result);
+        }
+        // add_effect: the slot is how the effect is addressed afterwards.
+        // pushAndExecute swallows a throwing execute(), so confirm the insert
+        // actually happened before reporting a slot.
+        if (const auto* addEffect = dynamic_cast<const AddEffectCommand*>(shared.get())) {
+            if (!addEffect->wasExecuted()) {
+                result.status = CommandStatus::ExecutionError;
+                result.message = "failed to add effect";
+                result.undoable = false;
+                return finish(result);
+            }
+            result.status = CommandStatus::Success;
+            result.createdId = static_cast<uint64_t>(addEffect->getSlotIndex());
+            result.hasCreatedId = true;
+            result.message = "added effect in slot " + std::to_string(addEffect->getSlotIndex());
             return finish(result);
         }
     } catch (const std::exception& e) {

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -59,6 +59,65 @@ CommandResult CommandParser::parse(const std::string& input, CommandHistory& his
     return executed;
 }
 
+std::unique_ptr<ICommand> CommandParser::buildValidated(
+    const std::string& verb,
+    const std::unordered_map<std::string, std::string>& flags,
+    CommandStatus& outStatus,
+    std::string& outMessage) {
+    // Look up verb in MuseGrammar::allCommands()
+    const auto& allCmds = MuseGrammar::allCommands();
+    const CommandSchema* schema = nullptr;
+    for (const auto& cmd : allCmds) {
+        if (cmd.verb == verb) {
+            schema = &cmd;
+            break;
+        }
+    }
+
+    if (!schema) {
+        outStatus = CommandStatus::ParseError;
+        outMessage = "unknown command: " + verb;
+        return nullptr;
+    }
+
+    // Reject flags the schema does not define — accepting them would let a
+    // caller believe intent was honoured when it was silently dropped.
+    for (const auto& entry : flags) {
+        bool known = false;
+        for (const auto& flagSchema : schema->flags) {
+            if (flagSchema.name == entry.first) {
+                known = true;
+                break;
+            }
+        }
+        if (!known) {
+            outStatus = CommandStatus::ValidationError;
+            outMessage = "unknown flag for " + verb + ": --" + entry.first;
+            return nullptr;
+        }
+    }
+
+    // Validate required flags present and values within type + range
+    std::string validationError;
+    if (!validateFlags(*schema, flags, validationError)) {
+        outStatus = CommandStatus::ValidationError;
+        outMessage = std::move(validationError);
+        return nullptr;
+    }
+
+    // Build ICommand via registry
+    auto cmd = CommandRegistry::instance().build(verb, flags);
+    if (!cmd) {
+        outStatus = CommandStatus::ExecutionError;
+        outMessage = "failed to build command for: " + verb;
+        return nullptr;
+    }
+
+    outStatus = CommandStatus::Success;
+    outMessage.clear();
+    return cmd;
+}
+
 CommandResult CommandParser::execute(const std::string& verb,
                                      const std::unordered_map<std::string, std::string>& flags,
                                      CommandHistory& history) {
@@ -73,52 +132,12 @@ CommandResult CommandParser::execute(const std::string& verb,
         return r;
     };
 
-    // Look up verb in MuseGrammar::allCommands()
-    const auto& allCmds = MuseGrammar::allCommands();
-    const CommandSchema* schema = nullptr;
-    for (const auto& cmd : allCmds) {
-        if (cmd.verb == verb) {
-            schema = &cmd;
-            break;
-        }
-    }
-
-    if (!schema) {
-        result.status = CommandStatus::ParseError;
-        result.message = "unknown command: " + verb;
-        return finish(result);
-    }
-
-    // Reject flags the schema does not define — accepting them would let a
-    // caller believe intent was honoured when it was silently dropped.
-    for (const auto& entry : flags) {
-        bool known = false;
-        for (const auto& flagSchema : schema->flags) {
-            if (flagSchema.name == entry.first) {
-                known = true;
-                break;
-            }
-        }
-        if (!known) {
-            result.status = CommandStatus::ValidationError;
-            result.message = "unknown flag for " + verb + ": --" + entry.first;
-            return finish(result);
-        }
-    }
-
-    // Validate required flags present and values within type + range
-    std::string validationError;
-    if (!validateFlags(*schema, flags, validationError)) {
-        result.status = CommandStatus::ValidationError;
-        result.message = std::move(validationError);
-        return finish(result);
-    }
-
-    // Build ICommand via registry
-    auto cmd = CommandRegistry::instance().build(verb, flags);
+    CommandStatus buildStatus = CommandStatus::Success;
+    std::string buildMessage;
+    auto cmd = buildValidated(verb, flags, buildStatus, buildMessage);
     if (!cmd) {
-        result.status = CommandStatus::ExecutionError;
-        result.message = "failed to build command for: " + verb;
+        result.status = buildStatus;
+        result.message = std::move(buildMessage);
         return finish(result);
     }
 

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -3,6 +3,7 @@
 #include "Commands/AddClipCommand.h"
 #include "Commands/AddNoteCommand.h"
 #include "Commands/AddUnitCommand.h"
+#include "Commands/ArrangePatternCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -177,6 +178,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("delete_note", noopTrack);
         reg.registerCommand("move_note", noopTrack);
         reg.registerCommand("set_note", noopTrack);
+        reg.registerCommand("arrange_pattern", noopTrack);
         return;
     }
 
@@ -504,6 +506,41 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         }
         return std::make_unique<MoveNoteCommand>(tm->getPatternManager(), key->patternId, *note,
                                                  static_cast<double>(*toStartOpt), toPitch);
+    });
+
+    reg.registerCommand("arrange_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return nullptr;
+        auto startOpt = safeStof(*startRaw);
+        if (!startOpt) return nullptr;
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        // Tracks are mixer channels; the command creates matching playlist
+        // lanes, but the channel itself must already exist.
+        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount()) return nullptr;
+
+        // A unit has a single timeline route: arranging it onto a different
+        // track would silently reroute every earlier clip that uses it.
+        // Reject the conflict instead of corrupting existing arrangements.
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.unitId == 0) continue;
+            const int route = tm->getUnitManager().getUnitTimelineLane(note.unitId);
+            if (route >= 0 && route != *trackOpt) return nullptr;
+        }
+
+        return std::make_unique<ArrangePatternCommand>(*tm, patternId,
+                                                       static_cast<size_t>(*trackOpt),
+                                                       static_cast<double>(*startOpt));
     });
 
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -4,6 +4,8 @@
 #include "Commands/AddNoteCommand.h"
 #include "Commands/AddUnitCommand.h"
 #include "Commands/ArrangePatternCommand.h"
+#include "Commands/ClonePatternCommand.h"
+#include "Commands/SetPatternLengthCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -103,11 +105,25 @@ std::optional<uint64_t> safeStoull(std::string_view s) {
 }
 
 AudioEngine* s_audioEngine = nullptr;
+
+// Reason recorded by the most recent factory refusal (see CommandRegistry::fail).
+thread_local std::string t_lastBuildError;
 } // namespace
 
 CommandRegistry& CommandRegistry::instance() {
     static CommandRegistry s_instance;
     return s_instance;
+}
+
+std::unique_ptr<ICommand> CommandRegistry::fail(const std::string& reason) {
+    t_lastBuildError = reason;
+    return nullptr;
+}
+
+std::string CommandRegistry::consumeLastBuildError() {
+    std::string reason = std::move(t_lastBuildError);
+    t_lastBuildError.clear();
+    return reason;
 }
 
 void CommandRegistry::registerCommand(const std::string& verb, Factory factory) {
@@ -118,6 +134,7 @@ std::unique_ptr<ICommand> CommandRegistry::build(
     const std::string& verb,
     const std::unordered_map<std::string, std::string>& flags)
 {
+    t_lastBuildError.clear();
     auto it = m_factories.find(verb);
     if (it == m_factories.end())
         return nullptr;
@@ -185,6 +202,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("set_steps", noopTrack);
         reg.registerCommand("quantize_pattern", noopTrack);
         reg.registerCommand("transpose_pattern", noopTrack);
+        reg.registerCommand("clone_pattern", noopTrack);
+        reg.registerCommand("set_pattern_length", noopTrack);
         return;
     }
 
@@ -199,6 +218,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
         if (!trackOpt) return nullptr;
+        if (*trackOpt < 0 || !tm->getChannel(static_cast<size_t>(*trackOpt)))
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<DeleteTrackCommand>(*tm, *trackOpt);
     });
 
@@ -209,6 +230,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!trackOpt) return nullptr;
         auto nameIt = flags.find("name");
         if (nameIt == flags.end()) return nullptr;
+        if (*trackOpt < 0 || !tm->getChannel(static_cast<size_t>(*trackOpt)))
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<RenameTrackCommand>(*tm, *trackOpt, nameIt->second);
     });
 
@@ -222,7 +245,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         bool state = parseFlagBool(*stateRaw);
         if (!trackOpt.has_value() || *trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetMuteCommand>(*ch, state);
     });
 
@@ -236,7 +259,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         bool state = parseFlagBool(*stateRaw);
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetSoloCommand>(*ch, state);
     });
 
@@ -251,7 +274,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!valueOpt) return nullptr;
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetVolumeCommand>(*ch, *valueOpt);
     });
 
@@ -266,7 +289,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!valueOpt) return nullptr;
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
-        if (!ch) return nullptr;
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
         return std::make_unique<SetPanCommand>(*ch, *valueOpt);
     });
 
@@ -285,7 +308,7 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
         if (!laneId.isValid())
-            return nullptr;
+            return CommandRegistry::fail("track " + std::string(*trackRaw) + " has no playlist lane");
 
         ClipInstance clip;
         clip.startBeat = (*barOpt - 1) * 4.0;
@@ -384,7 +407,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
             if (typeIt->second == "808") {
                 type = UnitType::PitchedSampler;
             } else if (typeIt->second != "sampler") {
-                return nullptr; // schema comment advertises the accepted values
+                return CommandRegistry::fail("unknown unit type: " + typeIt->second +
+                                             " (expected sampler or 808)");
             }
         }
         return std::make_unique<AddUnitCommand>(tm->getUnitManager(), name, type);
@@ -398,9 +422,11 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         auto fileRaw = requireFlag(flags, "file");
         if (!fileRaw) return nullptr;
 
-        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        if (!tm->getUnitManager().getUnit(*unitOpt))
+            return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
         std::error_code ec;
-        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec)) return nullptr;
+        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec))
+            return CommandRegistry::fail("file not found: " + std::string(*fileRaw));
         return std::make_unique<LoadSampleCommand>(tm->getUnitManager(), *unitOpt, std::string(*fileRaw));
     });
 
@@ -472,8 +498,11 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         }
 
         const PatternSource* pattern = tm->getPatternManager().getPattern(key->patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
-        if (!tm->getUnitManager().getUnit(key->unitId)) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " +
+                                         std::to_string(key->patternId.value));
+        if (!tm->getUnitManager().getUnit(key->unitId))
+            return CommandRegistry::fail("no such unit: " + std::to_string(key->unitId));
 
         MidiNote note;
         note.pitch = key->pitch;
@@ -489,7 +518,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
         return std::make_unique<RemoveNoteCommand>(tm->getPatternManager(), key->patternId, *note);
     });
 
@@ -502,7 +536,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!toStartOpt) return nullptr;
 
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
 
         int toPitch = note->pitch;
         if (auto it = flags.find("to_pitch"); it != flags.end()) {
@@ -530,10 +569,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
         // Tracks are mixer channels; the command creates matching playlist
         // lanes, but the channel itself must already exist.
-        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount()) return nullptr;
+        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount())
+            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
 
         // A unit has a single timeline route: arranging it onto a different
         // track would silently reroute every earlier clip that uses it.
@@ -541,7 +582,10 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
             if (note.unitId == 0) continue;
             const int route = tm->getUnitManager().getUnitTimelineLane(note.unitId);
-            if (route >= 0 && route != *trackOpt) return nullptr;
+            if (route >= 0 && route != *trackOpt)
+                return CommandRegistry::fail(
+                    "unit " + std::to_string(note.unitId) + " is already routed to track " +
+                    std::to_string(route) + "; arrange on that track or undo the earlier arrange");
         }
 
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
@@ -586,18 +630,23 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
-        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
+        if (!tm->getUnitManager().getUnit(*unitOpt))
+            return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
 
         // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
         // typo the agent should hear about, not a silent rest.
         const std::string steps(*stepsRaw);
-        if (steps.empty() || steps.size() > 256) return nullptr;
+        if (steps.empty() || steps.size() > 256)
+            return CommandRegistry::fail("steps must be 1..256 characters");
         std::vector<MidiNote> rowNotes;
         for (size_t i = 0; i < steps.size(); ++i) {
             const char c = steps[i];
             if (c == '-' || c == '.' || c == ' ') continue;
-            if (c != 'x' && c != 'X') return nullptr;
+            if (c != 'x' && c != 'X')
+                return CommandRegistry::fail(std::string("invalid step character '") + c +
+                                             "' (use x, X, -, .)");
             MidiNote note;
             note.pitch = *pitchOpt;
             note.startBeat = static_cast<double>(i) * stepBeats;
@@ -638,7 +687,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
 
         return std::make_unique<QuantizePatternCommand>(tm->getPatternManager(), patternId,
                                                         static_cast<double>(*gridOpt), strength,
@@ -664,25 +714,61 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
-        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!pattern || !pattern->isMidi())
+            return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
 
         // Reject rather than clamp: a clamped transpose is not invertible,
         // which would corrupt undo.
         for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
             if (unitId != 0 && note.unitId != unitId) continue;
             const int shifted = note.pitch + *semitonesOpt;
-            if (shifted < 0 || shifted > 127) return nullptr;
+            if (shifted < 0 || shifted > 127)
+                return CommandRegistry::fail(
+                    "transpose would move pitch " + std::to_string(note.pitch) + " to " +
+                    std::to_string(shifted) + " (outside MIDI range 0..127)");
         }
 
         return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
                                                          *semitonesOpt, unitId);
     });
 
+    reg.registerCommand("clone_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        const PatternID patternId{*patternOpt};
+        if (!tm->getPatternManager().getPattern(patternId))
+            return CommandRegistry::fail("no such pattern: " + std::string(*patternRaw));
+        return std::make_unique<ClonePatternCommand>(tm->getPatternManager(), patternId);
+    });
+
+    reg.registerCommand("set_pattern_length", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto beatsRaw = requireFlag(flags, "beats");
+        if (!beatsRaw) return nullptr;
+        auto beatsOpt = safeStof(*beatsRaw);
+        if (!beatsOpt) return nullptr;
+        const PatternID patternId{*patternOpt};
+        if (!tm->getPatternManager().getPattern(patternId))
+            return CommandRegistry::fail("no such pattern: " + std::string(*patternRaw));
+        return std::make_unique<SetPatternLengthCommand>(tm->getPatternManager(), patternId,
+                                                         static_cast<double>(*beatsOpt));
+    });
+
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
-        if (!note) return nullptr;
+        if (!note)
+            return CommandRegistry::fail("no note at pattern " +
+                                         std::to_string(key->patternId.value) + ", unit " +
+                                         std::to_string(key->unitId) + ", pitch " +
+                                         std::to_string(key->pitch) + ", start " +
+                                         std::to_string(key->startBeat));
 
         float velocity = note->velocity;
         if (auto it = flags.find("velocity"); it != flags.end()) {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -8,6 +8,9 @@
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/MoveNoteCommand.h"
+#include "Commands/QuantizePatternCommand.h"
+#include "Commands/SetStepsCommand.h"
+#include "Commands/TransposePatternCommand.h"
 #include "Commands/RemoveClipCommand.h"
 #include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
@@ -179,6 +182,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("move_note", noopTrack);
         reg.registerCommand("set_note", noopTrack);
         reg.registerCommand("arrange_pattern", noopTrack);
+        reg.registerCommand("set_steps", noopTrack);
+        reg.registerCommand("quantize_pattern", noopTrack);
+        reg.registerCommand("transpose_pattern", noopTrack);
         return;
     }
 
@@ -541,6 +547,135 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
                                                        static_cast<size_t>(*trackOpt),
                                                        static_cast<double>(*startOpt));
+    });
+
+    reg.registerCommand("set_steps", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return nullptr;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return nullptr;
+        auto pitchRaw = requireFlag(flags, "pitch");
+        if (!pitchRaw) return nullptr;
+        auto pitchOpt = safeStoi(*pitchRaw);
+        if (!pitchOpt) return nullptr;
+        auto stepsRaw = requireFlag(flags, "steps");
+        if (!stepsRaw) return nullptr;
+
+        double stepBeats = 0.25; // 16th notes
+        if (auto it = flags.find("step"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            stepBeats = static_cast<double>(*v);
+        }
+        float velocity = 0.8f;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float gate = 0.9f;
+        if (auto it = flags.find("gate"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            gate = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+
+        // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
+        // typo the agent should hear about, not a silent rest.
+        const std::string steps(*stepsRaw);
+        if (steps.empty() || steps.size() > 256) return nullptr;
+        std::vector<MidiNote> rowNotes;
+        for (size_t i = 0; i < steps.size(); ++i) {
+            const char c = steps[i];
+            if (c == '-' || c == '.' || c == ' ') continue;
+            if (c != 'x' && c != 'X') return nullptr;
+            MidiNote note;
+            note.pitch = *pitchOpt;
+            note.startBeat = static_cast<double>(i) * stepBeats;
+            note.durationBeats = stepBeats * static_cast<double>(gate);
+            note.velocity = (c == 'X') ? std::min(1.0f, velocity + 0.2f) : velocity;
+            note.unitId = *unitOpt;
+            rowNotes.push_back(note);
+        }
+
+        const double rowLengthBeats = static_cast<double>(steps.size()) * stepBeats;
+        return std::make_unique<SetStepsCommand>(tm->getPatternManager(), patternId,
+                                                 std::move(rowNotes), *unitOpt, *pitchOpt,
+                                                 rowLengthBeats);
+    });
+
+    reg.registerCommand("quantize_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto gridRaw = requireFlag(flags, "grid");
+        if (!gridRaw) return nullptr;
+        auto gridOpt = safeStof(*gridRaw);
+        if (!gridOpt) return nullptr;
+
+        double strength = 1.0;
+        if (auto it = flags.find("strength"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            strength = static_cast<double>(*v);
+        }
+        uint64_t unitId = 0; // all units
+        if (auto it = flags.find("unit"); it != flags.end()) {
+            auto v = safeStoull(it->second);
+            if (!v) return nullptr;
+            unitId = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+
+        return std::make_unique<QuantizePatternCommand>(tm->getPatternManager(), patternId,
+                                                        static_cast<double>(*gridOpt), strength,
+                                                        unitId);
+    });
+
+    reg.registerCommand("transpose_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return nullptr;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return nullptr;
+        auto semitonesRaw = requireFlag(flags, "semitones");
+        if (!semitonesRaw) return nullptr;
+        auto semitonesOpt = safeStoi(*semitonesRaw);
+        if (!semitonesOpt) return nullptr;
+
+        uint64_t unitId = 0; // all units
+        if (auto it = flags.find("unit"); it != flags.end()) {
+            auto v = safeStoull(it->second);
+            if (!v) return nullptr;
+            unitId = *v;
+        }
+
+        const PatternID patternId{*patternOpt};
+        const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+
+        // Reject rather than clamp: a clamped transpose is not invertible,
+        // which would corrupt undo.
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (unitId != 0 && note.unitId != unitId) continue;
+            const int shifted = note.pitch + *semitonesOpt;
+            if (shifted < 0 || shifted > 127) return nullptr;
+        }
+
+        return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
+                                                         *semitonesOpt, unitId);
     });
 
     reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -634,6 +634,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
             if (!v) return nullptr;
             gate = *v;
         }
+        double swing = 0.0;
+        if (auto it = flags.find("swing"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            swing = static_cast<double>(*v);
+        }
 
         const PatternID patternId{*patternOpt};
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
@@ -642,8 +648,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         if (!tm->getUnitManager().getUnit(*unitOpt))
             return CommandRegistry::fail("no such unit: " + std::string(*unitRaw));
 
-        // steps: 'x' hit, 'X' accent, '-' '.' or ' ' rest. Anything else is a
-        // typo the agent should hear about, not a silent rest.
+        // steps: 'x' hit, 'X' accent, digits '1'-'9' hit at velocity n/9,
+        // '-' '.' or ' ' rest. Anything else is a typo the agent should hear
+        // about, not a silent rest.
         const std::string steps(*stepsRaw);
         if (steps.empty() || steps.size() > 256)
             return CommandRegistry::fail("steps must be 1..256 characters");
@@ -651,14 +658,27 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         for (size_t i = 0; i < steps.size(); ++i) {
             const char c = steps[i];
             if (c == '-' || c == '.' || c == ' ') continue;
-            if (c != 'x' && c != 'X')
+            float noteVelocity;
+            if (c == 'x') {
+                noteVelocity = velocity;
+            } else if (c == 'X') {
+                noteVelocity = std::min(1.0f, velocity + 0.2f);
+            } else if (c >= '1' && c <= '9') {
+                noteVelocity = static_cast<float>(c - '0') / 9.0f;
+            } else {
                 return CommandRegistry::fail(std::string("invalid step character '") + c +
-                                             "' (use x, X, -, .)");
+                                             "' (use x, X, 1-9, -, ., or space)");
+            }
             MidiNote note;
             note.pitch = *pitchOpt;
             note.startBeat = static_cast<double>(i) * stepBeats;
+            // Swing: every second step lands late by swing * step/2 — the
+            // classic shuffle placement.
+            if (i % 2 == 1) {
+                note.startBeat += swing * stepBeats * 0.5;
+            }
             note.durationBeats = stepBeats * static_cast<double>(gate);
-            note.velocity = (c == 'X') ? std::min(1.0f, velocity + 0.2f) : velocity;
+            note.velocity = noteVelocity;
             note.unitId = *unitOpt;
             rowNotes.push_back(note);
         }

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -5,7 +5,9 @@
 #include "Commands/AddUnitCommand.h"
 #include "Commands/ArrangePatternCommand.h"
 #include "Commands/ClonePatternCommand.h"
+#include "Commands/EffectCommands.h"
 #include "Commands/SetPatternLengthCommand.h"
+#include "Plugin/PluginManager.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -31,6 +33,7 @@
 #include <cmath>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -204,6 +207,10 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("transpose_pattern", noopTrack);
         reg.registerCommand("clone_pattern", noopTrack);
         reg.registerCommand("set_pattern_length", noopTrack);
+        reg.registerCommand("add_effect", noopTrack);
+        reg.registerCommand("remove_effect", noopTrack);
+        reg.registerCommand("bypass_effect", noopTrack);
+        reg.registerCommand("set_effect_param", noopTrack);
         return;
     }
 
@@ -730,6 +737,158 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
 
         return std::make_unique<TransposePatternCommand>(tm->getPatternManager(), patternId,
                                                          *semitonesOpt, unitId);
+    });
+
+    // Shared by the effect factories: case-insensitive string equality.
+    const auto equalsIgnoreCase = [](std::string_view a, std::string_view b) {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); ++i) {
+            if (std::tolower(static_cast<unsigned char>(a[i])) !=
+                std::tolower(static_cast<unsigned char>(b[i])))
+                return false;
+        }
+        return true;
+    };
+
+    reg.registerCommand("add_effect", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto effectRaw = requireFlag(flags, "effect");
+        if (!effectRaw) return nullptr;
+
+        auto& pluginManager = PluginManager::getInstance();
+        const PluginInfo* match = nullptr;
+        const auto effects = pluginManager.getEffectPlugins();
+        for (const auto& info : effects) {
+            if (info.id == *effectRaw || equalsIgnoreCase(info.name, *effectRaw)) {
+                match = &info;
+                break;
+            }
+        }
+        if (!match)
+            return CommandRegistry::fail("unknown effect: " + std::string(*effectRaw) +
+                                         " (list_plugins shows what is available)");
+
+        auto& chain = ch->getEffectChain();
+        size_t slot = chain.getFirstEmptySlot();
+        if (auto it = flags.find("slot"); it != flags.end()) {
+            auto s = safeStoi(it->second);
+            if (!s) return nullptr;
+            slot = static_cast<size_t>(*s);
+            if (chain.getPlugin(slot))
+                return CommandRegistry::fail("slot " + it->second + " on track " +
+                                             std::string(*trackRaw) + " is occupied");
+        }
+        if (slot >= EffectChain::MAX_SLOTS)
+            return CommandRegistry::fail("no empty effect slots on track " +
+                                         std::string(*trackRaw));
+
+        // Same lifecycle the app runs before inserting an effect.
+        auto instance = pluginManager.createInstanceById(match->id);
+        if (!instance)
+            return CommandRegistry::fail("failed to create effect: " + match->id);
+        if (!instance->initialize(pluginManager.getDefaultSampleRate(),
+                                  pluginManager.getDefaultBlockSize()))
+            return CommandRegistry::fail("failed to initialize effect: " + match->id);
+        instance->activate();
+        chain.prepare(pluginManager.getDefaultSampleRate(), pluginManager.getDefaultBlockSize());
+
+        return std::make_unique<AddEffectCommand>(*tm, *ch, slot, std::move(instance),
+                                                  match->name);
+    });
+
+    reg.registerCommand("remove_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        if (!ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt)))
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        return std::make_unique<RemoveEffectCommand>(*tm, *ch, static_cast<size_t>(*slotOpt));
+    });
+
+    reg.registerCommand("bypass_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        auto stateRaw = requireFlag(flags, "state");
+        if (!stateRaw) return nullptr;
+        if (!ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt)))
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        return std::make_unique<SetEffectBypassCommand>(*tm, *ch, static_cast<size_t>(*slotOpt),
+                                                        parseFlagBool(*stateRaw));
+    });
+
+    reg.registerCommand("set_effect_param", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto trackRaw = requireFlag(flags, "track");
+        if (!trackRaw) return nullptr;
+        auto trackOpt = safeStoi(*trackRaw);
+        if (!trackOpt || *trackOpt < 0) return nullptr;
+        MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
+        if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
+        auto slotRaw = requireFlag(flags, "slot");
+        if (!slotRaw) return nullptr;
+        auto slotOpt = safeStoi(*slotRaw);
+        if (!slotOpt) return nullptr;
+        auto plugin = ch->getEffectChain().getPlugin(static_cast<size_t>(*slotOpt));
+        if (!plugin)
+            return CommandRegistry::fail("no effect in slot " + std::string(*slotRaw) +
+                                         " of track " + std::string(*trackRaw));
+        auto paramRaw = requireFlag(flags, "param");
+        if (!paramRaw) return nullptr;
+        auto valueRaw = requireFlag(flags, "value");
+        if (!valueRaw) return nullptr;
+        auto valueOpt = safeStof(*valueRaw);
+        if (!valueOpt) return nullptr;
+
+        // param is a name (case-insensitive) or a numeric id from get_effects.
+        const auto params = plugin->getParameters();
+        const PluginParameter* target = nullptr;
+        if (auto numeric = safeStoull(*paramRaw);
+            numeric && *numeric <= std::numeric_limits<uint32_t>::max()) {
+            for (const auto& param : params) {
+                if (param.id == static_cast<uint32_t>(*numeric)) {
+                    target = &param;
+                    break;
+                }
+            }
+        }
+        if (!target) {
+            for (const auto& param : params) {
+                if (equalsIgnoreCase(param.name, *paramRaw) ||
+                    equalsIgnoreCase(param.shortName, *paramRaw)) {
+                    target = &param;
+                    break;
+                }
+            }
+        }
+        if (!target)
+            return CommandRegistry::fail("no parameter '" + std::string(*paramRaw) + "' on " +
+                                         plugin->getInfo().name +
+                                         " (get_effects lists parameters)");
+        if (target->isReadOnly)
+            return CommandRegistry::fail("parameter '" + target->name + "' is read-only");
+
+        return std::make_unique<SetEffectParamCommand>(plugin, target->id, *valueOpt);
     });
 
     reg.registerCommand("clone_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -1,14 +1,20 @@
 #include "Commands/CommandRegistry.h"
 #include "Commands/AddChannelCommand.h"
 #include "Commands/AddClipCommand.h"
+#include "Commands/AddNoteCommand.h"
+#include "Commands/AddUnitCommand.h"
 #include "Commands/DuplicateClipCommand.h"
+#include "Commands/LoadSampleCommand.h"
 #include "Commands/MoveClipCommand.h"
+#include "Commands/MoveNoteCommand.h"
 #include "Commands/RemoveClipCommand.h"
+#include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetSoloCommand.h"
 #include "Commands/SetVolumeCommand.h"
 #include "Commands/TrimClipCommand.h"
+#include "Commands/UpdateNoteCommand.h"
 #include "Commands/MuseStubs.h"
 #include "Models/ClipInstance.h"
 #include "Models/TrackManager.h"
@@ -18,9 +24,11 @@
 #include <cctype>
 #include <cmath>
 #include <exception>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 
 namespace Aestra {
 namespace Audio {
@@ -163,6 +171,12 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         reg.registerCommand("move_clip", noopTrack);
         reg.registerCommand("duplicate_clip", noopTrack);
         reg.registerCommand("trim_clip", noopTrack);
+        reg.registerCommand("add_unit", noopTrack);
+        reg.registerCommand("load_sample", noopTrack);
+        reg.registerCommand("add_note", noopTrack);
+        reg.registerCommand("delete_note", noopTrack);
+        reg.registerCommand("move_note", noopTrack);
+        reg.registerCommand("set_note", noopTrack);
         return;
     }
 
@@ -350,6 +364,168 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         ClipInstanceID clipId;
         clipId.low = *idOpt;
         return std::make_unique<TrimClipCommand>(*pm, clipId, *startOpt, *endOpt);
+    });
+
+    // ===== Unit (2) =====
+    reg.registerCommand("add_unit", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto nameIt = flags.find("name");
+        std::string name = (nameIt != flags.end()) ? nameIt->second : "";
+        UnitType type = UnitType::Sampler;
+        auto typeIt = flags.find("type");
+        if (typeIt != flags.end()) {
+            if (typeIt->second == "808") {
+                type = UnitType::PitchedSampler;
+            } else if (typeIt->second != "sampler") {
+                return nullptr; // schema comment advertises the accepted values
+            }
+        }
+        return std::make_unique<AddUnitCommand>(tm->getUnitManager(), name, type);
+    });
+
+    reg.registerCommand("load_sample", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return nullptr;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return nullptr;
+        auto fileRaw = requireFlag(flags, "file");
+        if (!fileRaw) return nullptr;
+
+        if (!tm->getUnitManager().getUnit(*unitOpt)) return nullptr;
+        std::error_code ec;
+        if (!std::filesystem::exists(std::filesystem::path(std::string(*fileRaw)), ec)) return nullptr;
+        return std::make_unique<LoadSampleCommand>(tm->getUnitManager(), *unitOpt, std::string(*fileRaw));
+    });
+
+    // ===== Pattern / note (4) =====
+    // Notes are addressed by (pattern, unit, pitch, start) — the same key the
+    // piano-roll note commands match on. `findNote` resolves that key against
+    // stored notes with a small tolerance on start, because the caller's beat
+    // value round-tripped through JSON text.
+    const auto findNote = [](TrackManager& tm, PatternID patternId, uint64_t unitId, int pitch,
+                             double startBeat) -> std::optional<MidiNote> {
+        const PatternSource* pattern = tm.getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) return std::nullopt;
+        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+            if (note.pitch == pitch && note.unitId == unitId &&
+                std::abs(note.startBeat - startBeat) < 1e-6) {
+                return note;
+            }
+        }
+        return std::nullopt;
+    };
+
+    // Shared front half: parse pattern/unit/pitch/start, which every note verb takes.
+    struct NoteKey {
+        PatternID patternId;
+        uint64_t unitId;
+        int pitch;
+        double startBeat;
+    };
+    const auto parseNoteKey =
+        [](const std::unordered_map<std::string, std::string>& flags) -> std::optional<NoteKey> {
+        auto patternRaw = requireFlag(flags, "pattern");
+        if (!patternRaw) return std::nullopt;
+        auto patternOpt = safeStoull(*patternRaw);
+        if (!patternOpt) return std::nullopt;
+        auto unitRaw = requireFlag(flags, "unit");
+        if (!unitRaw) return std::nullopt;
+        auto unitOpt = safeStoull(*unitRaw);
+        if (!unitOpt) return std::nullopt;
+        auto pitchRaw = requireFlag(flags, "pitch");
+        if (!pitchRaw) return std::nullopt;
+        auto pitchOpt = safeStoi(*pitchRaw);
+        if (!pitchOpt) return std::nullopt;
+        auto startRaw = requireFlag(flags, "start");
+        if (!startRaw) return std::nullopt;
+        auto startOpt = safeStof(*startRaw);
+        if (!startOpt) return std::nullopt;
+        return NoteKey{PatternID{*patternOpt}, *unitOpt, *pitchOpt, static_cast<double>(*startOpt)};
+    };
+
+    reg.registerCommand("add_note", [tm = trackManager, parseNoteKey](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto durationRaw = requireFlag(flags, "duration");
+        if (!durationRaw) return nullptr;
+        auto durationOpt = safeStof(*durationRaw);
+        if (!durationOpt) return nullptr;
+
+        float velocity = 0.8f;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float pan = 0.0f;
+        if (auto it = flags.find("pan"); it != flags.end()) {
+            auto p = safeStof(it->second);
+            if (!p) return nullptr;
+            pan = *p;
+        }
+
+        const PatternSource* pattern = tm->getPatternManager().getPattern(key->patternId);
+        if (!pattern || !pattern->isMidi()) return nullptr;
+        if (!tm->getUnitManager().getUnit(key->unitId)) return nullptr;
+
+        MidiNote note;
+        note.pitch = key->pitch;
+        note.startBeat = key->startBeat;
+        note.durationBeats = static_cast<double>(*durationOpt);
+        note.velocity = velocity;
+        note.pan = pan;
+        note.unitId = key->unitId;
+        return std::make_unique<AddNoteCommand>(tm->getPatternManager(), key->patternId, note);
+    });
+
+    reg.registerCommand("delete_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+        return std::make_unique<RemoveNoteCommand>(tm->getPatternManager(), key->patternId, *note);
+    });
+
+    reg.registerCommand("move_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto toStartRaw = requireFlag(flags, "to_start");
+        if (!toStartRaw) return nullptr;
+        auto toStartOpt = safeStof(*toStartRaw);
+        if (!toStartOpt) return nullptr;
+
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+
+        int toPitch = note->pitch;
+        if (auto it = flags.find("to_pitch"); it != flags.end()) {
+            auto p = safeStoi(it->second);
+            if (!p) return nullptr;
+            toPitch = *p;
+        }
+        return std::make_unique<MoveNoteCommand>(tm->getPatternManager(), key->patternId, *note,
+                                                 static_cast<double>(*toStartOpt), toPitch);
+    });
+
+    reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+        auto key = parseNoteKey(flags);
+        if (!key) return nullptr;
+        auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
+        if (!note) return nullptr;
+
+        float velocity = note->velocity;
+        if (auto it = flags.find("velocity"); it != flags.end()) {
+            auto v = safeStof(it->second);
+            if (!v) return nullptr;
+            velocity = *v;
+        }
+        float pan = note->pan;
+        if (auto it = flags.find("pan"); it != flags.end()) {
+            auto p = safeStof(it->second);
+            if (!p) return nullptr;
+            pan = *p;
+        }
+        return std::make_unique<UpdateNoteCommand>(tm->getPatternManager(), key->patternId, *note,
+                                                   velocity, pan);
     });
 }
 

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -19,9 +19,10 @@ static const std::vector<CommandSchema> s_schemas = {
     }},
 
     // === Track (8) ===
+    // NOTE: no "type" flag until the factory consumes one — advertising a
+    // flag the registry ignores would make the schema lie to agents.
     {"add_track", CommandCategory::Track, {
-        {"name", FlagType::String, false},
-        {"type", FlagType::String, true}
+        {"name", FlagType::String, false}
     }},
     {"delete_track", CommandCategory::Track, {
         {"track", FlagType::Int, true}

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -116,6 +116,29 @@ static const std::vector<CommandSchema> s_schemas = {
         {"track", FlagType::Int, true, 0.0},
         {"start", FlagType::Float, true, 0.0}
     }},
+    // steps: one char per step — 'x' hit, 'X' accented hit, '-' or '.' rest.
+    // The string defines the ENTIRE row for that (unit, pitch): re-issuing
+    // the verb rewrites the groove, an all-rest string clears it.
+    {"set_steps", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"steps", FlagType::String, true},
+        {"step", FlagType::Float, false, 0.015625, 4.0},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"gate", FlagType::Float, false, 0.05, 1.0}
+    }},
+    {"quantize_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"grid", FlagType::Float, true, 0.015625, 16.0},
+        {"strength", FlagType::Float, false, 0.0, 1.0},
+        {"unit", FlagType::Int, false, 1.0}
+    }},
+    {"transpose_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"semitones", FlagType::Int, true, -48.0, 48.0},
+        {"unit", FlagType::Int, false, 1.0}
+    }},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -147,9 +147,10 @@ static const std::vector<CommandSchema> s_schemas = {
         {"steps", FlagType::String, true},
         {"step", FlagType::Float, false, 0.015625, 4.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
-        {"gate", FlagType::Float, false, 0.05, 1.0}
+        {"gate", FlagType::Float, false, 0.05, 1.0},
+        {"swing", FlagType::Float, false, 0.0, 0.9}
     },
-     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it."},
+     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it. Digits 1-9 are hits at velocity n/9; swing delays every second step."},
     {"quantize_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"grid", FlagType::Float, true, 0.015625, 16.0},
@@ -275,6 +276,7 @@ std::string schemaToJsonString() {
   {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
   {"verb": "list_plugins", "args": "none", "description": "available effect plugins: id, name, category. Use id or name with add_effect."},
   {"verb": "get_effects", "args": "{\"track\": <index>}", "description": "a track's effect chain: slot, id, name, bypassed, and every parameter (id, name, value 0..1, display, unit)."},
+  {"verb": "list_samples", "args": "{\"dir\": <path>}", "description": "audio files under a directory (recursive, depth 3, max 500): path, name, sizeBytes. Feed paths to load_sample."},
   {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
   {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
 ],
@@ -288,7 +290,7 @@ std::string schemaToJsonString() {
   "unitTypes": "sampler = polyphonic sampler; 808 = mono pitched sampler with glide.",
   "patterns": "Every non-audio unit gets a default MIDI pattern at creation (list_units.defaultPatternId). A pattern is just a container: notes carry their unit, so one pattern can hold a whole multi-unit groove.",
   "routing": "A unit routes to at most one timeline track. arrange_pattern routes the pattern's units to its track and rejects conflicting arrangements.",
-  "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
+  "steps": "Step strings: 'x' hit at the row velocity, 'X' accented hit (+0.2), digits '1'-'9' hit at velocity n/9, '-', '.', ' ' rest. Default step is 0.25 beats (16ths). swing (0..0.9) delays every second step by swing * step/2 for shuffle feels.",
   "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
   "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
   "effects": "Effect parameters are normalized 0..1; get_effects shows the human display value after a set. A track chain has 10 slots.",

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -71,6 +71,53 @@ static const std::vector<CommandSchema> s_schemas = {
         {"id", FlagType::Int, true},
         {"start", FlagType::Float, true},
         {"end", FlagType::Float, true}
+    }},
+
+    // === Unit (2) ===
+    // "type" accepts: sampler (default), 808. The schema format cannot
+    // express enums yet; the factory rejects anything else.
+    {"add_unit", CommandCategory::Unit, {
+        {"name", FlagType::String, false},
+        {"type", FlagType::String, false}
+    }},
+    {"load_sample", CommandCategory::Unit, {
+        {"unit", FlagType::Int, true, 1.0},
+        {"file", FlagType::String, true}
+    }},
+
+    // === Pattern (4) ===
+    // Notes are identified by (pattern, unit, pitch, start) — the same key
+    // the piano-roll note commands match on.
+    {"add_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"duration", FlagType::Float, true, 0.001},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"pan", FlagType::Float, false, -1.0, 1.0}
+    }},
+    {"delete_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0}
+    }},
+    {"move_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"to_start", FlagType::Float, true, 0.0},
+        {"to_pitch", FlagType::Int, false, 0.0, 127.0}
+    }},
+    {"set_note", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"unit", FlagType::Int, true, 1.0},
+        {"pitch", FlagType::Int, true, 0.0, 127.0},
+        {"start", FlagType::Float, true, 0.0},
+        {"velocity", FlagType::Float, false, 0.0, 1.0},
+        {"pan", FlagType::Float, false, -1.0, 1.0}
     }}
 };
 
@@ -91,6 +138,8 @@ std::string schemaToJsonString() {
         case CommandCategory::Transport: catStr = "transport"; break;
         case CommandCategory::Track: catStr = "track"; break;
         case CommandCategory::Clip: catStr = "clip"; break;
+        case CommandCategory::Unit: catStr = "unit"; break;
+        case CommandCategory::Pattern: catStr = "pattern"; break;
         }
         out << "    \"category\": \"" << catStr << "\",\n";
         out << "    \"flags\": [\n";

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <fstream>
+#include <sstream>
 
 namespace Aestra {
 namespace Audio {
@@ -77,11 +78,8 @@ const std::vector<CommandSchema>& allCommands() {
     return s_schemas;
 }
 
-void exportSchemaToJson(const std::string& outputPath) {
-    std::ofstream out(outputPath);
-    if (!out.is_open())
-        return;
-
+std::string schemaToJsonString() {
+    std::ostringstream out;
     out << "[\n";
     for (size_t i = 0; i < s_schemas.size(); ++i) {
         const auto& cmd = s_schemas[i];
@@ -127,6 +125,14 @@ void exportSchemaToJson(const std::string& outputPath) {
         out << "\n";
     }
     out << "]\n";
+    return out.str();
+}
+
+void exportSchemaToJson(const std::string& outputPath) {
+    std::ofstream out(outputPath);
+    if (!out.is_open())
+        return;
+    out << schemaToJsonString();
 }
 
 } // namespace MuseGrammar

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -13,65 +13,80 @@ static const std::vector<CommandSchema> s_schemas = {
     // === Transport (3) ===
     {"set_bpm", CommandCategory::Transport, {
         {"value", FlagType::Float, true, 1.0, 999.0}
-    }},
+    },
+     "Set the session tempo in BPM."},
     {"play", CommandCategory::Transport, {
-    }},
+    },
+     "Start transport playback."},
     {"stop", CommandCategory::Transport, {
-    }},
+    },
+     "Stop transport playback."},
 
     // === Track (8) ===
     // NOTE: no "type" flag until the factory consumes one — advertising a
     // flag the registry ignores would make the schema lie to agents.
     {"add_track", CommandCategory::Track, {
         {"name", FlagType::String, false}
-    }},
+    },
+     "Add a mixer track (channel). Tracks are addressed by index in later commands."},
     {"delete_track", CommandCategory::Track, {
         {"track", FlagType::Int, true}
-    }},
+    },
+     "Delete the track at this index. Later indexes shift down; ids stay stable."},
     {"rename_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"name", FlagType::String, true}
-    }},
+    },
+     "Rename the track at this index."},
     {"mute_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"state", FlagType::Bool, true}
-    }},
+    },
+     "Set the mute state of a track."},
     {"solo_track", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"state", FlagType::Bool, true}
-    }},
+    },
+     "Set the solo state of a track."},
     {"set_volume", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"value", FlagType::Float, true, 0.0, 1.0}
-    }},
+    },
+     "Set track volume (0..1 linear)."},
     {"set_pan", CommandCategory::Track, {
         {"track", FlagType::Int, true},
         {"value", FlagType::Float, true, -1.0, 1.0}
-    }},
+    },
+     "Set track pan (-1 left .. 1 right)."},
 
     // === Clip (5) ===
     {"add_clip", CommandCategory::Clip, {
         {"track", FlagType::Int, true},
         {"file", FlagType::String, true},
         {"bar", FlagType::Int, true}
-    }},
+    },
+     "Add a file-based clip on a track at a bar position."},
     {"delete_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true}
-    }},
+    },
+     "Delete a clip by id."},
     {"move_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"track", FlagType::Int, true},
         {"start", FlagType::Float, true}
-    }},
+    },
+     "Move a clip to a track and start beat."},
     {"duplicate_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"bar", FlagType::Int, true}
-    }},
+    },
+     "Duplicate a clip to a bar position."},
     {"trim_clip", CommandCategory::Clip, {
         {"id", FlagType::Int, true},
         {"start", FlagType::Float, true},
         {"end", FlagType::Float, true}
-    }},
+    },
+     "Trim a clip to a start/end beat range."},
 
     // === Unit (2) ===
     // "type" accepts: sampler (default), 808. The schema format cannot
@@ -79,11 +94,13 @@ static const std::vector<CommandSchema> s_schemas = {
     {"add_unit", CommandCategory::Unit, {
         {"name", FlagType::String, false},
         {"type", FlagType::String, false}
-    }},
+    },
+     "Add an Arsenal unit: sampler (polyphonic, default) or 808 (mono with glide). Also creates the unit default MIDI pattern (see list_units.defaultPatternId)."},
     {"load_sample", CommandCategory::Unit, {
         {"unit", FlagType::Int, true, 1.0},
         {"file", FlagType::String, true}
-    }},
+    },
+     "Load an audio file into a unit sampler. MIDI pitch 60 plays it unshifted."},
 
     // === Pattern (4) ===
     // Notes are identified by (pattern, unit, pitch, start) — the same key
@@ -96,13 +113,15 @@ static const std::vector<CommandSchema> s_schemas = {
         {"duration", FlagType::Float, true, 0.001},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"pan", FlagType::Float, false, -1.0, 1.0}
-    }},
+    },
+     "Add one note. Notes carry the unit they play through; one pattern may hold notes from many units."},
     {"delete_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
         {"pitch", FlagType::Int, true, 0.0, 127.0},
         {"start", FlagType::Float, true, 0.0}
-    }},
+    },
+     "Delete the note identified by (pattern, unit, pitch, start)."},
     {"move_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -110,12 +129,14 @@ static const std::vector<CommandSchema> s_schemas = {
         {"start", FlagType::Float, true, 0.0},
         {"to_start", FlagType::Float, true, 0.0},
         {"to_pitch", FlagType::Int, false, 0.0, 127.0}
-    }},
+    },
+     "Move a note to a new start and optionally a new pitch."},
     {"arrange_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"track", FlagType::Int, true, 0.0},
         {"start", FlagType::Float, true, 0.0}
-    }},
+    },
+     "Place a pattern on the timeline as a clip, routing its units to that track. A unit routes to at most one track; conflicts are rejected."},
     // steps: one char per step — 'x' hit, 'X' accented hit, '-' or '.' rest.
     // The string defines the ENTIRE row for that (unit, pitch): re-issuing
     // the verb rewrites the groove, an all-rest string clears it.
@@ -127,18 +148,30 @@ static const std::vector<CommandSchema> s_schemas = {
         {"step", FlagType::Float, false, 0.015625, 4.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"gate", FlagType::Float, false, 0.05, 1.0}
-    }},
+    },
+     "Write one drum row from a step string. The string defines the ENTIRE row for (unit, pitch): re-issuing rewrites it, an all-rest string clears it."},
     {"quantize_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"grid", FlagType::Float, true, 0.015625, 16.0},
         {"strength", FlagType::Float, false, 0.0, 1.0},
         {"unit", FlagType::Int, false, 1.0}
-    }},
+    },
+     "Move note starts toward the grid (in beats). strength 1 = snap; omit unit to affect all units."},
     {"transpose_pattern", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"semitones", FlagType::Int, true, -48.0, 48.0},
         {"unit", FlagType::Int, false, 1.0}
-    }},
+    },
+     "Shift note pitches by semitones. Rejected if any note would leave MIDI range 0..127."},
+    {"clone_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0}
+    },
+     "Duplicate a pattern (notes, name, length). The new pattern id is returned in result.createdId; list_patterns shows it."},
+    {"set_pattern_length", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"beats", FlagType::Float, true, 1.0, 512.0}
+    },
+     "Set the length of a pattern in beats. Playback and arranged clip scheduling use this length."},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -146,7 +179,8 @@ static const std::vector<CommandSchema> s_schemas = {
         {"start", FlagType::Float, true, 0.0},
         {"velocity", FlagType::Float, false, 0.0, 1.0},
         {"pan", FlagType::Float, false, -1.0, 1.0}
-    }}
+    },
+     "Update velocity and/or pan of the note identified by (pattern, unit, pitch, start)."}
 };
 
 const std::vector<CommandSchema>& allCommands() {
@@ -155,11 +189,13 @@ const std::vector<CommandSchema>& allCommands() {
 
 std::string schemaToJsonString() {
     std::ostringstream out;
-    out << "[\n";
+    out << "{\n\"commands\": [\n";
     for (size_t i = 0; i < s_schemas.size(); ++i) {
         const auto& cmd = s_schemas[i];
         out << "  {\n";
         out << "    \"verb\": \"" << cmd.verb << "\",\n";
+        if (!cmd.description.empty())
+            out << "    \"description\": \"" << cmd.description << "\",\n";
 
         const char* catStr = "unknown";
         switch (cmd.category) {
@@ -201,7 +237,36 @@ std::string schemaToJsonString() {
             out << ",";
         out << "\n";
     }
-    out << "]\n";
+    out << "],\n";
+
+    // Queries and actions are implemented by MuseService; keep this list in
+    // sync with its isQueryVerb()/isActionVerb().
+    out << R"("queries": [
+  {"verb": "get_transport", "args": "none", "description": "bpm, playing, positionSeconds."},
+  {"verb": "list_tracks", "args": "none", "description": "index, stable id, name, volume, pan, muted, soloed per track."},
+  {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, timelineLane (-1 = preview), samplePath per unit."},
+  {"verb": "list_clips", "args": "none", "description": "playlist lanes with clips (id, name, startBeat, durationBeats, pattern; pattern 0 = not a pattern clip)."},
+  {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
+  {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
+  {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
+],
+"actions": [
+  {"verb": "render_pattern", "args": "{\"pattern\": <id>, \"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce one pattern (Arsenal preview routing) to a float32 WAV. Result carries durationSeconds, frames, sampleRate, peakDb."},
+  {"verb": "render_song", "args": "{\"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce the arranged timeline to a float32 WAV. Errors on an empty timeline. Result carries durationSeconds, frames, sampleRate, peakDb."},
+  {"verb": "batch", "args": "{\"commands\": [{\"verb\": ..., \"args\": ...}, ...]}", "description": "Run 1..64 mutation verbs all-or-nothing as a single undo step. Members execute against the state their predecessors produced."}
+],
+"notes": {
+  "samplerPitch": "The sampler root is MIDI pitch 60: notes at 60 play the loaded sample unshifted, other pitches resample relative to 60. Put drum hits at pitch 60; write melodies around 60.",
+  "unitTypes": "sampler = polyphonic sampler; 808 = mono pitched sampler with glide.",
+  "patterns": "Every non-audio unit gets a default MIDI pattern at creation (list_units.defaultPatternId). A pattern is just a container: notes carry their unit, so one pattern can hold a whole multi-unit groove.",
+  "routing": "A unit routes to at most one timeline track. arrange_pattern routes the pattern's units to its track and rejects conflicting arrangements.",
+  "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
+  "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
+  "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
+  "undo": "Every mutation and every batch is one step in the same undo history the UI uses."
+}
+}
+)";
     return out.str();
 }
 

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -172,6 +172,32 @@ static const std::vector<CommandSchema> s_schemas = {
         {"beats", FlagType::Float, true, 1.0, 512.0}
     },
      "Set the length of a pattern in beats. Playback and arranged clip scheduling use this length."},
+
+    // === Effects (4) ===
+    {"add_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"effect", FlagType::String, true},
+        {"slot", FlagType::Int, false, 0.0, 9.0}
+    },
+     "Insert an effect on a track (first empty slot unless given). effect = id or name from list_plugins. result.createdId carries the slot."},
+    {"remove_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0}
+    },
+     "Remove the effect in a slot of a track's chain."},
+    {"bypass_effect", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0},
+        {"state", FlagType::Bool, true}
+    },
+     "Bypass (true) or re-enable (false) an effect slot."},
+    {"set_effect_param", CommandCategory::Track, {
+        {"track", FlagType::Int, true, 0.0},
+        {"slot", FlagType::Int, true, 0.0, 9.0},
+        {"param", FlagType::String, true},
+        {"value", FlagType::Float, true, 0.0, 1.0}
+    },
+     "Set an effect parameter, normalized 0..1. param = name (case-insensitive) or numeric id from get_effects; get_effects shows the resulting display value."},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},
@@ -247,6 +273,8 @@ std::string schemaToJsonString() {
   {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, timelineLane (-1 = preview), samplePath per unit."},
   {"verb": "list_clips", "args": "none", "description": "playlist lanes with clips (id, name, startBeat, durationBeats, pattern; pattern 0 = not a pattern clip)."},
   {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
+  {"verb": "list_plugins", "args": "none", "description": "available effect plugins: id, name, category. Use id or name with add_effect."},
+  {"verb": "get_effects", "args": "{\"track\": <index>}", "description": "a track's effect chain: slot, id, name, bypassed, and every parameter (id, name, value 0..1, display, unit)."},
   {"verb": "get_pattern", "args": "{\"pattern\": <id>}", "description": "one pattern with its notes (pitch, start, duration, velocity, pan, unit)."},
   {"verb": "get_session_state", "args": "none", "description": "transport + tracks + laneCount + unitCount + canUndo in one call."}
 ],
@@ -263,6 +291,7 @@ std::string schemaToJsonString() {
   "steps": "Step strings: 'x' hit, 'X' accented hit (+0.2 velocity), '-', '.', ' ' rest. Default step is 0.25 beats (16ths).",
   "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
   "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",
+  "effects": "Effect parameters are normalized 0..1; get_effects shows the human display value after a set. A track chain has 10 slots.",
   "undo": "Every mutation and every batch is one step in the same undo history the UI uses."
 }
 }

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -111,6 +111,11 @@ static const std::vector<CommandSchema> s_schemas = {
         {"to_start", FlagType::Float, true, 0.0},
         {"to_pitch", FlagType::Int, false, 0.0, 127.0}
     }},
+    {"arrange_pattern", CommandCategory::Pattern, {
+        {"pattern", FlagType::Int, true, 1.0},
+        {"track", FlagType::Int, true, 0.0},
+        {"start", FlagType::Float, true, 0.0}
+    }},
     {"set_note", CommandCategory::Pattern, {
         {"pattern", FlagType::Int, true, 1.0},
         {"unit", FlagType::Int, true, 1.0},

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -3,6 +3,7 @@
 
 #include "Commands/CommandParser.h"
 #include "Commands/CommandResult.h"
+#include "Commands/CommandTransaction.h"
 #include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
@@ -112,10 +113,34 @@ bool isQueryVerb(const std::string& verb) {
 }
 
 // Service actions: handled here like queries, but they do work (render a
-// file) rather than read state. Not routed through CommandHistory — a bounce
-// is not an undoable project edit.
+// file, run a batch) rather than read state. render_pattern is not routed
+// through CommandHistory — a bounce is not an undoable project edit; batch
+// pushes one CommandTransaction so the whole group is a single undo step.
 bool isActionVerb(const std::string& verb) {
-    return verb == "render_pattern";
+    return verb == "render_pattern" || verb == "batch";
+}
+
+// JSON args -> flag map for the schema/registry path. Returns false with
+// outError set when a value has a type the flag grammar cannot carry.
+bool jsonArgsToFlags(JSON& args, std::unordered_map<std::string, std::string>& outFlags,
+                     std::string& outError) {
+    // Non-const asObject() returns a copy of the map (the const overload
+    // returns an empty static — a known footgun).
+    for (auto& entry : args.asObject()) {
+        const std::string& key = entry.first;
+        JSON& value = entry.second;
+        if (value.isString()) {
+            outFlags[key] = value.asString();
+        } else if (value.isNumber()) {
+            outFlags[key] = numberToFlagString(value.asNumber());
+        } else if (value.isBool()) {
+            outFlags[key] = value.asBool() ? "true" : "false";
+        } else {
+            outError = "arg '" + key + "' must be a string, number, or bool";
+            return false;
+        }
+    }
+    return true;
 }
 
 // JSON numbers are doubles; an id must be a non-negative integer that a
@@ -441,6 +466,141 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return finish(response);
         }
 
+        if (verb == "batch") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "batch requires args: {\"commands\": [{\"verb\": ..., \"args\": "
+                                 "...}, ...]}",
+                                 verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "commands") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for batch: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("commands") || !args["commands"].isArray()) {
+                return makeError(id, "validation_error", "arg 'commands' must be an array", verb)
+                    .toString();
+            }
+            JSON& commands = args["commands"];
+            const size_t count = commands.size();
+            constexpr size_t kMaxBatchCommands = 64;
+            if (count == 0) {
+                return makeError(id, "validation_error", "batch must contain at least one command",
+                                 verb)
+                    .toString();
+            }
+            if (count > kMaxBatchCommands) {
+                return makeError(id, "validation_error",
+                                 "batch too large: " + std::to_string(count) + " commands (max " +
+                                     std::to_string(kMaxBatchCommands) + ")",
+                                 verb)
+                    .toString();
+            }
+
+            // All-or-nothing, stepwise: each member is validated, built, and
+            // executed against the state its predecessors produced — so a
+            // batch can set the pan of a track it just added. On any failure
+            // the executed prefix is undone in reverse and nothing is
+            // recorded. On success the whole group lands in history as one
+            // already-executed CommandTransaction: a single undo step.
+            CommandParser parser;
+            auto transaction = std::make_shared<CommandTransaction>("Muse Batch");
+            std::vector<std::shared_ptr<ICommand>> executed;
+            executed.reserve(count);
+            // Unwind the executed prefix in reverse and produce the final
+            // error response. A rollback failure must not hide behind the
+            // member error: the response then reports execution_error and
+            // says the session may be inconsistent.
+            const auto failBatch = [&](const char* errorStatus,
+                                       const std::string& message) -> std::string {
+                bool rollbackClean = true;
+                for (auto it = executed.rbegin(); it != executed.rend(); ++it) {
+                    try {
+                        (*it)->undo();
+                    } catch (...) {
+                        // Keep unwinding the rest of the prefix, but remember.
+                        rollbackClean = false;
+                    }
+                }
+                if (!rollbackClean) {
+                    return makeError(id, "execution_error",
+                                     message +
+                                         " (rollback also failed; session state may be "
+                                         "inconsistent)",
+                                     verb)
+                        .toString();
+                }
+                return makeError(id, errorStatus, message, verb).toString();
+            };
+
+            for (size_t i = 0; i < count; ++i) {
+                const std::string prefix = "commands[" + std::to_string(i) + "]: ";
+                JSON& item = commands[i];
+                if (!item.isObject() || !item.has("verb") || !item["verb"].isString()) {
+                    return failBatch("validation_error",
+                                     prefix + "must be an object with a string verb");
+                }
+                const std::string subVerb = item["verb"].asString();
+                if (isQueryVerb(subVerb) || isActionVerb(subVerb)) {
+                    return failBatch("validation_error",
+                                     prefix + "only mutation verbs are allowed in a batch");
+                }
+
+                std::unordered_map<std::string, std::string> flags;
+                if (item.has("args")) {
+                    if (!item["args"].isObject()) {
+                        return failBatch("validation_error", prefix + "args must be an object");
+                    }
+                    std::string convertError;
+                    if (!jsonArgsToFlags(item["args"], flags, convertError)) {
+                        return failBatch("validation_error", prefix + convertError);
+                    }
+                }
+
+                CommandStatus buildStatus = CommandStatus::Success;
+                std::string buildMessage;
+                auto built = parser.buildValidated(subVerb, flags, buildStatus, buildMessage);
+                if (!built) {
+                    return failBatch(statusName(buildStatus), prefix + buildMessage);
+                }
+
+                std::shared_ptr<ICommand> cmd(std::move(built));
+                try {
+                    cmd->execute();
+                } catch (const std::exception& e) {
+                    return failBatch("execution_error", prefix + e.what());
+                } catch (...) {
+                    return failBatch("execution_error", prefix + "command threw");
+                }
+                executed.push_back(cmd);
+                transaction->add(cmd);
+            }
+
+            transaction->markExecuted();
+            if (!m_trackManager->getCommandHistory().pushExecuted(transaction)) {
+                // Executed but not recorded (e.g. a deferred transaction is
+                // active on this history). "ok, undoable" would be a lie —
+                // keep all-or-nothing honest by rolling the batch back.
+                return failBatch("execution_error",
+                                 "batch could not be recorded in history; rolled back");
+            }
+
+            JSON result = JSON::object();
+            result.set("count", JSON(static_cast<double>(count)));
+            JSON response = makeOk();
+            response.set("result", result);
+            response.set("undoable", JSON(true));
+            return finish(response);
+        }
+
         if (verb == "render_pattern") {
             if (!m_trackManager || !m_engine) {
                 return makeError(id, "execution_error",
@@ -624,22 +784,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             if (!args.isObject()) {
                 return makeError(id, "parse_error", "args must be an object", verb).toString();
             }
-            // Non-const asObject() returns a copy of the map (the const
-            // overload returns an empty static — a known footgun).
-            for (auto& entry : args.asObject()) {
-                const std::string& key = entry.first;
-                JSON& value = entry.second;
-                if (value.isString()) {
-                    flags[key] = value.asString();
-                } else if (value.isNumber()) {
-                    flags[key] = numberToFlagString(value.asNumber());
-                } else if (value.isBool()) {
-                    flags[key] = value.asBool() ? "true" : "false";
-                } else {
-                    return makeError(id, "parse_error",
-                                     "arg '" + key + "' must be a string, number, or bool", verb)
-                        .toString();
-                }
+            std::string convertError;
+            if (!jsonArgsToFlags(args, flags, convertError)) {
+                return makeError(id, "parse_error", convertError, verb).toString();
             }
         }
 

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -7,6 +7,8 @@
 #include "Core/AudioEngine.h"
 #include "Core/PlaybackGraphController.h"
 #include "IO/AudioExporter.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginManager.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -112,7 +114,12 @@ namespace {
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
-           verb == "list_patterns";
+           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects";
+}
+
+// The few queries that take arguments; every other query rejects them.
+bool queryTakesArgs(const std::string& verb) {
+    return verb == "get_pattern" || verb == "get_effects";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -249,9 +256,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return makeError(id, "parse_error", "unknown command: " + verb).toString();
         }
 
-        // Queries take no arguments — except get_pattern, which takes exactly
-        // one. Accepting anything else would silently drop caller intent.
-        if (isQueryVerb(verb) && verb != "get_pattern" && request.has("args") &&
+        // Most queries take no arguments; accepting any would silently drop
+        // caller intent.
+        if (isQueryVerb(verb) && !queryTakesArgs(verb) && request.has("args") &&
             request["args"].size() > 0) {
             return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
         }
@@ -408,6 +415,94 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_plugins") {
+            JSON plugins = JSON::array();
+            for (const auto& info : PluginManager::getInstance().getEffectPlugins()) {
+                JSON entry = JSON::object();
+                entry.set("id", JSON(info.id));
+                entry.set("name", JSON(info.name));
+                entry.set("category", JSON(info.category));
+                plugins.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("effects", plugins);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "get_effects") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "get_effects requires args: {\"track\": <index>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "track") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for get_effects: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            uint64_t trackIndex = 0;
+            if (!args.has("track") || !args["track"].isNumber() ||
+                !numberToId(args["track"].asNumber(), trackIndex)) {
+                return makeError(id, "validation_error",
+                                 "arg 'track' must be a non-negative integer", verb)
+                    .toString();
+            }
+            MixerChannel* channel = m_trackManager->getChannel(static_cast<size_t>(trackIndex));
+            if (!channel) {
+                return makeError(id, "execution_error",
+                                 "no such track: " + std::to_string(trackIndex), verb)
+                    .toString();
+            }
+
+            auto& chain = channel->getEffectChain();
+            JSON slots = JSON::array();
+            for (size_t slot = 0; slot < EffectChain::MAX_SLOTS; ++slot) {
+                auto plugin = chain.getPlugin(slot);
+                if (!plugin) continue;
+                JSON entry = JSON::object();
+                entry.set("slot", JSON(static_cast<double>(slot)));
+                entry.set("id", JSON(plugin->getInfo().id));
+                entry.set("name", JSON(plugin->getInfo().name));
+                entry.set("bypassed", JSON(chain.isSlotBypassed(slot)));
+                JSON params = JSON::array();
+                for (const auto& param : plugin->getParameters()) {
+                    JSON paramJson = JSON::object();
+                    paramJson.set("id", JSON(static_cast<double>(param.id)));
+                    paramJson.set("name", JSON(param.name));
+                    // Plugin output is untrusted: a NaN/Inf value would break
+                    // the JSON contract — fail loudly instead.
+                    const float value = plugin->getParameter(param.id);
+                    if (!std::isfinite(value)) {
+                        return makeError(id, "execution_error",
+                                         "plugin " + plugin->getInfo().name +
+                                             " returned a non-finite value for parameter '" +
+                                             param.name + "'",
+                                         verb)
+                            .toString();
+                    }
+                    paramJson.set("value", JSON(static_cast<double>(value)));
+                    paramJson.set("display", JSON(plugin->getParameterDisplay(param.id)));
+                    if (!param.unit.empty()) paramJson.set("unit", JSON(param.unit));
+                    params.push(paramJson);
+                }
+                entry.set("params", params);
+                slots.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("effects", slots);
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);
@@ -946,7 +1041,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         response.set("verb", JSON(verb));
         response.set("message", JSON(cmdResult.message));
         response.set("undoable", JSON(cmdResult.undoable));
-        if (cmdResult.createdId != 0) {
+        if (cmdResult.hasCreatedId) {
             // Structured id of the object the command created (e.g. the new
             // pattern from clone_pattern) — agents must not parse the message.
             JSON result = JSON::object();

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -111,7 +111,8 @@ namespace {
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
-           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
+           verb == "list_patterns";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -407,6 +408,32 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_patterns") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            JSON patterns = JSON::array();
+            for (const auto& pattern : m_trackManager->getPatternManager().getAllPatterns()) {
+                if (!pattern) continue;
+                JSON entry = JSON::object();
+                entry.set("id", JSON(static_cast<double>(pattern->id.value)));
+                entry.set("name", JSON(pattern->name));
+                entry.set("lengthBeats", JSON(pattern->lengthBeats));
+                const bool isMidi = pattern->isMidi();
+                entry.set("type", JSON(isMidi ? "midi" : "other"));
+                entry.set("noteCount",
+                          JSON(isMidi ? static_cast<double>(
+                                            std::get<MidiPayload>(pattern->payload).notes.size())
+                                      : 0.0));
+                patterns.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("patterns", patterns);
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);
@@ -919,6 +946,13 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         response.set("verb", JSON(verb));
         response.set("message", JSON(cmdResult.message));
         response.set("undoable", JSON(cmdResult.undoable));
+        if (cmdResult.createdId != 0) {
+            // Structured id of the object the command created (e.g. the new
+            // pattern from clone_pattern) — agents must not parse the message.
+            JSON result = JSON::object();
+            result.set("createdId", JSON(static_cast<double>(cmdResult.createdId)));
+            response.set("result", result);
+        }
         response.set("executionMs", JSON(cmdResult.executionMs));
         return response.toString();
     } catch (const std::exception& e) {

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -5,6 +5,8 @@
 #include "Commands/CommandResult.h"
 #include "Commands/CommandTransaction.h"
 #include "Core/AudioEngine.h"
+#include "Core/PlaybackGraphController.h"
+#include "IO/AudioExporter.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -117,7 +119,7 @@ bool isQueryVerb(const std::string& verb) {
 // through CommandHistory — a bounce is not an undoable project edit; batch
 // pushes one CommandTransaction so the whole group is a single undo step.
 bool isActionVerb(const std::string& verb) {
-    return verb == "render_pattern" || verb == "batch";
+    return verb == "render_pattern" || verb == "render_song" || verb == "batch";
 }
 
 // JSON args -> flag map for the schema/registry path. Returns false with
@@ -329,6 +331,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     c.set("name", JSON(clip.name));
                     c.set("startBeat", JSON(clip.startBeat));
                     c.set("durationBeats", JSON(clip.durationBeats));
+                    // 0 = not a pattern clip
+                    c.set("pattern", JSON(static_cast<double>(clip.patternId.value)));
                     clips.push(c);
                 }
                 laneJson.set("clips", clips);
@@ -394,6 +398,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 u.set("soloed", JSON(unit->isSolo));
                 u.set("defaultPatternId",
                       JSON(static_cast<double>(unit->defaultPatternId.value)));
+                // -1 = preview-to-master; >= 0 routes into that timeline track.
+                u.set("timelineLane",
+                      JSON(static_cast<double>(unitManager.getUnitTimelineLane(unitId))));
                 u.set("samplePath", JSON(unit->audioClipPath));
                 u.set("sampleDurationSeconds", JSON(unit->audioDurationSeconds));
                 units.push(u);
@@ -601,6 +608,114 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return finish(response);
         }
 
+        if (verb == "render_song") {
+            if (!m_trackManager || !m_engine) {
+                return makeError(id, "execution_error",
+                                 "render_song needs a track manager and an audio engine", verb)
+                    .toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "render_song requires args: {\"file\": <path>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "file" && entry.first != "tail") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for render_song: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("file") || !args["file"].isString() || args["file"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'file' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+            double tailSeconds = 1.0;
+            if (args.has("tail")) {
+                if (!args["tail"].isNumber()) {
+                    return makeError(id, "validation_error", "arg 'tail' must be a number", verb)
+                        .toString();
+                }
+                tailSeconds = args["tail"].asNumber();
+                if (!(tailSeconds >= 0.0 && tailSeconds <= 30.0)) {
+                    return makeError(id, "validation_error", "arg 'tail' must be 0..30 seconds",
+                                     verb)
+                        .toString();
+                }
+            }
+
+            // Channels may have been added since the engine was wired; the
+            // exporter render path resolves tracks through the slot map.
+            m_trackManager->buildAndShareSlotMap();
+            if (auto slotMap = m_trackManager->getChannelSlotMapShared()) {
+                m_engine->setChannelSlotMap(slotMap);
+            }
+
+            // The timeline render path routes tracks to master through the
+            // published audio graph; in the app AestraApp::run() drains
+            // rebuilds continuously, headless we drain here.
+            PlaybackGraphController graphController;
+            graphController.setTrackManager(m_trackManager);
+            graphController.setAudioEngine(m_engine);
+            graphController.requestRebuild(GraphDirtyReason::TimelineChanged);
+            graphController.drainIfDirty(static_cast<double>(m_engine->getSampleRate()));
+
+            AudioExporter::Result exportResult;
+            {
+                // TrackManager::play() is what schedules timeline MIDI clip
+                // instances into the pattern engine — the exporter only
+                // drives the engine transport. Guarantee stop + pattern-mode
+                // restore on every exit.
+                struct TimelineGuard {
+                    TrackManager& trackManager;
+                    AudioEngine& engine;
+                    ~TimelineGuard() {
+                        trackManager.stop();
+                        std::vector<float> settle(1024, 0.0f);
+                        for (int i = 0; i < 2; ++i) {
+                            engine.processBlock(settle.data(), nullptr, 512, 0.0);
+                            engine.performNonRealtimeMaintenance();
+                        }
+                    }
+                } guard{*m_trackManager, *m_engine};
+
+                // Leave any Arsenal pattern-mode state behind: TrackManager's
+                // play() only schedules timeline MIDI clip instances when its
+                // own pattern-mode flag is clear.
+                m_trackManager->stopArsenalPlayback(false);
+                m_engine->setPatternPlaybackMode(false, 4.0);
+                m_trackManager->setPosition(0.0);
+                m_trackManager->play();
+
+                AudioExporter exporter(*m_engine, *m_trackManager);
+                AudioExporter::Config config;
+                config.outputPath = args["file"].asString();
+                config.scope = AudioExporter::RenderScope::FullSong;
+                config.sampleRate = m_engine->getSampleRate();
+                config.bitDepth = AudioExporter::BitDepth::Float_32;
+                config.numChannels = 2;
+                config.tailSeconds = tailSeconds;
+                exportResult = exporter.render(config);
+            }
+
+            if (!exportResult.success) {
+                return makeError(id, "execution_error", exportResult.errorMessage, verb)
+                    .toString();
+            }
+
+            JSON result = JSON::object();
+            result.set("file", JSON(exportResult.outputPath));
+            result.set("durationSeconds", JSON(exportResult.durationSeconds));
+            result.set("frames", JSON(static_cast<double>(exportResult.framesRendered)));
+            result.set("sampleRate", JSON(static_cast<double>(m_engine->getSampleRate())));
+            result.set("peakDb", JSON(exportResult.peakDb));
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
         if (verb == "render_pattern") {
             if (!m_trackManager || !m_engine) {
                 return makeError(id, "execution_error",
@@ -698,7 +813,11 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     TrackManager& trackManager;
                     std::vector<float>& block;
                     ~TransportGuard() {
-                        trackManager.stop();
+                        // Full Arsenal teardown: stop, flush the scheduled
+                        // instance, and leave pattern mode — a lingering
+                        // pattern-mode flag or instance would bleed into the
+                        // next timeline play/render.
+                        trackManager.stopArsenalPlayback(false);
                         for (int i = 0; i < 2; ++i) {
                             std::memset(block.data(), 0, block.size() * sizeof(float));
                             engine.processBlock(block.data(), nullptr, kBlockFrames, 0.0);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -7,8 +7,11 @@
 #include "Core/AudioEngine.h"
 #include "Core/PlaybackGraphController.h"
 #include "IO/AudioExporter.h"
+#include "IO/AudioFileValidator.h"
 #include "Plugin/EffectChain.h"
 #include "Plugin/PluginManager.h"
+
+#include <filesystem>
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 
@@ -114,12 +117,13 @@ namespace {
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
-           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects";
+           verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects" ||
+           verb == "list_samples";
 }
 
 // The few queries that take arguments; every other query rejects them.
 bool queryTakesArgs(const std::string& verb) {
-    return verb == "get_pattern" || verb == "get_effects";
+    return verb == "get_pattern" || verb == "get_effects" || verb == "list_samples";
 }
 
 // Service actions: handled here like queries, but they do work (render a
@@ -415,6 +419,116 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_samples") {
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "list_samples requires args: {\"dir\": <path>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "dir") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for list_samples: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("dir") || !args["dir"].isString() || args["dir"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'dir' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+
+            const std::filesystem::path root(args["dir"].asString());
+            std::error_code ec;
+            if (!std::filesystem::is_directory(root, ec)) {
+                return makeError(id, "execution_error",
+                                 "not a directory: " + args["dir"].asString(), verb)
+                    .toString();
+            }
+
+            constexpr size_t kMaxEntries = 500;
+            constexpr int kMaxDepth = 3;   // subdirectory nesting below root
+            constexpr size_t kScanBudget = 20000; // entries examined, audio or not
+            bool truncated = false;
+            std::vector<std::filesystem::path> found;
+            size_t scanned = 0;
+
+            // Deterministic bounded traversal: depth-first with per-directory
+            // sorted entries, so a truncated listing is always the same
+            // stable prefix across calls and platforms. Directory read
+            // failures are errors, not silently partial results.
+            std::vector<std::pair<std::filesystem::path, int>> pending;
+            pending.emplace_back(root, 0);
+            while (!pending.empty() && !truncated) {
+                const auto [dir, depth] = pending.back();
+                pending.pop_back();
+
+                std::vector<std::filesystem::directory_entry> entries;
+                std::error_code dirEc;
+                std::filesystem::directory_iterator dirIt(
+                    dir, std::filesystem::directory_options::skip_permission_denied, dirEc);
+                const std::filesystem::directory_iterator dirEnd;
+                for (; !dirEc && dirIt != dirEnd; dirIt.increment(dirEc)) {
+                    entries.push_back(*dirIt);
+                }
+                if (dirEc) {
+                    return makeError(id, "execution_error",
+                                     "error reading directory " + dir.string() + ": " +
+                                         dirEc.message(),
+                                     verb)
+                        .toString();
+                }
+                std::sort(entries.begin(), entries.end(),
+                          [](const auto& a, const auto& b) { return a.path() < b.path(); });
+
+                std::vector<std::filesystem::path> subdirs;
+                for (const auto& entry : entries) {
+                    if (++scanned > kScanBudget) {
+                        truncated = true;
+                        break;
+                    }
+                    std::error_code typeEc;
+                    if (entry.is_directory(typeEc)) {
+                        if (depth < kMaxDepth) subdirs.push_back(entry.path());
+                        continue;
+                    }
+                    if (typeEc) continue;
+                    std::error_code fileEc;
+                    if (!entry.is_regular_file(fileEc) || fileEc) continue;
+                    if (!AudioFileValidator::isValidAudioFile(entry.path().string())) continue;
+                    if (found.size() >= kMaxEntries) {
+                        truncated = true;
+                        break;
+                    }
+                    found.push_back(entry.path());
+                }
+                // Reverse push so the stack pops subdirectories in sorted order.
+                for (auto it = subdirs.rbegin(); it != subdirs.rend(); ++it) {
+                    pending.emplace_back(*it, depth + 1);
+                }
+            }
+            std::sort(found.begin(), found.end());
+
+            JSON samples = JSON::array();
+            for (const auto& path : found) {
+                JSON entry = JSON::object();
+                entry.set("path", JSON(path.string()));
+                entry.set("name", JSON(path.filename().string()));
+                std::error_code sizeEc;
+                const auto size = std::filesystem::file_size(path, sizeEc);
+                // Absent field = size unknown; never a fake zero.
+                if (!sizeEc) entry.set("sizeBytes", JSON(static_cast<double>(size)));
+                samples.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("samples", samples);
+            result.set("truncated", JSON(truncated));
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -1,0 +1,311 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/MuseService.h"
+
+#include "Commands/CommandParser.h"
+#include "Commands/CommandResult.h"
+#include "Core/AudioEngine.h"
+#include "Models/TrackManager.h"
+
+#include "AestraJSON.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <exception>
+#include <unordered_map>
+
+namespace Aestra {
+namespace Audio {
+
+namespace {
+
+const char* statusName(CommandStatus status) {
+    switch (status) {
+    case CommandStatus::Success: return "ok";
+    case CommandStatus::ParseError: return "parse_error";
+    case CommandStatus::ValidationError: return "validation_error";
+    case CommandStatus::ExecutionError: return "execution_error";
+    }
+    return "execution_error";
+}
+
+// Render a JSON number the way the flag validators expect to re-parse it:
+// integral values without a fractional tail ("142", not "142.000000").
+std::string numberToFlagString(double value) {
+    if (std::isfinite(value) && value == std::floor(value) &&
+        std::abs(value) < 9.007199254740992e15) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.0f", value);
+        return buf;
+    }
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.9g", value);
+    return buf;
+}
+
+JSON makeError(double id, const char* status, const std::string& message,
+               const std::string& verb = "") {
+    JSON response = JSON::object();
+    response.set("id", JSON(id));
+    response.set("status", JSON(status));
+    if (!verb.empty()) response.set("verb", JSON(verb));
+    response.set("message", JSON(message));
+    return response;
+}
+
+JSON trackToJson(const MixerChannel& channel, size_t index) {
+    JSON t = JSON::object();
+    t.set("index", JSON(static_cast<double>(index)));
+    t.set("id", JSON(static_cast<double>(channel.getChannelId())));
+    t.set("name", JSON(channel.getName()));
+    t.set("volume", JSON(static_cast<double>(channel.getVolume())));
+    t.set("pan", JSON(static_cast<double>(channel.getPan())));
+    t.set("muted", JSON(channel.isMuted()));
+    t.set("soloed", JSON(channel.isSoloed()));
+    return t;
+}
+
+} // namespace
+
+MuseService::MuseService(TrackManager* trackManager, AudioEngine* engine)
+    : m_trackManager(trackManager), m_engine(engine) {}
+
+namespace {
+
+// Query verbs MuseService answers directly (mutations live in MuseGrammar).
+bool isQueryVerb(const std::string& verb) {
+    return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
+           verb == "get_session_state";
+}
+
+bool isKnownVerb(const std::string& verb) {
+    if (isQueryVerb(verb)) return true;
+    for (const auto& cmd : MuseGrammar::allCommands()) {
+        if (cmd.verb == verb) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+std::string MuseService::handleRequest(const std::string& requestJson) {
+    double id = 0.0;
+    std::string verb;
+
+    // Parsing gets its own try so only malformed JSON reports parse_error;
+    // runtime failures later map to execution_error.
+    JSON request;
+    try {
+        request = JSON::parse(requestJson);
+    } catch (const std::exception& e) {
+        return makeError(id, "parse_error", std::string("invalid request: ") + e.what()).toString();
+    } catch (...) {
+        return makeError(id, "parse_error", "invalid request").toString();
+    }
+
+    try {
+        if (!request.isObject()) {
+            return makeError(id, "parse_error", "request must be a JSON object").toString();
+        }
+
+        if (request.has("id")) {
+            if (!request["id"].isNumber()) {
+                // A wrong-typed id would silently echo 0 and mis-correlate
+                // responses; reject instead.
+                return makeError(id, "parse_error", "id must be a number").toString();
+            }
+            id = request["id"].asNumber();
+        }
+        if (!request.has("verb") || !request["verb"].isString()) {
+            return makeError(id, "parse_error", "missing string field: verb").toString();
+        }
+        verb = request["verb"].asString();
+
+        // Classify the verb before any dependency checks so protocol status
+        // never depends on how the service happens to be wired.
+        if (!isKnownVerb(verb)) {
+            return makeError(id, "parse_error", "unknown command: " + verb).toString();
+        }
+
+        // Queries take no arguments; accepting them would silently drop
+        // caller intent.
+        if (isQueryVerb(verb) && request.has("args") && request["args"].size() > 0) {
+            return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
+        }
+
+        // ------------------------------------------------------------------
+        // Query verbs: read-only, no history, stable IDs.
+        // ------------------------------------------------------------------
+        const auto startTime = std::chrono::steady_clock::now();
+        const auto finish = [&](JSON& response) {
+            const auto endTime = std::chrono::steady_clock::now();
+            response.set("executionMs",
+                         JSON(std::chrono::duration<double, std::milli>(endTime - startTime).count()));
+            return response.toString();
+        };
+        const auto makeOk = [&]() {
+            JSON response = JSON::object();
+            response.set("id", JSON(id));
+            response.set("status", JSON("ok"));
+            response.set("verb", JSON(verb));
+            return response;
+        };
+
+        if (verb == "get_transport") {
+            JSON result = JSON::object();
+            if (m_engine) {
+                result.set("bpm", JSON(static_cast<double>(m_engine->getBPM())));
+                result.set("playing", JSON(m_engine->isTransportPlaying()));
+                result.set("positionSeconds", JSON(m_engine->getPositionSeconds()));
+            } else if (m_trackManager) {
+                result.set("bpm", JSON(m_trackManager->getTimelineClock().getCurrentTempo()));
+                result.set("playing", JSON(m_trackManager->isPlaying()));
+                result.set("positionSeconds", JSON(m_trackManager->getPosition()));
+            } else {
+                return makeError(id, "execution_error", "no engine or track manager", verb).toString();
+            }
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_tracks") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            JSON tracks = JSON::array();
+            const size_t count = m_trackManager->getChannelCount();
+            for (size_t i = 0; i < count; ++i) {
+                if (const MixerChannel* ch = m_trackManager->getChannel(i)) {
+                    tracks.push(trackToJson(*ch, i));
+                }
+            }
+            JSON result = JSON::object();
+            result.set("tracks", tracks);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_clips") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            auto& playlist = m_trackManager->getPlaylistModel();
+            JSON lanes = JSON::array();
+            const size_t laneCount = playlist.getLaneCount();
+            for (size_t i = 0; i < laneCount; ++i) {
+                PlaylistLaneID laneId = playlist.getLaneId(i);
+                PlaylistLane* lane = playlist.getLane(laneId);
+                if (!lane) continue;
+                JSON laneJson = JSON::object();
+                laneJson.set("index", JSON(static_cast<double>(i)));
+                laneJson.set("id", JSON(laneId.toString())); // full UUID — lossless
+                laneJson.set("name", JSON(lane->name));
+                JSON clips = JSON::array();
+                for (const auto& clip : lane->clips) {
+                    JSON c = JSON::object();
+                    c.set("id", JSON(clip.id.toString())); // full UUID — lossless
+                    c.set("name", JSON(clip.name));
+                    c.set("startBeat", JSON(clip.startBeat));
+                    c.set("durationBeats", JSON(clip.durationBeats));
+                    clips.push(c);
+                }
+                laneJson.set("clips", clips);
+                lanes.push(laneJson);
+            }
+            JSON result = JSON::object();
+            result.set("lanes", lanes);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "get_session_state") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            JSON result = JSON::object();
+
+            JSON transport = JSON::object();
+            if (m_engine) {
+                transport.set("bpm", JSON(static_cast<double>(m_engine->getBPM())));
+                transport.set("playing", JSON(m_engine->isTransportPlaying()));
+            } else {
+                transport.set("bpm", JSON(m_trackManager->getTimelineClock().getCurrentTempo()));
+                transport.set("playing", JSON(m_trackManager->isPlaying()));
+            }
+            result.set("transport", transport);
+
+            JSON tracks = JSON::array();
+            const size_t count = m_trackManager->getChannelCount();
+            for (size_t i = 0; i < count; ++i) {
+                if (const MixerChannel* ch = m_trackManager->getChannel(i)) {
+                    tracks.push(trackToJson(*ch, i));
+                }
+            }
+            result.set("tracks", tracks);
+            result.set("laneCount",
+                       JSON(static_cast<double>(m_trackManager->getPlaylistModel().getLaneCount())));
+            result.set("canUndo", JSON(m_trackManager->getCommandHistory().canUndo()));
+
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        // ------------------------------------------------------------------
+        // Mutation verbs: JSON args -> flag map -> the same schema
+        // validation, registry factories, and CommandHistory the text
+        // parser uses.
+        // ------------------------------------------------------------------
+        if (!m_trackManager) {
+            return makeError(id, "execution_error", "no track manager", verb).toString();
+        }
+
+        std::unordered_map<std::string, std::string> flags;
+        if (request.has("args")) {
+            JSON& args = request["args"];
+            if (!args.isObject()) {
+                return makeError(id, "parse_error", "args must be an object", verb).toString();
+            }
+            // Non-const asObject() returns a copy of the map (the const
+            // overload returns an empty static — a known footgun).
+            for (auto& entry : args.asObject()) {
+                const std::string& key = entry.first;
+                JSON& value = entry.second;
+                if (value.isString()) {
+                    flags[key] = value.asString();
+                } else if (value.isNumber()) {
+                    flags[key] = numberToFlagString(value.asNumber());
+                } else if (value.isBool()) {
+                    flags[key] = value.asBool() ? "true" : "false";
+                } else {
+                    return makeError(id, "parse_error",
+                                     "arg '" + key + "' must be a string, number, or bool", verb)
+                        .toString();
+                }
+            }
+        }
+
+        CommandParser parser;
+        CommandResult cmdResult =
+            parser.execute(verb, flags, m_trackManager->getCommandHistory());
+
+        JSON response = JSON::object();
+        response.set("id", JSON(id));
+        response.set("status", JSON(statusName(cmdResult.status)));
+        response.set("verb", JSON(verb));
+        response.set("message", JSON(cmdResult.message));
+        response.set("undoable", JSON(cmdResult.undoable));
+        response.set("executionMs", JSON(cmdResult.executionMs));
+        return response.toString();
+    } catch (const std::exception& e) {
+        return makeError(id, "execution_error", e.what(), verb).toString();
+    } catch (...) {
+        return makeError(id, "execution_error", "internal error", verb).toString();
+    }
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -11,11 +11,15 @@
 
 #include "AestraJSON.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <exception>
+#include <fstream>
 #include <unordered_map>
+#include <vector>
 
 namespace Aestra {
 namespace Audio {
@@ -73,12 +77,89 @@ JSON trackToJson(const MixerChannel& channel, size_t index) {
 MuseService::MuseService(TrackManager* trackManager, AudioEngine* engine)
     : m_trackManager(trackManager), m_engine(engine) {}
 
+void MuseService::wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackManager,
+                                     AudioEngine& engine) {
+    engine.setTrackManager(trackManager);
+    engine.setUnitManager(&trackManager->getUnitManager());
+    engine.setPatternPlaybackEngine(&trackManager->getPatternPlaybackEngine());
+    engine.setContinuousParams(trackManager->getContinuousParams());
+    trackManager->buildAndShareSlotMap();
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+
+    // Transport commands (play/stop/seek) travel from TrackManager to the
+    // engine through this sink — the same relay AestraContent installs.
+    TrackManager* tm = trackManager.get();
+    AudioEngine* enginePtr = &engine;
+    tm->setCommandSink([enginePtr, tm](const AudioQueueCommand& cmd) {
+        enginePtr->commandQueue().push(cmd);
+        if (cmd.type == AudioQueueCommandType::SetTransportState) {
+            const double sampleRate =
+                std::max(1.0, static_cast<double>(enginePtr->getSampleRate()));
+            tm->onTransportStateApplied(cmd.value1 != 0.0f,
+                                        static_cast<double>(cmd.samplePos) / sampleRate);
+        }
+    });
+}
+
 namespace {
 
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+}
+
+// Service actions: handled here like queries, but they do work (render a
+// file) rather than read state. Not routed through CommandHistory — a bounce
+// is not an undoable project edit.
+bool isActionVerb(const std::string& verb) {
+    return verb == "render_pattern";
+}
+
+// JSON numbers are doubles; an id must be a non-negative integer that a
+// double represents exactly, or the cast would silently target the wrong
+// object.
+bool numberToId(double value, uint64_t& out) {
+    constexpr double kMaxExactJsonInteger = 9007199254740991.0; // 2^53 - 1
+    if (!std::isfinite(value) || value < 0.0 || value != std::floor(value) ||
+        value > kMaxExactJsonInteger) {
+        return false;
+    }
+    out = static_cast<uint64_t>(value);
+    return true;
+}
+
+// Interleaved stereo float32 WAV — the format the offline test renderer uses.
+bool writeFloat32Wav(const std::string& path, const std::vector<float>& samples,
+                     uint32_t sampleRate) {
+    std::ofstream file(path, std::ios::binary);
+    if (!file) return false;
+
+    const uint32_t dataBytes = static_cast<uint32_t>(samples.size() * sizeof(float));
+    const uint16_t channels = 2;
+    const uint16_t bitsPerSample = 32;
+    const uint16_t blockAlign = channels * bitsPerSample / 8;
+
+    auto u32 = [&](uint32_t v) { file.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { file.write(reinterpret_cast<const char*>(&v), 2); };
+    file.write("RIFF", 4);
+    u32(36 + dataBytes);
+    file.write("WAVE", 4);
+    file.write("fmt ", 4);
+    u32(16);
+    u16(3); // IEEE float
+    u16(channels);
+    u32(sampleRate);
+    u32(sampleRate * blockAlign);
+    u16(blockAlign);
+    u16(bitsPerSample);
+    file.write("data", 4);
+    u32(dataBytes);
+    file.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
+    file.close(); // a failed flush on close must not report success
+    return !file.fail();
 }
 
 const char* unitTypeName(UnitType type) {
@@ -92,7 +173,7 @@ const char* unitTypeName(UnitType type) {
 }
 
 bool isKnownVerb(const std::string& verb) {
-    if (isQueryVerb(verb)) return true;
+    if (isQueryVerb(verb) || isActionVerb(verb)) return true;
     for (const auto& cmd : MuseGrammar::allCommands()) {
         if (cmd.verb == verb) return true;
     }
@@ -318,12 +399,15 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                         .toString();
                 }
             }
-            if (!args.has("pattern") || !args["pattern"].isNumber()) {
-                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+            uint64_t patternValue = 0;
+            if (!args.has("pattern") || !args["pattern"].isNumber() ||
+                !numberToId(args["pattern"].asNumber(), patternValue)) {
+                return makeError(id, "validation_error",
+                                 "arg 'pattern' must be a non-negative integer", verb)
                     .toString();
             }
 
-            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternID patternId{patternValue};
             const PatternSource* pattern =
                 m_trackManager->getPatternManager().getPattern(patternId);
             if (!pattern) {
@@ -352,6 +436,174 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 }
                 result.set("notes", notes);
             }
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "render_pattern") {
+            if (!m_trackManager || !m_engine) {
+                return makeError(id, "execution_error",
+                                 "render_pattern needs a track manager and an audio engine", verb)
+                    .toString();
+            }
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(
+                           id, "validation_error",
+                           "render_pattern requires args: {\"pattern\": <id>, \"file\": <path>}",
+                           verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "pattern" && entry.first != "file" && entry.first != "tail") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for render_pattern: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            uint64_t patternValue = 0;
+            if (!args.has("pattern") || !args["pattern"].isNumber() ||
+                !numberToId(args["pattern"].asNumber(), patternValue)) {
+                return makeError(id, "validation_error",
+                                 "arg 'pattern' must be a non-negative integer", verb)
+                    .toString();
+            }
+            if (!args.has("file") || !args["file"].isString() || args["file"].asString().empty()) {
+                return makeError(id, "validation_error", "arg 'file' must be a non-empty string",
+                                 verb)
+                    .toString();
+            }
+            double tailSeconds = 1.0;
+            if (args.has("tail")) {
+                if (!args["tail"].isNumber()) {
+                    return makeError(id, "validation_error", "arg 'tail' must be a number", verb)
+                        .toString();
+                }
+                tailSeconds = args["tail"].asNumber();
+                if (!(tailSeconds >= 0.0 && tailSeconds <= 30.0)) {
+                    return makeError(id, "validation_error", "arg 'tail' must be 0..30 seconds",
+                                     verb)
+                        .toString();
+                }
+            }
+
+            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternSource* pattern =
+                m_trackManager->getPatternManager().getPattern(patternId);
+            if (!pattern) {
+                return makeError(id, "execution_error",
+                                 "no such pattern: " + std::to_string(patternId.value), verb)
+                    .toString();
+            }
+            if (!pattern->isMidi()) {
+                return makeError(id, "execution_error", "pattern is not a MIDI pattern", verb)
+                    .toString();
+            }
+
+            const double bpm = std::max(1.0, static_cast<double>(m_engine->getBPM()));
+            // playPatternInArsenal resolves pattern length to at least 8 beats.
+            const double lengthBeats = std::max(8.0, pattern->lengthBeats);
+            const double durationSeconds = lengthBeats * 60.0 / bpm + tailSeconds;
+            const uint32_t sampleRate = m_engine->getSampleRate();
+            const uint64_t totalFrames =
+                static_cast<uint64_t>(durationSeconds * static_cast<double>(sampleRate));
+            constexpr uint32_t kBlockFrames = 512;
+
+            // Bound the render before touching engine state: the whole take
+            // is buffered in memory and the RIFF format caps a WAV at 4 GiB.
+            constexpr double kMaxRenderSeconds = 600.0;
+            const uint64_t dataBytes = totalFrames * 2ull * sizeof(float);
+            if (durationSeconds > kMaxRenderSeconds ||
+                36ull + dataBytes > 0xFFFFFFFFull) {
+                return makeError(id, "validation_error",
+                                 "render too long: " + std::to_string(durationSeconds) +
+                                     "s (max " + std::to_string(kMaxRenderSeconds) + "s)",
+                                 verb)
+                    .toString();
+            }
+
+            std::vector<float> rendered;
+            rendered.reserve(static_cast<size_t>(totalFrames) * 2u);
+            std::vector<float> block(static_cast<size_t>(kBlockFrames) * 2u, 0.0f);
+            float peak = 0.0f;
+            bool nonFinite = false;
+
+            {
+                // Everything after playback starts must be undone even if the
+                // pump throws: stop the transport, drain the stop command with
+                // settle blocks, and leave pattern mode (app default length).
+                struct TransportGuard {
+                    AudioEngine& engine;
+                    TrackManager& trackManager;
+                    std::vector<float>& block;
+                    ~TransportGuard() {
+                        trackManager.stop();
+                        for (int i = 0; i < 2; ++i) {
+                            std::memset(block.data(), 0, block.size() * sizeof(float));
+                            engine.processBlock(block.data(), nullptr, kBlockFrames, 0.0);
+                            engine.performNonRealtimeMaintenance();
+                        }
+                        engine.setPatternPlaybackMode(false, 4.0);
+                    }
+                } guard{*m_engine, *m_trackManager, block};
+
+                // Offline bounce through the exact live engine path, the same
+                // way the headless test renderer pumps it. Arsenal preview
+                // routing is what the user hears when a pattern plays, so it
+                // is what the agent gets back. Pattern playback needs both
+                // sides armed: the scheduler (playPatternInArsenal) and the
+                // engine's pattern mode (the app sets it wherever it starts
+                // pattern playback).
+                m_engine->setPatternPlaybackMode(true, lengthBeats);
+                m_trackManager->playPatternInArsenal(patternId, 0.0);
+
+                uint64_t framesRemaining = totalFrames;
+                while (framesRemaining > 0 && !nonFinite) {
+                    const uint32_t framesThisBlock =
+                        static_cast<uint32_t>(std::min<uint64_t>(kBlockFrames, framesRemaining));
+                    std::memset(block.data(), 0, block.size() * sizeof(float));
+                    m_engine->processBlock(block.data(), nullptr, framesThisBlock, 0.0);
+                    // The pattern scheduler's RT queue is refilled from the
+                    // control thread; offline that's us (AudioExporter does
+                    // the same per block).
+                    m_engine->performNonRealtimeMaintenance();
+                    for (uint32_t i = 0; i < framesThisBlock * 2u; ++i) {
+                        // Plugin output is untrusted: NaN/Inf must fail the
+                        // render, not land in the file as "ok".
+                        if (!std::isfinite(block[i])) {
+                            nonFinite = true;
+                            break;
+                        }
+                        peak = std::max(peak, std::abs(block[i]));
+                    }
+                    if (nonFinite) break;
+                    rendered.insert(rendered.end(), block.begin(),
+                                    block.begin() + static_cast<size_t>(framesThisBlock) * 2u);
+                    framesRemaining -= framesThisBlock;
+                }
+            }
+
+            if (nonFinite) {
+                return makeError(id, "execution_error",
+                                 "engine produced non-finite audio; render aborted", verb)
+                    .toString();
+            }
+
+            if (!writeFloat32Wav(args["file"].asString(), rendered, sampleRate)) {
+                return makeError(id, "execution_error",
+                                 "cannot write output file: " + args["file"].asString(), verb)
+                    .toString();
+            }
+
+            const double peakDb = peak > 0.0f ? 20.0 * std::log10(static_cast<double>(peak))
+                                              : -144.0;
+            JSON result = JSON::object();
+            result.set("file", JSON(args["file"].asString()));
+            result.set("durationSeconds", JSON(durationSeconds));
+            result.set("frames", JSON(static_cast<double>(totalFrames)));
+            result.set("sampleRate", JSON(static_cast<double>(sampleRate)));
+            result.set("peakDb", JSON(peakDb));
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -5,6 +5,9 @@
 #include "Commands/CommandResult.h"
 #include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
+#include "Models/UnitManager.h"
+
+#include <variant>
 
 #include "AestraJSON.h"
 
@@ -75,7 +78,17 @@ namespace {
 // Query verbs MuseService answers directly (mutations live in MuseGrammar).
 bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
-           verb == "get_session_state";
+           verb == "get_session_state" || verb == "list_units" || verb == "get_pattern";
+}
+
+const char* unitTypeName(UnitType type) {
+    switch (type) {
+    case UnitType::Sampler: return "sampler";
+    case UnitType::PitchedSampler: return "808";
+    case UnitType::Instrument: return "instrument";
+    case UnitType::Audio: return "audio";
+    }
+    return "unknown";
 }
 
 bool isKnownVerb(const std::string& verb) {
@@ -127,9 +140,10 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return makeError(id, "parse_error", "unknown command: " + verb).toString();
         }
 
-        // Queries take no arguments; accepting them would silently drop
-        // caller intent.
-        if (isQueryVerb(verb) && request.has("args") && request["args"].size() > 0) {
+        // Queries take no arguments — except get_pattern, which takes exactly
+        // one. Accepting anything else would silently drop caller intent.
+        if (isQueryVerb(verb) && verb != "get_pattern" && request.has("args") &&
+            request["args"].size() > 0) {
             return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
         }
 
@@ -247,8 +261,97 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             result.set("tracks", tracks);
             result.set("laneCount",
                        JSON(static_cast<double>(m_trackManager->getPlaylistModel().getLaneCount())));
+            result.set("unitCount",
+                       JSON(static_cast<double>(m_trackManager->getUnitManager().getUnitCount())));
             result.set("canUndo", JSON(m_trackManager->getCommandHistory().canUndo()));
 
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "list_units") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            auto& unitManager = m_trackManager->getUnitManager();
+            JSON units = JSON::array();
+            for (UnitID unitId : unitManager.getAllUnitIDs()) {
+                const UnitInfo* unit = unitManager.getUnit(unitId);
+                if (!unit) continue;
+                JSON u = JSON::object();
+                u.set("id", JSON(static_cast<double>(unit->id)));
+                u.set("name", JSON(unit->name));
+                u.set("type", JSON(unitTypeName(unit->type)));
+                u.set("enabled", JSON(unit->isEnabled));
+                u.set("muted", JSON(unit->isMuted));
+                u.set("soloed", JSON(unit->isSolo));
+                u.set("defaultPatternId",
+                      JSON(static_cast<double>(unit->defaultPatternId.value)));
+                u.set("samplePath", JSON(unit->audioClipPath));
+                u.set("sampleDurationSeconds", JSON(unit->audioDurationSeconds));
+                units.push(u);
+            }
+            JSON result = JSON::object();
+            result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        if (verb == "get_pattern") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            // The one parameterized query: args must be exactly
+            // {"pattern": <number>}.
+            if (!request.has("args") || !request["args"].isObject()) {
+                return makeError(id, "validation_error",
+                                 "get_pattern requires args: {\"pattern\": <id>}", verb)
+                    .toString();
+            }
+            JSON& args = request["args"];
+            for (auto& entry : args.asObject()) {
+                if (entry.first != "pattern") {
+                    return makeError(id, "validation_error",
+                                     "unknown arg for get_pattern: " + entry.first, verb)
+                        .toString();
+                }
+            }
+            if (!args.has("pattern") || !args["pattern"].isNumber()) {
+                return makeError(id, "validation_error", "arg 'pattern' must be a number", verb)
+                    .toString();
+            }
+
+            const PatternID patternId{static_cast<uint64_t>(args["pattern"].asNumber())};
+            const PatternSource* pattern =
+                m_trackManager->getPatternManager().getPattern(patternId);
+            if (!pattern) {
+                return makeError(id, "execution_error",
+                                 "no such pattern: " + std::to_string(patternId.value), verb)
+                    .toString();
+            }
+
+            JSON result = JSON::object();
+            result.set("id", JSON(static_cast<double>(pattern->id.value)));
+            result.set("name", JSON(pattern->name));
+            result.set("lengthBeats", JSON(pattern->lengthBeats));
+            const bool isMidi = pattern->isMidi();
+            result.set("type", JSON(isMidi ? "midi" : "other"));
+            if (isMidi) {
+                JSON notes = JSON::array();
+                for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
+                    JSON n = JSON::object();
+                    n.set("pitch", JSON(static_cast<double>(note.pitch)));
+                    n.set("start", JSON(note.startBeat));
+                    n.set("duration", JSON(note.durationBeats));
+                    n.set("velocity", JSON(static_cast<double>(note.velocity)));
+                    n.set("pan", JSON(static_cast<double>(note.pan)));
+                    n.set("unit", JSON(static_cast<double>(note.unitId)));
+                    notes.push(n);
+                }
+                result.set("notes", notes);
+            }
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraDocs/design/Full_Theme_System_Audit_2026-07.md
+++ b/AestraDocs/design/Full_Theme_System_Audit_2026-07.md
@@ -1,0 +1,69 @@
+# Full Theme System Audit — July 2026
+
+## Scope and evidence
+
+This audit follows the UI consistency foundation in PR #517. It inspects the active desktop theme path, JSON loading, preference persistence, settings UI, invalidation, cached styling, and shared controls. The findings come from the current `feature/full-theme-system` tree and the runtime evidence captured by the preceding consistency pass.
+
+## Severity 1 — theme changes are not a live application contract
+
+- Aestra has two independent theme representations. `NUITheme` loads map-based JSON, while rendered application code primarily reads `NUIThemeManager` and `NUIThemeProperties`. No startup path installs a loaded JSON theme into the live manager.
+- `AestraWindowManager::initialize()` always activates `Aestra-dark`, despite `Preferences::theme` being loaded before window creation and serialized on shutdown.
+- Appearance settings always select index zero, expose a nonexistent `Midnight Blue` option, and have no selection handler. Apply and Cancel only clear a local dirty flag.
+- `NUIThemeManager` exposes one replaceable callback. A second interested surface silently disconnects the first, so application-wide invalidation and independent tooling cannot coexist.
+- `NUIThemedComponent` registration is stubbed and unused. No reliable root-to-leaf notification exists.
+- Animated `switchTheme()` interpolates only three legacy colors into a partially default-initialized theme, does not activate the target name, and completes by notifying listeners with the old active theme. This path is unsafe to expose as a theme feature.
+
+Impact: theme files can pass parser tests without affecting the real UI, saved selection is ignored, and a live switch can leave cached and uncached components showing different themes.
+
+## Severity 2 — cached theme values do not reliably refresh
+
+- Mixer widgets, routing views, panel windows, the timeline minimap, and other surfaces cache colors during construction.
+- `NUIIcon::setColorFromTheme()` resolves a token once and forgets the token name, so toolbar and transport icons cannot follow a later theme change.
+- Some shared controls refresh theme colors during render while other controls resolve once. The resulting behavior depends on component implementation rather than a common lifecycle.
+- Theme activation does not explicitly invalidate the root hierarchy. Idle frame elision can therefore leave a correctly changed manager with stale pixels until unrelated interaction occurs.
+
+Impact: switching themes is nondeterministic across major surfaces and can require mouse movement or reconstruction to become visible.
+
+## Severity 2 — JSON defaults and live defaults describe different products
+
+- `NUITheme::createDefault()` retains an older palette, 12 px default radius, 15 px body text, and 28 px title text.
+- `NUIThemeProperties` uses the compact desktop grammar established by the consistency pass: 3–7 px common radii and 9–14 px working typography.
+- Missing JSON fields correctly receive parser defaults, but those defaults are not the defaults used by live controls.
+- JSON accepts arbitrary token names for forward compatibility, but there is no documented mapping of accepted live semantic roles.
+
+Impact: a partial theme file may be internally valid yet produce unexpected geometry if connected directly to the current UI.
+
+## Severity 3 — remaining bypass paths
+
+- A repository scan finds raw color construction in both intentional domain rendering and accidental UI styling. Recording, meters, waveforms, track colors, and plugin response plots are intentional domains; generic panels, labels, borders, and interaction states should use semantic roles.
+- A few legacy widgets still query the per-component `NUITheme` object for font sizes, while the rest of the application uses `NUIThemeManager`.
+- Built-in preset families beyond Aestra and high-contrast are registered in the manager but are not product-facing choices. Exposing every internal compatibility preset would broaden the visual identity rather than complete the Aestra theme system.
+
+## Intentionally preserved distinctions
+
+- Track colors, waveform colors, meter thresholds, recording/armed state, mute, solo, bypass, warning, and error remain separate domain roles.
+- Plugin editors retain their neutral, flat direction and may use domain-specific graph colors where these communicate signal behavior.
+- Major/minor timeline grid contrast and the fractal-grid language remain distinct from ordinary dividers.
+- Dense DAW layouts keep compact metrics; this pass does not inflate rows, headers, or hit areas beyond the established minimums.
+- Existing arbitrary JSON keys remain loadable through `NUITheme` for compatibility, although only documented semantic keys affect the live manager.
+
+## Smallest reliable implementation plan
+
+1. Make `NUIThemeManager` the sole live owner while keeping `NUITheme` as the backward-compatible JSON and per-component adapter.
+2. Add deterministic theme registration/loading with a documented mapping from JSON semantic tokens to `NUIThemeProperties`; missing tokens inherit the selected base preset.
+3. Replace the single-listener limitation with explicit subscriptions while retaining the old callback API as a compatibility slot.
+4. Make theme activation atomic. Until every property has a safe interpolation rule, requested animated switches complete as one atomic change rather than emitting partial themes.
+5. Subscribe the application window once, propagate `onThemeChanged()` through the component tree, refresh cached components/icons, invalidate affected surfaces, and preserve idle rendering behavior.
+6. Wire startup and Appearance settings to `Preferences::theme`, with safe fallback for stale or unknown values and real Apply/Cancel behavior.
+7. Migrate confirmed-live generic styling bypasses, then validate dark, light, and high-contrast themes across the same main-surface runtime loop used for PR #517.
+
+## Performance and safety constraints
+
+- Parsing and registration occur only on user-driven load/reload paths, never during paint, layout, or audio processing.
+- Theme activation performs bounded UI-thread notification and one hierarchy invalidation.
+- Paint paths continue to read cached structs or manager references; no per-frame JSON parsing is introduced.
+- The theme system remains outside real-time audio paths and does not add locks, allocation, logging, or I/O to audio callbacks.
+
+## Muse handoff requirements
+
+The later Muse harness should consume public UI actions and stable observable state rather than component internals. The finalized theme contract should expose deterministic theme selection, active-theme identity, and screenshot-ready invalidation. Muse work remains a separate branch after this theming pass so automation does not become coupled to transitional UI implementation details.

--- a/AestraDocs/design/Theme_System_Contract.md
+++ b/AestraDocs/design/Theme_System_Contract.md
@@ -1,0 +1,87 @@
+# Aestra Theme System Contract
+
+## Live ownership
+
+`NUIThemeManager` is the single live theme owner. Components should read `NUIThemeProperties` or the manager's semantic accessors. `NUITheme` remains the backward-compatible JSON loader and per-component adapter; loading a file does not parse during paint or automatically mutate the application.
+
+Built-in product themes are:
+
+- `Aestra-dark`
+- `Aestra-light`
+- `high-contrast-dark`
+
+The manager retains lower-case and older internal preset names for compatibility. Product settings should expose only supported Aestra choices.
+
+## Activation and updates
+
+- `setActiveTheme(name)` returns `false` for an unknown name and leaves the current theme unchanged.
+- `switchTheme(name, duration)` currently performs the same atomic activation. A partial transition is deliberately not emitted because every semantic property would need a defined interpolation rule.
+- Use `subscribeToThemeChanges()` and retain the returned ID. Unsubscribe before the owner is destroyed.
+- `setOnThemeChanged()` is retained as one compatibility callback slot. New owners must use subscriptions so listeners cannot replace one another.
+- `AestraWindowManager` owns the application subscription and propagates `onThemeChanged()` through the component hierarchy. Theme-aware caches should refresh in their override and then call `NUIComponent::onThemeChanged(theme)`.
+- Explicit custom widget colors are preserved. Widgets using default colors refresh from the new active theme.
+
+Theme updates are UI-thread operations. Subscribers must not call audio-thread code.
+
+## JSON registration
+
+Use:
+
+```cpp
+auto& themes = AestraUI::NUIThemeManager::getInstance();
+if (themes.loadThemeFromFile("studio-custom", path, "Aestra-dark")) {
+    themes.setActiveTheme("studio-custom");
+}
+```
+
+The file is limited to 1 MiB. Missing fields inherit the requested base theme. Invalid entries are skipped according to the existing loader policy; malformed, incomplete, non-object, missing, or oversized files fail live registration and do not install a misleading fallback theme.
+
+Colors use `#RRGGBB` or `#RRGGBBAA`. Unknown token names remain available through `NUITheme` for backward and forward compatibility but do not affect the live manager until a semantic mapping is documented.
+
+### Live color roles
+
+Preferred JSON names are:
+
+- Surfaces: `appBackground`, `workspaceBackground`, `recessedPanel`, `elevatedPanel`, `surfaceRaised`
+- Controls: `controlBackground`, `controlHover`, `controlPressed`, `controlDisabled`
+- Structure: `borderSubtle`, `borderStrong`, `borderActive`, `divider`
+- Text: `textPrimary`, `textSecondary`, `textMuted`, `textDisabled`, `textLink`, `textCritical`, `textOnPrimary`
+- Accent and selection: `accent`, `accentHover`, `accentPressed`, `selection`, `focusRing`, `dragTarget`
+- Status: `success`, `warning`, `error`, `info`, `armed`, `muted`, `soloed`, `bypassed`
+- Input: `toggleDefault`, `toggleHover`, `toggleActive`, `inputBackground`, `inputBgHover`, `inputBorderFocus`, `sliderTrack`, `sliderHandle`, `sliderHandleHover`, `sliderHandlePressed`
+- Meter and grid: `meterSafe`, `meterWarn`, `meterCrit`, `meterBackground`, `meterActive`, `gridMajor`, `gridMinor`
+- Overlays: `shadow`, `overlay`, `backdrop`
+
+Legacy names such as `background`, `surface`, `primary`, `buttonBgDefault`, `buttonBgHover`, and `normal` font size remain supported.
+
+When a JSON file overrides the primary accent but omits dependent roles, hover, pressed, selection, focus, drag target, link, toggle, input-focus, and slider roles are derived deterministically. Warning, error, and info similarly feed muted, armed, meter, critical-text, and solo roles when those roles are not explicitly overridden.
+
+### Live dimensions and typography
+
+Supported dimensions include the shared spacing scale, three legacy radius keys, common control/row/header heights, icon and hit-area metrics, divider width, panel/dialog padding, file-browser width, track-controls width, track height, and transport height.
+
+Supported font keys are `micro`, `xs`, `s`, `m`, `l`, `xl`, `display-s`, and `display-l`; legacy `small`, `normal`, and `large` map to the compact live scale.
+
+Positive layout and typography values are validated. Missing values retain the base preset.
+
+## Compatibility
+
+- Existing theme files still load through `NUITheme::loadFromFile()` and still receive defaults for missing or invalid entries.
+- Preference key and serialization format are unchanged. Unknown saved theme names safely fall back to `Aestra-dark`.
+- The component-level `setTheme()` API remains available for compatibility, but application styling should use the live manager.
+- No project or plugin state format changes are involved.
+
+## Performance
+
+- JSON parsing and registration happen only on explicit load/reload paths.
+- Activation performs one bounded UI-thread notification and hierarchy invalidation.
+- Cached timeline layers are invalidated once; they are not rebuilt every frame.
+- Theme switching does not add audio-thread allocation, locking, logging, file I/O, or callbacks.
+
+## Intentional visual domains
+
+Track colors, waveform rendering, plugin response graphs, meter thresholds, recording, mute, solo, bypass, warning/error status, and major/minor timeline grids remain separate roles. The arrangement grid may retain its dark fractal-workspace language inside a light chrome theme; it is not an ordinary panel background.
+
+## Muse harness handoff
+
+Muse should automate stable public actions: open Settings, select a theme by identity, apply or cancel, wait for root invalidation, navigate major surfaces, and capture screenshots. It should observe active theme identity and visible UI state instead of reaching into component color fields. Building that harness after this contract lands avoids coupling Muse to transitional theme internals.

--- a/AestraUI/Base/NUICheckbox.cpp
+++ b/AestraUI/Base/NUICheckbox.cpp
@@ -63,6 +63,25 @@ void NUICheckbox::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUICheckbox::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        textColor_ = theme.textPrimary;
+        backgroundColor_ = theme.buttonBgDefault;
+        borderColor_ = theme.borderSubtle;
+        checkColor_ = theme.primary;
+        hoverColor_ = theme.buttonBgHover;
+        pressedColor_ = theme.buttonBgActive;
+        toggleThumbColor_ = theme.textOnPrimary;
+        toggleTrackColor_ = theme.toggleDefault;
+        toggleTrackCheckedColor_ = theme.toggleActive;
+        checkboxRadius_ = theme.radiusXS;
+    }
+    if (checkIcon_)
+        checkIcon_->setColor(checkColor_);
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUICheckbox::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isEnabled() || !isVisible()) return false;
@@ -174,54 +193,63 @@ void NUICheckbox::setCheckboxRadius(float radius)
 void NUICheckbox::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setCheckColor(const NUIColor& color)
 {
     checkColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setHoverColor(const NUIColor& color)
 {
     hoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setPressedColor(const NUIColor& color)
 {
     pressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleThumbColor(const NUIColor& color)
 {
     toggleThumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleTrackColor(const NUIColor& color)
 {
     toggleTrackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUICheckbox::setToggleTrackCheckedColor(const NUIColor& color)
 {
     toggleTrackCheckedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -538,8 +566,8 @@ void NUICheckbox::drawCheckmark(NUIRenderer& renderer, const NUIRect& rect)
     // Position the checkmark icon
     checkIcon_->setIconSize(iconSize, iconSize);
     checkIcon_->setPosition(centerX - iconSize * 0.5f, centerY - iconSize * 0.5f);
-    // Use white/primary color for checkmark to contrast with accent background
-    checkIcon_->setColor(NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+    // Contrast against the accent fill via the theme's on-primary token.
+    checkIcon_->setColor(NUIThemeManager::getInstance().getCurrentTheme().textOnPrimary);
     
     // Render the checkmark
     checkIcon_->onRender(renderer);

--- a/AestraUI/Base/NUICheckbox.h
+++ b/AestraUI/Base/NUICheckbox.h
@@ -39,6 +39,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseEnter() override;
     void onMouseLeave() override;
@@ -169,6 +170,7 @@ private:
     NUIColor toggleThumbColor_ = NUIColor::fromHex(0xffffffff);
     NUIColor toggleTrackColor_ = NUIColor::fromHex(0xff2a2d32);
     NUIColor toggleTrackCheckedColor_ = NUIColor::fromHex(0xffa855f7);
+    bool customColors_ = false;
 
     // Text properties
     NUITextAlignment textAlignment_ = NUITextAlignment::Left;

--- a/AestraUI/Base/NUIContextMenu.cpp
+++ b/AestraUI/Base/NUIContextMenu.cpp
@@ -126,6 +126,23 @@ void NUIContextMenu::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUIContextMenu::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        backgroundColor_ = theme.surfaceTertiary;
+        borderColor_ = theme.borderStrong;
+        textColor_ = theme.textPrimary;
+        hoverColor_ = theme.buttonBgHover;
+        separatorColor_ = theme.borderSubtle;
+        shortcutColor_ = theme.textSecondary;
+        borderRadius_ = theme.radiusM;
+        itemHeight_ = theme.layout.standardMenuRowHeight;
+        iconSize_ = theme.layout.standardIconSize;
+        updateSize();
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUIContextMenu::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isVisible() || !isEnabled()) return false;
@@ -359,36 +376,42 @@ void NUIContextMenu::hide()
 void NUIContextMenu::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setHoverColor(const NUIColor& color)
 {
     hoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setSeparatorColor(const NUIColor& color)
 {
     separatorColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIContextMenu::setShortcutColor(const NUIColor& color)
 {
     shortcutColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUIContextMenu.h
+++ b/AestraUI/Base/NUIContextMenu.h
@@ -96,6 +96,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
     void onMouseEnter() override;
@@ -213,6 +214,7 @@ private:
     NUIColor hoverColor_ = NUIColor::fromHex(0xff3a3d42);
     NUIColor separatorColor_ = NUIColor::fromHex(0xff666666);
     NUIColor shortcutColor_ = NUIColor::fromHex(0xff888888);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 7.0f;
     float itemHeight_ = 28.0f;

--- a/AestraUI/Base/NUIDropdown.cpp
+++ b/AestraUI/Base/NUIDropdown.cpp
@@ -29,7 +29,7 @@ NUIDropdown::NUIDropdown()
     try {
         auto& mgr = NUIThemeManager::getInstance();
         const auto& props = mgr.getCurrentTheme();
-        backgroundColor_ = props.surfaceRaised;
+        backgroundColor_ = props.surfaceTertiary; // keep in sync with refreshThemeColors()
         hoverColor_ = props.buttonBgHover;
         selectedColor_ = props.selected;
         borderColor_ = props.border;

--- a/AestraUI/Base/NUIIcon.cpp
+++ b/AestraUI/Base/NUIIcon.cpp
@@ -61,17 +61,29 @@ void NUIIcon::setIconSize(float width, float height) {
 void NUIIcon::setColor(const NUIColor& color) {
     color_ = color;
     hasCustomColor_ = true;
+    themeColorName_.clear();
     setDirty(true);
 }
 
 void NUIIcon::setColorFromTheme(const std::string& colorName) {
     auto& themeManager = NUIThemeManager::getInstance();
-    setColor(themeManager.getColor(colorName));
+    color_ = themeManager.getColor(colorName);
+    hasCustomColor_ = true;
+    themeColorName_ = colorName;
+    setDirty(true);
 }
 
 void NUIIcon::clearColor() {
     hasCustomColor_ = false;
+    themeColorName_.clear();
     setDirty(true);
+}
+
+void NUIIcon::onThemeChanged(const NUIThemeProperties& theme) {
+    (void)theme;
+    if (!themeColorName_.empty())
+        color_ = NUIThemeManager::getInstance().getColor(themeColorName_);
+    NUIComponent::onThemeChanged(theme);
 }
 
 void NUIIcon::updateBounds() {

--- a/AestraUI/Base/NUIIcon.h
+++ b/AestraUI/Base/NUIIcon.h
@@ -31,6 +31,7 @@ public:
     
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     
     // Icon management
     void loadSVG(const std::string& svgContent);
@@ -68,6 +69,7 @@ private:
     std::shared_ptr<NUISVGDocument> svgDoc_;
     NUIColor color_ = NUIColor::white();
     bool hasCustomColor_ = false;
+    std::string themeColorName_;
     float iconWidth_ = 24.0f;
     float iconHeight_ = 24.0f;
 };

--- a/AestraUI/Base/NUILabel.cpp
+++ b/AestraUI/Base/NUILabel.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUILabel.h"
 #include "NUITheme.h"
+#include "NUIThemeSystem.h"
 #include "Graphics/NUIRenderer.h"
 #include <algorithm>
 #include <cmath>
@@ -10,7 +11,12 @@ namespace AestraUI {
 NUILabel::NUILabel(const std::string& text)
     : text_(text)
 {
-    setSize(100, 20); // Default size
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    textColor_ = theme.textPrimary;
+    backgroundColor_ = NUIColor::transparent();
+    borderColor_ = theme.borderSubtle;
+    fontSize_ = theme.fontSizeM;
+    setSize(100, theme.layout.compactControlHeight);
 }
 
 void NUILabel::onRender(NUIRenderer& renderer)
@@ -103,6 +109,18 @@ void NUILabel::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUILabel::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customTextColor_)
+        textColor_ = theme.textPrimary;
+    if (!customBackgroundColor_)
+        backgroundColor_ = NUIColor::transparent();
+    if (!customBorderColor_)
+        borderColor_ = theme.borderSubtle;
+    textSizeValid_ = false;
+    NUIComponent::onThemeChanged(theme);
+}
+
 void NUILabel::setText(const std::string& text)
 {
     if (text_ != text) {
@@ -121,6 +139,7 @@ void NUILabel::setFont(std::shared_ptr<NUIFont> font)
 void NUILabel::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customTextColor_ = true;
     repaint();
 }
 
@@ -160,6 +179,7 @@ void NUILabel::setEllipsize(bool ellipsize)
 void NUILabel::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customBackgroundColor_ = true;
     repaint();
 }
 
@@ -172,6 +192,7 @@ void NUILabel::setBackgroundVisible(bool visible)
 void NUILabel::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customBorderColor_ = true;
     repaint();
 }
 

--- a/AestraUI/Base/NUILabel.h
+++ b/AestraUI/Base/NUILabel.h
@@ -31,6 +31,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
 
     // Text properties
     void setText(const std::string& text);
@@ -99,6 +100,9 @@ private:
     
     // Editable state
     bool editable_ = false;
+    bool customTextColor_ = false;
+    bool customBackgroundColor_ = false;
+    bool customBorderColor_ = false;
     
     // OPTIMIZATION: Cache text measurements
     mutable NUISize cachedTextSize_{0, 0};

--- a/AestraUI/Base/NUIProgressBar.cpp
+++ b/AestraUI/Base/NUIProgressBar.cpp
@@ -2,6 +2,7 @@
 #include "NUIProgressBar.h"
 #include "NUIRenderer.h"
 #include "NUITheme.h"
+#include "NUIThemeSystem.h"
 #include <algorithm>
 #include <cmath>
 #include <sstream>
@@ -12,7 +13,13 @@ namespace AestraUI {
 NUIProgressBar::NUIProgressBar()
     : NUIComponent()
 {
-    setSize(200, 20); // Default size
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    backgroundColor_ = theme.meterBackground;
+    progressColor_ = theme.meterActive;
+    borderColor_ = theme.borderSubtle;
+    textColor_ = theme.textPrimary;
+    borderRadius_ = theme.radiusS;
+    setSize(200, theme.layout.compactControlHeight);
 }
 
 void NUIProgressBar::onRender(NUIRenderer& renderer)
@@ -38,6 +45,18 @@ void NUIProgressBar::onRender(NUIRenderer& renderer)
     {
         drawText(renderer);
     }
+}
+
+void NUIProgressBar::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        backgroundColor_ = theme.meterBackground;
+        progressColor_ = theme.meterActive;
+        borderColor_ = theme.borderSubtle;
+        textColor_ = theme.textPrimary;
+        borderRadius_ = theme.radiusS;
+    }
+    NUIComponent::onThemeChanged(theme);
 }
 
 void NUIProgressBar::onUpdate(double deltaTime)
@@ -112,24 +131,28 @@ void NUIProgressBar::setOrientation(Orientation orientation)
 void NUIProgressBar::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setProgressColor(const NUIColor& color)
 {
     progressColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIProgressBar::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUIProgressBar.h
+++ b/AestraUI/Base/NUIProgressBar.h
@@ -36,6 +36,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     void onUpdate(double deltaTime) override;
 
     // Progress properties
@@ -154,6 +155,7 @@ private:
     NUIColor progressColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor borderColor_ = NUIColor::fromHex(0xff666666);
     NUIColor textColor_ = NUIColor::fromHex(0xffffffff);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float thickness_ = 8.0f;

--- a/AestraUI/Base/NUIScrollbar.cpp
+++ b/AestraUI/Base/NUIScrollbar.cpp
@@ -85,6 +85,27 @@ void NUIScrollbar::onRender(NUIRenderer& renderer)
     drawArrows(renderer);
 }
 
+void NUIScrollbar::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        trackColor_ = theme.backgroundSecondary.withAlpha(0.72f);
+        thumbColor_ = theme.textMuted.withAlpha(0.42f);
+        thumbHoverColor_ = theme.textSecondary.withAlpha(0.62f);
+        thumbPressedColor_ = theme.textPrimary.withAlpha(0.76f);
+        arrowColor_ = theme.textMuted;
+        arrowHoverColor_ = theme.textSecondary;
+        arrowPressedColor_ = theme.textPrimary;
+        borderColor_ = theme.borderSubtle;
+        borderRadius_ = theme.radiusXS;
+        arrowSize_ = theme.fontSizeM;
+        if (upArrowIcon_)
+            upArrowIcon_->setColor(arrowColor_);
+        if (downArrowIcon_)
+            downArrowIcon_->setColor(arrowColor_);
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 void NUIScrollbar::onUpdate(double deltaTime)
 {
     if (isAnimating_ && !isDragging_) {
@@ -426,48 +447,56 @@ void NUIScrollbar::setMinimumThumbSize(double size)
 void NUIScrollbar::setTrackColor(const NUIColor& color)
 {
     trackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbColor(const NUIColor& color)
 {
     thumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbHoverColor(const NUIColor& color)
 {
     thumbHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setThumbPressedColor(const NUIColor& color)
 {
     thumbPressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowColor(const NUIColor& color)
 {
     arrowColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowHoverColor(const NUIColor& color)
 {
     arrowHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setArrowPressedColor(const NUIColor& color)
 {
     arrowPressedColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUIScrollbar::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -1129,12 +1158,12 @@ void NUIScrollbar::drawEnhancedThumb(NUIRenderer& renderer, const NUIRect& thumb
         // Top horizontal white marker
         NUIRect topMarker(visualThumb.x + 2.0f, markerY, visualThumb.width - 4.0f, markerHeight);
         const float markerAlpha = thumbHot ? 0.24f : 0.12f;
-        renderer.fillRoundedRect(topMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(topMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
         
         // Bottom horizontal white marker
         NUIRect bottomMarker(visualThumb.x + 2.0f, markerY + markerHeight + markerSpacing, 
                              visualThumb.width - 4.0f, markerHeight);
-        renderer.fillRoundedRect(bottomMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(bottomMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
     }
     else
     {
@@ -1149,12 +1178,12 @@ void NUIScrollbar::drawEnhancedThumb(NUIRenderer& renderer, const NUIRect& thumb
         // Left vertical white marker
         NUIRect leftMarker(markerX, visualThumb.y + 2.0f, markerWidth, visualThumb.height - 4.0f);
         const float markerAlpha = thumbHot ? 0.24f : 0.12f;
-        renderer.fillRoundedRect(leftMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(leftMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
         
         // Right vertical white marker
         NUIRect rightMarker(markerX + markerWidth + markerSpacing, visualThumb.y + 2.0f, 
                             markerWidth, visualThumb.height - 4.0f);
-        renderer.fillRoundedRect(rightMarker, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, markerAlpha));
+        renderer.fillRoundedRect(rightMarker, 1.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(markerAlpha));
     }
     
     // Subtle inner highlight

--- a/AestraUI/Base/NUIScrollbar.h
+++ b/AestraUI/Base/NUIScrollbar.h
@@ -49,6 +49,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onUpdate(double deltaTime) override;
     void onMouseEnter() override;
@@ -198,6 +199,7 @@ private:
     NUIColor arrowHoverColor_ = NUIColor(0.95f, 0.95f, 0.95f, 0.45f);    // Brighter on hover
     NUIColor arrowPressedColor_ = NUIColor(0.70f, 0.70f, 0.70f, 0.65f);  // Stronger on press
     NUIColor borderColor_ = NUIColor(0.30f, 0.30f, 0.30f, 0.35f);        // Subtle border
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float arrowSize_ = 12.0f;

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -61,6 +61,18 @@ void NUISlider::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUISlider::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        trackColor_ = theme.sliderTrack;
+        fillColor_ = theme.sliderHandle;
+        thumbColor_ = theme.textPrimary;
+        thumbHoverColor_ = theme.sliderHandleHover;
+        sliderRadius_ = theme.radiusM;
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isEnabled() || !isVisible()) return false;
@@ -284,24 +296,28 @@ void NUISlider::setSliderRadius(float radius)
 void NUISlider::setTrackColor(const NUIColor& color)
 {
     trackColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setFillColor(const NUIColor& color)
 {
     fillColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setThumbColor(const NUIColor& color)
 {
     thumbColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUISlider::setThumbHoverColor(const NUIColor& color)
 {
     thumbHoverColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUISlider.h
+++ b/AestraUI/Base/NUISlider.h
@@ -45,6 +45,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseEnter() override;
     void onMouseLeave() override;
@@ -191,6 +192,7 @@ private:
     NUIColor fillColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor thumbColor_ = NUIColor::fromHex(0xffffffff);
     NUIColor thumbHoverColor_ = NUIColor::fromHex(0xffe5e7eb);
+    bool customColors_ = false;
 
     // Interaction state
     bool isDragging_ = false;

--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -125,6 +125,23 @@ void NUITextInput::onRender(NUIRenderer& renderer)
     }
 }
 
+void NUITextInput::onThemeChanged(const NUIThemeProperties& theme)
+{
+    if (!customColors_) {
+        textColor_ = theme.textPrimary;
+        backgroundColor_ = theme.inputBgDefault;
+        borderColor_ = theme.borderSubtle;
+        focusedBorderColor_ = theme.focusRing;
+        placeholderColor_ = theme.textMuted;
+        selectionColor_ = theme.selected;
+        caretColor_ = theme.textPrimary;
+        borderRadius_ = theme.radiusM;
+        padding_ = theme.spacingS;
+    }
+    invalidateLayout();
+    NUIComponent::onThemeChanged(theme);
+}
+
 bool NUITextInput::onMouseEvent(const NUIMouseEvent& event)
 {
     if (!isVisible() || !isEnabled()) return false;
@@ -352,12 +369,14 @@ void NUITextInput::setMinLength(int minLength)
 void NUITextInput::setTextColor(const NUIColor& color)
 {
     textColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setBackgroundColor(const NUIColor& color)
 {
     backgroundColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
@@ -370,30 +389,35 @@ void NUITextInput::setBackgroundVisible(bool visible)
 void NUITextInput::setBorderColor(const NUIColor& color)
 {
     borderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setFocusedBorderColor(const NUIColor& color)
 {
     focusedBorderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setPlaceholderColor(const NUIColor& color)
 {
     placeholderColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setSelectionColor(const NUIColor& color)
 {
     selectionColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 
 void NUITextInput::setCaretColor(const NUIColor& color)
 {
     caretColor_ = color;
+    customColors_ = true;
     setDirty(true);
 }
 

--- a/AestraUI/Base/NUITextInput.h
+++ b/AestraUI/Base/NUITextInput.h
@@ -53,6 +53,7 @@ public:
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
     void onFocusGained() override;
@@ -245,6 +246,7 @@ private:
     NUIColor placeholderColor_ = NUIColor::fromHex(0xff888888);
     NUIColor selectionColor_ = NUIColor::fromHex(0xffa855f7);
     NUIColor caretColor_ = NUIColor::fromHex(0xffffffff);
+    bool customColors_ = false;
     float borderWidth_ = 1.0f;
     float borderRadius_ = 4.0f;
     float padding_ = 8.0f;

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -488,6 +488,13 @@ std::shared_ptr<NUITheme> NUIComponent::getTheme() const {
     return nullptr;
 }
 
+void NUIComponent::onThemeChanged(const NUIThemeProperties& theme) {
+    (void)theme;
+    setDirty(true);
+    for (auto& child : children_)
+        child->onThemeChanged(theme);
+}
+
 // ============================================================================
 // Protected Methods
 // ============================================================================

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -10,6 +10,7 @@ namespace AestraUI {
 
 class NUIRenderer;
 class NUITheme;
+struct NUIThemeProperties;
 class NUIFont;
 
 /**
@@ -137,6 +138,8 @@ public:
     // Theme
     void setTheme(std::shared_ptr<NUITheme> theme);
     std::shared_ptr<NUITheme> getTheme() const;
+    /** Refresh cached theme state, then propagate the change to descendants. */
+    virtual void onThemeChanged(const NUIThemeProperties& theme);
     
     // Callbacks
     NUIMouseCallback onMouseDown;

--- a/AestraUI/Core/NUIDragDrop.h
+++ b/AestraUI/Core/NUIDragDrop.h
@@ -18,7 +18,6 @@ class NUIRenderer;
 enum class DragDataType {
     None,
     File,           // File from browser (path string)
-    AudioClip,      // Audio clip being moved in timeline
     MidiClip,       // MIDI clip being moved
     Pattern,        // Pattern from browser (to timeline)
     Plugin,         // Plugin from browser
@@ -33,14 +32,10 @@ struct DragData {
     std::string filePath;           // For file drags
     std::string displayName;        // Shown in drag ghost
     NUIColor accentColor;           // Visual feedback color
-    int sourceTrackIndex = -1;      // For clip moves
-    double sourceTimePosition = 0;  // For clip moves
     std::any customData;            // For extensibility
-    
-    // v3.0 arrangement manipulation
-    std::string sourceClipIdString; // UUID as string
-    int sourceLaneIndex = -1;
-    
+
+    std::string sourceClipIdString; // Plugin drags carry the plugin identifier here
+
     // Original dimensions for visual preview
     float previewWidth = 100.0f;
     float previewHeight = 30.0f;

--- a/AestraUI/Core/NUITheme.cpp
+++ b/AestraUI/Core/NUITheme.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <functional>
 #include <unordered_set>
+#include <vector>
 
 namespace AestraUI {
 
@@ -44,8 +45,37 @@ bool requiresPositiveDimension(const std::string& name) {
         "margin", "borderWidth", "compactControlHeight", "standardControlHeight", "dialogActionHeight",
         "standardRowHeight", "compactMenuRowHeight", "standardMenuRowHeight", "panelHeaderHeight",
         "sectionHeaderHeight", "standardIconSize", "minimumHitArea", "dividerWidth", "panelPadding",
-        "dialogPadding"};
+        "dialogPadding", "spacingXS", "spacingS", "spacingM", "spacingL", "spacingXL", "spacingXXL",
+        "fileBrowserWidth", "trackControlsWidth", "trackHeight", "transportBarHeight"};
     return positiveDimensions.find(name) != positiveDimensions.end();
+}
+
+bool hasCompleteJSONStructure(const std::string& content) {
+    std::vector<char> stack;
+    bool inString = false;
+    bool escaped = false;
+    for (char c : content) {
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                inString = false;
+            }
+            continue;
+        }
+        if (c == '"') {
+            inString = true;
+        } else if (c == '{' || c == '[') {
+            stack.push_back(c);
+        } else if (c == '}' || c == ']') {
+            if (stack.empty() || (c == '}' && stack.back() != '{') || (c == ']' && stack.back() != '['))
+                return false;
+            stack.pop_back();
+        }
+    }
+    return !inString && !escaped && stack.empty();
 }
 
 } // namespace
@@ -131,6 +161,8 @@ std::shared_ptr<NUITheme> NUITheme::createDefault() {
     theme->setFontSize("large", 20.0f);
     theme->setFontSize("title", 28.0f);
     theme->setFontSize("huge", 48.0f);
+
+    theme->loadedSuccessfully_ = true;
     
     return theme;
 }
@@ -140,6 +172,8 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
     // its default value. On any failure this default theme is returned (never
     // nullptr) and the failure is logged.
     auto theme = createDefault();
+    theme->loadedSuccessfully_ = false;
+    theme->clearOverrideTracking();
 
     std::ifstream file(filepath, std::ios::binary);
     if (!file.is_open()) {
@@ -161,11 +195,19 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
     std::string content(static_cast<size_t>(fileSize), '\0');
     file.read(content.data(), fileSize);
 
+    if (!hasCompleteJSONStructure(content)) {
+        Aestra::Log::error("[NUITheme] Theme file '" + filepath +
+                           "' has incomplete JSON structure — using default theme");
+        return theme;
+    }
+
     Aestra::JSON root = Aestra::JSON::parse(content);
     if (!root.isObject()) {
         Aestra::Log::error("[NUITheme] Theme file '" + filepath + "' is not a valid JSON object — using default theme");
         return theme;
     }
+
+    theme->loadedSuccessfully_ = true;
 
     int applied = 0;
     int skipped = 0;
@@ -251,6 +293,11 @@ std::shared_ptr<NUITheme> NUITheme::loadFromFile(const std::string& filepath) {
 
 void NUITheme::setColor(const std::string& name, const NUIColor& color) {
     colors_[name] = color;
+    colorOverrides_.insert(name);
+}
+
+bool NUITheme::hasColorOverride(const std::string& name) const {
+    return colorOverrides_.find(name) != colorOverrides_.end();
 }
 
 NUIColor NUITheme::getColor(const std::string& name, const NUIColor& defaultColor) const {
@@ -267,6 +314,11 @@ NUIColor NUITheme::getColor(const std::string& name, const NUIColor& defaultColo
 
 void NUITheme::setDimension(const std::string& name, float value) {
     dimensions_[name] = value;
+    dimensionOverrides_.insert(name);
+}
+
+bool NUITheme::hasDimensionOverride(const std::string& name) const {
+    return dimensionOverrides_.find(name) != dimensionOverrides_.end();
 }
 
 float NUITheme::getDimension(const std::string& name, float defaultValue) const {
@@ -283,6 +335,11 @@ float NUITheme::getDimension(const std::string& name, float defaultValue) const 
 
 void NUITheme::setEffect(const std::string& name, float value) {
     effects_[name] = value;
+    effectOverrides_.insert(name);
+}
+
+bool NUITheme::hasEffectOverride(const std::string& name) const {
+    return effectOverrides_.find(name) != effectOverrides_.end();
 }
 
 float NUITheme::getEffect(const std::string& name, float defaultValue) const {
@@ -299,6 +356,11 @@ float NUITheme::getEffect(const std::string& name, float defaultValue) const {
 
 void NUITheme::setFontSize(const std::string& name, float size) {
     fontSizes_[name] = size;
+    fontSizeOverrides_.insert(name);
+}
+
+bool NUITheme::hasFontSizeOverride(const std::string& name) const {
+    return fontSizeOverrides_.find(name) != fontSizeOverrides_.end();
 }
 
 float NUITheme::getFontSize(const std::string& name, float defaultSize) const {
@@ -307,6 +369,13 @@ float NUITheme::getFontSize(const std::string& name, float defaultSize) const {
         return it->second;
     }
     return defaultSize;
+}
+
+void NUITheme::clearOverrideTracking() {
+    colorOverrides_.clear();
+    dimensionOverrides_.clear();
+    effectOverrides_.clear();
+    fontSizeOverrides_.clear();
 }
 
 // TODO: Implement font creation when NUIFont supports copying

--- a/AestraUI/Core/NUITheme.h
+++ b/AestraUI/Core/NUITheme.h
@@ -4,6 +4,7 @@
 #include "NUITypes.h"
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <memory>
 
 namespace AestraUI {
@@ -32,6 +33,13 @@ public:
      * Load a theme from a JSON file.
      */
     static std::shared_ptr<NUITheme> loadFromFile(const std::string& filepath);
+
+    /** True when this instance was created from a valid JSON object. */
+    bool loadedSuccessfully() const { return loadedSuccessfully_; }
+    bool hasColorOverride(const std::string& name) const;
+    bool hasDimensionOverride(const std::string& name) const;
+    bool hasEffectOverride(const std::string& name) const;
+    bool hasFontSizeOverride(const std::string& name) const;
     
     // ========================================================================
     // Colors
@@ -95,10 +103,17 @@ public:
     // NUIFont getDefaultFont() const;
     
 private:
+    void clearOverrideTracking();
+
     std::unordered_map<std::string, NUIColor> colors_;
     std::unordered_map<std::string, float> dimensions_;
     std::unordered_map<std::string, float> effects_;
     std::unordered_map<std::string, float> fontSizes_;
+    std::unordered_set<std::string> colorOverrides_;
+    std::unordered_set<std::string> dimensionOverrides_;
+    std::unordered_set<std::string> effectOverrides_;
+    std::unordered_set<std::string> fontSizeOverrides_;
+    bool loadedSuccessfully_ = false;
 };
 
 } // namespace AestraUI

--- a/AestraUI/Core/NUIThemeSystem.cpp
+++ b/AestraUI/Core/NUIThemeSystem.cpp
@@ -1,9 +1,191 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUIThemeSystem.h"
+#include "NUITheme.h"
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 namespace AestraUI {
+
+namespace {
+
+void applyJSONThemeOverrides(const NUITheme& source, NUIThemeProperties& target) {
+    const auto color = [&](const char* name, NUIColor& value) {
+        if (source.hasColorOverride(name))
+            value = source.getColor(name, value);
+    };
+
+    color("appBackground", target.backgroundPrimary);
+    color("workspaceBackground", target.backgroundPrimary);
+    color("backgroundPrimary", target.backgroundPrimary);
+    color("recessedPanel", target.backgroundSecondary);
+    color("backgroundSecondary", target.backgroundSecondary);
+    color("elevatedPanel", target.surfaceTertiary);
+    color("surfaceTertiary", target.surfaceTertiary);
+    color("surfaceRaised", target.surfaceRaised);
+    color("background", target.background);
+    color("surface", target.surface);
+    color("surfaceVariant", target.surfaceVariant);
+
+    color("primary", target.primary);
+    color("accent", target.primary);
+    color("primaryHover", target.primaryHover);
+    color("accentHover", target.primaryHover);
+    color("primaryPressed", target.primaryPressed);
+    color("accentPressed", target.primaryPressed);
+    color("secondary", target.secondary);
+    color("accentCyan", target.accentCyan);
+    color("accentMagenta", target.accentMagenta);
+    color("accentLime", target.accentLime);
+    color("accentPrimary", target.accentPrimary);
+    color("accentSecondary", target.accentSecondary);
+
+    color("success", target.success);
+    color("warning", target.warning);
+    color("error", target.error);
+    color("info", target.info);
+    color("text", target.textPrimary);
+    color("textPrimary", target.textPrimary);
+    color("textSecondary", target.textSecondary);
+    color("textMuted", target.textMuted);
+    color("textDisabled", target.textDisabled);
+    color("textLink", target.textLink);
+    color("textCritical", target.textCritical);
+    color("textOnPrimary", target.textOnPrimary);
+    color("textOnSecondary", target.textOnSecondary);
+
+    color("border", target.border);
+    color("borderSubtle", target.borderSubtle);
+    color("borderStrong", target.borderStrong);
+    color("borderActive", target.borderActive);
+    color("divider", target.divider);
+    color("selection", target.selected);
+    color("selected", target.selected);
+    color("hover", target.hover);
+    color("pressed", target.pressed);
+    color("focused", target.focused);
+    color("disabled", target.disabled);
+    color("focusRing", target.focusRing);
+    color("armed", target.armed);
+    color("muted", target.muted);
+    color("soloed", target.soloed);
+    color("bypassed", target.bypassed);
+    color("dragTarget", target.dragTarget);
+
+    color("controlBackground", target.buttonBgDefault);
+    color("buttonBgDefault", target.buttonBgDefault);
+    color("controlHover", target.buttonBgHover);
+    color("buttonBgHover", target.buttonBgHover);
+    color("controlPressed", target.buttonBgActive);
+    color("buttonBgActive", target.buttonBgActive);
+    color("buttonTextDefault", target.buttonTextDefault);
+    color("buttonTextActive", target.buttonTextActive);
+    color("toggleDefault", target.toggleDefault);
+    color("toggleHover", target.toggleHover);
+    color("toggleActive", target.toggleActive);
+    color("inputBackground", target.inputBgDefault);
+    color("inputBgDefault", target.inputBgDefault);
+    color("inputBgHover", target.inputBgHover);
+    color("inputBorderFocus", target.inputBorderFocus);
+    color("sliderTrack", target.sliderTrack);
+    color("sliderHandle", target.sliderHandle);
+    color("sliderHandleHover", target.sliderHandleHover);
+    color("sliderHandlePressed", target.sliderHandlePressed);
+
+    color("shadow", target.shadow);
+    color("overlay", target.overlay);
+    color("backdrop", target.backdrop);
+    color("meterSafe", target.meterSafe);
+    color("meterWarn", target.meterWarn);
+    color("meterCrit", target.meterCrit);
+    color("meterBackground", target.meterBackground);
+    color("meterActive", target.meterActive);
+    color("gridMajor", target.gridMajor);
+    color("gridMinor", target.gridMinor);
+    color("mixerStripBg", target.mixerStripBg);
+    color("mixerMasterBorder", target.mixerMasterBorder);
+
+    const auto hasColor = [&](const char* primaryName, const char* alias = nullptr) {
+        return source.hasColorOverride(primaryName) || (alias && source.hasColorOverride(alias));
+    };
+    if (hasColor("primary", "accent")) {
+        if (!hasColor("primaryHover", "accentHover"))
+            target.primaryHover = target.primary.lightened(0.10f);
+        if (!hasColor("primaryPressed", "accentPressed"))
+            target.primaryPressed = target.primary.darkened(0.10f);
+        if (!hasColor("accentPrimary")) target.accentPrimary = target.primary;
+        if (!hasColor("borderActive")) target.borderActive = target.primary;
+        if (!hasColor("focusRing")) target.focusRing = target.primary.withAlpha(0.86f);
+        if (!hasColor("selection", "selected")) target.selected = target.primary.withAlpha(0.18f);
+        if (!hasColor("dragTarget")) target.dragTarget = target.primary.withAlpha(0.28f);
+        if (!hasColor("textLink")) target.textLink = target.primary;
+        if (!hasColor("toggleActive")) target.toggleActive = target.primary.withAlpha(0.85f);
+        if (!hasColor("inputBorderFocus")) target.inputBorderFocus = target.focusRing;
+        if (!hasColor("sliderHandle")) target.sliderHandle = target.primary;
+        if (!hasColor("sliderHandleHover")) target.sliderHandleHover = target.primaryHover;
+        if (!hasColor("sliderHandlePressed")) target.sliderHandlePressed = target.primaryPressed;
+    }
+    if (hasColor("warning")) {
+        if (!hasColor("muted")) target.muted = target.warning;
+        if (!hasColor("meterWarn")) target.meterWarn = target.warning;
+    }
+    if (hasColor("error")) {
+        if (!hasColor("armed")) target.armed = target.error;
+        if (!hasColor("meterCrit")) target.meterCrit = target.error;
+        if (!hasColor("textCritical")) target.textCritical = target.error;
+    }
+    if (hasColor("info") && !hasColor("soloed"))
+        target.soloed = target.info;
+
+    const auto dimension = [&](const char* name, float& value) {
+        if (source.hasDimensionOverride(name))
+            value = source.getDimension(name, value);
+    };
+    dimension("spacingXS", target.spacingXS);
+    dimension("spacingS", target.spacingS);
+    dimension("spacingM", target.spacingM);
+    dimension("spacingL", target.spacingL);
+    dimension("spacingXL", target.spacingXL);
+    dimension("spacingXXL", target.spacingXXL);
+    dimension("borderRadiusSmall", target.radiusS);
+    dimension("borderRadius", target.radiusM);
+    dimension("borderRadiusLarge", target.radiusL);
+    dimension("compactControlHeight", target.layout.compactControlHeight);
+    dimension("standardControlHeight", target.layout.standardControlHeight);
+    dimension("dialogActionHeight", target.layout.dialogActionHeight);
+    dimension("standardRowHeight", target.layout.standardRowHeight);
+    dimension("compactMenuRowHeight", target.layout.compactMenuRowHeight);
+    dimension("standardMenuRowHeight", target.layout.standardMenuRowHeight);
+    dimension("panelHeaderHeight", target.layout.panelHeaderHeight);
+    dimension("sectionHeaderHeight", target.layout.sectionHeaderHeight);
+    dimension("standardIconSize", target.layout.standardIconSize);
+    dimension("minimumHitArea", target.layout.minimumHitArea);
+    dimension("dividerWidth", target.layout.dividerWidth);
+    dimension("panelPadding", target.layout.panelPadding);
+    dimension("dialogPadding", target.layout.dialogPadding);
+    dimension("fileBrowserWidth", target.layout.fileBrowserWidth);
+    dimension("trackControlsWidth", target.layout.trackControlsWidth);
+    dimension("trackHeight", target.layout.trackHeight);
+    dimension("transportBarHeight", target.layout.transportBarHeight);
+
+    const auto fontSize = [&](const char* name, float& value) {
+        if (source.hasFontSizeOverride(name))
+            value = source.getFontSize(name, value);
+    };
+    fontSize("micro", target.fontSizeMicro);
+    fontSize("xs", target.fontSizeXS);
+    fontSize("small", target.fontSizeS);
+    fontSize("s", target.fontSizeS);
+    fontSize("normal", target.fontSizeM);
+    fontSize("m", target.fontSizeM);
+    fontSize("large", target.fontSizeL);
+    fontSize("l", target.fontSizeL);
+    fontSize("xl", target.fontSizeXL);
+    fontSize("display-s", target.fontSizeDisplayS);
+    fontSize("display-l", target.fontSizeDisplayL);
+}
+
+} // namespace
 
 NUIResolvedControlColors resolveControlColors(const NUIThemeProperties& theme,
                                               const NUIControlVisualState& state) {
@@ -81,15 +263,39 @@ void NUIThemeManager::setThemeVariant(NUIThemeVariant variant) {
 
 void NUIThemeManager::setCustomTheme(const std::string& name, const NUIThemeProperties& properties) {
     themes_[name] = properties;
+    if (activeTheme_ == name)
+        notifyThemeChanged();
 }
 
-void NUIThemeManager::setActiveTheme(const std::string& name) {
-    if (themes_.find(name) != themes_.end()) {
-        activeTheme_ = name;
-        if (onThemeChanged_) {
-            onThemeChanged_(getCurrentTheme());
-        }
-    }
+bool NUIThemeManager::loadThemeFromFile(const std::string& name, const std::string& filepath,
+                                        const std::string& baseTheme) {
+    const auto base = themes_.find(baseTheme);
+    if (name.empty() || base == themes_.end())
+        return false;
+
+    auto loaded = NUITheme::loadFromFile(filepath);
+    if (!loaded || !loaded->loadedSuccessfully())
+        return false;
+
+    NUIThemeProperties properties = base->second;
+    applyJSONThemeOverrides(*loaded, properties);
+    setCustomTheme(name, properties);
+    return true;
+}
+
+bool NUIThemeManager::setActiveTheme(const std::string& name) {
+    if (!hasTheme(name))
+        return false;
+    if (activeTheme_ == name)
+        return true;
+
+    activeTheme_ = name;
+    notifyThemeChanged();
+    return true;
+}
+
+bool NUIThemeManager::hasTheme(const std::string& name) const {
+    return themes_.find(name) != themes_.end();
 }
 
 const NUIThemeProperties& NUIThemeManager::getCurrentTheme() const {
@@ -105,46 +311,11 @@ NUIThemeProperties& NUIThemeManager::getCurrentThemeMutable() {
 }
 
 void NUIThemeManager::switchTheme(const std::string& name, float durationMs) {
-    if (themes_.find(name) == themes_.end()) return;
-    
-    if (durationMs <= 0.0f) {
-        setActiveTheme(name);
-        return;
-    }
-    
-    isTransitioning_ = true;
-    transitionFromTheme_ = getCurrentTheme();
-    transitionToTheme_ = themes_[name];
-    
-    themeTransitionAnimation_ = std::make_shared<NUIAnimation>();
-    themeTransitionAnimation_->setDuration(durationMs);
-    themeTransitionAnimation_->setEasing(NUIEasingType::EaseOutCubic);
-    themeTransitionAnimation_->setStartValue(0.0f);
-    themeTransitionAnimation_->setEndValue(1.0f);
-    
-    themeTransitionAnimation_->setOnUpdate([this](float progress) {
-        // Interpolate between themes
-        NUIThemeProperties currentTheme;
-        currentTheme.background = NUIColor::lerpHSL(transitionFromTheme_.background, transitionToTheme_.background, progress);
-        currentTheme.surface = NUIColor::lerpHSL(transitionFromTheme_.surface, transitionToTheme_.surface, progress);
-        currentTheme.primary = NUIColor::lerpHSL(transitionFromTheme_.primary, transitionToTheme_.primary, progress);
-        // ... interpolate other properties as needed
-        
-        if (onThemeChanged_) {
-            onThemeChanged_(currentTheme);
-        }
-    });
-    
-    themeTransitionAnimation_->setOnComplete([this]() {
-        isTransitioning_ = false;
-        // Note: activeTheme_ should be set before calling switchTheme
-        if (onThemeChanged_) {
-            onThemeChanged_(getCurrentTheme());
-        }
-    });
-    
-    themeTransitionAnimation_->start();
-    NUIAnimationManager::getInstance().addAnimation(themeTransitionAnimation_);
+    (void)durationMs;
+    // A partial interpolated theme is visually and semantically unsafe. Theme
+    // activation stays atomic until every semantic property has a defined
+    // transition rule.
+    setActiveTheme(name);
 }
 
 void NUIThemeManager::switchThemeVariant(NUIThemeVariant variant, float durationMs) {
@@ -167,6 +338,37 @@ void NUIThemeManager::switchThemeVariant(NUIThemeVariant variant, float duration
 
 void NUIThemeManager::setOnThemeChanged(std::function<void(const NUIThemeProperties&)> callback) {
     onThemeChanged_ = callback;
+}
+
+NUIThemeManager::ThemeSubscriptionId NUIThemeManager::subscribeToThemeChanges(
+    std::function<void(const NUIThemeProperties&)> callback) {
+    if (!callback)
+        return 0;
+    const ThemeSubscriptionId id = nextSubscriptionId_++;
+    themeSubscribers_.emplace(id, std::move(callback));
+    return id;
+}
+
+void NUIThemeManager::unsubscribeFromThemeChanges(ThemeSubscriptionId subscriptionId) {
+    if (subscriptionId != 0)
+        themeSubscribers_.erase(subscriptionId);
+}
+
+void NUIThemeManager::notifyThemeChanged() {
+    const auto& theme = getCurrentTheme();
+    if (onThemeChanged_)
+        onThemeChanged_(theme);
+
+    // Listeners may unsubscribe while handling a change. Copying callbacks is
+    // bounded, user-driven UI work and keeps notification lifetime-safe.
+    std::vector<std::function<void(const NUIThemeProperties&)>> callbacks;
+    callbacks.reserve(themeSubscribers_.size());
+    for (const auto& [id, callback] : themeSubscribers_) {
+        (void)id;
+        callbacks.push_back(callback);
+    }
+    for (const auto& callback : callbacks)
+        callback(theme);
 }
 
 NUIColor NUIThemeManager::getColor(const std::string& colorName) const {
@@ -310,6 +512,41 @@ NUIColor NUIThemeManager::getColor(const std::string& colorName) const {
     if (colorName == "mixerMasterBorder") return theme.mixerMasterBorder;
     
     // === Arsenal / Step Sequencer Tokens ===
+    // Timeline work bed + track chrome: derived per theme polarity. Dark
+    // themes keep the owner-directed pure-black grid and near-black chrome;
+    // light themes get a recessed light bed and clean white chrome instead.
+    if (colorName == "timelineBed" || colorName == "trackChrome") {
+        const float bgLuma = 0.2126f * theme.backgroundPrimary.r +
+                             0.7152f * theme.backgroundPrimary.g +
+                             0.0722f * theme.backgroundPrimary.b;
+        const bool darkTheme = bgLuma < 0.5f;
+        if (colorName == "timelineBed") {
+            return darkTheme ? NUIColor::black()
+                             : NUIColor(0.936f, 0.938f, 0.942f, 1.0f);
+        }
+        return darkTheme ? NUIColor(0.038f, 0.039f, 0.045f, 1.0f)
+                         : theme.backgroundSecondary;
+    }
+    // Plugin-editor internals share one polarity-aware language: cards,
+    // display wells, and control fills that are near-black on dark themes
+    // and clean light surfaces on light ones. Identity accents stay per-editor.
+    if (colorName == "editorCard" || colorName == "editorWell" || colorName == "editorControl") {
+        const float bgLuma = 0.2126f * theme.backgroundPrimary.r +
+                             0.7152f * theme.backgroundPrimary.g +
+                             0.0722f * theme.backgroundPrimary.b;
+        const bool darkTheme = bgLuma < 0.5f;
+        if (colorName == "editorCard") {
+            return darkTheme ? NUIColor(0.084f, 0.084f, 0.084f, 0.95f)
+                             : NUIColor(0.962f, 0.963f, 0.968f, 0.97f);
+        }
+        if (colorName == "editorWell") {
+            return darkTheme ? NUIColor(0.010f, 0.010f, 0.014f, 0.98f)
+                             : NUIColor(0.915f, 0.918f, 0.925f, 0.98f);
+        }
+        return darkTheme ? NUIColor(0.068f, 0.068f, 0.068f, 0.90f)
+                         : NUIColor(0.935f, 0.937f, 0.943f, 0.92f);
+    }
+
     // Step Grid Colors
     if (colorName == "stepActive") return theme.primary;                              // Active step (on)
     if (colorName == "stepInactive") return theme.surfaceRaised;                      // Inactive step (off)
@@ -536,16 +773,25 @@ void NUIThemeManager::updateSystemTheme() {
 }
 
 // NUIThemedComponent Implementation
+NUIThemedComponent::~NUIThemedComponent() {
+    unregisterFromThemeUpdates();
+}
+
 void NUIThemedComponent::registerForThemeUpdates() {
     if (!isThemeRegistered_) {
-        // TODO: Register with theme manager
+        themeSubscriptionId_ = NUIThemeManager::getInstance().subscribeToThemeChanges(
+            [this](const NUIThemeProperties& theme) {
+                applyTheme(theme);
+                onThemeChanged(theme);
+            });
         isThemeRegistered_ = true;
     }
 }
 
 void NUIThemedComponent::unregisterFromThemeUpdates() {
     if (isThemeRegistered_) {
-        // TODO: Unregister from theme manager
+        NUIThemeManager::getInstance().unsubscribeFromThemeChanges(themeSubscriptionId_);
+        themeSubscriptionId_ = 0;
         isThemeRegistered_ = false;
     }
 }
@@ -722,7 +968,7 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.backgroundPrimary = theme.background;
     theme.backgroundSecondary = theme.surface;
     theme.surfaceTertiary = theme.surfaceVariant;
-    theme.surfaceRaised = NUIColor(0.92f, 0.92f, 0.93f, 1.0f);
+    theme.surfaceRaised = NUIColor(0.955f, 0.957f, 0.962f, 1.0f);
     theme.primary = NUIColor(0.2f, 0.4f, 0.8f, 1.0f);
     theme.primaryVariant = NUIColor(0.1f, 0.3f, 0.7f, 1.0f);
     theme.primaryHover = NUIColor(0.26f, 0.46f, 0.86f, 1.0f);
@@ -740,10 +986,10 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.accentSecondary = theme.secondary;
     
     // Text colors
-    theme.textPrimary = NUIColor(0.1f, 0.1f, 0.1f, 1.0f);
-    theme.textSecondary = NUIColor(0.4f, 0.4f, 0.4f, 1.0f);
-    theme.textMuted = NUIColor(0.48f, 0.48f, 0.48f, 1.0f);
-    theme.textDisabled = NUIColor(0.6f, 0.6f, 0.6f, 1.0f);
+    theme.textPrimary = NUIColor(0.08f, 0.08f, 0.09f, 1.0f);
+    theme.textSecondary = NUIColor(0.26f, 0.26f, 0.28f, 1.0f);
+    theme.textMuted = NUIColor(0.38f, 0.38f, 0.40f, 1.0f);
+    theme.textDisabled = NUIColor(0.55f, 0.55f, 0.57f, 1.0f);
     theme.textLink = theme.primary;
     theme.textCritical = theme.error;
     theme.textOnPrimary = NUIColor::white();
@@ -772,9 +1018,9 @@ NUIThemeProperties NUIThemePresets::createAestraLight() {
     theme.highlightGlow = theme.primary.withAlpha(0.14f);
     
     // Borders
-    theme.border = NUIColor(0.8f, 0.8f, 0.8f, 1.0f);
+    theme.border = NUIColor(0.78f, 0.78f, 0.80f, 1.0f);
     theme.borderSubtle = theme.border.withAlpha(0.72f);
-    theme.borderStrong = NUIColor(0.68f, 0.68f, 0.70f, 1.0f);
+    theme.borderStrong = NUIColor(0.62f, 0.62f, 0.65f, 1.0f);
     theme.borderActive = theme.primary;
     theme.divider = NUIColor(0.9f, 0.9f, 0.9f, 1.0f);
     theme.outline = NUIColor(0.7f, 0.7f, 0.7f, 1.0f);
@@ -833,7 +1079,67 @@ NUIThemeProperties NUIThemePresets::createFluentLight() { return createAestraLig
 NUIThemeProperties NUIThemePresets::createFluentDark() { return createAestraDark(); }
 NUIThemeProperties NUIThemePresets::createCupertinoLight() { return createAestraLight(); }
 NUIThemeProperties NUIThemePresets::createCupertinoDark() { return createAestraDark(); }
-NUIThemeProperties NUIThemePresets::createHighContrastLight() { return createAestraLight(); }
-NUIThemeProperties NUIThemePresets::createHighContrastDark() { return createAestraDark(); }
+NUIThemeProperties NUIThemePresets::createHighContrastLight() {
+    auto theme = createAestraLight();
+    theme.backgroundPrimary = NUIColor::white();
+    theme.backgroundSecondary = NUIColor::fromHex(0xf5f5f5);
+    theme.surfaceTertiary = NUIColor::fromHex(0xebebeb);
+    theme.surfaceRaised = NUIColor::fromHex(0xdedede);
+    theme.background = theme.backgroundPrimary;
+    theme.surface = theme.backgroundSecondary;
+    theme.surfaceVariant = theme.surfaceTertiary;
+    theme.textPrimary = NUIColor::black();
+    theme.textSecondary = NUIColor::fromHex(0x303030);
+    theme.textMuted = NUIColor::fromHex(0x4a4a4a);
+    theme.borderSubtle = NUIColor::fromHex(0x777777);
+    theme.borderStrong = NUIColor::black();
+    theme.border = theme.borderStrong;
+    theme.divider = theme.borderSubtle;
+    theme.focusRing = theme.primary;
+    return theme;
+}
+
+NUIThemeProperties NUIThemePresets::createHighContrastDark() {
+    auto theme = createAestraDark();
+    theme.backgroundPrimary = NUIColor::black();
+    theme.backgroundSecondary = NUIColor::fromHex(0x0b0b0b);
+    theme.surfaceTertiary = NUIColor::fromHex(0x151515);
+    theme.surfaceRaised = NUIColor::fromHex(0x202020);
+    theme.background = theme.backgroundPrimary;
+    theme.surface = theme.backgroundSecondary;
+    theme.surfaceVariant = theme.surfaceTertiary;
+    theme.primary = NUIColor::fromHex(0xa78bfa);
+    theme.primaryHover = NUIColor::fromHex(0xc4b5fd);
+    theme.primaryPressed = NUIColor::fromHex(0x8b5cf6);
+    theme.accentPrimary = theme.primary;
+    theme.textOnPrimary = NUIColor::black();
+    theme.onPrimary = theme.textOnPrimary;
+    theme.textPrimary = NUIColor::white();
+    theme.textSecondary = NUIColor::white().withAlpha(0.78f);
+    theme.textMuted = NUIColor::white().withAlpha(0.62f);
+    theme.textDisabled = NUIColor::white().withAlpha(0.42f);
+    theme.borderSubtle = NUIColor::fromHex(0x666666);
+    theme.borderStrong = NUIColor::fromHex(0xb0b0b0);
+    theme.border = theme.borderStrong;
+    theme.divider = theme.borderSubtle;
+    theme.borderActive = theme.primary;
+    theme.focusRing = theme.primary;
+    theme.selected = theme.primary.withAlpha(0.34f);
+    theme.hover = NUIColor::white().withAlpha(0.13f);
+    theme.pressed = NUIColor::white().withAlpha(0.20f);
+    theme.buttonBgDefault = theme.surfaceTertiary;
+    theme.buttonBgHover = theme.surfaceRaised;
+    theme.buttonBgActive = theme.selected;
+    theme.inputBgDefault = theme.backgroundSecondary;
+    theme.inputBgHover = theme.surfaceTertiary;
+    theme.inputBorderFocus = theme.focusRing;
+    theme.sliderTrack = theme.borderSubtle;
+    theme.sliderHandle = theme.primary;
+    theme.sliderHandleHover = theme.primaryHover;
+    theme.sliderHandlePressed = theme.primaryPressed;
+    theme.gridMajor = NUIColor::white().withAlpha(0.24f);
+    theme.gridMinor = NUIColor::white().withAlpha(0.12f);
+    return theme;
+}
 
 } // namespace AestraUI

--- a/AestraUI/Core/NUIThemeSystem.h
+++ b/AestraUI/Core/NUIThemeSystem.h
@@ -5,7 +5,11 @@
 #include "NUIAnimation.h"
 #include <unordered_map>
 #include <string>
+#include <algorithm>
 #include <memory>
+#include <cstdint>
+#include <functional>
+#include <map>
 
 namespace AestraUI {
 
@@ -298,6 +302,8 @@ NUIResolvedControlColors resolveControlColors(const NUIThemeProperties& theme,
 // Theme manager
 class NUIThemeManager {
 public:
+    using ThemeSubscriptionId = std::uint64_t;
+
     static NUIThemeManager& getInstance();
     
     // Theme management
@@ -305,7 +311,10 @@ public:
     NUIThemeVariant getThemeVariant() const { return currentVariant_; }
     
     void setCustomTheme(const std::string& name, const NUIThemeProperties& properties);
-    void setActiveTheme(const std::string& name);
+    bool loadThemeFromFile(const std::string& name, const std::string& filepath,
+                           const std::string& baseTheme = "Aestra-dark");
+    bool setActiveTheme(const std::string& name);
+    bool hasTheme(const std::string& name) const;
     std::string getActiveTheme() const { return activeTheme_; }
     
     // Theme access
@@ -317,6 +326,10 @@ public:
     void switchThemeVariant(NUIThemeVariant variant, float durationMs = 300.0f);
     
     // Theme callbacks
+    ThemeSubscriptionId subscribeToThemeChanges(std::function<void(const NUIThemeProperties&)> callback);
+    void unsubscribeFromThemeChanges(ThemeSubscriptionId subscriptionId);
+    // Compatibility callback slot. New owners should use subscriptions so they
+    // do not replace one another.
     void setOnThemeChanged(std::function<void(const NUIThemeProperties&)> callback);
     
     // Utility methods
@@ -347,11 +360,14 @@ private:
     NUIThemeManager();
     void initializeDefaultThemes();
     void updateSystemTheme();
+    void notifyThemeChanged();
     
     NUIThemeVariant currentVariant_;
     std::string activeTheme_;
     std::unordered_map<std::string, NUIThemeProperties> themes_;
     std::function<void(const NUIThemeProperties&)> onThemeChanged_;
+    std::map<ThemeSubscriptionId, std::function<void(const NUIThemeProperties&)>> themeSubscribers_;
+    ThemeSubscriptionId nextSubscriptionId_ = 1;
     
     // Animation for theme switching
     std::shared_ptr<NUIAnimation> themeTransitionAnimation_;
@@ -363,7 +379,7 @@ private:
 // Theme-aware component base
 class NUIThemedComponent {
 public:
-    virtual ~NUIThemedComponent() = default;
+    virtual ~NUIThemedComponent();
     
     // Theme integration
     virtual void onThemeChanged(const NUIThemeProperties& theme) {}
@@ -383,6 +399,7 @@ protected:
     
 private:
     bool isThemeRegistered_ = false;
+    NUIThemeManager::ThemeSubscriptionId themeSubscriptionId_ = 0;
 };
 
 // Predefined theme presets
@@ -399,5 +416,41 @@ public:
     static NUIThemeProperties createHighContrastLight();
     static NUIThemeProperties createHighContrastDark();
 };
+
+// ---------------------------------------------------------------------------
+// Plugin-editor chrome helpers (polarity-aware neutrals)
+// ---------------------------------------------------------------------------
+
+/** True when the active theme is light (lights-on). */
+inline bool editorLightUi() {
+    const auto& bg = NUIThemeManager::getInstance().getCurrentTheme().backgroundPrimary;
+    return (0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b) >= 0.5f;
+}
+
+/**
+ * Map a plugin editor's dark neutral gray onto the active theme's polarity.
+ * Dark themes return the given gray untouched (editors keep their tuned
+ * near-blacks bit-for-bit); light themes mirror it onto the light-surface
+ * ramp, preserving the raised/recessed ordering (lighter = more raised).
+ */
+inline NUIColor editorNeutral(float darkGray, float alpha = 1.0f) {
+    if (!editorLightUi()) return NUIColor(darkGray, darkGray, darkGray, alpha);
+    const float g = std::min(0.905f + darkGray * 0.38f, 0.985f);
+    return NUIColor(g, g, g, alpha);
+}
+
+/** Tinted variant: dark themes keep the tuned color; light themes map its
+    luma onto the light ramp (the subtle tint reads as gray up there anyway). */
+inline NUIColor editorNeutral(const NUIColor& dark) {
+    if (!editorLightUi()) return dark;
+    const float luma = 0.2126f * dark.r + 0.7152f * dark.g + 0.0722f * dark.b;
+    const float g = std::min(0.905f + luma * 0.38f, 0.985f);
+    return NUIColor(g, g, g, dark.a);
+}
+
+/** The active theme's text ink — replaces hardcoded white overlays/labels. */
+inline NUIColor editorInk(float alpha = 1.0f) {
+    return NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(alpha);
+}
 
 } // namespace AestraUI

--- a/AestraUI/Graphics/NUIRenderer.h
+++ b/AestraUI/Graphics/NUIRenderer.h
@@ -85,6 +85,14 @@ public:
     /**
      * Set the current clip rectangle (scissor test).
      */
+    /**
+     * Compensate text weight for background polarity. Light glyphs on dark
+     * bloom (irradiation); dark glyphs on light do not, so text tuned on a
+     * dark theme reads thin in light mode. 1.0 = dark-theme tuning; values
+     * below 1.0 thicken strokes (light themes want ~0.86-0.92).
+     */
+    virtual void setTextContrast(float contrast) { (void)contrast; }
+
     virtual void setClipRect(const NUIRect& rect) = 0;
     
     /**

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -195,6 +195,8 @@ uniform bool uUseTexture;
 uniform vec2 uTextTexelSize;
 uniform float uTextSharpen;
 uniform float uTextGamma;
+uniform float uTextBold; // SDF edge-center shift; 0 = neutral, positive = bolder
+uniform float uTextAlphaLift; // exponent on text alpha; 1 = neutral, <1 lifts faded text
 uniform bool uOutputLinear;
 
 // Squircle SDF Implementation
@@ -256,13 +258,13 @@ void main() {
              float dist = texColor.r;
              float ddist = fwidth(dist);
              float edgeWidth = ddist * 0.7;
-             float center = 0.5 - smoothstep(0.1, 0.5, ddist) * 0.08; 
+             float center = 0.5 - smoothstep(0.1, 0.5, ddist) * 0.08 - uTextBold; 
              float alpha = smoothstep(center - edgeWidth, center + edgeWidth, dist);
-             color.a *= alpha;
+             color.a = pow(color.a, uTextAlphaLift) * alpha;
         } else if (primitiveID == 4) {
                // Bitmap text — atlas stores coverage in alpha channel.
                float coverage = pow(sampleTextCoverage(vTexCoord), uTextGamma);
-               color.a *= coverage;
+               color.a = pow(color.a, uTextAlphaLift) * coverage;
         } else {
              // Regular textured primitive
              color *= texColor;
@@ -2820,6 +2822,8 @@ void NUIRendererGL::drawTexture(const NUIRect& bounds, const unsigned char* rgba
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
+    glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -3124,6 +3128,8 @@ void NUIRendererGL::flush() {
     glUniform2f(primitiveShader_.textTexelSizeLoc, 0.0f, 0.0f);
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
+    glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
     // Note: opacity is already in vertex colors
     glUniform1i(primitiveShader_.primitiveTypeLoc, currentPrimitiveType_);
     // Default to no texturing; enable below if a texture is bound
@@ -3160,7 +3166,7 @@ void NUIRendererGL::flush() {
             const bool tinyAtlas = (currentTextureId_ == fontAtlasTextureIdXSmall_
                                     || currentTextureId_ == fontAtlasTextureIdSmall_);
             glUniform1f(primitiveShader_.textSharpenLoc, tinyAtlas ? 0.20f : 0.28f);
-            glUniform1f(primitiveShader_.textGammaLoc, tinyAtlas ? 0.74f : 0.93f);
+            glUniform1f(primitiveShader_.textGammaLoc, (tinyAtlas ? 0.74f : 0.93f) * textContrast_);
         }
     }
     
@@ -3245,6 +3251,8 @@ bool NUIRendererGL::loadShaders() {
     primitiveShader_.textTexelSizeLoc = glGetUniformLocation(primitiveShader_.id, "uTextTexelSize");
     primitiveShader_.textSharpenLoc = glGetUniformLocation(primitiveShader_.id, "uTextSharpen");
     primitiveShader_.textGammaLoc = glGetUniformLocation(primitiveShader_.id, "uTextGamma");
+    primitiveShader_.textBoldLoc = glGetUniformLocation(primitiveShader_.id, "uTextBold");
+    primitiveShader_.textAlphaLiftLoc = glGetUniformLocation(primitiveShader_.id, "uTextAlphaLift");
     primitiveShader_.outputLinearLoc = glGetUniformLocation(primitiveShader_.id, "uOutputLinear");
 
     

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -495,7 +495,7 @@ bool NUIRendererGL::initialize(int width, int height) {
 
     // Set initial state
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE); // Ensure we don't write to depth buffer in 2D mode
     glDisable(GL_CULL_FACE);
@@ -609,7 +609,7 @@ void NUIRendererGL::beginFrame() {
         glDisable(GL_FRAMEBUFFER_SRGB);
     }
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
     vertices_.clear();
     indices_.clear();
@@ -2542,7 +2542,7 @@ void NUIRendererGL::renderTextWithFont(const std::string& text, const NUIPoint& 
     // instead of the standard blend which gives: result = text * coverage^2 + bg * (1 - coverage)
     glBlendFunc(GL_ONE, GL_SRC_ALPHA);
     // Actually revert — pre-multiplied bleeds edges on dark backgrounds. Use standard.
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     
     // Pre-allocate vertex buffer space (4 vertices per glyph, 6 indices per glyph)
     // This avoids repeated vector resizing for large text blocks
@@ -2708,7 +2708,7 @@ void NUIRendererGL::renderTextWithFont(const std::string& text, const NUIPoint& 
     }
 
     // Restore blend func for non-text geometry
-    // glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // Already default
+    // glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA); // Already default
 }
 
 // ============================================================================
@@ -2823,7 +2823,7 @@ void NUIRendererGL::drawTexture(const NUIRect& bounds, const unsigned char* rgba
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
     glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
-    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.35f : 1.0f);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, texture);
@@ -3054,6 +3054,12 @@ uint32_t NUIRendererGL::getGLTextureId(uint32_t textureId) const {
     return it->second.glId;
 }
 
+// NOTE on blending: all default blend sites use glBlendFuncSeparate with
+// (ONE, ONE_MINUS_SRC_ALPHA) for the alpha channel. The classic
+// (SRC_ALPHA, ...) alpha blend squares coverage: text drawn at alpha a onto
+// an opaque cache texel left it at 1-a+a^2 < 1, so composites re-blended
+// glyphs against the surface behind the panel — invisible over dark themes,
+// a gray wash over light ones (and sub-1.0 backbuffer alpha for DWM).
 void NUIRendererGL::beginOffscreen(int width, int height) {
     // Offscreen caches render into linear GL_RGBA8 textures where
     // GL_FRAMEBUFFER_SRGB does NOT re-encode on write. The shader's
@@ -3129,7 +3135,7 @@ void NUIRendererGL::flush() {
     glUniform1f(primitiveShader_.textSharpenLoc, 0.0f);
     glUniform1f(primitiveShader_.textGammaLoc, 1.0f);
     glUniform1f(primitiveShader_.textBoldLoc, (1.0f - textContrast_) * 0.25f);
-    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.72f : 1.0f);
+    glUniform1f(primitiveShader_.textAlphaLiftLoc, textContrast_ < 1.0f ? 0.35f : 1.0f);
     // Note: opacity is already in vertex colors
     glUniform1i(primitiveShader_.primitiveTypeLoc, currentPrimitiveType_);
     // Default to no texturing; enable below if a texture is bound
@@ -3218,7 +3224,7 @@ bool NUIRendererGL::initializeGL() {
     
     // Enable blending for transparency
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     
     // OpenGL context should already be created by platform layer
     return true;

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.h
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.h
@@ -49,6 +49,7 @@ public:
     // ========================================================================
     
     void beginFrame() override;
+    void setTextContrast(float contrast) override { textContrast_ = contrast; }
     void endFrame() override;
     void clear(const NUIColor& color) override;
     
@@ -204,6 +205,8 @@ private:
         int32_t textTexelSizeLoc = -1;
         int32_t textSharpenLoc = -1;
         int32_t textGammaLoc = -1;
+        int32_t textBoldLoc = -1;
+        int32_t textAlphaLiftLoc = -1;
         int32_t outputLinearLoc = -1;
     };
     
@@ -312,6 +315,7 @@ private:
     bool scissorEnabled_ = false;
     bool debugTextBounds_ = false;
     bool framebufferSRGBEnabled_ = false;
+    float textContrast_ = 1.0f;
 
     
     // OpenGL objects

--- a/AestraUI/Helpers/TimelineGridRenderer.h
+++ b/AestraUI/Helpers/TimelineGridRenderer.h
@@ -36,7 +36,8 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
                                float gridEndX,
                                float scrollX,
                                float pixelsPerBeat,
-                               int beatsPerBar) {
+                               int beatsPerBar,
+                               const NUIColor& ink = NUIColor::white()) {
     const float gridWidth = std::max(0.0f, gridEndX - gridStartX);
     beatsPerBar = std::max(1, beatsPerBar);
     const float pixelsPerBar = pixelsPerBeat * static_cast<float>(beatsPerBar);
@@ -73,7 +74,7 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
             }
             if (rectWidth > 0.0f) {
                 renderer.fillRect(NUIRect(rectX, bounds.y, rectWidth, bounds.height),
-                                  NUIColor::white().withAlpha(alpha));
+                                  ink.withAlpha(alpha));
             }
         }
     };
@@ -91,7 +92,7 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
         renderer.drawLine(NUIPoint(x, bounds.y),
                           NUIPoint(x, bounds.bottom()),
                           1.0f,
-                          NUIColor::white().withAlpha(alpha));
+                          ink.withAlpha(alpha));
     };
     const float beatLineAlpha = lineAlpha(pixelsPerBeat);
     const float halfBeatLineAlpha = lineAlpha(pixelsPerBeat * 0.5f);

--- a/AestraUI/Widgets/AestraCompEditor.cpp
+++ b/AestraUI/Widgets/AestraCompEditor.cpp
@@ -16,11 +16,11 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 
-NUIColor insetBg() { return NUIColor(0.02f, 0.02f, 0.02f, 0.960f); }
-NUIColor curveBg() { return NUIColor(0.037f, 0.037f, 0.037f, 1.0f); }
+NUIColor insetBg() { return editorNeutral(0.02f, 0.960f); }
+NUIColor curveBg() { return editorNeutral(0.037f, 1.0f); }
 NUIColor amber() { return NUIColor(0.88f, 0.63f, 0.14f, 1.0f); }
 NUIColor purple() { return NUIColor(0.50f, 0.35f, 0.94f, 1.0f); }
-NUIColor dimText() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
+NUIColor dimText() { return editorInk(0.30f); }
 
 float levelToNorm(float linear) {
     const float db = linear > 1.0e-8f ? 20.0f * std::log10(linear) : -60.0f;
@@ -266,7 +266,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
     // Zone backgrounds — curve gets its own bg, stats + modes get a slightly darker treatment
     renderer.fillRoundedRect({curveLeft - 4.0f, b.y, curveW + 8.0f, b.height}, 6.0f, curveBg());
     renderer.fillRoundedRect({statsX - 4.0f, b.y, kStatsW + kModesW + kDividerW + kRightMargin + 8.0f, b.height},
-                             6.0f, NUIColor(0.014f, 0.014f, 0.014f, 0.92f));
+                             6.0f, editorNeutral(0.014f, 0.92f));
 
     renderer.strokeRoundedRect(b, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.05f));
     // Subtle top highlight
@@ -424,7 +424,7 @@ void AestraCompEditor::drawTransferCurve(NUIRenderer& renderer, NUIColor accent)
             renderer.drawTextCentered(pillLabels[i], r, 9.5f, NUIColor(1, 1, 1, 0.98f));
         } else {
             // Body — deep dark inset
-            renderer.fillRoundedRect(r, 5.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.90f));
+            renderer.fillRoundedRect(r, 5.0f, editorNeutral(0.018f, 0.90f));
             // Top inner shadow
             renderer.drawLine({r.x + 5.0f, r.y + 1.0f}, {r.x + r.width - 5.0f, r.y + 1.0f},
                               0.5f, NUIColor(0, 0, 0, 0.30f));
@@ -443,7 +443,7 @@ void AestraCompEditor::drawMeters(NUIRenderer& renderer, NUIColor accent) {
 
     auto drawMeter = [&](float x, const char* label, float norm, NUIColor color) {
         const NUIRect meterBounds(x, b.y, thirdW, b.height);
-        renderer.fillRoundedRect(meterBounds, 5.0f, NUIColor(0.008f, 0.008f, 0.008f, 1.0f));
+        renderer.fillRoundedRect(meterBounds, 5.0f, editorNeutral(0.008f, 1.0f));
         renderer.strokeRoundedRect(meterBounds, 5.0f, 1.0f, NUIColor(1, 1, 1, 0.055f));
 
         // Fill
@@ -478,7 +478,7 @@ void AestraCompEditor::drawControl(NUIRenderer& renderer, const KnobControl& con
 
     // Knob cell background + border
     const NUIColor cellBg(0.035f, 0.035f, 0.040f, 0.96f);
-    const NUIColor cellBorder = prim ? NUIColor(0.18f, 0.13f, 0.28f, 1.0f) : NUIColor(0.118f, 0.118f, 0.133f, 1.0f);
+    const NUIColor cellBorder = prim ? NUIColor(0.18f, 0.13f, 0.28f, 1.0f) : editorNeutral(NUIColor(0.118f, 0.118f, 0.133f, 1.0f));
     renderer.fillRoundedRect(control.bounds, 8.0f, cellBg);
     renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f, cellBorder);
     // Subtle top highlight on primary cells
@@ -517,14 +517,14 @@ void AestraCompEditor::drawControl(NUIRenderer& renderer, const KnobControl& con
 
     // Label (top of cell) — spec: rgba(255,255,255,0.5), 9px
     renderer.drawTextCentered(control.label, {control.bounds.x, control.bounds.y + 2.0f, control.bounds.width, 12.0f},
-                              9.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.50f));
+                              9.0f, editorInk(0.50f));
 
     // Value (bottom of cell) — primary: muted lavender #9b8fcc, utility: spec rgba(255,255,255,0.85)
     const float valueY = prim ? control.bounds.bottom() - 18.0f
                               : knobRect.bottom() + 4.0f;
     const NUIColor valueColor = prim
         ? NUIColor(0.608f, 0.561f, 0.800f, 1.0f)   // #9b8fcc
-        : NUIColor(1.0f, 1.0f, 1.0f, 0.85f);        // rgba(255,255,255,0.85)
+        : editorInk(0.85f);        // rgba(255,255,255,0.85)
     renderer.drawTextCentered(valueText(control.paramId),
                               {control.bounds.x, valueY, control.bounds.width, 14.0f},
                               11.0f, valueColor);
@@ -562,8 +562,8 @@ void AestraCompEditor::drawUtilityButtons(NUIRenderer& renderer, NUIColor accent
             renderer.strokeRoundedRect(btn.bounds, 5.0f, 1.0f, activeAccent.withAlpha(0.80f));
             renderer.drawTextCentered(btn.label, btn.bounds, 9.0f, NUIColor(1, 1, 1, 0.95f));
         } else {
-            const NUIColor bg = btn.hov ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
-                                        : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
+            const NUIColor bg = btn.hov ? editorNeutral(0.041f, 0.90f)
+                                        : editorNeutral(0.022f, 0.90f);
             renderer.fillRoundedRect(btn.bounds, 5.0f, bg);
             renderer.drawLine({btn.bounds.x + 5.0f, btn.bounds.y + 1.0f},
                               {btn.bounds.x + btn.bounds.width - 5.0f, btn.bounds.y + 1.0f},

--- a/AestraUI/Widgets/AestraDelayEditor.cpp
+++ b/AestraUI/Widgets/AestraDelayEditor.cpp
@@ -20,7 +20,7 @@ NUIColor cyanAccent() {
     return NUIColor(0.0f, 0.90f, 0.80f, 1.0f);
 }
 NUIColor cardBg() {
-    return NUIColor(0.084f, 0.084f, 0.084f, 0.95f);
+    return NUIThemeManager::getInstance().getColor("editorCard");
 }
 NUIRect offsetRect(const NUIRect& r, float dx, float dy) {
     return NUIRect(r.x + dx, r.y + dy, r.width, r.height);
@@ -267,10 +267,10 @@ void AestraDelayEditor::drawPillSwitches(NUIRenderer& renderer, float wx, float 
         const NUIRect groupLabelRect(outer.x - labelW, outer.y, labelW - 8.0f, outer.height);
         renderer.drawText(groupLabel, {groupLabelRect.x + 2.0f, groupLabelRect.y + 12.0f}, 9.0f,
                           theme.getColor("textSecondary").withAlpha(0.70f));
-        renderer.fillRoundedRect(outer, 9.0f, NUIColor(0.018f, 0.018f, 0.022f, 0.98f));
-        renderer.strokeRoundedRect(outer, 9.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.13f));
+        renderer.fillRoundedRect(outer, 9.0f, NUIThemeManager::getInstance().getColor("editorWell"));
+        renderer.strokeRoundedRect(outer, 9.0f, 1.0f, editorInk().withAlpha(0.13f));
         renderer.drawLine({right.x, outer.y + 7.0f}, {right.x, outer.bottom() - 7.0f}, 1.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, 0.10f));
+                          editorInk().withAlpha(0.10f));
         auto seg = [&](const NUIRect& rect, const char* label, bool active) {
             const NUIRect inset(rect.x + 3.0f, rect.y + 3.0f, rect.width - 6.0f, rect.height - 6.0f);
             if (active) {
@@ -294,7 +294,7 @@ void AestraDelayEditor::drawSectionFrame(NUIRenderer& renderer, const NUIRect& l
                                          const NUIColor& color, float wx, float wy) {
     auto& theme = NUIThemeManager::getInstance();
     const NUIRect rect = offsetRect(localRect, wx, wy);
-    renderer.fillRoundedRect(rect, 14.0f, NUIColor(0.020f, 0.020f, 0.024f, 0.98f));
+    renderer.fillRoundedRect(rect, 14.0f, NUIThemeManager::getInstance().getColor("editorWell"));
     renderer.strokeRoundedRect(rect, 14.0f, 1.5f, color.withAlpha(0.58f));
     renderer.fillRoundedRect({rect.x + 12.0f, rect.y + 12.0f, 4.0f, 16.0f}, 2.0f, color);
     renderer.drawText(title, {rect.x + 24.0f, rect.y + 14.0f}, 10.5f, theme.getColor("textPrimary").withAlpha(0.92f));
@@ -312,7 +312,7 @@ void AestraDelayEditor::drawEchoDisplay(NUIRenderer& renderer, float wx, float w
     const float stereo = m_instance->getParameter(Delay::kStereoShift) * 2.0f - 1.0f;
     const float modulation = m_instance->getParameter(Delay::kModDepth);
 
-    renderer.fillRoundedRect(rect, 10.0f, NUIColor(0.008f, 0.008f, 0.012f, 0.98f));
+    renderer.fillRoundedRect(rect, 10.0f, NUIThemeManager::getInstance().getColor("editorWell"));
     renderer.strokeRoundedRect(rect, 10.0f, 1.0f, cyanAccent().withAlpha(0.26f));
     renderer.drawText("ECHO PATH", {rect.x + 12.0f, rect.y + 9.0f}, 9.5f,
                       theme.getColor("textSecondary").withAlpha(0.82f));
@@ -382,7 +382,8 @@ void AestraDelayEditor::drawSyncPanel(NUIRenderer& renderer, float wx, float wy)
             renderer.fillRoundedRect(r, 6.0f, accent());
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textPrimary"));
         } else {
-            NUIColor fill = hovered ? NUIColor(0.099f, 0.099f, 0.099f, 0.92f) : NUIColor(0.068f, 0.068f, 0.068f, 0.90f);
+            NUIColor fill = NUIThemeManager::getInstance().getColor("editorControl");
+            if (hovered) fill = fill.lightened(0.03f);
             renderer.fillRoundedRect(r, 6.0f, fill);
             renderer.strokeRoundedRect(r, 6.0f, 1.0f, accent().withAlpha(0.32f));
             renderer.drawTextCentered(btn.label, r, 9.5f, theme.getColor("textSecondary").withAlpha(0.88f));
@@ -442,7 +443,7 @@ void AestraDelayEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, fl
     const float cy = knobRect.center().y;
     const float r = kKnobSize * 0.40f;
     renderer.fillCircle({cx, cy}, r + 7.0f, knobAccent.withAlpha(0.07f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, NUIThemeManager::getInstance().getColor("editorWell").withAlpha(0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, knobAccent.withAlpha(0.32f));
 
     const float sa = kPi * 0.75f;
@@ -469,7 +470,7 @@ void AestraDelayEditor::drawMixSlider(NUIRenderer& renderer, float wx, float wy)
     const float mix = m_instance ? m_instance->getParameter(Delay::kMix) : 0.0f;
     NUIRect mixRect = offsetRect(m_mixSliderRect, wx, wy);
     const NUIRect track(mixRect.x + 58.0f, mixRect.y + 12.0f, mixRect.width - 104.0f, 8.0f);
-    renderer.fillRoundedRect(mixRect, 10.0f, NUIColor(0.068f, 0.068f, 0.068f, 0.92f));
+    renderer.fillRoundedRect(mixRect, 10.0f, NUIThemeManager::getInstance().getColor("editorControl"));
     renderer.strokeRoundedRect(mixRect, 10.0f, 1.0f, accent().withAlpha(0.35f));
     renderer.drawText("Mix", {mixRect.x + 14.0f, mixRect.y + 10.0f}, 10.5f,
                       theme.getColor("textPrimary").withAlpha(0.95f));

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -29,13 +29,13 @@ NUIColor motionAccent() {
     return NUIColor(1.0f, 0.45f, 0.64f, 1.0f);
 }
 NUIColor shellSurface() {
-    return NUIColor(0.024f, 0.023f, 0.031f, 0.99f);
+    return editorNeutral(NUIColor(0.024f, 0.023f, 0.031f, 0.99f));
 }
 NUIColor panelSurface() {
-    return NUIColor(0.040f, 0.038f, 0.050f, 0.99f);
+    return editorNeutral(NUIColor(0.040f, 0.038f, 0.050f, 0.99f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.018f, 0.017f, 0.024f, 0.99f);
+    return editorNeutral(NUIColor(0.018f, 0.017f, 0.024f, 0.99f));
 }
 
 NUIColor parameterAccent(uint32_t parameterId) {
@@ -193,7 +193,7 @@ void AestraDriftEditor::drawPitchPanel(NUIRenderer& renderer) {
                                            : insetSurface());
         renderer.strokeRoundedRect(m_intervalBounds[i], 7.0f, 1.0f,
                                    active || hovered ? pitchAccent().withAlpha(0.56f)
-                                                     : NUIColor(1.0f, 1.0f, 1.0f, 0.05f));
+                                                     : editorInk(0.05f));
         const std::string label =
             kIntervals[i] > 0 ? "+" + std::to_string(kIntervals[i]) : std::to_string(kIntervals[i]);
         renderer.drawTextCentered(label, m_intervalBounds[i], 9.0f,
@@ -211,9 +211,9 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer) {
     renderer.fillCircle(center, radius, insetSurface());
     renderer.strokeCircle(center, radius, 1.0f,
                           m_pitchHovered || m_draggingPitch ? pitchAccent().withAlpha(0.54f)
-                                                            : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                                                            : editorInk(0.08f));
     drawArc(renderer, center, radius - 11.0f, kWheelStart, kWheelStart + kWheelSweep, 6.0f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+            editorInk(0.09f));
     drawArc(renderer, center, radius - 11.0f, kWheelStart, angle, 6.0f, pitchAccent().withAlpha(0.94f));
     for (int semitones : kIntervals) {
         const float t = (static_cast<float>(semitones) + 12.0f) / 24.0f;
@@ -228,7 +228,7 @@ void AestraDriftEditor::drawPitchWheel(NUIRenderer& renderer) {
     }
     const NUIPoint needle{center.x + std::cos(angle) * (radius - 35.0f), center.y + std::sin(angle) * (radius - 35.0f)};
     renderer.drawLine(center, needle, 2.3f, pitchAccent().withAlpha(0.88f));
-    renderer.fillCircle(center, 28.0f, NUIColor(0.048f, 0.045f, 0.060f, 1.0f));
+    renderer.fillCircle(center, 28.0f, editorNeutral(NUIColor(0.048f, 0.045f, 0.060f, 1.0f)));
     renderer.strokeCircle(center, 28.0f, 1.0f, pitchAccent().withAlpha(0.30f));
     renderer.drawTextCentered(pitchValueString(), {center.x - 34.0f, center.y - 11.0f, 68.0f, 22.0f}, 18.0f,
                               pitchAccent());
@@ -263,21 +263,21 @@ void AestraDriftEditor::drawKnob(NUIRenderer& renderer, const KnobControl& contr
         control.parameterId == Drift::kMotionRate && m_instance->getParameter(Drift::kMotion) < 0.001f;
     const NUIColor color = parameterAccent(control.parameterId);
     renderer.fillRoundedRect(control.bounds, 10.0f,
-                             hovered || dragging ? NUIColor(0.070f, 0.064f, 0.086f, 0.98f) : insetSurface());
+                             hovered || dragging ? editorNeutral(NUIColor(0.070f, 0.064f, 0.086f, 0.98f)) : insetSurface());
     renderer.strokeRoundedRect(control.bounds, 10.0f, 1.0f,
-                               hovered || dragging ? color.withAlpha(0.48f) : NUIColor(1.0f, 1.0f, 1.0f, 0.045f));
+                               hovered || dragging ? color.withAlpha(0.48f) : editorInk(0.045f));
     const float value = m_instance->getParameter(control.parameterId);
     const NUIPoint center = control.knobBounds.center();
     const float radius = control.knobBounds.width * 0.5f;
     const float angle = kWheelStart + value * kWheelSweep;
-    renderer.fillCircle(center, radius, NUIColor(0.030f, 0.029f, 0.039f, 1.0f));
-    renderer.strokeCircle(center, radius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+    renderer.fillCircle(center, radius, editorNeutral(NUIColor(0.030f, 0.029f, 0.039f, 1.0f)));
+    renderer.strokeCircle(center, radius, 1.0f, editorInk(0.07f));
     drawArc(renderer, center, radius - 6.0f, kWheelStart, kWheelStart + kWheelSweep, 3.5f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            editorInk(0.08f));
     drawArc(renderer, center, radius - 6.0f, kWheelStart, angle, 3.5f, color.withAlpha(rateInactive ? 0.30f : 0.92f));
     const NUIPoint needle{center.x + std::cos(angle) * (radius - 14.0f), center.y + std::sin(angle) * (radius - 14.0f)};
     renderer.drawLine(center, needle, 1.8f, color.withAlpha(rateInactive ? 0.28f : 0.86f));
-    renderer.fillCircle(center, 4.5f, NUIColor(0.070f, 0.066f, 0.086f, 1.0f));
+    renderer.fillCircle(center, 4.5f, editorNeutral(NUIColor(0.070f, 0.066f, 0.086f, 1.0f)));
     renderer.fillCircle(center, 1.8f, color.withAlpha(rateInactive ? 0.30f : 0.90f));
 
     const float labelY = control.knobBounds.bottom() + 5.0f;
@@ -297,7 +297,7 @@ void AestraDriftEditor::drawMixBar(NUIRenderer& renderer) {
     renderer.strokeRoundedRect(m_mixBounds, 11.0f, 1.0f, pitchAccent().withAlpha(m_draggingMix ? 0.56f : 0.18f));
     renderer.drawText("BLEND", {m_mixBounds.x + 14.0f, m_mixBounds.y + 15.0f}, 9.0f, theme.getColor("textPrimary"));
     const NUIRect track(m_mixBounds.x + 70.0f, m_mixBounds.y + 17.0f, m_mixBounds.width - 132.0f, 8.0f);
-    renderer.fillRoundedRect(track, 4.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+    renderer.fillRoundedRect(track, 4.0f, editorInk(0.09f));
     renderer.fillRoundedRect({track.x, track.y, track.width * mix, track.height}, 4.0f, pitchAccent().withAlpha(0.90f));
     const NUIPoint thumb{track.x + track.width * mix, track.center().y};
     renderer.fillCircle(thumb, 8.0f, pitchAccent().withAlpha(0.20f));

--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -23,7 +23,7 @@ constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accent() { return NUIColor(0.55f, 0.40f, 0.92f, 1.0f); }
 NUIColor accentSoft() { return NUIColor(0.55f, 0.40f, 0.92f, 0.35f); }
-NUIColor graphBg() { return NUIColor(0.045f, 0.045f, 0.045f, 0.96f); }
+NUIColor graphBg() { return editorNeutral(0.045f, 0.96f); }
 
 std::shared_ptr<NUIIcon> makeSvgIcon(const char* svg) {
     return std::make_shared<NUIIcon>(svg);
@@ -1398,7 +1398,7 @@ void AestraEQEditor::drawOutputGainPill(NUIRenderer& renderer) {
     const NUIColor outline =
         m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.44f) : NUIColor(1, 1, 1, 0.14f);
     const NUIColor fill = m_outputGainHovered || m_draggingOutputGain ? accent().withAlpha(0.11f)
-                                                                      : NUIColor(0.035f, 0.035f, 0.035f, 0.88f);
+                                                                      : editorNeutral(0.035f, 0.88f);
     renderer.fillRoundedRect(m_outputGainRect, 7.0f, fill);
     renderer.strokeRoundedRect(m_outputGainRect, 7.0f, 1.0f, outline);
     std::string gainText = formatGain(gain);
@@ -1452,7 +1452,7 @@ void AestraEQEditor::drawComparePills(NUIRenderer& renderer) {
     const char* label = m_compareActiveSlot == 0 ? "A>B" : "B>A";
     renderer.fillRoundedRect(m_compareCopyRect, 7.0f,
                              m_compareCopyHovered ? accent().withAlpha(0.11f)
-                                                  : NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
+                                                  : editorNeutral(0.035f, 0.88f));
     renderer.strokeRoundedRect(m_compareCopyRect, 7.0f, 1.0f,
                                m_compareCopyHovered ? accent().withAlpha(0.42f) : NUIColor(1, 1, 1, 0.13f));
     drawSvgIcon(renderer, compareCopyIcon(), {m_compareCopyRect.x + 7.0f, m_compareCopyRect.y + 5.0f, 14.0f, 14.0f},
@@ -1492,7 +1492,7 @@ void AestraEQEditor::drawAnalyzerSettingsPanel(NUIRenderer& renderer) {
         return;
 
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
+    renderer.fillRoundedRect(m_analyzerPanelRect, 8.0f, editorNeutral(0.031f, 0.94f));
     renderer.strokeRoundedRect(m_analyzerPanelRect, 8.0f, 1.0f, accent().withAlpha(0.34f));
     renderer.drawText("Analyzer", {m_analyzerPanelRect.x + 10.0f, m_analyzerPanelRect.y + 9.0f}, 9.5f,
                       theme.getColor("textPrimary").withAlpha(0.92f));
@@ -1632,7 +1632,7 @@ void AestraEQEditor::drawKnob(NUIRenderer& renderer, const NUIRect& bounds, floa
     const float r = bounds.width * 0.42f;
     const NUIColor col = active ? a : NUIColor(a.r, a.g, a.b, 0.30f);
     renderer.fillCircle({cx, cy}, r + 5.0f, col.withAlpha(active ? 0.08f : 0.04f));
-    renderer.fillCircle({cx, cy}, r, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle({cx, cy}, r, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle({cx, cy}, r, 1.0f, col.withAlpha(active ? 0.34f : 0.18f));
 
     const float sa = kPi * 0.75f;
@@ -1665,7 +1665,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         return;
 
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, NUIColor(0.046f, 0.046f, 0.046f, 0.97f));
+    renderer.fillRoundedRect(m_bandInspectorRect, 7.0f, editorNeutral(0.046f, 0.97f));
     renderer.strokeRoundedRect(m_bandInspectorRect, 7.0f, 1.0f, band.withAlpha(0.16f));
     renderer.fillRect({m_bandInspectorRect.x, m_bandInspectorRect.y, m_bandInspectorRect.width, 2.0f},
                       band.withAlpha(0.72f));
@@ -1746,7 +1746,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
                                                m_bandInspectorRect.right() - chipW - 10.0f);
                 const NUIRect hoverChip{chipX, slotRail.bottom() + 7.0f, chipW, 19.0f};
                 const NUIColor hoverColor = bandColor(hoverBand.slotIndex);
-                renderer.fillRoundedRect(hoverChip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+                renderer.fillRoundedRect(hoverChip, 5.0f, editorNeutral(0.026f, 0.96f));
                 renderer.strokeRoundedRect(hoverChip, 5.0f, 1.0f, hoverColor.withAlpha(0.34f));
                 renderer.drawTextCentered(hoverText, hoverChip, 7.8f, theme.getColor("textSecondary").withAlpha(0.88f));
             }
@@ -1818,7 +1818,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(bd.stereoButton.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           bd.stereoButton.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(modeHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1828,7 +1828,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const NUIRect tip{std::clamp(m_selectedCollapseRect.center().x - tipW * 0.5f, m_bandInspectorRect.x + 8.0f,
                                      m_bandInspectorRect.right() - tipW - 8.0f),
                           m_selectedCollapseRect.bottom() + 7.0f, tipW, 20.0f};
-        renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.96f));
+        renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.96f));
         renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.28f));
         renderer.drawTextCentered(collapseHelp, tip, 8.2f, theme.getColor("textSecondary").withAlpha(0.88f));
     }
@@ -1854,7 +1854,7 @@ void AestraEQEditor::drawBandCard(NUIRenderer& renderer, size_t idx) {
         const float trackY = lane.center().y;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(lane, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.95f));
+        renderer.fillRoundedRect(lane, 5.0f, editorNeutral(0.026f, 0.95f));
         renderer.fillRoundedRect({lane.x, lane.y, labelW, lane.height}, 5.0f,
                                  bd.enabled ? band.withAlpha(0.050f) : band.withAlpha(0.018f));
         renderer.fillRoundedRect({trackX, trackY - 1.5f, trackW, 3.0f}, 1.5f, NUIColor(1, 1, 1, 0.080f));
@@ -2114,7 +2114,7 @@ void AestraEQEditor::drawAnalyzerCollisionOverlay(NUIRenderer& renderer, const N
             std::clamp(inner.x + peakNorm * inner.width - chipW * 0.5f, inner.x + 8.0f, inner.right() - chipW - 8.0f);
         const NUIRect chip{chipX, inner.y + 28.0f, chipW, 22.0f};
         const NUIColor heat(1.0f, 0.40f, 0.18f, 1.0f);
-        renderer.fillRoundedRect(chip, 6.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.88f));
+        renderer.fillRoundedRect(chip, 6.0f, editorNeutral(0.035f, 0.88f));
         renderer.strokeRoundedRect(chip, 6.0f, 1.0f, heat.withAlpha(0.34f + peakMask * 0.22f));
         renderer.drawText(maskBuf, {chip.x + 8.0f, chip.y + 6.0f}, 8.3f, heat.withAlpha(0.92f));
         renderer.drawText(freqBuf, {chip.right() - 38.0f, chip.y + 6.0f}, 8.3f,
@@ -2208,11 +2208,11 @@ void AestraEQEditor::drawGraphCursorReadout(NUIRenderer& renderer, const NUIRect
     const NUIColor preview = canAddBand ? accent() : theme.getColor("textSecondary");
 
     renderer.drawLine({m_graphCursorPoint.x, inner.y}, {m_graphCursorPoint.x, inner.bottom()}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, canAddBand ? 0.085f : 0.040f));
+                      editorInk(canAddBand ? 0.085f : 0.040f));
     renderer.drawLine({inner.x, m_graphCursorPoint.y}, {inner.right(), m_graphCursorPoint.y}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, canAddBand ? 0.070f : 0.035f));
+                      editorInk(canAddBand ? 0.070f : 0.035f));
     renderer.fillCircle(m_graphCursorPoint, 10.0f, preview.withAlpha(canAddBand ? 0.050f : 0.025f));
-    renderer.fillCircle(m_graphCursorPoint, 4.0f, NUIColor(0.045f, 0.045f, 0.045f, 0.64f));
+    renderer.fillCircle(m_graphCursorPoint, 4.0f, editorNeutral(0.045f, 0.64f));
     renderer.strokeCircle(m_graphCursorPoint, 7.0f, 1.1f, preview.withAlpha(canAddBand ? 0.34f : 0.16f));
     renderer.drawLine({m_graphCursorPoint.x - 3.0f, m_graphCursorPoint.y},
                       {m_graphCursorPoint.x + 3.0f, m_graphCursorPoint.y}, 1.2f,
@@ -2314,7 +2314,7 @@ void AestraEQEditor::drawNodeHoverTooltip(NUIRenderer& renderer, const NUIRect& 
     y = std::clamp(y, inner.y + 6.0f, inner.bottom() - h - 6.0f);
     const NUIRect r{x, y, w, h};
 
-    renderer.fillRoundedRect(r, 5.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.90f));
+    renderer.fillRoundedRect(r, 5.0f, editorNeutral(0.031f, 0.90f));
     renderer.strokeRoundedRect(r, 5.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, r.x + 8.0f, r.right() - 8.0f);
     const float stemY = r.y > node.y ? r.y : r.bottom();
@@ -2344,7 +2344,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
     const bool canType = bd.typeId != 0 || !bd.legacySlot;
     const bool canDelete = !bd.legacySlot;
 
-    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, NUIColor(0.028f, 0.028f, 0.028f, 0.94f));
+    renderer.fillRoundedRect(m_nodeQuickActionRect, 7.0f, editorNeutral(0.028f, 0.94f));
     renderer.strokeRoundedRect(m_nodeQuickActionRect, 7.0f, 1.0f, band.withAlpha(0.32f));
     const float stemX = std::clamp(node.x, m_nodeQuickActionRect.x + 10.0f, m_nodeQuickActionRect.right() - 10.0f);
     const float stemY = m_nodeQuickActionRect.y > node.y ? m_nodeQuickActionRect.y : m_nodeQuickActionRect.bottom();
@@ -2359,11 +2359,11 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
         const NUIColor base = destructive ? red : band;
         const NUIColor fill = soloAction ? base.withAlpha(hovered ? 0.24f : 0.17f)
                                          : (enabled && hovered ? base.withAlpha(destructive ? 0.12f : 0.15f)
-                                                               : NUIColor(1.0f, 1.0f, 1.0f, enabled ? 0.026f : 0.010f));
+                                                               : editorInk(enabled ? 0.026f : 0.010f));
         const NUIColor edge = soloAction ? base.withAlpha(hovered ? 0.72f : 0.54f)
                               : enabled  ? (hovered ? base.withAlpha(destructive ? 0.48f : 0.44f)
                                                     : base.withAlpha(destructive ? 0.24f : 0.20f))
-                                         : NUIColor(1.0f, 1.0f, 1.0f, 0.040f);
+                                         : editorInk(0.040f);
         if (soloAction) {
             renderer.fillRoundedRect({r.x - 3.0f, r.y - 3.0f, r.width + 6.0f, r.height + 6.0f}, 7.0f,
                                      base.withAlpha(0.075f));
@@ -2440,7 +2440,7 @@ void AestraEQEditor::drawSelectedNodeQuickActions(NUIRenderer& renderer, const N
             }
             tipY = std::clamp(tipY, inner.y + 4.0f, inner.bottom() - 22.0f);
             const NUIRect tip{tipX, tipY, tipW, 18.0f};
-            renderer.fillRoundedRect(tip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.94f));
+            renderer.fillRoundedRect(tip, 5.0f, editorNeutral(0.026f, 0.94f));
             renderer.strokeRoundedRect(tip, 5.0f, 1.0f, band.withAlpha(0.26f));
             renderer.drawTextCentered(label, tip, 7.7f, theme.getColor("textSecondary").withAlpha(0.86f));
         }
@@ -2462,7 +2462,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
     for (int db = -gridMax; db <= gridMax; db += gridStep) {
         const float y = inner.bottom() - (static_cast<float>(db) + dbRange) / (dbRange * 2.0f) * inner.height;
         const float alpha = (db == 0) ? 0.28f : 0.10f;
-        renderer.drawLine({inner.x, y}, {inner.right(), y}, db == 0 ? 1.2f : 1.0f, NUIColor(1.0f, 1.0f, 1.0f, alpha));
+        renderer.drawLine({inner.x, y}, {inner.right(), y}, db == 0 ? 1.2f : 1.0f, editorInk(alpha));
         const std::string lbl = (db > 0 ? "+" : "") + std::to_string(db);
         renderer.drawTextCentered(lbl, {bounds.x + 3.0f, y - 7.0f, 26.0f, 14.0f}, 8.6f,
                                   theme.getColor("textSecondary").withAlpha(0.66f));
@@ -2474,7 +2474,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
     for (int i = 0; i < 6; ++i) {
         const float norm = (std::log10(freqs[i]) - logMin) / (logMax - logMin);
         const float x = inner.x + norm * inner.width;
-        renderer.drawLine({x, inner.y}, {x, inner.bottom()}, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+        renderer.drawLine({x, inner.y}, {x, inner.bottom()}, 1.0f, editorInk(0.07f));
         renderer.drawTextCentered(freqLabels[i], {x - 14.0f, inner.bottom() + 1.0f, 28.0f, 14.0f}, 8.6f,
                                   theme.getColor("textSecondary").withAlpha(0.70f));
     }
@@ -2560,7 +2560,7 @@ void AestraEQEditor::drawResponseCurve(NUIRenderer& renderer, const NUIRect& bou
         renderer.fillCircle(
             node, radius + (quietDynamicNode ? 2.4f : 4.0f),
             c.withAlpha((selected || dragging || soloed ? 0.18f : (quietDynamicNode ? 0.050f : 0.10f)) * activeAlpha));
-        renderer.fillCircle(node, radius, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+        renderer.fillCircle(node, radius, editorNeutral(0.045f, 0.96f));
         renderer.strokeCircle(node, radius, bd.enabled ? (quietDynamicNode ? 1.1f : 1.6f) : 1.1f,
                               c.withAlpha(bd.enabled ? (quietDynamicNode ? 0.58f : 1.0f) : 0.42f));
         if (bd.enabled) {
@@ -2631,7 +2631,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     const NUIRect handle{x - 6.0f, y - 6.0f, 12.0f, 12.0f};
     renderer.fillRoundedRect({handle.x - 4.0f, handle.y - 4.0f, handle.width + 8.0f, handle.height + 8.0f}, 5.0f,
                              c.withAlpha(dragging ? 0.12f : 0.06f));
-    renderer.fillRoundedRect(handle, 3.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.94f));
+    renderer.fillRoundedRect(handle, 3.0f, editorNeutral(0.031f, 0.94f));
     renderer.strokeRoundedRect(handle, 3.0f, dragging ? 1.6f : 1.1f, c.withAlpha(dragging ? 0.95f : 0.72f));
 
     char freqBuf[24];
@@ -2641,7 +2641,7 @@ void AestraEQEditor::drawDynamicDetectorHandle(NUIRenderer& renderer, const NUIR
     else
         std::snprintf(freqBuf, sizeof(freqBuf), "%.0f", hz);
     const NUIRect chip{std::clamp(x - 42.0f, inner.x + 6.0f, inner.right() - 84.0f), y + 11.0f, 84.0f, 19.0f};
-    renderer.fillRoundedRect(chip, 5.0f, NUIColor(0.026f, 0.026f, 0.026f, 0.86f));
+    renderer.fillRoundedRect(chip, 5.0f, editorNeutral(0.026f, 0.86f));
     renderer.strokeRoundedRect(chip, 5.0f, 1.0f, c.withAlpha(0.24f));
     renderer.drawText("DET", {chip.x + 7.0f, std::round(renderer.calculateTextY(chip, 7.4f))}, 7.4f,
                       c.withAlpha(0.76f));
@@ -2665,7 +2665,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
     const NUIRect r = layout.panel;
     const NUIColor c = bandColor(bd.slotIndex);
 
-    renderer.fillRoundedRect(r, 6.0f, NUIColor(0.052f, 0.052f, 0.052f, 0.96f));
+    renderer.fillRoundedRect(r, 6.0f, editorNeutral(0.052f, 0.96f));
     renderer.strokeRoundedRect(r, 6.0f, 1.0f, c.withAlpha(bd.enabled ? 0.35f : 0.16f));
     const float connectorX = std::clamp(node.x, r.x + 12.0f, r.right() - 12.0f);
     const float connectorY = node.y < r.y ? r.y + 8.0f : r.bottom() - 8.0f;
@@ -2679,7 +2679,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
     renderer.drawText(bandId, {r.x + 8.0f, tooltipHeaderY}, kTooltipHeaderFont,
                       c.withAlpha(bd.enabled ? 0.98f : 0.44f));
     renderer.fillRoundedRect(layout.typeRect, 4.0f,
-                             bd.enabled ? c.withAlpha(0.055f) : NUIColor(1.0f, 1.0f, 1.0f, 0.010f));
+                             bd.enabled ? c.withAlpha(0.055f) : editorInk(0.010f));
     if (bd.typeId != 0 || !bd.legacySlot)
         renderer.strokeRoundedRect(layout.typeRect, 4.0f, 1.0f, c.withAlpha(0.16f));
     renderer.drawTextCentered(typeLabel, layout.typeRect, 8.0f,
@@ -2688,9 +2688,9 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
         (bd.legacySlot && m_instance && bd.stereoId != 0) ? m_instance->getParameter(bd.stereoId) : bd.stereoNorm;
     const bool stereoScoped = quantizeStereoNorm(stereoNorm) > 0.0f;
     renderer.fillRoundedRect(layout.stereoRect, 4.0f,
-                             stereoScoped ? c.withAlpha(0.18f) : NUIColor(1.0f, 1.0f, 1.0f, 0.028f));
+                             stereoScoped ? c.withAlpha(0.18f) : editorInk(0.028f));
     renderer.strokeRoundedRect(layout.stereoRect, 4.0f, 1.0f,
-                               stereoScoped ? c.withAlpha(0.40f) : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                               stereoScoped ? c.withAlpha(0.40f) : editorInk(0.08f));
     renderer.drawTextCentered(stereoModeShortName(stereoNorm), layout.stereoRect, 7.4f,
                               stereoScoped ? c.withAlpha(0.96f) : theme.getColor("textSecondary").withAlpha(0.58f));
     renderer.fillCircle(layout.enableRect.center(), 3.0f,
@@ -2709,7 +2709,7 @@ void AestraEQEditor::drawFloatingBandWindow(NUIRenderer& renderer, const NUIRect
         const float trackY = row.center().y + 5.0f;
         const float tickX = trackX + trackW * amount;
 
-        renderer.fillRoundedRect(row, 4.0f, NUIColor(0.018f, 0.018f, 0.018f, 0.86f));
+        renderer.fillRoundedRect(row, 4.0f, editorNeutral(0.018f, 0.86f));
         renderer.fillRoundedRect({row.x, row.y, labelW, row.height}, 4.0f,
                                  bd.enabled ? c.withAlpha(draggingThis ? 0.16f : 0.075f) : c.withAlpha(0.025f));
         renderer.fillRoundedRect({trackX, trackY - 1.0f, trackW, 2.0f}, 1.0f, NUIColor(1, 1, 1, 0.055f));
@@ -2797,7 +2797,7 @@ void AestraEQEditor::drawBandTypeMenu(NUIRenderer& renderer) {
                              quantizeTypeNorm(m_instance ? m_instance->getParameter(bd.typeId) : bd.typeNorm) * 3.0f)),
                          0, 3)
             : std::clamp(static_cast<int>(std::round(std::clamp(bd.typeNorm, 0.0f, 1.0f) * 7.0f)), 0, 7);
-    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_typeMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_typeMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     for (size_t i = 0; i < optionCount; ++i) {
@@ -2824,7 +2824,7 @@ void AestraEQEditor::drawBandStereoMenu(NUIRenderer& renderer) {
         (bd.legacySlot && bd.stereoId != 0 && m_instance) ? m_instance->getParameter(bd.stereoId) : bd.stereoNorm;
     const int current = std::clamp(static_cast<int>(std::round(quantizeStereoNorm(stereoNorm) * 4.0f)), 0, 4);
 
-    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_stereoMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_stereoMenuRect, 8.0f, 1.0f, band.withAlpha(0.42f));
 
     static constexpr const char* kLabels[] = {"Stereo", "Left", "Right", "Mid", "Side"};
@@ -2855,7 +2855,7 @@ void AestraEQEditor::drawBandContextMenu(NUIRenderer& renderer) {
     const NUIColor band = bandColor(bd.slotIndex);
     const std::string bandId = bd.name.empty() ? bandIdLabel(static_cast<size_t>(m_bandContextMenuBand)) : bd.name;
     const std::string typeLabel = bandTypeSuffix(bd.typeName);
-    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(m_bandContextMenuRect, 8.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(m_bandContextMenuRect, 8.0f, 1.0f, band.withAlpha(0.34f));
     renderer.drawText(bandId, {m_bandContextMenuRect.x + 10.0f, m_bandContextMenuRect.y + 10.0f}, 9.5f,
                       band.withAlpha(0.96f));
@@ -2948,7 +2948,7 @@ void AestraEQEditor::drawNumericEditBox(NUIRenderer& renderer) {
     const NUIColor band = m_numericEditBand >= 0 && m_numericEditBand < static_cast<int>(m_bands.size())
                               ? bandColor(m_bands[static_cast<size_t>(m_numericEditBand)].slotIndex)
                               : accent();
-    renderer.fillRoundedRect(r, 7.0f, NUIColor(0.031f, 0.031f, 0.031f, 0.96f));
+    renderer.fillRoundedRect(r, 7.0f, editorNeutral(0.031f, 0.96f));
     renderer.strokeRoundedRect(r, 7.0f, 1.2f, band.withAlpha(0.62f));
     const char* label = "VALUE";
     switch (m_numericEditTarget) {

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -23,12 +23,14 @@ NUIColor accent() {
     return NUIColor(0.28f, 0.72f, 0.62f, 1.0f);
 } // filter teal
 NUIColor panelSurface() {
-    return NUIColor(0.018f, 0.021f, 0.022f, 0.98f);
+    return editorNeutral(NUIColor(0.018f, 0.021f, 0.022f, 0.98f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.028f, 0.034f, 0.035f, 0.98f);
+    return editorNeutral(NUIColor(0.028f, 0.034f, 0.035f, 0.98f));
 }
 NUIColor gridColor() {
+    // Teal-tinted grid ink over the response well; darkened on light themes.
+    if (editorLightUi()) return NUIColor(0.16f, 0.26f, 0.24f, 0.16f);
     return NUIColor(0.45f, 0.58f, 0.56f, 0.12f);
 }
 
@@ -164,7 +166,7 @@ void AestraFilterEditor::drawResponseDisplay(NUIRenderer& renderer) {
     // sit on the response border or compete with the live envelope meter.
     const NUIRect graph{m_responseRect.x + 14.0f, m_responseRect.y + 31.0f, m_responseRect.width - 28.0f,
                         m_responseRect.height - 65.0f};
-    renderer.fillRoundedRect(graph, 7.0f, NUIColor(0.006f, 0.010f, 0.011f, 0.98f));
+    renderer.fillRoundedRect(graph, 7.0f, editorNeutral(NUIColor(0.006f, 0.010f, 0.011f, 0.98f)));
 
     auto xForHz = [&graph](float hz) {
         const float norm = std::log10(std::clamp(hz, 20.0f, 20000.0f) / 20.0f) / 3.0f;
@@ -231,7 +233,7 @@ void AestraFilterEditor::drawResponseDisplay(NUIRenderer& renderer) {
     renderer.clearClipRect();
 
     const NUIRect envTrack{graph.x, m_responseRect.bottom() - 8.0f, graph.width, 3.0f};
-    renderer.fillRoundedRect(envTrack, 1.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.06f));
+    renderer.fillRoundedRect(envTrack, 1.5f, editorInk(0.06f));
     renderer.fillRoundedRect({envTrack.x, envTrack.y, envTrack.width * envelope, envTrack.height}, 1.5f,
                              accent().withAlpha(0.72f));
 }
@@ -245,10 +247,10 @@ void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, ui
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     if (bipolar) {
         // Bipolar knobs fill from the top-center detent toward the value.
         const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
@@ -264,7 +266,7 @@ void AestraFilterEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, ui
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -287,7 +289,7 @@ void AestraFilterEditor::drawTypeSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_typeRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_typeRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_typeRects[i], 9.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.36f, 0.62f, 0.92f, 1.0f);
 } // LFO blue
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -100,7 +100,7 @@ void AestraLFOEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawTargetSelector(renderer);
     drawWaveSelector(renderer);
@@ -121,10 +121,10 @@ void AestraLFOEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
 
     const float needleLen = r - (large ? 14.0f : 9.0f);
@@ -133,7 +133,7 @@ void AestraLFOEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -163,7 +163,7 @@ void AestraLFOEditor::drawTargetSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_targetRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_targetRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_targetRects[i], 10.5f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }
@@ -183,7 +183,7 @@ void AestraLFOEditor::drawWaveSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_waveRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_waveRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_waveRects[i], 10.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }
@@ -200,7 +200,7 @@ void AestraLFOEditor::drawSyncPill(NUIRenderer& renderer) {
         renderer.drawTextCentered("SYNC", m_syncRect, 10.0f, accent().withAlpha(0.98f));
     } else {
         renderer.fillRoundedRect(m_syncRect, kRadius, insetSurface());
-        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+        renderer.strokeRoundedRect(m_syncRect, kRadius, 1.0f, editorInk(0.08f));
         renderer.drawTextCentered("FREE", m_syncRect, 10.0f, theme.getColor("textPrimary").withAlpha(0.62f));
     }
 }

--- a/AestraUI/Widgets/AestraLimitEditor.cpp
+++ b/AestraUI/Widgets/AestraLimitEditor.cpp
@@ -17,10 +17,10 @@ namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
 NUIColor accentColor() { return NUIColor(0.95f, 0.60f, 0.12f, 1.0f); }
-NUIColor bgDark() { return NUIColor(0.02f, 0.02f, 0.02f, 0.96f); }
-NUIColor textDim() { return NUIColor(1.0f, 1.0f, 1.0f, 0.30f); }
-NUIColor textBright() { return NUIColor(1.0f, 1.0f, 1.0f, 0.88f); }
-NUIColor meterBg() { return NUIColor(0.008f, 0.008f, 0.008f, 1.0f); }
+NUIColor bgDark() { return editorNeutral(0.02f, 0.96f); }
+NUIColor textDim() { return editorInk(0.30f); }
+NUIColor textBright() { return editorInk(0.88f); }
+NUIColor meterBg() { return editorNeutral(0.008f, 1.0f); }
 
 float smoothMeter(float current, float target, float attack, float release) {
     const float coeff = target > current ? attack : release;
@@ -250,10 +250,10 @@ void AestraLimitEditor::drawKnob(NUIRenderer& renderer, const KnobControl& contr
     const NUIColor knobAccent = control.isPrimary ? accent : accent.withAlpha(0.72f);
 
     // Cell background
-    renderer.fillRoundedRect(control.bounds, 8.0f, NUIColor(0.035f, 0.035f, 0.035f, 0.96f));
+    renderer.fillRoundedRect(control.bounds, 8.0f, editorNeutral(0.035f, 0.96f));
     renderer.strokeRoundedRect(control.bounds, 8.0f, 1.0f,
                                control.isPrimary ? NUIColor(0.28f, 0.18f, 0.06f, 1.0f)
-                                                 : NUIColor(0.119f, 0.119f, 0.119f, 1.0f));
+                                                 : editorNeutral(0.119f, 1.0f));
 
     const NUIRect knobRect = control.slider ? control.slider->getBounds() : NUIRect();
     const float cx = knobRect.center().x;
@@ -315,8 +315,8 @@ void AestraLimitEditor::drawPill(NUIRenderer& renderer, NUIRect rect,
         renderer.strokeRoundedRect(rect, 5.0f, 1.0f, accent);
         renderer.drawTextCentered(label, rect, 9.5f, NUIColor(1, 1, 1, 0.97f));
     } else {
-        const NUIColor bg = hovered ? NUIColor(0.041f, 0.041f, 0.041f, 0.90f)
-                                    : NUIColor(0.022f, 0.022f, 0.022f, 0.90f);
+        const NUIColor bg = hovered ? editorNeutral(0.041f, 0.90f)
+                                    : editorNeutral(0.022f, 0.90f);
         renderer.fillRoundedRect(rect, 5.0f, bg);
         renderer.drawLine({rect.x + 5.0f, rect.y + 1.0f},
                           {rect.x + rect.width - 5.0f, rect.y + 1.0f},

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.74f, 0.42f, 0.88f, 1.0f);
 } // OTT violet
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -90,7 +90,7 @@ void AestraOTTEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawBypassPill(renderer);
     drawKnob(renderer, m_depthRect, AestraOTT::kDepth, "Depth", true, false);
@@ -113,10 +113,10 @@ void AestraOTTEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     if (bipolar) {
         // Bipolar knobs fill from the top-center detent toward the value.
         const float centerAngle = kKnobStart + 0.5f * kKnobSweep;
@@ -132,7 +132,7 @@ void AestraOTTEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.28f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,

--- a/AestraUI/Widgets/AestraPanelWindow.cpp
+++ b/AestraUI/Widgets/AestraPanelWindow.cpp
@@ -20,8 +20,8 @@ void AestraPanelWindow::cacheThemeColors()
     m_border = theme.getColor("borderSubtle");
     m_textSecondary = theme.getColor("textSecondary");
     m_textTertiary = theme.getColor("textDisabled");
-    m_closeHover = NUIColor::fromHex(0xffd95f5f);
-    m_closeActive = NUIColor::fromHex(0xffe57373);
+    m_closeHover = theme.getColor("error").withAlpha(0.78f);
+    m_closeActive = theme.getColor("error");
 }
 
 void AestraPanelWindow::setPanelTitle(const std::string& title)

--- a/AestraUI/Widgets/AestraPanelWindow.h
+++ b/AestraUI/Widgets/AestraPanelWindow.h
@@ -29,6 +29,7 @@ public:
     ~AestraPanelWindow() override = default;
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setPanelTitle(const std::string& title);

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -23,10 +23,10 @@ NUIColor accent() {
     return NUIColor(0.94f, 0.52f, 0.22f, 1.0f);
 } // heat orange
 NUIColor panelSurface() {
-    return NUIColor(0.027f, 0.027f, 0.027f, 0.96f);
+    return editorNeutral(0.027f, 0.96f);
 }
 NUIColor insetSurface() {
-    return NUIColor(0.038f, 0.038f, 0.038f, 0.96f);
+    return editorNeutral(0.038f, 0.96f);
 }
 
 void drawArc(NUIRenderer& renderer, NUIPoint center, float radius, float startAngle, float endAngle, float thickness,
@@ -91,7 +91,7 @@ void AestraSatEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentR
     const NUIRect workArea{contentRect.x + 12.0f, contentRect.y + 10.0f, contentRect.width - 24.0f,
                            contentRect.height - 18.0f};
     renderer.fillRoundedRect(workArea, 14.0f, panelSurface());
-    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+    renderer.strokeRoundedRect(workArea, 14.0f, 1.0f, editorInk(0.055f));
 
     drawModeSelector(renderer);
     drawBypassPill(renderer);
@@ -110,10 +110,10 @@ void AestraSatEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     const float angle = kKnobStart + value * kKnobSweep;
 
     renderer.fillCircle(c, r + 4.0f, insetSurface());
-    renderer.strokeCircle(c, r + 4.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.060f));
+    renderer.strokeCircle(c, r + 4.0f, 1.0f, editorInk(0.060f));
 
     drawArc(renderer, c, r - 3.0f, kKnobStart, kKnobStart + kKnobSweep, large ? 4.0f : 3.0f,
-            NUIColor(0.199f, 0.199f, 0.199f, 1.0f));
+            editorNeutral(0.199f, 1.0f));
     drawArc(renderer, c, r - 3.0f, kKnobStart, angle, large ? 4.0f : 3.0f, accent().withAlpha(0.92f));
 
     const float needleLen = r - (large ? 14.0f : 10.0f);
@@ -122,7 +122,7 @@ void AestraSatEditor::drawKnob(NUIRenderer& renderer, const NUIRect& rect, uint3
     renderer.fillCircle(tip, large ? 3.5f : 2.5f, accent());
 
     const float wellR = r * (large ? 0.34f : 0.30f);
-    renderer.fillCircle(c, wellR, NUIColor(0.045f, 0.045f, 0.045f, 0.96f));
+    renderer.fillCircle(c, wellR, editorNeutral(0.045f, 0.96f));
     renderer.strokeCircle(c, wellR, 1.2f, accent().withAlpha(0.36f));
 
     renderer.drawTextCentered(label, NUIRect(rect.x, rect.bottom() + 4.0f, rect.width, 14.0f), 10.5f,
@@ -145,7 +145,7 @@ void AestraSatEditor::drawModeSelector(NUIRenderer& renderer) {
             renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f, accent().withAlpha(0.98f));
         } else {
             renderer.fillRoundedRect(m_modeRects[i], 7.0f, insetSurface());
-            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+            renderer.strokeRoundedRect(m_modeRects[i], 7.0f, 1.0f, editorInk(0.08f));
             renderer.drawTextCentered(kLabels[i], m_modeRects[i], 10.0f,
                                       theme.getColor("textPrimary").withAlpha(0.62f));
         }

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -41,8 +41,8 @@ constexpr float kPresetListBottomPadding = 24.0f;
 constexpr float kPresetArtworkSize = 44.0f;
 constexpr float kPresetArtworkPixels = 256.0f; // matches the committed 256x256 preset artwork
 
-NUIColor verbSurfaceBg() { return NUIColor(0.044f, 0.044f, 0.044f, 0.985f); }
-NUIColor verbInsetBg() { return NUIColor(0.025f, 0.025f, 0.025f, 0.965f); }
+NUIColor verbSurfaceBg() { return editorNeutral(0.044f, 0.985f); }
+NUIColor verbInsetBg() { return editorNeutral(0.025f, 0.965f); }
 NUIColor verbGold() { return NUIColor(0.88f, 0.63f, 0.13f, 1.0f); }
 NUIColor verbAccent() { return NUIColor(0.498f, 0.353f, 0.941f, 1.0f); }
 float presetColumnWidth(float editorWidth) { return std::clamp(editorWidth * 0.235f, 168.0f, 210.0f); }
@@ -573,7 +573,7 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
     const float stripBottomY = b.y + b.height - 14.0f;
     const float stripH = stripBottomY - stripTopY;
     renderer.fillRoundedRect({stripX - 5.0f, stripTopY, stripW + 10.0f, stripH}, 8.0f,
-                             NUIColor(0.022f, 0.022f, 0.027f, 0.98f));
+                             editorNeutral(NUIColor(0.022f, 0.022f, 0.027f, 0.98f)));
     renderer.strokeRoundedRect({stripX - 5.0f, stripTopY, stripW + 10.0f, stripH}, 8.0f, 1.0f, NUIColor(1, 1, 1, 0.085f));
     const NUIRect libraryRow(stripX + 7.0f, stripTopY + 5.0f, stripW - 23.0f, 16.0f);
     renderer.drawText("PRESET LIBRARY", {libraryRow.x, std::round(renderer.calculateTextY(libraryRow, 8.5f))}, 8.5f,
@@ -619,8 +619,8 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
         const bool focused = static_cast<int>(i) == m_focusedPreset;
         const bool pressed = static_cast<int>(i) == m_pressedPreset;
         const NUIColor presetFill = active ? accent.withAlpha(pressed ? 0.17f : 0.125f)
-            : (pressed ? NUIColor(0.060f, 0.052f, 0.078f, 0.99f)
-                       : (p.hovered ? NUIColor(0.061f, 0.057f, 0.074f, 0.98f) : verbInsetBg().withAlpha(0.92f)));
+            : (pressed ? editorNeutral(NUIColor(0.060f, 0.052f, 0.078f, 0.99f))
+                       : (p.hovered ? editorNeutral(NUIColor(0.061f, 0.057f, 0.074f, 0.98f)) : verbInsetBg().withAlpha(0.92f)));
         renderer.fillRoundedRect(p.bounds, 6.0f, presetFill);
         renderer.strokeRoundedRect(p.bounds, 5.0f, 1.0f,
                                    active ? accent.withAlpha(0.42f)
@@ -644,7 +644,7 @@ void AestraVerbEditor::drawPresetStrip(NUIRenderer& renderer, NUIColor accent) {
             const float hue = modeHues[modeIdx];
             renderer.fillRectGradient(art,
                 NUIColor(hue * 0.8f + 0.15f, hue * 0.4f + 0.08f, 0.20f, 1.0f),
-                NUIColor(0.029f, 0.029f, 0.029f, 1.0f), true);
+                editorNeutral(0.029f, 1.0f), true);
             static const char* modeInitials[] = {"R", "H", "P", "C", "Ch", "B", "A", "S", "Sp"};
             const char* initial = (modeIdx >= 0 && modeIdx < kModeCount) ? modeInitials[modeIdx] : "R";
             renderer.drawTextCentered(initial, art, 14.0f, accent.withAlpha(0.65f));
@@ -705,7 +705,7 @@ void AestraVerbEditor::drawCategoryPills(NUIRenderer& renderer, NUIColor accent)
     const auto outer = NUIRect(m_categoryPills.front().bounds.x, m_categoryPills.front().bounds.y,
                                m_categoryPills.back().bounds.right() - m_categoryPills.front().bounds.x,
                                m_categoryPills.front().bounds.height);
-    renderer.fillRoundedRect(outer, 13.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
+    renderer.fillRoundedRect(outer, 13.0f, editorNeutral(0.027f, 0.985f));
     renderer.strokeRoundedRect(outer, 13.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
     const float pad = 2.0f;
     for (const auto& pill : m_categoryPills) {
@@ -799,7 +799,7 @@ void AestraVerbEditor::drawModeDropdown(NUIRenderer& renderer, NUIColor accent) 
     chevronIcon->onRender(renderer);
 
     if (m_dropdownOpen && !m_dropdownItems.empty()) {
-        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, NUIColor(0.027f, 0.027f, 0.027f, 0.985f));
+        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, editorNeutral(0.027f, 0.985f));
         renderer.strokeRoundedRect(m_dropdownListBounds, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
         for (const auto& item : m_dropdownItems) {
             const bool isCurrent = item.mode == modeIdx;
@@ -834,9 +834,9 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
         const float ringThickness = 11.0f;
         renderer.drawShadow(NUIRect{cx - macroR * 0.82f, cy - macroR * 0.82f, macroR * 1.64f, macroR * 1.64f}, 0.0f, 3.0f, 6.0f,
                             NUIColor(0, 0, 0, 0.52f));
-        renderer.fillCircle({cx, cy}, macroR - 10.0f, NUIColor(0.012f, 0.012f, 0.016f, 0.98f));
+        renderer.fillCircle({cx, cy}, macroR - 10.0f, editorNeutral(NUIColor(0.012f, 0.012f, 0.016f, 0.98f)));
         renderer.strokeCircle({cx, cy}, macroR - 15.0f, 1.0f, NUIColor(1, 1, 1, 0.045f));
-        renderer.strokeCircle({cx, cy}, macroR, ringThickness, NUIColor(0.091f, 0.091f, 0.091f, 1.0f));
+        renderer.strokeCircle({cx, cy}, macroR, ringThickness, editorNeutral(0.091f, 1.0f));
         const float dStartAngle = -kPi * 0.5f;
         const float dSweep = kTwoPi * 0.80f;
         const float dValue = k.slider ? k.slider->getValue() : 0.0f;
@@ -868,8 +868,8 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     if (k.verticalLayout) {
         renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                             NUIColor(0, 0, 0, 0.48f));
-        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
-        renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
+        renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : editorNeutral(0.039f, 1.0f));
+        renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, editorInk(0.09f + stateLift * 0.045f));
         renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
         const float startAngle = kPi * 0.75f;
         const float sweep = kPi * 1.5f;
@@ -879,7 +879,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
         drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
         const float pa = startAngle + value * kPi * 1.5f;
         renderer.drawLine({cx, cy}, {cx + std::cos(pa) * (r * 0.56f), cy + std::sin(pa) * (r * 0.56f)}, 2.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, active ? 0.98f : (hover ? 0.92f : 0.84f)));
+                          editorInk(active ? 0.98f : (hover ? 0.92f : 0.84f)));
         const float labelY = k.bounds.y + knobRect.height + 6.0f;
         renderer.drawTextCentered(k.label, {k.bounds.x, labelY, k.bounds.width, 14.0f}, 10.0f,
                                   theme.getColor("textPrimary").withAlpha(0.74f + stateLift * 0.12f));
@@ -891,8 +891,8 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     renderer.drawShadow(NUIRect{cx - r * 0.78f, cy - r * 0.78f, r * 1.56f, r * 1.56f}, 0.0f, 2.0f, 4.0f,
                         NUIColor(0, 0, 0, 0.48f));
     if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.25f));
-    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : NUIColor(0.039f, 0.039f, 0.039f, 1.0f));
-    renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.09f + stateLift * 0.045f));
+    renderer.fillCircle({cx, cy}, r * 0.76f, hover ? verbSurfaceBg().withAlpha(1.0f) : editorNeutral(0.039f, 1.0f));
+    renderer.strokeCircle({cx, cy}, r * 0.76f, 1.0f, editorInk(0.09f + stateLift * 0.045f));
     renderer.fillCircle({cx - r * 0.19f, cy - r * 0.22f}, r * 0.25f, NUIColor(1, 1, 1, 0.026f + stateLift * 0.016f));
     const float startAngle = kPi * 0.75f;
     const float sweep = kPi * 1.5f;
@@ -902,7 +902,7 @@ void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUI
     drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
     const float pa = startAngle + value * kPi * 1.5f;
     renderer.drawLine({cx, cy}, {cx + std::cos(pa) * (r * 0.56f), cy + std::sin(pa) * (r * 0.56f)}, 2.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, active ? 0.98f : (hover ? 0.92f : 0.84f)));
+                      editorInk(active ? 0.98f : (hover ? 0.92f : 0.84f)));
     const float textX = knobRect.right() + 9.0f;
     // Optically centre the label + value on the knob's centre (see opticalTextY).
     const float labelTextY = std::round(opticalTextY(renderer, cy, 9.5f));
@@ -1013,7 +1013,7 @@ void AestraVerbEditor::drawSectionLabels(NUIRenderer& renderer) {
 
     auto drawSection = [&](const char* label, const char* hint, float y, float height, int rows) {
         const NUIRect card(rightX, y, rightW, height);
-        renderer.fillRoundedRect(card, 9.0f, NUIColor(0.030f, 0.030f, 0.035f, 0.97f));
+        renderer.fillRoundedRect(card, 9.0f, editorNeutral(NUIColor(0.030f, 0.030f, 0.035f, 0.97f)));
         renderer.strokeRoundedRect(card, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.075f));
         renderer.fillCircle({rightX + 13.0f, y + 13.0f}, 2.0f, verbAccent().withAlpha(0.72f));
         const NUIRect headerRow(rightX + 21.0f, y, rightW - 33.0f, headerH);
@@ -1051,19 +1051,19 @@ void AestraVerbEditor::drawParamRow(NUIRenderer& renderer, NUIColor accent) {
         const bool hover = temp.slider ? temp.slider->isHovered() : false;
         const float stateLift = active ? 1.0f : (hover ? 0.55f : 0.0f);
         renderer.fillRoundedRect(rect, 7.0f,
-                                 hover ? NUIColor(0.034f, 0.031f, 0.044f, 0.98f)
-                                       : NUIColor(0.020f, 0.020f, 0.024f, 0.92f));
+                                 hover ? editorNeutral(NUIColor(0.034f, 0.031f, 0.044f, 0.98f))
+                                       : editorNeutral(NUIColor(0.020f, 0.020f, 0.024f, 0.92f)));
         renderer.strokeRoundedRect(rect, 7.0f, 1.0f,
                                    active ? accent.withAlpha(0.46f)
                                           : (hover ? accent.withAlpha(0.24f) : NUIColor(1, 1, 1, 0.065f)));
-        renderer.fillCircle({cx, cy}, r, NUIColor(0.01f, 0.01f, 0.01f, 1.0f));
+        renderer.fillCircle({cx, cy}, r, editorNeutral(0.01f, 1.0f));
         renderer.strokeCircle({cx, cy}, r, 1.0f, NUIColor(1, 1, 1, 0.10f + stateLift * 0.045f));
         if (hover) renderer.strokeCircle({cx, cy}, r + 1.5f, 1.0f, accent.withAlpha(0.20f));
         const float startAngle = kPi * 0.75f;
         const float sweep = kPi * 1.5f;
         const float value = temp.slider ? temp.slider->getValue() : 0.0f;
         const float endAngle = startAngle + value * sweep;
-        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, NUIColor(0.166f, 0.166f, 0.166f, 1.0f));
+        drawVerbArc(renderer, {cx, cy}, r, startAngle, startAngle + sweep, 3.0f, editorNeutral(0.166f, 1.0f));
         drawVerbArc(renderer, {cx, cy}, r, startAngle, endAngle, 3.0f, accent.withAlpha(0.86f + stateLift * 0.11f));
         const float pa = startAngle + value * kPi * 1.5f;
         renderer.fillCircle({cx + std::cos(pa) * (r - 2.0f), cy + std::sin(pa) * (r - 2.0f)}, 2.5f,
@@ -1093,18 +1093,18 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
     const float heroHeight = std::clamp(bodyH - 180.0f, 230.0f, 290.0f);
 
     renderer.fillRectGradient({b.x + 8.0f, b.y + 48.0f, b.width - 16.0f, b.height - 58.0f},
-                              NUIColor(0.024f, 0.022f, 0.030f, 0.98f),
-                              NUIColor(0.012f, 0.013f, 0.017f, 0.99f), true);
+                              editorNeutral(NUIColor(0.024f, 0.022f, 0.030f, 0.98f)),
+                              editorNeutral(NUIColor(0.012f, 0.013f, 0.017f, 0.99f)), true);
     drawPresetStrip(renderer, accent);
     drawCategoryPills(renderer, accent);
 
     renderer.fillRoundedRect({mainX - 8.0f, mainY - 6.0f, contentW + 16.0f, bodyH + 12.0f}, 11.0f,
-                             NUIColor(0.018f, 0.018f, 0.022f, 0.94f));
+                             editorNeutral(NUIColor(0.018f, 0.018f, 0.022f, 0.94f)));
     renderer.strokeRoundedRect({mainX - 8.0f, mainY - 6.0f, contentW + 16.0f, bodyH + 12.0f}, 11.0f, 1.0f,
                                NUIColor(1, 1, 1, 0.055f));
 
     const NUIRect heroCard(mainX, mainY, centerW, heroHeight);
-    renderer.fillRoundedRect(heroCard, 10.0f, NUIColor(0.026f, 0.025f, 0.033f, 0.98f));
+    renderer.fillRoundedRect(heroCard, 10.0f, editorNeutral(NUIColor(0.026f, 0.025f, 0.033f, 0.98f)));
     renderer.strokeRoundedRect(heroCard, 10.0f, 1.0f, accent.withAlpha(0.16f));
     renderer.fillCircle({heroCard.x + 15.0f, heroCard.y + 15.0f}, 2.0f, accent.withAlpha(0.82f));
     const NUIRect heroHeader(heroCard.x + 23.0f, heroCard.y + 2.0f, heroCard.width - 37.0f, 26.0f);
@@ -1118,13 +1118,13 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
 
     const NUIRect mixCard(m_mixBounds.x - 10.0f, m_mixBounds.y - 5.0f,
                           m_mixBounds.width + 20.0f, m_mixBounds.height + 10.0f);
-    renderer.fillRoundedRect(mixCard, 9.0f, NUIColor(0.026f, 0.025f, 0.033f, 0.96f));
+    renderer.fillRoundedRect(mixCard, 9.0f, editorNeutral(NUIColor(0.026f, 0.025f, 0.033f, 0.96f)));
     renderer.strokeRoundedRect(mixCard, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.06f));
 
     const NUIRect utilityCard(m_bypassBounds.x - 10.0f, m_bypassBounds.y - 10.0f,
                               m_mixLockBounds.right() - m_bypassBounds.x + 20.0f,
                               m_abBoundsB.bottom() - m_bypassBounds.y + 20.0f);
-    renderer.fillRoundedRect(utilityCard, 9.0f, NUIColor(0.023f, 0.023f, 0.029f, 0.94f));
+    renderer.fillRoundedRect(utilityCard, 9.0f, editorNeutral(NUIColor(0.023f, 0.023f, 0.029f, 0.94f)));
     renderer.strokeRoundedRect(utilityCard, 9.0f, 1.0f, NUIColor(1, 1, 1, 0.055f));
 
     drawSectionLabels(renderer);
@@ -1218,7 +1218,7 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
         for (auto& btn : btns) {
             if (btn.hov && btn.tip) {
                 const NUIRect tipBounds(btn.bounds.x, btn.bounds.y - 18.0f, btn.bounds.width, 16.0f);
-                renderer.fillRoundedRect(tipBounds, 3.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.92f));
+                renderer.fillRoundedRect(tipBounds, 3.0f, editorNeutral(0.0f, 0.92f));
                 renderer.drawTextCentered(btn.tip, tipBounds, 8.0f, NUIColor(1, 1, 1, 0.78f));
             }
         }
@@ -1227,7 +1227,7 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
         const auto& tip = m_presets[static_cast<size_t>(m_hoveredPreset)];
         if (!tip.tooltip.empty()) {
             const NUIRect tipBounds(tip.bounds.x, tip.bounds.bottom() + 4.0f, tip.bounds.width, 20.0f);
-            renderer.fillRoundedRect(tipBounds, 4.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.92f));
+            renderer.fillRoundedRect(tipBounds, 4.0f, editorNeutral(0.0f, 0.92f));
             renderer.drawText(tip.tooltip, {tip.bounds.x + 6.0f, tip.bounds.bottom() + 8.0f}, 8.5f,
                               NUIColor(1, 1, 1, 0.78f));
         }

--- a/AestraUI/Widgets/GenericPluginEditor.cpp
+++ b/AestraUI/Widgets/GenericPluginEditor.cpp
@@ -119,11 +119,11 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
                     LABEL_WIDTH + SLIDER_WIDTH + VALUE_WIDTH + PADDING * 3.0f + 12.0f,
                     PARAMETER_HEIGHT - 2.0f);
     renderer.fillRoundedRect(rowRect, 9.0f,
-        hovered || p.isDragging ? NUIColor(0.181f, 0.181f, 0.181f, 0.92f)
-                                : NUIColor(0.111f, 0.111f, 0.111f, 0.74f));
+        hovered || p.isDragging ? editorNeutral(0.181f, 0.92f)
+                                : editorNeutral(0.111f, 0.74f));
     renderer.strokeRoundedRect(rowRect, 9.0f, 1.0f,
         hovered || p.isDragging ? theme.getColor("accentPrimary").withAlpha(0.30f)
-                                : NUIColor(1.0f, 1.0f, 1.0f, 0.05f));
+                                : editorInk(0.05f));
 
     float labelY = offsetY + p.sliderBounds.y + (p.sliderBounds.height * 0.5f) - 5.0f; 
     renderer.drawText(p.shortName, 
@@ -135,7 +135,7 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
     NUIRect track(offsetX + p.sliderBounds.x, trackY, 
                   p.sliderBounds.width, trackH);
 
-    renderer.fillRoundedRect(track, 3.0f, NUIColor(0.039f, 0.039f, 0.039f, 0.78f));
+    renderer.fillRoundedRect(track, 3.0f, editorNeutral(0.039f, 0.78f));
 
     float fillWidth = track.width * p.normalizedValue;
     if (fillWidth > 0) {
@@ -158,7 +158,7 @@ void GenericPluginEditor::drawParameter(NUIRenderer& renderer, const ParameterWi
     NUIRect thumbRect(thumbX, thumbY, thumbSize, thumbSize);
 
     if (hovered || p.isDragging) {
-         renderer.fillRoundedRect(thumbRect, thumbSize * 0.5f, NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+         renderer.fillRoundedRect(thumbRect, thumbSize * 0.5f, editorInk(1.0f));
          renderer.strokeRoundedRect(thumbRect, thumbSize * 0.5f, 1.5f, theme.getColor("accentPrimary"));
     } else {
          float idleSize = 8.0f;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.cpp
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.cpp
@@ -505,7 +505,7 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
     const auto bounds = getBounds();
     auto& theme = NUIThemeManager::getInstance();
 
-    const auto rulerBackground = NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
+    const auto rulerBackground = NUIThemeManager::getInstance().getColor("backgroundPrimary");
     const auto border = NUIColor::white().withAlpha(0.075f);
     const auto highlight = NUIColor::white().withAlpha(0.014f);
     const auto text = theme.getColor("textPrimary").withAlpha(0.86f);
@@ -1010,12 +1010,14 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
 
     renderer.setClipRect(bounds);
-    renderer.fillRect(bounds, NUIColor::black());
+    renderer.fillRect(bounds, theme.getColor("timelineBed"));
 
-    const auto accidentalRow = NUIColor::white().withAlpha(0.022f);
+    const auto gridInk = theme.getCurrentTheme().textPrimary;
+    const auto accidentalRow = gridInk.withAlpha(0.032f);
     const auto rootRow = theme.getColor("accentPrimary").withAlpha(0.055f);
-    const auto outOfScaleRow = NUIColor::black().withAlpha(0.24f);
-    const auto rowLine = NUIColor::white().withAlpha(0.045f);
+    // Out-of-scale rows recede toward the bed's own polarity, not toward black.
+    const auto outOfScaleRow = gridInk.withAlpha(0.10f);
+    const auto rowLine = gridInk.withAlpha(0.045f);
 
     int startPitch = 127 - static_cast<int>(scrollY_ / keyHeight_);
     int endPitch = 127 - static_cast<int>((scrollY_ + bounds.height) / keyHeight_);
@@ -1040,7 +1042,7 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     }
 
     renderTimelineGrid(
-        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
+        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk);
 
     if (hoveredPitch_ >= 0 && hoveredPitch_ <= 127) {
         const float hoverY = bounds.y + (127 - hoveredPitch_) * keyHeight_ - scrollY_;
@@ -1062,7 +1064,7 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     if (patternEndX < bounds.right()) {
         const float shadeX = std::max(bounds.x, patternEndX);
         renderer.fillRect(NUIRect(shadeX, bounds.y, bounds.right() - shadeX, bounds.height),
-                          NUIColor::black().withAlpha(0.58f));
+                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
     }
     if (patternEndX >= bounds.x && patternEndX <= bounds.right()) {
         renderer.drawLine(NUIPoint(patternEndX, bounds.y),
@@ -1811,8 +1813,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
 
     // Rubber-band selection rectangle (already normalized during drag)
     if (state_ == State::SelectingBox && selectionRect_.width > 0 && selectionRect_.height > 0) {
-        renderer.fillRoundedRect(selectionRect_, 2.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.15f));
-        renderer.strokeRoundedRect(selectionRect_, 2.0f, 1.0f, NUIColor(0.545f, 0.498f, 1.0f, 0.55f));
+        renderer.fillRoundedRect(selectionRect_, 2.0f, NUIThemeManager::getInstance().getColor("accentPrimary").withAlpha(0.15f));
+        renderer.strokeRoundedRect(selectionRect_, 2.0f, 1.0f, NUIThemeManager::getInstance().getColor("accentPrimary").withAlpha(0.55f));
     }
 
     renderNoteProperties(renderer);
@@ -3111,7 +3113,8 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(contentRect);
 
     const float startX = contentRect.x;
-    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_);
+    renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_,
+                       themeManager.getCurrentTheme().textPrimary);
 
     const float availH = std::max(1.0f, b.height - 28.0f);
     const float bottomY = b.bottom() - 8.0f;
@@ -3128,7 +3131,7 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     if (patternEndX < contentRect.right()) {
         const float shadeX = std::max(contentRect.x, patternEndX);
         renderer.fillRect(NUIRect(shadeX, contentRect.y, contentRect.right() - shadeX, contentRect.height),
-                          NUIColor::black().withAlpha(0.58f));
+                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
     }
     if (patternEndX >= contentRect.x && patternEndX <= contentRect.right()) {
         renderer.drawLine(NUIPoint(patternEndX, contentRect.y),

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -45,8 +45,6 @@ namespace Colors {
     static const NUIColor badgeVst3Text = NUIColor(0.655f, 0.545f, 0.980f, 1.0f);
     static const NUIColor badgeClapBg   = NUIColor(0.204f, 0.835f, 0.600f, 0.20f);
     static const NUIColor badgeClapText = NUIColor(0.204f, 0.835f, 0.600f, 1.0f);
-    static const NUIColor badgeIntBg    = NUIColor(1.0f, 1.0f, 1.0f, 0.08f);
-    static const NUIColor badgeIntText  = NUIColor(1.0f, 1.0f, 1.0f, 0.40f);
 
     // Active pill
     NUIColor pillActiveBg() { return NUIThemeManager::getInstance().getColor("selection"); }
@@ -877,7 +875,7 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
 
     // DEBUG: Visual indicator for pending removal
     if (slot.pendingRemoval) {
-        renderer.strokeRoundedRect(slotRect, 4.0f, 2.0f, NUIColor(1.0f, 0.0f, 0.0f, 0.8f));
+        renderer.strokeRoundedRect(slotRect, 4.0f, 2.0f, NUIThemeManager::getInstance().getColor("error").withAlpha(0.8f));
     }
 
     // Shared vertical midline for the slot row — center everything around it

--- a/AestraUI/Widgets/RumblePluginEditor.cpp
+++ b/AestraUI/Widgets/RumblePluginEditor.cpp
@@ -33,13 +33,13 @@ NUIColor cleanAccent() {
     return NUIColor(0.35f, 0.72f, 1.0f, 1.0f);
 }
 NUIColor shellSurface() {
-    return NUIColor(0.026f, 0.025f, 0.032f, 0.985f);
+    return editorNeutral(NUIColor(0.026f, 0.025f, 0.032f, 0.985f));
 }
 NUIColor panelSurface() {
-    return NUIColor(0.043f, 0.041f, 0.052f, 0.98f);
+    return editorNeutral(NUIColor(0.043f, 0.041f, 0.052f, 0.98f));
 }
 NUIColor insetSurface() {
-    return NUIColor(0.022f, 0.021f, 0.027f, 0.98f);
+    return editorNeutral(NUIColor(0.022f, 0.021f, 0.027f, 0.98f));
 }
 
 std::shared_ptr<NUIIcon> chevronLeftIcon() {
@@ -289,7 +289,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
     const auto drawArrowButton = [&](const NUIRect& rect, const std::shared_ptr<NUIIcon>& icon, bool hovered) {
         renderer.fillRoundedRect(rect, 9.0f, hovered ? bodyAccent().withAlpha(0.26f) : insetSurface());
         renderer.strokeRoundedRect(rect, 9.0f, 1.0f,
-                                   hovered ? bodyAccent().withAlpha(0.62f) : NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                                   hovered ? bodyAccent().withAlpha(0.62f) : editorInk(0.08f));
         drawSvgIcon(renderer, icon, rect, hovered ? bodyAccent() : theme.getColor("textPrimary").withAlpha(0.72f),
                     15.0f);
     };
@@ -307,7 +307,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
                                                                        : insetSurface());
     renderer.strokeRoundedRect(m_presetButtonBounds, 9.0f, 1.0f,
                                m_presetButtonHovered || m_presetMenuOpen ? bodyAccent().withAlpha(0.65f)
-                                                                         : NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+                                                                         : editorInk(0.09f));
     renderer.fillRoundedRect({m_presetButtonBounds.x + 9.0f, m_presetButtonBounds.y + 10.0f, 3.0f, 28.0f}, 1.5f,
                              (factory ? presetAccent(m_activePreset) : bodyAccent()).withAlpha(0.88f));
     renderer.drawText(factory ? std::string(preset.category) : "CUSTOM",
@@ -318,7 +318,7 @@ void RumblePluginEditor::drawHeader(NUIRenderer& renderer) {
                       factory ? presetAccent(m_activePreset) : theme.getColor("textPrimary"));
     renderer.drawLine({m_presetButtonBounds.right() - 32.0f, m_presetButtonBounds.y + 8.0f},
                       {m_presetButtonBounds.right() - 32.0f, m_presetButtonBounds.bottom() - 8.0f}, 1.0f,
-                      NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+                      editorInk(0.07f));
     const NUIRect chevronBounds(m_presetButtonBounds.right() - 30.0f, m_presetButtonBounds.y, 28.0f,
                                 m_presetButtonBounds.height);
     drawSvgIcon(renderer, m_presetMenuOpen ? chevronUpIcon() : chevronDownIcon(), chevronBounds,
@@ -361,7 +361,7 @@ void RumblePluginEditor::drawImpactShape(NUIRenderer& renderer) {
     for (int i = 1; i < 4; ++i) {
         const float x = m_impactShapeBounds.x + m_impactShapeBounds.width * static_cast<float>(i) / 4.0f;
         renderer.drawLine({x, m_impactShapeBounds.y + 12.0f}, {x, m_impactShapeBounds.bottom() - 12.0f}, 1.0f,
-                          NUIColor(1.0f, 1.0f, 1.0f, 0.035f));
+                          editorInk(0.035f));
     }
     const float punch = m_controls.size() > 0 ? m_controls[0].normalizedValue : 0.0f;
     const float sweep = m_controls.size() > 1 ? m_controls[1].normalizedValue : 0.0f;
@@ -389,23 +389,23 @@ void RumblePluginEditor::drawKnob(NUIRenderer& renderer, const MacroControl& con
     const bool dragging = m_draggingControl == controlIndex;
     const NUIColor accent = controlAccent(control.parameterId);
     renderer.fillRoundedRect(control.bounds, 11.0f,
-                             hovered || dragging ? NUIColor(0.068f, 0.064f, 0.080f, 0.98f)
-                                                 : NUIColor(0.036f, 0.034f, 0.043f, 0.82f));
+                             hovered || dragging ? editorNeutral(NUIColor(0.068f, 0.064f, 0.080f, 0.98f))
+                                                 : editorNeutral(NUIColor(0.036f, 0.034f, 0.043f, 0.82f)));
     renderer.strokeRoundedRect(control.bounds, 11.0f, 1.0f,
-                               hovered || dragging ? accent.withAlpha(0.50f) : NUIColor(1.0f, 1.0f, 1.0f, 0.045f));
+                               hovered || dragging ? accent.withAlpha(0.50f) : editorInk(0.045f));
 
     const NUIPoint center = control.knobBounds.center();
     const float radius = control.knobBounds.width * 0.5f;
     const float valueAngle = kKnobStart + control.normalizedValue * kKnobSweep;
     renderer.fillCircle(center, radius, insetSurface());
-    renderer.strokeCircle(center, radius, 1.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.07f));
+    renderer.strokeCircle(center, radius, 1.0f, editorInk(0.07f));
     drawArc(renderer, center, radius - 6.0f, kKnobStart, kKnobStart + kKnobSweep, primary ? 4.0f : 3.2f,
-            NUIColor(1.0f, 1.0f, 1.0f, 0.09f));
+            editorInk(0.09f));
     drawArc(renderer, center, radius - 6.0f, kKnobStart, valueAngle, primary ? 4.0f : 3.2f, accent.withAlpha(0.94f));
     const float needleLength = radius - (primary ? 16.0f : 13.0f);
     const NUIPoint tip{center.x + std::cos(valueAngle) * needleLength, center.y + std::sin(valueAngle) * needleLength};
     renderer.drawLine(center, tip, 2.0f, accent.withAlpha(0.86f));
-    renderer.fillCircle(center, primary ? 7.0f : 5.5f, NUIColor(0.075f, 0.071f, 0.088f, 1.0f));
+    renderer.fillCircle(center, primary ? 7.0f : 5.5f, editorNeutral(NUIColor(0.075f, 0.071f, 0.088f, 1.0f)));
     renderer.fillCircle(center, primary ? 2.8f : 2.2f, accent.withAlpha(0.90f));
 
     const float labelY = control.knobBounds.bottom() + (primary ? 8.0f : 5.0f);
@@ -423,7 +423,7 @@ void RumblePluginEditor::drawKnob(NUIRenderer& renderer, const MacroControl& con
 
 void RumblePluginEditor::drawPresetBrowser(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
-    renderer.fillRoundedRect(m_presetMenuBounds, 16.0f, NUIColor(0.018f, 0.017f, 0.023f, 1.0f));
+    renderer.fillRoundedRect(m_presetMenuBounds, 16.0f, editorNeutral(NUIColor(0.018f, 0.017f, 0.023f, 1.0f)));
     renderer.strokeRoundedRect(m_presetMenuBounds, 16.0f, 1.2f, bodyAccent().withAlpha(0.58f));
     renderer.drawText("FACTORY SOUNDS", {m_presetMenuBounds.x + 18.0f, m_presetMenuBounds.y + 17.0f}, 11.0f,
                       theme.getColor("textPrimary"));
@@ -444,10 +444,10 @@ void RumblePluginEditor::drawPresetBrowser(NUIRenderer& renderer) {
         const NUIColor accent = presetAccent(i);
         renderer.fillRoundedRect(m_presetItemBounds[i], 8.0f,
                                  active    ? accent.withAlpha(0.22f)
-                                 : hovered ? NUIColor(0.095f, 0.088f, 0.115f, 0.96f)
+                                 : hovered ? editorNeutral(NUIColor(0.095f, 0.088f, 0.115f, 0.96f))
                                            : panelSurface());
         renderer.strokeRoundedRect(m_presetItemBounds[i], 8.0f, 1.0f,
-                                   active || hovered ? accent.withAlpha(0.58f) : NUIColor(1.0f, 1.0f, 1.0f, 0.055f));
+                                   active || hovered ? accent.withAlpha(0.58f) : editorInk(0.055f));
         renderer.drawText(std::string(Aestra::Plugins::kRumbleFactoryPresets[i].name),
                           {m_presetItemBounds[i].x + 10.0f, m_presetItemBounds[i].y + 13.0f}, 9.5f,
                           active ? accent : theme.getColor("textPrimary").withAlpha(0.88f));

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -54,10 +54,9 @@ void UIMixerButtonRow::cacheThemeColors()
     m_textOnBright = theme.getColor("textPrimary");
     m_textOnRed = theme.getColor("textPrimary");
 
-    // Active glow colors (amber mute, yellow solo, red arm)
-    m_muteOn = NUIColor(1.0f, 0.75f, 0.2f, 1.0f);   // amber
-    m_soloOn = NUIColor(1.0f, 0.92f, 0.3f, 1.0f);   // yellow
-    m_armOn  = NUIColor(1.0f, 0.25f, 0.25f, 1.0f);  // red
+    m_muteOn = theme.getColor("muted");
+    m_soloOn = theme.getColor("soloed");
+    m_armOn = theme.getColor("armed");
 }
 
 void UIMixerButtonRow::layoutButtons()

--- a/AestraUI/Widgets/UIMixerButtonRow.h
+++ b/AestraUI/Widgets/UIMixerButtonRow.h
@@ -19,6 +19,7 @@ public:
     UIMixerButtonRow();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseLeave() override;
@@ -72,4 +73,3 @@ private:
 };
 
 } // namespace AestraUI
-

--- a/AestraUI/Widgets/UIMixerFXSummary.h
+++ b/AestraUI/Widgets/UIMixerFXSummary.h
@@ -16,6 +16,7 @@ public:
     UIMixerFXSummary();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setFxCount(int count);

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -31,13 +31,15 @@ void UIMixerFader::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();
     // Track: Deep Glass Slot
-    m_trackBg = AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.6f);
+    m_trackBg = theme.getColor("meterBackground").withAlpha(0.72f);
     // Fill: Gradient handled in render
     m_trackFg = theme.getColor("accentPrimary"); 
     m_handle = theme.getColor("backgroundSecondary"); // Handle Core
     m_handleHover = theme.getColor("textPrimary");    // Handle Active
     m_text = theme.getColor("textPrimary");
     m_textSecondary = theme.getColor("textSecondary");
+    m_border = theme.getColor("borderStrong");
+    m_tooltipBg = theme.getColor("elevatedPanel").withAlpha(0.98f);
 }
 
 float UIMixerFader::clampDb(float db) const
@@ -102,7 +104,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
 
     // 1. Track Background (deep recessed slot)
     renderer.fillRoundedRect(trackRect, 2.0f, m_trackBg);
-    renderer.strokeRoundedRect(trackRect, 2.0f, 1.0f, NUIColor(0.0f, 0.0f, 0.0f, 0.6f));
+    renderer.strokeRoundedRect(trackRect, 2.0f, 1.0f, m_border.withAlpha(0.60f));
 
     // 2. Filled Portion (subtle, no wide glow)
     const float norm = (m_valueDb - m_minDb) / std::max(1e-3f, (m_maxDb - m_minDb));
@@ -135,11 +137,11 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
 
     // Handle Body (dark surface) — flat, no drop shadow; the border + slit
     // give it enough definition.
-    renderer.fillRoundedRect(handleRect, handleRad, NUIColor(0.18f, 0.18f, 0.18f, 0.98f));
+    renderer.fillRoundedRect(handleRect, handleRad, m_handle.withAlpha(0.98f));
 
     // Handle Border (accent when active/hovered, subtle white otherwise)
     bool handleActive = isHovered() || m_dragging;
-    NUIColor handleBorder = handleActive ? m_trackFg : NUIColor(1.0f, 1.0f, 1.0f, 0.25f);
+    NUIColor handleBorder = handleActive ? m_trackFg : m_border;
     renderer.strokeRoundedRect(handleRect, handleRad, 1.0f, handleBorder);
 
     // Center accent line (the "light slit")
@@ -148,7 +150,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
     renderer.fillRoundedRect(
         NUIRect{handleX + (handleW - slitW)*0.5f, handleY + (handleH - slitH)*0.5f, slitW, slitH},
         1.5f,
-        handleActive ? m_trackFg : NUIColor(1.0f, 1.0f, 1.0f, 0.5f)
+        handleActive ? m_trackFg : m_textSecondary
     );
 
     // 4. Fixed dB readout at top of fader area (not attached to handle)
@@ -168,7 +170,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
             tipY = handleY + handleH + 4.0f;
         }
 
-        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, NUIColor(0.05f, 0.05f, 0.05f, 0.95f));
+        renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, m_tooltipBg);
         renderer.strokeRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, 1.0f, m_trackFg.withAlpha(0.5f));
         renderer.drawTextCentered(m_cachedText, {tipX, tipY, tipW, tipH}, 10.5f, m_text);
     }

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -24,6 +24,7 @@ public:
     UIMixerFader();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setRangeDb(float minDb, float maxDb);
@@ -69,6 +70,8 @@ private:
     NUIColor m_handleHover;
     NUIColor m_text;
     NUIColor m_textSecondary;
+    NUIColor m_border;
+    NUIColor m_tooltipBg;
 
     static constexpr float FADER_FLOOR_THRESHOLD = -60.0f;
 

--- a/AestraUI/Widgets/UIMixerFooter.h
+++ b/AestraUI/Widgets/UIMixerFooter.h
@@ -15,6 +15,7 @@ public:
     UIMixerFooter();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
 
     void setTrackNumber(int number);
 

--- a/AestraUI/Widgets/UIMixerHeader.h
+++ b/AestraUI/Widgets/UIMixerHeader.h
@@ -17,6 +17,7 @@ public:
     UIMixerHeader();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setTrackName(std::string name);

--- a/AestraUI/Widgets/UIMixerInspector.h
+++ b/AestraUI/Widgets/UIMixerInspector.h
@@ -31,6 +31,7 @@ public:
     explicit UIMixerInspector(Aestra::MixerViewModel* viewModel);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIMixerKnob.h
+++ b/AestraUI/Widgets/UIMixerKnob.h
@@ -27,6 +27,7 @@ public:
     explicit UIMixerKnob(UIMixerKnobType type);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setValue(float value);

--- a/AestraUI/Widgets/UIMixerMeter.cpp
+++ b/AestraUI/Widgets/UIMixerMeter.cpp
@@ -29,7 +29,7 @@ void UIMixerMeter::cacheThemeColors()
     m_colorYellowDim = m_colorYellow.withSaturation(0.0f).withAlpha(0.55f);
     m_colorRedDim = m_colorRed.withSaturation(0.0f).withAlpha(0.55f);
     // Match fader track background (Dark Glass)
-    m_colorBackground = AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.3f);
+    m_colorBackground = theme.getColor("meterBackground").withAlpha(0.3f);
     m_colorPeakHold = theme.getColor("textPrimary"); // #E5E5E8
     m_colorPeakOverlay = m_colorPeakHold.withAlpha(0.8f);
     m_colorPeakOverlayDim = m_colorPeakOverlay.withSaturation(0.0f).withAlpha(0.6f);
@@ -250,7 +250,7 @@ void UIMixerMeter::renderMeterBar(NUIRenderer& renderer, const NUIRect& bounds,
         // Draw hold line (white 0.85 alpha, 1px thick)
         const NUIColor holdColor = m_dimmed
             ? m_colorPeakOverlayDim
-            : NUIColor(1.0f, 1.0f, 1.0f, 0.85f);
+            : m_colorPeakHold.withAlpha(0.85f);
         renderer.fillRect(NUIRect{meterArea.x, peakY, meterArea.width, PEAK_HOLD_HEIGHT}, holdColor);
     }
 
@@ -310,7 +310,7 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
         
         // Background (distinct from main meter)
         // Use a visible gray track (0.25f)
-        renderer.fillRect(corrBounds, NUIColor(0.25f, 0.25f, 0.25f, 1.0f));
+        renderer.fillRect(corrBounds, NUIThemeManager::getInstance().getColor("controlBackground"));
         
         // Center line (white/bright) - 2px width
         float centerX = corrBounds.x + corrBounds.width * 0.5f;
@@ -392,7 +392,7 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
             lineHeight
         };
         std::string lufsLabel = "LUFS " + m_cachedLufsStr;
-        renderer.drawTextCentered(lufsLabel, lufsRect, 7.0f, NUIColor(1.0f, 1.0f, 1.0f, 0.45f));
+        renderer.drawTextCentered(lufsLabel, lufsRect, 7.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.45f));
         
     } else if (hasPeak) {
         // Regular tracks: Show Peak dB or −∞ at silence floor

--- a/AestraUI/Widgets/UIMixerMeter.h
+++ b/AestraUI/Widgets/UIMixerMeter.h
@@ -23,6 +23,7 @@ public:
     UIMixerMeter();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
 
     /**

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -50,6 +50,7 @@ public:
     ~UIMixerPanel() override;
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIMixerPluginDropdown.h
+++ b/AestraUI/Widgets/UIMixerPluginDropdown.h
@@ -22,6 +22,7 @@ public:
     UIMixerPluginDropdown();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -39,6 +39,7 @@ public:
                  std::shared_ptr<Aestra::Audio::ContinuousParamBuffer> continuousParams);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -87,6 +87,7 @@ void UIRoutingMap::cacheThemeColors() {
     m_textInfo = tm.getColor("info");
     m_accent = tm.getColor("accentPrimary");
     m_warning = tm.getColor("warning");
+    m_error = tm.getColor("error");
 }
 
 void UIRoutingMap::rebuildGraph() {
@@ -730,7 +731,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
     // === Chrome: flat rounded card ===
     // Solid dark card so the workspace doesn't bleed through. Flat — no fake
     // drop shadow, no depth gradient (matches the app's flat surface language).
-    renderer.fillRoundedRect(bounds, kCornerRadius, NUIColor(0.046f, 0.046f, 0.046f, 1.0f));
+    renderer.fillRoundedRect(bounds, kCornerRadius, m_bg);
 
     // === Title bar === charcoal (backgroundSecondary), matching the transport
     // bar and every docked panel's chrome — rounded top, squared flush bottom.
@@ -822,7 +823,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
             float itemH = 22.0f;
             float dropH = static_cast<float>(m_searchMatches.size()) * itemH + 4.0f;
             NUIRect dropRect{searchX, dropY, searchW, dropH};
-            renderer.fillRoundedRect(dropRect, 5.0f, NUIColor(0.085f, 0.085f, 0.085f, 0.98f));
+            renderer.fillRoundedRect(dropRect, 5.0f, m_bgTertiary.withAlpha(0.98f));
             renderer.strokeRoundedRect(dropRect, 5.0f, 1.0f, m_border.withAlpha(0.35f));
             for (size_t i = 0; i < m_searchMatches.size() && i < 5; ++i) {
                 int nodeIdx = m_searchMatches[i];
@@ -1106,7 +1107,7 @@ void UIRoutingMap::renderFullPanel(NUIRenderer& renderer) {
         const float pillH = kLegFont + kPadY * 2.0f + 2.0f;
         NUIRect legendBg{bounds.x + 14.0f, bounds.bottom() - pillH - 12.0f,
                          contentW + kPadX * 2.0f, pillH};
-        renderer.fillRoundedRect(legendBg, 5.0f, NUIColor(0.046f, 0.046f, 0.046f, 0.85f));
+        renderer.fillRoundedRect(legendBg, 5.0f, m_bgTertiary.withAlpha(0.85f));
         renderer.strokeRoundedRect(legendBg, 5.0f, 1.0f, m_border.withAlpha(0.14f));
 
         const float textY = legendBg.y + kPadY;
@@ -1168,11 +1169,9 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
         // the destination stays visually distinct.
         NUIColor bg;
         if (node.type == Node::Master) {
-            bg = node.hovered ? NUIColor(0.22f, 0.16f, 0.32f, 1.0f)
-                              : NUIColor(0.18f, 0.13f, 0.27f, 1.0f);
+            bg = node.hovered ? m_accent.withAlpha(0.28f) : m_accent.withAlpha(0.20f);
         } else {
-            bg = node.hovered ? NUIColor(0.137f, 0.137f, 0.137f, 1.0f)
-                              : NUIColor(0.097f, 0.097f, 0.097f, 1.0f);
+            bg = node.hovered ? m_bgTertiary : m_bgSecondary;
         }
         renderer.fillRoundedRect(nodeRect, radius, bg);
 
@@ -1195,8 +1194,7 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
 
         // Muted overlay: dim the entire node
         if (node.muted) {
-            renderer.fillRoundedRect(nodeRect, radius,
-                                      NUIColor(0.0f, 0.0f, 0.0f, 0.55f));
+            renderer.fillRoundedRect(nodeRect, radius, m_bg.withAlpha(0.72f));
         }
 
         if (node.type == Node::Master) {
@@ -1260,14 +1258,14 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
             }
             if (node.muted) {
                 NUIRect bRect{badgeX - 16.0f, ny + 6.0f, 16.0f, 16.0f};
-                renderer.fillRoundedRect(bRect, 4.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.85f));
+                renderer.fillRoundedRect(bRect, 4.0f, m_error.withAlpha(0.85f));
                 renderer.drawTextCentered("M", bRect, 10.0f, NUIColor::white());
             }
 
             // Routing warning badge (top-left, overlapping the color strip)
             if (node.hasRoutingWarning) {
                 NUIRect wRect{nx + 6.0f, ny + 6.0f, 16.0f, 16.0f};
-                renderer.fillRoundedRect(wRect, 4.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.9f));
+                renderer.fillRoundedRect(wRect, 4.0f, m_warning.withAlpha(0.9f));
                 renderer.drawTextCentered("!", wRect, 11.0f, NUIColor::white());
             }
 
@@ -1281,7 +1279,7 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
                 float trackH_meter = 3.0f;
                 float meterY = ny + nh - trackH_meter - 4.0f;
                 NUIRect track{nx + 14.0f, meterY, nw - 24.0f, trackH_meter};
-                renderer.fillRoundedRect(track, 1.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.08f));
+                renderer.fillRoundedRect(track, 1.5f, m_text.withAlpha(0.08f));
 
                 // Map dB to 0..1: -60dB → 0, 0dB → 1
                 float normalized = std::clamp((node.peakDb + 60.0f) / 60.0f, 0.0f, 1.0f);
@@ -1326,13 +1324,13 @@ void UIRoutingMap::drawNode(NUIRenderer& renderer, const Node& node, float scale
     } else {
         // === Minimap mode ===
         // Brighter overlay so nodes contrast against the dark card.
-        NUIColor nodeFill = NUIColor(1.0f, 1.0f, 1.0f, node.hovered ? 0.18f : 0.12f);
+        NUIColor nodeFill = m_text.withAlpha(node.hovered ? 0.18f : 0.12f);
         renderer.fillRoundedRect(nodeRect, radius, nodeFill);
 
         // Border picks up solo/selection state too
         bool isSelected = (m_viewModel &&
                            static_cast<int32_t>(node.id) == m_viewModel->getSelectedChannelId());
-        NUIColor strokeColor = NUIColor(1.0f, 1.0f, 1.0f, 0.22f);
+        NUIColor strokeColor = m_text.withAlpha(0.22f);
         if (node.soloed) strokeColor = m_warning.withAlpha(0.95f);
         else if (isSelected) strokeColor = m_accent.withAlpha(0.85f);
         else if (node.hovered) strokeColor = m_accent.withAlpha(0.7f);
@@ -2351,29 +2349,30 @@ void UIRoutingMap::drawSendLevelLabel(NUIRenderer& renderer, const NUIPoint& a, 
     float textW = renderer.measureText(buf, fontSize).width;
     float textH = fontSize + 2.0f;
     NUIRect bg{mx - textW * 0.5f - 3.0f, my - textH * 0.5f, textW + 6.0f, textH};
-    renderer.fillRoundedRect(bg, 3.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.85f));
+    renderer.fillRoundedRect(bg, 3.0f, m_bgSecondary.withAlpha(0.85f));
     renderer.strokeRoundedRect(bg, 3.0f, 0.5f, m_borderSecondary.withAlpha(0.4f));
     renderer.drawTextCentered(buf, bg, fontSize, m_textSecondary.withAlpha(0.85f));
 }
 
 NUIColor UIRoutingMap::resolveInsertColor(const std::string& name) const {
+    auto& tm = NUIThemeManager::getInstance();
     std::string low;
     low.reserve(name.size());
     for (char c : name) low.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
 
     if (low.find("eq") != std::string::npos || low.find("filter") != std::string::npos)
-        return NUIColor(0.46f, 0.92f, 0.92f, 0.92f); // cyan
+        return tm.getColor("accentCyan").withAlpha(0.92f);
     if (low.find("comp") != std::string::npos || low.find("limit") != std::string::npos)
-        return NUIColor(0.96f, 0.60f, 0.26f, 0.92f); // orange
+        return tm.getColor("accentAmber").withAlpha(0.92f);
     if (low.find("reverb") != std::string::npos || low.find("delay") != std::string::npos)
-        return NUIColor(0.36f, 0.58f, 0.96f, 0.92f); // blue
+        return tm.getColor("info").withAlpha(0.92f);
     if (low.find("dist") != std::string::npos || low.find("sat") != std::string::npos || low.find("drive") != std::string::npos)
-        return NUIColor(0.96f, 0.36f, 0.36f, 0.92f); // red
+        return tm.getColor("accentRed").withAlpha(0.92f);
     if (low.find("chorus") != std::string::npos || low.find("flang") != std::string::npos || low.find("phaser") != std::string::npos)
-        return NUIColor(0.46f, 0.86f, 0.46f, 0.92f); // green
+        return tm.getColor("accentLime").withAlpha(0.92f);
     if (low.find("sampler") != std::string::npos || low.find("sample") != std::string::npos)
-        return NUIColor(0.96f, 0.86f, 0.36f, 0.92f); // yellow
-    return NUIColor(0.72f, 0.52f, 0.96f, 0.92f); // purple default
+        return tm.getColor("warning").withAlpha(0.92f);
+    return tm.getColor("accentPrimary").withAlpha(0.92f);
 }
 
 void UIRoutingMap::drawInsertDots(NUIRenderer& renderer, const Node& node, float nx, float ny, float nw, float nh) {
@@ -2385,7 +2384,7 @@ void UIRoutingMap::drawInsertDots(NUIRenderer& renderer, const Node& node, float
     for (size_t i = 0; i < node.insertNames.size(); ++i) {
         NUIColor col = resolveInsertColor(node.insertNames[i]);
         renderer.fillCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, col);
-        renderer.strokeCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, 0.5f, NUIColor(1.0f, 1.0f, 1.0f, 0.25f));
+        renderer.strokeCircle({startX + i * (dotR * 2.0f + gap), startY}, dotR, 0.5f, m_text.withAlpha(0.25f));
     }
 }
 
@@ -2447,7 +2446,7 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
     float offsetY = insetY + insetH * 0.5f - (m_worldMinY + worldH * 0.5f) * scale;
 
     // Background
-    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, NUIColor(0.055f, 0.055f, 0.055f, 0.92f));
+    renderer.fillRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, m_bgSecondary.withAlpha(0.92f));
     renderer.strokeRoundedRect({insetX, insetY, insetW, insetH}, 6.0f, 1.0f, m_border.withAlpha(0.35f));
 
     // Draw all edges as thin faint lines
@@ -2475,8 +2474,8 @@ void UIRoutingMap::renderMiniOverview(NUIRenderer& renderer) {
         float ny = offsetY + node.y * scale;
         float nw = node.w * scale;
         float nh = node.h * scale;
-        NUIColor fill = NUIColor(0.169f, 0.169f, 0.169f, 0.85f);
-        if (node.type == Node::Master) fill = NUIColor(0.25f, 0.18f, 0.36f, 0.85f);
+        NUIColor fill = m_bgTertiary.withAlpha(0.85f);
+        if (node.type == Node::Master) fill = m_accent.withAlpha(0.24f);
         renderer.fillRoundedRect({nx, ny, nw, nh}, 2.0f, fill);
         renderer.strokeRoundedRect({nx, ny, nw, nh}, 2.0f, 0.5f, m_border.withAlpha(0.4f));
     }
@@ -2535,7 +2534,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     m_inspectorPanelRect = NUIRect{insetX, insetY, kInspectorW, insetH};
 
     // Background
-    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, NUIColor(0.065f, 0.065f, 0.065f, 0.96f));
+    renderer.fillRoundedRect(m_inspectorPanelRect, 8.0f, m_bgSecondary.withAlpha(0.96f));
     renderer.strokeRoundedRect(m_inspectorPanelRect, 8.0f, 1.0f, m_border.withAlpha(0.45f));
 
     // Clip content to panel interior (scrollable area)
@@ -2574,7 +2573,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
         }
         if (ch->muted) {
             NUIRect bRect{badgeX, y, 20.0f, 18.0f};
-            renderer.fillRoundedRect(bRect, 4.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.85f));
+            renderer.fillRoundedRect(bRect, 4.0f, m_error.withAlpha(0.85f));
             renderer.drawTextCentered("M", bRect, 10.0f, NUIColor::white());
         }
         y += 24.0f;
@@ -2583,10 +2582,10 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     // Routing warning
     if (node.hasRoutingWarning) {
         std::string warn = m_viewModel->getRoutingWarning(node.id);
-        renderer.fillRoundedRect({left, y, textW, 20.0f}, 4.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.18f));
-        renderer.strokeRoundedRect({left, y, textW, 20.0f}, 4.0f, 1.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.5f));
+        renderer.fillRoundedRect({left, y, textW, 20.0f}, 4.0f, m_warning.withAlpha(0.18f));
+        renderer.strokeRoundedRect({left, y, textW, 20.0f}, 4.0f, 1.0f, m_warning.withAlpha(0.5f));
         std::string wtext = fitLabel(renderer, warn, 10.0f, textW - 8.0f);
-        renderer.drawText(wtext, {left + 6.0f, y + 3.0f}, 10.0f, NUIColor(0.9f, 0.5f, 0.2f, 0.9f));
+        renderer.drawText(wtext, {left + 6.0f, y + 3.0f}, 10.0f, m_warning.withAlpha(0.9f));
         y += 28.0f;
     }
 
@@ -2684,7 +2683,7 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
                 metaX += renderer.measureText("pre", 9.0f).width + 8.0f;
             }
             if (send.muted) {
-                renderer.drawText("muted", {metaX, metaY}, 9.0f, NUIColor(0.7f, 0.2f, 0.2f, 0.75f));
+                renderer.drawText("muted", {metaX, metaY}, 9.0f, m_error.withAlpha(0.75f));
             }
 
             y += 28.0f;
@@ -2697,8 +2696,8 @@ void UIRoutingMap::renderInspector(NUIRenderer& renderer) {
     // Close button (top-right of panel)
     m_inspectorCloseRect = NUIRect{insetX + kInspectorW - 26.0f, insetY + 8.0f, 18.0f, 18.0f};
     renderer.fillRoundedRect(m_inspectorCloseRect, 5.0f,
-                             m_inspectorCloseHovered ? NUIColor(0.9f, 0.3f, 0.3f, 0.45f)
-                                                      : NUIColor(0.2f, 0.2f, 0.2f, 0.4f));
+                             m_inspectorCloseHovered ? m_warning.withAlpha(0.45f)
+                                                      : m_bgTertiary.withAlpha(0.4f));
     renderer.drawTextCentered("x", m_inspectorCloseRect, 12.0f, m_textSecondary.withAlpha(0.85f));
 }
 

--- a/AestraUI/Widgets/UIRoutingMap.h
+++ b/AestraUI/Widgets/UIRoutingMap.h
@@ -29,6 +29,7 @@ public:
     explicit UIRoutingMap(Mode mode = Mode::Minimap);
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
@@ -244,6 +245,7 @@ private:
     NUIColor m_textInfo;
     NUIColor m_accent;
     NUIColor m_warning;
+    NUIColor m_error;
 
     void cacheThemeColors();
     void rebuildGraph();

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -259,7 +259,7 @@ void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     auto& theme = NUIThemeManager::getInstance();
     
     NUIColor bgColor = active ? theme.getColor("warning") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? NUIColor(0.0f, 0.0f, 0.0f, 1.0f) : theme.getColor("textSecondary");
+    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
     NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
 
     // Circular Button
@@ -280,7 +280,7 @@ void UnitRow::drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     auto& theme = NUIThemeManager::getInstance();
 
     NUIColor bgColor = active ? theme.getColor("success") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? NUIColor(0.0f, 0.0f, 0.0f, 1.0f) : theme.getColor("textSecondary");
+    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
     NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
 
     // Circular Button

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,47 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessMain.cpp")
   message(STATUS "AestraHeadless configured")
 endif()
 
+# =============================================================================
+# MuseRepl - Agentic runtime entry point (JSONL over stdin/stdout, no UI)
+# =============================================================================
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/MuseReplMain.cpp")
+  add_executable(MuseRepl
+    Source/App/MuseReplMain.cpp
+  )
+
+  if(MSVC)
+    target_compile_options(MuseRepl PRIVATE /utf-8)
+  endif()
+
+  set_target_properties(MuseRepl PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+
+  target_link_libraries(MuseRepl PRIVATE
+    AestraAudioCore
+    AestraCore
+  )
+
+  target_include_directories(MuseRepl PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+  )
+
+  if(WIN32)
+    target_compile_definitions(MuseRepl PRIVATE
+      _CRT_SECURE_NO_WARNINGS
+      NOMINMAX
+    )
+  endif()
+
+  message(STATUS "MuseRepl configured")
+endif()
+
 if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessExportMain.cpp")
   add_executable(AestraHeadlessExport
     Source/App/HeadlessExportMain.cpp

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -22,6 +22,7 @@
 #include "PluginManager.h"
 #include "AudioGraphBuilder.h"
 #include "TakeManager.h"
+#include "../Panels/TakesPanel.h"
 #include "../../AestraAudio/include/Core/PlaybackGraphController.h"
 #include "../../AestraAudio/include/IO/AudioExporter.h"
 
@@ -61,10 +62,6 @@ void syncRecordingProjectPath(const std::shared_ptr<AestraContent>& content, con
     }
 }
 
-std::string takeMenuLabel(const TakeManager::TakeEntry& take) {
-    const std::string name = take.name.empty() ? take.id : take.name;
-    return take.active ? ("[current] " + name) : name;
-}
 }
 
 // =============================================================================
@@ -308,6 +305,8 @@ void AestraApp::initializeContent() {
     m_windowManager->setContent(m_content);
     m_audioController->setContent(m_content);
 
+    wireTakesPanel();
+
     // Performance HUD is created eagerly: it must exist independently of the
     // lazily built settings dialogs, or F12 / View → Performance Stats are
     // silent no-ops until the user happens to open Settings or Export first.
@@ -450,77 +449,20 @@ void AestraApp::buildMenuBar() {
             }
         });
 
-        auto takesMenu = std::make_shared<AestraUI::NUIContextMenu>();
-        const bool hasProjectContext = m_content && m_content->getTrackManager() && !m_projectPath.empty();
-        if (!hasProjectContext) {
-            auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Active Project");
-            emptyItem->setEnabled(false);
-            takesMenu->addItem(emptyItem);
-        } else {
-            takesMenu->addItem("Create Take from Current State", [this]() {
-                if (!createTakeFromCurrentProject()) {
-                    Log::error("Failed to create Take");
-                }
-            });
-            takesMenu->addItem("Save Active Take", [this]() {
-                if (!saveProject()) {
-                    Log::error("Failed to save active Take");
-                }
-            });
-            takesMenu->addSeparator();
+        menu->addSeparator();
 
-            const auto manifest = TakeManager::loadManifest(m_projectPath);
-            if (!manifest.ok) {
-                if (manifest.errorMessage == "No Takes manifest") {
-                    auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Takes Yet");
-                    emptyItem->setEnabled(false);
-                    takesMenu->addItem(emptyItem);
-                } else {
-                    Log::warning("[Takes] Could not load manifest: " + manifest.errorMessage);
-                    auto errItem = std::make_shared<AestraUI::NUIContextMenuItem>("Error loading takes");
-                    errItem->setEnabled(false);
-                    takesMenu->addItem(errItem);
-                }
-            } else {
-                size_t count = 0;
-                for (const auto& take : manifest.takes) {
-                    if (count++ >= 20)
-                        break;
-                    auto item = std::make_shared<AestraUI::NUIContextMenuItem>(takeMenuLabel(take));
-                    item->setEnabled(!take.active);
-                    item->setOnClick([this, takeId = take.id]() {
-                        auto result = switchToTake(takeId);
-                        if (!result.ok) {
-                            Log::error("Failed to switch Take: " + takeId + " (" + result.errorMessage + ")");
-                        }
-                    });
-                    takesMenu->addItem(item);
-                }
-            }
-        }
+        // Takes = "which version of the work do I want?" — opens the Takes
+        // workspace panel (create/name/open/duplicate/branch project versions).
+        menu->addItem("Takes", [this]() {
+            if (m_content) m_content->toggleTakesPanel();
+        });
 
-        menu->addSubmenu("Takes", takesMenu);
+        // History = "what actions did I perform?" — opens the command-timeline
+        // panel wired to the undo/redo system.
+        menu->addItem("History  Ctrl+H", [this]() {
+            if (m_content) m_content->toggleHistoryPanel();
+        });
 
-        auto historyMenu = std::make_shared<AestraUI::NUIContextMenu>();
-        const auto historyEntries = ProjectSerializer::listHistory(m_projectPath);
-        if (historyEntries.empty()) {
-            auto emptyItem = std::make_shared<AestraUI::NUIContextMenuItem>("No Save History");
-            emptyItem->setEnabled(false);
-            historyMenu->addItem(emptyItem);
-        } else {
-            size_t count = 0;
-            for (const auto& entry : historyEntries) {
-                if (count++ >= 10) break;
-                historyMenu->addItem(entry.label, [this, snapshotPath = entry.path]() {
-                    auto result = loadProjectFromPath(snapshotPath, m_projectPath);
-                    if (!result.ok) {
-                        Log::error("Failed to restore snapshot: " + snapshotPath + " (" + result.errorMessage + ")");
-                    }
-                });
-            }
-        }
-
-        menu->addSubmenu("Project History", historyMenu);
         menu->addSeparator();
         menu->addItem("Export Audio...", [this]() { startExport(); });
         menu->addSeparator();
@@ -615,6 +557,9 @@ void AestraApp::buildMenuBar() {
         });
         menu->addItem("Show History  Ctrl+H", [this]() {
             if (m_content) m_content->toggleHistoryPanel();
+        });
+        menu->addItem("Show Takes", [this]() {
+            if (m_content) m_content->toggleTakesPanel();
         });
 
         m_windowManager->showDropdownMenu(menu, 100.0f);
@@ -1290,6 +1235,13 @@ ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& 
     if (result.ui) {
         applyUIState(*result.ui);
     }
+    // Loading may change the project (and its takes manifest) out from under
+    // an open Takes panel — re-pull the providers.
+    if (m_content) {
+        if (auto takesPanel = m_content->getTakesPanel(); takesPanel && takesPanel->isVisible()) {
+            takesPanel->refreshTakes();
+        }
+    }
     updateWindowTitle();
     Log::info("Project loaded into app state from " + path);
     return result;
@@ -1364,6 +1316,12 @@ bool AestraApp::saveProjectToPath(const std::string& path) {
         } else {
             Log::warning("[Takes] Project saved but take snapshot failed, keeping dirty state");
             return false;
+        }
+    }
+    // A save updates the active take's timestamp — keep an open Takes panel honest.
+    if (ok) {
+        if (auto takesPanel = m_content->getTakesPanel(); takesPanel && takesPanel->isVisible()) {
+            takesPanel->refreshTakes();
         }
     }
     return ok;
@@ -1485,6 +1443,135 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
 
     Log::info("[Takes] Switched to Take: " + activeResult.take.name);
     return result;
+}
+
+bool AestraApp::branchFromTake(const std::string& takeId) {
+    if (m_projectPath.empty() || takeId.empty()) {
+        return false;
+    }
+
+    // Preserve the working state before anything else touches the manifest.
+    if (!saveProject()) {
+        Log::warning("[Takes] Could not save the current Take before branching");
+        return false;
+    }
+
+    const auto manifest = TakeManager::loadManifest(m_projectPath);
+    const auto* source = manifest.ok ? manifest.findTake(takeId) : nullptr;
+    const std::string branchName = source ? (source->name + " Branch") : "";
+
+    auto dup = TakeManager::duplicateTake(m_projectPath, takeId, branchName);
+    if (!dup.ok) {
+        Log::warning("[Takes] Could not branch from Take: " + dup.errorMessage);
+        return false;
+    }
+
+    auto result = switchToTake(dup.take.id);
+    if (!result.ok) {
+        // Don't leave a half-made branch behind: the duplicate is not active
+        // (the failed switch rolled back), so it can be deleted safely.
+        auto rollback = TakeManager::deleteTake(m_projectPath, dup.take.id);
+        Log::error("[Takes] Branch created but could not switch to it: " + result.errorMessage +
+                   (rollback.ok ? " (branch rolled back)" : " (rollback also failed: " + rollback.errorMessage + ")"));
+        return false;
+    }
+    return true;
+}
+
+void AestraApp::wireTakesPanel() {
+    if (!m_content) {
+        return;
+    }
+    auto takesPanel = m_content->getTakesPanel();
+    if (!takesPanel) {
+        return;
+    }
+
+    takesPanel->setTakesProvider([this]() -> TakeManager::Manifest {
+        if (m_projectPath.empty()) {
+            TakeManager::Manifest manifest;
+            manifest.errorMessage = "No Takes manifest";
+            return manifest;
+        }
+        return TakeManager::loadManifest(m_projectPath);
+    });
+
+    takesPanel->setSnapshotsProvider([this]() {
+        std::vector<Aestra::Audio::TakesPanel::SnapshotEntry> entries;
+        if (m_projectPath.empty()) {
+            return entries;
+        }
+        for (const auto& entry : ProjectSerializer::listHistory(m_projectPath)) {
+            entries.push_back({entry.path, entry.label});
+        }
+        return entries;
+    });
+
+    takesPanel->setOnCreateTake([this]() { return createTakeFromCurrentProject(); });
+    takesPanel->setOnSaveActiveTake([this]() { return saveProject(); });
+
+    takesPanel->setOnOpenTake([this](const std::string& takeId) {
+        auto result = switchToTake(takeId);
+        if (!result.ok) {
+            Log::error("[Takes] Failed to open Take: " + takeId + " (" + result.errorMessage + ")");
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnRenameTake([this](const std::string& takeId, const std::string& name) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::renameTake(m_projectPath, takeId, name);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not rename Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnDuplicateTake([this](const std::string& takeId) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::duplicateTake(m_projectPath, takeId);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not duplicate Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnDeleteTake([this](const std::string& takeId) {
+        if (m_projectPath.empty()) {
+            return false;
+        }
+        auto result = TakeManager::deleteTake(m_projectPath, takeId);
+        if (!result.ok) {
+            Log::warning("[Takes] Could not delete Take: " + result.errorMessage);
+        }
+        return result.ok;
+    });
+
+    takesPanel->setOnBranchTake([this](const std::string& takeId) { return branchFromTake(takeId); });
+
+    takesPanel->setOnRestoreSnapshot([this](const std::string& path) {
+        // Save the current take first so a snapshot restore never silently
+        // destroys the working state.
+        if (!saveProject()) {
+            Log::warning("[Takes] Could not save the current Take before restoring a snapshot");
+            return false;
+        }
+        auto result = loadProjectFromPath(path, m_projectPath);
+        if (!result.ok) {
+            Log::error("Failed to restore snapshot: " + path + " (" + result.errorMessage + ")");
+            return false;
+        }
+        // The project file still holds the pre-restore save; the restored
+        // state is unsaved work until the user commits it.
+        if (m_content && m_content->getTrackManager()) {
+            m_content->getTrackManager()->markModified();
+        }
+        return true;
+    });
 }
 
 void AestraApp::reinitAutosaveManager() {

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -93,6 +93,8 @@ private:
     bool saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState = nullptr);
     bool createTakeFromCurrentProject();
     ProjectSerializer::LoadResult switchToTake(const std::string& takeId);
+    bool branchFromTake(const std::string& takeId);
+    void wireTakesPanel();
     void reinitAutosaveManager();
     ProjectSerializer::UIState captureUIState() const;
     void applyUIState(const ProjectSerializer::UIState& state);

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -67,6 +67,9 @@ int main(int argc, char** argv) {
     trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputChannelCount(0);
+    // The app wires this in AestraContent; without it, creating a unit does
+    // not create its default MIDI pattern.
+    trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
 
     AudioEngine engine;
     engine.setSampleRate(sampleRate);

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -22,6 +22,7 @@
 #include "Commands/CommandRegistry.h"
 #include "Commands/MuseGrammar.h"
 #include "Commands/MuseService.h"
+#include "Plugin/PluginManager.h"
 #include "TrackManager.h"
 
 #include <cctype>
@@ -63,6 +64,13 @@ int main(int argc, char** argv) {
 
     // Session setup mirrors the app's wiring: TrackManager owns the model and
     // history, AudioEngine owns transport/tempo, the registry binds both.
+    // Built-in plugins (the sampler load_sample instantiates) register inside
+    // PluginManager::initialize(); without it units stay silent.
+    if (!PluginManager::getInstance().initialize()) {
+        std::cerr << "failed to initialize plugin manager\n";
+        return 1;
+    }
+
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
     trackManager->setInputSampleRate(static_cast<double>(sampleRate));
@@ -74,6 +82,11 @@ int main(int argc, char** argv) {
     AudioEngine engine;
     engine.setSampleRate(sampleRate);
     engine.setBufferConfig(512, 2);
+    MuseService::wireHeadlessEngine(trackManager, engine);
+    if (!engine.initialize()) {
+        std::cerr << "failed to initialize audio engine\n";
+        return 1;
+    }
 
     CommandRegistry::initialize(trackManager.get());
     CommandRegistry::setAudioEngine(&engine);

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -1,0 +1,97 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// MuseRepl — the stdin/stdout entry point to Aestra's agentic runtime.
+//
+// One JSON request per input line, one JSON response per output line
+// (JSONL both ways). Everything goes through MuseService: the same schema
+// validation, command factories, and undo history the UI uses. This is how
+// an external agent (or a human with a pipe) drives a headless session:
+//
+//   $ MuseRepl <<'EOF'
+//   {"id": 1, "verb": "set_bpm", "args": {"value": 142}}
+//   {"id": 2, "verb": "add_track", "args": {"name": "Drums"}}
+//   {"id": 3, "verb": "list_tracks"}
+//   EOF
+//
+// Flags:
+//   --schema      print the MuseGrammar command schema as JSON and exit
+//                 (the agent's tool manifest)
+//   --sample-rate <hz>  engine sample rate (default 48000)
+
+#include "AudioEngine.h"
+#include "Commands/CommandRegistry.h"
+#include "Commands/MuseGrammar.h"
+#include "Commands/MuseService.h"
+#include "TrackManager.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace Aestra::Audio;
+
+int main(int argc, char** argv) {
+    uint32_t sampleRate = 48000;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--schema") {
+            std::cout << MuseGrammar::schemaToJsonString();
+            return 0;
+        }
+        if (arg == "--sample-rate" && i + 1 < argc) {
+            const long parsed = std::strtol(argv[++i], nullptr, 10);
+            if (parsed >= 8000 && parsed <= 192000) {
+                sampleRate = static_cast<uint32_t>(parsed);
+            } else {
+                std::cerr << "invalid --sample-rate, using 48000\n";
+            }
+            continue;
+        }
+        if (arg == "--help" || arg == "-h") {
+            std::cout << "MuseRepl: JSONL in on stdin, JSONL out on stdout.\n"
+                         "  --schema             print command schema JSON and exit\n"
+                         "  --sample-rate <hz>   engine sample rate (default 48000)\n";
+            return 0;
+        }
+        std::cerr << "unknown argument: " << arg << "\n";
+        return 2;
+    }
+
+    // Session setup mirrors the app's wiring: TrackManager owns the model and
+    // history, AudioEngine owns transport/tempo, the registry binds both.
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputSampleRate(static_cast<double>(sampleRate));
+    trackManager->setInputChannelCount(0);
+
+    AudioEngine engine;
+    engine.setSampleRate(sampleRate);
+    engine.setBufferConfig(512, 2);
+
+    CommandRegistry::initialize(trackManager.get());
+    CommandRegistry::setAudioEngine(&engine);
+
+    MuseService service(trackManager.get(), &engine);
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        // Skip blank lines so hand-driven sessions can space things out.
+        bool blank = true;
+        for (char c : line) {
+            if (!std::isspace(static_cast<unsigned char>(c))) {
+                blank = false;
+                break;
+            }
+        }
+        if (blank) continue;
+
+        std::cout << service.handleRequest(line) << "\n";
+        std::cout.flush();
+    }
+
+    return 0;
+}

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -81,7 +81,9 @@ int main(int argc, char** argv) {
 
     AudioEngine engine;
     engine.setSampleRate(sampleRate);
-    engine.setBufferConfig(512, 2);
+    // Must cover AudioExporter's 4096-frame render blocks (render_song):
+    // processBlock does not split blocks larger than the configured maximum.
+    engine.setBufferConfig(4096, 2);
     MuseService::wireHeadlessEngine(trackManager, engine);
     if (!engine.initialize()) {
         std::cerr << "failed to initialize audio engine\n";

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -50,6 +50,8 @@ set(Aestra_SOURCES
 	Panels/AuditionPanel.cpp
 	Panels/AestraHistoryPanel.h
 	Panels/AestraHistoryPanel.cpp
+	Panels/TakesPanel.h
+	Panels/TakesPanel.cpp
 	Panels/SampleEditorPanel.h
 	Panels/SampleEditorPanel.cpp
 	

--- a/Source/Components/AudioVisualizer.cpp
+++ b/Source/Components/AudioVisualizer.cpp
@@ -197,6 +197,17 @@ void AudioVisualizer::onResize(int width, int height) {
     currentSample_ = 0;
 }
 
+void AudioVisualizer::onThemeChanged(const NUIThemeProperties& theme) {
+    backgroundColor_ = theme.backgroundPrimary;
+    gridColor_ = theme.border;
+    textColor_ = theme.textPrimary;
+    if (!customColorScheme_) {
+        primaryColor_ = theme.accentCyan;
+        secondaryColor_ = theme.accentMagenta;
+    }
+    NUIComponent::onThemeChanged(theme);
+}
+
 // =============================================================================
 // SECTION: Audio Data Input
 // =============================================================================
@@ -303,6 +314,7 @@ void AudioVisualizer::setDecayRate(float decayRate) {
 void AudioVisualizer::setColorScheme(const NUIColor& primary, const NUIColor& secondary) {
     primaryColor_ = primary;
     secondaryColor_ = secondary;
+    customColorScheme_ = true;
     setDirty(true);
 }
 
@@ -378,7 +390,7 @@ void AudioVisualizer::renderWaveform(NUIRenderer& renderer) {
     
     // Liminal Dark v2.0 background gradient - top: #121214 â†’ bottom: #18181b
     NUIColor topColor = backgroundColor_;  // #121214 - Deep charcoal
-    NUIColor bottomColor = NUIColor(0.094f, 0.094f, 0.094f, 1.0f);  // #181818 - Slightly lighter
+    NUIColor bottomColor = AestraUI::NUIThemeManager::getInstance().getColor("backgroundSecondary");
     
     // Draw gradient background
     for (int i = 0; i < static_cast<int>(bounds.height); ++i) {
@@ -521,7 +533,7 @@ void AudioVisualizer::renderWaveform(NUIRenderer& renderer) {
     
     // Audio active pulse indicator - Liminal Dark v2.0
     float pulse = 0.5f + 0.5f * std::sin(animationTime_ * 3.5f);
-    NUIColor pulseColor = NUIColor(0.620f, 1.0f, 0.380f, pulse * glowIntensity);  // #9eff61 - Accent lime
+    NUIColor pulseColor = AestraUI::NUIThemeManager::getInstance().getColor("accentLime").withAlpha(pulse * glowIntensity);
     float pulseRadius = 5.0f + (glowIntensity * 2.0f);
     renderer.fillCircle(NUIPoint(bounds.x + bounds.width - 15, bounds.y + bounds.height - 15), 
                        pulseRadius, pulseColor);
@@ -718,7 +730,7 @@ void AudioVisualizer::renderOscilloscope(NUIRenderer& renderer) {
     // Add trigger level indicator
     float triggerLevel = 0.3f; // Fixed trigger level for demo
     float triggerY = centerY - triggerLevel * bounds.height / 2.0f;
-    renderer.drawLine(NUIPoint(bounds.x, triggerY), NUIPoint(bounds.x + bounds.width, triggerY), 1, NUIColor(1.0f, 1.0f, 0.0f, 0.6f));
+    renderer.drawLine(NUIPoint(bounds.x, triggerY), NUIPoint(bounds.x + bounds.width, triggerY), 1, AestraUI::NUIThemeManager::getInstance().getColor("warning").withAlpha(0.6f));
     
     // Add timebase indicator
     std::string timebaseText = "1ms/div";

--- a/Source/Components/AudioVisualizer.h
+++ b/Source/Components/AudioVisualizer.h
@@ -40,6 +40,7 @@ public:
     void onRender(NUIRenderer& renderer) override;
     void onUpdate(double deltaTime) override;
     void onResize(int width, int height) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override;
     
     // Audio data input
     void setAudioData(const float* leftChannel, const float* rightChannel, size_t numSamples, double sampleRate);
@@ -115,6 +116,7 @@ private:
     float decayRate_;
     NUIColor primaryColor_;
     NUIColor secondaryColor_;
+    bool customColorScheme_{false};
     bool showStereo_;
     bool showPeakHold_;
     

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -172,7 +172,7 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
         
         // Meter background (Dark Slot)
         AestraUI::NUIRect meterBg(meterX, meterY, meterW, meterH);
-        renderer.fillRoundedRect(meterBg, 2.0f, AestraUI::NUIColor(0.05f, 0.05f, 0.05f, 0.8f));
+        renderer.fillRoundedRect(meterBg, 2.0f, theme.getColor("meterBackground"));
         
         // Get current level (Mock/Placeholder)
         float level = m_track->getVolume(); // Simple mapping
@@ -193,12 +193,12 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
             
             if (isActive) {
                 float n = static_cast<float>(i) / numSegments;
-                if (n < 0.7f) segColor = AestraUI::NUIColor::fromHex(0x00ffaa); // Cyan
-                else if (n < 0.9f) segColor = AestraUI::NUIColor::fromHex(0xffaa00); // Amber
-                else segColor = AestraUI::NUIColor::fromHex(0xff3333); // Red
+                if (n < 0.7f) segColor = theme.getColor("meterSafe");
+                else if (n < 0.9f) segColor = theme.getColor("meterWarn");
+                else segColor = theme.getColor("meterCrit");
                 segColor = segColor.withAlpha(0.9f);
             } else {
-                segColor = AestraUI::NUIColor(0.2f, 0.2f, 0.2f, 0.3f);
+                segColor = theme.getColor("meterBackground").withAlpha(0.55f);
             }
             
             renderer.fillRect(AestraUI::NUIRect(meterX + 1.0f, y + segGap, meterW - 2.0f, segH - segGap), segColor);
@@ -273,15 +273,13 @@ void MixerView::onRender(AestraUI::NUIRenderer& renderer) {
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     auto bounds = getBounds();
     
-    // Deep Void Background
-    auto bgColor = AestraUI::NUIColor::fromHex(0x050505); // Matches Playlist
-    renderer.fillRect(bounds, bgColor);
+    renderer.fillRect(bounds, theme.getColor("workspaceBackground"));
     
     // Subtle Top Gradient (Header Shadow)
     renderer.fillRectGradient(
         AestraUI::NUIRect(bounds.x, bounds.y, bounds.width, 20.0f),
-        AestraUI::NUIColor(0,0,0,0.4f),
-        AestraUI::NUIColor(0,0,0,0.0f),
+        theme.getColor("shadow").withAlpha(0.40f),
+        theme.getColor("shadow").withAlpha(0.0f),
         true
     );
     

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -180,9 +180,9 @@ void TimelineMinimapBar::endDrag_()
 void TimelineMinimapBar::cacheThemeColors_()
 {
     auto& theme = NUIThemeManager::getInstance();
-    // Near-black shell matching the ruler material exactly (one continuous
-    // band; the old surfaceRaised tint read blue against neighboring rows).
-    colors_.glassFill = NUIColor(0.012f, 0.012f, 0.012f, 0.98f);
+    // Match the ruler's recessed material so the band remains continuous in
+    // every theme.
+    colors_.glassFill = theme.getColor("recessedPanel");
     colors_.glassBorder = theme.getColor("border").withAlpha(0.28f);
     colors_.cornerSeparator = theme.getColor("border").withAlpha(0.28f);
 
@@ -196,8 +196,8 @@ void TimelineMinimapBar::cacheThemeColors_()
     colors_.selectionFill = theme.getColor("accentCyan").withAlpha(0.10f);
     colors_.loopFill = theme.getColor("accentPrimary").withAlpha(0.08f);
 
-    colors_.playheadDark = NUIColor(0.0f, 0.0f, 0.0f, 0.75f);
-    colors_.playheadBright = NUIColor(1.0f, 1.0f, 1.0f, 0.85f);
+    colors_.playheadDark = theme.getColor("shadow").withAlpha(0.75f);
+    colors_.playheadBright = theme.getColor("textPrimary").withAlpha(0.85f);
 
     colors_.text = theme.getColor("textPrimary");
 }

--- a/Source/Components/TimelineMinimapBar.h
+++ b/Source/Components/TimelineMinimapBar.h
@@ -29,6 +29,7 @@ public:
     TimelineMinimapBar();
 
     void onRender(NUIRenderer& renderer) override;
+    void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors_(); NUIComponent::onThemeChanged(theme); }
     void onUpdate(double deltaTime) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     void onMouseLeave() override;

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -1785,12 +1785,12 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
     // Draw background (control area + full grid area - no bounds restriction)
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor::black(); // pure black grid (owner direction)
+    const AestraUI::NUIColor gridBgColor = themeManager.getColor("timelineBed"); // pure black on dark (owner direction), recessed on light
 
     if (m_playlistVisible) {
         // Background for control area (always visible)
         AestraUI::NUIRect controlBg(bounds.x, bounds.y, controlAreaWidth, bounds.height);
-        renderer.fillRect(controlBg, AestraUI::NUIColor(0.035f, 0.035f, 0.035f, 1.0f));
+        renderer.fillRect(controlBg, themeManager.getColor("recessedPanel"));
 
         // Background for grid area (match track background; zebra grid provides contrast)
         float scrollbarWidth = kTimelineScrollbarWidth;
@@ -1870,9 +1870,10 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         if (trackBounds.bottom() < viewportTop || trackBounds.y > viewportBottom)
             continue;
 
-        // Uniform pure-black row base (owner direction: no row zebra; the bar
-        // zebra inside drawPlaylistGrid provides the only alternation).
-        renderer.fillRect(trackBounds, AestraUI::NUIColor::black());
+        // Uniform row base (owner direction: no row zebra; the bar zebra
+        // inside drawPlaylistGrid provides the only alternation). Pure black
+        // on dark themes, recessed light bed on light themes.
+        renderer.fillRect(trackBounds, themeManager.getColor("timelineBed"));
 
         track->renderStatic(renderer);
 
@@ -1883,7 +1884,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         const AestraUI::NUIRect gapRect(bounds.x + gridStartX, trackBounds.bottom(),
                                         std::max(0.0f, trackWidth - gridStartX),
                                         static_cast<float>(m_trackSpacing));
-        renderer.fillRect(gapRect, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.30f));
+        renderer.fillRect(gapRect, AestraUI::NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.30f));
     }
 
     // Clear clip rect before drawing header/ruler (they should draw fully)
@@ -1901,7 +1902,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         AestraUI::NUIRect headerRect(bounds.x, bounds.y, headerWidth, headerHeight);
         // Elevated header: base fill + soft vertical gradient + glass top edge.
         // Rendered into the playlist FBO cache, so the richness is free per frame.
-        renderer.fillRect(headerRect, AestraUI::NUIColor(0.031f, 0.031f, 0.031f, 1.0f));
+        renderer.fillRect(headerRect, themeManager.getColor("recessedPanel"));
         // Shade-only elevation — any white component reads as a sheen on this
         // near-black chrome (owner direction: no light gradients anywhere).
         renderer.fillRectGradient(headerRect, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
@@ -3738,8 +3739,8 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
 
     // Opaque near-black ruler material — identical across the full row and the
     // grid shell so the corner over the track controls is flush by construction.
-    auto glassBg = AestraUI::NUIColor(0.012f, 0.012f, 0.012f, 1.0f);
-    auto glassHighlight = AestraUI::NUIColor::white().withAlpha(0.014f);
+    auto glassBg = themeManager.getColor("recessedPanel");
+    auto glassHighlight = themeManager.getColor("textPrimary").withAlpha(0.014f);
 
     auto textCol = themeManager.getColor("textPrimary").withAlpha(0.86f);
     auto majorTickCol = themeManager.getColor("gridMajor");
@@ -4158,7 +4159,7 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
 
     AestraUI::NUIRect textureBounds(0, 0, static_cast<float>(width), static_cast<float>(height));
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-    const AestraUI::NUIColor gridBgColor = AestraUI::NUIColor(0.08235f, 0.08235f, 0.08235f, 1.0f); // #151515
+    const AestraUI::NUIColor gridBgColor = themeManager.getColor("workspaceBackground");
     AestraUI::NUIColor borderColor = themeManager.getColor("border");
 
     // Draw background panels
@@ -4196,9 +4197,9 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
     double maxExtentInBeats = maxExtent / secondsPerBeat;
 
     // Ruler Render: "Mature" Playlist Style
-    auto bg = AestraUI::NUIColor(0.08f, 0.08f, 0.08f, 1.0f);
-    auto textCol = AestraUI::NUIColor(0.82f, 0.82f, 0.82f, 1.0f); // bright gray for ruler labels
-    auto tickCol = AestraUI::NUIColor(0.45f, 0.45f, 0.45f, 1.0f); // visible tick marks
+    auto bg = themeManager.getColor("recessedPanel");
+    auto textCol = themeManager.getColor("textPrimary");
+    auto tickCol = themeManager.getColor("gridMajor");
 
     // Draw ruler background
     renderer.fillRect(rulerRect, bg);
@@ -5166,7 +5167,7 @@ void TrackManagerUI::renderDropPreview(AestraUI::NUIRenderer& renderer) {
             const float clipLabelFont = themeManager.getFontSize("xs");
             const float labelTextY = headerRect.y + std::max(0.0f, (headerRect.height - clipLabelFont) * 0.5f);
             AestraUI::NUIPoint textPos(clipPreview.x + 6.0f, labelTextY);
-            renderer.drawText(displayName, textPos, clipLabelFont, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+            renderer.drawText(displayName, textPos, clipLabelFont, AestraUI::NUIThemeManager::getInstance().getCurrentTheme().textPrimary);
         }
     }
 }

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -4372,9 +4372,11 @@ void TrackManagerUI::deleteSelectedClip() {
 AestraUI::DropFeedback TrackManagerUI::onDragEnter(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) {
     Log::info("[TrackManagerUI] Drag entered");
 
-    // Accept file drops, audio clip moves, plugins, and MIDI clips
-    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::AudioClip &&
-        data.type != AestraUI::DragDataType::Plugin && data.type != AestraUI::DragDataType::MidiClip) {
+    // Accept file drops, plugins, patterns, and MIDI clips. (Timeline clip
+    // moves are an internal mouse drag, not a DragData transfer — see
+    // m_draggedClipId.)
+    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::Plugin &&
+        data.type != AestraUI::DragDataType::MidiClip && data.type != AestraUI::DragDataType::Pattern) {
         return AestraUI::DropFeedback::Invalid;
     }
 
@@ -4400,9 +4402,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragEnter(const AestraUI::DragData& dat
     if (m_dropTargetTrack >= 0 && m_dropTargetTrack <= trackCount) {
         m_showDropPreview = true;
         setDirty(true);
-        // Move for clips; Copy for files and plugins
-        return data.type == AestraUI::DragDataType::AudioClip ? AestraUI::DropFeedback::Move
-                                                              : AestraUI::DropFeedback::Copy;
+        return AestraUI::DropFeedback::Copy;
     }
 
     return AestraUI::DropFeedback::Invalid;
@@ -4456,9 +4456,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data
         if (m_dropTargetTrack >= 0 && m_dropTargetTrack <= trackCount) {
             m_showDropPreview = true;
             setDirty(true);
-            // Move for clips; Copy for files and plugins
-            return data.type == AestraUI::DragDataType::AudioClip ? AestraUI::DropFeedback::Move
-                                                                  : AestraUI::DropFeedback::Copy;
+            return AestraUI::DropFeedback::Copy;
         } else {
             m_showDropPreview = false;
             setDirty(true);
@@ -4468,8 +4466,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data
 
     // Return appropriate feedback based on preview state
     if (m_showDropPreview) {
-        return data.type == AestraUI::DragDataType::AudioClip ? AestraUI::DropFeedback::Move
-                                                              : AestraUI::DropFeedback::Copy;
+        return AestraUI::DropFeedback::Copy;
     }
     return AestraUI::DropFeedback::Invalid;
 }
@@ -4531,32 +4528,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
         targetLaneId = playlist.getLaneId(laneIndex);
     }
 
-    // 3. Handle AudioClip repositioning
-    if (data.type == AestraUI::DragDataType::AudioClip) {
-        ClipInstanceID clipId = ClipInstanceID::fromString(data.sourceClipIdString);
-
-        if (clipId.isValid()) {
-            auto cmd = std::make_shared<MoveClipCommand>(playlist, clipId, timePositionBeats, targetLaneId);
-            m_trackManager->getCommandHistory().pushAndExecute(cmd);
-            result.accepted = true;
-            result.message =
-                "Clip moved to lane " + std::to_string(laneIndex) + " at beat " + std::to_string(timePositionBeats);
-            Log::info("[TrackManagerUI] Clip moved via PlaylistModel: " + data.sourceClipIdString);
-        } else {
-            result.accepted = false;
-            result.message = "Invalid clip reference";
-        }
-
-        refreshTracks();
-        invalidateCache();
-        clearDropPreview();
-        refreshTracks();
-        invalidateCache();
-        clearDropPreview();
-        return result;
-    }
-
-    // 4. Handle Pattern Drop
+    // 3. Handle Pattern Drop
     if (data.type == AestraUI::DragDataType::Pattern) {
         PatternID pid;
 

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -64,6 +64,10 @@ class TrackManagerUI : public ::AestraUI::NUIComponent, public ::AestraUI::IDrop
 public:
     TrackManagerUI(std::shared_ptr<TrackManager> trackManager);
     ~TrackManagerUI() override;
+    void onThemeChanged(const ::AestraUI::NUIThemeProperties& theme) override {
+        invalidateAllCaches();
+        ::AestraUI::NUIComponent::onThemeChanged(theme);
+    }
 
     void setPlatformWindow(::AestraUI::NUIPlatformBridge* window);
     ::AestraUI::NUIPlatformBridge* getPlatformWindow() const { return m_window; }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -888,7 +888,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
             AestraUI::NUIPoint(clipBounds.x + 4.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
             AestraUI::NUIPoint(clipBounds.right() - 4.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
             1.0f,
-            AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.09f)
+            themeManager.getCurrentTheme().textPrimary.withAlpha(0.09f)
         );
 
         const std::string displayName = truncateClipLabel(sampleName, clipBounds.width - 16.0f, 6.0f);
@@ -904,7 +904,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
             renderer.drawText(displayName,
                               AestraUI::NUIPoint(clipBounds.x + 6.0f, textY),
                               kClipLabelFontSize,
-                              AestraUI::NUIColor(1.0f, 1.0f, 1.0f, clipSelected ? 0.92f : 0.78f));
+                              themeManager.getCurrentTheme().textPrimary.withAlpha(clipSelected ? 0.92f : 0.78f));
         }
     }
 }
@@ -1026,7 +1026,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
     }
 
     const float clipRadius = themeManager.getRadius("s");
-    renderer.fillRoundedRect(clipBounds, clipRadius, AestraUI::NUIColor(0.071f, 0.071f, 0.071f, 0.96f));
+    renderer.fillRoundedRect(clipBounds, clipRadius, themeManager.getColor("elevatedPanel").withAlpha(0.96f));
     renderer.fillRoundedRect(clipBounds, clipRadius, baseColor.withAlpha(isSelected ? 0.38f : 0.28f));
     renderer.strokeRoundedRect(
         clipBounds,
@@ -1051,7 +1051,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
         AestraUI::NUIPoint(clipBounds.x + 6.0f, clipBounds.y + headerHeight + 1.0f),
         AestraUI::NUIPoint(clipBounds.right() - 6.0f, clipBounds.y + headerHeight + 1.0f),
         1.0f,
-        AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.08f)
+        themeManager.getCurrentTheme().textPrimary.withAlpha(0.08f)
     );
 
     std::string clipName = clip.name;
@@ -1065,7 +1065,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
     const std::string displayName = truncateClipLabel(clipName, clipBounds.width - 46.0f, 5.9f);
     if (!displayName.empty()) {
         renderer.drawText(displayName, AestraUI::NUIPoint(clipBounds.x + 10.0f, clipBounds.y + 4.0f),
-                          9.5f, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 1.0f));
+                          9.5f, themeManager.getCurrentTheme().textPrimary);
     }
 
     if (m_trackManager && clip.patternId.isValid()) {
@@ -1099,7 +1099,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     AestraUI::NUIPoint(clipBounds.x + 7.0f, y),
                     AestraUI::NUIPoint(clipBounds.right() - 4.0f, y),
                     1.0f,
-                    AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.06f)
+                    themeManager.getCurrentTheme().textPrimary.withAlpha(0.06f)
                 );
             }
 
@@ -1113,7 +1113,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     AestraUI::NUIPoint(stepX, noteAreaY + 1.0f),
                     AestraUI::NUIPoint(stepX, clipBounds.bottom() - 4.0f),
                     1.0f,
-                    AestraUI::NUIColor(1.0f, 1.0f, 1.0f, major ? 0.08f : 0.04f)
+                    themeManager.getCurrentTheme().textPrimary.withAlpha(major ? 0.08f : 0.04f)
                 );
             }
             
@@ -1136,7 +1136,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
                     if (noteRect.x + noteRect.width > clipBounds.x + clipBounds.width) {
                         noteRect.width = (clipBounds.x + clipBounds.width) - noteRect.x;
                     }
-                    renderer.fillRoundedRect(noteRect, themeProps.radiusXS, AestraUI::NUIColor(1.0f, 0.985f, 0.93f, isSelected ? 0.88f : 0.78f));
+                    renderer.fillRoundedRect(noteRect, themeProps.radiusXS, themeManager.getCurrentTheme().textPrimary.withAlpha(isSelected ? 0.88f : 0.78f));
                     if (noteRect.width > 6.0f && noteRect.height > 2.5f) {
                         renderer.fillRoundedRect(
                             {noteRect.x + 1.0f, noteRect.y + 1.0f, std::max(0.0f, noteRect.width - 2.0f), std::max(0.0f, noteRect.height - 2.0f)},
@@ -1178,7 +1178,7 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
          AestraUI::NUIColor selectedColor = themeManager.getColor("accentPrimary").withAlpha(0.075f);
          trackBgColor = selectedColor; 
     } else if (isHovered()) {
-         trackBgColor = AestraUI::NUIColor::white().withAlpha(0.026f);
+         trackBgColor = themeManager.getCurrentTheme().textPrimary.withAlpha(0.026f);
     }
     
     // Apply background
@@ -1193,9 +1193,9 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
     if (m_isPrimaryForLane) {
         AestraUI::NUIRect controlBounds(bounds.x, bounds.y, controlAreaWidth, bounds.height);
 
-        // Control Area base: elevated surface from palette.
-        // Near-black chrome per owner direction (was surfaceTertiary, read bluish-grey).
-        AestraUI::NUIColor baseControlColor(0.038f, 0.039f, 0.045f, 1.0f);
+        // Control Area base: near-black chrome on dark themes (owner
+        // direction — surfaceTertiary read bluish-grey), clean surface on light.
+        AestraUI::NUIColor baseControlColor = themeManager.getColor("trackChrome");
 
         // Static Control Area State
         if (m_channel) {
@@ -1592,7 +1592,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                     trackPoints.push_back({cx + std::cos(theta) * r, cy + std::sin(theta) * r});
                 }
                 renderer.drawPolyline(trackPoints.data(), static_cast<int>(trackPoints.size()), 2.0f,
-                                      AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.13f));
+                                      themeManager.getCurrentTheme().textPrimary.withAlpha(0.13f));
 
                 // Active value arc
                 if (t > 0.0f) {
@@ -1612,7 +1612,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                 // Pointer dot at current value
                 const float ptrX = cx + std::cos(currentAng) * (r * 0.72f);
                 const float ptrY = cy + std::sin(currentAng) * (r * 0.72f);
-                renderer.fillCircle({ptrX, ptrY}, 1.8f, AestraUI::NUIColor(1.0f, 1.0f, 1.0f, 0.9f));
+                renderer.fillCircle({ptrX, ptrY}, 1.8f, themeManager.getCurrentTheme().textPrimary.withAlpha(0.9f));
             }
         }
 
@@ -1654,7 +1654,8 @@ void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const A
     const float gridEndX = bounds.right();
 
     AestraUI::renderTimelineGrid(
-        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar);
+        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar,
+        themeManager.getCurrentTheme().textPrimary);
 }
 
 void TrackUIComponent::onMouseEnter() {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -12,6 +12,7 @@
 #include "../AestraUI/Widgets/UIMixerInspector.h"
 #include "../AestraUI/Widgets/UIMixerPanel.h"
 #include "AestraHistoryPanel.h"
+#include "TakesPanel.h"
 #include "ArsenalPanel.h"
 #include "AudioGraphBuilder.h"
 #include "AuditionEngine.h" // Audition Mode backend
@@ -1088,6 +1089,26 @@ AestraContent::AestraContent()
             m_sequencerPanel->refreshUnits();
         m_trackManager->markModified();
     });
+    // Create Takes panel — data providers and action callbacks are wired by the
+    // app layer (AestraApp) because take operations need the project path and
+    // the save/load safety rules that live there.
+    m_takesPanel = std::make_shared<Aestra::Audio::TakesPanel>();
+    m_takesPanel->setVisible(false);
+    m_takesPanel->setOnClose([this]() { toggleTakesPanel(); });
+    m_takesPanel->setOnDragStart([this](const AestraUI::NUIPoint& pos) { beginPanelDrag(ViewType::Takes, pos); });
+    m_takesPanel->setOnDragMove([this](const AestraUI::NUIPoint& pos) { updatePanelDrag(ViewType::Takes, pos); });
+    m_takesPanel->setOnDragEnd([this]() { endPanelDrag(ViewType::Takes); });
+    m_takesPanel->setOnResizeMove([this](const AestraUI::NUIRect& proposed) {
+        const auto allowed = computeAllowedRectForPanels();
+        m_viewState.takesRect = clampRectToAllowed(proposed, allowed);
+        if (m_takesPanel)
+            m_takesPanel->setBounds(m_viewState.takesRect);
+        setDirty(true);
+    });
+    m_takesPanel->setMaximized(false);
+    m_takesPanel->setOnMaximizeToggle(
+        [this](bool) { onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height)); });
+
     // NOTE: History panel is added LAST so it's on top and receives mouse events first.
 
     // Wire CommandHistory state-changed callback to refresh the history panel
@@ -1154,7 +1175,8 @@ AestraContent::AestraContent()
     m_audioVisualizer->setShowStereo(true);
     m_overlayLayer->addChild(m_audioVisualizer);
 
-    // Add History panel LAST to overlay so it's on top and receives mouse events first
+    // Add Takes + History panels LAST to overlay so they're on top and receive mouse events first
+    m_overlayLayer->addChild(m_takesPanel);
     m_overlayLayer->addChild(m_historyPanel);
 
     // Initialize preview engine
@@ -1658,6 +1680,15 @@ void AestraContent::onResize(int width, int height) {
         } else {
             m_viewState.historyRect = clampRectToAllowed(m_viewState.historyRect, allowed);
             m_historyPanel->setBounds(m_viewState.historyRect);
+        }
+    }
+
+    if (m_takesPanel && m_takesPanel->isVisible()) {
+        if (m_takesPanel->isMaximized()) {
+            m_takesPanel->setBounds(maxRect);
+        } else {
+            m_viewState.takesRect = clampRectToAllowed(m_viewState.takesRect, allowed);
+            m_takesPanel->setBounds(m_viewState.takesRect);
         }
     }
 
@@ -2488,6 +2519,9 @@ void AestraContent::beginPanelDrag(Audio::ViewType view, const AestraUI::NUIPoin
     case Audio::ViewType::History:
         m_viewState.dragStartRect = m_viewState.historyRect;
         break;
+    case Audio::ViewType::Takes:
+        m_viewState.dragStartRect = m_viewState.takesRect;
+        break;
     default:
         break;
     }
@@ -2529,6 +2563,11 @@ void AestraContent::updatePanelDrag(Audio::ViewType view, const AestraUI::NUIPoi
         m_viewState.historyRect = finalRect;
         if (m_historyPanel)
             m_historyPanel->setBounds(finalRect);
+        break;
+    case Audio::ViewType::Takes:
+        m_viewState.takesRect = finalRect;
+        if (m_takesPanel)
+            m_takesPanel->setBounds(finalRect);
         break;
     default:
         break;
@@ -3813,7 +3852,33 @@ void AestraContent::toggleHistoryPanel() {
         float y = 80.0f;
         m_viewState.historyRect = AestraUI::NUIRect(x, y, w, h);
         m_historyPanel->setBounds(m_viewState.historyRect);
+        m_historyPanel->bringToFront();
         m_historyPanel->refreshHistory();
+    }
+    onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
+}
+
+void AestraContent::toggleTakesPanel() {
+    if (!m_takesPanel)
+        return;
+    bool show = !m_takesPanel->isVisible();
+    m_takesPanel->setVisible(show);
+    if (show) {
+        // Default position below the transport bar on first open only —
+        // later opens keep the user's dragged/resized bounds (clamped by
+        // the onResize below).
+        if (!m_takesRectInitialized) {
+            auto root = getBounds();
+            float w = 320.0f;
+            float h = std::min(520.0f, root.height * 0.7f);
+            float x = std::max(0.0f, root.width * 0.5f - w - 12.0f);
+            float y = 80.0f;
+            m_viewState.takesRect = AestraUI::NUIRect(x, y, w, h);
+            m_takesRectInitialized = true;
+        }
+        m_takesPanel->setBounds(m_viewState.takesRect);
+        m_takesPanel->bringToFront();
+        m_takesPanel->refreshTakes();
     }
     onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
 }
@@ -3841,6 +3906,11 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
 
     if (!event.pressed)
         return false;
+
+    // Takes panel inline rename captures typing while active — it must win
+    // over global shortcuts so Ctrl+Z etc. don't fire mid-edit.
+    if (m_takesPanel && m_takesPanel->isVisible() && m_takesPanel->handleKeyEvent(event))
+        return true;
 
     // Forward to piano roll when visible — its local undo/redo
     // and note shortcuts must take priority over global handlers

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -64,6 +64,7 @@ namespace Aestra::Audio {
     class PatternBrowserPanel;
     class WindowPanel;
     class AestraHistoryPanel;
+    class TakesPanel;
     class AuditionEngine;  // For Audition Mode
     class PlaybackGraphController;
 }
@@ -128,6 +129,7 @@ public:
         /** @brief Arsenal overlay bounds in overlay-local coordinates. */
         AestraUI::NUIRect sequencerRect = {0, 0, 600, 300};
         AestraUI::NUIRect historyRect = {0, 80, 280, 460};
+        AestraUI::NUIRect takesRect = {0, 80, 320, 480};
 
         /** @brief True while an overlay panel is being dragged. */
         bool isDragging = false;
@@ -184,6 +186,10 @@ public:
     void toggleArsenalPanel();
     /** @brief Toggle the History panel visibility. */
     void toggleHistoryPanel();
+    /** @brief Toggle the Takes panel visibility. */
+    void toggleTakesPanel();
+    /** @brief Get the Takes panel (for app-level action wiring). */
+    std::shared_ptr<Aestra::Audio::TakesPanel> getTakesPanel() const { return m_takesPanel; }
 
     /** @brief Compute the safe workspace rectangle after chrome and sidebars. */
     AestraUI::NUIRect computeSafeRect() const;
@@ -355,6 +361,10 @@ private:
     Aestra::KeyboardNoteInput m_keyboardNoteInput;
     std::shared_ptr<Aestra::Audio::ArsenalPanel> m_sequencerPanel;
     std::shared_ptr<Aestra::Audio::AestraHistoryPanel> m_historyPanel;
+    std::shared_ptr<Aestra::Audio::TakesPanel> m_takesPanel;
+    // First-open flag: the Takes panel gets a default rect once, then keeps
+    // whatever bounds the user dragged/resized across close/reopen.
+    bool m_takesRectInitialized{false};
     std::shared_ptr<AestraUI::PluginUIController> m_pluginController;
     std::shared_ptr<AestraUI::UIRoutingMap> m_routingMapPanel;
 

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -11,6 +11,7 @@
 #include "TrackManagerUI.h"
 #include "FileBrowser.h"
 #include "TransportBar.h"
+#include "Preferences.h"
 
 #include "../AestraUI/Graphics/OpenGL/NUIRendererGL.h"
 #include "../AestraUI/Core/NUIDragDrop.h"
@@ -150,15 +151,27 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
         return false;
     }
 
-    // Initialize Aestra theme
+    // Initialize the persisted theme before constructing theme-aware widgets.
     auto& themeManager = NUIThemeManager::getInstance();
-    themeManager.setActiveTheme("Aestra-dark");
+    auto& preferences = Preferences::instance();
+    if (!themeManager.setActiveTheme(preferences.theme)) {
+        preferences.theme = "Aestra-dark";
+        themeManager.setActiveTheme(preferences.theme);
+        Log::warning("Unknown saved theme; using Aestra-dark");
+    }
     Log::info("Theme system initialized");
 
     // Create root component
     m_rootComponent = std::make_shared<AestraRootComponent>();
     m_rootComponent->setBounds(NUIRect(0, 0, desc.width, desc.height));
     m_window->setRootComponent(m_rootComponent.get()); // WIRED: Events flow to this root
+    m_themeSubscriptionId = themeManager.subscribeToThemeChanges(
+        [this](const NUIThemeProperties& theme) {
+            if (m_rootComponent)
+                m_rootComponent->onThemeChanged(theme);
+            if (m_adaptiveFPS)
+                m_adaptiveFPS->signalActivity(AestraUI::NUIAdaptiveFPS::ActivityType::Animation);
+        });
 
     // Create custom window with title bar
     m_customWindow = std::make_shared<NUICustomWindow>();
@@ -431,6 +444,10 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
 }
 
 void AestraWindowManager::shutdown() {
+    if (m_themeSubscriptionId != 0) {
+        NUIThemeManager::getInstance().unsubscribeFromThemeChanges(m_themeSubscriptionId);
+        m_themeSubscriptionId = 0;
+    }
     if (m_window) {
         m_window->destroy();
     }
@@ -707,6 +724,13 @@ void AestraWindowManager::render() {
     NUIColor bgColor = themeManager.getColor("background").withAlpha(1.0f);
 
     m_renderer->clear(bgColor);
+    // Dark-on-light text lacks the bloom light-on-dark gets; thicken strokes
+    // on light themes so labels keep the same perceived weight in both modes.
+    {
+        const auto& themeBg = themeManager.getCurrentTheme().backgroundPrimary;
+        const float bgLuma = 0.2126f * themeBg.r + 0.7152f * themeBg.g + 0.0722f * themeBg.b;
+        m_renderer->setTextContrast(bgLuma < 0.5f ? 1.0f : 0.88f);
+    }
     m_renderer->beginFrame();
     if (m_confirmationDialog && m_confirmationDialog->isDialogVisible()) {
         m_confirmationDialog->setBounds(m_rootComponent->getBounds());

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -194,6 +194,7 @@ private:
     std::shared_ptr<class ExportDialog> m_exportDialog;
 
     std::unique_ptr<AestraUI::NUIAdaptiveFPS> m_adaptiveFPS;
+    AestraUI::NUIThemeManager::ThemeSubscriptionId m_themeSubscriptionId{0};
 
     // Menus
     std::shared_ptr<AestraUI::NUIMenuBar> m_menuBar;

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -697,6 +697,10 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
     // 1. Save Sources
     JSON sourcesJson = JSON::array();
     std::vector<ClipSourceID> sourceIds = sourceManager.getAllSourceIDs();
+    // Deterministic order: the store is an unordered_map, and byte-stable
+    // save→load→save (#446) needs identical array order every time.
+    std::sort(sourceIds.begin(), sourceIds.end(),
+              [](const ClipSourceID& a, const ClipSourceID& b) { return a.value < b.value; });
     for (const auto& id : sourceIds) {
         if (const auto* source = sourceManager.getSource(id)) {
             JSON s = JSON::object();
@@ -712,6 +716,11 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
     // 2. Save Patterns
     JSON patternsJson = JSON::array();
     std::vector<std::shared_ptr<PatternSource>> patterns = patternManager.getAllPatterns();
+    // Deterministic order (see sources note above / #446).
+    std::sort(patterns.begin(), patterns.end(),
+              [](const std::shared_ptr<PatternSource>& a, const std::shared_ptr<PatternSource>& b) {
+                  return a->id.value < b->id.value;
+              });
     for (const auto& p : patterns) {
         JSON pjs = JSON::object();
         pjs.set("id", JSON(static_cast<double>(p->id.value)));
@@ -1371,7 +1380,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 std::filesystem::path resolvedPath = resolveProjectAssetPath(assetRoot, storedPath);
                 const std::string sourcePath = storedPath; // Use original storedPath for serialization
                 const std::string filePath = resolvedPath.string(); // Use resolvedPath only for file I/O
-                ClipSourceID newId = sourceManager.getOrCreateSource(sourcePath);
+                // Restore the serialized source identity (#446); the idMap
+                // remains for files whose ids collide or fail to restore.
+                ClipSourceID newId = sourceManager.getOrCreateSourceWithId(ClipSourceID{oldId}, sourcePath);
                 idMap[oldId] = newId;
                 const bool assetReadable =
                     std::filesystem::exists(resolvedPath) && std::filesystem::is_regular_file(resolvedPath);
@@ -1463,7 +1474,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                 payload.slices.push_back(slice);
                             }
                         }
-                        PatternID newId = patternManager.createAudioPattern(name, length, payload);
+                        // Restore serialized pattern identity (#446); the map
+                        // still covers collision/mint fallbacks.
+                        PatternID newId = patternManager.createAudioPatternWithId(PatternID{oldId}, name, length, payload);
                         patternMap[oldId] = newId;
                     }
                 } else {
@@ -1487,7 +1500,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             payload.notes.push_back(note);
                         }
                     }
-                    PatternID newId = patternManager.createMidiPattern(name, length, payload);
+                    // Restore serialized pattern identity (#446), as above.
+                    PatternID newId = patternManager.createMidiPatternWithId(PatternID{oldId}, name, length, payload);
                     patternMap[oldId] = newId;
     
                     // Deserialize scale context if present
@@ -1539,6 +1553,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         }
     
         // 4. Load Lanes and Clips
+        // Clip ids restored from the file must stay unique — a hand-edited or
+        // corrupted file with duplicates would silently break id lookups.
+        std::unordered_set<AestraUUID> seenClipIds;
         if (root.has("lanes")) {
             const JSON& lj = root["lanes"];
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
@@ -1549,7 +1566,17 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 Log::info("[ProjectLoad] Lane[" + std::to_string(i) + "] name='" + lj[i]["name"].asString() + "'");
         #endif
                 const std::string laneName = boundedStringOr(lj[i], "name", "Track", PROJECT_MAX_STRING_BYTES);
-                PlaylistLaneID laneId = playlist.createLane(laneName);
+                // Restore the serialized lane identity so save→load→save is
+                // id-stable (#446); invalid/missing ids fall back to minting.
+                PlaylistLaneID storedLaneId;
+                {
+                    AestraUUID parsedLaneId;
+                    if (AestraUUID::tryParse(boundedStringOr(lj[i], "id", "", PROJECT_MAX_STRING_BYTES),
+                                             parsedLaneId)) {
+                        storedLaneId = PlaylistLaneID(parsedLaneId);
+                    }
+                }
+                PlaylistLaneID laneId = playlist.createLaneWithId(storedLaneId, laneName);
                 if (!laneId.isValid()) {
                     warningLimiter.warning(
                         ProjectLoadWarningCategory::LaneCreate,
@@ -1722,6 +1749,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             if (patternMap.count(oldPatId)) {
                                 ClipInstance clip;
                                 clip.id = ClipInstanceID::fromString(boundedStringOr(cj[c], "id", "", PROJECT_MAX_STRING_BYTES));
+                                if (clip.id.isValid() && !seenClipIds.insert(clip.id).second) {
+                                    clip.id = ClipInstanceID(); // duplicate in file — mint below
+                                }
                                 clip.patternId = patternMap[oldPatId];
                                 clip.sourceId = clip.patternId.value;
                                 clip.startBeat = finiteNumberOr(cj[c], "start", 0.0, 0.0, 1000000.0);

--- a/Source/Core/TakeManager.cpp
+++ b/Source/Core/TakeManager.cpp
@@ -500,3 +500,142 @@ TakeManager::Result TakeManager::setActiveTake(const std::string& projectPath, c
 
     return makeResult(true, "", manifest, selectedCopy);
 }
+
+TakeManager::Result TakeManager::renameTake(const std::string& projectPath, const std::string& takeId,
+                                            const std::string& newName) {
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+
+    std::string trimmedName = newName;
+    trimmedName.erase(0, trimmedName.find_first_not_of(" \t\r\n"));
+    trimmedName.erase(trimmedName.find_last_not_of(" \t\r\n") + 1);
+    if (trimmedName.empty()) {
+        return makeResult(false, "Take name cannot be empty", manifest);
+    }
+    if (trimmedName.size() > TAKE_MAX_STRING_BYTES) {
+        trimmedName.resize(TAKE_MAX_STRING_BYTES);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    TakeEntry* target = nullptr;
+    for (auto& take : manifest.takes) {
+        if (take.id == sanitizedId) {
+            target = &take;
+            break;
+        }
+    }
+    if (!target) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+
+    target->name = trimmedName;
+    target->updatedAtMs = nowMs();
+
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        return makeResult(false, error, manifest, *target);
+    }
+    return makeResult(true, "", manifest, *target);
+}
+
+TakeManager::Result TakeManager::duplicateTake(const std::string& projectPath, const std::string& takeId,
+                                               const std::string& newName) {
+    namespace fs = std::filesystem;
+
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+    if (manifest.takes.size() >= TAKE_MAX_ENTRIES) {
+        return makeResult(false, "Maximum number of takes reached (" + std::to_string(TAKE_MAX_ENTRIES) + ")", manifest);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    const TakeEntry* source = manifest.findTake(sanitizedId);
+    if (!source) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+
+    const std::string sourceSnapshot = resolveSnapshotPath(projectPath, *source);
+    std::error_code ec;
+    if (sourceSnapshot.empty() || !fs::exists(sourceSnapshot, ec) || ec) {
+        return makeResult(false, "Source take snapshot is missing: " + source->id, manifest);
+    }
+
+    TakeEntry copy;
+    copy.id = makeTakeId();
+    copy.name = newName.empty() ? (source->name + " Copy") : newName;
+    copy.parentId = source->id;
+    copy.snapshotPath = makeSnapshotFilename(copy.id);
+    copy.createdAtMs = nowMs();
+    copy.updatedAtMs = copy.createdAtMs;
+    copy.active = false;
+
+    const std::string copySnapshot = resolveSnapshotPath(projectPath, copy);
+    if (copySnapshot.empty()) {
+        return makeResult(false, "Could not resolve duplicate snapshot path", manifest);
+    }
+    fs::copy_file(sourceSnapshot, copySnapshot, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        return makeResult(false, "Could not copy take snapshot: " + ec.message(), manifest);
+    }
+
+    const std::string sourceName = source->name; // push_back below may reallocate and dangle `source`
+    manifest.takes.push_back(copy);
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        fs::remove(copySnapshot, ec); // best effort: don't leave an orphan snapshot
+        return makeResult(false, error, manifest, copy);
+    }
+
+    Aestra::Log::info("[Takes] Duplicated take '" + sourceName + "' as '" + copy.name + "'");
+    return makeResult(true, "", manifest, copy);
+}
+
+TakeManager::Result TakeManager::deleteTake(const std::string& projectPath, const std::string& takeId) {
+    namespace fs = std::filesystem;
+
+    Manifest manifest = loadManifest(projectPath);
+    if (!manifest.ok) {
+        return makeResult(false, manifest.errorMessage, manifest);
+    }
+
+    const std::string sanitizedId = sanitizeIdPart(takeId);
+    const TakeEntry* target = manifest.findTake(sanitizedId);
+    if (!target) {
+        return makeResult(false, "Take not found: " + takeId, manifest);
+    }
+    if (sanitizedId == manifest.activeTakeId) {
+        return makeResult(false, "Cannot delete the active take — switch to another take first", manifest, *target);
+    }
+
+    TakeEntry deleted = *target;
+    const std::string snapshotPath = resolveSnapshotPath(projectPath, deleted);
+
+    // Children keep their history by moving up to the deleted take's parent.
+    for (auto& take : manifest.takes) {
+        if (take.parentId == deleted.id) {
+            take.parentId = deleted.parentId;
+        }
+    }
+    manifest.takes.erase(std::remove_if(manifest.takes.begin(), manifest.takes.end(),
+                                        [&deleted](const TakeEntry& take) { return take.id == deleted.id; }),
+                         manifest.takes.end());
+
+    std::string error;
+    if (!saveManifest(manifest, error)) {
+        return makeResult(false, error, manifest, deleted);
+    }
+
+    // Snapshot removal is best-effort: an orphan file is harmless, a manifest
+    // pointing at a deleted file is not — so the manifest write comes first.
+    if (!snapshotPath.empty()) {
+        std::error_code ec;
+        fs::remove(snapshotPath, ec);
+    }
+
+    Aestra::Log::info("[Takes] Deleted take '" + deleted.name + "'");
+    return makeResult(true, "", manifest, deleted);
+}

--- a/Source/Core/TakeManager.h
+++ b/Source/Core/TakeManager.h
@@ -89,4 +89,37 @@ public:
      * @param takeId       ID of the take to activate.
      */
     static Result setActiveTake(const std::string& projectPath, const std::string& takeId);
+
+    /**
+     * @brief Renames an existing take. Snapshot contents are untouched.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to rename.
+     * @param newName      New human-readable name (must be non-empty).
+     */
+    static Result renameTake(const std::string& projectPath, const std::string& takeId, const std::string& newName);
+
+    /**
+     * @brief Duplicates a take by copying its snapshot into a new take entry.
+     *
+     * The duplicate records the source take as its parent and does NOT become
+     * active — the caller's working state is never touched.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to duplicate.
+     * @param newName      Name for the duplicate (empty derives "<source> Copy").
+     */
+    static Result duplicateTake(const std::string& projectPath, const std::string& takeId,
+                                const std::string& newName = "");
+
+    /**
+     * @brief Deletes a take from the manifest and removes its snapshot.
+     *
+     * The active take can never be deleted (switch away first), so the working
+     * state is always safe. Children of the deleted take are re-parented to
+     * its parent to keep lineage intact. Success means the manifest was
+     * updated; snapshot-file removal is best-effort and may leave an orphaned
+     * (harmless, unreferenced) file behind.
+     * @param projectPath  Path to the project directory.
+     * @param takeId       ID of the take to delete.
+     */
+    static Result deleteTake(const std::string& projectPath, const std::string& takeId);
 };

--- a/Source/Panels/AestraHistoryPanel.cpp
+++ b/Source/Panels/AestraHistoryPanel.cpp
@@ -35,6 +35,16 @@ AestraHistoryPanel::AestraHistoryPanel(std::shared_ptr<TrackManager> trackManage
 
 void AestraHistoryPanel::refreshHistory() { rebuildEntries(); }
 
+void AestraHistoryPanel::activateEntry(int index)
+{
+    if (!m_trackManager || index < 0 || index >= static_cast<int>(m_entries.size())) return;
+    auto& history = m_trackManager->getCommandHistory();
+    if (m_entries[index].isRedo) history.redoTo(m_entries[index].stackIndex);
+    else history.undoTo(m_entries[index].stackIndex);
+    refreshHistory();
+    if (m_onHistoryChanged) m_onHistoryChanged();
+}
+
 void AestraHistoryPanel::rebuildEntries()
 {
     m_entries.clear();
@@ -50,6 +60,9 @@ void AestraHistoryPanel::rebuildEntries()
         m_entries.push_back({name.empty() ? "(unnamed)" : name, false, i});
     }
     m_contentHeight = m_entries.size() * ROW_HEIGHT + ROW_HEIGHT;
+    // Clamp against the visible height so a shrunken list snaps back fully.
+    const float visibleH = std::max(0.0f, getBounds().height - HEADER_HEIGHT);
+    m_scrollY = std::min(m_scrollY, std::max(0.0f, m_contentHeight - visibleH));
 }
 
 void AestraHistoryPanel::onResize(int width, int height) {
@@ -66,9 +79,8 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     if (bounds.width <= 0 || bounds.height <= 0) return;
 
     // Content area starts below WindowPanel's title bar + padding
-    float headerH = 36.0f; // WindowPanel title bar height
-    float contentY = bounds.y + headerH;
-    float contentH = bounds.height - headerH;
+    float contentY = bounds.y + HEADER_HEIGHT;
+    float contentH = bounds.height - HEADER_HEIGHT;
 
     // Empty state
     if (m_entries.empty()) {
@@ -82,18 +94,20 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     int headRedo = 0;
     for (const auto& e : m_entries) { if (e.isRedo) ++headRedo; else break; }
 
-    // Draw entries top-down from header
+    // Draw entries top-down from header, offset by the scroll position
     for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
         const auto& entry = m_entries[i];
-        float rowY = contentY + i * ROW_HEIGHT;
+        float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
 
-                // Skip entries outside visible area
+        // Skip entries outside visible area
         if (rowY + ROW_HEIGHT < contentY || rowY > contentY + contentH) continue;
 
         bool hovered = (i == m_hoveredEntry);
         if (hovered) {
+            // Keep the lift subtle — the hover token is light, and a strong
+            // fill washes out light row text.
             renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
-                theme.getColor("hover").withAlpha(entry.isRedo ? 0.42f : 0.92f));
+                theme.getColor("hover").withAlpha(entry.isRedo ? 0.08f : 0.14f));
         }
 
         // Category dot
@@ -111,7 +125,7 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
     }
 
     // HEAD marker
-    float headY = contentY + headRedo * ROW_HEIGHT;
+    float headY = contentY + headRedo * ROW_HEIGHT - m_scrollY;
     if (headY >= contentY && headY < contentY + contentH) {
         renderer.fillRect(NUIRect(bounds.x, headY, 3.0f, ROW_HEIGHT), theme.getColor("secondary").withAlpha(0.92f));
         renderer.drawText("HEAD", NUIPoint(bounds.x + 6.0f, headY + 7.0f), 9.0f,
@@ -124,24 +138,20 @@ void AestraHistoryPanel::onRender(NUIRenderer& renderer)
 
 bool AestraHistoryPanel::onMouseEvent(const NUIMouseEvent& event)
 {
-    if (event.pressed && isVisible()) {    }
-
     if (!isVisible()) return false;
 
     auto bounds = getBounds();
-    float headerH = 32.0f;
-    float contentY = bounds.y + headerH;
-    float contentH = bounds.height - headerH;
+    float contentY = bounds.y + HEADER_HEIGHT;
+    float contentH = bounds.height - HEADER_HEIGHT;
+    const bool inContent = bounds.contains(event.position) && event.position.y >= contentY;
 
-    // Handle click on entries
-    if (event.pressed && event.button == NUIMouseButton::Left && m_trackManager) {        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
-            float rowY = contentY + i * ROW_HEIGHT;
-            bool match = (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT);            if (match) {
-                auto& history = m_trackManager->getCommandHistory();
-                if (m_entries[i].isRedo) history.redoTo(m_entries[i].stackIndex);
-                else history.undoTo(m_entries[i].stackIndex);
-                refreshHistory();
-                if (m_onHistoryChanged) m_onHistoryChanged();
+    // Handle click on entries (scroll-aware)
+    if (event.pressed && event.button == NUIMouseButton::Left && m_trackManager && inContent) {
+        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
+            float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
+            if (rowY + ROW_HEIGHT < contentY) continue;
+            if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) {
+                activateEntry(i);
                 return true;
             }
         }
@@ -150,9 +160,12 @@ bool AestraHistoryPanel::onMouseEvent(const NUIMouseEvent& event)
     // Handle hover
     if (event.type == NUIMouseEventType::Move) {
         m_hoveredEntry = -1;
-        for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
-            float rowY = contentY + i * ROW_HEIGHT;
-            if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) { m_hoveredEntry = i; break; }
+        if (inContent) {
+            for (int i = 0; i < static_cast<int>(m_entries.size()); ++i) {
+                float rowY = contentY + i * ROW_HEIGHT - m_scrollY;
+                if (rowY + ROW_HEIGHT < contentY) continue;
+                if (event.position.y >= rowY && event.position.y < rowY + ROW_HEIGHT) { m_hoveredEntry = i; break; }
+            }
         }
     }
 

--- a/Source/Panels/AestraHistoryPanel.h
+++ b/Source/Panels/AestraHistoryPanel.h
@@ -31,8 +31,19 @@ public:
     /** @brief Set callback for when user clicks to undo/redo (so UI panels refresh). */
     void setOnHistoryChanged(std::function<void()> cb) { m_onHistoryChanged = std::move(cb); }
 
+    // --- Introspection (used by tests and tooling) ---------------------------
+    /** @brief Number of displayed history entries (redo + undo). */
+    int getEntryCount() const { return static_cast<int>(m_entries.size()); }
+    /** @brief Display name of an entry (top row first). */
+    const std::string& getEntryName(int index) const { return m_entries[static_cast<size_t>(index)].name; }
+    /** @brief True if the entry sits on the redo stack (above HEAD). */
+    bool isEntryRedo(int index) const { return m_entries[static_cast<size_t>(index)].isRedo; }
+    /** @brief Navigate to an entry exactly like a mouse click on its row. */
+    void activateEntry(int index);
+
 private:
     static constexpr float ROW_HEIGHT = 26.0f;
+    static constexpr float HEADER_HEIGHT = 36.0f; // content offset below the WindowPanel title bar
     static constexpr float INDICATOR_SIZE = 6.0f;
     static constexpr float LEFT_PAD = 12.0f;
     static constexpr float TEXT_LEFT_PAD = 28.0f;

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -101,7 +101,7 @@ public:
         auto b = getBounds();
         auto& theme = NUIThemeManager::getInstance();
 
-        renderer.fillRect(b, NUIColor(0.045f, 0.045f, 0.045f, 1.0f));
+        renderer.fillRect(b, theme.getColor("workspaceBackground"));
 
         const float pad = 8.0f;
         const float gutter = 6.0f;
@@ -150,8 +150,9 @@ void ADSRDisplayComponent::onRender(NUIRenderer& renderer) {
     auto& theme = NUIThemeManager::getInstance();
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.055f, 0.055f, 0.055f, 1.0f));
-    renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.22f));
+    const float radius = theme.getRadius("s");
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), radius, theme.getColor("recessedPanel"));
+    renderer.strokeRoundedRect(b, radius, 1.0f, theme.getColor("borderSubtle"));
 
     const auto g = calculateADSRGeometry(b, m_attack, m_decay, m_sustain, m_release);
     const std::vector<NUIPoint> pts{g.start, g.attack, g.decay, g.releaseStart, g.end};
@@ -401,8 +402,9 @@ void WaveformDisplayComponent::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(b);
 
     // Background
-    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), 5.0f, NUIColor(0.05f, 0.05f, 0.05f, 1.0f));
-    renderer.strokeRoundedRect(b, 5.0f, 1.0f, theme.getColor("secondary").withAlpha(0.24f));
+    const float radius = theme.getRadius("s");
+    renderer.fillRoundedRect(NUIRect(b.x, b.y, b.width, b.height), radius, theme.getColor("recessedPanel"));
+    renderer.strokeRoundedRect(b, radius, 1.0f, theme.getColor("borderSubtle"));
 
     // Center line
     float centerY = b.y + b.height * 0.5f;

--- a/Source/Panels/TakesPanel.cpp
+++ b/Source/Panels/TakesPanel.cpp
@@ -1,0 +1,640 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "TakesPanel.h"
+
+#include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../AestraUI/Graphics/NUIRenderer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <unordered_map>
+
+using namespace AestraUI;
+
+namespace Aestra {
+namespace Audio {
+
+namespace {
+constexpr float ACTION_BUTTON_PAD = 8.0f;
+constexpr float TOOLBAR_BUTTON_HEIGHT = 22.0f;
+} // namespace
+
+TakesPanel::TakesPanel() : WindowPanel("TAKES") {
+    setMinimumPanelSize(280.0f, 260.0f);
+}
+
+void TakesPanel::refreshTakes() {
+    rebuildRows();
+    setDirty(true);
+}
+
+void TakesPanel::rebuildRows() {
+    std::string previousSelectedId;
+    if (m_selectedTake >= 0 && m_selectedTake < static_cast<int>(m_takeRows.size())) {
+        previousSelectedId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    }
+    std::string previousSelectedSnapshotPath;
+    if (m_selectedSnapshot >= 0 && m_selectedSnapshot < static_cast<int>(m_snapshotRows.size())) {
+        previousSelectedSnapshotPath = m_snapshotRows[static_cast<size_t>(m_selectedSnapshot)].path;
+    }
+
+    m_takeRows.clear();
+    m_snapshotRows.clear();
+    m_manifestError.clear();
+
+    if (m_takesProvider) {
+        TakeManager::Manifest manifest = m_takesProvider();
+        if (manifest.ok) {
+            // Depth = length of the parent chain; guards against cycles/orphans.
+            std::unordered_map<std::string, std::string> parentOf;
+            for (const auto& take : manifest.takes) {
+                parentOf[take.id] = take.parentId;
+            }
+            for (const auto& take : manifest.takes) {
+                int depth = 0;
+                std::string cursor = take.parentId;
+                while (!cursor.empty() && depth < 8) {
+                    auto it = parentOf.find(cursor);
+                    if (it == parentOf.end()) {
+                        break;
+                    }
+                    ++depth;
+                    cursor = it->second;
+                }
+                m_takeRows.push_back({take, depth});
+            }
+        } else if (manifest.errorMessage != "No Takes manifest") {
+            m_manifestError = manifest.errorMessage;
+        }
+    }
+
+    if (m_snapshotsProvider) {
+        auto snapshots = m_snapshotsProvider();
+        if (snapshots.size() > MAX_SNAPSHOT_ROWS) {
+            snapshots.resize(MAX_SNAPSHOT_ROWS);
+        }
+        m_snapshotRows = std::move(snapshots);
+    }
+
+    // Selection follows the take's identity, not its row index.
+    m_selectedTake = -1;
+    if (!previousSelectedId.empty()) {
+        for (int i = 0; i < static_cast<int>(m_takeRows.size()); ++i) {
+            if (m_takeRows[static_cast<size_t>(i)].take.id == previousSelectedId) {
+                m_selectedTake = i;
+                break;
+            }
+        }
+    }
+    m_selectedSnapshot = -1;
+    if (!previousSelectedSnapshotPath.empty()) {
+        for (int i = 0; i < static_cast<int>(m_snapshotRows.size()); ++i) {
+            if (m_snapshotRows[static_cast<size_t>(i)].path == previousSelectedSnapshotPath) {
+                m_selectedSnapshot = i;
+                break;
+            }
+        }
+    }
+    if (m_renameActive) {
+        // The renamed take may have vanished (external change) — drop the edit.
+        bool stillPresent = false;
+        for (const auto& row : m_takeRows) {
+            if (row.take.id == m_renameTakeId) {
+                stillPresent = true;
+                break;
+            }
+        }
+        if (!stillPresent) {
+            cancelRename();
+        }
+    }
+}
+
+TakesPanel::Layout TakesPanel::computeLayout() const {
+    Layout layout;
+    const auto bounds = getBounds();
+    const float x = bounds.x;
+    const float w = bounds.width;
+    float top = bounds.y + HEADER_HEIGHT;
+    float bottom = bounds.y + bounds.height;
+
+    if (!m_statusText.empty()) {
+        bottom -= STATUS_HEIGHT;
+        layout.statusLine = NUIRect(x, bottom, w, STATUS_HEIGHT);
+    }
+
+    if (!m_snapshotRows.empty()) {
+        const float snapshotListH = static_cast<float>(m_snapshotRows.size()) * ROW_HEIGHT;
+        bottom -= snapshotListH;
+        layout.snapshotList = NUIRect(x, bottom, w, snapshotListH);
+        bottom -= SECTION_HEADER_HEIGHT;
+        layout.snapshotHeader = NUIRect(x, bottom, w, SECTION_HEADER_HEIGHT);
+    }
+
+    layout.actionBarVisible = (m_selectedTake >= 0 || m_selectedSnapshot >= 0);
+    if (layout.actionBarVisible) {
+        bottom -= ACTION_BAR_HEIGHT;
+        layout.actionBar = NUIRect(x, bottom, w, ACTION_BAR_HEIGHT);
+    }
+
+    layout.toolbar = NUIRect(x, top, w, TOOLBAR_HEIGHT);
+    const float buttonY = top + (TOOLBAR_HEIGHT - TOOLBAR_BUTTON_HEIGHT) * 0.5f;
+    const float buttonW = (w - LEFT_PAD * 3.0f) * 0.5f;
+    layout.newTakeButton = NUIRect(x + LEFT_PAD, buttonY, buttonW, TOOLBAR_BUTTON_HEIGHT);
+    layout.saveActiveButton = NUIRect(x + LEFT_PAD * 2.0f + buttonW, buttonY, buttonW, TOOLBAR_BUTTON_HEIGHT);
+
+    top += TOOLBAR_HEIGHT;
+    layout.takesList = NUIRect(x, top, w, std::max(0.0f, bottom - top));
+    return layout;
+}
+
+int TakesPanel::takeRowAt(const NUIPoint& point, const Layout& layout) const {
+    if (!layout.takesList.contains(point)) {
+        return -1;
+    }
+    const int index = static_cast<int>((point.y - layout.takesList.y + m_scrollY) / ROW_HEIGHT);
+    if (index < 0 || index >= static_cast<int>(m_takeRows.size())) {
+        return -1;
+    }
+    return index;
+}
+
+int TakesPanel::snapshotRowAt(const NUIPoint& point, const Layout& layout) const {
+    if (m_snapshotRows.empty() || !layout.snapshotList.contains(point)) {
+        return -1;
+    }
+    const int index = static_cast<int>((point.y - layout.snapshotList.y) / ROW_HEIGHT);
+    if (index < 0 || index >= static_cast<int>(m_snapshotRows.size())) {
+        return -1;
+    }
+    return index;
+}
+
+std::vector<std::string> TakesPanel::actionButtonLabels() const {
+    if (m_selectedSnapshot >= 0) {
+        return {"RESTORE"};
+    }
+    if (m_selectedTake >= 0) {
+        const bool active = m_takeRows[static_cast<size_t>(m_selectedTake)].take.active;
+        if (active) {
+            // The active take can't be opened (it already is) or deleted
+            // (the working state must never be pulled out from under itself).
+            return {"RENAME", "DUP", "BRANCH"};
+        }
+        return {"OPEN", "RENAME", "DUP", "BRANCH", "DELETE"};
+    }
+    return {};
+}
+
+std::vector<NUIRect> TakesPanel::actionButtonRects(const Layout& layout) const {
+    std::vector<NUIRect> rects;
+    if (!layout.actionBarVisible) {
+        return rects;
+    }
+    const auto labels = actionButtonLabels();
+    if (labels.empty()) {
+        return rects;
+    }
+    const float buttonH = ACTION_BAR_HEIGHT - 8.0f;
+    const float totalPad = LEFT_PAD * 2.0f + ACTION_BUTTON_PAD * static_cast<float>(labels.size() - 1);
+    const float buttonW = (layout.actionBar.width - totalPad) / static_cast<float>(labels.size());
+    float bx = layout.actionBar.x + LEFT_PAD;
+    for (size_t i = 0; i < labels.size(); ++i) {
+        rects.emplace_back(bx, layout.actionBar.y + 4.0f, buttonW, buttonH);
+        bx += buttonW + ACTION_BUTTON_PAD;
+    }
+    return rects;
+}
+
+void TakesPanel::selectTake(int index) {
+    if (index < -1 || index >= static_cast<int>(m_takeRows.size())) {
+        index = -1;
+    }
+    if (m_renameActive && index != m_selectedTake) {
+        cancelRename();
+    }
+    m_selectedTake = index;
+    if (index >= 0) {
+        m_selectedSnapshot = -1;
+    }
+    setDirty(true);
+}
+
+void TakesPanel::selectSnapshot(int index) {
+    if (index < -1 || index >= static_cast<int>(m_snapshotRows.size())) {
+        index = -1;
+    }
+    if (m_renameActive) {
+        cancelRename();
+    }
+    m_selectedSnapshot = index;
+    if (index >= 0) {
+        m_selectedTake = -1;
+    }
+    setDirty(true);
+}
+
+void TakesPanel::setStatus(const std::string& text) {
+    m_statusText = text;
+    setDirty(true);
+}
+
+bool TakesPanel::invokeAction(const std::function<bool()>& action, const char* failureMessage) {
+    if (!action) {
+        return false;
+    }
+    setStatus("");
+    const bool ok = action();
+    if (!ok) {
+        setStatus(failureMessage);
+    }
+    refreshTakes();
+    return ok;
+}
+
+bool TakesPanel::requestCreateTake() {
+    return invokeAction([this]() { return m_onCreateTake && m_onCreateTake(); }, "Could not create take");
+}
+
+bool TakesPanel::requestSaveActiveTake() {
+    return invokeAction([this]() { return m_onSaveActiveTake && m_onSaveActiveTake(); },
+                        "Could not save the active take");
+}
+
+bool TakesPanel::requestOpenSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onOpenTake && m_onOpenTake(takeId); }, "Could not open take");
+}
+
+bool TakesPanel::requestDuplicateSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onDuplicateTake && m_onDuplicateTake(takeId); },
+                        "Could not duplicate take");
+}
+
+bool TakesPanel::requestBranchSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const std::string takeId = m_takeRows[static_cast<size_t>(m_selectedTake)].take.id;
+    return invokeAction([this, takeId]() { return m_onBranchTake && m_onBranchTake(takeId); },
+                        "Could not branch from take");
+}
+
+bool TakesPanel::requestDeleteSelected() {
+    if (m_selectedTake < 0) {
+        return false;
+    }
+    const auto& take = m_takeRows[static_cast<size_t>(m_selectedTake)].take;
+    if (take.active) {
+        setStatus("Switch to another take before deleting this one");
+        return false;
+    }
+    const std::string takeId = take.id;
+    return invokeAction([this, takeId]() { return m_onDeleteTake && m_onDeleteTake(takeId); },
+                        "Could not delete take");
+}
+
+bool TakesPanel::requestRestoreSelectedSnapshot() {
+    if (m_selectedSnapshot < 0) {
+        return false;
+    }
+    const std::string path = m_snapshotRows[static_cast<size_t>(m_selectedSnapshot)].path;
+    return invokeAction([this, path]() { return m_onRestoreSnapshot && m_onRestoreSnapshot(path); },
+                        "Could not restore snapshot");
+}
+
+void TakesPanel::beginRenameSelected() {
+    if (m_selectedTake < 0) {
+        return;
+    }
+    const auto& take = m_takeRows[static_cast<size_t>(m_selectedTake)].take;
+    m_renameActive = true;
+    m_renameTakeId = take.id;
+    m_renameBuffer = take.name;
+    // Printable characters are delivered through the focused-component text
+    // path (see AestraWindowManager charCallback), so claim focus for the edit.
+    setFocused(true);
+    setStatus("");
+    setDirty(true);
+}
+
+bool TakesPanel::commitRename() {
+    if (!m_renameActive) {
+        return false;
+    }
+    const std::string takeId = m_renameTakeId;
+    const std::string name = m_renameBuffer;
+    m_renameActive = false;
+    m_renameTakeId.clear();
+    m_renameBuffer.clear();
+    setFocused(false);
+    if (name.empty()) {
+        setStatus("Take name cannot be empty");
+        return false;
+    }
+    return invokeAction([this, takeId, name]() { return m_onRenameTake && m_onRenameTake(takeId, name); },
+                        "Could not rename take");
+}
+
+void TakesPanel::cancelRename() {
+    m_renameActive = false;
+    m_renameTakeId.clear();
+    m_renameBuffer.clear();
+    setFocused(false);
+    setDirty(true);
+}
+
+bool TakesPanel::onKeyEvent(const NUIKeyEvent& event) {
+    return handleKeyEvent(event);
+}
+
+bool TakesPanel::handleKeyEvent(const NUIKeyEvent& event) {
+    if (!m_renameActive || !isVisible() || !event.pressed) {
+        return false;
+    }
+
+    if (event.keyCode == NUIKeyCode::Enter) {
+        commitRename();
+        return true;
+    }
+    if (event.keyCode == NUIKeyCode::Escape) {
+        cancelRename();
+        return true;
+    }
+    if (event.keyCode == NUIKeyCode::Backspace) {
+        if (!m_renameBuffer.empty()) {
+            m_renameBuffer.pop_back();
+            setDirty(true);
+        }
+        return true;
+    }
+    if (event.character >= 32 && event.character != 127) {
+        if (m_renameBuffer.size() < 128) {
+            m_renameBuffer.push_back(event.character);
+            setDirty(true);
+        }
+        return true;
+    }
+    // While editing, swallow other presses so global shortcuts don't fire.
+    return true;
+}
+
+bool TakesPanel::runRowAction(int actionIndex) {
+    const auto labels = actionButtonLabels();
+    if (actionIndex < 0 || actionIndex >= static_cast<int>(labels.size())) {
+        return false;
+    }
+    const std::string& label = labels[static_cast<size_t>(actionIndex)];
+    if (label == "OPEN") {
+        return requestOpenSelected();
+    }
+    if (label == "RENAME") {
+        beginRenameSelected();
+        return true;
+    }
+    if (label == "DUP") {
+        return requestDuplicateSelected();
+    }
+    if (label == "BRANCH") {
+        return requestBranchSelected();
+    }
+    if (label == "DELETE") {
+        return requestDeleteSelected();
+    }
+    if (label == "RESTORE") {
+        return requestRestoreSelectedSnapshot();
+    }
+    return false;
+}
+
+std::string TakesPanel::relativeTimeLabel(uint64_t epochMs) {
+    if (epochMs == 0) {
+        return {};
+    }
+    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+    const int64_t deltaSec = std::max<int64_t>(0, (static_cast<int64_t>(now) - static_cast<int64_t>(epochMs)) / 1000);
+    if (deltaSec < 60) {
+        return "now";
+    }
+    if (deltaSec < 3600) {
+        return std::to_string(deltaSec / 60) + "m";
+    }
+    if (deltaSec < 86400) {
+        return std::to_string(deltaSec / 3600) + "h";
+    }
+    return std::to_string(deltaSec / 86400) + "d";
+}
+
+void TakesPanel::onRender(NUIRenderer& renderer) {
+    auto& theme = NUIThemeManager::getInstance();
+    WindowPanel::onRender(renderer);
+
+    const auto bounds = getBounds();
+    if (bounds.width <= 0 || bounds.height <= 0 || isMinimized()) {
+        return;
+    }
+
+    const Layout layout = computeLayout();
+
+    // Toolbar buttons
+    const auto drawButton = [&](const NUIRect& rect, const std::string& label, bool accent) {
+        renderer.fillRoundedRect(rect, 4.0f,
+                                 (accent ? theme.getColor("accentPrimary") : theme.getColor("backgroundSecondary"))
+                                     .withAlpha(accent ? 0.28f : 0.9f));
+        const NUISize textSize = renderer.measureText(label, 11.0f);
+        renderer.drawText(label,
+                          NUIPoint(rect.x + (rect.width - textSize.width) * 0.5f,
+                                   rect.y + (rect.height - textSize.height) * 0.5f),
+                          11.0f, theme.getColor(accent ? "textPrimary" : "textSecondary"));
+    };
+    drawButton(layout.newTakeButton, "+ NEW TAKE", true);
+    drawButton(layout.saveActiveButton, "SAVE ACTIVE", false);
+    renderer.drawLine(NUIPoint(bounds.x, layout.toolbar.y + layout.toolbar.height),
+                      NUIPoint(bounds.x + bounds.width, layout.toolbar.y + layout.toolbar.height), 0.5f,
+                      theme.getColor("divider").withAlpha(0.86f));
+
+    // Takes list
+    if (m_takeRows.empty()) {
+        const std::string hint = !m_manifestError.empty()
+                                     ? ("Takes unavailable: " + m_manifestError)
+                                     : "No takes yet — save a version with + NEW TAKE";
+        renderer.drawText(hint, NUIPoint(bounds.x + LEFT_PAD, layout.takesList.y + ROW_HEIGHT * 0.6f), 12.0f,
+                          theme.getColor("textSecondary").withAlpha(0.72f));
+    }
+    for (int i = 0; i < static_cast<int>(m_takeRows.size()); ++i) {
+        const auto& row = m_takeRows[static_cast<size_t>(i)];
+        const float rowY = layout.takesList.y + static_cast<float>(i) * ROW_HEIGHT - m_scrollY;
+        if (rowY + ROW_HEIGHT < layout.takesList.y || rowY > layout.takesList.y + layout.takesList.height) {
+            continue;
+        }
+
+        if (i == m_selectedTake) {
+            renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                              theme.getColor("accentPrimary").withAlpha(0.18f));
+        } else if (i == m_hoveredTake) {
+            renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                              theme.getColor("hover").withAlpha(0.12f));
+        }
+
+        const float indent = static_cast<float>(row.depth) * DEPTH_INDENT;
+        const NUIColor dotColor =
+            row.take.active ? theme.getColor("accentPrimary") : theme.getColor("textDisabled").withAlpha(0.7f);
+        renderer.fillCircle(NUIPoint(bounds.x + LEFT_PAD + indent, rowY + ROW_HEIGHT * 0.5f), 3.0f, dotColor);
+
+        const bool editingThisRow = m_renameActive && row.take.id == m_renameTakeId;
+        if (editingThisRow) {
+            renderer.fillRect(NUIRect(bounds.x + TEXT_LEFT_PAD + indent - 4.0f, rowY + 3.0f,
+                                      bounds.width - TEXT_LEFT_PAD - indent - LEFT_PAD, ROW_HEIGHT - 6.0f),
+                              theme.getColor("backgroundSecondary").withAlpha(0.95f));
+            renderer.drawText(m_renameBuffer + "|", NUIPoint(bounds.x + TEXT_LEFT_PAD + indent, rowY + 7.0f), 12.0f,
+                              theme.getColor("textPrimary"));
+        } else {
+            const NUIColor textColor = row.take.active ? theme.getColor("textPrimary")
+                                                       : theme.getColor("textPrimary").withAlpha(0.82f);
+            renderer.drawText(row.take.name, NUIPoint(bounds.x + TEXT_LEFT_PAD + indent, rowY + 7.0f), 12.0f,
+                              textColor);
+            const std::string timeLabel = relativeTimeLabel(row.take.updatedAtMs);
+            if (!timeLabel.empty()) {
+                const NUISize timeSize = renderer.measureText(timeLabel, 10.0f);
+                renderer.drawText(timeLabel,
+                                  NUIPoint(bounds.x + bounds.width - LEFT_PAD - timeSize.width, rowY + 8.0f), 10.0f,
+                                  theme.getColor("textSecondary").withAlpha(0.7f));
+            }
+        }
+
+        renderer.drawLine(NUIPoint(bounds.x + TEXT_LEFT_PAD, rowY + ROW_HEIGHT),
+                          NUIPoint(bounds.x + bounds.width, rowY + ROW_HEIGHT), 0.5f,
+                          theme.getColor("divider").withAlpha(0.7f));
+    }
+
+    // Action bar for the current selection
+    if (layout.actionBarVisible) {
+        renderer.fillRect(layout.actionBar, theme.getColor("backgroundSecondary").withAlpha(0.55f));
+        const auto labels = actionButtonLabels();
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < labels.size() && i < rects.size(); ++i) {
+            const bool hovered = static_cast<int>(i) == m_hoveredAction;
+            const bool destructive = labels[i] == "DELETE";
+            const char* fillToken = destructive ? "warning" : (hovered ? "accentPrimary" : "borderSubtle");
+            renderer.fillRoundedRect(rects[i], 4.0f,
+                                     theme.getColor(fillToken).withAlpha(hovered ? 0.32f : (destructive ? 0.2f : 0.5f)));
+            const NUISize textSize = renderer.measureText(labels[i], 10.0f);
+            renderer.drawText(labels[i],
+                              NUIPoint(rects[i].x + (rects[i].width - textSize.width) * 0.5f,
+                                       rects[i].y + (rects[i].height - textSize.height) * 0.5f),
+                              10.0f, theme.getColor("textPrimary").withAlpha(0.92f));
+        }
+    }
+
+    // Recovery snapshot section — automatic save history, restore-only.
+    if (!m_snapshotRows.empty()) {
+        renderer.fillRect(layout.snapshotHeader, theme.getColor("backgroundSecondary").withAlpha(0.4f));
+        renderer.drawText("RECOVERY SNAPSHOTS", NUIPoint(bounds.x + LEFT_PAD, layout.snapshotHeader.y + 5.0f), 9.0f,
+                          theme.getColor("textSecondary").withAlpha(0.8f));
+        for (int i = 0; i < static_cast<int>(m_snapshotRows.size()); ++i) {
+            const float rowY = layout.snapshotList.y + static_cast<float>(i) * ROW_HEIGHT;
+            if (i == m_selectedSnapshot) {
+                renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                                  theme.getColor("accentPrimary").withAlpha(0.18f));
+            } else if (i == m_hoveredSnapshot) {
+                renderer.fillRect(NUIRect(bounds.x, rowY, bounds.width, ROW_HEIGHT),
+                                  theme.getColor("hover").withAlpha(0.12f));
+            }
+            renderer.fillCircle(NUIPoint(bounds.x + LEFT_PAD, rowY + ROW_HEIGHT * 0.5f), 3.0f,
+                                theme.getColor("warning").withAlpha(0.75f));
+            renderer.drawText(m_snapshotRows[static_cast<size_t>(i)].label,
+                              NUIPoint(bounds.x + TEXT_LEFT_PAD, rowY + 7.0f), 11.0f,
+                              theme.getColor("textSecondary").withAlpha(0.95f));
+        }
+    }
+
+    if (!m_statusText.empty()) {
+        renderer.fillRect(layout.statusLine, theme.getColor("warning").withAlpha(0.14f));
+        renderer.drawText(m_statusText, NUIPoint(bounds.x + LEFT_PAD, layout.statusLine.y + 3.0f), 10.0f,
+                          theme.getColor("warning").withAlpha(0.95f));
+    }
+}
+
+bool TakesPanel::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible()) {
+        return false;
+    }
+    if (isMinimized()) {
+        return WindowPanel::onMouseEvent(event);
+    }
+
+    const Layout layout = computeLayout();
+
+    if (event.type == NUIMouseEventType::Move) {
+        m_hoveredTake = takeRowAt(event.position, layout);
+        m_hoveredSnapshot = snapshotRowAt(event.position, layout);
+        m_hoveredAction = -1;
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < rects.size(); ++i) {
+            if (rects[i].contains(event.position)) {
+                m_hoveredAction = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+
+    if (event.type == NUIMouseEventType::Scroll && layout.takesList.contains(event.position)) {
+        const float contentHeight = static_cast<float>(m_takeRows.size()) * ROW_HEIGHT;
+        const float maxScroll = std::max(0.0f, contentHeight - layout.takesList.height);
+        m_scrollY = std::clamp(m_scrollY - event.wheelDelta * 30.0f, 0.0f, maxScroll);
+        setDirty(true);
+        return true;
+    }
+
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        if (layout.newTakeButton.contains(event.position)) {
+            requestCreateTake();
+            return true;
+        }
+        if (layout.saveActiveButton.contains(event.position)) {
+            requestSaveActiveTake();
+            return true;
+        }
+
+        const auto rects = actionButtonRects(layout);
+        for (size_t i = 0; i < rects.size(); ++i) {
+            if (rects[i].contains(event.position)) {
+                runRowAction(static_cast<int>(i));
+                return true;
+            }
+        }
+
+        const int takeRow = takeRowAt(event.position, layout);
+        if (takeRow >= 0) {
+            if (event.type == NUIMouseEventType::DoubleClick) {
+                selectTake(takeRow);
+                if (!m_takeRows[static_cast<size_t>(takeRow)].take.active) {
+                    requestOpenSelected();
+                }
+            } else {
+                selectTake(takeRow);
+            }
+            return true;
+        }
+
+        const int snapshotRow = snapshotRowAt(event.position, layout);
+        if (snapshotRow >= 0) {
+            selectSnapshot(snapshotRow);
+            return true;
+        }
+    }
+
+    // Title bar, drag, resize, close, click-swallow inside panel bounds.
+    return WindowPanel::onMouseEvent(event);
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/TakesPanel.h
+++ b/Source/Panels/TakesPanel.h
@@ -1,0 +1,198 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "WindowPanel.h"
+#include "../Core/TakeManager.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Workspace panel for project Takes — named, versioned project states.
+ *
+ * Answers "which version of the work do I want?" (the History panel answers
+ * "what actions did I perform?"). Lists the takes manifest with lineage
+ * indentation, lets the user create, open, rename, duplicate and branch takes,
+ * and exposes recent automatic save snapshots as a recovery section.
+ *
+ * The panel owns no project logic: data arrives through providers and every
+ * action is delegated through a callback so the app layer keeps its
+ * save-before-switch safety rules in one place. Callbacks return false on
+ * failure and the panel surfaces a status line.
+ */
+class TakesPanel : public WindowPanel {
+public:
+    /** @brief A recovery snapshot row (from the automatic save history). */
+    struct SnapshotEntry {
+        std::string path;   ///< Absolute snapshot file path.
+        std::string label;  ///< Human-readable label (timestamp).
+    };
+
+    using TakesProvider = std::function<TakeManager::Manifest()>;
+    using SnapshotsProvider = std::function<std::vector<SnapshotEntry>()>;
+
+    TakesPanel();
+    ~TakesPanel() override = default;
+
+    void onRender(AestraUI::NUIRenderer& renderer) override;
+    bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
+    /** @brief Focused key delivery (text input arrives here while renaming). */
+    bool onKeyEvent(const AestraUI::NUIKeyEvent& event) override;
+
+    /** @brief Handle keys while an inline rename is active. Returns true if consumed. */
+    bool handleKeyEvent(const AestraUI::NUIKeyEvent& event);
+
+    /** @brief Bind the manifest source (typically TakeManager::loadManifest). */
+    void setTakesProvider(TakesProvider provider) { m_takesProvider = std::move(provider); }
+    /** @brief Bind the recovery-snapshot source (automatic save history). */
+    void setSnapshotsProvider(SnapshotsProvider provider) { m_snapshotsProvider = std::move(provider); }
+
+    /** @brief Capture the current project state as a new take. */
+    void setOnCreateTake(std::function<bool()> cb) { m_onCreateTake = std::move(cb); }
+    /** @brief Save the current state into the active take's snapshot. */
+    void setOnSaveActiveTake(std::function<bool()> cb) { m_onSaveActiveTake = std::move(cb); }
+    /** @brief Open (restore) a take after safely saving the current one. */
+    void setOnOpenTake(std::function<bool(const std::string& takeId)> cb) { m_onOpenTake = std::move(cb); }
+    /** @brief Rename a take. */
+    void setOnRenameTake(std::function<bool(const std::string& takeId, const std::string& name)> cb) {
+        m_onRenameTake = std::move(cb);
+    }
+    /** @brief Duplicate a take without activating it. */
+    void setOnDuplicateTake(std::function<bool(const std::string& takeId)> cb) { m_onDuplicateTake = std::move(cb); }
+    /** @brief Delete a non-active take. */
+    void setOnDeleteTake(std::function<bool(const std::string& takeId)> cb) { m_onDeleteTake = std::move(cb); }
+    /** @brief Branch: duplicate a take and continue working on the branch. */
+    void setOnBranchTake(std::function<bool(const std::string& takeId)> cb) { m_onBranchTake = std::move(cb); }
+    /** @brief Restore a recovery snapshot after safely saving the current take. */
+    void setOnRestoreSnapshot(std::function<bool(const std::string& path)> cb) {
+        m_onRestoreSnapshot = std::move(cb);
+    }
+
+    /** @brief Rebuild rows from the providers. Call after any take operation. */
+    void refreshTakes();
+
+    // --- Introspection + programmatic actions -------------------------------
+    // The mouse handlers route through these; tests drive them directly.
+
+    /** @brief Number of take rows currently displayed. */
+    int getTakeCount() const { return static_cast<int>(m_takeRows.size()); }
+    /** @brief Take entry for a displayed row (row order = manifest order). */
+    const TakeManager::TakeEntry& getTakeAt(int index) const { return m_takeRows[static_cast<size_t>(index)].take; }
+    /** @brief Lineage depth used for row indentation. */
+    int getTakeDepthAt(int index) const { return m_takeRows[static_cast<size_t>(index)].depth; }
+    /** @brief Number of recovery snapshot rows currently displayed. */
+    int getSnapshotCount() const { return static_cast<int>(m_snapshotRows.size()); }
+    /** @brief Selected take row index, or -1. */
+    int getSelectedTake() const { return m_selectedTake; }
+    /** @brief Selected snapshot row index, or -1. */
+    int getSelectedSnapshot() const { return m_selectedSnapshot; }
+    /** @brief Status line shown at the bottom of the panel (empty when clear). */
+    const std::string& getStatusText() const { return m_statusText; }
+    /** @brief True while an inline rename edit is active. */
+    bool isRenameActive() const { return m_renameActive; }
+    /** @brief Current rename edit buffer. */
+    const std::string& getRenameBuffer() const { return m_renameBuffer; }
+
+    /** @brief Select a take row (clears any snapshot selection). -1 clears. */
+    void selectTake(int index);
+    /** @brief Select a snapshot row (clears any take selection). -1 clears. */
+    void selectSnapshot(int index);
+
+    /** @brief Create a new take from the current state. */
+    bool requestCreateTake();
+    /** @brief Save the current state into the active take. */
+    bool requestSaveActiveTake();
+    /** @brief Open the selected take. */
+    bool requestOpenSelected();
+    /** @brief Duplicate the selected take (stays on the current take). */
+    bool requestDuplicateSelected();
+    /** @brief Branch from the selected take and switch to the branch. */
+    bool requestBranchSelected();
+    /** @brief Delete the selected take (refused for the active take). */
+    bool requestDeleteSelected();
+    /** @brief Restore the selected recovery snapshot. */
+    bool requestRestoreSelectedSnapshot();
+    /** @brief Start inline rename for the selected take. */
+    void beginRenameSelected();
+    /** @brief Commit the inline rename buffer. */
+    bool commitRename();
+    /** @brief Abandon the inline rename. */
+    void cancelRename();
+
+private:
+    static constexpr float ROW_HEIGHT = 26.0f;
+    static constexpr float HEADER_HEIGHT = 36.0f;   // WindowPanel title bar area
+    static constexpr float TOOLBAR_HEIGHT = 30.0f;
+    static constexpr float ACTION_BAR_HEIGHT = 28.0f;
+    static constexpr float SECTION_HEADER_HEIGHT = 22.0f;
+    static constexpr float STATUS_HEIGHT = 18.0f;
+    static constexpr float LEFT_PAD = 12.0f;
+    static constexpr float TEXT_LEFT_PAD = 28.0f;
+    static constexpr float DEPTH_INDENT = 12.0f;
+    static constexpr size_t MAX_SNAPSHOT_ROWS = 4;
+
+    struct TakeRow {
+        TakeManager::TakeEntry take;
+        int depth{0};
+    };
+
+    struct Layout {
+        AestraUI::NUIRect toolbar;
+        AestraUI::NUIRect newTakeButton;
+        AestraUI::NUIRect saveActiveButton;
+        AestraUI::NUIRect takesList;
+        AestraUI::NUIRect actionBar;
+        AestraUI::NUIRect snapshotHeader;
+        AestraUI::NUIRect snapshotList;
+        AestraUI::NUIRect statusLine;
+        bool actionBarVisible{false};
+    };
+
+    Layout computeLayout() const;
+    void rebuildRows();
+    int takeRowAt(const AestraUI::NUIPoint& point, const Layout& layout) const;
+    int snapshotRowAt(const AestraUI::NUIPoint& point, const Layout& layout) const;
+    std::vector<AestraUI::NUIRect> actionButtonRects(const Layout& layout) const;
+    std::vector<std::string> actionButtonLabels() const;
+    bool runRowAction(int actionIndex);
+    void setStatus(const std::string& text);
+    bool invokeAction(const std::function<bool()>& action, const char* failureMessage);
+    static std::string relativeTimeLabel(uint64_t epochMs);
+
+    TakesProvider m_takesProvider;
+    SnapshotsProvider m_snapshotsProvider;
+
+    std::function<bool()> m_onCreateTake;
+    std::function<bool()> m_onSaveActiveTake;
+    std::function<bool(const std::string&)> m_onOpenTake;
+    std::function<bool(const std::string&, const std::string&)> m_onRenameTake;
+    std::function<bool(const std::string&)> m_onDuplicateTake;
+    std::function<bool(const std::string&)> m_onDeleteTake;
+    std::function<bool(const std::string&)> m_onBranchTake;
+    std::function<bool(const std::string&)> m_onRestoreSnapshot;
+
+    std::vector<TakeRow> m_takeRows;
+    std::vector<SnapshotEntry> m_snapshotRows;
+    std::string m_manifestError;
+
+    int m_selectedTake{-1};
+    int m_selectedSnapshot{-1};
+    int m_hoveredTake{-1};
+    int m_hoveredSnapshot{-1};
+    int m_hoveredAction{-1};
+    float m_scrollY{0.0f};
+    std::string m_statusText;
+
+    bool m_renameActive{false};
+    std::string m_renameBuffer;
+    std::string m_renameTakeId;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Settings/AppearanceSettingsPage.cpp
+++ b/Source/Settings/AppearanceSettingsPage.cpp
@@ -1,8 +1,15 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "AppearanceSettingsPage.h"
 #include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../Core/Preferences.h"
+
+#include <array>
 
 namespace Aestra {
+
+namespace {
+constexpr std::array<const char*, 3> kThemeNames{"Aestra-dark", "Aestra-light", "high-contrast-dark"};
+}
 
 AppearanceSettingsPage::AppearanceSettingsPage() {
     createUI();
@@ -17,10 +24,57 @@ void AppearanceSettingsPage::createUI() {
     m_themeDropdown = std::make_shared<AestraUI::NUIDropdown>();
     m_themeDropdown->addItem("Aestra Dark (Default)", 0);
     m_themeDropdown->addItem("Aestra Light", 1);
-    m_themeDropdown->addItem("Midnight Blue", 2);
-    m_themeDropdown->addItem("High Contrast", 3);
-    m_themeDropdown->setSelectedIndex(0);
+    m_themeDropdown->addItem("High Contrast Dark", 2);
+    m_themeDropdown->setOnSelectionChanged([this](int index) {
+        if (!m_syncingSelection && index >= 0 && index < static_cast<int>(kThemeNames.size()))
+            selectTheme(kThemeNames[static_cast<size_t>(index)]);
+    });
     addChild(m_themeDropdown);
+
+    onShow();
+}
+
+void AppearanceSettingsPage::onShow() {
+    auto& manager = AestraUI::NUIThemeManager::getInstance();
+    m_originalTheme = manager.getActiveTheme();
+    m_pendingTheme = m_originalTheme;
+    m_dirty = false;
+    m_syncingSelection = true;
+    m_themeDropdown->setSelectedIndex(indexForTheme(m_pendingTheme));
+    m_syncingSelection = false;
+}
+
+void AppearanceSettingsPage::selectTheme(const std::string& themeName) {
+    auto& manager = AestraUI::NUIThemeManager::getInstance();
+    if (!manager.setActiveTheme(themeName))
+        return;
+    m_pendingTheme = themeName;
+    m_dirty = m_pendingTheme != m_originalTheme;
+}
+
+void AppearanceSettingsPage::applyChanges() {
+    auto& preferences = Preferences::instance();
+    preferences.theme = m_pendingTheme;
+    preferences.save();
+    m_originalTheme = m_pendingTheme;
+    m_dirty = false;
+}
+
+void AppearanceSettingsPage::cancelChanges() {
+    AestraUI::NUIThemeManager::getInstance().setActiveTheme(m_originalTheme);
+    m_pendingTheme = m_originalTheme;
+    m_syncingSelection = true;
+    m_themeDropdown->setSelectedIndex(indexForTheme(m_pendingTheme));
+    m_syncingSelection = false;
+    m_dirty = false;
+}
+
+int AppearanceSettingsPage::indexForTheme(const std::string& themeName) const {
+    for (size_t i = 0; i < kThemeNames.size(); ++i) {
+        if (themeName == kThemeNames[i])
+            return static_cast<int>(i);
+    }
+    return 0;
 }
 
 void AppearanceSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {

--- a/Source/Settings/AppearanceSettingsPage.h
+++ b/Source/Settings/AppearanceSettingsPage.h
@@ -15,9 +15,10 @@ public:
     std::string getPageID() const override { return "appearance"; }
     std::string getTitle() const override { return "Appearance"; }
 
-    void applyChanges() override { m_dirty = false; }
-    void cancelChanges() override { m_dirty = false; }
+    void applyChanges() override;
+    void cancelChanges() override;
     bool hasUnsavedChanges() const override { return m_dirty; }
+    void onShow() override;
 
     void onRender(AestraUI::NUIRenderer& renderer) override;
     void onResize(int width, int height) override;
@@ -25,8 +26,13 @@ public:
 private:
     void createUI();
     void layoutComponents();
+    void selectTheme(const std::string& themeName);
+    int indexForTheme(const std::string& themeName) const;
 
     bool m_dirty = false;
+    bool m_syncingSelection = false;
+    std::string m_originalTheme;
+    std::string m_pendingTheme;
     
     std::shared_ptr<AestraUI::NUILabel> m_themeLabel;
     std::shared_ptr<AestraUI::NUIDropdown> m_themeDropdown;

--- a/Source/Settings/SettingsDialog.cpp
+++ b/Source/Settings/SettingsDialog.cpp
@@ -3,6 +3,8 @@
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraCore/include/AestraLog.h"
 
+#include <algorithm>
+
 namespace Aestra {
 
 SettingsDialog::SettingsDialog() 
@@ -51,14 +53,8 @@ void SettingsDialog::show() {
         auto parentBounds = getParent()->getBounds();
         if (parentBounds.width > 0 && parentBounds.height > 0) {
             setBounds(parentBounds); // Force resize to parent
+            updateDialogBounds(parentBounds);
         }
-    }
-
-    // Center on screen
-    auto componentBounds = getBounds();
-    if (componentBounds.width > 0 && componentBounds.height > 0) {
-        m_dialogBounds.x = componentBounds.x + (componentBounds.width - m_dialogBounds.width) / 2;
-        m_dialogBounds.y = componentBounds.y + (componentBounds.height - m_dialogBounds.height) / 2;
     }
     
     layoutComponents();
@@ -113,11 +109,12 @@ void SettingsDialog::setActivePage(const std::string& pageID) {
 
 void SettingsDialog::layoutComponents() {
     if (!m_visible) return;
-    
-    float padding = 20.0f;
-    float sidebarWidth = 220.0f;
-    float footerHeight = 60.0f;
-    float titleHeight = 32.0f;
+
+    const auto& props = AestraUI::NUIThemeManager::getInstance().getCurrentTheme();
+    const float padding = props.layout.dialogPadding;
+    const float sidebarWidth = std::clamp(m_dialogBounds.width * 0.23f, 150.0f, 220.0f);
+    const float footerHeight = props.layout.dialogActionHeight + padding * 2.0f;
+    const float titleHeight = props.layout.panelHeaderHeight;
 
     // Sidebar
     m_sidebarBounds = AestraUI::NUIRect(
@@ -144,16 +141,16 @@ void SettingsDialog::layoutComponents() {
 
     // Sidebar items layout
     float itemY = m_sidebarBounds.y + padding;
-    float itemHeight = 36.0f;
+    const float itemHeight = std::max(props.layout.standardRowHeight, 32.0f);
     for (auto& item : m_sidebarItems) {
         item.bounds = AestraUI::NUIRect(m_dialogBounds.x, itemY, sidebarWidth, itemHeight);
         itemY += itemHeight;
     }
     
     // Footer buttons
-    float buttonWidth = 100.0f;
-    float buttonHeight = 32.0f;
-    float buttonY = m_dialogBounds.y + m_dialogBounds.height - 46.0f;
+    const float buttonWidth = m_dialogBounds.width < 560.0f ? 84.0f : 98.0f;
+    const float buttonHeight = props.layout.dialogActionHeight;
+    const float buttonY = m_dialogBounds.bottom() - padding - buttonHeight;
     float rightX = m_dialogBounds.x + m_dialogBounds.width - padding;
     
     m_okButton->setBounds(AestraUI::NUIRect(rightX - buttonWidth, buttonY, buttonWidth, buttonHeight));
@@ -168,13 +165,26 @@ void SettingsDialog::layoutComponents() {
     }
 }
 
+void SettingsDialog::updateDialogBounds(const AestraUI::NUIRect& parentBounds) {
+    constexpr float kPreferredWidth = 950.0f;
+    constexpr float kPreferredHeight = 600.0f;
+    constexpr float kWindowMargin = 16.0f;
+    constexpr float kMinimumWidth = 360.0f;
+    constexpr float kMinimumHeight = 320.0f;
+
+    const float availableWidth = std::max(kMinimumWidth, parentBounds.width - kWindowMargin * 2.0f);
+    const float availableHeight = std::max(kMinimumHeight, parentBounds.height - kWindowMargin * 2.0f);
+    m_dialogBounds.width = std::min(kPreferredWidth, availableWidth);
+    m_dialogBounds.height = std::min(kPreferredHeight, availableHeight);
+    m_dialogBounds.x = parentBounds.x + (parentBounds.width - m_dialogBounds.width) * 0.5f;
+    m_dialogBounds.y = parentBounds.y + (parentBounds.height - m_dialogBounds.height) * 0.5f;
+}
+
 void SettingsDialog::onResize(int width, int height) {
     // Parent bounds (window size)
     setBounds(AestraUI::NUIRect(0, 0, (float)width, (float)height));
     
-    // Center dialog
-    m_dialogBounds.x = (width - m_dialogBounds.width) / 2;
-    m_dialogBounds.y = (height - m_dialogBounds.height) / 2;
+    updateDialogBounds(getBounds());
     
     layoutComponents();
 }

--- a/Source/Settings/SettingsDialog.h
+++ b/Source/Settings/SettingsDialog.h
@@ -41,6 +41,7 @@ public:
 private:
     void createUI();
     void layoutComponents();
+    void updateDialogBounds(const AestraUI::NUIRect& parentBounds);
     void updateSidebar();
 
     bool m_visible;

--- a/Source/ViewTypes.h
+++ b/Source/ViewTypes.h
@@ -12,7 +12,8 @@ enum class ViewType {
     Sequencer,
     PianoRoll,
     Playlist,
-    History
+    History,
+    Takes
 };
 
 } // namespace Audio

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -1,9 +1,12 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "NUIThemeSystem.h"
+#include "NUIComponent.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -12,6 +15,18 @@ using namespace AestraUI;
 namespace {
 
 int gFailures = 0;
+
+class ThemeProbe final : public NUIComponent {
+public:
+    void onThemeChanged(const NUIThemeProperties& theme) override {
+        ++changeCount;
+        observedPrimary = theme.primary;
+        NUIComponent::onThemeChanged(theme);
+    }
+
+    int changeCount = 0;
+    NUIColor observedPrimary;
+};
 
 void check(bool condition, const std::string& label) {
     std::cout << "  " << (condition ? "PASS " : "FAIL ") << label << '\n';
@@ -126,6 +141,95 @@ void testThemeChangeResolution() {
     manager.setOnThemeChanged({});
 }
 
+void testIndependentSubscriptionsAndAtomicSwitching() {
+    std::cout << "[Test] independent subscribers and atomic switching\n";
+    auto& manager = NUIThemeManager::getInstance();
+    manager.setActiveTheme("Aestra-dark");
+
+    auto target = NUIThemePresets::createAestraLight();
+    target.primary = NUIColor::fromHex(0x13579b);
+    target.layout.standardControlHeight = 31.0f;
+    manager.setCustomTheme("subscription-test", target);
+
+    int firstCount = 0;
+    int secondCount = 0;
+    bool observedCompleteTheme = false;
+    const auto first = manager.subscribeToThemeChanges([&](const NUIThemeProperties&) { ++firstCount; });
+    const auto second = manager.subscribeToThemeChanges([&](const NUIThemeProperties& theme) {
+        ++secondCount;
+        observedCompleteTheme = colorsEqual(theme.primary, target.primary) &&
+                                nearlyEqual(theme.layout.standardControlHeight, 31.0f);
+    });
+
+    manager.switchTheme("subscription-test", 300.0f);
+    check(manager.getActiveTheme() == "subscription-test", "animated API activates the requested theme atomically");
+    check(firstCount == 1 && secondCount == 1, "independent subscribers each receive one notification");
+    check(observedCompleteTheme, "subscriber receives a complete target theme, not a partial interpolation");
+
+    manager.unsubscribeFromThemeChanges(first);
+    manager.setActiveTheme("Aestra-dark");
+    check(firstCount == 1 && secondCount == 2, "unsubscribing one listener does not disconnect another");
+    manager.unsubscribeFromThemeChanges(second);
+}
+
+void testLiveJSONThemeRegistration() {
+    std::cout << "[Test] JSON overrides register into the live manager\n";
+    const std::string path = "live_theme_registration_test.json";
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out << R"({
+            "colors": { "accent": "#2468ac", "focusRing": "#abcdef" },
+            "dimensions": { "standardControlHeight": 30.0 },
+            "fontSizes": { "normal": 13.0 }
+        })";
+    }
+
+    auto& manager = NUIThemeManager::getInstance();
+    const auto base = NUIThemePresets::createAestraDark();
+    check(manager.loadThemeFromFile("live-json-test", path), "valid JSON theme registers successfully");
+    check(manager.setActiveTheme("live-json-test"), "registered JSON theme can become active");
+    const auto& loaded = manager.getCurrentTheme();
+    check(colorsEqual(loaded.primary, NUIColor::fromHex(0x2468ac)), "legacy accent key maps to live primary role");
+    check(colorsEqual(loaded.focusRing, NUIColor::fromHex(0xabcdef)), "semantic focus ring maps into live state");
+    check(colorsEqual(loaded.backgroundPrimary, base.backgroundPrimary), "missing live token inherits the base preset");
+    check(nearlyEqual(loaded.layout.standardControlHeight, 30.0f), "live control dimension is overridden");
+    check(nearlyEqual(loaded.fontSizeM, 13.0f), "legacy normal font size maps to live body text");
+
+    int reloadCount = 0;
+    const auto reloadSubscription = manager.subscribeToThemeChanges(
+        [&](const NUIThemeProperties&) { ++reloadCount; });
+    check(manager.loadThemeFromFile("live-json-test", path), "active JSON theme can be reloaded");
+    check(reloadCount == 1, "reloading the active theme emits one update");
+    manager.unsubscribeFromThemeChanges(reloadSubscription);
+    std::remove(path.c_str());
+
+    const std::string invalidPath = "invalid_live_theme_registration_test.json";
+    {
+        std::ofstream out(invalidPath, std::ios::binary | std::ios::trunc);
+        out << "{ invalid";
+    }
+    check(!manager.loadThemeFromFile("invalid-live-json-test", invalidPath),
+          "malformed JSON is rejected by live registration");
+    check(!manager.hasTheme("invalid-live-json-test"), "failed registration does not install a misleading fallback");
+    std::remove(invalidPath.c_str());
+    manager.setActiveTheme("Aestra-dark");
+}
+
+void testHierarchyInvalidation() {
+    std::cout << "[Test] component hierarchy theme propagation\n";
+    auto root = std::make_shared<ThemeProbe>();
+    auto child = std::make_shared<ThemeProbe>();
+    root->addChild(child);
+    root->setDirty(false);
+    child->setDirty(false);
+
+    const auto theme = NUIThemePresets::createAestraLight();
+    root->onThemeChanged(theme);
+    check(root->changeCount == 1 && child->changeCount == 1, "theme change reaches each hierarchy node once");
+    check(root->isDirty() && child->isDirty(), "theme change invalidates root and descendants");
+    check(colorsEqual(child->observedPrimary, theme.primary), "descendant observes the complete active theme");
+}
+
 void testCompatibilityAliases() {
     std::cout << "[Test] live component token aliases\n";
     auto& manager = NUIThemeManager::getInstance();
@@ -164,6 +268,23 @@ void testLightPresetCompleteness() {
           "light primary action text remains readable");
 }
 
+void testHighContrastPreset() {
+    std::cout << "[Test] high-contrast preset is distinct and readable\n";
+    const auto ordinary = NUIThemePresets::createAestraDark();
+    const auto highContrast = NUIThemePresets::createHighContrastDark();
+
+    check(!colorsEqual(highContrast.borderStrong, ordinary.borderStrong),
+          "high contrast is not an alias of ordinary dark");
+    check(contrastRatio(highContrast.textPrimary, highContrast.backgroundPrimary) >= 7.0f,
+          "high-contrast primary text exceeds enhanced contrast");
+    check(contrastRatio(highContrast.textSecondary, highContrast.backgroundSecondary) >= 4.5f,
+          "high-contrast secondary text remains readable");
+    check(contrastRatio(highContrast.textOnPrimary, highContrast.primary) >= 4.5f,
+          "high-contrast accent action text remains readable");
+    check(highContrast.gridMajor.a > ordinary.gridMajor.a && highContrast.gridMinor.a > ordinary.gridMinor.a,
+          "high-contrast grid hierarchy is stronger without flattening major/minor distinction");
+}
+
 } // namespace
 
 int main() {
@@ -171,8 +292,12 @@ int main() {
     testStatePriorityAndGeometry();
     testDefaultContrast();
     testThemeChangeResolution();
+    testIndependentSubscriptionsAndAtomicSwitching();
+    testLiveJSONThemeRegistration();
+    testHierarchyInvalidation();
     testCompatibilityAliases();
     testLightPresetCompleteness();
+    testHighContrastPreset();
 
     if (gFailures == 0) {
         std::cout << "All UI theme consistency checks passed\n";

--- a/Tests/AestraUI/NUIThemeJSONTest.cpp
+++ b/Tests/AestraUI/NUIThemeJSONTest.cpp
@@ -65,6 +65,9 @@ void testValidThemeApplies() {
 
     auto theme = NUITheme::loadFromFile(path);
     check(theme != nullptr, "theme is not null");
+    check(theme->loadedSuccessfully(), "valid JSON reports a successful load");
+    check(theme->hasColorOverride("primary") && !theme->hasColorOverride("textMuted"),
+          "explicit color overrides are distinguished from defaults");
     check(colorsEqual(theme->getColor("primary"), NUIColor::fromHex(0xff0000)), "primary = #ff0000");
     check(colorsEqual(theme->getColor("background"), NUIColor::fromHex(0x00ff00)), "background = #00ff00");
     check(colorsEqual(theme->getColor("surface"), NUIColor::fromHex(0x0000ff, 128.0f / 255.0f)),
@@ -108,6 +111,7 @@ void testNonexistentFileReturnsDefault() {
     auto theme = NUITheme::loadFromFile("theme_does_not_exist_test.json");
     auto defaults = NUITheme::createDefault();
     check(theme != nullptr, "theme is not null");
+    check(!theme->loadedSuccessfully(), "missing file reports a failed load");
     check(colorsEqual(theme->getColor("primary"), defaults->getColor("primary")), "matches default theme");
 }
 
@@ -117,6 +121,7 @@ void testMalformedJSONReturnsDefault() {
     auto theme = NUITheme::loadFromFile(path);
     auto defaults = NUITheme::createDefault();
     check(theme != nullptr, "theme is not null");
+    check(!theme->loadedSuccessfully(), "malformed JSON reports a failed load");
     check(colorsEqual(theme->getColor("primary"), defaults->getColor("primary")), "matches default theme");
     std::remove(path.c_str());
 
@@ -138,7 +143,7 @@ void testInvalidEntriesKeepDefaults() {
             "textSecondary": "#abc",
             "error": "#ff00ff"
         },
-        "dimensions": { "borderRadius": "twelve", "compactControlHeight": -1.0 },
+        "dimensions": { "borderRadius": "twelve", "compactControlHeight": -1.0, "spacingM": -8.0 },
         "fontSizes": { "normal": -5, "small": 11.0 }
     })");
 
@@ -155,6 +160,8 @@ void testInvalidEntriesKeepDefaults() {
           "string-as-dimension rejected");
     check(nearlyEqual(theme->getDimension("compactControlHeight"), defaults->getDimension("compactControlHeight")),
           "non-positive semantic dimension rejected");
+    check(nearlyEqual(theme->getDimension("spacingM"), defaults->getDimension("spacingM")),
+          "non-positive spacing token rejected");
     check(nearlyEqual(theme->getFontSize("normal"), defaults->getFontSize("normal")),
           "non-positive font size rejected");
     check(nearlyEqual(theme->getFontSize("small"), 11.0f), "valid sibling font size applied");

--- a/Tests/AestraUI/TakesHistoryPanelTest.cpp
+++ b/Tests/AestraUI/TakesHistoryPanelTest.cpp
@@ -1,0 +1,367 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Takes/History workspace panel behavior:
+//   * History panel presents the session command timeline (undo + redo stacks),
+//     refreshes on state change, and navigates safely through activateEntry.
+//   * Takes panel lists the takes manifest with lineage depth, routes every
+//     action through app-layer callbacks, supports inline rename via key
+//     events, and never mutates project state itself.
+//   * Panel opening: hidden panels ignore input; showing + refresh presents
+//     current data.
+
+#include "../../Source/Panels/AestraHistoryPanel.h"
+#include "../../Source/Panels/TakesPanel.h"
+
+#include "../../Source/Core/TakeManager.h"
+#include "../Support/TestTempDirectory.h"
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+
+using Aestra::Audio::AestraHistoryPanel;
+using Aestra::Audio::TakesPanel;
+using Aestra::Audio::TrackManager;
+
+namespace {
+
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+/** Minimal named command so the history panel has real timeline entries. */
+class NamedTestCommand : public Aestra::Audio::ICommand {
+public:
+    NamedTestCommand(std::string name, int& counter) : m_name(std::move(name)), m_counter(counter) {}
+    void execute() override { ++m_counter; }
+    void undo() override { --m_counter; }
+    void redo() override { ++m_counter; }
+    std::string getName() const override { return m_name; }
+
+private:
+    std::string m_name;
+    int& m_counter;
+};
+
+std::string readFileContents(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+AestraUI::NUIKeyEvent keyPress(AestraUI::NUIKeyCode code, char character = 0) {
+    AestraUI::NUIKeyEvent e;
+    e.keyCode = code;
+    e.character = character;
+    e.pressed = true;
+    return e;
+}
+
+AestraUI::NUIMouseEvent leftPress(float x, float y) {
+    AestraUI::NUIMouseEvent e;
+    e.type = AestraUI::NUIMouseEventType::Down;
+    e.pressed = true;
+    e.button = AestraUI::NUIMouseButton::Left;
+    e.position = {x, y};
+    return e;
+}
+
+AestraUI::NUIMouseEvent scrollBy(float x, float y, float wheelDelta) {
+    AestraUI::NUIMouseEvent e;
+    e.type = AestraUI::NUIMouseEventType::Scroll;
+    e.wheelDelta = wheelDelta;
+    e.position = {x, y};
+    return e;
+}
+
+// =============================================================================
+// History panel — command timeline presentation and navigation
+// =============================================================================
+
+void testHistoryPanel() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& history = trackManager->getCommandHistory();
+
+    AestraHistoryPanel panel(trackManager);
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 280.0f, 460.0f));
+    panel.setVisible(true);
+
+    require(panel.getEntryCount() == 0, "History panel should start empty");
+
+    int counter = 0;
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Move Clip", counter));
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Add Track", counter));
+    history.pushAndExecute(std::make_shared<NamedTestCommand>("Change Volume", counter));
+    require(counter == 3, "Commands should have executed");
+
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 3, "Panel should present all executed commands");
+    for (int i = 0; i < 3; ++i) {
+        require(!panel.isEntryRedo(i), "No redo entries expected before undo");
+    }
+    bool sawMove = false, sawAdd = false, sawVolume = false;
+    for (int i = 0; i < 3; ++i) {
+        const auto& name = panel.getEntryName(i);
+        sawMove = sawMove || name == "Move Clip";
+        sawAdd = sawAdd || name == "Add Track";
+        sawVolume = sawVolume || name == "Change Volume";
+    }
+    require(sawMove && sawAdd && sawVolume, "Panel entries should carry command names");
+
+    // Undo → most recent command moves to the redo (greyed) region.
+    require(history.undo(), "Undo should succeed");
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 3, "Undone commands stay visible in the timeline");
+    int redoCount = 0;
+    for (int i = 0; i < panel.getEntryCount(); ++i) {
+        if (panel.isEntryRedo(i)) {
+            ++redoCount;
+            require(panel.getEntryName(i) == "Change Volume", "Undone command should appear as redo entry");
+        }
+    }
+    require(redoCount == 1, "Exactly one redo entry expected after a single undo");
+    require(counter == 2, "Undo should have reverted the command");
+
+    // Navigate by clicking the redo entry — redoes it and fires the callback.
+    int historyChangedCalls = 0;
+    panel.setOnHistoryChanged([&historyChangedCalls]() { ++historyChangedCalls; });
+    int redoIndex = -1;
+    for (int i = 0; i < panel.getEntryCount(); ++i) {
+        if (panel.isEntryRedo(i)) {
+            redoIndex = i;
+            break;
+        }
+    }
+    require(redoIndex >= 0, "Redo entry should exist");
+    panel.activateEntry(redoIndex);
+    require(counter == 3, "Activating a redo entry should re-apply the command");
+    require(!history.canRedo(), "Redo stack should be drained");
+    require(historyChangedCalls == 1, "History navigation should notify listeners");
+
+    // Jump back to the beginning of the session through the timeline.
+    panel.activateEntry(panel.getEntryCount() - 1); // deepest undo row keeps that stackIndex
+    require(history.canRedo(), "Timeline jump should produce redoable commands");
+    require(counter < 3, "Timeline jump should have undone commands");
+
+    // Hidden panel must ignore input entirely.
+    panel.setVisible(false);
+    require(!panel.onMouseEvent(leftPress(10.0f, 50.0f)), "Hidden history panel must not consume events");
+
+    std::cout << "[PASS] History panel timeline\n";
+}
+
+// Clicking rows after scrolling must hit the visually shifted entries —
+// regression for the scroll offset being tracked but never applied.
+void testHistoryPanelScrolledClick() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& history = trackManager->getCommandHistory();
+
+    AestraHistoryPanel panel(trackManager);
+    // 36px header + room for ~3 of the 26px rows: most entries start clipped.
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 280.0f, 114.0f));
+    panel.setVisible(true);
+
+    int counter = 0;
+    for (int i = 0; i < 10; ++i) {
+        history.pushAndExecute(std::make_shared<NamedTestCommand>("Cmd " + std::to_string(i), counter));
+    }
+    panel.refreshHistory();
+    require(panel.getEntryCount() == 10, "All commands should be listed");
+    require(counter == 10, "All commands should have executed");
+
+    // Two wheel notches = 60px of scroll (30px per notch).
+    require(panel.onMouseEvent(scrollBy(100.0f, 60.0f, -1.0f)), "Scroll should be consumed");
+    require(panel.onMouseEvent(scrollBy(100.0f, 60.0f, -1.0f)), "Scroll should be consumed");
+
+    // With scrollY=60, row i spans y = [36 + 26*i - 60, +26) → y=40 hits row 2.
+    // Entry 2 = undoStack[2], so undoTo(2) keeps exactly 2 commands applied.
+    require(panel.onMouseEvent(leftPress(100.0f, 40.0f)), "Row click should be consumed");
+    require(counter == 2, "Scrolled click should activate the visually shifted entry");
+    require(history.canRedo(), "Timeline jump should leave redoable commands");
+
+    std::cout << "[PASS] History panel scrolled click\n";
+}
+
+// =============================================================================
+// Takes panel — manifest presentation, actions, rename, non-destructive branch
+// =============================================================================
+
+void testTakesPanel() {
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"TakesPanel"};
+    const auto projectPath = (tempDirScope.path() / "panel_project.aes").string();
+
+    auto init = TakeManager::ensureManifest(projectPath, "state-main", "Main");
+    require(init.ok, "Failed to initialize takes manifest");
+    auto created = TakeManager::createTake(projectPath, "state-idea-b", "Idea B");
+    require(created.ok, "Failed to create second take");
+
+    TakesPanel panel;
+    panel.setBounds(AestraUI::NUIRect(0.0f, 0.0f, 320.0f, 480.0f));
+    panel.setVisible(true);
+    panel.setTakesProvider([&projectPath]() { return TakeManager::loadManifest(projectPath); });
+    panel.setSnapshotsProvider([]() {
+        return std::vector<TakesPanel::SnapshotEntry>{{"/nonexistent/snapshot.aes", "Jul 16 10:00"}};
+    });
+
+    // Opening semantics: refresh presents current manifest + snapshots.
+    panel.refreshTakes();
+    require(panel.getTakeCount() == 2, "Panel should list both takes");
+    require(panel.getSnapshotCount() == 1, "Panel should list recovery snapshots");
+
+    int mainRow = -1, ideaRow = -1;
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") mainRow = i;
+        if (panel.getTakeAt(i).name == "Idea B") ideaRow = i;
+    }
+    require(mainRow >= 0 && ideaRow >= 0, "Both takes should be present");
+    require(panel.getTakeDepthAt(mainRow) == 0, "Root take should have depth 0");
+    require(panel.getTakeDepthAt(ideaRow) == 1, "Child take should be indented under its parent");
+    require(panel.getTakeAt(ideaRow).active, "Newly created take should be marked active");
+
+    // Open action routes through the callback with the selected take's id.
+    std::string openedId;
+    panel.setOnOpenTake([&](const std::string& takeId) {
+        openedId = takeId;
+        // Mimic the app: activate the take in the manifest (snapshot load is app-side).
+        return TakeManager::setActiveTake(projectPath, takeId).ok;
+    });
+    panel.selectTake(mainRow);
+    require(panel.getSelectedTake() == mainRow, "Selection should stick");
+    require(panel.requestOpenSelected(), "Open action should succeed");
+    require(openedId == "main", "Open action should receive the selected take id");
+    // The refresh after the action must reflect the new active take.
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") {
+            require(panel.getTakeAt(i).active, "Manifest refresh should show the opened take as active");
+        }
+    }
+
+    // Create action → new take appears after the built-in refresh.
+    panel.setOnCreateTake([&]() { return TakeManager::createTake(projectPath, "state-c", "Idea C").ok; });
+    require(panel.requestCreateTake(), "Create action should succeed");
+    require(panel.getTakeCount() == 3, "New take should appear in the panel");
+
+    // Mouse selection: click on the first take row.
+    panel.selectTake(-1);
+    const float rowCenterY = 36.0f + 30.0f + 13.0f; // header + toolbar + half row
+    require(panel.onMouseEvent(leftPress(160.0f, rowCenterY)), "Row click should be consumed");
+    require(panel.getSelectedTake() == 0, "Click should select the first take row");
+
+    // Inline rename: keyboard-driven edit, committed through the callback.
+    panel.setOnRenameTake([&](const std::string& takeId, const std::string& name) {
+        return TakeManager::renameTake(projectPath, takeId, name).ok;
+    });
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).name == "Idea C") panel.selectTake(i);
+    }
+    panel.beginRenameSelected();
+    require(panel.isRenameActive(), "Rename edit should be active");
+    // Text input is delivered via the focused-component path — the panel must
+    // hold focus for the duration of the edit and release it afterwards.
+    require(panel.isFocused(), "Rename edit must claim keyboard focus");
+    // Clear the prefilled name, type a new one, commit with Enter.
+    while (!panel.getRenameBuffer().empty()) {
+        require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Backspace)), "Backspace should be consumed");
+    }
+    for (char c : std::string("Chorus V2")) {
+        require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Unknown, c)), "Typing should be consumed");
+    }
+    require(panel.getRenameBuffer() == "Chorus V2", "Rename buffer should reflect typed name");
+    require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Enter)), "Enter should commit rename");
+    require(!panel.isRenameActive(), "Rename edit should end on commit");
+    require(!panel.isFocused(), "Committing a rename must release keyboard focus");
+    auto renamedManifest = TakeManager::loadManifest(projectPath);
+    require(renamedManifest.ok, "Manifest should reload after rename");
+    bool foundRenamed = false;
+    for (const auto& take : renamedManifest.takes) {
+        foundRenamed = foundRenamed || take.name == "Chorus V2";
+    }
+    require(foundRenamed, "Rename should persist to the manifest");
+
+    // Escape cancels a rename without touching the manifest.
+    panel.beginRenameSelected();
+    require(panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Escape)), "Escape should be consumed");
+    require(!panel.isRenameActive(), "Escape should cancel rename");
+    require(!panel.isFocused(), "Cancelling a rename must release keyboard focus");
+
+    // Branch: duplicate + activate, source take untouched (non-destructive).
+    const auto beforeBranch = TakeManager::loadManifest(projectPath);
+    require(beforeBranch.ok, "Manifest should load before branch");
+    const auto* branchSource = beforeBranch.findTake("main");
+    require(branchSource != nullptr, "Branch source should exist");
+    const std::string sourceSnapshotPath = TakeManager::resolveSnapshotPath(projectPath, *branchSource);
+    const std::string sourceContentsBefore = readFileContents(sourceSnapshotPath);
+    require(!sourceContentsBefore.empty(), "Branch source snapshot should exist");
+
+    panel.setOnBranchTake([&](const std::string& takeId) {
+        auto dup = TakeManager::duplicateTake(projectPath, takeId, "Main Branch");
+        if (!dup.ok) return false;
+        return TakeManager::setActiveTake(projectPath, dup.take.id).ok;
+    });
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).id == "main") panel.selectTake(i);
+    }
+    require(panel.requestBranchSelected(), "Branch action should succeed");
+
+    const auto afterBranch = TakeManager::loadManifest(projectPath);
+    require(afterBranch.ok, "Manifest should load after branch");
+    require(afterBranch.takes.size() == beforeBranch.takes.size() + 1, "Branch should add a take");
+    const auto* branch = afterBranch.activeTake();
+    require(branch != nullptr && branch->name == "Main Branch", "Branch should be active");
+    require(branch->parentId == "main", "Branch should record its source as parent");
+    require(readFileContents(sourceSnapshotPath) == sourceContentsBefore,
+            "Branching must not modify the source take snapshot");
+    require(readFileContents(TakeManager::resolveSnapshotPath(projectPath, *branch)) == sourceContentsBefore,
+            "Branch snapshot should start as a copy of its source");
+
+    // Delete: refused for the active take, works for others, row disappears.
+    panel.setOnDeleteTake([&](const std::string& takeId) { return TakeManager::deleteTake(projectPath, takeId).ok; });
+    int activeRow = -1, chorusRow = -1;
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        if (panel.getTakeAt(i).active) activeRow = i;
+        if (panel.getTakeAt(i).name == "Chorus V2") chorusRow = i;
+    }
+    require(activeRow >= 0 && chorusRow >= 0, "Active and Chorus V2 takes should exist before delete");
+    panel.selectTake(activeRow);
+    require(!panel.requestDeleteSelected(), "Deleting the active take must be refused by the panel");
+    require(!panel.getStatusText().empty(), "Refused delete should explain itself");
+    const int countBeforeDelete = panel.getTakeCount();
+    panel.selectTake(chorusRow);
+    require(panel.requestDeleteSelected(), "Deleting a non-active take should succeed");
+    require(panel.getTakeCount() == countBeforeDelete - 1, "Deleted take row should disappear");
+    for (int i = 0; i < panel.getTakeCount(); ++i) {
+        require(panel.getTakeAt(i).name != "Chorus V2", "Deleted take must not reappear");
+    }
+
+    // A failing action surfaces a status message instead of silently dropping.
+    panel.setOnDuplicateTake([](const std::string&) { return false; });
+    panel.selectTake(0);
+    require(!panel.requestDuplicateSelected(), "Failing duplicate should report false");
+    require(!panel.getStatusText().empty(), "Failing action should surface a status message");
+
+    // Hidden panel ignores input.
+    panel.setVisible(false);
+    require(!panel.onMouseEvent(leftPress(160.0f, rowCenterY)), "Hidden takes panel must not consume events");
+    require(!panel.handleKeyEvent(keyPress(AestraUI::NUIKeyCode::Enter)), "Hidden takes panel must not consume keys");
+
+    std::cout << "[PASS] Takes panel actions\n";
+}
+
+} // namespace
+
+int main() {
+    testHistoryPanel();
+    testHistoryPanelScrolledClick();
+    testTakesPanel();
+    std::cout << "[PASS] TakesHistoryPanelTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1965,6 +1965,16 @@ target_include_directories(CommandRegistryParseSafetyTest PRIVATE
 add_test(NAME CommandRegistryParseSafetyTest COMMAND CommandRegistryParseSafetyTest)
 set_tests_properties(CommandRegistryParseSafetyTest PROPERTIES LABELS "commands;regression")
 
+# MuseService — the structured JSON surface agents drive Aestra through.
+add_executable(MuseServiceTest Commands/MuseServiceTest.cpp)
+target_link_libraries(MuseServiceTest PRIVATE AestraAudioCore)
+target_include_directories(MuseServiceTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME MuseServiceTest COMMAND MuseServiceTest)
+set_tests_properties(MuseServiceTest PROPERTIES LABELS "commands;muse")
+
 # Rumble state and migration are deterministic pure-logic coverage. Keep this in
 # the normal test tier so stable parameter IDs cannot drift behind a runtime gate.
 if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/RumbleStateTest.cpp")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -259,6 +259,33 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectValueFidelityTest.cpp"
     set_tests_properties(ProjectValueFidelityTest PROPERTIES LABELS "integration;serialization")
 endif()
 
+# Identity stability (#446): serialized clip/lane/pattern/source IDs survive
+# load, save->load->save is a byte-identical fixed point, post-load mints
+# never collide with restored IDs.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectIdentityStabilityTest.cpp")
+    add_executable(ProjectIdentityStabilityTest
+        Integration/ProjectIdentityStabilityTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(ProjectIdentityStabilityTest PRIVATE AestraAudio)
+    target_include_directories(ProjectIdentityStabilityTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    add_test(NAME ProjectIdentityStabilityTest COMMAND ProjectIdentityStabilityTest)
+    set_tests_properties(ProjectIdentityStabilityTest PROPERTIES LABELS "integration;serialization;identity")
+endif()
+
 # Project Load Regression Tests (routing safety, missing references, non-destructive load)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectLoadRegressionTest.cpp")
     add_executable(ProjectLoadRegressionTest

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1777,6 +1777,45 @@ else()
     message(STATUS "PanelWindowClickSwallowTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Takes/History workspace panels: command-timeline presentation + navigation,
+# takes manifest listing, actions, inline rename, non-destructive branching.
+if(TARGET AestraUI_Core)
+    add_executable(TakesHistoryPanelTest
+        AestraUI/TakesHistoryPanelTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/WindowPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/AestraHistoryPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/TakesPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/TakeManager.cpp
+    )
+    target_link_libraries(TakesHistoryPanelTest PRIVATE AestraUI_Core AestraAudio)
+    target_include_directories(TakesHistoryPanelTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+        ${CMAKE_SOURCE_DIR}/AestraUI/Graphics
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/Source/Panels
+    )
+    add_test(NAME TakesHistoryPanelTest COMMAND TakesHistoryPanelTest)
+    set_tests_properties(TakesHistoryPanelTest PROPERTIES LABELS "ui;takes;history;regression")
+else()
+    message(STATUS "TakesHistoryPanelTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # Plugin-browser filtering must preserve selection by stable plugin ID rather
 # than silently selecting whichever row inherits the old numeric index.
 if(TARGET AestraUI_Core)

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -12,6 +12,7 @@
 
 #include "AestraJSON.h"
 
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cmath>
@@ -707,6 +708,98 @@ int main() {
         trackManager->getCommandHistory().undo(); // add_effect
         r = call(service, "{\"id\": 204, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
         check(r["result"]["effects"].size() == 0, "full undo chain leaves a clean track");
+    }
+
+    // --- Sample discovery + expressive step strings ---
+    {
+        // A tiny library: one wav, one decoy, one nested wav.
+        // Unique per run so stale files or parallel runs cannot change counts.
+        const auto uniqueSuffix = std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count());
+        const auto libDir = std::filesystem::temp_directory_path() /
+                            ("muse_service_test_lib_" + uniqueSuffix);
+        std::filesystem::remove_all(libDir);
+        std::filesystem::create_directories(libDir / "kicks");
+        {
+            // Real WAVs (the validator checks magic bytes, not just extension).
+            const std::string source = writeTestWav();
+            std::filesystem::copy_file(source, libDir / "top.wav",
+                                       std::filesystem::copy_options::overwrite_existing);
+            std::filesystem::copy_file(source, libDir / "kicks" / "deep.wav",
+                                       std::filesystem::copy_options::overwrite_existing);
+            std::FILE* f = std::fopen((libDir / "notes.txt").string().c_str(), "wb");
+            check(f != nullptr, "decoy file created");
+            if (f) {
+                std::fputs("not audio", f);
+                std::fclose(f);
+            }
+        }
+
+        JSON req = JSON::object();
+        req.set("id", JSON(210.0));
+        req.set("verb", JSON("list_samples"));
+        JSON dirArgs = JSON::object();
+        dirArgs.set("dir", JSON(libDir.string()));
+        req.set("args", dirArgs);
+        JSON r = call(service, req.toString());
+        check(status(r) == "ok", "list_samples ok");
+        check(r["result"]["samples"].size() == 2, "only audio files listed (txt skipped)");
+        check(!r["result"]["truncated"].asBool(), "listing not truncated");
+        bool sawNested = false;
+        for (size_t i = 0; i < r["result"]["samples"].size(); ++i) {
+            if (r["result"]["samples"][i]["name"].asString() == "deep.wav") sawNested = true;
+        }
+        check(sawNested, "nested sample found");
+
+        r = call(service,
+                 "{\"id\": 211, \"verb\": \"list_samples\", \"args\": {\"dir\": \"/nonexistent_muse_lib\"}}");
+        check(status(r) == "execution_error", "missing dir -> execution_error");
+        r = call(service, "{\"id\": 212, \"verb\": \"list_samples\"}");
+        check(status(r) == "validation_error", "missing dir arg -> validation_error");
+        std::filesystem::remove_all(libDir);
+
+        // Velocity digits: '9' is full velocity, '3' is a third.
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+        r = call(service, "{\"id\": 213, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 44, \"steps\": \"9-3-\"}}");
+        check(status(r) == "ok", "digit steps ok");
+        r = call(service,
+                 "{\"id\": 214, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        double v9 = -1.0, v3 = -1.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() == 44.0) {
+                if (note["start"].asNumber() == 0.0) v9 = note["velocity"].asNumber();
+                if (note["start"].asNumber() == 0.5) v3 = note["velocity"].asNumber();
+            }
+        }
+        check(std::abs(v9 - 1.0) < 1e-6, "digit 9 lands at full velocity");
+        check(std::abs(v3 - 3.0 / 9.0) < 1e-6, "digit 3 lands at a third velocity");
+
+        // Swing: odd steps land late by swing * step / 2.
+        r = call(service, "{\"id\": 215, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 44, \"steps\": \"x-x-xx\", \"swing\": 0.6}}");
+        check(status(r) == "ok", "swing steps ok");
+        r = call(service,
+                 "{\"id\": 216, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool sawSwung = false, sawStraight = false;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() != 44.0) continue;
+            const double start = note["start"].asNumber();
+            // step 5 (odd) at 1.25 + 0.6*0.125 = 1.325
+            if (std::abs(start - 1.325) < 1e-6) sawSwung = true;
+            if (std::abs(start - 1.0) < 1e-6) sawStraight = true;
+        }
+        check(sawSwung, "odd step swung late");
+        check(sawStraight, "even step stays on the grid");
+
+        // Cleanup: clear the scratch row.
+        r = call(service, "{\"id\": 217, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 44, \"steps\": \"-\"}}");
+        check(status(r) == "ok", "scratch row cleared");
     }
 
     // --- Render: the beat comes back as a file with signal in it ---

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -452,6 +452,91 @@ int main() {
         std::filesystem::remove(outPath);
     }
 
+    // --- Batch: all-or-nothing groups that undo as one step ---
+    {
+        // Baseline state for this section.
+        JSON r = call(service, "{\"id\": 90, \"verb\": \"list_tracks\"}");
+        const size_t tracksBefore = r["result"]["tracks"].size();
+        const bool muteBefore = r["result"]["tracks"][0]["muted"].asBool();
+
+        r = call(service,
+                 "{\"id\": 91, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"add_track\", \"args\": {\"name\": \"Perc\"}},"
+                 "{\"verb\": \"set_volume\", \"args\": {\"track\": 0, \"value\": 0.25}},"
+                 "{\"verb\": \"mute_track\", \"args\": {\"track\": 0, \"state\": " +
+                     std::string(muteBefore ? "false" : "true") + "}}]}}");
+        check(status(r) == "ok", "batch of three mutations ok");
+        check(r["result"]["count"].asNumber() == 3.0, "batch reports member count");
+        check(r["undoable"].asBool(), "batch is undoable");
+
+        r = call(service, "{\"id\": 92, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == tracksBefore + 1, "batch added the track");
+        const double vol = r["result"]["tracks"][0]["volume"].asNumber();
+        check(vol > 0.24 && vol < 0.26 &&
+                  r["result"]["tracks"][0]["muted"].asBool() == !muteBefore,
+              "batch applied volume and mute flip");
+
+        // One undo reverts the entire batch.
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 93, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == tracksBefore, "single undo removes batch track");
+        check(r["result"]["tracks"][0]["muted"].asBool() == muteBefore,
+              "single undo reverts mute from the same batch");
+
+        // Dependent batch: members run against the state their predecessors
+        // produced, so a batch can configure the track it just added.
+        r = call(service,
+                 "{\"id\": 101, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"add_track\", \"args\": {\"name\": \"Lead\"}},"
+                 "{\"verb\": \"set_pan\", \"args\": {\"track\": " +
+                     std::to_string(tracksBefore) + ", \"value\": -0.5}}]}}");
+        check(status(r) == "ok", "dependent batch (pan the track it added) ok");
+        r = call(service, "{\"id\": 102, \"verb\": \"list_tracks\"}");
+        const double newPan = r["result"]["tracks"][tracksBefore]["pan"].asNumber();
+        check(newPan < -0.49 && newPan > -0.51, "dependent batch applied pan to new track");
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 103, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == tracksBefore, "dependent batch undoes as one step");
+
+        // A failing member anywhere means nothing executes — including
+        // rolling back members that already ran.
+        r = call(service,
+                 "{\"id\": 94, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"add_track\", \"args\": {\"name\": \"Ghost\"}},"
+                 "{\"verb\": \"set_volume\", \"args\": {\"track\": 0, \"value\": 9.0}}"
+                 "]}}");
+        check(status(r) == "validation_error" &&
+                  r["message"].asString().find("commands[1]") != std::string::npos,
+              "invalid member -> validation_error naming the index");
+        r = call(service, "{\"id\": 95, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == tracksBefore,
+              "failed batch executed nothing (no Ghost track)");
+
+        // Contract: shape errors and non-mutation members are rejected.
+        r = call(service, "{\"id\": 96, \"verb\": \"batch\", \"args\": {\"commands\": []}}");
+        check(status(r) == "validation_error", "empty batch -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 97, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"list_tracks\"}]}}");
+        check(status(r) == "validation_error", "query verb inside batch -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 98, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"batch\", \"args\": {\"commands\": []}}]}}");
+        check(status(r) == "validation_error", "nested batch -> validation_error");
+
+        r = call(service, "{\"id\": 99, \"verb\": \"batch\"}");
+        check(status(r) == "validation_error", "batch without args -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 100, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"warp_reality\"}]}}");
+        check(status(r) == "parse_error" &&
+                  r["message"].asString().find("commands[0]") != std::string::npos,
+              "unknown verb inside batch -> parse_error naming the index");
+    }
+
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
               << std::endl;
     return g_failures == 0 ? 0 : 1;

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -1,0 +1,175 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// MuseService Tests — the structured JSON surface agents drive Aestra through.
+// Covers: request/response protocol, query verbs (eyes), mutation verbs
+// routed through CommandHistory (hands + undo), stable IDs, and malformed
+// input never crashing or corrupting the session.
+
+#include "Commands/CommandRegistry.h"
+#include "Commands/MuseService.h"
+#include "Models/TrackManager.h"
+
+#include "AestraJSON.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Aestra::Audio::CommandRegistry;
+using Aestra::Audio::MuseService;
+using Aestra::Audio::TrackManager;
+using Aestra::JSON;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << "\n";
+    } else {
+        std::cout << "FAIL: " << label << "\n";
+        ++g_failures;
+    }
+}
+
+JSON call(MuseService& service, const std::string& request) {
+    const std::string responseText = service.handleRequest(request);
+    return JSON::parse(responseText);
+}
+
+std::string status(JSON& response) {
+    return response.has("status") ? response["status"].asString() : "<missing>";
+}
+
+} // namespace
+
+int main() {
+    auto trackManager = std::make_shared<TrackManager>();
+    CommandRegistry::initialize(trackManager.get());
+    MuseService service(trackManager.get(), nullptr);
+
+    // --- Protocol: malformed input never crashes, always structured error ---
+    {
+        JSON r = call(service, "not json at all");
+        check(status(r) == "parse_error", "garbage input -> parse_error");
+
+        r = call(service, "[1,2,3]");
+        check(status(r) == "parse_error", "non-object request -> parse_error");
+
+        r = call(service, "{\"id\": 7}");
+        check(status(r) == "parse_error" && r["id"].asNumber() == 7.0,
+              "missing verb -> parse_error, id echoed");
+
+        r = call(service, "{\"id\": 8, \"verb\": \"warp_reality\"}");
+        check(status(r) == "parse_error" && r["message"].asString().find("unknown") != std::string::npos,
+              "unknown verb -> parse_error with message");
+
+        r = call(service, "{\"id\": \"abc\", \"verb\": \"list_tracks\"}");
+        check(status(r) == "parse_error", "non-numeric id -> parse_error, not silent 0");
+    }
+
+    // --- Eyes: queries on an empty session ---
+    {
+        JSON r = call(service, "{\"id\": 1, \"verb\": \"list_tracks\"}");
+        check(status(r) == "ok", "list_tracks ok on empty session");
+        check(r["result"]["tracks"].size() == 0, "empty session has zero tracks");
+
+        r = call(service, "{\"id\": 2, \"verb\": \"get_session_state\"}");
+        check(status(r) == "ok", "get_session_state ok");
+        check(r["result"]["transport"]["playing"].isBool(), "session state reports transport");
+    }
+
+    // --- Hands: build a session through mutations ---
+    {
+        JSON r = call(service, "{\"id\": 10, \"verb\": \"add_track\", \"args\": {\"name\": \"Drums\"}}");
+        check(status(r) == "ok", "add_track Drums ok");
+        r = call(service, "{\"id\": 11, \"verb\": \"add_track\", \"args\": {\"name\": \"Bass\"}}");
+        check(status(r) == "ok", "add_track Bass ok");
+
+        r = call(service, "{\"id\": 12, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == 2, "two tracks listed");
+        check(r["result"]["tracks"][0]["name"].asString() == "Drums", "track 0 named Drums");
+        check(r["result"]["tracks"][1]["name"].asString() == "Bass", "track 1 named Bass");
+        check(r["result"]["tracks"][0]["id"].isNumber() &&
+                  r["result"]["tracks"][0]["id"].asNumber() !=
+                      r["result"]["tracks"][1]["id"].asNumber(),
+              "tracks carry distinct stable ids");
+    }
+
+    // --- Typed args: numbers and bools cross the JSON->flag boundary ---
+    {
+        JSON r = call(service,
+                      "{\"id\": 20, \"verb\": \"set_volume\", \"args\": {\"track\": 0, \"value\": 0.5}}");
+        check(status(r) == "ok", "set_volume with numeric args ok");
+
+        r = call(service, "{\"id\": 21, \"verb\": \"list_tracks\"}");
+        const double vol = r["result"]["tracks"][0]["volume"].asNumber();
+        check(vol > 0.49 && vol < 0.51, "volume readback reflects mutation");
+
+        r = call(service,
+                 "{\"id\": 22, \"verb\": \"mute_track\", \"args\": {\"track\": 1, \"state\": true}}");
+        check(status(r) == "ok", "mute_track with bool arg ok");
+        r = call(service, "{\"id\": 23, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"][1]["muted"].asBool(), "mute readback reflects mutation");
+    }
+
+    // --- Validation: schema ranges still guard the JSON path ---
+    {
+        JSON r = call(service,
+                      "{\"id\": 30, \"verb\": \"set_volume\", \"args\": {\"track\": 0, \"value\": 4.0}}");
+        check(status(r) == "validation_error", "out-of-range volume -> validation_error");
+
+        r = call(service, "{\"id\": 31, \"verb\": \"set_volume\", \"args\": {\"track\": 0}}");
+        check(status(r) == "validation_error", "missing required flag -> validation_error");
+
+        r = call(service, "{\"id\": 32, \"verb\": \"list_tracks\"}");
+        const double vol = r["result"]["tracks"][0]["volume"].asNumber();
+        check(vol > 0.49 && vol < 0.51, "failed mutations leave state untouched");
+    }
+
+    // --- Contract honesty: nothing the protocol ignores returns ok ---
+    {
+        JSON r = call(service,
+                      "{\"id\": 35, \"verb\": \"set_volume\", "
+                      "\"args\": {\"track\": 0, \"value\": 0.5, \"wobble\": 9}}");
+        check(status(r) == "validation_error", "unknown mutation flag -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 36, \"verb\": \"add_track\", "
+                 "\"args\": {\"name\": \"X\", \"type\": \"sampler\"}}");
+        check(status(r) == "validation_error",
+              "add_track type (unconsumed by factory) -> validation_error");
+
+        r = call(service, "{\"id\": 37, \"verb\": \"list_tracks\", \"args\": {\"track\": 0}}");
+        check(status(r) == "validation_error", "arguments to a query -> validation_error");
+    }
+
+    // --- Stable IDs survive edits that shift indexes ---
+    {
+        JSON r = call(service, "{\"id\": 38, \"verb\": \"list_tracks\"}");
+        const double bassId = r["result"]["tracks"][1]["id"].asNumber();
+
+        r = call(service, "{\"id\": 39, \"verb\": \"delete_track\", \"args\": {\"track\": 0}}");
+        check(status(r) == "ok", "delete_track ok");
+
+        r = call(service, "{\"id\": 40, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == 1, "one track remains after delete");
+        check(r["result"]["tracks"][0]["id"].asNumber() == bassId,
+              "surviving track keeps its id after index shift");
+        check(r["result"]["tracks"][0]["name"].asString() == "Bass",
+              "surviving track is Bass");
+    }
+
+    // --- Revision loop: undo through the same history the UI uses ---
+    {
+        auto& history = trackManager->getCommandHistory();
+        check(history.canUndo(), "mutations were recorded as undoable history");
+        history.undo(); // restore the deleted Drums track
+        JSON r = call(service, "{\"id\": 41, \"verb\": \"list_tracks\"}");
+        check(r["result"]["tracks"].size() == 2, "undo restores the deleted track");
+    }
+
+    std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
+              << std::endl;
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -10,6 +10,10 @@
 
 #include "AestraJSON.h"
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -41,10 +45,47 @@ std::string status(JSON& response) {
     return response.has("status") ? response["status"].asString() : "<missing>";
 }
 
+// Minimal valid PCM16 mono WAV (8 frames of silence) for load_sample.
+std::string writeTestWav() {
+    const std::string path =
+        (std::filesystem::temp_directory_path() / "muse_service_test_sample.wav").string();
+    const uint32_t sampleRate = 48000;
+    const uint16_t channels = 1;
+    const uint16_t bitsPerSample = 16;
+    const uint32_t dataBytes = 8 * sizeof(int16_t);
+    const uint32_t byteRate = sampleRate * channels * bitsPerSample / 8;
+    const uint16_t blockAlign = channels * bitsPerSample / 8;
+
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return "";
+    auto u32 = [&](uint32_t v) { std::fwrite(&v, 4, 1, f); };
+    auto u16 = [&](uint16_t v) { std::fwrite(&v, 2, 1, f); };
+    std::fwrite("RIFF", 1, 4, f);
+    u32(36 + dataBytes);
+    std::fwrite("WAVE", 1, 4, f);
+    std::fwrite("fmt ", 1, 4, f);
+    u32(16);
+    u16(1); // PCM
+    u16(channels);
+    u32(sampleRate);
+    u32(byteRate);
+    u16(blockAlign);
+    u16(bitsPerSample);
+    std::fwrite("data", 1, 4, f);
+    u32(dataBytes);
+    const int16_t silence[8] = {};
+    std::fwrite(silence, sizeof(int16_t), 8, f);
+    std::fclose(f);
+    return path;
+}
+
 } // namespace
 
 int main() {
     auto trackManager = std::make_shared<TrackManager>();
+    // Mirror the app wiring (AestraContent): units need the pattern manager
+    // to auto-create their default MIDI pattern.
+    trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
     CommandRegistry::initialize(trackManager.get());
     MuseService service(trackManager.get(), nullptr);
 
@@ -167,6 +208,134 @@ int main() {
         history.undo(); // restore the deleted Drums track
         JSON r = call(service, "{\"id\": 41, \"verb\": \"list_tracks\"}");
         check(r["result"]["tracks"].size() == 2, "undo restores the deleted track");
+    }
+
+    // --- Beat path: units ---
+    double kickUnit = 0.0;
+    double kickPattern = 0.0;
+    {
+        JSON r = call(service,
+                      "{\"id\": 50, \"verb\": \"add_unit\", \"args\": {\"name\": \"Kick\"}}");
+        check(status(r) == "ok", "add_unit Kick ok");
+
+        r = call(service,
+                 "{\"id\": 51, \"verb\": \"add_unit\", "
+                 "\"args\": {\"name\": \"Sub\", \"type\": \"808\"}}");
+        check(status(r) == "ok", "add_unit 808 ok");
+
+        r = call(service,
+                 "{\"id\": 52, \"verb\": \"add_unit\", "
+                 "\"args\": {\"name\": \"X\", \"type\": \"theremin\"}}");
+        check(status(r) == "execution_error", "unknown unit type rejected");
+
+        r = call(service, "{\"id\": 53, \"verb\": \"list_units\"}");
+        check(status(r) == "ok", "list_units ok");
+        check(r["result"]["units"].size() == 2, "two units listed");
+        check(r["result"]["units"][0]["name"].asString() == "Kick", "unit 0 named Kick");
+        check(r["result"]["units"][1]["type"].asString() == "808", "unit 1 typed 808");
+        kickUnit = r["result"]["units"][0]["id"].asNumber();
+        kickPattern = r["result"]["units"][0]["defaultPatternId"].asNumber();
+        check(kickPattern > 0.0, "unit creation minted a default pattern");
+    }
+
+    // --- Beat path: sample loading ---
+    {
+        JSON r = call(service,
+                      "{\"id\": 55, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
+                          std::to_string(static_cast<long long>(kickUnit)) +
+                          ", \"file\": \"/nonexistent/kick.wav\"}}");
+        check(status(r) == "execution_error", "load_sample on missing file -> execution_error");
+
+        const std::string wavPath = writeTestWav();
+        check(!wavPath.empty(), "test wav written");
+        r = call(service, "{\"id\": 56, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
+                              std::to_string(static_cast<long long>(kickUnit)) +
+                              ", \"file\": \"" + wavPath + "\"}}");
+        check(status(r) == "ok", "load_sample ok");
+        r = call(service, "{\"id\": 57, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["samplePath"].asString() == wavPath,
+              "unit readback carries sample path");
+    }
+
+    // --- Beat path: notes in the unit's default pattern ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        JSON r = call(service, "{\"id\": 60, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                                   ", \"unit\": " + u +
+                                   ", \"pitch\": 36, \"start\": 0, \"duration\": 1}}");
+        check(status(r) == "ok", "add_note ok");
+
+        r = call(service, "{\"id\": 61, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 2.5, \"duration\": 0.5, "
+                              "\"velocity\": 0.6, \"pan\": -0.25}}");
+        check(status(r) == "ok", "add_note with expression ok");
+
+        r = call(service, "{\"id\": 62, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 200, \"start\": 0, \"duration\": 1}}");
+        check(status(r) == "validation_error", "out-of-range pitch -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 63, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(status(r) == "ok", "get_pattern ok");
+        check(r["result"]["notes"].size() == 2, "pattern readback lists both notes");
+        check(r["result"]["notes"][1]["velocity"].asNumber() > 0.59 &&
+                  r["result"]["notes"][1]["velocity"].asNumber() < 0.61,
+              "note expression round-trips");
+
+        // Revision loop: move the second hit, then soften it, then delete it.
+        r = call(service, "{\"id\": 64, \"verb\": \"move_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 2.5, \"to_start\": 3}}");
+        check(status(r) == "ok", "move_note ok");
+
+        r = call(service, "{\"id\": 65, \"verb\": \"set_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 36, \"start\": 3, \"velocity\": 0.3}}");
+        check(status(r) == "ok", "set_note ok");
+
+        r = call(service,
+                 "{\"id\": 66, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"][1]["start"].asNumber() == 3.0, "moved note reads back at 3");
+        check(r["result"]["notes"][1]["velocity"].asNumber() < 0.31,
+              "softened velocity reads back");
+        check(r["result"]["notes"][1]["pan"].asNumber() < -0.24,
+              "set_note leaves untouched expression alone");
+
+        r = call(service, "{\"id\": 67, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 36, \"start\": 3}}");
+        check(status(r) == "ok", "delete_note ok");
+
+        r = call(service, "{\"id\": 68, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 36, \"start\": 3}}");
+        check(status(r) == "execution_error", "deleting a missing note -> execution_error");
+
+        r = call(service,
+                 "{\"id\": 69, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 1, "one note remains after delete");
+
+        trackManager->getCommandHistory().undo(); // restore the deleted note
+        r = call(service,
+                 "{\"id\": 70, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2, "undo restores the deleted note");
+    }
+
+    // --- get_pattern arg contract ---
+    {
+        JSON r = call(service, "{\"id\": 75, \"verb\": \"get_pattern\"}");
+        check(status(r) == "validation_error", "get_pattern without args -> validation_error");
+
+        r = call(service,
+                 "{\"id\": 76, \"verb\": \"get_pattern\", \"args\": {\"pattern\": 999999}}");
+        check(status(r) == "execution_error", "get_pattern unknown id -> execution_error");
+
+        r = call(service,
+                 "{\"id\": 77, \"verb\": \"get_pattern\", "
+                 "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
+        check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -6,7 +6,9 @@
 
 #include "Commands/CommandRegistry.h"
 #include "Commands/MuseService.h"
+#include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
+#include "Plugin/PluginManager.h"
 
 #include "AestraJSON.h"
 
@@ -18,6 +20,7 @@
 #include <memory>
 #include <string>
 
+using Aestra::Audio::AudioEngine;
 using Aestra::Audio::CommandRegistry;
 using Aestra::Audio::MuseService;
 using Aestra::Audio::TrackManager;
@@ -45,14 +48,31 @@ std::string status(JSON& response) {
     return response.has("status") ? response["status"].asString() : "<missing>";
 }
 
-// Minimal valid PCM16 mono WAV (8 frames of silence) for load_sample.
+// Requests carrying filesystem paths must be serialized, not interpolated —
+// Windows paths contain backslashes that are invalid JSON escapes raw.
+std::string fileRequest(double id, const std::string& verb, const std::string& idKey,
+                        double idValue, const std::string& file, double tail = -1.0) {
+    JSON req = JSON::object();
+    req.set("id", JSON(id));
+    req.set("verb", JSON(verb));
+    JSON args = JSON::object();
+    args.set(idKey, JSON(idValue));
+    args.set("file", JSON(file));
+    if (tail >= 0.0) args.set("tail", JSON(tail));
+    req.set("args", args);
+    return req.toString();
+}
+
+// Minimal valid PCM16 mono WAV for load_sample: a loud 480-frame click so a
+// rendered pattern that triggers it is measurably non-silent.
 std::string writeTestWav() {
     const std::string path =
         (std::filesystem::temp_directory_path() / "muse_service_test_sample.wav").string();
     const uint32_t sampleRate = 48000;
     const uint16_t channels = 1;
     const uint16_t bitsPerSample = 16;
-    const uint32_t dataBytes = 8 * sizeof(int16_t);
+    const uint32_t numFrames = 480;
+    const uint32_t dataBytes = numFrames * sizeof(int16_t);
     const uint32_t byteRate = sampleRate * channels * bitsPerSample / 8;
     const uint16_t blockAlign = channels * bitsPerSample / 8;
 
@@ -73,8 +93,10 @@ std::string writeTestWav() {
     u16(bitsPerSample);
     std::fwrite("data", 1, 4, f);
     u32(dataBytes);
-    const int16_t silence[8] = {};
-    std::fwrite(silence, sizeof(int16_t), 8, f);
+    for (uint32_t i = 0; i < numFrames; ++i) {
+        const int16_t sample = (i % 2 == 0) ? 29000 : -29000;
+        std::fwrite(&sample, sizeof(int16_t), 1, f);
+    }
     std::fclose(f);
     return path;
 }
@@ -82,12 +104,32 @@ std::string writeTestWav() {
 } // namespace
 
 int main() {
+    // Built-ins (the sampler) register inside PluginManager::initialize();
+    // without it load_sample sets the path but never instantiates a plugin,
+    // and renders come back silent.
+    if (!Aestra::Audio::PluginManager::getInstance().initialize()) {
+        std::cout << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+
     auto trackManager = std::make_shared<TrackManager>();
     // Mirror the app wiring (AestraContent): units need the pattern manager
     // to auto-create their default MIDI pattern.
     trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
+
+    // Engine wired like MuseRepl so render_pattern can pump the live path.
+    AudioEngine engine;
+    engine.setSampleRate(48000);
+    engine.setBufferConfig(512, 2);
+    MuseService::wireHeadlessEngine(trackManager, engine);
+    if (!engine.initialize()) {
+        std::cout << "FAIL: engine initialize\n";
+        return 1;
+    }
+
     CommandRegistry::initialize(trackManager.get());
-    MuseService service(trackManager.get(), nullptr);
+    CommandRegistry::setAudioEngine(&engine);
+    MuseService service(trackManager.get(), &engine);
 
     // --- Protocol: malformed input never crashes, always structured error ---
     {
@@ -241,16 +283,12 @@ int main() {
     // --- Beat path: sample loading ---
     {
         JSON r = call(service,
-                      "{\"id\": 55, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
-                          std::to_string(static_cast<long long>(kickUnit)) +
-                          ", \"file\": \"/nonexistent/kick.wav\"}}");
+                      fileRequest(55, "load_sample", "unit", kickUnit, "/nonexistent/kick.wav"));
         check(status(r) == "execution_error", "load_sample on missing file -> execution_error");
 
         const std::string wavPath = writeTestWav();
         check(!wavPath.empty(), "test wav written");
-        r = call(service, "{\"id\": 56, \"verb\": \"load_sample\", \"args\": {\"unit\": " +
-                              std::to_string(static_cast<long long>(kickUnit)) +
-                              ", \"file\": \"" + wavPath + "\"}}");
+        r = call(service, fileRequest(56, "load_sample", "unit", kickUnit, wavPath));
         check(status(r) == "ok", "load_sample ok");
         r = call(service, "{\"id\": 57, \"verb\": \"list_units\"}");
         check(r["result"]["units"][0]["samplePath"].asString() == wavPath,
@@ -336,6 +374,82 @@ int main() {
                  "{\"id\": 77, \"verb\": \"get_pattern\", "
                  "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
         check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
+    }
+
+    // --- Render: the beat comes back as a file with signal in it ---
+    {
+        const std::string outPath =
+            (std::filesystem::temp_directory_path() / "muse_service_test_render.wav").string();
+        std::filesystem::remove(outPath);
+
+        JSON r = call(service, "{\"id\": 80, \"verb\": \"render_pattern\"}");
+        check(status(r) == "validation_error", "render_pattern without args -> validation_error");
+
+        r = call(service, fileRequest(81, "render_pattern", "pattern", 999999.0, outPath));
+        check(status(r) == "execution_error", "render_pattern unknown pattern -> execution_error");
+
+        r = call(service, "{\"id\": 84, \"verb\": \"render_pattern\", "
+                          "\"args\": {\"pattern\": -3, \"file\": \"x.wav\"}}");
+        check(status(r) == "validation_error", "negative pattern id -> validation_error");
+
+        r = call(service, fileRequest(82, "render_pattern", "pattern", kickPattern, outPath, 0.25));
+        check(status(r) == "ok", "render_pattern ok");
+        const double frames = r["result"]["frames"].asNumber();
+        check(frames > 0.0, "render reports frames");
+        // The pattern triggers the loud test click through the sampler; a
+        // silent render means the pattern->unit->engine path is broken.
+        check(r["result"]["peakDb"].asNumber() > -90.0,
+              "rendered audio is not silent (peakDb " +
+                  std::to_string(r["result"]["peakDb"].asNumber()) + ")");
+        check(!engine.isTransportPlaying(), "engine transport stopped after render");
+
+        // The file must honor the advertised contract: IEEE-float stereo at
+        // the engine rate, with chunk sizes agreeing with reported frames.
+        {
+            std::ifstream wav(outPath, std::ios::binary);
+            check(wav.good(), "rendered wav exists");
+            char riff[4] = {}, wave[4] = {};
+            uint32_t riffSize = 0, fmtSize = 0, byteRate = 0, dataSize = 0, sampleRate = 0;
+            uint16_t format = 0, channels = 0, blockAlign = 0, bits = 0;
+            char tag[4] = {};
+            wav.read(riff, 4);
+            wav.read(reinterpret_cast<char*>(&riffSize), 4);
+            wav.read(wave, 4);
+            wav.read(tag, 4); // "fmt "
+            wav.read(reinterpret_cast<char*>(&fmtSize), 4);
+            wav.read(reinterpret_cast<char*>(&format), 2);
+            wav.read(reinterpret_cast<char*>(&channels), 2);
+            wav.read(reinterpret_cast<char*>(&sampleRate), 4);
+            wav.read(reinterpret_cast<char*>(&byteRate), 4);
+            wav.read(reinterpret_cast<char*>(&blockAlign), 2);
+            wav.read(reinterpret_cast<char*>(&bits), 2);
+            wav.read(tag, 4); // "data"
+            wav.read(reinterpret_cast<char*>(&dataSize), 4);
+            check(std::memcmp(riff, "RIFF", 4) == 0 && std::memcmp(wave, "WAVE", 4) == 0,
+                  "wav container tags");
+            check(format == 3 && channels == 2 && bits == 32,
+                  "wav is IEEE-float stereo 32-bit");
+            check(sampleRate == 48000, "wav sample rate matches engine");
+            check(dataSize == static_cast<uint32_t>(frames) * 8u,
+                  "wav data size agrees with reported frames");
+            check(std::filesystem::file_size(outPath) == 44u + dataSize,
+                  "file size agrees with header");
+            const double reported = r["result"]["durationSeconds"].asNumber();
+            check(std::abs(frames / 48000.0 - reported) < 0.001,
+                  "durationSeconds agrees with frames");
+        }
+
+        JSON bad = JSON::object();
+        bad.set("id", JSON(83.0));
+        bad.set("verb", JSON("render_pattern"));
+        JSON badArgs = JSON::object();
+        badArgs.set("pattern", JSON(kickPattern));
+        badArgs.set("file", JSON(outPath));
+        badArgs.set("wobble", JSON(1.0));
+        bad.set("args", badArgs);
+        r = call(service, bad.toString());
+        check(status(r) == "validation_error", "render_pattern unknown arg -> validation_error");
+        std::filesystem::remove(outPath);
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
@@ -376,6 +377,161 @@ int main() {
                  "{\"id\": 77, \"verb\": \"get_pattern\", "
                  "\"args\": {\"pattern\": 1, \"wobble\": 2}}");
         check(status(r) == "validation_error", "get_pattern unknown arg -> validation_error");
+    }
+
+    // --- Musical verbs: whole grooves in one gesture ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        JSON r = call(service,
+                      "{\"id\": 140, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                          ", \"unit\": " + u +
+                          ", \"pitch\": 40, \"steps\": \"x---X---x---X-x-\"}}");
+        check(status(r) == "ok", "set_steps writes a 16-step row");
+
+        r = call(service,
+                 "{\"id\": 141, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        size_t rowNotes = 0;
+        double accentVelocity = 0.0;
+        double plainVelocity = 0.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            JSON note = r["result"]["notes"][i];
+            if (note["pitch"].asNumber() == 40.0) {
+                ++rowNotes;
+                if (note["start"].asNumber() == 1.0) accentVelocity = note["velocity"].asNumber();
+                if (note["start"].asNumber() == 0.0) plainVelocity = note["velocity"].asNumber();
+            }
+        }
+        check(rowNotes == 5, "step string with 5 hits lands 5 notes");
+        check(accentVelocity > plainVelocity, "accented step is louder than plain step");
+
+        // Rewriting the row replaces it — the revision gesture.
+        r = call(service, "{\"id\": 142, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x-------\"}}");
+        check(status(r) == "ok", "rewriting the row ok");
+        r = call(service,
+                 "{\"id\": 143, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        rowNotes = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 40.0) ++rowNotes;
+        }
+        check(rowNotes == 1, "rewritten row replaced the old one");
+
+        // Undo restores the previous groove, not an empty row.
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 144, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        rowNotes = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 40.0) ++rowNotes;
+        }
+        check(rowNotes == 5, "undoing the rewrite restores the previous row");
+
+        // Garbage in the step string is an error, not a silent rest.
+        r = call(service, "{\"id\": 145, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x--q\"}}");
+        check(status(r) == "execution_error", "invalid step character rejected");
+
+        // Quantize: drag an off-grid note onto the grid.
+        r = call(service, "{\"id\": 146, \"verb\": \"add_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 41, \"start\": 1.13, \"duration\": 0.5}}");
+        check(status(r) == "ok", "off-grid note added");
+        r = call(service, "{\"id\": 147, \"verb\": \"quantize_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"grid\": 0.25}}");
+        check(status(r) == "ok", "quantize_pattern ok");
+        r = call(service,
+                 "{\"id\": 148, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        double quantizedStart = -1.0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 41.0) {
+                quantizedStart = r["result"]["notes"][i]["start"].asNumber();
+            }
+        }
+        check(std::abs(quantizedStart - 1.25) < 1e-9, "off-grid note snapped to 1.25");
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 149, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 41.0) {
+                quantizedStart = r["result"]["notes"][i]["start"].asNumber();
+            }
+        }
+        // 1.13 crossed the JSON->flag->float boundary, so compare at float
+        // precision.
+        check(std::abs(quantizedStart - 1.13) < 1e-6, "undo restores the exact off-grid start");
+
+        // Transpose: shift the whole pattern up an octave and back.
+        r = call(service,
+                 "{\"id\": 150, \"verb\": \"transpose_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"semitones\": 12}}");
+        check(status(r) == "ok", "transpose up an octave ok");
+        r = call(service,
+                 "{\"id\": 151, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool sawShifted = false;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            if (r["result"]["notes"][i]["pitch"].asNumber() == 52.0) sawShifted = true;
+        }
+        check(sawShifted, "row pitch 40 reads back at 52 after transpose");
+        trackManager->getCommandHistory().undo();
+
+        // Undo must land every note back on its original pitch.
+        r = call(service,
+                 "{\"id\": 156, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        size_t at40 = 0, at52 = 0;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            const double pitch = r["result"]["notes"][i]["pitch"].asNumber();
+            if (pitch == 40.0) ++at40;
+            if (pitch == 52.0) ++at52;
+        }
+        check(at40 == 5 && at52 == 0, "undo returns all row notes to pitch 40");
+
+        // Out-of-range transpose is rejected, state untouched.
+        r = call(service,
+                 "{\"id\": 152, \"verb\": \"transpose_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"semitones\": -48}}");
+        check(status(r) == "execution_error", "transpose past MIDI range rejected");
+        r = call(service,
+                 "{\"id\": 157, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        bool pitchesIntact = true;
+        for (size_t i = 0; i < r["result"]["notes"].size(); ++i) {
+            const double pitch = r["result"]["notes"][i]["pitch"].asNumber();
+            if (pitch != 36.0 && pitch != 40.0 && pitch != 41.0) pitchesIntact = false;
+        }
+        check(pitchesIntact, "rejected transpose left no partially shifted pitches");
+
+        // Cleanup: drop the scratch notes so later sections see the original
+        // two-note pattern.
+        r = call(service, "{\"id\": 153, \"verb\": \"delete_note\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 41, \"start\": 1.13}}");
+        check(status(r) == "ok", "scratch quantize note removed");
+        r = call(service, "{\"id\": 154, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u +
+                              ", \"pitch\": 40, \"steps\": \"----------------\"}}");
+        check(status(r) == "ok", "row cleared with an all-rest step string");
+        r = call(service,
+                 "{\"id\": 155, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2, "pattern back to its two original notes");
+
+        // Batch composition: a whole groove in one gesture, one undo step.
+        r = call(service,
+                 "{\"id\": 158, \"verb\": \"batch\", \"args\": {\"commands\": ["
+                 "{\"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                     ", \"unit\": " + u + ", \"pitch\": 45, \"steps\": \"x---x---\"}},"
+                 "{\"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                     ", \"unit\": " + u + ", \"pitch\": 47, \"steps\": \"--x---x-\"}},"
+                 "{\"verb\": \"quantize_pattern\", \"args\": {\"pattern\": " + p +
+                     ", \"grid\": 0.25}}]}}");
+        check(status(r) == "ok", "batch of musical verbs ok");
+        r = call(service,
+                 "{\"id\": 159, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 6, "batch groove landed both rows");
+        trackManager->getCommandHistory().undo();
+        r = call(service,
+                 "{\"id\": 160, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " + p + "}}");
+        check(r["result"]["notes"].size() == 2,
+              "single undo reverts the whole musical batch");
     }
 
     // --- Render: the beat comes back as a file with signal in it ---

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -534,6 +534,92 @@ int main() {
               "single undo reverts the whole musical batch");
     }
 
+    // --- Agent UX: refusals carry reasons, schema carries semantics ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string u = std::to_string(static_cast<long long>(kickUnit));
+
+        // Factory refusals name the object and the rule, not just the verb.
+        JSON r = call(service,
+                      "{\"id\": 170, \"verb\": \"set_steps\", \"args\": {\"pattern\": 999999, "
+                      "\"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x---\"}}");
+        check(status(r) == "execution_error" &&
+                  r["message"].asString().find("no such MIDI pattern: 999999") != std::string::npos,
+              "unknown pattern refusal names the pattern");
+
+        r = call(service, "{\"id\": 171, \"verb\": \"set_steps\", \"args\": {\"pattern\": " + p +
+                              ", \"unit\": " + u + ", \"pitch\": 40, \"steps\": \"x--q\"}}");
+        check(r["message"].asString().find("invalid step character 'q'") != std::string::npos,
+              "bad step char refusal names the character");
+
+        r = call(service,
+                 "{\"id\": 172, \"verb\": \"set_volume\", \"args\": {\"track\": 97, \"value\": 0.5}}");
+        check(r["message"].asString().find("no such track: 97") != std::string::npos,
+              "unknown track refusal names the index");
+
+        r = call(service,
+                 "{\"id\": 173, \"verb\": \"add_unit\", \"args\": {\"name\": \"X\", \"type\": "
+                 "\"theremin\"}}");
+        check(r["message"].asString().find("unknown unit type: theremin") != std::string::npos,
+              "unknown unit type refusal names the type");
+
+        // The schema manifest documents queries, actions, and semantics.
+        const std::string schema = Aestra::Audio::MuseGrammar::schemaToJsonString();
+        JSON manifest = JSON::parse(schema);
+        check(manifest.has("commands") && manifest.has("queries") && manifest.has("actions") &&
+                  manifest.has("notes"),
+              "schema manifest has commands, queries, actions, notes");
+        check(manifest["notes"]["samplerPitch"].asString().find("60") != std::string::npos,
+              "schema notes document the sampler root");
+        check(manifest["commands"][0].has("description"),
+              "mutation entries carry descriptions");
+    }
+
+    // --- Pattern lifecycle: clone and length ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+
+        JSON r = call(service,
+                      "{\"id\": 180, \"verb\": \"clone_pattern\", \"args\": {\"pattern\": " + p +
+                          "}}");
+        check(status(r) == "ok", "clone_pattern ok");
+        check(r["message"].asString().find("cloned pattern -> ") != std::string::npos,
+              "clone message is human-readable");
+        check(r.has("result") && r["result"]["createdId"].isNumber(),
+              "clone response carries the new id as structured data");
+        const uint64_t clonedId = static_cast<uint64_t>(r["result"]["createdId"].asNumber());
+
+        r = call(service, "{\"id\": 181, \"verb\": \"list_patterns\"}");
+        check(status(r) == "ok", "list_patterns ok");
+        bool sawClone = false;
+        size_t patternCount = r["result"]["patterns"].size();
+        double sourceNotes = -1.0, cloneNotes = -2.0;
+        for (size_t i = 0; i < patternCount; ++i) {
+            JSON entry = r["result"]["patterns"][i];
+            if (entry["id"].asNumber() == static_cast<double>(clonedId)) {
+                sawClone = true;
+                cloneNotes = entry["noteCount"].asNumber();
+            }
+            if (entry["id"].asNumber() == kickPattern) sourceNotes = entry["noteCount"].asNumber();
+        }
+        check(sawClone, "clone appears in list_patterns");
+        check(cloneNotes == sourceNotes, "clone carries the source notes");
+
+        r = call(service, "{\"id\": 182, \"verb\": \"set_pattern_length\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + ", \"beats\": 16}}");
+        check(status(r) == "ok", "set_pattern_length ok");
+        r = call(service, "{\"id\": 183, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + "}}");
+        check(r["result"]["lengthBeats"].asNumber() == 16.0, "length readback is 16 beats");
+
+        // Undo unwinds length then the clone itself.
+        trackManager->getCommandHistory().undo();
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 184, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " +
+                              std::to_string(clonedId) + "}}");
+        check(status(r) == "execution_error", "undo removes the cloned pattern");
+    }
+
     // --- Render: the beat comes back as a file with signal in it ---
     {
         const std::string outPath =

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -120,7 +120,9 @@ int main() {
     // Engine wired like MuseRepl so render_pattern can pump the live path.
     AudioEngine engine;
     engine.setSampleRate(48000);
-    engine.setBufferConfig(512, 2);
+    // Must cover AudioExporter's 4096-frame render blocks: processBlock does
+    // not split blocks larger than the configured maximum, it overruns.
+    engine.setBufferConfig(4096, 2);
     MuseService::wireHeadlessEngine(trackManager, engine);
     if (!engine.initialize()) {
         std::cout << "FAIL: engine initialize\n";
@@ -535,6 +537,138 @@ int main() {
         check(status(r) == "parse_error" &&
                   r["message"].asString().find("commands[0]") != std::string::npos,
               "unknown verb inside batch -> parse_error naming the index");
+    }
+
+    // --- Arrange: pattern onto the timeline as a clip ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+
+        // Earlier sections leave track 0 muted (the typed-args mute survived
+        // the delete/undo reorder); the arranged pattern routes here, so an
+        // accidentally muted target would make the song render silent for
+        // reasons unrelated to the arrange path.
+        JSON unmute = call(service,
+                           "{\"id\": 109, \"verb\": \"mute_track\", "
+                           "\"args\": {\"track\": 0, \"state\": false}}");
+        check(status(unmute) == "ok", "unmute render target track");
+
+        JSON r = call(service, "{\"id\": 110, \"verb\": \"list_clips\"}");
+        const size_t lanesBefore = r["result"]["lanes"].size();
+
+        r = call(service, "{\"id\": 111, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 0}}");
+        check(status(r) == "ok", "arrange_pattern ok");
+
+        r = call(service, "{\"id\": 112, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"].size() > lanesBefore, "arrange created the missing lane");
+        check(r["result"]["lanes"][0]["clips"].size() == 1, "lane carries one clip");
+        check(r["result"]["lanes"][0]["clips"][0]["pattern"].asNumber() == kickPattern,
+              "clip is bound to the pattern");
+        check(r["result"]["lanes"][0]["clips"][0]["durationBeats"].asNumber() > 0.0,
+              "clip sized from pattern length");
+
+        r = call(service, "{\"id\": 113, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["timelineLane"].asNumber() == 0.0,
+              "pattern's unit routed to timeline lane 0");
+
+        r = call(service, "{\"id\": 114, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 8}}");
+        check(status(r) == "ok", "second arrange at beat 8 ok");
+        r = call(service, "{\"id\": 115, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"][0]["clips"].size() == 2, "two clips on the lane");
+        check(r["result"]["lanes"][0]["clips"][1]["startBeat"].asNumber() == 8.0,
+              "second clip starts at the requested beat");
+
+        // Conflict: the pattern's unit is routed to lane 0; arranging it on
+        // another track would silently reroute the clips already placed.
+        r = call(service, "{\"id\": 130, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 1, \"start\": 0}}");
+        check(status(r) == "execution_error",
+              "arrange onto a conflicting track -> execution_error");
+
+        // Undo unwinds the whole gesture: clip, unit routing, created lane.
+        trackManager->getCommandHistory().undo();
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 116, \"verb\": \"list_clips\"}");
+        check(r["result"]["lanes"].size() == lanesBefore, "undo removes the created lane");
+        r = call(service, "{\"id\": 117, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["timelineLane"].asNumber() == -1.0,
+              "undo restores the unit's preview routing");
+
+        // Contract: bad targets never build.
+        r = call(service,
+                 "{\"id\": 118, \"verb\": \"arrange_pattern\", "
+                 "\"args\": {\"pattern\": 999999, \"track\": 0, \"start\": 0}}");
+        check(status(r) == "execution_error", "arrange unknown pattern -> execution_error");
+        r = call(service, "{\"id\": 119, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 99, \"start\": 0}}");
+        check(status(r) == "execution_error", "arrange onto missing channel -> execution_error");
+    }
+
+    // --- Render the arrangement: the song comes back as audio ---
+    {
+        const std::string p = std::to_string(static_cast<long long>(kickPattern));
+        const std::string outPath =
+            (std::filesystem::temp_directory_path() / "muse_service_test_song.wav").string();
+        std::filesystem::remove(outPath);
+
+        JSON r = call(service, "{\"id\": 120, \"verb\": \"render_song\"}");
+        check(status(r) == "validation_error", "render_song without args -> validation_error");
+
+        r = call(service, fileRequest(121, "render_song", "pattern", 1.0, outPath));
+        check(status(r) == "validation_error", "render_song unknown arg -> validation_error");
+
+        // The arrange section undid its clips: the timeline is empty here.
+        JSON emptyReq = JSON::object();
+        emptyReq.set("id", JSON(124.0));
+        emptyReq.set("verb", JSON("render_song"));
+        JSON emptyArgs = JSON::object();
+        emptyArgs.set("file", JSON(outPath));
+        emptyReq.set("args", emptyArgs);
+        r = call(service, emptyReq.toString());
+        check(status(r) == "execution_error", "empty timeline -> execution_error");
+        check(!std::filesystem::exists(outPath), "empty timeline writes no file");
+
+        r = call(service, "{\"id\": 122, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 0}}");
+        check(status(r) == "ok", "re-arrange for render ok");
+        r = call(service, "{\"id\": 125, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
+                              p + ", \"track\": 0, \"start\": 8}}");
+        check(status(r) == "ok", "late clip at beat 8 for render ok");
+
+        // Unwritable destination must fail loudly, not report a phantom file.
+        JSON badDest = JSON::object();
+        badDest.set("id", JSON(126.0));
+        badDest.set("verb", JSON("render_song"));
+        JSON badDestArgs = JSON::object();
+        badDestArgs.set("file", JSON("/nonexistent_muse_dir/song.wav"));
+        badDest.set("args", badDestArgs);
+        r = call(service, badDest.toString());
+        check(status(r) == "execution_error", "unwritable destination -> execution_error");
+
+        JSON req = JSON::object();
+        req.set("id", JSON(123.0));
+        req.set("verb", JSON("render_song"));
+        JSON reqArgs = JSON::object();
+        reqArgs.set("file", JSON(outPath));
+        reqArgs.set("tail", JSON(0.25));
+        req.set("args", reqArgs);
+        r = call(service, req.toString());
+        check(status(r) == "ok", "render_song ok");
+        check(r["result"]["frames"].asNumber() > 0.0, "song render reports frames");
+        // Two 8-beat clips at 0 and 8 = 16 beats; at 120 BPM that's 8 s. A
+        // render that ignored the late clip would come back shorter.
+        check(r["result"]["durationSeconds"].asNumber() >= 8.0,
+              "render duration reaches the late clip");
+        check(std::filesystem::exists(outPath) && std::filesystem::file_size(outPath) > 44,
+              "song wav exists with data");
+        // The timeline clip triggers the loud test click through the routed
+        // unit; silence means the clip->schedule->unit->track path is broken.
+        check(r["result"]["peakDb"].asNumber() > -90.0,
+              "song render is not silent (peakDb " +
+                  std::to_string(r["result"]["peakDb"].asNumber()) + ")");
+        check(!engine.isTransportPlaying(), "engine transport stopped after song render");
+        std::filesystem::remove(outPath);
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -620,6 +620,95 @@ int main() {
         check(status(r) == "execution_error", "undo removes the cloned pattern");
     }
 
+    // --- Effects: the mixing loop (discover, insert, tweak, read back) ---
+    {
+        JSON r = call(service, "{\"id\": 190, \"verb\": \"list_plugins\"}");
+        check(status(r) == "ok", "list_plugins ok");
+        check(r["result"]["effects"].size() > 0, "effects are discoverable");
+        bool sawEq = false;
+        std::string eqName;
+        for (size_t i = 0; i < r["result"]["effects"].size(); ++i) {
+            if (r["result"]["effects"][i]["id"].asString() == "com.Aestrastudios.eq") {
+                sawEq = true;
+                eqName = r["result"]["effects"][i]["name"].asString();
+            }
+        }
+        check(sawEq, "built-in EQ listed");
+
+        // Insert by id; the response carries the slot as structured data.
+        r = call(service,
+                 "{\"id\": 191, \"verb\": \"add_effect\", "
+                 "\"args\": {\"track\": 0, \"effect\": \"com.Aestrastudios.eq\"}}");
+        check(status(r) == "ok", "add_effect by id ok");
+        check(r.has("result") && r["result"]["createdId"].isNumber(),
+              "add_effect returns the slot as structured data");
+        const int slot = static_cast<int>(r["result"]["createdId"].asNumber());
+
+        // Read the chain, pick a writable parameter, set it by name.
+        r = call(service, "{\"id\": 192, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(status(r) == "ok", "get_effects ok");
+        check(r["result"]["effects"].size() == 1, "chain shows one effect");
+        JSON effect = r["result"]["effects"][0];
+        check(effect["name"].asString() == eqName, "chain entry matches list_plugins name");
+        check(effect["params"].size() > 0, "effect exposes parameters");
+        const std::string paramName = effect["params"][0]["name"].asString();
+        const double originalValue = effect["params"][0]["value"].asNumber();
+
+        r = call(service, "{\"id\": 193, \"verb\": \"set_effect_param\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + ", \"param\": \"" + paramName +
+                          "\", \"value\": 0.8}}");
+        check(status(r) == "ok", "set_effect_param by name ok");
+        r = call(service, "{\"id\": 194, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        const double paramValue = r["result"]["effects"][0]["params"][0]["value"].asNumber();
+        check(paramValue > 0.79 && paramValue < 0.81, "parameter readback reflects the set");
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 195, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(std::abs(r["result"]["effects"][0]["params"][0]["value"].asNumber() -
+                       originalValue) < 1e-6,
+              "param undo restores the original value");
+        trackManager->getCommandHistory().redo();
+
+        // Bypass round-trip.
+        r = call(service, "{\"id\": 196, \"verb\": \"bypass_effect\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + ", \"state\": true}}");
+        check(status(r) == "ok", "bypass_effect ok");
+        r = call(service, "{\"id\": 197, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"][0]["bypassed"].asBool(), "bypass readback true");
+
+        // Refusals carry reasons.
+        r = call(service,
+                 "{\"id\": 198, \"verb\": \"add_effect\", "
+                 "\"args\": {\"track\": 0, \"effect\": \"MegaVerb 9000\"}}");
+        check(status(r) == "execution_error" &&
+                  r["message"].asString().find("unknown effect: MegaVerb 9000") !=
+                      std::string::npos,
+              "unknown effect refusal names it");
+        r = call(service, "{\"id\": 199, \"verb\": \"set_effect_param\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) +
+                          ", \"param\": \"wobble\", \"value\": 0.5}}");
+        check(r["message"].asString().find("no parameter 'wobble'") != std::string::npos,
+              "unknown param refusal names it");
+        r = call(service,
+                 "{\"id\": 200, \"verb\": \"remove_effect\", \"args\": {\"track\": 0, \"slot\": 7}}");
+        check(r["message"].asString().find("no effect in slot 7") != std::string::npos,
+              "empty slot refusal names it");
+
+        // Remove and verify the chain is empty again.
+        r = call(service, "{\"id\": 201, \"verb\": \"remove_effect\", \"args\": {\"track\": 0, "
+                          "\"slot\": " + std::to_string(slot) + "}}");
+        check(status(r) == "ok", "remove_effect ok");
+        r = call(service, "{\"id\": 202, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 0, "chain empty after remove");
+        trackManager->getCommandHistory().undo();
+        r = call(service, "{\"id\": 203, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 1, "undo restores the removed effect");
+        trackManager->getCommandHistory().undo(); // bypass
+        trackManager->getCommandHistory().undo(); // param
+        trackManager->getCommandHistory().undo(); // add_effect
+        r = call(service, "{\"id\": 204, \"verb\": \"get_effects\", \"args\": {\"track\": 0}}");
+        check(r["result"]["effects"].size() == 0, "full undo chain leaves a clean track");
+    }
+
     // --- Render: the beat comes back as a file with signal in it ---
     {
         const std::string outPath =

--- a/Tests/Integration/ProjectIdentityStabilityTest.cpp
+++ b/Tests/Integration/ProjectIdentityStabilityTest.cpp
@@ -1,0 +1,285 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// ProjectIdentityStabilityTest (#446) — serialized identities must survive
+// load, and save→load→save must be a byte-identical fixed point.
+//
+// Before this fix the loader re-minted clip UUIDs, pattern IDs, lane IDs and
+// source IDs on every load (remapping references so semantics survived but
+// identity didn't), and the writer emitted patterns/sources in unordered_map
+// order. Consequences: no whole-file fixed-point regression gate, and no
+// stable identity for Takes across sessions, diffing, or external references.
+//
+// Asserted here:
+//   - clip / pattern / lane / source IDs are identical after a load cycle
+//   - save→load→save produces byte-identical project contents (fixed point),
+//     and stays identical over a further generation (idempotence)
+//   - IDs minted AFTER a load never collide with restored IDs
+//   - AestraUUID::tryParse round-trips toString() and rejects garbage
+//     (invalid/absent ids keep minting, so legacy files still load)
+//   - duplicate clip ids in a hand-edited file are re-minted, not aliased
+//   - UINT64_MAX pattern/source ids are re-minted (restoring would wrap the
+//     mint counter to zero and poison every later mint)
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
+#include "Models/ClipSource.h"
+#include "Models/PatternSource.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Minimal PCM 16-bit mono WAV writer (enough to satisfy SourceManager loading).
+bool writeMinimalWavMono16(const std::filesystem::path& path, int sampleRate, int numSamples) {
+    if (sampleRate <= 0 || numSamples <= 0)
+        return false;
+    const int numChannels = 1;
+    const int bitsPerSample = 16;
+    const int bytesPerSample = bitsPerSample / 8;
+    const int blockAlign = numChannels * bytesPerSample;
+    const int byteRate = sampleRate * blockAlign;
+    const std::uint32_t dataSize = static_cast<std::uint32_t>(numSamples * blockAlign);
+
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out)
+        return false;
+    auto writeU32 = [&](std::uint32_t v) { out.write(reinterpret_cast<const char*>(&v), 4); };
+    auto writeU16 = [&](std::uint16_t v) { out.write(reinterpret_cast<const char*>(&v), 2); };
+    out.write("RIFF", 4);
+    writeU32(36u + dataSize);
+    out.write("WAVE", 4);
+    out.write("fmt ", 4);
+    writeU32(16u);
+    writeU16(1u); // PCM
+    writeU16(static_cast<std::uint16_t>(numChannels));
+    writeU32(static_cast<std::uint32_t>(sampleRate));
+    writeU32(static_cast<std::uint32_t>(byteRate));
+    writeU16(static_cast<std::uint16_t>(blockAlign));
+    writeU16(static_cast<std::uint16_t>(bitsPerSample));
+    out.write("data", 4);
+    writeU32(dataSize);
+    std::vector<char> silence(dataSize, 0);
+    out.write(silence.data(), static_cast<std::streamsize>(silence.size()));
+    return static_cast<bool>(out);
+}
+
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+std::vector<std::string> collectClipIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<std::string> ids;
+    auto& playlist = tm.getPlaylistModel();
+    for (const auto& laneId : playlist.getLaneIDs()) {
+        if (const auto* lane = playlist.getLane(laneId)) {
+            for (const auto& clip : lane->clips) {
+                ids.push_back(clip.id.toString());
+            }
+        }
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<std::string> collectLaneIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<std::string> ids;
+    for (const auto& laneId : tm.getPlaylistModel().getLaneIDs()) {
+        ids.push_back(laneId.toString());
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<uint64_t> collectPatternIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<uint64_t> ids;
+    for (const auto& p : tm.getPatternManager().getAllPatterns()) {
+        ids.push_back(p->id.value);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+std::vector<uint64_t> collectSourceIds(Aestra::Audio::TrackManager& tm) {
+    std::vector<uint64_t> ids;
+    for (const auto& id : tm.getSourceManager().getAllSourceIDs()) {
+        ids.push_back(id.value);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"ProjectIdentityStability"};
+    const auto& tempDir = tempDirScope.path();
+    const auto wavPath = tempDir / "identity.wav";
+    const auto projectPath = tempDir / "identity.aes";
+    require(writeMinimalWavMono16(wavPath, 48000, 4800), "could not write test WAV");
+
+    constexpr double kTempo = 120.0;
+    constexpr double kPlayhead = 0.0;
+
+    // ---------------- AestraUUID parsing contract
+    {
+        const AestraUUID original = AestraUUID::generate();
+        AestraUUID parsed;
+        require(AestraUUID::tryParse(original.toString(), parsed), "tryParse must accept toString output");
+        require(parsed == original, "tryParse(toString()) must round-trip exactly");
+        require(!AestraUUID::tryParse("", parsed), "empty string must not parse");
+        require(!AestraUUID::tryParse("not-a-uuid", parsed), "garbage must not parse");
+        require(!AestraUUID::tryParse(std::string(31, 'a'), parsed), "short string must not parse");
+        require(!AestraUUID::tryParse(std::string(31, 'a') + "g", parsed), "non-hex chars must not parse");
+        require(!ClipInstanceID::fromString("").isValid(), "legacy empty clip id must stay invalid (mint on add)");
+    }
+
+    // ---------------- Arrange: lanes, MIDI + audio patterns, clips
+    auto tm1 = std::make_shared<TrackManager>();
+    tm1->getPlaylistModel().setPatternManager(&tm1->getPatternManager());
+    auto& playlist1 = tm1->getPlaylistModel();
+    playlist1.setBPM(kTempo);
+
+    PlaylistLaneID laneAId = playlist1.createLane("Identity A");
+    auto* chanA = tm1->addChannel("Identity A");
+    PlaylistLaneID laneBId = playlist1.createLane("Identity B");
+    auto* chanB = tm1->addChannel("Identity B");
+    require(laneAId.isValid() && laneBId.isValid() && chanA && chanB, "setup: lanes/channels");
+
+    MidiPayload midi;
+    MidiNote note;
+    note.pitch = 64;
+    note.startBeat = 1.5;
+    note.durationBeats = 0.5;
+    note.velocity = 0.8f;
+    midi.notes.push_back(note);
+    PatternID midiPatId = tm1->getPatternManager().createMidiPattern("IdentityMelody", 8.0, midi);
+
+    ClipSourceID srcId = tm1->getSourceManager().getOrCreateSource(wavPath.string());
+    AudioSlicePayload slicePayload;
+    slicePayload.audioSourceId = srcId;
+    PatternID audioPatId = tm1->getPatternManager().createAudioPattern("IdentityAudio", 4.0, slicePayload);
+    require(midiPatId.isValid() && srcId.isValid() && audioPatId.isValid(), "setup: patterns/source");
+
+    ClipInstanceID midiClipId = playlist1.addClipFromPattern(laneAId, midiPatId, 0.0, 8.0);
+    ClipInstanceID audioClipId = playlist1.addClipFromPattern(laneBId, audioPatId, 4.0, 4.0);
+    require(midiClipId.isValid() && audioClipId.isValid(), "setup: clips");
+
+    const auto clipIds1 = collectClipIds(*tm1);
+    const auto laneIds1 = collectLaneIds(*tm1);
+    const auto patternIds1 = collectPatternIds(*tm1);
+    const auto sourceIds1 = collectSourceIds(*tm1);
+
+    // ---------------- Generation 2: identities must survive the load
+    auto ser1 = ProjectSerializer::serialize(tm1, kTempo, kPlayhead, 2);
+    require(ser1.ok && !ser1.contents.empty(), "generation-1 serialize failed");
+    require(ProjectSerializer::writeAtomically(projectPath.string(), ser1.contents), "generation-1 write failed");
+
+    auto tm2 = std::make_shared<TrackManager>();
+    tm2->getPlaylistModel().setPatternManager(&tm2->getPatternManager());
+    ProjectSerializer::LoadResult load1 = ProjectSerializer::load(projectPath.string(), tm2);
+    require(load1.ok, "generation-2 load failed");
+
+    require(collectClipIds(*tm2) == clipIds1, "clip UUIDs must survive load unchanged");
+    require(collectLaneIds(*tm2) == laneIds1, "lane UUIDs must survive load unchanged");
+    require(collectPatternIds(*tm2) == patternIds1, "pattern IDs must survive load unchanged");
+    require(collectSourceIds(*tm2) == sourceIds1, "source IDs must survive load unchanged");
+
+    // ---------------- Byte-stable fixed point + idempotence
+    auto ser2 = ProjectSerializer::serialize(tm2, load1.tempo, load1.playhead, 2);
+    require(ser2.ok, "generation-2 serialize failed");
+    require(ser2.contents == ser1.contents, "save->load->save must be byte-identical (fixed point)");
+
+    const auto gen3Path = tempDir / "identity_gen3.aes";
+    require(ProjectSerializer::writeAtomically(gen3Path.string(), ser2.contents), "generation-3 write failed");
+    auto tm3 = std::make_shared<TrackManager>();
+    tm3->getPlaylistModel().setPatternManager(&tm3->getPatternManager());
+    ProjectSerializer::LoadResult load2 = ProjectSerializer::load(gen3Path.string(), tm3);
+    require(load2.ok, "generation-3 load failed");
+    auto ser3 = ProjectSerializer::serialize(tm3, load2.tempo, load2.playhead, 2);
+    require(ser3.ok, "generation-3 serialize failed");
+    require(ser3.contents == ser2.contents, "fixed point must hold across further generations");
+
+    // ---------------- Collision safety: post-load mints never reuse restored IDs
+    {
+        const uint64_t maxPattern = patternIds1.back();
+        PatternID freshPattern = tm2->getPatternManager().createMidiPattern("PostLoad", 4.0, MidiPayload{});
+        require(freshPattern.value > maxPattern, "post-load pattern mint must exceed restored pattern IDs");
+
+        const uint64_t maxSource = sourceIds1.back();
+        const auto wav2 = tempDir / "identity2.wav";
+        require(writeMinimalWavMono16(wav2, 48000, 480), "could not write second WAV");
+        ClipSourceID freshSource = tm2->getSourceManager().getOrCreateSource(wav2.string());
+        require(freshSource.value > maxSource, "post-load source mint must exceed restored source IDs");
+
+        PlaylistLaneID freshLane = tm2->getPlaylistModel().createLane("PostLoad");
+        require(freshLane.isValid(), "post-load lane create failed");
+        auto laneIds2 = collectLaneIds(*tm2);
+        require(std::count(laneIds2.begin(), laneIds2.end(), freshLane.toString()) == 1,
+                "post-load lane ID must be unique");
+
+        ClipInstanceID freshClip =
+            tm2->getPlaylistModel().addClipFromPattern(freshLane, freshPattern, 0.0, 4.0);
+        require(freshClip.isValid(), "post-load clip create failed");
+        require(std::count(clipIds1.begin(), clipIds1.end(), freshClip.toString()) == 0,
+                "post-load clip UUID must not collide with restored clips");
+    }
+
+    // ---------------- Duplicate clip ids in a hand-edited file get re-minted
+    {
+        std::string mangled = ser1.contents;
+        const std::string fromId = audioClipId.toString();
+        const std::string toId = midiClipId.toString();
+        const size_t pos = mangled.find(fromId);
+        require(pos != std::string::npos, "mangle setup: audio clip id not found in contents");
+        mangled.replace(pos, fromId.size(), toId);
+
+        const auto dupPath = tempDir / "identity_dup.aes";
+        require(ProjectSerializer::writeAtomically(dupPath.string(), mangled), "duplicate-id write failed");
+        auto tmDup = std::make_shared<TrackManager>();
+        tmDup->getPlaylistModel().setPatternManager(&tmDup->getPatternManager());
+        ProjectSerializer::LoadResult loadDup = ProjectSerializer::load(dupPath.string(), tmDup);
+        require(loadDup.ok, "duplicate-id load failed");
+
+        auto dupClipIds = collectClipIds(*tmDup);
+        require(dupClipIds.size() == 2, "both clips must survive a duplicate-id file");
+        require(dupClipIds[0] != dupClipIds[1], "duplicate clip ids must be re-minted, not aliased");
+    }
+
+    // ---------------- UINT64_MAX ids are re-minted (restoring would wrap the counter)
+    {
+        constexpr uint64_t maxId = std::numeric_limits<uint64_t>::max();
+
+        PatternManager pm;
+        const PatternID cappedPat = pm.createAudioPatternWithId(PatternID{maxId}, "max", 4.0, AudioSlicePayload{});
+        require(cappedPat.isValid() && cappedPat.value != maxId,
+                "UINT64_MAX pattern id must be re-minted, not restored");
+        const PatternID afterCapPat = pm.createAudioPattern("next", 4.0, AudioSlicePayload{});
+        require(afterCapPat.isValid() && afterCapPat.value != cappedPat.value,
+                "pattern mint after a UINT64_MAX request must stay valid and unique");
+
+        SourceManager sm;
+        const ClipSourceID cappedSrc = sm.getOrCreateSourceWithId(ClipSourceID{maxId}, (tempDir / "max_a.wav").string());
+        require(cappedSrc.isValid() && cappedSrc.value != maxId,
+                "UINT64_MAX source id must be re-minted, not restored");
+        const ClipSourceID afterCapSrc = sm.getOrCreateSourceWithId(ClipSourceID{}, (tempDir / "max_b.wav").string());
+        require(afterCapSrc.isValid() && afterCapSrc.value != cappedSrc.value,
+                "source mint after a UINT64_MAX request must stay valid and unique");
+    }
+
+    std::cout << "[PASS] ProjectIdentityStabilityTest\n";
+    return 0;
+}

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -310,7 +310,10 @@ void testArsenalDefaultPatternRebindsAfterLoad() {
     const auto* unit = tm->getUnitManager().getUnit(7);
     assert(unit);
     assert(unit->defaultPatternId.isValid());
-    assert(unit->defaultPatternId.value != 42);
+    // Serialized pattern identity is restored on load since #446, so the
+    // rebind map resolves 42 -> 42. The binding itself (unit points at the
+    // pattern that carries its notes) is what this test guards.
+    assert(unit->defaultPatternId.value == 42);
 
     const auto* pattern = tm->getPatternManager().getPattern(unit->defaultPatternId);
     assert(pattern);

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -23,10 +23,10 @@
 // at beat 0; and the slice loader filling startOffset/duration instead of the
 // startSamples/lengthSamples fields the writer persists.
 //
-// NOT asserted here: byte-identical save->load->save output. Clip UUIDs and
-// pattern numeric IDs are re-minted by the loader (identity is session-scoped
-// today), which also reorders the patterns array between generations. Stable
-// persisted identity is tracked as its own serialization-cluster issue.
+// NOT asserted here: byte-identical save->load->save output and identity
+// stability — ProjectIdentityStabilityTest owns those (#446: the loader now
+// restores clip/lane UUIDs and pattern/source numeric IDs, and the writer
+// emits patterns/sources in sorted order).
 
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../Support/TestTempDirectory.h"

--- a/Tests/Integration/TakeManagerTest.cpp
+++ b/Tests/Integration/TakeManagerTest.cpp
@@ -141,6 +141,85 @@ int main() {
     require(switchedManifest.activeTake() && switchedManifest.activeTake()->active,
             "Active take marker was not restored");
 
+    // --- Rename: name changes persist, snapshot contents stay untouched ------
+    auto renamed = TakeManager::renameTake(projectPath.string(), created.take.id, "  Drum Bus V2  ");
+    require(renamed.ok, "Failed to rename Take");
+    require(renamed.take.name == "Drum Bus V2", "Rename should trim whitespace");
+    auto renamedManifest = TakeManager::loadManifest(projectPath.string());
+    require(renamedManifest.ok, "Failed to reload manifest after rename");
+    const auto* renamedTake = renamedManifest.findTake(created.take.id);
+    require(renamedTake != nullptr && renamedTake->name == "Drum Bus V2", "Rename did not persist");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *renamedTake)) ==
+                "Variation Saved Lane",
+            "Rename must not modify the take snapshot");
+    require(!TakeManager::renameTake(projectPath.string(), created.take.id, "   ").ok,
+            "Blank take names must be rejected");
+    require(!TakeManager::renameTake(projectPath.string(), "no_such_take", "X").ok,
+            "Renaming a missing take must fail");
+
+    // --- Duplicate: non-destructive copy, records lineage, stays inactive ----
+    auto duplicated = TakeManager::duplicateTake(projectPath.string(), created.take.id);
+    require(duplicated.ok, "Failed to duplicate Take");
+    require(duplicated.take.parentId == created.take.id, "Duplicate should record its source as parent");
+    require(duplicated.take.name == "Drum Bus V2 Copy", "Duplicate should derive a Copy name");
+    require(duplicated.manifest.activeTakeId == "main", "Duplicating must not change the active take");
+    require(duplicated.manifest.takes.size() == 3, "Duplicate should add a manifest entry");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), duplicated.take)) ==
+                "Variation Saved Lane",
+            "Duplicate snapshot should be a copy of its source");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *renamedTake)) ==
+                "Variation Saved Lane",
+            "Duplicating must not modify the source snapshot");
+    require(!TakeManager::duplicateTake(projectPath.string(), "no_such_take").ok,
+            "Duplicating a missing take must fail");
+
+    // --- Branch flow: duplicate + activate leaves every prior take intact ----
+    auto branch = TakeManager::duplicateTake(projectPath.string(), "main", "Main Branch");
+    require(branch.ok, "Failed to create branch duplicate");
+    auto branchActive = TakeManager::setActiveTake(projectPath.string(), branch.take.id);
+    require(branchActive.ok, "Failed to activate branch take");
+    auto branchedManifest = TakeManager::loadManifest(projectPath.string());
+    require(branchedManifest.ok, "Failed to reload manifest after branching");
+    require(branchedManifest.activeTakeId == branch.take.id, "Branch take should be active");
+    const auto* branchEntry = branchedManifest.findTake(branch.take.id);
+    require(branchEntry != nullptr && branchEntry->parentId == "main", "Branch should descend from Main");
+    const auto* mainAfterBranch = branchedManifest.findTake("main");
+    require(mainAfterBranch != nullptr, "Main take must survive branching");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *mainAfterBranch)) ==
+                "Main Lane",
+            "Branching must not modify the Main snapshot");
+    require(loadFirstLaneName(TakeManager::resolveSnapshotPath(projectPath.string(), *branchEntry)) == "Main Lane",
+            "Branch snapshot should start from its source state");
+
+    // --- Delete: refuses the active take, reparents children, removes files --
+    require(!TakeManager::deleteTake(projectPath.string(), branch.take.id).ok,
+            "Deleting the active take must be refused");
+    require(!TakeManager::deleteTake(projectPath.string(), "no_such_take").ok,
+            "Deleting a missing take must fail");
+
+    // duplicated (parent = renamed variation) must survive its parent's
+    // deletion by moving up to the variation's parent ("main").
+    const std::string dupSnapshotPath = TakeManager::resolveSnapshotPath(projectPath.string(), duplicated.take);
+    const auto beforeDeleteManifest = TakeManager::loadManifest(projectPath.string());
+    require(beforeDeleteManifest.ok, "Manifest should load before deletion");
+    const auto* renamedBeforeDelete = beforeDeleteManifest.findTake(created.take.id);
+    require(renamedBeforeDelete != nullptr, "Renamed take should exist before deletion");
+    const std::string renamedSnapshotPath =
+        TakeManager::resolveSnapshotPath(projectPath.string(), *renamedBeforeDelete);
+    require(std::filesystem::exists(renamedSnapshotPath), "Renamed take snapshot should exist before deletion");
+
+    auto deleted = TakeManager::deleteTake(projectPath.string(), created.take.id);
+    require(deleted.ok, "Failed to delete a non-active take");
+    auto afterDelete = TakeManager::loadManifest(projectPath.string());
+    require(afterDelete.ok, "Manifest should reload after deletion");
+    require(afterDelete.findTake(created.take.id) == nullptr, "Deleted take must leave the manifest");
+    require(!std::filesystem::exists(renamedSnapshotPath), "Deleted take snapshot must be removed from disk");
+    const auto* orphan = afterDelete.findTake(duplicated.take.id);
+    require(orphan != nullptr, "Child of a deleted take must survive");
+    require(orphan->parentId == "main", "Child of a deleted take must reparent to its grandparent");
+    require(std::filesystem::exists(dupSnapshotPath), "Deleting a take must not touch other snapshots");
+    require(afterDelete.activeTakeId == branch.take.id, "Deletion must not change the active take");
+
     std::cout << "[PASS] TakeManagerTest\n";
     return 0;
 }


### PR DESCRIPTION
Promotes 15 merged PRs to main — the theme system, workspace panels, serialization hardening, and the complete **Muse agentic runtime** arc.

## Theme & workspace
- **#523** — full theme system: live switching, lights-on/lights-out across shell and editors
- **#524** — dedicated Takes and History panels
- **#525** — destination-alpha blending fix; stronger light-mode text lift

## Engine & serialization
- **#528** — stable serialization identities: save→load→save is byte-identical
- **#532** — remove dead AudioClip drag-drop path

## Muse agentic runtime (#526 → #540)
The controllable-DAW-runtime arc, end to end:
- **#526** structured JSON surface (`MuseService`) with query verbs and stable ids
- **#527** `MuseRepl` — JSONL stdin/stdout entry point (`--schema` = the agent tool manifest)
- **#530** vertical beat path: units (sampler/808), `load_sample`, note CRUD with expression
- **#531** `render_pattern` — offline bounce through the live engine path, `peakDb` in the result
- **#533** `batch` — all-or-nothing command groups, one undo step, dependent members supported
- **#534** `arrange_pattern` + `render_song` — patterns onto the timeline, whole song back as audio
- **#535** musical verbs: `set_steps` step strings, `quantize_pattern`, `transpose_pattern`
- **#537** agent UX: reasoned refusals (26 sites), semantic schema manifest, `clone_pattern`/`set_pattern_length`/`list_patterns`
- **#539** effect verbs: `add_effect`/`set_effect_param`/`bypass_effect`/`remove_effect` + `list_plugins`/`get_effects` — the agentic mixing loop
- **#540** `list_samples` discovery + `set_steps` velocity digits and swing

Every mutation runs through the same schema validation, command factories, and undo history the UI uses. Acceptance was live: a full beat (five synthesized samples, quantized 808 lines, arranged clips, mixed and bounced) produced through the pipe in 15 commands with zero errors, rendered at ~62× realtime.

Merge with a merge commit to preserve develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)