### PR TITLE
test: classify group 3 — application and core, completing the migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessExportMain.cpp")
       COMMAND AestraHeadlessExport --duration nope)
     set_tests_properties(AestraHeadlessExportRejectsBadArgs PROPERTIES
       WILL_FAIL TRUE
-      LABELS "cli;headless")
+      LABELS "cli;headless;contract:application")
 
     # Real end-to-end export invocation: arg parse -> template project -> export
     # attempt. Regression guard for the getInstance() abort (SIGABRT on develop;
@@ -380,7 +380,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/Source/App/HeadlessExportMain.cpp")
         -DOUT_FILE=${CMAKE_BINARY_DIR}/headless_export_e2e.wav
         -P ${CMAKE_SOURCE_DIR}/Tests/Headless/run_headless_export_e2e.cmake)
     set_tests_properties(AestraHeadlessExportEndToEnd PROPERTIES
-      LABELS "cli;headless;export;integrity"
+      LABELS "cli;headless;export;integrity;contract:audio"
       TIMEOUT 120)
   endif()
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -336,7 +336,7 @@ if(BUILD_TESTING)
 			-P "${CMAKE_SOURCE_DIR}/Tests/Guards/verify_aestra_font_bundle.cmake"
 	)
 	set_tests_properties(AestraDesktopFontBundleTest PROPERTIES
-		LABELS "ui;assets;fonts;regression"
+		LABELS "ui;assets;fonts;regression;contract:application"
 		TIMEOUT 30
 	)
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -71,7 +71,7 @@ add_executable(TestTempDirectoryStressTest Support/TestTempDirectoryStressTest.c
 find_package(Threads REQUIRED)
 target_link_libraries(TestTempDirectoryStressTest PRIVATE Threads::Threads)
 add_test(NAME TestTempDirectoryStressTest COMMAND TestTempDirectoryStressTest)
-set_tests_properties(TestTempDirectoryStressTest PROPERTIES LABELS "support;infrastructure")
+set_tests_properties(TestTempDirectoryStressTest PROPERTIES LABELS "support;infrastructure;contract:core")
 
 # Project RoundTrip Test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripTest.cpp")
@@ -699,7 +699,7 @@ add_executable(AestraWaveformLockTest
 target_link_libraries(AestraWaveformLockTest PRIVATE AestraAudio)
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraWaveformLockTest COMMAND AestraWaveformLockTest)
-    set_tests_properties(AestraWaveformLockTest PROPERTIES LABELS "experimental;unstable")
+    set_tests_properties(AestraWaveformLockTest PROPERTIES LABELS "experimental;unstable;contract:application")
 else()
     message(STATUS "AestraWaveformLockTest built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
@@ -712,7 +712,7 @@ add_executable(AestraWaveformCacheTest
 target_link_libraries(AestraWaveformCacheTest PRIVATE AestraAudio)
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraWaveformCacheTest COMMAND AestraWaveformCacheTest)
-    set_tests_properties(AestraWaveformCacheTest PROPERTIES LABELS "experimental;unstable")
+    set_tests_properties(AestraWaveformCacheTest PROPERTIES LABELS "experimental;unstable;contract:audio")
 else()
     message(STATUS "AestraWaveformCacheTest built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
@@ -942,7 +942,7 @@ add_executable(AestraAudioCallbackTest AestraAudio/AudioCallbackTest.cpp)
 target_link_libraries(AestraAudioCallbackTest PRIVATE AestraAudio)
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraAudioCallbackTest COMMAND AestraAudioCallbackTest)
-    set_tests_properties(AestraAudioCallbackTest PROPERTIES LABELS "experimental;unstable")
+    set_tests_properties(AestraAudioCallbackTest PROPERTIES LABELS "experimental;unstable;contract:core")
 else()
     message(STATUS "AestraAudioCallbackTest built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
@@ -952,7 +952,7 @@ add_executable(AestraFilterTest AestraAudio/FilterTest.cpp)
 target_link_libraries(AestraFilterTest PRIVATE AestraAudio)
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraFilterTest COMMAND AestraFilterTest)
-    set_tests_properties(AestraFilterTest PROPERTIES LABELS "experimental;unstable")
+    set_tests_properties(AestraFilterTest PROPERTIES LABELS "experimental;unstable;contract:audio")
 else()
     message(STATUS "AestraFilterTest built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
@@ -1011,7 +1011,7 @@ target_include_directories(AestraUUIDTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AestraUUIDTest COMMAND AestraUUIDTest)
-set_tests_properties(AestraUUIDTest PROPERTIES LABELS "audio;uuid")
+set_tests_properties(AestraUUIDTest PROPERTIES LABELS "audio;uuid;contract:core")
 
 # Arsenal route-mode compatibility test
 add_executable(ArsenalRouteModeCompatibilityTest AestraAudio/ArsenalRouteModeCompatibilityTest.cpp)
@@ -1074,7 +1074,7 @@ target_include_directories(ArsenalRouteModePolicyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ArsenalRouteModePolicyTest COMMAND ArsenalRouteModePolicyTest)
-set_tests_properties(ArsenalRouteModePolicyTest PROPERTIES LABELS "audio;arsenal;policy")
+set_tests_properties(ArsenalRouteModePolicyTest PROPERTIES LABELS "audio;arsenal;policy;contract:application")
 
 if(NOT WIN32)
     add_executable(PluginScannerSigpipeTest AestraAudio/PluginScannerSigpipeTest.cpp)
@@ -1098,7 +1098,7 @@ target_include_directories(ArsenalBridgeContractTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ArsenalBridgeContractTest COMMAND ArsenalBridgeContractTest)
-set_tests_properties(ArsenalBridgeContractTest PROPERTIES LABELS "arsenal;policy")
+set_tests_properties(ArsenalBridgeContractTest PROPERTIES LABELS "arsenal;policy;contract:application")
 
 # Arsenal export current-policy parity guard (Phase 2C)
 add_executable(ArsenalExportCurrentPolicyTest AestraAudio/ArsenalExportCurrentPolicyTest.cpp)
@@ -1146,7 +1146,7 @@ target_link_libraries(AestraSampleRateConverterTest PRIVATE AestraAudio)
 target_compile_definitions(AestraSampleRateConverterTest PRIVATE AESTRA_SRC_TEST_ACCESS=1)
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraSampleRateConverterTest COMMAND AestraSampleRateConverterTest)
-    set_tests_properties(AestraSampleRateConverterTest PROPERTIES LABELS "experimental;unstable")
+    set_tests_properties(AestraSampleRateConverterTest PROPERTIES LABELS "experimental;unstable;contract:audio")
 else()
     message(STATUS "AestraSampleRateConverterTest built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()
@@ -1172,7 +1172,7 @@ target_include_directories(RecordingPathTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source
 )
 add_test(NAME RecordingPathTest COMMAND RecordingPathTest)
-set_tests_properties(RecordingPathTest PROPERTIES LABELS "audio;recording;headless")
+set_tests_properties(RecordingPathTest PROPERTIES LABELS "audio;recording;headless;contract:application")
 
 
 # =============================================================================
@@ -1288,7 +1288,7 @@ target_include_directories(AudioEngineOwnershipTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AudioEngineOwnershipTest COMMAND AudioEngineOwnershipTest)
-set_tests_properties(AudioEngineOwnershipTest PROPERTIES LABELS "audio;engine;integrity" TIMEOUT 120)
+set_tests_properties(AudioEngineOwnershipTest PROPERTIES LABELS "audio;engine;integrity;contract:core" TIMEOUT 120)
 
 # Zero-tolerance source guard (R2): fails if any AudioEngine global-instance
 # mechanism (accessor, registration pointer) reappears anywhere in the tree.
@@ -1296,7 +1296,7 @@ add_test(NAME NoAudioEngineSingletonGuard
     COMMAND ${CMAKE_COMMAND}
         -DREPO_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_SOURCE_DIR}/Tests/Guards/no_audioengine_singleton.cmake)
-set_tests_properties(NoAudioEngineSingletonGuard PROPERTIES LABELS "guard;architecture" TIMEOUT 120)
+set_tests_properties(NoAudioEngineSingletonGuard PROPERTIES LABELS "guard;architecture;contract:core" TIMEOUT 120)
 
 # Self-test: runs the guard against fixture trees — every forbidden shape
 # (including renamed static/global mechanisms) must fail, benign ownership
@@ -1306,7 +1306,7 @@ add_test(NAME NoAudioEngineSingletonGuardSelfTest
         -DGUARD_SCRIPT=${CMAKE_SOURCE_DIR}/Tests/Guards/no_audioengine_singleton.cmake
         -DWORK_DIR=${CMAKE_BINARY_DIR}/guard_selftest
         -P ${CMAKE_SOURCE_DIR}/Tests/Guards/no_audioengine_singleton_selftest.cmake)
-set_tests_properties(NoAudioEngineSingletonGuardSelfTest PROPERTIES LABELS "guard;architecture" TIMEOUT 120)
+set_tests_properties(NoAudioEngineSingletonGuardSelfTest PROPERTIES LABELS "guard;architecture;contract:core" TIMEOUT 120)
 
 # Callback Deadline Telemetry — validates AudioTelemetry::recordCallbackDuration
 # (avg/worst/budget/over-budget math) synthetically, plus a live smoke over
@@ -1509,7 +1509,7 @@ target_link_libraries(PlatformWindowTest PRIVATE AestraPlat)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/TextRendererSTBSpaceTest.cpp")
     add_executable(TextRendererSTBSpaceTest AestraUI/TextRendererSTBSpaceTest.cpp)
     add_test(NAME TextRendererSTBSpaceTest COMMAND TextRendererSTBSpaceTest)
-    set_tests_properties(TextRendererSTBSpaceTest PROPERTIES LABELS "ui;regression")
+    set_tests_properties(TextRendererSTBSpaceTest PROPERTIES LABELS "ui;regression;contract:application")
     message(STATUS "TextRendererSTBSpaceTest added - Issue #121 regression test")
 endif()
 
@@ -1520,7 +1520,7 @@ add_executable(CursorServiceTest
     ${CMAKE_SOURCE_DIR}/AestraUI/Platform/NUICursorService.cpp
 )
 add_test(NAME CursorServiceTest COMMAND CursorServiceTest)
-set_tests_properties(CursorServiceTest PROPERTIES LABELS "ui;cursor;regression" TIMEOUT 60)
+set_tests_properties(CursorServiceTest PROPERTIES LABELS "ui;cursor;regression;contract:application" TIMEOUT 60)
 
 # NUITheme JSON loading test (Issue #259)
 # Compiles NUITheme.cpp directly (its only deps are header-only: NUITypes.h,
@@ -1536,7 +1536,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeJSONTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME NUIThemeJSONTest COMMAND NUIThemeJSONTest)
-    set_tests_properties(NUIThemeJSONTest PROPERTIES LABELS "ui;theme")
+    set_tests_properties(NUIThemeJSONTest PROPERTIES LABELS "ui;theme;contract:application")
     message(STATUS "NUIThemeJSONTest added - Issue #259 theme JSON loading test")
 endif()
 
@@ -1548,14 +1548,14 @@ target_include_directories(SafeClampFloatTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source/Components
 )
 add_test(NAME SafeClampFloatTest COMMAND SafeClampFloatTest)
-set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression")
+set_tests_properties(SafeClampFloatTest PROPERTIES LABELS "ui;timeline;regression;contract:application")
 
 add_executable(TimelineGeometryTest AestraUI/TimelineGeometryTest.cpp)
 target_include_directories(TimelineGeometryTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source/Components
 )
 add_test(NAME TimelineGeometryTest COMMAND TimelineGeometryTest)
-set_tests_properties(TimelineGeometryTest PROPERTIES LABELS "ui;timeline;geometry;regression")
+set_tests_properties(TimelineGeometryTest PROPERTIES LABELS "ui;timeline;geometry;regression;contract:application")
 
 add_executable(TimelineInteractionPolicyTest AestraUI/TimelineInteractionPolicyTest.cpp)
 target_include_directories(TimelineInteractionPolicyTest PRIVATE
@@ -1564,7 +1564,7 @@ target_include_directories(TimelineInteractionPolicyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
 )
 add_test(NAME TimelineInteractionPolicyTest COMMAND TimelineInteractionPolicyTest)
-set_tests_properties(TimelineInteractionPolicyTest PROPERTIES LABELS "ui;timeline;selection;regression")
+set_tests_properties(TimelineInteractionPolicyTest PROPERTIES LABELS "ui;timeline;selection;regression;contract:application")
 
 # Clip contrast contract: waveform ink must stay brighter than the clip body it
 # is drawn on, for every lane identity and both selection states.
@@ -1574,7 +1574,7 @@ target_include_directories(TimelineClipContrastTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraUI/Core
 )
 add_test(NAME TimelineClipContrastTest COMMAND TimelineClipContrastTest)
-set_tests_properties(TimelineClipContrastTest PROPERTIES LABELS "ui;timeline;color;regression")
+set_tests_properties(TimelineClipContrastTest PROPERTIES LABELS "ui;timeline;color;regression;contract:application")
 
 # Settings persistence policy (#648). Same shape as SafeClampFloatTest above:
 # header-only and widget-free so the decision that was destroying saved device
@@ -1584,13 +1584,13 @@ target_include_directories(SettingsPersistencePolicyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source/Settings
 )
 add_test(NAME SettingsPersistencePolicyTest COMMAND SettingsPersistencePolicyTest)
-set_tests_properties(SettingsPersistencePolicyTest PROPERTIES LABELS "ui;settings;regression")
+set_tests_properties(SettingsPersistencePolicyTest PROPERTIES LABELS "ui;settings;regression;contract:application")
 
 if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIThemeConsistencyTest.cpp")
     add_executable(NUIThemeConsistencyTest AestraUI/NUIThemeConsistencyTest.cpp)
     target_link_libraries(NUIThemeConsistencyTest PRIVATE AestraUI_Core)
     add_test(NAME NUIThemeConsistencyTest COMMAND NUIThemeConsistencyTest)
-    set_tests_properties(NUIThemeConsistencyTest PROPERTIES LABELS "ui;theme;consistency")
+    set_tests_properties(NUIThemeConsistencyTest PROPERTIES LABELS "ui;theme;consistency;contract:application")
 else()
     message(STATUS "NUIThemeConsistencyTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1604,7 +1604,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Base
     )
     add_test(NAME NUIContextMenuInteractionTest COMMAND NUIContextMenuInteractionTest)
-    set_tests_properties(NUIContextMenuInteractionTest PROPERTIES LABELS "ui;menu;input;regression")
+    set_tests_properties(NUIContextMenuInteractionTest PROPERTIES LABELS "ui;menu;input;regression;contract:application")
 
     add_executable(ModalDialogInteractionTest
         AestraUI/ModalDialogInteractionTest.cpp
@@ -1620,7 +1620,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME ModalDialogInteractionTest COMMAND ModalDialogInteractionTest)
-    set_tests_properties(ModalDialogInteractionTest PROPERTIES LABELS "ui;modal;input;regression")
+    set_tests_properties(ModalDialogInteractionTest PROPERTIES LABELS "ui;modal;input;regression;contract:application")
 else()
     message(STATUS "NUIContextMenuInteractionTest and ModalDialogInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1634,7 +1634,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/KeyboardNoteInputTest.cpp")
         ${CMAKE_SOURCE_DIR}/Source/Core
     )
     add_test(NAME KeyboardNoteInputTest COMMAND KeyboardNoteInputTest)
-    set_tests_properties(KeyboardNoteInputTest PROPERTIES LABELS "ui;input;midi")
+    set_tests_properties(KeyboardNoteInputTest PROPERTIES LABELS "ui;input;midi;contract:application")
 endif()
 
 # PianoRollInteraction Test - tests for pure helper functions
@@ -1647,7 +1647,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Common
     )
     add_test(NAME PianoRollInteractionTest COMMAND PianoRollInteractionTest)
