### PR TITLE
Project dirty state is an invariant of the command history

### DIFF
--- a/AestraAudio/include/CommandManager.h
+++ b/AestraAudio/include/CommandManager.h
@@ -78,8 +78,8 @@ public:
     std::string getUndoName() const { return m_history.getUndoName(); }
     std::string getRedoName() const { return m_history.getRedoName(); }
 
-    void setOnStateChanged(CommandHistory::StateChangedCallback cb) {
-        m_history.setOnStateChanged(std::move(cb));
+    void addOnStateChanged(CommandHistory::StateChangedCallback cb) {
+        m_history.addOnStateChanged(std::move(cb));
     }
 
 private:

--- a/AestraAudio/include/Commands/CommandHistory.h
+++ b/AestraAudio/include/Commands/CommandHistory.h
@@ -128,9 +128,16 @@ public:
 
     // Callbacks for UI updates
     using StateChangedCallback = std::function<void()>;
-    /** @brief Replace all state-changed callbacks with a single one. */
-    void setOnStateChanged(StateChangedCallback cb) { m_onStateChangedCallbacks = {std::move(cb)}; }
-    /** @brief Add an additional state-changed callback without removing existing ones. */
+    /**
+     * @brief Register a state-changed listener.
+     *
+     * Listeners only ever accumulate: several unrelated subsystems observe this
+     * history (project dirty tracking, the history panel, the mixer panel, the
+     * piano roll) and none of them can know about the others. There is
+     * deliberately no "replace all listeners" entry point — the previous
+     * setOnStateChanged() silently destroyed every earlier registration, and
+     * whichever subsystem happened to initialise last won.
+     */
     void addOnStateChanged(StateChangedCallback cb) { m_onStateChangedCallbacks.push_back(std::move(cb)); }
 
 private:

--- a/AestraAudio/include/Commands/CommandHistory.h
+++ b/AestraAudio/include/Commands/CommandHistory.h
@@ -138,7 +138,7 @@ public:
      * setOnStateChanged() silently destroyed every earlier registration, and
      * whichever subsystem happened to initialise last won.
      */
-    void addOnStateChanged(StateChangedCallback cb) { m_onStateChangedCallbacks.push_back(std::move(cb)); }
+    void addOnStateChanged(StateChangedCallback cb);
 
 private:
     std::vector<std::shared_ptr<ICommand>> m_undoStack;
@@ -157,6 +157,17 @@ private:
     void trimHistory();
     void trimHistoryByMemory();
     size_t calculateMemoryUsage() const;
+
+    /**
+     * @brief Invoke every state-changed listener, off the lock.
+     *
+     * Snapshots the listener list under m_mutex and invokes the copies with the
+     * lock released. Both halves matter: callbacks re-enter this class to ask
+     * canUndo()/getUndoName(), so calling them under the lock deadlocks, and
+     * iterating the live vector unlocked races with a registration that
+     * reallocates it.
+     */
+    void notifyStateChanged();
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -83,6 +83,13 @@ public:
         // Wire up playlist model to trigger audio graph rebuild when clips change
         m_playlistModel.setClipChangedCallback(
             [this](const ClipInstanceID&) { requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged); });
