### PR TITLE
Icons: drop the invented "RACK" name, redraw timeline tools, remove dead SVG colour

### DIFF
--- a/AestraUI/Widgets/AestraEQEditor.cpp
+++ b/AestraUI/Widgets/AestraEQEditor.cpp
@@ -190,12 +190,15 @@ std::shared_ptr<NUIIcon> polarityIcon() {
 }
 
 std::shared_ptr<NUIIcon> compareSlotIcon() {
+    // This one draws at 11px — the smallest icon in the editor. A 2px-stroked
+    // outline with two more strokes inside it resolves to a featureless blob at
+    // that size, so the slot is a solid card with its two lines cut out of it
+    // instead. Everything else here draws at 13-16px, where strokes still hold.
     static auto icon = makeSvgIcon(R"svg(
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-             stroke-linecap="round" stroke-linejoin="round">
-            <rect x="5" y="5" width="14" height="14" rx="4"/>
-            <path d="M8 13h8"/>
-            <path d="M9 9h6"/>
+        <svg viewBox="0 0 24 24">
+            <path fill="currentColor" fill-rule="evenodd"
+                  d="M7 4H17A3 3 0 0 1 20 7V17A3 3 0 0 1 17 20H7A3 3 0 0 1 4 17V7A3 3 0 0 1 7 4Z
+                     M7.6 8.4H16.4V10.6H7.6Z M7.6 13.4H16.4V15.6H7.6Z"/>
         </svg>
     )svg");
     return icon;

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -22,11 +22,11 @@ namespace {
     // track-header control icons (Source/Components/TrackUIComponent.cpp) so the
     // mixer and the arrangement lanes speak one icon language.
     constexpr const char* kMuteIconSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="#fff"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="#fff" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="currentColor"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
     constexpr const char* kSoloIconSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="#fff"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="currentColor"/></svg>)";
     constexpr const char* kRecordIconSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="#fff" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="#fff"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="currentColor"/></svg>)";
 
     // Parsed once, then rasterized+cached per size/tint by NUISVGRenderer, so the
     // per-frame cost is a single texture draw.

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -421,7 +421,9 @@ FileBrowser::FileBrowser()
     // Use inline SVG content for reliable icon loading
     // Folder icon (Mac-style smooth)
     folderIcon_ = std::make_shared<NUIIcon>();
-    const char* folderSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2.06 11L15 10l.94-2H21v9h-3.06z" opacity="0.8"/><path d="M20,6H12L10,4H4A2,2,0,0,0,2,6V18A2,2,0,0,0,4,20H20A2,2,0,0,0,22,18V8A2,2,0,0,0,20,6Z"/></svg>)";
+    // Single solid folder. The old version drew a second, opacity-0.8 path that
+    // the solid one covered completely — invisible work on every rasterization.
+    const char* folderSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20,6H12L10,4H4A2,2,0,0,0,2,6V18A2,2,0,0,0,4,20H20A2,2,0,0,0,22,18V8A2,2,0,0,0,20,6Z"/></svg>)";
     folderIcon_->loadSVG(folderSvg);
     folderIcon_->setIconSize(20, 20);
     folderIcon_->setColor(themeManager.getColor("textSecondary"));
@@ -443,28 +445,48 @@ FileBrowser::FileBrowser()
 
     // WAV Icon (Waveform visual)
     wavFileIcon_ = std::make_shared<NUIIcon>();
-    const char* wavSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 9.25a.75.75 0 0 1 .75.75v4a.75.75 0 0 1-1.5 0v-4a.75.75 0 0 1 .75-.75Zm3-3a.75.75 0 0 1 .75.75v10a.75.75 0 0 1-1.5 0v-10A.75.75 0 0 1 9 6.25Zm3 2.5a.75.75 0 0 1 .75.75v6.5a.75.75 0 0 1-1.5 0v-6.5a.75.75 0 0 1 .75-.75Zm3-1.5a.75.75 0 0 1 .75.75v9.5a.75.75 0 0 1-1.5 0v-9.5A.75.75 0 0 1 15 7.25Zm3 3.5a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 .75-.75Z"/></svg>)";
+    // WAV — a sample's peak envelope, mirrored about the centre line. The old
+    // bars all grew from a shared baseline, which reads as a bar chart or a
+    // level meter rather than audio.
+    const char* wavSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="2.1" y="9.4" width="1.9" height="5.2" rx="0.95"/><rect x="5.2" y="6.6" width="1.9" height="10.8" rx="0.95"/><rect x="8.3" y="8.6" width="1.9" height="6.8" rx="0.95"/><rect x="11.4" y="4.4" width="1.9" height="15.2" rx="0.95"/><rect x="14.5" y="7.4" width="1.9" height="9.2" rx="0.95"/><rect x="17.6" y="5.8" width="1.9" height="12.4" rx="0.95"/><rect x="20.7" y="9.8" width="1.9" height="4.4" rx="0.95"/></svg>)";
     wavFileIcon_->loadSVG(wavSvg);
     wavFileIcon_->setIconSize(20, 20);
     wavFileIcon_->setColor(themeManager.getColor("textSecondary"));
 
     // MP3 Icon (Music Note Circle)
     mp3FileIcon_ = std::make_shared<NUIIcon>();
