### PR TITLE
Render clip audio into new durable sources (slice 1)

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -203,6 +203,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Models/UnitManager.cpp
     src/Models/PatternManager.cpp
     src/Models/ClipSource.cpp
+    src/Models/ClipRenderService.cpp
     src/Models/AudioClip.cpp
 
     # DSP
@@ -237,6 +238,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/CommandHistory.cpp
     src/Commands/CommandTransaction.cpp
     src/Commands/SplitClipCommand.cpp
+    src/Commands/RenderAudioClipCommand.cpp
     src/Commands/AddClipCommand.cpp
     src/Commands/CreateLaneCommand.cpp
     src/Commands/AddNoteCommand.cpp

--- a/AestraAudio/include/Commands/RenderAudioClipCommand.h
+++ b/AestraAudio/include/Commands/RenderAudioClipCommand.h
@@ -62,7 +62,10 @@ private:
     PatternID m_renderedPatternId;
     std::unique_ptr<PatternSource> m_detachedPattern;
     ClipEdits m_originalEdits;
+    double m_originalSourceOffset{0.0};
+    double m_originalSourceOffsetSeconds{0.0};
     bool m_editsChanged{false};
+    bool m_offsetsCleared{false};
     bool m_executed{false};
 };
 

--- a/AestraAudio/include/Commands/RenderAudioClipCommand.h
+++ b/AestraAudio/include/Commands/RenderAudioClipCommand.h
@@ -1,0 +1,106 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/ClipInstance.h"
+#include "Models/PatternSource.h"
+
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+
+/**
+ * @brief Base for destructive clip operations that commit a new audio file.
+ *
+ * Reverse, commit-edits and (later) consolidate all share one shape: render
+ * the clip's current audio through some transform, write it as a new source,
+ * and repoint the clip at the result. Undo puts the original pattern back and
+ * detaches — rather than destroys — the rendered one, so redo is instant and
+ * never re-renders. The rendered file is deliberately left on disk: a detached
+ * pattern still references it, and deleting it would break redo.
+ */
+class RenderAudioClipCommand : public ICommand {
+public:
+    RenderAudioClipCommand(TrackManager& manager, ClipInstanceID clipId) : m_manager(manager), m_clipId(clipId) {}
+
+    void execute() override;
+    void undo() override;
+    void redo() override { execute(); }
+
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    /** @brief False when execute() could not render (nothing was changed). */
+    bool isUndoable() const override { return m_executed; }
+
+protected:
+    /**
+     * @brief Produce the replacement audio for this clip.
+     * @param clip The clip being rendered, for edit values.
+     * @return Null to abort the command without touching project state.
+     */
+    virtual std::shared_ptr<AudioBufferData> renderBuffer(const ClipInstance& clip) = 0;
+
+    /** @brief Suffix appended to the new pattern/file name, e.g. "Reversed". */
+    virtual std::string renderSuffix() const = 0;
+
+    /**
+     * @brief Hook for edits that become redundant once baked into the audio.
+     * Default keeps the clip's edits untouched.
+     */
+    virtual void adjustEditsAfterRender(ClipEdits& /*edits*/) const {}
+
+    TrackManager& m_manager;
+    ClipInstanceID m_clipId;
+
+private:
+    PatternID m_originalPatternId;
+    PatternID m_renderedPatternId;
+    std::unique_ptr<PatternSource> m_detachedPattern;
+    ClipEdits m_originalEdits;
+    bool m_editsChanged{false};
+    bool m_executed{false};
+};
+
+/** @brief Replace a clip's audio with a reversed copy of itself. */
+class ReverseAudioClipCommand final : public RenderAudioClipCommand {
+public:
+    using RenderAudioClipCommand::RenderAudioClipCommand;
+
+    std::string getName() const override { return "Reverse Audio Clip"; }
+
+protected:
+    std::shared_ptr<AudioBufferData> renderBuffer(const ClipInstance& clip) override;
+    std::string renderSuffix() const override { return "Reversed"; }
+};
+
+/**
+ * @brief Bake a clip's own gain and fades into a new flat source.
+ *
+ * The clip sounds the same afterwards but its edits return to unity, so the
+ * result can be dragged elsewhere, or handed to a plugin, without carrying
+ * invisible state. This is the "commit" half of nondestructive editing.
+ *
+ * Deliberately NOT called "bounce in place": this renders only clip-local
+ * edits. It does not run the track's plugins, automation, sends, routing or
+ * PDC. Reserve "Bounce in Place" for the later graph-level operation that
+ * does, so the two never collapse into one ambiguous name.
+ */
+class CommitAudioClipEditsCommand final : public RenderAudioClipCommand {
+public:
+    using RenderAudioClipCommand::RenderAudioClipCommand;
+
+    std::string getName() const override { return "Commit Clip Edits"; }
+
+protected:
+    std::shared_ptr<AudioBufferData> renderBuffer(const ClipInstance& clip) override;
+    std::string renderSuffix() const override { return "Committed"; }
+    void adjustEditsAfterRender(ClipEdits& edits) const override;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -78,6 +78,18 @@ struct ClipEdits {
         edits.gainLinear = DEFAULT_AUDIO_CLIP_GAIN_LINEAR;
         return edits;
     }
+
+    /**
+     * Compares every field. Callers deciding whether an edit needs persisting
+     * must not hand-pick fields: a check that named only gain and the fades
+     * silently dropped any other baked change.
+     */
+    bool operator==(const ClipEdits& other) const {
+        return fadeInBeats == other.fadeInBeats && fadeOutBeats == other.fadeOutBeats &&
+               gainLinear == other.gainLinear && pan == other.pan && muted == other.muted &&
+               playbackRate == other.playbackRate && sourceStart == other.sourceStart;
+    }
+    bool operator!=(const ClipEdits& other) const { return !(*this == other); }
 };
 
 /**

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -60,10 +60,9 @@ struct PlaylistLaneID : public AestraUUID {
 struct ClipEdits {
     float fadeInBeats = 0.0f;
     float fadeOutBeats = 0.0f;
-    float gain = 1.0f;
-    float gainLinear = 1.0f; // Alternative name for gain
-    float pitchSemitones = 0.0f;
-    double timeStretchRatio = 1.0;
+    /** Clip level, linear. The only gain field: the render path, the editor
+     *  display and the serializer all read this one. */
+    float gainLinear = 1.0f;
     float pan = 0.0f;
     bool muted = false;
     float playbackRate = 1.0f;
