### PR TITLE
Extract the per-clip render body to a private helper

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -722,6 +722,33 @@ private:
     // renderTrack phase helpers (verbatim extractions; RT path — no allocation).
     void renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
                      bool& srcActiveThisBlock);
+
+    /**
+     * @brief What rendering one clip reported back, beyond the audio it mixed.
+     *
+     * Not a bare bool: `false` means "direct-rate audio was mixed
+     * successfully", not "the clip contributed nothing". Naming the field
+     * keeps SRC meaning *sample-rate conversion ran*.
+     */
+    struct ClipRenderResult {
+        bool usedSampleRateConversion{false};
+    };
+
+    /**
+     * @brief Render one clip into @p destination. Pure relocation of the
+     *        per-clip body of renderClips(); the arithmetic is unchanged.
+     *
+     * Knows nothing about telemetry. The caller aggregates the result across
+     * the block and increments the counter once, preserving the existing
+     * contract of one SRC-active increment per block rather than per clip.
+     *
+     * [[nodiscard]] deliberately: discarding the result would keep every audio
+     * sample identical while silently deleting SRC telemetry, which the
+     * characterization digests cannot see.
+     */
+    [[nodiscard]] ClipRenderResult renderClipInto(const ClipRenderState& clip, uint64_t blockStart, uint64_t blockEnd,
+                                                  double* destination, uint32_t cachedSampleRate,
+                                                  Interpolators::InterpolationQuality cachedInterpQuality);
     void renderTrackUnits(uint32_t mixerChannelId, std::vector<double>& buffer, const RenderContext& ctx);
     float processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
                               uint32_t numFrames);

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2227,6 +2227,230 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     }
 }
 
