### PR TITLE
A drop that appends a lane is one undo step

### DIFF
--- a/AestraAudio/src/Commands/CreateLaneCommand.cpp
+++ b/AestraAudio/src/Commands/CreateLaneCommand.cpp
@@ -14,7 +14,17 @@ void CreateLaneCommand::execute() {
     if (m_executed)
         return;
 
-    m_laneId = m_model.createLane(m_name);
+    // Re-executing after an undo must restore the lane's ORIGINAL identity, not mint
+    // a fresh one. Anything grouped with this command in the same undo step still
+    // refers to the old ID — an AddClipCommand batched with it holds the lane it was
+    // told to add to — so a new ID silently drops those members onto a lane that no
+    // longer exists. CommandTransaction replays its members through execute() rather
+    // than redo(), so the restore has to live here and not only in redo().
+    //
+    // On the first execute m_laneId is invalid and createLaneWithId generates one;
+    // it also falls back to a generated ID if the requested one has been taken in
+    // the meantime (#446).
+    m_laneId = m_model.createLaneWithId(m_laneId, m_name);
     m_executed = true;
 }
 
@@ -30,9 +40,8 @@ void CreateLaneCommand::redo() {
     if (m_executed)
         return;
 
-    // Re-create the lane with the same name
-    // The ID will be different on redo since we can't reuse the old ID
-    m_laneId = m_model.createLane(m_name);
+    // Same identity restore as execute(); see the note there.
+    m_laneId = m_model.createLaneWithId(m_laneId, m_name);
     m_executed = true;
 }
 

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -79,6 +79,18 @@ AestraUI::DropFeedback TrackManagerUI::onDragEnter(const AestraUI::DragData& dat
 }
 
 AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) {
+    // Same payload allowlist as onDragEnter. Without it, dragging an effect across
+    // the timeline showed Copy feedback for the whole traverse — onDragEnter refused
+    // it and onDrop refuses it, but the cursor said it would land.
+    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::MidiClip &&
+        data.type != AestraUI::DragDataType::Pattern) {
+        if (m_showDropPreview) {
+            m_showDropPreview = false;
+            setDirty(true);
+        }
+        return AestraUI::DropFeedback::Invalid;
+    }
+
     // Keep feedback "Invalid" for unsupported formats while hovering.
     if (data.type == AestraUI::DragDataType::File && !AudioFileValidator::hasValidAudioExtension(data.filePath)) {
         if (m_showDropPreview) {
@@ -197,17 +209,53 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     }
 
     // 2. Resolve target lane
+    //
+    // A drop that has to append a lane must undo as ONE step: the lane is part of
+    // the edit, not scaffolding around it. Creating it through CreateLaneCommand
+    // rather than calling playlist.createLane() directly is what lets it join the
+    // clip in a single transaction — otherwise Ctrl+Z removes the clip and leaves
+    // an empty orphan lane the user never asked for and cannot undo away.
     PlaylistLaneID targetLaneId;
-    bool createdTargetLane = false;
+    std::shared_ptr<CreateLaneCommand> laneCommand;
     if (laneIndex == static_cast<int>(laneCount)) {
-        // Create new lane if dropping at the end
-        targetLaneId = playlist.createLane("Lane " + std::to_string(laneIndex + 1));
-        createdTargetLane = targetLaneId.isValid();
+        laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Lane " + std::to_string(laneIndex + 1));
+        laneCommand->execute();
+        targetLaneId = laneCommand->getLaneId();
+        if (!targetLaneId.isValid()) {
+            laneCommand.reset();
+            result.accepted = false;
+            result.message = "Could not create lane";
+            clearDropPreview();
+            return result;
+        }
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
     } else {
         targetLaneId = playlist.getLaneId(laneIndex);
     }
+
+    // Undo the appended lane without recording anything: a drop that failed is not
+    // history. Reused lanes are left alone.
+    auto rollbackLane = [&laneCommand]() {
+        if (laneCommand) {
+            laneCommand->undo();
+        }
+    };
+
+    // Adopt an already-executed clip command, plus the lane it needed, as one undo
+    // step. The members were executed stepwise — each validated against the state
+    // its predecessor produced — so the transaction is adopted with
+    // markExecuted()/pushExecuted() rather than replayed by the history.
+    auto commitDrop = [this, &laneCommand](const std::string& name,
+                                           const std::shared_ptr<ICommand>& clipCommand) {
+        auto transaction = std::make_shared<CommandTransaction>(name);
+        if (laneCommand) {
+            transaction->add(laneCommand);
+        }
+        transaction->add(clipCommand);
+        transaction->markExecuted();
+        return m_trackManager->getCommandHistory().pushExecuted(transaction);
+    };
 
     // 3. Handle Pattern Drop
     if (data.type == AestraUI::DragDataType::Pattern) {
@@ -238,17 +286,17 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 }
 
                 auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
-                m_trackManager->getCommandHistory().pushAndExecute(cmd);
+                cmd->execute();
 
                 if (!playlist.getClip(clip.id)) {
-                    if (createdTargetLane) {
-                        playlist.removeLane(targetLaneId);
-                    }
+                    rollbackLane();
                     result.accepted = false;
                     result.message = "Could not place pattern";
                     clearDropPreview();
                     return result;
                 }
+
+                commitDrop("Add Pattern Clip", cmd);
 
                 result.accepted = true;
                 result.message = "Pattern added: " + pattern->name;
@@ -258,16 +306,12 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 invalidateCache();
                 scheduleTimelineMinimapRebuild();
             } else {
-                if (createdTargetLane) {
-                    playlist.removeLane(targetLaneId);
-                }
+                rollbackLane();
                 result.accepted = false;
                 result.message = "Pattern not found";
             }
         } else {
-            if (createdTargetLane) {
-                playlist.removeLane(targetLaneId);
-            }
+            rollbackLane();
             result.accepted = false;
             result.message = "Invalid pattern ID";
         }
