### PR TITLE
Expand audio clip routing and mixer workflows

### DIFF
--- a/AestraAudio/include/Commands/MuseStubs.h
+++ b/AestraAudio/include/Commands/MuseStubs.h
@@ -70,6 +70,12 @@ private:
     uint32_t m_deletedId = 0;
     std::vector<UnitID> m_routedUnits;
     std::vector<PatternID> m_routedAudioPatterns;
+    struct MixerRouteSnapshot {
+        uint32_t sourceChannelId{0};
+        uint32_t mainOutputId{0xFFFFFFFFu};
+        std::vector<AudioRoute> sends;
+    };
+    std::vector<MixerRouteSnapshot> m_mixerRoutes;
     bool m_routesCaptured = false;
     bool m_executed = false;
     /**

--- a/AestraAudio/include/Core/AudioCommandQueue.h
+++ b/AestraAudio/include/Core/AudioCommandQueue.h
@@ -18,10 +18,10 @@ namespace Audio {
 enum class AudioQueueCommandType : uint8_t {
     None = 0,
     SetTransportState, // value1: 1.0 = play, 0.0 = stop; samplePos used for seek
-    SetTrackVolume,    // trackIndex, value1
-    SetTrackPan,       // trackIndex, value1 (-1..1)
-    SetTrackMute,      // trackIndex, value1 (0/1)
-    SetTrackSolo,      // trackIndex, value1 (0/1)
+    SetTrackVolume,    // channelId (preferred) or trackIndex, value1
+    SetTrackPan,       // channelId (preferred) or trackIndex, value1 (-1..1)
+    SetTrackMute,      // channelId (preferred) or trackIndex, value1 (0/1)
+    SetTrackSolo,      // channelId (preferred) or trackIndex, value1 (0/1)
     LoadProjectState,
     UpdateClipState,
     StartPreview,
@@ -50,6 +50,7 @@ struct alignas(32) AudioQueueCommand {
     float value1{0.0f};       // Generic value (gain/pan/mute flag/etc.)
     float value2{0.0f};       // Optional secondary value
     uint64_t samplePos{0};    // For seeks / absolute positions
+    uint32_t channelId{0};    // Stable mixer channel ID; translated through ChannelSlotMap
     uint32_t payloadIndex{0}; // Optional external payload reference
 };
 

--- a/AestraAudio/include/Core/AudioGraph.h
+++ b/AestraAudio/include/Core/AudioGraph.h
@@ -33,6 +33,7 @@ struct ClipRenderState {
     uint32_t channels{2};                      // Source channels (1=mono, 2=stereo)
     float gain{1.0f};
     float pan{0.0f};
+    float playbackRate{1.0f};
     uint64_t fadeInSamples{0};
     uint64_t fadeOutSamples{0};
 };

--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -233,6 +233,8 @@ public:
     std::vector<AudioRoute> getSends() const;
     /** @brief Add a send route. */
     void addSend(const AudioRoute& route);
