### PR TITLE
ci: skip the C++ lanes for changes that provably cannot affect a build (#620 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       # See scripts/ci/classify-changes.sh.
       - name: Classify change scope
         id: scope
+        # Windows runners default `run:` to PowerShell, which parses this bash as
+        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
+        # runner, so pinning the shell keeps one implementation across all three
+        # platforms rather than maintaining a pwsh twin of the same logic.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -50,7 +55,9 @@ jobs:
           gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json files \
             --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          # Invoked through bash explicitly rather than relying on the exec bit
+          # surviving a Windows checkout and on shebang resolution under Git Bash.
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -136,6 +143,11 @@ jobs:
       # See scripts/ci/classify-changes.sh.
       - name: Classify change scope
         id: scope
+        # Windows runners default `run:` to PowerShell, which parses this bash as
+        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
+        # runner, so pinning the shell keeps one implementation across all three
+        # platforms rather than maintaining a pwsh twin of the same logic.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -150,7 +162,9 @@ jobs:
           gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json files \
             --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          # Invoked through bash explicitly rather than relying on the exec bit
+          # surviving a Windows checkout and on shebang resolution under Git Bash.
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -193,6 +207,11 @@ jobs:
       # See scripts/ci/classify-changes.sh.
       - name: Classify change scope
         id: scope
+        # Windows runners default `run:` to PowerShell, which parses this bash as
+        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
+        # runner, so pinning the shell keeps one implementation across all three
+        # platforms rather than maintaining a pwsh twin of the same logic.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -207,7 +226,9 @@ jobs:
           gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json files \
             --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          # Invoked through bash explicitly rather than relying on the exec bit
+          # surviving a Windows checkout and on shebang resolution under Git Bash.
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -341,6 +362,11 @@ jobs:
       # See scripts/ci/classify-changes.sh.
       - name: Classify change scope
         id: scope
+        # Windows runners default `run:` to PowerShell, which parses this bash as
+        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
+        # runner, so pinning the shell keeps one implementation across all three
+        # platforms rather than maintaining a pwsh twin of the same logic.
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -355,7 +381,9 @@ jobs:
           gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json files \
             --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          # Invoked through bash explicitly rather than relying on the exec bit
+          # surviving a Windows checkout and on shebang resolution under Git Bash.
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,22 @@ jobs:
             echo "run_cxx=true" >> "$GITHUB_OUTPUT"
             echo "targets main: running everything"; exit 0
           fi
-          gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json files \
-            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The REST files endpoint with --paginate, not `gh pr view --json files`:
+          # the latter goes through GraphQL and can return a short list without
+          # saying so. A silently truncated list is SHORT, so it sails under the
+          # size guard and would classify narrow on a change it never saw.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The PR's own changedFiles total, passed to the classifier so it can
+          # refuse to answer when the list it was handed is not the whole change.
+          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json changedFiles \
+            --jq '.changedFiles' 2>/dev/null || echo "")
+          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -159,12 +169,22 @@ jobs:
             echo "run_cxx=true" >> "$GITHUB_OUTPUT"
             echo "targets main: running everything"; exit 0
           fi
-          gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json files \
-            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The REST files endpoint with --paginate, not `gh pr view --json files`:
+          # the latter goes through GraphQL and can return a short list without
+          # saying so. A silently truncated list is SHORT, so it sails under the
+          # size guard and would classify narrow on a change it never saw.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The PR's own changedFiles total, passed to the classifier so it can
+          # refuse to answer when the list it was handed is not the whole change.
+          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json changedFiles \
+            --jq '.changedFiles' 2>/dev/null || echo "")
+          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -223,12 +243,22 @@ jobs:
             echo "run_cxx=true" >> "$GITHUB_OUTPUT"
             echo "targets main: running everything"; exit 0
           fi
-          gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json files \
-            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The REST files endpoint with --paginate, not `gh pr view --json files`:
+          # the latter goes through GraphQL and can return a short list without
+          # saying so. A silently truncated list is SHORT, so it sails under the
+          # size guard and would classify narrow on a change it never saw.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The PR's own changedFiles total, passed to the classifier so it can
+          # refuse to answer when the list it was handed is not the whole change.
+          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json changedFiles \
+            --jq '.changedFiles' 2>/dev/null || echo "")
+          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"
@@ -378,12 +408,22 @@ jobs:
             echo "run_cxx=true" >> "$GITHUB_OUTPUT"
             echo "targets main: running everything"; exit 0
           fi
-          gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json files \
-            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The REST files endpoint with --paginate, not `gh pr view --json files`:
+          # the latter goes through GraphQL and can return a short list without
+          # saying so. A silently truncated list is SHORT, so it sails under the
+          # size guard and would classify narrow on a change it never saw.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          # The PR's own changedFiles total, passed to the classifier so it can
+          # refuse to answer when the list it was handed is not the whole change.
+          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json changedFiles \
+            --jq '.changedFiles' 2>/dev/null || echo "")
+          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
           echo "classifier verdict: ${verdict}"
           if [ "${verdict}" = "skip-cxx" ]; then
             echo "run_cxx=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,27 @@ jobs:
           # the latter goes through GraphQL and can return a short list without
           # saying so. A silently truncated list is SHORT, so it sails under the
           # size guard and would classify narrow on a change it never saw.
