### PR TITLE
Muse: HostVerbRegistry — the seam that lets an agent operate Aestra

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -250,6 +250,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/CommandRegistry.cpp
     src/Commands/SessionLog.cpp
     src/Commands/MuseStubs.cpp
+    src/Commands/HostVerbRegistry.cpp
     src/Commands/MuseService.cpp
     src/Commands/MuseSocketServer.cpp
     

--- a/AestraAudio/include/Commands/HostVerbRegistry.h
+++ b/AestraAudio/include/Commands/HostVerbRegistry.h
@@ -6,6 +6,7 @@
 #include "AestraJSON.h"
 
 #include <functional>
+#include <limits> // HostVerbArg's NaN bounds — not left to reach us transitively
 #include <map>
 #include <string>
 #include <vector>
@@ -169,6 +170,9 @@ public:
     /** @brief The domain prefix for a name, or empty when it has none. */
     static std::string domainPrefixOf(const std::string& name);
     static const char* domainName(HostVerbDomain domain);
+    /** @brief Wire name for an argument type. One table, so a new FlagType cannot
+     *         be added to half the places that render it. */
+    static const char* argTypeName(FlagType type);
 
 private:
     struct Entry {

--- a/AestraAudio/include/Commands/HostVerbRegistry.h
+++ b/AestraAudio/include/Commands/HostVerbRegistry.h
@@ -1,0 +1,182 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/MuseGrammar.h" // FlagType
+
+#include "AestraJSON.h"
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @file HostVerbRegistry.h
+ * @brief The seam that lets Muse operate Aestra, not just its audio engine.
+ *
+ * MuseService lives in AestraAudio and can therefore only reach what
+ * AestraAudio owns. Settings, view navigation, the browser and dialogs live in
+ * the application layer, so until now they were structurally unreachable — the
+ * agent could change a gain but not open the mixer.
+ *
+ * The fix is NOT for AestraAudio to reach up into Source/; that would invert
+ * the dependency the whole codebase is built on. Instead the application
+ * registers its capabilities INTO this registry at startup:
+ *
+ *     Source/ ────registers────> MuseService
+ *                                    ^
+ *     Muse CLI / agent ───────────────┘
+ *
+ * MuseService never learns what a SettingsDialog or a TrackManagerUI is. It
+ * holds a name, an argument schema, and a callable.
+ *
+ * ## A verb is an application capability, not a UI gesture
+ *
+ * Register `view.openMixer`, `settings.setAudioDevice`, `browser.search`.
+ * Never `clickMixerButton` or `pressBrowserSearchField`. The first survives a
+ * UI redesign and lets Muse operate Aestra semantically; the second makes Muse
+ * an accessibility macro system welded to today's widgets, and every future
+ * layout change silently breaks it.
+ *
+ * This is why registration requires a declared domain and a typed argument
+ * schema rather than accepting an arbitrary `(name, std::function<JSON(JSON)>)`
+ * pair. A generic escape hatch would become an undocumented internal RPC API
+ * within a release or two, and nothing in the type system would object.
+ */
+
+/** @brief The capability domains the host may register into. */
+enum class HostVerbDomain {
+    Project,  ///< project/session lifecycle: save, load, export targets
+    Settings, ///< application preferences and device configuration
+    View,     ///< navigation between workspaces and panels
+    Browser,  ///< the file/sample/plugin browser
+    Dialog    ///< modal flows the host owns
+};
+
+/**
+ * @brief Where a verb is allowed to run.
+ *
+ * Host capabilities almost always touch UI-owned state, which is main-thread
+ * only. Headless processes (MuseRepl, tests) have no such thread at all, so
+ * this is not merely a marshalling hint: it decides whether a verb can be
+ * honoured in this process or must be refused with a reason.
+ */
+enum class HostThreadAffinity {
+    Any,         ///< safe to run wherever the request arrives
+    HostUiThread ///< requires the host's UI thread; refused where there is none
+};
+
+/** @brief One typed argument. Mirrors FlagSchema so both render alike in the manifest. */
+struct HostVerbArg {
+    std::string name;
+    FlagType type = FlagType::String;
+    bool required = false;
+    double minValue = std::numeric_limits<double>::quiet_NaN();
+    double maxValue = std::numeric_limits<double>::quiet_NaN();
+    std::string description;
+};
+
+/**
+ * @brief What a host verb returns.
+ *
+ * Deliberately not "arbitrary JSON". A handler must say whether it succeeded,
+ * and a failure must carry a machine-readable code — agents that have to
+ * pattern-match prose to find out what happened will do it badly, and the code
+ * is what lets a caller distinguish "no such device" from "device busy"
+ * without parsing English.
+ */
+struct HostVerbResult {
+    bool ok = false;
+    std::string errorCode; ///< empty when ok; snake_case, e.g. "no_such_device"
+    std::string message;   ///< human-readable detail, never the API contract
+    JSON result = JSON::object();
+
+    static HostVerbResult success(JSON payload = JSON::object()) {
+        HostVerbResult r;
+        r.ok = true;
+        r.result = std::move(payload);
+        return r;
+    }
+    static HostVerbResult failure(std::string code, std::string detail) {
+        HostVerbResult r;
+        r.ok = false;
+        r.errorCode = std::move(code);
+        r.message = std::move(detail);
+        return r;
+    }
+};
+
+/** @brief Everything the registry knows about a capability, minus its implementation. */
+struct HostVerbSpec {
+    std::string name; ///< "<domain>.<lowerCamelCase>", e.g. "settings.setAudioDevice"
+    HostVerbDomain domain = HostVerbDomain::View;
+    std::vector<HostVerbArg> args;
+    HostThreadAffinity affinity = HostThreadAffinity::HostUiThread;
+    /** True when the verb changes persistent state a user would expect to undo or save. */
+    bool mutates = false;
+    std::string description;
+};
+
+using HostVerbHandler = std::function<HostVerbResult(const JSON& args)>;
+
+/**
+ * @brief Names the host may register, and the validation every call passes.
+ *
+ * Not thread-safe by construction: registration happens once during host
+ * startup, before any request can arrive, and invocation is serialised by
+ * MuseService onto the thread that owns it.
+ */
+class HostVerbRegistry {
+public:
+    enum class RegisterStatus {
+        Ok,
+        NameMalformed,  ///< not "<domain>.<name>", or the name part is empty/ill-formed
+        DomainMismatch, ///< the prefix does not match the declared domain
+        ReservedDomain, ///< "audio." belongs to the native engine surface
+        Duplicate,      ///< already registered
+        NoHandler
+    };
+
+    /**
+     * @param outError filled with a message naming the offending part.
+     * @note Registration is refused rather than overwritten. A silent
+     *       last-one-wins would make two components fight over a capability
+     *       with no diagnostic and a load-order-dependent winner.
+     */
+    RegisterStatus registerVerb(HostVerbSpec spec, HostVerbHandler handler, std::string& outError);
+
+    bool has(const std::string& name) const;
+    size_t size() const { return m_verbs.size(); }
+
+    /**
+     * @brief Validate arguments, check thread affinity, then invoke.
+     *
+     * @param hostUiThreadAvailable false in headless processes; HostUiThread
+     *        verbs are refused with "host_unavailable" rather than run somewhere
+     *        they would corrupt UI state.
+     * @return a failure result when validation or affinity refuses; the
+     *         handler's own result otherwise.
+     */
+    HostVerbResult invoke(const std::string& name, const JSON& args,
+                          bool hostUiThreadAvailable) const;
+
+    /** @brief Every registered capability, ordered by name. The answer to "what can this host do?". */
+    std::vector<HostVerbSpec> capabilities() const;
+
+    /** @brief The domain prefix for a name, or empty when it has none. */
+    static std::string domainPrefixOf(const std::string& name);
+    static const char* domainName(HostVerbDomain domain);
+
+private:
+    struct Entry {
+        HostVerbSpec spec;
+        HostVerbHandler handler;
+    };
+    std::map<std::string, Entry> m_verbs; ///< ordered so enumeration is deterministic
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MuseService.h
+++ b/AestraAudio/include/Commands/MuseService.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include "Commands/HostVerbRegistry.h"
 #include <memory>
 #include <string>
 
@@ -50,9 +51,35 @@ public:
     static void wireHeadlessEngine(const std::shared_ptr<TrackManager>& trackManager,
                                    AudioEngine& engine);
 
+    /**
+     * @brief The seam the application registers its capabilities into.
+     *
+     * MuseService cannot reach the UI layer — the dependency runs the other
+     * way. The host calls this during startup to register `settings.*`,
+     * `view.*`, `browser.*`, `dialog.*` and `project.*` verbs; MuseService
+     * only ever sees a name, an argument schema and a callable. See
+     * HostVerbRegistry.h for why this is a typed registry rather than a
+     * generic (name, function) escape hatch.
+     */
+    HostVerbRegistry& hostVerbs() { return m_hostVerbs; }
+    const HostVerbRegistry& hostVerbs() const { return m_hostVerbs; }
+
+    /**
+     * @brief Declare that requests run where the host's UI thread lives.
+     *
+     * Default false, so a headless process refuses UI-affine host verbs with
+     * a reason instead of running host code on a thread that does not own the
+     * state it touches. The in-app socket server executes requests from the
+     * main-thread pump, so AestraApp sets this true.
+     */
+    void setHostUiThreadAvailable(bool available) { m_hostUiThreadAvailable = available; }
+    bool hostUiThreadAvailable() const { return m_hostUiThreadAvailable; }
+
 private:
     TrackManager* m_trackManager = nullptr;
     AudioEngine* m_engine = nullptr;
+    HostVerbRegistry m_hostVerbs;
+    bool m_hostUiThreadAvailable = false;
 };
 
 } // namespace Audio

