### PR TITLE
docs: bound pricing and founder commitments

### DIFF
--- a/AestraDocs/design/Design-Language.md
+++ b/AestraDocs/design/Design-Language.md
@@ -1,7 +1,7 @@
 # Aestra Design Language — Borrowed Metaphors
 
 **Status:** Internal — Core design philosophy
-**Last Updated:** 2026-04-11
+**Last Updated:** 2026-08-01
 **Owner:** Dylan
 
 ---
@@ -205,17 +205,15 @@ track | reverb_send | reverb_return | master
 **Cards:**
 | Tier | Color | Rarity | Obtained By |
 |------|-------|--------|-------------|
-| Core | Grey | Common | Free — everyone gets one |
-| Campus | Blue | Academic | Free — .edu verification |
-| Supporter | Silver | Uncommon | $5/mo subscription |
-| Founder | Gold | Legendary | $129 one-time (limited window) |
+| Core | Neutral | Standard | Free — everyone belongs |
+| Supporter | Violet | Active | $5/mo or $50/yr subscription |
+| Founder | Gold | Numbered | $129 one-time, maximum 500 |
 
 **Properties:**
 - Visual card art with tier-specific styling
-- Unique ID number (especially Founders: #0042)
-- Seasonal variants for active Supporters
-- Level/frame upgrades through usage (not payment)
-- Physical card for Founders (metal, engraved)
+- Unique digital ID number for Founders, for example #0042
+- Fully digital; no physical card, production, or shipping promise
+- Founder display is optional and must not imply product access superiority
 
 **Display locations:**
 - App header (small card icon)

--- a/AestraDocs/product/Collaboration-Entitlements.md
+++ b/AestraDocs/product/Collaboration-Entitlements.md
@@ -1,0 +1,96 @@
+# Collaboration Entitlements
+
+**Status:** Internal product contract — implement before launch
+**Last Updated:** 2026-08-01
+**Owner:** Dylan
+
+---
+
+## Product promise
+
+> Supporter funds Aestra and receives the Native Suite, local Muse capabilities, asynchronous versioned collaboration, cloud workspace storage, and a closer product relationship. The core DAW and access to your own music remain free.
+
+Collaboration v1 is asynchronous project collaboration through Takes. It is not simultaneous DAW control, shared transport, remote recording, live audio streaming, or real-time co-editing.
+
+The subscription governs the shared cloud workspace. It never governs a user's local project or music. Any downloaded project remains an ordinary Aestra project that Core can open, edit, duplicate, and export without a subscription.
+
+## Three separate concepts
+
+| Concept | Meaning |
+|---------|---------|
+| Workspace owner | Controls billing, quota, workspace deletion, and ownership transfer. An active collaborative workspace must be owned by an active Supporter. |
+| Project role | Owner, editor, or viewer. This controls workspace permissions, not billing eligibility. |
+| Supporter entitlement | Allows an account to create or own active collaborative workspaces. Invitees do not need Supporter to participate. |
+
+An invited Core user can be an editor or viewer. Do not require every band member to subscribe.
+
+## Workspace state machine
+
+| State | Cloud behavior | Allowed transitions |
+|-------|----------------|---------------------|
+| Active | Full Takes collaboration, uploads, invitations, ownership transfer, and quota use. Editors may add revisions; viewers may inspect and download. | Lapsed when the owner's paid period ends; Deleted by an explicit owner deletion request under the deletion policy. |
+| Lapsed | Cloud workspace becomes read-only. Existing members may inspect history, download project data, and export available artifacts. No uploads, new Takes, invitations, or cloud-history changes. A clear deletion date is calculated and the first warning is sent. | Active by renewal; Active by accepted transfer to another eligible Supporter; Grace after the lapsed notice stage. |
+| Grace | Cloud remains read-only. Show the deletion date in product, send repeated warnings, and keep renewal, download, and ownership transfer available. Grace lasts at least 30 days from the first deletion notice. | Active by renewal or accepted transfer; Deleted after the published date. |
+| Deleted | Cloud blobs and retained Takes are removed according to the published deletion policy. Only the minimum billing, security, and deletion audit records required by law or fraud controls may remain. | No restoration promise. A local copy may be uploaded later as a new workspace by an eligible Supporter. |
+
+Local copies remain editable and exportable in every state. A cloud-state transition must never lock, alter, or remotely delete a local project.
+
+## Roles and permissions
+
+| Capability | Owner | Editor | Viewer |
+|------------|-------|--------|--------|
+| View and download | Yes | Yes | Yes |
+| Create Takes and upload revisions while Active | Yes | Yes | No |
+| Invite or remove members | Yes | No | No |
+| Change roles | Yes | No | No |
+| View quota usage | Yes | Optional project usage | No billing detail |
+| Buy additional storage | Yes | No | No |
+| Transfer or delete workspace | Yes | No | No |
+
+Ownership transfer requires explicit acceptance by another active Supporter with sufficient quota. The recipient sees the storage impact before accepting. Transfer moves billing, quota, deletion authority, and workspace ownership together.
+
+## Quota contract
+
+- An active Supporter receives 10 GB total across all cloud workspaces they own, not 10 GB per workspace.
+- Project assets, retained Takes, generated previews, and trash awaiting permanent deletion count toward the quota.
+- Storage is charged to the workspace owner, including files uploaded by editors.
+- Identical content-addressed blobs count once per owner. System-generated snapshots must reference existing blobs rather than silently duplicating whole projects.
+- Show total usage, per-workspace usage, version-history usage, trash usage, and the effect of deleting or compacting data.
+- Warn at meaningful thresholds before the quota is full. Reaching the limit blocks new cloud uploads and revisions, never local editing, opening, duplication, or export.
+- Additional storage is a separately priced add-on. Do not silently overage-bill.
+
+## Version-history safeguards
+
+Normal collaboration must not consume unpredictable storage merely because the system creates history.
+
+- Provide visible retention and compaction controls before launch.
+- Automatically compact redundant system checkpoints where content is already represented by a retained Take.
+- Never remove named Takes, branch heads, conflict evidence, or the last known-good revision without explicit user confirmation or a clearly published retention rule.
+- Preview the bytes reclaimed before destructive compaction.
+- Keep quota accounting deterministic: the same retained graph and assets must produce the same displayed usage.
+
+## Conflict and durability rules
+
+- Every cloud revision is immutable and attributable to an account and parent Take.
+- Concurrent edits create visible branches or an explicit conflict; last-writer-wins is not acceptable for project state.
+- Upload completion must be durable before the client reports success.
+- Download/export must include enough project and asset data to reopen the work locally without collaboration services.
+- Rendered compatibility artifacts may supplement plugin state but must not replace the original editable project data.
+
+## Privacy and safety gates
+
+Before launch, publish the storage provider and subprocessors, retention and deletion periods, encryption behavior, invite-token security, access revocation, abuse limits, and incident-response path. Workspace access must be least-privilege and auditable. Training or hosted Muse use of workspace data is not implied and requires a separate explicit opt-in.
+
+## Launch acceptance
+
+Collaboration cannot ship until tests prove:
+
+- every state transition and permission in this document
+- Core invitees can participate without becoming Supporters
+- lapse affects only the cloud workspace
+- local open, edit, duplicate, audio export, and stem export remain available after lapse and deletion
+- quota usage is visible, deterministic, and bounded under repeated automatic Takes
+- ownership transfer preserves history and permissions atomically
+- a complete workspace export can be reopened offline
+
+Any public pricing or terms change that conflicts with this document requires this contract to change in the same review.

--- a/AestraDocs/product/Muse-AI-Spec.md
+++ b/AestraDocs/product/Muse-AI-Spec.md
@@ -1,7 +1,7 @@
 # Muse AI — Predictive Creative Assistant
 
 **Status:** Internal — Post-Beta (v1.1 target, Q2 2027)
-**Last Updated:** 2026-04-11
+**Last Updated:** 2026-08-01
 **Owner:** Dylan
 
 ---
@@ -110,8 +110,8 @@ Muse is the second one. Always.
 - Frequency masking detection via FFT analysis
 - No deep learning required for initial launch
 
-**Phase 2 (v1.2+):** Lightweight ML models
-- Trained on anonymized Aestra usage data
+**Phase 2 (v1.2+):** Lightweight local models
+- Any training on Aestra usage data requires a separate, explicit opt-in program and privacy review
 - Per-user personalization (Muse learns YOUR style)
 - Runs locally (no cloud inference for predictions)
 - Small model size (<100MB) for fast inference
@@ -192,11 +192,10 @@ Over time, Muse learns to stop suggesting things the user always dismisses. This
 | Tier | Muse Access |
 |------|------------|
 | Core (Free) | None |
-| Supporter ($5/mo) | Full Muse AI |
-| Founder ($129) | Full Muse AI, lifetime |
-| Campus (Free) | Full Muse AI |
+| Supporter ($5/mo or $50/yr) | Local Muse while active, when ready |
+| Founder ($129) | Local Muse through the included 24 months of Supporter; renewable afterward at the permanent Founder discount |
 
-Muse is the primary justification for the Supporter subscription. It must be genuinely useful or the subscription has no value prop beyond plugins.
+Muse is local-first and must be genuinely useful before it ships. If Aestra later trains or serves a hosted model, that is a separate opt-in product and pricing decision; the local-Muse promise does not silently become a cloud entitlement.
 
 ---
 

--- a/AestraDocs/product/Pricing.md
+++ b/AestraDocs/product/Pricing.md
@@ -95,9 +95,11 @@ Aestra is free. Revenue comes from making users better, not from restricting acc
 
 Collaboration is a future Supporter benefit. A Supporter creates and owns the shared workspace; invited Core users can join and edit without subscribing. Each active Supporter includes 10 GB of shared-project storage. Storage is charged to the workspace owner rather than every collaborator, and additional storage is priced separately.
 
-If Supporter ends, shared workspaces become read-only with at least 30 days to download or export. Users receive notice before any later deletion under the storage policy then in force.
+If Supporter ends, only the cloud workspace becomes read-only. Local projects remain editable and exportable with Core. The cloud workspace provides at least 30 days to download, transfer ownership, or reactivate, with repeated warnings before deletion.
 
 This model still requires storage caps, lifecycle rules, abuse controls, and measured unit economics. Backblaze B2 is a leading storage candidate, but provider pricing does not make a perpetual customer promise sustainable. No Founder copy may imply lifetime storage.
+
+The enforceable workspace state machine, roles, quota accounting, history safeguards, and launch tests live in [Collaboration-Entitlements.md](./Collaboration-Entitlements.md).
 
 ---
 

--- a/AestraDocs/product/Pricing.md
+++ b/AestraDocs/product/Pricing.md
@@ -1,7 +1,7 @@
-# Aestra Pricing & Card System
+# Aestra Pricing & Offer System
 
-**Status:** Internal — Public December 2026
-**Last Updated:** 2026-04-11
+**Status:** Internal — approved direction for public beta
+**Last Updated:** 2026-08-01
 **Owner:** Dylan
 
 ---
@@ -12,8 +12,10 @@ Aestra is free. Revenue comes from making users better, not from restricting acc
 
 **Key principles:**
 - Free users can make a professional album. No watermarks on audio exports.
-- Paying supporters get creative tools and identity, not feature unlocks.
+- Paying supporters get optional creative tools and a closer product relationship, not DAW feature gates.
 - The psychological frame is "support the craft" not "pay for software."
+- Recurring infrastructure is never sold as a perpetual entitlement.
+- Muse is local-first. A future hosted or training service is a separate, opt-in decision with its own economics and privacy review.
 
 ---
 
@@ -24,15 +26,15 @@ Aestra is free. Revenue comes from making users better, not from restricting acc
 | Aspect | Detail |
 |--------|--------|
 | Price | $0 |
-| Card | Grey (clean, starter — not punishment) |
+| Digital identity | Standard Aestra account |
 | DAW Features | Everything. Full routing, plugin hosting, recording, export, audition, version control |
 | Plugins | Basic built-in plugins (EQ, compressor, reverb, delay) |
-| Cloud | None |
-| Muse AI | None |
-| Sound Packs | None |
-| Community | Standard Discord access |
+| Collaboration | Join and edit projects when invited, when available |
+| Cloud | No owned workspace or storage allowance |
+| Muse | Not included |
+| Community | Public channels |
 
-**Psychological frame:** "You belong here. This is your starter card."
+**Psychological frame:** "You belong here. The DAW is complete."
 
 ---
 
@@ -41,72 +43,61 @@ Aestra is free. Revenue comes from making users better, not from restricting acc
 | Aspect | Detail |
 |--------|--------|
 | Price | $5/month or $50/year (save $10) |
-| Card | Silver (metallic) |
 | DAW Features | Same as Core — no feature gates |
-| Plugins | Premium plugins included (AestraRumble 808 synth + future releases) |
-| Cloud | Cloud Takes — sync version control to cloud |
-| Muse AI | Full access — piano roll prediction, mixer suggestions, arrangement assist |
-| Sound Packs | Monthly curated packs (samples, presets, one-shots) |
-| Community | Supporter Discord role, early feature access, feedback pipeline |
-| Card Perks | Seasonal card variants, limited edition colors |
+| Plugins | Native Suite catalogue while the subscription is active |
+| Releases | New Native Suite releases when they are ready; no monthly or quarterly cadence promise |
+| Muse | Local-on-device Muse when ready |
+| Collaboration | Create and own shared workspaces when available; invited Core users participate without subscribing |
+| Included storage | 10 GB for shared projects |
+| Additional storage | Priced separately |
+| Community | Development updates and a Supporter feedback channel |
 
 **Psychological frame:** "You support the craft. You get a creative partner."
 
 **Retention mechanics:**
-- Monthly sound packs give recurring tangible value
-- Muse AI improves over time (more usage data = better predictions)
-- Card variants create collector motivation
-- $5/mo is impulse territory — lower friction than any competitor's entry price
+- The Native Suite catalogue gains value as useful plugins ship
+- Local Muse adds value without recurring inference cost or cloud dependency
+- Development access and feedback create relationship value
+- Retention must come from product usefulness, not an artificial release cadence
 
 ---
 
-### Founder ($129 one-time, limited window)
+### Founder ($129 one-time, limited to 500)
 
 | Aspect | Detail |
 |--------|--------|
-| Price | $129 one-time (limited to first 500-1000 buyers or time window) |
-| Card | Gold (metallic) |
+| Price | $129 one-time, maximum 500 sales |
 | DAW Features | Same as Core |
-| Everything in Supporter | Lifetime — no subscription |
-| Physical Card | Limited edition metal card, shipped |
-| Credits | Name in app credits ("Founding Supporters") |
-| Beta Access | Early access to new platforms (mobile, tablet) |
-| Influence | Vote on feature priorities |
-| Community | Founder Discord role, direct access to team |
+| Founder Collection | Fixed launch bundle, owned permanently |
+| Supporter | Included for 24 months from public beta |
+| After 24 months | Permanent 25% discount on Supporter renewal |
+| Founder card | Numbered digital record, permanent |
+| Credits | Optional name in Founding Supporters credits |
+| Physical goods | None; the offer is fully digital |
+| Collaboration | Included through the 24-month Supporter period; renewable afterward at the Founder discount |
+| Cloud | No lifetime storage or perpetual usage entitlement |
 
 **Psychological frame:** "You believed first. This is your legacy."
 
 **Scarcity mechanics:**
-- Limited window (e.g., first 6 months after v1.0 launch)
-- Numbered cards ("Founder #0042")
-- Physical card is genuinely premium (metal, engraved, not cheap plastic)
-- After window closes, Gold is never available again — this is permanent scarcity
+- Hard cap of 500 completed purchases
+- Numbered digital cards ("Founder #0042")
+- Sales open at public beta; the waitlist sends notice and does not reserve a number
+- The Founder Collection is defined before sale rather than expanding into every future release
 
 **Why $129 works:**
-- FL Studio costs $99-$499. Producers are used to paying $100+ for DAW software.
-- One-time purchase appeals to subscription-fatigued users.
-- $129 > $50 × 12 months = $600 lifetime value from subscriptions. Founders get a deal, you get upfront capital.
-- Physical card alone could cost $15-25 to produce. Net margin ~$100 per Founder.
+- A capped digital offer produces at most $64,500 gross launch capital with no fulfillment inventory.
+- Twenty-four months of Supporter has a $100 annual-plan list value, leaving a bounded premium for the permanent collection, digital record, and early backing.
+- The model avoids an open-ended storage, inference, support, or release obligation.
+- Forecast net receipts after payment fees, taxes, refunds, and regional pricing; gross sales are not margin.
 
----
+### Collaboration and additional storage
 
-### Campus (Free, .edu verified)
+Collaboration is a future Supporter benefit. A Supporter creates and owns the shared workspace; invited Core users can join and edit without subscribing. Each active Supporter includes 10 GB of shared-project storage. Storage is charged to the workspace owner rather than every collaborator, and additional storage is priced separately.
 
-| Aspect | Detail |
-|--------|--------|
-| Price | Free (requires .edu email verification) |
-| Card | Blue (academic) |
-| Everything in Supporter | Full access, no payment |
-| Limitation | Educational use; watermarked exports (optional, decide later) |
-| Duration | 4 years (re-verify) or while enrolled |
+If Supporter ends, shared workspaces become read-only with at least 30 days to download or export. Users receive notice before any later deletion under the storage policy then in force.
 
-**Psychological frame:** "Investing in the next generation."
-
-**Why this matters:**
-- Students become professionals who pay for Supporter tier
-- University music programs become organic marketing channels
-- Professors recommend Aestra to classes
-- Long-term user pipeline at zero acquisition cost
+This model still requires storage caps, lifecycle rules, abuse controls, and measured unit economics. Backblaze B2 is a leading storage candidate, but provider pricing does not make a perpetual customer promise sustainable. No Founder copy may imply lifetime storage.
 
 ---
 
@@ -114,38 +105,27 @@ Aestra is free. Revenue comes from making users better, not from restricting acc
 
 ### What Cards Are
 
-Cards are collectible digital identities tied to your Aestra account. They represent your relationship with Aestra — not what you're allowed to do, but who you are in the community.
+The Founder card is a collectible digital record tied to an Aestra account. It represents early backing, not software access or product status.
 
 ### Card Properties
 
 | Property | Description |
 |----------|-------------|
-| Tier | Core, Supporter, Founder, Campus |
-| Color | Grey, Silver, Gold, Blue |
-| Variant | Standard, Seasonal, Limited Edition |
-| Number | Unique ID (especially for Founders: #0042) |
-| Level | Earned through usage (future — glow effects, frames) |
-| Physical | Gold Founders receive a physical metal card |
+| Offer | Founder |
+| Format | Digital only |
+| Number | Unique ID, for example #0042 |
+| Ownership | Permanent account record |
+| Public display | Opt-in only |
 
 ### Card Display Locations
 
 | Location | How Card Shows |
 |----------|---------------|
-| App header | Small card icon with tier color |
-| Audition "Now Playing" | Card displayed when sharing what you're listening to |
-| Project sharing (future) | Card shown alongside shared projects |
-| Community/Discord | Role badge matching card tier |
-| Profile (future cloud) | Full card art on your Aestra profile |
+| Account | Full digital card and number |
+| App credits | Optional Founding Supporters credit |
+| Community profile | Optional display if profiles ship |
 
-### Card Evolution (Future)
-
-Cards can evolve through usage, not payment:
-- Complete tutorials → card gains a glow
-- Use Aestra for 100+ hours → card frame upgrades
-- Release a project publicly → special badge on card
-- Seasonal events → limited-time card variants (e.g., "Summer '27" border)
-
-**Important:** Card evolution is about *engagement*, not *spending*. This keeps the system feeling earned, not bought.
+Do not add paid rarity, random rewards, or engagement mechanics without a separate product review. The card should remain a quiet record of early backing.
 
 ---
 
@@ -155,9 +135,8 @@ Cards can evolve through usage, not payment:
 |--------|------|--------|
 | Supporter subscriptions | Recurring | Primary revenue |
 | Founder sales | One-time (limited) | Upfront capital, community seeding |
-| Premium plugin releases | Included in Supporter | Retention driver (quarterly releases) |
-| Sound packs | Included in Supporter | Retention driver (monthly drops) |
-| Physical merch (future) | One-time | Community building, brand |
+| Individual plugin purchases | One-time | Optional ownership outside Supporter |
+| Extra collaboration storage | Recurring/usage-backed | Separate add-on only after unit economics are proven |
 
 ### Not Revenue Streams (Important)
 
@@ -167,31 +146,29 @@ These are deliberately NOT monetized:
 - Track count — never limited
 - Plugin hosting — never restricted
 - Basic plugins — always free
+- Lifetime cloud storage — never promised
+- Hosted Muse inference — not bundled into a local-Muse promise
 
 ---
 
-## Revenue Projections (Year 1)
+## Financial operating model
 
-Conservative → Optimistic range based on 10K-50K free users:
+Do not forecast from gross conversion alone. The launch model must track:
 
-| Metric | Conservative | Optimistic |
-|--------|-------------|-----------|
-| Free users | 10,000 | 50,000 |
-| Supporter conversion | 5% | 8% |
-| Supporters | 500 | 4,000 |
-| Monthly Supporter revenue | $2,500 | $20,000 |
-| Founder sales (first 6 months) | 200 × $129 | 500 × $129 |
-| Founder revenue | $25,800 | $64,500 |
-| Year 1 total | $55,800 | $304,500 |
+- free-to-Supporter conversion by cohort
+- monthly and annual Supporter churn
+- net revenue after payment fees, taxes, refunds, and regional pricing
+- plugin production and support cost
+- Founder attachment and post-included-period renewal
+- cloud storage, operation, egress, abuse, and support cost per active user before pricing cloud
 
-**Note:** These are rough estimates. Actuals depend on launch marketing, community growth, and regional pricing (see below).
+Founder gross is capped at $64,500. Treat it as launch capital, not recurring revenue. Supporter is the primary business; the Native Suite, local Muse, and collaboration workflow are the places to lean. The included 10 GB allowance and any extra-storage pricing must be validated against observed unit economics before collaboration launches.
 
 ### Regional Pricing Consideration
 
 $5/mo is impulse in the US/EU but significant in Kenya, India, Brazil, Southeast Asia. Consider:
 - Regional pricing for Supporter tier (e.g., $2-3/mo in emerging markets)
-- Campus tier covers students globally
-- Founder is global flat rate (scarcity > accessibility for this tier)
+- Founder is global flat rate, while regional affordability is handled through Supporter
 
 ---
 

--- a/AestraDocs/product/Product-Strategy.md
+++ b/AestraDocs/product/Product-Strategy.md
@@ -1,7 +1,7 @@
 # Aestra Product Strategy
 
-**Status:** Internal — Public December 2026 with v1 Beta
-**Last Updated:** 2026-04-11
+**Status:** Internal — public-beta direction
+**Last Updated:** 2026-08-01
 **Owner:** Dylan
 
 ---
@@ -14,7 +14,7 @@
 
 ## What Aestra Is
 
-Aestra is a free, full-featured DAW with no feature gates. It uses design metaphors borrowed from gaming, design tools, and developer workflows to create a creative environment that *thinks differently* from any other DAW. Revenue comes from a supporter tier that provides premium plugins, predictive AI (Muse), and collectible identity (card system) — not from feature restrictions.
+Aestra is a free, full-featured DAW with no feature gates. It uses design metaphors borrowed from gaming, design tools, and developer workflows to create a creative environment that *thinks differently* from any other DAW. Revenue comes primarily from a Supporter offer that provides the Native Suite, local Muse, collaboration when ready, development updates, and a feedback channel — not from feature restrictions.
 
 ## What Aestra Is Not
 
@@ -107,7 +107,7 @@ Hip-hop and electronic music producers, ages 16-30, globally. Price-sensitive (s
 Professional producers looking for a secondary DAW for specific workflows (pattern-based writing, audition/reference). Linux users underserved by existing DAWs.
 
 ### Tertiary (Future)
-Music educators (Campus tier). Collaborative production teams (cloud Takes).
+Music educators and collaborative production teams, after the core desktop product and business model are proven.
 
 ---
 
@@ -116,10 +116,12 @@ Music educators (Campus tier). Collaborative production teams (cloud Takes).
 See [Pricing.md](./Pricing.md) for full pricing matrix.
 
 Summary:
-- **Core** (Free): Full DAW, basic plugins, grey card
-- **Supporter** ($5/mo): Premium plugins, Muse AI, cloud storage, sound packs, silver card
-- **Founder** ($129 one-time, limited): Lifetime Supporter + physical gold card + credits
-- **Campus** (Free, .edu): Supporter perks, blue card
+- **Core** (Free): Complete DAW with no feature gates; can join and edit invited collaborative projects when collaboration ships
+- **Supporter** ($5/mo or $50/yr): Native Suite catalogue while active, new releases when ready, local Muse when ready, development updates, feedback, and the ability to create shared workspaces with 10 GB included
+- **Founder** ($129 one-time, limited to 500): Fixed Founder Collection, numbered digital card, optional credits, 24 months of Supporter, then a permanent 25% Supporter discount
+- **Additional storage**: Separate usage-backed add-on only if storage, operations, support, and abuse economics are proven
+
+Founder is fully digital. It includes no physical goods, lifetime cloud storage, lifetime Supporter, direct support, voting rights, or blanket entitlement to future products.
 
 ---
 
@@ -131,7 +133,7 @@ Summary:
 - **v1 Beta (Dec 2026):** Free DAW. No monetization. Build user base.
 - **v1.0 (Q1 2027):** Card system + Supporter tier launch.
 - **v1.1 (Q2 2027):** Muse AI launch (Supporters only).
-- **v1.2+ (Q3 2027+):** Cloud Takes, collaboration, mobile/tablet.
+- **v1.2+ (Q3 2027+):** Research collaboration and mobile/tablet; collaboration ships as a Supporter benefit with 10 GB included only after its unit economics are proven.
 
 ---
 
@@ -139,10 +141,11 @@ Summary:
 
 | Risk | Likelihood | Mitigation |
 |------|-----------|-----------|
-| Free tier too good, no one pays | Medium | Muse AI and premium plugins must be genuinely valuable |
-| Muse AI predictions are bad | High (early) | Don't ship until quality bar is met; train on Aestra usage data |
-| Card system feels gimmicky | Low | Keep card aesthetics premium; never make Core card feel like punishment |
-| Plugin release cadence too slow | Medium | Plan quarterly plugin releases; community can submit plugins (future) |
+| Free tier too good, no one pays | Medium | The Native Suite and local Muse must be genuinely valuable without weakening Core |
+| Muse AI predictions are bad | High (early) | Don't ship until the quality bar is met; local models first, with any training-data program separately opt-in |
+| Founder identity feels gimmicky | Low | Keep the numbered digital card restrained, permanent, and opt-in when displayed publicly |
+| Plugin catalogue grows too slowly | Medium | Promise useful releases when ready, not an artificial monthly or quarterly cadence |
+| Collaboration gross margin collapses | Medium | Cap included storage at 10 GB, price extra storage separately, and measure operations, egress, abuse, and support before launch |
 | Competitors copy the free model | Low (long-term) | The moat is community + design language, not the price tag |
 
 ---
@@ -152,8 +155,8 @@ Summary:
 | Metric | Target (Year 1) |
 |--------|----------------|
 | Free users | 10K-50K |
-| Supporter conversion | 5-8% |
-| Supporter retention (monthly) | >80% |
+| Supporter conversion | Establish from observed launch cohorts |
+| Supporter retention | Track monthly and annual churn separately |
 | Founder sales | 200-500 |
 | NPS (Net Promoter Score) | >60 |
 

--- a/AestraDocs/product/Product-Strategy.md
+++ b/AestraDocs/product/Product-Strategy.md
@@ -114,6 +114,7 @@ Music educators and collaborative production teams, after the core desktop produ
 ## Revenue Model
 
 See [Pricing.md](./Pricing.md) for full pricing matrix.
+See [Collaboration-Entitlements.md](./Collaboration-Entitlements.md) for the collaboration product contract.
 
 Summary:
 - **Core** (Free): Complete DAW with no feature gates; can join and edit invited collaborative projects when collaboration ships

--- a/AestraDocs/product/Roadmap-Product.md
+++ b/AestraDocs/product/Roadmap-Product.md
@@ -1,7 +1,7 @@
 # Aestra Product Roadmap
 
 **Status:** Internal — Execution plan
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-08-01
 **Owner:** Dylan
 
 Cross-ref:
@@ -138,16 +138,16 @@ Technical work: freeze, bug fixes, performance optimization.
 ## Phase 6: v1.0 — Cards + Subscriptions (Q1 2027)
 
 ### What ships:
-- Card system (Core Grey, Campus Blue)
-- Supporter tier ($5/mo, $50/yr) with Silver card
-- Founder tier ($129 one-time, limited) with Gold card + physical card
+- Core remains complete and free; Supporter launches at $5/mo or $50/yr
+- Restrained digital identity for the capped Founder offer
+- Founder offer ($129 one-time, limited to 500) with a numbered digital card, fixed Founder Collection, 24 months of Supporter, and a permanent 25% Supporter discount thereafter
 - Premium plugins (AestraRumble + 1-2 new plugins)
 - Community features (Discord integration, roles)
 
 ### Launch strategy:
-- **Message:** "Beta is over. Aestra stays free. Your Gold card is waiting."
-- **Special:** Beta users get first access to Founder tier (2-week exclusive window)
-- **Target:** 200-500 Founders, 5-8% Supporter conversion
+- **Message:** "Aestra stays free. Back the work early."
+- **Special:** Founder sales open at public beta; the waitlist sends notice and does not reserve a numbered card
+- **Target:** Up to 500 Founders; establish Supporter conversion from observed cohorts rather than a launch assumption
 
 ---
 
@@ -160,7 +160,7 @@ Technical work: freeze, bug fixes, performance optimization.
 - Arrangement assist (pattern variation, transition suggestions)
 
 ### Prerequisites:
-- Minimum 3-6 months of Aestra usage data for training
+- Local-first implementation; any future training-data program is a separate, explicit opt-in decision
 - Prediction quality must meet "useful, not annoying" bar
 - Opt-in data collection from Supporters (with clear privacy policy)
 
@@ -174,10 +174,9 @@ Technical work: freeze, bug fixes, performance optimization.
 ## Phase 8: v1.2+ — Platform Expansion (Q3 2027+)
 
 ### What ships (prioritized by demand):
-- Cloud Takes (sync version control to cloud)
+- Supporter collaboration research: workspace owners receive 10 GB, invited Core users participate without subscribing, and only extra storage is separately priced
 - macOS support
-- Collaboration features (share Takes with other Aestra users)
-- Mobile/tablet beta (Founders first)
+- Mobile/tablet research after desktop quality and demand justify it
 - Plugin marketplace (third-party plugins)
 - Community sound pack submissions
 

--- a/AestraDocs/product/Roadmap-Product.md
+++ b/AestraDocs/product/Roadmap-Product.md
@@ -180,6 +180,8 @@ Technical work: freeze, bug fixes, performance optimization.
 - Plugin marketplace (third-party plugins)
 - Community sound pack submissions
 
+Collaboration v1 is asynchronous sharing through Takes and must satisfy [Collaboration-Entitlements.md](./Collaboration-Entitlements.md). Real-time co-editing, shared transport, remote recording, and live audio streaming are not v1 scope.
+
 ---
 
 ## Audio Quality Status (as of 2026-05-14)


### PR DESCRIPTION
## What changed

- bound Founder to a fully digital, 500-sale offer with a fixed collection, 24 months of Supporter, and a permanent renewal discount
- define Supporter as the Native Suite, local Muse when ready, development access, feedback, and collaboration when available
- let invited Core users participate in shared projects without subscribing
- include 10 GB of shared-project storage for workspace owners and price only additional storage separately
- document the read-only and 30-day export grace after Supporter ends
- add an enforceable collaboration contract covering Active, Lapsed, Grace, and Deleted workspace states
- separate workspace ownership, project roles, and Supporter entitlement so Core invitees remain full participants
- guarantee that lapse affects only the cloud workspace while local projects remain editable and exportable in Core
- define deterministic quota accounting, visible history usage, compaction safeguards, conflict rules, and launch acceptance tests
- replace optimistic gross projections with cohort, churn, net-revenue, support-cost, and cloud-unit-economics controls

## Why

The previous internal documents promised lifetime Supporter, physical fulfilment, bundled cloud storage, fixed release cadence, and unsupported conversion assumptions. Those promises created open-ended cost and delivery risk and no longer matched the public pricing model.

This keeps collaboration inside one understandable Supporter offer while preserving a free participation path and bounding recurring infrastructure costs.

Collaboration v1 is explicitly asynchronous project sharing through Takes. Real-time co-editing, shared transport, remote recording, and live audio streaming are not part of this contract.

## Impact

This is documentation-only. It defines the product and acceptance boundary but does not implement collaboration, storage, billing, Muse, or account entitlements.

## Validation

- `git diff --check`
- relative Markdown links in the five changed documents resolve locally
- `scripts/docs-check.sh` ran; Doxygen and `markdown-link-check` are not installed in the environment, so their optional checks were skipped
