### PR TITLE
feat(ui): cursor phase 3 — plugin editor knob capture + Shift-fine

### DIFF
--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -148,7 +148,7 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
                 if (isRotary && platformBridge_)
                 {
                     // Check modifier state for fine-tuning (can change mid-drag)
-                    isFineDrag_ = (event.modifiers & (NUIModifiers::Ctrl | NUIModifiers::Super)) != 0;
+                    isFineDrag_ = (event.modifiers & NUIModifiers::Shift) != 0;  // Shift = fine (unified across all knobs/sliders)
 
                     // Service-owned delta (recentered; no absolute-coord read).
                     float dy = event.delta.y;
@@ -187,7 +187,7 @@ bool NUISlider::onMouseEvent(const NUIMouseEvent& event)
             m_lastDragY = event.position.y;
 
             // Check for fine-tuning modifier at drag start
-            isFineDrag_ = (event.modifiers & (NUIModifiers::Ctrl | NUIModifiers::Super)) != 0;
+            isFineDrag_ = (event.modifiers & NUIModifiers::Shift) != 0;  // Shift = fine (unified across all knobs/sliders)
 
             // Begin cursor capture (this gives the "infinite travel" feel):
             // hides the cursor and confines the pointer to the window so the

--- a/AestraUI/Platform/NUICursorService.cpp
+++ b/AestraUI/Platform/NUICursorService.cpp
@@ -1,6 +1,5 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUICursorService.h"
-#include <cstdio>
 
 namespace AestraUI {
 

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -398,7 +398,7 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (m_draggingPitch) {
             // Service-owned frame delta (up = increase), accumulated into value.
             setParameter(Drift::kPitch,
-                         m_instance->getParameter(Drift::kPitch) + (-event.delta.y) / kDragRangePixels);
+                         m_instance->getParameter(Drift::kPitch) + knobDragStep(event, kDragRangePixels));
             return true;
         }
         if (m_draggingMix) {
@@ -408,7 +408,7 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (m_draggingKnob >= 0) {
             const auto& knob = m_knobs[static_cast<size_t>(m_draggingKnob)];
             setParameter(knob.parameterId,
-                         m_instance->getParameter(knob.parameterId) + (-event.delta.y) / kDragRangePixels);
+                         m_instance->getParameter(knob.parameterId) + knobDragStep(event, kDragRangePixels));
             return true;
         }
         m_pitchHovered = m_pitchWheelBounds.contains(event.position);

--- a/AestraUI/Widgets/AestraDriftEditor.cpp
+++ b/AestraUI/Widgets/AestraDriftEditor.cpp
@@ -342,6 +342,9 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
                            m_mixBounds.height - 14.0f);
     if (event.released) {
         const bool wasDragging = m_draggingPitch || m_draggingMix || m_draggingKnob >= 0;
+        // Pitch wheel + knobs capture the cursor; the mix track does not.
+        if (m_draggingPitch || m_draggingKnob >= 0)
+            endKnobCapture();
         m_draggingPitch = false;
         m_draggingMix = false;
         m_draggingKnob = -1;
@@ -375,8 +378,7 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
         if (m_pitchWheelBounds.contains(event.position)) {
             m_draggingPitch = true;
-            m_dragStartY = event.position.y;
-            m_dragStartValue = m_instance->getParameter(Drift::kPitch);
+            beginKnobCapture(m_pitchWheelBounds.center(), event.position);
             return true;
         }
         if (mixTrack.contains(event.position)) {
@@ -387,15 +389,16 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         const int knob = hitTestKnob(event.position);
         if (knob >= 0) {
             m_draggingKnob = knob;
-            m_dragStartY = event.position.y;
-            m_dragStartValue = m_instance->getParameter(m_knobs[static_cast<size_t>(knob)].parameterId);
+            beginKnobCapture(m_knobs[static_cast<size_t>(knob)].bounds.center(), event.position);
             return true;
         }
     }
 
     if (event.type == NUIMouseEventType::Move || event.button == NUIMouseButton::None) {
         if (m_draggingPitch) {
-            setParameter(Drift::kPitch, m_dragStartValue + (m_dragStartY - event.position.y) / kDragRangePixels);
+            // Service-owned frame delta (up = increase), accumulated into value.
+            setParameter(Drift::kPitch,
+                         m_instance->getParameter(Drift::kPitch) + (-event.delta.y) / kDragRangePixels);
             return true;
         }
         if (m_draggingMix) {
@@ -404,7 +407,8 @@ bool AestraDriftEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
         if (m_draggingKnob >= 0) {
             const auto& knob = m_knobs[static_cast<size_t>(m_draggingKnob)];
-            setParameter(knob.parameterId, m_dragStartValue + (m_dragStartY - event.position.y) / kDragRangePixels);
+            setParameter(knob.parameterId,
+                         m_instance->getParameter(knob.parameterId) + (-event.delta.y) / kDragRangePixels);
             return true;
         }
         m_pitchHovered = m_pitchWheelBounds.contains(event.position);

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -348,7 +348,6 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
         return false;
 
     const float mx = event.position.x;
-    const float my = event.position.y;
 
     // Bypass pill
     if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
@@ -371,16 +370,20 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    // Knob vertical drag
+    // Knob vertical drag (rotary → cursor capture)
     if (m_draggingParam >= 0) {
         if (event.released) {
+            endKnobCapture();
             m_draggingParam = -1;
             return true;
         }
         if (event.button == NUIMouseButton::None) {
-            const float delta = (m_dragStartY - my) / kDragRangePx;
+            // Service-owned frame delta (up = increase); accumulates into the
+            // current value, so total travel matches the old absolute mapping.
+            const float step = -event.delta.y / kDragRangePx;
+            const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
-                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+                                     std::clamp(cur + step, 0.0f, 1.0f));
             setDirty();
             return true;
         }
@@ -397,8 +400,9 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
         for (const auto& k : knobs) {
             if (k.rect.contains(event.position)) {
                 m_draggingParam = static_cast<int>(k.param);
-                m_dragStartY = my;
                 m_dragStartValue = m_instance->getParameter(k.param);
+                beginKnobCapture({k.rect.x + k.rect.width * 0.5f, k.rect.y + k.rect.height * 0.5f},
+                                 event.position);
                 return true;
             }
         }

--- a/AestraUI/Widgets/AestraFilterEditor.cpp
+++ b/AestraUI/Widgets/AestraFilterEditor.cpp
@@ -380,7 +380,7 @@ bool AestraFilterEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (event.button == NUIMouseButton::None) {
             // Service-owned frame delta (up = increase); accumulates into the
             // current value, so total travel matches the old absolute mapping.
-            const float step = -event.delta.y / kDragRangePx;
+            const float step = knobDragStep(event, kDragRangePx);
             const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
                                      std::clamp(cur + step, 0.0f, 1.0f));

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -231,7 +231,6 @@ bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
     if (!m_instance)
         return false;
 
-    const float my = event.position.y;
 
     // Bypass pill
     if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
@@ -272,13 +271,17 @@ bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
     // Knob vertical drag
     if (m_draggingParam >= 0) {
         if (event.released) {
+            endKnobCapture();
             m_draggingParam = -1;
             return true;
         }
         if (event.button == NUIMouseButton::None) {
-            const float delta = (m_dragStartY - my) / kDragRangePx;
+            // Service-owned frame delta (up = increase); accumulates into the
+            // current value, so total travel matches the old absolute mapping.
+            const float step = -event.delta.y / kDragRangePx;
+            const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
-                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+                                     std::clamp(cur + step, 0.0f, 1.0f));
             setDirty();
             return true;
         }
@@ -298,8 +301,9 @@ bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
         for (const auto& k : knobs) {
             if (k.rect.contains(event.position)) {
                 m_draggingParam = static_cast<int>(k.param);
-                m_dragStartY = my;
                 m_dragStartValue = m_instance->getParameter(k.param);
+                beginKnobCapture({k.rect.x + k.rect.width * 0.5f, k.rect.y + k.rect.height * 0.5f},
+                                 event.position);
                 return true;
             }
         }

--- a/AestraUI/Widgets/AestraLFOEditor.cpp
+++ b/AestraUI/Widgets/AestraLFOEditor.cpp
@@ -278,7 +278,7 @@ bool AestraLFOEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (event.button == NUIMouseButton::None) {
             // Service-owned frame delta (up = increase); accumulates into the
             // current value, so total travel matches the old absolute mapping.
-            const float step = -event.delta.y / kDragRangePx;
+            const float step = knobDragStep(event, kDragRangePx);
             const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
                                      std::clamp(cur + step, 0.0f, 1.0f));

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -168,7 +168,6 @@ bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
     if (!m_instance)
         return false;
 
-    const float my = event.position.y;
 
     // Bypass pill
     if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
@@ -182,13 +181,17 @@ bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
     // Knob vertical drag
     if (m_draggingParam >= 0) {
         if (event.released) {
+            endKnobCapture();
             m_draggingParam = -1;
             return true;
         }
         if (event.button == NUIMouseButton::None) {
-            const float delta = (m_dragStartY - my) / kDragRangePx;
+            // Service-owned frame delta (up = increase); accumulates into the
+            // current value, so total travel matches the old absolute mapping.
+            const float step = -event.delta.y / kDragRangePx;
+            const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
-                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+                                     std::clamp(cur + step, 0.0f, 1.0f));
             setDirty();
             return true;
         }
@@ -205,8 +208,9 @@ bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
         for (const auto& k : knobs) {
             if (k.rect.contains(event.position)) {
                 m_draggingParam = static_cast<int>(k.param);
-                m_dragStartY = my;
                 m_dragStartValue = m_instance->getParameter(k.param);
+                beginKnobCapture({k.rect.x + k.rect.width * 0.5f, k.rect.y + k.rect.height * 0.5f},
+                                 event.position);
                 return true;
             }
         }

--- a/AestraUI/Widgets/AestraOTTEditor.cpp
+++ b/AestraUI/Widgets/AestraOTTEditor.cpp
@@ -188,7 +188,7 @@ bool AestraOTTEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (event.button == NUIMouseButton::None) {
             // Service-owned frame delta (up = increase); accumulates into the
             // current value, so total travel matches the old absolute mapping.
-            const float step = -event.delta.y / kDragRangePx;
+            const float step = knobDragStep(event, kDragRangePx);
             const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
                                      std::clamp(cur + step, 0.0f, 1.0f));

--- a/AestraUI/Widgets/AestraPanelWindow.cpp
+++ b/AestraUI/Widgets/AestraPanelWindow.cpp
@@ -38,6 +38,15 @@ void AestraPanelWindow::endKnobCapture()
         static_cast<int>(m_captureKnobCenter.x), static_cast<int>(m_captureKnobCenter.y));
 }
 
+float AestraPanelWindow::knobDragStep(const NUIMouseEvent& event, float rangePx) const
+{
+    // Shift = surgical precision (quarter speed). Held state is read per frame
+    // so it can be toggled mid-drag. Default (no modifier) speed is unchanged.
+    constexpr float kFineDragScale = 0.25f;
+    const float fine = (event.modifiers & NUIModifiers::Shift) ? kFineDragScale : 1.0f;
+    return (-event.delta.y / rangePx) * fine;
+}
+
 void AestraPanelWindow::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();

--- a/AestraUI/Widgets/AestraPanelWindow.cpp
+++ b/AestraUI/Widgets/AestraPanelWindow.cpp
@@ -13,6 +13,31 @@ AestraPanelWindow::AestraPanelWindow()
     cacheThemeColors();
 }
 
