### PR TITLE
fix(ui): NUIConfigLoader loads JSON so saved configs actually restore (#585)

### DIFF
--- a/AestraUI/Core/NUIConfigLoader.cpp
+++ b/AestraUI/Core/NUIConfigLoader.cpp
@@ -28,9 +28,31 @@ bool NUIConfigLoader::loadConfig(const std::string& filePath) {
     return loadConfigFromString(content);
 }
 
-bool NUIConfigLoader::loadConfigFromString(const std::string& yamlContent) {
+bool NUIConfigLoader::loadConfigFromString(const std::string& content) {
     config_ = Aestra::JSON::object();
-    configLoaded_ = parseYAML(yamlContent);
+
+    // saveConfig() serializes the theme as JSON (Aestra::JSON::toString), but the
+    // hand-authored config assets under AestraUI/Config/ are YAML. Detect which
+    // format we were handed: a JSON document must be parsed with the JSON parser,
+    // a YAML document with the line-based parseYAML(). Feeding JSON to parseYAML()
+    // silently restored nothing — loadConfig() returned true but applied no values,
+    // so a saved config never round-tripped. See issue #585.
+    const size_t firstNonSpace = content.find_first_not_of(" \t\r\n");
+    const bool looksLikeJson =
+        firstNonSpace != std::string::npos && content[firstNonSpace] == '{';
+
+    if (looksLikeJson) {
+        Aestra::JSON parsed = Aestra::JSON::parse(content);
+        // parse() yields a null (non-object) JSON on malformed input; accept only a
+        // real object so a truncated or corrupt file fails loudly instead of
+        // wiping the live theme with an empty config.
+        configLoaded_ = parsed.isObject();
+        if (configLoaded_) {
+            config_ = std::move(parsed);
+        }
+    } else {
+        configLoaded_ = parseYAML(content);
+    }
 
     if (configLoaded_) {
         applyConfig();

--- a/AestraUI/Core/NUIConfigLoader.h
+++ b/AestraUI/Core/NUIConfigLoader.h
@@ -27,11 +27,13 @@ public:
     bool loadConfig(const std::string& filePath);
 
     /**
-     * Load configuration from YAML string
-     * @param yamlContent YAML content as string
+     * Load configuration from a config string. Accepts either JSON (as emitted by
+     * saveConfig) or the legacy hand-authored YAML format; the format is detected
+     * from the content. See issue #585.
+     * @param content JSON or YAML configuration content as a string
      * @return true if loaded successfully, false otherwise
      */
-    bool loadConfigFromString(const std::string& yamlContent);
+    bool loadConfigFromString(const std::string& content);
 
     /**
      * Apply loaded configuration to current theme

--- a/Tests/AestraUI/NUIThemeConsistencyTest.cpp
+++ b/Tests/AestraUI/NUIThemeConsistencyTest.cpp
@@ -7,9 +7,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <system_error>
 
 using namespace AestraUI;
 
@@ -369,6 +371,63 @@ void testChromeDimensionConfigLoad() {
     }
 }
 
+// #585 regression: saveConfig() serializes the theme as JSON, so loadConfig()
+// must parse JSON. Before the format-detecting loader, loadConfig() ran the JSON
+// document through the YAML line-parser, returned true, and applied nothing — a
+// saved config silently failed to restore. This drives the real file round-trip
+// (saveConfig -> clobber -> loadConfig), which must fail without the fix.
+void testConfigSaveLoadRoundtrip() {
+    std::cout << "[Test] saveConfig -> loadConfig round-trips through JSON (#585)\n";
+    auto& manager = NUIThemeManager::getInstance();
+    auto& configLoader = NUIConfigLoader::getInstance();
+
+    // Known, distinct values to persist. The color uses fromHex so it survives
+    // the hex serialization exactly.
+    {
+        auto& theme = manager.getCurrentThemeMutable();
+        theme.layout.trackHeight = 63.0f;
+        theme.layout.titleBarHeight = 37.0f;
+        theme.layout.viewToggleWidth = 311.0f;
+        theme.layout.viewToggleHeight = 29.0f;
+        theme.spacingM = 17.0f;
+        theme.spacingS = 9.0f;
+        theme.primary = NUIColor::fromHex(0xBB86FC);
+    }
+
+    const std::filesystem::path tmp =
+        std::filesystem::temp_directory_path() / "aestra_nuiconfig_roundtrip_585.cfg";
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec); // clear any stale leftover
+    configLoader.saveConfig(tmp.string());
+
+    // Clobber every persisted value in memory so a no-op load is detectable: if
+    // loadConfig applies nothing, these sentinels survive and the checks fail.
+    {
+        auto& theme = manager.getCurrentThemeMutable();
+        theme.layout.trackHeight = 1.0f;
+        theme.layout.titleBarHeight = 1.0f;
+        theme.layout.viewToggleWidth = 1.0f;
+        theme.layout.viewToggleHeight = 1.0f;
+        theme.spacingM = 1.0f;
+        theme.spacingS = 1.0f;
+        theme.primary = NUIColor::fromHex(0x010203);
+    }
+
+    check(configLoader.loadConfig(tmp.string()), "saved config file loads");
+    {
+        const auto& t = manager.getCurrentTheme();
+        check(nearlyEqual(t.layout.trackHeight, 63.0f), "trackHeight restored from saved config");
+        check(nearlyEqual(t.layout.titleBarHeight, 37.0f), "titleBarHeight restored from saved config");
+        check(nearlyEqual(t.layout.viewToggleWidth, 311.0f), "viewToggleWidth restored from saved config");
+        check(nearlyEqual(t.layout.viewToggleHeight, 29.0f), "viewToggleHeight restored from saved config");
+        check(nearlyEqual(t.spacingM, 17.0f), "panelMargin (spacingM) restored from saved config");
+        check(nearlyEqual(t.spacingS, 9.0f), "componentPadding (spacingS) restored from saved config");
+        check(colorsEqual(t.primary, NUIColor::fromHex(0xBB86FC)), "primary color restored from saved config");
+    }
+
+    std::filesystem::remove(tmp, ec);
+}
+
 } // namespace
 
 int main() {
@@ -379,6 +438,7 @@ int main() {
     testIndependentSubscriptionsAndAtomicSwitching();
     testLiveJSONThemeRegistration();
     testChromeDimensionConfigLoad();
+    testConfigSaveLoadRoundtrip();
     testHierarchyInvalidation();
     testCompatibilityAliases();
     testLightPresetCompleteness();


### PR DESCRIPTION
## Summary
`NUIConfigLoader::saveConfig()` serializes the theme as **JSON** (`Aestra::JSON::toString`), but `loadConfig()`/`loadConfigFromString()` parsed every file with the naive line-based `parseYAML()`. Fed JSON, `parseYAML()` returns `true` yet matches nothing — so `loadConfig()` reported success while applying **no values**. A persisted config silently failed to restore (every key: colors, layout, spacing). Fixes #585.

## Why
The save side and load side disagreed on format. But the fix isn't a blind swap to `JSON::parse`: there are **real hand-authored YAML assets** under `AestraUI/Config/` (`aestra_ui_config.yaml`, `titlebar_config.yaml`, `slider_config.yaml`) that `parseYAML()` still needs to read. So the loader now **detects the format**:

- First non-space char is `{` → parse with `Aestra::JSON::parse` (the `saveConfig` round-trip path).
- Otherwise → fall back to `parseYAML` (legacy/authored YAML).
- A malformed JSON document yields a non-object and is **rejected** rather than wiping the live theme with an empty config.

## Testing performed
- Added `testConfigSaveLoadRoundtrip` — a real `saveConfig()` → clobber-in-memory → `loadConfig()` **file** round-trip (colors, layout extents, spacing).
- **Verified it encodes the bug:** reverted the loader to pre-fix and reran — `loadConfig` returns `true` ("saved config file loads" passes) but **all 7 restore assertions fail**, exactly the reported symptom. With the fix, all pass.
- The existing YAML-string test (`testChromeDimensionConfigLoad`) continues to pass, covering the legacy fallback path.
- `ctest -R NUIThemeConsistencyTest` — green.

## Docs updated?
Header doc comment updated to state the loader accepts JSON or YAML (removed the YAML-only wording).

## Risk / rollback
Config-persistence deserialization change, scoped to `NUIConfigLoader`. No production code currently calls `loadConfig`/`saveConfig` (the loader is dormant), so blast radius is limited to the theme-config path and its tests. Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated `NUIConfigLoader` to detect and parse JSON saved configurations while retaining legacy YAML support.
- Rejects malformed or non-object JSON instead of silently succeeding.
- Added a file-based save/load regression test covering colors, dimensions, spacing, and layout restoration.
- Clarified API documentation to describe JSON and YAML support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->