### PR TITLE
A hidden widget must refuse input it is handed directly

### DIFF
--- a/AestraUI/Base/NUIButton.cpp
+++ b/AestraUI/Base/NUIButton.cpp
@@ -145,8 +145,26 @@ void NUIButton::onUpdate(double deltaTime) {
 }
 
 bool NUIButton::onMouseEvent(const NUIMouseEvent& event) {
-    if (!isEnabled()) return false;
-    
+    // A hidden button must not act on input, and it has to say so itself (#672).
+    //
+    // NUIComponent::onMouseEvent already refuses events for invisible components,
+    // but that is not enough here: this override calls the base for its side
+    // effects and DISCARDS the result (below), then proceeds to hit-test and fire
+    // onClick_ regardless. Hidden components keep their bounds, so containsPoint
+    // still succeeds — a press forwarded to a hidden button used to invoke its
+    // callback.
+    //
+    // Only #674's parent-side visibility filter stands between that and a live
+    // defect, and it is bypassed by the ~12 places that forward directly to a
+    // named child instead of relying on the generic child walk (SettingsDialog's
+    // footer buttons, PianoRollToolbar's tool strip, TrackUIComponent's
+    // mute/solo/record routing). None of those buttons is hidden today, so this
+    // is a trap rather than a bug — but it is the exact shape of #671, and the
+    // sibling base widgets (NUISlider, NUIDropdown, NUITextInput, NUIContextMenu,
+    // NUIScrollbar, NUIToggle, NUICheckbox) all already self-guard. NUIButton was
+    // the only one that did not.
+    if (!isVisible() || !isEnabled()) return false;
+
     // CRITICAL: Call base class to handle hover state and callbacks (onMouseMove, etc.)
     // This allows parents to use onMouseMove for forced repaints when buttons are hovered.
     NUIComponent::onMouseEvent(event);

--- a/AestraUI/Base/NUIButton.cpp
+++ b/AestraUI/Base/NUIButton.cpp
@@ -163,7 +163,20 @@ bool NUIButton::onMouseEvent(const NUIMouseEvent& event) {
     // sibling base widgets (NUISlider, NUIDropdown, NUITextInput, NUIContextMenu,
     // NUIScrollbar, NUIToggle, NUICheckbox) all already self-guard. NUIButton was
     // the only one that did not.
-    if (!isVisible() || !isEnabled()) return false;
+    // Refusing the event is not enough on its own: every release used to clear
+    // pressed_, via either the out-of-bounds branch below or the in-bounds one, and
+    // returning early here skips both. A press accepted while visible would stay
+    // latched when its release arrived hidden — the button reappeared looking
+    // pressed, and the next release landing inside it completed a click whose press
+    // had been cancelled. Hiding or disabling mid-gesture must CANCEL the gesture,
+    // not suspend it.
+    if (!isVisible() || !isEnabled()) {
+        if (pressed_) {
+            pressed_ = false;
+            setDirty();
+        }
+        return false;
+    }
 
     // CRITICAL: Call base class to handle hover state and callbacks (onMouseMove, etc.)
     // This allows parents to use onMouseMove for forced repaints when buttons are hovered.

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -113,9 +113,23 @@ public:
     void setFocused(bool focused);
     bool isFocused() const { return focused_; }
 
+    // Drag-and-drop target eligibility only — NOT mouse dispatch.
+    //
+    // isComponentEligibleForDragTarget() (NUIDragDrop.cpp) walks the ancestor
+    // chain and rejects a drop target if any node has this cleared. Mouse event
+    // routing never consults it: onMouseEvent() gates on visible_/enabled_, and
+    // the parent-side filter added in #674 gates on isVisible(). The name reads
+    // like a general hit-testing switch, which is misleading in both directions —
+    // clearing it does not make a component click-through, and setting it does not
+    // make one clickable. UIRoutingMap's constructor used to call the setter with
+    // `true`, its own default, evidently expecting some effect; that no-op is gone.
+    //
+    // Nothing in the tree currently clears it, so the drag-eligibility check above
+    // is inert today. Left in place because it is a functioning hook with a real
+    // consumer, not dead code (#672 checklist: decided keep, on that evidence).
     void setHitTestVisible(bool visible) { hitTestVisible_ = visible; }
     bool isHitTestVisible() const { return hitTestVisible_; }
-    
+
     static NUIComponent* getFocusedComponent();
     static void clearFocusedComponent();
     

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -52,7 +52,6 @@ namespace {
 
 UIRoutingMap::UIRoutingMap(Mode mode) : m_mode(mode) {
     cacheThemeColors();
-    setHitTestVisible(true);
 }
 
 void UIRoutingMap::setMode(Mode mode) {

--- a/Tests/AestraUI/NUIWidgetHiddenInputTest.cpp
+++ b/Tests/AestraUI/NUIWidgetHiddenInputTest.cpp
@@ -1,0 +1,183 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+//
+// Regression coverage for the leaf-side half of #672.
+//
+// NUIHiddenChildDispatchTest pins the PARENT-side guard added in #674: the
+// generic child walk in NUIComponent::onMouseEvent refuses to offer input to an
+// invisible child. That closed the live defect (#671), but it is not the whole
+// invariant, because roughly a dozen overrides in this codebase do not use the
+// generic walk at all — they forward straight to a named child:
+//
+//   SettingsDialog.cpp:298-303      m_applyButton / m_cancelButton / m_okButton
+//   PianoRollToolbar.cpp:457-462    the seven tool-strip buttons
+//   TrackUIComponent.cpp:1865       routeControlButton() -> mute / solo / record
+//
+// Those forwards bypass the parent filter entirely, so the guarantee has to also
+// hold when a widget is handed an event directly. Every other base widget
+// already self-guards (NUISlider, NUIDropdown, NUITextInput, NUIContextMenu,
+// NUIScrollbar, NUIToggle, NUICheckbox all open with an isVisible() test).
+// NUIButton did not: it checked only isEnabled(), called the base for its hover
+// side effects while DISCARDING the result, then hit-tested and fired onClick_.
+// Hidden components keep their bounds, so containsPoint() still matched.
+//
+// No shipping caller hides one of the directly-forwarded buttons today, so this
+// was a trap rather than an outage — the same trap that produced #671 once a
+// hidden sibling acquired overlapping geometry. These tests make the leaf-side
+// property explicit so it cannot regress silently.
+
+#include "NUIButton.h"
+
+#include <iostream>
+#include <memory>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+NUIMouseEvent makePress(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent makeRelease(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Up;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.released = true;
+    return event;
+}
+
+struct ButtonFixture {
+    std::shared_ptr<NUIButton> button = std::make_shared<NUIButton>("Sign Out");
+    int clicks = 0;
+
+    ButtonFixture() {
+        button->setBounds({100.0f, 200.0f, 120.0f, 32.0f});
+        button->setOnClick([this] { ++clicks; });
+    }
+
+    /// A press+release pair delivered straight to the widget, exactly as
+    /// SettingsDialog / PianoRollToolbar / TrackUIComponent do.
+    void clickDirectly() {
+        button->onMouseEvent(makePress(160.0f, 216.0f));
+        button->onMouseEvent(makeRelease(160.0f, 216.0f));
+    }
+};
+
+void testVisibleButtonStillClicks() {
+    // Proves the reason the negative case below passes. Without this, a button
+    // that never fires at all would satisfy the hidden-button assertion and the
+    // test would be worthless.
+    ButtonFixture fixture;
+
+    fixture.clickDirectly();
+
+    check(fixture.clicks == 1, "a visible button invoked directly still fires onClick");
+}
+
+void testHiddenButtonDoesNotClick() {
+    ButtonFixture fixture;
+    fixture.button->setVisible(false);
+
+    fixture.clickDirectly();
+
+    check(fixture.clicks == 0,
+          "a hidden button handed a press+release directly must not fire onClick");
+}
+
+void testHiddenButtonReportsEventUnhandled() {
+    // Consuming the event would be its own defect: the forwarding parent treats
+    // `true` as "someone dealt with this" and stops routing, so a hidden button
+    // that returned true would create a dead zone over whatever is underneath —
+    // precisely the #671 symptom.
+    ButtonFixture fixture;
+    fixture.button->setVisible(false);
+
+    const bool pressHandled = fixture.button->onMouseEvent(makePress(160.0f, 216.0f));
+    const bool releaseHandled = fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));
+
+    check(!pressHandled, "a hidden button must report the press as unhandled");
+    check(!releaseHandled, "a hidden button must report the release as unhandled");
+}
+
+void testHiddenToggleDoesNotToggle() {
+    // The toggle path is a separate branch from onClick_ and carries persistent
+    // state, so a spurious fire is worse: the button's own toggled_ flips and the
+    // observer is told about it.
+    ButtonFixture fixture;
+    bool toggledTo = false;
+    int toggleCount = 0;
+    fixture.button->setToggleable(true);
+    fixture.button->setOnToggle([&](bool on) {
+        toggledTo = on;
+        ++toggleCount;
+    });
+    fixture.button->setVisible(false);
+
+    fixture.clickDirectly();
+
+    check(toggleCount == 0, "a hidden toggle button must not invoke its toggle observer");
+    check(!toggledTo, "a hidden toggle button must not report a new toggle state");
+    check(!fixture.button->isToggled(), "a hidden toggle button must not flip its own state");
+}
+
+void testReshownButtonWorksAgain() {
+    // The guard must gate on current visibility, not latch. A button hidden and
+    // shown again has to behave normally, or panels that swap visibility (the
+    // membership page's login/sign-out pair) would go permanently dead.
+    ButtonFixture fixture;
+    fixture.button->setVisible(false);
+    fixture.clickDirectly();
+    check(fixture.clicks == 0, "still suppressed while hidden");
+
+    fixture.button->setVisible(true);
+    fixture.clickDirectly();
+
+    check(fixture.clicks == 1, "a re-shown button fires again");
+}
+
+void testHiddenButtonDoesNotLatchPressedState() {
+    // A press swallowed while hidden must not leave pressed_ armed, or the next
+    // release after being re-shown would fire a click the user never started.
+    ButtonFixture fixture;
+    fixture.button->setVisible(false);
+
+    fixture.button->onMouseEvent(makePress(160.0f, 216.0f));
+    fixture.button->setVisible(true);
+    fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));
+
+    check(fixture.clicks == 0,
+          "a release after re-showing must not complete a press that was never accepted");
+}
+
+}  // namespace
+
+int main() {
+    testVisibleButtonStillClicks();
+    testHiddenButtonDoesNotClick();
+    testHiddenButtonReportsEventUnhandled();
+    testHiddenToggleDoesNotToggle();
+    testReshownButtonWorksAgain();
+    testHiddenButtonDoesNotLatchPressedState();
+
+    if (g_failures != 0) {
+        std::cout << "[FAIL] NUIWidgetHiddenInputTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] NUIWidgetHiddenInputTest\n";
+    return 0;
+}

--- a/Tests/AestraUI/NUIWidgetHiddenInputTest.cpp
+++ b/Tests/AestraUI/NUIWidgetHiddenInputTest.cpp
@@ -164,6 +164,51 @@ void testHiddenButtonDoesNotLatchPressedState() {
           "a release after re-showing must not complete a press that was never accepted");
 }
 