-    set_tests_properties(PianoRollInteractionTest PROPERTIES LABELS "ui;interaction")
+    set_tests_properties(PianoRollInteractionTest PROPERTIES LABELS "ui;interaction;contract:application")
 else()
     message(STATUS "PianoRollInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1662,7 +1662,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Core
     )
     add_test(NAME EditorCloseDeferredTest COMMAND EditorCloseDeferredTest)
-    set_tests_properties(EditorCloseDeferredTest PROPERTIES LABELS "ui;lifecycle;regression")
+    set_tests_properties(EditorCloseDeferredTest PROPERTIES LABELS "ui;lifecycle;regression;contract:application")
 else()
     message(STATUS "EditorCloseDeferredTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1679,7 +1679,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
     )
     add_test(NAME PanelWindowClickSwallowTest COMMAND PanelWindowClickSwallowTest)
-    set_tests_properties(PanelWindowClickSwallowTest PROPERTIES LABELS "ui;input;regression")
+    set_tests_properties(PanelWindowClickSwallowTest PROPERTIES LABELS "ui;input;regression;contract:application")
 else()
     message(STATUS "PanelWindowClickSwallowTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1718,7 +1718,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/Source/Panels
     )
     add_test(NAME TakesHistoryPanelTest COMMAND TakesHistoryPanelTest)
