### PR TITLE
fix(ui): harden timeline interaction reliability

### DIFF
--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -527,6 +527,16 @@ KeyCode PlatformWindowLinux::translateKey(SDL_Keycode key) {
         return KeyCode::Backspace;
     case SDLK_DELETE:
         return KeyCode::Delete;
+    case SDLK_INSERT:
+        return KeyCode::Insert;
+    case SDLK_HOME:
+        return KeyCode::Home;
+    case SDLK_END:
+        return KeyCode::End;
+    case SDLK_PAGEUP:
+        return KeyCode::PageUp;
+    case SDLK_PAGEDOWN:
+        return KeyCode::PageDown;
     case SDLK_UP:
         return KeyCode::Up;
     case SDLK_DOWN:

--- a/AestraUI/Base/NUIContextMenu.cpp
+++ b/AestraUI/Base/NUIContextMenu.cpp
@@ -102,7 +102,12 @@ void NUIContextMenu::onRender(NUIRenderer& renderer)
 
     drawBackground(renderer);
 
-    // Draw items
+    // Tall menus keep their items inside the popup surface. Submenus are
+    // rendered after the clip is cleared so they remain independent popups.
+    const NUIRect bounds = getBounds();
+    renderer.setClipRect({bounds.x + borderWidth_, bounds.y + borderWidth_,
+                          std::max(0.0f, bounds.width - borderWidth_ * 2.0f),
+                          std::max(0.0f, bounds.height - borderWidth_ * 2.0f)});
     for (int i = 0; i < getItemCount(); ++i)
     {
         auto item = getItem(i);
@@ -117,6 +122,18 @@ void NUIContextMenu::onRender(NUIRenderer& renderer)
                 drawItem(renderer, item, i);
             }
         }
+    }
+    renderer.clearClipRect();
+
+    const float contentHeight = calculateContentHeight();
+    if (scrollable_ && contentHeight > bounds.height) {
+        const float trackHeight = std::max(1.0f, bounds.height - 8.0f);
+        const float thumbHeight = std::max(24.0f, trackHeight * (bounds.height / contentHeight));
+        const float travel = std::max(0.0f, trackHeight - thumbHeight);
+        const float progress = maximumScrollOffset() > 0.0f ? scrollOffset_ / maximumScrollOffset() : 0.0f;
+        const NUIRect thumb(bounds.right() - 4.0f, bounds.y + 4.0f + travel * progress, 2.0f, thumbHeight);
+        renderer.fillRoundedRect(thumb, 1.0f,
+                                 NUIThemeManager::getInstance().getColor("textMuted").withAlpha(0.55f));
     }
 
     // Render active submenu on top
@@ -164,6 +181,17 @@ bool NUIContextMenu::onMouseEvent(const NUIMouseEvent& event)
     if (!menuBounds.contains(event.position)) {
         if (event.pressed) hide(); // dismiss on click outside, don't consume the event
         return false;
+    }
+
+    if (event.wheelDelta != 0.0f && scrollable_ && maximumScrollOffset() > 0.0f) {
+        scrollOffset_ += event.wheelDelta > 0.0f ? -itemHeight_ : itemHeight_;
+        clampScrollOffset();
+        NUIPoint localPos = event.position;
+        localPos.x -= menuBounds.x;
+        localPos.y -= menuBounds.y;
+        hoveredItemIndex_ = getItemAtPosition(localPos);
+        setDirty(true);
+        return true;
     }
 
     // Convert absolute/window position to menu-local for item lookup
@@ -218,22 +246,43 @@ bool NUIContextMenu::onKeyEvent(const NUIKeyEvent& event)
                 hide();
                 return true;
             case NUIKeyCode::Up:
-                if (hoveredItemIndex_ > 0)
-                {
-                    hoveredItemIndex_--;
-                    setDirty(true);
-                }
+                navigateUp();
                 return true;
             case NUIKeyCode::Down:
