### PR TITLE
refactor(eq-editor): decompose AestraEQEditor::onMouseEvent into named handlers

### DIFF
--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -4531,6 +4531,33 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
     if (handleSelectedNodeQuickActionClick(event))
         return true;
 
+    if (handleRightClickActions(event)) {
+        return true;
+    }
+    if (handleOpenMenusClick(event)) {
+        return true;
+    }
+    if (handleHeaderButtonsClick(event)) {
+        return true;
+    }
+    if (handleAnalyzerPanelClick(event)) {
+        return true;
+    }
+    if (handleWheel(event)) {
+        return true;
+    }
+    if (handlePress(event)) {
+        return true;
+    }
+    if (handleDragUpdate(event)) {
+        return true;
+    }
+    handleHoverUpdate(event);
+
+    return contains;
+}
+
+bool AestraEQEditor::handleRightClickActions(const NUIMouseEvent& event) {
     if (event.pressed && event.button == NUIMouseButton::Right) {
         using EQ = Aestra::Audio::Plugins::AestraEQ;
         closeBandContextMenu();
@@ -4583,7 +4610,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
     }
+    return false;
+}
 
+bool AestraEQEditor::handleOpenMenusClick(const NUIMouseEvent& event) {
     if (m_bandContextMenuBand >= 0 && event.pressed && event.button == NUIMouseButton::Left) {
         static constexpr BandMenuAction kActions[] = {BandMenuAction::Reset,         BandMenuAction::InvertGain,
                                                       BandMenuAction::ToggleDynamic, BandMenuAction::SplitLR,
@@ -4630,7 +4660,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
             setDirty(true);
         }
     }
+    return false;
+}
 
+bool AestraEQEditor::handleHeaderButtonsClick(const NUIMouseEvent& event) {
     // Bypass click
     if (event.pressed && event.button == NUIMouseButton::Left && m_bypassRect.contains(event.position)) {
         setBypassed(!isBypassed());
@@ -4667,7 +4700,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
         setDirty(true);
         return true;
     }
+    return false;
+}
 
+bool AestraEQEditor::handleAnalyzerPanelClick(const NUIMouseEvent& event) {
     if (m_analyzerPanelOpen && event.pressed && event.button == NUIMouseButton::Left &&
         m_analyzerSourceRect.contains(event.position)) {
         cycleAnalyzerSource();
@@ -4715,7 +4751,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
         m_analyzerPanelOpen = false;
         setDirty(true);
     }
+    return false;
+}
 
+bool AestraEQEditor::handleWheel(const NUIMouseEvent& event) {
     if (event.wheelDelta != 0.0f && m_outputGainRect.contains(event.position)) {
         const float stepDb = (event.modifiers & NUIModifiers::Shift) ? 0.1f : 1.0f;
         setOutputGain(outputGain() + (event.wheelDelta > 0 ? stepDb : -stepDb) / 36.0f);
@@ -4744,7 +4783,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
     }
+    return false;
+}
 
+bool AestraEQEditor::handlePress(const NUIMouseEvent& event) {
     // Press
     if (event.pressed && event.button == NUIMouseButton::Left) {
         const int selectedIdx =
@@ -4899,7 +4941,10 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
     }
+    return false;
+}
 
+bool AestraEQEditor::handleDragUpdate(const NUIMouseEvent& event) {
     // Drag
     if (m_draggingGraphBand >= 0) {
         updateBandFromGraphPosition(m_draggingGraphBand, event.position, event.modifiers);
@@ -4928,7 +4973,11 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
         return true;
     }
+    return false;
+}
 
+void AestraEQEditor::handleHoverUpdate(const NUIMouseEvent& event) {
+    const bool contains = getBounds().contains(event.position);
     // Hover
     if (!event.pressed && !event.released) {
         Knob k = Knob::None;
@@ -5152,8 +5201,6 @@ bool AestraEQEditor::onMouseEvent(const NUIMouseEvent& event) {
             setDirty(true);
         }
     }
-
-    return contains;
 }
 
 bool AestraEQEditor::onKeyEvent(const NUIKeyEvent& event) {

--- a/AestraUI/Widgets/AestraEQEditor.h
+++ b/AestraUI/Widgets/AestraEQEditor.h
@@ -31,6 +31,17 @@ public:
     void onResize() { layoutControls(); }
 
 private:
+    // onMouseEvent decomposition — called by the dispatcher in this order;
+    // bool handlers return true when the event was consumed.
+    bool handleRightClickActions(const NUIMouseEvent& event);
+    bool handleOpenMenusClick(const NUIMouseEvent& event);
+    bool handleHeaderButtonsClick(const NUIMouseEvent& event);
+    bool handleAnalyzerPanelClick(const NUIMouseEvent& event);
+    bool handleWheel(const NUIMouseEvent& event);
+    bool handlePress(const NUIMouseEvent& event);
+    bool handleDragUpdate(const NUIMouseEvent& event);
+    void handleHoverUpdate(const NUIMouseEvent& event);
+
     enum class Knob { None, Enable, Freq, Gain, Q, Type, Stereo, DynamicEnable, Threshold, Attack, Release };
     enum class BandMenuAction {
         Reset,


### PR DESCRIPTION
## What

Step 3b of the monolith-streamlining series (#536, #538, #543). Same treatment as #543, applied to the second-largest handler: `AestraEQEditor::onMouseEvent` was **652 lines**; it is now a **52-line dispatcher** calling eight named private handlers in the exact original evaluation order:

| Handler | Concern |
|---|---|
| `handleRightClickActions` | right-click resets (bypass/gain/polarity), compare copy, band context-menu opens |
| `handleOpenMenusClick` | band context / type / stereo menu option clicks + click-outside dismiss |
| `handleHeaderButtonsClick` | bypass, polarity, compare A/B/copy, curve scale, analyzer toggle |
| `handleAnalyzerPanelClick` | analyzer panel option rows |
| `handleWheel` | output-gain wheel + Q/slope wheel on graph nodes |
| `handlePress` | left-press: drag starts, band create, knob grabs, numeric edit |
| `handleDragUpdate` | graph-band / detector / output-gain / card-knob drags |
| `handleHoverUpdate` | all hover state (void — never consumes) |

## Behavior preservation

- Bodies moved **verbatim** (script-driven on asserted anchors); bool handlers keep internal `return true` exits and gained the original fall-through as `return false`. The dispatcher ends with the original `return contains;` tail.
- Menu-dismiss fall-through semantics preserved: clicking outside an open menu closes it *and continues* to the blocks below, exactly as before.
- One deliberate addition: `handleHoverUpdate` recomputes `const bool contains = getBounds().contains(event.position);` which it previously read from the enclosing function scope (same value by construction).

Remaining in step 3: `FileBrowser::onMouseEvent` (468 lines) — deliberately deferred to its own PR because that function has entangled scoping (stray brace levels, cross-block locals) that deserves a careful manual pass, not a mechanical move.

## Testing

- Full rebuild clean (Linux, GCC)
- ctest: **169/169** pass (excluding env-dependent `SecAccountApiClient`, CI-excluded per #201)
- App boot smoke: clean boot, autosave fires, no ERROR/FATAL lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Refactored `AestraEQEditor::onMouseEvent` into eight focused private handlers while preserving the original evaluation order and behavior.
- Preserved menu-dismissal fall-through and bounds-containment return semantics.
- Added local bounds recomputation for hover updates, improving handler independence.
- Verified with a clean Linux/GCC rebuild, 169 passing tests, and an application boot smoke test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->