### PR TITLE
docs: lock the Consolidate contract before implementation

### DIFF
--- a/AestraDocs/INDEX.md
+++ b/AestraDocs/INDEX.md
@@ -50,6 +50,7 @@ Behavioral/interaction specs for subsystems.
 - [Transport-Aware Preview Ducking](specs/transport-aware-preview-ducking.md)
 - [Unbounded Timeline](specs/UNBOUNDED_TIMELINE.md)
 - [Routing Implementation Checklist](specs/Routing-Implementation-Checklist.md)
+- [Consolidate Audio Range](specs/consolidate-audio-range.md)
 
 ## Audio quality
 - [Path to All-A](audio/Path-to-All-A.md) — audio-quality grade roadmap

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -138,6 +138,51 @@ into the rendered audio, so leaving them set would apply them twice.
 - **redo** — reuses the rendered file, source and pattern. It must **not**
   render again or write another file.
 
+## 4b. Reaching the runtime kernel — characterize before extracting
+
+§3.1 requires mirroring `AudioEngine`'s clip render path rather than re-deriving
+it. That logic currently sits inside `processBlock`, interleaved with graph
+concerns, so "mirror" will in practice mean extracting a shared clip-local
+kernel both callers use. **Characterize it before touching it.**
+
+Order of work, not negotiable:
+
+1. Add focused fixtures capturing **current** runtime output for the cases that
+   matter: unity-rate, resampled, panned, faded, overlapping, and short clips.
+2. Sabotage against those fixtures, so they are *known* to detect altered clip
+   behaviour before they are trusted to protect a refactor.
+3. Extract only the pure clip-local kernel.
+4. Re-run the characterization tests and require **identical** output.
+5. Build `AudioConsolidationRenderer` on that kernel.
+
+The extraction is acceptable while it moves arithmetic without changing
+ownership or scheduling. **Stop** the moment it requires touching any of:
+
+- `processBlock` orchestration
+- graph traversal or topology
+- track / effect / routing order
+- RT buffer ownership or allocation
+- transport state
+- callback timing
+- PDC or automation application
+
+At that point, copying the logic is **also not acceptable** — it would
+immediately create the second interpretation §3.1 exists to forbid. The correct
+response is to pause and decide whether the live-path refactor deserves its own
+narrowly scoped, zero-audio-change PR.
+
+If that preparatory PR happens, it carries one extra gate beyond the normal
+suite:
+
+> The refactor must pass a **before/after rendered-byte comparison on fixed
+> fixtures**, not merely the existing tests.
+
+Ordinary tolerance-based assertions can miss a shifted interpolation phase, an
+off-by-one in edge-ramp indexing, a changed pan law, a different overlap order,
+or altered floating-point accumulation order. Exact bytes are not portable
+across architectures, so keep the strict comparison **within one build and
+environment**, and keep tolerance-based semantic tests for cross-platform CI.
+
 ## 5. Separation from graph rendering
 
 This is **source-domain only**. It must not evaluate track plugins, sends,

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -1,0 +1,208 @@
+# Consolidate Audio Range — Contract
+
+**Status:** Locked before implementation — build to this, not to the nearest code seam
+**Owner:** Dylan
+**Last Updated:** 2026-08-01
+**Scope:** Internal architecture doc. Not public-facing.
+
+> Written before the renderer exists, deliberately. Consolidation carries enough
+> hidden decisions that an implementation grown from whichever seam is nearest
+> would quietly become the specification, and would then be permanently
+> inconsistent with playback.
+
+Two statements govern everything below.
+
+> **The reference implementation for audible behaviour is the runtime clip
+> renderer, not a parallel interpretation of clip edits.**
+
+> **Consolidation equivalence is measured on the engine's rendered output before
+> and after the operation, including the samples immediately around every
+> original clip boundary.**
+
+---
+
+## 1. Public command and range semantics
+
+```
+consolidate_audio --lane <canonical-lane-id> --start <beat> --end <beat>
+```
+
+Stateless and explicit. There is deliberately **no** Muse selection object and
+no `set_selection` verb: invisible state drifts between calls, and a GUI
+selection is trivially translated into these three arguments at the call site.
+
+The lane is addressed by its **canonical UUID**, not a positional index.
+`list_clips` already emits it losslessly (`MuseService.cpp`,
+`laneJson.set("id", laneId.toString())`). Positional indexes shift when lanes
+are deleted; this is the same identity class already repaired for clips.
+
+*Note: no first-class timeline selection model exists in the tree today. The
+only thing resembling one is `TrackManagerUI::m_selectionBoxStart/End`, which is
+pixel-space rubber-band state, not a model range. A selection verb would have
+had to fabricate the state it then hid.*
+
+**Range is half-open: `[startBeat, endBeat)`.** The resulting clip occupies that
+exact range, including any silence between contributing clips.
+
+## 2. Accepted and refused inputs
+
+Accepted:
+- One or more audible audio clips on the lane intersecting the range.
+- Gaps between them (rendered as silence).
+- Overlaps between them (summed).
+
+Refused, precisely — never silently discarded or omitted:
+- **Any audio clip crossing `startBeat` or `endBeat`** (see §3.3).
+- A MIDI clip, or any unsupported clip type, intersecting the range.
+- An audible clip edit the renderer does not implement.
+- An invalid or unknown lane id, a non-finite or inverted range, an empty range.
+- A range containing no audio clip at all.
+
+The refusal rule is the load-bearing one: **an audible property that cannot be
+reproduced must stop the operation.** Silent omission produces a consolidated
+clip that sounds wrong and looks committed.
+
+## 3. Audible contributions and edge-fade policy
+
+### 3.1 What must be reproduced
+
+Every clip contributes exactly what playback would give it: source offsets,
+slip (`ClipEdits::sourceStart`, in project-rate samples — rescale it), playback
+rate and the resulting resampling through the canonical resampler, mute, gain,
+pan, and fades. Overlaps sum exactly as playback sums them. Gaps stay silent.
+
+Per the governing statement above: mirror `AudioEngine`'s clip render path.
+Do not re-derive an interpretation of `ClipEdits` in parallel — that is how the
+fade shape in the first render slice ended up disagreeing with playback.
+
+### 3.2 Edge fades — the subtle part
+
+The engine applies an automatic edge fade (`CLIP_EDGE_FADE_SAMPLES`, 128) at
+every clip boundary, as an anti-click measure. Consolidation **removes the
+boundaries between the original clips**, so the engine will no longer apply
+those fades. It will, however, apply them at the two boundaries of the new
+consolidated clip.
+
+The policy:
+
+> **Bake every original automatic clip-edge fade, except an edge exactly
+> coincident with the corresponding outer consolidation boundary.**
+
+Why each half matters:
+
+- **Internal boundaries must be baked.** After consolidation there is no
+  boundary there, so nothing re-applies the fade. Not baking it changes the
+  sound at every original seam. This includes a clip that starts after
+  `startBeat` or ends before `endBeat` even when separated by silence — that is
+  still an internal boundary.
+- **Outer boundaries must not be baked.** The new clip receives the engine's
+  automatic edge fade at `startBeat` and `endBeat`. Baking it as well applies
+  the ramp twice — the outer edge is attenuated by `r²` instead of `r`.
+
+Delegating the outer boundary is mathematically safe. Where several clips begin
+exactly at the range boundary, applying the same linear ramp `r` to each before
+summing gives `r·A + r·B`, which equals `r·(A + B)` — applying it once to the
+sum. So the new clip's own edge fade reproduces it exactly, and baking is not
+merely redundant but wrong.
+
+### 3.3 Why boundary alignment is required in v1
+
+A range cutting through the middle of a clip creates a clip boundary where
+playback previously had none. The consolidated result then gains an edge fade
+that the original never had, and the operation is no longer audibly equivalent.
+
+**v1 therefore rejects any range that cuts through an audio clip.** This still
+delivers the functionality that matters — multiple clips, overlaps, silent gaps
+— without quietly changing audio.
+
+Arbitrary boundary cuts wait for an explicit per-edge policy (whether an
+automatic edge fade is enabled, or already baked). When that arrives it must be
+**serialized, consumed by playback, and covered by equivalence tests in the same
+PR**. It must never be another passive field: this arc began by deleting
+`pitchSemitones` and `timeStretchRatio`, which were declared, compared, and read
+by nothing.
+
+## 4. Ownership through execute, failure, undo and redo
+
+The result references **one flat audio source**, starts at `startBeat`, and
+carries unity/default edits with no inherited offsets — the offsets are baked
+into the rendered audio, so leaving them set would apply them twice.
+
+- **execute** — render, write, register source and pattern, remove the original
+  clips, place the consolidated clip. All project mutation belongs to the
+  command; the factory validates and constructs only, never mutates.
+- **failure** (render, write, or placement) — leaves **no** new clip, pattern or
+  source, and no command-history entry. A source this command introduced is
+  withdrawn; a source the project already had is not.
+- **undo** — restores the original clips exactly, including their ids.
+- **redo** — reuses the rendered file, source and pattern. It must **not**
+  render again or write another file.
+
+## 5. Separation from graph rendering
+
+This is **source-domain only**. It must not evaluate track plugins, sends,
+automation, routing or PDC.
+
+Those belong to the later range/graph renderer that will back Freeze, stem
+printing and bus printing. The two layers may share the WAV writer and source
+registration; they must not share rendering semantics. Anything needing the
+audio graph does not belong here.
+
+**Three pieces — do not stretch `ClipRenderService` into something vague:**
+
+| Piece | Responsibility |
+|---|---|
+| `AudioConsolidationRenderer` | Mix multiple source-domain clips into one timeline-aligned buffer |
+| `ClipRenderService` (existing) | Durable WAV writing, source and pattern registration |
+| `ConsolidateAudioRangeCommand` | Clip removal, replacement, rollback, undo, redo |
+
+## 6. Muse schema
+
+```
+{"consolidate_audio", CommandCategory::Clip, {
+    {"lane",  FlagType::Id,    true},
+    {"start", FlagType::Float, true},
+    {"end",   FlagType::Float, true}
+},
+ "Replace a lane's audio across [start, end) with one equivalent clip. Refuses a range that cuts through a clip, or that contains a non-audio clip."}
+```
+
+`lane` is `FlagType::Id` — the canonical form, matching the clip verbs. `Int` is
+for indexes and counts, never object identity.
+
+## 7. Equivalence and sabotage gates
+
+Load-bearing tests:
+
+1. Two clips separated by silence → one clip with the same gap.
+2. Overlapping clips → the same rendered sum before and after.
+3. Differing source sample rates → playback preserved through the canonical
+   resampler.
+4. Gain, pan, fades, mute and playback rate all survive audibly.
+5. Redo invokes no rendering and writes no file.
+6. Placement or write failure restores every original clip and resource.
+7. `render_song` before vs after is equivalent across the selected range.
+
+**Test material must be deliberately discontinuous.** Smooth material is already
+near zero at a boundary and will conceal a missing edge fade. Use signals with a
+real step at every original clip boundary, and assert on the samples immediately
+around those boundaries specifically — not only on aggregate energy.
+
+**Sabotage gates** — each of these must be shown to fail the suite:
+- one timeline offset (prove alignment is checked),
+- one overlap addition (prove summing is checked),
+- one rollback branch (prove failure cleanup is checked).
+
+A passing test that has never been seen failing is not evidence. Note also that
+sabotage proves a test detects *some* change; it does not prove the test encodes
+the correct specification. The runtime renderer is the authority for that.
+
+## 8. Naming
+
+**Consolidate**, internally and in the UI. "Glue" may become an alias later; the
+internal operation keeps the precise meaning — *replace a lane's audio across a
+defined timeline range with one equivalent source-domain clip*.
+
+"Bounce in Place" remains reserved for the graph-level operation and must not be
+used here, for the same reason `CommitAudioClipEditsCommand` is not called
+bounce.


