### PR TITLE
Engineering health: durable contract, weekly targets, and a PR prompt that binds them

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,23 @@
 
 -
 
+## Authority / invariant
+
+<!-- Required for architectural or hardening changes; delete this section for
+     anything else (a typo fix owes nobody an invariant).
+
+     State the authority or invariant this change establishes, and what now
+     prevents it from drifting again. See docs/technical/engineering-health.md.
+
+     Two questions, two lines:
+       What became the single source of truth?
+       What now prevents that truth from drifting again?
+
+     "A named constant, so 37 copies can't disagree" is an answer.
+     "Cleaned up the geometry code" is not. -->
+
+-
+
 ## Producer note
 
 <!-- One sentence for the public changelog, in the voice of someone who

--- a/AestraDocs/INDEX.md
+++ b/AestraDocs/INDEX.md
@@ -103,6 +103,7 @@ Behavioral/interaction specs for subsystems.
 - [Documentation Status](status/DOCUMENTATION_STATUS.md)
 - [Branching Strategy](status/BRANCHING_STRATEGY.md)
 - [Issue Governance Policy](status/issue-governance-policy.md)
+- [Weekly Health — 2026-W31](status/Weekly-Health-2026-W31.md) — expires end of week; durable contract is `docs/technical/engineering-health.md`
 - [Screenshot Limitation](status/SCREENSHOT_LIMITATION.md)
 
 ## Bug reports