+void testHidingMidPressCancelsTheGesture() {
+    // The inverse of the case above, and a regression the visibility guard itself
+    // introduced. Before the guard, EVERY release cleared pressed_ — either via
+    // the out-of-bounds branch or the in-bounds one. An early return skips both,
+    // so a press accepted while visible stayed latched when its release arrived
+    // hidden. The button then reappeared looking pressed, and the next release
+    // landing inside it completed a click whose press had been cancelled.
+    //
+    // Hiding a component mid-gesture must cancel that gesture, not suspend it.
+    ButtonFixture fixture;
+
+    fixture.button->onMouseEvent(makePress(160.0f, 216.0f));  // accepted, visible
+    check(fixture.button->isPressed(), "the visible press is accepted and latched");
+
+    fixture.button->setVisible(false);
+    fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));  // swallowed
+
+    check(!fixture.button->isPressed(),
+          "hiding mid-press must clear the latched press, not suspend it");
+
+    fixture.button->setVisible(true);
+    fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));  // unmatched release
+
+    check(fixture.clicks == 0,
+          "an unmatched release after re-showing must not complete the cancelled press");
+}
+
+void testDisablingMidPressCancelsTheGesture() {
+    // Same latch, reached through the enabled_ half of the same guard. Buttons are
+    // disabled far more often than they are hidden (transport state, sign-in
+    // state), so this path is the more likely one in practice.
+    ButtonFixture fixture;
+
+    fixture.button->onMouseEvent(makePress(160.0f, 216.0f));
+    fixture.button->setEnabled(false);
+    fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));
+
+    check(!fixture.button->isPressed(), "disabling mid-press must clear the latched press");
+
+    fixture.button->setEnabled(true);
+    fixture.button->onMouseEvent(makeRelease(160.0f, 216.0f));
+
+    check(fixture.clicks == 0, "an unmatched release after re-enabling must not fire a click");
+}
+
 }  // namespace
 
 int main() {
@@ -173,6 +218,8 @@ int main() {
     testHiddenToggleDoesNotToggle();
     testReshownButtonWorksAgain();
     testHiddenButtonDoesNotLatchPressedState();
+    testHidingMidPressCancelsTheGesture();
+    testDisablingMidPressCancelsTheGesture();
 
     if (g_failures != 0) {
         std::cout << "[FAIL] NUIWidgetHiddenInputTest: " << g_failures << " failure(s)\n";

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1725,6 +1725,17 @@ if(TARGET AestraUI_Core)
     )
     add_test(NAME NUIHiddenChildDispatchTest COMMAND NUIHiddenChildDispatchTest)
     set_tests_properties(NUIHiddenChildDispatchTest PROPERTIES LABELS "ui;dispatch;regression")
+
+    # #672 leaf side: a widget handed an event directly (bypassing the parent-side
+    # filter added in #674) must still refuse it while hidden.
+    add_executable(NUIWidgetHiddenInputTest AestraUI/NUIWidgetHiddenInputTest.cpp)
+    target_link_libraries(NUIWidgetHiddenInputTest PRIVATE AestraUI_Core)
+    target_include_directories(NUIWidgetHiddenInputTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+    )
+    add_test(NAME NUIWidgetHiddenInputTest COMMAND NUIWidgetHiddenInputTest)
+    set_tests_properties(NUIWidgetHiddenInputTest PROPERTIES LABELS "ui;dispatch;regression")
 else()
     message(STATUS "Dropdown/tooltip interaction tests skipped (AestraUI_Core target unavailable in this build mode)")
 endif()


### PR DESCRIPTION
Closes the leaf-side half of the **#672** checklist, and records what the audit of all 89 `onMouseEvent` overrides actually found.

## Why this is not already covered by #674

#674 filtered invisible children inside `NUIComponent::onMouseEvent`'s generic child walk. That closed #671. But **18 of the 89 overrides do not use the generic walk** — they forward straight to a named child, bypassing the parent-side filter entirely:

```
SettingsDialog.cpp:298-303      m_applyButton / m_cancelButton / m_okButton
PianoRollToolbar.cpp:457-462    the seven tool-strip buttons
TrackUIComponent.cpp:1865       routeControlButton() -> mute / solo / record
```

So the guarantee has to hold on the leaf side too.

## Audit result

| | count |
|---|---|
| `onMouseEvent` overrides total | 89 |
| forward to children themselves | 18 |
| of those, guard visibility correctly | 12 |
| of those, forward to a self-guarding child | 6 |
| **unguarded, non-self-guarding** | **1** |

Every base widget already opens with an `isVisible()` test — `NUISlider`, `NUIDropdown`, `NUITextInput`, `NUIContextMenu`, `NUIScrollbar`, `NUIToggle`, `NUICheckbox`.

`NUIButton` was the sole exception. It checked only `isEnabled()`, called the base for its hover side effects while **discarding the result**, then hit-tested and fired `onClick_`. Hidden components keep their bounds, so `containsPoint()` still matched.

**No live outage.** None of the directly-forwarded buttons is hidden today. But this is the exact shape of #671, and `MembershipSettingsPage.cpp:858` already carries a hand-rolled version of the same guard — *"mirrors the render gate so a signed-out click can't trigger an invisible button"* — so someone has hit this here before. That page hides four `NUIButton`s including sign-out; it is safe only because it happens to end with `return NUIComponent::onMouseEvent(event)`.

## `hitTestVisible_`: decided KEEP, and I had this wrong first

The checklist said decide-or-delete. I deleted it, and the build rejected that — `isComponentEligibleForDragTarget()` (`NUIDragDrop.cpp:14`) walks the ancestor chain and rejects drop targets that clear it. My sweep missed it because the pattern matched `setHitTestVisible`/`getHitTestVisible` but not **`is`**`HitTestVisible`.

So it is a functioning hook with a real consumer, not dead code. Restored and documented instead:

- The name reads like a general hit-testing switch. **Mouse dispatch never consults it** — `onMouseEvent` gates on `visible_`/`enabled_`, and #674's filter on `isVisible()`. Clearing it does not make a component click-through; setting it does not make one clickable.
- Nothing anywhere clears it, so the drag-eligibility clause is **inert today**.
- Removed `UIRoutingMap`'s `setHitTestVisible(true)` — a no-op call on the default value, evidently written expecting an effect.

## Verification

`NUIWidgetHiddenInputTest`, 6 cases: `onClick`; the separate toggle branch and its persisted state; unhandled-return (a hidden button *consuming* the event would itself recreate the #671 dead zone); re-show; and `pressed_` not latching across a hide.

**Mutation-probed.** Against the pre-fix guard, 9/9 negative assertions fail — while the positive control (`a visible button invoked directly still fires onClick`) passes in **both** runs, so the test discriminates rather than being globally broken.

| Rung | Result |
|---|---|
| compiles | full build clean, zero `error:` lines |
| executes | `NUIWidgetHiddenInputTest` PASS |
| observed to fail pre-fix | 9/9 negative assertions, positive control unaffected |
| regression-gated | registered, labels `ui;dispatch;regression` |
| no collateral | full `ctest` **213/213** (212 + the new test); `-L ui` 22/22 |

## Filed, not fixed here

- **#678** — `InsertSlot::onMouseEvent` fires its callback on any left press with no bounds *or* visibility check. Dead code: `ChannelStrip::addInsert()` has zero callers, `AestraUI::ChannelStrip` is never instantiated.
- **#679** — `TrackUIComponent` forwards mouse events to `m_volumeFader`, which line 1747 unconditionally hides. Harmless (NUISlider self-guards) but dead routing that reads as live.

Refs #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Prevent `NUIButton` from participating in mouse dispatch while it’s hidden or disabled, including when a press is already in-flight.
- Make the hidden/disabled guard state-safe: if visibility/enabled state changes mid-gesture, `NUIButton` now clears `pressed_` (and marks dirty) before refusing the input, avoiding “latched pressed” visuals and stray click/toggle completion on later releases.
- Add/expand regression coverage in `NUIWidgetHiddenInputTest` for press/release handling while hidden/disabled mid-gesture: suppression of `onClick` and toggle callbacks, correct “unhandled” returns, behavior after hiding and re-showing, and prevention of clicks from unmatched releases.
- Document that `hitTestVisible_` is intended for drag-target eligibility (not mouse routing), and remove a redundant no-op `UIRoutingMap::setHitTestVisible(true)` call from construction.
- Register the new `NUIWidgetHiddenInputTest` with CTest.
- Validation: `NUIWidgetHiddenInputTest` passes (8/8), UI tests pass (22/22), and full suite passes (213/213). Issues `#678` and `#679` are recorded but not fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->