+AestraPanelWindow::~AestraPanelWindow()
+{
+    // Torn down mid-drag: cancel the capture so the bridge never routes to a
+    // dangling owner and the cursor is never stranded hidden.
+    if (m_platformBridge && m_platformBridge->isCursorCaptureOwner(this)) {
+        m_platformBridge->cancelCursorCapture();
+    }
+}
+
+void AestraPanelWindow::beginKnobCapture(const NUIPoint& knobCenter, const NUIPoint& grabPos)
+{
+    if (!m_platformBridge) return;
+    m_captureKnobCenter = knobCenter;
+    m_platformBridge->beginCursorCapture(
+        this, AestraUI::NUICursorRestorePolicy::KnobCenter,
+        static_cast<int>(grabPos.x), static_cast<int>(grabPos.y));
+}
+
+void AestraPanelWindow::endKnobCapture()
+{
+    if (!m_platformBridge) return;
+    m_platformBridge->endCursorCapture(
+        static_cast<int>(m_captureKnobCenter.x), static_cast<int>(m_captureKnobCenter.y));
+}
+
 void AestraPanelWindow::cacheThemeColors()
 {
     auto& theme = NUIThemeManager::getInstance();

--- a/AestraUI/Widgets/AestraPanelWindow.h
+++ b/AestraUI/Widgets/AestraPanelWindow.h
@@ -81,6 +81,12 @@ protected:
     // Center the active capture will restore to.
     NUIPoint m_captureKnobCenter;
 
+    // Normalized vertical step for a knob drag during capture (up = positive).
+    // rangePx = pixels of travel for the full 0..1 range. Scaled down while
+    // Shift is held — opt-in fine/precision drag; the default (unmodified)
+    // feel is unchanged. Add to the current value each drag frame.
+    float knobDragStep(const NUIMouseEvent& event, float rangePx) const;
+
     // Window dragging from title bar
     bool m_isDraggingWindow = false;
     NUIPoint m_dragStartPos;

--- a/AestraUI/Widgets/AestraPanelWindow.h
+++ b/AestraUI/Widgets/AestraPanelWindow.h
@@ -26,7 +26,6 @@ class NUIPlatformBridge;
 class AestraPanelWindow : public NUIComponent {
 public:
     AestraPanelWindow();
-    ~AestraPanelWindow() override = default;
 
     void onRender(NUIRenderer& renderer) override;
     void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
@@ -68,7 +67,20 @@ public:
 
     void onUpdate(double deltaTime) override;
 
+    ~AestraPanelWindow() override; // cancels an active knob capture (see .cpp)
+
 protected:
+    // Shared infinite-drag capture for editor knobs. Continuous parameter
+    // knobs call beginKnobCapture() on press (hides + confines + routes here)
+    // and endKnobCapture() on release (restores the cursor at the knob
+    // center). During the drag, read the vertical delta from event.delta.y
+    // (service-owned; do NOT read absolute cursor position). No-op when no
+    // platform bridge is attached.
+    void beginKnobCapture(const NUIPoint& knobCenter, const NUIPoint& grabPos);
+    void endKnobCapture();
+    // Center the active capture will restore to.
+    NUIPoint m_captureKnobCenter;
+
     // Window dragging from title bar
     bool m_isDraggingWindow = false;
     NUIPoint m_dragStartPos;

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -230,7 +230,7 @@ bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (event.button == NUIMouseButton::None) {
             // Service-owned frame delta (up = increase); accumulates into the
             // current value, so total travel matches the old absolute mapping.
-            const float step = -event.delta.y / kDragRangePx;
+            const float step = knobDragStep(event, kDragRangePx);
             const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
                                      std::clamp(cur + step, 0.0f, 1.0f));

--- a/AestraUI/Widgets/AestraSatEditor.cpp
+++ b/AestraUI/Widgets/AestraSatEditor.cpp
@@ -199,7 +199,6 @@ bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
         return false;
 
     const float mx = event.position.x;
-    const float my = event.position.y;
 
     // Bypass pill
     if (m_bypassRect.contains(event.position) && event.pressed && event.button == NUIMouseButton::Left) {
@@ -221,16 +220,20 @@ bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    // Knob vertical drag
+    // Knob vertical drag (rotary → cursor capture)
     if (m_draggingParam >= 0) {
         if (event.released) {
+            endKnobCapture();
             m_draggingParam = -1;
             return true;
         }
         if (event.button == NUIMouseButton::None) {
-            const float delta = (m_dragStartY - my) / kDragRangePx;
+            // Service-owned frame delta (up = increase); accumulates into the
+            // current value, so total travel matches the old absolute mapping.
+            const float step = -event.delta.y / kDragRangePx;
+            const float cur = m_instance->getParameter(static_cast<uint32_t>(m_draggingParam));
             m_instance->setParameter(static_cast<uint32_t>(m_draggingParam),
-                                     std::clamp(m_dragStartValue + delta, 0.0f, 1.0f));
+                                     std::clamp(cur + step, 0.0f, 1.0f));
             setDirty();
             return true;
         }
@@ -247,8 +250,9 @@ bool AestraSatEditor::onMouseEvent(const NUIMouseEvent& event) {
         for (const auto& k : knobs) {
             if (k.rect.contains(event.position)) {
                 m_draggingParam = static_cast<int>(k.param);
-                m_dragStartY = my;
                 m_dragStartValue = m_instance->getParameter(k.param);
+                beginKnobCapture({k.rect.x + k.rect.width * 0.5f, k.rect.y + k.rect.height * 0.5f},
+                                 event.position);
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
Phase 3 of the cursor-unification arc. Stacked on #570; retargets to develop when #570 merges.

Migrates the plugin editors' rotary knobs to the unified cursor-capture service (they previously hand-rolled absolute-coord drag with no hide), plus a feel pass.

**Shared plumbing** in the common base `AestraPanelWindow`:
- `beginKnobCapture(knobCenter, grabPos)` / `endKnobCapture()` + owner-specific dtor cancel.
- `knobDragStep(event, rangePx)` — normalized up=positive step, ×0.25 while **Shift** held (opt-in precision; default speed unchanged). One place to tune the fine ratio.

**Migrated (5 hand-rolled editors):** LFO, OTT, Sat, Filter, Drift. Each: knob press → capture; drag → `event.delta.y` accumulated into value; release → restore at knob center. Per the interaction rule, position-based **mix sliders** (value = absolute X) stay on the visible cursor — only rotary knobs capture. Drift's pitch wheel + knobs capture; its mix track stays visible.

**Already covered (no change):** Delay/Verb/Comp/Limit use `NUISlider` rotary children (bridge propagated) → capture via NUISlider's migration and inherit Shift-fine automatically.

**Modifier unification:** fine-drag was split — `NUISlider` used Ctrl/Super, everything else Shift. Unified NUISlider to **Shift**, so fine-drag is Shift across every knob/slider. Transport numeric scrubber's deliberate dual-modifier scheme (Shift=fast/Ctrl=fine) left alone.

## Verification
- Direction "inversion" reported during testing was a **stale binary**, not a code bug — instrument-first trace (feedPhysicalMotion dy log) proved all knobs uniformly up=increase; a clean rebuild resolved it, no sign logic changed.
- Owner tested the migrated editors + Shift-fine + unified modifier end-to-end.
- Aestra builds clean; Hyprland boot smoke clean; `CursorServiceTest` passes.

## Remaining (follow-up, not this PR)
EQ (mixed spatial band-nodes + rotary knobs — needs per-control split) and Rumble (premium-gated build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)