-                if (hoveredItemIndex_ < getItemCount() - 1)
-                {
-                    hoveredItemIndex_++;
-                    setDirty(true);
+                navigateDown();
+                return true;
+            case NUIKeyCode::Home:
+                hoveredItemIndex_ = findSelectableItem(0, 1);
+                ensureItemVisible(hoveredItemIndex_);
+                setDirty(true);
+                return true;
+            case NUIKeyCode::End:
+                hoveredItemIndex_ = findSelectableItem(getItemCount() - 1, -1);
+                ensureItemVisible(hoveredItemIndex_);
+                setDirty(true);
+                return true;
+            case NUIKeyCode::Tab:
+                if (event.modifiers & NUIModifiers::Shift) navigateUp();
+                else navigateDown();
+                return true;
+            case NUIKeyCode::Right:
+                if (isSelectableItem(hoveredItemIndex_)) {
+                    auto item = getItem(hoveredItemIndex_);
+                    if (item && item->getType() == NUIContextMenuItem::Type::Submenu && item->getSubmenu()) {
+                        showSubmenu(hoveredItemIndex_);
+                    }
+                }
+                return true;
+            case NUIKeyCode::Left:
+                if (auto previous = previousFocus_.lock()) {
+                    if (dynamic_cast<NUIContextMenu*>(previous.get())) {
+                        hide();
+                    }
                 }
                 return true;
             case NUIKeyCode::Enter:
             case NUIKeyCode::Space:
-                if (hoveredItemIndex_ >= 0)
+                if (isSelectableItem(hoveredItemIndex_))
                 {
                     handleItemClick(hoveredItemIndex_);
                 }
@@ -319,6 +368,7 @@ void NUIContextMenu::addRadioItem(const std::string& text, const std::string& gr
 void NUIContextMenu::clear()
 {
     items_.clear();
+    scrollOffset_ = 0.0f;
     hoveredItemIndex_ = -1;
     pressedItemIndex_ = -1;
     updateLayout();
@@ -333,6 +383,7 @@ void NUIContextMenu::showAt(const NUIPoint& position)
 void NUIContextMenu::showAt(int x, int y)
 {
     updateLayout();
+    scrollOffset_ = 0.0f;
     float menuWidth = getBounds().width;
     float menuHeight = getBounds().height;
     
@@ -344,6 +395,12 @@ void NUIContextMenu::showAt(int x, int y)
         NUIRect parentBounds = parent->getBounds();
         float parentRight = parentBounds.x + parentBounds.width;
         float parentBottom = parentBounds.y + parentBounds.height;
+        const float availableHeight = std::max(1.0f, parentBounds.height - 20.0f);
+        if (menuHeight > availableHeight) {
+            menuHeight = availableHeight;
+            setSize(menuWidth, menuHeight);
+            clampScrollOffset();
+        }
         
         if (posX + menuWidth > parentRight) {
             posX = parentRight - menuWidth - 10.0f;
@@ -355,21 +412,43 @@ void NUIContextMenu::showAt(int x, int y)
         if (posY < parentBounds.y) posY = parentBounds.y + 10.0f;
     }
     
+    if (!isVisible_) {
+        previousFocus_.reset();
+        if (auto* focused = NUIComponent::getFocusedComponent(); focused && focused != this) {
+            try {
+                previousFocus_ = focused->shared_from_this();
+            } catch (const std::bad_weak_ptr&) {
+                // Stack-owned focus targets cannot be restored safely.
+            }
+        }
+    }
+
     setPosition(posX, posY);
     isVisible_ = true;
-    hoveredItemIndex_ = 0;
+    hoveredItemIndex_ = findSelectableItem(0, 1);
+    ensureItemVisible(hoveredItemIndex_);
     pressedItemIndex_ = -1;
+    setFocused(true);
     triggerShow();
     setDirty(true);
 }
 
 void NUIContextMenu::hide()
 {
+    const bool ownedFocus = ownsMenuFocus();
+    auto previousFocus = previousFocus_.lock();
     isVisible_ = false;
     hoveredItemIndex_ = -1;
     pressedItemIndex_ = -1;
     hideSubmenu();
     triggerHide();
+    if (ownedFocus) {
+        setFocused(false);
+        if (previousFocus && previousFocus.get() != this && previousFocus->isVisible() && previousFocus->isEnabled()) {
+            previousFocus->setFocused(true);
+        }
+    }
+    previousFocus_.reset();
     setDirty(true);
 }
 
@@ -459,7 +538,8 @@ void NUIContextMenu::setCloseOnSelection(bool close)
 
 void NUIContextMenu::setMaxHeight(float height)
 {
-    maxHeight_ = height;
+    maxHeight_ = std::max(1.0f, height);
+    clampScrollOffset();
     updateLayout();
     setDirty(true);
 }
@@ -467,6 +547,8 @@ void NUIContextMenu::setMaxHeight(float height)
 void NUIContextMenu::setScrollable(bool scrollable)
 {
     scrollable_ = scrollable;
+    if (!scrollable_) scrollOffset_ = 0.0f;
+    clampScrollOffset();
     updateLayout();
     setDirty(true);
 }
@@ -488,18 +570,80 @@ void NUIContextMenu::setOnItemClick(std::function<void(std::shared_ptr<NUIContex
 
 void NUIContextMenu::navigateUp()
 {
-    if (hoveredItemIndex_ > 0) {
-        hoveredItemIndex_--;
+    const int start = hoveredItemIndex_ < 0 ? getItemCount() - 1 : hoveredItemIndex_ - 1;
+    const int next = findSelectableItem(start, -1);
+    if (next >= 0) {
+        hoveredItemIndex_ = next;
+        ensureItemVisible(next);
         setDirty(true);
     }
 }
 
 void NUIContextMenu::navigateDown()
 {
-    if (hoveredItemIndex_ < getItemCount() - 1) {
-        hoveredItemIndex_++;
+    const int start = hoveredItemIndex_ < 0 ? 0 : hoveredItemIndex_ + 1;
+    const int next = findSelectableItem(start, 1);
+    if (next >= 0) {
+        hoveredItemIndex_ = next;
+        ensureItemVisible(next);
         setDirty(true);
     }
+}
+
+bool NUIContextMenu::isSelectableItem(int index) const
+{
+    auto item = getItem(index);
+    return item && item->isVisible() && item->isEnabled() &&
+           item->getType() != NUIContextMenuItem::Type::Separator;
+}
+
+int NUIContextMenu::findSelectableItem(int startIndex, int direction) const
+{
+    if (direction == 0 || getItemCount() == 0) return -1;
+    for (int index = startIndex; index >= 0 && index < getItemCount(); index += direction) {
+        if (isSelectableItem(index)) return index;
+    }
+    return -1;
+}
+
+bool NUIContextMenu::ownsMenuFocus() const
+{
+    if (NUIComponent::getFocusedComponent() == this) return true;
+    return activeSubmenu_ && activeSubmenu_->ownsMenuFocus();
+}
+
+float NUIContextMenu::calculateContentHeight() const
+{
+    float height = 0.0f;
+    for (const auto& item : items_) {
+        if (!item || !item->isVisible()) continue;
+        height += item->getType() == NUIContextMenuItem::Type::Separator ? 8.0f : itemHeight_;
+    }
+    return height;
+}
+
+float NUIContextMenu::maximumScrollOffset() const
+{
+    if (!scrollable_) return 0.0f;
+    return std::max(0.0f, calculateContentHeight() - getBounds().height);
+}
+
+void NUIContextMenu::clampScrollOffset()
+{
+    scrollOffset_ = std::clamp(scrollOffset_, 0.0f, maximumScrollOffset());
+}
+
+void NUIContextMenu::ensureItemVisible(int index)
+{
+    if (!scrollable_ || index < 0 || index >= getItemCount()) return;
+    const NUIRect itemRect = getItemRect(index);
+    const NUIRect bounds = getBounds();
+    if (itemRect.y < bounds.y) {
+        scrollOffset_ -= bounds.y - itemRect.y;
+    } else if (itemRect.bottom() > bounds.bottom()) {
+        scrollOffset_ += itemRect.bottom() - bounds.bottom();
+    }
+    clampScrollOffset();
 }
 
 
@@ -657,12 +801,15 @@ NUIRect NUIContextMenu::getItemRect(int index) const
     if (index < 0 || index >= getItemCount()) return NUIRect();
     
     NUIRect bounds = getBounds();
-    float y = bounds.y;
+    float y = bounds.y - scrollOffset_;
     
     // Calculate Y position accounting for separator heights
     for (int i = 0; i < index; ++i)
     {
         auto item = getItem(i);
+        if (!item || !item->isVisible()) {
+            continue;
+        }
         if (item && item->getType() == NUIContextMenuItem::Type::Separator)
         {
             y += 8.0f; // Separators are shorter
@@ -681,23 +828,8 @@ NUIRect NUIContextMenu::getItemRect(int index) const
 
 float NUIContextMenu::calculateMenuHeight() const
 {
-    float height = 0.0f;
-    for (const auto& item : items_)
-    {
-        if (item && item->isVisible())
-        {
-            if (item->getType() == NUIContextMenuItem::Type::Separator)
-            {
-                height += 8.0f; // Separators are shorter
-            }
-            else
-            {
-                height += itemHeight_;
-            }
-        }
-    }
-    
-    return (height < maxHeight_) ? height : maxHeight_;
+    const float contentHeight = calculateContentHeight();
+    return scrollable_ ? std::min(contentHeight, maxHeight_) : contentHeight;
 }
 
 int NUIContextMenu::getItemAtPosition(const NUIPoint& position) const
@@ -707,7 +839,7 @@ int NUIContextMenu::getItemAtPosition(const NUIPoint& position) const
     NUIRect localRect(0, 0, localBounds.width, localBounds.height);
     if (!localRect.contains(position)) return -1;
     
-    float relativeY = position.y;
+    float relativeY = position.y + scrollOffset_;
     float currentY = 0.0f;
     
     for (int i = 0; i < getItemCount(); ++i)
@@ -790,6 +922,7 @@ void NUIContextMenu::updateSize()
     float width = 220.0f; // Clean, compact width
     
     setSize(width, height);
+    clampScrollOffset();
 }
 
 void NUIContextMenu::showSubmenu(int itemIndex)
@@ -810,8 +943,31 @@ void NUIContextMenu::showSubmenu(int itemIndex)
     // Calculate position: right edge of menu + gap, same Y as the item
     float targetX = myBounds.x + myBounds.width + 2.0f;
     float targetY = itemRect.y;
-    
+
     activeSubmenu_->showAt(static_cast<int>(targetX), static_cast<int>(targetY));
+
+    // Submenus are rendered by their owning menu rather than attached as root
+    // children, so constrain them explicitly to the root viewport. Prefer
+    // opening left when the right edge has no room.
+    if (auto* viewportOwner = getParent()) {
+        const NUIRect viewport = viewportOwner->getBounds();
+        NUIRect submenuBounds = activeSubmenu_->getBounds();
+        const float availableHeight = std::max(1.0f, viewport.height - 20.0f);
+        if (submenuBounds.height > availableHeight) {
+            activeSubmenu_->setSize(submenuBounds.width, availableHeight);
+            activeSubmenu_->clampScrollOffset();
+            submenuBounds = activeSubmenu_->getBounds();
+        }
+        if (targetX + submenuBounds.width > viewport.right()) {
+            targetX = myBounds.x - submenuBounds.width - 2.0f;
+        }
+        if (targetY + submenuBounds.height > viewport.bottom()) {
+            targetY = viewport.bottom() - submenuBounds.height - 10.0f;
+        }
+        targetX = std::max(viewport.x + 10.0f, targetX);
+        targetY = std::max(viewport.y + 10.0f, targetY);
+        activeSubmenu_->setPosition(targetX, targetY);
+    }
 }
 
 void NUIContextMenu::hideSubmenu()

--- a/AestraUI/Base/NUIContextMenu.cpp
+++ b/AestraUI/Base/NUIContextMenu.cpp
@@ -437,6 +437,8 @@ void NUIContextMenu::hide()
 {
     const bool ownedFocus = ownsMenuFocus();
     auto previousFocus = previousFocus_.lock();
+    // Mark the parent hidden before cascading so a submenu cannot restore focus
+    // to an already-hidden menu.
     isVisible_ = false;
     hoveredItemIndex_ = -1;
     pressedItemIndex_ = -1;

--- a/AestraUI/Base/NUIContextMenu.h
+++ b/AestraUI/Base/NUIContextMenu.h
@@ -203,6 +203,13 @@ private:
     void triggerItemClick(std::shared_ptr<NUIContextMenuItem> item);
     void triggerShow();
     void triggerHide();
+    int findSelectableItem(int startIndex, int direction) const;
+    bool isSelectableItem(int index) const;
+    bool ownsMenuFocus() const;
+    float calculateContentHeight() const;
+    float maximumScrollOffset() const;
+    void clampScrollOffset();
+    void ensureItemVisible(int index);
 
     // Menu items
     std::vector<std::shared_ptr<NUIContextMenuItem>> items_;
@@ -233,6 +240,7 @@ private:
     int pressedItemIndex_ = -1;
     std::shared_ptr<NUIContextMenu> activeSubmenu_;
     int submenuItemIndex_ = -1;
+    std::weak_ptr<NUIComponent> previousFocus_;
 
     // Layout state
     float menuWidth_ = 0.0f;

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -107,12 +107,18 @@ void NUIPlatformBridge::setupEventBridges() {
         m_lastMouseX = x;
         m_lastMouseY = y;
 
+        const bool rootInputBlocked = m_rootInputBlockedCallback && m_rootInputBlockedCallback();
+
         if (m_mouseMoveCallback) {
             // Skip external callback during cursor capture to prevent hover effects,
             // cursor icon changes, and tooltip triggers in AestraWindowManager.
             if (m_currentCursorStyle != NUICursorStyle::Hidden) {
                 m_mouseMoveCallback(x, y);
             }
+        }
+
+        if (rootInputBlocked) {
+            return;
         }
 
         // Forward to root component for hover effects
@@ -164,8 +170,17 @@ void NUIPlatformBridge::setupEventBridges() {
         m_lastMouseX = x;
         m_lastMouseY = y;
         
+        // Snapshot modal ownership before the external callback. A button
+        // release may close the modal; that same release must still never be
+        // forwarded to the application underneath it.
+        const bool rootInputBlocked = m_rootInputBlockedCallback && m_rootInputBlockedCallback();
+
         if (m_mouseButtonCallback) {
             m_mouseButtonCallback(convertMouseButton(button), pressed);
+        }
+
+        if (rootInputBlocked) {
+            return;
         }
         
         // Forward to root component for AestraUI event handling
@@ -200,6 +215,10 @@ void NUIPlatformBridge::setupEventBridges() {
     // Mouse wheel
     m_window->setMouseWheelCallback([this](float delta) {
         if (!isWindowInteractive()) {
+            return;
+        }
+
+        if (m_rootInputBlockedCallback && m_rootInputBlockedCallback()) {
             return;
         }
 
@@ -254,6 +273,9 @@ void NUIPlatformBridge::setupEventBridges() {
     });
 
     m_window->setCharCallback([this](unsigned int codepoint) {
+        if (m_rootInputBlockedCallback && m_rootInputBlockedCallback()) {
+            return;
+        }
         if (m_charCallback) {
             m_charCallback(codepoint);
         }
@@ -505,6 +527,10 @@ void NUIPlatformBridge::setMouseButtonCallback(std::function<void(int, bool)> ca
 
 void NUIPlatformBridge::setMouseWheelCallback(std::function<void(float)> callback) {
     m_mouseWheelCallback = callback;
+}
+
+void NUIPlatformBridge::setRootInputBlockedCallback(std::function<bool()> callback) {
+    m_rootInputBlockedCallback = std::move(callback);
 }
 
 void NUIPlatformBridge::setMousePositionFilter(std::function<void(int&, int&)> callback) {

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -84,6 +84,8 @@ public:
     void setMouseMoveCallback(std::function<void(int, int)> callback);
     void setMouseButtonCallback(std::function<void(int, bool)> callback);
     void setMouseWheelCallback(std::function<void(float)> callback);
+    /** Block root-component pointer/text dispatch while an external modal owns input. */
+    void setRootInputBlockedCallback(std::function<bool()> callback);
     void setMousePositionFilter(std::function<void(int&, int&)> callback);
     void setKeyCallback(std::function<void(int, bool)> callback);
     void setKeyCallbackEx(std::function<void(int, bool, bool ctrl, bool shift, bool alt)> callback);
@@ -219,6 +221,7 @@ private:
     std::function<void(int, int)> m_mouseMoveCallback;
     std::function<void(int, bool)> m_mouseButtonCallback;
     std::function<void(float)> m_mouseWheelCallback;
+    std::function<bool()> m_rootInputBlockedCallback;
     std::function<void(int&, int&)> m_mousePositionFilter;
     std::function<void(int, bool)> m_keyCallback;
     std::function<void(int, bool, bool, bool, bool)> m_keyCallbackEx;

--- a/Source/Components/TimelineInteractionPolicy.h
+++ b/Source/Components/TimelineInteractionPolicy.h
@@ -1,0 +1,92 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "ClipInstance.h"
+
+#include <algorithm>
+#include <iterator>
+#include <unordered_set>
+#include <vector>
+
+namespace Aestra::Audio {
+
+enum class TrackSelectionIntent {
+    Replace,
+    Add,
+    Toggle,
+};
+
+/** Stable, widget-independent selection authority for Playlist lanes. */
+class TimelineTrackSelection {
+public:
+    void apply(const PlaylistLaneID& laneId, TrackSelectionIntent intent) {
+        if (!laneId.isValid()) {
+            return;
+        }
+
+        if (intent == TrackSelectionIntent::Replace) {
+            m_laneIds.clear();
+        } else if (intent == TrackSelectionIntent::Toggle) {
+            if (m_laneIds.erase(laneId) != 0) {
+                return;
+            }
+        }
+        m_laneIds.insert(laneId);
+    }
+
+    void clear() { m_laneIds.clear(); }
+    bool contains(const PlaylistLaneID& laneId) const { return m_laneIds.find(laneId) != m_laneIds.end(); }
+    size_t size() const { return m_laneIds.size(); }
+    bool empty() const { return m_laneIds.empty(); }
+
+    void selectAll(const std::vector<PlaylistLaneID>& laneIds) {
+        m_laneIds.clear();
+        for (const auto& laneId : laneIds) {
+            if (laneId.isValid()) {
+                m_laneIds.insert(laneId);
+            }
+        }
+    }
+
+    void retainOnly(const std::vector<PlaylistLaneID>& validLaneIds) {
+        const std::unordered_set<PlaylistLaneID> valid(validLaneIds.begin(), validLaneIds.end());
+        for (auto it = m_laneIds.begin(); it != m_laneIds.end();) {
+            it = valid.find(*it) == valid.end() ? m_laneIds.erase(it) : std::next(it);
+        }
+    }
+
+private:
+    std::unordered_set<PlaylistLaneID> m_laneIds;
+};
+
+enum class TimelineLoopPreset : int {
+    Off = 0,
+    OneBar = 1,
+    TwoBars = 2,
+    FourBars = 3,
+    EightBars = 4,
+    Selection = 5,
+    Project = 6,
+};
+
+constexpr int timelineLoopPresetId(TimelineLoopPreset preset) {
+    return static_cast<int>(preset);
+}
+
+constexpr TimelineLoopPreset timelineLoopPresetFromId(int preset) {
+    return preset >= timelineLoopPresetId(TimelineLoopPreset::Off) &&
+                   preset <= timelineLoopPresetId(TimelineLoopPreset::Project)
+               ? static_cast<TimelineLoopPreset>(preset)
+               : TimelineLoopPreset::Off;
+}
+
+constexpr int kDefaultEmptyProjectLoopBars = 16;
+
+inline double resolveProjectLoopEndBeat(double arrangementEndBeat, int beatsPerBar) {
+    if (arrangementEndBeat > 0.001) {
+        return arrangementEndBeat;
+    }
+    return static_cast<double>(std::max(1, beatsPerBar) * kDefaultEmptyProjectLoopBars);
+}
+
+} // namespace Aestra::Audio

--- a/Source/Components/TimelineInteractionPolicy.h
+++ b/Source/Components/TimelineInteractionPolicy.h
@@ -16,6 +16,16 @@ enum class TrackSelectionIntent {
     Toggle,
 };
 
+constexpr TrackSelectionIntent trackSelectionIntentForModifierState(bool toggleModifier, bool shiftModifier) {
+    if (toggleModifier) {
+        return TrackSelectionIntent::Toggle;
+    }
+    if (shiftModifier) {
+        return TrackSelectionIntent::Add;
+    }
+    return TrackSelectionIntent::Replace;
+}
+
 /** Stable, widget-independent selection authority for Playlist lanes. */
 class TimelineTrackSelection {
 public:

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -159,7 +159,9 @@ void TrackManagerUI::refreshTracks() {
     size_t laneCount = playlist.getLaneCount();
     Log::info("refreshTracks: looping over " + std::to_string(laneCount) + " lanes");
 
-    // Clear existing UI components
+    // Stable lane IDs own selection. Raw pointers only describe the current
+    // widget generation, so discard that view before destroying any rows.
+    m_selectedTracks.clear();
     for (auto& trackUI : m_trackUIComponents) {
         removeChild(trackUI);
     }
@@ -191,11 +193,13 @@ void TrackManagerUI::refreshTracks() {
         trackUI->setOnSplitRequested(
             [this](TrackUIComponent* trackComp, double splitTime) { this->onSplitRequested(trackComp, splitTime); });
 
-        trackUI->setOnClipSelected([this](TrackUIComponent* trackComp, ClipInstanceID clipId) {
-            this->m_selectedClipId = clipId;
-            Log::info("TrackManagerUI: Clip selected " + clipId.toString());
-            // Auto-Picking: Selecting a clip automatically loads it into the clipboard/brush
-            copySelectedClip();
+        trackUI->setOnClipSelected([this](TrackUIComponent*, ClipInstanceID clipId) {
+            selectClip(clipId);
+            if (clipId.isValid()) {
+                Log::info("TrackManagerUI: Clip selected " + clipId.toString());
+                // Auto-Picking: Selecting a clip automatically loads it into the clipboard/brush
+                copySelectedClip();
+            }
         });
 
         trackUI->setOnPatternClipOpenRequested([this](PatternID patternId) {
@@ -215,8 +219,9 @@ void TrackManagerUI::refreshTracks() {
             }
         });
 
-        trackUI->setOnTrackSelected(
-            [this](TrackUIComponent* trackComp, bool addToSelection) { this->selectTrack(trackComp, addToSelection); });
+        trackUI->setOnTrackSelected([this](TrackUIComponent* trackComp, TrackSelectionIntent intent) {
+            this->selectTrack(trackComp, intent);
+        });
 
         trackUI->setOnSendToAudition([this, i, lane]() {
             if (this->m_onSendToAudition) {
@@ -236,6 +241,21 @@ void TrackManagerUI::refreshTracks() {
         m_trackUIComponents.push_back(trackUI);
         addChild(trackUI);
     } // Close lane loop
+
+    std::vector<PlaylistLaneID> validLaneIds;
+    validLaneIds.reserve(m_trackUIComponents.size());
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            validLaneIds.push_back(trackUI->getLaneId());
+        }
+    }
+    m_trackSelection.retainOnly(validLaneIds);
+    syncTrackSelectionView();
+
+    if (m_selectedClipId.isValid() && !playlist.getClip(m_selectedClipId)) {
+        m_selectedClipId = ClipInstanceID{};
+    }
+    selectClip(m_selectedClipId);
 
     layoutTracks();
 
@@ -291,6 +311,9 @@ void TrackManagerUI::onClipDeleted(TrackUIComponent* trackComp, ClipInstanceID c
     // Core deletion: remove from PlaylistModel using command for undo support
     auto cmd = std::make_shared<RemoveClipCommand>(playlist, clipId);
     m_trackManager->getCommandHistory().pushAndExecute(cmd);
+    if (m_selectedClipId == clipId) {
+        m_selectedClipId = ClipInstanceID{};
+    }
 
     // FL-style transport behavior: if we just cleared the last clip while playing,
     // snap back to bar 1.
@@ -445,20 +468,20 @@ void TrackManagerUI::setPatternMode(bool enabled) {
 // =============================================================================
 
 void TrackManagerUI::selectTrack(TrackUIComponent* track, bool addToSelection) {
+    selectTrack(track, addToSelection ? TrackSelectionIntent::Add : TrackSelectionIntent::Replace);
+}
+
+void TrackManagerUI::selectTrack(TrackUIComponent* track, TrackSelectionIntent intent) {
     if (!track)
         return;
 
-    if (!addToSelection) {
-        // Clear existing selection first
-        clearSelection();
-    }
+    m_trackSelection.apply(track->getLaneId(), intent);
+    syncTrackSelectionView();
 
-    m_selectedTracks.insert(track);
-    track->setSelected(true);
-
-    std::string trackName = track->getTrack() ? track->getTrack()->getName() : "Unknown";
-    Log::info("[TrackManagerUI] Selected track: " + trackName +
-              " (total selected: " + std::to_string(m_selectedTracks.size()) + ")");
+    const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(track->getLaneId()) : nullptr;
+    const std::string trackName = lane ? lane->name : "Track";
+    Log::info("[TrackManagerUI] Track selection updated: " + trackName +
+              " (total selected: " + std::to_string(m_trackSelection.size()) + ")");
 
     invalidateCache();
 }
@@ -467,44 +490,62 @@ void TrackManagerUI::deselectTrack(TrackUIComponent* track) {
     if (!track)
         return;
 
-    auto it = m_selectedTracks.find(track);
-    if (it != m_selectedTracks.end()) {
-        m_selectedTracks.erase(it);
-        track->setSelected(false);
+    if (!m_trackSelection.contains(track->getLaneId()))
+        return;
 
-        std::string trackName = track->getTrack() ? track->getTrack()->getName() : "Unknown";
-        Log::info("[TrackManagerUI] Deselected track: " + trackName);
-        invalidateCache();
-    }
+    m_trackSelection.apply(track->getLaneId(), TrackSelectionIntent::Toggle);
+    syncTrackSelectionView();
+    invalidateCache();
 }
 
 void TrackManagerUI::clearSelection() {
-    for (auto* track : m_selectedTracks) {
-        if (track) {
-            track->setSelected(false);
-        }
-    }
-    m_selectedTracks.clear();
+    m_trackSelection.clear();
+    syncTrackSelectionView();
 
     Log::info("[TrackManagerUI] Cleared all track selection");
     invalidateCache();
 }
 
 bool TrackManagerUI::isTrackSelected(TrackUIComponent* track) const {
-    return m_selectedTracks.find(track) != m_selectedTracks.end();
+    return track && m_trackSelection.contains(track->getLaneId());
 }
 
 void TrackManagerUI::selectAllTracks() {
-    clearSelection();
-
+    std::vector<PlaylistLaneID> laneIds;
+    laneIds.reserve(m_trackUIComponents.size());
     for (auto& trackUI : m_trackUIComponents) {
         if (trackUI) {
-            m_selectedTracks.insert(trackUI.get());
-            trackUI->setSelected(true);
+            laneIds.push_back(trackUI->getLaneId());
         }
     }
+    m_trackSelection.selectAll(laneIds);
+    syncTrackSelectionView();
 
     Log::info("[TrackManagerUI] Selected all tracks (" + std::to_string(m_selectedTracks.size()) + ")");
+    invalidateCache();
+}
+
+void TrackManagerUI::syncTrackSelectionView() {
+    m_selectedTracks.clear();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (!trackUI) {
+            continue;
+        }
+        const bool selected = m_trackSelection.contains(trackUI->getLaneId());
+        trackUI->setSelected(selected);
+        if (selected) {
+            m_selectedTracks.insert(trackUI.get());
+        }
+    }
+}
+
+void TrackManagerUI::selectClip(ClipInstanceID clipId) {
+    m_selectedClipId = clipId;
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setSelectedClipId(clipId);
+        }
+    }
     invalidateCache();
 }
 
@@ -540,10 +581,48 @@ void TrackManagerUI::openTrackContextMenu(const ::AestraUI::NUIPoint& position,
     m_activeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
     auto menu = m_activeContextMenu;
 
+    TrackUIComponent* selectedTrack = getSelectedTrackUI();
+    auto* lane = selectedTrack && m_trackManager
+                     ? m_trackManager->getPlaylistModel().getLane(selectedTrack->getLaneId())
+                     : nullptr;
+    if (lane && selectedTrack) {
+        const PlaylistLaneID laneId = lane->id;
+        menu->addCheckbox("Mute Track", lane->muted, [this, laneId](bool muted) {
+            if (auto* target = m_trackManager->getPlaylistModel().getLane(laneId)) {
+                target->muted = muted;
+                m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+                m_trackManager->markModified();
+                for (const auto& trackUI : m_trackUIComponents) {
+                    if (trackUI && trackUI->getLaneId() == laneId) trackUI->updateUI();
+                }
+                invalidateCache();
+            }
+        });
+        menu->addCheckbox("Solo Track", lane->solo, [this, laneId](bool soloed) {
+            if (auto* target = m_trackManager->getPlaylistModel().getLane(laneId)) {
+                target->solo = soloed;
+                m_trackManager->requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+                m_trackManager->markModified();
+                for (const auto& trackUI : m_trackUIComponents) {
+                    if (trackUI && trackUI->getLaneId() == laneId) {
+                        onTrackSoloToggled(trackUI.get());
+                        break;
+                    }
+                }
+            }
+        });
+        menu->addSeparator();
+    }
+
     menu->addItem("Send Track to Audition", [onSendToAudition]() {
         if (onSendToAudition)
             onSendToAudition();
     });
+    menu->addSeparator();
+    auto selectAllItem = std::make_shared<AestraUI::NUIContextMenuItem>("Select All Tracks");
+    selectAllItem->setShortcut("Ctrl+A");
+    selectAllItem->setOnClick([this]() { selectAllTracks(); });
+    menu->addItem(selectAllItem);
 
     attachAndShowContextMenu(this, menu, position);
 }

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -20,6 +20,7 @@
 #include "TimelineMinimapBar.h"
 #include "TimelineMinimapModel.h"
 #include "TimelineSummaryCache.h"
+#include "TimelineInteractionPolicy.h"
 #include "WaveformCache.h"
 
 #include <functional>
@@ -139,7 +140,7 @@ public:
 
     // Loop control callback (preset: 0=Off, 1=1Bar, 2=2Bars, 3=4Bars, 4=8Bars, 5=Selection, 6=Project)
     void setOnLoopPresetChanged(std::function<void(int preset)> cb) { m_onLoopPresetChanged = cb; }
-    int getLoopPreset() const { return m_loopPreset; }
+    int getLoopPreset() const { return timelineLoopPresetId(m_loopPreset); }
 
     // Selection made callback - called when ruler selection is finalized (startBeat, endBeat)
     // This should jump playhead to start and set up the loop region
@@ -162,6 +163,7 @@ public:
 
     // === MULTI-SELECTION ===
     void selectTrack(TrackUIComponent* track, bool addToSelection = false);
+    void selectTrack(TrackUIComponent* track, TrackSelectionIntent intent);
     void deselectTrack(TrackUIComponent* track);
     void selectAllTracks();
     void clearSelection();
@@ -368,7 +370,7 @@ private:
     bool m_followPlayheadHovered = false;
 
     // Loop state
-    int m_loopPreset{0}; // 0=Off, 1=1Bar, 2=2Bars, 3=4Bars, 4=8Bars, 5=Selection, 6=Project
+    TimelineLoopPreset m_loopPreset{TimelineLoopPreset::Project};
     double m_lastProjectLoopExtentBeats{-1.0};
 
     // Current editing tool
@@ -377,6 +379,7 @@ private:
     std::function<void(bool)> m_onCursorVisibilityChanged;
 
     // Multi-selection
+    TimelineTrackSelection m_trackSelection;
     std::unordered_set<TrackUIComponent*> m_selectedTracks;
 
     // Instant clip dragging (no ghost)
@@ -415,8 +418,9 @@ private:
     bool m_hoveringLoopEnd = false;
     double m_loopDragStartBeat = 0.0; // Original beat position when drag started
 
-    // === SELECTION BOX (Right-click drag or MultiSelect tool) ===
+    // === SELECTION BOX (left- or right-drag with the Multi-Select tool) ===
     bool m_isDrawingSelectionBox = false;
+    ::AestraUI::NUIMouseButton m_selectionBoxButton = ::AestraUI::NUIMouseButton::None;
     ::AestraUI::NUIPoint m_selectionBoxStart;
     ::AestraUI::NUIPoint m_selectionBoxEnd;
 
@@ -523,6 +527,9 @@ private:
     void syncViewToggleButtons();
     void layoutTracks();
     void onAddTrackClicked();
+    void syncTrackSelectionView();
+    void selectClip(ClipInstanceID clipId);
+    void updateSelectionLoopRegion(double startBeat, double endBeat);
     void updateTrackPositions();
     void updateScrollbar();
     void onScroll(double position);

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -179,7 +179,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
     if (laneIndex < 0 || laneIndex > static_cast<int>(laneCount)) {
         result.accepted = false;
-        result.message = "Invalid lane position";
+        result.message = "Invalid track position";
         clearDropPreview();
         return result;
     }
@@ -217,13 +217,13 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     PlaylistLaneID targetLaneId;
     std::shared_ptr<CreateLaneCommand> laneCommand;
     if (laneIndex == static_cast<int>(laneCount)) {
-        laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Lane " + std::to_string(laneIndex + 1));
+        laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Track " + std::to_string(laneIndex + 1));
         laneCommand->execute();
         targetLaneId = laneCommand->getLaneId();
         if (!targetLaneId.isValid()) {
             laneCommand.reset();
             result.accepted = false;
-            result.message = "Could not create lane";
+            result.message = "Could not create track";
             clearDropPreview();
             return result;
         }

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -229,13 +229,10 @@ bool TrackManagerUI::handleTrackSeamSelect(const AestraUI::NUIMouseEvent& event,
         return false;
     }
 
-    TrackSelectionIntent intent = TrackSelectionIntent::Replace;
-    if ((event.modifiers & AestraUI::NUIModifiers::Ctrl) ||
-        (event.modifiers & AestraUI::NUIModifiers::Super)) {
-        intent = TrackSelectionIntent::Toggle;
-    } else if (event.modifiers & AestraUI::NUIModifiers::Shift) {
-        intent = TrackSelectionIntent::Add;
-    }
+    const bool toggleModifier =
+        (event.modifiers & AestraUI::NUIModifiers::Ctrl) || (event.modifiers & AestraUI::NUIModifiers::Super);
+    const TrackSelectionIntent intent =
+        trackSelectionIntentForModifierState(toggleModifier, event.modifiers & AestraUI::NUIModifiers::Shift);
     selectTrack(trackUI.get(), intent);
     invalidateCache();
     return true;

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -61,7 +61,9 @@ bool TrackManagerUI::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     }
 
     // Claim keyboard focus on click so keyboard routing moves off the file browser.
-    if (event.pressed && event.button == AestraUI::NUIMouseButton::Left && bounds.contains(event.position)) {
+    if (event.pressed &&
+        (event.button == AestraUI::NUIMouseButton::Left || event.button == AestraUI::NUIMouseButton::Right) &&
+        bounds.contains(event.position)) {
         setFocused(true);
     }
 
@@ -116,10 +118,10 @@ bool TrackManagerUI::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         return true;
     }
 
-    // Allow children (clips) to handle right-click press first.
-    // Right-click on a clip deletes it; only start selection
-    // box if nothing underneath handled the event.
-    if (event.pressed && event.button == AestraUI::NUIMouseButton::Right) {
+    // In the explicit Multi-Select tool, either mouse button owns the marquee.
+    // In every other tool, right-click remains a context-menu gesture.
+    if (event.pressed && event.button == AestraUI::NUIMouseButton::Right &&
+        m_currentTool != PlaylistTool::MultiSelect) {
         if (AestraUI::NUIComponent::onMouseEvent(event)) {
             return true;
         }
@@ -227,9 +229,14 @@ bool TrackManagerUI::handleTrackSeamSelect(const AestraUI::NUIMouseEvent& event,
         return false;
     }
 
-    const bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                       (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-    selectTrack(trackUI.get(), shift);
+    TrackSelectionIntent intent = TrackSelectionIntent::Replace;
+    if ((event.modifiers & AestraUI::NUIModifiers::Ctrl) ||
+        (event.modifiers & AestraUI::NUIModifiers::Super)) {
+        intent = TrackSelectionIntent::Toggle;
+    } else if (event.modifiers & AestraUI::NUIModifiers::Shift) {
+        intent = TrackSelectionIntent::Add;
+    }
+    selectTrack(trackUI.get(), intent);
     invalidateCache();
     return true;
 }
@@ -358,12 +365,13 @@ bool TrackManagerUI::handleContextMenuMouse(const AestraUI::NUIMouseEvent& event
 }
 
 bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& event, const AestraUI::NUIPoint& localPos) {
-    // === SELECTION BOX: Right-click drag or MultiSelect tool or Ctrl+LeftClick ===
-    // Start selection box on right-click drag OR left-click with MultiSelect tool OR Ctrl+LeftClick
-    bool ctrlHeld = (event.modifiers & AestraUI::NUIModifiers::Ctrl);
-    bool startSelectionBox = (event.pressed && event.button == AestraUI::NUIMouseButton::Right) ||
-                             (event.pressed && event.button == AestraUI::NUIMouseButton::Left &&
-                              (m_currentTool == PlaylistTool::MultiSelect || ctrlHeld));
+    // Marquee selection is owned by the visible Multi-Select tool. Supporting
+    // both buttons preserves the timeline's established right-drag gesture;
+    // outside this tool, right-click remains reserved for context menus.
+    const bool selectionButton = event.button == AestraUI::NUIMouseButton::Left ||
+                                 event.button == AestraUI::NUIMouseButton::Right;
+    const bool startSelectionBox = event.pressed && selectionButton &&
+                                   m_currentTool == PlaylistTool::MultiSelect;
 
     if (startSelectionBox && !m_isDrawingSelectionBox) {
         float headerHeight = kTimelineHeaderHeight;
@@ -376,6 +384,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             m_isDrawingSelectionBox = true;
             m_selectionBoxStart = event.position;
             m_selectionBoxEnd = event.position;
+            m_selectionBoxButton = event.button;
 
             // Note: System cursor is always hidden by Main.cpp custom cursor system
             return true;
@@ -420,10 +429,9 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             m_selectionBoxEnd = event.position;
         }
 
-        // Check for release to finalize selection
-        // Allow release of Left button even if tool isn't MultiSelect (e.g. Ctrl override case)
-        bool endSelectionBox = (event.released && event.button == AestraUI::NUIMouseButton::Right) ||
-                               (event.released && event.button == AestraUI::NUIMouseButton::Left);
+        // Only the release matching the button that began the marquee may
+        // finalize it; this prevents the other button from ending a drag.
+        const bool endSelectionBox = event.released && event.button == m_selectionBoxButton;
 
         if (endSelectionBox) {
             // Calculate selection rectangle
@@ -445,6 +453,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             // Note: System cursor is always hidden by Main.cpp custom cursor system
 
             m_isDrawingSelectionBox = false;
+            m_selectionBoxButton = AestraUI::NUIMouseButton::None;
             invalidateCache();
 
             Log::info("Selection box completed, selected " + std::to_string(m_selectedTracks.size()) + " tracks");
@@ -696,7 +705,8 @@ bool TrackManagerUI::handleRulerSelectionDrag(const AestraUI::NUIMouseEvent& eve
                 double selEndBeat = std::max(m_rulerSelectionStartBeat, m_rulerSelectionEndBeat);
 
                 // Update loop markers to match selection through centralized propagation.
-                setLoopRegion(selStartBeat, selEndBeat, true);
+                updateSelectionLoopRegion(selStartBeat, selEndBeat);
+                m_loopPreset = TimelineLoopPreset::Selection;
 
                 // Call selection callback - this will jump playhead and set loop region
                 if (m_onSelectionMade) {
@@ -705,7 +715,7 @@ bool TrackManagerUI::handleRulerSelectionDrag(const AestraUI::NUIMouseEvent& eve
 
                 // Also notify loop preset changed to selection mode
                 if (m_onLoopPresetChanged) {
-                    m_onLoopPresetChanged(5); // 5 = Selection preset
+                    m_onLoopPresetChanged(timelineLoopPresetId(TimelineLoopPreset::Selection));
                 }
 
                 Log::info("[TrackManagerUI] Ruler selection: " + std::to_string(selStartBeat) + " to " +
@@ -713,13 +723,14 @@ bool TrackManagerUI::handleRulerSelectionDrag(const AestraUI::NUIMouseEvent& eve
             } else {
                 // Click without drag - clear selection and disable loop
                 setLoopRegion(0.0, 0.0, false);
+                m_loopPreset = TimelineLoopPreset::Off;
 
                 // SPECIAL: If we clicked on an EXISTNG range on ruler, show menu
                 // (Wait, this is handled in the isInRuler block if it's an instant click)
 
                 // Trigger loop OFF callback
                 if (m_onLoopPresetChanged) {
-                    m_onLoopPresetChanged(0); // 0 = Off
+                    m_onLoopPresetChanged(timelineLoopPresetId(TimelineLoopPreset::Off));
                 }
             }
 
@@ -777,10 +788,11 @@ bool TrackManagerUI::handleLoopMarkerDrag(const AestraUI::NUIMouseEvent& event, 
         if (event.released && event.button == AestraUI::NUIMouseButton::Left) {
             m_isDraggingLoopStart = false;
             m_isDraggingLoopEnd = false;
+            m_loopPreset = TimelineLoopPreset::Selection;
 
             // Update audio engine loop region
             if (m_onLoopPresetChanged) {
-                m_onLoopPresetChanged(5); // Selection preset
+                m_onLoopPresetChanged(timelineLoopPresetId(TimelineLoopPreset::Selection));
             }
 
             return true;
@@ -797,17 +809,14 @@ bool TrackManagerUI::handleLoopMarkerDrag(const AestraUI::NUIMouseEvent& event, 
         if (m_isDraggingLoopStart) {
             // Don't allow start to go past end
             if (positionInBeats < m_loopEndBeat) {
-                setLoopRegion(positionInBeats, m_loopEndBeat, true);
+                updateSelectionLoopRegion(positionInBeats, m_loopEndBeat);
             }
         } else if (m_isDraggingLoopEnd) {
             // Don't allow end to go before start
             if (positionInBeats > m_loopStartBeat) {
-                setLoopRegion(m_loopStartBeat, positionInBeats, true);
+                updateSelectionLoopRegion(m_loopStartBeat, positionInBeats);
             }
         }
-
-        // Update minimap selection range
-        m_minimapSelectionBeatRange = {m_loopStartBeat, m_loopEndBeat};
 
         invalidateCache(); // Loop marker position changed
         return true;
@@ -915,8 +924,16 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
             return true;
         }
 
-        if (event.keyCode == AestraUI::NUIKeyCode::Delete || event.keyCode == AestraUI::NUIKeyCode::Backspace) {
+        if ((event.keyCode == AestraUI::NUIKeyCode::Delete || event.keyCode == AestraUI::NUIKeyCode::Backspace) &&
+            m_selectedClipId.isValid()) {
             deleteSelectedClip();
+            return true;
+        }
+
+        if (event.keyCode == AestraUI::NUIKeyCode::Escape &&
+            (m_selectedClipId.isValid() || !m_selectedTracks.empty())) {
+            selectClip(ClipInstanceID{});
+            clearSelection();
             return true;
         }
 
@@ -924,24 +941,29 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
 
         // Clipboard (Ctrl+C/V/X/D)
         if (event.modifiers & AestraUI::NUIModifiers::Ctrl) {
-            if (event.keyCode == AestraUI::NUIKeyCode::X) {
+            if (event.keyCode == AestraUI::NUIKeyCode::A) {
+                selectAllTracks();
+                return true;
+            }
+            if (event.keyCode == AestraUI::NUIKeyCode::X && m_selectedClipId.isValid()) {
                 cutSelectedClip();
                 return true;
             }
-            if (event.keyCode == AestraUI::NUIKeyCode::C) {
+            if (event.keyCode == AestraUI::NUIKeyCode::C && m_selectedClipId.isValid()) {
                 copySelectedClip();
                 return true;
             }
-            if (event.keyCode == AestraUI::NUIKeyCode::V) {
+            if (event.keyCode == AestraUI::NUIKeyCode::V && hasClipboardClip()) {
                 pasteClipboardAtCursor();
                 return true;
             }
-            if (event.keyCode == AestraUI::NUIKeyCode::D) {
+            if (event.keyCode == AestraUI::NUIKeyCode::D && m_selectedClipId.isValid()) {
                 duplicateSelectedClip();
                 return true;
             }
             // Ctrl+B: Paste-to-right (paste at end of selected clip, select new clip)
-            if (event.keyCode == AestraUI::NUIKeyCode::B) {
+            if (event.keyCode == AestraUI::NUIKeyCode::B &&
+                (m_selectedClipId.isValid() || hasClipboardClip())) {
                 pasteClipToRight();
                 return true;
             }

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -222,52 +222,10 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
 
             AestraUI::NUIRect clippedRect(clipX, clipY, clipR - clipX, clipB - clipY);
 
-            // "Glass Tech" Theme Style - POLISHED
-            AestraUI::NUIColor accent = themeManager.getColor("accentCyan");
-
-            // 1. Vertical Gradient Fill for "Glass" depth
-            // Top: More transparent
-            // Bottom: Denser
-            AestraUI::NUIColor fillTop = accent.withAlpha(0.04f);
-            AestraUI::NUIColor fillBottom = accent.withAlpha(0.15f);
-            renderer.fillRectGradient(clippedRect, fillTop, fillBottom, true /* vertical */);
-
-            // 2. Main Border with Glow
-            // Outer Glow (Blurred/Wide)
-            renderer.strokeRect(clippedRect, 3.0f, accent.withAlpha(0.25f));
-            // Inner Core (Sharp)
-            renderer.strokeRect(clippedRect, 1.0f, accent.withAlpha(0.9f));
-
-            // 3. Glowing Corners
-            // Helper for corner rendering
-            auto drawCorner = [&](float x, float y, float w, float h) {
-                // Outer Glow
-                renderer.fillRect(AestraUI::NUIRect(x - 1, y - 1, w + 2, h + 2), accent.withAlpha(0.5f));
-                // Core
-                renderer.fillRect(AestraUI::NUIRect(x, y, w, h), accent.withAlpha(1.0f));
-            };
-
-            float cornerLen = 6.0f;
-            float cornerThick = 2.0f;
-
-            // Only draw corners if rect is large enough
-            if (clippedRect.width > cornerLen * 2 && clippedRect.height > cornerLen * 2) {
-                // Top-Left
-                drawCorner(clipX, clipY, cornerLen, cornerThick);
-                drawCorner(clipX, clipY, cornerThick, cornerLen);
-
-                // Top-Right
-                drawCorner(clipR - cornerLen, clipY, cornerLen, cornerThick);
-                drawCorner(clipR - cornerThick, clipY, cornerThick, cornerLen);
-
-                // Bottom-Left
-                drawCorner(clipX, clipB - cornerThick, cornerLen, cornerThick);
-                drawCorner(clipX, clipB - cornerLen, cornerThick, cornerLen);
-
-                // Bottom-Right
-                drawCorner(clipR - cornerLen, clipB - cornerThick, cornerLen, cornerThick);
-                drawCorner(clipR - cornerThick, clipB - cornerLen, cornerThick, cornerLen);
-            }
+            // Match the Piano Roll's quiet purple rubber-band treatment.
+            const AestraUI::NUIColor accent = themeManager.getColor("accentPrimary");
+            renderer.fillRoundedRect(clippedRect, 2.0f, accent.withAlpha(0.15f));
+            renderer.strokeRoundedRect(clippedRect, 2.0f, 1.0f, accent.withAlpha(0.55f));
         }
     }
 
@@ -649,12 +607,14 @@ void TrackManagerUI::onUpdate(double deltaTime) {
 
     NUIComponent::onUpdate(deltaTime);
 
-    if (m_loopPreset == 6 && m_trackManager) {
+    if (m_activeContextMenu && !m_activeContextMenu->isVisible()) {
+        detachContextMenu(m_activeContextMenu);
+        m_activeContextMenu = nullptr;
+    }
+
+    if (m_loopPreset == TimelineLoopPreset::Project && m_trackManager) {
         double projectEndBeat = m_trackManager->getPlaylistModel().getTotalDurationBeats();
-        if (projectEndBeat <= 0.001) {
-            const double emptyProjectBeats = static_cast<double>(std::max(1, m_beatsPerBar)) * 16.0;
-            projectEndBeat = emptyProjectBeats;
-        }
+        projectEndBeat = resolveProjectLoopEndBeat(projectEndBeat, m_beatsPerBar);
 
         if (std::abs(projectEndBeat - m_lastProjectLoopExtentBeats) > 1e-3) {
             m_lastProjectLoopExtentBeats = projectEndBeat;
@@ -670,16 +630,6 @@ void TrackManagerUI::onUpdate(double deltaTime) {
     // Animate Menu Icon Rotation
     float targetRot = m_activeContextMenu ? 90.0f : 0.0f;
     float diff = targetRot - m_menuIconRotation;
-
-    // Debug logging (throttled)
-    static double logTimer = 0.0;
-    logTimer += deltaTime;
-    if (logTimer > 1.0) {
-        if (m_activeContextMenu) {
-            Log::info("TrackManagerUI::onUpdate - Menu Active. Rot: " + std::to_string(m_menuIconRotation));
-        }
-        logTimer = 0.0;
-    }
 
     // Smooth lerp toward target
     if (std::abs(diff) > 0.5f) {
@@ -884,12 +834,11 @@ void TrackManagerUI::onUpdate(double deltaTime) {
                 double positionInBeats = std::max(0.0, snapBeatToGrid(localMouseX / m_pixelsPerBeat));
                 if (m_isDraggingLoopStart) {
                     if (positionInBeats < m_loopEndBeat) {
-                        setLoopRegion(positionInBeats, m_loopEndBeat, true);
+                        updateSelectionLoopRegion(positionInBeats, m_loopEndBeat);
                     }
                 } else if (positionInBeats > m_loopStartBeat) {
-                    setLoopRegion(m_loopStartBeat, positionInBeats, true);
+                    updateSelectionLoopRegion(m_loopStartBeat, positionInBeats);
                 }
-                m_minimapSelectionBeatRange = {m_loopStartBeat, m_loopEndBeat};
                 invalidateCache();
             } else if (m_isDraggingPlayhead && m_trackManager) {
                 auto& playlist = m_trackManager->getPlaylistModel();

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -426,7 +426,7 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
         // === LOOP SUBMENU ===
         auto loopMenu = std::make_shared<AestraUI::NUIContextMenu>();
         auto addLoopItem = [&](const std::string& name, int id) {
-            bool isSelected = (m_loopPreset == id);
+            bool isSelected = (timelineLoopPresetId(m_loopPreset) == id);
             loopMenu->addRadioItem(name, "LoopGroup", isSelected, [this, id, name]() {
                 // m_loopPreset is assigned AFTER the branches below, not here. Two of
                 // them can decline to apply — "Selection" with no selection, "Project"
@@ -459,8 +459,7 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                     }
 
                     if (projectEnd <= 0.001) {
-                        const double emptyProjectBeats = static_cast<double>(std::max(1, m_beatsPerBar)) * 16.0;
-                        projectEnd = emptyProjectBeats;
+                        projectEnd = resolveProjectLoopEndBeat(projectEnd, m_beatsPerBar);
                         Log::info("Loop Project: Empty arrangement fallback -> " + std::to_string(projectEnd) +
                                   " beats");
                     }
@@ -480,11 +479,21 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                 // the state the project is now in.
                 const bool intendedToEnable = (id != 0);
                 const int appliedPreset = (intendedToEnable && !loopEnabled) ? 0 : id;
-                m_loopPreset = appliedPreset;
+                m_loopPreset = timelineLoopPresetFromId(appliedPreset);
 
-                setLoopRegion(loopStartBeat, loopEndBeat, loopEnabled);
+                if (m_loopPreset != TimelineLoopPreset::Selection) {
+                    m_hasRulerSelection = false;
+                    m_hoveringLoopStart = false;
+                    m_hoveringLoopEnd = false;
+                }
 
-                if (m_onLoopRegionUpdate) {
+                if (m_loopPreset == TimelineLoopPreset::Selection && loopEnabled) {
+                    updateSelectionLoopRegion(loopStartBeat, loopEndBeat);
+                } else {
+                    setLoopRegion(loopStartBeat, loopEndBeat, loopEnabled);
+                }
+
+                if (m_loopPreset != TimelineLoopPreset::Selection && m_onLoopRegionUpdate) {
                     if (loopEnabled) {
                         m_onLoopRegionUpdate(loopStartBeat, loopEndBeat);
                     } else {
@@ -503,18 +512,18 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
             });
         };
 
-        addLoopItem("Off", 0);
-        addLoopItem("1 Bar", 1);
-        addLoopItem("2 Bars", 2);
-        addLoopItem("4 Bars", 3);
-        addLoopItem("8 Bars", 4);
-        addLoopItem("Selection", 5);
-        addLoopItem("Project", 6);
+        addLoopItem("Off", timelineLoopPresetId(TimelineLoopPreset::Off));
+        addLoopItem("1 Bar", timelineLoopPresetId(TimelineLoopPreset::OneBar));
+        addLoopItem("2 Bars", timelineLoopPresetId(TimelineLoopPreset::TwoBars));
+        addLoopItem("4 Bars", timelineLoopPresetId(TimelineLoopPreset::FourBars));
+        addLoopItem("8 Bars", timelineLoopPresetId(TimelineLoopPreset::EightBars));
+        addLoopItem("Selection", timelineLoopPresetId(TimelineLoopPreset::Selection));
+        addLoopItem("Project", timelineLoopPresetId(TimelineLoopPreset::Project));
         menu->addSubmenu("Loop", loopMenu);
 
         // === AUDITION MODE ===
         menu->addSeparator();
-        menu->addItem("Send to Audition", [this]() {
+        menu->addItem("Send Track to Audition", [this]() {
             // Get selected track or first track
             if (m_onSendToAudition && m_trackManager) {
                 auto& playlist = m_trackManager->getPlaylistModel();

--- a/Source/Components/TrackManagerUIView.cpp
+++ b/Source/Components/TrackManagerUIView.cpp
@@ -395,20 +395,13 @@ void TrackManagerUI::onHorizontalScroll(double position) {
 }
 
 void TrackManagerUI::deselectAllTracks() {
-    for (auto& trackUI : m_trackUIComponents) {
-        trackUI->setSelected(false);
-    }
+    clearSelection();
 }
 // Set loop region (called from Main.cpp when loop preset changes)
 void TrackManagerUI::setLoopRegion(double startBeat, double endBeat, bool enabled) {
     m_loopStartBeat = startBeat;
     m_loopEndBeat = endBeat;
     m_loopEnabled = enabled;
-    m_hasRulerSelection = enabled && (endBeat > startBeat);
-    if (m_hasRulerSelection) {
-        m_rulerSelectionStartBeat = startBeat;
-        m_rulerSelectionEndBeat = endBeat;
-    }
     for (auto& trackUI : m_trackUIComponents) {
         if (!trackUI) {
             continue;
@@ -417,6 +410,17 @@ void TrackManagerUI::setLoopRegion(double startBeat, double endBeat, bool enable
         trackUI->setLoopRegion(startBeat, endBeat);
     }
     invalidateCache(); // Redraw to show updated markers
+}
+
+void TrackManagerUI::updateSelectionLoopRegion(double startBeat, double endBeat) {
+    setLoopRegion(startBeat, endBeat, true);
+    m_rulerSelectionStartBeat = startBeat;
+    m_rulerSelectionEndBeat = endBeat;
+    m_hasRulerSelection = endBeat > startBeat;
+    m_minimapSelectionBeatRange = {startBeat, endBeat};
+    if (m_onLoopRegionUpdate) {
+        m_onLoopRegionUpdate(startBeat, endBeat);
+    }
 }
 // Calculate maximum timeline extent needed based on all samples
 // Calculate maximum timeline extent needed based on all clips

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -98,6 +98,17 @@ std::string truncateClipLabel(const std::string& text, float availableWidth, flo
     return text.substr(0, maxChars - 2) + "..";
 }
 
+TrackSelectionIntent selectionIntentFor(const AestraUI::NUIMouseEvent& event) {
+    if ((event.modifiers & AestraUI::NUIModifiers::Ctrl) ||
+        (event.modifiers & AestraUI::NUIModifiers::Super)) {
+        return TrackSelectionIntent::Toggle;
+    }
+    if (event.modifiers & AestraUI::NUIModifiers::Shift) {
+        return TrackSelectionIntent::Add;
+    }
+    return TrackSelectionIntent::Replace;
+}
+
 AestraUI::NUIColor restrainDawColor(const AestraUI::NUIColor& color, float brightnessScale, float saturationScale,
                                     float alpha) {
     const float luma = (0.2126f * color.r) + (0.7152f * color.g) + (0.0722f * color.b);
@@ -108,6 +119,23 @@ AestraUI::NUIColor restrainDawColor(const AestraUI::NUIColor& color, float brigh
                               std::clamp(tonedG, 0.0f, 1.0f),
                               std::clamp(tonedB, 0.0f, 1.0f),
                               alpha >= 0.0f ? alpha : color.a);
+}
+
+// Keep Playlist clip selection in the same visual language as Piano Roll
+// notes: a lifted secondary accent, crisp white edge, grounded shadow, and
+// subtle edit handles. Clip identity colour remains visible underneath.
+void drawPianoRollStyleSelection(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds, float radius) {
+    auto& themeManager = AestraUI::NUIThemeManager::getInstance();
+    const auto selectedColor = themeManager.getColor("accentSecondary").lightened(0.12f);
+    renderer.drawShadow({bounds.x, bounds.y + 1.0f, bounds.width, bounds.height},
+                        0.0f, 2.0f, 5.0f, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.22f));
+    renderer.fillRoundedRect(bounds, radius, selectedColor.withAlpha(0.12f));
+    renderer.strokeRoundedRect(bounds, radius, 1.5f, AestraUI::NUIColor::white().withAlpha(0.78f));
+    const float handleHeight = std::max(2.0f, bounds.height - 6.0f);
+    renderer.fillRoundedRect({bounds.x + 1.0f, bounds.y + 3.0f, 2.0f, handleHeight},
+                             1.0f, AestraUI::NUIColor::white().withAlpha(0.68f));
+    renderer.fillRoundedRect({bounds.right() - 3.0f, bounds.y + 3.0f, 2.0f, handleHeight},
+                             1.0f, AestraUI::NUIColor::white().withAlpha(0.68f));
 }
 
 // Waveform ink derived from the clip color so the waveform reads as part of
@@ -148,13 +176,13 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     // Create track name label
     m_nameLabel = std::make_shared<AestraUI::NUILabel>();
     
-    std::string name = "Lane";
+    std::string name = "Track";
     if (m_trackManager) {
         if (auto lane = m_trackManager->getPlaylistModel().getLane(m_laneId)) {
             name = lane->name;
         }
     }
-    m_nameLabel->setText(name.empty() ? "Lane" : name);
+    m_nameLabel->setText(name.empty() ? "Track" : name);
 
     {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
@@ -186,7 +214,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     configureFlatTrackButton(m_muteButton);
     m_muteButton->setToggleable(true);
     m_muteButton->setOnToggle([this](bool) { onMuteToggled(); });
-    m_muteButton->setTooltip("Mute Playlist lane (M)");
+    m_muteButton->setTooltip("Mute Track (M)");
     addChild(m_muteButton);
 
     // Create solo button
@@ -195,7 +223,7 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     configureFlatTrackButton(m_soloButton);
     m_soloButton->setToggleable(true);
     m_soloButton->setOnToggle([this](bool) { onSoloToggled(); });
-    m_soloButton->setTooltip("Solo Playlist lane (S)");
+    m_soloButton->setTooltip("Solo Track (S)");
     addChild(m_soloButton);
 
     // Recording is armed from mixer inserts. A Playlist lane only receives a
@@ -235,11 +263,37 @@ void TrackUIComponent::showClipRoutingMenu(const ClipInstanceID& clipId, const A
     m_clipRoutingMenu = std::make_shared<AestraUI::NUIContextMenu>();
     m_clipRoutingMenu->setOnHide([this]() { detachContextMenu(m_clipRoutingMenu); });
 
+    auto addAction = [this](const std::string& label, const std::string& shortcut, std::function<void()> action) {
+        auto item = std::make_shared<AestraUI::NUIContextMenuItem>(label);
+        item->setShortcut(shortcut);
+        item->setOnClick(std::move(action));
+        m_clipRoutingMenu->addItem(item);
+    };
+
+    if (pattern && pattern->isMidi() && m_onPatternClipOpenRequested) {
+        addAction("Open in Piano Roll", "Enter", [this, patternId = pattern->id]() {
+            m_onPatternClipOpenRequested(patternId);
+        });
+    } else if (pattern && pattern->isAudio() && m_onAudioClipOpenRequested) {
+        addAction("Open in Audio Editor", "Enter", [this, clipId]() { m_onAudioClipOpenRequested(clipId); });
+    }
+
+    if (auto* parentManager = dynamic_cast<TrackManagerUI*>(getParent())) {
+        if (m_clipRoutingMenu->getItemCount() > 0) {
+            m_clipRoutingMenu->addSeparator();
+        }
+        addAction("Cut", "Ctrl+X", [parentManager]() { parentManager->cutSelectedClip(); });
+        addAction("Copy", "Ctrl+C", [parentManager]() { parentManager->copySelectedClip(); });
+        addAction("Duplicate", "Ctrl+D", [parentManager]() { parentManager->duplicateSelectedClip(); });
+    }
+
     if (pattern && pattern->isAudio()) {
         const uint32_t selectedId = pattern->getMixerChannelId();
-        const auto addDestination = [this, patternId = pattern->id, selectedId](uint32_t channelId,
-                                                                                const std::string& label) {
-            m_clipRoutingMenu->addItem((selectedId == channelId ? "✓ " : "  ") + label, [this, patternId, channelId]() {
+        auto routingMenu = std::make_shared<AestraUI::NUIContextMenu>();
+        const auto addDestination = [this, routingMenu, patternId = pattern->id, selectedId](uint32_t channelId,
+                                                                                            const std::string& label) {
+            routingMenu->addRadioItem(label, "ClipSourceRouting", selectedId == channelId,
+                                      [this, patternId, channelId]() {
                 if (m_trackManager->setAudioPatternMixerChannel(patternId, channelId)) {
                     repaint();
                     if (m_onCacheInvalidationCallback) {
@@ -249,7 +303,6 @@ void TrackUIComponent::showClipRoutingMenu(const ClipInstanceID& clipId, const A
             });
         };
 
-        m_clipRoutingMenu->addItem("Source routing (all linked clips)", []() {});
         m_clipRoutingMenu->addSeparator();
         addDestination(0, "Master");
         for (size_t i = 0; i < m_trackManager->getChannelCount(); ++i) {
@@ -257,14 +310,18 @@ void TrackUIComponent::showClipRoutingMenu(const ClipInstanceID& clipId, const A
                 addDestination(channel->getChannelId(), std::to_string(i + 1) + "  " + channel->getName());
             }
         }
-        m_clipRoutingMenu->addSeparator();
+        m_clipRoutingMenu->addSubmenu("Route Linked Clips", routingMenu);
     }
 
-    m_clipRoutingMenu->addItem("Delete clip", [this, clipId, position]() {
+    m_clipRoutingMenu->addSeparator();
+    auto deleteItem = std::make_shared<AestraUI::NUIContextMenuItem>("Delete Clip");
+    deleteItem->setShortcut("Delete");
+    deleteItem->setOnClick([this, clipId, position]() {
         if (m_onClipDeletedCallback) {
             m_onClipDeletedCallback(this, clipId, position);
         }
     });
+    m_clipRoutingMenu->addItem(deleteItem);
     attachAndShowContextMenu(this, m_clipRoutingMenu, position);
 }
 
@@ -517,7 +574,7 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
 
     // Waveform ink base is the clip hue at full brightness; deriveWaveformInk()
     // lifts it bright + near-opaque so the wave reads boldly over the fill.
-    const bool clipSelected = (clip.id == m_activeClipId);
+    const bool clipSelected = (clip.id == m_selectedClipId);
     AestraUI::NUIColor clipTint = restrainDawColor(resolveClipDisplayColor(clip), 1.0f, 0.92f, 1.0f);
     if (clipSelected) clipTint = clipTint.lightened(0.12f);
 
@@ -844,7 +901,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
         }
     }
     
-    bool clipSelected = (clip.id == m_activeClipId);
+    bool clipSelected = (clip.id == m_selectedClipId);
     // Selection eases the base look up slightly; the border and glow carry
     // the state so the fill doesn't visibly "pop" on click-and-hold
     // Deeper, less-saturated base so the clip reads rich rather than neon.
@@ -900,7 +957,7 @@ void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, con
             sampleName = pattern->name;
         }
     }
-    const bool clipSelected = (clip.id == m_activeClipId);
+    const bool clipSelected = (clip.id == m_selectedClipId);
 
     const AestraUI::NUIRect headerRect(clipBounds.x + 1.0f, clipBounds.y + 1.0f,
                                        std::max(0.0f, clipBounds.width - 2.0f), kClipHeaderHeight);
@@ -1031,6 +1088,10 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                     drawWaveformForClip(renderer, waveformInsideClip, clip, offsetRatio, visibleRatio);
                     drawSampleClipHeader(renderer, insetClippedClipBounds, clip);
                 }
+                if (clip.id == m_selectedClipId) {
+                    drawPianoRollStyleSelection(renderer, insetClippedClipBounds,
+                                                AestraUI::NUIThemeManager::getInstance().getRadius("s"));
+                }
             }
         }
     }
@@ -1050,7 +1111,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
             baseColor = themeManager.getColor("accentPrimary");
         }
     }
-    bool isSelected = (clip.id == m_activeClipId);
+    bool isSelected = (clip.id == m_selectedClipId);
 
     if (clip.edits.muted) {
         baseColor = baseColor.withAlpha(0.4f);
@@ -1206,14 +1267,19 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
 
     // Selection Highlight (Static base)
     if (isSelected()) {
-         AestraUI::NUIColor selectedColor = themeManager.getColor("accentPrimary").withAlpha(0.075f);
-         trackBgColor = selectedColor; 
+         trackBgColor = themeManager.getColor("accentSecondary").lightened(0.12f).withAlpha(0.045f);
     } else if (isHovered()) {
          trackBgColor = themeManager.getCurrentTheme().textPrimary.withAlpha(0.026f);
     }
     
     // Apply background
     renderer.fillRect(bounds, trackBgColor);
+    if (isSelected()) {
+        const auto selectionEdge = AestraUI::NUIColor::white().withAlpha(0.42f);
+        renderer.drawLine({bounds.x, bounds.y}, {bounds.right(), bounds.y}, 1.0f, selectionEdge);
+        renderer.drawLine({bounds.x, bounds.bottom() - 1.0f}, {bounds.right(), bounds.bottom() - 1.0f},
+                          1.0f, selectionEdge.withAlpha(0.28f));
+    }
 
     // Row separation is the light gap strip drawn by TrackManagerUI between
     // lanes — no per-row line here, so separators never stack.
@@ -1231,7 +1297,7 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
         // Static Playlist-lane state is independent from mixer insert state.
         if (lane) {
             if (m_selected) {
-                 baseControlColor = themeManager.getColor("primary").withAlpha(0.022f);
+                 baseControlColor = themeManager.getColor("accentSecondary").withAlpha(0.035f);
             } else if (lane->solo) {
                  baseControlColor = themeManager.getColor("accentCyan").withAlpha(0.10f);
             } else if (lane->muted) {
@@ -1446,9 +1512,10 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 
         // SELECTION OVERLAY
         if (m_selected) {
-            renderer.fillRect(controlAreaBounds, themeManager.getColor("primary").withAlpha(0.022f));
+            renderer.fillRect(controlAreaBounds, themeManager.getColor("accentSecondary").withAlpha(0.035f));
             AestraUI::NUIRect selectionBar(controlAreaBounds.x, controlAreaBounds.y, 3.0f, controlAreaBounds.height);
-            renderer.fillRect(selectionBar, themeManager.getColor("primary").withAlpha(0.18f));
+            renderer.fillRect(selectionBar,
+                              themeManager.getColor("accentSecondary").lightened(0.12f).withAlpha(0.82f));
         }
     }
 
@@ -1485,7 +1552,7 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 
         // Selection Highlight Line (Inner Glow)
         if (m_selected) {
-            auto glowColor = themeManager.getColor("highlightGlow");
+            auto glowColor = AestraUI::NUIColor::white().withAlpha(0.52f);
             // Top highlight line inside control area (skipping strip)
             renderer.fillRect(AestraUI::NUIRect(bounds.x + stripWidth, bounds.y, controlAreaWidth - stripWidth, 1.0f), glowColor);
             // Bottom highlight
@@ -1947,19 +2014,19 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 
         if (!event.cursorCaptured && isInsideBounds) {
             if (m_volumeFader && m_volumeFader->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Playlist lane volume", event.position, this);
+                AestraUI::NUIComponent::showRemoteTooltip("Track Volume", event.position, this);
             } else if (m_muteButton && m_muteButton->getBounds().contains(event.position)) {
                 const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
                 const std::string tooltip =
-                    lane && lane->muted && lane->solo ? "Muted • solo is held (M)" : "Mute Playlist lane (M)";
+                    lane && lane->muted && lane->solo ? "Muted • Solo is held (M)" : "Mute Track (M)";
                 AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_soloButton && m_soloButton->getBounds().contains(event.position)) {
                 const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
                 const std::string tooltip =
-                    lane && lane->muted && lane->solo ? "Solo held • lane is muted (S)" : "Solo Playlist lane (S)";
+                    lane && lane->muted && lane->solo ? "Solo held • Track is muted (S)" : "Solo Track (S)";
                 AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_recordButton && m_recordButton->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Arm for Recording (O)", event.position, this);
+                AestraUI::NUIComponent::showRemoteTooltip("Arm Track for Recording (O)", event.position, this);
             } else if (m_volumeKnobHovered) {
                 int pct = static_cast<int>(std::round(m_volumeKnobValue * 100.0f));
                 AestraUI::NUIPoint tipPos(
@@ -1974,8 +2041,9 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         if (event.pressed && event.button == AestraUI::NUIMouseButton::Right &&
             m_recordButton && m_recordButton->getBounds().contains(event.position)) {
             if (m_onTrackSelectedCallback) {
-                m_onTrackSelectedCallback(this, false);
+                m_onTrackSelectedCallback(this, TrackSelectionIntent::Replace);
             }
+            if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
             showRecordModeMenu(event.position);
             return true;
         }
@@ -1983,9 +2051,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         if (handledByControls) {
             // Clicking controls should also select the track (v3.1)
             if (event.pressed && event.button == AestraUI::NUIMouseButton::Left && m_onTrackSelectedCallback) {
-                bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                             (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                m_onTrackSelectedCallback(this, shift);
+                m_onTrackSelectedCallback(this, selectionIntentFor(event));
+                if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
             }
             return true;
         }
@@ -1994,8 +2061,9 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         if (event.pressed && event.button == AestraUI::NUIMouseButton::Right && event.position.x <= controlAreaEndX) {
             // Select track on right-click too
             if (m_onTrackSelectedCallback) {
-                m_onTrackSelectedCallback(this, false);
+                m_onTrackSelectedCallback(this, TrackSelectionIntent::Replace);
             }
+            if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
 
             if (auto parentMgr = dynamic_cast<TrackManagerUI*>(getParent())) {
                 parentMgr->openTrackContextMenu(event.position, m_onSendToAuditionCallback);
@@ -2141,10 +2209,9 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             // Allow selecting track in automation mode if not interacting with points
             if (event.pressed && event.button == AestraUI::NUIMouseButton::Left && isInsideBounds) {
                 if (m_onTrackSelectedCallback) {
-                    const bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                                       (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                    m_onTrackSelectedCallback(this, shift);
+                    m_onTrackSelectedCallback(this, selectionIntentFor(event));
                 }
+                if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
             }
             
             if (isInsideBounds) return true;
@@ -2406,9 +2473,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                     }
                     
                     if (m_onTrackSelectedCallback) {
-                        bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                                     (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                        m_onTrackSelectedCallback(this, shift);
+                        m_onTrackSelectedCallback(this, selectionIntentFor(event));
                     } else {
                         m_selected = true;
                     }
@@ -2441,9 +2506,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                     }
                     
                     if (m_onTrackSelectedCallback) {
-                        bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                                     (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                        m_onTrackSelectedCallback(this, shift);
+                        m_onTrackSelectedCallback(this, selectionIntentFor(event));
                     } else {
                         m_selected = true;
                     }
@@ -2455,9 +2518,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_clipDragStartPos = event.position;
                 m_activeClipId = clickedClipId;
                 if (m_onTrackSelectedCallback) {
-                    bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                                 (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                    m_onTrackSelectedCallback(this, shift);
+                    m_onTrackSelectedCallback(this, selectionIntentFor(event));
                 } else {
                     m_selected = true;
                 }
@@ -2474,24 +2535,22 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             
             // Grid area click (not on any clip) - select track
             if (m_onTrackSelectedCallback) {
-                bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                             (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                m_onTrackSelectedCallback(this, shift);
+                m_onTrackSelectedCallback(this, selectionIntentFor(event));
             } else {
                 m_selected = true;
             }
+            if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
             return true;
         }
         
         // Click in control area (but not on a button) - just select the track
         if (event.position.x < controlAreaEndX) {
             if (m_onTrackSelectedCallback) {
-                bool shift = (event.modifiers & AestraUI::NUIModifiers::Shift) ||
-                             (event.modifiers & AestraUI::NUIModifiers::CapsLock);
-                m_onTrackSelectedCallback(this, shift);
+                m_onTrackSelectedCallback(this, selectionIntentFor(event));
             } else {
                 m_selected = true;
             }
+            if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
             return true;
         }
     }
@@ -2510,7 +2569,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             m_activeClipId = clickedClipId;
 
             if (m_onTrackSelectedCallback) {
-                m_onTrackSelectedCallback(this, false);
+                m_onTrackSelectedCallback(this, TrackSelectionIntent::Replace);
             } else {
                 m_selected = true;
             }
@@ -2522,6 +2581,18 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             showClipRoutingMenu(clickedClipId, event.position);
             return true;
         }
+
+        // Empty timeline space still belongs to its track. Right-click opens
+        // the same track menu as the header; marquee selection is an explicit
+        // tool gesture, not a hidden alternate meaning for the context button.
+        if (m_onTrackSelectedCallback) {
+            m_onTrackSelectedCallback(this, TrackSelectionIntent::Replace);
+        }
+        if (m_onClipSelectedCallback) m_onClipSelectedCallback(this, ClipInstanceID{});
+        if (auto parentMgr = dynamic_cast<TrackManagerUI*>(getParent())) {
+            parentMgr->openTrackContextMenu(event.position, m_onSendToAuditionCallback);
+        }
+        return true;
     }
 
     // Pass through to parent if not handled

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -99,14 +99,9 @@ std::string truncateClipLabel(const std::string& text, float availableWidth, flo
 }
 
 TrackSelectionIntent selectionIntentFor(const AestraUI::NUIMouseEvent& event) {
-    if ((event.modifiers & AestraUI::NUIModifiers::Ctrl) ||
-        (event.modifiers & AestraUI::NUIModifiers::Super)) {
-        return TrackSelectionIntent::Toggle;
-    }
-    if (event.modifiers & AestraUI::NUIModifiers::Shift) {
-        return TrackSelectionIntent::Add;
-    }
-    return TrackSelectionIntent::Replace;
+    const bool toggleModifier =
+        (event.modifiers & AestraUI::NUIModifiers::Ctrl) || (event.modifiers & AestraUI::NUIModifiers::Super);
+    return trackSelectionIntentForModifierState(toggleModifier, event.modifiers & AestraUI::NUIModifiers::Shift);
 }
 
 AestraUI::NUIColor restrainDawColor(const AestraUI::NUIColor& color, float brightnessScale, float saturationScale,

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -4,6 +4,7 @@
 #include "MixerChannel.h"
 #include "ClipInstance.h"
 #include "PlaylistModel.h"
+#include "TimelineInteractionPolicy.h"
 #include "WaveformCache.h"
 
 #include "NUIComponent.h"
@@ -86,7 +87,9 @@ public:
     void setOnPatternClipDragStarted(std::function<void(PatternID)> callback) { m_onPatternClipDragStarted = std::move(callback); }
 
     // Callback for track selection
-    void setOnTrackSelected(std::function<void(TrackUIComponent*, bool)> callback) { m_onTrackSelectedCallback = callback; }
+    void setOnTrackSelected(std::function<void(TrackUIComponent*, TrackSelectionIntent)> callback) {
+        m_onTrackSelectedCallback = std::move(callback);
+    }
 
     // Audition integration
     void setOnSendToAudition(std::function<void()> callback) { m_onSendToAuditionCallback = callback; }
@@ -98,6 +101,13 @@ public:
     // Selection state
     void setSelected(bool selected) { m_selected = selected; }
     bool isSelected() const { return m_selected; }
+    void setSelectedClipId(ClipInstanceID clipId) {
+        if (m_selectedClipId != clipId) {
+            m_selectedClipId = clipId;
+            setDirty(true);
+        }
+    }
+    ClipInstanceID getSelectedClipId() const { return m_selectedClipId; }
     /** @brief Supply the parent-computed Playlist solo aggregate for this render pass. */
     void setAnyPlaylistLaneSoloed(bool anySoloed) { m_anyPlaylistLaneSoloed = anySoloed; }
     
@@ -161,6 +171,7 @@ protected:
 private:
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     bool m_selected = false; // Track selection state
+    ClipInstanceID m_selectedClipId; // Persistent clip selection supplied by TrackManagerUI
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
     bool m_anyPlaylistLaneSoloed = false;
     bool m_isLoading = false;
@@ -178,7 +189,7 @@ private:
     std::function<void(PatternID)> m_onPatternClipOpenRequested;
     std::function<void(ClipInstanceID)> m_onAudioClipOpenRequested;
     std::function<void(PatternID)> m_onPatternClipDragStarted;
-    std::function<void(TrackUIComponent*, bool)> m_onTrackSelectedCallback;
+    std::function<void(TrackUIComponent*, TrackSelectionIntent)> m_onTrackSelectedCallback;
     std::function<void()> m_onSendToAuditionCallback;
 
     

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -30,8 +30,9 @@
 #include "AudioClipEditorPanel.h"
 
 // AestraUI includes
-#include "../AestraUI/Core/NUIThemeSystem.h"
+#include "../AestraUI/Base/NUIContextMenu.h"
 #include "../AestraUI/Base/NUITextInput.h"
+#include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "../AestraUI/Widgets/NotificationToast.h"
@@ -4134,6 +4135,15 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
 
     if (!event.pressed)
         return false;
+
+    // Popup menus own navigation and activation while open. The application
+    // normally evaluates global shortcuts before focused widgets, so route the
+    // focused menu explicitly before Space or letter keys can trigger transport
+    // and musical typing underneath it.
+    if (auto* menu = dynamic_cast<AestraUI::NUIContextMenu*>(AestraUI::NUIComponent::getFocusedComponent());
+        menu && menu->isVisible() && menu->onKeyEvent(event)) {
+        return true;
+    }
 
     // Takes panel inline rename captures typing while active — it must win
     // over global shortcuts so Ctrl+Z etc. don't fire mid-edit.

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -37,7 +37,12 @@ namespace {
         if (key == static_cast<int>(KC::Tab)) return NUIKC::Tab;
         if (key == static_cast<int>(KC::Backspace)) return NUIKC::Backspace;
         if (key == static_cast<int>(KC::Delete)) return NUIKC::Delete;
+        if (key == static_cast<int>(KC::Insert)) return NUIKC::Insert;
         if (key == static_cast<int>(KC::CapsLock)) return NUIKC::CapsLock;
+        if (key == static_cast<int>(KC::Home)) return NUIKC::Home;
+        if (key == static_cast<int>(KC::End)) return NUIKC::End;
+        if (key == static_cast<int>(KC::PageUp)) return NUIKC::PageUp;
+        if (key == static_cast<int>(KC::PageDown)) return NUIKC::PageDown;
 
         // Arrow keys
         if (key == static_cast<int>(KC::Left)) return NUIKC::Left;
@@ -206,6 +211,14 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
     m_window->setRenderer(m_renderer.get());
     m_customWindow->setWindowHandle(m_window.get());
 
+    // Recovery and confirmation dialogs are routed explicitly below. Stop the
+    // bridge from subsequently forwarding the same pointer/text event into the
+    // root tree; the release that closes a modal must remain consumed too.
+    m_window->setRootInputBlockedCallback([this]() {
+        return (m_recoveryDialog && m_recoveryDialog->isDialogVisible()) ||
+               (m_confirmationDialog && m_confirmationDialog->isDialogVisible());
+    });
+
     // Input Callbacks
     // CALLBACK ORDER CONTRACT: This AWM callback fires SECOND on every mouse move.
     // NUIPlatformBridge's internal handler fires FIRST (cache update, flag checks,
@@ -277,6 +290,7 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.button = (button == 0) ? AestraUI::NUIMouseButton::Left :
                           (button == 1) ? AestraUI::NUIMouseButton::Right : AestraUI::NUIMouseButton::Middle;
             event.pressed = pressed;
+            event.released = !pressed;
             m_recoveryDialog->onMouseEvent(event);
             return; // Block all other mouse handling while recovery dialog is shown
         }

--- a/Source/Settings/RecoveryDialog.cpp
+++ b/Source/Settings/RecoveryDialog.cpp
@@ -183,6 +183,10 @@ void RecoveryDialog::onRender(AestraUI::NUIRenderer& renderer) {
 
 bool RecoveryDialog::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     if (!m_isVisible) return false;
+
+    // Input may arrive before the first rendered frame or immediately after a
+    // resize. Hit-test against current bounds rather than stale/default rects.
+    calculateLayout();
     
     float mx = event.position.x;
     float my = event.position.y;

--- a/Tests/AestraUI/ModalDialogInteractionTest.cpp
+++ b/Tests/AestraUI/ModalDialogInteractionTest.cpp
@@ -1,0 +1,93 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+#include "ConfirmationDialog.h"
+#include "NUIThemeSystem.h"
+#include "RecoveryDialog.h"
+
+#include <iostream>
+
+using namespace Aestra;
+using namespace AestraUI;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << '\n';
+        ++failures;
+    }
+}
+
+NUIMouseEvent leftButton(float x, float y, bool pressed) {
+    NUIMouseEvent event;
+    event.type = pressed ? NUIMouseEventType::Down : NUIMouseEventType::Up;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.pressed = pressed;
+    event.released = !pressed;
+    return event;
+}
+
+void testRecoveryRequiresMatchingPressAndRelease() {
+    RecoveryDialog dialog;
+    dialog.setBounds({0.0f, 0.0f, 800.0f, 600.0f});
+    RecoveryResponse response = RecoveryResponse::None;
+    int callbacks = 0;
+    dialog.show("", [&](RecoveryResponse value) {
+        response = value;
+        ++callbacks;
+    });
+
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    const float dialogX = (800.0f - 450.0f) * 0.5f;
+    const float dialogY = (600.0f - 180.0f) * 0.5f;
+    const float startX = dialogX + (450.0f - (240.0f + theme.spacingM)) * 0.5f;
+    const float discardX = startX + 120.0f + theme.spacingM + 20.0f;
+    const float buttonY = dialogY + 180.0f - theme.layout.dialogActionHeight - theme.spacingM + 10.0f;
+
+    check(dialog.onMouseEvent(leftButton(discardX, buttonY, true)), "recovery consumes the button press");
+    check(dialog.isDialogVisible() && callbacks == 0, "recovery waits for the matching release");
+    check(dialog.onMouseEvent(leftButton(discardX, buttonY, false)), "recovery consumes the button release");
+    check(!dialog.isDialogVisible() && response == RecoveryResponse::Discard && callbacks == 1,
+          "one recovery click activates Discard exactly once");
+}
+
+void testConfirmationReleaseCannotEscapeModal() {
+    ConfirmationDialog dialog;
+    dialog.setBounds({0.0f, 0.0f, 800.0f, 600.0f});
+    DialogResponse response = DialogResponse::None;
+    int callbacks = 0;
+    dialog.show("Unsaved Changes", "Save before closing?", [&](DialogResponse value) {
+        response = value;
+        ++callbacks;
+    });
+
+    const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
+    const float dialogX = (800.0f - 400.0f) * 0.5f;
+    const float dialogY = (600.0f - 172.0f) * 0.5f;
+    const float totalWidth = 84.0f + 104.0f + 96.0f + theme.spacingS * 2.0f;
+    const float startX = dialogX + 400.0f - theme.spacingL - totalWidth;
+    const float dontSaveX = startX + 84.0f + theme.spacingS + 20.0f;
+    const float buttonY = dialogY + 172.0f - theme.spacingL - theme.layout.dialogActionHeight + 10.0f;
+
+    dialog.onMouseEvent(leftButton(dontSaveX, buttonY, true));
+    dialog.onMouseEvent(leftButton(dontSaveX, buttonY, false));
+    check(!dialog.isDialogVisible() && response == DialogResponse::DontSave && callbacks == 1,
+          "confirmation consumes the full click and activates Don't Save once");
+}
+
+} // namespace
+
+int main() {
+    testRecoveryRequiresMatchingPressAndRelease();
+    testConfirmationReleaseCannotEscapeModal();
+
+    if (failures == 0) {
+        std::cout << "Modal dialog interaction tests passed\n";
+        return 0;
+    }
+    std::cout << failures << " modal dialog interaction test(s) failed\n";
+    return 1;
+}

--- a/Tests/AestraUI/NUIContextMenuInteractionTest.cpp
+++ b/Tests/AestraUI/NUIContextMenuInteractionTest.cpp
@@ -1,0 +1,134 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+#include "NUIContextMenu.h"
+
+#include <iostream>
+#include <memory>
+
+using namespace AestraUI;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << '\n';
+        ++failures;
+    }
+}
+
+NUIKeyEvent press(NUIKeyCode key, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIKeyEvent event;
+    event.keyCode = key;
+    event.modifiers = modifiers;
+    event.pressed = true;
+    return event;
+}
+
+void testKeyboardNavigationAndFocusRestoration() {
+    auto previous = std::make_shared<NUIComponent>();
+    previous->setFocused(true);
+
+    auto menu = std::make_shared<NUIContextMenu>();
+    auto disabled = std::make_shared<NUIContextMenuItem>("Unavailable");
+    disabled->setEnabled(false);
+    menu->addItem(disabled);
+    menu->addSeparator();
+    int activations = 0;
+    menu->addItem("Copy", [&]() { ++activations; });
+    menu->addSeparator();
+    menu->addItem("Delete", [&]() { activations += 10; });
+
+    menu->showAt(10, 10);
+    check(NUIComponent::getFocusedComponent() == menu.get(), "opening a menu transfers keyboard focus to it");
+    check(menu->getHoveredItemIndex() == 2, "initial focus skips disabled items and separators");
+
+    menu->onKeyEvent(press(NUIKeyCode::Down));
+    check(menu->getHoveredItemIndex() == 4, "Down skips separators");
+    menu->onKeyEvent(press(NUIKeyCode::Up));
+    check(menu->getHoveredItemIndex() == 2, "Up skips separators and disabled items");
+    menu->onKeyEvent(press(NUIKeyCode::Enter));
+
+    check(activations == 1, "Enter activates the highlighted action exactly once");
+    check(!menu->isVisible(), "choosing an action closes the menu");
+    check(NUIComponent::getFocusedComponent() == previous.get(), "closing a menu restores prior focus");
+}
+
+void testSubmenuKeyboardLifecycle() {
+    auto previous = std::make_shared<NUIComponent>();
+    previous->setFocused(true);
+    auto parent = std::make_shared<NUIContextMenu>();
+    auto child = std::make_shared<NUIContextMenu>();
+    child->addItem("Master", []() {});
+    parent->addSubmenu("Route Source", child);
+
+    parent->showAt(20, 20);
+    parent->onKeyEvent(press(NUIKeyCode::Right));
+    check(child->isVisible(), "Right opens the highlighted submenu");
+    check(NUIComponent::getFocusedComponent() == child.get(), "an open submenu owns keyboard focus");
+
+    child->onKeyEvent(press(NUIKeyCode::Escape));
+    check(!child->isVisible() && parent->isVisible(), "Escape closes only the active submenu first");
+    check(NUIComponent::getFocusedComponent() == parent.get(), "closing a submenu returns focus to its parent");
+
+    parent->onKeyEvent(press(NUIKeyCode::Escape));
+    check(!parent->isVisible(), "a second Escape closes the parent menu");
+    check(NUIComponent::getFocusedComponent() == previous.get(), "the complete menu stack restores original focus");
+}
+
+void testTallMenuScrollingAndViewportContainment() {
+    auto root = std::make_shared<NUIComponent>();
+    root->setBounds({0.0f, 0.0f, 480.0f, 220.0f});
+
+    auto parent = std::make_shared<NUIContextMenu>();
+    auto child = std::make_shared<NUIContextMenu>();
+    child->setMaxHeight(120.0f);
+    int activated = -1;
+    for (int index = 0; index < 20; ++index) {
+        child->addItem("Destination " + std::to_string(index), [&, index]() { activated = index; });
+    }
+    parent->addSubmenu("Route Linked Clips", child);
+    root->addChild(parent);
+
+    parent->showAt(430, 190);
+    parent->onKeyEvent(press(NUIKeyCode::Right));
+    check(child->isVisible(), "keyboard opens a tall submenu");
+    check(child->getBounds().right() <= root->getBounds().right() &&
+              child->getBounds().bottom() <= root->getBounds().bottom(),
+          "tall submenu stays inside its viewport");
+
+    NUIMouseEvent wheel;
+    wheel.type = NUIMouseEventType::Scroll;
+    wheel.position = {child->getBounds().x + 20.0f, child->getBounds().y + 14.0f};
+    wheel.wheelDelta = -1.0f;
+    check(child->onMouseEvent(wheel), "wheel input is consumed by a scrollable menu");
+
+    NUIMouseEvent pressEvent;
+    pressEvent.type = NUIMouseEventType::Down;
+    pressEvent.position = wheel.position;
+    pressEvent.button = NUIMouseButton::Left;
+    pressEvent.pressed = true;
+    child->onMouseEvent(pressEvent);
+    pressEvent.type = NUIMouseEventType::Up;
+    pressEvent.pressed = false;
+    pressEvent.released = true;
+    child->onMouseEvent(pressEvent);
+    check(activated == 1, "scrolling exposes and activates the next routing destination");
+}
+
+} // namespace
+
+int main() {
+    testKeyboardNavigationAndFocusRestoration();
+    testSubmenuKeyboardLifecycle();
+    testTallMenuScrollingAndViewportContainment();
+    NUIComponent::clearFocusedComponent();
+
+    if (failures == 0) {
+        std::cout << "Context menu interaction tests passed\n";
+        return 0;
+    }
+    std::cout << failures << " context menu interaction test(s) failed\n";
+    return 1;
+}

--- a/Tests/AestraUI/TimelineInteractionPolicyTest.cpp
+++ b/Tests/AestraUI/TimelineInteractionPolicyTest.cpp
@@ -45,6 +45,16 @@ void testStableSelectionLifecycle() {
     check(selection.empty(), "clear removes every selected lane");
 }
 
+void testModifierSelectionIntent() {
+    check(trackSelectionIntentForModifierState(false, false) == TrackSelectionIntent::Replace,
+          "plain clicks replace selection");
+    check(trackSelectionIntentForModifierState(false, true) == TrackSelectionIntent::Add, "Shift adds to selection");
+    check(trackSelectionIntentForModifierState(true, false) == TrackSelectionIntent::Toggle,
+          "the platform toggle modifier toggles selection");
+    check(trackSelectionIntentForModifierState(true, true) == TrackSelectionIntent::Toggle,
+          "the toggle modifier takes precedence over Shift");
+}
+
 void testProjectLoopPolicy() {
     check(timelineLoopPresetFromId(6) == TimelineLoopPreset::Project,
           "project preset id resolves to the single typed authority");
@@ -61,6 +71,7 @@ void testProjectLoopPolicy() {
 
 int main() {
     testStableSelectionLifecycle();
+    testModifierSelectionIntent();
     testProjectLoopPolicy();
 
     if (failures == 0) {

--- a/Tests/AestraUI/TimelineInteractionPolicyTest.cpp
+++ b/Tests/AestraUI/TimelineInteractionPolicyTest.cpp
@@ -1,0 +1,72 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+#include "TimelineInteractionPolicy.h"
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << '\n';
+        ++failures;
+    }
+}
+
+void testStableSelectionLifecycle() {
+    const PlaylistLaneID first = PlaylistLaneID::generate();
+    const PlaylistLaneID second = PlaylistLaneID::generate();
+    const PlaylistLaneID removed = PlaylistLaneID::generate();
+    TimelineTrackSelection selection;
+
+    selection.apply(first, TrackSelectionIntent::Replace);
+    selection.apply(second, TrackSelectionIntent::Add);
+    check(selection.size() == 2, "additive selection keeps both stable lane identities");
+
+    selection.apply(first, TrackSelectionIntent::Toggle);
+    check(!selection.contains(first) && selection.contains(second), "toggle removes an already selected lane");
+    selection.apply(first, TrackSelectionIntent::Toggle);
+    check(selection.contains(first), "toggle adds an unselected lane");
+
+    selection.apply(removed, TrackSelectionIntent::Add);
+    selection.retainOnly({first, second});
+    check(selection.size() == 2 && !selection.contains(removed),
+          "widget rebuild pruning removes deleted lanes without touching surviving selection");
+
+    selection.selectAll({first, second, PlaylistLaneID{}});
+    check(selection.size() == 2, "select all ignores invalid lane identities");
+    selection.clear();
+    check(selection.empty(), "clear removes every selected lane");
+}
+
+void testProjectLoopPolicy() {
+    check(timelineLoopPresetFromId(6) == TimelineLoopPreset::Project,
+          "project preset id resolves to the single typed authority");
+    check(timelineLoopPresetFromId(99) == TimelineLoopPreset::Off, "invalid preset ids fail closed to Off");
+    check(std::abs(resolveProjectLoopEndBeat(23.5, 4) - 23.5) < 1e-9,
+          "non-empty projects loop to their arrangement end");
+    check(std::abs(resolveProjectLoopEndBeat(0.0, 4) - 64.0) < 1e-9,
+          "empty 4/4 projects use the documented 16-bar range");
+    check(std::abs(resolveProjectLoopEndBeat(0.0, 0) - 16.0) < 1e-9,
+          "invalid time signatures still produce a bounded loop range");
+}
+
+} // namespace
+
+int main() {
+    testStableSelectionLifecycle();
+    testProjectLoopPolicy();
+
+    if (failures == 0) {
+        std::cout << "Timeline interaction policy tests passed\n";
+        return 0;
+    }
+    std::cout << failures << " timeline interaction policy test(s) failed\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1535,6 +1535,15 @@ target_include_directories(SafeClampFloatTest PRIVATE
 add_test(NAME SafeClampFloatTest COMMAND SafeClampFloatTest)
 set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression")
 
+add_executable(TimelineInteractionPolicyTest AestraUI/TimelineInteractionPolicyTest.cpp)
+target_include_directories(TimelineInteractionPolicyTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Components
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+)
+add_test(NAME TimelineInteractionPolicyTest COMMAND TimelineInteractionPolicyTest)
+set_tests_properties(TimelineInteractionPolicyTest PROPERTIES LABELS "ui;timeline;selection;regression")
+
 # Settings persistence policy (#648). Same shape as SafeClampFloatTest above:
 # header-only and widget-free so the decision that was destroying saved device
 # ids is reachable without linking AestraUI, which AESTRA_CI=ON disables.
@@ -1552,6 +1561,36 @@ if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThem
     set_tests_properties(NUIThemeConsistencyTest PROPERTIES LABELS "ui;theme;consistency")
 else()
     message(STATUS "NUIThemeConsistencyTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
+if(TARGET AestraUI_Core)
+    add_executable(NUIContextMenuInteractionTest AestraUI/NUIContextMenuInteractionTest.cpp)
+    target_link_libraries(NUIContextMenuInteractionTest PRIVATE AestraUI_Core)
+    target_include_directories(NUIContextMenuInteractionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+    )
+    add_test(NAME NUIContextMenuInteractionTest COMMAND NUIContextMenuInteractionTest)
+    set_tests_properties(NUIContextMenuInteractionTest PROPERTIES LABELS "ui;menu;input;regression")
+
+    add_executable(ModalDialogInteractionTest
+        AestraUI/ModalDialogInteractionTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Settings/ConfirmationDialog.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Settings/RecoveryDialog.cpp
+    )
+    target_link_libraries(ModalDialogInteractionTest PRIVATE AestraUI_Core AestraCore)
+    target_include_directories(ModalDialogInteractionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/Source/Settings
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME ModalDialogInteractionTest COMMAND ModalDialogInteractionTest)
+    set_tests_properties(ModalDialogInteractionTest PROPERTIES LABELS "ui;modal;input;regression")
+else()
+    message(STATUS "NUIContextMenuInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
 # KeyboardNoteInput Test — musical-typing translation logic (header-only, no

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1590,7 +1590,7 @@ if(TARGET AestraUI_Core)
     add_test(NAME ModalDialogInteractionTest COMMAND ModalDialogInteractionTest)
     set_tests_properties(ModalDialogInteractionTest PROPERTIES LABELS "ui;modal;input;regression")
 else()
-    message(STATUS "NUIContextMenuInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
+    message(STATUS "NUIContextMenuInteractionTest and ModalDialogInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
 # KeyboardNoteInput Test — musical-typing translation logic (header-only, no


### PR DESCRIPTION
## Summary

- make track and clip selection stable across UI refreshes with conventional replace, add, toggle, select-all, and escape semantics
- match the timeline marquee to the Piano Roll selection language and standardize track and clip context menus
- keep long routing submenus inside the viewport with wheel and keyboard scrolling
- default looping to Project and keep ruler, minimap, and engine loop authority synchronized
- prevent recovery and confirmation dialogs from passing their closing click through to the workspace
- add focused regressions for selection policy, popup focus/scroll behavior, and modal interaction

## Why

Timeline interactions could retain stale widget pointers, clip selection could disagree with its visual state, popup input could leak into global shortcuts, long routing menus could overflow, loop labels and state could diverge, and recovery-dialog releases could reach the UI underneath. This pass establishes deterministic input ownership and stable model identity across those paths.

## Testing

- `cmake --build build-linux -j2` — full affected build passed
- focused timeline/menu/modal suite — 8/8 passed
- UI-labelled suite — 25/25 passed
- `ctest --test-dir build-linux --output-on-failure -j2` — 233 passed, 1 environment-gated skip (`SecAccountEndToEndSmoke`), 0 failed
- live Linux QA: left/right Multi-Select marquee, Select-tool context menus, modifier selection, clip menu actions, selection survival across refresh, long route submenu scrolling through Insert 50, Project loop default, and modal click-through protection
- Muse smoke: schema/session/list/add-clip/audio-health paths succeeded with zero reported xruns, underruns, real-time violations, or command drops

An allocator anomaly appeared once during concurrent agent activity and did not reproduce in isolated repeated clean shutdowns or the full suite. It is disclosed here as an observation; this PR does not claim to fix it.

## Producer note

Timeline selection, context menus, looping, and recovery dialogs no longer lose or misroute your input.

## Docs updated?

No — this is behavior hardening with regression coverage; adversarial follow-ups are tracked separately.

## Risk / rollback

- UI and input behavior changed; DSP, audio latency, serialization, and project format did not change.
- Live validation was performed on Linux; cross-platform visual and DPI parity remains a follow-up.
- Roll back by reverting commit `b2f3e62e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Stabilized track and clip selection across refreshes with replace, add, toggle, select-all, and Escape behavior.
- Aligned marquee selection with Piano Roll behavior and standardized track and clip context menus.
- Added viewport-aware scrolling for long context-menu submenus.
- Defaulted looping to the full project and synchronized ruler, minimap, and engine loop state.
- Blocked workspace input while recovery and confirmation dialogs are active.
- Added key mappings for Insert, Home, End, Page Up, and Page Down.
- Added regression tests for timeline selection, context-menu navigation and scrolling, focus restoration, and modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->