-    set_tests_properties(TakesHistoryPanelTest PROPERTIES LABELS "ui;takes;history;regression")
+    set_tests_properties(TakesHistoryPanelTest PROPERTIES LABELS "ui;takes;history;regression;contract:application")
 else()
     message(STATUS "TakesHistoryPanelTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1734,7 +1734,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
     )
     add_test(NAME PluginBrowserSelectionTest COMMAND PluginBrowserSelectionTest)
-    set_tests_properties(PluginBrowserSelectionTest PROPERTIES LABELS "ui;plugin-browser;regression")
+    set_tests_properties(PluginBrowserSelectionTest PROPERTIES LABELS "ui;plugin-browser;regression;contract:application")
 else()
     message(STATUS "PluginBrowserSelectionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1748,7 +1748,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
     )
     add_test(NAME UIInsertRoutePickerTest COMMAND UIInsertRoutePickerTest)
-    set_tests_properties(UIInsertRoutePickerTest PROPERTIES LABELS "ui;routing;regression")
+    set_tests_properties(UIInsertRoutePickerTest PROPERTIES LABELS "ui;routing;regression;contract:application")
 else()
     message(STATUS "UIInsertRoutePickerTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1764,7 +1764,7 @@ if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIText
         ${CMAKE_SOURCE_DIR}/AestraPlat/include
     )
     add_test(NAME NUITextInputLayoutTest COMMAND NUITextInputLayoutTest)
