### PR TITLE
fix(ui): pencil/split tool no longer double-renders with the arrow cursor

### DIFF
--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -109,9 +109,15 @@ bool TrackManagerUI::isCustomCursorActive() const {
         }
     }
 
-    // 2. Split or Paint tool in grid area
+    // 2. Split or Paint tool in grid area.
+    // Use getBounds() (not getGlobalBounds()) so this suppression region shares
+    // the exact coordinate basis renderToolCursor()/renderMinimapResizeCursor()
+    // draw in. m_lastMousePos is window-space and this component's bounds are
+    // already window-absolute, so getGlobalBounds() double-counts the parent
+    // offset and shifts the region down, leaving a top strip where the arrow is
+    // not suppressed while the tool cursor still draws (both cursors visible).
     if (m_currentTool == PlaylistTool::Split || m_currentTool == PlaylistTool::Paint) {
-        AestraUI::NUIRect bounds = getGlobalBounds();
+        AestraUI::NUIRect bounds = getBounds();
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;


### PR DESCRIPTION
## Bug
With the pencil (Paint) or Split tool active, a strip along the **top of the clip grid** rendered *both* the tool cursor and the arrow cursor at once.

## Root cause (instrumented)
Three cursor code paths compute "the grid region", but on different coordinate bases:
- `renderToolCursor()` and `renderMinimapResizeCursor()` — draw the tool cursor, use **`getBounds()`**, hit-test against the window-space mouse.
- `isCustomCursorActive()` — tells the window manager to suppress the software arrow, used **`getGlobalBounds()`**.

`TrackManagerUI`'s bounds are already window-absolute, so `getGlobalBounds()` walks the parent chain and **double-counts the parent offset**. Instrumenting both authorities showed the suppression rect at top `y=210` and the tool rect at top `y=178` — a **32px band** where the tool drew the pencil but the arrow was not suppressed → both visible.

## Fix
Use `getBounds()` in `isCustomCursorActive()` so all three cursor paths share one coordinate basis.

## Validation
- `Aestra` app builds clean (`-j2`).
- Re-instrumented after the fix: the two rects now agree exactly (both top `y=178`), **zero** disagreement events across the former band, and no mouse position renders both cursors. Trace since removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)