### PR TITLE
test: assign contract labels to the 44 unclassified cases

### DIFF
--- a/AestraCore/CMakeLists.txt
+++ b/AestraCore/CMakeLists.txt
@@ -87,6 +87,21 @@ if(AESTRA_BUILD_TESTS)
     add_test(NAME ConfigAssertTests COMMAND ConfigAssertTests)
     add_test(NAME MemoryProfilingTest COMMAND MemoryProfilingTest)
     add_test(NAME MemoryAllocatorTest COMMAND MemoryAllocatorTest)
+
+    # Contract labels. Foundational utilities: a failure here means configuration,
+    # files, logging, threading or allocators may be broken. Exactly one
+    # contract:* label per case — descriptive labels are added separately and
+    # never satisfy coverage.
+    set_tests_properties(
+        MathTests
+        ThreadingTests
+        FileTests
+        LogTests
+        ConfigAssertTests
+        MemoryProfilingTest
+        MemoryAllocatorTest
+        PROPERTIES LABELS "contract:core"
+    )
 endif()
 
 message(STATUS "AestraCore configured")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -588,6 +588,7 @@ add_executable(AestraAudioPerformanceTest
 )
 target_link_libraries(AestraAudioPerformanceTest PRIVATE AestraAudio)
 add_test(NAME AestraAudioPerformanceTest COMMAND AestraAudioPerformanceTest)
+set_tests_properties(AestraAudioPerformanceTest PROPERTIES LABELS "contract:realtime")
 if(WIN32)
     target_link_libraries(AestraAudioPerformanceTest PRIVATE avrt)
 endif()
@@ -720,6 +721,7 @@ endif()
 add_executable(AestraAtomicSaveTest AestraAudio/AtomicSaveTest.cpp)
 target_link_libraries(AestraAtomicSaveTest PRIVATE)
 add_test(NAME AestraAtomicSaveTest COMMAND AestraAtomicSaveTest)
+set_tests_properties(AestraAtomicSaveTest PROPERTIES LABELS "contract:durability")
 
 # Deferred destruction / resource reclamation test
 add_executable(AestraGarbageCollectorTest AestraAudio/GarbageCollectorTest.cpp)
@@ -899,6 +901,7 @@ endif()
 add_executable(AestraWavLoaderTest AestraAudio/WavLoaderTest.cpp)
 target_link_libraries(AestraWavLoaderTest PRIVATE AestraAudio)
 add_test(NAME AestraWavLoaderTest COMMAND AestraWavLoaderTest)
+set_tests_properties(AestraWavLoaderTest PROPERTIES LABELS "contract:audio")
 
 # Arsenal content-type transition regression
 add_executable(ArsenalUnitTypeTransitionTest AestraAudio/ArsenalUnitTypeTransitionTest.cpp)
