### PR TITLE
fix(ui): cursor phase 2.5 — service deltas, anchor confinement, track-volume capture

### DIFF
--- a/AestraPlat/include/AestraPlatform.h
+++ b/AestraPlat/include/AestraPlatform.h
@@ -245,6 +245,17 @@ public:
     /** @brief Clip cursor to window bounds (for hidden-cursor drag to prevent escape). */
     virtual void setCursorClip(bool clipped) {}
 
+    /**
+     * @brief Clip the cursor to a small WINDOW-RELATIVE rectangle.
+     *
+     * Confining to the whole window is insufficient for a borderless
+     * custom-titlebar app: the title bar and in-window panels are inside the
+     * window, so the hidden drag pointer can still roam over them. A tiny rect
+     * around the drag anchor hard-locks the pointer to the control. Coords are
+     * client-area (same space as setCursorPosition). Default no-op.
+     */
+    virtual void setCursorClipRect(int x, int y, int w, int h) {}
+
     /** @brief Query current modifier-key state for wheel and gesture events. */
     virtual KeyModifiers getCurrentModifiers() const = 0;
 

--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -434,6 +434,13 @@ void PlatformWindowLinux::setCursorClip(bool clipped) {
     }
 }
 
+void PlatformWindowLinux::setCursorClipRect(int x, int y, int w, int h) {
+    if (m_window) {
+        SDL_Rect rect = {x, y, w, h}; // window-relative, matches SDL_WarpMouseInWindow
+        SDL_SetWindowMouseRect(m_window, &rect);
+    }
+}
+
 KeyModifiers PlatformWindowLinux::getCurrentModifiers() const {
     KeyModifiers mods = getModifiers(SDL_GetModState());
     if (m_syntheticShiftForHorizontalWheel) {

--- a/AestraPlat/src/Linux/PlatformWindowLinux.h
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.h
@@ -65,6 +65,7 @@ public:
 
     // Cursor Clip
     void setCursorClip(bool clipped) override;
+    void setCursorClipRect(int x, int y, int w, int h) override;
 
     // Modifier key state query
     KeyModifiers getCurrentModifiers() const override;

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -959,6 +959,33 @@ void PlatformWindowWin32::setCursorPosition(int x, int y) {
     SetCursorPos(pt.x, pt.y);
 }
 
+void PlatformWindowWin32::setCursorClipRect(int x, int y, int w, int h) {
+    if (!m_hwnd) return;
+    // Client-relative rect -> screen rect for ClipCursor.
+    POINT tl{x, y};
+    POINT br{x + w, y + h};
+    ClientToScreen(m_hwnd, &tl);
+    ClientToScreen(m_hwnd, &br);
+    RECT clip{tl.x, tl.y, br.x, br.y};
+    ClipCursor(&clip);
+}
+
+void PlatformWindowWin32::setCursorClip(bool clipped) {
+    if (clipped) {
+        RECT rc;
+        if (m_hwnd && GetClientRect(m_hwnd, &rc)) {
+            POINT tl{rc.left, rc.top};
+            POINT br{rc.right, rc.bottom};
+            ClientToScreen(m_hwnd, &tl);
+            ClientToScreen(m_hwnd, &br);
+            RECT clip{tl.x, tl.y, br.x, br.y};
+            ClipCursor(&clip);
+        }
+    } else {
+        ClipCursor(nullptr);
+    }
+}
+
 void PlatformWindowWin32::getCursorPosition(int& x, int& y) const {
     // Symmetric with setCursorPosition: report window-relative client coords.
     POINT pt{}; // zero-init: a failed GetCursorPos (secure desktop switch) must not return garbage

--- a/AestraPlat/src/Win32/PlatformWindowWin32.h
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.h
@@ -54,6 +54,8 @@ public:
 
     // Set cursor position (screen coordinates)
     void setCursorPosition(int x, int y) override;
+    void setCursorClip(bool clipped) override;
+    void setCursorClipRect(int x, int y, int w, int h) override;
     void getCursorPosition(int& x, int& y) const override;
 
     // Mouse Capture

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -150,9 +150,8 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
                     // Check modifier state for fine-tuning (can change mid-drag)
                     isFineDrag_ = (event.modifiers & (NUIModifiers::Ctrl | NUIModifiers::Super)) != 0;
 
-                    // Compute frame-to-frame delta
-                    float dy = event.position.y - m_lastDragY;
-                    m_lastDragY = event.position.y;
+                    // Service-owned delta (recentered; no absolute-coord read).
+                    float dy = event.delta.y;
 
                     float sensitivity = isFineDrag_ ? FINE_DRAG_SENSITIVITY : COARSE_DRAG_SENSITIVITY;
                     float delta = -dy * sensitivity * (maxValue_ - minValue_);

--- a/AestraUI/Platform/NUICursorService.cpp
+++ b/AestraUI/Platform/NUICursorService.cpp
@@ -1,5 +1,6 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUICursorService.h"
+#include <cstdio>
 
 namespace AestraUI {
 

--- a/AestraUI/Platform/NUICursorService.cpp
+++ b/AestraUI/Platform/NUICursorService.cpp
@@ -21,6 +21,10 @@ bool NUICursorService::beginDragCapture(NUICursorRestorePolicy policy, int grabO
     m_grabOriginY = grabOriginY;
     m_captured = true;
 
+    m_lastPhysX = grabOriginX;
+    m_lastPhysY = grabOriginY;
+    m_expectRecenterEvent = false;
+
     m_host.hostHideCursor();
     // Confine the pointer for the duration of the capture: on native Wayland a
     // warp is a silent no-op once the (hidden) pointer drifts out of the
@@ -59,6 +63,33 @@ void NUICursorService::cancelDragCapture() {
     m_host.hostShowCursor();
     m_host.hostSetPointerGrab(false);
     m_inTransition = false;
+}
+
+NUICursorService::Delta NUICursorService::feedPhysicalMotion(int physX, int physY) {
+    if (!m_captured) {
+        return {};
+    }
+    // Suppress the synthetic motion produced by our own recenter warp: it lands
+    // on the anchor and must not be reported as drag motion.
+    if (m_expectRecenterEvent && physX == m_grabOriginX && physY == m_grabOriginY) {
+        m_expectRecenterEvent = false;
+        m_lastPhysX = m_grabOriginX;
+        m_lastPhysY = m_grabOriginY;
+        return {};
+    }
+
+    const Delta d{physX - m_lastPhysX, physY - m_lastPhysY};
+    if (d.dx == 0 && d.dy == 0) {
+        return d; // no motion, no recenter (avoids warp spam while idle)
+    }
+
+    // Recenter to the anchor so the next delta is measured from the anchor
+    // again — the pointer is pinned and can never drift to the window edge.
+    m_host.hostWarpCursor(m_grabOriginX, m_grabOriginY);
+    m_lastPhysX = m_grabOriginX;
+    m_lastPhysY = m_grabOriginY;
+    m_expectRecenterEvent = true;
+    return d;
 }
 
 } // namespace AestraUI

--- a/AestraUI/Platform/NUICursorService.h
+++ b/AestraUI/Platform/NUICursorService.h
@@ -92,6 +92,21 @@ public:
     int anchorX() const { return m_grabOriginX; }
     int anchorY() const { return m_grabOriginY; }
 
+    /** Semantic drag delta returned by feedPhysicalMotion(). */
+    struct Delta { int dx = 0; int dy = 0; };
+
+    /**
+     * Feed one raw physical pointer position while captured. Returns the
+     * semantic drag delta (motion since the last recenter) and, as a side
+     * effect, recenters the physical pointer to the anchor via the host so it
+     * can never reach the window edge (which would saturate deltas on long
+     * drags). The synthetic motion produced by that recenter warp is detected
+     * and returned as a zero delta — so the OS pointer becomes a pure
+     * implementation detail; widgets consume only the delta.
+     * No-op returning {0,0} when not captured.
+     */
+    Delta feedPhysicalMotion(int physX, int physY);
+
 private:
     NUICursorHost& m_host;
     bool m_captured = false;
@@ -99,6 +114,10 @@ private:
     NUICursorRestorePolicy m_policy = NUICursorRestorePolicy::GrabOrigin;
     int m_grabOriginX = 0;
     int m_grabOriginY = 0;
+    // Delta/recenter accounting (feedPhysicalMotion):
+    int m_lastPhysX = 0;
+    int m_lastPhysY = 0;
+    bool m_expectRecenterEvent = false; // next motion to the anchor is our own warp
 };
 
 } // namespace AestraUI

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUIPlatformBridge.h"
+#include <cstdio>
 #include "NUITypes.h"
 #include "NUIComponent.h"
 #include "NUIRenderer.h"
@@ -656,7 +657,10 @@ void NUIPlatformBridge::applyCursorStyle(NUICursorStyle style) {
         case NUICursorStyle::Grabbing:   cursor = :: LoadCursor(NULL, IDC_HAND); break;
         case NUICursorStyle::Hidden:
             NUIComponent::setCursorCaptureActive(true);
-            if (m_window) m_window->setCursorClip(true);
+            // Don't re-assert a whole-window clip while a drag capture owns the
+            // pointer — the service confines to a small anchor rect (see
+            // hostSetPointerGrab); a whole-window clip here would clobber it.
+            if (m_window && !m_cursorService.isCaptured()) m_window->setCursorClip(true);
             ::SetCursor(NULL);
             return;
         default: cursor = ::LoadCursor(NULL, IDC_ARROW); break;
@@ -673,7 +677,9 @@ void NUIPlatformBridge::applyCursorStyle(NUICursorStyle style) {
         NUIComponent::setCursorCaptureActive(true);
         if (m_window) {
             m_window->setCursorVisible(false);
-            m_window->setCursorClip(true);
+            // See Win32 branch: the service owns a small anchor-rect clip during
+            // capture; don't clobber it with a whole-window clip.
+            if (!m_cursorService.isCaptured()) m_window->setCursorClip(true);
         }
         return;
     }

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -118,8 +118,6 @@ void NUIPlatformBridge::setupEventBridges() {
         if (m_rootComponent) {
             NUIMouseEvent event;
             event.type = NUIMouseEventType::Move;
-            event.position = {static_cast<float>(x), static_cast<float>(y)};
-            event.delta = {deltaX, deltaY};
             event.button = NUIMouseButton::None;
             event.pressed = false;
             event.released = false;
@@ -131,12 +129,21 @@ void NUIPlatformBridge::setupEventBridges() {
                 event.modifiers = convertModifiers(mods);
             }
 
-            // Routed dispatch: while captured, ONLY the capture owner sees
-            // motion — the rest of the tree must not hit-test, hover, or
-            // react to the hidden wandering pointer.
             if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
+                // Captured: the service owns delta. It computes the semantic
+                // drag delta from raw physical motion and recenters the pointer
+                // to the anchor (so it can never reach the window edge). The
+                // OS pointer is a pure implementation detail here — the owner
+                // sees an anchored position and a service-computed delta only.
+                const auto d = m_cursorService.feedPhysicalMotion(x, y);
+                event.position = {static_cast<float>(m_cursorService.anchorX()),
+                                  static_cast<float>(m_cursorService.anchorY())};
+                event.delta = {static_cast<float>(d.dx), static_cast<float>(d.dy)};
+                // Routed dispatch: ONLY the capture owner sees motion.
                 m_cursorCaptureOwner->onMouseEvent(event);
             } else {
+                event.position = {static_cast<float>(x), static_cast<float>(y)};
+                event.delta = {deltaX, deltaY};
                 m_rootComponent->onMouseEvent(event);
             }
         }

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -155,7 +155,21 @@ private:
         void hostShowCursor() override { m_bridge.applyCursorStyle(NUICursorStyle::Arrow); }
         void hostWarpCursor(int x, int y) override { m_bridge.setCursorPosition(x, y); }
         void hostSetPointerGrab(bool grabbed) override {
-            if (m_bridge.m_window) m_bridge.m_window->setCursorClip(grabbed);
+            if (!m_bridge.m_window) return;
+            if (grabbed) {
+                // Confine to a SMALL rect around the anchor, not the whole
+                // window — the title bar and in-window panels are inside the
+                // window, so a whole-window clip lets the hidden pointer roam
+                // over them (foreign hover, escape from the control). The
+                // per-frame recenter keeps the pointer at the anchor; this rect
+                // is the hard backstop that locks it to the control.
+                const int ax = m_bridge.m_cursorService.anchorX();
+                const int ay = m_bridge.m_cursorService.anchorY();
+                constexpr int kHalf = 8; // 16x16 px lock box around the anchor
+                m_bridge.m_window->setCursorClipRect(ax - kHalf, ay - kHalf, kHalf * 2, kHalf * 2);
+            } else {
+                m_bridge.m_window->setCursorClip(false);
+            }
         }
 
     private:

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -275,9 +275,8 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
     if (m_dragging && event.button == NUIMouseButton::None) {
         // Cursor-warp mode: use frame-to-frame delta
         if (m_platformBridge) {
-            // Compute frame-to-frame delta
-            float dy = event.position.y - m_lastDragY;
-            m_lastDragY = event.position.y;
+            // Service-owned delta (recentered; no absolute-coord read).
+            float dy = event.delta.y;
 
             // Invert Y for fader: up = positive
             const float deltaPx = -dy;

--- a/AestraUI/Widgets/UIMixerKnob.cpp
+++ b/AestraUI/Widgets/UIMixerKnob.cpp
@@ -330,9 +330,8 @@ bool UIMixerKnob::onMouseEvent(const NUIMouseEvent& event)
     if (m_dragging && event.button == NUIMouseButton::None) {
         // Cursor-warp mode: use frame-to-frame delta
         if (m_platformBridge) {
-            // Compute frame-to-frame delta
-            float dy = event.position.y - m_lastDragY;
-            m_lastDragY = event.position.y;
+            // Service-owned delta (recentered; no absolute-coord read).
+            float dy = event.delta.y;
 
             // Reduced sensitivity for cursor-warp mode since every pixel counts
             float sensitivity = (event.modifiers & NUIModifiers::Shift) ? 0.11f : 0.5f;

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -318,8 +318,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
 
             AestraUI::NUIRect globalBounds = getBounds();
 
-            int winX, winY;
-            m_window->getPosition(winX, winY);
+
 
             float gridTopLocal = globalBounds.y + headerHeight + rulerHeight + horizontalScrollbarHeight;
             float gridLeftLocal = globalBounds.x + controlAreaWidth + 5.0f;
@@ -333,9 +332,11 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             // Apply bounds to internal selection logic
             m_selectionBoxEnd = {targetX, targetY};
 
-            // Force physical cursor to match clamped position
-            // Add window offset to get screen coordinates
-            m_window->setCursorPosition(winX + (int)targetX, winY + (int)targetY);
+            // Force physical cursor to match the clamped position. setCursorPosition
+            // takes WINDOW-RELATIVE coords (targetX/Y are already window-local); the
+            // backend converts to screen. (Previously added the window offset, which
+            // is wrong under the window-relative cursor contract.)
+            m_window->setCursorPosition((int)targetX, (int)targetY);
         } else {
             m_selectionBoxEnd = event.position;
         }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -226,6 +226,11 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
 
 
 TrackUIComponent::~TrackUIComponent() {
+    // Torn down mid-drag: cancel the capture so the bridge never routes to a
+    // dangling owner and the cursor is never stranded hidden.
+    if (m_platformBridge && m_platformBridge->isCursorCaptureOwner(this)) {
+        m_platformBridge->cancelCursorCapture();
+    }
     detachContextMenu(m_recordModeMenu);
     Log::debug("TrackUIComponent destroyed for lane: " + m_laneId.toString());
 }
@@ -1874,11 +1879,14 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_volumeKnobDragStartPos = event.position;
                 m_volumeKnobDragStartValue = m_volumeKnobValue;
 
-                // Cursor capture: hide system cursor for infinite drag
+                // Cursor capture via the unified service: hides + confines to
+                // a small anchor rect + routes motion here only + recenters, so
+                // the hidden pointer can't roam other panels (foreign hover /
+                // escape). Restores at the knob center on release.
                 if (m_platformBridge) {
-                    m_volumeWarpOrigin = event.position;
-                    m_volumeLastDragY = event.position.y;
-                    m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Hidden);
+                    m_platformBridge->beginCursorCapture(
+                        this, AestraUI::NUICursorRestorePolicy::KnobCenter,
+                        static_cast<int>(event.position.x), static_cast<int>(event.position.y));
                 }
 
                 if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
@@ -1887,20 +1895,20 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_isDraggingVolumeKnob = false;
                 AestraUI::NUIComponent::hideRemoteTooltip(this);
 
-                // Restore cursor to knob center (matches current value position)
+                // End capture: service warps to knob center, unhides, releases
+                // confinement — in that order.
                 if (m_platformBridge) {
-                    m_platformBridge->setCursorPosition(
+                    m_platformBridge->endCursorCapture(
                         static_cast<int>(m_volumeKnobBounds.x + m_volumeKnobBounds.width * 0.5f),
                         static_cast<int>(m_volumeKnobBounds.y + m_volumeKnobBounds.height * 0.5f));
-                    m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
                 }
 
                 if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
                 handledByControls = true;
             } else if (m_isDraggingVolumeKnob && event.button == AestraUI::NUIMouseButton::None) {
-                // Dragging: frame-to-frame delta (up = louder)
-                float dy = m_volumeLastDragY - event.position.y;
-                m_volumeLastDragY = event.position.y;
+                // Dragging: service-owned delta (up = louder). event.delta.y is
+                // down-positive, so negate to keep up = louder.
+                float dy = -event.delta.y;
                 float delta = dy * 0.008f;
                 if (event.modifiers & AestraUI::NUIModifiers::Shift) {
                     delta *= 0.25f;

--- a/Tests/AestraUI/CursorServiceTest.cpp
+++ b/Tests/AestraUI/CursorServiceTest.cpp
@@ -131,6 +131,45 @@ void testReentrantBeginRefused() {
     std::puts("  reentrant-begin refused: ok");
 }
 
+void testFeedMotionDeltaAndRecenter() {
+    FakeHost host;
+    NUICursorService svc(host);
+    svc.beginDragCapture(NUICursorRestorePolicy::KnobCenter, 100, 100);
+    host.calls.clear();
+
+    // Physical pointer moves 100,100 -> 100,90 (up 10). Delta is measured from
+    // the anchor; the service recenters back to the anchor.
+    auto d1 = svc.feedPhysicalMotion(100, 90);
+    CHECK(d1.dx == 0 && d1.dy == -10);
+    CHECK((host.calls == std::vector<std::string>{"warp:100,100"})); // recentered
+
+    // The recenter warp's own synthetic event (lands on the anchor) is a zero
+    // delta and does NOT recenter again.
+    auto dSynthetic = svc.feedPhysicalMotion(100, 100);
+    CHECK(dSynthetic.dx == 0 && dSynthetic.dy == 0);
+    CHECK((host.calls == std::vector<std::string>{"warp:100,100"})); // unchanged
+
+    // Next real motion is again measured from the anchor (pointer was pinned
+    // there) — so a second up-10 gives the same delta regardless of how far
+    // the drag has travelled. This is what defeats window-edge saturation.
+    auto d2 = svc.feedPhysicalMotion(100, 90);
+    CHECK(d2.dx == 0 && d2.dy == -10);
+    CHECK((host.calls == std::vector<std::string>{"warp:100,100", "warp:100,100"}));
+
+    // Zero motion neither deltas nor warps (no spam while idle).
+    auto d3 = svc.feedPhysicalMotion(100, 100);
+    // (100,100 == anchor but m_expectRecenterEvent was cleared by dSynthetic and
+    // re-set by d2; this lands as the d2 recenter's synthetic -> zero, no warp.)
+    CHECK(d3.dx == 0 && d3.dy == 0);
+    CHECK(host.calls.size() == 2);
+
+    // After capture ends, motion is ignored.
+    svc.endDragCapture(100, 100);
+    auto d4 = svc.feedPhysicalMotion(50, 50);
+    CHECK(d4.dx == 0 && d4.dy == 0);
+    std::puts("  feed-motion delta + recenter: ok");
+}
+
 } // namespace
 
 int main() {
@@ -140,6 +179,7 @@ int main() {
     testCancelDoesNotWarp();
     testBeginWhileCapturedRecovers();
     testReentrantBeginRefused();
+    testFeedMotionDeltaAndRecenter();
     if (g_failures == 0) {
         std::puts("CursorServiceTest: PASS");
         return 0;


### PR DESCRIPTION
## Summary
Completes the cursor-unification arc on top of #567 (phase 1) and #568 (phase 2). Supersedes the auto-closed #569 (its base branch was deleted when #568 merged); same commits, rebased onto develop.

Three commits:
1. **Service-owned deltas + recentering** — `NUICursorService::feedPhysicalMotion()` computes the drag delta and recenters the pointer to the anchor each frame (synthetic-warp suppressed). Widgets consume `event.delta.y`, not absolute coords. Fixes long-drag edge saturation.
2. **Small-rect anchor confinement** — capture confines a 16×16 rect around the anchor, not the whole window (a whole-window clip let the hidden pointer roam the title bar / in-window panels in a borderless app). New `setCursorClipRect` on Linux (SDL) + Win32 (ClipCursor); Win32 previously had **no** clip at all.
3. **Track volume-knob capture migration + selection-box coord fix** — the *actual reported bug*: `TrackUIComponent`'s track-header volume knob still hid the cursor with the raw pre-migration pattern (never called `beginCursorCapture`), so it had no routing/confinement/recentering — the hidden pointer roamed and other panels hovered. Migrated to the service. Also fixes a #567 window-relative-contract regression in the timeline selection-box warp.

## Verification (live trace — owner-confirmed)
Instrumented the running app; owner drove the real gesture. Before: `BEGIN=0`, every motion `captured=0` while hidden. After migration: `BEGIN` fires, **2372 captured motions, 0 leaks, 1185 recenter warps** — pointer locked to the knob, zero foreign hover. Owner: "that was the fix."

## Testing
- `CursorServiceTest` — 6 cases (ordering, policies, cancel, recovery, reentrancy, delta/recenter/synthetic-suppression) PASS.
- Aestra builds; Hyprland boot smoke clean; diagnostics stripped.

## Still not captured (later phases)
The 7 plugin editors + remaining timeline gestures — separate migration (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added cross-platform cursor clipping and anchor confinement for captured pointer drags.
- Moved physical-motion delta calculation and recenter-warp handling into `NUICursorService`, preventing edge saturation and synthetic-motion feedback.
- Migrated mixer controls and the track-header volume knob to service-owned capture deltas, including cleanup of active captures.
- Corrected timeline selection-box cursor warping to use window-relative coordinates.
- Added coverage for motion deltas, recentering, zero movement, and post-capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->