### PR TITLE
feat(arsenal): The Understudy — step-sequencer + loop-timing overhaul

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -1035,6 +1035,16 @@ private:
     // (iteration * loopLen + wrapped pos) so the next iteration's events are
     // queued before the wrap instead of after a UI maintenance tick.
     std::atomic<uint64_t> m_patternLoopIteration{0};
+    // Coherent (iteration * loopLen + wrapped pos) snapshot for maintenance,
+    // published in ONE store at the end of each callback alongside
+    // m_globalSamplePos. Reading iteration and position as separate atomics
+    // could pair a new iteration with a stale position (they are written at
+    // different points in the callback) and schedule an epoch ahead.
+    std::atomic<uint64_t> m_patternMonotonicFrame{0};
+    // Last loop length (samples) used for a maintenance refill. Only touched
+    // on the maintenance thread; a change (BPM / sample-rate) means queued
+    // timestamps are in a stale domain and the pattern engine must flush.
+    uint64_t m_lastRefillLoopLenSamples{0};
 
     // Test Tone State
     std::atomic<bool> m_testToneEnabled{false};

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -317,6 +317,8 @@ public:
     bool isMetronomeEnabled() const { return m_metronomeEngine.isEnabled(); }
     /** @brief Set metronome output volume. */
     void setMetronomeVolume(float vol) { m_metronomeEngine.setVolume(vol); }
+    /** @brief Set metronome beats-per-bar (time-signature numerator). */
+    void setMetronomeBeatsPerBar(int beats) { m_metronomeEngine.setBeatsPerBar(beats); }
     /** @brief Get metronome output volume. */
     float getMetronomeVolume() const { return m_metronomeEngine.getVolume(); }
     /** @brief Set transport tempo in beats per minute. */
@@ -377,10 +379,7 @@ public:
     }
 
     /** @brief Enable or disable Arsenal pattern playback mode. */
-    void setPatternPlaybackMode(bool enabled, double lengthBeats) {
-        m_patternPlaybackMode.store(enabled, std::memory_order_relaxed);
-        m_patternLengthBeats.store(lengthBeats, std::memory_order_relaxed);
-    }
+    void setPatternPlaybackMode(bool enabled, double lengthBeats);
     /** @brief Check whether Arsenal pattern playback mode is active. */
     bool isPatternPlaybackMode() const { return m_patternPlaybackMode.load(std::memory_order_relaxed); }
 
@@ -1031,6 +1030,11 @@ private:
     // Pattern Playback Mode State
     std::atomic<bool> m_patternPlaybackMode{false};
     std::atomic<double> m_patternLengthBeats{4.0};
+    // Completed pattern-loop passes (audio thread writes at each wrap, reset
+    // while stopped). Gives pattern scheduling a MONOTONIC frame domain
+    // (iteration * loopLen + wrapped pos) so the next iteration's events are
+    // queued before the wrap instead of after a UI maintenance tick.
+    std::atomic<uint64_t> m_patternLoopIteration{0};
 
     // Test Tone State
     std::atomic<bool> m_testToneEnabled{false};

--- a/AestraAudio/include/Models/UnitManager.h
+++ b/AestraAudio/include/Models/UnitManager.h
@@ -316,6 +316,8 @@ public:
     std::shared_ptr<IPluginInstance> getUnitPlugin(UnitID id) const;
     /** @brief Get the plugin identifier attached to a unit. */
     std::string getUnitPluginId(UnitID id) const;
+    /** @brief Get the MIDI note that plays a unit's sample untransposed (60 fallback). */
+    int getUnitRootMidiNote(UnitID id) const;
 
     /** @brief Serialize the manager to JSON. */
     JSON saveToJSON() const;

--- a/AestraAudio/include/Playback/MetronomeEngine.h
+++ b/AestraAudio/include/Playback/MetronomeEngine.h
@@ -46,7 +46,10 @@ public:
     void loadClickSounds(const std::string& downbeatPath, const std::string& upbeatPath);
 
     // Reset internal state (e.g. on seek/loop)
-    void reset(uint64_t globalSamplePos, uint32_t sampleRate);
+    // Re-align beat scheduling to a new transport position. Pass
+    // skipCurrentBeat=true when the beat exactly at globalSamplePos already
+    // clicked in the pre-jump timeline (loop wrap) so it doesn't fire twice.
+    void reset(uint64_t globalSamplePos, uint32_t sampleRate, bool skipCurrentBeat = false);
 
     /** @brief Set the project sample rate and regenerate click sounds. */
     void setSampleRate(uint32_t rate);

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -176,11 +176,18 @@ public:
     /**
      * Refill lookahead window with events (non-RT thread)
      * Called periodically by scheduler
-     * @param currentFrame Current transport frame.
+     * @param currentFrame Current transport frame. In looped pattern mode this
+     *        is MONOTONIC (iteration * loopLengthSamples + wrapped position) so
+     *        the window can pre-schedule the next iteration's events before the
+     *        wrap — flushing at the wrap and rescheduling on the next UI tick
+     *        made every loop's downbeat land late by the maintenance latency.
      * @param sampleRate Active sample rate.
      * @param lookaheadSamples Number of frames to schedule ahead.
+     * @param loopLengthSamples Loop length in samples for looped pattern mode
+     *        (loop start == 0); 0 = no loop (timeline / offline bounce).
      */
-    void refillWindow(uint64_t currentFrame, int sampleRate, int lookaheadSamples = 4096);
+    void refillWindow(uint64_t currentFrame, int sampleRate, int lookaheadSamples = 4096,
+                      uint64_t loopLengthSamples = 0);
 
     /**
      * Process audio callback (RT-safe, audio thread only)

--- a/AestraAudio/include/Playback/TimelineClock.h
+++ b/AestraAudio/include/Playback/TimelineClock.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved.
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
@@ -21,12 +22,19 @@ public:
 
     double getTempoAtBeat(double beat) const;
     double getCurrentTempo() const { return m_defaultBPM; }
+
+    // Time signature numerator (beats per bar). The musical source of truth
+    // for bar math everywhere: Arsenal grids, pattern lengths, metronome
+    // accents, and piano-roll bar lines all derive from this.
+    void setBeatsPerBar(int beats) { m_beatsPerBar = std::clamp(beats, 1, 16); }
+    int getBeatsPerBar() const { return m_beatsPerBar; }
     double secondsAtBeat(double beat) const;
     uint64_t sampleFrameAtBeat(double beat, int sampleRate) const;
     double beatAtSampleFrame(uint64_t frame, int sampleRate) const;
 
 private:
     double m_defaultBPM{120.0};
+    int m_beatsPerBar{4};
     std::vector<TempoChange> m_tempoMap;
 };
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -551,6 +551,20 @@ void AudioEngine::refreshSamplerCacheToSnapshot(UnitManager& mgr, SamplerCacheSn
     }
 }
 
+void AudioEngine::setPatternPlaybackMode(bool enabled, double lengthBeats) {
+    const double oldLength = m_patternLengthBeats.exchange(lengthBeats, std::memory_order_relaxed);
+    const bool wasEnabled = m_patternPlaybackMode.exchange(enabled, std::memory_order_relaxed);
+    // A loop-length change while playing shifts the monotonic scheduling
+    // domain (iteration * loopLen + pos) on both threads at once; already
+    // queued events were stamped in the OLD domain and would never come due.
+    // Flush so the scheduler re-queues everything in the new domain.
+    if (enabled && (!wasEnabled || std::abs(oldLength - lengthBeats) > 1e-9)) {
+        if (auto* patEng = m_patternEngine.load(std::memory_order_acquire)) {
+            patEng->flush();
+        }
+    }
+}
+
 void AudioEngine::performNonRealtimeMaintenance() {
     if (reportRealtimeMisuse("AudioEngine::performNonRealtimeMaintenance")) {
         return;
@@ -577,7 +591,28 @@ void AudioEngine::performNonRealtimeMaintenance() {
         uint64_t currentFrame = m_globalSamplePos.load(std::memory_order_relaxed);
         uint32_t sr = m_sampleRate.load(std::memory_order_relaxed);
         if (sr > 0) {
-            patEng->refillWindow(currentFrame, static_cast<int>(sr), LOOKAHEAD_SAMPLES);
+            uint64_t loopLenSamples = 0;
+            if (m_patternPlaybackMode.load(std::memory_order_relaxed)) {
+                // Same formula as the audio callback so both agree on the
+                // monotonic domain (iteration * loopLen + wrapped position).
+                const double bpm = std::max(1.0, static_cast<double>(m_metronomeEngine.getBPM()));
+                const double samplesPerBeat = static_cast<double>(sr) * 60.0 / bpm;
+                loopLenSamples =
+                    static_cast<uint64_t>(m_patternLengthBeats.load(std::memory_order_relaxed) * samplesPerBeat);
+                if (loopLenSamples > 0) {
+                    // Consistent (iteration, position) pair: re-read once if a
+                    // loop wrap raced us between the two loads.
+                    uint64_t iter = m_patternLoopIteration.load(std::memory_order_acquire);
+                    uint64_t pos = m_globalSamplePos.load(std::memory_order_relaxed);
+                    const uint64_t iterCheck = m_patternLoopIteration.load(std::memory_order_acquire);
+                    if (iterCheck != iter) {
+                        iter = iterCheck;
+                        pos = m_globalSamplePos.load(std::memory_order_relaxed);
+                    }
+                    currentFrame = iter * loopLenSamples + pos;
+                }
+            }
+            patEng->refillWindow(currentFrame, static_cast<int>(sr), LOOKAHEAD_SAMPLES, loopLenSamples);
         }
     }
 
@@ -868,6 +903,15 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     uint64_t nextGlobalPos = currentGlobalPos;
     uint32_t loopSplitFrame = numFrames; // Default: no split
     uint64_t loopStartSample = 0;
+    uint64_t patternLoopLenSamples = 0; // Pattern-mode loop length (loop start == 0)
+
+    if (!playing && m_fadeState.load(std::memory_order_relaxed) != FadeState::FadingOut) {
+        // Stopped: pattern playback restarts from the loop top, so the
+        // monotonic iteration counter restarts with it.
+        if (m_patternLoopIteration.load(std::memory_order_relaxed) != 0) {
+            m_patternLoopIteration.store(0, std::memory_order_relaxed);
+        }
+    }
 
     if (playing || m_fadeState.load(std::memory_order_relaxed) == FadeState::FadingOut) {
         nextGlobalPos += numFrames;
@@ -879,6 +923,9 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
                 (static_cast<double>(currentSampleRate) * 60.0) / std::max(static_cast<double>(bpm), 1.0);
             uint64_t loopEndSample = static_cast<uint64_t>(loopEndBeat * samplesPerBeat);
             loopStartSample = static_cast<uint64_t>(loopStartBeat * samplesPerBeat);
+            if (patternMode && loopEndSample > loopStartSample) {
+                patternLoopLenSamples = loopEndSample - loopStartSample;
+            }
 
             // Check for loop crossing
             // Enhanced Logic: In Pattern Mode, we might start WAY past loop end (Timeline position).
@@ -953,23 +1000,32 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     }
 
     // === Arsenal Unit Processing (Pattern Playback) ===
-    // Process pattern MIDI events and mix sampler output into master buffer
-    // Must respect loop splitting similar to renderGraph
+    // Process pattern MIDI events and mix sampler output into master buffer.
+    // Positions handed to the pattern engine are MONOTONIC in pattern mode
+    // (iteration * loopLen + wrapped pos): refillWindow pre-schedules the next
+    // iteration's events in that domain, so the wrap needs no flush and the
+    // loop's downbeat lands sample-accurately instead of waiting for the next
+    // UI maintenance tick (which made every bar end audibly "off").
+    const auto patternMonotonic = [&](uint64_t wrappedPos) {
+        return m_patternLoopIteration.load(std::memory_order_relaxed) * patternLoopLenSamples + wrappedPos;
+    };
     if (loopSplitFrame < numFrames) {
         // Split Render
         if (loopSplitFrame > 0) {
-            processArsenalUnits(loopSplitFrame, 0, currentGlobalPos);
+            processArsenalUnits(loopSplitFrame, 0, patternMonotonic(currentGlobalPos));
         }
-        // Flush pattern events on loop wrap so we don't accumulate duplicates.
-        if (isPlaying) {
+        if (patternMode) {
+            m_patternLoopIteration.fetch_add(1, std::memory_order_release);
+        } else if (isPlaying) {
+            // Timeline loops keep the flush-on-wrap behavior.
             auto* pe = m_patternEngine.load(std::memory_order_relaxed);
             if (pe)
                 pe->flush();
         }
-        processArsenalUnits(numFrames - loopSplitFrame, loopSplitFrame, loopStartSample);
+        processArsenalUnits(numFrames - loopSplitFrame, loopSplitFrame, patternMonotonic(loopStartSample));
     } else {
         // Normal
-        processArsenalUnits(numFrames, 0, currentGlobalPos);
+        processArsenalUnits(numFrames, 0, patternMonotonic(currentGlobalPos));
     }
 
     mixTestTone(numFrames, currentSampleRate);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -592,6 +592,7 @@ void AudioEngine::performNonRealtimeMaintenance() {
         uint32_t sr = m_sampleRate.load(std::memory_order_relaxed);
         if (sr > 0) {
             uint64_t loopLenSamples = 0;
+            bool deferRefill = false;
             if (m_patternPlaybackMode.load(std::memory_order_relaxed)) {
                 // Same formula as the audio callback so both agree on the
                 // monotonic domain (iteration * loopLen + wrapped position).
@@ -606,19 +607,30 @@ void AudioEngine::performNonRealtimeMaintenance() {
                     // re-queue in the new domain (length-in-beats changes are
                     // already flushed by setPatternPlaybackMode).
                     if (m_lastRefillLoopLenSamples != 0 && m_lastRefillLoopLenSamples != loopLenSamples) {
+                        // m_patternMonotonicFrame is still encoded in the OLD
+                        // loop-length domain until the audio callback republishes
+                        // it (which it does every block, from the same BPM /
+                        // length source). Refilling now with the new loopLen but
+                        // the stale frame would schedule an epoch ahead, so flush
+                        // and DEFER this refill one maintenance tick — the next
+                        // tick reads a coherent new-domain frame. The lookahead
+                        // (~85ms) dwarfs one tick (~16ms), so no underrun.
                         patEng->flush();
+                        m_lastRefillLoopLenSamples = loopLenSamples;
+                        deferRefill = true; // skip the refill below this tick
+                    } else {
+                        m_lastRefillLoopLenSamples = loopLenSamples;
+                        // One coherent snapshot published by the audio callback.
+                        // Loading iteration and position as separate atomics could
+                        // pair a new iteration with a stale position (the callback
+                        // writes them at different points) and schedule an epoch
+                        // ahead, starving legitimate events.
+                        currentFrame = m_patternMonotonicFrame.load(std::memory_order_acquire);
                     }
-                    m_lastRefillLoopLenSamples = loopLenSamples;
-
-                    // One coherent snapshot published by the audio callback.
-                    // Loading iteration and position as separate atomics could
-                    // pair a new iteration with a stale position (the callback
-                    // writes them at different points) and schedule an epoch
-                    // ahead, starving legitimate events.
-                    currentFrame = m_patternMonotonicFrame.load(std::memory_order_acquire);
                 }
             }
-            patEng->refillWindow(currentFrame, static_cast<int>(sr), LOOKAHEAD_SAMPLES, loopLenSamples);
+            if (!deferRefill)
+                patEng->refillWindow(currentFrame, static_cast<int>(sr), LOOKAHEAD_SAMPLES, loopLenSamples);
         }
     }
 
@@ -3486,6 +3498,16 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     uint64_t endSample = static_cast<uint64_t>(endBeat * samplesPerBeat);
     uint64_t totalFrames = endSample - startSample;
 
+    // Keep pattern scheduling in the same monotonic loop domain live playback
+    // uses, so an isolated bounce of a looped pattern re-triggers events every
+    // loop instead of only rendering the first pass. The bounce frame advances
+    // linearly and never wraps, so `currentFrame` below is already the
+    // monotonic frame — only loopLenSamples needs threading through.
+    const uint64_t bounceLoopLenSamples =
+        m_patternPlaybackMode.load(std::memory_order_relaxed)
+            ? static_cast<uint64_t>(m_patternLengthBeats.load(std::memory_order_relaxed) * samplesPerBeat)
+            : 0;
+
     if (totalFrames == 0)
         return false;
 
@@ -3575,7 +3597,8 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         // Refill pattern engine lookahead (normally done by performNonRealtimeMaintenance)
         auto* patEng = m_patternEngine.load(std::memory_order_acquire);
         if (patEng) {
-            patEng->refillWindow(currentFrame, static_cast<int>(sampleRate), static_cast<int>(blockSize));
+            patEng->refillWindow(currentFrame, static_cast<int>(sampleRate), static_cast<int>(blockSize),
+                                 bounceLoopLenSamples);
         }
 
         // Render

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -600,16 +600,22 @@ void AudioEngine::performNonRealtimeMaintenance() {
                 loopLenSamples =
                     static_cast<uint64_t>(m_patternLengthBeats.load(std::memory_order_relaxed) * samplesPerBeat);
                 if (loopLenSamples > 0) {
-                    // Consistent (iteration, position) pair: re-read once if a
-                    // loop wrap raced us between the two loads.
-                    uint64_t iter = m_patternLoopIteration.load(std::memory_order_acquire);
-                    uint64_t pos = m_globalSamplePos.load(std::memory_order_relaxed);
-                    const uint64_t iterCheck = m_patternLoopIteration.load(std::memory_order_acquire);
-                    if (iterCheck != iter) {
-                        iter = iterCheck;
-                        pos = m_globalSamplePos.load(std::memory_order_relaxed);
+                    // BPM or sample-rate changes re-scale the sample domain:
+                    // queued event timestamps and scheduledThroughFrame were
+                    // computed against the old loopLenSamples — flush so they
+                    // re-queue in the new domain (length-in-beats changes are
+                    // already flushed by setPatternPlaybackMode).
+                    if (m_lastRefillLoopLenSamples != 0 && m_lastRefillLoopLenSamples != loopLenSamples) {
+                        patEng->flush();
                     }
-                    currentFrame = iter * loopLenSamples + pos;
+                    m_lastRefillLoopLenSamples = loopLenSamples;
+
+                    // One coherent snapshot published by the audio callback.
+                    // Loading iteration and position as separate atomics could
+                    // pair a new iteration with a stale position (the callback
+                    // writes them at different points) and schedule an epoch
+                    // ahead, starving legitimate events.
+                    currentFrame = m_patternMonotonicFrame.load(std::memory_order_acquire);
                 }
             }
             patEng->refillWindow(currentFrame, static_cast<int>(sr), LOOKAHEAD_SAMPLES, loopLenSamples);
@@ -910,6 +916,9 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         // monotonic iteration counter restarts with it.
         if (m_patternLoopIteration.load(std::memory_order_relaxed) != 0) {
             m_patternLoopIteration.store(0, std::memory_order_relaxed);
+        }
+        if (m_patternMonotonicFrame.load(std::memory_order_relaxed) != 0) {
+            m_patternMonotonicFrame.store(0, std::memory_order_relaxed);
         }
     }
 
@@ -1313,6 +1322,15 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     if (m_transportPlaying.load(std::memory_order_relaxed) ||
         m_fadeState.load(std::memory_order_relaxed) == FadeState::FadingOut) {
         m_globalSamplePos.store(nextGlobalPos, std::memory_order_relaxed);
+        if (patternMode && patternLoopLenSamples > 0) {
+            // Single-store coherent snapshot: iteration was bumped earlier in
+            // THIS callback if this block wrapped, so the pair is consistent
+            // here — maintenance reads one atomic instead of two.
+            m_patternMonotonicFrame.store(m_patternLoopIteration.load(std::memory_order_relaxed) *
+                                                  patternLoopLenSamples +
+                                              nextGlobalPos,
+                                          std::memory_order_release);
+        }
 
         // Handle Loop Metronome Reset. skipCurrentBeat: the boundary beat
         // already clicked in the pre-wrap part of this block.

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1258,9 +1258,11 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
         m_fadeState.load(std::memory_order_relaxed) == FadeState::FadingOut) {
         m_globalSamplePos.store(nextGlobalPos, std::memory_order_relaxed);
 
-        // Handle Loop Metronome Reset
+        // Handle Loop Metronome Reset. skipCurrentBeat: the boundary beat
+        // already clicked in the pre-wrap part of this block.
         if (loopSplitFrame < numFrames) {
-            m_metronomeEngine.reset(nextGlobalPos, static_cast<uint32_t>(m_sampleRate.load(std::memory_order_relaxed)));
+            m_metronomeEngine.reset(nextGlobalPos, static_cast<uint32_t>(m_sampleRate.load(std::memory_order_relaxed)),
+                                    true);
         }
     }
 

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -661,6 +661,15 @@ std::string UnitManager::getUnitPluginId(UnitID id) const {
     return u ? u->pluginId : std::string{};
 }
 
+int UnitManager::getUnitRootMidiNote(UnitID id) const {
+    // Notes placed at this pitch play the unit's sample untransposed; 60 is
+    // both the SamplerPlugin default root and the sensible non-sampler answer.
+    if (auto sampler = std::dynamic_pointer_cast<Plugins::SamplerPlugin>(getUnitPlugin(id))) {
+        return sampler->getRootMidiNote();
+    }
+    return 60;
+}
+
 JSON UnitManager::saveToJSON() const {
     JSON root = JSON::object();
     root.set("nextId", JSON(static_cast<double>(nextId)));

--- a/AestraAudio/src/Playback/MetronomeEngine.cpp
+++ b/AestraAudio/src/Playback/MetronomeEngine.cpp
@@ -201,6 +201,15 @@ void MetronomeEngine::reset(uint64_t globalSamplePos, uint32_t sampleRate, bool 
 
     m_sampleRate.store(sampleRate, std::memory_order_relaxed);
 
+    // A loop wrap (skipCurrentBeat) keeps the ringing click: the ~100 ms tail
+    // is position-independent and cutting it audibly truncates the last click
+    // of every loop. Any other reset is a start/locate — a stale tail from the
+    // previous run must not resume there.
+    if (!skipCurrentBeat) {
+        m_clickPlaying = false;
+        m_clickPlayhead = 0;
+    }
+
     float bpm = m_bpm.load(std::memory_order_relaxed);
     int beatsPerBar = m_beatsPerBar.load(std::memory_order_relaxed);
 
@@ -219,10 +228,6 @@ void MetronomeEngine::reset(uint64_t globalSamplePos, uint32_t sampleRate, bool 
         }
         m_nextBeatSample = beatSample;
         m_currentBeat = static_cast<int>(beatIndex % beatsPerBar);
-        // Deliberately keep any ringing click playing: reset() also fires when
-        // the transport wraps at a pattern-loop boundary, and killing the tail
-        // there audibly truncates the last click of every loop. The tail is
-        // ~100ms and position-independent, so letting it finish is always safe.
     }
 }
 

--- a/AestraAudio/src/Playback/MetronomeEngine.cpp
+++ b/AestraAudio/src/Playback/MetronomeEngine.cpp
@@ -195,7 +195,7 @@ void MetronomeEngine::loadClickSounds(const std::string& downbeatPath, const std
     m_activeClickSamples = &m_clickSamplesDown;
 }
 
-void MetronomeEngine::reset(uint64_t globalSamplePos, uint32_t sampleRate) {
+void MetronomeEngine::reset(uint64_t globalSamplePos, uint32_t sampleRate, bool skipCurrentBeat) {
     if (sampleRate == 0)
         return;
 
@@ -208,10 +208,21 @@ void MetronomeEngine::reset(uint64_t globalSamplePos, uint32_t sampleRate) {
     uint64_t samplesPerBeatInt = static_cast<uint64_t>(samplesPerBeat);
 
     if (samplesPerBeatInt > 0) {
-        m_nextBeatSample = (globalSamplePos / samplesPerBeatInt) * samplesPerBeatInt;
-        m_currentBeat = static_cast<int>((globalSamplePos / samplesPerBeatInt) % beatsPerBar);
-        m_clickPlaying = false;
-        m_clickPlayhead = 0;
+        uint64_t beatIndex = globalSamplePos / samplesPerBeatInt;
+        uint64_t beatSample = beatIndex * samplesPerBeatInt;
+        // At a loop wrap the boundary beat already clicked in the pre-wrap
+        // timeline (loop end == loop start); re-scheduling it here would make
+        // it fire twice with a cut in between.
+        if (skipCurrentBeat && beatSample == globalSamplePos) {
+            ++beatIndex;
+            beatSample += samplesPerBeatInt;
+        }
+        m_nextBeatSample = beatSample;
+        m_currentBeat = static_cast<int>(beatIndex % beatsPerBar);
+        // Deliberately keep any ringing click playing: reset() also fires when
+        // the transport wraps at a pattern-loop boundary, and killing the tail
+        // there audibly truncates the last click of every loop. The tail is
+        // ~100ms and position-independent, so letting it finish is always safe.
     }
 }
 
@@ -254,7 +265,12 @@ void MetronomeEngine::process(float* outputBuffer, uint32_t numFrames, uint32_t 
             triggerOffset = static_cast<uint32_t>(m_nextBeatSample - blockStart);
             break;
         }
+        // Skipping past an already-elapsed beat (after a reset/jump): advance
+        // the accent counter with it, or the next audible beat replays the
+        // skipped beat's sound — after a loop wrap that meant a second
+        // downbeat click right after the real one.
         m_nextBeatSample += samplesPerBeat;
+        m_currentBeat = (m_currentBeat + 1) % beatsPerBar;
     }
 
     // Mix TAIL

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -163,6 +163,12 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
         for (auto& inst : m_activeInstances) {
             inst.scheduledThroughFrame = 0;
         }
+        // The frame domain jumped backwards (bounce restart, stop→locate):
+        // events already queued for the old, higher frames — including the
+        // next loop iteration pre-scheduled before a wrap — would sit at the
+        // queue head and block everything queued below them. Drain; the
+        // window below re-queues whatever is actually due.
+        m_rtQueue.forceDrain();
     }
     m_lastRefillFrame = currentFrame;
 

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -138,7 +138,8 @@ uint16_t PatternPlaybackEngine::getChannelForUnit(UnitID unitId) const {
     return static_cast<uint16_t>(std::max(0, std::min(unit->targetMixerRoute, 15)));
 }
 
-void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, int lookaheadSamples) {
+void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, int lookaheadSamples,
+                                         uint64_t loopLengthSamples) {
     // RT safety: this method must NOT be called from the audio callback.
     // It acquires a mutex, allocates from scratch buffer, and calls pattern lookup.
     // See performNonRealtimeMaintenance() for the correct call site.
@@ -190,6 +191,18 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
             continue;
         }
 
+        // Looped pattern mode works in a monotonic frame domain: iterate every
+        // loop pass that intersects the window so the next iteration's events
+        // (downbeat included) are queued BEFORE the wrap, sample-accurately.
+        uint64_t iterBegin = 0;
+        uint64_t iterEnd = 0;
+        if (loopLengthSamples > 0) {
+            iterBegin = scheduleFromFrame / loopLengthSamples;
+            iterEnd = (windowEnd - 1) / loopLengthSamples;
+        }
+
+        for (uint64_t loopIter = iterBegin; loopIter <= iterEnd; ++loopIter) {
+        const uint64_t loopBase = loopIter * loopLengthSamples;
         for (const auto& note : midi.notes) {
             const double noteStartInSource = note.startBeat;
             const double noteEndInSource = note.startBeat + note.durationBeats;
@@ -203,7 +216,7 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                                              ? resolvePitchedSamplerMidiNote(note, resolveSamplerRootMidiNote(unit))
                                              : std::clamp(note.pitch, 0, 127);
             double noteBeat = inst.startBeat + note.startBeat;
-            uint64_t noteFrame = m_clock->sampleFrameAtBeat(noteBeat, sampleRate);
+            uint64_t noteFrame = loopBase + m_clock->sampleFrameAtBeat(noteBeat, sampleRate);
             double offBeat = std::min(noteBeat + note.durationBeats, inst.startBeat + inst.sourceEndBeat);
             bool suppressNoteOff = false;
 
@@ -221,7 +234,7 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 }
             }
 
-            uint64_t offFrame = m_clock->sampleFrameAtBeat(offBeat, sampleRate);
+            uint64_t offFrame = loopBase + m_clock->sampleFrameAtBeat(offBeat, sampleRate);
 
             uint16_t channelIdx = getChannelForUnit(note.unitId);
 
@@ -298,6 +311,7 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 m_scratchEvents.push_back(offEvent);
             }
         }
+        } // loopIter
 
         inst.scheduledThroughFrame = windowEnd;
     }

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -1,6 +1,7 @@
 #include "Plugin/SamplerPlugin.h"
 
 #include "AestraJSON.h"
+#include "AestraLog.h"
 #include "Plugin/BuiltInPlugins.h"
 #include "GarbageCollector.h"
 #include "IO/MiniAudioDecoder.h"
@@ -621,7 +622,12 @@ std::vector<PluginParameter> SamplerPlugin::getParameters() const {
     params.push_back({kParamDecay, "Decay", "Dec", "s", 0.1f, 0.0f, 2.0f});
     params.push_back({kParamSustain, "Sustain", "Sus", "", 1.0f, 0.0f, 1.0f});
     params.push_back({kParamRelease, "Release", "Rel", "s", 0.5f, 0.0f, 5.0f});
-    params.push_back({kParamPitch, "Pitch", "Ptc", "st", 0.0f, -24.0f, 24.0f});
+    // Pitch is STORED normalized (0.5 = 0 st; see getCoarseSemitones). The
+    // declared default/range must match the stored encoding: plugin creation
+    // writes param.defaultValue straight back via setParameter (BuiltInPlugins
+    // applyInfo), and a semitone-encoded 0.0 default here transposed every
+    // fresh sampler down an octave.
+    params.push_back({kParamPitch, "Pitch", "Ptc", "", 0.5f, 0.0f, 1.0f});
     return params;
 }
 
@@ -643,6 +649,10 @@ void SamplerPlugin::setParameter(uint32_t id, float value) {
 std::string SamplerPlugin::getParameterDisplay(uint32_t id) const {
     if (id >= kParamCount)
         return "";
+    if (id == kParamPitch) {
+        // Stored normalized; display in musician units.
+        return std::to_string(getCoarseSemitones()) + " st";
+    }
     float val = m_params[id].load();
     return std::to_string(val);
 }

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -101,6 +101,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/NUIVisualWidgets.cpp
     Widgets/NUIUtilityWidgets.h
     Widgets/NUIUtilityWidgets.cpp
+    Widgets/NotificationToast.h
+    Widgets/NotificationToast.cpp
     Widgets/NUIThematicWidgets.h
     Widgets/NUIThematicWidgets.cpp
     Widgets/NUIStepSequencer.h

--- a/AestraUI/Graphics/NUITextRendererSDF.cpp
+++ b/AestraUI/Graphics/NUITextRendererSDF.cpp
@@ -283,17 +283,24 @@ bool NUITextRendererSDF::loadFontAtlas(const std::string& fontPath, float fontSi
         // Get actual space advance from font metrics (this is the key fix!)
         int spaceAdvance, spaceLsb;
         stbtt_GetCodepointHMetrics(&font, ' ', &spaceAdvance, &spaceLsb);
-        
+
+        // Geist and Manrope declare a 0.20 em space — well below the 0.25–0.33 em
+        // of typical UI fonts — so at UI sizes words visually run together
+        // ("Audio,MIDI,and"). Floor the advance at 0.26 em. measureText shares
+        // glyphs_, so layout and rendering stay consistent.
+        const float unitsPerEm = 1.0f / stbtt_ScaleForMappingEmToPixels(&font, 1.0f);
+        const float minSpaceUnits = 0.26f * unitsPerEm;
+
         GlyphData spaceGlyph{};
         spaceGlyph.width = 0.0f;
         spaceGlyph.height = 0.0f;
         spaceGlyph.bearingX = 0.0f;
         spaceGlyph.bearingY = 0.0f;
-        spaceGlyph.advance = spaceAdvance * scale;  // Use ACTUAL font metrics
+        spaceGlyph.advance = std::max(static_cast<float>(spaceAdvance), minSpaceUnits) * scale;
         spaceGlyph.u0 = spaceGlyph.u1 = spaceGlyph.v0 = spaceGlyph.v1 = 0.0f;
         glyphs_[' '] = spaceGlyph;
-        
-        std::cout << "Space character created with advance: " << spaceGlyph.advance 
+
+        std::cout << "Space character created with advance: " << spaceGlyph.advance
                   << "px (font metrics)" << std::endl;
     }
 

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -2294,6 +2294,16 @@ charSet.push_back(0x23F9); // ⏹ Stop
             charData.bearingX = ftFace_->glyph->bitmap_left;
             charData.bearingY = ftFace_->glyph->bitmap_top;
             charData.advance = ftFace_->glyph->advance.x;
+            if (codepoint == ' ') {
+                // Geist/Manrope declare a 0.20 em space — well under the
+                // 0.25-0.33 em of typical UI fonts — so at UI sizes words
+                // visually run together ("Audio,MIDI,and"). Floor it at
+                // 0.26 em (26.6 fixed point). measureText shares this cache,
+                // so layout and rendering stay consistent.
+                const int minSpace =
+                    static_cast<int>(0.26f * ftFace_->size->metrics.x_ppem * 64.0f);
+                charData.advance = std::max(charData.advance, minSpace);
+            }
 
             float invW = 1.0f / fontAtlasWidth_;
             float invH = 1.0f / fontAtlasHeight_;
@@ -2481,6 +2491,11 @@ bool NUIRendererGL::tryAddGlyphToAtlas(uint32_t codepoint, FT_Face face, int atl
     charData.bearingX = face->glyph->bitmap_left;
     charData.bearingY = face->glyph->bitmap_top;
     charData.advance = face->glyph->advance.x;
+    if (codepoint == ' ') {
+        // Same 0.26 em space floor as the preload path — see comment there.
+        const int minSpace = static_cast<int>(0.26f * face->size->metrics.x_ppem * 64.0f);
+        charData.advance = std::max(charData.advance, minSpace);
+    }
     float invW = 1.0f / fontAtlasWidth_;
     float invH = 1.0f / fontAtlasHeight_;
     charData.u0 = atlasX * invW;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -313,6 +313,10 @@ public:
         std::vector<MidiNote> notes;
         /** @brief Ghost overlay color. */
         AestraUI::NUIColor color;
