### PR TITLE
feat(ui): cursor arc finale — EQ output-gain, Rumble, generic + insert-rack knobs

### DIFF
--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -4884,8 +4884,9 @@ bool AestraEQEditor::handlePress(const NUIMouseEvent& event) {
         }
         if (m_outputGainRect.contains(event.position)) {
             m_draggingOutputGain = true;
-            m_dragStartY = event.position.y;
-            m_dragStartValue = outputGain();
+            // Relative vertical drag → cursor capture (the graph nodes and card
+            // lanes are absolute-position and stay on the visible cursor).
+            beginKnobCapture(m_outputGainRect.center(), event.position);
             return true;
         }
         Knob knob = Knob::None;
@@ -4959,9 +4960,12 @@ bool AestraEQEditor::handleDragUpdate(const NUIMouseEvent& event) {
         return true;
     }
     if (m_draggingOutputGain) {
-        setOutputGain(m_dragStartValue + (m_dragStartY - event.position.y) / 180.0f);
-        if (!event.pressed && event.button == NUIMouseButton::Left)
+        // Service-owned frame delta (up = increase), accumulated into value.
+        setOutputGain(outputGain() + knobDragStep(event, 180.0f));
+        if (!event.pressed && event.button == NUIMouseButton::Left) {
+            endKnobCapture();
             m_draggingOutputGain = false;
+        }
         return true;
     }
     if (m_draggingCardBand >= 0) {

--- a/AestraUI/Widgets/GenericPluginEditor.cpp
+++ b/AestraUI/Widgets/GenericPluginEditor.cpp
@@ -211,30 +211,32 @@ bool GenericPluginEditor::onMouseEvent(const NUIMouseEvent& event) {
         repaint();
     }
 
-    // Handle slider dragging
+    // Handle slider dragging (relative horizontal → cursor capture)
     if (event.button == NUIMouseButton::Left) {
         if (event.pressed && paramIndex >= 0) {
-            // Start dragging
+            // Start dragging + capture: hide, confine, route here, recenter.
             m_parameters[paramIndex].isDragging = true;
-            m_parameters[paramIndex].dragStartX = event.position.x;
-            m_parameters[paramIndex].dragStartValue = m_parameters[paramIndex].normalizedValue;
+            beginKnobCapture(event.position, event.position); // restore at grab point
             return true;
         } else if (!event.pressed) {
             // Stop all dragging
+            bool wasDragging = false;
             for (auto& p : m_parameters) {
+                wasDragging = wasDragging || p.isDragging;
                 p.isDragging = false;
             }
+            if (wasDragging) endKnobCapture();
             return true;
         }
     }
 
-    // Update dragging parameters
+    // Update dragging parameters. Service-owned horizontal frame delta
+    // (right = increase), Shift = fine — matching knobDragStep's ratio.
     for (size_t i = 0; i < m_parameters.size(); ++i) {
         if (m_parameters[i].isDragging) {
-            float deltaX = event.position.x - m_parameters[i].dragStartX;
-            float deltaValue = deltaX / SLIDER_WIDTH;
-            float newValue = std::clamp(m_parameters[i].dragStartValue + deltaValue, 0.0f, 1.0f);
-
+            const float fine = (event.modifiers & NUIModifiers::Shift) ? 0.25f : 1.0f;
+            const float deltaValue = (event.delta.x / SLIDER_WIDTH) * fine;
+            const float newValue = std::clamp(m_parameters[i].normalizedValue + deltaValue, 0.0f, 1.0f);
             updateParameterValue(static_cast<int>(i), newValue);
             repaint();
             return true;

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "PluginBrowserPanel.h"
+#include "../Platform/NUIPlatformBridge.h"
 #include "NUIRenderer.h"
 #include "NUIDragDrop.h"
 #include "NUIContextMenu.h"
@@ -799,6 +800,14 @@ EffectChainRack::EffectChainRack() {
     m_bypassOverride.fill(-1);
 }
 
+EffectChainRack::~EffectChainRack() {
+    // Torn down mid-drag: cancel the capture so the bridge never routes to a
+    // dangling owner and the cursor is never stranded hidden.
+    if (m_platformBridge && m_platformBridge->isCursorCaptureOwner(this)) {
+        m_platformBridge->cancelCursorCapture();
+    }
+}
+
 void EffectChainRack::onRender(NUIRenderer& renderer) {
     auto bounds = getBounds();
     const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
@@ -1058,6 +1067,13 @@ bool EffectChainRack::onMouseEvent(const NUIMouseEvent& event) {
     // RELEASED Event Handling (Must be checked before general Drag handling to allow drops)
     if (event.released && event.button == NUIMouseButton::Left) {
         if (m_activeKnobSlot != -1) {
+            if (m_platformBridge) {
+                // Restore at the dry/wet knob center of the released slot.
+                NUIRect slotRect = getSlotBounds(m_activeKnobSlot);
+                m_platformBridge->endCursorCapture(
+                    static_cast<int>(slotRect.x + slotRect.width - 22.0f + 9.0f),
+                    static_cast<int>(slotRect.y + 14.0f));
+            }
             m_activeKnobSlot = -1;
             return true;
         }
@@ -1104,14 +1120,14 @@ bool EffectChainRack::onMouseEvent(const NUIMouseEvent& event) {
 
     // KNOB DRAG Handling
     if (m_activeKnobSlot != -1) {
-        const float dx = event.position.x - m_dragStartPos.x;
-        const float dy = m_dragStartPos.y - event.position.y; // Up is positive (Values go up as mouse goes up)
-        const float dragDelta = dx + dy;
+        // Service-owned frame delta; keep the original diagonal semantics
+        // (right and/or up = increase). Shift = fine, matching the app-wide rule.
+        const float dragDelta = event.delta.x + (-event.delta.y);
 
         float sensitivity = 0.005f;
-        if (event.modifiers & NUIModifiers::Shift) sensitivity *= 0.1f;
+        if (event.modifiers & NUIModifiers::Shift) sensitivity *= 0.25f;
 
-        float newValue = std::clamp(m_dragStartValue + dragDelta * sensitivity, 0.0f, 1.0f);
+        float newValue = std::clamp(m_slots[m_activeKnobSlot].dryWet + dragDelta * sensitivity, 0.0f, 1.0f);
 
         if (std::abs(newValue - m_slots[m_activeKnobSlot].dryWet) > 0.001f) {
             m_slots[m_activeKnobSlot].dryWet = newValue;
@@ -1132,8 +1148,11 @@ bool EffectChainRack::onMouseEvent(const NUIMouseEvent& event) {
              if (isOverKnob(slotIdx)) {
                  if (!m_slots[slotIdx].isEmpty) {
                      m_activeKnobSlot = slotIdx;
-                     m_dragStartValue = m_slots[slotIdx].dryWet;
-                     m_dragStartPos = event.position;
+                     if (m_platformBridge) {
+                         m_platformBridge->beginCursorCapture(
+                             this, NUICursorRestorePolicy::KnobCenter,
+                             static_cast<int>(event.position.x), static_cast<int>(event.position.y));
+                     }
                      return true;
                  }
              }

--- a/AestraUI/Widgets/PluginBrowserPanel.h
+++ b/AestraUI/Widgets/PluginBrowserPanel.h
@@ -271,6 +271,8 @@ private:
  * - Click to open plugin editor
  * - Slot context menu
  */
+class NUIPlatformBridge;
+
 class EffectChainRack : public NUIComponent {
 public:
     static constexpr int MAX_SLOTS = 10;
@@ -285,7 +287,10 @@ public:
     };
 
     EffectChainRack();
-    ~EffectChainRack() override = default;
+    ~EffectChainRack() override; // cancels an active knob capture (see .cpp)
+
+    /** Platform bridge for dry/wet knob cursor capture (may be null in tests). */
+    void setPlatformBridge(NUIPlatformBridge* bridge) { m_platformBridge = bridge; }
 
     void onRender(NUIRenderer& renderer) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
@@ -321,6 +326,7 @@ private:
     int hitTestSlot(float y) const;
     NUIRect slotRectForTop(float slotY) const;
 
+    NUIPlatformBridge* m_platformBridge = nullptr;
     std::array<EffectSlotInfo, MAX_SLOTS> m_slots;
     std::array<int, MAX_SLOTS> m_bypassOverride; // -1=None, 0=Active, 1=Bypassed
     int m_hoveredSlot = -1;
@@ -332,8 +338,7 @@ private:
 
     // Drag Interaction State
     int m_activeKnobSlot = -1;
-    NUIPoint m_dragStartPos{};
-    float m_dragStartValue = 0.0f;
+    NUIPoint m_dragStartPos{}; // slot-reorder drag origin (knob drag uses service deltas)
 
     std::function<void(int)> m_onSlotClicked;
     std::function<void(int, bool)> m_onSlotBypassToggled;

--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -342,6 +342,7 @@ void PluginUIController::openPluginEditor(
     } else if (pluginId == "com.Aestrastudios.rumble") {
         auto ed = std::make_shared<RumblePluginEditor>(instance);
         wireEditorClose(ed);
+        ed->setPlatformBridge(m_platformBridge);
         editor = ed;
 #endif
     } else if (pluginId == "com.Aestrastudios.eq") {
@@ -397,6 +398,7 @@ void PluginUIController::openPluginEditor(
     } else {
         auto ed = std::make_shared<GenericPluginEditor>(instance);
         wireEditorClose(ed);
+        ed->setPlatformBridge(m_platformBridge);
         editor = ed;
     }
     

--- a/AestraUI/Widgets/RumblePluginEditor.cpp
+++ b/AestraUI/Widgets/RumblePluginEditor.cpp
@@ -547,13 +547,15 @@ bool RumblePluginEditor::onMouseEvent(const NUIMouseEvent& event) {
     // pointer when it re-enters.
     if (m_draggingControl >= 0) {
         if (event.released) {
+            endKnobCapture();
             m_draggingControl = -1;
             setDirty(true);
             return true;
         }
         if (event.button == NUIMouseButton::None || event.type == NUIMouseEventType::Drag) {
-            const float delta = (m_dragStartY - event.position.y) / kDragRangePixels;
-            setControlValue(m_draggingControl, m_dragStartValue + delta);
+            // Service-owned frame delta (up = increase), accumulated into value.
+            const float cur = m_controls[static_cast<size_t>(m_draggingControl)].normalizedValue;
+            setControlValue(m_draggingControl, cur + knobDragStep(event, kDragRangePixels));
             return true;
         }
     }
@@ -613,8 +615,7 @@ bool RumblePluginEditor::onMouseEvent(const NUIMouseEvent& event) {
                 return true;
             }
             m_draggingControl = controlIndex;
-            m_dragStartY = event.position.y;
-            m_dragStartValue = m_controls[static_cast<size_t>(controlIndex)].normalizedValue;
+            beginKnobCapture(m_controls[static_cast<size_t>(controlIndex)].knobBounds.center(), event.position);
             return true;
         }
     }

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -1007,4 +1007,9 @@ bool UIMixerInspector::onMouseEvent(const NUIMouseEvent& event)
     return b.contains(event.position);
 }
 
+void UIMixerInspector::setPlatformBridge(NUIPlatformBridge* bridge)
+{
+    if (m_effectRack) m_effectRack->setPlatformBridge(bridge);
+}
+
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerInspector.h
+++ b/AestraUI/Widgets/UIMixerInspector.h
@@ -24,8 +24,13 @@ class EffectChainRack;
  * Displays simple tabs (Inserts/Sends/IO). Inserts tab includes an "Add FX"
  * placeholder button.
  */
+class NUIPlatformBridge;
+
 class UIMixerInspector : public NUIComponent {
 public:
+    /** Forward the platform bridge to the insert rack (dry/wet knob capture). */
+    void setPlatformBridge(NUIPlatformBridge* bridge);
+
     enum class Tab { Inserts = 0, Sends = 1, IO = 2 };
 
     explicit UIMixerInspector(Aestra::MixerViewModel* viewModel);

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -219,6 +219,7 @@ void UIMixerPanel::setPlatformBridge(NUIPlatformBridge* bridge)
         if (strip) strip->setPlatformBridge(bridge);
     }
     if (m_masterStrip) m_masterStrip->setPlatformBridge(bridge);
+    if (m_inspector) m_inspector->setPlatformBridge(bridge);
 }
 
 void UIMixerPanel::layoutMeters()


### PR DESCRIPTION
## Summary
Final PR of the cursor-unification arc (follows #567/#568/#570/#572, all merged). Three commits:

1. **EQ + Rumble** — EQ's 5 draggables classified by value mapping: only the **output gain** is a relative vertical drag → captured; graph band nodes, detector nodes, and card lanes are absolute-position → keep the visible cursor (interaction rule). Rumble's rotary knobs: standard capture recipe.
2. **Missing editor bridges + generic editor** — `RumblePluginEditor` and `GenericPluginEditor` were created **without** `setPlatformBridge` (copy-paste omission; found via `beginKnobCapture` trace printing `bridge=(nil)`). With a null bridge, capture silently no-ops while values still move — looked fine, cursor roamed. Both wired; every editor-creation site verified. GenericPluginEditor (third-party/insert fallback) migrated: horizontal drag → `event.delta.x` + Shift-fine.
3. **Insert-rack dry/wet knob** — the owner-reported "insert knob" is `EffectChainRack`'s per-slot dry/wet (bare NUIComponent, no bridge, hand-rolled diagonal drag, no hide). Migrated with diagonal semantics preserved (`delta.x + -delta.y`), Shift ×0.25 unified, restore at the slot knob; new bridge threading `UIMixerPanel → UIMixerInspector → EffectChainRack`; owner-specific dtor cancel.

## Verification
Owner drive-tested each round: EQ/Rumble knobs capture; insert-rack dry/wet confirmed **"clean"**. Instrument-first traces caught both real bugs (nil bridge; wrong widget). Aestra builds clean; `CursorServiceTest` passes; Hyprland boot smoke clean.

## Arc closure
With this, **every continuous-parameter control** in the app — mixer, track header, base sliders, all 11 plugin editors, generic/insert editors, and the insert rack — routes through `NUICursorService`: one hide/confine/recenter/restore model, one Shift-fine convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)