### PR TITLE
UI pass: mixer, minimization/responsive chrome, alignment fixes

### DIFF
--- a/AestraUI/Base/NUICustomTitleBar.cpp
+++ b/AestraUI/Base/NUICustomTitleBar.cpp
@@ -155,31 +155,48 @@ void NUICustomTitleBar::onRender(NUIRenderer& renderer) {
                         badgeW,
                         badgeH);
     const float statusX = badge.x - statusSize.width - 14.0f;
-    const float sharedBaselineY = std::round(renderer.calculateTextY({statusX, badgeY, statusSize.width, badgeH}, userFont));
-    renderer.drawText(status,
-                      {statusX, sharedBaselineY},
-                      userFont, muted);
 
-    const float badgeRadius = props.radiusM; // 8.0
-    const NUIColor badgeFill = membershipVerified_
-        ? accent.withAlpha(0.10f)
-        : accent.withAlpha(0.04f);
-    const NUIColor badgeStroke = membershipVerified_
-        ? accent.withAlpha(0.50f)
-        : accent.withAlpha(0.24f);
-    renderer.fillRoundedRect(badge, badgeRadius, badgeFill);
-    renderer.strokeRoundedRect(badge, badgeRadius, 1.0f, badgeStroke);
+    // Progressive collapse for narrow windows. The view toggle is centred on the
+    // whole title bar (AestraContent positions it), so on a small window it would
+    // collide with this right-hand status/badge cluster. Rather than let them
+    // overlap the tabs, hide the least-critical chrome first — the "Signed out"
+    // status text, then the Core badge — keeping the view tabs uncrowded. Primary
+    // controls never hide. Compare against the toggle's centred right edge.
+    const float toggleRightEdge = bounds.x + bounds.width * 0.5f
+                                  + props.layout.viewToggleWidth * 0.5f;
+    constexpr float kClusterGuard = 16.0f;
+    const bool showBadge = badge.x > toggleRightEdge + kClusterGuard;
+    const bool showStatus = showBadge && statusX > toggleRightEdge + kClusterGuard;
 
-    if (membershipVerified_) {
-        // Subtle status dot on the leading edge of the badge to reinforce verified state.
-        const float dotRadius = 3.0f;
-        const NUIPoint dotCenter(badge.x + 10.0f, badge.y + badge.height * 0.5f);
-        renderer.fillCircle(dotCenter, dotRadius, verifiedAccent.withAlpha(0.92f));
-        renderer.fillCircle(dotCenter, dotRadius * 0.45f, NUIColor::white().withAlpha(0.55f));
+    if (showStatus) {
+        const float sharedBaselineY = std::round(renderer.calculateTextY({statusX, badgeY, statusSize.width, badgeH}, userFont));
+        renderer.drawText(status,
+                          {statusX, sharedBaselineY},
+                          userFont, muted);
     }
 
-    renderer.drawTextCentered(membershipTier_, badge, props.fontSizeS - 2.0f, text.withAlpha(membershipVerified_ ? 0.92f : 0.78f));
-    
+    if (showBadge) {
+        const float badgeRadius = props.radiusM; // 8.0
+        const NUIColor badgeFill = membershipVerified_
+            ? accent.withAlpha(0.10f)
+            : accent.withAlpha(0.04f);
+        const NUIColor badgeStroke = membershipVerified_
+            ? accent.withAlpha(0.50f)
+            : accent.withAlpha(0.24f);
+        renderer.fillRoundedRect(badge, badgeRadius, badgeFill);
+        renderer.strokeRoundedRect(badge, badgeRadius, 1.0f, badgeStroke);
+
+        if (membershipVerified_) {
+            // Subtle status dot on the leading edge of the badge to reinforce verified state.
+            const float dotRadius = 3.0f;
+            const NUIPoint dotCenter(badge.x + 10.0f, badge.y + badge.height * 0.5f);
+            renderer.fillCircle(dotCenter, dotRadius, verifiedAccent.withAlpha(0.92f));
+            renderer.fillCircle(dotCenter, dotRadius * 0.45f, NUIColor::white().withAlpha(0.55f));
+        }
+
+        renderer.drawTextCentered(membershipTier_, badge, props.fontSizeS - 2.0f, text.withAlpha(membershipVerified_ ? 0.92f : 0.78f));
+    }
+
     // Render custom children (NUIMenuBar, view toggle, etc.)
     renderChildren(renderer);
 }

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -1229,9 +1229,11 @@ void NUIRendererGL::drawText(const std::string& text, const NUIPoint& position, 
         return;
     }
 
