### PR TITLE
ci: enforce founder decision citations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,36 @@
+## Decision citation
+
+<!-- Required on every pull request. FD-12 — the strategic record in
+     Aestra-Internals is the durable authority for scope, and work cites it.
+
+     Objective   what this advances, e.g. "N3 — producer-loop scenario".
+                 Leave as — only when Kind is corrective.
+     Decision    the governing entry AND the commit it lives in: FD-04 @ a30696a.
+                 The id alone is not enough. The record is a living file, so
+                 "FD-04" does not say which FD-04 — the SHA is what makes a stale
+                 citation visible in review.
+     Kind        planned    advances an objective the record authorises
+                 corrective fixes a defect in shipped or in-flight work
+                 unparked   starts work a decision forbids or parks
+     Reversal    unparked only. The NEW decision entry authorising it, by id.
+                 A verbal approval is not an entry. If no entry exists, this
+                 work is not ready to start — that is the point.
+
+     Worked example:
+
+       Objective:  N3 — producer-loop scenario in CI
+       Decision:   FD-04 @ a30696a
+       Kind:       planned
+       Reversal:   —
+
+     The check strips these comments before parsing, so the example above cannot
+     answer on your behalf. -->
+
+Objective:  <what this advances>
+Decision:   <FD-NN @ sha>
+Kind:       planned | corrective | unparked
+Reversal:   —
+
 ## Summary
 
 -

--- a/.github/workflows/decision-citation.yml
+++ b/.github/workflows/decision-citation.yml
@@ -131,11 +131,20 @@ jobs:
           # Every markdown file in the record directory is a candidate, rather than
           # one hard-coded filename. New decisions arrive as new files, so a fixed
           # path would need editing whenever a decision is recorded and would fail
-          # closed on a pull request that did nothing wrong. Searching the directory
-          # costs a few more API calls and survives any renaming.
-          tree=$(gh api "repos/${VAULT}/git/trees/${full_sha}?recursive=1" \
-                   --jq '.tree[] | select(.type=="blob") | .path' 2>/dev/null)
-          records=$(printf '%s\n' "${tree}" | grep -E "^${RECORD_DIR}/.*\.md$" || true)
+          # closed on a pull request that did nothing wrong. Binding to the FD-NN
+          # heading schema instead survives any renaming.
+          #
+          # The tree is asked for blob SHAs alongside paths, and the content is then
+          # read through git/blobs rather than /contents. This is not a stylistic
+          # choice. /contents addresses a file by PATH, and these paths contain
+          # spaces and an em dash, so every request needs URL encoding whose failure
+          # mode is a 404 that reads exactly like "this file does not exist" — a
+          # transport problem wearing the costume of a content problem. Blob SHAs
+          # come free from the tree call already being made, need no encoding at
+          # all, and keep the whole lookup inside the git/* namespace.
+          entries=$(gh api "repos/${VAULT}/git/trees/${full_sha}?recursive=1" \
+                      --jq '.tree[] | select(.type=="blob") | "\(.sha) \(.path)"' 2>/dev/null)
+          records=$(printf '%s\n' "${entries}" | grep -E " ${RECORD_DIR}/.*\.md$" || true)
 
           if [ -z "${records}" ]; then
             echo "::error::No decision record found under '${RECORD_DIR}/' at ${full_sha}."
@@ -143,30 +152,45 @@ jobs:
             exit 1
           fi
 
-          # Path is URL-encoded for the contents endpoint: the record directory and
-          # filenames both contain spaces, and an unencoded space yields a 404 that
-          # reads exactly like "the file does not exist".
+          # unreadable counts records this step could not fetch or decode. It exists
+          # so the verdict below can distinguish "every record was read and the entry
+          # is absent" from "some record could not be read". Reporting the first when
+          # only the second is known is how a check ends up asserting a conclusion it
+          # never established — the exact failure this lane exists to prevent, and
+          # one it committed itself on its first live run.
           found=""
-          while IFS= read -r path; do
-            [ -z "${path}" ] && continue
-            encoded=$(printf '%s' "${path}" | jq -sRr @uri)
-            if gh api "repos/${VAULT}/contents/${encoded}?ref=${full_sha}" \
-                 --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
-                 | grep -qE "^#{2,3} ${DECISION_ID} "; then
+          unreadable=0
+          while IFS= read -r entry; do
+            [ -z "${entry}" ] && continue
+            blob="${entry%% *}"
+            path="${entry#* }"
+            if ! gh api "repos/${VAULT}/git/blobs/${blob}" --jq '.content' 2>/tmp/blob-err \
+                 | base64 -d > /tmp/record.md 2>/dev/null; then
+              unreadable=$((unreadable + 1))
+              echo "::warning::could not read ${path} (blob ${blob:0:7})"
+              sed 's/^/  /' /tmp/blob-err
+              continue
+            fi
+            if grep -qE "^#{2,3} ${DECISION_ID} " /tmp/record.md; then
               found="${path}"
               break
             fi
           done <<< "${records}"
 
-          if [ -z "${found}" ]; then
+          if [ -n "${found}" ]; then
+            echo "${DECISION_ID} found in: ${found}"
+          elif [ "${unreadable}" -gt 0 ]; then
+            echo "::error::${unreadable} record(s) could not be read, so whether ${DECISION_ID} exists at ${full_sha} is unknown."
+            echo "This is a lookup failure, not a citation failure. Check the token's Contents permission on ${VAULT}."
+            exit 1
+          else
             echo "::error::${DECISION_ID} is not an entry in the strategic record at ${full_sha}."
