### PR TITLE
fix(audio): sanitize NaN/Inf at mix boundaries before they poison the mix (#207)

### DIFF
--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -118,6 +118,15 @@ inline double clampD(double v, double lo, double hi) {
     return (v < lo) ? lo : (v > hi) ? hi : v;
 }
 
+// Replace NaN/Inf with silence at a mix boundary. A misbehaving plugin or a
+// corrupted clip source can emit non-finite samples; catching them where they
+// enter the mix keeps the poison out of per-track effect state, meters, and
+// sends, rather than relying only on the final output-stage guard after the
+// damage has already accumulated. Branch is bounded and RT-safe.
+inline double sanitizeMix(double v) noexcept {
+    return std::isfinite(v) ? v : 0.0;
+}
+
 inline double dbToLinearD(double db) {
     // UI uses -90 dB as "silence"
     if (db <= -90.0)
@@ -2107,8 +2116,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             unit.plugin->process(nullptr, outputs, 0, 2, numFrames, midiBuf, nullptr);
 
             for (uint32_t i = 0; i < numFrames; ++i) {
-                masterBuf[i * 2] += static_cast<double>(outputs[0][i]);
-                masterBuf[i * 2 + 1] += static_cast<double>(outputs[1][i]);
+                masterBuf[i * 2] += sanitizeMix(static_cast<double>(outputs[0][i]));
+                masterBuf[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i]));
             }
         }
     }
@@ -2198,13 +2207,15 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                         }
                     }
 
+                    // Sanitize clip source reads: a corrupted audio file can
+                    // contain NaN/Inf that would otherwise poison the mix.
                     double sL, sR;
                     if (channels == 1) {
-                        sL = static_cast<double>(src[i]);
+                        sL = sanitizeMix(static_cast<double>(src[i]));
                         sR = sL;
                     } else {
-                        sL = static_cast<double>(src[i * 2]);
-                        sR = static_cast<double>(src[i * 2 + 1]);
+                        sL = sanitizeMix(static_cast<double>(src[i * 2]));
+                        sR = sanitizeMix(static_cast<double>(src[i * 2 + 1]));
                     }
 
                     dst[i * 2] += sL * clipGain * fade;
@@ -2455,8 +2466,8 @@ void AudioEngine::renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffe
                 const double unitGain = static_cast<double>(unit.gain);
                 double* dDst = buffer.data();
                 for (uint32_t k = 0; k < numFrames; ++k) {
-                    dDst[k * 2] += static_cast<double>(outputs[0][k]) * unitGain;
-                    dDst[k * 2 + 1] += static_cast<double>(outputs[1][k]) * unitGain;
+                    dDst[k * 2] += sanitizeMix(static_cast<double>(outputs[0][k])) * unitGain;
+                    dDst[k * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][k])) * unitGain;
                 }
             }
         }
@@ -3336,8 +3347,8 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
             (targetBuffer ? targetBuffer : m_masterBufferD.data()) + static_cast<size_t>(bufferOffset) * 2;
         const double unitGain = static_cast<double>(unit.gain);
         for (uint32_t i = 0; i < numFrames; ++i) {
-            masterD[i * 2 + 0] += static_cast<double>(outputs[0][i]) * unitGain; // Left
-            masterD[i * 2 + 1] += static_cast<double>(outputs[1][i]) * unitGain; // Right
+            masterD[i * 2 + 0] += sanitizeMix(static_cast<double>(outputs[0][i])) * unitGain; // Left
+            masterD[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i])) * unitGain; // Right
         }
 
         bufIdx++;

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -428,8 +428,11 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
             v.position += v.playbackRate;
         }
 
-        outputs[0][i] = L;
-        outputs[1][i] = R;
+        // Guard against non-finite output: sinc interpolation at extreme
+        // playback rates (or a corrupted sample) can produce NaN/Inf, which
+        // must not leave the plugin and poison the engine mix.
+        outputs[0][i] = std::isfinite(L) ? L : 0.0f;
+        outputs[1][i] = std::isfinite(R) ? R : 0.0f;
     }
 }
 

