### PR TITLE
test: classify group 2 — plugins and audio

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -343,7 +343,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectLoadRegressionTest.cpp
         $<$<CONFIG:Debug>:AESTRA_ENABLE_PROJECT_LOAD_LOGS>
     )
     add_test(NAME ProjectLoadRegressionTest COMMAND ProjectLoadRegressionTest)
-    set_tests_properties(ProjectLoadRegressionTest PROPERTIES LABELS "integration;regression;routing")
+    set_tests_properties(ProjectLoadRegressionTest PROPERTIES LABELS "integration;regression;routing;contract:durability")
 endif()
 
 # Project History Cap (issue #274 — .history directory disk-usage bound)
@@ -543,7 +543,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ResamplerWarTest.cpp")
         target_compile_definitions(ResamplerWarTest PRIVATE AESTRA_HAS_SOXR=1)
     endif()
     add_test(NAME ResamplerWarTest COMMAND ResamplerWarTest)
-    set_tests_properties(ResamplerWarTest PROPERTIES LABELS "audio;dsp;resampler;quality")
+    set_tests_properties(ResamplerWarTest PROPERTIES LABELS "audio;dsp;resampler;quality;contract:audio")
 endif()
 
 # =============================================================================
@@ -555,7 +555,7 @@ add_executable(AestraAudioTest AestraAudio/AudioTest.cpp)
 target_link_libraries(AestraAudioTest PRIVATE AestraAudio)
 if(AESTRA_ENABLE_RUNTIME_TESTS)
     add_test(NAME AestraAudioTest COMMAND AestraAudioTest)
-    set_tests_properties(AestraAudioTest PROPERTIES LABELS "audio;runtime;device")
+    set_tests_properties(AestraAudioTest PROPERTIES LABELS "audio;runtime;device;contract:audio")
 else()
     message(STATUS "AestraAudioTest built but not registered (set AESTRA_ENABLE_RUNTIME_TESTS=ON to enable)")
 endif()
@@ -628,7 +628,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerStereoParityTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME SamplerStereoParityTest COMMAND SamplerStereoParityTest)
-    set_tests_properties(SamplerStereoParityTest PROPERTIES LABELS "audio;sampler;regression")
+    set_tests_properties(SamplerStereoParityTest PROPERTIES LABELS "audio;sampler;regression;contract:audio")
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternPlaybackTempoChangeTest.cpp")
@@ -642,7 +642,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternPlaybackTempoChangeTes
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME PatternPlaybackTempoChangeTest COMMAND PatternPlaybackTempoChangeTest)
-    set_tests_properties(PatternPlaybackTempoChangeTest PROPERTIES LABELS "audio;transport;pattern;regression")
+    set_tests_properties(PatternPlaybackTempoChangeTest PROPERTIES LABELS "audio;transport;pattern;regression;contract:audio")
 endif()
 
 # Sinc Interpolator Benchmark
@@ -741,7 +741,7 @@ target_include_directories(AestraConnectionTest PRIVATE
     ${CMAKE_SOURCE_DIR}
 )
 add_test(NAME AestraConnectionTest COMMAND AestraConnectionTest)
-set_tests_properties(AestraConnectionTest PROPERTIES LABELS "audio;regression")
+set_tests_properties(AestraConnectionTest PROPERTIES LABELS "audio;regression;contract:audio")
 
 # EffectChain Snapshot Test (Pass 1: immutable snapshot type)
 add_executable(AestraEffectChainSnapshotTest AestraAudio/EffectChainSnapshotTest.cpp)
@@ -751,7 +751,7 @@ target_include_directories(AestraEffectChainSnapshotTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraEffectChainSnapshotTest COMMAND AestraEffectChainSnapshotTest)
-set_tests_properties(AestraEffectChainSnapshotTest PROPERTIES LABELS "audio;plugin")
+set_tests_properties(AestraEffectChainSnapshotTest PROPERTIES LABELS "audio;plugin;contract:plugins")
 
 add_executable(AestraEffectChainStateVersionTest AestraAudio/EffectChainStateVersionTest.cpp)
 target_link_libraries(AestraEffectChainStateVersionTest PRIVATE AestraAudio)
@@ -770,7 +770,7 @@ target_include_directories(AestraAudioEngineEffectChainPrepareTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraAudioEngineEffectChainPrepareTest COMMAND AestraAudioEngineEffectChainPrepareTest)
-set_tests_properties(AestraAudioEngineEffectChainPrepareTest PROPERTIES LABELS "audio;plugin;regression")
+set_tests_properties(AestraAudioEngineEffectChainPrepareTest PROPERTIES LABELS "audio;plugin;regression;contract:plugins")
 
 # Plugin insert/remove graph invalidation regression tests
 add_executable(AestraPluginGraphInvalidationTest AestraAudio/PluginGraphInvalidationTest.cpp)
@@ -782,7 +782,7 @@ target_include_directories(AestraPluginGraphInvalidationTest PRIVATE
 add_test(NAME PluginInsertTakesEffectWithoutClipMoveTest COMMAND AestraPluginGraphInvalidationTest)
 add_test(NAME PluginRemoveTakesEffectWithoutClipMoveTest COMMAND AestraPluginGraphInvalidationTest)
 set_tests_properties(PluginInsertTakesEffectWithoutClipMoveTest PluginRemoveTakesEffectWithoutClipMoveTest
-    PROPERTIES LABELS "audio;plugin;regression")
+    PROPERTIES LABELS "audio;plugin;regression;contract:audio")
 
 # MixerChannel scratch buffer regression tests
 add_executable(AestraMixerChannelScratchBufferTest AestraAudio/MixerChannelScratchBufferTest.cpp)
@@ -792,7 +792,7 @@ target_include_directories(AestraMixerChannelScratchBufferTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraMixerChannelScratchBufferTest COMMAND AestraMixerChannelScratchBufferTest)
-set_tests_properties(AestraMixerChannelScratchBufferTest PROPERTIES LABELS "audio;plugin;regression")
+set_tests_properties(AestraMixerChannelScratchBufferTest PROPERTIES LABELS "audio;plugin;regression;contract:audio")
 
 # AudioEngineDiagnostics Test
 add_executable(AestraAudioEngineDiagnosticsTest AestraAudio/AudioEngineDiagnosticsTest.cpp)