@@ -289,11 +333,16 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
             // Helper to create clip once source is ready. Async decode and queued tasks capture only weakSelf so
             // they cannot call back into a destroyed TrackManagerUI.
+            //
+            // Returns whether a clip was actually placed. The already-decoded branch
+            // below calls this synchronously and used to report success no matter what
+            // happened inside — a file whose duration decoded as zero, or whose pattern
+            // could not be created, still told the user "Imported".
             auto createClipFromSource = [weakSelf, sourceId, displayName = data.displayName, targetLaneId,
-                                         createdTargetLane, timePositionBeats]() {
+                                         laneCommand, timePositionBeats]() -> bool {
                 auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                 if (!self || !self->m_trackManager)
-                    return;
+                    return false;
 
                 auto& sourceManager = self->m_trackManager->getSourceManager();
                 ClipSource* source = sourceManager.getSource(sourceId);
@@ -314,18 +363,31 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 }
 
                 auto rollbackCreatedLane = [&]() {
-                    if (!createdTargetLane) {
+                    if (!laneCommand) {
                         return;
                     }
-                    self->m_trackManager->getPlaylistModel().removeLane(targetLaneId);
+                    laneCommand->undo();
                     self->refreshTracks();
                     self->invalidateCache();
                     self->scheduleTimelineMinimapRebuild();
                 };
 
+                // Same one-undo-step contract as the synchronous paths: the lane the
+                // import had to append belongs to the import, so it is adopted into the
+                // transaction alongside the clip rather than left outside history.
+                auto commitImport = [&](const std::shared_ptr<ICommand>& clipCommand) {
+                    auto transaction = std::make_shared<CommandTransaction>("Import Audio Clip");
+                    if (laneCommand) {
+                        transaction->add(laneCommand);
+                    }
+                    transaction->add(clipCommand);
+                    transaction->markExecuted();
+                    self->m_trackManager->getCommandHistory().pushExecuted(transaction);
+                };
+
                 if (!source || !source->isReady()) {
                     rollbackCreatedLane();
-                    return;
+                    return false;
                 }
 
                 double durationSeconds = source->getDurationSeconds();
@@ -334,7 +396,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     !std::isfinite(durationBeats) || durationBeats <= 0.0) {
                     rollbackCreatedLane();
                     Log::error("[TrackManagerUI] Invalid decoded duration for imported source");
-                    return;
+                    return false;
                 }
                 Log::info("[TrackManagerUI] Duration: " + std::to_string(durationSeconds) +
                           "s, beats: " + std::to_string(durationBeats));
