### PR TITLE
Timeline geometry: name the grid inset, centralise the x→beat conversion

### DIFF
--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -385,7 +385,7 @@ void TrackManagerUI::layoutTracks() {
     }
 
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = bounds.x + std::max(0.0f, controlAreaWidth + 5.0f);
+    float gridStartX = bounds.x + std::max(0.0f, controlAreaWidth + kTimelineGridInsetX);
     float trackAreaTop = bounds.y + std::max(0.0f, headerHeight + horizontalScrollbarHeight + rulerHeight);
 
     // === V3.0 LANE LAYOUT (Two-Rect Model) ===

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -547,6 +547,38 @@ private:
     void renderTrackManagerStatic(::AestraUI::NUIRenderer& renderer);  // Static content (cached)
     void renderTrackManagerDynamic(::AestraUI::NUIRenderer& renderer); // Dynamic content (real-time)
 
+    // --- Timeline geometry: one conversion, many coordinate bases (#550) -----
+    //
+    // These take a distance FROM the grid's left edge, not an absolute x. That is
+    // deliberate. The grid's origin is expressed in at least three different
+    // bases across this component — component-relative, window-absolute
+    // (getBounds()), and ruler-relative — and which one a call site means is
+    // knowledge that belongs at the call site. What was duplicated, and what is
+    // worth centralising, is the conversion itself: the same
+    // `(x + scroll) / pixelsPerBeat` was written out inline in four places
+    // alongside getTimeAtPosition, which does the same arithmetic and then
+    // converts to seconds and clamps.
+    //
+    // Beat domain, unclamped: the zoom handler needs to keep negative beats to
+    // compute an anchor, and clamping there would pin the zoom to bar 1.
+
+    /** @brief Convert a pixel distance from the grid's left edge into beats. */
+    double gridOffsetToBeat(float offsetFromGridStart) const {
+        // A zero or non-finite zoom would otherwise divide by zero. Callers get
+        // beat 0 rather than an infinity that propagates into clip positions.
+        const float pixelsPerBeat = m_pixelsPerBeat;
+        if (!(pixelsPerBeat > 0.0f)) {
+            return 0.0;
+        }
+        return (static_cast<double>(offsetFromGridStart) + static_cast<double>(m_timelineScrollOffset)) /
+               static_cast<double>(pixelsPerBeat);
+    }
+
+    /** @brief Convert beats into a pixel distance from the grid's left edge. */
+    float beatToGridOffset(double beat) const {
+        return static_cast<float>(beat * static_cast<double>(m_pixelsPerBeat)) - m_timelineScrollOffset;
+    }
+
     // Helper to convert mouse position to track/time
     int getTrackAtPosition(float y) const;
     double getTimeAtPosition(float x) const;

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -59,9 +59,9 @@ void TrackManagerUI::startInstantClipDrag(TrackUIComponent* trackComp, ClipInsta
     // Calculate offset (Cursor Beat - Clip Start Beat)
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    float gridStartX = getGlobalBounds().x + controlAreaWidth + 5.0f;
+    float gridStartX = getGlobalBounds().x + controlAreaWidth + kTimelineGridInsetX;
 
-    double cursorBeat = (clickPos.x - gridStartX + m_timelineScrollOffset) / m_pixelsPerBeat;
+    double cursorBeat = gridOffsetToBeat(clickPos.x - gridStartX);
     m_clipDragOffsetBeats = cursorBeat - clip->startBeat;
 
     if (m_window) {
@@ -78,14 +78,14 @@ void TrackManagerUI::updateInstantClipDrag(const AestraUI::NUIPoint& currentPos)
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
     const AestraUI::NUIRect bounds = getGlobalBounds();
-    const float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+    const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
     AestraUI::NUIPoint latchedPos = currentPos;
     clampInstantClipDragPosition(latchedPos);
 
     // Track mouse position for edge-scrolling in onUpdate
     m_lastMousePos = latchedPos;
 
-    double cursorBeat = (latchedPos.x - gridStartX + m_timelineScrollOffset) / m_pixelsPerBeat;
+    double cursorBeat = gridOffsetToBeat(latchedPos.x - gridStartX);
 
     // Apply relative offset
     double newStartBeat = cursorBeat - m_clipDragOffsetBeats;
@@ -133,7 +133,7 @@ bool TrackManagerUI::clampInstantClipDragPosition(AestraUI::NUIPoint& position) 
     const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
     const float rulerHeight = kTimelineRulerHeight;
     const float scrollbarWidth = kTimelineScrollbarWidth;
-    const float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+    const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
     const float gridEndX = bounds.x + bounds.width - scrollbarWidth;
     const float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
     const float trackAreaBottom = bounds.y + bounds.height;
@@ -165,7 +165,7 @@ bool TrackManagerUI::placeFileOnTimeline(const std::string& filePath, const std:
     const auto bounds = getBounds();
     const float trackAreaStartY = bounds.y + 38.0f + 24.0f + 28.0f;
     const float y = trackAreaStartY + (targetLane * (m_trackHeight + m_trackSpacing)) - m_scrollOffset + 2.0f;
-    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + 5.0f;
+    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + kTimelineGridInsetX;
     const double playheadBeats =
         snapBeatToGrid(m_trackManager->getPlaylistModel().secondsToBeats(std::max(0.0, m_trackManager->getPosition())));
     const float x =
@@ -198,7 +198,7 @@ bool TrackManagerUI::placePatternOnTimeline(PatternID patternId) {
     const auto bounds = getBounds();
     const float trackAreaStartY = bounds.y + 38.0f + 24.0f + 28.0f;
     const float y = trackAreaStartY + (targetLane * (m_trackHeight + m_trackSpacing)) - m_scrollOffset + 2.0f;
-    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + 5.0f;
+    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + kTimelineGridInsetX;
     const double playheadBeats =
         snapBeatToGrid(m_trackManager->getPlaylistModel().secondsToBeats(std::max(0.0, m_trackManager->getPosition())));
     const float x =

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -94,7 +94,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data
     // Explicit mapping: Workspace -> Grid -> Beat
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     float controlWidth = theme.getLayoutDimensions().trackControlsWidth;
-    float gridStartX = getBounds().x + controlWidth + 5.0f;
+    float gridStartX = getBounds().x + controlWidth + kTimelineGridInsetX;
 
     // REJECTION: If dropping on the control area
     if (position.x < gridStartX) {
@@ -106,8 +106,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data
         return AestraUI::DropFeedback::Invalid;
     }
 
-    double gridX = position.x - gridStartX;
-    double rawTimeBeats = (gridX + m_timelineScrollOffset) / m_pixelsPerBeat;
+    double rawTimeBeats = gridOffsetToBeat(position.x - gridStartX);
     double snappedBeats = snapBeatToGrid(rawTimeBeats);
     double newTime = m_trackManager->getPlaylistModel().beatToSeconds(snappedBeats);
 
@@ -616,19 +615,17 @@ double TrackManagerUI::getTimeAtPosition(float x) const {
 
     // Get control area width (where track buttons are)
     float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    float gridStartX = controlAreaWidth + 5;
+    float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
-    // Relative X position in grid area
-    float relativeX = x - bounds.x - gridStartX + m_timelineScrollOffset;
+    // Same conversion the drag and zoom paths use; this one then clamps and
+    // converts to seconds, which is why it could not simply be called from them.
+    const double beats = gridOffsetToBeat(x - bounds.x - gridStartX);
 
-    if (relativeX < 0) {
+    if (beats < 0.0) {
         return 0.0; // Before grid start
     }
 
-    // Convert pixels to beats, then to seconds
-    // pixels / pixelsPerBeat = beats
     // beats / beatsPerMinute * 60 = seconds
-    double beats = relativeX / m_pixelsPerBeat;
     double bpm = std::max(m_trackManager->getPlaylistModel().getBPM(), 1.0);
     double seconds = (beats / bpm) * 60.0;
 
@@ -651,7 +648,7 @@ void TrackManagerUI::renderDropPreview(AestraUI::NUIRenderer& renderer) {
 
     // Calculate grid area
     float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    float gridStartX = bounds.x + controlAreaWidth + 5;
+    float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
 
     // Calculate track Y position - MUST match layoutTracks() calculation exactly
     // layoutTracks uses: headerHeight(38) + horizontalScrollbarHeight(24) + rulerHeight(28)

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -380,7 +380,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
 
 
             float gridTopLocal = globalBounds.y + headerHeight + rulerHeight + horizontalScrollbarHeight;
-            float gridLeftLocal = globalBounds.x + controlAreaWidth + 5.0f;
+            float gridLeftLocal = globalBounds.x + controlAreaWidth + kTimelineGridInsetX;
             float gridRightLocal = globalBounds.x + globalBounds.width - scrollbarWidth; // Corrected width calc
             float gridBottomLocal = globalBounds.y + globalBounds.height;                // Full height down
 
@@ -454,13 +454,13 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
             // Calculate mouse position in "content space" BEFORE zoom
             auto& themeManager = AestraUI::NUIThemeManager::getInstance();
             float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-            float gridStartX = controlAreaWidth + 5.0f;
+            float gridStartX = controlAreaWidth + kTimelineGridInsetX;
             float gridWidthPx = getTimelineGridWidthPixels();
 
             float mouseRelX = localPos.x - gridStartX;
 
             // Current beat at mouse position
-            double mouseBeat = (mouseRelX + m_timelineScrollOffset) / m_pixelsPerBeat;
+            double mouseBeat = gridOffsetToBeat(mouseRelX);
 
             // Calculate min pixels/beat based on domain (can't zoom out beyond domain)
             const double domainWidth = std::max(1.0, m_minimapDomainEndBeat - m_minimapDomainStartBeat);
@@ -497,7 +497,7 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
             // HORIZONTAL SCROLL: Shift/Caps+wheel (and synthetic Shift from laptop horizontal wheel).
             auto& themeManager = AestraUI::NUIThemeManager::getInstance();
             const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-            const float gridStartX = controlAreaWidth + 5.0f;
+            const float gridStartX = controlAreaWidth + kTimelineGridInsetX;
             const float gridWidthPx = getTimelineGridWidthPixels();
             const double maxStartBeat = std::max(0.0, m_minimapDomainEndBeat - (gridWidthPx / m_pixelsPerBeat));
             const float maxTimelineScroll = static_cast<float>(maxStartBeat * m_pixelsPerBeat);
@@ -541,7 +541,7 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         // === LOOP MARKER INTERACTION (highest priority) ===
         if (m_hasRulerSelection) {
@@ -594,7 +594,7 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
             // Start ruler selection
             m_isDraggingRulerSelection = true;
 
-            float gridStartX = controlAreaWidth + 5;
+            float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
             // Convert mouse position to beat
             float mouseX = localPos.x - gridStartX + m_timelineScrollOffset;
@@ -621,7 +621,7 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
                 auto& themeManager = AestraUI::NUIThemeManager::getInstance();
                 const auto& layout = themeManager.getLayoutDimensions();
                 float controlAreaWidth = layout.trackControlsWidth;
-                float gridStartX = controlAreaWidth + 5;
+                float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
                 auto& playlist = m_trackManager->getPlaylistModel();
                 float mouseX = localPos.x - gridStartX + m_timelineScrollOffset;
@@ -645,7 +645,7 @@ bool TrackManagerUI::handleRulerSelectionDrag(const AestraUI::NUIMouseEvent& eve
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         // Update selection end position
         float mouseX = localPos.x - gridStartX + m_timelineScrollOffset;
@@ -717,7 +717,7 @@ bool TrackManagerUI::handleRulerSelectionMenu(const AestraUI::NUIMouseEvent& eve
         !m_hoveringLoopStart && !m_hoveringLoopEnd) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
-        float gridStartX = layout.trackControlsWidth + 5;
+        float gridStartX = layout.trackControlsWidth + kTimelineGridInsetX;
 
         float loopStartX =
             gridStartX + (static_cast<float>(m_loopStartBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
@@ -751,7 +751,7 @@ bool TrackManagerUI::handleLoopMarkerDrag(const AestraUI::NUIMouseEvent& event, 
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         // Stop dragging on mouse release
         if (event.released && event.button == AestraUI::NUIMouseButton::Left) {
@@ -812,7 +812,7 @@ bool TrackManagerUI::handlePlayheadDrag(const AestraUI::NUIMouseEvent& event, co
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         // Update playhead position while dragging
         auto& playlist = m_trackManager->getPlaylistModel();
@@ -843,7 +843,7 @@ bool TrackManagerUI::handleSplitToolClick(const AestraUI::NUIMouseEvent& event, 
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         float headerHeight = kTimelineHeaderHeight;
         float rulerHeight = kTimelineRulerHeight;

--- a/Source/Components/TrackManagerUIInternal.h
+++ b/Source/Components/TrackManagerUIInternal.h
@@ -26,6 +26,16 @@ constexpr float kTimelineRulerHeight = 28.0f;
 constexpr float kTimelineHorizontalScrollbarHeight = 24.0f;
 constexpr float kTimelineScrollbarWidth = 15.0f;
 
+/**
+ * @brief Gap between the track-controls column and the first grid pixel.
+ *
+ * Appeared as a bare `+ 5` in 30-odd `gridStartX` expressions across every
+ * TrackManagerUI translation unit (#550). Rendering, hit testing and drag math
+ * all have to agree on it, and a literal repeated that many times agrees only
+ * by luck.
+ */
+constexpr float kTimelineGridInsetX = 5.0f;
+
 /** @brief Clamp to [a, b] (order-agnostic); non-finite inputs collapse to a safe bound. */
 inline float safeClampFloat(float value, float a, float b) {
     if (!std::isfinite(value))

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -200,8 +200,8 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
         float scrollbarWidth = kTimelineScrollbarWidth;
 
         float gridTop = getBounds().y + headerHeight + rulerHeight + horizontalScrollbarHeight;
-        float gridLeft = getBounds().x + controlAreaWidth + 5.0f; // +5 margin
-        float gridWidth = getBounds().width - (controlAreaWidth + 5.0f) - scrollbarWidth;
+        float gridLeft = getBounds().x + controlAreaWidth + kTimelineGridInsetX; // gap between the controls column and the first grid pixel
+        float gridWidth = getBounds().width - (controlAreaWidth + kTimelineGridInsetX) - scrollbarWidth;
         float gridHeight = getBounds().height - (headerHeight + rulerHeight + horizontalScrollbarHeight);
 
         AestraUI::NUIRect gridBounds(gridLeft, gridTop, gridWidth, gridHeight);
@@ -281,7 +281,7 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
 
     // Calculate where the grid/background should end
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = controlAreaWidth + 5;
+    float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
     // Draw background (control area + full grid area - no bounds restriction)
     AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
@@ -497,7 +497,7 @@ void TrackManagerUI::renderTrackManagerDynamic(AestraUI::NUIRenderer& renderer) 
         double selEndBeat = std::max(m_rulerSelectionStartBeat, m_rulerSelectionEndBeat);
 
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+        float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
 
         float selStartX = gridStartX + static_cast<float>(selStartBeat * m_pixelsPerBeat) - m_timelineScrollOffset;
         float selEndX = gridStartX + static_cast<float>(selEndBeat * m_pixelsPerBeat) - m_timelineScrollOffset;
@@ -690,7 +690,7 @@ void TrackManagerUI::onUpdate(double deltaTime) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
-        float gridStartX = controlAreaWidth + 5;
+        float gridStartX = controlAreaWidth + kTimelineGridInsetX;
         float gridWidthPx = getTimelineGridWidthPixels();
 
         // Calculate world position under the zoom pivot point
@@ -813,7 +813,7 @@ void TrackManagerUI::onUpdate(double deltaTime) {
         float scrollbarWidth = kTimelineScrollbarWidth;
 
         AestraUI::NUIRect bounds = getBounds();
-        float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+        float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
         float gridEndX = bounds.x + bounds.width - scrollbarWidth;
         float gridWidth = gridEndX - gridStartX;
 
@@ -940,7 +940,7 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
 
     // Calculate grid bounds FIRST (before drawing)
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = rulerBounds.x + controlAreaWidth + 5.0f;
+    float gridStartX = rulerBounds.x + controlAreaWidth + kTimelineGridInsetX;
 
     float scrollbarWidth = kTimelineScrollbarWidth;
     float trackWidth = rulerBounds.width - scrollbarWidth;
@@ -1068,7 +1068,7 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
     // 2. Draw SOLID background for CONTROL AREA (left side - DRAWN LAST to fully cover any bleed)
     //    Use backgroundPrimary to match minimap's left section exactly
     auto controlBg = themeManager.getColor("backgroundSecondary");
-    AestraUI::NUIRect controlRect(rulerBounds.x, rulerBounds.y, controlAreaWidth + 5.0f, rulerBounds.height);
+    AestraUI::NUIRect controlRect(rulerBounds.x, rulerBounds.y, controlAreaWidth + kTimelineGridInsetX, rulerBounds.height);
     renderer.fillRect(controlRect, controlBg);
     renderer.drawLine(AestraUI::NUIPoint(controlRect.x, controlRect.bottom() - 1.0f),
                       AestraUI::NUIPoint(controlRect.right(), controlRect.bottom() - 1.0f), 1.0f,
@@ -1092,7 +1092,7 @@ void TrackManagerUI::renderLoopMarkers(AestraUI::NUIRenderer& renderer, const Ae
 
     // Calculate grid start (same as ruler)
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = rulerBounds.x + controlAreaWidth + 5.0f;
+    float gridStartX = rulerBounds.x + controlAreaWidth + kTimelineGridInsetX;
     float scrollbarWidth = kTimelineScrollbarWidth;
     float trackWidth = rulerBounds.width - scrollbarWidth;
     float gridWidth = trackWidth - controlAreaWidth - 10.0f;
@@ -1195,13 +1195,13 @@ void TrackManagerUI::renderPlayhead(AestraUI::NUIRenderer& renderer) {
     float controlAreaWidth = layout.trackControlsWidth;
 
     AestraUI::NUIRect bounds = getBounds();
-    float gridStartX = bounds.x + controlAreaWidth + 5;
+    float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
     float playheadX = gridStartX + static_cast<float>(relPositionX);
 
     // Calculate bounds and triangle size for precise culling
     float scrollbarWidth = kTimelineScrollbarWidth;
     float trackWidth = bounds.width - scrollbarWidth;
-    float gridWidth = trackWidth - (controlAreaWidth + 5.0f);
+    float gridWidth = trackWidth - (controlAreaWidth + kTimelineGridInsetX);
     float gridEndX = gridStartX + gridWidth;
     float triangleSize = 6.0f; // Marker extends this much left/right from playhead center
 
@@ -1296,7 +1296,7 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
 
     // Calculate layout dimensions
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = controlAreaWidth + 5;
+    float gridStartX = controlAreaWidth + kTimelineGridInsetX;
     float scrollbarWidth = kTimelineScrollbarWidth;
     float gridWidth = width - controlAreaWidth - scrollbarWidth - 5;
 
@@ -1460,7 +1460,7 @@ void Aestra::Audio::TrackManagerUI::renderPendingImports(AestraUI::NUIRenderer& 
     float rulerHeight = kTimelineRulerHeight;
     float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = getBounds().x + controlAreaWidth + 5.0f;
+    float gridStartX = getBounds().x + controlAreaWidth + kTimelineGridInsetX;
     float trackAreaTop = getBounds().y + headerHeight + horizontalScrollbarHeight + rulerHeight;
 
     // Tech/Holo Colors

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -137,7 +137,7 @@ bool TrackManagerUI::isCustomCursorActive() const {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;
-        const float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+        const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
         const float headerHeight = kTimelineHeaderHeight;
         const float rulerHeight = kTimelineRulerHeight;
         const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
@@ -621,7 +621,7 @@ void TrackManagerUI::renderToolCursor(AestraUI::NUIRenderer& renderer, const Aes
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const auto& layout = themeManager.getLayoutDimensions();
     float controlAreaWidth = layout.trackControlsWidth;
-    float gridStartX = bounds.x + controlAreaWidth + 5;
+    float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
     float headerHeight = kTimelineHeaderHeight;
     float rulerHeight = kTimelineRulerHeight;
     float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
@@ -736,7 +736,7 @@ void TrackManagerUI::renderMinimapResizeCursor(AestraUI::NUIRenderer& renderer, 
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;
-        const float gridStartX = bounds.x + controlAreaWidth + 5.0f;
+        const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
         const float headerHeight = kTimelineHeaderHeight;
         const float rulerHeight = kTimelineRulerHeight;
         const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;

--- a/Source/Components/TrackManagerUIView.cpp
+++ b/Source/Components/TrackManagerUIView.cpp
@@ -330,7 +330,7 @@ void TrackManagerUI::updateTimelineMinimap(double deltaTime) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;
-        const float gridStartXAbs = getBounds().x + controlAreaWidth + 5.0f;
+        const float gridStartXAbs = getBounds().x + controlAreaWidth + kTimelineGridInsetX;
 
         const float minX = std::min(m_selectionBoxStart.x, m_selectionBoxEnd.x);
         const float maxX = std::max(m_selectionBoxStart.x, m_selectionBoxEnd.x);


### PR DESCRIPTION
Two of the three parts of #550. The third is deliberately excluded, with reasons.

## 1. The magic inset is now a constant

`gridStartX = controlAreaWidth + 5` appeared **37 times** across all seven
TrackManagerUI translation units. Rendering, hit testing and drag math all have
to agree on that number, and a literal repeated 37 times agrees only by luck.

It joins the `kTimeline*` family the same audit produced for the vertical
geometry:

```cpp
constexpr float kTimelineGridInsetX = 5.0f;
```

Purely mechanical — same value, same expression shape, every site.

## 2. One x→beat conversion

`(x + scroll) / pixelsPerBeat` was written out inline in four places — twice in
`ClipOps`, once in the `DragDrop` hover path, once in the `Events` zoom handler —
right next to `getTimeAtPosition`, which does the same arithmetic and *then*
clamps and converts to seconds.

#550 flags that these are not interchangeable, and they aren't: the zoom path
needs **unclamped** beats to compute its anchor, and clamping there would pin the
zoom to bar 1. So the shared piece is a beat-domain primitive both can call:

```cpp
double gridOffsetToBeat(float offsetFromGridStart) const;
float  beatToGridOffset(double beat) const;
```

All four inline copies and `getTimeAtPosition` now route through it. It also
guards a zero or non-finite zoom, which the inline copies did not — that divided
by zero and pushed an infinity into clip positions.

## What this deliberately does not do — and why

**#550 suggests a `gridStartX()` helper. This does not add one.**

These helpers take a distance *from* the grid's left edge rather than an absolute
x, because the grid's **origin** is expressed in three different bases across
this component:

| basis | example |
|---|---|
| component-relative | `gridStartX = controlAreaWidth + inset` |
| window-absolute | `bounds.x + controlAreaWidth + inset` |
| ruler-relative | `rulerBounds.x + controlAreaWidth + inset` |

Which one a call site means is knowledge that lives at the call site. A single
`gridStartX()` would have to pick one and silently move every site that meant
another.

That is not hypothetical. **Three sites in `ClipOps` use `getGlobalBounds()`
where the rest use `getBounds()`** — and `TrackManagerUIToolbar.cpp:129` already
documents why that is wrong here:

> this component's bounds are already window-absolute, so `getGlobalBounds()`
> double-counts the parent offset

Those three are the instant clip drag's **grab offset and clamp region**.
Routing them through a shared `gridStartX()` would change drag behaviour —
probably fix it — but that is a behavioural change to a gesture, and nothing in
this repo can drive a drag headlessly to prove it either way. It wants a human at
the app, not a commit labelled "behaviour-preserving refactor".

So the dedup that kills a bug class ships; the one that silently changes a
coordinate basis does not. Worth a follow-up issue with someone driving a drag.

`TrackUIComponent.cpp` has two more copies of the same conversion against its own
members — out of scope here, which is the TrackManagerUI TUs.

## Verification

Behaviour-preserving by construction (identical arithmetic, identical bases), and
the desktop app builds clean — which is the only thing that exercises these TUs,
since `AESTRA_CI=ON` force-disables the UI in every other lane.

Refs #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)