### PR TITLE
Compile the plugin hosting code in CI at all

### DIFF
--- a/.github/actions/classify-scope/action.yml
+++ b/.github/actions/classify-scope/action.yml
@@ -20,7 +20,8 @@ inputs:
   lane:
     description: >
       Lane identifier: linux-gcc, windows-msvc, macos-clang, ui-app, asan, tsan,
-      lsan or tidy. An unrecognised value runs the lane (see lane-runs.sh).
+      lsan, tidy or plugin-host. An unrecognised value runs the lane (see
+      lane-runs.sh).
     required: true
   github-token:
     description: Token used to read the pull request's changed files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,102 @@ jobs:
           -DBUNDLED_FONT_ROOT=${{github.workspace}}/build-app/bin/AestraAssets/fonts
           -P ${{github.workspace}}/Tests/Guards/verify_aestra_font_bundle.cmake
 
+  build-plugin-host:
+    name: Plugin hosting (VST3 + CLAP compile)
+    runs-on: ubuntu-latest
+    steps:
+      # Unlike every other lane, this one NEEDS a submodule. The VST3 SDK lives in
+      # one, and AestraAudio/CMakeLists.txt gates AESTRA_HAS_VST3 on its presence,
+      # so with submodules: false the entire VST3 host path — VST3Host.cpp and the
+      # SDK hosting sources it links — is silently excluded from every other job.
+      # That is why this lane exists: the plugin hosting code was not compiled by
+      # CI at all, so nothing caught a break in it until someone built locally.
+      #
+      # Only vst3sdk is fetched, shallow. Pulling every submodule would drag in
+      # FreeType and SDL2 for a lane that never touches the UI.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Classify change scope
+        id: scope
+        uses: ./.github/actions/classify-scope
+        with:
+          lane: plugin-host
+          github-token: ${{ github.token }}
+
+      - name: Fetch VST3 SDK submodule
+        if: steps.scope.outputs.run == 'true'
+        run: git submodule update --init --depth 1 AestraAudio/External/vst3sdk
+
+      - name: Install Dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libasound2-dev libsodium-dev libx11-dev
+
+      # Configure once, and assert on that same run's output. A lane that compiles
+      # nothing would otherwise report green - which is the precise failure mode
+      # this lane exists to eliminate, so the assertion is not optional polish.
+      - name: Configure and assert both plugin formats are enabled
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          cmake -B build-plugins -S . \
+            -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+            -DAestra_CORE_MODE=ON \
+            -DAESTRA_HEADLESS_ONLY=ON \
+            -DAESTRA_ENABLE_TESTS=ON 2>&1 | tee configure.log
+          grep -q "VST3 SDK: Found" configure.log \
+            || { echo "::error::VST3 SDK not detected - this lane would compile nothing"; exit 1; }
+          grep -q "CLAP SDK: Found" configure.log \
+            || { echo "::error::CLAP SDK not detected - this lane would compile nothing"; exit 1; }
+
+      # Builds the default target, not just the two host targets. The plugin and
+      # sandbox tests below are separate executables: build only AestraAudioCore
+      # and AestraPluginHost and every test reports "(Not Run)", which fails the
+      # lane for a misleading reason instead of testing anything. Headless mode
+      # keeps the UI out, so this is comparable in cost to the Linux (GCC) lane -
+      # the difference being that here the plugin tests run against real VST3 and
+      # CLAP host code rather than against it compiled out.
+      - name: Build (headless, plugin formats enabled)
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          cmake --build build-plugins --config ${{env.BUILD_TYPE}} --parallel
+          test -x build-plugins/bin/AestraPluginHost \
+            || { echo "::error::AestraPluginHost was not produced"; exit 1; }
+
+      # Proves both formats are linked in, not merely compiled and discarded.
+      - name: Assert host symbols are present
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          lib=$(find build-plugins -name 'libAestraAudioCore.a' -print -quit)
+          test -n "${lib}" || { echo "::error::libAestraAudioCore.a not found"; exit 1; }
+          nm -C "${lib}" > syms.txt
+          grep -q "VST3PluginInstance" syms.txt \
+            || { echo "::error::VST3 host symbols missing from libAestraAudioCore"; exit 1; }
+          grep -q "CLAPPluginInstance" syms.txt \
+            || { echo "::error::CLAP host symbols missing from libAestraAudioCore"; exit 1; }
+
+      # Two selectors, both required. The plugin/clap labels do NOT carry the
+      # sandbox isolation tests (those are labelled security), and they are the
+      # ones that actually exercise out-of-process hosting - so they are named
+      # explicitly. Deliberately not chained with `||`: that would turn a real
+      # test failure into a silent retry of a different selector.
+      - name: Run plugin tests
+        if: steps.scope.outputs.run == 'true'
+        working-directory: build-plugins
+        run: ctest -L "plugin|clap" --output-on-failure
+
+      - name: Run sandbox isolation tests
+        if: steps.scope.outputs.run == 'true'
+        working-directory: build-plugins
+        run: >-
+          ctest --output-on-failure -R
+          "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecPluginCacheBounds|SecPluginTrustedPath|PluginScannerSigpipeTest"
+
   build-windows:
     name: Windows (MSVC)
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,12 @@ jobs:
   build-plugin-host:
     name: Plugin hosting (VST3 + CLAP compile)
     runs-on: ubuntu-latest
