### PR TITLE
Stop the JSON decimal separator depending on the process locale

### DIFF
--- a/AestraCore/include/AestraJSON.h
+++ b/AestraCore/include/AestraJSON.h
@@ -1,10 +1,12 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <clocale>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <locale>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -175,6 +177,45 @@ public:
         return value;
     }
 
+    // ---- Locale-independent number text (public so the regression test can
+    // drive them directly; they are pure functions with no JSON state) ----
+
+    /// The active C locale's decimal separator (".", ",", …).
+    ///
+    /// Read fresh every time: the process locale can change at runtime, and in
+    /// a plugin host it changes without our involvement.
+    static const char* localeDecimalPoint() {
+        const std::lconv* conv = std::localeconv();
+        if (conv == nullptr || conv->decimal_point == nullptr || *conv->decimal_point == '\0') {
+            return ".";
+        }
+        return conv->decimal_point;
+    }
+
+    /// Rewrite the locale's decimal separator to '.', in place.
+    ///
+    /// JSON has exactly one decimal separator and it is '.', regardless of what
+    /// the process locale thinks. Kept as its own function so it can be tested
+    /// directly against a separator this machine's locales may not offer.
+    static void normalizeDecimalPointToDot(char* buf, size_t bufSize, const char* decimalPoint) {
+        if (decimalPoint == nullptr || std::strcmp(decimalPoint, ".") == 0) {
+            return;
+        }
+        char* found = std::strstr(buf, decimalPoint);
+        if (found == nullptr) {
+            return; // Integral value: printf emitted no separator at all.
+        }
+        const size_t sepLen = std::strlen(decimalPoint);
+        *found = '.';
+        if (sepLen > 1) {
+            // Multi-byte separator: close the gap left behind. POSIX permits
+            // this even though the common locales are single-byte.
+            const size_t tailLen = std::strlen(found + sepLen);
+            std::memmove(found + 1, found + sepLen, tailLen + 1);
+        }
+        (void)bufSize;
+    }
+
 private:
     Type type_;
     bool boolValue_ = false;
@@ -218,8 +259,16 @@ private:
     // significant digits in [15..17] whose plain-decimal rendering strtod's
     // back to the identical bits, then trims trailing zeros. Plain decimal
     // (never exponent form) keeps output readable and parseable by every
-    // existing consumer. Note: like the stream insertion it replaces, this
-    // assumes the C numeric locale uses '.' as the decimal separator.
+    // existing consumer.
+    //
+    // Locale: snprintf("%f") and strtod both honour LC_NUMERIC, so under a
+    // comma-decimal locale this used to emit `1,5` — not merely ugly, but
+    // invalid JSON that no longer reloads. The exactness check is deliberately
+    // performed *before* normalisation, so printf and strtod stay in agreement
+    // with each other whatever the locale is; only the emitted text is forced
+    // to JSON's '.'. Aestra hosts third-party plugin binaries, and a plugin
+    // calling setlocale(LC_ALL, "") is a documented DAW hazard, so this cannot
+    // be dismissed as a configuration the user is responsible for avoiding.
     static void formatNumber(char* buf, size_t bufSize, double v) {
         if (!std::isfinite(v)) {
             // Preserve prior stream behavior for non-finite values ("nan"/"inf");
@@ -236,9 +285,13 @@ private:
                 int decimals = sigDigits - 1 - exp10 + bump;
                 decimals = decimals < 0 ? 0 : (decimals > 340 ? 340 : decimals);
                 std::snprintf(buf, bufSize, "%.*f", decimals, v);
+                // Same locale on both sides, so this comparison stays honest.
                 exact = (std::strtod(buf, nullptr) == v);
             }
         }
+        // Only now force JSON's separator; the trailing-zero trim below and
+        // every consumer of this buffer expect '.'.
+        normalizeDecimalPointToDot(buf, bufSize, localeDecimalPoint());
         char* dot = std::strchr(buf, '.');
         if (dot != nullptr) {
             char* end = buf + std::strlen(buf);
@@ -513,12 +566,19 @@ private:
             return JSON(0.0);
         }
 