+        // Dirty tracking is owned here, not by the application layer. This
+        // manager owns both the undo history and the modified flag, so anything
+        // that runs through the history is by definition a project change.
+        // Wiring it in the constructor means no edit path can forget to call
+        // markModified(), and dirty tracking cannot be lost when a subsystem
+        // that happens to own the wiring fails to initialise.
+        m_commandHistory.addOnStateChanged([this]() { markModified(); });
     }
 
     /**

--- a/AestraAudio/src/Commands/CommandHistory.cpp
+++ b/AestraAudio/src/Commands/CommandHistory.cpp
@@ -11,6 +11,32 @@ CommandHistory::CommandHistory() {
     m_redoStack.reserve(100);
 }
 
+void CommandHistory::addOnStateChanged(StateChangedCallback cb) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_onStateChangedCallbacks.push_back(std::move(cb));
+}
+
+void CommandHistory::notifyStateChanged() {
+    // Snapshot under the lock, invoke with it released.
+    //
+    // Both halves are load-bearing. Callbacks re-enter this class — the history
+    // panel asks canUndo()/getUndoName() from inside its own notification — so
+    // invoking them under m_mutex deadlocks, which is why every call site already
+    // dispatched outside it. But iterating the live vector unlocked races with a
+    // registration that reallocates it, and registration is no longer confined to
+    // startup now that TrackManager subscribes to its own history.
+    std::vector<StateChangedCallback> listeners;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        listeners = m_onStateChangedCallbacks;
+    }
+    for (const auto& cb : listeners) {
+        if (cb) {
+            cb();
+        }
+    }
+}
+
 void CommandHistory::pushAndExecute(std::shared_ptr<ICommand> cmd) {
     if (!cmd)
         return;
@@ -55,7 +81,7 @@ void CommandHistory::pushAndExecute(std::shared_ptr<ICommand> cmd) {
     // Notify listeners AFTER releasing lock to prevent deadlock
     // if callback queries CommandHistory state
     if (stateChanged) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
 }
 
@@ -82,7 +108,7 @@ bool CommandHistory::pushExecuted(std::shared_ptr<ICommand> cmd) {
     }
 
     if (recorded) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
     return recorded;
 }
@@ -128,7 +154,9 @@ void CommandHistory::commitTransaction() {
             stateChanged = true;
         }
 
-        if (stateChanged) { for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); } }
+        if (stateChanged) {
+            notifyStateChanged();
+        }
     }
 }
 
@@ -187,7 +215,7 @@ bool CommandHistory::undo() {
 
     // Phase 4: Notify listeners outside lock
     if (success) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
     return success;
 }
@@ -230,7 +258,7 @@ bool CommandHistory::redo() {
 
     // Phase 4: Notify listeners outside lock
     if (success) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
     return success;
 }
@@ -268,7 +296,9 @@ void CommandHistory::clear() {
         stateChanged = true;
     }
     // Notify AFTER releasing lock
-    if (stateChanged) { for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); } }
+    if (stateChanged) {
+        notifyStateChanged();
+    }
 }
 
 void CommandHistory::setMaxHistorySize(size_t size) {
@@ -365,7 +395,7 @@ void CommandHistory::undoTo(int targetIndex) {
 
     // Phase 4: Notify listeners outside lock
     if (!successfulUndos.empty()) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
 }
 
@@ -410,7 +440,7 @@ void CommandHistory::redoTo(int targetIndex) {
 
     // Phase 4: Notify listeners outside lock
     if (!successfulRedos.empty()) {
-        for (const auto& cb : m_onStateChangedCallbacks) { if (cb) cb(); }
+        notifyStateChanged();
     }
 }
 

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -335,6 +335,14 @@ void AestraApp::initializeContent() {
     m_windowManager->setContent(m_content);
     m_audioController->setContent(m_content);
 
+    // Forward project dirty state to autosave. TrackManager marks itself modified
+    // from its own command history (see its constructor); this is the only hop the
+    // application layer owns. It lives here, not in connectAudioToUI(), because a
+    // failed audio device must not cost the user their unsaved-changes tracking.
+    if (auto trackMgr = m_content->getTrackManager()) {
+        trackMgr->setOnModified([this]() { m_autoSaveManager.markDirty(); });
+    }
+
     wireTakesPanel();
 
     // Performance HUD is created eagerly: it must exist independently of the
@@ -788,13 +796,8 @@ void AestraApp::connectAudioToUI() {
             Aestra::ServiceLocator::provide<Aestra::Audio::TrackManager>(m_content->getTrackManager());
 
             auto trackMgr = m_content->getTrackManager();
-            trackMgr->getCommandHistory().setOnStateChanged([trackMgr]() {
-                if (trackMgr) trackMgr->markModified();
-            });
-            trackMgr->setOnModified([this]() {
-                m_autoSaveManager.markDirty();
-            });
-
+            // Dirty tracking (command history -> markModified -> autosave) is wired
+            // in initializeContent(); it must not depend on the audio device coming up.
             Aestra::PointerRegistry::expectNotNull("AudioEngine", m_audioController->getEngine());
             Aestra::PointerRegistry::expectNotNull("TrackManager", trackMgr.get());
             Aestra::PointerRegistry::validateAll();

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -404,7 +404,6 @@ void TrackManagerUI::pasteClipToRight() {
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
-    m_trackManager->markModified();
     Log::info("Paste-to-right at beat " + std::to_string(newClip.startBeat));
 }
 
@@ -437,7 +436,6 @@ void TrackManagerUI::duplicateSelectedClip() {
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
-    m_trackManager->markModified();
     Log::info("Duplicated selected clip");
 }
 
@@ -457,7 +455,6 @@ void TrackManagerUI::onPaintClip(TrackUIComponent* trackComp, double beat) {
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
-    m_trackManager->markModified();
     Log::info("Pasted clip via Paint/Paste");
 }
 // =============================================================================
@@ -496,7 +493,6 @@ void TrackManagerUI::splitSelectedClipAtPlayhead() {
     auto cmd = std::make_shared<SplitClipCommand>(playlist, m_selectedClipId, splitBeat);
     m_trackManager->getCommandHistory().pushAndExecute(cmd);
 
-    m_trackManager->markModified();
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();

--- a/Tests/AestraAudio/ProjectDirtyStateTest.cpp
+++ b/Tests/AestraAudio/ProjectDirtyStateTest.cpp
@@ -1,0 +1,184 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Project dirty-state integrity (#551).
+//
+// The invariant under test: a TrackManager marks its project modified whenever
+// something runs through its own command history — with no application-layer
+// wiring whatsoever. Dirty tracking used to be installed by AestraApp from
+// inside connectAudioToUI(), so it existed only when the audio device came up,
+// and individual edit paths had to remember to call markModified() by hand.
+// Move-completion, cut and delete never did, so those edits could be lost
+// without a save prompt.
+//
+// Everything below constructs a bare TrackManager. If dirty tracking is not
+// owned by TrackManager itself, these assertions fail.
+
+#include "Commands/AddClipCommand.h"
+#include "Commands/MoveClipCommand.h"
+#include "Commands/RemoveClipCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+using namespace Aestra::Audio;
+
+ClipInstance makeClip(double startBeat) {
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.name = "Clip";
+    clip.startBeat = startBeat;
+    clip.durationBeats = 4.0;
+    return clip;
+}
+
+// Seed a lane holding one clip, leaving the project clean.
+ClipInstanceID seedClip(TrackManager& tracks, PlaylistLaneID& laneOut, double startBeat = 0.0) {
+    auto& playlist = tracks.getPlaylistModel();
+    laneOut = playlist.createLane("Lane");
+    const ClipInstanceID clipId = playlist.addClip(laneOut, makeClip(startBeat));
+    tracks.setModified(false);
+    return clipId;
+}
+
+} // namespace
+
+int main() {
+    // A freshly constructed project has nothing to save.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        require(!tracksOwner->isModified(), "A new TrackManager must not start out modified");
+    }
+
+    // Adding a clip through the history dirties the project. This is the path
+    // that already worked (paste/duplicate/paint called markModified() by hand),
+    // so it pins the baseline the other cases are compared against.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        const PlaylistLaneID laneId = playlist.createLane("Lane");
+        tracks.setModified(false);
+
+        tracks.getCommandHistory().pushAndExecute(
+            std::make_shared<AddClipCommand>(playlist, laneId, makeClip(0.0)));
+        require(tracks.isModified(), "Adding a clip must mark the project modified");
+    }
+
+    // Move completion (TrackManagerUI::finishInstantClipDrag) pushes a
+    // MoveClipCommand and nothing else. Dragging a clip to a new position is an
+    // edit; it must survive as unsaved work.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        tracks.getCommandHistory().pushAndExecute(
+            std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
+        require(tracks.isModified(), "Completing a clip move must mark the project modified");
+    }
+
+    // Cut (TrackManagerUI::cutSelectedClip) and delete
+    // (TrackManagerUI::deleteSelectedClip) both push a RemoveClipCommand.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<RemoveClipCommand>(playlist, clipId));
+        require(tracks.isModified(), "Cutting or deleting a clip must mark the project modified");
+    }
+
+    // Undo and redo move the project away from whatever was last written to
+    // disk, so both are unsaved changes in their own right.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<RemoveClipCommand>(playlist, clipId));
+
+        tracks.setModified(false);
+        require(tracks.getCommandHistory().undo(), "Undo of a clip removal should succeed");
+        require(tracks.isModified(), "Undo must mark the project modified");
+
+        tracks.setModified(false);
+        require(tracks.getCommandHistory().redo(), "Redo of a clip removal should succeed");
+        require(tracks.isModified(), "Redo must mark the project modified");
+    }
+
+    // An operation that fails is not a project change. AddClipCommand reports
+    // itself non-undoable when execute() could not place the clip, so the
+    // history never records it and never reports a state change. The edit paths
+    // used to call markModified() by hand right after pushAndExecute(), which
+    // dirtied the project even when the paste had failed.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        playlist.createLane("Lane");
+        tracks.setModified(false);
+
+        // No lane was ever created with this ID, so the add cannot land.
+        tracks.getCommandHistory().pushAndExecute(
+            std::make_shared<AddClipCommand>(playlist, PlaylistLaneID::generate(), makeClip(0.0)));
+        require(!tracks.isModified(), "A failed clip add must not mark the project modified");
+    }
+
+    // markModified() forwards to the application-layer hook (autosave) on every
+    // history-driven edit, not just on the paths that called it explicitly.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        int onModifiedCount = 0;
+        tracks.setOnModified([&onModifiedCount]() { onModifiedCount++; });
+
+        tracks.getCommandHistory().pushAndExecute(
+            std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
+        require(onModifiedCount == 1, "The modified hook must fire once per history-driven edit");
+    }
+
+    // Panels register their own history listeners. Dirty tracking is not
+    // allowed to be a listener that a later registration can displace, and a
+    // panel listener is not allowed to displace dirty tracking either — the
+    // two must coexist. (CommandHistory deliberately has no replace-all entry
+    // point; this pins the composition behaviour that replaces it.)
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        int panelRefreshCount = 0;
+        tracks.getCommandHistory().addOnStateChanged([&panelRefreshCount]() { panelRefreshCount++; });
+
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<RemoveClipCommand>(playlist, clipId));
+        require(panelRefreshCount == 1, "A panel listener must be notified of history changes");
+        require(tracks.isModified(),
+                "Registering a panel listener must not displace project dirty tracking");
+    }
+
+    std::cout << "[PASS] ProjectDirtyStateTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1219,6 +1219,16 @@ target_include_directories(DropTransactionTest PRIVATE
 add_test(NAME DropTransactionTest COMMAND DropTransactionTest)
 set_tests_properties(DropTransactionTest PROPERTIES LABELS "audio;commands;project")
 
+# Project dirty-state integrity regression test (#551)
+add_executable(ProjectDirtyStateTest AestraAudio/ProjectDirtyStateTest.cpp)
+target_link_libraries(ProjectDirtyStateTest PRIVATE AestraAudioCore)
+target_include_directories(ProjectDirtyStateTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME ProjectDirtyStateTest COMMAND ProjectDirtyStateTest)
+set_tests_properties(ProjectDirtyStateTest PROPERTIES LABELS "audio;commands;project")
+
 # Audio clip instance gain, pan, and fade rendering regression test
 add_executable(AudioClipInstanceRenderTest AestraAudio/AudioClipInstanceRenderTest.cpp)
 target_link_libraries(AudioClipInstanceRenderTest PRIVATE AestraAudioCore)

--- a/Tests/Commands/CommandHistoryTest.cpp
+++ b/Tests/Commands/CommandHistoryTest.cpp
@@ -288,7 +288,7 @@ bool testCallback() {
     CommandHistory history;
     resetCallbackCount();
 
-    history.setOnStateChanged(incrementCallback);
+    history.addOnStateChanged(incrementCallback);
 
     int executeCount = 0;
     int undoCount = 0;
@@ -478,7 +478,7 @@ bool testCallbackCanQueryHistory() {
 
     // Register a callback that re-enters CommandHistory by querying state.
     // This would deadlock if callbacks were invoked while m_mutex is held.
-    history.setOnStateChanged([&]() {
+    history.addOnStateChanged([&]() {
         queryCount++;
         // These all acquire m_mutex internally — safe only if caller doesn't hold it
         [[maybe_unused]] bool cu = history.canUndo();
@@ -522,7 +522,7 @@ bool testCallbackReentryDuringUndoRedo() {
     CommandHistory history;
     int callbackQueries = 0;
 
-    history.setOnStateChanged([&]() {
+    history.addOnStateChanged([&]() {
         callbackQueries++;
         // Re-enter: query state from within the callback
         [[maybe_unused]] bool cu = history.canUndo();

--- a/Tests/Commands/CommandHistoryTest.cpp
+++ b/Tests/Commands/CommandHistoryTest.cpp
@@ -6,10 +6,12 @@
 
 #include "Commands/ICommand.h"
 
+#include <atomic>
 #include <cassert>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 using namespace Aestra::Audio;
 
@@ -590,6 +592,54 @@ bool testMultipleCallbacksReentry() {
     return true;
 }
 
+// Registration is no longer confined to startup: TrackManager subscribes to its
+// own history in its constructor, and panels subscribe as they are built. Adding
+// a listener while another thread is dispatching used to reallocate the vector
+// out from under the loop that was walking it. Run this under TSan.
+bool testConcurrentRegistrationAndDispatch() {
+    std::cout << "TEST: registration concurrent with dispatch... ";
+
+    CommandHistory history;
+    std::atomic<int> notifications{0};
+    history.addOnStateChanged([&notifications]() { notifications.fetch_add(1, std::memory_order_relaxed); });
+
+    // A fixed iteration count rather than a stop flag: the registrar finishes in
+    // microseconds, so a flag-driven dispatcher can be told to stop before the
+    // thread is ever scheduled, and the test then proves nothing while passing.
+    constexpr int kDispatches = 2000;
+    constexpr int kRegistrations = 200;
+
+    std::thread dispatcher([&history]() {
+        int executeCount = 0;
+        int undoCount = 0;
+        for (int i = 0; i < kDispatches; ++i) {
+            history.pushAndExecute(std::make_shared<TestCommand>("Churn", &executeCount, &undoCount));
+            history.undo();
+        }
+    });
+
+    // Registrar: add listeners while that is happening.
+    for (int i = 0; i < kRegistrations; ++i) {
+        history.addOnStateChanged([&notifications]() { notifications.fetch_add(1, std::memory_order_relaxed); });
+    }
+
+    dispatcher.join();
+
+    // The exact count depends on interleaving and is deliberately not asserted.
+    // What matters is that dispatch really happened and nothing raced.
+    assert(notifications.load(std::memory_order_relaxed) > 0);
+
+    // Every listener must still be live afterwards.
+    const int before = notifications.load(std::memory_order_relaxed);
+    int executeCount = 0;
+    int undoCount = 0;
+    history.pushAndExecute(std::make_shared<TestCommand>("Final", &executeCount, &undoCount));
+    assert(notifications.load(std::memory_order_relaxed) == before + kRegistrations + 1);
+
+    std::cout << "✅ PASS\n";
+    return true;
+}
+
 int main() {
     std::cout << "=================================\n";
     std::cout << "  CommandHistory Unit Tests\n";
@@ -622,6 +672,7 @@ int main() {
         {"Callback Re-entry Safety", testCallbackCanQueryHistory},
         {"Callback Re-entry Undo/Redo", testCallbackReentryDuringUndoRedo},
         {"Multiple Callbacks Re-entry", testMultipleCallbacksReentry},
+        {"Concurrent Registration and Dispatch", testConcurrentRegistrationAndDispatch},
     };
 
     for (const auto& test : tests) {

--- a/Tests/Commands/CommandHistoryTest.cpp
+++ b/Tests/Commands/CommandHistoryTest.cpp
@@ -592,6 +592,16 @@ bool testMultipleCallbacksReentry() {
     return true;
 }
 
+// Fixed iteration counts rather than a stop flag: the registrar finishes in
+// microseconds, so a flag-driven dispatcher can be told to stop before the thread
+// is ever scheduled, and the test then proves nothing while passing.
+//
+// Namespace scope, not function-local: MSVC refuses to let a lambda with an
+// explicit capture list reach a local constexpr without naming it in that list
+// (C3493), where GCC and Clang treat it as not odr-used.
+constexpr int kDispatches = 2000;
+constexpr int kRegistrations = 200;
+
 // Registration is no longer confined to startup: TrackManager subscribes to its
 // own history in its constructor, and panels subscribe as they are built. Adding
 // a listener while another thread is dispatching used to reallocate the vector
@@ -602,12 +612,6 @@ bool testConcurrentRegistrationAndDispatch() {
     CommandHistory history;
     std::atomic<int> notifications{0};
     history.addOnStateChanged([&notifications]() { notifications.fetch_add(1, std::memory_order_relaxed); });
-
-    // A fixed iteration count rather than a stop flag: the registrar finishes in
-    // microseconds, so a flag-driven dispatcher can be told to stop before the
-    // thread is ever scheduled, and the test then proves nothing while passing.
-    constexpr int kDispatches = 2000;
-    constexpr int kRegistrations = 200;
 
     std::thread dispatcher([&history]() {
         int executeCount = 0;

--- a/docs/technical/command_model.md
+++ b/docs/technical/command_model.md
@@ -297,11 +297,21 @@ Commands holding audio data should:
 ### 7.3 State Callback
 
 ```cpp
-commandHistory.setOnStateChanged([this]() {
+commandHistory.addOnStateChanged([this]() {
     updateUndoRedoButtons();
     updateEditMenu();
 });
 ```
+
+Listeners accumulate; there is no replace-all entry point. Several unrelated
+subsystems observe the same history — project dirty tracking, the history
+panel, the mixer panel and the piano roll — and none of them can know about the
+others, so a registration must never be able to displace another one.
+
+Project dirty state is not one of these listeners' responsibilities to install:
+`TrackManager` subscribes to its own history in its constructor and calls
+`markModified()`. Anything that runs through the history is a project change by
+definition, so edit paths do not call `markModified()` themselves.
 
 ---
 


### PR DESCRIPTION
Closes the correctness items in #551 that concern dirty state, and the two
architectural reasons they existed.

## What was wrong

**The reported symptom.** Move completion, cut and delete never called
`markModified()`. Paste, duplicate, paint and split did. Whether an edit
survived as unsaved work depended on whether that particular call site had
remembered to say so — dragging a clip, cutting one or deleting one could be
lost with no save prompt.

**Why the call sites could drift.** Dirty tracking was installed by
`AestraApp::connectAudioToUI()`, inside `if (m_audioController->isInitialized())`.
Audio failing to initialise is a supported state — the app logs
*"continuing without audio"* and keeps running — and in that state there was no
dirty tracking and no autosave at all.

**A second one found on the way.** That wiring used
`CommandHistory::setOnStateChanged()`, which **replaced** every previously
registered listener. `AestraContent::setupHistoryAndTakesPanels()` registers the
history-panel and mixer-panel refresh during construction (`AestraContent.cpp:1272`),
and `connectAudioToUI()` runs later (`AestraApp.cpp:598`), so on every start the
app destroyed the panel refresh it had just installed. `PianoRollPanel` registers
the same way and was hit too.

## The fix

`TrackManager` owns both the command history and the modified flag, so it
subscribes to its own history in its constructor. Anything that runs through the
history is a project change by definition. No edit path can forget, and nothing
outside can switch it off.

`setOnStateChanged()` is removed. Listeners now only accumulate — the only safe
rule when four unrelated subsystems observe one history and none can know about
the others. `CommandManager` exposed the same replace-all call and had no
callers; it follows.

The four hand-written `markModified()` calls in `TrackManagerUIClipOps.cpp` go
away as redundant. One was also wrong: `AddClipCommand::isUndoable()` returns
`m_executed`, so a paste whose `execute()` could not place the clip was reported
as not-a-change by the history and then dirtied the project by hand anyway.

## Test

`Tests/AestraAudio/ProjectDirtyStateTest.cpp`, on a bare `TrackManager` with no
application wiring at all:

- add, move, cut/delete, undo and redo each mark the project modified
- a **failed** add does not
- `setOnModified` fires once per history-driven edit
- registering a panel-style listener does not displace dirty tracking

Reverting the constructor wiring and rebuilding fails it at the first
history-driven assertion:

```
[FAIL] Adding a clip must mark the project modified
```

`CommandHistoryTest` (18 tests) and `UnitMixerRoutingTest` still pass; the
former's three `setOnStateChanged` uses were single registrations on fresh
objects and are unchanged in meaning.

## Not in this PR

The rest of #551 — cancelled-drag undo semantics, drop transactionality, the
async plugin-callback lifetime — lands separately, as that issue asks.

Refs #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Breaking API change:** Replaced `setOnStateChanged()` with additive `addOnStateChanged()` and removed the replace-all listener behavior so multiple subsystems can register without displacing each other.
- Made project dirty-state an invariant of command history by moving ownership into `TrackManager`, wiring it via command-history state callbacks (no longer dependent on audio initialization/app wiring).
- Hardened `CommandHistory` listener handling for concurrency: synchronized registration and snapshot-based dispatch invoke callbacks off-lock to avoid iterator invalidation, deadlocks, and re-entrancy issues.
- Removed redundant/manual `markModified()` calls from several clip operations, and ensured failed clip additions no longer mark the project modified.
- Updated docs and tests to reflect accumulating history listeners and the new dirty-state model, including undo/redo behavior, failed-add behavior, listener coexistence, and a concurrent listener-registration regression case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->