+        /** @brief Fill alpha — same-pattern unit ghosts read stronger than cross-pattern ghosts. */
+        float fillAlpha{0.1f};
+        /** @brief Stroke alpha. */
+        float strokeAlpha{0.2f};
     };
 
     /** @brief Create the editable piano-roll note layer. */

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -169,9 +169,14 @@ public:
     void setNoteLayer(std::shared_ptr<PianoRollNoteLayer> notes); // To set tools directly
     void setPatternLengthBeats(double beats);
     void setPatternChoices(const std::vector<PatternChoice>& choices, int selectedValue);
+    /** @brief Populate the unit switcher (reuses the PatternChoice value/label shape). */
+    void setUnitChoices(const std::vector<PatternChoice>& choices, int selectedValue);
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb) { onAdjustPatternLength_ = std::move(cb); }
     void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb) {
         onPatternChoiceSelected_ = std::move(cb);
+    }
+    void setOnUnitChoiceSelected(std::function<void(int unitValue)> cb) {
+        onUnitChoiceSelected_ = std::move(cb);
     }
     /** @brief Set callback fired by the menu's "Keyboard Shortcuts" item. */
     void setOnShowShortcutHelp(std::function<void()> cb) { onShowShortcutHelp_ = std::move(cb); }
@@ -193,8 +198,11 @@ private:
     std::shared_ptr<NUIButton> m_lengthDownBtn;
     std::shared_ptr<NUIButton> m_lengthUpBtn;
     std::shared_ptr<NUIDropdown> m_patternDropdown;
-    
+    std::shared_ptr<NUIDropdown> m_unitDropdown;
+    std::shared_ptr<NUIDropdown> m_snapDropdown;
+
     GlobalTool activeTool_ = GlobalTool::Pencil;
+    void applySnap(SnapGrid snap);
     
     // Icons
     std::shared_ptr<AestraUI::NUIIcon> m_menuIcon;
@@ -210,8 +218,11 @@ private:
     std::shared_ptr<NUIComponent> m_activeContextMenu;
     std::function<void(int barsDelta)> onAdjustPatternLength_;
     std::function<void(int patternValue)> onPatternChoiceSelected_;
+    std::function<void(int unitValue)> onUnitChoiceSelected_;
     std::function<void()> onShowShortcutHelp_;
     bool m_updatingPatternDropdown = false;
+    bool m_updatingUnitDropdown = false;
+    bool m_updatingSnapDropdown = false;
     SnapGrid m_currentSnap = SnapGrid::Beat;
 
     void closeActiveContextMenu();
@@ -616,6 +627,7 @@ public:
     const std::vector<MidiNote>& getNotes() const;
     void setPatternName(const std::string& name);
     void setPatternChoices(const std::vector<PianoRollToolbar::PatternChoice>& choices, int selectedValue);
+    void setUnitChoices(const std::vector<PianoRollToolbar::PatternChoice>& choices, int selectedValue);
     void setPatternLengthBeats(double beats);
     void setPlayheadBeat(double beat, bool follow = false);
     void setTotalDurationBeats(double beats);
@@ -636,6 +648,7 @@ public:
     void setOnPreviewNote(std::function<void(int pitch, int velocity)> cb);
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb);
     void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb);
+    void setOnUnitChoiceSelected(std::function<void(int unitValue)> cb);
     void setOnPlayheadScrubbed(std::function<void(double beat, bool active)> cb);
 
     void setPixelsPerBeat(float ppb);

--- a/AestraUI/Widgets/NUIUtilityWidgets.cpp
+++ b/AestraUI/Widgets/NUIUtilityWidgets.cpp
@@ -77,37 +77,6 @@ void Tooltip::setText(const std::string& text)
     repaint();
 }
 
-NotificationToast::NotificationToast()
-    : duration_(2.0), elapsed_(0.0)
-{
-}
-
-void NotificationToast::onRender(NUIRenderer& renderer)
-{
-    (void)renderer;
-}
-
-void NotificationToast::onUpdate(double deltaTime)
-{
-    elapsed_ += deltaTime;
-    if (elapsed_ >= duration_)
-    {
-        setVisible(false);
-    }
-}
-
-void NotificationToast::setText(const std::string& text)
-{
-    text_ = text;
-    repaint();
-}
-
-void NotificationToast::setDuration(double duration)
-{
-    duration_ = std::max(0.1, duration);
-    elapsed_ = 0.0;
-}
-
 ContextMenu::ContextMenu() = default;
 
 ModalOverlay::ModalOverlay()

--- a/AestraUI/Widgets/NUIUtilityWidgets.h
+++ b/AestraUI/Widgets/NUIUtilityWidgets.h
@@ -77,23 +77,10 @@ private:
     std::string text_;
 };
 
-class NotificationToast : public NUIComponent {
-public:
-    NotificationToast();
-
-    void onRender(NUIRenderer& renderer) override;
-    void onUpdate(double deltaTime) override;
-
-    void setText(const std::string& text);
-    const std::string& getText() const { return text_; }
-
-    void setDuration(double duration);
-
-private:
-    std::string text_;
-    double duration_;
-    double elapsed_;
-};
+// NotificationToast lives in Widgets/NotificationToast.h — this header's
+// FileBrowser/PluginBrowser stubs clash with the real Source/Components
+// classes of the same names, so app code must be able to get the toast
+// without including them.
 
 class ContextMenu : public NUIPopupMenu {
 public:

--- a/AestraUI/Widgets/NotificationToast.cpp
+++ b/AestraUI/Widgets/NotificationToast.cpp
@@ -47,6 +47,11 @@ void NotificationToast::onUpdate(double deltaTime)
     repaint(); // animate the fade while visible
 }
 