@@ -368,22 +430,26 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                     clip.edits = ClipEdits::forNewAudioClip();
 
                     auto cmd = std::make_shared<AddClipCommand>(playlist, targetLaneId, clip);
-                    self->m_trackManager->getCommandHistory().pushAndExecute(cmd);
+                    cmd->execute();
                     if (!playlist.getClip(clip.id)) {
                         patternManager.removePattern(patternId);
                         rollbackCreatedLane();
                         Log::error("[TrackManagerUI] Failed to add imported clip to target lane; removed orphan audio pattern");
-                        return;
+                        return false;
                     }
+
+                    commitImport(cmd);
 
                     self->refreshTracks();
                     self->invalidateCache();
                     self->scheduleTimelineMinimapRebuild();
                     Log::info("[TrackManagerUI] Clip added successfully via command");
-                } else {
-                    rollbackCreatedLane();
-                    Log::error("[TrackManagerUI] PatternManager::createAudioPattern failed");
+                    return true;
                 }
+
+                rollbackCreatedLane();
+                Log::error("[TrackManagerUI] PatternManager::createAudioPattern failed");
+                return false;
             };
 
             if (!source->isReady()) {
@@ -522,15 +588,19 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
                 result.accepted = true;
                 result.message = "Importing...";
             } else {
-                // Already loaded, proceed immediately
-                createClipFromSource();
-                result.accepted = true;
-                result.message = "Imported: " + data.displayName;
+                // Already loaded, proceed immediately — and report what actually
+                // happened. createClipFromSource rolls back the appended lane on every
+                // failure path, so a false here means nothing was left behind either.
+                if (createClipFromSource()) {
+                    result.accepted = true;
+                    result.message = "Imported: " + data.displayName;
+                } else {
+                    result.accepted = false;
+                    result.message = "Could not import " + data.displayName;
+                }
             }
         } else {
-            if (createdTargetLane) {
-                playlist.removeLane(targetLaneId);
-            }
+            rollbackLane();
             result.accepted = false;
             result.message = "Failed to create source";
         }

