### PR TITLE
Five UI-state truthfulness defects in the timeline

### DIFF
--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -332,6 +332,21 @@ bool TrackManagerUI::handleContextMenuMouse(const AestraUI::NUIMouseEvent& event
         if (!handled && event.pressed) {
             detachContextMenu(m_activeContextMenu);
             m_activeContextMenu = nullptr;
+
+            // Falling through lets the click also act on whatever is underneath
+            // (Stop button, track header, ...), which is what we want everywhere
+            // EXCEPT on the menu button itself: the control underneath there is the
+            // one that opens this menu, so handleToolbarClick would see the pointer
+            // we just cleared and immediately build a new menu. That is why the
+            // button could only ever open — the dismissal was real, it was just
+            // undone one handler later, in the same event.
+            //
+            // updateToolbarBounds() runs before this handler, so m_menuIconBounds is
+            // current.
+            if (m_menuIconBounds.contains(event.position)) {
+                setDirty(true);
+                return true;
+            }
             // Let execution continue so the click can interact with whatever is underneath
             // (e.g. Stop button, Track header, etc.)
         } else if (handled) {

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -242,6 +242,7 @@ void TrackManagerUI::updateToolbarHover(const AestraUI::NUIMouseEvent& event) {
         bool oldSelectHovered = m_selectToolHovered;
         bool oldSplitHovered = m_splitToolHovered;
         bool oldMultiSelectHovered = m_multiSelectToolHovered;
+        bool oldPaintHovered = m_paintToolHovered;
         bool oldFollowHovered = m_followPlayheadHovered;
 
         m_menuHovered = m_menuIconBounds.contains(event.position);
@@ -249,13 +250,14 @@ void TrackManagerUI::updateToolbarHover(const AestraUI::NUIMouseEvent& event) {
         m_selectToolHovered = m_selectToolBounds.contains(event.position);
         m_splitToolHovered = m_splitToolBounds.contains(event.position);
         m_multiSelectToolHovered = m_multiSelectToolBounds.contains(event.position);
+        m_paintToolHovered = m_paintToolBounds.contains(event.position);
         m_followPlayheadHovered = m_followPlayheadBounds.contains(event.position);
 
         // Toolbar Tooltips
         bool anyToolbarHovered = m_menuHovered || m_addTrackHovered || m_selectToolHovered || m_splitToolHovered ||
-                                 m_multiSelectToolHovered || m_followPlayheadHovered;
+                                 m_multiSelectToolHovered || m_paintToolHovered || m_followPlayheadHovered;
         bool anyOldHovered = oldMenuHovered || oldAddHovered || oldSelectHovered || oldSplitHovered ||
-                             oldMultiSelectHovered || oldFollowHovered;
+                             oldMultiSelectHovered || oldPaintHovered || oldFollowHovered;
 
         if (m_toolbarBounds.contains(event.position) && anyToolbarHovered) {
             std::string tooltipText;
@@ -269,6 +271,8 @@ void TrackManagerUI::updateToolbarHover(const AestraUI::NUIMouseEvent& event) {
                 tooltipText = "Split Tool";
             else if (m_multiSelectToolHovered && !oldMultiSelectHovered)
                 tooltipText = "Multi-Select Tool";
+            else if (m_paintToolHovered && !oldPaintHovered)
+                tooltipText = "Paint Tool";
             else if (m_followPlayheadHovered && !oldFollowHovered)
                 tooltipText = "Follow Playhead";
             if (!tooltipText.empty()) {
@@ -281,7 +285,8 @@ void TrackManagerUI::updateToolbarHover(const AestraUI::NUIMouseEvent& event) {
         // Toolbar is rendered outside the playlist cache; don't invalidate the cache on hover.
         if (m_menuHovered != oldMenuHovered || m_addTrackHovered != oldAddHovered ||
             m_selectToolHovered != oldSelectHovered || m_splitToolHovered != oldSplitHovered ||
-            m_multiSelectToolHovered != oldMultiSelectHovered || m_followPlayheadHovered != oldFollowHovered) {
+            m_multiSelectToolHovered != oldMultiSelectHovered || m_paintToolHovered != oldPaintHovered ||
+            m_followPlayheadHovered != oldFollowHovered) {
             setDirty(true);
         }
     }

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -70,37 +70,43 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
 
     auto* renderCache = renderer.getRenderCache();
     if (!renderCache) {
-        // Fallback: No cache available, render normally
+        // No FBO cache available (software renderer, cache creation failed). Draw the
+        // static content directly and FALL THROUGH — this used to `return`, which also
+        // skipped every dynamic pass below: overlays, meters, selection highlight, the
+        // playhead and the drop preview. The cache is a performance optimisation, so
+        // losing it must cost frame rate, never content.
         renderTrackManagerStatic(renderer);
-        return;
-    }
-
-    // === FBO CACHING ENABLED ===
-    // Get or create FBO cache (cache entire playlist view area)
-    AestraUI::NUISize cacheSize(static_cast<int>(bounds.width), static_cast<int>(bounds.height));
-    m_cachedRender = renderCache->getOrCreateCache(m_cacheId, cacheSize);
-
-    // Check if we need to invalidate the cache
-    if (m_cacheInvalidated && m_cachedRender) {
-        renderCache->invalidate(m_cacheId);
-        m_cacheInvalidated = false;
-    }
-
-    // Render using cache (auto-rebuild if invalid)
-    if (m_cachedRender) {
-        renderCache->renderCachedOrUpdate(m_cachedRender, bounds, [&]() {
-            // Re-render playlist contents into the cache
-            m_isRenderingToCache = true;
-
-            renderer.clear(AestraUI::NUIColor(0, 0, 0, 0));
-            renderer.pushTransform(-bounds.x, -bounds.y);
-            renderTrackManagerStatic(renderer);
-            renderer.popTransform();
-
-            m_isRenderingToCache = false;
-        });
     } else {
-        renderTrackManagerStatic(renderer);
+        // === FBO CACHING ENABLED ===
+        // Get or create FBO cache (cache entire playlist view area)
+        AestraUI::NUISize cacheSize(static_cast<int>(bounds.width), static_cast<int>(bounds.height));
+        m_cachedRender = renderCache->getOrCreateCache(m_cacheId, cacheSize);
+
+        // Check if we need to invalidate the cache
+        if (m_cacheInvalidated && m_cachedRender) {
+            renderCache->invalidate(m_cacheId);
+            m_cacheInvalidated = false;
+        }
+
+        // Render using cache (auto-rebuild if invalid)
+        if (m_cachedRender) {
+            renderCache->renderCachedOrUpdate(m_cachedRender, bounds, [&]() {
+                // Re-render playlist contents into the cache
+                m_isRenderingToCache = true;
+
+                renderer.clear(AestraUI::NUIColor(0, 0, 0, 0));
+                renderer.pushTransform(-bounds.x, -bounds.y);
+                renderTrackManagerStatic(renderer);
+                renderer.popTransform();
+
+                m_isRenderingToCache = false;
+            });
+        } else {
+            // Cache object unavailable but the cache system is present. This branch
+            // already fell through to the dynamic passes; the !renderCache one above
+            // now behaves the same way.
+            renderTrackManagerStatic(renderer);
+        }
     }
 
     // Render the left control strip OUTSIDE the cache to keep M/S/R hover/press responsive

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -390,10 +390,17 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
         Log::info("TrackManagerUI: Menu Icon Clicked! Bounds: " + std::to_string(m_menuIconBounds.x) + "," +
                   std::to_string(m_menuIconBounds.y));
 
-        // Clicking the button while its menu is open dismisses it. The early return
-        // is what makes this a toggle: without it, control fell through to the
-        // construction below and immediately reopened the menu that had just been
-        // closed, so the button could only ever open.
+        // Defensive only — NOT the toggle. handleContextMenuMouse runs before this
+        // handler (see onMouseEvent) and always clears m_activeContextMenu when a
+        // click lands outside the menu, so by the time a mouse click reaches here the
+        // pointer is already null. The toggle lives there, where the dismissal
+        // happens. This branch stays because "button clicked while its own menu is
+        // open" should close rather than rebuild for any caller that does reach it.
+        //
+        // What this block DID replace was a genuine artifact: an else-branch that
+        // constructed a menu, followed by an `if (!m_activeContextMenu)` that
+        // constructed another, under a comment reading "RE-ADDING MISSING LOGIC
+        // because I am replacing the block".
         if (m_activeContextMenu) {
             Log::info("TrackManagerUI: Closing existing menu");
             detachContextMenu(m_activeContextMenu);

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -390,22 +390,20 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
         Log::info("TrackManagerUI: Menu Icon Clicked! Bounds: " + std::to_string(m_menuIconBounds.x) + "," +
                   std::to_string(m_menuIconBounds.y));
 
-        // Cleanup previous menu if exists
+        // Clicking the button while its menu is open dismisses it. The early return
+        // is what makes this a toggle: without it, control fell through to the
+        // construction below and immediately reopened the menu that had just been
+        // closed, so the button could only ever open.
         if (m_activeContextMenu) {
             Log::info("TrackManagerUI: Closing existing menu");
             detachContextMenu(m_activeContextMenu);
             m_activeContextMenu = nullptr;
-        } else {
-            Log::info("TrackManagerUI: Creating new context menu");
-            // Create context menu
-            m_activeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
-            // ... capture rest of logic ...
+            setDirty(true);
+            return true;
         }
 
-        // Create context menu (RE-ADDING MISSING LOGIC because I am replacing the block)
-        if (!m_activeContextMenu) {
-            m_activeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
-        }
+        Log::info("TrackManagerUI: Creating new context menu");
+        m_activeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
         auto menu = m_activeContextMenu;
 
         // === SNAP SUBMENU ===
@@ -423,7 +421,11 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
         auto addLoopItem = [&](const std::string& name, int id) {
             bool isSelected = (m_loopPreset == id);
             loopMenu->addRadioItem(name, "LoopGroup", isSelected, [this, id, name]() {
-                m_loopPreset = id;
+                // m_loopPreset is assigned AFTER the branches below, not here. Two of
+                // them can decline to apply — "Selection" with no selection, "Project"
+                // with no resolvable extent — and assigning up front left the radio
+                // item checked for a preset that had not taken effect, so the menu
+                // showed "Selection" while looping was actually off.
                 bool loopEnabled = (id != 0);
                 double loopStartBeat = 0.0;
                 double loopEndBeat = 4.0;
@@ -466,6 +468,13 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                     }
                 }
 
+                // What is recorded is what actually happened. A preset that meant to
+                // enable looping but could not falls back to Off (0), because that is
+                // the state the project is now in.
+                const bool intendedToEnable = (id != 0);
+                const int appliedPreset = (intendedToEnable && !loopEnabled) ? 0 : id;
+                m_loopPreset = appliedPreset;
+
                 setLoopRegion(loopStartBeat, loopEndBeat, loopEnabled);
 
                 if (m_onLoopRegionUpdate) {
@@ -477,9 +486,13 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                 }
 
                 if (m_onLoopPresetChanged)
-                    m_onLoopPresetChanged(id);
+                    m_onLoopPresetChanged(appliedPreset);
                 invalidateCache();
-                Log::info("Loop preset changed to: " + name);
+                if (appliedPreset == id) {
+                    Log::info("Loop preset changed to: " + name);
+                } else {
+                    Log::info("Loop preset '" + name + "' could not be applied; loop is Off");
+                }
             });
         };
 

--- a/Source/Components/TrackManagerUIView.cpp
+++ b/Source/Components/TrackManagerUIView.cpp
@@ -281,6 +281,7 @@ void TrackManagerUI::updateTimelineMinimap(double deltaTime) {
     }
 
     // Update domain instantly (no cooldown needed)
+    bool domainShrank = false;
     if (!(m_minimapDomainEndBeat > 0.0)) {
         // First init
         m_minimapDomainEndBeat = requiredEndBeat;
@@ -293,8 +294,19 @@ void TrackManagerUI::updateTimelineMinimap(double deltaTime) {
         // Domain can shrink - also instant, no reason to delay
         m_minimapDomainEndBeat = requiredEndBeat;
         m_minimapNeedsRebuild = true;
+        domainShrank = true;
     }
     // else: domain unchanged, nothing to do
+
+    // A shrinking domain can leave the viewport scrolled past the new end — delete the
+    // last clip in a long arrangement and the view stays out where that clip used to
+    // be, showing empty grid with a minimap thumb pinned off its own track. Growing is
+    // safe (the old view is still inside the larger domain), so only the shrink needs
+    // this. setTimelineViewStartBeat applies exactly the clamp this needs and is safe
+    // to call here: it only re-enters updateTimelineMinimap when isFinal is false.
+    if (domainShrank) {
+        setTimelineViewStartBeat(viewStartBeat, /*isFinal=*/true);
+    }
 
     if (m_minimapNeedsRebuild) {
         std::vector<AestraUI::TimelineMinimapClipSpan> spans;

--- a/Source/Components/TrackManagerUIView.cpp
+++ b/Source/Components/TrackManagerUIView.cpp
@@ -216,9 +216,12 @@ void TrackManagerUI::updateTimelineMinimap(double deltaTime) {
     if (!(m_pixelsPerBeat > 0.0f) || gridWidthPx <= 0.0f)
         return;
 
-    const double viewStartBeat = static_cast<double>(m_timelineScrollOffset / m_pixelsPerBeat);
+    // Not const: a shrinking domain re-clamps the scroll offset further down, and the
+    // model published at the end of this function must describe the viewport we ended
+    // up with, not the one we started with.
+    double viewStartBeat = static_cast<double>(m_timelineScrollOffset / m_pixelsPerBeat);
     const double viewWidthBeats = static_cast<double>(gridWidthPx / m_pixelsPerBeat);
-    const double viewEndBeat = viewStartBeat + viewWidthBeats;
+    double viewEndBeat = viewStartBeat + viewWidthBeats;
 
     const double playheadBeat = secondsToBeats(m_trackManager->getUIPosition());
 
@@ -306,6 +309,13 @@ void TrackManagerUI::updateTimelineMinimap(double deltaTime) {
     // to call here: it only re-enters updateTimelineMinimap when isFinal is false.
     if (domainShrank) {
         setTimelineViewStartBeat(viewStartBeat, /*isFinal=*/true);
+
+        // Re-read what the clamp actually settled on. Zoom is untouched, so the width
+        // is unchanged and only the start moves. Without this the minimap model below
+        // would publish the pre-clamp viewport — the thumb would stay parked outside
+        // the domain for a frame, which is the exact symptom this block exists to fix.
+        viewStartBeat = static_cast<double>(m_timelineScrollOffset / m_pixelsPerBeat);
+        viewEndBeat = viewStartBeat + viewWidthBeats;
     }
 
     if (m_minimapNeedsRebuild) {


### PR DESCRIPTION
The remaining behavioural findings from #551, in the order agreed. All five were
re-verified against current code first — the line numbers in that issue are from
the #549 split and have moved.

They share one shape: **the state the UI reports is not the state the UI is in.**

## 1. The Paint tool never showed hover

The toolbar lays out **seven** buttons and declares **seven** `*Hovered` members.
The mouse-move handler assigned **six**. `m_paintToolHovered` was permanently
`false`, so the button never highlighted and never produced a tooltip — while its
bounds were laid out (`:222`), rendered with a hover argument (`:307`) and
clickable (`:555`).

Wired into all five places the others appear: old-state snapshot, assignment,
any-hovered aggregate, tooltip chain, repaint condition.

## 2. The menu button could only open

Clicking with the menu open closed it — then fell through to construction code
that immediately reopened it. The block still carried its own confession:

```cpp
// Create context menu (RE-ADDING MISSING LOGIC because I am replacing the block)
if (!m_activeContextMenu) {
    m_activeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
}
```

Closing now returns early, which is the thing that makes it a toggle.

## 3. The loop preset could check itself without applying

`m_loopPreset = id` ran **before** the branches that decide whether the preset
can be honoured. *Selection* with no selection and *Project* with no resolvable
extent both end with `loopEnabled == false` — so the menu showed that preset
checked while looping was off, and `m_onLoopPresetChanged(id)` reported it to the
app as applied.

The assignment now happens after those branches and records what actually took
effect, falling back to **Off** when a preset that meant to enable looping could
not.

## 4. Losing the render cache lost the content

```cpp
if (!renderCache) {
    renderTrackManagerStatic(renderer);
    return;              // <-- skips every dynamic pass below
}
```

That `return` skipped overlays, meters, selection highlight, the playhead and the
drop preview. The neighbouring branch for a null cache *object* already fell
through correctly, so the two paths disagreed with each other.

The cache is a performance optimisation. Losing it must cost frame rate, never
content.

## 5. A shrinking minimap domain left the viewport outside it

The shrink branch assigned `m_minimapDomainEndBeat` without re-clamping the
scroll offset. Delete the last clip in a long arrangement and the view stays
parked where that clip used to be: empty grid, minimap thumb off its own track.

Growing is safe — the old view is still inside the larger domain — so only the
shrink needs this. Reuses `setTimelineViewStartBeat`, which applies exactly this
clamp and only re-enters `updateTimelineMinimap` when `isFinal` is false, so
there is no recursion.

## Not included

**`safeClampFloat`'s zero-sentinel for non-finite input** — #551's last item. It
is a shared primitive whose "fix" could change behaviour at call sites relying on
the current semantics. It wants its own change and a call-site audit, not a
ride-along in a five-fix commit. #551 stays open for it.

## Verification, and its limit

These are UI-state behaviours in `TrackManagerUI`, which has no headless harness —
the same constraint recorded in #629 and #631. The desktop app **compiles clean**,
which is the only automated check that exercises these TUs at all, since
`AESTRA_CI=ON` force-disables the UI in every other lane.

Each fix is small and reasoned from the surrounding code rather than measured.
**The menu toggle and the paint hover in particular want thirty seconds of
clicking before anyone trusts them** — they are the two where I'd expect a
surprise if there is one.

Refs #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added Paint tool hover state handling for highlighting, tooltips, and repainting.
- Made the toolbar menu button toggle the context menu closed/open.
- Ensured loop presets reflect the preset actually applied, falling back to Off when looping is unavailable.
- Preserved dynamic rendering passes when render-cache creation is unavailable.
- Re-clamped the timeline viewport when the minimap domain shrinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->