### PR TITLE
fix: wait on worker completion instead of a fixed sleep (#622)

### DIFF
--- a/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
+++ b/AestraAudio/include/Plugin/OutOfProcessPluginInstance.h
@@ -72,6 +72,25 @@ public:
         sendCommand(command, &response, std::chrono::seconds(2));
         return response;
     }
+
+    /**
+     * @brief Blocks the worker has finished, monotonically increasing.
+     *
+     * The audio path here is a SINGLE-SLOT double buffer, not a queue: every
+     * process() overwrites the pending slot, so a block that has not been picked
+     * up yet is simply lost. That makes "has the worker caught up?" unobservable
+     * from outside, and tests were left sleeping a fixed 20ms and hoping — a race
+     * that failed on a loaded macOS runner (#622) and could not be fixed by
+     * polling, because polling means calling process(), which destroys the very
+     * block being waited for.
+     *
+     * This counter makes the completion an event a test can wait on. It is
+     * incremented after the worker publishes a result, so observing it advance
+     * means that result is readable on the next process() call.
+     */
+    uint64_t processedBlockCountForTest() const {
+        return m_processedBlocks.load(std::memory_order_acquire);
+    }
 #endif
 
 private:
@@ -104,6 +123,10 @@ private:
 
     std::thread m_workerThread;
     std::atomic<bool> m_workerStop{false};
+    // Counts blocks the worker has published. Always maintained, not just under
+    // test hooks: a counter that only exists in test builds would be measuring a
+    // different binary from the one that ships.
+    std::atomic<uint64_t> m_processedBlocks{0};
     std::atomic<bool> m_workerRunning{false};
 
     std::vector<float> m_pendingInput;

--- a/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
+++ b/AestraAudio/src/Plugin/OutOfProcessPluginInstance.cpp
@@ -660,6 +660,9 @@ void OutOfProcessPluginInstance::workerLoop() {
             std::copy_n(m_workerOutput.data(), outputSamples, m_readyOutput.data());
             m_readyFrames.store(frames, std::memory_order_release);
             m_readyState.store(2, std::memory_order_release);
+            // Published last, so an observer that sees this advance is guaranteed
+            // to find the result readable rather than half-written.
+            m_processedBlocks.fetch_add(1, std::memory_order_acq_rel);
         }
     }
 }

--- a/tests/security/out_of_process_plugin_host.cpp
+++ b/tests/security/out_of_process_plugin_host.cpp
@@ -56,6 +56,32 @@ PluginInstancePtr create(OutOfProcessPluginFactory& factory, const PluginInfo& i
     return created;
 }
 