+          # NOTE the field is `filename`. The REST files endpoint returns filename;
+          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
+          # file, exit status 0, and no error — an empty list that looks like a
+          # successful fetch, which then falls back to broad forever and makes this
+          # whole step inert while every check stays green.
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
           # The PR's own changedFiles total, passed to the classifier so it can
           # refuse to answer when the list it was handed is not the whole change.
           expected=$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json changedFiles \
             --jq '.changedFiles' 2>/dev/null || echo "")
-          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
+          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
+          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
+          # A mismatch is safe — the classifier falls back to broad — but it must not
+          # be silent, or a broken fetch degrades into "always broad" with every check
+          # green and nobody any the wiser.
+          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
+            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
+          fi
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
           verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
@@ -173,15 +185,27 @@ jobs:
           # the latter goes through GraphQL and can return a short list without
           # saying so. A silently truncated list is SHORT, so it sails under the
           # size guard and would classify narrow on a change it never saw.
+          # NOTE the field is `filename`. The REST files endpoint returns filename;
+          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
+          # file, exit status 0, and no error — an empty list that looks like a
+          # successful fetch, which then falls back to broad forever and makes this
+          # whole step inert while every check stays green.
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
           # The PR's own changedFiles total, passed to the classifier so it can
           # refuse to answer when the list it was handed is not the whole change.
           expected=$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json changedFiles \
             --jq '.changedFiles' 2>/dev/null || echo "")
-          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
+          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
+          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
+          # A mismatch is safe — the classifier falls back to broad — but it must not
+          # be silent, or a broken fetch degrades into "always broad" with every check
+          # green and nobody any the wiser.
+          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
+            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
+          fi
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
           verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
@@ -247,15 +271,27 @@ jobs:
           # the latter goes through GraphQL and can return a short list without
           # saying so. A silently truncated list is SHORT, so it sails under the
           # size guard and would classify narrow on a change it never saw.
+          # NOTE the field is `filename`. The REST files endpoint returns filename;
+          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
+          # file, exit status 0, and no error — an empty list that looks like a
+          # successful fetch, which then falls back to broad forever and makes this
+          # whole step inert while every check stays green.
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
           # The PR's own changedFiles total, passed to the classifier so it can
           # refuse to answer when the list it was handed is not the whole change.
           expected=$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json changedFiles \
             --jq '.changedFiles' 2>/dev/null || echo "")
-          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
+          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
+          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
+          # A mismatch is safe — the classifier falls back to broad — but it must not
+          # be silent, or a broken fetch degrades into "always broad" with every check
+          # green and nobody any the wiser.
+          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
+            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
+          fi
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
           verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
@@ -412,15 +448,27 @@ jobs:
           # the latter goes through GraphQL and can return a short list without
           # saying so. A silently truncated list is SHORT, so it sails under the
           # size guard and would classify narrow on a change it never saw.
+          # NOTE the field is `filename`. The REST files endpoint returns filename;
+          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
+          # file, exit status 0, and no error — an empty list that looks like a
+          # successful fetch, which then falls back to broad forever and makes this
+          # whole step inert while every check stays green.
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
           # The PR's own changedFiles total, passed to the classifier so it can
           # refuse to answer when the list it was handed is not the whole change.
           expected=$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" --json changedFiles \
             --jq '.changedFiles' 2>/dev/null || echo "")
-          echo "changed files: fetched $(grep -c . /tmp/changed-files.txt || echo 0), PR reports ${expected:-unknown}"
+          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
+          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
+          # A mismatch is safe — the classifier falls back to broad — but it must not
+          # be silent, or a broken fetch degrades into "always broad" with every check
+          # green and nobody any the wiser.
+          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
+            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
+          fi
           # Invoked through bash explicitly rather than relying on the exec bit
           # surviving a Windows checkout and on shebang resolution under Git Bash.
           verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,26 +24,66 @@ jobs:
         with:
           submodules: false
 
+      # --- Phase 1 lane selection (#620) -------------------------------------
+      # This job's NAME is a required status check on develop, so it must always run
+      # and always report a conclusion. A skipped workflow reports nothing at all, and
+      # a required context that never reports hangs every PR on "Expected — Waiting
+      # for status" forever. The job therefore runs unconditionally and decides
+      # internally whether the expensive steps below are worth doing.
+      #
+      # The classifier may only skip when certain: unknown paths, oversized change
+      # sets and anything targeting main fall back to running everything.
+      # See scripts/ci/classify-changes.sh.
+      - name: Classify change scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "push build: running everything"; exit 0
+          fi
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "targets main: running everything"; exit 0
+          fi
+          gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json files \
+            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          echo "classifier verdict: ${verdict}"
+          if [ "${verdict}" = "skip-cxx" ]; then
+            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
+            echo "nothing here can affect a C++ build; skipping compile and tests"
+          else
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run_cxx == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev cmake
 
       - name: Configure
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON
 
       - name: Build
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
+        if: steps.scope.outputs.run_cxx == 'true'
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-linux.xml
 
       - name: License verification tests
