### PR TITLE
A cancelled clip drag is not project history

### DIFF
--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -263,14 +263,23 @@ void TrackManagerUI::cancelInstantClipDrag() {
 
     Log::info("Cancelled instant clip drag");
 
-    // Revert position using command so it's undoable
+    // Put the clip back where the drag started, WITHOUT recording history.
+    //
+    // User cancellation is not project history. This used to revert by pushing a
+    // MoveClipCommand, which was undoable in exactly the wrong direction: the
+    // command captures the clip's current — i.e. dragged — position as its
+    // "original", so the next Ctrl+Z re-applied the movement the user had just
+    // cancelled. It also cleared the redo stack, so cancelling a drag destroyed
+    // whatever the user still had to redo.
+    //
+    // The live drag itself never went through the history either
+    // (updateInstantClipDrag moves the model directly for smoothness), so there is
+    // nothing on the stack to undo here — only a position to restore.
     if (m_trackManager && m_draggedClipId.isValid()) {
         auto& playlist = m_trackManager->getPlaylistModel();
         auto laneId = playlist.findClipLane(m_draggedClipId);
         if (laneId.isValid() && m_clipOriginalLaneId.isValid()) {
-            auto cmd = std::make_shared<MoveClipCommand>(playlist, m_draggedClipId, m_clipOriginalStartTime,
-                                                         m_clipOriginalLaneId);
-            m_trackManager->getCommandHistory().pushAndExecute(cmd);
+            playlist.moveClip(m_draggedClipId, m_clipOriginalStartTime, m_clipOriginalLaneId);
         }
     }
 

--- a/Tests/AestraAudio/CancelledDragHistoryTest.cpp
+++ b/Tests/AestraAudio/CancelledDragHistoryTest.cpp
@@ -1,0 +1,148 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// User cancellation is not project history (#551).
+//
+// TrackManagerUI::cancelInstantClipDrag used to put the clip back by pushing a
+// MoveClipCommand. That is undoable in exactly the wrong direction: the command
+// captures the clip's CURRENT position as its "original", and at cancel time the
+// current position is the dragged one. So the revert executed correctly, then sat
+// on the undo stack waiting to re-apply the movement the user had just cancelled.
+// Pushing it also cleared the redo stack, so cancelling a drag destroyed whatever
+// the user still had to redo.
+//
+// The live drag never went through the history in the first place —
+// updateInstantClipDrag moves the model directly for smoothness — so a cancel has
+// nothing to undo, only a position to restore.
+//
+// TrackManagerUI is not headless-testable. What is asserted here is the shape the
+// cancel path now has, and the shape it used to have, against the same model the
+// UI drives: the first block shows a command-based revert leaving the cancelled
+// position on the undo stack, the second shows a direct restore leaving history
+// untouched.
+
+#include "Commands/AddClipCommand.h"
+#include "Commands/MoveClipCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+using namespace Aestra::Audio;
+
+constexpr double kOriginalBeat = 0.0;
+constexpr double kDraggedBeat = 8.0;
+
+struct Fixture {
+    std::unique_ptr<TrackManager> tracks = std::make_unique<TrackManager>();
+    PlaylistLaneID laneA;
+    PlaylistLaneID laneB;
+    ClipInstanceID clipId;
+
+    Fixture() {
+        auto& playlist = tracks->getPlaylistModel();
+        laneA = playlist.createLane("A");
+        laneB = playlist.createLane("B");
+
+        ClipInstance clip;
+        clip.id = ClipInstanceID::generate();
+        clip.name = "Dragged";
+        clip.startBeat = kOriginalBeat;
+        clip.durationBeats = 4.0;
+        clipId = playlist.addClip(laneA, clip);
+        tracks->setModified(false);
+    }
+
+    // What updateInstantClipDrag does every frame: move the model directly, no
+    // command, so the drag stays smooth and leaves no history behind.
+    void dragTo(double beat, const PlaylistLaneID& lane) {
+        tracks->getPlaylistModel().moveClip(clipId, beat, lane);
+    }
+
+    double beat() const {
+        const auto* clip = tracks->getPlaylistModel().getClip(clipId);
+        return clip ? clip->startBeat : -1.0;
+    }
+};
+
+} // namespace
+
+int main() {
+    // --- why the command-based revert was wrong --------------------------------
+    // Reverting through the history does restore the position, but it leaves the
+    // cancelled movement on the undo stack, one Ctrl+Z away from coming back.
+    {
+        Fixture f;
+        auto& playlist = f.tracks->getPlaylistModel();
+        auto& history = f.tracks->getCommandHistory();
+
+        f.dragTo(kDraggedBeat, f.laneB);
+
+        auto revert = std::make_shared<MoveClipCommand>(playlist, f.clipId, kOriginalBeat, f.laneA);
+        history.pushAndExecute(revert);
+        require(f.beat() == kOriginalBeat, "The command-based revert did not restore the position");
+
+        require(history.canUndo(), "Precondition: the revert command is on the undo stack");
+        require(history.undo(), "Undo of the revert command failed");
+        require(f.beat() == kDraggedBeat,
+                "Precondition for this whole test: undoing a command-based revert resurrects the "
+                "cancelled drag. If this ever stops being true, the cancel path can be simplified.");
+    }
+
+    // --- the cancel path: restore, record nothing ------------------------------
+    {
+        Fixture f;
+        auto& playlist = f.tracks->getPlaylistModel();
+        auto& history = f.tracks->getCommandHistory();
+
+        f.dragTo(kDraggedBeat, f.laneB);
+        require(f.beat() == kDraggedBeat, "Precondition: the drag moved the clip");
+
+        // cancelInstantClipDrag
+        playlist.moveClip(f.clipId, kOriginalBeat, f.laneA);
+
+        require(f.beat() == kOriginalBeat, "Cancelling a drag must restore the original position");
+        require(playlist.findClipLane(f.clipId) == f.laneA, "Cancelling a drag must restore the original lane");
+        require(!history.canUndo(), "A cancelled drag must not put anything on the undo stack");
+        require(!f.tracks->isModified(),
+                "A cancelled drag leaves the project exactly as it was, so it is not a modification");
+    }
+
+    // --- cancelling must not destroy the user's redo ---------------------------
+    // pushAndExecute clears the redo stack. Reverting through the history therefore
+    // threw away redo state that had nothing to do with the drag.
+    {
+        Fixture f;
+        auto& playlist = f.tracks->getPlaylistModel();
+        auto& history = f.tracks->getCommandHistory();
+
+        // An unrelated edit, undone, so there is something to redo.
+        ClipInstance other;
+        other.id = ClipInstanceID::generate();
+        other.name = "Other";
+        other.startBeat = 16.0;
+        other.durationBeats = 4.0;
+        history.pushAndExecute(std::make_shared<AddClipCommand>(playlist, f.laneB, other));
+        require(history.undo(), "Setup: undoing the unrelated edit failed");
+        require(history.canRedo(), "Setup: the unrelated edit should be redoable");
+
+        f.dragTo(kDraggedBeat, f.laneB);
+        playlist.moveClip(f.clipId, kOriginalBeat, f.laneA); // cancelInstantClipDrag
+
+        require(history.canRedo(), "Cancelling a drag must not discard the user's redo history");
+        require(history.redo(), "Redo after a cancelled drag failed");
+        require(playlist.getClip(other.id) != nullptr, "Redo after a cancelled drag lost the unrelated edit");
+    }
+
+    std::cout << "[PASS] CancelledDragHistoryTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1219,6 +1219,16 @@ target_include_directories(DropTransactionTest PRIVATE
 add_test(NAME DropTransactionTest COMMAND DropTransactionTest)
 set_tests_properties(DropTransactionTest PROPERTIES LABELS "audio;commands;project")
 
+# Cancelled-drag history regression test (#551)
+add_executable(CancelledDragHistoryTest AestraAudio/CancelledDragHistoryTest.cpp)
+target_link_libraries(CancelledDragHistoryTest PRIVATE AestraAudioCore)
+target_include_directories(CancelledDragHistoryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME CancelledDragHistoryTest COMMAND CancelledDragHistoryTest)
+set_tests_properties(CancelledDragHistoryTest PROPERTIES LABELS "audio;commands;project")
+
 # Audio clip instance gain, pan, and fade rendering regression test
 add_executable(AudioClipInstanceRenderTest AestraAudio/AudioClipInstanceRenderTest.cpp)
 target_link_libraries(AudioClipInstanceRenderTest PRIVATE AestraAudioCore)


### PR DESCRIPTION
The undo-semantics item from #551.

## The bug

`cancelInstantClipDrag` put the clip back by **pushing a `MoveClipCommand`**:

```cpp
auto cmd = std::make_shared<MoveClipCommand>(playlist, m_draggedClipId,
                                             m_clipOriginalStartTime, m_clipOriginalLaneId);
m_trackManager->getCommandHistory().pushAndExecute(cmd);
```

That constructor is *"move to this position"*, and `execute()` captures the
clip's **current** position as the command's `m_originalStartBeat`. At cancel
time the current position is the **dragged** one. So the revert worked, and then
sat on the undo stack pointing back at the position the user had just rejected:

> Drag a clip, press Escape, press Ctrl+Z → the clip jumps to where you decided
> not to put it.

`pushAndExecute` also clears the redo stack, so cancelling a drag discarded redo
state that had nothing to do with the drag.

## The fix

The live drag never went through the history in the first place —
`updateInstantClipDrag` moves the model directly so the drag stays smooth — so a
cancel has **nothing to undo**. It has a position to restore, and now restores it
directly.

The invariant, stated once so the next edit path inherits it:

> **User cancellation is not project history.** An operation the user abandoned
> leaves the undo stack exactly as it found it.

## Test, and its honest limit

`TrackManagerUI` is not headless-testable — there is no UI harness that can
start and cancel a drag. `Tests/AestraAudio/CancelledDragHistoryTest.cpp`
therefore asserts the *shape* against the same model the UI drives, the same way
#629 does for the drop path:

1. **The precondition that makes this a bug at all** — a command-based revert
   restores the position, and then one `undo()` puts the clip back at the
   dragged beat. If that ever stops being true, the cancel path could be
   simplified; the test says so.
2. **The cancel path's contract** — a direct restore returns the clip to its
   original beat and lane, leaves `canUndo()` false, and leaves the project
   unmodified (a cancelled drag changed nothing, so it is not a modification).
3. **Cancelling does not destroy redo** — an unrelated undone edit is still
   redoable after a drag is cancelled, and redoing it still works.

What this does not do is drive `cancelInstantClipDrag` itself. Stated plainly
rather than implied.

Refs #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)