### PR TITLE
safeClampFloat: resolve non-finite values to the interval, not to zero

### DIFF
--- a/Source/Components/TrackManagerUIInternal.h
+++ b/Source/Components/TrackManagerUIInternal.h
@@ -6,6 +6,7 @@
 // API — include only from TrackManagerUI*.cpp files, after TrackManagerUI.h.
 
 #include "../AestraUI/Base/NUIContextMenu.h"
+#include "TrackManagerUIMath.h" // kTimeline* constants + safeClampFloat (no widget deps)
 
 #include <algorithm>
 #include <cmath>
@@ -18,42 +19,6 @@
 
 namespace Aestra {
 namespace Audio {
-
-// Shared by layout, rendering, hit testing, and drag math so visible and
-// interactive geometry cannot drift independently.
-constexpr float kTimelineHeaderHeight = 38.0f;
-constexpr float kTimelineRulerHeight = 28.0f;
-constexpr float kTimelineHorizontalScrollbarHeight = 24.0f;
-constexpr float kTimelineScrollbarWidth = 15.0f;
-
-/**
- * @brief Gap between the track-controls column and the first grid pixel.
- *
- * Appeared as a bare `+ 5` in 30-odd `gridStartX` expressions across every
- * TrackManagerUI translation unit (#550). Rendering, hit testing and drag math
- * all have to agree on it, and a literal repeated that many times agrees only
- * by luck.
- */
-constexpr float kTimelineGridInsetX = 5.0f;
-
-/** @brief Clamp to [a, b] (order-agnostic); non-finite inputs collapse to a safe bound. */
-inline float safeClampFloat(float value, float a, float b) {
-    if (!std::isfinite(value))
-        return 0.0f;
-    if (!std::isfinite(a) && !std::isfinite(b))
-        return 0.0f;
-    if (!std::isfinite(a))
-        a = b;
-    if (!std::isfinite(b))
-        b = a;
-    const float lo = std::min(a, b);
-    const float hi = std::max(a, b);
-    if (value <= lo)
-        return lo;
-    if (value >= hi)
-        return hi;
-    return value;
-}
 
 /** @brief Walk up the parent chain to the root component. */
 inline AestraUI::NUIComponent* getRootComponent(AestraUI::NUIComponent* component) {

--- a/Source/Components/TrackManagerUIMath.h
+++ b/Source/Components/TrackManagerUIMath.h
@@ -1,0 +1,93 @@
+// © 2026 Aestra Studios All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// Pure numeric and geometry values shared by the TrackManagerUI* translation
+// units. Split out of TrackManagerUIInternal.h, which also carries context-menu
+// helpers and therefore includes NUIContextMenu.h — nothing here needs a widget,
+// and a shared numeric primitive should be reachable by a test without dragging
+// the UI framework in behind it (AESTRA_CI=ON disables those targets entirely).
+//
+// Depends on <algorithm> and <cmath> and nothing else. Keep it that way.
+
+#include <algorithm>
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+
+// Shared by layout, rendering, hit testing, and drag math so visible and
+// interactive geometry cannot drift independently.
+constexpr float kTimelineHeaderHeight = 38.0f;
+constexpr float kTimelineRulerHeight = 28.0f;
+constexpr float kTimelineHorizontalScrollbarHeight = 24.0f;
+constexpr float kTimelineScrollbarWidth = 15.0f;
+
+/**
+ * @brief Gap between the track-controls column and the first grid pixel.
+ *
+ * Appeared as a bare `+ 5` in 30-odd `gridStartX` expressions across every
+ * TrackManagerUI translation unit (#550). Rendering, hit testing and drag math
+ * all have to agree on it, and a literal repeated that many times agrees only
+ * by luck.
+ */
+constexpr float kTimelineGridInsetX = 5.0f;
+
+/**
+ * @brief Clamp @p value into the interval described by @p a and @p b.
+ *
+ * The contract, in the order the function decides it:
+ *
+ * 1. **Bounds that describe no interval** (both non-finite) return `0.0f`. There
+ *    is no in-range answer to give, so this stays the defensive sentinel it has
+ *    always been. No caller passes such bounds today.
+ * 2. **One non-finite bound** collapses to the other, giving a degenerate
+ *    interval rather than discarding the call.
+ * 3. **Inverted finite bounds are normalised**, not rejected. This is relied
+ *    upon: `gridStartX = bounds.x + 236 + 5` and `gridEndX = bounds.x + width - 15`
+ *    invert below ~256px of component width, and narrow windows are a supported
+ *    layout (#551 audit).
+ * 4. **Degenerate bounds** (`lo == hi`) return that bound.
+ * 5. **Non-finite values, against a real interval**, resolve where the maths
+ *    says they belong: `-inf → lo`, `+inf → hi`, `NaN → lo`. NaN has no ordering,
+ *    so its answer is a deterministic choice rather than a derivation; the low
+ *    end is picked because every caller's lower bound is a legal value for it.
+ * 6. **Finite values** clamp normally.
+ *
+ * Rule 5 is the one that changed (#551). This previously returned `0.0f` for any
+ * non-finite value, which is only in range for 3 of the 12 call sites — the
+ * scroll-offset family, whose lower bound happens to be `0.0f`. For the other
+ * nine it produced a value outside the caller's own interval, and for the four
+ * zoom sites that value is a *divisor* in every x-to-beat conversion.
+ *
+ * Note this is hardening, not a repair: no path was found that actually feeds a
+ * non-finite value in. It removes an invalid-state escape rather than a
+ * reproducible defect.
+ */
+inline float safeClampFloat(float value, float a, float b) {
+    // Bounds first — "in range" is meaningless without a range.
+    if (!std::isfinite(a) && !std::isfinite(b))
+        return 0.0f;
+    if (!std::isfinite(a))
+        a = b;
+    if (!std::isfinite(b))
+        b = a;
+
+    const float lo = std::min(a, b);
+    const float hi = std::max(a, b);
+
+    // NaN compares false against everything, so it would otherwise fall through
+    // both bounds checks and be returned unchanged.
+    if (std::isnan(value))
+        return lo;
+
+    // These two also absorb -inf and +inf, which order correctly against finite
+    // bounds and so need no special case of their own.
+    if (value <= lo)
+        return lo;
+    if (value >= hi)
+        return hi;
+    return value;
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Tests/AestraUI/SafeClampFloatTest.cpp
+++ b/Tests/AestraUI/SafeClampFloatTest.cpp
@@ -1,0 +1,151 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// safeClampFloat boundary semantics (#551, last item).
+//
+// This test is meaningful only because the call-site audit came first. A test
+// written against the old implementation would have pinned "non-finite input
+// returns 0.0f" as the contract — immaculate coverage of the wrong semantics.
+// What the audit established, across 12 call sites in three families:
+//
+//   zoom / pixels-per-beat  (4)  bounds [1.0, 32000]        0 is NOT in range
+//   position -> grid rect   (5)  computed geometry          0 is NOT in range,
+//                                                           and bounds INVERT
+//                                                           below ~256px width
+//   scroll offset           (3)  bounds [0, maxScroll]      0 IS in range
+//
+// So the one property all twelve share is: the result must lie inside the
+// caller's own interval. The old sentinel violated that for nine of them, and
+// for the four zoom sites the violating value is a divisor.
+//
+// The inverted-bounds tolerance is the opposite case — it IS depended upon by
+// ordinary narrow-window layout, and must survive unchanged.
+
+#include "TrackManagerUIMath.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+using Aestra::Audio::safeClampFloat;
+
+constexpr float kNaN = std::numeric_limits<float>::quiet_NaN();
+constexpr float kInf = std::numeric_limits<float>::infinity();
+
+void expect(float value, float a, float b, float wanted, const std::string& what) {
+    const float got = safeClampFloat(value, a, b);
+    const bool ok = (std::isnan(wanted) && std::isnan(got)) || (got == wanted);
+    if (!ok) {
+        std::cerr << "[FAIL] " << what << ": got " << got << ", wanted " << wanted << '\n';
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    // --- finite values, ordinary bounds ---------------------------------------
+    expect(5.0f, 0.0f, 10.0f, 5.0f, "in range passes through");
+    expect(-1.0f, 0.0f, 10.0f, 0.0f, "below range clamps to lo");
+    expect(11.0f, 0.0f, 10.0f, 10.0f, "above range clamps to hi");
+    expect(0.0f, 0.0f, 10.0f, 0.0f, "exactly lo");
+    expect(10.0f, 0.0f, 10.0f, 10.0f, "exactly hi");
+
+    // --- inverted finite bounds are NORMALISED, not rejected -------------------
+    // Depended upon: gridStartX = bounds.x + 236 + 5 and gridEndX = bounds.x +
+    // width - 15 invert below ~256px of component width, which is a supported
+    // layout. Every case here must match its non-inverted twin above.
+    expect(5.0f, 10.0f, 0.0f, 5.0f, "inverted: in range passes through");
+    expect(-1.0f, 10.0f, 0.0f, 0.0f, "inverted: below clamps to lo");
+    expect(11.0f, 10.0f, 0.0f, 10.0f, "inverted: above clamps to hi");
+    // The real geometry, at the width where it flips (audit numbers).
+    expect(243.0f, 241.0f, 235.0f, 241.0f, "inverted grid bounds at width 250");
+    expect(200.0f, 241.0f, 235.0f, 235.0f, "inverted grid bounds, value below");
+
+    // --- degenerate bounds -----------------------------------------------------
+    expect(5.0f, 3.0f, 3.0f, 3.0f, "lo == hi returns that bound");
+    expect(1.0f, 3.0f, 3.0f, 3.0f, "lo == hi from below");
+    expect(3.0f, 3.0f, 3.0f, 3.0f, "lo == hi exactly");
+    expect(kNaN, 3.0f, 3.0f, 3.0f, "lo == hi with NaN value");
+
+    // --- NON-FINITE VALUES: the semantics that changed -------------------------
+    // -inf -> lo, +inf -> hi, NaN -> lo. Previously all three returned 0.0f.
+    expect(-kInf, 1.0f, 10.0f, 1.0f, "-inf resolves to lo");
+    expect(kInf, 1.0f, 10.0f, 10.0f, "+inf resolves to hi");
+    expect(kNaN, 1.0f, 10.0f, 1.0f, "NaN resolves to lo");
+
+    // Same, with bounds inverted — the two rules must compose.
+    expect(-kInf, 10.0f, 1.0f, 1.0f, "-inf resolves to lo (inverted bounds)");
+    expect(kInf, 10.0f, 1.0f, 10.0f, "+inf resolves to hi (inverted bounds)");
+    expect(kNaN, 10.0f, 1.0f, 1.0f, "NaN resolves to lo (inverted bounds)");
+
+    // --- the regression this exists to prevent, stated per family --------------
+    // Zoom: [1, 32000]. 0 is not a legal pixels-per-beat and is a DIVISOR in
+    // every x-to-beat conversion, so the old 0.0f sentinel was the worst possible
+    // answer here.
+    for (float bad : {kNaN, kInf, -kInf}) {
+        const float ppb = safeClampFloat(bad, 1.0f, 32000.0f);
+        check(ppb >= 1.0f && ppb <= 32000.0f, "zoom family: non-finite stays in [1, 32000]");
+        check(ppb != 0.0f, "zoom family: non-finite never yields a zero divisor");
+    }
+
+    // Position: window-absolute coordinates, 0 is off-screen-left of the grid.
+    for (float bad : {kNaN, kInf, -kInf}) {
+        const float x = safeClampFloat(bad, 241.0f, 656.0f);
+        check(x >= 241.0f && x <= 656.0f, "position family: non-finite stays inside the grid rect");
+    }
+
+    // Scroll: [0, max]. 0 IS in range here, so this family's behaviour is
+    // unchanged — pinned so a future edit cannot quietly move it.
+    expect(-kInf, 0.0f, 500.0f, 0.0f, "scroll family: -inf still resolves to 0");
+    expect(kNaN, 0.0f, 500.0f, 0.0f, "scroll family: NaN still resolves to 0");
+    expect(kInf, 0.0f, 500.0f, 500.0f, "scroll family: +inf resolves to max, not 0");
+
+    // --- bounds that describe no interval --------------------------------------
+    // No in-range answer exists, so the defensive sentinel is retained. No caller
+    // passes these today; pinned so the retention is deliberate rather than
+    // accidental.
+    expect(5.0f, kNaN, kNaN, 0.0f, "both bounds NaN -> sentinel");
+    expect(5.0f, kInf, -kInf, 0.0f, "both bounds infinite -> sentinel");
+    expect(kNaN, kNaN, kNaN, 0.0f, "everything non-finite -> sentinel");
+
+    // --- one non-finite bound collapses to the other ---------------------------
+    expect(5.0f, kNaN, 10.0f, 10.0f, "NaN lower bound collapses to the finite one");
+    expect(5.0f, 10.0f, kNaN, 10.0f, "NaN upper bound collapses to the finite one");
+    expect(5.0f, kInf, 7.0f, 7.0f, "infinite bound collapses to the finite one");
+
+    // --- the result is ALWAYS inside the interval, or the sentinel -------------
+    // The single property all twelve call sites share, asserted over a sweep
+    // rather than case by case.
+    const float values[] = {-kInf, -1e30f, -1.0f, 0.0f, 1.0f, 1e30f, kInf, kNaN};
+    const float bounds[][2] = {{0.0f, 10.0f}, {10.0f, 0.0f}, {1.0f, 32000.0f},
+                               {241.0f, 656.0f}, {241.0f, 235.0f}, {-5.0f, -1.0f}, {3.0f, 3.0f}};
+    for (float v : values) {
+        for (const auto& bnd : bounds) {
+            const float got = safeClampFloat(v, bnd[0], bnd[1]);
+            const float lo = std::min(bnd[0], bnd[1]);
+            const float hi = std::max(bnd[0], bnd[1]);
+            check(std::isfinite(got), "sweep: result is always finite");
+            check(got >= lo && got <= hi, "sweep: result is always inside the caller's interval");
+        }
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] SafeClampFloatTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] SafeClampFloatTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1525,6 +1525,16 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeJSONTest.cpp")
     message(STATUS "NUIThemeJSONTest added - Issue #259 theme JSON loading test")
 endif()
 
+# safeClampFloat boundary semantics (#551). Header-only and widget-free by
+# design — TrackManagerUIMath.h exists precisely so this primitive is reachable
+# without linking AestraUI, which AESTRA_CI=ON disables.
+add_executable(SafeClampFloatTest AestraUI/SafeClampFloatTest.cpp)
+target_include_directories(SafeClampFloatTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Components
+)
+add_test(NAME SafeClampFloatTest COMMAND SafeClampFloatTest)
+set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression")
+
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeConsistencyTest.cpp")
     add_executable(NUIThemeConsistencyTest AestraUI/NUIThemeConsistencyTest.cpp)
     target_link_libraries(NUIThemeConsistencyTest PRIVATE AestraUI_Core)


### PR DESCRIPTION
Last item on #551. The [call-site audit](https://github.com/currentsuspect/Aestra/issues/551#issuecomment-5092935265)
came first, because for a shared primitive the dangerous question is never *"does
it work"* but **"were all twelve callers relying on the same definition of
works"**.

## What the audit decided

12 call sites, three families. The decisive property is whether `0` is inside
that caller's range:

| family | sites | bounds | `0` in range? |
|---|---|---|---|
| zoom / pixels-per-beat | 4 | `[1, 32000]` | **no** |
| position → grid rect | 5 | computed geometry | **no** |
| scroll offset | 3 | `[0, maxScroll]` | yes |

So `!isfinite(value) → 0.0f` returned an **out-of-range value for nine of
twelve** — and for the four zoom sites that value is a **divisor** in every
x→beat conversion. The `!(pixelsPerBeat > 0.0f)` guard in `gridOffsetToBeat`
(#632) exists because zero there is destructive.

The audit also found the **opposite** conclusion for the other odd behaviour:
the inverted-bounds tolerance **is depended upon**.

```
width= 260  gridStartX=241.0  gridEndX=245.0  inverted=False
width= 250  gridStartX=241.0  gridEndX=235.0  inverted=True
```

Below ~256px of component width the bounds invert, and narrow windows are
supported layout. Two odd behaviours in one function needing **opposite**
treatment — which a test-first approach would have missed, since a test written
against the old code would have pinned the sentinel as the contract.

## What changed

Non-finite values resolve where the maths puts them:

```
-inf → lo      +inf → hi      NaN → lo
```

This is the owner's correction to my first proposal, which mapped everything to
`lo` and called it "nearest in-range" — not true for `+inf`. The primitive should
be coherent independently of which cases today's callers happen to hit.

`±inf` need no special case: they order correctly against finite bounds, so the
existing comparisons absorb them once the early return is gone. Only `NaN` needs
handling — it compares false against everything and would otherwise fall through
and be returned unchanged. Its answer is a deterministic *choice*, not a
derivation; `lo` because every caller's lower bound is a legal value for it.

**Unchanged:** inverted-bounds normalisation, degenerate bounds returning that
bound, and the `0.0f` sentinel when *both* bounds are non-finite — no in-range
answer exists and the audit established nothing better.

## Framing

**Hardening, not a repair.** No path was found that actually feeds a non-finite
value in, so #551's description of this as a defect overstates it. It removes an
invalid-state escape from a primitive whose output can become a divisor.

## Why a new header

`TrackManagerUIMath.h` takes the function plus the `kTimeline*` constants.
`TrackManagerUIInternal.h` also carries context-menu helpers, so it includes
`NUIContextMenu.h` — and a shared numeric primitive should be reachable by a test
without linking AestraUI, which `AESTRA_CI=ON` disables outright. The new header
depends on `<algorithm>` and `<cmath>` and nothing else.

That is what makes the requested Cartesian test *possible*, not scope creep.

## Verification — top rung, for once

A pure function admits a real regression test.
`Tests/AestraUI/SafeClampFloatTest.cpp` covers finite / `NaN` / `±inf` against
normal, inverted, degenerate and both-non-finite bounds, plus a sweep asserting
the one property all twelve callers share: **the result is finite and inside the
caller's own interval.**

Gate proven by reverting: restoring the old sentinel fails 8 assertions and
exits 1.

```
[FAIL] -inf resolves to lo: got 0, wanted 1
[FAIL] +inf resolves to hi: got 0, wanted 10
[FAIL] NaN resolves to lo: got 0, wanted 1
[FAIL] zoom family: non-finite stays in [1, 32000]
...
```

198 → 199 tests; desktop app builds clean.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated `safeClampFloat` so `-inf`, `+inf`, and `NaN` resolve within the requested interval while preserving inverted-bound, degenerate-bound, and non-finite-bound behavior.
- Extracted timeline math constants and the clamp helper into standalone `TrackManagerUIMath.h` for reuse and headless testing.
- Added regression coverage across finite/non-finite inputs, bound configurations, and caller-specific intervals.
- Registered the new `SafeClampFloatTest` CTest target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->