@@ -838,18 +838,18 @@ target_include_directories(AestraAudioQualityRegressionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraAudioQualityRegressionTest COMMAND AestraAudioQualityRegressionTest)
-set_tests_properties(AestraAudioQualityRegressionTest PROPERTIES LABELS "audio;quality;regression")
+set_tests_properties(AestraAudioQualityRegressionTest PROPERTIES LABELS "audio;quality;regression;contract:audio")
 
 # Playback path signal-integrity diagnostics
 add_executable(AestraPlaybackPathSignalIntegrityTest AestraAudio/PlaybackPathSignalIntegrityTest.cpp)
 target_link_libraries(AestraPlaybackPathSignalIntegrityTest PRIVATE AestraAudio)
 add_test(NAME AestraPlaybackPathSignalIntegrityTest COMMAND AestraPlaybackPathSignalIntegrityTest)
-set_tests_properties(AestraPlaybackPathSignalIntegrityTest PROPERTIES LABELS "audio;quality;regression;playback")
+set_tests_properties(AestraPlaybackPathSignalIntegrityTest PROPERTIES LABELS "audio;quality;regression;playback;contract:audio")
 
 add_executable(TrackManagerMasterDuckingAuditTest AestraAudio/TrackManagerMasterDuckingAuditTest.cpp)
 target_link_libraries(TrackManagerMasterDuckingAuditTest PRIVATE AestraAudio)
 add_test(NAME TrackManagerMasterDuckingAuditTest COMMAND TrackManagerMasterDuckingAuditTest)
-set_tests_properties(TrackManagerMasterDuckingAuditTest PROPERTIES LABELS "audio;quality;regression;playback;metering")
+set_tests_properties(TrackManagerMasterDuckingAuditTest PROPERTIES LABELS "audio;quality;regression;playback;metering;contract:audio")
 
 # AudioEngine output channel safety regression test
 add_executable(AestraAudioEngineOutputChannelTest AestraAudio/AudioEngineOutputChannelTest.cpp)
@@ -859,7 +859,7 @@ target_include_directories(AestraAudioEngineOutputChannelTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraAudioEngineOutputChannelTest COMMAND AestraAudioEngineOutputChannelTest)
-set_tests_properties(AestraAudioEngineOutputChannelTest PROPERTIES LABELS "audio;rt-safety;regression")
+set_tests_properties(AestraAudioEngineOutputChannelTest PROPERTIES LABELS "audio;rt-safety;regression;contract:audio")
 
 # Watchdog Test (requires VST3 SDK headers)
 if(EXISTS "${CMAKE_SOURCE_DIR}/AestraAudio/External/vst3sdk/pluginterfaces/vst/ivstaudioprocessor.h")
@@ -907,7 +907,7 @@ set_tests_properties(AestraWavLoaderTest PROPERTIES LABELS "contract:audio")
 add_executable(ArsenalUnitTypeTransitionTest AestraAudio/ArsenalUnitTypeTransitionTest.cpp)
 target_link_libraries(ArsenalUnitTypeTransitionTest PRIVATE AestraAudio)
 add_test(NAME ArsenalUnitTypeTransitionTest COMMAND ArsenalUnitTypeTransitionTest)
-set_tests_properties(ArsenalUnitTypeTransitionTest PROPERTIES LABELS "audio;arsenal;unit-type")
+set_tests_properties(ArsenalUnitTypeTransitionTest PROPERTIES LABELS "audio;arsenal;unit-type;contract:audio")
 
 # Audition Engine lifecycle regression
 add_executable(AestraAuditionEngineLifecycleTest AestraAudio/AuditionEngineLifecycleTest.cpp)