--- a/AestraDocs/status/Weekly-Health-2026-W31.md
+++ b/AestraDocs/status/Weekly-Health-2026-W31.md
@@ -1,0 +1,326 @@
+# Aestra Weekly Health — 2026-W31
+
+**Week: July 27 – August 2, 2026**
+
+Point-in-time. This document expires at the end of the week. The durable
+engineering contract lives in `docs/technical/engineering-health.md` and must not
+accumulate completed weekly objectives.
+
+## Mission
+
+Move Aestra materially forward across three axes:
+
+1. **Unification** — one canonical authority/path per concept.
+2. **Hardening** — encode assumptions as invariants, tests, and safe failure behaviour.
+3. **Expansion** — add capability only through the unified/hardened architecture.
+
+The week is healthy when Aestra ends with fewer competing concepts and fewer
+implicit assumptions, even though the feature surface grows.
+
+---
+
+## Baseline — as of Monday 2026-07-27
+
+Landed on `develop` today:
+
+| PR | What it established |
+|---|---|
+| #626 | audio clip routing and mixer workflows |
+| #624 | first Muse host verbs — `view.open`, `view.close`, `view.current` |
+| #630 | Muse application-state ownership map, exposing real authority problems before more host verbs |
+| #628 | CI phase 2 — source-tree blast-radius classification, conservative broad fallback preserved; advisory lanes gated |
+| #629 | a drop that creates a lane is one transactional undo step, including stable lane identity on redo |
+
+Open, in review:
+
+| PR | What it establishes |
+|---|---|
+| #627 | project dirty state becomes an invariant of `CommandHistory` rather than something individual edit paths remember to mark |
+| #631 | cancelled clip drags stop contaminating undo/redo history |
+| #632 | timeline geometry — named grid inset and one x→beat conversion (partial U1; see below) |
+
+These are committed work. Do not reopen their scope elsewhere.
+
+Also today: **#247 closed** (its acceptance criteria were already met by
+out-of-process hosting), **#633 opened** — Windows cannot start the plugin
+helper, so it loads no third-party plugins at all. That is a platform capability
+hole, not hardening.
+
+---
+
+# Backlog picks
+
+## P0 — Must-hit this week
+
+### U1 — Timeline geometry authority — #550
+
+Collapse `gridStartX`, x→beat, beat→x, snapping and related timeline
+calculations behind one geometry authority. There were multiple inline x→beat
+implementations and 37 repetitions of the grid-start calculation.
+
+**Target invariant:**
+
+> Timeline position has one interpretation everywhere.
+
+No clip operation, drag handler, zoom handler, renderer or selection path should
+independently reconstruct timeline coordinates.
+
+**Status:** #632 lands the representation half — the inset is a named constant
+and the four inline x→beat copies are one primitive. **The origin is not
+unified**, deliberately: the grid's origin is expressed in three bases
+(component-relative, window-absolute, ruler-relative), and three ClipOps sites
+use `getGlobalBounds()` where the rest use `getBounds()`, which the toolbar code
+already documents as double-counting the parent. Those three are the instant
+drag's grab offset and clamp region. Unifying them is a behavioural repair that
+needs a human driving a drag — see engineering-health principle 9. **Remaining
+work this week:** validate and land that seam.
+
+---
+
+### U2 — Move project serialization below the UI tier — #266
+
+`ProjectSerializer` lives under `Source/` despite being the canonical project
+schema, migration, validation and write implementation. That forces headless
+consumers toward the UI tier. Move the authority into `AestraAudio` or
+`AestraCore`.
+
+**Target invariant:**
+
+> Loading, validating, migrating and saving an Aestra project does not require
+> the desktop application.
+
+Clears the architectural path for eventual `project.*` Muse capabilities — which
+#630 identified as the only domain with a real headless story today.
+
+---
+
+### U3 — Establish an actual settings authority
+
+#630 found that `Preferences` looks like the settings model but seven fields have
+no readers, while `GeneralSettingsPage::applyChanges()` is a bare
+`m_dirty = false`. It also found `view.current` reports intent for four views and
+actual visibility for two.
+
+**A. View truth.** `view.current` must describe what the user or agent can
+actually see. Where desired state and physical visibility genuinely differ —
+they do, because `setViewFocus` hides panels in Audition mode while `m_viewState`
+deliberately retains the restore state — expose **both** (`requestedOpen` and
+`visible`) rather than collapsing them.
+
+**B. Settings truth.** For each setting:
+
+`persisted value → authoritative runtime owner → mutation path → observation path`
+
+No setting may successfully persist while having no effect.
+
+**Target invariant:**
+
+> A setting that reports success changes the state that actually governs the
+> application.
+
+Do this **before** `settings.*` expansion. Registering verbs first would
+fossilize whichever accidental state holder was picked.
+
+---
+
+### U4/H1 — Unify isolated bounce with the export path — #227
+
+Master bounce already uses `AudioExporter`; isolated-track bounce still goes
+through the older `AudioRenderer::renderBlock` path and therefore differs in
+master-stage processing and dithering.
+
+**Target invariant:**
+
+> Export and bounce are configurations of one rendering system, not parallel
+> render engines.
+
+Unification and audio hardening at once.
+
+---
+
+## P1 — High-value hardening
+
+### H2 — Portable DSP state — #210
+
+Several plugins deserialize persisted state by casting byte buffers directly to
+structs, embedding alignment, padding and portability assumptions into
+project/plugin state. Move toward explicit field serialization.
+
+**Target invariant:**
+
+> Persisted DSP state is a defined format, not the compiler's memory layout.
+
+---
+
+### H3 — Asset identity, not merely asset paths — #264
+
+Projects identify sample assets primarily by path, so a replaced file at the same
+path silently becomes the project's audio. Introduce content identity/hash
+verification.
+
+**Target invariant:**
+
+> Aestra never silently substitutes different audio for the audio a project was
+> saved with.
+
+Do this **after** the serializer move (U2), to avoid touching the persistence
+layer twice.
+
+---
+
+### H4 — Finish defining the audio boundary — #422 + #423
+
+Treat these as one mission. #422 defines the intended separation: internal float
+truth stays unclipped while hardware and integer conversion may enforce explicit
+boundary protection. #423 extends the purity harness into float32/int24/int16
+export and explicit dither/quantization behaviour.
+
+**Target invariant:**
+
+> Every nonlinear or lossy boundary in Aestra is intentional, named, measurable
+> and testable.
+
+No mystery clipping.
+
+---
+
+### H5 — CLAP host completeness — #270
+
+Several CLAP host callbacks remain no-ops, including restart, parameter rescan
+and parameter flush. Implement and test at minimum the subset needed for real
+parameter lifecycle behaviour. Matters before deeper plugin automation work.
+
+---
+
+# Expansion target
+
+## E1 — Automation, as one dependency chain
+
+Do not spread expansion across five unrelated surfaces this week. Automation is
+the single expansion thread.
+
+First settle **#466**: whether automation overrides or composes with mixer state.
+Current behaviour can make the mixer fader effectively irrelevant when volume
+automation exists. This is a product-policy decision, not an implementation
+detail.
+
+Then take **#467** as the first slice: internal-plugin parameter automation using
+stable parameter identity and the existing RT-safe parameter infrastructure.
+
+Order:
+
+> **policy → regression → engine capability → UI later**
+
+Do **not** start automation recording (#469) yet.
+
+---
+
+# CI and development health
+
+#628 landed without weakening the conservative contract: required check names
+unchanged, unknown scope still broad, selective paths carry explicit liveness
+tests, `develop` pushes still establish full repository truth.
+
+**Phase 3 remains blocked.** #620 measured **45 unlabelled tests**; selective test
+execution before that is resolved can silently redefine "green".
+
+**Week target:** bring unlabelled tests to **zero**, even if test-level slicing
+itself lands later.
+
+---
+
+## Review throughput
+
+CodeRabbit being the critical path is acceptable as an external constraint. It
+must **not** distort engineering decisions.
+
+- One pull request defends one primary invariant.
+- Do not combine unrelated changes merely to save review requests.
+- Keep preparing independent branches while review capacity is exhausted, but
+  avoid stacking branches that modify the same authority before the preceding
+  architectural change lands.
+- CI should get cheaper without pull requests getting larger.
+
+---
+
+# Backlog truth
+
+The tracker itself needs a health pass. Entries exist whose descriptions have
+been overtaken by merged work — #201 still says three security tests are excluded
+from CI, while #608 records that the final exclusion was removed and all three
+now run across the six CI lanes plus nightly.
+
+After the remaining pull requests merge:
+
+- close resolved findings in #551;
+- update #620 to reflect completed CI phases;
+- close demonstrably stale issues such as #201;
+- revalidate old issues before implementing them, rather than trusting historical
+  line numbers or architecture.
+
+**Target invariant:**
+
+> An open Aestra issue describes a problem that still exists.
+
+---
+
+# Explicitly deferred
+
+Do not let these steal the week:
+
+- macOS application implementation #267
+- cloud sync #286
+- theme/font polish #287 / #393
+- word wrapping #275
+- automation recording #469
+- large activation/monetization work #254
+- low-priority Arsenal limiter fixture #366
+
+They may matter; they do not compound this week's architectural work enough.
+
+---
+
+# Friday health gate
+
+## Unification
+
+- [ ] Timeline geometry has one authority
+- [ ] Project serialization no longer belongs to the UI tier
+- [ ] Settings have identifiable runtime authorities
+- [ ] Bounce/export no longer have competing rendering paths
+
+## Hardening
+
+- [ ] Completed, failed and cancelled edits have formally different history semantics
+- [ ] Persisted DSP state is moving away from compiler-layout serialization
+- [ ] Sample identity can be verified rather than assumed from a path
+- [ ] Float, hardware and integer-output boundaries have explicit policies
+- [ ] CI narrowing cannot create fake green
+
+## Expansion
+
+- [ ] Muse expansion waits for truthful state ownership
+- [ ] Automation semantics are deliberately chosen and regression-pinned
+- [ ] Internal-plugin parameter automation can proceed through stable IDs rather
+      than another bespoke mechanism
+
+## Repository / process
+
+- [ ] The pull requests open at the start of the week land cleanly
+- [ ] Unlabelled tests reach zero, or have a complete classified plan
+- [ ] Stale issues are closed or rewritten
+- [ ] CodeRabbit rate limits affect waiting time, not pull-request architecture
+
+---
+
+## North-star test
+
+For every substantial change this week:
+
+> **What became the single source of truth?**
+>
+> **What now prevents that truth from drifting again?**
+
+If neither answer is clear, the change probably is not contributing enough to
+this week's mission. See `docs/technical/engineering-health.md` for the durable
+version of this and the invariants reviewers enforce.

--- a/docs/TEMPLATE/PR_TEMPLATE.md
+++ b/docs/TEMPLATE/PR_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 **Use this template when submitting pull requests that update documentation.**
 
+> **Changing code, not docs?** Use the repository's default template
+> (`.github/pull_request_template.md`, applied automatically). For architectural
+> or hardening changes it asks you to state the authority or invariant being
+> established and what prevents it from drifting again — see
+> [Engineering Health](../technical/engineering-health.md).
+
 ---
 
 ## Description

--- a/docs/technical/engineering-health.md
+++ b/docs/technical/engineering-health.md
@@ -1,0 +1,220 @@
+# Aestra Engineering Health
+
+**Status:** durable engineering contract
+**Audience:** anyone writing or reviewing a change to Aestra
+
+This document is not a plan and not a status report. It is the set of properties
+Aestra's architecture is expected to hold, written so a reviewer can point at one
+and say *"this change violates it"*.
+
+Weekly targets live in `AestraDocs/status/` and expire. Nothing in this file
+should ever describe work in flight — if a principle here is satisfied, it stays
+here anyway, because it is what stops the problem from coming back.
+
+## The north-star questions
+
+Every substantial change should be able to answer both:
+
+> **What became the single source of truth?**
+>
+> **What now prevents that truth from drifting again?**
+
+If neither has an answer, the change is probably maintenance rather than
+architecture — which is fine, but it should not be described as the latter.
+
+---
+
+## 1. One source of truth per concept
+
+A concept has exactly one authority. Everything else derives from it or asks it.
+
+**What drift looks like:** the same value computed independently in several
+places; a "cache" that is really a second writable copy; a persisted field
+shadowing a live runtime owner that never reads it.
+
+**What to look for in review:** if a change adds a second place that decides the
+same thing, the change should say why, and what keeps the two in agreement. A
+constant repeated thirty times agrees only by luck.
+
+**Precedent:** `gridStartX = controlAreaWidth + 5` existed 37 times across seven
+translation units (#550). `Preferences` looked like the settings model while
+seven of its fields had no readers at all (#630) — a setting that persists and
+governs nothing is worse than a missing setting, because it reports success.
+
+---
+
+## 2. Audit before implementing a stale issue
+
+**Old issues are hypotheses, not specifications.** Before implementing one,
+reproduce the current failure and identify the authority currently responsible
+for it.
+
+**What to look for in review:** for any change that cites an issue older than the
+architecture it touches, the description should say whether the issue's premise
+still holds. When it does not, the right output is a re-scope or a new issue —
+not an implementation of the stale text.
+
+**Precedent:** three issues in one day described real historical problems and
+none described the present root cause. #247 asked for Linux plugin crash
+protection; that objective was already met by out-of-process hosting, while the
+live gap was the inverse (Windows cannot start the helper at all) and became
+#633. #551's "some clip operations forgot `markModified()`" was true, but
+patching those call sites would have preserved the design that made forgetting
+possible.
+
+**Corollary — see also principle 8.** Closing an issue as "already satisfied" is
+a claim that needs the same evidence as a fix.
+
+---
+
+## 3. User cancellation is not history
+
+An operation the user abandoned leaves the undo stack exactly as it found it.
+
+**What drift looks like:** a cancel path that "reverts using a command so it's
+undoable". A revert command captures the *current* state as its original, and at
+cancel time the current state is the abandoned one — so undo re-applies exactly
+what the user rejected. Pushing it also clears the redo stack, discarding
+history that had nothing to do with the cancelled gesture.
+
+**What to look for in review:** cancel paths restore state directly. If a live
+gesture never entered the history (because it mutates the model directly for
+smoothness), its cancel has nothing to undo.
+
+---
+
+## 4. Failed operations do not enter history
+
+An operation that did not change the project is not a project change: no undo
+entry, no dirty flag, no leftover scaffolding.
+
+**What drift looks like:** `construct → discover failure → clean up hopefully`.
+Structure created before validation and removed on failure by a rollback path
+that every future failure branch must remember to call. Or a success reported
+unconditionally because the work happened in a `void` helper.
+
+**What to look for in review:** validate what is cheap to validate before
+creating anything; make what must be created part of the same transaction as the
+thing it exists for; and return the real outcome rather than assuming it. A
+handler that cannot fail is usually a handler that cannot report failure.
+
+---
+
+## 5. Stable identity survives undo and redo
+
+An entity re-created by a redo keeps the identity it had before the undo.
+
+**What drift looks like:** "the ID will be different on redo since we can't reuse
+the old ID". Anything grouped in the same undo step still refers to the old
+identity, so replay silently attaches those members to something that no longer
+exists.
+
+**What to look for in review:** any command that creates an identified entity
+must restore that identity on re-execute, not only in `redo()` — batching
+mechanisms may replay members through `execute()`. Identity restoration should
+fall back to a fresh ID when the old one has been taken, never assume it is free.
+
+---
+
+## 6. Headless, live and export paths share authorities
+
+Where the same concept exists in more than one execution path, the paths share
+the implementation rather than each having their own.
+
+**What drift looks like:** an offline render that differs from playback in
+master-stage processing; a project that can only be loaded, validated or
+migrated by the desktop application; two rendering systems where there should be
+one system with two configurations.
+
+**What to look for in review:** a new path that reimplements an existing one
+should say why the existing authority could not be used, and what keeps the two
+in agreement when one changes.
+
+---
+
+## 7. Narrowing CI must fail broad, never fail open
+
+Anything that reduces what CI runs may only do so when it is certain, and every
+uncertainty must resolve toward running more.
+
+**Non-negotiables:**
+
+- Unknown, unrecognised or new paths → run everything.
+- A change set too large to trust, or one whose file list disagrees with the
+  authoritative count → run everything.
+- Changes targeting `main` → run everything.
+- Every required check always reports a conclusion. A required context that never
+  reports does not fail; it hangs every pull request forever.
+- Pushes to `develop` always run the complete suite. Selective CI is a
+  pull-request optimisation, never a definition of repository truth.
+
+**Test selection has a specific trap:** running a labelled subset silently drops
+unlabelled tests, which redefines "green" without anyone deciding to. Selective
+test execution stays blocked until labelling is trustworthy, with
+*unlabelled → always runs* as the standing rule.
+
+**Liveness is part of the contract.** A classifier that has silently died answers
+"broad" to everything and passes every safety assertion while doing nothing. Any
+narrowing mechanism needs at least one test that fails when the narrowing stops
+working, not only tests that fail when it becomes unsafe.
+
+---
+
+## 8. "Fixed" requires reproduction, or an explicit obsolescence argument
+
+A change that claims to fix something demonstrates the failure it removes —
+ideally as a test that fails before the change and passes after. Where the
+architecture has made the old failure impossible, say so explicitly and show
+what makes it impossible.
+
+**What to look for in review:** "added a test" is not the same as "the test
+rejects the bad state". Verify the gate by reverting the fix and watching it
+fail. Where a fix cannot be tested at the layer it lives in — UI gestures have no
+headless harness — say that plainly and pin the shape of the change one layer
+down, rather than implying coverage that does not exist.
+
+---
+
+## 9. Behaviour-preserving refactors stop where equivalence cannot be demonstrated
+
+A refactor described as behaviour-preserving must actually be. When part of it
+would change behaviour, that part stops and becomes its own change with its own
+justification and its own validation.
+
+**What drift looks like:** unifying call sites that were *nearly* identical, and
+absorbing the difference into the new abstraction. The refactor lands green, the
+behavioural change ships unannounced, and the commit message says the opposite.
+
+**What to look for in review:** where a unification has to pick between variants
+that were not equivalent, the pick is a behavioural decision. Leaving the seam
+visible and documented is better engineering than a prettier abstraction that
+silently resolves it.
+
+---
+
+## Working rules
+
+**A running build owns the working tree until it exits.** Do not switch branches,
+rebase, or check out files while a build is running against the tree — the build
+will either die or, worse, produce a binary from a mixture of two revisions.
+
+**One pull request defends one primary invariant.** Do not combine unrelated
+changes to save review capacity. When review is the constraint, prepare
+independent branches rather than larger ones — but avoid parallel branches that
+modify the same authority before the preceding architectural change lands.
+
+**An open issue describes a problem that still exists.** When an issue is
+overtaken by merged work, close it with the evidence, or rewrite its premise to
+match the system that exists now. Preserve the historical truth; do not mutate an
+old title into a new problem.
+
+---
+
+## Related
+
+- `docs/technical/command_model.md` — command, transaction and history semantics
+  (principles 3, 4, 5)
+- `docs/technical/muse_state_ownership.md` — per-domain state authorities
+  (principle 1)
+- `docs/technical/THREADING_MODEL.md` — thread ownership
+- `AestraDocs/status/` — weekly targets and point-in-time status; expires

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ not_in_nav: |
   /technical/TODO-E003-MacroCommand.md
   /technical/ai-guide.md
   /technical/command_model.md
+  /technical/engineering-health.md
   /technical/muse_state_ownership.md
   /technical/audio/IMPLEMENTATION_COMPLETE.md
   /technical/ui/ADAPTIVE_FPS_QUICKREF.md


### PR DESCRIPTION
Docs only. Splits what today produced into the two lifetimes it actually has.

## `docs/technical/engineering-health.md` — durable

Nine principles, each written so a reviewer can point at one and say *"this
change violates it"*: what drift looks like, and what to check for.

1. One source of truth per concept
2. Audit before implementing a stale issue
3. User cancellation is not history
4. Failed operations do not enter history
5. Stable identity survives undo and redo
6. Headless, live and export paths share authorities
7. Narrowing CI must fail broad, never fail open
8. "Fixed" requires reproduction, or an explicit obsolescence argument
9. Behaviour-preserving refactors stop where equivalence cannot be demonstrated

Plus working rules: **a running build owns the working tree until it exits**, one
PR defends one invariant, an open issue describes a problem that still exists.

Each principle carries its precedent, because an abstract rule is not
enforceable. Three of them exist because an issue described a real historical
problem while none described the present root cause — #247 → #633, and both
#551 items.

Nothing here describes work in flight. A principle stays even once satisfied,
because it is what stops the problem returning.

## `AestraDocs/status/Weekly-Health-2026-W31.md` — expires

This week's Unification / Hardening / Expansion targets and the Friday gate.
Separate on purpose, so the durable document does not slowly become a graveyard
of completed weekly objectives. `AestraDocs/INDEX.md` already describes
`status/` as *"point-in-time project status and process governance"*, which is
exactly this.

Two places where it records reality rather than the plan as written:

- **Baseline** lists what landed today (#626, #624, #630, #628, #629) versus
  what is still in review (#627, #631, #632), and notes #247 closed / #633
  opened.
- **U1 is marked half done.** #632 unifies the *representation*; the origin is
  deliberately not unified, because three ClipOps sites use `getGlobalBounds()`
  where the rest use `getBounds()` and those three are the instant drag's grab
  offset and clamp region. That is principle 9 in practice, and the remaining
  work is named as needing a human driving a drag.

## Making it bind

The contract asked to be referenced from `docs/TEMPLATE/PR_TEMPLATE.md` — but
that file is the **documentation** PR template (*"Use this template when
submitting pull requests that update documentation"*) and is applied manually.
Architectural guidance there would miss every code change.

So the prompt goes in **`.github/pull_request_template.md`**, which GitHub
applies to every PR automatically:

```markdown
## Authority / invariant

<!-- Required for architectural or hardening changes; delete for anything else.
     What became the single source of truth?
     What now prevents that truth from drifting again? -->
```

`docs/TEMPLATE/PR_TEMPLATE.md` gets a pointer to the default template instead, so
the location you named still leads there.

## Verification

- `mkdocs.yml` parses and `engineering-health.md` is registered in `not_in_nav`,
  alongside `command_model.md` and `muse_state_ownership.md`
- every cross-reference resolves (`command_model.md`,
  `muse_state_ownership.md`, `THREADING_MODEL.md`, `AestraDocs/status/`)
- `AestraDocs/INDEX.md` lists the weekly doc with its expiry noted

🤖 Generated with [Claude Code](https://claude.com/claude-code)