### PR TITLE
ci: subscribe to pull_request edited so retargets run the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # `edited` is not decoration. Without it, retargeting a pull request's base
+    # onto develop produces only an `edited` event, which the default type set
+    # (opened, synchronize, reopened) does not subscribe to — so no CI run is
+    # created and the five required contexts never report. The pull request then
+    # blocks permanently with nothing an author can do about it. #719 sat in that
+    # state until it was closed and reopened purely to manufacture a `reopened`
+    # event.
+    #
+    # The branch filter still evaluates the pull request's *target*, so adding
+    # `edited` widens which events are subscribed to, never which branches run.
+    #
+    # This also fires on title and description edits, which is wasteful and
+    # deliberate: the required jobs must not be conditionally skipped for
+    # non-base edits, because GitHub reports a skipped required job as
+    # successful. A selective implementation would turn a later metadata edit
+    # into false-green evidence over a matrix that had actually failed.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Subscribe `ci.yml` to the `edited` pull-request activity type so that retargeting a pull request's base runs the matrix.

```yaml
pull_request:
  branches: [main, develop]
  types: [opened, synchronize, reopened, edited]
```

That single line is the whole functional change. Everything else in the diff is the comment explaining it.

## Before

A pull request opened against a branch other than `main` or `develop`, then retargeted onto `develop`, receives only an `edited` event. The default `pull_request` type set is `opened, synchronize, reopened`, so **no CI run is created and the five required contexts never appear.** The pull request blocks permanently with no action available to its author.

Observed, not theorised. #719 was opened against the group 1 branch — correctly declined by the `branches` filter — then retargeted to `develop`. It sat at **2 of 7** required checks with an approving review and zero failures. The only checks reporting were the two that could:

| Check | Why it reported |
| --- | --- |
| `Decision citation` | `decision-citation.yml` explicitly lists `edited` |
| `license-signing` | `worker-ci.yml` has a bare `pull_request:` with no branch filter |

It was recovered by closing and reopening the PR purely to manufacture a `reopened` event.

## After, by specification

`edited` becomes a subscribed event. The `branches` filter still evaluates the pull request's **target**, so this widens which events are subscribed to, never which branches execute.

## What is unchanged

- Required job names and required contexts
- ctest selectors and job bodies
- `permissions:` blocks
- `concurrency` group and `cancel-in-progress`
- Branch protection on `main` and `develop`

## No required job is conditionally skipped

GitHub reports a **skipped required job as successful**. A selective implementation — running the matrix only when the base actually changed — would convert a later title or description edit into false-green evidence over a matrix that had genuinely failed.

Verified by parsing the workflow:

| Required job | `if:` | `continue-on-error` |
| --- | --- | --- |
| `build-linux` | — | false |
| `build-linux-app` | — | false |
| `build-plugin-host` | — | false |
| `build-windows` | — | false |
| `build-macos` | — | false |

The cost is that metadata edits also rerun the full matrix. Wasteful and deliberate; a more selective version needs its own proof that it cannot emit skipped-success required contexts.

`ready_for_review` is deliberately **not** added. No draft-PR trigger gap has been demonstrated, and adding an event on speculation is how a gate accumulates surface nobody can reason about.

## Validation

- Workflow parses; `pull_request.branches` and `pull_request.types` asserted to their exact expected values; job count asserted at 11.
- The complete matrix passes through the ordinary `opened` path — this PR's own CI run.
- `actionlint` is not installed locally and the repository has no actionlint job, so syntax evidence here is the YAML parse plus GitHub accepting and scheduling the workflow.

## Residual proof — stated, not implied

> **This PR cannot demonstrate its own `edited` trigger through its ordinary CI run.** Its checks arrive via `opened`. Real-event verification remains open until a later pull request is genuinely retargeted and the full matrix starts.

Deliberately not manufactured by retargeting this PR back and forth. The #719 incident already establishes the before-state; the next natural retarget establishes the after-state. Treating this PR's green matrix as proof of the newly added event path would be exactly the T3 error of letting a gate vouch for its own change.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**Risk: additional runner consumption.** Title and description edits now trigger a full matrix. Combined with unbounded push runs from the concurrency fix, this strengthens the separate case for path filters on `ci.yml`.

**No risk of weaker gating.** The change only adds a subscribed event. No branch, job, selector or required context is removed or relaxed.

**Rollback:** revert the commit. The prior behaviour returns immediately — including the retarget defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added the `pull_request` `edited` trigger to `.github/workflows/ci.yml`.
- Retargeted pull requests for `main` and `develop` now run the full matrix.
- Retained existing job names, permissions, concurrency settings, selectors, and branch filters.
- Metadata edits also trigger the matrix, which may increase runner usage.
- Added workflow validation for event types, branches, and job count. Real-event verification remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->