### PR TITLE
fix(audio): pause preserves the authoritative playhead — no rewind under rapid toggles (#590)

### DIFF
--- a/AestraAudio/include/Core/AudioCommandQueue.h
+++ b/AestraAudio/include/Core/AudioCommandQueue.h
@@ -30,6 +30,19 @@ enum class AudioQueueCommandType : uint8_t {
     AuditionUnit, // trackIndex = unitId, value1 = velocity
 };
 
+/**
+ * @brief Sentinel samplePos for a SetTransportState stop that must preserve the
+ *        audio thread's current playhead rather than seek.
+ *
+ * A pause has to stop transport without moving position. The UI-cached position
+ * lags the audio thread by up to a few buffers, so committing it would rewind the
+ * transport under rapid pause/play toggling (#590). Pause therefore sends this
+ * sentinel; the audio thread resolves it to its own authoritative m_globalSamplePos
+ * and the UI-side echo leaves the cached position for the next engine sync. No real
+ * seek ever targets UINT64_MAX (~12 million years at 48 kHz), so it is unambiguous.
+ */
+inline constexpr uint64_t kTransportPreservePosition = UINT64_MAX;
+
 // Ensure cache-friendly alignment for RT path
 struct alignas(32) AudioQueueCommand {
     AudioQueueCommandType type{AudioQueueCommandType::None};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -677,7 +677,10 @@ public:
     void pause() {
         m_isPlaying.store(false, std::memory_order_relaxed);
         m_isPaused.store(true, std::memory_order_relaxed);
-        pushTransportCommand(0.0f, m_position.load(std::memory_order_relaxed));
+        // Pause in place: preserve the audio thread's authoritative playhead rather
+        // than committing the UI-cached m_position, which lags playback by up to a
+        // few buffers and would rewind the transport under rapid toggles (#590).
+        pushTransportCommandSamples(0.0f, kTransportPreservePosition);
     }
 
     /**
@@ -894,12 +897,22 @@ public:
     /**
      * @brief Apply the transport state once it has been forwarded to the live engine.
      * @param playing True when the engine transport is now rolling.
-     * @param positionSeconds Transport position used for the command.
+     * @param samplePos Absolute sample position from the command, or the
+     *        kTransportPreservePosition sentinel for a pause-in-place (#590).
+     * @param sampleRate Engine sample rate used to convert samplePos to seconds.
      */
-    void onTransportStateApplied(bool playing, double positionSeconds) {
+    void onTransportStateApplied(bool playing, uint64_t samplePos, double sampleRate) {
         m_transportPlayingConfirmed.store(playing, std::memory_order_relaxed);
         if (!playing) {
-            m_position.store(positionSeconds, std::memory_order_relaxed);
+            // A pause requests kTransportPreservePosition so the audio thread keeps
+            // its authoritative playhead (#590). In that case leave the cached UI
+            // position untouched — syncPositionFromEngine refreshes it from the
+            // engine — instead of clobbering it with the sentinel. An explicit
+            // stop/seek carries a real sample position and updates the cache.
+            if (samplePos != kTransportPreservePosition) {
+                const double sr = std::max(1.0, sampleRate);
+                m_position.store(static_cast<double>(samplePos) / sr, std::memory_order_relaxed);
+            }
             clearDeferredRecordingStartBeat();
             if (m_isCapturing.load(std::memory_order_relaxed)) {
                 finalizeCaptureSession();
@@ -1490,6 +1503,13 @@ private:
     }
 
     void pushTransportCommand(float playing, double positionSeconds) {
+        pushTransportCommandSamples(playing, static_cast<uint64_t>(positionSeconds * m_outputSampleRate));
+    }
+
+    // Lower-level transport push that carries an absolute sample position (or the
+    // kTransportPreservePosition sentinel) verbatim, without the seconds→samples
+    // conversion that would mangle the sentinel.
+    void pushTransportCommandSamples(float playing, uint64_t samplePos) {
         if (!m_commandSink) {
             return;
         }
@@ -1497,7 +1517,7 @@ private:
         AudioQueueCommand cmd{};
         cmd.type = AudioQueueCommandType::SetTransportState;
         cmd.value1 = playing;
-        cmd.samplePos = static_cast<uint64_t>(positionSeconds * m_outputSampleRate);
+        cmd.samplePos = samplePos;
         m_commandSink(cmd);
     }
 

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -112,8 +112,9 @@ void MuseService::wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackM
         if (cmd.type == AudioQueueCommandType::SetTransportState) {
             const double sampleRate =
                 std::max(1.0, static_cast<double>(enginePtr->getSampleRate()));
-            tm->onTransportStateApplied(cmd.value1 != 0.0f,
-                                        static_cast<double>(cmd.samplePos) / sampleRate);
+            // onTransportStateApplied resolves the kTransportPreservePosition pause
+            // sentinel and the seconds conversion in one place (#590).
+            tm->onTransportStateApplied(cmd.value1 != 0.0f, cmd.samplePos, sampleRate);
         }
     });
 }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -218,11 +218,13 @@ void AudioEngine::applyPendingCommands() {
         if (cmd.type == AudioQueueCommandType::SetTransportState) {
             const bool nextPlaying = (cmd.value1 != 0.0f);
             // A pause carries kTransportPreservePosition: keep the authoritative
-            // playhead this thread already advanced instead of seeking to a stale
-            // UI snapshot, which would rewind under rapid pause/play toggles (#590).
-            const uint64_t nextPos = (cmd.samplePos == kTransportPreservePosition)
-                                         ? m_globalSamplePos.load(std::memory_order_relaxed)
-                                         : cmd.samplePos;
+            // playhead instead of seeking to a stale UI snapshot, which would
+            // rewind under rapid pause/play toggles (#590). Resolve against the
+            // in-block accumulator transportPos (seeded from m_globalSamplePos and
+            // updated per command) so a seek earlier in the SAME drain block is
+            // honored — m_globalSamplePos is only stored back after the loop.
+            const uint64_t nextPos =
+                (cmd.samplePos == kTransportPreservePosition) ? transportPos : cmd.samplePos;
             const bool posChanged = (nextPos != transportPos);
 
             if (nextPlaying && (!transportPlaying || posChanged)) {

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -217,7 +217,12 @@ void AudioEngine::applyPendingCommands() {
         // Transport commands: keep only the latest per block, but record edges.
         if (cmd.type == AudioQueueCommandType::SetTransportState) {
             const bool nextPlaying = (cmd.value1 != 0.0f);
-            const uint64_t nextPos = cmd.samplePos;
+            // A pause carries kTransportPreservePosition: keep the authoritative
+            // playhead this thread already advanced instead of seeking to a stale
+            // UI snapshot, which would rewind under rapid pause/play toggles (#590).
+            const uint64_t nextPos = (cmd.samplePos == kTransportPreservePosition)
+                                         ? m_globalSamplePos.load(std::memory_order_relaxed)
+                                         : cmd.samplePos;
             const bool posChanged = (nextPos != transportPos);
 
             if (nextPlaying && (!transportPlaying || posChanged)) {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3049,8 +3049,11 @@ void AestraContent::setAudioEngine(Aestra::Audio::AudioEngine* engine) {
                     if (m_trackManager) {
                         const double engineSampleRate =
                             std::max(1.0, static_cast<double>(m_audioEngine->getSampleRate()));
-                        const double positionSeconds = static_cast<double>(cmd.samplePos) / engineSampleRate;
-                        m_trackManager->onTransportStateApplied(cmd.value1 != 0.0f, positionSeconds);
+                        // Pass the raw sample position through: onTransportStateApplied
+                        // resolves the kTransportPreservePosition pause sentinel and the
+                        // seconds conversion in one place (#590).
+                        m_trackManager->onTransportStateApplied(cmd.value1 != 0.0f, cmd.samplePos,
+                                                                engineSampleRate);
                     }
                 } else {
                     m_audioEngine->commandQueue().push(cmd);

--- a/Tests/AestraAudio/RecordingPathTest.cpp
+++ b/Tests/AestraAudio/RecordingPathTest.cpp
@@ -64,15 +64,16 @@ bool testRecordingSessionLifecycle() {
     if (!tm->isRecordArmed()) { std::cerr << "FAILED: not armed\n"; return false; }
 
     // Transport starts playing → begins capture session
-    tm->onTransportStateApplied(true, 0.0);
+    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
     if (!tm->isRecording()) {
         // isRecording checks m_isCapturing which should be set by beginCaptureSession
         std::cerr << "FAILED: not recording after transport play\n";
         return false;
     }
 
-    // Transport stops → finalizes capture session
-    tm->onTransportStateApplied(false, 2.0);
+    // Transport stops → finalizes capture session (position 2.0s)
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(2.0 * kSampleRate),
+                                static_cast<double>(kSampleRate));
     if (tm->isRecording()) {
         std::cerr << "FAILED: still recording after transport stop\n";
         return false;
@@ -95,7 +96,7 @@ bool testUnarmedNoCapture() {
 
     // Even if we toggle record arm and start transport, no armed tracks = no capture
     tm->record();
-    tm->onTransportStateApplied(true, 0.0);
+    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
 
     // Since no tracks are armed, isRecording should be false
     if (tm->isRecording()) {
@@ -103,7 +104,8 @@ bool testUnarmedNoCapture() {
         return false;
     }
 
-    tm->onTransportStateApplied(false, 1.0);
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
+                                static_cast<double>(kSampleRate));
     tm->record(); // disarm
 
     std::cout << "PASSED\n";

--- a/Tests/AestraAudio/TransportPausePreservesPositionTest.cpp
+++ b/Tests/AestraAudio/TransportPausePreservesPositionTest.cpp
@@ -143,6 +143,16 @@ void enginePreservesPlayheadOnPause() {
     engine.processBlock(out.data(), nullptr, kFrames, 0.0);
     check(engine.getGlobalSamplePos() == seekPos,
           "an explicit stop/seek to a real position still moves the playhead");
+
+    // A seek immediately followed by a pause in the SAME command block must honor
+    // the seek: the sentinel resolves against the in-block accumulator, not the
+    // pre-block playhead, so the preceding seek is not reverted.
+    const uint64_t sameBlockSeek = seekPos + 500;
+    pushTransport(1.0f, sameBlockSeek);
+    pushTransport(0.0f, kTransportPreservePosition);
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    check(engine.getGlobalSamplePos() == sameBlockSeek,
+          "pause following a seek in the same block preserves the seek position");
 }
 
 } // namespace

--- a/Tests/AestraAudio/TransportPausePreservesPositionTest.cpp
+++ b/Tests/AestraAudio/TransportPausePreservesPositionTest.cpp
@@ -1,0 +1,158 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// TransportPausePreservesPositionTest — regression for #590.
+//
+// Pause must stop transport without rewinding. TrackManager::pause() historically
+// committed m_position (the UI-cached playhead, synced only at UI-frame cadence)
+// into the SetTransportState command. Under rapid pause/play toggling that cache
+// lags the audio thread by several buffers, so applying it moved the transport
+// backward and made the result depend on UI/audio timing.
+//
+// The fix: pause sends the kTransportPreservePosition sentinel; the audio thread
+// resolves it to its own authoritative m_globalSamplePos. This test pins both
+// halves — the producer emits the sentinel (not the stale UI position), and the
+// engine preserves the advanced playhead across a pause that follows several
+// audio callbacks of drift.
+
+#include "Core/AudioCommandQueue.h"
+#include "Core/AudioEngine.h"
+#include "Models/TrackManager.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::AudioEngine;
+using Aestra::Audio::AudioQueueCommand;
+using Aestra::Audio::AudioQueueCommandType;
+using Aestra::Audio::kTransportPreservePosition;
+using Aestra::Audio::TrackManager;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    std::cout << (condition ? "PASS: " : "FAIL: ") << label << "\n";
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+// --- Producer side: pause() must not commit the UI-cached position ------------
+//
+// This is the direct encoding of the reported bug: with a command sink capturing
+// the emitted transport command, a pause after the UI cache has fallen behind the
+// audio thread must carry the preserve sentinel, never the stale sample position.
+void producerPauseSendsPreserveSentinel() {
+    constexpr double kSampleRate = 48000.0;
+
+    TrackManager tm;
+    tm.setOutputSampleRate(kSampleRate);
+
+    AudioQueueCommand lastCmd{};
+    bool sawCommand = false;
+    tm.setCommandSink([&](const AudioQueueCommand& cmd) {
+        lastCmd = cmd;
+        sawCommand = true;
+    });
+
+    // Model UI lag: the audio thread has advanced well past the UI cache, but the
+    // UI-synced m_position still reflects an older sample position (2.0 s here).
+    // Pre-fix, pause() would send exactly this stale position.
+    const double stalePositionSeconds = 2.0;
+    tm.setPosition(stalePositionSeconds);
+    const uint64_t stalePositionSamples =
+        static_cast<uint64_t>(stalePositionSeconds * kSampleRate);
+
+    tm.pause();
+
+    check(sawCommand, "pause emits a transport command");
+    check(lastCmd.type == AudioQueueCommandType::SetTransportState,
+          "pause command is SetTransportState");
+    check(lastCmd.value1 == 0.0f, "pause command requests stop (playing = 0)");
+    check(lastCmd.samplePos == kTransportPreservePosition,
+          "pause carries the preserve-position sentinel");
+    // The heart of #590: the sentinel is NOT the stale UI-cached position.
+    check(lastCmd.samplePos != stalePositionSamples,
+          "pause does NOT commit the stale UI-cached sample position");
+
+    // The UI cache itself is left untouched by the pause echo — it is refreshed
+    // from the engine by syncPositionFromEngine, not clobbered by the sentinel.
+    tm.onTransportStateApplied(false, kTransportPreservePosition, kSampleRate);
+    check(tm.getPosition() == stalePositionSeconds,
+          "sentinel echo leaves the cached UI position unchanged");
+}
+
+// --- Consumer side: engine preserves the playhead across a paused block --------
+//
+// Drives real audio callbacks so the engine's authoritative playhead advances,
+// then applies the pause sentinel and asserts the playhead is preserved — the
+// end-to-end "no rewind under UI lag across multiple callbacks" guarantee.
+void enginePreservesPlayheadOnPause() {
+    constexpr uint32_t kFrames = 512;
+    constexpr uint32_t kChannels = 2;
+    constexpr uint32_t kSampleRate = 48000;
+    constexpr int kBlocksWhilePlaying = 8;
+
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "engine initializes");
+        return;
+    }
+    engine.setGlobalSamplePos(0);
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+    auto pushTransport = [&](float playing, uint64_t samplePos) {
+        AudioQueueCommand cmd{};
+        cmd.type = AudioQueueCommandType::SetTransportState;
+        cmd.value1 = playing;
+        cmd.samplePos = samplePos;
+        engine.commandQueue().push(cmd);
+    };
+
+    // Start playing from 0, then run several callbacks so the playhead advances.
+    pushTransport(1.0f, 0);
+    for (int i = 0; i < kBlocksWhilePlaying; ++i) {
+        engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    }
+    const uint64_t advancedPos = engine.getGlobalSamplePos();
+    check(advancedPos >= static_cast<uint64_t>(kFrames) * kBlocksWhilePlaying,
+          "playhead advanced across multiple audio callbacks");
+
+    // Pause using the preserve sentinel — as TrackManager::pause() now does. The
+    // engine must keep its own advanced playhead rather than seek anywhere.
+    pushTransport(0.0f, kTransportPreservePosition);
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    check(engine.getGlobalSamplePos() == advancedPos,
+          "pause with the sentinel preserves the engine playhead (no rewind)");
+    check(!engine.isTransportPlaying(), "pause stops transport");
+
+    // A paused engine does not advance on subsequent callbacks.
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    check(engine.getGlobalSamplePos() == advancedPos,
+          "playhead stays put while paused");
+
+    // A genuine seek (a real absolute position, not the sentinel) still applies —
+    // the sentinel path must not swallow ordinary stop/seek commands.
+    const uint64_t seekPos = 1000;
+    pushTransport(0.0f, seekPos);
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    check(engine.getGlobalSamplePos() == seekPos,
+          "an explicit stop/seek to a real position still moves the playhead");
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Transport Pause Preserves Position (#590) ===\n";
+    producerPauseSendsPreserveSentinel();
+    enginePreservesPlayheadOnPause();
+
+    std::cout << (g_failures == 0 ? "ALL PASSED\n"
+                                  : "FAILURES: " + std::to_string(g_failures) + "\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2245,6 +2245,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DCBlockerTest.cpp")
     set_tests_properties(DCBlockerTest PROPERTIES LABELS "audio;dsp;dc-removal")
 endif()
 
+# Transport pause preserves the authoritative playhead (#590)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TransportPausePreservesPositionTest.cpp")
+    add_executable(TransportPausePreservesPositionTest AestraAudio/TransportPausePreservesPositionTest.cpp)
+    target_link_libraries(TransportPausePreservesPositionTest PRIVATE AestraAudio)
+    target_include_directories(TransportPausePreservesPositionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME TransportPausePreservesPositionTest COMMAND TransportPausePreservesPositionTest)
+    set_tests_properties(TransportPausePreservesPositionTest PROPERTIES LABELS "audio;engine;transport;rt-safety")
+endif()
+
 # AudioEngine Diagnostics Test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineDiagnosticsTest.cpp")
     add_executable(AudioEngineDiagnosticsTest AestraAudio/AudioEngineDiagnosticsTest.cpp)


### PR DESCRIPTION
## Summary
`TrackManager::pause()` committed `m_position` — the UI-cached playhead, synced from the engine only at UI-frame cadence — into its `SetTransportState` command. Under rapid pause/play toggling that cache lags the audio thread by several buffers, so the audio thread applied an older sample position and **moved the transport backward**, with the result depending on UI/audio timing. Fixes #590.

## Why / approach
Pause is now a **stop-in-place**. It sends a `kTransportPreservePosition` sentinel (`UINT64_MAX` — unreachable as a real seek, ~12M years at 48 kHz). The audio thread resolves the sentinel to its own authoritative `m_globalSamplePos` instead of seeking, and the UI-side echo leaves the cached position untouched (`syncPositionFromEngine` refreshes it from the engine). Explicit stop/seek still carry a real position and apply normally.

- Composes with #591 (which already made `transportPos` read the engine authority for edge detection) — the sentinel resolves to that same authority, so a pause-in-place is correctly **not** treated as a seek edge.
- Callback path stays **lock-free and allocation-free** (a single atomic load).
- Transport authority stays in the engine; the UI never becomes the source of truth.
- `onTransportStateApplied` now takes the raw sample position + sample rate so the sentinel check and the seconds conversion live in one place; both command sinks (`AestraContent`, `MuseService::wireHeadlessEngine`) pass unchanged values through.

## Testing performed
- **New:** `TransportPausePreservesPositionTest` pins both halves:
  - *Producer:* with a command sink and a stale UI-cached position, `pause()` emits the sentinel, **not** the stale sample position; the sentinel echo leaves the cached position unchanged.
  - *Consumer:* drives real `processBlock` callbacks so the engine playhead advances, then applies the pause sentinel and asserts the playhead is **preserved** (no rewind), stays put while paused, and that an explicit stop/seek to a real position still moves it.
- **Verified it encodes the bug:** reverted both production edits — exactly the 4 fix-dependent assertions fail while the command-emission / stop / real-seek invariants still pass — then restored the fix and all pass.
- `RecordingPathTest` updated for the new `onTransportStateApplied` signature.
- Broader sweep green: 20/20 across `Transport|Playback|AudioEngine|Recording|Muse|Automation|OfflineRender`.

## Docs updated?
Doc comments on `pause()`, `onTransportStateApplied`, and the new `kTransportPreservePosition` sentinel / `pushTransportCommandSamples` helper.

## Risk / rollback
Touches the RT transport-application path — reviewed for lock-free/alloc-free safety (single atomic load, no new allocations/locks). The sentinel is unambiguous vs. any real seek. Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Preserve the audio thread’s authoritative playhead when pausing by introducing a `UINT64_MAX` transport sentinel, preventing rewinds caused by stale UI positions.
- Update transport callbacks and command forwarding to carry raw sample positions and sample rates, while keeping explicit stop/seek positions unchanged.
- Keep the transport callback lock-free and allocation-free.
- Add regression coverage for stale UI positions, pause stability, audio-thread advancement, and explicit stop/seek behavior.
- Update recording-path tests and register the new transport test with CTest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->