### PR TITLE
fix(ui): theme title-bar layout metrics

### DIFF
--- a/AestraUI/Core/NUIConfigLoader.cpp
+++ b/AestraUI/Core/NUIConfigLoader.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "NUIConfigLoader.h"
 #include "../../AestraCore/include/AestraJSON.h"
+#include <cmath>
 #include <sstream>
 #include <regex>
 #include <algorithm>
@@ -244,19 +245,32 @@ void NUIConfigLoader::applyLayout(const Aestra::JSON& layout) {
     auto& themeManager = NUIThemeManager::getInstance();
     auto& theme = themeManager.getCurrentThemeMutable();
 
-    if (layout.has("trackHeight")) theme.layout.trackHeight = parseDimension(layout["trackHeight"]);
-    if (layout.has("trackControlsWidth")) theme.layout.trackControlsWidth = parseDimension(layout["trackControlsWidth"]);
-    if (layout.has("fileBrowserWidth")) theme.layout.fileBrowserWidth = parseDimension(layout["fileBrowserWidth"]);
-    if (layout.has("transportBarHeight")) theme.layout.transportBarHeight = parseDimension(layout["transportBarHeight"]);
-    if (layout.has("titleBarHeight")) theme.layout.titleBarHeight = parseDimension(layout["titleBarHeight"]);
-    if (layout.has("viewToggleWidth")) theme.layout.viewToggleWidth = parseDimension(layout["viewToggleWidth"]);
-    if (layout.has("viewToggleHeight")) theme.layout.viewToggleHeight = parseDimension(layout["viewToggleHeight"]);
-    if (layout.has("transportButtonSize")) theme.layout.transportButtonSize = parseDimension(layout["transportButtonSize"]);
-    if (layout.has("controlButtonWidth")) theme.layout.controlButtonWidth = parseDimension(layout["controlButtonWidth"]);
-    if (layout.has("controlButtonHeight")) theme.layout.controlButtonHeight = parseDimension(layout["controlButtonHeight"]);
-    if (layout.has("gridLineSpacing")) theme.layout.gridLineSpacing = parseDimension(layout["gridLineSpacing"]);
-    if (layout.has("panelMargin")) theme.layout.panelMargin = parseDimension(layout["panelMargin"]);
-    if (layout.has("componentPadding")) theme.layout.componentPadding = parseDimension(layout["componentPadding"]);
+    // Only override a layout dimension when the JSON supplies a usable value.
+    // parseDimension() returns 0.0f for malformed input (non-numeric, NaN, "px"
+    // typos), and a zero/negative dimension is never valid — applying it would
+    // silently clobber the theme default and collapse the layout. Reject those
+    // and keep the current value instead.
+    const auto applyDim = [&](const char* key, float& target) {
+        if (!layout.has(key)) return;
+        const float value = parseDimension(layout[key]);
+        if (std::isfinite(value) && value > 0.0f) {
+            target = value;
+        }
+    };
+
+    applyDim("trackHeight", theme.layout.trackHeight);
+    applyDim("trackControlsWidth", theme.layout.trackControlsWidth);
+    applyDim("fileBrowserWidth", theme.layout.fileBrowserWidth);
+    applyDim("transportBarHeight", theme.layout.transportBarHeight);
+    applyDim("titleBarHeight", theme.layout.titleBarHeight);
+    applyDim("viewToggleWidth", theme.layout.viewToggleWidth);
+    applyDim("viewToggleHeight", theme.layout.viewToggleHeight);
+    applyDim("transportButtonSize", theme.layout.transportButtonSize);
+    applyDim("controlButtonWidth", theme.layout.controlButtonWidth);
+    applyDim("controlButtonHeight", theme.layout.controlButtonHeight);
+    applyDim("gridLineSpacing", theme.layout.gridLineSpacing);
+    applyDim("panelMargin", theme.layout.panelMargin);
+    applyDim("componentPadding", theme.layout.componentPadding);
 }
 
 void NUIConfigLoader::applySpacing(const Aestra::JSON& spacing) {

--- a/AestraUI/Core/NUIConfigLoader.cpp
+++ b/AestraUI/Core/NUIConfigLoader.cpp
@@ -86,6 +86,9 @@ void NUIConfigLoader::saveConfig(const std::string& filePath) {
     layout.set("trackControlsWidth", theme.layout.trackControlsWidth);
     layout.set("fileBrowserWidth", theme.layout.fileBrowserWidth);
     layout.set("transportBarHeight", theme.layout.transportBarHeight);
+    layout.set("titleBarHeight", theme.layout.titleBarHeight);
+    layout.set("viewToggleWidth", theme.layout.viewToggleWidth);
+    layout.set("viewToggleHeight", theme.layout.viewToggleHeight);
     config.set("layout", layout);
 
     // Save spacing
@@ -245,6 +248,9 @@ void NUIConfigLoader::applyLayout(const Aestra::JSON& layout) {
     if (layout.has("trackControlsWidth")) theme.layout.trackControlsWidth = parseDimension(layout["trackControlsWidth"]);
     if (layout.has("fileBrowserWidth")) theme.layout.fileBrowserWidth = parseDimension(layout["fileBrowserWidth"]);
     if (layout.has("transportBarHeight")) theme.layout.transportBarHeight = parseDimension(layout["transportBarHeight"]);
+    if (layout.has("titleBarHeight")) theme.layout.titleBarHeight = parseDimension(layout["titleBarHeight"]);
+    if (layout.has("viewToggleWidth")) theme.layout.viewToggleWidth = parseDimension(layout["viewToggleWidth"]);
+    if (layout.has("viewToggleHeight")) theme.layout.viewToggleHeight = parseDimension(layout["viewToggleHeight"]);
     if (layout.has("transportButtonSize")) theme.layout.transportButtonSize = parseDimension(layout["transportButtonSize"]);
     if (layout.has("controlButtonWidth")) theme.layout.controlButtonWidth = parseDimension(layout["controlButtonWidth"]);
     if (layout.has("controlButtonHeight")) theme.layout.controlButtonHeight = parseDimension(layout["controlButtonHeight"]);

--- a/AestraUI/Core/NUIConfigLoader.cpp
+++ b/AestraUI/Core/NUIConfigLoader.cpp
@@ -245,32 +245,44 @@ void NUIConfigLoader::applyLayout(const Aestra::JSON& layout) {
     auto& themeManager = NUIThemeManager::getInstance();
     auto& theme = themeManager.getCurrentThemeMutable();
 
-    // Only override a layout dimension when the JSON supplies a usable value.
+    // Only override a layout value when the JSON supplies a usable one.
     // parseDimension() returns 0.0f for malformed input (non-numeric, NaN, "px"
-    // typos), and a zero/negative dimension is never valid — applying it would
-    // silently clobber the theme default and collapse the layout. Reject those
-    // and keep the current value instead.
-    const auto applyDim = [&](const char* key, float& target) {
+    // typos), so both helpers reject non-finite values and keep the current
+    // default rather than silently clobbering it.
+    //
+    // The zero policy differs by role:
+    //  - applyExtent: dimensions that must occupy space (title bar, view toggle,
+    //    control sizes). Zero collapses the layout, so require strictly > 0.
+    //  - applySpacingDim: margins/padding where zero is a legitimate value
+    //    (a flush, no-gap layout), so accept finite >= 0.
+    const auto applyExtent = [&](const char* key, float& target) {
         if (!layout.has(key)) return;
         const float value = parseDimension(layout[key]);
         if (std::isfinite(value) && value > 0.0f) {
             target = value;
         }
     };
+    const auto applySpacingDim = [&](const char* key, float& target) {
+        if (!layout.has(key)) return;
+        const float value = parseDimension(layout[key]);
+        if (std::isfinite(value) && value >= 0.0f) {
+            target = value;
+        }
+    };
 
-    applyDim("trackHeight", theme.layout.trackHeight);
-    applyDim("trackControlsWidth", theme.layout.trackControlsWidth);
-    applyDim("fileBrowserWidth", theme.layout.fileBrowserWidth);
-    applyDim("transportBarHeight", theme.layout.transportBarHeight);
-    applyDim("titleBarHeight", theme.layout.titleBarHeight);
-    applyDim("viewToggleWidth", theme.layout.viewToggleWidth);
-    applyDim("viewToggleHeight", theme.layout.viewToggleHeight);
-    applyDim("transportButtonSize", theme.layout.transportButtonSize);
-    applyDim("controlButtonWidth", theme.layout.controlButtonWidth);
-    applyDim("controlButtonHeight", theme.layout.controlButtonHeight);
-    applyDim("gridLineSpacing", theme.layout.gridLineSpacing);
-    applyDim("panelMargin", theme.layout.panelMargin);
-    applyDim("componentPadding", theme.layout.componentPadding);
+    applyExtent("trackHeight", theme.layout.trackHeight);
+    applyExtent("trackControlsWidth", theme.layout.trackControlsWidth);
+    applyExtent("fileBrowserWidth", theme.layout.fileBrowserWidth);
+    applyExtent("transportBarHeight", theme.layout.transportBarHeight);
+    applyExtent("titleBarHeight", theme.layout.titleBarHeight);
+    applyExtent("viewToggleWidth", theme.layout.viewToggleWidth);
+    applyExtent("viewToggleHeight", theme.layout.viewToggleHeight);
+    applyExtent("transportButtonSize", theme.layout.transportButtonSize);
+    applyExtent("controlButtonWidth", theme.layout.controlButtonWidth);
+    applyExtent("controlButtonHeight", theme.layout.controlButtonHeight);
+    applyExtent("gridLineSpacing", theme.layout.gridLineSpacing);
+    applySpacingDim("panelMargin", theme.layout.panelMargin);
+    applySpacingDim("componentPadding", theme.layout.componentPadding);
 }
 
 void NUIConfigLoader::applySpacing(const Aestra::JSON& spacing) {

--- a/AestraUI/Core/NUIThemeSystem.cpp
+++ b/AestraUI/Core/NUIThemeSystem.cpp
@@ -167,6 +167,9 @@ void applyJSONThemeOverrides(const NUITheme& source, NUIThemeProperties& target)
     dimension("trackControlsWidth", target.layout.trackControlsWidth);
     dimension("trackHeight", target.layout.trackHeight);
     dimension("transportBarHeight", target.layout.transportBarHeight);
+    dimension("titleBarHeight", target.layout.titleBarHeight);
+    dimension("viewToggleWidth", target.layout.viewToggleWidth);
+    dimension("viewToggleHeight", target.layout.viewToggleHeight);
 
     const auto fontSize = [&](const char* name, float& value) {
         if (source.hasFontSizeOverride(name))
@@ -654,6 +657,11 @@ float NUIThemeManager::getLayoutDimension(const std::string& dimensionName) cons
     if (dimensionName == "transportBarHeight") return layout.transportBarHeight;
     if (dimensionName == "transportButtonSize") return layout.transportButtonSize;
     if (dimensionName == "transportButtonSpacing") return layout.transportButtonSpacing;
+
+    // Application chrome dimensions
+    if (dimensionName == "titleBarHeight") return layout.titleBarHeight;
+    if (dimensionName == "viewToggleWidth") return layout.viewToggleWidth;
+    if (dimensionName == "viewToggleHeight") return layout.viewToggleHeight;
 
     // Control dimensions
     if (dimensionName == "controlButtonWidth") return layout.controlButtonWidth;

--- a/AestraUI/Core/NUIThemeSystem.h
+++ b/AestraUI/Core/NUIThemeSystem.h
@@ -239,6 +239,11 @@ struct NUIThemeProperties {
         float transportButtonSize = 28.0f;
         float transportButtonSpacing = 8.0f;
 
+        // Application chrome dimensions
+        float titleBarHeight = 32.0f;
+        float viewToggleWidth = 310.0f;
+        float viewToggleHeight = 24.0f;
+
         // Control button dimensions
         float controlButtonWidth = 32.0f;
         float controlButtonHeight = 20.0f;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1437,18 +1437,16 @@ void AestraContent::onResize(int width, int height) {
     }
 
     if (m_viewToggle) {
-        // The view toggle is parented to the custom title bar (32px tall by default).
+        // The view toggle is parented to the custom title bar.
         // Center it horizontally in the window and vertically in the title bar.
-        constexpr float kViewToggleWidth = 310.0f;
-        constexpr float kViewToggleHeight = 24.0f;
-        constexpr float kTitleBarHeight = 32.0f;
-        const float yPos = std::round((kTitleBarHeight - kViewToggleHeight) * 0.5f);
+        const float yPos = std::round((layout.titleBarHeight - layout.viewToggleHeight) * 0.5f);
 
         const auto rootBounds = getBounds();
         const float centerX = rootBounds.width * 0.5f;
-        const float startX = std::round(centerX - kViewToggleWidth * 0.5f);
+        const float startX = std::round(centerX - layout.viewToggleWidth * 0.5f);
 
-        m_viewToggle->setBounds(AestraUI::NUIRect(startX, yPos, kViewToggleWidth, kViewToggleHeight));
+        m_viewToggle->setBounds(
+            AestraUI::NUIRect(startX, yPos, layout.viewToggleWidth, layout.viewToggleHeight));
     }
 
     if (m_scopeLabel) {

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -340,6 +340,33 @@ void testChromeDimensionConfigLoad() {
         check(nearlyEqual(t.layout.titleBarHeight, 41.0f), "zero titleBarHeight is rejected, default retained");
         check(nearlyEqual(t.layout.viewToggleWidth, 321.0f), "negative viewToggleWidth is rejected, default retained");
     }
+
+    // Non-numeric input hits parseDimension()'s 0.0f fallback; an extent
+    // dimension must reject it and keep the current value (CR #582 follow-up).
+    check(configLoader.loadConfigFromString(
+              "layout:\n"
+              "  viewToggleHeight: bad\n"),
+          "config with a non-numeric chrome dimension still parses");
+    check(nearlyEqual(manager.getCurrentTheme().layout.viewToggleHeight, 27.0f),
+          "non-numeric viewToggleHeight is rejected, default retained");
+
+    // Spacing tokens differ from extents: zero is a legitimate flush layout, so
+    // panelMargin/componentPadding accept 0 rather than being rejected.
+    {
+        auto& theme = manager.getCurrentThemeMutable();
+        theme.layout.panelMargin = 12.0f;
+        theme.layout.componentPadding = 8.0f;
+    }
+    check(configLoader.loadConfigFromString(
+              "layout:\n"
+              "  panelMargin: 0\n"
+              "  componentPadding: 0\n"),
+          "config with zero spacing parses");
+    {
+        const auto& t = manager.getCurrentTheme();
+        check(nearlyEqual(t.layout.panelMargin, 0.0f), "zero panelMargin is accepted (flush layout)");
+        check(nearlyEqual(t.layout.componentPadding, 0.0f), "zero componentPadding is accepted (flush layout)");
+    }
 }
 
 } // namespace

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -2,6 +2,7 @@
 
 #include "NUIThemeSystem.h"
 #include "NUIComponent.h"
+#include "NUIConfigLoader.h"
 
 #include <algorithm>
 #include <cmath>
@@ -297,6 +298,50 @@ void testHighContrastPreset() {
           "high-contrast grid hierarchy is stronger without flattening major/minor distinction");
 }
 
+// #582 review: the chrome layout dimensions must flow through NUIConfigLoader's
+// config parse+apply path, and malformed values must not clobber the theme
+// defaults with zero (see the applyLayout validation guard).
+void testChromeDimensionConfigLoad() {
+    std::cout << "[Test] chrome dimensions load through NUIConfigLoader and reject invalid values\n";
+    auto& manager = NUIThemeManager::getInstance();
+    auto& configLoader = NUIConfigLoader::getInstance();
+
+    {
+        auto& theme = manager.getCurrentThemeMutable();
+        theme.layout.titleBarHeight = 30.0f;
+        theme.layout.viewToggleWidth = 300.0f;
+        theme.layout.viewToggleHeight = 24.0f;
+    }
+
+    // Valid values apply. loadConfigFromString parses the config document with
+    // the loader's own parser, exercising applyLayout for the new chrome keys.
+    check(configLoader.loadConfigFromString(
+              "layout:\n"
+              "  titleBarHeight: 41.0\n"
+              "  viewToggleWidth: 321.0\n"
+              "  viewToggleHeight: 27.0\n"),
+          "config with chrome dimensions parses");
+    {
+        const auto& t = manager.getCurrentTheme();
+        check(nearlyEqual(t.layout.titleBarHeight, 41.0f), "titleBarHeight applied from config");
+        check(nearlyEqual(t.layout.viewToggleWidth, 321.0f), "viewToggleWidth applied from config");
+        check(nearlyEqual(t.layout.viewToggleHeight, 27.0f), "viewToggleHeight applied from config");
+    }
+
+    // Invalid (non-positive) values are rejected: the previously applied value
+    // is retained instead of being zeroed by parseDimension()'s 0.0f fallback.
+    check(configLoader.loadConfigFromString(
+              "layout:\n"
+              "  titleBarHeight: 0\n"
+              "  viewToggleWidth: -5\n"),
+          "config with invalid chrome dimensions still parses");
+    {
+        const auto& t = manager.getCurrentTheme();
+        check(nearlyEqual(t.layout.titleBarHeight, 41.0f), "zero titleBarHeight is rejected, default retained");
+        check(nearlyEqual(t.layout.viewToggleWidth, 321.0f), "negative viewToggleWidth is rejected, default retained");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -306,6 +351,7 @@ int main() {
     testThemeChangeResolution();
     testIndependentSubscriptionsAndAtomicSwitching();
     testLiveJSONThemeRegistration();
+    testChromeDimensionConfigLoad();
     testHierarchyInvalidation();
     testCompatibilityAliases();
     testLightPresetCompleteness();

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -82,6 +82,9 @@ void testSemanticDefaults() {
           "compact controls meet the minimum hit area");
     check(theme.layout.transportButtonSize == theme.layout.standardControlHeight,
           "transport and standard controls share the 28 px metric");
+    check(theme.layout.titleBarHeight == 32.0f && theme.layout.viewToggleWidth == 310.0f &&
+              theme.layout.viewToggleHeight == theme.layout.compactControlHeight,
+          "application chrome defaults use the shared compact metric");
     check(theme.layout.standardMenuRowHeight == theme.layout.standardRowHeight,
           "ordinary menu and list rows share a metric");
 }
@@ -179,7 +182,12 @@ void testLiveJSONThemeRegistration() {
         std::ofstream out(path, std::ios::binary | std::ios::trunc);
         out << R"({
             "colors": { "accent": "#2468ac", "focusRing": "#abcdef" },
-            "dimensions": { "standardControlHeight": 30.0 },
+            "dimensions": {
+                "standardControlHeight": 30.0,
+                "titleBarHeight": 34.0,
+                "viewToggleWidth": 300.0,
+                "viewToggleHeight": 26.0
+            },
             "fontSizes": { "normal": 13.0 }
         })";
     }
@@ -193,6 +201,10 @@ void testLiveJSONThemeRegistration() {
     check(colorsEqual(loaded.focusRing, NUIColor::fromHex(0xabcdef)), "semantic focus ring maps into live state");
     check(colorsEqual(loaded.backgroundPrimary, base.backgroundPrimary), "missing live token inherits the base preset");
     check(nearlyEqual(loaded.layout.standardControlHeight, 30.0f), "live control dimension is overridden");
+    check(nearlyEqual(manager.getLayoutDimension("titleBarHeight"), 34.0f) &&
+              nearlyEqual(manager.getLayoutDimension("viewToggleWidth"), 300.0f) &&
+              nearlyEqual(manager.getLayoutDimension("viewToggleHeight"), 26.0f),
+          "application chrome dimensions are overridden and exposed through the manager");
     check(nearlyEqual(loaded.fontSizeM, 13.0f), "legacy normal font size maps to live body text");
 
     int reloadCount = 0;


### PR DESCRIPTION
## Summary

- add `titleBarHeight`, `viewToggleWidth`, and `viewToggleHeight` to shared theme layout dimensions
- support the metrics in JSON theme overrides, config save/load, and generic layout lookup
- replace `AestraContent`'s local title-bar/view-toggle constants with the active theme values
- add regression coverage for defaults and live JSON overrides

## Why

The title-bar toggle geometry was still hardcoded in `AestraContent`, so theme files and presets could not control those dimensions consistently with the rest of the desktop layout.

## Testing performed

- `cmake --build build-linux -j2 --target NUIThemeConsistencyTest NUIThemeJSONTest`
- `ctest --test-dir build-linux -R '^(NUIThemeConsistencyTest|NUIThemeJSONTest)$' --output-on-failure`
- `cmake --build build-linux -j2 --target Aestra`
- `git diff --check`

## Docs updated?

No public docs. Existing theme files remain compatible because the new fields have defaults matching the prior geometry.

## Risk / rollback

UI-only, low risk. Default geometry is unchanged (`32 x 310 x 24` metrics). Custom themes can now override it. Reverting commit `a5678aab` restores the local constants.

Fixes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added shared theme layout tokens for `titleBarHeight`, `viewToggleWidth`, and `viewToggleHeight`, preserving the previous `32 × 310 × 24` geometry via defaults for existing themes.
- Extended theme layout override plumbing so these new dimensions can be overridden through JSON theme overrides and saved/applied via the config loader.
- Hardened config parsing for layout extents: extent dimensions are now only applied when they parse to finite positive values, while spacing-like tokens still allow finite non-negative (including zero) values.
- Replaced `AestraContent`’s hardcoded view-toggle sizing/positioning with the active theme’s new layout dimensions.
- Updated/expanded layout lookup support and regression tests covering semantic defaults, live JSON overrides, valid/invalid config values (including non-numeric and zero/negative), and zero-valued spacing tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->