### PR TITLE
CI: blast-radius classification by source tree, and gate the advisory lanes

### DIFF
--- a/.github/actions/classify-scope/action.yml
+++ b/.github/actions/classify-scope/action.yml
@@ -1,0 +1,98 @@
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Decide whether one CI lane must do real work for the change under test (#620).
+#
+# WHY A COMPOSITE ACTION AND NOT A REUSABLE WORKFLOW
+#
+# Four of the lanes that consult this are REQUIRED status checks on develop, and the
+# check name is the contract. A reusable workflow (`workflow_call`) reports as
+# "parent / child", which renames every context it runs and hangs every open PR on
+# "Expected — Waiting for status to be reported" forever. A composite action runs
+# inside the calling job, so the job name — and therefore the check name — is
+# untouched. That property is the whole reason for this file's shape.
+#
+# The caller must have checked the repository out first; this shells into scripts/ci.
+
+name: Classify change scope
+description: Decide whether this lane must run for the current change.
+
+inputs:
+  lane:
+    description: >
+      Lane identifier: linux-gcc, windows-msvc, macos-clang, ui-app, asan, tsan,
+      lsan or tidy. An unrecognised value runs the lane (see lane-runs.sh).
+    required: true
+  github-token:
+    description: Token used to read the pull request's changed files.
+    required: true
+
+outputs:
+  run:
+    description: '"true" when this lane must do its real work.'
+    value: ${{ steps.decide.outputs.run }}
+
+runs:
+  using: composite
+  steps:
+    - id: decide
+      # Windows runners default `run:` to PowerShell, which parses this bash as
+      # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
+      # runner, so pinning the shell keeps one implementation across all three
+      # platforms rather than maintaining a pwsh twin of the same logic.
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        LANE: ${{ inputs.lane }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -uo pipefail
+
+        # Push builds establish repository truth. They always run everything.
+        if [ "${EVENT_NAME}" != "pull_request" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "push build: running everything"; exit 0
+        fi
+        # main may only receive changes the full suite has seen.
+        if [ "${BASE_REF}" = "main" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "targets main: running everything"; exit 0
+        fi
+
+        # The REST files endpoint with --paginate, not `gh pr view --json files`:
+        # the latter goes through GraphQL and can return a short list without
+        # saying so. A silently truncated list is SHORT, so it sails under the
+        # size guard and would classify narrow on a change it never saw.
+        # NOTE the field is `filename`. The REST files endpoint returns filename;
+        # `path` is the GraphQL spelling. Asking for .path yields a blank line per
+        # file, exit status 0, and no error — an empty list that looks like a
+        # successful fetch, which then falls back to broad forever and makes this
+        # whole step inert while every check stays green.
+        gh api --paginate \
+          "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+          --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
+
+        # The PR's own changedFiles total, passed to the classifier so it can
+        # refuse to answer when the list it was handed is not the whole change.
+        expected=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+          --json changedFiles --jq '.changedFiles' 2>/dev/null || echo "")
+        fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
+        echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
+        # A mismatch is safe — the classifier falls back to broad — but it must not
+        # be silent, or a broken fetch degrades into "always broad" with every check
+        # green and nobody any the wiser.
+        if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
+          echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
+        fi
+
+        # Invoked through bash explicitly rather than relying on the exec bit
+        # surviving a Windows checkout and on shebang resolution under Git Bash.
+        verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
+        run=$(bash scripts/ci/lane-runs.sh "${verdict}" "${LANE}")
+        echo "classifier verdict: ${verdict} -> lane ${LANE}: ${run}"
+        echo "run=${run}" >> "$GITHUB_OUTPUT"
+        if [ "${run}" != "true" ]; then
+          echo "nothing in this change can affect the ${LANE} lane; skipping its work"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: false
 
-      # --- Phase 1 lane selection (#620) -------------------------------------
+      # --- Lane selection (#620) ---------------------------------------------
       # This job's NAME is a required status check on develop, so it must always run
       # and always report a conclusion. A skipped workflow reports nothing at all, and
       # a required context that never reports hangs every PR on "Expected — Waiting
@@ -33,86 +33,38 @@ jobs:
       #
       # The classifier may only skip when certain: unknown paths, oversized change
       # sets and anything targeting main fall back to running everything.
-      # See scripts/ci/classify-changes.sh.
+      # See scripts/ci/classify-changes.sh and scripts/ci/lane-runs.sh.
       - name: Classify change scope
         id: scope
-        # Windows runners default `run:` to PowerShell, which parses this bash as
-        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
-        # runner, so pinning the shell keeps one implementation across all three
-        # platforms rather than maintaining a pwsh twin of the same logic.
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "push build: running everything"; exit 0
-          fi
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "targets main: running everything"; exit 0
-          fi
-          # The REST files endpoint with --paginate, not `gh pr view --json files`:
-          # the latter goes through GraphQL and can return a short list without
-          # saying so. A silently truncated list is SHORT, so it sails under the
-          # size guard and would classify narrow on a change it never saw.
-          # NOTE the field is `filename`. The REST files endpoint returns filename;
-          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
-          # file, exit status 0, and no error — an empty list that looks like a
-          # successful fetch, which then falls back to broad forever and makes this
-          # whole step inert while every check stays green.
-          gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          # The PR's own changedFiles total, passed to the classifier so it can
-          # refuse to answer when the list it was handed is not the whole change.
-          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json changedFiles \
-            --jq '.changedFiles' 2>/dev/null || echo "")
-          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
-          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
-          # A mismatch is safe — the classifier falls back to broad — but it must not
-          # be silent, or a broken fetch degrades into "always broad" with every check
-          # green and nobody any the wiser.
-          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
-            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
-          fi
-          # Invoked through bash explicitly rather than relying on the exec bit
-          # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
-          echo "classifier verdict: ${verdict}"
-          if [ "${verdict}" = "skip-cxx" ]; then
-            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
-            echo "nothing here can affect a C++ build; skipping compile and tests"
-          else
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-          fi
-
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: linux-gcc
+          github-token: ${{ github.token }}
       - name: Install Dependencies
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev cmake
 
       - name: Configure
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON
 
       - name: Build
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-linux.xml
 
       - name: License verification tests
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always() && steps.scope.outputs.run_cxx == 'true'
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-linux
@@ -120,7 +72,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
@@ -153,7 +105,7 @@ jobs:
         with:
           submodules: false
 
-      # --- Phase 1 lane selection (#620) -------------------------------------
+      # --- Lane selection (#620) ---------------------------------------------
       # This job's NAME is a required status check on develop, so it must always run
       # and always report a conclusion. A skipped workflow reports nothing at all, and
       # a required context that never reports hangs every PR on "Expected — Waiting
@@ -162,73 +114,25 @@ jobs:
       #
       # The classifier may only skip when certain: unknown paths, oversized change
       # sets and anything targeting main fall back to running everything.
-      # See scripts/ci/classify-changes.sh.
+      # See scripts/ci/classify-changes.sh and scripts/ci/lane-runs.sh.
       - name: Classify change scope
         id: scope
-        # Windows runners default `run:` to PowerShell, which parses this bash as
-        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
-        # runner, so pinning the shell keeps one implementation across all three
-        # platforms rather than maintaining a pwsh twin of the same logic.
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "push build: running everything"; exit 0
-          fi
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "targets main: running everything"; exit 0
-          fi
-          # The REST files endpoint with --paginate, not `gh pr view --json files`:
-          # the latter goes through GraphQL and can return a short list without
-          # saying so. A silently truncated list is SHORT, so it sails under the
-          # size guard and would classify narrow on a change it never saw.
-          # NOTE the field is `filename`. The REST files endpoint returns filename;
-          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
-          # file, exit status 0, and no error — an empty list that looks like a
-          # successful fetch, which then falls back to broad forever and makes this
-          # whole step inert while every check stays green.
-          gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          # The PR's own changedFiles total, passed to the classifier so it can
-          # refuse to answer when the list it was handed is not the whole change.
-          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json changedFiles \
-            --jq '.changedFiles' 2>/dev/null || echo "")
-          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
-          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
-          # A mismatch is safe — the classifier falls back to broad — but it must not
-          # be silent, or a broken fetch degrades into "always broad" with every check
-          # green and nobody any the wiser.
-          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
-            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
-          fi
-          # Invoked through bash explicitly rather than relying on the exec bit
-          # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
-          echo "classifier verdict: ${verdict}"
-          if [ "${verdict}" = "skip-cxx" ]; then
-            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
-            echo "nothing here can affect a C++ build; skipping compile and tests"
-          else
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-          fi
-
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: ui-app
+          github-token: ${{ github.token }}
       - name: Install Dependencies
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libsdl2-dev libfreetype-dev
 
       - name: Configure (UI enabled)
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake -B build-app -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_ENABLE_UI=ON -DAESTRA_ENABLE_TESTS=OFF
 
       - name: Build app target
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build build-app --config ${{env.BUILD_TYPE}} --target Aestra --parallel
 
   build-windows:
@@ -239,7 +143,7 @@ jobs:
         with:
           submodules: false
 
-      # --- Phase 1 lane selection (#620) -------------------------------------
+      # --- Lane selection (#620) ---------------------------------------------
       # This job's NAME is a required status check on develop, so it must always run
       # and always report a conclusion. A skipped workflow reports nothing at all, and
       # a required context that never reports hangs every PR on "Expected — Waiting
@@ -248,63 +152,15 @@ jobs:
       #
       # The classifier may only skip when certain: unknown paths, oversized change
       # sets and anything targeting main fall back to running everything.
-      # See scripts/ci/classify-changes.sh.
+      # See scripts/ci/classify-changes.sh and scripts/ci/lane-runs.sh.
       - name: Classify change scope
         id: scope
-        # Windows runners default `run:` to PowerShell, which parses this bash as
-        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
-        # runner, so pinning the shell keeps one implementation across all three
-        # platforms rather than maintaining a pwsh twin of the same logic.
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "push build: running everything"; exit 0
-          fi
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "targets main: running everything"; exit 0
-          fi
-          # The REST files endpoint with --paginate, not `gh pr view --json files`:
-          # the latter goes through GraphQL and can return a short list without
-          # saying so. A silently truncated list is SHORT, so it sails under the
-          # size guard and would classify narrow on a change it never saw.
-          # NOTE the field is `filename`. The REST files endpoint returns filename;
-          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
-          # file, exit status 0, and no error — an empty list that looks like a
-          # successful fetch, which then falls back to broad forever and makes this
-          # whole step inert while every check stays green.
-          gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          # The PR's own changedFiles total, passed to the classifier so it can
-          # refuse to answer when the list it was handed is not the whole change.
-          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json changedFiles \
-            --jq '.changedFiles' 2>/dev/null || echo "")
-          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
-          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
-          # A mismatch is safe — the classifier falls back to broad — but it must not
-          # be silent, or a broken fetch degrades into "always broad" with every check
-          # green and nobody any the wiser.
-          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
-            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
-          fi
-          # Invoked through bash explicitly rather than relying on the exec bit
-          # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
-          echo "classifier verdict: ${verdict}"
-          if [ "${verdict}" = "skip-cxx" ]; then
-            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
-            echo "nothing here can affect a C++ build; skipping compile and tests"
-          else
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-          fi
-
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: windows-msvc
+          github-token: ${{ github.token }}
       - name: Cache vcpkg artifacts
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -318,7 +174,7 @@ jobs:
             windows-vcpkg-${{ env.VCPKG_REF }}-${{ runner.os }}-
 
       - name: Setup vcpkg and libsodium
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         shell: pwsh
         run: |
           $env:VCPKG_ROOT = "$env:RUNNER_TEMP\vcpkg"
