### PR TITLE
feat(routing): separate Playlist lanes from Mixer Inserts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,23 @@
 
 -
 
+## Producer note
+
+<!-- One sentence for the public changelog, in the voice of someone who
+     makes beats — or "None". Default is None; most PRs are internal.
+
+     Test: finish "now you can ..." or "X no longer ...".
+     If neither sentence works, it's internal. Answer None.
+
+       None                  refactor, test wiring, CI, dead code
+       "Hitting pause no longer rewinds you."          <- ships
+       "RMS detection with parameter smoothing"        <- fails the test
+
+     Rough wording is fine. It gets polished at release time, when
+     it's 25 lines to review instead of 400 commits to reconstruct. -->
+
+None
+
 ## Docs Updated?
 
 - [ ] Yes

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,8 @@ autosave.*
 # Audit cache files (regenerated on each run)
 .aestra/audit/*.json
 !.aestra/audit/snapshots/
+
+# Reverb lab scratch: local listening/AB/prototype artefacts, not source
+labs/reverb/listening/
+labs/reverb/tremolo/ab/
+labs/reverb/tremolo/proto/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,7 +556,7 @@ Write one sentence a producer would understand, or `None`.
   code removal and internal renames. Most PRs are `None`.
 * Rough wording is fine. It gets edited at release time.
 
-```
+```text
 "Hitting pause no longer rewinds you."        <- ships
 "RMS detection with parameter smoothing"      <- fails the test, use None
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,8 +537,37 @@ PRs should include:
 * Summary
 * Why
 * Testing performed
+* Producer note
 * Docs updated?
 * Risk/rollback notes
+
+### Producer note — required, defaults to `None`
+
+This field is consumed by a **different repository**. The public
+changelog on aestra.studio is built from it: `Aestra-website` runs
+`npm run changelog:draft`, which harvests every `## Producer note`
+block from PRs merged since the last release and prints a draft entry.
+
+Write one sentence a producer would understand, or `None`.
+
+* Test: finish **"now you can ..."** or **"X no longer ..."**.
+  If neither sentence works, it is internal — answer `None`.
+* `None` is the correct answer for refactors, test wiring, CI, dead
+  code removal and internal renames. Most PRs are `None`.
+* Rough wording is fine. It gets edited at release time.
+
+```
+"Hitting pause no longer rewinds you."        <- ships
+"RMS detection with parameter smoothing"      <- fails the test, use None
+```
+
+**Why this exists:** the website changelog once fell 374 commits
+behind, because reconstructing user-facing impact after the fact from
+engineering commit titles is unreliable even when done carefully — a
+manual pass over that backlog still missed a step-sequencer overhaul
+and a deleted-track restore fix. The note is cheap to write while the
+change is fresh and expensive to recover later. Agents opening a PR
+must fill this in rather than leaving the template placeholder.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,14 +561,6 @@ Write one sentence a producer would understand, or `None`.
 "RMS detection with parameter smoothing"      <- fails the test, use None
 ```
 
-**Why this exists:** the website changelog once fell 374 commits
-behind, because reconstructing user-facing impact after the fact from
-engineering commit titles is unreliable even when done carefully — a
-manual pass over that backlog still missed a step-sequencer overhaul
-and a deleted-track restore fix. The note is cheap to write while the
-change is fresh and expensive to recover later. Agents opening a PR
-must fill this in rather than leaving the template placeholder.
-
 ---
 
 ## 22. CodeRabbit and Review Tools

--- a/AestraAudio/include/Commands/ArrangePatternCommand.h
+++ b/AestraAudio/include/Commands/ArrangePatternCommand.h
@@ -5,8 +5,6 @@
 #include "Models/TrackManager.h"
 
 #include <string>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 namespace Aestra {
@@ -17,15 +15,12 @@ namespace Audio {
  *
  * Mirrors the whole pattern-drop gesture the timeline UI performs, not just
  * the clip insert:
- *  - creates playlist lanes up to the target track index (the app maintains
- *    a 1:1 lane/channel mapping),
- *  - routes every unit referenced by the pattern's notes to that timeline
- *    lane (route authority for playback and export),
+ *  - appends a Playlist lane when the target is the next lane index,
  *  - adds a pattern-bound clip sized to the pattern length.
  *
- * Undo removes the clip, restores each unit's previous route, and removes
- * any lanes this command created. Like AddChannelCommand, redo after undo
- * mints fresh lane/clip IDs.
+ * Unit-to-mixer routing is intentionally independent from clip placement.
+ * Undo removes the clip and any lanes this command created. Like
+ * AddChannelCommand, redo after undo mints fresh lane/clip IDs.
  */
 class ArrangePatternCommand : public ICommand {
 public:
@@ -37,25 +32,16 @@ public:
     void execute() override {
         if (m_executed) return;
         m_createdLanes.clear();
-        m_previousUnitRoutes.clear();
 
         auto& playlist = m_trackManager.getPlaylistModel();
-        auto& unitManager = m_trackManager.getUnitManager();
         const PatternSource* pattern = m_trackManager.getPatternManager().getPattern(m_patternId);
         if (!pattern || !pattern->isMidi()) return;
 
-        // A failure after partial mutation must not leave lanes or routes
-        // behind: unwind everything staged so far before returning without
-        // m_executed set.
+        // A failure after partial mutation must not leave lanes behind.
         const auto rollbackStaged = [&]() {
-            for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend();
-                 ++it) {
-                unitManager.assignUnitToTimelineLane(it->first, it->second);
-            }
             for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
                 playlist.removeLane(*it);
             }
-            m_previousUnitRoutes.clear();
             m_createdLanes.clear();
         };
 
@@ -72,15 +58,6 @@ public:
         if (!laneId.isValid()) {
             rollbackStaged();
             return;
-        }
-
-        std::unordered_set<UnitID> routed;
-        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
-            if (note.unitId == 0 || !routed.insert(note.unitId).second) continue;
-            if (!unitManager.getUnit(note.unitId)) continue;
-            m_previousUnitRoutes.emplace_back(note.unitId,
-                                              unitManager.getUnitTimelineLane(note.unitId));
-            unitManager.assignUnitToTimelineLane(note.unitId, static_cast<int>(m_trackIndex));
         }
 
         ClipInstance clip;
@@ -102,12 +79,8 @@ public:
     void undo() override {
         if (!m_executed) return;
         auto& playlist = m_trackManager.getPlaylistModel();
-        auto& unitManager = m_trackManager.getUnitManager();
 
         playlist.removeClip(m_clipId);
-        for (auto it = m_previousUnitRoutes.rbegin(); it != m_previousUnitRoutes.rend(); ++it) {
-            unitManager.assignUnitToTimelineLane(it->first, it->second);
-        }
         for (auto it = m_createdLanes.rbegin(); it != m_createdLanes.rend(); ++it) {
             playlist.removeLane(*it);
         }
@@ -131,7 +104,6 @@ private:
 
     // Recorded by execute() for undo
     std::vector<PlaylistLaneID> m_createdLanes;
-    std::vector<std::pair<UnitID, int>> m_previousUnitRoutes;
     ClipInstanceID m_clipId;
     bool m_executed = false;
 };

--- a/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
+++ b/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
@@ -86,6 +86,14 @@ private:
                 usedChannelIds.insert(channelId);
             }
         }
+        for (const auto& pattern : m_manager.getPatternManager().getAllPatterns()) {
+            if (!pattern || !pattern->isAudio())
+                continue;
+            const uint32_t channelId = pattern->getMixerChannelId();
+            if (channelId != MASTER_MIXER_CHANNEL_ID) {
+                usedChannelIds.insert(channelId);
+            }
+        }
 
         for (size_t i = 0; i < m_manager.getChannelCount(); ++i) {
             const auto* channel = m_manager.getChannel(i);

--- a/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
+++ b/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
@@ -1,0 +1,141 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <memory>
+#include <unordered_set>
+
+namespace Aestra {
+namespace Audio {
+
+/** Assign a unit to the first unused insert, atomically creating a lane and insert when necessary. */
+class AssignUnitToFirstFreeInsertCommand final : public ICommand {
+public:
+    AssignUnitToFirstFreeInsertCommand(TrackManager& manager, UnitID unitId, std::string destinationName,
+                                       uint32_t color)
+        : m_manager(manager), m_unitId(unitId), m_destinationName(std::move(destinationName)), m_color(color) {}
+
+    void execute() override {
+        if (m_executed || !m_manager.getUnitManager().getUnit(m_unitId))
+            return;
+
+        if (!m_capturedPreviousRoute) {
+            m_previousChannelId = m_manager.getUnitManager().getUnitMixerChannel(m_unitId);
+            m_capturedPreviousRoute = true;
+        }
+
+        if (m_createdDestination) {
+            auto& playlist = m_manager.getPlaylistModel();
+            const auto restoredLaneId = playlist.createLaneWithId(m_laneId, m_destinationName);
+            if (restoredLaneId != m_laneId) {
+                playlist.removeLane(restoredLaneId);
+                return;
+            }
+            if (!m_manager.reinsertChannel(m_detachedChannel, m_channelIndex)) {
+                playlist.removeLane(m_laneId);
+                return;
+            }
+            if (auto* lane = playlist.getLane(m_laneId)) {
+                lane->colorRGBA = m_color;
+            }
+        } else if (m_destinationChannelId == MASTER_MIXER_CHANNEL_ID) {
+            selectOrCreateDestination();
+            if (m_destinationChannelId == MASTER_MIXER_CHANNEL_ID)
+                return;
+        }
+
+        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_destinationChannelId);
+        m_manager.markModified();
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+
+        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_previousChannelId);
+        if (m_createdDestination) {
+            m_detachedChannel = m_manager.detachChannelById(m_destinationChannelId, m_channelIndex);
+            if (!m_detachedChannel) {
+                m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_destinationChannelId);
+                return;
+            }
+            m_manager.getPlaylistModel().removeLane(m_laneId);
+        }
+        m_manager.markModified();
+        m_executed = false;
+    }
+
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Assign Unit to First Free Insert"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+    bool isUndoable() const override { return m_executed; }
+
+private:
+    void selectOrCreateDestination() {
+        std::unordered_set<uint32_t> usedChannelIds;
+        for (const UnitID unitId : m_manager.getUnitManager().getAllUnitIDs()) {
+            if (unitId == m_unitId)
+                continue;
+            const uint32_t channelId = m_manager.getUnitManager().getUnitMixerChannel(unitId);
+            if (channelId != MASTER_MIXER_CHANNEL_ID) {
+                usedChannelIds.insert(channelId);
+            }
+        }
+
+        for (size_t i = 0; i < m_manager.getChannelCount(); ++i) {
+            const auto* channel = m_manager.getChannel(i);
+            if (channel && usedChannelIds.find(channel->getChannelId()) == usedChannelIds.end()) {
+                m_destinationChannelId = channel->getChannelId();
+                return;
+            }
+        }
+
+        auto& playlist = m_manager.getPlaylistModel();
+        m_laneId = playlist.createLane(m_destinationName);
+        if (!m_laneId.isValid())
+            return;
+
+        auto* channel = m_manager.addChannel(m_destinationName);
+        if (!channel) {
+            playlist.removeLane(m_laneId);
+            m_laneId = {};
+            return;
+        }
+
+        m_destinationChannelId = channel->getChannelId();
+        channel->setColor(m_color);
+        if (auto* lane = playlist.getLane(m_laneId)) {
+            lane->colorRGBA = m_color;
+        }
+        m_createdDestination = true;
+    }
+
+    TrackManager& m_manager;
+    UnitID m_unitId;
+    std::string m_destinationName;
+    uint32_t m_color;
+    uint32_t m_previousChannelId{MASTER_MIXER_CHANNEL_ID};
+    uint32_t m_destinationChannelId{MASTER_MIXER_CHANNEL_ID};
+    PlaylistLaneID m_laneId;
+    std::unique_ptr<MixerChannel> m_detachedChannel;
+    size_t m_channelIndex{0};
+    bool m_capturedPreviousRoute{false};
+    bool m_createdDestination{false};
+    bool m_executed{false};
+};
+
+/** Execute and record first-free routing, reporting whether project state changed. */
+inline bool assignUnitToFirstFreeInsert(TrackManager& manager, UnitID unitId, const std::string& destinationName,
+                                        uint32_t color) {
+    auto command = std::make_shared<AssignUnitToFirstFreeInsertCommand>(manager, unitId, destinationName, color);
+    manager.getCommandHistory().pushAndExecute(command);
+    return command->isUndoable();
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MakeAudioClipUniqueCommand.h
+++ b/AestraAudio/include/Commands/MakeAudioClipUniqueCommand.h
@@ -24,13 +24,19 @@ public:
         const auto* sourcePattern = m_manager.getPatternManager().getPattern(clip->patternId);
         if (!sourcePattern || !sourcePattern->isAudio())
             return;
-        m_originalPatternId = clip->patternId;
-        m_uniquePatternId = m_manager.getPatternManager().clonePattern(m_originalPatternId);
-        if (!m_uniquePatternId.isValid())
-            return;
+        if (!m_originalPatternId.isValid()) {
+            m_originalPatternId = clip->patternId;
+        }
+        if (m_detachedPattern) {
+            if (!m_manager.getPatternManager().reinsertPattern(m_detachedPattern))
+                return;
+        } else {
+            m_uniquePatternId = m_manager.getPatternManager().clonePattern(m_originalPatternId);
+            if (!m_uniquePatternId.isValid())
+                return;
+        }
         if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_uniquePatternId)) {
-            m_manager.getPatternManager().removePattern(m_uniquePatternId);
-            m_uniquePatternId = {};
+            m_detachedPattern = m_manager.getPatternManager().detachPattern(m_uniquePatternId);
             return;
         }
         m_manager.markModified();
@@ -41,8 +47,7 @@ public:
         if (!m_executed)
             return;
         if (m_manager.getPlaylistModel().setClipPattern(m_clipId, m_originalPatternId)) {
-            m_manager.getPatternManager().removePattern(m_uniquePatternId);
-            m_uniquePatternId = {};
+            m_detachedPattern = m_manager.getPatternManager().detachPattern(m_uniquePatternId);
             m_manager.markModified();
             m_executed = false;
         }
@@ -59,6 +64,7 @@ private:
     ClipInstanceID m_clipId;
     PatternID m_originalPatternId;
     PatternID m_uniquePatternId;
+    std::unique_ptr<PatternSource> m_detachedPattern;
     bool m_executed{false};
 };
 

--- a/AestraAudio/include/Commands/MakeAudioClipUniqueCommand.h
+++ b/AestraAudio/include/Commands/MakeAudioClipUniqueCommand.h
@@ -1,0 +1,66 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * Give one Playlist audio clip its own pattern identity while retaining the
+ * same underlying audio buffer and current source route.
+ */
+class MakeAudioClipUniqueCommand final : public ICommand {
+public:
+    MakeAudioClipUniqueCommand(TrackManager& manager, ClipInstanceID clipId) : m_manager(manager), m_clipId(clipId) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+        const auto* clip = m_manager.getPlaylistModel().getClip(m_clipId);
+        if (!clip || !clip->patternId.isValid())
+            return;
+        const auto* sourcePattern = m_manager.getPatternManager().getPattern(clip->patternId);
+        if (!sourcePattern || !sourcePattern->isAudio())
+            return;
+        m_originalPatternId = clip->patternId;
+        m_uniquePatternId = m_manager.getPatternManager().clonePattern(m_originalPatternId);
+        if (!m_uniquePatternId.isValid())
+            return;
+        if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_uniquePatternId)) {
+            m_manager.getPatternManager().removePattern(m_uniquePatternId);
+            m_uniquePatternId = {};
+            return;
+        }
+        m_manager.markModified();
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+        if (m_manager.getPlaylistModel().setClipPattern(m_clipId, m_originalPatternId)) {
+            m_manager.getPatternManager().removePattern(m_uniquePatternId);
+            m_uniquePatternId = {};
+            m_manager.markModified();
+            m_executed = false;
+        }
+    }
+
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Make Audio Clip Unique"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_manager;
+    ClipInstanceID m_clipId;
+    PatternID m_originalPatternId;
+    PatternID m_uniquePatternId;
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/MuseStubs.h
+++ b/AestraAudio/include/Commands/MuseStubs.h
@@ -5,6 +5,7 @@
 #include "Models/TrackManager.h"
 
 #include <string>
+#include <vector>
 
 namespace Aestra {
 namespace Audio {
@@ -67,6 +68,9 @@ private:
     int m_trackIndex;
     std::string m_deletedName;
     uint32_t m_deletedId = 0;
+    std::vector<UnitID> m_routedUnits;
+    std::vector<PatternID> m_routedAudioPatterns;
+    bool m_routesCaptured = false;
     bool m_executed = false;
     /**
      * The removed channel itself, held alive while the delete stands.

--- a/AestraAudio/include/Commands/SetAudioPatternMixerChannelCommand.h
+++ b/AestraAudio/include/Commands/SetAudioPatternMixerChannelCommand.h
@@ -1,0 +1,53 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+namespace Aestra {
+namespace Audio {
+
+/** Undoable source-owned routing change for an audio pattern. */
+class SetAudioPatternMixerChannelCommand final : public ICommand {
+public:
+    SetAudioPatternMixerChannelCommand(TrackManager& manager, PatternID patternId, uint32_t newChannelId)
+        : m_manager(manager), m_patternId(patternId), m_newChannelId(newChannelId) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+        const auto* pattern = m_manager.getPatternManager().getPattern(m_patternId);
+        if (!pattern || !pattern->isAudio())
+            return;
+        m_originalChannelId = pattern->getMixerChannelId();
+        m_executed = m_manager.setAudioPatternMixerChannel(m_patternId, m_newChannelId);
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+        if (m_manager.setAudioPatternMixerChannel(m_patternId, m_originalChannelId)) {
+            m_executed = false;
+        }
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+        m_executed = m_manager.setAudioPatternMixerChannel(m_patternId, m_newChannelId);
+    }
+
+    std::string getName() const override { return "Route Audio Source"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_manager;
+    PatternID m_patternId;
+    uint32_t m_originalChannelId{MASTER_MIXER_CHANNEL_ID};
+    uint32_t m_newChannelId{MASTER_MIXER_CHANNEL_ID};
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetClipEditsCommand.h
+++ b/AestraAudio/include/Commands/SetClipEditsCommand.h
@@ -1,0 +1,63 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/ClipInstance.h"
+#include "Models/PlaylistModel.h"
+
+namespace Aestra {
+namespace Audio {
+
+/** Undoable replacement of one Playlist clip instance's playback properties. */
+class SetClipEditsCommand final : public ICommand {
+public:
+    SetClipEditsCommand(PlaylistModel& model, ClipInstanceID clipId, ClipEdits newEdits)
+        : m_model(model), m_clipId(clipId), m_newEdits(newEdits) {}
+
+    SetClipEditsCommand(PlaylistModel& model, ClipInstanceID clipId, ClipEdits originalEdits, ClipEdits newEdits,
+                        bool alreadyExecuted)
+        : m_model(model), m_clipId(clipId), m_originalEdits(originalEdits), m_newEdits(newEdits), m_hasOriginal(true),
+          m_executed(alreadyExecuted) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+        if (!m_hasOriginal) {
+            const auto* clip = m_model.getClip(m_clipId);
+            if (!clip)
+                return;
+            m_originalEdits = clip->edits;
+            m_hasOriginal = true;
+        }
+        m_executed = m_model.setClipEdits(m_clipId, m_newEdits);
+    }
+
+    void undo() override {
+        if (!m_executed || !m_hasOriginal)
+            return;
+        if (m_model.setClipEdits(m_clipId, m_originalEdits)) {
+            m_executed = false;
+        }
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+        m_executed = m_model.setClipEdits(m_clipId, m_newEdits);
+    }
+
+    std::string getName() const override { return "Edit Audio Clip"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    PlaylistModel& m_model;
+    ClipInstanceID m_clipId;
+    ClipEdits m_originalEdits;
+    ClipEdits m_newEdits;
+    bool m_hasOriginal{false};
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetUnitMixerChannelCommand.h
+++ b/AestraAudio/include/Commands/SetUnitMixerChannelCommand.h
@@ -1,0 +1,57 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+namespace Aestra {
+namespace Audio {
+
+/** Route an Arsenal unit to a stable mixer destination through CommandHistory. */
+class SetUnitMixerChannelCommand final : public ICommand {
+public:
+    SetUnitMixerChannelCommand(TrackManager& manager, UnitID unitId, uint32_t channelId)
+        : m_manager(manager), m_unitId(unitId), m_channelId(channelId) {}
+
+    void execute() override {
+        if (m_executed || !m_manager.getUnitManager().getUnit(m_unitId))
+            return;
+        m_previousChannelId = m_manager.getUnitManager().getUnitMixerChannel(m_unitId);
+        if (m_previousChannelId == m_channelId)
+            return;
+        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_channelId);
+        m_manager.markModified();
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_previousChannelId);
+        m_manager.markModified();
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_channelId);
+        m_manager.markModified();
+        m_executed = true;
+    }
+
+    std::string getName() const override { return "Route Unit to Mixer Insert"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+    bool isUndoable() const override { return m_executed; }
+
+private:
+    TrackManager& m_manager;
+    UnitID m_unitId;
+    uint32_t m_channelId;
+    uint32_t m_previousChannelId{MASTER_MIXER_CHANNEL_ID};
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetUnitMixerChannelCommand.h
+++ b/AestraAudio/include/Commands/SetUnitMixerChannelCommand.h
@@ -32,13 +32,7 @@ public:
         m_executed = false;
     }
 
-    void redo() override {
-        if (m_executed)
-            return;
-        m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_channelId);
-        m_manager.markModified();
-        m_executed = true;
-    }
+    void redo() override { execute(); }
 
     std::string getName() const override { return "Route Unit to Mixer Insert"; }
     size_t getSizeInBytes() const override { return sizeof(*this); }

--- a/AestraAudio/include/Core/ArsenalProcessingContext.h
+++ b/AestraAudio/include/Core/ArsenalProcessingContext.h
@@ -38,6 +38,10 @@ public:
     ArsenalRouteMode resolveRouteMode(const UnitInfo& unit) const noexcept;
     ArsenalRouteMode resolveRouteMode(const UnitState& unit) const noexcept;
 
+    bool shouldRenderToMixerChannel(const UnitState& unit, uint32_t mixerChannelId) const noexcept;
+    bool shouldRenderToMaster(const UnitState& unit) const noexcept;
+
+    // Compatibility helpers for legacy Timeline ownership metadata.
     bool shouldRenderToTimelineTrack(const UnitState& unit, uint32_t trackIndex) const noexcept;
     bool shouldRenderToMasterPreview(const UnitState& unit) const noexcept;
     bool isFutureDraftMode(const UnitState& unit) const noexcept;

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -14,13 +14,13 @@
 #include "EngineState.h"
 #include "GarbageCollector.h"
 #include "Interpolators.h"
-#include "Playback/LiveMidiQueue.h"
 #include "LatencyTopology.h"
 #include "MasterSafetyLimiter.h"
 #include "MeterSnapshot.h"
 #include "MetronomeEngine.h"     // [NEW]
 #include "Models/TrackManager.h" // [NEW] For headless rendering
-#include "PluginHost.h"          // For MidiBuffer [NEW]
+#include "Playback/LiveMidiQueue.h"
+#include "PluginHost.h" // For MidiBuffer [NEW]
 
 #include <array>
 #include <atomic>
@@ -667,7 +667,7 @@ private:
     std::atomic<DitheringMode> m_ditheringMode{DitheringMode::Triangular}; // Default TPDF
 
     TrackRTState& ensureTrackState(uint32_t trackId);
-    void renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset = 0);
+    void renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset, uint64_t patternFrameStart);
     // Block-stable values renderGraph() derives once per call and every
     // per-track render reads. Bundled so renderTrack() takes them as one
     // argument instead of re-loading atomics per track.
@@ -679,6 +679,7 @@ private:
         uint64_t blockEnd;
         bool isPlaying;
         bool anySolo;
+        bool anyUnitSolo;
         uint32_t cachedSampleRate;
         const ChannelSlotMap* cachedSlotMap;
         ContinuousParamBuffer* cachedParams;
@@ -695,22 +696,21 @@ private:
     // renderGraph() per-track loop body; srcActiveThisBlock is the loop-carried
     // "any resampling happened" telemetry flag.
     // renderTrack phase helpers (verbatim extractions; RT path — no allocation).
-    void renderTrackClips(const TrackRenderState& track, std::vector<double>& buffer, const RenderContext& ctx,
-                          bool& srcActiveThisBlock);
-    void renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffer, const RenderContext& ctx);
+    void renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
+                     bool& srcActiveThisBlock);
+    void renderTrackUnits(uint32_t mixerChannelId, std::vector<double>& buffer, const RenderContext& ctx);
     float processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
                               uint32_t numFrames);
     void mixAndMeterTrack(const TrackRenderState& track, uint32_t trackIdx, uint32_t slot, TrackRTState& state,
                           std::vector<double>& buffer, const RenderContext& ctx, double volTarget, double panTarget,
                           float trackSidechainPeak, bool muted, bool audibleEligible);
-    void renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx,
-                     bool& srcActiveThisBlock);
+    void renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx, bool& srcActiveThisBlock);
     void prepareTrackStateForGraph(const AudioGraph& graph);
     void applyPendingCommands();
     void applyPendingMetronomeCountInRt();
     void clearMetronomeCountInRt();
     void processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset, uint64_t startFrame,
-                             double* targetBuffer = nullptr, int32_t isolatedTrackIndex = -1);
+                             double* targetBuffer = nullptr, int64_t isolatedMixerChannelId = -1);
     // processBlock leaf phases (audio thread only). Each is a verbatim
     // extraction of a self-contained section of processBlock; state lives in
     // the members they always used.

--- a/AestraAudio/include/Core/AudioGraph.h
+++ b/AestraAudio/include/Core/AudioGraph.h
@@ -33,6 +33,8 @@ struct ClipRenderState {
     uint32_t channels{2};                      // Source channels (1=mono, 2=stereo)
     float gain{1.0f};
     float pan{0.0f};
+    uint64_t fadeInSamples{0};
+    uint64_t fadeOutSamples{0};
 };
 
 /**
@@ -76,6 +78,8 @@ struct AudioGraph {
     static constexpr size_t kInvalidTrackIndex = std::numeric_limits<size_t>::max();
 
     std::vector<TrackRenderState> tracks;
+    /** Audio clips whose source routes directly to Master. */
+    std::vector<ClipRenderState> masterClips;
     bool anySolo{false};
     // Precomputed max end sample across all clips (engine sample rate).
     // Used for transport looping without scanning clips on the RT thread.

--- a/AestraAudio/include/Core/AudioRenderer.h
+++ b/AestraAudio/include/Core/AudioRenderer.h
@@ -69,12 +69,9 @@ static constexpr uint32_t CLIP_EDGE_FADE_SAMPLES = 128;
 
 private:
     /**
-     * @brief Helper to render Arsenal units assigned to a specific Timeline track.
-     *
-     * Current behavior is intentionally unchanged: routeId == trackIndex renders
-     * into that track path before Timeline track effects.
+     * @brief Render units assigned to a stable mixer channel before its effects.
      */
-    void renderArsenalUnitsForTrack(uint32_t trackIndex, double* trackBuffer, const Context& ctx,
+    void renderArsenalUnitsForTrack(uint32_t mixerChannelId, double* trackBuffer, const Context& ctx,
                                     AudioEngine& engineRef);
 
 private:

--- a/AestraAudio/include/Core/AutomationCurve.h
+++ b/AestraAudio/include/Core/AutomationCurve.h
@@ -48,6 +48,8 @@ struct AutomationPoint {
 
 struct AutomationCurve {
     uint32_t laneId{0};
+    /** Stable mixer insert destination. Zero means unassigned, not lane index zero. */
+    uint32_t mixerChannelId{0};
     std::vector<AutomationPoint> points;
 
     // Extended fields for full AutomationCurve API

--- a/AestraAudio/include/Headless/HeadlessMusicGenerator.h
+++ b/AestraAudio/include/Headless/HeadlessMusicGenerator.h
@@ -289,7 +289,7 @@ private:
     // build (com.Aestrastudios.sampler is the only always-available instrument).
     bool prepareToneSample();
     // Get-or-create the mixer channel + playlist lane + sampler unit that plays
-    // MIDI placed on `laneIndex`, routed to that timeline lane and on to master.
+    // MIDI placed on `laneIndex`, routed to that lane's stable mixer channel.
     // Returns the unit id, or 0 on failure.
     uint64_t ensureLaneInstrument(uint32_t laneIndex);
 

--- a/AestraAudio/include/Models/PatternManager.h
+++ b/AestraAudio/include/Models/PatternManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "PatternSource.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <unordered_map>
@@ -132,6 +133,48 @@ public:
         pattern->id = id;
         m_patterns[id.value] = std::move(pattern);
         return id;
+    }
+
+    /** Route an audio pattern to a stable mixer channel ID (0 means Master). */
+    bool setPatternMixerChannel(PatternID id, uint32_t channelId) {
+        auto* pattern = getPattern(id);
+        if (!pattern || !pattern->isAudio()) {
+            return false;
+        }
+        pattern->setMixerChannelId(channelId);
+        pattern->legacyMixerRoutePending = false;
+        return true;
+    }
+
+    /** Reset audio patterns that target a mixer channel being removed. */
+    bool resetMixerChannel(uint32_t channelId) {
+        bool changed = false;
+        for (auto& [id, pattern] : m_patterns) {
+            (void)id;
+            if (pattern && pattern->isAudio() && pattern->getMixerChannelId() == channelId) {
+                pattern->setMixerChannelId(0);
+                pattern->legacyMixerRoutePending = false;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    /** Resolve missing/invalid audio-pattern destinations after project channels load. */
+    void validateMixerChannels(const std::vector<uint32_t>& mixerChannelIds) {
+        for (auto& [id, pattern] : m_patterns) {
+            (void)id;
+            if (!pattern || !pattern->isAudio()) {
+                continue;
+            }
+            const uint32_t channelId = pattern->getMixerChannelId();
+            if (pattern->legacyMixerRoutePending ||
+                (channelId != 0 &&
+                 std::find(mixerChannelIds.begin(), mixerChannelIds.end(), channelId) == mixerChannelIds.end())) {
+                pattern->setMixerChannelId(0);
+            }
+            pattern->legacyMixerRoutePending = false;
+        }
     }
 
     /**

--- a/AestraAudio/include/Models/PatternManager.h
+++ b/AestraAudio/include/Models/PatternManager.h
@@ -186,6 +186,36 @@ public:
     }
 
     /**
+     * @brief Detach a pattern while preserving its identity and state for undo.
+     * @param id Pattern identifier to detach.
+     * @return Ownership of the pattern, or nullptr when it was not found.
+     */
+    std::unique_ptr<PatternSource> detachPattern(PatternID id) {
+        const auto it = m_patterns.find(id.value);
+        if (it == m_patterns.end()) {
+            return nullptr;
+        }
+        auto pattern = std::move(it->second);
+        m_patterns.erase(it);
+        return pattern;
+    }
+
+    /**
+     * @brief Reinsert a detached pattern with the same stable identity.
+     * @param pattern Detached pattern ownership; retained by the caller on failure.
+     * @return True when the pattern was restored.
+     */
+    bool reinsertPattern(std::unique_ptr<PatternSource>& pattern) {
+        if (!pattern || !pattern->id.isValid() || getPattern(pattern->id)) {
+            return false;
+        }
+        const uint64_t id = pattern->id.value;
+        m_patterns[id] = std::move(pattern);
+        nextId = std::max(nextId, id + 1);
+        return true;
+    }
+
+    /**
      * @brief Get or create a pattern
      * @param id Pattern identifier to look up or create.
      * @return Pointer to the requested pattern.

--- a/AestraAudio/include/Models/PatternSource.h
+++ b/AestraAudio/include/Models/PatternSource.h
@@ -90,11 +90,20 @@ public:
     double lengthBeats{4.0};
     Type type{Type::Empty};
     std::variant<std::monostate, MidiPayload, AudioSlicePayload> payload;
-    int m_mixerChannel{-1};
+    /** Stable mixer destination for audio patterns (0 routes directly to Master). */
+    uint32_t m_mixerChannelId{0};
+    /** True while a pre-source-routing project awaits lane-based migration. */
+    bool legacyMixerRoutePending{false};
     std::optional<ScaleContext> scaleOverride;
 
-    int getMixerChannel() const { return m_mixerChannel; }
-    void setMixerChannel(int ch) { m_mixerChannel = ch; }
+    uint32_t getMixerChannelId() const { return m_mixerChannelId; }
+    void setMixerChannelId(uint32_t channelId) { m_mixerChannelId = channelId; }
+
+    // Compatibility accessors for older UI callers. Values are stable IDs, not indexes.
+    int getMixerChannel() const {
+        return m_mixerChannelId <= static_cast<uint32_t>(INT32_MAX) ? static_cast<int>(m_mixerChannelId) : 0;
+    }
+    void setMixerChannel(int channelId) { m_mixerChannelId = channelId > 0 ? static_cast<uint32_t>(channelId) : 0; }
 
     bool isMidi() const { return type == Type::Midi && std::holds_alternative<MidiPayload>(payload); }
 

--- a/AestraAudio/include/Models/PatternSource.h
+++ b/AestraAudio/include/Models/PatternSource.h
@@ -99,12 +99,6 @@ public:
     uint32_t getMixerChannelId() const { return m_mixerChannelId; }
     void setMixerChannelId(uint32_t channelId) { m_mixerChannelId = channelId; }
 
-    // Compatibility accessors for older UI callers. Values are stable IDs, not indexes.
-    int getMixerChannel() const {
-        return m_mixerChannelId <= static_cast<uint32_t>(INT32_MAX) ? static_cast<int>(m_mixerChannelId) : 0;
-    }
-    void setMixerChannel(int channelId) { m_mixerChannelId = channelId > 0 ? static_cast<uint32_t>(channelId) : 0; }
-
     bool isMidi() const { return type == Type::Midi && std::holds_alternative<MidiPayload>(payload); }
 
     bool isAudio() const { return type == Type::Audio && std::holds_alternative<AudioSlicePayload>(payload); }

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -131,6 +131,13 @@ public:
         return m_lanes.size();
     }
 
+    /** @brief Return whether any unmuted Playlist lane is currently soloed. */
+    bool hasAudibleSoloLane() const {
+        std::shared_lock<std::shared_mutex> lock(m_mutex);
+        return std::any_of(m_lanes.begin(), m_lanes.end(),
+                           [](const PlaylistLane& lane) { return lane.solo && !lane.muted; });
+    }
+
     // === Clip Management ===
 
     /**
@@ -471,12 +478,18 @@ public:
                 clipInfo.startTime = static_cast<uint64_t>(clip.startBeat * samplesPerBeat);
                 clipInfo.duration = static_cast<uint64_t>(clip.durationBeats * samplesPerBeat);
                 clipInfo.sourceStart = static_cast<uint64_t>(clip.sourceOffset * samplesPerBeat);
-                clipInfo.gainLinear = clip.edits.gainLinear;
-                clipInfo.pan = std::clamp(clip.edits.pan, -1.0f, 1.0f);
-                clipInfo.fadeInSamples =
-                    static_cast<uint64_t>(std::max(0.0, static_cast<double>(clip.edits.fadeInBeats)) * samplesPerBeat);
-                clipInfo.fadeOutSamples =
-                    static_cast<uint64_t>(std::max(0.0, static_cast<double>(clip.edits.fadeOutBeats)) * samplesPerBeat);
+                clipInfo.gainLinear = std::isfinite(clip.edits.gainLinear) ? clip.edits.gainLinear : 1.0f;
+                clipInfo.pan =
+                    std::isfinite(clip.edits.pan) ? std::clamp(clip.edits.pan, -1.0f, 1.0f) : 0.0f;
+                const double fadeInBeats =
+                    std::isfinite(clip.edits.fadeInBeats) ? std::max(0.0, static_cast<double>(clip.edits.fadeInBeats))
+                                                         : 0.0;
+                const double fadeOutBeats =
+                    std::isfinite(clip.edits.fadeOutBeats)
+                        ? std::max(0.0, static_cast<double>(clip.edits.fadeOutBeats))
+                        : 0.0;
+                clipInfo.fadeInSamples = static_cast<uint64_t>(fadeInBeats * samplesPerBeat);
+                clipInfo.fadeOutSamples = static_cast<uint64_t>(fadeOutBeats * samplesPerBeat);
                 clipInfo.isAudioClip = true;
 
                 if (!laneAudible || clip.edits.muted) {

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -206,6 +206,43 @@ public:
     }
 
     /**
+     * @brief Replace the editable playback properties for one clip instance.
+     *
+     * The mutation stays behind PlaylistModel's lock and emits the normal clip
+     * change notification so the immutable audio graph is rebuilt off-thread.
+     */
+    bool setClipEdits(const ClipInstanceID& clipId, const ClipEdits& edits) {
+        {
+            std::unique_lock<std::shared_mutex> lock(m_mutex);
+            auto* clip = getClipInternal(clipId);
+            if (!clip) {
+                return false;
+            }
+            clip->edits = edits;
+        }
+        notifyClipChanged(clipId);
+        return true;
+    }
+
+    /** Replace the source pattern referenced by one clip instance. */
+    bool setClipPattern(const ClipInstanceID& clipId, PatternID patternId) {
+        if (!patternId.isValid()) {
+            return false;
+        }
+        {
+            std::unique_lock<std::shared_mutex> lock(m_mutex);
+            auto* clip = getClipInternal(clipId);
+            if (!clip) {
+                return false;
+            }
+            clip->patternId = patternId;
+            clip->sourceId = patternId.value;
+        }
+        notifyClipChanged(clipId);
+        return true;
+    }
+
+    /**
      * @brief Find which lane a clip belongs to
      * @param clipId Clip identifier to resolve.
      * @return Owning lane identifier, or an invalid identifier when missing.
@@ -420,22 +457,37 @@ public:
 
         const double samplesPerBeat = (m_projectSampleRate * 60.0) / snapshot->bpm;
 
+        const bool anyLaneSolo = std::any_of(m_lanes.begin(), m_lanes.end(),
+                                             [](const PlaylistLane& lane) { return lane.solo && !lane.muted; });
+
         for (const auto& lane : m_lanes) {
             LaneRuntimeInfo laneInfo;
             laneInfo.clips.reserve(lane.clips.size());
+
+            const bool laneAudible = !lane.muted && (!anyLaneSolo || lane.solo);
 
             for (const auto& clip : lane.clips) {
                 ClipRuntimeInfo clipInfo;
                 clipInfo.startTime = static_cast<uint64_t>(clip.startBeat * samplesPerBeat);
                 clipInfo.duration = static_cast<uint64_t>(clip.durationBeats * samplesPerBeat);
                 clipInfo.sourceStart = static_cast<uint64_t>(clip.sourceOffset * samplesPerBeat);
-                clipInfo.gainLinear = clip.edits.gain;
+                clipInfo.gainLinear = clip.edits.gainLinear;
+                clipInfo.pan = std::clamp(clip.edits.pan, -1.0f, 1.0f);
+                clipInfo.fadeInSamples =
+                    static_cast<uint64_t>(std::max(0.0, static_cast<double>(clip.edits.fadeInBeats)) * samplesPerBeat);
+                clipInfo.fadeOutSamples =
+                    static_cast<uint64_t>(std::max(0.0, static_cast<double>(clip.edits.fadeOutBeats)) * samplesPerBeat);
                 clipInfo.isAudioClip = true;
+
+                if (!laneAudible || clip.edits.muted) {
+                    continue;
+                }
 
                 // Resolve audio data through pattern → AudioSlicePayload → source
                 if (clip.patternId.isValid()) {
                     auto* pattern = patterns.getPattern(clip.patternId);
                     if (pattern && pattern->isAudio()) {
+                        clipInfo.mixerChannelId = pattern->getMixerChannelId();
                         auto& audioPayload = std::get<AudioSlicePayload>(pattern->payload);
                         if (auto* source = sources.getSource(audioPayload.audioSourceId)) {
                             // Phase 4 (F1): prefer the anti-aliased filtered copy when
@@ -622,8 +674,16 @@ public:
     std::vector<MidiClipPlaybackInstance> collectMidiClipInstances(const PatternManager& patterns) const {
         std::shared_lock<std::shared_mutex> lock(m_mutex);
         std::vector<MidiClipPlaybackInstance> instances;
+        const bool anyLaneSolo = std::any_of(m_lanes.begin(), m_lanes.end(),
+                                             [](const PlaylistLane& lane) { return lane.solo && !lane.muted; });
         for (const auto& lane : m_lanes) {
+            if (lane.muted || (anyLaneSolo && !lane.solo)) {
+                continue;
+            }
             for (const auto& clip : lane.clips) {
+                if (clip.edits.muted) {
+                    continue;
+                }
                 if (!clip.patternId.isValid()) {
                     continue;
                 }

--- a/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
+++ b/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
@@ -34,6 +34,10 @@ struct ClipRuntimeInfo {
     // Parameters
     float gainLinear{1.0f};
     float pan{0.0f};
+    uint64_t fadeInSamples{0};
+    uint64_t fadeOutSamples{0};
+    /** Stable source-level mixer destination (0 routes directly to Master). */
+    uint32_t mixerChannelId{0};
 
     // Type
     bool isAudioClip{true};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -137,7 +137,7 @@ public:
             m_nextChannelId = std::max(m_nextChannelId, channelId + 1);
         }
         auto channel = std::make_unique<MixerChannel>(
-            name.empty() ? "Insert " + std::to_string(m_channels.size() + 1) : name, channelId);
+            name.empty() ? "Insert " + std::to_string(channelId) : name, channelId);
         channel->setCommandSink(m_commandSink);
         channel->setInputMonitoringStateChangedCallback([this]() { publishInputMonitoringSnapshot(); });
         if (m_channelPrepareCallback) {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -2,6 +2,8 @@
 #include "../Core/GraphDirtyReason.h"
 #include "../Commands/AddClipCommand.h"
 #include "../Commands/CommandHistory.h"
+#include "../Commands/CommandTransaction.h"
+#include "../Commands/CreateLaneCommand.h"
 #include "../Core/AudioCommandQueue.h"
 #include "../Core/AudioTelemetry.h"
 #include "../Core/ChannelSlotMap.h"
@@ -108,14 +110,34 @@ public:
     /**
      * @brief Add a new channel
      */
-    MixerChannel* addChannel(const std::string& name = "") {
+    MixerChannel* addChannel(const std::string& name = "") { return addChannelWithId(name, 0); }
+
+    /**
+     * @brief Add a channel while restoring a persisted stable identity.
+     * @param name User-facing channel name.
+     * @param requestedId Persisted channel ID, or 0 to mint a new ID.
+     */
+    MixerChannel* addChannelWithId(const std::string& name, uint32_t requestedId) {
         if (reportRealtimeMisuse("TrackManager::addChannel")) {
             return nullptr;
         }
-        // IDs start at 1 to avoid collision with Master (ID 0).
-        const uint32_t channelId = m_nextChannelId++;
+        // IDs start at 1 to avoid collision with Master (ID 0). A duplicate or
+        // invalid persisted ID is replaced instead of aliasing two live routes.
+        constexpr uint32_t invalidChannelId = std::numeric_limits<uint32_t>::max();
+        uint32_t channelId = requestedId;
+        if (channelId == 0 || channelId == invalidChannelId || getChannelById(channelId) != nullptr) {
+            while (m_nextChannelId != invalidChannelId && getChannelById(m_nextChannelId) != nullptr) {
+                ++m_nextChannelId;
+            }
+            if (m_nextChannelId == invalidChannelId) {
+                return nullptr;
+            }
+            channelId = m_nextChannelId++;
+        } else {
+            m_nextChannelId = std::max(m_nextChannelId, channelId + 1);
+        }
         auto channel = std::make_unique<MixerChannel>(
-            name.empty() ? "Track " + std::to_string(m_channels.size() + 1) : name, channelId);
+            name.empty() ? "Insert " + std::to_string(m_channels.size() + 1) : name, channelId);
         channel->setCommandSink(m_commandSink);
         channel->setInputMonitoringStateChangedCallback([this]() { publishInputMonitoringSnapshot(); });
         if (m_channelPrepareCallback) {
@@ -148,6 +170,9 @@ public:
     bool removeLastChannel() {
         if (m_channels.empty())
             return false;
+        const uint32_t removedChannelId = m_channels.back()->getChannelId();
+        m_unitManager.resetMixerChannel(removedChannelId);
+        m_patternManager.resetMixerChannel(removedChannelId);
         m_channels.pop_back();
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         m_modified.store(true, std::memory_order_relaxed);
@@ -166,6 +191,8 @@ public:
             return false;
         }
 
+        m_unitManager.resetMixerChannel(channelId);
+        m_patternManager.resetMixerChannel(channelId);
         m_channels.erase(it);
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         m_modified.store(true, std::memory_order_relaxed);
@@ -267,6 +294,35 @@ public:
      * @return Const track pointer or nullptr when out of range.
      */
     const MixerChannel* getTrack(size_t index) const { return getChannel(index); }
+
+    /** @brief Find a mixer channel by stable ID. */
+    MixerChannel* getChannelById(uint32_t channelId) {
+        const size_t index = findChannelIndexById(channelId);
+        return index < m_channels.size() ? m_channels[index].get() : nullptr;
+    }
+
+    /** @brief Find a mixer channel by stable ID. */
+    const MixerChannel* getChannelById(uint32_t channelId) const {
+        const size_t index = findChannelIndexById(channelId);
+        return index < m_channels.size() ? m_channels[index].get() : nullptr;
+    }
+
+    /** Route an audio source pattern independently from Playlist placement. */
+    bool setAudioPatternMixerChannel(PatternID patternId, int64_t channelId) {
+        uint32_t resolvedId = MASTER_MIXER_CHANNEL_ID;
+        if (channelId > 0 && channelId < static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+            const uint32_t candidate = static_cast<uint32_t>(channelId);
+            if (getChannelById(candidate)) {
+                resolvedId = candidate;
+            }
+        }
+        if (!m_patternManager.setPatternMixerChannel(patternId, resolvedId)) {
+            return false;
+        }
+        requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+        m_modified.store(true, std::memory_order_relaxed);
+        return true;
+    }
 
     /**
      * @brief Get the playlist model
@@ -1176,16 +1232,14 @@ private:
                 const auto& midi = std::get<MidiPayload>(pattern->payload);
                 size_t noteCount = midi.notes.size();
                 UnitID firstUnitId = noteCount > 0 ? midi.notes.front().unitId : 0;
-                int firstRoute = -999;
+                uint32_t firstMixerChannelId = MASTER_MIXER_CHANNEL_ID;
                 if (firstUnitId != 0) {
                     if (auto* unit = m_unitManager.getUnit(firstUnitId)) {
-                        firstRoute = unit->targetMixerRoute;
-                    } else {
-                        firstRoute = -998;
+                        firstMixerChannelId = unit->targetMixerChannelId;
                     }
                 }
                 routeSummary = "notes=" + std::to_string(noteCount) + " firstUnit=" + std::to_string(firstUnitId) +
-                               " firstRoute=" + std::to_string(firstRoute);
+                               " firstMixerChannelId=" + std::to_string(firstMixerChannelId);
             }
 
             Log::info("[TimelinePattern] pattern=" + std::to_string(instance.patternId.value) +
@@ -1310,15 +1364,9 @@ private:
             return;
         }
 
-        const size_t channelIndex = findChannelIndexById(channelId);
-        if (channelIndex == static_cast<size_t>(-1)) {
-            Log::warning("[TrackManager] Could not resolve lane for recorded track " + std::to_string(channelId));
-            return;
-        }
-
-        PlaylistLaneID laneId = m_playlistModel.getLaneId(channelIndex);
-        if (!laneId.isValid()) {
-            Log::warning("[TrackManager] Invalid lane target for recorded track " + std::to_string(channelId));
+        if (!getChannelById(channelId)) {
+            Log::warning("[TrackManager] Could not resolve mixer insert for recorded take " +
+                         std::to_string(channelId));
             return;
         }
 
@@ -1379,6 +1427,7 @@ private:
             Log::error("[TrackManager] Failed to create audio pattern for recorded take.");
             return;
         }
+        m_patternManager.setPatternMixerChannel(patternId, channelId);
 
         ClipInstance clip;
         clip.id = ClipInstanceID::generate();
@@ -1391,14 +1440,43 @@ private:
         clip.edits.gain = playbackGain;
         clip.edits.gainLinear = playbackGain;
 
-        auto cmd = std::make_shared<AddClipCommand>(m_playlistModel, laneId, clip);
-        m_commandHistory.pushAndExecute(cmd);
+        // Recording destination and Playlist placement are separate. Create a
+        // lane for the take while the PatternSource retains the armed insert.
+        auto createLane = std::make_shared<CreateLaneCommand>(m_playlistModel, takeName);
+        createLane->execute();
+        const PlaylistLaneID laneId = createLane->getLaneId();
+        if (!laneId.isValid()) {
+            m_patternManager.removePattern(patternId);
+            Log::error("[TrackManager] Failed to create a Playlist lane for recorded take.");
+            return;
+        }
+
+        auto addClip = std::make_shared<AddClipCommand>(m_playlistModel, laneId, clip);
+        addClip->execute();
+        if (!m_playlistModel.getClip(clip.id)) {
+            createLane->undo();
+            m_patternManager.removePattern(patternId);
+            Log::error("[TrackManager] Failed to place recorded take on its Playlist lane.");
+            return;
+        }
+
+        auto transaction = std::make_shared<CommandTransaction>("Record Take");
+        transaction->add(createLane);
+        transaction->add(addClip);
+        transaction->markExecuted();
+        if (!m_commandHistory.pushExecuted(transaction)) {
+            addClip->undo();
+            createLane->undo();
+            m_patternManager.removePattern(patternId);
+            Log::error("[TrackManager] Failed to add recorded take to command history.");
+            return;
+        }
         requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
         m_modified.store(true, std::memory_order_relaxed);
 
-        Log::info("[TrackManager] Recorded take committed: " + takePath + " on track " + std::to_string(channelId) +
-                  " at beat " + std::to_string(startBeat) + " with raw peak " + std::to_string(rawPeak) +
-                  ", conditioned peak " + std::to_string(conditionedPeak) + ", clip gain " +
+        Log::info("[TrackManager] Recorded take committed: " + takePath + " to mixer insert " +
+                  std::to_string(channelId) + " at beat " + std::to_string(startBeat) + " with raw peak " +
+                  std::to_string(rawPeak) + ", conditioned peak " + std::to_string(conditionedPeak) + ", clip gain " +
                   std::to_string(playbackGain));
     }
 

--- a/AestraAudio/include/Models/UnitManager.h
+++ b/AestraAudio/include/Models/UnitManager.h
@@ -18,12 +18,13 @@ namespace Audio {
 // Forward declarations
 class PatternManager;
 using UnitID = uint64_t;
+constexpr uint32_t MASTER_MIXER_CHANNEL_ID = 0;
 
 /**
  * @brief Explicit interpretation of current Arsenal route semantics.
  *
- * This enum is scaffolding for context ownership cleanup. It maps to the
- * existing `routeId` / `targetMixerRoute` behavior and does not alter routing.
+ * This enum preserves older Arsenal-to-Timeline ownership metadata. Mixer
+ * output routing is stored independently as a stable channel ID.
  */
 enum class ArsenalRouteMode : uint8_t {
     PreviewToMaster = 0,
@@ -72,28 +73,27 @@ struct UnitInfo {
     /**
      * @brief Timeline lane assignment compatibility field.
      *
-     * Current behavior maps this integer directly to route mode:
-     * - < 0 routes unit output to master preview path.
-     * - >= 0 routes unit output to the Timeline track at that index.
-     *
-     * Arsenal currently participates in the main engine render path. Timeline
-     * remains arrangement/export authority, and export follows live processBlock
-     * routing behavior.
+     * Older projects used this integer as both placement metadata and audio
+     * routing. It is retained for compatibility, but mixer output now follows
+     * @ref targetMixerChannelId.
      */
     int targetMixerRoute{-1};
+    /** @brief Stable mixer destination ID (0 routes directly to Master). */
+    uint32_t targetMixerChannelId{MASTER_MIXER_CHANNEL_ID};
+    /** @brief True while an older lane-index route awaits project-load migration. */
+    bool legacyMixerRoutePending{false};
     /**
      * @brief Explicit route mode field (Phase 2A scaffolding).
      *
-     * Compatibility note: current rendering authority remains legacy
-     * @ref targetMixerRoute mapping. This field is kept aligned for explicitness
-     * and future migration, but does not change current behavior.
+     * Compatibility note: this remains aligned with the legacy lane value and
+     * does not select mixer output.
      */
     ArsenalRouteMode routeMode{ArsenalRouteMode::PreviewToMaster};
-    /** @brief Effective route mode, preserving legacy route fields as authority until cleared. */
+    /** @brief Effective legacy Timeline ownership mode. */
     ArsenalRouteMode getRouteMode() const noexcept { return arsenalRouteModeFromRouteId(targetMixerRoute); }
-    /** @brief True when this unit currently routes into the Timeline track path. */
+    /** @brief True when this unit carries a legacy Timeline assignment. */
     bool routesToTimelineTrack() const noexcept { return getRouteMode() == ArsenalRouteMode::RoutedToTimelineTrack; }
-    /** @brief True when this unit currently routes to master preview path. */
+    /** @brief True when this unit has no legacy Timeline assignment. */
     bool routesToMasterPreview() const noexcept { return getRouteMode() == ArsenalRouteMode::PreviewToMaster; }
     /**
      * @brief Ownership metadata for Arsenal->Timeline bridge semantics.
@@ -150,12 +150,12 @@ struct UnitState {
     /** @brief Plugin instance used for rendering. */
     std::shared_ptr<IPluginInstance> plugin;
     /**
-     * @brief Legacy route id consumed by current render path.
-     *
-     * - < 0 routes to master preview path
-     * - >= 0 routes to Timeline track path
+     * @brief Legacy Timeline ownership metadata retained for compatibility.
+     * Mixer rendering uses @ref mixerChannelId.
      */
     int routeId;
+    /** @brief Stable mixer destination ID (0 routes directly to Master). */
+    uint32_t mixerChannelId{MASTER_MIXER_CHANNEL_ID};
     /** @brief Linear output gain applied at the unit's mix point. */
     float gain{1.0f};
     /** @brief True when the unit is muted (audio thread visibility). */
@@ -165,10 +165,10 @@ struct UnitState {
     /**
      * @brief Explicit route mode snapshot field (Phase 2A scaffolding).
      *
-     * Compatibility note: current rendering authority remains @ref routeId.
+     * Compatibility note: mixer rendering authority is @ref mixerChannelId.
      */
     ArsenalRouteMode routeMode{ArsenalRouteMode::PreviewToMaster};
-    /** @brief Effective route mode, preserving legacy route fields as authority until cleared. */
+    /** @brief Effective legacy Timeline ownership mode. */
     ArsenalRouteMode getRouteMode() const noexcept { return arsenalRouteModeFromRouteId(routeId); }
     /** @brief True when this unit currently routes into the Timeline track path. */
     bool routesToTimelineTrack() const noexcept { return getRouteMode() == ArsenalRouteMode::RoutedToTimelineTrack; }
@@ -183,9 +183,7 @@ struct AudioArsenalSnapshot {
     /**
      * @brief Ordered list of unit states visible to the audio engine.
      *
-     * Snapshot data currently feeds Arsenal processing that runs inside the main
-     * engine render path. Export authority remains tied to Timeline/live
-     * processBlock behavior.
+     * Live and export rendering consume the same stable mixer destinations.
      */
     std::vector<UnitState> units;
 };
@@ -276,11 +274,17 @@ public:
     void setUnitArmed(UnitID id, bool armed);
     /** @brief Set enabled state for a unit. */
     void setUnitEnabled(UnitID id, bool enabled);
-    /** @brief Legacy alias for Timeline lane assignment. */
-    void setUnitMixerChannel(UnitID id, int channel);
-    /** @brief Assign a unit to a Timeline lane for arrangement playback. */
+    /** @brief Route a unit to a stable mixer channel ID (0 or negative means Master). */
+    void setUnitMixerChannel(UnitID id, int64_t channelId);
+    /** @brief Return the unit's stable mixer destination ID (0 means Master). */
+    uint32_t getUnitMixerChannel(UnitID id) const;
+    /** @brief Resolve lane-index routes from projects saved before stable mixer IDs existed. */
+    void migrateLegacyMixerRoutes(const std::vector<uint32_t>& mixerChannelIds);
+    /** @brief Reset units targeting a mixer channel that is being removed. */
+    bool resetMixerChannel(uint32_t channelId);
+    /** @brief Retain a legacy Timeline lane assignment for ownership compatibility. */
     void assignUnitToTimelineLane(UnitID id, int laneIndex);
-    /** @brief Clear any Timeline lane assignment so the unit previews to master. */
+    /** @brief Clear legacy Timeline ownership metadata without changing mixer output. */
     void clearUnitTimelineLane(UnitID id);
     /** @brief Get the current Timeline lane assignment, or -1 when none. */
     int getUnitTimelineLane(UnitID id) const;

--- a/AestraAudio/include/Models/UnitManager.h
+++ b/AestraAudio/include/Models/UnitManager.h
@@ -274,8 +274,8 @@ public:
     void setUnitArmed(UnitID id, bool armed);
     /** @brief Set enabled state for a unit. */
     void setUnitEnabled(UnitID id, bool enabled);
-    /** @brief Route a unit to a stable mixer channel ID (0 or negative means Master). */
-    void setUnitMixerChannel(UnitID id, int64_t channelId);
+    /** @brief Route a unit to a stable mixer channel ID (0 means Master). */
+    void setUnitMixerChannel(UnitID id, uint32_t channelId);
     /** @brief Return the unit's stable mixer destination ID (0 means Master). */
     uint32_t getUnitMixerChannel(UnitID id) const;
     /** @brief Resolve lane-index routes from projects saved before stable mixer IDs existed. */

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -168,16 +168,9 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
         uint64_t maxEndSample = 0;
         double projectSampleRate = playlist.getProjectSampleRate();
 
-        // Map snapshot lanes to mixer tracks.
-        // In the current implementation, lane index usually corresponds to mixer channel index.
+        // Playlist lanes are arrangement-only. Audio patterns carry their own
+        // stable mixer destination, so moving a clip between lanes cannot reroute it.
         for (size_t laneIdx = 0; laneIdx < snapshot->lanes.size(); ++laneIdx) {
-            if (laneIdx >= graph.tracks.size()) {
-                AESTRA_DEBUG_ONLY(std::cerr << "[AudioGraphBuilder] Warning: snapshot has more lanes (" << snapshot->lanes.size()
-                          << ") than mixer tracks (" << graph.tracks.size() << "). Extra lanes dropped.\n");
-                break;
-            }
-
-            auto& trackState = graph.tracks[laneIdx];
             // Non-const: automationCurves below is genuinely moved out of the
             // snapshot (std::move through a const ref silently copies).
             auto& laneInfo = snapshot->lanes[laneIdx];
@@ -213,14 +206,42 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
 
                 clip.gain = clipInfo.gainLinear;
                 clip.pan = clipInfo.pan;
+                clip.fadeInSamples = clipInfo.fadeInSamples;
+                clip.fadeOutSamples = clipInfo.fadeOutSamples;
 
                 if (clip.endSample > maxEndSample) {
                     maxEndSample = clip.endSample;
                 }
 
-                trackState.clips.push_back(std::move(clip));
+                if (clipInfo.mixerChannelId == 0) {
+                    graph.masterClips.push_back(std::move(clip));
+                } else {
+                    const auto destination = std::find_if(graph.tracks.begin(), graph.tracks.end(),
+                                                          [&clipInfo](const TrackRenderState& track) {
+                                                              return track.trackId == clipInfo.mixerChannelId;
+                                                          });
+                    if (destination != graph.tracks.end()) {
+                        destination->clips.push_back(std::move(clip));
+                    } else {
+                        // Missing/corrupt destinations fail safe to Master rather
+                        // than dropping an audible source from the project.
+                        graph.masterClips.push_back(std::move(clip));
+                    }
+                }
             }
-            trackState.automationCurves = std::move(laneInfo.automationCurves);
+
+            // Automation is displayed on Playlist lanes but targets an
+            // explicit stable mixer insert. A lane may host curves for
+            // multiple inserts without owning any of them.
+            for (auto& curve : laneInfo.automationCurves) {
+                const auto destination =
+                    std::find_if(graph.tracks.begin(), graph.tracks.end(), [&curve](const TrackRenderState& track) {
+                        return curve.mixerChannelId != 0 && track.trackId == curve.mixerChannelId;
+                    });
+                if (destination != graph.tracks.end()) {
+                    destination->automationCurves.push_back(std::move(curve));
+                }
+            }
         }
 
         graph.timelineEndSample = maxEndSample;

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -89,8 +89,10 @@ void AudioRenderer::renderBlock(const Context& ctx, AudioGraphState& state, Audi
         // 1. Render Clips (Generates Audio) -> track.selfBuffer
         renderClipAudio(track.selfBuffer, trackState, track.trackIndex, ctx, engineRef);
 
-        // [NEW] 1.5 Render Arsenal Units assigned to this track
-        renderArsenalUnitsForTrack(track.trackIndex, track.selfBuffer, ctx, engineRef);
+        // 1.5 Render units assigned to this track's stable mixer identity.
+        if (track.trackIndex < ctx.graph->tracks.size()) {
+            renderArsenalUnitsForTrack(ctx.graph->tracks[track.trackIndex].trackId, track.selfBuffer, ctx, engineRef);
+        }
 
         // 2. Process Effects (In-Place) -> track.selfBuffer
         processTrackEffects(track, state, ctx.numFrames, ctx.bufferOffset, engineRef, *ctx.graph);
@@ -371,18 +373,22 @@ void AudioRenderer::processTrackEffects(const RenderTrack& track, AudioGraphStat
     }
 }
 
-void AudioRenderer::renderArsenalUnitsForTrack(uint32_t trackIndex, double* trackBuffer, const Context& ctx,
+void AudioRenderer::renderArsenalUnitsForTrack(uint32_t mixerChannelId, double* trackBuffer, const Context& ctx,
                                                AudioEngine& engineRef) {
     // Arsenal currently participates inside the main engine render path.
     ArsenalProcessingContext arsenal(engineRef.m_unitManager.load(std::memory_order_acquire));
     auto snap = arsenal.getSnapshot();
     if (!snap || snap->units.empty())
         return;
+    const bool anyUnitSolo = std::any_of(snap->units.begin(), snap->units.end(), [](const UnitState& unit) {
+        return unit.enabled && unit.isSolo && !unit.isMuted;
+    });
 
     const float* ins[2] = {engineRef.m_silentBufferF.data(), engineRef.m_silentBufferF.data()};
     size_t bIdx = 0;
     for (const auto& u : snap->units) {
-        if (u.enabled && u.plugin && arsenal.shouldRenderToTimelineTrack(u, trackIndex)) {
+        if (u.enabled && u.plugin && !u.isMuted && (!anyUnitSolo || u.isSolo) &&
+            arsenal.shouldRenderToMixerChannel(u, mixerChannelId)) {
             std::fill(engineRef.m_pluginBufferF.begin(), engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2, 0.0f);
             float* outs[2] = {engineRef.m_pluginBufferF.data(), engineRef.m_pluginBufferF.data() + ctx.numFrames};
             MidiBuffer* mIn =
@@ -397,9 +403,10 @@ void AudioRenderer::renderArsenalUnitsForTrack(uint32_t trackIndex, double* trac
             }
 
             double* dst = trackBuffer + (size_t)ctx.bufferOffset * 2;
+            const double unitGain = static_cast<double>(u.gain);
             for (uint32_t i = 0; i < ctx.numFrames; ++i) {
-                dst[i * 2] += (double)outs[0][i];
-                dst[i * 2 + 1] += (double)outs[1][i];
+                dst[i * 2] += static_cast<double>(outs[0][i]) * unitGain;
+                dst[i * 2 + 1] += static_cast<double>(outs[1][i]) * unitGain;
             }
         }
         bIdx++;
@@ -415,12 +422,14 @@ void AudioRenderer::processArsenalUnits(const Context& ctx, AudioEngine& engineR
     auto snap = arsenal.getSnapshot();
     if (!snap || snap->units.empty())
         return;
+    const bool anyUnitSolo = std::any_of(snap->units.begin(), snap->units.end(), [](const UnitState& unit) {
+        return unit.enabled && unit.isSolo && !unit.isMuted;
+    });
 
     const float* ins[2] = {engineRef.m_silentBufferF.data(), engineRef.m_silentBufferF.data()};
     size_t bIdx = 0;
     for (const auto& u : snap->units) {
-        // Only handle units not routed to a Timeline track.
-        if (u.enabled && u.plugin && arsenal.shouldRenderToMasterPreview(u)) {
+        if (u.enabled && u.plugin && !u.isMuted && (!anyUnitSolo || u.isSolo) && arsenal.shouldRenderToMaster(u)) {
             std::fill(engineRef.m_pluginBufferF.begin(), engineRef.m_pluginBufferF.begin() + ctx.numFrames * 2, 0.0f);
             float* outs[2] = {engineRef.m_pluginBufferF.data(), engineRef.m_pluginBufferF.data() + ctx.numFrames};
             MidiBuffer* mIn =
@@ -435,9 +444,10 @@ void AudioRenderer::processArsenalUnits(const Context& ctx, AudioEngine& engineR
             }
 
             double* dst = ctx.masterBuffer + (size_t)ctx.bufferOffset * 2;
+            const double unitGain = static_cast<double>(u.gain);
             for (uint32_t i = 0; i < ctx.numFrames; ++i) {
-                dst[i * 2] += (double)outs[0][i];
-                dst[i * 2 + 1] += (double)outs[1][i];
+                dst[i * 2] += static_cast<double>(outs[0][i]) * unitGain;
+                dst[i * 2 + 1] += static_cast<double>(outs[1][i]) * unitGain;
             }
         }
         bIdx++;

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -403,7 +403,7 @@ void AudioRenderer::renderArsenalUnitsForTrack(uint32_t mixerChannelId, double* 
             }
 
             double* dst = trackBuffer + (size_t)ctx.bufferOffset * 2;
-            const double unitGain = static_cast<double>(u.gain);
+            const double unitGain = std::isfinite(u.gain) ? static_cast<double>(u.gain) : 1.0;
             for (uint32_t i = 0; i < ctx.numFrames; ++i) {
                 dst[i * 2] += static_cast<double>(outs[0][i]) * unitGain;
                 dst[i * 2 + 1] += static_cast<double>(outs[1][i]) * unitGain;
@@ -444,7 +444,7 @@ void AudioRenderer::processArsenalUnits(const Context& ctx, AudioEngine& engineR
             }
 
             double* dst = ctx.masterBuffer + (size_t)ctx.bufferOffset * 2;
-            const double unitGain = static_cast<double>(u.gain);
+            const double unitGain = std::isfinite(u.gain) ? static_cast<double>(u.gain) : 1.0;
             for (uint32_t i = 0; i < ctx.numFrames; ++i) {
                 dst[i * 2] += static_cast<double>(outs[0][i]) * unitGain;
                 dst[i * 2 + 1] += static_cast<double>(outs[1][i]) * unitGain;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -587,22 +587,10 @@ void CommandRegistry::initialize() {
         const PatternSource* pattern = tm->getPatternManager().getPattern(patternId);
         if (!pattern || !pattern->isMidi())
             return CommandRegistry::fail("no such MIDI pattern: " + std::string(*patternRaw));
-        // Tracks are mixer channels; the command creates matching playlist
-        // lanes, but the channel itself must already exist.
-        if (static_cast<size_t>(*trackOpt) >= tm->getChannelCount())
-            return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
-
-        // A unit has a single timeline route: arranging it onto a different
-        // track would silently reroute every earlier clip that uses it.
-        // Reject the conflict instead of corrupting existing arrangements.
-        for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
-            if (note.unitId == 0) continue;
-            const int route = tm->getUnitManager().getUnitTimelineLane(note.unitId);
-            if (route >= 0 && route != *trackOpt)
-                return CommandRegistry::fail(
-                    "unit " + std::to_string(note.unitId) + " is already routed to track " +
-                    std::to_string(route) + "; arrange on that track or undo the earlier arrange");
-        }
+        // The target is a Playlist lane. Permit exactly one append position;
+        // mixer insert count is intentionally unrelated.
+        if (static_cast<size_t>(*trackOpt) > tm->getPlaylistModel().getLaneCount())
+            return CommandRegistry::fail("no such playlist lane: " + std::string(*trackRaw));
 
         return std::make_unique<ArrangePatternCommand>(*tm, patternId,
                                                        static_cast<size_t>(*trackOpt),

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -141,7 +141,7 @@ static const std::vector<CommandSchema> s_schemas = {
         {"track", FlagType::Int, true, 0.0},
         {"start", FlagType::Float, true, 0.0}
     },
-     "Place a pattern on the timeline as a clip, routing its units to that track. A unit routes to at most one track; conflicts are rejected."},
+     "Place a pattern on the timeline as a clip. Arrangement does not change the pattern units' mixer destinations."},
     // steps: one char per step — 'x' hit, 'X' accented hit, '-' or '.' rest.
     // The string defines the ENTIRE row for that (unit, pitch): re-issuing
     // the verb rewrites the groove, an all-rest string clears it.
@@ -275,10 +275,10 @@ std::string schemaToJsonString() {
     // sync with its isQueryVerb()/isActionVerb().
     out << R"("queries": [
   {"verb": "get_transport", "args": "none", "description": "bpm, playing, positionSeconds."},
-  {"verb": "list_tracks", "args": "none", "description": "index, stable id, name, volume, pan, muted, soloed per track."},
-  {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, timelineLane (-1 = preview), samplePath per unit."},
+  {"verb": "list_tracks", "args": "none", "description": "mixer inserts: index, stable id, name, volume, pan, muted, soloed. These are independent from Playlist lanes."},
+  {"verb": "list_units", "args": "none", "description": "id, name, type, defaultPatternId, mixerChannelId (0 = Master), legacy timelineLane, samplePath per unit."},
   {"verb": "list_clips", "args": "none", "description": "playlist lanes with clips (id, name, startBeat, durationBeats, pattern; pattern 0 = not a pattern clip)."},
-  {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount, type per pattern."},
+  {"verb": "list_patterns", "args": "none", "description": "id, name, lengthBeats, noteCount and type; audio sources also include mixerChannelId."},
   {"verb": "list_plugins", "args": "none", "description": "available effect plugins: id, name, category. Use id or name with add_effect."},
   {"verb": "get_effects", "args": "{\"track\": <index>}", "description": "a track's effect chain: slot, id, name, bypassed, and every parameter (id, name, value 0..1, display, unit)."},
   {"verb": "get_meters", "args": "none", "description": "master + per-track meters from the most recently processed audio block: peakDb, rmsDb, lufs, clip flags. Headless this reflects the last render; in-app it is live."},
@@ -298,7 +298,7 @@ std::string schemaToJsonString() {
   "samplerPitch": "The sampler root is MIDI pitch 60: notes at 60 play the loaded sample unshifted, other pitches resample relative to 60. Put drum hits at pitch 60; write melodies around 60.",
   "unitTypes": "sampler = polyphonic sampler; 808 = mono pitched sampler with glide.",
   "patterns": "Every non-audio unit gets a default MIDI pattern at creation (list_units.defaultPatternId). A pattern is just a container: notes carry their unit, so one pattern can hold a whole multi-unit groove.",
-  "routing": "A unit routes to at most one timeline track. arrange_pattern routes the pattern's units to its track and rejects conflicting arrangements.",
+  "routing": "Each unit has one stable mixer destination (mixerChannelId; 0 = Master). Timeline arrangement is independent, so the same pattern may be placed on multiple lanes without changing its audio destination.",
   "steps": "Step strings: 'x' hit at the row velocity, 'X' accented hit (+0.2), digits '1'-'9' hit at velocity n/9, '-', '.', ' ' rest. Default step is 0.25 beats (16ths). swing (0..0.9) delays every second step by swing * step/2 for shuffle feels.",
   "ids": "Track, unit, pattern and clip ids are stable across edits; indexes shift when items are deleted.",
   "units_of_measure": "velocity 0..1, pan -1..1, volume 0..1 linear, positions and durations in beats.",

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -427,7 +427,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 u.set("soloed", JSON(unit->isSolo));
                 u.set("defaultPatternId",
                       JSON(static_cast<double>(unit->defaultPatternId.value)));
-                // -1 = preview-to-master; >= 0 routes into that timeline track.
+                u.set("mixerChannelId", JSON(static_cast<double>(unitManager.getUnitMixerChannel(unitId))));
+                // Compatibility metadata retained for older clients. It no longer controls audio routing.
                 u.set("timelineLane",
                       JSON(static_cast<double>(unitManager.getUnitTimelineLane(unitId))));
                 u.set("samplePath", JSON(unit->audioClipPath));
@@ -773,7 +774,11 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 entry.set("name", JSON(pattern->name));
                 entry.set("lengthBeats", JSON(pattern->lengthBeats));
                 const bool isMidi = pattern->isMidi();
-                entry.set("type", JSON(isMidi ? "midi" : "other"));
+                const bool isAudio = pattern->isAudio();
+                entry.set("type", JSON(isMidi ? "midi" : (isAudio ? "audio" : "other")));
+                if (isAudio) {
+                    entry.set("mixerChannelId", JSON(static_cast<double>(pattern->getMixerChannelId())));
+                }
                 entry.set("noteCount",
                           JSON(isMidi ? static_cast<double>(
                                             std::get<MidiPayload>(pattern->payload).notes.size())
@@ -1229,6 +1234,19 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                                  verb)
                     .toString();
             }
+
+            // Pattern playback now shares the mixer graph with Timeline playback.
+            // Headless callers do not have the app loop to publish recent unit or
+            // channel changes, so prepare the current graph before pumping audio.
+            m_trackManager->buildAndShareSlotMap();
+            if (auto slotMap = m_trackManager->getChannelSlotMapShared()) {
+                m_engine->setChannelSlotMap(slotMap);
+            }
+            PlaybackGraphController graphController;
+            graphController.setTrackManager(m_trackManager);
+            graphController.setAudioEngine(m_engine);
+            graphController.requestRebuild(GraphDirtyReason::TimelineChanged);
+            graphController.drainIfDirty(static_cast<double>(sampleRate));
 
             std::vector<float> rendered;
             rendered.reserve(static_cast<size_t>(totalFrames) * 2u);

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -833,7 +833,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             result.set("name", JSON(pattern->name));
             result.set("lengthBeats", JSON(pattern->lengthBeats));
             const bool isMidi = pattern->isMidi();
-            result.set("type", JSON(isMidi ? "midi" : "other"));
+            result.set("type", JSON(isMidi ? "midi" : (pattern->isAudio() ? "audio" : "other")));
             if (isMidi) {
                 JSON notes = JSON::array();
                 for (const MidiNote& note : std::get<MidiPayload>(pattern->payload).notes) {
@@ -847,6 +847,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     notes.push(n);
                 }
                 result.set("notes", notes);
+            } else if (pattern->isAudio()) {
+                result.set("mixerChannelId", JSON(static_cast<double>(pattern->getMixerChannelId())));
             }
             JSON response = makeOk();
             response.set("result", result);

--- a/AestraAudio/src/Commands/MuseStubs.cpp
+++ b/AestraAudio/src/Commands/MuseStubs.cpp
@@ -6,8 +6,7 @@ namespace Aestra {
 namespace Audio {
 
 // === SetBpmCommand ===
-SetBpmCommand::SetBpmCommand(AudioEngine& engine, float bpm)
-    : m_engine(engine), m_bpm(bpm) {}
+SetBpmCommand::SetBpmCommand(AudioEngine& engine, float bpm) : m_engine(engine), m_bpm(bpm) {}
 
 void SetBpmCommand::execute() {
     if (m_executed)
@@ -37,8 +36,7 @@ std::string SetBpmCommand::getName() const {
 }
 
 // === PlayCommand ===
-PlayCommand::PlayCommand(AudioEngine& engine)
-    : m_engine(engine) {}
+PlayCommand::PlayCommand(AudioEngine& engine) : m_engine(engine) {}
 
 void PlayCommand::execute() {
     if (m_executed)
@@ -67,8 +65,7 @@ std::string PlayCommand::getName() const {
 }
 
 // === StopCommand ===
-StopCommand::StopCommand(AudioEngine& engine)
-    : m_engine(engine) {}
+StopCommand::StopCommand(AudioEngine& engine) : m_engine(engine) {}
 
 void StopCommand::execute() {
     if (m_executed)
@@ -111,13 +108,31 @@ void DeleteTrackCommand::execute() {
     m_deletedName = ch->getName();
     m_deletedId = ch->getChannelId();
 
+    if (!m_routesCaptured) {
+        for (UnitID unitId : m_manager.getUnitManager().getAllUnitIDs()) {
+            if (m_manager.getUnitManager().getUnitMixerChannel(unitId) == m_deletedId) {
+                m_routedUnits.push_back(unitId);
+            }
+        }
+        for (const auto& pattern : m_manager.getPatternManager().getAllPatterns()) {
+            if (pattern && pattern->isAudio() && pattern->getMixerChannelId() == m_deletedId) {
+                m_routedAudioPatterns.push_back(pattern->id);
+            }
+        }
+        m_routesCaptured = true;
+    }
+
     // Detach rather than destroy: this command owns the channel for as long as
     // the delete stands, so undo can put back the same object at the same id
     // and index. See the m_detached comment in the header for why an equivalent
     // channel is not good enough.
     m_detached = m_manager.detachChannelById(m_deletedId, m_detachedIndex);
-    if (m_detached)
+    if (m_detached) {
+        m_manager.getUnitManager().resetMixerChannel(m_deletedId);
+        m_manager.getPatternManager().resetMixerChannel(m_deletedId);
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = true;
+    }
 }
 
 void DeleteTrackCommand::undo() {
@@ -125,6 +140,13 @@ void DeleteTrackCommand::undo() {
         return;
 
     if (m_manager.reinsertChannel(m_detached, m_detachedIndex)) {
+        for (UnitID unitId : m_routedUnits) {
+            m_manager.getUnitManager().setUnitMixerChannel(unitId, m_deletedId);
+        }
+        for (PatternID patternId : m_routedAudioPatterns) {
+            m_manager.getPatternManager().setPatternMixerChannel(patternId, m_deletedId);
+        }
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = false;
     }
 }
@@ -134,8 +156,12 @@ void DeleteTrackCommand::redo() {
         return;
 
     m_detached = m_manager.detachChannelById(m_deletedId, m_detachedIndex);
-    if (m_detached)
+    if (m_detached) {
+        m_manager.getUnitManager().resetMixerChannel(m_deletedId);
+        m_manager.getPatternManager().resetMixerChannel(m_deletedId);
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = true;
+    }
 }
 
 std::string DeleteTrackCommand::getName() const {

--- a/AestraAudio/src/Core/ArsenalProcessingContext.cpp
+++ b/AestraAudio/src/Core/ArsenalProcessingContext.cpp
@@ -29,6 +29,15 @@ ArsenalRouteMode ArsenalProcessingContext::resolveRouteMode(const UnitState& uni
     return routeModeFromRouteId(unit.routeId);
 }
 
+bool ArsenalProcessingContext::shouldRenderToMixerChannel(const UnitState& unit,
+                                                          uint32_t mixerChannelId) const noexcept {
+    return mixerChannelId != MASTER_MIXER_CHANNEL_ID && unit.mixerChannelId == mixerChannelId;
+}
+
+bool ArsenalProcessingContext::shouldRenderToMaster(const UnitState& unit) const noexcept {
+    return unit.mixerChannelId == MASTER_MIXER_CHANNEL_ID;
+}
+
 bool ArsenalProcessingContext::shouldRenderToTimelineTrack(const UnitState& unit, uint32_t trackIndex) const noexcept {
     return resolveRouteMode(unit) == ArsenalRouteMode::RoutedToTimelineTrack && unit.routeId == static_cast<int>(trackIndex);
 }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2189,7 +2189,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             float* outputs[2] = {m_scratchL.data(), m_scratchR.data()};
             unit.plugin->process(nullptr, outputs, 0, 2, numFrames, midiBuf, nullptr);
 
-            const double unitGain = static_cast<double>(unit.gain);
+            const double unitGain = std::isfinite(unit.gain) ? static_cast<double>(unit.gain) : 1.0;
             for (uint32_t i = 0; i < numFrames; ++i) {
                 masterBuf[i * 2] += sanitizeMix(static_cast<double>(outputs[0][i])) * unitGain;
                 masterBuf[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i])) * unitGain;
@@ -2468,7 +2468,7 @@ void AudioEngine::renderTrackUnits(uint32_t mixerChannelId, std::vector<double>&
                 unit.plugin->process(nullptr, outputs, 0, 2, numFrames, midiBuf, nullptr);
 
                 // Mix to Track Buffer (Double Precision)
-                const double unitGain = static_cast<double>(unit.gain);
+                const double unitGain = std::isfinite(unit.gain) ? static_cast<double>(unit.gain) : 1.0;
                 double* dDst = buffer.data();
                 for (uint32_t k = 0; k < numFrames; ++k) {
                     dDst[k * 2] += sanitizeMix(static_cast<double>(outputs[0][k])) * unitGain;
@@ -3350,7 +3350,7 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
         // Mix plugin output into master buffer (mixing floats into double master)
         double* masterD =
             (targetBuffer ? targetBuffer : m_masterBufferD.data()) + static_cast<size_t>(bufferOffset) * 2;
-        const double unitGain = static_cast<double>(unit.gain);
+        const double unitGain = std::isfinite(unit.gain) ? static_cast<double>(unit.gain) : 1.0;
         for (uint32_t i = 0; i < numFrames; ++i) {
             masterD[i * 2 + 0] += sanitizeMix(static_cast<double>(outputs[0][i])) * unitGain; // Left
             masterD[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i])) * unitGain; // Right

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -43,8 +43,8 @@
 // Denormal protection macros
 #if (defined(_M_ARM64) || defined(_M_ARM64EC)) && defined(ARM64_FPCR)
 // MSVC ARM64/ARM64EC: use the toolchain-defined FPCR register selector, never a raw literal.
-#define DISABLE_DENORMALS                           \
-    uint64_t oldFPCR = _ReadStatusReg(ARM64_FPCR);  \
+#define DISABLE_DENORMALS                          \
+    uint64_t oldFPCR = _ReadStatusReg(ARM64_FPCR); \
     _WriteStatusReg(ARM64_FPCR, oldFPCR | (1ULL << 24));
 
 #define RESTORE_DENORMALS _WriteStatusReg(ARM64_FPCR, oldFPCR);
@@ -223,8 +223,7 @@ void AudioEngine::applyPendingCommands() {
             // in-block accumulator transportPos (seeded from m_globalSamplePos and
             // updated per command) so a seek earlier in the SAME drain block is
             // honored — m_globalSamplePos is only stored back after the loop.
-            const uint64_t nextPos =
-                (cmd.samplePos == kTransportPreservePosition) ? transportPos : cmd.samplePos;
+            const uint64_t nextPos = (cmd.samplePos == kTransportPreservePosition) ? transportPos : cmd.samplePos;
             const bool posChanged = (nextPos != transportPos);
 
             if (nextPlaying && (!transportPlaying || posChanged)) {
@@ -310,10 +309,8 @@ void AudioEngine::applyPendingCommands() {
             }
             slot->unitId = static_cast<UnitID>(cmd.trackIndex);
             slot->note = static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value1), 0, 127));
-            slot->velocity =
-                static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value2 * 127.0f), 1, 127));
-            slot->noteOffSamplesRemaining =
-                std::max<uint32_t>(1, m_sampleRate.load(std::memory_order_relaxed) / 8);
+            slot->velocity = static_cast<uint8_t>(std::clamp(static_cast<int>(cmd.value2 * 127.0f), 1, 127));
+            slot->noteOffSamplesRemaining = std::max<uint32_t>(1, m_sampleRate.load(std::memory_order_relaxed) / 8);
             slot->noteOnPending = true;
             slot->active = true;
             // Wake the master out of the post-stop Silent fast path so the
@@ -986,33 +983,35 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     }
 
     if (!m_masterBufferD.empty()) {
-        if (!patternMode) {
-            // === Timeline Mode: Render Graph ===
-            if (loopSplitFrame < numFrames) {
-                // Split Render
-                if (loopSplitFrame > 0) {
-                    renderGraph(graph, loopSplitFrame, 0);
-                }
-
-                // Part B: Jump to loop start
-                // Flush pattern events on loop wrap so we don't double-trigger across the wrap.
-                if (isPlaying) {
-                    auto* pe = m_patternEngine.load(std::memory_order_relaxed);
-                    if (pe)
-                        pe->flush();
-                }
-                m_globalSamplePos.store(loopStartSample, std::memory_order_relaxed);
-                renderGraph(graph, numFrames - loopSplitFrame, loopSplitFrame);
-                m_globalSamplePos.store(currentGlobalPos, std::memory_order_relaxed);
-
-            } else {
-                // Normal Render
-                renderGraph(graph, numFrames, 0);
+        // Timeline and pattern playback share the mixer graph. renderTrackClips
+        // suppresses Timeline clips in pattern mode while units continue through
+        // their assigned mixer channels, inserts, faders, sends, and Master.
+        const auto patternFrame = [&](uint64_t wrappedPosition) {
+            if (!patternMode || patternLoopLenSamples == 0) {
+                return wrappedPosition;
             }
+            return m_patternLoopIteration.load(std::memory_order_relaxed) * patternLoopLenSamples + wrappedPosition;
+        };
+        if (loopSplitFrame < numFrames) {
+            if (loopSplitFrame > 0) {
+                renderGraph(graph, loopSplitFrame, 0, patternFrame(currentGlobalPos));
+            }
+
+            if (patternMode) {
+                // Pattern events are scheduled in a monotonic loop domain, so
+                // advance the epoch instead of flushing pre-scheduled events.
+                m_patternLoopIteration.fetch_add(1, std::memory_order_release);
+            } else if (isPlaying) {
+                // Timeline loops keep the flush-on-wrap behavior.
+                auto* pe = m_patternEngine.load(std::memory_order_relaxed);
+                if (pe)
+                    pe->flush();
+            }
+            m_globalSamplePos.store(loopStartSample, std::memory_order_relaxed);
+            renderGraph(graph, numFrames - loopSplitFrame, loopSplitFrame, patternFrame(loopStartSample));
+            m_globalSamplePos.store(currentGlobalPos, std::memory_order_relaxed);
         } else {
-            // === Pattern Mode: Clear Buffer ===
-            std::fill(m_masterBufferD.begin(),
-                      m_masterBufferD.begin() + static_cast<size_t>(numFrames) * kInternalRenderChannels, 0.0);
+            renderGraph(graph, numFrames, 0, patternFrame(currentGlobalPos));
         }
     } else {
         // Zero the double buffer
@@ -1020,42 +1019,12 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
                   m_masterBufferD.begin() + static_cast<size_t>(numFrames) * kInternalRenderChannels, 0.0);
     }
 
-    // === Arsenal Unit Processing (Pattern Playback) ===
-    // Process pattern MIDI events and mix sampler output into master buffer.
-    // Positions handed to the pattern engine are MONOTONIC in pattern mode
-    // (iteration * loopLen + wrapped pos): refillWindow pre-schedules the next
-    // iteration's events in that domain, so the wrap needs no flush and the
-    // loop's downbeat lands sample-accurately instead of waiting for the next
-    // UI maintenance tick (which made every bar end audibly "off").
-    const auto patternMonotonic = [&](uint64_t wrappedPos) {
-        return m_patternLoopIteration.load(std::memory_order_relaxed) * patternLoopLenSamples + wrappedPos;
-    };
-    if (loopSplitFrame < numFrames) {
-        // Split Render
-        if (loopSplitFrame > 0) {
-            processArsenalUnits(loopSplitFrame, 0, patternMonotonic(currentGlobalPos));
-        }
-        if (patternMode) {
-            m_patternLoopIteration.fetch_add(1, std::memory_order_release);
-        } else if (isPlaying) {
-            // Timeline loops keep the flush-on-wrap behavior.
-            auto* pe = m_patternEngine.load(std::memory_order_relaxed);
-            if (pe)
-                pe->flush();
-        }
-        processArsenalUnits(numFrames - loopSplitFrame, loopSplitFrame, patternMonotonic(loopStartSample));
-    } else {
-        // Normal
-        processArsenalUnits(numFrames, 0, patternMonotonic(currentGlobalPos));
-    }
-
     mixTestTone(numFrames, currentSampleRate);
 
     // Preview duck gain ramps per-sample across the block (see gainDelta below),
     // so the 50ms/120ms fade is interpolated rather than block-stepped (issue #565).
     const PreviewDuckRamp duckRamp = computePreviewDuckGain(numFrames, currentSampleRate, isPlaying);
-    const double duckGainDelta =
-        numFrames > 0 ? (duckRamp.end - duckRamp.start) / static_cast<double>(numFrames) : 0.0;
+    const double duckGainDelta = numFrames > 0 ? (duckRamp.end - duckRamp.start) / static_cast<double>(numFrames) : 0.0;
     double duckGain = duckRamp.start;
 
     // === Final Output Stage (double -> float with processing) ===
@@ -1338,10 +1307,9 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
             // Single-store coherent snapshot: iteration was bumped earlier in
             // THIS callback if this block wrapped, so the pair is consistent
             // here — maintenance reads one atomic instead of two.
-            m_patternMonotonicFrame.store(m_patternLoopIteration.load(std::memory_order_relaxed) *
-                                                  patternLoopLenSamples +
-                                              nextGlobalPos,
-                                          std::memory_order_release);
+            m_patternMonotonicFrame.store(
+                m_patternLoopIteration.load(std::memory_order_relaxed) * patternLoopLenSamples + nextGlobalPos,
+                std::memory_order_release);
         }
 
         // Handle Loop Metronome Reset. skipCurrentBeat: the boundary beat
@@ -1420,8 +1388,8 @@ AudioEngine::PreviewDuckRamp AudioEngine::computePreviewDuckGain(uint32_t numFra
     const bool shouldDuckForPreview = duckingEnabled && isPlaying && m_previewDuckHoldSecondsRemaining > 0.0f;
     const double targetDuckGain =
         shouldDuckForPreview ? static_cast<double>(m_previewDuckTargetGain.load(std::memory_order_relaxed)) : 1.0;
-    const double fadeSeconds = targetDuckGain < static_cast<double>(m_smoothedPreviewDuckGain) ? duckAttackSeconds
-                                                                                               : duckReleaseSeconds;
+    const double fadeSeconds =
+        targetDuckGain < static_cast<double>(m_smoothedPreviewDuckGain) ? duckAttackSeconds : duckReleaseSeconds;
     const double duckFadeSamples = static_cast<double>(currentSampleRate) * fadeSeconds;
     const double duckFadeDelta = static_cast<double>(numFrames) / std::max(duckFadeSamples, 1.0);
 
@@ -1976,7 +1944,8 @@ void AudioEngine::loudnessWorkerLoop() {
     }
 }
 
-void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset) {
+void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint32_t bufferOffset,
+                              uint64_t patternFrameStart) {
     bool srcActiveThisBlock = false;
     constexpr uint32_t numChannels = kInternalRenderChannels;
 
@@ -1994,11 +1963,6 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     double* masterBuf = m_masterBufferD.data() + bufferOffset * numChannels;
 
     const size_t availableTracks = m_trackBuffersD.size();
-    if (availableTracks == 0) {
-        std::memset(masterBuf, 0, static_cast<size_t>(numFrames) * numChannels * sizeof(double));
-        m_telemetry.incrementUnderruns();
-        return;
-    }
 
     // Clear master
     std::memset(masterBuf, 0, static_cast<size_t>(numFrames) * numChannels * sizeof(double));
@@ -2085,10 +2049,14 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     std::shared_ptr<const AudioArsenalSnapshot> unitSnapshot;
     std::array<PatternPlaybackEngine::UnitMidiRoute, 256> unitMidiRoutes{};
     size_t unitMidiRouteCount = 0;
+    bool anyUnitSolo = false;
 
     if (unitMgr) {
         unitSnapshot = unitMgr->getAudioSnapshot();
         if (unitSnapshot && !unitSnapshot->units.empty()) {
+            anyUnitSolo =
+                std::any_of(unitSnapshot->units.begin(), unitSnapshot->units.end(),
+                            [](const UnitState& unit) { return unit.enabled && unit.isSolo && !unit.isMuted; });
             // Map valid units to preallocated MIDI buffers (allocation-free)
             size_t bufIdx = 0;
             for (const auto& unit : unitSnapshot->units) {
@@ -2116,24 +2084,20 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             // Pop MIDI from Pattern Engine (only while transport is playing)
             auto* patEng = m_patternEngine.load(std::memory_order_acquire);
             if (isPlaying && patEng) {
-                patEng->processAudio(blockStart, static_cast<int>(numFrames), unitMidiRoutes.data(),
+                patEng->processAudio(patternFrameStart, static_cast<int>(numFrames), unitMidiRoutes.data(),
                                      unitMidiRouteCount);
             }
 
             injectPendingUnitAudition(unitMidiRoutes.data(), unitMidiRouteCount, numFrames);
 
-            // Live note input in Timeline mode. Gated on !patternPlaybackMode so
-            // exactly one path drains the queue per block — Arsenal mode drains
-            // inside processArsenalUnits (which self-gates on the same flag).
-            if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
-                drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
-            }
-        } else if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
-            // No routable units in Timeline mode: drain-and-drop so stale live
-            // events cannot pile up and land as a burst when units appear.
+            // The shared graph path owns live note input in both Timeline and pattern modes.
+            drainLiveMidi(unitMidiRoutes.data(), unitMidiRouteCount);
+        } else {
+            // No routable units: drain-and-drop so stale live events cannot pile
+            // up and land as a burst when units appear.
             drainLiveMidi(nullptr, 0);
         }
-    } else if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
+    } else {
         drainLiveMidi(nullptr, 0);
     }
 
@@ -2185,6 +2149,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
                             blockEnd,
                             isPlaying,
                             anySolo,
+                            anyUnitSolo,
                             cachedSampleRate,
                             cachedSlotMap,
                             cachedParams,
@@ -2198,9 +2163,14 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         renderTrack(graph, orderedIndex, ctx, srcActiveThisBlock);
     }
 
+    // Sources routed to Master bypass mixer inserts but still share the same
+    // transport, clip-edit, resampling, and safety path as insert-routed clips.
+    renderClips(graph.masterClips, masterBuf, ctx, srcActiveThisBlock);
+
     if (unitSnapshot) {
         for (const auto& unit : unitSnapshot->units) {
-            if (unit.routeId >= 0 || !unit.enabled || !unit.plugin) {
+            if (unit.mixerChannelId != MASTER_MIXER_CHANNEL_ID || !unit.enabled || !unit.plugin || unit.isMuted ||
+                (anyUnitSolo && !unit.isSolo)) {
                 continue;
             }
 
@@ -2219,9 +2189,10 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
             float* outputs[2] = {m_scratchL.data(), m_scratchR.data()};
             unit.plugin->process(nullptr, outputs, 0, 2, numFrames, midiBuf, nullptr);
 
+            const double unitGain = static_cast<double>(unit.gain);
             for (uint32_t i = 0; i < numFrames; ++i) {
-                masterBuf[i * 2] += sanitizeMix(static_cast<double>(outputs[0][i]));
-                masterBuf[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i]));
+                masterBuf[i * 2] += sanitizeMix(static_cast<double>(outputs[0][i])) * unitGain;
+                masterBuf[i * 2 + 1] += sanitizeMix(static_cast<double>(outputs[1][i])) * unitGain;
             }
         }
     }
@@ -2231,8 +2202,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     }
 }
 
-void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<double>& buffer, const RenderContext& ctx,
-                                   bool& srcActiveThisBlock) {
+void AudioEngine::renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
+                              bool& srcActiveThisBlock) {
     // Verbatim clip-rendering phase moved out of renderTrack(); same ctx
     // unpack names the body has always used.
     const uint64_t blockStart = ctx.blockStart;
@@ -2247,7 +2218,7 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
     bool patternMode = cachedPatternMode;
 
     if (!patternMode) {
-        for (const auto& clip : track.clips) {
+        for (const auto& clip : clips) {
             if (!isPlaying)
                 continue;
             if (!clip.audioData || blockEnd <= clip.startSample || blockStart >= clip.endSample) {
@@ -2285,31 +2256,43 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
             const uint32_t channels = clip.channels;
             const uint32_t stride = channels;
 
-            double* dstBase = buffer.data();
+            double* dstBase = destination;
             const float* data = clip.audioData;
             double* dst = dstBase + static_cast<size_t>(localOffset) * 2;
 
-            const uint64_t fadeLen = CLIP_EDGE_FADE_SAMPLES;
+            const uint64_t clipLength = clip.endSample - clip.startSample;
+            const uint64_t fadeInLen =
+                std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeInSamples));
+            const uint64_t fadeOutLen =
+                std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeOutSamples));
+            const auto clipFadeAt = [&clip, fadeInLen, fadeOutLen](uint64_t projectSample) {
+                double fade = 1.0;
+                if (fadeInLen > 0 && projectSample < clip.startSample + fadeInLen) {
+                    fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
+                                              static_cast<double>(fadeInLen));
+                }
+                if (fadeOutLen > 0 && projectSample + fadeOutLen > clip.endSample) {
+                    fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
+                                              static_cast<double>(fadeOutLen));
+                }
+                return fade;
+            };
+            // Clip pan is an instance-level stereo balance before the insert.
+            // Centre must remain unity so opening the editor cannot change old
+            // projects or stack a second -3 dB centre law with the insert pan.
+            const double clipPan = clampD(static_cast<double>(clip.pan), -1.0, 1.0);
+            const double clipGain = static_cast<double>(clip.gain);
+            const double clipGainL = clipGain * (clipPan > 0.0 ? 1.0 - clipPan : 1.0);
+            const double clipGainR = clipGain * (clipPan < 0.0 ? 1.0 + clipPan : 1.0);
 
             // Fast path: matching sample rates - direct copy to double
             if (std::abs(ratio - 1.0) < 1e-9) {
                 const uint64_t srcStart = static_cast<uint64_t>(phase);
                 const float* src = data + srcStart * stride;
-                const double clipGain = static_cast<double>(clip.gain);
                 for (uint32_t i = 0; i < framesToRender; ++i) {
                     // Micro-fade at clip edges to avoid clicks/crackles.
-                    double fade = 1.0;
                     const uint64_t projectSample = start + i;
-                    if (fadeLen > 0) {
-                        if (projectSample < clip.startSample + fadeLen) {
-                            fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                   static_cast<double>(fadeLen)));
-                        }
-                        if (projectSample + fadeLen > clip.endSample) {
-                            fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                   static_cast<double>(fadeLen)));
-                        }
-                    }
+                    const double fade = clipFadeAt(projectSample);
 
                     // Sanitize clip source reads: a corrupted audio file can
                     // contain NaN/Inf that would otherwise poison the mix.
@@ -2322,8 +2305,8 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                         sR = sanitizeMix(static_cast<double>(src[i * 2 + 1]));
                     }
 
-                    dst[i * 2] += sL * clipGain * fade;
-                    dst[i * 2 + 1] += sR * clipGain * fade;
+                    dst[i * 2] += sL * clipGainL * fade;
+                    dst[i * 2 + 1] += sR * clipGainR * fade;
                 }
             } else {
                 srcActiveThisBlock = true;
@@ -2336,17 +2319,8 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     switch (cachedInterpQuality) {
                     case Interpolators::InterpolationQuality::Cubic:
                         for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            double fade = 1.0;
                             const uint64_t projectSample = start + i;
-                            if (fadeLen > 0) {
-                                if (projectSample < clip.startSample + fadeLen)
-                                    fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
-                                                              static_cast<double>(fadeLen));
-                                if (projectSample + fadeLen > clip.endSample)
-                                    fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
-                                                              static_cast<double>(fadeLen));
-                            }
-                            double clipGain = static_cast<double>(clip.gain);
+                            const double fade = clipFadeAt(projectSample);
                             float sample = 0.0f;
                             uint64_t idx = static_cast<uint64_t>(phase);
                             double frac = phase - static_cast<double>(idx);
@@ -2359,8 +2333,8 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                             sample = static_cast<float>(0.5 * ((2.0 * s1) + (-s0 + s2) * f +
                                                                (2.0 * s0 - 5.0 * s1 + 4.0 * s2 - s3) * f * f +
                                                                (-s0 + 3.0 * s1 - 3.0 * s2 + s3) * f * f * f));
-                            dst[i * 2] += sample * clipGain * fade;
-                            dst[i * 2 + 1] += sample * clipGain * fade;
+                            dst[i * 2] += sample * clipGainL * fade;
+                            dst[i * 2 + 1] += sample * clipGainR * fade;
                             phase += ratio;
                         }
                         continue;
@@ -2370,45 +2344,27 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     case Interpolators::InterpolationQuality::Sinc64:
                         // Sinc on mono: compute weighted sum, duplicate to L/R
                         for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            double fade = 1.0;
                             const uint64_t projectSample = start + i;
-                            if (fadeLen > 0) {
-                                if (projectSample < clip.startSample + fadeLen)
-                                    fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
-                                                              static_cast<double>(fadeLen));
-                                if (projectSample + fadeLen > clip.endSample)
-                                    fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
-                                                              static_cast<double>(fadeLen));
-                            }
-                            double clipGain = static_cast<double>(clip.gain);
+                            const double fade = clipFadeAt(projectSample);
                             double val =
                                 Interpolators::sincInterpolateMono(data, totalFrames, phase, cachedInterpQuality);
-                            dst[i * 2] += val * clipGain * fade;
-                            dst[i * 2 + 1] += val * clipGain * fade;
+                            dst[i * 2] += val * clipGainL * fade;
+                            dst[i * 2 + 1] += val * clipGainR * fade;
                             phase += ratio;
                         }
                         continue;
                     default:
                         // Linear fallback
                         for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            double fade = 1.0;
                             const uint64_t projectSample = start + i;
-                            if (fadeLen > 0) {
-                                if (projectSample < clip.startSample + fadeLen)
-                                    fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
-                                                              static_cast<double>(fadeLen));
-                                if (projectSample + fadeLen > clip.endSample)
-                                    fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
-                                                              static_cast<double>(fadeLen));
-                            }
-                            double clipGain = static_cast<double>(clip.gain);
+                            const double fade = clipFadeAt(projectSample);
                             uint64_t idx = static_cast<uint64_t>(phase);
                             double frac = phase - static_cast<double>(idx);
                             float s0 = data[idx];
                             float s1 = (idx + 1 < static_cast<uint64_t>(totalFrames)) ? data[idx + 1] : s0;
                             double val = s0 + frac * (s1 - s0);
-                            dst[i * 2] += val * clipGain * fade;
-                            dst[i * 2 + 1] += val * clipGain * fade;
+                            dst[i * 2] += val * clipGainL * fade;
+                            dst[i * 2 + 1] += val * clipGainR * fade;
                             phase += ratio;
                         }
                         continue;
@@ -2421,21 +2377,10 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
                         float outL, outR;
                         Interpolators::CubicInterpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        double fade = 1.0;
                         const uint64_t projectSample = start + i;
-                        if (fadeLen > 0) {
-                            if (projectSample < clip.startSample + fadeLen) {
-                                fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                            if (projectSample + fadeLen > clip.endSample) {
-                                fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                        }
-                        const double clipGain = static_cast<double>(clip.gain);
-                        dst[i * 2] += static_cast<double>(outL) * clipGain * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGain * fade;
+                        const double fade = clipFadeAt(projectSample);
+                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
                         phase += ratio;
                     }
                     break;
@@ -2443,21 +2388,10 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
                         float outL, outR;
                         Interpolators::Sinc8Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        double fade = 1.0;
                         const uint64_t projectSample = start + i;
-                        if (fadeLen > 0) {
-                            if (projectSample < clip.startSample + fadeLen) {
-                                fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                            if (projectSample + fadeLen > clip.endSample) {
-                                fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                        }
-                        const double clipGain = static_cast<double>(clip.gain);
-                        dst[i * 2] += static_cast<double>(outL) * clipGain * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGain * fade;
+                        const double fade = clipFadeAt(projectSample);
+                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
                         phase += ratio;
                     }
                     break;
@@ -2465,21 +2399,10 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
                         float outL, outR;
                         Interpolators::Sinc16Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        double fade = 1.0;
                         const uint64_t projectSample = start + i;
-                        if (fadeLen > 0) {
-                            if (projectSample < clip.startSample + fadeLen) {
-                                fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                            if (projectSample + fadeLen > clip.endSample) {
-                                fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                        }
-                        const double clipGain = static_cast<double>(clip.gain);
-                        dst[i * 2] += static_cast<double>(outL) * clipGain * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGain * fade;
+                        const double fade = clipFadeAt(projectSample);
+                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
                         phase += ratio;
                     }
                     break;
@@ -2487,21 +2410,10 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
                         float outL, outR;
                         Interpolators::Sinc32Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        double fade = 1.0;
                         const uint64_t projectSample = start + i;
-                        if (fadeLen > 0) {
-                            if (projectSample < clip.startSample + fadeLen) {
-                                fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                            if (projectSample + fadeLen > clip.endSample) {
-                                fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                        }
-                        const double clipGain = static_cast<double>(clip.gain);
-                        dst[i * 2] += static_cast<double>(outL) * clipGain * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGain * fade;
+                        const double fade = clipFadeAt(projectSample);
+                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
                         phase += ratio;
                     }
                     break;
@@ -2509,21 +2421,10 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
                     for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
                         float outL, outR;
                         Interpolators::Sinc64Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        double fade = 1.0;
                         const uint64_t projectSample = start + i;
-                        if (fadeLen > 0) {
-                            if (projectSample < clip.startSample + fadeLen) {
-                                fade = std::min(fade, (static_cast<double>(projectSample - clip.startSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                            if (projectSample + fadeLen > clip.endSample) {
-                                fade = std::min(fade, (static_cast<double>(clip.endSample - projectSample) /
-                                                       static_cast<double>(fadeLen)));
-                            }
-                        }
-                        const double clipGain = static_cast<double>(clip.gain);
-                        dst[i * 2] += static_cast<double>(outL) * clipGain * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGain * fade;
+                        const double fade = clipFadeAt(projectSample);
+                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
                         phase += ratio;
                     }
                     break;
@@ -2533,18 +2434,18 @@ void AudioEngine::renderTrackClips(const TrackRenderState& track, std::vector<do
     }
 }
 
-void AudioEngine::renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffer, const RenderContext& ctx) {
-    // Verbatim Arsenal-unit phase moved out of renderTrack().
+void AudioEngine::renderTrackUnits(uint32_t mixerChannelId, std::vector<double>& buffer, const RenderContext& ctx) {
     const uint32_t numFrames = ctx.numFrames;
     const AudioArsenalSnapshot* const unitSnapshot = ctx.unitSnapshot;
     const PatternPlaybackEngine::UnitMidiRoute* const unitMidiRoutes = ctx.unitMidiRoutes;
     const size_t unitMidiRouteCount = ctx.unitMidiRouteCount;
 
     // === ANTIGRAVITY UNIT RENDER (v3.1) ===
-    // Render any units routed to this track
+    // Render every unit whose stable mixer destination matches this track.
     if (unitSnapshot) {
         for (const auto& unit : unitSnapshot->units) {
-            if (static_cast<uint32_t>(unit.routeId) == trackIdx && unit.enabled && unit.plugin) {
+            if (unit.mixerChannelId == mixerChannelId && unit.enabled && unit.plugin && !unit.isMuted &&
+                (!ctx.anyUnitSolo || unit.isSolo)) {
                 // Found unit for this track
                 MidiBuffer* midiBuf = nullptr;
                 for (size_t r = 0; r < unitMidiRouteCount; ++r) {
@@ -2576,7 +2477,6 @@ void AudioEngine::renderTrackUnits(uint32_t trackIdx, std::vector<double>& buffe
             }
         }
     }
-
 }
 
 float AudioEngine::processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
@@ -2623,10 +2523,9 @@ float AudioEngine::processTrackEffects(const TrackRenderState& track, uint32_t t
     return trackSidechainPeak;
 }
 
-void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t trackIdx, uint32_t slot,
-                                   TrackRTState& state, std::vector<double>& buffer, const RenderContext& ctx,
-                                   double volTarget, double panTarget, float trackSidechainPeak, bool muted,
-                                   bool audibleEligible) {
+void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t trackIdx, uint32_t slot, TrackRTState& state,
+                                   std::vector<double>& buffer, const RenderContext& ctx, double volTarget,
+                                   double panTarget, float trackSidechainPeak, bool muted, bool audibleEligible) {
     // Verbatim output stage moved out of renderTrack(): plugin-delay
     // compensation, routing to master/destination + sends (with the peak/RMS
     // accumulation interleaved in the mix loop), and the meter snapshot write.
@@ -3041,9 +2940,9 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
 
     // Clip rendering, Arsenal units, and the effect chain are verbatim phase
     // extractions — see the helpers directly above renderTrack().
-    renderTrackClips(track, buffer, ctx, srcActiveThisBlock);
+    renderClips(track.clips, buffer.data(), ctx, srcActiveThisBlock);
 
-    renderTrackUnits(trackIdx, buffer, ctx);
+    renderTrackUnits(track.trackId, buffer, ctx);
 
     float trackSidechainPeak = processTrackEffects(track, trackIdx, buffer, numFrames);
 
@@ -3310,7 +3209,7 @@ void AudioEngine::requestVoiceResetOnPatternChange() {
 //==============================================================================
 
 void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset, uint64_t startFrame,
-                                      double* targetBuffer, int32_t isolatedTrackIndex) {
+                                      double* targetBuffer, int64_t isolatedMixerChannelId) {
     // [FIX] Only process Arsenal units in pattern/Arsenal mode
     // In Timeline mode, skip entirely to prevent audio bleed with wrong sample rate
     if (!m_patternPlaybackMode.load(std::memory_order_relaxed)) {
@@ -3354,6 +3253,9 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
             drainLiveMidi(nullptr, 0);
         return;
     }
+    const bool anyUnitSolo = std::any_of(snapshot->units.begin(), snapshot->units.end(), [](const UnitState& unit) {
+        return unit.enabled && unit.isSolo && !unit.isMuted;
+    });
 
     syncCachedSamplerSampleRatesRt(sampleRate);
 
@@ -3408,7 +3310,7 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
     const float* inputs[2] = {m_silentBufferF.data(), m_silentBufferF.data()};
 
     for (const auto& unit : snapshot->units) {
-        if (!unit.enabled || !unit.plugin) {
+        if (!unit.enabled || !unit.plugin || unit.isMuted || (anyUnitSolo && !unit.isSolo)) {
             bufIdx++;
             continue;
         }
@@ -3416,14 +3318,13 @@ void AudioEngine::processArsenalUnits(uint32_t numFrames, uint32_t bufferOffset,
         // During bounce (targetBuffer set), skip PreviewToMaster units.
         // renderBlock handles PreviewToMaster via AudioRenderer::processArsenalUnits.
         // During live processBlock, all units process through m_masterBufferD.
-        if (targetBuffer != nullptr && unit.getRouteMode() == ArsenalRouteMode::PreviewToMaster) {
+        if (targetBuffer != nullptr && unit.mixerChannelId == MASTER_MIXER_CHANNEL_ID) {
             bufIdx++;
             continue;
         }
 
-        // During isolated-track bounce, skip track-routed units not assigned
-        // to the isolated track.
-        if (isolatedTrackIndex >= 0 && unit.routeId >= 0 && unit.routeId != isolatedTrackIndex) {
+        // During isolated-track bounce, include only the stable destination selected by the caller.
+        if (isolatedMixerChannelId >= 0 && unit.mixerChannelId != static_cast<uint32_t>(isolatedMixerChannelId)) {
             bufIdx++;
             continue;
         }
@@ -3511,6 +3412,16 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     if (totalFrames == 0)
         return false;
 
+    int64_t isolatedMixerChannelId = -1;
+    if (trackId >= 0) {
+        auto trackManager = m_trackManager.lock();
+        const auto* channel = trackManager ? trackManager->getChannel(static_cast<size_t>(trackId)) : nullptr;
+        if (!channel) {
+            return false;
+        }
+        isolatedMixerChannelId = static_cast<int64_t>(channel->getChannelId());
+    }
+
     // 2. Prepare Encoder (MiniAudio)
     // First, stop playback to ensure safe rendering
     bool wasPlaying = m_transportPlaying.exchange(false, std::memory_order_relaxed);
@@ -3568,11 +3479,6 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
     // However, for simplicity and since we are stopped, we use the active graph.
     // Ideally we clone it.
 
-    // trackId parameter is the persistent track lane index.
-    // isolatedTrackIndex is used to compare against unit.routeId (which is also the lane index).
-    // Use trackId directly when >= 0 for the comparison.
-    int32_t isolatedTrackIndex = trackId;
-
     Aestra::Log::info("[AudioEngine] Starting isolated track bounce: " + std::to_string(totalFrames) + " frames.");
 
     while (framesRemaining > 0) {
@@ -3592,7 +3498,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         auto graphRead = m_state.activeGraphRead();
         ctx.graph = &graphRead.get();
         ctx.isOffline = true;
-        ctx.isolatedTrackIndex = isolatedTrackIndex;
+        ctx.isolatedTrackIndex = trackId;
 
         // Refill pattern engine lookahead (normally done by performNonRealtimeMaintenance)
         auto* patEng = m_patternEngine.load(std::memory_order_acquire);
@@ -3613,7 +3519,7 @@ bool AudioEngine::bounceRangeToWav(double startBeat, double endBeat, const std::
         // Process Arsenal pattern playback (MIDI buffer pop + unit render).
         // renderBlock handles PreviewToMaster; this call processes track-routed
         // Arsenal units that need MIDI buffer population for pattern playback.
-        processArsenalUnits(framesThisBlock, 0, currentFrame, blockBuffer.data(), isolatedTrackIndex);
+        processArsenalUnits(framesThisBlock, 0, currentFrame, blockBuffer.data(), isolatedMixerChannelId);
 
         // Buffer Conversion (Double -> Float)
         for (size_t i = 0; i < framesThisBlock * 2; ++i) {
@@ -4052,8 +3958,7 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
     // m_graphStates edge delays do not have double-buffered EdgeDelayState
     // objects (see step 4 notes); their writePos is stale, so we overlay
     // from m_trackState when available.
-    const auto* goldenState =
-        (trackIndex < m_trackState.size()) ? &m_trackState[trackIndex] : nullptr;
+    const auto* goldenState = (trackIndex < m_trackState.size()) ? &m_trackState[trackIndex] : nullptr;
 
     // Overlay writePos from m_trackState where the RT thread updates it.
     auto fillSlot = [](const std::unique_ptr<EdgeDelayState>& slotPtr) -> TrackEdgeDelaySnapshot::EdgeSlotSnapshot {

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -600,8 +600,7 @@ uint64_t HeadlessMusicGenerator::ensureLaneInstrument(uint32_t laneIndex) {
     const std::string label = "Lane " + std::to_string(laneIndex + 1);
 
     // Mixer channel that carries this lane's instrument to the master bus.
-    const size_t channelIndex = m_trackManager.getChannelCount();
-    m_trackManager.addChannel(label);
+    auto* mixerChannel = m_trackManager.addChannel(label);
 
     // Playlist lane the clips are placed on.
     PlaylistLaneID laneId = m_trackManager.getPlaylistModel().createLane(label);
@@ -624,7 +623,7 @@ uint64_t HeadlessMusicGenerator::ensureLaneInstrument(uint32_t laneIndex) {
     if (!m_toneSamplePath.empty()) {
         um.setUnitAudioClip(unit, m_toneSamplePath); // loads the tone into the sampler
     }
-    um.setUnitMixerChannel(unit, static_cast<int>(channelIndex));
+    um.setUnitMixerChannel(unit, mixerChannel ? static_cast<int>(mixerChannel->getChannelId()) : 0);
     um.assignUnitToTimelineLane(unit, static_cast<int>(laneIndex));
 
     m_laneUnits[laneIndex] = unit;
@@ -636,7 +635,7 @@ void HeadlessMusicGenerator::commitPatternsToManager() {
     // units and clips to the TrackManager on a second exportTo() call. State is
     // reset by createProject(). The MIDI PatternSources themselves are created
     // in commitPlaylistToModel(): each note routes to the sampler unit backing
-    // the lane its clip is placed on, so the routed pattern can only be built
+    // the lane its clip is placed on, so the pattern can only be built
     // once the placement (and thus the lane instrument) is known. Here we just
     // prepare the shared sampler source.
     if (m_committed) {

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -623,7 +623,7 @@ uint64_t HeadlessMusicGenerator::ensureLaneInstrument(uint32_t laneIndex) {
     if (!m_toneSamplePath.empty()) {
         um.setUnitAudioClip(unit, m_toneSamplePath); // loads the tone into the sampler
     }
-    um.setUnitMixerChannel(unit, mixerChannel ? static_cast<int>(mixerChannel->getChannelId()) : 0);
+    um.setUnitMixerChannel(unit, mixerChannel ? mixerChannel->getChannelId() : MASTER_MIXER_CHANNEL_ID);
     um.assignUnitToTimelineLane(unit, static_cast<int>(laneIndex));
 
     m_laneUnits[laneIndex] = unit;

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -268,7 +268,7 @@ void UnitManager::publishSnapshot() {
         state.routeId = unit->targetMixerRoute;
         state.mixerChannelId = unit->targetMixerChannelId;
         state.routeMode = arsenalRouteModeFromRouteId(state.routeId);
-        state.gain = unit->gain;
+        state.gain = std::isfinite(unit->gain) ? unit->gain : 1.0f;
         state.isMuted = unit->isMuted;
         state.isSolo = unit->isSolo;
         snapshot->units.push_back(state);
@@ -451,11 +451,10 @@ void UnitManager::setUnitEnabled(UnitID id, bool enabled) {
         publishSnapshot();
     }
 }
-void UnitManager::setUnitMixerChannel(UnitID id, int64_t channelId) {
+void UnitManager::setUnitMixerChannel(UnitID id, uint32_t channelId) {
     if (auto* u = getUnit(id)) {
-        u->targetMixerChannelId = channelId > 0 && channelId < static_cast<int64_t>(UINT32_MAX)
-                                      ? static_cast<uint32_t>(channelId)
-                                      : MASTER_MIXER_CHANNEL_ID;
+        u->targetMixerChannelId =
+            channelId < std::numeric_limits<uint32_t>::max() ? channelId : MASTER_MIXER_CHANNEL_ID;
         u->legacyMixerRoutePending = false;
         publishSnapshot();
     }
@@ -538,7 +537,7 @@ int UnitManager::getUnitTimelineLane(UnitID id) const {
 }
 void UnitManager::setUnitGain(UnitID id, float gain) {
     if (auto* u = getUnit(id)) {
-        u->gain = gain;
+        u->gain = std::isfinite(gain) ? gain : 1.0f;
         publishSnapshot();
     }
 }
@@ -826,14 +825,23 @@ void UnitManager::loadFromJSON(const JSON& json) {
         } else {
             unit.targetMixerRoute = ju.has("targetMixerRoute") ? ju["targetMixerRoute"].asInt() : -1;
         }
-        if (ju.has("targetMixerChannelId") && ju["targetMixerChannelId"].isNumber()) {
+        const bool hasStableMixerChannelId = ju.has("targetMixerChannelId");
+        bool validStableMixerChannelId = false;
+        if (hasStableMixerChannelId && ju["targetMixerChannelId"].isNumber()) {
             const double rawMixerChannelId = ju["targetMixerChannelId"].asNumber();
             if (std::isfinite(rawMixerChannelId) && rawMixerChannelId >= 0.0 &&
-                rawMixerChannelId < static_cast<double>(UINT32_MAX)) {
+                rawMixerChannelId < static_cast<double>(UINT32_MAX) &&
+                std::floor(rawMixerChannelId) == rawMixerChannelId) {
                 unit.targetMixerChannelId = static_cast<uint32_t>(rawMixerChannelId);
+                validStableMixerChannelId = true;
             }
-        } else {
+        }
+        if (!validStableMixerChannelId) {
             unit.legacyMixerRoutePending = unit.targetMixerRoute >= 0;
+            if (hasStableMixerChannelId) {
+                Log::warning("[UnitManager] Invalid targetMixerChannelId for unit " + std::to_string(unit.id) +
+                             "; falling back to legacy route metadata.");
+            }
         }
         const ArsenalRouteMode legacyResolvedRouteMode = arsenalRouteModeFromRouteId(unit.targetMixerRoute);
         unit.routeMode = legacyResolvedRouteMode;
@@ -877,7 +885,13 @@ void UnitManager::loadFromJSON(const JSON& json) {
         unit.isSolo = ju.has("solo") ? ju["solo"].asBool() : false;
         unit.isArmed = ju.has("armed") ? ju["armed"].asBool() : false;
         unit.audioClipPath = ju.has("audioClipPath") ? ju["audioClipPath"].asString() : std::string{};
-        unit.gain = ju.has("gain") ? static_cast<float>(ju["gain"].asNumber()) : 1.0f;
+        unit.gain = 1.0f;
+        if (ju.has("gain") && ju["gain"].isNumber()) {
+            const float loadedGain = static_cast<float>(ju["gain"].asNumber());
+            if (std::isfinite(loadedGain)) {
+                unit.gain = loadedGain;
+            }
+        }
         unit.audioDurationSeconds = ju.has("audioDurationSeconds") ? ju["audioDurationSeconds"].asNumber() : 0.0;
         if (ju.has("defaultPatternId")) {
             unit.defaultPatternId = PatternID(static_cast<uint64_t>(ju["defaultPatternId"].asNumber()));

--- a/AestraAudio/src/Models/UnitManager.cpp
+++ b/AestraAudio/src/Models/UnitManager.cpp
@@ -266,6 +266,7 @@ void UnitManager::publishSnapshot() {
         state.enabled = unit->enabled || unit->isEnabled;
         state.plugin = unit->plugin;
         state.routeId = unit->targetMixerRoute;
+        state.mixerChannelId = unit->targetMixerChannelId;
         state.routeMode = arsenalRouteModeFromRouteId(state.routeId);
         state.gain = unit->gain;
         state.isMuted = unit->isMuted;
@@ -335,6 +336,8 @@ UnitID UnitManager::duplicateUnit(UnitID sourceId) {
     // Copy scalar state
     dst->enabled          = src->enabled;
     dst->targetMixerRoute = src->targetMixerRoute;
+    dst->targetMixerChannelId = src->targetMixerChannelId;
+    dst->legacyMixerRoutePending = false;
     dst->routeMode        = src->routeMode;
     dst->bridgeMode       = src->bridgeMode;
     dst->color            = src->color;
@@ -448,7 +451,65 @@ void UnitManager::setUnitEnabled(UnitID id, bool enabled) {
         publishSnapshot();
     }
 }
-void UnitManager::setUnitMixerChannel(UnitID id, int channel) { assignUnitToTimelineLane(id, channel); }
+void UnitManager::setUnitMixerChannel(UnitID id, int64_t channelId) {
+    if (auto* u = getUnit(id)) {
+        u->targetMixerChannelId = channelId > 0 && channelId < static_cast<int64_t>(UINT32_MAX)
+                                      ? static_cast<uint32_t>(channelId)
+                                      : MASTER_MIXER_CHANNEL_ID;
+        u->legacyMixerRoutePending = false;
+        publishSnapshot();
+    }
+}
+
+uint32_t UnitManager::getUnitMixerChannel(UnitID id) const {
+    if (const auto* u = getUnit(id)) {
+        return u->targetMixerChannelId;
+    }
+    return MASTER_MIXER_CHANNEL_ID;
+}
+
+void UnitManager::migrateLegacyMixerRoutes(const std::vector<uint32_t>& mixerChannelIds) {
+    bool changed = false;
+    for (UnitID id : m_unitOrder) {
+        auto* unit = getUnit(id);
+        if (!unit) {
+            continue;
+        }
+
+        if (unit->legacyMixerRoutePending) {
+            if (unit->targetMixerRoute >= 0 && static_cast<size_t>(unit->targetMixerRoute) < mixerChannelIds.size()) {
+                unit->targetMixerChannelId = mixerChannelIds[static_cast<size_t>(unit->targetMixerRoute)];
+            } else {
+                unit->targetMixerChannelId = MASTER_MIXER_CHANNEL_ID;
+            }
+            unit->legacyMixerRoutePending = false;
+            changed = true;
+        } else if (unit->targetMixerChannelId != MASTER_MIXER_CHANNEL_ID &&
+                   std::find(mixerChannelIds.begin(), mixerChannelIds.end(), unit->targetMixerChannelId) ==
+                       mixerChannelIds.end()) {
+            unit->targetMixerChannelId = MASTER_MIXER_CHANNEL_ID;
+            changed = true;
+        }
+    }
+    if (changed) {
+        publishSnapshot();
+    }
+}
+
+bool UnitManager::resetMixerChannel(uint32_t channelId) {
+    bool changed = false;
+    for (UnitID id : m_unitOrder) {
+        if (auto* unit = getUnit(id); unit && unit->targetMixerChannelId == channelId) {
+            unit->targetMixerChannelId = MASTER_MIXER_CHANNEL_ID;
+            unit->legacyMixerRoutePending = false;
+            changed = true;
+        }
+    }
+    if (changed) {
+        publishSnapshot();
+    }
+    return changed;
+}
 void UnitManager::assignUnitToTimelineLane(UnitID id, int laneIndex) {
     if (auto* u = getUnit(id)) {
         u->targetMixerRoute = laneIndex;
@@ -685,6 +746,7 @@ JSON UnitManager::saveToJSON() const {
         u.set("enabled", JSON(unit->enabled || unit->isEnabled));
         u.set("targetMixerRoute", JSON(static_cast<double>(unit->targetMixerRoute)));
         u.set("timelineLaneAssignment", JSON(static_cast<double>(unit->targetMixerRoute)));
+        u.set("targetMixerChannelId", JSON(static_cast<double>(unit->targetMixerChannelId)));
         u.set("color", JSON(std::to_string(unit->color)));
         u.set("muted", JSON(unit->isMuted));
         u.set("solo", JSON(unit->isSolo));
@@ -763,6 +825,15 @@ void UnitManager::loadFromJSON(const JSON& json) {
             unit.targetMixerRoute = ju["timelineLaneAssignment"].asInt();
         } else {
             unit.targetMixerRoute = ju.has("targetMixerRoute") ? ju["targetMixerRoute"].asInt() : -1;
+        }
+        if (ju.has("targetMixerChannelId") && ju["targetMixerChannelId"].isNumber()) {
+            const double rawMixerChannelId = ju["targetMixerChannelId"].asNumber();
+            if (std::isfinite(rawMixerChannelId) && rawMixerChannelId >= 0.0 &&
+                rawMixerChannelId < static_cast<double>(UINT32_MAX)) {
+                unit.targetMixerChannelId = static_cast<uint32_t>(rawMixerChannelId);
+            }
+        } else {
+            unit.legacyMixerRoutePending = unit.targetMixerRoute >= 0;
         }
         const ArsenalRouteMode legacyResolvedRouteMode = arsenalRouteModeFromRouteId(unit.targetMixerRoute);
         unit.routeMode = legacyResolvedRouteMode;

--- a/AestraUI/CMakeLists.txt
+++ b/AestraUI/CMakeLists.txt
@@ -129,6 +129,8 @@ list(APPEND AESTRAUI_CORE_SOURCES
     Widgets/UIMixerInspector.cpp
     Widgets/UIMixerPluginDropdown.h
     Widgets/UIMixerPluginDropdown.cpp
+    Widgets/UIInsertRoutePicker.h
+    Widgets/UIInsertRoutePicker.cpp
     Widgets/UIRoutingMap.h
     Widgets/UIRoutingMap.cpp
     Widgets/UnitRow.h

--- a/AestraUI/Widgets/NUIMixerWidgets.cpp
+++ b/AestraUI/Widgets/NUIMixerWidgets.cpp
@@ -23,7 +23,7 @@ PanKnob::PanKnob()
 }
 
 TrackLabel::TrackLabel()
-    : text_("Track"), color_(NUIColor::fromHex(0xff6633ff))
+    : text_("Insert"), color_(NUIColor::fromHex(0xff6633ff))
 {
 }
 

--- a/AestraUI/Widgets/UIInsertRoutePicker.cpp
+++ b/AestraUI/Widgets/UIInsertRoutePicker.cpp
@@ -1,0 +1,363 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "UIInsertRoutePicker.h"
+
+#include "NUIRenderer.h"
+#include "NUITextInput.h"
+#include "NUIThemeSystem.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+
+namespace AestraUI {
+
+namespace {
+
+std::string lowercase(std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(),
+                   [](unsigned char character) { return static_cast<char>(std::tolower(character)); });
+    return text;
+}
+
+std::string trim(std::string text) {
+    const auto first = text.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos)
+        return {};
+    const auto last = text.find_last_not_of(" \t\r\n");
+    return text.substr(first, last - first + 1);
+}
+
+std::string searchableQuery(std::string query) {
+    query = lowercase(trim(std::move(query)));
+    if (query.rfind("insert ", 0) == 0)
+        query.erase(0, 7);
+    if (!query.empty() && query.front() == '#')
+        query.erase(query.begin());
+    return trim(std::move(query));
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return needle.empty() || lowercase(haystack).find(needle) != std::string::npos;
+}
+
+bool isNumber(const std::string& text) {
+    return !text.empty() &&
+           std::all_of(text.begin(), text.end(), [](unsigned char character) { return std::isdigit(character) != 0; });
+}
+
+NUIColor colorFromArgb(uint32_t argb) {
+    return NUIColor(static_cast<float>((argb >> 16) & 0xFF) / 255.0f, static_cast<float>((argb >> 8) & 0xFF) / 255.0f,
+                    static_cast<float>(argb & 0xFF) / 255.0f, static_cast<float>((argb >> 24) & 0xFF) / 255.0f);
+}
+
+std::string routeNumberLabel(const UIInsertRoutePicker::Route& route) {
+    if (route.insertNumber <= 0)
+        return "M";
+    std::ostringstream stream;
+    stream << std::setfill('0') << std::setw(2) << route.insertNumber;
+    return stream.str();
+}
+
+} // namespace
+
+UIInsertRoutePicker::UIInsertRoutePicker() {
+    setLayer(NUILayer::Dropdown);
+    m_searchInput = std::make_shared<NUITextInput>();
+    m_searchInput->setPlaceholderText("Type insert # or name…");
+    m_searchInput->setShowPlaceholderWhenFocused(true);
+    m_searchInput->setMaxLength(128);
+    m_searchInput->setBorderRadius(5.0f);
+    m_searchInput->setPadding(9.0f);
+    m_searchInput->setVisible(false);
+    m_searchInput->setOnTextChange([this](const std::string& query) {
+        m_searchQuery = query;
+        rebuildFilter();
+        repaint();
+    });
+    m_searchInput->setOnReturnKey([this]() { routeFirstMatch(); });
+    m_searchInput->setOnEscapeKey([this]() { close(); });
+    addChild(m_searchInput);
+}
+
+void UIInsertRoutePicker::setRoutes(std::vector<Route> routes, uint32_t selectedRouteId) {
+    m_routes = std::move(routes);
+    m_selectedRouteId = selectedRouteId;
+    if (!selectedRoute())
+        m_selectedRouteId = 0;
+    rebuildFilter();
+    repaint();
+}
+
+void UIInsertRoutePicker::setSelectedRoute(uint32_t routeId) {
+    const auto found =
+        std::find_if(m_routes.begin(), m_routes.end(), [routeId](const Route& route) { return route.id == routeId; });
+    m_selectedRouteId = found == m_routes.end() ? 0 : routeId;
+    repaint();
+}
+
+void UIInsertRoutePicker::setTriggerBounds(const NUIRect& bounds) {
+    m_triggerBounds = bounds;
+    setBounds(bounds);
+    updatePopupBounds();
+}
+
+void UIInsertRoutePicker::setSearchQuery(const std::string& query) {
+    m_searchQuery = query;
+    if (m_searchInput && m_searchInput->getText() != query)
+        m_searchInput->setText(query);
+    rebuildFilter();
+}
+
+std::vector<uint32_t> UIInsertRoutePicker::getFilteredRouteIds() const {
+    std::vector<uint32_t> result;
+    result.reserve(m_filteredIndices.size());
+    for (const size_t index : m_filteredIndices)
+        result.push_back(m_routes[index].id);
+    return result;
+}
+
+bool UIInsertRoutePicker::routeFirstMatch() {
+    if (m_filteredIndices.empty())
+        return false;
+
+    const std::string query = searchableQuery(m_searchQuery);
+    size_t matchIndex = m_filteredIndices.front();
+    if (!query.empty()) {
+        const auto exact = std::find_if(m_filteredIndices.begin(), m_filteredIndices.end(), [&](size_t index) {
+            const auto& route = m_routes[index];
+            return (isNumber(query) && std::to_string(route.insertNumber) == query) || lowercase(route.name) == query;
+        });
+        if (exact != m_filteredIndices.end())
+            matchIndex = *exact;
+    }
+    selectRoute(m_routes[matchIndex].id);
+    return true;
+}
+
+void UIInsertRoutePicker::open() {
+    if (m_open)
+        return;
+    m_open = true;
+    m_firstVisible = 0;
+    m_hoveredVisibleRow = -1;
+    m_searchQuery.clear();
+    rebuildFilter();
+    updatePopupBounds();
+    m_searchInput->setVisible(true);
+    m_searchInput->setText("");
+    m_searchInput->setFocused(true);
+    bringToFront();
+    repaint();
+}
+
+void UIInsertRoutePicker::close() {
+    if (!m_open)
+        return;
+    m_open = false;
+    m_hoveredVisibleRow = -1;
+    m_searchInput->setVisible(false);
+    m_searchInput->setFocused(false);
+    repaint();
+}
+
+void UIInsertRoutePicker::rebuildFilter() {
+    m_filteredIndices.clear();
+    const std::string query = searchableQuery(m_searchQuery);
+    const bool numericQuery = isNumber(query);
+    for (size_t index = 0; index < m_routes.size(); ++index) {
+        const auto& route = m_routes[index];
+        if (query.empty() || contains(route.name, query) ||
+            (numericQuery && std::to_string(route.insertNumber).find(query) != std::string::npos) ||
+            (route.insertNumber == 0 && std::string("master").find(query) != std::string::npos)) {
+            m_filteredIndices.push_back(index);
+        }
+    }
+
+    if (numericQuery) {
+        std::stable_sort(m_filteredIndices.begin(), m_filteredIndices.end(), [&](size_t left, size_t right) {
+            const bool leftExact = std::to_string(m_routes[left].insertNumber) == query;
+            const bool rightExact = std::to_string(m_routes[right].insertNumber) == query;
+            return leftExact && !rightExact;
+        });
+    }
+    const int maximumFirst = std::max(0, static_cast<int>(m_filteredIndices.size()) - kVisibleRows);
+    m_firstVisible = std::clamp(m_firstVisible, 0, maximumFirst);
+    m_hoveredVisibleRow = -1;
+}
+
+void UIInsertRoutePicker::updatePopupBounds() {
+    const float width = std::max(kPopupWidth, m_triggerBounds.width);
+    m_popupBounds = {m_triggerBounds.right() - width, m_triggerBounds.bottom() + 6.0f, width,
+                     kSearchHeight + kRowHeight * kVisibleRows + kFooterHeight};
+    if (m_searchInput) {
+        m_searchInput->setBounds(
+            {m_popupBounds.x + 8.0f, m_popupBounds.y + 6.0f, m_popupBounds.width - 16.0f, kSearchHeight - 12.0f});
+    }
+}
+
+void UIInsertRoutePicker::selectRoute(uint32_t routeId) {
+    setSelectedRoute(routeId);
+    close();
+    if (m_onRouteSelected)
+        m_onRouteSelected(m_selectedRouteId);
+}
+
+const UIInsertRoutePicker::Route* UIInsertRoutePicker::selectedRoute() const {
+    const auto found = std::find_if(m_routes.begin(), m_routes.end(),
+                                    [this](const Route& route) { return route.id == m_selectedRouteId; });
+    return found == m_routes.end() ? nullptr : &*found;
+}
+
+int UIInsertRoutePicker::hitTestVisibleRow(const NUIPoint& point) const {
+    const NUIRect listBounds{m_popupBounds.x, m_popupBounds.y + kSearchHeight, m_popupBounds.width,
+                             kRowHeight * kVisibleRows};
+    if (!listBounds.contains(point))
+        return -1;
+    const int visibleRow = static_cast<int>((point.y - listBounds.y) / kRowHeight);
+    const int filteredIndex = m_firstVisible + visibleRow;
+    return filteredIndex < static_cast<int>(m_filteredIndices.size()) ? visibleRow : -1;
+}
+
+void UIInsertRoutePicker::onRender(NUIRenderer& renderer) {
+    if (!isVisible())
+        return;
+
+    auto& theme = NUIThemeManager::getInstance();
+    const auto textPrimary = theme.getColor("textPrimary");
+    const auto textSecondary = theme.getColor("textSecondary");
+    const auto border = theme.getColor("borderSubtle");
+    const auto triggerBackground = theme.getColor("surfaceRaised").withAlpha(0.94f);
+    const auto accent = theme.getColor("secondary");
+
+    renderer.fillRoundedRect(m_triggerBounds, 6.0f,
+                             isHovered() ? triggerBackground.lightened(0.05f) : triggerBackground);
+    renderer.strokeRoundedRect(m_triggerBounds, 6.0f, m_open ? 1.5f : 1.0f, m_open ? accent.withAlpha(0.9f) : border);
+
+    const Route* selected = selectedRoute();
+    const std::string number = selected ? routeNumberLabel(*selected) : "M";
+    const std::string name = selected ? selected->name : "Master";
+    const NUIRect badge{m_triggerBounds.x + 7.0f, m_triggerBounds.y + 5.0f, 29.0f, m_triggerBounds.height - 10.0f};
+    renderer.fillRoundedRect(badge, 4.0f, accent.withAlpha(0.17f));
+    renderer.drawTextCentered(number, badge, 10.0f, accent.lightened(0.20f));
+    renderer.drawText(name, {m_triggerBounds.x + 44.0f, m_triggerBounds.y + 8.0f}, 12.0f, textPrimary);
+    renderer.drawText("FIND", {m_triggerBounds.right() - 39.0f, m_triggerBounds.y + 9.0f}, 9.0f, textSecondary);
+
+    if (!m_open) {
+        setDirty(false);
+        return;
+    }
+
+    const auto popupBackground = theme.getColor("backgroundPrimary");
+    const auto rowHover = theme.getColor("buttonBgHover").withAlpha(0.86f);
+    renderer.fillRoundedRect(m_popupBounds, 8.0f, popupBackground);
+    renderer.strokeRoundedRect(m_popupBounds, 8.0f, 1.0f, border.withAlpha(0.85f));
+
+    renderer.fillRect({m_popupBounds.x + 1.0f, m_popupBounds.y + kSearchHeight, m_popupBounds.width - 2.0f, 1.0f},
+                      border.withAlpha(0.55f));
+    renderChildren(renderer);
+
+    const NUIRect listBounds{m_popupBounds.x + 1.0f, m_popupBounds.y + kSearchHeight, m_popupBounds.width - 2.0f,
+                             kRowHeight * kVisibleRows};
+    renderer.setClipRect(listBounds);
+    const int visibleCount = std::min(kVisibleRows, static_cast<int>(m_filteredIndices.size()) - m_firstVisible);
+    for (int visibleRow = 0; visibleRow < visibleCount; ++visibleRow) {
+        const auto& route = m_routes[m_filteredIndices[static_cast<size_t>(m_firstVisible + visibleRow)]];
+        const float rowY = listBounds.y + visibleRow * kRowHeight;
+        const NUIRect rowBounds{listBounds.x, rowY, listBounds.width, kRowHeight};
+        const bool isSelected = route.id == m_selectedRouteId;
+        if (visibleRow == m_hoveredVisibleRow || isSelected)
+            renderer.fillRect(rowBounds, isSelected ? accent.withAlpha(0.13f) : rowHover);
+
+        const NUIRect numberBounds{rowBounds.x + 9.0f, rowBounds.y + 7.0f, 31.0f, rowBounds.height - 14.0f};
+        renderer.fillRoundedRect(numberBounds, 4.0f, accent.withAlpha(isSelected ? 0.24f : 0.10f));
+        renderer.drawTextCentered(routeNumberLabel(route), numberBounds, 10.0f,
+                                  isSelected ? accent.lightened(0.22f) : textSecondary);
+
+        if (route.colorArgb != 0) {
+            renderer.fillRoundedRect({rowBounds.x + 49.0f, rowBounds.y + 14.0f, 8.0f, 8.0f}, 2.0f,
+                                     colorFromArgb(route.colorArgb));
+        }
+        renderer.drawText(route.name, {rowBounds.x + 65.0f, rowBounds.y + 10.0f}, 12.0f, textPrimary);
+        if (isSelected)
+            renderer.drawText("ROUTED", {rowBounds.right() - 53.0f, rowBounds.y + 11.0f}, 9.0f, accent);
+    }
+    renderer.clearClipRect();
+
+    if (m_filteredIndices.empty()) {
+        renderer.drawTextCentered("No matching Inserts", listBounds, 12.0f, textSecondary);
+    }
+
+    const float footerY = m_popupBounds.bottom() - kFooterHeight;
+    renderer.fillRect({m_popupBounds.x + 1.0f, footerY, m_popupBounds.width - 2.0f, 1.0f}, border.withAlpha(0.55f));
+    const std::string footer = m_filteredIndices.size() > kVisibleRows
+                                   ? std::to_string(m_filteredIndices.size()) + " matches  •  wheel to browse"
+                                   : "Type a number or name  •  Enter routes";
+    renderer.drawText(footer, {m_popupBounds.x + 10.0f, footerY + 10.0f}, 10.0f, textSecondary);
+    setDirty(false);
+}
+
+bool UIInsertRoutePicker::onMouseEvent(const NUIMouseEvent& event) {
+    if (!isVisible() || !isEnabled())
+        return false;
+
+    if (!m_open) {
+        if (event.pressed && event.button == NUIMouseButton::Left && m_triggerBounds.contains(event.position)) {
+            open();
+            return true;
+        }
+        setHovered(m_triggerBounds.contains(event.position));
+        return false;
+    }
+
+    if (m_searchInput && m_searchInput->getBounds().contains(event.position) && m_searchInput->onMouseEvent(event))
+        return true;
+
+    if (event.wheelDelta != 0.0f && m_popupBounds.contains(event.position)) {
+        const int maximumFirst = std::max(0, static_cast<int>(m_filteredIndices.size()) - kVisibleRows);
+        const int direction = event.wheelDelta > 0.0f ? -1 : 1;
+        m_firstVisible = std::clamp(m_firstVisible + direction, 0, maximumFirst);
+        m_hoveredVisibleRow = hitTestVisibleRow(event.position);
+        repaint();
+        return true;
+    }
+
+    if (m_popupBounds.contains(event.position)) {
+        const int hovered = hitTestVisibleRow(event.position);
+        if (hovered != m_hoveredVisibleRow) {
+            m_hoveredVisibleRow = hovered;
+            repaint();
+        }
+        if (event.pressed && event.button == NUIMouseButton::Left && hovered >= 0) {
+            const int filteredIndex = m_firstVisible + hovered;
+            selectRoute(m_routes[m_filteredIndices[static_cast<size_t>(filteredIndex)]].id);
+        }
+        return true;
+    }
+
+    if (m_triggerBounds.contains(event.position)) {
+        if (event.pressed && event.button == NUIMouseButton::Left)
+            close();
+        return true;
+    }
+
+    if (event.pressed) {
+        close();
+        return true;
+    }
+    return false;
+}
+
+bool UIInsertRoutePicker::onKeyEvent(const NUIKeyEvent& event) {
+    if (!m_open)
+        return false;
+    if (event.pressed && event.keyCode == NUIKeyCode::Escape) {
+        close();
+        return true;
+    }
+    if (event.pressed && event.keyCode == NUIKeyCode::Enter)
+        return routeFirstMatch();
+    return false;
+}
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/UIInsertRoutePicker.h
+++ b/AestraUI/Widgets/UIInsertRoutePicker.h
@@ -1,0 +1,79 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "NUIComponent.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace AestraUI {
+
+class NUITextInput;
+
+/**
+ * Search-first mixer destination picker.
+ *
+ * Insert numbers are presentation only; selection callbacks always return the
+ * stable mixer channel ID.
+ */
+class UIInsertRoutePicker final : public NUIComponent {
+public:
+    struct Route {
+        uint32_t id{0};
+        int insertNumber{0};
+        std::string name;
+        uint32_t colorArgb{0};
+    };
+
+    UIInsertRoutePicker();
+
+    void setRoutes(std::vector<Route> routes, uint32_t selectedRouteId);
+    void setSelectedRoute(uint32_t routeId);
+    uint32_t getSelectedRoute() const { return m_selectedRouteId; }
+    void setTriggerBounds(const NUIRect& bounds);
+    void setOnRouteSelected(std::function<void(uint32_t)> callback) { m_onRouteSelected = std::move(callback); }
+
+    void setSearchQuery(const std::string& query);
+    std::vector<uint32_t> getFilteredRouteIds() const;
+    bool routeFirstMatch();
+
+    bool isOpen() const { return m_open; }
+    void close();
+
+    void onRender(NUIRenderer& renderer) override;
+    bool onMouseEvent(const NUIMouseEvent& event) override;
+    bool onKeyEvent(const NUIKeyEvent& event) override;
+
+private:
+    static constexpr float kPopupWidth = 340.0f;
+    static constexpr float kSearchHeight = 42.0f;
+    static constexpr float kRowHeight = 36.0f;
+    static constexpr float kFooterHeight = 30.0f;
+    static constexpr int kVisibleRows = 6;
+
+    std::vector<Route> m_routes;
+    std::vector<size_t> m_filteredIndices;
+    uint32_t m_selectedRouteId{0};
+    std::string m_searchQuery;
+    NUIRect m_triggerBounds;
+    NUIRect m_popupBounds;
+    int m_firstVisible{0};
+    int m_hoveredVisibleRow{-1};
+    bool m_open{false};
+
+    std::shared_ptr<NUITextInput> m_searchInput;
+    std::function<void(uint32_t)> m_onRouteSelected;
+
+    void open();
+    void rebuildFilter();
+    void updatePopupBounds();
+    void selectRoute(uint32_t routeId);
+    const Route* selectedRoute() const;
+    int hitTestVisibleRow(const NUIPoint& point) const;
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/UIItemSelector.cpp
+++ b/AestraUI/Widgets/UIItemSelector.cpp
@@ -101,18 +101,19 @@ void UIItemSelector::commitEditing() {
         }
     }
     
-    // 2. "Track X" number parsing
+    // 2. Mixer insert number parsing
     if (matchIndex == -1) {
         try {
             // Check if user just typed a number "7"
             int trackNum = std::stoi(text);
             
-            // Try to find "Track NUM" or "Track NUM *"
-            std::string prefix = "track " + std::to_string(trackNum);
-             for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
+            // Prefer current "Insert NUM" labels while accepting saved legacy names.
+            const std::string insertPrefix = "insert " + std::to_string(trackNum);
+            const std::string legacyTrackPrefix = "track " + std::to_string(trackNum);
+            for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
                 std::string item = m_items[i];
                 std::transform(item.begin(), item.end(), item.begin(), ::tolower);
-                if (item.find(prefix) == 0) { // Starts with "track N"
+                if (item.find(insertPrefix) == 0 || item.find(legacyTrackPrefix) == 0) {
                     matchIndex = i;
                     break;
                 }

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -334,8 +334,8 @@ void UIMixerInspector::updateHeaderCache(const Aestra::ChannelViewModel* channel
 
     m_cachedTrackNumber = findTrackNumber(channel->id);
     const std::string trackLabel = (m_cachedTrackNumber > 0)
-        ? ("Track " + std::to_string(m_cachedTrackNumber))
-        : "Channel";
+        ? ("Insert " + std::to_string(m_cachedTrackNumber))
+        : "Insert";
 
     m_cachedHeaderTitle = channel->name.empty()
         ? trackLabel
@@ -538,9 +538,9 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         renderer.fillRoundedRect(stateChip, 9.0f, m_bg.withAlpha(0.34f));
         renderer.strokeRoundedRect(stateChip, 9.0f, 1.0f, accent.withAlpha(0.20f));
         renderer.drawTextCentered("INSPECTOR", stateChip, 9.0f, m_textSecondary.withAlpha(0.90f));
-        renderer.drawTextCentered("Select a Track", {emptyCard.x + 18.0f, stateChip.bottom() + 16.0f, emptyCard.width - 36.0f, 18.0f},
+        renderer.drawTextCentered("Select an Insert", {emptyCard.x + 18.0f, stateChip.bottom() + 16.0f, emptyCard.width - 36.0f, 18.0f},
                                   13.0f, m_text.withAlpha(0.95f));
-        renderer.drawTextCentered("Choose a mixer channel to inspect",
+        renderer.drawTextCentered("Choose a mixer insert to inspect",
                                   {emptyCard.x + 24.0f, stateChip.bottom() + 38.0f, emptyCard.width - 48.0f, 14.0f},
                                   10.0f, m_textSecondary.withAlpha(0.86f));
         renderer.drawTextCentered("Inserts, Sends, and I/O.",
@@ -566,7 +566,7 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         titleAccent = NUIColor(r, g, b, a);
     }
     // Channel identity: a colour swatch beside the name. The old TRACK/BUS word
-    // pill was redundant with the "Track 1" title right below it — you're already
+    // pill was redundant with the numbered insert title right below it — you're already
     // in the mixer inspector, and the master reads as MASTER and is visually
     // distinct. The swatch gives this spot a real job: it ties the inspector to
     // the selected strip's colour.

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -50,9 +50,13 @@ namespace {
         if (targetId == 0 || targetName == "Master" || targetName == "MASTER") {
             return "M";
         }
-        const std::string trackPrefix = "Track ";
-        if (targetName.rfind(trackPrefix, 0) == 0) {
-            return "T" + targetName.substr(trackPrefix.size());
+        const std::string insertPrefix = "Insert ";
+        if (targetName.rfind(insertPrefix, 0) == 0) {
+            return "I" + targetName.substr(insertPrefix.size());
+        }
+        const std::string legacyTrackPrefix = "Track ";
+        if (targetName.rfind(legacyTrackPrefix, 0) == 0) {
+            return "I" + targetName.substr(legacyTrackPrefix.size());
         }
         const std::string lanePrefix = "Lane ";
         if (targetName.rfind(lanePrefix, 0) == 0) {

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -137,7 +137,7 @@ void UIRoutingMap::rebuildGraph() {
         Node node;
         node.id = ch->id;
         node.type = Node::Track;
-        node.label = ch->name.empty() ? ("Track " + std::to_string(i + 1)) : ch->name;
+        node.label = ch->name.empty() ? ("Insert " + std::to_string(i + 1)) : ch->name;
         node.color = paletteIndexToARGB(ch->trackColorIndex);
         node.insertCount = ch->fxCount;
         node.muted = ch->muted;
@@ -220,7 +220,7 @@ void UIRoutingMap::rebuildFocusedGraph(const Aestra::ChannelViewModel* selected)
     Node node;
     node.id = selected->id;
     node.type = Node::Track;
-    node.label = selected->name.empty() ? "Track" : selected->name;
+    node.label = selected->name.empty() ? "Insert" : selected->name;
     node.color = paletteIndexToARGB(selected->trackColorIndex);
     node.insertCount = selected->fxCount;
     node.muted = selected->muted;

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -3,6 +3,8 @@
 
 #include "../../AestraCore/include/AestraLog.h"
 #include "AudioEngine.h"
+#include "Commands/AssignUnitToFirstFreeInsertCommand.h"
+#include "Commands/SetUnitMixerChannelCommand.h"
 #include "NUIRenderer.h"
 #include "NUIThemeSystem.h"
 #include "PluginBrowserPanel.h"
@@ -11,7 +13,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
-#include <unordered_set>
 namespace AestraUI {
 
 namespace {
@@ -1303,52 +1304,20 @@ void UnitRow::routeToMixerChannel(uint32_t channelId) {
     if (!m_trackManager || !m_manager.getUnit(m_unitId)) {
         return;
     }
-    m_manager.setUnitMixerChannel(m_unitId, static_cast<int64_t>(channelId));
-    m_trackManager->markModified();
+    m_trackManager->getCommandHistory().pushAndExecute(
+        std::make_shared<Aestra::Audio::SetUnitMixerChannelCommand>(*m_trackManager, m_unitId, channelId));
     updateState();
 }
 
-void UnitRow::routeToFirstFreeMixerChannel() {
+bool UnitRow::routeToFirstFreeMixerChannel() {
     if (!m_trackManager || !m_manager.getUnit(m_unitId)) {
-        return;
+        return false;
     }
 
-    std::unordered_set<uint32_t> usedChannelIds;
-    for (const auto unitId : m_manager.getAllUnitIDs()) {
-        if (unitId == m_unitId)
-            continue;
-        const uint32_t channelId = m_manager.getUnitMixerChannel(unitId);
-        if (channelId != Aestra::Audio::MASTER_MIXER_CHANNEL_ID) {
-            usedChannelIds.insert(channelId);
-        }
-    }
-
-    for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
-        const auto* channel = m_trackManager->getChannel(i);
-        if (channel && usedChannelIds.find(channel->getChannelId()) == usedChannelIds.end()) {
-            routeToMixerChannel(channel->getChannelId());
-            return;
-        }
-    }
-
-    auto& playlist = m_trackManager->getPlaylistModel();
     const std::string destinationName = m_name.empty() ? "Mixer Insert" : m_name;
-    const auto laneId = playlist.createLane(destinationName);
-    if (!laneId.isValid()) {
-        return;
-    }
-
-    auto* channel = m_trackManager->addChannel(destinationName);
-    if (!channel) {
-        playlist.removeLane(laneId);
-        return;
-    }
-
-    channel->setColor(m_color);
-    if (auto* lane = playlist.getLane(laneId)) {
-        lane->colorRGBA = m_color;
-    }
-    routeToMixerChannel(channel->getChannelId());
+    const bool routed = Aestra::Audio::assignUnitToFirstFreeInsert(*m_trackManager, m_unitId, destinationName, m_color);
+    updateState();
+    return routed;
 }
 
 void UnitRow::showMixerRoutingMenu(const NUIPoint& pos) {

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -1,35 +1,32 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "UnitRow.h"
-#include "PluginBrowserPanel.h"
-#include <chrono>
-#include <algorithm>
-#include <cmath>
-#include "NUIThemeSystem.h"
-#include "NUIRenderer.h"
 
-#include "TrackManager.h"
-#include "AudioEngine.h"
 #include "../../AestraCore/include/AestraLog.h"
+#include "AudioEngine.h"
+#include "NUIRenderer.h"
+#include "NUIThemeSystem.h"
+#include "PluginBrowserPanel.h"
+#include "TrackManager.h"
 
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <unordered_set>
 namespace AestraUI {
 
 namespace {
-bool usesStepSequencerForType(Aestra::Audio::UnitType type)
-{
+bool usesStepSequencerForType(Aestra::Audio::UnitType type) {
     return type == Aestra::Audio::UnitType::Sampler || type == Aestra::Audio::UnitType::PitchedSampler;
 }
 
-bool usesPianoRollForType(Aestra::Audio::UnitType type)
-{
+bool usesPianoRollForType(Aestra::Audio::UnitType type) {
     return type == Aestra::Audio::UnitType::Instrument;
 }
 
 NUIColor colorFromUnitValue(uint32_t value) {
     constexpr float scale = 1.0f / 255.0f;
-    return NUIColor(static_cast<float>((value >> 16) & 0xff) * scale,
-                    static_cast<float>((value >> 8) & 0xff) * scale,
-                    static_cast<float>(value & 0xff) * scale,
-                    1.0f);
+    return NUIColor(static_cast<float>((value >> 16) & 0xff) * scale, static_cast<float>((value >> 8) & 0xff) * scale,
+                    static_cast<float>(value & 0xff) * scale, 1.0f);
 }
 
 AestraUI::NUIComponent* getRootComponent(AestraUI::NUIComponent* component) {
@@ -41,27 +38,29 @@ AestraUI::NUIComponent* getRootComponent(AestraUI::NUIComponent* component) {
 }
 
 void detachContextMenu(const std::shared_ptr<AestraUI::NUIContextMenu>& menu) {
-    if (!menu) return;
+    if (!menu)
+        return;
     if (auto* parent = menu->getParent()) {
         parent->removeChild(menu);
     }
 }
 
-void attachAndShowContextMenu(AestraUI::NUIComponent* owner,
-                              const std::shared_ptr<AestraUI::NUIContextMenu>& menu,
+void attachAndShowContextMenu(AestraUI::NUIComponent* owner, const std::shared_ptr<AestraUI::NUIContextMenu>& menu,
                               const AestraUI::NUIPoint& position) {
-    if (!owner || !menu) return;
+    if (!owner || !menu)
+        return;
     AestraUI::NUIComponent* root = getRootComponent(owner);
-    if (!root) root = owner;
+    if (!root)
+        root = owner;
     root->addChild(menu);
     menu->showAt(position);
     root->repaint();
 }
 } // namespace
 
-UnitRow::UnitRow(std::shared_ptr<Aestra::Audio::TrackManager> trackManager, Aestra::Audio::UnitManager& manager, Aestra::Audio::UnitID unitId, Aestra::Audio::PatternID patternId)
-    : m_trackManager(trackManager), m_manager(manager), m_unitId(unitId), m_patternId(patternId)
-{
+UnitRow::UnitRow(std::shared_ptr<Aestra::Audio::TrackManager> trackManager, Aestra::Audio::UnitManager& manager,
+                 Aestra::Audio::UnitID unitId, Aestra::Audio::PatternID patternId)
+    : m_trackManager(trackManager), m_manager(manager), m_unitId(unitId), m_patternId(patternId) {
     this->updateState();
 }
 
@@ -77,10 +76,25 @@ void UnitRow::updateState() {
         m_isArmed = unit->isArmed;
         m_isMuted = unit->isMuted;
         m_isSolo = unit->isSolo;
-        m_audioClip = unit->audioClipPath.empty() ? "" : 
-                      unit->audioClipPath.substr(unit->audioClipPath.find_last_of("/\\") + 1);
+        m_audioClip =
+            unit->audioClipPath.empty() ? "" : unit->audioClipPath.substr(unit->audioClipPath.find_last_of("/\\") + 1);
         m_pluginId = unit->pluginId;
-        m_mixerChannel = unit->targetMixerRoute;
+        m_mixerChannelId = unit->targetMixerChannelId;
+        m_mixerRouteShortLabel = "M";
+        if (m_mixerChannelId != Aestra::Audio::MASTER_MIXER_CHANNEL_ID && m_trackManager) {
+            bool resolved = false;
+            for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
+                const auto* channel = m_trackManager->getChannel(i);
+                if (channel && channel->getChannelId() == m_mixerChannelId) {
+                    m_mixerRouteShortLabel = std::to_string(i + 1);
+                    resolved = true;
+                    break;
+                }
+            }
+            if (!resolved) {
+                m_mixerRouteShortLabel = "!";
+            }
+        }
         m_audioDurationSeconds = unit->audioDurationSeconds;
         m_audioPreviewWaveform = unit->audioPreviewWaveform;
 
@@ -120,10 +134,12 @@ void UnitRow::updateState() {
         layoutNameLabel();
 
         m_nameLabel->m_onOpenEditor = [this]() {
-            if (m_onEditUnit) m_onEditUnit(m_unitId);
+            if (m_onEditUnit)
+                m_onEditUnit(m_unitId);
         };
         m_nameLabel->m_onRename = [this](const std::string& name) {
-            if (m_onRenameUnit) m_onRenameUnit(m_unitId, name);
+            if (m_onRenameUnit)
+                m_onRenameUnit(m_unitId, name);
         };
     } else {
         m_nameLabel->setUnitName(m_name);
@@ -139,9 +155,11 @@ void UnitRow::setStepCount(int count) {
 }
 
 void UnitRow::setFitToWidth(bool fit) {
-    if (fit == m_fitToWidth) return;
+    if (fit == m_fitToWidth)
+        return;
     m_fitToWidth = fit;
-    if (fit) m_scrollX = 0.0f; // Nothing to page when the whole loop is shown
+    if (fit)
+        m_scrollX = 0.0f; // Nothing to page when the whole loop is shown
     invalidateVisuals();
 }
 
@@ -171,11 +189,13 @@ void UnitRow::onRender(NUIRenderer& renderer) {
 
     // Render dynamic children (Input Widget, Context Menu) on top
     // Push UnitRow position so children (relative coords) draw correctly
-    if (hasViewport) renderer.setClipRect(m_viewport);
+    if (hasViewport)
+        renderer.setClipRect(m_viewport);
     renderer.pushTransform(bounds.x, bounds.y);
     renderChildren(renderer);
     renderer.popTransform();
-    if (hasViewport) renderer.clearClipRect();
+    if (hasViewport)
+        renderer.clearClipRect();
 }
 
 void UnitRow::drawContent(NUIRenderer& renderer) {
@@ -193,7 +213,8 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
         const float clipBottom = std::min(paintClip.bottom(), m_viewport.bottom());
         paintClip.y = clipTop;
         paintClip.height = clipBottom - clipTop;
-        if (paintClip.height <= 0.0f) return;
+        if (paintClip.height <= 0.0f)
+            return;
     }
     renderer.setClipRect(paintClip);
 
@@ -215,25 +236,24 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
 
     renderer.fillRoundedRect(cardBounds, radius, cardBg);
     renderer.strokeRoundedRect(cardBounds, radius, m_isDropHighlighted ? 2.0f : 1.0f, border);
-    renderer.fillRoundedRect({cardBounds.x + 1.0f, cardBounds.y + 8.0f, 4.0f, cardBounds.height - 16.0f},
-                             2.0f, unitAccent.withAlpha(m_isEnabled ? 0.95f : 0.35f));
+    renderer.fillRoundedRect({cardBounds.x + 1.0f, cardBounds.y + 8.0f, 4.0f, cardBounds.height - 16.0f}, 2.0f,
+                             unitAccent.withAlpha(m_isEnabled ? 0.95f : 0.35f));
 
     m_controlWidth = std::clamp(cardBounds.width * 0.38f, 220.0f, 312.0f);
 
     NUIRect dragRect(cardBounds.x + 6.0f, cardBounds.y + 6.0f, 32.0f, cardBounds.height - 12.0f);
     drawDragHandle(renderer, dragRect);
 
-    NUIRect controlRect(cardBounds.x + 42.0f, cardBounds.y,
-                        std::max(0.0f, m_controlWidth - 48.0f), cardBounds.height);
+    NUIRect controlRect(cardBounds.x + 42.0f, cardBounds.y, std::max(0.0f, m_controlWidth - 48.0f), cardBounds.height);
     drawControlBlock(renderer, controlRect);
 
     float separatorX = cardBounds.x + m_controlWidth;
     renderer.drawLine(NUIPoint(separatorX, cardBounds.y + 8.0f),
-                      NUIPoint(separatorX, cardBounds.y + cardBounds.height - 8.0f),
-                      1.0f,
+                      NUIPoint(separatorX, cardBounds.y + cardBounds.height - 8.0f), 1.0f,
                       theme.getColor("borderSubtle").withAlpha(0.55f));
 
-    NUIRect contextRect(separatorX + 8.0f, cardBounds.y + 6.0f, cardBounds.right() - separatorX - 14.0f, cardBounds.height - 12.0f);
+    NUIRect contextRect(separatorX + 8.0f, cardBounds.y + 6.0f, cardBounds.right() - separatorX - 14.0f,
+                        cardBounds.height - 12.0f);
     drawContextBlock(renderer, contextRect);
     renderer.clearClipRect();
 }
@@ -245,8 +265,7 @@ void UnitRow::drawDragHandle(NUIRenderer& renderer, const NUIRect& bounds) {
     const float clusterY = bounds.y + bounds.height * 0.5f - 6.0f;
     for (int row = 0; row < 3; ++row) {
         for (int col = 0; col < 2; ++col) {
-            renderer.fillCircle({clusterX + static_cast<float>(col) * 6.0f,
-                                 clusterY + static_cast<float>(row) * 6.0f},
+            renderer.fillCircle({clusterX + static_cast<float>(col) * 6.0f, clusterY + static_cast<float>(row) * 6.0f},
                                 1.35f, gripColor);
         }
     }
@@ -257,12 +276,12 @@ void UnitRow::drawPowerIcon(NUIRenderer& renderer, const NUIRect& bounds, bool a
     float cx = bounds.x + bounds.width / 2.0f;
     float cy = bounds.y + bounds.height / 2.0f;
     float radius = bounds.width / 2.0f - 2.0f;
-    
+
     NUIColor color = active ? theme.getColor("accentPrimary") : theme.getColor("textDisabled");
-    
+
     // Outer circle
     renderer.strokeCircle(NUIPoint(cx, cy), radius, 1.5f, color);
-    
+
     // Inner dot when active
     if (active) {
         renderer.fillCircle(NUIPoint(cx, cy), radius * 0.4f, color);
@@ -276,12 +295,12 @@ void UnitRow::drawArmIcon(NUIRenderer& renderer, const NUIRect& bounds, bool act
     float cx = bounds.x + bounds.width / 2.0f;
     float cy = bounds.y + bounds.height / 2.0f;
     float radius = bounds.width / 2.0f - 2.0f;
-    
+
     NUIColor color = active ? theme.getColor("accentRed") : theme.getColor("textSecondary");
-    
+
     // Outer circle (record button style)
     renderer.strokeCircle(NUIPoint(cx, cy), radius, 1.5f, color);
-    
+
     // Inner filled circle when armed
     if (active) {
         renderer.fillCircle(NUIPoint(cx, cy), radius * 0.6f, color);
@@ -290,7 +309,7 @@ void UnitRow::drawArmIcon(NUIRenderer& renderer, const NUIRect& bounds, bool act
 
 void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active) {
     auto& theme = NUIThemeManager::getInstance();
-    
+
     NUIColor bgColor = active ? theme.getColor("warning") : theme.getColor("backgroundPrimary");
     NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
     NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
@@ -332,18 +351,19 @@ void UnitRow::drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
 
 void UnitRow::drawGearIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active) {
     auto& theme = NUIThemeManager::getInstance();
-    
+
     NUIColor color = active ? theme.getColor("accentPrimary") : theme.getColor("textSecondary");
-    if (!m_isHovered && !active) color = theme.getColor("textDisabled");
-    
+    if (!m_isHovered && !active)
+        color = theme.getColor("textDisabled");
+
     float cx = bounds.x + bounds.width / 2.0f;
     float cy = bounds.y + bounds.height / 2.0f;
     float r = 6.0f;
-    
+
     // Simple "Settings" cog visual
     renderer.strokeCircle(NUIPoint(cx, cy), r, 1.5f, color);
     renderer.fillCircle(NUIPoint(cx, cy), 2.0f, color);
-    
+
     // Teeth (Cardinals)
     renderer.drawLine(NUIPoint(cx, cy - r - 2), NUIPoint(cx, cy + r + 2), 2.0f, color);
     renderer.drawLine(NUIPoint(cx - r - 2, cy), NUIPoint(cx + r + 2, cy), 2.0f, color);
@@ -364,15 +384,23 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     const float nameX = bounds.x + 12.0f;
     const NUIColor unitAccent = colorFromUnitValue(m_color);
 
-    renderer.fillCircle(NUIPoint(nameX, bounds.y + 18.0f),
-                        3.0f,
+    renderer.fillCircle(NUIPoint(nameX, bounds.y + 18.0f), 3.0f,
                         m_isEnabled ? unitAccent : theme.getColor("textDisabled"));
 
     // Name + type label are rendered by the UnitNameLabel child component.
 
     const float pillY = centerY - 10.0f;
+    const NUIRect routeRect(bounds.x + bounds.width - 142.0f, pillY, 42.0f, 20.0f);
     const NUIRect muteRect(bounds.x + bounds.width - 92.0f, pillY, 24.0f, 20.0f);
     const NUIRect soloRect(bounds.x + bounds.width - 62.0f, pillY, 24.0f, 20.0f);
+    const NUIColor routeFill = m_mixerChannelId == Aestra::Audio::MASTER_MIXER_CHANNEL_ID
+                                   ? theme.getColor("surfaceTertiary")
+                                   : unitAccent.withAlpha(0.16f);
+    const NUIColor routeStroke =
+        m_mixerRouteShortLabel == "!" ? theme.getColor("error").withAlpha(0.75f) : unitAccent.withAlpha(0.42f);
+    renderer.fillRoundedRect(routeRect, 4.0f, routeFill);
+    renderer.strokeRoundedRect(routeRect, 4.0f, 1.0f, routeStroke);
+    renderer.drawTextCentered(m_mixerRouteShortLabel, routeRect, 9.0f, theme.getColor("textPrimary").withAlpha(0.9f));
     drawMuteIcon(renderer, muteRect, m_isMuted);
     drawSoloIcon(renderer, soloRect, m_isSolo);
 
@@ -380,9 +408,8 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     for (int i = 0; i < 3; ++i) {
         const float h = 4.0f + i * 3.0f;
         const NUIRect bar(indicatorX + i * 4.0f, bounds.y + 28.0f - h * 0.5f, 2.0f, h);
-        const NUIColor color = hasContent
-            ? theme.getColor("accentPrimary").withAlpha(0.75f - i * 0.12f)
-            : theme.getColor("textDisabled").withAlpha(0.28f);
+        const NUIColor color = hasContent ? theme.getColor("accentPrimary").withAlpha(0.75f - i * 0.12f)
+                                          : theme.getColor("textDisabled").withAlpha(0.28f);
         renderer.fillRoundedRect(bar, 1.0f, color);
     }
 }
@@ -403,21 +430,19 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     renderer.fillRoundedRect(contentCard, themeProps.radiusS + 2.0f, theme.getColor("backgroundPrimary"));
 
     const float lanePadding = 6.0f;
-    const NUIRect timelineStrip(contentCard.x + lanePadding,
-                                contentCard.y + lanePadding,
+    const NUIRect timelineStrip(contentCard.x + lanePadding, contentCard.y + lanePadding,
                                 std::max(0.0f, contentCard.width - lanePadding * 2.0f),
                                 std::max(0.0f, contentCard.height - lanePadding * 2.0f));
-    
+
     // === Step Grid Layout ===
     float availWidth = timelineStrip.width;
     float stepWidth = gridStepWidth(availWidth);
     float totalWidth = stepWidth * m_stepCount;
 
-    
     // Clamp scroll
     float maxScroll = std::max(0.0f, totalWidth - availWidth);
     m_scrollX = std::max(0.0f, std::min(m_scrollX, maxScroll));
-    
+
     // === Fetch Active Steps ===
     std::vector<int> activeSteps;
     std::vector<NoteSpan> noteSpans;
@@ -433,13 +458,15 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             visibleLengthBeats = std::max(0.25, pattern->lengthBeats);
             auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
             for (const auto& note : midi.notes) {
-                if (note.unitId != m_unitId && note.unitId != 0) continue;
+                if (note.unitId != m_unitId && note.unitId != 0)
+                    continue;
                 unitHasContent = true;
                 if (m_type == Aestra::Audio::UnitType::Sampler &&
                     (note.pitch != m_rootMidiNote || std::abs(note.durationBeats - 0.25) > 0.01)) {
                     noteRollMode = true;
                 }
-                const int startStep = std::clamp(static_cast<int>(std::floor(note.startBeat / 0.25 + 0.0001)), 0, m_stepCount - 1);
+                const int startStep =
+                    std::clamp(static_cast<int>(std::floor(note.startBeat / 0.25 + 0.0001)), 0, m_stepCount - 1);
                 const double endBeat = std::max(note.startBeat + 0.25, note.startBeat + note.durationBeats);
                 const int endExclusive =
                     std::clamp(static_cast<int>(std::ceil(endBeat / 0.25 - 0.0001)), startStep + 1, m_stepCount);
@@ -447,8 +474,8 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                 for (int step = startStep; step < endExclusive; ++step) {
                     activeSteps.push_back(step);
                 }
-                noteSpans.push_back(NoteSpan{startStep, endExclusive, note.startBeat, endBeat, note.pitch,
-                                             note.velocity});
+                noteSpans.push_back(
+                    NoteSpan{startStep, endExclusive, note.startBeat, endBeat, note.pitch, note.velocity});
                 stepPitch[startStep] = note.pitch;
                 stepLength[startStep] = static_cast<float>(note.durationBeats);
                 stepVelocity[startStep] = note.velocity;
@@ -508,8 +535,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             if ((step + 1) % 4 == 0 && step + 1 < m_stepCount) {
                 const float markerX = cellRect.right() + (cellGap * 0.5f);
                 renderer.drawLine(NUIPoint(markerX, timelineStrip.y + 2.0f),
-                                  NUIPoint(markerX, timelineStrip.bottom() - 2.0f),
-                                  1.0f,
+                                  NUIPoint(markerX, timelineStrip.bottom() - 2.0f), 1.0f,
                                   theme.getColor("border").withAlpha(0.12f));
             }
         }
@@ -543,15 +569,16 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             renderer.fillRoundedRect(cellRect, 3.0f, cellFill);
             renderer.strokeRoundedRect(cellRect, 3.0f, 1.0f, inactiveStroke);
             if (isPlayhead) {
-                renderer.strokeRoundedRect(cellRect, 3.0f, 1.5f,
-                                           playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
+                renderer.strokeRoundedRect(cellRect, 3.0f, 1.5f, playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
             }
 
             const NUIRect pitchRect(cellX, pitchY, cellWidth, pitchLaneHeight);
             if (stepPitch[step] >= 0) {
                 const int display = stepPitch[step] - m_rootMidiNote; // semitones from root
-                renderer.drawTextCentered((display >= 0 ? "+" : "") + std::to_string(display), pitchRect, 8.0f, pitchText);
-                slidePoints.push_back(NUIPoint(pitchRect.x + pitchRect.width * 0.5f, pitchRect.y + pitchRect.height * 0.5f));
+                renderer.drawTextCentered((display >= 0 ? "+" : "") + std::to_string(display), pitchRect, 8.0f,
+                                          pitchText);
+                slidePoints.push_back(
+                    NUIPoint(pitchRect.x + pitchRect.width * 0.5f, pitchRect.y + pitchRect.height * 0.5f));
             } else {
                 renderer.drawTextCentered("·", pitchRect, 8.0f, pitchText.withAlpha(0.35f));
             }
@@ -571,17 +598,14 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     } else if (noteRollMode) {
         for (int lane = 0; lane < 5; ++lane) {
             const float y = timelineStrip.y + ((lane + 1) * timelineStrip.height / 5.0f);
-            renderer.drawLine(NUIPoint(timelineStrip.x, y),
-                              NUIPoint(timelineStrip.right(), y),
-                              1.0f,
+            renderer.drawLine(NUIPoint(timelineStrip.x, y), NUIPoint(timelineStrip.right(), y), 1.0f,
                               theme.getColor("border").withAlpha(0.07f));
         }
 
         const double barLineBeats =
             m_trackManager ? static_cast<double>(m_trackManager->getTimelineClock().getBeatsPerBar()) : 4.0;
         for (double beat = barLineBeats; beat < visibleLengthBeats; beat += barLineBeats) {
-            const float x = timelineStrip.x +
-                            static_cast<float>(beat / visibleLengthBeats) * totalWidth - m_scrollX;
+            const float x = timelineStrip.x + static_cast<float>(beat / visibleLengthBeats) * totalWidth - m_scrollX;
             renderer.drawLine(NUIPoint(x, timelineStrip.y), NUIPoint(x, timelineStrip.bottom()), 1.0f,
                               theme.getColor("border").withAlpha(0.10f));
         }
@@ -603,16 +627,16 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             const float startX = timelineStrip.x +
                                  static_cast<float>(span.startBeat / visibleLengthBeats) * totalWidth + 1.5f -
                                  m_scrollX;
-            const float endX = timelineStrip.x +
-                               static_cast<float>(span.endBeat / visibleLengthBeats) * totalWidth - 1.5f -
-                               m_scrollX;
+            const float endX =
+                timelineStrip.x + static_cast<float>(span.endBeat / visibleLengthBeats) * totalWidth - 1.5f - m_scrollX;
             const float width = std::max(6.0f, endX - startX);
             if (startX + width < timelineStrip.x || startX > timelineStrip.right()) {
                 continue;
             }
 
             float normalizedPitch = static_cast<float>(span.pitch - minPitch) / static_cast<float>(pitchRange);
-            float noteY = timelineStrip.bottom() - 2.0f - (normalizedPitch * (timelineStrip.height - noteHeight - 4.0f)) - noteHeight;
+            float noteY = timelineStrip.bottom() - 2.0f -
+                          (normalizedPitch * (timelineStrip.height - noteHeight - 4.0f)) - noteHeight;
             NUIRect noteRect(startX, noteY, width, noteHeight);
             const bool isPlaying = (playBeat >= 0.0 && playBeat >= span.startBeat && playBeat < span.endBeat);
             renderer.fillRoundedRect(noteRect, 2.0f, isPlaying ? playheadAccent : noteFill);
@@ -628,7 +652,8 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             for (size_t i = 0; i < m_audioPreviewWaveform.size(); ++i) {
                 const float x = timelineStrip.x + static_cast<float>(i) * binWidth;
                 const float amp = std::clamp(m_audioPreviewWaveform[i], 0.02f, 1.0f) * ampScale;
-                renderer.drawLine(NUIPoint(x, midY - amp), NUIPoint(x, midY + amp), std::max(1.0f, binWidth * 0.6f), waveColor);
+                renderer.drawLine(NUIPoint(x, midY - amp), NUIPoint(x, midY + amp), std::max(1.0f, binWidth * 0.6f),
+                                  waveColor);
             }
         }
     }
@@ -642,11 +667,12 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
         } else if (m_type == Aestra::Audio::UnitType::Audio) {
             emptyLabel = "Drop an audio clip";
         }
-        renderer.drawTextCentered("+", NUIRect(timelineStrip.x, timelineStrip.y + 2.0f, timelineStrip.width, 10.0f), 12.0f, theme.getColor("textSecondary").withAlpha(0.72f));
-        renderer.drawTextCentered(emptyLabel,
-                                  NUIRect(timelineStrip.x, timelineStrip.y + 10.0f, timelineStrip.width, timelineStrip.height - 10.0f),
-                                  9.0f,
-                                  theme.getColor("textSecondary").withAlpha(0.72f));
+        renderer.drawTextCentered("+", NUIRect(timelineStrip.x, timelineStrip.y + 2.0f, timelineStrip.width, 10.0f),
+                                  12.0f, theme.getColor("textSecondary").withAlpha(0.72f));
+        renderer.drawTextCentered(
+            emptyLabel,
+            NUIRect(timelineStrip.x, timelineStrip.y + 10.0f, timelineStrip.width, timelineStrip.height - 10.0f), 9.0f,
+            theme.getColor("textSecondary").withAlpha(0.72f));
     }
 }
 
@@ -666,7 +692,8 @@ double UnitRow::playheadBeatInPattern() const {
     const double bpm = m_trackManager->getTimelineClock().getCurrentTempo();
     double beat = m_trackManager->getPosition() * (bpm / 60.0);
     beat = std::fmod(beat, lengthBeats);
-    if (beat < 0.0) beat += lengthBeats;
+    if (beat < 0.0)
+        beat += lengthBeats;
     return beat;
 }
 
@@ -686,8 +713,7 @@ bool UnitRow::shouldUseNoteRoll() const {
     const auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
     return std::any_of(midi.notes.begin(), midi.notes.end(), [this](const Aestra::Audio::MidiNote& note) {
         const bool belongsToUnit = note.unitId == m_unitId || note.unitId == 0;
-        return belongsToUnit &&
-               (note.pitch != m_rootMidiNote || std::abs(note.durationBeats - 0.25) > 0.01);
+        return belongsToUnit && (note.pitch != m_rootMidiNote || std::abs(note.durationBeats - 0.25) > 0.01);
     });
 }
 
@@ -695,8 +721,8 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     // Pointer events outside the panel's list viewport belong to whatever is
     // rendered there (rows scrolled out of view are not clickable). Ongoing
     // drags/step edits keep receiving events so gestures can finish.
-    if (m_viewport.width > 0.0f && m_viewport.height > 0.0f &&
-        !m_isDragging && m_velEditStep < 0 && !m_viewport.contains(event.position)) {
+    if (m_viewport.width > 0.0f && m_viewport.height > 0.0f && !m_isDragging && m_velEditStep < 0 &&
+        !m_viewport.contains(event.position)) {
         if (m_isHovered || m_hoveredStep != -1) {
             m_isHovered = false;
             m_hoveredStep = -1;
@@ -745,9 +771,11 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         // Only scroll if hovering over context area (right of controls)
         if (bounds.contains(event.position) && (event.position.x - bounds.x > m_controlWidth)) {
             float delta = event.wheelDelta;
-            if (delta > 10.0f) delta = 1.0f;
-            if (delta < -10.0f) delta = -1.0f;
-            
+            if (delta > 10.0f)
+                delta = 1.0f;
+            if (delta < -10.0f)
+                delta = -1.0f;
+
             // Step-grid units (Sampler / 808) scroll the grid horizontally so the
             // whole loop is reachable when it's longer than the row is wide. Only
             // the piano-roll / note-roll display scrolls the pitch viewport.
@@ -775,22 +803,22 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
     }
-    
+
     // === Hover Detection ===
     bool wasHovered = m_isHovered;
     m_isHovered = bounds.contains(event.position);
-    
+
     // === Step Hover Detection (with Scroll) ===
     int oldHoveredStep = m_hoveredStep;
     m_hoveredStep = -1;
-    
+
     if (m_isHovered && localContextRect.contains(localPoint)) {
         const int stepIndex = resolveGridStep(localPoint, localGridRect);
         if (stepIndex >= 0 && stepIndex < m_stepCount) {
             m_hoveredStep = stepIndex;
         }
     }
-    
+
     if (wasHovered != m_isHovered || oldHoveredStep != m_hoveredStep) {
         invalidateVisuals();
     }
@@ -811,11 +839,9 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             return true;
         }
 
-        const bool isPointerMove =
-            !event.pressed && !event.released &&
-            (event.type == NUIMouseEventType::Drag ||
-             event.type == NUIMouseEventType::Move ||
-             event.button == NUIMouseButton::None);
+        const bool isPointerMove = !event.pressed && !event.released &&
+                                   (event.type == NUIMouseEventType::Drag || event.type == NUIMouseEventType::Move ||
+                                    event.button == NUIMouseButton::None);
         if (isPointerMove) {
             const float dy = m_velEditStartY - event.position.y; // up = louder
             if (!m_velEditMoved && std::abs(dy) > 3.0f) {
@@ -838,9 +864,9 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     if (event.pressed) {
         // Ensure focus
         if (bounds.contains(event.position)) {
-             setFocused(true);
+            setFocused(true);
         }
-    
+
         if (event.button == NUIMouseButton::Left) {
             // Note: NUITextInput handles its own focus loss/commit.
             // We just handle clicks on other elements.
@@ -849,15 +875,14 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                 if (localDragRect.contains(localPoint)) {
                     m_isDragging = true;
                     m_dragStartPos = event.position;
-                    if (m_onDragStart) m_onDragStart(m_unitId);
+                    if (m_onDragStart)
+                        m_onDragStart(m_unitId);
                     invalidateVisuals();
                     return true;
-                }
-                else if (localControlRect.contains(localPoint)) {
+                } else if (localControlRect.contains(localPoint)) {
                     handleControlClick(event, localControlRect);
                     return true;
-                }
-                else if (localContextRect.contains(localPoint)) {
+                } else if (localContextRect.contains(localPoint)) {
                     // Loaded Sampler step grid: arm a velocity-drag session.
                     // A vertical drag sets the step's velocity; a plain click
                     // toggles it on release. Empty units / pitched / note-roll
@@ -887,37 +912,39 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                 }
             }
         }
-        
+
         // === Right-click (row body, outside name label which is handled by UnitNameLabel child) ===
         if (event.button == NUIMouseButton::Right) {
             if (bounds.contains(event.position)) {
                 // On a step pad with a note: right-click deletes it (FL-style).
                 // Anywhere else on the row keeps the context menu.
-                if (localContextRect.contains(localPoint) && !shouldUseNoteRoll() &&
-                    m_patternId.isValid() && m_trackManager) {
+                if (localContextRect.contains(localPoint) && !shouldUseNoteRoll() && m_patternId.isValid() &&
+                    m_trackManager) {
                     const int stepIndex = resolveGridStep(localPoint, localGridRect);
                     if (stepIndex >= 0 && stepIndex < m_stepCount) {
                         bool removed = false;
                         m_trackManager->getPatternManager().applyPatch(
                             m_patternId, [this, stepIndex, &removed](Aestra::Audio::PatternSource& p) {
-                                if (!p.isMidi()) return;
+                                if (!p.isMidi())
+                                    return;
                                 auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
                                 const double targetBeat = stepIndex * 0.25;
-                                auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
-                                    [this, targetBeat](const Aestra::Audio::MidiNote& n) {
-                                        const double endBeat =
-                                            std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                                        return n.unitId == m_unitId &&
-                                               targetBeat >= n.startBeat - 0.01 &&
-                                               targetBeat < endBeat - 0.01;
-                                    });
+                                auto it =
+                                    std::find_if(midi.notes.begin(), midi.notes.end(),
+                                                 [this, targetBeat](const Aestra::Audio::MidiNote& n) {
+                                                     const double endBeat =
+                                                         std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                                                     return n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 &&
+                                                            targetBeat < endBeat - 0.01;
+                                                 });
                                 if (it != midi.notes.end()) {
                                     midi.notes.erase(it);
                                     removed = true;
                                 }
                             });
                         if (removed) {
-                            if (m_onPatternEdited) m_onPatternEdited(m_patternId);
+                            if (m_onPatternEdited)
+                                m_onPatternEdited(m_patternId);
                             invalidateVisuals();
                             return true;
                         }
@@ -934,7 +961,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         m_isDragging = false;
         invalidateVisuals();
     }
-    
+
     return false;
 }
 
@@ -957,7 +984,12 @@ void UnitRow::handleControlClick(const NUIMouseEvent& event, const NUIRect& boun
 
     const NUIRect muteRect(bounds.width - 92.0f, bounds.height * 0.5f - 10.0f, 24.0f, 20.0f);
     const NUIRect soloRect(bounds.width - 62.0f, bounds.height * 0.5f - 10.0f, 24.0f, 20.0f);
+    const NUIRect routeRect(bounds.width - 142.0f, bounds.height * 0.5f - 10.0f, 42.0f, 20.0f);
     const NUIPoint localPoint(localX, localY);
+    if (routeRect.contains(localPoint)) {
+        showMixerRoutingMenu(event.position);
+        return;
+    }
     if (muteRect.contains(localPoint)) {
         m_manager.setUnitMute(m_unitId, !m_isMuted);
         updateState();
@@ -974,8 +1006,7 @@ void UnitRow::handleControlClick(const NUIMouseEvent& event, const NUIRect& boun
 
 void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& bounds) {
     const auto rowBounds = getBounds();
-    const NUIPoint localPoint(event.position.x - rowBounds.x - bounds.x,
-                              event.position.y - rowBounds.y - bounds.y);
+    const NUIPoint localPoint(event.position.x - rowBounds.x - bounds.x, event.position.y - rowBounds.y - bounds.y);
 
     if (shouldUseNoteRoll()) {
         if (m_onOpenPatternEditor && m_patternId.isValid()) {
@@ -1002,7 +1033,8 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
 
     if (isDoubleClick && m_audioClip.empty() && m_pluginId.empty()) {
         // Empty unit: double-click is a shortcut to give it a sample.
-        if (m_onLoadUnitSample) m_onLoadUnitSample(m_unitId);
+        if (m_onLoadUnitSample)
+            m_onLoadUnitSample(m_unitId);
         return;
     }
 
@@ -1013,7 +1045,7 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
 
     float contentX = relativeX + m_scrollX;
     int stepIndex = static_cast<int>(contentX / stepWidth);
-    
+
     if (stepIndex >= 0 && stepIndex < m_stepCount && m_patternId.isValid()) {
         // Plain toggle: place if empty, remove if present. Silent — the running
         // loop hot-swaps the change on its next pass, which is the wanted
@@ -1034,9 +1066,11 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
 
 bool UnitRow::stepHasNote(int step, float& velocityOut) const {
     velocityOut = kDefaultStepVelocity;
-    if (!m_patternId.isValid() || !m_trackManager) return false;
+    if (!m_patternId.isValid() || !m_trackManager)
+        return false;
     const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
-    if (!pattern || !pattern->isMidi()) return false;
+    if (!pattern || !pattern->isMidi())
+        return false;
     const auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
     const double targetBeat = step * 0.25;
     for (const auto& n : midi.notes) {
@@ -1050,75 +1084,75 @@ bool UnitRow::stepHasNote(int step, float& velocityOut) const {
 }
 
 bool UnitRow::placeStepNote(int step) {
-    if (!m_patternId.isValid() || !m_trackManager) return false;
+    if (!m_patternId.isValid() || !m_trackManager)
+        return false;
     bool placed = false;
-    m_trackManager->getPatternManager().applyPatch(
-        m_patternId, [this, step, &placed](Aestra::Audio::PatternSource& p) {
-            if (!p.isMidi()) return;
-            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-            const double targetBeat = step * 0.25;
-            for (const auto& n : midi.notes) {
-                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
-                    return; // already present
-                }
+    m_trackManager->getPatternManager().applyPatch(m_patternId, [this, step, &placed](Aestra::Audio::PatternSource& p) {
+        if (!p.isMidi())
+            return;
+        auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+        const double targetBeat = step * 0.25;
+        for (const auto& n : midi.notes) {
+            const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+            if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
+                return; // already present
             }
-            // NB: explicit-field init — positional init would drop m_unitId into
-            // MidiNote::pan and leave unitId=0 (dropped by playback). Cf. #447.
-            Aestra::Audio::MidiNote note;
-            note.pitch = m_rootMidiNote; // root → sample plays untransposed
-            note.startBeat = targetBeat;
-            note.durationBeats = 0.25;
-            note.velocity = kDefaultStepVelocity;
-            note.unitId = m_unitId;
-            midi.notes.push_back(note);
-            placed = true;
-        });
+        }
+        // NB: explicit-field init — positional init would drop m_unitId into
+        // MidiNote::pan and leave unitId=0 (dropped by playback). Cf. #447.
+        Aestra::Audio::MidiNote note;
+        note.pitch = m_rootMidiNote; // root → sample plays untransposed
+        note.startBeat = targetBeat;
+        note.durationBeats = 0.25;
+        note.velocity = kDefaultStepVelocity;
+        note.unitId = m_unitId;
+        midi.notes.push_back(note);
+        placed = true;
+    });
     return placed;
 }
 
 bool UnitRow::removeStepNote(int step) {
-    if (!m_patternId.isValid() || !m_trackManager) return false;
+    if (!m_patternId.isValid() || !m_trackManager)
+        return false;
     bool removed = false;
-    m_trackManager->getPatternManager().applyPatch(
-        m_patternId, [this, step, &removed](Aestra::Audio::PatternSource& p) {
-            if (!p.isMidi()) return;
-            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-            const double targetBeat = step * 0.25;
-            auto it = std::find_if(midi.notes.begin(), midi.notes.end(),
-                [this, targetBeat](const Aestra::Audio::MidiNote& n) {
-                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                    return n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 &&
-                           targetBeat < endBeat - 0.01;
-                });
-            if (it != midi.notes.end()) {
-                midi.notes.erase(it);
-                removed = true;
-            }
-        });
+    m_trackManager->getPatternManager().applyPatch(m_patternId, [this, step,
+                                                                 &removed](Aestra::Audio::PatternSource& p) {
+        if (!p.isMidi())
+            return;
+        auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+        const double targetBeat = step * 0.25;
+        auto it =
+            std::find_if(midi.notes.begin(), midi.notes.end(), [this, targetBeat](const Aestra::Audio::MidiNote& n) {
+                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                return n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01;
+            });
+        if (it != midi.notes.end()) {
+            midi.notes.erase(it);
+            removed = true;
+        }
+    });
     return removed;
 }
 
 void UnitRow::setStepNoteVelocity(int step, float velocity) {
-    if (!m_patternId.isValid() || !m_trackManager) return;
+    if (!m_patternId.isValid() || !m_trackManager)
+        return;
     const float v = std::clamp(velocity, kMinStepVelocity, 1.0f);
-    m_trackManager->getPatternManager().applyPatch(
-        m_patternId, [this, step, v](Aestra::Audio::PatternSource& p) {
-            if (!p.isMidi()) return;
-            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-            const double targetBeat = step * 0.25;
-            for (auto& n : midi.notes) {
-                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
-                    n.velocity = v;
-                    return;
-                }
+    m_trackManager->getPatternManager().applyPatch(m_patternId, [this, step, v](Aestra::Audio::PatternSource& p) {
+        if (!p.isMidi())
+            return;
+        auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+        const double targetBeat = step * 0.25;
+        for (auto& n : midi.notes) {
+            const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+            if (n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 && targetBeat < endBeat - 0.01) {
+                n.velocity = v;
+                return;
             }
-        });
+        }
+    });
 }
-
-
-
 
 bool UnitRow::onKeyEvent(const NUIKeyEvent& event) {
     // Key events are forwarded to children automatically by NUIComponent.
@@ -1133,6 +1167,7 @@ bool UnitRow::onKeyEvent(const NUIKeyEvent& event) {
 
 UnitRow::~UnitRow() {
     detachContextMenu(m_rowContextMenu);
+    detachContextMenu(m_mixerRoutingMenu);
     NUIDragDropManager::getInstance().unregisterDropTarget(this);
 }
 
@@ -1159,7 +1194,7 @@ DropFeedback UnitRow::onDragEnter(const DragData& data, const NUIPoint& position
         std::string path = data.filePath;
         std::string ext = path.substr(path.find_last_of('.') + 1);
         std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-        
+
         if (ext == "wav" || ext == "mp3" || ext == "flac" || ext == "ogg" || ext == "aiff") {
             return markAccepted();
         }
@@ -1180,7 +1215,7 @@ DropResult UnitRow::onDrop(const DragData& data, const NUIPoint& position) {
     (void)position;
     DropResult result;
     m_isDropHighlighted = false;
-    
+
     if (data.type == DragDataType::Plugin && !data.sourceClipIdString.empty()) {
         if (const auto* plugin = std::any_cast<PluginListItem>(&data.customData)) {
             if (plugin->typeName != "Instrument") {
@@ -1206,31 +1241,31 @@ DropResult UnitRow::onDrop(const DragData& data, const NUIPoint& position) {
         std::string path = data.filePath;
         std::string ext = path.substr(path.find_last_of('.') + 1);
         std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-        
+
         if (ext == "wav" || ext == "mp3" || ext == "flac" || ext == "ogg" || ext == "aiff") {
             // Extract filename for unit name
             std::string filename = path.substr(path.find_last_of("/\\") + 1);
             // Remove extension
             filename = filename.substr(0, filename.find_last_of('.'));
-            
+
             // Update unit name and load sample
             m_manager.setUnitName(m_unitId, filename);
             m_manager.setUnitAudioClip(m_unitId, path);
-            
+
             // Trigger callback if set
             if (m_onSampleDropped) {
                 m_onSampleDropped(m_unitId, path);
             }
-            
+
             updateState();
             invalidateVisuals();
-            
+
             result.accepted = true;
             result.message = "Sample loaded: " + filename;
             Aestra::Log::info("[UnitRow] Sample dropped: " + filename);
         }
     }
-    
+
     invalidateVisuals();
     return result;
 }
@@ -1255,12 +1290,96 @@ void UnitRow::onResize(int width, int height) {
 }
 
 void UnitRow::layoutNameLabel() {
-    if (!m_nameLabel) return;
+    if (!m_nameLabel)
+        return;
     auto bounds = getBounds();
     float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
     float labelX = 54.0f; // 42 (control block) + 12 (name indent)
-    float labelWidth = std::max(56.0f, controlWidth - 158.0f);
+    float labelWidth = std::max(56.0f, controlWidth - 206.0f);
     m_nameLabel->setBounds(NUIRect(labelX, 8.0f, labelWidth, 30.0f));
+}
+
+void UnitRow::routeToMixerChannel(uint32_t channelId) {
+    if (!m_trackManager || !m_manager.getUnit(m_unitId)) {
+        return;
+    }
+    m_manager.setUnitMixerChannel(m_unitId, static_cast<int64_t>(channelId));
+    m_trackManager->markModified();
+    updateState();
+}
+
+void UnitRow::routeToFirstFreeMixerChannel() {
+    if (!m_trackManager || !m_manager.getUnit(m_unitId)) {
+        return;
+    }
+
+    std::unordered_set<uint32_t> usedChannelIds;
+    for (const auto unitId : m_manager.getAllUnitIDs()) {
+        if (unitId == m_unitId)
+            continue;
+        const uint32_t channelId = m_manager.getUnitMixerChannel(unitId);
+        if (channelId != Aestra::Audio::MASTER_MIXER_CHANNEL_ID) {
+            usedChannelIds.insert(channelId);
+        }
+    }
+
+    for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
+        const auto* channel = m_trackManager->getChannel(i);
+        if (channel && usedChannelIds.find(channel->getChannelId()) == usedChannelIds.end()) {
+            routeToMixerChannel(channel->getChannelId());
+            return;
+        }
+    }
+
+    auto& playlist = m_trackManager->getPlaylistModel();
+    const std::string destinationName = m_name.empty() ? "Mixer Insert" : m_name;
+    const auto laneId = playlist.createLane(destinationName);
+    if (!laneId.isValid()) {
+        return;
+    }
+
+    auto* channel = m_trackManager->addChannel(destinationName);
+    if (!channel) {
+        playlist.removeLane(laneId);
+        return;
+    }
+
+    channel->setColor(m_color);
+    if (auto* lane = playlist.getLane(laneId)) {
+        lane->colorRGBA = m_color;
+    }
+    routeToMixerChannel(channel->getChannelId());
+}
+
+void UnitRow::showMixerRoutingMenu(const NUIPoint& pos) {
+    detachContextMenu(m_mixerRoutingMenu);
+    if (!m_trackManager) {
+        return;
+    }
+
+    m_mixerRoutingMenu = std::make_shared<NUIContextMenu>();
+    m_mixerRoutingMenu->setOnHide([this]() { detachContextMenu(m_mixerRoutingMenu); });
+
+    const auto addRouteItem = [this](uint32_t channelId, const std::string& label) {
+        const bool selected = channelId == m_mixerChannelId;
+        m_mixerRoutingMenu->addItem((selected ? "✓ " : "  ") + label,
+                                    [this, channelId]() { routeToMixerChannel(channelId); });
+    };
+
+    addRouteItem(Aestra::Audio::MASTER_MIXER_CHANNEL_ID, "Master");
+    if (m_trackManager->getChannelCount() > 0) {
+        m_mixerRoutingMenu->addSeparator();
+    }
+    for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
+        const auto* channel = m_trackManager->getChannel(i);
+        if (!channel)
+            continue;
+        addRouteItem(channel->getChannelId(), std::to_string(i + 1) + "  " + channel->getName());
+    }
+
+    m_mixerRoutingMenu->addSeparator();
+    m_mixerRoutingMenu->addItem("Assign to first free insert", [this]() { routeToFirstFreeMixerChannel(); });
+    attachAndShowContextMenu(this, m_mixerRoutingMenu, pos);
 }
 
 void UnitRow::showRowContextMenu(const NUIPoint& pos) {
@@ -1279,7 +1398,8 @@ void UnitRow::showRowContextMenu(const NUIPoint& pos) {
     if (usesPianoRollForType(type) && hasPattern) {
         m_rowContextMenu->addItem("Open in Piano Roll", [this]() {
             // Verify unit still exists (defensive check against use-after-free)
-            if (!m_manager.getUnit(m_unitId)) return;
+            if (!m_manager.getUnit(m_unitId))
+                return;
             if (m_onOpenPatternEditor && m_patternId.isValid()) {
                 m_onOpenPatternEditor(m_patternId);
             }
@@ -1292,37 +1412,48 @@ void UnitRow::showRowContextMenu(const NUIPoint& pos) {
 
         if (hasSample) {
             m_rowContextMenu->addItem("Replace Sample", [this]() {
-                if (!m_manager.getUnit(m_unitId)) return;
-                if (m_onLoadUnitSample) m_onLoadUnitSample(m_unitId);
+                if (!m_manager.getUnit(m_unitId))
+                    return;
+                if (m_onLoadUnitSample)
+                    m_onLoadUnitSample(m_unitId);
             });
         } else {
             m_rowContextMenu->addItem("Load Sample", [this]() {
-                if (!m_manager.getUnit(m_unitId)) return;
-                if (m_onLoadUnitSample) m_onLoadUnitSample(m_unitId);
+                if (!m_manager.getUnit(m_unitId))
+                    return;
+                if (m_onLoadUnitSample)
+                    m_onLoadUnitSample(m_unitId);
             });
         }
     }
     if (type == Aestra::Audio::UnitType::Audio) {
         m_rowContextMenu->addItem("Load Audio Clip", [this]() {
-            if (!m_manager.getUnit(m_unitId)) return;
-            if (m_onLoadUnitSample) m_onLoadUnitSample(m_unitId);
+            if (!m_manager.getUnit(m_unitId))
+                return;
+            if (m_onLoadUnitSample)
+                m_onLoadUnitSample(m_unitId);
         });
     }
 
     m_rowContextMenu->addSeparator();
     m_rowContextMenu->addItem("Rename", [this]() {
-        if (!m_manager.getUnit(m_unitId)) return;
-        if (m_nameLabel) m_nameLabel->beginRename();
+        if (!m_manager.getUnit(m_unitId))
+            return;
+        if (m_nameLabel)
+            m_nameLabel->beginRename();
     });
 
     m_rowContextMenu->addItem("Duplicate Unit", [this]() {
-        if (!m_manager.getUnit(m_unitId)) return;
-        if (m_onDuplicateUnit) m_onDuplicateUnit(m_unitId);
+        if (!m_manager.getUnit(m_unitId))
+            return;
+        if (m_onDuplicateUnit)
+            m_onDuplicateUnit(m_unitId);
     });
 
     m_rowContextMenu->addSeparator();
     m_rowContextMenu->addItem("Delete Unit", [this, pos]() {
-        if (!m_manager.getUnit(m_unitId)) return;
+        if (!m_manager.getUnit(m_unitId))
+            return;
         showDeleteConfirmation(pos);
     });
 
@@ -1333,8 +1464,10 @@ void UnitRow::showDeleteConfirmation(const NUIPoint& pos) {
     auto confirm = std::make_shared<NUIContextMenu>();
     confirm->addItem("Confirm Delete", [this]() {
         // Verify unit still exists (defensive check against use-after-free)
-        if (!m_manager.getUnit(m_unitId)) return;
-        if (m_onDeleteUnit) m_onDeleteUnit(m_unitId);
+        if (!m_manager.getUnit(m_unitId))
+            return;
+        if (m_onDeleteUnit)
+            m_onDeleteUnit(m_unitId);
     });
     confirm->addItem("Cancel", []() {});
     attachAndShowContextMenu(this, confirm, pos);

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -47,6 +47,8 @@ public:
      * @brief Refresh cached unit state from the backing managers.
      */
     void updateState();
+    /** @brief Route this unit to the first unused mixer insert, creating one when needed. */
+    void routeToFirstFreeMixerChannel();
 
     /** @brief Callback fired when row dragging begins. */
     std::function<void(Aestra::Audio::UnitID)> m_onDragStart;
@@ -170,11 +172,14 @@ private:
     std::string m_groupLabel;
     double m_audioDurationSeconds = 0.0;
     std::vector<float> m_audioPreviewWaveform;
-    int m_mixerChannel = -1;
+    uint32_t m_mixerChannelId = Aestra::Audio::MASTER_MIXER_CHANNEL_ID;
+    std::string m_mixerRouteShortLabel{"M"};
 
     // === Internal State ===
     void layoutNameLabel();
     void showRowContextMenu(const NUIPoint& pos);
+    void showMixerRoutingMenu(const NUIPoint& pos);
+    void routeToMixerChannel(uint32_t channelId);
     void showDeleteConfirmation(const NUIPoint& pos);
 
     // === Layout Constants (Premium v2) ===
@@ -259,6 +264,7 @@ private:
     // Internal components
     std::shared_ptr<UnitNameLabel> m_nameLabel;
     std::shared_ptr<NUIContextMenu> m_rowContextMenu;
+    std::shared_ptr<NUIContextMenu> m_mixerRoutingMenu;
 
     // Cache management
     bool m_needsCacheUpdate = true;

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -48,7 +48,7 @@ public:
      */
     void updateState();
     /** @brief Route this unit to the first unused mixer insert, creating one when needed. */
-    void routeToFirstFreeMixerChannel();
+    bool routeToFirstFreeMixerChannel();
 
     /** @brief Callback fired when row dragging begins. */
     std::function<void(Aestra::Audio::UnitID)> m_onDragStart;

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -55,6 +55,8 @@ set(Aestra_SOURCES
 	Panels/TakesPanel.cpp
 	Panels/SampleEditorPanel.h
 	Panels/SampleEditorPanel.cpp
+	Panels/AudioClipEditorPanel.h
+	Panels/AudioClipEditorPanel.cpp
 	
 	# Settings
 	Settings/ConfirmationDialog.h

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -114,25 +114,9 @@ void ChannelStrip::onRender(AestraUI::NUIRenderer& renderer) {
             baseColor = theme.getColor("primary"); // Purple
             isMaster = true;
         } else {
-            // Priority: Use Playlist Lane Color (Visual Source of Truth)
-            bool colorFound = false;
-            
-            // Try mapped lane
-            if (m_laneId.isValid() && m_trackManager) {
-                const auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId);
-                // Ensure alpha is fully opaque for the base color extraction
-                if (lane && lane->colorRGBA != 0) {
-                    baseColor = AestraUI::NUIColor::fromHex(lane->colorRGBA).withAlpha(1.0f);
-                    colorFound = true;
-                }
-            }
-            
-            // Fallback to internal track color
-            if (!colorFound) {
-                uint32_t c = m_track->getColor();
-                if (c != 0) {
-                    baseColor = AestraUI::NUIColor::fromHex(c).withAlpha(1.0f);
-                } 
+            uint32_t c = m_track->getColor();
+            if (c != 0) {
+                baseColor = AestraUI::NUIColor::fromHex(c).withAlpha(1.0f);
             }
         }
     }
@@ -305,24 +289,10 @@ void MixerView::refreshChannels() {
     
     // THREAD-SAFE: Get a snapshot of channels to avoid race with Audio Thread
     auto channelsSnapshot = m_trackManager->getChannelsSnapshot();
-    auto& playlist = m_trackManager->getPlaylistModel();
-    
-    // Create channel strip for each track
-    // Assume 1:1 mapping between Playlist Lanes and non-skipped Mixer Channels for now
-    // (excluding Master which is special case ID 0)
-    size_t laneIndex = 0;
-    
+    // Mixer inserts are independent from Playlist lanes.
     for (const auto& track : channelsSnapshot) {
         if (track && track->getName() != "Preview") {  // Skip preview track
             auto channelStrip = std::make_shared<ChannelStrip>(std::shared_ptr<MixerChannel>(track, [](MixerChannel*){}), m_trackManager.get());
-
-            // Map to playlist lane if it's a regular track
-            if (track->getChannelId() != 0) {
-                if (laneIndex < playlist.getLaneCount()) {
-                     channelStrip->setPlaylistLaneID(playlist.getLaneId(laneIndex));
-                     laneIndex++;
-                }
-            }
 
             channelStrip->setPlatformBridge(m_platformBridge);
             m_channelStrips.push_back(channelStrip);

--- a/Source/Components/MixerView.h
+++ b/Source/Components/MixerView.h
@@ -47,13 +47,7 @@ private:
     float m_peakLevel{0.0f};
     float m_peakDecay{0.0f};
     
-    // Visual mapping
-    PlaylistLaneID m_laneId; 
-    
     void layoutControls();
-    
-public:
-    void setPlaylistLaneID(PlaylistLaneID id) { m_laneId = id; }
 };
 
 /**

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -9,9 +9,7 @@
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "AudioFileValidator.h"
 #include "ClipSource.h"
-#include "Commands/AddChannelCommand.h"
 #include "Commands/AddClipCommand.h"
-#include "Commands/CommandTransaction.h"
 #include "Commands/CreateLaneCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -133,26 +131,16 @@ void TrackManagerUI::addTrack(const std::string& name) {
     if (!m_trackManager)
         return;
 
-    // Use CommandTransaction so add track is a single undoable step
-    auto transaction = std::make_shared<CommandTransaction>("Add Track");
-
-    // Add lane creation command
+    // Playlist lanes are created independently from mixer inserts.
     auto laneCmd = std::make_shared<CreateLaneCommand>(m_trackManager->getPlaylistModel(), name);
-    transaction->add(laneCmd);
-
-    // Add mixer channel creation command
-    auto channelCmd = std::make_shared<AddChannelCommand>(*m_trackManager, name);
-    transaction->add(channelCmd);
-
-    // Execute the transaction (creates lane + channel atomically)
-    m_trackManager->getCommandHistory().pushAndExecute(transaction);
+    m_trackManager->getCommandHistory().pushAndExecute(laneCmd);
 
     // Rebuild UI from model state
     refreshTracks();
     layoutTracks();
     scheduleTimelineMinimapRebuild();
     invalidateCache();
-    Log::info("Added track via command: " + name);
+    Log::info("Added Playlist lane via command: " + name);
 }
 
 void TrackManagerUI::refreshTracks() {
@@ -184,16 +172,9 @@ void TrackManagerUI::refreshTracks() {
             continue;
         }
 
-        // Find associated MixerChannel (we maintain a 1:1 mapping between lane index and channel index for now)
-        auto channel = m_trackManager->getTrack(i);
-        if (!channel) {
-            Log::warning("refreshTracks: channel " + std::to_string(i) + " is null!");
-            continue;
-        }
-
-        // Create UI component with LaneID and MixerChannel
-        auto trackUI = std::make_shared<TrackUIComponent>(
-            laneId, std::shared_ptr<MixerChannel>(channel, [](MixerChannel*) {}), m_trackManager.get());
+        // Playlist lanes are arrangement-only; mixer inserts are managed in
+        // the mixer and sources keep their own stable destinations.
+        auto trackUI = std::make_shared<TrackUIComponent>(laneId, nullptr, m_trackManager.get());
 
         // Register callbacks
         trackUI->setOnSoloToggled([this](TrackUIComponent* soloedTrack) { this->onTrackSoloToggled(soloedTrack); });
@@ -220,6 +201,11 @@ void TrackManagerUI::refreshTracks() {
         trackUI->setOnPatternClipOpenRequested([this](PatternID patternId) {
             if (m_onOpenPatternInPianoRoll) {
                 m_onOpenPatternInPianoRoll(patternId);
+            }
+        });
+        trackUI->setOnAudioClipOpenRequested([this](ClipInstanceID clipId) {
+            if (m_onOpenAudioClipEditor) {
+                m_onOpenAudioClipEditor(clipId);
             }
         });
         trackUI->setOnPatternClipDragStarted([this](PatternID patternId) {
@@ -274,11 +260,9 @@ void TrackManagerUI::onTrackSoloToggled(TrackUIComponent* soloedTrack) {
         if (trackUI.get() == soloedTrack)
             continue;
 
-        // Check if other track is soloed
-        auto channel = trackUI->getChannel();
-        if (channel && channel->isSoloed()) {
-            channel->setSolo(false); // Unsolo model
-            trackUI->updateUI();     // Update UI
+        if (auto* lane = m_trackManager->getPlaylistModel().getLane(trackUI->getLaneId()); lane && lane->solo) {
+            lane->solo = false;
+            trackUI->updateUI(); // Update UI
             trackUI->repaint();
         }
     }

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -131,6 +131,9 @@ public:
     void setOnToggleSequencer(std::function<void()> cb) { m_onToggleSequencer = cb; }
     void setOnTogglePlaylist(std::function<void()> cb) { m_onTogglePlaylist = cb; }
     void setOnOpenPatternInPianoRoll(std::function<void(PatternID)> cb) { m_onOpenPatternInPianoRoll = std::move(cb); }
+    void setOnOpenAudioClipEditor(std::function<void(ClipInstanceID)> cb) {
+        m_onOpenAudioClipEditor = std::move(cb);
+    }
     void setOnPreviewPatternClip(std::function<void(PatternID)> cb) { m_onPreviewPatternClip = std::move(cb); }
     void setOnStopPatternClipPreview(std::function<void()> cb) { m_onStopPatternClipPreview = std::move(cb); }
 
@@ -501,6 +504,7 @@ private:
     std::function<void()> m_onToggleSequencer;
     std::function<void()> m_onTogglePlaylist;
     std::function<void(PatternID)> m_onOpenPatternInPianoRoll;
+    std::function<void(ClipInstanceID)> m_onOpenAudioClipEditor;
     std::function<void(PatternID)> m_onPreviewPatternClip;
     std::function<void()> m_onStopPatternClipPreview;
     std::function<void(int)> m_onLoopPresetChanged;        // Called when loop preset dropdown changes

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -41,11 +41,12 @@ namespace Audio {
 AestraUI::DropFeedback TrackManagerUI::onDragEnter(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) {
     Log::info("[TrackManagerUI] Drag entered");
 
-    // Accept file drops, plugins, patterns, and MIDI clips. (Timeline clip
+    // Accept source content, patterns, and MIDI clips. Effects belong to the
+    // mixer and never imply a Playlist-lane/mixer-insert association. (Timeline clip
     // moves are an internal mouse drag, not a DragData transfer — see
     // m_draggedClipId.)
-    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::Plugin &&
-        data.type != AestraUI::DragDataType::MidiClip && data.type != AestraUI::DragDataType::Pattern) {
+    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::MidiClip &&
+        data.type != AestraUI::DragDataType::Pattern) {
         return AestraUI::DropFeedback::Invalid;
     }
 
@@ -175,22 +176,33 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     // Set target track index for logging
     result.targetTrackIndex = laneIndex;
 
+    // Reject unsupported payloads before appending a lane.
+    if (data.type == AestraUI::DragDataType::Plugin) {
+        result.accepted = false;
+        result.message = "Drop effects on a mixer insert";
+        clearDropPreview();
+        return result;
+    }
+    if (data.type == AestraUI::DragDataType::MidiClip) {
+        result.accepted = false;
+        result.message = "MIDI track creation not yet implemented";
+        clearDropPreview();
+        return result;
+    }
+    if (data.type == AestraUI::DragDataType::File && !AudioFileValidator::isValidAudioFile(data.filePath)) {
+        result.accepted = false;
+        result.message = "Unsupported file format";
+        clearDropPreview();
+        return result;
+    }
+
     // 2. Resolve target lane
     PlaylistLaneID targetLaneId;
     bool createdTargetLane = false;
-    uint32_t createdChannelId = 0;
     if (laneIndex == static_cast<int>(laneCount)) {
         // Create new lane if dropping at the end
         targetLaneId = playlist.createLane("Lane " + std::to_string(laneIndex + 1));
         createdTargetLane = targetLaneId.isValid();
-
-        // Ensure we also have a mixer channel (we maintain 1:1 mapping for now)
-        if (m_trackManager->getChannelCount() <= static_cast<size_t>(laneIndex)) {
-            if (auto* channel =
-                    m_trackManager->addChannel("Channel " + std::to_string(m_trackManager->getChannelCount() + 1))) {
-                createdChannelId = channel->getChannelId();
-            }
-        }
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
     } else {
@@ -214,31 +226,6 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             auto pattern = m_trackManager->getPatternManager().getPattern(pid);
             if (pattern) {
                 double duration = pattern->lengthBeats;
-                auto& unitManager = m_trackManager->getUnitManager();
-                if (pattern->isMidi()) {
-                    const auto& midi = std::get<MidiPayload>(pattern->payload);
-                    std::unordered_set<UnitID> routedUnits;
-                    for (const auto& note : midi.notes) {
-                        if (note.unitId == 0 || routedUnits.find(note.unitId) != routedUnits.end()) {
-                            continue;
-                        }
-                        if (auto* unit = unitManager.getUnit(note.unitId)) {
-                            unitManager.assignUnitToTimelineLane(note.unitId, laneIndex);
-                            Log::info("[TrackManagerUI] Routed note unit " + std::to_string(note.unitId) +
-                                      " to timeline lane " + std::to_string(laneIndex));
-                            routedUnits.insert(note.unitId);
-                        }
-                    }
-                } else {
-                    for (const auto unitId : unitManager.getAllUnitIDs()) {
-                        if (auto* unit = unitManager.getUnit(unitId); unit && unit->defaultPatternId == pid) {
-                            unitManager.assignUnitToTimelineLane(unitId, laneIndex);
-                            Log::info("[TrackManagerUI] Routed owner unit " + std::to_string(unitId) +
-                                      " to timeline lane " + std::to_string(laneIndex));
-                            break;
-                        }
-                    }
-                }
                 // Create clip instance manually and use command for undo support
                 ClipInstance clip;
                 clip.id = ClipInstanceID::generate();
@@ -250,6 +237,16 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
                 m_trackManager->getCommandHistory().pushAndExecute(cmd);
 
+                if (!playlist.getClip(clip.id)) {
+                    if (createdTargetLane) {
+                        playlist.removeLane(targetLaneId);
+                    }
+                    result.accepted = false;
+                    result.message = "Could not place pattern";
+                    clearDropPreview();
+                    return result;
+                }
+
                 result.accepted = true;
                 result.message = "Pattern added: " + pattern->name;
                 Log::info("[TrackManagerUI] Pattern added to timeline: " + pattern->name);
@@ -258,10 +255,16 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 invalidateCache();
                 scheduleTimelineMinimapRebuild();
             } else {
+                if (createdTargetLane) {
+                    playlist.removeLane(targetLaneId);
+                }
                 result.accepted = false;
                 result.message = "Pattern not found";
             }
         } else {
+            if (createdTargetLane) {
+                playlist.removeLane(targetLaneId);
+            }
             result.accepted = false;
             result.message = "Invalid pattern ID";
         }
@@ -272,14 +275,6 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     // 4. Handle File Drop (New Audio Content)
     if (data.type == AestraUI::DragDataType::File) {
         Log::info("[TrackManagerUI] File drop received: " + data.filePath);
-
-        if (!AudioFileValidator::isValidAudioFile(data.filePath)) {
-            result.accepted = false;
-            result.message = "Unsupported file format";
-            Log::warning("[TrackManagerUI] File rejected (validator): " + data.filePath);
-            clearDropPreview();
-            return result;
-        }
 
         // Register file with SourceManager
         auto& sourceManager = m_trackManager->getSourceManager();
@@ -292,7 +287,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             // Helper to create clip once source is ready. Async decode and queued tasks capture only weakSelf so
             // they cannot call back into a destroyed TrackManagerUI.
             auto createClipFromSource = [weakSelf, sourceId, displayName = data.displayName, targetLaneId,
-                                         createdTargetLane, createdChannelId, timePositionBeats]() {
+                                         createdTargetLane, timePositionBeats]() {
                 auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                 if (!self || !self->m_trackManager)
                     return;
@@ -315,12 +310,9 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->m_onClipLibraryChanged();
                 }
 
-                auto rollbackCreatedTrack = [&]() {
+                auto rollbackCreatedLane = [&]() {
                     if (!createdTargetLane) {
                         return;
-                    }
-                    if (createdChannelId != 0) {
-                        self->m_trackManager->removeChannelById(createdChannelId);
                     }
                     self->m_trackManager->getPlaylistModel().removeLane(targetLaneId);
                     self->refreshTracks();
@@ -329,7 +321,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 };
 
                 if (!source || !source->isReady()) {
-                    rollbackCreatedTrack();
+                    rollbackCreatedLane();
                     return;
                 }
 
@@ -337,7 +329,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 double durationBeats = self->secondsToBeats(durationSeconds);
                 if (!std::isfinite(durationSeconds) || durationSeconds <= 0.0 ||
                     !std::isfinite(durationBeats) || durationBeats <= 0.0) {
-                    rollbackCreatedTrack();
+                    rollbackCreatedLane();
                     Log::error("[TrackManagerUI] Invalid decoded duration for imported source");
                     return;
                 }
@@ -375,7 +367,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->m_trackManager->getCommandHistory().pushAndExecute(cmd);
                     if (!playlist.getClip(clip.id)) {
                         patternManager.removePattern(patternId);
-                        rollbackCreatedTrack();
+                        rollbackCreatedLane();
                         Log::error("[TrackManagerUI] Failed to add imported clip to target lane; removed orphan audio pattern");
                         return;
                     }
@@ -385,7 +377,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     self->scheduleTimelineMinimapRebuild();
                     Log::info("[TrackManagerUI] Clip added successfully via command");
                 } else {
-                    rollbackCreatedTrack();
+                    rollbackCreatedLane();
                     Log::error("[TrackManagerUI] PatternManager::createAudioPattern failed");
                 }
             };
@@ -532,106 +524,11 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 result.message = "Imported: " + data.displayName;
             }
         } else {
+            if (createdTargetLane) {
+                playlist.removeLane(targetLaneId);
+            }
             result.accepted = false;
             result.message = "Failed to create source";
-        }
-
-        clearDropPreview();
-        return result;
-    }
-
-    // 5b. Handle MIDI Clip Drop (stub — full MIDI track creation is a future spec)
-    if (data.type == AestraUI::DragDataType::MidiClip) {
-        Log::info("[TrackManagerUI] MIDI drag received: " + data.filePath + " — MIDI track creation not yet implemented");
-        result.accepted = false;
-        result.message = "MIDI track creation not yet implemented";
-        clearDropPreview();
-        return result;
-    }
-
-    // 5. Handle Plugin Drop
-    if (data.type == AestraUI::DragDataType::Plugin) {
-        Log::info("[TrackManagerUI] Plugin drop received: " + data.displayName);
-
-        std::string pluginId = data.sourceClipIdString;
-        if (!pluginId.empty()) {
-            auto& pluginManager = Aestra::Audio::PluginManager::getInstance();
-
-            // Validate target channel exists
-            int channelIndex = laneIndex;
-            auto channel = m_trackManager->getTrack(channelIndex);
-
-            if (!channel) {
-                result.accepted = false;
-                result.message = "Target channel not found";
-                clearDropPreview();
-                return result;
-            }
-
-            // Check if chain has space (pre-check)
-            auto& chain = channel->getEffectChain();
-            if (chain.getFirstEmptySlot() >= Aestra::Audio::EffectChain::MAX_SLOTS) {
-                result.accepted = false;
-                result.message = "Effect chain full";
-                clearDropPreview();
-                return result;
-            }
-
-            // Request Plugin Creation (Async)
-            // Captured variables must be kept alive. m_trackManager is a shared_ptr.
-            // NOTE: The callback runs on a worker thread (PluginManager's factory thread),
-            // not the main/UI thread. We dispatch the actual plugin insertion to the main
-            // thread via m_pendingTasks to ensure proper sequencing with graph rebuild.
-            // This is documented in the plugin/effect-chain lifetime audit
-            // (labs/memory/plugin_effect_lifetime_audit.md).
-            std::string displayName = data.displayName;
-            auto trackManager = m_trackManager;
-
-            pluginManager.createInstanceByIdAsync(pluginId, [this, trackManager, channelIndex, displayName,
-                                                             pluginId](Aestra::Audio::PluginInstancePtr instance) {
-                if (!instance) {
-                    Log::error("[TrackManagerUI] Plugin creation failed for ID: " + pluginId);
-                    return;
-                }
-
-                std::lock_guard<std::mutex> lock(m_pendingTasksMutex);
-                m_pendingTasks.push_back([trackManager, channelIndex, displayName, pluginId, instance]() {
-                    auto channel = trackManager->getTrack(channelIndex);
-                    if (!channel)
-                        return;
-
-                    auto& pluginManager = Aestra::Audio::PluginManager::getInstance();
-                    if (instance->initialize(pluginManager.getDefaultSampleRate(),
-                                             pluginManager.getDefaultBlockSize())) {
-                        instance->activate();
-
-                        auto& chain = channel->getEffectChain();
-                        chain.prepare(pluginManager.getDefaultSampleRate(), pluginManager.getDefaultBlockSize());
-                        size_t slot = chain.getFirstEmptySlot();
-
-                        if (slot < Aestra::Audio::EffectChain::MAX_SLOTS) {
-                            chain.insertPlugin(slot, instance);
-                            Log::info("[TrackManagerUI] Added plugin (Async): " + displayName);
-                        } else {
-                            Log::warning("[TrackManagerUI] Effect chain became full during async load");
-                        }
-                    } else {
-                        Log::error("[TrackManagerUI] Plugin initialization failed for ID: " + pluginId);
-                    }
-
-                    // Request the same non-RT graph rebuild path used by timeline edits.
-                    trackManager->requestAudioGraphRebuild(
-                        Aestra::Audio::TrackManager::GraphDirtyReason::EffectChainChanged);
-                });
-            });
-
-            // Return immediate acceptance
-            result.accepted = true;
-            result.message = "Loading " + data.displayName + "...";
-
-        } else {
-            result.accepted = false;
-            result.message = "Invalid plugin ID";
         }
 
         clearDropPreview();

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -52,6 +52,14 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
     if (!isVisible())
         return;
 
+    const bool anyPlaylistLaneSoloed =
+        m_trackManager && m_trackManager->getPlaylistModel().hasAudibleSoloLane();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setAnyPlaylistLaneSoloed(anyPlaylistLaneSoloed);
+        }
+    }
+
     AestraUI::NUIRect bounds = getBounds();
 
     // Normal rendering with FBO CACHING for massive FPS boost! 🚀

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1317,20 +1317,8 @@ void TrackUIComponent::renderDynamic(AestraUI::NUIRenderer& renderer) {
 
     // Apply overlay for muted/solo state (Grid Area Only)
     if (m_isPrimaryForLane) {
-        bool anySoloed = false;
-        if (m_trackManager) {
-            auto& playlist = m_trackManager->getPlaylistModel();
-            for (size_t i = 0; i < playlist.getLaneCount(); ++i) {
-                const auto* candidate = playlist.getLane(playlist.getLaneId(i));
-                if (candidate && candidate->solo && !candidate->muted) {
-                    anySoloed = true;
-                    break;
-                }
-            }
-        }
-
         const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
-        const bool soloSuppressed = anySoloed && lane && !lane->solo;
+        const bool soloSuppressed = m_anyPlaylistLaneSoloed && lane && !lane->solo;
 
         AestraUI::NUIRect gridArea(
             bounds.x + controlAreaWidth,
@@ -1454,19 +1442,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 
     // Apply highlight overlay (Selection / Solo / Mute)
     if (lane) {
-        bool anySoloed = false;
-        if (m_trackManager) {
-            auto& playlist = m_trackManager->getPlaylistModel();
-            for (size_t i = 0; i < playlist.getLaneCount(); ++i) {
-                const auto* candidate = playlist.getLane(playlist.getLaneId(i));
-                if (candidate && candidate->solo && !candidate->muted) {
-                    anySoloed = true;
-                    break;
-                }
-            }
-        }
-
-        const bool soloSuppressed = anySoloed && !lane->solo;
+        const bool soloSuppressed = m_anyPlaylistLaneSoloed && !lane->solo;
 
         if (lane->solo) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("accentCyan").withAlpha(0.10f));
@@ -2641,6 +2617,7 @@ void TrackUIComponent::renderAutomationLayer(AestraUI::NUIRenderer& renderer, co
 
 
 void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds, float controlAreaWidth) {
+    if (!m_trackManager || !m_channel) return;
     if (!m_trackManager->isRecording()) return;
     if (!m_channel->isArmed()) return;
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -145,11 +145,6 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     , m_trackManager(trackManager)
 {
     // Log::info("TrackUIComponent ctor: " + m_laneId.toString());
-    if (!m_channel) {
-        Log::error("TrackUIComponent created with null channel");
-        return;
-    }
-
     // Create track name label
     m_nameLabel = std::make_shared<AestraUI::NUILabel>();
     
@@ -159,7 +154,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
             name = lane->name;
         }
     }
-    m_nameLabel->setText(name.empty() ? m_channel->getName() : name);
+    m_nameLabel->setText(name.empty() ? "Lane" : name);
 
     {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
@@ -203,13 +198,16 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     m_soloButton->setTooltip("Solo Track (S)");
     addChild(m_soloButton);
 
-    // Create record button
-    m_recordButton = std::make_shared<AestraUI::NUIButton>();
-    m_recordButton->setText("");
-    configureFlatTrackButton(m_recordButton);
-    m_recordButton->setToggleable(true);
-    m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
-    addChild(m_recordButton);
+    // Recording is armed from mixer inserts. A Playlist lane only receives a
+    // record control when an explicit mixer association is supplied.
+    if (m_channel) {
+        m_recordButton = std::make_shared<AestraUI::NUIButton>();
+        m_recordButton->setText("");
+        configureFlatTrackButton(m_recordButton);
+        m_recordButton->setToggleable(true);
+        m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
+        addChild(m_recordButton);
+    }
 
     updateUI();
 }
@@ -222,7 +220,52 @@ TrackUIComponent::~TrackUIComponent() {
         m_platformBridge->cancelCursorCapture();
     }
     detachContextMenu(m_recordModeMenu);
+    detachContextMenu(m_clipRoutingMenu);
     Log::debug("TrackUIComponent destroyed for lane: " + m_laneId.toString());
+}
+
+void TrackUIComponent::showClipRoutingMenu(const ClipInstanceID& clipId, const AestraUI::NUIPoint& position) {
+    detachContextMenu(m_clipRoutingMenu);
+    if (!m_trackManager) {
+        return;
+    }
+
+    const auto* clip = m_trackManager->getPlaylistModel().getClip(clipId);
+    auto* pattern = clip ? m_trackManager->getPatternManager().getPattern(clip->patternId) : nullptr;
+    m_clipRoutingMenu = std::make_shared<AestraUI::NUIContextMenu>();
+    m_clipRoutingMenu->setOnHide([this]() { detachContextMenu(m_clipRoutingMenu); });
+
+    if (pattern && pattern->isAudio()) {
+        const uint32_t selectedId = pattern->getMixerChannelId();
+        const auto addDestination = [this, patternId = pattern->id, selectedId](uint32_t channelId,
+                                                                                const std::string& label) {
+            m_clipRoutingMenu->addItem((selectedId == channelId ? "✓ " : "  ") + label, [this, patternId, channelId]() {
+                if (m_trackManager->setAudioPatternMixerChannel(patternId, channelId)) {
+                    repaint();
+                    if (m_onCacheInvalidationCallback) {
+                        m_onCacheInvalidationCallback();
+                    }
+                }
+            });
+        };
+
+        m_clipRoutingMenu->addItem("Source routing (all linked clips)", []() {});
+        m_clipRoutingMenu->addSeparator();
+        addDestination(0, "Master");
+        for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
+            if (const auto* channel = m_trackManager->getChannel(i)) {
+                addDestination(channel->getChannelId(), std::to_string(i + 1) + "  " + channel->getName());
+            }
+        }
+        m_clipRoutingMenu->addSeparator();
+    }
+
+    m_clipRoutingMenu->addItem("Delete clip", [this, clipId, position]() {
+        if (m_onClipDeletedCallback) {
+            m_onClipDeletedCallback(this, clipId, position);
+        }
+    });
+    attachAndShowContextMenu(this, m_clipRoutingMenu, position);
 }
 
 double TrackUIComponent::getSnapGridSizeBeats() const {
@@ -258,17 +301,16 @@ void TrackUIComponent::onPanChanged(float pan) {
 
 
 void TrackUIComponent::onMuteToggled() {
-    if (m_channel && m_trackManager) {
+    if (m_trackManager) {
         bool isMuted = m_muteButton->isToggled();
-        m_trackManager->getCommandHistory().pushAndExecute(
-            std::make_shared<SetMuteCommand>(*m_channel, isMuted));
-
-        // Mutual Exclusivity: If Muting, turn off Solo
-        if (isMuted && m_channel->isSoloed()) {
-             Log::info("Mutual Exclusivity: Turning OFF Solo because Mute activated.");
-             m_trackManager->getCommandHistory().pushAndExecute(
-                 std::make_shared<SetSoloCommand>(*m_channel, false));
-             if (m_soloButton) m_soloButton->setToggled(false);
+        if (auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
+            lane->muted = isMuted;
+            if (isMuted) {
+                lane->solo = false;
+                if (m_soloButton) m_soloButton->setToggled(false);
+            }
+            m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+            m_trackManager->markModified();
         }
 
         Log::info("Lane " + m_laneId.toString() + " muted: " + (isMuted ? "ON" : "OFF"));
@@ -280,17 +322,16 @@ void TrackUIComponent::onMuteToggled() {
 
 
 void TrackUIComponent::onSoloToggled() {
-    if (m_channel && m_trackManager) {
+    if (m_trackManager) {
         bool newSolo = m_soloButton->isToggled(); // Use button state
-        m_trackManager->getCommandHistory().pushAndExecute(
-            std::make_shared<SetSoloCommand>(*m_channel, newSolo));
-
-        // Mutual Exclusivity: If Soloing, turn off Mute
-        if (newSolo && m_channel->isMuted()) {
-            Log::info("Mutual Exclusivity: Turning OFF Mute because Solo activated.");
-            m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<SetMuteCommand>(*m_channel, false));
-            if (m_muteButton) m_muteButton->setToggled(false);
+        if (auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
+            lane->solo = newSolo;
+            if (newSolo) {
+                lane->muted = false;
+                if (m_muteButton) m_muteButton->setToggled(false);
+            }
+            m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+            m_trackManager->markModified();
         }
 
         if (newSolo && m_onSoloToggledCallback) {
@@ -359,8 +400,6 @@ void TrackUIComponent::updateRecordTooltip() {
 
 
 void TrackUIComponent::updateUI() {
-    if (!m_channel) return;
-
     // Invalidate parent cache since button colors are changing
     if (m_onCacheInvalidationCallback) {
         m_onCacheInvalidationCallback();
@@ -387,9 +426,10 @@ void TrackUIComponent::updateUI() {
         if (active) button->setBorderColor(statusColor.withAlpha(0.48f));
     };
 
-    configureStatusButton(m_muteButton, m_channel->isMuted(), themeManager.getColor("muted"));
-    configureStatusButton(m_soloButton, m_channel->isSoloed(), themeManager.getColor("soloed"));
-    configureStatusButton(m_recordButton, m_channel->isArmed(), themeManager.getColor("armed"));
+    const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+    configureStatusButton(m_muteButton, lane && lane->muted, themeManager.getColor("muted"));
+    configureStatusButton(m_soloButton, lane && lane->solo, themeManager.getColor("soloed"));
+    configureStatusButton(m_recordButton, m_channel && m_channel->isArmed(), themeManager.getColor("armed"));
 
     if (m_recordButton) {
         updateRecordTooltip();
@@ -404,22 +444,16 @@ void TrackUIComponent::updateUI() {
         m_volumeFader->setFillColor(themeManager.getColor("accentPrimary").withAlpha(0.72f));
         m_volumeFader->setThumbColor(themeManager.getColor("textPrimary").withAlpha(0.92f));
         m_volumeFader->setThumbHoverColor(themeManager.getColor("textPrimary"));
-        m_volumeFader->setValue(m_channel->getVolume());
+        m_volumeFader->setValue(m_channel ? m_channel->getVolume() : 1.0f);
     }
 }
 
 
 void TrackUIComponent::updateTrackNameColors() {
-    if (!m_nameLabel || !m_channel) return;
-
-    int colorIndex = m_channel->getTrackColorIndex();
-    if (colorIndex < 0 || colorIndex >= AestraUI::PALETTE_SIZE) {
-        // trackId is unsigned; guard id 0 or the subtraction wraps to UINT32_MAX.
-        uint32_t trackId = m_channel->getChannelId();
-        colorIndex = static_cast<int>((trackId > 0 ? trackId - 1 : 0) % AestraUI::PALETTE_SIZE);
+    if (!m_nameLabel || !m_trackManager) return;
+    if (const auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
+        m_nameLabel->setTextColor(AestraUI::NUIColor::fromARGB(lane->colorRGBA).withAlpha(0.82f));
     }
-    m_nameLabel->setTextColor(
-        AestraUI::NUIColor::fromARGB(AestraUI::paletteIndexToARGB(colorIndex)).withAlpha(0.82f));
 }
 
 void TrackUIComponent::generateWaveformCache(int, int) {
@@ -766,12 +800,13 @@ AestraUI::NUIColor TrackUIComponent::resolveClipDisplayColor(const ClipInstance&
     auto pattern = m_trackManager->getPatternManager().getPattern(clip.patternId);
     if (!pattern) return clipColor;
 
-    // Same TRACK_PALETTE lookup as updateTrackNameColors, so clips, track
-    // names, and mixer strips all share one curated color per track
-    if (m_channel) {
-        int colorIndex = m_channel->getTrackColorIndex();
+    // Audio-source color follows its mixer destination without coupling the
+    // Playlist lane itself to that insert.
+    auto routeChannel = pattern->isAudio() ? m_trackManager->getChannelById(pattern->getMixerChannelId()) : nullptr;
+    if (routeChannel) {
+        int colorIndex = routeChannel->getTrackColorIndex();
         if (colorIndex < 0 || colorIndex >= AestraUI::PALETTE_SIZE) {
-            uint32_t trackId = m_channel->getChannelId();
+            uint32_t trackId = routeChannel->getChannelId();
             colorIndex = static_cast<int>((trackId - 1) % AestraUI::PALETTE_SIZE);
         }
         clipColor = AestraUI::NUIColor::fromARGB(AestraUI::paletteIndexToARGB(colorIndex));
@@ -1201,13 +1236,13 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
         // direction — surfaceTertiary read bluish-grey), clean surface on light.
         AestraUI::NUIColor baseControlColor = themeManager.getColor("trackChrome");
 
-        // Static Control Area State
-        if (m_channel) {
+        // Static Playlist-lane state is independent from mixer insert state.
+        if (lane) {
             if (m_selected) {
                  baseControlColor = themeManager.getColor("primary").withAlpha(0.022f);
-             } else if (m_channel->isSoloed()) {
+            } else if (lane->solo) {
                  baseControlColor = themeManager.getColor("accentCyan").withAlpha(0.10f);
-             } else if (m_channel->isMuted()) {
+            } else if (lane->muted) {
                  baseControlColor = themeManager.getColor("backgroundSecondary");
              } else if (isHovered()) {
                  baseControlColor = themeManager.getColor("surfaceRaised").withAlpha(0.70f);
@@ -1243,7 +1278,7 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
             AestraUI::NUIColor stripColor(r, g, b, a > 0.0f ? a : 1.0f);
             
             const float stripWidth = 3.0f;
-            const float stripAlpha = (m_selected || (m_channel && (m_channel->isArmed() || m_channel->isSoloed()))) ? 0.86f : 0.52f;
+            const float stripAlpha = (m_selected || lane->solo) ? 0.86f : 0.52f;
             const auto stripBright = restrainDawColor(stripColor, 0.84f, 0.62f, stripAlpha);
             renderer.fillRect(AestraUI::NUIRect(bounds.x, bounds.y, stripWidth, bounds.height), stripBright);
         }
@@ -1284,17 +1319,18 @@ void TrackUIComponent::renderDynamic(AestraUI::NUIRenderer& renderer) {
     if (m_isPrimaryForLane) {
         bool anySoloed = false;
         if (m_trackManager) {
-            // Optimization: TrackManager should pass this state down? 
-            // For now, iterating 50 tracks is cheap.
-            for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
-                if (m_trackManager->getChannel(i)->isSoloed()) {
+            auto& playlist = m_trackManager->getPlaylistModel();
+            for (size_t i = 0; i < playlist.getLaneCount(); ++i) {
+                const auto* candidate = playlist.getLane(playlist.getLaneId(i));
+                if (candidate && candidate->solo && !candidate->muted) {
                     anySoloed = true;
                     break;
                 }
             }
         }
 
-        const bool soloSuppressed = anySoloed && m_channel && !m_channel->isSoloed();
+        const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+        const bool soloSuppressed = anySoloed && lane && !lane->solo;
 
         AestraUI::NUIRect gridArea(
             bounds.x + controlAreaWidth,
@@ -1303,13 +1339,13 @@ void TrackUIComponent::renderDynamic(AestraUI::NUIRenderer& renderer) {
             bounds.height
         );
         
-        if (m_channel && m_channel->isSoloed()) {
+        if (lane && lane->solo) {
             renderer.fillRect(gridArea, themeManager.getColor("accentCyan").withAlpha(0.06f));
         }
 
         float dimAlpha = 0.0f;
         if (soloSuppressed) dimAlpha = std::max(dimAlpha, 0.28f);
-        if (m_channel && m_channel->isMuted()) dimAlpha = std::max(dimAlpha, 0.40f);
+        if (lane && lane->muted) dimAlpha = std::max(dimAlpha, 0.40f);
 
         if (dimAlpha > 0.0f) {
             renderer.fillRect(gridArea, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, dimAlpha));
@@ -1414,26 +1450,27 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                          fontSize, cyan.withAlpha(0.8f));
     }
 
+    const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+
     // Apply highlight overlay (Selection / Solo / Mute)
-    if (m_channel) {
+    if (lane) {
         bool anySoloed = false;
         if (m_trackManager) {
-            const size_t channelCount = m_trackManager->getChannelCount();
-            for (size_t i = 0; i < channelCount; ++i) {
-                if (auto ch = m_trackManager->getChannel(i)) {
-                    if (ch->isSoloed()) {
-                        anySoloed = true;
-                        break;
-                    }
+            auto& playlist = m_trackManager->getPlaylistModel();
+            for (size_t i = 0; i < playlist.getLaneCount(); ++i) {
+                const auto* candidate = playlist.getLane(playlist.getLaneId(i));
+                if (candidate && candidate->solo && !candidate->muted) {
+                    anySoloed = true;
+                    break;
                 }
             }
         }
 
-        const bool soloSuppressed = anySoloed && !m_channel->isSoloed();
+        const bool soloSuppressed = anySoloed && !lane->solo;
 
-        if (m_channel->isSoloed()) {
+        if (lane->solo) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("accentCyan").withAlpha(0.10f));
-        } else if (m_channel->isMuted()) {
+        } else if (lane->muted) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("backgroundSecondary").withAlpha(0.62f));
         } else if (soloSuppressed) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("backgroundSecondary").withAlpha(0.44f));
@@ -1448,7 +1485,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
     }
 
     // Track color strip (identity)
-    if (m_channel) {
+    if (lane) {
         AestraUI::NUIColor stripColor;
         
         if (m_isLoading) {
@@ -1457,12 +1494,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             float pulse = (std::sin(static_cast<float>(Aestra::Platform::getUtils()->getTime()) * 8.0f) * 0.5f + 0.5f);
             stripColor = stripColor.withAlpha(0.6f + pulse * 0.4f);
         } else {
-            int colorIndex = m_channel->getTrackColorIndex();
-            if (colorIndex < 0 || colorIndex >= AestraUI::PALETTE_SIZE) {
-                uint32_t trackId = m_channel->getChannelId();
-                colorIndex = static_cast<int>((trackId - 1) % AestraUI::PALETTE_SIZE);
-            }
-            uint32_t argb = AestraUI::paletteIndexToARGB(colorIndex);
+            uint32_t argb = lane->colorRGBA;
             float a = ((argb >> 24) & 0xFF) / 255.0f;
             float r = ((argb >> 16) & 0xFF) / 255.0f;
             float g = ((argb >> 8) & 0xFF) / 255.0f;
@@ -1471,7 +1503,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         }
         
         const float stripWidth = 3.0f;
-        const float stripAlpha = (m_selected || m_channel->isArmed() || m_channel->isSoloed()) ? 0.90f : 0.64f;
+        const float stripAlpha = (m_selected || lane->solo) ? 0.90f : 0.64f;
         stripColor = restrainDawColor(stripColor, 0.86f, 0.62f, stripAlpha);
         
         // Draw strip
@@ -1524,7 +1556,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         m_nameLabel->onRender(renderer);
     }
 
-    if (m_channel) {
+    if (lane) {
         const auto textIdle = themeManager.getColor("textPrimary").withAlpha(isHovered() ? 0.74f : 0.60f);
         const auto muteActive = themeManager.getColor("warning").withAlpha(0.92f);
         const auto soloActive = themeManager.getColor("success").withAlpha(0.92f);
@@ -1573,8 +1605,9 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             AestraUI::NUISVGRenderer::render(renderer, *doc, iconRect, color);
         };
 
-        // Draw volume knob (replaces route button)
-        {
+        // A Playlist lane has no gain stage of its own. Only draw the knob
+        // when an explicit mixer association was supplied by another view.
+        if (m_channel) {
             const auto& knobBounds = m_volumeKnobBounds;
             if (!knobBounds.isEmpty()) {
                 const float cx = knobBounds.x + knobBounds.width * 0.5f;
@@ -1620,20 +1653,20 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             }
         }
 
-        drawControlIcon(m_muteButton, kMuteIconSvg, m_channel->isMuted() ? muteActive : textIdle,
-                        m_channel->isMuted(), muteActive);
-        drawControlIcon(m_soloButton, kSoloIconSvg, m_channel->isSoloed() ? soloActive : textIdle,
-                        m_channel->isSoloed(), soloActive);
-        drawControlIcon(m_recordButton, m_channel->isMonitoringEnabled() ? kMonitorIconSvg : kRecordIconSvg,
-                        m_channel->isArmed() ? recordActive : textIdle,
-                        m_channel->isArmed(), recordActive);
+        drawControlIcon(m_muteButton, kMuteIconSvg, lane->muted ? muteActive : textIdle, lane->muted, muteActive);
+        drawControlIcon(m_soloButton, kSoloIconSvg, lane->solo ? soloActive : textIdle, lane->solo, soloActive);
+        if (m_channel) {
+            drawControlIcon(m_recordButton, m_channel->isMonitoringEnabled() ? kMonitorIconSvg : kRecordIconSvg,
+                            m_channel->isArmed() ? recordActive : textIdle,
+                            m_channel->isArmed(), recordActive);
+        }
     }
 
     // Track number marker (left of name): fixed white — no dynamic dimming
     // (professional, defined feel per owner direction).
-    if (m_nameLabel && m_channel) {
+    if (m_nameLabel && lane) {
         constexpr float stripWidth = 3.0f;
-        uint32_t trackNumber = m_channel->getChannelId();
+        uint32_t trackNumber = static_cast<uint32_t>(lane->index + 1);
         const auto laneName = m_nameLabel->getText();
         uint32_t parsedNumber = 0;
         if (parseTrailingTrackNumber(laneName, parsedNumber)) {
@@ -1689,9 +1722,9 @@ void TrackUIComponent::onUpdate(double deltaTime) {
     // This prevents overriding hover colors unnecessarily
 
     // Update children state
-    if (m_channel) {
-        bool currentMuted = m_channel->isMuted();
-        bool currentSoloed = m_channel->isSoloed();
+    if (const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr) {
+        bool currentMuted = lane->muted;
+        bool currentSoloed = lane->solo;
 
         // Check if buttons match channel state
         if (m_muteButton && m_muteButton->isToggled() != currentMuted) {
@@ -1718,7 +1751,7 @@ void TrackUIComponent::onResize(int width, int height) {
     const float buttonW = 16.0f;
     const float buttonH = 18.0f;
     const float spacing = 6.0f;
-    const int numButtons = 4; // M, S, R, Volume knob
+    const int numButtons = m_channel ? 4 : 2; // Playlist lanes only own M/S.
     const float buttonsTotalW = numButtons * buttonW + (numButtons - 1) * spacing;
 
     const float leftPad = 14.0f;
@@ -1759,8 +1792,10 @@ void TrackUIComponent::onResize(int width, int height) {
         m_recordButton->setBounds(AestraUI::NUIRect(bounds.x + xCursor, bounds.y + localButtonsY, buttonW, buttonH));
         xCursor += buttonW + spacing;
     }
-    // Volume knob in the slot where route button was
-    m_volumeKnobBounds = AestraUI::NUIRect(bounds.x + xCursor, bounds.y + localButtonsY, buttonW + 2.0f, buttonH);
+    // Volume belongs to the mixer, never to a normal Playlist lane.
+    m_volumeKnobBounds = m_channel
+                             ? AestraUI::NUIRect(bounds.x + xCursor, bounds.y + localButtonsY, buttonW + 2.0f, buttonH)
+                             : AestraUI::NUIRect();
 
     AestraUI::NUIComponent::onResize(width, height);
 }
@@ -2339,6 +2374,10 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                                     m_onPatternClipOpenRequested(clip.patternId);
                                     return true;
                                 }
+                                if (pattern && pattern->isAudio() && m_onAudioClipOpenRequested) {
+                                    m_onAudioClipOpenRequested(clip.id);
+                                    return true;
+                                }
                                 break;
                             }
                         }
@@ -2485,10 +2524,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_onClipSelectedCallback(this, clickedClipId);
             }
 
-            if (m_onClipDeletedCallback) {
-                m_onClipDeletedCallback(this, clickedClipId, event.position);
-            }
-
+            showClipRoutingMenu(clickedClipId, event.position);
             return true;
         }
     }

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -80,6 +80,9 @@ public:
     // Callback for clip selection
     void setOnClipSelected(std::function<void(TrackUIComponent*, ClipInstanceID)> callback) { m_onClipSelectedCallback = callback; }
     void setOnPatternClipOpenRequested(std::function<void(PatternID)> callback) { m_onPatternClipOpenRequested = std::move(callback); }
+    void setOnAudioClipOpenRequested(std::function<void(ClipInstanceID)> callback) {
+        m_onAudioClipOpenRequested = std::move(callback);
+    }
     void setOnPatternClipDragStarted(std::function<void(PatternID)> callback) { m_onPatternClipDragStarted = std::move(callback); }
 
     // Callback for track selection
@@ -170,6 +173,7 @@ private:
     std::function<void(TrackUIComponent*, double)> m_onSplitRequestedCallback;
     std::function<void(TrackUIComponent*, ClipInstanceID)> m_onClipSelectedCallback;
     std::function<void(PatternID)> m_onPatternClipOpenRequested;
+    std::function<void(ClipInstanceID)> m_onAudioClipOpenRequested;
     std::function<void(PatternID)> m_onPatternClipDragStarted;
     std::function<void(TrackUIComponent*, bool)> m_onTrackSelectedCallback;
     std::function<void()> m_onSendToAuditionCallback;
@@ -242,6 +246,7 @@ private:
     std::shared_ptr<AestraUI::NUIButton> m_soloButton;
     std::shared_ptr<AestraUI::NUIButton> m_recordButton;
     std::shared_ptr<AestraUI::NUIContextMenu> m_recordModeMenu;
+    std::shared_ptr<AestraUI::NUIContextMenu> m_clipRoutingMenu;
 
     // Volume Knob (replaces route button)
     float m_volumeKnobValue = 1.0f;
@@ -319,6 +324,7 @@ private:
     // Playlist grid rendering
     void drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds);
     
+    void showClipRoutingMenu(const ClipInstanceID& clipId, const AestraUI::NUIPoint& position);
     // Helper to draw a single clip (waveform + container) at calculated position
     void drawClipAtPosition(AestraUI::NUIRenderer& renderer, const ClipInstance& clip,
                            const AestraUI::NUIRect& bounds, float controlAreaWidth);

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -98,6 +98,8 @@ public:
     // Selection state
     void setSelected(bool selected) { m_selected = selected; }
     bool isSelected() const { return m_selected; }
+    /** @brief Supply the parent-computed Playlist solo aggregate for this render pass. */
+    void setAnyPlaylistLaneSoloed(bool anySoloed) { m_anyPlaylistLaneSoloed = anySoloed; }
     
     // View mode support (v3.1)
     void setPlaylistMode(PlaylistMode mode) {
@@ -160,6 +162,7 @@ private:
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     bool m_selected = false; // Track selection state
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
+    bool m_anyPlaylistLaneSoloed = false;
     bool m_isLoading = false;
     float m_loadProgress = 0.0f;
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -27,6 +27,7 @@
 #include "Plugin/AestraLFO.h"
 #include "PluginManager.h"
 #include "SampleEditorPanel.h"
+#include "AudioClipEditorPanel.h"
 
 // AestraUI includes
 #include "../AestraUI/Core/NUIThemeSystem.h"
@@ -334,6 +335,7 @@ void AestraContent::setupTrackManagerUI() {
     m_trackManagerUI->setOnToggleMixer([this]() { toggleView(Audio::ViewType::Mixer); });
     m_trackManagerUI->setOnTogglePianoRoll([this]() { toggleView(Audio::ViewType::PianoRoll); });
     m_trackManagerUI->setOnOpenPatternInPianoRoll([this](PatternID patternId) { openPatternInPianoRoll(patternId); });
+    m_trackManagerUI->setOnOpenAudioClipEditor([this](ClipInstanceID clipId) { openAudioClipEditor(clipId); });
     m_trackManagerUI->setOnPreviewPatternClip([this](PatternID patternId) { startPatternClipPreview(patternId); });
     m_trackManagerUI->setOnStopPatternClipPreview([this]() { stopPatternClipPreview(true); });
     m_trackManagerUI->setOnToggleSequencer([this]() { toggleView(Audio::ViewType::Sequencer); });
@@ -1026,6 +1028,44 @@ void AestraContent::setupArsenalPanels() {
         m_trackManager->markModified();
     };
     m_overlayLayer->addChild(m_sampleEditorPanel);
+
+    m_audioClipEditorPanel = std::make_shared<AudioClipEditorPanel>(m_trackManager);
+    m_audioClipEditorPanel->setVisible(false);
+    m_audioClipEditorPanel->setOnClose([this]() {
+        if (m_audioClipEditorPanel) {
+            m_audioClipEditorPanel->setVisible(false);
+        }
+    });
+    m_audioClipEditorPanel->setOnMaximizeToggle(
+        [this](bool) { onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height)); });
+    m_audioClipEditorPanel->setOnDragStart([this](const AestraUI::NUIPoint& pos) {
+        if (!m_overlayLayer)
+            return;
+        m_sampleEditorDragging = true;
+        m_sampleEditorDragStartMouseOverlay = m_overlayLayer->globalToLocal(pos);
+        m_sampleEditorDragStartRect = m_sampleEditorRect;
+    });
+    m_audioClipEditorPanel->setOnDragMove([this](const AestraUI::NUIPoint& pos) {
+        if (!m_overlayLayer || !m_sampleEditorDragging || !m_audioClipEditorPanel)
+            return;
+        const AestraUI::NUIPoint currentMouseOverlay = m_overlayLayer->globalToLocal(pos);
+        const AestraUI::NUIPoint delta = currentMouseOverlay - m_sampleEditorDragStartMouseOverlay;
+        AestraUI::NUIRect proposed = m_sampleEditorDragStartRect;
+        proposed.x += delta.x;
+        proposed.y += delta.y;
+        m_sampleEditorRect = clampRectToAllowed(proposed, computeAllowedRectForPanels());
+        m_audioClipEditorPanel->setBounds(m_sampleEditorRect);
+        setDirty(true);
+    });
+    m_audioClipEditorPanel->setOnDragEnd([this]() { m_sampleEditorDragging = false; });
+    m_audioClipEditorPanel->setMinimumPanelSize(660.0f, 430.0f);
+    m_audioClipEditorPanel->setOnResizeMove([this](const AestraUI::NUIRect& proposed) {
+        m_sampleEditorRect = clampRectToAllowed(proposed, computeAllowedRectForPanels());
+        if (m_audioClipEditorPanel)
+            m_audioClipEditorPanel->setBounds(m_sampleEditorRect);
+        setDirty(true);
+    });
+    m_overlayLayer->addChild(m_audioClipEditorPanel);
 
     // Antigravity Bindings (v3.1)
     m_sequencerPanel->setOnRequestEditor([this](UnitID id) {
@@ -1762,15 +1802,21 @@ void AestraContent::onResize(int width, int height) {
         }
     }
 
-    if (m_sampleEditorPanel && m_sampleEditorPanel->isVisible()) {
+    if ((m_sampleEditorPanel && m_sampleEditorPanel->isVisible()) ||
+        (m_audioClipEditorPanel && m_audioClipEditorPanel->isVisible())) {
         if (m_sampleEditorRect.x == 0.0f && m_sampleEditorRect.y == 0.0f) {
-            m_sampleEditorRect.width = std::min(640.0f, allowed.width);
+            m_sampleEditorRect.width = std::min(700.0f, allowed.width);
             m_sampleEditorRect.height = std::min(430.0f, allowed.height);
             m_sampleEditorRect.x = allowed.x + (allowed.width - m_sampleEditorRect.width) * 0.5f;
             m_sampleEditorRect.y = allowed.y + (allowed.height - m_sampleEditorRect.height) * 0.5f;
         }
         m_sampleEditorRect = clampRectToAllowed(m_sampleEditorRect, allowed);
-        m_sampleEditorPanel->setBounds(m_sampleEditorRect);
+        if (m_sampleEditorPanel && m_sampleEditorPanel->isVisible()) {
+            m_sampleEditorPanel->setBounds(m_sampleEditorRect);
+        }
+        if (m_audioClipEditorPanel && m_audioClipEditorPanel->isVisible()) {
+            m_audioClipEditorPanel->setBounds(m_sampleEditorRect);
+        }
     }
 
     if (m_workspaceLayer) {
@@ -2558,6 +2604,10 @@ AestraUI::NUICursorStyle AestraContent::getPanelResizeCursorStyle(const AestraUI
     if (sampleStyle != AestraUI::NUICursorStyle::Arrow)
         return sampleStyle;
 
+    const auto audioClipStyle = resolveStyle(m_audioClipEditorPanel);
+    if (audioClipStyle != AestraUI::NUICursorStyle::Arrow)
+        return audioClipStyle;
+
     const auto pianoStyle = resolveStyle(m_pianoRollPanel);
     if (pianoStyle != AestraUI::NUICursorStyle::Arrow)
         return pianoStyle;
@@ -3224,9 +3274,9 @@ void AestraContent::addDemoTracks() {
     const int DEFAULT_TRACK_COUNT = 50;
 
     for (int i = 1; i <= DEFAULT_TRACK_COUNT; ++i) {
-        std::string name = "Track " + std::to_string(i);
-        PlaylistLaneID laneId = playlist.createLane(name);
-        m_trackManager->addChannel(name);
+        const std::string laneName = "Track " + std::to_string(i);
+        PlaylistLaneID laneId = playlist.createLane(laneName);
+        m_trackManager->addChannel("Insert " + std::to_string(i));
 
         if (auto* lane = playlist.getLane(laneId)) {
             // Cycle the shared track palette so the lane strip matches the
@@ -3235,6 +3285,9 @@ void AestraContent::addDemoTracks() {
 
             if (i == 1) {
                 AutomationCurve vol("Volume", AutomationTarget::Volume);
+                if (const auto* channel = m_trackManager->getChannel(static_cast<size_t>(i - 1))) {
+                    vol.mixerChannelId = channel->getChannelId();
+                }
                 vol.setDefaultValue(0.8);
                 double samplesPerBeat = (48000.0 * 60.0) / 120.0; // Demo values
                 vol.addPoint(0.0, 0.5, samplesPerBeat, 0.5f);
@@ -3664,12 +3717,32 @@ void AestraContent::openSampleEditorForUnit(UnitID unitId, const std::string& sa
         return;
     }
     m_sampleEditorUnitId = unitId;
+    if (m_audioClipEditorPanel) {
+        m_audioClipEditorPanel->setVisible(false);
+    }
     syncSampleEditorToUnit(unitId);
     m_sampleEditorPanel->loadSample(samplePath);
     m_sampleEditorPanel->setVisible(true);
     m_sampleEditorPanel->bringToFront();
     onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
     m_sampleEditorPanel->setDirty(true);
+}
+
+void AestraContent::openAudioClipEditor(ClipInstanceID clipId) {
+    if (!m_audioClipEditorPanel || !clipId.isValid()) {
+        return;
+    }
+    if (!m_audioClipEditorPanel->openClip(clipId)) {
+        return;
+    }
+    if (m_sampleEditorPanel) {
+        m_sampleEditorPanel->setVisible(false);
+    }
+    m_sampleEditorUnitId = 0;
+    m_audioClipEditorPanel->setVisible(true);
+    m_audioClipEditorPanel->bringToFront();
+    onResize(static_cast<int>(getBounds().width), static_cast<int>(getBounds().height));
+    m_audioClipEditorPanel->setDirty(true);
 }
 
 void AestraContent::updateSoundPreview() {
@@ -3743,21 +3816,9 @@ void AestraContent::loadEffectToSelectedTrack(const std::string& pluginId) {
     if (!m_trackManager)
         return;
 
-    // 2. Resolve the target channel: the selected track's mixer channel when a
-    //    track is selected (mirrors the sample-drop selection path), otherwise
-    //    fall back to the first channel. The shared_ptr keeps the selected
-    //    channel alive for the duration of this call.
-    MixerChannel* channel = nullptr;
-    std::shared_ptr<MixerChannel> selectedChannel;
-    if (m_trackManagerUI) {
-        if (auto* selectedTrack = m_trackManagerUI->getSelectedTrackUI()) {
-            selectedChannel = selectedTrack->getMixerChannel();
-            channel = selectedChannel.get();
-        }
-    }
-    if (!channel) {
-        channel = m_trackManager->getChannel(0);
-    }
+    // 2. Playlist selection does not imply a mixer destination. Until the
+    // mixer exposes its own selected-insert state, use the first insert.
+    MixerChannel* channel = m_trackManager->getChannel(0);
     if (!channel) {
         AESTRA_LOG_ERROR("Cannot load effect: no mixer channel available");
         return;

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -62,12 +62,14 @@ namespace Aestra::Audio {
     class PianoRollPanel;
     class ArsenalPanel;
     class SampleEditorPanel;
+    class AudioClipEditorPanel;
     class PatternBrowserPanel;
     class WindowPanel;
     class AestraHistoryPanel;
     class TakesPanel;
     class AuditionEngine;  // For Audition Mode
     class PlaybackGraphController;
+    struct ClipInstanceID;
 }
 
 namespace Aestra {
@@ -442,6 +444,7 @@ private:
     double m_pendingCountInTargetSeconds{0.0};
 
     std::shared_ptr<Aestra::Audio::SampleEditorPanel> m_sampleEditorPanel;
+    std::shared_ptr<Aestra::Audio::AudioClipEditorPanel> m_audioClipEditorPanel;
     AestraUI::NUIRect m_sampleEditorRect{0.0f, 0.0f, 640.0f, 430.0f};
 
     // Playback graph controller - single authoritative drain for graph rebuilds
@@ -455,6 +458,7 @@ private:
     AestraUI::NUIRect m_sampleEditorDragStartRect{0.0f, 0.0f, 0.0f, 0.0f};
 
     void openSampleEditorForUnit(Aestra::Audio::UnitID unitId, const std::string& samplePath);
+    void openAudioClipEditor(Aestra::Audio::ClipInstanceID clipId);
     void syncSampleEditorToUnit(Aestra::Audio::UnitID unitId);
     void enqueueMainThreadTask(std::function<void()> task);
     void drainMainThreadTasks();

--- a/Source/Core/ProjectMigrations.h
+++ b/Source/Core/ProjectMigrations.h
@@ -15,6 +15,8 @@ namespace Aestra {
  *
  * Version History:
  * - v1: Initial schema (Feb 2026)
+ * - v2: Stable identity baseline
+ * - v3: Playlist lanes and mixer channels persist independently
  *
  * When adding breaking changes:
  * 1. Increment PROJECT_VERSION_CURRENT in ProjectSerializer.cpp
@@ -38,11 +40,8 @@ public:
      */
     static const std::vector<Migration>& getMigrations() {
         static std::vector<Migration> migrations = {
-            {
-                1, 2,
-                migrateV1ToV2,
-                "No-op migration marker for v2 schema baseline"
-            },
+            {1, 2, migrateV1ToV2, "No-op migration marker for v2 schema baseline"},
+            {2, 3, migrateV2ToV3, "Separate Playlist placement from source-level mixer routing"},
         };
         return migrations;
     }
@@ -86,6 +85,9 @@ private:
         return true;
     }
 
+    // The v3 loader understands v2 lane-local mixer state and performs the
+    // source-route migration after stable channel identities are restored.
+    static bool migrateV2ToV3(JSON&) { return true; }
 };
 
 } // namespace Aestra

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -37,7 +37,7 @@ namespace {
     // - Increment CURRENT when making breaking changes
     // - MIN_SUPPORTED is the oldest version we can still load
     // - Future migration code can handle MIN_SUPPORTED <= version <= CURRENT
-    constexpr int PROJECT_VERSION_CURRENT = 2;
+    constexpr int PROJECT_VERSION_CURRENT = 3;
     constexpr int PROJECT_VERSION_MIN_SUPPORTED = 1;
     constexpr size_t PROJECT_HISTORY_DEFAULT_MAX_ENTRIES = 50;
     // Total on-disk cap for a project's .history directory. A large project can
@@ -387,6 +387,7 @@ namespace {
         if (!validArraySection(root, "sources", PROJECT_MAX_SOURCES, error)) return false;
         if (!validArraySection(root, "patterns", PROJECT_MAX_PATTERNS, error)) return false;
         if (!validArraySection(root, "lanes", PROJECT_MAX_LANES, error, true)) return false;
+        if (!validArraySection(root, "mixerChannels", PROJECT_MAX_LANES, error)) return false;
 
         if (root.has("sources")) {
             const JSON& sources = root["sources"];
@@ -454,6 +455,36 @@ namespace {
                 }
             }
         }
+
+    if (root.has("mixerChannels")) {
+        const JSON& channels = root["mixerChannels"];
+        for (size_t i = 0; i < channels.size(); ++i) {
+            if (!channels[i].isObject()) {
+                error = "Invalid project file: mixer channel entry must be an object";
+                return false;
+            }
+            if (!validFiniteNumber(channels[i], "id", error, true))
+                return false;
+            if (!validStringField(channels[i], "name", PROJECT_MAX_STRING_BYTES, error))
+                return false;
+            if (!validColorField(channels[i], "color", error))
+                return false;
+            if (channels[i].has("effectChainStateHex") &&
+                (!channels[i]["effectChainStateHex"].isString() ||
+                 channels[i]["effectChainStateHex"].asString().size() > PROJECT_MAX_EFFECT_STATE_HEX_BYTES)) {
+                error = "Invalid project file: mixer effect chain state is too large";
+                return false;
+            }
+            if (channels[i].has("routing") && channels[i]["routing"].isObject() &&
+                channels[i]["routing"].has("sends")) {
+                const JSON& sends = channels[i]["routing"]["sends"];
+                if (!sends.isArray() || sends.size() > PROJECT_MAX_SENDS_PER_LANE) {
+                    error = "Invalid project file: mixer sends must be a bounded array";
+                    return false;
+                }
+            }
+        }
+    }
 
         const JSON& lanes = root["lanes"];
         for (size_t i = 0; i < lanes.size(); ++i) {
@@ -766,6 +797,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
         pjs.set("id", JSON(static_cast<double>(p->id.value)));
         pjs.set("name", JSON(p->name));
         pjs.set("length", JSON(p->lengthBeats));
+        pjs.set("mixerChannelId", JSON(static_cast<double>(p->getMixerChannelId())));
         
         if (p->isAudio()) {
             pjs.set("type", JSON("audio"));
@@ -816,6 +848,56 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
     }
     root.set("patterns", patternsJson);
 
+    // Mixer channels are persisted independently from Playlist lanes. The
+    // lane-local copies below remain temporarily for backward readers, but this
+    // top-level section is authoritative for current projects.
+    JSON mixerChannelsJson = JSON::array();
+    for (size_t channelIndex = 0; channelIndex < trackManager->getChannelCount(); ++channelIndex) {
+        const auto* channel = trackManager->getChannel(channelIndex);
+        if (!channel) {
+            continue;
+        }
+        JSON mjs = JSON::object();
+        mjs.set("id", JSON(static_cast<double>(channel->getChannelId())));
+        mjs.set("name", JSON(channel->getName()));
+        mjs.set("color", JSON(std::to_string(channel->getColor())));
+        mjs.set("volume", JSON(static_cast<double>(channel->getVolume())));
+        mjs.set("pan", JSON(static_cast<double>(channel->getPan())));
+        mjs.set("mute", JSON(channel->isMuted()));
+        mjs.set("solo", JSON(channel->isSoloed()));
+        mjs.set("soloSafe", JSON(channel->isSoloSafe()));
+        mjs.set("armed", JSON(channel->isArmed()));
+        mjs.set("monitorInput", JSON(channel->isMonitoringEnabled()));
+        mjs.set("inputChannelIndex", JSON(static_cast<double>(channel->getInputChannelIndex())));
+        mjs.set("width", JSON(static_cast<double>(channel->getWidth())));
+        mjs.set("trackColorIndex", JSON(static_cast<double>(channel->getTrackColorIndex())));
+
+        JSON routingJson = JSON::object();
+        const uint32_t mainOutputId = channel->getMainOutputId();
+        routingJson.set("mainOutputId", JSON(static_cast<double>(mainOutputId == 0xFFFFFFFFu ? 0u : mainOutputId)));
+        JSON sendsJson = JSON::array();
+        for (const auto& send : channel->getSends()) {
+            JSON sjs = JSON::object();
+            sjs.set("targetId",
+                    JSON(static_cast<double>(send.targetChannelId == 0xFFFFFFFFu ? 0u : send.targetChannelId)));
+            sjs.set("gain", JSON(static_cast<double>(send.gain)));
+            sjs.set("pan", JSON(static_cast<double>(send.pan)));
+            sjs.set("postFader", JSON(send.postFader));
+            sjs.set("mute", JSON(send.mute));
+            sjs.set("sidechainOnly", JSON(send.sidechainOnly));
+            sendsJson.push(sjs);
+        }
+        routingJson.set("sends", sendsJson);
+        mjs.set("routing", routingJson);
+
+        const auto effectChainState = channel->getEffectChain().saveState();
+        if (!effectChainState.empty()) {
+            mjs.set("effectChainStateHex", JSON(bytesToHex(effectChainState)));
+        }
+        mixerChannelsJson.push(mjs);
+    }
+    root.set("mixerChannels", mixerChannelsJson);
+
     // 3. Save Lanes and Clips
     JSON lanesJson = JSON::array();
     size_t laneIndex = 0;
@@ -832,6 +914,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             ljs.set("solo", JSON(lane->solo));
             if (const auto* channel = trackManager->getChannel(laneIndex)) {
                 // MixerChannel state not covered by PlaylistLane
+                ljs.set("mixerChannelId", JSON(static_cast<double>(channel->getChannelId())));
                 ljs.set("soloSafe", JSON(channel->isSoloSafe()));
                 ljs.set("armed", JSON(channel->isArmed()));
                 ljs.set("monitorInput", JSON(channel->isMonitoringEnabled()));
@@ -869,6 +952,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 JSON cj = JSON::object();
                 cj.set("param", JSON(curve.getTarget()));
                 cj.set("targetEnum", JSON(static_cast<double>(curve.getAutomationTarget())));
+                cj.set("mixerChannelId", JSON(static_cast<double>(curve.mixerChannelId)));
                 cj.set("default", JSON(curve.getDefaultValue()));
                 if (curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Custom) {
                     // Plugin-parameter address (older builds ignore unknown keys;
@@ -1507,6 +1591,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
     
         // 3. Load Patterns
         std::unordered_map<uint64_t, PatternID> patternMap;
+        std::unordered_set<uint64_t> legacyAudioPatternIds;
+        std::unordered_map<uint64_t, std::unordered_map<uint32_t, PatternID>> legacyAudioRouteVariants;
         if (root.has("patterns")) {
             const JSON& pj = root["patterns"];
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
@@ -1545,6 +1631,18 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         // Restore serialized pattern identity (#446); the map
                         // still covers collision/mint fallbacks.
                         PatternID newId = patternManager.createAudioPatternWithId(PatternID{oldId}, name, length, payload);
+                        if (auto* pattern = patternManager.getPattern(newId)) {
+                            if (pj[i].has("mixerChannelId") && pj[i]["mixerChannelId"].isNumber()) {
+                                const double rawMixerChannelId = pj[i]["mixerChannelId"].asNumber();
+                                if (std::isfinite(rawMixerChannelId) && rawMixerChannelId >= 0.0 &&
+                                    rawMixerChannelId < static_cast<double>(UINT32_MAX)) {
+                                    pattern->setMixerChannelId(static_cast<uint32_t>(rawMixerChannelId));
+                                }
+                            } else {
+                                pattern->legacyMixerRoutePending = true;
+                                legacyAudioPatternIds.insert(newId.value);
+                            }
+                        }
                         patternMap[oldId] = newId;
                     }
                 } else {
@@ -1636,7 +1734,93 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             }
         }
     
-        // 4. Load Lanes and Clips
+        // 4. Load mixer channels independently from Playlist lanes (v3+).
+        const bool hasIndependentMixerChannels = root.has("mixerChannels") && root["mixerChannels"].isArray();
+        if (hasIndependentMixerChannels) {
+            const JSON& channels = root["mixerChannels"];
+            for (size_t i = 0; i < channels.size(); ++i) {
+                if (!channels[i].isObject()) {
+                    continue;
+                }
+                const std::string channelName =
+                    boundedStringOr(channels[i], "name", "Insert", PROJECT_MAX_STRING_BYTES);
+                const uint32_t storedId = static_cast<uint32_t>(
+                    finiteNumberOr(channels[i], "id", 0.0, 1.0, static_cast<double>(UINT32_MAX - 1)));
+                MixerChannel* channel = trackManager->addChannelWithId(channelName, storedId);
+                if (!channel) {
+                    warningLimiter.warning(ProjectLoadWarningCategory::LaneCreateChannel,
+                                           "[ProjectLoad] Failed to restore mixer channel '" + channelName + "'",
+                                           "[ProjectLoad] Additional mixer channel creation failures suppressed.");
+                    continue;
+                }
+
+                if (channels[i].has("color") && channels[i]["color"].isString()) {
+                    try {
+                        channel->setColor(
+                            static_cast<uint32_t>(std::stoull(channels[i]["color"].asString()) & 0xFFFFFFFFu));
+                    } catch (const std::exception&) {
+                        channel->setColor(0xFFFFFFFFu);
+                    }
+                }
+                channel->setVolume(static_cast<float>(finiteNumberOr(channels[i], "volume", 1.0, 0.0, 4.0)));
+                channel->setPan(static_cast<float>(finiteNumberOr(channels[i], "pan", 0.0, -1.0, 1.0)));
+                channel->setMute(channels[i].has("mute") && channels[i]["mute"].isBool() &&
+                                 channels[i]["mute"].asBool());
+                channel->setSolo(channels[i].has("solo") && channels[i]["solo"].isBool() &&
+                                 channels[i]["solo"].asBool());
+                if (channels[i].has("soloSafe") && channels[i]["soloSafe"].isBool())
+                    channel->setSoloSafe(channels[i]["soloSafe"].asBool());
+                if (channels[i].has("armed") && channels[i]["armed"].isBool())
+                    channel->setArmed(channels[i]["armed"].asBool());
+                if (channels[i].has("monitorInput") && channels[i]["monitorInput"].isBool())
+                    channel->setMonitoringEnabled(channels[i]["monitorInput"].asBool());
+                channel->setInputChannelIndex(
+                    static_cast<int>(finiteNumberOr(channels[i], "inputChannelIndex", -1.0, -2.0, 1024.0)));
+                channel->setWidth(static_cast<float>(finiteNumberOr(channels[i], "width", 1.0, 0.0, 4.0)));
+                channel->setTrackColorIndex(
+                    static_cast<int>(finiteNumberOr(channels[i], "trackColorIndex", -1.0, -1.0, 1024.0)));
+
+                if (channels[i].has("routing") && channels[i]["routing"].isObject()) {
+                    const JSON& routing = channels[i]["routing"];
+                    const uint32_t mainOutputId = static_cast<uint32_t>(
+                        finiteNumberOr(routing, "mainOutputId", 0.0, 0.0, static_cast<double>(UINT32_MAX)));
+                    channel->setMainOutputId(mainOutputId == 0 ? 0xFFFFFFFFu : mainOutputId);
+                    if (routing.has("sends") && routing["sends"].isArray()) {
+                        const JSON& sends = routing["sends"];
+                        for (size_t s = 0; s < sends.size(); ++s) {
+                            if (!sends[s].isObject())
+                                continue;
+                            AudioRoute route;
+                            const uint32_t targetId = static_cast<uint32_t>(
+                                finiteNumberOr(sends[s], "targetId", 0.0, 0.0, static_cast<double>(UINT32_MAX)));
+                            route.targetChannelId = targetId == 0 ? 0xFFFFFFFFu : targetId;
+                            route.gain = static_cast<float>(finiteNumberOr(sends[s], "gain", 1.0, 0.0, 16.0));
+                            route.pan = static_cast<float>(finiteNumberOr(sends[s], "pan", 0.0, -1.0, 1.0));
+                            route.postFader = !sends[s].has("postFader") || !sends[s]["postFader"].isBool() ||
+                                              sends[s]["postFader"].asBool();
+                            route.mute = sends[s].has("mute") && sends[s]["mute"].isBool() && sends[s]["mute"].asBool();
+                            route.sidechainOnly = sends[s].has("sidechainOnly") && sends[s]["sidechainOnly"].isBool() &&
+                                                  sends[s]["sidechainOnly"].asBool();
+                            channel->addSend(route);
+                        }
+                    }
+                }
+
+                auto& pluginManager = PluginManager::getInstance();
+                auto& chain = channel->getEffectChain();
+                chain.prepare(pluginManager.getDefaultSampleRate(), pluginManager.getDefaultBlockSize());
+                if (channels[i].has("effectChainStateHex") && channels[i]["effectChainStateHex"].isString()) {
+                    const auto effectState = hexToBytes(channels[i]["effectChainStateHex"].asString());
+                    if (!effectState.empty() && !chain.loadState(effectState, pluginManager)) {
+                        warningLimiter.warning(ProjectLoadWarningCategory::EffectChain,
+                                               "[ProjectLoad] Failed to restore mixer effect chain on: " + channelName,
+                                               "[ProjectLoad] Additional mixer effect-chain warnings suppressed.");
+                    }
+                }
+            }
+        }
+
+        // 5. Load Playlist lanes and clips.
         // Clip ids restored from the file must stay unique — a hand-edited or
         // corrupted file with duplicates would silently break id lookups.
         std::unordered_set<AestraUUID> seenClipIds;
@@ -1668,14 +1852,24 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         "[ProjectLoad] Additional lane creation failure warnings suppressed.");
                     continue;
                 }
-                MixerChannel* channel = trackManager->addChannel(laneName);
-                if (!channel) {
-                    warningLimiter.warning(
-                        ProjectLoadWarningCategory::LaneCreateChannel,
-                        "[ProjectLoad] Failed to create channel for lane '" + laneName + "' — removing lane",
-                        "[ProjectLoad] Additional lane channel creation failure warnings suppressed.");
-                    playlist.removeLane(laneId);
-                    continue;
+                MixerChannel* channel = nullptr;
+                if (!hasIndependentMixerChannels) {
+                    uint32_t storedMixerChannelId = 0;
+                    if (lj[i].has("mixerChannelId") && lj[i]["mixerChannelId"].isNumber()) {
+                        const double rawId = lj[i]["mixerChannelId"].asNumber();
+                        if (std::isfinite(rawId) && rawId > 0.0 && rawId < static_cast<double>(UINT32_MAX)) {
+                            storedMixerChannelId = static_cast<uint32_t>(rawId);
+                        }
+                    }
+                    channel = trackManager->addChannelWithId(laneName, storedMixerChannelId);
+                    if (!channel) {
+                        warningLimiter.warning(
+                            ProjectLoadWarningCategory::LaneCreateChannel,
+                            "[ProjectLoad] Failed to create channel for legacy lane '" + laneName + "' — removing lane",
+                            "[ProjectLoad] Additional legacy lane channel creation failures suppressed.");
+                        playlist.removeLane(laneId);
+                        continue;
+                    }
                 }
                 if (auto* lane = playlist.getLane(laneId)) {
                     if (lj[i].has("color") && lj[i]["color"].isString()) {
@@ -1802,6 +1996,16 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             }
                             
                             AutomationCurve curve(param, target);
+                            if (aj[a].has("mixerChannelId") && aj[a]["mixerChannelId"].isNumber()) {
+                                const double rawMixerId = aj[a]["mixerChannelId"].asNumber();
+                                if (std::isfinite(rawMixerId) && rawMixerId > 0.0 &&
+                                    rawMixerId < static_cast<double>(UINT32_MAX)) {
+                                    curve.mixerChannelId = static_cast<uint32_t>(rawMixerId);
+                                }
+                            } else if (channel) {
+                                // Pre-v3 curves inherited their lane's paired insert.
+                                curve.mixerChannelId = channel->getChannelId();
+                            }
                             curve.setDefaultValue(finiteNumberOr(aj[a], "default", 0.0, -1.0e6, 1.0e6));
                             // Plugin-parameter address (Custom target). Bounded:
                             // slot to the effect-chain size, paramId defensively.
@@ -1837,6 +2041,24 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                     clip.id = ClipInstanceID(); // duplicate in file — mint below
                                 }
                                 clip.patternId = patternMap[oldPatId];
+                                if (channel && legacyAudioPatternIds.count(clip.patternId.value) != 0) {
+                                    const uint32_t legacyDestination = channel->getChannelId();
+                                    auto& variants = legacyAudioRouteVariants[clip.patternId.value];
+                                    auto variant = variants.find(legacyDestination);
+                                    if (variant == variants.end()) {
+                                        PatternID routedPattern = clip.patternId;
+                                        if (!variants.empty()) {
+                                            routedPattern = patternManager.clonePattern(clip.patternId);
+                                        }
+                                        if (routedPattern.isValid()) {
+                                            patternManager.setPatternMixerChannel(routedPattern, legacyDestination);
+                                            variants.emplace(legacyDestination, routedPattern);
+                                            clip.patternId = routedPattern;
+                                        }
+                                    } else {
+                                        clip.patternId = variant->second;
+                                    }
+                                }
                                 clip.sourceId = clip.patternId.value;
                                 clip.startBeat = finiteNumberOr(cj[c], "start", 0.0, 0.0, 1000000.0);
                                 const auto* loadedPattern = patternManager.getPattern(clip.patternId);
@@ -1901,6 +2123,19 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             }
         }
     
+        // Resolve pre-stable-ID unit routes after all mixer channels exist.
+        {
+            std::vector<uint32_t> mixerChannelIds;
+            mixerChannelIds.reserve(trackManager->getChannelCount());
+            for (size_t ci = 0; ci < trackManager->getChannelCount(); ++ci) {
+                if (const auto* channel = trackManager->getChannel(ci)) {
+                    mixerChannelIds.push_back(channel->getChannelId());
+                }
+            }
+            trackManager->getUnitManager().migrateLegacyMixerRoutes(mixerChannelIds);
+            trackManager->getPatternManager().validateMixerChannels(mixerChannelIds);
+        }
+
         // PHASE 7: Validate send routing targets.
         // Unresolved sends are non-fatal — the audio runtime silently ignores them
         // via INVALID_SLOT checks. This warning helps diagnose silent routing loss.

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -1405,6 +1405,17 @@ bool ArsenalPanel::onKeyEvent(const NUIKeyEvent& event) {
         return true;
     }
 
+    // Assign the selected unit to the first unused mixer destination.
+    if (isCtrl && event.keyCode == NUIKeyCode::L) {
+        const auto row = std::find_if(m_unitRows.begin(), m_unitRows.end(), [this](const auto& candidate) {
+            return candidate && candidate->getUnitId() == m_selectedUnitId;
+        });
+        if (row != m_unitRows.end()) {
+            (*row)->routeToFirstFreeMixerChannel();
+            return true;
+        }
+    }
+
     if (event.keyCode == NUIKeyCode::Delete || event.keyCode == NUIKeyCode::Backspace) {
         return removeSelectedUnit();
     }

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -1,5 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "ArsenalPanel.h"
+
+#include "Commands/AssignUnitToFirstFreeInsertCommand.h"
 #include "PatternBrowserPanel.h" // For m_patternBrowser
 #include "../AestraUI/Widgets/PluginBrowserPanel.h"
 #include "NUIButton.h"
@@ -1407,13 +1409,14 @@ bool ArsenalPanel::onKeyEvent(const NUIKeyEvent& event) {
 
     // Assign the selected unit to the first unused mixer destination.
     if (isCtrl && event.keyCode == NUIKeyCode::L) {
-        const auto row = std::find_if(m_unitRows.begin(), m_unitRows.end(), [this](const auto& candidate) {
-            return candidate && candidate->getUnitId() == m_selectedUnitId;
-        });
-        if (row != m_unitRows.end()) {
-            (*row)->routeToFirstFreeMixerChannel();
-            return true;
-        }
+        if (!m_trackManager || m_selectedUnitId == 0)
+            return false;
+        const auto* unit = m_trackManager->getUnitManager().getUnit(m_selectedUnitId);
+        if (!unit)
+            return false;
+        const std::string destinationName = unit->name.empty() ? "Mixer Insert" : unit->name;
+        assignUnitToFirstFreeInsert(*m_trackManager, m_selectedUnitId, destinationName, unit->color);
+        return true;
     }
 
     if (event.keyCode == NUIKeyCode::Delete || event.keyCode == NUIKeyCode::Backspace) {

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -5,13 +5,14 @@
 #include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Commands/SetClipEditsCommand.h"
 #include "NUIButton.h"
-#include "NUIDropdown.h"
 #include "NUILabel.h"
 #include "NUIRenderer.h"
 #include "NUISlider.h"
 #include "NUIThemeSystem.h"
 #include "SampleEditorPanel.h"
+#include "TrackColorPalette.h"
 #include "TrackManager.h"
+#include "UIInsertRoutePicker.h"
 
 #include <algorithm>
 #include <cmath>
@@ -112,10 +113,8 @@ void AudioClipEditorPanel::buildUI() {
     m_routeLabel = makeLabel("OUTPUT INSERT", 10.0f);
     m_routeHintLabel = makeLabel("Source route • linked clips follow this destination", 10.0f);
     m_routeHintLabel->setAlignment(NUILabel::Alignment::Right);
-    m_routeDropdown = std::make_shared<NUIDropdown>();
-    m_routeDropdown->setPlaceholderText("Choose an insert");
-    m_routeDropdown->setMaxVisibleItems(9);
-    m_routeDropdown->setOnSelectionChanged([this](int index) { selectRouteIndex(index); });
+    m_routePicker = std::make_shared<UIInsertRoutePicker>();
+    m_routePicker->setOnRouteSelected([this](uint32_t routeId) { selectRoute(routeId); });
 
     m_waveform = std::make_shared<WaveformDisplayComponent>();
     m_instanceLabel = makeLabel("THIS CLIP", 10.0f);
@@ -181,11 +180,10 @@ void AudioClipEditorPanel::buildUI() {
     });
 
     const std::vector<std::shared_ptr<NUIComponent>> children{
-        m_sourceNameLabel, m_sourceMetaLabel, m_routeLabel,    m_routeHintLabel,   m_routeDropdown,
-        m_waveform,        m_instanceLabel,   m_gainLabel,     m_panLabel,         m_fadeInLabel,
-        m_fadeOutLabel,    m_gainValueLabel,  m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel,
-        m_gainSlider,      m_panSlider,       m_fadeInSlider,  m_fadeOutSlider,    m_muteButton,
-        m_resetButton,     m_makeUniqueButton};
+        m_sourceNameLabel, m_sourceMetaLabel,  m_routeLabel,        m_routeHintLabel,  m_routePicker,  m_waveform,
+        m_instanceLabel,   m_gainLabel,        m_panLabel,          m_fadeInLabel,     m_fadeOutLabel, m_gainValueLabel,
+        m_panValueLabel,   m_fadeInValueLabel, m_fadeOutValueLabel, m_gainSlider,      m_panSlider,    m_fadeInSlider,
+        m_fadeOutSlider,   m_muteButton,       m_resetButton,       m_makeUniqueButton};
     for (const auto& child : children) {
         m_surface->addChild(child);
     }
@@ -312,26 +310,22 @@ void AudioClipEditorPanel::rebuildRoutes(bool force) {
         return;
     m_routeFingerprint = fingerprint;
     m_suppressCallbacks = true;
-    m_routeDropdown->clearItems();
-    m_routeIds.clear();
-    m_routeIds.push_back(MASTER_MIXER_CHANNEL_ID);
-    m_routeDropdown->addItem("Master", 0);
+    std::vector<UIInsertRoutePicker::Route> routes;
+    routes.push_back({MASTER_MIXER_CHANNEL_ID, 0, "Master", 0});
     for (size_t index = 0; index < m_trackManager->getChannelCount(); ++index) {
         const auto* channel = m_trackManager->getChannel(index);
         if (!channel)
             continue;
-        m_routeIds.push_back(channel->getChannelId());
         const std::string name =
             channel->getName().empty() ? "Insert " + std::to_string(index + 1) : channel->getName();
-        m_routeDropdown->addItem(std::to_string(index + 1) + "  •  " + name, static_cast<int>(index + 1));
+        routes.push_back({channel->getChannelId(), static_cast<int>(index + 1), name,
+                          paletteIndexToARGB(channel->getTrackColorIndex())});
     }
     uint32_t selectedRoute = MASTER_MIXER_CHANNEL_ID;
     if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId)) {
         selectedRoute = pattern->getMixerChannelId();
     }
-    const auto selected = std::find(m_routeIds.begin(), m_routeIds.end(), selectedRoute);
-    m_routeDropdown->setSelectedIndex(
-        selected == m_routeIds.end() ? 0 : static_cast<int>(std::distance(m_routeIds.begin(), selected)));
+    m_routePicker->setRoutes(std::move(routes), selectedRoute);
     m_suppressCallbacks = false;
 }
 
@@ -405,14 +399,13 @@ void AudioClipEditorPanel::applyDiscreteEdit(const ClipEdits& edits) {
     syncControlsFromModel();
 }
 
-void AudioClipEditorPanel::selectRouteIndex(int index) {
-    if (m_suppressCallbacks || !m_trackManager || index < 0 || static_cast<size_t>(index) >= m_routeIds.size())
+void AudioClipEditorPanel::selectRoute(uint32_t routeId) {
+    if (m_suppressCallbacks || !m_trackManager)
         return;
     const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
-    if (!pattern || !pattern->isAudio() || pattern->getMixerChannelId() == m_routeIds[static_cast<size_t>(index)])
+    if (!pattern || !pattern->isAudio() || pattern->getMixerChannelId() == routeId)
         return;
-    auto command = std::make_shared<SetAudioPatternMixerChannelCommand>(*m_trackManager, m_patternId,
-                                                                        m_routeIds[static_cast<size_t>(index)]);
+    auto command = std::make_shared<SetAudioPatternMixerChannelCommand>(*m_trackManager, m_patternId, routeId);
     m_trackManager->getCommandHistory().pushAndExecute(command);
     m_routeFingerprint = 0;
     rebuildRoutes(true);
@@ -436,7 +429,7 @@ void AudioClipEditorPanel::onResize(int width, int height) {
     m_sourceNameLabel->setBounds({bounds.x + pad, bounds.y + 14.0f, contentWidth - routeWidth - 18.0f, 20.0f});
     m_sourceMetaLabel->setBounds({bounds.x + pad, bounds.y + 39.0f, contentWidth - routeWidth - 18.0f, 16.0f});
     m_routeLabel->setBounds({bounds.right() - pad - routeWidth, bounds.y + 14.0f, routeWidth, 14.0f});
-    m_routeDropdown->setBounds({bounds.right() - pad - routeWidth, bounds.y + 34.0f, routeWidth, 30.0f});
+    m_routePicker->setTriggerBounds({bounds.right() - pad - routeWidth, bounds.y + 34.0f, routeWidth, 30.0f});
     m_routeHintLabel->setBounds({bounds.x + pad, bounds.y + 61.0f, contentWidth, 14.0f});
 
     const float controlsTop = bounds.bottom() - 152.0f;

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -144,11 +144,17 @@ void AudioClipEditorPanel::buildUI() {
 
     const auto wireSlider = [this](const std::shared_ptr<NUISlider>& slider, auto update) {
         slider->setOnDragStart([this]() { beginEditGesture(); });
-        slider->setOnValueChange([this, update](double value) {
+        slider->setOnValueChange([this, slider, update](double value) {
             if (m_suppressCallbacks)
                 return;
+            if (!m_editGestureActive)
+                beginEditGesture();
             update(m_workingEdits, value);
             applyWorkingEdits();
+            // Double-click resets and other non-drag changes do not receive a
+            // drag-end callback, so commit them immediately.
+            if (!slider->isDragging())
+                commitEditGesture();
         });
         slider->setOnDragEnd([this]() { commitEditGesture(); });
     };
@@ -225,8 +231,10 @@ void AudioClipEditorPanel::rebuildWaveform() {
     PatternSource* pattern = nullptr;
     if (!resolveClip(clip, pattern))
         return;
-    const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
-    const auto* source = m_trackManager->getSourceManager().getSource(payload.audioSourceId);
+    const auto* payload = std::get_if<AudioSlicePayload>(&pattern->payload);
+    if (!payload)
+        return;
+    const auto* source = m_trackManager->getSourceManager().getSource(payload->audioSourceId);
     const auto* buffer = source ? source->getRawBuffer() : nullptr;
     if (!source || !buffer || !buffer->isValid()) {
         m_sourceNameLabel->setText(clip->name.empty() ? "Audio clip" : clip->name);
@@ -412,12 +420,6 @@ void AudioClipEditorPanel::selectRoute(uint32_t routeId) {
 }
 
 void AudioClipEditorPanel::onResize(int width, int height) {
-    const auto panelBounds = getBounds();
-    if (panelBounds.width < kMinPanelWidth || panelBounds.height < kMinPanelHeight) {
-        setBounds({panelBounds.x, panelBounds.y, std::max(panelBounds.width, kMinPanelWidth),
-                   std::max(panelBounds.height, kMinPanelHeight)});
-        return;
-    }
     WindowPanel::onResize(width, height);
     if (!m_surface)
         return;

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -1,0 +1,492 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AudioClipEditorPanel.h"
+
+#include "Commands/MakeAudioClipUniqueCommand.h"
+#include "Commands/SetAudioPatternMixerChannelCommand.h"
+#include "Commands/SetClipEditsCommand.h"
+#include "NUIButton.h"
+#include "NUIDropdown.h"
+#include "NUILabel.h"
+#include "NUIRenderer.h"
+#include "NUISlider.h"
+#include "NUIThemeSystem.h"
+#include "SampleEditorPanel.h"
+#include "TrackManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+using namespace AestraUI;
+
+namespace Aestra {
+namespace Audio {
+
+namespace {
+constexpr float kMinPanelWidth = 660.0f;
+constexpr float kMinPanelHeight = 430.0f;
+constexpr size_t kWaveformBuckets = 768;
+
+class AudioClipEditorSurface final : public NUIComponent {
+public:
+    void onRender(NUIRenderer& renderer) override {
+        if (!isVisible())
+            return;
+        const auto bounds = getBounds();
+        auto& theme = NUIThemeManager::getInstance();
+        renderer.fillRect(bounds, theme.getColor("workspaceBackground"));
+
+        const auto card = theme.getColor("surfaceTertiary").withAlpha(0.46f);
+        const auto stroke = theme.getColor("borderSubtle").withAlpha(0.68f);
+        const NUIRect sourceCard{bounds.x + 8.0f, bounds.y + 8.0f, bounds.width - 16.0f, 78.0f};
+        const NUIRect controlsCard{bounds.x + 8.0f, bounds.bottom() - 152.0f, bounds.width - 16.0f, 144.0f};
+        renderer.fillRoundedRect(sourceCard, 7.0f, card);
+        renderer.strokeRoundedRect(sourceCard, 7.0f, 1.0f, stroke);
+        renderer.fillRoundedRect(controlsCard, 7.0f, card.withAlpha(0.38f));
+        renderer.strokeRoundedRect(controlsCard, 7.0f, 1.0f, stroke);
+        renderChildren(renderer);
+        setDirty(false);
+    }
+};
+
+std::string formatFixed(double value, int precision) {
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(precision) << value;
+    return stream.str();
+}
+
+bool editsEqual(const ClipEdits& a, const ClipEdits& b) {
+    return a.fadeInBeats == b.fadeInBeats && a.fadeOutBeats == b.fadeOutBeats && a.gain == b.gain &&
+           a.gainLinear == b.gainLinear && a.pitchSemitones == b.pitchSemitones &&
+           a.timeStretchRatio == b.timeStretchRatio && a.pan == b.pan && a.muted == b.muted &&
+           a.playbackRate == b.playbackRate && a.sourceStart == b.sourceStart;
+}
+
+} // namespace
+
+AudioClipEditorPanel::AudioClipEditorPanel(std::shared_ptr<TrackManager> trackManager)
+    : WindowPanel("AUDIO CLIP"), m_trackManager(std::move(trackManager)) {
+    setMinimumPanelSize(kMinPanelWidth, kMinPanelHeight);
+    buildUI();
+}
+
+void AudioClipEditorPanel::buildUI() {
+    m_surface = std::make_shared<AudioClipEditorSurface>();
+    auto& theme = NUIThemeManager::getInstance();
+
+    const auto makeLabel = [&theme](const std::string& text, float size = 11.0f) {
+        auto label = std::make_shared<NUILabel>(text);
+        label->setFontSize(size);
+        label->setTextColor(theme.getColor("textSecondary").withAlpha(0.88f));
+        label->setEllipsize(true);
+        return label;
+    };
+    const auto makeSlider = [](const std::string& name, double minimum, double maximum, double initial) {
+        auto slider = std::make_shared<NUISlider>(name);
+        slider->setOrientation(NUISlider::Orientation::Horizontal);
+        slider->setTextBoxVisible(false);
+        slider->setSliderRadius(6.0f);
+        slider->setSliderThickness(5.0f);
+        slider->setRange(minimum, maximum);
+        slider->setValue(initial);
+        return slider;
+    };
+    const auto styleButton = [&theme](const std::shared_ptr<NUIButton>& button) {
+        button->setStyle(NUIButton::Style::Text);
+        button->setFontSize(11.0f);
+        button->setCornerRadius(5.0f);
+        button->setGlowEnabled(false);
+        button->setBackgroundColor(theme.getColor("surfaceRaised").withAlpha(0.72f));
+        button->setHoverColor(theme.getColor("secondary").withAlpha(0.18f));
+        button->setPressedColor(theme.getColor("secondary").withAlpha(0.28f));
+        button->setTextColor(theme.getColor("textPrimary").withAlpha(0.88f));
+        button->setBorderEnabled(true);
+        button->setBorderWidth(1.0f);
+        button->setBorderColor(theme.getColor("borderSubtle").withAlpha(0.72f));
+    };
+
+    m_sourceNameLabel = makeLabel("No audio clip selected", 14.0f);
+    m_sourceNameLabel->setTextColor(theme.getColor("textPrimary"));
+    m_sourceMetaLabel = makeLabel("");
+    m_routeLabel = makeLabel("OUTPUT INSERT", 10.0f);
+    m_routeHintLabel = makeLabel("Source route • linked clips follow this destination", 10.0f);
+    m_routeHintLabel->setAlignment(NUILabel::Alignment::Right);
+    m_routeDropdown = std::make_shared<NUIDropdown>();
+    m_routeDropdown->setPlaceholderText("Choose an insert");
+    m_routeDropdown->setMaxVisibleItems(9);
+    m_routeDropdown->setOnSelectionChanged([this](int index) { selectRouteIndex(index); });
+
+    m_waveform = std::make_shared<WaveformDisplayComponent>();
+    m_instanceLabel = makeLabel("THIS CLIP", 10.0f);
+    m_gainLabel = makeLabel("Gain");
+    m_panLabel = makeLabel("Pan");
+    m_fadeInLabel = makeLabel("Fade in");
+    m_fadeOutLabel = makeLabel("Fade out");
+    m_gainValueLabel = makeLabel("100%", 10.0f);
+    m_panValueLabel = makeLabel("Center", 10.0f);
+    m_fadeInValueLabel = makeLabel("0.00 beats", 10.0f);
+    m_fadeOutValueLabel = makeLabel("0.00 beats", 10.0f);
+    for (const auto& value : {m_gainValueLabel, m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel}) {
+        value->setAlignment(NUILabel::Alignment::Right);
+    }
+
+    m_gainSlider = makeSlider("Clip gain", 0.0, 2.0, 1.0);
+    m_panSlider = makeSlider("Clip pan", -1.0, 1.0, 0.0);
+    m_fadeInSlider = makeSlider("Fade in", 0.0, 4.0, 0.0);
+    m_fadeOutSlider = makeSlider("Fade out", 0.0, 4.0, 0.0);
+    m_muteButton = std::make_shared<NUIButton>("Mute clip");
+    m_muteButton->setToggleable(true);
+    m_resetButton = std::make_shared<NUIButton>("Reset instance");
+    m_makeUniqueButton = std::make_shared<NUIButton>("Make unique");
+    styleButton(m_muteButton);
+    styleButton(m_resetButton);
+    styleButton(m_makeUniqueButton);
+
+    const auto wireSlider = [this](const std::shared_ptr<NUISlider>& slider, auto update) {
+        slider->setOnDragStart([this]() { beginEditGesture(); });
+        slider->setOnValueChange([this, update](double value) {
+            if (m_suppressCallbacks)
+                return;
+            update(m_workingEdits, value);
+            applyWorkingEdits();
+        });
+        slider->setOnDragEnd([this]() { commitEditGesture(); });
+    };
+    wireSlider(m_gainSlider, [](ClipEdits& edits, double value) {
+        edits.gain = static_cast<float>(value);
+        edits.gainLinear = static_cast<float>(value);
+    });
+    wireSlider(m_panSlider, [](ClipEdits& edits, double value) { edits.pan = static_cast<float>(value); });
+    wireSlider(m_fadeInSlider, [](ClipEdits& edits, double value) { edits.fadeInBeats = static_cast<float>(value); });
+    wireSlider(m_fadeOutSlider, [](ClipEdits& edits, double value) { edits.fadeOutBeats = static_cast<float>(value); });
+
+    m_muteButton->setOnToggle([this](bool muted) {
+        if (m_suppressCallbacks)
+            return;
+        auto edits = m_workingEdits;
+        edits.muted = muted;
+        applyDiscreteEdit(edits);
+    });
+    m_resetButton->setOnClick([this]() {
+        ClipEdits reset;
+        applyDiscreteEdit(reset);
+    });
+    m_makeUniqueButton->setOnClick([this]() {
+        if (!m_trackManager || !m_clipId.isValid())
+            return;
+        auto command = std::make_shared<MakeAudioClipUniqueCommand>(*m_trackManager, m_clipId);
+        m_trackManager->getCommandHistory().pushAndExecute(command);
+        openClip(m_clipId);
+    });
+
+    const std::vector<std::shared_ptr<NUIComponent>> children{
+        m_sourceNameLabel, m_sourceMetaLabel, m_routeLabel,    m_routeHintLabel,   m_routeDropdown,
+        m_waveform,        m_instanceLabel,   m_gainLabel,     m_panLabel,         m_fadeInLabel,
+        m_fadeOutLabel,    m_gainValueLabel,  m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel,
+        m_gainSlider,      m_panSlider,       m_fadeInSlider,  m_fadeOutSlider,    m_muteButton,
+        m_resetButton,     m_makeUniqueButton};
+    for (const auto& child : children) {
+        m_surface->addChild(child);
+    }
+    setContent(m_surface);
+}
+
+bool AudioClipEditorPanel::resolveClip(ClipInstance*& clip, PatternSource*& pattern) const {
+    clip = nullptr;
+    pattern = nullptr;
+    if (!m_trackManager || !m_clipId.isValid())
+        return false;
+    clip = m_trackManager->getPlaylistModel().getClip(m_clipId);
+    if (!clip || !clip->patternId.isValid())
+        return false;
+    pattern = m_trackManager->getPatternManager().getPattern(clip->patternId);
+    return pattern && pattern->isAudio();
+}
+
+bool AudioClipEditorPanel::openClip(ClipInstanceID clipId) {
+    m_clipId = clipId;
+    ClipInstance* clip = nullptr;
+    PatternSource* pattern = nullptr;
+    if (!resolveClip(clip, pattern)) {
+        m_clipId = {};
+        return false;
+    }
+    m_patternId = pattern->id;
+    m_workingEdits = clip->edits;
+    setTitle(clip->name.empty() ? "AUDIO CLIP" : "AUDIO CLIP  •  " + clip->name);
+    rebuildWaveform();
+    syncControlsFromModel();
+    rebuildRoutes(true);
+    repaint();
+    return true;
+}
+
+void AudioClipEditorPanel::rebuildWaveform() {
+    ClipInstance* clip = nullptr;
+    PatternSource* pattern = nullptr;
+    if (!resolveClip(clip, pattern))
+        return;
+    const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
+    const auto* source = m_trackManager->getSourceManager().getSource(payload.audioSourceId);
+    const auto* buffer = source ? source->getRawBuffer() : nullptr;
+    if (!source || !buffer || !buffer->isValid()) {
+        m_sourceNameLabel->setText(clip->name.empty() ? "Audio clip" : clip->name);
+        m_sourceMetaLabel->setText("Source unavailable");
+        m_waveformData.assign(kWaveformBuckets * 2, 0.0f);
+        m_waveform->setWaveformData(m_waveformData);
+        return;
+    }
+
+    size_t linkedInstances = 0;
+    auto& playlist = m_trackManager->getPlaylistModel();
+    for (size_t laneIndex = 0; laneIndex < playlist.getLaneCount(); ++laneIndex) {
+        const auto* lane = playlist.getLane(playlist.getLaneId(laneIndex));
+        if (!lane)
+            continue;
+        linkedInstances += static_cast<size_t>(
+            std::count_if(lane->clips.begin(), lane->clips.end(),
+                          [pattern](const ClipInstance& candidate) { return candidate.patternId == pattern->id; }));
+    }
+
+    m_sourceNameLabel->setText(source->getName().empty() ? clip->name : source->getName());
+    const char* channelText =
+        buffer->numChannels == 1 ? "Mono" : (buffer->numChannels == 2 ? "Stereo" : "Multichannel");
+    m_sourceMetaLabel->setText(formatFixed(buffer->durationSeconds(), 2) + " s  •  " +
+                               std::to_string(buffer->sampleRate) + " Hz  •  " + channelText + "  •  " +
+                               std::to_string(linkedInstances) +
+                               (linkedInstances == 1 ? " linked clip" : " linked clips"));
+    m_makeUniqueButton->setVisible(linkedInstances > 1);
+
+    const size_t frameCount = static_cast<size_t>(buffer->numFrames);
+    const size_t channels = static_cast<size_t>(buffer->numChannels);
+    const size_t framesPerBucket = std::max<size_t>(1, (frameCount + kWaveformBuckets - 1) / kWaveformBuckets);
+    m_waveformData.clear();
+    m_waveformData.reserve(kWaveformBuckets * 2);
+    for (size_t bucket = 0; bucket < kWaveformBuckets; ++bucket) {
+        const size_t begin = bucket * framesPerBucket;
+        const size_t end = std::min(frameCount, begin + framesPerBucket);
+        float minimum = 0.0f;
+        float maximum = 0.0f;
+        for (size_t frame = begin; frame < end; ++frame) {
+            float mono = 0.0f;
+            for (size_t channel = 0; channel < channels; ++channel) {
+                mono += buffer->interleavedData[frame * channels + channel];
+            }
+            mono /= static_cast<float>(channels);
+            minimum = std::min(minimum, mono);
+            maximum = std::max(maximum, mono);
+        }
+        m_waveformData.push_back(maximum);
+        m_waveformData.push_back(minimum);
+    }
+    m_waveform->setWaveformData(m_waveformData);
+}
+
+uint64_t AudioClipEditorPanel::calculateRouteFingerprint() const {
+    if (!m_trackManager)
+        return 0;
+    uint64_t fingerprint = 1469598103934665603ull;
+    const auto mix = [&fingerprint](uint64_t value) {
+        fingerprint ^= value;
+        fingerprint *= 1099511628211ull;
+    };
+    mix(m_trackManager->getChannelCount());
+    for (size_t index = 0; index < m_trackManager->getChannelCount(); ++index) {
+        const auto* channel = m_trackManager->getChannel(index);
+        if (!channel)
+            continue;
+        mix(channel->getChannelId());
+        for (unsigned char c : channel->getName())
+            mix(c);
+    }
+    if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId)) {
+        mix(pattern->getMixerChannelId());
+    }
+    return fingerprint;
+}
+
+void AudioClipEditorPanel::rebuildRoutes(bool force) {
+    const uint64_t fingerprint = calculateRouteFingerprint();
+    if (!force && fingerprint == m_routeFingerprint)
+        return;
+    m_routeFingerprint = fingerprint;
+    m_suppressCallbacks = true;
+    m_routeDropdown->clearItems();
+    m_routeIds.clear();
+    m_routeIds.push_back(MASTER_MIXER_CHANNEL_ID);
+    m_routeDropdown->addItem("Master", 0);
+    for (size_t index = 0; index < m_trackManager->getChannelCount(); ++index) {
+        const auto* channel = m_trackManager->getChannel(index);
+        if (!channel)
+            continue;
+        m_routeIds.push_back(channel->getChannelId());
+        const std::string name =
+            channel->getName().empty() ? "Insert " + std::to_string(index + 1) : channel->getName();
+        m_routeDropdown->addItem(std::to_string(index + 1) + "  •  " + name, static_cast<int>(index + 1));
+    }
+    uint32_t selectedRoute = MASTER_MIXER_CHANNEL_ID;
+    if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId)) {
+        selectedRoute = pattern->getMixerChannelId();
+    }
+    const auto selected = std::find(m_routeIds.begin(), m_routeIds.end(), selectedRoute);
+    m_routeDropdown->setSelectedIndex(
+        selected == m_routeIds.end() ? 0 : static_cast<int>(std::distance(m_routeIds.begin(), selected)));
+    m_suppressCallbacks = false;
+}
+
+void AudioClipEditorPanel::syncControlsFromModel() {
+    ClipInstance* clip = nullptr;
+    PatternSource* pattern = nullptr;
+    if (!resolveClip(clip, pattern))
+        return;
+    m_workingEdits = clip->edits;
+    m_suppressCallbacks = true;
+    m_gainSlider->setValue(m_workingEdits.gainLinear);
+    m_panSlider->setValue(m_workingEdits.pan);
+    const double fadeMaximum = std::max(0.01, clip->durationBeats);
+    m_fadeInSlider->setRange(0.0, fadeMaximum);
+    m_fadeOutSlider->setRange(0.0, fadeMaximum);
+    m_fadeInSlider->setValue(std::min<double>(m_workingEdits.fadeInBeats, fadeMaximum));
+    m_fadeOutSlider->setValue(std::min<double>(m_workingEdits.fadeOutBeats, fadeMaximum));
+    m_muteButton->setToggled(m_workingEdits.muted);
+    m_muteButton->setText(m_workingEdits.muted ? "Unmute clip" : "Mute clip");
+    m_suppressCallbacks = false;
+    updateValueLabels();
+}
+
+void AudioClipEditorPanel::updateValueLabels() {
+    m_gainValueLabel->setText(std::to_string(static_cast<int>(std::round(m_workingEdits.gainLinear * 100.0f))) + "%");
+    if (std::abs(m_workingEdits.pan) < 0.005f) {
+        m_panValueLabel->setText("Center");
+    } else {
+        const char side = m_workingEdits.pan < 0.0f ? 'L' : 'R';
+        m_panValueLabel->setText(std::to_string(static_cast<int>(std::round(std::abs(m_workingEdits.pan) * 100.0f))) +
+                                 side);
+    }
+    m_fadeInValueLabel->setText(formatFixed(m_workingEdits.fadeInBeats, 2) + " beats");
+    m_fadeOutValueLabel->setText(formatFixed(m_workingEdits.fadeOutBeats, 2) + " beats");
+}
+
+void AudioClipEditorPanel::beginEditGesture() {
+    if (m_editGestureActive)
+        return;
+    m_gestureStartEdits = m_workingEdits;
+    m_editGestureActive = true;
+}
+
+void AudioClipEditorPanel::applyWorkingEdits() {
+    if (!m_trackManager || !m_clipId.isValid())
+        return;
+    if (!m_editGestureActive)
+        beginEditGesture();
+    m_trackManager->getPlaylistModel().setClipEdits(m_clipId, m_workingEdits);
+    m_trackManager->markModified();
+    updateValueLabels();
+}
+
+void AudioClipEditorPanel::commitEditGesture() {
+    if (!m_editGestureActive || !m_trackManager)
+        return;
+    m_editGestureActive = false;
+    if (!editsEqual(m_gestureStartEdits, m_workingEdits)) {
+        auto command = std::make_shared<SetClipEditsCommand>(m_trackManager->getPlaylistModel(), m_clipId,
+                                                             m_gestureStartEdits, m_workingEdits, true);
+        m_trackManager->getCommandHistory().pushExecuted(command);
+    }
+}
+
+void AudioClipEditorPanel::applyDiscreteEdit(const ClipEdits& edits) {
+    if (!m_trackManager || !m_clipId.isValid())
+        return;
+    auto command = std::make_shared<SetClipEditsCommand>(m_trackManager->getPlaylistModel(), m_clipId, edits);
+    m_trackManager->getCommandHistory().pushAndExecute(command);
+    m_trackManager->markModified();
+    syncControlsFromModel();
+}
+
+void AudioClipEditorPanel::selectRouteIndex(int index) {
+    if (m_suppressCallbacks || !m_trackManager || index < 0 || static_cast<size_t>(index) >= m_routeIds.size())
+        return;
+    const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
+    if (!pattern || !pattern->isAudio() || pattern->getMixerChannelId() == m_routeIds[static_cast<size_t>(index)])
+        return;
+    auto command = std::make_shared<SetAudioPatternMixerChannelCommand>(*m_trackManager, m_patternId,
+                                                                        m_routeIds[static_cast<size_t>(index)]);
+    m_trackManager->getCommandHistory().pushAndExecute(command);
+    m_routeFingerprint = 0;
+    rebuildRoutes(true);
+}
+
+void AudioClipEditorPanel::onResize(int width, int height) {
+    const auto panelBounds = getBounds();
+    if (panelBounds.width < kMinPanelWidth || panelBounds.height < kMinPanelHeight) {
+        setBounds({panelBounds.x, panelBounds.y, std::max(panelBounds.width, kMinPanelWidth),
+                   std::max(panelBounds.height, kMinPanelHeight)});
+        return;
+    }
+    WindowPanel::onResize(width, height);
+    if (!m_surface)
+        return;
+
+    const auto bounds = m_surface->getBounds();
+    const float pad = 16.0f;
+    const float contentWidth = bounds.width - pad * 2.0f;
+    const float routeWidth = std::min(270.0f, contentWidth * 0.36f);
+    m_sourceNameLabel->setBounds({bounds.x + pad, bounds.y + 14.0f, contentWidth - routeWidth - 18.0f, 20.0f});
+    m_sourceMetaLabel->setBounds({bounds.x + pad, bounds.y + 39.0f, contentWidth - routeWidth - 18.0f, 16.0f});
+    m_routeLabel->setBounds({bounds.right() - pad - routeWidth, bounds.y + 14.0f, routeWidth, 14.0f});
+    m_routeDropdown->setBounds({bounds.right() - pad - routeWidth, bounds.y + 34.0f, routeWidth, 30.0f});
+    m_routeHintLabel->setBounds({bounds.x + pad, bounds.y + 61.0f, contentWidth, 14.0f});
+
+    const float controlsTop = bounds.bottom() - 152.0f;
+    const float waveformTop = bounds.y + 96.0f;
+    m_waveform->setBounds(
+        {bounds.x + 8.0f, waveformTop, bounds.width - 16.0f, std::max(100.0f, controlsTop - waveformTop - 8.0f)});
+
+    m_instanceLabel->setBounds({bounds.x + pad, controlsTop + 10.0f, contentWidth, 14.0f});
+    const float buttonWidth = 104.0f;
+    m_makeUniqueButton->setBounds(
+        {bounds.right() - pad - buttonWidth * 3.0f - 12.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
+    m_muteButton->setBounds({bounds.right() - pad - buttonWidth * 2.0f - 6.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
+    m_resetButton->setBounds({bounds.right() - pad - buttonWidth, controlsTop + 8.0f, buttonWidth, 24.0f});
+
+    const float columnGap = 20.0f;
+    const float columnWidth = (contentWidth - columnGap) * 0.5f;
+    const float labelWidth = 58.0f;
+    const float valueWidth = 72.0f;
+    const float sliderWidth = columnWidth - labelWidth - valueWidth - 10.0f;
+    const auto layoutControl = [&](float x, float y, const auto& label, const auto& slider, const auto& value) {
+        label->setBounds({x, y + 5.0f, labelWidth, 16.0f});
+        slider->setBounds({x + labelWidth, y, sliderWidth, 24.0f});
+        value->setBounds({x + labelWidth + sliderWidth + 8.0f, y + 5.0f, valueWidth, 16.0f});
+    };
+    const float left = bounds.x + pad;
+    const float right = left + columnWidth + columnGap;
+    layoutControl(left, controlsTop + 42.0f, m_gainLabel, m_gainSlider, m_gainValueLabel);
+    layoutControl(right, controlsTop + 42.0f, m_panLabel, m_panSlider, m_panValueLabel);
+    layoutControl(left, controlsTop + 88.0f, m_fadeInLabel, m_fadeInSlider, m_fadeInValueLabel);
+    layoutControl(right, controlsTop + 88.0f, m_fadeOutLabel, m_fadeOutSlider, m_fadeOutValueLabel);
+}
+
+void AudioClipEditorPanel::onUpdate(double deltaTime) {
+    WindowPanel::onUpdate(deltaTime);
+    if (!isVisible())
+        return;
+    ClipInstance* clip = nullptr;
+    PatternSource* pattern = nullptr;
+    if (!resolveClip(clip, pattern)) {
+        setVisible(false);
+        return;
+    }
+    if (pattern->id != m_patternId) {
+        m_patternId = pattern->id;
+        rebuildWaveform();
+        syncControlsFromModel();
+        rebuildRoutes(true);
+    }
+    rebuildRoutes(false);
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -1,0 +1,92 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "ClipInstance.h"
+#include "PatternSource.h"
+#include "WindowPanel.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace AestraUI {
+class NUIButton;
+class NUIDropdown;
+class NUILabel;
+class NUISlider;
+} // namespace AestraUI
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+class WaveformDisplayComponent;
+
+/**
+ * Focused editor for one Playlist audio-clip instance and its shared source route.
+ *
+ * Instance controls affect only the selected clip. The output selector edits the
+ * referenced audio pattern, so every linked instance follows the same destination.
+ */
+class AudioClipEditorPanel final : public WindowPanel {
+public:
+    explicit AudioClipEditorPanel(std::shared_ptr<TrackManager> trackManager);
+
+    bool openClip(ClipInstanceID clipId);
+    ClipInstanceID getClipId() const { return m_clipId; }
+
+    void onResize(int width, int height) override;
+    void onUpdate(double deltaTime) override;
+
+private:
+    std::shared_ptr<TrackManager> m_trackManager;
+    ClipInstanceID m_clipId;
+    PatternID m_patternId;
+    ClipEdits m_workingEdits;
+    ClipEdits m_gestureStartEdits;
+    bool m_editGestureActive{false};
+    bool m_suppressCallbacks{false};
+    uint64_t m_routeFingerprint{0};
+    std::vector<uint32_t> m_routeIds;
+    std::vector<float> m_waveformData;
+
+    std::shared_ptr<AestraUI::NUIComponent> m_surface;
+    std::shared_ptr<WaveformDisplayComponent> m_waveform;
+    std::shared_ptr<AestraUI::NUILabel> m_sourceNameLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_sourceMetaLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_routeLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_routeHintLabel;
+    std::shared_ptr<AestraUI::NUIDropdown> m_routeDropdown;
+    std::shared_ptr<AestraUI::NUILabel> m_instanceLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_gainLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_panLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_fadeInLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_fadeOutLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_gainValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_panValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_fadeInValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_fadeOutValueLabel;
+    std::shared_ptr<AestraUI::NUISlider> m_gainSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_panSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_fadeInSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_fadeOutSlider;
+    std::shared_ptr<AestraUI::NUIButton> m_muteButton;
+    std::shared_ptr<AestraUI::NUIButton> m_resetButton;
+    std::shared_ptr<AestraUI::NUIButton> m_makeUniqueButton;
+
+    void buildUI();
+    bool resolveClip(ClipInstance*& clip, PatternSource*& pattern) const;
+    void rebuildWaveform();
+    void rebuildRoutes(bool force);
+    uint64_t calculateRouteFingerprint() const;
+    void syncControlsFromModel();
+    void updateValueLabels();
+    void beginEditGesture();
+    void applyWorkingEdits();
+    void commitEditGesture();
+    void applyDiscreteEdit(const ClipEdits& edits);
+    void selectRouteIndex(int index);
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -11,7 +11,7 @@
 
 namespace AestraUI {
 class NUIButton;
-class NUIDropdown;
+class UIInsertRoutePicker;
 class NUILabel;
 class NUISlider;
 } // namespace AestraUI
@@ -47,7 +47,6 @@ private:
     bool m_editGestureActive{false};
     bool m_suppressCallbacks{false};
     uint64_t m_routeFingerprint{0};
-    std::vector<uint32_t> m_routeIds;
     std::vector<float> m_waveformData;
 
     std::shared_ptr<AestraUI::NUIComponent> m_surface;
@@ -56,7 +55,7 @@ private:
     std::shared_ptr<AestraUI::NUILabel> m_sourceMetaLabel;
     std::shared_ptr<AestraUI::NUILabel> m_routeLabel;
     std::shared_ptr<AestraUI::NUILabel> m_routeHintLabel;
-    std::shared_ptr<AestraUI::NUIDropdown> m_routeDropdown;
+    std::shared_ptr<AestraUI::UIInsertRoutePicker> m_routePicker;
     std::shared_ptr<AestraUI::NUILabel> m_instanceLabel;
     std::shared_ptr<AestraUI::NUILabel> m_gainLabel;
     std::shared_ptr<AestraUI::NUILabel> m_panLabel;
@@ -85,7 +84,7 @@ private:
     void applyWorkingEdits();
     void commitEditGesture();
     void applyDiscreteEdit(const ClipEdits& edits);
-    void selectRouteIndex(int index);
+    void selectRoute(uint32_t routeId);
 };
 
 } // namespace Audio

--- a/Source/Panels/PatternBrowserPanel.cpp
+++ b/Source/Panels/PatternBrowserPanel.cpp
@@ -277,7 +277,6 @@ void PatternBrowserPanel::refreshPatterns() {
         entry.name = p->name;
         entry.isMidi = p->isMidi();
         entry.lengthBeats = p->lengthBeats;
-        entry.mixerChannel = p->getMixerChannel();
         entry.isPlacedOnTimeline = playlistModel.isPatternUsed(entry.id);
         m_patterns.push_back(entry);
     }

--- a/Source/Panels/PatternBrowserPanel.h
+++ b/Source/Panels/PatternBrowserPanel.h
@@ -86,7 +86,6 @@ private:
         std::string name;
         bool isMidi;
         double lengthBeats;
-        int mixerChannel = -1;
         bool isPlacedOnTimeline = false;
     };
     std::vector<PatternEntry> m_patterns;

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -96,7 +96,7 @@ struct ScenarioResult {
 ScenarioResult runScenario(const std::filesystem::path& tempRoot,
                            const char* name,
                            bool routeToTrack,
-                           float trackVolume) {
+                           float trackVolume, float unitGain = 1.0f, bool unitMuted = false) {
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(kSampleRate));
     tm->getPlaylistModel().setBPM(kBpm);
@@ -104,7 +104,7 @@ ScenarioResult runScenario(const std::filesystem::path& tempRoot,
     auto& playlist = tm->getPlaylistModel();
     const PlaylistLaneID laneId = playlist.createLane("Track 1");
     require(laneId.isValid(), "Failed to create lane for parity scenario");
-    auto* channel = tm->addChannel("Track 1");
+    auto* channel = tm->addChannelWithId("Track 1", 42);
     require(channel != nullptr, "Failed to create channel for parity scenario");
     if (auto* lane = playlist.getLane(laneId)) {
         lane->volume = trackVolume;
@@ -120,9 +120,13 @@ ScenarioResult runScenario(const std::filesystem::path& tempRoot,
     const UnitID unitId = unitManager.createUnit(std::string("Arsenal ") + name, UnitType::Sampler);
     unitManager.setUnitAudioClip(unitId, samplePath.string());
     unitManager.setUnitEnabled(unitId, true);
+    unitManager.setUnitGain(unitId, unitGain);
+    unitManager.setUnitMute(unitId, unitMuted);
     if (routeToTrack) {
+        unitManager.setUnitMixerChannel(unitId, static_cast<int>(channel->getChannelId()));
         unitManager.assignUnitToTimelineLane(unitId, 0);
     } else {
+        unitManager.setUnitMixerChannel(unitId, 0);
         unitManager.clearUnitTimelineLane(unitId);
     }
 
@@ -218,7 +222,7 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     auto& playlist = tm->getPlaylistModel();
     const PlaylistLaneID laneId = playlist.createLane("Mixed Track");
     require(laneId.isValid(), "Failed to create lane for mixed scenario");
-    auto* channel = tm->addChannel("Mixed Track");
+    auto* channel = tm->addChannelWithId("Mixed Track", 42);
     require(channel != nullptr, "Failed to create channel for mixed scenario");
     if (auto* lane = playlist.getLane(laneId)) {
         lane->volume = trackVolume;
@@ -237,6 +241,8 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     unitManager.setUnitAudioClip(trackUnitId, samplePath.string());
     unitManager.setUnitEnabled(previewUnitId, true);
     unitManager.setUnitEnabled(trackUnitId, true);
+    unitManager.setUnitMixerChannel(previewUnitId, 0);
+    unitManager.setUnitMixerChannel(trackUnitId, static_cast<int>(channel->getChannelId()));
     unitManager.clearUnitTimelineLane(previewUnitId);
     unitManager.assignUnitToTimelineLane(trackUnitId, 0);
 
@@ -353,7 +359,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
         lane->volume = 1.0f;
         lane->pan = 0.0f;
     }
-    auto* channel0 = tm->addChannel("Bounce Track 0");
+    auto* channel0 = tm->addChannelWithId("Bounce Track 0", 42);
     require(channel0 != nullptr, "Failed to create channel 0 for bounce");
     channel0->setVolume(1.0f);
     channel0->setPan(0.0f);
@@ -364,7 +370,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
         lane->volume = 1.0f;
         lane->pan = 0.0f;
     }
-    auto* channel1 = tm->addChannel("Bounce Track 1");
+    auto* channel1 = tm->addChannelWithId("Bounce Track 1", 77);
     require(channel1 != nullptr, "Failed to create channel 1 for bounce");
     channel1->setVolume(1.0f);
     channel1->setPan(0.0f);
@@ -376,6 +382,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
     const UnitID track0Unit = unitManager.createUnit("Bounce Track 0 Unit", UnitType::Sampler);
     unitManager.setUnitAudioClip(track0Unit, samplePath.string());
     unitManager.setUnitEnabled(track0Unit, true);
+    unitManager.setUnitMixerChannel(track0Unit, static_cast<int>(channel0->getChannelId()));
     unitManager.assignUnitToTimelineLane(track0Unit, 0);
 
     auto& patternManager = tm->getPatternManager();
@@ -507,31 +514,37 @@ int main() {
     require(previewMutedTrack.livePeak > 1.0e-4f, "PreviewToMaster should be audible in live output");
     require(previewMutedTrack.exportPeak > 1.0e-4f, "PreviewToMaster should currently participate in export");
 
-    // Case 2: Current live/export authority path still renders track-routed Arsenal
-    // in processBlock even when track volume is muted. This guards current behavior
-    // until routing policy is intentionally changed.
+    // Case 2: A track-routed unit follows the mixer fader in live and export.
     const ScenarioResult routedMutedTrack = runScenario(tempRoot, "routed_muted_track", true, 0.0f);
-    require(routedMutedTrack.livePeak > 1.0e-4f,
-            "Current policy regression: track-routed Arsenal became silent in muted-track live path");
-    require(routedMutedTrack.exportPeak > 1.0e-4f,
-            "Current policy regression: track-routed Arsenal became silent in muted-track export path");
+    require(routedMutedTrack.livePeak < 1.0e-5f, "Track-routed unit bypassed the muted mixer path in live playback");
+    require(routedMutedTrack.exportPeak < 1.0e-5f, "Track-routed unit bypassed the muted mixer path in export");
 
     // Case 3: Track-routed path is audible when track path is open.
     const ScenarioResult routedOpenTrack = runScenario(tempRoot, "routed_open_track", true, 1.0f);
     require(routedOpenTrack.livePeak > 1.0e-4f, "Track-routed Arsenal should be audible in live output when track is open");
     require(routedOpenTrack.exportPeak > 1.0e-4f, "Track-routed Arsenal should be audible in export when track is open");
 
-    // Case 4: Mixed route permutations — two units (preview + track-routed)
+    // Case 4: Unit gain and mute controls affect the shared live/export path.
+    const ScenarioResult reducedUnit = runScenario(tempRoot, "reduced_unit", false, 1.0f, 0.25f);
+    require(reducedUnit.livePeak > 1.0e-5f && reducedUnit.livePeak < previewMutedTrack.livePeak * 0.5f,
+            "Unit gain was not applied in live playback");
+    require(reducedUnit.exportPeak > 1.0e-5f && reducedUnit.exportPeak < previewMutedTrack.exportPeak * 0.5f,
+            "Unit gain was not applied in export");
+    const ScenarioResult mutedUnit = runScenario(tempRoot, "muted_unit", false, 1.0f, 1.0f, true);
+    require(mutedUnit.livePeak < 1.0e-5f, "Muted unit remained audible in live playback");
+    require(mutedUnit.exportPeak < 1.0e-5f, "Muted unit remained audible in export");
+
+    // Case 5: Mixed route permutations — two units (preview + track-routed)
     // running simultaneously must both be audible without cross-contamination.
-    std::cout << "[INFO] Case 4: Mixed route with two units simultaneously\n";
+    std::cout << "[INFO] Case 5: Mixed route with two units simultaneously\n";
     runMixedScenario(tempRoot, 1.0f);
 
-    // Case 5: Isolated-track bounce — verify bounceRangeToWav produces
+    // Case 6: Isolated-track bounce — verify bounceRangeToWav produces
     // correct output for the selected track and excludes non-selected paths.
-    std::cout << "[INFO] Case 5: Isolated-track bounce (full vs isolated)\n";
+    std::cout << "[INFO] Case 6: Isolated-track bounce (full vs isolated)\n";
     runIsolatedBounceScenario(tempRoot);
 
-    std::cout << "[INFO] Case 6: Write-failure cleanup (false return + partial file cleanup)\n";
+    std::cout << "[INFO] Case 7: Write-failure cleanup (false return + partial file cleanup)\n";
     runBounceWriteFailureCleanupScenario(tempRoot);
 
     std::cout << "[PASS] ArsenalExportLiveParityTest\n";

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -123,7 +123,7 @@ ScenarioResult runScenario(const std::filesystem::path& tempRoot,
     unitManager.setUnitGain(unitId, unitGain);
     unitManager.setUnitMute(unitId, unitMuted);
     if (routeToTrack) {
-        unitManager.setUnitMixerChannel(unitId, static_cast<int>(channel->getChannelId()));
+        unitManager.setUnitMixerChannel(unitId, channel->getChannelId());
         unitManager.assignUnitToTimelineLane(unitId, 0);
     } else {
         unitManager.setUnitMixerChannel(unitId, 0);
@@ -242,7 +242,7 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     unitManager.setUnitEnabled(previewUnitId, true);
     unitManager.setUnitEnabled(trackUnitId, true);
     unitManager.setUnitMixerChannel(previewUnitId, 0);
-    unitManager.setUnitMixerChannel(trackUnitId, static_cast<int>(channel->getChannelId()));
+    unitManager.setUnitMixerChannel(trackUnitId, channel->getChannelId());
     unitManager.clearUnitTimelineLane(previewUnitId);
     unitManager.assignUnitToTimelineLane(trackUnitId, 0);
 
@@ -382,7 +382,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
     const UnitID track0Unit = unitManager.createUnit("Bounce Track 0 Unit", UnitType::Sampler);
     unitManager.setUnitAudioClip(track0Unit, samplePath.string());
     unitManager.setUnitEnabled(track0Unit, true);
-    unitManager.setUnitMixerChannel(track0Unit, static_cast<int>(channel0->getChannelId()));
+    unitManager.setUnitMixerChannel(track0Unit, channel0->getChannelId());
     unitManager.assignUnitToTimelineLane(track0Unit, 0);
 
     auto& patternManager = tm->getPatternManager();

--- a/Tests/AestraAudio/ArsenalProcessingContextRoutingTest.cpp
+++ b/Tests/AestraAudio/ArsenalProcessingContextRoutingTest.cpp
@@ -30,6 +30,7 @@ int main() {
 
     const UnitID timelineUnit = manager.createUnit("Timeline Unit", UnitType::Sampler);
     manager.assignUnitToTimelineLane(timelineUnit, 2);
+    manager.setUnitMixerChannel(timelineUnit, 42);
 
     const UnitID previewUnit = manager.createUnit("Preview Unit", UnitType::Sampler);
     manager.clearUnitTimelineLane(previewUnit);
@@ -58,6 +59,11 @@ int main() {
     require(!ctx.shouldRenderToMasterPreview(*timelineState),
             "Timeline-routed unit should not render to master preview");
 
+    require(ctx.shouldRenderToMixerChannel(*timelineState, 42), "Unit should render to its stable mixer destination");
+    require(!ctx.shouldRenderToMixerChannel(*timelineState, 2),
+            "Mixer routing must not treat a Timeline index as a channel ID");
+    require(!ctx.shouldRenderToMaster(*timelineState), "Mixer-routed unit should not render directly to Master");
+    require(ctx.shouldRenderToMaster(*previewState), "New unit should use the safe Master mixer destination");
     require(ctx.shouldRenderToMasterPreview(*previewState),
             "Preview unit should render to master preview");
     require(!ctx.shouldRenderToTimelineTrack(*previewState, 2),

--- a/Tests/AestraAudio/ArsenalRouteModePolicyTest.cpp
+++ b/Tests/AestraAudio/ArsenalRouteModePolicyTest.cpp
@@ -146,7 +146,7 @@ int main() {
     unit.set("id", Aestra::JSON(1.0));
     unit.set("name", Aestra::JSON("Policy"));
     unit.set("enabled", Aestra::JSON(true));
-    unit.set("targetMixerRoute", Aestra::JSON(4.0)); // timeline route authority
+    unit.set("targetMixerRoute", Aestra::JSON(4.0)); // legacy timeline ownership metadata
     Aestra::JSON routeMode = Aestra::JSON::object();
     routeMode.set("id", Aestra::JSON(static_cast<double>(static_cast<uint8_t>(ArsenalRouteMode::PreviewToMaster))));
     routeMode.set("name", Aestra::JSON("PreviewToMaster"));

--- a/Tests/AestraAudio/ArsenalRouteModeRoundTripTest.cpp
+++ b/Tests/AestraAudio/ArsenalRouteModeRoundTripTest.cpp
@@ -55,12 +55,23 @@ void verifyCurrentProjectRoundTrip(const std::filesystem::path& path) {
     using namespace Aestra::Audio;
     auto tm1 = std::make_shared<TrackManager>();
     tm1->getPlaylistModel().setPatternManager(&tm1->getPatternManager());
-    tm1->addChannel("Track 1");
+    tm1->getPlaylistModel().createLane("Track 1");
+    tm1->getPlaylistModel().createLane("Arrangement only 2");
+    tm1->getPlaylistModel().createLane("Arrangement only 3");
+    auto* mixerChannel = tm1->addChannelWithId("Track 1", 42);
+    require(mixerChannel && mixerChannel->getChannelId() == 42, "Failed to create stable mixer channel");
+
+    AudioSlicePayload audioPayload;
+    audioPayload.audioSourceId = tm1->getSourceManager().getOrCreateSource("missing-routing-test.wav");
+    const PatternID audioPattern = tm1->getPatternManager().createAudioPattern("Routed audio", 4.0, audioPayload);
+    require(tm1->getPatternManager().setPatternMixerChannel(audioPattern, 42),
+            "Failed to route audio pattern before save");
 
     UnitManager& um1 = tm1->getUnitManager();
     const UnitID timelineUnit = um1.createUnit("Timeline", UnitType::Sampler);
     const UnitID previewUnit = um1.createUnit("Preview", UnitType::Sampler);
     um1.assignUnitToTimelineLane(timelineUnit, 0);
+    um1.setUnitMixerChannel(timelineUnit, 42);
     um1.clearUnitTimelineLane(previewUnit);
 
     require(ProjectSerializer::save(path.string(), tm1, 120.0, 0.0), "Failed to save project");
@@ -68,6 +79,10 @@ void verifyCurrentProjectRoundTrip(const std::filesystem::path& path) {
     const std::string saved = readFile(path);
     require(!saved.empty(), "Saved project is empty");
     require(saved.find("\"routeMode\"") != std::string::npos, "routeMode field should be serialized for arsenal units");
+    require(saved.find("\"targetMixerChannelId\"") != std::string::npos,
+            "Stable unit mixer destination should be serialized");
+    require(saved.find("\"mixerChannelId\"") != std::string::npos,
+            "Stable mixer channel identity should be serialized");
 
     auto tm2 = std::make_shared<TrackManager>();
     tm2->getPlaylistModel().setPatternManager(&tm2->getPatternManager());
@@ -79,6 +94,15 @@ void verifyCurrentProjectRoundTrip(const std::filesystem::path& path) {
     const UnitInfo* loadedPreview = um2.getUnit(previewUnit);
     require(loadedTimeline != nullptr, "Timeline unit missing after load");
     require(loadedPreview != nullptr, "Preview unit missing after load");
+    require(tm2->getChannelCount() == 1 && tm2->getChannel(0)->getChannelId() == 42,
+            "Mixer channel identity mismatch after load");
+    require(tm2->getPlaylistModel().getLaneCount() == 3, "Independent Playlist lane count mismatch after load");
+    const auto* loadedAudioPattern = tm2->getPatternManager().getPattern(audioPattern);
+    require(loadedAudioPattern && loadedAudioPattern->getMixerChannelId() == 42,
+            "Audio-pattern mixer destination mismatch after load");
+    require(loadedTimeline->targetMixerChannelId == 42, "Unit mixer destination mismatch after load");
+    require(loadedPreview->targetMixerChannelId == MASTER_MIXER_CHANNEL_ID,
+            "Preview unit should remain routed to Master");
     require(loadedTimeline->targetMixerRoute == 0, "Timeline routeId mismatch after load");
     require(loadedPreview->targetMixerRoute < 0, "Preview routeId mismatch after load");
     require(loadedTimeline->routeMode == ArsenalRouteMode::RoutedToTimelineTrack,
@@ -136,6 +160,45 @@ void verifyLegacyRouteIdOnlyProjectLoad(const std::filesystem::path& path) {
             "Legacy preview unit routeMode should resolve from routeId");
     require(track->routeMode == ArsenalRouteMode::RoutedToTimelineTrack,
             "Legacy track unit routeMode should resolve from routeId");
+}
+
+void verifyLegacySharedAudioPatternMigration(const std::filesystem::path& path) {
+    using namespace Aestra::Audio;
+    const std::string legacy = R"JSON({
+  "version": 2,
+  "tempo": 120,
+  "playhead": 0,
+  "sources": [{"id": 1, "path": "missing-legacy.wav", "name": "Legacy source"}],
+  "patterns": [{
+    "id": 7, "name": "Shared audio", "length": 4, "type": "audio",
+    "sourceId": 1, "durationSeconds": 2, "slices": [{"start": 0, "length": 88200}]
+  }],
+  "lanes": [
+    {"name": "Lane A", "mixerChannelId": 11, "clips": [{"patternId": 7, "start": 0, "duration": 4}]},
+    {"name": "Lane B", "mixerChannelId": 42, "clips": [{"patternId": 7, "start": 8, "duration": 4}]}
+  ]
+})JSON";
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out << legacy;
+    }
+
+    auto tm = std::make_shared<TrackManager>();
+    const auto loadResult = ProjectSerializer::load(path.string(), tm);
+    require(loadResult.ok, "Legacy shared-audio project failed to load");
+    require(tm->getChannelCount() == 2, "Legacy lane inserts were not restored");
+    require(tm->getPlaylistModel().getLaneCount() == 2, "Legacy lanes were not restored");
+
+    const auto* laneA = tm->getPlaylistModel().getLane(tm->getPlaylistModel().getLaneId(0));
+    const auto* laneB = tm->getPlaylistModel().getLane(tm->getPlaylistModel().getLaneId(1));
+    require(laneA && laneB && laneA->clips.size() == 1 && laneB->clips.size() == 1,
+            "Legacy shared clips were not restored");
+    require(laneA->clips[0].patternId != laneB->clips[0].patternId,
+            "Legacy source was not cloned to preserve different lane destinations");
+    const auto* sourceA = tm->getPatternManager().getPattern(laneA->clips[0].patternId);
+    const auto* sourceB = tm->getPatternManager().getPattern(laneB->clips[0].patternId);
+    require(sourceA && sourceB && sourceA->getMixerChannelId() == 11 && sourceB->getMixerChannelId() == 42,
+            "Legacy lane routes were not preserved as source destinations");
 }
 
 void verifyEQCurrentProjectRoundTrip(const std::filesystem::path& path) {
@@ -243,6 +306,7 @@ int main() {
     const TempDir tempDir{makeTempDir()};
     verifyCurrentProjectRoundTrip(tempDir.path / "current_roundtrip.aes");
     verifyLegacyRouteIdOnlyProjectLoad(tempDir.path / "legacy_routeid_only.aes");
+    verifyLegacySharedAudioPatternMigration(tempDir.path / "legacy_shared_audio.aes");
     verifyEQCurrentProjectRoundTrip(tempDir.path / "eq_current_roundtrip.aes");
 
     std::cout << "[PASS] ArsenalRouteModeRoundTripTest\n";

--- a/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
+++ b/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
@@ -1,0 +1,104 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace {
+using namespace Aestra::Audio;
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kTotalFrames = kSampleRate;
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::vector<float> render(const std::shared_ptr<TrackManager>& tracks) {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockSize, kChannels);
+    engine.setTrackManager(tracks);
+    engine.setBPM(120.0f);
+    engine.setSafetyLimiterEnabled(false);
+    engine.setMetronomeEnabled(false);
+    engine.setAuditionModeEnabled(false);
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tracks));
+    engine.initialize();
+    engine.setGlobalSamplePos(0);
+    engine.setTransportPlaying(true);
+
+    std::vector<float> output(static_cast<size_t>(kTotalFrames) * kChannels, 0.0f);
+    std::vector<float> block(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+    uint32_t rendered = 0;
+    while (rendered < kTotalFrames) {
+        const uint32_t frames = std::min(kBlockSize, kTotalFrames - rendered);
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, frames, 0.0);
+        std::copy_n(block.begin(), static_cast<size_t>(frames) * kChannels,
+                    output.begin() + static_cast<ptrdiff_t>(rendered) * kChannels);
+        rendered += frames;
+    }
+    engine.setTransportPlaying(false);
+    return output;
+}
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    auto tracks = std::make_shared<TrackManager>();
+    tracks->setOutputSampleRate(kSampleRate);
+
+    auto sourceBuffer = std::make_shared<AudioBufferData>();
+    sourceBuffer->sampleRate = kSampleRate;
+    sourceBuffer->numChannels = 1;
+    sourceBuffer->numFrames = kTotalFrames;
+    sourceBuffer->interleavedData.assign(kTotalFrames, 1.0f);
+
+    const ClipSourceID sourceId =
+        tracks->getSourceManager().createRecordedSource("instance-render.wav", "Instance Render", sourceBuffer);
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = 1.0;
+    payload.slices.push_back({0.0, 1.0, 0.0, static_cast<double>(kTotalFrames)});
+    const PatternID patternId = tracks->getPatternManager().createAudioPattern("Instance Render", 2.0, payload);
+    const PlaylistLaneID laneId = tracks->getPlaylistModel().createLane("Arrangement");
+    const ClipInstanceID clipId = tracks->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
+    auto* clip = tracks->getPlaylistModel().getClip(clipId);
+    require(clip != nullptr, "Audio clip setup failed");
+
+    ClipEdits edits = clip->edits;
+    edits.gain = 0.5f;
+    edits.gainLinear = 0.5f;
+    edits.pan = -1.0f;
+    edits.fadeInBeats = 0.5f;
+    edits.fadeOutBeats = 0.5f;
+    require(tracks->getPlaylistModel().setClipEdits(clipId, edits), "Clip edits were not accepted");
+
+    const auto output = render(tracks);
+    const auto leftAt = [&output](uint32_t frame) { return output[static_cast<size_t>(frame) * 2]; };
+    const auto rightAt = [&output](uint32_t frame) { return output[static_cast<size_t>(frame) * 2 + 1]; };
+
+    require(std::abs(leftAt(0)) < 1.0e-6f, "Fade-in did not begin at silence");
+    require(leftAt(6000) > 0.20f && leftAt(6000) < 0.30f, "Fade-in did not shape the rendered clip");
+    require(leftAt(18000) > 0.49f && leftAt(18000) < 0.51f, "Clip gain did not reach its steady-state level");
+    require(std::abs(rightAt(18000)) < 1.0e-6f, "Hard-left clip pan leaked into the right channel");
+    require(leftAt(42000) > 0.20f && leftAt(42000) < 0.30f, "Fade-out did not shape the rendered clip");
+    require(std::abs(rightAt(42000)) < 1.0e-6f, "Clip pan changed during fade-out");
+
+    std::cout << "[PASS] AudioClipInstanceRenderTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AudioPurityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioPurityAuditTest.cpp
@@ -269,6 +269,9 @@ RenderResult renderThroughAestraEngine(const std::vector<TrackFixture>& tracks, 
         }
         const PatternID patternId =
             trackManager->getPatternManager().createAudioPattern(stem, payload.durationSeconds * 2.0, payload);
+        if (channel) {
+            trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+        }
         trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
     }
 

--- a/Tests/AestraAudio/AudioQualityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioQualityAuditTest.cpp
@@ -60,7 +60,7 @@ static std::vector<float> renderSine(
 
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(sampleRate));
-    tm->addChannel("QualityTest");
+    auto* channel = tm->addChannel("QualityTest");
 
     // Portable temp path with a per-run unique name (avoids collisions in
     // parallel test runs; the source is in-memory, path is metadata only)
@@ -81,6 +81,9 @@ static std::vector<float> renderSine(
     PlaylistLaneID laneId = tm->getPlaylistModel().createLane("quality");
     PatternID patId = tm->getPatternManager().createAudioPattern(
         "quality_pat", durationSec * 2.0, payload);
+    if (channel) {
+        tm->getPatternManager().setPatternMixerChannel(patId, channel->getChannelId());
+    }
     tm->getPlaylistModel().addClipFromPattern(laneId, patId, 0.0, durationSec * 2.0);
 
     AudioEngine eng;

--- a/Tests/AestraAudio/ExportBounceParityTest.cpp
+++ b/Tests/AestraAudio/ExportBounceParityTest.cpp
@@ -135,6 +135,12 @@ int main() {
         PlaylistLaneID laneId = trackManager->getPlaylistModel().createLane(stem);
         PatternID patternId = trackManager->getPatternManager().createAudioPattern(
             stem, kDurationBeats, payload);
+        const auto* destination = trackManager->getChannel(static_cast<size_t>(t));
+        if (!destination ||
+            !trackManager->getPatternManager().setPatternMixerChannel(patternId, destination->getChannelId())) {
+            std::cerr << "Could not assign explicit source destination for track " << t << "\n";
+            return 1;
+        }
         trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationBeats);
     }
 

--- a/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
+++ b/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
@@ -122,7 +122,7 @@ inline Aestra::Audio::ClipSourceID addAudioTrack(Aestra::Audio::TrackManager& tm
                                                  const std::vector<float>& interleaved, uint32_t frames,
                                                  const SessionConfig& cfg) {
     using namespace Aestra::Audio;
-    tm.addChannel(label);
+    auto* channel = tm.addChannel(label);
 
     auto buffer = std::make_shared<AudioBufferData>();
     buffer->sampleRate = cfg.sampleRate;
@@ -144,6 +144,9 @@ inline Aestra::Audio::ClipSourceID addAudioTrack(Aestra::Audio::TrackManager& tm
         payload.durationSeconds * (static_cast<double>(cfg.bpm) / 60.0);
     PatternID patternId =
         tm.getPatternManager().createAudioPattern(label, durationBeats, payload);
+    if (channel) {
+        tm.getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+    }
     tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
     return sourceId;
 }

--- a/Tests/AestraAudio/GoldenReferenceTest.cpp
+++ b/Tests/AestraAudio/GoldenReferenceTest.cpp
@@ -86,7 +86,7 @@ AnalysisResult runSignalTest(const std::string& label, const std::vector<float>&
     // Create engine with a track that plays the reference signal
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
-    trackManager->addChannel("GoldenRef");
+    auto* channel = trackManager->addChannel("GoldenRef");
 
     auto buffer = std::make_shared<AudioBufferData>();
     buffer->sampleRate = kSampleRate;
@@ -104,6 +104,9 @@ AnalysisResult runSignalTest(const std::string& label, const std::vector<float>&
     PlaylistLaneID laneId = trackManager->getPlaylistModel().createLane("GoldenRef");
     PatternID patternId = trackManager->getPatternManager().createAudioPattern(
         "GoldenRef", payload.durationSeconds * 2.0, payload);
+    if (channel) {
+        trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+    }
     trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
 
     AudioEngine engine;

--- a/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
+++ b/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
@@ -114,7 +114,7 @@ void runCrossRateCase() {
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
     {
-        tm->addChannel("Cross48in96");
+        auto* channel = tm->addChannel("Cross48in96");
         auto buffer = std::make_shared<AudioBufferData>();
         buffer->sampleRate = clipRate;
         buffer->numChannels = 2;
@@ -128,6 +128,9 @@ void runCrossRateCase() {
         payload.slices.push_back({0.0, 1.0, 0.0, static_cast<double>(clipFrames)});
         PlaylistLaneID laneId = tm->getPlaylistModel().createLane("Cross48");
         PatternID patternId = tm->getPatternManager().createAudioPattern("Cross48", 2.0, payload);
+        if (channel) {
+            tm->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+        }
         tm->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
     }
 

--- a/Tests/AestraAudio/SummingEngineTest.cpp
+++ b/Tests/AestraAudio/SummingEngineTest.cpp
@@ -65,6 +65,9 @@ int main() {
         PlaylistLaneID laneId = trackManager->getPlaylistModel().createLane(stem);
         PatternID patternId = trackManager->getPatternManager().createAudioPattern(
             stem, kDurationSeconds * 2.0, payload);
+        if (auto* channel = trackManager->getChannel(t)) {
+            trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+        }
         trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationSeconds * 2.0);
     }
 

--- a/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
+++ b/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
@@ -107,6 +107,7 @@ std::shared_ptr<TrackManager> createOneTrackManager() {
     const PlaylistLaneID laneId = trackManager->getPlaylistModel().createLane("Track 1");
     const PatternID patternId =
         trackManager->getPatternManager().createAudioPattern("duck_audit_pattern", durationSeconds * 2.0, payload);
+    trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
     trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationSeconds * 2.0);
 
     trackManager->buildAndShareSlotMap();

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -1,6 +1,7 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "Commands/ArrangePatternCommand.h"
+#include "Commands/AssignUnitToFirstFreeInsertCommand.h"
 #include "Commands/MakeAudioClipUniqueCommand.h"
 #include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Commands/SetClipEditsCommand.h"
@@ -9,8 +10,10 @@
 #include "Models/UnitManager.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -43,7 +46,14 @@ int main() {
     units.setUnitMixerChannel(unitId, static_cast<int64_t>(UINT32_MAX));
     require(units.getUnitMixerChannel(unitId) == MASTER_MIXER_CHANNEL_ID,
             "Reserved mixer destination must fall back to Master");
+    units.setUnitMixerChannel(unitId, UINT32_MAX - 1);
+    require(units.getUnitMixerChannel(unitId) == UINT32_MAX - 1,
+            "High unsigned mixer destination was truncated or redirected");
     units.setUnitMixerChannel(unitId, 42);
+    units.setUnitGain(unitId, std::numeric_limits<float>::quiet_NaN());
+    snapshot = units.getAudioSnapshot();
+    require(snapshot && std::isfinite(snapshot->units.front().gain) && snapshot->units.front().gain == 1.0f,
+            "Non-finite unit gain reached the audio snapshot");
 
     const auto saved = units.saveToJSON();
     UnitManager restored;
@@ -66,6 +76,16 @@ int main() {
     require(migrated.getUnitMixerChannel(1) == 42,
             "Legacy lane-index destination did not migrate to the matching stable ID");
 
+    legacyUnit.set("targetMixerChannelId", Aestra::JSON("malformed"));
+    legacyUnits = Aestra::JSON::array();
+    legacyUnits.push(legacyUnit);
+    legacyRoot.set("units", legacyUnits);
+    UnitManager malformedStableRoute;
+    malformedStableRoute.loadFromJSON(legacyRoot);
+    malformedStableRoute.migrateLegacyMixerRoutes({11, 42});
+    require(malformedStableRoute.getUnitMixerChannel(1) == 42,
+            "Malformed stable destination blocked valid legacy route migration");
+
     TrackManager tracks;
     auto* restoredChannel = tracks.addChannelWithId("Restored", 42);
     require(restoredChannel && restoredChannel->getChannelId() == 42, "Persisted channel ID was not restored");
@@ -75,6 +95,49 @@ int main() {
     const auto* defaultInsert = defaultNames.addChannel();
     require(defaultInsert && defaultInsert->getName() == "Insert 1",
             "New mixer destinations must use Insert terminology");
+    require(defaultNames.removeChannelById(defaultInsert->getChannelId()), "Default insert deletion failed");
+    const auto* postDeleteInsert = defaultNames.addChannel();
+    require(postDeleteInsert && postDeleteInsert->getName() == "Insert 2",
+            "Default insert name reused a deleted channel number");
+
+    TrackManager firstFreeTracks;
+    const UnitID firstFreeUnit = firstFreeTracks.getUnitManager().createUnit("Bass", UnitType::Instrument);
+    firstFreeTracks.getCommandHistory().pushAndExecute(
+        std::make_shared<AssignUnitToFirstFreeInsertCommand>(firstFreeTracks, firstFreeUnit, "Bass", 0xFF336699));
+    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 1,
+            "First-free route did not atomically create its insert and lane");
+    const uint32_t createdDestinationId = firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit);
+    const auto createdLaneId = firstFreeTracks.getPlaylistModel().getLaneId(0);
+    require(createdDestinationId != MASTER_MIXER_CHANNEL_ID &&
+                firstFreeTracks.getChannel(0)->getColor() == 0xFF336699 &&
+                firstFreeTracks.getPlaylistModel().getLane(createdLaneId)->colorRGBA == 0xFF336699,
+            "First-free route did not apply destination identity and color");
+    require(firstFreeTracks.getCommandHistory().undo(), "First-free route undo was unavailable");
+    require(firstFreeTracks.getChannelCount() == 0 && firstFreeTracks.getPlaylistModel().getLaneCount() == 0 &&
+                firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == MASTER_MIXER_CHANNEL_ID,
+            "First-free route undo left created project state behind");
+    require(firstFreeTracks.getCommandHistory().redo(), "First-free route redo was unavailable");
+    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 1 &&
+                firstFreeTracks.getChannel(0)->getChannelId() == createdDestinationId &&
+                firstFreeTracks.getPlaylistModel().getLaneId(0) == createdLaneId &&
+                firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == createdDestinationId,
+            "First-free route redo did not restore stable identities atomically");
+
+    TrackManager shortcutTracks;
+    const UnitID shortcutUnit = shortcutTracks.getUnitManager().createUnit("Shortcut", UnitType::Instrument);
+    require(assignUnitToFirstFreeInsert(shortcutTracks, shortcutUnit, "Shortcut", 0xFF224466),
+            "Ctrl+L routing helper did not handle a selected unit");
+    require(shortcutTracks.getUnitManager().getUnitMixerChannel(shortcutUnit) != MASTER_MIXER_CHANNEL_ID,
+            "Ctrl+L routing helper did not route the selected unit");
+    const size_t shortcutChannelCount = shortcutTracks.getChannelCount();
+    const size_t shortcutLaneCount = shortcutTracks.getPlaylistModel().getLaneCount();
+    require(!assignUnitToFirstFreeInsert(shortcutTracks, 0, "Missing", 0xFFFFFFFF),
+            "Ctrl+L routing helper handled a missing selection");
+    require(!assignUnitToFirstFreeInsert(shortcutTracks, shortcutUnit + 999, "Missing", 0xFFFFFFFF),
+            "Ctrl+L routing helper handled a failed unit destination");
+    require(shortcutTracks.getChannelCount() == shortcutChannelCount &&
+                shortcutTracks.getPlaylistModel().getLaneCount() == shortcutLaneCount,
+            "Failed Ctrl+L routing changed project structure");
 
     auto& patternManager = tracks.getPatternManager();
     auto& trackUnits = tracks.getUnitManager();
@@ -194,7 +257,29 @@ int main() {
     stillLinkedClip = playlist.getClip(linkedClip.id);
     require(uniqueClip && stillLinkedClip && uniqueClip->patternId == stillLinkedClip->patternId,
             "Make unique undo did not restore the shared source identity");
+    require(tracks.getCommandHistory().redo(), "Make unique redo was unavailable");
+    uniqueClip = playlist.getClip(audioClip.id);
+    require(uniqueClip && uniqueClip->patternId == uniquePatternId,
+            "Make unique redo did not restore the original unique source identity");
+    require(patternManager.getPattern(uniquePatternId) &&
+                patternManager.getPattern(uniquePatternId)->getMixerChannelId() == 77,
+            "Make unique redo did not restore the unique source route");
+    require(tracks.getCommandHistory().undo(), "Second make unique undo was unavailable");
     playlist.removeClip(linkedClip.id);
+
+    ClipEdits poisonedEdits = audioClip.edits;
+    poisonedEdits.gainLinear = std::numeric_limits<float>::quiet_NaN();
+    poisonedEdits.pan = std::numeric_limits<float>::infinity();
+    poisonedEdits.fadeInBeats = std::numeric_limits<float>::quiet_NaN();
+    poisonedEdits.fadeOutBeats = std::numeric_limits<float>::infinity();
+    require(playlist.setClipEdits(audioClip.id, poisonedEdits), "Failed to install non-finite clip edits");
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && !findTrack(graph, 77)->clips.empty(), "Poisoned clip vanished from graph");
+    const auto& sanitizedClip = findTrack(graph, 77)->clips.front();
+    require(std::isfinite(sanitizedClip.gain) && sanitizedClip.gain == 1.0f && std::isfinite(sanitizedClip.pan) &&
+                sanitizedClip.pan == 0.0f && sanitizedClip.fadeInSamples == 0 && sanitizedClip.fadeOutSamples == 0,
+            "Non-finite clip edits reached the render graph");
+    require(playlist.setClipEdits(audioClip.id, audioClip.edits), "Failed to restore finite clip edits");
 
     playlist.moveClip(audioClip.id, 8.0, laneB);
     graph = AudioGraphBuilder::buildFromTrackManager(tracks);

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -5,6 +5,7 @@
 #include "Commands/MakeAudioClipUniqueCommand.h"
 #include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Commands/SetClipEditsCommand.h"
+#include "Commands/SetUnitMixerChannelCommand.h"
 #include "Core/AudioGraphBuilder.h"
 #include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
@@ -122,6 +123,43 @@ int main() {
                 firstFreeTracks.getPlaylistModel().getLaneId(0) == createdLaneId &&
                 firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == createdDestinationId,
             "First-free route redo did not restore stable identities atomically");
+
+    TrackManager patternOccupiedTracks;
+    const auto* patternInsert = patternOccupiedTracks.addChannel("Audio Source");
+    const auto* availableInsert = patternOccupiedTracks.addChannel("Available");
+    require(patternInsert && availableInsert, "Pattern-occupied route setup could not create inserts");
+    const uint32_t patternInsertId = patternInsert->getChannelId();
+    const uint32_t availableInsertId = availableInsert->getChannelId();
+    AudioSlicePayload occupiedPayload;
+    const PatternID occupiedPattern =
+        patternOccupiedTracks.getPatternManager().createAudioPattern("Occupied", 4.0, occupiedPayload);
+    require(patternOccupiedTracks.setAudioPatternMixerChannel(occupiedPattern, patternInsertId),
+            "Pattern-occupied route setup could not route its audio source");
+    const UnitID patternAwareUnit =
+        patternOccupiedTracks.getUnitManager().createUnit("Pattern Aware", UnitType::Instrument);
+    require(assignUnitToFirstFreeInsert(patternOccupiedTracks, patternAwareUnit, "Pattern Aware", 0xFF446688),
+            "First-free routing failed with an existing pattern-owned insert");
+    require(patternOccupiedTracks.getUnitManager().getUnitMixerChannel(patternAwareUnit) == availableInsertId,
+            "First-free routing reused an insert owned by an audio pattern");
+    require(patternOccupiedTracks.getChannelCount() == 2 &&
+                patternOccupiedTracks.getPlaylistModel().getLaneCount() == 0,
+            "First-free routing created project structure despite an available insert");
+
+    TrackManager missingRedoTracks;
+    const auto* redoInsert = missingRedoTracks.addChannel("Redo");
+    require(redoInsert, "Unit-route redo setup could not create an insert");
+    const UnitID missingRedoUnit =
+        missingRedoTracks.getUnitManager().createUnit("Transient", UnitType::Instrument);
+    auto missingRedoCommand =
+        std::make_shared<SetUnitMixerChannelCommand>(missingRedoTracks, missingRedoUnit, redoInsert->getChannelId());
+    missingRedoCommand->execute();
+    missingRedoCommand->undo();
+    require(missingRedoTracks.getUnitManager().removeUnit(missingRedoUnit),
+            "Unit-route redo setup could not remove its unit");
+    missingRedoTracks.setModified(false);
+    missingRedoCommand->redo();
+    require(!missingRedoCommand->isUndoable() && !missingRedoTracks.isModified(),
+            "Unit-route redo reported a project change after its unit was removed");
 
     TrackManager shortcutTracks;
     const UnitID shortcutUnit = shortcutTracks.getUnitManager().createUnit("Shortcut", UnitType::Instrument);

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -87,12 +87,16 @@ int main() {
     require(malformedStableRoute.getUnitMixerChannel(1) == 42,
             "Malformed stable destination blocked valid legacy route migration");
 
-    TrackManager tracks;
+    // TrackManager embeds large fixed-capacity RT queues. Keep the independent
+    // fixtures off the smaller default Windows process stack.
+    auto tracksOwner = std::make_unique<TrackManager>();
+    auto& tracks = *tracksOwner;
     auto* restoredChannel = tracks.addChannelWithId("Restored", 42);
     require(restoredChannel && restoredChannel->getChannelId() == 42, "Persisted channel ID was not restored");
     auto* nextChannel = tracks.addChannel("Next");
     require(nextChannel && nextChannel->getChannelId() == 43, "Channel ID source did not advance past restored ID");
-    TrackManager defaultNames;
+    auto defaultNamesOwner = std::make_unique<TrackManager>();
+    auto& defaultNames = *defaultNamesOwner;
     const auto* defaultInsert = defaultNames.addChannel();
     require(defaultInsert && defaultInsert->getName() == "Insert 1",
             "New mixer destinations must use Insert terminology");
@@ -101,7 +105,8 @@ int main() {
     require(postDeleteInsert && postDeleteInsert->getName() == "Insert 2",
             "Default insert name reused a deleted channel number");
 
-    TrackManager firstFreeTracks;
+    auto firstFreeTracksOwner = std::make_unique<TrackManager>();
+    auto& firstFreeTracks = *firstFreeTracksOwner;
     const UnitID firstFreeUnit = firstFreeTracks.getUnitManager().createUnit("Bass", UnitType::Instrument);
     firstFreeTracks.getCommandHistory().pushAndExecute(
         std::make_shared<AssignUnitToFirstFreeInsertCommand>(firstFreeTracks, firstFreeUnit, "Bass", 0xFF336699));
@@ -124,7 +129,8 @@ int main() {
                 firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == createdDestinationId,
             "First-free route redo did not restore stable identities atomically");
 
-    TrackManager patternOccupiedTracks;
+    auto patternOccupiedTracksOwner = std::make_unique<TrackManager>();
+    auto& patternOccupiedTracks = *patternOccupiedTracksOwner;
     const auto* patternInsert = patternOccupiedTracks.addChannel("Audio Source");
     const auto* availableInsert = patternOccupiedTracks.addChannel("Available");
     require(patternInsert && availableInsert, "Pattern-occupied route setup could not create inserts");
@@ -145,7 +151,8 @@ int main() {
                 patternOccupiedTracks.getPlaylistModel().getLaneCount() == 0,
             "First-free routing created project structure despite an available insert");
 
-    TrackManager missingRedoTracks;
+    auto missingRedoTracksOwner = std::make_unique<TrackManager>();
+    auto& missingRedoTracks = *missingRedoTracksOwner;
     const auto* redoInsert = missingRedoTracks.addChannel("Redo");
     require(redoInsert, "Unit-route redo setup could not create an insert");
     const UnitID missingRedoUnit =
@@ -161,7 +168,8 @@ int main() {
     require(!missingRedoCommand->isUndoable() && !missingRedoTracks.isModified(),
             "Unit-route redo reported a project change after its unit was removed");
 
-    TrackManager shortcutTracks;
+    auto shortcutTracksOwner = std::make_unique<TrackManager>();
+    auto& shortcutTracks = *shortcutTracksOwner;
     const UnitID shortcutUnit = shortcutTracks.getUnitManager().createUnit("Shortcut", UnitType::Instrument);
     require(assignUnitToFirstFreeInsert(shortcutTracks, shortcutUnit, "Shortcut", 0xFF224466),
             "Ctrl+L routing helper did not handle a selected unit");

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -1,0 +1,225 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Commands/ArrangePatternCommand.h"
+#include "Commands/MakeAudioClipUniqueCommand.h"
+#include "Commands/SetAudioPatternMixerChannelCommand.h"
+#include "Commands/SetClipEditsCommand.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Models/TrackManager.h"
+#include "Models/UnitManager.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace {
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+} // namespace
+
+int main() {
+    using namespace Aestra::Audio;
+
+    UnitManager units;
+    const UnitID unitId = units.createUnit("Drums", UnitType::Sampler);
+    require(units.getUnitMixerChannel(unitId) == MASTER_MIXER_CHANNEL_ID, "New units must route safely to Master");
+
+    units.assignUnitToTimelineLane(unitId, 7);
+    require(units.getUnitMixerChannel(unitId) == MASTER_MIXER_CHANNEL_ID,
+            "Timeline placement must not change mixer output");
+
+    units.setUnitMixerChannel(unitId, 42);
+    require(units.getUnitMixerChannel(unitId) == 42, "Explicit mixer destination was not stored");
+    auto snapshot = units.getAudioSnapshot();
+    require(snapshot && snapshot->units.size() == 1, "Unit snapshot missing");
+    require(snapshot->units.front().mixerChannelId == 42, "Mixer destination missing from audio snapshot");
+
+    units.setUnitMixerChannel(unitId, static_cast<int64_t>(UINT32_MAX));
+    require(units.getUnitMixerChannel(unitId) == MASTER_MIXER_CHANNEL_ID,
+            "Reserved mixer destination must fall back to Master");
+    units.setUnitMixerChannel(unitId, 42);
+
+    const auto saved = units.saveToJSON();
+    UnitManager restored;
+    restored.loadFromJSON(saved);
+    require(restored.getUnitMixerChannel(unitId) == 42, "Mixer destination did not round-trip");
+
+    Aestra::JSON legacyRoot = Aestra::JSON::object();
+    legacyRoot.set("nextId", Aestra::JSON(2.0));
+    Aestra::JSON legacyUnits = Aestra::JSON::array();
+    Aestra::JSON legacyUnit = Aestra::JSON::object();
+    legacyUnit.set("id", Aestra::JSON(1.0));
+    legacyUnit.set("name", Aestra::JSON("Legacy"));
+    legacyUnit.set("targetMixerRoute", Aestra::JSON(1.0));
+    legacyUnits.push(legacyUnit);
+    legacyRoot.set("units", legacyUnits);
+
+    UnitManager migrated;
+    migrated.loadFromJSON(legacyRoot);
+    migrated.migrateLegacyMixerRoutes({11, 42});
+    require(migrated.getUnitMixerChannel(1) == 42,
+            "Legacy lane-index destination did not migrate to the matching stable ID");
+
+    TrackManager tracks;
+    auto* restoredChannel = tracks.addChannelWithId("Restored", 42);
+    require(restoredChannel && restoredChannel->getChannelId() == 42, "Persisted channel ID was not restored");
+    auto* nextChannel = tracks.addChannel("Next");
+    require(nextChannel && nextChannel->getChannelId() == 43, "Channel ID source did not advance past restored ID");
+    TrackManager defaultNames;
+    const auto* defaultInsert = defaultNames.addChannel();
+    require(defaultInsert && defaultInsert->getName() == "Insert 1",
+            "New mixer destinations must use Insert terminology");
+
+    auto& patternManager = tracks.getPatternManager();
+    auto& trackUnits = tracks.getUnitManager();
+    const UnitID arrangedUnit = trackUnits.createUnit("Lead", UnitType::Instrument);
+    trackUnits.setUnitMixerChannel(arrangedUnit, 42);
+    MidiPayload midi;
+    midi.notes.push_back({60, 0.0, 1.0, 0.8f, 0.0f, arrangedUnit});
+    const PatternID patternId = patternManager.createMidiPattern("Lead Pattern", 4.0, midi);
+
+    ArrangePatternCommand arrange(tracks, patternId, 0, 0.0);
+    arrange.execute();
+    require(trackUnits.getUnitMixerChannel(arrangedUnit) == 42,
+            "Arranging a pattern changed its unit mixer destination");
+    require(trackUnits.getUnitTimelineLane(arrangedUnit) < 0,
+            "Arranging a pattern created hidden timeline routing state");
+    arrange.undo();
+    require(trackUnits.getUnitMixerChannel(arrangedUnit) == 42,
+            "Undoing arrangement changed its unit mixer destination");
+
+    // Audio clips follow their source's stable destination, never their lane.
+    auto* audioDestination = tracks.addChannelWithId("Audio Insert", 77);
+    require(audioDestination && audioDestination->getChannelId() == 77, "Audio insert ID was not restored");
+    auto& playlist = tracks.getPlaylistModel();
+    const PlaylistLaneID laneA = playlist.createLane("Arrangement A");
+    playlist.createLane("Spacer");
+    const PlaylistLaneID laneB = playlist.createLane("Arrangement B");
+    playlist.createLane("Extra lane without an insert");
+    require(playlist.getLaneCount() != tracks.getChannelCount(), "Test setup accidentally retained lane/insert parity");
+
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = 44100;
+    buffer->numChannels = 1;
+    buffer->numFrames = 64;
+    buffer->interleavedData.assign(64, 0.25f);
+    const ClipSourceID sourceId =
+        tracks.getSourceManager().createRecordedSource("unit-routing.wav", "Audio Source", buffer);
+    require(sourceId.isValid(), "Audio source setup failed");
+
+    AudioSlicePayload audioPayload;
+    audioPayload.audioSourceId = sourceId;
+    audioPayload.durationSeconds = buffer->durationSeconds();
+    AudioSlice slice;
+    slice.lengthSamples = static_cast<double>(buffer->numFrames);
+    audioPayload.slices.push_back(slice);
+    const PatternID audioPattern = patternManager.createAudioPattern("Audio Source", 1.0, audioPayload);
+    require(patternManager.setPatternMixerChannel(audioPattern, 77), "Audio source route was not stored");
+
+    ClipInstance audioClip;
+    audioClip.id = ClipInstanceID::generate();
+    audioClip.patternId = audioPattern;
+    audioClip.sourceId = audioPattern.value;
+    audioClip.durationBeats = 1.0;
+    audioClip.durationSeconds = buffer->durationSeconds();
+    playlist.addClip(laneA, audioClip);
+
+    ClipEdits edited = audioClip.edits;
+    edited.gain = 0.5f;
+    edited.gainLinear = 0.5f;
+    edited.pan = -0.25f;
+    edited.fadeInBeats = 0.25f;
+    edited.fadeOutBeats = 0.5f;
+    tracks.getCommandHistory().pushAndExecute(std::make_shared<SetClipEditsCommand>(playlist, audioClip.id, edited));
+
+    auto findTrack = [](AudioGraph& graph, uint32_t id) -> TrackRenderState* {
+        auto it = std::find_if(graph.tracks.begin(), graph.tracks.end(),
+                               [id](const TrackRenderState& state) { return state.trackId == id; });
+        return it == graph.tracks.end() ? nullptr : &*it;
+    };
+
+    auto graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && findTrack(graph, 77)->clips.size() == 1,
+            "Audio source did not reach its explicit mixer insert");
+    require(graph.masterClips.empty(), "Explicitly routed audio source leaked to Master");
+    const auto& renderedEdit = findTrack(graph, 77)->clips.front();
+    require(renderedEdit.gain == 0.5f && renderedEdit.pan == -0.25f,
+            "Clip editor gain/pan did not reach the audio graph");
+    require(renderedEdit.fadeInSamples > 0 && renderedEdit.fadeOutSamples > renderedEdit.fadeInSamples,
+            "Clip editor fades did not reach the audio graph");
+
+    require(tracks.getCommandHistory().undo(), "Clip edit undo was unavailable");
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77)->clips.front().gain == 1.0f && findTrack(graph, 77)->clips.front().fadeInSamples == 0,
+            "Undo did not restore clip instance properties");
+    require(tracks.getCommandHistory().redo(), "Clip edit redo was unavailable");
+
+    auto* alternateDestination = tracks.addChannelWithId("Alternate Insert", 88);
+    require(alternateDestination != nullptr, "Alternate insert setup failed");
+    tracks.getCommandHistory().pushAndExecute(
+        std::make_shared<SetAudioPatternMixerChannelCommand>(tracks, audioPattern, 88));
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 88) && findTrack(graph, 88)->clips.size() == 1,
+            "GUI-equivalent source route command did not reroute linked audio");
+    require(tracks.getCommandHistory().undo(), "Source route undo was unavailable");
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && findTrack(graph, 77)->clips.size() == 1,
+            "Undo did not restore the source mixer destination");
+
+    ClipInstance linkedClip = audioClip;
+    linkedClip.id = ClipInstanceID::generate();
+    linkedClip.startBeat = 2.0;
+    playlist.addClip(laneB, linkedClip);
+    tracks.getCommandHistory().pushAndExecute(std::make_shared<MakeAudioClipUniqueCommand>(tracks, audioClip.id));
+    const auto* uniqueClip = playlist.getClip(audioClip.id);
+    const auto* stillLinkedClip = playlist.getClip(linkedClip.id);
+    require(uniqueClip && stillLinkedClip && uniqueClip->patternId != stillLinkedClip->patternId,
+            "Make unique did not create an independent source identity");
+    const auto uniquePatternId = uniqueClip->patternId;
+    tracks.getCommandHistory().pushAndExecute(
+        std::make_shared<SetAudioPatternMixerChannelCommand>(tracks, uniquePatternId, 88));
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 88) && findTrack(graph, 88)->clips.size() == 1 && findTrack(graph, 77) &&
+                findTrack(graph, 77)->clips.size() == 1,
+            "Unique clip routing changed another linked instance");
+    require(tracks.getCommandHistory().undo(), "Unique source route undo was unavailable");
+    require(tracks.getCommandHistory().undo(), "Make unique undo was unavailable");
+    uniqueClip = playlist.getClip(audioClip.id);
+    stillLinkedClip = playlist.getClip(linkedClip.id);
+    require(uniqueClip && stillLinkedClip && uniqueClip->patternId == stillLinkedClip->patternId,
+            "Make unique undo did not restore the shared source identity");
+    playlist.removeClip(linkedClip.id);
+
+    playlist.moveClip(audioClip.id, 8.0, laneB);
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && findTrack(graph, 77)->clips.size() == 1,
+            "Moving an audio clip between lanes changed its mixer destination");
+
+    auto* mutedLane = playlist.getLane(laneB);
+    require(mutedLane != nullptr, "Moved clip lane disappeared");
+    mutedLane->muted = true;
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && findTrack(graph, 77)->clips.empty(),
+            "Playlist lane mute did not suppress its clip independently");
+    mutedLane->muted = false;
+
+    patternManager.getPattern(audioPattern)->setMixerChannelId(9999);
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(graph.masterClips.size() == 1, "Missing audio destination did not fail safe to Master");
+
+    patternManager.setPatternMixerChannel(audioPattern, 77);
+    require(tracks.removeChannelById(77), "Mixer insert removal failed");
+    require(patternManager.getPattern(audioPattern)->getMixerChannelId() == 0,
+            "Deleting a mixer insert did not reset its audio sources to Master");
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(graph.masterClips.size() == 1, "Source reset after insert deletion was not audible on Master");
+
+    std::cout << "[PASS] UnitMixerRoutingTest\n";
+    return 0;
+}

--- a/Tests/AestraUI/UIInsertRoutePickerTest.cpp
+++ b/Tests/AestraUI/UIInsertRoutePickerTest.cpp
@@ -1,0 +1,64 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+#include "UIInsertRoutePicker.h"
+
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << '\n';
+        ++failures;
+    }
+}
+
+bool equals(const std::vector<uint32_t>& actual, std::initializer_list<uint32_t> expected) {
+    return actual == std::vector<uint32_t>(expected);
+}
+
+} // namespace
+
+int main() {
+    using AestraUI::UIInsertRoutePicker;
+
+    UIInsertRoutePicker picker;
+    picker.setRoutes({{0, 0, "Master", 0}, {11, 1, "Drums", 0}, {42, 12, "Lead Bus", 0}, {99, 120, "Parallel FX", 0}},
+                     42);
+
+    check(picker.getSelectedRoute() == 42, "selection must preserve the stable mixer ID");
+
+    picker.setSearchQuery("drum");
+    check(equals(picker.getFilteredRouteIds(), {11}), "name search must find an Insert");
+
+    picker.setSearchQuery("12");
+    const auto numericMatches = picker.getFilteredRouteIds();
+    check(equals(numericMatches, {42, 99}), "numeric search must retain prefix matches");
+    check(!numericMatches.empty() && numericMatches.front() == 42, "exact Insert number must rank first");
+
+    uint32_t routedId = 0;
+    picker.setOnRouteSelected([&routedId](uint32_t routeId) { routedId = routeId; });
+    check(picker.routeFirstMatch(), "Enter-style first-match routing must succeed");
+    check(routedId == 42 && picker.getSelectedRoute() == 42,
+          "first-match routing must return the stable ID, not the display number");
+
+    picker.setSearchQuery("insert 120");
+    check(equals(picker.getFilteredRouteIds(), {99}), "Insert-prefixed search must normalize correctly");
+
+    picker.setSearchQuery("master");
+    check(equals(picker.getFilteredRouteIds(), {0}), "Master must remain searchable");
+
+    picker.setSearchQuery("not present");
+    check(picker.getFilteredRouteIds().empty(), "unmatched search must not silently choose a route");
+    check(!picker.routeFirstMatch(), "routing an empty result must be rejected");
+
+    if (failures != 0) {
+        std::cout << failures << " Insert route-picker check(s) failed\n";
+        return 1;
+    }
+    std::cout << "All Insert route-picker checks passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1142,7 +1142,13 @@ add_test(NAME AutomationStressTest COMMAND AutomationStressTest)
 # Arsenal Parameter Stress Test (requires runtime plugin system)
 if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins)
     add_executable(ArsenalParameterStressTest AestraAudio/ArsenalParameterStressTest.cpp)
-    target_link_libraries(ArsenalParameterStressTest PRIVATE AestraPremiumPlugins AestraAudioCore)
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(ArsenalParameterStressTest PRIVATE
+            -Wl,--start-group AestraRumble AestraAudioCore -Wl,--end-group
+        )
+    else()
+        target_link_libraries(ArsenalParameterStressTest PRIVATE AestraPremiumPlugins AestraAudioCore)
+    endif()
     target_compile_definitions(ArsenalParameterStressTest PRIVATE AESTRA_HEADLESS)
     if(AESTRA_ENABLE_RUNTIME_TESTS)
         add_test(NAME ArsenalParameterStressTest COMMAND ArsenalParameterStressTest)
@@ -1192,6 +1198,26 @@ target_include_directories(ArsenalProcessingContextRoutingTest PRIVATE
 )
 add_test(NAME ArsenalProcessingContextRoutingTest COMMAND ArsenalProcessingContextRoutingTest)
 set_tests_properties(ArsenalProcessingContextRoutingTest PROPERTIES LABELS "audio;arsenal")
+
+# Stable unit-to-mixer routing and arrangement independence regression test
+add_executable(UnitMixerRoutingTest AestraAudio/UnitMixerRoutingTest.cpp)
+target_link_libraries(UnitMixerRoutingTest PRIVATE AestraAudioCore)
+target_include_directories(UnitMixerRoutingTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME UnitMixerRoutingTest COMMAND UnitMixerRoutingTest)
+set_tests_properties(UnitMixerRoutingTest PROPERTIES LABELS "audio;arsenal;routing")
+
+# Audio clip instance gain, pan, and fade rendering regression test
+add_executable(AudioClipInstanceRenderTest AestraAudio/AudioClipInstanceRenderTest.cpp)
+target_link_libraries(AudioClipInstanceRenderTest PRIVATE AestraAudioCore)
+target_include_directories(AudioClipInstanceRenderTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AudioClipInstanceRenderTest COMMAND AudioClipInstanceRenderTest)
+set_tests_properties(AudioClipInstanceRenderTest PROPERTIES LABELS "audio;routing")
 
 # Arsenal route-mode project round-trip compatibility test
 add_executable(ArsenalRouteModeRoundTripTest
@@ -1941,7 +1967,7 @@ endif()
 # (click-through + spurious dismiss).
 if(TARGET AestraUI_Core)
     add_executable(PanelWindowClickSwallowTest AestraUI/PanelWindowClickSwallowTest.cpp)
-    target_link_libraries(PanelWindowClickSwallowTest PRIVATE AestraUI_Core)
+    target_link_libraries(PanelWindowClickSwallowTest PRIVATE AestraUI_Core AestraUI_Platform)
     target_include_directories(PanelWindowClickSwallowTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraUI
         ${CMAKE_SOURCE_DIR}/AestraUI/Core
@@ -1996,7 +2022,7 @@ endif()
 # than silently selecting whichever row inherits the old numeric index.
 if(TARGET AestraUI_Core)
     add_executable(PluginBrowserSelectionTest AestraUI/PluginBrowserSelectionTest.cpp)
-    target_link_libraries(PluginBrowserSelectionTest PRIVATE AestraUI_Core)
+    target_link_libraries(PluginBrowserSelectionTest PRIVATE AestraUI_Core AestraUI_Platform)
     target_include_directories(PluginBrowserSelectionTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraUI
         ${CMAKE_SOURCE_DIR}/AestraUI/Core

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2034,6 +2034,20 @@ else()
     message(STATUS "PluginBrowserSelectionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+if(TARGET AestraUI_Core)
+    add_executable(UIInsertRoutePickerTest AestraUI/UIInsertRoutePickerTest.cpp)
+    target_link_libraries(UIInsertRoutePickerTest PRIVATE AestraUI_Core AestraPlat)
+    target_include_directories(UIInsertRoutePickerTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+    )
+    add_test(NAME UIInsertRoutePickerTest COMMAND UIInsertRoutePickerTest)
+    set_tests_properties(UIInsertRoutePickerTest PROPERTIES LABELS "ui;routing;regression")
+else()
+    message(STATUS "UIInsertRoutePickerTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # NUITextInput Layout / Caret / Selection regression tests
 # Guard on target presence because headless/CI disables AestraUI targets.
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUITextInputLayoutTest.cpp")

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -51,7 +51,9 @@ void check(bool condition, const std::string& label) {
 
 // Not `near`: that is a legacy Windows macro (minwindef.h), so MSVC rejects a
 // function of that name outright.
-bool almostEqual(float a, float b) { return std::fabs(a - b) < 1e-5f; }
+bool almostEqual(float a, float b) {
+    return std::fabs(a - b) < 1e-5f;
+}
 
 } // namespace
 
@@ -70,6 +72,16 @@ int main() {
     const uint32_t victimId = victim->getChannelId();
     const uint32_t lastId = last->getChannelId();
 
+    // Route both source domains to the doomed Insert. Deletion must fail safe
+    // to Master, while undo must restore the stable destination once the exact
+    // same channel object is back.
+    auto& unitManager = manager.getUnitManager();
+    const auto routedUnit = unitManager.createUnit("Routed Unit", Aestra::Audio::UnitType::Instrument);
+    unitManager.setUnitMixerChannel(routedUnit, victimId);
+    auto& patternManager = manager.getPatternManager();
+    const auto routedAudio = patternManager.createAudioPattern("Routed Audio", 1.0, Aestra::Audio::AudioSlicePayload{});
+    patternManager.setPatternMixerChannel(routedAudio, victimId);
+
     // Give the doomed track state that only lives in the object, so a
     // re-created replacement would be detectably different.
     history.pushAndExecute(std::make_shared<SetVolumeCommand>(*victim, 0.25f));
@@ -82,6 +94,10 @@ int main() {
     check(manager.getChannelCount() == 2, "delete removed the track");
     check(manager.getChannel(1) != nullptr && manager.getChannel(1)->getChannelId() == lastId,
           "the track after it shifted down");
+    check(unitManager.getUnitMixerChannel(routedUnit) == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
+          "delete resets the Unit route to Master");
+    check(patternManager.getPattern(routedAudio)->getMixerChannelId() == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
+          "delete resets the audio-source route to Master");
 
     // --- undo the delete: the SAME channel must come back -------------------
     check(history.undo(), "undo of delete reported success");
@@ -95,9 +111,11 @@ int main() {
         check(restored->getName() == "Victim", "restored with its name");
         check(almostEqual(restored->getVolume(), 0.25f), "restored with its volume, not a default");
         check(almostEqual(restored->getPan(), -0.5f), "restored with its pan, not a default");
-        check(restored == victim,
-              "restored the SAME object, so references held by older commands stay valid");
+        check(restored == victim, "restored the SAME object, so references held by older commands stay valid");
     }
+    check(unitManager.getUnitMixerChannel(routedUnit) == victimId, "undo restores the Unit's stable mixer destination");
+    check(patternManager.getPattern(routedAudio)->getMixerChannelId() == victimId,
+          "undo restores the audio source's stable mixer destination");
     check(manager.getChannel(2) != nullptr && manager.getChannel(2)->getChannelId() == lastId,
           "the track after it moved back down");
 
@@ -116,6 +134,10 @@ int main() {
     check(history.redo() && almostEqual(restored->getPan(), -0.5f), "redo re-applies the pan");
     check(history.redo(), "redo re-applies the delete");
     check(manager.getChannelCount() == 2, "the track is deleted again");
+    check(unitManager.getUnitMixerChannel(routedUnit) == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
+          "redo resets the Unit route to Master again");
+    check(patternManager.getPattern(routedAudio)->getMixerChannelId() == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
+          "redo resets the audio-source route to Master again");
 
     // And a second round trip still restores the same identity, so the fix is
     // not a one-shot that works only until the channel has been detached twice.
@@ -123,6 +145,9 @@ int main() {
     check(manager.getChannelCount() == 3 && manager.getChannel(1) != nullptr &&
               manager.getChannel(1)->getChannelId() == victimId,
           "a second delete/undo round trip preserves the id");
+    check(unitManager.getUnitMixerChannel(routedUnit) == victimId &&
+              patternManager.getPattern(routedAudio)->getMixerChannelId() == victimId,
+          "a second delete/undo round trip restores both source routes");
 
     // --- deleting the last track restores to the end ------------------------
     {
@@ -207,7 +232,6 @@ int main() {
               "the retry restored the same object with its id");
     }
 
-    std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures))
-              << std::endl;
+    std::cout << (g_failures == 0 ? "ALL PASSED" : "FAILURES: " + std::to_string(g_failures)) << std::endl;
     return g_failures == 0 ? 0 : 1;
 }

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -991,8 +991,9 @@ int main() {
               "clip sized from pattern length");
 
         r = call(service, "{\"id\": 113, \"verb\": \"list_units\"}");
-        check(r["result"]["units"][0]["timelineLane"].asNumber() == 0.0,
-              "pattern's unit routed to timeline lane 0");
+        const double mixerChannelBefore = r["result"]["units"][0]["mixerChannelId"].asNumber();
+        check(r["result"]["units"][0]["timelineLane"].asNumber() == -1.0,
+              "arrangement leaves legacy timeline ownership unchanged");
 
         r = call(service, "{\"id\": 114, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
                               p + ", \"track\": 0, \"start\": 8}}");
@@ -1002,21 +1003,24 @@ int main() {
         check(r["result"]["lanes"][0]["clips"][1]["startBeat"].asNumber() == 8.0,
               "second clip starts at the requested beat");
 
-        // Conflict: the pattern's unit is routed to lane 0; arranging it on
-        // another track would silently reroute the clips already placed.
+        // The same pattern may appear on another lane without silently changing
+        // the unit's stable mixer destination.
         r = call(service, "{\"id\": 130, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
                               p + ", \"track\": 1, \"start\": 0}}");
-        check(status(r) == "execution_error",
-              "arrange onto a conflicting track -> execution_error");
+        check(status(r) == "ok", "arrange the same pattern on another lane");
+        r = call(service, "{\"id\": 131, \"verb\": \"list_units\"}");
+        check(r["result"]["units"][0]["mixerChannelId"].asNumber() == mixerChannelBefore,
+              "cross-lane arrangement preserves the mixer destination");
 
-        // Undo unwinds the whole gesture: clip, unit routing, created lane.
+        // Undo unwinds the three arrangement gestures and their created lanes.
+        trackManager->getCommandHistory().undo();
         trackManager->getCommandHistory().undo();
         trackManager->getCommandHistory().undo();
         r = call(service, "{\"id\": 116, \"verb\": \"list_clips\"}");
         check(r["result"]["lanes"].size() == lanesBefore, "undo removes the created lane");
         r = call(service, "{\"id\": 117, \"verb\": \"list_units\"}");
-        check(r["result"]["units"][0]["timelineLane"].asNumber() == -1.0,
-              "undo restores the unit's preview routing");
+        check(r["result"]["units"][0]["mixerChannelId"].asNumber() == mixerChannelBefore,
+              "undo preserves the unit's mixer destination");
 
         // Contract: bad targets never build.
         r = call(service,
@@ -1025,7 +1029,7 @@ int main() {
         check(status(r) == "execution_error", "arrange unknown pattern -> execution_error");
         r = call(service, "{\"id\": 119, \"verb\": \"arrange_pattern\", \"args\": {\"pattern\": " +
                               p + ", \"track\": 99, \"start\": 0}}");
-        check(status(r) == "execution_error", "arrange onto missing channel -> execution_error");
+        check(status(r) == "execution_error", "arrange beyond the next Playlist lane -> execution_error");
     }
 
     // --- Render the arrangement: the song comes back as audio ---

--- a/Tests/Commands/MuseServiceTest.cpp
+++ b/Tests/Commands/MuseServiceTest.cpp
@@ -327,6 +327,17 @@ int main() {
                   r["result"]["notes"][1]["velocity"].asNumber() < 0.61,
               "note expression round-trips");
 
+        Aestra::Audio::AudioSlicePayload audioPayload;
+        const auto audioPattern =
+            trackManager->getPatternManager().createAudioPattern("Audio query", 4.0, audioPayload);
+        trackManager->getPatternManager().setPatternMixerChannel(audioPattern, 73);
+        r = call(service, "{\"id\": 630, \"verb\": \"get_pattern\", \"args\": {\"pattern\": " +
+                              std::to_string(audioPattern.value) + "}}");
+        check(status(r) == "ok" && r["result"]["type"].asString() == "audio",
+              "get_pattern identifies audio patterns");
+        check(r["result"]["mixerChannelId"].asNumber() == 73.0,
+              "get_pattern reports an audio pattern's mixer destination");
+
         // Revision loop: move the second hit, then soften it, then delete it.
         r = call(service, "{\"id\": 64, \"verb\": \"move_note\", \"args\": {\"pattern\": " + p +
                               ", \"unit\": " + u +

--- a/Tests/Headless/AutomationPlaybackTest.cpp
+++ b/Tests/Headless/AutomationPlaybackTest.cpp
@@ -187,8 +187,8 @@ struct Rendered {
     bool hasInvalid = false;
 };
 
-// Builds a one-track project whose lane carries `curves`, sets the playlist
-// BPM to `renderBpm`, and renders `beats` beats of transport playback.
+// Builds a one-insert project whose Playlist-hosted `curves` explicitly target
+// that insert, sets the playlist BPM to `renderBpm`, and renders `beats` beats.
 // An optional extra effect is inserted at chain slot 1 (after the generator).
 Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double renderBpm, double beats,
                               std::shared_ptr<IPluginInstance> slot1Fx = nullptr) {
@@ -209,6 +209,9 @@ Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double
     auto* lane = playlist.getLane(laneId);
     require(lane != nullptr, "getLane failed");
     lane->automationCurves = curves;
+    for (auto& curve : lane->automationCurves) {
+        curve.mixerChannelId = src->getChannelId();
+    }
 
     AudioEngine engine;
     engine.setTrackManager(trackManager);

--- a/Tests/Headless/HardwareMidiInputTest.cpp
+++ b/Tests/Headless/HardwareMidiInputTest.cpp
@@ -118,7 +118,7 @@ int main() {
     UnitID unitId = unitManager.createUnit("HW Sampler", UnitGroup::Synth);
     unitManager.attachPlugin(unitId, "com.Aestrastudios.sampler", sampler);
     unitManager.setUnitEnabled(unitId, true);
-    unitManager.setUnitMixerChannel(unitId, -1);
+    unitManager.setUnitMixerChannel(unitId, MASTER_MIXER_CHANNEL_ID);
     unitManager.captureUnitPluginState(unitId);
 
     AudioEngine engine;

--- a/Tests/Headless/LiveMidiInputTest.cpp
+++ b/Tests/Headless/LiveMidiInputTest.cpp
@@ -81,7 +81,7 @@ int main() {
     UnitID unitId = unitManager.createUnit("Live Sampler", UnitGroup::Synth);
     unitManager.attachPlugin(unitId, "com.Aestrastudios.sampler", sampler);
     unitManager.setUnitEnabled(unitId, true);
-    unitManager.setUnitMixerChannel(unitId, -1); // route directly to master in Arsenal mode
+    unitManager.setUnitMixerChannel(unitId, MASTER_MIXER_CHANNEL_ID); // route directly to master in Arsenal mode
     unitManager.captureUnitPluginState(unitId);
 
     AudioEngine engine;

--- a/Tests/Headless/RumbleArsenalAudibleTest.cpp
+++ b/Tests/Headless/RumbleArsenalAudibleTest.cpp
@@ -74,7 +74,7 @@ int main() {
     UnitID unitId = unitManager.createUnit("Aestra Rumble", UnitGroup::Synth);
     unitManager.attachPlugin(unitId, "com.Aestrastudios.rumble", rumble);
     unitManager.setUnitEnabled(unitId, true);
-    unitManager.setUnitMixerChannel(unitId, -1); // route directly to master in Arsenal mode
+    unitManager.setUnitMixerChannel(unitId, MASTER_MIXER_CHANNEL_ID); // route directly to master in Arsenal mode
     unitManager.captureUnitPluginState(unitId);
 
     PatternID patternId = patternManager.createPattern();

--- a/Tests/Integration/ProjectFixtureCorpusTest.cpp
+++ b/Tests/Integration/ProjectFixtureCorpusTest.cpp
@@ -226,8 +226,8 @@ int main() {
     // ---------------- Migration proof: a re-save must be stamped current (v2).
     auto resave = ProjectSerializer::serialize(tm1, load1.tempo, load1.playhead, 2);
     require(resave.ok, "re-serialize failed");
-    require(resave.contents.find("\"version\": 2") != std::string::npos ||
-                resave.contents.find("\"version\":2") != std::string::npos,
+    require(resave.contents.find("\"version\": 3") != std::string::npos ||
+                resave.contents.find("\"version\":3") != std::string::npos,
             "re-save not stamped with current version (migration did not run)");
 
     // ---------------- The re-save must load with every value intact.

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -583,7 +583,7 @@ void testV1FixtureMigratesToCurrentVersion() {
     assert(std::abs(patterns[0]->getMidiNotes()[0].velocity - 0.75f) < 1e-6f);
 
     std::string saved = ProjectSerializer::serialize(trackManager, result.tempo, result.playhead, 0).contents;
-    assert(saved.find("\"version\": 2") != std::string::npos || saved.find("\"version\":2") != std::string::npos);
+    assert(saved.find("\"version\": 3") != std::string::npos || saved.find("\"version\":3") != std::string::npos);
 
     const Aestra::Tests::ScopedTempDirectory testDirScope{"ProjectLoadRegression"};
     const auto& testDir = testDirScope.path();

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -100,7 +100,7 @@ constexpr uint32_t kWinSkip = 8192;
 /// at native rate; PlaylistModel:428 copies buffer->sampleRate into the snapshot).
 void addAudioTrackAtRate(TrackManager& tm, const std::string& label, const AR::Signal& clip,
                          const GA::SessionConfig& cfg) {
-    tm.addChannel(label);
+    auto* channel = tm.addChannel(label);
 
     auto buffer = std::make_shared<AudioBufferData>();
     buffer->sampleRate = clip.sampleRate;
@@ -119,6 +119,9 @@ void addAudioTrackAtRate(TrackManager& tm, const std::string& label, const AR::S
     PlaylistLaneID laneId = tm.getPlaylistModel().createLane(label);
     const double durationBeats = payload.durationSeconds * (static_cast<double>(cfg.bpm) / 60.0);
     PatternID patternId = tm.getPatternManager().createAudioPattern(label, durationBeats, payload);
+    if (channel) {
+        tm.getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
+    }
     tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
 }
 
@@ -620,7 +623,7 @@ void runIsolatedBounceCase(AR::CheckSession& t, const fs::path& tempRoot) {
     const fs::path outPath = tempRoot / "isolated_bounce.wav";
     std::error_code ec;
     fs::remove(outPath, ec);
-    if (!t.expect("isolated bounce: bounceRangeToWav(trackId=0) succeeds",
+    if (!t.expect("isolated bounce: bounceRangeToWav(track index 0) succeeds",
                   engine.bounceRangeToWav(0.0, durationBeats, outPath.string(), 0))) {
         return;
     }


### PR DESCRIPTION
## Summary

- Separate Playlist lane placement from signal routing: audio sources and units now target stable Mixer Insert IDs, so moving a clip changes arrangement only.
- Add backward-compatible v3 project migration, safe Master fallback, stable Insert deletion/undo restoration, live/export routing, and regression coverage.
- Add a double-click audio clip editor with waveform context, clip gain/pan/fades/mute/reset, Make Unique, and a searchable Insert picker that accepts numbers or names.
- Use Insert terminology throughout Mixer-facing UI and preserve the new Producer-note workflow in the PR template.

## Why

Playlist lanes and Mixer destinations are different user concepts. Coupling them made clip movement silently affect signal flow, made lane and Insert counts depend on each other, and encouraged index-based routing that could rebind incorrectly after deletion. Source-owned stable routing keeps arrangement edits independent while retaining an explicit way to create a separately routable source with Make Unique.

## Testing Performed

- `cmake -S . -B build-linux`
- `cmake --build build-linux -j2`
- Focused routing/rebase integration batch: 13/13 passed, including `DeleteTrackUndoTest`, `UnitMixerRoutingTest`, `AudioClipInstanceRenderTest`, `ArsenalProcessingContextRoutingTest`, `ArsenalRouteModeRoundTripTest`, `PatternPlaybackTempoChangeTest`, `RTAllocationTrapTest`, and `UIInsertRoutePickerTest`
- Full suite: `ctest --test-dir build-linux --output-on-failure -j2` — 202/202 registered tests passed; `SecAccountEndToEndSmoke` was environment-gated and skipped
- Manual desktop smoke with 16 Inserts: double-click editor, numeric search (`14`), name search (`air`), Enter-to-route, and selected-route display verified

## Producer note

Now you can arrange clips freely and route their sources to any Mixer Insert from a searchable audio clip editor.

## Docs Updated?

- [x] Yes — automation policy and PR template
- [ ] No
- [ ] Not needed

## Risk / Rollback Notes

- Project schema advances to v3 with v1/v2 migration coverage. Older builds will not understand projects saved as v3, so rollback should happen before resaving affected projects in the older build.
- Routing IDs are stable and monotonic; missing/deleted destinations fail safe to Master and undo restores the original Insert identity and source routes.
- The rebase conflict resolution preserves the newer monotonic pattern-loop scheduler while processing units through the shared Mixer graph, avoiding duplicate unit rendering.
- No new real-time allocation, lock, logging, file I/O, or blocking path was introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Breaking change:** Playlist lane placement is now independent from mixer routing—clips/automation/units route to **stable Mixer Insert IDs**, so moving clips in the arrangement no longer changes their audio destination. Deleted/missing inserts fail safe to **Master**, while undo/redo restores the original insert identity and source routes.
- Split routing vs placement across the engine and commands: `ArrangePatternCommand` now only places clip lanes (no longer creates/restores unit lane routing), with dedicated routing commands for unit/audio-pattern destinations.
- Introduced **v3 project migration + serialization** to persist mixer channels/inserts separately from playlist lanes, including legacy compatibility/migration and safe fallback when an insert/channel can’t be resolved.
- Updated live/render/export pipelines and Arsenal/graph scheduling to render based on stable mixer destinations (including solo semantics and gain/pan/fade correctness).
- Expanded undoable command coverage:
  - Routing: `SetAudioPatternMixerChannel`, `SetUnitMixerChannel`, `AssignUnitToFirstFreeInsertCommand`
  - Clip editing: `SetClipEditsCommand`, `MakeAudioClipUniqueCommand`
  - Routing identity stability is restored correctly on undo/redo and track/inserts deletion/restore.
- UI/terminology overhaul: mixer destination UI now consistently uses **“Insert”** wording; mixer strips/inspector/route map labels updated to match the new model.
- Added **Audio Clip Editor** panel (double-click workflow) with waveform context and routed output selection via a searchable **Insert picker** (supports numeric and name searches + Master). Edits commit through the undoable command flow (including fades/gain/pan/mute/reset and Make Unique).
- Added regression coverage for the new routing model and UI behavior, including new tests for Insert picker selection/search, unit mixer routing persistence/migration, clip instance rendering (fade/pan/gain), and routing stability through undo scenarios (notably track deletion).
- CI/testing hardening: routing-focused tests were adjusted to avoid Windows stack overflow, and command history handling was hardened (first-free behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->