### PR TITLE
fix(project): preserve clips with unresolved patterns

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1144,7 +1144,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     std::unordered_set<uint64_t> allUnitIds;
     std::unordered_set<uint32_t> allSourceIds;
     std::unordered_map<uint64_t, std::string> patternNames;
-    std::unordered_set<uint64_t> orphanClipPatternIds;
+    std::unordered_set<uint64_t> unloadablePatternIds;
+    std::unordered_set<uint64_t> recoverableClipPatternIds;
     std::unordered_set<uint64_t> orphanNoteUnitIds;
     ProjectLoadWarningLimiter warningLimiter;
 
@@ -1163,6 +1164,14 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             if (id != 0) {
                 allPatternIds.insert(id);
                 patternNames[id] = boundedStringOr(pj[i], "name", "Pattern", PROJECT_MAX_STRING_BYTES);
+                const std::string type = boundedStringOr(pj[i], "type", "midi", PROJECT_MAX_STRING_BYTES);
+                if (type == "audio") {
+                    const uint32_t sourceId = static_cast<uint32_t>(
+                        finiteNumberOr(pj[i], "sourceId", 0.0, 0.0, static_cast<double>(UINT32_MAX)));
+                    if (sourceId == 0 || !allSourceIds.count(sourceId)) {
+                        unloadablePatternIds.insert(id);
+                    }
+                }
             }
         }
     }
@@ -1188,13 +1197,14 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 if (!cj[c].isObject()) continue;
                 uint64_t patternId = static_cast<uint64_t>(
                     finiteNumberOr(cj[c], "patternId", 0.0, 0.0, static_cast<double>(UINT64_MAX)));
-                if (patternId != 0 && !allPatternIds.count(patternId)) {
-                    orphanClipPatternIds.insert(patternId);
+                if (patternId != 0 &&
+                    (!allPatternIds.count(patternId) || unloadablePatternIds.count(patternId))) {
+                    recoverableClipPatternIds.insert(patternId);
                     warningLimiter.warning(
                         ProjectLoadWarningCategory::ReferenceClip,
-                        "[ProjectLoad] Clip references missing pattern " + std::to_string(patternId) +
+                        "[ProjectLoad] Clip references missing or unresolved pattern " + std::to_string(patternId) +
                             " - clip will be preserved with placeholder",
-                        "[ProjectLoad] Additional missing-pattern clip reference warnings suppressed.");
+                        "[ProjectLoad] Additional recoverable clip-pattern warnings suppressed.");
                 }
             }
         }
@@ -1224,7 +1234,7 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     }
 
     // Build structured report for reference validation issues
-    if (!orphanClipPatternIds.empty() || !orphanNoteUnitIds.empty() ||
+    if (!recoverableClipPatternIds.empty() || !orphanNoteUnitIds.empty() ||
         result.integrity == LoadIntegrity::Mismatch) {
         auto report = std::make_unique<ProjectLoadReport>();
         if (result.integrity == LoadIntegrity::Mismatch) {
@@ -1238,11 +1248,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 ""
             });
         }
-        for (const auto& pid : orphanClipPatternIds) {
+        for (const auto& pid : recoverableClipPatternIds) {
             report->issues.push_back({
                 LoadIssueSeverity::Warning,
                 "clip",
-                "Clip references missing pattern - clip will be preserved with placeholder",
+                "Clip references missing or unresolved pattern - clip will be preserved with placeholder",
                 pid,
                 std::to_string(pid),
                 ""
@@ -1545,6 +1555,22 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     }
                 }
             }
+        }
+
+        // Preserve clip placement when a project references a pattern record
+        // that is missing from the file. The empty MIDI placeholder keeps the
+        // serialized pattern identity recoverable and deliberately renders
+        // silence until the user replaces or repairs the missing pattern.
+        for (uint64_t oldId : recoverableClipPatternIds) {
+            MidiPayload placeholderPayload;
+            std::string placeholderName = "[Missing Pattern " + std::to_string(oldId) + "]";
+            const auto originalName = patternNames.find(oldId);
+            if (originalName != patternNames.end() && !originalName->second.empty()) {
+                placeholderName += " " + originalName->second;
+            }
+            const PatternID placeholderId = patternManager.createMidiPatternWithId(
+                PatternID{oldId}, placeholderName, 4.0, placeholderPayload);
+            patternMap[oldId] = placeholderId;
         }
 
         // Arsenal unit default patterns are serialized with project-file IDs.

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -163,8 +163,8 @@ void testTrailingJsonObjectIsRejectedNonDestructively() {
     std::cout << "[PASS] Trailing JSON object is rejected non-destructively" << std::endl;
 }
 
