### PR TITLE
Engineering health: name the verification ladder and the observe-first rule

### DIFF
--- a/docs/technical/engineering-health.md
+++ b/docs/technical/engineering-health.md
@@ -173,6 +173,34 @@ fail. Where a fix cannot be tested at the layer it lives in — UI gestures have
 headless harness — say that plainly and pin the shape of the change one layer
 down, rather than implying coverage that does not exist.
 
+### The verification ladder
+
+These four are different claims, and they get blurred precisely when a change is
+hard to test:
+
+| rung | means | typical evidence |
+|---|---|---|
+| **compiled** | the code is legal and links | CI build lane |
+| **code path executed** | the branch actually ran | a log line, a counter, a coverage run |
+| **behaviour observed** | the change did the thing, once | screenshot, trace, driven gesture |
+| **behaviour regression-tested** | it cannot silently stop doing the thing | a test that fails when reverted |
+
+A change may legitimately ship at any rung. What is not legitimate is claiming a
+higher one than was reached, or leaving the rung unstated so a reader assumes the
+top. Say which rung each part of a change is on.
+
+**Why the second rung is not free.** A fix can compile, read correctly, and never
+run. #638 shipped a menu-toggle fix whose guard sat in a handler that a mouse
+click never reached with the state it tested for — an earlier handler had already
+cleared it. The code was locally correct and globally inert. One log line settled
+in a single run what re-reading the file could not.
+
+**Observe before constructing a causal story.** Not because reasoning is bad, but
+because a false premise about control flow yields an impeccable explanation and a
+useless fix. This matters most for composition bugs, where every function is
+individually correct and the defect exists only in their ordering — those hide
+from single-file reading by construction.
+
 ---
 
 ## 9. Behaviour-preserving refactors stop where equivalence cannot be demonstrated
@@ -193,6 +221,13 @@ silently resolves it.
 ---
 
 ## Working rules
+
+**Instrument before theorising about runtime behaviour.** For anything about
+what the running system does — input, ordering, timing, "it does X when I do Y" —
+add the trace and observe first. The existing logs are often enough. This is not
+a substitute for reading the code; it is what stops you reading the wrong file
+confidently. (Pure logic and compile errors are exempt: there the code *is* the
+evidence.)
 
 **A running build owns the working tree until it exits.** Do not switch branches,
 rebase, or check out files while a build is running against the tree — the build

--- a/docs/technical/engineering-health.md
+++ b/docs/technical/engineering-health.md
@@ -194,6 +194,15 @@ nothing more, and it can still be skipped, flaky or incomplete. "Regression-test
 means *this* behaviour is pinned — not that the feature is safe. Naming the
 covered scenario is part of the claim.
 
+**Rung and extent are separate axes.** The rung says what *kind* of evidence
+exists; the named scenario says how far it reaches. Two changes can both be
+"regression-tested" while one pins a single reproduction and the other pins an
+entire semantic input space — the same rung, wildly different extent. State both:
+`safeClampFloat` is regression-tested over finite/NaN/±inf against normal,
+inverted, degenerate and non-finite bounds (#640), which is a very different
+claim from a test that reproduces one reported bug, even though both sit on the
+top rung.
+
 **Why the second rung is not free.** A fix can compile, read correctly, and never
 run. #638 shipped a menu-toggle fix whose guard sat in a handler that a mouse
 click never reached with the state it tested for — an earlier handler had already

--- a/docs/technical/engineering-health.md
+++ b/docs/technical/engineering-health.md
@@ -183,11 +183,16 @@ hard to test:
 | **compiled** | the code is legal and links | CI build lane |
 | **code path executed** | the branch actually ran | a log line, a counter, a coverage run |
 | **behaviour observed** | the change did the thing, once | screenshot, trace, driven gesture |
-| **behaviour regression-tested** | it cannot silently stop doing the thing | a test that fails when reverted |
+| **behaviour regression-tested** | the covered scenario is protected against silent regression | a test that fails when the change is reverted |
 
 A change may legitimately ship at any rung. What is not legitimate is claiming a
 higher one than was reached, or leaving the rung unstated so a reader assumes the
 top. Say which rung each part of a change is on.
+
+The top rung is not absolute either: a test protects the scenario it covers and
+nothing more, and it can still be skipped, flaky or incomplete. "Regression-tested"
+means *this* behaviour is pinned — not that the feature is safe. Naming the
+covered scenario is part of the claim.
 
 **Why the second rung is not free.** A fix can compile, read correctly, and never
 run. #638 shipped a menu-toggle fix whose guard sat in a handler that a mouse


### PR DESCRIPTION
Docs only. Sharpens principle 8 of `engineering-health.md` with what #638
demonstrated.

## Why

Principle 8 says *"fixed requires reproduction"* without naming what reproduction
means — and those meanings blur exactly when a change is hard to test. Four
distinct claims, now a table:

| rung | means | typical evidence |
|---|---|---|
| **compiled** | the code is legal and links | CI build lane |
| **code path executed** | the branch actually ran | a log line, a counter, coverage |
| **behaviour observed** | it did the thing, once | screenshot, trace, driven gesture |
| **behaviour regression-tested** | it cannot silently stop | a test that fails when reverted |

A change may legitimately ship at **any** rung. What is not legitimate is
claiming a higher one than was reached, or leaving it unstated so a reader
assumes the top.

## The concrete demonstration

#638 proved the second rung is not free. Its menu-toggle fix **compiled, read
correctly, and never ran** — the guard sat in a handler that a mouse click
reached only after an earlier handler had already cleared the state it tested
for. Locally correct, globally inert.

One log line settled in a single run what re-reading the file could not.

The honest counterweight, also recorded: **CodeRabbit reached the same conclusion
statically**, from the dispatch order alone. The static path existed. It just
was not the one being walked, because the file already believed to be the culprit
was the one being re-read.

## The working rule

> **Instrument before theorising about runtime behaviour.**

Phrased so it does not read as anti-analysis — it is what stops you reading the
wrong file confidently — and pure logic/compile errors are explicitly exempt,
since there the code *is* the evidence.

The framing **"observe before constructing a causal story"** is the owner's, and
names the failure better than "instrument first" does: the problem is not
skipping a step, it is building an impeccable explanation on one false premise.
Composition bugs are where this bites hardest — every function individually
correct, the defect only in their ordering, invisible to single-file reading by
construction.

Refs #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated principle 8 of `docs/technical/engineering-health.md` by adding “The verification ladder,” a four-rung framework for claiming evidence: **compiled**, **code path executed**, **behaviour observed**, and **behaviour regression-tested**.
- Clarified that changes may ship at any rung, but the achieved rung must be explicit and not overstated; also separated **evidence rung** from **extent** (what scenario/scope the claim covers).
- Added the rule **“Observe before constructing a causal story”** for runtime behaviour: reviewers should require instrumentation/observation before explaining causality; pure logic and compile errors are excluded because the code itself doesn’t provide runtime evidence.
- Expanded the rationale with **`#638`**: a menu-toggle fix compiled but didn’t execute due to handler ordering; a runtime log confirmed the behaviour while static analysis identified the dispatch-order problem.
- Refined the “regression-tested” meaning to protect **the named covered scenario** against silent regression, noting that tests may still be skipped, flaky, or incomplete—so naming the scenario is part of the verification claim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->