-            echo "Records searched at that commit:"
-            printf '%s\n' "${records}" | sed 's/^/  /'
+            echo "All records at that commit were read successfully. Searched:"
+            printf '%s\n' "${records}" | sed -E 's/^[0-9a-f]+ /  /'
             echo ""
             echo "Either the entry id is wrong, or the SHA predates the decision."
             exit 1
           fi
-          echo "${DECISION_ID} found in: ${found}"
 
           # --- is it current ---------------------------------------------
           # A warning, never a failure. FD-12 requires that a mismatch between

--- a/.github/workflows/decision-citation.yml
+++ b/.github/workflows/decision-citation.yml
@@ -1,0 +1,183 @@
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# FD-12 — every pull request cites the strategic decision it serves, by SHA.
+#
+# WHY THIS EXISTS
+#
+# Written plans enforced only through review are advisory. Engineering invariants
+# hold more reliably because automated checks enforce them at a checkpoint where the
+# author cannot negotiate with the result.
+#
+# This lane gives strategic decisions the same kind of checkpoint. A citation field
+# completed and reviewed by the same author is a log; validating it automatically
+# makes it a gate. That is the whole design, and it is why this must fail the build
+# rather than post a comment.
+#
+# TWO HALVES
+#
+#   structural   scripts/ci/check-decision-citation.sh — offline, unit-tested,
+#                29 cases in check-decision-citation.test.sh.
+#   referential  this file — does the cited SHA exist in Aestra-Internals, does the
+#                cited entry exist AT that SHA, and is it still current.
+#
+# The second half needs a token for a private repository, so it cannot live in the
+# script and cannot be unit-tested. Keeping the split is what lets the parser have
+# tests at all.
+
+name: Decision Citation (FD-12)
+
+on:
+  pull_request:
+    # `edited` is not optional. Without it, a PR opened with a bad citation stays
+    # red after the author fixes the body, because editing a description fires no
+    # other event. The check would be unfixable without pushing a commit, and a
+    # gate people cannot satisfy is a gate people route around.
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: decision-citation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # The job name is the contract — it becomes the status check name on develop.
+  # Renaming it silently detaches the branch protection rule and every PR goes
+  # green on a gate that is no longer running. Do not rename without updating
+  # branch protection in the same change.
+  citation:
+    name: Decision citation
+    runs-on: ubuntu-latest
+    # Bots cannot reason about strategic scope, and requiring a citation from one
+    # produces a mechanical answer that satisfies the check while meaning nothing.
+    # A dependency bump is not strategy.
+    if: >
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # The pull request body is untrusted input written by whoever opened the PR.
+      # It reaches the shell through an environment variable and never through
+      # ${{ }} interpolation: expanding it inline splices author-controlled text
+      # into the script GitHub generates, which is remote code execution on the
+      # runner via a markdown field. This is the single most important line here.
+      - name: Capture pull request body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "${PR_BODY}" > /tmp/pr-body.md
+
+      - name: Check citation structure
+        id: structure
+        run: bash scripts/ci/check-decision-citation.sh /tmp/pr-body.md
+
+      # ---------------------------------------------------------------------
+      # Referential half. Everything below resolves the citation against the
+      # strategic record itself.
+      # ---------------------------------------------------------------------
+
+      # Degrades to a warning rather than a pass or a hard failure. Without the
+      # token the structural gate above still binds — which is most of the value —
+      # but the claim "this SHA exists" becomes unverified, and an unverified claim
+      # must be visible rather than assumed. Failing outright instead would make
+      # every fork PR unmergeable for a reason the author cannot fix.
+      - name: Check for the vault token
+        id: token
+        env:
+          INTERNALS_TOKEN: ${{ secrets.INTERNALS_RO_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ -z "${INTERNALS_TOKEN}" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::INTERNALS_RO_TOKEN is not configured, so the cited SHA was not resolved against Aestra-Internals. Structural checks still ran. Fork pull requests cannot see this secret by design."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve the cited decision against the record
+        if: steps.token.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.INTERNALS_RO_TOKEN }}
+          VAULT: currentsuspect/Aestra-Internals
+          DECISION_ID: ${{ steps.structure.outputs.decision-id }}
+          DECISION_SHA: ${{ steps.structure.outputs.decision-sha }}
+          RECORD_DIR: 11 Decisions and Tradeoffs
+        run: |
+          set -uo pipefail
+
+          # --- does the commit exist -------------------------------------
+          # Short SHAs are what people paste, so the citation carries whatever the
+          # author had. This endpoint expands them, and returns the full SHA, which
+          # is what the staleness comparison below needs. An ambiguous short SHA
+          # fails here with GitHub's own message, which is clearer than anything a
+          # regex could have said upstream.
+          if ! full_sha=$(gh api "repos/${VAULT}/commits/${DECISION_SHA}" --jq '.sha' 2>/tmp/api-err); then
+            echo "::error::${DECISION_SHA} does not resolve to a commit in ${VAULT}."
+            echo "A citation must point at a commit that exists in the strategic record."
+            sed 's/^/  /' /tmp/api-err
+            exit 1
+          fi
+          echo "Cited commit resolves: ${full_sha}"
+
+          # --- does the entry exist AT that commit ------------------------
+          # The stronger of the two checks, and the reason this is not just an
+          # existence test. Citing a SHA that predates the decision is the natural
+          # mistake — you paste the SHA you have rather than the one that contains
+          # the entry — and it produces a citation that is wrong in the one way
+          # that matters: it points at a state where the decision had not been made.
+          #
+          # Every markdown file in the record directory is a candidate, rather than
+          # one hard-coded filename. New decisions arrive as new files, so a fixed
+          # path would need editing whenever a decision is recorded and would fail
+          # closed on a pull request that did nothing wrong. Searching the directory
+          # costs a few more API calls and survives any renaming.
+          tree=$(gh api "repos/${VAULT}/git/trees/${full_sha}?recursive=1" \
+                   --jq '.tree[] | select(.type=="blob") | .path' 2>/dev/null)
+          records=$(printf '%s\n' "${tree}" | grep -E "^${RECORD_DIR}/.*\.md$" || true)
+
+          if [ -z "${records}" ]; then
+            echo "::error::No decision record found under '${RECORD_DIR}/' at ${full_sha}."
+            echo "The cited commit predates the strategic record, so it cannot contain ${DECISION_ID}."
+            exit 1
+          fi
+
+          # Path is URL-encoded for the contents endpoint: the record directory and
+          # filenames both contain spaces, and an unencoded space yields a 404 that
+          # reads exactly like "the file does not exist".
+          found=""
+          while IFS= read -r path; do
+            [ -z "${path}" ] && continue
+            encoded=$(printf '%s' "${path}" | jq -sRr @uri)
+            if gh api "repos/${VAULT}/contents/${encoded}?ref=${full_sha}" \
+                 --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+                 | grep -qE "^#{2,3} ${DECISION_ID} "; then
+              found="${path}"
+              break
+            fi
+          done <<< "${records}"
+
+          if [ -z "${found}" ]; then
+            echo "::error::${DECISION_ID} is not an entry in the strategic record at ${full_sha}."
+            echo "Records searched at that commit:"
+            printf '%s\n' "${records}" | sed 's/^/  /'
+            echo ""
+            echo "Either the entry id is wrong, or the SHA predates the decision."
+            exit 1
+          fi
+          echo "${DECISION_ID} found in: ${found}"
+
+          # --- is it current ---------------------------------------------
+          # A warning, never a failure. FD-12 requires that a mismatch between
+          # implementation SHAs and the governing strategic state be VISIBLE during
+          # review — not that it be forbidden. Work legitimately outlives the SHA it
+          # started against, and failing here would force a body edit on every open
+          # pull request whenever a decision is recorded, which teaches everyone to
+          # paste the tip SHA without reading it. That is worse than stale.
+          tip=$(gh api "repos/${VAULT}/commits/HEAD" --jq '.sha' 2>/dev/null || echo "")
+          if [ -n "${tip}" ] && [ "${tip}" != "${full_sha}" ]; then
+            echo "::warning::The strategic record has moved since ${full_sha:0:7} (now ${tip:0:7}). ${DECISION_ID} still exists at the cited commit, so this is not a failure — but confirm the decision has not been superseded before merging."
+          else
+            echo "Citation is against the current strategic state."
+          fi

