### PR TITLE
fix(ui): complete timeline geometry authority

### DIFF
--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -21,6 +21,7 @@
 #include "TimelineMinimapModel.h"
 #include "TimelineSummaryCache.h"
 #include "TimelineInteractionPolicy.h"
+#include "TrackManagerUIMath.h"
 #include "WaveformCache.h"
 
 #include <functional>
@@ -571,19 +572,12 @@ private:
 
     /** @brief Convert a pixel distance from the grid's left edge into beats. */
     double gridOffsetToBeat(float offsetFromGridStart) const {
-        // A zero or non-finite zoom would otherwise divide by zero. Callers get
-        // beat 0 rather than an infinity that propagates into clip positions.
-        const float pixelsPerBeat = m_pixelsPerBeat;
-        if (!(pixelsPerBeat > 0.0f)) {
-            return 0.0;
-        }
-        return (static_cast<double>(offsetFromGridStart) + static_cast<double>(m_timelineScrollOffset)) /
-               static_cast<double>(pixelsPerBeat);
+        return timelineGridOffsetToBeat(offsetFromGridStart, m_timelineScrollOffset, m_pixelsPerBeat);
     }
 
     /** @brief Convert beats into a pixel distance from the grid's left edge. */
     float beatToGridOffset(double beat) const {
-        return static_cast<float>(beat * static_cast<double>(m_pixelsPerBeat)) - m_timelineScrollOffset;
+        return timelineBeatToGridOffset(beat, m_timelineScrollOffset, m_pixelsPerBeat);
     }
 
     // Helper to convert mouse position to track/time

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -59,7 +59,7 @@ void TrackManagerUI::startInstantClipDrag(TrackUIComponent* trackComp, ClipInsta
     // Calculate offset (Cursor Beat - Clip Start Beat)
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    float gridStartX = getGlobalBounds().x + controlAreaWidth + kTimelineGridInsetX;
+    const float gridStartX = timelineGridStartX(getBounds().x, controlAreaWidth);
 
     double cursorBeat = gridOffsetToBeat(clickPos.x - gridStartX);
     m_clipDragOffsetBeats = cursorBeat - clip->startBeat;
@@ -77,8 +77,8 @@ void TrackManagerUI::updateInstantClipDrag(const AestraUI::NUIPoint& currentPos)
 
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    const AestraUI::NUIRect bounds = getGlobalBounds();
-    const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
+    const AestraUI::NUIRect bounds = getBounds();
+    const float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
     AestraUI::NUIPoint latchedPos = currentPos;
     clampInstantClipDragPosition(latchedPos);
 
@@ -128,14 +128,10 @@ bool TrackManagerUI::clampInstantClipDragPosition(AestraUI::NUIPoint& position) 
 
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
-    const AestraUI::NUIRect bounds = getGlobalBounds();
-    const float headerHeight = kTimelineHeaderHeight;
-    const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    const float rulerHeight = kTimelineRulerHeight;
-    const float scrollbarWidth = kTimelineScrollbarWidth;
-    const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
-    const float gridEndX = bounds.x + bounds.width - scrollbarWidth;
-    const float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    const AestraUI::NUIRect bounds = getBounds();
+    const float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
+    const float gridEndX = timelineGridEndX(bounds.x, bounds.width);
+    const float trackAreaTop = timelineTrackAreaTopY(bounds.y);
     const float trackAreaBottom = bounds.y + bounds.height;
 
     const float clampedX = safeClampFloat(position.x, gridStartX, gridEndX);
@@ -163,9 +159,9 @@ bool TrackManagerUI::placeFileOnTimeline(const std::string& filePath, const std:
 
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     const auto bounds = getBounds();
-    const float trackAreaStartY = bounds.y + 38.0f + 24.0f + 28.0f;
+    const float trackAreaStartY = timelineTrackAreaTopY(bounds.y);
     const float y = trackAreaStartY + (targetLane * (m_trackHeight + m_trackSpacing)) - m_scrollOffset + 2.0f;
-    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + kTimelineGridInsetX;
+    const float gridStartX = timelineGridStartX(0.0f, theme.getLayoutDimensions().trackControlsWidth);
     const double playheadBeats =
         snapBeatToGrid(m_trackManager->getPlaylistModel().secondsToBeats(std::max(0.0, m_trackManager->getPosition())));
     const float x =
@@ -196,9 +192,9 @@ bool TrackManagerUI::placePatternOnTimeline(PatternID patternId) {
 
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     const auto bounds = getBounds();
-    const float trackAreaStartY = bounds.y + 38.0f + 24.0f + 28.0f;
+    const float trackAreaStartY = timelineTrackAreaTopY(bounds.y);
     const float y = trackAreaStartY + (targetLane * (m_trackHeight + m_trackSpacing)) - m_scrollOffset + 2.0f;
-    const float gridStartX = theme.getLayoutDimensions().trackControlsWidth + kTimelineGridInsetX;
+    const float gridStartX = timelineGridStartX(0.0f, theme.getLayoutDimensions().trackControlsWidth);
     const double playheadBeats =
         snapBeatToGrid(m_trackManager->getPlaylistModel().secondsToBeats(std::max(0.0, m_trackManager->getPosition())));
     const float x =

--- a/Source/Components/TrackManagerUIMath.h
+++ b/Source/Components/TrackManagerUIMath.h
@@ -33,6 +33,44 @@ constexpr float kTimelineScrollbarWidth = 15.0f;
 constexpr float kTimelineGridInsetX = 5.0f;
 
 /**
+ * @brief Resolve the first grid pixel in the caller's stated coordinate basis.
+ *
+ * Timeline code uses component-relative, window-absolute, and ruler-relative
+ * coordinates. Requiring the basis origin as an argument keeps that choice
+ * visible while centralising the layout formula shared by rendering and input.
+ */
+inline float timelineGridStartX(float basisOriginX, float controlAreaWidth) {
+    return basisOriginX + controlAreaWidth + kTimelineGridInsetX;
+}
+
+/** @brief Resolve the last interactive grid pixel in the same stated basis. */
+inline float timelineGridEndX(float basisOriginX, float boundsWidth) {
+    return basisOriginX + boundsWidth - kTimelineScrollbarWidth;
+}
+
+/** @brief Resolve the first track-row pixel in the caller's stated y basis. */
+inline float timelineTrackAreaTopY(float basisOriginY) {
+    return basisOriginY + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight + kTimelineRulerHeight;
+}
+
+/** @brief Convert a distance from the grid origin to an unclamped beat. */
+inline double timelineGridOffsetToBeat(float offsetFromGridStart, float scrollOffset, float pixelsPerBeat) {
+    if (!(pixelsPerBeat > 0.0f) || !std::isfinite(pixelsPerBeat)) {
+        return 0.0;
+    }
+    return (static_cast<double>(offsetFromGridStart) + static_cast<double>(scrollOffset)) /
+           static_cast<double>(pixelsPerBeat);
+}
+
+/** @brief Convert a beat to a distance from the grid origin. */
+inline float timelineBeatToGridOffset(double beat, float scrollOffset, float pixelsPerBeat) {
+    if (!(pixelsPerBeat > 0.0f) || !std::isfinite(pixelsPerBeat)) {
+        return 0.0f;
+    }
+    return static_cast<float>(beat * static_cast<double>(pixelsPerBeat)) - scrollOffset;
+}
+
+/**
  * @brief Clamp @p value into the interval described by @p a and @p b.
  *
  * The contract, in the order the function decides it:

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "TrackUIComponent.h"
 #include "TrackManagerUI.h"
+#include "TrackManagerUIMath.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "MixerChannel.h"
 #include "TrackManager.h"
@@ -995,11 +996,11 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
     
     // Calculate waveform dimensions in pixel space
     double relStartX = (startBeat * m_pixelsPerBeat) - static_cast<double>(m_timelineScrollOffset);
-    float waveformStartX = bounds.x + controlAreaWidth + 5 + static_cast<float>(relStartX);
+    float waveformStartX = timelineGridStartX(bounds.x, controlAreaWidth) + static_cast<float>(relStartX);
     float waveformWidthInPixels = static_cast<float>(durationBeats * m_pixelsPerBeat);
     
     // Only draw if waveform is visible in the current viewport
-    float gridStartX = bounds.x + controlAreaWidth + 5;
+    float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
     float gridWidth = bounds.width - controlAreaWidth - 10;
     float gridEndX = gridStartX + gridWidth;
     
@@ -1875,7 +1876,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     const auto& layout = themeManager.getLayoutDimensions();
     float controlAreaWidth = layout.trackControlsWidth;
     float controlAreaEndX = bounds.x + controlAreaWidth;
-    float gridStartX = bounds.x + controlAreaWidth + 5;
+    float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
     float gridEndX = bounds.x + bounds.width - 5;
     
     // === HOVER EDGE DETECTION (for resize cursor) ===
@@ -2088,7 +2089,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     
     if (m_playlistMode == PlaylistMode::Automation && (isInsideBounds || m_isDraggingPoint)) {
         if (event.position.x >= gridStartX || m_isDraggingPoint) {
-            double beat = (event.position.x - gridStartX + m_timelineScrollOffset) / m_pixelsPerBeat;
+            double beat =
+                timelineGridOffsetToBeat(event.position.x - gridStartX, m_timelineScrollOffset, m_pixelsPerBeat);
             double value = 1.0 - std::clamp((static_cast<double>(event.position.y) - bounds.y) / bounds.height, 0.0, 1.0);
             
             auto& playlist = m_trackManager->getPlaylistModel();
@@ -2390,9 +2392,9 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             if (isSplitToolActive && clickedClipId.isValid()) {
                 // Calculate beat position using same math as the visual cursor in TrackManagerUI
                 // This ensures the split occurs exactly where the preview line shows
-                float mouseRelX = event.position.x - gridStartX + m_timelineScrollOffset;
-                double mouseBeat = mouseRelX / static_cast<double>(m_pixelsPerBeat);
-                
+                double mouseBeat =
+                    timelineGridOffsetToBeat(event.position.x - gridStartX, m_timelineScrollOffset, m_pixelsPerBeat);
+
                 Log::info("Split requested at " + std::to_string(mouseBeat) + " beats");
                 
                 if (m_onSplitRequestedCallback) {
@@ -2405,9 +2407,10 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             // Handle PAINT TOOL - Click on empty space
             if (auto parentMgr = dynamic_cast<TrackManagerUI*>(getParent())) {
                 if (parentMgr->getCurrentTool() == PlaylistTool::Paint && !clickedClipId.isValid()) {
-                     double beat = (event.position.x - gridStartX + m_timelineScrollOffset) / m_pixelsPerBeat;
-                     parentMgr->onPaintClip(this, beat);
-                     return true;
+                    double beat = timelineGridOffsetToBeat(event.position.x - gridStartX, m_timelineScrollOffset,
+                                                           m_pixelsPerBeat);
+                    parentMgr->onPaintClip(this, beat);
+                    return true;
                 }
             }
             
@@ -2713,7 +2716,7 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     if (!gotSnapshot || recordingData.empty()) return;
 
     // Layout parameters
-    const float gridStartX = bounds.x + controlAreaWidth + 5.0f; // + gap
+    const float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
     const float centerY = bounds.y + bounds.height * 0.5f;
     const float halfHeight = bounds.height * 0.5f; // Use full height for live wave
     

--- a/Tests/AestraUI/TimelineGeometryTest.cpp
+++ b/Tests/AestraUI/TimelineGeometryTest.cpp
@@ -1,0 +1,65 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "TrackManagerUIMath.h"
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++g_failures;
+    }
+}
+
+void expectNear(double got, double wanted, double tolerance, const std::string& what) {
+    if (std::abs(got - wanted) > tolerance) {
+        std::cerr << "[FAIL] " << what << ": got " << got << ", wanted " << wanted << '\n';
+        ++g_failures;
+    }
+}
+
+using namespace Aestra::Audio;
+
+} // namespace
+
+int main() {
+    // Callers name the coordinate basis by supplying its origin. The formula is
+    // otherwise identical for component-, window-, and ruler-relative paths.
+    expectNear(timelineGridStartX(0.0f, 236.0f), 241.0, 0.0001, "component-relative grid origin");
+    expectNear(timelineGridStartX(80.0f, 236.0f), 321.0, 0.0001, "window-absolute grid origin");
+    expectNear(timelineGridStartX(17.5f, 236.0f), 258.5, 0.0001, "ruler-relative grid origin");
+
+    expectNear(timelineGridEndX(80.0f, 800.0f), 865.0, 0.0001, "grid end excludes scrollbar");
+    expectNear(timelineTrackAreaTopY(40.0f), 130.0, 0.0001, "track area follows shared vertical stack");
+
+    // Beat conversion is deliberately unclamped: zoom anchoring and dragging
+    // left of bar one must preserve negative intermediate values.
+    expectNear(timelineGridOffsetToBeat(-50.0f, 10.0f, 20.0f), -2.0, 0.0001,
+               "negative beat remains available to caller");
+    expectNear(timelineGridOffsetToBeat(150.0f, 50.0f, 25.0f), 8.0, 0.0001, "scroll participates exactly once");
+
+    for (double beat : {-8.0, 0.0, 1.25, 64.0}) {
+        const float offset = timelineBeatToGridOffset(beat, 37.0f, 18.0f);
+        expectNear(timelineGridOffsetToBeat(offset, 37.0f, 18.0f), beat, 0.0001, "beat/pixel conversion roundtrip");
+    }
+
+    const float infinity = std::numeric_limits<float>::infinity();
+    check(timelineGridOffsetToBeat(100.0f, 0.0f, 0.0f) == 0.0, "zero zoom has deterministic fallback");
+    check(timelineGridOffsetToBeat(100.0f, 0.0f, -4.0f) == 0.0, "negative zoom has deterministic fallback");
+    check(timelineGridOffsetToBeat(100.0f, 0.0f, infinity) == 0.0, "non-finite zoom has deterministic fallback");
+    check(timelineBeatToGridOffset(8.0, 0.0f, infinity) == 0.0f, "inverse conversion shares invalid-zoom fallback");
+
+    if (g_failures != 0) {
+        std::cerr << "[FAIL] TimelineGeometryTest: " << g_failures << " failure(s)\n";
+        return 1;
+    }
+    std::cout << "[PASS] TimelineGeometryTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1535,6 +1535,13 @@ target_include_directories(SafeClampFloatTest PRIVATE
 add_test(NAME SafeClampFloatTest COMMAND SafeClampFloatTest)
 set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression")
 
+add_executable(TimelineGeometryTest AestraUI/TimelineGeometryTest.cpp)
+target_include_directories(TimelineGeometryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Components
+)
+add_test(NAME TimelineGeometryTest COMMAND TimelineGeometryTest)
+set_tests_properties(TimelineGeometryTest PROPERTIES LABELS "ui;timeline;geometry;regression")
+
 add_executable(TimelineInteractionPolicyTest AestraUI/TimelineInteractionPolicyTest.cpp)
 target_include_directories(TimelineInteractionPolicyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source/Components


### PR DESCRIPTION
## Summary

- centralize timeline grid origins, grid limits, track-area bounds, and beat/pixel conversion in widget-free geometry primitives
- repair the three instant clip-drag paths that mixed `getGlobalBounds()` with window-absolute component bounds
- route TrackUI automation, split, paint, clip, and live-waveform calculations through the shared authority
- add deterministic geometry regression coverage for coordinate bases, scrolling, negative beats, roundtrips, and invalid zoom

## Why

Timeline geometry was expressed in several coordinate bases, but instant clip dragging applied the parent offset twice while TrackUI paths independently reconstructed the same beat conversion. That allowed rendering and interaction to disagree about the position under the cursor.

The shared helpers require callers to state their basis origin explicitly, preserving component-, window-, and ruler-relative use cases without letting each path reinvent the layout formula.

Closes #550.

## Testing performed

- `cmake --build build-linux -j2`
- `ctest --test-dir build-linux --output-on-failure -R 'TimelineGeometryTest|SafeClampFloatTest|TimelineInteractionPolicyTest' -j2` — 3/3 passed
- `ctest --test-dir build-linux --output-on-failure -j2` — 234 passed, 1 environment-gated skip, 0 failed
- `git diff --check`
- `clang-format --dry-run --Werror Source/Components/TrackManagerUIMath.h Tests/AestraUI/TimelineGeometryTest.cpp`
- live Linux/Muse QA: horizontal drag beat 4 → 8, vertical-only Track 3 → Track 4 with beat preserved, off-grid clamp to Track 1/beat 0, minimap/zoom coherence, and clean exit code 0

## Producer note

Dragging timeline clips no longer jumps because of mixed coordinate origins.

## Docs updated?

No public documentation change; this completes the existing #550 geometry invariant.

## Risk / rollback

The change is confined to timeline UI geometry and does not alter DSP, audio output, latency, serialization, or project format. Cross-platform visual/DPI parity remains tracked separately in #698. Rollback is the single commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Centralized timeline geometry in shared `TrackManagerUIMath.h` helpers for grid origins, bounds, track-area positioning, and beat/pixel conversion.
- Updated clip dragging, placement, automation, split, paint, hit testing, and live-waveform calculations to use the shared geometry.
- Preserved distinct coordinate bases and support for unclamped beat values, scrolling, negative beats, and invalid zoom values.
- Added deterministic timeline geometry regression tests and CTest integration.
- Builds, formatting checks, and Linux/Muse interaction QA pass. Tests report 234 passes with one environment-gated skip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->