### PR TITLE
Segmented indicator snaps on first sync instead of sliding in

### DIFF
--- a/AestraUI/Base/NUISegmentedControl.h
+++ b/AestraUI/Base/NUISegmentedControl.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 #include "NUIComponent.h"
+#include "NUISlidingIndicator.h"
 #include "NUIRenderer.h"
 #include "NUITypes.h"
 #include "NUIThemeSystem.h"
@@ -26,7 +27,6 @@ public:
     NUISegmentedControl(const std::vector<std::string>& segments)
         : segments_(segments)
         , selectedIndex_(0)
-        , indicatorPosition_(0.0f)
         , cornerRadius_(-1.0f)
         , accentColor_(NUIThemeManager::getInstance().getColor("accentPrimary"))
         , hoveredIndex_(-1)
@@ -39,14 +39,14 @@ public:
         if (index >= segments_.size()) return;
         if (index == selectedIndex_) {
             if (!animate) {
-                indicatorPosition_ = static_cast<float>(index);
+                indicator_.snapTo(static_cast<float>(index));
                 setDirty(true);
             }
             return;
         }
         selectedIndex_ = index;
         if (!animate) {
-            indicatorPosition_ = static_cast<float>(index);
+            indicator_.snapTo(static_cast<float>(index));
         }
         if (onSelectionChanged_) {
             onSelectionChanged_(selectedIndex_);
@@ -139,7 +139,7 @@ public:
         }
         
         // Sliding indicator
