### PR TITLE
Classify solver warnings and match edges by identity (#685)

### DIFF
--- a/AestraAudio/include/Core/LatencyTopology.h
+++ b/AestraAudio/include/Core/LatencyTopology.h
@@ -59,6 +59,29 @@ struct LatencyGraph {
 };
 
 /**
+ * @brief Machine-readable classification for a solver warning.
+ *
+ * Consumers must switch on this instead of matching `SolverWarning::message`
+ * text. The prose is a human-facing description and may be reworded freely;
+ * the code is the contract that diagnostic surfaces (e.g. the Muse latency
+ * report) map to their own stable issue codes.
+ */
+enum class SolverWarningCode : uint8_t {
+    /// A routing cycle was found; back edges contribute zero compensation.
+    RoutingCycle,
+    /// Edge(s) referenced out-of-range node indices; their compensation is zero.
+    InvalidEdgeIndices,
+};
+
+/**
+ * @brief One diagnostic raised during solve, classified and described.
+ */
+struct SolverWarning {
+    SolverWarningCode code{SolverWarningCode::RoutingCycle};
+    std::string message;
+};
+
+/**
  * @brief Immutable output artifact produced by the PDC solver.
  *
  * Consumed read-only by the RT engine. Per-edge / per-node ring-buffer state
@@ -106,7 +129,7 @@ struct SolvedLatencyTopology {
      * Consumed off-RT (e.g. logged once per generation). Never read from the
      * audio thread.
      */
-    std::vector<std::string> warnings;
+    std::vector<SolverWarning> warnings;
 
     uint64_t generation{0}; ///< Mirrors LatencyGraph::generation.
 };

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -1106,6 +1106,35 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 }
             }
 
