### PR TITLE
ci: preserve completed push coverage during PR supersession

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,25 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  # Superseding a pull-request run is correct: only the newest head matters, and
-  # `refs/pull/N/merge` scopes the group to that one PR.
+  # Pull requests share a group per PR; pushes get a group of their own.
+  #
+  # Superseding a pull-request run is correct — only the newest head matters — and
+  # `refs/pull/N/merge` scopes the group to that one PR, so a new commit cancels
+  # only that PR's older run.
   #
   # Superseding a push to develop is not. Every merge is a distinct integration
   # state, and because develop's protection sets `strict: false`, the PR that
   # produced it was never built against the develop it landed on. Cancelling here
   # meant the merged tree was verified by nothing until nightly — five of the
   # eight develop merges before this change never completed a CI run.
+  #
+  # `cancel-in-progress: false` alone does NOT fix that. A concurrency group holds
+  # at most one running and one *pending* run; a third arrival cancels the pending
+  # one. Three merges in quick succession would still leave the middle commit with
+  # no completed run — the same hole, one step further along. Keying pushes to
+  # `github.run_id`, which is unique per run, removes them from contention
+  # entirely so no push can ever cancel another.
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,15 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseding a pull-request run is correct: only the newest head matters, and
+  # `refs/pull/N/merge` scopes the group to that one PR.
+  #
+  # Superseding a push to develop is not. Every merge is a distinct integration
+  # state, and because develop's protection sets `strict: false`, the PR that
+  # produced it was never built against the develop it landed on. Cancelling here
+  # meant the merged tree was verified by nothing until nightly — five of the
+  # eight develop merges before this change never completed a CI run.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUILD_TYPE: Release


### PR DESCRIPTION
## Decision citation

Objective:  CI reliability
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Give push runs a concurrency group of their own so that every merged state on
`develop` gets a completed CI run, while pull-request supersession is preserved.

```yaml
group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Precisely:

- **Only PR-triggered runs use `cancel-in-progress`.** For a pull request the
  concurrency ref is `refs/pull/N/merge`, so the group is scoped to that one PR
  and a new commit supersedes only that PR's own earlier run. Unchanged.
- **Push runs always finish, preserving required-check evidence.** Pushes key on
  `github.run_id`, which is unique per run, so they never share a group and can
  never cancel one another. `workflow_dispatch` behaves the same way.
- **YAML parses cleanly and all 11 jobs remain present.** Asserted with
  `yaml.safe_load` after the edit, including the job count and that the
  expression folds to a single line.
- **Only `ci.yml` changed.** +20/−2 across two commits.
- **The dirty `vst3sdk` and `freetype_local` submodule pointers were untouched.**
  Dirty before the branch was cut, deliberately not staged, per `AGENTS.md` §15.

## Why

Five of the eight `develop` merges preceding this branch never completed a CI
run — each was cancelled by the next merge landing behind it:

| Merge | Result |
| --- | --- |
| #711 | cancelled at 15m |
| #713 | cancelled at 6m |
| #702 | cancelled at 3m |
| #712 | cancelled at 16m |
| #688 | cancelled at 8s |

This compounds with `strict: false` on `develop`'s protection, which allows a
pull request to merge without being rebuilt against the `develop` it lands on.
The pre-merge run proves something about a tree that no longer exists; the
post-merge run that would have proved something about the tree that does exist
was cancelled. Between those two facts the integrated state was verified by
nothing until the 23:00 UTC nightly, up to 24 hours later.

### Why `cancel-in-progress: false` was not sufficient

The first commit on this branch scoped `cancel-in-progress` to pull requests and
stopped there. That is incomplete, and review caught it.

A concurrency group holds at most one **running** and one **pending** run. A
third arrival cancels the pending run rather than queueing behind it:

| Arrival | State | Outcome |
| --- | --- | --- |
| merge A | running | completes |
| merge B | pending | **cancelled by C** |
| merge C | pending → running | completes |

Merge B still receives no completed CI. Protecting the in-progress run moves the
hole one position along instead of removing it. Unique push groups remove the
contention itself.

`queue: max` would serialise pushes instead of isolating them, but it cannot be
combined with `cancel-in-progress: true`, so one workflow-level block cannot
express queued pushes and superseded PR runs at once. Splitting the workflow or
relocating concurrency to job level is not warranted by a corrective change.

`strict: false` is deliberately left alone — changing merge-queue semantics is a
separate decision from making CI finish.

## Testing Performed

- `python3 -c "yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses; 11
  jobs present; `concurrency.group` and `cancel-in-progress` resolve to the
  intended expressions; job count asserted rather than eyeballed.
- `git diff --stat origin/develop` — one file, +20/−2.
- `git status --short` — only `.github/workflows/ci.yml` staged; both submodule
  pointers left unstaged.
- All seven required checks passed on the first commit and are re-running on
  6b78cf69.
- Behaviour itself is observable only after merge: the check is that the push run
  for this merge reaches a conclusion rather than `cancelled`. No test asserts
  concurrency semantics, and none is added — CI configuration is not reachable
  from ctest.

## Authority / invariant

Cancellation is now derived from event type, and contention is removed for the
event type that must not lose runs. "Supersede the stale run" and "discard the
only evidence for a merged tree" stop being the same setting.

What prevents drift: nothing mechanical yet. Reverting this is a one-line edit to
a file no test covers — and this PR is itself the demonstration, since the defect
review caught was a one-line reasoning error in the same block. The durable fix
is the meta-tier rule, that workflow files outrank the code they gate and need
their own review tier. Deliberately out of scope here and being written
separately. Recording the gap rather than implying it is closed.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**Risk: push runs are now unbounded.** Consecutive merges each consume a full
~20–30 minute matrix, with no cancellation and no queue ceiling. That cost is the
point — it is what buys a completed check per merged state — but it is real, and
it strengthens the separate case for path filters on `ci.yml` so cheap changes
stop paying full-matrix prices.

**No risk to PR feedback latency.** PR supersession is unchanged, so the common
path — push, supersede, rebuild — behaves exactly as before.

**Rollback:** revert both commits. Prior behaviour returns immediately, with no
migration and no state to unwind.