+    # Least privilege, declared rather than inherited, matching the classifier
+    # self-test job below. This one only reads the repo and lets classify-scope read
+    # pull-request file lists; nothing here pushes.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       # Unlike every other lane, this one NEEDS a submodule. The VST3 SDK lives in
       # one, and AestraAudio/CMakeLists.txt gates AESTRA_HAS_VST3 on its presence,
@@ -159,6 +165,12 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: false
+          # Nothing here pushes, so do not leave a credential in .git/config. Safe
+          # for the submodule fetch below because steinbergmedia/vst3sdk is public
+          # (see .gitmodules) and clones anonymously — this job would break if that
+          # submodule were ever made private, which is worth knowing explicitly
+          # rather than discovering through a confusing auth failure.
+          persist-credentials: false
 
       - name: Classify change scope
         id: scope
@@ -171,11 +183,21 @@ jobs:
         if: steps.scope.outputs.run == 'true'
         run: git submodule update --init --depth 1 AestraAudio/External/vst3sdk
 
+      # libsecret-1-dev is not optional: AestraLicense/CMakeLists.txt does an
+      # unconditional pkg_check_modules(LIBSECRET REQUIRED libsecret-1) on every
+      # non-Apple platform, so configure fails outright without it — which is exactly
+      # how this lane failed its own first run. Every other C++ lane in this file
+      # installs it; this list was written from scratch instead of copied from one of
+      # them, and a developer machine that already has the package cannot catch that.
+      #
+      # Deliberately NOT installed: libgl1-mesa-dev (headless build, no UI targets)
+      # and libgtest-dev (nothing in the tree uses GTest — its presence in the other
+      # lanes is vestigial and not worth copying).
       - name: Install Dependencies
         if: steps.scope.outputs.run == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libasound2-dev libsodium-dev libx11-dev
+          sudo apt-get install -y build-essential cmake libasound2-dev libsodium-dev libx11-dev libsecret-1-dev
 
       # Configure once, and assert on that same run's output. A lane that compiles
       # nothing would otherwise report green - which is the precise failure mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,22 @@ jobs:
           lane: plugin-host
           github-token: ${{ github.token }}
 
