### PR TITLE
feat(ui): NUICursorService — single owner of infinite-drag cursor capture (phase 1)

### DIFF
--- a/AestraDocs/cursor-unification-map-2026-07.md
+++ b/AestraDocs/cursor-unification-map-2026-07.md
@@ -1,0 +1,113 @@
+# Cursor / Pointer Unification — Full Map (2026-07-19)
+
+Symptom report (owner): cursor hiding during slider/knob drags is inconsistent —
+some surfaces hide (desired "infinite drag" magic), some don't; when it does
+hide, the cursor sometimes reappears at the wrong position.
+
+## The four competing cursor authorities
+
+| # | Authority | Where | Mechanism |
+|---|---|---|---|
+| 1 | **OS cursor** | `AestraPlatform.h` → `PlatformWindowWin32/Linux` | `setCursorVisible(bool)` (Win32: per-thread `ShowCursor` count loops; Linux: `SDL_ShowCursor`), `setCursorPosition` (**Win32: `SetCursorPos` = SCREEN coords; Linux: `SDL_WarpMouseInWindow` = window coords**). SDL relative-mouse mode deliberately removed ("focus-dependent, unreliable"). |
+| 2 | **WindowManager SVG cursor** | `AestraWindowManager` (`m_useCustomCursor{true}` by default) | OS cursor force-hidden while focused (`:438`, `:851`); SVG icon rendered every frame (`renderCustomCursor`, `:758`); skipped when bridge style == `Hidden` (`:858`); external `setCursorVisible` calls **suppressed** while custom cursor on (`:539`). |
+| 3 | **TrackManagerUI custom cursor** | timeline | `isCustomCursorActive()` — overrides the WindowManager SVG (`:761-768`). A third visual cursor system. |
+| 4 | **Widget hide+warp ("the magic")** | 3 independent hand-rolled copies | `NUISlider` (rotary), `UIMixerKnob`, `UIMixerFader`: `setCursorStyle(NUICursorStyle::Hidden)` on drag start → frame-delta value updates → on release warp (`setCursorPosition`) to knob-center / thumb-pos, then `setCursorStyle(Arrow)`. |
+
+Event plumbing: `NUIPlatformBridge` stamps `event.cursorCaptured =
+(m_currentCursorStyle == Hidden)` on mouse events (3 sites, `:127/171/200`);
+widgets branch on it.
+
+## Divergences → the observed symptoms
+
+### A. "Sometimes it doesn't hide"
+Only 3 widget classes implement the magic. Everything else drags with the
+cursor visible: `AestraEQEditor` band/knob drags, plugin editors (Verb, Sat,
+Filter, OTT, LFO editor knobs), `NUIUtilityWidgets` / `NUIMixerWidgets`
+sliders, `ExportDialog` sliders, piano-roll and timeline drag gestures.
+(Full per-widget census = first task of the implementation arc.)
+
+### B. "Reappears at unwanted positions"
+1. **Win32 coordinate bug**: widgets pass UI/window-space coords
+   (`bounds.x/y`) into `setCursorPosition` → bridge forwards verbatim →
+   `SetCursorPos()` interprets as **screen** coords. No `ClientToScreen`
+   anywhere in the chain. Every warp-back on Windows lands at
+   window-offset-wrong screen position. Linux is correct (window-relative).
+2. **No DPI / UI-scale conversion** in the warp path on either platform.
+3. **Inconsistent warp targets by design**: rotary → knob center; linear →
+   computed thumb position (separate H/V formulas, `sliderRadius_` insets);
+   three implementations drift independently.
+4. **Restore ordering**: warp and `setCursorStyle(Arrow)` order differs across
+   the three copies; if style is restored before the warp completes, the SVG
+   cursor renders ≥1 frame at the drifted OS-cursor position → visible jump.
+5. **Focus-loss mid-drag**: WindowManager's focus handler (`:438-440`)
+   flips OS-cursor visibility on focus change regardless of an active
+   Hidden-drag; widget never gets to warp back → cursor reappears wherever
+   the invisible OS cursor drifted.
+
+### C. Authority fights ("sometimes the magic dies")
+- Two hiding channels: style-based (`Hidden`) vs raw `setCursorVisible`.
+  Raw calls are silently ignored while the SVG cursor is active (`:539`) —
+  callers using the raw channel *think* they hid something.
+- Win32 `ShowCursor` is a per-thread **counter**; the impl loops to force
+  state and warns about cross-thread desync (`PlatformWindowWin32.cpp:1236`).
+- WindowManager decides SVG suppression by polling `getCursorStyle()` each
+  frame — races widget restore by up to a frame.
+- TrackManagerUI's cursor takes precedence over the SVG cursor via a
+  different flag, unrelated to both channels.
+
+## Recommended move: one owner, one API — `NUICursorService`
+
+Single state machine owned at the bridge/window-manager seam:
+
+```
+states: Normal(style) | CapturedDrag(token, restorePolicy)
+API:    beginDragCapture(DragCaptureSpec) -> CaptureToken
+        updateDrag(token)                  // delta accounting (already event-driven)
+        endDragCapture(token)              // warp-back + unhide, correct order
+        setStyle(style) / pushStyleOverride(provider)  // SVG + timeline cursors become providers
+```
+
+- **Hide** only via the style channel; raw `setCursorVisible` becomes private
+  to the service. The SVG cursor and TrackManagerUI cursor register as style
+  providers instead of parallel systems — one arbitration point.
+- **Warp-back** centralized: UI-space target → per-platform conversion
+  (`ClientToScreen` on Win32, window-relative on SDL), DPI-aware, and always
+  ordered warp-then-unhide. Restore policy enum: `KnobCenter`, `ThumbPosition`,
+  `GrabOrigin` — widgets declare intent, service computes.
+- **Cancellation safety**: service subscribes to focus-loss / window-leave and
+  performs the same restore path, so mid-drag interruptions can't strand a
+  hidden or mispositioned cursor.
+- `event.cursorCaptured` stamped from service state (single source).
+
+### Migration phases (each behavior-neutral, separately PR'd)
+1. **Service + NUISlider(rotary)** migrated as reference implementation;
+   Win32 ClientToScreen fix lands here (inside the service, one place).
+2. **UIMixerKnob + UIMixerFader** onto the service; delete their copies.
+3. **Adopt** in non-hiding drag surfaces: EQ editor first (highest-traffic
+   knobs), then plugin editors, utility/mixer widget sliders, ExportDialog.
+4. **Fold in** WindowManager SVG + TrackManagerUI cursors as style providers;
+   remove the raw `setCursorVisible` channel from widget reach; delete the
+   per-frame `getCursorStyle()` polling.
+
+### Open questions before phase 1
+- Census: exact list of drag surfaces for phase 3 (grep `onMouseEvent` +
+  drag-state members across AestraUI/Widgets + Source/Components).
+- Should linear sliders hide at all, or only rotary? (Current: NUISlider
+  hides only in rotary mode; fader hides. Decide the product rule.)
+- ~~Wayland: verify warp works on Hyprland~~ **RESOLVED 2026-07-19, empirical
+  (SDL 2.32.70, Hyprland, probe in scratchpad):**
+  - x11/XWayland: warp + hide fully work.
+  - Native Wayland: warp **works** once the window is mapped (needs a
+    committed buffer — bufferless windows never map) **and the pointer has
+    focus**; no `SDL_VIDEO_WAYLAND_EMULATE_MOUSE_WARP` hint needed on this
+    stack. Hide works.
+  - Warp is a **silent no-op without pointer focus**. Design consequence:
+    during a hidden infinite-drag the invisible pointer can drift OUT of the
+    window → focus lost → release-warp no-ops → cursor reappears outside the
+    window. This is the most plausible mechanism for the observed
+    "reappears at unwanted positions" on Linux. **The service must confine
+    the pointer during capture** (`SDL_SetWindowGrab` / pointer-constraints,
+    or re-warp-to-center each frame while focused) so release-warp is always
+    valid. Verify confinement in the real app during phase 1.
+  - Aestra runs the `wayland` driver by default on this machine (SDL 2.32
+    default preference; repo forces nothing).