@@ -918,7 +918,7 @@ set_tests_properties(AestraAuditionEngineLifecycleTest PROPERTIES LABELS "contra
 add_executable(PreviewAuditionGainParityTest AestraAudio/PreviewAuditionGainParityTest.cpp)
 target_link_libraries(PreviewAuditionGainParityTest PRIVATE AestraAudio)
 add_test(NAME PreviewAuditionGainParityTest COMMAND PreviewAuditionGainParityTest)
-set_tests_properties(PreviewAuditionGainParityTest PROPERTIES LABELS "audio;preview;audition;gain;regression")
+set_tests_properties(PreviewAuditionGainParityTest PROPERTIES LABELS "audio;preview;audition;gain;regression;contract:audio")
 
 # SamplePool Test
 add_executable(SamplePoolTest AestraAudio/SamplePoolTest.cpp)
@@ -1021,7 +1021,7 @@ target_include_directories(ArsenalRouteModeCompatibilityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ArsenalRouteModeCompatibilityTest COMMAND ArsenalRouteModeCompatibilityTest)
-set_tests_properties(ArsenalRouteModeCompatibilityTest PROPERTIES LABELS "audio;arsenal")
+set_tests_properties(ArsenalRouteModeCompatibilityTest PROPERTIES LABELS "audio;arsenal;contract:audio")
 
 # Arsenal processing context routing test
 add_executable(ArsenalProcessingContextRoutingTest AestraAudio/ArsenalProcessingContextRoutingTest.cpp)
@@ -1031,7 +1031,7 @@ target_include_directories(ArsenalProcessingContextRoutingTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ArsenalProcessingContextRoutingTest COMMAND ArsenalProcessingContextRoutingTest)
-set_tests_properties(ArsenalProcessingContextRoutingTest PROPERTIES LABELS "audio;arsenal")
+set_tests_properties(ArsenalProcessingContextRoutingTest PROPERTIES LABELS "audio;arsenal;contract:audio")
 
 # Stable unit-to-mixer routing and arrangement independence regression test
 add_executable(UnitMixerRoutingTest AestraAudio/UnitMixerRoutingTest.cpp)
@@ -1041,7 +1041,7 @@ target_include_directories(UnitMixerRoutingTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME UnitMixerRoutingTest COMMAND UnitMixerRoutingTest)
-set_tests_properties(UnitMixerRoutingTest PROPERTIES LABELS "audio;arsenal;routing")
+set_tests_properties(UnitMixerRoutingTest PROPERTIES LABELS "audio;arsenal;routing;contract:audio")
 
 # Arsenal route-mode project round-trip compatibility test
 add_executable(ArsenalRouteModeRoundTripTest
@@ -1108,7 +1108,7 @@ target_include_directories(ArsenalExportCurrentPolicyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ArsenalExportCurrentPolicyTest COMMAND ArsenalExportCurrentPolicyTest)
-set_tests_properties(ArsenalExportCurrentPolicyTest PROPERTIES LABELS "arsenal;policy;offline")
+set_tests_properties(ArsenalExportCurrentPolicyTest PROPERTIES LABELS "arsenal;policy;offline;contract:audio")
 
 # Arsenal live/export parity hardening test (Phase 3)
 add_executable(ArsenalExportLiveParityTest AestraAudio/ArsenalExportLiveParityTest.cpp)
@@ -1128,7 +1128,7 @@ target_include_directories(ArsenalExportLiveParityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source
 )
 add_test(NAME ArsenalExportLiveParityTest COMMAND ArsenalExportLiveParityTest)
-set_tests_properties(ArsenalExportLiveParityTest PROPERTIES LABELS "arsenal;offline;policy;regression")
+set_tests_properties(ArsenalExportLiveParityTest PROPERTIES LABELS "arsenal;offline;policy;regression;contract:audio")
 
 # Arsenal bridge metadata round-trip persistence guard (Phase 2D)
 add_executable(ArsenalBridgeModeRoundTripTest AestraAudio/ArsenalBridgeModeRoundTripTest.cpp)
@@ -1190,7 +1190,7 @@ target_include_directories(SummingEngineTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME SummingEngineTest COMMAND SummingEngineTest)
-set_tests_properties(SummingEngineTest PROPERTIES LABELS "audio;quality;summing;s-tier")
+set_tests_properties(SummingEngineTest PROPERTIES LABELS "audio;quality;summing;s-tier;contract:audio")
 
 # Golden Reference Test — Signal-level regression against in-memory
 # mathematical reference for 1kHz, 440Hz, 10kHz, and impulse signals.
@@ -1203,7 +1203,7 @@ target_include_directories(GoldenReferenceTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME GoldenReferenceTest COMMAND GoldenReferenceTest)
-set_tests_properties(GoldenReferenceTest PROPERTIES LABELS "audio;quality;golden;s-tier")
+set_tests_properties(GoldenReferenceTest PROPERTIES LABELS "audio;quality;golden;s-tier;contract:audio")
 
 # Golden Audio Regression — analytic golden cases for the render path:
 # silence/empty project, impulse via master, multi-track gain+pan mix.
@@ -1218,7 +1218,7 @@ target_include_directories(GoldenAudioRegressionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME GoldenAudioRegressionTest COMMAND GoldenAudioRegressionTest)
-set_tests_properties(GoldenAudioRegressionTest PROPERTIES LABELS "audio;quality;golden;integrity;s-tier" TIMEOUT 180)
+set_tests_properties(GoldenAudioRegressionTest PROPERTIES LABELS "audio;quality;golden;integrity;s-tier;contract:audio" TIMEOUT 180)
 
 # Metronome restart regression — transport restart edges must clear retained
 # click tails and rebase beat scheduling from the applied RT transport position.
@@ -1231,7 +1231,7 @@ target_include_directories(MetronomeRestartTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MetronomeRestartTest COMMAND MetronomeRestartTest)
-set_tests_properties(MetronomeRestartTest PROPERTIES LABELS "audio;metronome;transport;regression" TIMEOUT 120)
+set_tests_properties(MetronomeRestartTest PROPERTIES LABELS "audio;metronome;transport;regression;contract:audio" TIMEOUT 120)
 
 # Realtime/Export Parity — realtime processBlock output vs offline
 # bounceRangeToWav output for the same session, plus the preview-ducking
@@ -1245,7 +1245,7 @@ target_include_directories(RealtimeExportParityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME RealtimeExportParityTest COMMAND RealtimeExportParityTest)
-set_tests_properties(RealtimeExportParityTest PROPERTIES LABELS "audio;quality;export;parity;integrity;s-tier" TIMEOUT 180)
+set_tests_properties(RealtimeExportParityTest PROPERTIES LABELS "audio;quality;export;parity;integrity;s-tier;contract:audio" TIMEOUT 180)
 
 # RT Allocation Trap — overrides operator new/delete in the test binary and
 # renders a session; asserts ZERO steady-state heap activity on the audio
@@ -1334,7 +1334,7 @@ target_include_directories(SampleRateBufferTruthTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME SampleRateBufferTruthTest COMMAND SampleRateBufferTruthTest)
-set_tests_properties(SampleRateBufferTruthTest PROPERTIES LABELS "audio;quality;samplerate;buffers;integrity;s-tier" TIMEOUT 180)
+set_tests_properties(SampleRateBufferTruthTest PROPERTIES LABELS "audio;quality;samplerate;buffers;integrity;s-tier;contract:audio" TIMEOUT 180)
 
 # Audio Quality Audit — noise floor, THD+N, freq response, DC blocker, soft clipper
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
@@ -1347,7 +1347,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioQualityAuditTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME AudioQualityAuditTest COMMAND AudioQualityAuditTest)
-    set_tests_properties(AudioQualityAuditTest PROPERTIES LABELS "audio;quality;audit;s-tier" TIMEOUT 180)
+    set_tests_properties(AudioQualityAuditTest PROPERTIES LABELS "audio;quality;audit;s-tier;contract:audio" TIMEOUT 180)
 endif()
 
 # Audio Purity Audit — transparent path, summing, buffer invariance, hidden clipping, SRC invariants
@@ -1363,7 +1363,7 @@ target_include_directories(AudioPurityAuditTest PRIVATE
 add_test(NAME AudioPurityAuditTest COMMAND AudioPurityAuditTest
     --report ${CMAKE_BINARY_DIR}/audio-purity-report.json
     --text-report ${CMAKE_BINARY_DIR}/audio-purity-report.txt)
-set_tests_properties(AudioPurityAuditTest PROPERTIES LABELS "audio;quality;audit;purity;s-tier" TIMEOUT 240)
+set_tests_properties(AudioPurityAuditTest PROPERTIES LABELS "audio;quality;audit;purity;s-tier;contract:audio" TIMEOUT 240)
 
 # AudioEngine Torture Test — stress harness: silence, NaN/Inf, extreme gain,
 # buffer switching, sample rate switching, transport hammering, multi-track load
@@ -1384,7 +1384,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineTortureTest.cpp")
     target_compile_definitions(AudioEngineTortureTest PRIVATE
         $<$<CONFIG:Debug>:AESTRA_ENGINE_ASSERTS_ACTIVE=1>)
     add_test(NAME AudioEngineTortureTest COMMAND AudioEngineTortureTest)
-    set_tests_properties(AudioEngineTortureTest PROPERTIES LABELS "audio;stress;torture;s-tier" TIMEOUT 300)
+    set_tests_properties(AudioEngineTortureTest PROPERTIES LABELS "audio;stress;torture;s-tier;contract:audio" TIMEOUT 300)
 endif()
 
 # Export/Bounce Parity Test — Master bounce must equal sum of isolated
@@ -1399,7 +1399,7 @@ target_include_directories(ExportBounceParityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ExportBounceParityTest COMMAND ExportBounceParityTest)
-set_tests_properties(ExportBounceParityTest PROPERTIES LABELS "audio;quality;export;s-tier")
+set_tests_properties(ExportBounceParityTest PROPERTIES LABELS "audio;quality;export;s-tier;contract:audio")
 
 # =============================================================================
 # Audio Research Bench (Tests/Research)
@@ -1414,7 +1414,7 @@ set_tests_properties(ExportBounceParityTest PROPERTIES LABELS "audio;quality;exp
 # diff forensics) against analytic math before it is used to measure DSP.
 add_executable(MeasurementCoreSelfTest Research/MeasurementCoreSelfTest.cpp)
 add_test(NAME MeasurementCoreSelfTest COMMAND MeasurementCoreSelfTest)
-set_tests_properties(MeasurementCoreSelfTest PROPERTIES LABELS "audio;research;audio-research" TIMEOUT 120)
+set_tests_properties(MeasurementCoreSelfTest PROPERTIES LABELS "audio;research;audio-research;contract:audio" TIMEOUT 120)
 
 # Resampler Quality Audit — measures BOTH resampling engines: the production
 # clip-playback path (Interpolators + phase accumulator, as run by
@@ -1442,7 +1442,7 @@ if(SOXR_FOUND)
     target_compile_definitions(ResamplerQualityAuditTest PRIVATE AESTRA_HAS_SOXR=1)
 endif()
 add_test(NAME ResamplerQualityAuditTest COMMAND ResamplerQualityAuditTest)
-set_tests_properties(ResamplerQualityAuditTest PROPERTIES LABELS "audio;research;audio-research;resampler" TIMEOUT 180)
+set_tests_properties(ResamplerQualityAuditTest PROPERTIES LABELS "audio;research;audio-research;resampler;contract:audio" TIMEOUT 180)
 
 # Anti-Alias Policy Lab (Phase 3) — test-side prototype comparison for finding F1
 # (downsampling anti-aliasing): baseline legacy kernel vs an integrated ratio-aware
@@ -1468,7 +1468,7 @@ if(SOXR_FOUND)
     target_compile_definitions(AntiAliasPolicyLab PRIVATE AESTRA_HAS_SOXR=1)
 endif()
 add_test(NAME AntiAliasPolicyLab COMMAND AntiAliasPolicyLab)
-set_tests_properties(AntiAliasPolicyLab PROPERTIES LABELS "audio;research;audio-research;resampler" TIMEOUT 300)
+set_tests_properties(AntiAliasPolicyLab PROPERTIES LABELS "audio;research;audio-research;resampler;contract:audio" TIMEOUT 300)
 
 # Session Resampling Truth (Phase 2D) — proves the isolated resampler findings
 # through the actual shipped paths: realtime playback (TrackManager ->
@@ -1487,7 +1487,7 @@ target_include_directories(SessionResamplingTruthTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME SessionResamplingTruthTest COMMAND SessionResamplingTruthTest)
-set_tests_properties(SessionResamplingTruthTest PROPERTIES LABELS "audio;research;audio-research;resampler" TIMEOUT 300)
+set_tests_properties(SessionResamplingTruthTest PROPERTIES LABELS "audio;research;audio-research;resampler;contract:audio" TIMEOUT 300)
 
 # =============================================================================
 # AestraPlat Tests
@@ -1910,7 +1910,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Audio/DelayLineTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME DelayLineTest COMMAND DelayLineTest)
-    set_tests_properties(DelayLineTest PROPERTIES LABELS "audio;dsp;delay")
+    set_tests_properties(DelayLineTest PROPERTIES LABELS "audio;dsp;delay;contract:audio")
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DCBlockerTest.cpp")
@@ -1920,7 +1920,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/DCBlockerTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME DCBlockerTest COMMAND DCBlockerTest)
-    set_tests_properties(DCBlockerTest PROPERTIES LABELS "audio;dsp;dc-removal")
+    set_tests_properties(DCBlockerTest PROPERTIES LABELS "audio;dsp;dc-removal;contract:audio")
 endif()
 
 # Shared CLAP note-conversion rules (#244) — SDK-free, header-only
@@ -1931,7 +1931,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ClapNoteConversionTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ClapNoteConversionTest COMMAND ClapNoteConversionTest)
-    set_tests_properties(ClapNoteConversionTest PROPERTIES LABELS "audio;plugin;clap")
+    set_tests_properties(ClapNoteConversionTest PROPERTIES LABELS "audio;plugin;clap;contract:plugins")
 endif()
 
 # Transport pause preserves the authoritative playhead (#590)
