### PR TITLE
fix: restore deleted tracks instead of re-creating them (#611)

### DIFF
--- a/AestraAudio/include/Commands/AddChannelCommand.h
+++ b/AestraAudio/include/Commands/AddChannelCommand.h
@@ -59,9 +59,11 @@ public:
     void redo() override {
         if (m_executed) return;
         if (m_detached) {
-            if (m_manager.reinsertChannel(std::move(m_detached), m_detachedIndex)) {
+            if (m_manager.reinsertChannel(m_detached, m_detachedIndex)) {
                 m_executed = true;
             }
+            // A failed reinsert leaves m_detached intact, so a later redo can
+            // retry with the same object rather than minting a new id.
             return;
         }
         // No detached channel means undo never ran (or failed); fall back to

--- a/AestraAudio/include/Commands/AddChannelCommand.h
+++ b/AestraAudio/include/Commands/AddChannelCommand.h
@@ -4,6 +4,7 @@
 #include "Commands/ICommand.h"
 #include "Models/TrackManager.h"
 
+#include <memory>
 #include <string>
 
 namespace Aestra {
@@ -34,20 +35,37 @@ public:
     }
 
     /**
-     * @brief Remove the specific channel created by this command.
+     * @brief Detach the channel created by this command, keeping it alive.
+     *
+     * The mirror of the delete case (#611). Destroying it here and building a
+     * fresh one in redo() would give the channel a new id — orphaning anything
+     * routed to the old one — and leave every command that captured a
+     * `MixerChannel&` to it dangling, so add / set volume / undo / undo / redo /
+     * redo wrote through freed memory.
      */
     void undo() override {
         if (!m_executed) return;
-        if (m_manager.removeChannelById(m_createdChannelId)) {
+        size_t index = 0;
+        if (auto detached = m_manager.detachChannelById(m_createdChannelId, index)) {
+            m_detached = std::move(detached);
+            m_detachedIndex = index;
             m_executed = false;
         }
     }
 
     /**
-     * @brief Recreate the channel after an undo operation.
+     * @brief Put the same channel back after an undo.
      */
     void redo() override {
         if (m_executed) return;
+        if (m_detached) {
+            if (m_manager.reinsertChannel(std::move(m_detached), m_detachedIndex)) {
+                m_executed = true;
+            }
+            return;
+        }
+        // No detached channel means undo never ran (or failed); fall back to
+        // creating one, which is what execute() would have done.
         if (auto* channel = m_manager.addChannel(m_name)) {
             m_createdChannelId = channel->getChannelId();
             m_executed = true;
@@ -75,6 +93,9 @@ private:
     std::string m_name;
     bool m_executed = false;
     uint32_t m_createdChannelId = 0;
+    /** The channel itself while undone, so redo restores it rather than a copy (#611). */
+    std::unique_ptr<MixerChannel> m_detached;
+    size_t m_detachedIndex = 0;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/MuseStubs.h
+++ b/AestraAudio/include/Commands/MuseStubs.h
@@ -68,6 +68,17 @@ private:
     std::string m_deletedName;
     uint32_t m_deletedId = 0;
     bool m_executed = false;
+    /**
+     * The removed channel itself, held alive while the delete stands.
+     *
+     * Undo must restore this object, not an equivalent one: its channel id is
+     * what routing points at, its volume/pan/mute/solo and effect chain live
+     * inside it, and older commands in the undo history hold `MixerChannel&`
+     * to this exact address. Re-creating it lost all three and left those
+     * references dangling (#611).
+     */
+    std::unique_ptr<MixerChannel> m_detached;
+    size_t m_detachedIndex = 0;
 };
 
 class RenameTrackCommand : public ICommand {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -176,6 +176,76 @@ public:
         return true;
     }
 
+    /**
+     * @brief Remove a channel without destroying it, handing back ownership.
+     *
+     * Undoing a track delete must restore the SAME object, not an equivalent
+     * one. Three things live in the object rather than in anything that could
+     * be reconstructed from a name:
+     *   - its channel id, which routing is keyed on (a unit or audio pattern
+     *     points at an id, never a lane index), so a re-created channel
+     *     silently orphans everything routed to the old one;
+     *   - its volume, pan, mute, solo and whole effect chain;
+     *   - its address — SetVolumeCommand, SetPanCommand, SetMuteCommand,
+     *     SetSoloCommand and the effect/plugin commands all store a
+     *     `MixerChannel&`, so destroying it leaves every one of them in the
+     *     undo history holding a dangling reference.
+     *
+     * Keeping the object alive in the command that removed it is what makes
+     * undo safe: the references stay valid for as long as anything can undo
+     * through them.
+     *
+     * @param outIndex receives the position it occupied, so it can go back there.
+     * @return the channel, or nullptr when no channel has that id.
+     */
+    std::unique_ptr<MixerChannel> detachChannelById(uint32_t channelId, size_t& outIndex) {
+        if (reportRealtimeMisuse("TrackManager::detachChannelById")) {
+            return nullptr;
+        }
+        auto it = std::find_if(m_channels.begin(), m_channels.end(), [channelId](const auto& channel) {
+            return channel && channel->getChannelId() == channelId;
+        });
+        if (it == m_channels.end()) {
+            return nullptr;
+        }
+        outIndex = static_cast<size_t>(std::distance(m_channels.begin(), it));
+        std::unique_ptr<MixerChannel> detached = std::move(*it);
+        m_channels.erase(it);
+        requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
+        m_modified.store(true, std::memory_order_relaxed);
+        if (m_channelSlotMap) {
+            m_channelSlotMap->rebuild(m_channels);
+        }
+        publishInputMonitoringSnapshot();
+        return detached;
+    }
+
+    /**
+     * @brief Put a detached channel back where it came from.
+     *
+     * An index past the end appends, so a restore still succeeds if tracks were
+     * added while this one was away — better than refusing and stranding the
+     * channel inside a command nobody can undo.
+     *
+     * @return false only when the channel is null.
+     */
+    bool reinsertChannel(std::unique_ptr<MixerChannel> channel, size_t index) {
+        if (!channel || reportRealtimeMisuse("TrackManager::reinsertChannel")) {
+            return false;
+        }
+        const size_t clamped = std::min(index, m_channels.size());
+        m_channels.insert(m_channels.begin() + static_cast<std::ptrdiff_t>(clamped),
+                          std::move(channel));
+        requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
+        m_modified.store(true, std::memory_order_relaxed);
+        if (!m_channelSlotMap) {
+            m_channelSlotMap = std::make_shared<ChannelSlotMap>();
+        }
+        m_channelSlotMap->rebuild(m_channels);
+        publishInputMonitoringSnapshot();
+        return true;
+    }
+
     size_t getTrackCount() const { return getChannelCount(); }
     /**
      * @brief Get a track by zero-based index.

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -227,9 +227,17 @@ public:
      * added while this one was away — better than refusing and stranding the
      * channel inside a command nobody can undo.
      *
-     * @return false only when the channel is null.
+     * @param channel taken by REFERENCE, and moved from only on success. A
+     *        by-value parameter would destroy the channel on every failure
+     *        path: the caller's unique_ptr is already moved-from at the call
+     *        site, so a refusal inside this function would lose the object for
+     *        good — the same "the channel is gone" defect this pair of
+     *        functions exists to prevent, merely relocated. On failure the
+     *        caller still holds it and can retry.
+     * @return false when the channel is null, or when called from the audio
+     *         thread, where mutating the channel list is not allowed.
      */
-    bool reinsertChannel(std::unique_ptr<MixerChannel> channel, size_t index) {
+    bool reinsertChannel(std::unique_ptr<MixerChannel>& channel, size_t index) {
         if (!channel || reportRealtimeMisuse("TrackManager::reinsertChannel")) {
             return false;
         }

--- a/AestraAudio/src/Commands/MuseStubs.cpp
+++ b/AestraAudio/src/Commands/MuseStubs.cpp
@@ -111,17 +111,20 @@ void DeleteTrackCommand::execute() {
     m_deletedName = ch->getName();
     m_deletedId = ch->getChannelId();
 
-    if (m_manager.removeChannelById(m_deletedId))
+    // Detach rather than destroy: this command owns the channel for as long as
+    // the delete stands, so undo can put back the same object at the same id
+    // and index. See the m_detached comment in the header for why an equivalent
+    // channel is not good enough.
+    m_detached = m_manager.detachChannelById(m_deletedId, m_detachedIndex);
+    if (m_detached)
         m_executed = true;
 }
 
 void DeleteTrackCommand::undo() {
-    if (!m_executed)
+    if (!m_executed || !m_detached)
         return;
 
-    MixerChannel* ch = m_manager.addChannel(m_deletedName);
-    if (ch) {
-        m_deletedId = ch->getChannelId();
+    if (m_manager.reinsertChannel(std::move(m_detached), m_detachedIndex)) {
         m_executed = false;
     }
 }
@@ -130,7 +133,8 @@ void DeleteTrackCommand::redo() {
     if (m_executed)
         return;
 
-    if (m_manager.removeChannelById(m_deletedId))
+    m_detached = m_manager.detachChannelById(m_deletedId, m_detachedIndex);
+    if (m_detached)
         m_executed = true;
 }
 

--- a/AestraAudio/src/Commands/MuseStubs.cpp
+++ b/AestraAudio/src/Commands/MuseStubs.cpp
@@ -124,7 +124,7 @@ void DeleteTrackCommand::undo() {
     if (!m_executed || !m_detached)
         return;
 
-    if (m_manager.reinsertChannel(std::move(m_detached), m_detachedIndex)) {
+    if (m_manager.reinsertChannel(m_detached, m_detachedIndex)) {
         m_executed = false;
     }
 }

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3192,6 +3192,17 @@ void AestraContent::resetToDefaultProject() {
     // Suppress UI refresh during clear to avoid flicker
     playlist.clear();
     sourceManager.clear();
+
+    // Drop the undo history BEFORE destroying what it refers to (#611).
+    // clearAllChannels() destroys every MixerChannel outright, and commands in
+    // the history hold `MixerChannel&` to them — SetVolume, SetPan, SetMute,
+    // SetSolo and the effect/plugin commands all do. Without this, File > New
+    // Project followed by Ctrl+Z undoes an edit through freed memory.
+    //
+    // Project *load* already clears the history (AestraApp::loadProjectFromPath);
+    // the reset path did not, and every caller of this function is replacing the
+    // project wholesale, so the old history is meaningless here as well as unsafe.
+    m_trackManager->getCommandHistory().clear();
     m_trackManager->clearAllChannels();
 
     // Recreate default tracks

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2159,6 +2159,15 @@ target_include_directories(MuseCliRequestTest PRIVATE
 add_test(NAME MuseCliRequestTest COMMAND MuseCliRequestTest)
 set_tests_properties(MuseCliRequestTest PROPERTIES LABELS "commands;muse")
 
+add_executable(DeleteTrackUndoTest Commands/DeleteTrackUndoTest.cpp)
+target_link_libraries(DeleteTrackUndoTest PRIVATE AestraAudioCore)
+target_include_directories(DeleteTrackUndoTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME DeleteTrackUndoTest COMMAND DeleteTrackUndoTest)
+set_tests_properties(DeleteTrackUndoTest PROPERTIES LABELS "commands;regression")
+
 add_executable(MuseSocketServerTest Commands/MuseSocketServerTest.cpp)
 target_link_libraries(MuseSocketServerTest PRIVATE AestraAudioCore)
 target_include_directories(MuseSocketServerTest PRIVATE

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -48,7 +48,9 @@ void check(bool condition, const std::string& label) {
     }
 }
 
-bool near(float a, float b) { return std::fabs(a - b) < 1e-5f; }
+// Not `near`: that is a legacy Windows macro (minwindef.h), so MSVC rejects a
+// function of that name outright.
+bool almostEqual(float a, float b) { return std::fabs(a - b) < 1e-5f; }
 
 } // namespace
 
@@ -71,8 +73,8 @@ int main() {
     // re-created replacement would be detectably different.
     history.pushAndExecute(std::make_shared<SetVolumeCommand>(*victim, 0.25f));
     history.pushAndExecute(std::make_shared<SetPanCommand>(*victim, -0.5f));
-    check(near(victim->getVolume(), 0.25f), "fixture: volume applied");
-    check(near(victim->getPan(), -0.5f), "fixture: pan applied");
+    check(almostEqual(victim->getVolume(), 0.25f), "fixture: volume applied");
+    check(almostEqual(victim->getPan(), -0.5f), "fixture: pan applied");
 
     // Delete the middle track.
     history.pushAndExecute(std::make_shared<DeleteTrackCommand>(manager, 1));
@@ -90,8 +92,8 @@ int main() {
         check(restored->getChannelId() == victimId,
               "restored with its ORIGINAL channel id (routing points at ids, not indexes)");
         check(restored->getName() == "Victim", "restored with its name");
-        check(near(restored->getVolume(), 0.25f), "restored with its volume, not a default");
-        check(near(restored->getPan(), -0.5f), "restored with its pan, not a default");
+        check(almostEqual(restored->getVolume(), 0.25f), "restored with its volume, not a default");
+        check(almostEqual(restored->getPan(), -0.5f), "restored with its pan, not a default");
         check(restored == victim,
               "restored the SAME object, so references held by older commands stay valid");
     }
@@ -102,15 +104,15 @@ int main() {
     // Older commands hold `MixerChannel&` to the channel the delete removed.
     // With a re-created channel those references dangled; ASan caught the write.
     check(history.undo(), "undo of the pan change reported success");
-    check(restored != nullptr && near(restored->getPan(), 0.0f),
+    check(restored != nullptr && almostEqual(restored->getPan(), 0.0f),
           "pan undone through a reference that survived the delete");
     check(history.undo(), "undo of the volume change reported success");
-    check(restored != nullptr && near(restored->getVolume(), 1.0f),
+    check(restored != nullptr && almostEqual(restored->getVolume(), 1.0f),
           "volume undone through a reference that survived the delete");
 
     // --- redo forward again -------------------------------------------------
-    check(history.redo() && near(restored->getVolume(), 0.25f), "redo re-applies the volume");
-    check(history.redo() && near(restored->getPan(), -0.5f), "redo re-applies the pan");
+    check(history.redo() && almostEqual(restored->getVolume(), 0.25f), "redo re-applies the volume");
+    check(history.redo() && almostEqual(restored->getPan(), -0.5f), "redo re-applies the pan");
     check(history.redo(), "redo re-applies the delete");
     check(manager.getChannelCount() == 2, "the track is deleted again");
 
@@ -149,7 +151,7 @@ int main() {
         const uint32_t addedId = channel->getChannelId();
 
         addHistory.pushAndExecute(std::make_shared<SetVolumeCommand>(*channel, 0.4f));
-        check(near(channel->getVolume(), 0.4f), "volume applied to the added channel");
+        check(almostEqual(channel->getVolume(), 0.4f), "volume applied to the added channel");
 
         check(addHistory.undo(), "undo of the volume change");
         check(addHistory.undo(), "undo of the add");
@@ -163,7 +165,7 @@ int main() {
 
         // The step that used to write through freed memory.
         check(addHistory.redo(), "redo of the volume change");
-        check(back != nullptr && near(back->getVolume(), 0.4f),
+        check(back != nullptr && almostEqual(back->getVolume(), 0.4f),
               "volume re-applied through a reference that survived the undo");
     }
 

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -1,0 +1,173 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Regression test for #611: undoing a track delete used to re-create the
+// channel rather than restore it.
+//
+// Driven at the command layer, not through Muse, because that is where the bug
+// lives: the same sequence is reachable from the UI's Ctrl+Z. The original
+// DeleteTrackCommand::undo() called addChannel(), which mints a NEW MixerChannel
+// with a NEW id at the END of the vector, so undoing a delete:
+//   - left every older command holding `MixerChannel&` dangling (ASan: heap-use-
+//     after-free at std::atomic<float>::exchange),
+//   - changed the channel id that routing is keyed on,
+//   - moved the track to the wrong index,
+//   - and restored only the name, dropping volume/pan/mute/solo.
+//
+// Under a normal build the first of those is silent corruption, which is why it
+// went unnoticed. The undo-past-a-delete step below is the one that tripped ASan.
+
+#include "Commands/AddChannelCommand.h"
+#include "Commands/CommandHistory.h"
+#include "Commands/MuseStubs.h"
+#include "Commands/SetPanCommand.h"
+#include "Commands/SetVolumeCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Aestra::Audio::CommandHistory;
+using Aestra::Audio::DeleteTrackCommand;
+using Aestra::Audio::MixerChannel;
+using Aestra::Audio::SetPanCommand;
+using Aestra::Audio::SetVolumeCommand;
+using Aestra::Audio::TrackManager;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << "\n";
+    } else {
+        std::cout << "FAIL: " << label << "\n";
+        ++g_failures;
+    }
+}
+
+bool near(float a, float b) { return std::fabs(a - b) < 1e-5f; }
+
+} // namespace
+
+int main() {
+    TrackManager manager;
+    CommandHistory history;
+
+    MixerChannel* first = manager.addChannel("First");
+    MixerChannel* victim = manager.addChannel("Victim");
+    MixerChannel* last = manager.addChannel("Last");
+    if (!first || !victim || !last) {
+        std::cout << "FAIL: could not build the fixture\n";
+        return 1;
+    }
+
+    const uint32_t victimId = victim->getChannelId();
+    const uint32_t lastId = last->getChannelId();
+
+    // Give the doomed track state that only lives in the object, so a
+    // re-created replacement would be detectably different.
+    history.pushAndExecute(std::make_shared<SetVolumeCommand>(*victim, 0.25f));
+    history.pushAndExecute(std::make_shared<SetPanCommand>(*victim, -0.5f));
+    check(near(victim->getVolume(), 0.25f), "fixture: volume applied");
+    check(near(victim->getPan(), -0.5f), "fixture: pan applied");
+
+    // Delete the middle track.
+    history.pushAndExecute(std::make_shared<DeleteTrackCommand>(manager, 1));
+    check(manager.getChannelCount() == 2, "delete removed the track");
+    check(manager.getChannel(1) != nullptr && manager.getChannel(1)->getChannelId() == lastId,
+          "the track after it shifted down");
+
+    // --- undo the delete: the SAME channel must come back -------------------
+    check(history.undo(), "undo of delete reported success");
+    check(manager.getChannelCount() == 3, "the track is back");
+
+    MixerChannel* restored = manager.getChannel(1);
+    check(restored != nullptr, "restored at its original index, not appended");
+    if (restored != nullptr) {
+        check(restored->getChannelId() == victimId,
+              "restored with its ORIGINAL channel id (routing points at ids, not indexes)");
+        check(restored->getName() == "Victim", "restored with its name");
+        check(near(restored->getVolume(), 0.25f), "restored with its volume, not a default");
+        check(near(restored->getPan(), -0.5f), "restored with its pan, not a default");
+        check(restored == victim,
+              "restored the SAME object, so references held by older commands stay valid");
+    }
+    check(manager.getChannel(2) != nullptr && manager.getChannel(2)->getChannelId() == lastId,
+          "the track after it moved back down");
+
+    // --- undo past the delete: this is the step that used to be a UAF -------
+    // Older commands hold `MixerChannel&` to the channel the delete removed.
+    // With a re-created channel those references dangled; ASan caught the write.
+    check(history.undo(), "undo of the pan change reported success");
+    check(restored != nullptr && near(restored->getPan(), 0.0f),
+          "pan undone through a reference that survived the delete");
+    check(history.undo(), "undo of the volume change reported success");
+    check(restored != nullptr && near(restored->getVolume(), 1.0f),
+          "volume undone through a reference that survived the delete");
+
+    // --- redo forward again -------------------------------------------------
+    check(history.redo() && near(restored->getVolume(), 0.25f), "redo re-applies the volume");
+    check(history.redo() && near(restored->getPan(), -0.5f), "redo re-applies the pan");
+    check(history.redo(), "redo re-applies the delete");
+    check(manager.getChannelCount() == 2, "the track is deleted again");
+
+    // And a second round trip still restores the same identity, so the fix is
+    // not a one-shot that works only until the channel has been detached twice.
+    check(history.undo(), "undo of the re-applied delete");
+    check(manager.getChannelCount() == 3 && manager.getChannel(1) != nullptr &&
+              manager.getChannel(1)->getChannelId() == victimId,
+          "a second delete/undo round trip preserves the id");
+
+    // --- deleting the last track restores to the end ------------------------
+    {
+        TrackManager tail;
+        CommandHistory tailHistory;
+        tail.addChannel("A");
+        MixerChannel* b = tail.addChannel("B");
+        const uint32_t bId = b->getChannelId();
+        tailHistory.pushAndExecute(std::make_shared<DeleteTrackCommand>(tail, 1));
+        check(tail.getChannelCount() == 1, "tail delete removed the last track");
+        check(tailHistory.undo() && tail.getChannelCount() == 2, "tail delete undone");
+        check(tail.getChannel(1) != nullptr && tail.getChannel(1)->getChannelId() == bId,
+              "a deleted last track comes back at the end with its id");
+    }
+
+    // --- the mirror case: AddChannelCommand undo/redo -----------------------
+    // Same defect, opposite direction. undo() used to destroy the channel and
+    // redo() built a fresh one with a new id, so add / edit / undo / undo /
+    // redo / redo wrote the edit through a dangling reference.
+    {
+        TrackManager added;
+        CommandHistory addHistory;
+
+        addHistory.pushAndExecute(std::make_shared<Aestra::Audio::AddChannelCommand>(added, "Added"));
+        MixerChannel* channel = added.getChannel(0);
+        check(channel != nullptr, "add created a channel");
+        const uint32_t addedId = channel->getChannelId();
+
+        addHistory.pushAndExecute(std::make_shared<SetVolumeCommand>(*channel, 0.4f));
+        check(near(channel->getVolume(), 0.4f), "volume applied to the added channel");
+
+        check(addHistory.undo(), "undo of the volume change");
+        check(addHistory.undo(), "undo of the add");
+        check(added.getChannelCount() == 0, "the added channel is gone");
+
+        check(addHistory.redo(), "redo of the add");
+        MixerChannel* back = added.getChannel(0);
+        check(back != nullptr && back->getChannelId() == addedId,
+              "a redone add restores the ORIGINAL id, not a fresh one");
+        check(back == channel, "and the SAME object, so the volume command's reference is valid");
+
+        // The step that used to write through freed memory.
+        check(addHistory.redo(), "redo of the volume change");
+        check(back != nullptr && near(back->getVolume(), 0.4f),
+              "volume re-applied through a reference that survived the undo");
+    }
+
+    std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
+              << std::endl;
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -22,6 +22,7 @@
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetVolumeCommand.h"
 #include "Models/TrackManager.h"
+#include "RealtimeThreadGuard.h"
 
 #include <cmath>
 #include <iostream>
@@ -167,6 +168,43 @@ int main() {
         check(addHistory.redo(), "redo of the volume change");
         check(back != nullptr && almostEqual(back->getVolume(), 0.4f),
               "volume re-applied through a reference that survived the undo");
+    }
+
+    // --- a refused reinsert must not eat the channel ------------------------
+    // reinsertChannel takes the unique_ptr by reference and moves from it only
+    // on success. By value, the caller's pointer would already be moved-from at
+    // the call site, so any refusal inside the function would destroy the
+    // channel with the caller holding nothing — the same "the channel is gone"
+    // defect this whole change exists to prevent, merely relocated.
+    {
+        TrackManager guarded;
+        guarded.addChannel("Keep");
+        size_t index = 0;
+        const uint32_t keptId = guarded.getChannel(0)->getChannelId();
+        std::unique_ptr<MixerChannel> detached = guarded.detachChannelById(keptId, index);
+        check(detached != nullptr, "detached the channel for the refusal case");
+        check(guarded.getChannelCount() == 0, "and it left the track list");
+
+        {
+            // Pretend to be the audio thread, with a no-op handler so the debug
+            // assert inside reportRealtimeMisuse does not fire.
+            auto previous = Aestra::Audio::setRealtimeMisuseHandler(+[](const char*) noexcept {});
+            Aestra::Audio::ScopedRealtimeAudioThread pretendAudioThread;
+            const bool inserted = guarded.reinsertChannel(detached, index);
+            check(!inserted, "reinsert is refused on the audio thread");
+            Aestra::Audio::setRealtimeMisuseHandler(previous);
+        }
+
+        check(detached != nullptr, "the caller STILL owns the channel after a refusal");
+        check(guarded.getChannelCount() == 0, "and nothing was inserted");
+
+        // Off the audio thread it goes back, same object, same id.
+        MixerChannel* raw = detached.get();
+        check(guarded.reinsertChannel(detached, index), "the retry succeeds");
+        check(detached == nullptr, "ownership transferred only on success");
+        check(guarded.getChannelCount() == 1 && guarded.getChannel(0) == raw &&
+                  guarded.getChannel(0)->getChannelId() == keptId,
+              "the retry restored the same object with its id");
     }
 
     std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))


### PR DESCRIPTION
Fixes #611. **Three instances of the same defect**, all reachable from the UI's Ctrl+Z — none of them Muse-specific.

## The core bug

`DeleteTrackCommand::undo()` called `TrackManager::addChannel()`, which doesn't restore anything — it constructs a **new** `MixerChannel` with a **new** id, appended at the end, at default state. Four consequences from nine lines:

1. **Heap-use-after-free.** `SetVolumeCommand`, `SetPanCommand`, `SetMuteCommand`, `SetSoloCommand` and the effect/plugin commands all store a `MixerChannel&`. The original object died in the vector erase, so undoing any older command that touched that track wrote through freed memory. ASan reports it at `std::atomic<float>::exchange`; a normal build corrupts silently, which is why this went unnoticed.
2. **The channel id changed** — routing is keyed on the stable channel id, so units and audio patterns pointing at that track were orphaned by the very operation meant to restore it.
3. **Wrong index** — the track came back at the end of the vector.
4. **State lost** — only the name was restored; volume, pan, mute, solo and the whole effect chain came back at defaults.

## The fix

`TrackManager` gains `detachChannelById` / `reinsertChannel`: remove without destroying, hand ownership to the command that removed it, put the **same object** back where it was.

Keeping the object alive is what makes undo safe — the references stay valid for as long as anything can undo through them. And preserving the object fixes 2, 3 and 4 for free, because the id and the state live *in* the object rather than in anything reconstructible from a name.

## Two more instances found while checking other destroyers

**`AddChannelCommand` had the mirror defect.** `undo()` destroyed the channel; `redo()` built a fresh one with a fresh id. So *add track → set volume → undo → undo → redo → redo* wrote through a dangling reference and silently re-identified the track. Same fix. Fixing only the delete half would have left that door open.

**`AestraContent::resetToDefaultProject()` never cleared the undo history.** It calls `clearAllChannels()`, which destroys every channel outright. So **File → New Project, then Ctrl+Z** undid an edit through freed memory — no delete required. Project *load* already clears the history (`AestraApp::loadProjectFromPath`); the reset path didn't. Cleared inside `resetToDefaultProject` itself, which covers all three of its callers, since every one of them is replacing the project wholesale.

## Test

`DeleteTrackUndoTest` drives the **command layer directly**, not Muse — Ctrl+Z is the reachable path and this isn't a Muse bug.

Restoring the original `undo()` turns **ten** assertions red: original id, name, volume, pan, object identity, neighbour index, both redos, a second delete/undo round trip, and the deleted-last-track case. I checked, rather than trusting a green test over a bug it might never have been able to see.

Local: 188/190 pass. The two non-passing are `PanelWindowClickSwallowTest` and `HeadlessExportSessionInvarianceTest`, whose binaries aren't built in this configuration — absent, not failing, and untouched by this change.

Off `develop`, independent of #609, #610 and #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve `MixerChannel` identity, state, position, and lifetime when undoing track deletions or additions by detaching and reinserting the original object.
- Add `TrackManager` APIs for channel detachment and reinsertion, including audio graph, slot map, monitoring, and modification updates.
- Clear command history when resetting to the default project to prevent stale channel references.
- Add regression coverage for identity, state restoration, ordering, repeated undo/redo cycles, last-track deletion, and reference safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->