-        try {
-            double value = std::stod(numStr);
-            return JSON(value);
-        } catch (const std::exception&) {
+        // std::stod honours LC_NUMERIC, so under a comma-decimal locale it read
+        // "1.5" as 1 — silent, unbounded truncation of every fractional value
+        // in a project on load, with no error to notice. An istringstream
+        // imbued with the classic locale is independent of both the C locale
+        // and any std::locale::global a host or plugin may have installed.
+        std::istringstream stream(numStr);
+        stream.imbue(std::locale::classic());
+        double value = 0.0;
+        stream >> value;
+        if (stream.fail()) {
             return JSON(0.0);
         }
+        return JSON(value);
     }
 
     static JSON parseBool(const std::string& str, size_t& pos) {

--- a/AestraCore/include/AestraJSON.h
+++ b/AestraCore/include/AestraJSON.h
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #pragma once
 
+#include <cassert>
 #include <clocale>
 #include <cmath>
 #include <cstdio>
@@ -14,6 +15,53 @@
 #include <vector>
 
 namespace Aestra {
+
+namespace json_detail {
+
+/// The active C locale's decimal separator (".", ",", …).
+///
+/// Read fresh every time: the process locale can change at runtime, and in a
+/// plugin host it changes without our involvement.
+inline const char* localeDecimalPoint() {
+    const std::lconv* conv = std::localeconv();
+    if (conv == nullptr || conv->decimal_point == nullptr || *conv->decimal_point == '\0') {
+        return ".";
+    }
+    return conv->decimal_point;
+}
+
+/// Rewrite the locale's decimal separator to '.', in place.
+///
+/// JSON has exactly one decimal separator and it is '.', regardless of what the
+/// process locale thinks. A free function in json_detail rather than a member:
+/// it holds no JSON state, and the regression test needs to drive it against a
+/// separator this machine's locales may not offer — without that widening
+/// JSON's own public surface.
+inline void normalizeDecimalPointToDot(char* buf, size_t bufSize, const char* decimalPoint) {
+    // The rewrite only ever shrinks the string, so it cannot overflow today.
+    // Asserted anyway so a future edit cannot turn bufSize into a promise this
+    // function silently stopped keeping.
+    assert(buf != nullptr && std::strlen(buf) < bufSize);
+    (void)bufSize;
+
+    if (decimalPoint == nullptr || std::strcmp(decimalPoint, ".") == 0) {
+        return;
+    }
+    char* found = std::strstr(buf, decimalPoint);
+    if (found == nullptr) {
+        return; // Integral value: printf emitted no separator at all.
+    }
+    const size_t sepLen = std::strlen(decimalPoint);
+    *found = '.';
+    if (sepLen > 1) {
+        // Multi-byte separator: close the gap left behind. POSIX permits this
+        // even though the common locales are single-byte.
+        const size_t tailLen = std::strlen(found + sepLen);
+        std::memmove(found + 1, found + sepLen, tailLen + 1);
+    }
+}
+
+} // namespace json_detail
 
 // =============================================================================
 // Lightweight JSON Parser
@@ -177,45 +225,6 @@ public:
         return value;
     }
 
-    // ---- Locale-independent number text (public so the regression test can
-    // drive them directly; they are pure functions with no JSON state) ----
-
-    /// The active C locale's decimal separator (".", ",", …).
-    ///
-    /// Read fresh every time: the process locale can change at runtime, and in
-    /// a plugin host it changes without our involvement.
-    static const char* localeDecimalPoint() {
-        const std::lconv* conv = std::localeconv();
-        if (conv == nullptr || conv->decimal_point == nullptr || *conv->decimal_point == '\0') {
-            return ".";
-        }
-        return conv->decimal_point;
-    }
-
-    /// Rewrite the locale's decimal separator to '.', in place.
-    ///
-    /// JSON has exactly one decimal separator and it is '.', regardless of what
-    /// the process locale thinks. Kept as its own function so it can be tested
-    /// directly against a separator this machine's locales may not offer.
-    static void normalizeDecimalPointToDot(char* buf, size_t bufSize, const char* decimalPoint) {
-        if (decimalPoint == nullptr || std::strcmp(decimalPoint, ".") == 0) {
-            return;
-        }
-        char* found = std::strstr(buf, decimalPoint);
-        if (found == nullptr) {
-            return; // Integral value: printf emitted no separator at all.
-        }
-        const size_t sepLen = std::strlen(decimalPoint);
-        *found = '.';
-        if (sepLen > 1) {
-            // Multi-byte separator: close the gap left behind. POSIX permits
-            // this even though the common locales are single-byte.
-            const size_t tailLen = std::strlen(found + sepLen);
-            std::memmove(found + 1, found + sepLen, tailLen + 1);
-        }
-        (void)bufSize;
-    }
-
 private:
     Type type_;
     bool boolValue_ = false;
@@ -291,7 +300,7 @@ private:
         }
         // Only now force JSON's separator; the trailing-zero trim below and
         // every consumer of this buffer expect '.'.
