### PR TITLE
fix(ui): file-browser search blurs on any outside click + aligns selection highlight

### DIFF
--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -640,7 +640,19 @@ void NUITextInput::drawSelection(NUIRenderer& renderer)
 
     int start = std::max(0, std::min(selectionStart_, selectionEnd_));
     int end = std::max(0, std::max(selectionStart_, selectionEnd_));
-    
+
+    // Single-line vertical metrics must mirror drawText(), which positions the
+    // glyphs via renderer.calculateTextY() using the real font line height.
+    // getLineRenderY() approximates that centering with lineHeight = fontSize,
+    // so on renderers whose lineHeight exceeds fontSize the highlight otherwise
+    // lands below the text and covers only its lower half.
+    const bool singleLine = (!multiline_ || layoutLines_.size() <= 1);
+    const float fontSize = NUIThemeManager::getInstance().getFontSize("m");
+    const float singleLineTop = std::round(renderer.calculateTextY(textRect, fontSize));
+    float singleLineHeight = renderer.getFontMetrics(fontSize).lineHeight;
+    if (singleLineHeight <= 0.0f)
+        singleLineHeight = fontSize;
+
     // Find lines that intersect with selection
     for (const auto& line : layoutLines_)
     {
@@ -666,9 +678,9 @@ void NUITextInput::drawSelection(NUIRenderer& renderer)
         
         NUIRect selectionRect;
         selectionRect.x = textRect.x + startX;
-        selectionRect.y = std::round(getLineRenderY(line));
+        selectionRect.y = singleLine ? singleLineTop : std::round(getLineRenderY(line));
         selectionRect.width = endX - startX;
-        selectionRect.height = line.height;
+        selectionRect.height = singleLine ? singleLineHeight : line.height;
         
         // Draw selection highlight
         renderer.fillRoundedRect(selectionRect, 2.0f, selectionColor_.withAlpha(0.4f));

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -4528,6 +4528,14 @@ bool FileBrowser::isSearchBoxFocused() const {
     return searchInput_ ? searchInput_->isFocused() : false;
 }
 
+bool FileBrowser::blurSearchIfPressOutside(const NUIPoint& pos) {
+    if (searchInput_ && searchInput_->isFocused() && !searchInput_->getBounds().contains(pos)) {
+        searchInput_->setFocused(false);
+        return true;
+    }
+    return false;
+}
+
 // === PERSISTENT STATE SAVE/LOAD ===
 
 void FileBrowser::saveState(const std::string& filePath) {

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -145,6 +145,11 @@ public:
     void applyFilter();
     std::string getSearchQuery() const;
     bool isSearchBoxFocused() const;
+    // Drop search-box focus when a press at `pos` lands outside it. The content
+    // root calls this on every left-press so clicks in sibling panels (which
+    // consume the event before it ever reaches the browser) still dismiss the
+    // search caret. Returns true if focus was actually cleared.
+    bool blurSearchIfPressOutside(const NUIPoint& pos);
     
     // Preview panel
     void setPreviewPanelVisible(bool visible);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1698,6 +1698,15 @@ bool AestraContent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         return false;
     }
 
+    // Any left-press outside the file-browser search box dismisses its caret.
+    // The browser's own outside-click blur only fires when the event reaches
+    // the browser, but a press in another panel is consumed by that panel
+    // first — so drop search focus here, before routing, where every press is
+    // visible regardless of which sibling ends up handling it.
+    if (event.pressed && event.button == AestraUI::NUIMouseButton::Left && m_fileBrowser) {
+        m_fileBrowser->blurSearchIfPressOutside(event.position);
+    }
+
     // Wheel events need explicit hit routing because workspace siblings overlap
     // the browser's screen area and the generic child dispatcher only follows
     // z-order. Keep floating overlays first, then route the visible browser view


### PR DESCRIPTION
Two file-browser search-box defects, both verified fixed in-app.

## 1. Search caret didn't clear when clicking other panels
The browser's outside-click blur lived in `FileBrowser::onMouseEvent`, but a press in a sibling panel is consumed by that panel before the event ever reaches the browser — so the search caret stayed active unless you clicked within the browser's own (thin) container.

**Fix:** `FileBrowser::blurSearchIfPressOutside(pos)`, called from `AestraContent::onMouseEvent` on every left-press *before* routing, where all presses are visible regardless of which sibling ends up handling them.

## 2. Selection highlight sat half a line below the text
Single-line `drawText()` positions glyphs via `renderer.calculateTextY()` (real font line height), but `drawSelection()` used `getLineRenderY()`, which approximates the centering with `lineHeight = fontSize`. On renderers whose `lineHeight` exceeds `fontSize`, the highlight dropped by half the difference and covered only the lower half of the text.

**Fix:** the single-line selection rect now mirrors `drawText()`'s metrics (`calculateTextY` top + `getFontMetrics().lineHeight` height).

## Validation
- `Aestra` app target builds clean (`-j2`)
- App launches and shuts down cleanly
- Both gestures manually verified in-app: search blurs on clicks in any panel; highlight aligns to the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)