### PR TITLE
Centre the clip label in its header band

### DIFF
--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1153,8 +1153,14 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
 
     const std::string displayName = truncateClipLabel(clipName, clipBounds.width - 46.0f, 5.9f);
     if (!displayName.empty()) {
-        renderer.drawText(displayName, AestraUI::NUIPoint(clipBounds.x + 10.0f, clipBounds.y + 4.0f),
-                          9.5f, themeManager.getCurrentTheme().textPrimary);
+        // Centred in the header band rather than offset from the clip's top edge:
+        // headerHeight is clamped, so a fixed offset drifts as the band resizes and
+        // left the label flush against the band's lower edge at short clip heights.
+        constexpr float kClipLabelFontSize = 9.5f;
+        renderer.drawText(displayName,
+                          AestraUI::NUIPoint(clipBounds.x + 10.0f,
+                                             renderer.calculateTextY(headerRect, kClipLabelFontSize)),
+                          kClipLabelFontSize, themeManager.getCurrentTheme().textPrimary);
     }
 
     if (m_trackManager && clip.patternId.isValid()) {


### PR DESCRIPTION
## Summary

The clip name sat flush against the bottom edge of the band it lives in. Centres it properly.

One finding from the dense-session timeline QA pass, split out so it can land on its own.

## Why

The label was drawn at `clipBounds.y + 4.0f`, but the band it occupies is `headerRect`, whose
height is clamped:

```cpp
const float headerHeight = std::min(18.0f, std::max(14.0f, clipBounds.height * 0.26f));
```

So the offset is fixed while the band is not. Measured on a 44px clip (header clamped to its 14px
lower bound): label ink occupied y188–196 inside a band of y184–196 — **4px of space above the ink
and 0px below**. The text is not slightly off, it is touching the band's lower boundary, and the gap
drifts as clip height changes the clamp.

`renderer.calculateTextY(rect, fontSize)` returns `rect.y + (rect.height - lineHeight) * 0.5f`,
centring the full line box, and is already the convention used elsewhere for centring text against
a rect. Using it makes the label track the band at any clip height instead of only looking right at
one.

The font size was also an inline literal in the `drawText` call; it is now a named constant, since
the Y calculation and the draw must agree on it.

## Testing performed

- Full build clean, exit 0.
- Full suite: **235/235 passed** (`SecAccountEndToEndSmoke` skipped — pre-existing environment skip).
- **Not covered:** there is no automated assertion on rendered text position, so the visual result
  rests on the measurement above plus manual review. Verified on Linux/SDL2 only.

## Producer note

None

## Docs updated?

No.

## Risk / rollback

Very low — one label's Y coordinate. Rollback is reverting the single commit.

Worth noting the change is visible at **every** clip height, not just the clamped minimum, since the
old offset only coincided with centred at one particular band height. If the label now reads as
sitting too low or high, the band height itself is the thing to tune, not the offset.

Related dense-session findings not in this PR: clip-body brightness and minimap/timeline colour
coherence are being handled separately; the track-header resize cursor is filed but unreproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)