### PR TITLE
Persist inspector collapse as a UI preference, not project state

### DIFF
--- a/AestraUI/Widgets/InspectorCollapseState.h
+++ b/AestraUI/Widgets/InspectorCollapseState.h
@@ -1,0 +1,61 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+namespace AestraUI {
+
+/**
+ * @brief Collapse state for the mixer inspector: explicit intent vs. derived fit.
+ *
+ * Two states, not one. A single bool cannot express "the user wants this open,
+ * but there is no room for it right now" — and collapsing that distinction is
+ * how a responsive layout ends up destroying a preference the user set
+ * deliberately.
+ *
+ *   effectiveExpanded = expandedPreference && !forcedCollapsed
+ *
+ * - `expandedPreference` is the user's last *explicit* choice. It is the only
+ *   part that persists, and width changes must never write to it.
+ * - `forcedCollapsed` is derived from available width and is recomputed on
+ *   every layout. It is never persisted.
+ *
+ * Kept as a plain struct with no UI or renderer dependency so the transition
+ * sequences can be tested directly — those orderings are the easy thing to get
+ * wrong, and they are invisible in a screenshot.
+ */
+struct InspectorCollapseState {
+    /// Persisted explicit user choice. First run defaults to expanded.
+    bool expandedPreference{true};
+
+    /// Derived from available width; recomputed per layout, never persisted.
+    bool forcedCollapsed{false};
+
+    /// What the panel should actually draw.
+    bool effectiveExpanded() const { return expandedPreference && !forcedCollapsed; }
+
+    /// Recompute the width-driven constraint. Deliberately does not touch the
+    /// preference — that is the whole point of keeping the two apart.
+    void setForcedCollapsed(bool forced) { forcedCollapsed = forced; }
+
+    /**
+     * @brief Handle a click on the collapse rail.
+     *
+     * While width-constrained the panel is collapsed no matter what the
+     * preference says, so the only intent a click can express there is "I want
+     * this open". Recording that (rather than toggling, or ignoring the click)
+     * means the inspector reappears by itself once the width returns, instead
+     * of silently discarding what the user asked for.
+     */
+    void onRailClicked()
+    {
+        if (forcedCollapsed) {
+            expandedPreference = true;
+            return;
+        }
+        expandedPreference = !expandedPreference;
+    }
+
+    /// Restore the first-run default (reset layout / reset preferences).
+    void reset() { expandedPreference = true; forcedCollapsed = false; }
+};
+
+} // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -298,7 +298,17 @@ void UIMixerPanel::updateInspectorWidthConstraint()
     const float needed = MASTER_STRIP_WIDTH + STRIP_SPACING + INSPECTOR_WIDTH + STRIP_SPACING
                        + MIN_STRIPS_BESIDE_INSPECTOR * (STRIP_WIDTH + STRIP_SPACING);
 
+    const bool wasForced = m_inspectorCollapse.forcedCollapsed;
     m_inspectorCollapse.setForcedCollapsed(available < needed);
+
+    // The "window too narrow" tooltip is raised and cleared from onMouseEvent,
+    // and only when the pointer crosses the rail boundary. Widening the window
+    // lifts the constraint without moving the pointer, so a tooltip shown while
+    // narrow would keep asserting a reason that no longer holds until the user
+    // happened to move off the rail. Clear it as the constraint lifts.
+    if (wasForced && !m_inspectorCollapse.forcedCollapsed && m_inspectorToggleHovered) {
+        NUIComponent::hideRemoteTooltip(this);
+    }
 }
 
 void UIMixerPanel::setInspectorExpandedPreference(bool expanded)

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -296,7 +296,7 @@ void UIMixerPanel::updateInspectorWidthConstraint()
     // The inspector only earns its width if the strips it sits beside are still
     // usable. Below that, collapse is imposed regardless of preference.
     const float needed = MASTER_STRIP_WIDTH + STRIP_SPACING + INSPECTOR_WIDTH + STRIP_SPACING
-                       + kMinStripsBesideInspector * (STRIP_WIDTH + STRIP_SPACING);
+                       + MIN_STRIPS_BESIDE_INSPECTOR * (STRIP_WIDTH + STRIP_SPACING);
 
     m_inspectorCollapse.setForcedCollapsed(available < needed);
 }

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -224,6 +224,9 @@ void UIMixerPanel::setPlatformBridge(NUIPlatformBridge* bridge)
 
 void UIMixerPanel::layoutMeters()
 {
+    // Derived state first: the rest of the layout reads inspectorWidth().
+    updateInspectorWidthConstraint();
+
     auto bounds = getBounds();
     const NUIRect minimapRect = getMinimapRect();
     const float stripY = minimapRect.bottom() + MINIMAP_GAP;
@@ -242,8 +245,8 @@ void UIMixerPanel::layoutMeters()
         // Collapsed, the inspector yields its width to the channel strips and
         // leaves only the re-open rail drawn by the panel.
         m_inspector->setBounds(inspectorX, stripY, INSPECTOR_WIDTH, stripHeight);
-        m_inspector->setVisible(!m_inspectorCollapsed);
-        if (!m_inspectorCollapsed) {
+        m_inspector->setVisible(!isInspectorCollapsed());
+        if (!isInspectorCollapsed()) {
             m_inspector->onResize(static_cast<int>(INSPECTOR_WIDTH), static_cast<int>(stripHeight));
         }
     }
@@ -279,17 +282,48 @@ NUIRect UIMixerPanel::getInspectorToggleRect() const
 
     // Collapsed: the whole thin rail is the target. Expanded: a grip strip down
     // the inspector's leading edge.
-    const float railW = m_inspectorCollapsed ? INSPECTOR_COLLAPSED_WIDTH : 10.0f;
+    const float railW = isInspectorCollapsed() ? INSPECTOR_COLLAPSED_WIDTH : 10.0f;
     return NUIRect{inspectorX, stripY, railW, stripHeight};
 }
 
