### PR TITLE
fix(audio): rebase metronome on transport restart at unchanged position

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -770,7 +770,6 @@ private:
     std::atomic<bool> m_transportPlaying{false};
     // RT-side tracking of last known transport state (avoids race with UI atomic updates)
     bool m_rtLastTransportPlaying{false};
-    uint64_t m_rtLastTransportPos{0};
     // Transport edge flags (set in applyPendingCommands, consumed in processBlock)
     std::atomic<bool> m_transportRestartRequested{false};
     std::atomic<bool> m_transportStopRequested{false};

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -202,10 +202,12 @@ void AudioEngine::applyPendingCommands() {
 
     // Track transport transitions within this block even though we coalesce
     // the final transport state (stop->play can otherwise be missed).
-    // [FIX] Use RT-side tracked state, NOT the atomic (which UI updates immediately).
-    // This avoids race condition where UI sets m_transportPlaying before RT reads it.
+    // Use RT-side tracked playing state, NOT the atomic (which UI updates immediately).
+    // Read position from the current audio-thread authority: the previous command
+    // position does not advance with uninterrupted playback and cannot detect a
+    // seek back to that same numerical position.
     bool transportPlaying = m_rtLastTransportPlaying;
-    uint64_t transportPos = m_rtLastTransportPos;
+    uint64_t transportPos = m_globalSamplePos.load(std::memory_order_relaxed);
     bool sawRestartEdge = false;
     bool sawStopEdge = false;
     bool sawHardStopEdge = false;
@@ -340,7 +342,6 @@ void AudioEngine::applyPendingCommands() {
 
         // Update RT-side state tracking (used for edge detection next block)
         m_rtLastTransportPlaying = transportPlaying;
-        m_rtLastTransportPos = transportPos;
 
         m_transportPlaying.store(transportPlaying, std::memory_order_relaxed);
         m_globalSamplePos.store(transportPos, std::memory_order_relaxed);
@@ -711,6 +712,14 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     const bool patternModeNow = m_patternPlaybackMode.load(std::memory_order_relaxed);
     if (patternModeNow && (transportStop || transportRestart)) {
         m_globalSamplePos.store(0, std::memory_order_relaxed);
+    }
+
+    // A transport restart is a semantic metronome discontinuity even when the
+    // numerical position is unchanged (pause -> play at the same sample).
+    // Rebase from the position applied on the audio thread so an old click tail
+    // or next-beat schedule cannot leak into the new playback run.
+    if (transportRestart) {
+        m_metronomeEngine.reset(m_globalSamplePos.load(std::memory_order_relaxed), currentSampleRate);
     }
 
     // Restart/hard-stop should also send MIDI panic (helps for VST/CLAP instruments).

--- a/Tests/AestraAudio/MetronomeRestartTest.cpp
+++ b/Tests/AestraAudio/MetronomeRestartTest.cpp
@@ -1,0 +1,216 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Deterministic transport-restart coverage for metronome transient state.
+
+#include "Core/AudioEngine.h"
+#include "Playback/MetronomeEngine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kFrames = 256;
+constexpr uint32_t kChannels = 2;
+constexpr float kTolerance = 1.0e-6f;
+
+int g_failures = 0;
+
+bool require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++g_failures;
+    }
+    return condition;
+}
+
+std::unique_ptr<AudioEngine> makeEngine(float bpm = 120.0f) {
+    auto engine = std::make_unique<AudioEngine>();
+    engine->setSampleRate(kSampleRate);
+    engine->setBufferConfig(kFrames, kChannels);
+    engine->setSafetyLimiterEnabled(false);
+    engine->setAuditionModeEnabled(false);
+    engine->setMetronomeEnabled(true);
+    engine->setMetronomeVolume(0.7f);
+    engine->setBPM(bpm);
+    require(engine->initialize(), "AudioEngine initialization failed");
+    return engine;
+}
+
+void queueTransport(AudioEngine& engine, bool playing, uint64_t samplePos) {
+    AudioQueueCommand command{};
+    command.type = AudioQueueCommandType::SetTransportState;
+    command.value1 = playing ? 1.0f : 0.0f;
+    command.samplePos = samplePos;
+    require(engine.commandQueue().push(command), "Transport command queue rejected a command");
+}
+
+std::vector<float> renderBlock(AudioEngine& engine) {
+    std::vector<float> output(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+    engine.processBlock(output.data(), nullptr, kFrames, 0.0);
+    return output;
+}
+
+std::vector<float> renderBlocks(AudioEngine& engine, uint32_t blockCount) {
+    std::vector<float> output;
+    output.reserve(static_cast<size_t>(blockCount) * kFrames * kChannels);
+    for (uint32_t block = 0; block < blockCount; ++block) {
+        auto rendered = renderBlock(engine);
+        output.insert(output.end(), rendered.begin(), rendered.end());
+    }
+    return output;
+}
+
+float maxDifference(const std::vector<float>& lhs, const std::vector<float>& rhs) {
+    if (lhs.size() != rhs.size()) {
+        return INFINITY;
+    }
+
+    float difference = 0.0f;
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        difference = std::max(difference, std::abs(lhs[i] - rhs[i]));
+    }
+    return difference;
+}
+
+float peakMagnitude(const std::vector<float>& samples) {
+    float peak = 0.0f;
+    for (float sample : samples) {
+        peak = std::max(peak, std::abs(sample));
+    }
+    return peak;
+}
+
+std::vector<float> renderFreshStart(uint64_t samplePos, float bpm = 120.0f, uint32_t blocks = 1) {
+    auto engine = makeEngine(bpm);
+    queueTransport(*engine, true, samplePos);
+    return renderBlocks(*engine, blocks);
+}
+
+void testRestartAtZeroBeforeFirstCallback() {
+    const auto reference = renderFreshStart(0);
+
+    auto engine = makeEngine();
+    queueTransport(*engine, false, 0);
+    queueTransport(*engine, true, 0);
+    const auto restarted = renderBlock(*engine);
+
+    require(maxDifference(reference, restarted) <= kTolerance,
+            "restart at zero before the first callback differs from a fresh beat-zero render");
+}
+
+void testRestartAtZeroAfterFirstCallback() {
+    const auto reference = renderFreshStart(0);
+
+    auto engine = makeEngine();
+    queueTransport(*engine, true, 0);
+    (void)renderBlock(*engine); // Advance the active click by one callback.
+
+    queueTransport(*engine, false, 0);
+    (void)renderBlock(*engine);
+    queueTransport(*engine, true, 0);
+    const auto restarted = renderBlock(*engine);
+
+    require(maxDifference(reference, restarted) <= kTolerance,
+            "restart at zero resumed retained click state instead of starting a fresh click");
+}
+
+void testMidBeatRestartClearsActiveTail() {
+    constexpr uint64_t kRestartPosition = 1024;
+    const auto reference = renderFreshStart(kRestartPosition);
+
+    auto engine = makeEngine();
+    queueTransport(*engine, true, 0);
+    (void)renderBlock(*engine); // The 100 ms click still has an active tail.
+
+    queueTransport(*engine, false, kFrames);
+    (void)renderBlock(*engine);
+    queueTransport(*engine, true, kRestartPosition);
+    const auto restarted = renderBlock(*engine);
+
+    require(peakMagnitude(reference) <= kTolerance, "fresh mid-beat reference unexpectedly contains a click");
+    require(maxDifference(reference, restarted) <= kTolerance,
+            "mid-beat restart resumed the click tail from the previous playback run");
+}
+
+void testMidBeatRestartRebasesCompletedClickSchedule() {
+    constexpr uint64_t kRestartPosition = 12000;
+    constexpr uint32_t kComparisonBlocks = 150; // Crosses the 48,000-sample beat at 60 BPM.
+    const auto reference = renderFreshStart(kRestartPosition, 60.0f, kComparisonBlocks);
+
+    auto engine = makeEngine(120.0f);
+    queueTransport(*engine, true, 0);
+    (void)renderBlocks(*engine, 20); // 5,120 samples: the 100 ms click has completed.
+
+    const uint64_t stoppedPosition = engine->getGlobalSamplePos();
+    queueTransport(*engine, false, stoppedPosition);
+    (void)renderBlock(*engine);
+
+    engine->setBPM(60.0f);
+    queueTransport(*engine, true, kRestartPosition);
+    const auto restarted = renderBlocks(*engine, kComparisonBlocks);
+
+    require(maxDifference(reference, restarted) <= kTolerance,
+            "restart retained next-beat scheduling derived from the previous playback run");
+}
+
+void testUninterruptedPlaybackPreservesClickContinuation() {
+    auto engine = makeEngine();
+    queueTransport(*engine, true, 0);
+    const auto uninterrupted = renderBlocks(*engine, 2);
+
+    MetronomeEngine referenceMetronome;
+    referenceMetronome.setEnabled(true);
+    referenceMetronome.setVolume(0.7f);
+    referenceMetronome.setBPM(120.0f);
+    referenceMetronome.setSampleRate(kSampleRate);
+    std::vector<float> reference(uninterrupted.size(), 0.0f);
+    referenceMetronome.process(reference.data(), kFrames, kChannels, 0, kSampleRate, true);
+    referenceMetronome.process(reference.data() + static_cast<size_t>(kFrames) * kChannels, kFrames, kChannels, kFrames,
+                               kSampleRate, true);
+
+    const std::vector<float> secondBlock(uninterrupted.begin() + static_cast<size_t>(kFrames) * kChannels,
+                                         uninterrupted.end());
+    require(peakMagnitude(secondBlock) > 0.1f, "uninterrupted playback did not continue the active click tail");
+    require(maxDifference(reference, uninterrupted) <= kTolerance,
+            "ordinary uninterrupted metronome output changed from the direct reference path");
+}
+
+void testExplicitBackwardSeekRebasesMetronome() {
+    const auto reference = renderFreshStart(0);
+
+    auto engine = makeEngine();
+    queueTransport(*engine, true, 0);
+    (void)renderBlocks(*engine, 2);
+
+    queueTransport(*engine, true, 0); // Playing + position change is the production seek path.
+    const auto sought = renderBlock(*engine);
+    require(maxDifference(reference, sought) <= kTolerance,
+            "explicit backward seek to zero did not produce a fresh beat-zero click");
+}
+
+} // namespace
+
+int main() {
+    testRestartAtZeroBeforeFirstCallback();
+    testRestartAtZeroAfterFirstCallback();
+    testMidBeatRestartClearsActiveTail();
+    testMidBeatRestartRebasesCompletedClickSchedule();
+    testUninterruptedPlaybackPreservesClickContinuation();
+    testExplicitBackwardSeekRebasesMetronome();
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " metronome restart regression(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "All metronome restart regressions passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1524,6 +1524,19 @@ target_include_directories(GoldenAudioRegressionTest PRIVATE
 add_test(NAME GoldenAudioRegressionTest COMMAND GoldenAudioRegressionTest)
 set_tests_properties(GoldenAudioRegressionTest PROPERTIES LABELS "audio;quality;golden;integrity;s-tier" TIMEOUT 180)
 
+# Metronome restart regression — transport restart edges must clear retained
+# click tails and rebase beat scheduling from the applied RT transport position.
+add_executable(MetronomeRestartTest AestraAudio/MetronomeRestartTest.cpp)
+target_link_libraries(MetronomeRestartTest PRIVATE AestraAudio)
+target_include_directories(MetronomeRestartTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME MetronomeRestartTest COMMAND MetronomeRestartTest)
+set_tests_properties(MetronomeRestartTest PROPERTIES LABELS "audio;metronome;transport;regression" TIMEOUT 120)
+
 # Realtime/Export Parity — realtime processBlock output vs offline
 # bounceRangeToWav output for the same session, plus the preview-ducking
 # export-contamination probe. Doc: AestraDocs/audio-integrity-infrastructure.md.


### PR DESCRIPTION
## Problem

A transport restart is a semantic metronome discontinuity even when the sample position is unchanged (pause → play at the same sample). The old code read the transport position from the stale per-command `m_rtLastTransportPos`, which does not advance with uninterrupted playback and cannot detect a seek back to that same numerical position. As a result, a restart could leak an old click tail or next-beat schedule into the new playback run.

## Fix

- Read the transport position from the audio-thread authority (`m_globalSamplePos`) instead of `m_rtLastTransportPos` (now removed).
- Reset the metronome on transport restart edges, rebasing from the RT-applied position so no stale click state carries over.

## Tests

Adds `MetronomeRestartTest` covering:
- restart at zero before/after the first callback
- mid-beat restart clearing an active click tail
- completed-click next-beat schedule rebasing
- uninterrupted-playback click continuity (must NOT change)
- explicit backward seek rebasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)