### PR TITLE
view.current tells the truth: intent and visibility are separate

### DIFF
--- a/Source/App/MuseHostVerbs.cpp
+++ b/Source/App/MuseHostVerbs.cpp
@@ -69,6 +69,18 @@ bool lookupView(const std::string& name, ViewType& out) {
     return false;
 }
 
+// The workspace modes, as protocol strings. Same contract as kViews: agents will
+// hardcode these, so renaming one is a breaking change.
+const char* focusName(::ViewFocus focus) {
+    switch (focus) {
+    case ::ViewFocus::Arsenal:    return "arsenal";
+    case ::ViewFocus::Timeline:   return "timeline";
+    case ::ViewFocus::Audition:   return "audition";
+    case ::ViewFocus::RoutingMap: return "routingMap";
+    }
+    return "unknown";
+}
+
 HostVerbArg viewArg() {
     HostVerbArg arg;
     arg.name = "view";
@@ -101,8 +113,13 @@ void registerMuseHostVerbs(Audio::MuseService& service, ::AestraContent& content
             return HostVerbResult::failure(
                 "no_such_view", "no view named '" + requested + "'; known views: " + knownViewList());
         }
-        const bool already = c->isViewOpen(view);
+        // Compare against the STANDING INTENT, not against visibility. In a mode
+        // that hides panels (Audition), the mixer can be requestedOpen with
+        // visible=false; "open the mixer" there is not a no-op just because the
+        // panel is off screen, and it is not a change just because it is.
+        const bool already = c->getViewOpenState(view).requestedOpen;
         c->setViewOpen(view, open);
+        const auto after = c->getViewOpenState(view);
 
         JSON result = JSON::object();
         result.set("view", JSON(requested));
@@ -111,6 +128,12 @@ void registerMuseHostVerbs(Audio::MuseService& service, ::AestraContent& content
         // successful outcome, and a caller that cannot tell it apart from a
         // change will re-issue commands trying to force one.
         result.set("changed", JSON(already != open));
+        // Both halves of the outcome, so a caller can see when a request was
+        // honoured as intent but is not on screen yet — rather than concluding
+        // the verb failed.
+        result.set("requestedOpen", JSON(after.requestedOpen));
+        result.set("visible", JSON(after.visible));
+        result.set("focus", JSON(std::string(focusName(c->getViewFocus()))));
         return HostVerbResult::success(result);
     };
 
@@ -145,18 +168,28 @@ void registerMuseHostVerbs(Audio::MuseService& service, ::AestraContent& content
         spec.affinity = HostThreadAffinity::HostUiThread;
         spec.mutates = false;
         spec.description =
-            "Which workspaces are open right now. Returns every known view with its "
-            "open state, so an agent can see the workspace instead of assuming it.";
+            "Which workspaces are open right now. Each view reports 'visible' (on "
+            "screen) and 'requestedOpen' (standing intent, which survives modes that "
+            "hide panels), plus the workspace 'focus' that causes them to differ. "
+            "'open' is retained as an alias for 'visible'.";
         registerOrLog(service, std::move(spec), [c](const JSON&) {
             JSON views = JSON::array();
             for (const auto& v : kViews) {
+                const auto state = c->getViewOpenState(v.view);
                 JSON entry = JSON::object();
                 entry.set("view", JSON(std::string(v.name)));
-                entry.set("open", JSON(c->isViewOpen(v.view)));
+                // "open" is retained and means VISIBLE — the question an agent
+                // asking a single yes/no about a view actually means.
+                entry.set("open", JSON(state.visible));
+                entry.set("visible", JSON(state.visible));
+                entry.set("requestedOpen", JSON(state.requestedOpen));
                 views.push(entry);
             }
             JSON result = JSON::object();
             result.set("views", views);
+            // The mode that CAUSES intent and visibility to diverge. Without it an
+            // agent seeing requestedOpen=true, visible=false has no way to learn why.
+            result.set("focus", JSON(std::string(focusName(c->getViewFocus()))));
             return HostVerbResult::success(result);
         });
     }

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1916,16 +1916,47 @@ bool AestraContent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 // SECTION: View Management
 // =============================================================================
 
-bool AestraContent::isViewOpen(Audio::ViewType view) const {
+AestraContent::ViewOpenState AestraContent::getViewOpenState(Audio::ViewType view) const {
+    ViewOpenState state;
     switch (view) {
-    case Audio::ViewType::Mixer:     return m_viewState.mixerOpen;
-    case Audio::ViewType::PianoRoll: return m_viewState.pianoRollOpen;
-    case Audio::ViewType::Sequencer: return m_viewState.sequencerOpen;
-    case Audio::ViewType::Playlist:  return m_viewState.playlistActive;
-    case Audio::ViewType::History:   return m_historyPanel && m_historyPanel->isVisible();
-    case Audio::ViewType::Takes:     return m_takesPanel && m_takesPanel->isVisible();
+    case Audio::ViewType::Mixer:
+        state.requestedOpen = m_viewState.mixerOpen;
+        state.visible = m_mixerPanel && m_mixerPanel->isVisible();
+        break;
+    case Audio::ViewType::PianoRoll:
+        state.requestedOpen = m_viewState.pianoRollOpen;
+        state.visible = m_pianoRollPanel && m_pianoRollPanel->isVisible();
+        break;
+    case Audio::ViewType::Sequencer:
+        state.requestedOpen = m_viewState.sequencerOpen;
+        state.visible = m_sequencerPanel && m_sequencerPanel->isVisible();
+        break;
+    case Audio::ViewType::Playlist:
+        // The timeline is the workspace itself rather than an overlay panel, so
+        // its intent and its visibility are the same stored flag. Reported as
+        // both so callers do not have to special-case it.
+        state.requestedOpen = m_viewState.playlistActive;
+        state.visible = m_viewState.playlistActive;
+        break;
+    case Audio::ViewType::History:
+        // History and Takes carry no separate restore state, because nothing
+        // hides them behind the user's back — setViewFocus() only touches the
+        // mixer, piano roll and Arsenal panels. The panel is therefore the
+        // authority for both halves. If a future mode does hide these, they need
+        // their own intent field rather than this equivalence.
+        state.visible = m_historyPanel && m_historyPanel->isVisible();
+        state.requestedOpen = state.visible;
+        break;
+    case Audio::ViewType::Takes:
+        state.visible = m_takesPanel && m_takesPanel->isVisible();
+        state.requestedOpen = state.visible;
+        break;
     }
-    return false;
+    return state;
+}
+
+bool AestraContent::isViewOpen(Audio::ViewType view) const {
+    return getViewOpenState(view).visible;
 }
 
 void AestraContent::setViewOpen(Audio::ViewType view, bool open) {

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -162,12 +162,41 @@ public:
     /** @brief Toggle visibility for a specific workspace overlay. */
     void toggleView(Aestra::Audio::ViewType view);
     /**
-     * @brief Whether a workspace overlay is currently open.
+     * @brief The two independent truths about a workspace overlay.
      *
-     * The view state was previously write-only from outside this class: callers
-     * could open and close overlays but had no way to ask what was showing. The
-     * Muse host verbs need to answer "what is on screen right now" without
-     * guessing, so the state is now readable as well as writable.
+     * These are genuinely different properties, and collapsing them into one
+     * boolean is what made the old single-value query misleading (see
+     * `docs/technical/settings_view_state_map.md`, B1).
+     *
+     * `requestedOpen` is the user's or agent's standing intent, and survives
+     * modes that hide panels temporarily. `visible` is what is on screen right
+     * now. They diverge in Audition mode, where setViewFocus() hides the mixer,
+     * piano roll and Arsenal panels WITHOUT clearing the intent — deliberately,
+     * because that intent is what restores them on the way out.
+     */
+    struct ViewOpenState {
+        /** @brief Standing intent: what the user asked to be open. */
+        bool requestedOpen = false;
+        /** @brief Ground truth: what is actually on screen right now. */
+        bool visible = false;
+    };
+
+    /**
+     * @brief Both truths about a workspace overlay.
+     *
+     * Every view answers from the same two sources. Previously the query read
+     * intent for four views and actual visibility for the other two, so its
+     * meaning depended on which view you asked about.
+     */
+    ViewOpenState getViewOpenState(Aestra::Audio::ViewType view) const;
+
+    /**
+     * @brief Whether a workspace overlay is currently on screen.
+     *
+     * Deliberately the VISIBLE half, not the intent: a caller asking a single
+     * yes/no question about a view almost always means "can the user see it".
+     * A caller that needs the standing intent — to restore it, or to report both
+     * — should use getViewOpenState().
      */
     bool isViewOpen(Aestra::Audio::ViewType view) const;
     /** @brief Toggle visibility of the left browser area. */


### PR DESCRIPTION
**B1** of the settings/view flow map (#641). The one finding in that map that was
*observed* rather than inferred, so it goes first.

## The defect

`isViewOpen` mixed its sources — **intent** for mixer/pianoRoll/arsenal/timeline,
**actual visibility** for history/takes. What the query meant depended on which
view you asked about.

In Audition mode `setViewFocus` hides panels *without* clearing intent, so it
reported the mixer **open while the mixer was off screen**. That is precisely the
failure `view.current` exists to prevent — its own description says it is there
*"so an agent can see the workspace instead of assuming it."*

## Why neither concept could just be dropped

`m_viewState` **must** keep saying "open", or leaving Audition cannot restore the
panel. The defect was never a wrong value; it was a query collapsing two real
properties into one boolean.

```cpp
struct ViewOpenState {
    bool requestedOpen;  // standing intent; survives modes that hide panels
    bool visible;        // what is on screen right now
};
```

Every view now answers from the same two sources. `isViewOpen` is kept and
returns the **visible** half — a caller asking a single yes/no almost always
means "can the user see it".

History and Takes have no separate intent store, because nothing hides them
behind the user's back. The panel is the authority for both halves, noted in the
code so a future mode that *does* hide them adds a real field rather than
inheriting the equivalence.

## The verbs also report focus

`focus` is the state that **causes** the divergence. An agent seeing
`requestedOpen=true, visible=false` otherwise has no way to learn why.

`view.open` / `view.close` now compute `changed` against **intent**: opening the
mixer in Audition is not a no-op merely because the panel is hidden, and not a
change merely because it is.

## Drive-verified through the real socket

Not by reading state — by asking the running app, over the Muse socket, with the
reproduction from the map:

| step | `focus` | `requestedOpen` | `visible` | |
|---|---|---|---|---|
| timeline, mixer open | `timeline` | `true` | `true` | |
| switch to Audition | `audition` | `true` | **`false`** | ← previously reported as just "open" |
| `view.open mixer` | `audition` | `true` | `false` | `changed=false` |
| `view.close mixer` | `audition` | `false` | `false` | `changed=true` |
| `view.open`, back to timeline | `timeline` | `true` | **`true`** | ← restore path intact |

Row 2 is the bug. Row 5 is the reason the intent half had to stay.

## Compatibility

`open` is retained on every entry as an alias for `visible`, so an existing agent
keeps working — and now gets the honest answer to the question it was already
asking. `requestedOpen`, `visible` and `focus` are additive.

Refs #630, #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Behavior change:** `isViewOpen()` now reports on-screen visibility rather than persistent user intent; callers needing both should use `getViewOpenState()`.
- Added separate `requestedOpen` and `visible` state for overlays, preserving panel intent while modes such as Audition temporarily hide views.
- Updated `view.current`, `view.open`, and `view.close` responses to include visibility, requested state, workspace focus, and intent-based change detection.
- Retained `open` as a compatibility alias for `visible`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->