### PR TITLE
fix(build): fold whole-archived AestraRumble into the Linux rescan link group

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -674,9 +674,24 @@ elseif(UNIX)
         )
 
         add_library(AestraAudio INTERFACE)
-        target_link_libraries(AestraAudio INTERFACE
-            "$<LINK_GROUP:RESCAN,AestraAudioLinux,AestraAudioCore>"
-        )
+        if(TARGET AestraRumble)
+            # Rumble's static plugin registration references InternalPluginRegistry
+            # symbols that live in AestraAudioCore. Appended whole-archive AFTER the
+            # closed rescan group (the old AestraPremiumPlugins wiring) it could not
+            # resolve those symbols backwards — GNU ld is single-pass — which broke
+            # every full-UI test binary that didn't coincidentally pull the registry
+            # first (issue #555: undefined refs on some, silent/empty plugin registry
+            # on others). Fold it INTO the rescan group, keeping WHOLE_ARCHIVE so the
+            # self-registration TU is always linked and always resolvable.
+            target_link_libraries(AestraAudio INTERFACE
+                "$<LINK_GROUP:RESCAN,AestraAudioLinux,AestraAudioCore,$<LINK_LIBRARY:WHOLE_ARCHIVE,AestraRumble>>"
+            )
+            set(AESTRA_RUMBLE_IN_LINK_GROUP TRUE)
+        else()
+            target_link_libraries(AestraAudio INTERFACE
+                "$<LINK_GROUP:RESCAN,AestraAudioLinux,AestraAudioCore>"
+            )
+        endif()
     else()
         # No ALSA - stub already in AestraAudioCore
         # Create an interface library for compatibility
@@ -693,7 +708,10 @@ if(NOT TARGET AestraAudioWin AND NOT TARGET AestraAudioLinux)
     target_sources(AestraAudioCore PRIVATE src/IO/MidiInputService.cpp)
 endif()
 
-if(TARGET AestraAudio AND TARGET AestraPremiumPlugins)
+# On Linux+ALSA with Rumble present, Rumble is already whole-archived inside
+# the rescan group above; appending the premium interface (which wraps the same
+# archive in WHOLE_ARCHIVE) would double-link it into every consumer.
+if(TARGET AestraAudio AND TARGET AestraPremiumPlugins AND NOT AESTRA_RUMBLE_IN_LINK_GROUP)
     target_link_libraries(AestraAudio INTERFACE AestraPremiumPlugins)
 endif()
 


### PR DESCRIPTION
## Summary
Fixes #555. Rumble's static plugin registration references `InternalPluginRegistry` symbols in `AestraAudioCore`, but the premium interface appended it whole-archive **after** the closed `RESCAN` group — GNU ld is single-pass, so those references could never resolve backwards. Every full-UI test binary linking the `AestraAudio` interface without coincidentally pulling the registry first failed with undefined references: `AestraAudioTest`, `AudioEngineDiagnosticsTest` (both registrations), `AestraDriftQualityTest`.

**Fix (Linux+ALSA, Rumble present):**
```cmake
$<LINK_GROUP:RESCAN,AestraAudioLinux,AestraAudioCore,$<LINK_LIBRARY:WHOLE_ARCHIVE,AestraRumble>>
```
`WHOLE_ARCHIVE` preserved (self-registration TU always linked), now inside the group where it resolves. The separate `AestraPremiumPlugins` append is skipped in that configuration to avoid double-linking the same archive.

## Why CI never caught it
Test lanes build headless (different interface branch); the Linux UI/App lane compiles but doesn't run ctest. Worth considering a smoke-ctest in the UI lane as a follow-up — not included here (CI scope).

## Record correction (from the #555 investigation)
`RumbleRenderTest`/`RumbleArsenalAudibleTest` runtime failures previously blamed on this geometry were actually **local config**: those tests carry their own explicit whole-archive recipes and always registered fine; they refuse instance creation without `AESTRA_ENABLE_TEST_LICENSES=ON` (a cache setting on premium-enabled machines). Corrected on the issue.

## Testing performed (full-UI build-linux, -j2)
- All four previously-unlinkable targets **link and pass**.
- Premium suite green: RumbleState / UnauthorizedOutputSafety / Render / ArsenalAudible / Quality / PresetBank / SpectralPerformance.
- `Aestra` app + `MuseRepl` link via the modified interface.
- **Full suite: 184/185** — sole failure is env-gated `SecAccountApiClient`, excluded from every CI lane by design.
- Headless path untouched (non-ALSA/no-Rumble branches unchanged); public CI unaffected by construction (`AESTRA_ENABLE_PREMIUM_PLUGINS` off there).

## Risk / rollback
- Low: one CMake file; AGENTS §8 linker-group caution honored — group modified (extended), not removed, and validated on Linux full-UI, app included.
- Rollback: revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated Linux CMake linking to whole-archive `AestraRumble` inside the `RESCAN` group with `AestraAudioLinux` and `AestraAudioCore`.
- Prevented duplicate linking through `AestraPremiumPlugins`.
- Ensured static Rumble plugin registration resolves `InternalPluginRegistry` references under GNU ld’s single-pass behavior.
- Previously failing full-UI targets now link and pass; the suite completed with 184/185 tests passing, with only the environment-gated `SecAccountApiClient` failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->