+            // Match solved edges to current routing by identity, not position.
+            // Pairing solved edge `i` with currentEdges[i] was only correct
+            // while the model was unchanged: inserting or removing one route
+            // shifted everything after it, so a single routing edit reported
+            // pdc_edge_mapping_mismatch on every subsequent edge instead of
+            // the one that actually moved. pdc_edge_count_mismatch already
+            // reports that the shapes differ.
+            //
+            // (src, dst, sidechain) is not unique — a channel may hold two
+            // sends to the same target — so equal keys are consumed in
+            // discovery order, which keeps the pairing deterministic and
+            // still localizes a mismatch to the edge that changed.
+            // Mixed-radix rather than bit-packed: both indices are bounded by
+            // nodes.size(), so this is exact and collision-free without
+            // assuming either fits in a fixed bit width.
+            const uint64_t nodeCount = static_cast<uint64_t>(topology.nodes.size());
+            const auto edgeKey = [nodeCount](uint32_t src, uint32_t dst, bool sidechain) -> uint64_t {
+                return ((static_cast<uint64_t>(src) * nodeCount) + static_cast<uint64_t>(dst)) * 2ull +
+                       (sidechain ? 1ull : 0ull);
+            };
+            std::unordered_map<uint64_t, std::vector<size_t>> currentEdgesByKey;
+            for (size_t j = 0; j < currentEdges.size(); ++j) {
+                currentEdgesByKey[edgeKey(currentEdges[j].srcNodeIdx, currentEdges[j].dstNodeIdx,
+                                          currentEdges[j].sidechain)]
+                    .push_back(j);
+            }
+            std::unordered_map<uint64_t, size_t> currentEdgeCursor;
+            constexpr size_t kNoCurrentEdge = static_cast<size_t>(-1);
+
             for (size_t i = 0; i < topology.edges.size(); ++i) {
                 const auto& solution = topology.edges[i];
                 const bool sourceValid = solution.srcNodeIdx < topology.nodes.size();
@@ -1116,10 +1145,18 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                                                           ? nodeId(topology.nodes[solution.dstNodeIdx].channelId)
                                                           : "unknown:" + std::to_string(solution.dstNodeIdx);
 
-                const bool mappingMatches = i < currentEdges.size() &&
-                                            currentEdges[i].srcNodeIdx == solution.srcNodeIdx &&
-                                            currentEdges[i].dstNodeIdx == solution.dstNodeIdx &&
-                                            currentEdges[i].sidechain == solution.sidechain;
+                size_t currentEdgeIndex = kNoCurrentEdge;
+                if (sourceValid && destinationValid) {
+                    const uint64_t key = edgeKey(solution.srcNodeIdx, solution.dstNodeIdx, solution.sidechain);
+                    const auto candidates = currentEdgesByKey.find(key);
+                    if (candidates != currentEdgesByKey.end()) {
+                        auto& cursor = currentEdgeCursor[key];
+                        if (cursor < candidates->second.size()) {
+                            currentEdgeIndex = candidates->second[cursor++];
+                        }
+                    }
+                }
+                const bool mappingMatches = currentEdgeIndex != kNoCurrentEdge;
                 bool main = false;
                 size_t sendIndex = 0;
                 bool appliedAvailable = false;
@@ -1127,7 +1164,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 bool mismatch = !mappingMatches;
 
                 if (mappingMatches) {
-                    const auto& current = currentEdges[i];
+                    const auto& current = currentEdges[currentEdgeIndex];
                     main = current.main;
                     sendIndex = current.sendIndex;
                     const auto snapshot = m_engine->getTrackEdgeDelaySnapshot(current.trackIndex);
@@ -1226,16 +1263,26 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 addMismatch("pdc_recalculation_pending", "the published topology is pending recalculation", evidence);
             }
 
-            for (const auto& message : topology.warnings) {
-                const char* issueCode = "pdc_solver_warning";
-                if (message.find("routing cycle") != std::string::npos) {
-                    issueCode = "pdc_routing_cycle";
-                } else if (message.find("out-of-range") != std::string::npos) {
-                    issueCode = "pdc_invalid_edge_indices";
+            // Map the solver's classification onto this report's stable issue
+            // codes. Switching on the enum keeps the contract structural: a
+            // reworded diagnostic can no longer silently demote a specific
+            // code to the generic fallback, and adding a SolverWarningCode
+            // shows up here as an unhandled-enum warning rather than as a
+            // string that quietly stops matching.
+            const auto issueCodeFor = [](SolverWarningCode code) -> const char* {
+                switch (code) {
+                case SolverWarningCode::RoutingCycle:
+                    return "pdc_routing_cycle";
+                case SolverWarningCode::InvalidEdgeIndices:
+                    return "pdc_invalid_edge_indices";
                 }
+                return "pdc_solver_warning";
+            };
+
+            for (const auto& solverWarning : topology.warnings) {
                 JSON warning = JSON::object();
-                warning.set("issueCode", JSON(issueCode));
-                warning.set("message", JSON(message));
+                warning.set("issueCode", JSON(issueCodeFor(solverWarning.code)));
+                warning.set("message", JSON(solverWarning.message));
                 warning.set("stableIdentityAvailable", JSON(false));
                 warning.set("positionalIdentityAvailable", JSON(false));
                 warnings.push(warning);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -3961,7 +3961,7 @@ void AudioEngine::calculateLatencyCompensation() {
 
     // Off-RT: log any solver warnings once per generation.
     for (const auto& warning : topology.warnings) {
-        Aestra::Log::warning("[PDC] " + warning);
+        Aestra::Log::warning("[PDC] " + warning.message);
     }
 }
 

--- a/AestraAudio/src/Core/LatencyTopology.cpp
+++ b/AestraAudio/src/Core/LatencyTopology.cpp
@@ -65,7 +65,8 @@ SolvedLatencyTopology solveLatency(const LatencyGraph& graph) {
     }
     if (anyEdgeOutOfRange) {
         topology.warnings.push_back(
-            "LatencyGraph contains edge(s) with out-of-range node indices; their compensation was set to zero");
+            {SolverWarningCode::InvalidEdgeIndices,
+             "LatencyGraph contains edge(s) with out-of-range node indices; their compensation was set to zero"});
     }
 
     // Post-order DFS computing downstreamLatency per node, with three-color
@@ -121,7 +122,8 @@ SolvedLatencyTopology solveLatency(const LatencyGraph& graph) {
 
     if (cycleDetected) {
         topology.warnings.push_back(
-            "routing cycle detected in LatencyGraph; back edges contribute zero compensation");
+            {SolverWarningCode::RoutingCycle,
+             "routing cycle detected in LatencyGraph; back edges contribute zero compensation"});
     }
 
     // Per-edge compensation: for each audible edge F -> D, delay = F's slowest

--- a/Tests/Commands/LatencyReportTest.cpp
+++ b/Tests/Commands/LatencyReportTest.cpp
@@ -50,6 +50,16 @@ bool hasIssueCode(JSON& entries, const std::string& code) {
     return findByString(entries, "issueCode", code) != nullptr;
 }
 
+size_t countIssueCode(JSON& entries, const std::string& code) {
+    size_t total = 0;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].has("issueCode") && entries[i]["issueCode"].asString() == code) {
+            ++total;
+        }
+    }
+    return total;
+}
+
 struct Fixture {
     std::shared_ptr<TrackManager> tracks{std::make_shared<TrackManager>()};
     AudioEngine engine;
@@ -233,6 +243,62 @@ void testDisabledCompensationStatus() {
           "repeated disabled queries remain observational");
 }
 
