### PR TITLE
refactor(commands): thread CommandContext through build; drop CommandRegistry engine global (#559)

### DIFF
--- a/AestraAudio/include/Commands/CommandContext.h
+++ b/AestraAudio/include/Commands/CommandContext.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace Aestra {
+namespace Audio {
+
+class AudioEngine;
+class TrackManager;
+
+/**
+ * @brief Live session dependencies a command factory needs to build a command.
+ *
+ * Threaded explicitly from each caller (the owner of the engine + track model)
+ * through CommandParser into CommandRegistry::build, instead of being reached
+ * ambiently through a process-wide pointer. Both members are borrowed, never
+ * owned: the context outlives no build call and stores nothing.
+ *
+ * A member may be null when that dependency does not exist yet (e.g. the engine
+ * before AudioEngine wiring, or a headless registry with no track model). The
+ * factories that need a given member check it and refuse to build rather than
+ * dereference null — the same refusal the old ambient path produced.
+ */
+struct CommandContext {
+    AudioEngine* engine = nullptr;
+    TrackManager* trackManager = nullptr;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/CommandParser.h
+++ b/AestraAudio/include/Commands/CommandParser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Commands/CommandContext.h"
 #include "Commands/CommandResult.h"
 #include "Commands/MuseGrammar.h"
 
@@ -16,7 +17,10 @@ class ICommand;
 
 class CommandParser {
 public:
-    CommandResult parse(const std::string& input, CommandHistory& history);
+    // The parser is stateless: the live session dependencies a command needs to
+    // build (engine + track model) arrive per call via CommandContext, borrowed
+    // from the caller that owns them, and are threaded straight to the registry.
+    CommandResult parse(const std::string& input, CommandHistory& history, const CommandContext& context);
 
     /**
      * @brief Execute a verb from an already-tokenised flag map.
@@ -28,7 +32,8 @@ public:
      */
     CommandResult execute(const std::string& verb,
                           const std::unordered_map<std::string, std::string>& flags,
-                          CommandHistory& history);
+                          CommandHistory& history,
+                          const CommandContext& context);
 
     /**
      * @brief Validate and build a command without executing it.
@@ -42,7 +47,8 @@ public:
         const std::string& verb,
         const std::unordered_map<std::string, std::string>& flags,
         CommandStatus& outStatus,
-        std::string& outMessage);
+        std::string& outMessage,
+        const CommandContext& context);
 
 private:
     std::unordered_map<std::string, std::string> tokeniseFlags(

--- a/AestraAudio/include/Commands/CommandRegistry.h
+++ b/AestraAudio/include/Commands/CommandRegistry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Commands/CommandContext.h"
 #include "Commands/ICommand.h"
 #include "Commands/MuseGrammar.h"
 
@@ -11,20 +12,21 @@
 namespace Aestra {
 namespace Audio {
 
-class AudioEngine;
-class TrackManager;
-
 class CommandRegistry {
 public:
+    // Factories are registered once and are stateless: every runtime dependency
+    // (the engine, the track model) arrives per build through CommandContext,
+    // never captured or reached ambiently.
     using Factory = std::function<std::unique_ptr<ICommand>(
-        const std::unordered_map<std::string, std::string>&)>;
+        const std::unordered_map<std::string, std::string>&, const CommandContext&)>;
 
     static CommandRegistry& instance();
 
     void registerCommand(const std::string& verb, Factory factory);
     std::unique_ptr<ICommand> build(
         const std::string& verb,
-        const std::unordered_map<std::string, std::string>& flags);
+        const std::unordered_map<std::string, std::string>& flags,
+        const CommandContext& context);
 
     /**
      * @brief Record why a factory refused to build, then return nullptr.
@@ -43,11 +45,14 @@ public:
      */
     static std::string consumeLastBuildError();
 
-    static void initialize(TrackManager* trackManager);
-
-    /** Set the AudioEngine for transport commands (play/stop/set_bpm). */
-    static void setAudioEngine(AudioEngine* engine);
-    static AudioEngine* getAudioEngine();
+    /**
+     * @brief Register every Muse command factory once.
+     *
+     * Factories are stateless; they take no dependencies here. The engine and
+     * track model are supplied per build via CommandContext, so a single
+     * registration serves every session in the process.
+     */
+    static void initialize();
 
 private:
     CommandRegistry() = default;

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -25,7 +25,8 @@ static std::vector<std::string> splitWhitespace(const std::string& input) {
     return tokens;
 }
 
-CommandResult CommandParser::parse(const std::string& input, CommandHistory& history) {
+CommandResult CommandParser::parse(const std::string& input, CommandHistory& history,
+                                   const CommandContext& context) {
     CommandResult result;
     result.commandId = 0;
 
@@ -55,7 +56,7 @@ CommandResult CommandParser::parse(const std::string& input, CommandHistory& his
     }
 
     // 3. Shared back half: schema lookup, validation, build, execute
-    CommandResult executed = execute(result.verb, parsedFlags, history);
+    CommandResult executed = execute(result.verb, parsedFlags, history, context);
     auto endTime = std::chrono::steady_clock::now();
     executed.executionMs = std::chrono::duration<double, std::milli>(endTime - startTime).count();
     return executed;
@@ -65,7 +66,8 @@ std::unique_ptr<ICommand> CommandParser::buildValidated(
     const std::string& verb,
     const std::unordered_map<std::string, std::string>& flags,
     CommandStatus& outStatus,
-    std::string& outMessage) {
+    std::string& outMessage,
+    const CommandContext& context) {
     // Look up verb in MuseGrammar::allCommands()
     const auto& allCmds = MuseGrammar::allCommands();
     const CommandSchema* schema = nullptr;
@@ -108,7 +110,7 @@ std::unique_ptr<ICommand> CommandParser::buildValidated(
     }
 
     // Build ICommand via registry
-    auto cmd = CommandRegistry::instance().build(verb, flags);
+    auto cmd = CommandRegistry::instance().build(verb, flags, context);
     if (!cmd) {
         outStatus = CommandStatus::ExecutionError;
         const std::string reason = CommandRegistry::consumeLastBuildError();
@@ -123,7 +125,8 @@ std::unique_ptr<ICommand> CommandParser::buildValidated(
 
 CommandResult CommandParser::execute(const std::string& verb,
                                      const std::unordered_map<std::string, std::string>& flags,
-                                     CommandHistory& history) {
+                                     CommandHistory& history,
+                                     const CommandContext& context) {
     CommandResult result;
     result.commandId = 0;
     result.verb = verb;
@@ -137,7 +140,7 @@ CommandResult CommandParser::execute(const std::string& verb,
 
     CommandStatus buildStatus = CommandStatus::Success;
     std::string buildMessage;
-    auto cmd = buildValidated(verb, flags, buildStatus, buildMessage);
+    auto cmd = buildValidated(verb, flags, buildStatus, buildMessage, context);
     if (!cmd) {
         result.status = buildStatus;
         result.message = std::move(buildMessage);

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -108,8 +108,6 @@ std::optional<uint64_t> safeStoull(std::string_view s) {
     }
 }
 
-AudioEngine* s_audioEngine = nullptr;
-
 // Reason recorded by the most recent factory refusal (see CommandRegistry::fail).
 thread_local std::string t_lastBuildError;
 } // namespace
@@ -136,30 +134,22 @@ void CommandRegistry::registerCommand(const std::string& verb, Factory factory) 
 
 std::unique_ptr<ICommand> CommandRegistry::build(
     const std::string& verb,
-    const std::unordered_map<std::string, std::string>& flags)
+    const std::unordered_map<std::string, std::string>& flags,
+    const CommandContext& context)
 {
     t_lastBuildError.clear();
     auto it = m_factories.find(verb);
     if (it == m_factories.end())
         return nullptr;
-    return it->second(flags);
+    return it->second(flags, context);
 }
 
-void CommandRegistry::setAudioEngine(AudioEngine* engine) {
-    s_audioEngine = engine;
-}
-
-AudioEngine* CommandRegistry::getAudioEngine() {
-    return s_audioEngine;
-}
-
-void CommandRegistry::initialize(TrackManager* trackManager) {
+void CommandRegistry::initialize() {
     auto& reg = instance();
-    auto* pm = trackManager ? &trackManager->getPlaylistModel() : nullptr;
 
     // ===== Transport (3) =====
-    reg.registerCommand("set_bpm", [](const auto& flags) -> std::unique_ptr<ICommand> {
-        AudioEngine* engine = getAudioEngine();
+    reg.registerCommand("set_bpm", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        AudioEngine* engine = ctx.engine;
         if (!engine) return nullptr;
         auto valueRaw = requireFlag(flags, "value");
         if (!valueRaw) return nullptr;
@@ -168,61 +158,35 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<SetBpmCommand>(*engine, *valueOpt);
     });
 
-    reg.registerCommand("play", [](const auto&) -> std::unique_ptr<ICommand> {
-        AudioEngine* engine = getAudioEngine();
+    reg.registerCommand("play", [](const auto&, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        AudioEngine* engine = ctx.engine;
         if (!engine) return nullptr;
         return std::make_unique<PlayCommand>(*engine);
     });
 
-    reg.registerCommand("stop", [](const auto&) -> std::unique_ptr<ICommand> {
-        AudioEngine* engine = getAudioEngine();
+    reg.registerCommand("stop", [](const auto&, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        AudioEngine* engine = ctx.engine;
         if (!engine) return nullptr;
         return std::make_unique<StopCommand>(*engine);
     });
 
     // ===== Track (8) =====
-    if (!trackManager) {
-        // Register no-op factories when no TrackManager available
-        auto noopTrack = [](const auto&) -> std::unique_ptr<ICommand> { return nullptr; };
-        reg.registerCommand("add_track", noopTrack);
-        reg.registerCommand("delete_track", noopTrack);
-        reg.registerCommand("rename_track", noopTrack);
-        reg.registerCommand("mute_track", noopTrack);
-        reg.registerCommand("solo_track", noopTrack);
-        reg.registerCommand("set_volume", noopTrack);
-        reg.registerCommand("set_pan", noopTrack);
-        reg.registerCommand("add_clip", noopTrack);
-        reg.registerCommand("delete_clip", noopTrack);
-        reg.registerCommand("move_clip", noopTrack);
-        reg.registerCommand("duplicate_clip", noopTrack);
-        reg.registerCommand("trim_clip", noopTrack);
-        reg.registerCommand("add_unit", noopTrack);
-        reg.registerCommand("load_sample", noopTrack);
-        reg.registerCommand("set_unit_gain", noopTrack);
-        reg.registerCommand("add_note", noopTrack);
-        reg.registerCommand("delete_note", noopTrack);
-        reg.registerCommand("move_note", noopTrack);
-        reg.registerCommand("set_note", noopTrack);
-        reg.registerCommand("arrange_pattern", noopTrack);
-        reg.registerCommand("set_steps", noopTrack);
-        reg.registerCommand("quantize_pattern", noopTrack);
-        reg.registerCommand("transpose_pattern", noopTrack);
-        reg.registerCommand("clone_pattern", noopTrack);
-        reg.registerCommand("set_pattern_length", noopTrack);
-        reg.registerCommand("add_effect", noopTrack);
-        reg.registerCommand("remove_effect", noopTrack);
-        reg.registerCommand("bypass_effect", noopTrack);
-        reg.registerCommand("set_effect_param", noopTrack);
-        return;
-    }
+    // Every track/clip/unit/pattern/effect factory needs the track model. When
+    // the session has none (a headless registry with no TrackManager) the
+    // factory refuses to build — the same no-op the old null-TrackManager
+    // registration produced, now expressed as a per-factory guard on ctx.
 
-    reg.registerCommand("add_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto it = flags.find("name");
         std::string name = (it != flags.end()) ? it->second : "";
         return std::make_unique<AddChannelCommand>(*tm, name);
     });
 
-    reg.registerCommand("delete_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("delete_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -232,7 +196,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<DeleteTrackCommand>(*tm, *trackOpt);
     });
 
-    reg.registerCommand("rename_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("rename_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -244,7 +210,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<RenameTrackCommand>(*tm, *trackOpt, nameIt->second);
     });
 
-    reg.registerCommand("mute_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("mute_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -258,7 +226,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<SetMuteCommand>(*ch, state);
     });
 
-    reg.registerCommand("solo_track", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("solo_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -272,7 +242,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<SetSoloCommand>(*ch, state);
     });
 
-    reg.registerCommand("set_volume", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_volume", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -287,7 +259,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<SetVolumeCommand>(*ch, *valueOpt);
     });
 
-    reg.registerCommand("set_pan", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_pan", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -303,7 +277,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     // ===== Clip (5) =====
-    reg.registerCommand("add_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
@@ -336,7 +311,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<AddClipCommand>(*pm, laneId, clip);
     });
 
-    reg.registerCommand("delete_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("delete_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
@@ -348,7 +324,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<RemoveClipCommand>(*pm, clipId);
     });
 
-    reg.registerCommand("move_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("move_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
@@ -370,7 +347,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<MoveClipCommand>(*pm, clipId, *startOpt, laneId);
     });
 
-    reg.registerCommand("duplicate_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("duplicate_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
@@ -386,7 +364,8 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<DuplicateClipCommand>(*pm, clipId, static_cast<double>(*barOpt));
     });
 
-    reg.registerCommand("trim_clip", [pm](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("trim_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
@@ -407,7 +386,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
     });
 
     // ===== Unit (2) =====
-    reg.registerCommand("add_unit", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_unit", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto nameIt = flags.find("name");
         std::string name = (nameIt != flags.end()) ? nameIt->second : "";
         UnitType type = UnitType::Sampler;
@@ -423,7 +404,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<AddUnitCommand>(tm->getUnitManager(), name, type);
     });
 
-    reg.registerCommand("load_sample", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("load_sample", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto unitRaw = requireFlag(flags, "unit");
         if (!unitRaw) return nullptr;
         auto unitOpt = safeStoull(*unitRaw);
@@ -439,7 +422,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<LoadSampleCommand>(tm->getUnitManager(), *unitOpt, std::string(*fileRaw));
     });
 
-    reg.registerCommand("set_unit_gain", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_unit_gain", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto unitRaw = requireFlag(flags, "unit");
         if (!unitRaw) return nullptr;
         auto unitOpt = safeStoull(*unitRaw);
@@ -499,7 +484,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return NoteKey{PatternID{*patternOpt}, *unitOpt, *pitchOpt, static_cast<double>(*startOpt)};
     };
 
-    reg.registerCommand("add_note", [tm = trackManager, parseNoteKey](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_note", [parseNoteKey](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto durationRaw = requireFlag(flags, "duration");
@@ -537,7 +524,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<AddNoteCommand>(tm->getPatternManager(), key->patternId, note);
     });
 
-    reg.registerCommand("delete_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("delete_note", [parseNoteKey, findNote](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);
@@ -550,7 +539,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<RemoveNoteCommand>(tm->getPatternManager(), key->patternId, *note);
     });
 
-    reg.registerCommand("move_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("move_note", [parseNoteKey, findNote](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto toStartRaw = requireFlag(flags, "to_start");
@@ -576,7 +567,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                  static_cast<double>(*toStartOpt), toPitch);
     });
 
-    reg.registerCommand("arrange_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("arrange_pattern", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -616,7 +609,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                        static_cast<double>(*startOpt));
     });
 
-    reg.registerCommand("set_steps", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_steps", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -705,7 +700,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                  rowLengthBeats);
     });
 
-    reg.registerCommand("quantize_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("quantize_pattern", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -738,7 +735,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                         unitId);
     });
 
-    reg.registerCommand("transpose_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("transpose_pattern", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -786,7 +785,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return true;
     };
 
-    reg.registerCommand("add_effect", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_effect", [equalsIgnoreCase](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -837,7 +838,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                   match->name);
     });
 
-    reg.registerCommand("remove_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("remove_effect", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -854,7 +857,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<RemoveEffectCommand>(*tm, *ch, static_cast<size_t>(*slotOpt));
     });
 