+        if: steps.scope.outputs.run_cxx == 'true'
         run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always()
+        if: always() && steps.scope.outputs.run_cxx == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-linux
@@ -51,7 +91,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != ''
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
@@ -84,15 +124,53 @@ jobs:
         with:
           submodules: false
 
+      # --- Phase 1 lane selection (#620) -------------------------------------
+      # This job's NAME is a required status check on develop, so it must always run
+      # and always report a conclusion. A skipped workflow reports nothing at all, and
+      # a required context that never reports hangs every PR on "Expected — Waiting
+      # for status" forever. The job therefore runs unconditionally and decides
+      # internally whether the expensive steps below are worth doing.
+      #
+      # The classifier may only skip when certain: unknown paths, oversized change
+      # sets and anything targeting main fall back to running everything.
+      # See scripts/ci/classify-changes.sh.
+      - name: Classify change scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "push build: running everything"; exit 0
+          fi
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "targets main: running everything"; exit 0
+          fi
+          gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json files \
+            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          echo "classifier verdict: ${verdict}"
+          if [ "${verdict}" = "skip-cxx" ]; then
+            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
+            echo "nothing here can affect a C++ build; skipping compile and tests"
+          else
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run_cxx == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libsdl2-dev libfreetype-dev
 
       - name: Configure (UI enabled)
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake -B build-app -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_ENABLE_UI=ON -DAESTRA_ENABLE_TESTS=OFF
 
       - name: Build app target
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake --build build-app --config ${{env.BUILD_TYPE}} --target Aestra --parallel
 
   build-windows:
@@ -103,7 +181,43 @@ jobs:
         with:
           submodules: false
 
+      # --- Phase 1 lane selection (#620) -------------------------------------
+      # This job's NAME is a required status check on develop, so it must always run
+      # and always report a conclusion. A skipped workflow reports nothing at all, and
+      # a required context that never reports hangs every PR on "Expected — Waiting
+      # for status" forever. The job therefore runs unconditionally and decides
+      # internally whether the expensive steps below are worth doing.
+      #
+      # The classifier may only skip when certain: unknown paths, oversized change
+      # sets and anything targeting main fall back to running everything.
+      # See scripts/ci/classify-changes.sh.
+      - name: Classify change scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "push build: running everything"; exit 0
+          fi
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "targets main: running everything"; exit 0
+          fi
+          gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json files \
+            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          echo "classifier verdict: ${verdict}"
+          if [ "${verdict}" = "skip-cxx" ]; then
+            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
+            echo "nothing here can affect a C++ build; skipping compile and tests"
+          else
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache vcpkg artifacts
+        if: steps.scope.outputs.run_cxx == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -117,6 +231,7 @@ jobs:
             windows-vcpkg-${{ env.VCPKG_REF }}-${{ runner.os }}-
 
       - name: Setup vcpkg and libsodium
+        if: steps.scope.outputs.run_cxx == 'true'
         shell: pwsh
         run: |
           $env:VCPKG_ROOT = "$env:RUNNER_TEMP\vcpkg"
@@ -151,6 +266,7 @@ jobs:
           & "$env:VCPKG_ROOT\vcpkg.exe" install libsodium:x64-windows gtest:x64-windows
 
       - name: Configure
+        if: steps.scope.outputs.run_cxx == 'true'
         shell: pwsh
         run: |
           $env:VCPKG_ROOT = "$env:RUNNER_TEMP\vcpkg"
@@ -162,19 +278,22 @@ jobs:
             -DVCPKG_TARGET_TRIPLET=x64-windows
 
       - name: Build
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
+        if: steps.scope.outputs.run_cxx == 'true'
         working-directory: build
         shell: bash
         run: ctest --test-dir . -C ${{env.BUILD_TYPE}} --output-on-failure --output-junit ctest-results-windows.xml
 
       - name: License verification tests
+        if: steps.scope.outputs.run_cxx == 'true'
         shell: bash
         run: ctest --test-dir build -C ${{env.BUILD_TYPE}} -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always()
+        if: always() && steps.scope.outputs.run_cxx == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-windows
@@ -182,7 +301,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != ''
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
         shell: bash
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -210,26 +329,66 @@ jobs:
         with:
           submodules: false
 
