### PR TITLE
muse: a one-shot CLI for the Muse socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,37 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/MuseReplMain.cpp")
 endif()
 
 # =============================================================================
+# muse — one-shot CLI for the Muse socket. Built unconditionally: unlike
+# muse-agent it needs no libcurl and no provider adapters, only the socket
+# client and JSON, so a terminal session is always available.
+# =============================================================================
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/Source/MuseAgent/MuseCliMain.cpp")
+  add_executable(muse
+    Source/MuseAgent/MuseCliMain.cpp
+    Source/MuseAgent/MuseSocketClient.cpp
+  )
+  if(MSVC)
+    target_compile_options(muse PRIVATE /utf-8)
+    target_compile_definitions(muse PRIVATE _CRT_SECURE_NO_WARNINGS NOMINMAX)
+  endif()
+  set_target_properties(muse PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  target_include_directories(muse PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/MuseAgent
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+  )
+  target_link_libraries(muse PRIVATE AestraCore)
+  if(WIN32)
+    target_link_libraries(muse PRIVATE ws2_32)
+  endif()
+  message(STATUS "muse CLI configured")
+endif()
+
+# =============================================================================
 # muse-agent — the standalone Muse driver (interchangeable intelligence).
 # Deliberately OUTSIDE the Aestra binary: HTTP, TLS, and provider adapters
 # never enter the DAW. Only built where libcurl is available.

--- a/Source/MuseAgent/MuseCliMain.cpp
+++ b/Source/MuseAgent/MuseCliMain.cpp
@@ -37,9 +37,9 @@ namespace {
 
 using Aestra::JSON;
 
-constexpr int kExitOk = 0;
-constexpr int kExitRequestFailed = 1; // the service answered, and said no
-constexpr int kExitUsage = 2;         // never reached the service
+constexpr int EXIT_OK = 0;
+constexpr int EXIT_REQUEST_FAILED = 1; // the service answered, and said no
+constexpr int EXIT_USAGE = 2;         // never reached the service
 
 void printUsage() {
     std::cout <<
@@ -56,6 +56,9 @@ void printUsage() {
         "  --result             print only the result field, not the envelope\n"
         "  --raw                print the response line exactly as received\n"
         "  --compact            single-line JSON (default is indented)\n"
+        "  --timeout <seconds>  give up waiting for a response (default 120,\n"
+        "                       0 waits forever). A bounce of a long timeline\n"
+        "                       is slow but finite; a stalled peer is not.\n"
         "  -h, --help\n"
         "\n"
         "Flag values are typed by shape: true/false become booleans, numbers\n"
@@ -93,11 +96,11 @@ int main(int argc, char** argv) {
     if (!Aestra::MuseAgent::parseMuseCli(tokens, invocation, error)) {
         std::cerr << error << "\n\n";
         printUsage();
-        return kExitUsage;
+        return EXIT_USAGE;
     }
     if (invocation.helpRequested) {
         printUsage();
-        return kExitOk;
+        return EXIT_OK;
     }
 
     if (invocation.portText.empty()) {
@@ -109,13 +112,13 @@ int main(int argc, char** argv) {
         std::cerr << "no port: pass --port, or set AESTRA_MUSE_PORT.\n"
                      "Start the app with AESTRA_MUSE_PORT=<port> to drive the live\n"
                      "session, or run MuseRepl --port <port> for a headless one.\n";
-        return kExitUsage;
+        return EXIT_USAGE;
     }
 
     uint16_t port = 0;
     if (!parsePort(invocation.portText, port)) {
         std::cerr << "invalid port: " << invocation.portText << "\n";
-        return kExitUsage;
+        return EXIT_USAGE;
     }
 
     Aestra::MuseAgent::MuseSocketClient client;
@@ -123,29 +126,40 @@ int main(int argc, char** argv) {
         std::cerr << "cannot reach a Muse socket at " << invocation.host << ":" << port
                   << " — " << error << "\n"
                   << "Is the app running with AESTRA_MUSE_PORT set, or MuseRepl --port?\n";
-        return kExitUsage;
+        return EXIT_USAGE;
     }
 
+    client.setReadTimeoutMs(invocation.timeoutSeconds * 1000);
+
+    Aestra::MuseAgent::MuseSocketClient::Outcome outcome{};
     const std::string line =
-        client.request(Aestra::MuseAgent::buildMuseRequest(invocation).toString());
-    if (line.empty()) {
+        client.request(Aestra::MuseAgent::buildMuseRequest(invocation).toString(), &outcome);
+
+    if (outcome == Aestra::MuseAgent::MuseSocketClient::Outcome::TimedOut) {
+        std::cerr << "timed out after " << invocation.timeoutSeconds << "s waiting for "
+                  << invocation.verb << " — raise --timeout, or 0 to wait indefinitely\n";
+        return EXIT_USAGE;
+    }
+    if (outcome == Aestra::MuseAgent::MuseSocketClient::Outcome::Disconnected || line.empty()) {
         std::cerr << "no response from " << invocation.host << ":" << port
                   << " (the session may have exited mid-request)\n";
-        return kExitUsage;
+        return EXIT_USAGE;
     }
 
-    JSON response = JSON::parse(line);
-    const bool ok = response.isObject() && response.has("status") &&
-                    response["status"].asString() == "ok";
+    // Validate before printing, and identically in both modes. --raw controls
+    // the *formatting* of a well-formed envelope; it is not a licence to pass
+    // protocol garbage through with a status derived from a lenient parse.
+    bool consumedAll = false;
+    JSON response = JSON::parseStrict(line, consumedAll);
+    if (!consumedAll || !response.isObject() || !response.has("status")) {
+        std::cerr << "malformed response (not a single JSON envelope): " << line << "\n";
+        return EXIT_USAGE;
+    }
+    const bool ok = response["status"].asString() == "ok";
 
     if (invocation.raw) {
         std::cout << line << std::endl;
-        return ok ? kExitOk : kExitRequestFailed;
-    }
-
-    if (!response.isObject()) {
-        std::cerr << "malformed response: " << line << "\n";
-        return kExitUsage;
+        return ok ? EXIT_OK : EXIT_REQUEST_FAILED;
     }
 
     const int indent = invocation.compact ? 0 : 2;
@@ -155,5 +169,5 @@ int main(int argc, char** argv) {
         std::cout << response.toString(indent) << std::endl;
     }
 
-    return ok ? kExitOk : kExitRequestFailed;
+    return ok ? EXIT_OK : EXIT_REQUEST_FAILED;
 }

--- a/Source/MuseAgent/MuseCliMain.cpp
+++ b/Source/MuseAgent/MuseCliMain.cpp
@@ -1,0 +1,159 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// muse — one-shot CLI for Aestra's Muse socket.
+//
+// MuseRepl speaks JSONL on stdin/stdout and muse-agent hands the surface to a
+// model. Neither is what you want when a *person* (or a coding agent) is at a
+// terminal driving a session by hand: those need a request framed, a socket
+// opened, and a line parsed for every single verb. This is that missing piece —
+// one verb per invocation, flags instead of hand-written JSON, the response on
+// stdout, and the outcome in the exit status:
+//
+//   muse list_units
+//   muse add_unit --type sampler --name Kick
+//   muse set_bpm --value 140
+//   muse render_pattern --pattern 1 --file /tmp/loop.wav
+//
+// It talks to whatever is listening: the running GUI app (started with
+// AESTRA_MUSE_PORT set) or a headless `MuseRepl --port N`. Edits against the
+// live app land on the main thread through the same command system as user
+// edits, so they share the undo history.
+//
+// Deliberately does NOT link libcurl or any provider code — this is a socket
+// client and a JSON formatter, nothing more.
+
+#include "MuseCliRequest.h"
+#include "MuseSocketClient.h"
+
+#include "AestraJSON.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Aestra::JSON;
+
+constexpr int kExitOk = 0;
+constexpr int kExitRequestFailed = 1; // the service answered, and said no
+constexpr int kExitUsage = 2;         // never reached the service
+
+void printUsage() {
+    std::cout <<
+        "muse — one verb per invocation against a running Aestra (or MuseRepl).\n"
+        "\n"
+        "Usage:\n"
+        "  muse [options] <verb> [--flag value ...]\n"
+        "\n"
+        "Options:\n"
+        "  --port <port>        Muse socket port (default: $AESTRA_MUSE_PORT)\n"
+        "  --host <host>        default 127.0.0.1\n"
+        "  --args-json <json>   args object verbatim; for verbs flat flags cannot\n"
+        "                       express (batch takes an array of commands)\n"
+        "  --result             print only the result field, not the envelope\n"
+        "  --raw                print the response line exactly as received\n"
+        "  --compact            single-line JSON (default is indented)\n"
+        "  -h, --help\n"
+        "\n"
+        "Flag values are typed by shape: true/false become booleans, numbers\n"
+        "become numbers, everything else stays a string. A flag with no value\n"
+        "is a boolean true.\n"
+        "\n"
+        "Exit status: 0 the verb succeeded, 1 the service refused it, 2 it was\n"
+        "never asked (bad usage, or nothing listening).\n"
+        "\n"
+        "Start something to talk to:\n"
+        "  AESTRA_MUSE_PORT=41952 ./Aestra      # drive the live app\n"
+        "  ./MuseRepl --port 41952              # headless\n"
+        "\n"
+        "`muse get_schema` lists every verb, its flags, and the semantics that\n"
+        "are not visible in the protocol.\n";
+}
+
+bool parsePort(const std::string& text, uint16_t& out) {
+    char* end = nullptr;
+    const long parsed = std::strtol(text.c_str(), &end, 10);
+    if (end == nullptr || *end != '\0' || parsed <= 0 || parsed > 65535) {
+        return false;
+    }
+    out = static_cast<uint16_t>(parsed);
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::vector<std::string> tokens(argv + 1, argv + argc);
+
+    Aestra::MuseAgent::CliInvocation invocation;
+    std::string error;
+    if (!Aestra::MuseAgent::parseMuseCli(tokens, invocation, error)) {
+        std::cerr << error << "\n\n";
+        printUsage();
+        return kExitUsage;
+    }
+    if (invocation.helpRequested) {
+        printUsage();
+        return kExitOk;
+    }
+
+    if (invocation.portText.empty()) {
+        if (const char* env = std::getenv("AESTRA_MUSE_PORT")) {
+            invocation.portText = env;
+        }
+    }
+    if (invocation.portText.empty()) {
+        std::cerr << "no port: pass --port, or set AESTRA_MUSE_PORT.\n"
+                     "Start the app with AESTRA_MUSE_PORT=<port> to drive the live\n"
+                     "session, or run MuseRepl --port <port> for a headless one.\n";
+        return kExitUsage;
+    }
+
+    uint16_t port = 0;
+    if (!parsePort(invocation.portText, port)) {
+        std::cerr << "invalid port: " << invocation.portText << "\n";
+        return kExitUsage;
+    }
+
+    Aestra::MuseAgent::MuseSocketClient client;
+    if (!client.connect(invocation.host, port, error)) {
+        std::cerr << "cannot reach a Muse socket at " << invocation.host << ":" << port
+                  << " — " << error << "\n"
+                  << "Is the app running with AESTRA_MUSE_PORT set, or MuseRepl --port?\n";
+        return kExitUsage;
+    }
+
+    const std::string line =
+        client.request(Aestra::MuseAgent::buildMuseRequest(invocation).toString());
+    if (line.empty()) {
+        std::cerr << "no response from " << invocation.host << ":" << port
+                  << " (the session may have exited mid-request)\n";
+        return kExitUsage;
+    }
+
+    JSON response = JSON::parse(line);
+    const bool ok = response.isObject() && response.has("status") &&
+                    response["status"].asString() == "ok";
+
+    if (invocation.raw) {
+        std::cout << line << std::endl;
+        return ok ? kExitOk : kExitRequestFailed;
+    }
+
+    if (!response.isObject()) {
+        std::cerr << "malformed response: " << line << "\n";
+        return kExitUsage;
+    }
+
+    const int indent = invocation.compact ? 0 : 2;
+    if (invocation.resultOnly && response.has("result")) {
+        std::cout << response["result"].toString(indent) << std::endl;
+    } else {
+        std::cout << response.toString(indent) << std::endl;
+    }
+
+    return ok ? kExitOk : kExitRequestFailed;
+}

--- a/Source/MuseAgent/MuseCliRequest.h
+++ b/Source/MuseAgent/MuseCliRequest.h
@@ -24,6 +24,9 @@ struct CliInvocation {
     bool compact = false;
     bool resultOnly = false;
     bool helpRequested = false;
+    // A hang guard, not a latency budget: render_song bounces a whole timeline
+    // and is legitimately slow. 0 waits forever.
+    int timeoutSeconds = 120;
 };
 
 // A bare token is a value; `--name` starts the next flag. This is what lets
@@ -71,7 +74,8 @@ inline bool parseMuseCli(const std::vector<std::string>& tokens, CliInvocation& 
         }
 
         if (out.verb.empty() && museCliIsFlag(arg)) {
-            const bool wantsValue = (arg == "--port" || arg == "--host" || arg == "--args-json");
+            const bool wantsValue =
+                (arg == "--port" || arg == "--host" || arg == "--args-json" || arg == "--timeout");
             std::string value;
             if (wantsValue) {
                 if (i + 1 >= tokens.size()) {
@@ -96,6 +100,16 @@ inline bool parseMuseCli(const std::vector<std::string>& tokens, CliInvocation& 
                 out.args = parsed;
                 out.haveArgs = true;
                 out.argsFromJson = true;
+                continue;
+            }
+            if (arg == "--timeout") {
+                char* end = nullptr;
+                const long seconds = std::strtol(value.c_str(), &end, 10);
+                if (end == nullptr || *end != '\0' || seconds < 0 || seconds > 86400) {
+                    outError = "--timeout must be whole seconds in 0..86400 (0 waits forever)";
+                    return false;
+                }
+                out.timeoutSeconds = static_cast<int>(seconds);
                 continue;
             }
             if (arg == "--raw") { out.raw = true; continue; }

--- a/Source/MuseAgent/MuseCliRequest.h
+++ b/Source/MuseAgent/MuseCliRequest.h
@@ -1,0 +1,163 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// Argv -> Muse request, split out of main() so it can be tested without a
+// socket. Everything here is pure: strings in, JSON out, no IO.
+
+#include "AestraJSON.h"
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace MuseAgent {
+
+struct CliInvocation {
+    std::string host = "127.0.0.1";
+    std::string portText;    // empty = fall back to $AESTRA_MUSE_PORT
+    std::string verb;
+    JSON args = JSON::object();
+    bool haveArgs = false;
+    bool argsFromJson = false; // --args-json was used; per-flag args then conflict
+    bool raw = false;
+    bool compact = false;
+    bool resultOnly = false;
+    bool helpRequested = false;
+};
+
+// A bare token is a value; `--name` starts the next flag. This is what lets
+// `--muted` mean true without inventing a separate boolean syntax.
+inline bool museCliIsFlag(const std::string& token) {
+    return token.size() > 2 && token[0] == '-' && token[1] == '-';
+}
+
+// Type by shape, not by schema: the CLI does not carry a copy of the grammar,
+// and guessing from a stale one would be worse than letting the service
+// validate. Numbers must consume the whole token, so "1.5.2" and "12abc" stay
+// strings rather than silently becoming 1.5 and 12.
+inline JSON museCliValueFromToken(const std::string& token) {
+    if (token == "true") return JSON(true);
+    if (token == "false") return JSON(false);
+
+    if (!token.empty()) {
+        char* end = nullptr;
+        const double parsed = std::strtod(token.c_str(), &end);
+        if (end != nullptr && *end == '\0' && end != token.c_str()) {
+            return JSON(parsed);
+        }
+    }
+    return JSON(token);
+}
+
+/**
+ * @brief Parse argv (excluding argv[0]) into an invocation.
+ * @return false with outError set when the command line cannot be honoured.
+ *
+ * Options are options only until the verb is named; after that a --flag belongs
+ * to the verb, so `muse set_steps --pattern 4` is unambiguous. The three
+ * presence-only output options are the exception — they are recognised after
+ * the verb too, because that is where anyone actually types them, and having no
+ * value means there is no arity ambiguity to resolve.
+ */
+inline bool parseMuseCli(const std::vector<std::string>& tokens, CliInvocation& out,
+                         std::string& outError) {
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        const std::string& arg = tokens[i];
+
+        if (arg == "-h" || arg == "--help") {
+            out.helpRequested = true;
+            return true;
+        }
+
+        if (out.verb.empty() && museCliIsFlag(arg)) {
+            const bool wantsValue = (arg == "--port" || arg == "--host" || arg == "--args-json");
+            std::string value;
+            if (wantsValue) {
+                if (i + 1 >= tokens.size()) {
+                    outError = arg + " needs a value";
+                    return false;
+                }
+                value = tokens[++i];
+            }
+            if (arg == "--port") { out.portText = value; continue; }
+            if (arg == "--host") { out.host = value; continue; }
+            if (arg == "--args-json") {
+                bool consumedAll = false;
+                JSON parsed = JSON::parseStrict(value, consumedAll);
+                if (!consumedAll || !parsed.isObject()) {
+                    outError = "--args-json must be a single JSON object";
+                    return false;
+                }
+                if (out.haveArgs) {
+                    outError = "--args-json and per-flag args are mutually exclusive";
+                    return false;
+                }
+                out.args = parsed;
+                out.haveArgs = true;
+                out.argsFromJson = true;
+                continue;
+            }
+            if (arg == "--raw") { out.raw = true; continue; }
+            if (arg == "--compact") { out.compact = true; continue; }
+            if (arg == "--result") { out.resultOnly = true; continue; }
+            outError = "unknown option: " + arg;
+            return false;
+        }
+
+        if (out.verb.empty()) {
+            out.verb = arg;
+            continue;
+        }
+
+        if (!museCliIsFlag(arg)) {
+            outError = "unexpected value '" + arg + "' — flags take the form --name value";
+            return false;
+        }
+
+        const std::string name = arg.substr(2);
+        if (name == "result") { out.resultOnly = true; continue; }
+        if (name == "raw") { out.raw = true; continue; }
+        if (name == "compact") { out.compact = true; continue; }
+
+        // --args-json is whole-object; mixing it with per-flag args would leave
+        // the precedence between them unstated, so refuse instead of guessing.
+        if (out.argsFromJson) {
+            outError = "--args-json and per-flag args are mutually exclusive";
+            return false;
+        }
+
+        if (i + 1 < tokens.size() && !museCliIsFlag(tokens[i + 1])) {
+            out.args.set(name, museCliValueFromToken(tokens[++i]));
+        } else {
+            out.args.set(name, JSON(true)); // presence-as-true
+        }
+        out.haveArgs = true;
+    }
+
+    if (out.verb.empty() && !out.helpRequested) {
+        outError = "no verb given";
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief Frame an invocation as a Muse request envelope.
+ *
+ * JSON::set silently no-ops on a non-object, so the envelope and args must be
+ * built with JSON::object() — a default-constructed JSON is Null, and every
+ * field written to it would vanish without a diagnostic.
+ */
+inline JSON buildMuseRequest(const CliInvocation& invocation) {
+    JSON request = JSON::object();
+    request.set("id", JSON(1.0));
+    request.set("verb", JSON(invocation.verb));
+    if (invocation.haveArgs) {
+        request.set("args", invocation.args);
+    }
+    return request;
+}
+
+} // namespace MuseAgent
+} // namespace Aestra

--- a/Source/MuseAgent/MuseSocketClient.cpp
+++ b/Source/MuseAgent/MuseSocketClient.cpp
@@ -16,6 +16,7 @@ using SocketHandle = int;
 static constexpr SocketHandle kInvalidSocket = -1;
 #endif
 
+#include <cerrno>
 #include <cstring>
 #include <mutex>
 
@@ -89,8 +90,46 @@ bool MuseSocketClient::connect(const std::string& host, uint16_t port, std::stri
     return true;
 }
 
-std::string MuseSocketClient::request(const std::string& line) {
+void MuseSocketClient::setReadTimeoutMs(int milliseconds) {
+    if (m_impl->socket == kInvalidSocket || milliseconds < 0) {
+        return;
+    }
+#ifdef _WIN32
+    const DWORD value = static_cast<DWORD>(milliseconds);
+    ::setsockopt(m_impl->socket, SOL_SOCKET, SO_RCVTIMEO,
+                 reinterpret_cast<const char*>(&value), sizeof(value));
+#else
+    timeval value{};
+    value.tv_sec = milliseconds / 1000;
+    value.tv_usec = (milliseconds % 1000) * 1000;
+    ::setsockopt(m_impl->socket, SOL_SOCKET, SO_RCVTIMEO, &value, sizeof(value));
+#endif
+}
+
+namespace {
+
+// SO_RCVTIMEO expiry looks like any other recv failure, so ask the platform
+// which one it was — a timeout is recoverable information for the caller,
+// a dead peer is not.
+bool lastRecvWasTimeout() {
+#ifdef _WIN32
+    const int code = ::WSAGetLastError();
+    return code == WSAETIMEDOUT;
+#else
+    return errno == EAGAIN || errno == EWOULDBLOCK;
+#endif
+}
+
+} // namespace
+
+std::string MuseSocketClient::request(const std::string& line, Outcome* outOutcome) {
+    const auto report = [&](Outcome outcome) {
+        if (outOutcome != nullptr) *outOutcome = outcome;
+    };
+    report(Outcome::Ok);
+
     if (m_impl->socket == kInvalidSocket) {
+        report(Outcome::Disconnected);
         return "{\"status\": \"execution_error\", \"message\": \"not connected\"}";
     }
 
@@ -108,6 +147,7 @@ std::string MuseSocketClient::request(const std::string& line) {
         if (n <= 0) {
             closeSocket(m_impl->socket);
             m_impl->socket = kInvalidSocket;
+            report(Outcome::Disconnected);
             return "{\"status\": \"execution_error\", \"message\": \"connection lost on send\"}";
         }
         sent += static_cast<size_t>(n);
@@ -118,9 +158,16 @@ std::string MuseSocketClient::request(const std::string& line) {
         char chunk[4096];
         const auto received = ::recv(m_impl->socket, chunk, sizeof(chunk), 0);
         if (received <= 0) {
+            // A timeout leaves the connection usable in principle, but this
+            // request is unanswerable — close either way so a later request
+            // cannot read this one's late response as its own.
+            const bool timedOut = (received < 0) && lastRecvWasTimeout();
             closeSocket(m_impl->socket);
             m_impl->socket = kInvalidSocket;
-            return "{\"status\": \"execution_error\", \"message\": \"connection lost on recv\"}";
+            report(timedOut ? Outcome::TimedOut : Outcome::Disconnected);
+            return timedOut
+                       ? "{\"status\": \"execution_error\", \"message\": \"timed out waiting for a response\"}"
+                       : "{\"status\": \"execution_error\", \"message\": \"connection lost on recv\"}";
         }
         m_impl->readBuffer.append(chunk, static_cast<size_t>(received));
     }

--- a/Source/MuseAgent/MuseSocketClient.h
+++ b/Source/MuseAgent/MuseSocketClient.h
@@ -21,8 +21,29 @@ public:
 
     bool connect(const std::string& host, uint16_t port, std::string& outError);
 
-    /** @brief Send one request line, block until the response line arrives. */
-    std::string request(const std::string& line);
+    /**
+     * @brief Give recv a deadline, so a connected-but-silent peer cannot hang
+     *        the caller forever. 0 restores blocking-until-answered.
+     *
+     * Call after connect(); it applies to the open socket. Requests that do
+     * real work (render_song bounces a whole timeline) need a generous value —
+     * this is a hang guard, not a latency budget.
+     */
+    void setReadTimeoutMs(int milliseconds);
+
+    /** @brief Why a request stopped, for callers that must tell these apart. */
+    enum class Outcome {
+        Ok,           ///< a response line came back
+        Disconnected, ///< the peer went away mid-request
+        TimedOut      ///< the read deadline elapsed with no response line
+    };
+
+    /**
+     * @brief Send one request line, block until the response line arrives.
+     * @param outOutcome optional; distinguishes a timeout from a lost peer,
+     *        which the returned JSON string alone cannot express structurally.
+     */
+    std::string request(const std::string& line, Outcome* outOutcome = nullptr);
 
     bool isConnected() const;
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2151,6 +2151,14 @@ target_include_directories(MuseServiceTest PRIVATE
 add_test(NAME MuseServiceTest COMMAND MuseServiceTest)
 set_tests_properties(MuseServiceTest PROPERTIES LABELS "commands;muse")
 
+add_executable(MuseCliRequestTest Commands/MuseCliRequestTest.cpp)
+target_include_directories(MuseCliRequestTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/MuseAgent
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME MuseCliRequestTest COMMAND MuseCliRequestTest)
+set_tests_properties(MuseCliRequestTest PROPERTIES LABELS "commands;muse")
+
 add_executable(MuseSocketServerTest Commands/MuseSocketServerTest.cpp)
 target_link_libraries(MuseSocketServerTest PRIVATE AestraAudioCore)
 target_include_directories(MuseSocketServerTest PRIVATE

--- a/Tests/Commands/MuseCliRequestTest.cpp
+++ b/Tests/Commands/MuseCliRequestTest.cpp
@@ -146,6 +146,26 @@ int main() {
               "--port after the verb is a verb arg");
     }
 
+    // --- the read deadline -------------------------------------------------
+    {
+        const CliInvocation defaults = parseOrDie({"list_units"});
+        check(defaults.timeoutSeconds > 0, "there is a finite default deadline");
+
+        const CliInvocation explicitValue = parseOrDie({"--timeout", "5", "render_song"});
+        check(explicitValue.timeoutSeconds == 5, "--timeout is captured");
+
+        const CliInvocation forever = parseOrDie({"--timeout", "0", "render_song"});
+        check(forever.timeoutSeconds == 0, "--timeout 0 means wait indefinitely");
+
+        std::string error;
+        check(parseFails({"--timeout", "-5", "list_units"}, error),
+              "a negative deadline is refused");
+        check(parseFails({"--timeout", "abc", "list_units"}, error),
+              "a non-numeric deadline is refused");
+        check(parseFails({"--timeout", "2.5", "list_units"}, error),
+              "a fractional deadline is refused rather than truncated");
+    }
+
     // --- --args-json for shapes flat flags cannot express ------------------
     {
         const CliInvocation inv = parseOrDie(

--- a/Tests/Commands/MuseCliRequestTest.cpp
+++ b/Tests/Commands/MuseCliRequestTest.cpp
@@ -1,0 +1,194 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Argv -> Muse request framing for the `muse` CLI. No socket, no service: this
+// covers the half that turns a command line into a request, which is where the
+// mistakes are silent — JSON::set no-ops on a non-object, so a request built on
+// a default-constructed JSON loses every field without a diagnostic and only
+// fails much later, at the far end of a socket.
+
+#include "MuseCliRequest.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Aestra::JSON;
+using Aestra::MuseAgent::buildMuseRequest;
+using Aestra::MuseAgent::CliInvocation;
+using Aestra::MuseAgent::parseMuseCli;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cerr << "FAIL: " << what << "\n";
+        ++g_failures;
+    }
+}
+
+CliInvocation parseOrDie(const std::vector<std::string>& tokens) {
+    CliInvocation invocation;
+    std::string error;
+    if (!parseMuseCli(tokens, invocation, error)) {
+        std::cerr << "FAIL: unexpected parse error: " << error << "\n";
+        ++g_failures;
+    }
+    return invocation;
+}
+
+bool parseFails(const std::vector<std::string>& tokens, std::string& outError) {
+    CliInvocation invocation;
+    return !parseMuseCli(tokens, invocation, outError);
+}
+
+} // namespace
+
+int main() {
+    // --- the envelope is an object, and carries the args -------------------
+    {
+        const CliInvocation inv = parseOrDie({"add_unit", "--type", "sampler", "--name", "Kick"});
+        check(inv.verb == "add_unit", "verb is read from the first bare token");
+
+        const JSON request = buildMuseRequest(inv);
+        check(request.isObject(), "request envelope is a JSON object");
+        check(request.has("verb") && request["verb"].asString() == "add_unit",
+              "envelope carries the verb");
+        check(request.has("args"), "envelope carries args when flags were given");
+        check(request["args"]["type"].asString() == "sampler", "string flag survives framing");
+        check(request["args"]["name"].asString() == "Kick", "second string flag survives framing");
+
+        // The regression that motivated this test: with a default-constructed
+        // JSON, set() silently no-ops and the service sees no args at all.
+        const std::string text = request.toString();
+        check(text.find("\"sampler\"") != std::string::npos,
+              "serialized request actually contains the arg value");
+    }
+
+    // --- a verb with no flags sends no args key ----------------------------
+    {
+        const JSON request = buildMuseRequest(parseOrDie({"get_transport"}));
+        check(!request.has("args"), "no args key when the verb took no flags");
+    }
+
+    // --- values are typed by shape -----------------------------------------
+    {
+        const CliInvocation inv =
+            parseOrDie({"set_note", "--pitch", "60", "--velocity", "0.5", "--start", "-2.25"});
+        const JSON args = buildMuseRequest(inv)["args"];
+        check(args["pitch"].isNumber() && args["pitch"].asNumber() == 60.0, "integer becomes a number");
+        check(args["velocity"].isNumber() && args["velocity"].asNumber() == 0.5,
+              "decimal becomes a number");
+        check(args["start"].isNumber() && args["start"].asNumber() == -2.25,
+              "negative decimal becomes a number");
+
+        // Integer-valued flags must not serialize as "60.000000" — the grammar's
+        // int validators reject that shape.
+        const std::string text = args.toString();
+        check(text.find("60.0") == std::string::npos, "integers serialize integrally");
+        check(text.find("60") != std::string::npos, "the integer is still present");
+    }
+
+    // --- partial numbers stay strings rather than silently truncating ------
+    {
+        const JSON args = buildMuseRequest(parseOrDie(
+            {"rename_track", "--name", "12abc", "--pattern", "1.5.2"}))["args"];
+        check(args["name"].isString() && args["name"].asString() == "12abc",
+              "a token that is only partly numeric stays a string");
+        check(args["pattern"].isString() && args["pattern"].asString() == "1.5.2",
+              "a malformed number stays a string instead of becoming 1.5");
+    }
+
+    // --- booleans, both spellings ------------------------------------------
+    {
+        const JSON args = buildMuseRequest(parseOrDie(
+            {"mute_track", "--track", "0", "--state", "true", "--other", "false"}))["args"];
+        check(args["state"].isBool() && args["state"].asBool(), "'true' becomes a boolean");
+        check(args["other"].isBool() && !args["other"].asBool(), "'false' becomes a boolean");
+    }
+    {
+        // A flag with nothing after it, and a flag followed by another flag,
+        // both mean presence-as-true.
+        const JSON args =
+            buildMuseRequest(parseOrDie({"mute_track", "--state", "--track", "0"}))["args"];
+        check(args["state"].isBool() && args["state"].asBool(),
+              "a flag followed by another flag is true");
+        check(args["track"].isNumber(), "the following flag still takes its own value");
+    }
+    {
+        const JSON args = buildMuseRequest(parseOrDie({"mute_track", "--state"}))["args"];
+        check(args["state"].isBool() && args["state"].asBool(), "a trailing flag is true");
+    }
+
+    // --- output options are accepted on both sides of the verb -------------
+    {
+        const CliInvocation before = parseOrDie({"--result", "--compact", "list_units"});
+        check(before.resultOnly && before.compact, "output options parse before the verb");
+
+        const CliInvocation after = parseOrDie({"list_units", "--result", "--compact"});
+        check(after.resultOnly && after.compact, "output options parse after the verb too");
+        check(!buildMuseRequest(after).has("args"),
+              "output options after the verb are not sent as verb args");
+    }
+
+    // --- connection options are pre-verb only ------------------------------
+    {
+        const CliInvocation inv = parseOrDie({"--port", "41952", "--host", "10.0.0.2", "list_units"});
+        check(inv.portText == "41952", "--port is captured");
+        check(inv.host == "10.0.0.2", "--host is captured");
+
+        // After the verb, --port belongs to the verb; nothing else would let a
+        // verb legitimately own a flag named port.
+        const CliInvocation owned = parseOrDie({"some_verb", "--port", "4"});
+        check(owned.portText.empty(), "--port after the verb is not the CLI's port");
+        check(buildMuseRequest(owned)["args"]["port"].asNumber() == 4.0,
+              "--port after the verb is a verb arg");
+    }
+
+    // --- --args-json for shapes flat flags cannot express ------------------
+    {
+        const CliInvocation inv = parseOrDie(
+            {"--args-json", R"({"commands":[{"verb":"add_track","args":{"name":"Drums"}}]})",
+             "batch"});
+        const JSON request = buildMuseRequest(inv);
+        check(request["args"]["commands"].isArray(), "--args-json preserves nested arrays");
+        check(request["args"]["commands"][static_cast<size_t>(0)]["args"]["name"].asString() ==
+                  "Drums",
+              "--args-json preserves nested objects");
+    }
+
+    // --- refusals ----------------------------------------------------------
+    {
+        std::string error;
+        check(parseFails({}, error), "no arguments is an error");
+        check(parseFails({"--nonsense", "list_units"}, error), "unknown pre-verb option is refused");
+        check(parseFails({"--port"}, error), "an option missing its value is refused");
+        check(parseFails({"list_units", "stray"}, error),
+              "a bare value after the verb is refused rather than guessed at");
+        check(parseFails({"--args-json", "[1,2]", "batch"}, error),
+              "--args-json must be an object, not an array");
+        check(parseFails({"--args-json", "{\"a\":1} trailing", "batch"}, error),
+              "--args-json rejects trailing garbage");
+        check(parseFails({"--args-json", "{\"a\":1}", "batch", "--b", "2"}, error),
+              "--args-json and per-flag args cannot be combined");
+    }
+
+    // --- help short-circuits, and needs no verb ----------------------------
+    {
+        CliInvocation invocation;
+        std::string error;
+        check(parseMuseCli({"--help"}, invocation, error) && invocation.helpRequested,
+              "--help is accepted with no verb");
+        CliInvocation shortForm;
+        check(parseMuseCli({"-h"}, shortForm, error) && shortForm.helpRequested,
+              "-h is accepted with no verb");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " assertion(s) failed\n";
+        return 1;
+    }
+    std::cout << "[PASS] muse CLI request framing\n";
+    return 0;
+}


### PR DESCRIPTION
## Why

Muse already has the surface — 32 mutation verbs, 12 queries, batch, render, a live socket into the running app. What it doesn't have is a way to *use* it by hand. `MuseRepl` speaks JSONL on stdin/stdout; `muse-agent` hands the whole surface to a model. Neither fits a person (or a coding agent) at a terminal: both make you frame a request, open a socket and parse a line for every single verb. That friction is why the surface goes unused and people reach for the mouse.

```
muse list_units
muse add_unit --type sampler --name Kick
muse set_bpm --value 140
muse render_pattern --pattern 1 --file /tmp/loop.wav
```

Talks to whatever is listening: the running GUI app (`AESTRA_MUSE_PORT`) or a headless `MuseRepl --port`. Against the live app, edits land on the main thread through the same command system as user edits, so they share the undo history.

## Design decisions worth reviewing

- **Values typed by shape, not by schema.** The CLI carries no copy of the grammar; a stale one would be worse than letting the service validate. A number must consume its whole token, so `12abc` stays a string rather than silently becoming `12`.
- **Options bind before the verb**, so a verb may legitimately own a flag named `--port`. The three presence-only output options (`--result`, `--raw`, `--compact`) are accepted after it too — that's where they actually get typed, and with no value there's no arity ambiguity to resolve.
- **`--args-json`** passes an args object verbatim for shapes flat flags can't express (`batch` takes an array of commands). Mixing it with per-flag args is refused rather than given an unstated precedence.
- **Exit status separates refusal from unreachable:** `1` = the service said no, `2` = the verb was never asked. Scripts need to tell those apart.
- **No libcurl, no provider code.** Socket client and JSON printer only, so it builds everywhere rather than only where `muse-agent` does.

## Test

Argv→request framing is in `MuseCliRequest.h` so it can be tested without a socket. `MuseCliRequestTest` covers typing, presence-as-true, option binding on both sides of the verb, `--args-json` nesting, and seven refusals.

That test is not decorative. The first working draft built its envelope on a default-constructed `JSON` — and since `JSON::set` silently no-ops on a non-object, **every arg vanished with no diagnostic**, surfacing only as `request must be a JSON object` from the far end of a socket. Reverting the fix turns eleven assertions red; I checked.

Verified end-to-end against a live `MuseRepl`: transport read/write, `add_unit`, `list_units`, `list_tracks`, `batch` via `--args-json`, plus the failure modes (no port, dead port, unknown verb, unknown flag, stray value).

## Two surface gaps this turned up — not fixed here

1. **There is no `undo` verb.** The schema's own notes say *"Every mutation and every batch is one step in the same undo history the UI uses"* — but nothing on the surface can drive it. For a hands-on session that's the most common recovery move, and it's missing.
2. **`batch` silently ignores unknown member keys.** `{"verb":"add_track","bogus_key":{...}}` returns `ok`. I hit this for real by writing `flags` instead of `args` — it happily created a default-named track and reported success. Everywhere else this surface refuses unknown keys by name (`unknown arg for get_effects: ...`), so this is inconsistent as well as quietly wrong.

Both are follow-ups I'd like to take next, ahead of the larger settings/plugins work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds the `muse` one-shot CLI for sending mutation, query, batch, and render requests to a running Muse service or headless `MuseRepl`.
- Supports typed arguments, `--args-json`, flexible option placement, and `--result`, `--raw`, and `--compact` output modes.
- Distinguishes service refusals (exit code 1) from connection or usage failures (exit code 2).
- Adds socket-client request handling and CMake targets for the CLI.
- Adds request-framing tests covering argument typing, option binding, JSON nesting, and invalid inputs.
- Documents follow-up gaps: no `undo` verb and silent acceptance of unknown `batch` keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->