### PR TITLE
refactor(engine): extract renderTrack clip/unit/effect phases into named helpers (R3 PR-C)

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -695,6 +695,12 @@ private:
     // master/destination/sends, meter publication. Verbatim extraction of the
     // renderGraph() per-track loop body; srcActiveThisBlock is the loop-carried
     // "any resampling happened" telemetry flag.
+    // renderTrack phase helpers (verbatim extractions; RT path — no allocation).
+    void renderTrackClips(const TrackRenderState& track, std::vector<double>& buffer, const RenderContext& ctx,
+                          bool& srcActiveThisBlock);
+    void renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffer, const RenderContext& ctx);
+    float processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
+                              uint32_t numFrames);
     void renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx,
                      bool& srcActiveThisBlock);
     void prepareTrackStateForGraph(const AudioGraph& graph);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2108,151 +2108,16 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     }
 }
 
-void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx,
-                              bool& srcActiveThisBlock) {
-    // Unpack the block-stable render context under the names this body has
-    // always used; renderGraph() derives these once per block.
-    const uint32_t numFrames = ctx.numFrames;
-    double* const masterBuf = ctx.masterBuf;
-    const size_t availableTracks = ctx.availableTracks;
+void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<double>& buffer, const RenderContext& ctx,
+                                   bool& srcActiveThisBlock) {
+    // Verbatim clip-rendering phase moved out of renderTrack(); same ctx
+    // unpack names the body has always used.
     const uint64_t blockStart = ctx.blockStart;
     const uint64_t blockEnd = ctx.blockEnd;
     const bool isPlaying = ctx.isPlaying;
-    const bool anySolo = ctx.anySolo;
     const uint32_t cachedSampleRate = ctx.cachedSampleRate;
-    const ChannelSlotMap* const cachedSlotMap = ctx.cachedSlotMap;
-    ContinuousParamBuffer* const cachedParams = ctx.cachedParams;
-    MeterSnapshotBuffer* const cachedSnaps = ctx.cachedSnaps;
-    const bool cachedPatternMode = ctx.cachedPatternMode;
     const Interpolators::InterpolationQuality cachedInterpQuality = ctx.cachedInterpQuality;
-    const AudioArsenalSnapshot* const unitSnapshot = ctx.unitSnapshot;
-    const PatternPlaybackEngine::UnitMidiRoute* const unitMidiRoutes = ctx.unitMidiRoutes;
-    const size_t unitMidiRouteCount = ctx.unitMidiRouteCount;
-
-    const auto& track = graph.tracks[orderedIndex];
-    const uint32_t trackIdx = track.trackIndex;
-    if (static_cast<size_t>(trackIdx) >= availableTracks) {
-        m_telemetry.incrementOverruns();
-        return;
-    }
-    auto& state = ensureTrackState(trackIdx);
-
-    // Compute continuous params (slot-indexed) and apply to targets.
-    float faderDb = 0.0f;
-    float panParam = 0.0f;
-    float trimDb = 0.0f;
-    uint32_t slot = ChannelSlotMap::INVALID_SLOT;
-
-    auto* slotMap = cachedSlotMap;
-    if (slotMap) {
-        slot = slotMap->getSlotIndex(track.trackId);
-        auto* params = cachedParams;
-        if (slot != ChannelSlotMap::INVALID_SLOT && params) {
-            params->read(slot, faderDb, panParam, trimDb);
-        }
-    }
-
-    const double faderDbClamped = clampD(static_cast<double>(faderDb), -90.0, 6.0);
-    const double trimDbClamped = clampD(static_cast<double>(trimDb), -24.0, 24.0);
-    const double gain = dbToLinearD(faderDbClamped) * dbToLinearD(trimDbClamped);
-
-    double volTarget = static_cast<double>(track.volume) * gain;
-    double panTarget = clampD(static_cast<double>(track.pan) + static_cast<double>(panParam), -1.0, 1.0);
-
-    // Apply Automation Override (v3.1). Beat-domain evaluation: the curve
-    // interpolates on point beats directly, so tempo changes and UI point
-    // drags (which edit beats) stay musically aligned.
-    if (!track.automationCurves.empty() && cachedSampleRate > 0) {
-        uint64_t globalPos = m_globalSamplePos.load(std::memory_order_relaxed);
-        double currentBeat = (static_cast<double>(globalPos) / cachedSampleRate) * (graph.bpm / 60.0);
-        for (const auto& curve : track.automationCurves) {
-            if (curve.getAutomationTarget() == AutomationTarget::Volume) {
-                volTarget = curve.getValueAtBeat(currentBeat);
-            } else if (curve.getAutomationTarget() == AutomationTarget::Pan) {
-                panTarget = clampD(curve.getValueAtBeat(currentBeat), -1.0, 1.0);
-            } else if (curve.getAutomationTarget() == AutomationTarget::Custom) {
-                // Plugin-parameter automation. Internal-format plugins only:
-                // their parameter storage is atomic, so a per-block
-                // setParameter from this thread is lock-free and RT-safe.
-                // Third-party formats are skipped until host param queues
-                // exist (#467). Applied before the effect chain processes
-                // this block, so the value is in effect for these frames.
-                //
-                // Smoothing policy: the *plugin* owns parameter smoothing.
-                // setParameter only stores a target; each internal plugin's
-                // process() ramps toward it — the same contract used for UI
-                // knob moves. We deliberately hand the raw target over once
-                // per block instead of ramping engine-side, so automation
-                // and manual edits share one smoother and never cascade into
-                // double-smoothing. Every internal effect honors this (Drift
-                // was the last to gain per-sample Mix/Pitch smoothing).
-                if (track.effectChainSnapshot && curve.effectSlot < EffectChainSnapshot::MAX_SLOTS) {
-                    const auto& slot = track.effectChainSnapshot->slot(curve.effectSlot);
-                    if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {
-                        const float value = curve.getValueAtBeat(currentBeat);
-                        if (std::isfinite(value)) {
-                            slot.plugin->setParameter(curve.paramId, value);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Skip early (solo suppression only).
-    // Muted tracks still render so meters keep moving, but they don't mix into master.
-    const bool muted = track.mute || state.mute;
-    const bool audibleEligible =
-        !anySolo || (static_cast<size_t>(trackIdx) < availableTracks && m_rtAudibleEligible[trackIdx]);
-    const bool processActive =
-        !anySolo || (static_cast<size_t>(trackIdx) < availableTracks && m_rtProcessActive[trackIdx]);
-
-    // Initialize send gain smoothers when send count changes.
-    // Vectors are pre-sized to kMaxSendsPerTrack in setBufferConfig(),
-    // so we never resize here — only update the active entries.
-    const size_t sendCount = std::min(track.sends.size(), static_cast<size_t>(kMaxSendsPerTrack));
-    if (state.lastActiveSendCount != sendCount) {
-        state.lastActiveSendCount = sendCount;
-        for (size_t sendIndex = 0; sendIndex < sendCount; ++sendIndex) {
-            double targetL = 0.0;
-            double targetR = 0.0;
-            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
-                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
-            state.sendGainL[sendIndex].current = targetL;
-            state.sendGainL[sendIndex].target = targetL;
-            state.sendGainR[sendIndex].current = targetR;
-            state.sendGainR[sendIndex].target = targetR;
-        }
-    }
-
-    if (!muted) {
-        for (size_t sendIndex = 0; sendIndex < sendCount; ++sendIndex) {
-            if (track.sends[sendIndex].mute) {
-                continue;
-            }
-            double targetL = 0.0;
-            double targetR = 0.0;
-            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
-                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
-            state.sendGainL[sendIndex].setTarget(targetL);
-            state.sendGainR[sendIndex].setTarget(targetR);
-            state.sendGainL[sendIndex].beginRamp(numFrames);
-            state.sendGainR[sendIndex].beginRamp(numFrames);
-        }
-    }
-
-    if (!processActive) {
-        auto* snaps = cachedSnaps;
-        if (snaps && slot != ChannelSlotMap::INVALID_SLOT) {
-            snaps->writeLevels(slot, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -144.0f);
-            snaps->writeSidechainPeak(slot, 0.0f);
-        }
-        return;
-    }
-
-    // Buffers were already cleared up front so destination tracks can receive
-    // routed audio before their own clips/effects are processed.
-    auto& buffer = m_trackBuffersD[trackIdx];
+    const bool cachedPatternMode = ctx.cachedPatternMode;
 
     // Check isPlaying inside loop to avoid brace wrapping issues
     // [FIX] Suppress timeline clips if in Pattern Mode (Audio Isolation)
@@ -2541,6 +2406,14 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
             }
         } // End pattern mode check
     }
+}
+
+void AudioEngine::renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffer, const RenderContext& ctx) {
+    // Verbatim Arsenal-unit phase moved out of renderTrack().
+    const uint32_t numFrames = ctx.numFrames;
+    const AudioArsenalSnapshot* const unitSnapshot = ctx.unitSnapshot;
+    const PatternPlaybackEngine::UnitMidiRoute* const unitMidiRoutes = ctx.unitMidiRoutes;
+    const size_t unitMidiRouteCount = ctx.unitMidiRouteCount;
 
     // === ANTIGRAVITY UNIT RENDER (v3.1) ===
     // Render any units routed to this track
@@ -2579,6 +2452,12 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
         }
     }
 
+}
+
+float AudioEngine::processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
+                                       uint32_t numFrames) {
+    // Verbatim effect-chain phase moved out of renderTrack(); returns the
+    // sidechain peak consumed by the metering stage.
     // === Plugin Processing (EffectChain Snapshot) ===
     float trackSidechainPeak = 0.0f;
     if (track.effectChainSnapshot && track.effectChainSnapshot->getActiveSlotCount() > 0) {
@@ -2615,6 +2494,163 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
             }
         }
     }