-    const char* mp3Svg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 14.5c-2.49 0-4.5-2.01-4.5-4.5S9.51 7.5 12 7.5s4.5 2.01 4.5 4.5-2.01 4.5-4.5 4.5zm0-5.5c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1z"/></svg>)";
+    // MP3 — a record: outer disc, groove gap, centre label. A finished track
+    // rather than raw material, which is what an mp3 in a browser usually is.
+    const char* mp3Svg = R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm0 3.2a6.8 6.8 0 1 1 0 13.6 6.8 6.8 0 0 1 0-13.6z"/><circle cx="12" cy="12" r="2.4" fill="currentColor"/></svg>)";
     mp3FileIcon_->loadSVG(mp3Svg);
     mp3FileIcon_->setIconSize(20, 20);
     mp3FileIcon_->setColor(themeManager.getColor("textSecondary"));
 
     // FLAC Icon (HQ High fidelity box)
     flacFileIcon_ = std::make_shared<NUIIcon>();
-    const char* flacSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14h-2v-2h2v2zm0-4h-2V7h2v6zm4 4h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>)";
+    // FLAC — a continuous waveform, distinct from WAV's discrete peak bars so
+    // the two are told apart at a glance while both still read as audio. The
+    // old glyph was a rounded box with bars in it and said nothing at all.
+    const char* flacSvg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M1.8 12 C3.4 4.8 5.4 4.8 7 12 S10.6 19.2 12.2 12 S15.8 4.8 17.4 12 S21 17 22.2 12"/></svg>)";
     flacFileIcon_->loadSVG(flacSvg);
     flacFileIcon_->setIconSize(20, 20);
     flacFileIcon_->setColor(themeManager.getColor("textSecondary"));
 
-    // Project Icon (Aestra Diamond)
+    // MIDI Icon — piano-roll note blocks. MIDI files previously fell through to
+    // the generic document glyph because getIconForFileType had no MidiFile
+    // case, so a first-class producer file type looked like a text file.
+    // Deliberately not a waveform: MIDI carries no audio.
+    midiFileIcon_ = std::make_shared<NUIIcon>();
+    const char* midiSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="2.8" y="5.2" width="8.2" height="3" rx="1.5"/><rect x="12.2" y="9.4" width="9" height="3" rx="1.5"/><rect x="5.4" y="13.6" width="7.4" height="3" rx="1.5"/><rect x="13.6" y="17.8" width="7.6" height="3" rx="1.5"/></svg>)";
+    midiFileIcon_->loadSVG(midiSvg);
+    midiFileIcon_->setIconSize(20, 20);
+    midiFileIcon_->setColor(themeManager.getColor("textSecondary"));
+
+    // Project Icon
     projectFileIcon_ = std::make_shared<NUIIcon>();
-    const char* projectSvg = R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L4 12l8 10 8-10-8-10zm0 3.75l5 6.25-5 6.25-5-6.25 5-6.25z"/></svg>)";
+    // Project — an arrangement: a card with track lanes cut out of it. The old
+    // glyph was an abstract diamond that could have meant anything.
+    const char* projectSvg = R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M4.7 4H19.3A2.2 2.2 0 0 1 21.5 6.2V17.8A2.2 2.2 0 0 1 19.3 20H4.7A2.2 2.2 0 0 1 2.5 17.8V6.2A2.2 2.2 0 0 1 4.7 4ZM5.6 7.4H18.4V9.6H5.6ZM5.6 10.9H15.1V13.1H5.6ZM5.6 14.4H17.1V16.6H5.6Z"/></svg>)";
     projectFileIcon_->loadSVG(projectSvg);
     projectFileIcon_->setIconSize(20, 20);
     projectFileIcon_->setColor(themeManager.getColor("accentPrimary"));
@@ -2973,6 +2995,8 @@ std::shared_ptr<NUIIcon> FileBrowser::getIconForFileType(FileType type) {
             return mp3FileIcon_;
         case FileType::FlacFile:
             return flacFileIcon_;
+        case FileType::MidiFile:
+            return midiFileIcon_;
         default:
             return unknownFileIcon_;
     }

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -1106,45 +1106,76 @@ void FileBrowser::renderNavigationPane(NUIRenderer& renderer, const BrowserLayou
                 renderer.fillRoundedRect({cx - 4.0f, cy - 4.0f, 8.0f, 8.0f}, 4.0f,
                                          NUIColor::fromHex(0x3b82f6, selected ? 0.98f : 0.82f));
                 break;
+            // The rail rasterizes every glyph at exactly 16x16 (see setBounds
+            // above). These were all 1.8px stroked outlines, several of them
+            // stacking six to twelve subpaths, which is the size at which thin
+            // strokes stop resolving and a glyph turns into a smudge. They are
+            // solid silhouettes now, with internal contrast cut out via
+            // fill-rule="evenodd" so the background shows through instead of
+            // being drawn as more competing lines.
             case BrowserNavAction::Sounds:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 5v10.2"/><path d="M14 5l5-1.3v10.2"/><circle cx="10" cy="17" r="3.1"/><circle cx="17" cy="15.7" r="2.4"/></svg>)");