-void UIMixerPanel::setInspectorCollapsed(bool collapsed)
+void UIMixerPanel::updateInspectorWidthConstraint()
 {
-    if (m_inspectorCollapsed == collapsed) {
+    const float available = getBounds().width;
+    if (available <= 0.0f) {
+        return; // Pre-layout; leave the constraint alone rather than guessing.
+    }
+
+    // The inspector only earns its width if the strips it sits beside are still
+    // usable. Below that, collapse is imposed regardless of preference.
+    const float needed = MASTER_STRIP_WIDTH + STRIP_SPACING + INSPECTOR_WIDTH + STRIP_SPACING
+                       + kMinStripsBesideInspector * (STRIP_WIDTH + STRIP_SPACING);
+
+    m_inspectorCollapse.setForcedCollapsed(available < needed);
+}
+
+void UIMixerPanel::setInspectorExpandedPreference(bool expanded)
+{
+    if (m_inspectorCollapse.expandedPreference == expanded) {
         return;
     }
-    m_inspectorCollapsed = collapsed;
+    m_inspectorCollapse.expandedPreference = expanded;
+    if (onInspectorPreferenceChanged) {
+        onInspectorPreferenceChanged(expanded);
+    }
     layoutMeters();
+    repaint();
+}
+
+void UIMixerPanel::toggleInspectorCollapsed()
+{
+    const bool before = m_inspectorCollapse.expandedPreference;
+    m_inspectorCollapse.onRailClicked();
+    if (m_inspectorCollapse.expandedPreference != before) {
+        if (onInspectorPreferenceChanged) {
+            onInspectorPreferenceChanged(m_inspectorCollapse.expandedPreference);
+        }
+        layoutMeters();
+    }
     repaint();
 }
 
@@ -510,17 +544,26 @@ void UIMixerPanel::onRender(NUIRenderer& renderer)
     {
         auto& theme = NUIThemeManager::getInstance();
         const NUIRect rail = getInspectorToggleRect();
+        const bool collapsed = isInspectorCollapsed();
+        const bool forced = isInspectorForcedCollapsed();
+
+        // A width-imposed collapse reads as unavailable rather than chosen: the
+        // rail still accepts the click (it records intent) but must not look
+        // like it will open the panel right now, or it feels broken.
         const NUIColor railColor = m_inspectorToggleHovered
-            ? theme.getColor("accentPrimary").withAlpha(0.34f)
-            : theme.getColor("surfaceTertiary").withAlpha(m_inspectorCollapsed ? 0.72f : 0.34f);
+            ? theme.getColor("accentPrimary").withAlpha(forced ? 0.18f : 0.34f)
+            : theme.getColor("surfaceTertiary").withAlpha(collapsed ? 0.72f : 0.34f);
         renderer.fillRoundedRect(rail, 3.0f, railColor);
 
         // Chevron points the way the panel will move.
-        const NUIColor glyph = theme.getColor("textSecondary")
-                                   .withAlpha(m_inspectorToggleHovered ? 0.95f : 0.6f);
+        float glyphAlpha = m_inspectorToggleHovered ? 0.95f : 0.6f;
+        if (forced) {
+            glyphAlpha *= 0.45f;
+        }
+        const NUIColor glyph = theme.getColor("textSecondary").withAlpha(glyphAlpha);
         const float cx = rail.x + rail.width * 0.5f;
         const float cy = rail.y + rail.height * 0.5f;
-        const float dir = m_inspectorCollapsed ? -1.0f : 1.0f;
+        const float dir = collapsed ? -1.0f : 1.0f;
         for (int i = 0; i < 5; ++i) {
             const float dy = static_cast<float>(i) - 2.0f;
             const float dx = dir * (2.0f - std::abs(dy));
@@ -568,6 +611,16 @@ bool UIMixerPanel::onMouseEvent(const NUIMouseEvent& event)
         const bool overRail = rail.contains(event.position);
         if (m_inspectorToggleHovered != overRail) {
             m_inspectorToggleHovered = overRail;
+            if (overRail && isInspectorForcedCollapsed()) {
+                // Say why it will not open, so a recorded-but-not-applied click
+                // reads as "waiting for room" instead of "ignored".
+                NUIComponent::showRemoteTooltip(
+                    "Inspector hidden - window too narrow",
+                    NUIPoint{rail.x + rail.width + 8.0f, rail.y + rail.height * 0.5f},
+                    this);
+            } else if (!overRail) {
+                NUIComponent::hideRemoteTooltip(this);
+            }
             repaint();
         }
         if (overRail && event.pressed && event.button == NUIMouseButton::Left) {

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -5,6 +5,7 @@
 #include "NUIComponent.h"
 #include "NUIDragDrop.h"
 #include "NUITypes.h"
+#include "InspectorCollapseState.h"
 #include "UIMixerInspector.h"
 #include "UIMixerMeter.h"
 #include "UIMixerPluginDropdown.h"
@@ -92,15 +93,31 @@ public:
      * A dedicated mixer view should be able to become almost entirely channel
      * strips; collapsing the inspector returns its width to the strips.
      */
-    void setInspectorCollapsed(bool collapsed);
-    bool isInspectorCollapsed() const { return m_inspectorCollapsed; }
-    void toggleInspectorCollapsed() { setInspectorCollapsed(!m_inspectorCollapsed); }
+    /// Explicit user intent. Persisted; width changes never write to it.
+    void setInspectorExpandedPreference(bool expanded);
+    bool getInspectorExpandedPreference() const { return m_inspectorCollapse.expandedPreference; }
+
+    /// What the panel actually draws right now.
+    bool isInspectorCollapsed() const { return !m_inspectorCollapse.effectiveExpanded(); }
+
+    /// True when the collapse is imposed by width rather than chosen.
+    bool isInspectorForcedCollapsed() const { return m_inspectorCollapse.forcedCollapsed; }
+
+    /// Rail click — records intent even while width-constrained.
+    void toggleInspectorCollapsed();
+
+    /// Fires only when the *explicit* preference changes, so the host can
+    /// persist it. Width-driven collapse deliberately does not fire.
+    std::function<void(bool expanded)> onInspectorPreferenceChanged;
 
 private:
     /// Current inspector width — the collapsed rail or the full panel.
     float inspectorWidth() const {
-        return m_inspectorCollapsed ? INSPECTOR_COLLAPSED_WIDTH : INSPECTOR_WIDTH;
+        return m_inspectorCollapse.effectiveExpanded() ? INSPECTOR_WIDTH : INSPECTOR_COLLAPSED_WIDTH;
     }
+
+    /// Recompute the width-driven constraint from the current bounds.
+    void updateInspectorWidthConstraint();
 
     /// Rail/handle that collapses or restores the inspector.
     NUIRect getInspectorToggleRect() const;
@@ -139,7 +156,7 @@ private:
 
     /// Inspector panel (pinned on the right, before master)
     std::shared_ptr<UIMixerInspector> m_inspector;
-    bool m_inspectorCollapsed{false};
+    InspectorCollapseState m_inspectorCollapse;
     bool m_inspectorToggleHovered{false};
 
     /// Plugin finder dropdown (topmost, shown on Add Insert click)
@@ -164,6 +181,9 @@ private:
     static constexpr float MASTER_STRIP_WIDTH = 146.0f;
     static constexpr float INSPECTOR_WIDTH = 236.0f;
     static constexpr float INSPECTOR_COLLAPSED_WIDTH = 16.0f;
+    /// Strips that must remain usable beside the inspector before its width is
+    /// worth spending; below this the collapse is imposed by layout.
+    static constexpr int kMinStripsBesideInspector = 4;
     static constexpr float MINIMAP_HEIGHT = 22.0f;
     static constexpr float MINIMAP_GAP = 6.0f;
     static constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;

--- a/AestraUI/Widgets/UIMixerPanel.h
+++ b/AestraUI/Widgets/UIMixerPanel.h
@@ -183,7 +183,7 @@ private:
     static constexpr float INSPECTOR_COLLAPSED_WIDTH = 16.0f;
     /// Strips that must remain usable beside the inspector before its width is
     /// worth spending; below this the collapse is imposed by layout.
-    static constexpr int kMinStripsBesideInspector = 4;
+    static constexpr int MIN_STRIPS_BESIDE_INSPECTOR = 4;
     static constexpr float MINIMAP_HEIGHT = 22.0f;
     static constexpr float MINIMAP_GAP = 6.0f;
     static constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;

--- a/Source/Core/MixerUIPreferences.h
+++ b/Source/Core/MixerUIPreferences.h
@@ -1,0 +1,135 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraJSON.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+namespace Aestra {
+
+/**
+ * @brief Mixer layout preferences that belong to the *application*, not a project.
+ *
+ * Switching projects must never rearrange the mixer, so this deliberately does
+ * not go through ProjectSerializer. Mirrors browser_settings.json, which already
+ * persists FileBrowser layout the same way.
+ *
+ * Split out of MixerPanel so the save/load round trip is reachable from a test
+ * without constructing a panel, a TrackManager or a renderer — the same reason
+ * InspectorCollapseState is its own header.
+ */
+struct MixerUIPreferences {
+    /// The user's explicit choice. Never written from a width-derived collapse.
+    bool inspectorExpanded{true};
+
+    /// Directory holding Aestra's per-user config, or empty if it cannot be found.
+    ///
+    /// HOME alone is wrong on Windows, where it is normally unset — the mixer
+    /// preferences then silently never persisted at all.
+    static std::string configDirectory()
+    {
+        std::string home;
+        if (const char* h = std::getenv("HOME"); h != nullptr && *h != '\0') {
+            home = h;
+        }
+#if defined(_WIN32)
+        if (home.empty()) {
+            if (const char* up = std::getenv("USERPROFILE"); up != nullptr && *up != '\0') {
+                home = up;
+            }
+        }
+        if (home.empty()) {
+            const char* drive = std::getenv("HOMEDRIVE");
+            const char* path = std::getenv("HOMEPATH");
+            if (drive != nullptr && *drive != '\0' && path != nullptr && *path != '\0') {
+                home = std::string(drive) + path;
+            }
+        }
+#endif
+        if (home.empty()) {
+            return {};
+        }
+
+        const std::filesystem::path dir = std::filesystem::path(home) / ".config" / "aestra";
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+        if (ec) {
+            return {};
+        }
+        return dir.string();
+    }
+
+    /// Full path to mixer_settings.json, or empty when there is nowhere to put it.
+    static std::string settingsPath()
+    {
+        const std::string dir = configDirectory();
+        if (dir.empty()) {
+            return {};
+        }
+        return (std::filesystem::path(dir) / "mixer_settings.json").string();
+    }
+
+    /**
+     * @brief Read preferences from @p path.
+     *
+     * Anything unreadable, empty or malformed yields defaults rather than an
+     * error: a corrupt settings file must not stop the mixer opening, and an
+     * absent key must leave its default alone rather than applying false.
+     */
+    static MixerUIPreferences load(const std::string& path)
+    {
+        MixerUIPreferences prefs;
+        if (path.empty()) {
+            return prefs;
+        }
+
+        std::ifstream in(path);
+        if (!in) {
+            return prefs; // First run.
+        }
+
+        const std::string contents((std::istreambuf_iterator<char>(in)),
+                                   std::istreambuf_iterator<char>());
+        if (contents.empty()) {
+            return prefs;
+        }
+
+        bool consumedAll = false;
+        const JSON root = JSON::parseStrict(contents, consumedAll);
+        if (!consumedAll) {
+            return prefs;
+        }
+        if (root.has("inspectorExpanded")) {
+            prefs.inspectorExpanded = root["inspectorExpanded"].asBool();
+        }
+        return prefs;
+    }
+
+    /// Write preferences to @p path. Returns false if nothing was written.
+    bool save(const std::string& path) const
+    {
+        if (path.empty()) {
+            return false;
+        }
+
+        JSON root = JSON::object();
+        root.set("version", JSON(1.0));
+        // Only the explicit preference is written. The width-derived collapse is
+        // recomputed per layout and must never reach disk, or a session that
+        // happened to end in a narrow window would rewrite the choice.
+        root.set("inspectorExpanded", JSON(inspectorExpanded));
+
+        std::ofstream out(path, std::ios::trunc);
+        if (!out) {
+            return false;
+        }
+        out << root.toString(2);
+        return out.good();
+    }
+};
+
+} // namespace Aestra

--- a/Source/Core/MixerUIPreferences.h
+++ b/Source/Core/MixerUIPreferences.h
@@ -133,6 +133,10 @@ struct MixerUIPreferences {
             return false;
         }
         out << root.toString(2);
+        // Closed explicitly before the status check: the destructor would close
+        // too, but by then the flush result is unobservable — a settings file
+        // truncated by a full disk would report success.
+        out.close();
         return out.good();
     }
 };

--- a/Source/Core/MixerUIPreferences.h
+++ b/Source/Core/MixerUIPreferences.h
@@ -103,7 +103,12 @@ struct MixerUIPreferences {
         if (!consumedAll) {
             return prefs;
         }
-        if (root.has("inspectorExpanded")) {
+        // Type-checked, not merely present. JSON::asBool() returns its default
+        // false for any non-Boolean node, so {"inspectorExpanded": 1} would
+        // otherwise pass the has() check and collapse the inspector — the same
+        // failure the absent-key guard exists to prevent, arriving by a
+        // different route.
+        if (root.has("inspectorExpanded") && root["inspectorExpanded"].isBool()) {
             prefs.inspectorExpanded = root["inspectorExpanded"].asBool();
         }
         return prefs;

--- a/Source/Panels/MixerPanel.cpp
+++ b/Source/Panels/MixerPanel.cpp
@@ -7,9 +7,43 @@
 #include "../AestraUI/Base/NUISlider.h"
 #include "../App/ServiceLocator.h"
 #include "AudioDeviceManager.h"
+#include "../../AestraCore/include/AestraJSON.h"
+#include "../../AestraCore/include/AestraLog.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
 
 using namespace AestraUI;
 using namespace Aestra::Audio;
+
+namespace {
+
+/**
+ * @brief Path for mixer UI preferences.
+ *
+ * These are *application* preferences, not project data: switching projects
+ * must not change how the mixer is laid out, so this deliberately does not go
+ * through ProjectSerializer. Mirrors browser_settings.json, which already
+ * persists FileBrowser layout the same way.
+ */
+std::string mixerSettingsPath()
+{
+    const char* home = std::getenv("HOME");
+    if (!home || !*home) {
+        return {};
+    }
+    std::string dir = std::string(home) + "/.config/aestra";
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        return {};
+    }
+    return dir + "/mixer_settings.json";
+}
+
+} // namespace
 
 MixerPanel::MixerPanel(std::shared_ptr<TrackManager> trackManager)
     : WindowPanel("MIXER")
@@ -38,7 +72,52 @@ MixerPanel::MixerPanel(std::shared_ptr<TrackManager> trackManager)
     // Set as content of WindowPanel
     setContent(m_newMixer);
 
+    loadUIPreferences();
+    m_newMixer->onInspectorPreferenceChanged = [this](bool) { saveUIPreferences(); };
+
     refreshChannels();
+}
+
+void MixerPanel::loadUIPreferences()
+{
+    const std::string path = mixerSettingsPath();
+    if (path.empty() || !m_newMixer) return;
+
+    std::ifstream in(path);
+    if (!in) return;  // First run: the panel's own default (expanded) stands.
+
+    const std::string contents((std::istreambuf_iterator<char>(in)),
+                               std::istreambuf_iterator<char>());
+    if (contents.empty()) return;
+
+    bool consumedAll = false;
+    const Aestra::JSON root = Aestra::JSON::parseStrict(contents, consumedAll);
+    if (!consumedAll) {
+        AESTRA_LOG_WARNING("mixer_settings.json is unreadable; keeping mixer defaults");
+        return;
+    }
+
+    // Absent must mean "leave the default alone", never "apply false".
+    if (root.has("inspectorExpanded")) {
+        m_newMixer->setInspectorExpandedPreference(root["inspectorExpanded"].asBool());
+    }
+}
+
+void MixerPanel::saveUIPreferences() const
+{
+    const std::string path = mixerSettingsPath();
+    if (path.empty() || !m_newMixer) return;
+
+    Aestra::JSON root = Aestra::JSON::object();
+    root.set("version", Aestra::JSON(1.0));
+    // Only the explicit preference is written. The width-derived collapse is
+    // recomputed per layout and must never reach disk, or a session that
+    // happened to end in a narrow window would silently rewrite the choice.
+    root.set("inspectorExpanded", Aestra::JSON(m_newMixer->getInspectorExpandedPreference()));
+
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) return;
+    out << root.toString(2);
 }
 
 

--- a/Source/Panels/MixerPanel.cpp
+++ b/Source/Panels/MixerPanel.cpp
@@ -7,43 +7,11 @@
 #include "../AestraUI/Base/NUISlider.h"
 #include "../App/ServiceLocator.h"
 #include "AudioDeviceManager.h"
-#include "../../AestraCore/include/AestraJSON.h"
+#include "../Core/MixerUIPreferences.h"
 #include "../../AestraCore/include/AestraLog.h"
-
-#include <cstdlib>
-#include <filesystem>
-#include <fstream>
-#include <system_error>
 
 using namespace AestraUI;
 using namespace Aestra::Audio;
-
-namespace {
-
-/**
- * @brief Path for mixer UI preferences.
- *
- * These are *application* preferences, not project data: switching projects
- * must not change how the mixer is laid out, so this deliberately does not go
- * through ProjectSerializer. Mirrors browser_settings.json, which already
- * persists FileBrowser layout the same way.
- */
-std::string mixerSettingsPath()
-{
-    const char* home = std::getenv("HOME");
-    if (!home || !*home) {
-        return {};
-    }
-    std::string dir = std::string(home) + "/.config/aestra";
-    std::error_code ec;
-    std::filesystem::create_directories(dir, ec);
-    if (ec) {
-        return {};
-    }
-    return dir + "/mixer_settings.json";
-}
-
-} // namespace
 
 MixerPanel::MixerPanel(std::shared_ptr<TrackManager> trackManager)
     : WindowPanel("MIXER")
@@ -80,44 +48,29 @@ MixerPanel::MixerPanel(std::shared_ptr<TrackManager> trackManager)
 
 void MixerPanel::loadUIPreferences()
 {
-    const std::string path = mixerSettingsPath();
-    if (path.empty() || !m_newMixer) return;
+    if (!m_newMixer) return;
 
-    std::ifstream in(path);
-    if (!in) return;  // First run: the panel's own default (expanded) stands.
-
-    const std::string contents((std::istreambuf_iterator<char>(in)),
-                               std::istreambuf_iterator<char>());
-    if (contents.empty()) return;
-
-    bool consumedAll = false;
-    const Aestra::JSON root = Aestra::JSON::parseStrict(contents, consumedAll);
-    if (!consumedAll) {
-        AESTRA_LOG_WARNING("mixer_settings.json is unreadable; keeping mixer defaults");
+    const std::string path = Aestra::MixerUIPreferences::settingsPath();
+    if (path.empty()) {
+        AESTRA_LOG_WARNING("No config directory available; mixer layout will not persist");
         return;
     }
 
-    // Absent must mean "leave the default alone", never "apply false".
-    if (root.has("inspectorExpanded")) {
-        m_newMixer->setInspectorExpandedPreference(root["inspectorExpanded"].asBool());
-    }
+    // Absent keys keep the panel's own defaults; load() never invents a false.
+    const Aestra::MixerUIPreferences prefs = Aestra::MixerUIPreferences::load(path);
+    m_newMixer->setInspectorExpandedPreference(prefs.inspectorExpanded);
 }
 
 void MixerPanel::saveUIPreferences() const
 {
-    const std::string path = mixerSettingsPath();
-    if (path.empty() || !m_newMixer) return;
+    if (!m_newMixer) return;
 
-    Aestra::JSON root = Aestra::JSON::object();
-    root.set("version", Aestra::JSON(1.0));
-    // Only the explicit preference is written. The width-derived collapse is
-    // recomputed per layout and must never reach disk, or a session that
-    // happened to end in a narrow window would silently rewrite the choice.
-    root.set("inspectorExpanded", Aestra::JSON(m_newMixer->getInspectorExpandedPreference()));
+    const std::string path = Aestra::MixerUIPreferences::settingsPath();
+    if (path.empty()) return;
 
-    std::ofstream out(path, std::ios::trunc);
-    if (!out) return;
-    out << root.toString(2);
+    Aestra::MixerUIPreferences prefs;
+    prefs.inspectorExpanded = m_newMixer->getInspectorExpandedPreference();
+    prefs.save(path);
 }
 
 

--- a/Source/Panels/MixerPanel.h
+++ b/Source/Panels/MixerPanel.h
@@ -37,6 +37,12 @@ public:
 
     void setPlatformBridge(AestraUI::NUIPlatformBridge* bridge);
 
+    /// Mixer layout preferences live in ~/.config/aestra/mixer_settings.json —
+    /// application state, deliberately outside the project file so switching
+    /// projects never rearranges the mixer.
+    void loadUIPreferences();
+    void saveUIPreferences() const;
+
 private:
     std::shared_ptr<TrackManager> m_trackManager;
 

--- a/Tests/AestraUI/InspectorCollapseStateTest.cpp
+++ b/Tests/AestraUI/InspectorCollapseStateTest.cpp
@@ -189,17 +189,44 @@ static void test_reset_restores_default() {
 
 namespace {
 
+// Both helpers report failure rather than swallowing it. The reason is
+// specific: three of the tests below write a settings file and then assert the
+// expanded default is *kept*. If the write silently failed, load() would find
+// no file, return the default, and those assertions would pass — for entirely
+// the wrong reason. A scratch-directory problem would read as a green suite.
+
 std::string scratchSettingsPath(const char* name) {
     const std::filesystem::path dir =
         std::filesystem::temp_directory_path() / "aestra-mixer-prefs-test";
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
+    if (ec && !std::filesystem::exists(dir)) {
+        std::cout << "  FAIL: cannot create scratch directory " << dir.string()
+                  << " (" << ec.message() << ")\n";
+        ++testsFailed;
+        return {};
+    }
     return (dir / name).string();
 }
 
-void writeFile(const std::string& path, const std::string& contents) {
+bool writeFile(const std::string& path, const std::string& contents) {
+    if (path.empty()) {
+        return false;
+    }
     std::ofstream out(path, std::ios::trunc);
+    if (!out) {
+        return false;
+    }
     out << contents;
+    out.close();
+    if (!out.good()) {
+        return false;
+    }
+    // Prove the bytes actually landed: an assertion about "the default is kept"
+    // is only meaningful if the file it is reacting to really exists.
+    std::error_code ec;
+    return std::filesystem::exists(path, ec) &&
+           std::filesystem::file_size(path, ec) == contents.size();
 }
 
 } // namespace
@@ -209,6 +236,7 @@ static void test_settings_round_trip_both_values() {
 
     for (bool expanded : {true, false}) {
         const std::string path = scratchSettingsPath("roundtrip.json");
+        ASSERT(!path.empty(), "scratch path available");
         std::filesystem::remove(path);
 
         Aestra::MixerUIPreferences saved;
@@ -227,6 +255,7 @@ static void test_settings_round_trip_both_values() {
 
 static void test_missing_file_keeps_default() {
     const std::string path = scratchSettingsPath("does-not-exist.json");
+    ASSERT(!path.empty(), "scratch path available");
     std::filesystem::remove(path);
 
     const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
@@ -239,7 +268,8 @@ static void test_absent_key_keeps_default() {
     // false, which would collapse the inspector for anyone whose settings file
     // predates the key.
     const std::string path = scratchSettingsPath("other-keys.json");
-    writeFile(path, "{\"version\": 1, \"somethingElse\": true}");
+    ASSERT(writeFile(path, "{\"version\": 1, \"somethingElse\": true}"),
+           "scratch settings file written");
 
     const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
     ASSERT(loaded.inspectorExpanded, "absent key does not apply false");
@@ -258,7 +288,7 @@ static void test_wrong_typed_key_keeps_default() {
     };
     for (const char* payload : payloads) {
         const std::string path = scratchSettingsPath("wrong-type.json");
-        writeFile(path, payload);
+        ASSERT(writeFile(path, payload), "scratch settings file written");
         const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
         ASSERT(loaded.inspectorExpanded, "non-Boolean value does not collapse the inspector");
     }
@@ -267,7 +297,8 @@ static void test_wrong_typed_key_keeps_default() {
 
 static void test_corrupt_file_keeps_default() {
     const std::string path = scratchSettingsPath("corrupt.json");
-    writeFile(path, "{\"inspectorExpanded\": fal");  // truncated mid-write
+    ASSERT(writeFile(path, "{\"inspectorExpanded\": fal"),  // truncated mid-write
+           "scratch settings file written");
 
     const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
     ASSERT(loaded.inspectorExpanded, "unparseable settings do not collapse the inspector");
@@ -278,6 +309,7 @@ static void test_saved_file_does_not_carry_forced_state() {
     // forcedCollapsed is width-derived and must never reach disk: a session
     // that happened to end in a narrow window must not rewrite the choice.
     const std::string path = scratchSettingsPath("no-forced.json");
+    ASSERT(!path.empty(), "scratch path available");
     Aestra::MixerUIPreferences prefs;
     prefs.inspectorExpanded = true;
     ASSERT(prefs.save(path), "save reports success");

--- a/Tests/AestraUI/InspectorCollapseStateTest.cpp
+++ b/Tests/AestraUI/InspectorCollapseStateTest.cpp
@@ -1,0 +1,200 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+/**
+ * @file InspectorCollapseStateTest.cpp
+ * @brief Regression tests for mixer inspector collapse: explicit intent vs. derived fit.
+ *
+ * The contract under test:
+ *
+ *     effectiveExpanded = expandedPreference && !forcedCollapsed
+ *
+ * with the rule that a width change must NEVER write to expandedPreference.
+ * The transition orderings are the easy thing to get wrong and are invisible in
+ * a screenshot, which is why they are asserted directly.
+ */
+
+#include "Widgets/InspectorCollapseState.h"
+#include <iostream>
+#include <string>
+
+using namespace AestraUI;
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define PASS(msg) do { std::cout << "  PASS: " << msg << "\n"; ++testsPassed; } while(0)
+#define FAIL(msg) do { std::cout << "  FAIL: " << msg << "\n"; ++testsFailed; } while(0)
+#define ASSERT(cond, msg) do { if (!(cond)) { FAIL(msg); return; } } while(0)
+
+// ---------------------------------------------------------------------------
+// Defaults and the core formula
+// ---------------------------------------------------------------------------
+static void test_first_run_defaults_expanded() {
+    InspectorCollapseState s;
+    ASSERT(s.expandedPreference, "first run preference is expanded");
+    ASSERT(!s.forcedCollapsed, "first run is not width-constrained");
+    ASSERT(s.effectiveExpanded(), "first run renders expanded");
+    PASS("first run defaults to expanded");
+}
+
+static void test_effective_is_preference_and_not_forced() {
+    InspectorCollapseState s;
+
+    s.expandedPreference = true;  s.forcedCollapsed = false;
+    ASSERT(s.effectiveExpanded(), "wants open, room available -> expanded");
+
+    s.expandedPreference = true;  s.forcedCollapsed = true;
+    ASSERT(!s.effectiveExpanded(), "wants open, no room -> collapsed");
+
+    s.expandedPreference = false; s.forcedCollapsed = false;
+    ASSERT(!s.effectiveExpanded(), "wants closed, room available -> collapsed");
+
+    s.expandedPreference = false; s.forcedCollapsed = true;
+    ASSERT(!s.effectiveExpanded(), "wants closed, no room -> collapsed");
+
+    PASS("effectiveExpanded = preference && !forced");
+}
+
+// ---------------------------------------------------------------------------
+// Width changes must not corrupt the stored intent
+// ---------------------------------------------------------------------------
+static void test_width_constraint_never_writes_preference() {
+    InspectorCollapseState s;  // preference = expanded
+
+    s.setForcedCollapsed(true);
+    ASSERT(s.expandedPreference,
+           "auto-collapse must not overwrite the user's explicit preference");
+    ASSERT(!s.effectiveExpanded(), "but it must collapse visually");
+
+    s.setForcedCollapsed(false);
+    ASSERT(s.expandedPreference, "preference still intact after the constraint lifts");
+    PASS("width constraint never writes the preference");
+}
+
+// ---------------------------------------------------------------------------
+// The two sequences that are easiest to get wrong
+// ---------------------------------------------------------------------------
+
+/// 1. user collapses -> 2. narrow -> 3. wide again -> 4. STAYS collapsed.
+/// The failure mode is the widen step "restoring" a panel the user closed.
+static void test_explicit_collapse_survives_narrow_then_wide() {
+    InspectorCollapseState s;
+
+    s.onRailClicked();                       // 1. explicit collapse
+    ASSERT(!s.expandedPreference, "click collapsed the preference");
+    ASSERT(!s.effectiveExpanded(), "collapsed on screen");
+
+    s.setForcedCollapsed(true);              // 2. narrow
+    ASSERT(!s.effectiveExpanded(), "still collapsed while narrow");
+
+    s.setForcedCollapsed(false);             // 3. wide again
+    ASSERT(!s.expandedPreference, "widening must not resurrect the preference");
+    ASSERT(!s.effectiveExpanded(),           // 4.
+           "regression: inspector reopened itself after a width round-trip "
+           "even though the user had explicitly collapsed it");
+    PASS("explicit collapse survives narrow -> wide round-trip");
+}
+
+/// 1. user prefers expanded -> 2. narrow auto-collapses -> 3. wide again ->
+/// 4. RESTORES expanded. The failure mode is the auto-collapse having
+/// overwritten the preference, so the panel never comes back.
+static void test_auto_collapse_restores_expanded_when_width_returns() {
+    InspectorCollapseState s;                // 1. preference = expanded
+    ASSERT(s.effectiveExpanded(), "starts expanded");
+
+    s.setForcedCollapsed(true);              // 2. narrow
+    ASSERT(!s.effectiveExpanded(), "auto-collapsed while narrow");
+
+    s.setForcedCollapsed(false);             // 3. wide again
+    ASSERT(s.effectiveExpanded(),            // 4.
+           "regression: auto-collapse clobbered the preference, so the "
+           "inspector never returned when the width did");
+    PASS("auto-collapse restores expanded when width returns");
+}
+
+// ---------------------------------------------------------------------------
+// Clicking the rail while width-constrained
+// ---------------------------------------------------------------------------
+static void test_click_while_forced_records_expand_intent() {
+    InspectorCollapseState s;
+    s.onRailClicked();            // user collapses
+    s.setForcedCollapsed(true);   // then the window narrows
+
+    s.onRailClicked();            // user clicks the rail: "open this"
+
+    ASSERT(s.expandedPreference,
+           "a click while width-constrained must record expand intent, not be discarded");
+    ASSERT(!s.effectiveExpanded(),
+           "…but it stays visually collapsed while there is still no room");
+
+    s.setForcedCollapsed(false);  // room returns
+    ASSERT(s.effectiveExpanded(), "the recorded intent takes effect once width allows");
+    PASS("click while constrained records intent, applies when width returns");
+}
+
+/// While constrained the panel is collapsed regardless, so a click can only
+/// mean "expand" — it must not toggle the preference off.
+static void test_click_while_forced_does_not_toggle_off() {
+    InspectorCollapseState s;      // preference = expanded
+    s.setForcedCollapsed(true);
+
+    s.onRailClicked();
+
+    ASSERT(s.expandedPreference,
+           "clicking a forced-collapsed rail must not flip an expanded preference to collapsed");
+    PASS("click while constrained never toggles the preference off");
+}
+
+static void test_click_toggles_normally_when_unconstrained() {
+    InspectorCollapseState s;
+
+    s.onRailClicked();
+    ASSERT(!s.expandedPreference, "first click collapses");
+    s.onRailClicked();
+    ASSERT(s.expandedPreference, "second click expands");
+    ASSERT(s.effectiveExpanded(), "and it shows");
+    PASS("click toggles normally when unconstrained");
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+static void test_reset_restores_default() {
+    InspectorCollapseState s;
+    s.onRailClicked();            // collapse
+    s.setForcedCollapsed(true);
+
+    s.reset();
+
+    ASSERT(s.expandedPreference, "reset restores the expanded default");
+    ASSERT(!s.forcedCollapsed, "reset clears the derived constraint");
+    ASSERT(s.effectiveExpanded(), "reset renders expanded");
+    PASS("reset restores the first-run default");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+int main() {
+    std::cout << "============================================\n";
+    std::cout << "  Inspector Collapse State Regression Tests\n";
+    std::cout << "============================================\n\n";
+
+    test_first_run_defaults_expanded();
+    test_effective_is_preference_and_not_forced();
+    test_width_constraint_never_writes_preference();
+    test_explicit_collapse_survives_narrow_then_wide();
+    test_auto_collapse_restores_expanded_when_width_returns();
+    test_click_while_forced_records_expand_intent();
+    test_click_while_forced_does_not_toggle_off();
+    test_click_toggles_normally_when_unconstrained();
+    test_reset_restores_default();
+
+    std::cout << "\n============================================\n";
+    if (testsFailed == 0) {
+        std::cout << "  All " << testsPassed << " tests passed.\n";
+    } else {
+        std::cout << "  " << testsPassed << " passed, " << testsFailed << " failed.\n";
+    }
+    std::cout << "============================================\n";
+    return testsFailed > 0 ? 1 : 0;
+}

--- a/Tests/AestraUI/InspectorCollapseStateTest.cpp
+++ b/Tests/AestraUI/InspectorCollapseStateTest.cpp
@@ -13,6 +13,11 @@
  */
 
 #include "Widgets/InspectorCollapseState.h"
+#include "MixerUIPreferences.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -171,6 +176,103 @@ static void test_reset_restores_default() {
     PASS("reset restores the first-run default");
 }
 
+
+// ---------------------------------------------------------------------------
+// Settings round trip
+//
+// The state machine above is only half the feature: the preference has to
+// survive a restart, and an absent or damaged settings file must leave the
+// default alone rather than collapsing the inspector. Driven through
+// MixerUIPreferences rather than MixerPanel so it needs no panel, TrackManager
+// or renderer.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::string scratchSettingsPath(const char* name) {
+    const std::filesystem::path dir =
+        std::filesystem::temp_directory_path() / "aestra-mixer-prefs-test";
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    return (dir / name).string();
+}
+
+void writeFile(const std::string& path, const std::string& contents) {
+    std::ofstream out(path, std::ios::trunc);
+    out << contents;
+}
+
+} // namespace
+
+static void test_settings_round_trip_both_values() {
+    std::cout << "\n[settings round trip]\n";
+
+    for (bool expanded : {true, false}) {
+        const std::string path = scratchSettingsPath("roundtrip.json");
+        std::filesystem::remove(path);
+
+        Aestra::MixerUIPreferences saved;
+        saved.inspectorExpanded = expanded;
+        ASSERT(saved.save(path), "save reports success");
+
+        const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
+        // Parenthesised: '<<' binds tighter than '?:', so an unbracketed
+        // ternary would be parsed as part of the stream expression.
+        ASSERT(loaded.inspectorExpanded == expanded,
+               (expanded ? "expanded=true survives the round trip"
+                         : "expanded=false survives the round trip"));
+    }
+    PASS("both preference values round-trip through the settings file");
+}
+
+static void test_missing_file_keeps_default() {
+    const std::string path = scratchSettingsPath("does-not-exist.json");
+    std::filesystem::remove(path);
+
+    const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
+    ASSERT(loaded.inspectorExpanded, "first run leaves the inspector expanded");
+    PASS("absent settings file keeps the expanded default");
+}
+
+static void test_absent_key_keeps_default() {
+    // The trap this guards: reading a missing key as a default-constructed
+    // false, which would collapse the inspector for anyone whose settings file
+    // predates the key.
+    const std::string path = scratchSettingsPath("other-keys.json");
+    writeFile(path, "{\"version\": 1, \"somethingElse\": true}");
+
+    const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
+    ASSERT(loaded.inspectorExpanded, "absent key does not apply false");
+    PASS("settings file without the key keeps the expanded default");
+}
+
+static void test_corrupt_file_keeps_default() {
+    const std::string path = scratchSettingsPath("corrupt.json");
+    writeFile(path, "{\"inspectorExpanded\": fal");  // truncated mid-write
+
+    const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
+    ASSERT(loaded.inspectorExpanded, "unparseable settings do not collapse the inspector");
+    PASS("corrupt settings file keeps the expanded default");
+}
+
+static void test_saved_file_does_not_carry_forced_state() {
+    // forcedCollapsed is width-derived and must never reach disk: a session
+    // that happened to end in a narrow window must not rewrite the choice.
+    const std::string path = scratchSettingsPath("no-forced.json");
+    Aestra::MixerUIPreferences prefs;
+    prefs.inspectorExpanded = true;
+    ASSERT(prefs.save(path), "save reports success");
+
+    std::ifstream in(path);
+    const std::string contents((std::istreambuf_iterator<char>(in)),
+                               std::istreambuf_iterator<char>());
+    ASSERT(contents.find("forcedCollapsed") == std::string::npos,
+           "no width-derived state is written");
+    ASSERT(contents.find("inspectorExpanded") != std::string::npos,
+           "the explicit preference is written");
+    PASS("only the explicit preference is persisted");
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -188,6 +290,12 @@ int main() {
     test_click_while_forced_does_not_toggle_off();
     test_click_toggles_normally_when_unconstrained();
     test_reset_restores_default();
+
+    test_settings_round_trip_both_values();
+    test_missing_file_keeps_default();
+    test_absent_key_keeps_default();
+    test_corrupt_file_keeps_default();
+    test_saved_file_does_not_carry_forced_state();
 
     std::cout << "\n============================================\n";
     if (testsFailed == 0) {

--- a/Tests/AestraUI/InspectorCollapseStateTest.cpp
+++ b/Tests/AestraUI/InspectorCollapseStateTest.cpp
@@ -246,6 +246,25 @@ static void test_absent_key_keeps_default() {
     PASS("settings file without the key keeps the expanded default");
 }
 
+static void test_wrong_typed_key_keeps_default() {
+    // JSON::asBool() yields its default false for any non-Boolean node, so a
+    // present-but-wrong-typed value slips past a bare has() check and collapses
+    // the inspector. Same failure as the absent-key case, different route.
+    const char* payloads[] = {
+        "{\"inspectorExpanded\": 1}",
+        "{\"inspectorExpanded\": \"true\"}",
+        "{\"inspectorExpanded\": null}",
+        "{\"inspectorExpanded\": []}",
+    };
+    for (const char* payload : payloads) {
+        const std::string path = scratchSettingsPath("wrong-type.json");
+        writeFile(path, payload);
+        const Aestra::MixerUIPreferences loaded = Aestra::MixerUIPreferences::load(path);
+        ASSERT(loaded.inspectorExpanded, "non-Boolean value does not collapse the inspector");
+    }
+    PASS("present-but-wrong-typed key keeps the expanded default");
+}
+
 static void test_corrupt_file_keeps_default() {
     const std::string path = scratchSettingsPath("corrupt.json");
     writeFile(path, "{\"inspectorExpanded\": fal");  // truncated mid-write
@@ -294,6 +313,7 @@ int main() {
     test_settings_round_trip_both_values();
     test_missing_file_keeps_default();
     test_absent_key_keeps_default();
+    test_wrong_typed_key_keeps_default();
     test_corrupt_file_keeps_default();
     test_saved_file_does_not_carry_forced_state();
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1766,6 +1766,18 @@ else()
     message(STATUS "NUITextInputEditingTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Mixer inspector collapse — explicit preference vs. width-derived constraint.
+# Header-only state machine, so this needs no UI or renderer to run.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/InspectorCollapseStateTest.cpp")
+    add_executable(InspectorCollapseStateTest AestraUI/InspectorCollapseStateTest.cpp)
+    target_include_directories(InspectorCollapseStateTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+    )
+    add_test(NAME InspectorCollapseStateTest COMMAND InspectorCollapseStateTest)
+    set_tests_properties(InspectorCollapseStateTest PROPERTIES LABELS "ui;mixer;regression")
+    message(STATUS "InspectorCollapseStateTest added - inspector collapse preference/constraint tests")
+endif()
+
 if(TARGET AestraUI_Core)
     add_executable(NUIDropdownInteractionTest AestraUI/NUIDropdownInteractionTest.cpp)
     target_link_libraries(NUIDropdownInteractionTest PRIVATE AestraUI_Core)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1772,6 +1772,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/InspectorCollapseStateTest.cpp")
     add_executable(InspectorCollapseStateTest AestraUI/InspectorCollapseStateTest.cpp)
     target_include_directories(InspectorCollapseStateTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME InspectorCollapseStateTest COMMAND InspectorCollapseStateTest)
     set_tests_properties(InspectorCollapseStateTest PROPERTIES LABELS "ui;mixer;regression")


### PR DESCRIPTION
Inspector collapse was in-memory only, so it reset on every launch. This persists it — as **global application preference state, deliberately outside the project file**. Switching projects must never rearrange the mixer.

## Why two states and not one bool

A single bool cannot express *"the user wants this open, but there is no room right now"*, and collapsing that distinction is exactly how a responsive layout quietly destroys a deliberate choice: the window gets narrow, the layout writes `false`, and the preference is gone forever.

So the state is split:

```
effectiveExpanded = expandedPreference && !forcedCollapsed
```

| | meaning | persisted? |
|---|---|---|
| `expandedPreference` | the user's explicit choice | **yes** |
| `forcedCollapsed` | derived from available width, recomputed every layout | **never** |

Width changes only ever touch `forcedCollapsed`. A session that happened to end in a narrow window cannot rewrite the choice.

Clicking the rail while width-constrained records *expand intent* rather than discarding the click, so the inspector comes back by itself once there is room. It cannot toggle an expanded preference **off** in that state, since the panel is already collapsed and "expand" is the only intent a click can carry there. The constrained rail renders dimmer and explains itself with a tooltip, so it doesn't read as broken.

## Why the state machine is its own header

The transition *orderings* are the easy thing to get wrong and are invisible in a screenshot. `InspectorCollapseState` is header-only with no UI or renderer dependency, so all nine orderings run in the normal suite in 0.00s instead of needing an app harness.

## Persistence

`~/.config/aestra/mixer_settings.json`, mirroring the existing `browser_settings.json`. Absent keys leave defaults alone rather than applying `false` — a truncated or partial settings file must not silently collapse the inspector.

## Tests

Nine cases, all **mutation-verified** against three realistic wrong implementations, each caught by a different assertion:

| mutation | failures |
|---|---|
| preference clobbered on width change | 2 |
| rail click always toggles | 1 |
| rail click discarded when constrained | 1 |

```
PASS: first run defaults to expanded
PASS: effectiveExpanded = preference && !forced
PASS: width constraint never writes the preference
PASS: explicit collapse survives narrow -> wide round-trip
PASS: auto-collapse restores expanded when width returns
PASS: click while constrained records intent, applies when width returns
PASS: click while constrained never toggles the preference off
PASS: click toggles normally when unconstrained
PASS: reset restores the first-run default
```

Both required sequences are covered, and were also confirmed live:

- collapse → narrow → widen → **stays collapsed** (8 strips, no settings rewrite)
- expanded → narrow auto-collapse → widen → **restores expanded**

## Verification

Full build clean, **231/231 tests pass** on this branch, rebased onto `53c3b476` (current `develop`, includes #709).

One bookkeeping note in the interest of not overstating: on the #707 branch I reported a local count of 229, but the arithmetic here says `develop` alone is 230 and this PR adds exactly one `add_test`. Identical source content shouldn't yield different counts, so that earlier local number was almost certainly one short from a stale CMake configure in my working build directory — not a lost test. CI configures clean and was green across all 18 checks on #707, and every test registered here is confirmed present via `ctest -N`, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Breaking change:** Replaced `UIMixerPanel::setInspectorCollapsed(bool)` with preference-based APIs.
- Added `InspectorCollapseState` to separate the saved expansion preference from layout-driven forced collapse.
- Persisted mixer inspector preferences in platform-aware `mixer_settings.json` configuration paths.
- Added safe defaults and type validation for missing, malformed, or non-Boolean settings.
- Updated constrained rail clicks, toggling, width changes, and reset behavior.
- Added 15 regression tests covering state transitions and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->