### PR TITLE
fix(plugin): deliver host parameter changes to out-of-process plugins (#238)

### DIFF
--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -59,6 +59,11 @@ public:
     bool isBypassedByWatchdog() const override;
     bool isCrashed() const override { return m_crashed.load(std::memory_order_acquire); }
 
+    // Number of parameter changes dropped because the queue was full. Non-zero
+    // means setParameter outran the worker's drain — surfaced for diagnostics and
+    // tests since setParameter itself is void (#238).
+    uint64_t parameterDropCount() const { return m_paramDrops.load(std::memory_order_relaxed); }
+
 private:
     bool sendCommand(const std::string& command, std::string* response = nullptr,
                      std::chrono::milliseconds timeout = std::chrono::milliseconds(500));
@@ -118,7 +123,13 @@ private:
         uint32_t id{0};
         float value{0.0f};
     };
-    static constexpr size_t kParamQueueCapacity = 512;
+    // Sized to comfortably absorb a full-preset burst (hundreds of distinct
+    // parameters applied in a tight loop) before the worker drains it.
+    static constexpr size_t kParamQueueCapacity = 4096;
+    // Cap per worker pass so a large burst against a slow child cannot monopolize
+    // the worker and starve PROCESS (which would make the RT callback fall back to
+    // audible passThrough). The remainder stays queued for the next pass.
+    static constexpr size_t kMaxParamDrainPerPass = 64;
     LockFreeRingBuffer<ParamChange, kParamQueueCapacity> m_paramQueue;
     std::atomic<uint64_t> m_paramDrops{0};
 

--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -3,6 +3,8 @@
 
 #include "PluginHost.h"
 
+#include "AestraThreading.h"
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -100,6 +102,27 @@ private:
     std::atomic<uint32_t> m_readyFrames{0};
     std::atomic<uint8_t> m_pendingState{0};
     std::atomic<uint8_t> m_readyState{0};