@@ -1943,7 +1943,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TransportPausePreservesPositi
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME TransportPausePreservesPositionTest COMMAND TransportPausePreservesPositionTest)
-    set_tests_properties(TransportPausePreservesPositionTest PROPERTIES LABELS "audio;engine;transport;rt-safety")
+    set_tests_properties(TransportPausePreservesPositionTest PROPERTIES LABELS "audio;engine;transport;rt-safety;contract:audio")
 endif()
 
 # AudioEngine Diagnostics Test
@@ -1955,7 +1955,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineDiagnosticsTest.cp
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME AudioEngineDiagnosticsTest COMMAND AudioEngineDiagnosticsTest)
-    set_tests_properties(AudioEngineDiagnosticsTest PROPERTIES LABELS "audio;engine;diagnostics")
+    set_tests_properties(AudioEngineDiagnosticsTest PROPERTIES LABELS "audio;engine;diagnostics;contract:realtime")
 endif()
 
 # True Peak Meter Test
@@ -1967,7 +1967,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TruePeakMeterTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME TruePeakMeterTest COMMAND TruePeakMeterTest)
-    set_tests_properties(TruePeakMeterTest PROPERTIES LABELS "audio;dsp;metering")
+    set_tests_properties(TruePeakMeterTest PROPERTIES LABELS "audio;dsp;metering;contract:audio")
 endif()
 
 # Piano Roll Edge Case Stress Test