+void testRoutingEditIsReportedWithoutCascading() {
+    Fixture fx;
+    auto* source = fx.tracks->addChannelWithId("Source", 30);
+    auto* busA = fx.tracks->addChannelWithId("BusA", 31);
+    auto* busB = fx.tracks->addChannelWithId("BusB", 32);
+    auto* busC = fx.tracks->addChannelWithId("BusC", 33);
+    check(source != nullptr && busA != nullptr && busB != nullptr && busC != nullptr, "routing-edit fixture created");
+    if (!source || !busA || !busB || !busC)
+        return;
+
+    // Distinct latencies so each send edge carries its own compensation.
+    check(busA->getEffectChain().insertPlugin(0, std::make_shared<MockLatencyPlugin>(128, "A")), "bus A plugin");
+    check(busB->getEffectChain().insertPlugin(0, std::make_shared<MockLatencyPlugin>(256, "B")), "bus B plugin");
+    check(busC->getEffectChain().insertPlugin(0, std::make_shared<MockLatencyPlugin>(384, "C")), "bus C plugin");
+
+    for (uint32_t target : {31u, 32u, 33u}) {
+        AudioRoute send;
+        send.targetChannelId = target;
+        source->addSend(send);
+    }
+    fx.engine.calculateLatencyCompensation();
+
+    JSON baseline = call(fx.service, R"({"id":10,"verb":"get_latency_report"})");
+    check(baseline["result"]["status"].asString() == "clean" && baseline["result"]["mismatches"].size() == 0,
+          "multi-send routing solves clean before the edit");
+
+    // Remove the *first* send behind the published solve. Every later send
+    // shifts down a slot, which is precisely the case positional pairing got
+    // wrong: it reported every subsequent edge as unmappable.
+    source->removeSend(0);
+
+    JSON response = call(fx.service, R"({"id":11,"verb":"get_latency_report"})");
+    JSON& report = response["result"];
+    JSON* countMismatch = findByString(report["mismatches"], "issueCode", "pdc_edge_count_mismatch");
+    check(countMismatch != nullptr, "a routing edit behind the solve reports an edge count mismatch");
+    if (countMismatch) {
+        JSON& evidence = (*countMismatch)["evidence"];
+        check(evidence["solvedEdgeCount"].asNumber() == evidence["currentMappableEdgeCount"].asNumber() + 1.0,
+              "edge count evidence shows the solve carries exactly one edge more than the model");
+    }
+
+    // The removed send is the only edge that can no longer be mapped. Under
+    // the old index pairing this was 3 (the removed edge plus the two that
+    // merely shifted); identity matching localizes it to the one that moved.
+    check(countIssueCode(report["mismatches"], "pdc_edge_mapping_mismatch") == 1,
+          "only the removed edge is unmappable — the mismatch does not cascade");
+
+    size_t unresolved = 0;
+    for (size_t i = 0; i < report["edges"].size(); ++i) {
+        if (report["edges"][i]["routeType"].asString() == "unresolved") {
+            ++unresolved;
+        }
+    }
+    check(unresolved == 1, "exactly one edge is reported unresolved after a single-send removal");
+}
+
 void testSchemaAndArgumentRejection() {
     JSON schema = JSON::parse(Aestra::Audio::MuseGrammar::schemaToJsonString());
     bool documented = false;
@@ -258,6 +324,7 @@ int main() {
     testBranchCompensationAndSidechainLimitation();
     testPendingSolveStaysObservational();
     testDisabledCompensationStatus();
+    testRoutingEditIsReportedWithoutCascading();
     testSchemaAndArgumentRejection();
 
     if (g_failures == 0) {

--- a/Tests/Headless/PDCSolverPurityTest.cpp
+++ b/Tests/Headless/PDCSolverPurityTest.cpp
@@ -285,9 +285,12 @@ void testSolverCycleDetection() {
 
     const auto t = solveLatency(g);
     EXPECT_TRUE(!t.warnings.empty());
+    // Assert on the classification, not the prose. Matching message text was
+    // exactly the coupling that let a reword silently change a warning's
+    // meaning for downstream consumers.
     bool sawCycleWarning = false;
     for (const auto& w : t.warnings) {
-        if (w.find("cycle") != std::string::npos) {
+        if (w.code == SolverWarningCode::RoutingCycle) {
             sawCycleWarning = true;
             break;
         }
@@ -306,6 +309,14 @@ void testSolverOutOfRangeEdge() {
     g.edges.push_back({0, 42, false}); // dst out of range
     const auto t = solveLatency(g);
     EXPECT_TRUE(!t.warnings.empty());
+    bool sawInvalidEdgeWarning = false;
+    for (const auto& w : t.warnings) {
+        if (w.code == SolverWarningCode::InvalidEdgeIndices) {
+            sawInvalidEdgeWarning = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(sawInvalidEdgeWarning);
     EXPECT_EQ(t.edges.size(), 1u);
     EXPECT_EQ(t.edges[0].compensationSamples, 0u);
 }


### PR DESCRIPTION
## Summary

- give solver warnings a `SolverWarningCode` so issue codes stop depending on diagnostic prose
- match solved edges to current routing by `(srcNodeIdx, dstNodeIdx, sidechain)` instead of by list position
- cover `pdc_edge_count_mismatch`, and prove a single routing edit no longer cascades
- record why the fourth item in #685 is obsolete rather than done

Closes #685. All three are follow-ups from #683's review, grouped because they touch the same comparison and the same tests.

## Prose-matched issue codes

`MuseService` picked issue codes with `message.find("routing cycle")` and `message.find("out-of-range")`. A harmless reword in `LatencyTopology.cpp` would silently demote a specific code to the `pdc_solver_warning` fallback — and stable codes are the entire selling point of this report. Nothing would have failed; the report would just have quietly gotten less useful.

`SolvedLatencyTopology::warnings` is now `std::vector<SolverWarning>`, each carrying a `SolverWarningCode` (`RoutingCycle`, `InvalidEdgeIndices`) alongside its message. `MuseService` maps code → wire string with a switch, so adding a solver warning surfaces as an unhandled-enum warning rather than a string that stops matching. The enum lives in the solver's domain and the Muse-facing strings stay in `MuseService`, so `LatencyTopology` gains no report vocabulary.

`PDCSolverPurityTest` was doing the same thing to itself (`w.find("cycle")`) and now asserts on the code — that test would have passed through exactly the reword it was meant to catch.

## Positional edge pairing

Pairing solved edge `i` with `currentEdges[i]` is correct only while the model is unchanged. Insert or remove one route and everything after it shifts, so a single edit reported `pdc_edge_mapping_mismatch` on *every* subsequent edge instead of the one that moved — noise an agent has to reason past, when `pdc_edge_count_mismatch` already says the shapes differ.

Two things the obvious implementation gets wrong, both handled:

- **The key is not unique.** A channel may hold two sends to the same target with the same sidechain flag. Equal keys are consumed in discovery order, so pairing stays deterministic instead of depending on hash iteration.
- **The key must not overflow.** `(src << 33) | (dst << 1) | sidechain` overflows `uint64_t` for large indices. Both indices are bounded by `nodes.size()` but not by any fixed bit width, so the key is mixed-radix — `(src * nodeCount + dst) * 2 + sidechain` — which is exact and collision-free for any topology that fits in memory.

## Coverage

`testRoutingEditIsReportedWithoutCascading`: three sends into distinct-latency buses, solve clean, then remove the **first** send behind the published solve. Asserts `pdc_edge_count_mismatch` is raised with evidence showing exactly one surplus solved edge, that precisely one `pdc_edge_mapping_mismatch` results, and that exactly one edge is reported `unresolved`.

Verified as a real gate: with positional pairing restored, both localization assertions fail — the removed edge plus the two that merely shifted all report unmappable, which is the cascade this change removes.

## The fourth item is obsolete, not done

#685 asked for the disabled-compensation test to iterate every node rather than checking `mixer:123`. That is no longer possible: #686 made a disabled engine publish an empty solve, so the disabled report has no nodes. The invariant it guarded — per-node applied state not contradicting the engine-wide toggle — already moved to `PDCDisableClearsCompensationTest`, which checks it for every track. Calling this out rather than quietly closing the issue with one item unaddressed.

## Testing performed

- `cmake --build build-linux -j2` — clean
- `ctest --test-dir build-linux -j2` — **219/219 passed**
- new edge-localization assertions verified failing under the previous positional pairing
- `LatencyReportTest` 37 assertions green
- changed-line `git clang-format` clean; `git diff --check` clean

## Risk / rollback

No RT-path code is touched; this is off-RT reporting plus a solver diagnostic type. The warning type change is source-breaking for consumers of `topology.warnings`, and all three in-tree consumers are updated (`AudioEngine` logging, `MuseService`, `PDCSolverPurityTest`). Rollback is the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** `SolvedLatencyTopology::warnings` now stores `SolverWarning` objects instead of strings. Use `SolverWarningCode` for warning classification.
- Match solved edges to current routing by `(srcNodeIdx, dstNodeIdx, sidechain)`. Consume duplicate keys in discovery order.
- Map solver warning codes to `MuseService` report issues without matching diagnostic text.
- Add coverage for edge-count mismatches and localized routing changes.
- Update solver warning tests and logging for structured warnings.
- All 219 tests pass, including 37 `LatencyReportTest` assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->