### PR TITLE
Disabling latency compensation must actually withdraw it (#684)

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -650,6 +650,16 @@ public:
     }
 
 private:
+    /**
+     * @brief Withdraw all applied latency compensation from the RT state.
+     *
+     * Zeroes every per-node output compensation and per-edge compensation
+     * count in both m_trackState and the active m_graphStates slot, so the RT
+     * path stops delaying audio. Called from calculateLatencyCompensation()
+     * on the disabled path; not a substitute for the apply pass. Off-RT only.
+     */
+    void clearAppliedLatencyCompensation();
+
     struct ChannelPrepareConfig {
         std::atomic<uint32_t> sampleRate{48000};
         std::atomic<uint32_t> maxBlockSize{4096};

--- a/AestraAudio/include/Core/AudioGraphState.h
+++ b/AestraAudio/include/Core/AudioGraphState.h
@@ -149,9 +149,14 @@ struct TrackRTState {
 
     // === Plugin Delay Compensation ===
     uint32_t pluginLatencySamples{0};        // Total latency from effect chain
-    uint32_t compensationDelaySamples{0};    // Delay to apply for alignment
-    bool compensationEnabled{true};          // Can be disabled per-track
-    
+    // Delay to apply for alignment. Zero means "do not delay this track" —
+    // this is the single gate the RT path consults. There is deliberately no
+    // per-track enable flag: one existed, nothing ever wrote it, and being
+    // pinned true is what let a disabled engine keep compensating (#684).
+    // Engine-wide enablement lives in AudioEngine::m_latencyCompensationEnabled
+    // and reaches the RT path by zeroing this value.
+    uint32_t compensationDelaySamples{0};
+
     // Fixed-size compensation buffer (stereo interleaved)
     // 16384 samples = ~340ms @ 48kHz, ~170ms @ 96kHz
     std::array<float, 32768> compensationBuffer{}; // 16384 frames * 2 channels

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2566,7 +2566,7 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
     // === Apply Plugin Delay Compensation ===
     // Compensation must apply to dry tracks too; those are often the tracks
     // delayed to align with a parallel latent path elsewhere in the graph.
-    if (state.compensationEnabled && state.compensationDelaySamples > 0) {
+    if (state.compensationDelaySamples > 0) {
         const uint32_t delay = state.compensationDelaySamples;
         const uint32_t capacity = static_cast<uint32_t>(state.compensationBuffer.size() / 2);
         if (delay < capacity) {
@@ -3643,6 +3643,11 @@ void AudioEngine::calculateLatencyCompensation() {
     if (!m_latencyCompensationEnabled) {
         m_maxProjectLatency = 0;
         m_latencyDirty = false;
+        // Compensation that was already applied must be withdrawn, not merely
+        // left unsolved (#684). Returning here without clearing left every
+        // track delayed by its last solved amount, so switching PDC off did
+        // not stop it compensating.
+        clearAppliedLatencyCompensation();
         // Publish a zero topology via the double-buffer flip so off-RT readers
         // observe a consistent disabled state.
         {
@@ -4030,13 +4035,48 @@ AudioEngine::TrackEdgeDelaySnapshot AudioEngine::getTrackEdgeDelaySnapshot(size_
     return snap;
 }
 
+void AudioEngine::clearAppliedLatencyCompensation() {
+    // Withdraw every delay the RT path could still act on. Buffers stay
+    // allocated: only the published sample counts decide whether the RT path
+    // reads them, and keeping the allocations lets a re-enable avoid churn.
+    // The ring-buffer cursors are deliberately left alone — the apply pass
+    // resets them whenever a delay changes from zero to non-zero, so a
+    // re-enable starts from silence without extra RT-visible writes here.
+    auto clearStates = [](std::vector<TrackRTState>& states) {
+        for (auto& state : states) {
+            state.compensationDelaySamples = 0;
+            if (state.mainOutEdgeDelay) {
+                state.mainOutEdgeDelay->compensationSamples.store(0, std::memory_order_release);
+            }
+            for (auto& slot : state.sendEdgeDelays) {
+                if (slot) {
+                    slot->compensationSamples.store(0, std::memory_order_release);
+                }
+            }
+        }
+    };
+
+    clearStates(m_trackState);
+
+    const int activeIdx = m_activeRenderTrackIndex.load(std::memory_order_relaxed);
+    clearStates(m_graphStates[activeIdx].trackStates);
+    m_graphStates[activeIdx].maxProjectLatencySamples = 0;
+    m_graphStates[activeIdx].latencyCompensationEnabled = m_latencyCompensationEnabled;
+}
+
 void AudioEngine::setLatencyCompensationEnabled(bool enabled) {
-    if (m_latencyCompensationEnabled != enabled) {
-        m_latencyCompensationEnabled = enabled;
+    if (m_latencyCompensationEnabled == enabled) {
+        return;
     }
-    if (m_latencyDirty && m_latencyCompensationEnabled) {
-        calculateLatencyCompensation();
-    }
+    m_latencyCompensationEnabled = enabled;
+    // Both directions need the solver. Enabling has to re-solve and re-apply;
+    // disabling has to clear what is already applied. Routing everything
+    // through calculateLatencyCompensation() keeps the one apply path as the
+    // sole writer of RT compensation state. The previous guard only re-solved
+    // when enabling *and* already dirty, which is why disabling was a no-op
+    // and why re-enabling an unchanged graph would not restore it (#684).
+    m_latencyDirty = true;
+    calculateLatencyCompensation();
 }
 
 bool AudioEngine::isLatencyCompensationEnabled() const {

--- a/Tests/Commands/LatencyReportTest.cpp
+++ b/Tests/Commands/LatencyReportTest.cpp
@@ -208,28 +208,29 @@ void testDisabledCompensationStatus() {
         return;
 
     fx.engine.calculateLatencyCompensation();
-    const uint64_t generationBefore = fx.engine.getLastSolvedLatencyTopology().generation;
     fx.engine.setLatencyCompensationEnabled(false);
+
+    // Disabling withdraws the applied compensation and publishes an empty
+    // solve to say so (#684), so the report is observed but carries no nodes:
+    // with compensation off there is no per-node compensation to describe.
+    const uint64_t generationAfterDisable = fx.engine.getLastSolvedLatencyTopology().generation;
 
     JSON response = call(fx.service, R"({"id":7,"verb":"get_latency_report"})");
     JSON& report = response["result"];
     check(report["status"].asString() == "disabled" && report["observed"].asBool() &&
               !report["compensationEnabled"].asBool(),
           "disabled global compensation has an explicit report status");
-    check(fx.engine.getLastSolvedLatencyTopology().generation == generationBefore,
-          "disabled query does not publish a replacement topology");
+    check(report["nodes"].size() == 0 && report["edges"].size() == 0,
+          "disabled report describes no compensated nodes or edges");
 
-    // The per-node applied state must not contradict the top-level toggle.
-    // TrackRTState carries a vestigial per-track `compensationEnabled` that is
-    // pinned true because nothing writes it; forwarding it made every node
-    // claim compensation was on while the engine-wide toggle was off.
-    JSON* node = findByString(report["nodes"], "nodeId", "mixer:123");
-    check(node != nullptr, "disabled report still identifies the mixer node");
-    if (node) {
-        check((*node)["applied"]["available"].asBool() &&
-                  (*node)["applied"]["compensationEnabled"].asBool() == report["compensationEnabled"].asBool(),
-              "per-node applied compensation flag agrees with the engine-wide toggle");
-    }
+    // The query itself must stay observational. Baseline is taken *after* the
+    // toggle, because the toggle legitimately publishes; only the query is
+    // forbidden from mutating.
+    check(fx.engine.getLastSolvedLatencyTopology().generation == generationAfterDisable,
+          "disabled query does not publish a replacement topology");
+    call(fx.service, R"({"id":9,"verb":"get_latency_report"})");
+    check(fx.engine.getLastSolvedLatencyTopology().generation == generationAfterDisable,
+          "repeated disabled queries remain observational");
 }
 
 void testSchemaAndArgumentRejection() {

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -392,4 +392,20 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/RoutingSendPanParityTest.cpp")
     )
 endif()
 
+# PDC disable-clears-compensation regression (#684)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCDisableClearsCompensationTest.cpp")
+    add_executable(PDCDisableClearsCompensationTest PDCDisableClearsCompensationTest.cpp)
+    target_link_libraries(PDCDisableClearsCompensationTest PRIVATE AestraAudio)
+    target_include_directories(PDCDisableClearsCompensationTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    add_test(NAME PDCDisableClearsCompensationTest COMMAND PDCDisableClearsCompensationTest)
+    set_tests_properties(PDCDisableClearsCompensationTest PROPERTIES
+        LABELS "headless;pdc;engine;regression"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 message(STATUS "Headless tests enabled - AudioEngine API implemented")

--- a/Tests/Headless/PDCDisableClearsCompensationTest.cpp
+++ b/Tests/Headless/PDCDisableClearsCompensationTest.cpp
@@ -1,0 +1,235 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// PDCDisableClearsCompensationTest — regression cover for #684.
+//
+// Disabling latency compensation must actually stop compensating. Before the
+// fix, setLatencyCompensationEnabled(false) never re-solved, the disabled
+// early-return in calculateLatencyCompensation() never zeroed the applied
+// per-node/per-edge delays, and the vestigial per-track enable flag left the
+// RT gate as `compensationDelaySamples > 0`. Tracks therefore kept their last
+// solved delay after PDC was switched off.
+//
+// The setter has no production callers today, so this was latent rather than
+// something users could hear — but it is one UI hookup away from being
+// audible, and the engine API is expected to honour the toggle regardless.
+//
+// These tests assert the invariant over *every* track and *every* edge slot
+// rather than a sampled one, so a partially-cleared apply pass fails here.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraph.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "PDCTestHelpers.h"
+#include "Plugin/EffectChain.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBufferFrames = 256;
+constexpr uint32_t kChannels = 2;
+
+int g_failures = 0;
+
+void reportFailure(const char* expr, const char* file, int line, const std::string& detail = {}) {
+    std::fprintf(stderr, "[FAIL] %s (%s:%d)", expr, file, line);
+    if (!detail.empty()) {
+        std::fprintf(stderr, " — %s", detail.c_str());
+    }
+    std::fprintf(stderr, "\n");
+    ++g_failures;
+}
+
+#define EXPECT_EQ(expr, expected)                                                           \
+    do {                                                                                    \
+        const auto _v = (expr);                                                             \
+        const auto _e = (expected);                                                         \
+        if (_v != _e) {                                                                     \
+            reportFailure(#expr " == " #expected, __FILE__, __LINE__,                       \
+                          "got " + std::to_string(_v) + " expected " + std::to_string(_e)); \
+        }                                                                                   \
+    } while (0)
+
+#define EXPECT_TRUE(expr)                             \
+    do {                                              \
+        if (!(expr)) {                                \
+            reportFailure(#expr, __FILE__, __LINE__); \
+        }                                             \
+    } while (0)
+
+struct Fixture {
+    std::shared_ptr<TrackManager> trackManager;
+    AudioEngine engine;
+    std::vector<float> outputBuf;
+
+    Fixture() {
+        trackManager = std::make_shared<TrackManager>();
+        engine.setTrackManager(trackManager);
+        engine.setSampleRate(kSampleRate);
+        engine.setBufferConfig(kBufferFrames, kChannels);
+        outputBuf.assign(static_cast<size_t>(kBufferFrames) * kChannels, 0.0f);
+    }
+
+    MixerChannel* addTrack(const std::string& name) { return trackManager->addChannel(name); }
+
+    void renderBlocks(uint32_t n) {
+        for (uint32_t b = 0; b < n; ++b) {
+            std::fill(outputBuf.begin(), outputBuf.end(), 0.0f);
+            engine.processBlock(outputBuf.data(), nullptr, kBufferFrames,
+                                static_cast<double>(b * kBufferFrames) / kSampleRate);
+        }
+    }
+
+    size_t trackCount() const { return trackManager->getChannelCount(); }
+
+    /// Sum of every compensation value the RT path could act on: per-node
+    /// output compensation plus every per-edge slot. Zero means nothing is
+    /// being delayed anywhere.
+    uint64_t totalAppliedCompensation() const {
+        uint64_t total = 0;
+        for (size_t i = 0; i < trackCount(); ++i) {
+            const auto snap = engine.getTrackEdgeDelaySnapshot(i);
+            if (!snap.valid) {
+                continue;
+            }
+            total += snap.outputCompensationSamples;
+            total += snap.mainOutEdgeDelay.compensationSamples;
+            for (const auto& slot : snap.sendEdgeDelays) {
+                total += slot.compensationSamples;
+            }
+        }
+        return total;
+    }
+
+    /// Builds a graph that stages both kinds of compensation: a dry track that
+    /// must be delayed to align with a latent sibling (per-node), and a send
+    /// into a latent bus (per-edge).
+    void buildCompensatedGraph() {
+        auto* latent = addTrack("latent");
+        addTrack("dry");
+        auto* source = addTrack("source");
+        auto* bus = addTrack("bus");
+
+        auto latentPlug = std::make_shared<PDCTest::MockLatencyPlugin>(256, "LatentPlugin");
+        EXPECT_TRUE(latent->getEffectChain().insertPlugin(0, latentPlug));
+
+        auto busPlug = std::make_shared<PDCTest::MockLatencyPlugin>(512, "BusPlugin");
+        EXPECT_TRUE(bus->getEffectChain().insertPlugin(0, busPlug));
+
+        AudioRoute send;
+        send.targetChannelId = bus->getChannelId();
+        send.gain = 1.0f;
+        send.sidechainOnly = false;
+        source->addSend(send);
+    }
+};
+
+void testDisableClearsEveryAppliedDelay() {
+    std::printf("[PDCDisableClearsCompensationTest] disabling compensation clears every applied delay...\n");
+    Fixture fx;
+    fx.buildCompensatedGraph();
+    fx.engine.calculateLatencyCompensation();
+
+    // Precondition: the fixture really does stage compensation. Without this
+    // the post-disable assertions would pass vacuously.
+    const uint64_t compensated = fx.totalAppliedCompensation();
+    EXPECT_TRUE(compensated > 0);
+    EXPECT_TRUE(fx.engine.getMaxProjectLatency() > 0);
+
+    fx.engine.setLatencyCompensationEnabled(false);
+
+    // Every track, every edge slot — nothing may still be delaying audio.
+    EXPECT_EQ(fx.totalAppliedCompensation(), static_cast<uint64_t>(0));
+    EXPECT_EQ(fx.engine.getMaxProjectLatency(), 0u);
+    EXPECT_TRUE(!fx.engine.isLatencyCompensationEnabled());
+
+    // The diagnostic snapshot must not contradict the engine-wide toggle
+    // either. This guards the #683 fix: the snapshot used to forward a
+    // per-track flag that nothing wrote, so it reported compensation as
+    // enabled on every track while the engine had it switched off. Checked
+    // for every track, not a sampled one.
+    for (size_t i = 0; i < fx.trackCount(); ++i) {
+        const auto snap = fx.engine.getTrackEdgeDelaySnapshot(i);
+        if (!snap.valid) {
+            continue;
+        }
+        EXPECT_TRUE(snap.compensationEnabled == fx.engine.isLatencyCompensationEnabled());
+    }
+}
+
+void testReEnableRestoresCompensation() {
+    std::printf("[PDCDisableClearsCompensationTest] re-enabling compensation restores the solved delays...\n");
+    Fixture fx;
+    fx.buildCompensatedGraph();
+    fx.engine.calculateLatencyCompensation();
+    const uint64_t before = fx.totalAppliedCompensation();
+    EXPECT_TRUE(before > 0);
+
+    fx.engine.setLatencyCompensationEnabled(false);
+    EXPECT_EQ(fx.totalAppliedCompensation(), static_cast<uint64_t>(0));
+
+    // Clearing on disable is only correct if enabling puts it back. Nothing
+    // about the graph changed, so the restored total must match exactly.
+    fx.engine.setLatencyCompensationEnabled(true);
+    EXPECT_EQ(fx.totalAppliedCompensation(), before);
+    EXPECT_TRUE(fx.engine.isLatencyCompensationEnabled());
+}
+
+void testDisabledEngineKeepsRenderingSafely() {
+    std::printf("[PDCDisableClearsCompensationTest] RT path stays stable across a mid-render toggle...\n");
+    Fixture fx;
+    fx.buildCompensatedGraph();
+    fx.engine.calculateLatencyCompensation();
+
+    fx.renderBlocks(8);
+    fx.engine.setLatencyCompensationEnabled(false);
+    fx.renderBlocks(8);
+    EXPECT_EQ(fx.totalAppliedCompensation(), static_cast<uint64_t>(0));
+
+    fx.engine.setLatencyCompensationEnabled(true);
+    fx.renderBlocks(8);
+    EXPECT_TRUE(fx.totalAppliedCompensation() > 0);
+}
+
+void testDisableIsIdempotentAndSurvivesResolve() {
+    std::printf("[PDCDisableClearsCompensationTest] repeat disables and re-solves stay cleared...\n");
+    Fixture fx;
+    fx.buildCompensatedGraph();
+    fx.engine.calculateLatencyCompensation();
+
+    fx.engine.setLatencyCompensationEnabled(false);
+    fx.engine.setLatencyCompensationEnabled(false);
+    EXPECT_EQ(fx.totalAppliedCompensation(), static_cast<uint64_t>(0));
+
+    // A recompute requested while disabled must not quietly re-apply delays.
+    fx.engine.markLatencyDirty();
+    fx.engine.calculateLatencyCompensation();
+    EXPECT_EQ(fx.totalAppliedCompensation(), static_cast<uint64_t>(0));
+    EXPECT_EQ(fx.engine.getMaxProjectLatency(), 0u);
+}
+
+} // namespace
+
+int main() {
+    std::printf("=== PDCDisableClearsCompensationTest (#684) ===\n");
+
+    testDisableClearsEveryAppliedDelay();
+    testReEnableRestoresCompensation();
+    testDisabledEngineKeepsRenderingSafely();
+    testDisableIsIdempotentAndSurvivesResolve();
+
+    if (g_failures == 0) {
+        std::printf("=== PDCDisableClearsCompensationTest: all checks passed ===\n");
+        return EXIT_SUCCESS;
+    }
+    std::fprintf(stderr, "=== PDCDisableClearsCompensationTest: %d failure(s) ===\n", g_failures);
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- clear applied per-node and per-edge compensation when PDC is switched off, instead of leaving the last solved delays in place
- route both toggle directions through the solver, so re-enabling an unchanged graph restores compensation
- delete the vestigial `TrackRTState::compensationEnabled`, which nothing ever wrote
- add `PDCDisableClearsCompensationTest` covering every track and every edge slot

Closes #684.

## Why

`setLatencyCompensationEnabled(false)` did not stop compensation. Three things lined up:

1. The setter only re-solved when *enabling* and already dirty (`if (m_latencyDirty && m_latencyCompensationEnabled)`), so disabling never called the solver at all.
2. The disabled early-return in `calculateLatencyCompensation()` zeroed `m_maxProjectLatency` and published an empty topology, but never touched `rtState.compensationDelaySamples` — the apply pass that would zero it sits further down and is skipped.
3. The RT gate was `state.compensationEnabled && state.compensationDelaySamples > 0`. `TrackRTState::compensationEnabled` was declared "can be disabled per-track" but **nothing in the tree ever wrote it**, so it was pinned at its `true` default and the gate reduced to the stale-but-nonzero delay check.

Measured before the fix, on a graph with 256- and 512-sample latency plugins:

```
enabled   totalAppliedCompensation=1280  maxProjectLatency=512
disabled  totalAppliedCompensation=1280  maxProjectLatency=512
```

Fixing the setter surfaced the mirror-image bug: because the old guard required `m_latencyDirty`, re-enabling an unchanged graph would not have restored compensation once disabling actually cleared it. `testReEnableRestoresCompensation` covers that.

## Scope note — this was latent, not audible

`setLatencyCompensationEnabled` has **no production callers**. The only writer of `m_latencyCompensationEnabled` is that setter, it is called exclusively from tests, and nothing in `Source/`, `AestraApp/`, or `AestraUI/` exposes a PDC on/off control. The flag defaults to `true`, so no user is currently hearing this.

It is worth fixing now precisely because wiring a "disable PDC" checkbox looks like a trivial UI change, and the engine is expected to honour its own toggle. Flagging it explicitly so nobody reads "audible PDC bug" into the changelog.

## On removing `TrackRTState::compensationEnabled`

#684 asked for a decision: make it real per-track enablement, or delete it. Deleted. It was dead state whose comment promised a guarantee that does not exist, and it had already caused one reporting bug (#683, where the Muse latency report claimed compensation was enabled per node while the engine had it off). If per-track enablement is wanted later it should be reintroduced with actual writers and its own tests. The RT gate is now the delay value alone, which is the single source of truth the apply pass already controls.

## A changed assertion in LatencyReportTest

`testDisabledCompensationStatus` (added in #683) had two assertions that encoded the old behaviour:

- `generation == generationBefore`, with the baseline captured *before* the toggle. Disabling now legitimately publishes an empty solve, so the baseline moves to after the toggle — which is what the assertion's name ("disabled query does not publish a replacement topology") always meant. It now also issues a second query and re-checks, so it tests the query's observationality rather than the toggle's.
- a per-node `applied.compensationEnabled` agreement check. A disabled engine now reports no nodes, so this is unreachable through the report. The invariant it guarded is real, so it moved to the engine-level snapshot in `PDCDisableClearsCompensationTest`, where it is checked for every track.

Calling this out rather than quietly editing a test that was green two commits ago.

## Testing performed

- `cmake --build build-linux -j2` — clean
- `ctest --test-dir build-linux -j2` — **219/219 passed**
- new test verified to fail against the unfixed engine (6 failures, exactly the disable-path assertions) before the fix was applied
- `ctest -R '^(LatencyReportTest|PDCDisableClearsCompensationTest|PDCFlatChainTest|PDCSolverPurityTest|PDCRTConsumptionTest|LatencyCompensationTest)$'` — 6/6
- changed-line `git clang-format` clean; `git diff --check` clean

## Risk / rollback

The RT-visible change is narrow: compensation counts are zeroed through the same release-store discipline the apply pass already uses, and buffers are left allocated so no ownership changes on the RT path. Ring-buffer cursors are deliberately not touched — the apply pass already resets them when a delay goes from zero to non-zero, so a re-enable starts from silence without extra RT-visible writes. `PDCDisableClearsCompensationTest` toggles mid-render to exercise this. Rollback is the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed latency compensation disablement by routing both enable and disable changes through the solver.
- When disabled, the engine clears all per-node and per-edge compensation and resets project latency.
- Removed the unused `TrackRTState::compensationEnabled` field.
- Updated latency reporting to validate the empty disabled topology.
- Added regression coverage for all tracks, edge slots, re-enable behavior, repeated disables, and mid-render toggles.
- No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->