### PR TITLE
Give plugin instances a permanent identity (#667 slice 1)

### DIFF
--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -28,7 +28,11 @@ public:
 
     void execute() override {
         if (m_executed) return;
-        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin);
+        // A redo must restore the identity the first execute minted, not invent a
+        // second one for the same plugin (#667) — see AddPluginCommand. 0 on the
+        // first pass is exactly the "mint one" signal.
+        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin, m_instanceId);
+        m_instanceId = m_channel.getEffectChain().getSlotInstanceId(m_slotIndex);
         m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
         m_executed = true;
     }
@@ -59,6 +63,7 @@ private:
     size_t m_slotIndex;
     PluginInstancePtr m_plugin;
     std::string m_effectName;
+    uint64_t m_instanceId{0};
     bool m_executed = false;
 };
 
@@ -72,6 +77,9 @@ public:
 
     void execute() override {
         if (m_executed) return;
+        // Capture before removing so undo re-seats the SAME plugin rather than a
+        // new one wearing its slot (#667) — see RemovePluginCommand.
+        m_removedInstanceId = m_channel.getEffectChain().getSlotInstanceId(m_slotIndex);
         m_removedPlugin = m_channel.getEffectChain().removePlugin(m_slotIndex);
         m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
         m_executed = true;
@@ -80,7 +88,7 @@ public:
     void undo() override {
         if (!m_executed) return;
         if (m_removedPlugin) {
-            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin);
+            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin, m_removedInstanceId);
         }
         m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
         m_executed = false;
@@ -100,6 +108,7 @@ private:
     MixerChannel& m_channel;
     size_t m_slotIndex;
     PluginInstancePtr m_removedPlugin;
+    uint64_t m_removedInstanceId{0};
     bool m_executed = false;
 };
 

