### PR TITLE
Resolve the crash-flag path while platform utilities are alive

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -2,6 +2,7 @@
 #include "AestraApp.h"
 #include "MuseHostVerbs.h"
 #include "AppLifecycle.h"
+#include "CrashFlagPath.h"
 #include "ServiceLocator.h"
 #include "AestraRootComponent.h"
 #include "Preferences.h"
@@ -121,8 +122,19 @@ std::string AestraApp::getCrashFlagPath() {
     return (std::filesystem::path(getAppDataPath()) / "crash_flag").string();
 }
 
+std::string AestraApp::activeCrashFlagPath() {
+    // Prefer the path resolved while platform utilities were alive. The
+    // fallback only applies before priming, where getAppDataPath() is still
+    // able to resolve correctly.
+    return CrashFlagPath::isPrimed() ? CrashFlagPath::get() : getCrashFlagPath();
+}
+
 void AestraApp::writeCrashFlag() {
     std::string flagPath = getCrashFlagPath();
+    // Retain the authoritative path while platform utilities are still alive.
+    // shutdown() clears the flag after Platform::shutdown() has destroyed them,
+    // and re-resolving there silently yields <cwd>/crash_flag (#675).
+    CrashFlagPath::prime(flagPath);
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
         out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";
@@ -143,7 +155,19 @@ void AestraApp::writeCrashFlag() {
 }
 
 void AestraApp::clearCrashFlag() {
-    std::string flagPath = getCrashFlagPath();
+    // Use the path retained at startup. Resolving it here would go through
+    // getAppDataPath(), which falls back to the working directory once
+    // Platform::shutdown() has released the platform utilities — the flag would
+    // then never be found and never be cleared (#675).
+    //
+    // Not primed means writeCrashFlag() never ran, so there is nothing this
+    // process wrote to clear. Say so loudly rather than resolving a path that
+    // is wrong by construction at this point in shutdown.
+    if (!CrashFlagPath::isPrimed()) {
+        Log::warning("[CrashDetection] Crash flag path was never resolved; nothing to clear");
+        return;
+    }
+    const std::string& flagPath = CrashFlagPath::get();
     std::error_code ec;
     if (std::filesystem::exists(flagPath, ec)) {
         std::filesystem::remove(flagPath, ec);
@@ -156,7 +180,7 @@ void AestraApp::clearCrashFlag() {
 }
 
 bool AestraApp::isCrashedSession() {
-    std::string flagPath = getCrashFlagPath();
+    const std::string flagPath = activeCrashFlagPath();
     std::error_code ec;
     return std::filesystem::exists(flagPath, ec);
 }
@@ -166,7 +190,7 @@ std::string AestraApp::getRecoveryMarkerPath(const std::string& autosavePath) {
 }
 
 std::string AestraApp::readCrashFlagToken() {
-    std::ifstream in(getCrashFlagPath(), std::ios::binary);
+    std::ifstream in(activeCrashFlagPath(), std::ios::binary);
     std::string token;
     std::getline(in, token);
     return token;
@@ -211,10 +235,6 @@ bool AestraApp::initialize(const std::string& projectPath) {
 
     Log::info("Aestra v1.0.0 - Initializing...");
 
-    // Check for crashed session BEFORE initializing platform.
-    bool crashedSession = isCrashedSession();
-    m_previousRecoverySessionToken = crashedSession ? readCrashFlagToken() : "";
-
     {
         StartupTimer t("Platform init");
         if (!Platform::initialize()) {
@@ -222,6 +242,26 @@ bool AestraApp::initialize(const std::string& projectPath) {
             return false;
         }
     }
+
+    // Resolve the crash-flag path ONCE, now that platform utilities exist, and
+    // reuse it for every crash-flag operation in this process (#675).
+    //
+    // Every one of those operations previously called getAppDataPath()
+    // independently, and that function silently falls back to the process
+    // working directory whenever platform utilities are absent. Detection used
+    // to run BEFORE Platform::initialize() and clearing runs AFTER
+    // Platform::shutdown(), so both sat in exactly that window: the flag was
+    // written to app-data, then looked for in the working directory. Clean
+    // exits never cleared it, and — worse — a real crash was never detected,
+    // because the read missed the file too. Proven by launching with a flag in
+    // the working directory only: recovery fired.
+    //
+    // Detection therefore moved below platform init. Nothing between the old
+    // and new positions consumed the result.
+    CrashFlagPath::prime(getCrashFlagPath());
+
+    const bool crashedSession = isCrashedSession();
+    m_previousRecoverySessionToken = crashedSession ? readCrashFlagToken() : "";
 
     // An app-data autosave is recovery state, never an implicit canonical project.
     m_documentState.startUntitled(getAutosavePath());

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -130,11 +130,14 @@ std::string AestraApp::activeCrashFlagPath() {
 }
 
 void AestraApp::writeCrashFlag() {
-    std::string flagPath = getCrashFlagPath();
-    // Retain the authoritative path while platform utilities are still alive.
-    // shutdown() clears the flag after Platform::shutdown() has destroyed them,
-    // and re-resolving there silently yields <cwd>/crash_flag (#675).
-    CrashFlagPath::prime(flagPath);
+    // initialize() primes this immediately after Platform::initialize(). Prime
+    // here only as a fallback for callers that reach the write without going
+    // through startup — re-resolving unconditionally would let detection use
+    // one path while the write and the clear use another (#675).
+    if (!CrashFlagPath::isPrimed()) {
+        CrashFlagPath::prime(getCrashFlagPath());
+    }
+    const std::string flagPath = activeCrashFlagPath();
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
         out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -60,6 +60,7 @@ public:
     static void writeCrashFlag();
     static void clearCrashFlag();
     static bool isCrashedSession();
+    static std::string activeCrashFlagPath();
 
 private:
     enum class ProjectLoadSource { Canonical, Recovery, Snapshot };

--- a/Source/App/CrashFlagPath.h
+++ b/Source/App/CrashFlagPath.h
@@ -1,0 +1,53 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+// Authoritative crash-flag path, resolved while platform utilities are alive
+// and retained for use during final shutdown (#675).
+//
+// The defect this exists to prevent: `AestraApp::shutdown()` clears the crash
+// flag LAST, deliberately, so that a crash during any earlier teardown step
+// leaves the flag behind for recovery. But `Platform::shutdown()` runs before
+// that final clear and destroys the platform utilities, and
+// `AestraApp::getAppDataPath()` silently falls back to the process working
+// directory when those utilities are gone. The clear therefore looked for
+// `<cwd>/crash_flag`, found nothing, and returned having done nothing — and
+// logged nothing either, because both its success and failure messages live
+// inside the `exists()` branch. Every clean exit left the flag behind, so every
+// next launch offered a spurious recovery.
+//
+// The ordering is correct and must not change. What must change is the path
+// resolution: resolve once, early, and reuse that exact string at the end.
+//
+// Deliberately a plain string holder with no dependency on Platform, the app,
+// or the filesystem, so the behaviour is unit-testable despite Source/ having
+// no linkable library target (#666).
+
+#include <string>
+
+namespace Aestra {
+
+class CrashFlagPath {
+public:
+    /// Record the resolved path. Called while platform utilities are alive —
+    /// in practice when the crash flag is written at startup.
+    static void prime(std::string path) { storage() = std::move(path); }
+
+    /// True once a path has been recorded. Callers that clear the flag must
+    /// check this rather than silently resolving a fresh (and by then wrong)
+    /// path.
+    static bool isPrimed() { return !storage().empty(); }
+
+    /// The recorded path. Empty when never primed.
+    static const std::string& get() { return storage(); }
+
+    /// Test-only: return to the un-primed state.
+    static void resetForTesting() { storage().clear(); }
+
+private:
+    static std::string& storage() {
+        static std::string path;
+        return path;
+    }
+};
+
+} // namespace Aestra

--- a/Source/App/CrashFlagPath.h
+++ b/Source/App/CrashFlagPath.h
@@ -23,6 +23,7 @@
 // no linkable library target (#666).
 
 #include <string>
+#include <utility>  // std::move — used below; do not rely on <string> pulling it in
 
 namespace Aestra {
 

--- a/Tests/App/CrashFlagPathTest.cpp
+++ b/Tests/App/CrashFlagPathTest.cpp
@@ -1,0 +1,106 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+//
+// Regression coverage for #675: the crash flag must still be clearable after
+// platform teardown has destroyed the utilities that resolve app-data paths.
+//
+// The live defect: AestraApp::shutdown() deliberately clears the crash flag
+// LAST, so a crash during earlier teardown leaves the flag for recovery. But
+// Platform::shutdown() runs first and destroys the platform utilities, and
+// AestraApp::getAppDataPath() silently falls back to the process working
+// directory when they are gone. The final clear therefore looked for
+// <cwd>/crash_flag, found nothing, removed nothing, and logged nothing —
+// because both its success and failure messages sit inside the exists() branch.
+// Every clean exit left the flag behind and every next launch offered a
+// spurious recovery.
+//
+// These tests pin the property that makes the fix work: a path resolved while
+// the platform was alive stays available and unchanged afterwards. Source/ has
+// no linkable library target (#666), so the resolution/retention behaviour was
+// deliberately factored into a dependency-free header that can be tested
+// directly.
+
+#include "CrashFlagPath.h"
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+/// Stands in for AestraApp::getAppDataPath(): resolves correctly while the
+/// platform is alive, and silently degrades to the working directory once it is
+/// gone — which is exactly what the real one does.
+struct FakePlatform {
+    bool aliveFlag = true;
+    std::string appData = "/home/user/.local/share/Aestra";
+    std::string cwd = "/some/working/dir";
+
+    std::string resolveCrashFlagPath() const {
+        return (aliveFlag ? appData : cwd) + "/crash_flag";
+    }
+    void shutdown() { aliveFlag = false; }
+};
+
+void testUnprimedIsDetectable() {
+    Aestra::CrashFlagPath::resetForTesting();
+    check(!Aestra::CrashFlagPath::isPrimed(), "an un-primed path reports itself as un-primed");
+    check(Aestra::CrashFlagPath::get().empty(), "an un-primed path is empty rather than a plausible wrong path");
+}
+
+void testPathSurvivesPlatformTeardown() {
+    Aestra::CrashFlagPath::resetForTesting();
+    FakePlatform platform;
+
+    // Startup: resolve while the platform is alive, as writeCrashFlag() does.
+    Aestra::CrashFlagPath::prime(platform.resolveCrashFlagPath());
+    const std::string atStartup = Aestra::CrashFlagPath::get();
+    check(atStartup == "/home/user/.local/share/Aestra/crash_flag",
+          "the primed path is the app-data path");
+
+    // Shutdown: platform utilities are destroyed before the final clear.
+    platform.shutdown();
+
+    // The regression: re-resolving now yields the wrong path...
+    check(platform.resolveCrashFlagPath() == "/some/working/dir/crash_flag",
+          "re-resolving after teardown does produce the wrong path (defect premise)");
+
+    // ...but the retained one is unchanged, which is what the clear must use.
+    check(Aestra::CrashFlagPath::isPrimed(), "the path is still primed after teardown");
+    check(Aestra::CrashFlagPath::get() == atStartup,
+          "the retained path is unchanged after platform teardown");
+    check(Aestra::CrashFlagPath::get() != platform.resolveCrashFlagPath(),
+          "the retained path differs from what post-teardown resolution would give");
+}
+
+void testPrimingIsIdempotentlyOverwritable() {
+    // Re-priming must replace, not append or ignore: a second app instance in
+    // the same process (tests, tooling) has to be able to correct the path.
+    Aestra::CrashFlagPath::resetForTesting();
+    Aestra::CrashFlagPath::prime("/first/crash_flag");
+    Aestra::CrashFlagPath::prime("/second/crash_flag");
+    check(Aestra::CrashFlagPath::get() == "/second/crash_flag",
+          "re-priming replaces the retained path");
+}
+
+} // namespace
+
+int main() {
+    testUnprimedIsDetectable();
+    testPathSurvivesPlatformTeardown();
+    testPrimingIsIdempotentlyOverwritable();
+
+    if (g_failures != 0) {
+        std::cout << "[FAIL] CrashFlagPathTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] CrashFlagPathTest\n";
+    return 0;
+}

--- a/Tests/Guards/verify_crash_flag_shutdown_order.cmake
+++ b/Tests/Guards/verify_crash_flag_shutdown_order.cmake
@@ -31,21 +31,48 @@ endif()
 file(READ "${APP_SOURCE}" APP_TEXT)
 
 # --- Property 2: the clear uses the retained path --------------------------
-string(FIND "${APP_TEXT}" "CrashFlagPath::isPrimed()" USES_PRIMED_CHECK)
-string(FIND "${APP_TEXT}" "CrashFlagPath::get()" USES_RETAINED_PATH)
+# Scoped to the body of clearCrashFlag(). A whole-file search is NOT sufficient:
+# the helper activeCrashFlagPath() legitimately contains both
+# CrashFlagPath::isPrimed() and CrashFlagPath::get(), so a file-wide match would
+# still succeed after clearCrashFlag() regressed to fresh resolution. That hole
+# was demonstrated, not hypothesised — the guard passed against a deliberately
+# regressed clear before this was scoped.
+string(FIND "${APP_TEXT}" "void AestraApp::clearCrashFlag()" CLEAR_FN_AT)
+if(CLEAR_FN_AT EQUAL -1)
+    message(FATAL_ERROR "Could not find AestraApp::clearCrashFlag() to inspect")
+endif()
+# Body runs to the next function definition at column 0, which is the closing
+# brace followed by a blank line and a new top-level definition.
+string(SUBSTRING "${APP_TEXT}" ${CLEAR_FN_AT} 1200 CLEAR_BODY)
+string(FIND "${CLEAR_BODY}" "\n}" CLEAR_END)
+if(NOT CLEAR_END EQUAL -1)
+    string(SUBSTRING "${CLEAR_BODY}" 0 ${CLEAR_END} CLEAR_BODY)
+endif()
+
+string(FIND "${CLEAR_BODY}" "CrashFlagPath::isPrimed()" USES_PRIMED_CHECK)
+string(FIND "${CLEAR_BODY}" "CrashFlagPath::get()" USES_RETAINED_PATH)
+string(FIND "${CLEAR_BODY}" "getCrashFlagPath()" CLEAR_RERESOLVES)
 if(USES_PRIMED_CHECK EQUAL -1 OR USES_RETAINED_PATH EQUAL -1)
     message(FATAL_ERROR
         "clearCrashFlag no longer uses the retained crash-flag path.\n"
         "Resolving it during shutdown goes through getAppDataPath(), which "
         "falls back to the working directory once Platform::shutdown() has "
         "released the platform utilities — the flag is then never cleared and "
-        "every launch offers a spurious recovery (#675).")
+        "a real crash is never detected (#675).")
+endif()
+if(NOT CLEAR_RERESOLVES EQUAL -1)
+    message(FATAL_ERROR
+        "clearCrashFlag calls getCrashFlagPath() again.\n"
+        "By that point Platform::shutdown() has released the platform "
+        "utilities, so the path resolves to the working directory (#675).")
 endif()
 
-string(FIND "${APP_TEXT}" "CrashFlagPath::prime(" PRIMES_PATH)
+# Priming must happen at a real call site, not merely be defined somewhere.
+string(FIND "${APP_TEXT}" "CrashFlagPath::prime(getCrashFlagPath())" PRIMES_PATH)
 if(PRIMES_PATH EQUAL -1)
     message(FATAL_ERROR
-        "Nothing primes the crash-flag path while platform utilities are alive (#675).")
+        "Nothing primes the crash-flag path from a resolved value while platform "
+        "utilities are alive (#675).")
 endif()
 
 # --- Property 1: the clear still happens after platform teardown -----------
@@ -84,10 +111,21 @@ if(DETECT_AT LESS PLATFORM_INIT_AT)
         "crash is ever detected (#675).")
 endif()
 
-string(FIND "${APP_TEXT}" "activeCrashFlagPath()" READS_RESOLVED)
+# Scoped for the same reason as Property 2: the helper's own definition would
+# otherwise satisfy a file-wide search.
+string(FIND "${APP_TEXT}" "bool AestraApp::isCrashedSession()" DETECT_FN_AT)
+if(DETECT_FN_AT EQUAL -1)
+    message(FATAL_ERROR "Could not find AestraApp::isCrashedSession() to inspect")
+endif()
+string(SUBSTRING "${APP_TEXT}" ${DETECT_FN_AT} 400 DETECT_BODY)
+string(FIND "${DETECT_BODY}" "\n}" DETECT_END)
+if(NOT DETECT_END EQUAL -1)
+    string(SUBSTRING "${DETECT_BODY}" 0 ${DETECT_END} DETECT_BODY)
+endif()
+string(FIND "${DETECT_BODY}" "activeCrashFlagPath()" READS_RESOLVED)
 if(READS_RESOLVED EQUAL -1)
     message(FATAL_ERROR
-        "Crash-flag readers no longer share the resolved path helper (#675).")
+        "isCrashedSession no longer reads through the resolved path helper (#675).")
 endif()
 
 message(STATUS "Verified crash-flag shutdown ordering, detection ordering and resolved-path use")

--- a/Tests/Guards/verify_crash_flag_shutdown_order.cmake
+++ b/Tests/Guards/verify_crash_flag_shutdown_order.cmake
@@ -1,0 +1,93 @@
+# Shutdown-ordering guard for the crash flag (#675).
+#
+# Two properties have to hold together, and neither is expressible as a unit
+# test while Source/ has no linkable library target (#666):
+#
+#   1. The crash flag is cleared AFTER all fallible teardown work, so a crash
+#      during shutdown leaves the flag behind for recovery. This is why the fix
+#      for #675 must NOT be "move clearCrashFlag() earlier".
+#   2. The clear uses the path retained at startup, not a freshly resolved one.
+#      Platform::shutdown() destroys the platform utilities, after which
+#      getAppDataPath() silently falls back to the working directory — so
+#      re-resolving there finds nothing, removes nothing, and logs nothing.
+#
+# The application source path is resolved HERE rather than passed in from
+# Tests/cmake/*.cmake: scripts/ci/classify-changes.sh derives its
+# headless-compiled deny-list by grepping those files for `(Source|AestraUI)/…
+# .cpp`, and a literal app-source path there is indistinguishable from a
+# compiled input (lesson from #669). Tests/Guards/ is not scanned.
+
+cmake_minimum_required(VERSION 3.16)
+
+if(NOT DEFINED AESTRA_SOURCE_ROOT OR AESTRA_SOURCE_ROOT STREQUAL "")
+    message(FATAL_ERROR "AESTRA_SOURCE_ROOT was not provided to the crash-flag guard")
+endif()
+
+set(APP_SOURCE "${AESTRA_SOURCE_ROOT}/Source/App/AestraApp.cpp")
+if(NOT EXISTS "${APP_SOURCE}")
+    message(FATAL_ERROR "Guard cannot find the application source at ${APP_SOURCE}")
+endif()
+
+file(READ "${APP_SOURCE}" APP_TEXT)
+
+# --- Property 2: the clear uses the retained path --------------------------
+string(FIND "${APP_TEXT}" "CrashFlagPath::isPrimed()" USES_PRIMED_CHECK)
+string(FIND "${APP_TEXT}" "CrashFlagPath::get()" USES_RETAINED_PATH)
+if(USES_PRIMED_CHECK EQUAL -1 OR USES_RETAINED_PATH EQUAL -1)
+    message(FATAL_ERROR
+        "clearCrashFlag no longer uses the retained crash-flag path.\n"
+        "Resolving it during shutdown goes through getAppDataPath(), which "
+        "falls back to the working directory once Platform::shutdown() has "
+        "released the platform utilities — the flag is then never cleared and "
+        "every launch offers a spurious recovery (#675).")
+endif()
+
+string(FIND "${APP_TEXT}" "CrashFlagPath::prime(" PRIMES_PATH)
+if(PRIMES_PATH EQUAL -1)
+    message(FATAL_ERROR
+        "Nothing primes the crash-flag path while platform utilities are alive (#675).")
+endif()
+
+# --- Property 1: the clear still happens after platform teardown -----------
+string(FIND "${APP_TEXT}" "Platform::shutdown();" PLATFORM_SHUTDOWN_AT)
+string(FIND "${APP_TEXT}" "clearCrashFlag();" CLEAR_CALL_AT)
+if(PLATFORM_SHUTDOWN_AT EQUAL -1)
+    message(FATAL_ERROR "Could not find Platform::shutdown() in the application shutdown path")
+endif()
+if(CLEAR_CALL_AT EQUAL -1)
+    message(FATAL_ERROR "Could not find the clearCrashFlag() call in the application shutdown path")
+endif()
+if(CLEAR_CALL_AT LESS PLATFORM_SHUTDOWN_AT)
+    message(FATAL_ERROR
+        "clearCrashFlag() now runs BEFORE Platform::shutdown().\n"
+        "The flag must be cleared only after all fallible teardown work, or a "
+        "crash during shutdown is recorded as a clean exit and the session is "
+        "not offered for recovery (#675). Fix the path resolution, not the "
+        "ordering.")
+endif()
+
+# --- Property 3: detection reads the resolved path, after platform init ----
+# A crashed session was previously never detected: isCrashedSession() ran
+# before Platform::initialize(), so it looked in the working directory and
+# missed the real flag entirely. Proven by launching with a flag in the working
+# directory only — recovery fired.
+string(FIND "${APP_TEXT}" "Platform::initialize()" PLATFORM_INIT_AT)
+string(FIND "${APP_TEXT}" "isCrashedSession();" DETECT_AT)
+if(PLATFORM_INIT_AT EQUAL -1 OR DETECT_AT EQUAL -1)
+    message(FATAL_ERROR "Could not locate platform init / crash detection in the startup path")
+endif()
+if(DETECT_AT LESS PLATFORM_INIT_AT)
+    message(FATAL_ERROR
+        "Crash detection runs BEFORE Platform::initialize() again.\n"
+        "getAppDataPath() falls back to the working directory when platform "
+        "utilities are absent, so detection there reads the wrong file and no "
+        "crash is ever detected (#675).")
+endif()
+
+string(FIND "${APP_TEXT}" "activeCrashFlagPath()" READS_RESOLVED)
+if(READS_RESOLVED EQUAL -1)
+    message(FATAL_ERROR
+        "Crash-flag readers no longer share the resolved path helper (#675).")
+endif()
+
+message(STATUS "Verified crash-flag shutdown ordering, detection ordering and resolved-path use")

--- a/Tests/cmake/ProjectTests.cmake
+++ b/Tests/cmake/ProjectTests.cmake
@@ -105,3 +105,25 @@ add_test(NAME ProjectFixtureImmutabilityTest
 set_tests_properties(ProjectFixtureImmutabilityTest PROPERTIES
     LABELS "serialization;fixtures;compatibility"
 )
+
+# --- Crash-flag lifecycle (#675) -------------------------------------------
+# Header-only holder, so this links nothing from Source/ — which is why it can
+# exist at all while Source/ has no library target (#666).
+add_executable(CrashFlagPathTest App/CrashFlagPathTest.cpp)
+target_include_directories(CrashFlagPathTest PRIVATE ${CMAKE_SOURCE_DIR}/Source/App)
+add_test(NAME CrashFlagPathTest COMMAND CrashFlagPathTest)
+set_tests_properties(CrashFlagPathTest PROPERTIES LABELS "app;recovery;regression")
+
+# Source guard: the shutdown ORDERING is the invariant that makes the crash flag
+# meaningful, and it is not expressible in a unit test while Source/ cannot be
+# linked. Path resolution lives in Tests/Guards/ so the blast-radius classifier
+# does not treat the app source path as a compiled input (lesson from #669).
+add_test(
+    NAME CrashFlagShutdownOrderGuardTest
+    COMMAND ${CMAKE_COMMAND}
+        -DAESTRA_SOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/Guards/verify_crash_flag_shutdown_order.cmake
+)
+set_tests_properties(CrashFlagShutdownOrderGuardTest PROPERTIES
+    LABELS "app;recovery;guard"
+)


### PR DESCRIPTION
Fixes #675.

## The filed diagnosis was half right — the other half is worse

`getAppDataPath()` (`AestraApp.cpp:99`) silently returns the process **working directory** when `Platform::getUtils()` is null. Two crash-flag operations sat in exactly that window, at opposite ends of the process lifetime:

| | When it runs | What it resolved | Effect |
| --- | --- | --- | --- |
| `clearCrashFlag()` | after `Platform::shutdown()` (`s_utils.reset()`) | `<cwd>/crash_flag` | flag never cleared; **silent**, because both log lines live inside the `exists()` branch |
| `isCrashedSession()` | **before** `Platform::initialize()` | `<cwd>/crash_flag` | **a real crash was never detected** |

The second one inverts #675's premise. The symptom was not spurious recovery — it was **recovery that never fired**.

**Proven directly:** with app-data clean and a flag placed only in the working directory, launching produced `[Recovery] Crash detected, showing recovery dialog`. Detection was reading the CWD.

### Pre-fix reproduction (`develop @ 959e7b25`)

| Step | Observation |
| --- | --- |
| before launch | appdata `absent`, cwd `absent` |
| running | appdata **PRESENT** (`Wrote crash flag: …/.local/share/Aestra/crash_flag`) |
| after clean quit, `Exiting with code: 0` | appdata **PRESENT**, cwd `absent` |
| | `Cleared crash flag` × **0**, `Failed to clear crash flag` × **0** |

Both messages absent proves `exists()` short-circuited — the removal was never attempted, it didn't fail.

## Fix

Resolve the path **once**, immediately after `Platform::initialize()`, and reuse it for detection, token read, write and clear. Detection moves below platform init; nothing between the old and new positions consumed its result.

**The shutdown ordering is unchanged, deliberately.** The flag is still cleared last, after all fallible teardown, so a crash during shutdown is not recorded as a clean exit. Moving the clear earlier was explicitly rejected — the guard below fails if anyone tries it.

`CrashFlagPath` is a dependency-free string holder so the retention behaviour is unit-testable despite `Source/` having no linkable library target (#666).

## Verification ladder

| # | Property | Result |
| --- | --- | --- |
| 1 | regression test reproducing resolution after teardown | `CrashFlagPathTest` ✅ |
| 2 | clean shutdown removes the real app-data flag | ✅ `absent` |
| 3 | `Cleared crash flag` appears on clean shutdown | ✅ ×1 |
| 4 | nothing created or removed in the working directory | ✅ `absent` before and after |
| 5 | crash contract preserved | ✅ SIGKILL retains the flag, **and the next launch now detects it** |
| 6 | focused then required suites | ✅ 44/44; classifier 59/59; lane selection 35/35 |

## Tests

- **`CrashFlagPathTest`** — a fake platform that resolves correctly while alive and degrades to the CWD after teardown; asserts the retained path is unchanged, differs from what post-teardown resolution gives, and that an un-primed state is detectable rather than silently wrong.
- **`CrashFlagShutdownOrderGuardTest`** — pins all three invariants that a unit test cannot reach while `Source/` is unlinkable: clear-after-teardown, detect-after-init, shared resolved path. Path resolution lives in `Tests/Guards/` so the blast-radius classifier does not treat the app source as a compiled input (lesson from #669).

**Mutation probes, all bite:** dropping retention fails 2 assertions; re-resolving inside the clear trips the guard; moving the clear above `Platform::shutdown()` trips it too.

## Scope

The silent `current_path()` fallback is **not** changed here — it wasn't required for the fix — and is filed as **#676** with the evidence, including a check that no autosave caller currently sits in the danger window (`:1417` is inside `requestClose()`, and `shutdown()` never calls it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added a cached, “primed” crash-flag path that’s resolved right after `Platform::initialize()` and reused consistently for crash detection, token reads, crash-flag writes, and shutdown clearing—preventing accidental fallback to the working directory during parts of the app lifecycle.
- Moved the crash-session detection (and related token read) to occur after `Platform::initialize()`, while keeping crash-flag clearing until after `Platform::shutdown()` to avoid lifecycle/order-related issues.
- Introduced `Aestra::CrashFlagPath` and a new `AestraApp::activeCrashFlagPath()` helper so reads/writes use the retained path when primed; `clearCrashFlag()` now refuses to clear unless the path has been primed.
- Added `CrashFlagPathTest` and a CMake-based shutdown-order guard (`CrashFlagShutdownOrderGuardTest`) to verify path retention across teardown, initialization/teardown ordering, and working-directory isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->