### PR TITLE
feat(headless): implement generator commit layer — headless export renders audible MIDI (#556)

### DIFF
--- a/AestraAudio/include/Headless/HeadlessMusicGenerator.h
+++ b/AestraAudio/include/Headless/HeadlessMusicGenerator.h
@@ -314,7 +314,8 @@ private:
     // Mixer
     std::vector<std::string> m_channelNames;
 
-    // #556 render wiring — populated by the commit layer, reset per export.
+    // #556 render wiring — populated by the commit layer once per project.
+    bool m_committed = false;                      // guards against duplicate commits on re-export
     std::string m_toneSamplePath;                 // synthetic sampler source (temp file)
     std::map<uint32_t, uint64_t> m_laneUnits;     // laneIndex -> sampler UnitID
     std::map<uint32_t, PlaylistLaneID> m_laneIds; // laneIndex -> playlist lane

--- a/AestraAudio/include/Headless/HeadlessMusicGenerator.h
+++ b/AestraAudio/include/Headless/HeadlessMusicGenerator.h
@@ -282,7 +282,17 @@ private:
     
     void commitPatternsToManager();
     void commitPlaylistToModel();
-    
+
+    // #556 headless-render helpers.
+    // Writes a short synthetic sine WAV that the built-in sampler loads as its
+    // source — the license-free way to make MIDI audible in a shipping headless
+    // build (com.Aestrastudios.sampler is the only always-available instrument).
+    bool prepareToneSample();
+    // Get-or-create the mixer channel + playlist lane + sampler unit that plays
+    // MIDI placed on `laneIndex`, routed to that timeline lane and on to master.
+    // Returns the unit id, or 0 on failure.
+    uint64_t ensureLaneInstrument(uint32_t laneIndex);
+
 private:
     AudioEngine& m_engine;
     TrackManager& m_trackManager;
@@ -303,6 +313,11 @@ private:
     
     // Mixer
     std::vector<std::string> m_channelNames;
+
+    // #556 render wiring — populated by the commit layer, reset per export.
+    std::string m_toneSamplePath;                 // synthetic sampler source (temp file)
+    std::map<uint32_t, uint64_t> m_laneUnits;     // laneIndex -> sampler UnitID
+    std::map<uint32_t, PlaylistLaneID> m_laneIds; // laneIndex -> playlist lane
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -697,6 +697,21 @@ public:
      */
     bool isPlaying() const { return m_isPlaying.load(std::memory_order_relaxed); }
     bool isPaused() const { return m_isPaused.load(std::memory_order_relaxed); }
+
+    /**
+     * @brief Schedule the committed timeline's MIDI clips into the pattern-playback
+     *        engine for an offline render, without touching live transport state.
+     *
+     * play() also schedules these instances, but as a side effect of starting the
+     * live transport (playing flag, position, transport command). An offline
+     * render (headless export) drives the engine's own transport instead, so it
+     * only needs the scheduling — this leaves isPlaying/isPaused/position
+     * untouched. Callers flush() the pattern engine before and after so the
+     * render's scheduled instances do not leak into the caller's session.
+     */
+    void scheduleTimelineForOfflineRender(double playStartPositionSeconds = 0.0) {
+        scheduleTimelinePatternInstances(playStartPositionSeconds);
+    }
     bool hasArmedTracks() const { return getArmedTrackCount() > 0; }
 
     /**

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -2,8 +2,15 @@
 
 #include "Headless/HeadlessMusicGenerator.h"
 #include "AestraLog.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/UnitManager.h"
+#include "Models/PatternSource.h"
+#include "Plugin/PluginManager.h"
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <numeric>
 
 namespace Aestra {
@@ -29,6 +36,9 @@ HeadlessMusicGenerator& HeadlessMusicGenerator::createProject(const std::string&
     m_playlistClips.clear();
     m_channelNames.clear();
     m_currentPatternName.clear();
+    m_toneSamplePath.clear();
+    m_laneUnits.clear();
+    m_laneIds.clear();
     
     // Reset track manager
     m_trackManager.getPlaylistModel().clear();
@@ -348,10 +358,60 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     
     // Commit patterns to track manager
     commitPatternsToManager();
-    
+
     // Commit playlist
     commitPlaylistToModel();
-    
+
+    const uint32_t effectiveRate = sampleRate > 0 ? sampleRate : m_sampleRate;
+
+    // --- Wire the export engine to render the committed timeline ---------------
+    // AudioExporter::render drives AudioEngine::processBlock — the same path the
+    // live engine uses — so the committed MIDI clips synthesize through their
+    // sampler units (live/export parity, AGENTS.md §20).
+    //
+    // setTrackManager stores a weak_ptr, so `borrowedTrackManager` must stay
+    // alive for the whole render. The guard restores the engine to an unwired
+    // state on every exit path (including failures) — the engine keeps a raw
+    // UnitManager*, an owned slot map and a graph copy, none of which may
+    // outlive this call. The render is fully synchronous: no callback or
+    // retained object can touch this wiring once exportTo returns.
+    struct EngineWiringGuard {
+        AudioEngine& engine;
+        ~EngineWiringGuard() {
+            engine.setGraph(AudioGraph{});
+            engine.setPatternPlaybackEngine(nullptr);
+            engine.setUnitManager(nullptr);
+            engine.setChannelSlotMap(nullptr);
+            engine.setTrackManager(nullptr);
+        }
+    };
+
+    // Non-owning shared_ptr: setTrackManager currently requires shared ownership,
+    // but the caller owns m_trackManager and guarantees it outlives this render.
+    // The no-op deleter means the borrowed TrackManager is never freed here.
+    std::shared_ptr<TrackManager> borrowedTrackManager(&m_trackManager, [](TrackManager*) {});
+    EngineWiringGuard wiringGuard{m_engine}; // destroyed before borrowedTrackManager
+
+    m_engine.setSampleRate(effectiveRate);
+    m_engine.setBufferConfig(512, 2);
+    m_engine.setBPM(static_cast<float>(m_tempo));
+    m_engine.setTrackManager(borrowedTrackManager);
+    m_engine.setUnitManager(&m_trackManager.getUnitManager());
+    m_engine.setPatternPlaybackEngine(&m_trackManager.getPatternPlaybackEngine());
+    m_trackManager.buildAndShareSlotMap();
+    if (auto slotMap = m_trackManager.getChannelSlotMapShared()) {
+        m_engine.setChannelSlotMap(slotMap);
+    }
+    m_engine.setGraph(AudioGraphBuilder::buildFromTrackManager(m_trackManager));
+    m_engine.initialize();
+
+    // MIDI clips reach their units through the pattern-playback engine
+    // (AudioEngine::processBlock pops scheduled notes into unit MIDI routes).
+    // play() flushes the engine and schedules the committed timeline clips from
+    // the current position (0 on this fresh manager), which is what makes the
+    // render emit the notes rather than silence.
+    m_trackManager.play();
+
     // Setup exporter
     AudioExporter exporter(m_engine, m_trackManager);
     
@@ -368,7 +428,14 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // Render
     Log::info("[HeadlessGenerator] Exporting to: " + outputPath);
     auto result = exporter.render(config);
-    
+
+    // The sampler decoded the tone into memory at load time, so the temp source
+    // file is no longer needed once the render is done.
+    if (!m_toneSamplePath.empty()) {
+        std::error_code rmEc;
+        std::filesystem::remove(m_toneSamplePath, rmEc);
+    }
+
     if (result.success) {
         Log::info("[HeadlessGenerator] Export complete: " + 
                   std::to_string(result.durationSeconds) + "s, peak: " +
@@ -446,33 +513,159 @@ HeadlessMusicGenerator::PatternData* HeadlessMusicGenerator::findPattern(const s
     return nullptr;
 }
 
+// Steps map to sixteenth notes — 16 steps per 4/4 bar — matching the set_steps
+// Muse command and the header's fluent-API examples.
+static constexpr double kStepBeats = 0.25;
+
+bool HeadlessMusicGenerator::prepareToneSample() {
+    // A short synthetic sine the built-in sampler loads as its source and
+    // pitch-shifts per MIDI note. Written to a unique temp file because the
+    // sampler loads by path (UnitManager::setUnitAudioClip -> loadSample).
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path dir = fs::temp_directory_path(ec);
+    if (ec) {
+        Log::error("[HeadlessGenerator] No temp directory for tone sample: " + ec.message());
+        return false;
+    }
+    const fs::path path =
+        dir / ("aestra_headless_tone_" + std::to_string(reinterpret_cast<uintptr_t>(this)) + ".wav");
+
+    const uint32_t rate = m_sampleRate > 0 ? m_sampleRate : 48000u;
+    const uint32_t frames = rate / 2; // 0.5 s
+    const double freq = 440.0;
+    const double twoPi = 6.283185307179586;
+
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        Log::error("[HeadlessGenerator] Cannot write tone sample: " + path.string());
+        return false;
+    }
+    auto w16 = [&](uint16_t v) { out.put(static_cast<char>(v & 0xff)); out.put(static_cast<char>((v >> 8) & 0xff)); };
+    auto w32 = [&](uint32_t v) {
+        out.put(static_cast<char>(v & 0xff));
+        out.put(static_cast<char>((v >> 8) & 0xff));
+        out.put(static_cast<char>((v >> 16) & 0xff));
+        out.put(static_cast<char>((v >> 24) & 0xff));
+    };
+    const uint32_t dataBytes = frames * 2; // mono, 16-bit
+    out.write("RIFF", 4); w32(36 + dataBytes); out.write("WAVE", 4);
+    out.write("fmt ", 4); w32(16); w16(1); w16(1); w32(rate); w32(rate * 2); w16(2); w16(16);
+    out.write("data", 4); w32(dataBytes);
+    for (uint32_t i = 0; i < frames; ++i) {
+        // Short fades at both ends so the looped/one-shot sample has no click.
+        double env = 1.0;
+        const uint32_t fade = rate / 100; // 10 ms
+        if (i < fade) env = static_cast<double>(i) / fade;
+        else if (i >= frames - fade) env = static_cast<double>(frames - i) / fade;
+        const double s = std::sin(twoPi * freq * static_cast<double>(i) / rate) * 0.8 * env;
+        w16(static_cast<uint16_t>(static_cast<int16_t>(std::clamp(s, -1.0, 1.0) * 32767.0)));
+    }
+    if (!out.good()) {
+        Log::error("[HeadlessGenerator] Failed writing tone sample: " + path.string());
+        return false;
+    }
+    m_toneSamplePath = path.string();
+    return true;
+}
+
+uint64_t HeadlessMusicGenerator::ensureLaneInstrument(uint32_t laneIndex) {
+    if (auto it = m_laneUnits.find(laneIndex); it != m_laneUnits.end()) {
+        return it->second;
+    }
+
+    auto& um = m_trackManager.getUnitManager();
+    const std::string label = "Lane " + std::to_string(laneIndex + 1);
+
+    // Mixer channel that carries this lane's instrument to the master bus.
+    const size_t channelIndex = m_trackManager.getChannelCount();
+    m_trackManager.addChannel(label);
+
+    // Playlist lane the clips are placed on.
+    PlaylistLaneID laneId = m_trackManager.getPlaylistModel().createLane(label);
+    m_laneIds[laneIndex] = laneId;
+
+    // Built-in sampler — the only always-available (license-free) instrument.
+    auto& pluginManager = PluginManager::getInstance();
+    pluginManager.initialize();
+    auto sampler = pluginManager.createInstanceById("com.Aestrastudios.sampler");
+    if (!sampler) {
+        Log::error("[HeadlessGenerator] Failed to create built-in sampler instrument");
+        return 0;
+    }
+    sampler->initialize(m_sampleRate > 0 ? m_sampleRate : 48000u, 512);
+    sampler->activate();
+
+    const UnitID unit = um.createUnit("Instrument " + std::to_string(laneIndex + 1), UnitType::Sampler);
+    um.attachPlugin(unit, "com.Aestrastudios.sampler", sampler);
+    um.setUnitEnabled(unit, true);
+    if (!m_toneSamplePath.empty()) {
+        um.setUnitAudioClip(unit, m_toneSamplePath); // loads the tone into the sampler
+    }
+    um.setUnitMixerChannel(unit, static_cast<int>(channelIndex));
+    um.assignUnitToTimelineLane(unit, static_cast<int>(laneIndex));
+
+    m_laneUnits[laneIndex] = unit;
+    return unit;
+}
+
 void HeadlessMusicGenerator::commitPatternsToManager() {
-    auto& patternManager = m_trackManager.getPatternManager();
-    
-    // TODO: Convert PatternData to PatternSource and add to manager
-    // This is a simplified version - real implementation would create actual PatternSource objects
-    Log::info("[HeadlessGenerator] Committed " + std::to_string(m_patterns.size()) + " patterns");
+    // The MIDI PatternSources are created in commitPlaylistToModel(): each note
+    // routes to the sampler unit backing the lane its clip is placed on, so the
+    // routed pattern can only be built once the placement (and thus the lane
+    // instrument) is known. Here we just prepare the shared sampler source.
+    m_laneUnits.clear();
+    m_laneIds.clear();
+    if (!prepareToneSample()) {
+        Log::warning("[HeadlessGenerator] Tone sample unavailable — render will be silent");
+    }
+    Log::info("[HeadlessGenerator] Prepared " + std::to_string(m_patterns.size()) +
+              " patterns for placement");
 }
 
 void HeadlessMusicGenerator::commitPlaylistToModel() {
+    auto& patternManager = m_trackManager.getPatternManager();
     auto& playlist = m_trackManager.getPlaylistModel();
-    
-    // Ensure we have enough lanes
-    uint32_t maxLane = 0;
+
+    size_t committed = 0;
     for (const auto& clip : m_playlistClips) {
-        maxLane = std::max(maxLane, clip.laneIndex);
+        auto patternIt = m_patterns.find(clip.patternName);
+        if (patternIt == m_patterns.end()) {
+            continue; // validate() already rejected unknown patterns
+        }
+        const PatternData& data = patternIt->second;
+
+        const uint64_t unitId = ensureLaneInstrument(clip.laneIndex);
+        if (unitId == 0) {
+            continue;
+        }
+
+        // Convert the step-grid notes to beat-domain MidiNotes routed to the
+        // lane's sampler unit.
+        MidiPayload payload;
+        payload.notes.reserve(data.notes.size());
+        for (const auto& n : data.notes) {
+            MidiNote mn;
+            mn.pitch = n.pitch;
+            mn.startBeat = static_cast<double>(n.step) * kStepBeats;
+            mn.durationBeats = n.duration * kStepBeats;
+            mn.velocity = std::clamp(static_cast<float>(n.velocity) / 127.0f, 0.0f, 1.0f);
+            mn.unitId = unitId;
+            payload.notes.push_back(mn);
+        }
+
+        const double lengthBeats = static_cast<double>(data.length) * kStepBeats;
+        const PatternID patternId = patternManager.createMidiPattern(clip.patternName, lengthBeats, payload);
+
+        auto laneIt = m_laneIds.find(clip.laneIndex);
+        if (laneIt == m_laneIds.end()) {
+            continue;
+        }
+        playlist.addClipFromPattern(laneIt->second, patternId, clip.startBeat, clip.durationBeats);
+        ++committed;
     }
-    
-    // Create lanes
-    for (uint32_t i = 0; i <= maxLane; ++i) {
-        playlist.createLane("Lane " + std::to_string(i + 1));
-    }
-    
-    // Add clips to playlist
-    // TODO: Convert to actual ClipInstance and add to playlist
-    // This requires PatternIDs from commitPatternsToManager
-    
-    Log::info("[HeadlessGenerator] Committed " + std::to_string(m_playlistClips.size()) + " clips to playlist");
+
+    Log::info("[HeadlessGenerator] Committed " + std::to_string(committed) + " clips to playlist");
 }
 
 } // namespace Audio

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -36,6 +36,7 @@ HeadlessMusicGenerator& HeadlessMusicGenerator::createProject(const std::string&
     m_playlistClips.clear();
     m_channelNames.clear();
     m_currentPatternName.clear();
+    m_committed = false;
     m_toneSamplePath.clear();
     m_laneUnits.clear();
     m_laneIds.clear();
@@ -355,14 +356,30 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
         Log::error("[HeadlessGenerator] Validation failed: " + error);
         return false;
     }
-    
+
+    // Reconcile the render sample rate before committing so the sampler
+    // instruments are initialized at the same rate the engine renders at (the
+    // exportTo sampleRate argument overrides the configured project rate).
+    const uint32_t effectiveRate = sampleRate > 0 ? sampleRate : m_sampleRate;
+    m_sampleRate = effectiveRate;
+
     // Commit patterns to track manager
     commitPatternsToManager();
 
     // Commit playlist
     commitPlaylistToModel();
 
-    const uint32_t effectiveRate = sampleRate > 0 ? sampleRate : m_sampleRate;
+    // Remove the temp tone sample on every exit path, including an exception
+    // out of render() (the sampler decoded it into memory at load time).
+    struct ToneSampleCleanup {
+        const std::string& path;
+        ~ToneSampleCleanup() {
+            if (!path.empty()) {
+                std::error_code ec;
+                std::filesystem::remove(path, ec);
+            }
+        }
+    } toneCleanup{m_toneSamplePath};
 
     // --- Wire the export engine to render the committed timeline ---------------
     // AudioExporter::render drives AudioEngine::processBlock — the same path the
@@ -439,14 +456,7 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     
     // Render
     Log::info("[HeadlessGenerator] Exporting to: " + outputPath);
-    auto result = exporter.render(config);
-
-    // The sampler decoded the tone into memory at load time, so the temp source
-    // file is no longer needed once the render is done.
-    if (!m_toneSamplePath.empty()) {
-        std::error_code rmEc;
-        std::filesystem::remove(m_toneSamplePath, rmEc);
-    }
+    auto result = exporter.render(config); // toneCleanup removes the temp sample on scope exit
 
     if (result.success) {
         Log::info("[HeadlessGenerator] Export complete: " + 
@@ -622,12 +632,16 @@ uint64_t HeadlessMusicGenerator::ensureLaneInstrument(uint32_t laneIndex) {
 }
 
 void HeadlessMusicGenerator::commitPatternsToManager() {
-    // The MIDI PatternSources are created in commitPlaylistToModel(): each note
-    // routes to the sampler unit backing the lane its clip is placed on, so the
-    // routed pattern can only be built once the placement (and thus the lane
-    // instrument) is known. Here we just prepare the shared sampler source.
-    m_laneUnits.clear();
-    m_laneIds.clear();
+    // Commit once per project: re-committing would append duplicate lanes,
+    // units and clips to the TrackManager on a second exportTo() call. State is
+    // reset by createProject(). The MIDI PatternSources themselves are created
+    // in commitPlaylistToModel(): each note routes to the sampler unit backing
+    // the lane its clip is placed on, so the routed pattern can only be built
+    // once the placement (and thus the lane instrument) is known. Here we just
+    // prepare the shared sampler source.
+    if (m_committed) {
+        return;
+    }
     if (!prepareToneSample()) {
         Log::warning("[HeadlessGenerator] Tone sample unavailable — render will be silent");
     }
@@ -636,6 +650,9 @@ void HeadlessMusicGenerator::commitPatternsToManager() {
 }
 
 void HeadlessMusicGenerator::commitPlaylistToModel() {
+    if (m_committed) {
+        return;
+    }
     auto& patternManager = m_trackManager.getPatternManager();
     auto& playlist = m_trackManager.getPlaylistModel();
 
@@ -677,6 +694,7 @@ void HeadlessMusicGenerator::commitPlaylistToModel() {
         ++committed;
     }
 
+    m_committed = true;
     Log::info("[HeadlessGenerator] Committed " + std::to_string(committed) + " clips to playlist");
 }
 

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -375,14 +375,24 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // UnitManager*, an owned slot map and a graph copy, none of which may
     // outlive this call. The render is fully synchronous: no callback or
     // retained object can touch this wiring once exportTo returns.
-    struct EngineWiringGuard {
+    // Restores everything this render mutates on every exit path, so a
+    // synchronous export leaves the caller's engine and session unchanged:
+    //  - engine wiring (weak TrackManager ref, raw UnitManager*, owned slot map,
+    //    graph copy, pattern-engine pointer) is cleared;
+    //  - the pattern-playback engine is flushed so the timeline instances this
+    //    render scheduled do not leak into the caller's TrackManager.
+    // The transport flags/position are never touched (see
+    // scheduleTimelineForOfflineRender below), so there is nothing else to undo.
+    struct RenderStateGuard {
         AudioEngine& engine;
-        ~EngineWiringGuard() {
+        TrackManager& trackManager;
+        ~RenderStateGuard() {
             engine.setGraph(AudioGraph{});
             engine.setPatternPlaybackEngine(nullptr);
             engine.setUnitManager(nullptr);
             engine.setChannelSlotMap(nullptr);
             engine.setTrackManager(nullptr);
+            trackManager.getPatternPlaybackEngine().flush();
         }
     };
 
@@ -390,7 +400,7 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // but the caller owns m_trackManager and guarantees it outlives this render.
     // The no-op deleter means the borrowed TrackManager is never freed here.
     std::shared_ptr<TrackManager> borrowedTrackManager(&m_trackManager, [](TrackManager*) {});
-    EngineWiringGuard wiringGuard{m_engine}; // destroyed before borrowedTrackManager
+    RenderStateGuard renderGuard{m_engine, m_trackManager}; // destroyed before borrowedTrackManager
 
     m_engine.setSampleRate(effectiveRate);
     m_engine.setBufferConfig(512, 2);
@@ -407,10 +417,12 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
 
     // MIDI clips reach their units through the pattern-playback engine
     // (AudioEngine::processBlock pops scheduled notes into unit MIDI routes).
-    // play() flushes the engine and schedules the committed timeline clips from
-    // the current position (0 on this fresh manager), which is what makes the
-    // render emit the notes rather than silence.
-    m_trackManager.play();
+    // Schedule the committed timeline into it WITHOUT starting live transport —
+    // the exporter drives the engine's own transport, so we must not mutate the
+    // caller's playing flag / position. flush() first clears any prior contents;
+    // the render guard flushes again on exit so these instances don't leak.
+    m_trackManager.getPatternPlaybackEngine().flush();
+    m_trackManager.scheduleTimelineForOfflineRender(0.0);
 
     // Setup exporter
     AudioExporter exporter(m_engine, m_trackManager);

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -64,6 +64,26 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/EngineOutputStageCharacterizationTest.cpp
     )
 endif()
 
+# Headless export session invariance (exportTo must not mutate live transport)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HeadlessExportSessionInvarianceTest.cpp")
+    add_executable(HeadlessExportSessionInvarianceTest
+        HeadlessExportSessionInvarianceTest.cpp
+    )
+    target_link_libraries(HeadlessExportSessionInvarianceTest PRIVATE AestraAudio)
+    target_include_directories(HeadlessExportSessionInvarianceTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME HeadlessExportSessionInvarianceTest
+        COMMAND HeadlessExportSessionInvarianceTest
+    )
+    set_tests_properties(HeadlessExportSessionInvarianceTest PROPERTIES
+        LABELS "headless;export;engine"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 # Rumble DSP Quality Contract
 if(AESTRA_ENABLE_TEST_LICENSES AND TARGET AestraAudioCore AND TARGET AestraPremiumPlugins AND
    EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/RumbleQualityTest.cpp")

--- a/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
+++ b/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
@@ -1,0 +1,124 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// HeadlessExportSessionInvarianceTest
+//
+// Encodes the invariant established in #556: HeadlessMusicGenerator::exportTo()
+// is a synchronous offline render that must not mutate the caller's live
+// session. It schedules the timeline into the pattern-playback engine via
+// TrackManager::scheduleTimelineForOfflineRender() — NOT play() — so the
+// transport flags and position are left untouched, and its RenderStateGuard
+// flushes the pattern engine on every exit path so the render's scheduled
+// instances do not leak.
+//
+// This test snapshots (isPlaying, isPaused, position) before exportTo() and
+// asserts they are unchanged afterward, on BOTH the success path and a forced
+// failure path (empty output path — the exporter rejects it after the engine
+// wiring is already in place, exercising the guard's cleanup on failure).
+
+#include "Core/AudioEngine.h"
+#include "Headless/HeadlessMusicGenerator.h"
+#include "Models/TrackManager.h"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+void require(bool cond, const char* msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+struct TransportSnapshot {
+    bool playing;
+    bool paused;
+    double position;
+};
+
+TransportSnapshot snapshot(const TrackManager& tm) {
+    return {tm.isPlaying(), tm.isPaused(), tm.getPosition()};
+}
+
+void requireUnchanged(const TrackManager& tm, const TransportSnapshot& before, const char* path) {
+    const TransportSnapshot after = snapshot(tm);
+    require(after.playing == before.playing,
+            (std::string("export must not change isPlaying (") + path + ")").c_str());
+    require(after.paused == before.paused,
+            (std::string("export must not change isPaused (") + path + ")").c_str());
+    require(std::abs(after.position - before.position) < 1e-9,
+            (std::string("export must not change transport position (") + path + ")").c_str());
+}
+
+// Builds a small but genuinely audible project on the given engine/manager.
+void buildMinimalProject(HeadlessMusicGenerator& gen) {
+    gen.createProject("invariance")
+        .setTempo(120.0)
+        .setSampleRate(48000)
+        .createPattern("Kick", 16)
+        .addNote(0, 36, 100, 1.0)
+        .addNote(8, 36, 100, 1.0)
+        .addClipToPlaylist("Kick", 0.0, 4.0);
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    const fs::path outPath = fs::temp_directory_path() / "aestra_export_invariance.wav";
+    fs::remove(outPath);
+
+    // --- Success path: a real render leaves transport state untouched ---------
+    {
+        AudioEngine engine;
+        TrackManager trackManager;
+
+        HeadlessMusicGenerator gen(engine, trackManager);
+        buildMinimalProject(gen);
+
+        // Put the session in a known, non-default transport state. isPlaying
+        // starts false; if exportTo() ever reverts to play() this flips to true.
+        trackManager.setPosition(3.5);
+        const TransportSnapshot before = snapshot(trackManager);
+        require(!before.playing, "precondition: session not playing");
+        require(std::abs(before.position - 3.5) < 1e-9, "precondition: position is 3.5");
+
+        const bool ok = gen.exportTo(outPath.string(), 48000, AudioExporter::BitDepth::PCM_16);
+        require(ok, "export of a valid project should succeed");
+        require(fs::exists(outPath) && fs::file_size(outPath) > 1024,
+                "successful export should write a non-trivial WAV");
+
+        requireUnchanged(trackManager, before, "success");
+        std::cout << "[INFO] success path: transport state preserved.\n";
+    }
+    fs::remove(outPath);
+
+    // --- Forced failure path: the guard restores state even when render fails --
+    {
+        AudioEngine engine;
+        TrackManager trackManager;
+
+        HeadlessMusicGenerator gen(engine, trackManager);
+        buildMinimalProject(gen);
+
+        trackManager.setPosition(2.0);
+        const TransportSnapshot before = snapshot(trackManager);
+
+        // Empty output path: validate() passes (it checks project/patterns/clips),
+        // so the commit layer runs and the engine is fully wired before the
+        // exporter rejects the path. That exercises RenderStateGuard on failure.
+        const bool ok = gen.exportTo(std::string{}, 48000, AudioExporter::BitDepth::PCM_16);
+        require(!ok, "export with an empty output path must fail");
+
+        requireUnchanged(trackManager, before, "forced-failure");
+        std::cout << "[INFO] forced-failure path: transport state preserved.\n";
+    }
+
+    std::cout << "[PASS] HeadlessExportSessionInvarianceTest\n";
+    return 0;
+}

--- a/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
+++ b/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
@@ -94,7 +94,17 @@ int main() {
                 "successful export should write a non-trivial WAV");
 
         requireUnchanged(trackManager, before, "success");
-        std::cout << "[INFO] success path: transport state preserved.\n";
+
+        // Re-export the same project: the commit layer is idempotent, so it must
+        // not append duplicate channels/units/clips to the TrackManager.
+        const size_t channelsAfterFirst = trackManager.getChannelCount();
+        fs::remove(outPath);
+        const bool ok2 = gen.exportTo(outPath.string(), 48000, AudioExporter::BitDepth::PCM_16);
+        require(ok2, "re-export of the same project should also succeed");
+        require(trackManager.getChannelCount() == channelsAfterFirst,
+                "re-export must not duplicate committed channels (idempotent commit)");
+        requireUnchanged(trackManager, before, "re-export");
+        std::cout << "[INFO] success path: transport state preserved, commit idempotent.\n";
     }
     fs::remove(outPath);
 

--- a/Tests/Headless/run_headless_export_e2e.cmake
+++ b/Tests/Headless/run_headless_export_e2e.cmake
@@ -1,17 +1,18 @@
 # End-to-end driver for AestraHeadlessExport.
 #
 # Runs the real export binary through the full path — argument parsing, template
-# project generation, and the export attempt — and enforces the current contract:
+# project generation, the generator commit layer, and the render — and enforces
+# the contract that headless export actually produces audible audio (#556):
 #
-#   exit 0  full export success -> the output WAV must exist and contain audio
-#   exit 1  graceful, diagnosed failure -> allowed FOR NOW: the
-#           HeadlessMusicGenerator commit layer is stubbed (logs "Committed N"
-#           but populates nothing), so the exporter correctly reports an empty
-#           timeline. Tracked in issue #556; when that feature lands, tighten
-#           this driver to require exit 0 + WAV validation.
+#   exit 0  -> the output WAV must exist, be substantially larger than a bare
+#              header, and the render's reported peak must be above the silence
+#              floor (the stubbed commit layer used to render an empty timeline
+#              at the -96 dB noise floor; a working render lands far louder).
+#   exit 1  -> failure. No longer tolerated: the generator commit layer is
+#              implemented, so an empty/silent timeline is a regression.
 #   anything else (exit 2 = arg error on valid args, or a signal such as
-#           "Subprocess aborted") -> regression. On develop this run died with
-#           SIGABRT from AudioEngine::getInstance() before any engine existed.
+#              "Subprocess aborted") -> regression. On develop the pre-#557 path
+#              died with SIGABRT from AudioEngine::getInstance().
 #
 # Required -D args:
 #   EXPORT_BIN  path to the AestraHeadlessExport executable
@@ -40,37 +41,48 @@ message(STATUS "AestraHeadlessExport exit: ${exit_code}")
 message(STATUS "AestraHeadlessExport stdout:\n${stdout_log}")
 message(STATUS "AestraHeadlessExport stderr:\n${stderr_log}")
 
+set(combined_log "${stdout_log}${stderr_log}")
+
 # Singleton regression check first, independent of exit code: the abort path
 # dies on a signal (exit_code becomes e.g. "Subprocess aborted", not "1"), so
 # this must run before the exit-code dispatch to produce the specific diagnosis.
-if(stdout_log MATCHES "getInstance\\(\\) called before engine was created" OR
-   stderr_log MATCHES "getInstance\\(\\) called before engine was created")
+if(combined_log MATCHES "getInstance\\(\\) called before engine was created")
     message(FATAL_ERROR "Export path still depends on the AudioEngine singleton "
                         "(getInstance() called before any engine was constructed).")
 endif()
 
-if(exit_code STREQUAL "0")
-    # Full success claimed: hold the binary to it.
-    if(NOT EXISTS "${OUT_FILE}")
-        message(FATAL_ERROR "Export reported success but produced no output at '${OUT_FILE}'.")
-    endif()
-    file(SIZE "${OUT_FILE}" out_size)
-    # A bare WAV header is 44 bytes; require substantially more so we know real
-    # audio frames were written, not just an empty container.
-    if(out_size LESS 1024)
-        message(FATAL_ERROR "Export output '${OUT_FILE}' is ${out_size} bytes — too small to contain audio.")
-    endif()
-    message(STATUS "Export E2E OK: ${OUT_FILE} (${out_size} bytes)")
-    file(REMOVE "${OUT_FILE}")
-elseif(exit_code STREQUAL "1")
-    # Graceful diagnosed failure. Acceptable only while the generator commit
-    # layer is unimplemented — but it must be a *diagnosed* failure, never a
-    # crash, and never a silent success with no file. (The singleton-abort
-    # message is already checked above, before the exit-code dispatch.)
-    message(STATUS "Export failed gracefully (generator commit layer not yet implemented) — no crash.")
-else()
+if(NOT exit_code STREQUAL "0")
     message(FATAL_ERROR
-        "AestraHeadlessExport terminated abnormally (result: '${exit_code}'). "
-        "A signal here (e.g. 'Subprocess aborted') means the export path crashed "
-        "instead of failing diagnostically.")
+        "AestraHeadlessExport did not succeed (result: '${exit_code}'). "
+        "Exit 1 means the generator commit layer produced an empty/failed render; "
+        "a signal means the export path crashed. Headless export must exit 0 with "
+        "audible output (#556).")
 endif()
+
+# --- exit 0: hold the binary to a real, audible render ----------------------
+if(NOT EXISTS "${OUT_FILE}")
+    message(FATAL_ERROR "Export reported success but produced no output at '${OUT_FILE}'.")
+endif()
+file(SIZE "${OUT_FILE}" out_size)
+# A bare WAV header is 44 bytes; require substantially more so we know real
+# audio frames were written, not just an empty container.
+if(out_size LESS 1024)
+    message(FATAL_ERROR "Export output '${OUT_FILE}' is ${out_size} bytes — too small to contain audio.")
+endif()
+
+# Non-silence: parse the render's reported peak (dBFS) and require it above the
+# silence floor. The stubbed commit layer rendered an empty timeline at the
+# -96 dB noise floor; a real render is far louder (the Minimal template lands
+# near -22 dBFS). Capture the integer dB part for a robust integer compare.
+if(NOT combined_log MATCHES "peak: (-?[0-9]+)")
+    message(FATAL_ERROR "Export produced no peak-level report to validate against silence.")
+endif()
+set(peak_db "${CMAKE_MATCH_1}")
+if(NOT peak_db GREATER -80)
+    message(FATAL_ERROR
+        "Export output peaked at ${peak_db} dBFS — at or below the silence floor. "
+        "The render produced no audible signal (empty/unrouted timeline).")
+endif()
+
+message(STATUS "Export E2E OK: ${OUT_FILE} (${out_size} bytes, peak ${peak_db} dBFS)")
+file(REMOVE "${OUT_FILE}")


### PR DESCRIPTION
## Summary
Closes #556. `HeadlessMusicGenerator`'s commit layer was stubbed (`commitPatternsToManager`/`commitPlaylistToModel` logged `"Committed N"` but wrote nothing), so `AudioExporter::render(FullSong)` always reported an empty timeline and **the export tool never produced audio** — even after the `getInstance()` abort fix (#557).

This implements the commit layer over the **shared live/export rendering path** (Strategy A): the committed MIDI clips synthesize through sampler units via the same `AudioEngine::processBlock` path the live engine uses. This is a *shared render path*, not a claim of sample-identical live-vs-export PCM — the E2E proves the export path renders audibly; it doesn't compare against a live capture bit-for-bit.

## Change
- **`commitPlaylistToModel()`** — converts each placed pattern's step-grid `Note`s to beat-domain `MidiNote`s (`step*0.25` beats, `velocity/127`) routed to the sampler unit backing the clip's lane, creates a real MIDI `PatternSource`, and adds a real `ClipInstance` via `addClipFromPattern`.
- **`ensureLaneInstrument()`** — per lane, creates a mixer channel + playlist lane + a unit running `com.Aestrastudios.sampler` (the only license-free built-in instrument), routed to the channel and assigned to the timeline lane.
- **`prepareToneSample()`** — writes a short synthetic sine WAV the sampler loads as its source and pitch-shifts per note; removed after the render decodes it into memory.
- **`exportTo()`** — wires the export engine and schedules the committed timeline into the pattern-playback engine. MIDI reaches units **only** through that engine (`processBlock` pops scheduled notes into unit MIDI routes); without it the timeline rendered at the −96 dB noise floor. This is the playlist-clip ↔ pattern-instance reconciliation the issue flagged.

## Causal chain (−96 → −22 dBFS)
1. Commit layer populates the timeline → exporter stops reporting "empty timeline" (was silent because there was nothing to render).
2. Scheduling the timeline into the pattern-playback engine → MIDI notes actually reach the sampler units → **−22 dBFS audible output**.

## State handling (review-driven)
- **Engine wiring lifetime:** `setTrackManager` stores a **`weak_ptr`**, so a **non-owning borrowed `shared_ptr`** (no-op deleter) is held for the whole *synchronous* render. `RenderStateGuard` restores the engine to an unwired state on **every exit path** (clears graph, pattern engine, unit manager, slot map, track manager).
- **No live-transport mutation:** the render drives the *engine's* transport, so it schedules via a new `TrackManager::scheduleTimelineForOfflineRender()` instead of `play()` — the caller's `isPlaying`/`isPaused`/`position` are never touched. The guard also **flushes the pattern-playback engine** on exit so the render's scheduled instances don't leak into the caller's `TrackManager`. Verified the output is byte-identical to the earlier `play()`-based version, confirming the transport mutation was never load-bearing.

## Test tightening
`Tests/Headless/run_headless_export_e2e.cmake` now requires **exit 0 + WAV size + a non-silence check** (parses the render's reported peak: the stub rendered −96 dB, a real render lands near −22 dB). Drops the exit-1 tolerance the stub required, per the issue's acceptance.

## Testing (build-linux, `-j2`)
| Check | Result |
|-------|--------|
| `AestraHeadlessExportEndToEnd` | **PASS** — exit 0, 1.09 MB WAV, peak −22 dBFS |
| Minimal / Techno / House templates | all audible: −22 / −14 / −19 dBFS |
| Signal inspection (Minimal) | 41% non-zero samples, note-structured envelope (not DC/clicks) |
| Transport state after export | untouched (no `play()`); pattern engine flushed |
| Temp tone file | cleaned up after render |

## Acceptance criteria (#556)
- ✅ `AestraHeadlessExport --template Minimal --duration 1 --output x.wav` exits 0 and writes a valid, non-silent WAV.
- ✅ E2E tightened to require exit 0 + WAV validation (+ non-silence).
- ✅ Shared live/export render path (export renders through the live `processBlock` path).

## Change type
- DSP: no (wires existing synthesis) · UI: no · Serialization/project format: no · Build/CI config: no · Public docs: no

## Risk / rollback
Contained to `HeadlessMusicGenerator`, one new `TrackManager` offline-scheduling method, and the E2E driver; no engine/exporter code changed. Driver ownership untouched. Rollback = revert (export returns to its prior stubbed/silent state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Implemented headless full-song MIDI rendering by converting pattern step grids into timeline clips with beat-based timing, velocity, and lane routing.
- Added per-lane sampler, mixer, playlist, and synthetic tone-sample wiring so exports produce audible audio.
- Added offline timeline scheduling that preserves live transport state.
- Added render-state cleanup and guaranteed flushing of scheduled pattern instances and temporary tone files.
- Strengthened the headless E2E test to require successful execution, a valid WAV, and non-silent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->