+      # --- Phase 1 lane selection (#620) -------------------------------------
+      # This job's NAME is a required status check on develop, so it must always run
+      # and always report a conclusion. A skipped workflow reports nothing at all, and
+      # a required context that never reports hangs every PR on "Expected — Waiting
+      # for status" forever. The job therefore runs unconditionally and decides
+      # internally whether the expensive steps below are worth doing.
+      #
+      # The classifier may only skip when certain: unknown paths, oversized change
+      # sets and anything targeting main fall back to running everything.
+      # See scripts/ci/classify-changes.sh.
+      - name: Classify change scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "push build: running everything"; exit 0
+          fi
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+            echo "targets main: running everything"; exit 0
+          fi
+          gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json files \
+            --jq '.files[].path' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+          verdict=$(scripts/ci/classify-changes.sh /tmp/changed-files.txt)
+          echo "classifier verdict: ${verdict}"
+          if [ "${verdict}" = "skip-cxx" ]; then
+            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
+            echo "nothing here can affect a C++ build; skipping compile and tests"
+          else
+            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run_cxx == 'true'
         run: |
           brew update
           brew install cmake pkg-config libsodium googletest
 
       - name: Configure
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON -DCMAKE_PREFIX_PATH="/opt/homebrew;/usr/local"
 
       - name: Build
+        if: steps.scope.outputs.run_cxx == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
+        if: steps.scope.outputs.run_cxx == 'true'
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml
 
       - name: License verification tests
+        if: steps.scope.outputs.run_cxx == 'true'
         run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always()
+        if: always() && steps.scope.outputs.run_cxx == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-macos
@@ -237,7 +396,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != ''
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,84 @@ jobs:
           EOF
           curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" --data @discord_payload.json "$DISCORD_WEBHOOK"
 
+  classifier-selftest:
+    name: CI classifier self-test
+    runs-on: ubuntu-latest
+    # Two separate guarantees, and the second is the one that was missing.
+    #
+    #   SAFETY   uncertainty falls back to broad
+    #   LIVENESS a change that IS narrow actually produces a narrow verdict
+    #
+    # Safety alone is satisfiable by a classifier that has silently died: answer
+    # "broad" to everything and every correctness assertion still passes while the
+    # feature does nothing. That is exactly what shipped in this PR's first draft —
+    # the fetch asked for a GraphQL field name against a REST endpoint, returned
+    # blank lines with exit 0, and degraded into always-broad behind a fully green
+    # matrix. Nothing failed, because nothing could fail.
+    #
+    # So this job asserts both directions, at both levels: the script in isolation,
+    # and the real fetch pipeline end to end against two MERGED pull requests whose
+    # file lists can never change again.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      # Level 1: the classifier itself. 42 cases, both directions, including the
+      # look-alike paths and the degenerate input that produced a fail-open.
+      - name: Classifier unit tests
+        run: bash scripts/ci/classify-changes.test.sh
+
+      # Level 2: the wiring. The unit tests all passed while the pipeline was dead,
+      # because the bug was in how the file list was fetched, not in how it was
+      # judged. This runs the real command against known history.
+      - name: Fetch pipeline liveness and safety
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # verdict_for <pr-number>  — the exact pipeline the scope steps run.
+          verdict_for() {
+            local pr="$1"
+            gh api --paginate "repos/${{ github.repository }}/pulls/${pr}/files" \
+              --jq '.[].filename' > "/tmp/files-${pr}.txt"
+            local expected
+            expected=$(gh pr view "${pr}" --repo "${{ github.repository }}" \
+              --json changedFiles --jq '.changedFiles')
+            local got
+            got=$(grep -c . "/tmp/files-${pr}.txt") || got=0
+            echo "  PR #${pr}: fetched ${got}, reports ${expected}" >&2
+            if [ "${got}" -eq 0 ] && [ "${expected}" -gt 0 ]; then
+              echo "::error::changed-file fetch returned nothing for #${pr} — the pipeline is dead" >&2
+              return 1
+            fi
+            bash scripts/ci/classify-changes.sh "/tmp/files-${pr}.txt" "${expected}"
+          }
+
+          # LIVENESS: #619 was documentation only. If this stops saying skip-cxx,
+          # the classifier has degraded to running everything and the feature is
+          # dead — the failure this job exists to make visible.
+          v=$(verdict_for 619) || fail=1
+          if [ "${v:-}" != "skip-cxx" ]; then
+            echo "::error::LIVENESS: docs-only #619 classified '${v:-<none>}', expected skip-cxx"
+            fail=1
+          else
+            echo "liveness ok: docs-only #619 -> skip-cxx"
+          fi
+
+          # SAFETY: #618 changed a workflow. It must never be skippable.
+          v=$(verdict_for 618) || fail=1
+          if [ "${v:-}" != "broad" ]; then
+            echo "::error::SAFETY: workflow change #618 classified '${v:-<none>}', expected broad"
+            fail=1
+          else
+            echo "safety ok: workflow-only #618 -> broad"
+          fi
+
+          exit "${fail}"
+
   format-check:
     name: Formatting (advisory)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,12 @@ jobs:
   classifier-selftest:
     name: CI classifier self-test
     runs-on: ubuntu-latest
+    # Least privilege, declared rather than inherited. This job shells out and
+    # queries two historical pull requests, so it reads repo contents and PR
+    # metadata and needs nothing else — least of all a token that could push.
+    permissions:
+      contents: read
+      pull-requests: read
     # Two separate guarantees, and the second is the one that was missing.
     #
     #   SAFETY   uncertainty falls back to broad