-    set_tests_properties(NUITextInputLayoutTest PROPERTIES LABELS "ui;textinput;regression")
+    set_tests_properties(NUITextInputLayoutTest PROPERTIES LABELS "ui;textinput;regression;contract:application")
     message(STATUS "NUITextInputLayoutTest added - multiline layout/caret regression tests")
 else()
     message(STATUS "NUITextInputLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
@@ -1782,7 +1782,7 @@ if(TARGET AestraUI_Core AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/NUIText
         ${CMAKE_SOURCE_DIR}/AestraPlat/include
     )
     add_test(NAME NUITextInputEditingTest COMMAND NUITextInputEditingTest)
-    set_tests_properties(NUITextInputEditingTest PROPERTIES LABELS "ui;textinput;regression")
+    set_tests_properties(NUITextInputEditingTest PROPERTIES LABELS "ui;textinput;regression;contract:application")
     message(STATUS "NUITextInputEditingTest added - selection-replace editing regression tests")
 else()
     message(STATUS "NUITextInputEditingTest skipped (AestraUI_Core target unavailable in this build mode)")
@@ -1798,7 +1798,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraUI/InspectorCollapseStateTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME InspectorCollapseStateTest COMMAND InspectorCollapseStateTest)
-    set_tests_properties(InspectorCollapseStateTest PROPERTIES LABELS "ui;mixer;regression")
+    set_tests_properties(InspectorCollapseStateTest PROPERTIES LABELS "ui;mixer;regression;contract:application")
     message(STATUS "InspectorCollapseStateTest added - inspector collapse preference/constraint tests")
 endif()
 
@@ -1810,7 +1810,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Core
     )
     add_test(NAME NUIDropdownInteractionTest COMMAND NUIDropdownInteractionTest)
-    set_tests_properties(NUIDropdownInteractionTest PROPERTIES LABELS "ui;dropdown;regression")
+    set_tests_properties(NUIDropdownInteractionTest PROPERTIES LABELS "ui;dropdown;regression;contract:application")
 
     add_executable(NUIComponentTooltipTest AestraUI/NUIComponentTooltipTest.cpp)
     target_link_libraries(NUIComponentTooltipTest PRIVATE AestraUI_Core)
@@ -1818,7 +1818,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Core
     )
     add_test(NAME NUIComponentTooltipTest COMMAND NUIComponentTooltipTest)
-    set_tests_properties(NUIComponentTooltipTest PROPERTIES LABELS "ui;tooltip;regression")
+    set_tests_properties(NUIComponentTooltipTest PROPERTIES LABELS "ui;tooltip;regression;contract:application")
 
     # #672: an inactive workspace must never intercept the active one's input.
     add_executable(NUIHiddenChildDispatchTest AestraUI/NUIHiddenChildDispatchTest.cpp)
@@ -1827,7 +1827,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Core
     )
     add_test(NAME NUIHiddenChildDispatchTest COMMAND NUIHiddenChildDispatchTest)
-    set_tests_properties(NUIHiddenChildDispatchTest PROPERTIES LABELS "ui;dispatch;regression")
+    set_tests_properties(NUIHiddenChildDispatchTest PROPERTIES LABELS "ui;dispatch;regression;contract:application")
 
     # #672 leaf side: a widget handed an event directly (bypassing the parent-side
     # filter added in #674) must still refuse it while hidden.