@@ -1991,7 +1991,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PluginHostStressTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME PluginHostStressTest COMMAND PluginHostStressTest)
-    set_tests_properties(PluginHostStressTest PROPERTIES LABELS "audio;plugin;stress")
+    set_tests_properties(PluginHostStressTest PROPERTIES LABELS "audio;plugin;stress;contract:plugins")
 endif()
 
 # Transport Stress Test
@@ -2027,7 +2027,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/MixerChannelStressTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME MixerChannelStressTest COMMAND MixerChannelStressTest)
-    set_tests_properties(MixerChannelStressTest PROPERTIES LABELS "audio;mixer;stress")
+    set_tests_properties(MixerChannelStressTest PROPERTIES LABELS "audio;mixer;stress;contract:audio")
 endif()
 
 # Track Manager Stress Test

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -20,7 +20,7 @@ add_test(NAME HeadlessOfflineRenderer
             "${CMAKE_CURRENT_BINARY_DIR}/dummy_out.wav"
 )
 set_tests_properties(HeadlessOfflineRenderer PROPERTIES
-    LABELS "headless;offline;rendering"
+    LABELS "headless;offline;rendering;contract:audio"
     ENVIRONMENT "AESTRA_HEADLESS=1"
 )
 
@@ -39,7 +39,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/OfflineRenderRegressionTest.cpp")
         COMMAND OfflineRenderRegressionTest
     )
     set_tests_properties(OfflineRenderRegressionTest PROPERTIES
-        LABELS "headless;regression;offline"
+        LABELS "headless;regression;offline;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -59,7 +59,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/EngineOutputStageCharacterizationTest.cpp
         COMMAND EngineOutputStageCharacterizationTest
     )
     set_tests_properties(EngineOutputStageCharacterizationTest PROPERTIES
-        LABELS "headless;characterization;engine"
+        LABELS "headless;characterization;engine;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -79,7 +79,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HeadlessExportSessionInvarianceTest.cpp")
         COMMAND HeadlessExportSessionInvarianceTest
     )
     set_tests_properties(HeadlessExportSessionInvarianceTest PROPERTIES
-        LABELS "headless;export;engine"
+        LABELS "headless;export;engine;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -198,7 +198,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/LiveMidiInputT
     )
     add_test(NAME LiveMidiInputTest COMMAND LiveMidiInputTest)
     set_tests_properties(LiveMidiInputTest PROPERTIES
-        LABELS "headless;arsenal;audio;midi"
+        LABELS "headless;arsenal;audio;midi;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -220,7 +220,7 @@ if(TARGET AestraAudioCore)
     )
     add_test(NAME HardwareMidiInputTest COMMAND HardwareMidiInputTest)
     set_tests_properties(HardwareMidiInputTest PROPERTIES
-        LABELS "headless;arsenal;audio;midi"
+        LABELS "headless;arsenal;audio;midi;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -240,7 +240,7 @@ if(TARGET AestraAudioCore)
     )
     add_test(NAME SamplerOneShotEnvelopeTest COMMAND SamplerOneShotEnvelopeTest)
     set_tests_properties(SamplerOneShotEnvelopeTest PROPERTIES
-        LABELS "headless;sampler;audio;dsp;regression"
+        LABELS "headless;sampler;audio;dsp;regression;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -260,7 +260,7 @@ if(TARGET AestraAudioCore)
     )
     add_test(NAME AutomationPlaybackTest COMMAND AutomationPlaybackTest)
     set_tests_properties(AutomationPlaybackTest PROPERTIES
-        LABELS "headless;automation;audio;engine;regression"
+        LABELS "headless;automation;audio;engine;regression;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -276,7 +276,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCFlatChainTest.cpp")
     )
     add_test(NAME PDCFlatChainTest COMMAND PDCFlatChainTest)
     set_tests_properties(PDCFlatChainTest PROPERTIES
-        LABELS "headless;pdc;regression"
+        LABELS "headless;pdc;regression;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -293,7 +293,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PluginLifecycleSmokeTest.cpp")
     )
     add_test(NAME PluginLifecycleSmokeTest COMMAND PluginLifecycleSmokeTest)
     set_tests_properties(PluginLifecycleSmokeTest PROPERTIES
-        LABELS "headless;plugins;lifecycle"
+        LABELS "headless;plugins;lifecycle;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -308,7 +308,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCSolverPurityTest.cpp")
     )
     add_test(NAME PDCSolverPurityTest COMMAND PDCSolverPurityTest)
     set_tests_properties(PDCSolverPurityTest PROPERTIES
-        LABELS "headless;pdc;solver"
+        LABELS "headless;pdc;solver;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -324,7 +324,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCBusChainTest.cpp")
     )
     add_test(NAME PDCBusChainTest COMMAND PDCBusChainTest)
     set_tests_properties(PDCBusChainTest PROPERTIES
-        LABELS "headless;pdc;solver"
+        LABELS "headless;pdc;solver;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -339,7 +339,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCBranchingConvergenceTest.cpp")
     )
     add_test(NAME PDCBranchingConvergenceTest COMMAND PDCBranchingConvergenceTest)
     set_tests_properties(PDCBranchingConvergenceTest PROPERTIES
-        LABELS "headless;pdc;solver;regression"
+        LABELS "headless;pdc;solver;regression;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -371,7 +371,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCEngineEdgeConstructionTest.cpp")
     )
     add_test(NAME PDCEngineEdgeConstructionTest COMMAND PDCEngineEdgeConstructionTest)
     set_tests_properties(PDCEngineEdgeConstructionTest PROPERTIES
-        LABELS "headless;pdc;engine"
+        LABELS "headless;pdc;engine;contract:plugins"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -387,7 +387,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/RoutingSendPanParityTest.cpp")
     )
     add_test(NAME RoutingSendPanParityTest COMMAND RoutingSendPanParityTest)
     set_tests_properties(RoutingSendPanParityTest PROPERTIES
-        LABELS "headless;routing;dsp;regression"
+        LABELS "headless;routing;dsp;regression;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()
@@ -403,7 +403,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCDisableClearsCompensationTest.cpp")
     )
     add_test(NAME PDCDisableClearsCompensationTest COMMAND PDCDisableClearsCompensationTest)
     set_tests_properties(PDCDisableClearsCompensationTest PROPERTIES
-        LABELS "headless;pdc;engine;regression"
+        LABELS "headless;pdc;engine;regression;contract:audio"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -286,7 +286,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/ClipR
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ClipRenderServiceTest COMMAND ClipRenderServiceTest)
-    set_tests_properties(ClipRenderServiceTest PROPERTIES LABELS "commands;audio;clip-render")
+    set_tests_properties(ClipRenderServiceTest PROPERTIES LABELS "commands;audio;clip-render;contract:audio")
 endif()
 
 if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/RenderAudioClipCommandTest.cpp")
