### PR TITLE
Muse: first host verbs — view.open, view.close, view.current

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios - All Rights Reserved. Licensed for personal & educational use only.
 #include "AestraApp.h"
+#include "MuseHostVerbs.h"
 #include "AppLifecycle.h"
 #include "ServiceLocator.h"
 #include "AestraRootComponent.h"
@@ -1059,6 +1060,14 @@ void AestraApp::startMuseSocketIfConfigured() {
 
     m_museService = std::make_unique<Aestra::Audio::MuseService>(
         m_content->getTrackManager().get(), m_audioController->getEngine());
+
+    // Requests are executed from the frame pump (see processPending in UI_Update),
+    // so UI-affine host verbs can be honoured here. Headless processes leave this
+    // false and refuse them with a reason rather than running host code on a
+    // thread that does not own the state it touches.
+    m_museService->setHostUiThreadAvailable(true);
+    registerMuseHostVerbs(*m_museService, *m_content);
+
     m_museSocketServer = std::make_unique<Aestra::Audio::MuseSocketServer>();
     std::string error;
     if (!m_museSocketServer->start(static_cast<uint16_t>(port), error)) {

--- a/Source/App/MuseHostVerbs.cpp
+++ b/Source/App/MuseHostVerbs.cpp
@@ -1,0 +1,165 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "MuseHostVerbs.h"
+
+#include "Commands/HostVerbRegistry.h"
+#include "Commands/MuseService.h"
+#include "Core/AestraContent.h"
+#include "ViewTypes.h"
+
+#include "AestraLog.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Aestra {
+namespace {
+
+using Audio::HostThreadAffinity;
+using Audio::HostVerbArg;
+using Audio::HostVerbDomain;
+using Audio::HostVerbResult;
+using Audio::HostVerbSpec;
+using Audio::ViewType;
+
+// The workspaces Muse can name. These strings are protocol: they appear in
+// get_capabilities, agents will hardcode them, and renaming one is a breaking
+// change even though the enum behind it is free to move.
+struct NamedView {
+    const char* name;
+    ViewType view;
+};
+
+constexpr std::array<NamedView, 6> kViews{{
+    {"mixer", ViewType::Mixer},
+    {"arsenal", ViewType::Sequencer},   // "Sequencer" internally; Arsenal in the product
+    {"pianoRoll", ViewType::PianoRoll},
+    {"timeline", ViewType::Playlist},   // "Playlist" internally; Timeline in the product
+    {"history", ViewType::History},
+    {"takes", ViewType::Takes},
+}};
+
+std::string knownViewList() {
+    std::string out;
+    for (const auto& v : kViews) {
+        if (!out.empty()) out += ", ";
+        out += v.name;
+    }
+    return out;
+}
+
+// Case-insensitive, because an agent that read "pianoRoll" from get_capabilities
+// and typed "pianoroll" has made no meaningful error.
+bool lookupView(const std::string& name, ViewType& out) {
+    const auto lower = [](std::string s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    };
+    const std::string wanted = lower(name);
+    for (const auto& v : kViews) {
+        if (lower(v.name) == wanted) {
+            out = v.view;
+            return true;
+        }
+    }
+    return false;
+}
+
+HostVerbArg viewArg() {
+    HostVerbArg arg;
+    arg.name = "view";
+    arg.type = Audio::FlagType::String;
+    arg.required = true;
+    arg.description = "one of: " + knownViewList();
+    return arg;
+}
+
+void registerOrLog(Audio::MuseService& service, HostVerbSpec spec, Audio::HostVerbHandler handler) {
+    std::string error;
+    const auto status = service.hostVerbs().registerVerb(std::move(spec), std::move(handler), error);
+    if (status != Audio::HostVerbRegistry::RegisterStatus::Ok) {
+        // Registration is refused rather than overwritten, so a duplicate or a
+        // malformed name is a programming error here, not a runtime condition.
+        Log::warning("[MuseHostVerbs] refused: " + error);
+    }
+}
+
+} // namespace
+
+void registerMuseHostVerbs(Audio::MuseService& service, ::AestraContent& content) {
+    ::AestraContent* c = &content;
+
+    // --- view.open / view.close ---------------------------------------------
+    const auto setOpen = [c](const JSON& args, bool open) -> HostVerbResult {
+        ViewType view{};
+        const std::string requested = args["view"].asString();
+        if (!lookupView(requested, view)) {
+            return HostVerbResult::failure(
+                "no_such_view", "no view named '" + requested + "'; known views: " + knownViewList());
+        }
+        const bool already = c->isViewOpen(view);
+        c->setViewOpen(view, open);
+
+        JSON result = JSON::object();
+        result.set("view", JSON(requested));
+        result.set("open", JSON(open));
+        // Say whether anything actually moved. "Already open" is a legitimate,
+        // successful outcome, and a caller that cannot tell it apart from a
+        // change will re-issue commands trying to force one.
+        result.set("changed", JSON(already != open));
+        return HostVerbResult::success(result);
+    };
+
+    {
+        HostVerbSpec spec;
+        spec.name = "view.open";
+        spec.domain = HostVerbDomain::View;
+        spec.affinity = HostThreadAffinity::HostUiThread;
+        spec.mutates = false; // window layout, not project state — nothing to undo
+        spec.description = "Open a workspace overlay. Known views: " + knownViewList() + ".";
+        spec.args.push_back(viewArg());
+        registerOrLog(service, std::move(spec),
+                      [setOpen](const JSON& args) { return setOpen(args, true); });
+    }
+    {
+        HostVerbSpec spec;
+        spec.name = "view.close";
+        spec.domain = HostVerbDomain::View;
+        spec.affinity = HostThreadAffinity::HostUiThread;
+        spec.mutates = false;
+        spec.description = "Close a workspace overlay. Known views: " + knownViewList() + ".";
+        spec.args.push_back(viewArg());
+        registerOrLog(service, std::move(spec),
+                      [setOpen](const JSON& args) { return setOpen(args, false); });
+    }
+
+    // --- view.current --------------------------------------------------------
+    {
+        HostVerbSpec spec;
+        spec.name = "view.current";
+        spec.domain = HostVerbDomain::View;
+        spec.affinity = HostThreadAffinity::HostUiThread;
+        spec.mutates = false;
+        spec.description =
+            "Which workspaces are open right now. Returns every known view with its "
+            "open state, so an agent can see the workspace instead of assuming it.";
+        registerOrLog(service, std::move(spec), [c](const JSON&) {
+            JSON views = JSON::array();
+            for (const auto& v : kViews) {
+                JSON entry = JSON::object();
+                entry.set("view", JSON(std::string(v.name)));
+                entry.set("open", JSON(c->isViewOpen(v.view)));
+                views.push(entry);
+            }
+            JSON result = JSON::object();
+            result.set("views", views);
+            return HostVerbResult::success(result);
+        });
+    }
+}
+
+} // namespace Aestra

--- a/Source/App/MuseHostVerbs.h
+++ b/Source/App/MuseHostVerbs.h
@@ -1,0 +1,35 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// AestraContent lives in the GLOBAL namespace, not in Aestra — the namespace
+// block above its declaration in AestraContent.h closes before the class. A
+// forward declaration inside namespace Aestra silently creates a second,
+// unrelated type and makes the name ambiguous wherever both are visible.
+class AestraContent;
+
+namespace Aestra {
+
+namespace Audio { class MuseService; }
+
+/**
+ * @brief Register the application's capabilities into a MuseService.
+ *
+ * This is the application side of the seam introduced in #612. MuseService lives
+ * in AestraAudio and cannot reach the UI layer — the dependency deliberately runs
+ * the other way — so the app hands it callables at startup and MuseService never
+ * learns what an AestraContent is.
+ *
+ * A verb registered here is an APPLICATION CAPABILITY, not a UI gesture:
+ * view.open takes the name of a workspace, not the coordinates of a button.
+ * The first survives a UI redesign; the second would make Muse an accessibility
+ * macro system welded to today's widget tree.
+ *
+ * Every verb here is main-thread affine. The socket server executes requests from
+ * the frame pump, so that is satisfied in the app and correctly refused in
+ * headless processes, which have no UI thread to satisfy it with.
+ *
+ * @param content borrowed, must outlive the service.
+ */
+void registerMuseHostVerbs(Audio::MuseService& service, ::AestraContent& content);
+
+} // namespace Aestra

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -12,6 +12,7 @@ set(Aestra_SOURCES
 	App/Main.cpp
 	App/AestraApp.h
 	App/AestraApp.cpp
+    App/MuseHostVerbs.cpp
 	
 	# Core
 	Core/AestraAudioController.h

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1870,6 +1870,18 @@ bool AestraContent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 // SECTION: View Management
 // =============================================================================
 
+bool AestraContent::isViewOpen(Audio::ViewType view) const {
+    switch (view) {
+    case Audio::ViewType::Mixer:     return m_viewState.mixerOpen;
+    case Audio::ViewType::PianoRoll: return m_viewState.pianoRollOpen;
+    case Audio::ViewType::Sequencer: return m_viewState.sequencerOpen;
+    case Audio::ViewType::Playlist:  return m_viewState.playlistActive;
+    case Audio::ViewType::History:   return m_historyPanel && m_historyPanel->isVisible();
+    case Audio::ViewType::Takes:     return m_takesPanel && m_takesPanel->isVisible();
+    }
+    return false;
+}
+
 void AestraContent::setViewOpen(Audio::ViewType view, bool open) {
     bool changed = false;
     switch (view) {

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -159,6 +159,15 @@ public:
     void setViewOpen(Aestra::Audio::ViewType view, bool open);
     /** @brief Toggle visibility for a specific workspace overlay. */
     void toggleView(Aestra::Audio::ViewType view);
+    /**
+     * @brief Whether a workspace overlay is currently open.
+     *
+     * The view state was previously write-only from outside this class: callers
+     * could open and close overlays but had no way to ask what was showing. The
+     * Muse host verbs need to answer "what is on screen right now" without
+     * guessing, so the state is now readable as well as writable.
+     */
+    bool isViewOpen(Aestra::Audio::ViewType view) const;
     /** @brief Toggle visibility of the left browser area. */
     void toggleFileBrowser();
     /** @brief Synchronize overlay state into owned child views. */


### PR DESCRIPTION
The first host verbs. #612 shipped the `HostVerbRegistry` seam with **zero verbs registered**; this is the application side that makes it real.

## What it does

```bash
AESTRA_MUSE_PORT=41952 ./Aestra    # then, from any terminal:
muse view.current --result
muse view.open  --view pianoRoll
muse view.close --view mixer
```

`AestraApp` hands `MuseService` callables at startup. `MuseService` still has no idea what an `AestraContent` is — the dependency runs `Source/` → `MuseService`, never the reverse.

## Capabilities, not gestures

`view.open` takes the **name of a workspace**, not the coordinates of a button, so it survives a UI redesign.

The names are protocol — they appear in `get_capabilities` and agents will hardcode them — so two deliberately use the *product's* vocabulary rather than the code's:

| verb name | internal enum |
|---|---|
| `arsenal` | `ViewType::Sequencer` |
| `timeline` | `ViewType::Playlist` |

The enum is free to move. The strings are not.

## Supporting change

`AestraContent` gains `isViewOpen()`. View state was **write-only from outside the class** — callers could open and close overlays but could not ask what was showing, so `view.current` had nothing to read.

## Details worth reviewing

- **The result carries `changed`.** "Already open" and "just opened" are both successes, and a caller that cannot tell them apart will re-issue commands trying to force a change that already happened.
- **Lookup is case-insensitive.** An agent that read `pianoRoll` from `get_capabilities` and typed `pianoroll` has made no meaningful error.
- **All three are `HostUiThread` affine, `mutates=false`** — window layout is not project state and has nothing to undo. `AestraApp` sets `hostUiThreadAvailable(true)` because the socket server executes from the frame pump; headless processes leave it false and refuse with a reason.
- `MuseHostVerbs.h` forward-declares `AestraContent` in the **global** namespace, which is where it actually lives — the `namespace Aestra` block above its declaration closes before the class. Declaring it inside `namespace Aestra` silently creates a second, unrelated type and makes the name ambiguous at every existing use. That mistake cost a build; the comment is there so it costs nobody else one.

## Verified by driving the running app, not asserted

Closed the mixer and opened the piano roll over the socket, confirmed **on screen**, and confirmed `view.current` reflected it:

```
view.close --view mixer      -> {"changed":true,  "open":false, "view":"mixer"}
view.open  --view pianoRoll  -> {"changed":true,  "open":true,  "view":"pianoRoll"}
view.open  --view pianoRoll  -> {"changed":false, "open":true,  "view":"pianoRoll"}
```

Refusals verified too — each fails by name with a machine-readable code:

| input | result |
|---|---|
| `--view nonsense` | `no_such_view`, lists the known views |
| no `--view` | `missing_arg` |
| `--veiw mixer` | `invalid_args`, names the unknown arg |
| `--view PIANOROLL` | accepted |

Native verbs (`get_transport`) still dispatch unaffected.

## Not in this PR

`settings.*` — the settings model needs locating first; the pages under `Source/Settings/` are views over state that lives elsewhere. Worth its own change rather than guessing at it here.
