### PR TITLE
Building the default project is not an edit (#653)

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -241,6 +241,17 @@ AestraContent::AestraContent()
 
     addDemoTracks();
 
+    // Building the default project is not an edit (#653). addDemoTracks() calls
+    // TrackManager::addChannel() fifty times, and addChannel legitimately marks
+    // the project modified — so construction left every fresh launch dirty, and
+    // closing without touching anything prompted "Unsaved Changes".
+    //
+    // resetToDefaultProject() already ends this way; only the constructor path
+    // omitted it. The clear belongs here rather than inside addDemoTracks(),
+    // which is named for what it adds and should not carry a surprising
+    // dirty-state side effect for any future caller.
+    m_trackManager->setModified(false);
+
     // Defer audio-engine wiring until setAudioEngine() receives the live controller engine.
 
     setupTrackManagerUI();

--- a/Tests/AestraAudio/ProjectDirtyStateTest.cpp
+++ b/Tests/AestraAudio/ProjectDirtyStateTest.cpp
@@ -179,6 +179,49 @@ int main() {
                 "Registering a panel listener must not displace project dirty tracking");
     }
 
+    // -------------------------------------------------------------------
+    // Building default content is not an edit (#653).
+    //
+    // AestraContent's constructor calls addDemoTracks(), which calls
+    // addChannel() fifty times. addChannel legitimately marks the project
+    // modified, so construction left every fresh launch dirty and closing
+    // without touching anything prompted "Unsaved Changes" — confirmed by
+    // instrumenting all eight dirty-write sites: exactly one transition,
+    // addChannel during ContentConstruction, never cleared.
+    //
+    // AestraContent cannot be constructed headlessly, so this pins the
+    // TrackManager half of the contract: the population-then-clear sequence
+    // the constructor now performs must leave the project clean, AND a real
+    // edit afterwards must still dirty it.
+    //
+    // The second half is the important one. It fails if anyone ever "fixes"
+    // this class of defect with a startup-wide suppression guard or by
+    // weakening addChannel — both of which would make the first assertion
+    // pass and this one fail.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+
+        require(!tracks.isModified(), "A newly constructed TrackManager is not modified");
+
+        // What addDemoTracks() does.
+        for (int i = 1; i <= 50; ++i) {
+            tracks.addChannel("Insert " + std::to_string(i));
+        }
+        require(tracks.isModified(),
+                "addChannel must still mark the project modified — the defect is not "
+                "that addChannel dirties, it is that construction never cleared");
+
+        // What the constructor now does after populating.
+        tracks.setModified(false);
+        require(!tracks.isModified(), "Default content, once built, leaves the project clean");
+
+        // A real user edit through the very same path must dirty it again.
+        tracks.addChannel("User added this one");
+        require(tracks.isModified(),
+                "A channel added after construction must mark the project modified");
+    }
+
     std::cout << "[PASS] ProjectDirtyStateTest\n";
     return 0;
 }


### PR DESCRIPTION
Fixes #653.

A fresh launch reported unsaved changes. Closing without touching anything prompted **"Unsaved Changes"** — which trains users to dismiss the one warning that protects against losing real work.

## Root cause — corrected

I initially narrowed this to the Settings dialog, using periodic-autosave cadence as an instrument for dirtiness. **That was wrong, and the instrumentation disproved it.**

There are two flags. The close prompt reads `TrackManager::isModified()`; periodic autosave reads `AutosaveManager::m_isDirty`. `addChannel` writes the first via a direct `m_modified.store(true)` that never fires `m_onModified`, so autosave was never told. The project was dirty from content construction in every run — including the two earlier runs that "agreed" with each other, because they shared the same false premise.

Instrumenting all **eight** dirty-write sites (seven of which bypass `markModified()` entirely) found exactly one startup transition, identical in all five cases:

