### PR TITLE
Muse audio-clip round-trip integrity

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -239,6 +239,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/CommandTransaction.cpp
     src/Commands/SplitClipCommand.cpp
     src/Commands/RenderAudioClipCommand.cpp
+    src/Commands/ImportAudioClipCommand.cpp
     src/Commands/AddClipCommand.cpp
     src/Commands/CreateLaneCommand.cpp
     src/Commands/AddNoteCommand.cpp

--- a/AestraAudio/include/Commands/ImportAudioClipCommand.h
+++ b/AestraAudio/include/Commands/ImportAudioClipCommand.h
@@ -1,0 +1,68 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/ClipInstance.h"
+#include "Models/ClipSource.h"
+#include "Models/PatternSource.h"
+
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+
+/**
+ * @brief Import a decoded audio file as a playable clip on a lane.
+ *
+ * Mirrors what the drag-and-drop import does, and for the same reason: a clip
+ * that names a file but carries no pattern is a silent, structurally invalid
+ * object. The decode happens before the command is built, so an unreadable or
+ * unsupported file is reported as a precise error and nothing is created.
+ *
+ * Path ownership follows the UI: the source references the file where it lies
+ * (path is SourceManager's dedupe key) and is never copied into the project.
+ *
+ * execute() creates the audio pattern and places the clip; undo() removes the
+ * clip and detaches the pattern, so redo reuses it rather than re-decoding.
+ */
+class ImportAudioClipCommand final : public ICommand {
+public:
+    ImportAudioClipCommand(TrackManager& manager, PlaylistLaneID laneId, ClipSourceID sourceId, std::string displayName,
+                           double startBeat, double durationSeconds, double durationBeats, uint64_t sourceFrames)
+        : m_manager(manager), m_laneId(laneId), m_sourceId(sourceId), m_displayName(std::move(displayName)),
+          m_startBeat(startBeat), m_durationSeconds(durationSeconds), m_durationBeats(durationBeats),
+          m_sourceFrames(sourceFrames) {}
+
+    void execute() override;
+    void undo() override;
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Import Audio Clip"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+    bool isUndoable() const override { return m_executed; }
+
+    /** @brief Id of the placed clip, for reporting back to the caller. */
+    ClipInstanceID getClipId() const { return m_clipId; }
+
+private:
+    TrackManager& m_manager;
+    PlaylistLaneID m_laneId;
+    ClipSourceID m_sourceId;
+    std::string m_displayName;
+    double m_startBeat{0.0};
+    double m_durationSeconds{0.0};
+    double m_durationBeats{0.0};
+    uint64_t m_sourceFrames{0};
+
+    ClipInstanceID m_clipId;
+    PatternID m_patternId;
+    std::unique_ptr<PatternSource> m_detachedPattern;
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/ImportAudioClipCommand.h
+++ b/AestraAudio/include/Commands/ImportAudioClipCommand.h
@@ -19,22 +19,31 @@ class TrackManager;
  *
  * Mirrors what the drag-and-drop import does, and for the same reason: a clip
  * that names a file but carries no pattern is a silent, structurally invalid
- * object. The decode happens before the command is built, so an unreadable or
- * unsupported file is reported as a precise error and nothing is created.
+ * object.
+ *
+ * The command owns every project mutation. Its factory only decodes and
+ * validates, then hands the finished buffer here — so an unreadable or
+ * unsupported file is refused before anything is constructed, and nothing
+ * touches the project until execute() runs inside the history. Registering the
+ * source in the factory instead would mutate state no undo entry covers, which
+ * breaks down as soon as batches, previews or dry runs enter the picture.
  *
  * Path ownership follows the UI: the source references the file where it lies
  * (path is SourceManager's dedupe key) and is never copied into the project.
  *
- * execute() creates the audio pattern and places the clip; undo() removes the
- * clip and detaches the pattern, so redo reuses it rather than re-decoding.
+ * Rollback is asymmetric on purpose. If the first execute() fails partway, a
+ * source this command introduced is taken back out, because nothing else has
+ * seen it. A normal undo keeps both the source and the detached pattern, so
+ * redo is instant and never decodes twice.
  */
 class ImportAudioClipCommand final : public ICommand {
 public:
-    ImportAudioClipCommand(TrackManager& manager, PlaylistLaneID laneId, ClipSourceID sourceId, std::string displayName,
-                           double startBeat, double durationSeconds, double durationBeats, uint64_t sourceFrames)
-        : m_manager(manager), m_laneId(laneId), m_sourceId(sourceId), m_displayName(std::move(displayName)),
-          m_startBeat(startBeat), m_durationSeconds(durationSeconds), m_durationBeats(durationBeats),
-          m_sourceFrames(sourceFrames) {}
+    ImportAudioClipCommand(TrackManager& manager, PlaylistLaneID laneId, std::string filePath, std::string displayName,
+                           std::shared_ptr<AudioBufferData> buffer, double startBeat, double durationSeconds,
+                           double durationBeats)
+        : m_manager(manager), m_laneId(laneId), m_filePath(std::move(filePath)),
+          m_displayName(std::move(displayName)), m_buffer(std::move(buffer)), m_startBeat(startBeat),
+          m_durationSeconds(durationSeconds), m_durationBeats(durationBeats) {}
 
     void execute() override;
     void undo() override;
@@ -49,18 +58,24 @@ public:
     ClipInstanceID getClipId() const { return m_clipId; }
 
 private:
+    /** @brief Unwind a partial first execute(): no clip, no pattern, no new source. */
+    void rollbackFailedFirstExecute();
+
     TrackManager& m_manager;
     PlaylistLaneID m_laneId;
-    ClipSourceID m_sourceId;
+    std::string m_filePath;
     std::string m_displayName;
+    std::shared_ptr<AudioBufferData> m_buffer;
     double m_startBeat{0.0};
     double m_durationSeconds{0.0};
     double m_durationBeats{0.0};
-    uint64_t m_sourceFrames{0};
 
     ClipInstanceID m_clipId;
+    ClipSourceID m_sourceId;
     PatternID m_patternId;
     std::unique_ptr<PatternSource> m_detachedPattern;
+    /** True when this command is what put m_sourceId into the project. */
+    bool m_createdSource{false};
     bool m_executed{false};
 };
 

--- a/AestraAudio/include/Commands/MuseGrammar.h
+++ b/AestraAudio/include/Commands/MuseGrammar.h
@@ -7,7 +7,13 @@
 namespace Aestra {
 namespace Audio {
 
-enum class FlagType { String, Int, Float, Bool };
+/**
+ * Id is the canonical 32-hex-char object identifier that queries emit
+ * (AestraUUID::toString). It exists so an id an agent reads back from
+ * list_clips can be passed to a verb unchanged — the one representation, in
+ * both directions. Int is for indexes and counts, never for object identity.
+ */
+enum class FlagType { String, Int, Float, Bool, Id };
 enum class CommandCategory { Transport, Track, Clip, Unit, Pattern };
 
 struct FlagSchema {

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -136,6 +136,46 @@ public:
     }
 
     /**
+     * @brief Look up an existing source by file path without creating one.
+     *
+     * Lets a caller tell "this file was already in the project" from "I am the
+     * one who introduced it", which decides whether it may be taken back out
+     * again on failure.
+     * @return An invalid ID when no source holds that path.
+     */
+    ClipSourceID findSourceByPath(const std::string& filePath) const {
+        auto it = m_pathToId.find(filePath);
+        return it != m_pathToId.end() ? it->second : ClipSourceID{};
+    }
+
+    /**
+     * @brief Remove a source nothing references yet.
+     *
+     * Only safe for a source whose registration is being rolled back before it
+     * ever reached a pattern or a built AudioGraph — an import that failed
+     * partway. Never call it to "clean up" a source a project object still
+     * points at.
+     *
+     * Same reasoning as clear(): buffers are co-owned via
+     * shared_ptr<AudioBufferData>, so any in-flight graph keeps its audio
+     * alive regardless.
+     * @return True when a source was removed.
+     */
+    bool removeSource(ClipSourceID id) {
+        auto it = m_sources.find(id.value);
+        if (it == m_sources.end()) {
+            return false;
+        }
+        const std::string path = it->second ? it->second->getFilePath() : std::string{};
+        m_sources.erase(it);
+        auto pathIt = m_pathToId.find(path);
+        if (pathIt != m_pathToId.end() && pathIt->second.value == id.value) {
+            m_pathToId.erase(pathIt);
+        }
+        return true;
+    }
+
+    /**
      * @brief Clear all sources
      *
      * No mutex required: ClipSource buffers are now co-owned via

--- a/AestraAudio/src/Commands/CommandParser.cpp
+++ b/AestraAudio/src/Commands/CommandParser.cpp
@@ -1,4 +1,6 @@
 #include "Commands/CommandParser.h"
+
+#include "AestraUUID.h"
 #include "Commands/ClonePatternCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Commands/CommandRegistry.h"
@@ -275,6 +277,21 @@ bool CommandParser::convertAndValidateValue(
     switch (flag.type) {
     case FlagType::String:
         return true;
+
+    case FlagType::Id: {
+        // Exactly the form queries print, so a listed id round-trips verbatim.
+        AestraUUID parsed;
+        if (!AestraUUID::tryParse(rawValue, parsed)) {
+            outError = "flag --" + flag.name + " requires a 32-character hex id as returned by the list_* queries, got: " +
+                       rawValue;
+            return false;
+        }
+        if (parsed.low == 0 && parsed.high == 0) {
+            outError = "flag --" + flag.name + " is the null id, which addresses no object: " + rawValue;
+            return false;
+        }
+        return true;
+    }
 
     case FlagType::Int: {
         char* end = nullptr;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -302,10 +302,11 @@ void CommandRegistry::initialize() {
         return std::make_unique<CreateLaneCommand>(*pm, name);
     });
 
-    // Imports the file for real: decode, register the source, then let the
-    // command create the pattern and place the clip. This used to record the
-    // path as the clip's name and nothing else, producing a silent clip with
-    // no pattern — a promise of import that the object never kept.
+    // Imports the file for real. This used to record the path as the clip's
+    // name and nothing else, producing a silent clip with no pattern — a
+    // promise of import that the object never kept. The decode happens here so
+    // a bad file is refused precisely; everything that touches the project
+    // happens inside ImportAudioClipCommand.
     reg.registerCommand("add_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
         TrackManager* tm = ctx.trackManager;
         if (!tm) return nullptr;
@@ -352,18 +353,13 @@ void CommandRegistry::initialize() {
             durationBeats <= 0.0)
             return CommandRegistry::fail("audio file has no usable duration: " + filePath);
 
-        // Registered only once the decode succeeded, so a bad file leaves no
-        // half-built source behind. Path is the dedupe key, as in the UI: the
-        // file is referenced where it lies and never copied into the project.
+        // The factory stops here: it decodes and validates, but registers
+        // nothing. Every project mutation belongs to the command, so the whole
+        // import is one entry the history owns and batches/dry runs can trust.
         const std::string displayName = std::filesystem::path(filePath).stem().string();
-        const uint64_t sourceFrames = buffer->numFrames;
-        const ClipSourceID sourceId = tm->getSourceManager().createRecordedSource(filePath, displayName, buffer);
-        if (!sourceId.isValid())
-            return CommandRegistry::fail("could not register the decoded audio source for: " + filePath);
-
         const double startBeat = (*barOpt - 1) * 4.0;
-        return std::make_unique<ImportAudioClipCommand>(*tm, laneId, sourceId, displayName, startBeat, durationSeconds,
-                                                        durationBeats, sourceFrames);
+        return std::make_unique<ImportAudioClipCommand>(*tm, laneId, filePath, displayName, std::move(buffer),
+                                                        startBeat, durationSeconds, durationBeats);
     });
 
     reg.registerCommand("delete_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -16,6 +16,9 @@
 #include "Commands/QuantizePatternCommand.h"
 #include "Commands/SetStepsCommand.h"
 #include "Commands/TransposePatternCommand.h"
+#include "Commands/CreateLaneCommand.h"
+#include "Commands/ImportAudioClipCommand.h"
+#include "IO/MiniAudioDecoder.h"
 #include "Commands/RemoveClipCommand.h"
 #include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
@@ -106,6 +109,19 @@ std::optional<uint64_t> safeStoull(std::string_view s) {
     } catch (const std::exception&) {
         return std::nullopt;
     }
+}
+
+/**
+ * Parse the canonical 32-hex-char object id the list_* queries print.
+ *
+ * Both halves matter: the old code assigned only `low`, so two ids sharing a
+ * low word addressed the same object and no listed id could be used at all.
+ */
+std::optional<AestraUUID> parseObjectId(std::string_view s) {
+    AestraUUID parsed;
+    if (!AestraUUID::tryParse(std::string(s), parsed)) return std::nullopt;
+    if (parsed.low == 0 && parsed.high == 0) return std::nullopt;
+    return parsed;
 }
 
 // Reason recorded by the most recent factory refusal (see CommandRegistry::fail).
@@ -277,9 +293,23 @@ void CommandRegistry::initialize() {
     });
 
     // ===== Clip (5) =====
-    reg.registerCommand("add_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+    reg.registerCommand("add_lane", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
         PlaylistModel* pm = ctx.trackManager ? &ctx.trackManager->getPlaylistModel() : nullptr;
         if (!pm) return nullptr;
+        std::string name;
+        auto nameIt = flags.find("name");
+        if (nameIt != flags.end()) name = nameIt->second;
+        return std::make_unique<CreateLaneCommand>(*pm, name);
+    });
+
+    // Imports the file for real: decode, register the source, then let the
+    // command create the pattern and place the clip. This used to record the
+    // path as the clip's name and nothing else, producing a silent clip with
+    // no pattern — a promise of import that the object never kept.
+    reg.registerCommand("add_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
+        PlaylistModel* pm = &tm->getPlaylistModel();
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -289,26 +319,51 @@ void CommandRegistry::initialize() {
         auto barOpt = safeStoi(*barRaw);
         if (!barOpt) return nullptr;
         if (*trackOpt < 0) return nullptr;
+        auto fileIt = flags.find("file");
+        if (fileIt == flags.end()) return nullptr;
+        const std::string& filePath = fileIt->second;
 
         PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
         if (!laneId.isValid())
             return CommandRegistry::fail("track " + std::string(*trackRaw) + " has no playlist lane");
 
-        ClipInstance clip;
-        clip.startBeat = (*barOpt - 1) * 4.0;
-        clip.durationBeats = 4.0;
-        auto fileIt = flags.find("file");
-        if (fileIt == flags.end()) return nullptr;
-        clip.name = fileIt->second;
+        std::error_code ec;
+        if (!std::filesystem::exists(filePath, ec) || ec)
+            return CommandRegistry::fail("no such audio file: " + filePath);
 
-        auto srcIt = flags.find("source");
-        if (srcIt != flags.end()) {
-            auto srcOpt = safeStoull(srcIt->second);
-            if (!srcOpt) return nullptr;
-            clip.sourceId = *srcOpt;
-        }
+        // Same decoder the UI import uses; there is no Muse-specific importer.
+        std::vector<float> decoded;
+        uint32_t sampleRate = 0;
+        uint32_t numChannels = 0;
+        if (!decodeAudioFile(filePath, decoded, sampleRate, numChannels))
+            return CommandRegistry::fail("could not decode audio file (unsupported or corrupt): " + filePath);
+        if (decoded.empty() || sampleRate == 0 || numChannels == 0)
+            return CommandRegistry::fail("audio file decoded to nothing: " + filePath);
 
-        return std::make_unique<AddClipCommand>(*pm, laneId, clip);
+        auto buffer = std::make_shared<AudioBufferData>();
+        buffer->interleavedData = std::move(decoded);
+        buffer->sampleRate = sampleRate;
+        buffer->numChannels = numChannels;
+        buffer->numFrames = buffer->interleavedData.size() / numChannels;
+
+        const double durationSeconds = buffer->durationSeconds();
+        const double durationBeats = pm->secondsToBeats(durationSeconds);
+        if (!std::isfinite(durationSeconds) || durationSeconds <= 0.0 || !std::isfinite(durationBeats) ||
+            durationBeats <= 0.0)
+            return CommandRegistry::fail("audio file has no usable duration: " + filePath);
+
+        // Registered only once the decode succeeded, so a bad file leaves no
+        // half-built source behind. Path is the dedupe key, as in the UI: the
+        // file is referenced where it lies and never copied into the project.
+        const std::string displayName = std::filesystem::path(filePath).stem().string();
+        const uint64_t sourceFrames = buffer->numFrames;
+        const ClipSourceID sourceId = tm->getSourceManager().createRecordedSource(filePath, displayName, buffer);
+        if (!sourceId.isValid())
+            return CommandRegistry::fail("could not register the decoded audio source for: " + filePath);
+
+        const double startBeat = (*barOpt - 1) * 4.0;
+        return std::make_unique<ImportAudioClipCommand>(*tm, laneId, sourceId, displayName, startBeat, durationSeconds,
+                                                        durationBeats, sourceFrames);
     });
 
     reg.registerCommand("delete_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
@@ -316,11 +371,10 @@ void CommandRegistry::initialize() {
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
-        auto idOpt = safeStoull(*idRaw);
-        if (!idOpt) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
 
-        ClipInstanceID clipId;
-        clipId.low = *idOpt;
+        ClipInstanceID clipId(*idOpt);
         return std::make_unique<RemoveClipCommand>(*pm, clipId);
     });
 
@@ -329,8 +383,8 @@ void CommandRegistry::initialize() {
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
-        auto idOpt = safeStoull(*idRaw);
-        if (!idOpt) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
         auto trackRaw = requireFlag(flags, "track");
         if (!trackRaw) return nullptr;
         auto trackOpt = safeStoi(*trackRaw);
@@ -341,8 +395,7 @@ void CommandRegistry::initialize() {
         auto startOpt = safeStof(*startRaw);
         if (!startOpt) return nullptr;
 
-        ClipInstanceID clipId;
-        clipId.low = *idOpt;
+        ClipInstanceID clipId(*idOpt);
         PlaylistLaneID laneId = pm->getLaneId(static_cast<size_t>(*trackOpt));
         return std::make_unique<MoveClipCommand>(*pm, clipId, *startOpt, laneId);
     });
@@ -352,15 +405,14 @@ void CommandRegistry::initialize() {
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
-        auto idOpt = safeStoull(*idRaw);
-        if (!idOpt) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
         auto barRaw = requireFlag(flags, "bar");
         if (!barRaw) return nullptr;
         auto barOpt = safeStoi(*barRaw);
         if (!barOpt) return nullptr;
 
-        ClipInstanceID clipId;
-        clipId.low = *idOpt;
+        ClipInstanceID clipId(*idOpt);
         return std::make_unique<DuplicateClipCommand>(*pm, clipId, static_cast<double>(*barOpt));
     });
 
@@ -369,8 +421,8 @@ void CommandRegistry::initialize() {
         if (!pm) return nullptr;
         auto idRaw = requireFlag(flags, "id");
         if (!idRaw) return nullptr;
-        auto idOpt = safeStoull(*idRaw);
-        if (!idOpt) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
         auto startRaw = requireFlag(flags, "start");
         if (!startRaw) return nullptr;
         auto startOpt = safeStof(*startRaw);
@@ -380,8 +432,7 @@ void CommandRegistry::initialize() {
         auto endOpt = safeStof(*endRaw);
         if (!endOpt) return nullptr;
 
-        ClipInstanceID clipId;
-        clipId.low = *idOpt;
+        ClipInstanceID clipId(*idOpt);
         return std::make_unique<TrimClipCommand>(*pm, clipId, *startOpt, *endOpt);
     });
 

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -329,8 +329,13 @@ void CommandRegistry::initialize() {
         if (!laneId.isValid())
             return CommandRegistry::fail("track " + std::string(*trackRaw) + " has no playlist lane");
 
+        // "cannot be read" and "is not there" are different problems for
+        // whoever has to fix it, so do not collapse them into one message.
         std::error_code ec;
-        if (!std::filesystem::exists(filePath, ec) || ec)
+        const bool present = std::filesystem::exists(filePath, ec);
+        if (ec)
+            return CommandRegistry::fail("could not read the path (" + ec.message() + "): " + filePath);
+        if (!present)
             return CommandRegistry::fail("no such audio file: " + filePath);
 
         // Same decoder the UI import uses; there is no Muse-specific importer.

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -20,6 +20,7 @@
 #include "Commands/ImportAudioClipCommand.h"
 #include "IO/MiniAudioDecoder.h"
 #include "Commands/RemoveClipCommand.h"
+#include "Commands/RenderAudioClipCommand.h"
 #include "Commands/RemoveNoteCommand.h"
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetPanCommand.h"
@@ -372,6 +373,25 @@ void CommandRegistry::initialize() {
 
         ClipInstanceID clipId(*idOpt);
         return std::make_unique<RemoveClipCommand>(*pm, clipId);
+    });
+
+    reg.registerCommand("reverse_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        if (!ctx.trackManager) return nullptr;
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
+        return std::make_unique<ReverseAudioClipCommand>(*ctx.trackManager, ClipInstanceID(*idOpt));
+    });
+
+    reg.registerCommand("commit_clip_edits", [](const auto& flags,
+                                                const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        if (!ctx.trackManager) return nullptr;
+        auto idRaw = requireFlag(flags, "id");
+        if (!idRaw) return nullptr;
+        auto idOpt = parseObjectId(*idRaw);
+        if (!idOpt) return CommandRegistry::fail("not a clip id: " + std::string(*idRaw));
+        return std::make_unique<CommitAudioClipEditsCommand>(*ctx.trackManager, ClipInstanceID(*idOpt));
     });
 
     reg.registerCommand("move_clip", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {

--- a/AestraAudio/src/Commands/HostVerbRegistry.cpp
+++ b/AestraAudio/src/Commands/HostVerbRegistry.cpp
@@ -1,5 +1,6 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "Commands/HostVerbRegistry.h"
+#include "AestraUUID.h"
 
 #include <algorithm>
 #include <cctype>
@@ -41,6 +42,20 @@ bool valueMatches(const HostVerbArg& arg, const JSON& value, std::string& outErr
             return false;
         }
         return true;
+    case FlagType::Id: {
+        // Canonical 32-hex-char object id, exactly as the list_* queries print
+        // it, so a listed id can be handed straight back.
+        if (!value.isString()) {
+            outError = "arg '" + arg.name + "' must be a 32-character hex id string";
+            return false;
+        }
+        AestraUUID parsed;
+        if (!AestraUUID::tryParse(value.asString(), parsed) || (parsed.low == 0 && parsed.high == 0)) {
+            outError = "arg '" + arg.name + "' must be a 32-character hex id as returned by the list_* queries";
+            return false;
+        }
+        return true;
+    }
     case FlagType::Int:
     case FlagType::Float: {
         if (!value.isNumber()) {
@@ -81,6 +96,7 @@ const char* HostVerbRegistry::argTypeName(FlagType type) {
     case FlagType::Int:    return "int";
     case FlagType::Float:  return "float";
     case FlagType::Bool:   return "bool";
+    case FlagType::Id:     return "id";
     }
     return "string";
 }

--- a/AestraAudio/src/Commands/ImportAudioClipCommand.cpp
+++ b/AestraAudio/src/Commands/ImportAudioClipCommand.cpp
@@ -4,18 +4,68 @@
 #include "AestraLog.h"
 #include "Models/TrackManager.h"
 
-#include <cmath>
-
 namespace Aestra {
 namespace Audio {
+
+void ImportAudioClipCommand::rollbackFailedFirstExecute() {
+    auto& patterns = m_manager.getPatternManager();
+    if (m_patternId.isValid()) {
+        m_detachedPattern = patterns.detachPattern(m_patternId);
+        m_detachedPattern.reset();
+        m_patternId = PatternID{};
+    }
+    // Only a source this command introduced may be withdrawn, and only here:
+    // nothing has referenced it yet. A source the project already had stays.
+    if (m_createdSource && m_sourceId.isValid()) {
+        m_manager.getSourceManager().removeSource(m_sourceId);
+        m_sourceId = ClipSourceID{};
+        m_createdSource = false;
+    }
+}
 
 void ImportAudioClipCommand::execute() {
     if (m_executed) {
         return;
     }
 
+    auto& sources = m_manager.getSourceManager();
     auto& patterns = m_manager.getPatternManager();
     auto& playlist = m_manager.getPlaylistModel();
+
+    const bool firstRun = !m_sourceId.isValid();
+
+    // Register the decoded audio here rather than in the factory, so the whole
+    // import is one mutation the history owns.
+    if (firstRun) {
+        if (!m_buffer || !m_buffer->isValid()) {
+            Log::error("[ImportAudioClipCommand] No decoded audio to import: " + m_filePath);
+            return;
+        }
+        const ClipSourceID existing = sources.findSourceByPath(m_filePath);
+        if (existing.isValid()) {
+            // Already in the project (path is the dedupe key): adopt it, and
+            // never withdraw it on failure.
+            m_sourceId = existing;
+            m_createdSource = false;
+        } else {
+            m_sourceId = sources.createRecordedSource(m_filePath, m_displayName, m_buffer);
+            if (!m_sourceId.isValid()) {
+                Log::error("[ImportAudioClipCommand] Could not register the decoded source for: " + m_filePath);
+                return;
+            }
+            m_createdSource = true;
+        }
+    }
+
+    const ClipSource* source = sources.getSource(m_sourceId);
+    const uint64_t sourceFrames = source ? source->getNumFrames() : 0;
+    if (sourceFrames == 0) {
+        Log::error("[ImportAudioClipCommand] The registered source carries no audio: " + m_filePath);
+        if (firstRun) {
+            rollbackFailedFirstExecute();
+        }
+        return;
+    }
 
     if (m_detachedPattern) {
         // Redo: the pattern already describes this import, so put it back
@@ -29,12 +79,15 @@ void ImportAudioClipCommand::execute() {
         payload.durationSeconds = m_durationSeconds;
         AudioSlice fullSlice;
         fullSlice.startSamples = 0.0;
-        fullSlice.lengthSamples = static_cast<double>(m_sourceFrames);
+        fullSlice.lengthSamples = static_cast<double>(sourceFrames);
         payload.slices.push_back(fullSlice);
 
         m_patternId = patterns.createAudioPattern(m_displayName, m_durationBeats, payload);
         if (!m_patternId.isValid()) {
             Log::error("[ImportAudioClipCommand] Could not create the audio pattern for: " + m_displayName);
+            if (firstRun) {
+                rollbackFailedFirstExecute();
+            }
             return;
         }
     }
@@ -51,9 +104,13 @@ void ImportAudioClipCommand::execute() {
 
     const ClipInstanceID placed = playlist.addClip(m_laneId, clip);
     if (!placed.isValid() || !playlist.getClip(placed)) {
-        // Leave nothing behind: the pattern only existed for this clip.
-        m_detachedPattern = patterns.detachPattern(m_patternId);
         Log::error("[ImportAudioClipCommand] Could not place the imported clip on its lane.");
+        if (firstRun) {
+            rollbackFailedFirstExecute();
+        } else {
+            // A failed redo keeps the source: undo is what put it in reach.
+            m_detachedPattern = patterns.detachPattern(m_patternId);
+        }
         return;
     }
 
@@ -72,8 +129,8 @@ void ImportAudioClipCommand::undo() {
     if (playlist.getClip(m_clipId)) {
         return;
     }
-    // Detach rather than remove so redo reuses this pattern and the decoded
-    // source stays referenced.
+    // Detach rather than remove, and keep the source: redo reuses both instead
+    // of decoding the file a second time.
     m_detachedPattern = m_manager.getPatternManager().detachPattern(m_patternId);
     m_manager.markModified();
     m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);

--- a/AestraAudio/src/Commands/ImportAudioClipCommand.cpp
+++ b/AestraAudio/src/Commands/ImportAudioClipCommand.cpp
@@ -1,0 +1,84 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/ImportAudioClipCommand.h"
+
+#include "AestraLog.h"
+#include "Models/TrackManager.h"
+
+#include <cmath>
+
+namespace Aestra {
+namespace Audio {
+
+void ImportAudioClipCommand::execute() {
+    if (m_executed) {
+        return;
+    }
+
+    auto& patterns = m_manager.getPatternManager();
+    auto& playlist = m_manager.getPlaylistModel();
+
+    if (m_detachedPattern) {
+        // Redo: the pattern already describes this import, so put it back
+        // rather than minting a second one for the same audio.
+        if (!patterns.reinsertPattern(m_detachedPattern)) {
+            return;
+        }
+    } else {
+        AudioSlicePayload payload;
+        payload.audioSourceId = m_sourceId;
+        payload.durationSeconds = m_durationSeconds;
+        AudioSlice fullSlice;
+        fullSlice.startSamples = 0.0;
+        fullSlice.lengthSamples = static_cast<double>(m_sourceFrames);
+        payload.slices.push_back(fullSlice);
+
+        m_patternId = patterns.createAudioPattern(m_displayName, m_durationBeats, payload);
+        if (!m_patternId.isValid()) {
+            Log::error("[ImportAudioClipCommand] Could not create the audio pattern for: " + m_displayName);
+            return;
+        }
+    }
+
+    ClipInstance clip;
+    clip.id = m_clipId.isValid() ? m_clipId : ClipInstanceID::generate();
+    clip.name = m_displayName;
+    clip.startBeat = m_startBeat;
+    clip.durationBeats = m_durationBeats;
+    clip.durationSeconds = m_durationSeconds;
+    clip.patternId = m_patternId;
+    clip.sourceId = m_patternId.value;
+    clip.edits = ClipEdits::forNewAudioClip();
+
+    const ClipInstanceID placed = playlist.addClip(m_laneId, clip);
+    if (!placed.isValid() || !playlist.getClip(placed)) {
+        // Leave nothing behind: the pattern only existed for this clip.
+        m_detachedPattern = patterns.detachPattern(m_patternId);
+        Log::error("[ImportAudioClipCommand] Could not place the imported clip on its lane.");
+        return;
+    }
+
+    m_clipId = placed;
+    m_manager.markModified();
+    m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = true;
+}
+
+void ImportAudioClipCommand::undo() {
+    if (!m_executed) {
+        return;
+    }
+    auto& playlist = m_manager.getPlaylistModel();
+    playlist.removeClip(m_clipId);
+    if (playlist.getClip(m_clipId)) {
+        return;
+    }
+    // Detach rather than remove so redo reuses this pattern and the decoded
+    // source stays referenced.
+    m_detachedPattern = m_manager.getPatternManager().detachPattern(m_patternId);
+    m_manager.markModified();
+    m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = false;
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -59,7 +59,7 @@ static const std::vector<CommandSchema> s_schemas = {
     },
      "Set track pan (-1 left .. 1 right)."},
 
-    // === Clip (6) ===
+    // === Clip (8) ===
     // Every "id" here is FlagType::Id: the same 32-hex-char string list_clips
     // prints. These used to be Int, which no listed id could satisfy.
     {"add_lane", CommandCategory::Clip, {
@@ -93,6 +93,14 @@ static const std::vector<CommandSchema> s_schemas = {
         {"end", FlagType::Float, true}
     },
      "Trim a clip to a start/end beat range."},
+    {"reverse_clip", CommandCategory::Clip, {
+        {"id", FlagType::Id, true}
+    },
+     "Replace an audio clip's source with a reversed render of itself. Writes a new file; undo restores the original."},
+    {"commit_clip_edits", CommandCategory::Clip, {
+        {"id", FlagType::Id, true}
+    },
+     "Bake an audio clip's own gain and fades into a new source file and reset those edits to unity. Clip-local only: this does not render the track's plugins, automation, sends or routing."},
     // === Unit (2) ===
     // "type" accepts: sampler (default), 808. The schema format cannot
     // express enums yet; the factory rejects anything else.

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -59,35 +59,40 @@ static const std::vector<CommandSchema> s_schemas = {
     },
      "Set track pan (-1 left .. 1 right)."},
 
-    // === Clip (5) ===
+    // === Clip (6) ===
+    // Every "id" here is FlagType::Id: the same 32-hex-char string list_clips
+    // prints. These used to be Int, which no listed id could satisfy.
+    {"add_lane", CommandCategory::Clip, {
+        {"name", FlagType::String, false}
+    },
+     "Create a playlist lane. Clips live on lanes, so a blank project needs one before add_clip."},
     {"add_clip", CommandCategory::Clip, {
         {"track", FlagType::Int, true},
         {"file", FlagType::String, true},
         {"bar", FlagType::Int, true}
     },
-     "Add a file-based clip on a track at a bar position."},
+     "Import an audio file and place it as a playable clip on a lane at a bar position. Decodes the file, registers it as a source and creates its audio pattern; on any failure nothing is added."},
     {"delete_clip", CommandCategory::Clip, {
-        {"id", FlagType::Int, true}
+        {"id", FlagType::Id, true}
     },
      "Delete a clip by id."},
     {"move_clip", CommandCategory::Clip, {
-        {"id", FlagType::Int, true},
+        {"id", FlagType::Id, true},
         {"track", FlagType::Int, true},
         {"start", FlagType::Float, true}
     },
      "Move a clip to a track and start beat."},
     {"duplicate_clip", CommandCategory::Clip, {
-        {"id", FlagType::Int, true},
+        {"id", FlagType::Id, true},
         {"bar", FlagType::Int, true}
     },
      "Duplicate a clip to a bar position."},
     {"trim_clip", CommandCategory::Clip, {
-        {"id", FlagType::Int, true},
+        {"id", FlagType::Id, true},
         {"start", FlagType::Float, true},
         {"end", FlagType::Float, true}
     },
      "Trim a clip to a start/end beat range."},
-
     // === Unit (2) ===
     // "type" accepts: sampler (default), 808. The schema format cannot
     // express enums yet; the factory rejects anything else.
@@ -248,6 +253,7 @@ std::string schemaToJsonString() {
             case FlagType::Int: typeStr = "int"; break;
             case FlagType::Float: typeStr = "float"; break;
             case FlagType::Bool: typeStr = "bool"; break;
+            case FlagType::Id: typeStr = "id"; break;
             }
             out << "      {\n";
             out << "        \"name\": \"" << flag.name << "\",\n";

--- a/AestraAudio/src/Commands/MuseGrammar.cpp
+++ b/AestraAudio/src/Commands/MuseGrammar.cpp
@@ -69,7 +69,7 @@ static const std::vector<CommandSchema> s_schemas = {
     {"add_clip", CommandCategory::Clip, {
         {"track", FlagType::Int, true},
         {"file", FlagType::String, true},
-        {"bar", FlagType::Int, true}
+        {"bar", FlagType::Int, true, 1.0}
     },
      "Import an audio file and place it as a playable clip on a lane at a bar position. Decodes the file, registers it as a source and creates its audio pattern; on any failure nothing is added."},
     {"delete_clip", CommandCategory::Clip, {
@@ -84,7 +84,7 @@ static const std::vector<CommandSchema> s_schemas = {
      "Move a clip to a track and start beat."},
     {"duplicate_clip", CommandCategory::Clip, {
         {"id", FlagType::Id, true},
-        {"bar", FlagType::Int, true}
+        {"bar", FlagType::Int, true, 1.0}
     },
      "Duplicate a clip to a bar position."},
     {"trim_clip", CommandCategory::Clip, {

--- a/Tests/Commands/MuseClipRoundTripTest.cpp
+++ b/Tests/Commands/MuseClipRoundTripTest.cpp
@@ -339,6 +339,20 @@ int main() {
         std::filesystem::remove(junkPath, junkEc);
     }
 
+    // --- bar is 1-based, and says so ---------------------------------------
+    {
+        JSON args = JSON::object();
+        args.set("track", JSON(0.0));
+        args.set("file", JSON(wavPath));
+        args.set("bar", JSON(0.0));
+        JSON r = call(service, request("add_clip", args));
+        // bar 0 would place the clip at beat -4; refuse it rather than build
+        // a clip at a negative timeline position.
+        check(status(r) != "ok", "add_clip refuses bar 0 instead of placing at a negative beat");
+        check(trackManager->getSourceManager().getAllSourceIDs().empty(),
+              "a refused bar leaves no source behind");
+    }
+
     std::string clipId;
     {
         JSON args = JSON::object();

--- a/Tests/Commands/MuseClipRoundTripTest.cpp
+++ b/Tests/Commands/MuseClipRoundTripTest.cpp
@@ -13,6 +13,8 @@
 // without decoding it, leaving a silent clip with no pattern.
 
 #include "Commands/CommandRegistry.h"
+#include "Commands/ImportAudioClipCommand.h"
+#include "IO/MiniAudioDecoder.h"
 #include "Commands/MuseService.h"
 #include "Core/AudioEngine.h"
 #include "Models/TrackManager.h"
@@ -28,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <variant>
+#include <vector>
 
 using Aestra::Audio::AudioEngine;
 using Aestra::Audio::CommandRegistry;
@@ -128,6 +131,68 @@ double halfEnergy(const Aestra::Audio::AudioBufferData& buffer, bool front) {
 
 } // namespace
 
+/**
+ * The failure the Muse verbs cannot reach: the decode succeeds, the source is
+ * registered, and then placement fails. Driven at the command level because
+ * add_clip validates the lane before building, so the verb can never get here.
+ */
+void testPlacementFailureLeavesNoOrphanSource(TrackManager& tm, const std::string& wavPath) {
+    const size_t sourcesBefore = tm.getSourceManager().getAllSourceIDs().size();
+    const size_t patternsBefore = tm.getPatternManager().getAllPatterns().size();
+
+    std::vector<float> decoded;
+    uint32_t sampleRate = 0;
+    uint32_t numChannels = 0;
+    if (!Aestra::Audio::decodeAudioFile(wavPath, decoded, sampleRate, numChannels)) {
+        check(false, "test fixture decodes");
+        return;
+    }
+    auto buffer = std::make_shared<Aestra::Audio::AudioBufferData>();
+    buffer->interleavedData = std::move(decoded);
+    buffer->sampleRate = sampleRate;
+    buffer->numChannels = numChannels;
+    buffer->numFrames = buffer->interleavedData.size() / numChannels;
+
+    // A lane id that belongs to no lane: addClip cannot place the clip.
+    Aestra::Audio::PlaylistLaneID nowhere = Aestra::Audio::PlaylistLaneID::generate();
+
+    Aestra::Audio::ImportAudioClipCommand command(tm, nowhere, wavPath, "orphan-probe", buffer, 0.0, 0.5, 1.0);
+    command.execute();
+
+    check(!command.isUndoable(), "an import that cannot place its clip reports failure");
+    check(tm.getSourceManager().getAllSourceIDs().size() == sourcesBefore,
+          "a failed placement withdraws the source it registered");
+    check(tm.getPatternManager().getAllPatterns().size() == patternsBefore,
+          "a failed placement leaves no orphan pattern");
+}
+
+/**
+ * A source the project already had must survive a failed import: this command
+ * did not introduce it, so it is not this command's to withdraw.
+ */
+void testPreexistingSourceSurvivesFailure(TrackManager& tm, const std::string& wavPath) {
+    // Put the file in the project first, the way a previous import would have.
+    auto seed = std::make_shared<Aestra::Audio::AudioBufferData>();
+    seed->sampleRate = 48000;
+    seed->numChannels = 2;
+    seed->numFrames = 128;
+    seed->interleavedData.assign(128 * 2, 0.25f);
+    const auto seeded = tm.getSourceManager().createRecordedSource(wavPath, "already-here", seed);
+    check(seeded.isValid(), "the fixture source registers");
+
+    const size_t sourcesBefore = tm.getSourceManager().getAllSourceIDs().size();
+
+    auto buffer = std::make_shared<Aestra::Audio::AudioBufferData>(*seed);
+    Aestra::Audio::PlaylistLaneID nowhere = Aestra::Audio::PlaylistLaneID::generate();
+    Aestra::Audio::ImportAudioClipCommand command(tm, nowhere, wavPath, "orphan-probe", buffer, 0.0, 0.5, 1.0);
+    command.execute();
+
+    check(!command.isUndoable(), "the import still fails");
+    check(tm.getSourceManager().getAllSourceIDs().size() == sourcesBefore,
+          "a source the project already had is not withdrawn");
+    check(tm.getSourceManager().getSource(seeded) != nullptr, "the pre-existing source is still addressable");
+}
+
 int main() {
     if (!Aestra::Audio::PluginManager::getInstance().initialize()) {
         std::cout << "FAIL: plugin manager initialize\n";
@@ -178,6 +243,34 @@ int main() {
         const bool noClip = !clips.has("result") || !clips["result"].has("lanes") ||
                             clips["result"]["lanes"][0]["clips"].size() == 0;
         check(noClip, "a refused import leaves no clip behind");
+        // Nothing may reach the project before the command runs: the factory
+        // decodes and validates, it does not register.
+        check(trackManager->getSourceManager().getAllSourceIDs().empty(),
+              "a refused import registers no source either");
+        check(trackManager->getPatternManager().getAllPatterns().empty(),
+              "a refused import creates no pattern");
+    }
+
+    // --- an undecodable file is refused just as cleanly ---------------------
+    {
+        const std::string junkPath = (std::filesystem::temp_directory_path() / "muse_clip_junk.wav").string();
+        std::FILE* junk = std::fopen(junkPath.c_str(), "wb");
+        if (junk) {
+            const char garbage[] = "this is not audio";
+            std::fwrite(garbage, 1, sizeof(garbage), junk);
+            std::fclose(junk);
+        }
+        JSON args = JSON::object();
+        args.set("track", JSON(0.0));
+        args.set("file", JSON(junkPath));
+        args.set("bar", JSON(1.0));
+        JSON r = call(service, request("add_clip", args));
+        check(status(r) != "ok", "add_clip on an undecodable file refuses");
+        check(trackManager->getSourceManager().getAllSourceIDs().empty(),
+              "an undecodable file leaves no source behind");
+
+        std::error_code junkEc;
+        std::filesystem::remove(junkPath, junkEc);
     }
 
     std::string clipId;
@@ -271,6 +364,18 @@ int main() {
                 }
             }
         }
+    }
+
+    // --- atomicity beyond what the verbs can reach --------------------------
+    {
+        // A fresh project so the counts mean something.
+        auto probeManager = std::make_shared<TrackManager>();
+        probeManager->getUnitManager().setPatternManager(&probeManager->getPatternManager());
+        testPlacementFailureLeavesNoOrphanSource(*probeManager, wavPath);
+
+        auto seededManager = std::make_shared<TrackManager>();
+        seededManager->getUnitManager().setPatternManager(&seededManager->getPatternManager());
+        testPreexistingSourceSurvivesFailure(*seededManager, wavPath);
     }
 
     std::error_code ec;

--- a/Tests/Commands/MuseClipRoundTripTest.cpp
+++ b/Tests/Commands/MuseClipRoundTripTest.cpp
@@ -1,0 +1,285 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Muse audio-clip round-trip integrity.
+//
+// The invariant: anything Muse creates or lists can be addressed unchanged and
+// produces the same real project object the GUI would. Concretely —
+//
+//   blank project -> add_lane -> add_clip --file -> list_clips
+//     -> reuse the returned id verbatim -> act on the clip -> undo/redo
+//
+// Before this, list_clips printed a 32-hex-char id that every clip verb
+// rejected as a non-integer, and add_clip recorded the file path as a name
+// without decoding it, leaving a silent clip with no pattern.
+
+#include "Commands/CommandRegistry.h"
+#include "Commands/MuseService.h"
+#include "Core/AudioEngine.h"
+#include "Models/TrackManager.h"
+#include "Plugin/PluginManager.h"
+
+#include "AestraJSON.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <variant>
+
+using Aestra::Audio::AudioEngine;
+using Aestra::Audio::CommandRegistry;
+using Aestra::Audio::MuseService;
+using Aestra::Audio::TrackManager;
+using Aestra::JSON;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << "\n";
+    } else {
+        std::cout << "FAIL: " << label << "\n";
+        ++g_failures;
+    }
+}
+
+JSON call(MuseService& service, const std::string& request) {
+    return JSON::parse(service.handleRequest(request));
+}
+
+std::string status(JSON& response) {
+    return response.has("status") ? response["status"].asString() : "<missing>";
+}
+
+std::string message(JSON& response) {
+    return response.has("message") ? response["message"].asString() : "";
+}
+
+/** A request whose args are built as JSON, so Windows paths survive escaping. */
+std::string request(const std::string& verb, const JSON& args) {
+    JSON req = JSON::object();
+    req.set("id", JSON(1.0));
+    req.set("verb", JSON(verb));
+    req.set("args", args);
+    return req.toString();
+}
+
+std::string verbWithId(const std::string& verb, const std::string& clipId) {
+    JSON args = JSON::object();
+    args.set("id", JSON(clipId));
+    return request(verb, args);
+}
+
+/**
+ * Front-loaded float32 stereo WAV: loud attack, near-silent tail. Reversing it
+ * is measurable rather than merely plausible.
+ */
+std::string writeDecayWav() {
+    const std::string path = (std::filesystem::temp_directory_path() / "muse_clip_roundtrip.wav").string();
+    const uint32_t sampleRate = 48000;
+    const uint16_t channels = 2;
+    const uint32_t numFrames = 24000; // 0.5 s
+    const uint32_t dataBytes = numFrames * channels * sizeof(float);
+
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return "";
+    auto u32 = [&](uint32_t v) { std::fwrite(&v, 4, 1, f); };
+    auto u16 = [&](uint16_t v) { std::fwrite(&v, 2, 1, f); };
+    std::fwrite("RIFF", 1, 4, f);
+    u32(36 + dataBytes);
+    std::fwrite("WAVE", 1, 4, f);
+    std::fwrite("fmt ", 1, 4, f);
+    u32(16);
+    u16(3); // IEEE float
+    u16(channels);
+    u32(sampleRate);
+    u32(sampleRate * channels * 4);
+    u16(static_cast<uint16_t>(channels * 4));
+    u16(32);
+    std::fwrite("data", 1, 4, f);
+    u32(dataBytes);
+    for (uint32_t i = 0; i < numFrames; ++i) {
+        const float env = 1.0f - static_cast<float>(i) / static_cast<float>(numFrames);
+        const float s = env * env * 0.8f;
+        std::fwrite(&s, sizeof(float), 1, f);
+        std::fwrite(&s, sizeof(float), 1, f);
+    }
+    std::fclose(f);
+    return path;
+}
+
+/** Energy in the first or last half of whatever audio the clip resolves to. */
+double halfEnergy(const Aestra::Audio::AudioBufferData& buffer, bool front) {
+    const uint64_t half = buffer.numFrames / 2;
+    const uint64_t begin = front ? 0 : half;
+    const uint64_t end = front ? half : buffer.numFrames;
+    double energy = 0.0;
+    for (uint64_t f = begin; f < end; ++f) {
+        const double s = buffer.interleavedData[f * buffer.numChannels];
+        energy += s * s;
+    }
+    return energy;
+}
+
+} // namespace
+
+int main() {
+    if (!Aestra::Audio::PluginManager::getInstance().initialize()) {
+        std::cout << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->getUnitManager().setPatternManager(&trackManager->getPatternManager());
+
+    AudioEngine engine;
+    engine.setSampleRate(48000);
+    engine.setBufferConfig(4096, 2);
+    MuseService::wireHeadlessEngine(trackManager, engine);
+    if (!engine.initialize()) {
+        std::cout << "FAIL: engine initialize\n";
+        return 1;
+    }
+
+    CommandRegistry::initialize();
+    MuseService service(trackManager.get(), &engine);
+
+    const std::string wavPath = writeDecayWav();
+    if (wavPath.empty()) {
+        std::cout << "FAIL: could not write the test wav\n";
+        return 1;
+    }
+
+    // --- add_lane: a blank project can be given somewhere to put clips ------
+    {
+        JSON args = JSON::object();
+        args.set("name", JSON(std::string("QA")));
+        JSON r = call(service, request("add_lane", args));
+        check(status(r) == "ok", "add_lane creates a playlist lane");
+    }
+
+    // --- add_clip: really imports, or changes nothing -----------------------
+    {
+        JSON args = JSON::object();
+        args.set("track", JSON(0.0));
+        args.set("file", JSON(std::string("/nonexistent/definitely_not_here.wav")));
+        args.set("bar", JSON(1.0));
+        JSON r = call(service, request("add_clip", args));
+        check(status(r) != "ok", "add_clip on a missing file refuses");
+        check(message(r).find("no such audio file") != std::string::npos,
+              "add_clip names the missing file in its error");
+
+        JSON clips = call(service, request("list_clips", JSON::object()));
+        const bool noClip = !clips.has("result") || !clips["result"].has("lanes") ||
+                            clips["result"]["lanes"][0]["clips"].size() == 0;
+        check(noClip, "a refused import leaves no clip behind");
+    }
+
+    std::string clipId;
+    {
+        JSON args = JSON::object();
+        args.set("track", JSON(0.0));
+        args.set("file", JSON(wavPath));
+        args.set("bar", JSON(1.0));
+        JSON r = call(service, request("add_clip", args));
+        check(status(r) == "ok", "add_clip imports a real audio file");
+    }
+
+    // --- list_clips reports an id, and the clip is a real audio object ------
+    {
+        JSON r = call(service, request("list_clips", JSON::object()));
+        JSON lanes = r["result"]["lanes"];
+        check(lanes.size() == 1, "the imported clip is on its lane");
+        if (lanes.size() == 1 && lanes[0]["clips"].size() == 1) {
+            JSON clip = lanes[0]["clips"][0];
+            clipId = clip["id"].asString();
+            check(!clipId.empty(), "list_clips reports a clip id");
+            // The bug this slice exists for: a clip that names a file but
+            // carries no pattern is silent and structurally invalid.
+            const double pattern = clip.has("pattern") ? clip["pattern"].asNumber() : 0.0;
+            check(pattern != 0.0, "the imported clip carries a real audio pattern");
+        } else {
+            check(false, "exactly one clip was imported");
+        }
+    }
+
+    // --- the reported id is accepted verbatim by the clip verbs -------------
+    if (!clipId.empty()) {
+        // Every clip verb shares one id parser; prove the listed id reaches it
+        // rather than being rejected before the command is ever built.
+        JSON r = call(service, verbWithId("delete_clip", clipId));
+        check(status(r) == "ok", "a listed clip id is accepted verbatim by delete_clip");
+
+        r = call(service, request("undo", JSON::object()));
+        check(status(r) == "ok", "the delete undoes");
+
+        // A malformed id is refused as an id, not silently truncated.
+        r = call(service, verbWithId("delete_clip", std::string("12")));
+        check(status(r) != "ok", "a non-canonical id is refused");
+        r = call(service, verbWithId("delete_clip", std::string("00000000000000000000000000000000")));
+        check(status(r) != "ok", "the null id is refused");
+    }
+
+    // --- undo/redo of the import restores and reuses -------------------------
+    if (!clipId.empty()) {
+        JSON r = call(service, request("undo", JSON::object()));
+        check(status(r) == "ok", "the import undoes");
+
+        JSON clips = call(service, request("list_clips", JSON::object()));
+        const bool empty = clips["result"]["lanes"][0]["clips"].size() == 0;
+        check(empty, "undoing the import removes the clip");
+
+        r = call(service, request("redo", JSON::object()));
+        check(status(r) == "ok", "the import redoes");
+
+        clips = call(service, request("list_clips", JSON::object()));
+        check(clips["result"]["lanes"][0]["clips"].size() == 1, "redo restores the clip");
+        if (clips["result"]["lanes"][0]["clips"].size() == 1) {
+            check(clips["result"]["lanes"][0]["clips"][0]["id"].asString() == clipId,
+                  "redo restores the clip under the same id");
+        }
+    }
+
+    // --- the imported audio is really the file's audio -----------------------
+    if (!clipId.empty()) {
+        Aestra::Audio::ClipInstanceID id;
+        Aestra::Audio::AestraUUID parsed;
+        check(Aestra::Audio::AestraUUID::tryParse(clipId, parsed), "the reported id parses as a canonical id");
+        id = Aestra::Audio::ClipInstanceID(parsed);
+
+        const auto* clip = trackManager->getPlaylistModel().getClip(id);
+        check(clip != nullptr, "the reported id resolves to the very clip that was created");
+        if (clip) {
+            // clip -> pattern -> audio payload -> decoded source buffer
+            const auto* pattern = trackManager->getPatternManager().getPattern(clip->patternId);
+            check(pattern != nullptr && pattern->isAudio(), "the clip points at an audio pattern");
+            if (pattern && pattern->isAudio()) {
+                const auto& payload = std::get<Aestra::Audio::AudioSlicePayload>(pattern->payload);
+                const auto* source = trackManager->getSourceManager().getSource(payload.audioSourceId);
+                check(source != nullptr, "the audio pattern points at a registered source");
+                auto buffer = source ? source->getSharedBuffer() : nullptr;
+                check(buffer && buffer->isValid(), "the source carries decoded audio, not just a path");
+                if (buffer && buffer->isValid()) {
+                    check(buffer->numFrames > 0, "the decoded audio has frames");
+                    check(halfEnergy(*buffer, true) > halfEnergy(*buffer, false) * 2.0,
+                          "the decoded audio is the front-loaded file that was imported");
+                }
+            }
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(wavPath, ec);
+
+    if (g_failures != 0) {
+        std::cout << "\nFAILED: " << g_failures << " check(s)\n";
+        return 1;
+    }
+    std::cout << "\nAll Muse clip round-trip checks passed.\n";
+    return 0;
+}

--- a/Tests/Commands/MuseClipRoundTripTest.cpp
+++ b/Tests/Commands/MuseClipRoundTripTest.cpp
@@ -22,9 +22,11 @@
 
 #include "AestraJSON.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -114,6 +116,70 @@ std::string writeDecayWav() {
     }
     std::fclose(f);
     return path;
+}
+
+/**
+ * Read back a float32 WAV that render_song produced, so the assertions are
+ * about audio that actually left the engine rather than about a buffer sitting
+ * in SourceManager.
+ */
+bool readFloatWav(const std::string& path, std::vector<float>& out, uint32_t& channels) {
+    std::FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return false;
+    char riff[4], wave[4];
+    if (std::fread(riff, 1, 4, f) != 4) { std::fclose(f); return false; }
+    uint32_t chunkSize = 0;
+    if (std::fread(&chunkSize, 4, 1, f) != 1) { std::fclose(f); return false; }
+    if (std::fread(wave, 1, 4, f) != 4) { std::fclose(f); return false; }
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) { std::fclose(f); return false; }
+
+    channels = 0;
+    uint16_t bits = 0;
+    while (true) {
+        char id[4];
+        uint32_t size = 0;
+        if (std::fread(id, 1, 4, f) != 4) break;
+        if (std::fread(&size, 4, 1, f) != 1) break;
+        if (std::memcmp(id, "fmt ", 4) == 0) {
+            uint16_t fmt = 0, ch = 0;
+            uint32_t rate = 0, byteRate = 0;
+            uint16_t block = 0;
+            std::fread(&fmt, 2, 1, f);
+            std::fread(&ch, 2, 1, f);
+            std::fread(&rate, 4, 1, f);
+            std::fread(&byteRate, 4, 1, f);
+            std::fread(&block, 2, 1, f);
+            std::fread(&bits, 2, 1, f);
+            channels = ch;
+            if (size > 16) std::fseek(f, static_cast<long>(size - 16), SEEK_CUR);
+        } else if (std::memcmp(id, "data", 4) == 0) {
+            if (bits != 32 || channels == 0) { std::fclose(f); return false; }
+            out.resize(size / sizeof(float));
+            const size_t read = std::fread(out.data(), sizeof(float), out.size(), f);
+            out.resize(read);
+            std::fclose(f);
+            return !out.empty();
+        } else {
+            std::fseek(f, static_cast<long>(size + (size & 1u)), SEEK_CUR);
+        }
+    }
+    std::fclose(f);
+    return false;
+}
+
+/** Energy in the first or last half of an interleaved buffer. */
+double halfEnergyOf(const std::vector<float>& data, uint32_t channels, bool front) {
+    if (channels == 0 || data.empty()) return 0.0;
+    const size_t frames = data.size() / channels;
+    const size_t half = frames / 2;
+    const size_t begin = front ? 0 : half;
+    const size_t end = front ? half : frames;
+    double energy = 0.0;
+    for (size_t f = begin; f < end; ++f) {
+        const double s = data[f * channels];
+        energy += s * s;
+    }
+    return energy;
 }
 
 /** Energy in the first or last half of whatever audio the clip resolves to. */
@@ -376,6 +442,101 @@ int main() {
         auto seededManager = std::make_shared<TrackManager>();
         seededManager->getUnitManager().setPatternManager(&seededManager->getPatternManager());
         testPreexistingSourceSurvivesFailure(*seededManager, wavPath);
+    }
+
+    // --- render_song proves the audio, not just the model -------------------
+    if (!clipId.empty()) {
+        const std::string beforePath = (std::filesystem::temp_directory_path() / "muse_rt_before.wav").string();
+        const std::string afterPath = (std::filesystem::temp_directory_path() / "muse_rt_after.wav").string();
+
+        JSON args = JSON::object();
+        args.set("file", JSON(beforePath));
+        args.set("tail", JSON(0.0));
+        JSON r = call(service, request("render_song", args));
+        check(status(r) == "ok", "render_song bounces the arranged timeline");
+
+        std::vector<float> before;
+        uint32_t beforeChannels = 0;
+        check(readFloatWav(beforePath, before, beforeChannels), "the rendered mix reads back");
+        const double frontBefore = halfEnergyOf(before, beforeChannels, true);
+        const double backBefore = halfEnergyOf(before, beforeChannels, false);
+        check(frontBefore > backBefore * 2.0, "the rendered mix is front-loaded, like the imported file");
+
+        // Reverse addressed by the id list_clips reported.
+        r = call(service, verbWithId("reverse_clip", clipId));
+        check(status(r) == "ok", "reverse_clip runs against the listed id");
+
+        args = JSON::object();
+        args.set("file", JSON(afterPath));
+        args.set("tail", JSON(0.0));
+        r = call(service, request("render_song", args));
+        check(status(r) == "ok", "render_song bounces the reversed timeline");
+
+        std::vector<float> after;
+        uint32_t afterChannels = 0;
+        check(readFloatWav(afterPath, after, afterChannels), "the reversed mix reads back");
+        const double frontAfter = halfEnergyOf(after, afterChannels, true);
+        const double backAfter = halfEnergyOf(after, afterChannels, false);
+        // The whole point of the round trip: audio that actually left the
+        // engine changed, in the direction reverse implies.
+        check(backAfter > frontAfter * 2.0, "the reversed mix is back-loaded");
+
+        r = call(service, request("undo", JSON::object()));
+        check(status(r) == "ok", "the reverse undoes");
+
+        std::error_code renderEc;
+        std::filesystem::remove(beforePath, renderEc);
+        std::filesystem::remove(afterPath, renderEc);
+    }
+
+    // --- commit_clip_edits is audibly equivalent ----------------------------
+    if (!clipId.empty()) {
+        const std::string preCommit = (std::filesystem::temp_directory_path() / "muse_rt_precommit.wav").string();
+        const std::string postCommit = (std::filesystem::temp_directory_path() / "muse_rt_postcommit.wav").string();
+
+        // Something to bake: a clear gain change.
+        Aestra::Audio::AestraUUID parsedId;
+        Aestra::Audio::AestraUUID::tryParse(clipId, parsedId);
+        const Aestra::Audio::ClipInstanceID id(parsedId);
+        if (auto* clip = trackManager->getPlaylistModel().getClip(id)) {
+            Aestra::Audio::ClipEdits edits = clip->edits;
+            edits.gainLinear = 0.35f;
+            trackManager->getPlaylistModel().setClipEdits(id, edits);
+        }
+
+        JSON args = JSON::object();
+        args.set("file", JSON(preCommit));
+        args.set("tail", JSON(0.0));
+        JSON r = call(service, request("render_song", args));
+        check(status(r) == "ok", "render_song bounces before the commit");
+        std::vector<float> pre;
+        uint32_t preChannels = 0;
+        check(readFloatWav(preCommit, pre, preChannels), "the pre-commit mix reads back");
+
+        r = call(service, verbWithId("commit_clip_edits", clipId));
+        check(status(r) == "ok", "commit_clip_edits runs against the listed id");
+
+        args = JSON::object();
+        args.set("file", JSON(postCommit));
+        args.set("tail", JSON(0.0));
+        r = call(service, request("render_song", args));
+        check(status(r) == "ok", "render_song bounces after the commit");
+        std::vector<float> post;
+        uint32_t postChannels = 0;
+        check(readFloatWav(postCommit, post, postChannels), "the post-commit mix reads back");
+
+        // The defining invariant: committing clip-local edits must not change
+        // what the timeline sounds like.
+        check(preChannels == postChannels, "the commit does not change the channel count");
+        const double preEnergy = halfEnergyOf(pre, preChannels, true) + halfEnergyOf(pre, preChannels, false);
+        const double postEnergy = halfEnergyOf(post, postChannels, true) + halfEnergyOf(post, postChannels, false);
+        const double denominator = std::max(preEnergy, 1.0e-9);
+        check(std::fabs(preEnergy - postEnergy) / denominator < 0.02,
+              "committing clip edits leaves the rendered mix audibly equivalent");
+
+        std::error_code renderEc;
+        std::filesystem::remove(preCommit, renderEc);
+        std::filesystem::remove(postCommit, renderEc);
     }
 
     std::error_code ec;

--- a/Tests/Commands/MuseClipRoundTripTest.cpp
+++ b/Tests/Commands/MuseClipRoundTripTest.cpp
@@ -509,14 +509,26 @@ int main() {
         const std::string postCommit = (std::filesystem::temp_directory_path() / "muse_rt_postcommit.wav").string();
 
         // Something to bake: a clear gain change.
+        //
+        // Every step here is asserted, because this test fails open otherwise:
+        // if the id did not parse, or the clip were unreachable, or the edit
+        // did not stick, the commit would have nothing to bake and the
+        // equivalence check below would compare two identical renders and
+        // pass while proving nothing.
         Aestra::Audio::AestraUUID parsedId;
-        Aestra::Audio::AestraUUID::tryParse(clipId, parsedId);
+        check(Aestra::Audio::AestraUUID::tryParse(clipId, parsedId),
+              "the listed id parses before the commit check");
         const Aestra::Audio::ClipInstanceID id(parsedId);
-        if (auto* clip = trackManager->getPlaylistModel().getClip(id)) {
+        auto* clip = trackManager->getPlaylistModel().getClip(id);
+        check(clip != nullptr, "the clip is addressable before the commit check");
+        if (clip) {
             Aestra::Audio::ClipEdits edits = clip->edits;
             edits.gainLinear = 0.35f;
-            trackManager->getPlaylistModel().setClipEdits(id, edits);
+            check(trackManager->getPlaylistModel().setClipEdits(id, edits), "the gain edit applies");
         }
+        const auto* staged = trackManager->getPlaylistModel().getClip(id);
+        check(staged != nullptr && std::fabs(staged->edits.gainLinear - 0.35f) < 1.0e-6f,
+              "there is a real gain to bake, so the commit is not a no-op");
 
         JSON args = JSON::object();
         args.set("file", JSON(preCommit));
@@ -529,6 +541,12 @@ int main() {
 
         r = call(service, verbWithId("commit_clip_edits", clipId));
         check(status(r) == "ok", "commit_clip_edits runs against the listed id");
+        // The other half of failing open: if the bake silently did nothing,
+        // the gain would still be 0.35 and the two renders would again match
+        // for the wrong reason.
+        const auto* committed = trackManager->getPlaylistModel().getClip(id);
+        check(committed != nullptr && std::fabs(committed->edits.gainLinear - 1.0f) < 1.0e-6f,
+              "the commit really baked the gain and reset it to unity");
 
         args = JSON::object();
         args.set("file", JSON(postCommit));

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -298,6 +298,15 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/Rende
     )
     add_test(NAME RenderAudioClipCommandTest COMMAND RenderAudioClipCommandTest)
     set_tests_properties(RenderAudioClipCommandTest PROPERTIES LABELS "commands;audio;clip-render;undo")
+if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/MuseClipRoundTripTest.cpp")
+    add_executable(MuseClipRoundTripTest Commands/MuseClipRoundTripTest.cpp)
+    target_link_libraries(MuseClipRoundTripTest PRIVATE AestraAudioCore)
+    target_include_directories(MuseClipRoundTripTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME MuseClipRoundTripTest COMMAND MuseClipRoundTripTest)
+    set_tests_properties(MuseClipRoundTripTest PROPERTIES LABELS "commands;muse;clip;roundtrip")
 endif()
 
 message(STATUS "Commands tests added - Phase 2 undo/redo system")

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -298,6 +298,8 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/Rende
     )
     add_test(NAME RenderAudioClipCommandTest COMMAND RenderAudioClipCommandTest)
     set_tests_properties(RenderAudioClipCommandTest PROPERTIES LABELS "commands;audio;clip-render;undo")
+endif()
+
 if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/MuseClipRoundTripTest.cpp")
     add_executable(MuseClipRoundTripTest Commands/MuseClipRoundTripTest.cpp)
     target_link_libraries(MuseClipRoundTripTest PRIVATE AestraAudioCore)


### PR DESCRIPTION
Muse could list clips it could not act on, and could "add" a clip that played nothing. Both halves of the round trip are repaired here, so Muse becomes a harness that can actually create and exercise the object every later clip operation needs.

The invariant: **anything Muse creates or lists can be addressed unchanged and produces the same real project object the GUI would.**

## Canonical clip ids

`list_clips` prints `AestraUUID::toString` — 32 hex chars. Every clip verb declared its `id` as `FlagType::Int` and parsed it with `safeStoull` into `ClipInstanceID::low` alone. So:

- no id an agent read back could be passed to any verb (`"flag --id requires an integer"`), and
- two ids sharing a low word addressed the same clip.

Adds `FlagType::Id`, validated in both the CLI parser and the JSON host-verb path, and converts the whole family in one pass — `delete_clip`, `move_clip`, `duplicate_clip`, `trim_clip`. Ids now have exactly one public representation in both directions.

Only the canonical form is accepted. The integer form never worked end-to-end (no query emitted one), so there are no working scripts to preserve and no reason to carry two public formats.

## Real `add_clip --file` import

It set `clip.name` to the file path and left `patternId` invalid — a silent, structurally invalid clip that `list_clips` reported as `pattern: 0`. It now:

1. decodes through `decodeAudioFile`, the same decoder drag-and-drop import uses — no Muse-specific importer,
2. registers the source via `SourceManager::createRecordedSource`,
3. creates the audio pattern with the real source id, and
4. creates the clip with that pattern and a duration derived from the decoded frames and sample rate.

Path ownership follows the UI: path is `SourceManager`'s dedupe key, the file is referenced where it lies and never copied into the project.

**Atomic.** A missing file, an undecodable or empty file, an unusable duration, a missing lane or a failed source registration each return a precise error and create nothing. The source is registered only *after* the decode succeeds, so a bad file leaves no half-built source. If the clip cannot be placed, the pattern it needed is detached again. `undo()` removes the clip and detaches the pattern so redo reuses it rather than decoding twice.

Release bar met: `add_clip --file X` either creates a playable clip backed by X, or changes nothing and returns a precise error.

## `add_lane`

Exposes `CreateLaneCommand`, which was implemented but never registered. Without it `add_clip` was unreachable from a blank project.

## Verification

`MuseClipRoundTripTest` walks the whole invariant end to end: blank project → `add_lane` → `add_clip --file` → `list_clips` → reuse the returned id **verbatim** → act on it → undo/redo, plus the refusal paths (missing file leaves no clip; a non-canonical id and the null id are both rejected).

Both repairs verified by sabotage:
- restoring the low-word integer parser fails three checks,
- stubbing the decode to silence fails the audio check.

**220/220 tests pass.**

## Follow-up

`reverse_clip` and `commit_clip_edits` are written and held back one step: they depend on #689, and including them here would stack the PRs. They land immediately after #689 merges — at which point the end-to-end audible test (import → reverse → verify reversed audio → undo/redo) closes on this same harness.

Then consolidate/glue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Breaking change:** Clip operations now require canonical 32-character hexadecimal UUIDs through `FlagType::Id`.
- `add_clip --file` now decodes audio, registers or reuses its source, creates a playable audio pattern, and derives clip duration from the decoded audio.
- Imports are atomic and return precise errors for missing files, filesystem failures, invalid audio, placement failures, and invalid `--bar` values.
- Added `add_lane` support for blank-project workflows.
- Added `reverse_clip` and `commit_clip_edits` with rendered-audio round-trip verification.
- Added undo/redo support that preserves reusable patterns, manages source ownership, and removes only sources introduced by failed imports.
- Expanded `MuseClipRoundTripTest` to cover canonical IDs, refusal paths, audio rendering, edit commits, source reuse, and undo/redo.
- All 222 tests pass, including CI and sanitizer workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->