--- a/.github/workflows/decision-citation.yml
+++ b/.github/workflows/decision-citation.yml
@@ -81,20 +81,49 @@ jobs:
       # Degrades to a warning rather than a pass or a hard failure. Without the
       # token the structural gate above still binds — which is most of the value —
       # but the claim "this SHA exists" becomes unverified, and an unverified claim
-      # must be visible rather than assumed. Failing outright instead would make
-      # every fork PR unmergeable for a reason the author cannot fix.
+      # must be visible rather than assumed.
+      #
+      # A missing token means two different things depending on where the pull
+      # request came from, and they cannot share a disposition:
+      #
+      #   fork        Secrets are withheld by design. The author cannot fix this and
+      #               never could, so failing would make every fork pull request
+      #               permanently unmergeable for a reason outside its control.
+      #               Warn, run the structural half, and let review carry the rest.
+      #
+      #   same-repo   The token is missing because the repository is misconfigured.
+      #               Passing here would let branch protection accept "referential
+      #               validation was never attempted" as though it were "referential
+      #               validation passed" — a green tick over a gate that is not
+      #               running, which is the one outcome this lane must never produce.
+      #               Deleting the secret would silently disarm the check.
       - name: Check for the vault token
         id: token
         env:
           INTERNALS_TOKEN: ${{ secrets.INTERNALS_RO_TOKEN }}
