### PR TITLE
Give lane colour one restraint authority, and let the waveform outrank its clip

### DIFF
--- a/AestraUI/Widgets/TrackColorPalette.h
+++ b/AestraUI/Widgets/TrackColorPalette.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "../Core/NUITypes.h"
+
+#include <algorithm>
 #include <cstdint>
 #include <climits>
 
@@ -31,6 +34,38 @@ static constexpr const char* PALETTE_NAMES[] = {
 inline uint32_t paletteIndexToARGB(int index) {
     if (index < 0 || index >= PALETTE_SIZE) return 0xFF808080;
     return TRACK_PALETTE[index];
+}
+
+/**
+ * @brief Pull a raw palette hue back to the timeline's restrained tone.
+ *
+ * TRACK_PALETTE stores identity hues at full strength. Nothing should paint
+ * them raw: the timeline deliberately tones lane and clip colour down so the
+ * musical content stays the brightest thing on screen. Any surface that shows
+ * the *same* lane identity has to apply the same restraint, or one view reads
+ * as a different colour system from the next.
+ *
+ * @param brightnessScale Multiplies final luma (below 1 darkens).
+ * @param saturationScale Pulls channels toward luma (below 1 desaturates).
+ * @param alpha Output alpha; negative keeps the input's.
+ */
+inline NUIColor restrainDawColor(const NUIColor& color, float brightnessScale, float saturationScale, float alpha) {
+    const float luma = (0.2126f * color.r) + (0.7152f * color.g) + (0.0722f * color.b);
+    const float tonedR = ((color.r - luma) * saturationScale + luma) * brightnessScale;
+    const float tonedG = ((color.g - luma) * saturationScale + luma) * brightnessScale;
+    const float tonedB = ((color.b - luma) * saturationScale + luma) * brightnessScale;
+    return NUIColor(std::clamp(tonedR, 0.0f, 1.0f), std::clamp(tonedG, 0.0f, 1.0f), std::clamp(tonedB, 0.0f, 1.0f),
+                    alpha >= 0.0f ? alpha : color.a);
+}
+
+/**
+ * @brief Restraint applied to a lane-identity stripe.
+ *
+ * Shared by the timeline's lane strips and the minimap's per-lane lines so a
+ * lane reads as one colour in both.
+ */
+inline NUIColor restrainLaneIdentityColor(const NUIColor& color, float alpha) {
+    return restrainDawColor(color, 0.84f, 0.62f, alpha);
 }
 
 inline int nearestPaletteIndex(uint32_t argb) {

--- a/AestraUI/Widgets/TrackColorPalette.h
+++ b/AestraUI/Widgets/TrackColorPalette.h
@@ -68,6 +68,38 @@ inline NUIColor restrainLaneIdentityColor(const NUIColor& color, float alpha) {
     return restrainDawColor(color, 0.84f, 0.62f, alpha);
 }
 
+// ---------------------------------------------------------------------------
+// Clip contrast contract
+//
+// A clip is a surface with audio drawn on it. The body is deliberately toned
+// well down; the waveform keeps the identity hue near full strength and is then
+// lifted toward white. Both halves live here, together, because the thing that
+// matters is not either constant but the *gap* between them — separate the two
+// derivations and a later edit can quietly invert the hierarchy, which is the
+// bug this pairing exists to prevent. TimelineClipContrastTest guards the gap.
+// ---------------------------------------------------------------------------
+
+/** @brief The clip body: a deep, desaturated surface that must stay the quieter half. */
+inline NUIColor clipBodyTone(const NUIColor& identity, bool selected) {
+    return restrainDawColor(identity, selected ? 0.78f : 0.68f, selected ? 0.62f : 0.56f, 1.0f);
+}
+
+/** @brief The identity tint the waveform is lifted from — kept bright so it has headroom. */
+inline NUIColor waveformTintTone(const NUIColor& identity, bool selected) {
+    const NUIColor tint = restrainDawColor(identity, 1.0f, 0.92f, 1.0f);
+    return selected ? tint.lightened(0.12f) : tint;
+}
+
+/** @brief Lift a waveform tint toward white. Sole authority for the lift amount. */
+inline NUIColor liftWaveformInk(const NUIColor& tint) {
+    return NUIColor::lerp(tint, NUIColor::white(), 0.52f);
+}
+
+/** @brief The ink actually drawn over the body. Must stay brighter than clipBodyTone(). */
+inline NUIColor waveformInkTone(const NUIColor& identity, bool selected) {
+    return liftWaveformInk(waveformTintTone(identity, selected));
+}
+
 inline int nearestPaletteIndex(uint32_t argb) {
     if (argb == 0) return -1;
     int best = 0;

--- a/Source/Components/TimelineMinimapRenderer.cpp
+++ b/Source/Components/TimelineMinimapRenderer.cpp
@@ -234,9 +234,13 @@ void TimelineMinimapRenderer::render(NUIRenderer& renderer, const TimelineMinima
                  // Stop drawing if out of bounds (culling)
                  if (currentY + trackH > barBottom) break; 
                  
-                 // Shared TRACK_PALETTE, same modulo as the track-color fallback
-                 const NUIColor lineTint =
-                     NUIColor::fromARGB(paletteIndexToARGB(static_cast<int>(i % PALETTE_SIZE))).withAlpha(0.9f);
+                 // Shared TRACK_PALETTE, same modulo as the track-color fallback.
+                 // Restrained through the same helper the timeline's lane strips
+                 // use: raw palette hues here read as a second, louder colour
+                 // system sitting above a timeline that deliberately tones the
+                 // very same lane identity down.
+                 const NUIColor lineTint = restrainLaneIdentityColor(
+                     NUIColor::fromARGB(paletteIndexToARGB(static_cast<int>(i % PALETTE_SIZE))), 0.9f);
 
                  NUIRect lineRect(x, currentY, 1.0f, trackH);
                  renderer.fillRect(lineRect, lineTint);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -104,17 +104,10 @@ TrackSelectionIntent selectionIntentFor(const AestraUI::NUIMouseEvent& event) {
     return trackSelectionIntentForModifierState(toggleModifier, event.modifiers & AestraUI::NUIModifiers::Shift);
 }
 
-AestraUI::NUIColor restrainDawColor(const AestraUI::NUIColor& color, float brightnessScale, float saturationScale,
-                                    float alpha) {
-    const float luma = (0.2126f * color.r) + (0.7152f * color.g) + (0.0722f * color.b);
-    const float tonedR = ((color.r - luma) * saturationScale + luma) * brightnessScale;
-    const float tonedG = ((color.g - luma) * saturationScale + luma) * brightnessScale;
-    const float tonedB = ((color.b - luma) * saturationScale + luma) * brightnessScale;
-    return AestraUI::NUIColor(std::clamp(tonedR, 0.0f, 1.0f),
-                              std::clamp(tonedG, 0.0f, 1.0f),
-                              std::clamp(tonedB, 0.0f, 1.0f),
-                              alpha >= 0.0f ? alpha : color.a);
-}
+// restrainDawColor now lives in AestraUI/Widgets/TrackColorPalette.h next to the
+// palette it tones, so the minimap applies the identical restraint to the same
+// lane identities. Brought into scope here to keep the call sites unqualified.
+using AestraUI::restrainDawColor;
 
 // Keep Playlist clip selection in the same visual language as Piano Roll
 // notes: a lifted secondary accent, crisp white edge, grounded shadow, and
@@ -902,8 +895,13 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
     // Selection eases the base look up slightly; the border and glow carry
     // the state so the fill doesn't visibly "pop" on click-and-hold
     // Deeper, less-saturated base so the clip reads rich rather than neon.
+    // Body sits lower than the waveform on purpose. deriveWaveformInk() lifts the
+    // ink from a separately restrained tint (1.0 brightness / 0.92 saturation), so
+    // dropping the body brightness here widens waveform-vs-body contrast without
+    // touching the waveform: the clip stops reading as a bright slab and starts
+    // reading as a surface with audio drawn on it.
     const AestraUI::NUIColor clipBase = restrainDawColor(clipColor,
-                                                         clipSelected ? 0.90f : 0.80f,
+                                                         clipSelected ? 0.78f : 0.68f,
                                                          clipSelected ? 0.62f : 0.56f,
                                                          1.0f);
     AestraUI::NUIColor tintFill = clipBase.withAlpha(clipSelected ? 0.88f : 0.80f);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -139,8 +139,10 @@ struct WaveformInk {
 WaveformInk deriveWaveformInk(const AestraUI::NUIColor& base) {
     // Bold, near-solid waveform so it reads as a clear waveform shape (not faint
     // texture) against the clip fill: a bright lift of the clip hue at high alpha,
-    // with the min/max envelope nearly as opaque as the RMS body.
-    const AestraUI::NUIColor bright = AestraUI::NUIColor::lerp(base, AestraUI::NUIColor::white(), 0.52f);
+    // with the min/max envelope nearly as opaque as the RMS body. The lift amount
+    // is shared with clipBodyTone()'s counterpart so the contrast contract has one
+    // authority (see TrackColorPalette.h).
+    const AestraUI::NUIColor bright = AestraUI::liftWaveformInk(base);
     WaveformInk ink;
     ink.rms = bright.withAlpha(0.97f);
     ink.envTop = bright.withAlpha(0.90f);
@@ -565,8 +567,7 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     // Waveform ink base is the clip hue at full brightness; deriveWaveformInk()
     // lifts it bright + near-opaque so the wave reads boldly over the fill.
     const bool clipSelected = (clip.id == m_selectedClipId);
-    AestraUI::NUIColor clipTint = restrainDawColor(resolveClipDisplayColor(clip), 1.0f, 0.92f, 1.0f);
-    if (clipSelected) clipTint = clipTint.lightened(0.12f);
+    const AestraUI::NUIColor clipTint = AestraUI::waveformTintTone(resolveClipDisplayColor(clip), clipSelected);
 
     const double samplesPerPixel = static_cast<double>(visibleFrames) / static_cast<double>(width);
 
@@ -895,15 +896,11 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
     // Selection eases the base look up slightly; the border and glow carry
     // the state so the fill doesn't visibly "pop" on click-and-hold
     // Deeper, less-saturated base so the clip reads rich rather than neon.
-    // Body sits lower than the waveform on purpose. deriveWaveformInk() lifts the
-    // ink from a separately restrained tint (1.0 brightness / 0.92 saturation), so
-    // dropping the body brightness here widens waveform-vs-body contrast without
-    // touching the waveform: the clip stops reading as a bright slab and starts
-    // reading as a surface with audio drawn on it.
-    const AestraUI::NUIColor clipBase = restrainDawColor(clipColor,
-                                                         clipSelected ? 0.78f : 0.68f,
-                                                         clipSelected ? 0.62f : 0.56f,
-                                                         1.0f);
+    // Body sits lower than the waveform on purpose. Both tones are derived
+    // together in TrackColorPalette.h so the gap between them cannot drift: the
+    // clip stops reading as a bright slab and starts reading as a surface with
+    // audio drawn on it.
+    const AestraUI::NUIColor clipBase = AestraUI::clipBodyTone(clipColor, clipSelected);
     AestraUI::NUIColor tintFill = clipBase.withAlpha(clipSelected ? 0.88f : 0.80f);
     // Opaque deep base so the timeline grid doesn't bleed through the clip body.
     renderer.fillRoundedRect(clipBounds, clipRadius, themeManager.getColor("backgroundPrimary"));

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -104,10 +104,9 @@ TrackSelectionIntent selectionIntentFor(const AestraUI::NUIMouseEvent& event) {
     return trackSelectionIntentForModifierState(toggleModifier, event.modifiers & AestraUI::NUIModifiers::Shift);
 }
 
-// restrainDawColor now lives in AestraUI/Widgets/TrackColorPalette.h next to the
-// palette it tones, so the minimap applies the identical restraint to the same
-// lane identities. Brought into scope here to keep the call sites unqualified.
-using AestraUI::restrainDawColor;
+// Clip and lane tones all come from AestraUI/Widgets/TrackColorPalette.h now
+// (clipBodyTone / waveformTintTone / restrainLaneIdentityColor), so nothing here
+// open-codes a restraint the minimap cannot see.
 
 // Keep Playlist clip selection in the same visual language as Piano Roll
 // notes: a lifted secondary accent, crisp white edge, grounded shadow, and
@@ -1329,7 +1328,7 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
             
             const float stripWidth = 3.0f;
             const float stripAlpha = (m_selected || lane->solo) ? 0.82f : 0.40f;
-            const auto stripBright = restrainDawColor(stripColor, 0.84f, 0.62f, stripAlpha);
+            const auto stripBright = AestraUI::restrainLaneIdentityColor(stripColor, stripAlpha);
             renderer.fillRect(AestraUI::NUIRect(bounds.x, bounds.y, stripWidth, bounds.height), stripBright);
         }
 
@@ -1531,7 +1530,10 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         
         const float stripWidth = 3.0f;
         const float stripAlpha = (m_selected || lane->solo) ? 0.84f : 0.42f;
-        stripColor = restrainDawColor(stripColor, 0.86f, 0.62f, stripAlpha);
+        // Was 0.86f here against 0.84f in the static pass, so one lane strip had
+        // two brightnesses depending on which pass drew it. Both now go through
+        // the shared lane-identity restraint the minimap uses.
+        stripColor = AestraUI::restrainLaneIdentityColor(stripColor, stripAlpha);
         
         // Draw strip
         renderer.fillRect(AestraUI::NUIRect(bounds.x, bounds.y, stripWidth, bounds.height), stripColor);

--- a/Tests/AestraUI/TimelineClipContrastTest.cpp
+++ b/Tests/AestraUI/TimelineClipContrastTest.cpp
@@ -1,0 +1,153 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Guards the timeline clip contrast contract: a clip is a surface with audio
+// drawn on it, so the waveform ink must stay meaningfully brighter than the clip
+// body it sits on, for every lane identity and in both selection states.
+//
+// Deliberately does NOT assert the brightness constants themselves. Those are
+// taste values the owner is expected to retune; a test that restates 0.68f only
+// duplicates the literal and turns every future tweak into a test edit. What
+// must not regress is the *ordering and margin* between the two tones — that is
+// what makes a waveform readable, and it is what silently breaks if someone
+// brightens the body or dims the ink without looking at the other half.
+//
+// The pairing is only checkable because clipBodyTone() and waveformInkTone() are
+// derived side by side in TrackColorPalette.h. If a later change moves one of
+// them somewhere else, this test stops being able to see the contract.
+
+#include "Widgets/TrackColorPalette.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+using AestraUI::clipBodyTone;
+using AestraUI::NUIColor;
+using AestraUI::paletteIndexToARGB;
+using AestraUI::PALETTE_SIZE;
+using AestraUI::waveformInkTone;
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        ++failures;
+    }
+}
+
+// Perceptual (WCAG) relative luminance, so the margin means something to an eye
+// rather than to a raw channel sum.
+float relativeLuminance(const NUIColor& c) {
+    const auto channel = [](float v) {
+        return (v <= 0.03928f) ? (v / 12.92f) : std::pow((v + 0.055f) / 1.055f, 2.4f);
+    };
+    return 0.2126f * channel(c.r) + 0.7152f * channel(c.g) + 0.0722f * channel(c.b);
+}
+
+float contrastRatio(const NUIColor& a, const NUIColor& b) {
+    const float la = relativeLuminance(a);
+    const float lb = relativeLuminance(b);
+    const float hi = (la > lb) ? la : lb;
+    const float lo = (la > lb) ? lb : la;
+    return (hi + 0.05f) / (lo + 0.05f);
+}
+
+// Below this the waveform stops reading as a distinct shape over its fill. Set
+// under the current measured value so ordinary retuning does not trip it, but
+// far enough above 1.0 that a collapse is caught.
+constexpr float kMinInkOverBody = 1.35f;
+
+std::string describe(const NUIColor& c) {
+    return "(" + std::to_string(static_cast<int>(c.r * 255.0f)) + "," +
+           std::to_string(static_cast<int>(c.g * 255.0f)) + "," +
+           std::to_string(static_cast<int>(c.b * 255.0f)) + ")";
+}
+
+// The core contract, over every palette identity plus the unset-colour grey
+// fallback, in both selection states.
+void testInkOutranksBodyForEveryIdentity() {
+    for (int i = 0; i <= PALETTE_SIZE; ++i) {
+        // One past the palette exercises paletteIndexToARGB's out-of-range grey,
+        // which is what an uncoloured clip actually renders with.
+        const NUIColor identity = NUIColor::fromARGB(paletteIndexToARGB(i));
+
+        for (const bool selected : {false, true}) {
+            const NUIColor body = clipBodyTone(identity, selected);
+            const NUIColor ink = waveformInkTone(identity, selected);
+            const std::string where =
+                "lane " + std::to_string(i) + (selected ? " (selected)" : " (unselected)");
+
+            check(relativeLuminance(ink) > relativeLuminance(body),
+                  where + ": waveform ink " + describe(ink) + " must be brighter than body " +
+                      describe(body));
+
+            const float ratio = contrastRatio(ink, body);
+            check(ratio >= kMinInkOverBody,
+                  where + ": ink-over-body contrast " + std::to_string(ratio) + ":1 fell below the " +
+                      std::to_string(kMinInkOverBody) + ":1 floor");
+        }
+    }
+}
+
+// Selecting a clip must not darken it — the selected body carries state, and an
+// inverted delta would make selection read as "disabled".
+void testSelectionLiftsRatherThanDarkens() {
+    for (int i = 0; i < PALETTE_SIZE; ++i) {
+        const NUIColor identity = NUIColor::fromARGB(paletteIndexToARGB(i));
+        const float plain = relativeLuminance(clipBodyTone(identity, false));
+        const float selected = relativeLuminance(clipBodyTone(identity, true));
+        check(selected > plain, "lane " + std::to_string(i) +
+                                   ": selected body must be brighter than unselected");
+    }
+}
+
+// The body must stay clearly visible against the timeline's black canvas, or the
+// quieting has gone too far and clips vanish instead of receding.
+void testBodyStaysVisibleAgainstCanvas() {
+    const NUIColor canvas(0.0f, 0.0f, 0.0f, 1.0f);
+    for (int i = 0; i <= PALETTE_SIZE; ++i) {
+        const NUIColor identity = NUIColor::fromARGB(paletteIndexToARGB(i));
+        const NUIColor body = clipBodyTone(identity, false);
+        const float ratio = contrastRatio(body, canvas);
+        check(ratio >= 2.0f, "lane " + std::to_string(i) + ": body-vs-canvas contrast " +
+                                 std::to_string(ratio) + ":1 is too low to see the clip");
+    }
+}
+
+// Restraint has to actually restrain: a no-op would silently reintroduce the raw
+// palette everywhere the helper is used.
+void testLaneIdentityRestraintIsNotAnIdentityFunction() {
+    for (int i = 0; i < PALETTE_SIZE; ++i) {
+        const NUIColor raw = NUIColor::fromARGB(paletteIndexToARGB(i));
+        const NUIColor restrained = AestraUI::restrainLaneIdentityColor(raw, 1.0f);
+        check(relativeLuminance(restrained) < relativeLuminance(raw),
+              "lane " + std::to_string(i) + ": restrained identity must be darker than the raw palette hue");
+
+        const auto saturation = [](const NUIColor& c) {
+            const float mx = std::max(c.r, std::max(c.g, c.b));
+            const float mn = std::min(c.r, std::min(c.g, c.b));
+            return (mx <= 0.0f) ? 0.0f : (mx - mn) / mx;
+        };
+        check(saturation(restrained) < saturation(raw),
+              "lane " + std::to_string(i) + ": restrained identity must be less saturated than raw");
+    }
+}
+
+} // namespace
+
+int main() {
+    testInkOutranksBodyForEveryIdentity();
+    testSelectionLiftsRatherThanDarkens();
+    testBodyStaysVisibleAgainstCanvas();
+    testLaneIdentityRestraintIsNotAnIdentityFunction();
+
+    if (failures > 0) {
+        std::cerr << "[FAIL] TimelineClipContrastTest: " << failures << " check(s) failed\n";
+        return 1;
+    }
+    std::cout << "[PASS] TimelineClipContrastTest\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1544,6 +1544,16 @@ target_include_directories(TimelineInteractionPolicyTest PRIVATE
 add_test(NAME TimelineInteractionPolicyTest COMMAND TimelineInteractionPolicyTest)
 set_tests_properties(TimelineInteractionPolicyTest PROPERTIES LABELS "ui;timeline;selection;regression")
 
+# Clip contrast contract: waveform ink must stay brighter than the clip body it
+# is drawn on, for every lane identity and both selection states.
+add_executable(TimelineClipContrastTest AestraUI/TimelineClipContrastTest.cpp)
+target_include_directories(TimelineClipContrastTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraUI
+    ${CMAKE_SOURCE_DIR}/AestraUI/Core
+)
+add_test(NAME TimelineClipContrastTest COMMAND TimelineClipContrastTest)
+set_tests_properties(TimelineClipContrastTest PROPERTIES LABELS "ui;timeline;color;regression")
+
 # Settings persistence policy (#648). Same shape as SafeClampFloatTest above:
 # header-only and widget-free so the decision that was destroying saved device
 # ids is reachable without linking AestraUI, which AESTRA_CI=ON disables.


### PR DESCRIPTION
## Summary

Two dense-session QA findings, both about the timeline shouting:

1. The minimap painted lane identity from the raw palette while the timeline tones the *same*
   identity down — two colour systems for one song.
2. The clip body was bright enough to compete with the audio drawn on it.

## Why

### Minimap / timeline colour coherence

The minimap drew per-lane lines straight from `TRACK_PALETTE` at 0.9 alpha. The timeline runs the
same lane identity through `restrainDawColor()` first. So a lane rendered as a saturated hue up top
and a restrained neutral below — which is exactly why the minimap read as bolted-on rather than as a
view of the same arrangement.

`restrainDawColor()` was a **file-local helper inside `TrackUIComponent.cpp`**, so the minimap
structurally could not reach it. Moved to `TrackColorPalette.h`, beside the palette it tones, giving
one authority instead of a formula one surface owns and another duplicates. Added
`restrainLaneIdentityColor()` for the lane-stripe treatment (0.84 brightness / 0.62 saturation) now
shared by both.

Measured across all 8 palette entries — saturation **−12% to −33%**, luminance **−7% to −20%**:

| lane | raw | restrained |
| --- | --- | --- |
| Teal | `(0,201,167)` | `(50,154,137)` |
| Amber | `(240,165,0)` | `(179,140,54)` |
| Coral | `(255,87,87)` | `(172,84,84)` |
| Sky | `(79,179,255)` | `(93,145,185)` |

Lanes stay distinguishable; they stop competing.

### Clip body brightness

Body brightness scale 0.80 → 0.68 (selected 0.90 → 0.78, same selected/unselected delta preserved).

The point is the *ratio*, not the absolute. `deriveWaveformInk()` builds the waveform from a
**separately** restrained tint (1.0 brightness / 0.92 saturation), so lowering the body does not dim
the waveform — it widens the gap between them. Measured on grey clips:

| | before | after |
| --- | --- | --- |
| body vs black canvas | 5.39:1 | **4.06:1** |
| waveform ink vs body | 1.86:1 | **2.47:1** (+33%) |

The clip reads as a surface with audio on it rather than a bright slab, which is what was asked for.

## Testing performed

- Verified live on a 6-lane session **rebased onto #704**, so waveforms actually render — the whole
  point of the ratio change is unobservable without it. 6 waveform builds logged, waveform envelope
  visible with real dynamics against the quieter body.
- Full build clean (exit 0); all **10** `TrackColorPalette.h` consumers compile with the new
  `NUITypes.h` dependency.
- Full suite: **235/235 passed**.
- **Not covered:** no automated assertion on rendered colour — the numbers above are `grim` +
  PIL measurements plus manual review. Linux/SDL2 only.

### A correction worth recording

I earlier reported the clip body at **10.82:1** from the dense-session screenshot. A like-for-like
measurement on the same code gives **5.39:1**, consistent across five lanes, and I could not
reproduce the higher figure. The 0.68 value here is tuned to the number that reproduces. If the
body now reads too dark to you, that is a taste call on a measured baseline, not a hunt for a
number I could not confirm.

## Producer note

Timeline clips are easier on the eyes over a long session, and the minimap's colours now match the
tracks they represent.

## Docs updated?

No.

## Risk / rollback

Low — colour values and one helper relocation, no behavioural change. Rollback is reverting the
single commit.

The helper move makes `TrackColorPalette.h` depend on `NUITypes.h`; it was previously a pure-data
header. Full build confirms every consumer is fine, but that is the one structural change here.

Both remaining dense-session items are unresolved and not in this PR: the track-header resize
cursor is filed but **unreproduced** (two theories instrumented and refuted), and clip-label
repetition across duplicates is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Centralized timeline color restraint and tone derivation in `TrackColorPalette.h`.
- Added `restrainLaneIdentityColor()` for consistent minimap and timeline lane colors.
- Reduced clip body brightness while preserving waveform ink brightness to improve contrast.
- Added and registered `TimelineClipContrastTest` for waveform contrast, selection brightness, body visibility, and lane-color restraint.
- Validation reports 236 passing tests, a clean build, mutation verification, and manual six-lane waveform testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->