### PR TITLE
perf(audio): move blocking audio-startup work off the UI thread (mlockall + cycle-Hz)

### DIFF
--- a/AestraAudio/src/Linux/RtAudioDriver.cpp
+++ b/AestraAudio/src/Linux/RtAudioDriver.cpp
@@ -164,6 +164,9 @@ void RtAudioDriver::closeStream() {
 
 #ifdef __linux__
     stopRealtimePriorityWorker();
+    if (m_memLockWorker.joinable()) {
+        m_memLockWorker.join();
+    }
 #endif
     if (m_rtAudio->isStreamRunning()) {
         stopStream();
@@ -197,14 +200,25 @@ bool RtAudioDriver::startStream() {
     if (m_telemetry) {
         m_telemetry->clearThreadPriorityStatus();
     }
-    // mlockall is process-wide and can be requested from the starter thread.
-    if (mlockall(MCL_CURRENT | MCL_FUTURE) == 0) {
-        if (m_telemetry) {
-            m_telemetry->setThreadPriorityBit(0x02); // mlockall success
-        }
-    } else if (m_telemetry) {
-        m_telemetry->updateLinuxRtPriorityErrno(errno);
+    // mlockall(MCL_CURRENT | MCL_FUTURE) locks every resident page and pre-faults
+    // future ones; on a large process (plugins, GL, UI) it costs 0.3-4s and was
+    // blocking the UI thread that starts the stream, freezing startup. The audio
+    // device itself starts in microseconds, so lock memory asynchronously: the
+    // stream goes live immediately and the lock lands shortly after (the RT
+    // callback only risks a few page-fault glitches in that brief window). The
+    // worker is joined in closeStream(), so it never outlives the driver.
+    if (m_memLockWorker.joinable()) {
+        m_memLockWorker.join();
     }
+    m_memLockWorker = std::thread([this]() {
+        if (mlockall(MCL_CURRENT | MCL_FUTURE) == 0) {
+            if (m_telemetry) {
+                m_telemetry->setThreadPriorityBit(0x02); // mlockall success
+            }
+        } else if (m_telemetry) {
+            m_telemetry->updateLinuxRtPriorityErrno(errno);
+        }
+    });
 #endif
 
     RtAudioErrorType error = m_rtAudio->startStream();

--- a/AestraAudio/src/Linux/RtAudioDriver.h
+++ b/AestraAudio/src/Linux/RtAudioDriver.h
@@ -68,6 +68,10 @@ private:
     std::atomic<uintptr_t> m_audioThreadToken{0};
     std::atomic<bool> m_rtPriorityWorkerStop{false};
     std::thread m_rtPriorityWorker;
+    // mlockall() locks every resident page + pre-faults future ones (0.3-4s on a
+    // large process). Run it off the UI thread that starts the stream; joined in
+    // closeStream() so it never outlives the driver.
+    std::thread m_memLockWorker;
 #endif
     DriverStatistics m_stats;
     std::string m_lastError;

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -189,6 +189,11 @@ void AestraAudioController::shutdown() {
         stopStream();
         closeStream();
     }
+    // Join the cycle-Hz calibration worker before tearing down the engine it
+    // writes telemetry into.
+    if (m_cycleHzWorker.joinable()) {
+        m_cycleHzWorker.join();
+    }
     if (m_audioEngine) {
         m_audioEngine->drainDeferredResourcesForShutdown();
     }
@@ -351,11 +356,19 @@ bool AestraAudioController::startStream() {
             }
         }, this);
 
-        // Setup Telemetry
-        const uint64_t hz = estimateCycleHz();
-        if (hz > 0) {
-            m_audioEngine->telemetry().cycleHz.store(hz, std::memory_order_relaxed);
+        // Setup Telemetry. estimateCycleHz() sleeps 50ms to calibrate the TSC
+        // frequency, and it only feeds diagnostics — so compute it off this
+        // (UI) thread that starts the stream. shutdown() joins the worker before
+        // m_audioEngine is destroyed, so the telemetry target stays valid.
+        if (m_cycleHzWorker.joinable()) {
+            m_cycleHzWorker.join();
         }
+        m_cycleHzWorker = std::thread([this]() {
+            const uint64_t hz = estimateCycleHz();
+            if (hz > 0 && m_audioEngine) {
+                m_audioEngine->telemetry().cycleHz.store(hz, std::memory_order_relaxed);
+            }
+        });
 
         m_audioEngine->loadMetronomeClicks(
             "AestraAudio/assets/Aestra_metronome.wav",

--- a/Source/Core/AestraAudioController.h
+++ b/Source/Core/AestraAudioController.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 // Forward declarations
@@ -65,6 +66,11 @@ private:
     Aestra::Audio::AudioStreamConfig m_streamConfig;
     bool m_initialized{false};
     bool m_isAudioRunning{false};
+
+    // estimateCycleHz() sleeps 50ms to calibrate the TSC frequency for telemetry
+    // only; it runs on this worker so it never blocks the UI thread that starts
+    // the stream. Joined in shutdown() before m_audioEngine is destroyed.
+    std::thread m_cycleHzWorker;
 
     // Weak UI reference plus atomically published ownership for callback routing.
     std::weak_ptr<AestraContent> m_content;


### PR DESCRIPTION
## Symptom
"Deferred audio stream start" was slow and wildly inconsistent — **0.5–1.7s, spiking to ~4s** — and froze the window shortly after it appeared. Found while profiling startup.

## Root cause (instrumented, sub-step timed)
The entire cost was two synchronous calls on the UI thread in the audio-start path:

| sub-step | typical |
|---|---|
| **mlockall(MCL_CURRENT \| MCL_FUTURE)** | **330–1440ms (→ ~4s)** |
| **estimateCycleHz** (fixed 50ms sleep) | **50ms** |
| rtAudio->startStream (actual device start) | 0.01ms |
| getDevices / openStream / connectAudioToUI | 7 / 130 / 0ms |

- `mlockall` locks every resident page + pre-faults future ones; on a large process (200+ plugins, GL, UI) that's 0.3–4s and scales with memory pressure — worst on the 4 GB target.
- `estimateCycleHz` sleeps 50ms to calibrate the TSC frequency for telemetry/HUD only.

Both ran synchronously on the UI thread that starts the stream → multi-second freeze.

## Fix
Move both off the UI thread onto joinable workers, each joined at teardown so they never outlive their targets:
- `mlockall` → `m_memLockWorker` in `RtAudioDriver`, joined in `closeStream()` (mirrors the existing `m_rtPriorityWorker`).
- `estimateCycleHz` → `m_cycleHzWorker` in `AestraAudioController`, joined in `shutdown()` before `m_audioEngine` is destroyed.

The audio device itself starts in microseconds, so the stream goes live immediately; the workers land shortly after. The RT callback only risks a few page-fault glitches before the lock completes — a far better trade than a multi-second UI freeze.

## Result
Deferred audio start: **~130–185ms typical** (down from 0.5–4s), and the multi-second freeze is gone. The remaining floor is `openStream` (~130ms device-open); moving that off-thread would need threading the whole audio-open (engine/content setup) and is intentionally out of scope here.

Verified by running the app repeatedly and reading the permanent `[Startup] Deferred audio stream start` timer; sub-step timing captured with temporary instrumentation (removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)