+          # Renders as the literal string "true" or "false". A head repo that no
+          # longer exists compares unequal and is treated as a fork, which is the
+          # safe direction: such a pull request could not have had the secret anyway.
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -uo pipefail
-          if [ -z "${INTERNALS_TOKEN}" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::INTERNALS_RO_TOKEN is not configured, so the cited SHA was not resolved against Aestra-Internals. Structural checks still ran. Fork pull requests cannot see this secret by design."
-          else
+          if [ -n "${INTERNALS_TOKEN}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          echo "available=false" >> "$GITHUB_OUTPUT"
+
+          if [ "${IS_FORK}" = "true" ]; then
+            echo "::warning::Fork pull request: INTERNALS_RO_TOKEN is withheld by design, so the cited SHA was not resolved against the record. Structural checks still ran; confirm the citation manually before merging."
+            exit 0
+          fi
+
+          echo "::error::INTERNALS_RO_TOKEN is not configured on this repository."
+          echo "This is a same-repository pull request, so the secret should be available."
+          echo "Passing here would report a referential check that never ran."
+          echo "Configure the secret with read-only Contents access to the record repository."
+          exit 1
 
       - name: Resolve the cited decision against the record
         if: steps.token.outputs.available == 'true'

--- a/scripts/ci/check-decision-citation.sh
+++ b/scripts/ci/check-decision-citation.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Validate a pull request's decision citation block. Implements FD-12.
+#
+# Usage:  check-decision-citation.sh <pr-body-file>
+# Exit:   0 = the block is well formed. 1 = it is not.
+#
+# Diagnostics go to stdout. When GITHUB_OUTPUT is set, the parsed fields are
+# appended to it as decision-id / decision-sha / kind, so the workflow can do the
+# cross-repo half (does that SHA exist, does that entry exist in it) afterwards.
+#
+# THE CONTRACT — this script inverts lane-runs.sh's default deliberately.
+#
+# lane-runs.sh answers "true" for anything it does not recognise, because a typo in
+# a lane id must cost compute and never coverage. Here the opposite is true: an
+# unparsable citation must FAIL. A citation check that passes when it cannot read
+# the citation is not a check, it is a green tick over a gate that is not running —
+# which is worse than having no gate, because it reports compliance.
+#
+# So: every path out of this script that is not a positively verified citation
+# exits 1.
+#
+# WHAT FD-12 REQUIRES, AND WHAT THAT MEANS HERE
+#
+#   Objective    the active objective the work advances
+#   Decision     the governing decision, cited as FD-NN @ <sha>
+#   Kind         planned | corrective | unparked
+#   Reversal     the decision entry authorising a reversal — unparked only
+#
+# The SHA is not decoration. Citing "FD-04" alone says nothing about WHICH FD-04;
+# the strategic record is a living file. FD-04 @ <sha> is what makes staleness
+# visible during review, which is the requirement FD-12 actually states.
+#
+# STRUCTURAL ONLY
+#
+# This half is offline and therefore unit-testable. It does not know whether the
+# SHA exists, whether the entry exists, or whether either is current — the workflow
+# does that against Aestra-Internals, because it needs a token and a network.
+# Keeping the split here is what lets the parser have tests at all.
+
+set -uo pipefail
+
+BODY_FILE="${1:-}"
+
+# Fields the block may carry. Order here is the order errors are reported in.
+KEY_OBJECTIVE="Objective"
+KEY_DECISION="Decision"
+KEY_KIND="Kind"
+KEY_REVERSAL="Reversal"
+
+errors=0
+
+fail() {
+    printf '::error::%s\n' "$1"
+    errors=$((errors + 1))
+}
+
+note() {
+    printf '  %s\n' "$1"
+}
+
+# --- reading the body -------------------------------------------------------
+#
+# Two transformations, both load-bearing:
+#
+#   CRLF     GitHub returns pull request bodies with \r\n. Left in place, a value
+#            captured to end-of-line carries a trailing \r, so "FD-04 @ a30696a"
+#            arrives as "a30696a\r", fails the hex test, and reports a malformed
+#            SHA that looks perfectly correct in the error message. Hours of
+#            confusion for one invisible byte.
+#
+#   comments The pull request template explains each field inside <!-- --> blocks,
+#            and those blocks contain worked examples. Parsing before stripping
+#            them means the template's own example satisfies the check and every
+#            PR passes without an author typing anything. The comment stripper
+#            must therefore run first, and must handle multi-line comments.
+read_body() {
+    if [ -z "${BODY_FILE}" ]; then
+        fail "no pull request body file given (usage: check-decision-citation.sh <file>)"
+        return 1
+    fi
+    if [ ! -f "${BODY_FILE}" ]; then
+        fail "pull request body file not found: ${BODY_FILE}"
+        return 1
+    fi
+    # sed strips CR; awk strips <!-- ... --> across lines.
+    sed 's/\r$//' "${BODY_FILE}" | awk '
+        BEGIN { in_comment = 0 }
+        {
+            line = $0
+            out = ""
+            while (1) {
+                if (in_comment) {
+                    idx = index(line, "-->")
+                    if (idx == 0) { line = ""; break }
+                    line = substr(line, idx + 3)
+                    in_comment = 0
+                } else {
+                    idx = index(line, "<!--")
+                    if (idx == 0) { out = out line; break }
+                    out = out substr(line, 1, idx - 1)
+                    line = substr(line, idx + 4)
+                    in_comment = 1
+                }
+            }
+            print out
+        }
+    '
+}
+
+# --- field extraction -------------------------------------------------------
+#
+# Keys are matched case-insensitively, anywhere in the body, with any leading
+# whitespace or list marker. Authors reformat templates; the check should care
+# about the citation being present and correct, not about it sitting at a
+# particular line number. Only the first occurrence of a key counts, so a stray
+# mention later in a description cannot override the real block.
+#
+# Everything up to the first colon is discarded rather than matching the key a
+# second time in sed. sed's case-insensitive flag is a GNU extension, so matching
+# the key twice would make this script pass under CI and fail on a contributor's
+# machine — the class of difference that is worst to debug because the code looks
+# right in both places.
+extract() {
+    local key="$1" body="$2"
+    printf '%s\n' "${body}" \
+        | grep -iE "^[[:space:]]*[-*]?[[:space:]]*${key}[[:space:]]*:" \
+        | head -n 1 \
+        | sed -E 's/^[^:]*:[[:space:]]*//' \
+        | sed -E 's/[[:space:]]+$//'
+}
+
+# A value that is present but says nothing. Backticks, angle brackets and the
+# template's own em-dash placeholder all count as absent — otherwise the check
+# passes on an untouched template, which is the same as not having a check.
+is_placeholder() {
+    local value="$1"
+    [ -z "${value}" ] && return 0
+    case "$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')" in
+        -|--|—|–|n/a|na|none|tbd|todo|to\ do|xxx|\?|\?\?\?) return 0 ;;
+    esac
+    # <angle bracket placeholder> or `backtick placeholder` left from the template.
+    # Matched with grep and a single-quoted ERE, not a case pattern: a backtick in
+    # an unquoted case pattern is a command substitution waiting to happen, and a
+    # validator that executes fragments of the thing it is validating is a
+    # vulnerability rather than a check.
+    printf '%s' "${value}" | grep -qE '^<.*>$|^`.*`$' && return 0
+    return 1
+}
+
+# --- validation -------------------------------------------------------------
+
+main() {
+    local body
+    body="$(read_body)" || return 1
+
+    local objective decision kind reversal
+    objective="$(extract "${KEY_OBJECTIVE}" "${body}")"
+    decision="$(extract "${KEY_DECISION}" "${body}")"
+    kind="$(extract "${KEY_KIND}" "${body}")"
+    reversal="$(extract "${KEY_REVERSAL}" "${body}")"
+
+    # Absent block, as opposed to a wrong one. Reported separately because the fix
+    # is different: paste the template, versus correct the field you got wrong.
+    if [ -z "${objective}${decision}${kind}" ]; then
+        fail "no decision citation block found. FD-12 requires every pull request to carry one:"
+        note ""
+        note "Objective:  N3 — producer-loop scenario in CI"
+        note "Decision:   FD-04 @ <sha of the governing entry>"
+        note "Kind:       planned | corrective | unparked"
+        note "Reversal:   <required only when Kind is unparked>"
+        note ""
+        note "See the decision record in Aestra-Internals."
+        return 1
+    fi
+
+    # --- Kind ---------------------------------------------------------------
+    # Validated first: it decides how strict the other three are.
+    local kind_lc
+    kind_lc="$(printf '%s' "${kind}" | tr '[:upper:]' '[:lower:]')"
+    case "${kind_lc}" in
+        planned|corrective|unparked) : ;;
+        "")
+            fail "Kind is missing. Must be one of: planned, corrective, unparked."
+            ;;
+        *)
+            fail "Kind is '${kind}'. Must be one of: planned, corrective, unparked."
+            note "planned    — advances an objective the strategic record authorises"
+            note "corrective — fixes a defect in shipped or in-flight work"
+            note "unparked   — starts work a decision forbids or parks; needs a new decision entry"
+            ;;
+    esac
+
+    # --- Objective ----------------------------------------------------------
+    # Corrective work is exempt from naming a strategic objective, because fixing a
+    # defect does not advance one and pretending otherwise teaches authors to write
+    # fiction in the field. Everything else must name what it serves.
+    if is_placeholder "${objective}"; then
+        if [ "${kind_lc}" = "corrective" ]; then
+            note "Objective is empty; allowed because Kind is corrective."
+        else
+            fail "Objective is empty. Name the objective this work advances (e.g. 'N3 — producer-loop scenario')."
+            note "If this is a defect fix rather than planned work, set Kind: corrective."
+        fi
+    fi
+
+    # --- Decision -----------------------------------------------------------
+    # FD-NN @ <7-40 hex>. Short SHAs are accepted because that is what people paste;
+    # the workflow resolves whatever is given against the vault, and an ambiguous
+    # short SHA fails there with a clearer message than a regex could give.
+    if is_placeholder "${decision}"; then
+        fail "Decision is empty. Cite the governing entry as 'FD-NN @ <sha>'."
+    elif ! printf '%s' "${decision}" \
+        | grep -qiE '^FD-[0-9]{2}[[:space:]]*@[[:space:]]*[0-9a-f]{7,40}$'; then
+        fail "Decision is '${decision}', which is not of the form 'FD-NN @ <sha>'."
+        if printf '%s' "${decision}" | grep -qiE '^FD-[0-9]{2}[[:space:]]*$'; then
+            note "An entry id alone is not enough. The strategic record is a living file,"
+            note "so 'FD-04' does not say which FD-04. The SHA is what makes staleness visible."
+        fi
+        note "Example: FD-04 @ a30696a"
+    else
+        local decision_id decision_sha
+        decision_id="$(printf '%s' "${decision}" | sed -E 's/^([Ff][Dd]-[0-9]{2}).*/\1/' | tr '[:lower:]' '[:upper:]')"
+        decision_sha="$(printf '%s' "${decision}" | sed -E 's/.*@[[:space:]]*//' | tr '[:upper:]' '[:lower:]')"
+        note "Cited: ${decision_id} @ ${decision_sha}"
+        if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+                printf 'decision-id=%s\n' "${decision_id}"
+                printf 'decision-sha=%s\n' "${decision_sha}"
+                printf 'kind=%s\n' "${kind_lc}"
+            } >> "${GITHUB_OUTPUT}"
+        fi
+    fi
+
+    # --- Reversal -----------------------------------------------------------
+    # The whole point of FD-12. Starting work a decision parks is the one kind that
+    # cannot be self-authorised, because self-authorisation is indistinguishable
+    # from the deferral never having existed. It needs a decision entry, by id.
+    if [ "${kind_lc}" = "unparked" ]; then
+        if is_placeholder "${reversal}"; then
+            fail "Kind is unparked, so Reversal must name the decision entry authorising it."
+            note "Unparking work a decision forbids requires a NEW entry in the strategic"
+            note "record, cited by id. Without one, the deferral has no force."
+        elif ! printf '%s' "${reversal}" | grep -qiE 'FD-[0-9]{2}'; then
+            fail "Reversal is '${reversal}', which names no decision entry."
+            note "Cite the entry that authorises the reversal, e.g. 'FD-13 — hosting unparked'."
+        fi
+    elif ! is_placeholder "${reversal}" && [ "${kind_lc}" != "unparked" ]; then
+        note "Reversal given but Kind is ${kind_lc}; ignored."
+    fi
+
+    [ "${errors}" -eq 0 ]
+}
+
+if main; then
+    printf 'Decision citation OK.\n'
+    exit 0
+fi
+
+printf '\nDecision citation check failed with %d error(s).\n' "${errors}"
+printf 'FD-12: this vault is the durable authority for strategic scope.\n'
+exit 1