-    // Fallback only if FreeType not initialized - simple rectangles
-    float charWidth = fontSize * 0.5f;
-    float charHeight = fontSize * 0.8f;
+    // Fallback only if FreeType not initialized - simple rectangles.
+    // Size from effectiveFontSize (not raw fontSize) so this matches the floor
+    // measureText() applies, keeping fallback measure and render consistent.
+    float charWidth = effectiveFontSize * 0.5f;
+    float charHeight = effectiveFontSize * 0.8f;
     
     for (size_t i = 0; i < text.length(); ++i) {
         char c = text[i];

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -95,15 +95,25 @@ static uint32_t decodeUTF8(const std::string& text, size_t& index) {
     return 0; // Invalid UTF-8
 }
 
-static float normalizeSmallTextSize(float requestedSize, float alpha) {
-    // Policy: tiny secondary labels should not dip below a practical readable floor.
-    if (alpha < 0.80f && requestedSize < 12.0f) {
-        return 12.0f;
-    }
-    if (alpha < 0.92f && requestedSize < 11.0f) {
-        return 11.0f;
-    }
-    return requestedSize;
+static float normalizeSmallTextSize(float requestedSize) {
+    // Readability floor for small text, applied to SIZE ONLY.
+    //
+    // This used to also key off the colour's alpha (dim text floored to 12px,
+    // bright text left at its requested size). That coupled rendered size to
+    // colour, with two consequences:
+    //   1. Two labels written at the "same" size rendered at different sizes if
+    //      one was dimmer — so adjacent label/value pairs no longer aligned and
+    //      the smaller one looked jagged (e.g. the I/O tab's Source/Auto row).
+    //   2. measureText() has no alpha and never applied the floor, so dim small
+    //      text measured narrow but rendered wide — layout (wrap/centre/fit)
+    //      disagreed with what hit the screen.
+    // A single size-based floor keeps small text legible while measure and
+    // render always agree. 11px sits between the old two-tier floor (11/12):
+    // it lifts the previously-unfloored bright small text (which looked jagged)
+    // up to a readable, crisp size, while barely nudging the dim labels that
+    // already floored to 12 — so compact one-line rows still fit.
+    constexpr float kMinReadableSize = 11.0f;
+    return std::max(requestedSize, kMinReadableSize);
 }
 
 float NUIRendererGL::getKerningUnits(FT_Face face, uint32_t previousGlyph, uint32_t currentGlyph) const {
@@ -1204,7 +1214,7 @@ void NUIRendererGL::drawShadow(const NUIRect& rect, float offsetX, float offsetY
 // ============================================================================
 
 void NUIRendererGL::drawText(const std::string& text, const NUIPoint& position, float fontSize, const NUIColor& color) {
-    const float effectiveFontSize = normalizeSmallTextSize(fontSize, color.a);
+    const float effectiveFontSize = normalizeSmallTextSize(fontSize);
     // Use FreeType atlas for ALL text - consistent rendering
     
     if (fontInitialized_) {
@@ -1948,7 +1958,7 @@ void NUIRendererGL::drawCharacter(char c, float x, float y, float width, float h
 }
 
 void NUIRendererGL::drawTextCentered(const std::string& text, const NUIRect& rect, float fontSize, const NUIColor& color) {
-    const float effectiveFontSize = normalizeSmallTextSize(fontSize, color.a);
+    const float effectiveFontSize = normalizeSmallTextSize(fontSize);
     // Measure actual text dimensions
     NUISize textSize = measureText(text, effectiveFontSize);
 
@@ -1985,7 +1995,11 @@ NUIRenderer::FontMetrics NUIRendererGL::getFontMetrics(float fontSize) const {
 NUISize NUIRendererGL::measureText(const std::string& text, float fontSize) {
     // IMPORTANT: drawText() renders via the FreeType atlas path; prefer matching metrics here
     // so layout (centering/truncation) matches what actually hits the screen.
-    
+    // Apply the SAME readability floor drawText() uses, or a small string would
+    // measure narrower than it renders and wrap/centre/fit calculations would be
+    // wrong (the size is colour-independent, so measureText can apply it too).
+    fontSize = normalizeSmallTextSize(fontSize);
+
     // Handle empty text quickly
     if (text.empty()) {
         if (fontInitialized_) {

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -241,7 +241,10 @@ void UIMixerInspector::layoutHitRects()
     }
 
     if (m_ioInputDropdown) {
-        const float dropdownY = contentY + 68.0f;
+        // Sits between the "Verify level…" caption (ends ~+53) and the
+        // Source/Mode meta row (render pass places it at +88). The old +68 sat
+        // on top of the meta row; +52 clipped the caption above — +58 clears both.
+        const float dropdownY = contentY + 58.0f;
         m_ioInputDropdown->setBounds(x + 12.0f, dropdownY, w - 24.0f, IO_DROPDOWN_H);
     }
     if (m_mainOutputDropdown) {
@@ -750,7 +753,7 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         if (isMaster) {
              renderer.drawTextCentered("Master Output is fixed to Hardware Output 1/2", contentRect, 11.0f, m_textSecondary);
         } else if (m_activeTab == Tab::IO) {
-             const NUIRect sourceCard{contentRect.x, contentRect.y, contentRect.width, 102.0f};
+             const NUIRect sourceCard{contentRect.x, contentRect.y, contentRect.width, 110.0f};
              renderer.fillRoundedRect(sourceCard, 12.0f, m_tabBg.withAlpha(0.46f));
              renderer.strokeRoundedRect(sourceCard, 12.0f, 1.0f, accent.withAlpha(0.20f));
 
@@ -762,7 +765,10 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
                                {sourceCard.x + 12.0f, sourceCard.y + 42.0f}, 9.0f,
                                m_textSecondary.withAlpha(0.76f));
 
-             const float metaY = sourceCard.y + 77.0f;
+             // Meta row sits BELOW the input dropdown (layoutHitRects places it at
+             // contentY + 58, height 22 → bottom ~80). Anchoring the labels here
+             // keeps them clear of the dropdown instead of under it.
+             const float metaY = sourceCard.y + 88.0f;
              renderer.drawText("Source", {sourceCard.x + 12.0f, metaY}, 8.5f,
                                m_textSecondary.withAlpha(0.70f));
              renderer.drawText(fitText(renderer, channel->inputSourceName, 9.5f, 72.0f),
@@ -775,7 +781,7 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
                                {sourceCard.x + 158.0f, metaY - 1.0f}, 9.5f, m_text.withAlpha(0.92f));
 
              const float signalTop = sourceCard.bottom() + 10.0f;
-             const NUIRect signalCard{contentRect.x, signalTop, contentRect.width, 74.0f};
+             const NUIRect signalCard{contentRect.x, signalTop, contentRect.width, 94.0f};
              renderer.fillRoundedRect(signalCard, 12.0f, m_tabBg.withAlpha(0.38f));
              renderer.strokeRoundedRect(signalCard, 12.0f, 1.0f, m_border.withAlpha(0.34f));
 
@@ -806,9 +812,26 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
                  renderer.fillRoundedRect({meterRect.x, meterRect.y, fillWidth, meterRect.height}, 6.0f, meterColor.withAlpha(0.95f));
              }
 
-             renderer.drawText("Flat or clipped input usually means the selected source needs attention.",
-                               {signalCard.x + 12.0f, signalCard.y + 55.0f},
-                               8.5f, m_textSecondary.withAlpha(0.72f));
+             // Short hint, word-wrapped as a safety net. (The old long copy
+             // overflowed the card into the master strip — measured width also
+             // under-reads actual render at this size, so keep it concise.)
+             {
+                 const std::string hint = "Flat or clipped? Recheck the source.";
+                 const float hintMaxW = signalCard.width - 24.0f;
+                 std::string line1 = hint, line2;
+                 while (renderer.measureText(line1, 8.5f).width > hintMaxW) {
+                     const size_t sp = line1.find_last_of(' ');
+                     if (sp == std::string::npos) break;
+                     line2 = line1.substr(sp + 1) + (line2.empty() ? "" : " " + line2);
+                     line1 = line1.substr(0, sp);
+                 }
+                 const NUIColor hintColor = m_textSecondary.withAlpha(0.72f);
+                 renderer.drawText(line1, {signalCard.x + 12.0f, signalCard.y + 54.0f}, 8.5f, hintColor);
+                 if (!line2.empty()) {
+                     renderer.drawText(fitText(renderer, line2, 8.5f, hintMaxW),
+                                       {signalCard.x + 12.0f, signalCard.y + 68.0f}, 8.5f, hintColor);
+                 }
+             }
         }
     }
 

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -768,17 +768,22 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
              // Meta row sits BELOW the input dropdown (layoutHitRects places it at
              // contentY + 58, height 22 → bottom ~80). Anchoring the labels here
              // keeps them clear of the dropdown instead of under it.
+             // Label and value share one size and baseline so they align. The
+             // value's prominence comes from a brighter colour, not a larger
+             // size — previously it was 9.5px vs the label's 8.5px (which the
+             // renderer floored differently by alpha), so they mismatched.
              const float metaY = sourceCard.y + 88.0f;
-             renderer.drawText("Source", {sourceCard.x + 12.0f, metaY}, 8.5f,
+             constexpr float kMetaSize = 10.0f;
+             renderer.drawText("Source", {sourceCard.x + 12.0f, metaY}, kMetaSize,
                                m_textSecondary.withAlpha(0.70f));
-             renderer.drawText(fitText(renderer, channel->inputSourceName, 9.5f, 72.0f),
-                               {sourceCard.x + 58.0f, metaY - 1.0f}, 9.5f, m_text.withAlpha(0.92f));
+             renderer.drawText(fitText(renderer, channel->inputSourceName, kMetaSize, 60.0f),
+                               {sourceCard.x + 58.0f, metaY}, kMetaSize, m_text.withAlpha(0.92f));
 
              const std::string monitorMode = channel->monitored ? "Arm + Monitor" : "Arm Only";
-             renderer.drawText("Mode", {sourceCard.x + 122.0f, metaY}, 8.5f,
+             renderer.drawText("Mode", {sourceCard.x + 122.0f, metaY}, kMetaSize,
                                m_textSecondary.withAlpha(0.70f));
-             renderer.drawText(fitText(renderer, monitorMode, 9.5f, sourceCard.right() - sourceCard.x - 166.0f),
-                               {sourceCard.x + 158.0f, metaY - 1.0f}, 9.5f, m_text.withAlpha(0.92f));
+             renderer.drawText(fitText(renderer, monitorMode, kMetaSize, sourceCard.right() - sourceCard.x - 160.0f),
+                               {sourceCard.x + 158.0f, metaY}, kMetaSize, m_text.withAlpha(0.92f));
 
              const float signalTop = sourceCard.bottom() + 10.0f;
              const NUIRect signalCard{contentRect.x, signalTop, contentRect.width, 94.0f};

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -502,14 +502,13 @@ void UIMixerStrip::layoutChildren()
         m_footer->setBounds(contentX, footerY, contentW, FOOTER_H);
     }
 
-    const float contentY = y;
-    const float contentH = std::max(1.0f, footerY - y);
-
     const float meterW = (m_channelId == 0) ? MASTER_METER_W : METER_W;
 
-    const float availableH = std::max(1.0f, contentH - PAD);
-    const float meterH = availableH * 0.62f;
-    const float meterY = footerY - GAP - meterH;
+    // Meter + fader fill the strip between the channel controls and the footer.
+    // (Previously sized to 62% of the free height and bottom-anchored, which
+    // left a large dead gap above the fader — the tallest, most-used control.)
+    const float meterY = y;
+    const float meterH = std::max(16.0f, (footerY - GAP) - y);
     const float meterX = contentX + 2.0f;
 
     if (m_meter) {

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -1020,7 +1020,8 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     auto drawSection = [&](const std::string& label) {
         if (compact) {
             y += 5.0f;
-            renderer.drawLine({layout.navPane.x + 15.0f, y}, {layout.navPane.right() - 15.0f, y}, 1.0f,
+            // Small inset so the rule spans the narrow rail instead of a centre stub.
+            renderer.drawLine({layout.navPane.x + 8.0f, y}, {layout.navPane.right() - 8.0f, y}, 1.0f,
                               divider.withAlpha(0.38f));
             y += 6.0f;
             return;
@@ -1061,7 +1062,9 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
 
         switch (action) {
             case BrowserNavAction::Favorites:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.8l2.25 4.55 5.03.73-3.64 3.55.86 5.01L12 15.28l-4.5 2.36.86-5.01L4.72 9.08l5.03-.73L12 3.8z"/></svg>)");
+                // Filled star: a thin stroked outline aliased badly at 16px (sharp
+                // points), looking rough next to the crisp filled colour dots.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 3.5l2.7 5.47 6.05.88-4.38 4.27 1.03 6.02L12 17.28l-5.4 2.84 1.03-6.02L3.25 9.85l6.05-.88L12 3.5z"/></svg>)");
                 break;
             case BrowserNavAction::Purple:
                 renderer.fillRoundedRect({cx - 4.0f, cy - 4.0f, 8.0f, 8.0f}, 4.0f,
@@ -1153,8 +1156,10 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
 
     auto drawDivider = [&]() {
         y += compact ? 3.0f : 5.0f;
-        renderer.drawLine({layout.navPane.x + 14.0f, y},
-                          {layout.navPane.right() - 14.0f, y},
+        // Narrow rail: smaller inset so the rule reads as a divider, not a stub.
+        const float divInset = compact ? 8.0f : 14.0f;
+        renderer.drawLine({layout.navPane.x + divInset, y},
+                          {layout.navPane.right() - divInset, y},
                           1.0f, divider.withAlpha(0.45f));
         y += compact ? 4.0f : 8.0f;
     };

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -963,7 +963,7 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
     const NUIRect navHeader(layout.navPane.x, layout.navPane.y, layout.navPane.width, navHeaderH);
     renderer.fillRect(navHeader, themeManager.getColor("backgroundSecondary").darkened(0.03f));
     renderer.drawLine({navHeader.x, navHeader.bottom()}, {navHeader.right(), navHeader.bottom()},
-                      1.0f, themeManager.getColor("border").withAlpha(0.40f));
+                      1.0f, themeManager.getColor("border")); // matches list header bottom rule → continuous line
 
     // Folder name at top (like breadcrumb on the right)
     const auto& themeProps = themeManager.getCurrentTheme();
@@ -990,14 +990,17 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
                           9.0f, themeManager.getColor("textSecondary").withAlpha(0.58f));
     }
 
-    // Inner divider (like right header)
-    renderer.drawLine({navHeader.x, navHeader.y + 27.0f},
-                      {navHeader.right(), navHeader.y + 27.0f},
+    // Inner divider — aligned with the list header's inner rule (listHeader.y + 29)
+    // so the two form one continuous line across the browser.
+    renderer.drawLine({navHeader.x, navHeader.y + 29.0f},
+                      {navHeader.right(), navHeader.y + 29.0f},
                       1.0f, themeManager.getColor("border").withAlpha(0.65f));
 
     // Scrollable content region below the fixed folder-name header. Short
-    // windows keep the tail rows reachable without moving the header.
-    const float navContentTop = layout.navPane.y + 28.0f;
+    // windows keep the tail rows reachable without moving the header. Start at the
+    // full header height so the first nav row lines up with the first file row (the
+    // list header is BROWSER_LIST_HEADER_H tall).
+    const float navContentTop = layout.navPane.y + BROWSER_LIST_HEADER_H;
     navViewportHeight_ = std::max(0.0f, layout.navPane.bottom() - navContentTop);
     const float navMaxScroll = std::max(0.0f, navContentHeight_ - navViewportHeight_);
     navScrollOffset_ = std::clamp(navScrollOffset_, 0.0f, navMaxScroll);
@@ -1019,11 +1022,10 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
 
     auto drawSection = [&](const std::string& label) {
         if (compact) {
-            y += 5.0f;
-            // Small inset so the rule spans the narrow rail instead of a centre stub.
-            renderer.drawLine({layout.navPane.x + 8.0f, y}, {layout.navPane.right() - 8.0f, y}, 1.0f,
-                              divider.withAlpha(0.38f));
-            y += 6.0f;
+            // No rule for label-less compact sections. The explicit drawDivider()
+            // between groups already separates them; a section rule here doubled the
+            // divider at group boundaries and drew a lone line that isolated the
+            // first icon (the star) from the header.
             return;
         }
         std::string upper = label;
@@ -3766,8 +3768,9 @@ bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const B
     if (event.cursorCaptured) return false;
 
     // Ignore the fixed folder-name header band: rows scrolled up under it are
-    // visually clipped, so they must not be clickable there either.
-    const float navContentTop = layout.navPane.y + 28.0f;
+    // visually clipped, so they must not be clickable there either. Must match the
+    // render-side navContentTop (full header height).
+    const float navContentTop = layout.navPane.y + BROWSER_LIST_HEADER_H;
     const bool insideNav = layout.navPane.contains(event.position) && event.position.y >= navContentTop;
     int newHovered = -1;
     if (insideNav) {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1639,20 +1639,34 @@ void AestraContent::onResize(int width, int height) {
         if (m_waveformVisualizer)
             totalWidth += waveformWidth + gap;
 
-        float xStart = width - totalWidth - layout.panelMargin;
-        if (m_transportBar) {
-            // The visualizers overlay the transport row; tell the bar so its
-            // KEYS status pill hides instead of rendering underneath them.
-            m_transportBar->setRightReservedWidth(totalWidth + layout.panelMargin + gap);
-        }
-        if (m_waveformVisualizer) {
-            m_waveformVisualizer->setBounds(
-                AestraUI::NUIAbsolute(contentBounds, xStart, vuY, waveformWidth, visualizerHeight));
-            xStart += waveformWidth + gap;
-        }
-        if (m_audioVisualizer) {
-            m_audioVisualizer->setBounds(
-                AestraUI::NUIAbsolute(contentBounds, xStart, vuY, meterWidth, visualizerHeight));
+        // The scope + meter overlay the right of the transport row. They only clear
+        // the centre-anchored transport island near full width; on a narrow window
+        // they'd sit on top of the view buttons. Treat them as secondary chrome:
+        // hide them below that width and drop the reserve so the transport island
+        // reclaims the whole row. (The threshold leaves room for the full island.)
+        constexpr float kVisualizerMinWidth = 1230.0f;
+        const bool showVisualizers = width >= kVisualizerMinWidth;
+        if (m_waveformVisualizer) m_waveformVisualizer->setVisible(showVisualizers);
+        if (m_audioVisualizer) m_audioVisualizer->setVisible(showVisualizers);
+
+        if (!showVisualizers) {
+            if (m_transportBar) m_transportBar->setRightReservedWidth(0.0f);
+        } else {
+            float xStart = width - totalWidth - layout.panelMargin;
+            if (m_transportBar) {
+                // Visualizers overlay the transport row; reserve their width so the
+                // bar's KEYS status pill hides instead of rendering underneath them.
+                m_transportBar->setRightReservedWidth(totalWidth + layout.panelMargin + gap);
+            }
+            if (m_waveformVisualizer) {
+                m_waveformVisualizer->setBounds(
+                    AestraUI::NUIAbsolute(contentBounds, xStart, vuY, waveformWidth, visualizerHeight));
+                xStart += waveformWidth + gap;
+            }
+            if (m_audioVisualizer) {
+                m_audioVisualizer->setBounds(
+                    AestraUI::NUIAbsolute(contentBounds, xStart, vuY, meterWidth, visualizerHeight));
+            }
         }
     }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3999,6 +3999,26 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
     if (m_takesPanel && m_takesPanel->isVisible() && m_takesPanel->handleKeyEvent(event))
         return true;
 
+    // Global view-toggle shortcuts (the transport view buttons advertise these
+    // in their tooltips). F-keys never reach text inputs or musical typing, so
+    // handle them here as unconditional global shortcuts.
+    switch (event.keyCode) {
+    case AestraUI::NUIKeyCode::F3:
+        toggleView(Audio::ViewType::Mixer);
+        return true;
+    case AestraUI::NUIKeyCode::F5:
+        toggleView(Audio::ViewType::Playlist);
+        return true;
+    case AestraUI::NUIKeyCode::F6:
+        toggleView(Audio::ViewType::Sequencer); // Channel Rack (Arsenal)
+        return true;
+    case AestraUI::NUIKeyCode::F7:
+        toggleView(Audio::ViewType::PianoRoll);
+        return true;
+    default:
+        break;
+    }
+
     // Forward to piano roll when visible — its local undo/redo
     // and note shortcuts must take priority over global handlers
     if (m_pianoRollPanel && m_pianoRollPanel->isVisible()) {

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -11,6 +11,8 @@
 #include <iomanip>
 #include <cmath>
 #include <chrono>
+#include <vector>
+#include <utility>
 
 namespace Aestra {
 
@@ -21,6 +23,35 @@ constexpr float TRANSPORT_BUTTON_SPACING = 8.0f;
 constexpr float TRANSPORT_GROUP_SPACING = 24.0f;
 constexpr float TRANSPORT_ISLAND_PADDING = 12.0f;
 constexpr float TRANSPORT_ISLAND_HEIGHT = 48.0f;
+constexpr float TRANSPORT_INFO_WIDTH = 260.0f;
+
+// Progressive collapse for narrow windows. The transport island packs four fixed
+// groups (transport / extras / info / views). When the window can't hold them all
+// it used to place them at full width anyway and clip the rightmost group off the
+// edge. Instead, hide the secondary groups — the record-aid extras first
+// (count-in / wait / loop-record / metronome), then the view switches — keeping
+// the transport buttons and tempo/time readout always visible. The transport
+// buttons and info readout never hide.
+struct TransportLayoutTier {
+    bool showExtras = true;   // count-in / wait / loop-record / metronome
+    bool showViews = true;    // mixer / sequencer / piano-roll / playlist
+};
+
+inline TransportLayoutTier transportTierFor(float availWidth) {
+    const float bs = TRANSPORT_BUTTON_SIZE;
+    const float sp = TRANSPORT_BUTTON_SPACING;
+    const float gs = TRANSPORT_GROUP_SPACING;
+    const float pad = TRANSPORT_ISLAND_PADDING;
+    const float g1 = bs * 3.0f + sp * 2.0f;         // transport (3 buttons)
+    const float g = bs * 4.0f + sp * 3.0f;          // extras / views (4 buttons each)
+    const float info = TRANSPORT_INFO_WIDTH;
+    const float margin = 20.0f;                     // mirrors the island width clamp
+    const float full    = (g1 + gs + g + gs + info + gs + g) + pad * 2.0f;
+    const float noExtras = (g1 + gs + info + gs + g) + pad * 2.0f;
+    if (availWidth >= full + margin)    return {true, true};
+    if (availWidth >= noExtras + margin) return {false, true};
+    return {false, false};
+}
 
 } // namespace
 
@@ -505,7 +536,7 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
                                  bool isActive,
                                  bool isRecording = false,
                                  bool isPrimaryTransport = false) {
-        if (!btn || !icon) return;
+        if (!btn || !icon || !btn->isVisible()) return; // collapsed groups draw nothing
 
         AestraUI::NUIRect buttonRect = btn->getBounds(); // Use bounds set in layoutComponents
         bool isHovered = btn->isHovered() && btn->isEnabled();
@@ -650,9 +681,14 @@ void TransportBar::layoutComponents() {
     // Group 4: Views (Mixer, Seq, Piano, Playlist) - 4 buttons
     float group4Width = (buttonSize * 4) + (spacing * 3);
 
-    // Total Content Width
-    float totalContentWidth =
-        group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
+    // Which secondary groups fit? (hide extras first, then views — see helper)
+    const TransportLayoutTier tier = transportTierFor(bounds.width);
+
+    // Total Content Width — only count the groups we'll actually place. Order is
+    // transport, (extras), info, (views), with one gap between adjacent groups.
+    float totalContentWidth = group1Width + groupSpacing + infoWidth
+        + (tier.showExtras ? group2Width + groupSpacing : 0.0f)
+        + (tier.showViews ? groupSpacing + group4Width : 0.0f);
     float islandPadding = TRANSPORT_ISLAND_PADDING;
     float islandWidth = totalContentWidth + (islandPadding * 2.0f);
     
@@ -693,42 +729,44 @@ void TransportBar::layoutComponents() {
     placePrimaryButton(m_recordButton, xCursor);
     xCursor += buttonSize + groupSpacing; // GAP
 
-    // Group 2: Extras
-    m_countInButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-    xCursor += buttonSize + spacing;
-    
-    m_waitButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-    xCursor += buttonSize + spacing;
-    
-    m_loopRecordButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-    xCursor += buttonSize + spacing;
-    
-    m_metronomeButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-    xCursor += buttonSize + groupSpacing; // GAP to Info
+    // Group 2: Extras — hidden on narrow windows (see tier). Toggle visibility so
+    // the buttons neither render nor take clicks when collapsed.
+    const auto placeExtra = [&](const std::shared_ptr<AestraUI::NUIButton>& button) {
+        if (!button) return;
+        button->setVisible(tier.showExtras);
+        if (tier.showExtras) {
+            button->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
+            xCursor += buttonSize + spacing;
+        }
+    };
+    placeExtra(m_countInButton);
+    placeExtra(m_waitButton);
+    placeExtra(m_loopRecordButton);
+    placeExtra(m_metronomeButton);
+    if (tier.showExtras) {
+        xCursor += -spacing + groupSpacing; // last extra added a trailing spacing; swap it for a GAP
+    }
 
-    // Group 3: Info Container
+    // Group 3: Info Container (always shown)
     if (m_infoContainer) {
         m_infoContainer->setBounds(NUIAbsolute(bounds, xCursor, islandY, infoWidth, islandHeight));
     }
-    xCursor += infoWidth + groupSpacing; // GAP
+    xCursor += infoWidth;
 
-    // Group 4: Views
-    if (m_mixerButton) {
-        m_mixerButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-        xCursor += buttonSize + spacing;
-    }
-    if (m_sequencerButton) {
-        m_sequencerButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-        xCursor += buttonSize + spacing;
-    }
-    if (m_pianoRollButton) {
-        m_pianoRollButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-        xCursor += buttonSize + spacing;
-    }
-    if (m_playlistButton) {
-        m_playlistButton->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
-        // xCursor += buttonSize + spacing;
-    }
+    // Group 4: Views — hidden first on the narrowest windows.
+    const auto placeView = [&](const std::shared_ptr<AestraUI::NUIButton>& button, bool advance) {
+        if (!button) return;
+        button->setVisible(tier.showViews);
+        if (tier.showViews) {
+            button->setBounds(NUIAbsolute(bounds, xCursor, centerOffsetY, buttonSize, buttonSize));
+            if (advance) xCursor += buttonSize + spacing;
+        }
+    };
+    if (tier.showViews) xCursor += groupSpacing; // GAP before views
+    placeView(m_mixerButton, true);
+    placeView(m_sequencerButton, true);
+    placeView(m_pianoRollButton, true);
+    placeView(m_playlistButton, false);
 
     if (m_musicalTypingLabel) {
         constexpr float statusWidth = 82.0f;
@@ -763,11 +801,15 @@ void TransportBar::onRender(AestraUI::NUIRenderer& renderer) {
     float groupSpacing = TRANSPORT_GROUP_SPACING;
     float group1Width = (buttonSize * 3) + (spacing * 2);
     float group2Width = (buttonSize * 4) + (spacing * 3);
-    float infoWidth = 260.0f;
+    float infoWidth = TRANSPORT_INFO_WIDTH;
     float group4Width = (buttonSize * 4) + (spacing * 3);
 
-    float totalContentWidth =
-        group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing + group4Width;
+    // Must mirror layoutComponents: same collapse tier drives which groups exist.
+    const TransportLayoutTier tier = transportTierFor(bounds.width);
+
+    float totalContentWidth = group1Width + groupSpacing + infoWidth
+        + (tier.showExtras ? group2Width + groupSpacing : 0.0f)
+        + (tier.showViews ? groupSpacing + group4Width : 0.0f);
     float islandPadding = TRANSPORT_ISLAND_PADDING;
     float islandWidth = totalContentWidth + (islandPadding * 2.0f);
     
@@ -809,25 +851,36 @@ void TransportBar::onRender(AestraUI::NUIRenderer& renderer) {
         renderer.strokeRoundedRect(groupRect, groupRadius, 1.0f, groupBorder);
     };
 
-    const float g1X = leftEdge - 6.0f;
-    const float g2X = leftEdge + group1Width + groupSpacing - 6.0f;
-    const float infoX = leftEdge + group1Width + groupSpacing + group2Width + groupSpacing - 6.0f;
-    const float g4X = leftEdge + group1Width + groupSpacing + group2Width + groupSpacing + infoWidth + groupSpacing - 6.0f;
-    drawGroup(g1X, group1Width + 12.0f);
-    drawGroup(g2X, group2Width + 12.0f);
-    drawGroup(infoX, infoWidth + 12.0f);
-    drawGroup(g4X, group4Width + 12.0f);
+    // Build the present groups in order (transport, [extras], info, [views]) so the
+    // shells + separators match whatever layoutComponents placed for this tier.
+    std::vector<std::pair<float, float>> groupContent; // (x, contentWidth)
+    float cx = leftEdge;
+    groupContent.emplace_back(cx, group1Width);
+    cx += group1Width + groupSpacing;
+    if (tier.showExtras) {
+        groupContent.emplace_back(cx, group2Width);
+        cx += group2Width + groupSpacing;
+    }
+    groupContent.emplace_back(cx, infoWidth);
+    cx += infoWidth + groupSpacing;
+    if (tier.showViews) {
+        groupContent.emplace_back(cx, group4Width);
+        cx += group4Width + groupSpacing;
+    }
 
-    const float sep1X = leftEdge + group1Width + (groupSpacing * 0.5f);
-    const float sep2X = sep1X + groupSpacing * 0.5f + group2Width + (groupSpacing * 0.5f);
-    const float sep3X = sep2X + groupSpacing * 0.5f + infoWidth + (groupSpacing * 0.5f);
+    for (const auto& g : groupContent) {
+        drawGroup(g.first - 6.0f, g.second + 12.0f);
+    }
+
     const float sepTop = islandRect.y + 8.0f;
     const float sepBottom = islandRect.bottom() - 8.0f;
     const auto sepColor = themeManager.getColor("borderSubtle").withAlpha(0.58f);
-    renderer.drawLine({sep1X, sepTop}, {sep1X, sepBottom}, 1.0f, sepColor);
-    renderer.drawLine({sep2X, sepTop}, {sep2X, sepBottom}, 1.0f, sepColor);
-    renderer.drawLine({sep3X, sepTop}, {sep3X, sepBottom}, 1.0f, sepColor);
-    
+    for (size_t i = 1; i < groupContent.size(); ++i) {
+        const float prevRight = groupContent[i - 1].first + groupContent[i - 1].second;
+        const float sepX = (prevRight + groupContent[i].first) * 0.5f;
+        renderer.drawLine({sepX, sepTop}, {sepX, sepBottom}, 1.0f, sepColor);
+    }
+
     renderChildren(renderer);
     renderButtonIcons(renderer);
 }

--- a/Source/Settings/MembershipSettingsPage.cpp
+++ b/Source/Settings/MembershipSettingsPage.cpp
@@ -112,6 +112,21 @@ inline void drawMembershipIcon(AestraUI::NUIRenderer& renderer, const char* name
     icon->onRender(renderer);
 }
 
+// Draw a leading icon + label as one row, both vertically centred on centreY.
+// calculateTextY() centres the full line box against a zero-height rect at
+// centreY, exactly how the SYNC-card rows position their icon (at the row centre)
+// and label — those sit level to sub-pixel. Prefer this over hand-tuned Y offsets
+// like `cy + 2`, which measured ~5px low against the geometrically centred icon.
+inline void drawIconLabel(AestraUI::NUIRenderer& renderer, const char* iconName,
+                          const std::string& label, float iconCx, float textX,
+                          float centreY, float iconSize, float fontSize,
+                          const AestraUI::NUIColor& iconColor,
+                          const AestraUI::NUIColor& textColor) {
+    drawMembershipIcon(renderer, iconName, iconCx, centreY, iconSize, iconColor);
+    const AestraUI::NUIRect rowRect(textX, centreY, 0.0f, 0.0f);
+    renderer.drawText(label, {textX, renderer.calculateTextY(rowRect, fontSize)}, fontSize, textColor);
+}
+
 #if defined(AESTRA_HAS_LICENSE_GATE) && AESTRA_HAS_LICENSE_GATE
 std::string serviceStatusMessage(Aestra::License::AccountServiceStatus status) {
     switch (status) {
@@ -550,23 +565,24 @@ void MembershipSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {
                                      statusColor.withAlpha(m_signedIn ? 0.14f : 0.08f));
             renderer.strokeRoundedRect(AestraUI::NUIRect(px, py, pillW, pillH), 999.0f, 0.5f,
                                        statusColor.withAlpha(m_signedIn ? 0.35f : 0.22f));
-            drawMembershipIcon(renderer, statusIcon, px + 14.0f, py + pillH * 0.5f, 14.0f, statusColor);
-            renderer.drawText(statusText, {px + 24.0f, py + 5.0f}, props.fontSizeS, statusColor);
+            drawIconLabel(renderer, statusIcon, statusText, px + 14.0f, px + 24.0f,
+                          py + pillH * 0.5f, 14.0f, props.fontSizeS, statusColor, statusColor);
         }
 
-        // Account meta rows
-        drawMembershipIcon(renderer, "mail", cx + 7.0f, cy + 7.0f, 15.0f, textSecondary.withAlpha(0.6f));
-        renderer.drawText(m_accountLabel->getText().empty() ? "currentsuspect@gmail.com"
-                                                            : m_accountLabel->getText(),
-                          {cx + 20.0f, cy + 2.0f}, props.fontSizeM, textSecondary);
+        // Account meta rows. Icon + label share one centre line via drawIconLabel
+        // so they sit level; the old {cx+20, cy+2} text offset rendered ~5px low.
+        const AestraUI::NUIColor metaIcon = textSecondary.withAlpha(0.6f);
+        drawIconLabel(renderer, "mail",
+                      m_accountLabel->getText().empty() ? "currentsuspect@gmail.com" : m_accountLabel->getText(),
+                      cx + 7.0f, cx + 20.0f, cy + 7.0f, 15.0f, props.fontSizeM, metaIcon, textSecondary);
         cy += 22.0f;
-        drawMembershipIcon(renderer, "file-badge", cx + 7.0f, cy + 7.0f, 15.0f, textSecondary.withAlpha(0.6f));
-        renderer.drawText(m_verificationLabel->getText().empty() ? "Signed lease \u00b7 verified locally"
-                                                               : m_verificationLabel->getText(),
-                          {cx + 20.0f, cy + 2.0f}, props.fontSizeM, textSecondary);
+        drawIconLabel(renderer, "file-badge",
+                      m_verificationLabel->getText().empty() ? "Signed lease \u00b7 verified locally"
+                                                             : m_verificationLabel->getText(),
+                      cx + 7.0f, cx + 20.0f, cy + 7.0f, 15.0f, props.fontSizeM, metaIcon, textSecondary);
         cy += 22.0f;
-        drawMembershipIcon(renderer, "clock", cx + 7.0f, cy + 7.0f, 15.0f, textSecondary.withAlpha(0.6f));
-        renderer.drawText("Last refresh: this session", {cx + 20.0f, cy + 2.0f}, props.fontSizeM, textSecondary);
+        drawIconLabel(renderer, "clock", "Last refresh: this session",
+                      cx + 7.0f, cx + 20.0f, cy + 7.0f, 15.0f, props.fontSizeM, metaIcon, textSecondary);
     }
 
     // --- 2. FEATURES CARD ---
@@ -628,9 +644,8 @@ void MembershipSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {
 
         // Footer note
         float footY = fy + 4.0f * (chipH + chipGap) + 10.0f;
-        drawMembershipIcon(renderer, "info", fx + 7.0f, footY + 7.0f, 14.0f, textTertiary);
-        renderer.drawText("Locked features require verified membership", {fx + 22.0f, footY + 3.0f},
-                          props.fontSizeS, textTertiary);
+        drawIconLabel(renderer, "info", "Locked features require verified membership",
+                      fx + 7.0f, fx + 22.0f, footY + 7.0f, 14.0f, props.fontSizeS, textTertiary, textTertiary);
     }
 
     // --- 3. SYNC & SESSION CARD ---

--- a/Source/Settings/MembershipSettingsPage.cpp
+++ b/Source/Settings/MembershipSettingsPage.cpp
@@ -649,7 +649,9 @@ void MembershipSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {
     }
 
     // --- 3. SYNC & SESSION CARD ---
-    {
+    // Hidden on narrow dialogs (layoutComponents collapses it to a zero rect so
+    // Features can take the full width).
+    if (m_syncCardBounds.width > 0.0f) {
         const auto& cb = m_syncCardBounds;
         const float r = 12.0f;
         renderer.fillRoundedRect(cb, r, bgPrimary);
@@ -887,17 +889,29 @@ void MembershipSettingsPage::layoutComponents() {
     m_founderCardBounds = AestraUI::NUIRect(x, y, contentW, founderH);
     y += founderH + cardGap;
 
-    // Features + Sync cards (side by side)
-    const float cardW = (contentW - cardGap) * 0.5f;
+    // Features + Sync cards. Side by side when there's room; on a narrow dialog the
+    // two-column feature chips clip badly, so give Features the full width and hide
+    // the secondary Sync & Session card instead of squeezing both. (Height is
+    // unchanged either way — the dialog can't scroll and has no vertical slack.)
+    const float sideCardW = (contentW - cardGap) * 0.5f;
     const float chipH = 30.0f;
     const float chipGap = 8.0f;
     const float chipRows = 4.0f;
     const float featuresCardH = 16.0f + 24.0f + (chipRows * chipH + (chipRows - 1.0f) * chipGap) + 10.0f + 14.0f + 16.0f;
     const float syncCardH = 16.0f + 28.0f + 4.0f * 36.0f + 16.0f;
-    const float cardH = std::max(featuresCardH, syncCardH);
-    m_featuresCardBounds = AestraUI::NUIRect(x, y, cardW, cardH);
-    m_syncCardBounds = AestraUI::NUIRect(x + cardW + cardGap, y, cardW, cardH);
-    y += cardH + cardGap;
+    const bool narrowCards = sideCardW < 300.0f;
+    float cardsBlockH;
+    if (narrowCards) {
+        m_featuresCardBounds = AestraUI::NUIRect(x, y, contentW, featuresCardH);
+        m_syncCardBounds = AestraUI::NUIRect(0.0f, 0.0f, 0.0f, 0.0f); // hidden — see onRender guard
+        cardsBlockH = featuresCardH;
+    } else {
+        const float cardH = std::max(featuresCardH, syncCardH);
+        m_featuresCardBounds = AestraUI::NUIRect(x, y, sideCardW, cardH);
+        m_syncCardBounds = AestraUI::NUIRect(x + sideCardW + cardGap, y, sideCardW, cardH);
+        cardsBlockH = cardH;
+    }
+    y += cardsBlockH + cardGap;
 
     // Actions row
     const float actionH = 36.0f;
@@ -923,7 +937,7 @@ void MembershipSettingsPage::layoutComponents() {
         // the form takes the Actions row's slot instead of sitting a whole row
         // below the now-empty space — which left it hanging too low. The small
         // lift seats the "Sign in" heading just under the cards.
-        float signY = b.y + vPad + founderH + cardGap + cardH + cardGap - 10.0f;
+        float signY = b.y + vPad + founderH + cardGap + cardsBlockH + cardGap - 10.0f;
         const float inputWidth = std::max(180.0f, contentW - buttonWidth - sBtnGap);
         m_signInTitleLabel->setBounds(AestraUI::NUIRect(x, signY, contentW, rowHeight));
         m_signInTitleLabel->setVisible(true);

--- a/Source/Settings/MembershipSettingsPage.cpp
+++ b/Source/Settings/MembershipSettingsPage.cpp
@@ -573,7 +573,7 @@ void MembershipSettingsPage::onRender(AestraUI::NUIRenderer& renderer) {
         // so they sit level; the old {cx+20, cy+2} text offset rendered ~5px low.
         const AestraUI::NUIColor metaIcon = textSecondary.withAlpha(0.6f);
         drawIconLabel(renderer, "mail",
-                      m_accountLabel->getText().empty() ? "currentsuspect@gmail.com" : m_accountLabel->getText(),
+                      m_accountLabel->getText().empty() ? "Account unavailable" : m_accountLabel->getText(),
                       cx + 7.0f, cx + 20.0f, cy + 7.0f, 15.0f, props.fontSizeM, metaIcon, textSecondary);
         cy += 22.0f;
         drawIconLabel(renderer, "file-badge",


### PR DESCRIPTION
A hands-on UI pass driven by running the app at narrow (half-screen) and wide widths. Each fix was verified live before commit.

## Mixer
- **fader + meter fill the channel strip** — they were pinned to the bottom 62%, leaving dead space above every strip.
- **I/O tab layout repaired** — dropdown no longer overlaps the Source/Mode meta text; help copy no longer overflows the card.
- **I/O meta row alignment** — label and value now share size + baseline (prominence via brightness, not a hidden size bump).

## Text rendering (global)
- **Decoupled the small-text readability floor from colour alpha.** The floor keyed off the text colour, so two labels written at the same size rendered at different sizes when one was dimmer (lost baseline, looked jagged), and `measureText()` disagreed with what `drawText()` painted (layout/wrap/centre off). Now it's a size-only 11px floor applied in `measureText` too, so measure == render.

## Minimization / responsive chrome
Policy (owner's call): **hide secondary chrome** as width shrinks; primary controls keep full size.
- **Title bar** — the centred view tabs collided with the right-anchored membership status/badge on narrow windows. Now the "Signed out" text hides first, then the "Core" badge, once either would cross the tabs; both return when wide.
- **Transport** — the centre island clipped off the right edge and the scope/meter overlaid the view buttons. Now the record-aid extras collapse first (then views on the narrowest widths), and the decorative scope/meter hide below 1230px. Also fixed a latent bug where hidden buttons still painted icons at stale positions.
- **Membership dialog** — Features + Sync cards were half-width each; on the narrow dialog the two-column chips clipped. The dialog can't scroll, so instead of stacking (would overflow) the Sync card hides and Features takes the full width; both return side by side when wide.

## Membership page
- **Row icons aligned with labels** — account meta rows, the status pill, and the footer note used hand-tuned Y offsets that left labels ~3-5px below the icon centre. Routed through a shared `drawIconLabel` helper using `calculateTextY` + icon-at-centre.

## Library browser rail
- **Crisp favorites star** — a thin stroked SVG that aliased at 16px, now a filled star matching the colour dots.
- **Rail dividers aligned with the file list** — removed the rule that isolated the star, matched the rail's header rules to the list header's (one continuous line across the browser), started nav content at the full header height so the star lines up with the first file row, and dropped the doubled rule at each group boundary.

## Also
- Wired the dead F3/F5/F6/F7 view-toggle shortcuts (were no-ops despite the tooltips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Mixer UI: expanded meter/fader usage to fill the available channel-strip height; refreshed mixer I/O card layout (IO dropdown positioning, card heights, meta-row alignment) and replaced the long hint with a short wrapped 2-line hint.
- Rendering consistency: standardized small-text behavior with a single 11px minimum applied consistently to both measurement and rendering (including the non-FreeType fallback sizing), so layout matches what’s drawn.
- Responsive/layout improvements: introduced width-based collapsing/hiding for multiple areas—transport bar extra/view groups, title-bar membership “Core” badge + status text, and transport visualizer elements—plus narrow-width membership card layout changes.
- Navigation/library polish: aligned FileBrowser nav header/border rules continuously with the list header styling, fixed nav header hit-testing to match the render boundary, adjusted divider insets, and swapped the favorites star to a filled-style icon with aligned rail dividers.
- View shortcuts: wired F3/F5/F6/F7 to toggle Mixer/Playlist/Sequencer- & Arsenal/Piano Roll views globally after the Takes panel consumes typing.
- Membership UI alignment: improved icon+label row alignment via a shared centered drawing helper and adjusted founder/features card rendering to stay consistent across widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->