```
main → AestraApp::initialize → initializeContent
     → AestraContent::AestraContent()
     → AestraContent::addDemoTracks()      (50 default tracks)
     → TrackManager::addChannel()
```

First call transitions 0→1; the other 49 are no-ops. Nothing after `addDemoTracks()` touches the flag.

**Classification: initialization leakage.** `addChannel` marks the project modified, and it is right to — adding a channel *is* an edit when a user does it. The defect is that building the default project runs through that path and never clears afterwards. Loading a project masked it, because load clears the flag one line later; only the no-project path — what a normal launch takes — stayed dirty.

## The fix

`resetToDefaultProject()` already ends with `setModified(false)` after the same `addDemoTracks()` call. **The constructor path simply omitted it.** This makes two paths that construct the same content agree — engineering-health §6, not a new suppression.

Placed at the call site rather than inside `addDemoTracks()`, which is named for what it adds and should not carry a dirty-state side effect for a future caller.

**Rejected**, and why:
- *Startup-wide suppression guard* — would hide legitimate migrations and every future defect of this shape.
- *Weakening `addChannel`* — the mutation is real; the problem is the context, not the call.

## Cases run

| case | before | after |
|---|---|---|
| new empty project | dirty, never cleared | clean |
| v3 current, no migration | masked by load's clear | unchanged |
| v2 requiring migration | masked by load's clear | unchanged |
| project with unavailable plugin | masked by load's clear | unchanged — the plugin path never reaches `markModified()` |
| launch → no action → close | **prompt** | **no prompt** |

The missing-plugin fixture had its integrity checksum stripped so the Mismatch path could not confound the result.

## Runtime verification — both directions

Both matter. A fix that silently disabled the save prompt would look identical to one that worked.

```
launch → zero interaction → close
  exits cleanly, no prompt, no emergency autosave
  (the emergency autosave is gated on isModified(), so its absence is a second signal)

launch → add a track → close
  "Added Playlist lane via command", laneCount 50 → 51
  prompt appears, emergency autosave fires
```

Run in a nested Xephyr + openbox session so it did not disturb the desktop.

## Test

Appended to `ProjectDirtyStateTest` — already the dirty-state authority test from #551/#627:

1. fresh `TrackManager` is not modified
2. 50 × `addChannel` → **modified** (pins that `addChannel` is not weakened)
3. `setModified(false)` → clean (what the constructor now does)
4. one more `addChannel` → **modified** (a real edit after construction still dirties)

**Assertions 2 and 4 are the point.** They fail if anyone later "fixes" this class of defect with a startup-wide guard or by making `addChannel` non-dirtying — both of which would leave assertion 3 passing.

## Verification rung — stated precisely

- **Behaviour observed** for the end-to-end fix, both directions, driven.
- **Behaviour regression-tested** for the contract: population-then-clear leaves clean; a subsequent edit dirties.
- **The `AestraContent` call site itself is not unit-tested.** `AestraContent` cannot be constructed headlessly, so reverting the one-line change would *not* fail the test. The contract is pinned; the call site is drive-verified only. Saying so rather than implying coverage that does not exist.

## Instrumentation

Fully removed. `DirtyStateTrace.h` deleted, all eight sites restored, build flags reset. The diff is two files.

## Split out, deliberately not expanded into this PR

- **#662** — the post-load `setModified(false)` is unconditional and `LoadResult` carries no migration signal, so a future meaningful migration would be masked. Latent today because `migrateV2ToV3` is a documented no-op.
- **#663** — seven of eight dirty writes bypass `markModified()`, so the callback observer cannot be authoritative while direct stores remain valid write paths. No live data-loss path established; the structural hazard is what already produced my wrong conclusion above.

## Compatibility

None affected. No format, schema or API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Clear the project’s modified state after creating the 50 default demo tracks, preventing an unsaved-changes prompt on fresh launches.
- Add regression coverage confirming default population is cleared while subsequent track additions still mark the project as modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->