### PR TITLE
test: represent the benchmark exception through two independent keys

### DIFF
--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -174,7 +174,15 @@ target_include_directories(AestraFilterBench PRIVATE
 )
 if(AESTRA_ENABLE_EXPERIMENTAL_TESTS)
     add_test(NAME AestraFilterBench COMMAND AestraFilterBench)
-    set_tests_properties(AestraFilterBench PROPERTIES LABELS "audio;benchmark;experimental")
+    # No contract label. This case reports per-callback cost and asserts no
+    # threshold, so it cannot fail on a regression — calling it
+    # contract:realtime would claim a gate that does not exist.
+    #
+    # The exemption needs two independent keys: this role, and an exact-name
+    # entry in Tests/policy/benchmark-allowlist.txt. Neither alone exempts a
+    # case, so adding this label to a failing test buys nothing without a
+    # separate change to the allowlist.
+    set_tests_properties(AestraFilterBench PROPERTIES LABELS "audio;benchmark;experimental;role:benchmark")
 else()
     message(STATUS "AestraFilterBench built but not registered (set AESTRA_ENABLE_EXPERIMENTAL_TESTS=ON to enable)")
 endif()

--- a/Tests/policy/benchmark-allowlist.txt
+++ b/Tests/policy/benchmark-allowlist.txt
@@ -1,0 +1,1 @@
+AestraFilterBench


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Represent the approved benchmark exception through **two independent keys**.

| File | Change |
| --- | --- |
| `Tests/cmake/PluginTests.cmake` | `AestraFilterBench` gains `role:benchmark` |
| `Tests/policy/benchmark-allowlist.txt` | new file, one line: `AestraFilterBench` |

`AestraFilterBench` reports per-callback cost and asserts no threshold, so it cannot fail on a regression. It therefore carries **no contract label** — naming it `contract:realtime` would claim a gate that does not exist.

## Why two keys

Neither key alone exempts a case. Adding `role:benchmark` to a failing test buys nothing without a separate change to the allowlist. That is the property which stops the role becoming a laundering route, and it is why both keys land together — shipping only the label would leave a temporary one-key exemption on `develop`.

## Why the allowlist is not CMake

CMake is registration and build configuration. This file is an **exception authority**. The later guard must be able to read it without configuring a build, choosing a test configuration, or interpreting executable CMake.

It is deliberately **not** `include()`d anywhere. The only CMake mention of it is a comment.

Format is narrow on purpose:

- UTF-8 text, one exact CTest name per line
- No globs, regexes, prefixes, or CMake variables
- No inline comments
- No duplicate entries
- Only the final newline is ignored; meaningful leading or trailing whitespace is not silently trimmed
- Empty lines are not accepted syntax — the guard should fail on them

Rationale is kept here and in Internals, never in the authority file, so the parser never acquires comment syntax, normalisation rules, or other interpretation surface it would then have to keep honouring.

The file is exactly 18 bytes:

```
0000000   A   e   s   t   r   a   F   i   l   t   e   r   B   e   n   c
0000020   h  \n
```

## Proof — two independently enumerated sets

| | |
| --- | --- |
| CTest cases carrying `role:benchmark` | `{AestraFilterBench}` |
| Exact lines in the allowlist file | `{AestraFilterBench}` |
| **Equal, and equal to the expected singleton** | ✅ |

Additionally:

| Check | Result |
| --- | ---: |
| Contract labels on `AestraFilterBench` | **0** |
| Other `role:*` carriers | **0** |
| Allowlist entries absent from the CTest census | **0** |
| `role:benchmark` cases absent from the allowlist | **0** |
| Duplicate entries | **0** |
| Entries with leading/trailing whitespace | **0** |

## Census across five configurations

| Configuration | Cases | `role:benchmark` | Uncontracted |
| --- | ---: | ---: | ---: |
| `HL=ON rt=OFF ex=OFF` | 215 | 0 | 0 |
| `HL=ON rt=OFF ex=ON` | 221 | 1 | 1 |
| `HL=ON rt=ON ex=OFF` | 221 | 0 | 0 |
| `HL=ON rt=ON ex=ON` | 227 | 1 | 1 |
| `HL=OFF` maximal | **243** | **1** | **1** |

In every configuration the uncontracted count and the `role:benchmark` count are the **same number** — because they are the same case. Where the benchmark is not registered, both are zero.

- Names and membership **identical** to `develop`.
- **Exactly one** label delta: `AestraFilterBench`.
- No label removed anywhere.
- Maximal still **equals** the measured union (243).
- Classification stable across all five (0 differ).

## What this does not do

> The repository now represents the approved benchmark exception through two independent keys. **No gate yet prevents either key from drifting**; the following coverage-guard PR introduces that enforcement.

No selector, workflow, test body or registration condition changes. No CI lane begins selecting or excluding benchmarks. Nothing that could merge yesterday is blocked today.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**No execution risk.** One CTest label added; one text file added and read by nothing yet.

**The drift window is real and stated.** Until the coverage guard lands, either key can be edited without the other. That window is accepted deliberately: the alternative is combining the exception and the gate that judges it into one change, where the gate would be validating a state introduced by the same commit.

**Rollback:** revert the commit. The label and the file disappear together.