@@ -297,7 +297,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/Rende
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME RenderAudioClipCommandTest COMMAND RenderAudioClipCommandTest)
-    set_tests_properties(RenderAudioClipCommandTest PROPERTIES LABELS "commands;audio;clip-render;undo")
+    set_tests_properties(RenderAudioClipCommandTest PROPERTIES LABELS "commands;audio;clip-render;undo;contract:audio")
 endif()
 
 if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/MuseClipRoundTripTest.cpp")
@@ -319,7 +319,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/Cl
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ClipRenderCharacterizationTest COMMAND ClipRenderCharacterizationTest)
-    set_tests_properties(ClipRenderCharacterizationTest PROPERTIES LABELS "audio;clip-render;characterization")
+    set_tests_properties(ClipRenderCharacterizationTest PROPERTIES LABELS "audio;clip-render;characterization;contract:audio")
 endif()
 
 if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ClipSrcTelemetryTest.cpp")
@@ -330,7 +330,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/Cl
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ClipSrcTelemetryTest COMMAND ClipSrcTelemetryTest)
-    set_tests_properties(ClipSrcTelemetryTest PROPERTIES LABELS "audio;clip-render;telemetry")
+    set_tests_properties(ClipSrcTelemetryTest PROPERTIES LABELS "audio;clip-render;telemetry;contract:audio")
 endif()
 
 message(STATUS "Commands tests added - Phase 2 undo/redo system")

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -24,7 +24,7 @@ target_include_directories(AestraEQTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraEQTest COMMAND AestraEQTest)
-set_tests_properties(AestraEQTest PROPERTIES LABELS "audio;plugins;eq")
+set_tests_properties(AestraEQTest PROPERTIES LABELS "audio;plugins;eq;contract:audio")
 
 # Aestra EQ Measurement Test
 add_executable(AestraEQMeasurementTest AestraAudio/AestraEQMeasurementTest.cpp)
@@ -35,7 +35,7 @@ target_include_directories(AestraEQMeasurementTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraEQMeasurementTest COMMAND AestraEQMeasurementTest)
-set_tests_properties(AestraEQMeasurementTest PROPERTIES LABELS "audio;plugins;eq;measurement")
+set_tests_properties(AestraEQMeasurementTest PROPERTIES LABELS "audio;plugins;eq;measurement;contract:audio")
 
 # Aestra EQ Material Lab
 add_executable(AestraEQMaterialLab AestraAudio/AestraEQMaterialLab.cpp)
@@ -58,7 +58,7 @@ target_include_directories(AestraCompPhase0Test PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraCompPhase0Test COMMAND AestraCompPhase0Test)
-set_tests_properties(AestraCompPhase0Test PROPERTIES LABELS "audio;plugins;comp;phase0")
+set_tests_properties(AestraCompPhase0Test PROPERTIES LABELS "audio;plugins;comp;phase0;contract:audio")
 
 # Aestra Comp Phase 1 Test
 add_executable(AestraCompPhase1Test AestraAudio/AestraCompPhase1Test.cpp)
@@ -69,7 +69,7 @@ target_include_directories(AestraCompPhase1Test PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraCompPhase1Test COMMAND AestraCompPhase1Test)
-set_tests_properties(AestraCompPhase1Test PROPERTIES LABELS "audio;plugins;comp;phase1")
+set_tests_properties(AestraCompPhase1Test PROPERTIES LABELS "audio;plugins;comp;phase1;contract:plugins")
 
 # Aestra Comp Oversampling Test (#228)
 add_executable(AestraCompOversamplingTest AestraAudio/AestraCompOversamplingTest.cpp)
@@ -80,7 +80,7 @@ target_include_directories(AestraCompOversamplingTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraCompOversamplingTest COMMAND AestraCompOversamplingTest)
-set_tests_properties(AestraCompOversamplingTest PROPERTIES LABELS "audio;plugins;comp;oversampling")
+set_tests_properties(AestraCompOversamplingTest PROPERTIES LABELS "audio;plugins;comp;oversampling;contract:audio")
 
 # Aestra Comp Upgrade Test
 add_executable(AestraCompUpgradeTest AestraAudio/AestraCompUpgradeTest.cpp)
@@ -92,7 +92,7 @@ target_include_directories(AestraCompUpgradeTest PRIVATE
 )
 if(AESTRA_ENABLE_RUNTIME_TESTS)
     add_test(NAME AestraCompUpgradeTest COMMAND AestraCompUpgradeTest)
-    set_tests_properties(AestraCompUpgradeTest PROPERTIES LABELS "audio;plugins;comp;upgrade")
+    set_tests_properties(AestraCompUpgradeTest PROPERTIES LABELS "audio;plugins;comp;upgrade;contract:plugins")
 else()
     message(STATUS "AestraCompUpgradeTest built but not registered (set AESTRA_ENABLE_RUNTIME_TESTS=ON to enable)")
 endif()
@@ -107,7 +107,7 @@ target_include_directories(AestraCompressorMaterialLab PRIVATE
 )
 target_compile_definitions(AestraCompressorMaterialLab PRIVATE AESTRA_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME AestraCompressorMaterialLab COMMAND AestraCompressorMaterialLab)
-set_tests_properties(AestraCompressorMaterialLab PROPERTIES LABELS "audio;plugins;comp;lab")
+set_tests_properties(AestraCompressorMaterialLab PROPERTIES LABELS "audio;plugins;comp;lab;contract:audio")
 
 # Aestra Delay Upgrade Test
 add_executable(AestraDelayUpgradeTest AestraAudio/AestraDelayUpgradeTest.cpp)
