### PR TITLE
Fix global select and tooltip interactions

### DIFF
--- a/AestraUI/Base/NUIDropdown.cpp
+++ b/AestraUI/Base/NUIDropdown.cpp
@@ -9,7 +9,7 @@
 
 namespace AestraUI {
 
-// Track the currently open dropdown so other dropdowns ignore clicks while one is open
+// Keep one shared dropdown open at a time.
 static NUIDropdown* s_openDropdown = nullptr;
 constexpr float kDropdownGap = 6.0f;
 
@@ -104,7 +104,19 @@ void NUIDropdown::addItem(const DropdownItem& item) {
 
 void NUIDropdown::setItemVisible(int index, bool visible) {
     if (index >= 0 && index < static_cast<int>(items_.size())) {
+        if (items_[index].visible == visible)
+            return;
         items_[index].visible = visible;
+        if (!visible && selectedIndex_ == index) {
+            selectedIndex_ = -1;
+        }
+        if (!visible && hoveredIndex_ == index) {
+            hoveredIndex_ = -1;
+        }
+        clampScrollOffset();
+        if (isOpen_ && getVisibleItemCount() == 0) {
+            closeDropdown();
+        }
         setDirty(true);
         itemWidthCacheValid_ = false;
         cacheDirty_ = true;
@@ -113,16 +125,24 @@ void NUIDropdown::setItemVisible(int index, bool visible) {
 
 void NUIDropdown::setItemEnabled(int index, bool enabled) {
     if (index >= 0 && index < static_cast<int>(items_.size())) {
+        if (items_[index].enabled == enabled)
+            return;
         items_[index].enabled = enabled;
+        if (!enabled && hoveredIndex_ == index) {
+            hoveredIndex_ = getNextSelectableIndex(index, 1);
+            ensureItemVisible(hoveredIndex_);
+        }
         setDirty(true);
-        itemWidthCacheValid_ = false;
         cacheDirty_ = true;
     }
 }
 
 void NUIDropdown::clearItems() {
+    closeDropdown();
     items_.clear();
     selectedIndex_ = -1;
+    hoveredIndex_ = -1;
+    scrollOffset_ = 0;
     setDirty(true);
     itemWidthCacheValid_ = false;
     cacheDirty_ = true;
@@ -150,27 +170,49 @@ std::optional<DropdownItem> NUIDropdown::getSelectedItem() const {
 }
 
 void NUIDropdown::setSelectedIndex(int index) {
-    if (selectedIndex_ == index) return;
+    if (selectedIndex_ == index)
+        return;
 
-    if (index >= -1 && index < static_cast<int>(items_.size())) {
+    if (index >= -1 && index < static_cast<int>(items_.size()) && (index == -1 || items_[index].visible)) {
         selectedIndex_ = index;
         notifySelectionChanged();
-        
+
         if (selectedIndex_ >= 0 && items_[selectedIndex_].callback) {
             items_[selectedIndex_].callback();
         }
-        
+
         setDirty(true);
     }
 }
 
 void NUIDropdown::setSelectedByValue(int value) {
     for (int i = 0; i < static_cast<int>(items_.size()); ++i) {
-        if (items_[i].value == value) {
+        if (items_[i].visible && items_[i].value == value) {
             setSelectedIndex(i);
             return;
         }
     }
+    setSelectedIndex(-1);
+}
+
+void NUIDropdown::setMaxVisibleItems(int count) {
+    const int clamped = std::max(1, count);
+    if (maxVisibleItems_ == clamped)
+        return;
+    maxVisibleItems_ = clamped;
+    clampScrollOffset();
+    ensureItemVisible(hoveredIndex_ >= 0 ? hoveredIndex_ : selectedIndex_);
+    setDirty(true);
+    cacheDirty_ = true;
+}
+
+void NUIDropdown::setItemHeight(float height) {
+    const float clamped = std::max(1.0f, height);
+    if (itemHeight_ == clamped)
+        return;
+    itemHeight_ = clamped;
+    setDirty(true);
+    cacheDirty_ = true;
 }
 
 void NUIDropdown::onRender(NUIRenderer& renderer) {
@@ -262,24 +304,38 @@ void NUIDropdown::onRender(NUIRenderer& renderer) {
 }
 
 bool NUIDropdown::onMouseEvent(const NUIMouseEvent& event) {
-    if (!isEnabled()) return false;
+    if (!isVisible() || !isEnabled())
+        return false;
 
     auto bounds = getBounds();
 
+    if (isOpen_ && event.wheelDelta != 0.0f) {
+        const NUIRect listBounds = getDropdownBounds();
+        if (listBounds.contains(event.position)) {
+            const int previousOffset = scrollOffset_;
+            scrollOffset_ += event.wheelDelta > 0.0f ? -1 : 1;
+            clampScrollOffset();
+            hoveredIndex_ = getItemUnderMouse(event.position);
+            if (scrollOffset_ != previousOffset) {
+                setDirty(true);
+                cacheDirty_ = true;
+            }
+            return true;
+        }
+    }
+
     if (event.pressed && event.button == NUIMouseButton::Left) {
         if (isOpen_) {
-            int visibleItems = std::min(maxVisibleItems_, static_cast<int>(items_.size()));
-            float listHeight = itemHeight_ * visibleItems;
-            NUIRect listBounds(bounds.x, bounds.y + bounds.height + kDropdownGap, bounds.width, listHeight);
-            
+            const NUIRect listBounds = getDropdownBounds();
+
             if (listBounds.contains(event.position)) {
                 int clickedIndex = getItemUnderMouse(event.position);
                 if (clickedIndex >= 0 && clickedIndex < static_cast<int>(items_.size())) {
                     const auto& item = items_[clickedIndex];
                     if (item.enabled && item.visible) {
                         setSelectedIndex(clickedIndex);
+                        closeDropdown();
                     }
-                    closeDropdown();
                 }
                 return true;
             }
@@ -287,7 +343,7 @@ bool NUIDropdown::onMouseEvent(const NUIMouseEvent& event) {
 
         if (bounds.contains(event.position)) {
             if (!isOpen_ && s_openDropdown != nullptr && s_openDropdown != this) {
-                return false;
+                s_openDropdown->closeDropdown();
             }
             bringToFront();
             setFocused(true);
@@ -297,7 +353,9 @@ bool NUIDropdown::onMouseEvent(const NUIMouseEvent& event) {
 
         if (isOpen_) {
             closeDropdown();
-            return true;
+            // Let the same press continue through the parent dispatch so a
+            // sibling control can activate without requiring a second click.
+            return false;
         }
     }
 
@@ -310,36 +368,46 @@ bool NUIDropdown::onMouseEvent(const NUIMouseEvent& event) {
 }
 
 bool NUIDropdown::onKeyEvent(const NUIKeyEvent& event) {
-    if (!isEnabled() || !isFocused()) return false;
+    if (!isEnabled() || !isFocused())
+        return false;
 
     if (event.pressed) {
         switch (event.keyCode) {
-            case NUIKeyCode::Enter:
-            case NUIKeyCode::Space:
-                toggleDropdown();
+        case NUIKeyCode::Enter:
+        case NUIKeyCode::Space:
+            if (!isOpen_) {
+                openDropdown();
+            } else {
+                if (hoveredIndex_ >= 0 && items_[hoveredIndex_].visible && items_[hoveredIndex_].enabled) {
+                    setSelectedIndex(hoveredIndex_);
+                }
+                closeDropdown();
+            }
+            return true;
+        case NUIKeyCode::Escape:
+            if (isOpen_) {
+                closeDropdown();
                 return true;
-            case NUIKeyCode::Escape:
-                if (isOpen_) {
-                    closeDropdown();
-                    return true;
-                }
-                break;
-            case NUIKeyCode::Up:
-                if (isOpen_) {
-                    int newIndex = selectedIndex_ > 0 ? selectedIndex_ - 1 : static_cast<int>(items_.size()) - 1;
-                    setSelectedIndex(newIndex);
-                    return true;
-                }
-                break;
-            case NUIKeyCode::Down:
-                if (isOpen_) {
-                    int newIndex = selectedIndex_ < static_cast<int>(items_.size()) - 1 ? selectedIndex_ + 1 : 0;
-                    setSelectedIndex(newIndex);
-                    return true;
-                }
-                break;
-            default:
-                break;
+            }
+            break;
+        case NUIKeyCode::Up:
+            if (isOpen_) {
+                hoveredIndex_ = getNextSelectableIndex(hoveredIndex_ >= 0 ? hoveredIndex_ : selectedIndex_, -1);
+                ensureItemVisible(hoveredIndex_);
+                setDirty(true);
+                return true;
+            }
+            break;
+        case NUIKeyCode::Down:
+            if (isOpen_) {
+                hoveredIndex_ = getNextSelectableIndex(hoveredIndex_ >= 0 ? hoveredIndex_ : selectedIndex_, 1);
+                ensureItemVisible(hoveredIndex_);
+                setDirty(true);
+                return true;
+            }
+            break;
+        default:
+            break;
         }
     }
     return false;
@@ -359,21 +427,33 @@ void NUIDropdown::toggleDropdown() {
 }
 
 void NUIDropdown::openDropdown() {
-    if (isOpen_) return;
+    if (isOpen_ || getVisibleItemCount() == 0)
+        return;
+    if (s_openDropdown && s_openDropdown != this) {
+        s_openDropdown->closeDropdown();
+    }
+    NUIComponent::hideRemoteTooltip();
     isOpen_ = true;
-    hoveredIndex_ = selectedIndex_;
-    if (onOpen_) onOpen_();
+    hoveredIndex_ =
+        selectedIndex_ >= 0 && items_[selectedIndex_].enabled ? selectedIndex_ : getNextSelectableIndex(-1, 1);
+    ensureItemVisible(hoveredIndex_);
+    if (onOpen_)
+        onOpen_();
     s_openDropdown = this;
     setDirty(true);
     cacheDirty_ = true;
 }
 
 void NUIDropdown::closeDropdown() {
-    if (!isOpen_) return;
+    if (!isOpen_)
+        return;
     isOpen_ = false;
     hoveredIndex_ = -1;
-    if (onClose_) onClose_();
-    if (s_openDropdown == this) s_openDropdown = nullptr;
+    scrollOffset_ = 0;
+    if (onClose_)
+        onClose_();
+    if (s_openDropdown == this)
+        s_openDropdown = nullptr;
     setDirty(true);
 }
 
@@ -394,15 +474,13 @@ void NUIDropdown::onUpdate(double deltaTime) {
 }
 
 void NUIDropdown::renderDropdownListInternal(NUIRenderer& renderer) {
-    if (items_.empty()) return;
+    if (getVisibleItemCount() == 0)
+        return;
 
     refreshThemeColors();
     const auto& props = NUIThemeManager::getInstance().getCurrentTheme();
-    auto bounds = getBounds();
-    int visibleItems = std::min(maxVisibleItems_, static_cast<int>(items_.size()));
-    float listHeight = itemHeight_ * visibleItems;
-
-    NUIRect dropdownBounds(bounds.x, bounds.y + bounds.height + kDropdownGap, bounds.width, listHeight);
+    const NUIRect dropdownBounds = getDropdownBounds();
+    const int displayedRows = getDisplayedRowCount();
 
     renderer.setOpacity(1.0f);
     renderer.pushTransform(0, 0, 0, 1.0f);
@@ -423,13 +501,16 @@ void NUIDropdown::renderDropdownListInternal(NUIRenderer& renderer) {
     renderer.fillRoundedRect(dropdownBounds, props.radiusL, backgroundColor_.withAlpha(0.985f));
     renderer.strokeRoundedRect(dropdownBounds, props.radiusL, 1.0f, borderColor_);
 
-    for (int i = 0; i < visibleItems && i < static_cast<int>(items_.size()); ++i) {
-        NUIRect itemBounds(dropdownBounds.x, dropdownBounds.y + i * itemHeight_, dropdownBounds.width, itemHeight_);
-        bool isSelected = (i == selectedIndex_);
-        bool isHovered = (i == hoveredIndex_);
-        renderItem(renderer, i, itemBounds, isSelected, isHovered);
+    for (int row = 0; row < displayedRows; ++row) {
+        const int itemIndex = getItemIndexForVisibleRow(scrollOffset_ + row);
+        if (itemIndex < 0)
+            break;
+        NUIRect itemBounds(dropdownBounds.x, dropdownBounds.y + row * itemHeight_, dropdownBounds.width, itemHeight_);
+        bool isSelected = (itemIndex == selectedIndex_);
+        bool isHovered = (itemIndex == hoveredIndex_);
+        renderItem(renderer, itemIndex, itemBounds, isSelected, isHovered);
         
-        if (i < visibleItems - 1) {
+        if (row < displayedRows - 1) {
             float dividerY = itemBounds.y + itemBounds.height;
             float dividerPadding = props.spacingS;
             renderer.drawLine(NUIPoint(itemBounds.x + dividerPadding, dividerY), 
@@ -442,13 +523,11 @@ void NUIDropdown::renderDropdownListInternal(NUIRenderer& renderer) {
 }
 
 void NUIDropdown::renderDropdownList(NUIRenderer& renderer) {
-    if (items_.empty()) return;
+    if (getVisibleItemCount() == 0)
+        return;
     AESTRA_ZONE("Dropdown_RenderList");
 
-    auto bounds = getBounds();
-    int visibleItems = std::min(maxVisibleItems_, static_cast<int>(items_.size()));
-    float listHeight = itemHeight_ * visibleItems;
-    NUIRect dropdownBounds(bounds.x, bounds.y + bounds.height + kDropdownGap, bounds.width, listHeight);
+    const NUIRect dropdownBounds = getDropdownBounds();
 
     if (cachedTextureId_ != 0 && !cacheDirty_) {
         renderer.drawTexture(cachedTextureId_, dropdownBounds, NUIRect(0,0,cachedTextureWidth_, cachedTextureHeight_));
@@ -508,15 +587,104 @@ void NUIDropdown::renderItem(NUIRenderer& renderer, int index, const NUIRect& bo
 }
 
 int NUIDropdown::getItemUnderMouse(const NUIPoint& mousePos) const {
-    if (!isOpen_) return -1;
-    auto bounds = getBounds();
-    int visibleItems = std::min(maxVisibleItems_, static_cast<int>(items_.size()));
-    NUIRect dropdownBounds(bounds.x, bounds.y + bounds.height + kDropdownGap, bounds.width, itemHeight_ * visibleItems);
-    if (!dropdownBounds.contains(mousePos)) return -1;
+    if (!isOpen_)
+        return -1;
+    const NUIRect dropdownBounds = getDropdownBounds();
+    if (!dropdownBounds.contains(mousePos))
+        return -1;
     float localY = mousePos.y - dropdownBounds.y;
-    int index = static_cast<int>(localY / itemHeight_);
-    if (index >= 0 && index < static_cast<int>(items_.size())) return index;
+    const int row = static_cast<int>(localY / itemHeight_);
+    return getItemIndexForVisibleRow(scrollOffset_ + row);
+}
+
+int NUIDropdown::getVisibleItemCount() const {
+    return static_cast<int>(
+        std::count_if(items_.begin(), items_.end(), [](const DropdownItem& item) { return item.visible; }));
+}
+
+int NUIDropdown::getItemIndexForVisibleRow(int row) const {
+    if (row < 0)
+        return -1;
+    int visibleRow = 0;
+    for (int index = 0; index < static_cast<int>(items_.size()); ++index) {
+        if (!items_[index].visible)
+            continue;
+        if (visibleRow == row)
+            return index;
+        ++visibleRow;
+    }
     return -1;
+}
+
+int NUIDropdown::getVisibleRowForItem(int index) const {
+    if (index < 0 || index >= static_cast<int>(items_.size()) || !items_[index].visible)
+        return -1;
+    int visibleRow = 0;
+    for (int current = 0; current < index; ++current) {
+        if (items_[current].visible)
+            ++visibleRow;
+    }
+    return visibleRow;
+}
+
+int NUIDropdown::getDisplayedRowCount() const {
+    return std::min(maxVisibleItems_, getVisibleItemCount());
+}
+
+int NUIDropdown::getNextSelectableIndex(int currentIndex, int direction) const {
+    if (items_.empty() || direction == 0)
+        return -1;
+    const int itemCount = static_cast<int>(items_.size());
+    int index = currentIndex;
+    for (int attempt = 0; attempt < itemCount; ++attempt) {
+        index += direction > 0 ? 1 : -1;
+        if (index >= itemCount)
+            index = 0;
+        if (index < 0)
+            index = itemCount - 1;
+        if (items_[index].visible && items_[index].enabled)
+            return index;
+    }
+    return -1;
+}
+
+NUIRect NUIDropdown::getDropdownBounds() const {
+    const NUIRect bounds = getBounds();
+    const float listHeight = itemHeight_ * getDisplayedRowCount();
+    float y = bounds.bottom() + kDropdownGap;
+
+    const NUIComponent* root = this;
+    while (root->getParent()) {
+        root = root->getParent();
+    }
+    const NUIRect viewport = root->getBounds();
+    const float aboveY = bounds.y - kDropdownGap - listHeight;
+    if (viewport.height > 0.0f && y + listHeight > viewport.bottom() && aboveY >= viewport.y) {
+        y = aboveY;
+    }
+
+    return {bounds.x, y, bounds.width, listHeight};
+}
+
+void NUIDropdown::clampScrollOffset() {
+    const int maxOffset = std::max(0, getVisibleItemCount() - getDisplayedRowCount());
+    scrollOffset_ = std::clamp(scrollOffset_, 0, maxOffset);
+}
+
+void NUIDropdown::ensureItemVisible(int index) {
+    const int row = getVisibleRowForItem(index);
+    if (row < 0) {
+        clampScrollOffset();
+        return;
+    }
+
+    const int displayedRows = getDisplayedRowCount();
+    if (row < scrollOffset_) {
+        scrollOffset_ = row;
+    } else if (row >= scrollOffset_ + displayedRows) {
+        scrollOffset_ = row - displayedRows + 1;
+    }
+    clampScrollOffset();
 }
 
 void NUIDropdown::notifySelectionChanged() {

--- a/AestraUI/Base/NUIDropdown.h
+++ b/AestraUI/Base/NUIDropdown.h
@@ -47,8 +47,8 @@ public:
 
     // Visual configuration
     void setPlaceholderText(const std::string& text) { placeholderText_ = text; setDirty(true); }
-    void setMaxVisibleItems(int count) { maxVisibleItems_ = count; setDirty(true); }
-    void setItemHeight(float height) { itemHeight_ = height; setDirty(true); }
+    void setMaxVisibleItems(int count);
+    void setItemHeight(float height);
     
     // Render dropdown list separately for proper z-order
     void renderDropdownList(NUIRenderer& renderer);
@@ -94,6 +94,14 @@ protected:
 private:
     void renderItem(NUIRenderer& renderer, int index, const NUIRect& bounds, bool isSelected, bool isHovered);
     int getItemUnderMouse(const NUIPoint& mousePos) const;
+    int getVisibleItemCount() const;
+    int getItemIndexForVisibleRow(int row) const;
+    int getVisibleRowForItem(int index) const;
+    int getDisplayedRowCount() const;
+    int getNextSelectableIndex(int currentIndex, int direction) const;
+    NUIRect getDropdownBounds() const;
+    void clampScrollOffset();
+    void ensureItemVisible(int index);
     void notifySelectionChanged();
 
     std::vector<DropdownItem> items_;
@@ -105,6 +113,7 @@ private:
     int maxVisibleItems_ = 5;
     float itemHeight_ = 28.0f;
     int hoveredIndex_ = -1;
+    int scrollOffset_ = 0;
 
     // Colors
     NUIColor backgroundColor_;

--- a/AestraUI/Base/NUIDropdown.h
+++ b/AestraUI/Base/NUIDropdown.h
@@ -41,6 +41,19 @@ public:
     void addItem(const std::string& text, int value, const std::function<void()>& callback);
     void addItem(const DropdownItem& item);
     
+    /**
+     * @brief Show or hide an item.
+     *
+     * Hiding the CURRENTLY SELECTED item clears the selection outright — it does
+     * not retain a hidden logical selection, and it does not advance to another
+     * visible row. Auto-advancing would change the user's choice without asking,
+     * which for a settings control is a silent intent change.
+     *
+     * Consumers must therefore treat "no selection" as a real state. Use
+     * getSelectedItem(), which returns std::nullopt; getSelectedValue() returns
+     * 0 in that state, and 0 is a legal item value, so it cannot distinguish
+     * "nothing selected" from "the item whose value is 0".
+     */
     void setItemVisible(int index, bool visible);
     void setItemEnabled(int index, bool enabled);
     void clearItems();

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -29,6 +29,7 @@ NUIComponent::NUIComponent() {
 }
 
 NUIComponent::~NUIComponent() {
+    hideRemoteTooltip(this);
     if (g_focusedComponent == this) {
         g_focusedComponent = nullptr;
     }
@@ -111,16 +112,7 @@ bool NUIComponent::onMouseEvent(const NUIMouseEvent& event) {
 
     // Update hover state if it changed
     if (wasHovered != shouldBeHovered && !event.cursorCaptured) {
-        // Store the mouse position when hover state changes for tooltip positioning
-        if (shouldBeHovered && !tooltipText_.empty()) {
-            s_tooltipState.hoverPos = event.position;
-        }
         setHovered(shouldBeHovered);
-    }
-    
-    // Update hover position continuously while hovering (for accurate tooltip placement)
-    if (hovered_ && !tooltipText_.empty() && s_tooltipState.text == tooltipText_) {
-        s_tooltipState.hoverPos = event.position;
     }
 
     return eventHandledByChild || eventHandledBySelf;
@@ -155,34 +147,19 @@ void NUIComponent::onFocusLost() {
 
 void NUIComponent::onMouseEnter() {
     hovered_ = true;
-    
-    // Trigger global tooltip if text is set
+
     if (!tooltipText_.empty()) {
-        s_tooltipState.text = tooltipText_;
-        
-        // Get global position for tooltip using localToGlobal for accurate transformation
-        // Calculate center-bottom of this component in local coords, then convert to global
         NUIPoint localCenter(bounds_.width * 0.5f, bounds_.height + 6.0f);
-        NUIPoint globalPos = localToGlobal(localCenter);
-        s_tooltipState.position = globalPos;
-        
-        s_tooltipState.active = true;
-        s_tooltipState.delayTimer = 0.0f; // Reset delay
-        s_tooltipState.alpha = 0.0f; // Start faded out
+        showRemoteTooltip(tooltipText_, localToGlobal(localCenter), this);
     }
-    
+
     setDirty();
 }
 
 void NUIComponent::onMouseLeave() {
     hovered_ = false;
-    
-    // Hide tooltip if this component was the source (simple check)
-    // In a complex system we might check if s_tooltipState.text == tooltipText_
-    if (!tooltipText_.empty() && s_tooltipState.text == tooltipText_) {
-        s_tooltipState.active = false;
-    }
-    
+    hideRemoteTooltip(this);
+
     setDirty();
 }
 
@@ -383,6 +360,10 @@ NUIPoint NUIComponent::globalToLocal(const NUIPoint& global) const {
 void NUIComponent::setVisible(bool visible) {
     if (visible_ != visible) {
         visible_ = visible;
+        if (!visible_) {
+            setHovered(false);
+            hideRemoteTooltip(this);
+        }
         setDirty();
     }
 }
@@ -432,7 +413,8 @@ void NUIComponent::clearFocusedComponent() {
 }
 
 void NUIComponent::setHovered(bool hovered) {
-    if (s_cursorCaptureActive) return;
+    if (s_cursorCaptureActive && hovered)
+        return;
     if (hovered_ != hovered) {
         hovered_ = hovered;
         if (hovered) {
@@ -534,29 +516,49 @@ std::shared_ptr<NUIComponent> NUIComponent::findChildAt(const NUIPoint& point) {
     return nullptr;
 }
 
-
-
 // ============================================================================
 // Tooltip Implementation
 // ============================================================================
 
 void NUIComponent::setTooltip(const std::string& text) {
+    if (tooltipText_ == text)
+        return;
+    hideRemoteTooltip(this);
     tooltipText_ = text;
+    if (hovered_ && !tooltipText_.empty()) {
+        const NUIPoint localCenter(bounds_.width * 0.5f, bounds_.height + 6.0f);
+        showRemoteTooltip(tooltipText_, localToGlobal(localCenter), this);
+    }
 }
 
 void NUIComponent::showRemoteTooltip(const std::string& text, const NUIPoint& position, const void* owner, bool force) {
-    // Suppress all tooltips during hidden-cursor drag unless forced
-    if (!force && s_cursorCaptureActive) return;
+    constexpr float kTooltipDelaySeconds = 0.45f;
 
-    const bool wasActive = s_tooltipState.active;
-    s_tooltipState.text = text;
-    s_tooltipState.position = position;
-    s_tooltipState.hoverPos = position;  // Set both for manual tooltip calls
-    s_tooltipState.owner = owner;
-    s_tooltipState.active = true;
-    if (!wasActive) {
+    if (text.empty()) {
+        hideRemoteTooltip(owner);
+        return;
+    }
+
+    if (!force && s_cursorCaptureActive)
+        return;
+
+    const bool ownerChanged = !s_tooltipState.active || s_tooltipState.owner != owner;
+    const bool contentChanged = s_tooltipState.text != text;
+    const bool shouldRestart = ownerChanged || (contentChanged && !force);
+
+    if (shouldRestart) {
+        s_tooltipState.text = text;
+        s_tooltipState.position = position;
+        s_tooltipState.owner = owner;
+        s_tooltipState.active = true;
+        s_tooltipState.immediate = force;
         s_tooltipState.delayTimer = 0.0f;
         s_tooltipState.alpha = 0.0f;
+    } else if (force) {
+        s_tooltipState.text = text;
+        s_tooltipState.position = position;
+        s_tooltipState.immediate = true;
+        s_tooltipState.delayTimer = kTooltipDelaySeconds;
     }
 }
 
@@ -564,62 +566,89 @@ void NUIComponent::hideRemoteTooltip(const void* owner) {
     if (owner != nullptr && s_tooltipState.owner != owner) {
         return;
     }
-    if (owner == nullptr && s_tooltipState.owner != nullptr) {
-        return;
-    }
     s_tooltipState.active = false;
     s_tooltipState.owner = nullptr;
+    s_tooltipState.immediate = false;
+    s_tooltipState.alpha = 0.0f;
+    s_tooltipState.delayTimer = 0.0f;
 }
 
 void NUIComponent::updateGlobalTooltip(double deltaTime) {
+    constexpr float kTooltipDelaySeconds = 0.45f;
+    constexpr float kFadeSpeed = 8.0f;
+
     if (s_tooltipState.active) {
-        // Fade in
-        const float FADE_SPEED = 5.0f;
-        s_tooltipState.alpha = std::min(1.0f, s_tooltipState.alpha + static_cast<float>(deltaTime * FADE_SPEED));
+        s_tooltipState.delayTimer += static_cast<float>(std::max(0.0, deltaTime));
+        if (s_tooltipState.immediate || s_tooltipState.delayTimer >= kTooltipDelaySeconds) {
+            s_tooltipState.alpha =
+                std::min(1.0f, s_tooltipState.alpha + static_cast<float>(std::max(0.0, deltaTime) * kFadeSpeed));
+        }
     } else {
-         s_tooltipState.alpha = 0.0f; // Instant hide for responsiveness
+        s_tooltipState.alpha = 0.0f;
     }
 }
 
+NUIRect NUIComponent::calculateTooltipBounds(const NUIPoint& anchor, const NUISize& tooltipSize,
+                                             const NUIRect& viewport) {
+    constexpr float kMargin = 4.0f;
+    float x = anchor.x + 10.0f;
+    float y = anchor.y - tooltipSize.height - 6.0f;
 
+    const bool hasViewport = viewport.width > 0.0f && viewport.height > 0.0f;
+    const float top = hasViewport ? viewport.y + kMargin : kMargin;
+    if (y < top) {
+        y = anchor.y + 16.0f;
+    }
 
-void NUIComponent::renderGlobalTooltip(NUIRenderer& renderer) {
-    if (!s_tooltipState.active || s_tooltipState.alpha <= 0.01f) return;
+    if (hasViewport) {
+        const float left = viewport.x + kMargin;
+        const float right = viewport.right() - kMargin;
+        const float bottom = viewport.bottom() - kMargin;
+        x = std::clamp(x, left, std::max(left, right - tooltipSize.width));
+        y = std::clamp(y, top, std::max(top, bottom - tooltipSize.height));
+    } else {
+        x = std::max(kMargin, x);
+        y = std::max(kMargin, y);
+    }
+
+    return {x, y, tooltipSize.width, tooltipSize.height};
+}
+
+void NUIComponent::renderGlobalTooltip(NUIRenderer& renderer, const NUIRect& viewport) {
+    if (!s_tooltipState.active || s_tooltipState.alpha <= 0.01f)
+        return;
     auto& theme = NUIThemeManager::getInstance();
     const auto& props = theme.getCurrentTheme();
-    
-    // Reuse minimap tooltip pattern - position relative to hoverPos (actual mouse position)
+
+    // Reuse the compact minimap tooltip styling around the stable hover anchor.
     const float tooltipPadX = props.spacingS;
     const float tooltipPadY = props.spacingXS;
     const float tooltipRadius = props.radiusS;
     const float fontSize = props.fontSizeXS;
     const auto size = renderer.measureText(s_tooltipState.text, fontSize);
-    
+
     const float w = size.width + tooltipPadX * 2.0f;
     const float h = size.height + tooltipPadY * 2.0f;
-    
-    // Position: offset from mouse cursor (like minimap tooltip)
-    float x = s_tooltipState.hoverPos.x + 10.0f;
-    float y = s_tooltipState.hoverPos.y - h - 6.0f;
-    
-    // If tooltip would go above screen, show below cursor instead
-    if (y < 4.0f) {
-        y = s_tooltipState.hoverPos.y + 16.0f;
-    }
-    
-    // Clamp to reasonable screen bounds
-    if (x < 4.0f) x = 4.0f;
-    
-    const NUIRect tipRect(x, y, w, h);
-    
+
+    const NUIRect tipRect = calculateTooltipBounds(s_tooltipState.position, {w, h}, viewport);
+
     // Theme colors (matching minimap style)
     const NUIColor bg = theme.getColor("elevatedPanel").withAlpha(0.98f * s_tooltipState.alpha);
     const NUIColor border = theme.getColor("borderStrong").withAlpha(0.88f * s_tooltipState.alpha);
     const NUIColor text = theme.getColor("textPrimary").withAlpha(0.96f * s_tooltipState.alpha);
-    
+
     renderer.fillRoundedRect(tipRect, tooltipRadius, bg);
     renderer.strokeRoundedRect(tipRect, tooltipRadius, props.layout.dividerWidth, border);
     renderer.drawTextCentered(s_tooltipState.text, tipRect, fontSize, text);
+}
+
+void NUIComponent::setCursorCaptureActive(bool active) {
+    if (s_cursorCaptureActive == active)
+        return;
+    s_cursorCaptureActive = active;
+    if (active) {
+        hideRemoteTooltip();
+    }
 }
 
 } // namespace AestraUI

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -542,6 +542,20 @@ void NUIComponent::showRemoteTooltip(const std::string& text, const NUIPoint& po
     if (!force && s_cursorCaptureActive)
         return;
 
+    const bool canResumePendingDismiss = !s_tooltipState.active && s_tooltipState.dismissGraceTimer > 0.0f &&
+        owner != nullptr &&
+        s_tooltipState.owner == owner && s_tooltipState.text == text;
+    if (canResumePendingDismiss) {
+        s_tooltipState.active = true;
+        s_tooltipState.dismissGraceTimer = 0.0f;
+        if (force) {
+            s_tooltipState.position = position;
+            s_tooltipState.immediate = true;
+            s_tooltipState.delayTimer = kTooltipDelaySeconds;
+        }
+        return;
+    }
+
     const bool ownerChanged = !s_tooltipState.active || s_tooltipState.owner != owner;
     const bool contentChanged = s_tooltipState.text != text;
     const bool shouldRestart = ownerChanged || (contentChanged && !force);
@@ -554,6 +568,7 @@ void NUIComponent::showRemoteTooltip(const std::string& text, const NUIPoint& po
         s_tooltipState.immediate = force;
         s_tooltipState.delayTimer = 0.0f;
         s_tooltipState.alpha = 0.0f;
+        s_tooltipState.dismissGraceTimer = 0.0f;
     } else if (force) {
         s_tooltipState.text = text;
         s_tooltipState.position = position;
@@ -563,7 +578,17 @@ void NUIComponent::showRemoteTooltip(const std::string& text, const NUIPoint& po
 }
 
 void NUIComponent::hideRemoteTooltip(const void* owner) {
+    constexpr float kDismissGraceSeconds = 0.50f;
+
     if (owner != nullptr && s_tooltipState.owner != owner) {
+        return;
+    }
+    if (owner != nullptr) {
+        // Keep a short resume window. Complex components can route adjacent
+        // pointer events through multiple internal tooltip regions; the same
+        // owner may reassert the tooltip without restarting its delay or fade.
+        s_tooltipState.active = false;
+        s_tooltipState.dismissGraceTimer = kDismissGraceSeconds;
         return;
     }
     s_tooltipState.active = false;
@@ -571,6 +596,7 @@ void NUIComponent::hideRemoteTooltip(const void* owner) {
     s_tooltipState.immediate = false;
     s_tooltipState.alpha = 0.0f;
     s_tooltipState.delayTimer = 0.0f;
+    s_tooltipState.dismissGraceTimer = 0.0f;
 }
 
 void NUIComponent::updateGlobalTooltip(double deltaTime) {
@@ -578,13 +604,21 @@ void NUIComponent::updateGlobalTooltip(double deltaTime) {
     constexpr float kFadeSpeed = 8.0f;
 
     if (s_tooltipState.active) {
+        s_tooltipState.dismissGraceTimer = 0.0f;
         s_tooltipState.delayTimer += static_cast<float>(std::max(0.0, deltaTime));
         if (s_tooltipState.immediate || s_tooltipState.delayTimer >= kTooltipDelaySeconds) {
             s_tooltipState.alpha =
                 std::min(1.0f, s_tooltipState.alpha + static_cast<float>(std::max(0.0, deltaTime) * kFadeSpeed));
         }
     } else {
-        s_tooltipState.alpha = 0.0f;
+        s_tooltipState.dismissGraceTimer -= static_cast<float>(std::max(0.0, deltaTime));
+        if (s_tooltipState.dismissGraceTimer <= 0.0f) {
+            s_tooltipState.alpha = 0.0f;
+            s_tooltipState.owner = nullptr;
+            s_tooltipState.immediate = false;
+            s_tooltipState.delayTimer = 0.0f;
+            s_tooltipState.dismissGraceTimer = 0.0f;
+        }
     }
 }
 

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -36,6 +36,7 @@ struct TooltipState {
     bool immediate = false;
     float alpha = 0.0f;
     float delayTimer = 0.0f;
+    float dismissGraceTimer = 0.0f;
 };
 
 /**

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -31,9 +31,9 @@ enum class NUILayer {
 struct TooltipState {
     std::string text;
     NUIPoint position;
-    NUIPoint hoverPos;  // Actual mouse position when tooltip was triggered
     const void* owner = nullptr;
     bool active = false;
+    bool immediate = false;
     float alpha = 0.0f;
     float delayTimer = 0.0f;
 };
@@ -186,9 +186,12 @@ public:
     // Global Tooltip Management
     static void showRemoteTooltip(const std::string& text, const NUIPoint& position, const void* owner = nullptr, bool force = false);
     static void hideRemoteTooltip(const void* owner = nullptr);
-    static void renderGlobalTooltip(NUIRenderer& renderer);
+    static void renderGlobalTooltip(NUIRenderer& renderer, const NUIRect& viewport = {});
     static void updateGlobalTooltip(double deltaTime);
-    static void setCursorCaptureActive(bool active) { s_cursorCaptureActive = active; }
+    static NUIRect calculateTooltipBounds(const NUIPoint& anchor, const NUISize& tooltipSize,
+                                          const NUIRect& viewport);
+    static const TooltipState& getGlobalTooltipState() { return s_tooltipState; }
+    static void setCursorCaptureActive(bool active);
     static bool isCursorCaptureActive() { return s_cursorCaptureActive; }
 
 };

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -3846,7 +3846,10 @@ bool FileBrowser::handleNavigationMouseEvent(const NUIMouseEvent& event, const B
         NUIPoint tooltipPosition = event.position;
         tooltipPosition.x = layout.navPane.right() + 8.0f;
         NUIComponent::showRemoteTooltip(navHits_[newHovered].label, tooltipPosition, this);
-    } else if (newHovered < 0 || !usesCompactNavigation()) {
+    } else if (layout.navPane.contains(event.position)) {
+        // Only dismiss the navigation tooltip while the pointer is still in
+        // this region. The file list shares this component as its tooltip
+        // owner and will manage its own tooltip outside the navigation pane.
         NUIComponent::hideRemoteTooltip(this);
     }
 

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -377,7 +377,7 @@ void TimelineMinimapBar::onMouseLeave()
     hoverInMap_ = false;
     hoverToggleIndex_ = -1;
     hoverOnResizeEdge_ = false;
-    AestraUI::NUIComponent::hideRemoteTooltip();
+    AestraUI::NUIComponent::hideRemoteTooltip(this);
     if (dragKind_ == DragKind::ResizeLeft || dragKind_ == DragKind::ResizeRight) {
         cursorHint_ = TimelineMinimapCursorHint::ResizeHorizontal;
     } else {
@@ -401,7 +401,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
         hoverToggleIndex_ = -1;
         hoverOnResizeEdge_ = false;
         cursorHint_ = TimelineMinimapCursorHint::Default;
-        AestraUI::NUIComponent::hideRemoteTooltip();
+        AestraUI::NUIComponent::hideRemoteTooltip(this);
         repaint();
         return false;
     }
@@ -446,16 +446,16 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
             if (hoverToggleIndex_ == 0) text = "C: Clips (where audio/MIDI exists)";
             else if (hoverToggleIndex_ == 1) text = "E: Energy (approx. loudness per region)";
             else text = "A: Automation (where automation exists)";
-            AestraUI::NUIComponent::showRemoteTooltip(text, event.position);
+            AestraUI::NUIComponent::showRemoteTooltip(text, event.position, this);
         } else if (hoverInMap_) {
-            AestraUI::NUIComponent::showRemoteTooltip(formatHoverText_(hoverBeat_), event.position);
+            AestraUI::NUIComponent::showRemoteTooltip(formatHoverText_(hoverBeat_), event.position, this);
         } else {
-            AestraUI::NUIComponent::hideRemoteTooltip();
+            AestraUI::NUIComponent::hideRemoteTooltip(this);
         }
     } else {
         // Clear any stale minimap tooltip shown before capture started
         // (won't clear component-owned tooltips like volume knob's)
-        AestraUI::NUIComponent::hideRemoteTooltip();
+        AestraUI::NUIComponent::hideRemoteTooltip(this);
     }
 
     // Mode toggles.

--- a/Source/Core/AestraRootComponent.h
+++ b/Source/Core/AestraRootComponent.h
@@ -86,7 +86,7 @@ public:
         // Audio settings dialog is handled by its own render method
         
         // Fix: Render global tooltips last so they appear on top of everything
-        NUIComponent::renderGlobalTooltip(renderer);
+        NUIComponent::renderGlobalTooltip(renderer, getBounds());
     }
     
     bool onKeyEvent(const NUIKeyEvent& event) override;

--- a/Tests/AestraUI/NUIComponentTooltipTest.cpp
+++ b/Tests/AestraUI/NUIComponentTooltipTest.cpp
@@ -80,6 +80,39 @@ void testOwnerlessHideIsAnUnconditionalGlobalDismiss() {
     check(!NUIComponent::getGlobalTooltipState().active, "ownerless hide dismisses an owner-scoped tooltip");
 }
 
+void testDifferentOwnerCannotDismissTooltip() {
+    resetTooltip();
+    int tooltipOwner = 0;
+    int unrelatedOwner = 0;
+    NUIComponent::showRemoteTooltip("Owned", {10.0f, 10.0f}, &tooltipOwner, true);
+    NUIComponent::hideRemoteTooltip(&unrelatedOwner);
+    check(NUIComponent::getGlobalTooltipState().active, "unrelated components cannot dismiss an owned tooltip");
+    check(NUIComponent::getGlobalTooltipState().owner == &tooltipOwner, "the original owner remains active");
+}
+
+void testSameOwnerCanReassertWithinResumeWindow() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("Stable", {10.0f, 10.0f}, &owner);
+    NUIComponent::updateGlobalTooltip(0.60);
+    const float visibleAlpha = NUIComponent::getGlobalTooltipState().alpha;
+
+    NUIComponent::hideRemoteTooltip(&owner);
+    NUIComponent::updateGlobalTooltip(0.25);
+    NUIComponent::showRemoteTooltip("Stable", {30.0f, 30.0f}, &owner);
+    const auto& resumed = NUIComponent::getGlobalTooltipState();
+    check(resumed.active, "same owner can reassert a tooltip after a brief routing gap");
+    check(resumed.alpha == visibleAlpha, "brief same-owner reassertion preserves visible opacity");
+    check(resumed.position.x == 10.0f && resumed.position.y == 10.0f,
+          "brief same-owner reassertion preserves the stable anchor");
+
+    NUIComponent::hideRemoteTooltip(&owner);
+    NUIComponent::updateGlobalTooltip(0.51);
+    const auto& cleared = NUIComponent::getGlobalTooltipState();
+    check(!cleared.active && cleared.owner == nullptr && cleared.alpha == 0.0f,
+          "an owner-scoped hide clears after the resume window expires");
+}
+
 void testCaptureDismissesHoverTooltipButForcedReadoutCanShow() {
     resetTooltip();
     int owner = 0;
@@ -114,6 +147,8 @@ int main() {
     testTextChangeForSameHoverOwnerRestartsDelay();
     testForcedReadoutKeepsOpacityAcrossValueChanges();
     testOwnerlessHideIsAnUnconditionalGlobalDismiss();
+    testDifferentOwnerCannotDismissTooltip();
+    testSameOwnerCanReassertWithinResumeWindow();
     testCaptureDismissesHoverTooltipButForcedReadoutCanShow();
     testTooltipBoundsStayInsideViewportEdges();
 

--- a/Tests/AestraUI/NUIComponentTooltipTest.cpp
+++ b/Tests/AestraUI/NUIComponentTooltipTest.cpp
@@ -1,0 +1,128 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// Regression coverage for the shared global tooltip lifecycle and placement.
+
+#include "NUIComponent.h"
+
+#include <iostream>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+void resetTooltip() {
+    NUIComponent::setCursorCaptureActive(false);
+    NUIComponent::hideRemoteTooltip();
+}
+
+void testHoverTooltipsWaitForStableIntent() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("Delayed", {20.0f, 20.0f}, &owner);
+    NUIComponent::updateGlobalTooltip(0.20);
+    check(NUIComponent::getGlobalTooltipState().alpha == 0.0f, "tooltip remains hidden during hover delay");
+
+    NUIComponent::showRemoteTooltip("Delayed", {80.0f, 80.0f}, &owner);
+    NUIComponent::updateGlobalTooltip(0.26);
+    const auto& state = NUIComponent::getGlobalTooltipState();
+    check(state.alpha > 0.0f, "repeated show calls do not restart the hover delay");
+    check(state.position.x == 20.0f && state.position.y == 20.0f, "visible tooltip keeps a stable anchor");
+}
+
+void testOwnershipHandoffRestartsTooltip() {
+    resetTooltip();
+    int firstOwner = 0;
+    int secondOwner = 0;
+    NUIComponent::showRemoteTooltip("First", {10.0f, 10.0f}, &firstOwner);
+    NUIComponent::updateGlobalTooltip(0.60);
+    check(NUIComponent::getGlobalTooltipState().alpha > 0.0f, "first owner tooltip became visible");
+
+    NUIComponent::showRemoteTooltip("Second", {30.0f, 40.0f}, &secondOwner);
+    const auto& state = NUIComponent::getGlobalTooltipState();
+    check(state.alpha == 0.0f, "owner handoff does not morph an already-visible tooltip");
+    check(state.owner == &secondOwner, "new owner controls the tooltip");
+    check(state.position.x == 30.0f && state.position.y == 40.0f, "owner handoff adopts the new anchor");
+}
+
+void testTextChangeForSameHoverOwnerRestartsDelay() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("First row", {10.0f, 10.0f}, &owner);
+    NUIComponent::updateGlobalTooltip(0.60);
+    NUIComponent::showRemoteTooltip("Second row", {30.0f, 40.0f}, &owner);
+    check(NUIComponent::getGlobalTooltipState().alpha == 0.0f, "new hover content restarts the delay");
+}
+
+void testForcedReadoutKeepsOpacityAcrossValueChanges() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("Value 10", {10.0f, 10.0f}, &owner, true);
+    NUIComponent::updateGlobalTooltip(0.10);
+    const float previousAlpha = NUIComponent::getGlobalTooltipState().alpha;
+    NUIComponent::showRemoteTooltip("Value 11", {12.0f, 12.0f}, &owner, true);
+    check(NUIComponent::getGlobalTooltipState().alpha == previousAlpha,
+          "forced value changes do not flicker by resetting opacity");
+}
+
+void testOwnerlessHideIsAnUnconditionalGlobalDismiss() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("Owned", {10.0f, 10.0f}, &owner, true);
+    NUIComponent::hideRemoteTooltip();
+    check(!NUIComponent::getGlobalTooltipState().active, "ownerless hide dismisses an owner-scoped tooltip");
+}
+
+void testCaptureDismissesHoverTooltipButForcedReadoutCanShow() {
+    resetTooltip();
+    int owner = 0;
+    NUIComponent::showRemoteTooltip("Hover", {10.0f, 10.0f}, &owner);
+    NUIComponent::setCursorCaptureActive(true);
+    check(!NUIComponent::getGlobalTooltipState().active, "cursor capture dismisses the hover tooltip");
+
+    NUIComponent::showRemoteTooltip("Drag value", {14.0f, 16.0f}, &owner, true);
+    NUIComponent::updateGlobalTooltip(0.016);
+    check(NUIComponent::getGlobalTooltipState().alpha > 0.0f, "forced drag readout bypasses hover delay");
+    resetTooltip();
+}
+
+void testTooltipBoundsStayInsideViewportEdges() {
+    const NUIRect viewport(0.0f, 0.0f, 320.0f, 180.0f);
+    const NUISize tooltipSize(100.0f, 30.0f);
+
+    const NUIRect topRight = NUIComponent::calculateTooltipBounds({315.0f, 3.0f}, tooltipSize, viewport);
+    check(topRight.x >= 4.0f && topRight.right() <= 316.0f, "right-edge tooltip is horizontally clamped");
+    check(topRight.y >= 4.0f && topRight.bottom() <= 176.0f, "top-edge tooltip flips and stays vertically clamped");
+
+    const NUIRect bottomRight = NUIComponent::calculateTooltipBounds({319.0f, 179.0f}, tooltipSize, viewport);
+    check(bottomRight.right() <= 316.0f, "bottom-right tooltip stays inside right edge");
+    check(bottomRight.bottom() <= 176.0f, "bottom-right tooltip stays inside bottom edge");
+}
+
+} // namespace
+
+int main() {
+    testHoverTooltipsWaitForStableIntent();
+    testOwnershipHandoffRestartsTooltip();
+    testTextChangeForSameHoverOwnerRestartsDelay();
+    testForcedReadoutKeepsOpacityAcrossValueChanges();
+    testOwnerlessHideIsAnUnconditionalGlobalDismiss();
+    testCaptureDismissesHoverTooltipButForcedReadoutCanShow();
+    testTooltipBoundsStayInsideViewportEdges();
+
+    resetTooltip();
+    if (g_failures != 0) {
+        std::cout << g_failures << " tooltip check(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "All global tooltip checks passed\n";
+    return 0;
+}

--- a/Tests/AestraUI/NUIDropdownInteractionTest.cpp
+++ b/Tests/AestraUI/NUIDropdownInteractionTest.cpp
@@ -156,6 +156,38 @@ void testHidingSelectionDoesNotLeaveInvisibleValueDisplayed() {
     dropdown->setItemVisible(1, false);
 
     check(dropdown->getSelectedIndex() == -1, "hiding the selected item clears stale selection");
+
+    // Pin what the two value accessors report in the no-selection state, not
+    // just the index. This is the product policy, and a consumer has already
+    // depended on it: getSelectedValue() returns 0 here, which is
+    // indistinguishable from the item whose value IS 0, so it cannot be used to
+    // detect "nothing selected". getSelectedItem() is the accessor that can say
+    // nothing without inventing a legal-looking value. PR #657 persists audio
+    // device ids and would have written this 0 over a real device.
+    check(!dropdown->getSelectedItem().has_value(),
+          "no selection reports std::nullopt — the unambiguous accessor");
+    check(dropdown->getSelectedValue() == 0,
+          "getSelectedValue() reports 0 with nothing selected; it is NOT a selection signal");
+
+    // The other half of the discriminator: a genuine selection whose value is 0
+    // must be reportable, so consumers cannot special-case 0 as "absent".
+    auto zeroValued = makeDropdown();
+    zeroValued->addItem("Device zero", 0);
+    zeroValued->setSelectedIndex(0);
+    check(zeroValued->getSelectedItem().has_value(), "a real selection reports a value");
+    check(zeroValued->getSelectedValue() == 0, "a real selection of value 0 reports 0");
+
+    // Hiding must clear the selection rather than silently moving it to another
+    // visible row. Auto-advancing would change the user's choice without asking,
+    // which for a settings control is a silent intent change.
+    auto multi = makeDropdown();
+    multi->addItem("First", 1);
+    multi->addItem("Chosen", 2);
+    multi->addItem("Third", 3);
+    multi->setSelectedIndex(1);
+    multi->setItemVisible(1, false);
+    check(multi->getSelectedIndex() == -1, "hiding the selection does not auto-advance to a neighbour");
+    check(!multi->getSelectedItem().has_value(), "and leaves no phantom selection behind");
 }
 
 } // namespace

--- a/Tests/AestraUI/NUIDropdownInteractionTest.cpp
+++ b/Tests/AestraUI/NUIDropdownInteractionTest.cpp
@@ -1,0 +1,179 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// Regression coverage for shared select/dropdown interaction behavior.
+
+#include "NUIDropdown.h"
+
+#include <iostream>
+#include <memory>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+NUIMouseEvent leftPress(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent wheel(float x, float y, float delta) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Scroll;
+    event.position = {x, y};
+    event.wheelDelta = delta;
+    return event;
+}
+
+NUIKeyEvent keyPress(NUIKeyCode key) {
+    NUIKeyEvent event;
+    event.keyCode = key;
+    event.pressed = true;
+    return event;
+}
+
+std::shared_ptr<NUIDropdown> makeDropdown(float x = 10.0f) {
+    auto dropdown = std::make_shared<NUIDropdown>();
+    dropdown->setBounds(x, 10.0f, 140.0f, 32.0f);
+    return dropdown;
+}
+
+void open(const std::shared_ptr<NUIDropdown>& dropdown) {
+    const auto bounds = dropdown->getBounds();
+    check(dropdown->onMouseEvent(leftPress(bounds.x + 4.0f, bounds.y + 4.0f)), "trigger press handled");
+    check(dropdown->isOpen(), "dropdown opened");
+}
+
+void testHiddenRowsDoNotOccupyMenuSlots() {
+    auto dropdown = makeDropdown();
+    dropdown->addItem("Hidden", 0);
+    dropdown->addItem("First visible", 1);
+    dropdown->addItem("Second visible", 2);
+    dropdown->setItemVisible(0, false);
+
+    open(dropdown);
+    check(dropdown->onMouseEvent(leftPress(20.0f, 50.0f)), "visible row press handled");
+    check(dropdown->getSelectedValue() == 1, "first rendered row maps to first visible item");
+}
+
+void testDisabledRowsDoNotDismissMenu() {
+    auto dropdown = makeDropdown();
+    dropdown->addItem("Disabled", 0);
+    dropdown->addItem("Enabled", 1);
+    dropdown->setItemEnabled(0, false);
+
+    open(dropdown);
+    check(dropdown->onMouseEvent(leftPress(20.0f, 50.0f)), "disabled row press consumed");
+    check(dropdown->isOpen(), "disabled row does not dismiss the menu");
+    check(dropdown->getSelectedIndex() == -1, "disabled row is not selected");
+}
+
+void testKeyboardNavigationPreviewsAndSkipsUnavailableItems() {
+    auto dropdown = makeDropdown();
+    dropdown->addItem("Current", 0);
+    dropdown->addItem("Hidden", 1);
+    dropdown->addItem("Disabled", 2);
+    dropdown->addItem("Next", 3);
+    dropdown->setItemVisible(1, false);
+    dropdown->setItemEnabled(2, false);
+    dropdown->setSelectedIndex(0);
+    dropdown->setFocused(true);
+    int callbackCount = 0;
+    dropdown->setOnSelectionChanged([&callbackCount](int) { ++callbackCount; });
+
+    open(dropdown);
+    check(dropdown->onKeyEvent(keyPress(NUIKeyCode::Down)), "down key handled");
+    check(dropdown->getSelectedValue() == 0, "navigation does not commit before confirmation");
+    check(callbackCount == 0, "navigation preview does not fire selection callbacks");
+    check(dropdown->onKeyEvent(keyPress(NUIKeyCode::Enter)), "enter key handled");
+    check(dropdown->getSelectedValue() == 3, "enter commits the next enabled visible item");
+    check(callbackCount == 1, "confirmation fires one selection callback");
+    check(!dropdown->isOpen(), "enter closes after committing");
+}
+
+void testLongMenusScrollToReachEveryItem() {
+    auto dropdown = makeDropdown();
+    dropdown->setMaxVisibleItems(2);
+    dropdown->addItem("Zero", 0);
+    dropdown->addItem("One", 1);
+    dropdown->addItem("Two", 2);
+    dropdown->addItem("Three", 3);
+
+    open(dropdown);
+    check(dropdown->onMouseEvent(wheel(20.0f, 60.0f, -1.0f)), "menu wheel handled");
+    check(dropdown->onMouseEvent(leftPress(20.0f, 80.0f)), "scrolled row press handled");
+    check(dropdown->getSelectedValue() == 2, "scroll exposes and selects items beyond the initial window");
+}
+
+void testSwitchingDropdownsTakesOneClick() {
+    auto root = std::make_shared<NUIComponent>();
+    root->setBounds(0.0f, 0.0f, 400.0f, 200.0f);
+    auto first = makeDropdown(10.0f);
+    auto second = makeDropdown(170.0f);
+    first->addItem("A", 1);
+    second->addItem("B", 2);
+    root->addChild(first);
+    root->addChild(second);
+
+    check(root->onMouseEvent(leftPress(14.0f, 14.0f)), "first trigger press handled through parent");
+    check(first->isOpen(), "first dropdown opened through parent");
+    check(root->onMouseEvent(leftPress(174.0f, 14.0f)), "second trigger press handled through parent");
+    check(!first->isOpen(), "opening another dropdown closes the previous one");
+    check(second->isOpen(), "second dropdown opens on the same click");
+}
+
+void testMenuFlipsAboveWhenLowerViewportEdgeIsTight() {
+    auto root = std::make_shared<NUIComponent>();
+    root->setBounds(0.0f, 0.0f, 300.0f, 160.0f);
+    auto dropdown = std::make_shared<NUIDropdown>();
+    dropdown->setBounds(10.0f, 120.0f, 140.0f, 32.0f);
+    dropdown->addItem("First", 1);
+    dropdown->addItem("Second", 2);
+    root->addChild(dropdown);
+
+    check(root->onMouseEvent(leftPress(14.0f, 124.0f)), "bottom-edge trigger press handled");
+    check(dropdown->isOpen(), "bottom-edge dropdown opened");
+    check(root->onMouseEvent(leftPress(20.0f, 66.0f)), "row above the trigger handled");
+    check(dropdown->getSelectedValue() == 1, "menu flips above instead of rendering beyond viewport");
+}
+
+void testHidingSelectionDoesNotLeaveInvisibleValueDisplayed() {
+    auto dropdown = makeDropdown();
+    dropdown->addItem("Visible", 1);
+    dropdown->addItem("Will hide", 2);
+    dropdown->setSelectedIndex(1);
+    dropdown->setItemVisible(1, false);
+
+    check(dropdown->getSelectedIndex() == -1, "hiding the selected item clears stale selection");
+}
+
+} // namespace
+
+int main() {
+    testHiddenRowsDoNotOccupyMenuSlots();
+    testDisabledRowsDoNotDismissMenu();
+    testKeyboardNavigationPreviewsAndSkipsUnavailableItems();
+    testLongMenusScrollToReachEveryItem();
+    testSwitchingDropdownsTakesOneClick();
+    testMenuFlipsAboveWhenLowerViewportEdgeIsTight();
+    testHidingSelectionDoesNotLeaveInvisibleValueDisplayed();
+
+    if (g_failures != 0) {
+        std::cout << g_failures << " dropdown interaction check(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "All dropdown interaction checks passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1699,6 +1699,27 @@ else()
     message(STATUS "NUITextInputLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+if(TARGET AestraUI_Core)
+    add_executable(NUIDropdownInteractionTest AestraUI/NUIDropdownInteractionTest.cpp)
+    target_link_libraries(NUIDropdownInteractionTest PRIVATE AestraUI_Core)
+    target_include_directories(NUIDropdownInteractionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+    )
+    add_test(NAME NUIDropdownInteractionTest COMMAND NUIDropdownInteractionTest)
+    set_tests_properties(NUIDropdownInteractionTest PROPERTIES LABELS "ui;dropdown;regression")
+
+    add_executable(NUIComponentTooltipTest AestraUI/NUIComponentTooltipTest.cpp)
+    target_link_libraries(NUIComponentTooltipTest PRIVATE AestraUI_Core)
+    target_include_directories(NUIComponentTooltipTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+    )
+    add_test(NAME NUIComponentTooltipTest COMMAND NUIComponentTooltipTest)
+    set_tests_properties(NUIComponentTooltipTest PROPERTIES LABELS "ui;tooltip;regression")
+else()
+    message(STATUS "Dropdown/tooltip interaction tests skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # No EXISTS guard: a missing committed test source must fail configure, not
 # silently drop coverage (repo policy since #454/#463).
 add_executable(MusicalTypingControllerTest


### PR DESCRIPTION
## Summary
- repair the shared dropdown so hidden/disabled items map correctly, long menus scroll, keyboard navigation previews before commit, sibling selects switch in one click, and lower-edge menus flip above
- make global tooltip ownership deterministic with delayed stable hover tips, forced drag readouts, viewport clamping, cursor-capture dismissal, and a brief same-owner resume window
- stop the timeline minimap and File Browser navigation region from clearing tooltips owned by unrelated or adjacent UI regions
- add focused dropdown and tooltip regression suites

## Why
Select controls could render or hit-test hidden rows, dismiss on disabled rows, commit during keyboard navigation, strand options beyond `maxVisibleItems`, and require two clicks to switch between sibling controls. Tooltips could flicker or morph across owners, chase the pointer, survive global dismissal/capture, render off-screen, and be erased by unrelated minimap or browser-region pointer handling.

## Testing performed
- established a red baseline: `NUIDropdownInteractionTest` produced 10 targeted failures before the fix, then passed after implementation
- `cmake --build build-select-tooltip --target Aestra -j2`
- `ctest --test-dir build-select-tooltip --output-on-failure -R 'NUIDropdownInteractionTest|NUIComponentTooltipTest|PianoRollInteractionTest|NUITextInputLayoutTest|UIInsertRoutePickerTest|PanelWindowClickSwallowTest|EditorCloseDeferredTest|NUIThemeConsistencyTest'` — 8/8 passed
- real desktop QA with isolated `XDG_DATA_HOME`: verified rendered text, delayed transport tooltip appearance, tooltip owner handoff, truncated File Browser tooltip placement, one-click sibling dropdown switching, keyboard selection/commit, Escape/cancel behavior, and clean process exit code 0

## Producer note
Select menus no longer hide reachable options or require two clicks, and tooltips no longer flicker, erase each other, or run off-screen.

## Docs updated?
No. This changes shared UI behavior and regression coverage only.

## Risk / rollback notes
- UI-only: no DSP, audio output, latency, serialization/project format, or public documentation changes
- build configuration change is limited to registering the two new test executables
- rollback commits `0a2a4123` and `3d4a58a4`
- the build still reports pre-existing GCC warnings in `NUICustomWindow` and `SampleEditorPanel`; this PR does not suppress or alter them