### PR TITLE
fix(worker): clear the postcss advisory, and align workers-types with wrangler

### DIFF
--- a/workers/license-signing/package-lock.json
+++ b/workers/license-signing/package-lock.json
@@ -11,7 +11,7 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260428.0",
+        "@cloudflare/workers-types": "^5.20260722.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.2",
         "wrangler": "^4.114.0"
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "version": "5.20260724.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260724.1.tgz",
+      "integrity": "sha512-gl0brZ60JhkZU3INgr1jsxaFEiWf3AB9RsCjLTMwT5RKspWRUpsFd0wxwbys7gb8Ywkfq9tORhw0y9G+7bDUYw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2315,7 +2315,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/workers/license-signing/package.json
+++ b/workers/license-signing/package.json
@@ -17,7 +17,7 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260428.0",
+    "@cloudflare/workers-types": "^5.20260722.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2",
     "wrangler": "^4.114.0"


### PR DESCRIPTION
Two changes — the second found by attempting the first.

## postcss 8.5.16 → 8.5.23

Clears **GHSA-r28c-9q8g-f849** (path traversal via `sourceMappingURL` auto-loading, high). It arrives transitively through `vite` ← `vitest`, which already allowed `^8.5.16`, so this is a lockfile refresh rather than a version-range change.

Dev-only, like everything in this worker's tree except `tweetnacl` — it never reaches the deployed bundle.

## @cloudflare/workers-types ^4 → ^5 (not optional)

#615 bumped wrangler to 4.114.0, which declares `peerOptional @cloudflare/workers-types@^5.20260722.1`, while the root stayed on `^4`.

`npm ci` tolerated it — the lockfile was already resolved and the peer is optional — so nothing surfaced. But **any command that recomputes the tree failed with `ERESOLVE`**, which is exactly how it turned up: `npm update postcss` could not run at all until the peer was aligned. Left alone it would have blocked the next person to touch this package, with an error that looks unrelated to whatever they were doing.

## Verification, from a clean tree

`rm -rf node_modules && npm ci`, then:

| | |
|---|---|
| `npm audit` | **0 vulnerabilities** (was 1 high) |
| `npm run typecheck` | clean, across the workers-types **v4 → v5 major** |
| `npm test` | **57/57**, 4 files |
| `wrangler deploy --dry-run` | builds; `AESTRA_LICENSE_DB` (D1) and `AESTRA_STORAGE_MODE` resolve |

The dry-run upload is **133.57 KiB — byte-for-byte the same size as before**, which is what you'd expect when only devDependencies move, and is the cheapest available evidence that nothing reached the shipped worker.

Deploying still needs a real `cf:check` against the account; this proves the build and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates `@cloudflare/workers-types` from v4 to v5 to align with Wrangler 4.114.0 and avoid dependency resolution errors.
- Refreshes transitive PostCSS to 8.5.23, addressing GHSA-r28c-9q8g-f849.
- Clean-install verification passes: zero audit vulnerabilities, type checking, 57 tests, and Wrangler dry run. The dry-run upload remains 133.57 KiB; account-backed deployment verification is still needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->