--- a/Tests/AestraAudio/DropTransactionTest.cpp
+++ b/Tests/AestraAudio/DropTransactionTest.cpp
@@ -1,0 +1,149 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// A drop that appends a lane is one undo step (#551).
+//
+// TrackManagerUI::onDrop used to call playlist.createLane() directly and then push
+// the AddClipCommand on its own. The lane was therefore outside history: undoing the
+// drop removed the clip and left an empty orphan lane the user never asked for and
+// could not undo away. It now builds a CommandTransaction holding the lane command
+// and the clip command, executed stepwise and adopted via markExecuted() +
+// pushExecuted().
+//
+// Grouping them exposed a second defect. CreateLaneCommand::redo() used to mint a
+// fresh lane ID ("the ID will be different on redo since we can't reuse the old
+// ID"), but AddClipCommand still holds the lane it was constructed with — so redo
+// re-created an empty lane and dropped the clip onto an ID that no longer existed.
+//
+// This test drives the commands directly. The UI layer is not headless-testable, but
+// the transaction shape it now builds is exactly what is asserted here.
+
+#include "Commands/AddClipCommand.h"
+#include "Commands/CommandTransaction.h"
+#include "Commands/CreateLaneCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+using namespace Aestra::Audio;
+
+ClipInstance makeClip() {
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.name = "Dropped";
+    clip.startBeat = 4.0;
+    clip.durationBeats = 4.0;
+    return clip;
+}
+
+} // namespace
+
+int main() {
+    // --- a drop onto an appended lane undoes and redoes as one step -------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        const size_t lanesBefore = playlist.getLaneCount();
+
+        // What onDrop does: append the lane through a command, place the clip, then
+        // adopt both as a single already-executed transaction.
+        auto laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Lane 1");
+        laneCommand->execute();
+        const PlaylistLaneID laneId = laneCommand->getLaneId();
+        require(laneId.isValid(), "Lane command did not produce a lane");
+
+        const ClipInstance clip = makeClip();
+        auto clipCommand = std::make_shared<AddClipCommand>(playlist, laneId, clip);
+        clipCommand->execute();
+        require(playlist.getClip(clip.id) != nullptr, "Clip was not placed on the appended lane");
+
+        auto transaction = std::make_shared<CommandTransaction>("Add Pattern Clip");
+        transaction->add(laneCommand);
+        transaction->add(clipCommand);
+        transaction->markExecuted();
+        require(history.pushExecuted(transaction), "The drop transaction was refused by the history");
+
+        require(playlist.getLaneCount() == lanesBefore + 1, "Drop did not append its lane");
+
+        // One Ctrl+Z removes the clip AND the lane it had to create.
+        require(history.undo(), "Undo of the drop transaction failed");
+        require(playlist.getClip(clip.id) == nullptr, "Undo left the dropped clip behind");
+        require(playlist.getLaneCount() == lanesBefore,
+                "Undo left an orphan lane behind — the lane was not part of the undo step");
+
+        // Redo must restore the lane's ORIGINAL identity, or the clip command
+        // re-adds to a lane that no longer exists and the clip is silently lost.
+        require(history.redo(), "Redo of the drop transaction failed");
+        require(playlist.getLaneCount() == lanesBefore + 1, "Redo did not restore the lane");
+        require(laneCommand->getLaneId() == laneId, "Redo minted a new lane ID instead of restoring the original");
+        require(playlist.getClip(clip.id) != nullptr, "Redo lost the dropped clip");
+        require(playlist.findClipLane(clip.id) == laneId, "Redo restored the clip onto the wrong lane");
+    }
+
+    // --- a drop onto an existing lane records only the clip ---------------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        const PlaylistLaneID existing = playlist.createLane("Existing");
+        const size_t lanesBefore = playlist.getLaneCount();
+
+        const ClipInstance clip = makeClip();
+        auto clipCommand = std::make_shared<AddClipCommand>(playlist, existing, clip);
+        clipCommand->execute();
+
+        auto transaction = std::make_shared<CommandTransaction>("Add Pattern Clip");
+        transaction->add(clipCommand); // no lane command: the lane was reused
+        transaction->markExecuted();
+        require(history.pushExecuted(transaction), "The drop transaction was refused by the history");
+
+        require(history.undo(), "Undo of the drop transaction failed");
+        require(playlist.getClip(clip.id) == nullptr, "Undo left the dropped clip behind");
+        require(playlist.getLaneCount() == lanesBefore, "Undo removed a lane the drop did not create");
+    }
+
+    // --- a failed drop is not history, and leaves nothing behind ----------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        const size_t lanesBefore = playlist.getLaneCount();
+
+        auto laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Lane 1");
+        laneCommand->execute();
+        require(playlist.getLaneCount() == lanesBefore + 1, "Lane command did not append a lane");
+
+        // The clip cannot be placed — this stands in for a pattern that could not be
+        // resolved or a source that decoded to nothing. onDrop rolls the lane back
+        // directly, without recording anything.
+        const ClipInstance clip = makeClip();
+        auto clipCommand = std::make_shared<AddClipCommand>(playlist, PlaylistLaneID::generate(), clip);
+        clipCommand->execute();
+        require(playlist.getClip(clip.id) == nullptr, "The failed drop unexpectedly placed its clip");
+
+        laneCommand->undo();
+
+        require(playlist.getLaneCount() == lanesBefore, "A failed drop left its appended lane behind");
+        require(!history.canUndo(), "A failed drop was recorded in the undo history");
+    }
+
+    std::cout << "[PASS] DropTransactionTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1209,6 +1209,16 @@ target_include_directories(UnitMixerRoutingTest PRIVATE
 add_test(NAME UnitMixerRoutingTest COMMAND UnitMixerRoutingTest)
 set_tests_properties(UnitMixerRoutingTest PROPERTIES LABELS "audio;arsenal;routing")
 
