### PR TITLE
fix: harden project lifecycle and audio reliability

### DIFF
--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -42,7 +42,10 @@ public:
     // =============================================================================
     
     /**
-     * @brief Serialization callback - called on background thread to get project data
+     * @brief Serialization callback used to capture project data.
+     *
+     * Called on the background thread by default, or by
+     * captureSnapshotIfDue() when owner-thread capture is enabled.
      * @param outData Output string to fill with serialized project data
      * @return true if serialization succeeded
      */
@@ -63,6 +66,11 @@ public:
 
         // Serialization callback (REQUIRED)
         SerializerFunc serializer;
+
+        // When true, the owner must call captureSnapshotIfDue() from the thread
+        // that owns the serialized model. The background thread then performs
+        // only backup rotation and file I/O on the immutable captured string.
+        bool captureSnapshotOnCallingThread{false};
 
         // Optional explicit autosave path. When set, overrides the derived
         // path from getAutosavePathForProject(). Used when the application
@@ -133,7 +141,7 @@ public:
     // =============================================================================
     
     void setEnabled(bool enabled);
-    bool isEnabled() const { return m_config.enabled; }
+    bool isEnabled() const { return m_enabled.load(std::memory_order_acquire); }
     
     /**
      * @brief Force an immediate autosave (even if not dirty)
@@ -151,6 +159,16 @@ public:
      * @return true if an autosave was performed.
      */
     bool autosaveIfDue();
+
+    /**
+     * @brief Capture one due snapshot on the calling/model-owner thread.
+     *
+     * Valid only when Config::captureSnapshotOnCallingThread is true. The
+     * serialized string is queued for background commit, so this call performs
+     * no file I/O. A concurrent markDirty() remains pending for the next capture.
+     * @return true if a snapshot was captured and queued.
+     */
+    bool captureSnapshotIfDue();
     
     std::string getAutosavePath() const;
     std::string getBackupDirectory() const;
@@ -180,6 +198,9 @@ public:
 private:
     void autosaveThreadFunc();
     bool performAutosave();
+    bool performAutosaveWithData(std::string data, uint64_t generation);
+    bool writeAutosaveData(const std::string& data, uint64_t generation);
+    bool claimDirtyIfDue();
     void rotateBackups();
     void notifyStatus(const std::string& msg);
     void notifyError(const std::string& err);
@@ -194,6 +215,8 @@ private:
     std::atomic<bool> m_isAutosaving{false};
     std::atomic<bool> m_shouldStop{false};
     std::atomic<bool> m_initialized{false};
+    std::atomic<bool> m_enabled{false};
+    std::atomic<uint64_t> m_nextSnapshotGeneration{1};
     
     // steady_clock milliseconds since epoch. Atomic so markDirty() (callable from
     // any thread) and the autosave gate can write/read it without the mutex.
@@ -202,7 +225,12 @@ private:
     
     std::unique_ptr<std::thread> m_autosaveThread;
     mutable std::mutex m_mutex;
+    std::mutex m_commitMutex;
     std::condition_variable m_cv;
+    std::string m_pendingSnapshot;
+    uint64_t m_pendingSnapshotGeneration{0};
+    uint64_t m_lastCommittedGeneration{0}; // guarded by m_commitMutex
+    bool m_hasPendingSnapshot{false};
     
     StatusCallback m_onStatus;
     ErrorCallback m_onError;

--- a/AestraAudio/include/Core/AutosaveManager.h
+++ b/AestraAudio/include/Core/AutosaveManager.h
@@ -179,6 +179,7 @@ public:
     
     static RecoveryInfo checkForRecovery(const std::string& projectPath);
     static std::vector<std::string> listBackups(const std::string& projectPath);
+    static std::vector<std::string> listBackupsForAutosavePath(const std::string& autosavePath);
     static void cleanupAutosaves(const std::string& projectPath);
     static bool recoverTo(const RecoveryInfo& recoveryInfo, const std::string& targetPath);
     

