### PR TITLE
Clip waveforms no longer wait for a project reload

### DIFF
--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -35,6 +35,7 @@ public:
 
         m_sources[id.value] = std::move(source);
         m_pathToId[filePath] = id;
+        ++m_revision;
 
         return id;
     }
@@ -76,6 +77,7 @@ public:
 
         m_sources[id.value] = std::move(source);
         m_pathToId[filePath] = id;
+        ++m_revision;
 
         return id;
     }
@@ -100,6 +102,10 @@ public:
         }
 
         source->setBuffer(std::move(buffer));
+        // Bumped unconditionally: an existing source deduped by path does not
+        // mint a new ID, but attaching a buffer still flips it to ready, which
+        // is the transition waveform-cache builders watch for.
+        ++m_revision;
         return id;
     }
 
@@ -172,6 +178,7 @@ public:
         if (pathIt != m_pathToId.end() && pathIt->second.value == id.value) {
             m_pathToId.erase(pathIt);
         }
+        ++m_revision;
         return true;
     }
 
@@ -188,6 +195,19 @@ public:
     void clear() {
         m_sources.clear();
         m_pathToId.clear();
+        ++m_revision;
+    }
+
+    /**
+     * @brief Monotonic counter bumped whenever the source set or a source's
+     *        readiness changes.
+     *
+     * Lets a UI change-gate an O(n) sweep over sources (such as building
+     * missing waveform caches) down to an O(1) comparison per frame, without
+     * every import path having to remember to notify anyone.
+     */
+    uint64_t getRevision() const {
+        return m_revision;
     }
 
 private:
@@ -208,6 +228,7 @@ private:
     }
 
     uint64_t nextId{1};
+    uint64_t m_revision{0};
     std::unordered_map<uint64_t, std::unique_ptr<ClipSource>> m_sources;
     std::unordered_map<std::string, ClipSourceID> m_pathToId;
 };

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -636,6 +636,13 @@ private:
     // each source itself.
     uint64_t m_lastSourcesRevision{0};
 
+    // Waveform builds already dispatched, as source ID -> the content revision
+    // being built. A queued build installs its cache asynchronously, so this is
+    // what stops an import burst re-queueing the same source on every sweep.
+    // Main-thread only: written by buildAllWaveformCaches() and released from
+    // the drained pending task, never from the builder thread.
+    std::unordered_map<uint64_t, uint64_t> m_waveformBuildsInFlight;
+
     // Async Task Queue (for main thread callbacks)
     std::mutex m_pendingTasksMutex;
     std::vector<std::function<void()>> m_pendingTasks;

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -631,6 +631,11 @@ private:
     // Async waveform builder
     ::Aestra::Audio::WaveformCacheBuilder m_waveformBuilder;
 
