### PR TITLE
Apply persisted audio and DSP settings at startup (#649)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ add_subdirectory(AestraAudio)
 if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessMain.cpp")
   add_executable(AestraHeadless
     Source/App/HeadlessMain.cpp
+    Source/Core/AudioSettingsStore.cpp
     Source/Core/ProjectSerializer.cpp
   )
 

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -848,12 +848,18 @@ void AestraApp::finalizeAudioSetup() {
     // Pass nullptr so openDefaultStream falls back to 'this' (the controller)
     // as the audio-callback userData, which the callback expects.
     if (m_audioController->openDefaultStream(nullptr)) {
+        // Establish the effective DSP configuration BEFORE the stream starts
+        // producing callbacks. This is not merely tidier ordering: setThreadCount
+        // replaces the engine's thread pool outright
+        // (m_threadPool = std::make_unique<RealTimeThreadPool>(count)), so running
+        // it against a live stream races the audio thread that is using that pool.
+        applyPersistedEngineSettings();
+
         m_audioController->startStream();
         if (m_content) {
             m_content->setAudioStatus(true);
         }
         connectAudioToUI(); // Sync configs now that stream is open
-        applyPersistedEngineSettings();
         m_audioStreamReady = true;
 
         // Re-wire the performance HUD in case the engine wasn't constructed
@@ -891,12 +897,20 @@ void AestraApp::applyPersistedEngineSettings() {
         engine->setDCRemovalEnabled(saved.dcRemoval != 0);
     }
     if (Aestra::isSet(saved.dithering)) {
-        engine->setDitheringMode(static_cast<Aestra::Audio::DitheringMode>(saved.dithering));
+        if (Aestra::isPlausibleDitheringMode(saved.dithering)) {
+            engine->setDitheringMode(static_cast<Aestra::Audio::DitheringMode>(saved.dithering));
+        } else {
+            Log::warning("[Audio] dithering " + std::to_string(saved.dithering) +
+                         " is not a valid mode; leaving the engine default");
+        }
     }
     if (Aestra::isSet(saved.previewDuckingDb)) {
         engine->setPreviewDuckingAttenuationDb(static_cast<float>(saved.previewDuckingDb));
     }
-    if (Aestra::isSet(saved.resampling)) {
+    if (Aestra::isSet(saved.resampling) && !Aestra::isPlausibleResamplingIndex(saved.resampling)) {
+        Log::warning("[Audio] resampling " + std::to_string(saved.resampling) +
+                     " is not a valid quality index; leaving the engine default");
+    } else if (Aestra::isSet(saved.resampling)) {
         // Index-to-quality mapping mirrors AudioSettingsPage::applyChanges. It is
         // duplicated rather than shared only because the page cannot be linked
         // headlessly; unifying it belongs with the page rewire.
@@ -908,7 +922,7 @@ void AestraApp::applyPersistedEngineSettings() {
             case 1: engineQ = InterpolationQuality::Sinc32; globalQ = Aestra::Audio::ClipResamplingQuality::Draft;    break;
             case 2: engineQ = InterpolationQuality::Cubic;  globalQ = Aestra::Audio::ClipResamplingQuality::Standard; break;
             case 3: engineQ = InterpolationQuality::Sinc64; globalQ = Aestra::Audio::ClipResamplingQuality::High;     break;
-            default: break;
+            default: break; // unreachable: guarded by isPlausibleResamplingIndex above
         }
         engine->setInterpolationQuality(engineQ);
         Aestra::Audio::PlaylistMixer::setResamplingQuality(globalQ);

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -30,6 +30,9 @@
 #include <iostream>
 #include <fstream>
 #include <chrono>
+#include "../Core/AudioSettingsStore.h"
+#include "PlaylistMixer.h"
+#include "ClipResampler.h"
 #include <thread>
 #include <cmath>
 #include <algorithm>
@@ -850,6 +853,7 @@ void AestraApp::finalizeAudioSetup() {
             m_content->setAudioStatus(true);
         }
         connectAudioToUI(); // Sync configs now that stream is open
+        applyPersistedEngineSettings();
         m_audioStreamReady = true;
 
         // Re-wire the performance HUD in case the engine wasn't constructed
@@ -859,6 +863,72 @@ void AestraApp::finalizeAudioSetup() {
             hud->setAudioEngine(m_audioController->getEngine());
         }
     }
+}
+
+// Apply the persisted DSP configuration once the engine exists (#649).
+//
+// These settings used to be applied by AudioSettingsPage's constructor, reached
+// lazily through ensureSettingsAndDialogs() — so whether the engine ran with the
+// user's safety-limiter, dither and multi-threading choices depended on whether
+// they had opened the Settings dialog this session. The safety limiter in
+// particular defaults to ON (AudioEngine.h), so a user who turned it off got it
+// back every launch and lost it again mid-session on opening Settings.
+//
+// Startup owns this now. The Settings dialog edits and displays; it does not
+// initialise.
+void AestraApp::applyPersistedEngineSettings() {
+    auto* engine = m_audioController ? m_audioController->getEngine() : nullptr;
+    if (!engine) {
+        return;
+    }
+
+    const Aestra::AudioSettings saved = Aestra::loadAudioSettings();
+
+    if (Aestra::isSet(saved.masterLimiter)) {
+        engine->setSafetyLimiterEnabled(saved.masterLimiter != 0);
+    }
+    if (Aestra::isSet(saved.dcRemoval)) {
+        engine->setDCRemovalEnabled(saved.dcRemoval != 0);
+    }
+    if (Aestra::isSet(saved.dithering)) {
+        engine->setDitheringMode(static_cast<Aestra::Audio::DitheringMode>(saved.dithering));
+    }
+    if (Aestra::isSet(saved.previewDuckingDb)) {
+        engine->setPreviewDuckingAttenuationDb(static_cast<float>(saved.previewDuckingDb));
+    }
+    if (Aestra::isSet(saved.resampling)) {
+        // Index-to-quality mapping mirrors AudioSettingsPage::applyChanges. It is
+        // duplicated rather than shared only because the page cannot be linked
+        // headlessly; unifying it belongs with the page rewire.
+        using Aestra::Audio::Interpolators::InterpolationQuality;
+        InterpolationQuality engineQ = InterpolationQuality::Sinc16;
+        Aestra::Audio::ClipResamplingQuality globalQ = Aestra::Audio::ClipResamplingQuality::High;
+        switch (saved.resampling) {
+            case 0: engineQ = InterpolationQuality::Cubic;  globalQ = Aestra::Audio::ClipResamplingQuality::Fast;     break;
+            case 1: engineQ = InterpolationQuality::Sinc32; globalQ = Aestra::Audio::ClipResamplingQuality::Draft;    break;
+            case 2: engineQ = InterpolationQuality::Cubic;  globalQ = Aestra::Audio::ClipResamplingQuality::Standard; break;
+            case 3: engineQ = InterpolationQuality::Sinc64; globalQ = Aestra::Audio::ClipResamplingQuality::High;     break;
+            default: break;
+        }
+        engine->setInterpolationQuality(engineQ);
+        Aestra::Audio::PlaylistMixer::setResamplingQuality(globalQ);
+    }
+    if (Aestra::isSet(saved.multiThreading)) {
+        const bool enabled = saved.multiThreading != 0;
+        engine->setMultiThreadingEnabled(enabled);
+        if (enabled && Aestra::isSet(saved.threads)) {
+            const unsigned hw = std::thread::hardware_concurrency();
+            const int maxThreads = hw > 0 ? static_cast<int>(hw) : 8;
+            const int clamped = std::max(1, std::min(saved.threads, maxThreads));
+            if (clamped != saved.threads) {
+                Log::warning("[Audio] threads " + std::to_string(saved.threads) + " out of range; using " +
+                             std::to_string(clamped));
+            }
+            engine->setThreadCount(clamped);
+        }
+    }
+
+    Log::info("[Audio] Applied persisted engine settings at startup");
 }
 
 void AestraApp::setupCallbacks() {

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -87,6 +87,7 @@ private:
     void setupCallbacks();
     void connectAudioToUI();
     void finalizeAudioSetup(); // Deferred after window shown for instant startup
+    void applyPersistedEngineSettings(); // #649: startup owns DSP config, not the dialog
 
     // Project management
     void requestClose();

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -30,6 +30,7 @@ set(Aestra_SOURCES
 	Core/TakeManager.h
 	Core/TakeManager.cpp
 	Core/Preferences.h
+	Core/AudioSettingsStore.cpp
 	Core/Preferences.cpp
 	Core/UIState.h
 	Core/UIState.cpp

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -254,8 +254,29 @@ bool AestraAudioController::openDefaultStream(void* userData) {
         // intent", NOT "apply the default" — the two are indistinguishable
         // downstream, and conflating them is what pinned every install to 512
         // regardless of what the user chose (#649).
-        config.sampleRate = Aestra::isSet(saved.sampleRate) ? static_cast<uint32_t>(saved.sampleRate) : 48000u;
-        config.bufferSize = Aestra::isSet(saved.bufferSize) ? static_cast<uint32_t>(saved.bufferSize) : 512u;
+        // Presence is not sanity: kUnset rules out only -1, so a corrupted
+        // `buffersize=0` would otherwise reach the driver as a divisor and an
+        // allocation size. An implausible value carries no user intent, so it
+        // falls back to the default with a diagnostic rather than silently.
+        config.sampleRate = 48000u;
+        if (Aestra::isSet(saved.sampleRate)) {
+            if (Aestra::isPlausibleSampleRate(saved.sampleRate)) {
+                config.sampleRate = static_cast<uint32_t>(saved.sampleRate);
+            } else {
+                Log::warning("[Audio] samplerate " + std::to_string(saved.sampleRate) +
+                             " is out of range; using " + std::to_string(config.sampleRate));
+            }
+        }
+
+        config.bufferSize = 512u;
+        if (Aestra::isSet(saved.bufferSize)) {
+            if (Aestra::isPlausibleBufferSize(saved.bufferSize)) {
+                config.bufferSize = static_cast<uint32_t>(saved.bufferSize);
+            } else {
+                Log::warning("[Audio] buffersize " + std::to_string(saved.bufferSize) +
+                             " is out of range; using " + std::to_string(config.bufferSize));
+            }
+        }
 
         config.numInputChannels = inputDevice ? std::min<uint32_t>(inputDevice->maxInputChannels, 32u) : 0u;
         config.numOutputChannels = std::min<uint32_t>(2, std::max<uint32_t>(1, outputDevice->maxOutputChannels));

--- a/Source/Core/AestraAudioController.cpp
+++ b/Source/Core/AestraAudioController.cpp
@@ -8,6 +8,7 @@
 #include "PreviewEngine.h"
 #include "TrackManager.h"
 #include "AestraPlatform.h"
+#include "AudioSettingsStore.h"
 #include "../AestraCore/include/AestraLog.h"
 
 #include <algorithm>
@@ -48,42 +49,6 @@ uint64_t estimateCycleHz() {
 #else
     return 0;
 #endif
-}
-
-struct SavedAudioSelection {
-    int outputDeviceId{-1};
-    int inputDeviceId{-1};
-};
-
-SavedAudioSelection loadSavedAudioSelection() {
-    SavedAudioSelection selection;
-
-    const std::filesystem::path configPath = getAudioSettingsConfigPath();
-    std::ifstream file(configPath);
-    if (!file.is_open()) {
-        return selection;
-    }
-
-    std::string line;
-    while (std::getline(file, line)) {
-        const auto eq = line.find('=');
-        if (eq == std::string::npos) {
-            continue;
-        }
-
-        const std::string key = line.substr(0, eq);
-        const std::string value = line.substr(eq + 1);
-        try {
-            if (key == "device") {
-                selection.outputDeviceId = std::stoi(value);
-            } else if (key == "input_device") {
-                selection.inputDeviceId = std::stoi(value);
-            }
-        } catch (const std::exception&) {
-        }
-    }
-
-    return selection;
 }
 
 const AudioDeviceInfo* findDeviceById(const std::vector<AudioDeviceInfo>& devices, int id) {
@@ -247,9 +212,12 @@ bool AestraAudioController::openDefaultStream(void* userData) {
                       " defaultOut=" + std::string(device.isDefaultOutput ? "yes" : "no"));
         }
 
-        const SavedAudioSelection savedSelection = loadSavedAudioSelection();
+        // One parser for audio_settings.conf (#649). The previous local reader
+        // understood only `device`/`input_device`, which is why the user's saved
+        // sample rate and buffer size reached nothing.
+        const Aestra::AudioSettings saved = Aestra::loadAudioSettings();
 
-        const AudioDeviceInfo* outputDevice = findDeviceById(devices, savedSelection.outputDeviceId);
+        const AudioDeviceInfo* outputDevice = findDeviceById(devices, saved.deviceId);
         if (!outputDevice || outputDevice->maxOutputChannels == 0) {
             AudioDeviceInfo defaultOutput = m_audioManager->getDefaultOutputDevice();
             outputDevice = findDeviceById(devices, static_cast<int>(defaultOutput.id));
@@ -270,7 +238,7 @@ bool AestraAudioController::openDefaultStream(void* userData) {
 
         Log::info("Using audio device: " + outputDevice->name);
 
-        const AudioDeviceInfo* inputDevice = choosePreferredInputDevice(devices, savedSelection.inputDeviceId);
+        const AudioDeviceInfo* inputDevice = choosePreferredInputDevice(devices, saved.inputDeviceId);
         if (inputDevice) {
             Log::info("Using input device: " + inputDevice->name + " (" +
                       std::to_string(inputDevice->maxInputChannels) + " channels)");
@@ -282,8 +250,12 @@ bool AestraAudioController::openDefaultStream(void* userData) {
         AudioStreamConfig config;
         config.deviceId = outputDevice->id;
         config.inputDeviceId = inputDevice ? inputDevice->id : outputDevice->id;
-        config.sampleRate = 48000;
-        config.bufferSize = 512;
+        // Apply the persisted rate/buffer if present. Absent means "no stored
+        // intent", NOT "apply the default" — the two are indistinguishable
+        // downstream, and conflating them is what pinned every install to 512
+        // regardless of what the user chose (#649).
+        config.sampleRate = Aestra::isSet(saved.sampleRate) ? static_cast<uint32_t>(saved.sampleRate) : 48000u;
+        config.bufferSize = Aestra::isSet(saved.bufferSize) ? static_cast<uint32_t>(saved.bufferSize) : 512u;
 
         config.numInputChannels = inputDevice ? std::min<uint32_t>(inputDevice->maxInputChannels, 32u) : 0u;
         config.numOutputChannels = std::min<uint32_t>(2, std::max<uint32_t>(1, outputDevice->maxOutputChannels));

--- a/Source/Core/AudioSettingsStore.cpp
+++ b/Source/Core/AudioSettingsStore.cpp
@@ -1,0 +1,136 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "AudioSettingsStore.h"
+
+#include "AestraPlatform.h"
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+
+namespace Aestra {
+
+namespace {
+
+struct KeyBinding {
+    const char* key;
+    int AudioSettings::*field;
+};
+
+// The complete key set. Both the parser and the serializer drive off this, so a
+// key cannot be readable but unwritable (or the reverse) — which is exactly the
+// asymmetry that let `buffersize` be saved by one component and unknown to
+// another.
+constexpr std::array<KeyBinding, 13> kBindings{{
+    {"driver", &AudioSettings::driver},
+    {"device", &AudioSettings::deviceId},
+    {"input_device", &AudioSettings::inputDeviceId},
+    {"samplerate", &AudioSettings::sampleRate},
+    {"buffersize", &AudioSettings::bufferSize},
+    {"quality_preset", &AudioSettings::qualityPreset},
+    {"resampling", &AudioSettings::resampling},
+    {"dithering", &AudioSettings::dithering},
+    {"threads", &AudioSettings::threads},
+    {"dc_removal", &AudioSettings::dcRemoval},
+    {"master_limiter", &AudioSettings::masterLimiter},
+    {"preview_ducking_db", &AudioSettings::previewDuckingDb},
+    {"multi_threading", &AudioSettings::multiThreading},
+}};
+
+std::string trim(const std::string& s) {
+    const auto first = s.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return {};
+    }
+    const auto last = s.find_last_not_of(" \t\r\n");
+    return s.substr(first, last - first + 1);
+}
+
+} // namespace
+
+AudioSettings parseAudioSettings(std::istream& in) {
+    AudioSettings settings;
+
+    std::string line;
+    while (std::getline(in, line)) {
+        const auto eq = line.find('=');
+        if (eq == std::string::npos) {
+            continue;
+        }
+
+        const std::string key = trim(line.substr(0, eq));
+        const std::string value = trim(line.substr(eq + 1));
+        if (key.empty() || value.empty()) {
+            continue;
+        }
+
+        for (const auto& binding : kBindings) {
+            if (key != binding.key) {
+                continue;
+            }
+            // A malformed value leaves the field UNSET rather than defaulting.
+            // Defaulting here would be indistinguishable, downstream, from the
+            // user having chosen the default.
+            try {
+                size_t consumed = 0;
+                const int parsed = std::stoi(value, &consumed);
+                if (consumed == value.size()) {
+                    settings.*(binding.field) = parsed;
+                }
+            } catch (const std::exception&) {
+                // leave unset
+            }
+            break;
+        }
+    }
+
+    return settings;
+}
+
+void serializeAudioSettings(std::ostream& out, const AudioSettings& settings) {
+    for (const auto& binding : kBindings) {
+        const int value = settings.*(binding.field);
+        if (value != AudioSettings::kUnset) {
+            out << binding.key << '=' << value << '\n';
+        }
+    }
+}
+
+std::string audioSettingsConfigPath() {
+    std::error_code ec;
+    if (auto* utils = Aestra::Platform::getUtils()) {
+        std::filesystem::path appDataDir(utils->getAppDataPath("Aestra"));
+        if (!appDataDir.empty()) {
+            std::filesystem::create_directories(appDataDir, ec);
+            if (!ec) {
+                std::filesystem::path appDataPath = appDataDir / "audio_settings.conf";
+                if (std::filesystem::exists(appDataPath, ec)) {
+                    return appDataPath.string();
+                }
+            }
+        }
+    }
+
+    // Legacy location: a config written before the app-data move.
+    std::filesystem::path legacyPath = std::filesystem::current_path() / "audio_settings.conf";
+    if (std::filesystem::exists(legacyPath, ec)) {
+        return legacyPath.string();
+    }
+
+    if (auto* utils = Aestra::Platform::getUtils()) {
+        std::filesystem::path appDataDir(utils->getAppDataPath("Aestra"));
+        if (!appDataDir.empty()) {
+            return (appDataDir / "audio_settings.conf").string();
+        }
+    }
+    return legacyPath.string();
+}
+
+AudioSettings loadAudioSettings() {
+    std::ifstream file(audioSettingsConfigPath());
+    if (!file.is_open()) {
+        return {}; // all unset — nothing persisted, so nothing to apply
+    }
+    return parseAudioSettings(file);
+}
+
+} // namespace Aestra

--- a/Source/Core/AudioSettingsStore.h
+++ b/Source/Core/AudioSettingsStore.h
@@ -1,0 +1,78 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// One parser for audio_settings.conf (#649).
+//
+// The file previously had two independent readers that disagreed about what it
+// contained: AestraAudioController::loadSavedAudioSelection read `device` and
+// `input_device` and nothing else, while AudioSettingsPage::loadSettings read
+// all thirteen keys but could not apply any of them. That is why `samplerate`
+// and `buffersize` were persisted, displayed, and applied by nobody — the
+// reader that ran at startup did not know they existed.
+//
+// parse() and serialize() are stream-based and dependency-free so they can be
+// tested without a platform layer or a UI; only path resolution and the
+// convenience load()/save() wrappers live in the .cpp.
+
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <string>
+
+namespace Aestra {
+
+/**
+ * @brief Audio configuration as persisted in audio_settings.conf.
+ *
+ * Every field carries an explicit "not present in the file" state. That
+ * distinction is load-bearing: applying a *default* over a value the driver
+ * negotiated is indistinguishable, at the call site, from applying a value the
+ * user chose. Absent must mean "leave it alone", not "apply the default".
+ */
+struct AudioSettings {
+    /// Sentinel for a key that was absent or unparseable.
+    static constexpr int kUnset = -1;
+
+    // Device-manager settings: applied before the stream is opened.
+    int driver{kUnset};
+    int deviceId{kUnset};
+    int inputDeviceId{kUnset};
+    int sampleRate{kUnset};
+    int bufferSize{kUnset};
+
+    // Engine DSP settings: applied once the engine exists.
+    int qualityPreset{kUnset};
+    int resampling{kUnset};
+    int dithering{kUnset};
+    int threads{kUnset};
+    int previewDuckingDb{kUnset};
+    int dcRemoval{kUnset};     ///< tri-state: kUnset / 0 off / 1 on
+    int masterLimiter{kUnset}; ///< tri-state
+    int multiThreading{kUnset};///< tri-state
+};
+
+/// True when a field was actually present in the file.
+inline bool isSet(int field) { return field != AudioSettings::kUnset; }
+
+/**
+ * @brief Parse `key=value` lines. Unknown keys are ignored; malformed values
+ *        leave their field unset rather than defaulting.
+ *
+ * Deliberately tolerant: a corrupt line must not discard the rest of the file,
+ * because that would silently reset every setting after it.
+ */
+AudioSettings parseAudioSettings(std::istream& in);
+
+/**
+ * @brief Write every SET field. Unset fields are omitted, so a round trip
+ *        through parse/serialize never invents a value that was not there.
+ */
+void serializeAudioSettings(std::ostream& out, const AudioSettings& settings);
+
+/// Resolved path to audio_settings.conf (app-data, with the legacy cwd fallback).
+std::string audioSettingsConfigPath();
+
+/// Convenience: parse the file at audioSettingsConfigPath(). All-unset if absent.
+AudioSettings loadAudioSettings();
+
+} // namespace Aestra

--- a/Source/Core/AudioSettingsStore.h
+++ b/Source/Core/AudioSettingsStore.h
@@ -54,6 +54,28 @@ struct AudioSettings {
 /// True when a field was actually present in the file.
 inline bool isSet(int field) { return field != AudioSettings::kUnset; }
 
+// Presence is not sanity. kUnset rules out exactly one value (-1), so a
+// hand-edited or corrupted config can still carry 0 or a negative through
+// isSet() and reach a consumer. buffersize=0 is the dangerous one: it is a
+// divisor and an allocation size. A value outside these ranges carries no user
+// intent, so consumers treat it as absent and fall back to their default —
+// loudly, never silently.
+
+/// Plausible device sample rates. Generous on purpose; this rejects garbage,
+/// not unusual-but-real hardware.
+inline bool isPlausibleSampleRate(int v) { return v >= 8000 && v <= 768000; }
+
+/// Plausible driver buffer sizes, in frames.
+inline bool isPlausibleBufferSize(int v) { return v >= 16 && v <= 16384; }
+
+/// Valid DitheringMode enumerators (None, Triangular, HighPass, NoiseShaped).
+/// Casting an out-of-range integer to the enum and handing it to the engine is
+/// not something the engine is required to survive.
+inline bool isPlausibleDitheringMode(int v) { return v >= 0 && v <= 3; }
+
+/// Valid resampling-quality indices as offered by the settings dropdown.
+inline bool isPlausibleResamplingIndex(int v) { return v >= 0 && v <= 3; }
+
 /**
  * @brief Parse `key=value` lines. Unknown keys are ignored; malformed values
  *        leave their field unset rather than defaulting.

--- a/Tests/AestraUI/AudioSettingsStoreTest.cpp
+++ b/Tests/AestraUI/AudioSettingsStoreTest.cpp
@@ -1,0 +1,213 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// One parser for audio_settings.conf (#649).
+//
+// Before this, the file had two readers that disagreed about its contents:
+// AestraAudioController parsed `device`/`input_device` only, while
+// AudioSettingsPage parsed all thirteen keys but could apply none of them. The
+// startup path therefore opened the stream with hard-coded literals —
+//
+//     config.sampleRate = 48000;
+//     config.bufferSize = 512;
+//
+// — while the user's file said 256, and the Settings dialog displayed 256 with
+// an "Est. Latency: 5 ms" derived from it. Observed on a real machine.
+//
+// The property that matters most here is the UNSET/DEFAULT distinction. "Absent
+// from the file" and "set to the default" must not be the same value, because
+// the caller has to choose between leaving a driver-negotiated setting alone and
+// overwriting it. Most of the assertions below exist to pin that.
+
+#include "AudioSettingsStore.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using Aestra::AudioSettings;
+using Aestra::isSet;
+using Aestra::parseAudioSettings;
+using Aestra::serializeAudioSettings;
+
+namespace {
+
+int g_failures = 0;
+
+void expectEq(int got, int wanted, const std::string& what) {
+    if (got != wanted) {
+        std::cerr << "[FAIL] " << what << ": got " << got << ", wanted " << wanted << '\n';
+        ++g_failures;
+    }
+}
+
+void check(bool cond, const std::string& what) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+AudioSettings parseText(const std::string& text) {
+    std::istringstream in(text);
+    return parseAudioSettings(in);
+}
+
+std::string serializeText(const AudioSettings& s) {
+    std::ostringstream out;
+    serializeAudioSettings(out, s);
+    return out.str();
+}
+
+// The exact file from the reporting machine.
+const char* kRealConfig =
+    "driver=0\n"
+    "device=0\n"
+    "input_device=0\n"
+    "samplerate=48000\n"
+    "buffersize=256\n"
+    "quality_preset=2\n"
+    "resampling=3\n"
+    "dithering=1\n"
+    "threads=3\n"
+    "dc_removal=0\n"
+    "master_limiter=0\n"
+    "preview_ducking_db=6\n"
+    "multi_threading=1\n";
+
+} // namespace
+
+int main() {
+    // --- the real file parses completely -------------------------------------
+    {
+        const AudioSettings s = parseText(kRealConfig);
+        expectEq(s.driver, 0, "driver");
+        expectEq(s.deviceId, 0, "device");
+        expectEq(s.inputDeviceId, 0, "input_device");
+        expectEq(s.sampleRate, 48000, "samplerate");
+        expectEq(s.bufferSize, 256, "buffersize — the value startup was ignoring");
+        expectEq(s.qualityPreset, 2, "quality_preset");
+        expectEq(s.resampling, 3, "resampling");
+        expectEq(s.dithering, 1, "dithering");
+        expectEq(s.threads, 3, "threads");
+        expectEq(s.dcRemoval, 0, "dc_removal");
+        expectEq(s.masterLimiter, 0, "master_limiter — the value the engine defaulted over");
+        expectEq(s.previewDuckingDb, 6, "preview_ducking_db");
+        expectEq(s.multiThreading, 1, "multi_threading");
+    }
+
+    // --- absent is NOT default ------------------------------------------------
+    // The distinction the whole design rests on: a caller must be able to tell
+    // "the user chose 512" from "there is no stored value, leave the negotiated
+    // one alone".
+    {
+        const AudioSettings s = parseText("samplerate=44100\n");
+        check(isSet(s.sampleRate), "present key is set");
+        check(!isSet(s.bufferSize), "absent key is UNSET, not defaulted");
+        check(!isSet(s.masterLimiter), "absent tri-state is UNSET, not false");
+        check(!isSet(s.deviceId), "absent device is UNSET, not 0");
+
+        const AudioSettings empty;
+        check(!isSet(empty.sampleRate) && !isSet(empty.bufferSize) && !isSet(empty.masterLimiter),
+              "default-constructed settings are entirely unset");
+    }
+
+    // 0 is a legal stored value and must be distinguishable from unset — the
+    // same trap as #648, where an unpopulated control reporting 0 destroyed a
+    // real device id.
+    {
+        const AudioSettings s = parseText("device=0\nmaster_limiter=0\ndc_removal=0\n");
+        check(isSet(s.deviceId), "device=0 is SET");
+        expectEq(s.deviceId, 0, "device=0 parses as 0");
+        check(isSet(s.masterLimiter), "master_limiter=0 is SET");
+        expectEq(s.masterLimiter, 0, "master_limiter=0 parses as 0 (off), not unset");
+    }
+
+    // --- malformed input leaves fields unset rather than defaulting -----------
+    {
+        const AudioSettings s = parseText("buffersize=notanumber\nsamplerate=48000\n");
+        check(!isSet(s.bufferSize), "unparseable value leaves the field unset");
+        expectEq(s.sampleRate, 48000, "a bad line does not discard the rest of the file");
+    }
+    {
+        const AudioSettings s = parseText("buffersize=256abc\n");
+        check(!isSet(s.bufferSize), "trailing garbage rejects the value entirely");
+    }
+    {
+        const AudioSettings s = parseText("buffersize=99999999999999999999\n");
+        check(!isSet(s.bufferSize), "out-of-range value is rejected, not truncated");
+    }
+
+    // --- tolerant of real-world file shapes ----------------------------------
+    {
+        const AudioSettings s = parseText("\n\n  buffersize = 128  \n# a comment\nnonsense\n=5\nkey=\nsamplerate=44100\n");
+        expectEq(s.bufferSize, 128, "surrounding whitespace tolerated");
+        expectEq(s.sampleRate, 44100, "comments, blank and malformed lines skipped");
+    }
+    {
+        const AudioSettings s = parseText("unknown_key=7\nbuffersize=64\n");
+        expectEq(s.bufferSize, 64, "unknown keys ignored without disturbing known ones");
+    }
+    {
+        const AudioSettings s = parseText("buffersize=128\nbuffersize=512\n");
+        expectEq(s.bufferSize, 512, "last occurrence wins");
+    }
+
+    // --- round trip -----------------------------------------------------------
+    {
+        const AudioSettings first = parseText(kRealConfig);
+        const std::string out = serializeText(first);
+        const AudioSettings second = parseText(out);
+
+        expectEq(second.bufferSize, first.bufferSize, "round trip: buffersize");
+        expectEq(second.masterLimiter, first.masterLimiter, "round trip: master_limiter");
+        expectEq(second.deviceId, first.deviceId, "round trip: device");
+        expectEq(second.threads, first.threads, "round trip: threads");
+        check(serializeText(second) == out, "serialize is stable across repeated cycles");
+    }
+
+    // Unset fields are omitted, so a round trip never invents a value.
+    {
+        AudioSettings partial;
+        partial.bufferSize = 256;
+        const std::string out = serializeText(partial);
+        check(out == "buffersize=256\n", "only set fields are written");
+
+        const AudioSettings back = parseText(out);
+        check(!isSet(back.sampleRate), "omitted field stays unset after a round trip");
+        expectEq(back.bufferSize, 256, "set field survives");
+    }
+
+    // --- every key is both readable and writable ------------------------------
+    // The asymmetry this prevents is the original defect in miniature: a key one
+    // component could write and another did not know existed.
+    {
+        AudioSettings all;
+        all.driver = 1; all.deviceId = 2; all.inputDeviceId = 3;
+        all.sampleRate = 44100; all.bufferSize = 128; all.qualityPreset = 1;
+        all.resampling = 2; all.dithering = 1; all.threads = 4;
+        all.previewDuckingDb = 12; all.dcRemoval = 1; all.masterLimiter = 1;
+        all.multiThreading = 0;
+
+        const AudioSettings back = parseText(serializeText(all));
+        expectEq(back.driver, 1, "rw driver");
+        expectEq(back.deviceId, 2, "rw device");
+        expectEq(back.inputDeviceId, 3, "rw input_device");
+        expectEq(back.sampleRate, 44100, "rw samplerate");
+        expectEq(back.bufferSize, 128, "rw buffersize");
+        expectEq(back.qualityPreset, 1, "rw quality_preset");
+        expectEq(back.resampling, 2, "rw resampling");
+        expectEq(back.dithering, 1, "rw dithering");
+        expectEq(back.threads, 4, "rw threads");
+        expectEq(back.previewDuckingDb, 12, "rw preview_ducking_db");
+        expectEq(back.dcRemoval, 1, "rw dc_removal");
+        expectEq(back.masterLimiter, 1, "rw master_limiter");
+        expectEq(back.multiThreading, 0, "rw multi_threading");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] AudioSettingsStoreTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] AudioSettingsStoreTest\n";
+    return 0;
+}

--- a/Tests/AestraUI/AudioSettingsStoreTest.cpp
+++ b/Tests/AestraUI/AudioSettingsStoreTest.cpp
@@ -25,6 +25,10 @@
 #include <string>
 
 using Aestra::AudioSettings;
+using Aestra::isPlausibleBufferSize;
+using Aestra::isPlausibleDitheringMode;
+using Aestra::isPlausibleResamplingIndex;
+using Aestra::isPlausibleSampleRate;
 using Aestra::isSet;
 using Aestra::parseAudioSettings;
 using Aestra::serializeAudioSettings;
@@ -203,6 +207,42 @@ int main() {
         expectEq(back.masterLimiter, 1, "rw master_limiter");
         expectEq(back.multiThreading, 0, "rw multi_threading");
     }
+
+    // --- presence is not sanity (review finding, #660) --------------------------
+    // kUnset rules out exactly one value (-1), so a hand-edited or corrupted
+    // config can still carry 0 or a negative through isSet() and reach a
+    // consumer. buffersize=0 is the dangerous one: a divisor and an allocation
+    // size. These are parsed faithfully — the store reports what the file said —
+    // and rejected at the point of application.
+    {
+        const AudioSettings s = parseText("buffersize=0\nsamplerate=0\n");
+        check(isSet(s.bufferSize), "buffersize=0 parses as SET (the file really said 0)");
+        expectEq(s.bufferSize, 0, "buffersize=0 is preserved by the parser");
+        check(!isPlausibleBufferSize(s.bufferSize), "buffersize=0 is rejected as implausible");
+        check(!isPlausibleSampleRate(s.sampleRate), "samplerate=0 is rejected as implausible");
+    }
+    {
+        const AudioSettings s = parseText("buffersize=-8\nsamplerate=-1\n");
+        check(!isPlausibleBufferSize(s.bufferSize), "negative buffersize rejected");
+        // samplerate=-1 collides with kUnset; it reads as absent, which is also safe.
+        check(!isSet(s.sampleRate) || !isPlausibleSampleRate(s.sampleRate),
+              "samplerate=-1 is either absent or implausible — never applied");
+    }
+
+    check(isPlausibleBufferSize(64) && isPlausibleBufferSize(256) && isPlausibleBufferSize(2048),
+          "the buffer sizes the UI offers are all plausible");
+    check(isPlausibleSampleRate(44100) && isPlausibleSampleRate(48000) && isPlausibleSampleRate(96000),
+          "the sample rates the UI offers are all plausible");
+    check(!isPlausibleBufferSize(15) && !isPlausibleBufferSize(16385), "buffer bounds are exclusive outside");
+    check(isPlausibleBufferSize(16) && isPlausibleBufferSize(16384), "buffer bounds are inclusive inside");
+    check(!isPlausibleSampleRate(7999) && !isPlausibleSampleRate(768001), "rate bounds exclusive outside");
+
+    // DitheringMode has four enumerators; casting anything else to the enum and
+    // handing it to the engine is not something the engine must survive.
+    for (int v : {0, 1, 2, 3}) check(isPlausibleDitheringMode(v), "valid dithering mode accepted");
+    for (int v : {-2, 4, 99}) check(!isPlausibleDitheringMode(v), "invalid dithering mode rejected");
+    for (int v : {0, 1, 2, 3}) check(isPlausibleResamplingIndex(v), "valid resampling index accepted");
+    for (int v : {-2, 4, 99}) check(!isPlausibleResamplingIndex(v), "invalid resampling index rejected");
 
     if (g_failures != 0) {
         std::cerr << "[FAIL] AudioSettingsStoreTest: " << g_failures << " failure(s)\n";

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1935,3 +1935,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/LatencyCompensationTest.cpp")
     add_test(NAME LatencyCompensationTest COMMAND LatencyCompensationTest)
     set_tests_properties(LatencyCompensationTest PROPERTIES LABELS "audio;latency;pdc")
 endif()
+
+# One parser for audio_settings.conf (#649). parse/serialize are stream-based
+# and platform-free by design, so the decision that was leaving the user's
+# buffer size unapplied is reachable without linking the app or a UI.
+add_executable(AudioSettingsStoreTest AestraUI/AudioSettingsStoreTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/AudioSettingsStore.cpp)
+target_link_libraries(AudioSettingsStoreTest PRIVATE AestraPlat AestraCore)
+target_include_directories(AudioSettingsStoreTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Core
+    ${CMAKE_SOURCE_DIR}/AestraPlat/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME AudioSettingsStoreTest COMMAND AudioSettingsStoreTest)
+set_tests_properties(AudioSettingsStoreTest PROPERTIES LABELS "audio;settings;regression")


### PR DESCRIPTION
Fixes #649 (C3 and C4).

Persisted audio and DSP settings now take effect at startup, before any Settings UI exists.

## Root cause

`audio_settings.conf` had **two independent readers that disagreed about what it contained**:

- `AestraAudioController::loadSavedAudioSelection` — `device` and `input_device` only.
- `AudioSettingsPage::loadSettings` — all thirteen keys, able to apply none of them (`skipAudioCalls` is unconditionally true, and the page is lazily constructed).

So the stream opened with literals:

```cpp
config.sampleRate = 48000;
config.bufferSize = 512;
```

while the user's file said `256`, and the Settings dialog displayed `256` with a latency estimate derived from it. Engine DSP settings were applied only as a side effect of *first opening the dialog* — so whether the engine ran with the user's safety-limiter, dither and multi-threading choices depended on dialog history. The limiter defaults to ON, so turning it off survived neither a relaunch nor, once relaunched, the act of opening Settings.

## Invariant established

> **Startup establishes effective runtime state.** The persisted configuration is applied by an explicit startup path that does not depend on any UI surface being constructed. Persisted, effective and displayed values agree.

## Design: the unset sentinel is load-bearing

`AudioSettings` gives every field an explicit `kUnset`. **"Absent from the file" and "set to the default" must be distinguishable**, because the caller chooses between leaving a driver-negotiated value alone and overwriting it — and conflating them is precisely what pinned every install to 512.

This is the #648 trap in another costume: `device=0` and `master_limiter=0` are legal *stored* values that must not read as absent. The test spends most of its assertions there.

`parse` and `serialize` drive off **one key table**, so a key cannot be readable but unwritable — the asymmetry that caused the original defect.

## Scope: `AudioSettingsPage` deliberately untouched

That page is heavily rewritten by #657. Editing it here would either conflict or force a stacked PR, which this repo's history says gets auto-closed unrecoverably when the parent merges. **The page rewire and `skipAudioCalls` removal are a follow-up** once both land — step 4 of the plan in #649, not this PR.

Consequence, stated plainly: until that follow-up, the page still applies settings on construction. That is now redundant rather than authoritative, and it is idempotent, so it changes nothing — but it is not yet *removed*.

## Files changed

| file | change |
|---|---|
| `Source/Core/AudioSettingsStore.{h,cpp}` | new — one parser, one key table, explicit unset |
| `Source/Core/AestraAudioController.cpp` | uses the store; local device-only parser deleted; **C3** — rate/buffer applied |
| `Source/App/AestraApp.{h,cpp}` | **C4** — `applyPersistedEngineSettings()` from `finalizeAudioSetup` |
| `Tests/AestraUI/AudioSettingsStoreTest.cpp` | new |
| `CMakeLists.txt`, `Source/CMakeLists.txt`, `Tests/CMakeLists.txt` | registration |

## Runtime reproduction, before and after

Config under test: `buffersize=256`, `master_limiter=0`, `threads=99` (deliberately out of range so the DSP path produces observable output).

**Before:**
```
AestraAudioController: Stream Config Target - Rate: 48000.000000, Buffer: 512
```
Settings displayed `Buffer Size: 256` and `Est. Latency: 5 ms (256 spl)` over a 512-frame stream — wrong by 2x.

**After, no dialog opened:**
```
AestraAudioController: Stream Config Target - Rate: 48000.000000, Buffer: 256
[WARN]  [Audio] threads 99 out of range; using 4
[INFO]  [Audio] Applied persisted engine settings at startup
```

Then opening Settings shows `Buffer Size: 256`, `Est. Latency: 5 ms (256 spl)` — now **true** — and `Thread Count: 4`, the clamped value the engine actually got rather than the 99 in the file.

## Tests

`AudioSettingsStoreTest` — 60+ assertions, no platform or UI linkage. Includes the reporting machine's config file verbatim; the unset-vs-default distinction; `device=0` / `master_limiter=0` as set-and-zero; malformed values leaving fields unset rather than defaulting; a bad line not discarding the rest of the file; out-of-range and trailing-garbage rejection; whitespace and comment tolerance; last-occurrence-wins; round-trip stability; and every key proven both readable and writable.

Regression: `ProjectRoundTripTest`, `ProjectRoundTripIntegrityTest`, `DeviceManagerRaceTest`, `AudioSettingsStoreTest` — 4/4 pass.

## Verification rung

- **Behaviour observed** for C3 (buffer 512 → 256 in the engine log) and for the C4 path executing and clamping.
- **Behaviour regression-tested** for the parser, over the scenario named above.
- The individual DSP setters (`setDitheringMode`, `setInterpolationQuality`, …) are **code path executed**, not individually observed — the clamp warning proves the block ran and read the file, but I did not verify each setter's audible effect. Stated rather than implied.

## Compatibility

No format change. Same keys, same `key=value` syntax, same path resolution including the legacy cwd fallback. A config written by an older build parses identically; unknown keys are ignored rather than dropped on read.

## Remaining risks

- The resampling index-to-quality mapping is **duplicated** from `AudioSettingsPage::applyChanges` rather than shared, because the page cannot be linked headlessly. Flagged in a comment; unifying it belongs with the page rewire. This is a knowing seam, not an oversight — principle 9.
- `driver` is parsed and carried but not applied at startup; driver switching has its own reopen semantics and belongs with #650's device work.
- A device id absent from the machine still falls back to the default device **without** rewriting the file, deliberately — absent hardware is transient, and #648 established that silently rewriting a stored device id is itself the bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added a shared `AudioSettingsStore` with explicit unset-value handling and consistent parsing/serialization of `audio_settings.conf`.
- Applied persisted audio device, input device, sample rate, and buffer size before opening the audio stream.
- Applied persisted DSP settings during startup, including limiter, dithering, resampling, DC removal, preview ducking, and multithreading options.
- Added regression coverage for parsing, serialization, malformed and zero-valued settings, duplicate keys, unset fields, and key round-tripping.
- Integrated the new store and test target into the build. The Settings UI and driver-switching behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->