--- a/AestraAudio/include/Commands/PluginCommands.h
+++ b/AestraAudio/include/Commands/PluginCommands.h
@@ -13,7 +13,12 @@ public:
         : m_channel(channel), m_slotIndex(slotIndex), m_plugin(std::move(plugin)) {}
 
     void execute() override {
-        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin);
+        // The first execute mints; a redo restores what that mint produced, so
+        // undo/redo of an add is a round trip rather than a new plugin wearing
+        // the old one's slot (#667). m_instanceId is 0 on the first pass, which
+        // is exactly the "mint one" signal.
+        m_channel.getEffectChain().insertPlugin(m_slotIndex, m_plugin, m_instanceId);
+        m_instanceId = m_channel.getEffectChain().getSlotInstanceId(m_slotIndex);
     }
     void undo() override {
         m_channel.getEffectChain().removePlugin(m_slotIndex);
@@ -31,6 +36,7 @@ private:
     MixerChannel& m_channel;
     size_t m_slotIndex;
     PluginInstancePtr m_plugin;
+    uint64_t m_instanceId{0};
 };
 
 class RemovePluginCommand : public ICommand {
@@ -39,12 +45,18 @@ public:
         : m_channel(channel), m_slotIndex(slotIndex) {}
 
     void execute() override {
+        // Capture the identity before removing, so undo can put the SAME plugin
+        // back rather than a new one that merely looks the same (#667). Without
+        // this, insertPlugin mints a fresh id on undo and every automation curve
+        // addressed to this plugin is orphaned by a Ctrl+Z the user reads as
+        // "put it back".
+        m_removedInstanceId = m_channel.getEffectChain().getSlotInstanceId(m_slotIndex);
         // Remove and store the plugin so we can undo
         m_removedPlugin = m_channel.getEffectChain().removePlugin(m_slotIndex);
     }
     void undo() override {
         if (m_removedPlugin) {
-            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin);
+            m_channel.getEffectChain().insertPlugin(m_slotIndex, m_removedPlugin, m_removedInstanceId);
         }
     }
     void redo() override {
@@ -60,6 +72,7 @@ private:
     MixerChannel& m_channel;
     size_t m_slotIndex;
     PluginInstancePtr m_removedPlugin;
+    uint64_t m_removedInstanceId{0};
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -173,9 +173,23 @@ public:
      *
      * @param slotIndex Slot index (0 to MAX_SLOTS-1)
      * @param plugin Plugin instance to insert
+     * @param preservedInstanceId Identity to restore, or 0 to mint a fresh one.
+     *
+     * Pass 0 (the default) whenever the slot is genuinely acquiring a new
+     * occupant — that is the ordinary case, and a fresh identity is what stops
+     * a replacement from inheriting its predecessor's automation.
+     *
+     * Pass a non-zero id only when re-seating an occupant that already had one
+     * and never stopped being the same plugin to the user. Undo of a plugin
+     * removal is the case that ships today: RemovePluginCommand hands back the
+     * very same instance, so minting there would change the identity of a
+     * plugin the user only ever saw disappear and come back. The id is reserved
+     * against the mint counter, so restoring an id from outside this process
+     * (a loaded project) can never collide with one minted inside it.
+     *
      * @return true if inserted successfully
      */
-    bool insertPlugin(size_t slotIndex, PluginInstancePtr plugin);
+    bool insertPlugin(size_t slotIndex, PluginInstancePtr plugin, uint64_t preservedInstanceId = 0);
 
     /**
      * @brief Remove plugin from slot

--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -59,12 +59,55 @@ struct EffectSlot {
     /// This, not isEmpty(), is what "can I put a plugin here" should ask.
     bool isOccupied() const { return plugin != nullptr || !missingPluginId.empty(); }
 
+    // Permanent identity for whatever occupies this slot (#667).
+    //
+    // The slot INDEX is a position; this is an identity. Automation must address
+    // the plugin instance a curve was drawn for, never the position that instance
+    // happened to occupy — reordering a chain is a rearrangement, never a
+    // retarget. movePlugin/swapPlugins carry this value with the plugin, so a
+    // reorder cannot silently re-point anything that refers to it.
+    //
+    // Zero means "nothing here". Minted by insertPlugin() and by loadState() for
+    // slots restored from a pre-v2 chain that predates identity; cleared by
+    // removePlugin(). A missing-plugin placeholder (#647) keeps its id, because
+    // the slot still stands for the same plugin — automation addressed to a
+    // plugin that failed to load must survive the round trip exactly as the
+    // placeholder itself does.
+    //
+    // Minted process-wide rather than per-chain: a plugin dragged from one
+    // channel strip to another keeps its identity, and per-chain counters would
+    // collide across channels.
+    uint64_t instanceId{0};
+
     void clearMissingPlugin() {
         missingPluginId.clear();
         missingPluginState.clear();
         missingPluginState.shrink_to_fit();
     }
 };
+
+/**
+ * @brief Mint a process-unique plugin-instance id (#667).
+ *
+ * Follows the house pattern established for unit ids (#528): a monotonic
+ * counter, plus a re-mint guard on load so restored ids can never be handed out
+ * a second time (see EffectChain::loadState). Never returns zero, which is the
+ * reserved "no instance" value.
+ *
+ * Non-RT only. Called from slot mutation, which is already main/control-thread
+ * only per the EffectChain mutation contract.
+ */
+uint64_t mintPluginInstanceId();
+
+/**
+ * @brief Ensure future mints exceed @p seenId.
+ *
+ * Called for every id restored by loadState. Without this, a project whose ids
+ * were minted in a previous run would collide with ids minted in this one, and
+ * two slots could share an identity — which is precisely the ambiguity the id
+ * exists to remove.
+ */
+void reserveMintedPluginInstanceId(uint64_t seenId);
 
 /**
  * @brief Effect chain for insert effects on a mixer channel
@@ -172,6 +215,26 @@ public:
      * @brief Check if slot is empty
      */
     bool isSlotEmpty(size_t slotIndex) const;
+
+    /**
+     * @brief The permanent identity of whatever occupies @p slotIndex (#667).
+     * @return The instance id, or 0 for an out-of-range or unoccupied slot.
+     */
+    uint64_t getSlotInstanceId(size_t slotIndex) const;
+
+    /**
+     * @brief Find the slot currently holding plugin instance @p instanceId (#667).
+     *
+     * This is the identity→position translation that lets automation address a
+     * plugin instance instead of a chain position, mirroring what ChannelSlotMap
+     * does for channels. Callers must re-resolve rather than cache the index: the
+     * whole point is that the index moves and the id does not.
+     *
+     * @return The slot index, or MAX_SLOTS if no slot holds that id. Passing 0
+     *         always returns MAX_SLOTS — 0 means "no instance", so it must never
+     *         match an unoccupied slot's zeroed id.
+     */
+    size_t findSlotByInstanceId(uint64_t instanceId) const;
 
     /**
      * @brief Get first empty slot index
@@ -379,6 +442,10 @@ struct EffectChainSnapshotSlot {
     bool bypassed;                                    ///< Bypass state (copied value)
     float dryWetMix;                                  ///< Dry/wet mix (copied value)
     std::shared_ptr<EffectSlotFaultState> faultState; ///< Shared RT-visible fault state
+    /// Permanent identity of this slot's occupant, 0 if unoccupied (#667).
+    /// Carried into the snapshot so the render thread can resolve automation by
+    /// identity without touching the mutable chain.
+    uint64_t instanceId{0};
 
     bool isEmpty() const { return plugin == nullptr; }
 };
@@ -404,8 +471,28 @@ public:
             m_slots[i].bypassed = slots[i].bypassed.load(std::memory_order_acquire);
             m_slots[i].dryWetMix = slots[i].dryWetMix.load(std::memory_order_acquire);
             m_slots[i].faultState = slots[i].faultState;
+            m_slots[i].instanceId = slots[i].instanceId;
         }
         m_slotCount = MAX_SLOTS;
+    }
+
+    /**
+     * @brief Find the snapshot slot holding plugin instance @p instanceId (#667).
+     *
+     * RT-safe: a bounded linear scan over MAX_SLOTS with no allocation, the same
+     * shape as ChannelSlotMap::getSlotIndex(). Returns MAX_SLOTS when the id is
+     * absent, and always for id 0 ("no instance").
+     */
+    size_t findSlotByInstanceId(uint64_t instanceId) const noexcept {
+        if (instanceId == 0) {
+            return MAX_SLOTS;
+        }
+        for (size_t i = 0; i < MAX_SLOTS; ++i) {
+            if (m_slots[i].instanceId == instanceId) {
+                return i;
+            }
+        }
+        return MAX_SLOTS;
     }
 
     size_t slotCount() const noexcept { return m_slotCount; }

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <limits>
 #include <cmath>
 #include <cstring>
 
@@ -33,6 +34,15 @@ uint64_t mintPluginInstanceId() {
 
 void reserveMintedPluginInstanceId(uint64_t seenId) {
     if (seenId == 0) {
+        return;
+    }
+    // UINT64_MAX is never reserved, matching the house policy already stated for
+    // source ids (SourceManager.h) and pattern ids (PatternManager.h): advancing
+    // the counter past it wraps to zero, and the next mint then takes its wrap
+    // branch and hands out 1 — an id almost certainly already in use. Refusing
+    // here keeps the counter monotonic no matter what a caller passes, so the
+    // guarantee does not depend on every call site remembering the boundary.
+    if (seenId == std::numeric_limits<uint64_t>::max()) {
         return;
     }
     uint64_t expected = g_nextPluginInstanceId.load(std::memory_order_relaxed);
@@ -172,7 +182,17 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin, uint6
     // removal is that case: minting there would mean Ctrl+Z silently orphaned
     // every curve pointing at the plugin it just brought back. Reserve the id
     // first so one restored from outside this process can never be minted again.
-    if (receivedPlugin && preservedInstanceId != 0) {
+    //
+    // A preserved id is honoured only if it can actually be held uniquely. Two
+    // cases fall back to a fresh mint, matching how SourceManager treats a
+    // requested source id: UINT64_MAX, which cannot be reserved without wrapping
+    // the counter to zero, and an id already live in this chain, which would put
+    // the same identity in two slots. Falling back is right rather than failing
+    // the insert — the plugin still belongs in the slot, it just cannot keep a
+    // name that is unusable or taken.
+    if (receivedPlugin && preservedInstanceId != 0
+        && preservedInstanceId != std::numeric_limits<uint64_t>::max()
+        && findSlotByInstanceId(preservedInstanceId) == MAX_SLOTS) {
         reserveMintedPluginInstanceId(preservedInstanceId);
         m_slots[slotIndex].instanceId = preservedInstanceId;
     } else {

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -5,11 +5,45 @@
 #include "AestraLog.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstring>
 
 namespace Aestra {
 namespace Audio {
+
+namespace {
+// Process-wide plugin-instance id counter (#667). Atomic because chains on
+// different channels are mutated from the main/control thread but nothing
+// guarantees a single thread across a session; the RT thread never touches it.
+std::atomic<uint64_t> g_nextPluginInstanceId{1};
+}  // namespace
+
+uint64_t mintPluginInstanceId() {
+    uint64_t id = g_nextPluginInstanceId.fetch_add(1, std::memory_order_relaxed);
+    // Wrap guard, mirroring the unit-id counter (#528). Exhausting 2^64 ids is not
+    // reachable in practice, but returning 0 would silently mean "no instance" and
+    // un-address every curve pointing at this slot, so refuse to produce it.
+    if (id == 0) {
+        g_nextPluginInstanceId.store(1, std::memory_order_relaxed);
+        id = 1;
+    }
+    return id;
+}
+
+void reserveMintedPluginInstanceId(uint64_t seenId) {
+    if (seenId == 0) {
+        return;
+    }
+    uint64_t expected = g_nextPluginInstanceId.load(std::memory_order_relaxed);
+    while (expected <= seenId) {
+        if (g_nextPluginInstanceId.compare_exchange_weak(expected, seenId + 1,
+                                                         std::memory_order_relaxed)) {
+            return;
+        }
+        // expected is refreshed by compare_exchange_weak; loop re-tests it.
+    }
+}
 
 namespace {
 bool processPluginNoexcept(IPluginInstance& plugin, const float* const* inputs, float** outputs,
@@ -120,10 +154,19 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
         (void)plugin->getInfo();
     }
 
+    // Whether the CALLER handed us a plugin — checked before the move, which
+    // leaves `plugin` null either way.
+    const bool receivedPlugin = plugin != nullptr;
     m_slots[slotIndex].plugin = std::move(plugin);
     // The slot now genuinely holds what the caller put here, so any retained
     // missing-plugin record for it is superseded (#647).
     m_slots[slotIndex].clearMissingPlugin();
+    // A different plugin instance occupies this slot, so it is a different
+    // identity — mint a fresh one rather than inheriting whatever was here
+    // (#667). Inheriting would silently hand the previous plugin's automation to
+    // its replacement, which is the same class of defect as the positional
+    // addressing this id exists to remove.
+    m_slots[slotIndex].instanceId = receivedPlugin ? mintPluginInstanceId() : 0;
     m_slots[slotIndex].bypassed.store(false);
     m_slots[slotIndex].dryWetMix.store(1.0f);
     m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
@@ -147,6 +190,10 @@ PluginInstancePtr EffectChain::removePlugin(size_t slotIndex) {
     m_slots[slotIndex].plugin = nullptr;
     // Removing a slot removes it, placeholder included (#647).
     m_slots[slotIndex].clearMissingPlugin();
+    // The instance is gone, so its identity goes with it (#667). Anything still
+    // addressing this id now resolves to nothing, which is the honest outcome —
+    // far better than resolving to whatever occupies the index next.
+    m_slots[slotIndex].instanceId = 0;
     m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
 
     publishSnapshot();
@@ -175,6 +222,10 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
     }
 
     m_slots[toSlot].plugin = std::move(m_slots[fromSlot].plugin);
+    // The identity travels with the instance (#667). This is the whole point of
+    // the id: a move changes which index holds the plugin and nothing else, so
+    // automation addressed to it keeps resolving to the same plugin.
+    m_slots[toSlot].instanceId = m_slots[fromSlot].instanceId;
     m_slots[toSlot].missingPluginId = std::move(m_slots[fromSlot].missingPluginId);
     m_slots[toSlot].missingPluginState = std::move(m_slots[fromSlot].missingPluginState);
     m_slots[toSlot].bypassed.store(m_slots[fromSlot].bypassed.load());
@@ -186,6 +237,7 @@ bool EffectChain::movePlugin(size_t fromSlot, size_t toSlot) {
 
     m_slots[fromSlot].plugin = nullptr;
     m_slots[fromSlot].clearMissingPlugin();
+    m_slots[fromSlot].instanceId = 0;  // vacated — no instance lives here now (#667)
     m_slots[fromSlot].bypassed.store(false);
     m_slots[fromSlot].dryWetMix.store(1.0f);
     m_slots[fromSlot].faultState = std::make_shared<EffectSlotFaultState>();
@@ -207,6 +259,8 @@ bool EffectChain::swapPlugins(size_t slot1, size_t slot2) {
     }
 
     std::swap(m_slots[slot1].plugin, m_slots[slot2].plugin);
+    // Identities swap with their instances (#667) — see movePlugin.
+    std::swap(m_slots[slot1].instanceId, m_slots[slot2].instanceId);
     std::swap(m_slots[slot1].missingPluginId, m_slots[slot2].missingPluginId);
     std::swap(m_slots[slot1].missingPluginState, m_slots[slot2].missingPluginState);
     std::swap(m_slots[slot1].faultState, m_slots[slot2].faultState);
@@ -245,6 +299,27 @@ bool EffectChain::isSlotEmpty(size_t slotIndex) const {
     // "Free to use", not the RT predicate: a retained missing-plugin record
     // claims its slot (#647).
     return !m_slots[slotIndex].isOccupied();
+}
+
+uint64_t EffectChain::getSlotInstanceId(size_t slotIndex) const {
+    if (slotIndex >= MAX_SLOTS) {
+        return 0;
+    }
+    return m_slots[slotIndex].instanceId;
+}
+
+size_t EffectChain::findSlotByInstanceId(uint64_t instanceId) const {
+    // Id 0 means "no instance". Unoccupied slots carry 0, so matching on it would
+    // resolve every un-addressed curve to the first empty slot (#667).
+    if (instanceId == 0) {
+        return MAX_SLOTS;
+    }
+    for (size_t i = 0; i < MAX_SLOTS; ++i) {
+        if (m_slots[i].instanceId == instanceId) {
+            return i;
+        }
+    }
+    return MAX_SLOTS;
 }
 
 size_t EffectChain::getFirstEmptySlot() const {
@@ -290,6 +365,7 @@ void EffectChain::clear() {
     for (auto& slot : m_slots) {
         slot.plugin = nullptr;
         slot.clearMissingPlugin();
+        slot.instanceId = 0;  // every instance is gone, so every identity is (#667)
         slot.bypassed.store(false);
         slot.dryWetMix.store(1.0f);
         slot.faultState = std::make_shared<EffectSlotFaultState>();

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -129,7 +129,7 @@ void EffectChain::publishSnapshot() {
 // Slot Management
 // ==============================
 
-bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
+bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin, uint64_t preservedInstanceId) {
     if (reportRealtimeMisuse("EffectChain::insertPlugin")) {
         return false;
     }
@@ -166,7 +166,18 @@ bool EffectChain::insertPlugin(size_t slotIndex, PluginInstancePtr plugin) {
     // (#667). Inheriting would silently hand the previous plugin's automation to
     // its replacement, which is the same class of defect as the positional
     // addressing this id exists to remove.
-    m_slots[slotIndex].instanceId = receivedPlugin ? mintPluginInstanceId() : 0;
+    //
+    // The exception is a caller re-seating an occupant that already HAD an
+    // identity and, to the user, never stopped being the same plugin. Undo of a
+    // removal is that case: minting there would mean Ctrl+Z silently orphaned
+    // every curve pointing at the plugin it just brought back. Reserve the id
+    // first so one restored from outside this process can never be minted again.
+    if (receivedPlugin && preservedInstanceId != 0) {
+        reserveMintedPluginInstanceId(preservedInstanceId);
+        m_slots[slotIndex].instanceId = preservedInstanceId;
+    } else {
+        m_slots[slotIndex].instanceId = receivedPlugin ? mintPluginInstanceId() : 0;
+    }
     m_slots[slotIndex].bypassed.store(false);
     m_slots[slotIndex].dryWetMix.store(1.0f);
     m_slots[slotIndex].faultState = std::make_shared<EffectSlotFaultState>();
@@ -801,6 +812,10 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
         if (!hasPlugin) {
             m_slots[i].plugin = nullptr;
             m_slots[i].clearMissingPlugin();
+            // Loading into a chain that was already populated must not leave the
+            // previous occupant's identity behind on a now-empty slot, or a
+            // lookup for that id would resolve to a slot holding nothing (#667).
+            m_slots[i].instanceId = 0;
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
             continue;
         }
@@ -864,6 +879,12 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
             m_slots[i].plugin = std::move(instance);
             m_slots[i].clearMissingPlugin();
+            // v1 chains predate identity, so there is nothing on the wire to
+            // restore — mint. Reserving would be wrong here for the same reason:
+            // there is no persisted id that a future mint could collide with.
+            // When v2 lands, this is the branch that reads the stored id and
+            // calls reserveMintedPluginInstanceId instead (#667).
+            m_slots[i].instanceId = mintPluginInstanceId();
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
@@ -880,6 +901,10 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
             m_slots[i].plugin = nullptr;
             m_slots[i].missingPluginId = pluginId;
             m_slots[i].missingPluginState = std::move(pluginState);
+            // A placeholder is an occupant, so it gets an identity like any
+            // other (#647/#667). Automation addressed to a plugin that failed to
+            // load has to survive the round trip exactly as the placeholder does.
+            m_slots[i].instanceId = mintPluginInstanceId();
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();

--- a/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
+++ b/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
@@ -27,6 +27,7 @@
 
 #include "Plugin/EffectChain.h"
 
+#include "Commands/EffectCommands.h"
 #include "Commands/PluginCommands.h"
 #include "Core/MixerChannel.h"
 #include "Plugin/PluginManager.h"
@@ -452,6 +453,40 @@ void testRedoOfAddKeepsTheOriginalIdentity() {
           "redoing an add restores the original identity");
 }
 
+void testUndoOfEffectRemoveRestoresTheSameIdentity() {
+    // EffectCommands.h carries a second, independent add/remove pair with the
+    // same shape as PluginCommands.h — different constructor, same defect. Both
+    // are wired into history, so covering only one would leave the identity
+    // guarantee true through one undo path and false through the other.
+    TrackManager trackManager;
+    MixerChannel channel("Identity", 3);
+    auto& chain = channel.getEffectChain();
+    chain.insertPlugin(2, makePlugin("effect.undo.subject"));
+    const uint64_t original = chain.getSlotInstanceId(2);
+
+    RemoveEffectCommand command(trackManager, channel, 2);
+    command.execute();
+    command.undo();
+
+    check(chain.getSlotInstanceId(2) == original,
+          "undoing RemoveEffectCommand restores the identity too");
+}
+
+void testRedoOfEffectAddKeepsTheOriginalIdentity() {
+    TrackManager trackManager;
+    MixerChannel channel("Identity", 4);
+    auto& chain = channel.getEffectChain();
+
+    AddEffectCommand command(trackManager, channel, 0, makePlugin("effect.redo.subject"), "Reverb");
+    command.execute();
+    const uint64_t original = chain.getSlotInstanceId(0);
+    command.undo();
+    command.redo();
+
+    check(chain.getSlotInstanceId(0) == original,
+          "redoing AddEffectCommand restores the original identity too");
+}
+
 void testPreservedIdentityIsReservedAgainstFutureMints() {
     // A preserved id can come from outside this process once v2 persists it. If
     // restoring one did not advance the mint counter, the very next insert could
@@ -499,6 +534,8 @@ int main() {
     testLoadClearsIdentityOnSerializedEmptySlots();
     testUndoOfRemoveRestoresTheSameIdentity();
     testRedoOfAddKeepsTheOriginalIdentity();
+    testUndoOfEffectRemoveRestoresTheSameIdentity();
+    testRedoOfEffectAddKeepsTheOriginalIdentity();
     testPreservedIdentityIsReservedAgainstFutureMints();
     testPreservedZeroStillMints();
 

--- a/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
+++ b/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
@@ -27,6 +27,10 @@
 
 #include "Plugin/EffectChain.h"
 
+#include "Commands/PluginCommands.h"
+#include "Core/MixerChannel.h"
+#include "Plugin/PluginManager.h"
+
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -336,6 +340,143 @@ void testSnapshotCarriesIdentity() {
           "the snapshot also refuses the reserved 0");
 }
 
+// ---------------------------------------------------------------------------
+// Restoration: load, and the undo/redo round trips (CodeRabbit review, #681)
+// ---------------------------------------------------------------------------
+//
+// Minting on insert is only half the invariant. The other half is that every
+// path which puts an occupant into a slot leaves a coherent identity behind —
+// including the paths that RESTORE an occupant rather than introduce one.
+//
+// The load tests deliberately serialize plugins whose ids are not registered
+// with PluginManager, so loadState takes the missing-plugin branch (#647). That
+// keeps them independent of the plugin registry and scan cache while still
+// exercising real restoration: a placeholder is an occupant and must carry an
+// identity like any other.
+
+/// Build a serialized chain: slot 0 occupied, everything else empty.
+std::vector<uint8_t> serializeChainWithOccupantInSlotZero() {
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("aestra.test.identity.unregistered"));
+    return chain.saveState();
+}
+
+void testLoadMintsIdentityForRestoredSlots() {
+    // Before this, loadState never touched instanceId, so every plugin in a
+    // freshly opened project came back with identity 0 — i.e. unaddressable, and
+    // indistinguishable from an empty slot to findSlotByInstanceId.
+    EffectChain source;
+    source.insertPlugin(0, makePlugin("aestra.test.identity.unregistered.a"));
+    source.insertPlugin(3, makePlugin("aestra.test.identity.unregistered.b"));
+    const std::vector<uint8_t> blob = source.saveState();
+
+    EffectChain restored;
+    std::vector<std::string> missing;
+    check(restored.loadState(blob, PluginManager::getInstance(), &missing),
+          "the serialized chain loads");
+
+    const uint64_t a = restored.getSlotInstanceId(0);
+    const uint64_t b = restored.getSlotInstanceId(3);
+    check(a != 0, "a restored occupant has an identity");
+    check(b != 0, "every restored occupant has one, not just the first");
+    check(a != b, "restored occupants get distinct identities");
+    check(restored.findSlotByInstanceId(a) == 0, "a restored identity resolves to its slot");
+    check(restored.findSlotByInstanceId(b) == 3, "and so does the second");
+}
+
+void testLoadClearsIdentityOnSerializedEmptySlots() {
+    // The inverse, and the more dangerous half: loading into a chain that was
+    // already populated. A slot the blob says is empty must not keep the
+    // previous occupant's id, or a lookup for that id resolves to a slot holding
+    // nothing — a dangling identity rather than a missing one.
+    const std::vector<uint8_t> blob = serializeChainWithOccupantInSlotZero();
+
+    EffectChain reused;
+    reused.insertPlugin(0, makePlugin("occupant.0"));
+    reused.insertPlugin(2, makePlugin("occupant.2"));
+    const uint64_t staleId = reused.getSlotInstanceId(2);
+    check(staleId != 0, "the slot about to be emptied really had an identity");
+
+    std::vector<std::string> missing;
+    check(reused.loadState(blob, PluginManager::getInstance(), &missing),
+          "the blob loads over the populated chain");
+
+    check(reused.getSlotInstanceId(2) == 0,
+          "a slot the blob says is empty must not keep its old identity");
+    check(reused.findSlotByInstanceId(staleId) == EffectChain::MAX_SLOTS,
+          "the retired identity must not resolve to the now-empty slot");
+    check(reused.getSlotInstanceId(0) != staleId,
+          "nor may it drift onto the slot the blob did fill");
+}
+
+void testUndoOfRemoveRestoresTheSameIdentity() {
+    // The path that actually ships. MixerViewModel::removeInsert pushes a
+    // RemovePluginCommand, and its undo re-inserts the very same instance. Before
+    // the preserved-id parameter, insertPlugin minted there, so Ctrl+Z after a
+    // remove returned a plugin the user saw as unchanged but which every curve
+    // addressed to it no longer matched.
+    MixerChannel channel("Identity", 1);
+    auto& chain = channel.getEffectChain();
+    chain.insertPlugin(1, makePlugin("undo.subject"));
+    const uint64_t original = chain.getSlotInstanceId(1);
+    check(original != 0, "the plugin has an identity before removal");
+
+    RemovePluginCommand command(channel, 1);
+    command.execute();
+    check(chain.getSlotInstanceId(1) == 0, "removal retires the identity");
+
+    command.undo();
+    check(chain.getSlotInstanceId(1) == original,
+          "undoing a removal restores the identity, it does not mint a new one");
+    check(chain.findSlotByInstanceId(original) == 1,
+          "and the restored identity resolves to the slot again");
+}
+
+void testRedoOfAddKeepsTheOriginalIdentity() {
+    // Same defect through AddPluginCommand: undo then redo has to be a round
+    // trip. If redo minted, automation drawn before the undo would be orphaned by
+    // a redo the user reads as "put it back exactly as it was".
+    MixerChannel channel("Identity", 2);
+    auto& chain = channel.getEffectChain();
+
+    AddPluginCommand command(channel, 0, makePlugin("redo.subject"));
+    command.execute();
+    const uint64_t original = chain.getSlotInstanceId(0);
+    check(original != 0, "the added plugin has an identity");
+
+    command.undo();
+    check(chain.getSlotInstanceId(0) == 0, "undoing the add empties the slot");
+
+    command.redo();
+    check(chain.getSlotInstanceId(0) == original,
+          "redoing an add restores the original identity");
+}
+
+void testPreservedIdentityIsReservedAgainstFutureMints() {
+    // A preserved id can come from outside this process once v2 persists it. If
+    // restoring one did not advance the mint counter, the very next insert could
+    // hand out the same value and two slots would share an identity — the exact
+    // ambiguity the id exists to remove.
+    EffectChain chain;
+    const uint64_t farFuture = 9'000'000'000ULL;
+    chain.insertPlugin(0, makePlugin("restored"), farFuture);
+    check(chain.getSlotInstanceId(0) == farFuture, "the preserved identity is taken as given");
+
+    chain.insertPlugin(1, makePlugin("fresh"));
+    check(chain.getSlotInstanceId(1) > farFuture,
+          "a later mint must clear a restored identity, not collide with it");
+}
+
+void testPreservedZeroStillMints() {
+    // 0 is the "no identity" sentinel, so passing it must mean "mint one" rather
+    // than "install 0 as the identity" — otherwise every existing caller, which
+    // relies on the default, would insert unaddressable plugins.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("defaulted"), 0);
+    check(chain.getSlotInstanceId(0) != 0,
+          "passing the reserved 0 mints a real identity instead of storing 0");
+}
+
 }  // namespace
 
 int main() {
@@ -354,6 +495,12 @@ int main() {
     testMintNeverReturnsZero();
     testResetPreservesIdentities();
     testSnapshotCarriesIdentity();
+    testLoadMintsIdentityForRestoredSlots();
+    testLoadClearsIdentityOnSerializedEmptySlots();
+    testUndoOfRemoveRestoresTheSameIdentity();
+    testRedoOfAddKeepsTheOriginalIdentity();
+    testPreservedIdentityIsReservedAgainstFutureMints();
+    testPreservedZeroStillMints();
 
     if (g_failures != 0) {
         std::cerr << "[FAIL] EffectChainInstanceIdentityTest: " << g_failures << " failure(s)\n";

--- a/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
+++ b/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
@@ -33,6 +33,7 @@
 #include "Plugin/PluginManager.h"
 
 #include <cstdint>
+#include <limits>
 #include <iostream>
 #include <memory>
 #include <set>
@@ -502,6 +503,76 @@ void testPreservedIdentityIsReservedAgainstFutureMints() {
           "a later mint must clear a restored identity, not collide with it");
 }
 
+void testPreservedMaxIdCannotPoisonTheCounter() {
+    // The boundary CodeRabbit caught on the second pass, and the reason it is
+    // dangerous rather than merely odd:
+    //
+    //   reserve(UINT64_MAX) stored seenId + 1, which wraps the counter to 0.
+    //   The next mint's fetch_add then returns 0, the wrap guard fires, and it
+    //   hands out 1 — an id that has almost certainly already been minted. Two
+    //   live occupants would share an identity, which is exactly the ambiguity
+    //   this whole mechanism exists to remove.
+    //
+    // The codebase already had a policy for this and I had not applied it:
+    // SourceManager and PatternManager both refuse to restore UINT64_MAX for the
+    // same wrap reason. This pins the same rule here.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("ordinary"));
+    const uint64_t ordinary = chain.getSlotInstanceId(0);
+    check(ordinary != 0, "an ordinary identity was minted first");
+
+    // Preserving the boundary value must fall back to a fresh mint rather than
+    // installing an id the counter cannot be advanced past.
+    chain.insertPlugin(1, makePlugin("boundary"), std::numeric_limits<uint64_t>::max());
+    const uint64_t boundary = chain.getSlotInstanceId(1);
+    check(boundary != std::numeric_limits<uint64_t>::max(),
+          "UINT64_MAX is refused as a preserved identity");
+    check(boundary != 0, "the fallback still produces a real identity");
+    check(boundary != ordinary, "and it does not collide with the one already minted");
+
+    // The counter must still be healthy afterwards: the failure mode was that
+    // every LATER mint got poisoned, so the next two ids are the real assertion.
+    chain.insertPlugin(2, makePlugin("after.a"));
+    chain.insertPlugin(3, makePlugin("after.b"));
+    const uint64_t afterA = chain.getSlotInstanceId(2);
+    const uint64_t afterB = chain.getSlotInstanceId(3);
+    std::set<uint64_t> unique{ordinary, boundary, afterA, afterB};
+    check(unique.size() == 4, "mints after the boundary attempt stay unique");
+    check(afterA != 0 && afterB != 0, "and stay non-zero");
+}
+
+void testReserveIgnoresTheMaxIdDirectly() {
+    // Same rule at the helper's own boundary, so the guarantee does not depend on
+    // insertPlugin being the only caller — v2 load will call reserve directly.
+    reserveMintedPluginInstanceId(std::numeric_limits<uint64_t>::max());
+
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("after.reserve.max"));
+    const uint64_t first = chain.getSlotInstanceId(0);
+    chain.insertPlugin(1, makePlugin("after.reserve.max.2"));
+    const uint64_t second = chain.getSlotInstanceId(1);
+
+    check(first != 0 && second != 0, "minting still works after reserving the boundary value");
+    check(first != second, "and still produces distinct identities");
+}
+
+void testPreservedIdAlreadyLiveInChainFallsBackToMint() {
+    // A preserved id that is already occupied elsewhere in the same chain cannot
+    // be honoured without putting one identity in two slots. Fall back to a mint:
+    // the plugin still belongs in the slot, it just cannot keep a taken name.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("incumbent"));
+    const uint64_t incumbent = chain.getSlotInstanceId(0);
+
+    chain.insertPlugin(1, makePlugin("claimant"), incumbent);
+
+    check(chain.getSlotInstanceId(1) != incumbent,
+          "a preserved id already live in the chain is refused");
+    check(chain.getSlotInstanceId(1) != 0, "the claimant still gets a real identity");
+    check(chain.findSlotByInstanceId(incumbent) == 0,
+          "and the incumbent keeps its identity, unambiguously");
+}
+
 void testPreservedZeroStillMints() {
     // 0 is the "no identity" sentinel, so passing it must mean "mint one" rather
     // than "install 0 as the identity" — otherwise every existing caller, which
@@ -537,6 +608,9 @@ int main() {
     testUndoOfEffectRemoveRestoresTheSameIdentity();
     testRedoOfEffectAddKeepsTheOriginalIdentity();
     testPreservedIdentityIsReservedAgainstFutureMints();
+    testPreservedMaxIdCannotPoisonTheCounter();
+    testReserveIgnoresTheMaxIdDirectly();
+    testPreservedIdAlreadyLiveInChainFallsBackToMint();
     testPreservedZeroStillMints();
 
     if (g_failures != 0) {

--- a/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
+++ b/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
@@ -1,0 +1,364 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Plugin-instance identity must survive chain reordering (#667).
+//
+// The defect this exists to prevent: automation addressed a plugin parameter by
+// {effectSlot, paramId}, where effectSlot is a POSITION. EffectChain::movePlugin
+// and swapPlugins relocate slot contents, and automation curves live on the lane
+// rather than on the chain, so nothing updated them. Reordering an effect chain
+// silently re-pointed every plugin-parameter curve on that lane at whatever now
+// occupied the slot — no parse failure, no warning, no crash, and destructive on
+// the next save because the wrong reading became canonical.
+//
+// The invariant these tests pin:
+//
+//   Automation addresses the plugin INSTANCE it was drawn for, not the position
+//   that instance happened to occupy. Reordering a chain is a rearrangement,
+//   never a retarget.
+//
+// This slice establishes the identity and its behaviour under every in-memory
+// slot mutation. Making automation resolve through it, and persisting it across
+// save/load, follow — the id is deliberately not yet read by the engine, so
+// these tests are about the identity's own contract, not about audio.
+//
+// Scope note: the tests use a locally defined IPluginInstance so they never
+// depend on a plugin being installed or on the scan cache. A test that needed a
+// real plugin could pass or fail for reasons unrelated to the invariant.
+
+#include "Plugin/EffectChain.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+/// Minimal effect instance. Only identity matters here, so process() is a copy
+/// and everything else is the smallest legal implementation.
+class IdentityTestPlugin final : public IPluginInstance {
+public:
+    explicit IdentityTestPlugin(const std::string& id) {
+        m_info.id = id;
+        m_info.name = id;
+        m_info.vendor = "Aestra Tests";
+        m_info.version = "1";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override { m_active = true; }
+    void deactivate() override { m_active = false; }
+    bool isActive() const override { return m_active; }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* = nullptr,
+                 MidiBuffer* = nullptr) override {
+        if (inputs == nullptr || outputs == nullptr) {
+            return;
+        }
+        const uint32_t channels = numInputChannels < numOutputChannels ? numInputChannels
+                                                                       : numOutputChannels;
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                outputs[ch][i] = inputs[ch][i];
+            }
+        }
+    }
+
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+private:
+    bool m_active{false};
+    PluginInfo m_info{};
+};
+
+PluginInstancePtr makePlugin(const std::string& id) {
+    return std::make_shared<IdentityTestPlugin>(id);
+}
+
+// --- the identity's own contract --------------------------------------------
+
+void testInsertMintsDistinctNonZeroIds() {
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    chain.insertPlugin(1, makePlugin("b"));
+    chain.insertPlugin(2, makePlugin("c"));
+
+    const uint64_t a = chain.getSlotInstanceId(0);
+    const uint64_t b = chain.getSlotInstanceId(1);
+    const uint64_t c = chain.getSlotInstanceId(2);
+
+    check(a != 0 && b != 0 && c != 0, "every occupied slot has a non-zero identity");
+    std::set<uint64_t> unique{a, b, c};
+    check(unique.size() == 3, "identities are distinct across slots");
+}
+
+void testUnoccupiedSlotsHaveNoIdentity() {
+    // Zero is the reserved "no instance" value. If an empty slot carried a real
+    // id, an un-addressed curve would resolve to it.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+
+    check(chain.getSlotInstanceId(1) == 0, "an empty slot has no identity");
+    check(chain.getSlotInstanceId(EffectChain::MAX_SLOTS) == 0,
+          "an out-of-range slot reports no identity rather than reading past the array");
+}
+
+void testMoveCarriesIdentityToTheNewPosition() {
+    // The core case. This is what silently retargeted automation.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("keeper"));
+    const uint64_t original = chain.getSlotInstanceId(0);
+
+    check(chain.movePlugin(0, 4), "the move succeeds into a free slot");
+
+    check(chain.getSlotInstanceId(4) == original,
+          "the identity travels with the instance to its new position");
+    check(chain.getSlotInstanceId(0) == 0, "the vacated slot keeps no identity behind");
+    check(chain.findSlotByInstanceId(original) == 4,
+          "the instance is found at its new position by identity");
+}
+
+void testSwapExchangesIdentitiesWithInstances() {
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("first"));
+    chain.insertPlugin(1, makePlugin("second"));
+    const uint64_t first = chain.getSlotInstanceId(0);
+    const uint64_t second = chain.getSlotInstanceId(1);
+
+    check(chain.swapPlugins(0, 1), "the swap succeeds");
+
+    check(chain.getSlotInstanceId(0) == second && chain.getSlotInstanceId(1) == first,
+          "identities exchange along with their instances");
+    check(chain.findSlotByInstanceId(first) == 1 && chain.findSlotByInstanceId(second) == 0,
+          "each instance is still found by its own identity after the swap");
+}
+
+void testReorderDoesNotRetarget() {
+    // The defect stated positively, at the level a curve would experience it.
+    // Resolve an address before the reorder and after, and require it to name the
+    // same plugin both times — which the positional scheme could not do.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("reverb"));
+    chain.insertPlugin(1, makePlugin("compressor"));
+
+    const uint64_t reverbId = chain.getSlotInstanceId(0);
+    const std::string before = chain.getPlugin(chain.findSlotByInstanceId(reverbId))->getInfo().id;
+
+    check(chain.swapPlugins(0, 1), "reorder the chain");
+
+    const size_t nowAt = chain.findSlotByInstanceId(reverbId);
+    check(nowAt != EffectChain::MAX_SLOTS, "the addressed instance is still resolvable");
+    const std::string after = chain.getPlugin(nowAt)->getInfo().id;
+
+    check(before == after && after == "reverb",
+          "an address resolved before and after a reorder names the same plugin");
+    check(nowAt == 1, "and it moved position, so the test is not passing by nothing happening");
+}
+
+void testRemoveRetiresTheIdentity() {
+    // A removed instance's id must resolve to nothing, not to whatever occupies
+    // the index next. Resolving to a successor is the exact defect.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("doomed"));
+    const uint64_t doomed = chain.getSlotInstanceId(0);
+
+    chain.removePlugin(0);
+    check(chain.getSlotInstanceId(0) == 0, "the emptied slot has no identity");
+    check(chain.findSlotByInstanceId(doomed) == EffectChain::MAX_SLOTS,
+          "a removed instance's identity resolves to nothing");
+
+    chain.insertPlugin(0, makePlugin("successor"));
+    check(chain.findSlotByInstanceId(doomed) == EffectChain::MAX_SLOTS,
+          "the successor in the same slot does NOT inherit the removed identity");
+    check(chain.getSlotInstanceId(0) != doomed,
+          "the successor received a fresh identity of its own");
+}
+
+void testReplacingInSlotMintsFresh() {
+    // insertPlugin over an occupied slot is a replacement, so it is a different
+    // instance and must not inherit the previous plugin's automation.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("old"));
+    const uint64_t oldId = chain.getSlotInstanceId(0);
+
+    chain.insertPlugin(0, makePlugin("new"));
+    const uint64_t newId = chain.getSlotInstanceId(0);
+
+    check(newId != 0, "the replacement has an identity");
+    check(newId != oldId, "the replacement does not inherit the replaced instance's identity");
+    check(chain.findSlotByInstanceId(oldId) == EffectChain::MAX_SLOTS,
+          "the replaced identity no longer resolves anywhere");
+}
+
+void testClearRetiresEveryIdentity() {
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    chain.insertPlugin(1, makePlugin("b"));
+    const uint64_t a = chain.getSlotInstanceId(0);
+    const uint64_t b = chain.getSlotInstanceId(1);
+
+    chain.clear();
+
+    check(chain.findSlotByInstanceId(a) == EffectChain::MAX_SLOTS &&
+              chain.findSlotByInstanceId(b) == EffectChain::MAX_SLOTS,
+          "clear() retires every identity in the chain");
+}
+
+void testLookupRejectsTheReservedZero() {
+    // Every unoccupied slot stores 0. A lookup that matched it would hand the
+    // first empty slot to anything not addressing a real instance.
+    EffectChain chain;
+    chain.insertPlugin(3, makePlugin("only"));
+
+    check(chain.findSlotByInstanceId(0) == EffectChain::MAX_SLOTS,
+          "id 0 never resolves, even though empty slots store 0");
+}
+
+void testUnknownIdentityDoesNotResolve() {
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    const uint64_t real = chain.getSlotInstanceId(0);
+
+    check(chain.findSlotByInstanceId(real + 99999) == EffectChain::MAX_SLOTS,
+          "an identity this chain never issued does not resolve");
+}
+
+void testIdentitiesAreUniqueAcrossChains() {
+    // Ids are minted process-wide, not per chain: a plugin dragged between
+    // channel strips keeps its identity, and per-chain counters would collide.
+    EffectChain first;
+    EffectChain second;
+    first.insertPlugin(0, makePlugin("a"));
+    second.insertPlugin(0, makePlugin("b"));
+
+    check(first.getSlotInstanceId(0) != second.getSlotInstanceId(0),
+          "two chains never mint the same identity for different instances");
+    check(second.findSlotByInstanceId(first.getSlotInstanceId(0)) == EffectChain::MAX_SLOTS,
+          "one chain's identity does not resolve inside another");
+}
+
+void testReserveMintedIdPreventsCollision() {
+    // The re-mint guard (#528's pattern). Ids restored from a project were minted
+    // in a previous run; without reserving them, this run would hand the same
+    // value out again and two slots would share an identity.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    const uint64_t restored = chain.getSlotInstanceId(0) + 5000;
+
+    reserveMintedPluginInstanceId(restored);
+
+    chain.insertPlugin(1, makePlugin("b"));
+    check(chain.getSlotInstanceId(1) > restored,
+          "ids minted after reserving a restored value exceed it");
+}
+
+void testMintNeverReturnsZero() {
+    for (int i = 0; i < 1000; ++i) {
+        if (mintPluginInstanceId() == 0) {
+            check(false, "mintPluginInstanceId must never return the reserved 0");
+            return;
+        }
+    }
+}
+
+void testResetPreservesIdentities() {
+    // reset() reboots plugins to flush their internal buffers; it does not remove
+    // them. The instances are the same, so their identities must be untouched —
+    // otherwise a panic/reset would orphan every curve in the project.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    chain.insertPlugin(1, makePlugin("b"));
+    const uint64_t a = chain.getSlotInstanceId(0);
+    const uint64_t b = chain.getSlotInstanceId(1);
+
+    chain.reset();
+
+    check(chain.getSlotInstanceId(0) == a && chain.getSlotInstanceId(1) == b,
+          "reset() reboots plugins without changing their identities");
+}
+
+void testSnapshotCarriesIdentity() {
+    // The render thread resolves against the snapshot, never the mutable chain,
+    // so the identity has to cross that boundary or it is unusable for audio.
+    EffectChain chain;
+    chain.insertPlugin(0, makePlugin("a"));
+    chain.insertPlugin(1, makePlugin("b"));
+    const uint64_t b = chain.getSlotInstanceId(1);
+
+    auto snapshot = chain.getSnapshot();
+    check(snapshot != nullptr, "a snapshot is published after mutation");
+    if (snapshot == nullptr) {
+        return;
+    }
+
+    check(snapshot->slot(1).instanceId == b, "the snapshot copies each slot's identity");
+    check(snapshot->findSlotByInstanceId(b) == 1, "the snapshot resolves by identity");
+    check(snapshot->findSlotByInstanceId(0) == EffectChainSnapshot::MAX_SLOTS,
+          "the snapshot also refuses the reserved 0");
+}
+
+}  // namespace
+
+int main() {
+    testInsertMintsDistinctNonZeroIds();
+    testUnoccupiedSlotsHaveNoIdentity();
+    testMoveCarriesIdentityToTheNewPosition();
+    testSwapExchangesIdentitiesWithInstances();
+    testReorderDoesNotRetarget();
+    testRemoveRetiresTheIdentity();
+    testReplacingInSlotMintsFresh();
+    testClearRetiresEveryIdentity();
+    testLookupRejectsTheReservedZero();
+    testUnknownIdentityDoesNotResolve();
+    testIdentitiesAreUniqueAcrossChains();
+    testReserveMintedIdPreventsCollision();
+    testMintNeverReturnsZero();
+    testResetPreservesIdentities();
+    testSnapshotCarriesIdentity();
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] EffectChainInstanceIdentityTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] EffectChainInstanceIdentityTest\n";
+    return 0;
+}

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -224,3 +224,15 @@ target_include_directories(EffectChainMissingPluginTest PRIVATE
 )
 add_test(NAME EffectChainMissingPluginTest COMMAND EffectChainMissingPluginTest)
 set_tests_properties(EffectChainMissingPluginTest PROPERTIES LABELS "audio;plugins;serialization")
+
+# Plugin-instance identity must survive chain reordering (#667) — automation
+# addresses the instance a curve was drawn for, never the position it occupied.
+add_executable(EffectChainInstanceIdentityTest AestraAudio/EffectChainInstanceIdentityTest.cpp)
+target_link_libraries(EffectChainInstanceIdentityTest PRIVATE AestraAudio)
+target_include_directories(EffectChainInstanceIdentityTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME EffectChainInstanceIdentityTest COMMAND EffectChainInstanceIdentityTest)
+set_tests_properties(EffectChainInstanceIdentityTest PROPERTIES LABELS "audio;plugins;automation;regression")


### PR DESCRIPTION
Slice 1 of #667. **This does not close the issue** — see Scope below.

## The mechanism, confirmed on `develop`

`AutomationCurve` addresses a plugin parameter by `{effectSlot, paramId}`, where `effectSlot` is a **position**. `EffectChain::movePlugin` and `swapPlugins` relocate slot contents (plugin, missing-id, state, bypass, mix, fault state), and automation curves live on the **lane**, not the chain — so nothing updates them. `AudioEngine.cpp:2901` then resolves `curve.effectSlot` positionally.

**The invariant:** automation addresses the plugin *instance* a curve was drawn for, not the position that instance happened to occupy. Reordering a chain is a rearrangement, never a retarget.

## What this adds

Follows two existing house patterns rather than inventing a mechanism — `ChannelSlotMap` already does identity→position translation for channels (`ChannelSlotMap.h:32`), and `UnitManager`'s `nextId` + re-mint guard is the minting precedent (#528).

| Behaviour | Why |
|---|---|
| `EffectSlot::instanceId`, minted **process-wide** | per-chain counters collide when a plugin is dragged between strips |
| `movePlugin` carries it, `swapPlugins` swaps it | the two lines the whole issue turns on |
| `removePlugin` / `clear` retire it | a retired id resolving to nothing is honest; resolving to the slot's next occupant *is* the defect |
| `insertPlugin` over an occupied slot mints fresh | a replacement must never inherit its predecessor's automation |
| `reset()` **preserves** them | it reboots plugins without removing them, so the instances are the same |
| `findSlotByInstanceId` refuses the reserved `0` | unoccupied slots store `0`, so matching it would resolve every un-addressed curve to the first empty slot |
| snapshot carries the id | the render thread resolves against the snapshot, never the mutable chain |

## Scope — read this before treating it as the fix

`instanceId` is **in-memory only**. It is not yet written to the chain's binary state, and the engine still resolves `curve.effectSlot` positionally.

**Slice 2 closes #667:** state format v2 + re-mint on load, `AutomationCurve::pluginInstanceId`, engine resolution by identity, and a load-time migration mapping old `effectSlot` → the id now in that slot.

Split here because an identity that doesn't persist isn't one, and a verified half beats an unverified whole.

## Premise correction

#667 states the defect *"can alter music today."* **It cannot.** No `Custom` curve is authorable in the shipping app:

- one UI curve-creation site — `AestraContent.cpp:3341`, explicitly `AutomationTarget::Volume`
- `effectSlot`/`paramId` are written **only** by the serializer (save 958, load 2028) and three test files
- no setter API — no `setEffectSlot`, `setParamId`, `setTarget`
- the load path defaults `targetEnum` to `0.0` (Volume), so pre-existing projects don't become `Custom`

`Custom` is only the *default member initializer* (`AutomationCurve.h:57`); nothing selects it deliberately. The sole route to a positionally-addressed curve is hand-editing a `.aes` file. So #667 is latent and gated behind #467 — and #467's original claim was half right, not stale: the engine now *evaluates* Custom curves, but nothing *authors* them.

Doing this now is still correct, for a different reason: **there is currently zero positionally-addressed user data, so identity needs no migration. After #467 ships, it would.**

## Verification

`EffectChainInstanceIdentityTest`, 15 cases, using a locally defined `IPluginInstance` so it never depends on an installed plugin or the scan cache.

**Mutation-probed.** Removing *only* the two identity-carrying lines from `movePlugin`/`swapPlugins` produces 6 failures, including:

```
[FAIL] an address resolved before and after a reorder names the same plugin
[FAIL] and it moved position, so the test is not passing by nothing happening
```

So the tests catch the defect itself, not merely the field's existence.

`ctest -L plugins` 17/17. Full-suite and full-build results are in the PR comments once they finish locally; CI is the gate either way.

Refs #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added permanent, process-wide nonzero `EffectSlot::instanceId` to represent plugin-instance identity (with `0` meaning “no instance”) so automation/targets won’t silently retarget after chain reorders.
- Preserved `instanceId` across slot moves/swaps and across `reset()`; retired (`instanceId = 0`) on removals/clears and when loading serialized-empty slots to prevent stale identity resolution.
- Extended insert/state restoration to carry or re-mint identities: `insertPlugin(..., preservedInstanceId)` restores a preserved identity when safe, mints fresh IDs for replacements and v1-loaded occupants, and initializes `instanceId` correctly during `loadState()` (including missing-plugin placeholders).
- Added identity-based lookup and render-thread support: `getSlotInstanceId` / `findSlotByInstanceId` plus render-thread snapshot propagation of `EffectChainSnapshotSlot::instanceId`.
- Hardened identity minting against collisions: rejects/avoids reserved `UINT64_MAX`, prevents reusing already-live preserved IDs, and prevents counter wraparound.
- Updated plugin/effect command undo/redo to restore the same preserved identities (not new ones) for both add/remove command families.
- Added 26 identity-focused regression tests covering identity lifecycle, uniqueness/collision avoidance, reorder/swap/missing-plugin behaviors, state loading, and snapshot propagation; persistence/automation curve migration/identity-based engine resolution remain for Slice 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->