### PR TITLE
Retain unavailable plugins instead of erasing them (#647)

### DIFF
--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace Aestra {
@@ -29,12 +30,40 @@ struct EffectSlotFaultState {
  * @brief Single slot in an effect chain
  */
 struct EffectSlot {
-    PluginInstancePtr plugin;           ///< Plugin instance (nullptr = empty)
+    PluginInstancePtr plugin;           ///< Plugin instance (nullptr = empty or missing)
     std::atomic<bool> bypassed{false};  ///< Bypass this slot
     std::atomic<float> dryWetMix{1.0f}; ///< 0.0 = dry only, 1.0 = wet only
     std::shared_ptr<EffectSlotFaultState> faultState{std::make_shared<EffectSlotFaultState>()};
 
+    // Missing-plugin placeholder (#647).
+    //
+    // When loadState() cannot instantiate a plugin — it is not installed, the
+    // scan cache is stale, or its id changed — the slot retains the plugin's
+    // identity and its opaque state here instead of silently becoming empty.
+    // saveState() re-emits the retained record verbatim, so a load/save cycle on
+    // a machine missing the plugin does not destroy it.
+    //
+    // Non-RT only. process() never reads these; the RT predicate is isEmpty(),
+    // which stays `plugin == nullptr` precisely so a placeholder is skipped by
+    // the audio path without a null check.
+    std::string missingPluginId;
+    std::vector<uint8_t> missingPluginState;
+
+    /// RT predicate: is there a plugin to process here? Placeholders answer true.
     bool isEmpty() const { return plugin == nullptr; }
+
+    /// Does this slot hold a retained record for a plugin that would not load?
+    bool hasMissingPlugin() const { return plugin == nullptr && !missingPluginId.empty(); }
+
+    /// Is this slot spoken for — by a live plugin or by a retained placeholder?
+    /// This, not isEmpty(), is what "can I put a plugin here" should ask.
+    bool isOccupied() const { return plugin != nullptr || !missingPluginId.empty(); }
+
+    void clearMissingPlugin() {
+        missingPluginId.clear();
+        missingPluginState.clear();
+        missingPluginState.shrink_to_fit();
+    }
 };
 
 /**
@@ -250,11 +279,38 @@ public:
 
     /**
      * @brief Load entire chain state
+     *
+     * A plugin the manager cannot instantiate does NOT make this fail and does
+     * NOT clear the slot. The slot retains the plugin id, bypass, dry/wet and
+     * opaque state as a placeholder (#647) so the next saveState() re-emits the
+     * record intact. The return value continues to mean "the blob parsed";
+     * unavailable plugins are reported through @p outMissingPluginIds.
+     *
+     * Same-session availability: a placeholder is NOT re-instantiated if the
+     * plugin becomes available later in the session — re-inserting a live plugin
+     * requires a graph rebuild and RT coordination the loader does not own. The
+     * placeholder resolves on the next project load. Inserting a plugin into the
+     * slot explicitly (insertPlugin) discards the placeholder, because the slot
+     * then genuinely holds what the user put there.
+     *
      * @param state State data from saveState()
      * @param manager PluginManager for recreating instances
-     * @return true on success
+     * @param outMissingPluginIds Optional; receives the id of every plugin that
+     *        could not be instantiated, in slot order. Not cleared on entry.
+     * @return true if the state blob was well-formed
      */
-    bool loadState(const std::vector<uint8_t>& state, PluginManager& manager);
+    bool loadState(const std::vector<uint8_t>& state, PluginManager& manager,
+                   std::vector<std::string>* outMissingPluginIds = nullptr);
+
+    /**
+     * @brief Number of slots currently holding a missing-plugin placeholder.
+     */
+    size_t getMissingPluginCount() const;
+
+    /**
+     * @brief Plugin id retained for a slot, or empty if the slot has no placeholder.
+     */
+    std::string getMissingPluginId(size_t slotIndex) const;
 
     // ==============================
     // Latency

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -121,6 +121,9 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
     }
 
     m_slots[slotIndex].plugin = std::move(plugin);
+    // The slot now genuinely holds what the caller put here, so any retained
+    // missing-plugin record for it is superseded (#647).
+    m_slots[slotIndex].clearMissingPlugin();
     m_slots[slotIndex].bypassed.store(false);
     m_slots[slotIndex].dryWetMix.store(1.0f);
     m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
@@ -142,6 +145,8 @@ PluginInstancePtr EffectChain::removePlugin(size_t slotIndex) {
 
     auto plugin = std::move(m_slots[slotIndex].plugin);
     m_slots[slotIndex].plugin = nullptr;
+    // Removing a slot removes it, placeholder included (#647).
+    m_slots[slotIndex].clearMissingPlugin();
     m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
 
     publishSnapshot();
@@ -163,12 +168,15 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
         return true;
     }
 
-    // Can only move to empty slot
-    if (!m_slots[toSlot].isEmpty()) {
+    // Can only move to a slot nothing else claims. A placeholder claims its slot
+    // (#647) — moving onto it would silently destroy a retained record.
+    if (m_slots[toSlot].isOccupied()) {
         return false;
     }
 
     m_slots[toSlot].plugin = std::move(m_slots[fromSlot].plugin);
+    m_slots[toSlot].missingPluginId = std::move(m_slots[fromSlot].missingPluginId);
+    m_slots[toSlot].missingPluginState = std::move(m_slots[fromSlot].missingPluginState);
     m_slots[toSlot].bypassed.store(m_slots[fromSlot].bypassed.load());
     m_slots[toSlot].dryWetMix.store(m_slots[fromSlot].dryWetMix.load());
     m_slots[toSlot].faultState = std::move(m_slots[fromSlot].faultState);
@@ -177,6 +185,7 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
     }
 
     m_slots[fromSlot].plugin = nullptr;
+    m_slots[fromSlot].clearMissingPlugin();
     m_slots[fromSlot].bypassed.store(false);
     m_slots[fromSlot].dryWetMix.store(1.0f);
     m_slots[fromSlot].faultState = std::make_shared<EffectSlotFaultState>();
@@ -198,6 +207,8 @@ bool EffectChain::swapPlugins(size_t slot1, size_t slot2) {
     }
 
     std::swap(m_slots[slot1].plugin, m_slots[slot2].plugin);
+    std::swap(m_slots[slot1].missingPluginId, m_slots[slot2].missingPluginId);
+    std::swap(m_slots[slot1].missingPluginState, m_slots[slot2].missingPluginState);
     std::swap(m_slots[slot1].faultState, m_slots[slot2].faultState);
 
     bool bypass1 = m_slots[slot1].bypassed.load();
@@ -231,16 +242,35 @@ bool EffectChain::isSlotEmpty(size_t slotIndex) const {
     if (slotIndex >= MAX_SLOTS) {
         return true;
     }
-    return m_slots[slotIndex].isEmpty();
+    // "Free to use", not the RT predicate: a retained missing-plugin record
+    // claims its slot (#647).
+    return !m_slots[slotIndex].isOccupied();
 }
 
 size_t EffectChain::getFirstEmptySlot() const {
     for (size_t i = 0; i < MAX_SLOTS; ++i) {
-        if (m_slots[i].isEmpty()) {
+        if (!m_slots[i].isOccupied()) {
             return i;
         }
     }
     return MAX_SLOTS;
+}
+
+size_t EffectChain::getMissingPluginCount() const {
+    size_t count = 0;
+    for (const auto& slot : m_slots) {
+        if (slot.hasMissingPlugin()) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::string EffectChain::getMissingPluginId(size_t slotIndex) const {
+    if (slotIndex >= MAX_SLOTS) {
+        return {};
+    }
+    return m_slots[slotIndex].missingPluginId;
 }
 
 size_t EffectChain::getActiveSlotCount() const {
@@ -259,6 +289,7 @@ void EffectChain::clear() {
     }
     for (auto& slot : m_slots) {
         slot.plugin = nullptr;
+        slot.clearMissingPlugin();
         slot.bypassed.store(false);
         slot.dryWetMix.store(1.0f);
         slot.faultState = std::make_shared<EffectSlotFaultState>();
@@ -595,6 +626,32 @@ std::vector<uint8_t> EffectChain::saveState() const {
     for (size_t i = 0; i < MAX_SLOTS; ++i) {
         const auto& slot = m_slots[i];
 
+        // A slot holding a placeholder for a plugin that would not load is NOT
+        // empty (#647). Re-emit the retained record verbatim so a load/save on a
+        // machine missing the plugin preserves it rather than deleting it. The
+        // layout is identical to the live-plugin case below, so the file format
+        // is unchanged and a machine that has the plugin loads it normally.
+        if (slot.hasMissingPlugin()) {
+            state.push_back(1); // Has plugin flag
+
+            uint32_t idLen = static_cast<uint32_t>(slot.missingPluginId.size());
+            state.insert(state.end(), reinterpret_cast<const uint8_t*>(&idLen),
+                         reinterpret_cast<const uint8_t*>(&idLen) + sizeof(idLen));
+            state.insert(state.end(), slot.missingPluginId.begin(), slot.missingPluginId.end());
+
+            state.push_back(slot.bypassed.load() ? 1 : 0);
+
+            float dryWet = slot.dryWetMix.load();
+            state.insert(state.end(), reinterpret_cast<const uint8_t*>(&dryWet),
+                         reinterpret_cast<const uint8_t*>(&dryWet) + sizeof(dryWet));
+
+            uint32_t stateLen = static_cast<uint32_t>(slot.missingPluginState.size());
+            state.insert(state.end(), reinterpret_cast<const uint8_t*>(&stateLen),
+                         reinterpret_cast<const uint8_t*>(&stateLen) + sizeof(stateLen));
+            state.insert(state.end(), slot.missingPluginState.begin(), slot.missingPluginState.end());
+            continue;
+        }
+
         if (slot.isEmpty()) {
             state.push_back(0); // Empty flag
             continue;
@@ -628,7 +685,8 @@ std::vector<uint8_t> EffectChain::saveState() const {
     return state;
 }
 
-bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& manager) {
+bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& manager,
+                            std::vector<std::string>* outMissingPluginIds) {
     if (reportRealtimeMisuse("EffectChain::loadState")) {
         return false;
     }
@@ -666,6 +724,7 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
         if (!hasPlugin) {
             m_slots[i].plugin = nullptr;
+            m_slots[i].clearMissingPlugin();
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
             continue;
         }
@@ -728,9 +787,32 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
             instance->activate();
 
             m_slots[i].plugin = std::move(instance);
+            m_slots[i].clearMissingPlugin();
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
+        } else {
+            // The plugin is unavailable on this machine. Retain the record
+            // instead of dropping it (#647) — dropping it here is what made the
+            // next save erase the slot permanently and silently.
+            //
+            // The opaque state is stored exactly as it came off the wire; it is
+            // never interpreted or normalised, so repeated load/save cycles
+            // cannot progressively mutate it. bypass and dry/wet are stored
+            // post-sanitisation, which is what a live plugin round-trips to as
+            // well, so both paths converge after one cycle and stay fixed.
+            m_slots[i].plugin = nullptr;
+            m_slots[i].missingPluginId = pluginId;
+            m_slots[i].missingPluginState = std::move(pluginState);
+            m_slots[i].bypassed.store(bypassed);
+            m_slots[i].dryWetMix.store(dryWet);
+            m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
+
+            if (outMissingPluginIds) {
+                outMissingPluginIds->push_back(pluginId);
+            }
+            Aestra::Log::warning("[EffectChain] Plugin unavailable for slot " + std::to_string(i) + ": " + pluginId +
+                                 " — slot state retained and will be preserved on save");
         }
     }
 

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1811,10 +1811,14 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 chain.prepare(pluginManager.getDefaultSampleRate(), pluginManager.getDefaultBlockSize());
                 if (channels[i].has("effectChainStateHex") && channels[i]["effectChainStateHex"].isString()) {
                     const auto effectState = hexToBytes(channels[i]["effectChainStateHex"].asString());
-                    if (!effectState.empty() && !chain.loadState(effectState, pluginManager)) {
+                    std::vector<std::string> missingIds;
+                    if (!effectState.empty() && !chain.loadState(effectState, pluginManager, &missingIds)) {
                         warningLimiter.warning(ProjectLoadWarningCategory::EffectChain,
                                                "[ProjectLoad] Failed to restore mixer effect chain on: " + channelName,
                                                "[ProjectLoad] Additional mixer effect-chain warnings suppressed.");
+                    }
+                    for (auto& id : missingIds) {
+                        result.missingPlugins.push_back({std::move(id), channelName});
                     }
                 }
             }
@@ -1956,11 +1960,15 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             if (lj[i].has("effectChainStateHex") && lj[i]["effectChainStateHex"].isString()) {
                                 const auto effectState = hexToBytes(lj[i]["effectChainStateHex"].asString());
                                 if (!effectState.empty()) {
-                                    if (!chain.loadState(effectState, pluginManager)) {
+                                    std::vector<std::string> missingIds;
+                                    if (!chain.loadState(effectState, pluginManager, &missingIds)) {
                                         warningLimiter.warning(
                                             ProjectLoadWarningCategory::EffectChain,
                                             "[ProjectLoad] Failed to restore effect chain on lane: " + lane->name,
                                             "[ProjectLoad] Additional effect chain restore warnings suppressed.");
+                                    }
+                                    for (auto& id : missingIds) {
+                                        result.missingPlugins.push_back({std::move(id), lane->name});
                                     }
                                 }
                             }

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -77,12 +77,27 @@ public:
      */
     enum class LoadIntegrity { Unchecked, Verified, Mismatch };
 
+    /**
+     * @brief A plugin referenced by the project that could not be instantiated (#647).
+     *
+     * Deliberately NOT folded into `missingAssets`, which carries filesystem
+     * paths for samples. A plugin id is not a path, cannot be relinked by
+     * browsing for a file, and its slot state is retained in the project rather
+     * than dropped — so giving both the same collection would make the API lie
+     * about what a caller can do with the entry.
+     */
+    struct MissingPlugin {
+        std::string pluginId; ///< The id as stored in the project file.
+        std::string location; ///< Human-readable owner: mixer channel or lane name.
+    };
+
     struct LoadResult {
         bool ok{false};
         double tempo{120.0};
         double playhead{0.0};
         std::string errorMessage;
         std::vector<std::string> missingAssets;
+        std::vector<MissingPlugin> missingPlugins;
         LoadIntegrity integrity{LoadIntegrity::Unchecked};
 
         std::optional<UIState> ui;

--- a/Tests/AestraAudio/EffectChainMissingPluginTest.cpp
+++ b/Tests/AestraAudio/EffectChainMissingPluginTest.cpp
@@ -1,0 +1,313 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// A plugin that cannot be instantiated must survive load/save (#647).
+//
+// Before this test's fix, EffectChain::loadState dropped the slot when
+// createInstanceById returned null — and still returned true, so the caller's
+// failure guard never fired. saveState then wrote "empty" over the record, and
+// the plugin id plus its opaque state were gone from the project permanently.
+//
+// The test deliberately does NOT depend on any plugin being installed. Missing
+// slots are driven with fabricated ids that no manager can resolve, and the
+// "available" side of mixed chains is established with insertPlugin() on a
+// locally-defined instance. A test that needed a real plugin scan could pass or
+// fail for reasons unrelated to the invariant.
+
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginManager.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+// --- wire format helpers ----------------------------------------------------
+// Mirrors EffectChain::saveState. Written independently so the test pins the
+// format rather than restating whatever the implementation happens to do.
+
+struct SlotRecord {
+    bool present = false;
+    std::string id;
+    bool bypassed = false;
+    float dryWet = 1.0f;
+    std::vector<uint8_t> state;
+};
+
+template <typename T> void appendRaw(std::vector<uint8_t>& out, const T& value) {
+    const auto* p = reinterpret_cast<const uint8_t*>(&value);
+    out.insert(out.end(), p, p + sizeof(T));
+}
+
+std::vector<uint8_t> buildBlob(const std::vector<SlotRecord>& slots) {
+    std::vector<uint8_t> out{'N', 'E', 'C', EffectChain::kStateFormatVersion,
+                             static_cast<uint8_t>(EffectChain::MAX_SLOTS)};
+    for (size_t i = 0; i < EffectChain::MAX_SLOTS; ++i) {
+        const SlotRecord empty;
+        const SlotRecord& s = i < slots.size() ? slots[i] : empty;
+        if (!s.present) {
+            out.push_back(0);
+            continue;
+        }
+        out.push_back(1);
+        appendRaw(out, static_cast<uint32_t>(s.id.size()));
+        out.insert(out.end(), s.id.begin(), s.id.end());
+        out.push_back(s.bypassed ? 1 : 0);
+        appendRaw(out, s.dryWet);
+        appendRaw(out, static_cast<uint32_t>(s.state.size()));
+        out.insert(out.end(), s.state.begin(), s.state.end());
+    }
+    return out;
+}
+
+// Parse a blob back so assertions can talk about slots rather than byte offsets.
+bool parseBlob(const std::vector<uint8_t>& blob, std::vector<SlotRecord>& out) {
+    out.assign(EffectChain::MAX_SLOTS, SlotRecord{});
+    if (blob.size() < 5 || blob[0] != 'N' || blob[1] != 'E' || blob[2] != 'C') {
+        return false;
+    }
+    if (blob[4] != static_cast<uint8_t>(EffectChain::MAX_SLOTS)) {
+        return false;
+    }
+    size_t off = 5;
+    for (size_t i = 0; i < EffectChain::MAX_SLOTS; ++i) {
+        if (off >= blob.size()) return false;
+        const uint8_t has = blob[off++];
+        if (!has) continue;
+
+        SlotRecord r;
+        r.present = true;
+        uint32_t idLen = 0;
+        if (off + sizeof(idLen) > blob.size()) return false;
+        std::memcpy(&idLen, &blob[off], sizeof(idLen));
+        off += sizeof(idLen);
+        if (off + idLen > blob.size()) return false;
+        r.id.assign(reinterpret_cast<const char*>(&blob[off]), idLen);
+        off += idLen;
+
+        if (off + 1 + sizeof(float) + sizeof(uint32_t) > blob.size()) return false;
+        r.bypassed = blob[off++] != 0;
+        std::memcpy(&r.dryWet, &blob[off], sizeof(float));
+        off += sizeof(float);
+        uint32_t stateLen = 0;
+        std::memcpy(&stateLen, &blob[off], sizeof(stateLen));
+        off += sizeof(stateLen);
+        if (off + stateLen > blob.size()) return false;
+        r.state.assign(blob.begin() + static_cast<long>(off), blob.begin() + static_cast<long>(off + stateLen));
+        off += stateLen;
+
+        out[i] = std::move(r);
+    }
+    return true;
+}
+
+std::vector<uint8_t> bytes(std::initializer_list<int> vals) {
+    std::vector<uint8_t> v;
+    for (int x : vals) v.push_back(static_cast<uint8_t>(x));
+    return v;
+}
+
+// Ids no plugin manager can resolve. This is the whole point: the test needs a
+// guaranteed instantiation failure, not a plugin that happens to be absent.
+const char* kMissingA = "com.aestra.tests.definitely-not-installed.A";
+const char* kMissingB = "com.aestra.tests.definitely-not-installed.B";
+
+PluginManager& manager() { return PluginManager::getInstance(); }
+
+} // namespace
+
+int main() {
+    // ---------------------------------------------------------------------
+    // The core invariant: a chain of unavailable plugins survives load/save.
+    // ---------------------------------------------------------------------
+    std::vector<SlotRecord> original(EffectChain::MAX_SLOTS);
+    original[0] = {true, kMissingA, true, 0.375f, bytes({0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01})};
+    original[3] = {true, kMissingB, false, 1.0f, bytes({0x11, 0x22})};
+    original[7] = {true, kMissingA, false, 0.0f, {}}; // empty opaque state is legal
+
+    const std::vector<uint8_t> blob0 = buildBlob(original);
+
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        std::vector<std::string> missing;
+        check(chain.loadState(blob0, manager(), &missing), "loadState reports a well-formed blob as ok");
+
+        check(missing.size() == 3, "all three unavailable plugins are reported");
+        if (missing.size() == 3) {
+            check(missing[0] == kMissingA && missing[1] == kMissingB && missing[2] == kMissingA,
+                  "reported ids arrive in slot order");
+        }
+        check(chain.getMissingPluginCount() == 3, "chain counts three placeholders");
+        check(chain.getMissingPluginId(0) == kMissingA, "slot 0 retains its id");
+        check(chain.getMissingPluginId(3) == kMissingB, "slot 3 retains its id");
+        check(chain.getMissingPluginId(1).empty(), "an untouched slot has no placeholder");
+
+        // The RT predicate must still treat the slot as having nothing to run,
+        // or process() would dereference a null plugin on the audio thread.
+        const EffectSlot* s0 = chain.getSlot(0);
+        check(s0 != nullptr && s0->isEmpty(), "RT predicate isEmpty() stays true for a placeholder");
+        check(s0 != nullptr && s0->hasMissingPlugin(), "placeholder is distinguishable from an empty slot");
+        check(s0 != nullptr && s0->isOccupied(), "placeholder occupies its slot");
+
+        // ...and the record comes back out intact.
+        const std::vector<uint8_t> blob1 = chain.saveState();
+        check(blob1 == blob0, "one load/save cycle reproduces the blob byte-for-byte");
+    }
+
+    // ---------------------------------------------------------------------
+    // Repeated cycles must not progressively mutate the preserved bytes.
+    // ---------------------------------------------------------------------
+    {
+        std::vector<uint8_t> current = blob0;
+        for (int cycle = 0; cycle < 5; ++cycle) {
+            EffectChain chain;
+            chain.prepare(48000.0, 512);
+            check(chain.loadState(current, manager()), "cycle: loadState ok");
+            const std::vector<uint8_t> next = chain.saveState();
+            check(next == blob0, "cycle " + std::to_string(cycle) + ": bytes identical to the original");
+            current = next;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Field fidelity, stated per field so a failure names itself.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        check(chain.loadState(blob0, manager()), "fidelity: loadState ok");
+        std::vector<SlotRecord> out;
+        check(parseBlob(chain.saveState(), out), "fidelity: resaved blob parses");
+        if (out.size() == EffectChain::MAX_SLOTS) {
+            check(out[0].present && out[0].id == kMissingA, "slot 0 id preserved");
+            check(out[0].bypassed, "slot 0 bypass=true preserved");
+            check(out[0].dryWet == 0.375f, "slot 0 dry/wet preserved exactly");
+            check(out[0].state == original[0].state, "slot 0 opaque state preserved byte-for-byte");
+            check(out[3].present && out[3].id == kMissingB, "slot 3 id preserved");
+            check(out[7].present && out[7].dryWet == 0.0f, "slot 7 dry/wet 0.0 preserved");
+            check(out[7].state.empty(), "slot 7 empty opaque state preserved");
+            check(!out[1].present && !out[2].present, "genuinely empty slots stay empty");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Slot position stability: a placeholder does not shift its neighbours,
+    // and neighbours do not shift it.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        check(chain.loadState(blob0, manager()), "position: loadState ok");
+        std::vector<SlotRecord> out;
+        check(parseBlob(chain.saveState(), out), "position: resaved blob parses");
+        if (out.size() == EffectChain::MAX_SLOTS) {
+            check(out[0].present && out[3].present && out[7].present,
+                  "placeholders stay at slots 0, 3 and 7");
+            for (size_t i : {1u, 2u, 4u, 5u, 6u, 8u, 9u}) {
+                check(!out[i].present, "slot " + std::to_string(i) + " stays empty");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // A placeholder claims its slot: automatic insertion must not land on it.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        std::vector<SlotRecord> recs(EffectChain::MAX_SLOTS);
+        recs[0] = {true, kMissingA, false, 1.0f, bytes({0x01})};
+        check(chain.loadState(buildBlob(recs), manager()), "occupancy: loadState ok");
+
+        check(!chain.isSlotEmpty(0), "a placeholder slot does not report itself free");
+        check(chain.isSlotEmpty(1), "a genuinely empty slot reports free");
+        check(chain.getFirstEmptySlot() == 1, "first free slot skips the placeholder");
+
+        // Moving onto a placeholder would silently destroy the retained record.
+        check(!chain.movePlugin(5, 0), "move onto a placeholder is refused");
+    }
+
+    // ---------------------------------------------------------------------
+    // Mixed chain: a live plugin inserted over a placeholder supersedes it,
+    // while other placeholders are untouched.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        std::vector<SlotRecord> recs(EffectChain::MAX_SLOTS);
+        recs[0] = {true, kMissingA, false, 1.0f, bytes({0xAA})};
+        recs[1] = {true, kMissingB, false, 1.0f, bytes({0xBB})};
+        check(chain.loadState(buildBlob(recs), manager()), "mixed: loadState ok");
+        check(chain.getMissingPluginCount() == 2, "mixed: two placeholders to start");
+
+        // Explicitly targeting the slot replaces it — the user put something there.
+        chain.removePlugin(1);
+        check(chain.getMissingPluginCount() == 1, "explicit removal drops that placeholder");
+        check(chain.getMissingPluginId(1).empty(), "removed slot has no retained id");
+        check(chain.getMissingPluginId(0) == kMissingA, "the other placeholder is untouched");
+
+        std::vector<SlotRecord> out;
+        check(parseBlob(chain.saveState(), out), "mixed: resaved blob parses");
+        if (out.size() == EffectChain::MAX_SLOTS) {
+            check(out[0].present && out[0].id == kMissingA, "surviving placeholder still written");
+            check(out[0].state == bytes({0xAA}), "surviving placeholder keeps its bytes");
+            check(!out[1].present, "removed slot is written as empty");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Backward compatibility: chains with nothing missing behave as before.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        const std::vector<uint8_t> emptyBlob = buildBlob({});
+        std::vector<std::string> missing;
+        check(chain.loadState(emptyBlob, manager(), &missing), "all-empty chain loads");
+        check(missing.empty(), "all-empty chain reports nothing missing");
+        check(chain.getMissingPluginCount() == 0, "all-empty chain has no placeholders");
+        check(chain.saveState() == emptyBlob, "all-empty chain round-trips unchanged");
+        check(chain.getFirstEmptySlot() == 0, "all-empty chain offers slot 0");
+
+        // Malformed input is still rejected, and rejection must not leave
+        // placeholders behind.
+        EffectChain bad;
+        bad.prepare(48000.0, 512);
+        check(!bad.loadState(bytes({'X', 'X', 'X', 1, 10}), manager()), "wrong magic still rejected");
+        check(bad.getMissingPluginCount() == 0, "rejected load leaves no placeholders");
+    }
+
+    // ---------------------------------------------------------------------
+    // clear() means clear.
+    // ---------------------------------------------------------------------
+    {
+        EffectChain chain;
+        chain.prepare(48000.0, 512);
+        check(chain.loadState(blob0, manager()), "clear: loadState ok");
+        check(chain.getMissingPluginCount() == 3, "clear: placeholders present first");
+        chain.clear();
+        check(chain.getMissingPluginCount() == 0, "clear() removes placeholders");
+        check(chain.saveState() == buildBlob({}), "cleared chain saves as all-empty");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] EffectChainMissingPluginTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] EffectChainMissingPluginTest\n";
+    return 0;
+}

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -212,3 +212,15 @@ target_include_directories(PluginInitContractTest PRIVATE
 )
 add_test(NAME PluginInitContractTest COMMAND PluginInitContractTest)
 set_tests_properties(PluginInitContractTest PROPERTIES LABELS "audio;plugins;lifecycle")
+
+# Missing-plugin state preservation (#647) — a plugin that cannot be
+# instantiated must survive load/save instead of being silently erased.
+add_executable(EffectChainMissingPluginTest AestraAudio/EffectChainMissingPluginTest.cpp)
+target_link_libraries(EffectChainMissingPluginTest PRIVATE AestraAudio)
+target_include_directories(EffectChainMissingPluginTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME EffectChainMissingPluginTest COMMAND EffectChainMissingPluginTest)
+set_tests_properties(EffectChainMissingPluginTest PROPERTIES LABELS "audio;plugins;serialization")


### PR DESCRIPTION
Fixes #647.

A plugin that cannot be instantiated is no longer deleted from the project. It becomes a durable placeholder that survives load/save intact.

## Root cause

`EffectChain::loadState` parsed each slot's `{id, bypass, dryWet, opaqueState}` and then, if `createInstanceById` returned null, simply fell off the end of an `if (instance)` with no `else`. The parsed record was discarded and the slot left empty.

Two things made that silent rather than merely wrong:

- `loadState` still returned `true`, so the caller's guard in `ProjectSerializer` (`:1814` mixer, `:1959` lane) never fired its warning — the load looked completely successful.
- `saveState` writes `if (slot.isEmpty()) { push_back(0); continue; }`, so the very next save replaced a full slot record with "no plugin".

Open a project on a machine missing a plugin, let autosave fire, and the id plus all its parameters were gone from the file with nothing logged.

## Invariant established

> **An entity that cannot be instantiated is retained, not dropped.** Load preserves the identity and opaque state of anything it cannot reconstruct; save re-emits it verbatim. Unavailability is reported, never expressed as deletion.

## Design notes

**`isEmpty()` deliberately still means `plugin == nullptr`.** It is the RT predicate — `EffectChainSnapshot::process` and `EffectChain::process` use it to decide whether to run a slot (`:377`, `:493`). Making a placeholder "non-empty" there would have walked the audio thread straight into a null dereference. Placeholders are therefore invisible to the audio path by construction, with no added null check.

The occupancy question ("can I put a plugin here?") is separate and now asks `isOccupied()`. `EffectChain::isSlotEmpty()` and `getFirstEmptySlot()` moved to that predicate so automatic slot assignment cannot land on — and silently destroy — a retained record. `isSlotEmpty()` had no callers outside the class; `getFirstEmptySlot()` has two, both "add to first free slot", which is exactly the case that needed fixing.

**The wire format is unchanged.** A placeholder re-emits the same `hasPlugin=1` record layout a live plugin would. A machine that *has* the plugin opens the same file and loads it normally. No version bump, no migration.

**Opaque state is never interpreted.** It is stored exactly as it came off the wire and written back byte-for-byte, so repeated cycles cannot progressively mutate it. `bypass`/`dryWet` are stored post-sanitisation — identical to what a live plugin round-trips to — so both paths converge after one cycle and stay fixed.

**Same-session availability is defined, not implemented.** A placeholder is not re-instantiated if the plugin appears later in the session: that needs a graph rebuild and RT coordination the loader does not own. It resolves on the next project load. Explicitly inserting a plugin into the slot discards the placeholder, because the slot then genuinely holds what the user put there. Documented on `loadState`.

**Reporting is a separate collection.** `LoadResult::missingPlugins` carries `{pluginId, location}`. Deliberately not folded into `missingAssets`, which holds filesystem paths for samples — a plugin id is not a path and cannot be relinked by browsing for a file, so sharing the collection would make the API lie about what a caller can do with the entry.

## Files changed

| file | change |
|---|---|
| `AestraAudio/include/Plugin/EffectChain.h` | `EffectSlot` gains `missingPluginId` / `missingPluginState` + `hasMissingPlugin()` / `isOccupied()` / `clearMissingPlugin()`; `loadState` gains an optional out-param; two query accessors |
| `AestraAudio/src/Plugin/EffectChain.cpp` | retention in `loadState`; re-emission in `saveState`; placeholder handling in `insertPlugin`, `removePlugin`, `movePlugin`, `swapPlugins`, `clear`; occupancy in `isSlotEmpty` / `getFirstEmptySlot` |
| `Source/Core/ProjectSerializer.h` | `MissingPlugin` struct + `LoadResult::missingPlugins` |
| `Source/Core/ProjectSerializer.cpp` | collect reported ids at both chain-load sites, tagged with channel/lane name |
| `Tests/AestraAudio/EffectChainMissingPluginTest.cpp` | new |
| `Tests/cmake/PluginTests.cmake` | registration, appended at end of file |

## Tests

`EffectChainMissingPluginTest` — 40+ assertions, no dependency on any plugin being installed. Missing slots use fabricated ids that no manager can resolve, so the failure being tested is guaranteed rather than incidental; the "available" side of mixed chains is established via `insertPlugin`/`removePlugin` on the chain directly.

Covers: byte-identical single cycle; **five** repeated cycles all identical to the original; per-field fidelity (id, bypass, dry/wet incl. `0.0` and `0.375`, opaque state incl. empty); slot position stability with placeholders at 0/3/7 and every other slot asserted still empty; multiple missing plugins; mixed live/placeholder chains; occupancy (`isSlotEmpty`, `getFirstEmptySlot`, move-onto-placeholder refused); the RT predicate still reporting the slot as having nothing to process; `clear()`; malformed input still rejected with no placeholders left behind; and all-empty chains round-tripping unchanged.

The test also pins the wire format independently — it builds and parses blobs with its own helpers rather than round-tripping through the implementation, so a format change has to be deliberate.

**Revert-check performed.** Disabling only the retention (keeping signatures so it still compiles) produces 12+ failures including `one load/save cycle reproduces the blob byte-for-byte` and all five cycle assertions. The gate rejects the pre-fix behaviour.

## Verification rung

**Behaviour regression-tested** at the `EffectChain` layer, over the scenario named above.

Not yet driven end-to-end through a real project file with a real uninstalled plugin — that is a UI/plugin-scan journey with no headless harness. The layer where the data was being destroyed is fully pinned; the serializer wiring above it is **compiled** and reasoned, not observed.

## Compatibility

- **Project format unchanged.** No version bump. Placeholders serialize as ordinary plugin records.
- **Old projects load unchanged** — asserted for all-empty chains and for chains whose plugins all resolve.
- **Files written by this build open correctly on older builds**, which will simply fail to instantiate the plugin and drop it exactly as they do today. No new failure mode is introduced for them.
- `loadState`'s new third parameter is defaulted; existing call sites compile unchanged.

## Remaining risks

- `getActiveSlotCount()` still counts live plugins only. That is intentional — it feeds latency/processing decisions, not occupancy — but it now differs from `getFirstEmptySlot()`'s notion. Left as-is rather than changed speculatively.
- The UI renders a placeholder slot as blank. It is no longer *offered* for automatic insertion, but there is no "Missing: <id>" affordance yet. The data is now available for one; deliberately out of scope here.
- `missingPlugins` has no UI consumer yet. It is a structured result field rather than dead configuration, but it should get a surface — most naturally alongside the #650 fallback status work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **API changes:** Extended `EffectChain::loadState()` with an optional missing-plugin output parameter and added placeholder inspection APIs.
- Preserve unavailable plugins as occupied placeholders, retaining their ID, slot, bypass state, dry/wet value, and opaque state across load/save cycles.
- Prevent placeholders from being overwritten or dereferenced by real-time processing, while allowing them to be cleared or replaced when the plugin becomes available.
- Report missing plugins separately through `ProjectSerializer::LoadResult::missingPlugins` for mixer channels and playlist lanes.
- Sanitize non-finite dry/wet values and preserve existing wire-format compatibility.
- Added regression coverage for byte-preserving round trips, slot stability, mixed chains, clearing, malformed input, and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->