--- a/AestraDocs/cursor-unification-map-2026-07.md
+++ b/AestraDocs/cursor-unification-map-2026-07.md
@@ -90,8 +90,18 @@ API:    beginDragCapture(DragCaptureSpec) -> CaptureToken
    per-frame `getCursorStyle()` polling.
 
 ### Open questions before phase 1
-- Census: exact list of drag surfaces for phase 3 (grep `onMouseEvent` +
-  drag-state members across AestraUI/Widgets + Source/Components).
+- ~~Census~~ **DONE 2026-07-19** (owner confirmed symptom: "some plugin knobs
+  still use the old rotary mouse"):
+  - **NUISlider-based → phase-1 magic free once merged**: AestraVerbEditor,
+    AestraDelayEditor, AestraCompEditor, AestraLimitEditor, NUIMixerWidgets,
+    UIMixerPanel.
+  - **Hand-rolled rotary drag, NO hide (phase-3 targets)**: AestraLFOEditor,
+    AestraSatEditor, RumblePluginEditor, AestraEQEditor, AestraFilterEditor,
+    AestraOTTEditor, AestraDriftEditor — all 7 have their own delta-drag code
+    and zero Hidden/capture usage.
+  - **Phase-2 targets** (own hide+warp copies to delete): UIMixerKnob,
+    UIMixerFader.
+  - FileBrowser drag = spatial (scroll) → keeps normal cursor per rule.
 - Should linear sliders hide at all, or only rotary? (Current: NUISlider
   hides only in rotary mode; fader hides. Decide the product rule.)
 - ~~Wayland: verify warp works on Hyprland~~ **RESOLVED 2026-07-19, empirical

--- a/AestraDocs/cursor-unification-map-2026-07.md
+++ b/AestraDocs/cursor-unification-map-2026-07.md
@@ -79,6 +79,37 @@ API:    beginDragCapture(DragCaptureSpec) -> CaptureToken
   hidden or mispositioned cursor.
 - `event.cursorCaptured` stamped from service state (single source).
 
+### Amended capture invariant (owner, 2026-07-19)
+
+> While captured, the physical pointer may generate deltas but no longer
+> participates in normal UI hover or hit-testing. `NUICursorService` owns
+> hover arbitration and exposes an anchored logical cursor position. Normal
+> widget hit-testing, hover transitions, tooltips, and style-provider changes
+> are suspended until capture ends or cancels.
+
+Implemented in phase 1 (bridge level):
+- **Routed dispatch**: motion/button/wheel events go ONLY to the capture
+  owner while captured; the rest of the tree never sees the wandering
+  pointer. (`s_cursorCaptureActive` already froze `setHovered` globally;
+  routing removes every other reaction class.)
+- **Style-steal guard**: external `setCursorStyle` calls are ignored during
+  capture (previously any widget under the hidden pointer could overwrite
+  `Hidden`, which un-clipped and broke the un-hide — the "cursor lost in
+  another panel" glitch). The service bypasses the guard internally.
+- **Anchored logical position**: `getCursorPosition()` and wheel-event
+  positions pin to the capture anchor (grab origin on the control);
+  physical position feeds deltas only.
+- **Focus-loss cancel**: synthetic release to the owner at the anchor, then
+  cancel (unhide in place, no warp) — the safe fallback.
+- **Owner-teardown guard**: widget dtors cancel an active capture so the
+  bridge never routes to a dangling owner.
+
+Deferred (phase 2.5, polish): small-rect confinement around the anchor +
+per-frame recenter warp with synthetic-motion suppression. Removes delta
+saturation when the hidden pointer reaches the window edge on very long
+drags (pre-existing limitation). Requires moving widgets from event-position
+deltas to service-provided deltas; do after phases 1-2 are validated by ear.
+
 ### Migration phases (each behavior-neutral, separately PR'd)
 1. **Service + NUISlider(rotary)** migrated as reference implementation;
    Win32 ClientToScreen fix lands here (inside the service, one place).

--- a/AestraPlat/include/AestraPlatform.h
+++ b/AestraPlat/include/AestraPlatform.h
@@ -224,10 +224,19 @@ public:
     // Thread requirements: MUST be called from the same thread that created the window (window thread).
     virtual void setCursorVisible(bool visible) = 0;
 
-    /** @brief Warp the cursor to a screen-space position. */
+    /**
+     * @brief Warp the cursor to a WINDOW-RELATIVE position (client-area coords).
+     *
+     * Contract: callers (NUI widgets, window manager) pass UI/window
+     * coordinates. Backends convert to whatever the OS API expects (Win32
+     * SetCursorPos is screen-space -> ClientToScreen; SDL warp is already
+     * window-relative). This doc previously said "screen-space", which only
+     * the Win32 backend believed — that mismatch sent every drag-release
+     * warp-back on Windows to the wrong screen position.
+     */
     virtual void setCursorPosition(int x, int y) = 0;
 
-    /** @brief Query the current cursor position in screen-space coordinates. */
+    /** @brief Query the current cursor position in WINDOW-RELATIVE coordinates. */
     virtual void getCursorPosition(int& x, int& y) const = 0;
 
     /** @brief Capture or release the mouse for drag operations outside the window. */

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -961,7 +961,7 @@ void PlatformWindowWin32::setCursorPosition(int x, int y) {
 
 void PlatformWindowWin32::getCursorPosition(int& x, int& y) const {
     // Symmetric with setCursorPosition: report window-relative client coords.
-    POINT pt;
+    POINT pt{}; // zero-init: a failed GetCursorPos (secure desktop switch) must not return garbage
     GetCursorPos(&pt);
     if (m_hwnd) {
         ScreenToClient(m_hwnd, &pt);

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -948,12 +948,24 @@ void PlatformWindowWin32::getPosition(int& x, int& y) const {
 }
 
 void PlatformWindowWin32::setCursorPosition(int x, int y) {
-    SetCursorPos(x, y);
+    // Interface contract is WINDOW-RELATIVE client coords (see AestraPlatform.h).
+    // SetCursorPos wants screen coords; convert. Client coords are physical
+    // pixels for a per-monitor-DPI-aware process, so ClientToScreen is the
+    // complete, DPI-correct conversion (mouse events arrive in the same space).
+    POINT pt{x, y};
+    if (m_hwnd) {
+        ClientToScreen(m_hwnd, &pt);
+    }
+    SetCursorPos(pt.x, pt.y);
 }
 
 void PlatformWindowWin32::getCursorPosition(int& x, int& y) const {
+    // Symmetric with setCursorPosition: report window-relative client coords.
     POINT pt;
     GetCursorPos(&pt);
+    if (m_hwnd) {
+        ScreenToClient(m_hwnd, &pt);
+    }
     x = pt.x;
     y = pt.y;
 }

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -97,13 +97,17 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
             if (platformBridge_)
             {
                 if (isRotary) {
-                    // Knob: warp to center — cursor appears where the knob is
+                    // Knob: end capture via the cursor service — warps to the
+                    // knob center (cursor reappears where the knob is), then
+                    // unhides, then releases confinement, in that order.
                     auto bounds = getBounds();
-                    platformBridge_->setCursorPosition(
+                    platformBridge_->cursorService().endDragCapture(
                         static_cast<int>(bounds.x + bounds.width * 0.5f),
                         static_cast<int>(bounds.y + bounds.height * 0.5f));
                 } else {
-                    // Linear: warp to thumb position (matches current value)
+                    // Linear: warp to thumb position (matches current value).
+                    // Linear drags never hide the cursor today; adoption of the
+                    // capture service here is a later migration phase.
                     auto b = getBounds();
                     if (orientation_ == Orientation::Horizontal) {
                         float inset = std::min(sliderRadius_, b.width * 0.5f);
@@ -118,8 +122,8 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
                             static_cast<int>(b.x + b.width * 0.5f),
                             static_cast<int>(b.y + inset + usableHeight * (1.0f - valueToProportionOfLength(value_))));
                     }
+                    platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
                 }
-                platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
             }
 
             isDragging_ = false;
@@ -177,8 +181,13 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
             // Check for fine-tuning modifier at drag start
             isFineDrag_ = (event.modifiers & (NUIModifiers::Ctrl | NUIModifiers::Super)) != 0;
 
-            // Hide cursor (this gives the "infinite travel" feel)
-            platformBridge_->setCursorStyle(NUICursorStyle::Hidden);
+            // Begin cursor capture (this gives the "infinite travel" feel):
+            // hides the cursor and confines the pointer to the window so the
+            // release-warp is always valid (native Wayland warps silently
+            // no-op once the hidden pointer drifts out and loses focus).
+            platformBridge_->cursorService().beginDragCapture(
+                NUICursorRestorePolicy::KnobCenter,
+                static_cast<int>(event.position.x), static_cast<int>(event.position.y));
         }
 
         // Click mode updates only on click, drag mode updates only while dragging.

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -33,6 +33,15 @@ NUISlider::NUISlider(const std::string& name)
     setSize(100, 6); // Modern 6px height for horizontal slider
 }
 
+NUISlider::~NUISlider()
+{
+    // Torn down mid-drag: cancel the capture so the bridge never routes to a
+    // dangling owner and the cursor is never stranded hidden.
+    if (isDragging_ && platformBridge_ && platformBridge_->cursorService().isCaptured()) {
+        platformBridge_->cancelCursorCapture();
+    }
+}
+
 void NUISlider::onRender(NUIRenderer& renderer)
 {
     if (!isVisible()) return;
@@ -101,7 +110,7 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
                     // knob center (cursor reappears where the knob is), then
                     // unhides, then releases confinement, in that order.
                     auto bounds = getBounds();
-                    platformBridge_->cursorService().endDragCapture(
+                    platformBridge_->endCursorCapture(
                         static_cast<int>(bounds.x + bounds.width * 0.5f),
                         static_cast<int>(bounds.y + bounds.height * 0.5f));
                 } else {
@@ -185,8 +194,8 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
             // hides the cursor and confines the pointer to the window so the
             // release-warp is always valid (native Wayland warps silently
             // no-op once the hidden pointer drifts out and loses focus).
-            platformBridge_->cursorService().beginDragCapture(
-                NUICursorRestorePolicy::KnobCenter,
+            platformBridge_->beginCursorCapture(
+                this, NUICursorRestorePolicy::KnobCenter,
                 static_cast<int>(event.position.x), static_cast<int>(event.position.y));
         }
 

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -37,7 +37,7 @@ NUISlider::~NUISlider()
 {
     // Torn down mid-drag: cancel the capture so the bridge never routes to a
     // dangling owner and the cursor is never stranded hidden.
-    if (isDragging_ && platformBridge_ && platformBridge_->cursorService().isCaptured()) {
+    if (platformBridge_ && platformBridge_->isCursorCaptureOwner(this)) {
         platformBridge_->cancelCursorCapture();
     }
 }

--- a/AestraUI/Base/NUISlider.h
+++ b/AestraUI/Base/NUISlider.h
@@ -41,7 +41,7 @@ public:
     };
 
     NUISlider(const std::string& name = "");
-    ~NUISlider() override = default;
+    ~NUISlider() override; // cancels an active cursor capture (see .cpp)
 
     // Component interface
     void onRender(NUIRenderer& renderer) override;

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -351,6 +351,8 @@ endif()
 set(AESTRAUI_PLATFORM_SOURCES
     Platform/NUIPlatformBridge.h
     Platform/NUIPlatformBridge.cpp
+    Platform/NUICursorService.h
+    Platform/NUICursorService.cpp
 )
 
 # Platform name for logging

--- a/AestraUI/Core/NUITypes.h
+++ b/AestraUI/Core/NUITypes.h
@@ -445,6 +445,8 @@ struct NUIMouseEvent {
     bool released = false;
     bool doubleClick = false;
     bool cursorCaptured = false;  // True during hidden-cursor drag; components should skip hover/tooltip updates
+    bool synthetic = false;       // Bridge-generated (focus-loss release, post-capture style re-resolution) —
+                                  // controls with commit-on-release semantics should treat this as "stop", not "accept"
 };
 
 struct NUIKeyEvent {

--- a/AestraUI/Platform/NUICursorService.cpp
+++ b/AestraUI/Platform/NUICursorService.cpp
@@ -3,7 +3,13 @@
 
 namespace AestraUI {
 
-void NUICursorService::beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY) {
+bool NUICursorService::beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY) {
+    if (m_inTransition) {
+        // A host callback fired during end/cancel tried to start a new capture
+        // before the old one reached idle. Refuse: interleaving hide/show/grab
+        // sequences would corrupt both captures' host state.
+        return false;
+    }
     if (m_captured) {
         // A begin while captured means a release event was lost (focus churn,
         // popup, teardown). Recover instead of wedging: restore visibility at
@@ -20,6 +26,7 @@ void NUICursorService::beginDragCapture(NUICursorRestorePolicy policy, int grabO
     // warp is a silent no-op once the (hidden) pointer drifts out of the
     // window and loses focus — the grab keeps the release-warp valid.
     m_host.hostSetPointerGrab(true);
+    return true;
 }
 
 void NUICursorService::endDragCapture(int restoreX, int restoreY) {
@@ -27,6 +34,7 @@ void NUICursorService::endDragCapture(int restoreX, int restoreY) {
         return;
     }
     m_captured = false;
+    m_inTransition = true;
 
     const int x = (m_policy == NUICursorRestorePolicy::GrabOrigin) ? m_grabOriginX : restoreX;
     const int y = (m_policy == NUICursorRestorePolicy::GrabOrigin) ? m_grabOriginY : restoreY;
@@ -37,6 +45,7 @@ void NUICursorService::endDragCapture(int restoreX, int restoreY) {
     m_host.hostWarpCursor(x, y);
     m_host.hostShowCursor();
     m_host.hostSetPointerGrab(false);
+    m_inTransition = false;
 }
 
 void NUICursorService::cancelDragCapture() {
@@ -44,10 +53,12 @@ void NUICursorService::cancelDragCapture() {
         return;
     }
     m_captured = false;
+    m_inTransition = true;
     // No warp: a cancel means the warp target may no longer be valid (focus
     // gone, window hidden). Just make the cursor visible wherever it is.
     m_host.hostShowCursor();
     m_host.hostSetPointerGrab(false);
+    m_inTransition = false;
 }
 
 } // namespace AestraUI

--- a/AestraUI/Platform/NUICursorService.cpp
+++ b/AestraUI/Platform/NUICursorService.cpp
@@ -1,0 +1,53 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "NUICursorService.h"
+
+namespace AestraUI {
+
+void NUICursorService::beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY) {
+    if (m_captured) {
+        // A begin while captured means a release event was lost (focus churn,
+        // popup, teardown). Recover instead of wedging: restore visibility at
+        // the platform's current position, then start the new capture.
+        cancelDragCapture();
+    }
+    m_policy = policy;
+    m_grabOriginX = grabOriginX;
+    m_grabOriginY = grabOriginY;
+    m_captured = true;
+
+    m_host.hostHideCursor();
+    // Confine the pointer for the duration of the capture: on native Wayland a
+    // warp is a silent no-op once the (hidden) pointer drifts out of the
+    // window and loses focus — the grab keeps the release-warp valid.
+    m_host.hostSetPointerGrab(true);
+}
+
+void NUICursorService::endDragCapture(int restoreX, int restoreY) {
+    if (!m_captured) {
+        return;
+    }
+    m_captured = false;
+
+    const int x = (m_policy == NUICursorRestorePolicy::GrabOrigin) ? m_grabOriginX : restoreX;
+    const int y = (m_policy == NUICursorRestorePolicy::GrabOrigin) ? m_grabOriginY : restoreY;
+
+    // Order matters: warp while still hidden so the cursor never renders a
+    // frame at the drifted pre-warp position, then unhide, then release the
+    // grab (releasing first would let the warp race the un-confinement).
+    m_host.hostWarpCursor(x, y);
+    m_host.hostShowCursor();
+    m_host.hostSetPointerGrab(false);
+}
+
+void NUICursorService::cancelDragCapture() {
+    if (!m_captured) {
+        return;
+    }
+    m_captured = false;
+    // No warp: a cancel means the warp target may no longer be valid (focus
+    // gone, window hidden). Just make the cursor visible wherever it is.
+    m_host.hostShowCursor();
+    m_host.hostSetPointerGrab(false);
+}
+
+} // namespace AestraUI

--- a/AestraUI/Platform/NUICursorService.h
+++ b/AestraUI/Platform/NUICursorService.h
@@ -78,6 +78,15 @@ public:
     bool isCaptured() const { return m_captured; }
     NUICursorRestorePolicy activePolicy() const { return m_policy; }
 
+    /**
+     * Anchored logical cursor position while captured (the grab origin — a
+     * point on the control). The physical pointer only produces deltas during
+     * capture; anything that needs "where the cursor is" (wheel routing,
+     * position queries) should see the anchor, not the drifting pointer.
+     */
+    int anchorX() const { return m_grabOriginX; }
+    int anchorY() const { return m_grabOriginY; }
+
 private:
     NUICursorHost& m_host;
     bool m_captured = false;

--- a/AestraUI/Platform/NUICursorService.h
+++ b/AestraUI/Platform/NUICursorService.h
@@ -57,8 +57,13 @@ class NUICursorService {
 public:
     explicit NUICursorService(NUICursorHost& host) : m_host(host) {}
 
-    /** Begin an infinite-drag capture: hides the cursor and confines the pointer. */
-    void beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY);
+    /**
+     * Begin an infinite-drag capture: hides the cursor and confines the pointer.
+     * @return false (no capture started) when called reentrantly from an
+     * end/cancel host callback — the old capture must fully transition to
+     * idle before a new one may begin.
+     */
+    bool beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY);
 
     /**
      * End the capture: warp to the restore point, then unhide, then release
@@ -90,6 +95,7 @@ public:
 private:
     NUICursorHost& m_host;
     bool m_captured = false;
+    bool m_inTransition = false; // guards against re-begin from end/cancel callbacks
     NUICursorRestorePolicy m_policy = NUICursorRestorePolicy::GrabOrigin;
     int m_grabOriginX = 0;
     int m_grabOriginY = 0;

--- a/AestraUI/Platform/NUICursorService.h
+++ b/AestraUI/Platform/NUICursorService.h
@@ -1,0 +1,89 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+/**
+ * @file NUICursorService.h
+ * @brief Single owner of pointer-capture ("infinite drag") cursor behavior.
+ *
+ * Continuous parameter controls (knobs, parameter sliders, faders) hide the
+ * cursor while dragging and restore it at a semantically meaningful position
+ * on release. Before this service, three widgets each hand-rolled that
+ * pattern with divergent warp targets, restore ordering, and no platform
+ * awareness (see AestraDocs/cursor-unification-map-2026-07.md).
+ *
+ * The service is the one place that knows:
+ *  - hide/unhide ordering (always warp BEFORE unhide, so the cursor never
+ *    renders a frame at the drifted position),
+ *  - pointer confinement during capture (native Wayland warps are silent
+ *    no-ops without pointer focus; grabbing keeps focus valid so the
+ *    release-warp lands — with a safe no-warp fallback otherwise),
+ *  - platform coordinate conversion (delegated to the platform window,
+ *    whose contract is window-relative UI coordinates).
+ *
+ * Phase 1 scope: rotary NUISlider is the reference client. Interaction-based
+ * product rule (owner, 2026-07-19): all continuous parameter controls adopt
+ * capture in later phases; spatial interactions (scrollbars, timeline/clip
+ * drags, piano roll, range handles) keep the normal cursor.
+ */
+
+namespace AestraUI {
+
+/** Where the cursor reappears when a capture ends. */
+enum class NUICursorRestorePolicy {
+    KnobCenter,     ///< Center of the control's bounds (rotary knobs).
+    ThumbPosition,  ///< Position representing the current value (linear thumbs).
+    GrabOrigin      ///< Where the pointer was when capture began.
+};
+
+/**
+ * @brief Minimal host the service drives. Implemented by NUIPlatformBridge;
+ * a fake in tests exercises the state machine headlessly.
+ */
+class NUICursorHost {
+public:
+    virtual ~NUICursorHost() = default;
+    virtual void hostHideCursor() = 0;                 ///< Style-channel hide (Hidden).
+    virtual void hostShowCursor() = 0;                 ///< Style-channel restore (Arrow).
+    virtual void hostWarpCursor(int x, int y) = 0;     ///< Window-relative UI coords.
+    virtual void hostSetPointerGrab(bool grabbed) = 0; ///< Confine pointer to window.
+};
+
+/**
+ * @brief State machine: Idle <-> Captured. One capture at a time (pointer
+ * interactions are inherently exclusive); re-begin while captured is treated
+ * as a cancel + begin so a lost release event can never wedge the cursor.
+ */
+class NUICursorService {
+public:
+    explicit NUICursorService(NUICursorHost& host) : m_host(host) {}
+
+    /** Begin an infinite-drag capture: hides the cursor and confines the pointer. */
+    void beginDragCapture(NUICursorRestorePolicy policy, int grabOriginX, int grabOriginY);
+
+    /**
+     * End the capture: warp to the restore point, then unhide, then release
+     * the grab. @p restoreX/Y are the client-computed restore coordinates for
+     * the policy (KnobCenter/ThumbPosition); ignored for GrabOrigin, which
+     * uses the stored begin position.
+     */
+    void endDragCapture(int restoreX, int restoreY);
+
+    /**
+     * Abort without warping (focus lost, window deactivated, client destroyed
+     * mid-drag). Unhides and releases the grab; the cursor stays where the
+     * platform last had it — the safe fallback when a warp cannot land.
+     */
+    void cancelDragCapture();
+
+    bool isCaptured() const { return m_captured; }
+    NUICursorRestorePolicy activePolicy() const { return m_policy; }
+
+private:
+    NUICursorHost& m_host;
+    bool m_captured = false;
+    NUICursorRestorePolicy m_policy = NUICursorRestorePolicy::GrabOrigin;
+    int m_grabOriginX = 0;
+    int m_grabOriginY = 0;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -131,7 +131,14 @@ void NUIPlatformBridge::setupEventBridges() {
                 event.modifiers = convertModifiers(mods);
             }
 
-            m_rootComponent->onMouseEvent(event);
+            // Routed dispatch: while captured, ONLY the capture owner sees
+            // motion — the rest of the tree must not hit-test, hover, or
+            // react to the hidden wandering pointer.
+            if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
+                m_cursorCaptureOwner->onMouseEvent(event);
+            } else {
+                m_rootComponent->onMouseEvent(event);
+            }
         }
     });
 
@@ -174,7 +181,11 @@ void NUIPlatformBridge::setupEventBridges() {
                 mods.capsLock = mods.capsLock || m_capsLockLatched;
                 event.modifiers = convertModifiers(mods);
             }
-            m_rootComponent->onMouseEvent(event);
+            if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
+                m_cursorCaptureOwner->onMouseEvent(event);
+            } else {
+                m_rootComponent->onMouseEvent(event);
+            }
         }
     });
 