+# Drop-as-one-undo-step regression test (#551)
+add_executable(DropTransactionTest AestraAudio/DropTransactionTest.cpp)
+target_link_libraries(DropTransactionTest PRIVATE AestraAudioCore)
+target_include_directories(DropTransactionTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME DropTransactionTest COMMAND DropTransactionTest)
+set_tests_properties(DropTransactionTest PROPERTIES LABELS "audio;commands;project")
+
 # Audio clip instance gain, pan, and fade rendering regression test
 add_executable(AudioClipInstanceRenderTest AestraAudio/AudioClipInstanceRenderTest.cpp)
 target_link_libraries(AudioClipInstanceRenderTest PRIVATE AestraAudioCore)


### PR DESCRIPTION
The drop-transactionality item from #551, plus a history-identity bug it
uncovered.

## The lane was outside history

`onDrop` called `playlist.createLane()` directly and then pushed the
`AddClipCommand` separately. Undoing a drop removed the clip and **left the lane
behind** — empty, unasked for, and not removable by another Ctrl+Z. The lane is
part of the edit, not scaffolding around it.

Both are now adopted into one `CommandTransaction` via
`markExecuted()`/`pushExecuted()` — the stepwise-batch path `CommandHistory`
already documents for members validated against the state their predecessors
produced. Failure rolls the lane back directly and records nothing: a drop that
failed is not history.

The audio-import path carries the lane command into its async completion, so a
decode that finishes minutes later still commits as a single step.

## Which exposed a redo-identity bug

`CreateLaneCommand` minted a **fresh lane ID** whenever it re-ran:

```cpp
// Re-create the lane with the same name
// The ID will be different on redo since we can't reuse the old ID
m_laneId = m_model.createLane(m_name);
```

Any command grouped with it still holds the ID it was constructed with. So redo
re-created an empty lane and re-added the clip to an ID that no longer existed —
the clip silently vanished.

It now restores its original identity through `createLaneWithId` (#446), which
falls back to a generated ID if the old one has been taken. The restore lives in
`execute()`, **not only `redo()`**, because `CommandTransaction::redo()` replays
its members through `execute()` — the first fix went in `redo()` alone and the
test still failed.

## Two smaller items from the same audit

- **The already-decoded import path reported success unconditionally.** A file
  whose duration decoded as zero, or whose pattern could not be created, still
  told the user *"Imported"*. `createClipFromSource` now returns whether a clip
  was placed and the caller reports that.
- **`onDragOver` did not apply `onDragEnter`'s payload allowlist**, so dragging
  an effect across the timeline showed `Copy` feedback for the whole traverse
  even though enter had refused it and drop would refuse it too.

## Test

`Tests/AestraAudio/DropTransactionTest.cpp` drives the commands directly. The UI
layer is not headless-testable, but the transaction shape `onDrop` now builds is
exactly what is asserted:

- undo removes the clip **and** the lane it had to create
- redo restores the lane under its **original ID**, with the clip back inside it
- a drop onto an existing lane does not remove that lane on undo
- a failed drop leaves neither a lane nor a history entry

Reverting `CreateLaneCommand` and rebuilding fails it:

```
[FAIL] Redo minted a new lane ID instead of restoring the original
```

## Stale parts of the #551 entry

- *"async plugin callback captures `this` strongly"* — already fixed; every
  async path in this file captures `weak_from_this()`.
- *"creates the lane **and mixer channel** before validating"* — `onDrop` no
  longer creates a mixer channel at all.

Unsupported payloads were already rejected before lane creation; what remained
was that the lane, once created, was not part of the edit's history.

Refs #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)