--- a/AestraAudio/include/Core/RealtimeObjectPublisher.h
+++ b/AestraAudio/include/Core/RealtimeObjectPublisher.h
@@ -1,0 +1,70 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraAtomicSharedPtr.h"
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Publishes shared control-thread ownership as a non-owning real-time pointer.
+ *
+ * One control thread owns publish(), owner(), and collectRetired(). One real-time
+ * reader uses acquireRealtime()/releaseRealtime(). Replaced objects remain owned
+ * by the control thread until the real-time hazard no longer references them, so
+ * the last shared_ptr release never occurs in the callback.
+ */
+template <typename T> class RealtimeObjectPublisher {
+public:
+    RealtimeObjectPublisher() = default;
+    explicit RealtimeObjectPublisher(std::shared_ptr<T> initial) { publish(std::move(initial)); }
+
+    RealtimeObjectPublisher(const RealtimeObjectPublisher&) = delete;
+    RealtimeObjectPublisher& operator=(const RealtimeObjectPublisher&) = delete;
+
+    void publish(std::shared_ptr<T> object) {
+        auto previous = m_owner.exchange(object, std::memory_order_acq_rel);
+        m_published.store(object.get(), std::memory_order_release);
+        if (previous && previous.get() != object.get()) {
+            m_retired.push_back(std::move(previous));
+        }
+        collectRetired();
+    }
+
+    std::shared_ptr<T> owner() const { return m_owner.load(std::memory_order_acquire); }
+
+    T* acquireRealtime() noexcept {
+        T* object = nullptr;
+        do {
+            object = m_published.load(std::memory_order_acquire);
+            m_realtimeHazard.store(object, std::memory_order_release);
+        } while (object != m_published.load(std::memory_order_acquire));
+        return object;
+    }
+
+    void releaseRealtime() noexcept { m_realtimeHazard.store(nullptr, std::memory_order_release); }
+
+    void collectRetired() {
+        const T* active = m_published.load(std::memory_order_acquire);
+        const T* inUse = m_realtimeHazard.load(std::memory_order_acquire);
+        m_retired.erase(std::remove_if(m_retired.begin(), m_retired.end(),
+                                       [active, inUse](const auto& object) {
+                                           return object.get() != active && object.get() != inUse;
+                                       }),
+                        m_retired.end());
+    }
+
+private:
+    AtomicSharedPtr<T> m_owner;
+    std::atomic<T*> m_published{nullptr};
+    std::atomic<T*> m_realtimeHazard{nullptr};
+    std::vector<std::shared_ptr<T>> m_retired;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Playback/PreviewEngine.h
+++ b/AestraAudio/include/Playback/PreviewEngine.h
@@ -2,16 +2,17 @@
 #pragma once
 
 #include "../IO/SamplePool.h"
+#include "RealtimeObjectPublisher.h"
 
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <memory>
-#include "AestraAtomicSharedPtr.h"
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace Aestra {
 namespace Audio {
@@ -96,8 +97,10 @@ private:
     void decodeAsync(const std::string& path, std::shared_ptr<PreviewVoice> voice, double maxSeconds);
     PreviewResult startVoiceWithBuffer(std::shared_ptr<AudioBuffer> buffer, const std::string& path, float gainDb,
                                        double maxSeconds);
+    void publishActiveVoice(std::shared_ptr<PreviewVoice> voice);
+    void collectRetiredVoices();
 
-    AtomicSharedPtr<PreviewVoice> m_activeVoice;
+    RealtimeObjectPublisher<PreviewVoice> m_activeVoice;
     std::atomic<double> m_outputSampleRate;
     std::atomic<float> m_globalGainDb;
     std::atomic<float> m_playbackRate{1.0f};

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -79,6 +79,12 @@ void AutosaveManager::initialize(const std::string& projectPath, Config config) 
     m_isDirty = false;
     m_isAutosaving = false;
     m_shouldStop = false;
+    m_enabled.store(m_config.enabled, std::memory_order_release);
+    m_nextSnapshotGeneration.store(1, std::memory_order_release);
+    m_pendingSnapshot.clear();
+    m_pendingSnapshotGeneration = 0;
+    m_lastCommittedGeneration = 0;
+    m_hasPendingSnapshot = false;
     m_lastAutosaveTime = std::chrono::steady_clock::now();
     m_lastDirtyTimeMs.store(steadyNowMs(), std::memory_order_release);
     
@@ -93,7 +99,7 @@ void AutosaveManager::initialize(const std::string& projectPath, Config config) 
     }
     
     // Start background thread if enabled
-    if (m_config.enabled) {
+    if (m_enabled.load(std::memory_order_acquire)) {
         m_autosaveThread = std::make_unique<std::thread>(
             &AutosaveManager::autosaveThreadFunc, this);
         Log::info("AutosaveManager initialized for: " + projectPath);
@@ -121,6 +127,9 @@ void AutosaveManager::shutdown() {
     
     std::lock_guard<std::mutex> lock(m_mutex);
     m_initialized = false;
+    m_pendingSnapshot.clear();
+    m_pendingSnapshotGeneration = 0;
+    m_hasPendingSnapshot = false;
     
     Log::info("AutosaveManager shutdown");
 }
@@ -143,7 +152,7 @@ void AutosaveManager::markClean() {
 }
 
 void AutosaveManager::setEnabled(bool enabled) {
-    m_config.enabled = enabled;
+    m_enabled.store(enabled, std::memory_order_release);
     if (enabled && !m_autosaveThread) {
         // Restart thread if enabling
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -153,6 +162,7 @@ void AutosaveManager::setEnabled(bool enabled) {
                 &AutosaveManager::autosaveThreadFunc, this);
         }
     }
+    m_cv.notify_all();
 }
 
 //==============================================================================
@@ -187,6 +197,48 @@ bool AutosaveManager::autosaveIfDue() {
         return false;
     }
     notifyStatus("Project saved");
+    return true;
+}
+
+bool AutosaveManager::claimDirtyIfDue() {
+    if (!m_isDirty.load(std::memory_order_acquire)) {
+        return false;
+    }
+    const int64_t sinceMs = steadyNowMs() - m_lastDirtyTimeMs.load(std::memory_order_acquire);
+    const int64_t minDelayMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(m_config.minDirtyDelay).count();
+    if (sinceMs < minDelayMs) {
+        return false;
+    }
+    return m_isDirty.exchange(false, std::memory_order_acq_rel);
+}
+
+bool AutosaveManager::captureSnapshotIfDue() {
+    if (!m_config.captureSnapshotOnCallingThread || !m_initialized.load(std::memory_order_acquire) ||
+        !m_enabled.load(std::memory_order_acquire) || !claimDirtyIfDue()) {
+        return false;
+    }
+
+    std::string data;
+    if (!m_config.serializer || !m_config.serializer(data)) {
+        m_isDirty.store(true, std::memory_order_release);
+        notifyError("Autosave failed: serialization error");
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_shouldStop.load(std::memory_order_acquire)) {
+            m_isDirty.store(true, std::memory_order_release);
+            return false;
+        }
+        // Only the latest immutable snapshot matters if the writer has not yet
+        // consumed an older one. Dirty changes made during capture remain set.
+        m_pendingSnapshot = std::move(data);
+        m_pendingSnapshotGeneration = m_nextSnapshotGeneration.fetch_add(1, std::memory_order_acq_rel);
+        m_hasPendingSnapshot = true;
+    }
+    m_cv.notify_all();
     return true;
 }
 
@@ -342,20 +394,58 @@ std::chrono::seconds AutosaveManager::getTimeSinceLastAutosave() const {
 
 void AutosaveManager::autosaveThreadFunc() {
     Log::info("Autosave thread started");
+
+    if (m_config.captureSnapshotOnCallingThread) {
+        while (!m_shouldStop.load(std::memory_order_acquire)) {
+            std::string snapshot;
+            uint64_t snapshotGeneration = 0;
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_cv.wait(lock, [this] {
+                    return m_shouldStop.load(std::memory_order_acquire) ||
+                           (m_enabled.load(std::memory_order_acquire) && m_hasPendingSnapshot);
+                });
+
+                if (m_shouldStop.load(std::memory_order_acquire)) {
+                    break;
+                }
+                if (!m_enabled.load(std::memory_order_acquire) || !m_hasPendingSnapshot) {
+                    continue;
+                }
+
+                snapshot = std::move(m_pendingSnapshot);
+                snapshotGeneration = m_pendingSnapshotGeneration;
+                m_pendingSnapshot.clear();
+                m_pendingSnapshotGeneration = 0;
+                m_hasPendingSnapshot = false;
+            }
+
+            if (performAutosaveWithData(std::move(snapshot), snapshotGeneration)) {
+                notifyStatus("Project saved");
+            } else {
+                // The immutable snapshot could not be committed. Capture a new
+                // current snapshot on the owner thread on the next cycle.
+                m_isDirty.store(true, std::memory_order_release);
+            }
+        }
+
+        Log::info("Autosave thread stopped");
+        return;
+    }
     
     while (!m_shouldStop.load(std::memory_order_acquire)) {
         std::unique_lock<std::mutex> lock(m_mutex);
         
-        auto waitResult = m_cv.wait_for(lock, m_config.autosaveInterval, [this] {
+        m_cv.wait_for(lock, m_config.autosaveInterval, [this] {
             return m_shouldStop.load(std::memory_order_acquire) || 
-                   (m_config.enabled && m_isDirty.load(std::memory_order_acquire));
+                   (m_enabled.load(std::memory_order_acquire) && m_isDirty.load(std::memory_order_acquire));
         });
         
         if (m_shouldStop.load(std::memory_order_acquire)) {
             break;
         }
         
-        if (!m_config.enabled) {
+        if (!m_enabled.load(std::memory_order_acquire)) {
             continue;
         }
         
@@ -391,10 +481,8 @@ void AutosaveManager::autosaveThreadFunc() {
 }
 
 bool AutosaveManager::performAutosave() {
-    bool expected = false;
-    if (!m_isAutosaving.compare_exchange_strong(expected, true)) {
-        return false;
-    }
+    std::lock_guard<std::mutex> commitLock(m_commitMutex);
+    m_isAutosaving.store(true, std::memory_order_release);
 
     struct AutosavingGuard {
         std::atomic<bool>& flag;
@@ -402,28 +490,48 @@ bool AutosaveManager::performAutosave() {
         ~AutosavingGuard() { flag.store(false, std::memory_order_release); }
     } guard(m_isAutosaving);
 
+    if (!m_config.serializer) {
+        notifyError("Autosave failed: no serializer callback");
+        return false;
+    }
+
+    std::string data;
+    if (!m_config.serializer(data)) {
+        notifyError("Autosave failed: serialization error");
+        return false;
+    }
+
+    const uint64_t generation = m_nextSnapshotGeneration.fetch_add(1, std::memory_order_acq_rel);
+    return writeAutosaveData(data, generation);
+}
+
+bool AutosaveManager::performAutosaveWithData(std::string data, uint64_t generation) {
+    std::lock_guard<std::mutex> commitLock(m_commitMutex);
+    m_isAutosaving.store(true, std::memory_order_release);
+
+    struct AutosavingGuard {
+        std::atomic<bool>& flag;
+        explicit AutosavingGuard(std::atomic<bool>& f) : flag(f) {}
+        ~AutosavingGuard() { flag.store(false, std::memory_order_release); }
+    } guard(m_isAutosaving);
+
+    return writeAutosaveData(data, generation);
+}
+
+bool AutosaveManager::writeAutosaveData(const std::string& data, uint64_t generation) {
+    if (generation <= m_lastCommittedGeneration) {
+        return true;
+    }
+
     std::string autosavePath = getAutosavePath();
     if (autosavePath.empty()) {
         notifyError("Autosave failed: no autosave path");
         return false;
     }
 
-    if (!m_config.serializer) {
-        notifyError("Autosave failed: no serializer callback");
-        return false;
-    }
-
     notifyStatus("Autosaving...");
-
     rotateBackups();
-    
-    // Call the serializer callback to get project data
-    std::string data;
-    if (!m_config.serializer(data)) {
-        notifyError("Autosave failed: serialization error");
-        return false;
-    }
-    
+
     // Write atomically
     fs::path target(autosavePath);
     fs::path tmp = target;
@@ -490,6 +598,8 @@ bool AutosaveManager::performAutosave() {
     if (m_config.onAutosaveCommitted) {
         m_config.onAutosaveCommitted(autosavePath);
     }
+
+    m_lastCommittedGeneration = generation;
     
     return true;
 }

--- a/AestraAudio/src/Core/AutosaveManager.cpp
+++ b/AestraAudio/src/Core/AutosaveManager.cpp
@@ -262,6 +262,46 @@ std::string AutosaveManager::getBackupDirectory() const {
     return getBackupDirForProject(m_projectPath);
 }
 
+std::vector<std::string> AutosaveManager::listBackupsForAutosavePath(const std::string& autosavePath) {
+    if (autosavePath.empty()) {
+        return {};
+    }
+
+    const fs::path autosave(autosavePath);
+    const fs::path backupDir = autosave.has_parent_path()
+                                   ? autosave.parent_path() / (autosave.stem().string() + ".autosave")
+                                   : fs::path{};
+    if (backupDir.empty()) {
+        return {};
+    }
+
+    std::error_code ec;
+    if (!fs::is_directory(backupDir, ec) || ec) {
+        return {};
+    }
+
+    std::vector<std::string> backups;
+    for (const auto& entry : fs::directory_iterator(backupDir, ec)) {
+        if (ec) {
+            break;
+        }
+        if (entry.is_regular_file(ec) && !ec && entry.path().extension() == ".aes") {
+            backups.push_back(entry.path().string());
+        }
+    }
+    std::sort(backups.begin(), backups.end(), [](const std::string& a, const std::string& b) {
+        std::error_code aEc;
+        std::error_code bEc;
+        const auto aTime = fs::last_write_time(a, aEc);
+        const auto bTime = fs::last_write_time(b, bEc);
+        if (aEc || bEc || aTime == bTime) {
+            return a > b;
+        }
+        return aTime > bTime;
+    });
+    return backups;
+}
+
 //==============================================================================
 // Recovery (Static)
 //==============================================================================

--- a/AestraAudio/src/IO/AudioExporter.cpp
+++ b/AestraAudio/src/IO/AudioExporter.cpp
@@ -1,6 +1,7 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "AudioExporter.h"
+#include "AudioGraphBuilder.h"
 #include "AestraFile.h"
 #include "AestraLog.h"
 
@@ -201,6 +202,11 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
     // Set engine to export sample rate
     m_engine.setSampleRate(config.sampleRate);
     m_trackManager.setOutputSampleRate(sampleRate);
+    // Clip start/end samples in AudioGraph are derived from timeline beats at
+    // graph-build time. Rebuild after changing the project/output rate or a
+    // 48 -> 96 kHz export retains 48 kHz clip bounds and renders silence over
+    // the second half of every clip.
+    m_engine.setGraph(AudioGraphBuilder::buildFromTrackManager(m_trackManager));
 
     // Offline export should follow the exact live engine path to avoid render-path
     // mismatches between playback and export.
@@ -275,6 +281,7 @@ AudioExporter::Result AudioExporter::render(const Config& config) {
     m_engine.setTransportPlaying(false);
     m_engine.setSampleRate(originalSampleRate);
     m_trackManager.setOutputSampleRate(static_cast<double>(originalSampleRate));
+    m_engine.setGraph(AudioGraphBuilder::buildFromTrackManager(m_trackManager));
     m_engine.setMetronomeEnabled(wasMetronomeEnabled);
     m_engine.setAuditionModeEnabled(wasAuditionEnabled);
     // Restore the configured duck depth only; live playback re-smooths the

--- a/AestraAudio/src/Playback/PreviewEngine.cpp
+++ b/AestraAudio/src/Playback/PreviewEngine.cpp
@@ -37,7 +37,7 @@ double previewDecodeSecondsLimit(double maxSeconds) {
 } // namespace
 
 PreviewEngine::PreviewEngine()
-    : m_activeVoice(nullptr), m_outputSampleRate(48000.0), m_globalGainDb(0.0f), m_decodeGeneration(0),
+    : m_outputSampleRate(48000.0), m_globalGainDb(0.0f), m_decodeGeneration(0),
       m_workerRunning(true) // Initialize running state
 {
     // Start worker thread
@@ -56,6 +56,16 @@ PreviewEngine::~PreviewEngine() {
     if (m_workerThread.joinable()) {
         m_workerThread.join();
     }
+    m_activeVoice.publish(nullptr);
+    m_activeVoice.collectRetired();
+}
+
+void PreviewEngine::publishActiveVoice(std::shared_ptr<PreviewVoice> voice) {
+    m_activeVoice.publish(std::move(voice));
+}
+
+void PreviewEngine::collectRetiredVoices() {
+    m_activeVoice.collectRetired();
 }
 
 float PreviewEngine::dbToLinear(float db) const {
@@ -108,7 +118,7 @@ PreviewResult PreviewEngine::startVoiceWithBuffer(std::shared_ptr<AudioBuffer> b
     voice->bufferReady.store(true, std::memory_order_release);
     voice->playing.store(true, std::memory_order_release);
 
-    m_activeVoice.store(voice, std::memory_order_release);
+    publishActiveVoice(voice);
     Log::info("PreviewEngine: Playing '" + path + "' (" + std::to_string(sampleRate) + " Hz, " +
               std::to_string(voice->durationSeconds) + " sec)");
     return PreviewResult::Success;
@@ -162,7 +172,7 @@ void PreviewEngine::workerLoop() {
         // 4. Update Voice
         auto voice = job.voice;
         // Verify voice is still active (redundant with generation but safe)
-        auto currentVoice = m_activeVoice.load(std::memory_order_acquire);
+        auto currentVoice = m_activeVoice.owner();
         if (currentVoice.get() != voice.get()) {
             voice->playing.store(false, std::memory_order_release);
             continue;
@@ -209,7 +219,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
     voice->playing.store(true, std::memory_order_release);      // Voice is active
 
     // Set as active voice immediately (will output silence until buffer ready)
-    m_activeVoice.store(voice, std::memory_order_release);
+    publishActiveVoice(voice);
 
     // Start async decode (non-blocking)
     decodeAsync(path, voice, maxSeconds);
@@ -219,7 +229,7 @@ PreviewResult PreviewEngine::play(const std::string& path, float gainDb, double 
 }
 
 void PreviewEngine::stop() {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     if (voice) {
         voice->stopRequested.store(true, std::memory_order_release);
         voice->fadeOutActive = true;
@@ -242,7 +252,13 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
         m_lastOutputPeak.store(0.0f, std::memory_order_release);
         return;
     }
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    PreviewVoice* voice = m_activeVoice.acquireRealtime();
+
+    struct VoiceUseGuard {
+        RealtimeObjectPublisher<PreviewVoice>& publisher;
+        ~VoiceUseGuard() { publisher.releaseRealtime(); }
+    } voiceUseGuard{m_activeVoice};
+
     if (!voice || !voice->playing.load(std::memory_order_acquire) || !interleavedOutput) {
         m_lastOutputPeak.store(0.0f, std::memory_order_release);
         return;
@@ -255,7 +271,7 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
         return;
     }
 
-    auto buffer = voice->buffer;
+    const AudioBuffer* buffer = voice->buffer.get();
     if (!buffer || buffer->data.empty() || buffer->sampleRate == 0) {
         m_lastOutputPeak.store(0.0f, std::memory_order_release);
         return;
@@ -576,7 +592,7 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
         voice->playing.store(false, std::memory_order_release);
         blockPreviewPeak = 0.0f;
         PreviewVoice* expected = nullptr;
-        if (m_completedVoice.compare_exchange_strong(expected, voice.get(), std::memory_order_acq_rel,
+        if (m_completedVoice.compare_exchange_strong(expected, voice, std::memory_order_acq_rel,
                                                      std::memory_order_relaxed)) {
             m_completionPending.store(true, std::memory_order_release);
         }
@@ -588,13 +604,13 @@ void PreviewEngine::processRealtime(float* interleavedOutput, uint32_t numFrames
 }
 
 bool PreviewEngine::isPlaying() const {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     return voice && voice->playing.load(std::memory_order_acquire);
 }
 
 bool PreviewEngine::isAudiblyPlaying() const {
     constexpr float kAudiblePreviewThreshold = 1.0e-5f;
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     return voice && voice->playing.load(std::memory_order_acquire) &&
            !voice->stopRequested.load(std::memory_order_acquire) &&
            voice->bufferReady.load(std::memory_order_acquire) &&
@@ -602,7 +618,7 @@ bool PreviewEngine::isAudiblyPlaying() const {
 }
 
 bool PreviewEngine::isBufferReady() const {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     return voice && voice->bufferReady.load(std::memory_order_acquire);
 }
 
@@ -619,26 +635,27 @@ float PreviewEngine::getGlobalPreviewVolume() const {
 }
 
 void PreviewEngine::seek(double seconds) {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     if (voice) {
         voice->seekRequestSeconds.store(seconds, std::memory_order_release);
     }
 }
 
 double PreviewEngine::getPlaybackPosition() const {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     return voice ? voice->elapsedSeconds : 0.0;
 }
 
 double PreviewEngine::getDuration() const {
-    auto voice = m_activeVoice.load(std::memory_order_acquire);
+    auto voice = m_activeVoice.owner();
     return voice ? voice->durationSeconds : 0.0;
 }
 
 void PreviewEngine::handleDeferredCompletion() {
+    collectRetiredVoices();
     if (m_completionPending.exchange(false, std::memory_order_acq_rel)) {
         PreviewVoice* completed = m_completedVoice.exchange(nullptr, std::memory_order_acq_rel);
-        auto voice = m_activeVoice.load(std::memory_order_acquire);
+        auto voice = m_activeVoice.owner();
         if (!completed || !voice || voice.get() != completed) {
             return;
         }
@@ -650,9 +667,7 @@ void PreviewEngine::handleDeferredCompletion() {
             path = m_completedPathStr;
         }
 
-        std::shared_ptr<PreviewVoice> expected = voice;
-        m_activeVoice.compare_exchange_strong(expected, std::shared_ptr<PreviewVoice>(),
-                                                     std::memory_order_acq_rel, std::memory_order_relaxed);
+        publishActiveVoice(nullptr);
 
         if (!path.empty() && m_onComplete) {
             m_onComplete(path);

--- a/AestraCore/include/AestraJSON.h
+++ b/AestraCore/include/AestraJSON.h
@@ -160,6 +160,21 @@ public:
         return parseValue(jsonString, pos, 0);
     }
 
+    // Parse exactly one JSON value and reject any non-whitespace suffix. Keep
+    // parse() for compatibility with non-file call sites that historically
+    // accepted a prefix value.
+    static JSON parseStrict(const std::string& jsonString, bool& consumedAllInput) {
+        consumedAllInput = false;
+        if (exceedsMaxDepth(jsonString)) {
+            return JSON();
+        }
+        size_t pos = 0;
+        JSON value = parseValue(jsonString, pos, 0);
+        skipWhitespace(jsonString, pos);
+        consumedAllInput = pos == jsonString.size();
+        return value;
+    }
+
 private:
     Type type_;
     bool boolValue_ = false;

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1318,6 +1318,10 @@ ProjectSerializer::LoadResult AestraApp::applyLoadedProject(const std::string& p
         m_documentState.restoreSnapshot(path, resolvedCanonicalPath);
         break;
     }
+    if (result.integrity == ProjectSerializer::LoadIntegrity::Mismatch) {
+        m_documentState.protectCanonicalFromOverwrite();
+    }
+
     if (m_audioController && m_audioController->getEngine()) {
         auto* engine = m_audioController->getEngine();
         engine->setTransportPlaying(false);

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -82,7 +82,7 @@ AestraApp::AestraApp()
     Log::init(m_asyncLogger);
     Log::info("Logging initialized to console and " + logPath);
 
-    // Note: m_projectPath initialized lazily in initialize() after Platform is ready
+    // Project document paths are initialized lazily after Platform is ready.
     m_windowManager = std::make_unique<AestraWindowManager>();
     m_audioController = std::make_unique<AestraAudioController>();
 }
@@ -159,7 +159,8 @@ std::string AestraApp::readCrashFlagToken() {
     return token;
 }
 
-void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) const {
+void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath,
+                                               const std::string& canonicalProjectPath) const {
     if (m_recoverySessionToken.empty()) {
         return;
     }
@@ -170,6 +171,24 @@ void AestraApp::writeRecoveryMarkerForAutosave(const std::string& autosavePath) 
         return;
     }
     out << m_recoverySessionToken << "\n";
+    out << canonicalProjectPath << "\n";
+}
+
+std::string AestraApp::readRecoveryOriginalProjectPath(const std::string& recoveryMarkerPath,
+                                                       const std::string& expectedSessionToken) {
+    if (expectedSessionToken.empty()) {
+        return {};
+    }
+
+    std::ifstream marker(recoveryMarkerPath, std::ios::binary);
+    std::string markerToken;
+    if (!std::getline(marker, markerToken) || markerToken != expectedSessionToken) {
+        return {};
+    }
+
+    std::string originalProjectPath;
+    std::getline(marker, originalProjectPath);
+    return originalProjectPath;
 }
 
 bool AestraApp::initialize(const std::string& projectPath) {
@@ -191,8 +210,8 @@ bool AestraApp::initialize(const std::string& projectPath) {
         }
     }
 
-    // Initialize m_projectPath AFTER Platform is initialized
-    m_projectPath = getAutosavePath();
+    // An app-data autosave is recovery state, never an implicit canonical project.
+    m_documentState.startUntitled(getAutosavePath());
 
     // ALWAYS write crash flag at session start. It is cleared only on clean
     // shutdown. If the app crashes at any point, the flag persists and the
@@ -301,7 +320,7 @@ void AestraApp::initializeContent() {
         m_content->setAudioEngine(m_audioController->getEngine());
     }
     m_content->setMidiInput(m_audioController->getMidiInput());
-    syncRecordingProjectPath(m_content, m_projectPath);
+    syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
 
     m_windowManager->setContent(m_content);
     m_audioController->setContent(m_content);
@@ -323,9 +342,11 @@ void AestraApp::initializeAutosave(bool enabled) {
     Aestra::Audio::AutosaveManager::Config config;
     config.enabled = enabled;
     config.autosaveInterval = std::chrono::seconds(60);
-    config.autosavePathOverride = getAutosavePath();
-    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
-        writeRecoveryMarkerForAutosave(autosavePath);
+    config.captureSnapshotOnCallingThread = true;
+    config.autosavePathOverride = m_documentState.autosavePath();
+    const std::string canonicalProjectPath = m_documentState.canonicalPath();
+    config.onAutosaveCommitted = [this, canonicalProjectPath](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath, canonicalProjectPath);
     };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
@@ -338,7 +359,7 @@ void AestraApp::initializeAutosave(bool enabled) {
         outData = std::move(ser.contents);
         return true;
     };
-    m_autoSaveManager.initialize(m_projectPath, std::move(config));
+    m_autoSaveManager.initialize(m_documentState.canonicalPath(), std::move(config));
 }
 
 void AestraApp::buildRecoveryDialog() {
@@ -406,10 +427,11 @@ void AestraApp::buildMenuBar() {
         menu->addItem("New Project", [this]() {
             if (m_content && m_content->getTrackManager()) m_content->getTrackManager()->stop();
             if (m_content) m_content->resetToDefaultProject();
-            m_projectPath = getAutosavePath();
+            m_documentState.startUntitled(getAutosavePath());
             reinitAutosaveManager();
-            syncRecordingProjectPath(m_content, m_projectPath);
+            syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
             m_lastWindowTitle.clear();
+            updateWindowTitle();
             Log::info("New project created");
         });
 
@@ -431,24 +453,7 @@ void AestraApp::buildMenuBar() {
 
         menu->addItem("Save", [this]() { saveCurrentProject(); });
 
-        menu->addItem("Save As...", [this]() {
-            if (auto* utils = Aestra::Platform::getUtils()) {
-                Aestra::IPlatformUtils::SaveFileDialogOptions options;
-                options.title = "Save Project As";
-                options.filter = std::string("Aestra Project\0*.aes\0All Files\0*.*\0",
-                                             sizeof("Aestra Project\0*.aes\0All Files\0*.*\0") - 1);
-                options.defaultPath = m_projectPath.empty() ? getAutosavePath() : m_projectPath;
-                options.defaultExtension = "aes";
-                const std::string pickedPath = utils->saveFileDialog(options);
-                if (!pickedPath.empty()) {
-                    m_projectPath = pickedPath;
-                    reinitAutosaveManager();
-                    if (saveProject()) {
-                        Log::info("Project saved as: " + pickedPath);
-                    }
-                }
-            }
-        });
+        menu->addItem("Save As...", [this]() { saveProjectAs(); });
 
         menu->addSeparator();
 
@@ -598,49 +603,60 @@ void AestraApp::initializePlugins() {
 }
 
 void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashedSession) {
-    if (!projectPath.empty() && std::filesystem::exists(projectPath)) {
-        const std::string previousProjectPath = m_projectPath;
-        m_projectPath = projectPath;
-        auto result = loadProject();
-        if (result.ok) {
-            reinitAutosaveManager();
-            syncRecordingProjectPath(m_content, m_projectPath);
-            if (result.ui) applyUIState(*result.ui);
-        } else {
-            m_projectPath = previousProjectPath;
+    const bool hasRequestedProject = !projectPath.empty() && std::filesystem::exists(projectPath);
+    const std::string autosavePath = m_documentState.autosavePath();
+    std::string timestamp;
+    const std::string recoveryMarkerPath = getRecoveryMarkerPath(autosavePath);
+    std::vector<std::string> recoveryCandidates;
+    const bool primaryAutosaveDetected =
+        crashedSession && !m_previousRecoverySessionToken.empty() &&
+        RecoveryDialog::detectAutosave(autosavePath, recoveryMarkerPath, m_previousRecoverySessionToken, timestamp);
+    if (primaryAutosaveDetected) {
+        recoveryCandidates.push_back(autosavePath);
+    }
+    if (crashedSession && !m_previousRecoverySessionToken.empty()) {
+        for (auto& backup : Aestra::Audio::AutosaveManager::listBackupsForAutosavePath(autosavePath)) {
+            recoveryCandidates.push_back(std::move(backup));
         }
-        return;
     }
 
-    std::string autosavePath = getAutosavePath();
-    std::string timestamp;
-
-    const std::string recoveryMarkerPath = getRecoveryMarkerPath(autosavePath);
-
-    if (crashedSession && !m_previousRecoverySessionToken.empty() &&
-        RecoveryDialog::detectAutosave(autosavePath, recoveryMarkerPath, m_previousRecoverySessionToken, timestamp)) {
+    if (!recoveryCandidates.empty()) {
+        const std::string recoveryDisplayPath = recoveryCandidates.front();
         Log::info("[Recovery] Crash detected, showing recovery dialog");
-        m_pendingAutosavePath = autosavePath;
+        m_pendingAutosavePath = recoveryDisplayPath;
         m_recoveryHandled = false;
 
         if (auto recoveryDialog = m_windowManager->getRecoveryDialog()) {
             auto alive = m_aliveToken;
-            recoveryDialog->show(autosavePath, [this, alive, autosavePath](Aestra::RecoveryResponse response) {
-                if (!*alive) return;
+            const std::string originalProjectPath =
+                readRecoveryOriginalProjectPath(recoveryMarkerPath, m_previousRecoverySessionToken);
+            recoveryDialog->show(recoveryDisplayPath,
+                                 [this, alive, autosavePath, projectPath, hasRequestedProject, originalProjectPath,
+                                  recoveryCandidates](Aestra::RecoveryResponse response) {
+                if (!*alive)
+                    return;
                 m_recoveryHandled = true;
+                m_pendingAutosavePath.clear();
                 if (response == Aestra::RecoveryResponse::Recover) {
-                    const std::string previousProjectPath = m_projectPath;
-                    m_projectPath = autosavePath;
-                    auto result = loadProject();
+                    auto selected = ProjectSerializer::loadFirstValid(
+                        recoveryCandidates, m_content ? m_content->getTrackManager() : nullptr, originalProjectPath);
+                    auto result = std::move(selected.result);
                     if (result.ok) {
-                        reinitAutosaveManager();
-                        syncRecordingProjectPath(m_content, m_projectPath);
-                        if (result.ui) applyUIState(*result.ui);
-                        Log::info("[Recovery] Autosave recovered successfully");
+                        result = applyLoadedProject(selected.loadedPath, ProjectLoadSource::Recovery,
+                                                    originalProjectPath, std::move(result));
+                        if (m_content && m_content->getTrackManager()) {
+                            m_content->getTrackManager()->markModified();
+                        }
+                        m_autoSaveManager.markDirty();
+                        updateWindowTitle();
+                        Log::info("[Recovery] Autosave recovered successfully from: " + selected.loadedPath);
                     } else {
-                        m_projectPath = previousProjectPath;
                         Log::error("[Recovery] Failed to load autosave");
-                        if (m_content) m_content->resetToDefaultProject();
+                        if (m_content)
+                            m_content->resetToDefaultProject();
+                        m_documentState.startUntitled(getAutosavePath());
+                        reinitAutosaveManager();
+                        syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
                     }
                 } else if (response == Aestra::RecoveryResponse::Discard) {
                     std::error_code ec;
@@ -651,10 +667,19 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
                     } else {
                         Log::info("[Recovery] Autosave discarded");
                     }
-                    if (m_content) m_content->resetToDefaultProject();
-                    m_projectPath = getAutosavePath();
-                    reinitAutosaveManager();
-                    syncRecordingProjectPath(m_content, m_projectPath);
+                    if (hasRequestedProject) {
+                        auto result = loadProjectFromPath(projectPath);
+                        if (!result.ok) {
+                            Log::error("Failed to load requested project after discarding recovery: " + projectPath);
+                        }
+                    } else {
+                        if (m_content)
+                            m_content->resetToDefaultProject();
+                        m_documentState.startUntitled(getAutosavePath());
+                        reinitAutosaveManager();
+                        syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
+                        updateWindowTitle();
+                    }
                 }
             });
             Log::info("[Recovery] Showing recovery dialog for autosave");
@@ -664,9 +689,19 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
             std::filesystem::remove(autosavePath, ec);
             std::filesystem::remove(recoveryMarkerPath, ec);
             m_recoveryHandled = true;
+            if (hasRequestedProject) {
+                loadProjectFromPath(projectPath);
+            }
         }
-    } else {
-        m_recoveryHandled = true;
+        return;
+    }
+
+    m_recoveryHandled = true;
+    if (hasRequestedProject) {
+        auto result = loadProjectFromPath(projectPath);
+        if (!result.ok) {
+            Log::error("Failed to load requested project: " + projectPath + " (" + result.errorMessage + ")");
+        }
     }
 }
 
@@ -924,8 +959,10 @@ void AestraApp::run() {
             m_windowManager->render();
         }
 
-        // Autosave is handled entirely by AutosaveManager's background thread,
-        // triggered via markDirty() from TrackManager::setOnModified().
+        // Capture the mutable project graph only on its owning application
+        // thread. AutosaveManager commits the resulting immutable string on its
+        // worker, so active edits never race ProjectSerializer traversal.
+        m_autoSaveManager.captureSnapshotIfDue();
 
         // Non-realtime audio work (graph rebuilds, plugin state commits) should
         // happen before frame pacing so it doesn't eat into the sleep budget.
@@ -1187,7 +1224,7 @@ void AestraApp::requestClose() {
                  [this](Aestra::DialogResponse response) {
                      switch (response) {
                      case Aestra::DialogResponse::Save:
-                         if (saveProject()) {
+                         if (saveCurrentProject()) {
                              m_running = false;
                          } else {
                              m_pendingClose = false;
@@ -1213,27 +1250,74 @@ void AestraApp::requestClose() {
                  });
 }
 
-void AestraApp::saveCurrentProject() {
-    saveProject();
+bool AestraApp::saveCurrentProject() {
+    return m_documentState.requiresSaveAs() ? saveProjectAs() : saveProject();
 }
 
-ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& path, const std::string& activeProjectPathOverride) {
+bool AestraApp::saveProjectAs() {
+    auto* utils = Aestra::Platform::getUtils();
+    if (!utils) {
+        Log::warning("Cannot save project: platform file dialog is unavailable");
+        return false;
+    }
+
+    Aestra::IPlatformUtils::SaveFileDialogOptions options;
+    options.title = "Save Project As";
+    options.filter =
+        std::string("Aestra Project\0*.aes\0All Files\0*.*\0", sizeof("Aestra Project\0*.aes\0All Files\0*.*\0") - 1);
+    options.defaultPath = m_documentState.canonicalPath();
+    options.defaultExtension = "aes";
+    const std::string pickedPath = utils->saveFileDialog(options);
+    if (pickedPath.empty()) {
+        return false;
+    }
+
+    const bool ok = saveProjectToPath(pickedPath, true);
+    if (ok) {
+        Log::info("Project saved as: " + pickedPath);
+    }
+    return ok;
+}
+
+ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& path, ProjectLoadSource source,
+                                                             const std::string& canonicalPath) {
     ProjectSerializer::LoadResult result;
     if (path.empty()) {
         result.errorMessage = "Project path is empty";
         return result;
     }
 
-    const std::string previousProjectPath = m_projectPath;
-    m_projectPath = activeProjectPathOverride.empty() ? path : activeProjectPathOverride;
-
-    result = ProjectSerializer::load(path, m_content ? m_content->getTrackManager() : nullptr);
+    const std::string assetBasePath =
+        source == ProjectLoadSource::Canonical || canonicalPath.empty() ? path : canonicalPath;
+    result = ProjectSerializer::load(path, m_content ? m_content->getTrackManager() : nullptr, assetBasePath);
     if (!result.ok) {
-        m_projectPath = previousProjectPath;
         Log::error("Failed to load project: " + path + " (" + result.errorMessage + ")");
         return result;
     }
 
+    return applyLoadedProject(path, source, canonicalPath, std::move(result));
+}
+
+ProjectSerializer::LoadResult AestraApp::applyLoadedProject(const std::string& path, ProjectLoadSource source,
+                                                            const std::string& canonicalPath,
+                                                            ProjectSerializer::LoadResult result) {
+
+    // Snapshot callers may pass the current canonical path by reference.
+    // Resolve it before mutating the document state.
+    const std::string resolvedCanonicalPath =
+        canonicalPath.empty() ? m_documentState.canonicalPath() : canonicalPath;
+
+    switch (source) {
+    case ProjectLoadSource::Canonical:
+        m_documentState.openCanonical(path);
+        break;
+    case ProjectLoadSource::Recovery:
+        m_documentState.recoverFrom(path, resolvedCanonicalPath);
+        break;
+    case ProjectLoadSource::Snapshot:
+        m_documentState.restoreSnapshot(path, resolvedCanonicalPath);
+        break;
+    }
     if (m_audioController && m_audioController->getEngine()) {
         auto* engine = m_audioController->getEngine();
         engine->setTransportPlaying(false);
@@ -1277,7 +1361,7 @@ ProjectSerializer::LoadResult AestraApp::loadProjectFromPath(const std::string& 
         }
     }
 
-    syncRecordingProjectPath(m_content, m_projectPath);
+    syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
     reinitAutosaveManager();
     if (result.ui) {
         applyUIState(*result.ui);
@@ -1302,19 +1386,20 @@ ProjectSerializer::LoadResult AestraApp::loadProject() {
         return result;
     }
 
-    if (m_projectPath.empty()) {
+    if (m_documentState.canonicalPath().empty()) {
         result.errorMessage = "Project path is empty";
         return result;
     }
 
-    return loadProjectFromPath(m_projectPath);
+    return loadProjectFromPath(m_documentState.canonicalPath());
 }
 
 bool AestraApp::saveProject() {
-    if (m_projectPath.empty()) {
-        m_projectPath = getAutosavePath();
+    if (m_documentState.requiresSaveAs()) {
+        Log::warning("Cannot use Save without a canonical project path");
+        return false;
     }
-    return saveProjectToPath(m_projectPath);
+    return saveProjectToPath(m_documentState.canonicalPath());
 }
 
 ProjectSerializer::SerializeResult AestraApp::serializeCurrentProject(int indentSpaces,
@@ -1332,7 +1417,7 @@ ProjectSerializer::SerializeResult AestraApp::serializeCurrentProject(int indent
     return ProjectSerializer::serialize(m_content->getTrackManager(), tempo, playhead, indentSpaces, uiState);
 }
 
-bool AestraApp::saveProjectToPath(const std::string& path) {
+bool AestraApp::saveProjectToPath(const std::string& path, bool establishCanonical) {
     if (!m_content || !m_content->getTrackManager()) {
         Log::warning("Cannot save project without an active TrackManager");
         return false;
@@ -1354,11 +1439,17 @@ bool AestraApp::saveProjectToPath(const std::string& path) {
                                             tempo,
                                             playhead,
                                             &uiState);
-    if (ok && path == m_projectPath) {
+    if (ok && establishCanonical) {
+        m_documentState.adoptCanonical(path);
+        reinitAutosaveManager();
+    }
+
+    if (ok && path == m_documentState.canonicalPath()) {
+        m_documentState.adoptCanonical(path);
         if (saveActiveTakeSnapshot(&uiState)) {
             m_content->getTrackManager()->setModified(false);
             m_autoSaveManager.markClean();
-            syncRecordingProjectPath(m_content, m_projectPath);
+            syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
             updateWindowTitle();
         } else {
             Log::warning("[Takes] Project saved but take snapshot failed, keeping dirty state");
@@ -1375,7 +1466,7 @@ bool AestraApp::saveProjectToPath(const std::string& path) {
 }
 
 bool AestraApp::saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState) {
-    if (m_projectPath.empty() || !m_content || !m_content->getTrackManager()) {
+    if (m_documentState.canonicalPath().empty() || !m_content || !m_content->getTrackManager()) {
         return false;
     }
 
@@ -1392,7 +1483,7 @@ bool AestraApp::saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState
         return false;
     }
 
-    auto result = TakeManager::saveActiveTake(m_projectPath, ser.contents);
+    auto result = TakeManager::saveActiveTake(m_documentState.canonicalPath(), ser.contents);
     if (!result.ok) {
         Log::warning("[Takes] Could not save active Take: " + result.errorMessage);
         return false;
@@ -1401,7 +1492,7 @@ bool AestraApp::saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState
 }
 
 bool AestraApp::createTakeFromCurrentProject() {
-    if (m_projectPath.empty() || !m_content || !m_content->getTrackManager()) {
+    if (m_documentState.canonicalPath().empty() || !m_content || !m_content->getTrackManager()) {
         return false;
     }
 
@@ -1416,9 +1507,9 @@ bool AestraApp::createTakeFromCurrentProject() {
         return false;
     }
 
-    const auto manifest = TakeManager::loadManifest(m_projectPath);
+    const auto manifest = TakeManager::loadManifest(m_documentState.canonicalPath());
     const std::string takeName = "Take " + std::to_string(manifest.ok ? manifest.takes.size() + 1 : 2);
-    auto result = TakeManager::createTake(m_projectPath, ser.contents, takeName);
+    auto result = TakeManager::createTake(m_documentState.canonicalPath(), ser.contents, takeName);
     if (!result.ok) {
         Log::warning("[Takes] Could not create Take: " + result.errorMessage);
         return false;
@@ -1434,7 +1525,7 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
         result.errorMessage = "Take id is empty";
         return result;
     }
-    if (m_projectPath.empty()) {
+    if (m_documentState.canonicalPath().empty()) {
         result.errorMessage = "Project path is empty";
         return result;
     }
@@ -1444,7 +1535,7 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
         return result;
     }
 
-    const auto manifest = TakeManager::loadManifest(m_projectPath);
+    const auto manifest = TakeManager::loadManifest(m_documentState.canonicalPath());
     if (!manifest.ok) {
         result.errorMessage = manifest.errorMessage;
         return result;
@@ -1456,20 +1547,20 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
         return result;
     }
 
-    const std::string snapshotPath = TakeManager::resolveSnapshotPath(m_projectPath, *take);
+    const std::string snapshotPath = TakeManager::resolveSnapshotPath(m_documentState.canonicalPath(), *take);
     if (snapshotPath.empty() || !std::filesystem::exists(snapshotPath)) {
         result.errorMessage = "Take snapshot is missing: " + snapshotPath;
         return result;
     }
 
-    result = loadProjectFromPath(snapshotPath, m_projectPath);
+    result = loadProjectFromPath(snapshotPath, ProjectLoadSource::Snapshot, m_documentState.canonicalPath());
     if (!result.ok) {
         return result;
     }
 
-    auto activeResult = TakeManager::setActiveTake(m_projectPath, takeId);
+    auto activeResult = TakeManager::setActiveTake(m_documentState.canonicalPath(), takeId);
     if (!activeResult.ok) {
-        auto rollback = loadProjectFromPath(m_projectPath, m_projectPath);
+        auto rollback = loadProjectFromPath(m_documentState.canonicalPath());
         if (!rollback.ok) {
             Log::error("[Takes] CRITICAL: Failed to rollback after failed Take switch: " + rollback.errorMessage);
         }
@@ -1479,7 +1570,7 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
     }
 
     if (!saveProject()) {
-        auto rollback = loadProjectFromPath(m_projectPath, m_projectPath);
+        auto rollback = loadProjectFromPath(m_documentState.canonicalPath());
         if (!rollback.ok) {
             Log::error("[Takes] CRITICAL: Failed to rollback after failed mirror save: " + rollback.errorMessage);
         }
@@ -1493,7 +1584,7 @@ ProjectSerializer::LoadResult AestraApp::switchToTake(const std::string& takeId)
 }
 
 bool AestraApp::branchFromTake(const std::string& takeId) {
-    if (m_projectPath.empty() || takeId.empty()) {
+    if (m_documentState.canonicalPath().empty() || takeId.empty()) {
         return false;
     }
 
@@ -1503,11 +1594,11 @@ bool AestraApp::branchFromTake(const std::string& takeId) {
         return false;
     }
 
-    const auto manifest = TakeManager::loadManifest(m_projectPath);
+    const auto manifest = TakeManager::loadManifest(m_documentState.canonicalPath());
     const auto* source = manifest.ok ? manifest.findTake(takeId) : nullptr;
     const std::string branchName = source ? (source->name + " Branch") : "";
 
-    auto dup = TakeManager::duplicateTake(m_projectPath, takeId, branchName);
+    auto dup = TakeManager::duplicateTake(m_documentState.canonicalPath(), takeId, branchName);
     if (!dup.ok) {
         Log::warning("[Takes] Could not branch from Take: " + dup.errorMessage);
         return false;
@@ -1517,7 +1608,7 @@ bool AestraApp::branchFromTake(const std::string& takeId) {
     if (!result.ok) {
         // Don't leave a half-made branch behind: the duplicate is not active
         // (the failed switch rolled back), so it can be deleted safely.
-        auto rollback = TakeManager::deleteTake(m_projectPath, dup.take.id);
+        auto rollback = TakeManager::deleteTake(m_documentState.canonicalPath(), dup.take.id);
         Log::error("[Takes] Branch created but could not switch to it: " + result.errorMessage +
                    (rollback.ok ? " (branch rolled back)" : " (rollback also failed: " + rollback.errorMessage + ")"));
         return false;
@@ -1535,20 +1626,20 @@ void AestraApp::wireTakesPanel() {
     }
 
     takesPanel->setTakesProvider([this]() -> TakeManager::Manifest {
-        if (m_projectPath.empty()) {
+        if (m_documentState.canonicalPath().empty()) {
             TakeManager::Manifest manifest;
             manifest.errorMessage = "No Takes manifest";
             return manifest;
         }
-        return TakeManager::loadManifest(m_projectPath);
+        return TakeManager::loadManifest(m_documentState.canonicalPath());
     });
 
     takesPanel->setSnapshotsProvider([this]() {
         std::vector<Aestra::Audio::TakesPanel::SnapshotEntry> entries;
-        if (m_projectPath.empty()) {
+        if (m_documentState.canonicalPath().empty()) {
             return entries;
         }
-        for (const auto& entry : ProjectSerializer::listHistory(m_projectPath)) {
+        for (const auto& entry : ProjectSerializer::listHistory(m_documentState.canonicalPath())) {
             entries.push_back({entry.path, entry.label});
         }
         return entries;
@@ -1566,10 +1657,10 @@ void AestraApp::wireTakesPanel() {
     });
 
     takesPanel->setOnRenameTake([this](const std::string& takeId, const std::string& name) {
-        if (m_projectPath.empty()) {
+        if (m_documentState.canonicalPath().empty()) {
             return false;
         }
-        auto result = TakeManager::renameTake(m_projectPath, takeId, name);
+        auto result = TakeManager::renameTake(m_documentState.canonicalPath(), takeId, name);
         if (!result.ok) {
             Log::warning("[Takes] Could not rename Take: " + result.errorMessage);
         }
@@ -1577,10 +1668,10 @@ void AestraApp::wireTakesPanel() {
     });
 
     takesPanel->setOnDuplicateTake([this](const std::string& takeId) {
-        if (m_projectPath.empty()) {
+        if (m_documentState.canonicalPath().empty()) {
             return false;
         }
-        auto result = TakeManager::duplicateTake(m_projectPath, takeId);
+        auto result = TakeManager::duplicateTake(m_documentState.canonicalPath(), takeId);
         if (!result.ok) {
             Log::warning("[Takes] Could not duplicate Take: " + result.errorMessage);
         }
@@ -1588,10 +1679,10 @@ void AestraApp::wireTakesPanel() {
     });
 
     takesPanel->setOnDeleteTake([this](const std::string& takeId) {
-        if (m_projectPath.empty()) {
+        if (m_documentState.canonicalPath().empty()) {
             return false;
         }
-        auto result = TakeManager::deleteTake(m_projectPath, takeId);
+        auto result = TakeManager::deleteTake(m_documentState.canonicalPath(), takeId);
         if (!result.ok) {
             Log::warning("[Takes] Could not delete Take: " + result.errorMessage);
         }
@@ -1607,7 +1698,7 @@ void AestraApp::wireTakesPanel() {
             Log::warning("[Takes] Could not save the current Take before restoring a snapshot");
             return false;
         }
-        auto result = loadProjectFromPath(path, m_projectPath);
+        auto result = loadProjectFromPath(path, ProjectLoadSource::Snapshot, m_documentState.canonicalPath());
         if (!result.ok) {
             Log::error("Failed to restore snapshot: " + path + " (" + result.errorMessage + ")");
             return false;
@@ -1625,9 +1716,11 @@ void AestraApp::reinitAutosaveManager() {
     Aestra::Audio::AutosaveManager::Config config;
     config.enabled = m_autoSaveManager.isEnabled();
     config.autosaveInterval = std::chrono::seconds(60);
-    config.autosavePathOverride = getAutosavePath();
-    config.onAutosaveCommitted = [this](const std::string& autosavePath) {
-        writeRecoveryMarkerForAutosave(autosavePath);
+    config.captureSnapshotOnCallingThread = true;
+    config.autosavePathOverride = m_documentState.autosavePath();
+    const std::string canonicalProjectPath = m_documentState.canonicalPath();
+    config.onAutosaveCommitted = [this, canonicalProjectPath](const std::string& autosavePath) {
+        writeRecoveryMarkerForAutosave(autosavePath, canonicalProjectPath);
     };
     config.serializer = [this](std::string& outData) -> bool {
         if (!m_content || !m_content->getTrackManager()) return false;
@@ -1640,7 +1733,7 @@ void AestraApp::reinitAutosaveManager() {
         outData = std::move(ser.contents);
         return true;
     };
-    m_autoSaveManager.initialize(m_projectPath, std::move(config));
+    m_autoSaveManager.initialize(m_documentState.canonicalPath(), std::move(config));
 }
 
 ProjectSerializer::UIState AestraApp::captureUIState() const {
@@ -1674,10 +1767,7 @@ void AestraApp::applyUIState(const ProjectSerializer::UIState& state) {
 }
 
 void AestraApp::updateWindowTitle() {
-    // Logic moved here or delegated to WindowManager::setWindowTitle
-    std::string title = "Aestra";
-    if (m_projectPath.size()) title = m_projectPath + " - Aestra";
-    m_windowManager->setWindowTitle(title);
+    m_windowManager->setWindowTitle(m_documentState.windowTitle());
 }
 
 void AestraApp::startExport() {
@@ -1694,6 +1784,6 @@ void AestraApp::startExport() {
     auto& trackMgr = *m_content->getTrackManager();
     auto exportDialog = m_windowManager->getExportDialog();
     if (exportDialog) {
-        exportDialog->show(m_projectPath, *engine, trackMgr);
+        exportDialog->show(m_documentState.canonicalPath(), *engine, trackMgr);
     }
 }

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -7,10 +7,10 @@
 #include "AestraContent.h"
 #include "AestraWindowManager.h"
 #include "AutosaveManager.h"
-#include "ProjectSerializer.h"
-
 #include "Commands/MuseService.h"
 #include "Commands/MuseSocketServer.h"
+#include "ProjectDocumentState.h"
+#include "ProjectSerializer.h"
 
 #include <chrono>
 #include <filesystem>
@@ -19,7 +19,7 @@
 
 /**
  * @brief Main application class
- * 
+ *
  * Manages the lifecycle of all AESTRA subsystems and the main event loop.
  * Refactored to delegate to AestraWindowManager and AestraAudioController.
  */
@@ -48,7 +48,9 @@ public:
      * @brief Access content manager (needed for audio callbacks)
      */
     std::shared_ptr<AestraContent> getAestraContent() const { return m_content; }
-    Aestra::Audio::AudioEngine* getAudioEngine() const { return m_audioController ? m_audioController->getEngine() : nullptr; }
+    Aestra::Audio::AudioEngine* getAudioEngine() const {
+        return m_audioController ? m_audioController->getEngine() : nullptr;
+    }
 
     // Helpers exposed for easier refactoring
     static std::string getAppDataPath();
@@ -60,19 +62,21 @@ public:
     static bool isCrashedSession();
 
 private:
+    enum class ProjectLoadSource { Canonical, Recovery, Snapshot };
+
     // Initialization helpers (extracted from initialize() for readability)
     bool transitionToInitializing();
     bool initializePlatformAndWindow(const Aestra::UIState& uiState);
     bool initializeAudio();
     void initializeContent();
     void initializeAutosave(bool enabled);
-    void buildRecoveryDialog();              // lightweight — needed during startup
+    void buildRecoveryDialog(); // lightweight — needed during startup
     // Idle frame elision (labs/perf/idle-frame-elision-spec.md)
     bool shouldRenderThisFrame();
     std::chrono::steady_clock::time_point m_lastPresentedFrame{};
 
-    void buildSettingsAndDialogs();          // heavy — deferred until first open
-    void ensureSettingsAndDialogs();         // lazy guard
+    void buildSettingsAndDialogs();  // heavy — deferred until first open
+    void ensureSettingsAndDialogs(); // lazy guard
     void buildMenuBar();
     void initializePlugins();
     void loadOrRecoverProject(const std::string& projectPath, bool crashedSession);
@@ -86,13 +90,20 @@ private:
 
     // Project management
     void requestClose();
-    void saveCurrentProject();
-    ProjectSerializer::LoadResult loadProjectFromPath(const std::string& path, const std::string& activeProjectPathOverride = "");
+    bool saveCurrentProject();
+    bool saveProjectAs();
+    ProjectSerializer::LoadResult loadProjectFromPath(const std::string& path,
+                                                      ProjectLoadSource source = ProjectLoadSource::Canonical,
+                                                      const std::string& canonicalPath = "");
+    ProjectSerializer::LoadResult applyLoadedProject(const std::string& path,
+                                                     ProjectLoadSource source,
+                                                     const std::string& canonicalPath,
+                                                     ProjectSerializer::LoadResult result);
     ProjectSerializer::LoadResult loadProject();
     bool saveProject();
-    bool saveProjectToPath(const std::string& path);
-    ProjectSerializer::SerializeResult serializeCurrentProject(int indentSpaces,
-                                                               const ProjectSerializer::UIState* uiState = nullptr) const;
+    bool saveProjectToPath(const std::string& path, bool establishCanonical = false);
+    ProjectSerializer::SerializeResult
+    serializeCurrentProject(int indentSpaces, const ProjectSerializer::UIState* uiState = nullptr) const;
     bool saveActiveTakeSnapshot(const ProjectSerializer::UIState* uiState = nullptr);
     bool createTakeFromCurrentProject();
     ProjectSerializer::LoadResult switchToTake(const std::string& takeId);
@@ -105,7 +116,9 @@ private:
     void startExport();
     static std::string getRecoveryMarkerPath(const std::string& autosavePath);
     static std::string readCrashFlagToken();
-    void writeRecoveryMarkerForAutosave(const std::string& autosavePath) const;
+    static std::string readRecoveryOriginalProjectPath(const std::string& recoveryMarkerPath,
+                                                       const std::string& expectedSessionToken);
+    void writeRecoveryMarkerForAutosave(const std::string& autosavePath, const std::string& canonicalProjectPath) const;
 
 private:
     std::unique_ptr<AestraWindowManager> m_windowManager;
@@ -123,7 +136,7 @@ private:
 
     bool m_running;
     bool m_pendingClose{false};
-    std::string m_projectPath;
+    Aestra::ProjectDocumentState m_documentState;
 
     // Auto-save
     Aestra::Audio::AutosaveManager m_autoSaveManager;

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -24,6 +24,7 @@ set(Aestra_SOURCES
 	Core/AestraContent.cpp
 	Core/MusicalTypingController.h
 	Core/MusicalTypingController.cpp
+	Core/ProjectDocumentState.h
 	Core/ProjectSerializer.cpp
 	Core/TakeManager.h
 	Core/TakeManager.cpp

--- a/Source/Core/ProjectDocumentState.h
+++ b/Source/Core/ProjectDocumentState.h
@@ -1,0 +1,94 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace Aestra {
+
+/**
+ * @brief Tracks the distinct file identities involved in one editing session.
+ *
+ * The canonical path is the only path targeted by an ordinary Save. Autosave,
+ * recovery, and snapshot paths are sources of session state, never implicit
+ * canonical documents.
+ */
+class ProjectDocumentState {
+public:
+    enum class SourceKind { Untitled, Canonical, Recovery, Snapshot };
+
+    void startUntitled(std::string autosavePath) {
+        m_canonicalPath.clear();
+        m_autosavePath = std::move(autosavePath);
+        m_recoveryPath.clear();
+        m_snapshotPath.clear();
+        m_overwriteProtected = false;
+        m_sourceKind = SourceKind::Untitled;
+    }
+
+    void openCanonical(std::string canonicalPath) {
+        m_canonicalPath = std::move(canonicalPath);
+        m_recoveryPath.clear();
+        m_snapshotPath.clear();
+        m_overwriteProtected = false;
+        m_sourceKind = m_canonicalPath.empty() ? SourceKind::Untitled : SourceKind::Canonical;
+    }
+
+    void recoverFrom(std::string recoveryPath, std::string canonicalPath = {}) {
+        m_canonicalPath = std::move(canonicalPath);
+        m_recoveryPath = std::move(recoveryPath);
+        m_snapshotPath.clear();
+        m_overwriteProtected = false;
+        m_sourceKind = SourceKind::Recovery;
+    }
+
+    void restoreSnapshot(std::string snapshotPath, std::string canonicalPath) {
+        m_canonicalPath = std::move(canonicalPath);
+        m_recoveryPath.clear();
+        m_snapshotPath = std::move(snapshotPath);
+        m_overwriteProtected = false;
+        m_sourceKind = SourceKind::Snapshot;
+    }
+
+    void adoptCanonical(std::string canonicalPath) {
+        m_canonicalPath = std::move(canonicalPath);
+        m_recoveryPath.clear();
+        m_snapshotPath.clear();
+        m_overwriteProtected = false;
+        m_sourceKind = m_canonicalPath.empty() ? SourceKind::Untitled : SourceKind::Canonical;
+    }
+
+    const std::string& canonicalPath() const { return m_canonicalPath; }
+    const std::string& autosavePath() const { return m_autosavePath; }
+    const std::string& recoveryPath() const { return m_recoveryPath; }
+    const std::string& snapshotPath() const { return m_snapshotPath; }
+    SourceKind sourceKind() const { return m_sourceKind; }
+    void protectCanonicalFromOverwrite() { m_overwriteProtected = true; }
+    bool requiresSaveAs() const { return m_canonicalPath.empty() || m_overwriteProtected; }
+    bool isOverwriteProtected() const { return m_overwriteProtected; }
+    bool isRecovered() const { return m_sourceKind == SourceKind::Recovery; }
+    bool isSnapshotRestore() const { return m_sourceKind == SourceKind::Snapshot; }
+
+    std::string windowTitle() const {
+        std::string title = m_canonicalPath.empty() ? "Untitled - Aestra" : m_canonicalPath + " - Aestra";
+        if (isRecovered()) {
+            title = "Recovered - " + title;
+        } else if (isSnapshotRestore()) {
+            title = "Snapshot Restore - " + title;
+        }
+        if (m_overwriteProtected) {
+            title = "Integrity Warning - " + title;
+        }
+        return title;
+    }
+
+private:
+    std::string m_canonicalPath;
+    std::string m_autosavePath;
+    std::string m_recoveryPath;
+    std::string m_snapshotPath;
+    bool m_overwriteProtected{false};
+    SourceKind m_sourceKind{SourceKind::Untitled};
+};
+
+} // namespace Aestra

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1052,9 +1052,10 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         return result;
     }
 
-    JSON root = JSON::parse(contents);
-    if (!root.isObject()) {
-        result.errorMessage = "Invalid project file: not a valid JSON object";
+    bool consumedAllInput = false;
+    JSON root = JSON::parseStrict(contents, consumedAllInput);
+    if (!root.isObject() || !consumedAllInput) {
+        result.errorMessage = "Invalid project file: not exactly one valid JSON object";
         Log::error("[ProjectLoad] " + result.errorMessage);
         return result;
     }

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -981,6 +981,23 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     return load(path, trackManager, path);
 }
 
+ProjectSerializer::CandidateLoadResult
+ProjectSerializer::loadFirstValid(const std::vector<std::string>& candidatePaths,
+                                  const std::shared_ptr<TrackManager>& trackManager,
+                                  const std::string& assetBasePath) {
+    CandidateLoadResult selected;
+    for (const auto& candidate : candidatePaths) {
+        selected.result = load(candidate, trackManager, assetBasePath.empty() ? candidate : assetBasePath);
+        if (selected.result.ok) {
+            selected.loadedPath = candidate;
+            return selected;
+        }
+        Log::warning("[ProjectLoad] Recovery candidate rejected: " + candidate + " (" +
+                     selected.result.errorMessage + ")");
+    }
+    return selected;
+}
+
 ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                                       const std::shared_ptr<TrackManager>& trackManager,
                                                       const std::string& assetBasePath) {

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -94,6 +94,11 @@ public:
         std::string contents;
     };
 
+    struct CandidateLoadResult {
+        LoadResult result;
+        std::string loadedPath;
+    };
+
     struct HistoryEntry {
         std::string path;
         std::string label;
@@ -126,6 +131,13 @@ public:
     static LoadResult load(const std::string& path,
                            const std::shared_ptr<Aestra::Audio::TrackManager>& trackManager,
                            const std::string& assetBasePath);
+
+    // Recovery files are ordered newest-first. Try them without requiring the
+    // application layer to replicate serializer failure handling.
+    static CandidateLoadResult
+    loadFirstValid(const std::vector<std::string>& candidatePaths,
+                   const std::shared_ptr<Aestra::Audio::TrackManager>& trackManager,
+                   const std::string& assetBasePath);
 
     static std::string getHistoryDirectory(const std::string& projectPath);
     static std::vector<HistoryEntry> listHistory(const std::string& projectPath);

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -155,7 +155,7 @@ int main() {
         manager.forceAutosave();
         manager.shutdown();
 
-        auto backupDir = tempDir / "override.autosave";
+        auto backupDir = tempDir / "override.autosave.autosave";
         int backupCount = 0;
         if (std::filesystem::exists(backupDir)) {
             for (const auto& entry : std::filesystem::directory_iterator(backupDir)) {
@@ -165,6 +165,10 @@ int main() {
             }
         }
         require(backupCount <= 2, "Backup rotation should limit to maxBackupFiles");
+        const auto recoveryBackups = AutosaveManager::listBackupsForAutosavePath(autosavePath.string());
+        require(!recoveryBackups.empty(), "rotated backups must be discoverable from the explicit autosave path");
+        require(static_cast<int>(recoveryBackups.size()) == backupCount,
+                "recovery backup discovery should match the files retained by rotation");
         std::cout << "[INFO] Backup rotation passed (" << backupCount << " backups).\n";
     }
 

--- a/Tests/AestraAudio/AutosaveManagerTest.cpp
+++ b/Tests/AestraAudio/AutosaveManagerTest.cpp
@@ -6,9 +6,11 @@
 #include "AestraLog.h"
 
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -196,6 +198,63 @@ int main() {
         require(manager.isDirty(), "a change made during the save must keep the project dirty");
         manager.shutdown();
         std::cout << "[INFO] concurrent-dirty preservation passed.\n";
+    }
+
+    // --- Test 6: mutable model capture stays on its owner thread ---
+    // Aestra's ProjectSerializer traverses TrackManager and related mutable
+    // models. The autosave worker may write the captured string, but it must
+    // never invoke that traversal concurrently with active edits.
+    {
+        const auto ownerCapturePath = tempDir / "owner-capture.autosave.aes";
+        const auto ownerThread = std::this_thread::get_id();
+        std::thread::id serializerThread;
+        std::thread::id commitThread;
+        std::mutex commitMutex;
+        std::condition_variable commitCv;
+        bool committed = false;
+        bool markedDuringCapture = false;
+
+        AutosaveManager manager;
+        AutosaveManager::Config config;
+        config.enabled = true;
+        config.autosaveInterval = std::chrono::seconds(60);
+        config.minDirtyDelay = std::chrono::seconds(0);
+        config.autosavePathOverride = ownerCapturePath.string();
+        config.captureSnapshotOnCallingThread = true;
+        config.serializer = [&](std::string& outData) -> bool {
+            serializerThread = std::this_thread::get_id();
+            outData = "immutable owner-thread snapshot";
+            markedDuringCapture = true;
+            manager.markDirty();
+            return true;
+        };
+        config.onAutosaveCommitted = [&](const std::string&) {
+            {
+                std::lock_guard<std::mutex> lock(commitMutex);
+                commitThread = std::this_thread::get_id();
+                committed = true;
+            }
+            commitCv.notify_one();
+        };
+
+        manager.initialize((tempDir / "project6.aes").string(), std::move(config));
+        manager.markDirty();
+        require(manager.captureSnapshotIfDue(), "owner thread should capture a due autosave snapshot");
+        require(serializerThread == ownerThread, "serializer must run on the model-owner thread");
+        require(markedDuringCapture && manager.isDirty(), "an edit during snapshot capture must remain pending");
+
+        {
+            std::unique_lock<std::mutex> lock(commitMutex);
+            require(commitCv.wait_for(lock, std::chrono::seconds(5), [&] { return committed; }),
+                    "background autosave commit timed out");
+        }
+        manager.shutdown();
+
+        require(commitThread != ownerThread, "immutable snapshot file commit should run on the worker thread");
+        std::ifstream in(ownerCapturePath, std::ios::binary);
+        std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        require(contents == "immutable owner-thread snapshot", "owner-thread snapshot contents mismatch");
+        std::cout << "[INFO] owner-thread snapshot capture passed.\n";
     }
 
     std::cout << "[PASS] AutosaveManagerTest\n";

--- a/Tests/AestraAudio/RealtimeExportParityTest.cpp
+++ b/Tests/AestraAudio/RealtimeExportParityTest.cpp
@@ -19,6 +19,7 @@
 #include "GoldenAudio/GoldenAudioHarness.h"
 
 #include "DSP/ContinuousParamBuffer.h"
+#include "IO/AudioExporter.h"
 #include "IO/MiniAudioDecoder.h"
 #include "Playback/PreviewEngine.h"
 
@@ -99,6 +100,17 @@ double rmsOf(const std::vector<float>& v) {
     double sumSq = 0.0;
     for (float s : v) sumSq += static_cast<double>(s) * static_cast<double>(s);
     return std::sqrt(sumSq / static_cast<double>(v.size()));
+}
+
+double rmsRange(const std::vector<float>& interleaved, size_t firstFrame, size_t endFrame, uint32_t channels) {
+    if (channels == 0 || firstFrame >= endFrame || endFrame * channels > interleaved.size()) return 0.0;
+    double sumSq = 0.0;
+    const size_t firstSample = firstFrame * channels;
+    const size_t endSample = endFrame * channels;
+    for (size_t i = firstSample; i < endSample; ++i) {
+        sumSq += static_cast<double>(interleaved[i]) * static_cast<double>(interleaved[i]);
+    }
+    return std::sqrt(sumSq / static_cast<double>(endSample - firstSample));
 }
 
 // Warm the engine's param/track state to steady state before the measured
@@ -243,6 +255,61 @@ bool runDuckContaminationCase(const std::shared_ptr<TrackManager>& tm, const Ses
     return pass;
 }
 
+// -----------------------------------------------------------------------------
+// Case 3: exporting above the live sample rate preserves the whole timeline
+// -----------------------------------------------------------------------------
+bool runCrossSampleRateCase(const SessionConfig& liveCfg, const fs::path& tempRoot) {
+    constexpr uint32_t exportRate = 96000;
+    const uint32_t sourceFrames = liveCfg.sampleRate * kSeconds;
+    auto tm = buildSession(liveCfg, sourceFrames);
+
+    AudioEngine engine;
+    prepareEngine(engine, tm, liveCfg);
+    applyParams(engine);
+    warmupEngine(engine, liveCfg);
+
+    AudioExporter exporter(engine, *tm);
+    AudioExporter::Config config;
+    config.outputPath = (tempRoot / "parity_48_to_96.wav").string();
+    config.scope = AudioExporter::RenderScope::FullSong;
+    config.startBeat = 0.0;
+    config.endBeat = kBeats;
+    config.sampleRate = exportRate;
+    config.bitDepth = AudioExporter::BitDepth::Float_32;
+    config.numChannels = liveCfg.channels;
+    config.tailSeconds = 0.0;
+
+    const auto result = exporter.render(config);
+    if (!result.success) {
+        std::cerr << "cross-sample-rate export failed: " << result.errorMessage << "\n";
+        return false;
+    }
+
+    std::vector<float> decoded;
+    uint32_t decodedRate = 0;
+    uint32_t decodedChannels = 0;
+    if (!decodeAudioFile(config.outputPath, decoded, decodedRate, decodedChannels)) {
+        std::cerr << "failed to decode cross-sample-rate export\n";
+        return false;
+    }
+
+    const size_t decodedFrames = decodedChannels > 0 ? decoded.size() / decodedChannels : 0;
+    const size_t expectedFrames = static_cast<size_t>(exportRate) * kSeconds;
+    const double firstHalfRms = rmsRange(decoded, exportRate / 4, exportRate, decodedChannels);
+    const double secondHalfRms = rmsRange(decoded, exportRate, exportRate * 7 / 4, decodedChannels);
+    const double halfDeltaDb =
+        20.0 * std::log10(std::max(secondHalfRms, 1e-15) / std::max(firstHalfRms, 1e-15));
+
+    const bool pass = decodedRate == exportRate && decodedChannels == liveCfg.channels &&
+                      decodedFrames == expectedFrames && secondHalfRms > 0.01 && std::abs(halfDeltaDb) < 1.0 &&
+                      engine.getSampleRate() == liveCfg.sampleRate &&
+                      tm->getPlaylistModel().getProjectSampleRate() == static_cast<double>(liveCfg.sampleRate);
+    std::cout << (pass ? "[PASS]" : "[FAIL]") << " Export_48k_To_96k_Full_Timeline"
+              << " frames=" << decodedFrames << "/" << expectedFrames << " firstHalfRms=" << firstHalfRms
+              << " secondHalfRms=" << secondHalfRms << " delta=" << halfDeltaDb << " dB\n";
+    return pass;
+}
+
 } // namespace
 
 int main() {
@@ -264,6 +331,7 @@ int main() {
     int failures = 0;
     if (!runParityCase(tm, cfg, cleanExport)) ++failures;
     if (!runDuckContaminationCase(tm, cfg, cleanExport, tempRoot)) ++failures;
+    if (!runCrossSampleRateCase(cfg, tempRoot)) ++failures;
 
     fs::remove_all(tempRoot, ec);
     std::cout << "\n" << (failures == 0 ? "ALL PASS" : "FAILURES: " + std::to_string(failures)) << "\n";

--- a/Tests/AestraAudio/RealtimeObjectPublisherTest.cpp
+++ b/Tests/AestraAudio/RealtimeObjectPublisherTest.cpp
@@ -1,0 +1,114 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Core/RealtimeObjectPublisher.h"
+
+#include <condition_variable>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << "\n";
+        std::exit(1);
+    }
+}
+
+struct DestructionRecord {
+    std::mutex mutex;
+    int firstDestroyed{0};
+    std::thread::id firstDestructionThread;
+};
+
+struct Probe {
+    Probe(int probeId, std::shared_ptr<DestructionRecord> destructionRecord)
+        : id(probeId), record(std::move(destructionRecord)) {}
+
+    int id{0};
+    std::shared_ptr<DestructionRecord> record;
+
+    ~Probe() {
+        if (id == 1) {
+            std::lock_guard<std::mutex> lock(record->mutex);
+            ++record->firstDestroyed;
+            record->firstDestructionThread = std::this_thread::get_id();
+        }
+    }
+};
+
+} // namespace
+
+int main() {
+    Aestra::Audio::RealtimeObjectPublisher<Probe> publisher;
+    auto record = std::make_shared<DestructionRecord>();
+    publisher.publish(std::make_shared<Probe>(1, record));
+
+    std::mutex phaseMutex;
+    std::condition_variable phaseCv;
+    bool acquired = false;
+    bool mayRelease = false;
+    bool readerSawExpectedObject = false;
+    std::thread::id readerThreadId;
+
+    std::thread reader([&] {
+        readerThreadId = std::this_thread::get_id();
+        Probe* object = publisher.acquireRealtime();
+        {
+            std::lock_guard<std::mutex> lock(phaseMutex);
+            readerSawExpectedObject = object && object->id == 1;
+            acquired = true;
+        }
+        phaseCv.notify_one();
+
+        {
+            std::unique_lock<std::mutex> lock(phaseMutex);
+            phaseCv.wait(lock, [&] { return mayRelease; });
+        }
+        publisher.releaseRealtime();
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(phaseMutex);
+        phaseCv.wait(lock, [&] { return acquired; });
+    }
+    require(readerSawExpectedObject, "real-time reader did not acquire the published object");
+
+    publisher.publish(std::make_shared<Probe>(2, record));
+    {
+        std::lock_guard<std::mutex> lock(record->mutex);
+        require(record->firstDestroyed == 0, "replaced object was reclaimed while the reader still held its hazard");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(phaseMutex);
+        mayRelease = true;
+    }
+    phaseCv.notify_one();
+    reader.join();
+
+    const std::thread::id controlThreadId = std::this_thread::get_id();
+    publisher.collectRetired();
+    {
+        std::lock_guard<std::mutex> lock(record->mutex);
+        require(record->firstDestroyed == 1, "released object was not reclaimed exactly once");
+        require(record->firstDestructionThread == controlThreadId,
+                "last shared ownership was not released on the control thread");
+        require(record->firstDestructionThread != readerThreadId,
+                "last shared ownership was released on the real-time reader thread");
+    }
+
+    Probe* current = publisher.acquireRealtime();
+    require(current && current->id == 2, "new publication was not visible to the real-time reader");
+    publisher.releaseRealtime();
+    publisher.publish(nullptr);
+    publisher.collectRetired();
+
+    std::cout << "[PASS] RealtimeObjectPublisherTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/RealtimePathStressTest.cpp
+++ b/Tests/AestraAudio/RealtimePathStressTest.cpp
@@ -18,6 +18,10 @@
 #include <thread>
 #include <vector>
 
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
 using namespace Aestra::Audio;
 
 namespace {
@@ -89,7 +93,12 @@ int main(int argc, char** argv) {
     constexpr uint32_t kSampleRate = 48000;
     constexpr uint32_t kFrames = 64;
     constexpr uint32_t kChannels = 2;
-    const bool lowMemoryProfile = argc > 1 && std::string(argv[1]) == "--low-memory-profile";
+    bool lowMemoryProfile = false;
+    bool diagnostics = false;
+    for (int i = 1; i < argc; ++i) {
+        lowMemoryProfile = lowMemoryProfile || std::string(argv[i]) == "--low-memory-profile";
+        diagnostics = diagnostics || std::string(argv[i]) == "--diagnostics";
+    }
     const int blockCount = lowMemoryProfile ? 512 : 256;
 
     // Use a guaranteed-writable temp directory instead of hardcoded /tmp/
@@ -165,6 +174,19 @@ int main(int argc, char** argv) {
     uint64_t localOverruns = 0;
     uint64_t lastCallbackNs = 0;
     uint64_t maxCallbackNs = 0;
+    int maxCallbackBlock = -1;
+    uint64_t maxEngineNs = 0;
+    uint64_t maxMonitoringNs = 0;
+    uint64_t maxPreviewNs = 0;
+    uint64_t maxSamplerNs = 0;
+
+#ifndef _WIN32
+    rusage usageBefore {};
+    rusage usageAfter {};
+    if (diagnostics) {
+        getrusage(RUSAGE_SELF, &usageBefore);
+    }
+#endif
 
     for (int block = 0; block < blockCount; ++block) {
         if ((block % 7) == 0) {
@@ -177,12 +199,37 @@ int main(int argc, char** argv) {
 
         const auto start = std::chrono::steady_clock::now();
         engine.processBlock(engineOut.data(), nullptr, kFrames, 0.0);
+        const auto afterEngine = diagnostics ? std::chrono::steady_clock::now() : start;
         tracks.mixInputMonitoring(input.data(), monitorOut.data(), kFrames, kChannels);
+        const auto afterMonitoring = diagnostics ? std::chrono::steady_clock::now() : start;
         preview.processRealtime(engineOut.data(), kFrames, kChannels);
+        const auto afterPreview = diagnostics ? std::chrono::steady_clock::now() : start;
         sampler.process(nullptr, samplerOutputs, 0, 2, kFrames, block == 0 ? &midi : nullptr, nullptr);
         const auto elapsed = std::chrono::steady_clock::now() - start;
         lastCallbackNs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count());
-        maxCallbackNs = std::max(maxCallbackNs, lastCallbackNs);
+        if (lastCallbackNs > maxCallbackNs) {
+            maxCallbackNs = lastCallbackNs;
+            maxCallbackBlock = block;
+        }
+
+        if (diagnostics) {
+            maxEngineNs = std::max(
+                maxEngineNs,
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(afterEngine - start).count()));
+            maxMonitoringNs = std::max(
+                maxMonitoringNs,
+                static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(afterMonitoring - afterEngine).count()));
+            maxPreviewNs = std::max(
+                maxPreviewNs,
+                static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(afterPreview - afterMonitoring).count()));
+            maxSamplerNs = std::max(
+                maxSamplerNs,
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                          start + elapsed - afterPreview)
+                                          .count()));
+        }
 
         if (elapsed > deadline) {
             ++localOverruns;
@@ -191,10 +238,16 @@ int main(int argc, char** argv) {
 
     const auto& tel = engine.telemetry();
     const size_t rssKb = currentRssKb();
+#ifndef _WIN32
+    if (diagnostics) {
+        getrusage(RUSAGE_SELF, &usageAfter);
+    }
+#endif
     std::cout << "profile=" << (lowMemoryProfile ? "low-memory" : "standard") << "\n";
     std::cout << "blocks=" << blockCount << "\n";
     std::cout << "lastCallbackNs=" << lastCallbackNs << "\n";
     std::cout << "maxCallbackNs=" << maxCallbackNs << "\n";
+    std::cout << "maxCallbackBlock=" << maxCallbackBlock << "\n";
     std::cout << "xruns=" << tel.getXruns() << "\n";
     std::cout << "underruns=" << tel.getUnderruns() << "\n";
     if (rssKb > 0) {
@@ -205,6 +258,16 @@ int main(int argc, char** argv) {
     std::cout << "engineOverruns=" << tel.getOverruns() << "\n";
     std::cout << "rtLockViolations=" << tel.getRtLockViolations() << "\n";
     std::cout << "rtLogViolations=" << tel.getRtLogViolations() << "\n";
+    if (diagnostics) {
+        std::cout << "maxEngineNs=" << maxEngineNs << "\n";
+        std::cout << "maxMonitoringNs=" << maxMonitoringNs << "\n";
+        std::cout << "maxPreviewNs=" << maxPreviewNs << "\n";
+        std::cout << "maxSamplerNs=" << maxSamplerNs << "\n";
+#ifndef _WIN32
+        std::cout << "voluntaryContextSwitches=" << usageAfter.ru_nvcsw - usageBefore.ru_nvcsw << "\n";
+        std::cout << "involuntaryContextSwitches=" << usageAfter.ru_nivcsw - usageBefore.ru_nivcsw << "\n";
+#endif
+    }
 
     if (localOverruns > 0 || tel.getOverruns() > 0 || tel.getRtLockViolations() != 0 || tel.getRtLogViolations() != 0) {
         return 1;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -560,6 +560,15 @@ else()
     message(STATUS "AestraRealtimePathStressTest built but not registered (set AESTRA_ENABLE_RUNTIME_TESTS=ON to enable)")
 endif()
 
+add_executable(RealtimeObjectPublisherTest AestraAudio/RealtimeObjectPublisherTest.cpp)
+target_link_libraries(RealtimeObjectPublisherTest PRIVATE Threads::Threads)
+target_include_directories(RealtimeObjectPublisherTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME RealtimeObjectPublisherTest COMMAND RealtimeObjectPublisherTest)
+set_tests_properties(RealtimeObjectPublisherTest PROPERTIES LABELS "audio;rt-safety;reclamation;regression")
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerStereoParityTest.cpp")
     add_executable(SamplerStereoParityTest AestraAudio/SamplerStereoParityTest.cpp)
     target_link_libraries(SamplerStereoParityTest PRIVATE AestraAudio)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -113,6 +113,30 @@ target_include_directories(ProjectDocumentStateTest PRIVATE
 add_test(NAME ProjectDocumentStateTest COMMAND ProjectDocumentStateTest)
 set_tests_properties(ProjectDocumentStateTest PROPERTIES LABELS "unit;project;identity;recovery")
 
+add_executable(ProjectLifecycleInteractionTest
+    Integration/ProjectLifecycleInteractionTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+)
+target_link_libraries(ProjectLifecycleInteractionTest PRIVATE AestraAudio)
+target_include_directories(ProjectLifecycleInteractionTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Source/Core
+    ${CMAKE_SOURCE_DIR}/Tests
+)
+add_test(NAME ProjectLifecycleInteractionTest COMMAND ProjectLifecycleInteractionTest)
+set_tests_properties(ProjectLifecycleInteractionTest PROPERTIES LABELS "integration;project;recovery;integrity")
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/SessionRecoveryTest.cpp")
     add_executable(SessionRecoveryTest
         Integration/SessionRecoveryTest.cpp

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -106,6 +106,13 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripTest.cpp")
 endif()
 
 # Session Recovery Test (autosave + crash flag + recovery flow)
+add_executable(ProjectDocumentStateTest Integration/ProjectDocumentStateTest.cpp)
+target_include_directories(ProjectDocumentStateTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Core
+)
+add_test(NAME ProjectDocumentStateTest COMMAND ProjectDocumentStateTest)
+set_tests_properties(ProjectDocumentStateTest PROPERTIES LABELS "unit;project;identity;recovery")
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/SessionRecoveryTest.cpp")
     add_executable(SessionRecoveryTest
         Integration/SessionRecoveryTest.cpp

--- a/Tests/Integration/ProjectDocumentStateTest.cpp
+++ b/Tests/Integration/ProjectDocumentStateTest.cpp
@@ -1,0 +1,66 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "ProjectDocumentState.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << "\n";
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main() {
+    using Aestra::ProjectDocumentState;
+
+    ProjectDocumentState state;
+    state.startUntitled("/app-data/autosave.aes");
+    require(state.canonicalPath().empty(), "untitled project acquired a canonical path");
+    require(state.autosavePath() == "/app-data/autosave.aes", "untitled autosave identity was lost");
+    require(state.requiresSaveAs(), "ordinary Save must require Save As for an untitled project");
+
+    state.recoverFrom("/app-data/autosave.aes");
+    require(state.isRecovered(), "recovery source kind was not retained");
+    require(state.recoveryPath() == "/app-data/autosave.aes", "recovery source path was not retained");
+    require(state.canonicalPath().empty(), "legacy recovery silently treated autosave as canonical");
+    require(state.requiresSaveAs(), "legacy recovery without an original path must require Save As");
+
+    state.recoverFrom("/app-data/autosave.aes", "/projects/song.aes");
+    require(state.isRecovered(), "recovered canonical project lost its recovery state");
+    require(state.canonicalPath() == "/projects/song.aes", "original canonical path was not restored");
+    require(state.recoveryPath() == "/app-data/autosave.aes", "canonical and recovery identities collapsed");
+    require(!state.requiresSaveAs(), "recovered named project should save to its original canonical path");
+    require(state.autosavePath() == "/app-data/autosave.aes", "recovery changed the autosave destination");
+
+    state.restoreSnapshot("/projects/song.history/snapshot.aes", "/projects/song.aes");
+    require(state.isSnapshotRestore(), "snapshot source kind was not retained");
+    require(state.snapshotPath() == "/projects/song.history/snapshot.aes", "snapshot path was not retained");
+    require(state.canonicalPath() == "/projects/song.aes", "snapshot replaced the canonical identity");
+
+    state.adoptCanonical("/projects/song-recovered.aes");
+    require(state.sourceKind() == ProjectDocumentState::SourceKind::Canonical,
+            "successful Save As did not establish a canonical document");
+    require(state.canonicalPath() == "/projects/song-recovered.aes", "Save As canonical path was not retained");
+    require(state.recoveryPath().empty() && state.snapshotPath().empty(),
+            "transient recovery or snapshot identity survived canonical save");
+    require(!state.requiresSaveAs(), "canonical document still requires Save As");
+    require(state.autosavePath() == "/app-data/autosave.aes", "Save As collapsed canonical and autosave identities");
+
+    state.protectCanonicalFromOverwrite();
+    require(state.isOverwriteProtected(), "integrity mismatch did not protect the canonical project");
+    require(state.requiresSaveAs(), "protected canonical project must not be overwritten by ordinary Save");
+
+    state.adoptCanonical("/projects/song-reviewed.aes");
+    require(!state.isOverwriteProtected(), "successful Save As did not clear overwrite protection");
+    require(!state.requiresSaveAs(), "reviewed Save As target should become canonical");
+
+    std::cout << "[PASS] ProjectDocumentStateTest\n";
+    return 0;
+}

--- a/Tests/Integration/ProjectLifecycleInteractionTest.cpp
+++ b/Tests/Integration/ProjectLifecycleInteractionTest.cpp
@@ -1,0 +1,110 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Core/AutosaveManager.h"
+#include "Models/TrackManager.h"
+#include "ProjectDocumentState.h"
+#include "ProjectSerializer.h"
+#include "Support/TestTempDirectory.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << "\n";
+        std::exit(1);
+    }
+}
+
+std::shared_ptr<Aestra::Audio::TrackManager> makeProject(const std::string& name) {
+    auto tracks = std::make_shared<Aestra::Audio::TrackManager>();
+    tracks->getPlaylistModel().setPatternManager(&tracks->getPatternManager());
+    tracks->getPlaylistModel().createLane(name);
+    tracks->addChannel(name);
+    return tracks;
+}
+
+} // namespace
+
+int main() {
+    using Aestra::Audio::AutosaveManager;
+
+    const Aestra::Tests::ScopedTempDirectory tempDir{"ProjectLifecycleInteraction"};
+    const auto canonicalPath = tempDir.path() / "song.aes";
+    const auto reviewedPath = tempDir.path() / "song-reviewed.aes";
+    const auto autosavePath = tempDir.path() / "autosave.aes";
+    const auto backupDir = tempDir.path() / "autosave.autosave";
+    const auto backupPath = backupDir / "20260718_120000.aes";
+
+    auto source = makeProject("Lifecycle Lane");
+    const auto serialized = ProjectSerializer::serialize(source, 126.0, 2.5, 0);
+    require(serialized.ok, "production serializer failed to create the fixture project");
+    require(ProjectSerializer::writeAtomically(canonicalPath.string(), serialized.contents),
+            "canonical project write failed");
+
+    Aestra::ProjectDocumentState document;
+    document.startUntitled(autosavePath.string());
+    require(document.requiresSaveAs(), "untitled Save must route through Save As");
+    require(document.windowTitle() == "Untitled - Aestra", "untitled title is not user-visible");
+
+    document.adoptCanonical(canonicalPath.string());
+    require(!document.requiresSaveAs(), "successful Save As did not establish direct Save routing");
+    require(document.windowTitle() == canonicalPath.string() + " - Aestra", "canonical title lost its path");
+
+    std::filesystem::create_directories(backupDir);
+    std::filesystem::copy_file(canonicalPath, backupPath, std::filesystem::copy_options::overwrite_existing);
+    {
+        std::ofstream primary(autosavePath, std::ios::binary | std::ios::trunc);
+        primary << "{\"version\":";
+    }
+
+    std::vector<std::string> candidates{autosavePath.string()};
+    const auto backups = AutosaveManager::listBackupsForAutosavePath(autosavePath.string());
+    candidates.insert(candidates.end(), backups.begin(), backups.end());
+
+    auto recoveredTracks = makeProject("State That Must Be Replaced");
+    auto selected = ProjectSerializer::loadFirstValid(candidates, recoveredTracks, canonicalPath.string());
+    require(selected.result.ok, "recovery rejected every candidate");
+    require(selected.loadedPath == backupPath.string(), "recovery did not fall back from corrupt primary");
+    require(recoveredTracks->getChannelCount() == 1, "recovery did not replace the active project model");
+    require(recoveredTracks->getChannel(0) && recoveredTracks->getChannel(0)->getName() == "Lifecycle Lane",
+            "recovery left the pre-existing session model in place");
+
+    document.recoverFrom(selected.loadedPath, canonicalPath.string());
+    require(!document.requiresSaveAs(), "named recovery did not retain direct Save routing");
+    require(document.windowTitle() == "Recovered - " + canonicalPath.string() + " - Aestra",
+            "recovery state is not visible in the title");
+
+    std::string mismatchedContents = serialized.contents;
+    const auto namePos = mismatchedContents.find("Lifecycle Lane");
+    require(namePos != std::string::npos, "fixture project did not contain its channel name");
+    mismatchedContents.replace(namePos, std::string("Lifecycle Lane").size(), "Lifecycle Lame");
+    require(ProjectSerializer::writeAtomically(canonicalPath.string(), mismatchedContents),
+            "integrity-mismatch fixture write failed");
+
+    auto integrityTracks = makeProject("State That Must Be Replaced");
+    const auto mismatch = ProjectSerializer::load(canonicalPath.string(), integrityTracks);
+    require(mismatch.ok, "recoverable integrity mismatch should remain loadable");
+    require(mismatch.integrity == ProjectSerializer::LoadIntegrity::Mismatch,
+            "production serializer did not expose the integrity mismatch");
+
+    document.openCanonical(canonicalPath.string());
+    document.protectCanonicalFromOverwrite();
+    require(document.requiresSaveAs(), "integrity mismatch did not block ordinary overwrite");
+    require(document.windowTitle() == "Integrity Warning - " + canonicalPath.string() + " - Aestra",
+            "integrity warning is not visible in the application title");
+
+    document.adoptCanonical(reviewedPath.string());
+    require(!document.requiresSaveAs(), "reviewed Save As target did not restore direct Save routing");
+    require(!document.isOverwriteProtected(), "reviewed Save As did not clear overwrite protection");
+
+    std::cout << "[PASS] ProjectLifecycleInteractionTest\n";
+    return 0;
+}

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -134,6 +134,35 @@ void testValidProjectLoad() {
     std::cout << "[PASS] Valid project load" << std::endl;
 }
 
+void testTrailingJsonObjectIsRejectedNonDestructively() {
+    std::cout << "[TEST] Trailing JSON object is rejected non-destructively..." << std::endl;
+
+    const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadTrailingJson"};
+    const auto projectPath = testDirScope.path() / "trailing.aes";
+
+    auto source = std::make_shared<TrackManager>();
+    source->getPlaylistModel().createLane("Serialized Lane");
+    source->addChannel("Serialized Lane");
+    auto serialized = ProjectSerializer::serialize(source, 120.0, 0.0, 0);
+    assert(serialized.ok);
+
+    std::ofstream out(projectPath, std::ios::binary | std::ios::trunc);
+    out << serialized.contents << "\n{\"unexpectedSuffix\":true}";
+    out.close();
+
+    auto destination = std::make_shared<TrackManager>();
+    destination->getPlaylistModel().createLane("Existing Lane");
+    destination->addChannel("Existing Lane");
+    const size_t channelsBefore = destination->getChannelCount();
+
+    auto result = ProjectSerializer::load(projectPath.string(), destination);
+    assert(!result.ok);
+    assert(result.errorMessage.find("exactly one") != std::string::npos);
+    assert(destination->getChannelCount() == channelsBefore);
+
+    std::cout << "[PASS] Trailing JSON object is rejected non-destructively" << std::endl;
+}
+
 void testMissingPatternReference() {
     std::cout << "[TEST] Missing pattern reference preserves placeholder..." << std::endl;
 
@@ -830,6 +859,7 @@ int main() {
     std::cout << "=== Project Load Regression Tests ===" << std::endl;
 
     testValidProjectLoad();
+    testTrailingJsonObjectIsRejectedNonDestructively();
     testMissingPatternReference();
     testMissingArsenalUnitReference();
     testFailedValidationDoesNotClear();

--- a/Tests/Integration/SessionRecoveryTest.cpp
+++ b/Tests/Integration/SessionRecoveryTest.cpp
@@ -3,6 +3,7 @@
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "../Support/TestTempDirectory.h"
+#include "Core/AutosaveManager.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -229,6 +230,28 @@ int main() {
             "Recovered main output destination mismatch");
     require(std::abs(recoveredChannel1->getVolume() - 0.75f) < 1e-6f, "Recovered channel 1 volume mismatch");
     require(std::abs(recoveredChannel1->getPan() - (-0.25f)) < 1e-6f, "Recovered channel 1 pan mismatch");
+
+    // --- Rotated fallback: a corrupt primary must not strand a valid backup
+    const auto backupDir = tempDir / "autosave.autosave";
+    std::filesystem::create_directories(backupDir);
+    const auto rotatedBackup = backupDir / "20260718_120000.aes";
+    std::filesystem::copy_file(autosavePath, rotatedBackup, std::filesystem::copy_options::overwrite_existing);
+    {
+        std::ofstream corruptPrimary(autosavePath, std::ios::binary | std::ios::trunc);
+        corruptPrimary << "{\"version\":";
+    }
+
+    auto recoveryCandidates = AutosaveManager::listBackupsForAutosavePath(autosavePath.string());
+    require(recoveryCandidates.size() == 1 && recoveryCandidates.front() == rotatedBackup.string(),
+            "Recovery should discover the rotated backup after primary corruption");
+
+    auto tm3 = std::make_shared<TrackManager>();
+    tm3->getPlaylistModel().setPatternManager(&tm3->getPatternManager());
+    recoveryCandidates.insert(recoveryCandidates.begin(), autosavePath.string());
+    auto selected = ProjectSerializer::loadFirstValid(recoveryCandidates, tm3, autosavePath.string());
+    require(selected.result.ok, "Valid rotated backup did not load after corrupt primary");
+    require(selected.loadedPath == rotatedBackup.string(), "Recovery did not select the valid rotated backup");
+    require(tm3->getChannelCount() == 2, "Rotated backup recovery lost project channels");
 
     // --- Clean up
     clearCrashFlag(crashFlagPath);

--- a/tests/security/account_api_client_test.cpp
+++ b/tests/security/account_api_client_test.cpp
@@ -677,12 +677,13 @@ bool testLoginFlowFull() {
     return ok;
 }
 
-bool testAccountApiRequiresExplicitBaseUrl() {
+bool testAccountApiUsesCanonicalDefaultBaseUrl() {
     ScopedEnvironmentVariable baseUrl("AESTRA_ACCOUNT_API_BASE_URL");
     baseUrl.unset();
     const AccountApiConfig config = accountApiConfigFromEnvironment();
     bool ok = true;
-    ok &= expect(config.baseUrl.empty(), "accountApiConfigFromEnvironment requires explicit base URL");
+    ok &= expect(config.baseUrl == "https://www.aestra.studio",
+                 "accountApiConfigFromEnvironment uses the canonical production URL by default");
     return ok;
 }
 
@@ -691,11 +692,12 @@ bool testRealWorkerLoginStartSendsMail() {
         std::cout << "libcurl transport unavailable; skipping real Worker login test.\n";
         return true;
     }
-    const AccountApiConfig config = accountApiConfigFromEnvironment();
-    if (config.baseUrl.empty()) {
-        std::cout << "no Worker URL; skipping real Worker login test.\n";
+    const char* explicitBaseUrl = std::getenv("AESTRA_ACCOUNT_API_BASE_URL");
+    if (!explicitBaseUrl || !*explicitBaseUrl) {
+        std::cout << "no explicit Worker URL; skipping real Worker login test.\n";
         return true;
     }
+    const AccountApiConfig config = accountApiConfigFromEnvironment();
 
     std::unique_ptr<IHttpTransport> curlTransport = createDefaultHttpTransport();
     AccountApiClient client(config, *curlTransport);
@@ -719,7 +721,7 @@ int main() {
     ok &= testServiceFailureBoundaries();
 #ifndef _WIN32
     ok &= testLoginFlowFull();
-    ok &= testAccountApiRequiresExplicitBaseUrl();
+    ok &= testAccountApiUsesCanonicalDefaultBaseUrl();
     ok &= testRealWorkerLoginStartSendsMail();
 #endif
     fs::remove_all(fs::temp_directory_path() / "aestra_account_api_client_tests");


### PR DESCRIPTION
## Summary

Hardens the highest-risk persistence, recovery, export, and realtime preview paths identified by the reliability audit.

- separates canonical project identity from autosave, recovery, and snapshot identities
- routes untitled and protected sessions through Save As instead of silently saving to `autosave.aes`
- captures mutable project snapshots on the model-owner thread and commits immutable data in the autosave worker
- falls back through rotated autosave backups when the primary recovery file is corrupt
- rejects trailing or partial data after the project JSON document
- protects integrity-mismatched sessions from overwriting their canonical source until explicitly reviewed and saved elsewhere
- fixes cross-sample-rate export duration and output completeness
- moves preview voice ownership reclamation off the realtime callback
- makes account API tests hermetic and adds callback scheduler diagnostics

## Why

The previous paths could report a successful save without establishing a discoverable project file, race autosave serialization against active edits, ignore valid rotated recovery backups, accept trailing garbage, truncate cross-rate exports, or release shared ownership from an audio callback. These are user-facing data-loss, audio-integrity, and realtime reliability failures.

## Validation

- `cmake --preset headless`
- `cmake --build build/headless -j2`
- `cmake --build build-linux --target Aestra -j2`
- `ctest --test-dir build/headless --output-on-failure -j2`
  - 171 registered tests, zero failures
  - `SecAccountEndToEndSmoke` skipped as designed without external credentials
- focused lifecycle, recovery, parser, autosave, export, preview reclamation, and account regressions
- realtime stress diagnostics: normal-scheduling misses correlated with involuntary context switches; FIFO/pinned run completed with zero overruns

## Risk and rollback

Persistence behavior is intentionally stricter, but the serialized `.aes` output schema is unchanged. The recovery marker gains an optional canonical-path line. Each reliability fix is isolated in its own commit so it can be reviewed or reverted independently.

No public documentation, licensing, pricing, or release posture changes.