+                // Solid eighth note.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="8.4" cy="16.8" r="3.9"/><path d="M10.4 3.2h2.1v13.6h-2.1z"/><path d="M12.5 3.2c3.5 1.2 5.5 3.1 5.7 6.1-1.2-2.3-3.1-3.4-5.7-3.7z"/></svg>)");
                 break;
             case BrowserNavAction::Drums:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.6"/><rect x="14" y="5" width="6" height="6" rx="1.6"/><rect x="4" y="15" width="6" height="4" rx="1.4"/><rect x="14" y="15" width="6" height="4" rx="1.4"/></svg>)");
+                // Four solid pads — a pad grid rather than four outlined boxes.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="3.4" y="3.8" width="7.6" height="7.6" rx="1.8"/><rect x="13" y="3.8" width="7.6" height="7.6" rx="1.8"/><rect x="3.4" y="13" width="7.6" height="7.6" rx="1.8"/><rect x="13" y="13" width="7.6" height="7.6" rx="1.8"/></svg>)");
                 break;
             case BrowserNavAction::Instruments:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="6" width="17" height="12" rx="2"/><path d="M3.5 11h17"/><path d="M8 6v12"/><path d="M12 11v7"/><path d="M16 6v12"/></svg>)");
+                // Same keyboard treatment as the piano-roll glyph: black keys as
+                // negative space, because in one flat colour a bright "black key"
+                // is indistinguishable from a bright key divider.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M3 6H21V18H3Z M7.7 6H10.3V13H7.7Z M13.7 6H16.3V13H13.7Z M8.55 13H9.45V18H8.55Z M14.55 13H15.45V18H14.55Z"/></svg>)");
                 break;
             case BrowserNavAction::AudioEffects:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4v16"/><path d="M12 4v16"/><path d="M18 4v16"/><circle cx="6" cy="9" r="2"/><circle cx="12" cy="15" r="2"/><circle cx="18" cy="8" r="2"/></svg>)");
+                // Processor sliders: solid tracks with chunky handles.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="4.6" y="3.2" width="1.8" height="17.6" rx="0.9"/><rect x="11.1" y="3.2" width="1.8" height="17.6" rx="0.9"/><rect x="17.6" y="3.2" width="1.8" height="17.6" rx="0.9"/><rect x="2.4" y="6.4" width="6.2" height="3.6" rx="1.6"/><rect x="8.9" y="13" width="6.2" height="3.6" rx="1.6"/><rect x="15.4" y="8.6" width="6.2" height="3.6" rx="1.6"/></svg>)");
                 break;
             case BrowserNavAction::Plugins:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><rect x="9.5" y="9.5" width="5" height="5" rx="1.2"/><path d="M9 2.8V6"/><path d="M15 2.8V6"/><path d="M9 18v3.2"/><path d="M15 18v3.2"/><path d="M2.8 9H6"/><path d="M2.8 15H6"/><path d="M18 9h3.2"/><path d="M18 15h3.2"/></svg>)");
+                // A jack plug with its cable — you plug a plugin in. The old
+                // glyph stacked eight pins and two nested outlines, twelve
+                // subpaths fighting inside a 16px box.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><rect x="9.6" y="2.4" width="4.8" height="6.2" rx="1.4" fill="currentColor"/><rect x="6.8" y="8" width="10.4" height="7" rx="2.2" fill="currentColor"/><path d="M12 15.4v2.1a3.3 3.3 0 0 0 3.3 3.3h4.5" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/></svg>)");
                 break;
             case BrowserNavAction::Patterns:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="14" rx="2"/><path d="M8 9h8"/><path d="M8 13h5"/><circle cx="16" cy="13" r="1.5"/></svg>)");
+                // A step grid with an actual pattern in it, not a uniform block.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M4 5H20A2 2 0 0 1 22 7V17A2 2 0 0 1 20 19H4A2 2 0 0 1 2 17V7A2 2 0 0 1 4 5Z M5 8.2H8.2V11H5Z M10.4 8.2H13.6V11H10.4Z M15.8 8.2H19V11H15.8Z M5 13H8.2V15.8H5Z M15.8 13H19V15.8H15.8Z"/></svg>)");
                 break;
             case BrowserNavAction::Clips:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="6" width="16" height="12" rx="2"/><path d="M10 9.5l5 2.5-5 2.5v-5z"/></svg>)");
+                // A clip block with the play triangle cut out of it.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M5.6 5H18.4A2 2 0 0 1 20.4 7V17A2 2 0 0 1 18.4 19H5.6A2 2 0 0 1 3.6 17V7A2 2 0 0 1 5.6 5Z M10.2 8.7L16 12L10.2 15.3Z"/></svg>)");
                 break;
             case BrowserNavAction::Samples:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="7" width="16" height="10" rx="2"/><path d="M7 12h1.4l1.2-3 2.2 6 1.8-5 1.4 2h2"/></svg>)");