@@ -76,7 +75,6 @@ struct ClipEdits {
      */
     static ClipEdits forNewAudioClip() {
         ClipEdits edits;
-        edits.gain = DEFAULT_AUDIO_CLIP_GAIN_LINEAR;
         edits.gainLinear = DEFAULT_AUDIO_CLIP_GAIN_LINEAR;
         return edits;
     }

--- a/AestraAudio/include/Models/ClipRenderService.h
+++ b/AestraAudio/include/Models/ClipRenderService.h
@@ -1,0 +1,128 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "ClipInstance.h"
+#include "ClipSource.h"
+#include "PatternSource.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+class PatternManager;
+class SourceManager;
+
+/**
+ * @brief Renders *source-domain* audio into new, committed source files.
+ *
+ * Scope, deliberately narrow: this service only ever reads a clip's own source
+ * buffer and its clip-local edits. It powers reverse, commit-clip-edits, and
+ * the source-copying half of consolidate. Each of those is "take some frames,
+ * transform them, and hand back a new source that stands on its own", so the
+ * file writing, source registration and pattern creation live here once
+ * instead of in each command.
+ *
+ * NOT the universal render primitive. Freeze, stem printing and bus printing
+ * must reflect plugins, automation, sends, sidechains, routing, PDC and an
+ * output scope — none of which exist at this layer. Those belong to a separate
+ * range/graph renderer driven by the audio graph. The two may share the WAV
+ * writer and source registration below, but must not share rendering
+ * semantics: anything that needs the graph does not belong in this file.
+ *
+ * The transforms are deliberately static and free of any manager dependency so
+ * they can be tested on a bare buffer. Only commit() needs project state.
+ */
+class ClipRenderService {
+public:
+    /** Frames rendered plus the file they were committed to. */
+    struct CommitResult {
+        PatternID patternId;
+        ClipSourceID sourceId;
+        std::string filePath;
+
+        bool isValid() const { return patternId.isValid() && sourceId.isValid(); }
+    };
+
+    /**
+     * @brief The concrete audio a clip currently points at.
+     *
+     * Resolving a clip means walking clip -> pattern -> audio payload -> source
+     * buffer, and every destructive op starts by doing exactly that.
+     */
+    struct SourceRegion {
+        std::shared_ptr<const AudioBufferData> buffer;
+        uint64_t startFrame{0};
+        uint64_t frameCount{0};
+        uint32_t mixerChannelId{0};
+        double lengthBeats{4.0};
+        std::string name;
+
+        bool isValid() const { return buffer != nullptr && frameCount > 0; }
+    };
+
+    ClipRenderService(SourceManager& sources, PatternManager& patterns) : m_sources(sources), m_patterns(patterns) {}
+
+    /**
+     * @brief Resolve the audio a clip currently plays.
+     * @return An invalid region when the clip is missing, is not an audio
+     *         clip, or its source has no decoded buffer.
+     */
+    SourceRegion resolveClipRegion(const ClipInstance& clip) const;
+
+    // --- Pure transforms -----------------------------------------------------
+
+    /**
+     * @brief Copy a frame range out of @p source into a fresh buffer.
+     *
+     * A range that starts past the end yields an empty (invalid) buffer rather
+     * than a zero-filled one, so callers can tell "nothing to render" from
+     * "rendered silence". Ranges that overhang the end are clamped.
+     */
+    static std::shared_ptr<AudioBufferData> extractRegion(const AudioBufferData& source, uint64_t startFrame,
+                                                          uint64_t frameCount);
+
+    /** @brief Reverse @p buffer in place, keeping channel interleaving intact. */
+    static void reverseInPlace(AudioBufferData& buffer);
+
+    /** @brief Scale every sample by @p gainLinear. Non-finite gains are ignored. */
+    static void applyGain(AudioBufferData& buffer, float gainLinear);
+
+    /**
+     * @brief Apply linear fade-in/fade-out ramps measured in frames.
+     *
+     * Overlapping ramps (fadeIn + fadeOut longer than the buffer) are each
+     * clamped so the two never multiply into an unintended notch.
+     */
+    static void applyFades(AudioBufferData& buffer, uint64_t fadeInFrames, uint64_t fadeOutFrames);
+
+    /** @brief Peak absolute sample value, or 0 for an empty buffer. */
+    static float peakMagnitude(const AudioBufferData& buffer);
+
+    // --- Commit --------------------------------------------------------------
+
+    /**
+     * @brief Write @p buffer to disk and register it as a new source + pattern.
+     *
+     * The file lands next to the project's other rendered material under
+     * @p renderDirectory. @p baseName is only a hint: the final filename is
+     * uniquified so two bounces of the same clip never collide.
+     *
+     * @return An invalid result if the buffer is unusable or the write failed;
+     *         no source or pattern is registered in that case.
+     */
+    CommitResult commit(const AudioBufferData& buffer, const std::string& renderDirectory,
+                        const std::string& baseName, double lengthBeats, uint32_t mixerChannelId);
+
+private:
+    static bool writeFloatWav(const std::string& path, const AudioBufferData& buffer);
+    static std::string uniqueRenderPath(const std::string& directory, const std::string& baseName);
+
+    SourceManager& m_sources;
+    PatternManager& m_patterns;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/ClipRenderService.h
+++ b/AestraAudio/include/Models/ClipRenderService.h
@@ -67,10 +67,18 @@ public:
 
     /**
      * @brief Resolve the audio a clip currently plays.
+     *
+     * Applies the same offset contract as playback: the pattern slice, plus
+     * the clip's canonical source offset, plus the instance-level
+     * ClipEdits::sourceStart — which is stored in *project*-rate samples and
+     * so must be rescaled to the source's own rate. Ignoring these rendered
+     * the wrong audio for any slipped or trimmed clip.
+     *
+     * @param projectSampleRate Rate ClipEdits::sourceStart is expressed in.
      * @return An invalid region when the clip is missing, is not an audio
      *         clip, or its source has no decoded buffer.
      */
-    SourceRegion resolveClipRegion(const ClipInstance& clip) const;
+    SourceRegion resolveClipRegion(const ClipInstance& clip, double projectSampleRate) const;
 
     // --- Pure transforms -----------------------------------------------------
 

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -418,6 +418,29 @@ public:
     void setRecordingProjectPath(const std::string& projectPath) { m_recordingProjectPath = projectPath; }
 
     /**
+     * @brief Directory for audio committed by destructive clip operations.
+     *
+     * Sits beside Recordings so a project folder stays self-describing: takes
+     * the user performed in one place, audio Aestra rendered for them in
+     * another. Falls back to the same user-documents root as recording when
+     * the project has never been saved.
+     */
+    std::string renderRootDirectory() const {
+        namespace fs = std::filesystem;
+        if (!m_recordingProjectPath.empty()) {
+            fs::path projectPath(m_recordingProjectPath);
+            if (projectPath.has_extension()) {
+                return (projectPath.parent_path() / "Renders").string();
+            }
+            return (projectPath / "Renders").string();
+        }
+        if (const char* home = std::getenv("HOME")) {
+            return (fs::path(home) / "Documents" / "Aestra" / "Renders").string();
+        }
+        return (fs::current_path() / "Renders").string();
+    }
+
+    /**
      * @brief Get output sample rate
      * @return Output sample rate in Hz.
      */
@@ -1468,7 +1491,6 @@ private:
         clip.durationSeconds = durationSeconds;
         clip.patternId = patternId;
         clip.sourceId = patternId.value;
-        clip.edits.gain = playbackGain;
         clip.edits.gainLinear = playbackGain;
 
         // Recording destination and Playlist placement are separate. Create a

--- a/AestraAudio/src/Commands/RenderAudioClipCommand.cpp
+++ b/AestraAudio/src/Commands/RenderAudioClipCommand.cpp
@@ -1,0 +1,150 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/RenderAudioClipCommand.h"
+
+#include "AestraLog.h"
+#include "Models/ClipRenderService.h"
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+
+void RenderAudioClipCommand::execute() {
+    if (m_executed) {
+        return;
+    }
+    const ClipInstance* clip = m_manager.getPlaylistModel().getClip(m_clipId);
+    if (!clip) {
+        return;
+    }
+    if (!m_originalPatternId.isValid()) {
+        m_originalPatternId = clip->patternId;
+        m_originalEdits = clip->edits;
+    }
+
+    // Redo path: the audio was rendered once already, so put the detached
+    // pattern back instead of writing a second identical file.
+    if (m_detachedPattern) {
+        if (!m_manager.getPatternManager().reinsertPattern(m_detachedPattern)) {
+            return;
+        }
+    } else {
+        ClipInstance clipCopy = *clip;
+        auto rendered = renderBuffer(clipCopy);
+        if (!rendered || !rendered->isValid()) {
+            return;
+        }
+
+        ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
+        const auto region = service.resolveClipRegion(clipCopy);
+        const std::string baseName = (region.name.empty() ? clipCopy.name : region.name) + " " + renderSuffix();
+
+        const auto result = service.commit(*rendered, m_manager.renderRootDirectory(), baseName, region.lengthBeats,
+                                           region.mixerChannelId);
+        if (!result.isValid()) {
+            return;
+        }
+        m_renderedPatternId = result.patternId;
+    }
+
+    if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_renderedPatternId)) {
+        // Leave no orphan pattern behind if the repoint failed.
+        m_detachedPattern = m_manager.getPatternManager().detachPattern(m_renderedPatternId);
+        return;
+    }
+
+    ClipEdits edits = m_originalEdits;
+    adjustEditsAfterRender(edits);
+    if (!(edits.gainLinear == m_originalEdits.gainLinear && edits.fadeInBeats == m_originalEdits.fadeInBeats &&
+          edits.fadeOutBeats == m_originalEdits.fadeOutBeats)) {
+        m_editsChanged = m_manager.getPlaylistModel().setClipEdits(m_clipId, edits);
+    }
+
+    m_manager.markModified();
+    m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = true;
+}
+
+void RenderAudioClipCommand::undo() {
+    if (!m_executed) {
+        return;
+    }
+    if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_originalPatternId)) {
+        return;
+    }
+    if (m_editsChanged) {
+        m_manager.getPlaylistModel().setClipEdits(m_clipId, m_originalEdits);
+        m_editsChanged = false;
+    }
+    // Detach rather than remove: redo reinserts this exact pattern, and the
+    // rendered file it points at is still on disk.
+    m_detachedPattern = m_manager.getPatternManager().detachPattern(m_renderedPatternId);
+    m_manager.markModified();
+    m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = false;
+}
+
+// --- Reverse ----------------------------------------------------------------
+
+std::shared_ptr<AudioBufferData> ReverseAudioClipCommand::renderBuffer(const ClipInstance& clip) {
+    ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
+    const auto region = service.resolveClipRegion(clip);
+    if (!region.isValid()) {
+        Log::warning("[ReverseAudioClipCommand] Clip has no resolvable audio to reverse.");
+        return nullptr;
+    }
+
+    auto buffer = ClipRenderService::extractRegion(*region.buffer, region.startFrame, region.frameCount);
+    if (!buffer) {
+        return nullptr;
+    }
+    ClipRenderService::reverseInPlace(*buffer);
+    return buffer;
+}
+
+// --- Commit clip edits ------------------------------------------------------
+
+std::shared_ptr<AudioBufferData> CommitAudioClipEditsCommand::renderBuffer(const ClipInstance& clip) {
+    ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
+    const auto region = service.resolveClipRegion(clip);
+    if (!region.isValid()) {
+        Log::warning("[CommitAudioClipEditsCommand] Clip has no resolvable audio to commit.");
+        return nullptr;
+    }
+
+    auto buffer = ClipRenderService::extractRegion(*region.buffer, region.startFrame, region.frameCount);
+    if (!buffer) {
+        return nullptr;
+    }
+
+    // Fades are authored in beats, so they only become frame counts at the
+    // project tempo the user is hearing them at.
+    const double bpm = std::max(1.0, m_manager.getPlaylistModel().getBPM());
+    const double framesPerBeat = (static_cast<double>(buffer->sampleRate) * 60.0) / bpm;
+    const auto toFrames = [framesPerBeat](float beats) -> uint64_t {
+        if (!std::isfinite(beats) || beats <= 0.0f) {
+            return 0;
+        }
+        const double frames = static_cast<double>(beats) * framesPerBeat;
+        return frames > 0.0 ? static_cast<uint64_t>(frames) : 0;
+    };
+
+    ClipRenderService::applyFades(*buffer, toFrames(clip.edits.fadeInBeats), toFrames(clip.edits.fadeOutBeats));
+
+    const float gain = std::isfinite(clip.edits.gainLinear) ? clip.edits.gainLinear : 1.0f;
+    ClipRenderService::applyGain(*buffer, gain);
+
+    return buffer;
+}
+
+void CommitAudioClipEditsCommand::adjustEditsAfterRender(ClipEdits& edits) const {
+    // These are now part of the audio; leaving them set would apply them twice.
+    edits.gainLinear = 1.0f;
+    edits.fadeInBeats = 0.0f;
+    edits.fadeOutBeats = 0.0f;
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/RenderAudioClipCommand.cpp
+++ b/AestraAudio/src/Commands/RenderAudioClipCommand.cpp
@@ -38,7 +38,7 @@ void RenderAudioClipCommand::execute() {
         }
 
         ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
-        const auto region = service.resolveClipRegion(clipCopy);
+        const auto region = service.resolveClipRegion(clipCopy, m_manager.getPlaylistModel().getProjectSampleRate());
         const std::string baseName = (region.name.empty() ? clipCopy.name : region.name) + " " + renderSuffix();
 
         const auto result = service.commit(*rendered, m_manager.renderRootDirectory(), baseName, region.lengthBeats,
@@ -56,10 +56,24 @@ void RenderAudioClipCommand::execute() {
     }
 
     ClipEdits edits = m_originalEdits;
+    // The rendered source begins exactly at the region that was resolved, so
+    // the slip that selected that region is already baked in. Leaving it set
+    // would apply the offset a second time against the new full-length source.
+    edits.sourceStart = 0.0;
     adjustEditsAfterRender(edits);
-    if (!(edits.gainLinear == m_originalEdits.gainLinear && edits.fadeInBeats == m_originalEdits.fadeInBeats &&
-          edits.fadeOutBeats == m_originalEdits.fadeOutBeats)) {
+    // Compare every field: a subclass may reset anything it baked.
+    if (edits != m_originalEdits) {
         m_editsChanged = m_manager.getPlaylistModel().setClipEdits(m_clipId, edits);
+    }
+    // Same reasoning for the canonical per-clip offset.
+    if (auto* placed = m_manager.getPlaylistModel().getClip(m_clipId)) {
+        m_originalSourceOffset = placed->sourceOffset;
+        m_originalSourceOffsetSeconds = placed->sourceOffsetSeconds;
+        if (placed->sourceOffset != 0.0 || placed->sourceOffsetSeconds != 0.0) {
+            placed->sourceOffset = 0.0;
+            placed->sourceOffsetSeconds = 0.0;
+            m_offsetsCleared = true;
+        }
     }
 
     m_manager.markModified();
@@ -78,6 +92,13 @@ void RenderAudioClipCommand::undo() {
         m_manager.getPlaylistModel().setClipEdits(m_clipId, m_originalEdits);
         m_editsChanged = false;
     }
+    if (m_offsetsCleared) {
+        if (auto* restored = m_manager.getPlaylistModel().getClip(m_clipId)) {
+            restored->sourceOffset = m_originalSourceOffset;
+            restored->sourceOffsetSeconds = m_originalSourceOffsetSeconds;
+        }
+        m_offsetsCleared = false;
+    }
     // Detach rather than remove: redo reinserts this exact pattern, and the
     // rendered file it points at is still on disk.
     m_detachedPattern = m_manager.getPatternManager().detachPattern(m_renderedPatternId);
@@ -90,7 +111,7 @@ void RenderAudioClipCommand::undo() {
 
 std::shared_ptr<AudioBufferData> ReverseAudioClipCommand::renderBuffer(const ClipInstance& clip) {
     ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
-    const auto region = service.resolveClipRegion(clip);
+    const auto region = service.resolveClipRegion(clip, m_manager.getPlaylistModel().getProjectSampleRate());
     if (!region.isValid()) {
         Log::warning("[ReverseAudioClipCommand] Clip has no resolvable audio to reverse.");
         return nullptr;
@@ -108,7 +129,7 @@ std::shared_ptr<AudioBufferData> ReverseAudioClipCommand::renderBuffer(const Cli
 
 std::shared_ptr<AudioBufferData> CommitAudioClipEditsCommand::renderBuffer(const ClipInstance& clip) {
     ClipRenderService service(m_manager.getSourceManager(), m_manager.getPatternManager());
-    const auto region = service.resolveClipRegion(clip);
+    const auto region = service.resolveClipRegion(clip, m_manager.getPlaylistModel().getProjectSampleRate());
     if (!region.isValid()) {
         Log::warning("[CommitAudioClipEditsCommand] Clip has no resolvable audio to commit.");
         return nullptr;

--- a/AestraAudio/src/Models/ClipRenderService.cpp
+++ b/AestraAudio/src/Models/ClipRenderService.cpp
@@ -36,7 +36,8 @@ bool framesToSamples(uint64_t frames, uint32_t channels, size_t& outSamples) {
 
 } // namespace
 
-ClipRenderService::SourceRegion ClipRenderService::resolveClipRegion(const ClipInstance& clip) const {
+ClipRenderService::SourceRegion ClipRenderService::resolveClipRegion(const ClipInstance& clip,
+                                                                     double projectSampleRate) const {
     SourceRegion region;
     if (!clip.patternId.isValid()) {
         return region;
@@ -69,10 +70,37 @@ ClipRenderService::SourceRegion ClipRenderService::resolveClipRegion(const ClipI
             frameCount = static_cast<uint64_t>(slice.lengthSamples);
         }
     }
+    // Same offsets the runtime snapshot applies (PlaylistModel::buildSnapshot):
+    // the canonical per-clip offset, then the instance slip. sourceStart is in
+    // project-rate samples, so convert it into this source's frames.
+    const double sourceRate = static_cast<double>(buffer->sampleRate);
+    double offsetFrames = 0.0;
+    if (clip.durationSeconds > 0.0 && std::isfinite(clip.sourceOffsetSeconds) && clip.sourceOffsetSeconds > 0.0) {
+        offsetFrames += clip.sourceOffsetSeconds * sourceRate;
+    }
+    if (std::isfinite(clip.edits.sourceStart) && clip.edits.sourceStart > 0.0) {
+        const double rateScale = (projectSampleRate > 0.0) ? sourceRate / projectSampleRate : 1.0;
+        offsetFrames += clip.edits.sourceStart * rateScale;
+    }
+    if (offsetFrames > 0.0) {
+        const double maxOffset = static_cast<double>(buffer->numFrames);
+        startFrame += static_cast<uint64_t>(std::min(offsetFrames, maxOffset));
+    }
+
     if (startFrame >= buffer->numFrames) {
         return region;
     }
     frameCount = std::min(frameCount, buffer->numFrames - startFrame);
+
+    // A trimmed clip plays only its own duration, so that is what gets
+    // rendered; otherwise reversing a trim would drag in audio the user
+    // cannot hear.
+    if (clip.durationSeconds > 0.0 && std::isfinite(clip.durationSeconds)) {
+        const double audibleFrames = clip.durationSeconds * sourceRate;
+        if (audibleFrames >= 1.0) {
+            frameCount = std::min(frameCount, static_cast<uint64_t>(audibleFrames));
+        }
+    }
 
     region.buffer = std::move(buffer);
     region.startFrame = startFrame;
@@ -157,35 +185,39 @@ void ClipRenderService::applyFades(AudioBufferData& buffer, uint64_t fadeInFrame
         return;
     }
 
-    // Ramps that together exceed the clip would otherwise multiply in the
-    // overlap and dig a hole in the middle. Shrink them proportionally so they
-    // meet exactly once, which is what a DAW crossfade-at-the-seam looks like.
-    if (fadeInFrames + fadeOutFrames > buffer.numFrames) {
-        const long double total = static_cast<long double>(fadeInFrames) + static_cast<long double>(fadeOutFrames);
-        if (total <= 0.0L) {
-            return;
-        }
-        const long double scale = static_cast<long double>(buffer.numFrames) / total;
-        fadeInFrames = static_cast<uint64_t>(static_cast<long double>(fadeInFrames) * scale);
-        fadeOutFrames = buffer.numFrames - fadeInFrames;
+    // Clamp BEFORE any arithmetic on the pair: a fade longer than the clip is
+    // legal input (a corrupt project, or a tempo change shrinking the clip),
+    // and summing two unclamped uint64 lengths can wrap past the guard and
+    // send the ramp loop off the end of the buffer.
+    const uint64_t fadeIn = std::min(fadeInFrames, buffer.numFrames);
+    const uint64_t fadeOut = std::min(fadeOutFrames, buffer.numFrames);
+    if (fadeIn == 0 && fadeOut == 0) {
+        return;
     }
 
+    // Mirrors AudioEngine's clipFadeAt so a committed clip sounds like the one
+    // that was playing: the fade-in starts at zero, the fade-out's seam sample
+    // stays at unity (strict >), and overlapping ramps take the MINIMUM rather
+    // than multiplying into a notch.
+    //
+    // The engine's CLIP_EDGE_FADE_SAMPLES micro-fade is deliberately not baked
+    // in: it is a playback-time anti-click that still applies to the committed
+    // clip, so baking it too would attenuate those 128 samples twice.
     float* data = buffer.interleavedData.data();
-
-    for (uint64_t frame = 0; frame < fadeInFrames; ++frame) {
-        const float g = static_cast<float>(static_cast<double>(frame + 1) / static_cast<double>(fadeInFrames + 1));
-        float* f = data + static_cast<size_t>(frame) * channels;
-        for (uint32_t ch = 0; ch < channels; ++ch) {
-            f[ch] *= g;
+    for (uint64_t frame = 0; frame < buffer.numFrames; ++frame) {
+        double gain = 1.0;
+        if (fadeIn > 0 && frame < fadeIn) {
+            gain = std::min(gain, static_cast<double>(frame) / static_cast<double>(fadeIn));
         }
-    }
-
-    for (uint64_t i = 0; i < fadeOutFrames; ++i) {
-        const uint64_t frame = buffer.numFrames - 1 - i;
-        const float g = static_cast<float>(static_cast<double>(i + 1) / static_cast<double>(fadeOutFrames + 1));
+        if (fadeOut > 0 && frame + fadeOut > buffer.numFrames) {
+            gain = std::min(gain, static_cast<double>(buffer.numFrames - frame) / static_cast<double>(fadeOut));
+        }
+        if (gain >= 1.0) {
+            continue;
+        }
         float* f = data + static_cast<size_t>(frame) * channels;
         for (uint32_t ch = 0; ch < channels; ++ch) {
-            f[ch] *= g;
+            f[ch] = static_cast<float>(static_cast<double>(f[ch]) * gain);
         }
     }
 }

--- a/AestraAudio/src/Models/ClipRenderService.cpp
+++ b/AestraAudio/src/Models/ClipRenderService.cpp
@@ -1,0 +1,345 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Models/ClipRenderService.h"
+
+#include "Models/PatternManager.h"
+#include "Models/SourceManager.h"
+#include "AestraLog.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
+namespace Aestra {
+namespace Audio {
+
+namespace {
+
+/** Interleaved sample count for a frame range, guarded against overflow. */
+bool framesToSamples(uint64_t frames, uint32_t channels, size_t& outSamples) {
+    if (channels == 0) {
+        return false;
+    }
+    if (frames > std::numeric_limits<size_t>::max() / channels) {
+        return false;
+    }
+    outSamples = static_cast<size_t>(frames) * channels;
+    return true;
+}
+
+} // namespace
+
+ClipRenderService::SourceRegion ClipRenderService::resolveClipRegion(const ClipInstance& clip) const {
+    SourceRegion region;
+    if (!clip.patternId.isValid()) {
+        return region;
+    }
+    const PatternSource* pattern = m_patterns.getPattern(clip.patternId);
+    if (!pattern || !pattern->isAudio()) {
+        return region;
+    }
+
+    const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
+    const ClipSource* source = m_sources.getSource(payload.audioSourceId);
+    if (!source) {
+        return region;
+    }
+    auto buffer = source->getSharedBuffer();
+    if (!buffer || !buffer->isValid()) {
+        return region;
+    }
+
+    // Patterns written by import and by recording both carry one full-extent
+    // slice; a missing or empty slice means "the whole source".
+    uint64_t startFrame = 0;
+    uint64_t frameCount = buffer->numFrames;
+    if (!payload.slices.empty()) {
+        const AudioSlice& slice = payload.slices.front();
+        if (std::isfinite(slice.startSamples) && slice.startSamples > 0.0) {
+            startFrame = static_cast<uint64_t>(slice.startSamples);
+        }
+        if (std::isfinite(slice.lengthSamples) && slice.lengthSamples > 0.0) {
+            frameCount = static_cast<uint64_t>(slice.lengthSamples);
+        }
+    }
+    if (startFrame >= buffer->numFrames) {
+        return region;
+    }
+    frameCount = std::min(frameCount, buffer->numFrames - startFrame);
+
+    region.buffer = std::move(buffer);
+    region.startFrame = startFrame;
+    region.frameCount = frameCount;
+    region.mixerChannelId = pattern->getMixerChannelId();
+    region.lengthBeats = pattern->lengthBeats;
+    region.name = pattern->name.empty() ? clip.name : pattern->name;
+    return region;
+}
+
+std::shared_ptr<AudioBufferData> ClipRenderService::extractRegion(const AudioBufferData& source, uint64_t startFrame,
+                                                                 uint64_t frameCount) {
+    if (!source.isValid() || frameCount == 0 || startFrame >= source.numFrames) {
+        return nullptr;
+    }
+
+    // Clamp an overhanging range instead of reading past the buffer. A clip
+    // whose length outlives its source is normal after tempo edits.
+    const uint64_t available = source.numFrames - startFrame;
+    const uint64_t framesToCopy = std::min(frameCount, available);
+
+    size_t sampleCount = 0;
+    size_t sampleOffset = 0;
+    if (!framesToSamples(framesToCopy, source.numChannels, sampleCount) ||
+        !framesToSamples(startFrame, source.numChannels, sampleOffset)) {
+        return nullptr;
+    }
+    if (sampleOffset + sampleCount > source.interleavedData.size()) {
+        return nullptr;
+    }
+
+    auto out = std::make_shared<AudioBufferData>();
+    out->sampleRate = source.sampleRate;
+    out->numChannels = source.numChannels;
+    out->numFrames = framesToCopy;
+    out->interleavedData.assign(source.interleavedData.begin() + static_cast<std::ptrdiff_t>(sampleOffset),
+                                source.interleavedData.begin() +
+                                    static_cast<std::ptrdiff_t>(sampleOffset + sampleCount));
+    return out;
+}
+
+void ClipRenderService::reverseInPlace(AudioBufferData& buffer) {
+    if (!buffer.isValid() || buffer.numFrames < 2) {
+        return;
+    }
+    const uint32_t channels = buffer.numChannels;
+    size_t usableSamples = 0;
+    if (!framesToSamples(buffer.numFrames, channels, usableSamples) ||
+        usableSamples > buffer.interleavedData.size()) {
+        return;
+    }
+
+    // Swap whole frames so a stereo image survives the reverse; reversing the
+    // flat sample array would also swap L and R.
+    float* data = buffer.interleavedData.data();
+    for (uint64_t front = 0, back = buffer.numFrames - 1; front < back; ++front, --back) {
+        float* a = data + static_cast<size_t>(front) * channels;
+        float* b = data + static_cast<size_t>(back) * channels;
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            std::swap(a[ch], b[ch]);
+        }
+    }
+}
+
+void ClipRenderService::applyGain(AudioBufferData& buffer, float gainLinear) {
+    if (!std::isfinite(gainLinear) || gainLinear == 1.0f) {
+        return;
+    }
+    for (float& sample : buffer.interleavedData) {
+        sample *= gainLinear;
+    }
+}
+
+void ClipRenderService::applyFades(AudioBufferData& buffer, uint64_t fadeInFrames, uint64_t fadeOutFrames) {
+    if (!buffer.isValid() || buffer.numFrames == 0) {
+        return;
+    }
+    const uint32_t channels = buffer.numChannels;
+    size_t usableSamples = 0;
+    if (!framesToSamples(buffer.numFrames, channels, usableSamples) ||
+        usableSamples > buffer.interleavedData.size()) {
+        return;
+    }
+
+    // Ramps that together exceed the clip would otherwise multiply in the
+    // overlap and dig a hole in the middle. Shrink them proportionally so they
+    // meet exactly once, which is what a DAW crossfade-at-the-seam looks like.
+    if (fadeInFrames + fadeOutFrames > buffer.numFrames) {
+        const long double total = static_cast<long double>(fadeInFrames) + static_cast<long double>(fadeOutFrames);
+        if (total <= 0.0L) {
+            return;
+        }
+        const long double scale = static_cast<long double>(buffer.numFrames) / total;
+        fadeInFrames = static_cast<uint64_t>(static_cast<long double>(fadeInFrames) * scale);
+        fadeOutFrames = buffer.numFrames - fadeInFrames;
+    }
+
+    float* data = buffer.interleavedData.data();
+
+    for (uint64_t frame = 0; frame < fadeInFrames; ++frame) {
+        const float g = static_cast<float>(static_cast<double>(frame + 1) / static_cast<double>(fadeInFrames + 1));
+        float* f = data + static_cast<size_t>(frame) * channels;
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            f[ch] *= g;
+        }
+    }
+
+    for (uint64_t i = 0; i < fadeOutFrames; ++i) {
+        const uint64_t frame = buffer.numFrames - 1 - i;
+        const float g = static_cast<float>(static_cast<double>(i + 1) / static_cast<double>(fadeOutFrames + 1));
+        float* f = data + static_cast<size_t>(frame) * channels;
+        for (uint32_t ch = 0; ch < channels; ++ch) {
+            f[ch] *= g;
+        }
+    }
+}
+
+float ClipRenderService::peakMagnitude(const AudioBufferData& buffer) {
+    float peak = 0.0f;
+    for (const float sample : buffer.interleavedData) {
+        if (std::isfinite(sample)) {
+            peak = std::max(peak, std::fabs(sample));
+        }
+    }
+    return peak;
+}
+
+std::string ClipRenderService::uniqueRenderPath(const std::string& directory, const std::string& baseName) {
+    namespace fs = std::filesystem;
+
+    // Strip anything that would be awkward in a filename; the pattern name is
+    // user-supplied and may contain separators.
+    std::string safe;
+    safe.reserve(baseName.size());
+    for (const char c : baseName) {
+        const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' ||
+                        c == '_' || c == ' ';
+        safe.push_back(ok ? c : '_');
+    }
+    if (safe.empty()) {
+        safe = "render";
+    }
+
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &time);
+#else
+    localtime_r(&time, &tm);
+#endif
+
+    static std::atomic<uint64_t> s_counter{0};
+    const uint64_t uniq = s_counter.fetch_add(1, std::memory_order_relaxed);
+
+    std::ostringstream oss;
+    oss << safe << "_" << std::put_time(&tm, "%Y%m%d_%H%M%S") << "_" << uniq << ".wav";
+    return (fs::path(directory) / oss.str()).string();
+}
+
+bool ClipRenderService::writeFloatWav(const std::string& path, const AudioBufferData& buffer) {
+    if (buffer.numChannels == 0 || buffer.numChannels > std::numeric_limits<uint16_t>::max() ||
+        buffer.sampleRate == 0 || buffer.numFrames > std::numeric_limits<uint32_t>::max() ||
+        buffer.interleavedData.size() > (std::numeric_limits<uint32_t>::max() / sizeof(float))) {
+        return false;
+    }
+
+    const uint16_t audioFormat = 3; // IEEE float
+    const uint16_t numChannels = static_cast<uint16_t>(buffer.numChannels);
+    const uint32_t sampleRate = buffer.sampleRate;
+    const uint16_t bitsPerSample = 32;
+    const uint16_t blockAlign = static_cast<uint16_t>(numChannels * (bitsPerSample / 8));
+    if (blockAlign == 0 || sampleRate > std::numeric_limits<uint32_t>::max() / blockAlign) {
+        return false;
+    }
+    const uint32_t byteRate = sampleRate * blockAlign;
+    const uint32_t dataSize = static_cast<uint32_t>(buffer.interleavedData.size() * sizeof(float));
+    const uint32_t sampleCount = static_cast<uint32_t>(buffer.numFrames);
+    const uint32_t factChunkSize = 4;
+    if (dataSize > std::numeric_limits<uint32_t>::max() - 48u) {
+        return false;
+    }
+    const uint32_t riffChunkSize = 48u + dataSize;
+    const uint32_t fmtChunkSize = 16;
+
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    file.write("RIFF", 4);
+    file.write(reinterpret_cast<const char*>(&riffChunkSize), sizeof(riffChunkSize));
+    file.write("WAVE", 4);
+    file.write("fmt ", 4);
+    file.write(reinterpret_cast<const char*>(&fmtChunkSize), sizeof(fmtChunkSize));
+    file.write(reinterpret_cast<const char*>(&audioFormat), sizeof(audioFormat));
+    file.write(reinterpret_cast<const char*>(&numChannels), sizeof(numChannels));
+    file.write(reinterpret_cast<const char*>(&sampleRate), sizeof(sampleRate));
+    file.write(reinterpret_cast<const char*>(&byteRate), sizeof(byteRate));
+    file.write(reinterpret_cast<const char*>(&blockAlign), sizeof(blockAlign));
+    file.write(reinterpret_cast<const char*>(&bitsPerSample), sizeof(bitsPerSample));
+    file.write("fact", 4);
+    file.write(reinterpret_cast<const char*>(&factChunkSize), sizeof(factChunkSize));
+    file.write(reinterpret_cast<const char*>(&sampleCount), sizeof(sampleCount));
+    file.write("data", 4);
+    file.write(reinterpret_cast<const char*>(&dataSize), sizeof(dataSize));
+    file.write(reinterpret_cast<const char*>(buffer.interleavedData.data()), dataSize);
+
+    return file.good();
+}
+
+ClipRenderService::CommitResult ClipRenderService::commit(const AudioBufferData& buffer,
+                                                          const std::string& renderDirectory,
+                                                          const std::string& baseName, double lengthBeats,
+                                                          uint32_t mixerChannelId) {
+    CommitResult result;
+    if (!buffer.isValid() || buffer.numFrames == 0) {
+        return result;
+    }
+
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(renderDirectory, ec);
+    if (ec) {
+        Log::error("[ClipRenderService] Could not create render directory: " + renderDirectory);
+        return result;
+    }
+
+    const std::string path = uniqueRenderPath(renderDirectory, baseName);
+    if (!writeFloatWav(path, buffer)) {
+        Log::error("[ClipRenderService] Failed to write rendered audio: " + path);
+        // A partial file would look like a valid source on the next load.
+        fs::remove(path, ec);
+        return result;
+    }
+
+    // Hand the in-memory copy straight to the source so playback does not have
+    // to wait for a decode of the file we just wrote.
+    auto owned = std::make_shared<AudioBufferData>(buffer);
+    const ClipSourceID sourceId = m_sources.createRecordedSource(path, baseName, std::move(owned));
+    if (!sourceId.isValid()) {
+        Log::error("[ClipRenderService] Failed to register rendered source: " + path);
+        fs::remove(path, ec);
+        return result;
+    }
+
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = buffer.durationSeconds();
+    AudioSlice fullSlice;
+    fullSlice.startSamples = 0.0;
+    fullSlice.lengthSamples = static_cast<double>(buffer.numFrames);
+    payload.slices.push_back(fullSlice);
+
+    const double beats = (std::isfinite(lengthBeats) && lengthBeats > 0.0) ? lengthBeats : 4.0;
+    const PatternID patternId = m_patterns.createAudioPattern(baseName, beats, payload);
+    if (!patternId.isValid()) {
+        Log::error("[ClipRenderService] Failed to create pattern for rendered audio: " + path);
+        return result;
+    }
+    m_patterns.setPatternMixerChannel(patternId, mixerChannelId);
+
+    result.patternId = patternId;
+    result.sourceId = sourceId;
+    result.filePath = path;
+    return result;
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -231,6 +231,12 @@ void AudioClipEditorPanel::buildUI() {
     m_commitButton->setOnClick([this]() {
         if (!m_trackManager || !m_clipId.isValid())
             return;
+        // Nothing baked means nothing to commit: rendering here would write a
+        // dead file, mint a source and pattern, and add an undo step that
+        // changes nothing audible.
+        if (m_workingEdits.gainLinear == 1.0f && m_workingEdits.fadeInBeats == 0.0f &&
+            m_workingEdits.fadeOutBeats == 0.0f && m_workingEdits.sourceStart == 0.0)
+            return;
         auto command = std::make_shared<CommitAudioClipEditsCommand>(*m_trackManager, m_clipId);
         m_trackManager->getCommandHistory().pushAndExecute(command);
         openClip(m_clipId);

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -2,6 +2,7 @@
 #include "AudioClipEditorPanel.h"
 
 #include "Commands/MakeAudioClipUniqueCommand.h"
+#include "Commands/RenderAudioClipCommand.h"
 #include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Commands/SetClipEditsCommand.h"
 #include "NUIButton.h"
@@ -68,10 +69,9 @@ std::string formatGainDb(float linear) {
 }
 
 bool editsEqual(const ClipEdits& a, const ClipEdits& b) {
-    return a.fadeInBeats == b.fadeInBeats && a.fadeOutBeats == b.fadeOutBeats && a.gain == b.gain &&
-           a.gainLinear == b.gainLinear && a.pitchSemitones == b.pitchSemitones &&
-           a.timeStretchRatio == b.timeStretchRatio && a.pan == b.pan && a.muted == b.muted &&
-           a.playbackRate == b.playbackRate && a.sourceStart == b.sourceStart;
+    return a.fadeInBeats == b.fadeInBeats && a.fadeOutBeats == b.fadeOutBeats && a.gainLinear == b.gainLinear &&
+           a.pan == b.pan && a.muted == b.muted && a.playbackRate == b.playbackRate &&
+           a.sourceStart == b.sourceStart;
 }
 
 } // namespace
@@ -158,10 +158,14 @@ void AudioClipEditorPanel::buildUI() {
     m_normalizeButton = std::make_shared<NUIButton>("Normalize");
     m_resetButton = std::make_shared<NUIButton>("Reset instance");
     m_makeUniqueButton = std::make_shared<NUIButton>("Make unique");
+    m_reverseButton = std::make_shared<NUIButton>("Reverse");
+    m_commitButton = std::make_shared<NUIButton>("Commit");
     styleButton(m_muteButton);
     styleButton(m_normalizeButton);
     styleButton(m_resetButton);
     styleButton(m_makeUniqueButton);
+    styleButton(m_reverseButton);
+    styleButton(m_commitButton);
 
     const auto wireSlider = [this](const std::shared_ptr<NUISlider>& slider, auto update) {
         slider->setOnDragStart([this]() { beginEditGesture(); });
@@ -180,7 +184,6 @@ void AudioClipEditorPanel::buildUI() {
         slider->setOnDragEnd([this]() { commitEditGesture(); });
     };
     wireSlider(m_gainSlider, [](ClipEdits& edits, double value) {
-        edits.gain = static_cast<float>(value);
         edits.gainLinear = static_cast<float>(value);
     });
     wireSlider(m_panSlider, [](ClipEdits& edits, double value) { edits.pan = static_cast<float>(value); });
@@ -206,7 +209,6 @@ void AudioClipEditorPanel::buildUI() {
             return;
         auto edits = m_workingEdits;
         const float normalizedGain = std::clamp(kNormalizeTargetLinear / m_sourcePeak, 0.0f, 2.0f);
-        edits.gain = normalizedGain;
         edits.gainLinear = normalizedGain;
         applyDiscreteEdit(edits);
     });
@@ -217,6 +219,22 @@ void AudioClipEditorPanel::buildUI() {
         m_trackManager->getCommandHistory().pushAndExecute(command);
         openClip(m_clipId);
     });
+    m_reverseButton->setOnClick([this]() {
+        if (!m_trackManager || !m_clipId.isValid())
+            return;
+        auto command = std::make_shared<ReverseAudioClipCommand>(*m_trackManager, m_clipId);
+        m_trackManager->getCommandHistory().pushAndExecute(command);
+        // The clip now points at a different source, so re-read it to refresh
+        // the waveform and the edit values.
+        openClip(m_clipId);
+    });
+    m_commitButton->setOnClick([this]() {
+        if (!m_trackManager || !m_clipId.isValid())
+            return;
+        auto command = std::make_shared<CommitAudioClipEditsCommand>(*m_trackManager, m_clipId);
+        m_trackManager->getCommandHistory().pushAndExecute(command);
+        openClip(m_clipId);
+    });
 
     const std::vector<std::shared_ptr<NUIComponent>> children{
         m_sourceNameLabel,   m_sourceMetaLabel,   m_routeLabel,        m_routeHintLabel,   m_routePicker,
@@ -224,7 +242,8 @@ void AudioClipEditorPanel::buildUI() {
         m_fadeInLabel,       m_fadeOutLabel,      m_speedLabel,        m_sourceStartLabel, m_gainValueLabel,
         m_panValueLabel,     m_fadeInValueLabel,  m_fadeOutValueLabel, m_speedValueLabel,  m_sourceStartValueLabel,
         m_gainSlider,        m_panSlider,         m_fadeInSlider,      m_fadeOutSlider,    m_speedSlider,
-        m_sourceStartSlider, m_muteButton,        m_normalizeButton,   m_resetButton,      m_makeUniqueButton};
+        m_sourceStartSlider, m_muteButton,        m_normalizeButton,   m_resetButton,      m_makeUniqueButton,
+        m_reverseButton,     m_commitButton};
     for (const auto& child : children) {
         m_surface->addChild(child);
     }
@@ -500,13 +519,22 @@ void AudioClipEditorPanel::onResize(int width, int height) {
     m_waveformHintLabel->setBounds({bounds.x + pad, controlsTop - 23.0f, contentWidth - 4.0f, 14.0f});
 
     m_instanceLabel->setBounds({bounds.x + pad, controlsTop + 10.0f, contentWidth, 14.0f});
-    const float buttonWidth = 104.0f;
-    m_makeUniqueButton->setBounds(
-        {bounds.right() - pad - buttonWidth * 4.0f - 18.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
-    m_normalizeButton->setBounds(
-        {bounds.right() - pad - buttonWidth * 3.0f - 12.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
-    m_muteButton->setBounds({bounds.right() - pad - buttonWidth * 2.0f - 6.0f, controlsTop + 8.0f, buttonWidth, 24.0f});
-    m_resetButton->setBounds({bounds.right() - pad - buttonWidth, controlsTop + 8.0f, buttonWidth, 24.0f});
+    // Right-aligned strip, laid out right-to-left so the row stays anchored to
+    // the panel edge as buttons are added. Destructive operations (Reverse,
+    // Commit) sit left of the reversible ones so a misclick is less likely to
+    // land on the one that writes a file.
+    const float buttonGap = 6.0f;
+    const std::shared_ptr<NUIButton> buttonRow[] = {m_resetButton,  m_muteButton,    m_normalizeButton,
+                                                    m_commitButton, m_reverseButton, m_makeUniqueButton};
+    constexpr size_t buttonCount = sizeof(buttonRow) / sizeof(buttonRow[0]);
+    const float availableWidth = contentWidth - buttonGap * static_cast<float>(buttonCount - 1);
+    const float buttonWidth = std::clamp(availableWidth / static_cast<float>(buttonCount), 64.0f, 104.0f);
+
+    float buttonRight = bounds.right() - pad;
+    for (const auto& button : buttonRow) {
+        button->setBounds({buttonRight - buttonWidth, controlsTop + 8.0f, buttonWidth, 24.0f});
+        buttonRight -= buttonWidth + buttonGap;
+    }
 
     const float columnGap = 20.0f;
     const float columnWidth = (contentWidth - columnGap) * 0.5f;

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -82,6 +82,8 @@ private:
     std::shared_ptr<AestraUI::NUIButton> m_normalizeButton;
     std::shared_ptr<AestraUI::NUIButton> m_resetButton;
     std::shared_ptr<AestraUI::NUIButton> m_makeUniqueButton;
+    std::shared_ptr<AestraUI::NUIButton> m_reverseButton;
+    std::shared_ptr<AestraUI::NUIButton> m_commitButton;
 
     void buildUI();
     bool resolveClip(ClipInstance*& clip, PatternSource*& pattern) const;

--- a/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
+++ b/Tests/AestraAudio/AudioClipInstanceRenderTest.cpp
@@ -83,7 +83,6 @@ int main() {
             "New audio clip did not start with the headroom-preserving gain");
 
     ClipEdits edits = clip->edits;
-    edits.gain = 0.5f;
     edits.gainLinear = 0.5f;
     edits.pan = -1.0f;
     edits.fadeInBeats = 0.5f;
@@ -108,7 +107,6 @@ int main() {
     for (uint32_t frame = 0; frame < kTotalFrames; ++frame) {
         sourceBuffer->interleavedData[frame] = static_cast<float>(frame) / static_cast<float>(kTotalFrames);
     }
-    edits.gain = 1.0f;
     edits.gainLinear = 1.0f;
     edits.pan = 0.0f;
     edits.fadeInBeats = 0.0f;

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -247,7 +247,6 @@ int main() {
     playlist.addClip(laneA, audioClip);
 
     ClipEdits edited = audioClip.edits;
-    edited.gain = 0.5f;
     edited.gainLinear = 0.5f;
     edited.pan = -0.25f;
     edited.fadeInBeats = 0.25f;

--- a/Tests/Commands/ClipRenderServiceTest.cpp
+++ b/Tests/Commands/ClipRenderServiceTest.cpp
@@ -1,0 +1,179 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Proves the pure transforms behind every destructive clip operation. These run
+// on bare buffers so a failure points at the DSP, not at project plumbing.
+
+#include "Models/ClipRenderService.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::AudioBufferData;
+using Aestra::Audio::ClipRenderService;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const std::string& what) {
+    if (!condition) {
+        std::printf("  FAIL: %s\n", what.c_str());
+        ++g_failures;
+    }
+}
+
+void requireClose(float actual, float expected, const std::string& what) {
+    if (std::fabs(actual - expected) > 1.0e-5f) {
+        std::printf("  FAIL: %s (expected %f, got %f)\n", what.c_str(), expected, actual);
+        ++g_failures;
+    }
+}
+
+/** Stereo ramp where L is the frame index and R is its negation. */
+AudioBufferData makeRamp(uint64_t frames) {
+    AudioBufferData buffer;
+    buffer.sampleRate = 48000;
+    buffer.numChannels = 2;
+    buffer.numFrames = frames;
+    buffer.interleavedData.resize(static_cast<size_t>(frames) * 2);
+    for (uint64_t i = 0; i < frames; ++i) {
+        buffer.interleavedData[i * 2] = static_cast<float>(i);
+        buffer.interleavedData[i * 2 + 1] = -static_cast<float>(i);
+    }
+    return buffer;
+}
+
+void testExtractRegion() {
+    std::printf("extractRegion...\n");
+    const AudioBufferData source = makeRamp(100);
+
+    auto mid = ClipRenderService::extractRegion(source, 10, 20);
+    require(mid != nullptr, "mid-buffer region is extracted");
+    if (mid) {
+        require(mid->numFrames == 20, "region has the requested frame count");
+        require(mid->numChannels == source.numChannels, "region keeps the channel count");
+        require(mid->sampleRate == source.sampleRate, "region keeps the sample rate");
+        requireClose(mid->interleavedData[0], 10.0f, "region starts at the requested frame");
+        requireClose(mid->interleavedData[1], -10.0f, "region keeps channel pairing");
+    }
+
+    // A clip may outlive its source after a tempo edit; clamp, do not overrun.
+    auto overhang = ClipRenderService::extractRegion(source, 90, 50);
+    require(overhang != nullptr, "overhanging region still extracts");
+    if (overhang) {
+        require(overhang->numFrames == 10, "overhanging region clamps to the source end");
+    }
+
+    require(ClipRenderService::extractRegion(source, 100, 10) == nullptr,
+            "a region starting past the end yields nothing, not silence");
+    require(ClipRenderService::extractRegion(source, 0, 0) == nullptr, "an empty region yields nothing");
+}
+
+void testReverse() {
+    std::printf("reverseInPlace...\n");
+    AudioBufferData buffer = makeRamp(8);
+    ClipRenderService::reverseInPlace(buffer);
+
+    require(buffer.numFrames == 8, "reverse preserves length");
+    requireClose(buffer.interleavedData[0], 7.0f, "first frame becomes the last");
+    requireClose(buffer.interleavedData[14], 0.0f, "last frame becomes the first");
+
+    // The regression that matters: reversing the flat sample array would put
+    // the right channel where the left belongs.
+    for (uint64_t i = 0; i < buffer.numFrames; ++i) {
+        const float l = buffer.interleavedData[i * 2];
+        const float r = buffer.interleavedData[i * 2 + 1];
+        requireClose(r, -l, "reverse keeps L/R paired within each frame");
+    }
+
+    AudioBufferData single = makeRamp(1);
+    ClipRenderService::reverseInPlace(single);
+    requireClose(single.interleavedData[0], 0.0f, "single-frame reverse is a no-op");
+
+    // Reversing twice must return the original exactly.
+    AudioBufferData twice = makeRamp(9);
+    ClipRenderService::reverseInPlace(twice);
+    ClipRenderService::reverseInPlace(twice);
+    const AudioBufferData original = makeRamp(9);
+    for (size_t i = 0; i < original.interleavedData.size(); ++i) {
+        requireClose(twice.interleavedData[i], original.interleavedData[i], "double reverse restores the original");
+    }
+}
+
+void testGain() {
+    std::printf("applyGain...\n");
+    AudioBufferData buffer = makeRamp(4);
+    ClipRenderService::applyGain(buffer, 0.5f);
+    requireClose(buffer.interleavedData[2], 0.5f, "gain scales samples");
+
+    // A non-finite gain must not poison the buffer with NaN.
+    AudioBufferData guarded = makeRamp(4);
+    ClipRenderService::applyGain(guarded, std::nanf(""));
+    requireClose(guarded.interleavedData[2], 1.0f, "non-finite gain is ignored");
+}
+
+void testFades() {
+    std::printf("applyFades...\n");
+    AudioBufferData buffer;
+    buffer.sampleRate = 48000;
+    buffer.numChannels = 1;
+    buffer.numFrames = 100;
+    buffer.interleavedData.assign(100, 1.0f);
+
+    ClipRenderService::applyFades(buffer, 10, 10);
+    require(buffer.interleavedData[0] < 1.0f, "fade-in attenuates the first frame");
+    require(buffer.interleavedData[0] > 0.0f, "fade-in does not fully mute the first frame");
+    requireClose(buffer.interleavedData[50], 1.0f, "the middle is left at unity");
+    require(buffer.interleavedData[99] < 1.0f, "fade-out attenuates the last frame");
+
+    // Ramps are monotonic across their span.
+    for (uint64_t i = 1; i < 10; ++i) {
+        require(buffer.interleavedData[i] > buffer.interleavedData[i - 1], "fade-in rises monotonically");
+    }
+
+    // Overlapping ramps must not multiply into a notch in the middle.
+    AudioBufferData overlapped;
+    overlapped.sampleRate = 48000;
+    overlapped.numChannels = 1;
+    overlapped.numFrames = 20;
+    overlapped.interleavedData.assign(20, 1.0f);
+    ClipRenderService::applyFades(overlapped, 100, 100);
+    for (const float sample : overlapped.interleavedData) {
+        require(sample >= 0.0f && sample <= 1.0f, "over-long fades stay within unity");
+    }
+    require(overlapped.interleavedData[10] > 0.0f, "over-long fades do not silence the middle");
+}
+
+void testPeak() {
+    std::printf("peakMagnitude...\n");
+    AudioBufferData buffer;
+    buffer.sampleRate = 48000;
+    buffer.numChannels = 1;
+    buffer.numFrames = 4;
+    buffer.interleavedData = {0.1f, -0.8f, 0.3f, 0.2f};
+    requireClose(ClipRenderService::peakMagnitude(buffer), 0.8f, "peak uses absolute value");
+
+    buffer.interleavedData = {0.1f, std::nanf(""), 0.3f, 0.2f};
+    requireClose(ClipRenderService::peakMagnitude(buffer), 0.3f, "peak skips non-finite samples");
+}
+
+} // namespace
+
+int main() {
+    std::printf("=== ClipRenderService transforms ===\n");
+    testExtractRegion();
+    testReverse();
+    testGain();
+    testFades();
+    testPeak();
+
+    if (g_failures != 0) {
+        std::printf("FAILED: %d check(s)\n", g_failures);
+        return EXIT_FAILURE;
+    }
+    std::printf("All ClipRenderService transform checks passed.\n");
+    return EXIT_SUCCESS;
+}

--- a/Tests/Commands/ClipRenderServiceTest.cpp
+++ b/Tests/Commands/ClipRenderServiceTest.cpp
@@ -5,9 +5,11 @@
 
 #include "Models/ClipRenderService.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -124,8 +126,9 @@ void testFades() {
     buffer.interleavedData.assign(100, 1.0f);
 
     ClipRenderService::applyFades(buffer, 10, 10);
-    require(buffer.interleavedData[0] < 1.0f, "fade-in attenuates the first frame");
-    require(buffer.interleavedData[0] > 0.0f, "fade-in does not fully mute the first frame");
+    // The engine's clipFadeAt starts a fade-in at silence, so a baked fade
+    // must too; see testFadeMatchesEngineShape for the exact contract.
+    requireClose(buffer.interleavedData[0], 0.0f, "fade-in starts at silence");
     requireClose(buffer.interleavedData[50], 1.0f, "the middle is left at unity");
     require(buffer.interleavedData[99] < 1.0f, "fade-out attenuates the last frame");
 
@@ -145,6 +148,63 @@ void testFades() {
         require(sample >= 0.0f && sample <= 1.0f, "over-long fades stay within unity");
     }
     require(overlapped.interleavedData[10] > 0.0f, "over-long fades do not silence the middle");
+}
+
+void testFadeLengthsCannotOverrun() {
+    std::printf("applyFades: absurd fade lengths are clamped...\n");
+    // A fade longer than the clip is legal input (corrupt project, or a tempo
+    // change shrinking the clip). Summing two unclamped uint64 lengths wraps
+    // past the guard, so the ramp loop used to run off the end of the buffer.
+    const uint64_t huge = std::numeric_limits<uint64_t>::max() - 4;
+
+    AudioBufferData buffer = makeRamp(64);
+    const size_t originalSamples = buffer.interleavedData.size();
+    ClipRenderService::applyFades(buffer, huge, 8);
+    require(buffer.numFrames == 64, "an absurd fade-in leaves the length alone");
+    require(buffer.interleavedData.size() == originalSamples, "an absurd fade-in does not resize the buffer");
+
+    AudioBufferData both = makeRamp(64);
+    ClipRenderService::applyFades(both, huge, huge);
+    require(both.numFrames == 64, "two absurd fades leave the length alone");
+    require(both.interleavedData.size() == originalSamples, "two absurd fades do not resize the buffer");
+    for (size_t i = 0; i < both.interleavedData.size(); ++i) {
+        const float original = static_cast<float>(i / 2);
+        const float actual = std::fabs(both.interleavedData[i]);
+        require(std::isfinite(actual) && actual <= original + 1.0e-4f, "clamped fades never amplify");
+    }
+}
+
+void testFadeMatchesEngineShape() {
+    std::printf("applyFades: ramps match the engine's clip fade...\n");
+    AudioBufferData buffer;
+    buffer.sampleRate = 48000;
+    buffer.numChannels = 1;
+    buffer.numFrames = 100;
+    buffer.interleavedData.assign(100, 1.0f);
+
+    ClipRenderService::applyFades(buffer, 10, 10);
+    // AudioEngine::clipFadeAt starts the fade-in at zero...
+    requireClose(buffer.interleavedData[0], 0.0f, "fade-in starts at silence like the engine");
+    requireClose(buffer.interleavedData[5], 0.5f, "fade-in is linear in frame/fadeLen");
+    requireClose(buffer.interleavedData[10], 1.0f, "fade-in reaches unity at its length");
+    // ...and leaves the fade-out's seam sample at unity (strict >).
+    requireClose(buffer.interleavedData[90], 1.0f, "the fade-out seam sample stays at unity");
+    requireClose(buffer.interleavedData[95], 0.5f, "fade-out is linear in remaining/fadeLen");
+    requireClose(buffer.interleavedData[99], 0.1f, "the last frame is one step above silence");
+
+    // Overlapping ramps take the minimum, as the engine does, not the product.
+    AudioBufferData overlap;
+    overlap.sampleRate = 48000;
+    overlap.numChannels = 1;
+    overlap.numFrames = 10;
+    overlap.interleavedData.assign(10, 1.0f);
+    ClipRenderService::applyFades(overlap, 8, 8);
+    for (uint64_t i = 0; i < overlap.numFrames; ++i) {
+        const double fadeIn = (i < 8) ? static_cast<double>(i) / 8.0 : 1.0;
+        const double fadeOut = (i + 8 > 10) ? static_cast<double>(10 - i) / 8.0 : 1.0;
+        requireClose(overlap.interleavedData[i], static_cast<float>(std::min({1.0, fadeIn, fadeOut})),
+                     "overlapping fades take the minimum, not the product");
+    }
 }
 
 void testPeak() {
@@ -168,6 +228,8 @@ int main() {
     testReverse();
     testGain();
     testFades();
+    testFadeLengthsCannotOverrun();
+    testFadeMatchesEngineShape();
     testPeak();
 
     if (g_failures != 0) {

--- a/Tests/Commands/RenderAudioClipCommandTest.cpp
+++ b/Tests/Commands/RenderAudioClipCommandTest.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<const AudioBufferData> currentAudio(TrackManager& tm, ClipInstan
         return nullptr;
     }
     ClipRenderService service(tm.getSourceManager(), tm.getPatternManager());
-    return service.resolveClipRegion(*clip).buffer;
+    return service.resolveClipRegion(*clip, tm.getPlaylistModel().getProjectSampleRate()).buffer;
 }
 
 struct Fixture {
@@ -132,6 +132,18 @@ void testReverseChangesAudioAndUndoRestores(const std::string& dir) {
     command.execute();
 
     require(command.isUndoable(), "reverse reports that it changed something");
+
+    // commit() returning invalid makes execute() bail, which would otherwise
+    // look identical to "reverse did nothing"; pin the write path itself.
+    bool wroteWav = false;
+    std::error_code renderEc;
+    for (const auto& entry : std::filesystem::directory_iterator(fx.tm->renderRootDirectory(), renderEc)) {
+        if (entry.path().extension() == ".wav") {
+            wroteWav = true;
+            break;
+        }
+    }
+    require(wroteWav, "reverse writes its rendered audio to the render directory");
     const PatternID patternAfter = fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId;
     require(!(patternAfter == patternBefore), "reverse repoints the clip at a new pattern");
 
@@ -202,6 +214,57 @@ void testCommitBakesGainAndResetsEdits(const std::string& dir) {
     }
 }
 
+void testSlipOffsetIsHonouredAndBaked(const std::string& dir) {
+    std::printf("reverse: a slipped clip renders the region it plays...\n");
+    Fixture fx = makeClipFixture(dir);
+
+    // Slip halfway in, the way the editor's "Source start" slider does. The
+    // region resolver used to ignore this and render from frame 0, so reverse
+    // committed audio the user could not hear.
+    auto* clip = fx.tm->getPlaylistModel().getClip(fx.clipId);
+    require(clip != nullptr, "fixture clip exists");
+    if (!clip) {
+        return;
+    }
+    const uint64_t sourceFrames = 2000;
+    const double projectRate = fx.tm->getPlaylistModel().getProjectSampleRate();
+    ClipEdits edits = clip->edits;
+    edits.gainLinear = 1.0f;
+    edits.sourceStart = static_cast<double>(sourceFrames / 2) * (projectRate / 48000.0);
+    fx.tm->getPlaylistModel().setClipEdits(fx.clipId, edits);
+
+    {
+        ClipRenderService service(fx.tm->getSourceManager(), fx.tm->getPatternManager());
+        const auto* live = fx.tm->getPlaylistModel().getClip(fx.clipId);
+        const auto region = service.resolveClipRegion(*live, projectRate);
+        require(region.isValid(), "a slipped clip still resolves");
+        if (region.isValid()) {
+            require(region.startFrame >= sourceFrames / 2 - 1 && region.startFrame <= sourceFrames / 2 + 1,
+                    "the resolved region starts at the slip, not at frame 0");
+            require(region.frameCount <= sourceFrames / 2 + 1, "the resolved region ends with the source");
+            // The fixture ramps down from 1.0, so the second half peaks near 0.5.
+            auto extracted = ClipRenderService::extractRegion(*region.buffer, region.startFrame, region.frameCount);
+            require(extracted != nullptr, "the slipped region extracts");
+            if (extracted) {
+                require(ClipRenderService::peakMagnitude(*extracted) < 0.6f,
+                        "the resolved audio is the second half, not the whole source");
+            }
+        }
+    }
+
+    ReverseAudioClipCommand command(*fx.tm, fx.clipId);
+    command.execute();
+    require(command.isUndoable(), "reversing a slipped clip succeeds");
+
+    // The new source starts at the region, so the slip is already baked in.
+    const ClipEdits after = fx.tm->getPlaylistModel().getClip(fx.clipId)->edits;
+    require(after.sourceStart == 0.0, "the baked slip is cleared so it is not applied twice");
+
+    command.undo();
+    const ClipEdits undone = fx.tm->getPlaylistModel().getClip(fx.clipId)->edits;
+    require(std::fabs(undone.sourceStart - edits.sourceStart) < 1.0e-6, "undo restores the original slip");
+}
+
 void testMidiClipIsRefused(const std::string& dir) {
     std::printf("reverse: a non-audio clip is refused, not corrupted...\n");
     Fixture fx = makeClipFixture(dir);
@@ -235,6 +298,7 @@ int main() {
 
     testReverseChangesAudioAndUndoRestores(dir.string());
     testCommitBakesGainAndResetsEdits(dir.string());
+    testSlipOffsetIsHonouredAndBaked(dir.string());
     testMidiClipIsRefused(dir.string());
 
     fs::remove_all(dir, ec);

--- a/Tests/Commands/RenderAudioClipCommandTest.cpp
+++ b/Tests/Commands/RenderAudioClipCommandTest.cpp
@@ -1,0 +1,248 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// End-to-end proof that the destructive clip operations change what a clip
+// actually plays, and that undo puts the original audio back. The clip is built
+// the same way the import path builds one (source -> audio pattern -> clip), so
+// a break in that contract fails here rather than only in the app.
+
+#include "Commands/RenderAudioClipCommand.h"
+#include "Models/ClipRenderService.h"
+#include "Models/TrackManager.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const std::string& what) {
+    if (!condition) {
+        std::printf("  FAIL: %s\n", what.c_str());
+        ++g_failures;
+    }
+}
+
+/** Front-loaded ramp: frame 0 is loudest, the tail is near silence. */
+std::shared_ptr<AudioBufferData> makeDecayBuffer(uint64_t frames) {
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = 48000;
+    buffer->numChannels = 2;
+    buffer->numFrames = frames;
+    buffer->interleavedData.resize(static_cast<size_t>(frames) * 2);
+    for (uint64_t i = 0; i < frames; ++i) {
+        const float v = 1.0f - static_cast<float>(i) / static_cast<float>(frames);
+        buffer->interleavedData[i * 2] = v;
+        buffer->interleavedData[i * 2 + 1] = v;
+    }
+    return buffer;
+}
+
+/** Sum of squares over the first or last half of a clip's current audio. */
+double halfEnergy(const AudioBufferData& buffer, bool front) {
+    const uint64_t half = buffer.numFrames / 2;
+    const uint64_t begin = front ? 0 : half;
+    const uint64_t end = front ? half : buffer.numFrames;
+    double energy = 0.0;
+    for (uint64_t f = begin; f < end; ++f) {
+        const double s = buffer.interleavedData[f * 2];
+        energy += s * s;
+    }
+    return energy;
+}
+
+/** Resolve the audio a clip currently points at, via the production seam. */
+std::shared_ptr<const AudioBufferData> currentAudio(TrackManager& tm, ClipInstanceID clipId) {
+    const ClipInstance* clip = tm.getPlaylistModel().getClip(clipId);
+    if (!clip) {
+        return nullptr;
+    }
+    ClipRenderService service(tm.getSourceManager(), tm.getPatternManager());
+    return service.resolveClipRegion(*clip).buffer;
+}
+
+struct Fixture {
+    std::shared_ptr<TrackManager> tm;
+    ClipInstanceID clipId;
+    std::string renderDir;
+};
+
+/** Build source -> audio pattern -> clip exactly as the import path does. */
+Fixture makeClipFixture(const std::string& renderDir) {
+    Fixture fx;
+    fx.tm = std::make_shared<TrackManager>();
+    fx.renderDir = renderDir;
+    // Keeps rendered files inside the test's own directory.
+    fx.tm->setRecordingProjectPath(renderDir);
+
+    auto buffer = makeDecayBuffer(2000);
+    const double durationSeconds = buffer->durationSeconds();
+
+    const ClipSourceID sourceId =
+        fx.tm->getSourceManager().createRecordedSource(renderDir + "/source.wav", "source", buffer);
+
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    payload.durationSeconds = durationSeconds;
+    AudioSlice fullSlice;
+    fullSlice.startSamples = 0.0;
+    fullSlice.lengthSamples = static_cast<double>(buffer->numFrames);
+    payload.slices.push_back(fullSlice);
+
+    const double durationBeats = durationSeconds * fx.tm->getPlaylistModel().getBPM() / 60.0;
+    const PatternID patternId = fx.tm->getPatternManager().createAudioPattern("source", durationBeats, payload);
+
+    const PlaylistLaneID laneId = fx.tm->getPlaylistModel().createLane("Lane");
+
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.name = "source";
+    clip.startBeat = 0.0;
+    clip.durationBeats = durationBeats;
+    clip.durationSeconds = durationSeconds;
+    clip.patternId = patternId;
+    clip.edits = ClipEdits::forNewAudioClip();
+    fx.tm->getPlaylistModel().addClip(laneId, clip);
+    fx.clipId = clip.id;
+    return fx;
+}
+
+void testReverseChangesAudioAndUndoRestores(const std::string& dir) {
+    std::printf("reverse: audio flips, undo restores...\n");
+    Fixture fx = makeClipFixture(dir);
+
+    auto before = currentAudio(*fx.tm, fx.clipId);
+    require(before != nullptr, "clip resolves to audio before reverse");
+    if (!before) {
+        return;
+    }
+    const double frontBefore = halfEnergy(*before, true);
+    const double backBefore = halfEnergy(*before, false);
+    require(frontBefore > backBefore * 2.0, "fixture really is front-loaded");
+
+    const PatternID patternBefore = fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId;
+
+    ReverseAudioClipCommand command(*fx.tm, fx.clipId);
+    command.execute();
+
+    require(command.isUndoable(), "reverse reports that it changed something");
+    const PatternID patternAfter = fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId;
+    require(!(patternAfter == patternBefore), "reverse repoints the clip at a new pattern");
+
+    auto after = currentAudio(*fx.tm, fx.clipId);
+    require(after != nullptr, "clip still resolves to audio after reverse");
+    if (after) {
+        // The whole point: the energy must move to the back half.
+        const double frontAfter = halfEnergy(*after, true);
+        const double backAfter = halfEnergy(*after, false);
+        require(backAfter > frontAfter * 2.0, "reversed clip is back-loaded");
+        require(after->numFrames == before->numFrames, "reverse preserves length");
+    }
+
+    command.undo();
+    const PatternID patternUndone = fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId;
+    require(patternUndone == patternBefore, "undo restores the original pattern");
+    auto undone = currentAudio(*fx.tm, fx.clipId);
+    require(undone != nullptr, "clip resolves to audio after undo");
+    if (undone) {
+        require(halfEnergy(*undone, true) > halfEnergy(*undone, false) * 2.0, "undo restores front-loaded audio");
+    }
+
+    // Redo must not render a second file; it reuses the detached pattern.
+    command.redo();
+    require(fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId == patternAfter,
+            "redo returns the same rendered pattern");
+}
+
+void testCommitBakesGainAndResetsEdits(const std::string& dir) {
+    std::printf("commit edits: gain is baked and edits reset...\n");
+    Fixture fx = makeClipFixture(dir);
+
+    ClipEdits edits = fx.tm->getPlaylistModel().getClip(fx.clipId)->edits;
+    edits.gainLinear = 0.25f;
+    edits.fadeInBeats = 0.0f;
+    edits.fadeOutBeats = 0.0f;
+    fx.tm->getPlaylistModel().setClipEdits(fx.clipId, edits);
+
+    auto before = currentAudio(*fx.tm, fx.clipId);
+    require(before != nullptr, "clip resolves before commit");
+    if (!before) {
+        return;
+    }
+    const float peakBefore = ClipRenderService::peakMagnitude(*before);
+
+    CommitAudioClipEditsCommand command(*fx.tm, fx.clipId);
+    command.execute();
+    require(command.isUndoable(), "commit reports that it changed something");
+
+    auto after = currentAudio(*fx.tm, fx.clipId);
+    require(after != nullptr, "clip resolves after commit");
+    if (after) {
+        const float peakAfter = ClipRenderService::peakMagnitude(*after);
+        // 0.25 gain baked in: the committed audio is a quarter as loud.
+        require(std::fabs(peakAfter - peakBefore * 0.25f) < 0.01f, "commit bakes the clip gain into the audio");
+    }
+
+    const ClipEdits afterEdits = fx.tm->getPlaylistModel().getClip(fx.clipId)->edits;
+    require(std::fabs(afterEdits.gainLinear - 1.0f) < 1.0e-6f, "commit resets gain to unity so it is not applied twice");
+
+    command.undo();
+    const ClipEdits undoneEdits = fx.tm->getPlaylistModel().getClip(fx.clipId)->edits;
+    require(std::fabs(undoneEdits.gainLinear - 0.25f) < 1.0e-6f, "undo restores the original gain");
+    auto undone = currentAudio(*fx.tm, fx.clipId);
+    if (undone) {
+        require(std::fabs(ClipRenderService::peakMagnitude(*undone) - peakBefore) < 1.0e-4f,
+                "undo restores the original audio");
+    }
+}
+
+void testMidiClipIsRefused(const std::string& dir) {
+    std::printf("reverse: a non-audio clip is refused, not corrupted...\n");
+    Fixture fx = makeClipFixture(dir);
+
+    // Point the clip at a MIDI pattern; reverse has nothing to render.
+    const PatternID midiPattern = fx.tm->getPatternManager().createMidiPattern("midi", 4.0, MidiPayload{});
+    fx.tm->getPlaylistModel().setClipPattern(fx.clipId, midiPattern);
+
+    ReverseAudioClipCommand command(*fx.tm, fx.clipId);
+    command.execute();
+
+    require(!command.isUndoable(), "reversing a MIDI clip reports that nothing changed");
+    require(fx.tm->getPlaylistModel().getClip(fx.clipId)->patternId == midiPattern,
+            "a refused reverse leaves the clip pointing where it was");
+}
+
+} // namespace
+
+int main() {
+    std::printf("=== RenderAudioClipCommand ===\n");
+
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() / "aestra_render_clip_test";
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    fs::create_directories(dir, ec);
+    if (ec) {
+        std::printf("FAILED: could not create test directory\n");
+        return EXIT_FAILURE;
+    }
+
+    testReverseChangesAudioAndUndoRestores(dir.string());
+    testCommitBakesGainAndResetsEdits(dir.string());
+    testMidiClipIsRefused(dir.string());
+
+    fs::remove_all(dir, ec);
+
+    if (g_failures != 0) {
+        std::printf("FAILED: %d check(s)\n", g_failures);
+        return EXIT_FAILURE;
+    }
+    std::printf("All RenderAudioClipCommand checks passed.\n");
+    return EXIT_SUCCESS;
+}

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -278,4 +278,26 @@ if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins AND TARGET AestraRumbl
     set_tests_properties(RumbleUnauthorizedOutputSafetyTest PROPERTIES LABELS "plugins;rumble;license;safety")
 endif()
 
+if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/ClipRenderServiceTest.cpp")
+    add_executable(ClipRenderServiceTest Commands/ClipRenderServiceTest.cpp)
+    target_link_libraries(ClipRenderServiceTest PRIVATE AestraAudioCore)
+    target_include_directories(ClipRenderServiceTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ClipRenderServiceTest COMMAND ClipRenderServiceTest)
+    set_tests_properties(ClipRenderServiceTest PROPERTIES LABELS "commands;audio;clip-render")
+endif()
+
+if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/RenderAudioClipCommandTest.cpp")
+    add_executable(RenderAudioClipCommandTest Commands/RenderAudioClipCommandTest.cpp)
+    target_link_libraries(RenderAudioClipCommandTest PRIVATE AestraAudioCore)
+    target_include_directories(RenderAudioClipCommandTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME RenderAudioClipCommandTest COMMAND RenderAudioClipCommandTest)
+    set_tests_properties(RenderAudioClipCommandTest PROPERTIES LABELS "commands;audio;clip-render;undo")
+endif()
+
 message(STATUS "Commands tests added - Phase 2 undo/redo system")


### PR DESCRIPTION
First slice of the audio-transformation layer: the primitive that turns a clip into a new, committed source file, and the first two operations built on it.

## What this adds

**`ClipRenderService`** — resolves a clip down to the frames it actually plays (`clip → pattern → audio payload → source buffer`), transforms them, writes a WAV, and registers a new source and audio pattern.

Its scope is deliberately narrow and the header says so: it reads only a clip's own source buffer and its clip-local edits. **Freeze, stem printing and bus printing must not be built on this.** Those need plugins, automation, sends, sidechains, routing, PDC and an output scope — none of which exist at this layer. They belong to a separate range/graph renderer. The two can share the WAV writer and source registration, but not rendering semantics.

**`ReverseAudioClipCommand`** and **`CommitAudioClipEditsCommand`** follow the detach/reinsert model `MakeAudioClipUniqueCommand` already uses: undo restores the original pattern and detaches the rendered one, so redo never re-renders and the file on disk stays referenced.

`CommitAudioClipEditsCommand` is named for what it does — it bakes only clip-local gain and fades, and resets those edits to unity so they cannot apply twice. **"Bounce in Place" is deliberately reserved** for the later graph-level operation, so the two never collapse into one ambiguous name. UI button reads **Commit**.

## Phantom fields removed from `ClipEdits`

- `pitchSemitones` and `timeStretchRatio` were declared and compared in the panel's equality operator, but never read by any renderer, never serialized, and never written by any UI. They advertised capability that did not exist.
- `gain` duplicated `gainLinear`. It had four writers and no readers, while display, render and serialization all used `gainLinear` — so the two silently diverged across a save/load round trip.

## Verification

- **221/221 tests pass**, full build clean, app target builds.
- `ClipRenderServiceTest` — transform-level checks on bare buffers (region extraction and clamping, frame-wise reverse, gain, fade ramps including the overlapping case, peak).
- `RenderAudioClipCommandTest` — end-to-end: builds source/pattern/clip the way the import path does, then proves reverse moves the clip's energy to its back half, commit bakes gain into the audio, undo restores both, redo reuses the rendered pattern, and a MIDI clip is refused rather than corrupted.
- **Both gates were verified by sabotage.** Reversing the flat sample array instead of whole frames fails the transform test (L/R swap: `expected 7.0, got -7.0`); making reverse a no-op fails the integration test. A passing test never seen failing isn't evidence.
- A repository-wide build caught `UnitMixerRoutingTest` still using `edits.gain` — targeted builds had never recompiled it.

## Not in this PR

- **Consolidate/glue** — needs multi-clip mixing and a lane range selection; different shape from these single-clip ops.
- **Muse verbs** for these operations. They were written and deliberately pulled back out: clip ids returned by `list_clips` are UUID hex strings that every clip verb rejects as non-integer, so the verbs would have advertised operations an agent cannot invoke — the same phantom-capability failure this PR removes from the clip model. Muse clip identity/import is the next slice; the verbs land after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** `ClipEdits` now uses only `gainLinear`. The public `gain`, `pitchSemitones`, and `timeStretchRatio` fields were removed.
- Added `ClipRenderService` to extract, reverse, apply gain and fades, measure peaks, and write rendered WAV sources.
- Added `ReverseAudioClipCommand` and `CommitAudioClipEditsCommand` with undo/redo support. Redo reuses rendered patterns.
- Added editor controls for Reverse and Commit. Commit bakes gain and fades, then resets the clip edits.
- Added validation for source regions, non-finite values, MIDI rejection, render cleanup, and unique output paths.
- Added unit and end-to-end tests for rendering, transformations, persistence, and undo/redo behavior.
- Graph-level rendering, consolidate/glue, and Muse verbs remain outside this slice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->