@@ -353,7 +209,7 @@ jobs:
           & "$env:VCPKG_ROOT\vcpkg.exe" install libsodium:x64-windows gtest:x64-windows
 
       - name: Configure
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         shell: pwsh
         run: |
           $env:VCPKG_ROOT = "$env:RUNNER_TEMP\vcpkg"
@@ -365,22 +221,22 @@ jobs:
             -DVCPKG_TARGET_TRIPLET=x64-windows
 
       - name: Build
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         working-directory: build
         shell: bash
         run: ctest --test-dir . -C ${{env.BUILD_TYPE}} --output-on-failure --output-junit ctest-results-windows.xml
 
       - name: License verification tests
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         shell: bash
         run: ctest --test-dir build -C ${{env.BUILD_TYPE}} -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always() && steps.scope.outputs.run_cxx == 'true'
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-windows
@@ -388,7 +244,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run == 'true'
         shell: bash
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -416,7 +272,7 @@ jobs:
         with:
           submodules: false
 
-      # --- Phase 1 lane selection (#620) -------------------------------------
+      # --- Lane selection (#620) ---------------------------------------------
       # This job's NAME is a required status check on develop, so it must always run
       # and always report a conclusion. A skipped workflow reports nothing at all, and
       # a required context that never reports hangs every PR on "Expected — Waiting
