### PR TITLE
chore(audio): remove obsolete model stubs

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -205,7 +205,6 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Models/PatternManager.cpp
     src/Models/ClipSource.cpp
     src/Models/AudioClip.cpp
-    src/Models/PlaylistTrack.cpp
 
     # DSP
     src/DSP/AudioProcessor.cpp
@@ -349,7 +348,6 @@ set(AESTRA_AUDIO_CORE_HEADERS
     include/Models/ClipInstance.h
     include/Models/PatternManager.h
     include/IO/MiniAudioDecoder.h
-    include/Models/PlaylistTrack.h
     # Multi-clip playlist system
     include/Models/TimeTypes.h
     include/Models/ClipSource.h
@@ -357,7 +355,6 @@ set(AESTRA_AUDIO_CORE_HEADERS
     include/Models/PlaylistRuntimeSnapshot.h
     include/Models/PlaylistMixer.h
     include/IO/WaveformCache.h
-    include/Models/PlaylistSerializer.h
     include/Models/UnitManager.h
     include/Music/ScaleContext.h
 

--- a/AestraAudio/include/Models/PlaylistSerializer.h
+++ b/AestraAudio/include/Models/PlaylistSerializer.h
@@ -1,6 +1,0 @@
-#pragma once
-namespace Aestra {
-namespace Audio {
-class PlaylistSerializer {};
-} // namespace Audio
-} // namespace Aestra

--- a/AestraAudio/include/Models/PlaylistTrack.h
+++ b/AestraAudio/include/Models/PlaylistTrack.h
@@ -1,6 +1,0 @@
-#pragma once
-namespace Aestra {
-namespace Audio {
-class PlaylistTrack {};
-} // namespace Audio
-} // namespace Aestra

--- a/AestraAudio/src/Models/PlaylistTrack.cpp
+++ b/AestraAudio/src/Models/PlaylistTrack.cpp
@@ -1,6 +1,0 @@
-// Stub
-namespace Aestra {
-namespace Audio {
-// Stub
-}
-} // namespace Aestra

--- a/Tests/AestraAudio/WavLoaderTest.cpp
+++ b/Tests/AestraAudio/WavLoaderTest.cpp
@@ -1,5 +1,4 @@
 #include "MiniAudioDecoder.h"
-#include "PlaylistTrack.h"
 
 #include <cmath>
 #include <filesystem>


### PR DESCRIPTION
## Summary

- remove the remaining empty `PlaylistTrack` and `PlaylistSerializer` model declarations
- remove the empty `PlaylistTrack.cpp` translation unit
- remove their audio-core build-list entries and the unrelated test include

## Why

Four of the six stubs originally reported in #204 are already gone. The two remaining declarations have no behavior and no consumers; keeping them in the public include tree implies APIs that do not exist.

## Testing performed

- `cmake --build build-linux -j2 --target AestraWavLoaderTest`
- `ctest --test-dir build-linux -R '^AestraWavLoaderTest$' --output-on-failure`
- `git diff --check`

## Docs updated?

No. This removes unimplemented dead declarations and does not change documented behavior.

## Risk / rollback

Low risk. Repository-wide reference checks found no consumers beyond an unused include in `WavLoaderTest`. Reverting commit `e5b422ef` restores the stubs.

Fixes #204