### PR TITLE
Inactive workspaces must not intercept active-workspace input

### DIFF
--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -74,8 +74,37 @@ bool NUIComponent::onMouseEvent(const NUIMouseEvent& event) {
     bool wasHovered = hovered_;
 
     // First, let children handle the event (front to back)
+    //
+    // An invisible child must not be offered ordinary input (#672). The guard
+    // on line 71 is NOT sufficient on its own: this loop dispatches VIRTUALLY,
+    // so any subclass whose onMouseEvent returns before delegating to this
+    // implementation never executes it. That is exactly how a hidden
+    // AuditionPanel swallowed Timeline clicks (#671) — it returned true from
+    // its own override, and the base guard it would eventually have called was
+    // never reached. There are 80+ overrides in this codebase; relying on each
+    // one to re-check visibility is how the invariant gets lost.
+    //
+    // Enforcing it here, in the parent, is the only place an override cannot
+    // bypass.
+    //
+    // Deliberately visibility ONLY. No bounds check belongs here: captured
+    // drags, popovers and intentionally extended hit regions all rely on
+    // out-of-bounds delivery (TrackUIComponent's trim/clip-drag/fader-capture
+    // paths depend on it). Bounds remain each component's own business.
+    //
+    // Capture exemption: while the cursor is captured, the owning component
+    // must keep receiving events even if something hides it mid-drag, or the
+    // drag hangs with no terminating release. This framework has no capture-
+    // owner registry, so the captured flag on the event is the available
+    // signal — during capture the filter is skipped entirely, preserving the
+    // pre-existing delivery behaviour for that case.
+    const bool cursorCaptureInFlight = event.cursorCaptured;
+
     bool eventHandledByChild = false;
     for (auto it = children_.rbegin(); it != children_.rend(); ++it) {
+        if (!cursorCaptureInFlight && !(*it)->isVisible()) {
+            continue;  // hidden: not eligible for ordinary input
+        }
         if ((*it)->onMouseEvent(event)) {
             eventHandledByChild = true;
             break;  // Stop at first child that handles the event

--- a/Source/Panels/AuditionPanel.cpp
+++ b/Source/Panels/AuditionPanel.cpp
@@ -1163,7 +1163,13 @@ bool AuditionPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     // this override may also be invoked directly, and because the base guard
     // this method eventually delegates to is only reached on some paths — the
     // queue branch returns long before it.
-    if (!isVisible()) {
+    // The captured-cursor exemption must match the parent's contract exactly:
+    // this panel keeps interaction state that deliberately survives the pointer
+    // leaving its bounds (`m_isScrubbingWaveform`, see the early-out below), so
+    // a panel hidden mid-scrub still needs its terminating move/release or the
+    // scrub stays latched. Guarding on visibility alone would strand it —
+    // the same class of defect this change exists to remove, one file over.
+    if (!isVisible() && !event.cursorCaptured) {
         return false;
     }
 

--- a/Source/Panels/AuditionPanel.cpp
+++ b/Source/Panels/AuditionPanel.cpp
@@ -1143,6 +1143,30 @@ void AuditionPanel::renderWaveform(AestraUI::NUIRenderer& renderer, const Aestra
 
 
 bool AuditionPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
+    // A hidden Audition workspace must never intercept input belonging to the
+    // active one (#671).
+    //
+    // This panel is laid out even while hidden, and its bounds cover the whole
+    // content area, so with Timeline showing its `m_queueArea` lands squarely
+    // over two playlist lanes. Any press there used to reach the queue branch
+    // below and be swallowed by `if (queueSize <= 0) return true;` — the lane
+    // never saw the click, and because motion events are never marked handled
+    // the rows still hovered normally, which made it look like a dead zone
+    // rather than an interception.
+    //
+    // Verified by controlled toggle on the live process: visible_ is 1 with
+    // Audition active and 0 with Timeline active, so visibility is the correct
+    // predicate for "this workspace is active".
+    //
+    // NUIComponent's parent-level filter (#672) already skips hidden children,
+    // making this redundant for the child-dispatch path. It is kept because
+    // this override may also be invoked directly, and because the base guard
+    // this method eventually delegates to is only reached on some paths — the
+    // queue branch returns long before it.
+    if (!isVisible()) {
+        return false;
+    }
+
     auto bounds = getBounds();
     constexpr float queueHeaderH = 24.0f;
     constexpr float queueRowPitch = 42.0f;

--- a/Tests/AestraUI/NUIHiddenChildDispatchTest.cpp
+++ b/Tests/AestraUI/NUIHiddenChildDispatchTest.cpp
@@ -1,0 +1,185 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+//
+// Regression coverage for #672: an inactive workspace must never intercept
+// input belonging to the active one.
+//
+// This reproduces the MECHANISM behind #671, not its symptom. The live defect
+// looked like "playlist rows 5 and 6 are dead", but the rows were incidental —
+// a hidden AuditionPanel was laid out over them and swallowed presses. What
+// mattered was the shape:
+//
+//   * a hidden sibling is still laid out, with geometry overlapping the visible
+//     one;
+//   * its onMouseEvent override returns true before ever delegating to
+//     NUIComponent::onMouseEvent, so the base's `if (!visible_) return false`
+//     never runs;
+//   * the parent dispatches to children virtually, so nothing stops it.
+//
+// The test therefore builds a hidden overlapper whose override unconditionally
+// consumes presses — the worst-case override — and proves the parent refuses to
+// offer it the event at all.
+
+#include "NUIComponent.h"
+
+#include <iostream>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+/// Stands in for AuditionPanel: an override that consumes every press it is
+/// offered and never consults visibility itself. Consuming unconditionally is
+/// deliberate — a guard that only works for well-behaved children would not
+/// have prevented #671.
+class GreedyPanel : public NUIComponent {
+public:
+    int pressesSeen = 0;
+
+    bool onMouseEvent(const NUIMouseEvent& event) override {
+        ++pressesSeen;
+        if (event.pressed) {
+            return true;  // swallow, exactly as the queue branch did
+        }
+        return false;
+    }
+};
+
+/// Stands in for a playlist lane: records whether it ever got the press.
+class LaneSpy : public NUIComponent {
+public:
+    int pressesSeen = 0;
+
+    bool onMouseEvent(const NUIMouseEvent& event) override {
+        if (event.pressed) {
+            ++pressesSeen;
+            return true;
+        }
+        return false;
+    }
+};
+
+NUIMouseEvent makePress(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent makeMove(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Move;
+    event.position = {x, y};
+    return event;
+}
+
+struct Fixture {
+    NUIComponent root;
+    std::shared_ptr<LaneSpy> lane = std::make_shared<LaneSpy>();
+    std::shared_ptr<GreedyPanel> panel = std::make_shared<GreedyPanel>();
+
+    Fixture() {
+        root.setBounds({0.0f, 0.0f, 1000.0f, 700.0f});
+        // The lane is added first, the overlapping panel second, so the panel is
+        // visited FIRST in the front-to-back (reverse) walk — the same ordering
+        // that let the real panel win.
+        lane->setBounds({100.0f, 300.0f, 800.0f, 50.0f});
+        panel->setBounds({0.0f, 0.0f, 1000.0f, 700.0f});
+        root.addChild(lane);
+        root.addChild(panel);
+    }
+};
+
+void testHiddenOverlapperDoesNotInterceptPress() {
+    Fixture fixture;
+    fixture.panel->setVisible(false);
+
+    const bool handled = fixture.root.onMouseEvent(makePress(400.0f, 320.0f));
+
+    check(fixture.panel->pressesSeen == 0,
+          "a hidden child must not be offered a press at all");
+    check(fixture.lane->pressesSeen == 1,
+          "the visible component underneath must receive the press");
+    check(handled, "the press must still be reported as handled by the visible child");
+}
+
+void testVisibleOverlapperStillIntercepts() {
+    // The guard must not turn into "hidden panels never win"; a VISIBLE overlay
+    // consuming input is correct behaviour and must be preserved.
+    Fixture fixture;
+    fixture.panel->setVisible(true);
+
+    fixture.root.onMouseEvent(makePress(400.0f, 320.0f));
+
+    check(fixture.panel->pressesSeen == 1, "a visible overlay is still offered the press");
+    check(fixture.lane->pressesSeen == 0, "a visible overlay still consumes the press");
+}
+
+void testHiddenChildIsSkippedForMotionToo() {
+    // Motion is where the original defect hid: hover kept working over the dead
+    // rows because moves are never marked handled, which disguised the
+    // interception as a dead zone. A hidden child should not see motion either.
+    Fixture fixture;
+    fixture.panel->setVisible(false);
+
+    fixture.root.onMouseEvent(makeMove(400.0f, 320.0f));
+
+    check(fixture.panel->pressesSeen == 0, "a hidden child must not be offered motion");
+}
+
+void testCapturedCursorStillReachesHiddenChild() {
+    // A component hidden mid-drag must still get its terminating events, or the
+    // drag hangs forever. The captured flag is the framework's only signal for
+    // this, so the visibility filter is skipped while it is set.
+    Fixture fixture;
+    fixture.panel->setVisible(false);
+
+    NUIMouseEvent event = makePress(400.0f, 320.0f);
+    event.cursorCaptured = true;
+    fixture.root.onMouseEvent(event);
+
+    check(fixture.panel->pressesSeen == 1,
+          "a captured drag must still reach a child hidden mid-drag");
+}
+
+void testStaleGeometryOverlappingActiveWorkspace() {
+    // The #671 shape specifically: the hidden panel's geometry covers only PART
+    // of the visible surface (its queue rectangle), so some rows were dead and
+    // others were not. Both must work once the panel is hidden.
+    Fixture fixture;
+    fixture.panel->setVisible(false);
+    fixture.panel->setBounds({100.0f, 300.0f, 800.0f, 50.0f});  // exactly over the lane
+
+    fixture.root.onMouseEvent(makePress(400.0f, 320.0f));  // inside the overlap
+    check(fixture.lane->pressesSeen == 1, "lane under a hidden panel's rect receives the press");
+
+    fixture.root.onMouseEvent(makePress(400.0f, 340.0f));  // also inside the lane
+    check(fixture.lane->pressesSeen == 2, "second press in the same band also lands");
+}
+
+}  // namespace
+
+int main() {
+    testHiddenOverlapperDoesNotInterceptPress();
+    testVisibleOverlapperStillIntercepts();
+    testHiddenChildIsSkippedForMotionToo();
+    testCapturedCursorStillReachesHiddenChild();
+    testStaleGeometryOverlappingActiveWorkspace();
+
+    if (g_failures != 0) {
+        std::cout << "[FAIL] NUIHiddenChildDispatchTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] NUIHiddenChildDispatchTest\n";
+    return 0;
+}

--- a/Tests/AestraUI/NUIHiddenChildDispatchTest.cpp
+++ b/Tests/AestraUI/NUIHiddenChildDispatchTest.cpp
@@ -152,6 +152,33 @@ void testCapturedCursorStillReachesHiddenChild() {
           "a captured drag must still reach a child hidden mid-drag");
 }
 
+void testCapturedReleaseReachesHiddenChildAfterPress() {
+    // The stranding scenario in full: a drag starts while the component is
+    // visible, the workspace is switched mid-drag, and the terminating release
+    // arrives captured. If the release is filtered out, the component's drag
+    // state stays latched forever. Panels that keep such state (AuditionPanel's
+    // waveform scrub) depend on this.
+    Fixture fixture;
+
+    NUIMouseEvent press = makePress(400.0f, 320.0f);
+    press.cursorCaptured = true;
+    fixture.root.onMouseEvent(press);
+    const int seenAfterPress = fixture.panel->pressesSeen;
+
+    fixture.panel->setVisible(false);  // hidden mid-drag
+
+    NUIMouseEvent release;
+    release.type = NUIMouseEventType::Up;
+    release.position = {400.0f, 320.0f};
+    release.button = NUIMouseButton::Left;
+    release.released = true;
+    release.cursorCaptured = true;
+    fixture.root.onMouseEvent(release);
+
+    check(fixture.panel->pressesSeen == seenAfterPress + 1,
+          "a captured release must reach a child hidden mid-drag so its state can unwind");
+}
+
 void testStaleGeometryOverlappingActiveWorkspace() {
     // The #671 shape specifically: the hidden panel's geometry covers only PART
     // of the visible surface (its queue rectangle), so some rows were dead and
@@ -174,6 +201,7 @@ int main() {
     testVisibleOverlapperStillIntercepts();
     testHiddenChildIsSkippedForMotionToo();
     testCapturedCursorStillReachesHiddenChild();
+    testCapturedReleaseReachesHiddenChildAfterPress();
     testStaleGeometryOverlappingActiveWorkspace();
 
     if (g_failures != 0) {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1716,6 +1716,15 @@ if(TARGET AestraUI_Core)
     )
     add_test(NAME NUIComponentTooltipTest COMMAND NUIComponentTooltipTest)
     set_tests_properties(NUIComponentTooltipTest PROPERTIES LABELS "ui;tooltip;regression")
+
+    # #672: an inactive workspace must never intercept the active one's input.
+    add_executable(NUIHiddenChildDispatchTest AestraUI/NUIHiddenChildDispatchTest.cpp)
+    target_link_libraries(NUIHiddenChildDispatchTest PRIVATE AestraUI_Core)
+    target_include_directories(NUIHiddenChildDispatchTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+    )
+    add_test(NAME NUIHiddenChildDispatchTest COMMAND NUIHiddenChildDispatchTest)
+    set_tests_properties(NUIHiddenChildDispatchTest PROPERTIES LABELS "ui;dispatch;regression")
 else()
     message(STATUS "Dropdown/tooltip interaction tests skipped (AestraUI_Core target unavailable in this build mode)")
 endif()


### PR DESCRIPTION
Fixes #671 and #672.

## What was wrong

Two playlist rows went completely inert to the mouse — no selection, no mute, no context menu, **no log line of any kind** — while still hovering normally. The rows were incidental. A **hidden `AuditionPanel` was laid out over them and swallowed the presses.**

## Mechanism

Established by debugging the live process, before it was disturbed:

- `NUIComponent::onMouseEvent` guards itself with `if (!visible_ || !enabled_) return false;` — but the parent dispatches to children **virtually**, so any override that returns before delegating to the base never runs that guard. There are **83** such overrides in the tree.
- `AuditionPanel` is laid out even while hidden; its bounds cover the whole content area, and with Timeline showing its `m_queueArea` sits at `(278, 389.44, 1058, 80)` — squarely over two lanes.
- A press there reached `if (queueSize <= 0) return true;` (`AuditionPanel.cpp:1285`) and was consumed, ending dispatch before `TrackManagerUI`.
- **Hover survived** because the base marks events handled only for pressed/released/wheel, never for move — which disguised interception as a "dead zone".

Traced dispatch chains:

| | Working row | Dead row |
| --- | --- | --- |
| Calls | 29, continuing into **47** `TrackUIComponent`s → `selectTrack` | **17, terminating at `AuditionPanel`** |

The first 9 calls are identical; the *same* panel object returns `false` for one and `true` for the other.

## The fix

**#672 — parent-loop visibility filter.** Enforced where an override cannot bypass it:

```cpp
if (!cursorCaptureInFlight && !(*it)->isVisible()) continue;
```

- **Visibility only.** No central bounds check: captured drags, popovers and intentionally extended hit regions depend on out-of-bounds delivery — `TrackUIComponent`'s trim, clip-drag and fader-capture paths do exactly that.
- **Captured cursors skip the filter**, so a component hidden mid-drag still receives its terminating release instead of hanging. This framework has no capture-owner registry, so `event.cursorCaptured` is the available signal.

**#671 — `AuditionPanel::onMouseEvent` returns early when not visible.** Redundant with the above for child dispatch; kept because the override can be invoked directly and its own delegation to the base (`:1203`/`:1393`) happens after the queue branch has already returned.

**Deliberately not changed:** `queueSize <= 0 → return true`. With the visibility guard in place that branch only runs when Audition is genuinely active, where consuming a background click inside its own queue area is plausibly intentional. Flipping it would leak clicks through to whatever sits underneath, and needs its own justification rather than riding along here.

That **visibility is the right predicate** was verified by controlled toggle on the live process — same object, 20 seconds apart, only the workspace changed:

| | Audition active | Timeline active |
| --- | --- | --- |
| `visible_` | 1 | **0** |
| `m_queueArea` | (278, 338, 1058, 80) | (278, **389.44**, 1058, 80) |

The Timeline-mode value is byte-identical to the fault-time reading, so the geometry was never stale — the panel was correctly hidden and still received input.

## Tests

`Tests/AestraUI/NUIHiddenChildDispatchTest.cpp` reproduces the **mechanism**, not the row numbers: a hidden overlapper whose override consumes every press unconditionally (the worst-case override — a guard that only works for well-behaved children would not have prevented this).

Covers: hidden overlapper does not intercept; **visible** overlay still does; motion is filtered too; a captured drag still reaches a child hidden mid-drag; and geometry overlapping only part of the surface.

**Mutation probe:** disabling the filter fails 5 of its assertions, and the two that shouldn't depend on it still pass.

## Verification

- `ctest -L ui` — **21/21**, including the 8 dropdown/tooltip tests from #658 that exercise this same dispatch path.
- `ctest -L "serialization|migration|compatibility|project"` — **19/19**.
- App rebuilt and driven end-to-end: the two previously dead rows now **select and mute**, on the same recovered project with the same marker on screen; Audition still receives input when active (DSP preset switch logged).

## Note

`hitTestVisible_` exists on `NUIComponent` with accessors and is consulted nowhere in dispatch. Left alone here; called out in #672 as decide-or-delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed hidden workspace components intercepting mouse input intended for active components.
- Filtered invisible children during mouse dispatch while preserving captured-drag and extended hit-region behavior.
- Added an early visibility guard to `AuditionPanel::onMouseEvent`.
- Added regression coverage for hidden/visible overlays, motion events, captured drags, and partial overlap geometry.
- Registered the new UI dispatch test with CTest.
- Verified all UI and project-format tests pass, with end-to-end selection and mute behavior confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->