### PR TITLE
Make Preferences govern what it persists

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -362,7 +362,20 @@ void AestraApp::initializeContent() {
 void AestraApp::initializeAutosave(bool enabled) {
     Aestra::Audio::AutosaveManager::Config config;
     config.enabled = enabled;
-    config.autosaveInterval = std::chrono::seconds(60);
+    // Three numbers used to describe this interval and disagreed: Preferences
+    // said 300, AutosaveManager's own default said 30, and this line hard-coded
+    // 60 — which won, because the other two were never consulted. Preferences is
+    // the persisted authority; clamped because it is user-editable JSON on disk.
+    {
+        const int persisted = Preferences::instance().autoSaveIntervalSeconds;
+        const int seconds = std::clamp(persisted, 10, 3600);
+        if (seconds != persisted) {
+            Log::warning("[AutoSave] autoSaveIntervalSeconds " + std::to_string(persisted) +
+                         " out of range; using " + std::to_string(seconds));
+            Preferences::instance().autoSaveIntervalSeconds = seconds;
+        }
+        config.autosaveInterval = std::chrono::seconds(seconds);
+    }
     config.captureSnapshotOnCallingThread = true;
     config.autosavePathOverride = m_documentState.autosavePath();
     const std::string canonicalProjectPath = m_documentState.canonicalPath();
@@ -393,6 +406,11 @@ void AestraApp::buildSettingsAndDialogs() {
     auto generalPage = std::make_shared<GeneralSettingsPage>();
     generalPage->setOnAutoSaveToggled([this](bool enabled) {
         m_autoSaveManager.setEnabled(enabled);
+        // Persist as well as apply. Startup reads Preferences::autoSaveEnabled
+        // (see run()), but nothing ever wrote it back, so turning autosave off
+        // held for the session and silently came back on at the next launch.
+        // Preferences::save() runs at shutdown, so recording it here is enough.
+        Preferences::instance().autoSaveEnabled = enabled;
         Log::info(std::string("[AutoSave] ") + (enabled ? "Enabled" : "Disabled"));
     });
     settingsDialog->addPage(generalPage);

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -359,6 +359,28 @@ void AestraApp::initializeContent() {
     m_windowManager->setUnifiedHUD(unifiedHUD);
 }
 
+std::chrono::seconds AestraApp::resolveAutosaveInterval() {
+    // ONE place decides this. Three numbers used to describe the autosave
+    // interval and disagreed: Preferences said 300, AutosaveManager's own
+    // default said 30, and initializeAutosave hard-coded 60 — which won,
+    // because the other two were never consulted.
+    //
+    // reinitAutosaveManager() hard-coded 60 a second time, so a user's stored
+    // interval was silently discarded whenever the autosave manager was rebuilt
+    // (project load, save-as). Both sites now resolve through here.
+    //
+    // Clamped because this is user-editable JSON on disk, and the corrected
+    // value is written back so the file and the running config agree.
+    const int persisted = Preferences::instance().autoSaveIntervalSeconds;
+    const int seconds = std::clamp(persisted, 10, 3600);
+    if (seconds != persisted) {
+        Log::warning("[AutoSave] autoSaveIntervalSeconds " + std::to_string(persisted) +
+                     " out of range; using " + std::to_string(seconds));
+        Preferences::instance().autoSaveIntervalSeconds = seconds;
+    }
+    return std::chrono::seconds(seconds);
+}
+
 void AestraApp::initializeAutosave(bool enabled) {
     Aestra::Audio::AutosaveManager::Config config;
     config.enabled = enabled;
@@ -366,16 +388,7 @@ void AestraApp::initializeAutosave(bool enabled) {
     // said 300, AutosaveManager's own default said 30, and this line hard-coded
     // 60 — which won, because the other two were never consulted. Preferences is
     // the persisted authority; clamped because it is user-editable JSON on disk.
-    {
-        const int persisted = Preferences::instance().autoSaveIntervalSeconds;
-        const int seconds = std::clamp(persisted, 10, 3600);
-        if (seconds != persisted) {
-            Log::warning("[AutoSave] autoSaveIntervalSeconds " + std::to_string(persisted) +
-                         " out of range; using " + std::to_string(seconds));
-            Preferences::instance().autoSaveIntervalSeconds = seconds;
-        }
-        config.autosaveInterval = std::chrono::seconds(seconds);
-    }
+    config.autosaveInterval = resolveAutosaveInterval();
     config.captureSnapshotOnCallingThread = true;
     config.autosavePathOverride = m_documentState.autosavePath();
     const std::string canonicalProjectPath = m_documentState.canonicalPath();
@@ -1842,7 +1855,7 @@ void AestraApp::wireTakesPanel() {
 void AestraApp::reinitAutosaveManager() {
     Aestra::Audio::AutosaveManager::Config config;
     config.enabled = m_autoSaveManager.isEnabled();
-    config.autosaveInterval = std::chrono::seconds(60);
+    config.autosaveInterval = resolveAutosaveInterval();
     config.captureSnapshotOnCallingThread = true;
     config.autosavePathOverride = m_documentState.autosavePath();
     const std::string canonicalProjectPath = m_documentState.canonicalPath();

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -69,6 +69,9 @@ private:
     bool initializePlatformAndWindow(const Aestra::UIState& uiState);
     bool initializeAudio();
     void initializeContent();
+    /// The one place the autosave interval is decided (#646). Both the initial
+    /// setup and reinitAutosaveManager() resolve through this.
+    std::chrono::seconds resolveAutosaveInterval();
     void initializeAutosave(bool enabled);
     void buildRecoveryDialog(); // lightweight — needed during startup
     // Idle frame elision (labs/perf/idle-frame-elision-spec.md)

--- a/Source/Core/Preferences.h
+++ b/Source/Core/Preferences.h
@@ -15,23 +15,48 @@ class Preferences {
 public:
     static Preferences& instance();
     
-    // Audio settings
+    // WHICH OF THESE ACTUALLY GOVERN ANYTHING
+    //
+    // A persisted field that nothing reads is worse than a missing one: it makes
+    // a setting look configurable, and any code written against it validates,
+    // persists, reports success and changes nothing. Each field below says which
+    // it is. Keep this accurate — the audit that produced it is in
+    // docs/technical/settings_view_state_map.md (B4).
+
+    // --- Audio settings: NOT WIRED -------------------------------------------
+    // Shadowed by AudioDeviceManager, which is the live authority and never
+    // consults these. Device choice therefore does not survive a restart.
+    // Wiring them means restoring a device by id at startup and handling the
+    // case where it is gone — a feature with real failure modes, not a
+    // one-liner. Do not write a settings path against these until that is done.
     std::string audioDeviceId = "default";
     int sampleRate = 48000;
     int bufferSize = 512;
     bool exclusiveMode = false;
-    
-    // UI settings
+
+    // --- UI settings ----------------------------------------------------------
+    // showGrid / snapToGrid / gridSize: NOT WIRED. Shadowed by TrackManagerUI's
+    // own m_snapEnabled / m_snapSetting, which are the live authority. Snap
+    // choice does not survive a restart.
     bool showGrid = true;
     bool snapToGrid = true;
     float gridSize = 0.25f;  // beats
+    // theme: LIVE. Written by AppearanceSettingsPage::applyChanges, read at
+    // startup by AestraWindowManager. The live authority is NUIThemeManager, so
+    // anything changing the theme must write both.
     std::string theme = "Aestra-dark";
-    
-    // Auto-save
+
+    // --- Auto-save: LIVE ------------------------------------------------------
+    // Both are read at startup by AestraApp and applied to AutosaveManager.
     bool autoSaveEnabled = true;
-    int autoSaveIntervalSeconds = 300;  // 5 minutes default
-    
-    // Recent files
+    int autoSaveIntervalSeconds = 300;  // clamped to [10, 3600] on load
+
+    // --- Recent files: NOT WIRED ---------------------------------------------
+    // The storage, cap, and add/clear helpers below are implemented and correct;
+    // nothing calls them and no UI surfaces the list. Kept rather than deleted
+    // because a Recent Files menu is a plausible near-term feature and this is
+    // the plumbing it would need — but until something calls addRecentFile(),
+    // this list is always empty.
     std::vector<std::string> recentFiles;
     static constexpr size_t MAX_RECENT_FILES = 10;
     

--- a/Source/Core/Preferences.h
+++ b/Source/Core/Preferences.h
@@ -23,12 +23,19 @@ public:
     // it is. Keep this accurate — the audit that produced it is in
     // docs/technical/settings_view_state_map.md (B4).
 
-    // --- Audio settings: NOT WIRED -------------------------------------------
-    // Shadowed by AudioDeviceManager, which is the live authority and never
-    // consults these. Device choice therefore does not survive a restart.
-    // Wiring them means restoring a device by id at startup and handling the
-    // case where it is gone — a feature with real failure modes, not a
-    // one-liner. Do not write a settings path against these until that is done.
+    // --- Audio settings: NOT WIRED, and now a DUPLICATE ----------------------
+    // Nothing reads these. audio_settings.conf is the persisted authority — one
+    // parser, AudioSettingsStore — and AudioDeviceManager is the runtime one.
+    //
+    // Device, sample rate and buffer size DO survive a restart as of #649; they
+    // are applied at startup from that file, before any settings UI exists. So
+    // these fields are not an unimplemented feature waiting to be wired: they
+    // are a second, dead copy of settings that already work elsewhere, and the
+    // two have already drifted (this said bufferSize 512 while the live config
+    // said 256).
+    //
+    // Do not wire them. Removing them is tracked in #652; until then, anything
+    // written against these would silently override a working setting.
     std::string audioDeviceId = "default";
     int sampleRate = 48000;
     int bufferSize = 512;

--- a/Source/Core/Preferences.h
+++ b/Source/Core/Preferences.h
@@ -55,8 +55,14 @@ public:
 
     // --- Auto-save: LIVE ------------------------------------------------------
     // Both are read at startup by AestraApp and applied to AutosaveManager.
+    //
+    // load() stores whatever the file says, unvalidated. The clamp to
+    // [10, 3600] happens in AestraApp::resolveAutosaveInterval(), which is the
+    // single place the interval is resolved for both autosave initialisation
+    // and reinitialisation, and which writes the corrected value back. So an
+    // out-of-range value can exist in memory between load() and that call.
     bool autoSaveEnabled = true;
-    int autoSaveIntervalSeconds = 300;  // clamped to [10, 3600] on load
+    int autoSaveIntervalSeconds = 300;
 
     // --- Recent files: NOT WIRED ---------------------------------------------
     // The storage, cap, and add/clear helpers below are implemented and correct;


### PR DESCRIPTION
**B4** of the settings/view flow map (#641). The audit corrected the map **twice**
before any code changed — which is the argument for auditing first.

## Two corrections to my own map

**`autoSaveIntervalSeconds` was filed as dead. It isn't** — it's an unwired
mirror, and **three numbers described this interval while disagreeing**:

| source | value |
|---|---|
| `Preferences::autoSaveIntervalSeconds` | 300 |
| `AutosaveManager::Config` default | 30 |
| `AestraApp::initializeAutosave` hard-coded | **60 ← won** |

The hard-coded one won, because the other two were never consulted.

**B3 said `GeneralSettingsPage` "applies nothing". Half wrong.** The auto-save
toggle *is* wired — `setOnAutoSaveToggled` → `AutosaveManager::setEnabled`,
bypassing `applyChanges()` entirely. Only the projects-path field is inert.

## The real defect, which neither the map nor the issue had named

**The toggle applies but never persists.** `Preferences::autoSaveEnabled` is read
at startup and passed to `initializeAutosave`; nothing ever writes it back. So:

> Turn autosave off → it works → restart → **it's on again.**

Silently, because `Preferences::save()` at shutdown faithfully writes the value
it loaded.

## Fixed

- the toggle records `Preferences::autoSaveEnabled` alongside applying it
- `initializeAutosave` reads the persisted interval instead of hard-coding 60,
  clamped to `[10, 3600]` — it's user-editable JSON on disk — and a corrected
  value is written back rather than silently accepted

## Not fixed, deliberately — and now said so in the header

`Preferences.h` annotates every field with whether it governs anything:

| bucket | fields |
|---|---|
| **LIVE** | `theme`, `autoSaveEnabled`, `autoSaveIntervalSeconds` |
| **NOT WIRED** — shadowed by `AudioDeviceManager` | `audioDeviceId`, `sampleRate`, `bufferSize`, `exclusiveMode` |
| **NOT WIRED** — shadowed by `TrackManagerUI` snap state | `showGrid`, `snapToGrid`, `gridSize` |
| **NOT WIRED** — no consumer at all | `recentFiles` |

The audio fields are **not a one-liner**: wiring them means restoring a device by
id at startup and handling the case where it's gone. `recentFiles` is kept rather
than deleted because a Recent Files menu is a plausible near-term feature and
this is exactly the plumbing it needs — the storage, cap and add/clear helpers
are implemented and correct.

Both are honest as *documented gaps*. They were not honest as fields that look
configurable.

## Drive-verified end to end

Persistence is only real across a restart, so it was tested across one:

```
set intervalSeconds=5 in preferences.json, launch
  → "[AutoSave] autoSaveIntervalSeconds 5 out of range; using 10"

File ▸ Settings ▸ General, click the Auto-Save toggle
  → "[AutoSave] Disabled", button reads "Disabled"

close cleanly (Unsaved Changes → Don't Save)

read preferences.json
  → autoSave.enabled = false
  → autoSave.intervalSeconds = 10
```

Before this change the first line did not appear, and the last read back
`enabled = true`.

*(Incidentally: that Unsaved Changes prompt is #627's dirty-state work behaving
correctly — clicking around a project now reliably marks it modified.)*

## Observed and not fixed here

The toggle's label renders **"Enabled (5 min)"** from a hard-coded string while
the real interval was 10 seconds — the same displayed-vs-committed family, in the
label rather than the value. Left for its own change so this one stays about
persistence.

Refs #641, #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Persist autosave enablement changes so user preferences apply across restarts.
- Centralize autosave interval resolution, clamping values to 10–3600 seconds and saving corrections.
- Use the resolved interval for both autosave initialization and manager reinitialization.
- Clarify which Preferences fields are live, unwired, or shadowed by other settings owners, including audio settings and recent-files storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->