### PR TITLE
Muse: undo/redo verbs, and batch members that refuse unknown keys

### DIFF
--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -290,7 +290,9 @@ std::string schemaToJsonString() {
 "actions": [
   {"verb": "render_pattern", "args": "{\"pattern\": <id>, \"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce one pattern (Arsenal preview routing) to a float32 WAV. Result carries durationSeconds, frames, sampleRate, peakDb."},
   {"verb": "render_song", "args": "{\"file\": <path>, \"tail\": <seconds 0..30>}", "description": "Bounce the arranged timeline to a float32 WAV. Errors on an empty timeline. Result carries durationSeconds, frames, sampleRate, peakDb."},
-  {"verb": "batch", "args": "{\"commands\": [{\"verb\": ..., \"args\": ...}, ...]}", "description": "Run 1..64 mutation verbs all-or-nothing as a single undo step. Members execute against the state their predecessors produced."}
+  {"verb": "batch", "args": "{\"commands\": [{\"verb\": ..., \"args\": ...}, ...]}", "description": "Run 1..64 mutation verbs all-or-nothing as a single undo step. Members execute against the state their predecessors produced. A member takes only \"verb\" and \"args\"; any other key is refused."},
+  {"verb": "undo", "args": "none", "description": "Step back one entry in the shared undo history (a batch is one entry). Refuses with 'nothing to undo' at the end of the stack rather than reporting a no-op as success. Result carries canUndo, canRedo."},
+  {"verb": "redo", "args": "none", "description": "Step forward one entry. Refuses with 'nothing to redo' at the end of the stack. Result carries canUndo, canRedo."}
 ],
 "notes": {
   "samplerPitch": "The sampler root is MIDI pitch 60: notes at 60 play the loaded sample unshifted, other pitches resample relative to 60. Put drum hits at pitch 60; write melodies around 60.",

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -139,7 +139,8 @@ bool queryTakesArgs(const std::string& verb) {
 // through CommandHistory — a bounce is not an undoable project edit; batch
 // pushes one CommandTransaction so the whole group is a single undo step.
 bool isActionVerb(const std::string& verb) {
-    return verb == "render_pattern" || verb == "render_song" || verb == "batch";
+    return verb == "render_pattern" || verb == "render_song" || verb == "batch" ||
+           verb == "undo" || verb == "redo";
 }
 
 // JSON args -> flag map for the schema/registry path. Returns false with
@@ -774,6 +775,50 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             return finish(response);
         }
 
+        // ------------------------------------------------------------------
+        // undo / redo — drive the same history the UI's Ctrl+Z drives.
+        //
+        // Every mutation verb and every batch already lands there as one step;
+        // without these the surface could build that history but never walk it,
+        // so the only way back from a mistake was to hand-write the inverse
+        // edit. Against the live app these move the user's undo stack, which is
+        // the point: agent edits and hand edits are the same edits.
+        // ------------------------------------------------------------------
+        if (verb == "undo" || verb == "redo") {
+            if (!m_trackManager) {
+                return makeError(id, "execution_error", "no track manager", verb).toString();
+            }
+            if (request.has("args") && request["args"].isObject() &&
+                !request["args"].asObject().empty()) {
+                return makeError(id, "validation_error", verb + " takes no args", verb).toString();
+            }
+
+            CommandHistory& history = m_trackManager->getCommandHistory();
+            const bool undoing = (verb == "undo");
+
+            // An empty history is a refusal, not a silent success: a caller that
+            // gets ok back would reasonably believe an edit was reverted.
+            if (undoing ? !history.canUndo() : !history.canRedo()) {
+                return makeError(id, "execution_error",
+                                 undoing ? "nothing to undo" : "nothing to redo", verb)
+                    .toString();
+            }
+            if (!(undoing ? history.undo() : history.redo())) {
+                return makeError(id, "execution_error",
+                                 std::string(undoing ? "undo" : "redo") + " failed", verb)
+                    .toString();
+            }
+
+            // Report the new ends of the stack so a caller can walk it without
+            // guessing when to stop.
+            JSON result = JSON::object();
+            result.set("canUndo", JSON(history.canUndo()));
+            result.set("canRedo", JSON(history.canRedo()));
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
         if (verb == "batch") {
             if (!m_trackManager) {
                 return makeError(id, "execution_error", "no track manager", verb).toString();
@@ -855,6 +900,18 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 if (!item.isObject() || !item.has("verb") || !item["verb"].isString()) {
                     return failBatch("validation_error",
                                      prefix + "must be an object with a string verb");
+                }
+                // Refuse unknown member keys by name, the way every other args
+                // object here does. Accepting them silently is how a member
+                // written with "flags" instead of "args" runs with NO args and
+                // still reports ok — an add_track that quietly takes its default
+                // name rather than the one asked for.
+                for (auto& memberEntry : item.asObject()) {
+                    if (memberEntry.first != "verb" && memberEntry.first != "args") {
+                        return failBatch("validation_error",
+                                         prefix + "unknown key: " + memberEntry.first +
+                                             " (a member is {\"verb\": ..., \"args\": ...})");
+                    }
                 }
                 const std::string subVerb = item["verb"].asString();
                 if (isQueryVerb(subVerb) || isActionVerb(subVerb)) {

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -1166,23 +1166,46 @@ int main() {
         check(r["result"]["canRedo"].isBool() && !r["result"]["canRedo"].asBool(),
               "redo reports the stack is now at its top");
 
-        // Walk back to the end of the stack, then confirm the refusal. Reporting
-        // a no-op as ok would tell a caller an edit was reverted when none was.
-        int guard = 0;
-        for (; guard < 5000; ++guard) {
-            JSON step = call(service, "{\"id\": 243, \"verb\": \"undo\"}");
-            if (status(step) != "ok") {
-                break;
-            }
-        }
-        check(guard < 5000, "undo terminates rather than succeeding forever");
-        r = call(service, "{\"id\": 244, \"verb\": \"undo\"}");
-        check(status(r) == "execution_error" && r["message"].asString() == "nothing to undo",
-              "undo at the end of the stack refuses by name");
+        // Exhaustion is checked on a FRESH session, not by unwinding the long
+        // history this file has built up. That history contains a delete_track,
+        // and unwinding past one is currently unsafe for reasons that have
+        // nothing to do with undo/redo: DeleteTrackCommand::undo() calls
+        // addChannel(), which mints a NEW MixerChannel with a NEW id at the END
+        // of the vector, so every older command still holding `MixerChannel&`
+        // (SetVolume/SetPan/SetMute/SetSolo and the effect commands all do)
+        // is left dangling. ASan catches it as a heap-use-after-free the moment
+        // one of those older commands is undone.
+        //
+        // That bug predates this change and is reachable from the UI's Ctrl+Z;
+        // it is filed separately rather than smuggled in here. Scoping this
+        // assertion to a clean history tests what this change actually adds
+        // without also driving a broken path it does not own.
+        {
+            auto freshManager = std::make_shared<TrackManager>();
+            freshManager->getUnitManager().setPatternManager(&freshManager->getPatternManager());
+            MuseService fresh(freshManager.get(), &engine);
 
-        r = call(service, "{\"id\": 245, \"verb\": \"undo\", \"args\": {\"steps\": 2}}");
+            JSON f = call(fresh, "{\"id\": 243, \"verb\": \"undo\"}");
+            check(status(f) == "execution_error" && f["message"].asString() == "nothing to undo",
+                  "undo on an untouched session refuses by name");
+            f = call(fresh, "{\"id\": 244, \"verb\": \"redo\"}");
+            check(status(f) == "execution_error" && f["message"].asString() == "nothing to redo",
+                  "redo on an untouched session refuses by name");
+
+            f = call(fresh, "{\"id\": 245, \"verb\": \"add_track\", \"args\": {\"name\": \"Only\"}}");
+            check(status(f) == "ok", "fresh session takes one edit");
+            f = call(fresh, "{\"id\": 246, \"verb\": \"undo\"}");
+            check(status(f) == "ok" && f["result"]["canUndo"].isBool() &&
+                      !f["result"]["canUndo"].asBool(),
+                  "undoing the only edit empties the undo stack");
+            f = call(fresh, "{\"id\": 247, \"verb\": \"undo\"}");
+            check(status(f) == "execution_error",
+                  "a second undo at the end of the stack refuses rather than reporting a no-op");
+        }
+
+        r = call(service, "{\"id\": 248, \"verb\": \"undo\", \"args\": {\"steps\": 2}}");
         check(status(r) == "validation_error", "undo takes no args");
-        r = call(service, "{\"id\": 246, \"verb\": \"redo\", \"args\": {\"steps\": 2}}");
+        r = call(service, "{\"id\": 249, \"verb\": \"redo\", \"args\": {\"steps\": 2}}");
         check(status(r) == "validation_error", "redo takes no args");
 
         // undo/redo act on history, so they are not batch members.

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -1146,6 +1146,81 @@ int main() {
         std::filesystem::remove(outPath);
     }
 
+    // --- undo / redo: the surface can walk the history it writes ------------
+    {
+        const size_t before = trackManager->getChannelCount();
+
+        JSON r = call(service, "{\"id\": 240, \"verb\": \"add_track\", \"args\": {\"name\": \"Undoable\"}}");
+        check(status(r) == "ok", "add_track for the undo case");
+        check(trackManager->getChannelCount() == before + 1, "track was added");
+
+        r = call(service, "{\"id\": 241, \"verb\": \"undo\"}");
+        check(status(r) == "ok", "undo ok");
+        check(trackManager->getChannelCount() == before, "undo removed the track");
+        check(r["result"]["canRedo"].isBool() && r["result"]["canRedo"].asBool(),
+              "undo reports that a redo is now available");
+
+        r = call(service, "{\"id\": 242, \"verb\": \"redo\"}");
+        check(status(r) == "ok", "redo ok");
+        check(trackManager->getChannelCount() == before + 1, "redo restored the track");
+        check(r["result"]["canRedo"].isBool() && !r["result"]["canRedo"].asBool(),
+              "redo reports the stack is now at its top");
+
+        // Walk back to the end of the stack, then confirm the refusal. Reporting
+        // a no-op as ok would tell a caller an edit was reverted when none was.
+        int guard = 0;
+        for (; guard < 5000; ++guard) {
+            JSON step = call(service, "{\"id\": 243, \"verb\": \"undo\"}");
+            if (status(step) != "ok") {
+                break;
+            }
+        }
+        check(guard < 5000, "undo terminates rather than succeeding forever");
+        r = call(service, "{\"id\": 244, \"verb\": \"undo\"}");
+        check(status(r) == "execution_error" && r["message"].asString() == "nothing to undo",
+              "undo at the end of the stack refuses by name");
+
+        r = call(service, "{\"id\": 245, \"verb\": \"undo\", \"args\": {\"steps\": 2}}");
+        check(status(r) == "validation_error", "undo takes no args");
+        r = call(service, "{\"id\": 246, \"verb\": \"redo\", \"args\": {\"steps\": 2}}");
+        check(status(r) == "validation_error", "redo takes no args");
+
+        // undo/redo act on history, so they are not batch members.
+        r = call(service,
+                 "{\"id\": 247, \"verb\": \"batch\", \"args\": {\"commands\": [{\"verb\": \"undo\"}]}}");
+        check(status(r) == "validation_error", "undo is rejected inside a batch");
+    }
+
+    // --- a batch member takes only verb and args ----------------------------
+    {
+        const size_t before = trackManager->getChannelCount();
+
+        // The real mistake this catches: "flags" instead of "args". It used to
+        // run with NO args and report ok, silently creating a default-named
+        // track instead of the one asked for.
+        JSON r = call(service,
+                      "{\"id\": 250, \"verb\": \"batch\", \"args\": {\"commands\": [{\"verb\": "
+                      "\"add_track\", \"flags\": {\"name\": \"Typo\"}}]}}");
+        check(status(r) == "validation_error", "batch member with 'flags' is refused");
+        check(r["message"].asString().find("unknown key: flags") != std::string::npos,
+              "the refusal names the offending key");
+        check(r["message"].asString().find("commands[0]") != std::string::npos,
+              "the refusal names the offending member");
+        check(trackManager->getChannelCount() == before,
+              "a refused batch member adds nothing");
+
+        // The correct spelling still works, and lands as one undo step.
+        r = call(service,
+                 "{\"id\": 251, \"verb\": \"batch\", \"args\": {\"commands\": [{\"verb\": "
+                 "\"add_track\", \"args\": {\"name\": \"Correct\"}}]}}");
+        check(status(r) == "ok", "batch member with 'args' is accepted");
+        check(trackManager->getChannelCount() == before + 1, "the batch added its track");
+
+        r = call(service, "{\"id\": 252, \"verb\": \"undo\"}");
+        check(status(r) == "ok" && trackManager->getChannelCount() == before,
+              "the whole batch undoes as a single step");
+    }
+
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
               << std::endl;
     return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
Two holes found by *driving* the Muse surface by hand rather than reading it. Both surfaced while building the `muse` CLI (#609), but neither is CLI-specific — they're gaps in the surface itself, so they land separately and independently.

## 1. There was no way to undo

The schema's own notes say:

> "Every mutation and every batch is one step in the same undo history the UI uses."

True — and unreachable. Nothing on the surface could walk that history. The only way back from a mistake was to hand-write the inverse edit, which for anything structural is neither obvious nor always possible.

`undo` and `redo` are service actions: they act on history, not on the project. That means they're rejected inside a `batch`, where they'd be incoherent.

**An exhausted history refuses rather than returning ok.** `nothing to undo` is an error, not a success with no effect. A no-op reported as `ok` is worse than an error here — a caller has every reason to read `ok` as "the edit was reverted" and carry on from a state that never changed. The result carries `canUndo`/`canRedo` so a caller can walk the stack without guessing where it ends.

Against the live app these move the *user's* undo stack, which is the design: agent edits and hand edits are the same edits.

## 2. A batch member silently accepted unknown keys

I hit this for real by writing `flags` instead of `args`:

```json
{"verb": "batch", "args": {"commands": [{"verb": "add_track", "flags": {"name": "Drums"}}]}}
```

The member ran **with no args at all** and the batch reported `ok` — quietly creating a default-named track instead of the one asked for. Every other args object in this service refuses unknown keys by name (`unknown arg for get_effects: ...`), so this was inconsistent as well as quietly wrong.

Members now take only `verb` and `args`, and the refusal names both the offending key and the member index:

```
commands[0]: unknown key: flags (a member is {"verb": ..., "args": ...})
```

## Tests

Covered in `MuseServiceTest`: undo/redo round-trip, `canRedo` transitions, refusal at both ends of the stack, args rejection, `undo` refused inside a batch, the `flags`-instead-of-`args` case naming both key and index, that a refused member adds nothing, and that a batch undoes as a single step.

Neutralising either fix turns the new assertions red — I checked rather than assumed, since a passing test proves nothing about a bug it was never able to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)