+    // Last SourceManager revision swept for missing waveform caches. Change-gate
+    // only; never a correctness authority, since buildAllWaveformCaches() checks
+    // each source itself.
+    uint64_t m_lastSourcesRevision{0};
+
     // Async Task Queue (for main thread callbacks)
     std::mutex m_pendingTasksMutex;
     std::vector<std::function<void()>> m_pendingTasks;

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -1367,32 +1367,57 @@ void TrackManagerUI::buildAllWaveformCaches() {
     int queued = 0;
     for (auto srcId : ids) {
         auto* src = srcMgr.getSource(srcId);
-        if (src && src->isReady() && !src->getWaveformCache()) {
-            const uint64_t sourceRevision = src->getContentRevision();
-            ++queued;
-            m_waveformBuilder.buildAsync(
-                *src, [weakSelf, srcId, sourceRevision](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
-                    if (!cache) return;
+        if (!src || !src->isReady() || src->getWaveformCache()) {
+            continue;
+        }
+
+        const uint64_t sourceRevision = src->getContentRevision();
+
+        // A queued build installs its cache later, on the main thread, so the
+        // getWaveformCache() check above cannot see work that is still running.
+        // Without this guard a burst of imports re-queues the same source on
+        // every sweep until its cache lands. Keyed on content revision so a
+        // source that changes underneath an in-flight build still gets rebuilt.
+        auto inFlight = m_waveformBuildsInFlight.find(srcId.value);
+        if (inFlight != m_waveformBuildsInFlight.end() && inFlight->second == sourceRevision) {
+            continue;
+        }
+        m_waveformBuildsInFlight[srcId.value] = sourceRevision;
+
+        ++queued;
+        m_waveformBuilder.buildAsync(
+            *src, [weakSelf, srcId, sourceRevision](std::shared_ptr<Aestra::Audio::WaveformCache> cache) {
+                auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
+                if (!self) return;
+
+                // Marshalled even when the build failed (null cache): the
+                // in-flight slot has to be released on every outcome, or that
+                // source can never be retried.
+                std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
+                self->m_pendingTasks.push_back([weakSelf, srcId, sourceRevision, cache]() {
                     auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
                     if (!self) return;
 
-                    std::lock_guard<std::mutex> lock(self->m_pendingTasksMutex);
-                    self->m_pendingTasks.push_back([weakSelf, srcId, sourceRevision, cache]() {
-                        auto self = std::dynamic_pointer_cast<TrackManagerUI>(weakSelf.lock());
-                        if (!self) return;
-                        if (!self->m_trackManager) return;
+                    // Release only our own slot: a newer revision may already
+                    // have claimed it while this build was running.
+                    auto slot = self->m_waveformBuildsInFlight.find(srcId.value);
+                    if (slot != self->m_waveformBuildsInFlight.end() && slot->second == sourceRevision) {
+                        self->m_waveformBuildsInFlight.erase(slot);
+                    }
 
-                        auto* src = self->m_trackManager->getSourceManager().getSource(srcId);
-                        if (!src) return;
-                        if (src->getContentRevision() != sourceRevision) return;
+                    if (!cache) return;
+                    if (!self->m_trackManager) return;
 
-                        src->setWaveformCache(cache);
-                        self->invalidateCache();
-                        self->m_backgroundNeedsUpdate = true;
-                        self->setDirty(true);
-                    });
+                    auto* src = self->m_trackManager->getSourceManager().getSource(srcId);
+                    if (!src) return;
+                    if (src->getContentRevision() != sourceRevision) return;
+
+                    src->setWaveformCache(cache);
+                    self->invalidateCache();
+                    self->m_backgroundNeedsUpdate = true;
+                    self->setDirty(true);
                 });
-        }
+            });
     }
     if (queued > 0) {
         Log::info("[TrackManagerUI] Queued " + std::to_string(queued) + " waveform cache builds (async)");

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -580,6 +580,18 @@ void TrackManagerUI::onUpdate(double deltaTime) {
         }
     }
 
+    // Any source that became ready without a waveform cache renders as a bare
+    // centre line (drawWaveformForClip's mip fallback), so the caches cannot be
+    // left to whichever import path happened to remember to build them. Gated
+    // on SourceManager's revision so the steady state is one integer compare.
+    if (m_trackManager) {
+        const uint64_t sourcesRevision = m_trackManager->getSourceManager().getRevision();
+        if (sourcesRevision != m_lastSourcesRevision) {
+            m_lastSourcesRevision = sourcesRevision;
+            buildAllWaveformCaches();
+        }
+    }
+
     // Plugin insert/remove requests go through the PlaybackGraphController.
     // TrackManagerUI does NOT consume graph dirty state here - the controller drains in AestraApp::run().
     // UI code should only request rebuilds via requestAudioGraphRebuild().

--- a/Tests/AestraAudio/SourceManagerRevisionTest.cpp
+++ b/Tests/AestraAudio/SourceManagerRevisionTest.cpp
@@ -108,6 +108,25 @@ void testFailedRemoveDoesNotBump() {
     require(mgr.getRevision() == before, "failedRemove: a failed removeSource must not bump the revision");
 }
 
+// A source restored from a serialized project (#446) comes in through
+// getOrCreateSourceWithId, which also mints a source and so must bump — a loaded
+// project's clips need waveforms on the same terms as freshly imported ones.
+void testRestoredIdBumpsThenDedupes() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-restored.wav";
+    const uint64_t before = mgr.getRevision();
+
+    const ClipSourceID restored = mgr.getOrCreateSourceWithId(ClipSourceID{4242}, path);
+    require(restored.isValid(), "restoredId: expected a valid source id");
+    require(restored.value == 4242, "restoredId: precondition — a free requested id must be restored verbatim");
+    require(mgr.getRevision() != before, "restoredId: restoring a source must bump the revision");
+
+    const uint64_t afterRestore = mgr.getRevision();
+    const ClipSourceID again = mgr.getOrCreateSourceWithId(ClipSourceID{7777}, path);
+    require(again.value == restored.value, "restoredId: precondition — path dedupe must win over the requested id");
+    require(mgr.getRevision() == afterRestore, "restoredId: a path-deduped restore must not bump the revision");
+}
+
 // The counter only has to change on mutation; a caller comparing snapshots must
 // never see it run backwards, or a sweep would be skipped.
 void testRevisionIsMonotonic() {
@@ -130,6 +149,7 @@ int main() {
     testReadinessFlipBumpsOnExistingSource();
     testRemoveAndClearBump();
     testFailedRemoveDoesNotBump();
+    testRestoredIdBumpsThenDedupes();
     testRevisionIsMonotonic();
 
     std::cout << "[PASS] SourceManagerRevisionTest\n";

--- a/Tests/AestraAudio/SourceManagerRevisionTest.cpp
+++ b/Tests/AestraAudio/SourceManagerRevisionTest.cpp
@@ -1,0 +1,137 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Guards the SourceManager revision counter that the timeline uses to notice
+// "some source is ready but has no waveform cache yet".
+//
+// Why this exists: clip waveforms are drawn from a WaveformCache, and above the
+// finest mip level a source without one renders as a bare centre line. Building
+// those caches used to be the responsibility of whichever import path happened
+// to remember, so a clip imported mid-session showed no waveform until the
+// project was saved and reloaded. TrackManagerUI now sweeps for missing caches,
+// change-gated on getRevision() so the steady state costs one integer compare.
+//
+// That makes the counter load-bearing: if a mutation stops bumping it, the sweep
+// silently stops running and the waveforms silently disappear again. Each case
+// below asserts the precondition first so it cannot pass vacuously.
+
+#include "Models/SourceManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+using namespace Aestra::Audio;
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::shared_ptr<AudioBufferData> makeBuffer(uint32_t frames = 128) {
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->numChannels = 2;
+    buffer->sampleRate = 48000;
+    buffer->interleavedData.assign(static_cast<size_t>(frames) * 2, 0.25f);
+    buffer->numFrames = frames;
+    return buffer;
+}
+
+// A newly created source bumps the revision.
+void testCreateBumps() {
+    SourceManager mgr;
+    const uint64_t before = mgr.getRevision();
+
+    const ClipSourceID id = mgr.getOrCreateSource("/tmp/aestra-test-a.wav");
+    require(id.isValid(), "createBumps: expected a valid source id");
+    require(mgr.getRevision() != before, "createBumps: creating a source must bump the revision");
+}
+
+// Re-requesting the same path dedupes to the existing source, so there is no new
+// readiness transition and nothing for the sweep to do.
+void testDedupeDoesNotBump() {
+    SourceManager mgr;
+    const ClipSourceID first = mgr.getOrCreateSource("/tmp/aestra-test-a.wav");
+    const uint64_t after = mgr.getRevision();
+
+    const ClipSourceID second = mgr.getOrCreateSource("/tmp/aestra-test-a.wav");
+    require(second.value == first.value, "dedupe: same path must return the same source id");
+    require(mgr.getRevision() == after, "dedupe: returning an existing source must not bump the revision");
+}
+
+// The case the bug turned on: the source already exists (so no id is minted),
+// but attaching a buffer flips it to ready. That IS a transition the sweep must
+// see, so the revision has to move even though the source set did not change.
+void testReadinessFlipBumpsOnExistingSource() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-b.wav";
+    const ClipSourceID created = mgr.getOrCreateSource(path);
+    const uint64_t beforeBuffer = mgr.getRevision();
+
+    ClipSource* source = mgr.getSource(created);
+    require(source != nullptr, "readinessFlip: source lookup failed");
+    require(!source->isReady(), "readinessFlip: precondition — source must not be ready before a buffer is attached");
+
+    const ClipSourceID recorded = mgr.createRecordedSource(path, "Take", makeBuffer());
+    require(recorded.value == created.value, "readinessFlip: precondition — path dedupe must reuse the same id");
+    require(mgr.getSource(recorded)->isReady(), "readinessFlip: source must be ready once a buffer is attached");
+    require(mgr.getRevision() != beforeBuffer,
+            "readinessFlip: attaching a buffer to an existing source must bump the revision");
+}
+
+// Removal and clear change which sources exist, so both must bump.
+void testRemoveAndClearBump() {
+    SourceManager mgr;
+    const ClipSourceID id = mgr.getOrCreateSource("/tmp/aestra-test-c.wav");
+
+    const uint64_t beforeRemove = mgr.getRevision();
+    require(mgr.removeSource(id), "removeAndClear: precondition — removing an existing source must succeed");
+    require(mgr.getRevision() != beforeRemove, "removeAndClear: removeSource must bump the revision");
+
+    mgr.getOrCreateSource("/tmp/aestra-test-d.wav");
+    const uint64_t beforeClear = mgr.getRevision();
+    mgr.clear();
+    require(mgr.getRevision() != beforeClear, "removeAndClear: clear must bump the revision");
+}
+
+// Removing a source that is not there changes nothing, so it must not bump —
+// otherwise the sweep would be woken by a no-op.
+void testFailedRemoveDoesNotBump() {
+    SourceManager mgr;
+    mgr.getOrCreateSource("/tmp/aestra-test-e.wav");
+    const uint64_t before = mgr.getRevision();
+
+    require(!mgr.removeSource(ClipSourceID{999999}), "failedRemove: precondition — removing an absent id must fail");
+    require(mgr.getRevision() == before, "failedRemove: a failed removeSource must not bump the revision");
+}
+
+// The counter only has to change on mutation; a caller comparing snapshots must
+// never see it run backwards, or a sweep would be skipped.
+void testRevisionIsMonotonic() {
+    SourceManager mgr;
+    uint64_t previous = mgr.getRevision();
+    for (int i = 0; i < 8; ++i) {
+        mgr.getOrCreateSource("/tmp/aestra-test-mono-" + std::to_string(i) + ".wav");
+        const uint64_t current = mgr.getRevision();
+        require(current >= previous, "monotonic: revision must never decrease");
+        require(current != previous, "monotonic: each new source must move the revision");
+        previous = current;
+    }
+}
+
+} // namespace
+
+int main() {
+    testCreateBumps();
+    testDedupeDoesNotBump();
+    testReadinessFlipBumpsOnExistingSource();
+    testRemoveAndClearBump();
+    testFailedRemoveDoesNotBump();
+    testRevisionIsMonotonic();
+
+    std::cout << "[PASS] SourceManagerRevisionTest\n";
+    return 0;
+}

--- a/Tests/cmake/ProjectTests.cmake
+++ b/Tests/cmake/ProjectTests.cmake
@@ -137,3 +137,14 @@ add_test(
 set_tests_properties(ProjectLoadReportLifecycleGuardTest PROPERTIES
     LABELS "app;project;muse;recovery;guard"
 )
+
+# SourceManager revision counter — the change signal TrackManagerUI uses to
+# notice sources that are ready but still have no waveform cache.
+add_executable(SourceManagerRevisionTest AestraAudio/SourceManagerRevisionTest.cpp)
+target_link_libraries(SourceManagerRevisionTest PRIVATE AestraAudioCore)
+target_include_directories(SourceManagerRevisionTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME SourceManagerRevisionTest COMMAND SourceManagerRevisionTest)
+set_tests_properties(SourceManagerRevisionTest PROPERTIES LABELS "audio;waveform")


### PR DESCRIPTION
## Summary

A clip imported mid-session rendered as a flat slab with a single faint centre line, and stayed
that way until the project was saved and reloaded. This makes the waveform appear immediately.

Found while building a dense session for a timeline visual QA pass — 42 clips in, every one was a
featureless grey block.

## Why

`drawWaveformForClip` only draws from a ready `WaveformCache` once `samplesPerPixel` reaches
`DEFAULT_BASE_SAMPLES_PER_PEAK` (64). That is *every* practical zoom — the direct-peaks branch
below it needs roughly 700px per second of audio. With no cache it falls through to the faint
centre line, which is exactly what the timeline was showing.

Building those caches was left to whichever import path remembered:

| Path | Builds a cache? |
| --- | --- |
| Drop that has to decode the file | yes, inline |
| Drop that reuses an already-decoded source | **no** |
| Command path (Muse `add_clip`, clip verbs) | **no** |
| Project load | yes, via `buildAllWaveformCaches()` |

`buildAllWaveformCaches()` — the function whose entire job is "every ready source has a cache" —
had exactly one caller, `refreshProjectViews()`, itself reached only from the project-load path in
`AestraApp`. The caches were a load-time side effect.

Rather than add a fourth build call and wait for the fifth import path to forget it, `SourceManager`
now carries a monotonic revision bumped when the source set changes or a source flips to ready, and
`TrackManagerUI::onUpdate` sweeps for missing caches gated on it. Steady state is one integer
compare per frame — no allocation, no dirty-marking, so **idle frame elision is unaffected**.
`buildAllWaveformCaches()` already guarded each source itself, so the counter is only a wake-up
hint, never a correctness authority.

The bump in `createRecordedSource` is deliberately unconditional: a source deduped by path mints no
new ID, but attaching its buffer still flips it to ready — precisely the transition being missed.

### A dead end worth recording

My first instinct was to hang this off `refreshTracks()`, which has ~20 call sites and looks like
the natural "timeline content changed" hook. The session log showed it fired **twice in eight
minutes** — startup and one GUI drop — and never for any of the 42 command-path imports. That fix
would have missed the exact case this bug reproduces on.

## Testing performed

- **Verified live, not by inspection.** Relaunched with the fix and imported through Muse: the log
  went from **0** waveform builds to `Queued 1 waveform cache builds (async)` per import, and clip
  bodies went from `spread=0` on *every* row (flat 186 fill + a single 204 centre line) to a real
  tapering envelope. Screenshot-confirmed.
- **New `SourceManagerRevisionTest`** — 6 cases, each asserting its precondition first so none can
  pass vacuously: create bumps, path-dedupe does not, readiness-flip on an existing source bumps,
  remove/clear bump, a *failed* remove does not, and the counter never runs backwards.
- **Proved the test catches the bug** rather than trusting a green run: removing the
  `createRecordedSource` bump fails with
  `readinessFlip: attaching a buffer to an existing source must bump the revision`; restoring it
  passes.
- Full suite: **235/235 passed** (`SecAccountEndToEndSmoke` skipped — pre-existing environment
  skip). Full build clean, exit 0.

## Docs updated?

No — restores intended behaviour, no new surface.

## Risk / rollback

Low. `SourceManager` gains one counter and an accessor; no existing behaviour changes. The UI side
adds one integer compare per frame. Rollback is reverting the single commit.

**Known gap, deliberately not fixed here:** the async-decode drop branch calls `buildAsync` itself,
yet a clip imported that way still showed no waveform for minutes in my session — so there may be a
second latent issue in that callback. The sweep now covers that case regardless, so it is no longer
user-visible, but it is not explained. Flagging rather than widening scope.

Not addressed: this is one finding from the dense-session QA pass. The clip-body brightness,
label centring, minimap/timeline colour coherence, and the track-header resize cursor are separate
follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixes timeline clips that rendered as flat slabs until project reload by rebuilding missing waveform caches when `SourceManager` state changes.
- Adds monotonic `SourceManager::getRevision()` tracking for source creation, readiness changes, removal, and clearing.
- Updates `TrackManagerUI::onUpdate` to sweep for missing caches without per-frame allocations or dirty-marking.
- Adds revision behavior tests and CTest registration, including deduplication, failed removal, readiness transitions, and monotonicity.
- No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->