@@ -553,6 +559,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: false
+          # Nothing here pushes, so do not leave a credential in .git/config
+          # for the scripts this job runs to find.
+          persist-credentials: false
 
       # Level 1: the classifier itself. 42 cases, both directions, including the
       # look-alike paths and the degenerate input that produced a fail-open.

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -19,7 +19,14 @@
 # safe unit today is therefore the whole lane. Subsystem and test-level selection are
 # phases 2 and 3 of #620, and phase 3 is blocked on 45 unlabelled tests.
 #
-# Usage:  classify-changes.sh <file-with-one-changed-path-per-line>
+# Usage:  classify-changes.sh <file-with-one-changed-path-per-line> [expected-count]
+#
+# expected-count is the PR's authoritative changedFiles total. When supplied, the
+# list must contain exactly that many entries or the answer is broad. Without it,
+# a SILENTLY TRUNCATED list is indistinguishable from a genuinely small change:
+# the size guard below only fires when the returned list is large, and a truncated
+# list is by definition short. The cross-check is what closes that hole.
+#
 # Output: "broad" or "skip-cxx" on stdout.
 #
 # Exit status is 0 for a successful classification; a non-zero exit means the caller
@@ -28,6 +35,7 @@
 set -uo pipefail
 
 FILE_LIST="${1:-}"
+EXPECTED_COUNT="${2:-}"
 
 # Above this many changed files, do not trust the list. GitHub's changed-files API
 # truncates at 300 entries, and a truncated list looks exactly like a smaller change
