### PR TITLE
fix(dsp): interpolate preview duck gain per-sample to avoid zipper noise (#565)

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -716,8 +716,16 @@ private:
     // extraction of a self-contained section of processBlock; state lives in
     // the members they always used.
     void mixTestTone(uint32_t numFrames, uint32_t currentSampleRate);
-    // Returns the smoothed duck gain the master output stage applies this block.
-    double computePreviewDuckGain(uint32_t numFrames, uint32_t currentSampleRate, bool isPlaying);
+    // Per-block preview duck-gain ramp. The master output stage interpolates duck
+    // gain from `start` (the previous block's end value) to `end` (this block's
+    // smoothed target) once per sample — mirroring the master fader's per-sample
+    // ramp — so the 50ms/120ms fade never steps at block boundaries (zipper noise).
+    struct PreviewDuckRamp {
+        double start = 1.0;
+        double end = 1.0;
+    };
+    // Advances the smoothed duck gain one block and returns its start/end for the ramp.
+    PreviewDuckRamp computePreviewDuckGain(uint32_t numFrames, uint32_t currentSampleRate, bool isPlaying);
     void mixMetronomeClicks(float* outputBuffer, uint32_t numFrames);
     void updateTruePeakMeters(const float* outputBuffer, uint32_t numFrames, uint32_t numOutputChannels);
     void resetCachedSamplerVoicesRt() noexcept;

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -949,7 +949,12 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
 
     mixTestTone(numFrames, currentSampleRate);
 
-    const double duckGain = computePreviewDuckGain(numFrames, currentSampleRate, isPlaying);
+    // Preview duck gain ramps per-sample across the block (see gainDelta below),
+    // so the 50ms/120ms fade is interpolated rather than block-stepped (issue #565).
+    const PreviewDuckRamp duckRamp = computePreviewDuckGain(numFrames, currentSampleRate, isPlaying);
+    const double duckGainDelta =
+        numFrames > 0 ? (duckRamp.end - duckRamp.start) / static_cast<double>(numFrames) : 0.0;
+    double duckGain = duckRamp.start;
 
     // === Final Output Stage (double -> float with processing) ===
     // Pre-compute master gain for this block (avoid per-sample target update)
@@ -1106,6 +1111,7 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         }
 
         gain += gainDelta;
+        duckGain += duckGainDelta;
     }
 
     // Update atomic counters (once per block, not per sample)
@@ -1276,7 +1282,8 @@ void AudioEngine::mixTestTone(uint32_t numFrames, uint32_t currentSampleRate) {
     }
 }
 