--- a/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
+++ b/Tests/AestraAudio/PlaybackPathSignalIntegrityTest.cpp
@@ -1,6 +1,9 @@
 #include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Core/ChannelSlotMap.h"
 #include "Core/MasterSafetyLimiter.h"
 #include "DSP/PanLaw.h"
+#include "Models/TrackManager.h"
 #include "Playback/AuditionEngine.h"
 #include "Playback/PreviewEngine.h"
 
@@ -12,6 +15,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -273,6 +277,92 @@ void mainAudioEngineSafetyLimiterChangesHotMasterOutput() {
               << ", limitedPeak=" << limitedPeak << "\n";
 }
 
+// #207: a corrupted clip source containing NaN/Inf must not poison the mix.
+// The engine sanitizes clip sample reads at the mix boundary, so the non-finite
+// samples are neutralized BEFORE they accumulate into the master buffer or reach
+// any downstream per-track effect state. This is verified two ways:
+//   1. master output stays finite (end-to-end smoke), and
+//   2. getNaNCount() stays 0 — the final output-stage NaN sanitizer (which is a
+//      separate, last-resort guard) never fires, proving the poison was caught
+//      at the boundary rather than after it had spread through the mix. Without
+//      the boundary guard this counter is non-zero.
+void nanClipSourceProducesFiniteOutput() {
+    using namespace Aestra::Audio;
+
+    constexpr uint32_t kRenderBlock = 512;
+    constexpr double kBpm = 120.0;
+    constexpr double kDurationSeconds = 1.0;
+    constexpr double kDurationBeats = 2.0; // 1s at 120 BPM
+    const uint32_t numFrames = static_cast<uint32_t>(kSampleRate * kDurationSeconds);
+
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
+    trackManager->addChannel("NaN Track");
+
+    // Source buffer where every sample is non-finite (NaN and +/-Inf).
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = kSampleRate;
+    buffer->numChannels = kChannels;
+    buffer->numFrames = numFrames;
+    buffer->interleavedData.resize(static_cast<size_t>(numFrames) * kChannels);
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < buffer->interleavedData.size(); ++i) {
+        buffer->interleavedData[i] = (i % 3 == 0) ? nan : (i % 3 == 1 ? inf : -inf);
+    }
+
+    const ClipSourceID sourceId =
+        trackManager->getSourceManager().createRecordedSource("nan_source.wav", "nan_source", buffer);
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = kDurationSeconds;
+    payload.slices.push_back({0.0, kDurationSeconds, 0.0, static_cast<double>(numFrames)});
+
+    const PlaylistLaneID laneId = trackManager->getPlaylistModel().createLane("nan_lane");
+    const PatternID patternId =
+        trackManager->getPatternManager().createAudioPattern("nan_source", kDurationBeats, payload);
+    trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationBeats);
+
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kRenderBlock, kChannels);
+    engine.setTrackManager(trackManager);
+    engine.setBPM(static_cast<float>(kBpm));
+    trackManager->buildAndShareSlotMap();
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*trackManager));
+    engine.setSafetyLimiterEnabled(false); // isolate the boundary guard from the final limiter
+    engine.setMetronomeEnabled(false);
+    assert(engine.initialize());
+    engine.setGlobalSamplePos(0);
+    engine.setTransportPlaying(true);
+
+    std::vector<float> out(static_cast<size_t>(kRenderBlock) * kChannels, 0.0f);
+    bool allFinite = true;
+    const uint32_t blocks = (numFrames + kRenderBlock - 1) / kRenderBlock;
+    for (uint32_t b = 0; b < blocks; ++b) {
+        std::fill(out.begin(), out.end(), 0.0f);
+        engine.processBlock(out.data(), nullptr, kRenderBlock, 0.0);
+        for (float s : out) {
+            if (!std::isfinite(s)) {
+                allFinite = false;
+                break;
+            }
+        }
+        if (!allFinite) break;
+    }
+
+    assert(allFinite);
+    // The boundary guard caught every non-finite sample, so the last-resort
+    // final-stage sanitizer never had to fire. If the boundary guard were
+    // removed, the NaN/Inf would reach the output stage and this would be > 0.
+    assert(engine.getNaNCount() == 0);
+    std::cout << "PASS: NaN/Inf clip source is sanitized at the mix boundary "
+                 "(finite output, final-stage NaN guard never fired)\n";
+}
+
 } // namespace
 
 int main() {
@@ -294,6 +384,7 @@ int main() {
     previewMatchesCenteredTrackGainBelowLimiter(coldPath, coldDecoded);
     previewLimiterChangesBoostedHotMaterialButAuditionBypassDoesNot(hotPath, hotDecoded);
     mainAudioEngineSafetyLimiterChangesHotMasterOutput();
+    nanClipSourceProducesFiniteOutput();
 
     std::error_code ec;
     fs::remove(coldPath, ec);


### PR DESCRIPTION
## Summary
Closes #207. Plugin output, clip source reads, and sampler output were mixed into the double master/track buffers **without NaN/Inf validation**. The only existing guard was the *final* output stage (after master gain), so a misbehaving plugin or a corrupted clip file could push non-finite samples through per-track effect chains, meters, and sends — corrupting downstream DSP state **before** the last-resort sanitizer ran.

## Change
- New file-local `sanitizeMix(double) -> std::isfinite(v) ? v : 0.0` (bounded, RT-safe, matches the existing `clampD`/`dbToLinearD` helper style).
- Applied at **all three plugin-output mix sites** (Arsenal preview→master, unit→track buffer, unit→master) and the **direct clip sample reads**.
- **`SamplerPlugin`**: guards its output write — sinc interpolation at extreme playback rates (or NaN in the loaded sample) can produce non-finite output; now zeroed before leaving the plugin.

## Why boundary guards (not just the final stage)
The final output-stage sanitizer makes the *master output* finite, but only after NaN has already accumulated through the mix and any per-track effect state. A stuck biquad or a poisoned meter isn't undone by a per-sample output clamp. Catching non-finite samples where they enter the mix keeps the poison out of downstream state.

## Test (discriminating — it encodes the bug)
`PlaybackPathSignalIntegrityTest` gains `nanClipSourceProducesFiniteOutput`: renders a clip whose every source sample is NaN/+Inf/−Inf and asserts
1. the master output is finite, **and**
2. `engine.getNaNCount() == 0` — the final-stage sanitizer *never fired*, proving the boundary guard caught the poison first.

**Verified the test FAILS** (SIGABRT on the `getNaNCount()` assertion, exit 134) when the clip-read guard is removed, and passes with it — so it can't pass without the fix. (An earlier master-output-only assertion passed even without the guard because the final stage masks it; the `getNaNCount()` assertion is what makes it discriminating.)

## DSP report
- **Audio output changed:** only for already-broken (non-finite) inputs — now silenced at the boundary instead of at the output. Finite signal is **bit-identical** (verified: existing integrity/parity assertions unchanged).
- **Latency:** unchanged. **State/serialization format:** unchanged.
- **RT-safety:** no allocations/locks/branches of unbounded cost added — a single `isfinite` ternary per sample at boundaries that already loop per sample.
- **Live/export parity:** unaffected (same code path).

## Change type
DSP: yes (guards only) · UI: no · Serialization: no · Build/CI: no · Public docs: no

## Testing
`AestraPlaybackPathSignalIntegrityTest` — all cases PASS including the new NaN-clip case; build clean (`-j2`).

## Risk / rollback
Low; additive guards. Rollback = revert. The negative-control run (guard removed → test aborts) documents the exact behavior being protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added audio mix-boundary sanitization that converts NaN/Inf samples to silence before downstream DSP processing.
- Protected plugin, clip, unit, and sampler outputs from propagating non-finite values into effects, meters, sends, and mixes.
- Added signal-integrity coverage verifying corrupted clip sources produce finite master output without relying on the final-stage sanitizer.
- Finite audio behavior, latency, and serialization remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->