### PR TITLE
feat(plugin): CLAP note-ports dialect negotiation + native note events (#244)

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -544,6 +544,11 @@ add_executable(AestraPluginHost
     src/Plugin/AestraPluginHostMain.cpp
 )
 
+# The helper is otherwise self-contained (hand-mirrored plugin ABIs), but it now
+# includes the shared Plugin/ClapNoteConversion.h header, so it needs AestraAudio's
+# include root on every config — not only when VST3 links AestraAudioCore (#244).
+target_include_directories(AestraPluginHost PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 set_target_properties(AestraPluginHost PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )

--- a/AestraAudio/include/Plugin/CLAPHost.h
+++ b/AestraAudio/include/Plugin/CLAPHost.h
@@ -104,6 +104,16 @@ private:
     double m_sampleRate = 44100.0;
     uint32_t m_maxBlockSize = 512;
 
+    // Note-input dialect decided once at initialize() (deactivated, main thread),
+    // shared with the OOP host via Plugin/ClapNoteConversion.h (#244).
+    //  - m_noteDialect: kDialectClap / kDialectMidi, or 0 for "no shared dialect".
+    //  - m_rawMidiAllowed: may we send raw CLAP_EVENT_MIDI on this port?
+    //  - m_noteDialectFromLegacyFallback: plugin exposes no clap.note-ports; we send
+    //    raw MIDI for back-compat (a named legacy fallback, not a compliant result).
+    uint32_t m_noteDialect = 2 /* ClapNote::kDialectMidi */;
+    bool m_rawMidiAllowed = true;
+    bool m_noteDialectFromLegacyFallback = true;
+
     // CLAP types (using void* to avoid header pollution)
     void* m_library = nullptr; // DLL/dylib handle
     const clap_plugin_entry* m_entry = nullptr;
@@ -116,7 +126,9 @@ private:
     mutable bool m_parameterCacheValid = false;
 
     void buildParameterCache() const;
-    static clap_host* createHost();
+    // Non-static: populates the instance's m_hostStorage. (Was erroneously declared
+    // static; latent because CLAPHost.cpp is not built without the CLAP SDK.)
+    clap_host* createHost();
 };
 
 /**

--- a/AestraAudio/include/Plugin/CLAPHost.h
+++ b/AestraAudio/include/Plugin/CLAPHost.h
@@ -13,6 +13,14 @@ struct clap_plugin;
 struct clap_plugin_entry;
 struct clap_host;
 
+// Event structs are needed by value for the reusable per-block scratch storage
+// below. They are only pulled in (and the scratch members only exist) when the
+// CLAP SDK is present — this header is also included by the plugin factory/scanner
+// in CLAP-off builds, which must stay SDK-free (#244).
+#ifdef AESTRA_HAS_CLAP
+#include <clap/events.h>
+#endif
+
 namespace Aestra {
 namespace Audio {
 
@@ -113,6 +121,19 @@ private:
     uint32_t m_noteDialect = 2 /* ClapNote::kDialectMidi */;
     bool m_rawMidiAllowed = true;
     bool m_noteDialectFromLegacyFallback = true;
+
+    // Reusable per-block note-event scratch, sized once in initialize() so the
+    // audio thread never allocates and never puts ~70KB of event arrays on the
+    // stack (#244 review). One capacity governs the backing vectors, the ordered
+    // header view, and the per-block accept cap. Safe as instance members because
+    // a single plugin instance's process() is only ever called by the one render
+    // thread — never re-entered or run concurrently for the same instance.
+    static constexpr size_t kMaxNoteEventsPerBlock = 1024;
+#ifdef AESTRA_HAS_CLAP
+    std::vector<clap_event_note> m_noteEvents;
+    std::vector<clap_event_midi> m_midiEvents;
+    std::vector<const clap_event_header*> m_eventOrder;
+#endif
 
     // CLAP types (using void* to avoid header pollution)
     void* m_library = nullptr; // DLL/dylib handle

--- a/AestraAudio/include/Plugin/ClapNoteConversion.h
+++ b/AestraAudio/include/Plugin/ClapNoteConversion.h
@@ -1,0 +1,94 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <cstdint>
+
+// Shared CLAP note-conversion rules used by BOTH CLAP hosting paths — the
+// in-process host (CLAPHost.cpp, real CLAP SDK) and the out-of-process child
+// (AestraPluginHostMain.cpp, hand-mirrored CLAP ABI). Keeping the dialect
+// selection and MIDI decoding here means the two paths cannot drift (#244).
+//
+// This header is deliberately SDK-free (the OOP child has no CLAP headers) and
+// allocation-free/branch-only, so it is safe to call from the audio thread. It
+// deals in plain integers; each caller builds its own event struct (real
+// clap_event_note vs. the child's mirror) from the decoded fields.
+
+namespace Aestra {
+namespace Audio {
+namespace ClapNote {
+
+// clap_note_dialect bits (clap/ext/note-ports.h), mirrored so this header needs
+// no SDK. Only CLAP and MIDI are handled here; MPE / MIDI2 are out of scope.
+enum : uint32_t {
+    kDialectClap = 1u << 0,
+    kDialectMidi = 1u << 1,
+    kDialectMidiMpe = 1u << 2,
+    kDialectMidi2 = 1u << 3,
+};
+
+enum class MidiNoteKind : uint8_t { NoteOn, NoteOff, Other };
+
+struct DecodedNote {
+    MidiNoteKind kind{MidiNoteKind::Other};
+    uint8_t channel{0};  // 0..15
+    uint8_t key{0};      // 0..127
+    uint8_t velocity{0}; // 0..127 (0 on a note-on means note-off)
+};
+
+// Decode a 3-byte MIDI channel-voice message. A note-on with velocity 0 is the
+// running-status note-off convention and is reported as NoteOff.
+inline DecodedNote decodeMidiMessage(const uint8_t* data) {
+    DecodedNote out;
+    if (!data) {
+        return out;
+    }
+    const uint8_t status = static_cast<uint8_t>(data[0] & 0xF0);
+    out.channel = static_cast<uint8_t>(data[0] & 0x0F);
+    out.key = static_cast<uint8_t>(data[1] & 0x7F);
+    out.velocity = static_cast<uint8_t>(data[2] & 0x7F);
+    if (status == 0x90) { // Note On
+        out.kind = out.velocity > 0 ? MidiNoteKind::NoteOn : MidiNoteKind::NoteOff;
+    } else if (status == 0x80) { // Note Off
+        out.kind = MidiNoteKind::NoteOff;
+    }
+    return out;
+}
+
+// Host-emittable note dialects (Aestra can produce native CLAP and raw MIDI;
+// MPE / MIDI2 are out of scope for #244).
+constexpr uint32_t kHostSupportedDialects = kDialectClap | kDialectMidi;
+
+// Pick the note dialect to deliver on a plugin note-input port, deterministically.
+//   - Honor a validly-advertised preference: if preferred_dialect is a single
+//     dialect present in BOTH the plugin's supported mask and the host's, use it.
+//     (In particular, a plugin that supports CLAP+MIDI but prefers CLAP gets
+//     CLAP — we never pick raw MIDI merely because MIDI is in supported_dialects.)
+//   - If the preference is absent (0) or not mutually supported, fall back
+//     deterministically to native CLAP when the port supports it, else MIDI.
+//     This is a documented tie-break, not a MIDI-by-default.
+//   - Return 0 when there is no mutually supported dialect; the caller must then
+//     deliver no notes (and log a diagnostic).
+// @param supported  supported_dialects bitmask from the note port.
+// @param preferred  preferred_dialect from the note port (one bit, or 0).
+inline uint32_t selectDialect(uint32_t supported, uint32_t preferred) {
+    const uint32_t usable = supported & kHostSupportedDialects;
+    if (usable == 0) {
+        return 0; // no mutually supported dialect — caller delivers no notes
+    }
+    // A validly-advertised preference is a single dialect we both support.
+    const bool preferredIsSingleBit = preferred != 0 && (preferred & (preferred - 1)) == 0;
+    if (preferredIsSingleBit && (preferred & usable) == preferred) {
+        return preferred;
+    }
+    // Absent or unsupported preference: deterministic documented fallback.
+    return (usable & kDialectClap) ? kDialectClap : kDialectMidi;
+}
+
+// Normalized CLAP note velocity (0..1) from a 7-bit MIDI velocity.
+inline double normalizedVelocity(uint8_t midiVelocity) {
+    return static_cast<double>(midiVelocity) / 127.0;
+}
+
+} // namespace ClapNote
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -64,6 +64,16 @@ public:
     // tests since setParameter itself is void (#238).
     uint64_t parameterDropCount() const { return m_paramDrops.load(std::memory_order_relaxed); }
 
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+    // Send a raw command to the helper and return its reply. Test-only: used by the
+    // #244 CLAP-note e2e test to read the fake plugin's recorded events (TESTNOTES).
+    std::string sendRawCommandForTest(const std::string& command) {
+        std::string response;
+        sendCommand(command, &response, std::chrono::seconds(2));
+        return response;
+    }
+#endif
+
 private:
     bool sendCommand(const std::string& command, std::string* response = nullptr,
                      std::chrono::milliseconds timeout = std::chrono::milliseconds(500));

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -13,23 +13,25 @@
 #include <string>
 #include <vector>
 
-#include "Plugin/ClapNoteConversion.h"
-
 #ifdef AESTRA_HAS_VST3
 #include "Plugin/VST3Host.h"
 #endif
 
+// CLAP hosting in this child is POSIX-only (dlopen). The shared note-conversion
+// rules are only needed there, so keep the include off the Windows build, where
+// this header is not on the include path.
 #ifndef _WIN32
+#include "Plugin/ClapNoteConversion.h"
 #include <dlfcn.h>
 #endif
 
 namespace {
 
+#ifndef _WIN32
 // The shared CLAP note-conversion rules live in Aestra::Audio::ClapNote; this
 // file is in the global namespace, so alias it for brevity (#244).
 namespace ClapNote = Aestra::Audio::ClapNote;
 
-#ifndef _WIN32
 struct ClapVersion {
     uint32_t major;
     uint32_t minor;
@@ -485,6 +487,11 @@ struct ClapModule {
     uint32_t noteDialect = ClapNote::kDialectMidi;
     bool rawMidiAllowed = true;
     bool noteDialectFromLegacyFallback = true;
+    // One capacity governs all note-event storage: the midi/note backing vectors,
+    // the heterogeneous event-order view, and the per-block accept cap. The
+    // backing vectors are reserved to this once (initialize), so the header
+    // pointers recorded in noteEventOrder stay valid for the whole process() call.
+    static constexpr size_t kMaxNoteEventsPerBlock = 1024;
     std::vector<ClapEventNote> noteEvents;
     // Heterogeneous in-order view over midiEvents/noteEvents for process.in_events.
     std::vector<const ClapEventHeader*> noteEventOrder;
@@ -662,9 +669,9 @@ struct ClapModule {
         for (auto& storage : outputStorage) {
             storage.assign(maxBlockSize, 0.0f);
         }
-        midiEvents.reserve(1024);
-        noteEvents.reserve(1024);
-        noteEventOrder.reserve(1024);
+        midiEvents.reserve(kMaxNoteEventsPerBlock);
+        noteEvents.reserve(kMaxNoteEventsPerBlock);
+        noteEventOrder.reserve(kMaxNoteEventsPerBlock);
         inputPlanes[0] = inputStorage[0].data();
         inputPlanes[1] = inputStorage[1].data();
         outputPlanes[0] = outputStorage[0].data();
@@ -744,12 +751,11 @@ struct ClapModule {
         // supports CLAP, else raw CLAP_EVENT_MIDI. Non-note messages stay raw MIDI.
         // noteEventOrder preserves original stream order across both event types;
         // backing vectors are reserved so the recorded header pointers stay valid.
-        static constexpr size_t kMaxNoteEvents = 1024;
         midiEvents.clear();
         noteEvents.clear();
         noteEventOrder.clear();
         if (midiData && midiBytes <= midiData->size() && (midiBytes % 8) == 0) {
-            for (size_t offset = 0; offset < midiBytes && noteEventOrder.size() < kMaxNoteEvents;
+            for (size_t offset = 0; offset < midiBytes && noteEventOrder.size() < kMaxNoteEventsPerBlock;
                  offset += 8) {
                 const uint8_t size = (*midiData)[offset + 4];
                 if (size != 3) {

--- a/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
+++ b/AestraAudio/src/Plugin/AestraPluginHostMain.cpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+#include "Plugin/ClapNoteConversion.h"
+
 #ifdef AESTRA_HAS_VST3
 #include "Plugin/VST3Host.h"
 #endif
@@ -22,6 +24,10 @@
 #endif
 
 namespace {
+
+// The shared CLAP note-conversion rules live in Aestra::Audio::ClapNote; this
+// file is in the global namespace, so alias it for brevity (#244).
+namespace ClapNote = Aestra::Audio::ClapNote;
 
 #ifndef _WIN32
 struct ClapVersion {
@@ -159,6 +165,35 @@ struct ClapEventParamValue {
 
 constexpr uint16_t kClapEventParamValue = 5;
 
+// clap_event_note ABI (clap/events.h) — native CLAP note-on/off events (#244).
+struct ClapEventNote {
+    ClapEventHeader header;
+    int32_t noteId;    // -1 if unspecified
+    int16_t portIndex; // note input port
+    int16_t channel;   // 0..15
+    int16_t key;       // 0..127
+    double velocity;   // 0..1
+};
+
+constexpr uint16_t kClapEventNoteOn = 0;
+constexpr uint16_t kClapEventNoteOff = 1;
+
+// clap.note-ports extension ABI (clap/ext/note-ports.h) — lets the host learn a
+// plugin's note input ports and which note dialects each accepts (#244).
+struct ClapNotePortInfo {
+    uint32_t id;
+    uint32_t supportedDialects;
+    uint32_t preferredDialect;
+    char name[256];
+};
+
+struct ClapPluginNotePorts {
+    uint32_t (*count)(const ClapPlugin* plugin, bool isInput);
+    bool (*get)(const ClapPlugin* plugin, uint32_t index, bool isInput, ClapNotePortInfo* info);
+};
+
+constexpr const char* kClapExtNotePorts = "clap.note-ports";
+
 struct ClapOstream {
     void* ctx;
     int64_t (*write)(const ClapOstream* stream, const void* buffer, uint64_t size);
@@ -255,6 +290,24 @@ const ClapEventHeader* singleParamEventGet(const ClapInputEvents* list, uint32_t
     return &static_cast<const ClapEventParamValue*>(list->ctx)->header;
 }
 
+// Heterogeneous, order-preserving input-event list: ctx is a vector of event
+// header pointers into stable backing storage. Lets note-on/off (CLAP dialect)
+// and raw MIDI events (CC etc.) be delivered in their original stream order (#244).
+uint32_t orderedEventsSize(const ClapInputEvents* list) {
+    const auto* order =
+        list ? static_cast<const std::vector<const ClapEventHeader*>*>(list->ctx) : nullptr;
+    return order ? static_cast<uint32_t>(order->size()) : 0;
+}
+
+const ClapEventHeader* orderedEventsGet(const ClapInputEvents* list, uint32_t index) {
+    const auto* order =
+        list ? static_cast<const std::vector<const ClapEventHeader*>*>(list->ctx) : nullptr;
+    if (!order || index >= order->size()) {
+        return nullptr;
+    }
+    return (*order)[index];
+}
+
 int64_t writeStateStream(const ClapOstream* stream, const void* buffer, uint64_t size) {
     auto* out = stream ? static_cast<std::vector<uint8_t>*>(stream->ctx) : nullptr;
     if (!out || (!buffer && size != 0)) {
@@ -302,6 +355,101 @@ void hostRequestCallback(const ClapHost* host) {
     (void)host;
 }
 
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+// A fake CLAP plugin used by the #244 headless tests. It advertises a
+// configurable note-input dialect and records every event actually delivered
+// through process.in_events, so a test can drive the REAL ClapModule::process
+// conversion boundary and assert exactly what dialect/payload the plugin received.
+namespace fakeclap {
+
+struct Recorded {
+    uint16_t type{0}; // kClapEventNoteOn / kClapEventNoteOff / kClapEventMidi
+    uint32_t time{0};
+    int16_t portIndex{0};
+    int16_t channel{0};
+    int16_t key{0};
+    double velocity{0.0};
+    uint8_t midi[3]{0, 0, 0};
+};
+
+struct State {
+    bool exposeNotePorts{true};
+    uint32_t supportedDialects{ClapNote::kDialectMidi};
+    uint32_t preferredDialect{0};
+    std::vector<Recorded> events;
+};
+State g_state;
+
+uint32_t notePortsCount(const ClapPlugin*, bool isInput) { return isInput ? 1u : 0u; }
+
+bool notePortsGet(const ClapPlugin*, uint32_t index, bool isInput, ClapNotePortInfo* info) {
+    if (!isInput || index != 0 || !info) {
+        return false;
+    }
+    *info = {};
+    info->id = 0;
+    info->supportedDialects = g_state.supportedDialects;
+    info->preferredDialect = g_state.preferredDialect;
+    std::snprintf(info->name, sizeof(info->name), "%s", "fake-note-in");
+    return true;
+}
+
+ClapPluginNotePorts g_notePorts = {notePortsCount, notePortsGet};
+
+bool init(const ClapPlugin*) { return true; }
+void destroy(const ClapPlugin*) {}
+bool activate(const ClapPlugin*, double, uint32_t, uint32_t) { return true; }
+void deactivate(const ClapPlugin*) {}
+bool startProcessing(const ClapPlugin*) { return true; }
+void stopProcessing(const ClapPlugin*) {}
+void reset(const ClapPlugin*) {}
+
+ClapProcessStatus process(const ClapPlugin*, const ClapProcess* proc) {
+    if (proc && proc->inEvents && proc->inEvents->size && proc->inEvents->get) {
+        const uint32_t n = proc->inEvents->size(proc->inEvents);
+        for (uint32_t i = 0; i < n; ++i) {
+            const ClapEventHeader* h = proc->inEvents->get(proc->inEvents, i);
+            if (!h) {
+                continue;
+            }
+            Recorded rec{};
+            rec.type = h->type;
+            rec.time = h->time;
+            if (h->type == kClapEventNoteOn || h->type == kClapEventNoteOff) {
+                const auto* note = reinterpret_cast<const ClapEventNote*>(h);
+                rec.portIndex = note->portIndex;
+                rec.channel = note->channel;
+                rec.key = note->key;
+                rec.velocity = note->velocity;
+            } else if (h->type == kClapEventMidi) {
+                const auto* midi = reinterpret_cast<const ClapEventMidi*>(h);
+                rec.portIndex = static_cast<int16_t>(midi->portIndex);
+                std::memcpy(rec.midi, midi->data, 3);
+            }
+            g_state.events.push_back(rec);
+        }
+    }
+    return kClapProcessError + 1; // CLAP_PROCESS_CONTINUE (non-error)
+}
+
+const void* getExtension(const ClapPlugin*, const char* id) {
+    if (g_state.exposeNotePorts && id && std::strcmp(id, kClapExtNotePorts) == 0) {
+        return &g_notePorts;
+    }
+    return nullptr;
+}
+
+void onMainThread(const ClapPlugin*) {}
+
+ClapPluginDescriptor g_descriptor = {};
+ClapPlugin g_plugin = {&g_descriptor, nullptr,        init,
+                       destroy,       activate,       deactivate,
+                       startProcessing, stopProcessing, reset,
+                       process,       getExtension,   onMainThread};
+
+} // namespace fakeclap
+#endif // AESTRA_ENABLE_TEST_HOOKS
+
 struct ClapModule {
     void* library = nullptr;
     const ClapPluginEntry* entry = nullptr;
@@ -321,6 +469,25 @@ struct ClapModule {
     ClapInputEvents emptyInputEvents = {nullptr, emptyInputEventsSize, emptyInputEventsGet};
     ClapOutputEvents outputEvents = {nullptr, dropOutputEvent};
     const ClapPluginParams* paramsExt = nullptr;
+    const ClapPluginNotePorts* notePortsExt = nullptr;
+    // Note-delivery decision for input port 0, computed once at load (#244).
+    //  - noteDialect: kDialectClap / kDialectMidi, or 0 meaning "no mutually
+    //    supported dialect" → deliver no notes.
+    //  - rawMidiAllowed: may we send a raw CLAP_EVENT_MIDI on this port? True only
+    //    when the port advertises the MIDI dialect (or under the legacy fallback).
+    //    Non-note MIDI (CC etc.) on a CLAP-only port is dropped, never emitted as a
+    //    MIDI dialect the port did not advertise.
+    //  - noteDialectFromLegacyFallback: the plugin exposes no clap.note-ports
+    //    extension. Per the CLAP contract that means "no note ports"; Aestra
+    //    nonetheless sends raw MIDI to avoid regressing plugins that worked before
+    //    note-ports negotiation existed. This is a named legacy compatibility
+    //    fallback, NOT a standards-compliant negotiation result.
+    uint32_t noteDialect = ClapNote::kDialectMidi;
+    bool rawMidiAllowed = true;
+    bool noteDialectFromLegacyFallback = true;
+    std::vector<ClapEventNote> noteEvents;
+    // Heterogeneous in-order view over midiEvents/noteEvents for process.in_events.
+    std::vector<const ClapEventHeader*> noteEventOrder;
 
     ~ClapModule() { close(); }
 
@@ -331,6 +498,10 @@ struct ClapModule {
     void close() {
         deactivate();
         paramsExt = nullptr;
+        notePortsExt = nullptr;
+        noteDialect = ClapNote::kDialectMidi;
+        rawMidiAllowed = true;
+        noteDialectFromLegacyFallback = true;
         if (plugin && plugin->destroy) {
             plugin->destroy(plugin);
         }
@@ -423,9 +594,61 @@ struct ClapModule {
         }
         if (plugin->getExtension) {
             paramsExt = static_cast<const ClapPluginParams*>(plugin->getExtension(plugin, kClapExtParams));
+            notePortsExt =
+                static_cast<const ClapPluginNotePorts*>(plugin->getExtension(plugin, kClapExtNotePorts));
         }
+        resolveNoteDialect();
         return true;
     }
+
+    // Decide, once (on the main thread, while deactivated — never on the RT path),
+    // how to deliver notes on input port 0. Advertised note-ports drive real
+    // negotiation; a missing extension is the named legacy compatibility fallback
+    // (Aestra sends raw MIDI as it always has, which is NOT the CLAP-compliant
+    // result — absence of the extension means "no note ports") (#244). Assumes
+    // plugin and notePortsExt are already resolved.
+    void resolveNoteDialect() {
+        const bool hasNotePort = plugin && notePortsExt && notePortsExt->count && notePortsExt->get &&
+                                 notePortsExt->count(plugin, /*isInput=*/true) > 0;
+        if (hasNotePort) {
+            noteDialectFromLegacyFallback = false;
+            ClapNotePortInfo info{};
+            if (notePortsExt->get(plugin, 0, /*isInput=*/true, &info)) {
+                noteDialect = ClapNote::selectDialect(info.supportedDialects, info.preferredDialect);
+                rawMidiAllowed = (info.supportedDialects & ClapNote::kDialectMidi) != 0;
+                if (noteDialect == 0) {
+                    std::cerr << "[AestraPluginHost] note port 0 advertises no host-supported "
+                                 "dialect; delivering no notes\n";
+                }
+            } else {
+                // Extension present but the port could not be read — deliver nothing
+                // rather than guess a dialect the plugin did not advertise.
+                noteDialect = 0;
+                rawMidiAllowed = false;
+            }
+        } else {
+            noteDialectFromLegacyFallback = true;
+            noteDialect = ClapNote::kDialectMidi;
+            rawMidiAllowed = true;
+        }
+    }
+
+#ifdef AESTRA_ENABLE_TEST_HOOKS
+    // Wire the fake CLAP plugin in place of a dlopen'd module and run the SAME
+    // note-ports resolution the real path uses, so tests exercise the production
+    // conversion boundary (#244). The fake's note-ports configuration is set on
+    // fakeclap::g_state before calling this.
+    void loadFakeForTest() {
+        close();
+        plugin = &fakeclap::g_plugin;
+        paramsExt = nullptr;
+        notePortsExt = plugin->getExtension
+                           ? static_cast<const ClapPluginNotePorts*>(
+                                 plugin->getExtension(plugin, kClapExtNotePorts))
+                           : nullptr;
+        resolveNoteDialect();
+    }
+#endif
 
     bool initialize(double sampleRate, uint32_t blockSize, std::string& error) {
         if (!plugin || sampleRate <= 0.0 || blockSize == 0 || blockSize > 65536) {
@@ -440,6 +663,8 @@ struct ClapModule {
             storage.assign(maxBlockSize, 0.0f);
         }
         midiEvents.reserve(1024);
+        noteEvents.reserve(1024);
+        noteEventOrder.reserve(1024);
         inputPlanes[0] = inputStorage[0].data();
         inputPlanes[1] = inputStorage[1].data();
         outputPlanes[0] = outputStorage[0].data();
@@ -514,27 +739,79 @@ struct ClapModule {
             }
         }
 
+        // Convert incoming raw MIDI to the note dialect selected for this plugin's
+        // input port (#244): native CLAP note-on/off when the port prefers/only
+        // supports CLAP, else raw CLAP_EVENT_MIDI. Non-note messages stay raw MIDI.
+        // noteEventOrder preserves original stream order across both event types;
+        // backing vectors are reserved so the recorded header pointers stay valid.
+        static constexpr size_t kMaxNoteEvents = 1024;
         midiEvents.clear();
+        noteEvents.clear();
+        noteEventOrder.clear();
         if (midiData && midiBytes <= midiData->size() && (midiBytes % 8) == 0) {
-            for (size_t offset = 0; offset < midiBytes; offset += 8) {
+            for (size_t offset = 0; offset < midiBytes && noteEventOrder.size() < kMaxNoteEvents;
+                 offset += 8) {
                 const uint8_t size = (*midiData)[offset + 4];
                 if (size != 3) {
                     continue;
                 }
                 uint32_t sampleOffset = 0;
                 std::memcpy(&sampleOffset, midiData->data() + offset, sizeof(sampleOffset));
-                ClapEventMidi event{};
-                event.header.size = sizeof(event);
-                event.header.time = std::min<uint32_t>(sampleOffset, frames > 0 ? frames - 1 : 0);
-                event.header.spaceId = kClapCoreEventSpaceId;
-                event.header.type = kClapEventMidi;
-                event.header.flags = 0;
-                event.portIndex = 0;
-                std::memcpy(event.data, midiData->data() + offset + 5, 3);
-                midiEvents.push_back(event);
+                const uint32_t time = std::min<uint32_t>(sampleOffset, frames > 0 ? frames - 1 : 0);
+                const uint8_t* bytes = midiData->data() + offset + 5;
+                const ClapNote::DecodedNote note = ClapNote::decodeMidiMessage(bytes);
+                const bool isNote = note.kind == ClapNote::MidiNoteKind::NoteOn ||
+                                    note.kind == ClapNote::MidiNoteKind::NoteOff;
+
+                if (isNote) {
+                    // A note goes out in the selected dialect. noteDialect==0 means
+                    // the port shares no dialect with us — drop rather than guess.
+                    if (noteDialect == ClapNote::kDialectClap) {
+                        ClapEventNote event{};
+                        event.header.size = sizeof(event);
+                        event.header.time = time;
+                        event.header.spaceId = kClapCoreEventSpaceId;
+                        event.header.type = note.kind == ClapNote::MidiNoteKind::NoteOn ? kClapEventNoteOn
+                                                                                       : kClapEventNoteOff;
+                        event.header.flags = 0;
+                        event.noteId = -1;
+                        event.portIndex = 0;
+                        event.channel = static_cast<int16_t>(note.channel);
+                        event.key = static_cast<int16_t>(note.key);
+                        event.velocity = ClapNote::normalizedVelocity(note.velocity);
+                        noteEvents.push_back(event);
+                        noteEventOrder.push_back(&noteEvents.back().header);
+                    } else if (noteDialect == ClapNote::kDialectMidi) {
+                        ClapEventMidi event{};
+                        event.header.size = sizeof(event);
+                        event.header.time = time;
+                        event.header.spaceId = kClapCoreEventSpaceId;
+                        event.header.type = kClapEventMidi;
+                        event.header.flags = 0;
+                        event.portIndex = 0;
+                        std::memcpy(event.data, bytes, 3);
+                        midiEvents.push_back(event);
+                        noteEventOrder.push_back(&midiEvents.back().header);
+                    }
+                    // else noteDialect == 0: no mutually supported dialect, drop.
+                } else if (rawMidiAllowed) {
+                    // Non-note MIDI (CC, pitch bend…) rides the raw-MIDI dialect only
+                    // when the port advertises it. On a CLAP-only port it is dropped
+                    // deliberately — never emitted as a dialect the port did not accept.
+                    ClapEventMidi event{};
+                    event.header.size = sizeof(event);
+                    event.header.time = time;
+                    event.header.spaceId = kClapCoreEventSpaceId;
+                    event.header.type = kClapEventMidi;
+                    event.header.flags = 0;
+                    event.portIndex = 0;
+                    std::memcpy(event.data, bytes, 3);
+                    midiEvents.push_back(event);
+                    noteEventOrder.push_back(&midiEvents.back().header);
+                }
             }
         }
-        ClapInputEvents midiInputEvents = {&midiEvents, midiInputEventsSize, midiInputEventsGet};
+        ClapInputEvents midiInputEvents = {&noteEventOrder, orderedEventsSize, orderedEventsGet};
 
         ClapAudioBuffer inputBuffer = {};
         inputBuffer.data32 = inputPlanes;
@@ -556,7 +833,7 @@ struct ClapModule {
         processData.audioOutputs = &outputBuffer;
         processData.audioInputsCount = 1;
         processData.audioOutputsCount = 1;
-        processData.inEvents = midiEvents.empty() ? &emptyInputEvents : &midiInputEvents;
+        processData.inEvents = noteEventOrder.empty() ? &emptyInputEvents : &midiInputEvents;
         processData.outEvents = &outputEvents;
 
         if (plugin->process(plugin, &processData) == kClapProcessError) {
@@ -979,6 +1256,37 @@ int main(int argc, char** argv) {
             if (id == "__aestra_test_crash__") {
                 std::abort();
             }
+#ifndef _WIN32
+            // Fake CLAP note endpoints (#244): configure the fake's advertised note
+            // dialect, then wire it through the REAL ClapModule so the test exercises
+            // the production note-conversion boundary. g_state also records events.
+            {
+                bool isFakeClap = true;
+                fakeclap::g_state = {}; // reset config + clear recorded events
+                if (id == "__aestra_test_clap_note__") {
+                    fakeclap::g_state.supportedDialects = ClapNote::kDialectClap;
+                    fakeclap::g_state.preferredDialect = ClapNote::kDialectClap;
+                } else if (id == "__aestra_test_clap_midi__") {
+                    fakeclap::g_state.supportedDialects = ClapNote::kDialectMidi;
+                    fakeclap::g_state.preferredDialect = ClapNote::kDialectMidi;
+                } else if (id == "__aestra_test_clap_dual_pref_clap__") {
+                    fakeclap::g_state.supportedDialects =
+                        ClapNote::kDialectClap | ClapNote::kDialectMidi;
+                    fakeclap::g_state.preferredDialect = ClapNote::kDialectClap;
+                } else if (id == "__aestra_test_clap_legacy__") {
+                    fakeclap::g_state.exposeNotePorts = false; // no note-ports extension
+                } else {
+                    isFakeClap = false;
+                }
+                if (isFakeClap) {
+                    clapModule.loadFakeForTest();
+                    loaded = true;
+                    echoPlugin = false;
+                    reply("OK LOADED");
+                    continue;
+                }
+            }
+#endif
 #endif
             if (format != "vst3" && format != "clap") {
                 reply("ERR unsupported-format");
@@ -1113,6 +1421,21 @@ int main(int argc, char** argv) {
             }
 #endif
             reply("ERR no-plugin");
+#if defined(AESTRA_ENABLE_TEST_HOOKS) && !defined(_WIN32)
+        } else if (command == "TESTNOTES") {
+            // Dump the events the fake CLAP plugin actually received through
+            // process.in_events (#244). Format: "OK <n>" then one token per event:
+            //   type:time:port:channel:key:velocity:m0:m1:m2
+            // (channel/key/velocity are the note fields; m0..m2 the raw MIDI bytes).
+            std::ostringstream out;
+            out << "OK " << fakeclap::g_state.events.size();
+            for (const auto& e : fakeclap::g_state.events) {
+                out << ' ' << e.type << ':' << e.time << ':' << e.portIndex << ':' << e.channel << ':'
+                    << e.key << ':' << e.velocity << ':' << static_cast<int>(e.midi[0]) << ':'
+                    << static_cast<int>(e.midi[1]) << ':' << static_cast<int>(e.midi[2]);
+            }
+            reply(out.str());
+#endif
         } else if (command == "SAVESTATE") {
             if (!loaded) {
                 reply("ERR not-loaded");

--- a/AestraAudio/src/Plugin/CLAPHost.cpp
+++ b/AestraAudio/src/Plugin/CLAPHost.cpp
@@ -13,7 +13,11 @@
 // CLAP SDK includes
 #include <clap/clap.h>
 #include <clap/events.h>
+#include <clap/ext/note-ports.h>
 #include <clap/ext/state.h>
+
+// Shared note-dialect rules (also used by the OOP child) — must agree (#244).
+#include "Plugin/ClapNoteConversion.h"
 
 #include <algorithm>
 #include <array>
@@ -80,8 +84,10 @@ static clap_host_params createHostParams() {
 }
 static clap_host_params g_hostParams = createHostParams();
 
+// Order-preserving view over heterogeneous input events (native notes + raw MIDI),
+// mirroring the OOP child so both hosts deliver identical event streams (#244).
 struct ClapInputEventList {
-    const clap_event_midi* events{nullptr};
+    const clap_event_header* const* order{nullptr};
     uint32_t count{0};
 };
 
@@ -97,10 +103,10 @@ uint32_t inputEventsSize(const clap_input_events* list) {
 
 const clap_event_header* inputEventsGet(const clap_input_events* list, uint32_t index) {
     const auto* ctx = list ? static_cast<const ClapInputEventList*>(list->ctx) : nullptr;
-    if (!ctx || !ctx->events || index >= ctx->count) {
+    if (!ctx || !ctx->order || index >= ctx->count) {
         return nullptr;
     }
-    return &ctx->events[index].header;
+    return ctx->order[index];
 }
 
 bool dropOutputEvent(const clap_output_events*, const clap_event_header*) {
@@ -350,6 +356,28 @@ bool CLAPPluginInstance::initialize(double sampleRate, uint32_t maxBlockSize) {
     m_sampleRate = sampleRate;
     m_maxBlockSize = maxBlockSize;
 
+    // Decide the note-input dialect once, here (loaded, not yet activated, main
+    // thread) — never on the audio thread. Uses the shared rules so the in-process
+    // and OOP hosts cannot drift (#244).
+    m_noteDialect = Aestra::Audio::ClapNote::kDialectMidi;
+    m_rawMidiAllowed = true;
+    m_noteDialectFromLegacyFallback = true;
+    const auto* notePorts =
+        static_cast<const clap_plugin_note_ports*>(m_plugin->get_extension(m_plugin, CLAP_EXT_NOTE_PORTS));
+    if (notePorts && notePorts->count && notePorts->get && notePorts->count(m_plugin, true) > 0) {
+        m_noteDialectFromLegacyFallback = false;
+        clap_note_port_info_t info{};
+        if (notePorts->get(m_plugin, 0, true, &info)) {
+            m_noteDialect =
+                Aestra::Audio::ClapNote::selectDialect(info.supported_dialects, info.preferred_dialect);
+            m_rawMidiAllowed = (info.supported_dialects & Aestra::Audio::ClapNote::kDialectMidi) != 0;
+        } else {
+            m_noteDialect = 0;
+            m_rawMidiAllowed = false;
+        }
+    }
+    // else: legacy compatibility fallback (no note-ports extension) — keep raw MIDI.
+
     return true;
 }
 
@@ -387,26 +415,58 @@ void CLAPPluginInstance::process(const float* const* inputs, float** outputs, ui
 
     (void)midiOutput;
 
+    // Convert MIDI to the negotiated note dialect (#244), shared with the OOP
+    // child via ClapNote. Notes go native (clap_event_note) on a CLAP port, raw
+    // (clap_event_midi) on a MIDI port; noteDialect==0 drops notes. Non-note MIDI
+    // rides the raw dialect only when the port advertises it. Order is preserved.
+    namespace ClapNote = Aestra::Audio::ClapNote;
     static constexpr size_t kMaxClapMidiEvents = 1024;
+    std::array<clap_event_note, kMaxClapMidiEvents> noteEvents{};
     std::array<clap_event_midi, kMaxClapMidiEvents> midiEvents{};
+    std::array<const clap_event_header*, kMaxClapMidiEvents> eventOrder{};
     ClapInputEventList inputEventList{};
+    size_t noteCount = 0;
+    size_t midiCount = 0;
     if (midiInput) {
         const size_t eventCount = std::min(midiInput->getEventCount(), kMaxClapMidiEvents);
-        for (size_t i = 0; i < eventCount; ++i) {
+        for (size_t i = 0; i < eventCount && inputEventList.count < kMaxClapMidiEvents; ++i) {
             const auto& event = midiInput->getEvent(i);
             if (event.size != 3) {
                 continue;
             }
-            clap_event_midi& clapEvent = midiEvents[inputEventList.count++];
-            clapEvent.header.size = sizeof(clapEvent);
-            clapEvent.header.time = std::min<uint32_t>(event.sampleOffset, numFrames > 0 ? numFrames - 1 : 0);
-            clapEvent.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            clapEvent.header.type = CLAP_EVENT_MIDI;
-            clapEvent.header.flags = 0;
-            clapEvent.port_index = 0;
-            std::memcpy(clapEvent.data, event.data, sizeof(clapEvent.data));
+            const uint32_t time = std::min<uint32_t>(event.sampleOffset, numFrames > 0 ? numFrames - 1 : 0);
+            const ClapNote::DecodedNote note = ClapNote::decodeMidiMessage(event.data);
+            const bool isNote = note.kind == ClapNote::MidiNoteKind::NoteOn ||
+                                note.kind == ClapNote::MidiNoteKind::NoteOff;
+
+            if (isNote && m_noteDialect == ClapNote::kDialectClap) {
+                clap_event_note& ev = noteEvents[noteCount++];
+                ev.header.size = sizeof(ev);
+                ev.header.time = time;
+                ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+                ev.header.type = note.kind == ClapNote::MidiNoteKind::NoteOn ? CLAP_EVENT_NOTE_ON
+                                                                             : CLAP_EVENT_NOTE_OFF;
+                ev.header.flags = 0;
+                ev.note_id = -1;
+                ev.port_index = 0;
+                ev.channel = note.channel;
+                ev.key = note.key;
+                ev.velocity = ClapNote::normalizedVelocity(note.velocity);
+                eventOrder[inputEventList.count++] = &ev.header;
+            } else if (isNote ? (m_noteDialect == ClapNote::kDialectMidi) : m_rawMidiAllowed) {
+                clap_event_midi& ev = midiEvents[midiCount++];
+                ev.header.size = sizeof(ev);
+                ev.header.time = time;
+                ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+                ev.header.type = CLAP_EVENT_MIDI;
+                ev.header.flags = 0;
+                ev.port_index = 0;
+                std::memcpy(ev.data, event.data, sizeof(ev.data));
+                eventOrder[inputEventList.count++] = &ev.header;
+            }
+            // else: note on a no-shared-dialect port, or CC on a CLAP-only port — dropped.
         }
-        inputEventList.events = midiEvents.data();
+        inputEventList.order = eventOrder.data();
     }
     clap_input_events inputEvents = {&inputEventList, inputEventsSize, inputEventsGet};
     clap_output_events outputEvents = {nullptr, dropOutputEvent};

--- a/AestraAudio/src/Plugin/CLAPHost.cpp
+++ b/AestraAudio/src/Plugin/CLAPHost.cpp
@@ -356,6 +356,12 @@ bool CLAPPluginInstance::initialize(double sampleRate, uint32_t maxBlockSize) {
     m_sampleRate = sampleRate;
     m_maxBlockSize = maxBlockSize;
 
+    // Reserve the reusable per-block event scratch now, off the audio thread, so
+    // process() is allocation-free and keeps large arrays off the stack (#244).
+    m_noteEvents.reserve(kMaxNoteEventsPerBlock);
+    m_midiEvents.reserve(kMaxNoteEventsPerBlock);
+    m_eventOrder.reserve(kMaxNoteEventsPerBlock);
+
     // Decide the note-input dialect once, here (loaded, not yet activated, main
     // thread) — never on the audio thread. Uses the shared rules so the in-process
     // and OOP hosts cannot drift (#244).
@@ -420,16 +426,16 @@ void CLAPPluginInstance::process(const float* const* inputs, float** outputs, ui
     // (clap_event_midi) on a MIDI port; noteDialect==0 drops notes. Non-note MIDI
     // rides the raw dialect only when the port advertises it. Order is preserved.
     namespace ClapNote = Aestra::Audio::ClapNote;
-    static constexpr size_t kMaxClapMidiEvents = 1024;
-    std::array<clap_event_note, kMaxClapMidiEvents> noteEvents{};
-    std::array<clap_event_midi, kMaxClapMidiEvents> midiEvents{};
-    std::array<const clap_event_header*, kMaxClapMidiEvents> eventOrder{};
+    // Reusable members (reserved in initialize()) — no allocation, no big stack
+    // arrays. Reserved capacity means the header pointers recorded in m_eventOrder
+    // stay valid for the whole call (no reallocation).
+    m_noteEvents.clear();
+    m_midiEvents.clear();
+    m_eventOrder.clear();
     ClapInputEventList inputEventList{};
-    size_t noteCount = 0;
-    size_t midiCount = 0;
     if (midiInput) {
-        const size_t eventCount = std::min(midiInput->getEventCount(), kMaxClapMidiEvents);
-        for (size_t i = 0; i < eventCount && inputEventList.count < kMaxClapMidiEvents; ++i) {
+        const size_t eventCount = std::min(midiInput->getEventCount(), kMaxNoteEventsPerBlock);
+        for (size_t i = 0; i < eventCount && m_eventOrder.size() < kMaxNoteEventsPerBlock; ++i) {
             const auto& event = midiInput->getEvent(i);
             if (event.size != 3) {
                 continue;
@@ -440,33 +446,34 @@ void CLAPPluginInstance::process(const float* const* inputs, float** outputs, ui
                                 note.kind == ClapNote::MidiNoteKind::NoteOff;
 
             if (isNote && m_noteDialect == ClapNote::kDialectClap) {
-                clap_event_note& ev = noteEvents[noteCount++];
+                clap_event_note ev{};
                 ev.header.size = sizeof(ev);
                 ev.header.time = time;
                 ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
                 ev.header.type = note.kind == ClapNote::MidiNoteKind::NoteOn ? CLAP_EVENT_NOTE_ON
                                                                              : CLAP_EVENT_NOTE_OFF;
-                ev.header.flags = 0;
                 ev.note_id = -1;
                 ev.port_index = 0;
                 ev.channel = note.channel;
                 ev.key = note.key;
                 ev.velocity = ClapNote::normalizedVelocity(note.velocity);
-                eventOrder[inputEventList.count++] = &ev.header;
+                m_noteEvents.push_back(ev);
+                m_eventOrder.push_back(&m_noteEvents.back().header);
             } else if (isNote ? (m_noteDialect == ClapNote::kDialectMidi) : m_rawMidiAllowed) {
-                clap_event_midi& ev = midiEvents[midiCount++];
+                clap_event_midi ev{};
                 ev.header.size = sizeof(ev);
                 ev.header.time = time;
                 ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
                 ev.header.type = CLAP_EVENT_MIDI;
-                ev.header.flags = 0;
                 ev.port_index = 0;
                 std::memcpy(ev.data, event.data, sizeof(ev.data));
-                eventOrder[inputEventList.count++] = &ev.header;
+                m_midiEvents.push_back(ev);
+                m_eventOrder.push_back(&m_midiEvents.back().header);
             }
             // else: note on a no-shared-dialect port, or CC on a CLAP-only port — dropped.
         }
-        inputEventList.order = eventOrder.data();
+        inputEventList.order = m_eventOrder.data();
+        inputEventList.count = static_cast<uint32_t>(m_eventOrder.size());
     }
     clap_input_events inputEvents = {&inputEventList, inputEventsSize, inputEventsGet};
     clap_output_events outputEvents = {nullptr, dropOutputEvent};

--- a/Tests/AestraAudio/ClapNoteConversionTest.cpp
+++ b/Tests/AestraAudio/ClapNoteConversionTest.cpp
@@ -1,0 +1,98 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// ClapNoteConversionTest — the shared CLAP note-conversion rules used by both the
+// in-process host and the OOP child (#244). Proving them here pins the "both
+// paths use the same rules" contract at the shared-logic level (the in-process
+// CLAPHost.cpp is SDK-gated and not built in CI, so the shared rules are the
+// only place the two paths can be jointly verified).
+
+#include "Plugin/ClapNoteConversion.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+using namespace Aestra::Audio::ClapNote;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const std::string& label) {
+    std::cout << (cond ? "PASS: " : "FAIL: ") << label << "\n";
+    if (!cond) {
+        ++g_failures;
+    }
+}
+
+DecodedNote decode(uint8_t s, uint8_t d1, uint8_t d2) {
+    const uint8_t bytes[3] = {s, d1, d2};
+    return decodeMidiMessage(bytes);
+}
+
+} // namespace
+
+int main() {
+    // --- MIDI decode ----------------------------------------------------------
+    {
+        const DecodedNote on = decode(0x90 | 5, 60, 100); // note on, ch 5, key 60, vel 100
+        check(on.kind == MidiNoteKind::NoteOn, "0x90 with velocity>0 is a note-on");
+        check(on.channel == 5, "channel decoded");
+        check(on.key == 60, "key decoded");
+        check(on.velocity == 100, "velocity decoded");
+
+        const DecodedNote off = decode(0x80 | 3, 64, 0); // note off, ch 3
+        check(off.kind == MidiNoteKind::NoteOff, "0x80 is a note-off");
+        check(off.channel == 3 && off.key == 64, "note-off channel/key decoded");
+
+        const DecodedNote zeroVel = decode(0x90 | 1, 72, 0); // note on, velocity 0
+        check(zeroVel.kind == MidiNoteKind::NoteOff, "note-on velocity 0 is a note-off (running status)");
+
+        const DecodedNote cc = decode(0xB0, 7, 127); // control change
+        check(cc.kind == MidiNoteKind::Other, "non-note messages are Other");
+
+        check(decodeMidiMessage(nullptr).kind == MidiNoteKind::Other, "null decode is safe");
+    }
+
+    // --- normalized velocity --------------------------------------------------
+    {
+        check(normalizedVelocity(127) == 1.0, "velocity 127 -> 1.0");
+        check(normalizedVelocity(0) == 0.0, "velocity 0 -> 0.0");
+        check(std::abs(normalizedVelocity(64) - 64.0 / 127.0) < 1e-9, "velocity 64 normalized");
+    }
+
+    // --- dialect selection (policy per #244 review) ---------------------------
+    {
+        // Single-dialect ports.
+        check(selectDialect(kDialectClap, 0) == kDialectClap, "CLAP only -> CLAP");
+        check(selectDialect(kDialectMidi, 0) == kDialectMidi, "MIDI only -> MIDI");
+
+        // Honor a validly-advertised preference in a dual-dialect port.
+        check(selectDialect(kDialectClap | kDialectMidi, kDialectClap) == kDialectClap,
+              "CLAP+MIDI, preferred CLAP -> CLAP");
+        check(selectDialect(kDialectClap | kDialectMidi, kDialectMidi) == kDialectMidi,
+              "CLAP+MIDI, preferred MIDI -> MIDI");
+
+        // A preference honored even though the other dialect is also supported —
+        // we must NOT pick MIDI merely because it is in the supported mask.
+        check(selectDialect(kDialectClap | kDialectMidi, kDialectClap) != kDialectMidi,
+              "preferred CLAP is not overridden by MIDI being supported");
+
+        // Preferred dialect absent from the supported mask -> documented fallback
+        // (native CLAP first where supported, else MIDI).
+        check(selectDialect(kDialectMidi, kDialectClap) == kDialectMidi,
+              "preferred CLAP unsupported (MIDI-only port) -> MIDI fallback");
+        check(selectDialect(kDialectClap | kDialectMidi, 0) == kDialectClap,
+              "no preference on a dual port -> CLAP fallback (not MIDI-by-default)");
+        check(selectDialect(kDialectClap | kDialectMidi, kDialectMidiMpe) == kDialectClap,
+              "unsupported (MPE) preference -> CLAP fallback");
+
+        // No mutually supported dialect -> 0 (caller delivers no notes).
+        check(selectDialect(0, 0) == 0, "no supported dialect -> 0");
+        check(selectDialect(kDialectMidiMpe | kDialectMidi2, kDialectMidiMpe) == 0,
+              "only MPE/MIDI2 (out of scope) -> 0, even with a preference");
+    }
+
+    std::cout << (g_failures == 0 ? "ALL PASSED\n"
+                                  : "FAILURES: " + std::to_string(g_failures) + "\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2245,6 +2245,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DCBlockerTest.cpp")
     set_tests_properties(DCBlockerTest PROPERTIES LABELS "audio;dsp;dc-removal")
 endif()
 
+# Shared CLAP note-conversion rules (#244) — SDK-free, header-only
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ClapNoteConversionTest.cpp")
+    add_executable(ClapNoteConversionTest AestraAudio/ClapNoteConversionTest.cpp)
+    target_include_directories(ClapNoteConversionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ClapNoteConversionTest COMMAND ClapNoteConversionTest)
+    set_tests_properties(ClapNoteConversionTest PROPERTIES LABELS "audio;plugin;clap")
+endif()
+
 # Transport pause preserves the authoritative playhead (#590)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TransportPausePreservesPositionTest.cpp")
     add_executable(TransportPausePreservesPositionTest AestraAudio/TransportPausePreservesPositionTest.cpp)

--- a/tests/security/CMakeLists.txt
+++ b/tests/security/CMakeLists.txt
@@ -187,6 +187,9 @@ if(TARGET AestraAudio AND TARGET AestraCore AND TARGET AestraPlat)
         ${REPO_ROOT}/AestraAudio/include/Plugin
         ${REPO_ROOT}/AestraCore/include
     )
+    # Enables the OutOfProcessPluginInstance TESTNOTES accessor used by the #244
+    # CLAP-note e2e checks (matches the AestraPluginHost test-hooks build).
+    target_compile_definitions(SecOutOfProcessPluginHost PRIVATE AESTRA_ENABLE_TEST_HOOKS)
     target_link_libraries(SecOutOfProcessPluginHost PRIVATE AestraAudio)
 
     target_include_directories(SecPluginScanIsolation PRIVATE

--- a/tests/security/out_of_process_plugin_host.cpp
+++ b/tests/security/out_of_process_plugin_host.cpp
@@ -2,13 +2,18 @@
 // Out-of-process plugin host containment proof.
 
 #include "Plugin/PluginFactory.h"
+#include "Plugin/OutOfProcessPluginInstance.h"
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 using namespace Aestra::Audio;
 
@@ -48,6 +53,125 @@ PluginInstancePtr create(OutOfProcessPluginFactory& factory, const PluginInfo& i
     PluginInstancePtr created;
     factory.createPluginAsync(info, [&](PluginInstancePtr instance) { created = std::move(instance); });
     return created;
+}
+
+// Pump process() until the echo output steady-states at input*gain, tolerating
+// the async worker/double-buffer latency (#238 param delivery is not synchronous).
+// Returns true once every frame matches; false if it never converges.
+bool pumpUntilGain(const PluginInstancePtr& instance, const float* in, float gain, int tries = 100) {
+    float outL[4] = {};
+    float outR[4] = {};
+    float* outputs[2] = {outL, outR};
+    const float* inputs[2] = {in, in};
+    for (int t = 0; t < tries; ++t) {
+        std::memset(outL, 0, sizeof(outL));
+        std::memset(outR, 0, sizeof(outR));
+        instance->process(inputs, outputs, 2, 2, 4);
+        bool converged = true;
+        for (int i = 0; i < 4; ++i) {
+            if (std::fabs(outL[i] - in[i] * gain) > 1e-5f || std::fabs(outR[i] - in[i] * gain) > 1e-5f) {
+                converged = false;
+            }
+        }
+        if (converged) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+}
+
+// --- #244 CLAP note-dialect e2e helpers -----------------------------------
+PluginInfo makeClapInfo(const std::string& id) {
+    PluginInfo info;
+    info.id = id;
+    info.name = id;
+    info.vendor = "Aestra Test";
+    info.version = "1";
+    info.category = "Instrument";
+    info.format = PluginFormat::CLAP;
+    info.type = PluginType::Instrument;
+    info.path = "/tmp/aestra-fake.clap";
+    info.numAudioInputs = 2;
+    info.numAudioOutputs = 2;
+    return info;
+}
+
+struct DeliveredEvent {
+    int type = -1; // 0 note-on, 1 note-off, 10 raw MIDI (child CLAP event type ids)
+    uint32_t time = 0;
+    int port = 0;
+    int channel = 0;
+    int key = 0;
+    double velocity = 0.0;
+    int midi[3] = {0, 0, 0};
+};
+
+// Parse the child's TESTNOTES reply: "OK <n> type:time:port:ch:key:vel:m0:m1:m2 ...".
+std::vector<DeliveredEvent> parseTestNotes(const std::string& reply) {
+    std::vector<DeliveredEvent> out;
+    std::istringstream in(reply);
+    std::string ok;
+    size_t n = 0;
+    in >> ok >> n;
+    if (ok != "OK") {
+        return out;
+    }
+    std::string tok;
+    while (in >> tok) {
+        DeliveredEvent e;
+        std::replace(tok.begin(), tok.end(), ':', ' ');
+        std::istringstream ts(tok);
+        ts >> e.type >> e.time >> e.port >> e.channel >> e.key >> e.velocity >> e.midi[0] >> e.midi[1] >>
+            e.midi[2];
+        out.push_back(e);
+    }
+    return out;
+}
+
+// Load a fake CLAP endpoint, deliver one MIDI block (note-on ch4 key60 vel100 @0,
+// CC @2, note-off ch4 key60 @4), and return the events the plugin actually
+// received through process.in_events.
+std::vector<DeliveredEvent> deliverNotesToFakeClap(OutOfProcessPluginFactory& factory,
+                                                   const std::string& id, bool& ok) {
+    ok = false;
+    auto instance = create(factory, makeClapInfo(id));
+    if (!instance || !instance->initialize(48000.0, 64)) {
+        return {};
+    }
+    instance->activate();
+    if (!instance->isActive() || instance->isCrashed()) {
+        return {};
+    }
+
+    MidiBuffer midi;
+    midi.addNoteOn(4, 60, 100, 0);                                    // ch4(=MIDI ch3), key60, vel100 @0
+    const uint8_t cc[3] = {static_cast<uint8_t>(0xB0 | 3), 7, 64};    // CC7 on ch3 @2
+    midi.addEvent(2, cc, 3);
+    midi.addNoteOff(4, 60, 0, 4);                                     // note-off @4
+
+    float inL[64] = {};
+    float inR[64] = {};
+    const float* inputs[2] = {inL, inR};
+    float outL[64] = {};
+    float outR[64] = {};
+    float* outputs[2] = {outL, outR};
+    instance->process(inputs, outputs, 2, 2, 64, &midi, nullptr);
+
+    // Poll until the worker has forwarded the block (PROCESSMIDI) and the fake
+    // recorded it — tolerating async worker latency rather than a fixed sleep.
+    auto* oop = static_cast<OutOfProcessPluginInstance*>(instance.get());
+    std::vector<DeliveredEvent> events;
+    for (int t = 0; t < 100; ++t) {
+        events = parseTestNotes(oop->sendRawCommandForTest("TESTNOTES"));
+        if (!events.empty()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    instance->shutdown();
+    ok = true;
+    return events;
 }
 
 } // namespace
@@ -140,65 +264,88 @@ int main(int argc, char** argv) {
     // flow through a lock-free queue drained by the proxy's worker thread, so a
     // settle interval is needed (matching the process double-buffer above).
     const float paramIn[4] = {0.4f, 0.5f, 0.6f, 0.7f};
-    const float* paramInputs[2] = {paramIn, paramIn};
 
     instance->setParameter(0, 0.5f); // half gain
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    std::memset(outL, 0, sizeof(outL));
-    std::memset(outR, 0, sizeof(outR));
-    instance->process(paramInputs, outputs, 2, 2, 4); // submit block under the new gain
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    instance->process(paramInputs, outputs, 2, 2, 4); // retrieve the gained block
-    for (int i = 0; i < 4; ++i) {
-        const float expected = paramIn[i] * 0.5f;
-        if (std::fabs(outL[i] - expected) > 1e-5f || std::fabs(outR[i] - expected) > 1e-5f) {
-            std::cerr << "parameter change did not reach and gain the child plugin (frame " << i
-                      << ": got " << outL[i] << " expected " << expected << ")\n";
-            return 1;
-        }
+    if (!pumpUntilGain(instance, paramIn, 0.5f)) {
+        std::cerr << "parameter change did not reach and gain the child plugin\n";
+        return 1;
     }
 
     // Successive changes arrive in order — the last write to a parameter wins.
     instance->setParameter(0, 0.25f);
     instance->setParameter(0, 0.75f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    std::memset(outL, 0, sizeof(outL));
-    std::memset(outR, 0, sizeof(outR));
-    instance->process(paramInputs, outputs, 2, 2, 4);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    instance->process(paramInputs, outputs, 2, 2, 4);
-    for (int i = 0; i < 4; ++i) {
-        const float expected = paramIn[i] * 0.75f;
-        if (std::fabs(outL[i] - expected) > 1e-5f) {
-            std::cerr << "ordered parameter changes did not settle on the last value (frame " << i
-                      << ": got " << outL[i] << " expected " << expected << ")\n";
-            return 1;
-        }
+    if (!pumpUntilGain(instance, paramIn, 0.75f)) {
+        std::cerr << "ordered parameter changes did not settle on the last value\n";
+        return 1;
     }
 
     // An out-of-range parameter id is rejected by the child but must not crash the
-    // proxy: the change is dropped and the instance keeps working.
+    // proxy, and the instance keeps working (unity gain restores cleanly after).
     instance->setParameter(99999u, 0.5f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    if (instance->isCrashed()) {
-        std::cerr << "out-of-range parameter id crashed the isolated plugin proxy\n";
-        return 1;
-    }
-    // Restore unity gain and confirm the proxy still processes after the bad id.
     instance->setParameter(0, 1.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    std::memset(outL, 0, sizeof(outL));
-    std::memset(outR, 0, sizeof(outR));
-    instance->process(paramInputs, outputs, 2, 2, 4);
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
-    instance->process(paramInputs, outputs, 2, 2, 4);
-    if (instance->isCrashed()) {
-        std::cerr << "isolated plugin proxy did not survive parameter stress\n";
+    if (!pumpUntilGain(instance, paramIn, 1.0f) || instance->isCrashed()) {
+        std::cerr << "proxy did not survive / recover after an out-of-range parameter id\n";
         return 1;
     }
-    for (int i = 0; i < 4; ++i) {
-        if (std::fabs(outL[i] - paramIn[i]) > 1e-5f) {
-            std::cerr << "unity gain not restored after out-of-range parameter id\n";
+
+    // --- #244 CLAP note-dialect delivery, end to end through the proxy --------
+    // Drives real MIDI through OutOfProcessPluginInstance -> forked child ->
+    // ClapModule::process, and reads back exactly what the fake CLAP plugin
+    // received via process.in_events for each advertised dialect.
+    {
+        bool ran = false;
+
+        // Native CLAP-only port: notes arrive as native NOTE_ON/OFF; the CC (a raw
+        // MIDI dialect the port did not advertise) is deliberately dropped.
+        auto clap = deliverNotesToFakeClap(factory, "__aestra_test_clap_note__", ran);
+        if (!ran) {
+            std::cerr << "fake CLAP (native) endpoint did not run\n";
+            return 1;
+        }
+        if (clap.size() != 2) {
+            std::cerr << "native CLAP port: expected 2 note events (CC dropped), got " << clap.size()
+                      << "\n";
+            return 1;
+        }
+        if (clap[0].type != 0 || clap[0].channel != 3 || clap[0].key != 60 || clap[0].time != 0 ||
+            std::fabs(clap[0].velocity - 100.0 / 127.0) > 1e-4) {
+            std::cerr << "native CLAP note-on payload mismatch\n";
+            return 1;
+        }
+        if (clap[1].type != 1 || clap[1].channel != 3 || clap[1].key != 60 || clap[1].time != 4) {
+            std::cerr << "native CLAP note-off payload mismatch\n";
+            return 1;
+        }
+
+        // MIDI-dialect port: everything arrives as raw CLAP_EVENT_MIDI, in order.
+        auto rawmidi = deliverNotesToFakeClap(factory, "__aestra_test_clap_midi__", ran);
+        if (rawmidi.size() != 3 || rawmidi[0].type != 10 || rawmidi[1].type != 10 ||
+            rawmidi[2].type != 10) {
+            std::cerr << "MIDI-dialect port: expected 3 raw MIDI events\n";
+            return 1;
+        }
+        if (rawmidi[0].midi[0] != (0x90 | 3) || rawmidi[0].midi[1] != 60 || rawmidi[0].midi[2] != 100 ||
+            rawmidi[1].midi[0] != (0xB0 | 3) || rawmidi[2].midi[0] != (0x80 | 3)) {
+            std::cerr << "MIDI-dialect payload/order mismatch\n";
+            return 1;
+        }
+
+        // Dual-dialect port preferring CLAP: notes go native, the CC rides raw MIDI
+        // (the port also advertises MIDI), and chronological order is preserved.
+        auto dual = deliverNotesToFakeClap(factory, "__aestra_test_clap_dual_pref_clap__", ran);
+        if (dual.size() != 3 || dual[0].type != 0 || dual[1].type != 10 || dual[2].type != 1) {
+            std::cerr << "dual-dialect port: expected native note-on, raw CC, native note-off in order\n";
+            return 1;
+        }
+        if (dual[0].time != 0 || dual[1].time != 2 || dual[2].time != 4) {
+            std::cerr << "dual-dialect mixed-event ordering/timestamps not preserved\n";
+            return 1;
+        }
+
+        // Legacy compatibility fallback: no clap.note-ports extension -> raw MIDI.
+        auto legacy = deliverNotesToFakeClap(factory, "__aestra_test_clap_legacy__", ran);
+        if (legacy.size() != 3 || legacy[0].type != 10 || legacy[1].type != 10 || legacy[2].type != 10) {
+            std::cerr << "legacy (no note-ports) fallback: expected 3 raw MIDI events\n";
             return 1;
         }
     }


### PR DESCRIPTION
## Summary
Aestra only ever delivered raw `CLAP_EVENT_MIDI` to CLAP note ports and never queried `clap.note-ports`, so CLAP instruments that accept **only** the native note dialect received no playable notes. Both CLAP hosts now negotiate the note dialect per input port and emit native `CLAP_EVENT_NOTE_ON/OFF` when appropriate. Implements the re-scoped #244.

## Shared rules — `Plugin/ClapNoteConversion.h`
Used by **both** hosts so they can't drift; SDK-free, allocation-free, audio-thread-safe:
- `decodeMidiMessage()` — 3-byte MIDI → `{kind, channel, key, velocity}`; note-on velocity 0 → note-off.
- `selectDialect()` — honors a **validly-advertised single preference** present in both the plugin's and host's masks; on absent/unsupported preference, a **documented deterministic fallback** (native CLAP where supported, else MIDI) — never MIDI just because it's in `supported_dialects`; returns 0 (deliver no notes) when there's no mutually-supported dialect.

## Out-of-process child (production path for third-party CLAP)
`clap.note-ports` + `clap_event_note` ABI mirrors; queries the port dialect once at load (deactivated, main thread, off the RT path); converts per message via the shared rules, **preserving stream order** across native-note and raw-MIDI events. Non-note MIDI on a CLAP-only port is **dropped deliberately** (never emitted as a dialect the port didn't advertise). Missing `clap.note-ports` is an explicitly-named **legacy compatibility fallback** (raw MIDI), not a standards-compliant negotiation.

## In-process host (`CLAPHost.cpp`, `AESTRA_HAS_CLAP`)
Same shared rules + native event construction against the real SDK. Also fixes a **pre-existing latent bug**: `createHost()` was declared `static` while using an instance member — it never compiled against the SDK, hidden because CI builds with the CLAP submodule absent.

**Compiled locally against the real SDK** (your merge bar — CI stays CLAP-off, `External/clap` not committed):
```
git clone --depth 1 https://github.com/free-audio/clap /tmp/clap-sdk
cp -r /tmp/clap-sdk/include AestraAudio/External/clap/
cmake -S . -B build-linux            # -> "CLAP SDK: Found", AESTRA_HAS_CLAP=ON
cmake --build build-linux --target AestraAudioCore -j2   # CLAPHost.cpp compiles
```

## Tests (deterministic, headless)
- **`ClapNoteConversionTest`** — the shared decode + full dialect policy (CLAP-only, MIDI-only, CLAP+MIDI preferred each way, unsupported-preference fallback, no-shared-dialect → 0).
- **`SecOutOfProcessPluginHost`** — a **fake CLAP endpoint** that advertises a configurable dialect and **records the events actually delivered through `process.in_events`**, driven end to end through `OutOfProcessPluginInstance` → forked child → `ClapModule::process`. Proves native-CLAP / raw-MIDI / dual-preferring-CLAP (mixed, order-preserved) / legacy-fallback ports; channel/key/velocity/sample-offset/port survive; CC-on-CLAP-only-port dropped. **Verified failing** when dialect selection is broken (native note-on → raw MIDI).
- Also **hardens the async #238 parameter checks** to poll for convergence — they were timing-flaky (fixed sleeps racing the worker); now deterministic (ran 6/6).

**Config coverage:** builds + tests green both with `AESTRA_HAS_CLAP=OFF` (CI config) and `=ON` (local, real SDK).

## Scope
One-way: the host reads the plugin's note ports. Aestra's host does **not** expose a `clap.note-ports` extension to plugins (`get_extension` offers only params), so host `supported_dialects` aren't advertised — that host-side callback stays in **#270**; no two-way negotiation is claimed here. No per-note expression, MIDI 2.0, or output events.

## Risk / rollback
Touches both CLAP hosting paths' note delivery. RT path unaffected (dialect decided once at load; per-block conversion is branch-only/allocation-free). In-process path is SDK-gated (off in CI). Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes; legacy raw-MIDI fallback remains available for plugins without note-port support.
- Added shared, SDK-free CLAP note dialect negotiation and MIDI note decoding for both in-process and out-of-process hosts.
- Hosts now deliver native CLAP note events or raw MIDI according to the negotiated port dialect, preserving event order and dropping unsupported events.
- Added CLAP note-port discovery, legacy fallback handling, and safer heterogeneous input-event access.
- Fixed the in-process `createHost()` declaration so it correctly accesses instance host storage.
- Added test hooks and coverage for conversion rules, dialect fallback, event fields and ordering, end-to-end delivery, and asynchronous parameter convergence.
- Scope is limited to host-to-plugin note delivery; host advertisement, per-note expression, MIDI 2.0, and output events are not included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->