+AudioEngine::ClipRenderResult AudioEngine::renderClipInto(const ClipRenderState& clip, uint64_t blockStart,
+                                                          uint64_t blockEnd, double* destination,
+                                                          uint32_t cachedSampleRate,
+                                                          Interpolators::InterpolationQuality cachedInterpQuality) {
+    // Verbatim relocation of the per-clip body of renderClips(). The only
+    // changes are mechanical: the loop-carried telemetry flag became this
+    // result, and each clip-level `continue` became a return of it. Transport
+    // and pattern-mode guards stay at the call site; this never sees them.
+    ClipRenderResult result{};
+
+        if (!clip.audioData || blockEnd <= clip.startSample || blockStart >= clip.endSample) {
+            return result;
+        }
+
+        const uint64_t start = std::max(blockStart, clip.startSample);
+        const uint64_t end = std::min(blockEnd, clip.endSample);
+        const uint32_t localOffset = static_cast<uint32_t>(start - blockStart);
+        uint32_t framesToRender = static_cast<uint32_t>(end - start);
+
+        // Sample rate ratio
+        const double outputRate = static_cast<double>(cachedSampleRate);
+        const double srcRate = clip.sourceSampleRate > 0.0 ? clip.sourceSampleRate : outputRate;
+        const double playbackRate =
+            std::isfinite(clip.playbackRate) ? clampD(static_cast<double>(clip.playbackRate), 0.25, 4.0) : 1.0;
+        const double ratio = (srcRate / outputRate) * playbackRate;
+
+        // Source position
+        const double outputFrameOffset = static_cast<double>(start - clip.startSample);
+        double phase = clip.sampleOffset + outputFrameOffset * ratio;
+
+        // Bounds
+        const int64_t totalFrames = static_cast<int64_t>(clip.totalFrames);
+        const uint64_t totalFrameCount = static_cast<uint64_t>(totalFrames);
+        if (totalFrames > 0 && phase >= static_cast<double>(totalFrames)) {
+            return result;
+        }
+        if (totalFrames > 0) {
+            const double remaining = static_cast<double>(totalFrames) - phase;
+            const uint32_t maxFrames = static_cast<uint32_t>(remaining / ratio);
+            framesToRender = std::min(framesToRender, maxFrames);
+        }
+        if (framesToRender == 0)
+            return result;
+
+        const uint32_t channels = clip.channels;
+        const uint32_t stride = channels;
+
+        double* dstBase = destination;
+        const float* data = clip.audioData;
+        double* dst = dstBase + static_cast<size_t>(localOffset) * 2;
+
+        const uint64_t clipLength = clip.endSample - clip.startSample;
+        const uint64_t fadeInLen =
+            std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeInSamples));
+        const uint64_t fadeOutLen =
+            std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeOutSamples));
+        const auto clipFadeAt = [&clip, fadeInLen, fadeOutLen](uint64_t projectSample) {
+            double fade = 1.0;
+            if (fadeInLen > 0 && projectSample < clip.startSample + fadeInLen) {
+                fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
+                                          static_cast<double>(fadeInLen));
+            }
+            if (fadeOutLen > 0 && projectSample + fadeOutLen > clip.endSample) {
+                fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
+                                          static_cast<double>(fadeOutLen));
+            }
+            return fade;
+        };
+        // Clip pan is an instance-level stereo balance before the insert.
+        // Centre must remain unity so opening the editor cannot change old
+        // projects or stack a second -3 dB centre law with the insert pan.
+        const double clipPan = clampD(static_cast<double>(clip.pan), -1.0, 1.0);
+        const double clipGain = static_cast<double>(clip.gain);
+        const double clipGainL = clipGain * (clipPan > 0.0 ? 1.0 - clipPan : 1.0);
+        const double clipGainR = clipGain * (clipPan < 0.0 ? 1.0 + clipPan : 1.0);
+
+        // Fast path: matching sample rates - direct copy to double
+        if (std::abs(ratio - 1.0) < 1e-9) {
+            const uint64_t srcStart = static_cast<uint64_t>(phase);
+            const float* src = data + srcStart * stride;
+            for (uint32_t i = 0; i < framesToRender; ++i) {
+                // Micro-fade at clip edges to avoid clicks/crackles.
+                const uint64_t projectSample = start + i;
+                const double fade = clipFadeAt(projectSample);
+
+                // Sanitize clip source reads: a corrupted audio file can
+                // contain NaN/Inf that would otherwise poison the mix.
+                double sL, sR;
+                if (channels == 1) {
+                    sL = sanitizeMix(static_cast<double>(src[i]));
+                    sR = sL;
+                } else {
+                    sL = sanitizeMix(static_cast<double>(src[i * 2]));
+                    sR = sanitizeMix(static_cast<double>(src[i * 2 + 1]));
+                }
+
+                dst[i * 2] += sL * clipGainL * fade;
+                dst[i * 2 + 1] += sR * clipGainR * fade;
+            }
+        } else {
+            result.usedSampleRateConversion = true;
+            // Resampling - use selected quality, pre-compute end condition
+            const double phaseEnd = static_cast<double>(totalFrames);
+
+            if (channels == 1) {
+                // Mono Resampling — use the same quality interpolators as stereo.
+                // The mono path reads a single float per frame, so we duplicate to L/R.
+                switch (cachedInterpQuality) {
+                case Interpolators::InterpolationQuality::Cubic:
+                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                        const uint64_t projectSample = start + i;
+                        const double fade = clipFadeAt(projectSample);
+                        float sample = 0.0f;
+                        uint64_t idx = static_cast<uint64_t>(phase);
+                        double frac = phase - static_cast<double>(idx);
+                        // Catmull-Rom 4-point on mono data
+                        float s0 = (idx > 0) ? data[idx - 1] : data[idx];
+                        float s1 = data[idx];
+                        float s2 = (idx + 1 < totalFrameCount) ? data[idx + 1] : data[idx];
+                        float s3 = (idx + 2 < totalFrameCount) ? data[idx + 2] : s2;
+                        double f = frac;
+                        sample = static_cast<float>(0.5 * ((2.0 * s1) + (-s0 + s2) * f +
+                                                           (2.0 * s0 - 5.0 * s1 + 4.0 * s2 - s3) * f * f +
+                                                           (-s0 + 3.0 * s1 - 3.0 * s2 + s3) * f * f * f));
+                        dst[i * 2] += sample * clipGainL * fade;
+                        dst[i * 2 + 1] += sample * clipGainR * fade;
+                        phase += ratio;
+                    }
+                    return result;
+                case Interpolators::InterpolationQuality::Sinc8:
+                case Interpolators::InterpolationQuality::Sinc16:
+                case Interpolators::InterpolationQuality::Sinc32:
+                case Interpolators::InterpolationQuality::Sinc64:
+                    // Sinc on mono: compute weighted sum, duplicate to L/R
+                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                        const uint64_t projectSample = start + i;
+                        const double fade = clipFadeAt(projectSample);
+                        double val =
+                            Interpolators::sincInterpolateMono(data, totalFrames, phase, cachedInterpQuality);
+                        dst[i * 2] += val * clipGainL * fade;
+                        dst[i * 2 + 1] += val * clipGainR * fade;
+                        phase += ratio;
+                    }
+                    return result;
+                default:
+                    // Linear fallback
+                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                        const uint64_t projectSample = start + i;
+                        const double fade = clipFadeAt(projectSample);
+                        uint64_t idx = static_cast<uint64_t>(phase);
+                        double frac = phase - static_cast<double>(idx);
+                        float s0 = data[idx];
+                        float s1 = (idx + 1 < static_cast<uint64_t>(totalFrames)) ? data[idx + 1] : s0;
+                        double val = s0 + frac * (s1 - s0);
+                        dst[i * 2] += val * clipGainL * fade;
+                        dst[i * 2 + 1] += val * clipGainR * fade;
+                        phase += ratio;
+                    }
+                    return result;
+                }
+            }
+
+            // Select interpolator at block level, not per-sample
+            switch (m_interpQuality.load(std::memory_order_relaxed)) {
+            case Interpolators::InterpolationQuality::Cubic:
+                for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                    float outL, outR;
+                    Interpolators::CubicInterpolator::interpolate(data, totalFrames, phase, outL, outR);
+                    const uint64_t projectSample = start + i;
+                    const double fade = clipFadeAt(projectSample);
+                    dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                    dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
+                    phase += ratio;
+                }
+                break;
+            case Interpolators::InterpolationQuality::Sinc8:
+                for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                    float outL, outR;
+                    Interpolators::Sinc8Interpolator::interpolate(data, totalFrames, phase, outL, outR);
+                    const uint64_t projectSample = start + i;
+                    const double fade = clipFadeAt(projectSample);
+                    dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                    dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
+                    phase += ratio;
+                }
+                break;
+            case Interpolators::InterpolationQuality::Sinc16:
+                for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                    float outL, outR;
+                    Interpolators::Sinc16Interpolator::interpolate(data, totalFrames, phase, outL, outR);
+                    const uint64_t projectSample = start + i;
+                    const double fade = clipFadeAt(projectSample);
+                    dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                    dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
+                    phase += ratio;
+                }
+                break;
+            case Interpolators::InterpolationQuality::Sinc32:
+                for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                    float outL, outR;
+                    Interpolators::Sinc32Interpolator::interpolate(data, totalFrames, phase, outL, outR);
+                    const uint64_t projectSample = start + i;
+                    const double fade = clipFadeAt(projectSample);
+                    dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                    dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
+                    phase += ratio;
+                }
+                break;
+            case Interpolators::InterpolationQuality::Sinc64:
+                for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
+                    float outL, outR;
+                    Interpolators::Sinc64Interpolator::interpolate(data, totalFrames, phase, outL, outR);
+                    const uint64_t projectSample = start + i;
+                    const double fade = clipFadeAt(projectSample);
+                    dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
+                    dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
+                    phase += ratio;
+                }
+                break;
+            }
+        }
+    return result;
+}
+
 void AudioEngine::renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
                               bool& srcActiveThisBlock) {
     // Verbatim clip-rendering phase moved out of renderTrack(); same ctx
@@ -2246,218 +2470,14 @@ void AudioEngine::renderClips(const std::vector<ClipRenderState>& clips, double*
         for (const auto& clip : clips) {
             if (!isPlaying)
                 continue;
-            if (!clip.audioData || blockEnd <= clip.startSample || blockStart >= clip.endSample) {
-                continue;
-            }
-
-            const uint64_t start = std::max(blockStart, clip.startSample);
-            const uint64_t end = std::min(blockEnd, clip.endSample);
-            const uint32_t localOffset = static_cast<uint32_t>(start - blockStart);
-            uint32_t framesToRender = static_cast<uint32_t>(end - start);
-
-            // Sample rate ratio
-            const double outputRate = static_cast<double>(cachedSampleRate);
-            const double srcRate = clip.sourceSampleRate > 0.0 ? clip.sourceSampleRate : outputRate;
-            const double playbackRate =
-                std::isfinite(clip.playbackRate) ? clampD(static_cast<double>(clip.playbackRate), 0.25, 4.0) : 1.0;
-            const double ratio = (srcRate / outputRate) * playbackRate;
-
-            // Source position
-            const double outputFrameOffset = static_cast<double>(start - clip.startSample);
-            double phase = clip.sampleOffset + outputFrameOffset * ratio;
-
-            // Bounds
-            const int64_t totalFrames = static_cast<int64_t>(clip.totalFrames);
-            const uint64_t totalFrameCount = static_cast<uint64_t>(totalFrames);
-            if (totalFrames > 0 && phase >= static_cast<double>(totalFrames)) {
-                continue;
-            }
-            if (totalFrames > 0) {
-                const double remaining = static_cast<double>(totalFrames) - phase;
-                const uint32_t maxFrames = static_cast<uint32_t>(remaining / ratio);
-                framesToRender = std::min(framesToRender, maxFrames);
-            }
-            if (framesToRender == 0)
-                continue;
-
-            const uint32_t channels = clip.channels;
-            const uint32_t stride = channels;
-
-            double* dstBase = destination;
-            const float* data = clip.audioData;
-            double* dst = dstBase + static_cast<size_t>(localOffset) * 2;
-
-            const uint64_t clipLength = clip.endSample - clip.startSample;
-            const uint64_t fadeInLen =
-                std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeInSamples));
-            const uint64_t fadeOutLen =
-                std::min(clipLength, std::max<uint64_t>(CLIP_EDGE_FADE_SAMPLES, clip.fadeOutSamples));
-            const auto clipFadeAt = [&clip, fadeInLen, fadeOutLen](uint64_t projectSample) {
-                double fade = 1.0;
-                if (fadeInLen > 0 && projectSample < clip.startSample + fadeInLen) {
-                    fade = std::min(fade, static_cast<double>(projectSample - clip.startSample) /
-                                              static_cast<double>(fadeInLen));
-                }
-                if (fadeOutLen > 0 && projectSample + fadeOutLen > clip.endSample) {
-                    fade = std::min(fade, static_cast<double>(clip.endSample - projectSample) /
-                                              static_cast<double>(fadeOutLen));
-                }
-                return fade;
-            };
-            // Clip pan is an instance-level stereo balance before the insert.
-            // Centre must remain unity so opening the editor cannot change old
-            // projects or stack a second -3 dB centre law with the insert pan.
-            const double clipPan = clampD(static_cast<double>(clip.pan), -1.0, 1.0);
-            const double clipGain = static_cast<double>(clip.gain);
-            const double clipGainL = clipGain * (clipPan > 0.0 ? 1.0 - clipPan : 1.0);
-            const double clipGainR = clipGain * (clipPan < 0.0 ? 1.0 + clipPan : 1.0);
-
-            // Fast path: matching sample rates - direct copy to double
-            if (std::abs(ratio - 1.0) < 1e-9) {
-                const uint64_t srcStart = static_cast<uint64_t>(phase);
-                const float* src = data + srcStart * stride;
-                for (uint32_t i = 0; i < framesToRender; ++i) {
-                    // Micro-fade at clip edges to avoid clicks/crackles.
-                    const uint64_t projectSample = start + i;
-                    const double fade = clipFadeAt(projectSample);
-
-                    // Sanitize clip source reads: a corrupted audio file can
-                    // contain NaN/Inf that would otherwise poison the mix.
-                    double sL, sR;
-                    if (channels == 1) {
-                        sL = sanitizeMix(static_cast<double>(src[i]));
-                        sR = sL;
-                    } else {
-                        sL = sanitizeMix(static_cast<double>(src[i * 2]));
-                        sR = sanitizeMix(static_cast<double>(src[i * 2 + 1]));
-                    }
-
-                    dst[i * 2] += sL * clipGainL * fade;
-                    dst[i * 2 + 1] += sR * clipGainR * fade;
-                }
-            } else {
-                srcActiveThisBlock = true;
-                // Resampling - use selected quality, pre-compute end condition
-                const double phaseEnd = static_cast<double>(totalFrames);
-
-                if (channels == 1) {
-                    // Mono Resampling — use the same quality interpolators as stereo.
-                    // The mono path reads a single float per frame, so we duplicate to L/R.
-                    switch (cachedInterpQuality) {
-                    case Interpolators::InterpolationQuality::Cubic:
-                        for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            const uint64_t projectSample = start + i;
-                            const double fade = clipFadeAt(projectSample);
-                            float sample = 0.0f;
-                            uint64_t idx = static_cast<uint64_t>(phase);
-                            double frac = phase - static_cast<double>(idx);
-                            // Catmull-Rom 4-point on mono data
-                            float s0 = (idx > 0) ? data[idx - 1] : data[idx];
-                            float s1 = data[idx];
-                            float s2 = (idx + 1 < totalFrameCount) ? data[idx + 1] : data[idx];
-                            float s3 = (idx + 2 < totalFrameCount) ? data[idx + 2] : s2;
-                            double f = frac;
-                            sample = static_cast<float>(0.5 * ((2.0 * s1) + (-s0 + s2) * f +
-                                                               (2.0 * s0 - 5.0 * s1 + 4.0 * s2 - s3) * f * f +
-                                                               (-s0 + 3.0 * s1 - 3.0 * s2 + s3) * f * f * f));
-                            dst[i * 2] += sample * clipGainL * fade;
-                            dst[i * 2 + 1] += sample * clipGainR * fade;
-                            phase += ratio;
-                        }
-                        continue;
-                    case Interpolators::InterpolationQuality::Sinc8:
-                    case Interpolators::InterpolationQuality::Sinc16:
-                    case Interpolators::InterpolationQuality::Sinc32:
-                    case Interpolators::InterpolationQuality::Sinc64:
-                        // Sinc on mono: compute weighted sum, duplicate to L/R
-                        for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            const uint64_t projectSample = start + i;
-                            const double fade = clipFadeAt(projectSample);
-                            double val =
-                                Interpolators::sincInterpolateMono(data, totalFrames, phase, cachedInterpQuality);
-                            dst[i * 2] += val * clipGainL * fade;
-                            dst[i * 2 + 1] += val * clipGainR * fade;
-                            phase += ratio;
-                        }
-                        continue;
-                    default:
-                        // Linear fallback
-                        for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                            const uint64_t projectSample = start + i;
-                            const double fade = clipFadeAt(projectSample);
-                            uint64_t idx = static_cast<uint64_t>(phase);
-                            double frac = phase - static_cast<double>(idx);
-                            float s0 = data[idx];
-                            float s1 = (idx + 1 < static_cast<uint64_t>(totalFrames)) ? data[idx + 1] : s0;
-                            double val = s0 + frac * (s1 - s0);
-                            dst[i * 2] += val * clipGainL * fade;
-                            dst[i * 2 + 1] += val * clipGainR * fade;
-                            phase += ratio;
-                        }
-                        continue;
-                    }
-                }
-
-                // Select interpolator at block level, not per-sample
-                switch (m_interpQuality.load(std::memory_order_relaxed)) {
-                case Interpolators::InterpolationQuality::Cubic:
-                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                        float outL, outR;
-                        Interpolators::CubicInterpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        const uint64_t projectSample = start + i;
-                        const double fade = clipFadeAt(projectSample);
-                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
-                        phase += ratio;
-                    }
-                    break;
-                case Interpolators::InterpolationQuality::Sinc8:
-                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                        float outL, outR;
-                        Interpolators::Sinc8Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        const uint64_t projectSample = start + i;
-                        const double fade = clipFadeAt(projectSample);
-                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
-                        phase += ratio;
-                    }
-                    break;
-                case Interpolators::InterpolationQuality::Sinc16:
-                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                        float outL, outR;
-                        Interpolators::Sinc16Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        const uint64_t projectSample = start + i;
-                        const double fade = clipFadeAt(projectSample);
-                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
-                        phase += ratio;
-                    }
-                    break;
-                case Interpolators::InterpolationQuality::Sinc32:
-                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                        float outL, outR;
-                        Interpolators::Sinc32Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        const uint64_t projectSample = start + i;
-                        const double fade = clipFadeAt(projectSample);
-                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
-                        phase += ratio;
-                    }
-                    break;
-                case Interpolators::InterpolationQuality::Sinc64:
-                    for (uint32_t i = 0; i < framesToRender && phase < phaseEnd; ++i) {
-                        float outL, outR;
-                        Interpolators::Sinc64Interpolator::interpolate(data, totalFrames, phase, outL, outR);
-                        const uint64_t projectSample = start + i;
-                        const double fade = clipFadeAt(projectSample);
-                        dst[i * 2] += static_cast<double>(outL) * clipGainL * fade;
-                        dst[i * 2 + 1] += static_cast<double>(outR) * clipGainR * fade;
-                        phase += ratio;
-                    }
-                    break;
-                }
-            }
-        } // End pattern mode check
+            // Non-short-circuiting |= on purpose. With ||, the first clip that
+            // converted would set the flag and every later clip in the block
+            // would never be rendered — telemetry would still report one
+            // SRC-active block, correctly, while the audio quietly lost a clip.
+            const ClipRenderResult result =
+                renderClipInto(clip, blockStart, blockEnd, destination, cachedSampleRate, cachedInterpQuality);
+            srcActiveThisBlock |= result.usedSampleRateConversion;
+        }
     }
 }
 

