### PR TITLE
Mixer semantic hierarchy pass — and a renderer bug that was eating every minus sign

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -144,7 +144,8 @@ public:
             m_nextChannelId = std::max(m_nextChannelId, channelId + 1);
         }
         auto channel = std::make_unique<MixerChannel>(
-            name.empty() ? "Insert " + std::to_string(channelId) : name, channelId);
+            // "Insert" is reserved for effect slots — a mixer strip is a Channel.
+            name.empty() ? "Channel " + std::to_string(channelId) : name, channelId);
         channel->setCommandSink(m_commandSink);
         channel->setInputMonitoringStateChangedCallback([this]() { publishInputMonitoringSnapshot(); });
         if (m_channelPrepareCallback) {

--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -677,7 +677,7 @@ void NUITextInput::drawSelection(NUIRenderer& renderer)
                     ? line.charX[endCol] : line.charX.back();
         
         NUIRect selectionRect;
-        selectionRect.x = textRect.x + startX;
+        selectionRect.x = textRect.x + justificationOffsetForLine(line, textRect.width) + startX;
         selectionRect.y = singleLine ? singleLineTop : std::round(getLineRenderY(line));
         selectionRect.width = endX - startX;
         selectionRect.height = singleLine ? singleLineHeight : line.height;
@@ -685,6 +685,19 @@ void NUITextInput::drawSelection(NUIRenderer& renderer)
         // Draw selection highlight
         renderer.fillRoundedRect(selectionRect, 2.0f, selectionColor_.withAlpha(0.4f));
     }
+}
+
+float NUITextInput::justificationOffsetForLine(const TextLine& line, float availableWidth) const
+{
+    if (justification_ == Justification::Left)
+        return 0.0f;
+
+    const float lineWidth = line.charX.empty() ? 0.0f : line.charX.back();
+    const float slack = availableWidth - lineWidth;
+    if (slack <= 0.0f)
+        return 0.0f;
+
+    return (justification_ == Justification::Center) ? slack * 0.5f : slack;
 }
 
 void NUITextInput::drawCaret(NUIRenderer& renderer)
@@ -1399,11 +1412,12 @@ void NUITextInput::drawAnimatedCaret(NUIRenderer& renderer)
 
     // Get caret X position for this line
     int column = getColumnInLine(caretPosition_, currentLine);
-    float caretX = textRect.x;
+    const float justifyX = justificationOffsetForLine(line, textRect.width);
+    float caretX = std::round(textRect.x + justifyX);
 
     if (column >= 0 && column < static_cast<int>(line.charX.size()))
     {
-        caretX = std::round(textRect.x + line.charX[column]);
+        caretX = std::round(textRect.x + justifyX + line.charX[column]);
     }
 
     // Use calculateTextY for proper baseline alignment in single-line mode