--- a/scripts/ci/check-decision-citation.sh
+++ b/scripts/ci/check-decision-citation.sh
@@ -242,9 +242,24 @@ main() {
             fail "Kind is unparked, so Reversal must name the decision entry authorising it."
             note "Unparking work a decision forbids requires a NEW entry in the strategic"
             note "record, cited by id. Without one, the deferral has no force."
-        elif ! printf '%s' "${reversal}" | grep -qiE 'FD-[0-9]{2}'; then
-            fail "Reversal is '${reversal}', which names no decision entry."
+        elif ! printf '%s' "${reversal}" | grep -qiE '^FD-[0-9]{2}([[:space:]]|$)'; then
+            # Anchored, not "contains". An unanchored match accepts "approved
+            # verbally, maybe see FD-13 sometime" — prose with an id somewhere in
+            # it, which is the thing this field exists to stop being sufficient.
+            fail "Reversal is '${reversal}', which does not begin with a decision entry id."
             note "Cite the entry that authorises the reversal, e.g. 'FD-13 — hosting unparked'."
+        else
+            # The governing decision cannot authorise its own reversal. Permitting
+            # it makes 'unparked' indistinguishable from the deferral never having
+            # existed, which is precisely the state this kind exists to surface.
+            local reversal_id
+            reversal_id="$(printf '%s' "${reversal}" \
+                | sed -E 's/^([Ff][Dd]-[0-9]{2}).*/\1/' | tr '[:lower:]' '[:upper:]')"
+            if [ -n "${decision_id:-}" ] && [ "${reversal_id}" = "${decision_id}" ]; then
+                fail "Reversal cites ${reversal_id}, which is the governing decision itself."
+                note "A decision cannot authorise its own reversal. Unparking requires a NEW"
+                note "entry in the strategic record."
+            fi
         fi
     elif ! is_placeholder "${reversal}" && [ "${kind_lc}" != "unparked" ]; then
         note "Reversal given but Kind is ${kind_lc}; ignored."

--- a/scripts/ci/check-decision-citation.test.sh
+++ b/scripts/ci/check-decision-citation.test.sh
@@ -220,6 +220,39 @@ Kind:       unparked
 Reversal:   approved verbally
 EOF
 
+# An unanchored "contains FD-NN" test accepts prose with an id buried in it,
+# which is the thing this field exists to stop being sufficient.
+expect fail "unparked with the entry id buried in prose" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   approved verbally, maybe see FD-13 sometime
+EOF
+
+# Self-authorisation. A decision that parks work cannot be the decision that
+# authorises unparking it — that is the deferral never having existed, wearing
+# a citation. Both of these passed before the anchoring fix.
+expect fail "unparked authorised by the governing decision itself" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   FD-03
+EOF
+
+expect fail "self-authorisation with trailing prose" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   FD-03 — still fine in my opinion
+EOF
+
+expect pass "bare entry id with nothing after it" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   FD-13
+EOF
+
 # ---------------------------------------------------------------------------
 # Rejected — objective
 # ---------------------------------------------------------------------------

--- a/scripts/ci/check-decision-citation.test.sh
+++ b/scripts/ci/check-decision-citation.test.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Tests for check-decision-citation.sh — the FD-12 citation parser.
+#
+# The direction that matters here is the FALSE PASS. A wrong rejection is loud: the
+# author sees a red check and a message, and fixes the block. A wrong acceptance is
+# silent, and a governance mechanism that silently accepts anything binds nothing
+# while reporting that it does. So the accept cases below are deliberately few and
+# the reject cases deliberately hostile.
+#
+# Everything here is offline. The cross-repo half (does the SHA exist in
+# Aestra-Internals, does the entry exist at that SHA) lives in the workflow and is
+# not exercised by these tests.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${HERE}/check-decision-citation.sh"
+
+failures=0
+checks=0
+
+# expect <pass|fail> <label> <<< body
+expect() {
+    local expected="$1" label="$2"
+    local body tmp actual status
+    body="$(cat)"
+    tmp="$(mktemp)"
+    printf '%s' "${body}" > "${tmp}"
+    checks=$((checks + 1))
+
+    # GITHUB_OUTPUT is deliberately unset: the script must not require it.
+    actual="$(env -u GITHUB_OUTPUT bash "${CHECK}" "${tmp}" 2>&1)"
+    status=$?
+    rm -f "${tmp}"
+
+    local got="pass"
+    [ "${status}" -ne 0 ] && got="fail"
+
+    if [ "${got}" = "${expected}" ]; then
+        printf 'PASS  %-52s -> %s\n' "${label}" "${got}"
+    else
+        printf 'FAIL  %-52s -> %s (expected %s)\n' "${label}" "${got}" "${expected}"
+        printf '%s\n' "${actual}" | sed 's/^/        | /'
+        failures=$((failures + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Accepted
+# ---------------------------------------------------------------------------
+
+expect pass "canonical planned block" <<'EOF'
+## Summary
+- Adds the loop scenario.
+
+Objective:  A1 — example objective
+Decision:   FD-04 @ a30696a
+Kind:       planned
+Reversal:   —
+EOF
+
+expect pass "corrective work needs no objective" <<'EOF'
+Objective:  —
+Decision:   FD-06 @ a30696a858b2f723030c3732e7a9deb80bb103c5
+Kind:       corrective
+Reversal:   —
+EOF
+
+expect pass "unparked with an authorising entry" <<'EOF'
+Objective:  A2 — example objective
+Decision:   FD-04 @ a30696a
+Kind:       unparked
+Reversal:   FD-13 — authorised by decision entry
+EOF
+
+expect pass "lowercase keys and kind" <<'EOF'
+objective:  a1
+decision:   fd-04 @ A30696A
+kind:       PLANNED
+EOF
+
+expect pass "markdown list markers and ragged spacing" <<'EOF'
+- Objective:A1
+* Decision:  FD-04@a30696a
+- Kind:planned
+EOF
+
+expect pass "full 40-character sha" <<'EOF'
+Objective:  A3 — example objective
+Decision:   FD-11 @ a30696a858b2f723030c3732e7a9deb80bb103c5
+Kind:       planned
+EOF
+
+# ---------------------------------------------------------------------------
+# Rejected — absent or inert
+# ---------------------------------------------------------------------------
+
+expect fail "no block at all" <<'EOF'
+## Summary
+- Fixed a typo.
+EOF
+
+expect fail "empty body" <<'EOF'
+EOF
+
+# The trap this check exists to survive. The pull request template documents each
+# field inside an HTML comment, worked examples included. Parse before stripping
+# comments and the template answers the check on the author's behalf, forever.
+expect fail "template example inside an HTML comment does not count" <<'EOF'
+## Summary
+- Something.
+
+<!--
+Objective:  A1 — example objective
+Decision:   FD-04 @ a30696a
+Kind:       planned
+-->
+EOF
+
+expect fail "multi-line comment spanning the whole block" <<'EOF'
+<!-- fill this in:
+Objective: x
+Decision: FD-01 @ a30696a
+Kind: planned
+--> and nothing else
+EOF
+
+expect fail "untouched template placeholders" <<'EOF'
+Objective:  <what this advances>
+Decision:   <FD-NN @ sha>
+Kind:       planned | corrective | unparked
+EOF
+
+expect fail "em-dash placeholders throughout" <<'EOF'
+Objective:  —
+Decision:   —
+Kind:       —
+EOF
+
+# ---------------------------------------------------------------------------
+# Rejected — the SHA requirement, which is the entire mechanism
+# ---------------------------------------------------------------------------
+
+expect fail "entry id with no sha" <<'EOF'
+Objective:  A1
+Decision:   FD-04
+Kind:       planned
+EOF
+
+expect fail "sha too short to be unambiguous" <<'EOF'
+Objective:  A1
+Decision:   FD-04 @ a306
+Kind:       planned
+EOF
+
+expect fail "sha is not hex" <<'EOF'
+Objective:  A1
+Decision:   FD-04 @ zzzzzzz
+Kind:       planned
+EOF
+
+expect fail "prose instead of a citation" <<'EOF'
+Objective:  A1
+Decision:   see the decision record
+Kind:       planned
+EOF
+
+expect fail "entry id malformed" <<'EOF'
+Objective:  A1
+Decision:   FD4 @ a30696a
+Kind:       planned
+EOF
+
+# ---------------------------------------------------------------------------
+# Rejected — Kind
+# ---------------------------------------------------------------------------
+
+expect fail "kind missing" <<'EOF'
+Objective:  A1
+Decision:   FD-04 @ a30696a
+EOF
+
+expect fail "kind invented" <<'EOF'
+Objective:  A1
+Decision:   FD-04 @ a30696a
+Kind:       urgent
+EOF
+
+expect fail "kind left as the template's alternatives" <<'EOF'
+Objective:  A1
+Decision:   FD-04 @ a30696a
+Kind:       planned | corrective | unparked
+EOF
+
+# ---------------------------------------------------------------------------
+# Rejected — unparking without authority
+#
+# Work that a decision parks, started anyway. Self-authorisation must not pass.
+# ---------------------------------------------------------------------------
+
+expect fail "unparked with no reversal" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+EOF
+
+expect fail "unparked with an empty reversal" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   —
+EOF
+
+expect fail "unparked authorised by prose rather than an entry" <<'EOF'
+Objective:  A4 — example objective
+Decision:   FD-03 @ a30696a
+Kind:       unparked
+Reversal:   approved verbally
+EOF
+
+# ---------------------------------------------------------------------------
+# Rejected — objective
+# ---------------------------------------------------------------------------
+
+expect fail "planned work with no objective" <<'EOF'
+Objective:
+Decision:   FD-04 @ a30696a
+Kind:       planned
+EOF
+
+expect fail "objective is a bare dash" <<'EOF'
+Objective:  -
+Decision:   FD-04 @ a30696a
+Kind:       planned
+EOF
+
+expect fail "objective is TBD" <<'EOF'
+Objective:  TBD
+Decision:   FD-04 @ a30696a
+Kind:       planned
+EOF
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+# GitHub returns bodies CRLF-terminated. Left unhandled, the trailing \r rides
+# along inside the captured SHA, fails the hex test, and prints an error message
+# in which the SHA looks perfectly correct.
+printf 'Objective:  A1\r\nDecision:   FD-04 @ a30696a\r\nKind:       planned\r\n' \
+    | expect pass "CRLF line endings"
+
+expect pass "block below a long description" <<'EOF'
+## Summary
+
+Long prose. Several paragraphs. Mentions FD-99 @ deadbeef in passing, which must
+not be mistaken for the citation because it is not on a keyed line.
+
+## Authority / invariant
+
+- Example invariant note.
+
+Objective:  A3 — example objective
+Decision:   FD-11 @ a30696a
+Kind:       planned
+EOF
+
+# First keyed occurrence wins, so a later stray mention cannot override a real
+# block by appearing further down the body.
+expect fail "later stray key cannot rescue an earlier bad citation" <<'EOF'
+Objective:  A1
+Decision:   nonsense
+Kind:       planned
+
+Decision:   FD-04 @ a30696a
+EOF
+
+# ---------------------------------------------------------------------------
+
+printf '\n%d checks, %d failures\n' "${checks}" "${failures}"
+[ "${failures}" -eq 0 ]


### PR DESCRIPTION
Objective:  N3 — producer-loop scenario
Decision:   FD-12 @ 0536fb3
Kind:       planned
Reversal:   —

## Summary

- Adds `Decision citation`, a CI lane that validates the decision citation block on every pull request.
- Adds `scripts/ci/check-decision-citation.sh` — an offline structural validator — and `check-decision-citation.test.sh` with 28 assertions.
- Adds the citation block to `.github/pull_request_template.md`.

The lane has two halves, split where testability ends:

| Half | Where | Offline |
| --- | --- | --- |
| Structural — is the block well formed? | `scripts/ci/check-decision-citation.sh` | Yes, unit-tested |
| Referential — does the cited entry exist at the cited commit, and is it current? | the workflow, via the GitHub API | No, needs a token |

## Why

A citation field completed and reviewed by the same author is a log. Validating it automatically makes it a gate.

The script inverts `lane-runs.sh`'s contract deliberately. That script answers `true` for anything it does not recognise, because a typo in a lane id must cost compute and never coverage. Here an unparsable citation must **fail**: a check that passes when it cannot read the citation is a green tick over a gate that is not running, which is worse than no gate because it reports compliance.

Staleness warns rather than fails. A mismatch between an implementation SHA and the governing decision must be visible during review, not forbidden — work legitimately outlives the SHA it started against, and failing would force a body edit on every open PR whenever a decision is recorded.

The record directory is globbed for all `.md` files rather than one filename, so the lookup binds to the `## FD-NN` schema rather than to a path that will change.

## Testing Performed

- `bash scripts/ci/check-decision-citation.test.sh` — **28 checks, 0 failures.**
- Cases cover: canonical blocks, lowercase keys, list markers, ragged spacing, 7- and 40-character SHAs, CRLF bodies, and blocks below long prose. Rejection cases cover absent blocks, template examples inside HTML comments, untouched placeholders, id-without-SHA, short and non-hex SHAs, invented `Kind` values, unparked without a reversal, unparked authorised by prose, and empty objectives on planned work.
- By hand: the untouched `pull_request_template.md` fails with three errors; a filled one passes; `GITHUB_OUTPUT` carries the `decision-id`, `decision-sha` and `kind` the workflow's second half consumes.
- Workflow YAML parses; job `citation`; triggers `opened, edited, synchronize, reopened, ready_for_review`.

**Not verified.** The referential path has never executed — it needs `INTERNALS_RO_TOKEN` and a live pull request. This PR is that test. The tree and contents API calls, the URL encoding of paths containing spaces, and the staleness comparison are reasoned through but unproven. `shellcheck` was not available on the authoring machine, so neither script has been linted.

## Authority / invariant

One authority for "which decision governs this change": the citation block, validated in CI rather than asserted in review.

What prevents drift: the lane fails the build when the block is absent, malformed, or cites a commit in which the named entry does not exist. The author cannot satisfy it by intending to.

## Producer note

None

## Docs Updated?

- [x] Yes
- [ ] No
- [ ] Not needed

## Risk / Rollback Notes

- **Not a gate until required.** The status check is named `Decision citation` — the job's `name:`, not its id `citation`. Branch protection on `develop` must require that exact string.
- **The check name is stable API.** Renaming the job silently detaches the branch-protection rule: the lane keeps running, the requirement stops applying, and every PR goes green on a gate nobody enforces. Renaming requires updating branch protection in the same change.
- **Needs `INTERNALS_RO_TOKEN`** with read-only `contents` access and nothing else. Without it the referential half degrades to a loud warning; the structural half still binds.
- **Fork pull requests** cannot see the secret by design and get the structural half only.
- **`edited` is in the trigger list** deliberately: without it, a PR opened with a bad citation stays red after the body is fixed, because editing a description fires no other event.
- **Rollback** is deleting the workflow file; nothing else in the build depends on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds a `Decision citation` CI lane for pull requests.
- Adds a required citation block to the pull request template.
- Adds offline structural validation for citation fields, SHA format, decision kind, objectives, placement, and reversal authorization.
- Adds 28 structural tests, including CRLF and template-content cases.
- Adds optional GitHub API checks for decision existence, commit validity, path encoding, and stale SHAs.
- The lane requires `INTERNALS_RO_TOKEN` and branch-protection configuration before it becomes a required gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->