### PR TITLE
fix(crash-recovery): fsync the crash flag sentinel

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -4,6 +4,7 @@
 #include "ServiceLocator.h"
 #include "AestraRootComponent.h"
 #include "Preferences.h"
+#include "../AestraCore/include/AestraFile.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraCore/include/PointerRegistry.h"
 #include "FileBrowser.h"
@@ -118,10 +119,15 @@ std::string AestraApp::getCrashFlagPath() {
 
 void AestraApp::writeCrashFlag() {
     std::string flagPath = getCrashFlagPath();
-    std::error_code ec;
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
         out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";
+        // The flag is a crash sentinel: without fsync a hard crash or power loss
+        // right after startup can lose it to the OS cache — exactly the case
+        // crash detection exists for (issue #284).
+        if (!Aestra::syncOfstream(out, flagPath)) {
+            Log::warning("[CrashDetection] Failed to sync crash flag: " + flagPath);
+        }
         out.close();
         Log::info("[CrashDetection] Wrote crash flag: " + flagPath);
     } else {

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -126,10 +126,13 @@ void AestraApp::writeCrashFlag() {
         // right after startup can lose it to the OS cache — exactly the case
         // crash detection exists for (issue #284).
         if (!Aestra::syncOfstream(out, flagPath)) {
+            // Best-effort: the unsynced flag stays on disk, but don't log success.
             Log::warning("[CrashDetection] Failed to sync crash flag: " + flagPath);
+            out.close();
+        } else {
+            out.close();
+            Log::info("[CrashDetection] Wrote crash flag: " + flagPath);
         }
-        out.close();
-        Log::info("[CrashDetection] Wrote crash flag: " + flagPath);
     } else {
         Log::warning("[CrashDetection] Failed to write crash flag: " + flagPath);
     }


### PR DESCRIPTION
## Summary
Fixes #284. `AestraApp::writeCrashFlag()` wrote the crash sentinel without any sync — a hard crash or power loss right after startup (the exact case crash detection exists for) could lose the flag to the OS page cache, so the next boot would silently skip recovery.

One-call fix: `Aestra::syncOfstream(out, flagPath)` before close — the same durability helper already used by UIState, Preferences, and ProjectSerializer. Sync failure logs a warning and keeps the best-effort flag. Also removes an unused `std::error_code` local.

## Testing performed
- `Aestra` app target builds clean (full-UI build-linux, -j2); syntax-checked with real compile flags.
- No behavior change on the happy path; flag content/location unchanged; `clearCrashFlag`/detection logic untouched.

## Tracker hygiene in the same pass
- #280 closed as already-fixed (UIState/Preferences verified atomic on develop).
- #554 closed (fixed by #557; auto-close doesn't fire on non-default-branch merges).

## Risk/rollback
Minimal — one write path, no format change. Revert the commit to roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added an explicit stream sync when writing the crash flag, ensuring it is persisted before closing.
- Logs a warning if syncing fails while retaining the best-effort crash flag.
- Removed an unused `std::error_code` variable; crash flag behavior remains otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->