@@ -910,6 +913,7 @@ set_tests_properties(ArsenalUnitTypeTransitionTest PROPERTIES LABELS "audio;arse
 add_executable(AestraAuditionEngineLifecycleTest AestraAudio/AuditionEngineLifecycleTest.cpp)
 target_link_libraries(AestraAuditionEngineLifecycleTest PRIVATE AestraAudio)
 add_test(NAME AestraAuditionEngineLifecycleTest COMMAND AestraAuditionEngineLifecycleTest)
+set_tests_properties(AestraAuditionEngineLifecycleTest PROPERTIES LABELS "contract:application")
 
 add_executable(PreviewAuditionGainParityTest AestraAudio/PreviewAuditionGainParityTest.cpp)
 target_link_libraries(PreviewAuditionGainParityTest PRIVATE AestraAudio)
@@ -920,6 +924,7 @@ set_tests_properties(PreviewAuditionGainParityTest PROPERTIES LABELS "audio;prev
 add_executable(SamplePoolTest AestraAudio/SamplePoolTest.cpp)
 target_link_libraries(SamplePoolTest PRIVATE AestraAudio)
 add_test(NAME SamplePoolTest COMMAND SamplePoolTest)
+set_tests_properties(SamplePoolTest PROPERTIES LABELS "contract:core")
 
 # Device Manager Test (Windows only)
 if(WIN32 AND AESTRA_ENABLE_RUNTIME_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DeviceManagerTest.cpp")
@@ -957,12 +962,14 @@ add_executable(AestraOscillatorTest AestraAudio/OscillatorTest.cpp)
 target_link_libraries(AestraOscillatorTest PRIVATE AestraAudio)
 target_compile_definitions(AestraOscillatorTest PRIVATE AESTRA_HEADLESS)
 add_test(NAME AestraOscillatorTest COMMAND AestraOscillatorTest)
+set_tests_properties(AestraOscillatorTest PROPERTIES LABELS "contract:audio")
 
 # Automation Stress Test
 add_executable(AutomationStressTest AestraAudio/AutomationStressTest.cpp)
 target_link_libraries(AutomationStressTest PRIVATE AestraAudio)
 target_compile_definitions(AutomationStressTest PRIVATE AESTRA_HEADLESS)
 add_test(NAME AutomationStressTest COMMAND AutomationStressTest)
+set_tests_properties(AutomationStressTest PROPERTIES LABELS "contract:audio")
 
 # Arsenal Parameter Stress Test (requires runtime plugin system)
 if(TARGET AestraAudioCore AND TARGET AestraPremiumPlugins)
@@ -987,12 +994,14 @@ add_executable(MixerBusStressTest AestraAudio/MixerBusStressTest.cpp)
 target_link_libraries(MixerBusStressTest PRIVATE AestraAudio)
 target_compile_definitions(MixerBusStressTest PRIVATE AESTRA_HEADLESS)
 add_test(NAME MixerBusStressTest COMMAND MixerBusStressTest)
+set_tests_properties(MixerBusStressTest PROPERTIES LABELS "contract:audio")
 
 # Mixer Bus Test
 add_executable(AestraMixerBusTest AestraAudio/MixerBusTest.cpp)
 target_link_libraries(AestraMixerBusTest PRIVATE AestraAudio)
 target_compile_definitions(AestraMixerBusTest PRIVATE AESTRA_HEADLESS)
 add_test(NAME AestraMixerBusTest COMMAND AestraMixerBusTest)
+set_tests_properties(AestraMixerBusTest PROPERTIES LABELS "contract:audio")
 
 # AestraUUID Test (header-only, no audio hardware required)
 add_executable(AestraUUIDTest AestraAudio/AestraUUIDTest.cpp)

--- a/Tests/cmake/ReverbTests.cmake
+++ b/Tests/cmake/ReverbTests.cmake
@@ -192,6 +192,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbMaterialLab.cpp")
     # Register test only on Linux to avoid false failures from cross-platform FP drift.
     if(AESTRA_ENABLE_RUNTIME_TESTS AND UNIX AND NOT APPLE)
         add_test(NAME ReverbMaterialLabTest COMMAND AestraReverbMaterialLab)
+        set_tests_properties(ReverbMaterialLabTest PROPERTIES LABELS "contract:audio")
     elseif(NOT AESTRA_ENABLE_RUNTIME_TESTS)
         message(STATUS "ReverbMaterialLabTest built but not registered (set AESTRA_ENABLE_RUNTIME_TESTS=ON to enable)")
     endif()

--- a/tests/security/CMakeLists.txt
+++ b/tests/security/CMakeLists.txt
@@ -259,3 +259,20 @@ if(TARGET AestraLicense)
     )
     target_link_libraries(SecMembershipViewModel PRIVATE AestraLicense)
 endif()
+
+# --- Contract labels --------------------------------------------------------
+#
+# Every test in this directory protects the same promise: that untrusted input,
+# privilege, licence integrity, process isolation or an injection boundary is
+# safe. So the contract is assigned from the directory property rather than
+# repeated 27 times.
+#
+# Reading the registered set back is deliberate, not clever. Nine of these tests
+# live inside `if(TARGET AestraLicense)`, so a flat literal list would name tests
+# that do not exist whenever AestraLicense is absent — and set_tests_properties
+# on an unregistered test is a hard configure error. This form is correct under
+# both conditions, and a new security test inherits the contract by construction.
+get_property(_aestra_security_tests DIRECTORY PROPERTY TESTS)
+if(_aestra_security_tests)
+    set_tests_properties(${_aestra_security_tests} PROPERTIES LABELS "contract:security")
+endif()


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Assign exactly one `contract:*` label to each of the 44 registered CTest cases
that previously carried none. **Classification only** — no selector, workflow
YAML, test source, registration condition or legacy label is touched.

| Contract | Cases | What |
| --- | ---: | --- |
| `contract:security` | 27 | the entire `tests/security` suite |
| `contract:core` | 8 | `AestraCore` utilities, plus `SamplePoolTest` |
| `contract:audio` | 6 | mixer, oscillator, reverb lab, WAV decode, automation + mixer-bus stress |
| `contract:realtime` | 1 | `AestraAudioPerformanceTest` |
| `contract:durability` | 1 | `AestraAtomicSaveTest` |
| `contract:application` | 1 | `AestraAuditionEngineLifecycleTest` |

## Why

Three copies of a hand-written test-name list currently stand in for a contract:

```
ci.yml:82   ctest -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening"
ci.yml:410  (same)
ci.yml:486  (same)
```

That list exists because there was no label to select on. Assigning contracts is
the prerequisite for replacing it — but replacing it is deliberately **not** part
of this PR.

## Verification

Enumerated with `ctest --show-only=json-v1` across five configured trees
(`HEADLESS_ONLY` × `RUNTIME_TESTS` × `EXPERIMENTAL_TESTS`, `CORE_MODE=ON`):

| Configuration | Cases | Unlabelled |
| --- | ---: | ---: |
| `HL=ON  rt=OFF ex=OFF` | 215 | 0 |
| `HL=ON  rt=OFF ex=ON` | 221 | 0 |
| `HL=ON  rt=ON  ex=OFF` | 221 | 0 |
| `HL=ON  rt=ON  ex=ON` | 227 | 0 |
| `HL=OFF rt=ON  ex=ON` (maximal) | **243** | **0** |

1. **Maximal census unchanged** — 243 → 243.
2. **Unlabelled count is zero** — 44 → 0.
3. **No case carries more than one `contract:*`, and none is unknown.**
4. **Execution unchanged** — exactly 44 label deltas; no pre-existing label was
   removed or altered.
5. **All CTest names identical** — set comparison before/after is empty.

Additionally: **maximal still equals the union** of all five configurations, and
classification is stable across configurations (0 cases differ).

## How the six contested cases were decided

Verified against source, not assigned by name or subsystem:

| Test | Contract | Evidence |
| --- | --- | --- |
| `AestraAudioPerformanceTest` | `realtime` | Computes `budgetUs = (kBlockSize / 48000.0) * 1e6`, sets MMCSS/thread priority, and ramps "until we miss deadlines" — a direct realtime-budget assertion |
| `AutomationStressTest` | `audio` | Grep for deadline/budget/elapsed/chrono/xrun/allocat/mutex/lock/callback returns **nothing**. Stress alone does not make a test realtime |
| `MixerBusStressTest` | `audio` | Single match is a comment (`// In real code, this would register the bus during audio callback`), not an assertion |
| `SamplePoolTest` | `core` | Asserts `tryGetCached` identity, cache reuse and eviction — pool mechanics, not signal |
| `AestraAuditionEngineLifecycleTest` | `application` | `main()` asserts only that construct → queue → play → clear → destruct does not crash |
| `AestraWavLoaderTest` | `audio` | Four of six subtests assert decode and sample correctness. See caveat below |

> **Caveat on `AestraWavLoaderTest`.** It does contain one malformed-input case —
> `runInvalidMetadataTest` writes a 0-channel WAV and a `data` chunk claiming 3
> bytes, then requires `decodeAudioFile` to reject both. `contract:audio` holds by
> dominance, but its boundary with `SecFreadTruncatedWav` is thinner than a clean
> split would suggest. Flagging rather than hiding it.

## Why `tests/security` uses the directory property

```cmake
get_property(_aestra_security_tests DIRECTORY PROPERTY TESTS)
```

Nine of those 27 tests are registered inside `if(TARGET AestraLicense)`. A flat
literal list would name tests that do not exist whenever `AestraLicense` is
absent, and `set_tests_properties` on an unregistered test is a **hard configure
error** — it would break every checkout without that target. Reading the
registered set back is correct under both conditions, and a new security test
inherits the contract by construction.

## Authority / invariant

Every registered case now answers "which promise breaks if this fails" in a
closed vocabulary, rather than in 127 free-form descriptive labels.

What prevents drift: **nothing yet.** That is the coverage guard's job, and it is
a separate PR by design. This change is the precondition, not the enforcement.

## Known gap — stated, not hidden

**199 cases carry descriptive labels but still have no `contract:*`.** A guard
requiring exactly one contract per registered case cannot go green until those
are classified. This PR closes the *unlabelled* set, not the *uncontracted* set.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**Risk: none to execution.** CTest labels are metadata. No test is added,
removed, renamed, skipped or reordered, and no selector reads `contract:*` yet —
so no lane's membership changes.

**One behavioural surface worth naming:** the `tests/security` directory property
auto-assigns `contract:security` to any future test added there. That is correct
for a homogeneous directory, but it means a test that belongs to a different
contract would be silently mislabelled rather than caught. The
`aestra_add_test(... CONTRACT ...)` wrapper is the durable answer, and is queued
as its own T3 change.

**Rollback:** revert the commit. Labels vanish, execution is unaffected either
way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added one `contract:*` CTest label to each of the 44 previously unlabelled tests.
- Classified tests across Core, Audio, Realtime, Durability, Application, and Security areas.
- Applied directory-wide `contract:security` labeling, including conditionally registered license tests.
- Preserved test selectors, names, workflows, sources, registration conditions, and legacy labels.
- Verified five configurations with no unlabelled cases, duplicate or unknown labels, census changes, name changes, or execution changes.
- Documented evidence for six contested classifications. A remaining 199 tests still need `contract:*` labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->