@@ -118,7 +118,7 @@ target_include_directories(AestraDelayUpgradeTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraDelayUpgradeTest COMMAND AestraDelayUpgradeTest)
-set_tests_properties(AestraDelayUpgradeTest PROPERTIES LABELS "audio;plugins;delay;upgrade")
+set_tests_properties(AestraDelayUpgradeTest PROPERTIES LABELS "audio;plugins;delay;upgrade;contract:audio")
 
 add_executable(AestraDriftQualityTest AestraAudio/AestraDriftQualityTest.cpp)
 target_link_libraries(AestraDriftQualityTest PRIVATE AestraAudio)
@@ -126,7 +126,7 @@ target_include_directories(AestraDriftQualityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include
 )
 add_test(NAME AestraDriftQualityTest COMMAND AestraDriftQualityTest)
-set_tests_properties(AestraDriftQualityTest PROPERTIES LABELS "audio;plugins;drift;quality")
+set_tests_properties(AestraDriftQualityTest PROPERTIES LABELS "audio;plugins;drift;quality;contract:audio")
 
 # Aestra Limit Test
 add_executable(AestraLimitTest AestraAudio/AestraLimitTest.cpp)
@@ -137,7 +137,7 @@ target_include_directories(AestraLimitTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraLimitTest COMMAND AestraLimitTest)
-set_tests_properties(AestraLimitTest PROPERTIES LABELS "audio;plugins;limiter")
+set_tests_properties(AestraLimitTest PROPERTIES LABELS "audio;plugins;limiter;contract:audio")
 
 # Aestra Sat Test
 add_executable(AestraSatTest AestraAudio/AestraSatTest.cpp)
@@ -148,7 +148,7 @@ target_include_directories(AestraSatTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraSatTest COMMAND AestraSatTest)
-set_tests_properties(AestraSatTest PROPERTIES LABELS "audio;plugins;saturation")
+set_tests_properties(AestraSatTest PROPERTIES LABELS "audio;plugins;saturation;contract:audio")
 
 # Aestra Filter plugin test. Not to be confused with AestraFilterTest, which is
 # the DSP::Filter lab (AestraAudio/FilterTest.cpp, registered in Tests/CMakeLists.txt
@@ -161,7 +161,7 @@ target_include_directories(AestraFilterPluginTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraFilterPluginTest COMMAND AestraFilterPluginTest)
-set_tests_properties(AestraFilterPluginTest PROPERTIES LABELS "audio;plugins;filter")
+set_tests_properties(AestraFilterPluginTest PROPERTIES LABELS "audio;plugins;filter;contract:audio")
 
 # Aestra Filter multi-instance benchmark — build always, register only when
 # experimental tests are enabled (never in the always-on CI tier).
@@ -188,7 +188,7 @@ target_include_directories(AestraOTTTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraOTTTest COMMAND AestraOTTTest)
-set_tests_properties(AestraOTTTest PROPERTIES LABELS "audio;plugins;ott")
+set_tests_properties(AestraOTTTest PROPERTIES LABELS "audio;plugins;ott;contract:audio")
 
 # Aestra LFO Test
 add_executable(AestraLFOTest AestraAudio/AestraLFOTest.cpp)
@@ -199,7 +199,7 @@ target_include_directories(AestraLFOTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraLFOTest COMMAND AestraLFOTest)
-set_tests_properties(AestraLFOTest PROPERTIES LABELS "audio;plugins;lfo")
+set_tests_properties(AestraLFOTest PROPERTIES LABELS "audio;plugins;lfo;contract:audio")
 
 # Plugin initialization contract — parameters must survive EffectChain::prepare()
 # re-initialize (sample-rate/device changes), across every internal effect.
@@ -211,7 +211,7 @@ target_include_directories(PluginInitContractTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME PluginInitContractTest COMMAND PluginInitContractTest)
-set_tests_properties(PluginInitContractTest PROPERTIES LABELS "audio;plugins;lifecycle")
+set_tests_properties(PluginInitContractTest PROPERTIES LABELS "audio;plugins;lifecycle;contract:plugins")
 
 # Missing-plugin state preservation (#647) — a plugin that cannot be
 # instantiated must survive load/save instead of being silently erased.
@@ -235,4 +235,4 @@ target_include_directories(EffectChainInstanceIdentityTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME EffectChainInstanceIdentityTest COMMAND EffectChainInstanceIdentityTest)
-set_tests_properties(EffectChainInstanceIdentityTest PROPERTIES LABELS "audio;plugins;automation;regression")
+set_tests_properties(EffectChainInstanceIdentityTest PROPERTIES LABELS "audio;plugins;automation;regression;contract:plugins")

--- a/Tests/cmake/ProjectTests.cmake
+++ b/Tests/cmake/ProjectTests.cmake
@@ -53,7 +53,7 @@ target_include_directories(AudioClipInstanceRenderTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AudioClipInstanceRenderTest COMMAND AudioClipInstanceRenderTest)
-set_tests_properties(AudioClipInstanceRenderTest PROPERTIES LABELS "audio;routing")
+set_tests_properties(AudioClipInstanceRenderTest PROPERTIES LABELS "audio;routing;contract:audio")
 
 # Project-format compatibility policy: migration completeness, observable
 # outcomes, historical fixtures, and non-destructive unsupported-version loads.

--- a/Tests/cmake/ReverbTests.cmake
+++ b/Tests/cmake/ReverbTests.cmake
@@ -40,7 +40,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbSIMDParityTest.cpp")
     # actually a silent skip on every SSE machine.
     target_compile_definitions(ReverbSIMDParityTest PRIVATE AESTRA_ENABLE_RUNTIME_TESTS=1)
     add_test(NAME ReverbSIMDParityTest COMMAND ReverbSIMDParityTest)