-    reg.registerCommand("bypass_effect", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("bypass_effect", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -874,7 +879,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                         parseFlagBool(*stateRaw));
     });
 
-    reg.registerCommand("set_effect_param", [tm = trackManager, equalsIgnoreCase](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_effect_param", [equalsIgnoreCase](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -927,7 +934,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<SetEffectParamCommand>(plugin, target->id, *valueOpt);
     });
 
-    reg.registerCommand("clone_pattern", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("clone_pattern", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -938,7 +947,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
         return std::make_unique<ClonePatternCommand>(tm->getPatternManager(), patternId);
     });
 
-    reg.registerCommand("set_pattern_length", [tm = trackManager](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_pattern_length", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto patternRaw = requireFlag(flags, "pattern");
         if (!patternRaw) return nullptr;
         auto patternOpt = safeStoull(*patternRaw);
@@ -954,7 +965,9 @@ void CommandRegistry::initialize(TrackManager* trackManager) {
                                                          static_cast<double>(*beatsOpt));
     });
 
-    reg.registerCommand("set_note", [tm = trackManager, parseNoteKey, findNote](const auto& flags) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("set_note", [parseNoteKey, findNote](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
         auto key = parseNoteKey(flags);
         if (!key) return nullptr;
         auto note = findNote(*tm, key->patternId, key->unitId, key->pitch, key->startBeat);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -874,7 +874,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
 
                 CommandStatus buildStatus = CommandStatus::Success;
                 std::string buildMessage;
-                auto built = parser.buildValidated(subVerb, flags, buildStatus, buildMessage);
+                const CommandContext ctx{m_engine, m_trackManager};
+                auto built = parser.buildValidated(subVerb, flags, buildStatus, buildMessage, ctx);
                 if (!built) {
                     return failBatch(statusName(buildStatus), prefix + buildMessage);
                 }
@@ -1210,8 +1211,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         }
 
         CommandParser parser;
+        const CommandContext ctx{m_engine, m_trackManager};
         CommandResult cmdResult =
-            parser.execute(verb, flags, m_trackManager->getCommandHistory());
+            parser.execute(verb, flags, m_trackManager->getCommandHistory(), ctx);
 
         JSON response = JSON::object();
         response.set("id", JSON(id));

--- a/Source/App/MuseReplMain.cpp
+++ b/Source/App/MuseReplMain.cpp
@@ -107,8 +107,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    CommandRegistry::initialize(trackManager.get());
-    CommandRegistry::setAudioEngine(&engine);
+    CommandRegistry::initialize();
 
     MuseService service(trackManager.get(), &engine);
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -230,8 +230,9 @@ AestraContent::AestraContent()
     // Create track manager for multi-track functionality
     m_trackManager = std::make_shared<TrackManager>();
 
-    // Initialize Muse command registry with TrackManager dependencies
-    Aestra::Audio::CommandRegistry::initialize(m_trackManager.get());
+    // Register the Muse command factories once. They are stateless; the engine
+    // and track model are supplied per command via CommandContext at parse time.
+    Aestra::Audio::CommandRegistry::initialize();
 
     // TrackManager is owned by AestraContent, and the destructor clears this stored callback before teardown.
     m_trackManager->setStopPreviewCallback([this]() { stopSoundPreview(); });
@@ -3023,7 +3024,6 @@ void AestraContent::setAudioEngine(Aestra::Audio::AudioEngine* engine) {
     }
     m_audioEngine = engine;
     m_musicalTyping.setTargetUnit(m_sequencerPanel ? m_sequencerPanel->getSelectedUnitId() : 0);
-    Aestra::Audio::CommandRegistry::setAudioEngine(engine);
     if (m_audioEngine && m_previewEngine) {
         m_audioEngine->setPreviewEngine(m_previewEngine.get());
     }
@@ -4031,7 +4031,8 @@ Aestra::Audio::CommandResult AestraContent::executeMuseCommand(const std::string
     }
 
     auto& history = m_trackManager->getCommandHistory();
-    Aestra::Audio::CommandResult result = m_commandParser.parse(input, history);
+    const Aestra::Audio::CommandContext ctx{m_audioEngine, m_trackManager.get()};
+    Aestra::Audio::CommandResult result = m_commandParser.parse(input, history, ctx);
 
     if (m_sessionLog) {
         // Build resolved args map from the parsed input

--- a/Tests/Commands/MuseAgentLoopTest.cpp
+++ b/Tests/Commands/MuseAgentLoopTest.cpp
@@ -103,8 +103,7 @@ int main() {
     trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
     AudioEngine engine;
     engine.setSampleRate(48000);
-    CommandRegistry::initialize(trackManager.get());
-    CommandRegistry::setAudioEngine(&engine);
+    CommandRegistry::initialize();
     MuseService service(trackManager.get(), &engine);
 
     const AgentLoop::Transport transport = [&service](const std::string& line) {

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -131,8 +131,7 @@ int main() {
         return 1;
     }
 
-    CommandRegistry::initialize(trackManager.get());
-    CommandRegistry::setAudioEngine(&engine);
+    CommandRegistry::initialize();
     MuseService service(trackManager.get(), &engine);
 
     // --- Protocol: malformed input never crashes, always structured error ---

--- a/Tests/Commands/MuseSocketServerTest.cpp
+++ b/Tests/Commands/MuseSocketServerTest.cpp
@@ -121,7 +121,7 @@ std::string pumpAndRead(MuseSocketServer& server, MuseService& service, SocketHa
 int main() {
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
-    CommandRegistry::initialize(trackManager.get());
+    CommandRegistry::initialize();
     MuseService service(trackManager.get(), nullptr);
 
     MuseSocketServer server;

--- a/Tests/Guards/no_audioengine_singleton.cmake
+++ b/Tests/Guards/no_audioengine_singleton.cmake
@@ -25,11 +25,11 @@
 # the *realistic* reintroductions — a renamed static pointer or accessor —
 # cannot land silently.
 #
-# Exemption (single, tracked): CommandRegistry.{h,cpp} carry an explicitly
-# injected static AudioEngine* for Muse transport commands. That is a distinct
-# (still undesirable) mechanism scheduled for context-injection migration in
-# issue #559; patterns 1-3 remain enforced there, only pattern 4/5 is waived.
-# Do not add further exemptions — remove this one via #559.
+# Exemptions: none. CommandRegistry.{h,cpp} formerly carried an injected static
+# AudioEngine* for Muse transport commands; issue #559 migrated that to explicit
+# CommandContext injection through CommandRegistry::build, so the last exemption
+# was removed and every pattern (1-5) is now enforced everywhere. Do not add new
+# exemptions — thread dependencies through the owner instead.
 #
 # Required -D args:
 #   REPO_ROOT  absolute path to the repository root
@@ -49,10 +49,10 @@ set(scan_dirs
     aestra-core
 )
 
-set(exempt_static_pattern
-    "AestraAudio/include/Commands/CommandRegistry.h"
-    "AestraAudio/src/Commands/CommandRegistry.cpp"
-)
+# No files are exempt from the structural static/global engine shapes (#559
+# retired the last exemption). Kept as an empty list so the FIND below stays
+# well-formed and a future exemption is a deliberate, reviewable edit.
+set(exempt_static_pattern "")
 
 set(violations "")
 foreach(dir ${scan_dirs})

--- a/Tests/Guards/no_audioengine_singleton_selftest.cmake
+++ b/Tests/Guards/no_audioengine_singleton_selftest.cmake
@@ -1,9 +1,10 @@
 # Self-test for no_audioengine_singleton.cmake — pins the guard's contract.
 #
 # Materializes fixture trees in WORK_DIR and runs the real guard against each,
-# asserting it fails on every forbidden shape (including renamed mechanisms)
-# and passes on benign ownership patterns, the prefix-type control, and the
-# tracked CommandRegistry exemption (#559).
+# asserting it fails on every forbidden shape (including renamed mechanisms) and
+# passes on benign ownership patterns and the prefix-type control. Since #559
+# retired the CommandRegistry exemption, it also pins that the former-exempt
+# path is now enforced like everywhere else.
 #
 # Required -D args:
 #   GUARD_SCRIPT  absolute path to no_audioengine_singleton.cmake
@@ -64,12 +65,14 @@ run_fixture(stack-local "Tests/K.cpp"
 run_fixture(prefix-type-control "Source/L.cpp"
     "static AudioEngineDiagnosticsHelper s_helper\;" PASS)
 
-# ── Exemption semantics (#559): waived for pattern 4/5 only, path-exact ─────
-run_fixture(exempt-path-static-ok "AestraAudio/include/Commands/CommandRegistry.h"
-    "class CommandRegistry { static AudioEngine* s_engine\; }\;" PASS)
-run_fixture(exempt-path-legacy-still-fails "AestraAudio/src/Commands/CommandRegistry.cpp"
+# ── Exemption removed (#559): CommandRegistry is enforced like anywhere else ─
+# The path that used to be waived for pattern 4/5 now fails on the same static
+# pointer shape — proving the exemption is gone, not just unused.
+run_fixture(former-exempt-path-now-fails "AestraAudio/include/Commands/CommandRegistry.h"
+    "class CommandRegistry { static AudioEngine* s_engine\; }\;" FAIL)
+run_fixture(former-exempt-path-legacy-fails "AestraAudio/src/Commands/CommandRegistry.cpp"
     "static AudioEngine* g_audioEngineInstance = nullptr\;" FAIL)
-run_fixture(non-exempt-path-same-shape "AestraAudio/src/Commands/OtherFile.cpp"
+run_fixture(commands-dir-same-shape-fails "AestraAudio/src/Commands/OtherFile.cpp"
     "static AudioEngine* s_engine = nullptr\;" FAIL)
 
 file(REMOVE_RECURSE "${WORK_DIR}/tree")


### PR DESCRIPTION
## Summary
Closes #559. `CommandRegistry` held a process-wide **static `AudioEngine*`** (`setAudioEngine`/`getAudioEngine`) that the transport factories (`play`/`stop`/`set_bpm`) reached ambiently — the last global-engine mechanism after the singleton removal (#558), carried under the **sole tracked exemption** in the no-AudioEngine-singleton guard.

This replaces it with explicit **per-build dependency injection**, and — following the issue discussion — threads **both** the engine and the track model through a `CommandContext` so factories become fully stateless (rather than fixing only the engine global while leaving the `TrackManager` capture in place).

## Change
- **New `CommandContext { AudioEngine* engine; TrackManager* trackManager; }`** — the live session dependencies a factory needs, borrowed from the caller that owns them.
  - **Pointers, not references**, deliberately: a null engine is a real, handled state. `MuseSocketServerTest` builds `MuseService` with a null engine, and the transport factories refuse to build when `ctx.engine == nullptr` — exactly what the old `getAudioEngine() == nullptr` path did. A reference would turn that handled refusal into UB.
  - Kept narrow (no service-bag growth), per the discussion.
- **`CommandRegistry::Factory` → `(flags, const CommandContext&)`.** All 30 factories are stateless: they read `ctx.trackManager` (and derive the `PlaylistModel`) instead of capturing it at `initialize()` time, with a per-factory refusal when the model is absent — collapsing the old null-`TrackManager` noop-registration block into uniform guards.
- **`initialize()` drops its `TrackManager*` parameter:** registration is a one-time, dependency-free step; runtime dependencies enter only through `build(context)`.
- **`CommandParser`** threads `const CommandContext&` through `parse`/`execute`/`buildValidated` into the single registry `build` funnel. Callers (`AestraContent`, `MuseService` ×2) already own both objects and pass `{engine, trackManager}` directly.
- **Deleted** `setAudioEngine`/`getAudioEngine`/`s_audioEngine` and every call site.
- **Guard:** removed the `CommandRegistry` exemption so patterns 4/5 are enforced everywhere; the self-test now pins that the former-exempt path **fails** on the same static-pointer shape (exemption gone, not merely unused).

## Testing (build-linux, `-j2`)
| Check | Result |
|-------|--------|
| `MuseServiceTest` | **ALL PASSED** |
| `MuseAgentLoopTest` | **ALL PASSED** |
| `MuseSocketServerTest` (exercises the null-engine build path) | **ALL PASSED** |
| `NoAudioEngineSingletonGuard` + `…SelfTest` | pass (exemption removed, self-test updated) |
| `AudioEngineOwnershipTest` | pass |
| `MuseRepl` link · `AestraContent.cpp` compile (app/UI layer) | clean |

## Acceptance criteria (#559)
- ✅ No static/global `AudioEngine*` anywhere — guard exemption removed, guard green.
- ✅ Muse transport commands still work (MuseService/MuseRepl/socket flows).
- ✅ `AudioEngineOwnershipTest` green.

## Change type
- DSP: no · UI: no (wiring only) · Serialization/project format: no · Build/CI config: no · Public docs: no

## Risk / rollback
Mechanical, contained to the command surface; one funnel (`build`) and ~6 call sites. Rollback = revert this commit. No behavior change to command semantics — the same factories build the same commands, only the dependency source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking API change:** Command parsing and registry building now require a `CommandContext`; `initialize()` no longer accepts dependencies, and static `AudioEngine` accessors were removed.
- Replaced process-wide engine state with explicit per-call injection of `AudioEngine*` and `TrackManager*`, improving isolation and testability.
- Made command factories stateless and added null-dependency validation during command construction.
- Updated application services, command execution paths, and tests to pass runtime context explicitly.
- Removed the singleton guard exemption and expanded its self-tests to enforce the restriction for `CommandRegistry`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->