+
+    return trackSidechainPeak;
+}
+
+void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx,
+                              bool& srcActiveThisBlock) {
+    // Unpack the block-stable render context under the names this body has
+    // always used; renderGraph() derives these once per block.
+    const uint32_t numFrames = ctx.numFrames;
+    double* const masterBuf = ctx.masterBuf;
+    const size_t availableTracks = ctx.availableTracks;
+    const uint64_t blockStart = ctx.blockStart;
+    const uint64_t blockEnd = ctx.blockEnd;
+    const bool isPlaying = ctx.isPlaying;
+    const bool anySolo = ctx.anySolo;
+    const uint32_t cachedSampleRate = ctx.cachedSampleRate;
+    const ChannelSlotMap* const cachedSlotMap = ctx.cachedSlotMap;
+    ContinuousParamBuffer* const cachedParams = ctx.cachedParams;
+    MeterSnapshotBuffer* const cachedSnaps = ctx.cachedSnaps;
+    const bool cachedPatternMode = ctx.cachedPatternMode;
+    const Interpolators::InterpolationQuality cachedInterpQuality = ctx.cachedInterpQuality;
+    const AudioArsenalSnapshot* const unitSnapshot = ctx.unitSnapshot;
+    const PatternPlaybackEngine::UnitMidiRoute* const unitMidiRoutes = ctx.unitMidiRoutes;
+    const size_t unitMidiRouteCount = ctx.unitMidiRouteCount;
+
+    const auto& track = graph.tracks[orderedIndex];
+    const uint32_t trackIdx = track.trackIndex;
+    if (static_cast<size_t>(trackIdx) >= availableTracks) {
+        m_telemetry.incrementOverruns();
+        return;
+    }
+    auto& state = ensureTrackState(trackIdx);
+
+    // Compute continuous params (slot-indexed) and apply to targets.
+    float faderDb = 0.0f;
+    float panParam = 0.0f;
+    float trimDb = 0.0f;
+    uint32_t slot = ChannelSlotMap::INVALID_SLOT;
+
+    auto* slotMap = cachedSlotMap;
+    if (slotMap) {
+        slot = slotMap->getSlotIndex(track.trackId);
+        auto* params = cachedParams;
+        if (slot != ChannelSlotMap::INVALID_SLOT && params) {
+            params->read(slot, faderDb, panParam, trimDb);
+        }
+    }
+
+    const double faderDbClamped = clampD(static_cast<double>(faderDb), -90.0, 6.0);
+    const double trimDbClamped = clampD(static_cast<double>(trimDb), -24.0, 24.0);
+    const double gain = dbToLinearD(faderDbClamped) * dbToLinearD(trimDbClamped);
+
+    double volTarget = static_cast<double>(track.volume) * gain;
+    double panTarget = clampD(static_cast<double>(track.pan) + static_cast<double>(panParam), -1.0, 1.0);
+
+    // Apply Automation Override (v3.1). Beat-domain evaluation: the curve
+    // interpolates on point beats directly, so tempo changes and UI point
+    // drags (which edit beats) stay musically aligned.
+    if (!track.automationCurves.empty() && cachedSampleRate > 0) {
+        uint64_t globalPos = m_globalSamplePos.load(std::memory_order_relaxed);
+        double currentBeat = (static_cast<double>(globalPos) / cachedSampleRate) * (graph.bpm / 60.0);
+        for (const auto& curve : track.automationCurves) {
+            if (curve.getAutomationTarget() == AutomationTarget::Volume) {
+                volTarget = curve.getValueAtBeat(currentBeat);
+            } else if (curve.getAutomationTarget() == AutomationTarget::Pan) {
+                panTarget = clampD(curve.getValueAtBeat(currentBeat), -1.0, 1.0);
+            } else if (curve.getAutomationTarget() == AutomationTarget::Custom) {
+                // Plugin-parameter automation. Internal-format plugins only:
+                // their parameter storage is atomic, so a per-block
+                // setParameter from this thread is lock-free and RT-safe.
+                // Third-party formats are skipped until host param queues
+                // exist (#467). Applied before the effect chain processes
+                // this block, so the value is in effect for these frames.
+                //
+                // Smoothing policy: the *plugin* owns parameter smoothing.
+                // setParameter only stores a target; each internal plugin's
+                // process() ramps toward it — the same contract used for UI
+                // knob moves. We deliberately hand the raw target over once
+                // per block instead of ramping engine-side, so automation
+                // and manual edits share one smoother and never cascade into
+                // double-smoothing. Every internal effect honors this (Drift
+                // was the last to gain per-sample Mix/Pitch smoothing).
+                if (track.effectChainSnapshot && curve.effectSlot < EffectChainSnapshot::MAX_SLOTS) {
+                    const auto& slot = track.effectChainSnapshot->slot(curve.effectSlot);
+                    if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {
+                        const float value = curve.getValueAtBeat(currentBeat);
+                        if (std::isfinite(value)) {
+                            slot.plugin->setParameter(curve.paramId, value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Skip early (solo suppression only).
+    // Muted tracks still render so meters keep moving, but they don't mix into master.
+    const bool muted = track.mute || state.mute;
+    const bool audibleEligible =
+        !anySolo || (static_cast<size_t>(trackIdx) < availableTracks && m_rtAudibleEligible[trackIdx]);
+    const bool processActive =
+        !anySolo || (static_cast<size_t>(trackIdx) < availableTracks && m_rtProcessActive[trackIdx]);
+
+    // Initialize send gain smoothers when send count changes.
+    // Vectors are pre-sized to kMaxSendsPerTrack in setBufferConfig(),
+    // so we never resize here — only update the active entries.
+    const size_t sendCount = std::min(track.sends.size(), static_cast<size_t>(kMaxSendsPerTrack));
+    if (state.lastActiveSendCount != sendCount) {
+        state.lastActiveSendCount = sendCount;
+        for (size_t sendIndex = 0; sendIndex < sendCount; ++sendIndex) {
+            double targetL = 0.0;
+            double targetR = 0.0;
+            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
+                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
+            state.sendGainL[sendIndex].current = targetL;
+            state.sendGainL[sendIndex].target = targetL;
+            state.sendGainR[sendIndex].current = targetR;
+            state.sendGainR[sendIndex].target = targetR;
+        }
+    }
+
+    if (!muted) {
+        for (size_t sendIndex = 0; sendIndex < sendCount; ++sendIndex) {
+            if (track.sends[sendIndex].mute) {
+                continue;
+            }
+            double targetL = 0.0;
+            double targetR = 0.0;
+            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
+                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
+            state.sendGainL[sendIndex].setTarget(targetL);
+            state.sendGainR[sendIndex].setTarget(targetR);
+            state.sendGainL[sendIndex].beginRamp(numFrames);
+            state.sendGainR[sendIndex].beginRamp(numFrames);
+        }
+    }
+
+    if (!processActive) {
+        auto* snaps = cachedSnaps;
+        if (snaps && slot != ChannelSlotMap::INVALID_SLOT) {
+            snaps->writeLevels(slot, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -144.0f);
+            snaps->writeSidechainPeak(slot, 0.0f);
+        }
+        return;
+    }
+
+    // Buffers were already cleared up front so destination tracks can receive
+    // routed audio before their own clips/effects are processed.
+    auto& buffer = m_trackBuffersD[trackIdx];
+
+    // Clip rendering, Arsenal units, and the effect chain are verbatim phase
+    // extractions — see the helpers directly above renderTrack().
+    renderTrackClips(track, buffer, ctx, srcActiveThisBlock);
+
+    renderTrackUnits(trackIdx, buffer, ctx);
+
+    float trackSidechainPeak = processTrackEffects(track, trackIdx, buffer, numFrames);
 
     // === Apply Plugin Delay Compensation ===
     // Compensation must apply to dry tracks too; those are often the tracks


### PR DESCRIPTION
## Summary
Continues the R3 AudioEngine decomposition (#552 characterization → #563 processBlock leaves → #566 renderTrack extraction). `renderTrack()` was a verbatim 764-line move in #566; this splits its three clearly-bounded middle phases into member helpers via script-driven verbatim moves on asserted content anchors:

| Helper | Lines | Phase |
|---|---|---|
| `renderTrackClips` | ~287 | timeline clip loop: pattern-mode gate, same-rate fast path with edge micro-fades, linear/Catmull-Rom/sinc resampling |
| `renderTrackUnits` | ~37 | Arsenal unit render + mix |
| `processTrackEffects` | ~37 | EffectChain snapshot processing; **returns** the sidechain peak consumed by metering (the one cross-phase value) |

`renderTrack`: **764 → 409 lines** (params/automation prelude + PDC/routing/metering tail remain — the tail is the PR-D candidate).

## RT-safety
Pure code motion: no allocation, no locks, plain member functions; signature additions are references into pre-allocated state. Helpers unpack the same block-stable `RenderContext` names the bodies always used.

## Testing performed
- Parity/characterization battery (13/13): EngineOutputStageCharacterization, GoldenAudioRegression, RealtimeExportParity, ArsenalExportLiveParity, ExportBounceParity, AutomationPlayback, RoutingSendPanParity, PDC suite.
- Full `audio` label: **80/80** (one stale binary built + passed).
- Audio output unchanged, latency unchanged, state format unchanged; live/export parity covered by the parity tests above.

## Risk/rollback
Low — verbatim moves guarded by the characterization suite built for exactly this refactor. Revert the commit to roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Refactored `renderTrack()` into three private real-time rendering helpers:
  - `renderTrackClips()` handles clip processing, fades, fast-path copying, and resampling.
  - `renderTrackUnits()` handles Arsenal unit rendering and mixing.
  - `processTrackEffects()` handles effect chains and returns the sidechain peak for metering.
- Preserved existing audio behavior, latency, state format, and allocation-free/lock-free RT-path constraints while improving readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->