+                // Same mirrored peak envelope as the .wav file glyph, so a
+                // sample reads the same wherever it appears.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="2.4" y="9" width="2.2" height="6" rx="1.1"/><rect x="6.8" y="5.4" width="2.2" height="13.2" rx="1.1"/><rect x="11.2" y="7.8" width="2.2" height="8.4" rx="1.1"/><rect x="15.6" y="4" width="2.2" height="16" rx="1.1"/><rect x="20" y="8.6" width="2.2" height="6.8" rx="1.1"/></svg>)");
                 break;
             case BrowserNavAction::Packs:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7.5l5-2.8 5 2.8v9l-5 2.8-5-2.8v-9z"/><path d="M7.3 7.8L12 10.5l4.7-2.7"/><path d="M12 10.5v8.6"/></svg>)");
+                // A wrapped box — ribbon both ways. The old isometric cube
+                // needed three strokes to imply a top face and read as a
+                // scribble at this size. The ribbon is one cross-shaped subpath
+                // rather than two crossing bars: under evenodd, overlapping
+                // holes cancel and would leave the crossing filled in.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><circle cx="10.1" cy="3.9" r="1.9" fill="currentColor"/><circle cx="13.9" cy="3.9" r="1.9" fill="currentColor"/><path fill="currentColor" fill-rule="evenodd" d="M4 5.4H20A1.9 1.9 0 0 1 21.9 7.3V17.9A1.9 1.9 0 0 1 20 19.8H4A1.9 1.9 0 0 1 2.1 17.9V7.3A1.9 1.9 0 0 1 4 5.4Z M10.9 5.4H13.1V11.5H21.9V13.7H13.1V19.8H10.9V13.7H2.1V11.5H10.9Z"/></svg>)");
                 break;
             case BrowserNavAction::UserLibrary:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.2"/><path d="M5.5 19c1.2-3.4 3.4-5.1 6.5-5.1s5.3 1.7 6.5 5.1"/></svg>)");
+                // Solid figure.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="7.6" r="4"/><path d="M12 13c-4 0-6.9 2.4-8 6.4a1 1 0 0 0 1 1.3h14a1 1 0 0 0 1-1.3c-1.1-4-4-6.4-8-6.4z"/></svg>)");
                 break;
             case BrowserNavAction::CurrentProject:
             case BrowserNavAction::CustomPlace:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8.2h6l1.6 2H20v7.3a1.8 1.8 0 0 1-1.8 1.8H5.8A1.8 1.8 0 0 1 4 17.5V8.2z"/><path d="M4 8.2V6.7A1.8 1.8 0 0 1 5.8 5h4.4l1.4 1.8H18"/></svg>)");
+                // Same solid folder the file list uses.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20,6H12L10,4H4A2,2,0,0,0,2,6V18A2,2,0,0,0,4,20H20A2,2,0,0,0,22,18V8A2,2,0,0,0,20,6Z"/></svg>)");
                 break;
             case BrowserNavAction::AddFolder:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.2h6l1.6 2H18v7.1a1.7 1.7 0 0 1-1.7 1.7H5.2a1.7 1.7 0 0 1-1.7-1.7V8.2z"/><path d="M16.5 5.5v6"/><path d="M13.5 8.5h6"/></svg>)");
+                // Folder with the plus cut out. The plus is one cross-shaped
+                // subpath, not two overlapping bars — under evenodd, overlapping
+                // holes cancel and would leave a filled square at the crossing.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M20,6H12L10,4H4A2,2,0,0,0,2,6V18A2,2,0,0,0,4,20H20A2,2,0,0,0,22,18V8A2,2,0,0,0,20,6Z M11.15 9.6H12.85V12.15H15.4V13.85H12.85V16.4H11.15V13.85H8.6V12.15H11.15Z"/></svg>)");
                 break;
             default:
-                drawSvgIcon(R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="14" height="14" rx="2"/><path d="M8.5 10h7"/><path d="M8.5 14h7"/></svg>)");
+                // Generic list card.
+                drawSvgIcon(R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M5 5H19A2 2 0 0 1 21 7V17A2 2 0 0 1 19 19H5A2 2 0 0 1 3 17V7A2 2 0 0 1 5 5Z M7.5 9H16.5V10.6H7.5Z M7.5 13.4H16.5V15H7.5Z"/></svg>)");
                 break;
         }
     };

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -507,6 +507,7 @@ public:
     std::shared_ptr<NUIIcon> wavFileIcon_;
     std::shared_ptr<NUIIcon> mp3FileIcon_;
     std::shared_ptr<NUIIcon> flacFileIcon_;