### PR DESCRIPTION
Doc-only. Settles the semantics of Consolidate **before** the renderer exists, so the implementation cannot quietly become the specification.

Independent of #690 — touches `AestraDocs/` only, so it can land in any order.

## Why now

Consolidation has enough hidden decisions that an implementation grown from whichever code seam is nearest would end up permanently inconsistent with playback. Two statements govern the document:

> The reference implementation for audible behaviour is the runtime clip renderer, not a parallel interpretation of clip edits.

> Consolidation equivalence is measured on the engine's rendered output before and after the operation, including the samples immediately around every original clip boundary.

The first one is not hypothetical — the fade shape in #689 disagreed with `AudioEngine::clipFadeAt` precisely because it was re-derived rather than mirrored.

## The interface

```
consolidate_audio --lane <canonical-lane-id> --start <beat> --end <beat>
```

Stateless, with no Muse selection object and no `set_selection` verb — invisible state drifts between calls. Verified while writing this: there is no first-class timeline selection in the tree to translate from either, only `TrackManagerUI`'s pixel-space rubber-band. A selection verb would have had to fabricate the state it then hid.

The lane is addressed by canonical UUID, which `list_clips` already emits losslessly. Positional indexes shift when lanes are deleted — the same identity class repaired for clips in #690.

## The edge-fade policy