+      # Two levels, because the VST3 SDK keeps its own tree in nested submodules.
+      # `--init` on the outer path alone leaves base/, pluginterfaces/ and
+      # public.sdk/ as empty directories, which is how this lane failed its second
+      # run: configure announced "VST3 SDK: Found" and then died at add_library.
+      #
+      # Named explicitly rather than --recursive: these three are the only ones the
+      # build compiles from (see VST3_HOST_SOURCES in AestraAudio/CMakeLists.txt).
+      # --recursive would additionally clone vstgui4, doc and tutorials, which
+      # nothing here touches and vstgui4 is the largest of the set.
       - name: Fetch VST3 SDK submodule
         if: steps.scope.outputs.run == 'true'
-        run: git submodule update --init --depth 1 AestraAudio/External/vst3sdk
+        run: |
+          set -euo pipefail
+          git submodule update --init --depth 1 AestraAudio/External/vst3sdk
+          git -C AestraAudio/External/vst3sdk submodule update --init --depth 1 \
+            base pluginterfaces public.sdk
 
       # libsecret-1-dev is not optional: AestraLicense/CMakeLists.txt does an
       # unconditional pkg_check_modules(LIBSECRET REQUIRED libsecret-1) on every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,11 +236,28 @@ jobs:
       # keeps the UI out, so this is comparable in cost to the Linux (GCC) lane -
       # the difference being that here the plugin tests run against real VST3 and
       # CLAP host code rather than against it compiled out.
+      # Serial. `--parallel` with no argument uses one job per core, and this build
+      # has 200+ targets whose link steps are individually memory-hungry: the runner
+      # ran out of memory and the service killed the job — dozens of simultaneous
+      # "Terminated" lines and "The operation was canceled", with no compile error
+      # anywhere.
+      #
+      # Nothing in this file parallelises a full default-target build without a
+      # bound. Linux (GCC), macOS, Windows and ASan all build serially; the UI/App
+      # lane uses --parallel but scoped to a single target; TSan and LSan use an
+      # explicit --parallel 2. Unbounded on the whole target set was novel here, and
+      # this is why. `--parallel 2` would likely be fine and roughly halve wall time,
+      # but serial is the setting actually proven against this target set, and after
+      # three red runs the proven one wins.
+      #
+      # Do not reintroduce an unbounded --parallel without measuring peak memory:
+      # the failure presents as an infrastructure flake rather than as anything this
+      # lane did wrong, which makes it expensive to diagnose a second time.
       - name: Build (headless, plugin formats enabled)
         if: steps.scope.outputs.run == 'true'
         run: |
           set -euo pipefail
-          cmake --build build-plugins --config ${{env.BUILD_TYPE}} --parallel
+          cmake --build build-plugins --config ${{env.BUILD_TYPE}}
           test -x build-plugins/bin/AestraPluginHost \
             || { echo "::error::AestraPluginHost was not produced"; exit 1; }
 

--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -94,7 +94,20 @@ endif()
 
 set(VST3_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/External/vst3sdk)
 
-if(EXISTS ${VST3_SDK_DIR}/pluginterfaces AND EXISTS ${VST3_SDK_DIR}/public.sdk)
+# Probe actual FILES, not directories. The VST3 SDK keeps base/, pluginterfaces/ and
+# public.sdk/ in nested submodules of its own, so a non-recursive
+# `git submodule update --init` leaves those directories present but EMPTY — and
+# `EXISTS <dir>` is satisfied by an empty directory. That combination announced
+# "VST3 SDK: Found", set AESTRA_HAS_VST3 ON, and then failed at add_library() with
+# "Cannot find source file", while any check that trusted the message was told the
+# SDK was usable. Tests/CMakeLists.txt already probes a real header for this reason;
+# this is the same test applied to the decision that actually gates the build.
+#
+# One file per nested submodule, each one the build genuinely compiles, so a
+# partially-initialised checkout cannot pass.
+if(EXISTS "${VST3_SDK_DIR}/pluginterfaces/base/funknown.cpp"
+   AND EXISTS "${VST3_SDK_DIR}/public.sdk/source/vst/hosting/module.cpp"
+   AND EXISTS "${VST3_SDK_DIR}/base/source/fstring.cpp")
     set(AESTRA_HAS_VST3 ON)
     message(STATUS "VST3 SDK: Found at ${VST3_SDK_DIR}")
     

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -864,6 +864,11 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces/vst/i
     add_executable(AestraWatchdogTest AestraAudio/WatchdogTest.cpp)
     target_link_libraries(AestraWatchdogTest PRIVATE AestraAudio)
     add_test(NAME AestraWatchdogTest COMMAND AestraWatchdogTest)