-        float indicatorX = bounds.x + padding + indicatorPosition_ * segmentWidth;
+        float indicatorX = bounds.x + padding + indicator_.position() * segmentWidth;
         NUIRect indicatorRect(indicatorX, bounds.y + padding, indicatorWidth, indicatorHeight);
         
         renderer.fillRoundedRect(indicatorRect, radius - padding,
@@ -166,18 +166,15 @@ public:
     }
     
     void onUpdate(double deltaTime) override {
-        // Animate indicator sliding
-        float targetPos = static_cast<float>(selectedIndex_);
-        float diff = targetPos - indicatorPosition_;
-        if (std::abs(diff) > 0.001f) {
-            float speed = 12.0f; // Animation speed
-            indicatorPosition_ += diff * speed * static_cast<float>(deltaTime);
-            if (std::abs(targetPos - indicatorPosition_) < 0.01f) {
-                indicatorPosition_ = targetPos;
-            }
+        // selectedIndex_ remains the single authority; the indicator chases it.
+        // The first sync snaps (nothing to animate from), later ones animate,
+        // and an unchanged target does nothing — so layout, resize or segment
+        // changes never replay a selection animation.
+        constexpr float kIndicatorSpeed = 12.0f;
+        if (indicator_.sync(static_cast<float>(selectedIndex_), deltaTime, kIndicatorSpeed)) {
             setDirty(true);
         }
-        
+
         NUIComponent::onUpdate(deltaTime);
     }
     
@@ -233,7 +230,11 @@ public:
 private:
     std::vector<std::string> segments_;
     size_t selectedIndex_;
-    float indicatorPosition_; // Animated position (0.0 to segments_.size()-1)
+    // Indicator position + whether it has ever been synchronised (#653 follow-up).
+    // Initialisation is explicit state, not inferred from the position value:
+    // 0.0f is a valid position, so it cannot distinguish "never initialised"
+    // from "correctly on segment zero".
+    NUISlidingIndicator indicator_;
     float cornerRadius_;
     NUIColor accentColor_;
     int hoveredIndex_;

--- a/AestraUI/Base/NUISlidingIndicator.h
+++ b/AestraUI/Base/NUISlidingIndicator.h
@@ -1,0 +1,99 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// Sliding-indicator animation state for segmented controls (#653 follow-up).
+//
+// The defect this exists to prevent: an indicator whose position is simply
+// default-initialized to 0 animates from segment 0 to its real segment on the
+// first frames, so a control that opens on any segment other than the first
+// visibly slides in from the left — animating from a position it was never in.
+//
+// Aestra's view toggle defaults to "Timeline" (index 1), which made it visible
+// on every launch. Four other segmented controls avoided it only because they
+// happen to select index 0, which is where the default position already sits.
+// That is luck, not correctness, and it is why this is caller-proof rather than
+// an `animate=false` argument every call site has to remember.
+//
+// Deliberately free of widget, renderer and theme dependencies so the behaviour
+// can be tested without linking AestraUI (which AESTRA_CI=ON disables).
+
+#include <cmath>
+
+namespace AestraUI {
+
+/**
+ * @brief Position of a sliding selection indicator, in SEGMENT-INDEX space.
+ *
+ * Index space rather than pixels is what makes resizing safe: the logical
+ * position is resolution-independent, so a geometry change recomputes pixel
+ * coordinates from the same index without replaying a selection animation.
+ */
+class NUISlidingIndicator {
+public:
+    /// Distance below which the indicator is considered settled on its target.
+    static constexpr float kSettleEpsilon = 0.01f;
+
+    /**
+     * @brief Has this indicator ever been synchronised to an authoritative target?
+     *
+     * Tracked explicitly. It must NOT be inferred from the position value —
+     * 0.0f is a perfectly valid position (segment zero), so "position == 0"
+     * cannot distinguish "never initialised" from "correctly sitting on the
+     * first segment". Conflating them is the original defect.
+     */
+    bool isInitialized() const { return initialized_; }
+
+    /// Current position, in segment-index space.
+    float position() const { return position_; }
+
+    /**
+     * @brief Synchronise toward the authoritative selected segment.
+     *
+     * The FIRST synchronisation snaps: an indicator that has never had a real
+     * position has nothing to animate from. Every later synchronisation
+     * animates, and only when the target actually differs from where the
+     * indicator already is.
+     *
+     * @return true when the position changed and the caller should repaint.
+     */
+    bool sync(float target, double deltaTime, float speed) {
+        if (!initialized_) {
+            position_ = target;
+            initialized_ = true;
+            return true;
+        }
+
+        const float diff = target - position_;
+        if (std::abs(diff) <= kSettleEpsilon) {
+            if (position_ != target) {
+                position_ = target; // settle exactly; no further frames needed
+                return true;
+            }
+            return false; // already there — unchanged target does nothing
+        }
+
+        position_ += diff * speed * static_cast<float>(deltaTime);
+        if (std::abs(target - position_) < kSettleEpsilon) {
+            position_ = target;
+        }
+        return true;
+    }
+
+    /**
+     * @brief Place the indicator directly, without animating.
+     *
+     * For an explicitly non-animated selection, and for any geometry change
+     * that must preserve the logical segment rather than replay a selection
+     * animation. Counts as initialisation.
+     */
+    void snapTo(float target) {
+        position_ = target;
+        initialized_ = true;
+    }
+
+private:
+    float position_ = 0.0f;
+    bool initialized_ = false;
+};
+
+} // namespace AestraUI

--- a/Tests/AestraUI/SlidingIndicatorTest.cpp
+++ b/Tests/AestraUI/SlidingIndicatorTest.cpp
@@ -1,0 +1,196 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Sliding-indicator first-sync semantics (segmented control, #653 follow-up).
+//
+// The reported symptom: on launch the view toggle's indicator "comes from the
+// far left and bounces in". Aestra's toggle defaults to Timeline (index 1),
+// while the indicator position was default-constructed to 0 — so the first
+// frames animated it from segment 0 to segment 1. It was animating from a
+// position it had never been in.
+//
+// Four other segmented controls in the tree avoided this only because they
+// select index 0, which is where the default position already sat. That is
+// luck, not correctness, which is why the fix is caller-proof rather than an
+// `animate=false` argument every call site must remember.
+//
+// The invariant under test:
+//
+//   The first synchronisation snaps the indicator directly to the authoritative
+//   selected segment. Only subsequent genuine selection transitions animate.
+
+#include "NUISlidingIndicator.h"
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+using AestraUI::NUISlidingIndicator;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const std::string& what) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+void nearly(float got, float want, const std::string& what) {
+    if (std::abs(got - want) > 1e-4f) {
+        std::cerr << "[FAIL] " << what << ": got " << got << ", wanted " << want << '\n';
+        ++g_failures;
+    }
+}
+
+constexpr double kFrame = 1.0 / 60.0;
+constexpr float kSpeed = 12.0f;
+
+// Run frames until settled or the budget runs out; returns frames consumed.
+int settle(NUISlidingIndicator& ind, float target, int maxFrames = 600) {
+    int frames = 0;
+    while (frames < maxFrames && ind.sync(target, kFrame, kSpeed)) {
+        ++frames;
+    }
+    return frames;
+}
+
+} // namespace
+
+int main() {
+    // --- 1. constructed with a NON-first segment selected -> appears there at once
+    // This is the reported bug: Timeline is index 1.
+    {
+        NUISlidingIndicator ind;
+        check(!ind.isInitialized(), "starts uninitialised");
+
+        const bool changed = ind.sync(1.0f, kFrame, kSpeed);
+        check(changed, "first sync reports a change");
+        nearly(ind.position(), 1.0f, "first sync SNAPS to segment 1, no slide from 0");
+        check(ind.isInitialized(), "first sync marks initialised");
+
+        // And it must be settled — not mid-animation.
+        check(!ind.sync(1.0f, kFrame, kSpeed), "already on target: no further movement");
+    }
+
+    // --- 2. first selection is segment ZERO -> still initialises correctly
+    // Zero is a valid position, so initialisation cannot be inferred from it.
+    {
+        NUISlidingIndicator ind;
+        check(!ind.isInitialized(), "uninitialised before first sync");
+        ind.sync(0.0f, kFrame, kSpeed);
+        check(ind.isInitialized(), "syncing to zero initialises (zero is a valid position)");
+        nearly(ind.position(), 0.0f, "position is zero");
+
+        // The proof that it really initialised rather than staying unset: a
+        // later change must ANIMATE, not snap.
+        const bool moved = ind.sync(2.0f, kFrame, kSpeed);
+        check(moved, "later change moves");
+        check(ind.position() > 0.0f && ind.position() < 2.0f,
+              "later change ANIMATES from zero rather than snapping");
+    }
+
+    // --- 3. change selection after initialisation -> animates
+    {
+        NUISlidingIndicator ind;
+        ind.sync(0.0f, kFrame, kSpeed); // initialise
+
+        ind.sync(3.0f, kFrame, kSpeed);
+        check(ind.position() > 0.0f && ind.position() < 3.0f, "animates toward the new target");
+
+        const int frames = settle(ind, 3.0f);
+        check(frames > 1, "took multiple frames (it animated rather than snapping)");
+        nearly(ind.position(), 3.0f, "settles exactly on the target");
+    }
+
+    // --- 4. setting the SAME selection again -> no animation restart
+    {
+        NUISlidingIndicator ind;
+        ind.snapTo(2.0f);
+        check(!ind.sync(2.0f, kFrame, kSpeed), "unchanged target: no change reported");
+        nearly(ind.position(), 2.0f, "unchanged target: position untouched");
+
+        // Repeated syncs must stay quiet — a control that keeps reporting
+        // changes would repaint forever.
+        for (int i = 0; i < 10; ++i) {
+            check(!ind.sync(2.0f, kFrame, kSpeed), "repeated identical sync stays quiet");
+        }
+    }
+
+    // --- 5. programmatic restoration -> first synchronisation snaps
+    // Same path as user selection; the only difference is that nothing has
+    // synchronised yet.
+    {
+        NUISlidingIndicator restored;
+        restored.sync(4.0f, kFrame, kSpeed);
+        nearly(restored.position(), 4.0f, "restored selection snaps on first sync");
+
+        // Explicit non-animated selection also snaps, at any time.
+        NUISlidingIndicator ind;
+        ind.sync(0.0f, kFrame, kSpeed);
+        ind.snapTo(5.0f);
+        nearly(ind.position(), 5.0f, "snapTo places directly");
+        check(!ind.sync(5.0f, kFrame, kSpeed), "after snapTo it is settled, not animating");
+    }
+
+    // --- 6. resize after initialisation -> stays aligned with the segment
+    // Position is in SEGMENT-INDEX space, so a geometry change recomputes pixel
+    // coordinates from the same index. Nothing about a resize may move it or
+    // replay a selection animation.
+    {
+        NUISlidingIndicator ind;
+        ind.sync(2.0f, kFrame, kSpeed);
+
+        // A resize is not a selection change: the target is unchanged, so
+        // syncing across it must be a no-op.
+        for (int i = 0; i < 5; ++i) {
+            check(!ind.sync(2.0f, kFrame, kSpeed), "resize frames do not move the indicator");
+        }
+        nearly(ind.position(), 2.0f, "still on its segment after resize frames");
+
+        // Geometry rebuild that wants an explicit re-place must not animate.
+        ind.snapTo(2.0f);
+        nearly(ind.position(), 2.0f, "explicit geometry snap keeps the logical segment");
+        check(!ind.sync(2.0f, kFrame, kSpeed), "no animation replayed after geometry snap");
+    }
+
+    // --- 7. rapid successive changes -> ends at the LATEST authoritative target
+    {
+        NUISlidingIndicator ind;
+        ind.sync(0.0f, kFrame, kSpeed);
+
+        ind.sync(1.0f, kFrame, kSpeed);
+        ind.sync(4.0f, kFrame, kSpeed);
+        ind.sync(2.0f, kFrame, kSpeed); // user lands here
+
+        const int frames = settle(ind, 2.0f);
+        check(frames > 0, "still animating toward the final target");
+        nearly(ind.position(), 2.0f, "settles on the LATEST target, not an intermediate one");
+
+        // Never overshoots past the final target during the chase.
+        NUISlidingIndicator ind2;
+        ind2.sync(0.0f, kFrame, kSpeed);
+        for (int i = 0; i < 200; ++i) {
+            ind2.sync(3.0f, kFrame, kSpeed);
+            check(ind2.position() <= 3.0f + 1e-4f, "never overshoots the target");
+        }
+    }
+
+    // --- backwards motion works too (higher index -> lower)
+    {
+        NUISlidingIndicator ind;
+        ind.snapTo(5.0f);
+        ind.sync(1.0f, kFrame, kSpeed);
+        check(ind.position() < 5.0f && ind.position() > 1.0f, "animates backwards");
+        settle(ind, 1.0f);
+        nearly(ind.position(), 1.0f, "settles going backwards");
+    }
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] SlidingIndicatorTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] SlidingIndicatorTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1949,3 +1949,13 @@ target_include_directories(AudioSettingsStoreTest PRIVATE
 )
 add_test(NAME AudioSettingsStoreTest COMMAND AudioSettingsStoreTest)
 set_tests_properties(AudioSettingsStoreTest PROPERTIES LABELS "audio;settings;regression")