+    std::shared_ptr<NUIIcon> midiFileIcon_;
     std::shared_ptr<NUIIcon> unknownFileIcon_;
     std::shared_ptr<NUIIcon> chevronIcon_;
     

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -38,25 +38,37 @@ namespace Audio {
 // SECTION: Toolbar & Tools
 // =============================================================================
 
+// These icons are all tinted via NUIIcon::setColor at render time, and the tint
+// is a flat RGB overwrite of every opaque pixel — so any colour baked into the
+// SVG is discarded. The old hard-coded palette here (#AAAAAA / #FF6B6B /
+// #4FC3F7 / #BB86FC) was never visible; it only made the source misleading.
+// Everything is currentColor now, and shapes carry the meaning instead.
 void TrackManagerUI::createToolIcons() {
-    // === POINTER/SELECT TOOL ICON (Simple arrow) ===
+    // === POINTER/SELECT TOOL ICON ===
+    // Solid arrow. The old one filled grey and outlined it in a 0.5px darker
+    // grey that could never resolve at toolbar size.
     const char* selectSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M5 3 L5 17 L9 13 L12 19 L14 18 L11 12 L16 12 Z" fill="#AAAAAA" stroke="#666666" stroke-width="0.5"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 2.8 L6 19.4 L10.3 15.2 L13.2 21.5 L16 20.2 L13.1 14 L18.9 14 Z"/></svg>)";
     m_selectToolIcon = std::make_shared<AestraUI::NUIIcon>(selectSvg);
 
-    // === SPLIT TOOL ICON (Scissors) ===
+    // === SPLIT TOOL ICON ===
+    // A clip parted by the cut, with the blade line through the gap. The old
+    // glyph was two rings and a grey X that read as scissors at best and as
+    // nothing at 16px.
     const char* splitSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" r="3" fill="none" stroke="#FF6B6B" stroke-width="1.5"/><circle cx="6" cy="18" r="3" fill="none" stroke="#FF6B6B" stroke-width="1.5"/><line x1="8" y1="8" x2="18" y2="16" stroke="#AAAAAA" stroke-width="2"/><line x1="8" y1="16" x2="18" y2="8" stroke="#AAAAAA" stroke-width="2"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" fill="currentColor"><rect x="2.4" y="5.6" width="8" height="12.8" rx="1.6"/><rect x="13.6" y="5.6" width="8" height="12.8" rx="1.6"/><rect x="11.3" y="2.6" width="1.4" height="18.8" rx="0.7"/></svg>)";
     m_splitToolIcon = std::make_shared<AestraUI::NUIIcon>(splitSvg);
 
-    // === MULTI-SELECT TOOL ICON (Dashed box) ===
+    // === MULTI-SELECT TOOL ICON ===
+    // Corner brackets rather than a dashed outline: a 3,2 dash pattern turns to
+    // mush once the icon is scaled down to toolbar size.
     const char* multiSelectSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="6" width="16" height="12" fill="none" stroke="#4FC3F7" stroke-width="2" stroke-dasharray="3,2"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 3h7v2.1H5.1V10H3V3zm11 0h7v7h-2.1V5.1H14V3zM3 14h2.1v4.9H10V21H3v-7zm15.9 0H21v7h-7v-2.1h4.9V14z"/></svg>)";
     m_multiSelectToolIcon = std::make_shared<AestraUI::NUIIcon>(multiSelectSvg);
 
     // === PAINT/STAMP TOOL ICON (Brush/stamp) ===
     const char* paintSvg =
-        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M7 14c-1.66 0-3 1.34-3 3 0 1.31-1.16 2-2 2 .92 1.22 2.49 2 4 2 2.21 0 4-1.79 4-4 0-1.66-1.34-3-3-3zm13.71-9.37l-1.34-1.34a.996.996 0 00-1.41 0L9 12.25 11.75 15l8.96-8.96a.996.996 0 000-1.41z" fill="#BB86FC"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M7 14c-1.66 0-3 1.34-3 3 0 1.31-1.16 2-2 2 .92 1.22 2.49 2 4 2 2.21 0 4-1.79 4-4 0-1.66-1.34-3-3-3zm13.71-9.37l-1.34-1.34a.996.996 0 00-1.41 0L9 12.25 11.75 15l8.96-8.96a.996.996 0 000-1.41z" fill="currentColor"/></svg>)";
     m_paintToolIcon = std::make_shared<AestraUI::NUIIcon>(paintSvg);
 
     // === MENU ICON (Hamburger) ===
@@ -65,8 +77,12 @@ void TrackManagerUI::createToolIcons() {
     m_menuIcon = std::make_shared<AestraUI::NUIIcon>(menuSvg);
 
     // === VISUAL MOVE CURSOR (4-way arrow) ===
+    // Solid arrowheads on a slim cross. The old version drew four chevrons plus
+    // a full-width crosshair in 2px strokes — six subpaths competing in a 16px
+    // box. It also carried a path-level stroke="#FFFFFF" that silently beat the
+    // svg-level currentColor, so it never followed the theme.
     const char* moveSvg =
-        R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" xmlns="http://www.w3.org/2000/svg"><path d="M5 9l-3 3 3 3M9 5l3-3 3 3M19 9l3 3-3 3M9 19l3 3 3-3M2 12h20M12 2v20" stroke="#FFFFFF" stroke-opacity="0.9"/></svg>)";
+        R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.05 2.2h1.9v19.6h-1.9z"/><path d="M2.2 11.05h19.6v1.9H2.2z"/><path d="M12 1 15.1 5.2H8.9L12 1zm0 22-3.1-4.2h6.2L12 23zM1 12l4.2-3.1v6.2L1 12zm22 0-4.2 3.1V8.9L23 12z"/></svg>)";
     m_moveCursorIcon = std::make_shared<AestraUI::NUIIcon>(moveSvg);
 
     Log::info("Tool icons created");

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -71,13 +71,13 @@ const AestraUI::NUISVGDocument* trackControlIcon(const char* svg) {
 }
 
 constexpr const char* kMuteIconSvg =
-    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="#fff"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="#fff" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 9v6h4l5 4.5v-15L8 9H4z" fill="currentColor"/><path d="M16 9.5 21 14.5 M21 9.5 16 14.5" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" fill="none"/></svg>)";
 constexpr const char* kSoloIconSvg =
-    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="#fff"/></svg>)";
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 4.5a7.5 7.5 0 0 0-7.5 7.5v5.2a1.8 1.8 0 0 0 1.8 1.8h1.2a1 1 0 0 0 1-1v-4.2a1 1 0 0 0-1-1H6.5V12a5.5 5.5 0 0 1 11 0v.8h-1a1 1 0 0 0-1 1V18a1 1 0 0 0 1 1h1.2a1.8 1.8 0 0 0 1.8-1.8V12A7.5 7.5 0 0 0 12 4.5z" fill="currentColor"/></svg>)";
 constexpr const char* kRecordIconSvg =
-    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="#fff" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="#fff"/></svg>)";
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="12" cy="12" r="3.4" fill="currentColor"/></svg>)";
 constexpr const char* kMonitorIconSvg =