+    /** @brief Replace all send routes from an off-audio-thread snapshot. */
+    void replaceSends(const std::vector<AudioRoute>& routes);
     /** @brief Remove a send route by index. */
     void removeSend(int index);
     /** @brief Update send level by index. */

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -11,6 +11,10 @@
 namespace Aestra {
 namespace Audio {
 
+/** New audio clips start below unity to preserve useful summing headroom. */
+constexpr float DEFAULT_AUDIO_CLIP_GAIN_DB = -5.0f;
+constexpr float DEFAULT_AUDIO_CLIP_GAIN_LINEAR = 0.56234133f;
+
 /**
  * @brief Unique identifier for a clip instance
  */
@@ -64,6 +68,18 @@ struct ClipEdits {
     bool muted = false;
     float playbackRate = 1.0f;
     double sourceStart = 0.0;
+
+    /**
+     * Defaults for a newly created audio clip. The value-initialized defaults
+     * above intentionally remain unity for legacy project fields and generic
+     * clip construction, so loading an older project cannot change its mix.
+     */
+    static ClipEdits forNewAudioClip() {
+        ClipEdits edits;
+        edits.gain = DEFAULT_AUDIO_CLIP_GAIN_LINEAR;
+        edits.gainLinear = DEFAULT_AUDIO_CLIP_GAIN_LINEAR;
+        return edits;
+    }
 };
 
 /**

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -463,6 +464,18 @@ public:
         snapshot->projectSampleRate = m_projectSampleRate;
 
         const double samplesPerBeat = (m_projectSampleRate * 60.0) / snapshot->bpm;
+        constexpr uint64_t kMaxSampleOffset = std::numeric_limits<uint64_t>::max();
+        const auto toSampleOffset = [](double offset, double scale) -> uint64_t {
+            if (!std::isfinite(offset) || offset <= 0.0 || !std::isfinite(scale) || scale <= 0.0) {
+                return 0;
+            }
+
+            const long double scaled = static_cast<long double>(offset) * static_cast<long double>(scale);
+            if (scaled >= static_cast<long double>(kMaxSampleOffset)) {
+                return kMaxSampleOffset;
+            }
+            return static_cast<uint64_t>(scaled);
+        };
 
         const bool anyLaneSolo = std::any_of(m_lanes.begin(), m_lanes.end(),
                                              [](const PlaylistLane& lane) { return lane.solo && !lane.muted; });
@@ -477,12 +490,13 @@ public:
                 ClipRuntimeInfo clipInfo;
                 clipInfo.startTime = static_cast<uint64_t>(clip.startBeat * samplesPerBeat);
                 clipInfo.duration = static_cast<uint64_t>(clip.durationBeats * samplesPerBeat);
-                const double canonicalSourceStart = clip.durationSeconds > 0.0
-                                                        ? std::max(0.0, clip.sourceOffsetSeconds) * m_projectSampleRate
-                                                        : std::max(0.0, clip.sourceOffset) * samplesPerBeat;
-                const double instanceSourceStart =
-                    std::isfinite(clip.edits.sourceStart) ? std::max(0.0, clip.edits.sourceStart) : 0.0;
-                clipInfo.sourceStart = static_cast<uint64_t>(canonicalSourceStart + instanceSourceStart);
+                const uint64_t canonicalSourceStart =
+                    clip.durationSeconds > 0.0 ? toSampleOffset(clip.sourceOffsetSeconds, m_projectSampleRate)
+                                               : toSampleOffset(clip.sourceOffset, samplesPerBeat);
+                const uint64_t instanceSourceStart = toSampleOffset(clip.edits.sourceStart, 1.0);
+                clipInfo.sourceStart = instanceSourceStart > kMaxSampleOffset - canonicalSourceStart
+                                           ? kMaxSampleOffset
+                                           : canonicalSourceStart + instanceSourceStart;
                 clipInfo.gainLinear = std::isfinite(clip.edits.gainLinear) ? clip.edits.gainLinear : 1.0f;
                 clipInfo.pan =
                     std::isfinite(clip.edits.pan) ? std::clamp(clip.edits.pan, -1.0f, 1.0f) : 0.0f;

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -477,10 +477,17 @@ public:
                 ClipRuntimeInfo clipInfo;
                 clipInfo.startTime = static_cast<uint64_t>(clip.startBeat * samplesPerBeat);
                 clipInfo.duration = static_cast<uint64_t>(clip.durationBeats * samplesPerBeat);
-                clipInfo.sourceStart = static_cast<uint64_t>(clip.sourceOffset * samplesPerBeat);
+                const double canonicalSourceStart = clip.durationSeconds > 0.0
+                                                        ? std::max(0.0, clip.sourceOffsetSeconds) * m_projectSampleRate
+                                                        : std::max(0.0, clip.sourceOffset) * samplesPerBeat;
+                const double instanceSourceStart =
+                    std::isfinite(clip.edits.sourceStart) ? std::max(0.0, clip.edits.sourceStart) : 0.0;
+                clipInfo.sourceStart = static_cast<uint64_t>(canonicalSourceStart + instanceSourceStart);
                 clipInfo.gainLinear = std::isfinite(clip.edits.gainLinear) ? clip.edits.gainLinear : 1.0f;
                 clipInfo.pan =
                     std::isfinite(clip.edits.pan) ? std::clamp(clip.edits.pan, -1.0f, 1.0f) : 0.0f;
+                clipInfo.playbackRate =
+                    std::isfinite(clip.edits.playbackRate) ? std::clamp(clip.edits.playbackRate, 0.25f, 4.0f) : 1.0f;
                 const double fadeInBeats =
                     std::isfinite(clip.edits.fadeInBeats) ? std::max(0.0, static_cast<double>(clip.edits.fadeInBeats))
                                                          : 0.0;
@@ -655,6 +662,7 @@ public:
         if (m_patternManager) {
             const auto* pattern = m_patternManager->getPattern(patternId);
             if (pattern && pattern->isAudio()) {
+                clip.edits = ClipEdits::forNewAudioClip();
                 const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
                 if (payload.durationSeconds > 0.0) {
                     clip.durationSeconds = payload.durationSeconds;

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -466,13 +466,14 @@ public:
         const double samplesPerBeat = (m_projectSampleRate * 60.0) / snapshot->bpm;
         constexpr uint64_t kMaxSampleOffset = std::numeric_limits<uint64_t>::max();
         const auto toSampleOffset = [](double offset, double scale) -> uint64_t {
+            constexpr uint64_t kMaxOffset = std::numeric_limits<uint64_t>::max();
             if (!std::isfinite(offset) || offset <= 0.0 || !std::isfinite(scale) || scale <= 0.0) {
                 return 0;
             }
 
             const long double scaled = static_cast<long double>(offset) * static_cast<long double>(scale);
-            if (scaled >= static_cast<long double>(kMaxSampleOffset)) {
-                return kMaxSampleOffset;
+            if (scaled >= static_cast<long double>(kMaxOffset)) {
+                return kMaxOffset;
             }
             return static_cast<uint64_t>(scaled);
         };

--- a/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
+++ b/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
@@ -34,6 +34,7 @@ struct ClipRuntimeInfo {
     // Parameters
     float gainLinear{1.0f};
     float pan{0.0f};
+    float playbackRate{1.0f};
     uint64_t fadeInSamples{0};
     uint64_t fadeOutSamples{0};
     /** Stable source-level mixer destination (0 routes directly to Master). */

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -174,6 +174,7 @@ public:
         m_unitManager.resetMixerChannel(removedChannelId);
         m_patternManager.resetMixerChannel(removedChannelId);
         m_channels.pop_back();
+        resetMixerRoutingDestination(removedChannelId);
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         m_modified.store(true, std::memory_order_relaxed);
         if (m_channelSlotMap) {
@@ -194,6 +195,7 @@ public:
         m_unitManager.resetMixerChannel(channelId);
         m_patternManager.resetMixerChannel(channelId);
         m_channels.erase(it);
+        resetMixerRoutingDestination(channelId);
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         m_modified.store(true, std::memory_order_relaxed);
         if (m_channelSlotMap) {
@@ -201,6 +203,28 @@ public:
         }
         publishInputMonitoringSnapshot();
         return true;
+    }
+
+    /**
+     * Fail safe after a mixer insert disappears. Main paths fall back to
+     * Master; auxiliary/control routes to the missing destination are removed.
+     * Undoable deletion commands snapshot and restore these routes separately.
+     */
+    void resetMixerRoutingDestination(uint32_t removedChannelId) {
+        for (auto& channel : m_channels) {
+            if (!channel)
+                continue;
+            if (channel->getMainOutputId() == removedChannelId) {
+                channel->setMainOutputId(0xFFFFFFFFu);
+            }
+            auto sends = channel->getSends();
+            sends.erase(std::remove_if(sends.begin(), sends.end(),
+                                       [removedChannelId](const AudioRoute& route) {
+                                           return route.targetChannelId == removedChannelId;
+                                       }),
+                        sends.end());
+            channel->replaceSends(sends);
+        }
     }
 
     /**

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -27,7 +27,7 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
     uint32_t maxTrackId = 0;
     for (const auto& track : graph.tracks) {
         maxTrackId = std::max(maxTrackId, track.trackId);
-        graph.anySolo = graph.anySolo || track.solo;
+        graph.anySolo = graph.anySolo || (track.solo && !track.mute);
     }
 
     graph.trackIndexById.assign(static_cast<size_t>(maxTrackId) + 1, AudioGraph::kInvalidTrackIndex);
@@ -145,7 +145,7 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
         trackState.pan = channel->getPan();
         trackState.mute = channel->isMuted();
         trackState.solo = channel->isSoloed();
-        if (trackState.solo)
+        if (trackState.solo && !trackState.mute)
             anySoloFound = true;
         trackState.isSoloSafe = channel->isSoloSafe();
 
@@ -206,6 +206,7 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
 
                 clip.gain = clipInfo.gainLinear;
                 clip.pan = clipInfo.pan;
+                clip.playbackRate = clipInfo.playbackRate;
                 clip.fadeInSamples = clipInfo.fadeInSamples;
                 clip.fadeOutSamples = clipInfo.fadeOutSamples;
 

--- a/AestraAudio/src/Commands/MuseStubs.cpp
+++ b/AestraAudio/src/Commands/MuseStubs.cpp
@@ -1,5 +1,6 @@
 #include "Commands/MuseStubs.h"
 
+#include <algorithm>
 #include <string>
 
 namespace Aestra {
@@ -119,6 +120,18 @@ void DeleteTrackCommand::execute() {
                 m_routedAudioPatterns.push_back(pattern->id);
             }
         }
+        for (const auto& channel : m_manager.getChannelsSnapshot()) {
+            if (!channel || channel->getChannelId() == m_deletedId)
+                continue;
+            const auto sends = channel->getSends();
+            const bool routesToDeleted = channel->getMainOutputId() == m_deletedId ||
+                                         std::any_of(sends.begin(), sends.end(), [this](const AudioRoute& route) {
+                                             return route.targetChannelId == m_deletedId;
+                                         });
+            if (routesToDeleted) {
+                m_mixerRoutes.push_back({channel->getChannelId(), channel->getMainOutputId(), sends});
+            }
+        }
         m_routesCaptured = true;
     }
 
@@ -130,6 +143,7 @@ void DeleteTrackCommand::execute() {
     if (m_detached) {
         m_manager.getUnitManager().resetMixerChannel(m_deletedId);
         m_manager.getPatternManager().resetMixerChannel(m_deletedId);
+        m_manager.resetMixerRoutingDestination(m_deletedId);
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = true;
     }
@@ -146,6 +160,12 @@ void DeleteTrackCommand::undo() {
         for (PatternID patternId : m_routedAudioPatterns) {
             m_manager.getPatternManager().setPatternMixerChannel(patternId, m_deletedId);
         }
+        for (const auto& routeSnapshot : m_mixerRoutes) {
+            if (auto* channel = m_manager.getChannelById(routeSnapshot.sourceChannelId)) {
+                channel->setMainOutputId(routeSnapshot.mainOutputId);
+                channel->replaceSends(routeSnapshot.sends);
+            }
+        }
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = false;
     }
@@ -159,6 +179,7 @@ void DeleteTrackCommand::redo() {
     if (m_detached) {
         m_manager.getUnitManager().resetMixerChannel(m_deletedId);
         m_manager.getPatternManager().resetMixerChannel(m_deletedId);
+        m_manager.resetMixerRoutingDestination(m_deletedId);
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         m_executed = true;
     }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -211,6 +211,17 @@ void AudioEngine::applyPendingCommands() {
     bool sawRestartEdge = false;
     bool sawStopEdge = false;
     bool sawHardStopEdge = false;
+    const auto resolveTrackIndex = [this](const AudioQueueCommand& command) {
+        if (command.channelId == 0) {
+            return command.trackIndex;
+        }
+        if (auto* slotMap = m_channelSlotMapRaw.load(std::memory_order_acquire)) {
+            return slotMap->getSlotIndex(command.channelId);
+        }
+        // Compatibility for standalone engines without a slot map. Production
+        // paths always install one; contiguous IDs preserve the legacy result.
+        return command.channelId - 1;
+    };
 
     while (cmdCount < 16 && m_commandQueue.pop(cmd)) {
         ++cmdCount;
@@ -253,7 +264,10 @@ void AudioEngine::applyPendingCommands() {
             setMetronomeEnabled(static_cast<bool>(cmd.value1));
             break;
         case AudioQueueCommandType::SetTrackVolume: {
-            auto& state = ensureTrackState(cmd.trackIndex);
+            const uint32_t trackIndex = resolveTrackIndex(cmd);
+            if (trackIndex == ChannelSlotMap::INVALID_SLOT)
+                break;
+            auto& state = ensureTrackState(trackIndex);
             state.currentVolume = cmd.value1;
 
             // Recalculate Targets using FastMath
@@ -266,7 +280,10 @@ void AudioEngine::applyPendingCommands() {
             break;
         }
         case AudioQueueCommandType::SetTrackPan: {
-            auto& state = ensureTrackState(cmd.trackIndex);
+            const uint32_t trackIndex = resolveTrackIndex(cmd);
+            if (trackIndex == ChannelSlotMap::INVALID_SLOT)
+                break;
+            auto& state = ensureTrackState(trackIndex);
             state.currentPan = cmd.value1;
 
             // Recalculate Targets using FastMath
@@ -279,12 +296,18 @@ void AudioEngine::applyPendingCommands() {
             break;
         }
         case AudioQueueCommandType::SetTrackMute: {
-            auto& state = ensureTrackState(cmd.trackIndex);
+            const uint32_t trackIndex = resolveTrackIndex(cmd);
+            if (trackIndex == ChannelSlotMap::INVALID_SLOT)
+                break;
+            auto& state = ensureTrackState(trackIndex);
             state.mute = (cmd.value1 != 0.0f);
             break;
         }
         case AudioQueueCommandType::SetTrackSolo: {
-            auto& state = ensureTrackState(cmd.trackIndex);
+            const uint32_t trackIndex = resolveTrackIndex(cmd);
+            if (trackIndex == ChannelSlotMap::INVALID_SLOT)
+                break;
+            auto& state = ensureTrackState(trackIndex);
             state.solo = (cmd.value1 != 0.0f);
             break;
         }
@@ -1973,7 +1996,7 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
 
     // Solo state can still change through RT track state, while routing topology
     // is compiled into AudioGraph before publication.
-    bool anySolo = graph.anySolo;
+    bool anySolo = false;
     const size_t numTracks = graph.tracks.size();
     std::fill(m_rtAudibleEligible.begin(), m_rtAudibleEligible.begin() + availableTracks, false);
     std::fill(m_rtProcessActive.begin(), m_rtProcessActive.begin() + availableTracks, false);
@@ -1981,7 +2004,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     for (size_t i = 0; i < graph.tracks.size(); ++i) {
         const auto& tr = graph.tracks[i];
         auto& state = ensureTrackState(tr.trackIndex);
-        if (tr.solo || state.solo) {
+        const bool muted = tr.mute || state.mute;
+        if ((tr.solo || state.solo) && !muted) {
             anySolo = true;
         }
     }
@@ -1996,7 +2020,8 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
         for (size_t i = 0; i < graph.tracks.size(); ++i) {
             const auto& tr = graph.tracks[i];
             auto& state = ensureTrackState(tr.trackIndex);
-            const bool soloed = tr.solo || state.solo;
+            const bool muted = tr.mute || state.mute;
+            const bool soloed = (tr.solo || state.solo) && !muted;
             const bool soloSafe = tr.isSoloSafe || state.soloSafe;
             if (!soloed && !soloSafe) {
                 continue;
@@ -2233,7 +2258,9 @@ void AudioEngine::renderClips(const std::vector<ClipRenderState>& clips, double*
             // Sample rate ratio
             const double outputRate = static_cast<double>(cachedSampleRate);
             const double srcRate = clip.sourceSampleRate > 0.0 ? clip.sourceSampleRate : outputRate;
-            const double ratio = srcRate / outputRate;
+            const double playbackRate =
+                std::isfinite(clip.playbackRate) ? clampD(static_cast<double>(clip.playbackRate), 0.25, 4.0) : 1.0;
+            const double ratio = (srcRate / outputRate) * playbackRate;
 
             // Source position
             const double outputFrameOffset = static_cast<double>(start - clip.startSample);

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -40,7 +40,7 @@ void MixerChannel::setVolume(float volume) {
     if (m_commandSink && m_channelId > 0 && std::abs(previous - volume) > 0.0001f) {
         AudioQueueCommand cmd{};
         cmd.type = AudioQueueCommandType::SetTrackVolume;
-        cmd.trackIndex = m_channelId - 1;
+        cmd.channelId = m_channelId;
         cmd.value1 = volume;
         m_commandSink(cmd);
     }
@@ -53,7 +53,7 @@ void MixerChannel::setPan(float pan) {
     if (m_commandSink && m_channelId > 0 && std::abs(previous - pan) > 0.0001f) {
         AudioQueueCommand cmd{};
         cmd.type = AudioQueueCommandType::SetTrackPan;
-        cmd.trackIndex = m_channelId - 1;
+        cmd.channelId = m_channelId;
         cmd.value1 = pan;
         m_commandSink(cmd);
     }
@@ -72,7 +72,7 @@ void MixerChannel::setMute(bool mute) {
     if (m_commandSink && m_channelId > 0 && previous != mute) {
         AudioQueueCommand cmd{};
         cmd.type = AudioQueueCommandType::SetTrackMute;
-        cmd.trackIndex = m_channelId - 1;
+        cmd.channelId = m_channelId;
         cmd.value1 = mute ? 1.0f : 0.0f;
         m_commandSink(cmd);
     }
@@ -85,7 +85,7 @@ void MixerChannel::setSolo(bool solo) {
     if (m_commandSink && m_channelId > 0 && previous != solo) {
         AudioQueueCommand cmd{};
         cmd.type = AudioQueueCommandType::SetTrackSolo;
-        cmd.trackIndex = m_channelId - 1;
+        cmd.channelId = m_channelId;
         cmd.value1 = solo ? 1.0f : 0.0f;
         m_commandSink(cmd);
     }
@@ -171,7 +171,22 @@ std::vector<AudioRoute> MixerChannel::getSends() const {
 
 void MixerChannel::addSend(const AudioRoute& route) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
-    m_sends.push_back(route);
+    AudioRoute sanitized = route;
+    sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
+    sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+    m_sends.push_back(sanitized);
+}
+
+void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
+    std::lock_guard<std::mutex> lock(m_sendMutex);
+    m_sends.clear();
+    m_sends.reserve(routes.size());
+    for (const auto& route : routes) {
+        AudioRoute sanitized = route;
+        sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
+        sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+        m_sends.push_back(sanitized);
+    }
 }
 
 void MixerChannel::removeSend(int index) {
@@ -184,14 +199,14 @@ void MixerChannel::removeSend(int index) {
 void MixerChannel::setSendLevel(int index, float level) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
     if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].gain = level;
+        m_sends[index].gain = std::isfinite(level) ? std::clamp(level, 0.0f, 4.0f) : 0.0f;
     }
 }
 
 void MixerChannel::setSendPan(int index, float pan) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
     if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].pan = pan;
+        m_sends[index].pan = std::isfinite(pan) ? std::clamp(pan, -1.0f, 1.0f) : 0.0f;
     }
 }
 

--- a/AestraUI/Core/NUIDragDrop.h
+++ b/AestraUI/Core/NUIDragDrop.h
@@ -21,6 +21,7 @@ enum class DragDataType {
     MidiClip,       // MIDI clip being moved
     Pattern,        // Pattern from browser (to timeline)
     Plugin,         // Plugin from browser
+    AudioSourceRoute, // Audio-pattern source being routed to a mixer insert
     Custom          // User-defined data
 };
 

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -736,18 +736,27 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         m_maxScrollOffset = std::max(0.0f, addButtonY + ROW_H - contentRect.bottom());
         clampScrollOffsets();
 
-        // "Add Send" button
-        m_addFxRect = NUIRect{contentRect.x, addButtonY, contentRect.width, ROW_H};
+        // Parallel audio sends start conservatively, while sidechains are
+        // control-only and start at unity detector level.
+        const float actionGap = 6.0f;
+        const float actionWidth = (contentRect.width - actionGap) * 0.5f;
+        m_addFxRect = NUIRect{contentRect.x, addButtonY, actionWidth, ROW_H};
+        m_addSidechainRect = NUIRect{contentRect.x + actionWidth + actionGap, addButtonY, actionWidth, ROW_H};
         
         NUIColor addBg = m_addPressed ? m_addHover : (m_addHovered ? m_addHover : m_addBg);
         renderer.fillRoundedRect(m_addFxRect, ROW_RADIUS, addBg);
         renderer.strokeRoundedRect(m_addFxRect, ROW_RADIUS, 1.0f, m_border);
         renderer.drawTextCentered("Add Send", m_addFxRect, 11.0f, m_addText);
+        NUIColor sidechainBg = m_addSidechainPressed ? m_addHover : (m_addSidechainHovered ? m_addHover : m_addBg);
+        renderer.fillRoundedRect(m_addSidechainRect, ROW_RADIUS, sidechainBg);
+        renderer.strokeRoundedRect(m_addSidechainRect, ROW_RADIUS, 1.0f, m_border);
+        renderer.drawTextCentered("Add Sidechain", m_addSidechainRect, 11.0f, m_addText);
 
     } else {
         // I/O Tab or Inserts
         // Clear the add rect so it doesn't capture clicks in other tabs
         m_addFxRect = NUIRect{0,0,0,0};
+        m_addSidechainRect = NUIRect{0,0,0,0};
         
         bool isMaster = (channel && channel->id == 0);
         if (isMaster) {
@@ -996,8 +1005,14 @@ bool UIMixerInspector::onMouseEvent(const NUIMouseEvent& event)
 
     if (event.button == NUIMouseButton::None) {
         const bool addHover = (m_viewModel && m_viewModel->getSelectedChannel()) && m_addFxRect.contains(event.position);
+        const bool sidechainHover =
+            (m_viewModel && m_viewModel->getSelectedChannel()) && m_addSidechainRect.contains(event.position);
         if (addHover != m_addHovered) {
             m_addHovered = addHover;
+            repaint();
+        }
+        if (sidechainHover != m_addSidechainHovered) {
+            m_addSidechainHovered = sidechainHover;
             repaint();
         }
         // Consume hover if inside bounds to prevent hover-through to components behind
@@ -1007,6 +1022,12 @@ bool UIMixerInspector::onMouseEvent(const NUIMouseEvent& event)
     if (event.pressed && event.button == NUIMouseButton::Left) {
         if (m_activeTab == Tab::Sends && (m_viewModel && m_viewModel->getSelectedChannel()) && m_addFxRect.contains(event.position)) {
             m_addPressed = true;
+            repaint();
+            return true;
+        }
+        if (m_activeTab == Tab::Sends && (m_viewModel && m_viewModel->getSelectedChannel()) &&
+            m_addSidechainRect.contains(event.position)) {
+            m_addSidechainPressed = true;
             repaint();
             return true;
         }
@@ -1026,6 +1047,16 @@ bool UIMixerInspector::onMouseEvent(const NUIMouseEvent& event)
                     rebuildSendWidgets(m_viewModel->getSelectedChannel());
                     repaint();
                 }
+            }
+            return true;
+        }
+        if (m_addSidechainPressed) {
+            m_addSidechainPressed = false;
+            repaint();
+            if (m_activeTab == Tab::Sends && m_viewModel && m_viewModel->getSelectedChannel()) {
+                m_viewModel->addSidechain(m_viewModel->getSelectedChannel()->id);
+                rebuildSendWidgets(m_viewModel->getSelectedChannel());
+                repaint();
             }
             return true;
         }

--- a/AestraUI/Widgets/UIMixerInspector.h
+++ b/AestraUI/Widgets/UIMixerInspector.h
@@ -67,10 +67,13 @@ private:
     // Hit rectangles
     NUIRect m_tabRects[3]{};
     NUIRect m_addFxRect{};
+    NUIRect m_addSidechainRect{};
 
     int m_hoveredTab{-1};
     bool m_addHovered{false};
     bool m_addPressed{false};
+    bool m_addSidechainHovered{false};
+    bool m_addSidechainPressed{false};
 
     // Inserts
     std::shared_ptr<EffectChainRack> m_effectRack;

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -14,6 +14,7 @@
 #include "TrackManager.h"
 #include "PluginManager.h"
 #include "Commands/PluginCommands.h"
+#include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Plugin/EffectChain.h"
 #include "Plugin/AestraDelay.h"
 #include <algorithm>
@@ -149,10 +150,9 @@ void UIMixerPanel::refreshChannels()
 
         // Wire fader to CommandHistory for undo/redo
         uint32_t chId = channel->id;
-        int slotIdx = channel->slotIndex;
-        strip->onFaderChanged = [this, chId, slotIdx](float newDb) {
+        strip->onFaderChanged = [this, chId](float newDb) {
             if (!m_trackManager) return;
-            auto* mixerChannel = m_trackManager->getChannel(static_cast<size_t>(slotIdx));
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
             if (!mixerChannel) return;
 
             // Convert dB to linear gain
@@ -167,9 +167,9 @@ void UIMixerPanel::refreshChannels()
         };
 
         // Wire mute to CommandHistory for undo/redo
-        strip->onMuteChanged = [this, slotIdx](bool muted) {
+        strip->onMuteChanged = [this, chId](bool muted) {
             if (!m_trackManager) return;
-            auto* mixerChannel = m_trackManager->getChannel(static_cast<size_t>(slotIdx));
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
@@ -177,9 +177,9 @@ void UIMixerPanel::refreshChannels()
         };
 
         // Wire solo to CommandHistory for undo/redo
-        strip->onSoloChanged = [this, slotIdx](bool soloed) {
+        strip->onSoloChanged = [this, chId](bool soloed) {
             if (!m_trackManager) return;
-            auto* mixerChannel = m_trackManager->getChannel(static_cast<size_t>(slotIdx));
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
@@ -187,9 +187,9 @@ void UIMixerPanel::refreshChannels()
         };
 
         // Wire pan to CommandHistory for undo/redo
-        strip->onPanChanged = [this, slotIdx](float pan) {
+        strip->onPanChanged = [this, chId](float pan) {
             if (!m_trackManager) return;
-            auto* mixerChannel = m_trackManager->getChannel(static_cast<size_t>(slotIdx));
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
@@ -733,7 +733,7 @@ DropFeedback UIMixerPanel::onDragEnter(const DragData& data, const NUIPoint& pos
 
 DropFeedback UIMixerPanel::onDragOver(const DragData& data, const NUIPoint& position) {
     m_dropHoverChannelId = -1;
-    if (data.type != DragDataType::Plugin) {
+    if (data.type != DragDataType::Plugin && data.type != DragDataType::AudioSourceRoute) {
         return DropFeedback::Invalid;
     }
     auto* strip = stripAt(position);
@@ -741,7 +741,7 @@ DropFeedback UIMixerPanel::onDragOver(const DragData& data, const NUIPoint& posi
         return DropFeedback::Invalid;
     }
     m_dropHoverChannelId = static_cast<int64_t>(strip->getChannelId());
-    return DropFeedback::Copy;
+    return data.type == DragDataType::AudioSourceRoute ? DropFeedback::Move : DropFeedback::Copy;
 }
 
 void UIMixerPanel::onDragLeave() {
@@ -755,9 +755,9 @@ DropResult UIMixerPanel::onDrop(const DragData& data, const NUIPoint& position) 
     // The mixer claims every drop over its bounds, including ones it rejects:
     // letting a rejected drop fall through to the timeline behind the mixer is
     // exactly the misrouting this target exists to prevent (#395).
-    if (data.type != DragDataType::Plugin) {
+    if (data.type != DragDataType::Plugin && data.type != DragDataType::AudioSourceRoute) {
         result.accepted = false;
-        result.message = "Only plugins can be dropped on the mixer";
+        result.message = "Only plugins and audio-source routes can be dropped on the mixer";
         return result;
     }
 
@@ -766,6 +766,41 @@ DropResult UIMixerPanel::onDrop(const DragData& data, const NUIPoint& position) 
     if (!strip || !vmChannel) {
         result.accepted = false;
         result.message = "No mixer strip under drop";
+        return result;
+    }
+
+    if (data.type == DragDataType::AudioSourceRoute) {
+        const auto* patternValue = std::any_cast<uint64_t>(&data.customData);
+        if (!patternValue || *patternValue == 0 || !m_trackManager) {
+            result.accepted = false;
+            result.message = "Drag data missing audio source";
+            return result;
+        }
+
+        const Aestra::Audio::PatternID patternId(*patternValue);
+        const auto* pattern = m_trackManager->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isAudio()) {
+            result.accepted = false;
+            result.message = "Audio source is no longer available";
+            return result;
+        }
+
+        const uint32_t destinationId =
+            vmChannel->id == 0 ? Aestra::Audio::MASTER_MIXER_CHANNEL_ID : vmChannel->id;
+        if (pattern->getMixerChannelId() != destinationId) {
+            auto command = std::make_shared<Aestra::Audio::SetAudioPatternMixerChannelCommand>(
+                *m_trackManager, patternId, destinationId);
+            m_trackManager->getCommandHistory().pushAndExecute(command);
+        }
+        if (m_viewModel) {
+            m_viewModel->setSelectedChannelId(static_cast<int32_t>(vmChannel->id));
+        }
+
+        result.accepted = true;
+        result.targetTrackIndex = static_cast<int>(vmChannel->id);
+        result.message = "Routed " + (data.displayName.empty() ? pattern->name : data.displayName) + " to " +
+                         (vmChannel->id == 0 ? "Master" : vmChannel->name);
+        Aestra::Log::info("[UIMixerPanel] Audio source drop: " + result.message);
         return result;
     }
 

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -275,13 +275,6 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
         channel->muted = muted;
         invalidateStaticCache();
 
-        if (auto mc = channel->channel) {
-            if (muted && mc->isSoloed()) {
-                mc->setSolo(false);
-                channel->soloed = false;
-            }
-        }
-
         // Fire undo/redo callback
         if (onMuteChanged) onMuteChanged(muted);
     };
@@ -293,51 +286,17 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
         // Solo Safe Logic (Ctrl + Click)
         const bool isCtrl = (modifiers & NUIModifiers::Ctrl);
         if (isCtrl) {
-            // Revert the local toggle because pure solo state shouldn't change
-            // But wait, the button row just toggled its internal visual state.
-            // For Solo Safe, we actually want to toggle a *different* visual state 
-            // (maybe different color or icon?), but for now let's just update the logic.
-            // NOTE: UIMixerButtonRow tracks 'soloed' boolean. If we are setting 'solo safe',
-            // we should probably revert the 'soloed' state on the button if it wasn't already soloed.
-            // Or, ideally, Solo Safe is an independent state.
-            // Given the button row is simple, let's treat it as:
-            // Ctrl+Click -> Toggle Safe. Restore Solo button state to what it was.
-            
-            // Revert button state visually (hacky but works for stateless widget)
-            m_buttons->setSoloed(!soloed); 
-            
-            // Toggle proper safe state
+            // Solo-safe is independent from solo. Restore the button's prior
+            // state, then toggle only the processing-safe flag.
+            m_buttons->setSoloed(!soloed);
             if (auto mc = channel->channel) {
-               bool newSafe = !mc->isSoloSafe();
-               mc->setSoloSafe(newSafe);
-               // Visual feedback? UIMixerStrip doesn't have a distinct 'Safe' icon yet.
-               // We might rely on the user knowing they did it, or add a small indicator later.
+                mc->setSoloSafe(!mc->isSoloSafe());
             }
             return;
         }
 
-        // Exclusive solo: clear other solos first (matches playlist behavior).
-        if (soloed) {
-            const size_t count = m_viewModel->getChannelCount();
-            for (size_t i = 0; i < count; ++i) {
-                auto* other = m_viewModel->getChannelByIndex(i);
-                if (!other || other->id == channel->id) continue;
-                if (auto otherMC = other->channel) {
-                    otherMC->setSolo(false);
-                }
-                other->soloed = false;
-            }
-        }
-
         channel->soloed = soloed;
         invalidateStaticCache();
-
-        if (auto mc = channel->channel) {
-            if (soloed && mc->isMuted()) {
-                mc->setMute(false);
-                channel->muted = false;
-            }
-        }
 
         // Fire undo/redo callback
         if (onSoloChanged) onSoloChanged(soloed);

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -70,15 +70,8 @@ ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackMana
     m_soloButton = std::make_shared<AestraUI::SoloButton>();
     m_soloButton->setOnToggle([this](bool toggled) {
         if (m_track && m_trackManager) {
-            bool newSolo = toggled;
-
-            // If enabling solo, clear all other solos first (exclusive solo)
-            if (newSolo) {
-                m_trackManager->clearAllSolos();
-            }
-
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<SetSoloCommand>(*m_track, newSolo));
+                std::make_shared<SetSoloCommand>(*m_track, toggled));
         }
     });
     // Initialize state

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -595,21 +595,19 @@ void MixerViewModel::addSend(uint32_t channelId) {
     std::string defaultName = "Master";
     
     auto available = getAvailableDestinations(channelId);
-    bool foundBetter = false;
     for (const auto& dest : available) {
         // Pick the first available Send that isn't Master (0).
         // e.g., a Reverb Bus or Group Channel
         if (dest.id != 0) {
             defaultTarget = dest.id;
             defaultName = dest.name;
-            foundBetter = true;
             break;
         }
     }
 
     send.targetId = defaultTarget; 
     send.targetName = defaultName;
-    send.gain = 1.0f; // 0dB
+    send.gain = 0.25f; // -12 dB leaves headroom when adding a parallel path
     send.sidechainOnly = false;
     ch->sends.push_back(send);
 
@@ -618,10 +616,27 @@ void MixerViewModel::addSend(uint32_t channelId) {
         Audio::AudioRoute route{};
         // Map 0 -> 0xFFFFFFFF for engine
         route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFF : defaultTarget; 
-        route.gain = 1.0f;
+        route.gain = 0.25f;
         route.sidechainOnly = false;
         mc->addSend(route);
         
+        graphDirty.emit();
+        projectModified.emit();
+    }
+}
+
+void MixerViewModel::addSidechain(uint32_t channelId) {
+    addSend(channelId);
+    auto* ch = getChannelById(channelId);
+    if (!ch || ch->sends.empty())
+        return;
+
+    const int sendIndex = static_cast<int>(ch->sends.size() - 1);
+    ch->sends.back().gain = 1.0f;
+    ch->sends.back().sidechainOnly = true;
+    if (auto* mc = ch->channel) {
+        mc->setSendLevel(sendIndex, 1.0f);
+        mc->setSendSidechainOnly(sendIndex, true);
         graphDirty.emit();
         projectModified.emit();
     }
@@ -666,11 +681,6 @@ void MixerViewModel::toggleMute(uint32_t channelId) {
     bool newMute = !ch->channel->isMuted();
     ch->channel->setMute(newMute);
     ch->muted = newMute;
-    // Mutual exclusivity: muting turns off solo
-    if (newMute && ch->channel->isSoloed()) {
-        ch->channel->setSolo(false);
-        ch->soloed = false;
-    }
     graphDirty.emit();
     projectModified.emit();
 }
@@ -681,11 +691,6 @@ void MixerViewModel::toggleSolo(uint32_t channelId) {
     bool newSolo = !ch->channel->isSoloed();
     ch->channel->setSolo(newSolo);
     ch->soloed = newSolo;
-    // Mutual exclusivity: soloing turns off mute
-    if (newSolo && ch->channel->isMuted()) {
-        ch->channel->setMute(false);
-        ch->muted = false;
-    }
     graphDirty.emit();
     projectModified.emit();
 }
@@ -710,11 +715,14 @@ void MixerViewModel::setSendLevel(uint32_t channelId, int sendIndex, float linea
     auto* ch = getChannelById(channelId);
     if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
 
+    linearGain = std::isfinite(linearGain) ? std::clamp(linearGain, 0.0f, 4.0f) : 0.0f;
     ch->sends[sendIndex].gain = linearGain;
 
     // Update Engine
     if (auto mc = ch->channel) {
         mc->setSendLevel(sendIndex, linearGain);
+        graphDirty.emit();
+        projectModified.emit();
     }
 }
 

--- a/Source/Components/MixerViewModel.h
+++ b/Source/Components/MixerViewModel.h
@@ -284,6 +284,7 @@ public:
 
     // Send Management
     void addSend(uint32_t channelId);
+    void addSidechain(uint32_t channelId);
     void addSend(uint32_t channelId, uint32_t targetId);
     void removeSend(uint32_t channelId, int sendIndex);
     void setSendLevel(uint32_t channelId, int sendIndex, float linearGain);

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -254,21 +254,15 @@ void TrackManagerUI::onTrackSoloToggled(TrackUIComponent* soloedTrack) {
     if (!m_trackManager || !soloedTrack)
         return;
 
-    // Exclusive Solo: Unsolo everyone ELSE
+    // Playlist solos are additive. Refresh every lane because the aggregate
+    // solo gate changes the dimmed/audible state of non-soloed lanes.
     for (auto& trackUI : m_trackUIComponents) {
-        // Skip the track that was just soloed
-        if (trackUI.get() == soloedTrack)
-            continue;
-
-        if (auto* lane = m_trackManager->getPlaylistModel().getLane(trackUI->getLaneId()); lane && lane->solo) {
-            lane->solo = false;
-            trackUI->updateUI(); // Update UI
-            trackUI->repaint();
-        }
+        trackUI->updateUI();
+        trackUI->repaint();
     }
 
     invalidateCache();
-    Log::info("Solo coordination: Cleared other solos (Exclusive Mode)");
+    Log::info("Playlist solo set changed (additive mode)");
 }
 
 void TrackManagerUI::onClipDeleted(TrackUIComponent* trackComp, ClipInstanceID clipId,

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -82,7 +82,7 @@ public:
     void invalidateCache(); // Keep for compatibility
     void buildAllWaveformCaches();
 
-    // Solo coordination (exclusive solo behavior)
+    // Solo coordination (refreshes the additive Playlist solo set)
     void onTrackSoloToggled(TrackUIComponent* soloedTrack);
 
     void onClipDeleted(TrackUIComponent* trackComp, ClipInstanceID clipId, const ::AestraUI::NUIPoint& rippleCenter);

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -233,6 +233,9 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 clip.durationBeats = duration;
                 clip.patternId = pid;
                 clip.sourceId = pid.value;
+                if (pattern->isAudio()) {
+                    clip.edits = ClipEdits::forNewAudioClip();
+                }
 
                 auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
                 m_trackManager->getCommandHistory().pushAndExecute(cmd);
@@ -362,6 +365,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     clip.durationSeconds = durationSeconds;
                     clip.patternId = patternId;
                     clip.sourceId = patternId.value;
+                    clip.edits = ClipEdits::forNewAudioClip();
 
                     auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
                     self->m_trackManager->getCommandHistory().pushAndExecute(cmd);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -186,7 +186,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     configureFlatTrackButton(m_muteButton);
     m_muteButton->setToggleable(true);
     m_muteButton->setOnToggle([this](bool) { onMuteToggled(); });
-    m_muteButton->setTooltip("Mute Track (M)");
+    m_muteButton->setTooltip("Mute Playlist lane (M)");
     addChild(m_muteButton);
 
     // Create solo button
@@ -195,7 +195,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     configureFlatTrackButton(m_soloButton);
     m_soloButton->setToggleable(true);
     m_soloButton->setOnToggle([this](bool) { onSoloToggled(); });
-    m_soloButton->setTooltip("Solo Track (S)");
+    m_soloButton->setTooltip("Solo Playlist lane (S)");
     addChild(m_soloButton);
 
     // Recording is armed from mixer inserts. A Playlist lane only receives a
@@ -305,10 +305,6 @@ void TrackUIComponent::onMuteToggled() {
         bool isMuted = m_muteButton->isToggled();
         if (auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
             lane->muted = isMuted;
-            if (isMuted) {
-                lane->solo = false;
-                if (m_soloButton) m_soloButton->setToggled(false);
-            }
             m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
             m_trackManager->markModified();
         }
@@ -326,15 +322,11 @@ void TrackUIComponent::onSoloToggled() {
         bool newSolo = m_soloButton->isToggled(); // Use button state
         if (auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
             lane->solo = newSolo;
-            if (newSolo) {
-                lane->muted = false;
-                if (m_muteButton) m_muteButton->setToggled(false);
-            }
             m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
             m_trackManager->markModified();
         }
 
-        if (newSolo && m_onSoloToggledCallback) {
+        if (m_onSoloToggledCallback) {
             m_onSoloToggledCallback(this);
         }
 
@@ -1955,11 +1947,17 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 
         if (!event.cursorCaptured && isInsideBounds) {
             if (m_volumeFader && m_volumeFader->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Track Volume", event.position, this);
+                AestraUI::NUIComponent::showRemoteTooltip("Playlist lane volume", event.position, this);
             } else if (m_muteButton && m_muteButton->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Mute Track (M)", event.position, this);
+                const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+                const std::string tooltip =
+                    lane && lane->muted && lane->solo ? "Muted • solo is held (M)" : "Mute Playlist lane (M)";
+                AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_soloButton && m_soloButton->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Solo Track (S)", event.position, this);
+                const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+                const std::string tooltip =
+                    lane && lane->muted && lane->solo ? "Solo held • lane is muted (S)" : "Solo Playlist lane (S)";
+                AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_recordButton && m_recordButton->getBounds().contains(event.position)) {
                 AestraUI::NUIComponent::showRemoteTooltip("Arm for Recording (O)", event.position, this);
             } else if (m_volumeKnobHovered) {
@@ -2249,10 +2247,31 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         
         const float DRAG_THRESHOLD = 5.0f;
         if (distance >= DRAG_THRESHOLD && m_activeClipId.isValid()) {
-            m_isDraggingClip = true;
             m_clipDragPotential = false;
-            
-            // Replaced DragManager with Instant Drag
+
+            // Alt-drag routes the referenced audio source. Normal drag remains
+            // arrangement-only, so moving a clip can never change its signal path.
+            if ((event.modifiers & AestraUI::NUIModifiers::Alt) && m_trackManager) {
+                const auto* clip = m_trackManager->getPlaylistModel().getClip(m_activeClipId);
+                const auto* pattern = clip ? m_trackManager->getPatternManager().getPattern(clip->patternId) : nullptr;
+                if (clip && pattern && pattern->isAudio()) {
+                    AestraUI::DragData routeDrag;
+                    routeDrag.type = AestraUI::DragDataType::AudioSourceRoute;
+                    routeDrag.displayName = clip->name.empty() ? pattern->name : clip->name;
+                    routeDrag.customData = pattern->id.value;
+                    const auto boundsIt = m_allClipBounds.find(m_activeClipId);
+                    if (boundsIt != m_allClipBounds.end()) {
+                        routeDrag.previewWidth = std::max(100.0f, boundsIt->second.width);
+                        routeDrag.previewHeight = std::max(24.0f, boundsIt->second.height);
+                    }
+                    dragManager.beginDrag(routeDrag, m_clipDragStartPos, this);
+                    return true;
+                }
+            }
+
+            m_isDraggingClip = true;
+
+            // Normal clip movement uses the low-latency arrangement drag path.
             if (auto parentMgr = dynamic_cast<TrackManagerUI*>(getParent())) {
                 if (m_trackManager) {
                     auto lane = m_trackManager->getPlaylistModel().getLane(m_laneId);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1436,10 +1436,10 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
     if (lane) {
         const bool soloSuppressed = m_anyPlaylistLaneSoloed && !lane->solo;
 
-        if (lane->solo) {
-            renderer.fillRect(controlAreaBounds, themeManager.getColor("accentCyan").withAlpha(0.10f));
-        } else if (lane->muted) {
+        if (lane->muted) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("backgroundSecondary").withAlpha(0.62f));
+        } else if (lane->solo) {
+            renderer.fillRect(controlAreaBounds, themeManager.getColor("accentCyan").withAlpha(0.10f));
         } else if (soloSuppressed) {
             renderer.fillRect(controlAreaBounds, themeManager.getColor("backgroundSecondary").withAlpha(0.44f));
         }

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3666,6 +3666,7 @@ void AestraContent::loadSampleIntoSelectedTrack(const std::string& filePath) {
     clip.durationBeats = durationBeats;
     clip.durationSeconds = durationSeconds;
     clip.name = patternName;
+    clip.edits = Aestra::Audio::ClipEdits::forNewAudioClip();
     const auto clipId = playlist.addClip(targetLaneId, clip);
     if (!clipId.isValid()) {
         patternManager.removePattern(patternId);

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -26,8 +26,10 @@ namespace Audio {
 
 namespace {
 constexpr float kMinPanelWidth = 660.0f;
-constexpr float kMinPanelHeight = 430.0f;
+constexpr float kMinPanelHeight = 500.0f;
 constexpr size_t kWaveformBuckets = 768;
+constexpr float kNormalizeTargetLinear = 0.89125094f; // -1 dBFS peak
+constexpr float kControlsCardHeight = 194.0f;
 
 class AudioClipEditorSurface final : public NUIComponent {
 public:
@@ -41,7 +43,8 @@ public:
         const auto card = theme.getColor("surfaceTertiary").withAlpha(0.46f);
         const auto stroke = theme.getColor("borderSubtle").withAlpha(0.68f);
         const NUIRect sourceCard{bounds.x + 8.0f, bounds.y + 8.0f, bounds.width - 16.0f, 78.0f};
-        const NUIRect controlsCard{bounds.x + 8.0f, bounds.bottom() - 152.0f, bounds.width - 16.0f, 144.0f};
+        const NUIRect controlsCard{bounds.x + 8.0f, bounds.bottom() - kControlsCardHeight - 8.0f, bounds.width - 16.0f,
+                                   kControlsCardHeight};
         renderer.fillRoundedRect(sourceCard, 7.0f, card);
         renderer.strokeRoundedRect(sourceCard, 7.0f, 1.0f, stroke);
         renderer.fillRoundedRect(controlsCard, 7.0f, card.withAlpha(0.38f));
@@ -55,6 +58,13 @@ std::string formatFixed(double value, int precision) {
     std::ostringstream stream;
     stream << std::fixed << std::setprecision(precision) << value;
     return stream.str();
+}
+
+std::string formatGainDb(float linear) {
+    if (!std::isfinite(linear) || linear <= 0.000001f)
+        return "-inf dB";
+    const double db = 20.0 * std::log10(static_cast<double>(linear));
+    return formatFixed(db, 1) + " dB";
 }
 
 bool editsEqual(const ClipEdits& a, const ClipEdits& b) {
@@ -111,7 +121,7 @@ void AudioClipEditorPanel::buildUI() {
     m_sourceNameLabel->setTextColor(theme.getColor("textPrimary"));
     m_sourceMetaLabel = makeLabel("");
     m_routeLabel = makeLabel("OUTPUT INSERT", 10.0f);
-    m_routeHintLabel = makeLabel("Source route • linked clips follow this destination", 10.0f);
+    m_routeHintLabel = makeLabel("Source route • Alt-drag this clip onto an Insert", 10.0f);
     m_routeHintLabel->setAlignment(NUILabel::Alignment::Right);
     m_routePicker = std::make_shared<UIInsertRoutePicker>();
     m_routePicker->setOnRouteSelected([this](uint32_t routeId) { selectRoute(routeId); });
@@ -122,23 +132,34 @@ void AudioClipEditorPanel::buildUI() {
     m_panLabel = makeLabel("Pan");
     m_fadeInLabel = makeLabel("Fade in");
     m_fadeOutLabel = makeLabel("Fade out");
-    m_gainValueLabel = makeLabel("100%", 10.0f);
+    m_speedLabel = makeLabel("Speed");
+    m_sourceStartLabel = makeLabel("Start");
+    m_gainValueLabel = makeLabel("-5.0 dB", 10.0f);
     m_panValueLabel = makeLabel("Center", 10.0f);
     m_fadeInValueLabel = makeLabel("0.00 beats", 10.0f);
     m_fadeOutValueLabel = makeLabel("0.00 beats", 10.0f);
-    for (const auto& value : {m_gainValueLabel, m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel}) {
+    m_speedValueLabel = makeLabel("1.00x", 10.0f);
+    m_sourceStartValueLabel = makeLabel("0.000 s", 10.0f);
+    m_waveformHintLabel = makeLabel("Scroll to zoom • edits are non-destructive", 10.0f);
+    m_waveformHintLabel->setAlignment(NUILabel::Alignment::Right);
+    for (const auto& value : {m_gainValueLabel, m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel,
+                              m_speedValueLabel, m_sourceStartValueLabel}) {
         value->setAlignment(NUILabel::Alignment::Right);
     }
 
-    m_gainSlider = makeSlider("Clip gain", 0.0, 2.0, 1.0);
+    m_gainSlider = makeSlider("Clip gain", 0.0, 2.0, DEFAULT_AUDIO_CLIP_GAIN_LINEAR);
     m_panSlider = makeSlider("Clip pan", -1.0, 1.0, 0.0);
     m_fadeInSlider = makeSlider("Fade in", 0.0, 4.0, 0.0);
     m_fadeOutSlider = makeSlider("Fade out", 0.0, 4.0, 0.0);
+    m_speedSlider = makeSlider("Playback speed", 0.25, 4.0, 1.0);
+    m_sourceStartSlider = makeSlider("Source start", 0.0, 1.0, 0.0);
     m_muteButton = std::make_shared<NUIButton>("Mute clip");
     m_muteButton->setToggleable(true);
+    m_normalizeButton = std::make_shared<NUIButton>("Normalize");
     m_resetButton = std::make_shared<NUIButton>("Reset instance");
     m_makeUniqueButton = std::make_shared<NUIButton>("Make unique");
     styleButton(m_muteButton);
+    styleButton(m_normalizeButton);
     styleButton(m_resetButton);
     styleButton(m_makeUniqueButton);
 
@@ -165,6 +186,12 @@ void AudioClipEditorPanel::buildUI() {
     wireSlider(m_panSlider, [](ClipEdits& edits, double value) { edits.pan = static_cast<float>(value); });
     wireSlider(m_fadeInSlider, [](ClipEdits& edits, double value) { edits.fadeInBeats = static_cast<float>(value); });
     wireSlider(m_fadeOutSlider, [](ClipEdits& edits, double value) { edits.fadeOutBeats = static_cast<float>(value); });
+    wireSlider(m_speedSlider, [](ClipEdits& edits, double value) { edits.playbackRate = static_cast<float>(value); });
+    wireSlider(m_sourceStartSlider, [this](ClipEdits& edits, double value) {
+        const double projectRate =
+            m_trackManager ? std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate()) : 48000.0;
+        edits.sourceStart = value * projectRate;
+    });
 
     m_muteButton->setOnToggle([this](bool muted) {
         if (m_suppressCallbacks)
@@ -173,9 +200,15 @@ void AudioClipEditorPanel::buildUI() {
         edits.muted = muted;
         applyDiscreteEdit(edits);
     });
-    m_resetButton->setOnClick([this]() {
-        ClipEdits reset;
-        applyDiscreteEdit(reset);
+    m_resetButton->setOnClick([this]() { applyDiscreteEdit(ClipEdits::forNewAudioClip()); });
+    m_normalizeButton->setOnClick([this]() {
+        if (!std::isfinite(m_sourcePeak) || m_sourcePeak <= 0.000001f)
+            return;
+        auto edits = m_workingEdits;
+        const float normalizedGain = std::clamp(kNormalizeTargetLinear / m_sourcePeak, 0.0f, 2.0f);
+        edits.gain = normalizedGain;
+        edits.gainLinear = normalizedGain;
+        applyDiscreteEdit(edits);
     });
     m_makeUniqueButton->setOnClick([this]() {
         if (!m_trackManager || !m_clipId.isValid())
@@ -186,10 +219,12 @@ void AudioClipEditorPanel::buildUI() {
     });
 
     const std::vector<std::shared_ptr<NUIComponent>> children{
-        m_sourceNameLabel, m_sourceMetaLabel,  m_routeLabel,        m_routeHintLabel,  m_routePicker,  m_waveform,
-        m_instanceLabel,   m_gainLabel,        m_panLabel,          m_fadeInLabel,     m_fadeOutLabel, m_gainValueLabel,
-        m_panValueLabel,   m_fadeInValueLabel, m_fadeOutValueLabel, m_gainSlider,      m_panSlider,    m_fadeInSlider,
-        m_fadeOutSlider,   m_muteButton,       m_resetButton,       m_makeUniqueButton};
+        m_sourceNameLabel,   m_sourceMetaLabel,   m_routeLabel,        m_routeHintLabel,   m_routePicker,
+        m_waveform,          m_waveformHintLabel, m_instanceLabel,     m_gainLabel,        m_panLabel,
+        m_fadeInLabel,       m_fadeOutLabel,      m_speedLabel,        m_sourceStartLabel, m_gainValueLabel,
+        m_panValueLabel,     m_fadeInValueLabel,  m_fadeOutValueLabel, m_speedValueLabel,  m_sourceStartValueLabel,
+        m_gainSlider,        m_panSlider,         m_fadeInSlider,      m_fadeOutSlider,    m_speedSlider,
+        m_sourceStartSlider, m_muteButton,        m_normalizeButton,   m_resetButton,      m_makeUniqueButton};
     for (const auto& child : children) {
         m_surface->addChild(child);
     }
@@ -237,6 +272,8 @@ void AudioClipEditorPanel::rebuildWaveform() {
     const auto* source = m_trackManager->getSourceManager().getSource(payload->audioSourceId);
     const auto* buffer = source ? source->getRawBuffer() : nullptr;
     if (!source || !buffer || !buffer->isValid()) {
+        m_sourceDurationSeconds = 0.0;
+        m_sourcePeak = 0.0f;
         m_sourceNameLabel->setText(clip->name.empty() ? "Audio clip" : clip->name);
         m_sourceMetaLabel->setText("Source unavailable");
         m_waveformData.assign(kWaveformBuckets * 2, 0.0f);
@@ -255,14 +292,26 @@ void AudioClipEditorPanel::rebuildWaveform() {
                           [pattern](const ClipInstance& candidate) { return candidate.patternId == pattern->id; }));
     }
 
+    m_sourceDurationSeconds = buffer->durationSeconds();
+    m_sourcePeak = 0.0f;
+    for (const float sample : buffer->interleavedData) {
+        if (std::isfinite(sample))
+            m_sourcePeak = std::max(m_sourcePeak, std::abs(sample));
+    }
+
     m_sourceNameLabel->setText(source->getName().empty() ? clip->name : source->getName());
     const char* channelText =
         buffer->numChannels == 1 ? "Mono" : (buffer->numChannels == 2 ? "Stereo" : "Multichannel");
     m_sourceMetaLabel->setText(formatFixed(buffer->durationSeconds(), 2) + " s  •  " +
                                std::to_string(buffer->sampleRate) + " Hz  •  " + channelText + "  •  " +
-                               std::to_string(linkedInstances) +
-                               (linkedInstances == 1 ? " linked clip" : " linked clips"));
+                               (linkedInstances > 1
+                                    ? "Shared source • " + std::to_string(linkedInstances) + " instances"
+                                    : "Unique source • 1 instance"));
     m_makeUniqueButton->setVisible(linkedInstances > 1);
+    m_makeUniqueButton->setText(linkedInstances > 1 ? "Make unique" : "Unique");
+    m_routeHintLabel->setText(linkedInstances > 1 ? "Shared source route • changes " + std::to_string(linkedInstances) +
+                                                        " clips • Alt-drag to an Insert"
+                                                  : "Unique source route • Alt-drag this clip onto an Insert");
 
     const size_t frameCount = static_cast<size_t>(buffer->numFrames);
     const size_t channels = static_cast<size_t>(buffer->numChannels);
@@ -351,6 +400,12 @@ void AudioClipEditorPanel::syncControlsFromModel() {
     m_fadeOutSlider->setRange(0.0, fadeMaximum);
     m_fadeInSlider->setValue(std::min<double>(m_workingEdits.fadeInBeats, fadeMaximum));
     m_fadeOutSlider->setValue(std::min<double>(m_workingEdits.fadeOutBeats, fadeMaximum));
+    m_speedSlider->setValue(std::clamp<double>(m_workingEdits.playbackRate, 0.25, 4.0));
+    const double projectRate = std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate());
+    const double sourceStartSeconds = std::max(0.0, m_workingEdits.sourceStart) / projectRate;
+    const double sourceStartMaximum = std::max(0.001, m_sourceDurationSeconds);
+    m_sourceStartSlider->setRange(0.0, sourceStartMaximum);
+    m_sourceStartSlider->setValue(std::min(sourceStartSeconds, sourceStartMaximum));
     m_muteButton->setToggled(m_workingEdits.muted);
     m_muteButton->setText(m_workingEdits.muted ? "Unmute clip" : "Mute clip");
     m_suppressCallbacks = false;
@@ -358,7 +413,7 @@ void AudioClipEditorPanel::syncControlsFromModel() {
 }
 
 void AudioClipEditorPanel::updateValueLabels() {
-    m_gainValueLabel->setText(std::to_string(static_cast<int>(std::round(m_workingEdits.gainLinear * 100.0f))) + "%");
+    m_gainValueLabel->setText(formatGainDb(m_workingEdits.gainLinear));
     if (std::abs(m_workingEdits.pan) < 0.005f) {
         m_panValueLabel->setText("Center");
     } else {
@@ -368,6 +423,10 @@ void AudioClipEditorPanel::updateValueLabels() {
     }
     m_fadeInValueLabel->setText(formatFixed(m_workingEdits.fadeInBeats, 2) + " beats");
     m_fadeOutValueLabel->setText(formatFixed(m_workingEdits.fadeOutBeats, 2) + " beats");
+    m_speedValueLabel->setText(formatFixed(m_workingEdits.playbackRate, 2) + "x");
+    const double projectRate =
+        m_trackManager ? std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate()) : 48000.0;
+    m_sourceStartValueLabel->setText(formatFixed(std::max(0.0, m_workingEdits.sourceStart) / projectRate, 3) + " s");
 }
 
 void AudioClipEditorPanel::beginEditGesture() {
@@ -434,14 +493,17 @@ void AudioClipEditorPanel::onResize(int width, int height) {
     m_routePicker->setTriggerBounds({bounds.right() - pad - routeWidth, bounds.y + 34.0f, routeWidth, 30.0f});
     m_routeHintLabel->setBounds({bounds.x + pad, bounds.y + 61.0f, contentWidth, 14.0f});
 
-    const float controlsTop = bounds.bottom() - 152.0f;
+    const float controlsTop = bounds.bottom() - kControlsCardHeight - 8.0f;
     const float waveformTop = bounds.y + 96.0f;
     m_waveform->setBounds(
         {bounds.x + 8.0f, waveformTop, bounds.width - 16.0f, std::max(100.0f, controlsTop - waveformTop - 8.0f)});
+    m_waveformHintLabel->setBounds({bounds.x + pad, controlsTop - 23.0f, contentWidth - 4.0f, 14.0f});
 
     m_instanceLabel->setBounds({bounds.x + pad, controlsTop + 10.0f, contentWidth, 14.0f});
     const float buttonWidth = 104.0f;
     m_makeUniqueButton->setBounds(
+        {bounds.right() - pad - buttonWidth * 4.0f - 18.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
+    m_normalizeButton->setBounds(
         {bounds.right() - pad - buttonWidth * 3.0f - 12.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
     m_muteButton->setBounds({bounds.right() - pad - buttonWidth * 2.0f - 6.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
     m_resetButton->setBounds({bounds.right() - pad - buttonWidth, controlsTop + 8.0f, buttonWidth, 24.0f});
@@ -462,6 +524,8 @@ void AudioClipEditorPanel::onResize(int width, int height) {
     layoutControl(right, controlsTop + 42.0f, m_panLabel, m_panSlider, m_panValueLabel);
     layoutControl(left, controlsTop + 88.0f, m_fadeInLabel, m_fadeInSlider, m_fadeInValueLabel);
     layoutControl(right, controlsTop + 88.0f, m_fadeOutLabel, m_fadeOutSlider, m_fadeOutValueLabel);
+    layoutControl(left, controlsTop + 134.0f, m_speedLabel, m_speedSlider, m_speedValueLabel);
+    layoutControl(right, controlsTop + 134.0f, m_sourceStartLabel, m_sourceStartSlider, m_sourceStartValueLabel);
 }
 
 void AudioClipEditorPanel::onUpdate(double deltaTime) {
@@ -479,6 +543,8 @@ void AudioClipEditorPanel::onUpdate(double deltaTime) {
         rebuildWaveform();
         syncControlsFromModel();
         rebuildRoutes(true);
+    } else if (!editsEqual(clip->edits, m_workingEdits) && !m_editGestureActive) {
+        syncControlsFromModel();
     }
     rebuildRoutes(false);
 }

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -47,6 +47,8 @@ private:
     bool m_editGestureActive{false};
     bool m_suppressCallbacks{false};
     uint64_t m_routeFingerprint{0};
+    double m_sourceDurationSeconds{0.0};
+    float m_sourcePeak{0.0f};
     std::vector<float> m_waveformData;
 
     std::shared_ptr<AestraUI::NUIComponent> m_surface;
@@ -61,15 +63,23 @@ private:
     std::shared_ptr<AestraUI::NUILabel> m_panLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeInLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeOutLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_speedLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_sourceStartLabel;
     std::shared_ptr<AestraUI::NUILabel> m_gainValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_panValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeInValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeOutValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_speedValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_sourceStartValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_waveformHintLabel;
     std::shared_ptr<AestraUI::NUISlider> m_gainSlider;
     std::shared_ptr<AestraUI::NUISlider> m_panSlider;
     std::shared_ptr<AestraUI::NUISlider> m_fadeInSlider;
     std::shared_ptr<AestraUI::NUISlider> m_fadeOutSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_speedSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_sourceStartSlider;
     std::shared_ptr<AestraUI::NUIButton> m_muteButton;
+    std::shared_ptr<AestraUI::NUIButton> m_normalizeButton;
     std::shared_ptr<AestraUI::NUIButton> m_resetButton;
     std::shared_ptr<AestraUI::NUIButton> m_makeUniqueButton;
 

--- a/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
+++ b/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
@@ -102,7 +102,9 @@ int main() {
     require(std::abs(rightAt(42000)) < 1.0e-6f, "Clip pan changed during fade-out");
 
     // Playback speed and source-start are instance edits. They must reach the
-    // same graph used by live playback and offline export.
+    // same graph used by live playback and offline export, including when an
+    // imported source uses a different sample rate from the project.
+    sourceBuffer->sampleRate = kSampleRate / 2;
     for (uint32_t frame = 0; frame < kTotalFrames; ++frame) {
         sourceBuffer->interleavedData[frame] = static_cast<float>(frame) / static_cast<float>(kTotalFrames);
     }
@@ -119,12 +121,12 @@ int main() {
     const auto shiftedLeftAt = [&shiftedOutput](uint32_t frame) {
         return shiftedOutput[static_cast<size_t>(frame) * 2];
     };
-    require(shiftedLeftAt(6000) > 0.49f && shiftedLeftAt(6000) < 0.51f,
-            "Playback speed or source-start did not reach the renderer");
-    require(shiftedLeftAt(12000) > 0.74f && shiftedLeftAt(12000) < 0.76f,
-            "Playback rate did not advance through the source at the requested speed");
-    require(std::abs(shiftedLeftAt(18000)) < 1.0e-6f,
-            "Playback continued after the rate-adjusted source region was exhausted");
+    require(shiftedLeftAt(6000) > 0.24f && shiftedLeftAt(6000) < 0.26f,
+            "Source-rate conversion or source-start did not reach the renderer");
+    require(shiftedLeftAt(12000) > 0.36f && shiftedLeftAt(12000) < 0.39f,
+            "Source and playback rates did not combine at the requested speed");
+    require(std::abs(shiftedLeftAt(42000)) < 1.0e-6f,
+            "Playback continued after the mixed-rate source region was exhausted");
 
     std::cout << "[PASS] AudioClipInstanceRenderTest\n";
     return 0;

--- a/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
+++ b/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
@@ -79,6 +79,8 @@ int main() {
     const ClipInstanceID clipId = tracks->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
     auto* clip = tracks->getPlaylistModel().getClip(clipId);
     require(clip != nullptr, "Audio clip setup failed");
+    require(std::abs(clip->edits.gainLinear - DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f,
+            "New audio clip did not start with the headroom-preserving gain");
 
     ClipEdits edits = clip->edits;
     edits.gain = 0.5f;
@@ -98,6 +100,31 @@ int main() {
     require(std::abs(rightAt(18000)) < 1.0e-6f, "Hard-left clip pan leaked into the right channel");
     require(leftAt(42000) > 0.20f && leftAt(42000) < 0.30f, "Fade-out did not shape the rendered clip");
     require(std::abs(rightAt(42000)) < 1.0e-6f, "Clip pan changed during fade-out");
+
+    // Playback speed and source-start are instance edits. They must reach the
+    // same graph used by live playback and offline export.
+    for (uint32_t frame = 0; frame < kTotalFrames; ++frame) {
+        sourceBuffer->interleavedData[frame] = static_cast<float>(frame) / static_cast<float>(kTotalFrames);
+    }
+    edits.gain = 1.0f;
+    edits.gainLinear = 1.0f;
+    edits.pan = 0.0f;
+    edits.fadeInBeats = 0.0f;
+    edits.fadeOutBeats = 0.0f;
+    edits.playbackRate = 2.0f;
+    edits.sourceStart = kSampleRate / 4.0;
+    require(tracks->getPlaylistModel().setClipEdits(clipId, edits), "Playback edits were not accepted");
+
+    const auto shiftedOutput = render(tracks);
+    const auto shiftedLeftAt = [&shiftedOutput](uint32_t frame) {
+        return shiftedOutput[static_cast<size_t>(frame) * 2];
+    };
+    require(shiftedLeftAt(6000) > 0.49f && shiftedLeftAt(6000) < 0.51f,
+            "Playback speed or source-start did not reach the renderer");
+    require(shiftedLeftAt(12000) > 0.74f && shiftedLeftAt(12000) < 0.76f,
+            "Playback rate did not advance through the source at the requested speed");
+    require(std::abs(shiftedLeftAt(18000)) < 1.0e-6f,
+            "Playback continued after the rate-adjusted source region was exhausted");
 
     std::cout << "[PASS] AudioClipInstanceRenderTest\n";
     return 0;

--- a/Tests/AestraAudio/AudioPurityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioPurityAuditTest.cpp
@@ -272,7 +272,12 @@ RenderResult renderThroughAestraEngine(const std::vector<TrackFixture>& tracks, 
         if (channel) {
             trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
         }
-        trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
+        const ClipInstanceID clipId =
+            trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
+        if (!trackManager->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+            std::cerr << "Failed to configure unity-gain audio-purity fixture\n";
+            return {};
+        }
     }
 
     AudioEngine engine;

--- a/Tests/AestraAudio/AudioQualityAuditTest.cpp
+++ b/Tests/AestraAudio/AudioQualityAuditTest.cpp
@@ -84,7 +84,11 @@ static std::vector<float> renderSine(
     if (channel) {
         tm->getPatternManager().setPatternMixerChannel(patId, channel->getChannelId());
     }
-    tm->getPlaylistModel().addClipFromPattern(laneId, patId, 0.0, durationSec * 2.0);
+    const ClipInstanceID clipId = tm->getPlaylistModel().addClipFromPattern(laneId, patId, 0.0, durationSec * 2.0);
+    if (!tm->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+        CHECK(false, "Quality fixture uses unity clip gain");
+        return {};
+    }
 
     AudioEngine eng;
     eng.setSampleRate(sampleRate);

--- a/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
+++ b/Tests/AestraAudio/GoldenAudio/GoldenAudioHarness.h
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -147,7 +148,10 @@ inline Aestra::Audio::ClipSourceID addAudioTrack(Aestra::Audio::TrackManager& tm
     if (channel) {
         tm.getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
     }
-    tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+    const ClipInstanceID clipId = tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+    if (!tm.getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+        throw std::runtime_error("Failed to configure unity-gain golden-audio clip");
+    }
     return sourceId;
 }
 

--- a/Tests/AestraAudio/GoldenReferenceTest.cpp
+++ b/Tests/AestraAudio/GoldenReferenceTest.cpp
@@ -107,7 +107,11 @@ AnalysisResult runSignalTest(const std::string& label, const std::vector<float>&
     if (channel) {
         trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
     }
-    trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
+    const ClipInstanceID clipId =
+        trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, payload.durationSeconds * 2.0);
+    if (!trackManager->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+        return {label, false, 0.0, 0.0, 0.0};
+    }
 
     AudioEngine engine;
     engine.setSampleRate(kSampleRate);

--- a/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
+++ b/Tests/AestraAudio/SampleRateBufferTruthTest.cpp
@@ -131,7 +131,11 @@ void runCrossRateCase() {
         if (channel) {
             tm->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
         }
-        tm->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
+        const ClipInstanceID clipId = tm->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, 2.0);
+        if (!tm->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+            verdict(false, "Cross-rate fixture uses unity clip gain");
+            return;
+        }
     }
 
     AudioEngine engine;

--- a/Tests/AestraAudio/SummingEngineTest.cpp
+++ b/Tests/AestraAudio/SummingEngineTest.cpp
@@ -68,7 +68,12 @@ int main() {
         if (auto* channel = trackManager->getChannel(t)) {
             trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
         }
-        trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationSeconds * 2.0);
+        const ClipInstanceID clipId =
+            trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationSeconds * 2.0);
+        if (!trackManager->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+            std::cerr << "Failed to configure unity-gain summing fixture\n";
+            return 1;
+        }
     }
 
     // Initialize engine

--- a/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
+++ b/Tests/AestraAudio/TrackManagerMasterDuckingAuditTest.cpp
@@ -108,7 +108,10 @@ std::shared_ptr<TrackManager> createOneTrackManager() {
     const PatternID patternId =
         trackManager->getPatternManager().createAudioPattern("duck_audit_pattern", durationSeconds * 2.0, payload);
     trackManager->getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
-    trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationSeconds * 2.0);
+    const ClipInstanceID clipId =
+        trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationSeconds * 2.0);
+    require(trackManager->getPlaylistModel().setClipEdits(clipId, ClipEdits{}),
+            "failed to configure unity-gain ducking audit clip");
 
     trackManager->buildAndShareSlotMap();
     return trackManager;

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -231,6 +231,13 @@ int main() {
     const PatternID audioPattern = patternManager.createAudioPattern("Audio Source", 1.0, audioPayload);
     require(patternManager.setPatternMixerChannel(audioPattern, 77), "Audio source route was not stored");
 
+    const ClipInstanceID defaultAudioClip = playlist.addClipFromPattern(laneA, audioPattern, 4.0, 1.0);
+    const auto* defaultAudioClipState = playlist.getClip(defaultAudioClip);
+    require(defaultAudioClipState &&
+                std::abs(defaultAudioClipState->edits.gainLinear - DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f,
+            "New audio clip factory did not preserve default headroom");
+    playlist.removeClip(defaultAudioClip);
+
     ClipInstance audioClip;
     audioClip.id = ClipInstanceID::generate();
     audioClip.patternId = audioPattern;
@@ -245,6 +252,8 @@ int main() {
     edited.pan = -0.25f;
     edited.fadeInBeats = 0.25f;
     edited.fadeOutBeats = 0.5f;
+    edited.playbackRate = 1.5f;
+    edited.sourceStart = 12.0;
     tracks.getCommandHistory().pushAndExecute(std::make_shared<SetClipEditsCommand>(playlist, audioClip.id, edited));
 
     auto findTrack = [](AudioGraph& graph, uint32_t id) -> TrackRenderState* {
@@ -262,6 +271,8 @@ int main() {
             "Clip editor gain/pan did not reach the audio graph");
     require(renderedEdit.fadeInSamples > 0 && renderedEdit.fadeOutSamples > renderedEdit.fadeInSamples,
             "Clip editor fades did not reach the audio graph");
+    require(renderedEdit.playbackRate == 1.5f && renderedEdit.sampleOffset > 0.0,
+            "Clip editor speed/source-start did not reach the audio graph");
 
     require(tracks.getCommandHistory().undo(), "Clip edit undo was unavailable");
     graph = AudioGraphBuilder::buildFromTrackManager(tracks);
@@ -271,6 +282,20 @@ int main() {
 
     auto* alternateDestination = tracks.addChannelWithId("Alternate Insert", 88);
     require(alternateDestination != nullptr, "Alternate insert setup failed");
+    AudioQueueCommand capturedMixerCommand{};
+    alternateDestination->setCommandSink(
+        [&capturedMixerCommand](const AudioQueueCommand& command) { capturedMixerCommand = command; });
+    alternateDestination->setPan(0.25f);
+    require(capturedMixerCommand.type == AudioQueueCommandType::SetTrackPan && capturedMixerCommand.channelId == 88,
+            "Mixer control command used a derived dense index instead of its stable Insert ID");
+    alternateDestination->setCommandSink({});
+    alternateDestination->setSolo(true);
+    alternateDestination->setMute(true);
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(alternateDestination->isSoloed() && alternateDestination->isMuted() && !graph.anySolo,
+            "Muted mixer solo did not preserve state or incorrectly suppressed other inserts");
+    alternateDestination->setMute(false);
+    alternateDestination->setSolo(false);
     tracks.getCommandHistory().pushAndExecute(
         std::make_shared<SetAudioPatternMixerChannelCommand>(tracks, audioPattern, 88));
     graph = AudioGraphBuilder::buildFromTrackManager(tracks);
@@ -285,6 +310,23 @@ int main() {
     linkedClip.id = ClipInstanceID::generate();
     linkedClip.startBeat = 2.0;
     playlist.addClip(laneB, linkedClip);
+
+    auto* laneAState = playlist.getLane(laneA);
+    auto* laneBState = playlist.getLane(laneB);
+    require(laneAState && laneBState, "Solo-domain test lanes disappeared");
+    laneAState->solo = true;
+    laneBState->solo = true;
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(findTrack(graph, 77) && findTrack(graph, 77)->clips.size() == 2,
+            "Additive Playlist solos did not keep both lanes audible");
+    laneAState->muted = true;
+    graph = AudioGraphBuilder::buildFromTrackManager(tracks);
+    require(laneAState->solo && findTrack(graph, 77) && findTrack(graph, 77)->clips.size() == 1,
+            "Playlist mute erased solo state or failed to gate its own lane");
+    laneAState->muted = false;
+    laneAState->solo = false;
+    laneBState->solo = false;
+
     tracks.getCommandHistory().pushAndExecute(std::make_shared<MakeAudioClipUniqueCommand>(tracks, audioClip.id));
     const auto* uniqueClip = playlist.getClip(audioClip.id);
     const auto* stillLinkedClip = playlist.getClip(linkedClip.id);

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -256,6 +256,22 @@ int main() {
     edited.sourceStart = 12.0;
     tracks.getCommandHistory().pushAndExecute(std::make_shared<SetClipEditsCommand>(playlist, audioClip.id, edited));
 
+    auto* malformedOffsetClip = playlist.getClip(audioClip.id);
+    require(malformedOffsetClip != nullptr, "Audio clip was unavailable for oversized offset coverage");
+    malformedOffsetClip->sourceOffsetSeconds = std::numeric_limits<double>::max();
+    ClipEdits oversizedOffsetEdits = edited;
+    oversizedOffsetEdits.sourceStart = std::numeric_limits<double>::max();
+    require(playlist.setClipEdits(audioClip.id, oversizedOffsetEdits), "Oversized finite clip offsets were rejected");
+    const auto oversizedOffsetSnapshot =
+        playlist.buildRuntimeSnapshot(tracks.getPatternManager(), tracks.getSourceManager());
+    require(oversizedOffsetSnapshot && !oversizedOffsetSnapshot->lanes.empty() &&
+                !oversizedOffsetSnapshot->lanes.front().clips.empty() &&
+                oversizedOffsetSnapshot->lanes.front().clips.front().sourceStart ==
+                    std::numeric_limits<uint64_t>::max(),
+            "Oversized finite clip offsets did not saturate safely");
+    malformedOffsetClip->sourceOffsetSeconds = 0.0;
+    require(playlist.setClipEdits(audioClip.id, edited), "Finite clip edits were not restored after offset coverage");
+
     auto findTrack = [](AudioGraph& graph, uint32_t id) -> TrackRenderState* {
         auto it = std::find_if(graph.tracks.begin(), graph.tracks.end(),
                                [id](const TrackRenderState& state) { return state.trackId == id; });

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -71,6 +71,11 @@ int main() {
 
     const uint32_t victimId = victim->getChannelId();
     const uint32_t lastId = last->getChannelId();
+    first->setMainOutputId(victimId);
+    Aestra::Audio::AudioRoute sidechainToVictim{};
+    sidechainToVictim.targetChannelId = victimId;
+    sidechainToVictim.sidechainOnly = true;
+    last->addSend(sidechainToVictim);
 
     // Route both source domains to the doomed Insert. Deletion must fail safe
     // to Master, while undo must restore the stable destination once the exact
@@ -98,6 +103,9 @@ int main() {
           "delete resets the Unit route to Master");
     check(patternManager.getPattern(routedAudio)->getMixerChannelId() == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
           "delete resets the audio-source route to Master");
+    check(first->getMainOutputId() == 0xFFFFFFFFu,
+          "delete resets an insert main path targeting the removed Insert to Master");
+    check(last->getSends().empty(), "delete removes sends and sidechains targeting the removed Insert");
 
     // --- undo the delete: the SAME channel must come back -------------------
     check(history.undo(), "undo of delete reported success");
@@ -116,6 +124,10 @@ int main() {
     check(unitManager.getUnitMixerChannel(routedUnit) == victimId, "undo restores the Unit's stable mixer destination");
     check(patternManager.getPattern(routedAudio)->getMixerChannelId() == victimId,
           "undo restores the audio source's stable mixer destination");
+    check(first->getMainOutputId() == victimId, "undo restores the insert main path");
+    check(last->getSends().size() == 1 && last->getSends().front().targetChannelId == victimId &&
+              last->getSends().front().sidechainOnly,
+          "undo restores the sidechain route with its stable destination");
     check(manager.getChannel(2) != nullptr && manager.getChannel(2)->getChannelId() == lastId,
           "the track after it moved back down");
 
@@ -138,6 +150,8 @@ int main() {
           "redo resets the Unit route to Master again");
     check(patternManager.getPattern(routedAudio)->getMixerChannelId() == Aestra::Audio::MASTER_MIXER_CHANNEL_ID,
           "redo resets the audio-source route to Master again");
+    check(first->getMainOutputId() == 0xFFFFFFFFu && last->getSends().empty(),
+          "redo safely removes insert routes again");
 
     // And a second round trip still restores the same identity, so the fix is
     // not a one-shot that works only until the channel has been detached twice.
@@ -148,6 +162,9 @@ int main() {
     check(unitManager.getUnitMixerChannel(routedUnit) == victimId &&
               patternManager.getPattern(routedAudio)->getMixerChannelId() == victimId,
           "a second delete/undo round trip restores both source routes");
+    check(first->getMainOutputId() == victimId && last->getSends().size() == 1 &&
+              last->getSends().front().targetChannelId == victimId,
+          "a second delete/undo round trip restores mixer routes");
 
     // --- deleting the last track restores to the end ------------------------
     {

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -731,6 +731,7 @@ void testAudioClipDurationSecondsMigrationAndTempoRecompute() {
     auto* midiPattern = tm->getPatternManager().getPattern(lane->clips[1].patternId);
     assert(audioPattern && audioPattern->isAudio());
     assert(midiPattern && midiPattern->isMidi());
+    assert(std::abs(lane->clips[0].edits.gainLinear - 1.0f) < 1.0e-7f);
     assert(std::abs(lane->clips[0].durationSeconds - 2.0) < 1.0e-9);
     assert(std::abs(lane->clips[0].durationBeats - 4.0) < 1.0e-9);
     assert(std::abs(lane->clips[1].durationBeats - 4.0) < 1.0e-9);
@@ -778,6 +779,7 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
 
     const auto* clip = playlist.getClip(clipId);
     assert(clip);
+    assert(std::abs(clip->edits.gainLinear - Aestra::Audio::DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f);
     assert(std::abs(clip->durationSeconds - 1.0) < 1.0e-9);
 
     std::string firstSave = serializeProject(*tm1, 120.0, 0.0);
@@ -795,6 +797,7 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     const auto* loadedLane = tm2->getPlaylistModel().getLane(loadedLaneId);
     assert(loadedLane);
     assert(loadedLane->clips.size() == 1);
+    assert(std::abs(loadedLane->clips[0].edits.gainLinear - Aestra::Audio::DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f);
     assert(std::abs(loadedLane->clips[0].durationSeconds - 1.0) < 1.0e-9);
     assert(std::abs(loadedLane->clips[0].durationBeats - 2.0) < 1.0e-9);
 

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -781,6 +781,10 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     assert(clip);
     assert(std::abs(clip->edits.gainLinear - Aestra::Audio::DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f);
     assert(std::abs(clip->durationSeconds - 1.0) < 1.0e-9);
+    auto persistedEdits = clip->edits;
+    persistedEdits.playbackRate = 1.75f;
+    persistedEdits.sourceStart = 1234.5;
+    assert(playlist.setClipEdits(clipId, persistedEdits));
 
     std::string firstSave = serializeProject(*tm1, 120.0, 0.0);
     assert(firstSave.find("\"durationSeconds\"") != std::string::npos);
@@ -798,6 +802,8 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     assert(loadedLane);
     assert(loadedLane->clips.size() == 1);
     assert(std::abs(loadedLane->clips[0].edits.gainLinear - Aestra::Audio::DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f);
+    assert(std::abs(loadedLane->clips[0].edits.playbackRate - 1.75f) < 1.0e-7f);
+    assert(std::abs(loadedLane->clips[0].edits.sourceStart - 1234.5) < 1.0e-9);
     assert(std::abs(loadedLane->clips[0].durationSeconds - 1.0) < 1.0e-9);
     assert(std::abs(loadedLane->clips[0].durationBeats - 2.0) < 1.0e-9);
 

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -51,17 +51,15 @@
 // with [MEASURE] are the raw data quoted in AestraDocs/audio-research-bench.md.
 
 #include "AudioMeasure.h"
-#include "SignalLab.h"
-
-#include "GoldenAudio/GoldenAudioHarness.h"
-
 #include "DSP/ClipPrefilter.h"
 #include "DSP/Interpolators.h"
 #include "DSP/PanLaw.h"
+#include "GoldenAudio/GoldenAudioHarness.h"
 #include "IO/MiniAudioDecoder.h"
 #include "Playback/PreviewEngine.h"
 #include "Plugin/SamplerPlugin.h"
 #include "PluginHost.h"
+#include "SignalLab.h"
 
 #include <algorithm>
 #include <chrono>
@@ -71,6 +69,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -122,7 +121,10 @@ void addAudioTrackAtRate(TrackManager& tm, const std::string& label, const AR::S
     if (channel) {
         tm.getPatternManager().setPatternMixerChannel(patternId, channel->getChannelId());
     }
-    tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+    const ClipInstanceID clipId = tm.getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+    if (!tm.getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+        throw std::runtime_error("Failed to configure unity-gain resampling fixture");
+    }
 }
 
 std::shared_ptr<TrackManager> buildSession(const std::string& label, const AR::Signal& clip,


### PR DESCRIPTION
## Summary

- Give newly created audio clips 5 dB of headroom while preserving unity gain for legacy projects and existing saved values.
- Expand the non-destructive audio clip editor with dB gain readout, normalization, playback speed, source start, linked-source clarity, and Make Unique behavior.
- Add direct audio-source routing by Alt-dragging a clip onto a Mixer Insert, backed by stable Insert IDs rather than Playlist lane positions.
- Expose one-click sends and sidechains, use a conservative default send level, and harden route deletion/undo so missing Inserts fall back safely without ID rebinding.
- Make Playlist and Mixer mute/solo domains additive and independent, with UI feedback for held-solo-plus-muted states.

## Why

Playlist placement and signal routing are separate concerns. The UI and engine now preserve that boundary consistently while making source-owned routing much faster to operate and safer around linked clips, deleted Inserts, sends, export, and project reloads.

## Testing performed

- `cmake --build build-linux --target Aestra AudioClipInstanceRenderTest UnitMixerRoutingTest DeleteTrackUndoTest ProjectRoundTripIntegrityTest UIInsertRoutePickerTest -j2`
- `ctest --test-dir build-linux --output-on-failure -j2 -R '^(AudioClipInstanceRenderTest|UnitMixerRoutingTest|DeleteTrackUndoTest|ProjectRoundTripIntegrityTest|ProjectValueFidelityTest|UIInsertRoutePickerTest|RoutingSendPanParityTest|PDCEngineEdgeConstructionTest|PDCRTConsumptionTest|MixerCommandsTest)$'` — 10/10 passed
- `ctest --test-dir build-linux --output-on-failure -j2` — 202/202 configured tests passed; `SecAccountEndToEndSmoke` skipped by its environment gate
- Post-review `cmake --build build-linux --target Aestra -j2` passed

## Producer note

Now you can edit audio clips with safer default headroom and route their shared source directly to any Mixer Insert.

## Docs updated?

No public documentation changed; the controls and interaction hints are self-describing.

## Risk / rollback

Routing, live rendering, export parity, and project loading are touched. Existing persisted clip-edit fields are reused, so there is no project schema bump; missing legacy gain fields still load at unity. Rollback is the two commits in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes: clip-edit persistence is reused without a schema bump; legacy projects and existing saved clip values keep unity gain behavior.
- New audio clips now start with -5 dB (≈0.562 linear) headroom, while legacy/unmodified saved clips retain unity gain.
- Expanded the non-destructive audio clip editor to show gain in dB (with safer -inf handling), plus controls for normalization, playback speed, source start, and clearer shared-vs-unique routing with improved Make Unique/reset behavior.
- Improved routing workflows: clips can be Alt-dragged directly to mixer inserts using stable insert/channel IDs, and mixer send/sidechain operations have safer defaults, sanitization, and more reliable deletion/undo restoration.
- Made playback and timeline behavior consistent by propagating playbackRate and source-start through runtime snapshots/rendering with finite checks and clamping (including overflow-safe sample offset math).
- Refined solo/mute semantics for clearer, additive behavior across Playlist and Mixer: solo is now suppressed when effectively muted, and UI feedback updates for held-solo and muted states; mixer/playlist toggles no longer force each other off.
- Strengthened internal routing and safety: engine/commands now prefer channelId-based targeting; mixer route updates sanitize gain/pan; track/mixer deletion/undo now snapshots/restores mixer routing more robustly.
- Updated UI and tests: added separate “Add Send” vs “Add Sidechain” controls and new drag type for audio-source routes; tests were updated to explicitly set clip edits (unity-gain fixtures) for reliability, and all configured tests passed with the environment-gated smoke test skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->