### PR TITLE
feat(project): cap .history directory disk usage by count and total bytes (#274)

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -39,7 +39,16 @@ namespace {
     // - Future migration code can handle MIN_SUPPORTED <= version <= CURRENT
     constexpr int PROJECT_VERSION_CURRENT = 2;
     constexpr int PROJECT_VERSION_MIN_SUPPORTED = 1;
-    constexpr size_t PROJECT_HISTORY_MAX_ENTRIES = 50;
+    constexpr size_t PROJECT_HISTORY_DEFAULT_MAX_ENTRIES = 50;
+    // Total on-disk cap for a project's .history directory. A large project can
+    // produce multi-MB snapshots, so a count-only limit (50) let history grow to
+    // GBs (issue #274). Newest snapshots are always kept; older ones are pruned
+    // once either the count or this byte budget is exceeded. Both limits are
+    // runtime-configurable via ProjectSerializer::setHistoryLimits().
+    constexpr uintmax_t PROJECT_HISTORY_DEFAULT_MAX_TOTAL_BYTES = 512ull * 1024ull * 1024ull; // 512 MB
+
+    std::atomic<size_t> g_historyMaxEntries{PROJECT_HISTORY_DEFAULT_MAX_ENTRIES};
+    std::atomic<uintmax_t> g_historyMaxTotalBytes{PROJECT_HISTORY_DEFAULT_MAX_TOTAL_BYTES};
     constexpr uintmax_t PROJECT_MAX_FILE_BYTES = 64ull * 1024ull * 1024ull;
     constexpr size_t PROJECT_MAX_SOURCES = 10000;
     constexpr size_t PROJECT_MAX_PATTERNS = 100000;
@@ -624,27 +633,58 @@ static void pruneHistorySnapshots(const std::filesystem::path& historyDir) {
     }
 
     std::vector<fs::directory_entry> entries;
+    uintmax_t totalBytes = 0;
     for (const auto& entry : fs::directory_iterator(historyDir, ec)) {
         if (ec) {
             return;
         }
         if (entry.is_regular_file(ec) && entry.path().extension() == ".aes") {
             entries.push_back(entry);
+            std::error_code sizeEc;
+            totalBytes += fs::file_size(entry.path(), sizeEc);
         }
     }
 
-    if (entries.size() <= PROJECT_HISTORY_MAX_ENTRIES) {
+    const size_t maxEntries = g_historyMaxEntries.load(std::memory_order_relaxed);
+    const uintmax_t maxTotalBytes = g_historyMaxTotalBytes.load(std::memory_order_relaxed);
+    if (entries.size() <= maxEntries && totalBytes <= maxTotalBytes) {
         return;
     }
 
+    // Newest first, so the retained prefix is always the most recent snapshots.
     std::sort(entries.begin(), entries.end(), [](const fs::directory_entry& a, const fs::directory_entry& b) {
         std::error_code aec;
         std::error_code bec;
         return fs::last_write_time(a.path(), aec) > fs::last_write_time(b.path(), bec);
     });
 
-    for (size_t i = PROJECT_HISTORY_MAX_ENTRIES; i < entries.size(); ++i) {
+    // Keep snapshots while they fit both the count cap and the cumulative byte
+    // budget; remove everything past the first cap hit. The newest snapshot is
+    // always retained even if it alone exceeds the budget — losing it would
+    // defeat the point of writing history at all.
+    uintmax_t keptBytes = 0;
+    size_t kept = 0;
+    bool prunedForSize = false;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        std::error_code sizeEc;
+        const uintmax_t entryBytes = fs::file_size(entries[i].path(), sizeEc);
+        const bool withinCount = kept < maxEntries;
+        const bool withinBytes = kept == 0 || keptBytes + entryBytes <= maxTotalBytes;
+        if (withinCount && withinBytes) {
+            keptBytes += entryBytes;
+            ++kept;
+            continue;
+        }
+        if (!withinBytes) {
+            prunedForSize = true;
+        }
         fs::remove(entries[i].path(), ec);
+    }
+
+    if (prunedForSize) {
+        Log::warning("Project history exceeded its " +
+                     std::to_string(maxTotalBytes / (1024ull * 1024ull)) +
+                     " MB budget; pruned oldest snapshots in " + historyDir.string());
     }
 }
 
@@ -1953,6 +1993,15 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     result.ok = true;
     Log::info("Project loaded: " + path);
     return result;
+}
+
+void ProjectSerializer::setHistoryLimits(size_t maxEntries, uintmax_t maxTotalBytes) {
+    // A zero cap would delete all history (or all-but-newest); guard against it
+    // so a misconfiguration can't silently disable history entirely.
+    g_historyMaxEntries.store(maxEntries == 0 ? PROJECT_HISTORY_DEFAULT_MAX_ENTRIES : maxEntries,
+                              std::memory_order_relaxed);
+    g_historyMaxTotalBytes.store(maxTotalBytes == 0 ? PROJECT_HISTORY_DEFAULT_MAX_TOTAL_BYTES : maxTotalBytes,
+                                 std::memory_order_relaxed);
 }
 
 std::string ProjectSerializer::getHistoryDirectory(const std::string& projectPath) {

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -141,4 +141,14 @@ public:
 
     static std::string getHistoryDirectory(const std::string& projectPath);
     static std::vector<HistoryEntry> listHistory(const std::string& projectPath);
+
+    /**
+     * @brief Configure the .history directory caps (issue #274).
+     *
+     * History snapshots are pruned so the directory keeps at most @p maxEntries
+     * snapshots AND stays within @p maxTotalBytes on disk, whichever is hit
+     * first; the newest snapshot is always retained. Defaults are 50 entries /
+     * 512 MB. Applies to subsequent saves. Thread-safe.
+     */
+    static void setHistoryLimits(size_t maxEntries, uintmax_t maxTotalBytes);
 };

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -346,6 +346,24 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectLoadRegressionTest.cpp
     set_tests_properties(ProjectLoadRegressionTest PROPERTIES LABELS "integration;regression;routing")
 endif()
 
+# Project History Cap (issue #274 — .history directory disk-usage bound)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectHistoryCapTest.cpp")
+    add_executable(ProjectHistoryCapTest
+        Integration/ProjectHistoryCapTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(ProjectHistoryCapTest PRIVATE AestraAudio)
+    target_include_directories(ProjectHistoryCapTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    add_test(NAME ProjectHistoryCapTest COMMAND ProjectHistoryCapTest)
+    set_tests_properties(ProjectHistoryCapTest PROPERTIES LABELS "integration;project;serialization")
+endif()
+
 # Takes manifest/snapshot regression test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/TakeManagerTest.cpp")
     add_executable(TakeManagerTest

--- a/Tests/Integration/ProjectHistoryCapTest.cpp
+++ b/Tests/Integration/ProjectHistoryCapTest.cpp
@@ -1,0 +1,126 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// ProjectHistoryCapTest
+//
+// Guards #274: the per-project .history directory must stay bounded. Each save
+// writes a history snapshot; without a cap a large project could grow history
+// to gigabytes. ProjectSerializer::setHistoryLimits() configures a count cap
+// and a cumulative-byte cap, and pruneHistorySnapshots keeps only the newest
+// snapshots within both. This verifies both caps, with the newest always kept.
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "Models/TrackManager.h"
+
+#include "../Support/TestTempDirectory.h"
+
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+int gFailures = 0;
+
+void check(bool cond, const std::string& label) {
+    std::cout << "  " << (cond ? "PASS " : "FAIL ") << label << "\n";
+    if (!cond) {
+        ++gFailures;
+    }
+}
+
+// Count *.aes snapshots and total bytes in a project's .history directory.
+struct DirStats {
+    size_t count = 0;
+    uintmax_t bytes = 0;
+};
+
+DirStats historyStats(const std::string& projectPath) {
+    DirStats stats;
+    const fs::path dir = ProjectSerializer::getHistoryDirectory(projectPath);
+    std::error_code ec;
+    if (!fs::exists(dir, ec)) {
+        return stats;
+    }
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        if (entry.is_regular_file(ec) && entry.path().extension() == ".aes") {
+            ++stats.count;
+            std::error_code sec;
+            stats.bytes += fs::file_size(entry.path(), sec);
+        }
+    }
+    return stats;
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    const Aestra::Tests::ScopedTempDirectory tempScope{"ProjectHistoryCap"};
+
+    // --- Count cap: keep at most N newest snapshots ---------------------------
+    {
+        const auto projectPath = (tempScope.path() / "count.aes").string();
+        ProjectSerializer::setHistoryLimits(/*maxEntries=*/3, /*maxTotalBytes=*/1ull << 40); // huge byte cap
+
+        auto tm = std::make_shared<TrackManager>();
+        for (int i = 0; i < 8; ++i) {
+            const bool ok = ProjectSerializer::save(projectPath, tm, 120.0, 0.0);
+            check(ok, "save " + std::to_string(i) + " succeeded");
+        }
+
+        const DirStats stats = historyStats(projectPath);
+        check(stats.count == 3, "count cap retains exactly maxEntries snapshots (got " +
+                                    std::to_string(stats.count) + ")");
+    }
+
+    // --- Byte cap: prune oldest until under the cumulative budget -------------
+    {
+        const auto projectPath = (tempScope.path() / "bytes.aes").string();
+
+        // First measure a single snapshot's size, then set a byte cap that fits
+        // ~2 snapshots so a third forces size-based pruning.
+        ProjectSerializer::setHistoryLimits(/*maxEntries=*/1000, /*maxTotalBytes=*/1ull << 40);
+        auto tm = std::make_shared<TrackManager>();
+        ProjectSerializer::save(projectPath, tm, 120.0, 0.0);
+        const uintmax_t oneSnapshot = historyStats(projectPath).bytes;
+        check(oneSnapshot > 0, "a saved snapshot has non-zero size");
+
+        // Budget for ~2 snapshots.
+        ProjectSerializer::setHistoryLimits(/*maxEntries=*/1000, /*maxTotalBytes=*/oneSnapshot * 2 + oneSnapshot / 2);
+        for (int i = 0; i < 6; ++i) {
+            ProjectSerializer::save(projectPath, tm, 120.0, 0.0);
+        }
+
+        const DirStats stats = historyStats(projectPath);
+        check(stats.bytes <= oneSnapshot * 2 + oneSnapshot / 2,
+              "byte cap keeps cumulative history within budget (" + std::to_string(stats.bytes) +
+                  " <= " + std::to_string(oneSnapshot * 2 + oneSnapshot / 2) + ")");
+        check(stats.count >= 1, "at least the newest snapshot is retained");
+        check(stats.count <= 3, "byte cap pruned older snapshots (kept " + std::to_string(stats.count) + ")");
+    }
+
+    // --- Zero cap is rejected (guards against disabling history entirely) -----
+    {
+        const auto projectPath = (tempScope.path() / "zero.aes").string();
+        ProjectSerializer::setHistoryLimits(/*maxEntries=*/0, /*maxTotalBytes=*/0);
+        auto tm = std::make_shared<TrackManager>();
+        for (int i = 0; i < 3; ++i) {
+            ProjectSerializer::save(projectPath, tm, 120.0, 0.0);
+        }
+        const DirStats stats = historyStats(projectPath);
+        check(stats.count >= 1, "zero limits fall back to defaults, history is not wiped");
+    }
+
+    // Restore production defaults for any later tests in the same process.
+    ProjectSerializer::setHistoryLimits(50, 512ull * 1024ull * 1024ull);
+
+    if (gFailures == 0) {
+        std::cout << "ProjectHistoryCapTest: PASS\n";
+        return 0;
+    }
+    std::cout << "ProjectHistoryCapTest: FAIL (" << gFailures << ")\n";
+    return 1;
+}


### PR DESCRIPTION
## Summary
Closes #274. Project history snapshots were pruned by **count only** (`PROJECT_HISTORY_MAX_ENTRIES = 50`) with no size limit, so a large project (multi-MB per snapshot) could grow its hidden `.history` directory to **gigabytes** and unexpectedly fill the disk (the issue's example: 200 MB project × 50 → 10 GB).

## Change
- Add a **cumulative-byte cap** alongside the count cap. `pruneHistorySnapshots` keeps the newest snapshots while they fit **both** caps and removes the rest; the newest snapshot is always retained even if it alone exceeds the budget (losing it would defeat the point of history). Logs a warning when size-based pruning occurs.
- Make both caps **runtime-configurable** via `ProjectSerializer::setHistoryLimits(maxEntries, maxTotalBytes)` (atomics; defaults **50 entries / 512 MB**). A zero cap falls back to the default so a misconfiguration can't silently disable history.

## Test
`ProjectHistoryCapTest` drives **real saves** and verifies:
- count cap retains exactly N newest snapshots,
- byte cap keeps cumulative size within budget while retaining the newest (observed: 460 ≤ 575 B, older pruned, 2 kept),
- zero limits fall back to defaults (history not wiped).

All 14 assertions pass.

## Acceptance criteria (#274)
- ✅ History directory has a **configurable** size cap (`setHistoryLimits`).
- ✅ Old entries pruned when cap exceeded (count **and** bytes).
- ⚠️ "User-facing warning when history is large" — emitted here as a **log warning**. A UI toast belongs to the caller (`ProjectSerializer` is a backend module with no UI access, and is slated to move to a lower tier per #266); wiring a toast is a small follow-up on the app side.

## Change type
Serialization/project format: **unchanged** — snapshot contents and naming are identical; only the *retention policy* changed. DSP: no · UI: no · Build/CI: test target added · Public docs: no.

## Risk / rollback
Low. Pruning is more aggressive only when a project's history exceeds 512 MB (previously unbounded). Newest snapshot always kept. Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)