### PR TITLE
App-data paths report absence instead of inventing one (#676)

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -98,36 +98,69 @@ AestraApp::~AestraApp() {
     shutdown();
 }
 
-std::string AestraApp::getAppDataPath() {
+std::optional<std::string> AestraApp::getAppDataPath() {
     IPlatformUtils* utils = Platform::getUtils();
     if (!utils) {
-        return std::filesystem::current_path().string();
+        // Deliberately no fallback. This used to return the process working
+        // directory, which is a perfectly valid-looking path that happens to
+        // be the wrong one — callers could not tell, and neither could the
+        // log. That is what made both #675 defects silent. There is no
+        // portable-mode feature in the tree that wants a working-directory
+        // app-data location, so failing is the honest answer (#676).
+        Log::warning("[AppData] Platform utilities unavailable; no app-data path can be resolved");
+        return std::nullopt;
     }
     std::string appDataDir = utils->getAppDataPath("Aestra");
     std::error_code ec;
     if (!std::filesystem::create_directories(appDataDir, ec) && ec) {
-        // Log?
+        // create_directories() returns false without setting ec when the
+        // directory already exists, so a set ec is a genuine failure. A
+        // directory we cannot create is one we cannot write to either.
+        Log::warning("[AppData] Cannot create app-data directory " + appDataDir + ": " + ec.message());
+        return std::nullopt;
     }
     return appDataDir;
 }
 
-std::string AestraApp::getAutosavePath() {
-    return (std::filesystem::path(getAppDataPath()) / "autosave.aes").string();
+namespace {
+/// Join a file name onto the app-data directory, propagating "unresolved".
+std::optional<std::string> appDataFile(const std::optional<std::string>& appDataDir, const char* fileName) {
+    if (!appDataDir) {
+        return std::nullopt;
+    }
+    return (std::filesystem::path(*appDataDir) / fileName).string();
+}
+} // namespace
+
+std::optional<std::string> AestraApp::getAutosavePath() {
+    return appDataFile(getAppDataPath(), "autosave.aes");
 }
 
-std::string AestraApp::getLegacyAutosavePath() {
-    return (std::filesystem::path(getAppDataPath()) / "autosave.Aestraproj").string();
+std::optional<std::string> AestraApp::getLegacyAutosavePath() {
+    return appDataFile(getAppDataPath(), "autosave.Aestraproj");
 }
 
-std::string AestraApp::getCrashFlagPath() {
-    return (std::filesystem::path(getAppDataPath()) / "crash_flag").string();
+std::optional<std::string> AestraApp::getCrashFlagPath() {
+    return appDataFile(getAppDataPath(), "crash_flag");
 }
 
-std::string AestraApp::activeCrashFlagPath() {
-    // Prefer the path resolved while platform utilities were alive. The
-    // fallback only applies before priming, where getAppDataPath() is still
-    // able to resolve correctly.
-    return CrashFlagPath::isPrimed() ? CrashFlagPath::get() : getCrashFlagPath();
+std::string AestraApp::autosavePathOrEmpty() {
+    const auto path = getAutosavePath();
+    if (!path) {
+        Log::warning("[Autosave] No app-data path could be resolved; autosave is disabled for this document");
+        return {};
+    }
+    return *path;
+}
+
+std::optional<std::string> AestraApp::activeCrashFlagPath() {
+    // Prefer the path resolved while platform utilities were alive. Resolving
+    // fresh is only correct before priming; afterwards the platform may be
+    // gone and there is no substitute path to offer.
+    if (CrashFlagPath::isPrimed()) {
+        return CrashFlagPath::get();
+    }
+    return getCrashFlagPath();
 }
 
 void AestraApp::writeCrashFlag() {
@@ -136,9 +169,14 @@ void AestraApp::writeCrashFlag() {
     // through startup — re-resolving unconditionally would let detection use
     // one path while the write and the clear use another (#675).
     if (!CrashFlagPath::isPrimed()) {
-        CrashFlagPath::prime(getCrashFlagPath());
+        const auto resolved = getCrashFlagPath();
+        if (!resolved) {
+            Log::warning("[CrashDetection] Cannot resolve crash flag path; no crash flag written this session");
+            return;
+        }
+        CrashFlagPath::prime(*resolved);
     }
-    const std::string flagPath = activeCrashFlagPath();
+    const std::string flagPath = CrashFlagPath::get();
     std::ofstream out(flagPath, std::ios::trunc);
     if (out) {
         out << std::chrono::system_clock::now().time_since_epoch().count() << "\n";
@@ -184,9 +222,16 @@ void AestraApp::clearCrashFlag() {
 }
 
 bool AestraApp::isCrashedSession() {
-    const std::string flagPath = activeCrashFlagPath();
+    const auto flagPath = activeCrashFlagPath();
+    if (!flagPath) {
+        // Unresolvable is not the same as clean, but there is nothing to read
+        // and no substitute worth inventing. Say so rather than reporting a
+        // confident "no crash" derived from the wrong directory (#676).
+        Log::warning("[CrashDetection] Cannot resolve crash flag path; treating this session as not crashed");
+        return false;
+    }
     std::error_code ec;
-    return std::filesystem::exists(flagPath, ec);
+    return std::filesystem::exists(*flagPath, ec);
 }
 
 std::string AestraApp::getRecoveryMarkerPath(const std::string& autosavePath) {
@@ -194,7 +239,11 @@ std::string AestraApp::getRecoveryMarkerPath(const std::string& autosavePath) {
 }
 
 std::string AestraApp::readCrashFlagToken() {
-    std::ifstream in(activeCrashFlagPath(), std::ios::binary);
+    const auto flagPath = activeCrashFlagPath();
+    if (!flagPath) {
+        return {};
+    }
+    std::ifstream in(*flagPath, std::ios::binary);
     std::string token;
     std::getline(in, token);
     return token;
@@ -262,13 +311,18 @@ bool AestraApp::initialize(const std::string& projectPath) {
     //
     // Detection therefore moved below platform init. Nothing between the old
     // and new positions consumed the result.
-    CrashFlagPath::prime(getCrashFlagPath());
+    if (const auto crashFlagPath = getCrashFlagPath()) {
+        CrashFlagPath::prime(*crashFlagPath);
+    } else {
+        Log::error("[CrashDetection] Cannot resolve crash flag path at startup; "
+                   "crash detection and recovery are unavailable this session");
+    }
 
     const bool crashedSession = isCrashedSession();
     m_previousRecoverySessionToken = crashedSession ? readCrashFlagToken() : "";
 
     // An app-data autosave is recovery state, never an implicit canonical project.
-    m_documentState.startUntitled(getAutosavePath());
+    m_documentState.startUntitled(autosavePathOrEmpty());
 
     // ALWAYS write crash flag at session start. It is cleared only on clean
     // shutdown. If the app crashes at any point, the flag persists and the
@@ -528,7 +582,7 @@ void AestraApp::buildMenuBar() {
             if (m_content && m_content->getTrackManager()) m_content->getTrackManager()->stop();
             if (m_content) m_content->resetToDefaultProject();
             clearProjectLoadReport();
-            m_documentState.startUntitled(getAutosavePath());
+            m_documentState.startUntitled(autosavePathOrEmpty());
             reinitAutosaveManager();
             syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
             m_lastWindowTitle.clear();
@@ -758,7 +812,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
                         if (m_content)
                             m_content->resetToDefaultProject();
                         clearProjectLoadReport();
-                        m_documentState.startUntitled(getAutosavePath());
+                        m_documentState.startUntitled(autosavePathOrEmpty());
                         reinitAutosaveManager();
                         syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
                     }
@@ -780,7 +834,7 @@ void AestraApp::loadOrRecoverProject(const std::string& projectPath, bool crashe
                         if (m_content)
                             m_content->resetToDefaultProject();
                         clearProjectLoadReport();
-                        m_documentState.startUntitled(getAutosavePath());
+                        m_documentState.startUntitled(autosavePathOrEmpty());
                         reinitAutosaveManager();
                         syncRecordingProjectPath(m_content, m_documentState.canonicalPath());
                         updateWindowTitle();
@@ -1427,10 +1481,15 @@ void AestraApp::requestClose() {
                      case Aestra::DialogResponse::DontSave: {
                          // User explicitly chose not to save — remove the autosave
                          // so it isn't offered for recovery on the next launch.
-                         std::error_code ec;
-                         std::filesystem::remove(getAutosavePath(), ec);
-                         if (ec) {
-                             Log::warning("[Close] Failed to remove autosave on Discard: " + ec.message());
+                         if (const auto autosavePath = getAutosavePath()) {
+                             std::error_code ec;
+                             std::filesystem::remove(*autosavePath, ec);
+                             if (ec) {
+                                 Log::warning("[Close] Failed to remove autosave on Discard: " + ec.message());
+                             }
+                         } else {
+                             // Never delete based on a guessed path.
+                             Log::warning("[Close] Cannot resolve autosave path; nothing removed on Discard");
                          }
                          m_running = false;
                          break;

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -53,15 +53,28 @@ public:
         return m_audioController ? m_audioController->getEngine() : nullptr;
     }
 
-    // Helpers exposed for easier refactoring
-    static std::string getAppDataPath();
-    static std::string getAutosavePath();
-    static std::string getLegacyAutosavePath();
-    static std::string getCrashFlagPath();
+    // Helpers exposed for easier refactoring.
+    //
+    // These return std::nullopt rather than a substitute path when the app-data
+    // directory cannot be resolved. They used to fall back to the process
+    // working directory, which produced a different but equally valid-looking
+    // path that callers and the log could not distinguish from the real one —
+    // the mechanism behind both #675 defects. Callers must now decide what a
+    // missing app-data location means for them (#676).
+    static std::optional<std::string> getAppDataPath();
+    static std::optional<std::string> getAutosavePath();
+    static std::optional<std::string> getLegacyAutosavePath();
+    static std::optional<std::string> getCrashFlagPath();
     static void writeCrashFlag();
     static void clearCrashFlag();
     static bool isCrashedSession();
-    static std::string activeCrashFlagPath();
+    static std::optional<std::string> activeCrashFlagPath();
+
+    /// The autosave path, or an empty string when it cannot be resolved.
+    /// Empty disables autosave downstream (AutosaveManager treats an empty
+    /// override as "not set"), which is the correct degraded behaviour:
+    /// no autosave beats an autosave written somewhere unexpected.
+    static std::string autosavePathOrEmpty();
 
 private:
     enum class ProjectLoadSource { Canonical, Recovery, Snapshot };

--- a/Tests/App/CrashFlagPathTest.cpp
+++ b/Tests/App/CrashFlagPathTest.cpp
@@ -3,15 +3,20 @@
 // Regression coverage for #675: the crash flag must still be clearable after
 // platform teardown has destroyed the utilities that resolve app-data paths.
 //
-// The live defect: AestraApp::shutdown() deliberately clears the crash flag
+// The original defect: AestraApp::shutdown() deliberately clears the crash flag
 // LAST, so a crash during earlier teardown leaves the flag for recovery. But
 // Platform::shutdown() runs first and destroys the platform utilities, and
-// AestraApp::getAppDataPath() silently falls back to the process working
-// directory when they are gone. The final clear therefore looked for
+// AestraApp::getAppDataPath() *used to* silently fall back to the process
+// working directory when they were gone. The final clear therefore looked for
 // <cwd>/crash_flag, found nothing, removed nothing, and logged nothing —
 // because both its success and failure messages sit inside the exists() branch.
 // Every clean exit left the flag behind and every next launch offered a
 // spurious recovery.
+//
+// #676 removed that fallback: the path resolvers now return std::nullopt
+// instead of substituting a plausible wrong path. Retaining the primed path
+// (below) is still what makes the clear work, because after teardown there is
+// now no path to resolve at all.
 //
 // These tests pin the property that makes the fix work: a path resolved while
 // the platform was alive stays available and unchanged afterwards. Source/ has
@@ -22,6 +27,7 @@
 #include "CrashFlagPath.h"
 
 #include <iostream>
+#include <optional>
 #include <string>
 
 namespace {
@@ -35,16 +41,23 @@ void check(bool condition, const char* message) {
     }
 }
 
-/// Stands in for AestraApp::getAppDataPath(): resolves correctly while the
-/// platform is alive, and silently degrades to the working directory once it is
-/// gone — which is exactly what the real one does.
+/// Stands in for AestraApp::getAppDataPath(): resolves while the platform is
+/// alive and yields nothing once it is gone, matching the real one since #676.
+///
+/// It used to model the original behaviour — degrading to the working
+/// directory — because that is what the real function did. #676 removed that
+/// fallback: there is no portable-mode feature that wants a working-directory
+/// app-data location, so an unresolvable path is now reported as absent rather
+/// than substituted.
 struct FakePlatform {
     bool aliveFlag = true;
     std::string appData = "/home/user/.local/share/Aestra";
-    std::string cwd = "/some/working/dir";
 
-    std::string resolveCrashFlagPath() const {
-        return (aliveFlag ? appData : cwd) + "/crash_flag";
+    std::optional<std::string> resolveCrashFlagPath() const {
+        if (!aliveFlag) {
+            return std::nullopt;
+        }
+        return appData + "/crash_flag";
     }
     void shutdown() { aliveFlag = false; }
 };
@@ -60,7 +73,9 @@ void testPathSurvivesPlatformTeardown() {
     FakePlatform platform;
 
     // Startup: resolve while the platform is alive, as writeCrashFlag() does.
-    Aestra::CrashFlagPath::prime(platform.resolveCrashFlagPath());
+    const auto resolved = platform.resolveCrashFlagPath();
+    check(resolved.has_value(), "the path resolves while the platform is alive");
+    Aestra::CrashFlagPath::prime(*resolved);
     const std::string atStartup = Aestra::CrashFlagPath::get();
     check(atStartup == "/home/user/.local/share/Aestra/crash_flag",
           "the primed path is the app-data path");
@@ -68,16 +83,18 @@ void testPathSurvivesPlatformTeardown() {
     // Shutdown: platform utilities are destroyed before the final clear.
     platform.shutdown();
 
-    // The regression: re-resolving now yields the wrong path...
-    check(platform.resolveCrashFlagPath() == "/some/working/dir/crash_flag",
-          "re-resolving after teardown does produce the wrong path (defect premise)");
+    // Post-#676, re-resolving after teardown yields nothing at all. Before it,
+    // it produced a plausible working-directory path that nothing could
+    // distinguish from the real one — which is what made #675 silent.
+    check(!platform.resolveCrashFlagPath().has_value(),
+          "re-resolving after teardown yields nothing rather than a substitute path");
 
-    // ...but the retained one is unchanged, which is what the clear must use.
+    // The retained one is unchanged, which is what the clear must use.
     check(Aestra::CrashFlagPath::isPrimed(), "the path is still primed after teardown");
     check(Aestra::CrashFlagPath::get() == atStartup,
           "the retained path is unchanged after platform teardown");
-    check(Aestra::CrashFlagPath::get() != platform.resolveCrashFlagPath(),
-          "the retained path differs from what post-teardown resolution would give");
+    check(!Aestra::CrashFlagPath::get().empty() && !platform.resolveCrashFlagPath().has_value(),
+          "the retained path is usable precisely when fresh resolution is not");
 }
 
 void testPrimingIsIdempotentlyOverwritable() {

--- a/Tests/Guards/verify_crash_flag_shutdown_order.cmake
+++ b/Tests/Guards/verify_crash_flag_shutdown_order.cmake
@@ -8,8 +8,11 @@
 #      for #675 must NOT be "move clearCrashFlag() earlier".
 #   2. The clear uses the path retained at startup, not a freshly resolved one.
 #      Platform::shutdown() destroys the platform utilities, after which
-#      getAppDataPath() silently falls back to the working directory — so
-#      re-resolving there finds nothing, removes nothing, and logs nothing.
+#      getAppDataPath() cannot resolve at all. Before #676 it silently fell back
+#      to the working directory, so re-resolving there found nothing, removed
+#      nothing, and logged nothing; since #676 it returns std::nullopt, so
+#      re-resolving yields no path to clear. Either way the retained path is
+#      the only correct source, which is what this guard pins.
 #
 # The application source path is resolved HERE rather than passed in from
 # Tests/cmake/*.cmake: scripts/ci/classify-changes.sh derives its
@@ -68,8 +71,18 @@ if(NOT CLEAR_RERESOLVES EQUAL -1)
 endif()
 
 # Priming must happen at a real call site, not merely be defined somewhere.
-string(FIND "${APP_TEXT}" "CrashFlagPath::prime(getCrashFlagPath())" PRIMES_PATH)
-if(PRIMES_PATH EQUAL -1)
+#
+# Two shapes are accepted. The direct form primes straight from the resolver.
+# The guarded form — `if (const auto x = getCrashFlagPath())` — is what #676
+# required once getCrashFlagPath() became std::optional: the caller has to
+# check before priming, because there is no longer a substitute path to prime
+# with. The guarded pattern is matched by its trailing `)` so it identifies the
+# startup call site specifically, not writeCrashFlag()'s fallback priming,
+# which assigns to a local with `;`.
+string(FIND "${APP_TEXT}" "CrashFlagPath::prime(getCrashFlagPath())" PRIMES_DIRECT)
+string(FIND "${APP_TEXT}" "= getCrashFlagPath())" PRIMES_FROM_CHECKED_OPTIONAL)
+string(FIND "${APP_TEXT}" "CrashFlagPath::prime(" PRIMES_AT_ALL)
+if(PRIMES_AT_ALL EQUAL -1 OR (PRIMES_DIRECT EQUAL -1 AND PRIMES_FROM_CHECKED_OPTIONAL EQUAL -1))
     message(FATAL_ERROR
         "Nothing primes the crash-flag path from a resolved value while platform "
         "utilities are alive (#675).")


### PR DESCRIPTION
## Summary

- `getAppDataPath()` and its three wrappers return `std::optional<std::string>` instead of falling back to the process working directory
- every caller now has to decide what a missing app-data location means, enforced by the compiler
- a directory that cannot be created is reported as absent too, replacing the `// Log?` placeholder
- updates the stand-in test and shutdown guard that encoded the old behaviour

Closes #676.

## Why

```cpp
std::string AestraApp::getAppDataPath() {
    IPlatformUtils* utils = Platform::getUtils();
    if (!utils) {
        return std::filesystem::current_path().string();   // no warning, no error
    }
```

A working-directory path is not obviously wrong — it is a real, plausible path. Callers could not tell it apart from the app-data one and neither could the log. That is precisely what made both #675 defects silent for weeks: the crash flag was written to app-data and then looked for in the working directory, so clean exits never cleared it and real crashes were never detected.

## The open question, answered

The issue flagged as *not attempted*: does anything depend on the working-directory fallback deliberately, e.g. portable mode?

**Nothing does.** There is no portable-mode feature anywhere in the tree (`grep -riE "portable.?mode|AESTRA_PORTABLE"` over `Source`, `AestraPlat`, `AestraAudio` — no hits). Every other app-data consumer — `Preferences`, `UIState`, `AudioSettingsStore`, `AestraAudioController`, `AudioSettingsPage`, `PluginManager`, `PluginScanner` — calls `IPlatformUtils::getAppDataPath()` directly with its own null guard and never goes through this function. `AestraApp::getAppDataPath()` had exactly three users, all its own wrappers.

So this takes option 1 *and* option 3 from the issue: return an optional, and delete the fallback rather than merely logging it.

## Degraded behaviour, per caller

| Caller | When unresolvable |
|---|---|
| autosave (4 `startUntitled` sites) | `autosavePathOrEmpty()` → `""`, which `AutosaveManager` already treats as "no override, no autosave". No autosave beats an autosave written somewhere unexpected. |
| Discard (`requestClose`) | removes nothing, logs a warning — never delete based on a guessed path |
| crash flag, startup | logs an error; crash detection and recovery are unavailable for the session |
| `writeCrashFlag()` | writes nothing rather than writing somewhere arbitrary |
| `isCrashedSession()` | returns `false`, but logs a warning — "unresolvable" is not "clean", and there is no honest alternative to read |

## Two things that encoded the old behaviour

**`CrashFlagPathTest`'s stand-in** modelled the fallback on purpose (*"silently degrades to the working directory — which is exactly what the real one does"*) and asserted `"re-resolving after teardown does produce the wrong path (defect premise)"`. That premise is now false. The stand-in returns `std::nullopt` and the assertion states the stronger property: re-resolving yields *nothing*, not a substitute. Left alone it would have documented behaviour this PR deletes.

**The shutdown-order guard** matched the literal `CrashFlagPath::prime(getCrashFlagPath())`, which the optional-checked call site no longer produces. It now accepts both the direct and the guarded shape, matching the guarded one by its trailing `)` so it still identifies the startup site specifically rather than `writeCrashFlag()`'s fallback priming.

I verified the looser match did not open a hole: with startup priming removed, the guard still fails.

## What actually enforces this

The type change, at compile time — not a test. `Source/` has no linkable library target (#666), so `AestraApp::getAppDataPath()` cannot be unit-tested directly; that is why `CrashFlagPathTest` uses a stand-in in the first place. A mirror test would prove nothing about the real function, so I have not added one and am not claiming coverage I do not have. Making the degraded path unrepresentable in the type is the stronger guarantee here, and it is what the issue asked for.

## Note: `getLegacyAutosavePath()` is dead

It has zero callers — only its definition and declaration. I converted it rather than deleting it, since removing a public static is a call for the owner rather than a drive-by. Worth deleting in a follow-up.

## Testing performed

- `cmake --build build-linux -j2` — clean
- `ctest --test-dir build-linux -j2` — **219/219 passed**
- shutdown-order guard verified to still fail when startup priming is removed
- changed-line `git clang-format` clean; `git diff --check` clean

## Risk / rollback

No behaviour changes on the healthy path: when platform utilities are alive, every path resolves exactly as before. The changes only alter what happens in the window where the old code was silently wrong. Rollback is the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** `getAppDataPath()` and its path helpers now return `std::optional<std::string>`. Callers must handle unavailable paths explicitly.
- Removed the fallback to the process working directory. Paths are unavailable when platform resolution fails or required directories cannot be created.
- Updated autosave, discard, crash-flag, and crash-detection flows to use defined degraded behavior.
- Added `autosavePathOrEmpty()` for downstream autosave configuration.
- Updated crash-flag regression tests and the shutdown-order guard to verify safe behavior after platform teardown.
- All 219 tests passed. Build, formatting, and shutdown-order checks succeeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->