### PR TITLE
fix(audio): smooth preview ducking within blocks

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -716,7 +716,7 @@ private:
     // extraction of a self-contained section of processBlock; state lives in
     // the members they always used.
     void mixTestTone(uint32_t numFrames, uint32_t currentSampleRate);
-    // Returns the smoothed duck gain the master output stage applies this block.
+    // Advances and returns the preview-duck gain at the end of this block.
     double computePreviewDuckGain(uint32_t numFrames, uint32_t currentSampleRate, bool isPlaying);
     void mixMetronomeClicks(float* outputBuffer, uint32_t numFrames);
     void updateTruePeakMeters(const float* outputBuffer, uint32_t numFrames, uint32_t numOutputChannels);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -949,7 +949,10 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
 
     mixTestTone(numFrames, currentSampleRate);
 
-    const double duckGain = computePreviewDuckGain(numFrames, currentSampleRate, isPlaying);
+    const double duckGainStart = static_cast<double>(m_smoothedPreviewDuckGain);
+    const double duckGainEnd = computePreviewDuckGain(numFrames, currentSampleRate, isPlaying);
+    const double duckGainDelta = (duckGainEnd - duckGainStart) / static_cast<double>(numFrames);
+    double duckGain = duckGainStart;
 
     // === Final Output Stage (double -> float with processing) ===
     // Pre-compute master gain for this block (avoid per-sample target update)
@@ -1106,6 +1109,7 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         }
 
         gain += gainDelta;
+        duckGain += duckGainDelta;
     }
 
     // Update atomic counters (once per block, not per sample)

--- a/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
+++ b/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
@@ -261,7 +261,20 @@ int main() {
     engine.setPreviewEngine(&audiblePreview);
     primePreviewAudibility(audiblePreview);
 
-    const Readout settledDucked = renderLastBlock(engine, meters, 6);
+    std::vector<float> duckOnsetBlock(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+    engine.processBlock(duckOnsetBlock.data(), nullptr, kBlockSize, 0.0);
+    const float duckOnsetFirstRatio =
+        std::abs(duckOnsetBlock.front()) / std::max(baseline.engineOutputPeak, 1.0e-9f);
+    const float duckOnsetLastRatio =
+        std::abs(duckOnsetBlock[(kBlockSize - 1) * kChannels]) / std::max(baseline.engineOutputPeak, 1.0e-9f);
+    float duckOnsetMaxStep = 0.0f;
+    for (uint32_t frame = 1; frame < kBlockSize; ++frame) {
+        const float previous = duckOnsetBlock[(frame - 1) * kChannels];
+        const float current = duckOnsetBlock[frame * kChannels];
+        duckOnsetMaxStep = std::max(duckOnsetMaxStep, std::abs(current - previous));
+    }
+
+    const Readout settledDucked = renderLastBlock(engine, meters, 5);
     const auto duckSource = engine.getPreviewDuckSource();
 
     audiblePreview.stop();
@@ -298,6 +311,9 @@ int main() {
     std::cout << "settled_ducked_track_peak=" << settledDucked.trackPeak << "\n";
     std::cout << "settled_ducked_master_peak=" << settledDucked.masterPeak << "\n";
     std::cout << "settled_ducked_output_peak=" << settledDucked.engineOutputPeak << "\n";
+    std::cout << "duck_onset_first_ratio=" << duckOnsetFirstRatio << "\n";
+    std::cout << "duck_onset_last_ratio=" << duckOnsetLastRatio << "\n";
+    std::cout << "duck_onset_max_step=" << duckOnsetMaxStep << "\n";
     std::cout << "settled_track_ratio=" << settledTrackRatio << "\n";
     std::cout << "settled_master_ratio=" << settledMasterRatio << "\n";
     std::cout << "held_after_stop_master_ratio=" << heldMasterRatio << "\n";
@@ -321,6 +337,12 @@ int main() {
             "silent preview ducked the master");
     require(settledTrackRatio > 0.99f && settledTrackRatio < 1.01f,
             "settled track meter changed while preview ducking was active");
+    require(duckOnsetFirstRatio > 0.99f && duckOnsetFirstRatio < 1.01f,
+            "preview duck onset did not start continuously from the prior block gain");
+    require(duckOnsetLastRatio > 0.88f && duckOnsetLastRatio < 0.91f,
+            "preview duck onset did not ramp across the first block");
+    require(duckOnsetMaxStep < 0.0002f,
+            "preview duck onset contains a block-sized gain step");
     require(settledMasterRatio > 0.49f && settledMasterRatio < 0.51f,
             "audible preview did not duck to the expected 0.5 gain within the 50ms fade window");
     require(duckSource == AudioEngine::PreviewDuckSource::BrowserPreview,


### PR DESCRIPTION
## Summary

- interpolate preview duck gain from the prior block state to the newly computed end state per sample
- preserve the existing 50 ms attack, 120 ms release, hold behavior, published gain, and source reporting
- extend the master-ducking audit with deterministic onset continuity coverage

## Why

Preview ducking previously computed a smoothed gain once per block and applied that constant to every sample. During attack and release, the gain therefore jumped at block boundaries, creating buffer-size-dependent zipper/click risk.

## User impact

Browser-preview ducking now transitions continuously within each audio block while retaining the existing depth and timing policy. Track meters remain pre-duck, master/output meters remain post-duck, and offline export remains unaffected.

## Validation

- `cmake --build build-linux -j2 --target TrackManagerMasterDuckingAuditTest`
- `ctest --test-dir build-linux -R '^TrackManagerMasterDuckingAuditTest$' --output-on-failure`
- direct audit result: onset ratio `1.0 -> 0.89375`, maximum adjacent sample step `7.36713e-05`
- `cmake --build build-linux -j2 --target RealtimeExportParityTest`
- `ctest --test-dir build-linux -R '^RealtimeExportParityTest$' --output-on-failure`
- `git diff --check`

## Risk / rollback

The change is isolated to the master output gain multiplication and its regression test. It does not change latency, serialization, parameter IDs, preview duck timing, or export policy. Reverting commit `39fac329` restores the prior block-stepped behavior.

## Docs

No public documentation change required.

Fixes #565