+// Wait for the worker to publish one more finished block than it had before.
+//
+// The transport is a SINGLE-SLOT double buffer, not a queue: every process()
+// overwrites the pending slot, so a block the worker has not picked up yet is
+// simply dropped. That is why this cannot be done by polling with process() —
+// polling would destroy the very block being waited for — and why the original
+// fixed 20ms sleeps raced on a loaded macOS runner (#622).
+//
+// processedBlockCountForTest() makes completion observable. Sample it BEFORE the
+// process() that submits, then wait for it to move.
+bool waitForWorkerBlock(const PluginInstancePtr& instance, uint64_t countBefore,
+                        std::chrono::milliseconds budget = std::chrono::seconds(5)) {
+    auto* oop = static_cast<OutOfProcessPluginInstance*>(instance.get());
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (oop->processedBlockCountForTest() > countBefore) {
+            return true;
+        }
+        if (instance->isCrashed()) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
 // Pump process() until the echo output steady-states at input*gain, tolerating
 // the async worker/double-buffer latency (#238 param delivery is not synchronous).
 // Returns true once every frame matches; false if it never converges.
@@ -223,12 +249,18 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    auto* oopInstance = static_cast<OutOfProcessPluginInstance*>(instance.get());
+
     float inL[4] = {0.1f, 0.2f, 0.3f, 0.4f};
     float inR[4] = {-0.1f, -0.2f, -0.3f, -0.4f};
     const float* inputs[2] = {inL, inR};
     float outL[4] = {};
     float outR[4] = {};
     float* outputs[2] = {outL, outR};
+
+    // Each stage: sample the completed-block count, submit, then wait for the
+    // worker to publish. The block submitted here is read back on the NEXT call.
+    uint64_t blocksBefore = oopInstance->processedBlockCountForTest();
     instance->process(inputs, outputs, 2, 2, 4);
 
     if (std::memcmp(inL, outL, sizeof(inL)) != 0 || std::memcmp(inR, outR, sizeof(inR)) != 0) {
@@ -236,13 +268,17 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    if (!waitForWorkerBlock(instance, blocksBefore)) {
+        std::cerr << "helper did not finish the first audio block\n";
+        return 1;
+    }
 
     float nextInL[4] = {0.9f, 0.8f, 0.7f, 0.6f};
     float nextInR[4] = {-0.9f, -0.8f, -0.7f, -0.6f};
     const float* nextInputs[2] = {nextInL, nextInR};
     std::memset(outL, 0, sizeof(outL));
     std::memset(outR, 0, sizeof(outR));
+    blocksBefore = oopInstance->processedBlockCountForTest();
     instance->process(nextInputs, outputs, 2, 2, 4);
 
     if (std::memcmp(inL, outL, sizeof(inL)) != 0 || std::memcmp(inR, outR, sizeof(inR)) != 0) {
@@ -250,7 +286,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    if (!waitForWorkerBlock(instance, blocksBefore)) {
+        std::cerr << "helper did not finish the second audio block\n";
+        return 1;
+    }
 
     MidiBuffer midi;
     midi.addNoteOn(1, 60, 100, 1);
@@ -259,13 +298,17 @@ int main(int argc, char** argv) {
     const float* midiInputs[2] = {midiInL, midiInR};
     std::memset(outL, 0, sizeof(outL));
     std::memset(outR, 0, sizeof(outR));
+    blocksBefore = oopInstance->processedBlockCountForTest();
     instance->process(midiInputs, outputs, 2, 2, 4, &midi, nullptr);
     if (std::memcmp(nextInL, outL, sizeof(nextInL)) != 0 || std::memcmp(nextInR, outR, sizeof(nextInR)) != 0) {
         std::cerr << "isolated plugin proxy did not survive MIDI-bearing process command\n";
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    if (!waitForWorkerBlock(instance, blocksBefore)) {
+        std::cerr << "helper did not finish the MIDI-bearing block\n";
+        return 1;
+    }
     std::memset(outL, 0, sizeof(outL));
     std::memset(outR, 0, sizeof(outR));
     instance->process(nextInputs, outputs, 2, 2, 4);


### PR DESCRIPTION
Closes #622.

## What went wrong

`SecOutOfProcessPluginHost` failed on macOS in #621, then passed on a re-run of **the same commit**. It slept a fixed 20 ms and then asserted that an async worker had delivered a block across an IPC boundary. On a loaded runner, 20 ms is not a guarantee.

## The obvious fix does not work, and that shaped this one

I first tried replacing the sleeps with a bounded poll — re-submit a filler block, wait for the expected one. **Fails 10/10, deterministically.**

The transport is a **single-slot double buffer, not a queue**:

```cpp
m_pendingFrames.store(numFrames, ...);   // process() — overwrites
const uint32_t frames = m_pendingFrames.load(...);   // worker — takes what is there
```

Every `process()` **overwrites** the pending slot, so polling destroys the very block being waited for. The sleeps were not laziness — they were protecting the **submit → pickup** window, and nothing observable from the test side reported on it.

## The fix: make completion observable

`OutOfProcessPluginInstance` now counts blocks the worker has published, incremented *after* the result is readable, exposed via `processedBlockCountForTest()` under `AESTRA_ENABLE_TEST_HOOKS` — consistent with the existing `sendRawCommandForTest` / `TESTNOTES` seam.

The counter is maintained **unconditionally**, not only in test builds, so it cannot measure a different binary from the one that ships.

Each stage now samples the count, submits, and waits for it to advance — 5 s budget, early exit if the proxy crashes. Three fixed 20 ms sleeps are gone. The one remaining sleep guards only a finiteness check in the real-CLAP probe path, where timing does not affect the assertion.

## Honest limits of the verification

**The original flake never reproduced on this machine** — 0/10 unloaded, 0/12 with 12 spinners on 4 cores. So there is no before/after failure count to show, and I am not going to imply one.

What can be shown:

| | result |
|---|---|
| new version, unloaded | 10/10 pass |
| new version, 16 spinners on 4 cores | 12/12 pass |
| security suite | passes |

The argument is **structural rather than statistical**: the test no longer depends on a duration, so there is no timeout left to lose. That is a stronger guarantee than a tuned sleep, but it is worth being clear that it rests on reasoning about the mechanism, not on having reproduced the failure.

## Why this mattered enough to fix properly

These lanes became **required status checks** on `develop` and `main` today. A flaky required check trains people to re-run on red, and the next genuine failure gets re-run too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added a test-only processed-block counter to expose worker completion safely across the IPC boundary.
- Replaced fixed 20 ms sleeps in the security test with bounded waits that detect completion and fail early if the proxy crashes.
- Removed timing-dependent race conditions while preserving the existing assertions and audio/MIDI validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->