+
+    // Host->child parameter changes. setParameter() only pushes onto this
+    // lock-free queue (no IPC, no lock, no allocation, never blocks); the worker
+    // thread (single consumer) drains it and forwards each change to the child as
+    // an ordered SETPARAM command, keeping the realtime callback free of parameter
+    // IPC (#238). The ring is SPSC: setParameter must be called from one producer
+    // thread. Today that is the UI/message thread — automation gates plugin-
+    // parameter curves to Internal-format plugins in AudioEngine, so the render
+    // thread never reaches OOP setParameter. Because the push itself never blocks,
+    // a future single RT producer (e.g. third-party automation, #467) would remain
+    // realtime-safe; adding a *second* concurrent producer would require an MPSC
+    // queue instead.
+    struct ParamChange {
+        uint32_t id{0};
+        float value{0.0f};
+    };
+    static constexpr size_t kParamQueueCapacity = 512;
+    LockFreeRingBuffer<ParamChange, kParamQueueCapacity> m_paramQueue;
+    std::atomic<uint64_t> m_paramDrops{0};
+
+    void drainParamQueueToChild();
 };
 
 } // namespace Audio

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -150,7 +150,7 @@ struct ClapEventParamValue {
     ClapEventHeader header;
     uint32_t paramId;
     void* cookie;
-    int16_t noteId;
+    int32_t noteId; // clap_event_param_value_t::note_id is int32_t (not int16_t)
     int16_t portIndex;
     int16_t channel;
     int16_t key;

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -1,6 +1,8 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
@@ -142,6 +144,21 @@ struct ClapEventMidi {
     uint8_t data[3];
 };
 
+// clap_event_param_value ABI (clap/events.h). Host-driven parameter changes are
+// delivered to a CLAP plugin as this event through params.flush() (#238).
+struct ClapEventParamValue {
+    ClapEventHeader header;
+    uint32_t paramId;
+    void* cookie;
+    int16_t noteId;
+    int16_t portIndex;
+    int16_t channel;
+    int16_t key;
+    double value;
+};
+
+constexpr uint16_t kClapEventParamValue = 5;
+
 struct ClapOstream {
     void* ctx;
     int64_t (*write)(const ClapOstream* stream, const void* buffer, uint64_t size);
@@ -223,6 +240,19 @@ bool dropOutputEvent(const ClapOutputEvents* list, const ClapEventHeader* event)
     (void)list;
     (void)event;
     return true;
+}
+
+// Single clap_event_param_value input list, used to deliver a host-driven
+// parameter change to a CLAP plugin via params.flush() (#238).
+uint32_t singleParamEventSize(const ClapInputEvents* list) {
+    return (list && list->ctx) ? 1u : 0u;
+}
+
+const ClapEventHeader* singleParamEventGet(const ClapInputEvents* list, uint32_t index) {
+    if (!list || !list->ctx || index != 0) {
+        return nullptr;
+    }
+    return &static_cast<const ClapEventParamValue*>(list->ctx)->header;
 }
 
 int64_t writeStateStream(const ClapOstream* stream, const void* buffer, uint64_t size) {
@@ -438,6 +468,37 @@ struct ClapModule {
             }
         }
         active = false;
+    }
+
+    // Deliver a host-driven parameter change to the plugin. CLAP has no direct
+    // setter; the host queues a param-value event and calls params.flush(), which
+    // the plugin applies on its main thread (#238). Returns false if the plugin
+    // has no params extension or the id is out of range.
+    bool setParameter(uint32_t paramId, double value) {
+        if (!plugin || !paramsExt || !paramsExt->flush) {
+            return false;
+        }
+        if (paramsExt->count && paramId >= paramsExt->count(plugin)) {
+            return false;
+        }
+        ClapEventParamValue event{};
+        event.header.size = sizeof(event);
+        event.header.time = 0;
+        event.header.spaceId = kClapCoreEventSpaceId;
+        event.header.type = kClapEventParamValue;
+        event.header.flags = 0;
+        event.paramId = paramId;
+        event.cookie = nullptr;
+        event.noteId = -1;
+        event.portIndex = -1;
+        event.channel = -1;
+        event.key = -1;
+        event.value = value;
+
+        ClapInputEvents inEvents = {&event, singleParamEventSize, singleParamEventGet};
+        ClapOutputEvents outEvents = {nullptr, dropOutputEvent};
+        paramsExt->flush(plugin, &inEvents, &outEvents);
+        return true;
     }
 
     bool process(const std::vector<float>& interleavedInput, uint32_t channels, uint32_t frames,
@@ -845,6 +906,16 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> midiBuffer;
     std::vector<uint8_t> stateBuffer;
     std::string line;
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+    // The __aestra_test_echo__ fake plugin has no real module; it records applied
+    // parameters so tests can prove host->child parameter delivery end to end.
+    // Parameter 0 is treated as an output gain applied to the echoed audio, so a
+    // test can observe the change behaviorally rather than trusting a log (#238).
+    bool echoPlugin = false;
+    std::array<float, 16> echoParams{};
+    echoParams.fill(0.0f);
+    echoParams[0] = 1.0f; // unity gain until set
+#endif
 #ifndef _WIN32
     ClapModule clapModule;
 #endif
@@ -946,6 +1017,9 @@ int main(int argc, char** argv) {
             }
 #endif
             loaded = true;
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+            echoPlugin = (id == "__aestra_test_echo__");
+#endif
             reply("OK LOADED");
         } else if (command == "INIT") {
             if (!loaded) {
@@ -999,6 +1073,46 @@ int main(int argc, char** argv) {
             vst3Module.deactivate();
 #endif
             reply("OK INACTIVE");
+        } else if (command == "SETPARAM") {
+            if (!loaded) {
+                reply("ERR not-loaded");
+                continue;
+            }
+            uint32_t paramId = 0;
+            double value = 0.0;
+            if (!(input >> paramId >> value)) {
+                reply("ERR invalid-setparam");
+                continue;
+            }
+            if (!std::isfinite(value)) {
+                reply("ERR non-finite-value");
+                continue;
+            }
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+            if (echoPlugin) {
+                if (paramId >= echoParams.size()) {
+                    reply("ERR param-id-out-of-range");
+                    continue;
+                }
+                echoParams[paramId] = static_cast<float>(value);
+                reply("OK SETPARAM");
+                continue;
+            }
+#endif
+#ifndef _WIN32
+            if (clapModule.plugin) {
+                reply(clapModule.setParameter(paramId, value) ? "OK SETPARAM" : "ERR setparam-failed");
+                continue;
+            }
+#endif
+#ifdef AESTRA_HAS_VST3
+            if (vst3Module.plugin) {
+                vst3Module.plugin->setParameter(paramId, static_cast<float>(value));
+                reply("OK SETPARAM");
+                continue;
+            }
+#endif
+            reply("ERR no-plugin");
         } else if (command == "SAVESTATE") {
             if (!loaded) {
                 reply("ERR not-loaded");
@@ -1132,6 +1246,16 @@ int main(int argc, char** argv) {
 #endif
 
             const size_t byteCount = static_cast<size_t>(channels) * frames * sizeof(float);
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+            // Echo fake plugin: apply parameter 0 as an output gain so a test can
+            // observe host->child parameter delivery through the audio itself (#238).
+            if (echoPlugin && echoParams[0] != 1.0f) {
+                const size_t sampleCount = static_cast<size_t>(channels) * frames;
+                for (size_t i = 0; i < sampleCount && i < processBuffer.size(); ++i) {
+                    processBuffer[i] *= echoParams[0];
+                }
+            }
+#endif
             reply("OK " + hexEncodeBytes(processBuffer.data(), byteCount));
         } else {
             reply("ERR unknown-command");

--- a/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
+++ b/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
@@ -469,8 +469,36 @@ float OutOfProcessPluginInstance::getParameter(uint32_t id) const {
 }
 
 void OutOfProcessPluginInstance::setParameter(uint32_t id, float value) {
-    (void)id;
-    (void)value;
+    // Non-blocking by design: enqueue and return. No IPC, lock, or allocation
+    // here. The worker thread forwards the change to the child in order (#238).
+    // The queue is single-producer (see the header) — call from one thread. A
+    // full queue drops the newest change (a later setParameter for the same id
+    // supersedes it anyway) and bumps a diagnostic counter rather than blocking.
+    if (!m_paramQueue.push(ParamChange{id, value})) {
+        m_paramDrops.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+void OutOfProcessPluginInstance::drainParamQueueToChild() {
+    // Worker-thread only. Bounded: at most kParamQueueCapacity entries exist, and
+    // no producer can outpace an unbounded drain here because push is O(1). Each
+    // change is a single SETPARAM round-trip on the IPC channel this thread owns.
+    ParamChange change;
+    while (m_paramQueue.pop(change)) {
+        std::ostringstream command;
+        command << "SETPARAM " << change.id << " " << change.value;
+        std::string response;
+        if (!sendCommand(command.str(), &response) || response.find("OK") != 0) {
+            // A dead/unresponsive child fails the whole instance safely; a plugin
+            // that rejects one parameter (ERR) is logged but does not crash us.
+            if (!m_process || !m_process->isRunning()) {
+                markCrashed();
+                return;
+            }
+            Log::warning("[PluginHost] SETPARAM rejected for " + m_info.name + " (id=" +
+                         std::to_string(change.id) + ")");
+        }
+    }
 }
 
 std::string OutOfProcessPluginInstance::getParameterDisplay(uint32_t id) const {
@@ -585,6 +613,15 @@ void OutOfProcessPluginInstance::workerLoop() {
     while (!m_workerStop.load(std::memory_order_acquire)) {
         if (m_crashed.load(std::memory_order_acquire)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        // Forward any queued parameter changes to the child first, so a change
+        // requested before this block takes effect for it. Runs every iteration
+        // (even with no audio pending) so knob moves apply while transport is
+        // stopped too (#238).
+        drainParamQueueToChild();
+        if (m_crashed.load(std::memory_order_acquire)) {
             continue;
         }
 

--- a/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
+++ b/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
@@ -472,19 +472,24 @@ void OutOfProcessPluginInstance::setParameter(uint32_t id, float value) {
     // Non-blocking by design: enqueue and return. No IPC, lock, or allocation
     // here. The worker thread forwards the change to the child in order (#238).
     // The queue is single-producer (see the header) — call from one thread. A
-    // full queue drops the newest change (a later setParameter for the same id
-    // supersedes it anyway) and bumps a diagnostic counter rather than blocking.
+    // full queue drops the newest change and bumps a diagnostic counter
+    // (parameterDropCount) rather than blocking; the first drop is logged so the
+    // loss is observable instead of silent.
     if (!m_paramQueue.push(ParamChange{id, value})) {
-        m_paramDrops.fetch_add(1, std::memory_order_relaxed);
+        if (m_paramDrops.fetch_add(1, std::memory_order_relaxed) == 0) {
+            Log::warning("[PluginHost] parameter queue full for " + m_info.name +
+                         "; dropping changes (raise kParamQueueCapacity if this recurs)");
+        }
     }
 }
 
 void OutOfProcessPluginInstance::drainParamQueueToChild() {
-    // Worker-thread only. Bounded: at most kParamQueueCapacity entries exist, and
-    // no producer can outpace an unbounded drain here because push is O(1). Each
-    // change is a single SETPARAM round-trip on the IPC channel this thread owns.
+    // Worker-thread only. Each change is a single SETPARAM round-trip on the IPC
+    // channel this thread owns. Bounded per pass (kMaxParamDrainPerPass) so a big
+    // burst against a slow child cannot starve PROCESS; the remainder drains on
+    // the next worker iteration, in order.
     ParamChange change;
-    while (m_paramQueue.pop(change)) {
+    for (size_t drained = 0; drained < kMaxParamDrainPerPass && m_paramQueue.pop(change); ++drained) {
         std::ostringstream command;
         command << "SETPARAM " << change.id << " " << change.value;
         std::string response;

--- a/tests/security/out_of_process_plugin_host.cpp
+++ b/tests/security/out_of_process_plugin_host.cpp
@@ -133,6 +133,76 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // --- Host->child parameter delivery (#238) --------------------------------
+    // setParameter must reach the child and be applied to the hosted plugin. The
+    // echo helper treats parameter 0 as an output gain, so a delivered change is
+    // observable in the returned audio, not just a recorded log. Parameter changes
+    // flow through a lock-free queue drained by the proxy's worker thread, so a
+    // settle interval is needed (matching the process double-buffer above).
+    const float paramIn[4] = {0.4f, 0.5f, 0.6f, 0.7f};
+    const float* paramInputs[2] = {paramIn, paramIn};
+
+    instance->setParameter(0, 0.5f); // half gain
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::memset(outL, 0, sizeof(outL));
+    std::memset(outR, 0, sizeof(outR));
+    instance->process(paramInputs, outputs, 2, 2, 4); // submit block under the new gain
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    instance->process(paramInputs, outputs, 2, 2, 4); // retrieve the gained block
+    for (int i = 0; i < 4; ++i) {
+        const float expected = paramIn[i] * 0.5f;
+        if (std::fabs(outL[i] - expected) > 1e-5f || std::fabs(outR[i] - expected) > 1e-5f) {
+            std::cerr << "parameter change did not reach and gain the child plugin (frame " << i
+                      << ": got " << outL[i] << " expected " << expected << ")\n";
+            return 1;
+        }
+    }
+
+    // Successive changes arrive in order — the last write to a parameter wins.
+    instance->setParameter(0, 0.25f);
+    instance->setParameter(0, 0.75f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::memset(outL, 0, sizeof(outL));
+    std::memset(outR, 0, sizeof(outR));
+    instance->process(paramInputs, outputs, 2, 2, 4);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    instance->process(paramInputs, outputs, 2, 2, 4);
+    for (int i = 0; i < 4; ++i) {
+        const float expected = paramIn[i] * 0.75f;
+        if (std::fabs(outL[i] - expected) > 1e-5f) {
+            std::cerr << "ordered parameter changes did not settle on the last value (frame " << i
+                      << ": got " << outL[i] << " expected " << expected << ")\n";
+            return 1;
+        }
+    }
+
+    // An out-of-range parameter id is rejected by the child but must not crash the
+    // proxy: the change is dropped and the instance keeps working.
+    instance->setParameter(99999u, 0.5f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    if (instance->isCrashed()) {
+        std::cerr << "out-of-range parameter id crashed the isolated plugin proxy\n";
+        return 1;
+    }
+    // Restore unity gain and confirm the proxy still processes after the bad id.
+    instance->setParameter(0, 1.0f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    std::memset(outL, 0, sizeof(outL));
+    std::memset(outR, 0, sizeof(outR));
+    instance->process(paramInputs, outputs, 2, 2, 4);
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    instance->process(paramInputs, outputs, 2, 2, 4);
+    if (instance->isCrashed()) {
+        std::cerr << "isolated plugin proxy did not survive parameter stress\n";
+        return 1;
+    }
+    for (int i = 0; i < 4; ++i) {
+        if (std::fabs(outL[i] - paramIn[i]) > 1e-5f) {
+            std::cerr << "unity gain not restored after out-of-range parameter id\n";
+            return 1;
+        }
+    }
+
     auto missingVst3 = create(factory, makeInfo("com.aestra.missing-vst3"));
     if (missingVst3) {
         std::cerr << "missing real VST3 plugin should not fall back to echo processing\n";


### PR DESCRIPTION
## Summary
`OutOfProcessPluginInstance::setParameter()` was a no-op. Since `HybridPluginFactory` routes **all** third-party VST3/CLAP plugins out-of-process, host-driven parameter changes (knob moves, preset-applied params) never reached the plugin. Fixes #238.

## Threading investigation (done first, per request)
- `setParameter` on an OOP instance is reached **only from non-RT threads**. The one render-thread caller — automation at `AudioEngine.cpp:2875` — is **gated to `PluginFormat::Internal`** (line 2872), so OOP plugins are skipped on the audio thread. The `AutomationCurve` comment documents this exactly ("third-party formats need host param queues").
- The RT `process()` never does IPC; it hands off to a **host-side worker thread** that owns the (blocking) line-protocol IPC to the forked child. That worker is the right place to forward parameters.

## Design (non-blocking, narrow)
- `setParameter()` pushes `{id, value}` onto a **lock-free SPSC ring** and returns — no IPC, lock, or allocation on the caller, so it never blocks (satisfies the RT-safety requirement even though it isn't RT-reachable today; a future single RT producer for #467 stays safe).
- The **worker thread drains the queue in order** and sends a new `SETPARAM <id> <value>` command before each block (and while transport is stopped). A full queue drops the newest change (superseded anyway) and counts the drop; a dead child fails the instance safely (`markCrashed`).
- **Child** (`AestraPluginHostMain`) gains a `SETPARAM` handler: VST3 via the existing `VST3PluginInstance::setParameter` (`IEditController::setParamNormalized`); CLAP via a `clap_event_param_value` through `params.flush()`. Malformed/non-finite/out-of-range params are rejected with `ERR` and never crash the child.
- **Unchanged / out of scope:** `getParameter` read-back (child→host sync), parameter discovery, gestures.

## Testing (deterministic, headless)
Extended `SecOutOfProcessPluginHost` (already spawns the real forked child with the `__aestra_test_echo__` fake plugin). The echo plugin now treats parameter 0 as an **output gain**, so the test proves *behaviorally* that a `setParameter` reaches the child and is applied — observed in the returned audio (input × gain), not just a log:
1. `setParameter(0, 0.5)` → echoed output = input × 0.5.
2. Ordered successive changes settle on the last value (0.25 then 0.75 → ×0.75).
3. Out-of-range id is rejected without crashing the proxy; unity gain restores and processing continues.

**Verified the test has teeth:** with `setParameter` reverted to the no-op, it fails at *"parameter change did not reach and gain the child plugin (frame 0: got 0.4 expected 0.2)"* — the exact #238 bug. Restored → passes.

- `SecOutOfProcessPluginHost` — green (via ctest, absolute host path).
- 12/12 plugin-related tests (`OutOfProcess|PluginHost|PluginScan|Plugin`) green.
- Real VST3/CLAP application is exercised by the optional real-plugin path and remains a supplementary manual check, per scope.

## Risk / rollback
Touches the OOP plugin proxy and its child host. The RT audio callback is untouched (parameter IPC lives entirely on the worker thread). SPSC queue = single producer (the UI/message thread today); documented. Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restored host-driven parameter control for out-of-process VST3 and CLAP plugins.
- Added a lock-free parameter queue and `SETPARAM` IPC forwarding without blocking or allocating on the caller.
- Added child-host handling for VST3, CLAP, and test echo-plugin parameters, with validation for malformed or invalid values.
- Safely handles queue overflow, rejected parameters, IPC failures, and dead child processes.
- Added end-to-end tests covering gain changes, ordered updates, invalid parameters, and continued audio processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->