+
+# Sliding-indicator first-sync semantics (segmented control, #653 follow-up).
+# Header-only and widget-free by design so the animation contract is reachable
+# without linking AestraUI, which AESTRA_CI=ON disables.
+add_executable(SlidingIndicatorTest AestraUI/SlidingIndicatorTest.cpp)
+target_include_directories(SlidingIndicatorTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraUI/Base
+)
+add_test(NAME SlidingIndicatorTest COMMAND SlidingIndicatorTest)
+set_tests_properties(SlidingIndicatorTest PROPERTIES LABELS "ui;regression")


### PR DESCRIPTION
Reported directly: on boot the view toggle's indicator "comes from the far left and bounces in, like it wasn't there to begin with."

That reading is exactly right — it was animating from a position it had never been in.

## Root cause

```cpp
// NUISegmentedControl.h — constructor
, indicatorPosition_(0.0f)          // segment 0 = Arsenal

// AestraContent.cpp:287
m_viewToggle->setSelectedIndex(1);  // Timeline — `animate` defaults to TRUE
```

The indicator was default-constructed onto segment 0, then `onUpdate` animated it rightward to Timeline over the first frames.

**Four other segmented controls escaped this only because they select index 0**, which is where the default position already sat (`AestraContent.cpp:728, 1095, 1216`, plus `PatternBrowserPanel`, `UIMixerInspector`, `NUIMixerWidgets`). That is luck, not correctness — the moment any of them defaults to a non-zero segment, the same slide appears. Hence caller-proof rather than an `animate=false` argument every call site must remember.