@@ -425,86 +281,38 @@ jobs:
       #
       # The classifier may only skip when certain: unknown paths, oversized change
       # sets and anything targeting main fall back to running everything.
-      # See scripts/ci/classify-changes.sh.
+      # See scripts/ci/classify-changes.sh and scripts/ci/lane-runs.sh.
       - name: Classify change scope
         id: scope
-        # Windows runners default `run:` to PowerShell, which parses this bash as
-        # PowerShell and dies with a ParserError. Git Bash ships on every GitHub
-        # runner, so pinning the shell keeps one implementation across all three
-        # platforms rather than maintaining a pwsh twin of the same logic.
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "push build: running everything"; exit 0
-          fi
-          if [ "${{ github.base_ref }}" = "main" ]; then
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-            echo "targets main: running everything"; exit 0
-          fi
-          # The REST files endpoint with --paginate, not `gh pr view --json files`:
-          # the latter goes through GraphQL and can return a short list without
-          # saying so. A silently truncated list is SHORT, so it sails under the
-          # size guard and would classify narrow on a change it never saw.
-          # NOTE the field is `filename`. The REST files endpoint returns filename;
-          # `path` is the GraphQL spelling. Asking for .path yields a blank line per
-          # file, exit status 0, and no error — an empty list that looks like a
-          # successful fetch, which then falls back to broad forever and makes this
-          # whole step inert while every check stays green.
-          gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' > /tmp/changed-files.txt || : > /tmp/changed-files.txt
-          # The PR's own changedFiles total, passed to the classifier so it can
-          # refuse to answer when the list it was handed is not the whole change.
-          expected=$(gh pr view "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --json changedFiles \
-            --jq '.changedFiles' 2>/dev/null || echo "")
-          fetched=$(grep -c . /tmp/changed-files.txt) || fetched=0
-          echo "changed files: fetched ${fetched}, PR reports ${expected:-unknown}"
-          # A mismatch is safe — the classifier falls back to broad — but it must not
-          # be silent, or a broken fetch degrades into "always broad" with every check
-          # green and nobody any the wiser.
-          if [ -n "${expected}" ] && [ "${fetched}" != "${expected}" ]; then
-            echo "::warning::changed-file fetch returned ${fetched} of ${expected} files; falling back to a full build"
-          fi
-          # Invoked through bash explicitly rather than relying on the exec bit
-          # surviving a Windows checkout and on shebang resolution under Git Bash.
-          verdict=$(bash scripts/ci/classify-changes.sh /tmp/changed-files.txt "${expected}")
-          echo "classifier verdict: ${verdict}"
-          if [ "${verdict}" = "skip-cxx" ]; then
-            echo "run_cxx=false" >> "$GITHUB_OUTPUT"
-            echo "nothing here can affect a C++ build; skipping compile and tests"
-          else
-            echo "run_cxx=true" >> "$GITHUB_OUTPUT"
-          fi
-
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: macos-clang
+          github-token: ${{ github.token }}
       - name: Install Dependencies
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: |
           brew update
           brew install cmake pkg-config libsodium googletest
 
       - name: Configure
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAestra_CORE_MODE=ON -DAESTRA_CI=ON -DCMAKE_PREFIX_PATH="/opt/homebrew;/usr/local"
 
       - name: Build
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Test
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml
 
       - name: License verification tests
-        if: steps.scope.outputs.run_cxx == 'true'
+        if: steps.scope.outputs.run == 'true'
         run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
 
       - name: Upload test report
-        if: always() && steps.scope.outputs.run_cxx == 'true'
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-macos
@@ -512,7 +320,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Discord Notification
-        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run_cxx == 'true'
+        if: always() && env.DISCORD_WEBHOOK != '' && steps.scope.outputs.run == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
@@ -568,6 +376,11 @@ jobs:
       - name: Classifier unit tests
         run: bash scripts/ci/classify-changes.test.sh
 
+      # The verdict is only half the decision; this is the other half. A wrong entry
+      # here removes a check just as effectively as a wrong verdict does.
+      - name: Lane policy unit tests
+        run: bash scripts/ci/lane-runs.test.sh
+
       # Level 2: the wiring. The unit tests all passed while the pipeline was dead,
       # because the bug was in how the file list was fetched, not in how it was
       # judged. This runs the real command against known history.
@@ -616,6 +429,27 @@ jobs:
             echo "safety ok: workflow-only #618 -> broad"
           fi
 
+          # LIVENESS (phase 2): #596 changed one .cpp under Source/Components and
+          # nothing else. No headless target compiles that file — AESTRA_CI=ON
+          # force-disables the UI — so only the UI/App lane can observe it. If this
+          # stops saying ui-app-only, the phase 2 rule has gone inert.
+          v=$(verdict_for 596) || fail=1
+          if [ "${v:-}" != "ui-app-only" ]; then
+            echo "::error::LIVENESS: UI-only #596 classified '${v:-<none>}', expected ui-app-only"
+            fail=1
+          else
+            echo "liveness ok: UI-only #596 -> ui-app-only"
+          fi
+
+          # SAFETY: #610 touched AestraAudio and a test. Never narrow.
+          v=$(verdict_for 610) || fail=1
+          if [ "${v:-}" != "broad" ]; then
+            echo "::error::SAFETY: audio change #610 classified '${v:-<none>}', expected broad"
+            fail=1
+          else
+            echo "safety ok: audio+test #610 -> broad"
+          fi
+
           exit "${fail}"
 
   format-check:
@@ -644,15 +478,29 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # --- Lane selection (#620) ---------------------------------------------
+      # Advisory lanes are not required contexts, but they are 38.8 of the 85
+      # runner-minutes a PR costs. They build with AESTRA_CI=ON, which force-disables
+      # the UI, so a docs-only or UI-only change cannot produce a finding here.
+      - name: Classify change scope
+        id: scope
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: tidy
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-tidy-14 clang-format-14 libsodium-dev libsecret-1-dev
 
       - name: Configure
+        if: steps.scope.outputs.run == 'true'
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DAestra_CORE_MODE=ON -DAESTRA_CI=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run clang-tidy
+        if: steps.scope.outputs.run == 'true'
         run: |
           clang-tidy-14 --config-file=.clang-tidy \
             AestraCore/src/*.cpp \
@@ -671,12 +519,25 @@ jobs:
         with:
           submodules: false
 
+      # --- Lane selection (#620) ---------------------------------------------
+      # Advisory lanes are not required contexts, but they are 38.8 of the 85
+      # runner-minutes a PR costs. They build with AESTRA_CI=ON, which force-disables
+      # the UI, so a docs-only or UI-only change cannot produce a finding here.
+      - name: Classify change scope
+        id: scope
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: asan
+          github-token: ${{ github.token }}
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev libgtest-dev cmake
 
       - name: Configure
+        if: steps.scope.outputs.run == 'true'
         run: >
           cmake -B build-asan -S .
           -DCMAKE_BUILD_TYPE=Debug
@@ -686,14 +547,16 @@ jobs:
           -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
 
       - name: Build
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build build-asan --config Debug
 
       - name: Test
+        if: steps.scope.outputs.run == 'true'
         working-directory: build-asan
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-asan.xml
 
       - name: Upload sanitizer test report
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-asan
@@ -712,23 +575,38 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      # --- Lane selection (#620) ---------------------------------------------
+      # Advisory lanes are not required contexts, but they are 38.8 of the 85
+      # runner-minutes a PR costs. They build with AESTRA_CI=ON, which force-disables
+      # the UI, so a docs-only or UI-only change cannot produce a finding here.
+      - name: Classify change scope
+        id: scope
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: tsan
+          github-token: ${{ github.token }}
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
 
       - name: Configure
+        if: steps.scope.outputs.run == 'true'
         run: cmake --preset ci-tsan
 
       - name: Build
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build --preset ci-tsan --parallel 2
 
       - name: Test
+        if: steps.scope.outputs.run == 'true'
         working-directory: build/ci-tsan
         run: ctest --parallel 2 --output-on-failure --output-junit ctest-results-tsan.xml
 
       - name: Upload TSan test report
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-tsan
@@ -750,23 +628,38 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      # --- Lane selection (#620) ---------------------------------------------
+      # Advisory lanes are not required contexts, but they are 38.8 of the 85
+      # runner-minutes a PR costs. They build with AESTRA_CI=ON, which force-disables
+      # the UI, so a docs-only or UI-only change cannot produce a finding here.
+      - name: Classify change scope
+        id: scope
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: lsan
+          github-token: ${{ github.token }}
+
       - name: Install Dependencies
+        if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev libsodium-dev libsecret-1-dev cmake
 
       - name: Configure
+        if: steps.scope.outputs.run == 'true'
         run: cmake --preset ci-lsan
 
       - name: Build
+        if: steps.scope.outputs.run == 'true'
         run: cmake --build --preset ci-lsan --parallel 2
 
       - name: Test
+        if: steps.scope.outputs.run == 'true'
         working-directory: build/ci-lsan
         run: ctest --parallel 2 --output-on-failure --output-junit ctest-results-lsan.xml
 
       - name: Upload LSan test report
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ctest-results-lsan

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -12,12 +12,30 @@
 # "broad", because classifier uncertainty is allowed to cost compute and is never
 # allowed to cost correctness.
 #
-# Phase 1 is deliberately coarse: it answers one question — "is this change entirely
+# Phase 1 was deliberately coarse: it answered one question — "is this change entirely
 # within a set of paths that provably cannot affect a C++ build?" — and nothing else.
-# There is no per-subsystem selection here, because Aestra's lanes are organised by
-# PLATFORM, not by subsystem: each of Linux/Windows/macOS runs the whole suite. The
-# safe unit today is therefore the whole lane. Subsystem and test-level selection are
-# phases 2 and 3 of #620, and phase 3 is blocked on 45 unlabelled tests.
+#
+# Phase 2 adds one more verdict, and it rests on a fact about how Aestra is built
+# rather than on a judgement about how coupled its subsystems feel:
+#
+#   AESTRA_CI=ON force-disables AESTRA_ENABLE_UI (CMakeLists.txt), and every lane
+#   except "Linux (UI/App compile)" passes AESTRA_CI=ON.
+#
+# So AestraUI/ and Source/ are compiled by exactly ONE lane. A change confined to
+# them cannot break the others, because the others never see those files — the same
+# reason the UI/App lane had to be added in the first place (#396, #443).
+#
+# The exception, and the reason this is derived rather than hardcoded: a handful of
+# .cpp files under Source/ and AestraUI/ are named explicitly in the root and test
+# CMakeLists and therefore DO compile in headless builds — ProjectSerializer, the
+# Muse agent, the panel tests. Those are read out of the CMake files at classification
+# time (see headless_compiled_sources), so adding one cannot silently invalidate the
+# rule later.
+#
+# Headers are not eligible. A .h under Source/ or AestraUI/ may be included by one of
+# those headless-compiled .cpp files, and proving otherwise needs a real include graph.
+#
+# Test-level selection is phase 3 of #620 and remains blocked on 45 unlabelled tests.
 #
 # Usage:  classify-changes.sh <file-with-one-changed-path-per-line> [expected-count]
 #
@@ -27,7 +45,12 @@
 # the size guard below only fires when the returned list is large, and a truncated
 # list is by definition short. The cross-check is what closes that hole.
 #
-# Output: "broad" or "skip-cxx" on stdout.
+# Output, on stdout, one of:
+#   broad        run every lane
+#   skip-cxx     nothing here can affect a C++ build; no C++ lane needs to run
+#   ui-app-only  only the UI/App compile lane can observe this change
+#
+# scripts/ci/lane-runs.sh turns a verdict into a per-lane yes/no.
 #
 # Exit status is 0 for a successful classification; a non-zero exit means the caller
 # must treat the result as broad.
@@ -36,6 +59,9 @@ set -uo pipefail
 
 FILE_LIST="${1:-}"
 EXPECTED_COUNT="${2:-}"
+
+# Scratch file holding headless_compiled_sources(); populated by main().
+HEADLESS_LIST=""
 
 # Above this many changed files, do not trust the list. GitHub's changed-files API
 # truncates at 300 entries, and a truncated list looks exactly like a smaller change
@@ -60,6 +86,44 @@ is_cxx_irrelevant() {
         .gitignore|.gitattributes|.editorconfig) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+# The repository this script lives in. Derived from the script's own location so it
+# does not depend on the caller's working directory.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)" || REPO_ROOT=""
+
+# .cpp files under Source/ or AestraUI/ that headless builds compile anyway, because
+# the root or test CMakeLists names them explicitly rather than reaching them through
+# add_subdirectory(Source) / add_subdirectory(AestraUI) — both of which are inside
+# `if(AESTRA_ENABLE_UI)` and therefore absent whenever AESTRA_CI=ON.
+#
+# Read out of the CMake files rather than pinned here: a hardcoded list would go stale
+# the first time somebody adds a Source/*.cpp to a headless test target, and it would
+# go stale INTO A SKIP — the direction that costs correctness. Source/CMakeLists.txt is
+# deliberately not consulted; that file is the UI application itself.
+#
+# Over-capture is harmless. The list is only ever used to force a path back to broad,
+# so matching too much costs compute and never costs correctness.
+headless_compiled_sources() {
+    [[ -n "${REPO_ROOT}" ]] || return 1
+    local files=("${REPO_ROOT}/CMakeLists.txt" "${REPO_ROOT}/Tests/CMakeLists.txt")
+    local f
+    for f in "${REPO_ROOT}"/Tests/cmake/*.cmake; do
+        [[ -r "${f}" ]] && files+=("${f}")
+    done
+    grep -rhoE '(Source|AestraUI)/[A-Za-z0-9_./-]+\.cpp' "${files[@]}" 2>/dev/null | sort -u
+}
+
+# Is this path compiled only by the "Linux (UI/App compile)" lane?
+is_ui_app_only() {
+    # `case` globs span '/', so these cover every depth under the two trees.
+    case "$1" in
+        AestraUI/*.cpp|Source/*.cpp) ;;
+        *) return 1 ;;
+    esac
+    # Named by a headless CMake target: every lane compiles it.
+    grep -qxF -- "$1" "${HEADLESS_LIST}" && return 1
+    return 0
 }
 
 main() {
@@ -101,15 +165,40 @@ main() {
         fi
     fi
 
+    # Materialise the headless-compiled set once. If it comes back empty the
+    # derivation is broken — wrong working directory, renamed CMake file, a grep that
+    # stopped matching — and every UI path would look skippable. That is a fail-open,
+    # so refuse to classify narrow at all rather than trust it.
+    HEADLESS_LIST="$(mktemp)" || { echo "broad"; return 0; }
+    trap 'rm -f "${HEADLESS_LIST}"' EXIT
+    headless_compiled_sources > "${HEADLESS_LIST}"
+    local headless_count
+    headless_count=$(grep -c . "${HEADLESS_LIST}" 2>/dev/null) || headless_count=0
+    local trust_ui_rule=1
+    if [[ "${headless_count}" -eq 0 ]]; then
+        trust_ui_rule=0
+    fi
+
     # A single unrecognised path is enough to force the full matrix.
     local path
+    local saw_ui_app=0
     while IFS= read -r path; do
         [[ -z "${path}" ]] && continue
-        if ! is_cxx_irrelevant "${path}"; then
-            echo "broad"
-            return 0
+        if is_cxx_irrelevant "${path}"; then
+            continue
         fi
+        if [[ "${trust_ui_rule}" -eq 1 ]] && is_ui_app_only "${path}"; then
+            saw_ui_app=1
+            continue
+        fi
+        echo "broad"
+        return 0
     done < "${FILE_LIST}"
+
+    if [[ "${saw_ui_app}" -eq 1 ]]; then
+        echo "ui-app-only"
+        return 0
+    fi
 
     echo "skip-cxx"
 }

--- a/scripts/ci/classify-changes.test.sh
+++ b/scripts/ci/classify-changes.test.sh
@@ -57,10 +57,40 @@ expect skip-cxx "#619 as merged"                 "AestraDocs/images/aestra_daw_i
 expect skip-cxx "#615 as merged"                 "workers/license-signing/package.json" \
                                                  "workers/license-signing/package-lock.json"
 
+# --- phase 2: changes only the UI/App compile lane can observe ---------------
+# AESTRA_CI=ON force-disables AESTRA_ENABLE_UI, and every lane but "Linux (UI/App
+# compile)" sets it — so nothing else compiles these files.
+expect ui-app-only "UI widget source"            "AestraUI/Widgets/UIMixerButtonRow.cpp"
+expect ui-app-only "app source"                  "Source/App/AestraApp.cpp"
+expect ui-app-only "component source"            "Source/Components/TrackManagerUIClipOps.cpp"
+expect ui-app-only "several UI sources"          "AestraUI/Widgets/UIMixerButtonRow.cpp" \
+                                                 "Source/Panels/MixerPanel.cpp"
+expect ui-app-only "UI source plus docs"         "docs/index.md" "Source/App/AestraApp.cpp"
+
+# Headers are never eligible: a header under these trees may be included by one of
+# the .cpp files that headless targets DO compile, and one-level grepping cannot
+# prove otherwise.
+expect broad "UI header"                         "AestraUI/Widgets/UIMixerButtonRow.h"
+expect broad "app header"                        "Source/App/AestraApp.h"
+expect broad "UI source plus its own header"     "Source/App/AestraApp.cpp" "Source/App/AestraApp.h"
+
+# .cpp files under the UI trees that headless targets compile by name. These are read
+# out of the CMake files at classification time; if that derivation breaks, these
+# cases start failing rather than silently widening the skip.
+expect broad "serializer (compiled by tests)"    "Source/Core/ProjectSerializer.cpp"
+expect broad "take manager (compiled by tests)"  "Source/Core/TakeManager.cpp"
+expect broad "headless main"                     "Source/App/HeadlessMain.cpp"
+expect broad "muse agent"                        "Source/MuseAgent/AgentLoop.cpp"
+expect broad "panel compiled by a test"          "Source/Panels/WindowPanel.cpp"
+expect broad "theme compiled by a test"          "AestraUI/Core/NUITheme.cpp"
+expect broad "cursor service compiled by a test" "AestraUI/Platform/NUICursorService.cpp"
+expect broad "one headless source among UI"      "Source/App/AestraApp.cpp" \
+                                                 "Source/Core/ProjectSerializer.cpp"
+
 # --- anything touching the build must be broad ------------------------------
 expect broad "C++ source"                        "AestraAudio/src/Core/AudioEngine.cpp"
-expect broad "UI source"                         "AestraUI/Widgets/UIMixerButtonRow.cpp"
-expect broad "app source"                        "Source/App/AestraApp.cpp"
+expect broad "audio source with UI source"       "AestraAudio/src/Core/AudioEngine.cpp" \
+                                                 "Source/App/AestraApp.cpp"
 expect broad "header"                            "AestraCore/include/AestraJSON.h"
 expect broad "root CMakeLists"                   "CMakeLists.txt"
 expect broad "cmake module"                      "cmake/LowMemory.cmake"
@@ -79,8 +109,11 @@ expect broad "mostly docs, one CMake"            "README.md" "docs/index.md" "CM
 # --- paths that merely LOOK like the safe ones ------------------------------
 # These are the ones an unanchored pattern gets wrong, and the reason every rule
 # in the classifier is anchored at the start of the path.
-expect broad "source file named after docs"      "Source/Panels/AestraDocsPanel.cpp"
-expect broad "source path containing 'workers'"  "Source/Core/WorkersPool.cpp"
+# These two are app sources whose paths contain a safe-list word. Phase 2 classifies
+# them as UI/app work, which is the point: what must never happen is their being read
+# as documentation or as the worker tree and skipping the C++ matrix entirely.
+expect ui-app-only "source file named after docs"    "Source/Panels/AestraDocsPanel.cpp"
+expect ui-app-only "source path containing 'workers'" "Source/Core/WorkersPool.cpp"
 expect broad "a README inside a source tree"     "AestraAudio/README.md"
 expect broad "top-level file not on the list"    "requirements.txt"
 expect broad "new unknown directory"             "AestraNewModule/src/Thing.cpp"
@@ -156,6 +189,41 @@ tc broad    "list longer than reported"          1 "docs/a.md" "README.md"
 tc broad    "expected count not a number"        "abc" "docs/a.md"
 tc broad    "expected count empty-ish garbage"   "-1" "docs/a.md"
 tc broad    "truncated AND source present"       40 "docs/a.md" "AestraAudio/src/x.cpp"
+
+# --- the derivation must fail safe, not fail open ---------------------------
+# The ui-app-only rule depends on reading the headless-compiled .cpp list out of the
+# CMake files. If that read returns nothing — moved file, renamed variable, a grep
+# that stopped matching — every UI path would look skippable and the classifier would
+# quietly start skipping the one lane that compiles them. Copy the script somewhere
+# with no repository around it and confirm it refuses to classify narrow.
+orphan="${TMP}/orphan/scripts/ci"
+mkdir -p "${orphan}"
+cp "${CLASSIFY}" "${orphan}/classify-changes.sh"
+printf 'Source/App/AestraApp.cpp\n' > "${TMP}/orphan-list"
+checks=$((checks + 1))
+orphan_verdict="$(bash "${orphan}/classify-changes.sh" "${TMP}/orphan-list")"
+if [[ "${orphan_verdict}" == "broad" ]]; then
+    printf 'PASS  %-58s -> broad\n' "no CMake files to derive from (fail safe)"
+else
+    printf 'FAIL  %-58s -> %s (expected broad)\n' \
+        "no CMake files to derive from (fail safe)" "${orphan_verdict}"
+    failures=$((failures + 1))
+fi
+
+# LIVENESS, stated directly rather than left implicit. Every ui-app-only expectation
+# above would also pass if the classifier had degraded into answering broad to
+# everything, because broad is the safe answer and safety is what most of this file
+# asserts. Name the case that can only pass when the feature is actually working.
+checks=$((checks + 1))
+printf 'AestraUI/Widgets/UIMixerButtonRow.cpp\n' > "${TMP}/live-list"
+live_verdict="$("${CLASSIFY}" "${TMP}/live-list")"
+if [[ "${live_verdict}" == "ui-app-only" ]]; then
+    printf 'PASS  %-58s -> ui-app-only\n' "liveness: the narrow verdict is reachable"
+else
+    printf 'FAIL  %-58s -> %s (expected ui-app-only)\n' \
+        "liveness: the narrow verdict is reachable" "${live_verdict}"
+    failures=$((failures + 1))
+fi
 
 echo
 if [[ "${failures}" -eq 0 ]]; then

--- a/scripts/ci/lane-runs.sh
+++ b/scripts/ci/lane-runs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Turn a classifier verdict into a per-lane decision. See issue #620.
+#
+# Usage:  lane-runs.sh <verdict> <lane-id>
+# Output: "true" or "false" on stdout.
+#
+# THE CONTRACT — an unknown verdict or an unknown lane prints "true". Every path
+# through this script that is not a deliberate, justified skip must run the lane.
+# A typo in a lane id must cost compute, never coverage.
+#
+# This exists as a separate script, rather than as an `if` in the workflow, so the
+# policy is in one place and can be unit-tested. Eight jobs consult it; a table that
+# lived in YAML would be eight copies that drift.
+#
+# WHY EACH SKIP IS SAFE
+#
+#   skip-cxx     The change is documentation, prose or the Cloudflare worker. No lane
+#                compiles any of it.
+#
+#   ui-app-only  The change touches only .cpp files under AestraUI/ or Source/ that no
+#                headless target compiles. AESTRA_CI=ON force-disables AESTRA_ENABLE_UI
+#                (CMakeLists.txt), and every lane except "Linux (UI/App compile)" sets
+#                AESTRA_CI=ON — so no other lane has those files in its build at all.
+#                This is the same fact that made the UI/App lane necessary (#396, #443):
+#                the app could silently stop building for a week because nothing else
+#                compiled it. Read in the other direction, it says exactly this.
+#
+# NOT skipped for ui-app-only, deliberately:
+#
+#   format       12 seconds. Gating it costs more in complexity than it saves.
+#   ui-app       The one lane that can actually observe the change.
+
+set -uo pipefail
+
+VERDICT="${1:-}"
+LANE="${2:-}"
+
+# Lanes that compile with AESTRA_CI=ON, i.e. with the UI and the application
+# force-disabled. None of them can observe a change confined to the UI/app trees.
+is_headless_lane() {
+    case "$1" in
+        linux-gcc|windows-msvc|macos-clang|asan|tsan|lsan|tidy) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+main() {
+    case "${VERDICT}" in
+        skip-cxx)
+            # Nothing compiles prose. The UI/App lane included.
+            case "${LANE}" in
+                linux-gcc|windows-msvc|macos-clang|ui-app|asan|tsan|lsan|tidy)
+                    echo "false"; return 0 ;;
+            esac
+            ;;
+        ui-app-only)
+            if is_headless_lane "${LANE}"; then
+                echo "false"; return 0
+            fi
+            ;;
+        broad)
+            : # everything runs
+            ;;
+        *)
+            : # unknown verdict: everything runs
+            ;;
+    esac
+
+    echo "true"
+}
+
+main

--- a/scripts/ci/lane-runs.test.sh
+++ b/scripts/ci/lane-runs.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Tests for lane-runs.sh — the verdict → lane policy table.
+#
+# As with the classifier, the negative direction is the one that matters: this table
+# decides whether REQUIRED status checks do real work, so a wrong "false" removes a
+# gate. Unknown input must always come back "true".
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_RUNS="${HERE}/lane-runs.sh"
+
+failures=0
+checks=0
+
+# expect <expected> <verdict> <lane>
+expect() {
+    local expected="$1" verdict="$2" lane="$3"
+    checks=$((checks + 1))
+    local actual
+    actual="$(bash "${LANE_RUNS}" "${verdict}" "${lane}")"
+    if [[ "${actual}" == "${expected}" ]]; then
+        printf 'PASS  %-22s %-14s -> %s\n' "${verdict}" "${lane}" "${actual}"
+    else
+        printf 'FAIL  %-22s %-14s -> %s (expected %s)\n' \
+            "${verdict}" "${lane}" "${actual}" "${expected}"
+        failures=$((failures + 1))
+    fi
+}
+
+ALL_LANES=(linux-gcc windows-msvc macos-clang ui-app asan tsan lsan tidy)
+
+# --- broad runs everything --------------------------------------------------
+for lane in "${ALL_LANES[@]}"; do
+    expect true broad "${lane}"
+done
+
+# --- skip-cxx runs no C++ lane, the UI/App lane included --------------------
+for lane in "${ALL_LANES[@]}"; do
+    expect false skip-cxx "${lane}"
+done
+
+# --- ui-app-only: only the lane that compiles the UI ------------------------
+expect true  ui-app-only ui-app
+expect false ui-app-only linux-gcc
+expect false ui-app-only windows-msvc
+expect false ui-app-only macos-clang
+expect false ui-app-only asan
+expect false ui-app-only tsan
+expect false ui-app-only lsan
+expect false ui-app-only tidy
+
+# --- anything unrecognised must run -----------------------------------------
+# A typo in a verdict or a lane id is allowed to cost compute. It is never allowed to
+# remove a check, so every unknown combination answers true.
+expect true "" ""
+expect true "" linux-gcc
+expect true broad ""
+expect true skip-cxx ""
+expect true ui-app-only ""
+expect true "typo-verdict" linux-gcc
+expect true "typo-verdict" ui-app
+expect true skip-cxx "lane-that-does-not-exist"
+expect true ui-app-only "lane-that-does-not-exist"
+expect true "UI-APP-ONLY" linux-gcc  # case matters; a near-miss must not skip
+
+# --- liveness ----------------------------------------------------------------
+# Every assertion above except these would still pass if the script had degraded into
+# printing "true" unconditionally, because "true" is the safe answer. These are the
+# ones that fail when the feature stops working.
+checks=$((checks + 1))
+if [[ "$(bash "${LANE_RUNS}" ui-app-only windows-msvc)" == "false" &&
+      "$(bash "${LANE_RUNS}" skip-cxx linux-gcc)" == "false" ]]; then
+    printf 'PASS  %-37s -> false\n' "liveness: skips are reachable"
+else
+    printf 'FAIL  %-37s\n' "liveness: skips are reachable"
+    failures=$((failures + 1))
+fi
+
+echo
+if [[ "${failures}" -eq 0 ]]; then
+    echo "ALL PASSED (${checks} checks)"
+    exit 0
+fi
+echo "FAILURES: ${failures} of ${checks}"
+exit 1


### PR DESCRIPTION
Phase 2 of #620, plus a gap phase 1 left behind.

## 1. The advisory lanes were never gated

Phase 1 (#621) gated the four required C++ lanes. ASan, TSan, LSan and
clang-tidy — **38.8 of the 85 runner-minutes a PR costs** — were untouched, so a
documentation-only PR still ran the address sanitizer over the whole audio
engine. They now consult the same verdict.

## 2. Phase 2 rests on a build fact, not on a coupling judgement

```
CMakeLists.txt:50   AESTRA_CI=ON  →  AESTRA_ENABLE_UI=OFF (FORCE)
```

Every lane except **Linux (UI/App compile)** passes `AESTRA_CI=ON`. So
`AestraUI/` and `Source/` are compiled by exactly one lane. This is not an
inference about how coupled the subsystems feel — it is the same fact that made
the UI/App lane necessary in the first place (#396, #443: the app silently
stopped building for a week because nothing else compiled it). Read backwards,
it says a UI-only change needs exactly that one lane and nothing else.

New verdict `ui-app-only` → runs `ui-app`, skips `linux-gcc`, `windows-msvc`,
`macos-clang`, `asan`, `tsan`, `lsan`, `tidy`. Critical path 17.9 min → 4.4 min.

**The exception is derived, not pinned.** A handful of `.cpp` files under
`Source/` and `AestraUI/` are named explicitly by the root and test CMakeLists
and *do* compile headlessly — `ProjectSerializer`, `TakeManager`, the Muse
agent, the panel and theme tests. `classify-changes.sh` reads that set out of
the CMake files at classification time, so adding one cannot silently invalidate
the rule later. If the derivation ever returns nothing it refuses to classify
narrow at all, because fail-open is the only direction that costs correctness.

## What this does not do, and the honest measurement

**Headers are not eligible.** A `.h` under those trees may be included by one of
the headless-compiled `.cpp` files, and proving otherwise needs a real include
graph.

Measured against fourteen recent merged PRs, that is what keeps most of them
broad:

| shape | example | verdict |
|---|---|---|
| one `.cpp` under `Source/Components` | #596 | `ui-app-only` |
| one `.cpp` + its own header | #604, #595 | `broad` |
| audio + tests | #610, #623 | `broad` |
| everything else measured | 10 more | `broad` |

**1 of 14.** An include-closure rule over the headless-compiled sources would
catch #604 and #595 too, and is worth doing as a follow-up — but guessing at it
is not, so it is not in this PR.

## Structure

The verdict → lane decision moves to `scripts/ci/lane-runs.sh` so the policy is
one testable table rather than eight `if` expressions. The scope step becomes a
composite action at `.github/actions/classify-scope`.

Composite, deliberately, **not** a reusable workflow: `workflow_call` reports as
`parent / child`, which renames every required context and hangs every open PR
on *"Expected — Waiting for status to be reported"* forever, exactly as #620
warns. A composite action runs inside the calling job, so the job name — and
therefore the check name — is untouched.

All five required contexts verified unchanged: `Linux (GCC)`, `Windows (MSVC)`,
`macOS (Clang)`, `Linux (UI/App compile)`, `license-signing`.

## Coverage

- `classify-changes.test.sh`: 42 → **59** checks
- `lane-runs.test.sh`: **35** checks (new)

Both carry an explicit **liveness** case. Every other assertion in them would
also pass if the scripts had degraded into always-broad / always-run — that is
precisely the fail-open that shipped in phase 1's first draft and hid behind a
green matrix. Named cases now fail when the feature stops working.

The self-test job asserts the same end to end against merged PRs whose file
lists can never change: #619 → `skip-cxx`, **#596 → `ui-app-only`**, #618 →
`broad`, **#610 → `broad`**.

Phase 3 (test-level slicing) remains blocked on the 45 unlabelled tests, as
#620 requires.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)