### PR TITLE
fix(export): headless export owns its AudioEngine — no more getInstance() abort (R2 PR-0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,21 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessExportMain.cpp")
     set_tests_properties(AestraHeadlessExportRejectsBadArgs PROPERTIES
       WILL_FAIL TRUE
       LABELS "cli;headless")
+
+    # Real end-to-end export invocation: arg parse -> template project -> export
+    # attempt. Regression guard for the getInstance() abort (SIGABRT on develop;
+    # passes once the export path owns its engine). Exit 0 must come with a real
+    # non-empty WAV; exit 1 (graceful diagnosed failure) is tolerated only until
+    # the HeadlessMusicGenerator commit layer is implemented — see the driver
+    # script for the full contract.
+    add_test(NAME AestraHeadlessExportEndToEnd
+      COMMAND ${CMAKE_COMMAND}
+        -DEXPORT_BIN=$<TARGET_FILE:AestraHeadlessExport>
+        -DOUT_FILE=${CMAKE_BINARY_DIR}/headless_export_e2e.wav
+        -P ${CMAKE_SOURCE_DIR}/Tests/Headless/run_headless_export_e2e.cmake)
+    set_tests_properties(AestraHeadlessExportEndToEnd PROPERTIES
+      LABELS "cli;headless;export;integrity"
+      TIMEOUT 120)
   endif()
 
   message(STATUS "AestraHeadlessExport configured")

--- a/Source/App/HeadlessExportMain.cpp
+++ b/Source/App/HeadlessExportMain.cpp
@@ -160,9 +160,11 @@ int main(int argc, char* argv[]) {
     Log::info("========================================");
     
     try {
-        // Initialize audio engine
+        // Initialize audio engine. This tool owns its engine for the lifetime of
+        // the export (mirroring HeadlessMain / MuseReplMain) rather than reaching
+        // for a process-wide singleton — nothing else constructs one here.
         Log::info("Initializing audio engine...");
-        AudioEngine& engine = AudioEngine::getInstance();
+        AudioEngine engine;
         engine.setSampleRate(args.sampleRate);
         engine.setBPM(static_cast<float>(args.tempo));
         

--- a/Tests/Headless/run_headless_export_e2e.cmake
+++ b/Tests/Headless/run_headless_export_e2e.cmake
@@ -1,0 +1,69 @@
+# End-to-end driver for AestraHeadlessExport.
+#
+# Runs the real export binary through the full path — argument parsing, template
+# project generation, and the export attempt — and enforces the current contract:
+#
+#   exit 0  full export success -> the output WAV must exist and contain audio
+#   exit 1  graceful, diagnosed failure -> allowed FOR NOW: the
+#           HeadlessMusicGenerator commit layer is stubbed (logs "Committed N"
+#           but populates nothing), so the exporter correctly reports an empty
+#           timeline. Tracked in issue #556; when that feature lands, tighten
+#           this driver to require exit 0 + WAV validation.
+#   anything else (exit 2 = arg error on valid args, or a signal such as
+#           "Subprocess aborted") -> regression. On develop this run died with
+#           SIGABRT from AudioEngine::getInstance() before any engine existed.
+#
+# Required -D args:
+#   EXPORT_BIN  path to the AestraHeadlessExport executable
+#   OUT_FILE    path to write the exported .wav to (removed on success)
+
+if(NOT EXPORT_BIN OR NOT OUT_FILE)
+    message(FATAL_ERROR "EXPORT_BIN and OUT_FILE must be provided")
+endif()
+
+file(REMOVE "${OUT_FILE}")
+
+# Smallest valid session this binary can express: one bar of the sparse
+# "Minimal" template.
+execute_process(
+    COMMAND "${EXPORT_BIN}"
+            --template Minimal
+            --duration 1
+            --sample-rate 48000
+            --output "${OUT_FILE}"
+    RESULT_VARIABLE exit_code
+    OUTPUT_VARIABLE stdout_log
+    ERROR_VARIABLE  stderr_log
+)
+
+message(STATUS "AestraHeadlessExport exit: ${exit_code}")
+message(STATUS "AestraHeadlessExport stdout:\n${stdout_log}")
+message(STATUS "AestraHeadlessExport stderr:\n${stderr_log}")
+
+if(exit_code STREQUAL "0")
+    # Full success claimed: hold the binary to it.
+    if(NOT EXISTS "${OUT_FILE}")
+        message(FATAL_ERROR "Export reported success but produced no output at '${OUT_FILE}'.")
+    endif()
+    file(SIZE "${OUT_FILE}" out_size)
+    # A bare WAV header is 44 bytes; require substantially more so we know real
+    # audio frames were written, not just an empty container.
+    if(out_size LESS 1024)
+        message(FATAL_ERROR "Export output '${OUT_FILE}' is ${out_size} bytes — too small to contain audio.")
+    endif()
+    message(STATUS "Export E2E OK: ${OUT_FILE} (${out_size} bytes)")
+    file(REMOVE "${OUT_FILE}")
+elseif(exit_code STREQUAL "1")
+    # Graceful diagnosed failure. Acceptable only while the generator commit
+    # layer is unimplemented — but it must be a *diagnosed* failure, never a
+    # crash, and never a silent success with no file.
+    if(stderr_log MATCHES "getInstance\\(\\) called before engine was created")
+        message(FATAL_ERROR "Export path still depends on the AudioEngine singleton.")
+    endif()
+    message(STATUS "Export failed gracefully (generator commit layer not yet implemented) — no crash.")
+else()
+    message(FATAL_ERROR
+        "AestraHeadlessExport terminated abnormally (result: '${exit_code}'). "
+        "A signal here (e.g. 'Subprocess aborted') means the export path crashed "
+        "instead of failing diagnostically.")
+endif()

--- a/Tests/Headless/run_headless_export_e2e.cmake
+++ b/Tests/Headless/run_headless_export_e2e.cmake
@@ -40,6 +40,15 @@ message(STATUS "AestraHeadlessExport exit: ${exit_code}")
 message(STATUS "AestraHeadlessExport stdout:\n${stdout_log}")
 message(STATUS "AestraHeadlessExport stderr:\n${stderr_log}")
 
+# Singleton regression check first, independent of exit code: the abort path
+# dies on a signal (exit_code becomes e.g. "Subprocess aborted", not "1"), so
+# this must run before the exit-code dispatch to produce the specific diagnosis.
+if(stdout_log MATCHES "getInstance\\(\\) called before engine was created" OR
+   stderr_log MATCHES "getInstance\\(\\) called before engine was created")
+    message(FATAL_ERROR "Export path still depends on the AudioEngine singleton "
+                        "(getInstance() called before any engine was constructed).")
+endif()
+
 if(exit_code STREQUAL "0")
     # Full success claimed: hold the binary to it.
     if(NOT EXISTS "${OUT_FILE}")
@@ -56,10 +65,8 @@ if(exit_code STREQUAL "0")
 elseif(exit_code STREQUAL "1")
     # Graceful diagnosed failure. Acceptable only while the generator commit
     # layer is unimplemented — but it must be a *diagnosed* failure, never a
-    # crash, and never a silent success with no file.
-    if(stderr_log MATCHES "getInstance\\(\\) called before engine was created")
-        message(FATAL_ERROR "Export path still depends on the AudioEngine singleton.")
-    endif()
+    # crash, and never a silent success with no file. (The singleton-abort
+    # message is already checked above, before the exit-code dispatch.)
     message(STATUS "Export failed gracefully (generator commit layer not yet implemented) — no crash.")
 else()
     message(FATAL_ERROR


### PR DESCRIPTION
## Summary
`AestraHeadlessExport` **SIGABRTs on every real export** (#554): `main()` reads `AudioEngine::getInstance()` but the binary never constructs an engine, so the singleton pointer is null and `getInstance()` aborts by design. The only wired smoke test (`--duration nope`) returns on the arg-error path *before* the call, so CI never saw it. This was the **sole production reader** of the AudioEngine singleton (Architectural Risk R2).

**Fix:** the export tool constructs and owns a local `AudioEngine` (mirroring `HeadlessMain` / `MuseReplMain` ownership). One-line ownership change + comment.

## Why
- Restores the export binary from core-dump to diagnosed failure/success.
- R2 PR-0: with this merged, zero production readers of `getInstance()` remain — PR-1 deletes the singleton machinery outright.

## Honest limitation found while validating
Even without the crash, **the export cannot produce audio yet** — and never could. `HeadlessMusicGenerator::commitPatternsToManager()` / `commitPlaylistToModel()` are `TODO` stubs that log "Committed N" but populate nothing, so `AudioExporter` correctly reports `Nothing to render (empty timeline)` (exit 1, diagnosed). Making it render is a real feature build (instruments, `UnitManager` units, MIDI payload conversion, `PatternPlaybackEngine`/graph wiring) — deliberately **not** smuggled into this bugfix. Tracked in **#556** with the in-tree recipes (`RumbleArsenalAudibleTest`, `ExportBounceParityTest`).

## New test: `AestraHeadlessExportEndToEnd`
`cmake -P` driver (`Tests/Headless/run_headless_export_e2e.cmake`) runs the **real binary** with real export args and enforces:
- **exit 0** → output WAV must exist and be >1KB (real frames, not a bare header) — auto-tightens the day #556 lands
- **exit 1** → must be a diagnosed failure; fails the test if the singleton-abort message appears
- **any signal** (e.g. `Subprocess aborted`) → fail

Tolerating exit 1 is explicitly temporary, documented in the driver, and bound to #556; the acceptance there includes tightening this driver to require exit 0.

## Testing performed
- **Fails on develop-state binary** (fix stashed, rebuilt): `AestraHeadlessExport exit: Subprocess aborted` → test **Failed** ✓
- **Passes with fix** (restored, rebuilt): test **Passed** ✓
- `AestraHeadlessExportRejectsBadArgs` still passes.
- Manual verbose run: engine constructs, template generates, exporter fails with the empty-timeline diagnostic (exit 1, no core dump).

## Docs updated?
No public docs (tool was never claimed working). Issues #554 (this crash) and #556 (generator stub) carry the record.

## Risk / rollback
- **Low.** One TU (`HeadlessExportMain.cpp`) + test infra. No engine, exporter, DSP, or serialization changes; live/export parity untouched.
- Rollback: revert the commit.

## R2 context
PR-1 (after this merges): delete `getInstance()` + `g_audioEngineInstance` + ctor/dtor registration, add a zero-tolerance source guard, and add ownership tests (two simultaneously-alive engines independent; destruction isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed headless exports aborting by constructing and owning a local `AudioEngine` instead of using the uninitialized singleton.
- Added an end-to-end export test that runs the real binary, checks for crashes and singleton failures, and validates generated WAV output.
- The test temporarily accepts the known empty-timeline failure caused by unimplemented `HeadlessMusicGenerator` commit methods; rendering remains tracked separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->