## Invariant established

> **The first synchronisation of a segmented control snaps the indicator directly to the authoritative selected segment. Only subsequent genuine selection transitions animate.**

## Design

`NUISlidingIndicator` owns the position and an **explicit** initialization flag.

Initialization is deliberately *not* inferred from the position value. `0.0f` is a perfectly valid position, so `position == 0` cannot distinguish "never synchronised" from "correctly sitting on the first segment" — and conflating them is the original defect in miniature. This is the same trap as #648's `device=0` and #649's `kUnset`: a legal value being used as a sentinel.

- **First sync** → snap, mark initialized, no animation.
- **Later syncs** → animate toward the target, and only when it actually differs.
- **Unchanged target** → nothing happens, so layout, resize and segment-count changes never replay a selection animation.
- **Position stays in segment-index space**, so a geometry change recomputes pixel coordinates from the same logical index. Resize needs no special handling at all.
- `selectedIndex_` remains the single authority; the indicator chases it from `onUpdate`, which keeps programmatic restoration and user selection on **one** synchronisation path.
- `snapTo()` covers explicit non-animated selection and any geometry rebuild that must not animate.

Deliberately narrow: no restructuring of the control beyond replacing the raw float with the animator.

## Files

| file | change |
|---|---|
| `AestraUI/Base/NUISlidingIndicator.h` | new — position + explicit initialization, dependency-free |
| `AestraUI/Base/NUISegmentedControl.h` | uses it; `onUpdate` syncs; `setSelectedIndex(…, false)` snaps |
| `Tests/AestraUI/SlidingIndicatorTest.cpp` | new |
| `Tests/CMakeLists.txt` | registration |