@@ -77,6 +85,20 @@ main() {
     if [[ "${count}" -ge "${MAX_TRUSTED_FILES}" ]]; then
         echo "broad"
         return 0
+    fi
+
+    # Cross-check against the PR's own changedFiles total. Any disagreement means
+    # the list we classified is not the change that is being merged — truncation,
+    # pagination stopping early, or a partial fetch — so we do not trust it.
+    if [[ -n "${EXPECTED_COUNT}" ]]; then
+        if ! [[ "${EXPECTED_COUNT}" =~ ^[0-9]+$ ]]; then
+            echo "broad"
+            return 0
+        fi
+        if [[ "${count}" -ne "${EXPECTED_COUNT}" ]]; then
+            echo "broad"
+            return 0
+        fi
     fi
 
     # A single unrecognised path is enough to force the full matrix.

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Decide whether a changed-file set can safely skip the C++ build lanes.
+#
+# Every PR currently recompiles the universe: 85 runner-minutes, with a 17.9-minute
+# critical path set by Windows (MSVC). A docs-only change waits for the whole engine
+# to compile on three platforms in order to approve a Markdown edit. See issue #620.
+#
+# THE CONTRACT — this may only save compute when it is CERTAIN. It must never guess
+# narrow. Anything unrecognised, oversized, truncated, or aimed at main falls back to
+# "broad", because classifier uncertainty is allowed to cost compute and is never
+# allowed to cost correctness.
+#
+# Phase 1 is deliberately coarse: it answers one question — "is this change entirely
+# within a set of paths that provably cannot affect a C++ build?" — and nothing else.
+# There is no per-subsystem selection here, because Aestra's lanes are organised by
+# PLATFORM, not by subsystem: each of Linux/Windows/macOS runs the whole suite. The
+# safe unit today is therefore the whole lane. Subsystem and test-level selection are
+# phases 2 and 3 of #620, and phase 3 is blocked on 45 unlabelled tests.
+#
+# Usage:  classify-changes.sh <file-with-one-changed-path-per-line>
+# Output: "broad" or "skip-cxx" on stdout.
+#
+# Exit status is 0 for a successful classification; a non-zero exit means the caller
+# must treat the result as broad.
+
+set -uo pipefail
+
+FILE_LIST="${1:-}"
+
+# Above this many changed files, do not trust the list. GitHub's changed-files API
+# truncates at 300 entries, and a truncated list looks exactly like a smaller change
+# — it would read as "fewer paths touched" and classify narrower than reality. A
+# 129-file promotion PR is on record, and promotions are precisely the changes that
+# most need the full matrix.
+readonly MAX_TRUSTED_FILES=200
+
+# Paths that cannot affect a C++ compile or test run. Anchored, so a path merely
+# CONTAINING one of these words (docs/workers-guide.md, Source/AestraDocsPanel.cpp)
+# does not match. Every entry here is a promise; add to it only with evidence.
+is_cxx_irrelevant() {
+    case "$1" in
+        # Documentation trees and top-level prose.
+        docs/*|AestraDocs/*|meta/*) return 0 ;;
+        README.md|LICENSE|LICENSING.md|NOTICE|CHANGELOG.md|CONTRIBUTING.md) return 0 ;;
+        CODE_OF_CONDUCT.md|SECURITY.md|SUPPORT.md|RELEASES.md|BUILD.md|philosophy.md) return 0 ;;
+        mkdocs.yml|Doxyfile) return 0 ;;
+        # The Cloudflare worker: TypeScript, its own toolchain, its own CI lane.
+        workers/*) return 0 ;;
+        # Files that are inert everywhere.
+        .gitignore|.gitattributes|.editorconfig) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+main() {
+    # No list, unreadable list, or empty list: we know nothing. Broad.
+    if [[ -z "${FILE_LIST}" || ! -r "${FILE_LIST}" ]]; then
+        echo "broad"
+        return 0
+    fi
+
+    # NOT `grep -c . file || echo 0`: grep exits non-zero on no match AND prints 0,
+    # so the fallback appends a second 0 and the count becomes the string "0\n0".
+    # That is not a number, every numeric guard below then errors out instead of
+    # firing, and control falls through to the loop — which reads nothing and
+    # returns skip-cxx. An empty change set would have skipped the whole matrix.
+    local count
+    count=$(grep -c . "${FILE_LIST}" 2>/dev/null) || count=0
+
+    if [[ "${count}" -eq 0 ]]; then
+        echo "broad"
+        return 0
+    fi
+
+    if [[ "${count}" -ge "${MAX_TRUSTED_FILES}" ]]; then
+        echo "broad"
+        return 0
+    fi
+
+    # A single unrecognised path is enough to force the full matrix.
+    local path
+    while IFS= read -r path; do
+        [[ -z "${path}" ]] && continue
+        if ! is_cxx_irrelevant "${path}"; then
+            echo "broad"
+            return 0
+        fi
+    done < "${FILE_LIST}"
+
+    echo "skip-cxx"
+}
+
+main

--- a/scripts/ci/classify-changes.test.sh
+++ b/scripts/ci/classify-changes.test.sh
@@ -132,6 +132,31 @@ else
     printf 'FAIL  %-58s\n' "150 docs files (under the threshold)"; failures=$((failures + 1))
 fi
 
+# --- the truncation cross-check --------------------------------------------
+# The size guard alone cannot catch truncation: a truncated list is SHORT, so it
+# sails under the threshold and classifies narrow on a change it never saw. The
+# expected-count argument is what closes that.
+tc() {  # tc <expected-out> <label> <expected-count> <path>...
+    local want="$1"; shift; local label="$1"; shift; local n="$1"; shift
+    local list="${TMP}/tc"; : > "${list}"
+    local p; for p in "$@"; do printf '%s\n' "${p}" >> "${list}"; done
+    checks=$((checks + 1))
+    local got; got="$("${CLASSIFY}" "${list}" "${n}")"
+    if [[ "${got}" == "${want}" ]]; then
+        printf 'PASS  %-58s -> %s\n' "${label}" "${got}"
+    else
+        printf 'FAIL  %-58s -> %s (expected %s)\n' "${label}" "${got}" "${want}"
+        failures=$((failures + 1))
+    fi
+}
+
+tc skip-cxx "count matches, all safe"            2 "docs/a.md" "README.md"
+tc broad    "list truncated (2 of 40 returned)"  40 "docs/a.md" "README.md"
+tc broad    "list longer than reported"          1 "docs/a.md" "README.md"
+tc broad    "expected count not a number"        "abc" "docs/a.md"
+tc broad    "expected count empty-ish garbage"   "-1" "docs/a.md"
+tc broad    "truncated AND source present"       40 "docs/a.md" "AestraAudio/src/x.cpp"
+
 echo
 if [[ "${failures}" -eq 0 ]]; then
     echo "ALL PASSED (${checks} checks)"

--- a/scripts/ci/classify-changes.test.sh
+++ b/scripts/ci/classify-changes.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Tests for classify-changes.sh. This script gates REQUIRED status checks, so a bug
+# here either blocks every merge or silently skips the compile that would have caught
+# a break. It is worth more coverage than its size suggests.
+#
+# The important cases are the negative ones: the classifier is only allowed to say
+# "skip-cxx" when it is certain, so most of this file is about proving it says
+# "broad" whenever it is not.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFY="${HERE}/classify-changes.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+failures=0
+checks=0
+
+# expect <expected> <label> <path>...
+expect() {
+    local expected="$1"; shift
+    local label="$1"; shift
+    local list="${TMP}/list"
+    : > "${list}"
+    local p
+    for p in "$@"; do printf '%s\n' "${p}" >> "${list}"; done
+
+    checks=$((checks + 1))
+    local actual
+    actual="$("${CLASSIFY}" "${list}")"
+    if [[ "${actual}" == "${expected}" ]]; then
+        printf 'PASS  %-58s -> %s\n' "${label}" "${actual}"
+    else
+        printf 'FAIL  %-58s -> %s (expected %s)\n' "${label}" "${actual}" "${expected}"
+        failures=$((failures + 1))
+    fi
+}
+
+# --- changes that provably cannot affect a C++ build ------------------------
+expect skip-cxx "docs only"                      "docs/technical/roadmap.md"
+expect skip-cxx "top-level prose"                "README.md" "LICENSING.md" "NOTICE"
+expect skip-cxx "internal docs tree"             "AestraDocs/images/aestra_daw_interface.png"
+expect skip-cxx "worker only"                    "workers/license-signing/package.json"
+expect skip-cxx "worker + lockfile"              "workers/license-signing/package.json" \
+                                                 "workers/license-signing/package-lock.json"
+expect skip-cxx "docs + worker together"         "docs/index.md" "workers/license-signing/src/index.ts"
+expect skip-cxx "mkdocs config"                  "mkdocs.yml"
+expect skip-cxx "changelog"                      "meta/CHANGELOGS/CHANGELOG_2026Q2.md"
+
+# Real PRs from 2026-07-25 that should have skipped the C++ matrix (#620).
+expect skip-cxx "#619 as merged"                 "AestraDocs/images/aestra_daw_interface.png" \
+                                                 "LICENSING.md" "NOTICE" "README.md" \
+                                                 "docs/about/licensing.md"
+expect skip-cxx "#615 as merged"                 "workers/license-signing/package.json" \
+                                                 "workers/license-signing/package-lock.json"
+
+# --- anything touching the build must be broad ------------------------------
+expect broad "C++ source"                        "AestraAudio/src/Core/AudioEngine.cpp"
+expect broad "UI source"                         "AestraUI/Widgets/UIMixerButtonRow.cpp"
+expect broad "app source"                        "Source/App/AestraApp.cpp"
+expect broad "header"                            "AestraCore/include/AestraJSON.h"
+expect broad "root CMakeLists"                   "CMakeLists.txt"
+expect broad "cmake module"                      "cmake/LowMemory.cmake"
+expect broad "test source"                       "Tests/Commands/MuseServiceTest.cpp"
+expect broad "test cmake fragment"               "Tests/cmake/CommandsTests.cmake"
+expect broad "security test tree"                "tests/security/out_of_process_plugin_host.cpp"
+expect broad "workflow change"                   ".github/workflows/ci.yml"
+expect broad "the classifier itself"             "scripts/ci/classify-changes.sh"
+
+# --- one unrecognised path poisons an otherwise skippable set ---------------
+expect broad "docs plus one source file"         "docs/index.md" "AestraAudio/src/Core/AudioEngine.cpp"
+expect broad "worker plus one header"            "workers/license-signing/package.json" \
+                                                 "AestraCore/include/AestraLog.h"
+expect broad "mostly docs, one CMake"            "README.md" "docs/index.md" "CMakeLists.txt"
+
+# --- paths that merely LOOK like the safe ones ------------------------------
+# These are the ones an unanchored pattern gets wrong, and the reason every rule
+# in the classifier is anchored at the start of the path.
+expect broad "source file named after docs"      "Source/Panels/AestraDocsPanel.cpp"
+expect broad "source path containing 'workers'"  "Source/Core/WorkersPool.cpp"
+expect broad "a README inside a source tree"     "AestraAudio/README.md"
+expect broad "top-level file not on the list"    "requirements.txt"
+expect broad "new unknown directory"             "AestraNewModule/src/Thing.cpp"
+expect broad "dotfile not on the list"           ".clang-format"
+
+# --- degenerate and hostile input -------------------------------------------
+expect broad "empty change set"                  ""
+: > "${TMP}/list"; checks=$((checks + 1))
+if [[ "$("${CLASSIFY}" "${TMP}/list")" == "broad" ]]; then
+    printf 'PASS  %-58s -> broad\n' "genuinely empty file"
+else
+    printf 'FAIL  %-58s\n' "genuinely empty file"; failures=$((failures + 1))
+fi
+
+checks=$((checks + 1))
+if [[ "$("${CLASSIFY}" "${TMP}/does-not-exist")" == "broad" ]]; then
+    printf 'PASS  %-58s -> broad\n' "missing file list"
+else
+    printf 'FAIL  %-58s\n' "missing file list"; failures=$((failures + 1))
+fi
+
+checks=$((checks + 1))
+if [[ "$("${CLASSIFY}")" == "broad" ]]; then
+    printf 'PASS  %-58s -> broad\n' "no argument at all"
+else
+    printf 'FAIL  %-58s\n' "no argument at all"; failures=$((failures + 1))
+fi
+
+# --- the truncation guard ---------------------------------------------------
+# GitHub's changed-files API truncates at 300 entries. A truncated list is
+# indistinguishable from a genuinely smaller change, so a large docs-only set must
+# still fall back to broad rather than trusting a count it cannot verify.
+big="${TMP}/big"; : > "${big}"
+for i in $(seq 1 250); do printf 'docs/page-%s.md\n' "${i}" >> "${big}"; done
+checks=$((checks + 1))
+if [[ "$("${CLASSIFY}" "${big}")" == "broad" ]]; then
+    printf 'PASS  %-58s -> broad\n' "250 docs files (over the trust threshold)"
+else
+    printf 'FAIL  %-58s\n' "250 docs files (over the trust threshold)"; failures=$((failures + 1))
+fi
+
+# Just under the threshold, all provably safe: skipping is allowed.
+small="${TMP}/small"; : > "${small}"
+for i in $(seq 1 150); do printf 'docs/page-%s.md\n' "${i}" >> "${small}"; done
+checks=$((checks + 1))
+if [[ "$("${CLASSIFY}" "${small}")" == "skip-cxx" ]]; then
+    printf 'PASS  %-58s -> skip-cxx\n' "150 docs files (under the threshold)"
+else
+    printf 'FAIL  %-58s\n' "150 docs files (under the threshold)"; failures=$((failures + 1))
+fi
+
+echo
+if [[ "${failures}" -eq 0 ]]; then
+    echo "ALL PASSED (${checks} checks)"
+    exit 0
+fi
+echo "FAILURES: ${failures} of ${checks}"
+exit 1


### PR DESCRIPTION
Phase 1 of #620. Deliberately boring, deliberately coarse.

## What it does

The four required C++ lanes — `Linux (GCC)`, `Windows (MSVC)`, `macOS (Clang)`, `Linux (UI/App compile)` — now classify the change before doing expensive work, and skip compile and test when **nothing in the change can reach a C++ build**.

Expected effect on the three PRs from yesterday that needed none of it:

| PR | touched | before | after |
|---|---|---|---|
| #619 | docs, README, LICENSING, NOTICE | 85 min / 17.9 min path | ~0 |
| #615, #616 | `workers/` only | 85 min / 17.9 min path | ~0 |

## Why lanes and not tests

Aestra's lanes are organised by **platform**, not subsystem — each of Linux/Windows/macOS runs the whole suite. There is no "audio lane" to select, so the only safe unit today is the whole lane.

Test-level selection is phase 3 and is **blocked**: 192 tests, 147 labelled, **45 unlabelled**. `ctest -L audio` today would silently drop 45 tests and redefine passing without meaning to.

## The two invariants this had to respect

**Job names are a public API.** They are required status checks on `develop`. A required context that never reports doesn't fail — it hangs every PR on *"Expected — Waiting for status"* forever. So:

- no workflow-level `paths:` filter (a skipped workflow reports nothing)
- no reusable-workflow conversion (renames jobs to `parent / child`)
- no `needs:` chaining (a skipped dependent reports a conclusion GitHub may treat as success — fake green)

Each job runs unconditionally, decides internally, always reports. **Verified: all nine job names byte-identical, five advisory jobs untouched.**

**The classifier may only skip when certain.** Unknown paths, oversized change sets, unreadable input, and anything targeting `main` all fall back to running everything. Rules are anchored, so `docs/workers-guide.md` and `Source/Panels/AestraDocsPanel.cpp` both correctly force a full build.

## Two bugs caught before this went near a required check

**A fail-open.** The test found that an empty change set returned `skip-cxx`. Cause:

```bash
count=$(grep -c . "$FILE_LIST" || echo 0)   # WRONG
```

`grep -c` exits non-zero on no match **and** prints `0`, so the fallback appends a second `0`; the count becomes the string `"0\n0"`, every numeric guard errors instead of firing, and control falls through to a loop that reads nothing. **An empty file list would have skipped the entire matrix.**

**Clobbered step conditions.** Injecting the gate overwrote six pre-existing `if: always()` conditions on test-report upload and Discord notification, leaving *duplicate `if:` keys* where the YAML parser silently took the original and ignored my gate. Both now single combined conditions, so failure reporting still happens on a failed build.

## Test

`scripts/ci/classify-changes.sh` is a standalone script rather than inline YAML specifically so it can be tested without pushing. `classify-changes.test.sh` — **36 cases, all passing**:

- real merged PRs (#615, #619) as they actually landed
- every C++-relevant tree forces broad
- one unrecognised path poisons an otherwise skippable set
- look-alikes: `Source/Panels/AestraDocsPanel.cpp`, `Source/Core/WorkersPool.cpp`, `AestraAudio/README.md`
- degenerate input: empty, missing file, no argument
- the truncation guard at the file-count threshold, both sides

## What this PR is its own test of

It touches `.github/workflows/ci.yml` and `scripts/` — **not** a skippable path — so it should run the **full** matrix on itself. If any lane skips here, the classifier is wrong.

The skip path gets its first real exercise on the next docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added phase 1 “change scope” gating to the four main C++ CI lanes (Linux GCC, Linux UI/App, Windows MSVC, macOS Clang) so irrelevant docs-only changes skip expensive build/test work, while uncertain/unsafe cases run the full matrix.
- Implemented a new `scripts/ci/classify-changes.sh` classifier that conservatively returns `skip-cxx` only when every changed file is provably C++-irrelevant; otherwise it falls back to `broad` (including malformed/empty/oversized inputs, unreadable lists, count mismatches, and `main`-targeting PRs).
- Hardened the workflow’s changed-file fetching and Windows shell behavior (Bash invocation for affected steps, and paginated `gh api` retrieval with authoritative `changedFiles` count validation).
- Added `classifier-selftest` to validate classifier correctness and “liveness” against real historical PR behavior, and shipped a comprehensive test suite covering relevant paths, look-alikes, degenerate inputs, and truncation/file-count mismatch scenarios (42 cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->