@@ -1838,7 +1838,7 @@ if(TARGET AestraUI_Core)
         ${CMAKE_SOURCE_DIR}/AestraUI/Base
     )
     add_test(NAME NUIWidgetHiddenInputTest COMMAND NUIWidgetHiddenInputTest)
-    set_tests_properties(NUIWidgetHiddenInputTest PROPERTIES LABELS "ui;dispatch;regression")
+    set_tests_properties(NUIWidgetHiddenInputTest PROPERTIES LABELS "ui;dispatch;regression;contract:application")
 else()
     message(STATUS "Dropdown/tooltip interaction tests skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
@@ -1854,7 +1854,7 @@ target_include_directories(MusicalTypingControllerTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraUI/Core
 )
 add_test(NAME MusicalTypingControllerTest COMMAND MusicalTypingControllerTest)
-set_tests_properties(MusicalTypingControllerTest PROPERTIES LABELS "ui;midi;regression")
+set_tests_properties(MusicalTypingControllerTest PROPERTIES LABELS "ui;midi;regression;contract:application")
 
 # =============================================================================
 # Per-domain test fragments
@@ -1979,7 +1979,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PianoRollEdgeCaseStressTest.c
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME PianoRollEdgeCaseStressTest COMMAND PianoRollEdgeCaseStressTest)
-    set_tests_properties(PianoRollEdgeCaseStressTest PROPERTIES LABELS "audio;pianoroll;stress")
+    set_tests_properties(PianoRollEdgeCaseStressTest PROPERTIES LABELS "audio;pianoroll;stress;contract:application")
 endif()
 
 # Plugin Host Stress Test
@@ -2003,7 +2003,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TransportStressTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME TransportStressTest COMMAND TransportStressTest)
-    set_tests_properties(TransportStressTest PROPERTIES LABELS "audio;transport;stress")
+    set_tests_properties(TransportStressTest PROPERTIES LABELS "audio;transport;stress;contract:application")
 endif()
 
 # Pathological Chaos Stress Test
@@ -2039,7 +2039,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TrackManagerStressTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME TrackManagerStressTest COMMAND TrackManagerStressTest)
-    set_tests_properties(TrackManagerStressTest PROPERTIES LABELS "audio;trackmanager;stress")
+    set_tests_properties(TrackManagerStressTest PROPERTIES LABELS "audio;trackmanager;stress;contract:application")
 endif()
 
 # File Browser Stress Test
@@ -2051,7 +2051,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/FileBrowserStressTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME FileBrowserStressTest COMMAND FileBrowserStressTest)
-    set_tests_properties(FileBrowserStressTest PROPERTIES LABELS "audio;filebrowser;stress")
+    set_tests_properties(FileBrowserStressTest PROPERTIES LABELS "audio;filebrowser;stress;contract:application")
 endif()
 
 # Realtime Scheduling Test (Linux-only: uses sched_getscheduler, RLIMIT_RTPRIO, /proc/self/status)
@@ -2077,7 +2077,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/LatencyCompensationTest.cpp")
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME LatencyCompensationTest COMMAND LatencyCompensationTest)
-    set_tests_properties(LatencyCompensationTest PROPERTIES LABELS "audio;latency;pdc")
+    set_tests_properties(LatencyCompensationTest PROPERTIES LABELS "audio;latency;pdc;contract:plugins")
 endif()
 
 # One parser for audio_settings.conf (#649). parse/serialize are stream-based
@@ -2092,7 +2092,7 @@ target_include_directories(AudioSettingsStoreTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AudioSettingsStoreTest COMMAND AudioSettingsStoreTest)
-set_tests_properties(AudioSettingsStoreTest PROPERTIES LABELS "audio;settings;regression")
+set_tests_properties(AudioSettingsStoreTest PROPERTIES LABELS "audio;settings;regression;contract:core")
 
 # Sliding-indicator first-sync semantics (segmented control, #653 follow-up).
 # Header-only and widget-free by design so the animation contract is reachable
@@ -2102,7 +2102,7 @@ target_include_directories(SlidingIndicatorTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraUI/Base
 )
 add_test(NAME SlidingIndicatorTest COMMAND SlidingIndicatorTest)
-set_tests_properties(SlidingIndicatorTest PROPERTIES LABELS "ui;regression")
+set_tests_properties(SlidingIndicatorTest PROPERTIES LABELS "ui;regression;contract:application")
 
 # AestraJSON must round-trip doubles independently of LC_NUMERIC. AestraJSON.h
 # is header-only, so this needs no library — but it backs ProjectSerializer,
