### PR TITLE
Deploy desktop fonts beside Aestra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,14 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: cmake --build build-app --config ${{env.BUILD_TYPE}} --target Aestra --parallel
 
+      - name: Verify desktop font bundle
+        if: steps.scope.outputs.run == 'true'
+        run: >-
+          cmake
+          -DSOURCE_FONT_ROOT=${{github.workspace}}/AestraAssets/fonts
+          -DBUNDLED_FONT_ROOT=${{github.workspace}}/build-app/bin/AestraAssets/fonts
+          -P ${{github.workspace}}/Tests/Guards/verify_aestra_font_bundle.cmake
+
   build-windows:
     name: Windows (MSVC)
     runs-on: windows-latest

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -288,6 +288,36 @@ set_target_properties(Aestra PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+# Deploy the tracked desktop font bundle beside the executable. Main.cpp
+# resolves AestraAssets/fonts relative to the executable, so this keeps the
+# intended Geist/Manrope rendering independent of the process working directory
+# and works for external build trees as well as packaged desktop layouts.
+set(AESTRA_DESKTOP_FONT_SOURCE_DIR "${CMAKE_SOURCE_DIR}/AestraAssets/fonts")
+set(AESTRA_DESKTOP_FONT_FILES
+	Geist/Geist-Bold.ttf
+	Geist/Geist-Medium.ttf
+	Geist/Geist-Regular.ttf
+	Manrope/Manrope-Bold.ttf
+	Manrope/Manrope-Medium.ttf
+	Manrope/Manrope-Regular.ttf
+)
+
+foreach(font_relative_path IN LISTS AESTRA_DESKTOP_FONT_FILES)
+	set(font_source_path "${AESTRA_DESKTOP_FONT_SOURCE_DIR}/${font_relative_path}")
+	if(NOT EXISTS "${font_source_path}")
+		message(FATAL_ERROR "Required Aestra desktop font is missing: ${font_source_path}")
+	endif()
+
+	get_filename_component(font_subdirectory "${font_relative_path}" DIRECTORY)
+	add_custom_command(TARGET Aestra POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E make_directory
+			"$<TARGET_FILE_DIR:Aestra>/AestraAssets/fonts/${font_subdirectory}"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"${font_source_path}"
+			"$<TARGET_FILE_DIR:Aestra>/AestraAssets/fonts/${font_relative_path}"
+	)
+endforeach()
+
 # Copy mock license file alongside binary for contributors
 add_custom_command(TARGET Aestra POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:Aestra>/data"
@@ -295,5 +325,18 @@ add_custom_command(TARGET Aestra POST_BUILD
 		"${CMAKE_CURRENT_SOURCE_DIR}/license/user_info.json"
 		"$<TARGET_FILE_DIR:Aestra>/data/user_info.json"
 )
+
+if(BUILD_TESTING)
+	add_test(NAME AestraDesktopFontBundleTest
+		COMMAND ${CMAKE_COMMAND}
+			"-DSOURCE_FONT_ROOT=${AESTRA_DESKTOP_FONT_SOURCE_DIR}"
+			"-DBUNDLED_FONT_ROOT=$<TARGET_FILE_DIR:Aestra>/AestraAssets/fonts"
+			-P "${CMAKE_SOURCE_DIR}/Tests/Guards/verify_aestra_font_bundle.cmake"
+	)
+	set_tests_properties(AestraDesktopFontBundleTest PROPERTIES
+		LABELS "ui;assets;fonts;regression"
+		TIMEOUT 30
+	)
+endif()
 
 message(STATUS "Aestra application configured")

--- a/Tests/Guards/verify_aestra_font_bundle.cmake
+++ b/Tests/Guards/verify_aestra_font_bundle.cmake
@@ -9,14 +9,20 @@ if(NOT SOURCE_FONT_ROOT OR NOT BUNDLED_FONT_ROOT)
     message(FATAL_ERROR "SOURCE_FONT_ROOT and BUNDLED_FONT_ROOT must be provided")
 endif()
 
-set(required_fonts
-    Geist/Geist-Bold.ttf
-    Geist/Geist-Medium.ttf
-    Geist/Geist-Regular.ttf
-    Manrope/Manrope-Bold.ttf
-    Manrope/Manrope-Medium.ttf
-    Manrope/Manrope-Regular.ttf
-)
+# Derive the required set from the tracked tree rather than restating it.
+#
+# A second hard-coded list here would make the guard blind to the failure it
+# exists to catch: a font added to AestraAssets/fonts but not to the deploy list
+# in Source/CMakeLists.txt would not ship AND would still pass. The deploy list
+# stays explicit (repo convention: no configure-time globbing, which goes stale);
+# this runs via `cmake -P` at test time, so a glob here is always current.
+file(GLOB_RECURSE required_fonts RELATIVE "${SOURCE_FONT_ROOT}" "${SOURCE_FONT_ROOT}/*.ttf")
+
+# A verifier that iterates nothing must fail, not report success — otherwise a
+# wrong SOURCE_FONT_ROOT silently turns this into a no-op that passes.
+if(NOT required_fonts)
+    message(FATAL_ERROR "No tracked fonts found under ${SOURCE_FONT_ROOT}")
+endif()
 
 foreach(font_relative_path IN LISTS required_fonts)
     set(source_font "${SOURCE_FONT_ROOT}/${font_relative_path}")

--- a/Tests/Guards/verify_aestra_font_bundle.cmake
+++ b/Tests/Guards/verify_aestra_font_bundle.cmake
@@ -1,0 +1,39 @@
+# Verifies that the desktop binary's adjacent font bundle is complete and
+# byte-identical to the tracked AestraAssets source fonts.
+#
+# Required -D args:
+#   SOURCE_FONT_ROOT   tracked AestraAssets/fonts directory
+#   BUNDLED_FONT_ROOT  deployed directory beside the desktop executable
+
+if(NOT SOURCE_FONT_ROOT OR NOT BUNDLED_FONT_ROOT)
+    message(FATAL_ERROR "SOURCE_FONT_ROOT and BUNDLED_FONT_ROOT must be provided")
+endif()
+
+set(required_fonts
+    Geist/Geist-Bold.ttf
+    Geist/Geist-Medium.ttf
+    Geist/Geist-Regular.ttf
+    Manrope/Manrope-Bold.ttf
+    Manrope/Manrope-Medium.ttf
+    Manrope/Manrope-Regular.ttf
+)
+
+foreach(font_relative_path IN LISTS required_fonts)
+    set(source_font "${SOURCE_FONT_ROOT}/${font_relative_path}")
+    set(bundled_font "${BUNDLED_FONT_ROOT}/${font_relative_path}")
+
+    if(NOT EXISTS "${source_font}")
+        message(FATAL_ERROR "Tracked source font is missing: ${source_font}")
+    endif()
+    if(NOT EXISTS "${bundled_font}")
+        message(FATAL_ERROR "Desktop font bundle is missing: ${bundled_font}")
+    endif()
+
+    file(SHA256 "${source_font}" source_hash)
+    file(SHA256 "${bundled_font}" bundled_hash)
+    if(NOT source_hash STREQUAL bundled_hash)
+        message(FATAL_ERROR "Bundled font differs from tracked source: ${font_relative_path}")
+    endif()
+endforeach()
+
+message(STATUS "Aestra desktop font bundle is complete and byte-identical")


### PR DESCRIPTION
## Summary

- Deploy the tracked Geist and Manrope desktop fonts beside the Aestra executable during the app build.
- Add a regression check that verifies all six deployed fonts are present and byte-identical to their tracked sources.
- Run that check in the Linux UI/app CI lane after building Aestra.

## Why

Aestra's renderer already knows how to discover `AestraAssets/fonts` beside the executable, but the desktop build did not put those assets there. Builds launched outside the repository therefore fell through to substitute fonts, which made text appear noticeably softer and inconsistent. The earlier crisp-text result came from manually supplying that missing adjacent asset directory; this change makes that layout a permanent build contract.

## Testing performed

- Reproduced the old behavior with an external build after removing the manual font-directory symlink: Geist and Manrope loads failed and fallback rendering initialized.
- Confirmed the new verifier fails against that old external build because its font bundle is absent.
- Configured and built the `Aestra` target in a fresh external build tree with `-j2`.
- Ran `AestraDesktopFontBundleTest`: passed; all six bundled fonts matched their tracked SHA-256 hashes.
- Launched the new binary from an unrelated working directory with isolated runtime data: `AESTRA_FONT_DIR` resolved to the executable-adjacent bundle, no font-load failures were logged, and the intended crisp text rendered in the live UI.
- Closed the isolated runtime cleanly with exit code 0.

## Producer note

Aestra now renders its intended crisp text even when launched outside the repository or build directory.

## Docs updated?

No. This is enforced directly by the desktop build and CI regression.

## Risk / rollback notes

Low risk. The change copies existing tracked font assets after building the desktop executable and does not alter the text renderer, DSP, serialization, or audio paths. Rollback is the single commit on this branch.