-void testMissingPatternReference() {
-    std::cout << "[TEST] Missing pattern reference preserves placeholder..." << std::endl;
+void testRecoverablePatternReferences() {
+    std::cout << "[TEST] Missing or unresolved pattern references preserve placeholders..." << std::endl;
 
     const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
     const auto& testDir = testDirScope.path();
@@ -177,7 +177,8 @@ void testMissingPatternReference() {
         "playhead": 0.0,
         "sources": [],
         "patterns": [
-            {"id": 1, "name": "Existing Pattern", "type": "midi", "length": 4.0, "notes": []}
+            {"id": 1, "name": "Existing Pattern", "type": "midi", "length": 4.0, "notes": []},
+            {"id": 2, "name": "Missing Audio Source", "type": "audio", "length": 2.0, "sourceId": 77}
         ],
         "lanes": [
             {
@@ -186,7 +187,8 @@ void testMissingPatternReference() {
                 "volume": 1.0,
                 "pan": 0.0,
                 "clips": [
-                    {"id": "clip-1", "patternId": 999, "start": 0.0, "duration": 4.0, "name": "Missing Ref Clip"}
+                    {"id": "clip-1", "patternId": 999, "start": 0.0, "duration": 4.0, "name": "Missing Ref Clip"},
+                    {"id": "clip-2", "patternId": 2, "start": 4.0, "duration": 2.0, "name": "Missing Source Clip"}
                 ]
             }
         ],
@@ -202,19 +204,77 @@ void testMissingPatternReference() {
 
     assert(result.ok);
 
-    // Should have warning about missing pattern (report may contain warnings)
-    if (result.report) {
-        bool foundWarning = false;
-        for (const auto& issue : result.report->issues) {
-            if (issue.category == "clip" && issue.referenceId == "999") {
-                foundWarning = true;
-                break;
-            }
+    assert(result.report);
+    bool foundMissingPatternWarning = false;
+    bool foundMissingSourceWarning = false;
+    for (const auto& issue : result.report->issues) {
+        if (issue.category == "clip" && issue.referenceId == "999") {
+            foundMissingPatternWarning = true;
         }
-        assert(foundWarning);
+        if (issue.category == "clip" && issue.referenceId == "2") {
+            foundMissingSourceWarning = true;
+        }
     }
+    assert(foundMissingPatternWarning);
+    assert(foundMissingSourceWarning);
 
-    std::cout << "[PASS] Missing pattern reference preserves placeholder" << std::endl;
+    const auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+    assert(laneIds.size() == 1);
+    const auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->clips.size() == 2);
+    assert(lane->clips[0].name == "Missing Ref Clip");
+    assert(std::abs(lane->clips[0].startBeat) < 1e-9);
+    assert(std::abs(lane->clips[0].durationBeats - 4.0) < 1e-9);
+
+    const PatternID placeholderId = lane->clips[0].patternId;
+    assert(placeholderId.value == 999);
+    const auto* placeholder = trackManager->getPatternManager().getPattern(placeholderId);
+    assert(placeholder);
+    assert(placeholder->isMidi());
+    assert(placeholder->name == "[Missing Pattern 999]");
+    assert(placeholder->getMidiNotes().empty());
+
+    assert(lane->clips[1].name == "Missing Source Clip");
+    assert(std::abs(lane->clips[1].startBeat - 4.0) < 1e-9);
+    assert(std::abs(lane->clips[1].durationBeats - 2.0) < 1e-9);
+    assert(lane->clips[1].patternId.value == 2);
+    const auto* missingSourcePlaceholder =
+        trackManager->getPatternManager().getPattern(lane->clips[1].patternId);
+    assert(missingSourcePlaceholder);
+    assert(missingSourcePlaceholder->isMidi());
+    assert(missingSourcePlaceholder->name == "[Missing Pattern 2] Missing Audio Source");
+    assert(missingSourcePlaceholder->getMidiNotes().empty());
+
+    const auto serialized = ProjectSerializer::serialize(trackManager, result.tempo, result.playhead, 0);
+    assert(serialized.ok);
+    const auto roundTripPath = testDir / "roundtrip.aes";
+    std::ofstream roundTripOut(roundTripPath);
+    roundTripOut << serialized.contents;
+    roundTripOut.close();
+
+    auto roundTripManager = std::make_shared<TrackManager>();
+    const auto roundTripResult = ProjectSerializer::load(roundTripPath.string(), roundTripManager);
+    assert(roundTripResult.ok);
+    const auto roundTripLaneIds = roundTripManager->getPlaylistModel().getLaneIDs();
+    assert(roundTripLaneIds.size() == 1);
+    const auto* roundTripLane = roundTripManager->getPlaylistModel().getLane(roundTripLaneIds[0]);
+    assert(roundTripLane);
+    assert(roundTripLane->clips.size() == 2);
+    assert(roundTripLane->clips[0].name == "Missing Ref Clip");
+    assert(roundTripLane->clips[0].patternId.value == 999);
+    const auto* roundTripPlaceholder =
+        roundTripManager->getPatternManager().getPattern(roundTripLane->clips[0].patternId);
+    assert(roundTripPlaceholder);
+    assert(roundTripPlaceholder->name == "[Missing Pattern 999]");
+    assert(roundTripLane->clips[1].name == "Missing Source Clip");
+    assert(roundTripLane->clips[1].patternId.value == 2);
+    const auto* roundTripMissingSourcePlaceholder =
+        roundTripManager->getPatternManager().getPattern(roundTripLane->clips[1].patternId);
+    assert(roundTripMissingSourcePlaceholder);
+    assert(roundTripMissingSourcePlaceholder->name == "[Missing Pattern 2] Missing Audio Source");
+
+    std::cout << "[PASS] Missing or unresolved pattern references preserve placeholders" << std::endl;
 }
 
 void testMissingArsenalUnitReference() {
@@ -860,7 +920,7 @@ int main() {
 
     testValidProjectLoad();
     testTrailingJsonObjectIsRejectedNonDestructively();
-    testMissingPatternReference();
+    testRecoverablePatternReferences();
     testMissingArsenalUnitReference();
     testFailedValidationDoesNotClear();
     testUnitManagerSurvivesFailedLoad();


### PR DESCRIPTION
## Summary

- preserve clips whose serialized pattern record is absent instead of dropping their placement data
- preserve clips whose audio pattern exists but references a missing source record
- create silent MIDI placeholders under the original serialized pattern IDs, with clearly recoverable names
- extend the project-load regression through a full save/load round trip for both failure modes

## Why

The loader's preflight report claimed these clips would be preserved with placeholders, but the commit phase never created those placeholders. `patternMap` therefore lacked the referenced ID and the lane loader fell through to the clip-drop branch. Audio patterns with unresolved source IDs had the same result.

## User impact

Clip placement, duration, name, and pattern identity now survive damaged or partially missing project data. The placeholder deliberately renders silence until the missing pattern/source is repaired, while the structured load report continues warning the user.

## Validation

- `cmake --build build-linux -j2 --target ProjectLoadRegressionTest`
- `ctest --test-dir build-linux -R '^ProjectLoadRegressionTest$' --output-on-failure`
- `cmake --build build-linux -j2 --target ProjectRoundTripIntegrityTest ProjectFixtureCorpusTest ProjectIntegrityCheckTest`
- `ctest --test-dir build-linux -R '^(ProjectLoadRegressionTest|ProjectRoundTripIntegrityTest|ProjectFixtureCorpusTest|ProjectIntegrityCheckTest)$' --output-on-failure`
- all four persistence tests passed
- `git diff --check`

## Risk / rollback

This changes project-load recovery behavior but does not change the project schema or version. A damaged project that previously lost clips now gains empty MIDI placeholder pattern records on its next save. Valid projects are unchanged. Reverting commit `af636395` restores the prior drop behavior.

## Docs

No public documentation change required.

Fixes #213