-    set_tests_properties(ReverbSIMDParityTest PROPERTIES LABELS "audio;dsp;reverb")
+    set_tests_properties(ReverbSIMDParityTest PROPERTIES LABELS "audio;dsp;reverb;contract:audio")
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbSafetyRegressionTest.cpp")
@@ -52,7 +52,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbSafetyRegressionTest.cp
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ReverbSafetyRegressionTest COMMAND ReverbSafetyRegressionTest)
-    set_tests_properties(ReverbSafetyRegressionTest PROPERTIES LABELS "audio;dsp;reverb;safety")
+    set_tests_properties(ReverbSafetyRegressionTest PROPERTIES LABELS "audio;dsp;reverb;safety;contract:audio")
 endif()
 
 # Reverb Consistency Probe — hunts for inconsistency/offness (bypass parity,
@@ -68,7 +68,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbConsistencyProbe.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ReverbConsistencyProbe COMMAND ReverbConsistencyProbe)
-    set_tests_properties(ReverbConsistencyProbe PROPERTIES LABELS "audio;dsp;reverb;probe")
+    set_tests_properties(ReverbConsistencyProbe PROPERTIES LABELS "audio;dsp;reverb;probe;contract:audio")
 endif()
 
 # Reverb F4 modulation regression test (taps the real per-line modulator)
@@ -81,7 +81,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbModulationTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ReverbModulationTest COMMAND ReverbModulationTest)
-    set_tests_properties(ReverbModulationTest PROPERTIES LABELS "audio;dsp;reverb;modulation")
+    set_tests_properties(ReverbModulationTest PROPERTIES LABELS "audio;dsp;reverb;modulation;contract:audio")
 endif()
 
 # Reverb F6 stereo regression test (mono compatibility + width)
@@ -94,7 +94,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbStereoTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ReverbStereoTest COMMAND ReverbStereoTest)
-    set_tests_properties(ReverbStereoTest PROPERTIES LABELS "audio;dsp;reverb;stereo")
+    set_tests_properties(ReverbStereoTest PROPERTIES LABELS "audio;dsp;reverb;stereo;contract:audio")
 endif()
 
 # Reverb F8 tail-dormancy test (idle-instance optimization correctness)
@@ -107,7 +107,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ReverbDormancyTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ReverbDormancyTest COMMAND ReverbDormancyTest)
-    set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy")
+    set_tests_properties(ReverbDormancyTest PROPERTIES LABELS "audio;dsp;reverb;dormancy;contract:audio")
 endif()
 
 # Reverb Harmonic-Motion / Tremolo investigation labs — experimental tooling,


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

> Previously stacked on #718, which merged as `3c3b2d22`.
> Retargeted to `develop`; the resulting diff was re-enumerated and remains exactly
> 87 contract-label additions with no other label or test-membership changes.

## Summary

87 more cases receive a contract; **78 remain** for group 3.

| Contract | Cases |
| --- | ---: |
| `contract:audio` | 71 |
| `contract:plugins` | 14 |
| `contract:realtime` | 1 |
| `contract:durability` | 1 |

Classification only — no selector, workflow, test source or registration condition changes.

## The PDC cluster, split rather than kept together

| Test | Contract | Reason |
| --- | --- | --- |
| `PDCFlatChainTest`, `PDCBusChainTest`, `PDCBranchingConvergenceTest`, `PDCSolverPurityTest`, `PDCEngineEdgeConstructionTest` | `plugins` | Assert that **plugin-reported latency is received and propagated** through the solver and the engine's `LatencyGraph::edges` |
| `PDCDisableClearsCompensationTest` | `audio` | Asserts that disabling compensation actually **zeroes applied delays** — the failure is audible misalignment |
| `PDCRTConsumptionTest` | **deferred** | Still a no-crash smoke test, not a directly asserted RT invariant |
| `LatencyCompensationTest` | **deferred** | Header too thin to state an acceptance criterion |

## "Contains a plugin" did not decide anything

| Test | Contract | Why the name misleads |
| --- | --- | --- |
| `AestraDelayUpgradeTest` | `audio` | "Upgrade" suggests state compatibility; the header states **sync, ping-pong and saturation behaviour** — DSP output |
| `PluginInsertTakesEffectWithoutClipMoveTest`, `PluginRemoveTakesEffectWithoutClipMoveTest` | `audio` | "Plugin" in the name, but the assertion is that the **rendered graph changes** |
| `AestraCompPhase1Test`, `AestraCompUpgradeTest` | `plugins` | Conversely — labelled `audio`, but assert **parameter and state contracts**, which is plugin lifecycle |

## Two cases group 1 missed

Their descriptive labels pointed at the wrong group, which is the failure mode the candidate-generator rule predicts:

- **`ProjectLoadRegressionTest` → `durability`.** `ProjectSerializer` load behaviour, but labelled `routing`, so it never entered the group 1 candidate pool.
- **`AudioEngineDiagnosticsTest` → `realtime`.** Asserts RT violation recording and RT depth tracking with nested guards, but labelled `diagnostics`.

## Verification

Against the group 1 tree, maximal configuration:

| | |
| --- | --- |
| Census | 243 → **243** |
| CTest names | **identical** |
| Label deltas | **exactly 87**, no pre-existing label removed |
| Contracts | none multiple, none unknown |
| Contracted | 78 → **165**; 78 remain |

> A first attempt at this branch was based on `origin/develop` rather than on #718's branch, which made group 1's 34 labels read as *removed* in the delta check. The proof shape caught it before commit. Rebased onto the group 1 branch and re-verified.

## What remains — 78

| Likely group 3 | Count |
| --- | ---: |
| Application (UI, commands, Muse, transport, takes) | 58 |
| Core (guards, JSON/locale, temp-dir, UUID) | 7 |
| **Genuinely unclear** | **13** |

The 13 unclear cases are the reason group 3 may need a small separation pass first: five are `experimental;unstable` with no stated criterion (`AestraAudioCallbackTest`, `AestraFilterTest`, `AestraSampleRateConverterTest`, `AestraWaveformCacheTest`, `AestraWaveformLockTest`), and the rest are the deferred PDC pair plus `AudioEngineOwnershipTest`, `AestraFilterBench` (a benchmark that reports cost without asserting a threshold), and the two headless-export CLI tests.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**No execution risk.** CTest labels are metadata; nothing is added, removed, renamed, skipped or reordered, and no selector reads `contract:*` yet.

**Confidence is lower than group 1 on the DSP bulk.** Most `contract:audio` assignments rest on headers that state their own criterion verbatim ("DSP contract tests for…", "verifies digital summing accuracy against mathematical reference"). Where a header did not state a criterion, the test was deferred rather than assigned.

**Rollback:** revert the commit.
