### PR TITLE
fix(rt-safety): consolidate dual real-time thread guards into one flag (R1)

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -3,7 +3,6 @@
 #include "AppLifecycle.h"
 #include "ServiceLocator.h"
 #include "AestraRootComponent.h"
-#include "AudioThreadConstraints.h"
 #include "Preferences.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraCore/include/PointerRegistry.h"

--- a/Source/AudioThreadConstraints.h
+++ b/Source/AudioThreadConstraints.h
@@ -73,6 +73,8 @@
  * ═══════════════════════════════════════════════════════════════════════════
  */
 
+#include "RealtimeThreadGuard.h" // Canonical real-time thread detection (isRealtimeAudioThread / ScopedRealtimeAudioThread)
+
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -89,37 +91,11 @@
 namespace Aestra {
 namespace Audio {
 
-/**
- * @brief Thread-local flag indicating we're on the audio thread
- * 
- * Set to true at the start of the audio callback, false at the end.
- * Used by debug checks to detect constraint violations.
- */
-inline thread_local bool g_isAudioThread = false;
-
-/**
- * @brief Check if current thread is the audio thread
- */
-inline bool isAudioThread() {
-    return g_isAudioThread;
-}
-
-/**
- * @brief RAII guard for marking audio thread scope
- */
-class AudioThreadGuard {
-public:
-    AudioThreadGuard() { 
-        g_isAudioThread = true; 
-    }
-    ~AudioThreadGuard() { 
-        g_isAudioThread = false; 
-    }
-    
-    // Non-copyable
-    AudioThreadGuard(const AudioThreadGuard&) = delete;
-    AudioThreadGuard& operator=(const AudioThreadGuard&) = delete;
-};
+// Real-time thread detection lives in RealtimeThreadGuard.h and is the single
+// source of truth: isRealtimeAudioThread() / ScopedRealtimeAudioThread. This
+// header used to carry a parallel g_isAudioThread bool + AudioThreadGuard; those
+// were consolidated away so every constraint check keys off one flag. Mark the
+// audio callback scope with Aestra::Audio::ScopedRealtimeAudioThread.
 
 /**
  * @brief Runtime violation counter (for diagnostics)
@@ -179,7 +155,7 @@ struct AudioThreadStats {
  */
 #define AESTRA_ASSERT_NOT_AUDIO_THREAD() \
     do { \
-        if (Aestra::Audio::isAudioThread()) { \
+        if (Aestra::Audio::isRealtimeAudioThread()) { \
             Aestra::Audio::AudioThreadStats::instance().allocationViolations.fetch_add(1); \
             assert(false && "Audio thread constraint violation: forbidden operation"); \
         } \
@@ -192,7 +168,7 @@ struct AudioThreadStats {
  */
 #define AESTRA_ASSERT_AUDIO_THREAD() \
     do { \
-        assert(Aestra::Audio::isAudioThread() && "Expected to be on audio thread"); \
+        assert(Aestra::Audio::isRealtimeAudioThread() && "Expected to be on audio thread"); \
     } while(0)
 
 /**
@@ -221,7 +197,7 @@ struct AudioThreadStats {
         auto& stats = Aestra::Audio::AudioThreadStats::instance(); \
         stats.totalAllocations.fetch_add(1, std::memory_order_relaxed); \
         stats.updatePeak(size); \
-        if (Aestra::Audio::isAudioThread()) { \
+        if (Aestra::Audio::isRealtimeAudioThread()) { \
             stats.allocationViolations.fetch_add(1, std::memory_order_relaxed); \
             /* Debug break in MSVC: __debugbreak(); */ \
             (void)(source); \
@@ -243,7 +219,7 @@ struct AudioThreadStats {
  */
 #define AESTRA_TRACK_LOCK() \
     do { \
-        if (Aestra::Audio::isAudioThread()) { \
+        if (Aestra::Audio::isRealtimeAudioThread()) { \
             Aestra::Audio::AudioThreadStats::instance().lockViolations.fetch_add(1, std::memory_order_relaxed); \
         } \
     } while(0)
@@ -253,7 +229,7 @@ struct AudioThreadStats {
  */
 #define AESTRA_TRACK_FILE_IO() \
     do { \
-        if (Aestra::Audio::isAudioThread()) { \
+        if (Aestra::Audio::isRealtimeAudioThread()) { \
             Aestra::Audio::AudioThreadStats::instance().ioViolations.fetch_add(1, std::memory_order_relaxed); \
         } \
     } while(0)

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -434,8 +434,10 @@ bool AestraAudioController::setBufferSize(uint32_t bufferSize) {
 
 int AestraAudioController::audioCallback(float* outputBuffer, const float* inputBuffer,
                          uint32_t nFrames, double streamTime, void* userData) {
-    // B-005: Mark this as audio thread for constraint checking
-    Aestra::Audio::AudioThreadGuard audioThreadGuard;
+    // B-005: Mark this as audio thread for constraint checking.
+    // Uses the canonical RT flag (RealtimeThreadGuard.h); nests cleanly with the
+    // inner ScopedRealtimeAudioThread inside AudioEngine::processBlock.
+    Aestra::Audio::ScopedRealtimeAudioThread audioThreadGuard;
     Aestra::Audio::AudioThreadStats::instance().totalCallbacks.fetch_add(1, std::memory_order_relaxed);
 
     AestraAudioController* controller = static_cast<AestraAudioController*>(userData);

--- a/Tests/AestraAudio/RTGuardConsolidationTest.cpp
+++ b/Tests/AestraAudio/RTGuardConsolidationTest.cpp
@@ -1,0 +1,100 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// RTGuardConsolidationTest
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression guard for the real-time-thread-guard consolidation (R1).
+//
+// Before consolidation there were TWO independent thread-local flags:
+//   • g_realtimeAudioThreadDepth  (RealtimeThreadGuard.h, set by
+//     ScopedRealtimeAudioThread — the engine / processBlock path)
+//   • g_isAudioThread             (AudioThreadConstraints.h, set by the removed
+//     AudioThreadGuard — the app-layer callback path)
+//
+// The app-layer constraint macros (AESTRA_ASSERT_AUDIO_THREAD / AESTRA_TRACK_*)
+// keyed off the *app* flag, while the engine's RT-misuse checks keyed off the
+// *engine* flag. A thread marked only by ScopedRealtimeAudioThread would NOT be
+// recognized by the app-layer constraint layer — the "incomplete detection ->
+// false confidence" hazard.
+//
+// This test marks the thread using ONLY ScopedRealtimeAudioThread (exactly what
+// AestraAudioController::audioCallback now does) and proves the app-layer
+// constraint macros in AudioThreadConstraints.h recognize it as real-time. If a
+// second parallel flag is ever reintroduced, this test fails.
+
+// Force the debug constraint macros active regardless of the test build's
+// NDEBUG state, so the allocation/lock/IO detection paths are actually exercised.
+#define AESTRA_AUDIO_DEBUG 1
+
+#include "RealtimeThreadGuard.h"   // canonical: ScopedRealtimeAudioThread / isRealtimeAudioThread
+#include "AudioThreadConstraints.h" // app-layer constraint macros + AudioThreadStats
+
+#include <cstdio>
+
+using namespace Aestra::Audio;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL (line %d): %s\n", __LINE__, #cond);     \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+int main() {
+    auto& stats = AudioThreadStats::instance();
+    stats.reset();
+
+    // ── Precondition: worker/UI thread is not real-time ────────────────────
+    CHECK(!isRealtimeAudioThread());
+    AESTRA_ASSERT_NOT_AUDIO_THREAD(); // must not fire off the audio thread
+    AESTRA_TRACK_ALLOCATION(128, "off-thread");
+    CHECK(stats.totalAllocations.load() == 1);
+    CHECK(stats.allocationViolations.load() == 0); // no violation off-thread
+
+    // ── Mark the thread with ONLY the canonical engine guard ───────────────
+    {
+        ScopedRealtimeAudioThread rtScope;
+
+        // The app-layer constraint layer must recognize this as real-time.
+        CHECK(isRealtimeAudioThread());
+        AESTRA_ASSERT_AUDIO_THREAD(); // must pass while marked
+
+        // Allocation / lock / file-IO tracking must flag violations here.
+        AESTRA_TRACK_ALLOCATION(256, "rt-thread");
+        AESTRA_TRACK_LOCK();
+        AESTRA_TRACK_FILE_IO();
+
+        CHECK(stats.totalAllocations.load() == 2);
+        CHECK(stats.allocationViolations.load() == 1);
+        CHECK(stats.lockViolations.load() == 1);
+        CHECK(stats.ioViolations.load() == 1);
+        CHECK(stats.peakAllocationSize.load() == 256);
+    }
+
+    // ── Guard exit restores the non-real-time state ────────────────────────
+    CHECK(!isRealtimeAudioThread());
+    AESTRA_TRACK_ALLOCATION(64, "post-scope");
+    CHECK(stats.allocationViolations.load() == 1); // unchanged off-thread
+
+    // ── Nesting parity with AudioEngine::processBlock's inner guard ────────
+    // The callback guard and processBlock's guard nest; depth-counting (not a
+    // bool) must keep the thread real-time until the OUTERMOST scope exits.
+    {
+        ScopedRealtimeAudioThread outer;
+        {
+            ScopedRealtimeAudioThread inner;
+            CHECK(isRealtimeAudioThread());
+        }
+        CHECK(isRealtimeAudioThread()); // still RT after inner exits
+    }
+    CHECK(!isRealtimeAudioThread());
+
+    if (g_failures == 0) {
+        std::puts("RTGuardConsolidationTest: PASS");
+        return 0;
+    }
+    std::fprintf(stderr, "RTGuardConsolidationTest: FAILED (%d checks)\n", g_failures);
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1513,6 +1513,20 @@ target_include_directories(RTAllocationTrapTest PRIVATE
 add_test(NAME RTAllocationTrapTest COMMAND RTAllocationTrapTest)
 set_tests_properties(RTAllocationTrapTest PROPERTIES LABELS "audio;rt-safety;integrity;s-tier" TIMEOUT 180)
 
+# RT Guard Consolidation Test — proves the app-layer constraint macros in
+# Source/AudioThreadConstraints.h recognize a thread marked only by the canonical
+# ScopedRealtimeAudioThread (RealtimeThreadGuard.h). Regression guard for R1.
+# Header-only: RealtimeThreadGuard.h + AudioThreadConstraints.h define everything
+# inline, so no link deps (avoids dragging in the plugin registry link chain).
+add_executable(RTGuardConsolidationTest AestraAudio/RTGuardConsolidationTest.cpp)
+target_include_directories(RTGuardConsolidationTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+)
+add_test(NAME RTGuardConsolidationTest COMMAND RTGuardConsolidationTest)
+set_tests_properties(RTGuardConsolidationTest PROPERTIES LABELS "audio;rt-safety;integrity" TIMEOUT 120)
+
 # Callback Deadline Telemetry — validates AudioTelemetry::recordCallbackDuration
 # (avg/worst/budget/over-budget math) synthetically, plus a live smoke over
 # real processBlock timings.


### PR DESCRIPTION
## Summary
Collapses the two independent real-time-thread detection systems (Architectural Risk **R1**) into a single canonical flag.

Before this change, `Aestra::Audio` carried **two** thread-local RT flags:

| Flag | Header | Set by | Read by |
|---|---|---|---|
| `g_realtimeAudioThreadDepth` (int, depth) | `RealtimeThreadGuard.h` | `ScopedRealtimeAudioThread` | `reportRealtimeMisuse()` across EffectChain / AudioEngine / TrackManager / PatternPlaybackEngine / GarbageCollector (**canonical**) |
| `g_isAudioThread` (bool) | `AudioThreadConstraints.h` | `AudioThreadGuard` | **nobody** — `isAudioThread()` and the `AESTRA_ASSERT_*`/`AESTRA_TRACK_*` macros had **zero consumers** repo-wide |

## Why
On the one production callback path both flags were live, but with **asymmetric coverage**: `g_isAudioThread` spanned the whole `audioCallback`, while the canonical depth flag only spanned `AudioEngine::processBlock` (nested inside it). Any check keyed off the wrong flag — or any new consumer of the app-layer macros — would silently return the wrong answer: the *"incomplete detection → false confidence"* hazard R1 names.

**Live vs latent:** latent. `g_isAudioThread` was write-only (no readers), so nothing misfired today — but the divergence was one new call site away from a false negative on the RT thread.

**Callback path (proven):**
```
AestraAudioController::audioCallback         (sets g_isAudioThread — whole callback)
  └─ AudioEngine::processBlock               (sets g_realtimeAudioThreadDepth — nested only here)
```

## Change (consolidation only — no policy redesign)
- `RealtimeThreadGuard.h` is the single source of truth.
- `audioCallback` marks the thread with `ScopedRealtimeAudioThread` (nests cleanly with `processBlock`'s inner guard — depth counting, not a bool).
- `AESTRA_ASSERT_AUDIO_THREAD` / `AESTRA_TRACK_*` now key off `isRealtimeAudioThread()`.
- Removed the duplicate `g_isAudioThread`, `isAudioThread()`, `AudioThreadGuard`. Kept `AudioThreadStats`, the rewired macros, the threading-model doc, and lock-free utilities.
- Dropped a dead `AudioThreadConstraints.h` include from `AestraApp.cpp`.

> Note: `audioCallback` migrating to `ScopedRealtimeAudioThread` makes the canonical flag cover the whole callback — matching the scope the old app-layer bool already had. The engine's `reportRealtimeMisuse` guards (armed only during `processBlock` before) are now armed for the full callback; the monitoring/preview/waveform regions do not call any guarded mutation method, so no behavior changes in practice.

## Testing performed
- **New `RTGuardConsolidationTest`** (header-only, no link deps): marks the thread with *only* `ScopedRealtimeAudioThread` and asserts the app-layer constraint macros recognize it as real-time, allocation/lock/IO detection fires, and guard nesting keeps the thread RT until the outermost scope exits. **PASS.** Fails if a second parallel flag is reintroduced.
- Both changed Source TUs (`AestraAudioController.cpp`, `AestraApp.cpp`) syntax-checked with real compile flags → clean (confirms the include resolves and no transitive-include breakage from the removed include).
- `RTAllocationTrapTest` still passes.
- Full-repo grep: no stale consumers of `g_isAudioThread` / `isAudioThread()` / `AudioThreadGuard` remain (only a historical comment).

**Not run:** full `ctest` / app link. Several minimal AestraAudio tests (e.g. `AudioEngineDiagnosticsTest`) fail to *link* on a pre-existing AestraRumble → `InternalPluginRegistry` ordering fragility (AGENTS.md §8) — reproduced on the base tree with this change stashed, so it is unrelated to this PR. This change adds no new symbol surface, so the app link is unaffected.

## Docs updated?
No public docs. Header threading-model doc retained; a short note records the consolidation.

## Risk / rollback
- **Low.** Localized to RT-thread marking; `RealtimeThreadGuard.h` itself untouched; no serialization/DSP/plugin-ID surface touched.
- Rollback = revert the commit; both guards are inline header constructs with no ABI impact.

## Follow-up (not in this PR)
Pre-existing AestraRumble/`InternalPluginRegistry` static-link ordering makes minimal AestraAudio tests brittle — worth adding AestraRumble to the `RESCAN` link group. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking changes:** Removed the unused `isAudioThread()`, `g_isAudioThread`, and `AudioThreadGuard` APIs.
- Consolidated real-time thread detection around `RealtimeThreadGuard.h` and `isRealtimeAudioThread()`.
- Updated audio callbacks and thread-safety macros to use `ScopedRealtimeAudioThread`, preserving nested guard behavior.
- Removed the obsolete `AudioThreadConstraints.h` include from `AestraApp.cpp`.
- Added `RTGuardConsolidationTest` to verify thread detection, nested guards, and allocation/lock/I/O constraint tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->