The part most likely to be got wrong. Consolidation removes the boundaries *between* the original clips, so the engine stops applying its automatic edge fade there — while still applying it at the two boundaries of the new clip.

> Bake every original automatic clip-edge fade, except an edge exactly coincident with the corresponding outer consolidation boundary.

- Internal boundaries **must** be baked, or every original seam changes. This includes a clip starting after `startBeat` or ending before `endBeat`, even across silence.
- Outer boundaries **must not** be baked, or the edge is attenuated by `r²`.

Delegating the outer boundary is exact, not approximate: applying a linear ramp to each clip before summing gives `r·A + r·B = r·(A + B)`, which is what the new clip's own edge fade produces.

Separately, v1 rejects any range cutting through a clip — that would create a boundary playback never had, so the result gains a fade the original lacked. Arbitrary cuts wait for an explicit per-edge policy that is serialized, consumed by playback, and equivalence-tested **in the same PR**. Never another passive field; this arc opened by deleting two of those.

## Also recorded

- Nine-point range/ownership contract through execute, failure, undo and redo.
- Refusal rules: an audible property that cannot be reproduced must **stop** the operation, never be silently omitted.
- Three-piece architecture — `AudioConsolidationRenderer`, existing `ClipRenderService` helpers, `ConsolidateAudioRangeCommand` — explicitly *not* stretching `ClipRenderService`.
- The source-domain boundary against the later graph renderer that will back Freeze and stem printing.
- Test gates, including that material must be deliberately **discontinuous**: smooth signals sit near zero at a boundary and would hide a missing edge fade entirely.
- Naming: Consolidate, with "Bounce in Place" still reserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)