--- a/AestraAudio/src/Commands/HostVerbRegistry.cpp
+++ b/AestraAudio/src/Commands/HostVerbRegistry.cpp
@@ -25,16 +25,6 @@ bool isLowerCamelIdentifier(const std::string& text) {
     });
 }
 
-const char* flagTypeName(FlagType type) {
-    switch (type) {
-    case FlagType::String: return "string";
-    case FlagType::Int:    return "int";
-    case FlagType::Float:  return "float";
-    case FlagType::Bool:   return "bool";
-    }
-    return "string";
-}
-
 // Validate a JSON value against one typed argument. JSON carries real types,
 // so unlike the text-flag path there is nothing to parse — only to check.
 bool valueMatches(const HostVerbArg& arg, const JSON& value, std::string& outError) {
@@ -85,6 +75,16 @@ bool valueMatches(const HostVerbArg& arg, const JSON& value, std::string& outErr
 
 } // namespace
 
+const char* HostVerbRegistry::argTypeName(FlagType type) {
+    switch (type) {
+    case FlagType::String: return "string";
+    case FlagType::Int:    return "int";
+    case FlagType::Float:  return "float";
+    case FlagType::Bool:   return "bool";
+    }
+    return "string";
+}
+
 const char* HostVerbRegistry::domainName(HostVerbDomain domain) {
     switch (domain) {
     case HostVerbDomain::Project:  return "project";
@@ -114,14 +114,13 @@ HostVerbRegistry::RegisterStatus HostVerbRegistry::registerVerb(HostVerbSpec spe
         return RegisterStatus::ReservedDomain;
     }
 
-    const size_t dot = spec.name.find('.');
-    if (dot == std::string::npos) {
+    const std::string prefix = domainPrefixOf(spec.name);
+    if (prefix.empty()) {
         outError = "host verb '" + spec.name +
                    "' must be named <domain>.<capability>, e.g. settings.setAudioDevice";
         return RegisterStatus::NameMalformed;
     }
-    const std::string prefix = spec.name.substr(0, dot);
-    const std::string capability = spec.name.substr(dot + 1);
+    const std::string capability = spec.name.substr(prefix.size() + 1);
     if (!isLowerCamelIdentifier(capability) || capability.find('.') != std::string::npos) {
         outError = "'" + capability + "' is not a lowerCamelCase capability name";
         return RegisterStatus::NameMalformed;
@@ -183,6 +182,11 @@ HostVerbResult HostVerbRegistry::invoke(const std::string& name, const JSON& arg
     // Checked BEFORE required args on purpose. Typing "framez" for "frames"
     // otherwise reports the required arg as missing, which sends the caller
     // looking for an argument they did in fact pass, spelled wrong.
+    // The non-const copy is load-bearing: JSON's const asObject() returns an
+    // EMPTY static, while the non-const overload returns the real map by value.
+    // Inlining provided.asObject() here would make this loop iterate nothing and
+    // silently stop rejecting misspelled args. Same footgun as jsonArgsToFlags
+    // in MuseService.cpp.
     JSON mutableArgs = provided;
     for (const auto& entry : mutableArgs.asObject()) {
         const bool declared =
@@ -200,7 +204,7 @@ HostVerbResult HostVerbRegistry::invoke(const std::string& name, const JSON& arg
             if (arg.required) {
                 return HostVerbResult::failure("missing_arg",
                                                "'" + name + "' requires arg '" + arg.name + "' (" +
-                                                   flagTypeName(arg.type) + ")");
+                                                   argTypeName(arg.type) + ")");
             }
             continue;
         }

--- a/AestraAudio/src/Commands/HostVerbRegistry.cpp
+++ b/AestraAudio/src/Commands/HostVerbRegistry.cpp
@@ -1,0 +1,226 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/HostVerbRegistry.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+namespace {
+
+// The native engine surface (set_bpm, list_units, …) is conceptually the
+// audio.* domain, but those verbs are unprefixed for compatibility — renaming
+// 44 of them would break every existing caller and the published manifest.
+// Reserving the prefix keeps the conceptual model honest: nothing may register
+// a host verb that claims to be engine capability.
+constexpr const char* kReservedDomainPrefix = "audio.";
+
+bool isLowerCamelIdentifier(const std::string& text) {
+    if (text.empty() || !std::islower(static_cast<unsigned char>(text.front()))) {
+        return false;
+    }
+    return std::all_of(text.begin(), text.end(), [](unsigned char c) {
+        return std::isalnum(c) != 0;
+    });
+}
+
+const char* flagTypeName(FlagType type) {
+    switch (type) {
+    case FlagType::String: return "string";
+    case FlagType::Int:    return "int";
+    case FlagType::Float:  return "float";
+    case FlagType::Bool:   return "bool";
+    }
+    return "string";
+}
+
+// Validate a JSON value against one typed argument. JSON carries real types,
+// so unlike the text-flag path there is nothing to parse — only to check.
+bool valueMatches(const HostVerbArg& arg, const JSON& value, std::string& outError) {
+    switch (arg.type) {
+    case FlagType::Bool:
+        if (!value.isBool()) {
+            outError = "arg '" + arg.name + "' must be a bool";
+            return false;
+        }
+        return true;
+    case FlagType::String:
+        if (!value.isString()) {
+            outError = "arg '" + arg.name + "' must be a string";
+            return false;
+        }
+        return true;
+    case FlagType::Int:
+    case FlagType::Float: {
+        if (!value.isNumber()) {
+            outError = "arg '" + arg.name + "' must be a number";
+            return false;
+        }
+        const double number = value.asNumber();
+        if (!std::isfinite(number)) {
+            outError = "arg '" + arg.name + "' must be finite";
+            return false;
+        }
+        if (arg.type == FlagType::Int && number != std::floor(number)) {
+            outError = "arg '" + arg.name + "' must be a whole number";
+            return false;
+        }
+        if (!std::isnan(arg.minValue) && number < arg.minValue) {
+            outError = "arg '" + arg.name + "' is below its minimum of " +
+                       std::to_string(arg.minValue);
+            return false;
+        }
+        if (!std::isnan(arg.maxValue) && number > arg.maxValue) {
+            outError = "arg '" + arg.name + "' is above its maximum of " +
+                       std::to_string(arg.maxValue);
+            return false;
+        }
+        return true;
+    }
+    }
+    outError = "arg '" + arg.name + "' has an unknown type";
+    return false;
+}
+
+} // namespace
+
+const char* HostVerbRegistry::domainName(HostVerbDomain domain) {
+    switch (domain) {
+    case HostVerbDomain::Project:  return "project";
+    case HostVerbDomain::Settings: return "settings";
+    case HostVerbDomain::View:     return "view";
+    case HostVerbDomain::Browser:  return "browser";
+    case HostVerbDomain::Dialog:   return "dialog";
+    }
+    return "";
+}
+
+std::string HostVerbRegistry::domainPrefixOf(const std::string& name) {
+    const size_t dot = name.find('.');
+    return dot == std::string::npos ? std::string() : name.substr(0, dot);
+}
+
+HostVerbRegistry::RegisterStatus HostVerbRegistry::registerVerb(HostVerbSpec spec,
+                                                               HostVerbHandler handler,
+                                                               std::string& outError) {
+    if (!handler) {
+        outError = "no handler for " + spec.name;
+        return RegisterStatus::NoHandler;
+    }
+
+    if (spec.name.rfind(kReservedDomainPrefix, 0) == 0) {
+        outError = "the audio. domain is the native engine surface and cannot be registered into";
+        return RegisterStatus::ReservedDomain;
+    }
+
+    const size_t dot = spec.name.find('.');
+    if (dot == std::string::npos) {
+        outError = "host verb '" + spec.name +
+                   "' must be named <domain>.<capability>, e.g. settings.setAudioDevice";
+        return RegisterStatus::NameMalformed;
+    }
+    const std::string prefix = spec.name.substr(0, dot);
+    const std::string capability = spec.name.substr(dot + 1);
+    if (!isLowerCamelIdentifier(capability) || capability.find('.') != std::string::npos) {
+        outError = "'" + capability + "' is not a lowerCamelCase capability name";
+        return RegisterStatus::NameMalformed;
+    }
+    if (prefix != domainName(spec.domain)) {
+        outError = "'" + spec.name + "' is prefixed '" + prefix + "' but declares domain '" +
+                   domainName(spec.domain) + "'";
+        return RegisterStatus::DomainMismatch;
+    }
+
+    for (const auto& arg : spec.args) {
+        if (arg.name.empty()) {
+            outError = "'" + spec.name + "' declares an argument with no name";
+            return RegisterStatus::NameMalformed;
+        }
+    }
+
+    if (m_verbs.find(spec.name) != m_verbs.end()) {
+        outError = "'" + spec.name + "' is already registered";
+        return RegisterStatus::Duplicate;
+    }
+
+    const std::string name = spec.name;
+    m_verbs.emplace(name, Entry{std::move(spec), std::move(handler)});
+    return RegisterStatus::Ok;
+}
+
+bool HostVerbRegistry::has(const std::string& name) const {
+    return m_verbs.find(name) != m_verbs.end();
+}
+
+HostVerbResult HostVerbRegistry::invoke(const std::string& name, const JSON& args,
+                                        bool hostUiThreadAvailable) const {
+    const auto it = m_verbs.find(name);
+    if (it == m_verbs.end()) {
+        return HostVerbResult::failure("unknown_verb", "no host verb named '" + name + "'");
+    }
+    const HostVerbSpec& spec = it->second.spec;
+
+    if (spec.affinity == HostThreadAffinity::HostUiThread && !hostUiThreadAvailable) {
+        // Not a marshalling problem: this process has no UI thread to marshal
+        // onto. Say so, rather than running host code somewhere undefined.
+        return HostVerbResult::failure(
+            "host_unavailable",
+            "'" + name + "' needs the application's UI thread; this session is headless");
+    }
+
+    // Args are optional only if every declared argument is optional.
+    JSON empty = JSON::object();
+    const JSON& provided = args.isObject() ? args : empty;
+    if (!args.isNull() && !args.isObject()) {
+        return HostVerbResult::failure("invalid_args", "args must be an object");
+    }
+
+    // Unknown args are refused by name, matching the rest of this surface: a
+    // misspelled argument that is silently dropped runs the verb with a default
+    // the caller never asked for and reports success.
+    //
+    // Checked BEFORE required args on purpose. Typing "framez" for "frames"
+    // otherwise reports the required arg as missing, which sends the caller
+    // looking for an argument they did in fact pass, spelled wrong.
+    JSON mutableArgs = provided;
+    for (const auto& entry : mutableArgs.asObject()) {
+        const bool declared =
+            std::any_of(spec.args.begin(), spec.args.end(),
+                        [&](const HostVerbArg& arg) { return arg.name == entry.first; });
+        if (!declared) {
+            return HostVerbResult::failure("invalid_args",
+                                           "unknown arg for " + name + ": " + entry.first);
+        }
+    }
+
+    for (const auto& arg : spec.args) {
+        const bool present = provided.has(arg.name);
+        if (!present) {
+            if (arg.required) {
+                return HostVerbResult::failure("missing_arg",
+                                               "'" + name + "' requires arg '" + arg.name + "' (" +
+                                                   flagTypeName(arg.type) + ")");
+            }
+            continue;
+        }
+        std::string typeError;
+        if (!valueMatches(arg, provided[arg.name], typeError)) {
+            return HostVerbResult::failure("invalid_args", typeError);
+        }
+    }
+
+    return it->second.handler(provided);
+}
+
+std::vector<HostVerbSpec> HostVerbRegistry::capabilities() const {
+    std::vector<HostVerbSpec> out;
+    out.reserve(m_verbs.size());
+    for (const auto& entry : m_verbs) {
+        out.push_back(entry.second.spec);
+    }
+    return out; // m_verbs is ordered, so enumeration is stable across calls
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -126,7 +126,8 @@ bool isQueryVerb(const std::string& verb) {
     return verb == "get_transport" || verb == "list_tracks" || verb == "list_clips" ||
            verb == "get_session_state" || verb == "list_units" || verb == "get_pattern" ||
            verb == "list_patterns" || verb == "list_plugins" || verb == "get_effects" ||
-           verb == "list_samples" || verb == "get_meters" || verb == "get_schema";
+           verb == "list_samples" || verb == "get_meters" || verb == "get_schema" ||
+           verb == "get_capabilities";
 }
 
 // The few queries that take arguments; every other query rejects them.
@@ -220,6 +221,16 @@ const char* unitTypeName(UnitType type) {
     return "unknown";
 }
 
+const char* hostArgTypeName(FlagType type) {
+    switch (type) {
+    case FlagType::String: return "string";
+    case FlagType::Int:    return "int";
+    case FlagType::Float:  return "float";
+    case FlagType::Bool:   return "bool";
+    }
+    return "string";
+}
+
 bool isKnownVerb(const std::string& verb) {
     if (isQueryVerb(verb) || isActionVerb(verb)) return true;
     for (const auto& cmd : MuseGrammar::allCommands()) {
@@ -263,15 +274,21 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
         }
         verb = request["verb"].asString();
 
+        // Host verbs are namespaced (settings.setAudioDevice) and validated by
+        // the registry, which owns their argument schemas. Built-ins are
+        // checked here. A host verb can never shadow a built-in: the registry
+        // refuses the reserved audio. prefix and every built-in is unprefixed.
+        const bool isHostVerb = m_hostVerbs.has(verb);
+
         // Classify the verb before any dependency checks so protocol status
         // never depends on how the service happens to be wired.
-        if (!isKnownVerb(verb)) {
+        if (!isHostVerb && !isKnownVerb(verb)) {
             return makeError(id, "parse_error", "unknown command: " + verb).toString();
         }
 
         // Most queries take no arguments; accepting any would silently drop
         // caller intent.
-        if (isQueryVerb(verb) && !queryTakesArgs(verb) && request.has("args") &&
+        if (!isHostVerb && isQueryVerb(verb) && !queryTakesArgs(verb) && request.has("args") &&
             request["args"].size() > 0) {
             return makeError(id, "validation_error", verb + " takes no arguments", verb).toString();
         }
@@ -429,6 +446,72 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             }
             JSON result = JSON::object();
             result.set("units", units);
+            JSON response = makeOk();
+            response.set("result", result);
+            return finish(response);
+        }
+
+        // ------------------------------------------------------------------
+        // Host verbs: capabilities the application registered into the seam.
+        // MuseService does not know what any of them do — it validates against
+        // the declared schema, checks that this process can honour the verb's
+        // thread affinity, and calls the handler.
+        // ------------------------------------------------------------------
+        if (isHostVerb) {
+            JSON noArgs = JSON::object();
+            const JSON& hostArgs = request.has("args") ? request["args"] : noArgs;
+            const HostVerbResult hostResult =
+                m_hostVerbs.invoke(verb, hostArgs, m_hostUiThreadAvailable);
+
+            if (!hostResult.ok) {
+                // The registry's own refusals are argument/affinity problems;
+                // anything else is the host declining to do the thing. Keep the
+                // machine-readable code in the response so callers never have to
+                // pattern-match prose to tell them apart.
+                const bool validation = hostResult.errorCode == "invalid_args" ||
+                                        hostResult.errorCode == "missing_arg" ||
+                                        hostResult.errorCode == "unknown_verb";
+                JSON response = makeError(id, validation ? "validation_error" : "execution_error",
+                                          hostResult.message, verb);
+                response.set("errorCode", JSON(hostResult.errorCode));
+                return finish(response);
+            }
+
+            JSON response = makeOk();
+            response.set("result", hostResult.result);
+            return finish(response);
+        }
+
+        if (verb == "get_capabilities") {
+            // "What can this host do?" — so an agent discovers the surface
+            // instead of hardcoding assumptions about which build it is talking
+            // to. A headless session legitimately answers with an empty list.
+            JSON verbs = JSON::array();
+            for (const auto& spec : m_hostVerbs.capabilities()) {
+                JSON entry = JSON::object();
+                entry.set("verb", JSON(spec.name));
+                entry.set("domain", JSON(std::string(HostVerbRegistry::domainName(spec.domain))));
+                entry.set("description", JSON(spec.description));
+                entry.set("mutates", JSON(spec.mutates));
+                entry.set("requiresHostUi",
+                          JSON(spec.affinity == HostThreadAffinity::HostUiThread));
+                JSON args = JSON::array();
+                for (const auto& arg : spec.args) {
+                    JSON a = JSON::object();
+                    a.set("name", JSON(arg.name));
+                    a.set("type", JSON(std::string(hostArgTypeName(arg.type))));
+                    a.set("required", JSON(arg.required));
+                    if (!arg.description.empty()) a.set("description", JSON(arg.description));
+                    if (!std::isnan(arg.minValue)) a.set("min", JSON(arg.minValue));
+                    if (!std::isnan(arg.maxValue)) a.set("max", JSON(arg.maxValue));
+                    args.push(a);
+                }
+                entry.set("args", args);
+                verbs.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("hostVerbs", verbs);
+            result.set("hostUiAvailable", JSON(m_hostUiThreadAvailable));
             JSON response = makeOk();
             response.set("result", result);
             return finish(response);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -221,16 +221,6 @@ const char* unitTypeName(UnitType type) {
     return "unknown";
 }
 
-const char* hostArgTypeName(FlagType type) {
-    switch (type) {
-    case FlagType::String: return "string";
-    case FlagType::Int:    return "int";
-    case FlagType::Float:  return "float";
-    case FlagType::Bool:   return "bool";
-    }
-    return "string";
-}
-
 bool isKnownVerb(const std::string& verb) {
     if (isQueryVerb(verb) || isActionVerb(verb)) return true;
     for (const auto& cmd : MuseGrammar::allCommands()) {
@@ -499,7 +489,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 for (const auto& arg : spec.args) {
                     JSON a = JSON::object();
                     a.set("name", JSON(arg.name));
-                    a.set("type", JSON(std::string(hostArgTypeName(arg.type))));
+                    a.set("type", JSON(std::string(HostVerbRegistry::argTypeName(arg.type))));
                     a.set("required", JSON(arg.required));
                     if (!arg.description.empty()) a.set("description", JSON(arg.description));
                     if (!std::isnan(arg.minValue)) a.set("min", JSON(arg.minValue));

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2168,6 +2168,15 @@ target_include_directories(DeleteTrackUndoTest PRIVATE
 add_test(NAME DeleteTrackUndoTest COMMAND DeleteTrackUndoTest)
 set_tests_properties(DeleteTrackUndoTest PROPERTIES LABELS "commands;regression")
 
+add_executable(HostVerbRegistryTest Commands/HostVerbRegistryTest.cpp)
+target_link_libraries(HostVerbRegistryTest PRIVATE AestraAudioCore)
+target_include_directories(HostVerbRegistryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME HostVerbRegistryTest COMMAND HostVerbRegistryTest)
+set_tests_properties(HostVerbRegistryTest PROPERTIES LABELS "commands;muse")
+
 add_executable(MuseSocketServerTest Commands/MuseSocketServerTest.cpp)
 target_link_libraries(MuseSocketServerTest PRIVATE AestraAudioCore)
 target_include_directories(MuseSocketServerTest PRIVATE

--- a/Tests/Commands/HostVerbRegistryTest.cpp
+++ b/Tests/Commands/HostVerbRegistryTest.cpp
@@ -1,0 +1,291 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// The seam that lets Muse operate Aestra rather than only its audio engine.
+// Covers the registry's contract (naming, typed args, thread affinity,
+// enumeration) and its dispatch through MuseService — including that a
+// headless session refuses UI-affine verbs instead of running host code on a
+// thread that does not own the state it touches.
+
+#include "Commands/HostVerbRegistry.h"
+#include "Commands/MuseService.h"
+#include "Core/AudioEngine.h"
+#include "Models/TrackManager.h"
+
+#include "AestraJSON.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Aestra::JSON;
+using Aestra::Audio::AudioEngine;
+using Aestra::Audio::FlagType;
+using Aestra::Audio::HostThreadAffinity;
+using Aestra::Audio::HostVerbArg;
+using Aestra::Audio::HostVerbDomain;
+using Aestra::Audio::HostVerbRegistry;
+using Aestra::Audio::HostVerbResult;
+using Aestra::Audio::HostVerbSpec;
+using Aestra::Audio::MuseService;
+using Aestra::Audio::TrackManager;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << "\n";
+    } else {
+        std::cout << "FAIL: " << label << "\n";
+        ++g_failures;
+    }
+}
+
+HostVerbSpec spec(const std::string& name, HostVerbDomain domain,
+                  HostThreadAffinity affinity = HostThreadAffinity::Any) {
+    HostVerbSpec s;
+    s.name = name;
+    s.domain = domain;
+    s.affinity = affinity;
+    s.description = "test capability";
+    return s;
+}
+
+JSON args1(const std::string& key, const JSON& value) {
+    JSON a = JSON::object();
+    a.set(key, value);
+    return a;
+}
+
+JSON call(MuseService& service, const std::string& request) {
+    return JSON::parse(service.handleRequest(request));
+}
+
+std::string status(JSON& response) {
+    return response.has("status") ? response["status"].asString() : "<missing>";
+}
+
+} // namespace
+
+int main() {
+    // --- naming: a verb must declare a domain, and match it -----------------
+    {
+        HostVerbRegistry registry;
+        std::string error;
+        const auto ok = [&](const std::string& name, HostVerbDomain d) {
+            return registry.registerVerb(spec(name, d), [](const JSON&) {
+                return HostVerbResult::success();
+            }, error);
+        };
+
+        check(ok("view.openMixer", HostVerbDomain::View) == HostVerbRegistry::RegisterStatus::Ok,
+              "a well-formed capability registers");
+        check(registry.has("view.openMixer"), "and is then known by name");
+
+        check(ok("openMixer", HostVerbDomain::View) == HostVerbRegistry::RegisterStatus::NameMalformed,
+              "an unnamespaced verb is refused");
+        check(error.find("<domain>.<capability>") != std::string::npos,
+              "the refusal shows the expected shape");
+
+        check(ok("view.Open Mixer", HostVerbDomain::View) ==
+                  HostVerbRegistry::RegisterStatus::NameMalformed,
+              "a capability name that is not lowerCamelCase is refused");
+
+        check(ok("settings.openMixer", HostVerbDomain::View) ==
+                  HostVerbRegistry::RegisterStatus::DomainMismatch,
+              "a prefix that contradicts the declared domain is refused");
+        check(error.find("settings") != std::string::npos && error.find("view") != std::string::npos,
+              "the mismatch names both sides");
+
+        // The native engine surface is conceptually audio.*; nothing may
+        // register a host verb claiming to be engine capability.
+        check(ok("audio.setBpm", HostVerbDomain::Settings) ==
+                  HostVerbRegistry::RegisterStatus::ReservedDomain,
+              "the audio. domain is reserved");
+
+        check(ok("view.openMixer", HostVerbDomain::View) ==
+                  HostVerbRegistry::RegisterStatus::Duplicate,
+              "re-registering a name is refused, not silently overwritten");
+
+        HostVerbSpec noHandler = spec("view.openBrowser", HostVerbDomain::View);
+        check(registry.registerVerb(noHandler, nullptr, error) ==
+                  HostVerbRegistry::RegisterStatus::NoHandler,
+              "a spec with no handler is refused");
+    }
+
+    // --- typed arguments -----------------------------------------------------
+    {
+        HostVerbRegistry registry;
+        std::string error;
+
+        HostVerbSpec s = spec("settings.setBufferSize", HostVerbDomain::Settings);
+        s.args.push_back(HostVerbArg{"frames", FlagType::Int, true, 32.0, 8192.0, "block size"});
+        s.args.push_back(HostVerbArg{"exclusive", FlagType::Bool, false,
+                                     std::numeric_limits<double>::quiet_NaN(),
+                                     std::numeric_limits<double>::quiet_NaN(), ""});
+        double seen = -1.0;
+        registry.registerVerb(s, [&](const JSON& a) {
+            seen = a["frames"].asNumber();
+            return HostVerbResult::success(args1("applied", JSON(true)));
+        }, error);
+
+        HostVerbResult r = registry.invoke("settings.setBufferSize", JSON::object(), true);
+        check(!r.ok && r.errorCode == "missing_arg", "a missing required arg is refused by code");
+
+        r = registry.invoke("settings.setBufferSize", args1("frames", JSON("512")), true);
+        check(!r.ok && r.errorCode == "invalid_args", "a string where an int is declared is refused");
+
+        r = registry.invoke("settings.setBufferSize", args1("frames", JSON(512.5)), true);
+        check(!r.ok && r.errorCode == "invalid_args", "a fractional int is refused, not truncated");
+
+        r = registry.invoke("settings.setBufferSize", args1("frames", JSON(16.0)), true);
+        check(!r.ok && r.errorCode == "invalid_args", "a value below the declared minimum is refused");
+
+        r = registry.invoke("settings.setBufferSize", args1("frames", JSON(99999.0)), true);
+        check(!r.ok && r.errorCode == "invalid_args", "a value above the declared maximum is refused");
+
+        r = registry.invoke("settings.setBufferSize", args1("framez", JSON(512.0)), true);
+        check(!r.ok && r.errorCode == "invalid_args",
+              "a misspelled arg is refused rather than dropped and defaulted");
+
+        r = registry.invoke("settings.setBufferSize", args1("frames", JSON(512.0)), true);
+        check(r.ok && seen == 512.0, "a valid call reaches the handler with its value");
+        check(r.result["applied"].isBool(), "the handler's payload comes back in result");
+
+        r = registry.invoke("settings.nothingHere", JSON::object(), true);
+        check(!r.ok && r.errorCode == "unknown_verb", "an unregistered name is refused by code");
+    }
+
+    // --- thread affinity is a capability question, not a marshalling hint ----
+    {
+        HostVerbRegistry registry;
+        std::string error;
+        bool ran = false;
+        registry.registerVerb(spec("view.openMixer", HostVerbDomain::View,
+                                   HostThreadAffinity::HostUiThread),
+                              [&](const JSON&) {
+                                  ran = true;
+                                  return HostVerbResult::success();
+                              }, error);
+        registry.registerVerb(spec("project.describe", HostVerbDomain::Project,
+                                   HostThreadAffinity::Any),
+                              [](const JSON&) { return HostVerbResult::success(); }, error);
+
+        HostVerbResult r = registry.invoke("view.openMixer", JSON::object(), false);
+        check(!r.ok && r.errorCode == "host_unavailable",
+              "a UI-affine verb is refused where there is no UI thread");
+        check(!ran, "and its handler is never entered");
+        check(r.message.find("headless") != std::string::npos,
+              "the refusal explains why rather than just failing");
+
+        r = registry.invoke("project.describe", JSON::object(), false);
+        check(r.ok, "an affinity-free verb still runs headless");
+
+        r = registry.invoke("view.openMixer", JSON::object(), true);
+        check(r.ok && ran, "the same verb runs where the host UI thread exists");
+    }
+
+    // --- enumeration: "what can this host do?" -------------------------------
+    {
+        HostVerbRegistry registry;
+        std::string error;
+        const auto add = [&](const std::string& name, HostVerbDomain d) {
+            registry.registerVerb(spec(name, d), [](const JSON&) {
+                return HostVerbResult::success();
+            }, error);
+        };
+        add("view.openMixer", HostVerbDomain::View);
+        add("browser.search", HostVerbDomain::Browser);
+        add("settings.setAudioDevice", HostVerbDomain::Settings);
+
+        const auto caps = registry.capabilities();
+        check(caps.size() == 3, "every registered capability is enumerated");
+        check(caps[0].name == "browser.search" && caps[1].name == "settings.setAudioDevice" &&
+                  caps[2].name == "view.openMixer",
+              "enumeration is ordered, so callers can diff two hosts");
+    }
+
+    // --- dispatch through MuseService ---------------------------------------
+    {
+        auto trackManager = std::make_shared<TrackManager>();
+        AudioEngine engine;
+        engine.setSampleRate(48000);
+        engine.setBufferConfig(4096, 2);
+        MuseService service(trackManager.get(), &engine);
+
+        std::string error;
+        bool opened = false;
+        HostVerbSpec s = spec("view.openMixer", HostVerbDomain::View, HostThreadAffinity::HostUiThread);
+        s.mutates = false;
+        service.hostVerbs().registerVerb(s, [&](const JSON&) {
+            opened = true;
+            return HostVerbResult::success(args1("view", JSON("mixer")));
+        }, error);
+
+        HostVerbSpec named = spec("browser.search", HostVerbDomain::Browser, HostThreadAffinity::Any);
+        named.args.push_back(HostVerbArg{"query", FlagType::String, true,
+                                         std::numeric_limits<double>::quiet_NaN(),
+                                         std::numeric_limits<double>::quiet_NaN(), "search text"});
+        service.hostVerbs().registerVerb(named, [](const JSON& a) {
+            return HostVerbResult::success(args1("echo", JSON(a["query"].asString())));
+        }, error);
+
+        // Headless by default: the UI-affine verb must refuse, and say why.
+        JSON r = call(service, "{\"id\": 1, \"verb\": \"view.openMixer\"}");
+        check(status(r) == "execution_error", "headless service refuses a UI-affine host verb");
+        check(r["errorCode"].asString() == "host_unavailable",
+              "the machine-readable code survives to the wire");
+        check(!opened, "the host handler did not run");
+
+        service.setHostUiThreadAvailable(true);
+        r = call(service, "{\"id\": 2, \"verb\": \"view.openMixer\"}");
+        check(status(r) == "ok" && opened, "the same verb runs once the host declares its UI thread");
+        check(r["result"]["view"].asString() == "mixer", "the handler payload reaches the caller");
+
+        r = call(service, "{\"id\": 3, \"verb\": \"browser.search\", \"args\": {\"query\": \"kick\"}}");
+        check(status(r) == "ok" && r["result"]["echo"].asString() == "kick",
+              "a host verb with typed args round-trips");
+
+        r = call(service, "{\"id\": 4, \"verb\": \"browser.search\"}");
+        check(status(r) == "validation_error", "a missing required host arg is a validation error");
+
+        r = call(service, "{\"id\": 5, \"verb\": \"browser.nope\"}");
+        check(status(r) == "parse_error",
+              "an unregistered namespaced verb is unknown, not a host failure");
+
+        // Enumeration over the wire.
+        r = call(service, "{\"id\": 6, \"verb\": \"get_capabilities\"}");
+        check(status(r) == "ok", "get_capabilities ok");
+        check(r["result"]["hostVerbs"].size() == 2, "both registered capabilities are listed");
+        check(r["result"]["hostUiAvailable"].isBool() && r["result"]["hostUiAvailable"].asBool(),
+              "the host UI availability is reported so agents need not guess");
+        check(r["result"]["hostVerbs"][0]["verb"].asString() == "browser.search",
+              "enumeration over the wire keeps its order");
+        check(r["result"]["hostVerbs"][0]["args"][0]["name"].asString() == "query" &&
+                  r["result"]["hostVerbs"][0]["args"][0]["required"].asBool(),
+              "argument schemas are published, so an agent need not hardcode them");
+        check(r["result"]["hostVerbs"][1]["requiresHostUi"].asBool(),
+              "thread affinity is published too");
+
+        // Built-ins keep working, and are not shadowed by the registry.
+        r = call(service, "{\"id\": 7, \"verb\": \"get_transport\"}");
+        check(status(r) == "ok", "native verbs still dispatch with host verbs registered");
+    }
+
+    // --- a bare service enumerates honestly ----------------------------------
+    {
+        auto trackManager = std::make_shared<TrackManager>();
+        AudioEngine engine;
+        MuseService service(trackManager.get(), &engine);
+        JSON r = call(service, "{\"id\": 1, \"verb\": \"get_capabilities\"}");
+        check(status(r) == "ok" && r["result"]["hostVerbs"].size() == 0,
+              "a host that registered nothing reports an empty capability list");
+        check(!r["result"]["hostUiAvailable"].asBool(),
+              "and does not claim a UI thread it does not have");
+    }
+
+    std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
+              << std::endl;
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
`MuseService` lives in `AestraAudio`, so it can only reach what `AestraAudio` owns. Settings, view navigation, the browser and dialogs live in the application layer and were **structurally unreachable** — an agent could change a gain but not open the mixer.

The fix is not for `AestraAudio` to reach up into `Source/`; that inverts the dependency the whole codebase is built on. The application registers its capabilities *into* the service at startup:

```
Source/ ────registers────> MuseService
                               ^
Muse CLI / agent ──────────────┘
```

`MuseService` never learns what a `SettingsDialog` or a `TrackManagerUI` is. It holds a name, an argument schema, and a callable.

## A verb is an application capability, not a UI gesture

```
view.openMixer            not   clickMixerButton
settings.setAudioDevice   not   openSettingsWindow
browser.search            not   pressBrowserSearchField
```

The first survives a UI redesign and lets Muse operate Aestra *semantically*. The second would make Muse an accessibility macro system welded to today's widgets, breaking on every layout change.

That distinction is why registration is **typed** rather than a generic `(name, function<JSON(JSON)>)` pair. An untyped escape hatch becomes an undocumented internal RPC API within a release or two, and nothing in the type system would object.

## What the registry enforces

| | |
|---|---|
| **Naming** | `<domain>.<lowerCamelCase>`; prefix must match the declared domain; `audio.` is reserved |
| **Typed args** | validated natively against JSON, not through the string-flag path |
| **Explicit results** | `HostVerbResult{ok, errorCode, message, result}` — never arbitrary JSON |
| **Thread affinity** | `HostUiThread` verbs refuse in a headless process, with a reason |
| **Enumeration** | `get_capabilities` publishes names, domains, arg schemas, affinity |

A few decisions worth reviewing:

- **`audio.` is reserved, and the existing 44 verbs stay unprefixed.** Conceptually the native surface *is* the `audio.*` domain, but renaming `set_bpm` → `audio.setBpm` would break every existing caller and the published manifest. Reserving the prefix keeps the model honest without the breaking rename — nothing can register a host verb claiming to be engine capability.
- **Unknown args are checked *before* required ones.** Typing `framez` for `frames` otherwise reports the required arg as missing, sending the caller hunting for an argument they did pass, misspelled. (Caught by the test, which is how I noticed.)
- **Thread affinity is a capability question, not a marshalling hint.** `MuseRepl` has no UI thread to marshal onto — that's a fact to report (`host_unavailable`), not a detail to paper over.
- **Duplicate registration is refused, not overwritten.** Silent last-one-wins would let two components fight over a capability with no diagnostic and a load-order-dependent winner.

## Scope

**No host verbs are registered yet** — that's the application's side and lands separately, so this PR is reviewable as a contract rather than as a pile of UI wiring. `HostVerbRegistryTest` covers it end to end: naming refusals, every argument-validation path, affinity in both directions, ordered enumeration, dispatch through `MuseService`, that native verbs are not shadowed, and that a bare service enumerates honestly rather than claiming a UI thread it doesn't have.

Off `develop`, independent of #609 and #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added `HostVerbRegistry` for typed application capability registration and dispatch through `MuseService`, without inverting dependencies.
- Added domain-based naming and validation, reserved `audio.*` native verbs, duplicate protection, typed argument checks, structured results, and UI-thread affinity handling.
- Added deterministic capability enumeration through `get_capabilities`, including argument schemas and host UI availability.
- Extended `MuseService` with registry access and UI-thread availability state while preserving the existing 44 native verbs.
- Added comprehensive registration, validation, affinity, enumeration, dispatch, headless-mode, and native-verb protection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->