-    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 12h3.2l2.2-5.5 3.4 11 2.2-5.5H21" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 12h3.2l2.2-5.5 3.4 11 2.2-5.5H21" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
 
 bool parseTrailingTrackNumber(const std::string& trackName, uint32_t& trackNumberOut) {
     const size_t numberPos = trackName.find_last_not_of("0123456789");

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -37,11 +37,12 @@ constexpr float TRANSPORT_INFO_WIDTH = 260.0f;
 constexpr const char* TRANSPORT_LABEL_COUNT_IN = "COUNT";
 constexpr const char* TRANSPORT_LABEL_WAIT = "WAIT";
 constexpr const char* TRANSPORT_LABEL_LOOP_REC = "LOOP REC";
-constexpr const char* TRANSPORT_LABEL_MIXER = "MIX";
-// The view is called Arsenal everywhere else in the product. Labelling it
-// "RACK" invented a second name for one thing, which is exactly the kind of
-// translation a label is supposed to remove.
-constexpr const char* TRANSPORT_LABEL_ARSENAL = "ARSENAL";
+// The view switches carry no labels. Faders and a rack of channel strips are
+// vocabulary any producer already owns, so the glyphs stand on their own and
+// the workspace cluster stays visually light next to the labelled record aids.
+// Their tooltips name them ("Mixer (F3)", "Arsenal (F6)", "Piano Roll (F7)");
+// the view is called Arsenal everywhere else in the product, so nothing here
+// invents a second name for it.
 
 // 11px matches the renderer's small-text floor, so the size layout assumes is
 // the size that actually renders.
@@ -77,13 +78,11 @@ inline float transportExtrasWidth() {
          + TRANSPORT_BUTTON_SIZE;
 }
 
-// View cluster: MIX · ARSENAL · piano roll (icon only). No Timeline button — the
-// title-bar Timeline tab already owns that workspace, and duplicate navigation
-// is worse than an ambiguous icon.
+// View cluster: mixer · arsenal · piano roll, all icon-only. No Timeline button
+// — the title-bar Timeline tab already owns that workspace, and duplicate
+// navigation is worse than an ambiguous icon.
 inline float transportViewsWidth() {
-    return transportLabeledWidth(TRANSPORT_LABEL_MIXER) + TRANSPORT_BUTTON_SPACING
-         + transportLabeledWidth(TRANSPORT_LABEL_ARSENAL) + TRANSPORT_BUTTON_SPACING
-         + TRANSPORT_BUTTON_SIZE;
+    return TRANSPORT_BUTTON_SIZE * 3.0f + TRANSPORT_BUTTON_SPACING * 2.0f;
 }
 
 // Progressive collapse for narrow windows. The transport island packs four fixed
@@ -731,9 +730,10 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
     renderGlassButton(m_metronomeButton, m_metronomeIcon, m_metronomeActive);
 
     // --- View Toggles (Right) ---
-    renderGlassButton(m_mixerButton, m_mixerIcon, m_mixerActive, false, false, TRANSPORT_LABEL_MIXER);
-    renderGlassButton(m_sequencerButton, m_sequencerIcon, m_sequencerActive, false, false, TRANSPORT_LABEL_ARSENAL);
-    // Icon only: a keyboard reads as a piano roll without help.
+    // All icon-only: faders, a channel rack and a keyboard are vocabulary a
+    // producer already has. Tooltips confirm rather than translate.
+    renderGlassButton(m_mixerButton, m_mixerIcon, m_mixerActive);
+    renderGlassButton(m_sequencerButton, m_sequencerIcon, m_sequencerActive);
     renderGlassButton(m_pianoRollButton, m_pianoRollIcon, m_pianoRollActive);
 }
 
@@ -890,8 +890,8 @@ void TransportBar::layoutComponents() {
         }
     };
     if (tier.showViews) xCursor += TRANSPORT_SURFACE_GAP; // surface gap before the view cluster