## Tests — all seven required scenarios

1. Constructed with a non-first segment → **snaps** to it, settled, not mid-animation.
2. First selection is segment **zero** → still initialises; proven by a *later* change animating rather than snapping.
3. Change after initialisation → animates, takes multiple frames, settles exactly.
4. Same selection again → no change reported, and ten repeated syncs stay quiet (a control that kept reporting changes would repaint forever).
5. Programmatic restoration → first sync snaps; `snapTo` places directly and leaves it settled.
6. Resize frames → no movement, still on its segment; explicit geometry snap replays no animation.
7. Rapid successive changes → settles on the **latest** target, never overshoots across 200 frames.

Plus backwards motion (higher index → lower).

Header-only and widget-free by design, so it survives `AESTRA_CI=ON`.

**Revert-check performed.** Removing the first-sync snap fails immediately:

```
[FAIL] first sync SNAPS to segment 1, no slide from 0: got 0.2, wanted 1
[FAIL] already on target: no further movement
[FAIL] restored selection snaps on first sync: got 0.8, wanted 4
[FAIL] resize frames do not move the indicator   (x5)
```

`got 0.2` is literally the reported bug — the indicator caught mid-slide from segment 0.

## Drive-verified on the real caller

Burst-captured the toggle from the first rendered frame in a nested Xephyr session. The window maps seconds before the first paint, so the capture polls the region until pixels appear rather than waiting on `wmctrl`, then grabs 20 frames back-to-back.

**All 20 frames plus the settled frame are byte-identical** (`93d2899e…`), showing the indicator on Timeline from the first pixel. No slide.

## Verification rung

**Behaviour regression-tested** for the animation contract, over the seven scenarios above. **Behaviour observed** for the real caller.

## Compatibility

`setSelectedIndex(index, animate)` keeps its signature and meaning; `animate=false` still snaps. No caller changes required — existing call sites, including the four that were safe by luck, are now safe by construction.

## Note

`AestraContent.cpp:287` is deliberately left as `setSelectedIndex(1)`. Adding `animate=false` there would also work, but only for that one call site, and would leave the trap armed everywhere else.