+    # Labelled so label-based selection can find it. These two are the only tests in
+    # the tree gated on the VST3 SDK, and they were unlabelled — so the plugin-host
+    # lane compiled them and then never ran them, because its `ctest -L "plugin|clap"`
+    # had nothing to match on. Compiled is not executed.
+    set_tests_properties(AestraWatchdogTest PROPERTIES LABELS "plugin;vst3;watchdog")
     target_include_directories(AestraWatchdogTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk
         ${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces
@@ -879,6 +884,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces/vst/i
     add_executable(AestraCrashTest AestraAudio/CrashTest.cpp)
     target_link_libraries(AestraCrashTest PRIVATE AestraAudio)
     add_test(NAME AestraCrashTest COMMAND AestraCrashTest)
+    set_tests_properties(AestraCrashTest PROPERTIES LABELS "plugin;vst3;crash")
     target_include_directories(AestraCrashTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk
         ${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces

--- a/scripts/ci/lane-runs.sh
+++ b/scripts/ci/lane-runs.sh
@@ -41,7 +41,7 @@ LANE="${2:-}"
 # force-disabled. None of them can observe a change confined to the UI/app trees.
 is_headless_lane() {
     case "$1" in
-        linux-gcc|windows-msvc|macos-clang|asan|tsan|lsan|tidy) return 0 ;;
+        linux-gcc|windows-msvc|macos-clang|asan|tsan|lsan|tidy|plugin-host) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -51,7 +51,7 @@ main() {
         skip-cxx)
             # Nothing compiles prose. The UI/App lane included.
             case "${LANE}" in
-                linux-gcc|windows-msvc|macos-clang|ui-app|asan|tsan|lsan|tidy)
+                linux-gcc|windows-msvc|macos-clang|ui-app|asan|tsan|lsan|tidy|plugin-host)
                     echo "false"; return 0 ;;
             esac
             ;;

--- a/scripts/ci/lane-runs.test.sh
+++ b/scripts/ci/lane-runs.test.sh
@@ -30,7 +30,7 @@ expect() {
     fi
 }
 
-ALL_LANES=(linux-gcc windows-msvc macos-clang ui-app asan tsan lsan tidy)
+ALL_LANES=(linux-gcc windows-msvc macos-clang ui-app asan tsan lsan tidy plugin-host)
 
 # --- broad runs everything --------------------------------------------------
 for lane in "${ALL_LANES[@]}"; do
@@ -51,6 +51,7 @@ expect false ui-app-only asan
 expect false ui-app-only tsan
 expect false ui-app-only lsan
 expect false ui-app-only tidy
+expect false ui-app-only plugin-host
 
 # --- anything unrecognised must run -----------------------------------------
 # A typo in a verdict or a lane id is allowed to cost compute. It is never allowed to


### PR DESCRIPTION
## Summary

Adds a `Plugin hosting (VST3 + CLAP compile)` lane to `ci.yml`. Until this lands, **no CI job compiles the plugin hosting code at all.**

Every `actions/checkout` in `ci.yml` declines submodules — most set `submodules: false` explicitly, the rest inherit the same default. `AestraAudio/CMakeLists.txt` gates `AESTRA_HAS_VST3` on the SDK's presence, so with no submodule the flag is OFF and `VST3Host.cpp` plus the SDK hosting sources it links are silently excluded from every lane. CLAP was worse until #708: `External/clap/` held only `.gitkeep`, so `CLAPHost.cpp` had never been compiled by anything, ever.

The consequence is not hypothetical. Everything proved about plugin hosting in #708 and #709 — including the Windows sandbox — was proved by lanes that do not compile the VST3 host path. A break in it would have reached `develop` green.

## Why

This is phase 0 of `AestraDocs/plugin-editor-sandbox-architecture.md`, and it is deliberately first: hardening a subsystem CI does not compile means every reliability claim rests on one developer's local build.

## What it does

- Fetches **only** `AestraAudio/External/vst3sdk`, shallow. Pulling every submodule would drag FreeType and SDL2 into a lane that never touches the UI.
- Configures once and asserts `VST3 SDK: Found` **and** `CLAP SDK: Found` against that same run's output. A lane that compiles nothing must not be able to report green — that is the exact failure mode this exists to remove, so the assertion is load-bearing, not polish.
- Builds the **default** target, then asserts `AestraPluginHost` was produced.
- Greps `nm -C libAestraAudioCore.a` for `VST3PluginInstance` and `CLAPPluginInstance`, proving both formats are linked in rather than compiled and discarded.
- Runs two required test steps: `-L "plugin|clap"`, and an explicit `-R` naming the sandbox isolation tests.
- Registered as a headless lane in `scripts/ci/lane-runs.sh` and in the `skip-cxx` list, so a docs-only change does not pay for it. The classifier self-test goes 19 → 38 checks.

## Three flaws I found by running the lane locally before proposing it

Worth listing, because each would have produced a **green** lane that tested less than it appeared to:

1. **Building only `AestraAudioCore` and `AestraPluginHost` left every test `(Not Run)`.** The plugin and sandbox tests are separate executables. The lane failed for a misleading reason instead of testing anything. Fixed by building the default target.
2. **`-L "plugin|clap"` misses the sandbox isolation tests**, which are labelled `security`. The lane would have compiled the host code and then not run the tests that actually prove containment. Fixed with the explicit `-R` list alongside the label selector.
3. **`ctest … || ctest …` would have converted a real failure into a silent retry.** Removed; the two steps are independent and both required.

## Testing performed

Ran the lane's own steps verbatim on this branch, rebased onto `develop` after #708 and #709 merged:

- Configure: both assertions pass — and `CLAP SDK: Found` now holds from the merged vendored headers rather than temporarily borrowed ones, which is why this PR waited for #708 instead of stacking on it.
- Build: clean, `AestraPluginHost` produced.
- `ctest -L "plugin|clap"` → **100% passed, 26 tests**
- `ctest -R "SecOutOfProcessPluginHost|SecPluginScanIsolation|SecPluginCacheBounds|SecPluginTrustedPath|PluginScannerSigpipeTest"` → **100% passed, 5 tests**

No `(Not Run)` in either selector, which is the specific regression flaw 1 above would reintroduce.

## Producer note

None

## Docs updated?

No code or user-facing behaviour changes. The lane is phase 0 of the architecture note added in #708; that document already describes it.

## Risk / rollback

Low and self-contained: one new job plus two lane-table registrations. It adds runner minutes on C++ changes and is skipped for docs-only ones.

The realistic failure mode is the lane going red on a real break in host code that previously went unnoticed — which is the point, not a regression. Rollback is reverting the single commit, which returns plugin hosting to being compiled by nothing.

One limit stated plainly: this lane compiles the VST3 host path and runs the sandbox tests on Linux. It does not load a real third-party plugin, and it does not cover Windows or macOS host compilation, which remain gated on their own lanes not fetching the submodule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a `plugin-host` CI lane for Linux plugin hosting.
- The lane detects the VST3 and CLAP SDKs, builds the headless target, verifies host symbols, and runs plugin and sandbox isolation tests.
- Added lane classification and self-test coverage. The lane skips docs-only, C++-only, and UI/app-only changes.
- The lane is not included in branch protection yet. Windows, macOS, and third-party plugin loading remain outside its scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->