### PR TITLE
fix(ui): select track when clicking the seam between track rows

### DIFF
--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -572,6 +572,11 @@ private:
     bool handleLoopMarkerDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handlePlayheadDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handleSplitToolClick(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
+    // Rows render m_trackHeight tall on an m_trackHeight+m_trackSpacing stride,
+    // leaving an m_trackSpacing-px seam between them that lands inside no track's
+    // bounds. Map an otherwise-unhandled left press in that seam back to its row
+    // and select it, so clicks between rows are not silently swallowed.
+    bool handleTrackSeamSelect(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     void renderMinimapResizeCursor(::AestraUI::NUIRenderer& renderer, const ::AestraUI::NUIPoint& position);
 
     // Split tool

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -172,7 +172,66 @@ bool TrackManagerUI::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         return true;
     }
 
+    // Close the inter-row seam: a left press between two rows reaches here
+    // unhandled (it is inside no track's bounds). Split has its own gap-free
+    // mapping above, so this only needs to cover ordinary selection.
+    if (handleTrackSeamSelect(event, localPos)) {
+        return true;
+    }
+
     return handled;
+}
+
+bool TrackManagerUI::handleTrackSeamSelect(const AestraUI::NUIMouseEvent& event,
+                                           const AestraUI::NUIPoint& localPos) {
+    if (!m_playlistVisible || !event.pressed || event.button != AestraUI::NUIMouseButton::Left) {
+        return false;
+    }
+    // Split owns seam clicks in split mode (handleSplitToolClick already ran).
+    if (m_currentTool == PlaylistTool::Split) {
+        return false;
+    }
+
+    const float headerHeight = kTimelineHeaderHeight;
+    const float rulerHeight = kTimelineRulerHeight;
+    const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
+    const float trackAreaTop = headerHeight + horizontalScrollbarHeight + rulerHeight;
+    if (localPos.y < trackAreaTop) {
+        return false; // header / ruler / horizontal scrollbar
+    }
+
+    const float stride = static_cast<float>(m_trackHeight + m_trackSpacing);
+    if (stride <= 0.0f) {
+        return false;
+    }
+    const float relativeY = localPos.y - trackAreaTop + m_scrollOffset;
+    if (relativeY < 0.0f) {
+        return false;
+    }
+    const int idx = static_cast<int>(relativeY / stride);
+    if (idx < 0 || idx >= static_cast<int>(m_trackUIComponents.size())) {
+        return false;
+    }
+
+    auto& trackUI = m_trackUIComponents[idx];
+    if (!trackUI || !trackUI->isVisible()) {
+        return false;
+    }
+    // Only genuine seam clicks reach here; inside the row the child consumes it.
+    const AestraUI::NUIRect tb = trackUI->getBounds();
+    if (tb.contains(event.position)) {
+        return false;
+    }
+    // Stay within the row's horizontal extent (exclude the scrollbar gutter).
+    if (event.position.x < tb.x || event.position.x > tb.x + tb.width) {
+        return false;
+    }
+
+    const bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
+                       (event.modifiers & AestraUI::NUIModifiers::CapsLock);
+    selectTrack(trackUI.get(), shift);
+    invalidateCache();
+    return true;
 }
 
 void TrackManagerUI::updateToolbarHover(const AestraUI::NUIMouseEvent& event) {


### PR DESCRIPTION
## Bug
Clicking on a track sometimes did nothing — intermittently, at seemingly random spots. Reported as "track 5/6 sometimes don't click."

## Root cause (instrumented)
Track rows render `m_trackHeight` (46px) tall on an `m_trackHeight + m_trackSpacing` (49px) **stride**, so there is a **3px seam between every pair of rows** that lands inside *no* `TrackUIComponent`'s bounds. A left press in a seam is handled by no child (`NUIComponent::onMouseEvent` returns `handled=0`) and selects nothing.

Instrumenting the click path confirmed it — e.g. a press at y=667 falling between rows `[620.5, 666.5]` and `[669.5, 715.5]` registered a track hit with no selection. Nothing special about tracks 5/6; it reproduces at any row boundary (observed at the 3/4 and 10/11 seams).

## Fix
`handleTrackSeamSelect`: an otherwise-unhandled left press in the track lane is mapped back to its row via the existing stride formula (`relativeY / (m_trackHeight + m_trackSpacing)`) and selects it. Guards:
- only the `Select`-family tools (Split already has its own gap-free stride mapping);
- only genuine seam presses (a press inside a row's bounds is consumed by the child before reaching here);
- constrained to the row's horizontal extent (excludes the scrollbar gutter).

## Validation
- `Aestra` app target builds clean (`-j2`).
- Verified in-app with a temporary trace (since removed): a former dead click at (352,471) now routes to `SEAM-SELECT` and selects the row; zero remaining dead clicks in the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed track selection when clicking the 3px seams between track rows.
- Added fallback handling for otherwise-unhandled left-clicks, mapping seam clicks to the corresponding track row.
- Limited the behavior to Select-family tools, excluding clicks within row bounds and the scrollbar gutter; Split behavior remains unchanged.
- Supports Shift/CapsLock multi-selection and refreshes the track cache after selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->