-        normalizeDecimalPointToDot(buf, bufSize, localeDecimalPoint());
+        json_detail::normalizeDecimalPointToDot(buf, bufSize, json_detail::localeDecimalPoint());
         char* dot = std::strchr(buf, '.');
         if (dot != nullptr) {
             char* end = buf + std::strlen(buf);

--- a/Tests/AestraCore/JSONLocaleIndependenceTest.cpp
+++ b/Tests/AestraCore/JSONLocaleIndependenceTest.cpp
@@ -119,25 +119,28 @@ void testSeparatorRewrite() {
 
     char buf[64];
 
-    std::strcpy(buf, "1,5");
-    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    // Bounded copy rather than strcpy: every literal here is far under 64
+    // bytes, but SAST flags the unbounded form (CWE-120) and there is no
+    // reason to re-justify that on every review pass.
+    const auto rewrite = [&buf](const char* input, const char* separator) {
+        std::snprintf(buf, sizeof(buf), "%s", input);
+        Aestra::json_detail::normalizeDecimalPointToDot(buf, sizeof(buf), separator);
+    };
+
+    rewrite("1,5", ",");
     check(std::strcmp(buf, "1.5") == 0, "comma separator is rewritten to '.'");
 
-    std::strcpy(buf, "-1024,125");
-    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    rewrite("-1024,125", ",");
     check(std::strcmp(buf, "-1024.125") == 0, "negative value keeps its sign through the rewrite");
 
-    std::strcpy(buf, "42");
-    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    rewrite("42", ",");
     check(std::strcmp(buf, "42") == 0, "integral value with no separator is untouched");
 
-    std::strcpy(buf, "1.5");
-    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ".");
+    rewrite("1.5", ".");
     check(std::strcmp(buf, "1.5") == 0, "'.' locale is a no-op");
 
     // POSIX permits a multi-byte separator; the tail must close up behind it.
-    std::strcpy(buf, "3<SEP>25");
-    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), "<SEP>");
+    rewrite("3<SEP>25", "<SEP>");
     check(std::strcmp(buf, "3.25") == 0, "multi-byte separator collapses to a single '.'");
 }
 