+bool NotificationToast::onMouseEvent(const NUIMouseEvent& /*event*/)
+{
+    return false; // passive overlay — never intercept
+}
+
 void NotificationToast::setText(const std::string& text)
 {
     text_ = text;

--- a/AestraUI/Widgets/NotificationToast.cpp
+++ b/AestraUI/Widgets/NotificationToast.cpp
@@ -1,0 +1,62 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "NotificationToast.h"
+
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include <algorithm>
+
+namespace AestraUI {
+
+NotificationToast::NotificationToast()
+    : duration_(2.0), elapsed_(0.0)
+{
+}
+
+void NotificationToast::onRender(NUIRenderer& renderer)
+{
+    if (text_.empty())
+        return;
+
+    // Fade out over the toast's final moments instead of vanishing.
+    constexpr double kFadeSeconds = 0.35;
+    const double remaining = duration_ - elapsed_;
+    const float alpha = remaining >= kFadeSeconds
+        ? 1.0f
+        : std::max(0.0f, static_cast<float>(remaining / kFadeSeconds));
+
+    auto& theme = NUIThemeManager::getInstance();
+    const NUIRect bounds = getBounds();
+    constexpr float kFontSize = 12.0f;
+    const NUISize textSize = renderer.measureText(text_, kFontSize);
+    const float pillW = std::min(bounds.width, textSize.width + 32.0f);
+    const float pillH = std::min(bounds.height, 28.0f);
+    const NUIRect pill(bounds.x + (bounds.width - pillW) * 0.5f,
+                       bounds.y + (bounds.height - pillH) * 0.5f, pillW, pillH);
+    renderer.fillRoundedRect(pill, pillH * 0.5f, theme.getColor("surfaceTertiary").withAlpha(0.92f * alpha));
+    renderer.strokeRoundedRect(pill, pillH * 0.5f, 1.0f, theme.getColor("accentPrimary").withAlpha(0.55f * alpha));
+    renderer.drawTextCentered(text_, pill, kFontSize, theme.getColor("textPrimary").withAlpha(alpha));
+}
+
+void NotificationToast::onUpdate(double deltaTime)
+{
+    elapsed_ += deltaTime;
+    if (elapsed_ >= duration_)
+    {
+        setVisible(false);
+    }
+    repaint(); // animate the fade while visible
+}
+
+void NotificationToast::setText(const std::string& text)
+{
+    text_ = text;
+    repaint();
+}
+
+void NotificationToast::setDuration(double duration)
+{
+    duration_ = std::max(0.1, duration);
+    elapsed_ = 0.0;
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/NotificationToast.h
+++ b/AestraUI/Widgets/NotificationToast.h
@@ -18,6 +18,10 @@ public:
 
     void onRender(NUIRenderer& renderer) override;
     void onUpdate(double deltaTime) override;
+    /** Always mouse-transparent: the toast is a passive overlay and must never
+        consume clicks from the panels beneath it, even while it owns the
+        top-most z-order. */
+    bool onMouseEvent(const NUIMouseEvent& event) override;
 
     void setText(const std::string& text);
     const std::string& getText() const { return text_; }

--- a/AestraUI/Widgets/NotificationToast.h
+++ b/AestraUI/Widgets/NotificationToast.h
@@ -1,0 +1,34 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "NUIComponent.h"
+#include <string>
+
+namespace AestraUI {
+
+/**
+ * Transient status pill (toast). The owner sets an anchor strip via
+ * setBounds; the toast draws a centered pill sized to its text and hides
+ * itself after the configured duration (with a short fade). It installs no
+ * mouse handlers, so it never steals clicks from components beneath it.
+ */
+class NotificationToast : public NUIComponent {
+public:
+    NotificationToast();
+
+    void onRender(NUIRenderer& renderer) override;
+    void onUpdate(double deltaTime) override;
+
+    void setText(const std::string& text);
+    const std::string& getText() const { return text_; }
+
+    /** Restarts the visible window; the toast hides itself when it elapses. */
+    void setDuration(double duration);
+
+private:
+    std::string text_;
+    double duration_;
+    double elapsed_;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/PianoRollNoteLayer.cpp
+++ b/AestraUI/Widgets/PianoRollNoteLayer.cpp
@@ -545,8 +545,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
     
     // 1. GHOST NOTES (Read-only backgrounds)
     for (const auto& ghost : ghostPatterns_) {
-        NUIColor gCol = ghost.color.withAlpha(0.1f); 
-        NUIColor gBorder = ghost.color.withAlpha(0.2f);
+        NUIColor gCol = ghost.color.withAlpha(ghost.fillAlpha);
+        NUIColor gBorder = ghost.color.withAlpha(ghost.strokeAlpha);
         
         for (const auto& n : ghost.notes) {
             float x = snapRectX(beatToScreenX(n.startBeat, pixelsPerBeat_, scrollX_, b.x));

--- a/AestraUI/Widgets/PianoRollToolbar.cpp
+++ b/AestraUI/Widgets/PianoRollToolbar.cpp
@@ -60,10 +60,7 @@ void PianoRollToolbar::setupUI() {
         auto snaps = MusicTheory::getSnapOptions();
         for (auto snap : snaps) {
             snapMenu->addItem(MusicTheory::getSnapName(snap), [this, snap]() {
-                m_currentSnap = snap;
-                if (auto g = grid_.lock()) g->setSnap(snap);
-                if (auto n = notes_.lock()) n->setSnap(snap);
-                repaint();
+                applySnap(snap);
             });
         }
         menu->addSubmenu("Snap", snapMenu);
@@ -167,6 +164,30 @@ void PianoRollToolbar::setupUI() {
         }
     });
 
+    m_unitDropdown = std::make_shared<NUIDropdown>();
+    m_unitDropdown->setPlaceholderText("Unit");
+    m_unitDropdown->setMaxVisibleItems(8);
+    m_unitDropdown->setItemHeight(24.0f);
+    m_unitDropdown->setOnSelectionChanged([this](int, int value, const std::string&) {
+        if (!m_updatingUnitDropdown && onUnitChoiceSelected_) {
+            onUnitChoiceSelected_(value);
+        }
+    });
+
+    m_snapDropdown = std::make_shared<NUIDropdown>();
+    m_snapDropdown->setPlaceholderText("Snap");
+    m_snapDropdown->setMaxVisibleItems(8);
+    m_snapDropdown->setItemHeight(24.0f);
+    for (auto snap : MusicTheory::getSnapOptions()) {
+        m_snapDropdown->addItem(MusicTheory::getSnapName(snap), static_cast<int>(snap));
+    }
+    m_snapDropdown->setSelectedByValue(static_cast<int>(m_currentSnap));
+    m_snapDropdown->setOnSelectionChanged([this](int, int value, const std::string&) {
+        if (!m_updatingSnapDropdown) {
+            applySnap(static_cast<SnapGrid>(value));
+        }
+    });
+
     m_lengthDownBtn = std::make_shared<NUIButton>("");
     m_lengthDownBtn->setTooltip("Shorten Pattern By 2 Bars");
     m_lengthDownBtn->setOnClick([this]() {
@@ -199,8 +220,22 @@ void PianoRollToolbar::setupUI() {
     addChild(m_pencilBtn);
     addChild(m_eraserBtn);
     addChild(m_patternDropdown);
+    addChild(m_unitDropdown);
+    addChild(m_snapDropdown);
     addChild(m_lengthDownBtn);
     addChild(m_lengthUpBtn);
+}
+
+void PianoRollToolbar::applySnap(SnapGrid snap) {
+    m_currentSnap = snap;
+    if (auto g = grid_.lock()) g->setSnap(snap);
+    if (auto n = notes_.lock()) n->setSnap(snap);
+    if (m_snapDropdown) {
+        m_updatingSnapDropdown = true;
+        m_snapDropdown->setSelectedByValue(static_cast<int>(snap));
+        m_updatingSnapDropdown = false;
+    }
+    repaint();
 }
 
 void PianoRollToolbar::setPatternName(const std::string& name) {
@@ -225,6 +260,21 @@ void PianoRollToolbar::setPatternChoices(const std::vector<PatternChoice>& choic
     }
     m_patternDropdown->setSelectedByValue(selectedValue);
     m_updatingPatternDropdown = false;
+    repaint();
+}
+
+void PianoRollToolbar::setUnitChoices(const std::vector<PatternChoice>& choices, int selectedValue) {
+    if (!m_unitDropdown) {
+        return;
+    }
+
+    m_updatingUnitDropdown = true;
+    m_unitDropdown->clearItems();
+    for (const auto& choice : choices) {
+        m_unitDropdown->addItem(choice.label, choice.value);
+    }
+    m_unitDropdown->setSelectedByValue(selectedValue);
+    m_updatingUnitDropdown = false;
     repaint();
 }
 
@@ -320,6 +370,17 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
         currentX += dropdownW + buttonSpacing;
     }
 
+    if (m_unitDropdown) {
+        currentX += 8.0f;
+
+        const float unitDropdownW = std::clamp(b.width * 0.18f, 140.0f, 200.0f);
+        drawGroup(currentX - 3.0f, unitDropdownW + 6.0f);
+        m_unitDropdown->setBounds(NUIRect(currentX, currentY, unitDropdownW, buttonSize));
+        m_unitDropdown->onRender(renderer);
+        patternDropdownRight = currentX + unitDropdownW;
+        currentX += unitDropdownW + buttonSpacing;
+    }
+
     currentX += 8.0f;
 
     const int patternBars = std::max(1, static_cast<int>(std::lround(m_patternLengthBeats / 4.0)));
@@ -347,50 +408,20 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
 
     renderButton(m_lengthUpBtn, m_lengthUpIcon, false);
 
+    // Snap selector — a real dropdown (was a dead "SNAP Beat" text pill). The
+    // menu's Snap submenu and this dropdown stay in sync via applySnap().
     currentX += 8.0f;
-    const std::string snapLabel = "SNAP  " + MusicTheory::getSnapName(m_currentSnap);
-    const float snapFontSize = 9.0f;
-    const auto snapTextSize = renderer.measureText(snapLabel, snapFontSize);
-    const float snapWidth = std::max(78.0f, snapTextSize.width + 18.0f);
-    const NUIRect snapRect(currentX, currentY, snapWidth, buttonSize);
-    renderer.fillRoundedRect(snapRect, radius, groupBg);
-    renderer.strokeRoundedRect(snapRect, radius, 1.0f, groupBorder);
-    renderer.drawText(snapLabel,
-                      NUIPoint(snapRect.x + (snapRect.width - snapTextSize.width) * 0.5f,
-                               snapRect.y + (snapRect.height - snapTextSize.height) * 0.5f + 1.0f),
-                      snapFontSize,
-                      themeManager.getColor("textSecondary").withAlpha(0.76f));
-    currentX += snapWidth;
-
-    // Editing Pattern Label (Right Side)
-    if (!m_patternName.empty()) {
-        const float labelLeft = std::max(patternDropdownRight + 10.0f, currentX + 12.0f);
-        const float labelRight = b.right() - innerPad - 4.0f;
-        const float maxLabelWidth = labelRight - labelLeft;
-        if (maxLabelWidth < 24.0f) {
-            return;
-        }
-
-        std::string labelStr = m_patternName;
-        float fontSize = 10.0f;
-        auto measured = renderer.measureText(labelStr, fontSize);
-        while (measured.width > maxLabelWidth && labelStr.length() > 3) {
-            labelStr.pop_back();
-            measured = renderer.measureText(labelStr + "...", fontSize);
-        }
-        if (measured.width > maxLabelWidth) {
-            labelStr = "...";
-        } else if (labelStr.length() < m_patternName.length()) {
-            labelStr += "...";
-        }
-        auto size = renderer.measureText(labelStr, fontSize);
-        float lx = std::max(labelLeft, labelRight - size.width);
-        renderer.drawText(labelStr,
-                          NUIPoint(lx, currentY + (buttonSize - size.height) * 0.5f + 2.0f),
-                          fontSize,
-                          themeManager.getColor("textSecondary").withAlpha(0.68f));
+    if (m_snapDropdown) {
+        const float snapDropdownW = 104.0f;
+        drawGroup(currentX - 3.0f, snapDropdownW + 6.0f);
+        m_snapDropdown->setBounds(NUIRect(currentX, currentY, snapDropdownW, buttonSize));
+        m_snapDropdown->onRender(renderer);
+        currentX += snapDropdownW;
     }
 
+    // (The redundant right-side "Pattern · Unit" label was removed — the Pattern
+    // and Unit dropdowns already show that state.)
+    (void)patternDropdownRight;
 }
 
 void PianoRollToolbar::setGrid(std::shared_ptr<PianoRollGrid> grid) {
@@ -415,13 +446,21 @@ void PianoRollToolbar::setActiveTool(GlobalTool tool) {
 
 
 bool PianoRollToolbar::onMouseEvent(const NUIMouseEvent& event) {
+    // Dropdowns first — an open one's popup list extends below the toolbar strip,
+    // so it must get first crack at clicks (and this override otherwise never
+    // forwards events to the dropdown children at all, which is why the Pattern /
+    // Unit / Snap dropdowns did nothing).
+    if (m_patternDropdown && m_patternDropdown->onMouseEvent(event)) return true;
+    if (m_unitDropdown && m_unitDropdown->onMouseEvent(event)) return true;
+    if (m_snapDropdown && m_snapDropdown->onMouseEvent(event)) return true;
+
     if (m_menuBtn->onMouseEvent(event)) return true;
     if (m_ptrBtn->onMouseEvent(event)) return true;
     if (m_pencilBtn->onMouseEvent(event)) return true;
     if (m_eraserBtn->onMouseEvent(event)) return true;
     if (m_lengthDownBtn->onMouseEvent(event)) return true;
     if (m_lengthUpBtn->onMouseEvent(event)) return true;
-    
+
     return false;
 }
 

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -665,6 +665,12 @@ void PianoRollView::setPatternChoices(const std::vector<PianoRollToolbar::Patter
     }
 }
 
+void PianoRollView::setUnitChoices(const std::vector<PianoRollToolbar::PatternChoice>& choices, int selectedValue) {
+    if (m_toolbar) {
+        m_toolbar->setUnitChoices(choices, selectedValue);
+    }
+}
+
 void PianoRollView::setPatternLengthBeats(double beats) {
     m_patternLengthBeats = std::max(8.0, beats);
     if (m_toolbar) {
@@ -719,6 +725,12 @@ void PianoRollView::setOnAdjustPatternLength(std::function<void(int barsDelta)> 
 void PianoRollView::setOnPatternChoiceSelected(std::function<void(int patternValue)> cb) {
     if (m_toolbar) {
         m_toolbar->setOnPatternChoiceSelected(std::move(cb));
+    }
+}
+
+void PianoRollView::setOnUnitChoiceSelected(std::function<void(int unitValue)> cb) {
+    if (m_toolbar) {
+        m_toolbar->setOnUnitChoiceSelected(std::move(cb));
     }
 }
 

--- a/AestraUI/Widgets/UnitNameLabel.cpp
+++ b/AestraUI/Widgets/UnitNameLabel.cpp
@@ -110,11 +110,9 @@ bool UnitNameLabel::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
-    if (event.pressed && event.button == NUIMouseButton::Right) {
-        showNameContextMenu(event.position);
-        return true;
-    }
-
+    // Right-click falls through to UnitRow, whose row context menu already
+    // offers Rename (a label-local menu shown here was positioned in
+    // row-local coordinates and never appeared on screen).
     return false;
 }
 
@@ -122,12 +120,6 @@ bool UnitNameLabel::onKeyEvent(const NUIKeyEvent& event) {
     if (m_isRenaming && m_textInput)
         return m_textInput->onKeyEvent(event);
     return false;
-}
-
-void UnitNameLabel::showNameContextMenu(const NUIPoint& pos) {
-    auto menu = std::make_shared<NUIContextMenu>();
-    menu->addItem("Rename", [this]() { beginRename(); });
-    menu->showAt(pos);
 }
 
 void UnitNameLabel::beginRename() {

--- a/AestraUI/Widgets/UnitNameLabel.h
+++ b/AestraUI/Widgets/UnitNameLabel.h
@@ -38,7 +38,6 @@ public:
 private:
     void commitRename();
     void cancelRename();
-    void showNameContextMenu(const NUIPoint& pos);
 
     std::string m_unitName;
     Aestra::Audio::UnitType m_unitType;

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -422,6 +422,12 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     std::sort(activeSteps.begin(), activeSteps.end());
     activeSteps.erase(std::unique(activeSteps.begin(), activeSteps.end()), activeSteps.end());
 
+    // Live playhead within the pattern — used to light up the step / note the
+    // transport is currently over so the user can track it and time their edits.
+    const double playBeat = playheadBeatInPattern();
+    const int playStep = (playBeat >= 0.0) ? static_cast<int>(std::floor(playBeat / 0.25)) : -1;
+    const NUIColor playheadAccent = theme.getColor("accentPrimary");
+
     if (m_type == Aestra::Audio::UnitType::Sampler && !noteRollMode) {
         const NUIColor inactiveFill = theme.getColor("surfaceTertiary");
         const NUIColor inactiveStroke = theme.getColor("border").withAlpha(0.10f);
@@ -439,9 +445,18 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             }
 
             const bool isActive = std::binary_search(activeSteps.begin(), activeSteps.end(), step);
+            const bool isPlayhead = (step == playStep);
             NUIRect cellRect(cellX, cellY, cellWidth, cellHeight);
-            renderer.fillRoundedRect(cellRect, cellRadius, isActive ? activeFill : inactiveFill);
+            NUIColor cellFill = isActive ? activeFill : inactiveFill;
+            if (isPlayhead && isActive) {
+                cellFill = activeFill.lightened(0.35f); // note lights up under the playhead
+            }
+            renderer.fillRoundedRect(cellRect, cellRadius, cellFill);
             renderer.strokeRoundedRect(cellRect, cellRadius, 1.0f, inactiveStroke);
+            if (isPlayhead) {
+                renderer.strokeRoundedRect(cellRect, cellRadius, 1.5f,
+                                           playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
+            }
 
             if ((step + 1) % 4 == 0 && step + 1 < m_stepCount) {
                 const float markerX = cellRect.right() + (cellGap * 0.5f);
@@ -472,9 +487,18 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                 continue;
             }
             const bool isActive = std::binary_search(activeSteps.begin(), activeSteps.end(), step);
+            const bool isPlayhead = (step == playStep);
             NUIRect cellRect(cellX, topY, cellWidth, topHeight);
-            renderer.fillRoundedRect(cellRect, 3.0f, isActive ? activeFill : inactiveFill);
+            NUIColor cellFill = isActive ? activeFill : inactiveFill;
+            if (isPlayhead && isActive) {
+                cellFill = activeFill.lightened(0.35f);
+            }
+            renderer.fillRoundedRect(cellRect, 3.0f, cellFill);
             renderer.strokeRoundedRect(cellRect, 3.0f, 1.0f, inactiveStroke);
+            if (isPlayhead) {
+                renderer.strokeRoundedRect(cellRect, 3.0f, 1.5f,
+                                           playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
+            }
 
             const NUIRect pitchRect(cellX, pitchY, cellWidth, pitchLaneHeight);
             if (stepPitch[step] >= 0) {
@@ -541,8 +565,9 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             float normalizedPitch = static_cast<float>(span.pitch - minPitch) / static_cast<float>(pitchRange);
             float noteY = timelineStrip.bottom() - 2.0f - (normalizedPitch * (timelineStrip.height - noteHeight - 4.0f)) - noteHeight;
             NUIRect noteRect(startX, noteY, width, noteHeight);
-            renderer.fillRoundedRect(noteRect, 2.0f, noteFill);
-            renderer.strokeRoundedRect(noteRect, 2.0f, 1.0f, noteStroke);
+            const bool isPlaying = (playBeat >= 0.0 && playBeat >= span.startBeat && playBeat < span.endBeat);
+            renderer.fillRoundedRect(noteRect, 2.0f, isPlaying ? playheadAccent : noteFill);
+            renderer.strokeRoundedRect(noteRect, 2.0f, 1.0f, isPlaying ? playheadAccent : noteStroke);
         }
     } else if (m_type == Aestra::Audio::UnitType::Audio) {
         if (!m_audioPreviewWaveform.empty()) {
@@ -574,6 +599,26 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                                   9.0f,
                                   theme.getColor("textSecondary").withAlpha(0.72f));
     }
+}
+
+double UnitRow::playheadBeatInPattern() const {
+    if (!m_trackManager || !m_trackManager->isPatternMode()) {
+        return -1.0;
+    }
+    double lengthBeats = static_cast<double>(m_stepCount) * 0.25;
+    if (m_patternId.isValid()) {
+        if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId)) {
+            lengthBeats = std::max(lengthBeats, pattern->lengthBeats);
+        }
+    }
+    if (lengthBeats <= 0.0) {
+        return -1.0;
+    }
+    const double bpm = m_trackManager->getTimelineClock().getCurrentTempo();
+    double beat = m_trackManager->getPosition() * (bpm / 60.0);
+    beat = std::fmod(beat, lengthBeats);
+    if (beat < 0.0) beat += lengthBeats;
+    return beat;
 }
 
 bool UnitRow::shouldUseNoteRoll() const {
@@ -886,7 +931,17 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
             }
 
             const int defaultPitch = (m_type == Aestra::Audio::UnitType::PitchedSampler) ? 36 : 60;
-            midi.notes.push_back({defaultPitch, targetBeat, 0.25, 100.0f / 127.0f, m_unitId});
+            // NB: set fields explicitly — positional aggregate init would drop
+            // m_unitId into MidiNote::pan (the field before unitId) and leave
+            // unitId=0, which auditions/displays fine but is silently dropped by
+            // the playback router (routes require unitId != 0). Cf. AudioSlice #447.
+            Aestra::Audio::MidiNote note;
+            note.pitch = defaultPitch;
+            note.startBeat = targetBeat;
+            note.durationBeats = 0.25;
+            note.velocity = 100.0f / 127.0f;
+            note.unitId = m_unitId;
+            midi.notes.push_back(note);
         });
 
         if (removedExisting) {
@@ -898,10 +953,16 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
             m_stepEditStart = stepIndex;
             m_stepEditEndExclusive = stepIndex + 1;
 
+            // Audible feedback for the step just placed. The engine reads
+            // value1 as the MIDI note and value2 as normalized velocity
+            // (0..1, scaled by 127). Match the note we just wrote so the
+            // click actually plays the sampler instead of note 0 at v1.
+            const int auditionPitch = (m_type == Aestra::Audio::UnitType::PitchedSampler) ? 36 : 60;
             Aestra::Audio::AudioQueueCommand audCmd;
             audCmd.type = Aestra::Audio::AudioQueueCommandType::AuditionUnit;
             audCmd.trackIndex = m_unitId;
-            audCmd.value1 = 0.8f;
+            audCmd.value1 = static_cast<float>(auditionPitch);
+            audCmd.value2 = 100.0f / 127.0f;
             if (m_trackManager) {
                 m_trackManager->pushAudioCommand(audCmd);
             }

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -436,7 +436,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                 if (note.unitId != m_unitId && note.unitId != 0) continue;
                 unitHasContent = true;
                 if (m_type == Aestra::Audio::UnitType::Sampler &&
-                    (note.pitch != 60 || std::abs(note.durationBeats - 0.25) > 0.01)) {
+                    (note.pitch != m_rootMidiNote || std::abs(note.durationBeats - 0.25) > 0.01)) {
                     noteRollMode = true;
                 }
                 const int startStep = std::clamp(static_cast<int>(std::floor(note.startBeat / 0.25 + 0.0001)), 0, m_stepCount - 1);
@@ -687,7 +687,7 @@ bool UnitRow::shouldUseNoteRoll() const {
     return std::any_of(midi.notes.begin(), midi.notes.end(), [this](const Aestra::Audio::MidiNote& note) {
         const bool belongsToUnit = note.unitId == m_unitId || note.unitId == 0;
         return belongsToUnit &&
-               (note.pitch != 60 || std::abs(note.durationBeats - 0.25) > 0.01);
+               (note.pitch != m_rootMidiNote || std::abs(note.durationBeats - 0.25) > 0.01);
     });
 }
 

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -66,6 +66,7 @@ UnitRow::UnitRow(std::shared_ptr<Aestra::Audio::TrackManager> trackManager, Aest
 }
 
 void UnitRow::updateState() {
+    m_rootMidiNote = m_manager.getUnitRootMidiNote(m_unitId);
     auto* unit = m_manager.getUnit(m_unitId);
     if (unit) {
         m_name = unit->name;
@@ -145,15 +146,24 @@ void UnitRow::onRender(NUIRenderer& renderer) {
 
     auto bounds = getBounds();
 
+    // Stay inside the panel's list viewport: fully scrolled-out rows draw
+    // nothing, partially visible ones are clipped in drawContent.
+    const bool hasViewport = m_viewport.width > 0.0f && m_viewport.height > 0.0f;
+    if (hasViewport && !bounds.intersects(m_viewport)) {
+        return;
+    }
+
     // Render live for now. The widget cache path is currently producing
     // duplicate/local-space ghosts for Arsenal rows on Linux.
     drawContent(renderer);
-    
+
     // Render dynamic children (Input Widget, Context Menu) on top
     // Push UnitRow position so children (relative coords) draw correctly
+    if (hasViewport) renderer.setClipRect(m_viewport);
     renderer.pushTransform(bounds.x, bounds.y);
     renderChildren(renderer);
     renderer.popTransform();
+    if (hasViewport) renderer.clearClipRect();
 }
 
 void UnitRow::drawContent(NUIRenderer& renderer) {
@@ -162,6 +172,18 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
 
     NUIRect cardBounds = bounds;
     cardBounds.height = 56.0f;
+
+    // Clip all painting to the card, further trimmed to the panel's list
+    // viewport so rows scrolled past the panel edge don't spill over it.
+    NUIRect paintClip = cardBounds;
+    if (m_viewport.width > 0.0f && m_viewport.height > 0.0f) {
+        const float clipTop = std::max(paintClip.y, m_viewport.y);
+        const float clipBottom = std::min(paintClip.bottom(), m_viewport.bottom());
+        paintClip.y = clipTop;
+        paintClip.height = clipBottom - clipTop;
+        if (paintClip.height <= 0.0f) return;
+    }
+    renderer.setClipRect(paintClip);
 
     const auto& themeProps = theme.getCurrentTheme();
     const float radius = std::max(0.0f, themeProps.radiusM - 1.0f);
@@ -200,7 +222,6 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
                       theme.getColor("borderSubtle").withAlpha(0.55f));
 
     NUIRect contextRect(separatorX + 8.0f, cardBounds.y + 6.0f, cardBounds.right() - separatorX - 14.0f, cardBounds.height - 12.0f);
-    renderer.setClipRect(cardBounds);
     drawContextBlock(renderer, contextRect);
     renderer.clearClipRect();
 }
@@ -502,7 +523,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
 
             const NUIRect pitchRect(cellX, pitchY, cellWidth, pitchLaneHeight);
             if (stepPitch[step] >= 0) {
-                const int display = stepPitch[step] - 36;
+                const int display = stepPitch[step] - m_rootMidiNote; // semitones from root
                 renderer.drawTextCentered((display >= 0 ? "+" : "") + std::to_string(display), pitchRect, 8.0f, pitchText);
                 slidePoints.push_back(NUIPoint(pitchRect.x + pitchRect.width * 0.5f, pitchRect.y + pitchRect.height * 0.5f));
             } else {
@@ -643,6 +664,19 @@ bool UnitRow::shouldUseNoteRoll() const {
 }
 
 bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
+    // Pointer events outside the panel's list viewport belong to whatever is
+    // rendered there (rows scrolled out of view are not clickable). Ongoing
+    // drags/step edits keep receiving events so gestures can finish.
+    if (m_viewport.width > 0.0f && m_viewport.height > 0.0f &&
+        !m_isDragging && !m_isStepEditing && !m_viewport.contains(event.position)) {
+        if (m_isHovered || m_hoveredStep != -1) {
+            m_isHovered = false;
+            m_hoveredStep = -1;
+            invalidateVisuals();
+        }
+        return false;
+    }
+
     // Forward to UnitNameLabel first (same local-coordinate transform as old m_nameInput)
     if (m_nameLabel) {
         auto bounds = getBounds();
@@ -686,7 +720,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
                 [this, targetStart](const Aestra::Audio::MidiNote& n) {
                     return n.unitId == m_unitId &&
-                           n.pitch == 60 &&
+                           n.pitch == m_rootMidiNote &&
                            std::abs(n.startBeat - targetStart) < 0.01;
                 });
             if (it != midi.notes.end()) {
@@ -714,28 +748,20 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             if (delta > 10.0f) delta = 1.0f;
             if (delta < -10.0f) delta = -1.0f;
             
-            // If notes exist, scroll pitch viewport instead of horizontal
-            bool hasNotes = false;
-            if (m_patternId.isValid()) {
-                auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
-                if (pattern && pattern->isMidi()) {
-                    auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
-                    for (const auto& note : midi.notes) {
-                        if (note.unitId == m_unitId || note.unitId == 0) {
-                            hasNotes = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            
-            if (hasNotes) {
+            // Step-grid units (Sampler / 808) scroll the grid horizontally so the
+            // whole loop is reachable when it's longer than the row is wide. Only
+            // the piano-roll / note-roll display scrolls the pitch viewport.
+            if (shouldUseNoteRoll()) {
                 // Pitch viewport scroll (up/down = see higher/lower pitches)
                 m_minimapPitchOffset -= delta * 4.0f; // 4 semitones per tick
                 m_minimapPitchOffset = std::clamp(m_minimapPitchOffset, -60.0f, 60.0f);
+            } else if (m_onGridScroll) {
+                // Panel owns the shared offset: it clamps against the loop
+                // width and pushes the result to every row + the header.
+                m_onGridScroll(-delta * 40.0f);
             } else {
-                // Horizontal scroll for step grid
-                m_scrollX -= delta * 40.0f;
+                // Horizontal scroll for step grid (clamped against content in draw)
+                m_scrollX = std::max(0.0f, m_scrollX - delta * 40.0f);
             }
             invalidateVisuals();
             return true;
@@ -919,7 +945,7 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
                 [this, targetBeat](const Aestra::Audio::MidiNote& n) {
                     const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
                     return n.unitId == m_unitId &&
-                           n.pitch == 60 &&
+                           n.pitch == m_rootMidiNote &&
                            targetBeat >= n.startBeat - 0.01 &&
                            targetBeat < endBeat - 0.01;
                 });
@@ -930,7 +956,9 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
                 return;
             }
 
-            const int defaultPitch = (m_type == Aestra::Audio::UnitType::PitchedSampler) ? 36 : 60;
+            // Place at the unit's root so untouched steps play the sample at
+            // its original pitch; transposition belongs to the Piano Roll.
+            const int defaultPitch = m_rootMidiNote;
             // NB: set fields explicitly — positional aggregate init would drop
             // m_unitId into MidiNote::pan (the field before unitId) and leave
             // unitId=0, which auditions/displays fine but is silently dropped by
@@ -957,7 +985,7 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
             // value1 as the MIDI note and value2 as normalized velocity
             // (0..1, scaled by 127). Match the note we just wrote so the
             // click actually plays the sampler instead of note 0 at v1.
-            const int auditionPitch = (m_type == Aestra::Audio::UnitType::PitchedSampler) ? 36 : 60;
+            const int auditionPitch = m_rootMidiNote;
             Aestra::Audio::AudioQueueCommand audCmd;
             audCmd.type = Aestra::Audio::AudioQueueCommandType::AuditionUnit;
             audCmd.trackIndex = m_unitId;
@@ -1091,7 +1119,16 @@ DropResult UnitRow::onDrop(const DragData& data, const NUIPoint& position) {
 }
 
 NUIRect UnitRow::getDropBounds() const {
-    return getBounds();
+    // A row scrolled out of the list viewport is invisible — it must not
+    // catch drops either, so trim the drop area to what the user can see.
+    NUIRect bounds = getBounds();
+    if (m_viewport.width > 0.0f && m_viewport.height > 0.0f) {
+        const float top = std::max(bounds.y, m_viewport.y);
+        const float bottom = std::min(bounds.bottom(), m_viewport.bottom());
+        bounds.y = top;
+        bounds.height = std::max(0.0f, bottom - top);
+    }
+    return bounds;
 }
 
 void UnitRow::onResize(int width, int height) {

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -133,6 +133,11 @@ void UnitRow::updateState() {
     invalidateVisuals();
 }
 
+void UnitRow::setStepCount(int count) {
+    m_stepCount = count;
+    invalidateVisuals();
+}
+
 void UnitRow::onRender(NUIRenderer& renderer) {
     if (m_nameLabel) {
         m_nameLabel->setUnitType(shouldUseNoteRoll() ? Aestra::Audio::UnitType::Instrument : m_type);
@@ -400,6 +405,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     float availWidth = timelineStrip.width;
     float stepWidth = std::max(availWidth / static_cast<float>(m_stepCount), 20.0f);
     float totalWidth = stepWidth * m_stepCount;
+
     
     // Clamp scroll
     float maxScroll = std::max(0.0f, totalWidth - availWidth);
@@ -551,7 +557,9 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                               theme.getColor("border").withAlpha(0.07f));
         }
 
-        for (double beat = 4.0; beat < visibleLengthBeats; beat += 4.0) {
+        const double barLineBeats =
+            m_trackManager ? static_cast<double>(m_trackManager->getTimelineClock().getBeatsPerBar()) : 4.0;
+        for (double beat = barLineBeats; beat < visibleLengthBeats; beat += barLineBeats) {
             const float x = timelineStrip.x +
                             static_cast<float>(beat / visibleLengthBeats) * totalWidth - m_scrollX;
             renderer.drawLine(NUIPoint(x, timelineStrip.y), NUIPoint(x, timelineStrip.bottom()), 1.0f,
@@ -694,6 +702,14 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     const NUIRect localControlRect(42.0f, 0.0f, std::max(0.0f, m_controlWidth - 48.0f), 56.0f);
     const float separatorX = m_controlWidth;
     const NUIRect localContextRect(separatorX + 8.0f, 6.0f, std::max(0.0f, bounds.width - (separatorX + 14.0f)), 44.0f);
+    // Step math must use the same geometry the pads are DRAWN with:
+    // drawContextBlock insets the context rect by 6px lane padding before
+    // laying out steps. Resolving against the un-inset rect skewed the step
+    // width and offset, so clicks landed on neighboring pads (worse toward
+    // the right edge of long loops).
+    const NUIRect localGridRect(localContextRect.x + 6.0f, localContextRect.y + 6.0f,
+                                std::max(0.0f, localContextRect.width - 12.0f),
+                                std::max(0.0f, localContextRect.height - 12.0f));
     const NUIPoint localPoint(event.position.x - bounds.x, event.position.y - bounds.y);
 
     auto resolveGridStep = [this](const NUIPoint& position, const NUIRect& gridBounds) -> int {
@@ -777,7 +793,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     m_hoveredStep = -1;
     
     if (m_isHovered && localContextRect.contains(localPoint)) {
-        const int stepIndex = resolveGridStep(localPoint, localContextRect);
+        const int stepIndex = resolveGridStep(localPoint, localGridRect);
         if (stepIndex >= 0 && stepIndex < m_stepCount) {
             m_hoveredStep = stepIndex;
         }
@@ -800,7 +816,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
              event.button == NUIMouseButton::None);
 
         if (isPointerMoveWhileEditing) {
-            int stepIndex = resolveGridStep(localPoint, localContextRect);
+            int stepIndex = resolveGridStep(localPoint, localGridRect);
             stepIndex = std::max(m_stepEditStart, std::min(m_stepCount - 1, stepIndex));
             const int endExclusive = stepIndex + 1;
             if (endExclusive != m_stepEditEndExclusive) {
@@ -835,7 +851,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     return true;
                 }
                 else if (localContextRect.contains(localPoint)) {
-                    handleContextClick(event, localContextRect);
+                    handleContextClick(event, localGridRect);
                     return true;
                 }
             }
@@ -844,6 +860,38 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         // === Right-click (row body, outside name label which is handled by UnitNameLabel child) ===
         if (event.button == NUIMouseButton::Right) {
             if (bounds.contains(event.position)) {
+                // On a step pad with a note: right-click deletes it (FL-style).
+                // Anywhere else on the row keeps the context menu.
+                if (localContextRect.contains(localPoint) && !shouldUseNoteRoll() &&
+                    m_patternId.isValid() && m_trackManager) {
+                    const int stepIndex = resolveGridStep(localPoint, localGridRect);
+                    if (stepIndex >= 0 && stepIndex < m_stepCount) {
+                        bool removed = false;
+                        m_trackManager->getPatternManager().applyPatch(
+                            m_patternId, [this, stepIndex, &removed](Aestra::Audio::PatternSource& p) {
+                                if (!p.isMidi()) return;
+                                auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+                                const double targetBeat = stepIndex * 0.25;
+                                auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
+                                    [this, targetBeat](const Aestra::Audio::MidiNote& n) {
+                                        const double endBeat =
+                                            std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                                        return n.unitId == m_unitId &&
+                                               targetBeat >= n.startBeat - 0.01 &&
+                                               targetBeat < endBeat - 0.01;
+                                    });
+                                if (it != midi.notes.end()) {
+                                    midi.notes.erase(it);
+                                    removed = true;
+                                }
+                            });
+                        if (removed) {
+                            if (m_onPatternEdited) m_onPatternEdited(m_patternId);
+                            invalidateVisuals();
+                            return true;
+                        }
+                    }
+                }
                 showRowContextMenu(event.position);
                 return true;
             }
@@ -912,18 +960,21 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
         return;
     }
 
-    // === Double-click to load sample ===
+    // === Double-click to load sample (EMPTY units only) ===
+    // With a sample loaded, rapid taps are step programming — treating any two
+    // grid clicks within 400ms as "open the file picker" made fast FL-style
+    // tap-tap placement randomly hijack the second click.
     auto now = std::chrono::steady_clock::now();
     long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
     bool isDoubleClick = (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
     m_lastClipClickTimeMs = nowMs;
-    
-    if (isDoubleClick) {
-        // Trigger sample file picker
+
+    if (isDoubleClick && m_audioClip.empty() && m_pluginId.empty()) {
+        // Empty unit: double-click is a shortcut to give it a sample.
         if (m_onLoadUnitSample) m_onLoadUnitSample(m_unitId);
         return;
     }
-    
+
     // === Single click: Grid Interaction - Toggle Steps ===
     float relativeX = localPoint.x;
     float availWidth = bounds.width;
@@ -972,30 +1023,13 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
             midi.notes.push_back(note);
         });
 
-        if (removedExisting) {
-            if (m_onPatternEdited) {
-                m_onPatternEdited(m_patternId);
-            }
-        } else {
-            m_isStepEditing = true;
-            m_stepEditStart = stepIndex;
-            m_stepEditEndExclusive = stepIndex + 1;
-
-            // Audible feedback for the step just placed. The engine reads
-            // value1 as the MIDI note and value2 as normalized velocity
-            // (0..1, scaled by 127). Match the note we just wrote so the
-            // click actually plays the sampler instead of note 0 at v1.
-            const int auditionPitch = m_rootMidiNote;
-            Aestra::Audio::AudioQueueCommand audCmd;
-            audCmd.type = Aestra::Audio::AudioQueueCommandType::AuditionUnit;
-            audCmd.trackIndex = m_unitId;
-            audCmd.value1 = static_cast<float>(auditionPitch);
-            audCmd.value2 = 100.0f / 127.0f;
-            if (m_trackManager) {
-                m_trackManager->pushAudioCommand(audCmd);
-            }
+        // No drag-to-extend and no audition preview: a click is exactly one
+        // step toggled, silently — the running loop picks the note up itself
+        // (hot swap), which is the feedback the workflow wants.
+        if (m_onPatternEdited) {
+            m_onPatternEdited(m_patternId);
         }
-        
+
         invalidateVisuals();
     }
 }

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -423,6 +423,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     std::vector<NoteSpan> noteSpans;
     std::vector<int> stepPitch(m_stepCount, -1);
     std::vector<float> stepLength(m_stepCount, 0.0f);
+    std::vector<float> stepVelocity(m_stepCount, kDefaultStepVelocity);
     bool unitHasContent = !m_pluginId.empty() || !m_audioClip.empty();
     bool noteRollMode = usesPianoRollForType(m_type);
     double visibleLengthBeats = static_cast<double>(m_stepCount) * 0.25;
@@ -450,6 +451,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                                              note.velocity});
                 stepPitch[startStep] = note.pitch;
                 stepLength[startStep] = static_cast<float>(note.durationBeats);
+                stepVelocity[startStep] = note.velocity;
             }
         }
     }
@@ -485,7 +487,18 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             if (isPlayhead && isActive) {
                 cellFill = activeFill.lightened(0.35f); // note lights up under the playhead
             }
-            renderer.fillRoundedRect(cellRect, cellRadius, cellFill);
+            if (isActive) {
+                // Velocity meter: dim base + a brighter bar rising from the
+                // bottom to the note's velocity, so accents read at a glance
+                // and vertical drag has an obvious target.
+                renderer.fillRoundedRect(cellRect, cellRadius, cellFill.withAlpha(0.26f));
+                const float v = std::clamp(stepVelocity[step], kMinStepVelocity, 1.0f);
+                const float fillH = std::max(2.0f, cellHeight * v);
+                const NUIRect velRect(cellX, cellY + cellHeight - fillH, cellWidth, fillH);
+                renderer.fillRoundedRect(velRect, cellRadius, cellFill);
+            } else {
+                renderer.fillRoundedRect(cellRect, cellRadius, cellFill);
+            }
             renderer.strokeRoundedRect(cellRect, cellRadius, 1.0f, inactiveStroke);
             if (isPlayhead) {
                 renderer.strokeRoundedRect(cellRect, cellRadius, 1.5f,
@@ -683,7 +696,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     // rendered there (rows scrolled out of view are not clickable). Ongoing
     // drags/step edits keep receiving events so gestures can finish.
     if (m_viewport.width > 0.0f && m_viewport.height > 0.0f &&
-        !m_isDragging && !m_isStepEditing && !m_viewport.contains(event.position)) {
+        !m_isDragging && m_velEditStep < 0 && !m_viewport.contains(event.position)) {
         if (m_isHovered || m_hoveredStep != -1) {
             m_isHovered = false;
             m_hoveredStep = -1;
@@ -725,42 +738,6 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         float stepWidth = gridStepWidth(availWidth);
         float contentX = relativeX + m_scrollX;
         return static_cast<int>(contentX / stepWidth);
-    };
-
-    auto updateStepEditSpan = [this](int endExclusive) {
-        if (!m_patternId.isValid() || m_stepEditStart < 0 || endExclusive <= m_stepEditStart) {
-            return;
-        }
-
-        m_stepEditEndExclusive = std::max(m_stepEditStart + 1, std::min(m_stepCount, endExclusive));
-        const double targetStart = static_cast<double>(m_stepEditStart) * 0.25;
-        const double targetDuration = static_cast<double>(m_stepEditEndExclusive - m_stepEditStart) * 0.25;
-
-        auto& pm = m_trackManager->getPatternManager();
-        pm.applyPatch(m_patternId, [this, targetStart, targetDuration](Aestra::Audio::PatternSource& p) {
-            if (!p.isMidi()) return;
-            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-            auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
-                [this, targetStart](const Aestra::Audio::MidiNote& n) {
-                    return n.unitId == m_unitId &&
-                           n.pitch == m_rootMidiNote &&
-                           std::abs(n.startBeat - targetStart) < 0.01;
-                });
-            if (it != midi.notes.end()) {
-                it->durationBeats = targetDuration;
-            }
-        });
-    };
-
-    auto finishStepEdit = [this]() {
-        if (!m_isStepEditing) {
-            return;
-        }
-        m_isStepEditing = false;
-        if (m_onPatternEdited && m_patternId.isValid()) {
-            m_onPatternEdited(m_patternId);
-        }
-        invalidateVisuals();
     };
 
     // === Scroll Handling ===
@@ -818,30 +795,45 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         invalidateVisuals();
     }
 
-    if (m_isStepEditing) {
+    // === Velocity-drag session (Sampler step grid) ===
+    if (m_velEditStep >= 0) {
         if (event.released || event.type == NUIMouseEventType::Up) {
-            finishStepEdit();
+            // Release: a click that never moved vertically toggles the step
+            // (place was already done on press; remove if it pre-existed).
+            if (!m_velEditMoved && m_velEditWasActive) {
+                removeStepNote(m_velEditStep);
+            }
+            if (m_onPatternEdited && m_patternId.isValid()) {
+                m_onPatternEdited(m_patternId); // reschedule audio once, on release
+            }
+            m_velEditStep = -1;
+            invalidateVisuals();
             return true;
         }
 
-        const bool isPointerMoveWhileEditing =
+        const bool isPointerMove =
             !event.pressed && !event.released &&
             (event.type == NUIMouseEventType::Drag ||
              event.type == NUIMouseEventType::Move ||
              event.button == NUIMouseButton::None);
-
-        if (isPointerMoveWhileEditing) {
-            int stepIndex = resolveGridStep(localPoint, localGridRect);
-            stepIndex = std::max(m_stepEditStart, std::min(m_stepCount - 1, stepIndex));
-            const int endExclusive = stepIndex + 1;
-            if (endExclusive != m_stepEditEndExclusive) {
-                updateStepEditSpan(endExclusive);
+        if (isPointerMove) {
+            const float dy = m_velEditStartY - event.position.y; // up = louder
+            if (!m_velEditMoved && std::abs(dy) > 3.0f) {
+                m_velEditMoved = true;
+                if (!m_velEditWasActive) {
+                    // We placed on press; a drag now edits that fresh note.
+                }
+            }
+            if (m_velEditMoved) {
+                // Full row height ≈ full velocity range.
+                const float vel = m_velEditBaseVelocity + dy / 90.0f;
+                setStepNoteVelocity(m_velEditStep, vel);
                 invalidateVisuals();
             }
             return true;
         }
     }
-    
+
     // === Click Handling ===
     if (event.pressed) {
         // Ensure focus
@@ -866,6 +858,30 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     return true;
                 }
                 else if (localContextRect.contains(localPoint)) {
+                    // Loaded Sampler step grid: arm a velocity-drag session.
+                    // A vertical drag sets the step's velocity; a plain click
+                    // toggles it on release. Empty units / pitched / note-roll
+                    // fall through to the classic toggle.
+                    const bool hasContent = !m_audioClip.empty() || !m_pluginId.empty();
+                    if (m_type == Aestra::Audio::UnitType::Sampler && !shouldUseNoteRoll() && hasContent &&
+                        m_patternId.isValid() && m_trackManager) {
+                        const int step = resolveGridStep(localPoint, localGridRect);
+                        if (step >= 0 && step < m_stepCount) {
+                            float vel = kDefaultStepVelocity;
+                            const bool active = stepHasNote(step, vel);
+                            m_velEditStep = step;
+                            m_velEditStartY = event.position.y;
+                            m_velEditMoved = false;
+                            m_velEditWasActive = active;
+                            if (!active) {
+                                placeStepNote(step); // show immediately; kept unless click-removed
+                                vel = kDefaultStepVelocity;
+                            }
+                            m_velEditBaseVelocity = vel;
+                            invalidateVisuals();
+                            return true;
+                        }
+                    }
                     handleContextClick(event, localGridRect);
                     return true;
                 }
@@ -999,54 +1015,106 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
     int stepIndex = static_cast<int>(contentX / stepWidth);
     
     if (stepIndex >= 0 && stepIndex < m_stepCount && m_patternId.isValid()) {
-        auto& pm = m_trackManager->getPatternManager();
-
-        bool removedExisting = false;
-        pm.applyPatch(m_patternId, [this, stepIndex, &removedExisting](Aestra::Audio::PatternSource& p) {
-            if (!p.isMidi()) return;
-            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-
-            const double targetBeat = stepIndex * 0.25;
-            auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
-                [this, targetBeat](const Aestra::Audio::MidiNote& n) {
-                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                    return n.unitId == m_unitId &&
-                           n.pitch == m_rootMidiNote &&
-                           targetBeat >= n.startBeat - 0.01 &&
-                           targetBeat < endBeat - 0.01;
-                });
-
-            if (it != midi.notes.end()) {
-                midi.notes.erase(it);
-                removedExisting = true;
-                return;
-            }
-
-            // Place at the unit's root so untouched steps play the sample at
-            // its original pitch; transposition belongs to the Piano Roll.
-            const int defaultPitch = m_rootMidiNote;
-            // NB: set fields explicitly — positional aggregate init would drop
-            // m_unitId into MidiNote::pan (the field before unitId) and leave
-            // unitId=0, which auditions/displays fine but is silently dropped by
-            // the playback router (routes require unitId != 0). Cf. AudioSlice #447.
-            Aestra::Audio::MidiNote note;
-            note.pitch = defaultPitch;
-            note.startBeat = targetBeat;
-            note.durationBeats = 0.25;
-            note.velocity = 100.0f / 127.0f;
-            note.unitId = m_unitId;
-            midi.notes.push_back(note);
-        });
-
-        // No drag-to-extend and no audition preview: a click is exactly one
-        // step toggled, silently — the running loop picks the note up itself
-        // (hot swap), which is the feedback the workflow wants.
+        // Plain toggle: place if empty, remove if present. Silent — the running
+        // loop hot-swaps the change on its next pass, which is the wanted
+        // feedback. (The Sampler grid arms a velocity-drag session instead and
+        // never reaches here; this path covers pitched samplers + fallbacks.)
+        float dummy = kDefaultStepVelocity;
+        if (stepHasNote(stepIndex, dummy)) {
+            removeStepNote(stepIndex);
+        } else {
+            placeStepNote(stepIndex);
+        }
         if (m_onPatternEdited) {
             m_onPatternEdited(m_patternId);
         }
-
         invalidateVisuals();
     }
+}
+
+bool UnitRow::stepHasNote(int step, float& velocityOut) const {
+    velocityOut = kDefaultStepVelocity;
+    if (!m_patternId.isValid() || !m_trackManager) return false;
+    const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
+    if (!pattern || !pattern->isMidi()) return false;
+    const auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
+    const double targetBeat = step * 0.25;
+    for (const auto& n : midi.notes) {
+        const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+        if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
+            velocityOut = n.velocity;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool UnitRow::placeStepNote(int step) {
+    if (!m_patternId.isValid() || !m_trackManager) return false;
+    bool placed = false;
+    m_trackManager->getPatternManager().applyPatch(
+        m_patternId, [this, step, &placed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) return;
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            const double targetBeat = step * 0.25;
+            for (const auto& n : midi.notes) {
+                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
+                    return; // already present
+                }
+            }
+            // NB: explicit-field init — positional init would drop m_unitId into
+            // MidiNote::pan and leave unitId=0 (dropped by playback). Cf. #447.
+            Aestra::Audio::MidiNote note;
+            note.pitch = m_rootMidiNote; // root → sample plays untransposed
+            note.startBeat = targetBeat;
+            note.durationBeats = 0.25;
+            note.velocity = kDefaultStepVelocity;
+            note.unitId = m_unitId;
+            midi.notes.push_back(note);
+            placed = true;
+        });
+    return placed;
+}
+
+bool UnitRow::removeStepNote(int step) {
+    if (!m_patternId.isValid() || !m_trackManager) return false;
+    bool removed = false;
+    m_trackManager->getPatternManager().applyPatch(
+        m_patternId, [this, step, &removed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) return;
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            const double targetBeat = step * 0.25;
+            auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
+                [this, targetBeat](const Aestra::Audio::MidiNote& n) {
+                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                    return n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 &&
+                           targetBeat < endBeat - 0.01;
+                });
+            if (it != midi.notes.end()) {
+                midi.notes.erase(it);
+                removed = true;
+            }
+        });
+    return removed;
+}
+
+void UnitRow::setStepNoteVelocity(int step, float velocity) {
+    if (!m_patternId.isValid() || !m_trackManager) return;
+    const float v = std::clamp(velocity, kMinStepVelocity, 1.0f);
+    m_trackManager->getPatternManager().applyPatch(
+        m_patternId, [this, step, v](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) return;
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            const double targetBeat = step * 0.25;
+            for (auto& n : midi.notes) {
+                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
+                    n.velocity = v;
+                    return;
+                }
+            }
+        });
 }
 
 

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -138,6 +138,13 @@ void UnitRow::setStepCount(int count) {
     invalidateVisuals();
 }
 
+void UnitRow::setFitToWidth(bool fit) {
+    if (fit == m_fitToWidth) return;
+    m_fitToWidth = fit;
+    if (fit) m_scrollX = 0.0f; // Nothing to page when the whole loop is shown
+    invalidateVisuals();
+}
+
 void UnitRow::onRender(NUIRenderer& renderer) {
     if (m_nameLabel) {
         m_nameLabel->setUnitType(shouldUseNoteRoll() ? Aestra::Audio::UnitType::Instrument : m_type);
@@ -403,7 +410,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     
     // === Step Grid Layout ===
     float availWidth = timelineStrip.width;
-    float stepWidth = std::max(availWidth / static_cast<float>(m_stepCount), 20.0f);
+    float stepWidth = gridStepWidth(availWidth);
     float totalWidth = stepWidth * m_stepCount;
 
     
@@ -715,7 +722,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     auto resolveGridStep = [this](const NUIPoint& position, const NUIRect& gridBounds) -> int {
         float relativeX = position.x - gridBounds.x;
         float availWidth = gridBounds.width;
-        float stepWidth = std::max(availWidth / static_cast<float>(m_stepCount), 20.0f);
+        float stepWidth = gridStepWidth(availWidth);
         float contentX = relativeX + m_scrollX;
         return static_cast<int>(contentX / stepWidth);
     };
@@ -771,7 +778,15 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                 // Pitch viewport scroll (up/down = see higher/lower pitches)
                 m_minimapPitchOffset -= delta * 4.0f; // 4 semitones per tick
                 m_minimapPitchOffset = std::clamp(m_minimapPitchOffset, -60.0f, 60.0f);
-            } else if (m_onGridScroll) {
+                invalidateVisuals();
+                return true;
+            }
+            if (m_fitToWidth) {
+                // Whole loop is on screen — nothing to scroll horizontally, so
+                // let the wheel bubble up to the panel's vertical list scroll.
+                return false;
+            }
+            if (m_onGridScroll) {
                 // Panel owns the shared offset: it clamps against the loop
                 // width and pushes the result to every row + the header.
                 m_onGridScroll(-delta * 40.0f);
@@ -978,8 +993,8 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
     // === Single click: Grid Interaction - Toggle Steps ===
     float relativeX = localPoint.x;
     float availWidth = bounds.width;
-    float stepWidth = std::max(availWidth / static_cast<float>(m_stepCount), 20.0f);
-    
+    float stepWidth = gridStepWidth(availWidth);
+
     float contentX = relativeX + m_scrollX;
     int stepIndex = static_cast<int>(contentX / stepWidth);
     

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -179,6 +179,11 @@ private:
     void drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds);
     void drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds);
     bool shouldUseNoteRoll() const;
+    // Current playhead position within the active pattern (looped), in beats.
+    // Returns -1 when the transport is not driving the Arsenal (not pattern
+    // mode) so callers can skip the live-step highlight. Mirrors the Arsenal
+    // progress-header playhead so the row highlight stays in sync with it.
+    double playheadBeatInPattern() const;
 
     void handleControlClick(const NUIMouseEvent& event, const NUIRect& bounds);
     void handleContextClick(const NUIMouseEvent& event, const NUIRect& bounds);

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -213,9 +213,17 @@ private:
     bool m_isSelected = false;
     bool m_isDropHighlighted = false;
     NUIPoint m_dragStartPos;
-    bool m_isStepEditing = false;
-    int m_stepEditStart = -1;
-    int m_stepEditEndExclusive = -1;
+
+    // Velocity-drag session (Sampler step grid). A press arms a step; a
+    // vertical drag sets its velocity, a click without vertical movement
+    // toggles the step (place empty / remove active) on release.
+    static constexpr float kDefaultStepVelocity = 100.0f / 127.0f;
+    static constexpr float kMinStepVelocity = 0.05f;
+    int m_velEditStep = -1;         // -1 = no session
+    float m_velEditStartY = 0.0f;   // pointer Y at press
+    float m_velEditBaseVelocity = kDefaultStepVelocity;
+    bool m_velEditMoved = false;    // crossed the drag threshold → velocity edit
+    bool m_velEditWasActive = false; // step already had a note at press
 
     long long m_lastClipClickTimeMs = 0; // For double-click on clip/waveform area
 
@@ -233,6 +241,13 @@ private:
 
     void handleControlClick(const NUIMouseEvent& event, const NUIRect& bounds);
     void handleContextClick(const NUIMouseEvent& event, const NUIRect& bounds);
+
+    // Sampler step-grid note helpers (root pitch, single step). Each returns
+    // true if the pattern changed.
+    bool stepHasNote(int step, float& velocityOut) const; // true if a note exists at step
+    bool placeStepNote(int step);                          // place at root + default velocity
+    bool removeStepNote(int step);                         // remove note at step
+    void setStepNoteVelocity(int step, float velocity);    // set velocity of note at step
 
     // Icon drawing helpers
     void drawPowerIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active);

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -98,6 +98,33 @@ public:
     int getStepCount() const { return m_stepCount; }
     
     /**
+     * @brief Set the horizontal grid scroll offset (shared across rows by the panel).
+     * @param x Scroll offset in pixels (>= 0).
+     */
+    void setScrollX(float x) {
+        x = x < 0.0f ? 0.0f : x;
+        if (x != m_scrollX) { m_scrollX = x; invalidateVisuals(); }
+    }
+    /**
+     * @brief Get the horizontal grid scroll offset.
+     * @return Scroll offset in pixels.
+     */
+    float getScrollX() const { return m_scrollX; }
+    /**
+     * @brief Set the callback fired when the user wheel-scrolls the step grid.
+     * When set, the panel owns the scroll offset and pushes it back via setScrollX
+     * so every row (and the progress header) stays in lockstep.
+     * @param cb Callback receiving the requested scroll delta in pixels.
+     */
+    void setOnGridScroll(std::function<void(float)> cb) { m_onGridScroll = std::move(cb); }
+    /**
+     * @brief Restrict rendering and hit-testing to the panel's list viewport.
+     * Rows partially outside are clipped; rows fully outside skip rendering and
+     * ignore pointer events. An empty rect disables the restriction.
+     * @param viewport Viewport rect in window-absolute coordinates.
+     */
+    void setViewport(const NUIRect& viewport) { m_viewport = viewport; }
+    /**
      * @brief Get the unit identifier represented by this row.
      * @return Backing unit identifier.
      */
@@ -124,6 +151,7 @@ private:
     uint32_t m_color;
     Aestra::Audio::UnitGroup m_group;
     Aestra::Audio::UnitType m_type{Aestra::Audio::UnitType::Sampler};
+    int m_rootMidiNote = 60; // Pitch that plays the unit's sample untransposed
     bool m_isEnabled = true;
     bool m_isArmed = false;
     bool m_isMuted = false;
@@ -156,6 +184,8 @@ private:
     // Step sequencer
     int m_stepCount = 16;
     float m_scrollX = 0.0f;
+    std::function<void(float)> m_onGridScroll; // Panel-owned shared scroll (see setOnGridScroll)
+    NUIRect m_viewport{}; // Panel list viewport; empty = unrestricted
     int m_hoveredStep = -1;
     
     // Minimap pitch scroll

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -91,6 +91,14 @@ public:
      * @param count Number of step pads to render.
      */
     void setStepCount(int count);
+
+    /**
+     * @brief Choose whether the grid fits the whole loop to width or keeps a
+     *        readable minimum pad size and scrolls. Owned by the panel so all
+     *        rows + the header agree.
+     * @param fit True to fit the entire loop (pads shrink, no scroll).
+     */
+    void setFitToWidth(bool fit);
     /**
      * @brief Get the visible step count for the sequencer section.
      * @return Number of rendered steps.
@@ -183,7 +191,15 @@ private:
     
     // Step sequencer
     int m_stepCount = 16;
+    bool m_fitToWidth = true; // Fit whole loop vs readable-min + scroll
     float m_scrollX = 0.0f;
+
+    // Pad width for the current fit mode: fit shrinks to show every step,
+    // scroll mode keeps a readable minimum and lets m_scrollX page the grid.
+    float gridStepWidth(float availWidth) const {
+        const float w = availWidth / static_cast<float>(std::max(1, m_stepCount));
+        return m_fitToWidth ? std::max(w, 4.0f) : std::max(w, PAD_MIN_SIZE);
+    }
     std::function<void(float)> m_onGridScroll; // Panel-owned shared scroll (see setOnGridScroll)
     NUIRect m_viewport{}; // Panel list viewport; empty = unrestricted
     int m_hoveredStep = -1;

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -90,7 +90,7 @@ public:
      * @brief Set the visible step count for the sequencer section.
      * @param count Number of step pads to render.
      */
-    void setStepCount(int count) { m_stepCount = count; invalidateVisuals(); }
+    void setStepCount(int count);
     /**
      * @brief Get the visible step count for the sequencer section.
      * @return Number of rendered steps.

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -96,13 +96,11 @@ void attachAndShowPopupMenu(AestraUI::NUIComponent* owner,
     root->repaint();
 }
 
-// Centered, word-wrapped hint text for empty/scanning states. The hint copy is
-// longer than the list strip at narrow browser widths; wrapping keeps it
-// readable instead of letting a single centered line clip mid-letter.
-static void drawWrappedCenteredHint(NUIRenderer& renderer, const std::string& hint, const NUIRect& listClip,
-                                    float startY, float fontSize, const NUIColor& color) {
-    const float maxWidth = std::max(40.0f, listClip.width - 16.0f);
-    float y = startY;
+// Greedy word wrap for placeholder hint copy, which is longer than the list
+// strip at narrow browser widths.
+static std::vector<std::string> wrapHintLines(NUIRenderer& renderer, const std::string& hint, float fontSize,
+                                              float maxWidth) {
+    std::vector<std::string> lines;
     std::string remaining = hint;
     while (!remaining.empty()) {
         std::string line = remaining;
@@ -113,10 +111,23 @@ static void drawWrappedCenteredHint(NUIRenderer& renderer, const std::string& hi
             rest = line.substr(space + 1) + (rest.empty() ? "" : " " + rest);
             line = line.substr(0, space);
         }
-        renderer.drawTextCentered(line, NUIRect(listClip.x, y, listClip.width, 18.0f), fontSize, color);
-        y += 16.0f;
+        lines.push_back(line);
         remaining = rest;
     }
+    return lines;
+}
+
+// Greedy wrap leaves a short orphan last line ("...appear in / the browser").
+// Once the line count is known, re-wrap near the average width so the lines
+// come out visually balanced; keep the greedy result if that would add a line.
+static std::vector<std::string> wrapHintBalanced(NUIRenderer& renderer, const std::string& hint, float fontSize,
+                                                 float maxWidth) {
+    auto lines = wrapHintLines(renderer, hint, fontSize, maxWidth);
+    if (lines.size() < 2) return lines;
+    const float total = renderer.measureText(hint, fontSize).width;
+    const float target = (total / static_cast<float>(lines.size())) * 1.2f;
+    auto balanced = wrapHintLines(renderer, hint, fontSize, std::clamp(target, maxWidth * 0.5f, maxWidth));
+    return balanced.size() == lines.size() ? balanced : lines;
 }
 
 std::string ellipsizeMiddle(NUIRenderer& renderer, const std::string& text, float fontSize, float maxWidth) {
@@ -801,6 +812,47 @@ void FileBrowser::processScanResults() {
 // =============================================================================
 // SECTION: Rendering with FBO Caching
 // =============================================================================
+
+void FileBrowser::drawListEmptyState(NUIRenderer& renderer, const NUIRect& listClip,
+                                     const std::shared_ptr<NUIIcon>& icon, const std::string& title,
+                                     const std::string& hint) {
+    auto& themeManager = NUIThemeManager::getInstance();
+    const float titleFont = themeManager.getFontSize("l");
+    const float hintFont = themeManager.getFontSize("s");
+    constexpr float kIconSize = 28.0f;
+    constexpr float kIconGap = 12.0f;
+    constexpr float kTitleH = 20.0f;
+    constexpr float kTitleGap = 6.0f;
+    constexpr float kHintLineH = 16.0f;
+
+    // Cap the hint measure so it reads as a compact centered paragraph with
+    // real side margins instead of running edge to edge.
+    const float hintMaxWidth = std::max(60.0f, std::min(listClip.width - 48.0f, 240.0f));
+    const auto hintLines = wrapHintBalanced(renderer, hint, hintFont, hintMaxWidth);
+
+    float blockH = kTitleH + kTitleGap + static_cast<float>(hintLines.size()) * kHintLineH;
+    if (icon) blockH += kIconSize + kIconGap;
+    float y = listClip.y + std::max(12.0f, listClip.height * 0.42f - blockH * 0.5f);
+
+    renderer.setClipRect(listClip);
+    if (icon) {
+        const NUIRect iconRect(std::round(listClip.x + (listClip.width - kIconSize) * 0.5f), std::round(y),
+                               kIconSize, kIconSize);
+        icon->setBounds(iconRect);
+        icon->setColor(themeManager.getColor("textSecondary").withAlpha(0.30f));
+        icon->onRender(renderer);
+        y += kIconSize + kIconGap;
+    }
+    renderer.drawTextCentered(title, NUIRect(listClip.x, y, listClip.width, kTitleH), titleFont,
+                              themeManager.getColor("textPrimary").withAlpha(0.66f));
+    y += kTitleH + kTitleGap;
+    const NUIColor hintColor = themeManager.getColor("textSecondary").withAlpha(0.5f);
+    for (const auto& line : hintLines) {
+        renderer.drawTextCentered(line, NUIRect(listClip.x, y, listClip.width, kHintLineH), hintFont, hintColor);
+        y += kHintLineH;
+    }
+    renderer.clearClipRect();
+}
 
 FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
     NUIRect bounds = getBounds();
@@ -2930,37 +2982,22 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
     renderer.fillRect(browserLayout.list, themeManager.getColor("backgroundPrimary"));
 
     if (scanningRoot_ && view.empty()) {
-        renderer.setClipRect(listClip);
-        NUIRect titleRect(listClip.x, listClip.y + listClip.height * 0.43f - 12.0f, listClip.width, 20.0f);
-        renderer.drawTextCentered("Scanning library", titleRect, themeManager.getFontSize("l"),
-                                  themeManager.getColor("textPrimary").withAlpha(0.72f));
-        drawWrappedCenteredHint(renderer, "Large folders stay responsive while results load", listClip,
-                                titleRect.bottom() + 4.0f, themeManager.getFontSize("s"),
-                                themeManager.getColor("textSecondary").withAlpha(0.56f));
-        renderer.clearClipRect();
+        drawListEmptyState(renderer, listClip, folderIcon_, "Scanning library",
+                           "Results appear as they load");
         return;
     }
 
     if (view.empty()) {
-        renderer.setClipRect(listClip);
-        std::string title;
-        std::string hint;
         if (!scanError_.empty()) {
-            title = "Folder unavailable";
-            hint = "Press F5 to retry or choose another location";
+            drawListEmptyState(renderer, listClip, folderIcon_, "Folder unavailable",
+                               "Press F5 to retry, or choose another location");
         } else if (isFilterActive()) {
-            title = "No matches";
-            hint = "Press Esc to clear search and filters";
+            drawListEmptyState(renderer, listClip, unknownFileIcon_, "No matches",
+                               "Press Esc to clear the search and filters");
         } else {
-            title = "No supported files here";
-            hint = "Audio, MIDI, and Aestra projects appear in the browser";
+            drawListEmptyState(renderer, listClip, folderIcon_, "Nothing here yet",
+                               "Audio, MIDI, and Aestra projects show up here");
         }
-        NUIRect titleRect(listClip.x, listClip.y + listClip.height * 0.42f - 12.0f, listClip.width, 20.0f);
-        renderer.drawTextCentered(title, titleRect, themeManager.getFontSize("l"), themeManager.getColor("textPrimary").withAlpha(0.72f));
-        drawWrappedCenteredHint(renderer, hint, listClip, titleRect.bottom() + 4.0f,
-                                themeManager.getFontSize("s"),
-                                themeManager.getColor("textSecondary").withAlpha(0.58f));
-        renderer.clearClipRect();
         return;
     }
 

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -96,6 +96,29 @@ void attachAndShowPopupMenu(AestraUI::NUIComponent* owner,
     root->repaint();
 }
 
+// Centered, word-wrapped hint text for empty/scanning states. The hint copy is
+// longer than the list strip at narrow browser widths; wrapping keeps it
+// readable instead of letting a single centered line clip mid-letter.
+static void drawWrappedCenteredHint(NUIRenderer& renderer, const std::string& hint, const NUIRect& listClip,
+                                    float startY, float fontSize, const NUIColor& color) {
+    const float maxWidth = std::max(40.0f, listClip.width - 16.0f);
+    float y = startY;
+    std::string remaining = hint;
+    while (!remaining.empty()) {
+        std::string line = remaining;
+        std::string rest;
+        while (renderer.measureText(line, fontSize).width > maxWidth) {
+            const size_t space = line.find_last_of(' ');
+            if (space == std::string::npos) break; // single unbreakable word
+            rest = line.substr(space + 1) + (rest.empty() ? "" : " " + rest);
+            line = line.substr(0, space);
+        }
+        renderer.drawTextCentered(line, NUIRect(listClip.x, y, listClip.width, 18.0f), fontSize, color);
+        y += 16.0f;
+        remaining = rest;
+    }
+}
+
 std::string ellipsizeMiddle(NUIRenderer& renderer, const std::string& text, float fontSize, float maxWidth) {
     constexpr const char* kEllipsis = "...";
 
@@ -2788,6 +2811,12 @@ void FileBrowser::toggleFolder(const FileItem* item) {
     } else {
         if (!nonConstItem->hasLoadedChildren) {
             loadFolderContents(nonConstItem);
+        } else if (!nonConstItem->isLoadingChildren) {
+            // Folder contents can change while the app runs (users drop new
+            // samples into their library), so re-scan on every expand. The
+            // stale children stay visible until the fresh listing lands.
+            nonConstItem->isLoadingChildren = true;
+            enqueueScan(ScanKind::Folder, nonConstItem->path, nonConstItem->depth + 1);
         }
         nonConstItem->isExpanded = true;
     }
@@ -2903,12 +2932,11 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
     if (scanningRoot_ && view.empty()) {
         renderer.setClipRect(listClip);
         NUIRect titleRect(listClip.x, listClip.y + listClip.height * 0.43f - 12.0f, listClip.width, 20.0f);
-        NUIRect hintRect(listClip.x, titleRect.bottom() + 4.0f, listClip.width, 18.0f);
         renderer.drawTextCentered("Scanning library", titleRect, themeManager.getFontSize("l"),
                                   themeManager.getColor("textPrimary").withAlpha(0.72f));
-        renderer.drawTextCentered("Large folders stay responsive while results load", hintRect,
-                                  themeManager.getFontSize("s"),
-                                  themeManager.getColor("textSecondary").withAlpha(0.56f));
+        drawWrappedCenteredHint(renderer, "Large folders stay responsive while results load", listClip,
+                                titleRect.bottom() + 4.0f, themeManager.getFontSize("s"),
+                                themeManager.getColor("textSecondary").withAlpha(0.56f));
         renderer.clearClipRect();
         return;
     }
@@ -2928,9 +2956,10 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
             hint = "Audio, MIDI, and Aestra projects appear in the browser";
         }
         NUIRect titleRect(listClip.x, listClip.y + listClip.height * 0.42f - 12.0f, listClip.width, 20.0f);
-        NUIRect hintRect(listClip.x, titleRect.bottom() + 4.0f, listClip.width, 18.0f);
         renderer.drawTextCentered(title, titleRect, themeManager.getFontSize("l"), themeManager.getColor("textPrimary").withAlpha(0.72f));
-        renderer.drawTextCentered(hint, hintRect, themeManager.getFontSize("s"), themeManager.getColor("textSecondary").withAlpha(0.58f));
+        drawWrappedCenteredHint(renderer, hint, listClip, titleRect.bottom() + 4.0f,
+                                themeManager.getFontSize("s"),
+                                themeManager.getColor("textSecondary").withAlpha(0.58f));
         renderer.clearClipRect();
         return;
     }

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -320,6 +320,11 @@ public:
 		    void renderToolbar(NUIRenderer& renderer);
             void renderNavigationPane(NUIRenderer& renderer, const BrowserLayout& layout);
             void renderListHeader(NUIRenderer& renderer, const BrowserLayout& layout);
+            /// Centered empty/scanning/error block: optional glyph, title,
+            /// balanced word-wrapped hint. Shared by all list placeholder states.
+            void drawListEmptyState(NUIRenderer& renderer, const NUIRect& listClip,
+                                    const std::shared_ptr<NUIIcon>& icon, const std::string& title,
+                                    const std::string& hint);
 	    void renderScrollbar(NUIRenderer& renderer);
     void renderSearchBox(NUIRenderer& renderer);
     void updateScrollPosition();

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -33,6 +33,7 @@
 #include "../AestraUI/Base/NUITextInput.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
+#include "../AestraUI/Widgets/NotificationToast.h"
 #include "../AestraUI/Widgets/TrackColorPalette.h"
 
 // Component includes
@@ -302,6 +303,12 @@ AestraContent::AestraContent()
     // Add Takes + History panels LAST to overlay so they're on top and receive mouse events first
     m_overlayLayer->addChild(m_takesPanel);
     m_overlayLayer->addChild(m_historyPanel);
+
+    // Status toast: topmost but mouse-transparent (no handlers), so it never
+    // steals clicks from the panels beneath it.
+    m_notificationToast = std::make_shared<AestraUI::NotificationToast>();
+    m_notificationToast->setVisible(false);
+    m_overlayLayer->addChild(m_notificationToast);
 
     // Initialize preview engine
     m_previewEngine = std::make_unique<PreviewEngine>();
@@ -1054,6 +1061,18 @@ void AestraContent::setupArsenalPanels() {
             onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
         }
 
+        // Arming is otherwise invisible (the browser doesn't navigate or
+        // prompt), so tell the user what the next browser click will do.
+        std::string unitName;
+        if (m_trackManager) {
+            if (const auto* unit = m_trackManager->getUnitManager().getUnit(id)) {
+                unitName = unit->name;
+            }
+        }
+        showToast(unitName.empty() ? "Click a sample in the browser to load it"
+                                   : "Click a sample in the browser to load it into " + unitName,
+                  4.0);
+
         // Set one-shot selection callback
         m_fileBrowser->setOnFileSelected([this, id](const AestraUI::FileItem& file) {
             // Folder clicks fire onFileSelected too — ignore them so the pick
@@ -1635,6 +1654,11 @@ void AestraContent::onResize(int width, int height) {
             m_audioVisualizer->setBounds(
                 AestraUI::NUIAbsolute(contentBounds, xStart, vuY, meterWidth, visualizerHeight));
         }
+    }
+
+    if (m_notificationToast && m_notificationToast->isVisible()) {
+        m_notificationToast->setBounds(
+            AestraUI::NUIAbsolute(contentBounds, 0.0f, height - 72.0f, width, 40.0f));
     }
 
     if (m_trackManagerUI) {
@@ -3358,6 +3382,19 @@ void AestraContent::drainMainThreadTasks() {
     }
 }
 
+void AestraContent::showToast(const std::string& message, double seconds) {
+    if (!m_notificationToast) {
+        return;
+    }
+    m_notificationToast->setText(message);
+    m_notificationToast->setDuration(seconds);
+    const auto bounds = getBounds();
+    m_notificationToast->setBounds(
+        AestraUI::NUIAbsolute(bounds, 0.0f, bounds.height - 72.0f, bounds.width, 40.0f));
+    m_notificationToast->setVisible(true);
+    m_notificationToast->bringToFront();
+}
+
 void AestraContent::loadSampleIntoUnitAsync(UnitID unitId, const std::string& samplePath, bool openEditorWhenReady) {
     if (!m_trackManager || unitId == 0 || samplePath.empty()) {
         return;
@@ -3437,6 +3474,7 @@ void AestraContent::loadSampleIntoUnitAsync(UnitID unitId, const std::string& sa
                 !unitManager.setUnitAudioClipFromDecoded(unitId, samplePath, std::move(decodedData), sampleRate,
                                                          numChannels, std::move(previewWaveform), durationSeconds)) {
                 AESTRA_LOG_ERROR("Failed to load sample into Unit " + std::to_string(unitId) + ": " + samplePath);
+                self->showToast("Couldn't load " + std::filesystem::path(samplePath).filename().string());
                 return;
             }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -848,6 +848,14 @@ void AestraContent::setupPianoRollPanel() {
         }
         updatePatternLoopLength(patternId);
     });
+    m_pianoRollPanel->setOnEditingUnitChanged([this](UnitID unitId) {
+        // The Piano Roll's own unit switcher changed the editing unit — route it
+        // through the Arsenal's selection choke point so hardware MIDI, musical
+        // typing, and the Arsenal highlight all follow the same unit.
+        if (m_sequencerPanel) {
+            m_sequencerPanel->setSelectedUnit(unitId);
+        }
+    });
     m_pianoRollPanel->setOnClose([this]() {
         m_pianoRollPanel->savePattern();
         toggleView(Audio::ViewType::PianoRoll);
@@ -1040,9 +1048,11 @@ void AestraContent::setupArsenalPanels() {
                 onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
             });
 
-            // 2. Perform Load
+            // 2. Perform Load — do NOT auto-open the sample editor; loading a
+            // sample should just arm the unit. The editor is opened explicitly
+            // via the gear / double-click "edit" action.
             AESTRA_LOG_DEBUG("Loading sample into Unit " + std::to_string(id) + ": " + file.path);
-            loadSampleIntoUnitAsync(id, file.path, true);
+            loadSampleIntoUnitAsync(id, file.path, false);
         });
     });
     m_sequencerPanel->setOnRequestSampleEditor([this](UnitID id) {
@@ -1055,7 +1065,7 @@ void AestraContent::setupArsenalPanels() {
     m_sequencerPanel->setOnPluginDroppedToUnit(
         [this](UnitID unitId, const std::string& pluginId) { loadInstrumentIntoArsenalUnit(unitId, pluginId); });
     m_sequencerPanel->setOnSampleDroppedToUnit(
-        [this](UnitID unitId, const std::string& samplePath) { loadSampleIntoUnitAsync(unitId, samplePath, true); });
+        [this](UnitID unitId, const std::string& samplePath) { loadSampleIntoUnitAsync(unitId, samplePath, false); });
     m_sequencerPanel->setOnSelectedUnitChanged([this](UnitID unitId) {
         if (m_pianoRollPanel) {
             m_pianoRollPanel->setEditingUnit(unitId);
@@ -1080,6 +1090,13 @@ void AestraContent::setupArsenalPanels() {
         if (m_trackManagerUI) {
             m_trackManagerUI->refreshTracks();
             m_trackManagerUI->invalidateCache();
+        }
+        // Re-prepare the pattern so the playback engine re-schedules the notes
+        // just edited in the Arsenal grid. Without this, newly placed steps stay
+        // silent during pattern playback until some other path flushes (e.g.
+        // editing the same pattern in the Piano Roll). Mirrors setActivePattern.
+        if (m_trackManager) {
+            m_trackManager->preparePatternForArsenal(patternId);
         }
         // Update audio engine loop length to match actual pattern length
         updatePatternLoopLength(patternId);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1056,6 +1056,18 @@ void AestraContent::setupArsenalPanels() {
 
         // Set one-shot selection callback
         m_fileBrowser->setOnFileSelected([this, id](const AestraUI::FileItem& file) {
+            // Folder clicks fire onFileSelected too — ignore them so the pick
+            // stays armed while the user navigates to their sample.
+            if (file.isDirectory)
+                return;
+
+            // Copy out of the closure BEFORE the setOnFileSelected below —
+            // replacing the callback destroys this lambda and its captures;
+            // reading `id`/`file` afterwards was a use-after-free that made
+            // "Load Sample" silently load into a garbage unit id.
+            const UnitID targetUnit = id;
+            const std::string samplePath = file.path;
+
             // 1. Restore default behavior (Preview)
             m_fileBrowser->setOnFileSelected([this](const AestraUI::FileItem& f) {
                 stopSoundPreview();
@@ -1070,8 +1082,7 @@ void AestraContent::setupArsenalPanels() {
             // 2. Perform Load — do NOT auto-open the sample editor; loading a
             // sample should just arm the unit. The editor is opened explicitly
             // via the gear / double-click "edit" action.
-            AESTRA_LOG_DEBUG("Loading sample into Unit " + std::to_string(id) + ": " + file.path);
-            loadSampleIntoUnitAsync(id, file.path, false);
+            loadSampleIntoUnitAsync(targetUnit, samplePath, false);
         });
     });
     m_sequencerPanel->setOnRequestSampleEditor([this](UnitID id) {
@@ -1610,6 +1621,11 @@ void AestraContent::onResize(int width, int height) {
             totalWidth += waveformWidth + gap;
 
         float xStart = width - totalWidth - layout.panelMargin;
+        if (m_transportBar) {
+            // The visualizers overlay the transport row; tell the bar so its
+            // KEYS status pill hides instead of rendering underneath them.
+            m_transportBar->setRightReservedWidth(totalWidth + layout.panelMargin + gap);
+        }
         if (m_waveformVisualizer) {
             m_waveformVisualizer->setBounds(
                 AestraUI::NUIAbsolute(contentBounds, xStart, vuY, waveformWidth, visualizerHeight));

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -476,6 +476,25 @@ void AestraContent::setupTransportBar() {
             clearPendingCountIn();
         }
     });
+    m_transportBar->setOnTimeSignatureChange([this](int beatsPerBar) {
+        // Propagate the time signature to every bar-math consumer. The clock
+        // is the source of truth; the rest cache or re-derive from it.
+        if (m_trackManager) {
+            m_trackManager->getTimelineClock().setBeatsPerBar(beatsPerBar);
+        }
+        if (m_audioEngine) {
+            m_audioEngine->setMetronomeBeatsPerBar(beatsPerBar);
+        }
+        if (m_pianoRollPanel) {
+            m_pianoRollPanel->setBeatsPerBar(beatsPerBar);
+        }
+        if (m_trackManagerUI) {
+            m_trackManagerUI->setBeatsPerBar(beatsPerBar);
+        }
+        if (m_sequencerPanel) {
+            m_sequencerPanel->refreshUnits(); // Re-derive bar grouping + loop length
+        }
+    });
 
     // Helper: Stop preview when Audition Queue changes (drop)
     if (m_auditionEngine) {
@@ -2795,7 +2814,13 @@ void AestraContent::updatePatternLoopLength(PatternID patternId) {
     if (!pattern) {
         return;
     }
-    double lengthBeats = std::max(16.0, pattern->lengthBeats);
+    // Respect the pattern's real length, floored at one bar of the current
+    // time signature. The old 16-beat floor fought the Piano Roll's save path
+    // (which sets the true length): the loop length ping-ponged on every edit,
+    // playing phantom empty bars and desyncing the pattern scheduler's frame
+    // domain from the audio thread (= silence after the next wrap).
+    const double barBeats = static_cast<double>(m_trackManager->getTimelineClock().getBeatsPerBar());
+    double lengthBeats = std::max(barBeats, pattern->lengthBeats);
     m_audioEngine->setPatternPlaybackMode(true, lengthBeats);
 }
 

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -48,6 +48,7 @@ namespace AestraUI {
     class FileItem;
     class AudioVisualizer;
     class PluginUIController;
+    class NotificationToast;
 }
 
 // Forward declarations - Aestra::Audio (includes panel classes)
@@ -313,6 +314,9 @@ public:
     /** @brief Update the preview playhead visible in the UI. */
     void updatePreviewPlayhead();
 
+    /** @brief Show a transient status pill (bottom-center overlay). */
+    void showToast(const std::string& message, double seconds = 2.6);
+
     /** @brief Load an effect plugin onto the selected track. */
     void loadEffectToSelectedTrack(const std::string& pluginId);
     /** @brief Load an instrument plugin into Arsenal. */
@@ -362,6 +366,8 @@ private:
     
 
     
+    std::shared_ptr<AestraUI::NotificationToast> m_notificationToast;
+
     // Browser section
     std::shared_ptr<AestraUI::NUISegmentedControl> m_browserToggle;
     std::shared_ptr<AestraUI::FileBrowser> m_fileBrowser;

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -95,7 +95,7 @@ bool isAudioFileDrag(const AestraUI::DragData& data) {
     return ext == "wav" || ext == "mp3" || ext == "flac" || ext == "ogg" || ext == "aiff";
 }
 
-bool patternUsesNoteRoll(const PatternSource* pattern, UnitID unitId, UnitType type) {
+bool patternUsesNoteRoll(const PatternSource* pattern, UnitID unitId, UnitType type, int rootPitch) {
     if (type == UnitType::Instrument) {
         return true;
     }
@@ -103,11 +103,13 @@ bool patternUsesNoteRoll(const PatternSource* pattern, UnitID unitId, UnitType t
         return false;
     }
 
+    // rootPitch: the unit's sampler root note — grid steps are placed at the
+    // root, so only off-root/off-grid notes indicate real note-roll content.
     const auto& midi = std::get<MidiPayload>(pattern->payload);
-    return std::any_of(midi.notes.begin(), midi.notes.end(), [unitId](const MidiNote& note) {
+    return std::any_of(midi.notes.begin(), midi.notes.end(), [unitId, rootPitch](const MidiNote& note) {
         const bool belongsToUnit = note.unitId == unitId || note.unitId == 0;
         return belongsToUnit &&
-               (note.pitch != 60 || std::abs(note.durationBeats - 0.25) > 0.01);
+               (note.pitch != rootPitch || std::abs(note.durationBeats - 0.25) > 0.01);
     });
 }
 
@@ -642,7 +644,8 @@ void ArsenalPanel::drawCommandHeader(NUIRenderer& renderer) {
                 selectedType = unitTypeDisplayName(unit->type);
                 if (m_activePatternID.isValid()) {
                     const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID);
-                    if (patternUsesNoteRoll(pattern, m_selectedUnitId, unit->type)) {
+                    if (patternUsesNoteRoll(pattern, m_selectedUnitId, unit->type,
+                                            m_trackManager->getUnitManager().getUnitRootMidiNote(m_selectedUnitId))) {
                         selectedType = "MIDI";
                     }
                 }
@@ -887,7 +890,8 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     std::string contentLabel = unitTypeContentLabel(selectedType, m_stepCount, selectedDurationSeconds);
     if (m_trackManager && m_activePatternID.isValid()) {
         const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID);
-        if (patternUsesNoteRoll(pattern, m_selectedUnitId, selectedType)) {
+        if (patternUsesNoteRoll(pattern, m_selectedUnitId, selectedType,
+                                m_trackManager->getUnitManager().getUnitRootMidiNote(m_selectedUnitId))) {
             contentLabel = "Note Roll";
         }
     }

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -179,9 +179,70 @@ void ArsenalPanel::createLayout() {
     // The content of this method has been moved to the constructor or is handled by the base class.
 }
 
+int ArsenalPanel::computeLoopStepCount() const {
+    // One step per 1/16 note (0.25 beat), spanning the whole loop so the grid
+    // shows every bar of the pattern instead of a fixed single bar.
+    double lengthBeats = 4.0;
+    if (m_trackManager && m_activePatternID.isValid()) {
+        if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID)) {
+            lengthBeats = std::max(4.0, pattern->lengthBeats);
+        }
+    }
+    const int steps = static_cast<int>(std::lround(lengthBeats / 0.25));
+    return std::clamp(steps, 16, 256);
+}
+
+float ArsenalPanel::computeGridMaxScrollX() const {
+    // Mirrors the UnitRow grid geometry (control block + context paddings +
+    // min 20px pads) so the shared scroll clamps against the real content.
+    const float width = m_progressHeaderRect.width;
+    if (width <= 0.0f) return 0.0f;
+    const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
+    const float availWidth = std::max(1.0f, width - controlWidth - 26.0f);
+    const float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
+    return std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) - availWidth);
+}
+
+void ArsenalPanel::scrollGridBy(float deltaPx) {
+    const float clamped = std::clamp(m_gridScrollX + deltaPx, 0.0f, computeGridMaxScrollX());
+    m_gridScrollX = clamped;
+    for (auto& row : m_unitRows) {
+        if (row) row->setScrollX(clamped);
+    }
+    repaint();
+}
+
+void ArsenalPanel::followGridPlayhead() {
+    const int playStep = calculateCurrentStep();
+    if (playStep < 0) {
+        m_gridFollowSuspended = false; // Transport stopped: resume following next play
+        return;
+    }
+    const float width = m_progressHeaderRect.width;
+    if (width <= 0.0f) return;
+    const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
+    const float availWidth = std::max(1.0f, width - controlWidth - 26.0f);
+    const float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
+    const float maxScroll = std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) - availWidth);
+    if (maxScroll <= 0.0f) return; // Whole loop fits: nothing to follow
+
+    const float stepLeft = static_cast<float>(playStep) * stepWidth;
+    const bool visible = stepLeft >= m_gridScrollX &&
+                         stepLeft + stepWidth <= m_gridScrollX + availWidth;
+    if (visible) {
+        m_gridFollowSuspended = false; // Playhead in view again: re-arm following
+        return;
+    }
+    if (m_gridFollowSuspended) return; // Don't fight a deliberate manual scroll
+    // Page to the playing bar's start so a full musical bar reads at once.
+    const float barLeft = static_cast<float>((playStep / 16) * 16) * stepWidth;
+    scrollGridBy(std::clamp(barLeft, 0.0f, maxScroll) - m_gridScrollX);
+}
+
 void ArsenalPanel::refreshUnits() {
     if (!m_listContainer || !m_trackManager) return;
     auto& theme = NUIThemeManager::getInstance();
+    m_stepCount = computeLoopStepCount();
     const bool shouldRestoreDropTargets = m_dropTargetRegistered;
     if (shouldRestoreDropTargets) {
         unregisterDropTargets();
@@ -208,7 +269,15 @@ void ArsenalPanel::refreshUnits() {
         
         // Set step count
         row->setStepCount(m_stepCount);
-        
+
+        // Shared horizontal grid scroll: the panel owns the offset so the
+        // progress header and every row stay in lockstep.
+        row->setScrollX(m_gridScrollX);
+        row->setOnGridScroll([this](float deltaPx) {
+            m_gridFollowSuspended = true; // Manual scroll wins over playhead follow
+            scrollGridBy(deltaPx);
+        });
+
         // Set up callbacks for drag-drop and color picker
         row->setOnDragStart([this](UnitID id) {
             onUnitDragStart(id);
@@ -307,6 +376,7 @@ void ArsenalPanel::refreshUnits() {
     m_listContainer->addChild(m_addUnitBtn);
     
     layoutUnits();
+    scrollGridBy(0.0f); // Re-clamp the shared scroll for the (possibly new) loop length
     syncRowSelection();
     if (shouldRestoreDropTargets) {
         registerDropTargets(true);
@@ -599,15 +669,22 @@ void ArsenalPanel::layoutUnits() {
     float yPos = m_progressHeaderRect.bottom() + 8.0f - m_scrollY;
     float spacing = 8.0f;
     float rowHeight = 56.0f;
-    
+
+    // Rows may only draw / take clicks between the progress header and the
+    // panel bottom; anything scrolled past that is clipped by the row itself.
+    const float viewportTop = m_progressHeaderRect.bottom() + 4.0f;
+    const float viewportBottom = bounds.bottom() - 6.0f;
+    m_listViewportRect = {startX, viewportTop, width, std::max(0.0f, viewportBottom - viewportTop)};
+
     // Layout unit rows
     for (auto& row : m_unitRows) {
         if (row) {
             row->setBounds(NUIRect(startX, yPos, width, rowHeight));
+            row->setViewport(m_listViewportRect);
             yPos += rowHeight + spacing;
         }
     }
-    
+
 }
 
 void ArsenalPanel::onResize(int width, int height) {
@@ -637,6 +714,8 @@ void ArsenalPanel::onUpdate(double dt) {
         m_scrollY = m_targetScrollY;
         layoutUnits();
     }
+
+    followGridPlayhead();
 }
 
 void ArsenalPanel::registerDropTargets(bool reorder) {
@@ -756,10 +835,11 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     // Calculate current step from clock
     m_currentPlayStep = calculateCurrentStep();
     
-    // Step layout (matches UnitRow grid layout)
+    // Step layout (matches UnitRow grid layout: control block + 8px context
+    // inset + 6px lane padding, so header pads line up with row pads exactly)
     const float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
     const float gridStartX = bounds.x + controlWidth + 14.0f;
-    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 20.0f);
+    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 26.0f);
 
     double lengthBeats = static_cast<double>(m_stepCount) * 0.25;
     UnitType selectedType = UnitType::Sampler;
@@ -829,28 +909,38 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     renderer.fillRoundedRect(gridCard, cardRadius, theme.getColor("backgroundSecondary").withAlpha(0.82f));
     renderer.strokeRoundedRect(gridCard, cardRadius, 1.0f, theme.getColor("borderSubtle").withAlpha(0.7f));
 
-    float stepWidth = std::max(availWidth / static_cast<float>(m_stepCount), 20.0f);
+    // Same step width formula as the rows (min 20px pads) + the shared scroll
+    // offset, so the header ruler and every row grid stay in lockstep.
+    float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
+    const float totalWidth = stepWidth * static_cast<float>(m_stepCount);
+    const float maxScrollX = std::max(0.0f, totalWidth - availWidth);
+    m_gridScrollX = std::clamp(m_gridScrollX, 0.0f, maxScrollX);
     float indicatorHeight = PROGRESS_HEADER_HEIGHT - 10.0f;
     float indicatorY = bounds.y + 5.0f;
     const float indicatorRadius = themeProps.radiusXS;
 
-    // Scanlines/Clipping: Clip to header bounds to prevent overflow
-    renderer.setClipRect(bounds);
+    // Clip to the grid card so scrolled steps never paint over the bars pills.
+    renderer.setClipRect(gridCard);
 
     // Draw step indicators
     for (int i = 0; i < m_stepCount; ++i) {
-        float stepX = gridStartX + (i * stepWidth) + 2.0f;
+        float stepX = gridStartX + (i * stepWidth) - m_gridScrollX + 2.0f;
         float indicatorWidth = stepWidth - 4.0f;
+        if (stepX > gridCard.right()) break;
+        if (stepX + stepWidth < gridCard.x) continue;
 
         NUIRect indicatorRect(stepX, indicatorY, indicatorWidth, indicatorHeight);
 
         // Base color: more visible background
         NUIColor bgColor = theme.getColor("surfaceTertiary").withAlpha(0.5f);
 
-        // Bar/beat markers
-        bool isBarStart = (i % 4 == 0);
+        // Bar/beat markers (16 steps = 1 bar at 1/16 resolution)
+        const bool isBeatStart = (i % 4 == 0);
+        const bool isBarStart = (i % 16 == 0);
         if (isBarStart) {
-            bgColor = bgColor.lightened(0.1f);
+            bgColor = bgColor.lightened(0.16f);
+        } else if (isBeatStart) {
+            bgColor = bgColor.lightened(0.08f);
         }
 
         renderer.fillRoundedRect(indicatorRect, indicatorRadius, bgColor);
@@ -876,10 +966,24 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
                                    theme.getColor("borderSubtle").withAlpha(0.6f));
 
         if (isBarStart) {
-            renderer.drawTextCentered(std::to_string((i / 4) + 1), indicatorRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
+            const NUIRect labelRect(stepX, indicatorY, stepWidth * 16.0f, indicatorHeight);
+            renderer.drawTextCentered(std::to_string((i / 16) + 1), labelRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
         }
     }
-    
+
+    // Scroll indicator: show which slice of the loop the grids are viewing.
+    if (maxScrollX > 0.0f) {
+        const float trackX = gridCard.x + 3.0f;
+        const float trackWidth = std::max(0.0f, gridCard.width - 6.0f);
+        const float trackY = gridCard.bottom() - 4.0f;
+        renderer.fillRoundedRect({trackX, trackY, trackWidth, 2.5f}, 1.25f,
+                                 theme.getColor("borderSubtle").withAlpha(0.55f));
+        const float thumbWidth = std::max(16.0f, trackWidth * (availWidth / totalWidth));
+        const float thumbX = trackX + (trackWidth - thumbWidth) * (m_gridScrollX / maxScrollX);
+        renderer.fillRoundedRect({thumbX, trackY, thumbWidth, 2.5f}, 1.25f,
+                                 theme.getColor("accentPrimary").withAlpha(0.75f));
+    }
+
     renderer.clearClipRect();
 }
 
@@ -1214,8 +1318,10 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         return true;
     }
     
-    // Track which unit is selected (for copy/paste)
-    if (event.pressed && event.button == NUIMouseButton::Left) {
+    // Track which unit is selected (for copy/paste). Only rows inside the
+    // list viewport are clickable — scrolled-out rows are not rendered.
+    if (event.pressed && event.button == NUIMouseButton::Left &&
+        (m_listViewportRect.height <= 0.0f || m_listViewportRect.contains(event.position))) {
         for (size_t i = 0; i < m_unitRows.size(); ++i) {
             if (m_unitRows[i] && m_unitRows[i]->getBounds().contains(event.position)) {
                 m_selectedUnitId = m_unitRows[i]->getUnitId();

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -199,6 +199,7 @@ int ArsenalPanel::computeLoopStepCount() const {
 }
 
 float ArsenalPanel::computeGridMaxScrollX() const {
+    if (m_fitToWidth) return 0.0f; // Whole loop shown → nothing to scroll
     // Mirrors the UnitRow grid geometry (control block + context paddings +
     // min 20px pads) so the shared scroll clamps against the real content.
     const float width = m_progressHeaderRect.width;
@@ -276,6 +277,7 @@ void ArsenalPanel::refreshUnits() {
         
         // Set step count
         row->setStepCount(m_stepCount);
+        row->setFitToWidth(m_fitToWidth);
 
         // Shared horizontal grid scroll: the panel owns the offset so the
         // progress header and every row stay in lockstep.
@@ -655,6 +657,20 @@ void ArsenalPanel::drawCommandHeader(NUIRenderer& renderer) {
                           (unitCount == 1 ? " UNIT" : " UNITS"),
                       {textX, m_commandHeaderRect.y + 28.0f}, 8.5f,
                       theme.getColor("textSecondary").withAlpha(0.70f));
+
+    // View toggle: reflects current mode (accent = Fit, muted = Scroll).
+    if (m_fitToggleRect.width > 0.0f) {
+        const float radius = themeProps.radiusS;
+        const NUIColor fill = m_fitToWidth ? theme.getColor("accentPrimary").withAlpha(0.18f)
+                                           : theme.getColor("surfaceTertiary").withAlpha(0.85f);
+        const NUIColor stroke = m_fitToWidth ? theme.getColor("accentPrimary").withAlpha(0.70f)
+                                             : theme.getColor("borderSubtle").withAlpha(0.85f);
+        const NUIColor text = m_fitToWidth ? theme.getColor("accentPrimary")
+                                           : theme.getColor("textSecondary").withAlpha(0.9f);
+        renderer.fillRoundedRect(m_fitToggleRect, radius, fill);
+        renderer.strokeRoundedRect(m_fitToggleRect, radius, 1.0f, stroke);
+        renderer.drawTextCentered(m_fitToWidth ? "FIT" : "SCROLL", m_fitToggleRect, themeProps.fontSizeMicro, text);
+    }
 }
 
 void ArsenalPanel::layoutUnits() {
@@ -671,6 +687,10 @@ void ArsenalPanel::layoutUnits() {
     const float buttonY = m_commandHeaderRect.y + (m_commandHeaderRect.height - buttonH) * 0.5f;
     m_addUnitButtonRect = {m_commandHeaderRect.right() - 10.0f - addW, buttonY, addW, buttonH};
     if (m_addUnitBtn) m_addUnitBtn->setBounds(m_addUnitButtonRect);
+
+    // View toggle (Fit whole loop <-> readable + scroll) sits just left of Add.
+    constexpr float fitW = 84.0f;
+    m_fitToggleRect = {m_addUnitButtonRect.x - 8.0f - fitW, buttonY, fitW, buttonH};
 
     m_progressHeaderRect = {startX, m_commandHeaderRect.bottom() + 8.0f, width, PROGRESS_HEADER_HEIGHT};
     float yPos = m_progressHeaderRect.bottom() + 8.0f - m_scrollY;
@@ -920,9 +940,11 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     renderer.fillRoundedRect(gridCard, cardRadius, theme.getColor("backgroundSecondary").withAlpha(0.82f));
     renderer.strokeRoundedRect(gridCard, cardRadius, 1.0f, theme.getColor("borderSubtle").withAlpha(0.7f));
 
-    // Same step width formula as the rows (min 20px pads) + the shared scroll
-    // offset, so the header ruler and every row grid stay in lockstep.
-    float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
+    // Same step width formula as the rows + the shared scroll offset, so the
+    // header ruler and every row grid stay in lockstep. Fit mode shrinks pads
+    // to show the whole loop; scroll mode keeps a readable 20px minimum.
+    const float fitStepWidth = availWidth / static_cast<float>(std::max(1, m_stepCount));
+    float stepWidth = m_fitToWidth ? std::max(fitStepWidth, 4.0f) : std::max(fitStepWidth, 20.0f);
     const float totalWidth = stepWidth * static_cast<float>(m_stepCount);
     const float maxScrollX = std::max(0.0f, totalWidth - availWidth);
     m_gridScrollX = std::clamp(m_gridScrollX, 0.0f, maxScrollX);
@@ -1259,6 +1281,17 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
             repaint();
             return true;
         }
+    }
+
+    if (event.pressed && event.button == NUIMouseButton::Left && m_fitToggleRect.contains(event.position)) {
+        m_fitToWidth = !m_fitToWidth;
+        m_gridScrollX = 0.0f;
+        for (auto& row : m_unitRows) {
+            if (row) row->setFitToWidth(m_fitToWidth);
+        }
+        scrollGridBy(0.0f); // Re-clamp shared scroll for the new mode
+        repaint();
+        return true;
     }
 
     if (event.pressed && event.button == NUIMouseButton::Left) {

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -13,7 +13,7 @@ namespace Aestra {
 namespace Audio {
 
 namespace {
-constexpr int kArsenalMinPatternBars = 2;
+constexpr int kArsenalMinPatternBars = 1;
 constexpr int kArsenalMaxPatternBars = 16;
 
 const char* unitTypeDisplayName(UnitType type) {
@@ -179,17 +179,23 @@ void ArsenalPanel::createLayout() {
     // The content of this method has been moved to the constructor or is handled by the base class.
 }
 
+int ArsenalPanel::beatsPerBar() const {
+    return m_trackManager ? m_trackManager->getTimelineClock().getBeatsPerBar() : 4;
+}
+
 int ArsenalPanel::computeLoopStepCount() const {
     // One step per 1/16 note (0.25 beat), spanning the whole loop so the grid
-    // shows every bar of the pattern instead of a fixed single bar.
-    double lengthBeats = 4.0;
+    // shows every bar of the pattern instead of a fixed single bar. Minimum is
+    // one bar of the current time signature.
+    const double barBeats = static_cast<double>(beatsPerBar());
+    double lengthBeats = barBeats;
     if (m_trackManager && m_activePatternID.isValid()) {
         if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID)) {
-            lengthBeats = std::max(4.0, pattern->lengthBeats);
+            lengthBeats = std::max(barBeats, pattern->lengthBeats);
         }
     }
     const int steps = static_cast<int>(std::lround(lengthBeats / 0.25));
-    return std::clamp(steps, 16, 256);
+    return std::clamp(steps, beatsPerBar() * 4, 256);
 }
 
 float ArsenalPanel::computeGridMaxScrollX() const {
@@ -235,7 +241,8 @@ void ArsenalPanel::followGridPlayhead() {
     }
     if (m_gridFollowSuspended) return; // Don't fight a deliberate manual scroll
     // Page to the playing bar's start so a full musical bar reads at once.
-    const float barLeft = static_cast<float>((playStep / 16) * 16) * stepWidth;
+    const int stepsPerBar = beatsPerBar() * 4;
+    const float barLeft = static_cast<float>((playStep / stepsPerBar) * stepsPerBar) * stepWidth;
     scrollGridBy(std::clamp(barLeft, 0.0f, maxScroll) - m_gridScrollX);
 }
 
@@ -780,10 +787,11 @@ int ArsenalPanel::calculateCurrentStep() {
     double currentBeat = positionSeconds * beatsPerSecond;
     
     // Use the actual pattern length instead of a hard-coded 1-bar step grid.
-    double patternLengthBeats = 8.0;
+    const double barBeats = static_cast<double>(beatsPerBar());
+    double patternLengthBeats = barBeats;
     if (m_activePatternID.isValid()) {
         if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID)) {
-            patternLengthBeats = std::max(8.0, pattern->lengthBeats);
+            patternLengthBeats = std::max(barBeats, pattern->lengthBeats);
         }
     }
     const double beatsPerVisualStep = patternLengthBeats / std::max(1, m_stepCount);
@@ -808,12 +816,13 @@ void ArsenalPanel::adjustPatternBars(int deltaBars) {
         return;
     }
 
+    const double barBeats = static_cast<double>(beatsPerBar());
     const int currentBars = std::clamp(
-        static_cast<int>(std::round(std::max(8.0, pattern->lengthBeats) / 4.0)),
+        static_cast<int>(std::round(std::max(barBeats, pattern->lengthBeats) / barBeats)),
         kArsenalMinPatternBars,
         kArsenalMaxPatternBars);
     const int nextBars = std::clamp(currentBars + deltaBars, kArsenalMinPatternBars, kArsenalMaxPatternBars);
-    const double nextLengthBeats = static_cast<double>(nextBars) * 4.0;
+    const double nextLengthBeats = static_cast<double>(nextBars) * barBeats;
     if (std::abs(nextLengthBeats - pattern->lengthBeats) < 0.001) {
         return;
     }
@@ -863,7 +872,9 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
         }
     }
 
-    const int bars = std::clamp(static_cast<int>(std::round(lengthBeats / 4.0)), kArsenalMinPatternBars, kArsenalMaxPatternBars);
+    const int stepsPerBar = beatsPerBar() * 4;
+    const int bars = std::clamp(static_cast<int>(std::round(lengthBeats / static_cast<double>(beatsPerBar()))),
+                                kArsenalMinPatternBars, kArsenalMaxPatternBars);
     const bool decEnabled = bars > kArsenalMinPatternBars;
     const bool incEnabled = bars < kArsenalMaxPatternBars;
 
@@ -934,9 +945,9 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
         // Base color: more visible background
         NUIColor bgColor = theme.getColor("surfaceTertiary").withAlpha(0.5f);
 
-        // Bar/beat markers (16 steps = 1 bar at 1/16 resolution)
+        // Bar/beat markers (4 steps = 1 beat at 1/16 resolution)
         const bool isBeatStart = (i % 4 == 0);
-        const bool isBarStart = (i % 16 == 0);
+        const bool isBarStart = (i % stepsPerBar == 0);
         if (isBarStart) {
             bgColor = bgColor.lightened(0.16f);
         } else if (isBeatStart) {
@@ -966,8 +977,8 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
                                    theme.getColor("borderSubtle").withAlpha(0.6f));
 
         if (isBarStart) {
-            const NUIRect labelRect(stepX, indicatorY, stepWidth * 16.0f, indicatorHeight);
-            renderer.drawTextCentered(std::to_string((i / 16) + 1), labelRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
+            const NUIRect labelRect(stepX, indicatorY, stepWidth * static_cast<float>(stepsPerBar), indicatorHeight);
+            renderer.drawTextCentered(std::to_string((i / stepsPerBar) + 1), labelRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
         }
     }
 
@@ -1254,7 +1265,8 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         int bars = 4;
         if (m_trackManager && m_activePatternID.isValid()) {
             if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID)) {
-                bars = std::clamp(static_cast<int>(std::round(std::max(8.0, pattern->lengthBeats) / 4.0)),
+                const double barBeats = static_cast<double>(beatsPerBar());
+                bars = std::clamp(static_cast<int>(std::round(std::max(barBeats, pattern->lengthBeats) / barBeats)),
                                   kArsenalMinPatternBars,
                                   kArsenalMaxPatternBars);
             }

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -117,8 +117,13 @@ private:
     // Layout & Scrolling
     float m_scrollY = 0.0f;
     float m_targetScrollY = 0.0f;
+    float m_gridScrollX = 0.0f; // Shared horizontal step-grid scroll (header + all rows)
+    bool m_gridFollowSuspended = false; // User scrolled away while playing; stop chasing them
     int m_stepCount = 16; // Default step count
     void layoutUnits();
+    void scrollGridBy(float deltaPx); // Clamp + broadcast the shared grid scroll
+    float computeGridMaxScrollX() const;
+    void followGridPlayhead(); // Keep the playing bar in view unless the user scrolled away
     
     // Pattern Progress Visualization
     static constexpr float COMMAND_HEADER_HEIGHT = 52.0f;
@@ -127,6 +132,7 @@ private:
     void drawProgressHeader(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds);
     void drawCommandHeader(AestraUI::NUIRenderer& renderer);
     int calculateCurrentStep(); // Calculate step from TrackManager clock
+    int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (16/bar)
     void adjustPatternBars(int deltaBars);
     void createUnitOfType(UnitType type);
     void drawUnitTypePicker(AestraUI::NUIRenderer& renderer);
@@ -173,6 +179,7 @@ private:
     AestraUI::NUIRect m_addUnitButtonRect{};
     AestraUI::NUIRect m_commandHeaderRect{};
     AestraUI::NUIRect m_progressHeaderRect{};
+    AestraUI::NUIRect m_listViewportRect{}; // Visible area for unit rows (scroll clip + hit-test)
     AestraUI::NUIRect m_unitTypePickerRect{};
     AestraUI::NUIRect m_barsDecrementRect{};
     AestraUI::NUIRect m_barsValueRect{};

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -132,7 +132,8 @@ private:
     void drawProgressHeader(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds);
     void drawCommandHeader(AestraUI::NUIRenderer& renderer);
     int calculateCurrentStep(); // Calculate step from TrackManager clock
-    int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (16/bar)
+    int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (4/beat)
+    int beatsPerBar() const; // Time-signature numerator from the timeline clock
     void adjustPatternBars(int deltaBars);
     void createUnitOfType(UnitType type);
     void drawUnitTypePicker(AestraUI::NUIRenderer& renderer);

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -119,6 +119,7 @@ private:
     float m_targetScrollY = 0.0f;
     float m_gridScrollX = 0.0f; // Shared horizontal step-grid scroll (header + all rows)
     bool m_gridFollowSuspended = false; // User scrolled away while playing; stop chasing them
+    bool m_fitToWidth = true; // Fit whole loop to width vs readable-min + scroll
     int m_stepCount = 16; // Default step count
     void layoutUnits();
     void scrollGridBy(float deltaPx); // Clamp + broadcast the shared grid scroll
@@ -178,6 +179,7 @@ private:
     bool m_dropTargetRegistered = false;
     bool m_showUnitTypePicker = false;
     AestraUI::NUIRect m_addUnitButtonRect{};
+    AestraUI::NUIRect m_fitToggleRect{};
     AestraUI::NUIRect m_commandHeaderRect{};
     AestraUI::NUIRect m_progressHeaderRect{};
     AestraUI::NUIRect m_listViewportRect{}; // Visible area for unit rows (scroll clip + hit-test)

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -205,11 +205,20 @@ void PianoRollPanel::loadPattern(PatternID patternId) {
             m_pianoRoll->setSnapToScale(false);
         }
 
-        // Convert backend notes to UI notes
+        // Convert backend notes to UI notes. Only the editing unit's notes are
+        // editable in the roll; other units' notes are stashed and rendered as
+        // colored unit ghosts (and merged back untouched on save), so switching
+        // the unit dropdown visibly switches what you're editing.
         const auto& midiPayload = std::get<MidiPayload>(pattern->payload);
         std::vector<AestraUI::MidiNote> uiNotes;
-        
+        m_otherUnitNotes.clear();
+        const bool filterByUnit = m_editingUnitId != 0;
+
         for (const auto& vn : midiPayload.notes) {
+            if (filterByUnit && vn.unitId != 0 && vn.unitId != m_editingUnitId) {
+                m_otherUnitNotes.push_back(vn);
+                continue;
+            }
             AestraUI::MidiNote uiNote;
             uiNote.pitch = vn.pitch;
             uiNote.startBeat = vn.startBeat;
@@ -285,6 +294,10 @@ void PianoRollPanel::savePattern() {
         currentNotes.push_back(backendNote);
     }
 
+    // Other units' notes are hidden from the editor but still belong to the
+    // pattern — merge them back so the diff/revert below can't drop them.
+    currentNotes.insert(currentNotes.end(), m_otherUnitNotes.begin(), m_otherUnitNotes.end());
+
     // Diff the before/after states using the dedicated diff function.
     // diffNotes handles same-position/different-duration disambiguation via
     // a two-pass algorithm: exact full-field matching first, then position
@@ -344,10 +357,14 @@ void PianoRollPanel::savePattern() {
         m_applyingUndoRedo = false;
     }
 
-    // Update captured state for next edit
+    // Update captured state for next edit — BEFORE notifying listeners, so a
+    // reentrant savePattern (Arsenal refresh echo) diffs as empty and stops.
     m_notesBeforeEdit = currentNotes;
 
-    if (m_onPatternEdited) {
+    // Only notify when something actually changed: unconditional notification
+    // caused an Arsenal-refresh/refreshTracks storm on every no-op save and
+    // fed the setEditingUnit recursion.
+    if (!diff.empty() && m_onPatternEdited) {
         m_onPatternEdited(m_currentPatternId);
     }
 
@@ -415,9 +432,27 @@ void PianoRollPanel::adjustPatternLengthBars(int barsDelta) {
 }
 
 void PianoRollPanel::setEditingUnit(UnitID unitId) {
+    // Hard reentrancy guard: savePattern() below fires onPatternEdited, which
+    // walks through Arsenal refreshUnits -> onSelectedUnitChanged and back
+    // into setEditingUnit while m_editingUnitId is still the old id — without
+    // this flag that echo recurses until the stack blows (SIGSEGV in the wild).
+    if (m_switchingUnit) {
+        return;
+    }
+    const bool changed = unitId != m_editingUnitId;
+    if (changed && m_currentPatternId.isValid()) {
+        m_switchingUnit = true;
+        savePattern(); // Commit pending edits under the old unit before re-filtering
+        m_switchingUnit = false;
+    }
     m_editingUnitId = unitId;
     if (m_pianoRoll) {
         m_pianoRoll->setDefaultUnitId(unitId);
+    }
+    if (changed && m_currentPatternId.isValid()) {
+        // Re-split foreground notes vs unit ghosts for the new editing unit.
+        loadPattern(m_currentPatternId);
+        updateGhostChannels();
     }
     // Keep the toolbar's unit + pattern switchers reflecting the active unit.
     rebuildUnitSwitcher();
@@ -586,6 +621,40 @@ void PianoRollPanel::updateGhostChannels() {
         }
         ghosts.push_back(gp);
     }
-    
+
+    // Same-pattern notes belonging to other units: draw them in their unit's
+    // Arsenal color, stronger than cross-pattern ghosts, so switching the unit
+    // dropdown reads instantly (foreground = editing unit, tinted = the rest).
+    if (!m_otherUnitNotes.empty()) {
+        auto& unitMgr = m_trackManager->getUnitManager();
+        std::unordered_map<UnitID, AestraUI::PianoRollNoteLayer::GhostPattern> unitGhosts;
+        for (const auto& vn : m_otherUnitNotes) {
+            auto& gp = unitGhosts[vn.unitId];
+            if (gp.notes.empty()) {
+                uint32_t colorValue = 0x8892a6; // fallback slate
+                if (const auto* unit = unitMgr.getUnit(vn.unitId)) {
+                    colorValue = unit->color;
+                }
+                const float scale = 1.0f / 255.0f;
+                gp.color = AestraUI::NUIColor(((colorValue >> 16) & 0xff) * scale,
+                                              ((colorValue >> 8) & 0xff) * scale,
+                                              (colorValue & 0xff) * scale, 1.0f);
+                gp.fillAlpha = 0.30f;
+                gp.strokeAlpha = 0.55f;
+            }
+            AestraUI::MidiNote uiNote;
+            uiNote.pitch = vn.pitch;
+            uiNote.startBeat = vn.startBeat;
+            uiNote.durationBeats = vn.durationBeats;
+            uiNote.velocity = vn.velocity;
+            uiNote.selected = false;
+            uiNote.isDeleted = false;
+            gp.notes.push_back(uiNote);
+        }
+        for (auto& [unitId, gp] : unitGhosts) {
+            ghosts.push_back(std::move(gp));
+        }
+    }
+
     m_pianoRoll->setGhostPatterns(ghosts);
 }

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -22,14 +22,14 @@
 using namespace Aestra::Audio;
 
 namespace {
-double quantizePatternLengthBeats(double contentEndBeat) {
-    constexpr double kBeatsPerBar = 4.0;
-    constexpr double kBarsPerPatternBlock = 2.0;
-    constexpr double kPatternBlockBeats = kBeatsPerBar * kBarsPerPatternBlock; // 8 beats = 2 bars
-
+// Round pattern length up to whole bars of the CURRENT time signature,
+// minimum one bar. (Was hardcoded 2 bars of 4/4 = 8 beats, which both locked
+// non-4/4 signatures out and forced a 2-bar minimum.)
+double quantizePatternLengthBeats(double contentEndBeat, int beatsPerBar) {
+    const double barBeats = static_cast<double>(std::max(1, beatsPerBar));
     const double safeContentEnd = std::max(0.0, contentEndBeat);
-    const double blocksNeeded = std::max(1.0, std::ceil(safeContentEnd / kPatternBlockBeats));
-    return blocksNeeded * kPatternBlockBeats;
+    const double barsNeeded = std::max(1.0, std::ceil(safeContentEnd / barBeats));
+    return barsNeeded * barBeats;
 }
 } // namespace
 
@@ -176,6 +176,10 @@ void PianoRollPanel::setPixelsPerBeat(float ppb) {
     }
 }
 
+int PianoRollPanel::beatsPerBar() const {
+    return m_trackManager ? m_trackManager->getTimelineClock().getBeatsPerBar() : 4;
+}
+
 void PianoRollPanel::setBeatsPerBar(int bpb) {
     if (m_pianoRoll) {
         m_pianoRoll->setBeatsPerBar(bpb);
@@ -246,8 +250,9 @@ void PianoRollPanel::loadPattern(PatternID patternId) {
         for (const auto& note : midiPayload.notes) {
             longestBeat = std::max(longestBeat, note.startBeat + note.durationBeats);
         }
-        const double quantizedLengthBeats = quantizePatternLengthBeats(longestBeat);
-        const double resolvedLengthBeats = std::max(8.0, std::max(pattern->lengthBeats, quantizedLengthBeats));
+        const double barBeats = static_cast<double>(beatsPerBar());
+        const double quantizedLengthBeats = quantizePatternLengthBeats(longestBeat, beatsPerBar());
+        const double resolvedLengthBeats = std::max(barBeats, std::max(pattern->lengthBeats, quantizedLengthBeats));
         if (std::abs(resolvedLengthBeats - pattern->lengthBeats) > 0.001) {
             pm.applyPatch(patternId, [resolvedLengthBeats](PatternSource& p) {
                 p.lengthBeats = resolvedLengthBeats;
@@ -372,9 +377,9 @@ void PianoRollPanel::savePattern() {
     for (const auto& note : currentNotes) {
         longestBeat = std::max(longestBeat, note.startBeat + note.durationBeats);
     }
-    // Keep patterns musical in 4-bar blocks and let note content drive the
+    // Keep patterns musical in whole bars and let note content drive the
     // default loop size on add/delete.
-    const double newLengthBeats = quantizePatternLengthBeats(longestBeat);
+    const double newLengthBeats = quantizePatternLengthBeats(longestBeat, beatsPerBar());
     m_patternDurationBeats = newLengthBeats;
     m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);
     m_pianoRoll->setTotalDurationBeats(m_patternDurationBeats);
@@ -404,9 +409,10 @@ void PianoRollPanel::adjustPatternLengthBars(int barsDelta) {
         contentEndBeat = std::max(contentEndBeat, note.startBeat + note.durationBeats);
     }
 
-    const double minLengthBeats = quantizePatternLengthBeats(contentEndBeat);
-    const double requestedLengthBeats = m_patternDurationBeats + (static_cast<double>(barsDelta) * 4.0);
-    const double newLengthBeats = std::max(8.0, std::max(minLengthBeats, requestedLengthBeats));
+    const double barBeats = static_cast<double>(beatsPerBar());
+    const double minLengthBeats = quantizePatternLengthBeats(contentEndBeat, beatsPerBar());
+    const double requestedLengthBeats = m_patternDurationBeats + (static_cast<double>(barsDelta) * barBeats);
+    const double newLengthBeats = std::max(barBeats, std::max(minLengthBeats, requestedLengthBeats));
 
     if (std::abs(newLengthBeats - m_patternDurationBeats) <= 0.001) {
         m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -87,6 +87,25 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
         loadPattern(patternId);
     });
 
+    m_pianoRoll->setOnUnitChoiceSelected([this](int unitValue) {
+        if (unitValue <= 0 || !m_trackManager) {
+            return;
+        }
+        const UnitID unitId = static_cast<UnitID>(unitValue);
+        if (unitId == m_editingUnitId) {
+            return;
+        }
+        if (!m_trackManager->getUnitManager().getUnit(unitId)) {
+            return;
+        }
+        setEditingUnit(unitId);
+        // Let the rest of the app follow the switch (Arsenal selection, hardware
+        // MIDI + musical-typing target) via the same choke point Arsenal uses.
+        if (m_onEditingUnitChanged) {
+            m_onEditingUnitChanged(unitId);
+        }
+    });
+
     // Setup playback state check and note preview
     m_pianoRoll->setIsPlayingCallback([this]() {
         return m_trackManager && m_trackManager->isPlaying();
@@ -400,12 +419,41 @@ void PianoRollPanel::setEditingUnit(UnitID unitId) {
     if (m_pianoRoll) {
         m_pianoRoll->setDefaultUnitId(unitId);
     }
+    // Keep the toolbar's unit + pattern switchers reflecting the active unit.
+    rebuildUnitSwitcher();
+    rebuildPatternSwitcher();
+}
+
+void PianoRollPanel::rebuildUnitSwitcher() {
+    if (!m_trackManager || !m_pianoRoll) {
+        return;
+    }
+
+    std::vector<AestraUI::PianoRollToolbar::PatternChoice> choices;
+    const auto unitIds = m_trackManager->getUnitManager().getAllUnitIDs();
+    choices.reserve(unitIds.size());
+    for (const auto unitId : unitIds) {
+        if (unitId == 0 || unitId > static_cast<UnitID>(std::numeric_limits<int>::max())) {
+            continue;
+        }
+        const auto* unit = m_trackManager->getUnitManager().getUnit(unitId);
+        std::string label = (unit && !unit->name.empty()) ? unit->name
+                                                          : ("Unit " + std::to_string(unitId));
+        choices.push_back({static_cast<int>(unitId), std::move(label)});
+    }
+
+    const int selectedValue = (m_editingUnitId != 0 &&
+                               m_editingUnitId <= static_cast<UnitID>(std::numeric_limits<int>::max()))
+                                  ? static_cast<int>(m_editingUnitId)
+                                  : -1;
+    m_pianoRoll->setUnitChoices(choices, selectedValue);
 }
 
 void PianoRollPanel::onUpdate(double deltaTime) {
     WindowPanel::onUpdate(deltaTime);
     if (isVisible() && !m_wasVisible) {
         rebuildPatternSwitcher();
+        rebuildUnitSwitcher();
     }
     m_wasVisible = isVisible();
     if (isVisible()) {
@@ -433,8 +481,15 @@ void PianoRollPanel::onUpdate(double deltaTime) {
             }
 
             m_pianoRoll->setPlayheadBeat(playheadBeat, follow);
-            m_pianoRoll->repaint();
-
+            // Only force a redraw when the playhead is actually moving. Editing
+            // gestures (placing/dragging notes, hover) trigger their own
+            // repaints, so an unconditional per-frame repaint just pins a core
+            // at 100% while the panel sits idle. This was the Piano Roll heat.
+            const bool playheadMoved = std::abs(playheadBeat - m_lastPlayheadBeat) > 1e-6;
+            if (follow || playheadMoved) {
+                m_pianoRoll->repaint();
+            }
+            m_lastPlayheadBeat = playheadBeat;
         }
     }
 }

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -63,6 +63,11 @@ public:
      */
     void setOnPatternEdited(std::function<void(PatternID)> callback) { m_onPatternEdited = std::move(callback); }
     /**
+     * @brief Set the callback fired when the editing unit is switched from the
+     *        Piano Roll's own unit dropdown (so the rest of the app can follow).
+     */
+    void setOnEditingUnitChanged(std::function<void(UnitID)> callback) { m_onEditingUnitChanged = std::move(callback); }
+    /**
      * @brief Get the currently loaded pattern.
      * @return Active pattern identifier.
      */
@@ -89,6 +94,7 @@ public:
 private:
     void adjustPatternLengthBars(int barsDelta);
     void rebuildPatternSwitcher();
+    void rebuildUnitSwitcher();
     void updateGhostChannels();
     void rebuildTimelineMinimap();
     void layoutTimelineMinimap();
@@ -102,12 +108,14 @@ private:
     PatternID m_currentPatternId;
     UnitID m_editingUnitId{0};
     std::function<void(PatternID)> m_onPatternEdited;
+    std::function<void(UnitID)> m_onEditingUnitChanged;
     double m_patternDurationBeats{8.0};
 
     // Undo/redo support
     std::vector<MidiNote> m_notesBeforeEdit; // Captured state before user edits
     bool m_applyingUndoRedo{false};           // Guard flag to prevent re-entry
     bool m_wasVisible{false};
+    double m_lastPlayheadBeat{-1.0}; // Gates idle repaint; only redraw when the playhead actually moves
 };
 
 } // namespace Audio

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -107,6 +107,7 @@ private:
     AestraUI::TimelineSummarySnapshot m_timelineSummarySnapshot;
     PatternID m_currentPatternId;
     UnitID m_editingUnitId{0};
+    int beatsPerBar() const; // Time-signature numerator from the timeline clock
     std::function<void(PatternID)> m_onPatternEdited;
     std::function<void(UnitID)> m_onEditingUnitChanged;
     double m_patternDurationBeats{8.0};

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -113,7 +113,11 @@ private:
 
     // Undo/redo support
     std::vector<MidiNote> m_notesBeforeEdit; // Captured state before user edits
+    // Current pattern's notes owned by other units: hidden from editing,
+    // rendered as unit-colored ghosts, merged back verbatim on save.
+    std::vector<MidiNote> m_otherUnitNotes;
     bool m_applyingUndoRedo{false};           // Guard flag to prevent re-entry
+    bool m_switchingUnit{false};              // Guards setEditingUnit against save-echo recursion
     bool m_wasVisible{false};
     double m_lastPlayheadBeat{-1.0}; // Gates idle repaint; only redraw when the playhead actually moves
 };

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -31,12 +31,26 @@ constexpr float kSampleEditorPitchRowH = 64.0f;
 constexpr float kSampleEditorADSRH = 140.0f;
 constexpr float kSampleEditorButtonRowH = 36.0f;
 constexpr float kSampleEditorWaveformMinH = 120.0f;
-constexpr float kADSRHandleHitRadius = 8.0f;
+constexpr float kADSRHandleHitRadius = 11.0f; // Generous grab area — handles were hard to pick up
 constexpr float kTwoPi = 6.28318530718f;
 
 float remapClamped(float value, float inMin, float inMax, float outMin, float outMax) {
     const float t = std::clamp((value - inMin) / std::max(0.001f, inMax - inMin), 0.0f, 1.0f);
     return outMin + t * (outMax - outMin);
+}
+
+// Perceptual (logarithmic) time mapping for the envelope handles. The linear
+// mapping put ~13ms of attack on every pixel, so the tiniest drag jumped to
+// hundreds of ms and made short one-shot samples inaudible ("ADSR = silence").
+// Log spacing gives the musically useful 1-100ms range most of the travel.
+float adsrTimeToNorm(float seconds, float minSeconds, float maxSeconds) {
+    seconds = std::clamp(seconds, minSeconds, maxSeconds);
+    return std::log(seconds / minSeconds) / std::log(maxSeconds / minSeconds);
+}
+
+float adsrNormToTime(float norm, float minSeconds, float maxSeconds) {
+    norm = std::clamp(norm, 0.0f, 1.0f);
+    return minSeconds * std::pow(maxSeconds / minSeconds, norm);
 }
 
 struct ADSRGeometry {
@@ -65,9 +79,9 @@ ADSRGeometry calculateADSRGeometry(const NUIRect& b, float attack, float decay, 
     const float leftEdge = g.baseX + kADSRHandleHitRadius;
     const float rightEdge = g.baseX + g.graphW - kADSRHandleHitRadius;
     const float handleRange = std::max(1.0f, rightEdge - leftEdge);
-    const float attackNorm = std::clamp((attack - kADSRMinAttack) / (kADSRMaxAttack - kADSRMinAttack), 0.0f, 1.0f);
-    const float decayNorm = std::clamp((decay - kADSRMinDecay) / (kADSRMaxDecay - kADSRMinDecay), 0.0f, 1.0f);
-    const float releaseNorm = std::clamp((release - kADSRMinRelease) / (kADSRMaxRelease - kADSRMinRelease), 0.0f, 1.0f);
+    const float attackNorm = adsrTimeToNorm(attack, kADSRMinAttack, kADSRMaxAttack);
+    const float decayNorm = adsrTimeToNorm(decay, kADSRMinDecay, kADSRMaxDecay);
+    const float releaseNorm = adsrTimeToNorm(release, kADSRMinRelease, kADSRMaxRelease);
     const float attackX = leftEdge + handleRange * attackNorm * 0.35f;
     const float decayXAbs = std::clamp(attackX + handleRange * decayNorm * 0.32f, leftEdge, rightEdge);
     const float releaseXAbs = std::clamp(rightEdge - handleRange * releaseNorm * 0.42f, leftEdge, rightEdge);
@@ -320,13 +334,15 @@ bool ADSRDisplayComponent::onMouseEvent(const NUIMouseEvent& event) {
             case Handle::Attack:
             {
                 const float x = std::clamp(startG.attack.x + dx, leftEdge, rightEdge);
-                m_attack = remapClamped(x, leftEdge, leftEdge + handleRange * 0.35f, kADSRMinAttack, kADSRMaxAttack);
+                const float norm = (x - leftEdge) / (handleRange * 0.35f);
+                m_attack = adsrNormToTime(norm, kADSRMinAttack, kADSRMaxAttack);
                 break;
             }
             case Handle::Decay:
             {
                 const float x = std::clamp(startG.decay.x + dx, leftEdge, rightEdge);
-                m_decay = remapClamped(x, startG.attack.x, startG.attack.x + handleRange * 0.32f, kADSRMinDecay, kADSRMaxDecay);
+                const float norm = (x - startG.attack.x) / (handleRange * 0.32f);
+                m_decay = adsrNormToTime(norm, kADSRMinDecay, kADSRMaxDecay);
                 break;
             }
             case Handle::Sustain:
@@ -335,7 +351,8 @@ bool ADSRDisplayComponent::onMouseEvent(const NUIMouseEvent& event) {
             case Handle::Release:
             {
                 const float x = std::clamp(startG.releaseStart.x + dx, leftEdge, rightEdge);
-                m_release = remapClamped(rightEdge - x, 0.0f, handleRange * 0.42f, kADSRMinRelease, kADSRMaxRelease);
+                const float norm = (rightEdge - x) / (handleRange * 0.42f);
+                m_release = adsrNormToTime(norm, kADSRMinRelease, kADSRMaxRelease);
                 break;
             }
             case Handle::None:

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -609,6 +609,14 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
 
 // ... (Previous code)
 
+void TransportBar::setRightReservedWidth(float width) {
+    if (m_rightReservedWidth == width) {
+        return;
+    }
+    m_rightReservedWidth = width;
+    layoutComponents();
+}
+
 void TransportBar::layoutComponents() {
     AestraUI::NUIRect bounds = getBounds();
 
@@ -726,7 +734,7 @@ void TransportBar::layoutComponents() {
         constexpr float statusWidth = 82.0f;
         constexpr float statusHeight = 24.0f;
         const float statusX = islandX + islandWidth + 10.0f;
-        const bool hasRoom = statusX + statusWidth <= bounds.width - 8.0f;
+        const bool hasRoom = statusX + statusWidth <= bounds.width - 8.0f - m_rightReservedWidth;
         m_musicalTypingLabel->setVisible(hasRoom);
         if (hasRoom) {
             m_musicalTypingLabel->setBounds(NUIAbsolute(

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -66,7 +66,17 @@ TransportBar::TransportBar()
             }
         });
     }
-    
+
+    // Forward time-signature clicks to the app (this link was missing: the
+    // display cycled 2/4..7/8 but nothing outside the transport ever heard).
+    if (m_infoContainer && m_infoContainer->getTimeSignatureDisplay()) {
+        m_infoContainer->getTimeSignatureDisplay()->setOnTimeSignatureChange([this](int beatsPerBar) {
+            if (m_onTimeSignatureChange) {
+                m_onTimeSignatureChange(beatsPerBar);
+            }
+        });
+    }
+
     updateButtonStates();
 }
 

--- a/Source/Panels/TransportBar.h
+++ b/Source/Panels/TransportBar.h
@@ -99,6 +99,11 @@ public:
     void onResize(int width, int height) override;
     bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
 
+    /** Width at the bar's right edge occupied by overlay siblings (the
+        master meter / waveform visualizers laid out by AestraContent).
+        The KEYS status pill hides instead of rendering underneath them. */
+    void setRightReservedWidth(float width);
+
 private:
     // UI Components
     std::shared_ptr<AestraUI::NUIButton> m_playButton;
@@ -166,6 +171,7 @@ private:
     TransportState m_state;
     float m_tempo;
     double m_position;
+    float m_rightReservedWidth = 0.0f;
 
     // View Toggles state
     bool m_mixerActive{false};


### PR DESCRIPTION
## Codename: **The Understudy** 🎭

Quietly learning the lead's part. No press release, no fruit baskets — just an Arsenal that finally feels like an instrument. (Nothing to see here, certain sequencers.)

This started as five music-making complaints and grew into a full pass over the Arsenal step sequencer, the pattern playback clock, and the sampler. Everything below is drive-validated in the real app.

### Music-making UX (original 5 + follow-ons)
- Loading a sample no longer force-opens the sampler editor
- Piano Roll no longer pins a CPU core while idle (repaint gated on playhead movement)
- Placed Arsenal steps are audible on playback (was an aggregate-init bug dropping `unitId`)
- Unit switching from the Piano Roll actually works and is visible — editing unit's notes are foreground, other units render as colored ghosts, merged back on save
- Notes light up as the playhead crosses them
- Toolbar cleanup; the never-wired Pattern/Unit/Snap dropdowns now receive events

### Smart Arsenal grid
- Grid spans the full loop; one shared horizontal scroll keeps the header + every row in lockstep, with a scroll indicator and bar-aware playhead auto-follow
- Rows are clipped/contained to the panel viewport in restored mode (no more spill over the timeline); vertical scroll reaches every unit

### Sample-accurate loop timing
- Pattern scheduling runs in a monotonic frame domain so the next iteration's downbeat is queued **before** the wrap — kills the per-bar timing jitter
- Loop-length changes flush + re-queue in the new domain — fixes "silence after a note placed mid-play loops once"

### Time signature (was cosmetic)
- The transport signature widget now actually drives the app via the timeline clock: metronome accent, Arsenal bar grouping + bars control, pattern-length quantization, piano-roll bar lines
- Pattern minimum is now **1 bar of the current signature** (was hard-floored at 2 bars of 4/4)

### Sampler correctness
- Fresh samplers no longer play a semitone-encoded default (every new unit was −12 st / half speed)
- Arsenal steps use the unit's root note (was hardcoded −24 st for pitched samplers)
- ADSR envelope handles are log-scaled (linear made short one-shots inaudible) + bigger grab radius

### Metronome
- Loop wrap keeps the ringing click tail and no longer double-fires the boundary beat

### FL-style step feel
- Left-click = one silent toggle (hot swap), right-click deletes the note, no accidental drag-draw, no placement preview
- Grid hit-testing uses the drawn pad geometry (was skewing toward the right edge → wrong-pad clicks)

---

**Next:** feature-parity run against the FL channel rack — per-step velocity graph lane, swing, a fit/zoom toggle for long loops, stronger beat grouping. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.

- Fixed sample loading/arming flow: loading a unit’s sample no longer auto-opens the sampler editor; editor opens only via explicit user actions (with double-click constrained to empty units). Added async-failure toast feedback when sample loading fails.
- Corrected Arsenal step identity + pitch mapping: steps now preserve unit IDs and use each unit’s root MIDI note for playback, with playhead-driven step highlighting/accents aligned to pattern timing.
- Upgraded Piano Roll editing UX: added Unit + Snap switching to the toolbar (with robust dropdown syncing and guarded repainting), improved ghost-note rendering to use per-ghost alpha, and reduced repainting to only when the playhead actually advances.
- Overhauled Arsenal step interaction: left-click toggles notes using unit-aware beat windows, right-click deletes in-place when possible, and sampler editing now uses a dedicated velocity-drag session (with updated hit-testing and viewport-contained interaction).
- Made pattern scheduling sample-accurate: pattern-mode playback now uses a monotonic frame domain with loop-length aware refill scheduling; loop-length/BPM/sample-rate changes flush/realign queues so timing stays consistent.
- Fixed metronome + loop-wrap edge cases: time-signature changes now propagate to metronome accenting and bar/grid logic; loop wrapping resets metronome state to avoid duplicate boundary clicks while preserving click “tails” when appropriate.
- Improved time-signature-aware layout + synchronization: Arsenal and Piano Roll bar/step geometry, quantization, scrolling, and playhead following now honor `beatsPerBar`, including synchronized Arsenal grid scrolling with viewport-clipped hit-testing and a functional Fit/Scroll toolbar toggle.
- Additional polish across UI/audio: sampler pitch parameter encoding/display corrected (normalized pitch now shown as coarse semitones), ADSR envelope editing switched to perceptual/log time mapping, transport overlay sizing adjusted to prevent pill overlap, and file browser empty/loading hints upgraded (wrapped, clipped, state-preserving).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->