@@ -2113,6 +2113,6 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraCore/JSONLocaleIndependenceTest.cpp
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME JSONLocaleIndependenceTest COMMAND JSONLocaleIndependenceTest)
-    set_tests_properties(JSONLocaleIndependenceTest PROPERTIES LABELS "core;json;locale;regression")
+    set_tests_properties(JSONLocaleIndependenceTest PROPERTIES LABELS "core;json;locale;regression;contract:core")
     message(STATUS "JSONLocaleIndependenceTest added - JSON decimal separator locale independence")
 endif()

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -355,7 +355,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCRTConsumptionTest.cpp")
     )
     add_test(NAME PDCRTConsumptionTest COMMAND PDCRTConsumptionTest)
     set_tests_properties(PDCRTConsumptionTest PROPERTIES
-        LABELS "headless;pdc;engine;rt"
+        LABELS "headless;pdc;engine;rt;contract:core"
         ENVIRONMENT "AESTRA_HEADLESS=1"
     )
 endif()

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -26,7 +26,7 @@ target_include_directories(CommandHistoryTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME CommandHistoryTest COMMAND CommandHistoryTest)
-set_tests_properties(CommandHistoryTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(CommandHistoryTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # MoveClipCommand Test
 add_executable(MoveClipCommandTest Commands/MoveClipCommandTest.cpp)
@@ -36,7 +36,7 @@ target_include_directories(MoveClipCommandTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MoveClipCommandTest COMMAND MoveClipCommandTest)
-set_tests_properties(MoveClipCommandTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(MoveClipCommandTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # MacroCommand Test
 add_executable(MacroCommandTest Commands/MacroCommandTest.cpp)
@@ -46,7 +46,7 @@ target_include_directories(MacroCommandTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MacroCommandTest COMMAND MacroCommandTest)
-set_tests_properties(MacroCommandTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(MacroCommandTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # Note Commands Test (AddNote, RemoveNote, MoveNote, ResizeNote)
 add_executable(NoteCommandsTest Commands/NoteCommandsTest.cpp)
@@ -56,7 +56,7 @@ target_include_directories(NoteCommandsTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME NoteCommandsTest COMMAND NoteCommandsTest)
-set_tests_properties(NoteCommandsTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(NoteCommandsTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # NoteDiff Test (headless diffing logic for piano roll save path)
 add_executable(NoteDiffTest Commands/NoteDiffTest.cpp)
@@ -66,7 +66,7 @@ target_include_directories(NoteDiffTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME NoteDiffTest COMMAND NoteDiffTest)
-set_tests_properties(NoteDiffTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(NoteDiffTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # ScaleContext Test (scale context default values and helpers)
 add_executable(ScaleContextTest AestraAudio/ScaleContextTest.cpp)
@@ -76,7 +76,7 @@ target_include_directories(ScaleContextTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ScaleContextTest COMMAND ScaleContextTest)
-set_tests_properties(ScaleContextTest PROPERTIES LABELS "audio;scale;music")
+set_tests_properties(ScaleContextTest PROPERTIES LABELS "audio;scale;music;contract:application")
 
 # Mixer Commands Test (Volume, Pan, Mute, Solo)
 add_executable(MixerCommandsTest Commands/MixerCommandsTest.cpp)
@@ -86,7 +86,7 @@ target_include_directories(MixerCommandsTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MixerCommandsTest COMMAND MixerCommandsTest)
-set_tests_properties(MixerCommandsTest PROPERTIES LABELS "commands;phase2;mixer")
+set_tests_properties(MixerCommandsTest PROPERTIES LABELS "commands;phase2;mixer;contract:application")
 
 # Clip Commands Test (Trim, Duplicate)
 add_executable(ClipCommandsTest Commands/ClipCommandsTest.cpp)
@@ -96,7 +96,7 @@ target_include_directories(ClipCommandsTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME ClipCommandsTest COMMAND ClipCommandsTest)
-set_tests_properties(ClipCommandsTest PROPERTIES LABELS "commands;phase2;clip")
+set_tests_properties(ClipCommandsTest PROPERTIES LABELS "commands;phase2;clip;contract:application")
 
 # CommandTransaction Test
 add_executable(CommandTransactionTest Commands/CommandTransactionTest.cpp)
@@ -106,7 +106,7 @@ target_include_directories(CommandTransactionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME CommandTransactionTest COMMAND CommandTransactionTest)
-set_tests_properties(CommandTransactionTest PROPERTIES LABELS "commands;phase2")
+set_tests_properties(CommandTransactionTest PROPERTIES LABELS "commands;phase2;contract:application")
 
 # CommandRegistry Parse Safety Test (regression for #197)
 add_executable(CommandRegistryParseSafetyTest Commands/CommandRegistryParseSafetyTest.cpp)
@@ -115,7 +115,7 @@ target_include_directories(CommandRegistryParseSafetyTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME CommandRegistryParseSafetyTest COMMAND CommandRegistryParseSafetyTest)
-set_tests_properties(CommandRegistryParseSafetyTest PROPERTIES LABELS "commands;regression")
+set_tests_properties(CommandRegistryParseSafetyTest PROPERTIES LABELS "commands;regression;contract:application")
 
 # MuseService — the structured JSON surface agents drive Aestra through.
 add_executable(DeleteTrackUndoTest Commands/DeleteTrackUndoTest.cpp)
@@ -125,7 +125,7 @@ target_include_directories(DeleteTrackUndoTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME DeleteTrackUndoTest COMMAND DeleteTrackUndoTest)
-set_tests_properties(DeleteTrackUndoTest PROPERTIES LABELS "commands;regression")
+set_tests_properties(DeleteTrackUndoTest PROPERTIES LABELS "commands;regression;contract:application")
 
 # --- Muse surface ------------------------------------------------------------
 # The JSON verb surface agents drive Aestra through, and its clients.
@@ -138,7 +138,7 @@ target_include_directories(MuseServiceTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MuseServiceTest COMMAND MuseServiceTest)
-set_tests_properties(MuseServiceTest PROPERTIES LABELS "commands;muse")
+set_tests_properties(MuseServiceTest PROPERTIES LABELS "commands;muse;contract:application")
 
 add_executable(MuseCliRequestTest Commands/MuseCliRequestTest.cpp)
 target_include_directories(MuseCliRequestTest PRIVATE
@@ -146,7 +146,7 @@ target_include_directories(MuseCliRequestTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MuseCliRequestTest COMMAND MuseCliRequestTest)
-set_tests_properties(MuseCliRequestTest PROPERTIES LABELS "commands;muse")
+set_tests_properties(MuseCliRequestTest PROPERTIES LABELS "commands;muse;contract:application")
 
 add_executable(ProjectLoadReportTest
     Commands/ProjectLoadReportTest.cpp
@@ -173,7 +173,7 @@ target_compile_definitions(ProjectLoadReportTest PRIVATE
     AESTRA_PROJECT_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/Fixtures/ProjectFormat"
 )
 add_test(NAME ProjectLoadReportTest COMMAND ProjectLoadReportTest)
-set_tests_properties(ProjectLoadReportTest PROPERTIES LABELS "commands;muse;project;serialization")
+set_tests_properties(ProjectLoadReportTest PROPERTIES LABELS "commands;muse;project;serialization;contract:application")
 
 add_executable(RoutingGraphTest Commands/RoutingGraphTest.cpp)
 target_link_libraries(RoutingGraphTest PRIVATE AestraAudioCore)
@@ -182,7 +182,7 @@ target_include_directories(RoutingGraphTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME RoutingGraphTest COMMAND RoutingGraphTest)
-set_tests_properties(RoutingGraphTest PROPERTIES LABELS "commands;muse;routing")
+set_tests_properties(RoutingGraphTest PROPERTIES LABELS "commands;muse;routing;contract:application")
 
 add_executable(LatencyReportTest Commands/LatencyReportTest.cpp)
 target_link_libraries(LatencyReportTest PRIVATE AestraAudioCore)
@@ -192,7 +192,7 @@ target_include_directories(LatencyReportTest PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/Headless
 )
 add_test(NAME LatencyReportTest COMMAND LatencyReportTest)
-set_tests_properties(LatencyReportTest PROPERTIES LABELS "commands;muse;latency;pdc")
+set_tests_properties(LatencyReportTest PROPERTIES LABELS "commands;muse;latency;pdc;contract:application")
 
 # --- Host capabilities -------------------------------------------------------
 # The seam the application registers settings./view./browser. verbs into.
@@ -205,7 +205,7 @@ target_include_directories(HostVerbRegistryTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME HostVerbRegistryTest COMMAND HostVerbRegistryTest)
-set_tests_properties(HostVerbRegistryTest PROPERTIES LABELS "commands;muse")
+set_tests_properties(HostVerbRegistryTest PROPERTIES LABELS "commands;muse;contract:application")
 
 add_executable(MuseSocketServerTest Commands/MuseSocketServerTest.cpp)
 target_link_libraries(MuseSocketServerTest PRIVATE AestraAudioCore)
@@ -215,7 +215,7 @@ target_include_directories(MuseSocketServerTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME MuseSocketServerTest COMMAND MuseSocketServerTest)
-set_tests_properties(MuseSocketServerTest PROPERTIES LABELS "commands;muse")
+set_tests_properties(MuseSocketServerTest PROPERTIES LABELS "commands;muse;contract:application")
 
 if(TARGET MuseAgentCore)
     add_executable(MuseAgentLoopTest Commands/MuseAgentLoopTest.cpp)
@@ -226,7 +226,7 @@ if(TARGET MuseAgentCore)
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME MuseAgentLoopTest COMMAND MuseAgentLoopTest)
-    set_tests_properties(MuseAgentLoopTest PROPERTIES LABELS "commands;muse")
+    set_tests_properties(MuseAgentLoopTest PROPERTIES LABELS "commands;muse;contract:application")
 endif()
 
 # Rumble state and migration are deterministic pure-logic coverage. Keep this in
@@ -308,7 +308,7 @@ if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Commands/MuseC
         ${CMAKE_SOURCE_DIR}/AestraCore/include
     )
     add_test(NAME MuseClipRoundTripTest COMMAND MuseClipRoundTripTest)
-    set_tests_properties(MuseClipRoundTripTest PROPERTIES LABELS "commands;muse;clip;roundtrip")
+    set_tests_properties(MuseClipRoundTripTest PROPERTIES LABELS "commands;muse;clip;roundtrip;contract:application")
 endif()
 
 if(TARGET AestraAudioCore AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/ClipRenderCharacterizationTest.cpp")

--- a/Tests/cmake/ProjectTests.cmake
+++ b/Tests/cmake/ProjectTests.cmake
@@ -23,7 +23,7 @@ target_include_directories(DropTransactionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME DropTransactionTest COMMAND DropTransactionTest)
-set_tests_properties(DropTransactionTest PROPERTIES LABELS "audio;commands;project")
+set_tests_properties(DropTransactionTest PROPERTIES LABELS "audio;commands;project;contract:application")
 
 # Cancelled-drag history regression test (#551)
 add_executable(CancelledDragHistoryTest AestraAudio/CancelledDragHistoryTest.cpp)
@@ -33,7 +33,7 @@ target_include_directories(CancelledDragHistoryTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME CancelledDragHistoryTest COMMAND CancelledDragHistoryTest)
-set_tests_properties(CancelledDragHistoryTest PROPERTIES LABELS "audio;commands;project")
+set_tests_properties(CancelledDragHistoryTest PROPERTIES LABELS "audio;commands;project;contract:application")
 
 # Project dirty-state integrity regression test (#551)
 add_executable(ProjectDirtyStateTest AestraAudio/ProjectDirtyStateTest.cpp)
@@ -94,7 +94,7 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/Guards/verify_project_migration_lifecycle.cmake
 )
 set_tests_properties(ProjectMigrationLifecycleGuardTest PROPERTIES
-    LABELS "project;migration;compatibility;guard"
+    LABELS "project;migration;compatibility;guard;contract:durability"
 )
 
 add_test(NAME ProjectFixtureImmutabilityTest
@@ -125,7 +125,7 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/Guards/verify_crash_flag_shutdown_order.cmake
 )
 set_tests_properties(CrashFlagShutdownOrderGuardTest PROPERTIES
-    LABELS "app;recovery;guard"
+    LABELS "app;recovery;guard;contract:durability"
 )
 
 add_test(
@@ -135,7 +135,7 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/Guards/verify_project_load_report_lifecycle.cmake
 )
 set_tests_properties(ProjectLoadReportLifecycleGuardTest PROPERTIES
-    LABELS "app;project;muse;recovery;guard"
+    LABELS "app;project;muse;recovery;guard;contract:durability"
 )
 
 # SourceManager revision counter — the change signal TrackManagerUI uses to
@@ -147,4 +147,4 @@ target_include_directories(SourceManagerRevisionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME SourceManagerRevisionTest COMMAND SourceManagerRevisionTest)
-set_tests_properties(SourceManagerRevisionTest PROPERTIES LABELS "audio;waveform")
+set_tests_properties(SourceManagerRevisionTest PROPERTIES LABELS "audio;waveform;contract:application")


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Final classification pass. 77 cases receive a contract; exactly one registered case remains uncontracted **by ruling**.

| Contract | Cases |
| --- | ---: |
| `contract:application` | 60 |
| `contract:core` | 9 |
| `contract:audio` | 4 |
| `contract:durability` | 3 |
| `contract:plugins` | 1 |

## Completion condition

```text
243 registered cases
242 with exactly one contract:*
  1 uncontracted: AestraFilterBench
  0 role:benchmark labels
  0 selectors, workflows or test bodies changed
```

All five verified. `AestraFilterBench` is **completely untouched** — no contract label and no role label. Adding only the role here would create a temporary one-key exemption; the standalone T3 change establishes the role and its allowlist membership atomically.

## The five previously-unread cases

Decided from their failure paths, per the stated boundaries:

| Test | Contract | What makes it fail |
| --- | --- | --- |
| `AestraAudioCallbackTest` | `core` | Three hard failures: `initialize()`, `openStream()`, `startStream()` — device and stream lifecycle. The 10 ms latency check prints a **warning**, it does not fail |
| `AestraWaveformCacheTest` | `audio` | Mono/stereo peak correctness, LOD RMS aggregation, NaN/Inf sanitisation, silent and asymmetric waveforms — the representation must reflect decoded samples |
| `AestraWaveformLockTest` | `application` | Fails when max latency exceeds 5 ms with *"UI would stutter"*. UI/audio coordination; it never asserts the audio callback acquires or waits on a lock |
| `AestraHeadlessExportEndToEnd` | `audio` | The driver validates a **peak-level report against silence**; file existence and size are setup for that check |
| `AestraHeadlessExportRejectsBadArgs` | `application` | `WILL_FAIL TRUE` on `--duration nope` — argument handling and exit status only |

`AestraWaveformLockTest` is the one worth a second look: it measures a lock-latency bound, which reads as realtime until you notice the bound is on the **UI** side and the failure text says so.

## Verification

Five configurations (`HEADLESS_ONLY` × `RUNTIME_TESTS` × `EXPERIMENTAL_TESTS`, `CORE_MODE=ON`):

| Configuration | Cases | Contracted | Uncontracted |
| --- | ---: | ---: | ---: |
| `HL=ON rt=OFF ex=OFF` | 215 | **215** | 0 |
| `HL=ON rt=OFF ex=ON` | 221 | 220 | 1 |
| `HL=ON rt=ON ex=OFF` | 221 | **221** | 0 |
| `HL=ON rt=ON ex=ON` | 227 | 226 | 1 |
| `HL=OFF` maximal | 243 | **242** | 1 |

- Census 243 → **243**; names and membership identical.
- **Exactly 77** case-level contract additions; **no removals**.
- No case carries multiple or unknown contracts.
- Maximal still **equals** the measured union; classification stable across all five (0 differ).
- Every changed line in the diff is a `LABELS` line — verified by filtering the diff.

The default configuration is already at **215 of 215**: `AestraFilterBench` only registers when `EXPERIMENTAL_TESTS=ON`, so the benchmark exception affects no CI lane today.

## Contract distribution, complete

| Contract | Total |
| --- | ---: |
| `contract:audio` | 81 |
| `contract:application` | 61 |
| `contract:security` | 29 |
| `contract:durability` | 26 |
| `contract:core` | 17 |
| `contract:plugins` | 15 |
| `contract:realtime` | 13 |
| **Total** | **242** |

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**No execution risk.** CTest labels are metadata; nothing is added, removed, renamed, skipped or reordered, and no selector reads `contract:*` yet.

**What this does not do.** It does not enable the coverage guard, does not create `role:benchmark`, and does not replace the three hardcoded `Sec*` name lists in `ci.yml`. Those are separate changes in a deliberate order.

**Rollback:** revert the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added 77 contract labels across registered tests to complete the contract classification migration.
- Preserved all 243 registered cases without changing selectors, workflows, test bodies, or registrations.
- Classified 242 cases across five configurations. Left `AestraFilterBench` uncontracted by ruling.
- Verified that no cases have multiple or unknown contracts, benchmark role labels, or CI name-list changes.
- Classified the five previously unread cases from their failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->