--- a/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
+++ b/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
@@ -1,0 +1,289 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// SRC telemetry driven by actual rendering.
+//
+// The characterization harness compares rendered audio, so it is structurally
+// blind to this: `srcActiveThisBlock` is pure telemetry and never reaches the
+// mix. Extracting the clip body turns the mono resampling branch's
+// clip-level `continue` statements into `return`s, and a return that forgets
+// to carry the flag loses the counter while every digest stays identical.
+//
+// "SRC active" means *sample-rate conversion ran*, not "a clip contributed
+// audio". A unity-rate clip mixes real audio and must NOT set it.
+
+#include "Commands/CommandRegistry.h"
+#include "Commands/MuseService.h"
+#include "Core/AudioEngine.h"
+#include "Models/TrackManager.h"
+#include "Plugin/PluginManager.h"
+
+#include "AestraJSON.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Aestra::Audio::AudioBufferData;
+using Aestra::Audio::AudioEngine;
+using Aestra::Audio::ClipEdits;
+using Aestra::Audio::ClipInstance;
+using Aestra::Audio::ClipInstanceID;
+using Aestra::Audio::ClipSourceID;
+using Aestra::Audio::CommandRegistry;
+using Aestra::Audio::MuseService;
+using Aestra::Audio::PatternID;
+using Aestra::Audio::PlaylistLaneID;
+using Aestra::Audio::TrackManager;
+using Aestra::JSON;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << "\n";
+    } else {
+        std::cout << "FAIL: " << label << "\n";
+        ++g_failures;
+    }
+}
+
+std::shared_ptr<AudioBufferData> makeSource(uint32_t sampleRate, uint32_t channels, uint64_t frames) {
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = sampleRate;
+    buffer->numChannels = channels;
+    buffer->numFrames = frames;
+    buffer->interleavedData.resize(static_cast<size_t>(frames) * channels);
+    for (uint64_t i = 0; i < frames; ++i) {
+        const float step = ((i / 64) % 2 == 0) ? 0.7f : -0.7f;
+        for (uint32_t c = 0; c < channels; ++c) {
+            buffer->interleavedData[i * channels + c] = step;
+        }
+    }
+    return buffer;
+}
+
+struct Rig {
+    std::shared_ptr<TrackManager> tm;
+    std::unique_ptr<AudioEngine> engine;
+    std::unique_ptr<MuseService> service;
+    PlaylistLaneID lane;
+    std::string dir;
+
+    bool init(const std::string& d) {
+        dir = d;
+        tm = std::make_shared<TrackManager>();
+        tm->getUnitManager().setPatternManager(&tm->getPatternManager());
+        engine = std::make_unique<AudioEngine>();
+        engine->setSampleRate(48000);
+        engine->setBufferConfig(4096, 2);
+        MuseService::wireHeadlessEngine(tm, *engine);
+        if (!engine->initialize()) return false;
+        service = std::make_unique<MuseService>(tm.get(), engine.get());
+        lane = tm->getPlaylistModel().createLane("src");
+        return lane.isValid();
+    }
+
+    void addClip(const std::string& name, std::shared_ptr<AudioBufferData> buffer, double startBeat = 0.0,
+                 const ClipEdits& edits = ClipEdits{}) {
+        const double seconds = buffer->durationSeconds();
+        const uint64_t frames = buffer->numFrames;
+        const ClipSourceID sourceId =
+            tm->getSourceManager().createRecordedSource(dir + "/" + name + ".src", name, std::move(buffer));
+
+        Aestra::Audio::AudioSlicePayload payload;
+        payload.audioSourceId = sourceId;
+        payload.durationSeconds = seconds;
+        Aestra::Audio::AudioSlice slice;
+        slice.startSamples = 0.0;
+        slice.lengthSamples = static_cast<double>(frames);
+        payload.slices.push_back(slice);
+
+        const double beats = tm->getPlaylistModel().secondsToBeats(seconds);
+        const PatternID pattern = tm->getPatternManager().createAudioPattern(name, beats, payload);
+
+        ClipInstance clip;
+        clip.id = ClipInstanceID::generate();
+        clip.name = name;
+        clip.startBeat = startBeat;
+        clip.durationBeats = beats;
+        clip.durationSeconds = seconds;
+        clip.patternId = pattern;
+        clip.sourceId = pattern.value;
+        clip.edits = edits;
+        tm->getPlaylistModel().addClip(lane, clip);
+    }
+
+    /** Render the timeline and report how far the SRC counter advanced. */
+    uint64_t renderAndCountSrcBlocks(const std::string& file) {
+        const uint64_t before = engine->telemetry().getSrcActiveBlocks();
+        JSON args = JSON::object();
+        args.set("file", JSON(file));
+        args.set("tail", JSON(0.0));
+        JSON req = JSON::object();
+        req.set("id", JSON(1.0));
+        req.set("verb", JSON(std::string("render_song")));
+        req.set("args", args);
+        JSON r = JSON::parse(service->handleRequest(req.toString()));
+        if (!r.has("status") || r["status"].asString() != "ok") return UINT64_MAX;
+        return engine->telemetry().getSrcActiveBlocks() - before;
+    }
+};
+
+/** Set the engine's interpolation quality, exercising each mono switch case. */
+void runQualityCase(const std::string& dir, Aestra::Audio::Interpolators::InterpolationQuality quality,
+                    const std::string& label) {
+    Rig rig;
+    if (!rig.init(dir)) {
+        check(false, label + ": rig initialises");
+        return;
+    }
+    rig.engine->setInterpolationQuality(quality);
+    // Mono at a non-engine rate: forces the mono resampling branch, whose
+    // clip-level `continue` statements become returns once the body moves.
+    rig.addClip("mono44k_" + label, makeSource(44100, 1, 22050));
+    const uint64_t blocks = rig.renderAndCountSrcBlocks(dir + "/mono_" + label + ".wav");
+    check(blocks != UINT64_MAX, label + ": render succeeds");
+    check(blocks > 0, label + ": mono resampling marks SRC active");
+}
+
+} // namespace
+
+int main() {
+    if (!Aestra::Audio::PluginManager::getInstance().initialize()) {
+        std::cout << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+    CommandRegistry::initialize();
+
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() / "aestra_src_telemetry";
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    fs::create_directories(dir, ec);
+    if (ec) {
+        std::cout << "FAIL: could not create the working directory\n";
+        return 1;
+    }
+    const std::string d = dir.string();
+
+    std::cout << "=== SRC telemetry driven by rendering ===\n";
+
+    // A unity-rate clip mixes real audio through the direct-copy path. SRC
+    // must stay untouched: the flag means conversion ran, not "audio played".
+    {
+        Rig rig;
+        if (rig.init(d)) {
+            rig.addClip("unity", makeSource(48000, 2, 24000));
+            const uint64_t blocks = rig.renderAndCountSrcBlocks(d + "/unity.wav");
+            check(blocks != UINT64_MAX, "unity-rate: render succeeds");
+            check(blocks == 0, "unity-rate: mixes audio without marking SRC active");
+        } else {
+            check(false, "unity-rate: rig initialises");
+        }
+    }
+
+    // Stereo at a different rate: the stereo resampling branch.
+    {
+        Rig rig;
+        if (rig.init(d)) {
+            rig.addClip("stereo44k", makeSource(44100, 2, 22050));
+            const uint64_t blocks = rig.renderAndCountSrcBlocks(d + "/stereo.wav");
+            check(blocks != UINT64_MAX, "stereo resampled: render succeeds");
+            check(blocks > 0, "stereo resampled: marks SRC active");
+        } else {
+            check(false, "stereo resampled: rig initialises");
+        }
+    }
+
+    // Every mono switch case, because each ends in its own clip-level exit.
+    using Q = Aestra::Audio::Interpolators::InterpolationQuality;
+    runQualityCase(d, Q::Cubic, "cubic");
+    runQualityCase(d, Q::Sinc8, "sinc8");
+    runQualityCase(d, Q::Sinc16, "sinc16");
+    runQualityCase(d, Q::Sinc32, "sinc32");
+    runQualityCase(d, Q::Sinc64, "sinc64");
+
+    // The counter is one increment per *block* in which any clip converted,
+    // not one per clip. Two identical resampled clips over the same span must
+    // therefore advance it exactly as far as one does.
+    {
+        Rig one, two;
+        uint64_t oneClip = UINT64_MAX, twoClips = UINT64_MAX;
+        if (one.init(d)) {
+            one.addClip("solo", makeSource(44100, 2, 22050));
+            oneClip = one.renderAndCountSrcBlocks(d + "/solo.wav");
+        }
+        if (two.init(d)) {
+            two.addClip("dupA", makeSource(44100, 2, 22050));
+            two.addClip("dupB", makeSource(44100, 2, 22050));
+            twoClips = two.renderAndCountSrcBlocks(d + "/dup.wav");
+        }
+        check(oneClip != UINT64_MAX && twoClips != UINT64_MAX, "overlap: both renders succeed");
+        check(oneClip > 0, "overlap: a single resampled clip advances the counter");
+        check(twoClips == oneClip,
+              "overlap: two resampled clips in the same blocks advance it once per block, not per clip");
+    }
+
+    // A resampled clip that reaches the frame-count clamp but yields
+    // framesToRender == 0 must not mark SRC active. The flag means conversion
+    // actually ran, and it is set only *after* that rejection — so hoisting it
+    // earlier changes telemetry while leaving every audio sample identical.
+    //
+    // Constructed to land in exactly that window: ratio > 1 puts it on the
+    // resampling branch, and leaving fewer source frames than the ratio makes
+    // maxFrames = remaining / ratio truncate to zero. It must clear the
+    // preceding phase >= totalFrames guard, so remaining stays positive.
+    {
+        constexpr uint64_t kSourceFrames = 22050;
+        constexpr uint32_t kSourceRate = 48000;
+        constexpr uint32_t kEngineRate = 48000;
+        constexpr float kPlaybackRate = 4.0f;
+        constexpr double kRemaining = 2.0;
+
+        // Assert the predicate this witness exists to exercise, mirroring the
+        // engine's own arithmetic. Without this, a later change to the
+        // playback-rate clamp, the rate calculation or offset conversion could
+        // push the clip back to the earlier phase >= totalFrames exit while
+        // the telemetry expectation still passed — an outcome match that no
+        // longer witnesses the path.
+        const double ratio = (static_cast<double>(kSourceRate) / static_cast<double>(kEngineRate)) *
+                             static_cast<double>(kPlaybackRate);
+        const double phase = static_cast<double>(kSourceFrames) - kRemaining;
+        const double remaining = static_cast<double>(kSourceFrames) - phase;
+        check(std::abs(ratio - 1.0) >= 1e-9, "zero-frame clip: ratio is non-unity, so it takes the resampling branch");
+        check(phase < static_cast<double>(kSourceFrames),
+              "zero-frame clip: clears the phase >= totalFrames guard, so it reaches the length clamp");
+        check(remaining > 0.0 && remaining < ratio, "zero-frame clip: fewer source frames remain than the ratio");
+        check(static_cast<uint32_t>(remaining / ratio) == 0,
+              "zero-frame clip: the length clamp truncates framesToRender to zero");
+
+        Rig rig;
+        if (rig.init(d)) {
+            ClipEdits starved;
+            starved.playbackRate = kPlaybackRate;
+            starved.sourceStart = phase;
+            rig.addClip("starved", makeSource(kSourceRate, 2, kSourceFrames), 0.0, starved);
+            const uint64_t blocks = rig.renderAndCountSrcBlocks(d + "/starved.wav");
+            check(blocks != UINT64_MAX, "zero-frame clip: render succeeds");
+            check(blocks == 0,
+                  "zero-frame clip: a resampled clip clamped to zero frames does not mark SRC active");
+        } else {
+            check(false, "zero-frame clip: rig initialises");
+        }
+    }
+
+    fs::remove_all(dir, ec);
+
+    if (g_failures != 0) {
+        std::cout << "FAILED: " << g_failures << " check(s)\n";
+        return 1;
+    }
+    std::cout << "All SRC telemetry checks passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
+++ b/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -121,6 +122,8 @@ struct Rig {
 
     /** Total squared sample energy of the last render, for "did it contribute?". */
     double lastRenderEnergy{0.0};
+    /** Samples actually read from the data chunk, so a misread cannot look like silence. */
+    size_t lastRenderSamples{0};
 
     /** Render the timeline and report how far the SRC counter advanced. */
     uint64_t renderAndCountSrcBlocks(const std::string& file) {
@@ -135,13 +138,37 @@ struct Rig {
         JSON r = JSON::parse(service->handleRequest(req.toString()));
         if (!r.has("status") || r["status"].asString() != "ok") return UINT64_MAX;
 
+        // Scan for the data chunk rather than assuming a 44-byte header.
+        // AudioExporter emits exactly RIFF+WAVE+fmt+data today, so a fixed
+        // seek happens to work — but ClipRenderService's writer already emits
+        // a fact chunk, and a misaligned seek would sum garbage floats into a
+        // value still greater than zero. This test exists to catch a silently
+        // lost clip; it cannot afford to pass or fail for an unrelated reason.
         lastRenderEnergy = 0.0;
+        lastRenderSamples = 0;
         std::FILE* f = std::fopen(file.c_str(), "rb");
         if (f) {
-            std::fseek(f, 44, SEEK_SET); // past the canonical float32 header
-            float sample = 0.0f;
-            while (std::fread(&sample, sizeof(float), 1, f) == 1) {
-                if (std::isfinite(sample)) lastRenderEnergy += static_cast<double>(sample) * sample;
+            char riff[4], wave[4];
+            uint32_t riffSize = 0;
+            if (std::fread(riff, 1, 4, f) == 4 && std::fread(&riffSize, 4, 1, f) == 1 &&
+                std::fread(wave, 1, 4, f) == 4 && std::memcmp(riff, "RIFF", 4) == 0 &&
+                std::memcmp(wave, "WAVE", 4) == 0) {
+                char id[4];
+                uint32_t size = 0;
+                while (std::fread(id, 1, 4, f) == 4 && std::fread(&size, 4, 1, f) == 1) {
+                    if (std::memcmp(id, "data", 4) == 0) {
+                        const size_t count = size / sizeof(float);
+                        float sample = 0.0f;
+                        for (size_t i = 0; i < count && std::fread(&sample, sizeof(float), 1, f) == 1; ++i) {
+                            if (std::isfinite(sample)) {
+                                lastRenderEnergy += static_cast<double>(sample) * sample;
+                            }
+                            ++lastRenderSamples;
+                        }
+                        break;
+                    }
+                    std::fseek(f, static_cast<long>(size + (size & 1u)), SEEK_CUR);
+                }
             }
             std::fclose(f);
         }
@@ -248,6 +275,8 @@ int main() {
         // resampled clip sets the flag and every later clip in the block is
         // never rendered at all — telemetry still reports one SRC-active
         // block, correctly, while the audio silently loses a clip.
+        check(one.lastRenderSamples > 0 && two.lastRenderSamples > 0,
+              "overlap: the data chunk was located in both renders");
         check(one.lastRenderEnergy > 0.0, "overlap: the single-clip render carries audio");
         check(two.lastRenderEnergy > one.lastRenderEnergy * 1.5,
               "overlap: the second clip still contributes audio after the first set the flag");

--- a/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
+++ b/Tests/AestraAudio/ClipSrcTelemetryTest.cpp
@@ -119,6 +119,9 @@ struct Rig {
         tm->getPlaylistModel().addClip(lane, clip);
     }
 
+    /** Total squared sample energy of the last render, for "did it contribute?". */
+    double lastRenderEnergy{0.0};
+
     /** Render the timeline and report how far the SRC counter advanced. */
     uint64_t renderAndCountSrcBlocks(const std::string& file) {
         const uint64_t before = engine->telemetry().getSrcActiveBlocks();
@@ -131,6 +134,17 @@ struct Rig {
         req.set("args", args);
         JSON r = JSON::parse(service->handleRequest(req.toString()));
         if (!r.has("status") || r["status"].asString() != "ok") return UINT64_MAX;
+
+        lastRenderEnergy = 0.0;
+        std::FILE* f = std::fopen(file.c_str(), "rb");
+        if (f) {
+            std::fseek(f, 44, SEEK_SET); // past the canonical float32 header
+            float sample = 0.0f;
+            while (std::fread(&sample, sizeof(float), 1, f) == 1) {
+                if (std::isfinite(sample)) lastRenderEnergy += static_cast<double>(sample) * sample;
+            }
+            std::fclose(f);
+        }
         return engine->telemetry().getSrcActiveBlocks() - before;
     }
 };
@@ -228,6 +242,15 @@ int main() {
         check(oneClip > 0, "overlap: a single resampled clip advances the counter");
         check(twoClips == oneClip,
               "overlap: two resampled clips in the same blocks advance it once per block, not per clip");
+
+        // The counter alone cannot see this. If the caller ever aggregates the
+        // helper result with short-circuiting || instead of |=, the first
+        // resampled clip sets the flag and every later clip in the block is
+        // never rendered at all — telemetry still reports one SRC-active
+        // block, correctly, while the audio silently loses a clip.
+        check(one.lastRenderEnergy > 0.0, "overlap: the single-clip render carries audio");
+        check(two.lastRenderEnergy > one.lastRenderEnergy * 1.5,
+              "overlap: the second clip still contributes audio after the first set the flag");
     }
 
     // A resampled clip that reaches the frame-count clamp but yields

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -322,4 +322,15 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/Cl
     set_tests_properties(ClipRenderCharacterizationTest PROPERTIES LABELS "audio;clip-render;characterization")
 endif()
 
+if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ClipSrcTelemetryTest.cpp")
+    add_executable(ClipSrcTelemetryTest AestraAudio/ClipSrcTelemetryTest.cpp)
+    target_link_libraries(ClipSrcTelemetryTest PRIVATE AestraAudioCore)
+    target_include_directories(ClipSrcTelemetryTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ClipSrcTelemetryTest COMMAND ClipSrcTelemetryTest)
+    set_tests_properties(ClipSrcTelemetryTest PROPERTIES LABELS "audio;clip-render;telemetry")
+endif()
+
 message(STATUS "Commands tests added - Phase 2 undo/redo system")


### PR DESCRIPTION
Step 3 of [`AestraDocs/specs/consolidate-audio-range.md` §4b](AestraDocs/specs/consolidate-audio-range.md) (#691): extract the clip-local kernel so a consolidation renderer can reuse it, **without changing a sample or an observable**.

Three commits, deliberately ordered so the contracts exist before the change they constrain.

| Commit | Purpose |
|---|---|
| `46baf4b6` | SRC telemetry contract + path witnesses |
| `73f7613b` | Caller control-flow contract (`\|=` vs `\|\|`) |
| `ab330700` | The extraction |

## Two ranges, two different claims

**Complete safety story** — guards established first, then the implementation moved to satisfy them:

```bash
git diff --stat 46baf4b6..ab330700
```

**Mechanical-extraction proof** — the range to actually scrutinize, since it excludes the guards and makes stray work visible:

```bash
git diff --stat 73f7613b..ab330700
```

The mechanical range is `+252 / −205`, larger than a pure move implies: the body de-indented one level leaving the loop, so nearly every line reads as changed. That is exactly why line counts are not the evidence here — the digests are.

## Why the guards had to come first

The characterization harness (#692) compares rendered audio, so it is **structurally blind** to telemetry. `srcActiveThisBlock` never reaches the mix. Extraction turns the mono branch's clip-level `continue` statements into `return`s, and a return that forgets the flag deletes the counter while every digest stays identical.

Demonstrated before writing the extraction: making the mono branch drop the flag fails five telemetry checks and leaves all six digests matching.

The caller guard covers a second blind spot. Rewriting `|=` as `||` short-circuits: the first converted clip sets the flag and **every later clip in the block is never rendered**. Sabotage after the extraction landed confirms it fails *only* the audio-contribution assertion — the counter assertion stays correctly green, and the digests never notice, because their overlapping fixture uses unity-rate clips that never set the flag.

## The extraction

```cpp
for (const auto& clip : clips) {
    if (!isPlaying) continue;                       // transport stays at the call site
    const ClipRenderResult result =
        renderClipInto(clip, blockStart, blockEnd, destination,
                       cachedSampleRate, cachedInterpQuality);
    srcActiveThisBlock |= result.usedSampleRateConversion;
}
```

- **Six clip-level exits, not five.** I predicted five; inspecting each site found three pre-render guards (no audio data / out of range, phase past source end, `framesToRender == 0`) plus three mono quality exits. Guards sit above the former assignment and return `false`; mono exits sit below and return the populated `true`. Transforming on the predicted count would have got one wrong.
- **Named struct, not `bool`.** `false` means "direct-rate audio mixed successfully", not "contributed nothing". SRC means *sample-rate conversion ran*.
- **`[[nodiscard]]`** — discarding the result would keep every sample identical while deleting telemetry.
- **No telemetry in the helper.** The caller aggregates; one increment per block, not per clip.

## Deliberately NOT normalized

Mono reads the block snapshot `cachedInterpQuality`; stereo loads `m_interpQuality` mid-block. That dual authority is **preserved exactly** — 2 atomic loads before, 2 after, the one diff line being indentation only.

Choosing a single authority is a decision about block coherence, not relocation, so it stays out. B1 establishes that the helper preserves current behaviour, which is what lets B2 change it against a measurable before/after instead of hiding the decision inside a move.

## Evidence

```
ab3307000bdd1cd2f36527e66fde932711f9ae1f — clean tree
Audio baseline:  6/6 exact against develop@6b79af40
SRC telemetry:   25/25
Canonical suite: 224/224
m_interpQuality: 2 atomic loads before, 2 after
Baselines:       6 present, 0 modified
No shared math extraction, quality normalization, free kernel,
atomic movement, or helper-owned telemetry
```

The full suite matters here beyond the two targeted gates: `AudioEngine.h` is broadly included, so the build rebuilds the whole UI/App layer. A signature change can break a dependent that neither the digests nor the telemetry test would ever exercise.

## Next

B2 — decide the interpolation-quality authority explicitly, then convert the member helper into the free kernel `AudioConsolidationRenderer` builds on. The shared math header belongs there, not here: a private member in the same translation unit reaches the file-local guards directly, so adding it now would have enlarged B1 and implied the move required it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Extracted per-clip rendering from `renderClips()` into the private `AudioEngine::renderClipInto()` helper.
- Preserved audio output, transport and pattern-mode guards, interpolation quality, fades, panning, gain, and sanitization.
- Added `ClipRenderResult` with `[[nodiscard]]` SRC status reporting. Block-level telemetry uses non-short-circuiting `|=` aggregation.
- Added SRC telemetry coverage for mono and stereo resampling, overlapping clips, interpolation modes, and zero-frame paths.
- Registered the telemetry test with CTest. Six audio baselines, 25/25 SRC checks, and 224/224 canonical tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->