@@ -192,7 +203,10 @@ void NUIPlatformBridge::setupEventBridges() {
         if (m_rootComponent) {
             NUIMouseEvent event;
             event.type = NUIMouseEventType::Scroll;
-            event.position = {static_cast<float>(m_lastMouseX), static_cast<float>(m_lastMouseY)};
+            event.position = m_cursorService.isCaptured()
+                ? NUIPoint{static_cast<float>(m_cursorService.anchorX()),
+                           static_cast<float>(m_cursorService.anchorY())}
+                : NUIPoint{static_cast<float>(m_lastMouseX), static_cast<float>(m_lastMouseY)};
             event.button = NUIMouseButton::None;
             event.pressed = false;
             event.released = false;
@@ -204,7 +218,11 @@ void NUIPlatformBridge::setupEventBridges() {
                 mods.capsLock = mods.capsLock || m_capsLockLatched;
                 event.modifiers = convertModifiers(mods);
             }
-            m_rootComponent->onMouseEvent(event);
+            if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
+                m_cursorCaptureOwner->onMouseEvent(event);
+            } else {
+                m_rootComponent->onMouseEvent(event);
+            }
         }
     });
 
@@ -271,6 +289,28 @@ void NUIPlatformBridge::setupEventBridges() {
 
     // Window focus
     m_window->setFocusCallback([this](bool focused) {
+        // Focus loss mid-capture: the release event may never arrive and a
+        // warp can no longer land. Cancel (unhide in place, drop confinement)
+        // BEFORE forwarding, so downstream focus handling sees a sane cursor.
+        if (!focused && m_cursorService.isCaptured()) {
+            if (m_cursorCaptureOwner) {
+                // Let the owner terminate its drag state with a synthetic
+                // release at the anchor (value stays where the drag left it).
+                NUIMouseEvent event;
+                event.type = NUIMouseEventType::Up;
+                event.position = {static_cast<float>(m_cursorService.anchorX()),
+                                  static_cast<float>(m_cursorService.anchorY())};
+                event.button = NUIMouseButton::Left;
+                event.pressed = false;
+                event.released = true;
+                event.wheelDelta = 0.0f;
+                event.cursorCaptured = true;
+                m_cursorCaptureOwner->onMouseEvent(event);
+            }
+            // If the owner's release path already ended the capture (normal
+            // case), this is a no-op; otherwise it is the safety net.
+            cancelCursorCapture();
+        }
         if (m_focusCallback) {
             m_focusCallback(focused);
         }
@@ -502,11 +542,32 @@ void NUIPlatformBridge::setCursorPosition(int x, int y) {
 }
 
 NUIPoint NUIPlatformBridge::getCursorPosition() const {
+    // While captured, the logical cursor is pinned to the capture anchor —
+    // the physical pointer only exists to produce deltas.
+    if (m_cursorService.isCaptured()) {
+        return NUIPoint(static_cast<float>(m_cursorService.anchorX()),
+                        static_cast<float>(m_cursorService.anchorY()));
+    }
     int x = 0, y = 0;
     if (m_window) {
         m_window->getCursorPosition(x, y);
     }
     return NUIPoint(static_cast<float>(x), static_cast<float>(y));
+}
+
+void NUIPlatformBridge::beginCursorCapture(NUIComponent* owner, NUICursorRestorePolicy policy, int x, int y) {
+    m_cursorCaptureOwner = owner;
+    m_cursorService.beginDragCapture(policy, x, y);
+}
+
+void NUIPlatformBridge::endCursorCapture(int x, int y) {
+    m_cursorService.endDragCapture(x, y);
+    m_cursorCaptureOwner = nullptr;
+}
+
+void NUIPlatformBridge::cancelCursorCapture() {
+    m_cursorService.cancelDragCapture();
+    m_cursorCaptureOwner = nullptr;
 }
 
 void NUIPlatformBridge::setMouseCapture(bool captured) {
@@ -516,6 +577,17 @@ void NUIPlatformBridge::setMouseCapture(bool captured) {
 }
 
 void NUIPlatformBridge::setCursorStyle(NUICursorStyle style) {
+    // Style-steal guard: while a drag capture is active, widgets under the
+    // hidden wandering pointer must not change the cursor style — doing so
+    // would unhide/unclip mid-drag and break the capture. The service itself
+    // bypasses this via applyCursorStyle (see CursorHostImpl).
+    if (m_cursorService.isCaptured() && style != NUICursorStyle::Hidden) {
+        return;
+    }
+    applyCursorStyle(style);
+}
+
+void NUIPlatformBridge::applyCursorStyle(NUICursorStyle style) {
     m_currentCursorStyle = style;
     
 #ifdef _WIN32

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -218,6 +218,9 @@ void NUIPlatformBridge::setupEventBridges() {
                 mods.capsLock = mods.capsLock || m_capsLockLatched;
                 event.modifiers = convertModifiers(mods);
             }
+            // Intentional: wheel during capture adjusts the CAPTURED control
+            // (anchored position above); it must never leak to whatever sits
+            // under the hidden physical pointer.
             if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
                 m_cursorCaptureOwner->onMouseEvent(event);
             } else {
@@ -293,23 +296,29 @@ void NUIPlatformBridge::setupEventBridges() {
         // warp can no longer land. Cancel (unhide in place, drop confinement)
         // BEFORE forwarding, so downstream focus handling sees a sane cursor.
         if (!focused && m_cursorService.isCaptured()) {
-            if (m_cursorCaptureOwner) {
-                // Let the owner terminate its drag state with a synthetic
-                // release at the anchor (value stays where the drag left it).
+            // Cancel FIRST (unhide in place, drop confinement, NO warp — a
+            // warp cannot land without focus), THEN let the owner tear down
+            // its drag state with a synthetic release at the anchor. Because
+            // the service is already idle, the owner's normal release path
+            // calling endCursorCapture() is a harmless no-op — the no-warp
+            // guarantee of focus-loss cancellation survives the owner's own
+            // cleanup logic.
+            const int anchorX = m_cursorService.anchorX();
+            const int anchorY = m_cursorService.anchorY();
+            NUIComponent* owner = m_cursorCaptureOwner;
+            cancelCursorCapture();
+            if (owner) {
                 NUIMouseEvent event;
                 event.type = NUIMouseEventType::Up;
-                event.position = {static_cast<float>(m_cursorService.anchorX()),
-                                  static_cast<float>(m_cursorService.anchorY())};
+                event.position = {static_cast<float>(anchorX), static_cast<float>(anchorY)};
                 event.button = NUIMouseButton::Left;
                 event.pressed = false;
                 event.released = true;
                 event.wheelDelta = 0.0f;
                 event.cursorCaptured = true;
-                m_cursorCaptureOwner->onMouseEvent(event);
+                event.synthetic = true; // "stop", not "accept" — see NUIMouseEvent
+                owner->onMouseEvent(event);
             }
-            // If the owner's release path already ended the capture (normal
-            // case), this is a no-op; otherwise it is the safety net.
-            cancelCursorCapture();
         }
         if (m_focusCallback) {
             m_focusCallback(focused);
@@ -352,6 +361,29 @@ void NUIPlatformBridge::hide() {
 }
 
 bool NUIPlatformBridge::processEvents() {
+    // Post-capture style resolution: after end/cancel the cursor reappeared
+    // somewhere (knob center, thumb, or wherever cancel left it), but no real
+    // motion has occurred — a resize handle or text field under that point
+    // would show a stale Arrow until the mouse moves. Dispatch one synthetic
+    // Move at the restored position so hover and cursor style re-resolve.
+    // Deferred to here (not done inside end/cancel) so the tree is never
+    // re-entered from within the owner's own release handling.
+    if (m_pendingStyleResolve && !m_cursorService.isCaptured()) {
+        m_pendingStyleResolve = false;
+        if (m_rootComponent) {
+            NUIMouseEvent event;
+            event.type = NUIMouseEventType::Move;
+            event.position = getCursorPosition();
+            event.button = NUIMouseButton::None;
+            event.synthetic = true;
+            if (m_window) {
+                auto mods = m_window->getCurrentModifiers();
+                mods.capsLock = mods.capsLock || m_capsLockLatched;
+                event.modifiers = convertModifiers(mods);
+            }
+            m_rootComponent->onMouseEvent(event);
+        }
+    }
     return m_window ? m_window->pollEvents() : false;
 }
 
@@ -556,18 +588,24 @@ NUIPoint NUIPlatformBridge::getCursorPosition() const {
 }
 
 void NUIPlatformBridge::beginCursorCapture(NUIComponent* owner, NUICursorRestorePolicy policy, int x, int y) {
-    m_cursorCaptureOwner = owner;
-    m_cursorService.beginDragCapture(policy, x, y);
+    // Owner is registered only if the service accepts the capture (it refuses
+    // reentrant begins during an end/cancel transition) — routing must never
+    // point at an owner whose capture never started.
+    if (m_cursorService.beginDragCapture(policy, x, y)) {
+        m_cursorCaptureOwner = owner;
+    }
 }
 
 void NUIPlatformBridge::endCursorCapture(int x, int y) {
     m_cursorService.endDragCapture(x, y);
     m_cursorCaptureOwner = nullptr;
+    m_pendingStyleResolve = true;
 }
 
 void NUIPlatformBridge::cancelCursorCapture() {
     m_cursorService.cancelDragCapture();
     m_cursorCaptureOwner = nullptr;
+    m_pendingStyleResolve = true;
 }
 
 void NUIPlatformBridge::setMouseCapture(bool captured) {

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -120,10 +120,24 @@ public:
 
     /**
      * Single owner of infinite-drag cursor capture (hide + confine + warp-back).
-     * Continuous parameter controls call this instead of hand-rolling
-     * setCursorStyle(Hidden)/setCursorPosition sequences.
+     * Continuous parameter controls call the begin/end/cancel wrappers below;
+     * the service accessor is for state queries (isCaptured, anchor).
      */
     NUICursorService& cursorService() { return m_cursorService; }
+
+    /**
+     * Begin an infinite-drag capture owned by @p owner. While captured:
+     *  - motion/button/wheel events route ONLY to the owner (the rest of the
+     *    tree neither hit-tests nor hovers under the hidden pointer),
+     *  - external setCursorStyle calls are ignored (no style-steal can unhide
+     *    or unclip mid-drag),
+     *  - the logical cursor position is pinned to the capture anchor.
+     */
+    void beginCursorCapture(NUIComponent* owner, NUICursorRestorePolicy policy, int x, int y);
+    /** End the capture, restoring at (x, y) per the begin policy. */
+    void endCursorCapture(int x, int y);
+    /** Abort without warping (focus loss, owner teardown). */
+    void cancelCursorCapture();
 
 private:
     // NUICursorHost backing for m_cursorService: hide/show ride the existing
@@ -133,8 +147,8 @@ private:
     class CursorHostImpl : public NUICursorHost {
     public:
         explicit CursorHostImpl(NUIPlatformBridge& bridge) : m_bridge(bridge) {}
-        void hostHideCursor() override { m_bridge.setCursorStyle(NUICursorStyle::Hidden); }
-        void hostShowCursor() override { m_bridge.setCursorStyle(NUICursorStyle::Arrow); }
+        void hostHideCursor() override { m_bridge.applyCursorStyle(NUICursorStyle::Hidden); }
+        void hostShowCursor() override { m_bridge.applyCursorStyle(NUICursorStyle::Arrow); }
         void hostWarpCursor(int x, int y) override { m_bridge.setCursorPosition(x, y); }
         void hostSetPointerGrab(bool grabbed) override {
             if (m_bridge.m_window) m_bridge.m_window->setCursorClip(grabbed);
@@ -169,6 +183,13 @@ private:
     // service holds a reference to the host).
     CursorHostImpl m_cursorHost{*this};
     NUICursorService m_cursorService{m_cursorHost};
+    // Component that owns the active capture; all mouse events route here
+    // while the service is captured.
+    NUIComponent* m_cursorCaptureOwner = nullptr;
+
+    // The style channel with no capture guard — used by the cursor host so the
+    // service itself can hide/unhide while external calls are locked out.
+    void applyCursorStyle(NUICursorStyle style);
     
     // AestraUI-style callbacks
     std::function<void(int, int)> m_mouseMoveCallback;

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -138,6 +138,10 @@ public:
     void endCursorCapture(int x, int y);
     /** Abort without warping (focus loss, owner teardown). */
     void cancelCursorCapture();
+    /** True iff @p c owns the currently active capture (for owner-specific teardown). */
+    bool isCursorCaptureOwner(const NUIComponent* c) const {
+        return m_cursorService.isCaptured() && m_cursorCaptureOwner == c;
+    }
 
 private:
     // NUICursorHost backing for m_cursorService: hide/show ride the existing
@@ -186,6 +190,10 @@ private:
     // Component that owns the active capture; all mouse events route here
     // while the service is captured.
     NUIComponent* m_cursorCaptureOwner = nullptr;
+    // Set when a capture ends/cancels: next processEvents() dispatches one
+    // synthetic Move at the restored cursor position so hover and cursor
+    // style re-resolve from where the cursor actually reappeared.
+    bool m_pendingStyleResolve = false;
 
     // The style channel with no capture guard — used by the cursor host so the
     // service itself can hide/unhide while external calls are locked out.

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "../../AestraPlat/include/AestraPlatform.h"
+#include "NUICursorService.h"
 #include "NUITypes.h"
 #include <functional>
 
@@ -117,7 +118,32 @@ public:
     // Mouse Capture
     void setMouseCapture(bool captured);
 
+    /**
+     * Single owner of infinite-drag cursor capture (hide + confine + warp-back).
+     * Continuous parameter controls call this instead of hand-rolling
+     * setCursorStyle(Hidden)/setCursorPosition sequences.
+     */
+    NUICursorService& cursorService() { return m_cursorService; }
+
 private:
+    // NUICursorHost backing for m_cursorService: hide/show ride the existing
+    // style channel (which already clips/unclips and stamps cursorCaptured on
+    // events); the explicit grab call is belt-and-braces confinement so the
+    // service's contract holds even if the style path changes.
+    class CursorHostImpl : public NUICursorHost {
+    public:
+        explicit CursorHostImpl(NUIPlatformBridge& bridge) : m_bridge(bridge) {}
+        void hostHideCursor() override { m_bridge.setCursorStyle(NUICursorStyle::Hidden); }
+        void hostShowCursor() override { m_bridge.setCursorStyle(NUICursorStyle::Arrow); }
+        void hostWarpCursor(int x, int y) override { m_bridge.setCursorPosition(x, y); }
+        void hostSetPointerGrab(bool grabbed) override {
+            if (m_bridge.m_window) m_bridge.m_window->setCursorClip(grabbed);
+        }
+
+    private:
+        NUIPlatformBridge& m_bridge;
+    };
+
     // Convert AestraPlat events to AestraUI events
     void setupEventBridges();
     int convertMouseButton(Aestra::MouseButton button);
@@ -138,6 +164,11 @@ private:
     
     // Cursor style tracking
     NUICursorStyle m_currentCursorStyle = NUICursorStyle::Arrow;
+
+    // Cursor capture service (declaration order: host before service — the
+    // service holds a reference to the host).
+    CursorHostImpl m_cursorHost{*this};
+    NUICursorService m_cursorService{m_cursorHost};
     
     // AestraUI-style callbacks
     std::function<void(int, int)> m_mouseMoveCallback;

--- a/Tests/AestraUI/CursorServiceTest.cpp
+++ b/Tests/AestraUI/CursorServiceTest.cpp
@@ -98,6 +98,39 @@ void testBeginWhileCapturedRecovers() {
     std::puts("  begin-while-captured recovery: ok");
 }
 
+void testReentrantBeginRefused() {
+    struct EvilHost : NUICursorHost {
+        NUICursorService* svc = nullptr;
+        bool reentrantResult = true;
+        std::vector<std::string> calls;
+        void hostHideCursor() override { calls.push_back("hide"); }
+        void hostShowCursor() override {
+            calls.push_back("show");
+            // Fires during end/cancel transition: a begin here must be REFUSED
+            // so the old capture fully reaches idle first.
+            if (svc) reentrantResult = svc->beginDragCapture(NUICursorRestorePolicy::KnobCenter, 5, 5);
+        }
+        void hostWarpCursor(int x, int y) override {
+            calls.push_back("warp:" + std::to_string(x) + "," + std::to_string(y));
+        }
+        void hostSetPointerGrab(bool g) override { calls.push_back(g ? "grab" : "ungrab"); }
+    };
+    EvilHost host;
+    NUICursorService svc(host);
+    host.svc = &svc;
+    CHECK(svc.beginDragCapture(NUICursorRestorePolicy::KnobCenter, 1, 1));
+    svc.endDragCapture(9, 9);
+    CHECK(host.reentrantResult == false); // the mid-transition begin was refused
+    CHECK(!svc.isCaptured());             // and the service ended at idle
+    // Full, uncorrupted end sequence despite the reentrant attempt.
+    CHECK((host.calls == std::vector<std::string>{"hide", "grab", "warp:9,9", "show", "ungrab"}));
+    // After the transition completes, a fresh begin works again.
+    host.svc = nullptr;
+    CHECK(svc.beginDragCapture(NUICursorRestorePolicy::GrabOrigin, 2, 2));
+    CHECK(svc.isCaptured());
+    std::puts("  reentrant-begin refused: ok");
+}
+
 } // namespace
 
 int main() {
@@ -106,6 +139,7 @@ int main() {
     testGrabOriginPolicy();
     testCancelDoesNotWarp();
     testBeginWhileCapturedRecovers();
+    testReentrantBeginRefused();
     if (g_failures == 0) {
         std::puts("CursorServiceTest: PASS");
         return 0;

--- a/Tests/AestraUI/CursorServiceTest.cpp
+++ b/Tests/AestraUI/CursorServiceTest.cpp
@@ -1,0 +1,115 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// CursorServiceTest — pins the NUICursorService state machine (cursor
+// unification phase 1). A fake host records the exact call sequence so the
+// invariants that make the "infinite drag" magic reliable are enforced:
+//   * begin: hide THEN grab
+//   * end: warp THEN show THEN ungrab (cursor never renders at the drifted
+//     pre-warp position; grab released only after the warp landed)
+//   * cancel: show + ungrab, NO warp (safe fallback when focus is gone)
+//   * GrabOrigin policy restores the stored begin position
+//   * begin-while-captured recovers (cancel + fresh begin) instead of wedging
+
+#include "../../AestraUI/Platform/NUICursorService.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL (line %d): %s\n", __LINE__, #cond);     \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+struct FakeHost : NUICursorHost {
+    std::vector<std::string> calls;
+    void hostHideCursor() override { calls.push_back("hide"); }
+    void hostShowCursor() override { calls.push_back("show"); }
+    void hostWarpCursor(int x, int y) override {
+        calls.push_back("warp:" + std::to_string(x) + "," + std::to_string(y));
+    }
+    void hostSetPointerGrab(bool g) override { calls.push_back(g ? "grab" : "ungrab"); }
+};
+
+void testBeginEndOrdering() {
+    FakeHost host;
+    NUICursorService svc(host);
+    CHECK(!svc.isCaptured());
+
+    svc.beginDragCapture(NUICursorRestorePolicy::KnobCenter, 10, 20);
+    CHECK(svc.isCaptured());
+    CHECK((host.calls == std::vector<std::string>{"hide", "grab"}));
+
+    svc.endDragCapture(100, 200);
+    CHECK(!svc.isCaptured());
+    CHECK((host.calls ==
+           std::vector<std::string>{"hide", "grab", "warp:100,200", "show", "ungrab"}));
+    std::puts("  begin/end ordering: ok");
+}
+
+void testGrabOriginPolicy() {
+    FakeHost host;
+    NUICursorService svc(host);
+    svc.beginDragCapture(NUICursorRestorePolicy::GrabOrigin, 33, 44);
+    svc.endDragCapture(999, 999); // args must be ignored for GrabOrigin
+    CHECK((host.calls ==
+           std::vector<std::string>{"hide", "grab", "warp:33,44", "show", "ungrab"}));
+    std::puts("  grab-origin policy: ok");
+}
+
+void testCancelDoesNotWarp() {
+    FakeHost host;
+    NUICursorService svc(host);
+    svc.beginDragCapture(NUICursorRestorePolicy::KnobCenter, 1, 2);
+    svc.cancelDragCapture();
+    CHECK(!svc.isCaptured());
+    CHECK((host.calls == std::vector<std::string>{"hide", "grab", "show", "ungrab"}));
+
+    // end/cancel when idle are no-ops
+    svc.endDragCapture(5, 5);
+    svc.cancelDragCapture();
+    CHECK((host.calls == std::vector<std::string>{"hide", "grab", "show", "ungrab"}));
+    std::puts("  cancel semantics: ok");
+}
+
+void testBeginWhileCapturedRecovers() {
+    FakeHost host;
+    NUICursorService svc(host);
+    svc.beginDragCapture(NUICursorRestorePolicy::KnobCenter, 1, 1);
+    // Lost release event; a second begin must cancel (show+ungrab, no warp)
+    // then start cleanly.
+    svc.beginDragCapture(NUICursorRestorePolicy::GrabOrigin, 7, 8);
+    CHECK(svc.isCaptured());
+    CHECK((host.calls == std::vector<std::string>{"hide", "grab",       // first
+                                                  "show", "ungrab",     // recovery cancel
+                                                  "hide", "grab"}));    // second
+    svc.endDragCapture(0, 0);
+    CHECK((host.calls.back() == "ungrab"));
+    CHECK((host.calls[host.calls.size() - 3] == "warp:7,8")); // GrabOrigin of second begin
+    std::puts("  begin-while-captured recovery: ok");
+}
+
+} // namespace
+
+int main() {
+    std::puts("CursorServiceTest:");
+    testBeginEndOrdering();
+    testGrabOriginPolicy();
+    testCancelDoesNotWarp();
+    testBeginWhileCapturedRecovers();
+    if (g_failures == 0) {
+        std::puts("CursorServiceTest: PASS");
+        return 0;
+    }
+    std::fprintf(stderr, "CursorServiceTest: FAILED (%d checks)\n", g_failures);
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1804,6 +1804,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/TextRendererSTBSpaceTest.cpp")
     message(STATUS "TextRendererSTBSpaceTest added - Issue #121 regression test")
 endif()
 
+# NUICursorService state machine (cursor unification phase 1). Compiles the
+# service .cpp directly (dependency-free) so it also runs in headless builds.
+add_executable(CursorServiceTest
+    AestraUI/CursorServiceTest.cpp
+    ${CMAKE_SOURCE_DIR}/AestraUI/Platform/NUICursorService.cpp
+)
+add_test(NAME CursorServiceTest COMMAND CursorServiceTest)
+set_tests_properties(CursorServiceTest PROPERTIES LABELS "ui;cursor;regression" TIMEOUT 60)
+
 # NUITheme JSON loading test (Issue #259)
 # Compiles NUITheme.cpp directly (its only deps are header-only: NUITypes.h,
 # AestraJSON.h, AestraLog.h) so the test also runs in headless builds where


### PR DESCRIPTION
## Summary
Phase 1 of the cursor-unification arc (full map: `AestraDocs/cursor-unification-map-2026-07.md`, included). Behavior-neutral by design: introduces `NUICursorService`, migrates only the existing rotary `NUISlider` behavior, and centralizes both platform fixes. Linear sliders / mixer knob+fader copies migrate in later phases per the interaction-based product rule (continuous parameter controls capture; spatial interactions keep the normal cursor).

## Service state machine
`Idle <-> Captured` over a minimal `NUICursorHost` (bridge implements it; tests fake it):
- **begin**: hide → grab (confinement)
- **end**: warp → show → ungrab — cursor never renders a frame at the drifted pre-warp position, confinement released only after the warp landed
- **cancel**: show + ungrab, **no warp** — safe fallback when focus is gone
- begin-while-captured recovers (cancel + fresh begin) so a lost release can't wedge a hidden cursor
- Restore policies: `KnobCenter` / `ThumbPosition` / `GrabOrigin`

## Platform behavior
- **Wayland (empirical, Hyprland/SDL 2.32)**: warp works while the pointer has focus; silent no-op otherwise. Grab maps to `setCursorClip` → `SDL_SetWindowMouseRect` → pointer-constraints, keeping focus valid so release-warp always lands; `cancel` covers the unfocusable cases.
- **Windows**: `IPlatformWindow::set/getCursorPosition` contract corrected to WINDOW-RELATIVE (what every caller already passes, and what the SDL backend already implemented). Win32 now does `ClientToScreen`/`ScreenToClient`; client coords are physical pixels under per-monitor DPI awareness, so this is the complete DPI-correct conversion. Previously every warp-back on Windows landed at a wrong absolute screen position; the interface doc itself carried the contradiction.

## Testing performed
- `CursorServiceTest` (new, dependency-free, runs headless): pins call ordering, policies, cancel semantics, lost-release recovery — PASS.
- Full app builds; Hyprland boot smoke clean (window maps, no errors).
- Rotary drag behavior preserved verbatim (same hide, same delta math untouched, same knob-center restore, same ordering); linear-slider release warp untouched.
- **Not tested locally**: Windows runtime behavior (no Windows box) — compiles in CI; the conversion mirrors the WM_MOUSEMOVE event path exactly. Flagging for the next Windows session smoke.

## Observed regressions
None locally. Watch item: `getCursorPosition` on Win32 now returns client coords (one caller, `AestraWindowManager:911`, always expected that — it worked on Linux).

## Docs
Map + step-zero Wayland findings committed under AestraDocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Behavior change:** Cursor positioning now uses window-relative client coordinates, with DPI-correct Win32 conversions.
- Added `NUICursorService` to centralize infinite-drag capture, restoration, cancellation, confinement, and recovery.
- Routed captured pointer events exclusively to the owning component, with anchored positions, style protection, focus-loss cancellation, and teardown safety.
- Migrated rotary `NUISlider` capture handling to the service; linear sliders and mixer copies remain unchanged.
- Added documentation covering cursor ownership, migration phases, and platform behavior.
- Added regression tests covering lifecycle ordering, restore policies, cancellation, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->