-double AudioEngine::computePreviewDuckGain(uint32_t numFrames, uint32_t currentSampleRate, bool isPlaying) {
+AudioEngine::PreviewDuckRamp AudioEngine::computePreviewDuckGain(uint32_t numFrames, uint32_t currentSampleRate,
+                                                                 bool isPlaying) {
     // === Preview Ducking Gain Calculation ===
     // Duck transport only while preview has produced audible output. PreviewEngine
     // may exist, decode, or be selected without being audible.
@@ -1305,8 +1312,11 @@ double AudioEngine::computePreviewDuckGain(uint32_t numFrames, uint32_t currentS
     const double duckFadeSamples = static_cast<double>(currentSampleRate) * fadeSeconds;
     const double duckFadeDelta = static_cast<double>(numFrames) / std::max(duckFadeSamples, 1.0);
 
-    // Smooth the duck gain transition
-    double duckGain = m_smoothedPreviewDuckGain;
+    // Smooth the duck gain transition. Capture the start-of-block value so the
+    // master output stage can ramp per-sample from `startDuckGain` to `duckGain`
+    // instead of applying the block-end value as a constant (issue #565).
+    const double startDuckGain = m_smoothedPreviewDuckGain;
+    double duckGain = startDuckGain;
     if (duckGain < targetDuckGain) {
         duckGain += duckFadeDelta;
         if (duckGain > targetDuckGain)
@@ -1318,13 +1328,13 @@ double AudioEngine::computePreviewDuckGain(uint32_t numFrames, uint32_t currentS
     }
     m_smoothedPreviewDuckGain = duckGain;
 
-    // Publish smoothed gain for external queries
+    // Publish the block-end smoothed gain for external queries.
     m_previewDuckGain.store(static_cast<float>(duckGain), std::memory_order_relaxed);
     m_previewDuckSource.store(static_cast<uint8_t>((shouldDuckForPreview || duckGain < 0.995)
                                                        ? PreviewDuckSource::BrowserPreview
                                                        : PreviewDuckSource::None),
                               std::memory_order_relaxed);
-    return duckGain;
+    return {startDuckGain, duckGain};
 }
 
 void AudioEngine::mixMetronomeClicks(float* outputBuffer, uint32_t numFrames) {


### PR DESCRIPTION
## Summary
Fixes #565. Preview ducking gain was computed once per block and applied as a **constant** multiplier across the master output block:

```cpp
double L = src[i * 2] * gain * duckGain;   // duckGain constant for the whole block
```

During the 50 ms attack / 120 ms release the smoothed gain could step audibly between consecutive blocks (worse at larger buffer sizes) — block-quantized rather than per-sample ramped, i.e. zipper noise. The master fader `gain` in the *same* loop already ramps per-sample via `gainDelta`; duck gain now mirrors it.

## Change
- `computePreviewDuckGain()` now returns `PreviewDuckRamp{start, end}` — the start-of-block gain (previous block's end) and this block's smoothed target.
- The output loop seeds `duckGain = start` and advances `duckGain += duckGainDelta` per sample, alongside the existing `gain += gainDelta`, so the fade is linearly interpolated to the block-end value instead of stepped.
- Published `m_previewDuckGain` / `m_previewDuckSource` still carry the block-end value → external queries unchanged.
- At steady state `start == end`, so the ramp is flat and byte-identical to the old constant. **Only in-fade transient blocks change.**

## Why
Small, well-contained DSP fix flagged by CodeRabbit on #563 and deferred there because that PR was a strictly behavior-preserving verbatim move. Landing separately with its own validation, as the issue requested.

## Testing (build-linux, `-j2`)
| Test | Result |
|------|--------|
| `TrackManagerMasterDuckingAuditTest` | **PASS** — settled/held/released and −3 dB/off ratios unchanged: `0.5 / 0.5 / 1.0 / 0.708 / 1.0`. Measurements are taken on fully-settled final blocks where the ramp is flat, so the tolerances still hold. |
| `EngineOutputStageCharacterizationTest` | **PASS** — no preview attached → `duckGain` stays 1.0, change is a no-op. |
| `RealtimeExportParityTest` | **ALL PASS** — realtime/export parity byte-exact (`maxAbsErr=0`), `Export_Immune_To_Preview_Ducking` unaffected. |

## DSP report
- **Audio output changed:** yes — in-fade transient blocks only; the fade is now a smooth per-sample ramp instead of a per-block step. Steady-state and non-ducked output are byte-identical.
- **Latency changed:** no.
- **State/serialization format changed:** no.
- **Live/export parity affected:** no (export path has no preview → `duckGain` 1.0; parity test byte-exact).
- **Listening assumption:** the ramp reaches the same block-end value the old code used, so the fade's overall time constant (50 ms / 120 ms) is preserved — only intra-block quantization is removed.

## Docs updated?
No — internal DSP behavior, no public-facing surface.

## Risk / rollback
Low, self-contained (one helper + the output loop). Rollback = revert this commit. RT-safe: no allocations/locks added; the per-sample add mirrors the existing `gainDelta` advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Replaced block-level preview ducking gain steps with per-sample ramping across each audio block to eliminate zipper noise during attack and release.
- Updated duck gain computation to return block start/end values while preserving block-end reporting and source tracking.
- Kept steady-state and non-ducked output byte-identical, with no changes to latency, serialization, allocations, locks, or realtime/export parity.
- Validation passed for ducking behavior, output characterization, and realtime/export parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->