### PR TITLE
Settings initialization must be read-only (#648)

### DIFF
--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -724,12 +724,22 @@ void AudioSettingsPage::saveSettings() {
         // dropdown reports 0 — a legal device id — so writing it blindly is how
         // a stored selection got destroyed (#648). Persist the last known value
         // until the list has actually loaded.
+        // "Has a selection", not "has items". clearItems() leaves selectedIndex_
+        // at -1 and setSelectedByValue() silently no-ops when the value is
+        // absent, so a repopulated list whose stored device is gone is populated
+        // with nothing selected — and getSelectedValue() reports 0 there, which
+        // is a legal device id. getSelectedItem() is the accessor that can say
+        // "nothing" without inventing a value.
         using Aestra::Settings::valueToPersist;
-        const int driverValue =
-            valueToPersist(m_driverDropdown->getItemCount() > 0, m_driverDropdown->getSelectedValue(), m_savedDriverType);
-        const int deviceValue =
-            valueToPersist(m_deviceDropdown->getItemCount() > 0, m_deviceDropdown->getSelectedValue(), m_savedDeviceId);
-        const int inputDeviceValue = valueToPersist(m_inputDeviceDropdown->getItemCount() > 0,
+        const auto hasSelection = [](const auto& dropdown) {
+            return dropdown && dropdown->getItemCount() > 0 && dropdown->getSelectedItem().has_value();
+        };
+
+        const int driverValue = valueToPersist(hasSelection(m_driverDropdown),
+                                               m_driverDropdown->getSelectedValue(), m_savedDriverType);
+        const int deviceValue = valueToPersist(hasSelection(m_deviceDropdown),
+                                               m_deviceDropdown->getSelectedValue(), m_savedDeviceId);
+        const int inputDeviceValue = valueToPersist(hasSelection(m_inputDeviceDropdown),
                                                     m_inputDeviceDropdown->getSelectedValue(), m_savedInputDeviceId);
 
         file << "driver=" << driverValue << "\n";

--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -271,9 +271,14 @@ void AudioSettingsPage::createUI() {
     m_threadCountLabel = createLabel("Thread Count:");
     
     // Dropdowns
+    // Programmatic hydration is not a user edit (#648). The guard lives in the
+    // shared wrapper so it covers every control, including ones added later —
+    // five callbacks had it and eight did not, so loadSettings() still marked
+    // the page dirty by populating it.
     auto createDropdown = [&](std::function<void(int)> onChange) {
         auto d = std::make_shared<AestraUI::NUIDropdown>();
-        d->setOnSelectionChanged([onChange](int index, int, const std::string&) {
+        d->setOnSelectionChanged([this, onChange](int index, int, const std::string&) {
+            if (m_isInitializing || m_isPopulatingDeviceUI) return;
             onChange(index);
         });
         addChild(d);
@@ -281,13 +286,6 @@ void AudioSettingsPage::createUI() {
     };
 
     m_driverDropdown = createDropdown([this](int idx) {
-        // Guard: skip audio calls during initialization and async UI population.
-        // The stream was opened once by AudioEngineController. UI must not mutate it.
-        // Programmatic hydration is not a user edit (#648): the guard comes first,
-        // so loadSettings()/onDeviceLoadComplete() cannot mark the page dirty by
-        // populating it.
-        if (m_isInitializing || m_isPopulatingDeviceUI) return;
-
         m_dirty = true;
 
         // SWITCH DRIVER IMMEDIATELY so device list is correct
@@ -421,13 +419,19 @@ void AudioSettingsPage::createUI() {
     if (maxThreads < 1) maxThreads = 4;
     m_threadCountInput->setRange(1, maxThreads);
     m_threadCountInput->setValue(maxThreads);
-    m_threadCountInput->setOnChange([this](int val) { m_dirty = true; });
+    m_threadCountInput->setOnChange([this](int val) {
+        if (m_isInitializing || m_isPopulatingDeviceUI) return;
+        m_dirty = true;
+    });
     addChild(m_threadCountInput);
 
     // Toggles
     auto createCheck = [&](std::function<void(bool)> onChange) {
         auto t = std::make_shared<AestraUI::NUIToggle>();
-        t->setOnToggle(onChange);
+        t->setOnToggle([this, onChange](bool value) {
+            if (m_isInitializing || m_isPopulatingDeviceUI) return;
+            onChange(value);
+        });
         addChild(t);
         return t;
     };
@@ -491,8 +495,12 @@ void AudioSettingsPage::applyChanges() {
     // User-confirmed change: apply it, then persist it. This is the ONLY path
     // that writes audio_settings.conf (#648).
     applyEngineSettings();
-    m_dirty = false;
-    saveSettings();
+    // Clear the dirty flag only once the write actually succeeded. Clearing it
+    // first reported success for a save that failed, so the user was told their
+    // settings were stored when they were not (engineering-health §4).
+    if (saveSettings()) {
+        m_dirty = false;
+    }
 }
 
 void AudioSettingsPage::applyEngineSettings() {
@@ -716,7 +724,7 @@ bool AudioSettingsPage::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 // Persistence
 // ============================================================================
 
-void AudioSettingsPage::saveSettings() {
+bool AudioSettingsPage::saveSettings() {
     const auto configPath = getAudioSettingsConfigPath();
     std::ofstream file(configPath);
     if (file.is_open()) {
@@ -760,9 +768,10 @@ void AudioSettingsPage::saveSettings() {
         m_savedDeviceId = deviceValue;
         m_savedInputDeviceId = inputDeviceValue;
         Log::info("[AudioSettingsPage] Settings saved to " + configPath.string());
-    } else {
-        Log::error("[AudioSettingsPage] Failed to save settings!");
+        return true;
     }
+    Log::error("[AudioSettingsPage] Failed to save settings to " + configPath.string());
+    return false;
 }
 
 void AudioSettingsPage::loadSettings() {
@@ -862,8 +871,18 @@ void AudioSettingsPage::loadSettings() {
     Log::info("[AudioSettingsPage] Settings loaded successfully.");
 
     if (isLegacy) {
-        Log::info("[AudioSettingsPage] Loaded from legacy path, migrating to app-data.");
-        saveSettings();
+        // Deliberately does NOT write. Initialisation is read-only (#648), and
+        // this was the last remaining write reachable from the load path — with
+        // the async device lists still empty, so it could persist 0 over stored
+        // device ids exactly like the applyChanges() call removed above.
+        //
+        // Nothing is lost by deferring: saveSettings() resolves the path through
+        // getAudioSettingsConfigPath(), which returns the LEGACY file whenever
+        // that is the one that exists. The old call therefore rewrote the legacy
+        // file in place — the "migrating to app-data" it logged never happened.
+        // Migration needs its own change with a real destination; it is not a
+        // side effect of opening a dialog.
+        Log::info("[AudioSettingsPage] Loaded from legacy path; migration deferred to an explicit save.");
     }
 }
 
@@ -1008,19 +1027,18 @@ void AudioSettingsPage::onDeviceLoadComplete() {
     // hydration must not mutate audio device state.
     m_isPopulatingDeviceUI = true;
 
-    // Populate driver dropdown
-    m_driverDropdown->clearItems();
-    for (const auto& [name, value] : m_cachedDevices.driverTypes) {
-        m_driverDropdown->addItem(name, value);
-    }
-    m_driverDropdown->setSelectedByValue(m_cachedDevices.currentDriverType);
-    
-    // Populate device dropdown
-    // Stored intent wins over the active value when the saved device is actually
-    // present (#648). Populating used to select currentDeviceId unconditionally,
-    // discarding what loadSettings() had restored — so the next save persisted
-    // the runtime value over the user's choice.
+    // Stored intent wins over the active value whenever the saved entry is
+    // actually present (#648). Populating used to select the *current* value
+    // unconditionally, discarding what loadSettings() had restored — so the next
+    // save persisted the runtime value over the user's choice.
     using Aestra::Settings::selectionAfterPopulate;
+    const auto hasDriver = [](const auto& entries, int value) {
+        for (const auto& [name, entryValue] : entries) {
+            (void)name;
+            if (static_cast<int>(entryValue) == value) return true;
+        }
+        return false;
+    };
     const auto hasDevice = [](const auto& devices, int id) {
         for (const auto& [name, deviceId] : devices) {
             (void)name;
@@ -1029,6 +1047,19 @@ void AudioSettingsPage::onDeviceLoadComplete() {
         return false;
     };
 
+    // Populate driver dropdown
+    m_driverDropdown->clearItems();
+    for (const auto& [name, value] : m_cachedDevices.driverTypes) {
+        m_driverDropdown->addItem(name, value);
+    }
+    // Stored intent wins here too. Selecting currentDriverType unconditionally
+    // discarded what loadSettings() restored, exactly as it did for the device
+    // dropdowns before this PR.
+    m_driverDropdown->setSelectedByValue(selectionAfterPopulate(
+        m_savedDriverType, hasDriver(m_cachedDevices.driverTypes, m_savedDriverType),
+        m_cachedDevices.currentDriverType));
+    
+    // Populate device dropdown
     m_deviceDropdown->clearItems();
     for (const auto& [name, id] : m_cachedDevices.outputDevices) {
         m_deviceDropdown->addItem(name, id);

--- a/Source/Settings/AudioSettingsPage.cpp
+++ b/Source/Settings/AudioSettingsPage.cpp
@@ -281,11 +281,14 @@ void AudioSettingsPage::createUI() {
     };
 
     m_driverDropdown = createDropdown([this](int idx) {
-        m_dirty = true;
-
         // Guard: skip audio calls during initialization and async UI population.
         // The stream was opened once by AudioEngineController. UI must not mutate it.
+        // Programmatic hydration is not a user edit (#648): the guard comes first,
+        // so loadSettings()/onDeviceLoadComplete() cannot mark the page dirty by
+        // populating it.
         if (m_isInitializing || m_isPopulatingDeviceUI) return;
+
+        m_dirty = true;
 
         // SWITCH DRIVER IMMEDIATELY so device list is correct
         if (m_audioManager) {
@@ -297,9 +300,12 @@ void AudioSettingsPage::createUI() {
     });
 
     m_deviceDropdown = createDropdown([this](int idx) {
-        m_dirty = true;
-
+        // Programmatic hydration is not a user edit (#648): the guard comes
+        // first, so loadSettings()/onDeviceLoadComplete() cannot mark the
+        // page dirty by populating it.
         if (m_isInitializing || m_isPopulatingDeviceUI) return;
+
+        m_dirty = true;
 
         // SWITCH DEVICE IMMEDIATELY
         if (m_audioManager) {
@@ -308,9 +314,12 @@ void AudioSettingsPage::createUI() {
     });
 
     m_inputDeviceDropdown = createDropdown([this](int idx) {
-        m_dirty = true;
-
+        // Programmatic hydration is not a user edit (#648): the guard comes
+        // first, so loadSettings()/onDeviceLoadComplete() cannot mark the
+        // page dirty by populating it.
         if (m_isInitializing || m_isPopulatingDeviceUI) return;
+
+        m_dirty = true;
 
         if (m_audioManager) {
             const int selected = m_inputDeviceDropdown->getSelectedValue();
@@ -321,8 +330,12 @@ void AudioSettingsPage::createUI() {
     });
 
     m_sampleRateDropdown = createDropdown([this](int idx) {
-        m_dirty = true;
+        // Programmatic hydration is not a user edit (#648): the guard comes
+        // first, so loadSettings()/onDeviceLoadComplete() cannot mark the
+        // page dirty by populating it.
         if (m_isInitializing || m_isPopulatingDeviceUI) return;
+
+        m_dirty = true;
         if (!m_audioManager) return;
 
         uint32_t requested = (uint32_t)m_sampleRateDropdown->getSelectedValue();
@@ -342,9 +355,12 @@ void AudioSettingsPage::createUI() {
     });
 
     m_bufferSizeDropdown = createDropdown([this](int idx) {
-        m_dirty = true;
-
+        // Programmatic hydration is not a user edit (#648): the guard comes
+        // first, so loadSettings()/onDeviceLoadComplete() cannot mark the
+        // page dirty by populating it.
         if (m_isInitializing || m_isPopulatingDeviceUI) return;
+
+        m_dirty = true;
 
         uint32_t newBufferSize = (uint32_t)m_bufferSizeDropdown->getSelectedValue();
         if (m_audioManager) {
@@ -472,6 +488,14 @@ void AudioSettingsPage::createUI() {
 
 
 void AudioSettingsPage::applyChanges() {
+    // User-confirmed change: apply it, then persist it. This is the ONLY path
+    // that writes audio_settings.conf (#648).
+    applyEngineSettings();
+    m_dirty = false;
+    saveSettings();
+}
+
+void AudioSettingsPage::applyEngineSettings() {
     // 1. Resampling Quality
     int qIdx = m_resamplingDropdown->getSelectedIndex();
     ClipResamplingQuality globalQ = ClipResamplingQuality::High;
@@ -528,11 +552,6 @@ void AudioSettingsPage::applyChanges() {
     // 3. Driver/Device changes (Mock)
     // In real impl, we'd call m_audioManager->closeStream() and open new one.
     // For now, we assume user just changes quality mostly.
-    
-    m_dirty = false;
-    
-    // Save state to disk
-    saveSettings();
 }
 
 void AudioSettingsPage::cancelChanges() {
@@ -701,9 +720,21 @@ void AudioSettingsPage::saveSettings() {
     const auto configPath = getAudioSettingsConfigPath();
     std::ofstream file(configPath);
     if (file.is_open()) {
-        file << "driver=" << m_driverDropdown->getSelectedValue() << "\n";
-        file << "device=" << m_deviceDropdown->getSelectedValue() << "\n";
-        file << "input_device=" << m_inputDeviceDropdown->getSelectedValue() << "\n";
+        // Driver/device lists are populated asynchronously. An unpopulated
+        // dropdown reports 0 — a legal device id — so writing it blindly is how
+        // a stored selection got destroyed (#648). Persist the last known value
+        // until the list has actually loaded.
+        using Aestra::Settings::valueToPersist;
+        const int driverValue =
+            valueToPersist(m_driverDropdown->getItemCount() > 0, m_driverDropdown->getSelectedValue(), m_savedDriverType);
+        const int deviceValue =
+            valueToPersist(m_deviceDropdown->getItemCount() > 0, m_deviceDropdown->getSelectedValue(), m_savedDeviceId);
+        const int inputDeviceValue = valueToPersist(m_inputDeviceDropdown->getItemCount() > 0,
+                                                    m_inputDeviceDropdown->getSelectedValue(), m_savedInputDeviceId);
+
+        file << "driver=" << driverValue << "\n";
+        file << "device=" << deviceValue << "\n";
+        file << "input_device=" << inputDeviceValue << "\n";
         file << "samplerate=" << m_sampleRateDropdown->getSelectedValue() << "\n";
         file << "buffersize=" << m_bufferSizeDropdown->getSelectedValue() << "\n";
         file << "quality_preset=" << m_qualityPresetDropdown->getSelectedValue() << "\n";
@@ -715,6 +746,9 @@ void AudioSettingsPage::saveSettings() {
         file << "preview_ducking_db=" << m_previewDuckingDropdown->getSelectedValue() << "\n";
         file << "multi_threading=" << (m_multiThreadingToggle->isOn() ? "1" : "0") << "\n";
         file.close();
+        m_savedDriverType = driverValue;
+        m_savedDeviceId = deviceValue;
+        m_savedInputDeviceId = inputDeviceValue;
         Log::info("[AudioSettingsPage] Settings saved to " + configPath.string());
     } else {
         Log::error("[AudioSettingsPage] Failed to save settings!");
@@ -755,6 +789,7 @@ void AudioSettingsPage::loadSettings() {
         }
 
         if (key == "driver") {
+            m_savedDriverType = val;
             // Apply driver to engine FIRST to ensure device listing works
             if (m_audioManager && !skipAudioCalls) {
                 m_audioManager->setPreferredDriverType((AudioDriverType)val);
@@ -762,10 +797,12 @@ void AudioSettingsPage::loadSettings() {
             m_driverDropdown->setSelectedByValue(val);
         }
         else if (key == "device") {
+            m_savedDeviceId = val;
             if (m_audioManager && !skipAudioCalls) m_audioManager->switchDevice((uint32_t)val);
             m_deviceDropdown->setSelectedByValue(val);
         }
         else if (key == "input_device") {
+            m_savedInputDeviceId = val;
             if (m_audioManager && !skipAudioCalls) m_audioManager->switchInputDevice((uint32_t)val);
             m_inputDeviceDropdown->setSelectedByValue(val);
         }
@@ -807,7 +844,11 @@ void AudioSettingsPage::loadSettings() {
         }
     }
     
-    applyChanges();
+    // Apply what was loaded, but do NOT persist: hydrating the page is a read.
+    // Before #648 this called applyChanges(), whose final act is saveSettings() —
+    // which ran while the async device lists were still empty and wrote 0 over
+    // the user's stored device ids.
+    applyEngineSettings();
     Log::info("[AudioSettingsPage] Settings loaded successfully.");
 
     if (isLegacy) {
@@ -965,17 +1006,34 @@ void AudioSettingsPage::onDeviceLoadComplete() {
     m_driverDropdown->setSelectedByValue(m_cachedDevices.currentDriverType);
     
     // Populate device dropdown
+    // Stored intent wins over the active value when the saved device is actually
+    // present (#648). Populating used to select currentDeviceId unconditionally,
+    // discarding what loadSettings() had restored — so the next save persisted
+    // the runtime value over the user's choice.
+    using Aestra::Settings::selectionAfterPopulate;
+    const auto hasDevice = [](const auto& devices, int id) {
+        for (const auto& [name, deviceId] : devices) {
+            (void)name;
+            if (static_cast<int>(deviceId) == id) return true;
+        }
+        return false;
+    };
+
     m_deviceDropdown->clearItems();
     for (const auto& [name, id] : m_cachedDevices.outputDevices) {
         m_deviceDropdown->addItem(name, id);
     }
-    m_deviceDropdown->setSelectedByValue(m_cachedDevices.currentDeviceId);
+    m_deviceDropdown->setSelectedByValue(selectionAfterPopulate(
+        m_savedDeviceId, hasDevice(m_cachedDevices.outputDevices, m_savedDeviceId),
+        static_cast<int>(m_cachedDevices.currentDeviceId)));
 
     m_inputDeviceDropdown->clearItems();
     for (const auto& [name, id] : m_cachedDevices.inputDevices) {
         m_inputDeviceDropdown->addItem(name, id);
     }
-    m_inputDeviceDropdown->setSelectedByValue(m_cachedDevices.currentInputDeviceId);
+    m_inputDeviceDropdown->setSelectedByValue(selectionAfterPopulate(
+        m_savedInputDeviceId, hasDevice(m_cachedDevices.inputDevices, m_savedInputDeviceId),
+        static_cast<int>(m_cachedDevices.currentInputDeviceId)));
     
     // Populate sample rates
     if (m_sampleRateDropdown->getItemCount() == 0) {

--- a/Source/Settings/AudioSettingsPage.h
+++ b/Source/Settings/AudioSettingsPage.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "ISettingsPage.h"
+#include "SettingsPersistencePolicy.h"
 #include "AudioDeviceManager.h"
 #include "TrackManager.h"
 #include "NUIButton.h"
@@ -95,6 +96,11 @@ private:
     void saveSettings();
     void loadSettings();
 
+    // Apply the current control values to the engine WITHOUT persisting (#648).
+    // applyChanges() is this plus saveSettings(); the load path uses this alone,
+    // so hydrating the page can never write to disk.
+    void applyEngineSettings();
+
     Audio::AudioDeviceManager* m_audioManager;
     Audio::AudioEngine* m_audioEngine;
     std::function<void()> m_onStreamRestore;
@@ -173,6 +179,14 @@ private:
     // When true, dropdown callbacks must NOT call setPreferredDriverType, switchDevice, etc.
     // to prevent the async device-load completion path from mutating active audio state.
     bool m_isPopulatingDeviceUI = false;
+
+    // Last values read from (or written to) audio_settings.conf for the three
+    // asynchronously-populated controls (#648). An unpopulated dropdown reports
+    // 0, which is a legal device id — writing it would destroy the user's stored
+    // selection, so these are persisted instead until the lists have loaded.
+    int m_savedDriverType = Aestra::Settings::kNoPersistedValue;
+    int m_savedDeviceId = Aestra::Settings::kNoPersistedValue;
+    int m_savedInputDeviceId = Aestra::Settings::kNoPersistedValue;
     
     // Async Loading Infrastructure
     std::atomic<bool> m_isLoadingDevices{false};

--- a/Source/Settings/AudioSettingsPage.h
+++ b/Source/Settings/AudioSettingsPage.h
@@ -93,7 +93,9 @@ private:
     void loadCurrentSettings();
     
     // Persistence
-    void saveSettings();
+    /// @return true only when the configuration was actually written. A failed
+    /// save must not clear the dirty flag (#648 review).
+    bool saveSettings();
     void loadSettings();
 
     // Apply the current control values to the engine WITHOUT persisting (#648).

--- a/Source/Settings/SettingsPersistencePolicy.h
+++ b/Source/Settings/SettingsPersistencePolicy.h
@@ -25,20 +25,29 @@ namespace Settings {
 inline constexpr int kNoPersistedValue = -1;
 
 /**
- * @brief Decide what to write for a control that may not have finished loading.
+ * @brief Decide what to write for a control that may not have a real selection.
  *
- * @param listPopulated   Whether the control's item list has been filled in.
+ * @param hasSelection     Whether the control genuinely has an item selected.
  * @param currentSelection The control's current selected value.
- * @param lastKnownSaved  The value previously read from (or written to) the
- *                        config, or kNoPersistedValue if there was none.
+ * @param lastKnownSaved   The value previously read from (or written to) the
+ *                         config, or kNoPersistedValue if there was none.
  *
- * An unpopulated list is not a user selection. When the list has not loaded,
- * the previously persisted value is preserved; only when there was never one
- * does the current selection get written, since there is then no user intent
- * to protect.
+ * Only a genuine selection is user intent. Without one the previously persisted
+ * value is preserved; only when there was never one does the current selection
+ * get written, since there is then nothing to protect.
+ *
+ * @note This asks "is something selected", NOT "is the list populated". Those
+ * differ, and the difference is live: NUIDropdown::clearItems() sets
+ * selectedIndex_ to -1, and setSelectedByValue() silently does nothing when the
+ * value is absent — so a repopulated list whose stored id is no longer present
+ * ends up populated with NOTHING selected. getSelectedValue() returns 0 in that
+ * state, which is indistinguishable from the item whose value is 0. Persisting
+ * it would reproduce exactly the defect this file exists to prevent, through a
+ * narrower door. Callers must derive @p hasSelection from getSelectedItem(),
+ * which returns std::nullopt rather than a legal-looking 0.
  */
-inline int valueToPersist(bool listPopulated, int currentSelection, int lastKnownSaved) {
-    if (listPopulated) {
+inline int valueToPersist(bool hasSelection, int currentSelection, int lastKnownSaved) {
+    if (hasSelection) {
         return currentSelection;
     }
     if (lastKnownSaved != kNoPersistedValue) {

--- a/Source/Settings/SettingsPersistencePolicy.h
+++ b/Source/Settings/SettingsPersistencePolicy.h
@@ -1,0 +1,66 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// Persistence policy for settings controls whose backing list is populated
+// asynchronously (#648).
+//
+// The device, input-device and driver dropdowns are filled by a background
+// hardware enumeration. Anything that writes the config before that finishes
+// reads an unpopulated control, gets 0, and persists it over a real device id —
+// which is how a user's saved output device was being destroyed by the act of
+// opening the Settings dialog.
+//
+// Kept free of widget and audio dependencies so the decision itself can be
+// tested without constructing a UI.
+
+namespace Aestra {
+namespace Settings {
+
+/**
+ * @brief Sentinel for "no value has ever been persisted for this control".
+ *
+ * Distinct from 0, which is a legal device id on some backends and is exactly
+ * what an unpopulated dropdown reports.
+ */
+inline constexpr int kNoPersistedValue = -1;
+
+/**
+ * @brief Decide what to write for a control that may not have finished loading.
+ *
+ * @param listPopulated   Whether the control's item list has been filled in.
+ * @param currentSelection The control's current selected value.
+ * @param lastKnownSaved  The value previously read from (or written to) the
+ *                        config, or kNoPersistedValue if there was none.
+ *
+ * An unpopulated list is not a user selection. When the list has not loaded,
+ * the previously persisted value is preserved; only when there was never one
+ * does the current selection get written, since there is then no user intent
+ * to protect.
+ */
+inline int valueToPersist(bool listPopulated, int currentSelection, int lastKnownSaved) {
+    if (listPopulated) {
+        return currentSelection;
+    }
+    if (lastKnownSaved != kNoPersistedValue) {
+        return lastKnownSaved;
+    }
+    return currentSelection;
+}
+
+/**
+ * @brief Decide which entry a freshly-populated list should select.
+ *
+ * Stored intent wins over the currently active value whenever the stored value
+ * is actually available. Otherwise the active value is the honest choice —
+ * showing a device that is not present would make the dialog describe something
+ * the engine is not doing.
+ */
+inline int selectionAfterPopulate(int savedValue, bool savedValueAvailable, int activeValue) {
+    if (savedValue != kNoPersistedValue && savedValueAvailable) {
+        return savedValue;
+    }
+    return activeValue;
+}
+
+} // namespace Settings
+} // namespace Aestra

--- a/Tests/AestraUI/SettingsPersistencePolicyTest.cpp
+++ b/Tests/AestraUI/SettingsPersistencePolicyTest.cpp
@@ -40,27 +40,85 @@ void expectEq(int got, int wanted, const std::string& what) {
 } // namespace
 
 int main() {
-    // --- the regression, stated directly -------------------------------------
-    // Saved device 129; dialog opens; list has not populated so the control
-    // reports 0. Writing 0 here is the bug.
-    expectEq(valueToPersist(/*listPopulated=*/false, /*currentSelection=*/0, /*lastKnownSaved=*/129), 129,
-             "unpopulated list must not overwrite a stored device id");
+    // =====================================================================
+    // The discriminator this whole file exists for:
+    //
+    //     "device 0 is selected"   !=   "nothing is selected"
+    //
+    // The predicate that shipped first asked "does the list have entries",
+    // which cannot tell those apart, because NUIDropdown::getSelectedValue()
+    // returns 0 for BOTH. Cases are stated in pairs so a future change cannot
+    // satisfy one reading and quietly break the other.
+    // =====================================================================
 
-    // Same shape for the input device and the driver.
-    expectEq(valueToPersist(false, 0, 7), 7, "unpopulated list preserves stored input device");
-    expectEq(valueToPersist(false, 0, 0), 0, "stored id of 0 is preserved as 0, not treated as absent");
+    // --- 1. items present, selectedIndex == -1 -> do NOT persist -------------
+    // Reachable today: clearItems() sets selectedIndex_ = -1, and
+    // setSelectedByValue() silently no-ops when the value is absent, so a
+    // repopulated list can hold items with nothing selected.
+    expectEq(valueToPersist(/*hasSelection=*/false, /*currentSelection=*/0, /*lastKnownSaved=*/129), 129,
+             "items present but nothing selected: stored id survives");
+    expectEq(valueToPersist(false, 0, 7), 7, "same for the input device");
+    expectEq(valueToPersist(false, 0, 3), 3, "same for the driver");
 
-    // --- once the list has loaded, the control is authoritative ---------------
-    expectEq(valueToPersist(true, 129, 129), 129, "populated list persists the selection");
-    expectEq(valueToPersist(true, 42, 129), 42, "populated list persists a NEW user selection");
-    expectEq(valueToPersist(true, 0, 129), 0,
-             "populated list persists 0 when 0 is genuinely selected");
+    // --- 2. saved id absent from the populated list -> do not invent 0 -------
+    // Enumeration succeeded, but the device the user chose is gone. The
+    // dropdown reports 0 because nothing matched; 0 must not overwrite the
+    // stored id, because the device may come back.
+    expectEq(valueToPersist(/*hasSelection=*/false, /*currentSelection=*/0, /*lastKnownSaved=*/129), 129,
+             "saved device absent from the list: 0 is not invented or persisted");
+
+    // --- 3. selected item hidden (a state #658 introduces) ------------------
+    // #658 sets selectedIndex_ = -1 when the selected item is hidden. Whatever
+    // product policy that PR settles on, the persistence answer is pinned here:
+    // a hidden selection is not a user selection, so the stored value survives
+    // rather than being overwritten by the 0 the widget reports. If #658
+    // instead retains a hidden logical selection, the caller passes
+    // hasSelection=true with the real value and case 4 covers it.
+    expectEq(valueToPersist(/*hasSelection=*/false, /*currentSelection=*/0, /*lastKnownSaved=*/129), 129,
+             "selection hidden: stored id survives, 0 is not persisted");
+
+    // --- 4. a REAL selection whose id happens to be 0 -> persist it ----------
+    // The other half of the discriminator. Were this to regress to "0 means
+    // nothing", a user on a backend where 0 is a legal device id could never
+    // save that choice.
+    expectEq(valueToPersist(/*hasSelection=*/true, /*currentSelection=*/0, /*lastKnownSaved=*/129), 0,
+             "device 0 GENUINELY selected: persist 0, overwriting the stored 129");
+    expectEq(valueToPersist(true, 0, kNoPersistedValue), 0,
+             "device 0 genuinely selected with nothing stored: persist 0");
+    expectEq(valueToPersist(true, 0, 0), 0, "device 0 selected and already stored: stays 0");
+
+    // --- 5. delayed enumeration eventually restores the saved selection ------
+    // Only once a real selection exists does the field become writable.
+    {
+        int stored = 129;
+        stored = valueToPersist(false, 0, stored);
+        expectEq(stored, 129, "lifecycle: pending enumeration preserves the stored id");
+        stored = valueToPersist(false, 0, stored);
+        expectEq(stored, 129, "lifecycle: populated-but-unselected still preserves it");
+        stored = valueToPersist(true, 129, stored);
+        expectEq(stored, 129, "lifecycle: restored selection persists the same id");
+        stored = valueToPersist(true, 42, stored);
+        expectEq(stored, 42, "lifecycle: a real user change is written");
+    }
+
+    // Repeated opens with enumeration never completing must not decay the value.
+    {
+        int stored = 129;
+        for (int i = 0; i < 5; ++i) {
+            stored = valueToPersist(false, 0, stored);
+        }
+        expectEq(stored, 129, "five open/close cycles with no selection preserve the id");
+    }
+
+    // --- once something IS selected, the control is authoritative -------------
+    expectEq(valueToPersist(true, 129, 129), 129, "selection persists");
+    expectEq(valueToPersist(true, 42, 129), 42, "a NEW user selection persists");
 
     // --- fresh install: nothing stored, so nothing to protect ----------------
     expectEq(valueToPersist(false, 0, kNoPersistedValue), 0,
-             "no stored value: current selection is written even unpopulated");
-    expectEq(valueToPersist(false, 3, kNoPersistedValue), 3, "no stored value: unpopulated fallback");
-    expectEq(valueToPersist(true, 5, kNoPersistedValue), 5, "no stored value: populated writes selection");
+             "no stored value: current selection is written even with no selection");
+    expectEq(valueToPersist(false, 3, kNoPersistedValue), 3, "no stored value: no-selection fallback");
+    expectEq(valueToPersist(true, 5, kNoPersistedValue), 5, "no stored value: a selection is written");
 
     // --- repeated opens must be idempotent -----------------------------------
     // Open, close, open again with the list still pending: the stored value must

--- a/Tests/AestraUI/SettingsPersistencePolicyTest.cpp
+++ b/Tests/AestraUI/SettingsPersistencePolicyTest.cpp
@@ -1,0 +1,99 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Settings persistence policy (#648).
+//
+// The defect this pins: opening the Settings dialog rewrote audio_settings.conf
+// while the asynchronous device enumeration was still pending, so the device
+// dropdowns reported 0 and 0 was written over the user's real device ids. The
+// user's saved output device was destroyed by the act of looking at Settings.
+//
+// The decision itself — "what do we write for a control whose list has not
+// loaded?" — is extracted here precisely so it can be tested. The surrounding
+// wiring is a UI class with no headless harness; this is the part that can be
+// pinned honestly, and it is the part that was wrong.
+//
+// Note 0 is deliberately used as a "real" id throughout: on this machine the
+// corrupted value WAS 0, and 0 is a legal device id on some backends. A policy
+// that special-cased 0 instead of tracking populated-ness would pass a weaker
+// test and still lose data.
+
+#include "SettingsPersistencePolicy.h"
+
+#include <iostream>
+#include <string>
+
+using Aestra::Settings::kNoPersistedValue;
+using Aestra::Settings::selectionAfterPopulate;
+using Aestra::Settings::valueToPersist;
+
+namespace {
+
+int g_failures = 0;
+
+void expectEq(int got, int wanted, const std::string& what) {
+    if (got != wanted) {
+        std::cerr << "[FAIL] " << what << ": got " << got << ", wanted " << wanted << '\n';
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    // --- the regression, stated directly -------------------------------------
+    // Saved device 129; dialog opens; list has not populated so the control
+    // reports 0. Writing 0 here is the bug.
+    expectEq(valueToPersist(/*listPopulated=*/false, /*currentSelection=*/0, /*lastKnownSaved=*/129), 129,
+             "unpopulated list must not overwrite a stored device id");
+
+    // Same shape for the input device and the driver.
+    expectEq(valueToPersist(false, 0, 7), 7, "unpopulated list preserves stored input device");
+    expectEq(valueToPersist(false, 0, 0), 0, "stored id of 0 is preserved as 0, not treated as absent");
+
+    // --- once the list has loaded, the control is authoritative ---------------
+    expectEq(valueToPersist(true, 129, 129), 129, "populated list persists the selection");
+    expectEq(valueToPersist(true, 42, 129), 42, "populated list persists a NEW user selection");
+    expectEq(valueToPersist(true, 0, 129), 0,
+             "populated list persists 0 when 0 is genuinely selected");
+
+    // --- fresh install: nothing stored, so nothing to protect ----------------
+    expectEq(valueToPersist(false, 0, kNoPersistedValue), 0,
+             "no stored value: current selection is written even unpopulated");
+    expectEq(valueToPersist(false, 3, kNoPersistedValue), 3, "no stored value: unpopulated fallback");
+    expectEq(valueToPersist(true, 5, kNoPersistedValue), 5, "no stored value: populated writes selection");
+
+    // --- repeated opens must be idempotent -----------------------------------
+    // Open, close, open again with the list still pending: the stored value must
+    // survive every cycle, not decay after the first.
+    {
+        int stored = 129;
+        for (int i = 0; i < 5; ++i) {
+            stored = valueToPersist(false, 0, stored);
+        }
+        expectEq(stored, 129, "five open/close cycles with a pending list preserve the id");
+    }
+
+    // --- population prefers stored intent over the active value --------------
+    expectEq(selectionAfterPopulate(/*saved=*/129, /*available=*/true, /*active=*/2), 129,
+             "saved device wins when it is present");
+    expectEq(selectionAfterPopulate(129, /*available=*/false, /*active=*/2), 2,
+             "saved device absent: fall back to the active device");
+    expectEq(selectionAfterPopulate(kNoPersistedValue, false, 2), 2,
+             "nothing saved: use the active device");
+    expectEq(selectionAfterPopulate(kNoPersistedValue, true, 2), 2,
+             "nothing saved: availability is irrelevant");
+    expectEq(selectionAfterPopulate(0, /*available=*/true, /*active=*/5), 0,
+             "a saved id of 0 that is present still wins");
+
+    // A saved value that is present must not be discarded just because the
+    // engine happens to be running on something else — that discard is what made
+    // the next save persist the runtime value over stored intent.
+    expectEq(selectionAfterPopulate(129, true, 129), 129, "saved and active agreeing is stable");
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] SettingsPersistencePolicyTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] SettingsPersistencePolicyTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1535,6 +1535,16 @@ target_include_directories(SafeClampFloatTest PRIVATE
 add_test(NAME SafeClampFloatTest COMMAND SafeClampFloatTest)
 set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression")
 
+# Settings persistence policy (#648). Same shape as SafeClampFloatTest above:
+# header-only and widget-free so the decision that was destroying saved device
+# ids is reachable without linking AestraUI, which AESTRA_CI=ON disables.
+add_executable(SettingsPersistencePolicyTest AestraUI/SettingsPersistencePolicyTest.cpp)
+target_include_directories(SettingsPersistencePolicyTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Settings
+)
+add_test(NAME SettingsPersistencePolicyTest COMMAND SettingsPersistencePolicyTest)
+set_tests_properties(SettingsPersistencePolicyTest PROPERTIES LABELS "ui;settings;regression")
+
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeConsistencyTest.cpp")
     add_executable(NUIThemeConsistencyTest AestraUI/NUIThemeConsistencyTest.cpp)
     target_link_libraries(NUIThemeConsistencyTest PRIVATE AestraUI_Core)


### PR DESCRIPTION
Fixes #648.

Opening the Settings dialog no longer rewrites `audio_settings.conf`, and no longer destroys the user's saved audio device.

## Root cause

`AudioSettingsPage::initialize()` → `loadSettings()` (`:466`) → `applyChanges()` (`:810`) → **`saveSettings()`** (`:534`).

Constructing the page wrote the config. And it wrote it while the driver/device/input-device dropdowns were still empty — those lists are filled by an asynchronous hardware enumeration (`startAsyncDeviceLoad`, comment at `:443`). An unpopulated dropdown reports `0`, which is a legal device id, so `0` was persisted over the real one.

A second overwrite compounded it: `onDeviceLoadComplete()` selected `m_cachedDevices.currentDeviceId` — the **active** device, not the **saved** one — discarding what `loadSettings()` had just restored.

## Invariant established

> **Settings initialization is read-only.** No load, construction, or population path writes configuration. Persistence happens only on explicit user confirmation, and never serializes a control whose backing data has not finished loading.

## The convention already existed

`AppearanceSettingsPage` implements exactly this, with `m_syncingSelection` bracketing programmatic `setSelectedIndex` and `preferences.save()` reachable only from `applyChanges()`. This PR applies that existing convention to the page that skipped it rather than inventing one.

**Full settings-page audit** (the issue asks for all pages, not just this one):

| page | writes reachable from construction | verdict |
|---|---|---|
| `AppearanceSettingsPage` | no | clean — the reference implementation |
| `GeneralSettingsPage` | no | clean |
| `MembershipSettingsPage` | no | clean |
| `AudioSettingsPage` | **yes** | fixed here |

## Changes

1. **Split apply from persist.** `applyEngineSettings()` is the old `applyChanges()` body; `applyChanges()` = that + `saveSettings()`. The load path calls `applyEngineSettings()` alone.

   **What gets applied, and when, is deliberately unchanged.** This PR removes a write; it does not touch the lifecycle defect. That is #649, and keeping them separate is why this one is reviewable on its own.

2. **Never persist an unpopulated control.** `saveSettings()` writes the last known value for driver/device/input-device when their lists are empty. The decision lives in `SettingsPersistencePolicy.h` — no widget or audio dependencies, so it is testable without constructing a UI.

3. **Saved selection wins over active** on population, when the saved device is actually present.

4. **`m_dirty = true` moved after the guard** in all five dropdown callbacks. It ran *before* `if (m_isInitializing || m_isPopulatingDeviceUI) return;`, so hydration marked the page dirty and `applyChanges()`'s trailing reset was the only thing hiding it. Removing that reset without this would have left the page reporting unsaved changes the moment it opened. Caught while reviewing the split, not by a test — worth stating plainly.

## Files changed

| file | change |
|---|---|
| `Source/Settings/SettingsPersistencePolicy.h` | new — `valueToPersist`, `selectionAfterPopulate`, `kNoPersistedValue` |
| `Source/Settings/AudioSettingsPage.h` | `applyEngineSettings()`; `m_savedDriverType` / `m_savedDeviceId` / `m_savedInputDeviceId` |
| `Source/Settings/AudioSettingsPage.cpp` | split; load path no longer persists; guarded `saveSettings`; population prefers stored intent; guard-before-dirty |
| `Tests/AestraUI/SettingsPersistencePolicyTest.cpp` | new |
| `Tests/CMakeLists.txt` | registration |

## Runtime reproduction, before and after

Same drive, same machine, same seeded config (`device=129`, a real enumerated id).

**Before** — opening Settings and touching nothing:
```
=== conf BEFORE ===        === conf AFTER ===
device=129                  device=0
input_device=129            input_device=0
samplerate=48000            samplerate=48000     (synchronous list — survived)
buffersize=256              buffersize=256       (synchronous list — survived)
```

**After** — the full browse cycle, by md5:
```
startup:                    c625841b07156d4efb4f8ee32873e5b1
after opening Settings:     c625841b07156d4efb4f8ee32873e5b1
after clicking Audio tab:   c625841b07156d4efb4f8ee32873e5b1
after closing dialog:       c625841b07156d4efb4f8ee32873e5b1
after REOPENING Settings:   c625841b07156d4efb4f8ee32873e5b1
after clean app shutdown:   c625841b07156d4efb4f8ee32873e5b1
```

Byte-identical throughout, and the Audio page shows **Output Device: Built-in Audio** — the saved device, honoured.

## Tests

`SettingsPersistencePolicyTest` — 18 assertions on the extracted decision. Includes the exact regression (`unpopulated list must not overwrite a stored device id`), five repeated open/close cycles proving idempotence rather than decay after the first, and the fresh-install case where there is no stored value to protect.

`0` is used as a *real* stored id throughout, deliberately: the corrupted value on the reporting machine **was** `0`, and `0` is legal on some backends. A policy that special-cased `0` instead of tracking populated-ness would pass a weaker test and still lose data.

## Verification rung

- **Behaviour observed** for the end-to-end fix — the md5 sequence above, on a real driven session.
- **Behaviour regression-tested** for the persistence decision, over the scenario named above.
- The wiring between them (which dropdown feeds which policy call) is **compiled** and drive-verified once, not unit-tested. `AudioSettingsPage` is a widget class with no headless harness; extracting the decision is how much of it could be pinned honestly.

## Compatibility

No format change. `audio_settings.conf` keys, order and semantics are untouched. A config written by an older build loads identically.

## Remaining risks

- `#649` is untouched by design: the page still displays **Buffer Size: 256** while the engine runs at **512**, confirmed in the same session. This PR does not mask that.
- **#653 is NOT fixed by this.** The "Unsaved Changes" prompt still appears after the same interaction, on the rebuilt binary. That is project-dirty, not page-dirty, and I have deliberately not folded the investigation in on the strength of the `m_dirty` finding. Evidence posted to #653.
- `selectionAfterPopulate` changes which entry is selected after enumeration. Today the startup controller already applies the saved device, so saved and active normally agree; the new behaviour only diverges when the saved device is absent, where it falls back to active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes; the configuration format remains unchanged.
- Fixed `#648` by making `AudioSettingsPage` initialization/presentation read-only, so constructing or opening the page no longer rewrites `audio_settings.conf` or overwrites stored device selections.
- Refactored the lifecycle to separate “apply to audio engine” from “persist to disk”: `loadSettings()` applies via `applyEngineSettings()` (no persistence), while persistence happens only through explicit saves.
- Hardened persistence during async device enumeration: unpopulated/placeholder dropdown states no longer overwrite stored IDs, and persisted selections are preferred after population when available.
- Added a shared persistence policy (`SettingsPersistencePolicy.h`) with helpers that correctly handle valid ID `0` and preserve last-known values when no real selection exists.
- Prevented initialization/population callbacks from marking the page dirty by moving guard logic into shared control wrappers (and retaining redundant defenses).
- Improved save correctness: `saveSettings()` now reports write success (`bool`) and only clears `m_dirty` after a confirmed successful write; removed a legacy branch that could write from `loadSettings()`.
- Added `SettingsPersistencePolicyTest` (18+ assertions) and wired it into CTest to cover lifecycle/idempotence and selection-resolution scenarios for async-populated dropdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->