-    placeView(m_mixerButton, TRANSPORT_LABEL_MIXER, true);
-    placeView(m_sequencerButton, TRANSPORT_LABEL_ARSENAL, true);
+    placeView(m_mixerButton, nullptr, true);
+    placeView(m_sequencerButton, nullptr, true);
     placeView(m_pianoRollButton, nullptr, false);
 
     if (m_musicalTypingLabel) {

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -38,7 +38,10 @@ constexpr const char* TRANSPORT_LABEL_COUNT_IN = "COUNT";
 constexpr const char* TRANSPORT_LABEL_WAIT = "WAIT";
 constexpr const char* TRANSPORT_LABEL_LOOP_REC = "LOOP REC";
 constexpr const char* TRANSPORT_LABEL_MIXER = "MIX";
-constexpr const char* TRANSPORT_LABEL_RACK = "RACK";
+// The view is called Arsenal everywhere else in the product. Labelling it
+// "RACK" invented a second name for one thing, which is exactly the kind of
+// translation a label is supposed to remove.
+constexpr const char* TRANSPORT_LABEL_ARSENAL = "ARSENAL";
 
 // 11px matches the renderer's small-text floor, so the size layout assumes is
 // the size that actually renders.
@@ -74,12 +77,12 @@ inline float transportExtrasWidth() {
          + TRANSPORT_BUTTON_SIZE;
 }
 
-// View cluster: MIX · RACK · piano roll (icon only). No Timeline button — the
+// View cluster: MIX · ARSENAL · piano roll (icon only). No Timeline button — the
 // title-bar Timeline tab already owns that workspace, and duplicate navigation
 // is worse than an ambiguous icon.
 inline float transportViewsWidth() {
     return transportLabeledWidth(TRANSPORT_LABEL_MIXER) + TRANSPORT_BUTTON_SPACING
-         + transportLabeledWidth(TRANSPORT_LABEL_RACK) + TRANSPORT_BUTTON_SPACING
+         + transportLabeledWidth(TRANSPORT_LABEL_ARSENAL) + TRANSPORT_BUTTON_SPACING
          + TRANSPORT_BUTTON_SIZE;
 }
 
@@ -229,9 +232,18 @@ void TransportBar::createIcons() {
     m_mixerIcon->setColorFromTheme("textSecondary");
 
     // Sequencer icon (Grid)
+    // Arsenal — three channel strips, each a pad plus its lane. The old glyph
+    // was a plain 3x3 grid, which is the universal "apps" icon and said nothing
+    // about channels. Horizontal lanes also read differently from the mixer's
+    // vertical faders, so the two view buttons don't blur together.
     const char* sequencerSvg = R"(
         <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M4 4h4v4H4V4zm6 0h4v4h-4V4zm6 0h4v4h-4V4zM4 10h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4zM4 16h4v4H4v-4zm6 0h4v4h-4v-4zm6 0h4v4h-4v-4z"/>
+            <rect x="3" y="5.2" width="4" height="3.8" rx="1.1"/>
+            <rect x="8.8" y="5.2" width="12.2" height="3.8" rx="1.1"/>
+            <rect x="3" y="10.6" width="4" height="3.8" rx="1.1"/>
+            <rect x="8.8" y="10.6" width="9" height="3.8" rx="1.1"/>
+            <rect x="3" y="16" width="4" height="3.8" rx="1.1"/>
+            <rect x="8.8" y="16" width="10.8" height="3.8" rx="1.1"/>
         </svg>
     )";
     m_sequencerIcon = std::make_shared<AestraUI::NUIIcon>(sequencerSvg);
@@ -720,7 +732,7 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
 
     // --- View Toggles (Right) ---
     renderGlassButton(m_mixerButton, m_mixerIcon, m_mixerActive, false, false, TRANSPORT_LABEL_MIXER);
-    renderGlassButton(m_sequencerButton, m_sequencerIcon, m_sequencerActive, false, false, TRANSPORT_LABEL_RACK);
+    renderGlassButton(m_sequencerButton, m_sequencerIcon, m_sequencerActive, false, false, TRANSPORT_LABEL_ARSENAL);
     // Icon only: a keyboard reads as a piano roll without help.
     renderGlassButton(m_pianoRollButton, m_pianoRollIcon, m_pianoRollActive);
 }
@@ -879,7 +891,7 @@ void TransportBar::layoutComponents() {
     };
     if (tier.showViews) xCursor += TRANSPORT_SURFACE_GAP; // surface gap before the view cluster
     placeView(m_mixerButton, TRANSPORT_LABEL_MIXER, true);
-    placeView(m_sequencerButton, TRANSPORT_LABEL_RACK, true);
+    placeView(m_sequencerButton, TRANSPORT_LABEL_ARSENAL, true);
     placeView(m_pianoRollButton, nullptr, false);
 
     if (m_musicalTypingLabel) {
@@ -998,7 +1010,7 @@ bool TransportBar::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         {m_waitButton, "Wait for Input"},
         {m_loopRecordButton, "Loop Record"},
         {m_mixerButton, "Mixer (F3)"},
-        {m_sequencerButton, "Arsenal — Channel Rack (F6)"},
+        {m_sequencerButton, "Arsenal (F6)"},
         {m_pianoRollButton, "Piano Roll (F7)"}
     };
 

