### PR TITLE
Persist window restore geometry independently of maximized state (#655)

### DIFF
--- a/AestraPlat/include/AestraPlatform.h
+++ b/AestraPlat/include/AestraPlatform.h
@@ -193,6 +193,24 @@ public:
     virtual void restore() = 0;
     /** @brief Check whether the window is currently maximized. */
     virtual bool isMaximized() const = 0;
+
+    /**
+     * @brief The window's NON-maximized geometry (#655).
+     *
+     * getPosition/getSize report where the window is *now*, which while
+     * maximized is the maximized rectangle. Persisting that destroys the size
+     * the user actually chose, and there is no way to recover it: applyWindowState
+     * skips size entirely when the maximized flag is set, so the value is never
+     * even read back.
+     *
+     * Implementations must track this independently of the current rect —
+     * Win32 has it natively as WINDOWPLACEMENT::rcNormalPosition; other backends
+     * record the last geometry observed while not maximized.
+     *
+     * @return false if no restore geometry is known yet, leaving the outputs
+     *         untouched, so callers can fall back rather than persist zeroes.
+     */
+    virtual bool getRestoreBounds(int& x, int& y, int& width, int& height) const = 0;
     /** @brief Check whether the window is currently minimized. */
     virtual bool isMinimized() const = 0;
     /** @brief Ask the windowing backend to close the window gracefully. */

--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -68,6 +68,16 @@ bool PlatformWindowLinux::create(const WindowDesc& desc) {
     m_isFullscreen = desc.startFullscreen;
     m_isWindowVisible = true;
     m_isWindowMapped = true;
+    m_maximized = desc.startMaximized;
+
+    // Seed the restore geometry from what was requested. Without this, a session
+    // that starts maximized and is never un-maximized has no restore bounds to
+    // save, and the maximized size would win by default (#655).
+    m_restoreX = (x == SDL_WINDOWPOS_CENTERED) ? 0 : x;
+    m_restoreY = (y == SDL_WINDOWPOS_CENTERED) ? 0 : y;
+    m_restoreW = desc.width;
+    m_restoreH = desc.height;
+    m_hasRestoreBounds = desc.width > 0 && desc.height > 0;
 
     // Initial DPI check
     int dw, dh;
@@ -106,8 +116,15 @@ bool PlatformWindowLinux::pollEvents() {
         case SDL_WINDOWEVENT:
             if (e.window.windowID == SDL_GetWindowID(m_window)) {
                 switch (e.window.event) {
+                case SDL_WINDOWEVENT_MAXIMIZED:
+                    m_maximized = true;
+                    break;
+                case SDL_WINDOWEVENT_MOVED:
+                    rememberRestoreBoundsIfNormal();
+                    break;
                 case SDL_WINDOWEVENT_RESIZED:
                 case SDL_WINDOWEVENT_SIZE_CHANGED:
+                    rememberRestoreBoundsIfNormal();
                     if (m_resizeCallback)
                         m_resizeCallback(e.window.data1, e.window.data2);
                     {
@@ -146,9 +163,11 @@ bool PlatformWindowLinux::pollEvents() {
                     m_isWindowMapped = false;
                     break;
                 case SDL_WINDOWEVENT_RESTORED:
+                    m_maximized = false;
                     if (m_isWindowVisible) {
                         m_isWindowMapped = true;
                     }
+                    rememberRestoreBoundsIfNormal();
                     break;
                 }
             }
@@ -311,20 +330,56 @@ void PlatformWindowLinux::minimize() {
 }
 
 void PlatformWindowLinux::maximize() {
-    if (m_window)
+    if (m_window) {
+        rememberRestoreBoundsIfNormal(); // capture before the rect becomes the maximized one
         SDL_MaximizeWindow(m_window);
+        m_maximized = true;
+    }
 }
 
 void PlatformWindowLinux::restore() {
-    if (m_window)
+    if (m_window) {
         SDL_RestoreWindow(m_window);
+        m_maximized = false;
+    }
 }
 
 bool PlatformWindowLinux::isMaximized() const {
     if (!m_window)
         return false;
+    // Union of the tracked state and the SDL flag. The flag alone missed
+    // WM-initiated maximize (#655): a window with _NET_WM_STATE_MAXIMIZED_VERT
+    // and _HORZ set reported false, so shutdown persisted "not maximized"
+    // together with the maximized dimensions.
+    if (m_maximized)
+        return true;
     Uint32 flags = SDL_GetWindowFlags(m_window);
     return (flags & SDL_WINDOW_MAXIMIZED) != 0;
+}
+
+bool PlatformWindowLinux::getRestoreBounds(int& x, int& y, int& width, int& height) const {
+    if (!m_hasRestoreBounds)
+        return false;
+    x = m_restoreX;
+    y = m_restoreY;
+    width = m_restoreW;
+    height = m_restoreH;
+    return true;
+}
+
+void PlatformWindowLinux::rememberRestoreBoundsIfNormal() {
+    if (!m_window || isMaximized() || m_isFullscreen)
+        return;
+    int w = 0, h = 0, x = 0, y = 0;
+    SDL_GetWindowSize(m_window, &w, &h);
+    SDL_GetWindowPosition(m_window, &x, &y);
+    if (w <= 0 || h <= 0)
+        return;
+    m_restoreX = x;
+    m_restoreY = y;
+    m_restoreW = w;
+    m_restoreH = h;
+    m_hasRestoreBounds = true;
 }
 
 bool PlatformWindowLinux::isMinimized() const {

--- a/AestraPlat/src/Linux/PlatformWindowLinux.h
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.h
@@ -36,6 +36,7 @@ public:
     void maximize() override;
     void restore() override;
     bool isMaximized() const override;
+    bool getRestoreBounds(int& x, int& y, int& width, int& height) const override;
     bool isMinimized() const override;
     void requestClose() override;
 
@@ -93,6 +94,23 @@ private:
     SDL_Window* m_window = nullptr;
     SDL_GLContext m_glContext = nullptr;
     bool m_isFullscreen = false;
+
+    // Restore (non-maximized) geometry, tracked from window events (#655).
+    // SDL_GetWindowSize reports the maximized rect while maximized, so the
+    // user's chosen size has to be remembered separately or it is lost on save.
+    // Also tracks maximized state from SDL_WINDOWEVENT_MAXIMIZED/RESTORED rather
+    // than SDL_GetWindowFlags: a maximize initiated by the window manager (a
+    // keybind, a titlebar double-click, a tiling compositor) was observed NOT to
+    // update the flag, so the app recorded "not maximized" for a window the WM
+    // had genuinely maximized.
+    int m_restoreX = 0;
+    int m_restoreY = 0;
+    int m_restoreW = 0;
+    int m_restoreH = 0;
+    bool m_hasRestoreBounds = false;
+    bool m_maximized = false;
+
+    void rememberRestoreBoundsIfNormal();
     bool m_isWindowVisible = true;
     bool m_isWindowMapped = true;
     float m_dpiScale = 1.0f;

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -1036,6 +1036,25 @@ bool PlatformWindowWin32::isMaximized() const {
     return wp.showCmd == SW_MAXIMIZE;
 }
 
+bool PlatformWindowWin32::getRestoreBounds(int& x, int& y, int& width, int& height) const {
+    // Win32 maintains this natively: rcNormalPosition IS the restore rectangle,
+    // updated by the OS as the user moves and resizes the un-maximized window.
+    // isMaximized() above already fetches the same structure and discards it (#655).
+    WINDOWPLACEMENT wp = {};
+    wp.length = sizeof(WINDOWPLACEMENT);
+    if (!GetWindowPlacement(m_hwnd, &wp))
+        return false;
+    const LONG w = wp.rcNormalPosition.right - wp.rcNormalPosition.left;
+    const LONG h = wp.rcNormalPosition.bottom - wp.rcNormalPosition.top;
+    if (w <= 0 || h <= 0)
+        return false;
+    x = static_cast<int>(wp.rcNormalPosition.left);
+    y = static_cast<int>(wp.rcNormalPosition.top);
+    width = static_cast<int>(w);
+    height = static_cast<int>(h);
+    return true;
+}
+
 bool PlatformWindowWin32::isMinimized() const {
     return IsIconic(m_hwnd) == TRUE;
 }

--- a/AestraPlat/src/Win32/PlatformWindowWin32.h
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.h
@@ -36,6 +36,7 @@ public:
     void maximize() override;
     void restore() override;
     bool isMaximized() const override;
+    bool getRestoreBounds(int& x, int& y, int& width, int& height) const override;
     bool isMinimized() const override;
 
     void setFullscreen(bool fullscreen) override;

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -447,6 +447,10 @@ bool NUIPlatformBridge::isMaximized() const {
     return m_window ? m_window->isMaximized() : false;
 }
 
+bool NUIPlatformBridge::getRestoreBounds(int& x, int& y, int& width, int& height) const {
+    return m_window ? m_window->getRestoreBounds(x, y, width, height) : false;
+}
+
 void NUIPlatformBridge::requestClose() {
     if (m_window) {
         m_window->requestClose();

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -66,6 +66,8 @@ public:
     void maximize();
     void restore();
     bool isMaximized() const;
+    /// Non-maximized geometry; false when unknown, leaving outputs untouched (#655).
+    bool getRestoreBounds(int& x, int& y, int& width, int& height) const;
     void requestClose();  // Request window close through platform abstraction
     
     // Full screen support

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -295,6 +295,10 @@ bool AestraApp::initializePlatformAndWindow(const UIState& uiState) {
     winConfig.width = uiState.windowWidth;
     winConfig.height = uiState.windowHeight;
     winConfig.fullscreen = false;
+    // #655: the persisted state decides this. It used to be forced true inside
+    // the window manager, so a window saved un-maximized still came back
+    // maximized and the stored size was never visible.
+    winConfig.startMaximized = uiState.maximized;
 
     if (!m_windowManager->initialize(winConfig)) {
         Log::error("Failed to initialize Window Manager");

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -95,7 +95,10 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     desc.height = config.height;
     desc.resizable = true;
     desc.decorated = false;  // Borderless for custom title bar
-    desc.startMaximized = true;  // Start maximized by default
+    // Honour the persisted maximized state instead of forcing it (#655). This
+    // was hard-coded true, so every window was born maximized and a stored
+    // "not maximized" could never take effect.
+    desc.startMaximized = config.startMaximized;
 
     if (!m_window->create(desc)) {
         Log::error("Failed to create window");
@@ -933,27 +936,43 @@ void AestraWindowManager::renderCustomCursor() {
 AestraWindowManager::WindowState AestraWindowManager::captureWindowState() const {
     WindowState state;
     if (m_window) {
-        m_window->getPosition(state.x, state.y);
-        m_window->getSize(state.width, state.height);
+        // Persist the RESTORE geometry, not the current rect (#655). While
+        // maximized, getSize() returns the maximized rectangle; writing that into
+        // width/height destroyed the size the user actually chose, and
+        // applyWindowState never reads it back because it skips sizing entirely
+        // when the maximized flag is set. Verified under a nested stacking WM:
+        // a 500x360 window, maximized and closed, persisted as 640x480.
         state.maximized = m_window->isMaximized();
+        if (!m_window->getRestoreBounds(state.x, state.y, state.width, state.height)) {
+            m_window->getPosition(state.x, state.y);
+            m_window->getSize(state.width, state.height);
+        }
     }
     return state;
 }
 
 void AestraWindowManager::applyWindowState(const WindowState& state) {
     if (!m_window) return;
-    
-    // Only apply position/size if not maximized (maximized state handled separately)
-    if (!state.maximized) {
-        // Validate reasonable bounds (prevent off-screen or tiny windows)
-        if (state.width >= 640 && state.height >= 480) {
-            m_window->setSize(state.width, state.height);
-            // Only set position if it seems reasonable (not negative/off-screen by much)
-            if (state.x > -1000 && state.y > -1000) {
-                m_window->setPosition(state.x, state.y);
-            }
+
+    // Restore geometry is applied ALWAYS, then the maximized state is layered on
+    // top (#655). Previously the two were exclusive, so a window restored as
+    // maximized had no restore geometry to un-maximize back to, and a window
+    // restored as non-maximized could not escape the maximized state it was born
+    // in (see startMaximized in initialize()).
+    if (state.width >= 640 && state.height >= 480) {
+        m_window->setSize(state.width, state.height);
+        if (state.x > -1000 && state.y > -1000) {
+            m_window->setPosition(state.x, state.y);
         }
-    } else {
+    }
+
+    if (state.maximized) {
         m_window->maximize();
+    } else {
+        // Explicitly leave the maximized state. The window is created with
+        // SDL_WINDOW_MAXIMIZED (see initialize()), so without this a persisted
+        // "not maximized" was silently ignored — observed under a nested
+        // stacking WM as a 500x360 request rendering full-screen.
+        m_window->restore();
     }
 }

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -43,6 +43,8 @@ public:
         int height;
         /** @brief Whether the window starts in fullscreen mode. */
         bool fullscreen;
+        /** @brief Whether the window starts maximized (#655: was hard-coded true). */
+        bool startMaximized = true;
     };
 
     using TransportAction = Aestra::TransportAction;

--- a/scripts/verify-window-restore.sh
+++ b/scripts/verify-window-restore.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Verify window restore-geometry survival under a real stacking WM (#655).
+#
+# Hyprland tiles Aestra and reports _NET_WM_STATE_MAXIMIZED for a tiled window,
+# so maximize/restore semantics cannot be tested on the host session. This runs a
+# nested X server with openbox inside it. Nothing about the host display or
+# compositor configuration is touched.
+#
+# Requires: xorg-server-xephyr, openbox, wmctrl  (xprop optional but recommended)
+#
+# Usage:  ./verify-window-restore.sh /path/to/Aestra
+#
+# NOTE: -screen is deliberately FIXED (no -resizeable). A tiling host compositor
+# will size the Xephyr *window* to its own layout, and with -resizeable the
+# nested screen shrinks to match — which silently invalidates the test by making
+# the requested window larger than the screen.
+
+set -uo pipefail
+
+APP="${1:-./build-linux/bin/Aestra}"
+DISP=":9"
+SCREEN="1000x700"
+SEED_W=760
+SEED_H=540
+STATE="$HOME/.local/share/Aestra/ui_state.json"
+BACKUP="$(mktemp)"
+
+cleanup() {
+    [ -n "${APP_PID:-}" ] && kill -KILL "$APP_PID" 2>/dev/null
+    [ -n "${OB_PID:-}" ] && kill -KILL "$OB_PID" 2>/dev/null
+    [ -n "${XE_PID:-}" ] && kill -KILL "$XE_PID" 2>/dev/null
+    rm -f "$HOME/.local/share/Aestra/crash_flag"
+    if [ -s "$BACKUP" ]; then
+        cp "$BACKUP" "$STATE"
+        echo "[cleanup] ui_state.json restored"
+    fi
+    rm -f "$BACKUP"
+}
+trap cleanup EXIT
+
+[ -x "$APP" ] || { echo "no executable at $APP"; exit 2; }
+cp "$STATE" "$BACKUP" 2>/dev/null || true
+
+echo "== starting nested session on $DISP ($SCREEN) =="
+Xephyr "$DISP" -screen "$SCREEN" -ac >/dev/null 2>&1 &
+XE_PID=$!
+for _ in $(seq 1 20); do [ -S "/tmp/.X11-unix/X${DISP#:}" ] && break; sleep 1; done
+DISPLAY="$DISP" openbox --replace >/dev/null 2>&1 &
+OB_PID=$!
+sleep 3
+DISPLAY="$DISP" wmctrl -m >/dev/null 2>&1 || { echo "FAIL: no WM in nested session"; exit 1; }
+
+echo "== seeding ${SEED_W}x${SEED_H}, maximized=false =="
+python3 - "$STATE" "$SEED_W" "$SEED_H" <<'PY'
+import json, sys
+p, w, h = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+try:    d = json.load(open(p))
+except Exception: d = {}
+d["window"] = {"x": 40, "y": 30, "width": w, "height": h, "maximized": False}
+json.dump(d, open(p, "w"), indent=2)
+PY
+
+DISPLAY="$DISP" SDL_VIDEODRIVER=x11 "$APP" >/tmp/aestra-nested.log 2>&1 &
+APP_PID=$!
+for _ in $(seq 1 60); do DISPLAY="$DISP" wmctrl -l 2>/dev/null | grep -qi aestra && break; sleep 1; done
+sleep 4
+
+geom() { DISPLAY="$DISP" wmctrl -lG | grep -i aestra | awk '{print $5"x"$6}'; }
+state() { local id; id=$(DISPLAY="$DISP" wmctrl -l | grep -i aestra | awk '{print $1}')
+          DISPLAY="$DISP" xprop -id "$id" _NET_WM_STATE 2>/dev/null | grep -o MAXIMIZED_VERT || echo "not-maximized"; }
+
+echo
+echo "-- CHECK 1: a window seeded non-maximized must NOT be born maximized --"
+echo "   geometry: $(geom)   wm state: $(state)"
+[ "$(geom)" = "${SEED_W}x${SEED_H}" ] && echo "   PASS" || echo "   FAIL (expected ${SEED_W}x${SEED_H})"
+
+echo
+echo "-- CHECK 2: maximize, quit, and the RESTORE size must survive --"
+DISPLAY="$DISP" wmctrl -r "Aestra v1.0" -b add,maximized_vert,maximized_horz
+sleep 3
+echo "   maximized to: $(geom)"
+DISPLAY="$DISP" wmctrl -c "Aestra v1.0"
+echo "   (dismiss the unsaved-changes dialog if it appears)"
+for _ in $(seq 1 30); do kill -0 "$APP_PID" 2>/dev/null || break; sleep 1; done
+
+python3 - "$STATE" "$SEED_W" "$SEED_H" <<'PY'
+import json, sys
+p, w, h = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+d = json.load(open(p))["window"]
+print(f"   persisted: {d['width']}x{d['height']} maximized={d['maximized']}")
+ok = d["width"] == w and d["height"] == h and d["maximized"] is True
+print("   PASS" if ok else f"   FAIL (expected {w}x{h} maximized=True)")
+PY


### PR DESCRIPTION
Fixes #655.

Verified under a nested stacking window manager, which found **two defects the issue did not describe** — including one that made the whole feature inert.

## What the nested session changed

Hyprland tiles Aestra and reports `_NET_WM_STATE_MAXIMIZED` for a *tiled* window, so maximize/restore semantics are untestable on the host session. Running Xephyr + openbox made the real behaviour visible, and it was worse than the structural argument in the issue predicted.

## Root causes — three, not one

**A. The window was always born maximized.** `AestraWindowManager.cpp:98` hard-coded

```cpp
desc.startMaximized = true;  // Start maximized by default
```

so `SDL_WINDOW_MAXIMIZED` was set at creation regardless of the persisted state. A stored `maximized=false` could never take effect. Seeded 900×600 → rendered full-screen, with `xprop` confirming `_NET_WM_STATE_MAXIMIZED_VERT` and `_HORZ`.

**B. Maximized size overwrote the restore geometry** — the defect as filed. `getSize()` returns the maximized rect, and it was written into the same `width`/`height` fields meant to carry restore geometry, which `applyWindowState` then skipped reading because the maximized flag was set.

**C. `isMaximized()` missed WM-initiated maximize.** `SDL_GetWindowFlags & SDL_WINDOW_MAXIMIZED` returned **false** for a window the WM had genuinely maximized (verified by `xprop`). A maximize from a WM keybind, a titlebar double-click, or a tiling compositor does not update the flag.

B and C compose into the worst available outcome:

```
seeded:   500x360  maximized=false        (user intent)
written:  640x480  maximized=false        (maximized dims, wrong state)
```

The chosen size is destroyed **and** the app will apply the maximized size as a normal window next launch. Unrecoverable.

## The verification-ladder trap, live

The log said exactly the right thing while the behaviour did not happen:

```
[UIState] Applied window state: 900x600 at (60,50) maximized=false
```

Correct numbers, code path executed, window sitting full-screen. Un-maximizing it revealed 900×600 held as *restore* geometry — the setters had worked. The window was simply never told to leave the state it was born in. A log line asserting its own success, which is precisely what `docs/technical/engineering-health.md` §8 warns about.

## Invariant established

> **Restore geometry and maximized state are independent persisted facts.** The persisted size/position always describe the non-maximized window; the maximized flag is applied on top. Restoring applies geometry first, then re-maximizes if flagged.

## Changes

| file | change |
|---|---|
| `AestraPlat/include/AestraPlatform.h` | `IPlatformWindow::getRestoreBounds()` |
| `AestraPlat/src/Win32/PlatformWindowWin32.{h,cpp}` | returns `WINDOWPLACEMENT::rcNormalPosition` — which `isMaximized()` was already fetching and discarding |
| `AestraPlat/src/Linux/PlatformWindowLinux.{h,cpp}` | tracks restore bounds from `MOVED`/`RESIZED`/`RESTORED`; tracks maximized from `MAXIMIZED`/`RESTORED` events; seeds restore bounds from the creation size |
| `AestraUI/Platform/NUIPlatformBridge.{h,cpp}` | forwarder |
| `Source/Core/AestraWindowManager.{h,cpp}` | capture persists restore bounds; apply sets geometry **always** then layers maximize/restore; `startMaximized` comes from config |
| `Source/App/AestraApp.cpp` | passes the persisted `maximized` into the window config |
| `scripts/verify-window-restore.sh` | new — repeatable nested-WM verification |

`isMaximized()` now unions the tracked state with the SDL flag, so a WM-initiated maximize is seen without regressing the SDL-initiated path.

## Reproduction — fully repeatable, host untouched

```bash
scripts/verify-window-restore.sh ./build-linux/bin/Aestra
```

It brings up its own `Xephyr` + `openbox`, seeds a known geometry, checks, and restores your `ui_state.json` on exit via a trap. **Nothing about the host compositor or display configuration is changed.**

One trap worth knowing, documented in the script: `-screen` must be **fixed**, not `-resizeable`. A tiling host compositor sizes the Xephyr *window* to its own layout, and with `-resizeable` the nested screen shrinks to match — silently invalidating the test by making the requested window larger than the screen. That cost me a run.

A second, subtler one: the seed size must clear `applyWindowState`'s existing `>= 640x480` guard, or the size is legitimately ignored and the test fails for the wrong reason. I hit this with a 500×360 seed and corrected the protocol rather than the guard.

## Verification rung

**Behaviour observed**, before and after, in the nested session.

**Not unit-tested, deliberately.** The defect lives in window-manager interaction — creation flags, EWMH state, event-driven geometry tracking — which has no headless harness. A unit test here could only pin a one-line ternary and would imply coverage that does not exist. The scripted reproduction is the honest artefact, and it is checked in so the result is independently repeatable rather than a claim in a PR description.

**Win32 is compiled-only.** `rcNormalPosition` is the documented correct API and `isMaximized()` already used the same call, but I could not run it here. Stated rather than implied.

## Compatibility

**No schema change.** `window.width`/`height` keep their names and simply start holding what they were always meant to hold. Existing `ui_state.json` files load unchanged — some contain a maximized size, which is no worse than today's behaviour and self-corrects on the first clean shutdown.

## Remaining risks

- The pre-existing `>= 640x480` guard in `applyWindowState` still silently discards smaller persisted windows. Left as-is — changing it is a behavioural decision unrelated to this defect, and #655 is about geometry being destroyed, not about the threshold.
- Restore-bounds tracking on Linux depends on SDL delivering `MOVED`/`RESIZED` while un-maximized. If a compositor never sends them, the seeded creation size is the fallback, which is the previous behaviour rather than a regression.
- The `maximized` flag under a tiling compositor remains whatever the compositor reports. This PR does not add tiling-specific heuristics; on Hyprland the persisted state will still reflect Hyprland's notion of maximized, which is its own question.
