### PR TITLE
Share the render-state conversion, and correct the edge-fade contract

### DIFF
--- a/AestraAudio/include/Core/ClipRenderKernel.h
+++ b/AestraAudio/include/Core/ClipRenderKernel.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Core/AudioGraph.h"
+#include "Models/PlaylistRuntimeSnapshot.h"
 #include "DSP/Interpolators.h"
 
 #include <cstdint>
@@ -40,6 +41,20 @@ inline constexpr uint32_t kClipEdgeFadeSamples = 128;
 struct ClipRenderResult {
     bool usedSampleRateConversion{false};
 };
+
+/**
+ * @brief Build the render state for one clip from its runtime snapshot entry.
+ *
+ * The single conversion from model-domain ClipRuntimeInfo to the engine's
+ * ClipRenderState: source buffer and channel count, absolute sample bounds,
+ * and the slip offset rescaled from project rate to the source's own rate.
+ *
+ * Shared rather than duplicated for the same reason the kernel itself is:
+ * an offline caller that rebuilt this mapping would be a second
+ * interpretation of ClipEdits, which consolidate-audio-range.md §3.1 forbids.
+ * A pure function of its two arguments — no engine, no graph, no manager.
+ */
+[[nodiscard]] ClipRenderState makeClipRenderState(const ClipRuntimeInfo& clipInfo, double projectSampleRate);
 
 /**
  * @brief Mix one clip into @p destination for the block [blockStart, blockEnd).

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -1,5 +1,6 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "AudioGraphBuilder.h"
+#include "Core/ClipRenderKernel.h"
 
 #include "PlaylistRuntimeSnapshot.h"
 
@@ -179,36 +180,7 @@ AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) 
                 if (!clipInfo.isValid())
                     continue;
 
-                ClipRenderState clip;
-                // ClipRenderState.bufferOwner holds a shared_ptr<AudioBufferData>
-                // that extends the buffer's lifetime independently of SourceManager.
-                // audioData is extracted from the same buffer as a raw pointer for hot-path use.
-
-                if (clipInfo.isAudio()) {
-                    clip.audioData = clipInfo.audioData->interleavedData.data();
-                    clip.bufferOwner = clipInfo.sharedAudioData;
-                    clip.totalFrames = clipInfo.audioData->numFrames;
-                    clip.sourceSampleRate = static_cast<double>(clipInfo.sourceSampleRate);
-                    clip.channels = clipInfo.sourceChannels;
-                }
-
-                clip.startSample = clipInfo.startTime;
-                clip.endSample = clipInfo.getEndTime();
-
-                // Convert sourceStart (Project Rate) to sampleOffset (Source Rate)
-                // Use double precision to prevent audio popping due to sub-sample drift
-                if (projectSampleRate > 0.0 && clip.sourceSampleRate > 0.0) {
-                    clip.sampleOffset =
-                        static_cast<double>(clipInfo.sourceStart) * (clip.sourceSampleRate / projectSampleRate);
-                } else {
-                    clip.sampleOffset = static_cast<double>(clipInfo.sourceStart);
-                }
-
-                clip.gain = clipInfo.gainLinear;
-                clip.pan = clipInfo.pan;
-                clip.playbackRate = clipInfo.playbackRate;
-                clip.fadeInSamples = clipInfo.fadeInSamples;
-                clip.fadeOutSamples = clipInfo.fadeOutSamples;
+                ClipRenderState clip = ClipRenderKernel::makeClipRenderState(clipInfo, projectSampleRate);
 
                 if (clip.endSample > maxEndSample) {
                     maxEndSample = clip.endSample;

--- a/AestraAudio/src/Core/ClipRenderKernel.cpp
+++ b/AestraAudio/src/Core/ClipRenderKernel.cpp
@@ -11,6 +11,40 @@ namespace Aestra {
 namespace Audio {
 namespace ClipRenderKernel {
 
+ClipRenderState makeClipRenderState(const ClipRuntimeInfo& clipInfo, double projectSampleRate) {
+    ClipRenderState clip;
+    // ClipRenderState.bufferOwner holds a shared_ptr<AudioBufferData>
+    // that extends the buffer's lifetime independently of SourceManager.
+    // audioData is extracted from the same buffer as a raw pointer for hot-path use.
+
+    if (clipInfo.isAudio()) {
+        clip.audioData = clipInfo.audioData->interleavedData.data();
+        clip.bufferOwner = clipInfo.sharedAudioData;
+        clip.totalFrames = clipInfo.audioData->numFrames;
+        clip.sourceSampleRate = static_cast<double>(clipInfo.sourceSampleRate);
+        clip.channels = clipInfo.sourceChannels;
+    }
+
+    clip.startSample = clipInfo.startTime;
+    clip.endSample = clipInfo.getEndTime();
+
+    // Convert sourceStart (Project Rate) to sampleOffset (Source Rate)
+    // Use double precision to prevent audio popping due to sub-sample drift
+    if (projectSampleRate > 0.0 && clip.sourceSampleRate > 0.0) {
+        clip.sampleOffset =
+            static_cast<double>(clipInfo.sourceStart) * (clip.sourceSampleRate / projectSampleRate);
+    } else {
+        clip.sampleOffset = static_cast<double>(clipInfo.sourceStart);
+    }
+
+    clip.gain = clipInfo.gainLinear;
+    clip.pan = clipInfo.pan;
+    clip.playbackRate = clipInfo.playbackRate;
+    clip.fadeInSamples = clipInfo.fadeInSamples;
+    clip.fadeOutSamples = clipInfo.fadeOutSamples;
+    return clip;
+}
+
 ClipRenderResult renderClipInto(const ClipRenderState& clip, uint64_t blockStart, uint64_t blockEnd,
                                 double* destination, uint32_t engineSampleRate,
                                 Interpolators::InterpolationQuality quality) {

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -227,6 +227,7 @@ automatic protection there.
 | Trim/crop trailing edge | preserve | **reset to `true`** |
 | Slip / source-offset change | **reset to `true`** | **reset to `true`** |
 | Replace source | **reset to `true`** | **reset to `true`** |
+| Reverse (raw source reversal) | **swap with trailing** | **swap with leading** |
 | Playback-rate / stretch change | reset unless the operation re-renders equivalent edge envelopes | same |
 | Undo / redo | restore the exact prior values | restore the exact prior values |
 
@@ -241,12 +242,60 @@ edits wholesale and then clears `fadeInBeats` on the right piece while
 follows the same asymmetry.
 
 **Reverse** deserves an explicit decision rather than falling out of generic
-edit copying. `ReverseAudioClipCommand` produces a **newly rendered source** and
-bakes no edge fades — `applyFades` runs only in `CommitAudioClipEditsCommand`.
-The reversed result therefore has no baked edge behaviour, so both flags reset
-to `true`. Were reverse instead implemented as a source-mapping flip, the two
-flags would swap; the distinction is what the renderer actually baked, never
-what the previous clip happened to carry.
+edit copying, and the deciding question is *what the resulting source contains*
+— not what the command itself called.
+
+`ReverseAudioClipCommand` extracts the clip's existing source region and
+reverses those raw samples. It neither removes previously baked envelopes nor
+renders through the fade kernel. So for a consolidated input, whose source
+already carries baked ramps at both ends:
+
+```text
+source:    leading ramp baked ───── trailing ramp baked      policy: false / false
+reversed:  old trailing ramp  ───── old leading ramp
+```
+
+The baked behaviour still exists — it has changed sides. The flags therefore
+**swap**:
+
+```cpp
+result.autoFadeLeading  = original.autoFadeTrailing;
+result.autoFadeTrailing = original.autoFadeLeading;
+```
+
+Resetting both to `true` would lay fresh automatic ramps over the already-baked
+ones and recreate exactly the double attenuation this policy exists to prevent.
+
+"The reverse command calls no fade function" is insufficient reasoning, because
+the *input* source may already contain those fades.
+
+The test uses an **asymmetric** original, since a symmetric one cannot
+distinguish swapping from preserving:
+
+```cpp
+original.autoFadeLeading  = false;   original.autoFadeTrailing = true;
+// after reverse
+result.autoFadeLeading   == true;    result.autoFadeTrailing   == false;
+```
+
+That single case catches all three plausible mistakes: preserving both
+unchanged, resetting both to `true`, and resetting both to `false`.
+
+**User fades are a separate policy and are preserved.** `fadeInBeats` and
+`fadeOutBeats` are properties of the *placed clip's timeline edges*, not of
+source content: fade-in belongs to the leading timeline edge, fade-out to the
+trailing one, and reverse changes the content underneath those boundaries.
+Swapping them would treat user fades as source properties, contradicting the
+split precedent above. So:
+
+```text
+automatic baked-edge policy under raw reversal:  swap
+nondestructive user fades on timeline edges:     preserve
+```
+
+Only a different command — "reverse the exact currently audible render" — would
+bake the user fades, reverse the rendered result, and reset their metadata.
+That is not what `ReverseAudioClipCommand` does.
 
 ##### The split test
 

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -83,27 +83,95 @@ boundaries between the original clips**, so the engine will no longer apply
 those fades. It will, however, apply them at the two boundaries of the new
 consolidated clip.
 
-The policy:
+The policy — **revised**, see the correction below:
 
-> **Bake every original automatic clip-edge fade, except an edge exactly
-> coincident with the corresponding outer consolidation boundary.**
+> **Bake every contributor's fades exactly as the runtime renders them. Mark the
+> resulting consolidated clip so its own automatic edge fades are not applied
+> again.**
 
-Why each half matters:
+Internal boundaries must be baked: after consolidation there is no boundary
+there, so nothing re-applies the fade, and not baking it changes the sound at
+every original seam. This includes a clip that starts after `startBeat` or ends
+before `endBeat` even when separated by silence — that is still an internal
+boundary.
 
-- **Internal boundaries must be baked.** After consolidation there is no
-  boundary there, so nothing re-applies the fade. Not baking it changes the
-  sound at every original seam. This includes a clip that starts after
-  `startBeat` or ends before `endBeat` even when separated by silence — that is
-  still an internal boundary.
-- **Outer boundaries must not be baked.** The new clip receives the engine's
-  automatic edge fade at `startBeat` and `endBeat`. Baking it as well applies
-  the ramp twice — the outer edge is attenuated by `r²` instead of `r`.
+Outer boundaries must also be baked, and the *result* clip must be told not to
+fade them again. That is durable state on the clip, not a render-time argument.
 
-Delegating the outer boundary is mathematically safe. Where several clips begin
-exactly at the range boundary, applying the same linear ramp `r` to each before
-summing gives `r·A + r·B`, which equals `r·(A + B)` — applying it once to the
-sum. So the new clip's own edge fade reproduces it exactly, and baking is not
-merely redundant but wrong.
+#### Why the earlier strategy was wrong
+
+An earlier revision said to bake every fade *except* one coincident with the
+outer boundary, and to let the new clip's own automatic fade reproduce it —
+justified by linearity: applying ramp `r` to each contributor before summing
+gives `r·A + r·B = r·(A + B)`.
+
+That argument only holds when the delegated ramp is **the same ramp**. It is
+not, for two independent reasons.
+
+**User and automatic fades collapse into one ramp.** The runtime computes a
+single effective length:
+
+```cpp
+effectiveLength = min(clipLength, max(kClipEdgeFadeSamples, userFadeLength));
+```
+
+With a 500-sample user fade the original output has one 500-sample ramp. Baking
+the user ramp while delegating the automatic one yields the *product* of two
+ramps, where the original had a `max()`.
+
+**Lengths differ with clip length.** A 64-sample contributor consolidated into a
+512-sample result:
+
+```
+original automatic fade = min(64, 128)  =  64
+result automatic fade   = min(512, 128) = 128
+```
+
+Suppressing the original and relying on the result's fade substitutes a
+different envelope entirely.
+
+#### What this requires
+
+An ephemeral renderer argument (`suppressLeading`/`suppressTrailing`) is not
+sufficient: it would make consolidation sound correct only while being created.
+After save and reload the playback engine would have no durable explanation for
+why the result clip must not add another automatic fade.
+
+The state belongs on the clip:
+
+```cpp
+struct AutomaticEdgeFadePolicy {
+    bool applyLeading{true};
+    bool applyTrailing{true};
+};
+```
+
+and the runtime becomes:
+
+```cpp
+const uint64_t automaticLeading =
+    clip.edgeFadePolicy.applyLeading ? std::min<uint64_t>(clipLength, kClipEdgeFadeSamples) : 0;
+const uint64_t userLeading = std::min<uint64_t>(clipLength, clip.fadeInSamples);
+const uint64_t fadeInLen = std::max(automaticLeading, userLeading);
+```
+
+Defaults keep every existing clip bit-identical. A consolidated result sets both
+to `false` with zero user fades, because all original edge behaviour is already
+present in the rendered source.
+
+That state must be stored on the model clip, copied into `ClipRenderState`,
+consumed by the shared renderer, serialized and restored, defaulted to `true`
+for old projects, and covered by save/load and audible-equivalence tests. It is
+therefore **its own PR, landing before consolidation** — a zero-default-change
+edge-policy change, gated on: default policy 6/6 exact; each edge suppressible
+independently; user fades still working when automatic fades are suppressed;
+very short clips; serialization round-trip; and sabotage proving that a missing
+suppression causes outer-edge double attenuation.
+
+Inverse compensation — dividing the rendered mix by the result clip's future
+automatic envelope — would avoid serialized state, but it needs severe
+pre-emphasis for short boundary clips and can exceed the representable range of
+the stored format. Rejected as operationally fragile.
 
 ### 3.3 Why boundary alignment is required in v1
 

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -205,14 +205,72 @@ rather than a re-spelling of the old single expression.
   Asserting that a *newly constructed* clip defaults to `true` only tests the
   member initializer; the absent-key path in the deserializer is where old
   projects actually go;
-- **clone preservation** — duplicating, splitting or otherwise copying a clip
-  with automatic fades disabled must preserve both flags. An aggregate
-  initialization or constructor that silently restores `true` would recreate
-  the same divergence through *editing* rather than reopening, which is harder
-  to trace because no save/load boundary invites suspicion. `DuplicateClipCommand`
-  and `SplitClipCommand` both build clips from existing ones;
+- **boundary-policy propagation** — see the table below. This is *not* simple
+  preservation: an operation that creates, moves or remaps an edge must restore
+  automatic protection at that edge;
 - sabotage proving that a missing suppression causes outer-edge double
   attenuation.
+
+#### Boundary-policy propagation
+
+**The policy follows boundary provenance, not clip identity.** An edge flag is
+preserved only when the operation preserves that exact source boundary and its
+sample mapping. Anything that creates, moves or remaps an edge must restore
+automatic protection there.
+
+| Operation | Leading | Trailing |
+|---|---|---|
+| Duplicate, copy/paste, move, make unique | preserve | preserve |
+| Split — left result | preserve | **reset to `true`** |
+| Split — right result | **reset to `true`** | preserve |
+| Trim/crop leading edge | **reset to `true`** | preserve |
+| Trim/crop trailing edge | preserve | **reset to `true`** |
+| Slip / source-offset change | **reset to `true`** | **reset to `true`** |
+| Replace source | **reset to `true`** | **reset to `true`** |
+| Playback-rate / stretch change | reset unless the operation re-renders equivalent edge envelopes | same |
+| Undo / redo | restore the exact prior values | restore the exact prior values |
+
+Getting split wrong is quiet in the dangerous direction. A consolidated clip
+split in two would leave `applyLeading = false` on the right-hand piece, so the
+new seam gets **no** anti-click ramp — an audible click on a cut, blamed on the
+splitter rather than on a consolidation performed weeks earlier.
+
+Split already sets the precedent for user fades: `PlaylistModel` copies the
+edits wholesale and then clears `fadeInBeats` on the right piece while
+`SplitClipCommand` clears `fadeOutBeats` on the left. The automatic policy
+follows the same asymmetry.
+
+**Reverse** deserves an explicit decision rather than falling out of generic
+edit copying. `ReverseAudioClipCommand` produces a **newly rendered source** and
+bakes no edge fades — `applyFades` runs only in `CommitAudioClipEditsCommand`.
+The reversed result therefore has no baked edge behaviour, so both flags reset
+to `true`. Were reverse instead implemented as a source-mapping flip, the two
+flags would swap; the distinction is what the renderer actually baked, never
+what the previous clip happened to carry.
+
+##### The split test
+
+Start from a clip with **both** flags disabled, which is what a consolidated
+clip looks like:
+
+```cpp
+original.autoFadeLeading  = false;
+original.autoFadeTrailing = false;
+```
+
+After splitting:
+
+```cpp
+left.autoFadeLeading   == false;   left.autoFadeTrailing  == true;
+right.autoFadeLeading  == true;    right.autoFadeTrailing == false;
+```
+
+That single asymmetric result catches both plausible wrong implementations —
+copying all four flags unchanged, and resetting all four to `true`. Symmetric
+expectations catch neither.
+
+The same test confirms the existing user-fade behaviour at the seam: the left
+fade-out and right fade-in cleared, the untouched outer user fades preserved.
 
 Inverse compensation — dividing the rendered mix by the result clip's future
 automatic envelope — would avoid serialized state, but it needs severe

--- a/AestraDocs/specs/consolidate-audio-range.md
+++ b/AestraDocs/specs/consolidate-audio-range.md
@@ -23,7 +23,7 @@ Two statements govern everything below.
 
 ## 1. Public command and range semantics
 
-```
+```text
 consolidate_audio --lane <canonical-lane-id> --start <beat> --end <beat>
 ```
 
@@ -122,7 +122,7 @@ ramps, where the original had a `max()`.
 **Lengths differ with clip length.** A 64-sample contributor consolidated into a
 512-sample result:
 
-```
+```text
 original automatic fade = min(64, 128)  =  64
 result automatic fade   = min(512, 128) = 128
 ```
@@ -160,13 +160,59 @@ to `false` with zero user fades, because all original edge behaviour is already
 present in the rendered source.
 
 That state must be stored on the model clip, copied into `ClipRenderState`,
-consumed by the shared renderer, serialized and restored, defaulted to `true`
-for old projects, and covered by save/load and audible-equivalence tests. It is
-therefore **its own PR, landing before consolidation** — a zero-default-change
-edge-policy change, gated on: default policy 6/6 exact; each edge suppressible
-independently; user fades still working when automatic fades are suppressed;
-very short clips; serialization round-trip; and sabotage proving that a missing
-suppression causes outer-edge double attenuation.
+consumed by the shared renderer, serialized and restored, and preserved through
+every path that copies a clip. It is therefore **its own PR, landing before
+consolidation** — a zero-default-change edge-policy change.
+
+#### Persisted contract
+
+Serialized inside the clip's existing `edits` object, alongside `gain`, `pan`
+and the fade lengths:
+
+```json
+{
+  "autoFadeLeading":  true,
+  "autoFadeTrailing": true
+}
+```
+
+Both keys are **independently optional**. An absent key loads as `true` — the
+engine's automatic safety ramp is the default, and a project written before
+these fields existed must sound exactly as it did. A present key is honoured
+verbatim; there is no inference from one edge to the other, since a
+consolidated clip could in principle abut another consolidation on one side
+only.
+
+#### Suppression is not "never fade"
+
+`applyLeading = false` means *do not add the engine's automatic safety ramp*,
+not *this edge may never fade*. A user fade set on a suppressed edge must still
+produce exactly its own ramp — that is what the `max(automatic, user)`
+decomposition buys, and asserting it is what proves the decomposition is real
+rather than a re-spelling of the old single expression.
+
+#### Gates
+
+- default policy → 6/6 digests exact;
+- each edge suppressible **independently** (leading only, trailing only, both);
+- a 500-sample user fade still yields a 500-sample ramp with automatic
+  suppression active;
+- very short clips, where `clipLength < kClipEdgeFadeSamples`;
+- **serialization round-trip** with both values `false`, and with each `false`
+  independently;
+- **legacy fixture** — load a project predating the fields (the frozen
+  `v1_minimal` / `v1_rich` corpus) and prove both edges default to enabled.
+  Asserting that a *newly constructed* clip defaults to `true` only tests the
+  member initializer; the absent-key path in the deserializer is where old
+  projects actually go;
+- **clone preservation** — duplicating, splitting or otherwise copying a clip
+  with automatic fades disabled must preserve both flags. An aggregate
+  initialization or constructor that silently restores `true` would recreate
+  the same divergence through *editing* rather than reopening, which is harder
+  to trace because no save/load boundary invites suspicion. `DuplicateClipCommand`
+  and `SplitClipCommand` both build clips from existing ones;
+- sabotage proving that a missing suppression causes outer-edge double
+  attenuation.
 
 Inverse compensation — dividing the rendered mix by the result clip's future
 automatic envelope — would avoid serialized state, but it needs severe
@@ -271,7 +317,7 @@ audio graph does not belong here.
 
 ## 6. Muse schema
 
-```
+```cpp
 {"consolidate_audio", CommandCategory::Clip, {
     {"lane",  FlagType::Id,    true},
     {"start", FlagType::Float, true},


### PR DESCRIPTION
The extraction foundation for consolidation, plus the contract correction that **blocks** consolidation until a prerequisite lands.

No consolidation code here. That is the point.

## `2e44b760` — one authority for model → render state

Consolidation needs `ClipRenderState` for a lane's clips. `ClipRenderState` carries **no lane identity**, so filtering a built `AudioGraph` back to one lane is impossible — the approach I had assumed would work.

The runtime snapshot *does* keep lane grouping, which located the actual missing piece: the `ClipRuntimeInfo → ClipRenderState` conversion, inline in `AudioGraphBuilder`.

Now `ClipRenderKernel::makeClipRenderState`. A pure function of `(clipInfo, projectSampleRate)` — no manager, no graph — so it is a move, not a rewrite, and the six digests gate it because every render already flows through `AudioGraphBuilder`.

With this, both halves an offline caller needs are single-authority: the model→state mapping and the rendering itself. The consolidation renderer will mirror the runtime *by construction* rather than by discipline.

## `f5d02735` — §3.2 was wrong

The previous policy said: bake every fade **except** one coincident with the outer boundary, and let the result clip's own automatic fade reproduce it. Justified by linearity — `r·A + r·B = r·(A+B)`.

That holds only when the delegated ramp is **the same ramp**. It is not, for two independent reasons.

**User and automatic fades collapse into one ramp:**

```cpp
effectiveLength = min(clipLength, max(kClipEdgeFadeSamples, userFadeLength));
```

With a 500-sample user fade the original output has one 500-sample ramp. Baking the user ramp and delegating the automatic one yields the *product* of two ramps where the original had a `max()`.

**Lengths differ with clip length.** A 64-sample contributor gives `min(64,128) = 64`; a 512-sample result gives `min(512,128) = 128`. Suppressing the original and relying on the result's fade substitutes a different envelope.

### Corrected policy

Bake all contributor fades exactly as the runtime renders them, and mark the result so its own automatic edge fades are not applied again — as **durable clip state**, not a render-time argument.

An ephemeral `suppressLeading/suppressTrailing` parameter would make consolidation sound correct *only while being created*. After save and reload the engine would have no explanation for why that clip must not fade its own edges. The failure would present as "my glued clip sounds slightly different after reopening" — creation-time equivalence followed by persistent-state divergence, which is close to untraceable.

Inverse compensation (dividing by the result's future envelope) is recorded as considered and rejected: it avoids serialized state but needs severe pre-emphasis for short boundary clips and can exceed the representable range of the stored format.

## What this blocks

Consolidation cannot start until an `AutomaticEdgeFadePolicy` PR lands — durable model state, propagated into `ClipRenderState`, consumed by the renderer, serialized with a `true` default for old projects. That is a schema change and belongs on its own, from merged `develop`, not stacked here.

## Evidence

```
f5d02735571acef05fd13b8f0295e9034de5285f — clean tree
Audio baseline:  6/6 exact against develop@6422f0be
SRC telemetry:   29/29
Canonical suite: 224/224
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking behavior:** Consolidated clips must bake all contributor fades and disable automatic edge fades. The fade policy must persist through serialization, with `true` as the default for existing projects.
- Moved `ClipRuntimeInfo` to `ClipRenderState` conversion into the pure `ClipRenderKernel::makeClipRenderState` function.
- Updated `AudioGraphBuilder` to use the shared conversion function as the single mapping authority.
- Updated the consolidation specification with runtime, serialization, and audible-equivalence requirements. Consolidation remains blocked until the prerequisite policy change lands.
- Validation passed: 6/6 audio baseline checks, 29/29 SRC telemetry checks, and 224/224 canonical tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->