--- a/Tests/AestraCore/JSONLocaleIndependenceTest.cpp
+++ b/Tests/AestraCore/JSONLocaleIndependenceTest.cpp
@@ -1,0 +1,249 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// AestraJSON must produce and consume '.' as the decimal separator no matter
+// what the process locale is.
+//
+// This is not hypothetical tidiness. Aestra loads third-party VST3/CLAP
+// binaries into its own process, and a plugin calling setlocale(LC_ALL, "")
+// is a documented DAW hazard the VST3 SDK itself warns about. Under a
+// comma-decimal locale the old code:
+//
+//   - wrote  1.5  as  "1,5"   -> the .aes file is no longer valid JSON
+//   - read   "1.5" as   1     -> silent, unbounded truncation on load
+//
+// Neither failure reports an error, so nothing but a test catches them.
+
+#include "AestraJSON.h"
+
+#include <clocale>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <system_error>
+#include <iostream>
+#include <locale>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+int g_checks = 0;
+int g_skips = 0;
+
+void check(bool condition, const std::string& what) {
+    ++g_checks;
+    if (condition) {
+        std::cout << "  PASS: " << what << "\n";
+    } else {
+        std::cout << "  FAIL: " << what << "\n";
+        ++g_failures;
+    }
+}
+
+/// A locale whose decimal separator is ',', built from a facet so it works on
+/// every platform — no dependency on which locales the machine has installed.
+struct CommaNumpunct : std::numpunct<char> {
+protected:
+    char do_decimal_point() const override { return ','; }
+};
+
+bool isCommaDecimalNow() {
+    const std::lconv* conv = std::localeconv();
+    return conv != nullptr && conv->decimal_point != nullptr &&
+           std::strcmp(conv->decimal_point, ",") == 0;
+}
+
+const char* tryInstalledCommaLocale() {
+    static const char* kCandidates[] = {
+        "de_DE.UTF-8", "de_DE.utf8", "fr_FR.UTF-8", "fr_FR.utf8",
+        "de-DE",       "fr-FR",      "de_DE",       "fr_FR",
+    };
+    for (const char* name : kCandidates) {
+        if (std::setlocale(LC_ALL, name) != nullptr && isCommaDecimalNow()) {
+            return name;
+        }
+    }
+    std::setlocale(LC_ALL, "C");
+    return nullptr;
+}
+
+/// Build a comma-decimal locale into a temp directory and point LOCPATH at it.
+///
+/// Without this the end-to-end case silently skips on any runner that ships
+/// only C/en_US — which is most Linux CI images. That skip is not harmless:
+/// the read-side fix (parsing "1.5" as 1.5 rather than 1) is *only* observable
+/// with a real comma C locale, so skipping here would leave that half of the
+/// fix unverified while the suite still reported green.
+///
+/// glibc reads LOCPATH when setlocale() runs, not at process start, so
+/// generating and then setting it from inside main() works.
+const char* generateCommaCLocale() {
+#if defined(__linux__)
+    const std::string dir =
+        (std::filesystem::temp_directory_path() / "aestra-json-locale-test").string();
+    std::error_code ec;
+    std::filesystem::create_directories(dir + "/de_DE.UTF-8", ec);
+    if (ec) {
+        return nullptr;
+    }
+    // Test-only shell-out: localedef ships with glibc and there is no library
+    // API for compiling a locale.
+    const std::string cmd =
+        "localedef -i de_DE -f UTF-8 \"" + dir + "/de_DE.UTF-8\" >/dev/null 2>&1";
+    if (std::system(cmd.c_str()) != 0) {
+        return nullptr;
+    }
+    ::setenv("LOCPATH", dir.c_str(), 1);
+    if (std::setlocale(LC_ALL, "de_DE.UTF-8") != nullptr && isCommaDecimalNow()) {
+        return "de_DE.UTF-8 (generated)";
+    }
+#endif
+    std::setlocale(LC_ALL, "C");
+    return nullptr;
+}
+
+/// Put the *C* locale into comma-decimal mode by any means available.
+const char* activateCommaCLocale() {
+    if (const char* installed = tryInstalledCommaLocale()) {
+        return installed;
+    }
+    return generateCommaCLocale();
+}
+
+// ---------------------------------------------------------------------------
+
+/// The separator rewrite, driven directly. This is the part that has to work
+/// on every platform, so it is tested without depending on installed locales.
+void testSeparatorRewrite() {
+    std::cout << "\n[separator rewrite — no OS locale required]\n";
+
+    char buf[64];
+
+    std::strcpy(buf, "1,5");
+    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    check(std::strcmp(buf, "1.5") == 0, "comma separator is rewritten to '.'");
+
+    std::strcpy(buf, "-1024,125");
+    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    check(std::strcmp(buf, "-1024.125") == 0, "negative value keeps its sign through the rewrite");
+
+    std::strcpy(buf, "42");
+    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ",");
+    check(std::strcmp(buf, "42") == 0, "integral value with no separator is untouched");
+
+    std::strcpy(buf, "1.5");
+    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), ".");
+    check(std::strcmp(buf, "1.5") == 0, "'.' locale is a no-op");
+
+    // POSIX permits a multi-byte separator; the tail must close up behind it.
+    std::strcpy(buf, "3<SEP>25");
+    Aestra::JSON::normalizeDecimalPointToDot(buf, sizeof(buf), "<SEP>");
+    check(std::strcmp(buf, "3.25") == 0, "multi-byte separator collapses to a single '.'");
+}
+
+/// Guards the parse path against a std::locale::global installed by a host or
+/// a plugin. Portable: uses a facet, not an installed locale.
+void testGlobalCppLocaleDoesNotLeak() {
+    std::cout << "\n[global C++ locale set to comma]\n";
+
+    const std::locale previous = std::locale();
+    std::locale::global(std::locale(std::locale::classic(), new CommaNumpunct));
+
+    // Prove the mutation actually took effect — otherwise the assertions below
+    // would pass simply because nothing changed.
+    std::ostringstream probe;
+    probe << 1.5;
+    check(probe.str() == "1,5", "precondition: global C++ locale really is comma-decimal");
+
+    bool consumedAll = false;
+    const Aestra::JSON parsed = Aestra::JSON::parseStrict("{\"v\":1.5}", consumedAll);
+    check(consumedAll, "parse succeeds under a comma global locale");
+    check(parsed["v"].asNumber() == 1.5, "\"1.5\" parses to 1.5, not 1");
+
+    Aestra::JSON root = Aestra::JSON::object();
+    root.set("v", Aestra::JSON(1.5));
+    check(root.toString(0).find("1.5") != std::string::npos,
+          "serialised output still uses '.'");
+
+    std::locale::global(previous);
+}
+
+/// The end-to-end reproduction of the original bug. Only runs where the
+/// machine actually has a comma-decimal locale installed.
+void testCLocaleRoundTrip() {
+    std::cout << "\n[C locale set to comma — end-to-end]\n";
+
+    const char* name = activateCommaCLocale();
+    if (name == nullptr) {
+        std::cout << "  SKIPPED: no comma-decimal locale installed, and generating one\n"
+                  << "           failed. The read-side fix is UNVERIFIED in this run.\n";
+        ++g_skips;
+        return;
+    }
+
+    std::cout << "  (using locale: " << name << ")\n";
+
+    // Precondition: prove the locale is genuinely comma-decimal, so a silently
+    // failed setlocale cannot make the rest of this function pass vacuously.
+    char probe[32];
+    std::snprintf(probe, sizeof(probe), "%.1f", 1.5);
+    check(std::strcmp(probe, "1,5") == 0, "precondition: printf really emits a comma here");
+
+    Aestra::JSON root = Aestra::JSON::object();
+    root.set("startBeat", Aestra::JSON(1024.125));
+    root.set("gain", Aestra::JSON(-6.5));
+    const std::string text = root.toString(0);
+
+    check(text.find("1024.125") != std::string::npos, "writes 1024.125 with a '.' separator");
+    check(text.find(',') == std::string::npos || text.find("1024,125") == std::string::npos,
+          "no comma appears inside a number");
+
+    bool consumedAll = false;
+    const Aestra::JSON reloaded = Aestra::JSON::parseStrict(text, consumedAll);
+    check(consumedAll, "its own output reparses as valid JSON");
+    check(reloaded["startBeat"].asNumber() == 1024.125, "1024.125 survives the round trip exactly");
+    check(reloaded["gain"].asNumber() == -6.5, "-6.5 survives the round trip exactly");
+
+    std::setlocale(LC_ALL, "C");
+}
+
+/// The change must not cost the precision the formatter was written for.
+void testPrecisionUnchanged() {
+    std::cout << "\n[precision]\n";
+
+    const double values[] = {1024.125, -6.5, 0.1, 1e9, -0.0009765625, 3.141592653589793};
+    for (double v : values) {
+        Aestra::JSON root = Aestra::JSON::object();
+        root.set("v", Aestra::JSON(v));
+        bool consumedAll = false;
+        const Aestra::JSON back = Aestra::JSON::parseStrict(root.toString(0), consumedAll);
+        check(consumedAll && back["v"].asNumber() == v,
+              "exact round trip for " + std::to_string(v));
+    }
+}
+
+} // namespace
+
+int main() {
+    std::cout << "============================================\n"
+              << "  AestraJSON Locale Independence Tests\n"
+              << "============================================\n";
+
+    testSeparatorRewrite();
+    testGlobalCppLocaleDoesNotLeak();
+    testCLocaleRoundTrip();
+    testPrecisionUnchanged();
+
+    std::cout << "\n============================================\n";
+    if (g_failures == 0) {
+        std::cout << "  All " << g_checks << " checks passed.\n";
+        if (g_skips > 0) {
+            std::cout << "  WARNING: " << g_skips
+                      << " case(s) skipped — coverage is incomplete in this run.\n";
+        }
+    } else {
+        std::cout << "  " << g_failures << " of " << g_checks << " checks FAILED.\n";
+    }
+    std::cout << "============================================\n";
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2067,3 +2067,16 @@ target_include_directories(SlidingIndicatorTest PRIVATE
 )
 add_test(NAME SlidingIndicatorTest COMMAND SlidingIndicatorTest)
 set_tests_properties(SlidingIndicatorTest PROPERTIES LABELS "ui;regression")
+
+# AestraJSON must round-trip doubles independently of LC_NUMERIC. AestraJSON.h
+# is header-only, so this needs no library — but it backs ProjectSerializer,
+# so a regression here corrupts .aes files rather than merely a UI setting.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraCore/JSONLocaleIndependenceTest.cpp")
+    add_executable(JSONLocaleIndependenceTest AestraCore/JSONLocaleIndependenceTest.cpp)
+    target_include_directories(JSONLocaleIndependenceTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME JSONLocaleIndependenceTest COMMAND JSONLocaleIndependenceTest)
+    set_tests_properties(JSONLocaleIndependenceTest PROPERTIES LABELS "core;json;locale;regression")
+    message(STATUS "JSONLocaleIndependenceTest added - JSON decimal separator locale independence")
+endif()


### PR DESCRIPTION
`AestraJSON` round-tripped every double through `snprintf("%f")` and `std::stod`. Both honour `LC_NUMERIC`. Under a comma-decimal locale that means:

| direction | before | consequence |
|---|---|---|
| write | `1.5` → `"1,5"` | the `.aes` file **is no longer valid JSON** |
| read | `"1.5"` → `1` | **silent, unbounded truncation** of every fractional value on load |

Neither failure raises an error. A project saved in that state does not reload; one loaded in that state comes back with every clip position, gain and automation point quietly wrong.

This is not a UI setting — `AestraJSON` backs `ProjectSerializer`, `Preferences`, `LicenseVerifier`, `PluginScanner`, `TakeManager`, the theme loader and MuseAgent.

## Is it reachable?

**Latent, not live.** Nothing in `Source/`, `AestraUI/` or `AestraAudio/` calls `setlocale` (verified by grep), so the process stays in the `"C"` locale and the bug does not fire today.

**But it is reachable, and not by user misconfiguration.** Aestra loads arbitrary third-party VST3/CLAP binaries into its own process, and a plugin calling `setlocale(LC_ALL, "")` is a documented hazard the VST3 SDK itself warns about. One such plugin poisons every save that follows it. The header already carried the assumption in a comment — *"assumes the C numeric locale uses '.' as the decimal separator"* — but nothing enforced it.

## The fix

**Write** keeps `snprintf`. It is the hot path, and the round-trip-exactness loop depends on `printf` and `strtod` agreeing with each other. So the exactness check runs **before** normalisation — both stay in whatever locale is active — and only the emitted text is forced to JSON's `.`:

```cpp
std::snprintf(buf, bufSize, "%.*f", decimals, v);
exact = (std::strtod(buf, nullptr) == v);   // same locale on both sides
...
normalizeDecimalPointToDot(buf, bufSize, localeDecimalPoint());
```

**Read** drops `std::stod` for an `istringstream` imbued with `std::locale::classic()`, which is independent of both the C locale *and* any `std::locale::global` a host or plugin installs.

## Tests — and a real hole I had to close

21 checks, **mutation-verified** against two realistic wrong implementations:

| mutation | caught by |
|---|---|
| normalisation disabled (write bug) | 8 checks |
| parse reverted to `std::stod` (read bug) | 2 checks |

The read-side mutation is **only** observable under a real comma-decimal *C* locale. My first version of this test skipped that case whenever the machine had no such locale — which is most Linux CI images — and reported **"All 15 checks passed"**. A green run that verified half the fix.

So the test now builds the locale itself: `localedef -i de_DE -f UTF-8` into a temp dir, then points `LOCPATH` at it. glibc reads `LOCPATH` when `setlocale()` runs rather than at process start, so doing this from `main()` works. macOS and Windows already ship comma locales, so generation only engages on Linux. Confirmed locally:

```
(using locale: de_DE.UTF-8 (generated))
All 21 checks passed.
```

If generation *also* fails, it still skips — but increments a skip counter and prints `WARNING: coverage is incomplete in this run` instead of a clean pass.

## Verification

- Full suite **231/231**, build clean
- Precision guards green — `ProjectFixtureCorpusTest`, `ProjectValueFidelityTest`, `ProjectLoadRegressionTest`, which assert `1024.125` survives save/load byte-exact and are the real check on whether moving the normalisation step damaged the exactness loop

## Reviewer notes

- `localeDecimalPoint()` and `normalizeDecimalPointToDot()` are public because the test drives them directly; they are pure functions holding no JSON state.
- The test shells out to `localedef` via `std::system`. Deliberate and test-only: there is no library API for compiling a locale, and the alternative is leaving the read-side fix unverified on Linux CI.
- `%f` does not apply digit grouping unless the `'` flag is used, so the separator is the only locale artefact in the formatted output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Make `AestraJSON` independent of the process locale for decimal serialization and parsing.
- Normalize locale-specific decimal separators to `.` after serialization precision validation.
- Parse numbers with a classic-locale `istringstream` to prevent truncation under comma-decimal locales.
- Add locale regression tests for serialization, parsing, round trips, precision, and failure handling.
- Generate `de_DE.UTF-8` on Linux when needed and report incomplete locale coverage.
- Register the optional locale test with CTest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->