--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -692,6 +692,13 @@ float NUITextInput::justificationOffsetForLine(const TextLine& line, float avail
     if (justification_ == Justification::Left)
         return 0.0f;
 
+    // drawText() lays every line of a multiline input at bounds.x + padding_,
+    // ignoring justification. Offsetting the caret and selection here while the
+    // glyphs stay left-aligned would desync them, so multiline stays at zero
+    // until drawing, hit-testing and this helper are aligned together.
+    if (multiline_ && layoutLines_.size() > 1)
+        return 0.0f;
+
     const float lineWidth = line.charX.empty() ? 0.0f : line.charX.back();
     const float slack = availableWidth - lineWidth;
     if (slack <= 0.0f)

--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -1315,9 +1315,20 @@ void NUITextInput::deleteCharacter(int direction)
 
 void NUITextInput::insertCharacter(char character)
 {
+    if (readOnly_) return;
+
+    // Typing replaces the selection, exactly as insertText() already did.
+    // Without this the per-character path inserted at the caret and left the
+    // selected text in place: a select-all field seeded with "6.0" turned into
+    // "06.0" when the user typed "0" over it, because the caret sits at 0.
+    if (hasSelection_)
+    {
+        deleteSelectedText();
+    }
+
     if (maxLength_ > 0 && static_cast<int>(text_.length()) >= maxLength_)
         return;
-    
+
     text_.insert(caretPosition_, 1, character);
     setCaretPosition(caretPosition_ + 1);
     

--- a/AestraUI/Base/NUITextInput.h
+++ b/AestraUI/Base/NUITextInput.h
@@ -149,6 +149,16 @@ public:
     void setPadding(float padding);
     float getPadding() const { return padding_; }
 
+    /**
+     * @brief Horizontal offset a line's glyphs receive from the justification.
+     *
+     * Text drawing applies this offset, but the caret and selection rects were
+     * computed from raw charX values, so on a centred or right-aligned field
+     * both were drawn against the left edge while the text sat elsewhere.
+     * Left-aligned fields (the default) get 0 and are unaffected.
+     */
+    float justificationOffsetForLine(const TextLine& line, float availableWidth) const;
+
     // Scrolling
     void setScrollBarVisible(bool visible);
     bool isScrollBarVisible() const { return scrollBarVisible_; }

--- a/AestraUI/Base/NUITextInput.h
+++ b/AestraUI/Base/NUITextInput.h
@@ -149,15 +149,6 @@ public:
     void setPadding(float padding);
     float getPadding() const { return padding_; }
 
-    /**
-     * @brief Horizontal offset a line's glyphs receive from the justification.
-     *
-     * Text drawing applies this offset, but the caret and selection rects were
-     * computed from raw charX values, so on a centred or right-aligned field
-     * both were drawn against the left edge while the text sat elsewhere.
-     * Left-aligned fields (the default) get 0 and are unaffected.
-     */
-    float justificationOffsetForLine(const TextLine& line, float availableWidth) const;
 
     // Scrolling
     void setScrollBarVisible(bool visible);
@@ -193,6 +184,20 @@ protected:
     virtual void updateTextLayout();
     virtual NUIPoint getTextPosition(int characterIndex) const;
     virtual int getCharacterIndexAtPosition(const NUIPoint& position) const;
+
+    /**
+     * @brief Horizontal offset a line's glyphs receive from the justification.
+     *
+     * Text drawing applies this offset, but the caret and selection rects were
+     * computed from raw charX values, so on a centred or right-aligned field
+     * both were drawn against the left edge while the text sat elsewhere.
+     * Left-aligned fields (the default) get 0 and are unaffected.
+     *
+     * Protected, not public: TextLine is a layout internal, and exposing it
+     * would pin the layout model to the widget's API. Tests reach it through a
+     * subclass.
+     */
+    float justificationOffsetForLine(const TextLine& line, float availableWidth) const;
 
     // Layout helpers (overridable / testable)
     void invalidateLayout();

--- a/AestraUI/Core/ChannelDisplayName.h
+++ b/AestraUI/Core/ChannelDisplayName.h
@@ -1,0 +1,31 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace AestraUI {
+
+/**
+ * @brief Default label for a mixer channel that has no explicit name.
+ *
+ * Numbered from the *stable* channel id, matching TrackManager's own default.
+ * Numbering from a dense list position instead drifts the moment a channel is
+ * deleted or an id is restored, so the same channel would be labelled one way
+ * in the strip, another in the routing map and a third in the inspector.
+ *
+ * "Channel", not "Insert": an insert is an effect slot *on* a channel, and
+ * using the word for both makes the routing UI unreadable.
+ */
+inline std::string channelFallbackLabel(uint32_t channelId)
+{
+    return (channelId == 0) ? "MASTER" : ("Channel " + std::to_string(channelId));
+}
+
+/// User-facing name for a channel: its explicit name, or the stable fallback.
+inline std::string channelDisplayName(uint32_t channelId, const std::string& name)
+{
+    return name.empty() ? channelFallbackLabel(channelId) : name;
+}
+
+} // namespace AestraUI

--- a/AestraUI/Core/NUIDoubleClick.h
+++ b/AestraUI/Core/NUIDoubleClick.h
@@ -1,0 +1,64 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include <chrono>
+
+namespace AestraUI {
+
+/**
+ * @brief Double-click detection for platforms that never populate the event flag.
+ *
+ * Nothing in the tree assigns NUIMouseEvent::doubleClick, so any control that
+ * only checks that flag has a dead code path. Every control that wanted a
+ * double-click therefore paired up quick presses by hand, each with its own
+ * timestamp field and its own copy of the threshold — which is exactly how the
+ * window silently drifts apart between controls when one copy gets tuned.
+ *
+ * Usage:
+ * @code
+ *   if (event.pressed && event.button == NUIMouseButton::Left) {
+ *       if (m_clickTracker.registerPress() || event.doubleClick) {
+ *           resetToDefault();
+ *           return true;
+ *       }
+ *   }
+ * @endcode
+ *
+ * The platform flag is still worth OR-ing in: if a backend ever starts setting
+ * it, that path keeps working.
+ */
+class NUIDoubleClickTracker {
+public:
+    /// Window within which a second press counts as a double-click.
+    static constexpr long long kDoubleClickMs = 400;
+
+    /**
+     * @brief Record a press and report whether it completed a double-click.
+     *
+     * A detected double-click consumes the stored timestamp, so three rapid
+     * presses read as one double-click plus one single press rather than two
+     * overlapping double-clicks.
+     */
+    bool registerPress()
+    {
+        const long long now = nowMillis();
+        const bool isDouble = (m_lastPressMs != 0) && (now - m_lastPressMs < kDoubleClickMs);
+        m_lastPressMs = isDouble ? 0 : now;
+        return isDouble;
+    }
+
+    /// Forget any pending first press (e.g. when a drag starts instead).
+    void reset() { m_lastPressMs = 0; }
+
+private:
+    static long long nowMillis()
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    }
+
+    long long m_lastPressMs{0};
+};
+
+} // namespace AestraUI

--- a/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
+++ b/AestraUI/Graphics/OpenGL/NUIRendererGL.cpp
@@ -2678,8 +2678,17 @@ void NUIRendererGL::renderTextWithFont(const std::string& text, const NUIPoint& 
         const float gy = baseline - scaledBearingY; // Top of glyph
         const float xpos = std::round(gx);
         const float ypos = std::round(gy);
-        const float xposR = std::round(gx + w);
-        const float yposB = std::round(gy + h);
+        float xposR = std::round(gx + w);
+        float yposB = std::round(gy + h);
+
+        // Rounding all four edges collapses glyphs that are only about a pixel
+        // thick: the hyphen-minus rasterises to 7x1 at the small atlases, so
+        // round(gy) == round(gy + h) produced a zero-height quad and the glyph
+        // silently disappeared — taking the sign off every negative number
+        // whose baseline happened to land on the wrong side of .5. Keep at
+        // least one pixel whenever the source glyph has real coverage.
+        if (ch.width > 0 && xposR <= xpos) xposR = xpos + 1.0f;
+        if (ch.height > 0 && yposB <= ypos) yposB = ypos + 1.0f;
 
         minX = std::min(minX, xpos);
         minY = std::min(minY, ypos);

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -1117,6 +1117,10 @@ bool EffectChainRack::onMouseEvent(const NUIMouseEvent& event) {
 
         m_draggingSlotIndex = -1;
         m_isDraggingReorder = false;
+        // The rack shows every numbered slot while a reorder is in flight and
+        // collapses back to the populated rows the moment it ends, so a scroll
+        // offset that was legal during the drag can now point past the content.
+        clampScrollToContent();
         repaint();
         return true;
     }

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -812,11 +812,12 @@ void EffectChainRack::onRender(NUIRenderer& renderer) {
     auto bounds = getBounds();
     const auto& theme = NUIThemeManager::getInstance().getCurrentTheme();
 
+    // Background contrast groups the rack; it sits inside the inspector's own
+    // border, and each slot carries its own, so a third concentric outline here
+    // was pure nesting.
     renderer.fillRoundedRect(bounds, theme.radiusL, Colors::panelBackground().withAlpha(0.94f));
     renderer.fillRoundedRect({bounds.x, bounds.y, bounds.width, theme.layout.standardControlHeight},
                              theme.radiusL, Colors::panelTop().withAlpha(0.62f));
-    renderer.strokeRoundedRect(bounds, theme.radiusL, theme.layout.dividerWidth,
-                               Colors::panelBorder().withAlpha(0.84f));
 
     // Enable clipping
     renderer.setClipRect(bounds);

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -1052,8 +1052,10 @@ bool EffectChainRack::onMouseEvent(const NUIMouseEvent& event) {
     if (std::abs(event.wheelDelta) > 0.001f && m_activeKnobSlot == -1) {
         m_scrollOffset -= event.wheelDelta * 20.0f;
 
-        // Clamp scroll
-        float contentHeight = MAX_SLOTS * SLOT_HEIGHT + 10;
+        // Clamp against the rows actually drawn, not MAX_SLOTS. Bounding by ten
+        // rows let the offset run past the compact row set, and hitTestSlot then
+        // rejected the blank area — the rack looked empty until you scrolled back.
+        float contentHeight = visibleSlotCount() * SLOT_HEIGHT + 10;
         float viewHeight = getBounds().height;
         m_scrollOffset = std::clamp(m_scrollOffset, 0.0f, std::max(0.0f, contentHeight - viewHeight));
 
@@ -1319,8 +1321,17 @@ void EffectChainRack::setSlot(int index, const EffectSlotInfo& info) {
                 m_slots[index].bypassed = forcedState;
             }
         }
+        // Removing a plugin shrinks the drawn row set, which can leave the
+        // offset scrolled past the last row that still exists.
+        clampScrollToContent();
         repaint();
     }
+}
+
+void EffectChainRack::clampScrollToContent() {
+    const float contentHeight = visibleSlotCount() * SLOT_HEIGHT + 10.0f;
+    const float viewHeight = getBounds().height;
+    m_scrollOffset = std::clamp(m_scrollOffset, 0.0f, std::max(0.0f, contentHeight - viewHeight));
 }
 
 const EffectChainRack::EffectSlotInfo& EffectChainRack::getSlot(int index) const {

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -827,6 +827,20 @@ void EffectChainRack::onRender(NUIRenderer& renderer) {
         renderSlot(renderer, i, bounds.y + 8 + i * SLOT_HEIGHT - m_scrollOffset);
     }
 
+    // Deliberate empty state. Collapsing the rack to a single add row left a
+    // large blank region that read as unfinished rather than as "nothing here
+    // yet"; one quiet line under the add row names the state without
+    // reintroducing the column of dead slot outlines.
+    if (lastPopulatedSlot() < 0 && !m_isDraggingReorder) {
+        const float messageY = bounds.y + 8.0f + SLOT_HEIGHT - m_scrollOffset + 14.0f;
+        if (messageY < bounds.bottom() - 12.0f) {
+            renderer.drawTextCentered("No effects on this channel",
+                                      {bounds.x, messageY, bounds.width, 14.0f},
+                                      theme.fontSizeMicro,
+                                      Colors::textDisabled().withAlpha(0.55f));
+        }
+    }
+
     renderer.clearClipRect();
 
     // Render Drag Ghost

--- a/AestraUI/Widgets/PluginBrowserPanel.cpp
+++ b/AestraUI/Widgets/PluginBrowserPanel.cpp
@@ -821,7 +821,8 @@ void EffectChainRack::onRender(NUIRenderer& renderer) {
     // Enable clipping
     renderer.setClipRect(bounds);
 
-    for (int i = 0; i < MAX_SLOTS; ++i) {
+    const int visible = visibleSlotCount();
+    for (int i = 0; i < visible; ++i) {
         renderSlot(renderer, i, bounds.y + 8 + i * SLOT_HEIGHT - m_scrollOffset);
     }
 
@@ -913,12 +914,14 @@ void EffectChainRack::renderSlot(NUIRenderer& renderer, int index, float yOffset
     const float rowH = chipH; // 14 px — same height as the index chip
 
     if (slot.isEmpty) {
-        // Empty rows surface the affordance only on hover; the recessed row and
-        // subtle centre line already signal an available drop target, so the
-        // redundant em-dash placeholder is gone.
-        if (isHovered) {
+        // The single trailing empty row is the rack's call to action, so it is
+        // always labelled. Spare slots exposed during a reorder drag stay quiet
+        // and only name themselves on hover.
+        const bool isAddRow = (index == lastPopulatedSlot() + 1);
+        if (isAddRow || isHovered) {
             const NUIRect textRect{textX, slotMid - rowH * 0.5f, textW, rowH};
-            renderer.drawTextCentered("+ Add Insert", textRect, theme.fontSizeXS, Colors::textPrimary());
+            renderer.drawTextCentered("+ Add Insert", textRect, theme.fontSizeXS,
+                                      Colors::textPrimary());
         }
     } else {
         // Bypass uses color plus an explicit badge so it cannot be confused with
@@ -1337,6 +1340,24 @@ void EffectChainRack::setOnSlotMixChanged(std::function<void(int, float)> callba
     m_onSlotMixChanged = std::move(callback);
 }
 
+int EffectChainRack::lastPopulatedSlot() const {
+    for (int i = MAX_SLOTS - 1; i >= 0; --i) {
+        if (!m_slots[i].isEmpty) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int EffectChainRack::visibleSlotCount() const {
+    // A reorder drag needs every numbered target available as a drop site.
+    if (m_isDraggingReorder) {
+        return MAX_SLOTS;
+    }
+    // Populated slots, plus exactly one "+ Add insert" row.
+    return std::min(MAX_SLOTS, lastPopulatedSlot() + 2);
+}
+
 int EffectChainRack::hitTestSlot(float y) const {
     auto bounds = getBounds();
     float relativeY = y - bounds.y - 8 + m_scrollOffset;
@@ -1345,7 +1366,9 @@ int EffectChainRack::hitTestSlot(float y) const {
     }
 
     int index = static_cast<int>(std::floor(relativeY / SLOT_HEIGHT));
-    if (index >= 0 && index < MAX_SLOTS) {
+    // Only rows that are actually drawn are hittable — otherwise clicking the
+    // blank area below the rack silently targeted an invisible slot.
+    if (index >= 0 && index < visibleSlotCount()) {
         return index;
     }
     return -1;

--- a/AestraUI/Widgets/PluginBrowserPanel.h
+++ b/AestraUI/Widgets/PluginBrowserPanel.h
@@ -339,6 +339,11 @@ private:
      */
     int visibleSlotCount() const;
 
+    /// Keep m_scrollOffset within the rows actually drawn. The visible row set
+    /// shrinks when a plugin is removed or a reorder drag ends, and a stale
+    /// offset leaves the rack looking empty.
+    void clampScrollToContent();
+
     NUIPlatformBridge* m_platformBridge = nullptr;
     std::array<EffectSlotInfo, MAX_SLOTS> m_slots;
     std::array<int, MAX_SLOTS> m_bypassOverride; // -1=None, 0=Active, 1=Bypassed

--- a/AestraUI/Widgets/PluginBrowserPanel.h
+++ b/AestraUI/Widgets/PluginBrowserPanel.h
@@ -326,6 +326,19 @@ private:
     int hitTestSlot(float y) const;
     NUIRect slotRectForTop(float slotY) const;
 
+    /// Index of the last slot holding a plugin, or -1 when the rack is empty.
+    int lastPopulatedSlot() const;
+
+    /**
+     * @brief Rows the rack actually shows: every populated slot plus one
+     *        "+ Add insert" row.
+     *
+     * Drawing all MAX_SLOTS produced a column of identical empty outlines that
+     * carried no information. The spare slots are revealed only while a reorder
+     * drag is in flight, when numbered drop targets are genuinely useful.
+     */
+    int visibleSlotCount() const;
+
     NUIPlatformBridge* m_platformBridge = nullptr;
     std::array<EffectSlotInfo, MAX_SLOTS> m_slots;
     std::array<int, MAX_SLOTS> m_bypassOverride; // -1=None, 0=Active, 1=Bypassed

--- a/AestraUI/Widgets/UIItemSelector.cpp
+++ b/AestraUI/Widgets/UIItemSelector.cpp
@@ -107,18 +107,33 @@ void UIItemSelector::commitEditing() {
             // Check if user just typed a number "7"
             int trackNum = std::stoi(text);
             
-            // Prefer current "Channel NUM" labels while accepting saved legacy names.
-            const std::string channelPrefix = "channel " + std::to_string(trackNum);
-            const std::string legacyInsertPrefix = "insert " + std::to_string(trackNum);
-            const std::string legacyTrackPrefix = "track " + std::to_string(trackNum);
-            for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
-                std::string item = m_items[i];
-                std::transform(item.begin(), item.end(), item.begin(), ::tolower);
-                if (item.find(channelPrefix) == 0 || item.find(legacyInsertPrefix) == 0
-                    || item.find(legacyTrackPrefix) == 0) {
-                    matchIndex = i;
-                    break;
+            // "7" must not match "Channel 70", so the number has to end at a
+            // non-digit (or end of string) rather than merely prefix-match.
+            const std::string numText = std::to_string(trackNum);
+            auto matchesLabel = [&numText](const std::string& lowerItem,
+                                           const std::string& prefix) {
+                const std::string needle = prefix + numText;
+                if (lowerItem.rfind(needle, 0) != 0) {
+                    return false;
                 }
+                if (lowerItem.size() == needle.size()) {
+                    return true;
+                }
+                return std::isdigit(static_cast<unsigned char>(lowerItem[needle.size()])) == 0;
+            };
+
+            // Current labels win outright: a single pass would otherwise let a
+            // legacy "Insert 7" earlier in the list beat the real "Channel 7".
+            for (const char* prefix : {"channel ", "insert ", "track "}) {
+                for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
+                    std::string item = m_items[i];
+                    std::transform(item.begin(), item.end(), item.begin(), ::tolower);
+                    if (matchesLabel(item, prefix)) {
+                        matchIndex = i;
+                        break;
+                    }
+                }
+                if (matchIndex != -1) break;
             }
         } catch (...) {
             // Not a number

--- a/AestraUI/Widgets/UIItemSelector.cpp
+++ b/AestraUI/Widgets/UIItemSelector.cpp
@@ -107,13 +107,15 @@ void UIItemSelector::commitEditing() {
             // Check if user just typed a number "7"
             int trackNum = std::stoi(text);
             
-            // Prefer current "Insert NUM" labels while accepting saved legacy names.
-            const std::string insertPrefix = "insert " + std::to_string(trackNum);
+            // Prefer current "Channel NUM" labels while accepting saved legacy names.
+            const std::string channelPrefix = "channel " + std::to_string(trackNum);
+            const std::string legacyInsertPrefix = "insert " + std::to_string(trackNum);
             const std::string legacyTrackPrefix = "track " + std::to_string(trackNum);
             for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
                 std::string item = m_items[i];
                 std::transform(item.begin(), item.end(), item.begin(), ::tolower);
-                if (item.find(insertPrefix) == 0 || item.find(legacyTrackPrefix) == 0) {
+                if (item.find(channelPrefix) == 0 || item.find(legacyInsertPrefix) == 0
+                    || item.find(legacyTrackPrefix) == 0) {
                     matchIndex = i;
                     break;
                 }

--- a/AestraUI/Widgets/UIItemSelector.cpp
+++ b/AestraUI/Widgets/UIItemSelector.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <algorithm>
 #include <chrono>
+#include <stdexcept>
 
 namespace AestraUI {
 
@@ -101,12 +102,23 @@ void UIItemSelector::commitEditing() {
         }
     }
     
-    // 2. Mixer insert number parsing
+    // 2. Mixer channel number parsing
     if (matchIndex == -1) {
+        // Only the conversion is guarded. A blanket catch here would also
+        // swallow failures from the matching loop below and report them as
+        // "not a number".
+        int trackNum = 0;
+        bool isNumber = true;
         try {
             // Check if user just typed a number "7"
-            int trackNum = std::stoi(text);
-            
+            trackNum = std::stoi(text);
+        } catch (const std::invalid_argument&) {
+            isNumber = false;
+        } catch (const std::out_of_range&) {
+            isNumber = false;
+        }
+
+        if (isNumber) {
             // "7" must not match "Channel 70", so the number has to end at a
             // non-digit (or end of string) rather than merely prefix-match.
             const std::string numText = std::to_string(trackNum);
@@ -135,8 +147,6 @@ void UIItemSelector::commitEditing() {
                 }
                 if (matchIndex != -1) break;
             }
-        } catch (...) {
-            // Not a number
         }
     }
     

--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -167,11 +167,9 @@ void UIMixerButtonRow::onRender(NUIRenderer& renderer)
         // Flat active state (no glow): the coloured fill + border + white icon
         // carry the on-state, matching the flat-active language used elsewhere.
         renderer.fillRoundedRect(visualRect, BTN_RADIUS, bg);
+        // Single outline — the fill contrast carries the state, and the inset
+        // bevel only added another concentric edge.
         renderer.strokeRoundedRect(visualRect, BTN_RADIUS, 1.0f, border);
-        renderer.strokeRoundedRect({visualRect.x + 1.0f, visualRect.y + 1.0f, visualRect.width - 2.0f, visualRect.height - 2.0f},
-                                   std::max(0.0f, BTN_RADIUS - 1.0f),
-                                   1.0f,
-                                   NUIColor::white().withAlpha(0.025f));
         // Centre the glyph in the raw button bounds (not the half-pixel-inset
         // visualRect) so the offsets stay symmetric integers — matches the
         // track-header control icons exactly.

--- a/AestraUI/Widgets/UIMixerFXSummary.cpp
+++ b/AestraUI/Widgets/UIMixerFXSummary.cpp
@@ -80,11 +80,10 @@ void UIMixerFXSummary::onRender(NUIRenderer& renderer)
     const NUIColor border = hasFx
         ? m_accent.withAlpha(m_hovered ? 0.28f : 0.20f)
         : (m_hovered ? m_borderHover : m_border);
+    // One outline only. The inset bevel stroke that used to sit inside this one
+    // added a second concentric edge to a control that already lives inside a
+    // bordered strip.
     renderer.strokeRoundedRect(visualRect, RADIUS, 1.0f, border);
-    renderer.strokeRoundedRect({visualRect.x + 1.0f, visualRect.y + 1.0f, visualRect.width - 2.0f, visualRect.height - 2.0f},
-                               std::max(0.0f, RADIUS - 1.0f),
-                               1.0f,
-                               NUIColor::white().withAlpha(0.025f));
 
     const NUIColor text = hasFx ? m_textPrimary : (m_hovered ? m_textPrimary.withAlpha(0.92f) : m_textSecondary);
     const NUIRect chipRect{visualRect.x + 8.0f, visualRect.y + (visualRect.height - 10.0f) * 0.5f, 18.0f, 10.0f};

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -302,6 +302,7 @@ void UIMixerFader::beginEdit()
     // Printable characters are routed to the globally focused component, so the
     // field must take focus or it will never see any input.
     m_textInput->setFocused(true);
+    m_textInput->setCaretPosition(static_cast<int>(seed.length()));
     m_textInput->selectAll();
     repaint();
 }

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -154,6 +154,10 @@ void UIMixerFader::renderScale(NUIRenderer& renderer, float trackX, float trackW
 
 void UIMixerFader::onRender(NUIRenderer& renderer)
 {
+    // Safe point to free a committed/cancelled editor: we are no longer inside
+    // any NUITextInput callback.
+    m_retiredInput.reset();
+
     auto bounds = getBounds();
 
     // Track area
@@ -301,6 +305,8 @@ void UIMixerFader::commitEdit()
     m_editing = false;
     if (m_textInput) {
         removeChild(m_textInput);
+        // Park, don't free: this can run from the editor's own onFocusLost.
+        m_retiredInput = std::move(m_textInput);
         m_textInput.reset();
     }
 
@@ -327,6 +333,8 @@ void UIMixerFader::cancelEdit()
     m_editing = false;
     if (m_textInput) {
         removeChild(m_textInput);
+        // Park, don't free: this can run from the editor's own onFocusLost.
+        m_retiredInput = std::move(m_textInput);
         m_textInput.reset();
     }
     repaint();

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -273,7 +273,18 @@ void UIMixerFader::beginEdit()
 
     auto& theme = NUIThemeManager::getInstance();
     m_textInput = std::make_shared<NUITextInput>(seed);
-    m_textInput->setBounds(readoutRect());
+
+    // NUITextInput always draws its text and caret at the theme's "m" size, and
+    // sizes the caret to that font's full line height. The 14 px readout band is
+    // shorter than that, so the caret overflowed the field. Give the editor the
+    // height the font actually needs; it grows down over the top of the track,
+    // which is fine for a transient editor.
+    const float fontM = theme.getFontSize("m");
+    const float editH = std::max(readoutRect().height, std::ceil(fontM * 1.9f) + 4.0f);
+    const NUIRect readout = readoutRect();
+    m_textInput->setBounds(NUIRect{readout.x, getBounds().y, readout.width, editH});
+    // Default 8 px padding on each side leaves almost nothing in a ~66 px strip.
+    m_textInput->setPadding(4.0f);
     m_textInput->setInputType(NUITextInput::InputType::Number);
     m_textInput->setJustification(NUITextInput::Justification::Center);
     m_textInput->setTextColor(theme.getColor("textPrimary"));
@@ -338,6 +349,17 @@ void UIMixerFader::cancelEdit()
         m_textInput.reset();
     }
     repaint();
+}
+
+void UIMixerFader::dismissEditAt(const NUIPoint& position)
+{
+    if (!m_editing) {
+        return;
+    }
+    if (getBounds().contains(position)) {
+        return;
+    }
+    commitEdit();
 }
 
 bool UIMixerFader::onKeyEvent(const NUIKeyEvent& event)

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -3,22 +3,40 @@
 
 #include "NUIThemeSystem.h"
 #include "NUIRenderer.h"
+#include "NUITextInput.h"
 #include "../Platform/NUIPlatformBridge.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cmath>
+#include <exception>
+#include <string>
 
 namespace AestraUI {
 
 namespace {
     constexpr float TRACK_RADIUS = 4.0f;
     constexpr float HANDLE_RADIUS = 4.0f;
-    constexpr float HANDLE_HEIGHT = 18.0f;
+    constexpr float HANDLE_HEIGHT = 22.0f;  // taller cap: a real grab target
+    constexpr float HANDLE_WIDTH = 36.0f;
+    constexpr float TRACK_WIDTH = 6.0f;     // was 4 — thin enough to look like a meter
     constexpr float TOP_PAD = 18.0f;    // room for fixed dB readout at top
     constexpr float BOTTOM_PAD = 6.0f;   // minimal padding below track
     constexpr float SNAP_DB = 0.5f;
     constexpr float DRAG_SLOP = 1.5f;
+
+    // Restrained scale: unity plus a few orientation marks. Unity (0 dB) is the
+    // only one that gets emphasis and a label.
+    constexpr float SCALE_TICKS[] = {6.0f, 0.0f, -6.0f, -12.0f, -24.0f, -48.0f};
+
+    long long nowMillis()
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    }
 }
 
 UIMixerFader::UIMixerFader()
@@ -32,13 +50,18 @@ void UIMixerFader::cacheThemeColors()
     auto& theme = NUIThemeManager::getInstance();
     // Track: Deep Glass Slot
     m_trackBg = theme.getColor("meterBackground").withAlpha(0.72f);
-    // Fill: Gradient handled in render
-    m_trackFg = theme.getColor("accentPrimary"); 
+    // Rail fill is deliberately NEUTRAL. Colouring it with the channel accent
+    // made the fader read as a second level meter — the fader shows where the
+    // control is set, the meter beside it shows what the signal is doing.
+    m_railFill = theme.getColor("textPrimary").withAlpha(0.55f);
+    m_accent = theme.getColor("accentPrimary");
     m_handle = theme.getColor("backgroundSecondary"); // Handle Core
     m_handleHover = theme.getColor("textPrimary");    // Handle Active
     m_text = theme.getColor("textPrimary");
     m_textSecondary = theme.getColor("textSecondary");
     m_border = theme.getColor("borderStrong");
+    m_tick = theme.getColor("textSecondary").withAlpha(0.34f);
+    m_tickUnity = theme.getColor("textPrimary").withAlpha(0.72f);
     m_tooltipBg = theme.getColor("elevatedPanel").withAlpha(0.98f);
 }
 
@@ -68,7 +91,7 @@ void UIMixerFader::updateCachedText()
     }
 
     char buf[16];
-    std::snprintf(buf, sizeof(buf), "%.1f", m_valueDb);
+    std::snprintf(buf, sizeof(buf), "%.1f dB", m_valueDb);
     m_cachedText = buf;
 }
 
@@ -88,6 +111,47 @@ void UIMixerFader::setValueDb(float db)
     }
 }
 
+NUIRect UIMixerFader::readoutRect() const
+{
+    const auto bounds = getBounds();
+    return NUIRect{bounds.x, bounds.y + 2.0f, bounds.width, TOP_PAD - 4.0f};
+}
+
+float UIMixerFader::dbToY(float db, float trackTop, float trackHeight) const
+{
+    const float norm = (db - m_minDb) / std::max(1e-3f, (m_maxDb - m_minDb));
+    return trackTop + (1.0f - std::clamp(norm, 0.0f, 1.0f)) * trackHeight;
+}
+
+void UIMixerFader::renderScale(NUIRenderer& renderer, float trackX, float trackWidth,
+                               float trackTop, float trackHeight)
+{
+    // Ticks flank the rail on both sides so the cap never hides the scale.
+    constexpr float TICK_LEN = 4.0f;
+    constexpr float TICK_GAP = 3.0f;
+    const float leftEnd = trackX - TICK_GAP;
+    const float rightStart = trackX + trackWidth + TICK_GAP;
+
+    for (float db : SCALE_TICKS) {
+        if (db > m_maxDb || db < m_minDb) continue;
+
+        const bool unity = (std::abs(db) < 0.01f);
+        const float y = dbToY(db, trackTop, trackHeight);
+        const float len = unity ? TICK_LEN + 2.0f : TICK_LEN;
+        const float thickness = unity ? 2.0f : 1.0f;
+        const NUIColor color = unity ? m_tickUnity : m_tick;
+
+        renderer.fillRect(NUIRect{leftEnd - len, y - thickness * 0.5f, len, thickness}, color);
+        renderer.fillRect(NUIRect{rightStart, y - thickness * 0.5f, len, thickness}, color);
+    }
+
+    // Unity gets a label when there is room for it (master strip / wide layouts).
+    if (m_showScaleLabels && m_maxDb >= 0.0f && m_minDb <= 0.0f) {
+        const float y = dbToY(0.0f, trackTop, trackHeight);
+        renderer.drawText("0", NUIPoint{rightStart + TICK_LEN + 4.0f, y - 5.0f}, 9.0f, m_tickUnity);
+    }
+}
+
 void UIMixerFader::onRender(NUIRenderer& renderer)
 {
     auto bounds = getBounds();
@@ -97,68 +161,73 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
     const float trackBottom = bounds.y + bounds.height - BOTTOM_PAD;
     const float trackHeight = std::max(1.0f, trackBottom - trackTop);
 
-    // Narrow rail (4 px) centered in strip
-    const float trackWidth = 4.0f;
+    const float trackWidth = TRACK_WIDTH;
     const float trackX = bounds.x + (bounds.width - trackWidth) * 0.5f;
     NUIRect trackRect{trackX, trackTop, trackWidth, trackHeight};
 
-    // 1. Track Background (deep recessed slot)
-    renderer.fillRoundedRect(trackRect, 2.0f, m_trackBg);
-    renderer.strokeRoundedRect(trackRect, 2.0f, 1.0f, m_border.withAlpha(0.60f));
+    // 1. Scale first, so the rail and cap sit on top of it.
+    renderScale(renderer, trackX, trackWidth, trackTop, trackHeight);
 
-    // 2. Filled Portion (subtle, no wide glow)
+    // 2. Track Background (deep recessed slot)
+    renderer.fillRoundedRect(trackRect, 3.0f, m_trackBg);
+
+    // 3. Filled Portion — neutral. This is control state, not signal.
     const float norm = (m_valueDb - m_minDb) / std::max(1e-3f, (m_maxDb - m_minDb));
     const float filledH = std::clamp(norm, 0.0f, 1.0f) * trackHeight;
 
     if (filledH > 0.0f) {
         NUIRect fillRect{trackX, trackBottom - filledH, trackWidth, filledH};
-        // Core fill (slightly wider than track for crisp edge)
-        renderer.fillRoundedRect(fillRect, 2.0f, m_trackFg.withAlpha(0.85f));
-        // Very subtle inner glow (2px bleed)
-        renderer.fillRoundedRect(
-            NUIRect{fillRect.x - 1, fillRect.y, fillRect.width + 2, fillRect.height},
-            3.0f,
-            m_trackFg.withAlpha(0.15f)
-        );
+        renderer.fillRoundedRect(fillRect, 3.0f, m_railFill);
     }
 
-    // 3. Fader Handle (distinct grab block)
+    // 4. Fader Handle (distinct grab block)
     const float handleY = std::clamp(trackBottom - filledH - HANDLE_HEIGHT * 0.5f,
                                      trackTop - HANDLE_HEIGHT * 0.5f,
                                      trackBottom - HANDLE_HEIGHT * 0.5f);
 
-    // Handle: wider than track, clear visual weight
-    const float handleW = 32.0f;
+    const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
     const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
     const float handleH = HANDLE_HEIGHT;
 
     NUIRect handleRect{handleX, handleY, handleW, handleH};
     float handleRad = 4.0f;
 
-    // Handle Body (dark surface) — flat, no drop shadow; the border + slit
+    // Handle Body (dark surface) — flat, no drop shadow; the border + grip
     // give it enough definition.
     renderer.fillRoundedRect(handleRect, handleRad, m_handle.withAlpha(0.98f));
 
-    // Handle Border (accent when active/hovered, subtle white otherwise)
+    // Handle Border — the one place the per-channel accent appears on the fader,
+    // and only while the control is actually engaged.
     bool handleActive = isHovered() || m_dragging;
-    NUIColor handleBorder = handleActive ? m_trackFg : m_border;
+    NUIColor handleBorder = handleActive ? m_accent : m_border;
     renderer.strokeRoundedRect(handleRect, handleRad, 1.0f, handleBorder);
 
-    // Center accent line (the "light slit")
-    float slitW = 16.0f;
-    float slitH = 3.0f;
-    renderer.fillRoundedRect(
-        NUIRect{handleX + (handleW - slitW)*0.5f, handleY + (handleH - slitH)*0.5f, slitW, slitH},
-        1.5f,
-        handleActive ? m_trackFg : m_textSecondary
-    );
+    // Grip: three short lines read as "grab me" better than a single slit.
+    const float gripW = std::min(18.0f, handleW - 10.0f);
+    const float gripX = handleX + (handleW - gripW) * 0.5f;
+    const float gripCy = handleY + handleH * 0.5f;
+    const NUIColor gripColor = handleActive ? m_accent : m_textSecondary.withAlpha(0.85f);
+    for (int i = -1; i <= 1; ++i) {
+        renderer.fillRoundedRect(
+            NUIRect{gripX, gripCy + static_cast<float>(i) * 4.0f - 1.0f, gripW, 2.0f},
+            1.0f,
+            i == 0 ? gripColor : gripColor.withAlpha(gripColor.a * 0.45f));
+    }
 
-    // 4. Fixed dB readout at top of fader area (not attached to handle)
-    const float fontSize = 10.5f;
-    NUIRect textRect{bounds.x, bounds.y + 2.0f, bounds.width, TOP_PAD - 4.0f};
-    renderer.drawTextCentered(m_cachedText, textRect, fontSize, m_textSecondary);
+    // 5. dB readout at top — click target for exact entry.
+    if (m_editing && m_textInput) {
+        renderChildren(renderer);
+    } else {
+        const float fontSize = 10.5f;
+        const NUIRect textRect = readoutRect();
+        if (isHovered()) {
+            renderer.fillRoundedRect(textRect, 3.0f, m_trackBg.withAlpha(0.55f));
+        }
+        renderer.drawTextCentered(m_cachedText, textRect, fontSize,
+                                  isHovered() ? m_text : m_textSecondary);
+    }
 
-    // 5. Drag Value Tooltip (only while dragging)
+    // 6. Drag Value Tooltip (only while dragging)
     if (m_dragging) {
         const float tipW = 38.0f;
         const float tipH = 18.0f;
@@ -171,7 +240,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
         }
 
         renderer.fillRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, m_tooltipBg);
-        renderer.strokeRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, 1.0f, m_trackFg.withAlpha(0.5f));
+        renderer.strokeRoundedRect({tipX, tipY, tipW, tipH}, 3.0f, 1.0f, m_accent.withAlpha(0.5f));
         renderer.drawTextCentered(m_cachedText, {tipX, tipY, tipW, tipH}, 10.5f, m_text);
     }
 }
@@ -179,6 +248,96 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
 void UIMixerFader::setPlatformBridge(NUIPlatformBridge* bridge)
 {
     m_platformBridge = bridge;
+}
+
+void UIMixerFader::beginEdit()
+{
+    if (m_editing && m_textInput) {
+        return;
+    }
+
+    m_editing = true;
+
+    // Seed with the plain number so the user can just type over it. "−∞" is not
+    // round-trippable, so an inaudible fader starts from an empty field.
+    std::string seed;
+    if (m_valueDb > FADER_FLOOR_THRESHOLD) {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "%.1f", m_valueDb);
+        seed = buf;
+    }
+
+    auto& theme = NUIThemeManager::getInstance();
+    m_textInput = std::make_shared<NUITextInput>(seed);
+    m_textInput->setBounds(readoutRect());
+    m_textInput->setInputType(NUITextInput::InputType::Number);
+    m_textInput->setJustification(NUITextInput::Justification::Center);
+    m_textInput->setTextColor(theme.getColor("textPrimary"));
+    m_textInput->setBackgroundColor(theme.getColor("inputBgDefault"));
+    m_textInput->setBorderColor(theme.getColor("inputBorderFocus"));
+    m_textInput->setBorderWidth(1.0f);
+    m_textInput->setBorderRadius(3.0f);
+    m_textInput->setFocusedBorderColor(m_accent);
+
+    m_textInput->setOnReturnKey([this]() { commitEdit(); });
+    m_textInput->setOnEscapeKey([this]() { cancelEdit(); });
+    m_textInput->setOnFocusLost([this]() { commitEdit(); });
+
+    addChild(m_textInput);
+    // Printable characters are routed to the globally focused component, so the
+    // field must take focus or it will never see any input.
+    m_textInput->setFocused(true);
+    m_textInput->selectAll();
+    repaint();
+}
+
+void UIMixerFader::commitEdit()
+{
+    if (!m_editing) {
+        return;
+    }
+
+    const std::string entered = m_textInput ? m_textInput->getText() : std::string{};
+    m_editing = false;
+    if (m_textInput) {
+        removeChild(m_textInput);
+        m_textInput.reset();
+    }
+
+    // An empty field means "silence"; anything unparseable leaves the value alone.
+    if (entered.find_first_not_of(" \t") == std::string::npos) {
+        setValueDb(m_minDb);
+    } else {
+        try {
+            setValueDb(std::stof(entered));
+        } catch (const std::exception&) {
+            // Keep the current value on garbage input.
+        }
+    }
+
+    repaint();
+}
+
+void UIMixerFader::cancelEdit()
+{
+    if (!m_editing) {
+        return;
+    }
+
+    m_editing = false;
+    if (m_textInput) {
+        removeChild(m_textInput);
+        m_textInput.reset();
+    }
+    repaint();
+}
+
+bool UIMixerFader::onKeyEvent(const NUIKeyEvent& event)
+{
+    if (m_editing && m_textInput) {
+        return m_textInput->onKeyEvent(event);
+    }
+    return false;
 }
 
 UIMixerFader::~UIMixerFader() {
@@ -194,15 +353,41 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
     if (!isVisible() || !isEnabled()) return false;
 
     auto bounds = getBounds();
+
+    // While the value is being typed, the field owns the pointer.
+    if (m_editing && m_textInput) {
+        if (m_textInput->onMouseEvent(event)) {
+            return true;
+        }
+        if (event.pressed && !bounds.contains(event.position)) {
+            commitEdit();
+        }
+        return false;
+    }
+
     if (!event.cursorCaptured) {
         setHovered(bounds.contains(event.position));
     }
     if (!bounds.contains(event.position) && !m_dragging) return false;
 
-    // Double-click reset
-    if (event.doubleClick && event.pressed && event.button == NUIMouseButton::Left) {
-        setValueDb(m_defaultDb);
-        return true;
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        // The platform never populates event.doubleClick, so pair up quick
+        // presses ourselves — without this the reset below is dead code.
+        const long long nowMs = nowMillis();
+        const bool isDoubleClick = (nowMs - m_lastClickTimeMs < 400) || event.doubleClick;
+        m_lastClickTimeMs = nowMs;
+
+        // The readout is an entry field, not part of the track: clicking it used
+        // to slam the fader to whatever value that Y mapped to.
+        if (readoutRect().contains(event.position)) {
+            beginEdit();
+            return true;
+        }
+
+        if (isDoubleClick) {
+            setValueDb(m_defaultDb);
+            return true;
+        }
     }
 
     if (event.pressed && event.button == NUIMouseButton::Left) {
@@ -217,7 +402,7 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
         const float handleY = std::clamp(trackBottom - filledH - HANDLE_HEIGHT * 0.5f,
                                          trackTop - HANDLE_HEIGHT * 0.5f,
                                          trackBottom - HANDLE_HEIGHT * 0.5f);
-        const float handleW = 32.0f;
+        const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
         const float handleH = HANDLE_HEIGHT;
         const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
         const NUIRect handleRect{handleX, handleY, handleW, handleH};
@@ -258,7 +443,7 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
             const float handleY = std::clamp(trackBottom - filledH - HANDLE_HEIGHT * 0.5f,
                                              trackTop - HANDLE_HEIGHT * 0.5f,
                                              trackBottom - HANDLE_HEIGHT * 0.5f);
-            const float handleW = 32.0f;
+            const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
             const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
 
             // End capture: service warps to the handle, unhides, releases

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -31,12 +31,6 @@ namespace {
     // only one that gets emphasis and a label.
     constexpr float SCALE_TICKS[] = {6.0f, 0.0f, -6.0f, -12.0f, -24.0f, -48.0f};
 
-    long long nowMillis()
-    {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-                   std::chrono::steady_clock::now().time_since_epoch())
-            .count();
-    }
 }
 
 UIMixerFader::UIMixerFader()
@@ -327,7 +321,14 @@ void UIMixerFader::commitEdit()
         setValueDb(m_minDb);
     } else {
         try {
-            setValueDb(std::stof(entered));
+            // std::stof accepts "nan"/"inf"/"-inf" without throwing. clampDb
+            // happens to swallow those today only because of its comparison
+            // order — reject them explicitly so the guard survives a future
+            // edit to clampDb.
+            const float parsed = std::stof(entered);
+            if (std::isfinite(parsed)) {
+                setValueDb(parsed);
+            }
         } catch (const std::exception&) {
             // Keep the current value on garbage input.
         }
@@ -402,11 +403,9 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
     if (!bounds.contains(event.position) && !m_dragging) return false;
 
     if (event.pressed && event.button == NUIMouseButton::Left) {
-        // The platform never populates event.doubleClick, so pair up quick
-        // presses ourselves — without this the reset below is dead code.
-        const long long nowMs = nowMillis();
-        const bool isDoubleClick = (nowMs - m_lastClickTimeMs < 400) || event.doubleClick;
-        m_lastClickTimeMs = nowMs;
+        // The platform never populates event.doubleClick, so presses are paired
+        // up by the shared tracker — without this the reset below is dead code.
+        const bool isDoubleClick = m_clickTracker.registerPress() || event.doubleClick;
 
         // The readout is an entry field, not part of the track: clicking it used
         // to slam the fader to whatever value that Y mapped to.

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -12,6 +12,8 @@
 #include <cstdlib>
 #include <cmath>
 #include <exception>
+#include <locale>
+#include <sstream>
 #include <string>
 
 namespace AestraUI {
@@ -105,6 +107,13 @@ void UIMixerFader::setValueDb(float db)
     }
 }
 
+float UIMixerFader::handleWidth() const
+{
+    // The drawn handle and the drag hit-box must be the same rectangle; keeping
+    // one formula is what guarantees that.
+    return std::min(HANDLE_WIDTH, getBounds().width - 4.0f);
+}
+
 NUIRect UIMixerFader::readoutRect() const
 {
     const auto bounds = getBounds();
@@ -183,7 +192,7 @@ void UIMixerFader::onRender(NUIRenderer& renderer)
                                      trackTop - HANDLE_HEIGHT * 0.5f,
                                      trackBottom - HANDLE_HEIGHT * 0.5f);
 
-    const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
+    const float handleW = handleWidth();
     const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
     const float handleH = HANDLE_HEIGHT;
 
@@ -320,17 +329,20 @@ void UIMixerFader::commitEdit()
     if (entered.find_first_not_of(" \t") == std::string::npos) {
         setValueDb(m_minDb);
     } else {
-        try {
-            // std::stof accepts "nan"/"inf"/"-inf" without throwing. clampDb
-            // happens to swallow those today only because of its comparison
-            // order — reject them explicitly so the guard survives a future
-            // edit to clampDb.
-            const float parsed = std::stof(entered);
-            if (std::isfinite(parsed)) {
-                setValueDb(parsed);
-            }
-        } catch (const std::exception&) {
-            // Keep the current value on garbage input.
+        // Parsed in the C locale, not the process locale. A DAW loads arbitrary
+        // third-party plugin binaries, and a plugin that calls
+        // setlocale(LC_ALL, "") on a comma-decimal system would otherwise make
+        // std::stof read "-6.5" as -6.
+        std::istringstream stream(entered);
+        stream.imbue(std::locale::classic());
+        float parsed = 0.0f;
+        stream >> parsed;
+
+        // Reject "nan"/"inf": clampDb happens to swallow those today only
+        // because of its comparison order, and that is not a guarantee worth
+        // depending on. Garbage input leaves the current value alone.
+        if (!stream.fail() && std::isfinite(parsed)) {
+            setValueDb(parsed);
         }
     }
 
@@ -377,6 +389,17 @@ UIMixerFader::~UIMixerFader() {
     // dangling owner and the cursor is never stranded hidden.
     if (m_platformBridge && m_platformBridge->isCursorCaptureOwner(this)) {
         m_platformBridge->cancelCursorCapture();
+    }
+
+    // Torn down mid-edit: the editor's callbacks capture `this`, and it can
+    // outlive the fader — removeChild() defers while an event is dispatching,
+    // parking a strong reference elsewhere. Nothing fires focus loss during
+    // teardown today, so this is not a live crash; dropping the callbacks makes
+    // that independent of a future change to component destruction order.
+    if (m_textInput) {
+        m_textInput->setOnReturnKey(nullptr);
+        m_textInput->setOnEscapeKey(nullptr);
+        m_textInput->setOnFocusLost(nullptr);
     }
 }
 
@@ -432,7 +455,7 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
         const float handleY = std::clamp(trackBottom - filledH - HANDLE_HEIGHT * 0.5f,
                                          trackTop - HANDLE_HEIGHT * 0.5f,
                                          trackBottom - HANDLE_HEIGHT * 0.5f);
-        const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
+        const float handleW = handleWidth();
         const float handleH = HANDLE_HEIGHT;
         const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
         const NUIRect handleRect{handleX, handleY, handleW, handleH};
@@ -473,7 +496,7 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
             const float handleY = std::clamp(trackBottom - filledH - HANDLE_HEIGHT * 0.5f,
                                              trackTop - HANDLE_HEIGHT * 0.5f,
                                              trackBottom - HANDLE_HEIGHT * 0.5f);
-            const float handleW = std::min(HANDLE_WIDTH, bounds.width - 4.0f);
+            const float handleW = handleWidth();
             const float handleX = bounds.x + (bounds.width - handleW) * 0.5f;
 
             // End capture: service warps to the handle, unhides, releases

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -50,6 +50,11 @@ public:
     /// Wider scale/readout treatment for the master strip.
     void setShowScaleLabels(bool show) { m_showScaleLabels = show; repaint(); }
 
+    /// At or below this, a gain readout shows "−∞" rather than a number.
+    /// Public because any readout of the same value has to agree with the
+    /// fader — two copies of the threshold drift the moment one is tuned.
+    static constexpr float FADER_FLOOR_THRESHOLD = -60.0f;
+
     bool isDragging() const { return m_dragging; }
     bool isEditing() const { return m_editing; }
 
@@ -116,11 +121,12 @@ private:
     NUIColor m_tickUnity;
     NUIColor m_tooltipBg;
 
-    static constexpr float FADER_FLOOR_THRESHOLD = -60.0f;
-
     void cacheThemeColors();
     void updateCachedText();
     float clampDb(float db) const;
+
+    /// Drawn width of the handle, and therefore its drag hit-box.
+    float handleWidth() const;
 
     /// Readout band at the top of the fader — click target for inline entry.
     NUIRect readoutRect() const;

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "NUIComponent.h"
+#include "NUIDoubleClick.h"
 #include "NUITypes.h"
 #include <functional>
 #include <memory>
@@ -89,9 +90,8 @@ private:
     /// editor parks here and is released in onRender(), off that stack.
     std::shared_ptr<NUITextInput> m_retiredInput;
 
-    // The platform never populates NUIMouseEvent::doubleClick, so pair up quick
-    // same-spot presses here (house pattern — see UnitNameLabel).
-    long long m_lastClickTimeMs{0};
+    // The platform never populates NUIMouseEvent::doubleClick.
+    NUIDoubleClickTracker m_clickTracker;
 
     bool m_showScaleLabels{false};
 

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -52,6 +52,15 @@ public:
     bool isDragging() const { return m_dragging; }
     bool isEditing() const { return m_editing; }
 
+    /**
+     * @brief Commit an open inline edit when a press lands outside this fader.
+     *
+     * A press on another strip is never routed to this component, so the editor
+     * cannot dismiss itself and would stay open indefinitely. The panel calls
+     * this on every press so the mixer has one dismissal path.
+     */
+    void dismissEditAt(const NUIPoint& position);
+
     std::function<void(float db)> onValueChanged;
 
     // Platform bridge for cursor warp (infinite drag)

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -72,6 +72,14 @@ private:
     bool m_editing{false};
     std::shared_ptr<NUITextInput> m_textInput;
 
+    /// Editor kept alive until the next frame.
+    ///
+    /// commitEdit() runs from NUITextInput::onFocusLost(), which touches its own
+    /// members again after the callback returns. Dropping the last reference
+    /// inside that callback would free the object mid-call, so the retired
+    /// editor parks here and is released in onRender(), off that stack.
+    std::shared_ptr<NUITextInput> m_retiredInput;
+
     // The platform never populates NUIMouseEvent::doubleClick, so pair up quick
     // same-spot presses here (house pattern — see UnitNameLabel).
     long long m_lastClickTimeMs{0};

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -4,12 +4,14 @@
 #include "NUIComponent.h"
 #include "NUITypes.h"
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace AestraUI {
 
 // Forward declaration
 class NUIPlatformBridge;
+class NUITextInput;
 
 /**
  * @brief Vertical dB fader widget for the modern mixer UI.
@@ -18,6 +20,11 @@ class NUIPlatformBridge;
  * - Shift drag: fine mode (0.1x sensitivity)
  * - Ctrl/Alt drag: snap mode (0.5 dB increments)
  * - Double-click: reset to 0 dB
+ * - Click the dB readout: type an exact value
+ *
+ * The rail reads as *control state* only: it is deliberately neutral so the
+ * adjacent meter stays the sole carrier of live signal colour. The per-channel
+ * accent is used sparingly (active handle edge), never as the rail fill.
  */
 class UIMixerFader : public NUIComponent {
 public:
@@ -27,6 +34,7 @@ public:
     void onRender(NUIRenderer& renderer) override;
     void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
+    bool onKeyEvent(const NUIKeyEvent& event) override;
 
     void setRangeDb(float minDb, float maxDb);
     void setDefaultDb(float db) { m_defaultDb = db; }
@@ -34,10 +42,15 @@ public:
     void setValueDb(float db);
     float getValueDb() const { return m_valueDb; }
 
-    // Per-channel accent: fill/handle-active colour follows the track colour.
-    void setAccentColor(const NUIColor& color) { m_trackFg = color; repaint(); }
+    /// Per-channel accent. Tints the active handle edge only — never the rail
+    /// fill, which would make the fader read as a level meter.
+    void setAccentColor(const NUIColor& color) { m_accent = color; repaint(); }
+
+    /// Wider scale/readout treatment for the master strip.
+    void setShowScaleLabels(bool show) { m_showScaleLabels = show; repaint(); }
 
     bool isDragging() const { return m_dragging; }
+    bool isEditing() const { return m_editing; }
 
     std::function<void(float db)> onValueChanged;
 
@@ -55,6 +68,16 @@ private:
     NUIPoint m_dragStartPos{};
     float m_dragStartDb{0.0f};
 
+    // Inline numeric entry (same transient-NUITextInput pattern as UnitNameLabel).
+    bool m_editing{false};
+    std::shared_ptr<NUITextInput> m_textInput;
+
+    // The platform never populates NUIMouseEvent::doubleClick, so pair up quick
+    // same-spot presses here (house pattern — see UnitNameLabel).
+    long long m_lastClickTimeMs{0};
+
+    bool m_showScaleLabels{false};
+
     // Cursor-warp state (infinite drag)
     NUIPlatformBridge* m_platformBridge = nullptr;
     float m_lastDragY;            // Last cursor Y position for frame-to-frame delta
@@ -65,12 +88,15 @@ private:
 
     // Cached theme colors
     NUIColor m_trackBg;
-    NUIColor m_trackFg;
+    NUIColor m_railFill;      // neutral "how far up is this set" fill
+    NUIColor m_accent;        // per-channel identity, used sparingly
     NUIColor m_handle;
     NUIColor m_handleHover;
     NUIColor m_text;
     NUIColor m_textSecondary;
     NUIColor m_border;
+    NUIColor m_tick;
+    NUIColor m_tickUnity;
     NUIColor m_tooltipBg;
 
     static constexpr float FADER_FLOOR_THRESHOLD = -60.0f;
@@ -78,6 +104,16 @@ private:
     void cacheThemeColors();
     void updateCachedText();
     float clampDb(float db) const;
+
+    /// Readout band at the top of the fader — click target for inline entry.
+    NUIRect readoutRect() const;
+    float dbToY(float db, float trackTop, float trackHeight) const;
+    void renderScale(NUIRenderer& renderer, float trackX, float trackWidth,
+                     float trackTop, float trackHeight);
+
+    void beginEdit();
+    void commitEdit();
+    void cancelEdit();
 };
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -529,10 +529,6 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
         };
         renderer.fillRoundedRect(emptyCard, HEADER_RADIUS, m_tabBg.withAlpha(0.62f));
         renderer.strokeRoundedRect(emptyCard, HEADER_RADIUS, 1.0f, m_border.withAlpha(0.42f));
-        renderer.strokeRoundedRect({emptyCard.x + 1.0f, emptyCard.y + 1.0f, emptyCard.width - 2.0f, emptyCard.height - 2.0f},
-                                   std::max(0.0f, HEADER_RADIUS - 1.0f),
-                                   1.0f,
-                                   NUIColor::white().withAlpha(0.022f));
 
         const NUIRect stateChip{emptyCard.center().x - 34.0f, emptyCard.y + 18.0f, 68.0f, 18.0f};
         renderer.fillRoundedRect(stateChip, 9.0f, m_bg.withAlpha(0.34f));
@@ -551,10 +547,6 @@ void UIMixerInspector::onRender(NUIRenderer& renderer)
 
     renderer.fillRoundedRect(headerRect, HEADER_RADIUS, m_tabBg.withAlpha(0.70f));
     renderer.strokeRoundedRect(headerRect, HEADER_RADIUS, 1.0f, m_border.withAlpha(0.50f));
-    renderer.strokeRoundedRect({headerRect.x + 1.0f, headerRect.y + 1.0f, headerRect.width - 2.0f, headerRect.height - 2.0f},
-                               std::max(0.0f, HEADER_RADIUS - 1.0f),
-                               1.0f,
-                               NUIColor::white().withAlpha(0.022f));
 
     NUIColor titleAccent = accent;
     if (channel && channel->trackColorIndex >= 0) {

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "UIMixerInspector.h"
 
+#include "ChannelDisplayName.h"
 #include "NUIThemeSystem.h"
 #include "../../AestraCore/include/AestraLog.h"
 #include "NUIRenderer.h"
@@ -281,19 +282,6 @@ void UIMixerInspector::onResize(int width, int height)
     }
 }
 
-int UIMixerInspector::findTrackNumber(uint32_t channelId) const
-{
-    if (!m_viewModel || channelId == 0) return 0;
-    const size_t count = m_viewModel->getChannelCount();
-    for (size_t i = 0; i < count; ++i) {
-        const auto* ch = m_viewModel->getChannelByIndex(i);
-        if (ch && ch->id == channelId) {
-            return static_cast<int>(i + 1);
-        }
-    }
-    return 0;
-}
-
 void UIMixerInspector::updateHeaderCache(const Aestra::ChannelViewModel* channel)
 {
     const uint32_t selectedId = channel ? channel->id : 0xFFFFFFFFu;
@@ -312,7 +300,6 @@ void UIMixerInspector::updateHeaderCache(const Aestra::ChannelViewModel* channel
     m_cachedSelectedId = selectedId;
     m_cachedHeaderTitle.clear();
     m_cachedHeaderSubtitle.clear();
-    m_cachedTrackNumber = 0;
     m_cachedName = channel ? channel->name : std::string();
     m_cachedRoute = channel ? channel->routeName : std::string();
     m_cachedMainOutputId = channel ? channel->mainOutputId : 0xFFFFFFFFu;
@@ -332,10 +319,10 @@ void UIMixerInspector::updateHeaderCache(const Aestra::ChannelViewModel* channel
         return;
     }
 
-    m_cachedTrackNumber = findTrackNumber(channel->id);
-    const std::string trackLabel = (m_cachedTrackNumber > 0)
-        ? ("Channel " + std::to_string(m_cachedTrackNumber))
-        : "Channel";
+    // Same stable-id numbering as the strip and the routing map. Numbering from
+    // the dense list position instead meant the inspector could call the
+    // selected channel "Channel 3" while its own strip said "Channel 7".
+    const std::string trackLabel = channelFallbackLabel(channel->id);
 
     m_cachedHeaderTitle = channel->name.empty()
         ? trackLabel

--- a/AestraUI/Widgets/UIMixerInspector.cpp
+++ b/AestraUI/Widgets/UIMixerInspector.cpp
@@ -334,8 +334,8 @@ void UIMixerInspector::updateHeaderCache(const Aestra::ChannelViewModel* channel
 
     m_cachedTrackNumber = findTrackNumber(channel->id);
     const std::string trackLabel = (m_cachedTrackNumber > 0)
-        ? ("Insert " + std::to_string(m_cachedTrackNumber))
-        : "Insert";
+        ? ("Channel " + std::to_string(m_cachedTrackNumber))
+        : "Channel";
 
     m_cachedHeaderTitle = channel->name.empty()
         ? trackLabel

--- a/AestraUI/Widgets/UIMixerInspector.h
+++ b/AestraUI/Widgets/UIMixerInspector.h
@@ -101,7 +101,6 @@ private:
     std::string m_cachedRoute;
     std::string m_cachedHeaderTitle;
     std::string m_cachedHeaderSubtitle;
-    int m_cachedTrackNumber{0};
     uint32_t m_cachedMainOutputId{0xFFFFFFFFu};
     bool m_cachedMasterSendEnabled{true};
     size_t m_cachedSendsCount{0};
@@ -116,7 +115,6 @@ private:
     void cacheThemeColors();
     void layoutHitRects();
     int hitTestTab(const NUIPoint& p) const;
-    int findTrackNumber(uint32_t channelId) const;
     void updateHeaderCache(const Aestra::ChannelViewModel* channel);
     void clampScrollOffsets();
 };

--- a/AestraUI/Widgets/UIMixerKnob.cpp
+++ b/AestraUI/Widgets/UIMixerKnob.cpp
@@ -6,6 +6,7 @@
 #include "../Platform/NUIPlatformBridge.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 
@@ -34,6 +35,9 @@ void UIMixerKnob::cacheThemeColors()
     m_ring = theme.getColor("borderSubtle").withAlpha(0.65f);
     m_ringHover = theme.getColor("border").withAlpha(0.85f);
     m_indicator = theme.getColor("accentPrimary");
+    // Resting arcs are neutral. When every knob carried a saturated accent the
+    // whole strip read as "everything is active"; colour now marks engagement.
+    m_arcResting = theme.getColor("textPrimary").withAlpha(0.42f);
     m_text = theme.getColor("textPrimary");
     m_textSecondary = theme.getColor("textSecondary");
     m_tooltipBg = theme.getColor("backgroundSecondary").withAlpha(0.95f);
@@ -211,9 +215,8 @@ void UIMixerKnob::onRender(NUIRenderer& renderer)
          currentAng = ARC_START + t * (ARC_END - ARC_START);
     }
     
-    NUIColor activeColor = m_indicator;
-    if (hovered) activeColor = activeColor.withAlpha(1.0f);
-    else activeColor = activeColor.withAlpha(0.85f);
+    // `hovered` already folds in m_dragging above.
+    NUIColor activeColor = hovered ? m_indicator.withAlpha(1.0f) : m_arcResting;
     
     drawRoughArc(renderer, {cx, cy}, r, std::min(startAng, currentAng), std::max(startAng, currentAng), 3.0f, activeColor);
 
@@ -279,11 +282,20 @@ bool UIMixerKnob::onMouseEvent(const NUIMouseEvent& event)
     }
     if (!b.contains(event.position) && !m_dragging) return false;
 
-    // Double-click reset
-    if (event.doubleClick && event.pressed && event.button == NUIMouseButton::Left) {
-        setValue(defaultValue());
-        updateGlobalTooltip();
-        return true;
+    // Double-click reset. The platform never populates event.doubleClick, so
+    // quick same-button presses are paired up here (house pattern) — relying on
+    // the flag alone left this reset unreachable.
+    if (event.pressed && event.button == NUIMouseButton::Left) {
+        const long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now().time_since_epoch())
+                                    .count();
+        const bool isDoubleClick = (nowMs - m_lastClickTimeMs < 400) || event.doubleClick;
+        m_lastClickTimeMs = nowMs;
+        if (isDoubleClick) {
+            setValue(defaultValue());
+            updateGlobalTooltip();
+            return true;
+        }
     }
 
     if (event.pressed && event.button == NUIMouseButton::Left) {

--- a/AestraUI/Widgets/UIMixerKnob.cpp
+++ b/AestraUI/Widgets/UIMixerKnob.cpp
@@ -286,12 +286,7 @@ bool UIMixerKnob::onMouseEvent(const NUIMouseEvent& event)
     // quick same-button presses are paired up here (house pattern) — relying on
     // the flag alone left this reset unreachable.
     if (event.pressed && event.button == NUIMouseButton::Left) {
-        const long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now().time_since_epoch())
-                                    .count();
-        const bool isDoubleClick = (nowMs - m_lastClickTimeMs < 400) || event.doubleClick;
-        m_lastClickTimeMs = nowMs;
-        if (isDoubleClick) {
+        if (m_clickTracker.registerPress() || event.doubleClick) {
             setValue(defaultValue());
             updateGlobalTooltip();
             return true;

--- a/AestraUI/Widgets/UIMixerKnob.h
+++ b/AestraUI/Widgets/UIMixerKnob.h
@@ -65,7 +65,11 @@ private:
     NUIColor m_bgHover;
     NUIColor m_ring;
     NUIColor m_ringHover;
-    NUIColor m_indicator;
+    NUIColor m_indicator;   // engaged (hover/drag) arc
+    NUIColor m_arcResting;  // neutral resting arc
+
+    // The platform never sets NUIMouseEvent::doubleClick — pair presses here.
+    long long m_lastClickTimeMs{0};
     NUIColor m_text;
     NUIColor m_textSecondary;
     NUIColor m_tooltipBg;

--- a/AestraUI/Widgets/UIMixerKnob.h
+++ b/AestraUI/Widgets/UIMixerKnob.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "NUIComponent.h"
+#include "NUIDoubleClick.h"
 
 #include <functional>
 #include <string>
@@ -68,12 +69,13 @@ private:
     NUIColor m_indicator;   // engaged (hover/drag) arc
     NUIColor m_arcResting;  // neutral resting arc
 
-    // The platform never sets NUIMouseEvent::doubleClick — pair presses here.
-    long long m_lastClickTimeMs{0};
     NUIColor m_text;
     NUIColor m_textSecondary;
     NUIColor m_tooltipBg;
     NUIColor m_tooltipText;
+
+    // The platform never sets NUIMouseEvent::doubleClick.
+    NUIDoubleClickTracker m_clickTracker;
 
     void cacheThemeColors();
     float clampValue(float value) const;

--- a/AestraUI/Widgets/UIMixerMeter.cpp
+++ b/AestraUI/Widgets/UIMixerMeter.cpp
@@ -28,8 +28,10 @@ void UIMixerMeter::cacheThemeColors()
     m_colorGreenDim = m_colorGreen.withSaturation(0.0f).withAlpha(0.55f);
     m_colorYellowDim = m_colorYellow.withSaturation(0.0f).withAlpha(0.55f);
     m_colorRedDim = m_colorRed.withSaturation(0.0f).withAlpha(0.55f);
-    // Match fader track background (Dark Glass)
-    m_colorBackground = theme.getColor("meterBackground").withAlpha(0.3f);
+    // The meter must read as a meter even at silence, otherwise a resting strip
+    // shows only a fader and the "what is sounding" channel looks like padding.
+    // At 0.3 alpha the track was invisible against the strip background.
+    m_colorBackground = theme.getColor("meterBackground").withAlpha(0.72f);
     m_colorPeakHold = theme.getColor("textPrimary"); // #E5E5E8
     m_colorPeakOverlay = m_colorPeakHold.withAlpha(0.8f);
     m_colorPeakOverlayDim = m_colorPeakOverlay.withSaturation(0.0f).withAlpha(0.6f);

--- a/AestraUI/Widgets/UIMixerMeter.cpp
+++ b/AestraUI/Widgets/UIMixerMeter.cpp
@@ -32,6 +32,7 @@ void UIMixerMeter::cacheThemeColors()
     // shows only a fader and the "what is sounding" channel looks like padding.
     // At 0.3 alpha the track was invisible against the strip background.
     m_colorBackground = theme.getColor("meterBackground").withAlpha(0.72f);
+    m_colorRailEdge = theme.getColor("textPrimary").withAlpha(0.12f);
     m_colorPeakHold = theme.getColor("textPrimary"); // #E5E5E8
     m_colorPeakOverlay = m_colorPeakHold.withAlpha(0.8f);
     m_colorPeakOverlayDim = m_colorPeakOverlay.withSaturation(0.0f).withAlpha(0.6f);
@@ -177,8 +178,11 @@ NUIColor UIMixerMeter::getColorForLevel(float db) const
 void UIMixerMeter::renderMeterBar(NUIRenderer& renderer, const NUIRect& bounds,
                                    float peakDb, float rmsDb, float peakOverlayDb, float peakHoldDb, bool clip)
 {
-    // Background (flat fill - gradient caused edge artifacts)
+    // Resting rail. A bare dark fill was indistinguishable from the strip
+    // background, so a silent channel gave no clue where level would appear.
+    // The groove plus its top edge say "meter lives here" before any signal.
     renderer.fillRect(bounds, m_colorBackground);
+    renderer.strokeRect(bounds, 1.0f, m_colorRailEdge);
 
     const NUIColor& yellow = m_dimmed ? m_colorYellowDim : m_colorYellow;
     const NUIColor& red = m_dimmed ? m_colorRedDim : m_colorRed;
@@ -429,14 +433,17 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
         renderer.drawTextCentered(lufsLabel, lufsRect, 7.0f, NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.45f));
         
     } else if (hasPeak) {
-        // Regular tracks: Show Peak dB or −∞ at silence floor
+        // Regular tracks: peak dB or −∞ at the silence floor.
+        // The "PK" prefix is what separates this from the fader's gain readout
+        // sitting a few pixels to the right — position alone left a bare "−∞"
+        // next to "0.0 dB" as a small decoding task on every strip.
         if (std::abs(peak - m_cachedDbPeak) > 0.05f) {
             m_cachedDbPeak = peak;
             if (peak <= DB_MIN) {
-                m_cachedDbStr = "\xE2\x88\x92\xE2\x88\x9E";
+                m_cachedDbStr = "PK \xE2\x88\x92\xE2\x88\x9E";
             } else {
                 char buf[32];
-                std::snprintf(buf, sizeof(buf), "%.1f dB", peak);
+                std::snprintf(buf, sizeof(buf), "PK %.1f", peak);
                 m_cachedDbStr = buf;
             }
         }

--- a/AestraUI/Widgets/UIMixerMeter.cpp
+++ b/AestraUI/Widgets/UIMixerMeter.cpp
@@ -123,6 +123,22 @@ void UIMixerMeter::setDimmed(bool dimmed)
     }
 }
 
+void UIMixerMeter::setMasterMode(bool master)
+{
+    if (m_masterMode != master) {
+        m_masterMode = master;
+        repaint();
+    }
+}
+
+float UIMixerMeter::getDisplayPeakDb() const
+{
+    if (m_peakHoldL > DB_MIN || m_peakHoldR > DB_MIN) {
+        return std::max(m_peakHoldL, m_peakHoldR);
+    }
+    return std::max(m_peakL, m_peakR);
+}
+
 void UIMixerMeter::setIntegratedLufs(float lufs)
 {
     if (std::abs(m_integratedLufs - lufs) > 0.05f) {
@@ -279,18 +295,18 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
         meterHeight -= (CORR_HEIGHT + CORR_GAP);
     }
 
-    // Calculate bar widths (L/R)
-    // Reserve space for Text Readout at top (increased for better readability)
+    // Reserve space for Text Readout at top (increased for better readability).
+    // In master mode the strip owns a wider, explicitly labelled readout block,
+    // so the meter reclaims that space and only labels its two bars L / R.
     constexpr float TEXT_HEIGHT = 24.0f;
-
-    // Calculate bar widths (L/R)
-    float totalWidth = bounds.width;
-    // float barWidth = (totalWidth - METER_GAP) / 2.0f; // Unused variable warning fix
+    constexpr float LR_LABEL_HEIGHT = 11.0f;
+    const float topReserve = m_masterMode ? 0.0f : TEXT_HEIGHT;
+    const float bottomReserve = m_masterMode ? LR_LABEL_HEIGHT : 0.0f;
 
     // Left Meter
     NUIRect leftBounds = bounds;
-    leftBounds.y += TEXT_HEIGHT;
-    leftBounds.height = std::max(1.0f, meterHeight - TEXT_HEIGHT);
+    leftBounds.y += topReserve;
+    leftBounds.height = std::max(1.0f, meterHeight - topReserve - bottomReserve);
     leftBounds.width = (bounds.width - METER_GAP) * 0.5f;
     renderMeterBar(renderer, leftBounds, m_peakL, m_rmsL, m_peakOverlayL, m_peakHoldL, m_clipL);
 
@@ -298,6 +314,17 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
     NUIRect rightBounds = leftBounds;
     rightBounds.x += leftBounds.width + METER_GAP;
     renderMeterBar(renderer, rightBounds, m_peakR, m_rmsR, m_peakOverlayR, m_peakHoldR, m_clipR);
+
+    // Which bar is which — otherwise the master's two bars are unidentified.
+    if (m_masterMode) {
+        const NUIColor labelColor = m_colorPeakHold.withAlpha(0.55f);
+        const NUIRect lLabel{leftBounds.x, leftBounds.y + leftBounds.height,
+                             leftBounds.width, LR_LABEL_HEIGHT};
+        const NUIRect rLabel{rightBounds.x, rightBounds.y + rightBounds.height,
+                             rightBounds.width, LR_LABEL_HEIGHT};
+        renderer.drawTextCentered("L", lLabel, 9.0f, labelColor);
+        renderer.drawTextCentered("R", rLabel, 9.0f, labelColor);
+    }
 
     // Draw Correlation Meter
     if (m_showCorrelation) {
@@ -339,11 +366,16 @@ void UIMixerMeter::onRender(NUIRenderer& renderer)
         renderer.fillRect(barRect, barColor);
     }
     
-    // Draw Value Readout (Top)
-    // Master: Peak dB primary, LUFS secondary (below, smaller, dimmed)
-    // Tracks: Show Peak dB only
-    
-    // Get peak value (used for both master and regular tracks)
+    // Draw Value Readout (Top) — track strips only.
+    // The master's numbers are rendered by the strip instead: stacking "x.x dB"
+    // over "LUFS -13.5" inside a 36 px meter clipped the text, and losing the
+    // minus sign turns -13.5 LUFS into a radically different claim.
+    if (m_masterMode) {
+        renderChildren(renderer);
+        return;
+    }
+
+    // Get peak value
     float peak = std::max(m_peakL, m_peakR);
     if (m_peakHoldL > DB_MIN || m_peakHoldR > DB_MIN) {
         peak = std::max(m_peakHoldL, m_peakHoldR);

--- a/AestraUI/Widgets/UIMixerMeter.h
+++ b/AestraUI/Widgets/UIMixerMeter.h
@@ -126,6 +126,7 @@ private:
     NUIColor m_colorYellowDim;
     NUIColor m_colorRedDim;
     NUIColor m_colorBackground;
+    NUIColor m_colorRailEdge;   // faint resting outline so the rail reads at silence
     NUIColor m_colorPeakHold;
     NUIColor m_colorPeakOverlay;
     NUIColor m_colorPeakOverlayDim;

--- a/AestraUI/Widgets/UIMixerMeter.h
+++ b/AestraUI/Widgets/UIMixerMeter.h
@@ -81,6 +81,22 @@ public:
      */
     void setIntegratedLufs(float lufs);
 
+    /**
+     * @brief Master mode: label the bars L/R and suppress the in-meter numbers.
+     *
+     * The master strip renders an explicitly labelled Peak/LUFS/Gain block
+     * instead — at 36 px the stacked readouts here clipped their own text
+     * (notably the minus sign on a negative LUFS value, which inverts the
+     * meaning of the number).
+     */
+    void setMasterMode(bool master);
+
+    /// Highest peak currently shown, in dBFS (peak-hold when one is latched).
+    float getDisplayPeakDb() const;
+
+    /// True when either channel has a latched clip.
+    bool isClipped() const { return m_clipL || m_clipR; }
+
     /// Callback when clip indicator is clicked (to clear clip latch)
     std::function<void()> onClipCleared;
 
@@ -100,6 +116,7 @@ private:
     bool m_clipR{false};
     bool m_dimmed{false};
     bool m_showCorrelation{false};
+    bool m_masterMode{false};
 
     // Cached theme colors (avoid per-frame lookups)
     NUIColor m_colorGreen;

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -553,6 +553,15 @@ bool UIMixerPanel::onMouseEvent(const NUIMouseEvent& event)
     const float visibleW = getChannelViewportWidth();
     const float maxScroll = getChannelMaxScroll();
 
+    // One dismissal path for inline fader entry. A press on another strip is
+    // never routed to the editing fader, so without this the editor stays open.
+    if (event.pressed) {
+        for (const auto& strip : m_strips) {
+            if (strip) strip->dismissFaderEdit(event.position);
+        }
+        if (m_masterStrip) m_masterStrip->dismissFaderEdit(event.position);
+    }
+
     // Inspector collapse rail claims the pointer before anything underneath it.
     {
         const NUIRect rail = getInspectorToggleRect();

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -237,11 +237,15 @@ void UIMixerPanel::layoutMeters()
     }
 
     // Layout inspector just to the left of master.
-    const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
     if (m_inspector) {
+        // Collapsed, the inspector yields its width to the channel strips and
+        // leaves only the re-open rail drawn by the panel.
         m_inspector->setBounds(inspectorX, stripY, INSPECTOR_WIDTH, stripHeight);
-        m_inspector->setVisible(true);
-        m_inspector->onResize(static_cast<int>(INSPECTOR_WIDTH), static_cast<int>(stripHeight));
+        m_inspector->setVisible(!m_inspectorCollapsed);
+        if (!m_inspectorCollapsed) {
+            m_inspector->onResize(static_cast<int>(INSPECTOR_WIDTH), static_cast<int>(stripHeight));
+        }
     }
 
     // Layout channel strips to the left, keeping them out of the inspector/master area.
@@ -262,6 +266,31 @@ void UIMixerPanel::layoutMeters()
         m_strips[i]->setVisible(visible);
         m_strips[i]->setBounds(stripX, stripY, STRIP_WIDTH, stripHeight);
     }
+}
+
+NUIRect UIMixerPanel::getInspectorToggleRect() const
+{
+    const auto bounds = getBounds();
+    const NUIRect minimapRect = getMinimapRect();
+    const float stripY = minimapRect.bottom() + MINIMAP_GAP;
+    const float stripHeight = std::max(MIXER_MIN_CHANNEL_HEIGHT, bounds.bottom() - stripY - PADDING);
+    const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
+
+    // Collapsed: the whole thin rail is the target. Expanded: a grip strip down
+    // the inspector's leading edge.
+    const float railW = m_inspectorCollapsed ? INSPECTOR_COLLAPSED_WIDTH : 10.0f;
+    return NUIRect{inspectorX, stripY, railW, stripHeight};
+}
+
+void UIMixerPanel::setInspectorCollapsed(bool collapsed)
+{
+    if (m_inspectorCollapsed == collapsed) {
+        return;
+    }
+    m_inspectorCollapsed = collapsed;
+    layoutMeters();
+    repaint();
 }
 
 void UIMixerPanel::onResize(int width, int height)
@@ -346,7 +375,7 @@ void UIMixerPanel::renderSeparators(NUIRenderer& renderer)
     float y2 = bounds.y + bounds.height;
 
     const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
-    const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
     const float left = bounds.x;
     const float right = inspectorX - STRIP_SPACING;
 
@@ -439,7 +468,7 @@ void UIMixerPanel::onRender(NUIRenderer& renderer)
 
     // Render channel strips with a clip so they never draw into the inspector/master area.
     const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
-    const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
     const float channelW = std::max(0.0f, (inspectorX - STRIP_SPACING) - bounds.x);
     const float channelY = minimapRect.bottom() + MINIMAP_GAP;
     const NUIRect channelClip(bounds.x, channelY, channelW, std::max(0.0f, bounds.bottom() - channelY));
@@ -476,6 +505,29 @@ void UIMixerPanel::onRender(NUIRenderer& renderer)
         m_inspector->onRender(renderer);
     }
 
+    // Inspector collapse rail. Collapsed it is the only thing left of the
+    // inspector; expanded it is a slim grip on the panel's leading edge.
+    {
+        auto& theme = NUIThemeManager::getInstance();
+        const NUIRect rail = getInspectorToggleRect();
+        const NUIColor railColor = m_inspectorToggleHovered
+            ? theme.getColor("accentPrimary").withAlpha(0.34f)
+            : theme.getColor("surfaceTertiary").withAlpha(m_inspectorCollapsed ? 0.72f : 0.34f);
+        renderer.fillRoundedRect(rail, 3.0f, railColor);
+
+        // Chevron points the way the panel will move.
+        const NUIColor glyph = theme.getColor("textSecondary")
+                                   .withAlpha(m_inspectorToggleHovered ? 0.95f : 0.6f);
+        const float cx = rail.x + rail.width * 0.5f;
+        const float cy = rail.y + rail.height * 0.5f;
+        const float dir = m_inspectorCollapsed ? -1.0f : 1.0f;
+        for (int i = 0; i < 5; ++i) {
+            const float dy = static_cast<float>(i) - 2.0f;
+            const float dx = dir * (2.0f - std::abs(dy));
+            renderer.fillRect(NUIRect{cx + dx - 0.5f, cy + dy * 2.0f, 1.5f, 2.0f}, glyph);
+        }
+    }
+
     // Master strip renders on top / outside the clip.
     if (m_masterStrip && m_masterStrip->isVisible()) {
         m_masterStrip->onRender(renderer);
@@ -500,6 +552,20 @@ bool UIMixerPanel::onMouseEvent(const NUIMouseEvent& event)
     const float contentW = getChannelContentWidth();
     const float visibleW = getChannelViewportWidth();
     const float maxScroll = getChannelMaxScroll();
+
+    // Inspector collapse rail claims the pointer before anything underneath it.
+    {
+        const NUIRect rail = getInspectorToggleRect();
+        const bool overRail = rail.contains(event.position);
+        if (m_inspectorToggleHovered != overRail) {
+            m_inspectorToggleHovered = overRail;
+            repaint();
+        }
+        if (overRail && event.pressed && event.button == NUIMouseButton::Left) {
+            toggleInspectorCollapsed();
+            return true;
+        }
+    }
 
     if (m_isDraggingMinimap) {
         if (event.released && event.button == NUIMouseButton::Left) {
@@ -532,7 +598,7 @@ bool UIMixerPanel::onMouseEvent(const NUIMouseEvent& event)
     if (event.wheelDelta != 0.0f) {
         auto bounds = getBounds();
         const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
-        const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+        const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
         const float visibleW = std::max(0.0f, (inspectorX - STRIP_SPACING) - bounds.x);
         const float contentW = m_strips.empty() ? 0.0f : (m_strips.size() * (STRIP_WIDTH + STRIP_SPACING) - STRIP_SPACING);
         const float maxScroll = std::max(0.0f, contentW - visibleW);
@@ -553,7 +619,7 @@ NUIRect UIMixerPanel::getMinimapRect() const
 {
     auto bounds = getBounds();
     const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
-    const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
     const float width = std::max(0.0f, (inspectorX - STRIP_SPACING) - bounds.x);
     return NUIRect(bounds.x, bounds.y + 2.0f, width, MINIMAP_HEIGHT);
 }
@@ -562,7 +628,7 @@ float UIMixerPanel::getChannelViewportWidth() const
 {
     auto bounds = getBounds();
     const float masterX = bounds.x + bounds.width - MASTER_STRIP_WIDTH;
-    const float inspectorX = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorX = masterX - STRIP_SPACING - inspectorWidth();
     return std::max(0.0f, (inspectorX - STRIP_SPACING) - bounds.x);
 }
 
@@ -622,7 +688,7 @@ void UIMixerPanel::showPluginDropdown(uint32_t channelId)
 
     auto panelBounds = getBounds();
     const float masterX  = panelBounds.x + panelBounds.width - MASTER_STRIP_WIDTH;
-    const float inspectorLeft = masterX - STRIP_SPACING - INSPECTOR_WIDTH;
+    const float inspectorLeft = masterX - STRIP_SPACING - inspectorWidth();
     const float viewportRight = inspectorLeft - STRIP_SPACING;
 
     constexpr float DROP_W = 240.0f;
@@ -705,7 +771,7 @@ UIMixerStrip* UIMixerPanel::stripAt(const NUIPoint& position) const {
     // Channel strips are clipped to the viewport left of the inspector.
     auto panelBounds = getBounds();
     const float masterX = panelBounds.x + panelBounds.width - MASTER_STRIP_WIDTH;
-    const float viewportRight = masterX - STRIP_SPACING - INSPECTOR_WIDTH - STRIP_SPACING;
+    const float viewportRight = masterX - STRIP_SPACING - inspectorWidth() - STRIP_SPACING;
     if (position.x > viewportRight) {
         return nullptr;
     }

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -86,7 +86,25 @@ public:
      */
     void setPlatformBridge(class NUIPlatformBridge* bridge);
 
+    /**
+     * @brief Collapse the inspector to a thin re-open rail.
+     *
+     * A dedicated mixer view should be able to become almost entirely channel
+     * strips; collapsing the inspector returns its width to the strips.
+     */
+    void setInspectorCollapsed(bool collapsed);
+    bool isInspectorCollapsed() const { return m_inspectorCollapsed; }
+    void toggleInspectorCollapsed() { setInspectorCollapsed(!m_inspectorCollapsed); }
+
 private:
+    /// Current inspector width — the collapsed rail or the full panel.
+    float inspectorWidth() const {
+        return m_inspectorCollapsed ? INSPECTOR_COLLAPSED_WIDTH : INSPECTOR_WIDTH;
+    }
+
+    /// Rail/handle that collapses or restores the inspector.
+    NUIRect getInspectorToggleRect() const;
+
     bool channelLayoutMatchesViewModel() const;
     NUIRect getMinimapRect() const;
     float getChannelViewportWidth() const;
@@ -121,6 +139,8 @@ private:
 
     /// Inspector panel (pinned on the right, before master)
     std::shared_ptr<UIMixerInspector> m_inspector;
+    bool m_inspectorCollapsed{false};
+    bool m_inspectorToggleHovered{false};
 
     /// Plugin finder dropdown (topmost, shown on Add Insert click)
     std::shared_ptr<UIMixerPluginDropdown> m_pluginDropdown;
@@ -143,6 +163,7 @@ private:
     static constexpr float PADDING = 8.0f;
     static constexpr float MASTER_STRIP_WIDTH = 146.0f;
     static constexpr float INSPECTOR_WIDTH = 236.0f;
+    static constexpr float INSPECTOR_COLLAPSED_WIDTH = 16.0f;
     static constexpr float MINIMAP_HEIGHT = 22.0f;
     static constexpr float MINIMAP_GAP = 6.0f;
     static constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -31,9 +31,16 @@ namespace {
     constexpr float SECTION_GAP = 8.0f;
     constexpr float METER_W = 22.0f;
     constexpr float MASTER_METER_W = 36.0f;
-    // Labelled Peak / LUFS / Gain block at the foot of the master strip.
-    constexpr float MASTER_READOUT_H = 56.0f;
-    constexpr float MASTER_READOUT_ROW_H = 15.0f;
+    // Labelled Peak / LUFS / Gain blocks at the foot of the master strip.
+    // Each block is a label line stacked over a value line; two of them sit in
+    // the meter column, so the band must fit 2 * BLOCK_H exactly or the second
+    // value falls off the bottom of the strip.
+    constexpr float MASTER_LABEL_H = 12.0f;
+    constexpr float MASTER_VALUE_H = 14.0f;
+    constexpr float MASTER_BLOCK_H = MASTER_LABEL_H + MASTER_VALUE_H;  // 26
+    // Two stacked blocks plus bottom slack. With only 4px of slack the second
+    // value landed on the strip's bottom edge and was not drawn at all.
+    constexpr float MASTER_READOUT_H = MASTER_BLOCK_H * 2.0f + 14.0f;  // 66
 
     constexpr float SELECT_TOP_H = 3.0f;
     constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;
@@ -499,16 +506,28 @@ void UIMixerStrip::layoutChildren()
         m_fader->setBounds(faderX, meterY, faderW, meterH);
     }
 
-    m_masterReadoutRect = isMaster
-        ? NUIRect{contentX, footerY - MASTER_READOUT_H, contentW, MASTER_READOUT_H}
-        : NUIRect{};
+    // Readouts sit under the column they describe: observed signal (Peak, LUFS)
+    // under the meter, user-controlled gain under the fader. Keeping all three
+    // in one bottom block made the eye travel from the live bars to a detached
+    // table to interpret state, and blurred which side owns which number.
+    if (isMaster) {
+        const float readoutY = footerY - MASTER_READOUT_H;
+        m_masterMeterReadoutRect = NUIRect{meterX, readoutY, meterW + GAP, MASTER_READOUT_H};
+        const float gainX = meterX + meterW + GAP;
+        m_masterGainReadoutRect =
+            NUIRect{gainX, readoutY, std::max(16.0f, (contentX + contentW) - gainX), MASTER_READOUT_H};
+    } else {
+        m_masterMeterReadoutRect = NUIRect{};
+        m_masterGainReadoutRect = NUIRect{};
+    }
 }
 
 void UIMixerStrip::renderMasterReadout(NUIRenderer& renderer,
                                        const Aestra::ChannelViewModel& channel)
 {
-    const NUIRect& area = m_masterReadoutRect;
-    if (area.width <= 0.0f || area.height <= 0.0f) return;
+    const NUIRect& meterArea = m_masterMeterReadoutRect;
+    const NUIRect& gainArea = m_masterGainReadoutRect;
+    if (meterArea.width <= 0.0f || meterArea.height <= 0.0f) return;
 
     auto& theme = NUIThemeManager::getInstance();
     const NUIColor labelColor = theme.getColor("textSecondary").withAlpha(0.72f);
@@ -525,18 +544,18 @@ void UIMixerStrip::renderMasterReadout(NUIRenderer& renderer,
     }
 
     char buf[32];
-    auto row = [&](int index, const char* label, const std::string& value, const NUIColor& color) {
-        const NUIRect rowRect{area.x, area.y + static_cast<float>(index) * MASTER_READOUT_ROW_H,
-                              area.width, MASTER_READOUT_ROW_H};
-        const float textY = renderer.calculateTextY(rowRect, 9.5f);
-        renderer.drawText(label, NUIPoint{rowRect.x, textY}, 9.5f, labelColor);
-
-        const float valueW = renderer.measureText(value, 9.5f).width;
-        renderer.drawText(value,
-                          NUIPoint{rowRect.x + rowRect.width - valueW, textY},
-                          9.5f, color);
+    // Stacked label-over-value: the master columns are too narrow for a
+    // side-by-side label and a signed value.
+    auto block = [&](const NUIRect& area, int index, const char* label,
+                     const std::string& value, const NUIColor& color) {
+        const float y = area.y + static_cast<float>(index) * MASTER_BLOCK_H;
+        const NUIRect labelRect{area.x, y, area.width, MASTER_LABEL_H};
+        const NUIRect valueRect{area.x, y + MASTER_LABEL_H, area.width, MASTER_VALUE_H};
+        renderer.drawTextCentered(label, labelRect, 8.5f, labelColor);
+        renderer.drawTextCentered(value, valueRect, 10.0f, color);
     };
 
+    // --- Observed signal, under the meter ---
     // PEAK — dBFS, explicitly. Doubles as the clip/over indicator.
     std::string peakText;
     if (peakDb <= Aestra::MixerMath::DB_MIN) {
@@ -545,19 +564,23 @@ void UIMixerStrip::renderMasterReadout(NUIRenderer& renderer,
         std::snprintf(buf, sizeof(buf), "%.1f", peakDb);
         peakText = buf;
     }
-    row(0, clipped ? "PEAK  OVER" : "PEAK  dBFS", peakText, clipped ? clipColor : valueColor);
+    block(meterArea, 0, clipped ? "OVER" : "PEAK dBFS", peakText, clipped ? clipColor : valueColor);
 
     // LUFS — integrated, and the sign always survives (see UIMixerMeter).
-    std::string lufsText = "--";
+    // Integrated LUFS is undefined until the gate has material; show the same
+    // silence marker the peak readout uses rather than an ambiguous dash.
+    std::string lufsText = "\xE2\x88\x92\xE2\x88\x9E";
     if (channel.integratedLufs > -100.0f) {
         std::snprintf(buf, sizeof(buf), "%.1f", channel.integratedLufs);
         lufsText = buf;
     }
-    row(1, "LUFS  INT", lufsText, valueColor);
+    block(meterArea, 1, "LUFS INT", lufsText, valueColor);
 
-    // GAIN — the fader's own value, named so it is not read as a level.
-    std::snprintf(buf, sizeof(buf), "%.1f", channel.faderGainDb);
-    row(2, "GAIN  dB", buf, valueColor);
+    // --- User-controlled gain, under the fader ---
+    if (gainArea.width > 0.0f) {
+        std::snprintf(buf, sizeof(buf), "%.1f", channel.faderGainDb);
+        block(gainArea, 0, "GAIN dB", buf, valueColor);
+    }
 }
 
 void UIMixerStrip::onResize(int width, int height)
@@ -765,13 +788,15 @@ void UIMixerStrip::onRender(NUIRenderer& renderer)
     }
 
     if (selected) {
-        // Selection is background contrast + a top accent bar + ONE outline.
-        // It previously stacked five layers on the same strip (tint, top bar,
-        // an inner 34px highlight, an outer glow ring and the outline), which
-        // is most of the "nested outlines" the mixer was accumulating.
+        // Selection = a slight tinted body + a strong top edge. No outline.
+        //
+        // This started at five layers (tint, top bar, inner highlight, outer
+        // glow ring, outline). The outline was the last redundant one: with a
+        // tinted body and a bright edge the strip is already unmistakable, and
+        // the border was what made a selected strip read as a different kind of
+        // component rather than the same strip, selected.
         renderer.fillRoundedRect(bounds, radius, m_selectedTint);
         renderer.fillRect(NUIRect{bounds.x, bounds.y, bounds.width, SELECT_TOP_H}, m_selectedTopHighlight);
-        renderer.strokeRoundedRect(bounds, radius, 1.0f, m_selectedOutline);
     }
 
     // While dragging, render live (no caching) so interactive controls update every frame.

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -928,4 +928,11 @@ NUIRect UIMixerStrip::getFXSummaryBounds() const
     return m_fxSummary ? m_fxSummary->getBounds() : NUIRect{};
 }
 
+void UIMixerStrip::dismissFaderEdit(const NUIPoint& position)
+{
+    if (m_fader) {
+        m_fader->dismissEditAt(position);
+    }
+}
+
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -550,15 +550,15 @@ void UIMixerStrip::onUpdate(double deltaTime)
             m_cachedTrackColorArgb = static_cast<uint32_t>(channel->trackColorIndex + 1);
             invalidateStaticCache();
 
-            // Thread the track colour through the strip's accent controls so each
-            // channel reads as its own instrument. Master (id 0) keeps the neutral
-            // primary accent, and unset tracks fall back to the widget defaults.
+            // The track colour is the channel's IDENTITY, so it is carried by the
+            // header (and the overview strip) only. It used to be threaded into
+            // the fader fill and all three knob arcs as well, which left every
+            // control looking permanently "active" and made the coloured fader
+            // rail read as a second level meter. The fader now takes the accent
+            // for its engaged handle edge alone; the knobs stay neutral.
             if (m_channelId != 0 && channel->trackColorIndex >= 0) {
                 const NUIColor accent = trackColorFromIndex(channel->trackColorIndex);
                 if (m_fader) m_fader->setAccentColor(accent);
-                if (m_trimKnob) m_trimKnob->setAccentColor(accent);
-                if (m_panKnob) m_panKnob->setAccentColor(accent);
-                if (m_widthKnob) m_widthKnob->setAccentColor(accent);
             }
         }
         m_header->setTrackColorIndex(channel->trackColorIndex);

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -31,6 +31,9 @@ namespace {
     constexpr float SECTION_GAP = 8.0f;
     constexpr float METER_W = 22.0f;
     constexpr float MASTER_METER_W = 36.0f;
+    // Labelled Peak / LUFS / Gain block at the foot of the master strip.
+    constexpr float MASTER_READOUT_H = 56.0f;
+    constexpr float MASTER_READOUT_ROW_H = 15.0f;
 
     constexpr float SELECT_TOP_H = 3.0f;
     constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;
@@ -323,11 +326,14 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
 
     m_meter = std::make_shared<UIMixerMeter>();
     m_meter->setShowCorrelation(true);
+    m_meter->setMasterMode(m_channelId == 0);
     addChild(m_meter);
 
     m_fader = std::make_shared<UIMixerFader>();
     m_fader->setRangeDb(-90.0f, 6.0f);
     m_fader->setDefaultDb(0.0f);
+    // The master strip is wide enough to label its unity mark.
+    m_fader->setShowScaleLabels(m_channelId == 0);
     m_fader->onValueChanged = [this](float db) {
         if (!m_viewModel || !m_continuousParams) return;
         auto* channel = m_viewModel->getChannelById(m_channelId);
@@ -470,13 +476,18 @@ void UIMixerStrip::layoutChildren()
         m_footer->setBounds(contentX, footerY, contentW, FOOTER_H);
     }
 
-    const float meterW = (m_channelId == 0) ? MASTER_METER_W : METER_W;
+    const bool isMaster = (m_channelId == 0);
+    const float meterW = isMaster ? MASTER_METER_W : METER_W;
+
+    // The master reserves a labelled Peak/LUFS/Gain block at the foot of the
+    // strip; its footer is hidden, so that space is otherwise unused.
+    const float readoutH = isMaster ? MASTER_READOUT_H : 0.0f;
 
     // Meter + fader fill the strip between the channel controls and the footer.
     // (Previously sized to 62% of the free height and bottom-anchored, which
     // left a large dead gap above the fader — the tallest, most-used control.)
     const float meterY = y;
-    const float meterH = std::max(16.0f, (footerY - GAP) - y);
+    const float meterH = std::max(16.0f, (footerY - GAP - readoutH) - y);
     const float meterX = contentX + 2.0f;
 
     if (m_meter) {
@@ -488,6 +499,66 @@ void UIMixerStrip::layoutChildren()
         const float faderW = std::max(16.0f, (contentX + contentW) - faderX);
         m_fader->setBounds(faderX, meterY, faderW, meterH);
     }
+
+    m_masterReadoutRect = isMaster
+        ? NUIRect{contentX, footerY - MASTER_READOUT_H, contentW, MASTER_READOUT_H}
+        : NUIRect{};
+}
+
+void UIMixerStrip::renderMasterReadout(NUIRenderer& renderer,
+                                       const Aestra::ChannelViewModel& channel)
+{
+    const NUIRect& area = m_masterReadoutRect;
+    if (area.width <= 0.0f || area.height <= 0.0f) return;
+
+    auto& theme = NUIThemeManager::getInstance();
+    const NUIColor labelColor = theme.getColor("textSecondary").withAlpha(0.72f);
+    const NUIColor valueColor = theme.getColor("textPrimary").withAlpha(0.95f);
+    const NUIColor clipColor = theme.getColor("meterCrit");
+
+    const bool clipped = channel.clipLatchL || channel.clipLatchR;
+
+    // Peak: prefer the held value, which is what the meter's hold line shows.
+    float peakDb = std::max(channel.smoothedPeakL, channel.smoothedPeakR);
+    if (channel.peakHoldL > Aestra::MixerMath::DB_MIN ||
+        channel.peakHoldR > Aestra::MixerMath::DB_MIN) {
+        peakDb = std::max(channel.peakHoldL, channel.peakHoldR);
+    }
+
+    char buf[32];
+    auto row = [&](int index, const char* label, const std::string& value, const NUIColor& color) {
+        const NUIRect rowRect{area.x, area.y + static_cast<float>(index) * MASTER_READOUT_ROW_H,
+                              area.width, MASTER_READOUT_ROW_H};
+        const float textY = renderer.calculateTextY(rowRect, 9.5f);
+        renderer.drawText(label, NUIPoint{rowRect.x, textY}, 9.5f, labelColor);
+
+        const float valueW = renderer.measureText(value, 9.5f).width;
+        renderer.drawText(value,
+                          NUIPoint{rowRect.x + rowRect.width - valueW, textY},
+                          9.5f, color);
+    };
+
+    // PEAK — dBFS, explicitly. Doubles as the clip/over indicator.
+    std::string peakText;
+    if (peakDb <= Aestra::MixerMath::DB_MIN) {
+        peakText = "\xE2\x88\x92\xE2\x88\x9E";
+    } else {
+        std::snprintf(buf, sizeof(buf), "%.1f", peakDb);
+        peakText = buf;
+    }
+    row(0, clipped ? "PEAK  OVER" : "PEAK  dBFS", peakText, clipped ? clipColor : valueColor);
+
+    // LUFS — integrated, and the sign always survives (see UIMixerMeter).
+    std::string lufsText = "--";
+    if (channel.integratedLufs > -100.0f) {
+        std::snprintf(buf, sizeof(buf), "%.1f", channel.integratedLufs);
+        lufsText = buf;
+    }
+    row(1, "LUFS  INT", lufsText, valueColor);
+
+    // GAIN — the fader's own value, named so it is not read as a level.
+    std::snprintf(buf, sizeof(buf), "%.1f", channel.faderGainDb);
+    row(2, "GAIN  dB", buf, valueColor);
 }
 
 void UIMixerStrip::onResize(int width, int height)
@@ -718,6 +789,9 @@ void UIMixerStrip::onRender(NUIRenderer& renderer)
     if (dragging) {
         invalidateStaticCache();
         renderChildren(renderer);
+        if (m_channelId == 0 && channel) {
+            renderMasterReadout(renderer, *channel);
+        }
         if (channel && channel->muted) {
             renderer.fillRect(getBounds(), m_mutedOverlay);
         }
@@ -751,6 +825,9 @@ void UIMixerStrip::onRender(NUIRenderer& renderer)
     */
 
     renderChildren(renderer);
+    if (m_channelId == 0 && channel) {
+        renderMasterReadout(renderer, *channel);
+    }
     if (m_channelId == 0 && m_viewModel && m_viewModel->isPreviewDuckingActive()) {
         auto& theme = NUIThemeManager::getInstance();
         const float duckGain = m_viewModel->getPreviewDuckGain();

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -578,8 +578,15 @@ void UIMixerStrip::renderMasterReadout(NUIRenderer& renderer,
 
     // --- User-controlled gain, under the fader ---
     if (gainArea.width > 0.0f) {
-        std::snprintf(buf, sizeof(buf), "%.1f", channel.faderGainDb);
-        block(gainArea, 0, "GAIN dB", buf, valueColor);
+        // Same silence floor as UIMixerFader::updateCachedText. Without it the
+        // fader reads "−∞" while the readout right under it reads "-90.0",
+        // which looks like two different values for one control.
+        std::string gainText = "\xE2\x88\x92\xE2\x88\x9E";
+        if (channel.faderGainDb > UIMixerFader::FADER_FLOOR_THRESHOLD) {
+            std::snprintf(buf, sizeof(buf), "%.1f", channel.faderGainDb);
+            gainText = buf;
+        }
+        block(gainArea, 0, "GAIN dB", gainText, valueColor);
     }
 }
 

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -50,9 +50,14 @@ namespace {
         if (targetId == 0 || targetName == "Master" || targetName == "MASTER") {
             return "M";
         }
-        const std::string insertPrefix = "Insert ";
-        if (targetName.rfind(insertPrefix, 0) == 0) {
-            return "I" + targetName.substr(insertPrefix.size());
+        const std::string channelPrefix = "Channel ";
+        if (targetName.rfind(channelPrefix, 0) == 0) {
+            return "C" + targetName.substr(channelPrefix.size());
+        }
+        // Projects saved before strips were renamed still carry "Insert N".
+        const std::string legacyInsertPrefix = "Insert ";
+        if (targetName.rfind(legacyInsertPrefix, 0) == 0) {
+            return "I" + targetName.substr(legacyInsertPrefix.size());
         }
         const std::string legacyTrackPrefix = "Track ";
         if (targetName.rfind(legacyTrackPrefix, 0) == 0) {

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -400,7 +400,6 @@ void UIMixerStrip::cacheThemeColors()
     auto& theme = NUIThemeManager::getInstance();
     m_selectedTint = theme.getColor("primary").withAlpha(0.022f);
     m_selectedOutline = theme.getColor("primary").withAlpha(0.18f);
-    m_selectedGlow = theme.getColor("primary").withAlpha(0.10f);
     m_selectedTopHighlight = theme.getColor("primary").withAlpha(0.18f);
     
     // Master: Distinct Dark Glass
@@ -766,17 +765,12 @@ void UIMixerStrip::onRender(NUIRenderer& renderer)
     }
 
     if (selected) {
-        // Flat selection: no drop shadow — a tint + top highlight + outline only.
+        // Selection is background contrast + a top accent bar + ONE outline.
+        // It previously stacked five layers on the same strip (tint, top bar,
+        // an inner 34px highlight, an outer glow ring and the outline), which
+        // is most of the "nested outlines" the mixer was accumulating.
         renderer.fillRoundedRect(bounds, radius, m_selectedTint);
-
         renderer.fillRect(NUIRect{bounds.x, bounds.y, bounds.width, SELECT_TOP_H}, m_selectedTopHighlight);
-        renderer.fillRoundedRect(NUIRect{bounds.x + 2.0f, bounds.y + 2.0f, bounds.width - 4.0f, 34.0f},
-                                 std::max(0.0f, radius - 2.0f),
-                                 m_selectedTopHighlight.withAlpha(0.05f));
-        renderer.strokeRoundedRect(NUIRect{bounds.x - 1.0f, bounds.y - 1.0f, bounds.width + 2.0f, bounds.height + 2.0f},
-                                   radius + 1.0f,
-                                   1.0f,
-                                   m_selectedGlow.withAlpha(0.14f));
         renderer.strokeRoundedRect(bounds, radius, 1.0f, m_selectedOutline);
     }
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -52,6 +52,9 @@ public:
     /// Bounds of the FX summary (Add Insert) button in strip-local space.
     NUIRect getFXSummaryBounds() const;
 
+    /// Close this strip's inline fader entry when a press lands outside it.
+    void dismissFaderEdit(const NUIPoint& position);
+
     // Request opening the inspector on the Inserts tab for this channel.
     std::function<void(uint32_t channelId)> onFXClicked;
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -83,7 +83,6 @@ private:
     // Cached theme colors
     NUIColor m_selectedTint;
     NUIColor m_selectedOutline;
-    NUIColor m_selectedGlow;
     NUIColor m_selectedTopHighlight;
     NUIColor m_masterBackground;
     NUIColor m_mutedOverlay;

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -17,6 +17,7 @@
 
 namespace Aestra {
 class MixerViewModel;
+struct ChannelViewModel;
 namespace Audio {
 class MeterSnapshotBuffer;
 class ContinuousParamBuffer;
@@ -112,10 +113,14 @@ private:
     int m_cachedFxCount{0};
     std::string m_cachedFxStatus;
 
+    /// Master-only: labelled Peak / LUFS / Gain block, computed in layoutChildren.
+    NUIRect m_masterReadoutRect{};
+
     void cacheThemeColors();
     void layoutChildren();
     void invalidateStaticCache();
     void renderStaticLayer(NUIRenderer& renderer);
+    void renderMasterReadout(NUIRenderer& renderer, const Aestra::ChannelViewModel& channel);
 };
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -115,8 +115,10 @@ private:
     int m_cachedFxCount{0};
     std::string m_cachedFxStatus;
 
-    /// Master-only: labelled Peak / LUFS / Gain block, computed in layoutChildren.
-    NUIRect m_masterReadoutRect{};
+    /// Master-only readouts, computed in layoutChildren. Split so each number
+    /// sits under the column that owns it: observed signal vs applied gain.
+    NUIRect m_masterMeterReadoutRect{};
+    NUIRect m_masterGainReadoutRect{};
 
     void cacheThemeColors();
     void layoutChildren();

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -136,7 +136,7 @@ void UIRoutingMap::rebuildGraph() {
         Node node;
         node.id = ch->id;
         node.type = Node::Track;
-        node.label = ch->name.empty() ? ("Insert " + std::to_string(i + 1)) : ch->name;
+        node.label = ch->name.empty() ? ("Channel " + std::to_string(i + 1)) : ch->name;
         node.color = paletteIndexToARGB(ch->trackColorIndex);
         node.insertCount = ch->fxCount;
         node.muted = ch->muted;

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "UIRoutingMap.h"
 
+#include "ChannelDisplayName.h"
 #include "NUIThemeSystem.h"
 #include "NUIRenderer.h"
 #include "MixerViewModel.h"
@@ -31,19 +32,6 @@ namespace {
     constexpr float kPortRadius = 5.0f;
     constexpr float kMinimapPortRadius = 3.0f;
     constexpr float kMinSplitHeight = 32.0f;
-
-    /// Display name for a channel with no explicit name.
-    ///
-    /// Derived from the *stable* channel id, matching TrackManager's own
-    /// default. Numbering from the dense list index instead drifts as soon as a
-    /// channel is deleted or an id is restored, so the map would label a strip
-    /// differently from the mixer and the engine.
-    std::string channelFallbackName(uint32_t channelId, const std::string& name)
-    {
-        if (!name.empty()) return name;
-        if (channelId == 0) return "MASTER";
-        return "Channel " + std::to_string(channelId);
-    }
 
     std::string fitLabel(NUIRenderer& renderer, const std::string& text, float fontSize, float maxWidth)
     {
@@ -149,7 +137,7 @@ void UIRoutingMap::rebuildGraph() {
         Node node;
         node.id = ch->id;
         node.type = Node::Track;
-        node.label = channelFallbackName(ch->id, ch->name);
+        node.label = channelDisplayName(ch->id, ch->name);
         node.color = paletteIndexToARGB(ch->trackColorIndex);
         node.insertCount = ch->fxCount;
         node.muted = ch->muted;
@@ -232,7 +220,7 @@ void UIRoutingMap::rebuildFocusedGraph(const Aestra::ChannelViewModel* selected)
     Node node;
     node.id = selected->id;
     node.type = Node::Track;
-    node.label = channelFallbackName(selected->id, selected->name);
+    node.label = channelDisplayName(selected->id, selected->name);
     node.color = paletteIndexToARGB(selected->trackColorIndex);
     node.insertCount = selected->fxCount;
     node.muted = selected->muted;

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -32,6 +32,19 @@ namespace {
     constexpr float kMinimapPortRadius = 3.0f;
     constexpr float kMinSplitHeight = 32.0f;
 
+    /// Display name for a channel with no explicit name.
+    ///
+    /// Derived from the *stable* channel id, matching TrackManager's own
+    /// default. Numbering from the dense list index instead drifts as soon as a
+    /// channel is deleted or an id is restored, so the map would label a strip
+    /// differently from the mixer and the engine.
+    std::string channelFallbackName(uint32_t channelId, const std::string& name)
+    {
+        if (!name.empty()) return name;
+        if (channelId == 0) return "MASTER";
+        return "Channel " + std::to_string(channelId);
+    }
+
     std::string fitLabel(NUIRenderer& renderer, const std::string& text, float fontSize, float maxWidth)
     {
         if (renderer.measureText(text, fontSize).width <= maxWidth) return text;
@@ -136,7 +149,7 @@ void UIRoutingMap::rebuildGraph() {
         Node node;
         node.id = ch->id;
         node.type = Node::Track;
-        node.label = ch->name.empty() ? ("Channel " + std::to_string(i + 1)) : ch->name;
+        node.label = channelFallbackName(ch->id, ch->name);
         node.color = paletteIndexToARGB(ch->trackColorIndex);
         node.insertCount = ch->fxCount;
         node.muted = ch->muted;
@@ -219,7 +232,7 @@ void UIRoutingMap::rebuildFocusedGraph(const Aestra::ChannelViewModel* selected)
     Node node;
     node.id = selected->id;
     node.type = Node::Track;
-    node.label = selected->name.empty() ? "Insert" : selected->name;
+    node.label = channelFallbackName(selected->id, selected->name);
     node.color = paletteIndexToARGB(selected->trackColorIndex);
     node.insertCount = selected->fxCount;
     node.muted = selected->muted;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3331,7 +3331,10 @@ void AestraContent::addDemoTracks() {
     for (int i = 1; i <= DEFAULT_TRACK_COUNT; ++i) {
         const std::string laneName = "Track " + std::to_string(i);
         PlaylistLaneID laneId = playlist.createLane(laneName);
-        m_trackManager->addChannel("Insert " + std::to_string(i));
+        // "Channel", not "Insert": an insert is an effect slot living *on* this
+        // strip, so naming the strip itself "Insert 1" produced instructions
+        // like "add an insert to Insert 1".
+        m_trackManager->addChannel("Channel " + std::to_string(i));
 
         if (auto* lane = playlist.getLane(laneId)) {
             // Cycle the shared track palette so the lane strip matches the

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -4160,6 +4160,11 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
     case AestraUI::NUIKeyCode::F3:
         toggleView(Audio::ViewType::Mixer);
         return true;
+    case AestraUI::NUIKeyCode::F4:
+        // The browser permanently consumed ~20% of the window; toggleFileBrowser
+        // existed but had no caller anywhere, so it could never be collapsed.
+        toggleFileBrowser();
+        return true;
     case AestraUI::NUIKeyCode::F5:
         toggleView(Audio::ViewType::Playlist);
         return true;

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -399,7 +399,7 @@ void AudioClipEditorPanel::rebuildRoutes(bool force) {
         if (!channel)
             continue;
         const std::string name =
-            channel->getName().empty() ? "Insert " + std::to_string(index + 1) : channel->getName();
+            channel->getName().empty() ? "Channel " + std::to_string(index + 1) : channel->getName();
         routes.push_back({channel->getChannelId(), static_cast<int>(index + 1), name,
                           paletteIndexToARGB(channel->getTrackColorIndex())});
     }

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -398,8 +398,14 @@ void AudioClipEditorPanel::rebuildRoutes(bool force) {
         const auto* channel = m_trackManager->getChannel(index);
         if (!channel)
             continue;
+        // Fall back to the stable channel id, matching TrackManager's own
+        // default naming. The dense list index drifts once a channel is
+        // deleted, which would label the same channel differently here than in
+        // the mixer.
         const std::string name =
-            channel->getName().empty() ? "Channel " + std::to_string(index + 1) : channel->getName();
+            channel->getName().empty()
+                ? "Channel " + std::to_string(channel->getChannelId())
+                : channel->getName();
         routes.push_back({channel->getChannelId(), static_cast<int>(index + 1), name,
                           paletteIndexToARGB(channel->getTrackColorIndex())});
     }

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -5,6 +5,7 @@
 #include "Commands/RenderAudioClipCommand.h"
 #include "Commands/SetAudioPatternMixerChannelCommand.h"
 #include "Commands/SetClipEditsCommand.h"
+#include "ChannelDisplayName.h"
 #include "NUIButton.h"
 #include "NUILabel.h"
 #include "NUIRenderer.h"
@@ -120,8 +121,8 @@ void AudioClipEditorPanel::buildUI() {
     m_sourceNameLabel = makeLabel("No audio clip selected", 14.0f);
     m_sourceNameLabel->setTextColor(theme.getColor("textPrimary"));
     m_sourceMetaLabel = makeLabel("");
-    m_routeLabel = makeLabel("OUTPUT INSERT", 10.0f);
-    m_routeHintLabel = makeLabel("Source route • Alt-drag this clip onto an Insert", 10.0f);
+    m_routeLabel = makeLabel("OUTPUT CHANNEL", 10.0f);
+    m_routeHintLabel = makeLabel("Source route • Alt-drag this clip onto a channel", 10.0f);
     m_routeHintLabel->setAlignment(NUILabel::Alignment::Right);
     m_routePicker = std::make_shared<UIInsertRoutePicker>();
     m_routePicker->setOnRouteSelected([this](uint32_t routeId) { selectRoute(routeId); });
@@ -335,8 +336,8 @@ void AudioClipEditorPanel::rebuildWaveform() {
     m_makeUniqueButton->setVisible(linkedInstances > 1);
     m_makeUniqueButton->setText(linkedInstances > 1 ? "Make unique" : "Unique");
     m_routeHintLabel->setText(linkedInstances > 1 ? "Shared source route • changes " + std::to_string(linkedInstances) +
-                                                        " clips • Alt-drag to an Insert"
-                                                  : "Unique source route • Alt-drag this clip onto an Insert");
+                                                        " clips • Alt-drag to a channel"
+                                                  : "Unique source route • Alt-drag this clip onto a channel");
 
     const size_t frameCount = static_cast<size_t>(buffer->numFrames);
     const size_t channels = static_cast<size_t>(buffer->numChannels);
@@ -398,14 +399,8 @@ void AudioClipEditorPanel::rebuildRoutes(bool force) {
         const auto* channel = m_trackManager->getChannel(index);
         if (!channel)
             continue;
-        // Fall back to the stable channel id, matching TrackManager's own
-        // default naming. The dense list index drifts once a channel is
-        // deleted, which would label the same channel differently here than in
-        // the mixer.
         const std::string name =
-            channel->getName().empty()
-                ? "Channel " + std::to_string(channel->getChannelId())
-                : channel->getName();
+            AestraUI::channelDisplayName(channel->getChannelId(), channel->getName());
         routes.push_back({channel->getChannelId(), static_cast<int>(index + 1), name,
                           paletteIndexToARGB(channel->getTrackColorIndex())});
     }

--- a/Tests/AestraAudio/ProjectDirtyStateTest.cpp
+++ b/Tests/AestraAudio/ProjectDirtyStateTest.cpp
@@ -206,7 +206,7 @@ int main() {
 
         // What addDemoTracks() does.
         for (int i = 1; i <= 50; ++i) {
-            tracks.addChannel("Insert " + std::to_string(i));
+            tracks.addChannel("Channel " + std::to_string(i));
         }
         require(tracks.isModified(),
                 "addChannel must still mark the project modified — the defect is not "

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -98,12 +98,13 @@ int main() {
     auto defaultNamesOwner = std::make_unique<TrackManager>();
     auto& defaultNames = *defaultNamesOwner;
     const auto* defaultInsert = defaultNames.addChannel();
-    require(defaultInsert && defaultInsert->getName() == "Insert 1",
-            "New mixer destinations must use Insert terminology");
-    require(defaultNames.removeChannelById(defaultInsert->getChannelId()), "Default insert deletion failed");
+    require(defaultInsert && defaultInsert->getName() == "Channel 1",
+            "New mixer destinations must use Channel terminology — 'Insert' is "
+            "reserved for the effect slots that live on a channel");
+    require(defaultNames.removeChannelById(defaultInsert->getChannelId()), "Default channel deletion failed");
     const auto* postDeleteInsert = defaultNames.addChannel();
-    require(postDeleteInsert && postDeleteInsert->getName() == "Insert 2",
-            "Default insert name reused a deleted channel number");
+    require(postDeleteInsert && postDeleteInsert->getName() == "Channel 2",
+            "Default channel name reused a deleted channel number");
 
     auto firstFreeTracksOwner = std::make_unique<TrackManager>();
     auto& firstFreeTracks = *firstFreeTracksOwner;

--- a/Tests/AestraUI/NUITextInputEditingTest.cpp
+++ b/Tests/AestraUI/NUITextInputEditingTest.cpp
@@ -1,0 +1,213 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+/**
+ * @file NUITextInputEditingTest.cpp
+ * @brief Regression tests for NUITextInput editing semantics.
+ *
+ * Locks the contract that broke in practice: **typing over a selection must
+ * replace it**, exactly as pasting over a selection already did.
+ *
+ * NUITextInput has two insertion entry points. insertText() (the paste path)
+ * always called deleteSelectedText() first; insertCharacter() (the keyboard
+ * path) did not — it inserted at the caret and returned. So selectAll() drew a
+ * highlight the keyboard never honoured, and because the caret sits at 0 after
+ * a select-all, typed characters were *prepended*.
+ *
+ * That failure is silent, which is why it survived: a numeric field seeded
+ * "6.0" and select-alled became "06.0" when the user typed "0" over it, and
+ * "06.0" parses straight back to 6.0 — the edit simply appeared to do nothing.
+ * Every field using select-all-then-type shares this path, including inline
+ * rename.
+ *
+ * Characters are driven through onKeyEvent() rather than the private
+ * insertCharacter(), so these tests exercise the real production path:
+ * AestraWindowManager's char callback dispatches to the focused component's
+ * onKeyEvent, which routes printable characters to insertCharacter().
+ */
+
+#include "Base/NUITextInput.h"
+#include <iostream>
+#include <string>
+
+using namespace AestraUI;
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define PASS(msg) do { std::cout << "  PASS: " << msg << "\n"; ++testsPassed; } while(0)
+#define FAIL(msg) do { std::cout << "  FAIL: " << msg << "\n"; ++testsFailed; } while(0)
+#define ASSERT(cond, msg) do { if (!(cond)) { FAIL(msg); return; } } while(0)
+
+namespace {
+
+/// A focused, visible input — onKeyEvent() drops everything otherwise.
+std::unique_ptr<NUITextInput> makeFocusedInput(const std::string& text)
+{
+    auto input = std::make_unique<NUITextInput>(text);
+    input->setVisible(true);
+    input->setFocused(true);
+    return input;
+}
+
+/// Deliver one printable character the way the platform does.
+void typeChar(NUITextInput& input, char c)
+{
+    NUIKeyEvent event;
+    event.keyCode = NUIKeyCode::Unknown;  // not a navigation/edit key
+    event.character = c;
+    event.pressed = true;
+    input.onKeyEvent(event);
+}
+
+void typeString(NUITextInput& input, const std::string& s)
+{
+    for (char c : s) {
+        typeChar(input, c);
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The regression: keyboard insertion must replace a selection
+// ---------------------------------------------------------------------------
+static void test_typing_replaces_selection() {
+    auto input = makeFocusedInput("0.0");
+    input->selectAll();
+
+    typeChar(*input, '5');
+
+    ASSERT(input->getText() == "5",
+           "typing over a full selection must replace it, not insert at the caret "
+           "(got '" + input->getText() + "')");
+    PASS("typing over a selection replaces it");
+}
+
+static void test_paste_replaces_selection() {
+    auto input = makeFocusedInput("0.0");
+    input->selectAll();
+
+    input->insertText("5");
+
+    ASSERT(input->getText() == "5",
+           "pasting over a full selection must replace it (got '" + input->getText() + "')");
+    PASS("pasting over a selection replaces it");
+}
+
+/// The two entry points must not disagree — that divergence *was* the bug.
+static void test_keyboard_and_paste_parity() {
+    auto typed = makeFocusedInput("0.0");
+    typed->selectAll();
+    typeChar(*typed, '5');
+
+    auto pasted = makeFocusedInput("0.0");
+    pasted->selectAll();
+    pasted->insertText("5");
+
+    ASSERT(typed->getText() == pasted->getText(),
+           "keyboard and paste must produce identical text over a selection "
+           "(keyboard '" + typed->getText() + "' vs paste '" + pasted->getText() + "')");
+    ASSERT(typed->getCaretPosition() == pasted->getCaretPosition(),
+           "keyboard and paste must leave the caret in the same place");
+    PASS("keyboard/paste parity over a selection");
+}
+
+static void test_selection_cleared_and_caret_after_replacement() {
+    auto input = makeFocusedInput("0.0");
+    input->selectAll();
+
+    typeChar(*input, '5');
+
+    ASSERT(input->getSelectedText().empty(),
+           "the selection must be consumed by the replacement");
+    ASSERT(input->getCaretPosition() == 1,
+           "caret must land after the replacement text, not at 0");
+    PASS("selection cleared and caret lands after replacement");
+}
+
+// ---------------------------------------------------------------------------
+// The unselected path must keep working — the fix must not turn every
+// keystroke into a replacement.
+// ---------------------------------------------------------------------------
+static void test_no_selection_inserts_at_caret() {
+    auto input = makeFocusedInput("abc");
+    input->setCaretPosition(1);
+
+    typeChar(*input, 'X');
+
+    ASSERT(input->getText() == "aXbc",
+           "with no selection a character must insert at the caret "
+           "(got '" + input->getText() + "')");
+    ASSERT(input->getCaretPosition() == 2, "caret advances past the inserted character");
+    PASS("no selection inserts at the caret");
+}
+
+static void test_no_selection_append_at_end() {
+    auto input = makeFocusedInput("ab");
+    input->setCaretPosition(2);
+
+    typeChar(*input, 'c');
+
+    ASSERT(input->getText() == "abc",
+           "typing at the end appends (got '" + input->getText() + "')");
+    PASS("no selection appends at end of text");
+}
+
+// ---------------------------------------------------------------------------
+// The case that exposed it: a numeric readout edited in place.
+// ---------------------------------------------------------------------------
+static void test_negative_value_entry_over_selection() {
+    auto input = makeFocusedInput("0.0");
+    input->selectAll();
+
+    typeString(*input, "-4.5");
+
+    ASSERT(input->getText() == "-4.5",
+           "select-all then typing a negative value must yield exactly that value "
+           "(got '" + input->getText() + "')");
+    ASSERT(input->getSelectedText().empty(), "selection consumed by the first keystroke");
+    ASSERT(input->getCaretPosition() == 4, "caret at end of the typed value");
+    PASS("negative value typed over a selection yields exactly that value");
+}
+
+/// The precise silent-no-op that was shipping: "6.0" + typing "0" -> "06.0",
+/// which parses back to 6.0, so the edit looked like it did nothing at all.
+static void test_prepend_regression_is_gone() {
+    auto input = makeFocusedInput("6.0");
+    input->selectAll();
+
+    typeChar(*input, '0');
+
+    ASSERT(input->getText() != "06.0",
+           "regression: the typed character was prepended to the selected text");
+    ASSERT(input->getText() == "0",
+           "typing '0' over a selected '6.0' must leave exactly '0' "
+           "(got '" + input->getText() + "')");
+    PASS("no prepend-instead-of-replace regression");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+int main() {
+    std::cout << "========================================\n";
+    std::cout << "  NUITextInput Editing Regression Tests\n";
+    std::cout << "========================================\n\n";
+
+    test_typing_replaces_selection();
+    test_paste_replaces_selection();
+    test_keyboard_and_paste_parity();
+    test_selection_cleared_and_caret_after_replacement();
+    test_no_selection_inserts_at_caret();
+    test_no_selection_append_at_end();
+    test_negative_value_entry_over_selection();
+    test_prepend_regression_is_gone();
+
+    std::cout << "\n========================================\n";
+    if (testsFailed == 0) {
+        std::cout << "  All " << testsPassed << " tests passed.\n";
+    } else {
+        std::cout << "  " << testsPassed << " passed, " << testsFailed << " failed.\n";
+    }
+    std::cout << "========================================\n";
+    return testsFailed > 0 ? 1 : 0;
+}

--- a/Tests/AestraUI/NUITextInputLayoutTest.cpp
+++ b/Tests/AestraUI/NUITextInputLayoutTest.cpp
@@ -226,6 +226,80 @@ static void test_hit_testing_accounts_for_padding() {
 }
 
 // ---------------------------------------------------------------------------
+// Justification offset — caret/selection must follow the glyphs
+//
+// Text drawing applied a justification offset, but the caret and selection
+// rects were built from raw charX values. On a centred or right-aligned field
+// both were therefore drawn hard against the left edge while the glyphs sat
+// elsewhere. Left-aligned fields (the default, and nearly every field in the
+// app) get 0, which is why this hid until a centred numeric readout appeared.
+//
+// No renderer needed: the offset is derived from charX.back(), so a synthetic
+// TextLine is enough.
+// ---------------------------------------------------------------------------
+static TextLine makeLineOfWidth(float width) {
+    TextLine line;
+    line.startIndex = 0;
+    line.endIndex = 3;
+    line.charX = {0.0f, width * 0.5f, width};
+    return line;
+}
+
+static void test_justification_offset_left_is_zero() {
+    TestableTextInput input("abc");
+    input.setJustification(NUITextInput::Justification::Left);
+    const TextLine line = makeLineOfWidth(40.0f);
+
+    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 0.0f,
+           "left-aligned text must not be offset");
+    PASS("justification offset: left is zero");
+}
+
+static void test_justification_offset_center_halves_the_slack() {
+    TestableTextInput input("abc");
+    input.setJustification(NUITextInput::Justification::Center);
+    const TextLine line = makeLineOfWidth(40.0f);
+
+    // 100 available - 40 used = 60 slack, centred -> 30
+    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 30.0f,
+           "centred text offset must be half the leftover width");
+    PASS("justification offset: centre halves the slack");
+}
+
+static void test_justification_offset_right_uses_all_slack() {
+    TestableTextInput input("abc");
+    input.setJustification(NUITextInput::Justification::Right);
+    const TextLine line = makeLineOfWidth(40.0f);
+
+    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 60.0f,
+           "right-aligned text offset must consume the whole leftover width");
+    PASS("justification offset: right uses all slack");
+}
+
+static void test_justification_offset_never_negative_when_overflowing() {
+    TestableTextInput input("abc");
+    input.setJustification(NUITextInput::Justification::Center);
+    const TextLine line = makeLineOfWidth(200.0f);
+
+    // Text wider than the field must not drag the caret off to the left.
+    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 0.0f,
+           "overflowing text must clamp the offset to zero, not go negative");
+    PASS("justification offset: clamps to zero when text overflows");
+}
+
+static void test_justification_offset_empty_line() {
+    TestableTextInput input("");
+    input.setJustification(NUITextInput::Justification::Center);
+    TextLine line;
+    line.charX = {0.0f};  // INVARIANT: always at least position 0
+
+    // An empty line has zero width, so the caret centres in the whole field.
+    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 50.0f,
+           "empty centred line puts the caret at the field centre");
+    PASS("justification offset: empty line centres the caret");
+}
+
+// ---------------------------------------------------------------------------
 // Blink timer regression
 // ---------------------------------------------------------------------------
 static void test_blink_timer_is_per_instance() {
@@ -260,6 +334,11 @@ int main() {
     test_getLineRenderY_includes_bounds_and_padding();
     test_getTextPosition_widget_space();
     test_hit_testing_accounts_for_padding();
+    test_justification_offset_left_is_zero();
+    test_justification_offset_center_halves_the_slack();
+    test_justification_offset_right_uses_all_slack();
+    test_justification_offset_never_negative_when_overflowing();
+    test_justification_offset_empty_line();
     test_blink_timer_is_per_instance();
 
     std::cout << "\n========================================\n";

--- a/Tests/AestraUI/NUITextInputLayoutTest.cpp
+++ b/Tests/AestraUI/NUITextInputLayoutTest.cpp
@@ -42,6 +42,9 @@ public:
     float callGetLineRenderY(const TextLine& line) const { return getLineRenderY(line); }
     NUIPoint callGetTextPosition(int idx) const { return getTextPosition(idx); }
     int callGetCharacterIndexAtPosition(const NUIPoint& pos) const { return getCharacterIndexAtPosition(pos); }
+    float callJustificationOffsetForLine(const TextLine& line, float availableWidth) const {
+        return justificationOffsetForLine(line, availableWidth);
+    }
 
     const std::vector<TextLine>& getLayoutLines() const { return layoutLines_; }
 
@@ -250,7 +253,7 @@ static void test_justification_offset_left_is_zero() {
     input.setJustification(NUITextInput::Justification::Left);
     const TextLine line = makeLineOfWidth(40.0f);
 
-    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 0.0f,
+    ASSERT(input.callJustificationOffsetForLine(line, 100.0f) == 0.0f,
            "left-aligned text must not be offset");
     PASS("justification offset: left is zero");
 }
@@ -261,7 +264,7 @@ static void test_justification_offset_center_halves_the_slack() {
     const TextLine line = makeLineOfWidth(40.0f);
 
     // 100 available - 40 used = 60 slack, centred -> 30
-    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 30.0f,
+    ASSERT(input.callJustificationOffsetForLine(line, 100.0f) == 30.0f,
            "centred text offset must be half the leftover width");
     PASS("justification offset: centre halves the slack");
 }
@@ -271,7 +274,7 @@ static void test_justification_offset_right_uses_all_slack() {
     input.setJustification(NUITextInput::Justification::Right);
     const TextLine line = makeLineOfWidth(40.0f);
 
-    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 60.0f,
+    ASSERT(input.callJustificationOffsetForLine(line, 100.0f) == 60.0f,
            "right-aligned text offset must consume the whole leftover width");
     PASS("justification offset: right uses all slack");
 }
@@ -282,7 +285,7 @@ static void test_justification_offset_never_negative_when_overflowing() {
     const TextLine line = makeLineOfWidth(200.0f);
 
     // Text wider than the field must not drag the caret off to the left.
-    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 0.0f,
+    ASSERT(input.callJustificationOffsetForLine(line, 100.0f) == 0.0f,
            "overflowing text must clamp the offset to zero, not go negative");
     PASS("justification offset: clamps to zero when text overflows");
 }
@@ -294,7 +297,7 @@ static void test_justification_offset_empty_line() {
     line.charX = {0.0f};  // INVARIANT: always at least position 0
 
     // An empty line has zero width, so the caret centres in the whole field.
-    ASSERT(input.justificationOffsetForLine(line, 100.0f) == 50.0f,
+    ASSERT(input.callJustificationOffsetForLine(line, 100.0f) == 50.0f,
            "empty centred line puts the caret at the field centre");
     PASS("justification offset: empty line centres the caret");
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1738,6 +1738,24 @@ else()
     message(STATUS "NUITextInputLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# NUITextInput editing semantics — typing over a selection must replace it,
+# matching the paste path. Kept separate from the layout tests so the
+# behavioural regression stays legible.
+if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUITextInputEditingTest.cpp")
+    add_executable(NUITextInputEditingTest AestraUI/NUITextInputEditingTest.cpp)
+    target_link_libraries(NUITextInputEditingTest PRIVATE AestraUI_Core AestraPlat)
+    target_include_directories(NUITextInputEditingTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Base
+        ${CMAKE_SOURCE_DIR}/AestraPlat/include
+    )
+    add_test(NAME NUITextInputEditingTest COMMAND NUITextInputEditingTest)
+    set_tests_properties(NUITextInputEditingTest PROPERTIES LABELS "ui;textinput;regression")
+    message(STATUS "NUITextInputEditingTest added - selection-replace editing regression tests")
+else()
+    message(STATUS "NUITextInputEditingTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 if(TARGET AestraUI_Core)
     add_executable(NUIDropdownInteractionTest AestraUI/NUIDropdownInteractionTest.cpp)
     target_link_libraries(NUIDropdownInteractionTest PRIVATE AestraUI_Core)


### PR DESCRIPTION
Mixer semantic + functional hierarchy pass, from owner review feedback. The goal was not a redesign — it was to make state readable at a glance: what is selected, what is sounding, what is clipping, and what each control will change.

## The headline is a renderer bug, not styling

Chasing a missing LUFS value turned up a defect with far wider reach than the mixer.

`NUIRendererGL::renderTextWithFont` snaps all four glyph edges with `round()` so the atlas samples 1:1 and small labels stay crisp. **The hyphen-minus rasterises to 7x1 px** at the small atlases, so `round(gy) == round(gy + h)` — the quad collapsed to zero height and the glyph drew nothing, with no advance gap to hint anything was missing.

**Every negative number in the app was losing its minus sign**, intermittently, depending on where the baseline landed relative to `.5`. `-13.5` rendered as `13.5`. That inverts meaning on dB, LUFS, pan, trim and correlation.

Fix: keep at least one pixel of quad whenever the source glyph has coverage. Verified with a probe string — `-1.5A` rendered as `1.5A` before, `-1.5A` after.

It hid this long because no other string in that panel contains an ASCII hyphen: `−∞` is U+2212.

## Two more latent defects surfaced

- **`event.doubleClick` is never populated by the platform.** Nothing in the tree assigns it, so double-click reset on faders *and* knobs was unreachable dead code. Fixed with the house pairing pattern (`UnitNameLabel` already did this).
- **`AestraContent::toggleFileBrowser()` had zero callers** — fully implemented, no menu item, button or shortcut. The browser could not be collapsed at all. Bound to F4 alongside the existing F3/F5/F6/F7 toggles.

## The eight review items

1. **Meters vs faders.** The fader rail was filled with the per-channel track colour, so each strip showed two bright coloured bars and neither read as "control state" or "live signal". Rail is now neutral; the accent tints only the engaged handle edge. Meter rail gained a faint resting outline so a silent channel shows where level will appear.
2. **"Insert" reserved for effect slots.** Strips are `Channel N`. Renamed at source (`TrackManager` default, demo tracks) and every display fallback. Projects saved with the old names still resolve — `compactRouteName` and the item-selector number matcher keep the legacy `Insert N` / `Track N` prefixes.
3. **Master metering.** Bars labelled L/R; the meter yields its cramped text area. Readouts split by ownership — `PEAK dBFS` and `LUFS INT` under the meter, `GAIN dB` under the fader — so left = observed signal, right = applied gain.
4. **Colour de-duplicated.** Track colour no longer threaded into the trim/pan/width knob arcs; arcs rest neutral and take the accent only while engaged. Header keeps identity.
5. **Insert rack.** Populated slots plus a single always-labelled `+ Add Insert`, with `No effects on this channel` as a deliberate empty state. Spares reappear during a reorder drag. `hitTestSlot` bounded to match, so clicking below the rack no longer targets an invisible slot.
6. **Faders.** Rail 4→6px, cap 32x18→36x22 with a grip, restrained ticks with an emphasised 0 dB unity mark, and a click-to-type readout. That also fixed the readout slamming the fader when clicked.
7. **Borders flattened.** Selection went from five stacked layers to a tinted body plus a top accent, no outline. Dropped the inset bevel double-stroke on four controls and the rack's outer border.
8. **Collapse.** Browser on F4; inspector collapses to a 16px rail, with every layout site deriving from `inspectorWidth()` so the freed width goes to the strips. Verified live: 3.5 → 6 visible channels.

## Shared-widget change worth extra review

`NUITextInput` applied a justification offset when drawing text but computed caret and selection X from raw `charX`, so on a centred field both were drawn hard against the left edge while the glyphs sat in the middle. Added `justificationOffsetForLine()` and applied it in both places.

Left-aligned inputs get `0` and are unaffected. This also fixes the same latent bug in `UIItemSelector`, the only other centred input in the tree.

## Verification

- Full build clean; **228/228 tests pass** (1 pre-existing skip).
- No test registration changed: `git diff origin/develop...HEAD -- Tests/cmake/` is empty. A name-level diff against a `develop` scratch configure confirms nothing present in develop is missing here.
- Driven live: rename, neutral faders, master readouts, insert rack, inspector collapse, editor dismissal and caret alignment all confirmed on screen.

## Known gaps

- ~~Real-signal meter QA~~ — **done**, see the QA comment below. Sustained signal, transients, stereo imbalance, colour zones, peak hold, clipping/`OVER`, latch clear, decay and silence return all verified against live audio. That run also found and fixed a further shared-widget bug: typing over a selection inserted instead of replacing (`NUITextInput::insertCharacter` never checked `hasSelection_`), which affects every text field including inline rename.
- **The glyph-collapse fix has no regression test.** Asserting it needs a GL context the headless suite does not have. Extracting the edge-snap into a pure testable function is the obvious follow-up.
- **Inspector collapse does not persist across restart** here — that is deliberate scope. Persistence is built and parked on `ui/mixer-inspector-persistence`, to be opened as its own PR once this lands, so the two stay independently reviewable rather than stacked.
  *(Correction to an earlier draft of this description: I claimed mixer open/maximised state persists. It does not — `ViewState` has no save/load and `ProjectSerializer` does not carry it. Nothing about view layout was persisted before now.)*
- Channel-name inheritance from the routed track was deliberately **not** attempted — it needs its own behavioural spec (ownership, manual-rename precedence, re-routing, lane deletion) rather than a label change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes. Added optional mixer APIs for fader editing, meter master mode, and collapsible inspector panels.
- Clarified mixer hierarchy and labels for channels, meters, faders, inserts, borders, and signal levels.
- Fixed negative-value glyphs, text replacement, caret and selection alignment, double-click resets, numeric matching, rack scrolling, and NaN/Inf handling.
- Added meter QA improvements for peak hold, clipping, `OVER`, stereo levels, and master readouts.
- Added regression coverage for text editing and justification offsets.
- Build and 229/229 tests pass. Inspector-collapse persistence and GL glyph/channel-name inheritance coverage remain follow-up work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->