--- a/Source/Settings/MembershipSettingsPage.cpp
+++ b/Source/Settings/MembershipSettingsPage.cpp
@@ -55,47 +55,50 @@ inline std::shared_ptr<AestraUI::NUIIcon> NUIICON(const char* name) {
 
     const char* svg = "";
     if (std::strcmp(name, "shield-check") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 12 15 16 10"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 12 15 16 10"/></svg>)";
     } else if (std::strcmp(name, "mail") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>)";
     } else if (std::strcmp(name, "clock") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>)";
     } else if (std::strcmp(name, "check") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>)";
     } else if (std::strcmp(name, "lock") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>)";
     } else if (std::strcmp(name, "info") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>)";
     } else if (std::strcmp(name, "refresh") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>)";
     } else if (std::strcmp(name, "database") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>)";
     } else if (std::strcmp(name, "key") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.78 7.78 5.5 5.5 0 0 1 7.78-7.78zm0 0L15.5 7.5M19 11l2 2"/></svg>)";
+        // Solid key. The stroked Feather key loses its teeth entirely at the
+        // 14-15px this page draws at — what survived was a ring with a diagonal
+        // stub, which reads as the Mars symbol, not a key.
+        svg = R"(<svg viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M8.2 4.2a5.8 5.8 0 1 0 0 11.6 5.8 5.8 0 0 0 0-11.6zm0 3.5a2.3 2.3 0 1 1 0 4.6 2.3 2.3 0 0 1 0-4.6z"/><path fill="currentColor" d="M13.4 8.2H22V15.2H20V11.8H17.6V14.4H15.6V11.8H13.4Z"/></svg>)";
     } else if (std::strcmp(name, "laptop") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>)";
     } else if (std::strcmp(name, "external-link") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>)";
     } else if (std::strcmp(name, "log-out") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>)";
     } else if (std::strcmp(name, "monitor") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>)";
     } else if (std::strcmp(name, "activity") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>)";
     } else if (std::strcmp(name, "headphones") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/></svg>)";
     } else if (std::strcmp(name, "layers") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>)";
     } else if (std::strcmp(name, "award") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="7"/><polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="7"/><polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88"/></svg>)";
     } else if (std::strcmp(name, "crown") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4l3 12h14l3-12-6 7-4-7-4 7-6-7zm3 16h14"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4l3 12h14l3-12-6 7-4-7-4 7-6-7zm3 16h14"/></svg>)";
     } else if (std::strcmp(name, "cloud") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>)";
     } else if (std::strcmp(name, "zap") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>)";
     } else if (std::strcmp(name, "file-badge") == 0) {
-        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><circle cx="12" cy="15" r="2"/><path d="M12 13v-2"/><path d="M12 17v2"/></svg>)";
+        svg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><circle cx="12" cy="15" r="2"/><path d="M12 13v-2"/><path d="M12 17v2"/></svg>)";
     }
 
     auto icon = std::make_shared<AestraUI::NUIIcon>(svg);


### PR DESCRIPTION
Stacked on #604.

## Naming

The channel-rack view is called **Arsenal** everywhere else in the product, so
labelling its button `RACK` invented a second name for one thing — exactly the
translation a label is supposed to remove. Label is now `ARSENAL`, tooltip is
just "Arsenal (F6)".

Its icon was a plain 3×3 grid — the universal "apps" glyph, saying nothing about
channels. Now three channel strips (pad + lane). Horizontal lanes also read
differently from the mixer's vertical faders, so the two view buttons no longer
blur together.

## The dead-colour finding

Five toolbar icons carried a hard-coded palette (`#AAAAAA`, `#FF6B6B`,
`#4FC3F7`, `#BB86FC`, `#FFFFFF`). **None of it was ever visible.** These icons
are tinted through `NUIIcon::setColor`, and that tint is a flat RGB overwrite of
every opaque pixel:

```cpp
pixel[0] = tintR; pixel[1] = tintG; pixel[2] = tintB;
```

So any colour baked into an SVG is discarded before it reaches the screen. The
palette only made the source misleading — and in one case actively broke
theming: `moveSvg` carried a path-level `stroke="#FFFFFF"` that silently beat
its own svg-level `stroke="currentColor"`.

Everything is `currentColor` now. **No hard-coded colours remain in any SVG
literal outside `External/`.**

## Timeline tools redrawn

| Tool | Was | Now |
|---|---|---|
| Select | grey fill outlined in 0.5px darker grey — unresolvable at toolbar size | solid arrow |
| Split | two rings and a grey X | a clip parted by the cut, blade through the gap |
| Multi-select | `stroke-dasharray="3,2"` — mush once scaled down | corner brackets |
| Move | six subpaths of chevrons + crosshair in a 16px box | solid arrowheads on a slim cross |

Also converts the remaining `#fff` in the track-header and mixer-strip icons.

## Verification

Built and driven live: toolbar view cluster and the timeline tool palette both
captured and inspected at 6× zoom. Split needed a second pass — the first
version's halves were too small against the blade and read as a dumbbell.

## Scope

This is the highest-visibility slice, not the whole icon set. Still generic
(stock Material paths, working but not bespoke): the plugin editors
(AestraEQEditor ×31, AestraVerbEditor ×10, RumblePluginEditor ×4),
MembershipSettingsPage ×21, and FileBrowser ×22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)