### PR TITLE
ci: enforce test contract coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,6 +668,19 @@ jobs:
       - name: Verifier self-tests
         run: python3 scripts/ci/test-verify-test-contracts.py
 
+      # The maximal configuration enables UI, which pulls in AestraLicense and
+      # its pkg_check_modules(libsodium). The four headless configurations do
+      # not, which is why the first run of this job configured four of five and
+      # then failed — a gap a local dry-run cannot reproduce on a developer
+      # machine that already has the library. Same set as build-linux-app
+      # installs, so the two jobs cannot drift into disagreeing about what a
+      # configurable tree needs.
+      - name: Install configure-time dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libasound2-dev libgl1-mesa-dev \
+            libx11-dev libsodium-dev libsecret-1-dev libsdl2-dev libfreetype-dev
+
       # Configure only. The census is a property of a *configured* tree, and
       # nothing here needs a compiled binary — which is what keeps this job
       # minutes rather than tens of minutes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,79 @@ jobs:
 
           exit "${fail}"
 
+  contract-coverage:
+    name: Test contract coverage
+    runs-on: ubuntu-latest
+    # No `if:`, no `continue-on-error`, no `needs:`. A required context must
+    # always report. Gating this on a change classifier, or on another job whose
+    # failure could skip it, would make it reportable-sometimes — and GitHub
+    # counts a skipped required job as successful, so "sometimes" degrades to
+    # false green rather than to a block.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          persist-credentials: false
+
+      # Level 1: the verifier in isolation. A green baseline plus every
+      # prohibited state, each asserted to be rejected with its specific
+      # diagnostic — because a crash also exits non-zero, and exit-code-only
+      # tests would let a refactor turn a precise rejection into a stack trace
+      # and still look covered. Run BEFORE the real census, so a broken verifier
+      # is reported as a broken verifier rather than as a policy violation.
+      - name: Verifier self-tests
+        run: python3 scripts/ci/test-verify-test-contracts.py
+
+      # Configure only. The census is a property of a *configured* tree, and
+      # nothing here needs a compiled binary — which is what keeps this job
+      # minutes rather than tens of minutes.
+      - name: Configure the five declared configurations
+        run: |
+          set -euo pipefail
+          for rt in OFF ON; do
+            for ex in OFF ON; do
+              cmake -S . -B "build-hlON-rt${rt}-ex${ex}" \
+                -DAestra_CORE_MODE=ON \
+                -DAESTRA_HEADLESS_ONLY=ON \
+                -DAESTRA_ENABLE_TESTS=ON \
+                -DAESTRA_ENABLE_RUNTIME_TESTS=$rt \
+                -DAESTRA_ENABLE_EXPERIMENTAL_TESTS=$ex \
+                -DCMAKE_BUILD_TYPE=Release > /dev/null
+            done
+          done
+          cmake -S . -B build-maximal \
+            -DAestra_CORE_MODE=ON \
+            -DAESTRA_HEADLESS_ONLY=OFF \
+            -DAESTRA_ENABLE_UI=ON \
+            -DAESTRA_ENABLE_TESTS=ON \
+            -DAESTRA_ENABLE_RUNTIME_TESTS=ON \
+            -DAESTRA_ENABLE_EXPERIMENTAL_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=Release > /dev/null
+
+      - name: Enumerate each configuration
+        run: |
+          set -euo pipefail
+          for d in build-hlON-rtOFF-exOFF build-hlON-rtOFF-exON \
+                   build-hlON-rtON-exOFF build-hlON-rtON-exON build-maximal; do
+            ctest --test-dir "$d" --show-only=json-v1 > "census-$d.json"
+          done
+
+      # The maximal configuration must equal the union of the five. That is an
+      # observed property of this tree, not a law, so the verifier re-proves it
+      # on every run rather than trusting it.
+      - name: Verify test contract coverage
+        run: |
+          python3 scripts/ci/verify-test-contracts.py \
+            --allowlist Tests/policy/benchmark-allowlist.txt \
+            --maximal maximal \
+            --census "hl-on-rtOFF-exOFF=census-build-hlON-rtOFF-exOFF.json" \
+            --census "hl-on-rtOFF-exON=census-build-hlON-rtOFF-exON.json" \
+            --census "hl-on-rtON-exOFF=census-build-hlON-rtON-exOFF.json" \
+            --census "hl-on-rtON-exON=census-build-hlON-rtON-exON.json" \
+            --census "maximal=census-build-maximal.json"
+
   format-check:
     name: Formatting (advisory)
     runs-on: ubuntu-latest

--- a/scripts/ci/test-verify-test-contracts.py
+++ b/scripts/ci/test-verify-test-contracts.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Mutation tests for verify-test-contracts.py.
+#
+# Every case starts from a synthetic census that PASSES, mutates exactly one
+# thing, and requires that the verifier rejects it with a specific diagnostic.
+#
+# WHY THE DIAGNOSTICS ARE ASSERTED, NOT JUST THE EXIT CODE
+#
+# A verifier that crashes also exits non-zero. Asserting only the exit code
+# would let a future refactor turn a precise rejection into a stack trace and
+# still look covered — the test would pass while the operator lost the one line
+# telling them what to fix. Each case therefore pins a substring of the real
+# message.
+#
+# The baseline is deliberately small and synthetic rather than a copy of the
+# real census. Pinning the real 243-case tree here would make this suite fail
+# every time a test is legitimately added, which is the same freezing mistake
+# the verifier itself refuses to make.
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+FAILURES = []
+PASSES = 0
+
+
+def census_json(tests):
+    """tests: {name: [labels]} -> a CTest --show-only=json-v1 shaped document."""
+    return {
+        "kind": "ctestInfo",
+        "version": {"major": 1, "minor": 0},
+        "tests": [
+            {"name": name, "properties": [{"name": "LABELS", "value": labels}]}
+            for name, labels in tests.items()
+        ],
+    }
+
+
+BASE_SMALL = {
+    "AlphaTest": ["unit", "contract:core"],
+    "BetaTest": ["audio", "contract:audio"],
+}
+BASE_MAXIMAL = {
+    "AlphaTest": ["unit", "contract:core"],
+    "BetaTest": ["audio", "contract:audio"],
+    "GammaTest": ["ui", "contract:application"],
+    "BenchOne": ["benchmark", "role:benchmark"],
+}
+BASE_ALLOWLIST = "BenchOne\n"
+
+
+VERIFIER = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "verify-test-contracts.py"
+)
+
+
+def run_case(name, small, maximal, allowlist_text, expect_ok, expect_substring=None,
+             corrupt_census=None, allowlist_bytes=None, raw_census=None):
+    """Exercise the verifier through its real CLI.
+
+    Deliberately not through the imported functions: invoking the script proves
+    argument handling, file decoding, diagnostic rendering and exit status
+    together. A verifier whose internals are correct but whose CLI mis-parses
+    --census would pass a function-level suite and fail in CI.
+    """
+    global PASSES
+    with tempfile.TemporaryDirectory() as tmp:
+        allow = os.path.join(tmp, "allowlist.txt")
+        if allowlist_bytes is not None:
+            with open(allow, "wb") as handle:
+                handle.write(allowlist_bytes)
+        else:
+            with open(allow, "w", encoding="utf-8") as handle:
+                handle.write(allowlist_text)
+
+        specs = []
+        for label, tests in (("small", small), ("maximal", maximal)):
+            path = os.path.join(tmp, f"{label}.json")
+            with open(path, "w", encoding="utf-8") as handle:
+                if corrupt_census == label:
+                    handle.write("{ this is not json")
+                elif raw_census and label in raw_census:
+                    json.dump(raw_census[label], handle)
+                else:
+                    json.dump(census_json(tests), handle)
+            specs.append(f"--census={label}={path}")
+
+        proc = subprocess.run(
+            [sys.executable, VERIFIER, f"--allowlist={allow}", "--maximal=maximal"] + specs,
+            capture_output=True,
+            text=True,
+        )
+        message = proc.stdout + proc.stderr
+        ok = proc.returncode == 0
+
+    if expect_ok:
+        if ok:
+            PASSES += 1
+            return
+        FAILURES.append(f"{name}: expected PASS, got failure(s):\n    {message}")
+        return
+
+    if ok:
+        FAILURES.append(f"{name}: expected FAILURE, but the census was accepted")
+        return
+    if expect_substring and expect_substring not in message:
+        FAILURES.append(
+            f"{name}: rejected, but the diagnostic did not mention "
+            f"{expect_substring!r}\n    got: {message}"
+        )
+        return
+    PASSES += 1
+
+
+def mutate(base, **changes):
+    out = {k: list(v) for k, v in base.items()}
+    out.update({k: v for k, v in changes.items() if v is not None})
+    for k, v in changes.items():
+        if v is None:
+            out.pop(k, None)
+    return out
+
+
+# --- 0. baseline -----------------------------------------------------------
+
+run_case("baseline valid census", BASE_SMALL, BASE_MAXIMAL, BASE_ALLOWLIST, expect_ok=True)
+
+# --- 1. normal test with zero contracts ------------------------------------
+
+run_case(
+    "1 normal case with zero contracts",
+    mutate(BASE_SMALL, AlphaTest=["unit"]),
+    mutate(BASE_MAXIMAL, AlphaTest=["unit"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="AlphaTest: has no contract label",
+)
+
+# --- 2. normal test with multiple contracts --------------------------------
+
+run_case(
+    "2 normal case with two contracts",
+    mutate(BASE_SMALL, AlphaTest=["contract:core", "contract:audio"]),
+    mutate(BASE_MAXIMAL, AlphaTest=["contract:core", "contract:audio"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="expected exactly one",
+)
+
+# --- 3. unknown contract ---------------------------------------------------
+
+run_case(
+    "3 unknown contract label",
+    mutate(BASE_SMALL, AlphaTest=["contract:teapot"]),
+    mutate(BASE_MAXIMAL, AlphaTest=["contract:teapot"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="unknown contract label",
+)
+
+# --- 4. unknown role -------------------------------------------------------
+
+run_case(
+    "4 unknown role label",
+    mutate(BASE_SMALL, AlphaTest=["contract:core", "role:probe"]),
+    mutate(BASE_MAXIMAL, AlphaTest=["contract:core", "role:probe"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="unknown role label",
+)
+
+# --- 5. role:benchmark without allowlist membership ------------------------
+
+run_case(
+    "5 role:benchmark without allowlist membership",
+    BASE_SMALL,
+    mutate(BASE_MAXIMAL, GammaTest=["role:benchmark"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="not in the benchmark allowlist",
+)
+
+# --- 6. allowlist membership without role:benchmark ------------------------
+
+run_case(
+    "6 allowlisted but no role:benchmark",
+    BASE_SMALL,
+    mutate(BASE_MAXIMAL, BenchOne=["benchmark"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="does not carry role:benchmark",
+)
+
+# --- 7. benchmark carrying a contract --------------------------------------
+
+run_case(
+    "7 benchmark carrying a contract",
+    BASE_SMALL,
+    mutate(BASE_MAXIMAL, BenchOne=["role:benchmark", "contract:realtime"]),
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="must carry no contract",
+)
+
+# --- 8. stale allowlist entry ----------------------------------------------
+
+run_case(
+    "8 stale allowlist entry absent from the union",
+    BASE_SMALL,
+    BASE_MAXIMAL,
+    "BenchOne\nGhostBench\n",
+    expect_ok=False,
+    expect_substring="allowlist entries absent from the measured union",
+)
+
+# --- 9. allowlist format ---------------------------------------------------
+
+run_case(
+    "9a duplicate allowlist entry",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\nBenchOne\n",
+    expect_ok=False, expect_substring="duplicates",
+)
+run_case(
+    "9b blank allowlist line",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\n\n",
+    expect_ok=False, expect_substring="is blank",
+)
+run_case(
+    "9c whitespace-padded allowlist entry",
+    BASE_SMALL, BASE_MAXIMAL, "  BenchOne\n",
+    expect_ok=False, expect_substring="leading or trailing whitespace",
+)
+run_case(
+    "9d carriage return in allowlist",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\r\n",
+    expect_ok=False, expect_substring="carriage return",
+)
+run_case(
+    "9e allowlist without terminal newline",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne",
+    expect_ok=False, expect_substring="does not end with a newline",
+)
+run_case(
+    "9f allowlist not valid UTF-8",
+    BASE_SMALL, BASE_MAXIMAL, None,
+    expect_ok=False, expect_substring="not valid UTF-8",
+    allowlist_bytes=b"\xff\xfe\x00Bench\n",
+)
+
+# --- 10. classification drift between configurations -----------------------
+
+run_case(
+    "10 classification differs between configurations",
+    mutate(BASE_SMALL, BetaTest=["audio", "contract:realtime"]),
+    BASE_MAXIMAL,
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="policy identity differs between configurations",
+)
+
+# --- 11. maximal is not the union ------------------------------------------
+
+run_case(
+    "11 maximal configuration is not the union",
+    {**BASE_SMALL, "OrphanTest": ["contract:core"]},
+    BASE_MAXIMAL,
+    BASE_ALLOWLIST,
+    expect_ok=False,
+    expect_substring="is not the union",
+)
+
+# --- 12. malformed census json ---------------------------------------------
+
+run_case(
+    "12 malformed CTest JSON",
+    BASE_SMALL, BASE_MAXIMAL, BASE_ALLOWLIST,
+    expect_ok=False, expect_substring="not valid JSON",
+    corrupt_census="small",
+)
+
+# --- 10b. descriptive drift is ALLOWED -------------------------------------
+#
+# Pins the narrowing: only contract:* and role:* form the policy identity.
+# A descriptive label may legitimately differ by lane, and the guard must not
+# enforce a rule nobody agreed to.
+
+run_case(
+    "10b descriptive-only drift is accepted",
+    mutate(BASE_SMALL, BetaTest=["audio", "headless", "contract:audio"]),
+    BASE_MAXIMAL,
+    BASE_ALLOWLIST,
+    expect_ok=True,
+)
+
+# --- 13. duplicate test name in one census ---------------------------------
+#
+# Enumeration must diagnose duplicates BEFORE the list becomes a set. Collapsing
+# them would let two registrations of one name with different contracts appear
+# as a single valid case, with whichever came last winning.
+
+run_case(
+    "13 duplicate test name in a census",
+    BASE_SMALL, BASE_MAXIMAL, BASE_ALLOWLIST,
+    expect_ok=False, expect_substring="more than once",
+    raw_census={"small": {"tests": [
+        {"name": "AlphaTest", "properties": [{"name": "LABELS", "value": ["contract:core"]}]},
+        {"name": "AlphaTest", "properties": [{"name": "LABELS", "value": ["contract:audio"]}]},
+    ]}},
+)
+
+# --- 14. terminal-LF handling is exactly one element -----------------------
+
+run_case(
+    "14a exactly one terminal LF is accepted",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\n", expect_ok=True,
+)
+run_case(
+    "14b a second trailing LF is rejected",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\n\n",
+    expect_ok=False, expect_substring="line 2 is blank",
+)
+run_case(
+    "14c an internal blank line is rejected",
+    BASE_SMALL, BASE_MAXIMAL, "BenchOne\n\nOther\n",
+    expect_ok=False, expect_substring="line 2 is blank",
+)
+
+# --- report ----------------------------------------------------------------
+
+print(f"verify-test-contracts: {PASSES} assertion(s) passed")
+if FAILURES:
+    for failure in FAILURES:
+        print(f"::error::{failure}")
+    print(f"\n{len(FAILURES)} mutation test(s) FAILED.")
+    sys.exit(1)
+print("All mutation tests passed.")

--- a/scripts/ci/test-verify-test-contracts.py
+++ b/scripts/ci/test-verify-test-contracts.py
@@ -60,7 +60,7 @@ VERIFIER = os.path.join(
 
 
 def run_case(name, small, maximal, allowlist_text, expect_ok, expect_substring=None,
-             corrupt_census=None, allowlist_bytes=None, raw_census=None):
+             corrupt_census=None, allowlist_bytes=None, raw_census=None, extra_specs=None):
     """Exercise the verifier through its real CLI.
 
     Deliberately not through the imported functions: invoking the script proves
@@ -89,6 +89,9 @@ def run_case(name, small, maximal, allowlist_text, expect_ok, expect_substring=N
                 else:
                     json.dump(census_json(tests), handle)
             specs.append(f"--census={label}={path}")
+
+        for label, source in (extra_specs or []):
+            specs.append(f"--census={label}={os.path.join(tmp, source)}")
 
         proc = subprocess.run(
             [sys.executable, VERIFIER, f"--allowlist={allow}", "--maximal=maximal"] + specs,
@@ -328,6 +331,19 @@ run_case(
     "14c an internal blank line is rejected",
     BASE_SMALL, BASE_MAXIMAL, "BenchOne\n\nOther\n",
     expect_ok=False, expect_substring="line 2 is blank",
+)
+
+# --- 15. repeated --census label -------------------------------------------
+#
+# The same silent-collapse class as case 13, one level up: a repeated label
+# would overwrite the earlier configuration, removing it from the comparison
+# while every remaining check still passed.
+
+run_case(
+    "15 repeated --census label",
+    BASE_SMALL, BASE_MAXIMAL, BASE_ALLOWLIST,
+    expect_ok=False, expect_substring="was given more than once",
+    extra_specs=[("maximal", "small.json")],
 )
 
 # --- report ----------------------------------------------------------------

--- a/scripts/ci/verify-test-contracts.py
+++ b/scripts/ci/verify-test-contracts.py
@@ -320,11 +320,19 @@ def run(allowlist_path, maximal_label, census_args):
 
     allowlist = parse_allowlist(allowlist_path)
 
+    # A repeated --census label is diagnosed rather than silently overwritten.
+    # Same defect class as a duplicate test name inside one census: the second
+    # value would replace the first, one configuration would vanish from the
+    # comparison, and every remaining check would still pass. A coverage
+    # authority must not contain a silent-collapse path even where no caller
+    # currently exercises it.
     censuses = {}
     for spec in census_args:
         if "=" not in spec:
             raise PolicyError(f"--census expects <label>=<path>, got {spec!r}")
         label, path = spec.split("=", 1)
+        if label in censuses:
+            raise PolicyError(f"--census label {label!r} was given more than once")
         censuses[label] = parse_census(label, path)
 
     if not censuses:

--- a/scripts/ci/verify-test-contracts.py
+++ b/scripts/ci/verify-test-contracts.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#
+# Verify that every registered CTest case carries a valid policy identity.
+#
+# Usage:
+#   verify-test-contracts.py --allowlist <file> --maximal <label>
+#                            --census <label>=<ctest-json> [--census ...]
+#
+# Exit: 0 = every configuration satisfies the policy. 1 = it does not.
+#
+# THE CONTRACT
+#
+#   Normal registered case      exactly one known contract:*, and no role:*
+#   Allowlisted benchmark       zero contract:*, and exactly role:benchmark
+#   Anything else               fail
+#
+# The benchmark exemption needs BOTH keys. `role:benchmark` alone does not
+# exempt a case, and an allowlist entry alone does not either. That is the whole
+# point of the two-key design: adding a label to a failing test buys nothing
+# without a separate, reviewable change to the authority file.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO
+#
+# It does not hardcode today's census — not 243 cases, not 242 contracts, not
+# the current distribution. Those numbers prove one migration; baking them in
+# would block correctly classified tests from ever being added. The allowlist
+# decides the approved benchmark set; the structural rules decide whether a
+# census is valid. A guard that freezes a number stops being a policy and
+# becomes a snapshot.
+#
+# It reads enumerated CTest JSON, never CMake source. Parsing lost to
+# enumerating three times during the classification migration: tests live in ten
+# registration files, registration is conditional, and a label can be attached
+# far from the add_test() that created the case.
+
+import argparse
+import json
+import sys
+
+KNOWN_CONTRACTS = frozenset(
+    {
+        "contract:security",
+        "contract:durability",
+        "contract:audio",
+        "contract:realtime",
+        "contract:plugins",
+        "contract:application",
+        "contract:core",
+    }
+)
+
+KNOWN_ROLES = frozenset({"role:benchmark"})
+
+CONTRACT_PREFIX = "contract:"
+ROLE_PREFIX = "role:"
+
+
+class PolicyError(Exception):
+    """A diagnosable violation. Message is the operator-facing diagnostic."""
+
+
+# --- allowlist -------------------------------------------------------------
+#
+# The format is narrow on purpose. Every tolerance a parser grants is a
+# tolerance the authority file has to keep honouring, and an authority that
+# accepts comments today accepts `# temporarily exempt everything` tomorrow.
+
+
+def parse_allowlist(path):
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    except OSError as exc:
+        raise PolicyError(f"allowlist unreadable: {path}: {exc}") from exc
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PolicyError(f"allowlist is not valid UTF-8: {path}: {exc}") from exc
+
+    if "\r" in text:
+        raise PolicyError(f"allowlist contains a carriage return: {path}")
+
+    if text and not text.endswith("\n"):
+        raise PolicyError(f"allowlist does not end with a newline: {path}")
+
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines = lines[:-1]  # only the terminal LF is ignored
+
+    entries = []
+    seen = set()
+    for number, line in enumerate(lines, start=1):
+        if line == "":
+            raise PolicyError(f"allowlist line {number} is blank: {path}")
+        if line != line.strip():
+            raise PolicyError(
+                f"allowlist line {number} has leading or trailing whitespace: {line!r}"
+            )
+        if line in seen:
+            raise PolicyError(f"allowlist line {number} duplicates {line!r}")
+        seen.add(line)
+        entries.append(line)
+
+    return entries
+
+
+# --- census ----------------------------------------------------------------
+
+
+def parse_census(label, path):
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            document = json.load(handle)
+    except OSError as exc:
+        raise PolicyError(f"[{label}] census unreadable: {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"[{label}] census is not valid JSON: {path}: {exc}") from exc
+
+    if not isinstance(document, dict) or "tests" not in document:
+        raise PolicyError(f"[{label}] census has no 'tests' array: {path}")
+
+    tests = document["tests"]
+    if not isinstance(tests, list):
+        raise PolicyError(f"[{label}] census 'tests' is not an array: {path}")
+
+    # Duplicates are diagnosed BEFORE the list becomes a set. Collapsing them
+    # silently would let a broken registration hide: two add_test() calls with
+    # the same name and different labels would produce one entry, with whichever
+    # came last winning, and the policy would pass while the tree was ambiguous.
+    census = {}
+    for entry in tests:
+        if not isinstance(entry, dict) or "name" not in entry:
+            raise PolicyError(f"[{label}] census contains a test with no name: {path}")
+        name = entry["name"]
+        labels = []
+        for prop in entry.get("properties", []) or []:
+            if isinstance(prop, dict) and prop.get("name") == "LABELS":
+                value = prop.get("value", [])
+                labels = list(value) if isinstance(value, list) else [value]
+        if name in census:
+            raise PolicyError(
+                f"[{label}] census registers {name!r} more than once: {path}"
+            )
+        census[name] = labels
+
+    if not census:
+        raise PolicyError(f"[{label}] census registers no tests: {path}")
+
+    return census
+
+
+# --- per-configuration policy ----------------------------------------------
+
+
+def check_configuration(label, census, allowlist, failures):
+    allowed = set(allowlist)
+
+    for name in sorted(census):
+        labels = census[name]
+        contracts = sorted(l for l in labels if l.startswith(CONTRACT_PREFIX))
+        roles = sorted(l for l in labels if l.startswith(ROLE_PREFIX))
+
+        unknown_contracts = [l for l in contracts if l not in KNOWN_CONTRACTS]
+        if unknown_contracts:
+            failures.append(
+                f"[{label}] {name}: unknown contract label(s) {unknown_contracts}"
+            )
+            continue
+
+        unknown_roles = [l for l in roles if l not in KNOWN_ROLES]
+        if unknown_roles:
+            failures.append(f"[{label}] {name}: unknown role label(s) {unknown_roles}")
+            continue
+
+        is_allowlisted = name in allowed
+        has_benchmark_role = "role:benchmark" in roles
+
+        if is_allowlisted or has_benchmark_role:
+            # THE PER-CONFIGURATION RULE, which is the operative one:
+            #
+            #     benchmark_role_cases(C) == allowlist ∩ registered_cases(C)
+            #
+            # Enforced here as a biconditional on each registered case: a role
+            # carrier must be allowlisted, and a registered allowlist entry must
+            # carry the role. This is what makes an EXPERIMENTAL_TESTS=OFF
+            # configuration correct with *zero* carriers — the benchmark is not
+            # in registered_cases(C), so the intersection is empty and the
+            # equality holds without a special case.
+            #
+            # The global rule in check_across() is a different statement:
+            #
+            #     union(benchmark_role_cases(C)) == allowlist
+            #     allowlist ⊆ union(registered_cases(C))
+            #
+            # which is what rejects a stale entry naming nothing at all.
+            #
+            # Both keys are required. Either one alone is a policy violation,
+            # reported specifically so the fix is obvious.
+            if not is_allowlisted:
+                failures.append(
+                    f"[{label}] {name}: carries role:benchmark but is not in the "
+                    f"benchmark allowlist"
+                )
+                continue
+            if not has_benchmark_role:
+                failures.append(
+                    f"[{label}] {name}: is in the benchmark allowlist but does not "
+                    f"carry role:benchmark"
+                )
+                continue
+            if contracts:
+                failures.append(
+                    f"[{label}] {name}: is an allowlisted benchmark and must carry no "
+                    f"contract, but carries {contracts}"
+                )
+                continue
+            if roles != ["role:benchmark"]:
+                failures.append(
+                    f"[{label}] {name}: allowlisted benchmark must carry exactly "
+                    f"role:benchmark, but carries {roles}"
+                )
+            continue
+
+        if roles:
+            failures.append(f"[{label}] {name}: normal case must carry no role, has {roles}")
+            continue
+        if len(contracts) == 0:
+            failures.append(f"[{label}] {name}: has no contract label")
+            continue
+        if len(contracts) > 1:
+            failures.append(f"[{label}] {name}: has {len(contracts)} contracts {contracts}, expected exactly one")
+
+
+# --- cross-configuration policy --------------------------------------------
+
+
+def check_across(censuses, maximal_label, allowlist, failures):
+    union = set()
+    for census in censuses.values():
+        union |= set(census)
+
+    if maximal_label not in censuses:
+        failures.append(f"maximal configuration {maximal_label!r} was not measured")
+        return
+
+    maximal = set(censuses[maximal_label])
+    if maximal != union:
+        missing = sorted(union - maximal)
+        failures.append(
+            f"maximal configuration {maximal_label!r} is not the union: "
+            f"{len(missing)} case(s) registered elsewhere but not there: {missing[:5]}"
+        )
+
+    # A repeated name must have the same POLICY IDENTITY wherever it is
+    # registered — its contract:* and role:* labels only.
+    #
+    # Descriptive labels are deliberately excluded. They are outside this policy
+    # and may legitimately vary by lane: a case could reasonably carry `headless`
+    # in one configuration and not another. Requiring total label equality would
+    # make the guard enforce a rule nobody agreed to, and would block a
+    # descriptive change that has no bearing on which promise the test protects.
+    for name in sorted(union):
+        seen = {}
+        for label, census in censuses.items():
+            if name in census:
+                identity = tuple(
+                    sorted(
+                        l
+                        for l in census[name]
+                        if l.startswith(CONTRACT_PREFIX) or l.startswith(ROLE_PREFIX)
+                    )
+                )
+                seen.setdefault(identity, []).append(label)
+        if len(seen) > 1:
+            variants = "; ".join(
+                f"{list(v)} -> {list(k)}" for k, v in sorted(seen.items())
+            )
+            failures.append(
+                f"{name}: policy identity differs between configurations: {variants}"
+            )
+
+    # THE GLOBAL RULE:
+    #
+    #     union(benchmark_role_cases(C)) == allowlist
+    #     allowlist ⊆ union(registered_cases(C))
+    #
+    # The per-configuration biconditional in check_configuration() already
+    # guarantees the two keys agree wherever a case is registered. What is left
+    # for the global rule is the case that is registered NOWHERE: an allowlist
+    # entry naming a test that no configuration produces. Nothing per
+    # configuration can see that, because the name never appears.
+    role_carriers = {
+        name
+        for census in censuses.values()
+        for name, labels in census.items()
+        if "role:benchmark" in labels
+    }
+    stale = sorted(name for name in allowlist if name not in union)
+    if stale:
+        failures.append(
+            f"allowlist entries absent from the measured union: {stale}"
+        )
+
+    if role_carriers != set(allowlist) - set(stale):
+        only_role = sorted(role_carriers - set(allowlist))
+        only_list = sorted((set(allowlist) - set(stale)) - role_carriers)
+        failures.append(
+            "benchmark keys disagree across configurations: "
+            f"role:benchmark only = {only_role}, allowlist only = {only_list}"
+        )
+
+
+# --- entry point -----------------------------------------------------------
+
+
+def run(allowlist_path, maximal_label, census_args):
+    failures = []
+
+    allowlist = parse_allowlist(allowlist_path)
+
+    censuses = {}
+    for spec in census_args:
+        if "=" not in spec:
+            raise PolicyError(f"--census expects <label>=<path>, got {spec!r}")
+        label, path = spec.split("=", 1)
+        censuses[label] = parse_census(label, path)
+
+    if not censuses:
+        raise PolicyError("no configurations were measured")
+
+    for label in sorted(censuses):
+        check_configuration(label, censuses[label], allowlist, failures)
+
+    check_across(censuses, maximal_label, allowlist, failures)
+
+    return failures, censuses, allowlist
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Verify test contract coverage.")
+    parser.add_argument("--allowlist", required=True)
+    parser.add_argument("--maximal", required=True)
+    parser.add_argument("--census", action="append", default=[], metavar="LABEL=PATH")
+    args = parser.parse_args(argv)
+
+    try:
+        failures, censuses, allowlist = run(args.allowlist, args.maximal, args.census)
+    except PolicyError as exc:
+        print(f"::error::{exc}")
+        return 1
+
+    for label in sorted(censuses):
+        census = censuses[label]
+        contracted = sum(
+            1 for labels in census.values() if any(l.startswith(CONTRACT_PREFIX) for l in labels)
+        )
+        benchmarks = sum(1 for labels in census.values() if "role:benchmark" in labels)
+        print(f"  {label}: {len(census)} registered, {contracted} contracted, {benchmarks} benchmark")
+
+    print(f"  allowlist: {len(allowlist)} entry(ies)")
+
+    if failures:
+        for failure in failures:
+            print(f"::error::{failure}")
+        print(f"\nTest contract coverage FAILED with {len(failures)} violation(s).")
+        return 1
+
+    print("\nTest contract coverage OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

Adds the gate that reads the classification map. Until now every `contract:*` label was documentation — accurate, arrived at by reading 243 failure paths, but nothing prevented the next test from carrying none.

| File | Purpose |
| --- | --- |
| `scripts/ci/verify-test-contracts.py` | The verifier. Standard library only |
| `scripts/ci/test-verify-test-contracts.py` | 23 mutation assertions, run through the real CLI |
| `.github/workflows/ci.yml` | New job `Test contract coverage` |

## The policy

Per configuration:

```text
normal registered case      exactly one known contract:*, and no role:*
allowlisted benchmark       zero contract:*, and exactly role:benchmark
anything else               fail
```

Two set rules, kept separate because they answer different questions:

```text
per configuration   benchmark_role_cases(C) == allowlist ∩ registered_cases(C)
globally            union(benchmark_role_cases(C)) == allowlist
                    allowlist ⊆ union(registered_cases(C))
```

The per-configuration intersection is the **operative** rule, and it is why an `EXPERIMENTAL_TESTS=OFF` configuration is correct with **zero** carriers rather than needing a special case — the benchmark is not in `registered_cases(C)`, so the intersection is empty and the equality holds. The global rule catches what no single configuration can see: an allowlist entry naming a test that nothing registers.

Cross-configuration drift compares **policy identity only** — `contract:*` and `role:*`. Descriptive labels remain outside this policy and may legitimately vary by lane.

## Four stages of evidence, reported distinctly

| Stage | Result |
| --- | --- |
| **Verifier self-tests** | 23/23 prohibited and accepted states behave correctly |
| **Repository census** | five real configurations satisfy the policy |
| **Existing matrix** | unaffected checks remain green |
| **New guard** | reports green, but **cannot independently validate its own authority** |

> The new job passing on the pull request that introduces it is **supporting evidence, not independent proof**. It is running the version of itself under review. Independent proof arrives when the context is required and a later pull request is blocked by a real violation.

## Mutation coverage — 23 assertions, all through the real CLI

Invoked via `subprocess` with real `--allowlist`, `--maximal` and `--census` arguments against temporary files, so argument handling, file decoding, diagnostics and exit status are proven together. A verifier whose internals are correct but whose CLI mis-parses `--census` would pass a function-level suite and fail in CI.

| # | Prohibited state |
| --- | --- |
| 1 | normal case with zero contracts |
| 2 | normal case with multiple contracts |
| 3 | unknown `contract:*` |
| 4 | unknown `role:*` |
| 5 | `role:benchmark` without allowlist membership |
| 6 | allowlist membership without `role:benchmark` |
| 7 | benchmark carrying a contract |
| 8 | stale allowlist entry absent from the union |
| 9a–9f | duplicate / blank / whitespace-padded / carriage return / no terminal LF / invalid UTF-8 |
| 10 | policy identity drift between configurations |
| 11 | maximal configuration is not the union |
| 12 | malformed CTest JSON |
| 13 | duplicate test name within one census |
| 14a–14c | exactly one terminal LF accepted; second trailing LF and internal blank rejected |

Plus a green baseline and **10b**, which pins that *descriptive-only* drift is **accepted** — without it, a future refactor could quietly re-widen the comparison and every existing test would still be green.

Each case asserts a **substring of the real diagnostic**, not merely a non-zero exit: a crash also exits non-zero, and exit-code-only tests would let a refactor turn a precise rejection into a stack trace and still look covered.

## Design decisions worth reviewing

**No census is hardcoded.** Not 243 cases, not 242 contracts, not the current distribution. Those figures prove one migration; baking them in would block correctly classified tests from being added. The allowlist decides the approved benchmark set; structural rules decide whether a census is valid. A guard that freezes a number stops being a policy and becomes a snapshot.

**It reads enumerated CTest JSON, never CMake source.** Parsing lost to enumerating three times during classification: tests live in **ten** registration files, registration is conditional, and a label can be attached far from the `add_test()` that created the case.

**Duplicate test names are diagnosed before the list becomes a set.** Found while hardening: the original draft collapsed them, and the *later* entry won — so two registrations of one name with different contracts would have produced a single valid-looking case.

**The job carries no `if:`, no `needs:`, no `continue-on-error`, and there is no workflow path filter.** A required context must always report, and GitHub counts a skipped required job as successful — so a conditionally skipped gate degrades to false green rather than to a block.

**Self-tests run before the real census**, so a broken verifier is reported as a broken verifier rather than as a policy violation.

**Configure only, no build.** The census is a property of a configured tree; nothing here needs a compiled binary, which keeps the job minutes rather than tens of minutes.

## Verified locally

The exact CI command strings were dry-run end to end before commit:

```
  hl-on-rtOFF-exOFF: 215 registered, 215 contracted, 0 benchmark
  hl-on-rtOFF-exON:  221 registered, 220 contracted, 1 benchmark
  hl-on-rtON-exOFF:  221 registered, 221 contracted, 0 benchmark
  hl-on-rtON-exON:   227 registered, 226 contracted, 1 benchmark
  maximal:           243 registered, 242 contracted, 1 benchmark
  allowlist: 1 entry(ies)

Test contract coverage OK.
```

## Out of scope, deliberately

- **Branch protection.** The context is not added here. The job reports; it does not yet block.
- **The three hardcoded `Sec*` selectors** in `ci.yml`. Coverage answers *whether every test has a valid policy identity*; selector replacement answers *which identity a lane executes*. Separate T3 change.
- **`CORE_MODE=OFF`.** Premium modules are absent from this checkout, so that dimension stays unmeasured and the guard's claim is scoped to the public/core tree.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**Risk: a new advisory-in-practice job.** Until the context is added to branch protection it reports without blocking, so a violation merges. That gap is deliberate — adding protection in the same change would let the gate be required before anyone has seen it report.

**Risk: five extra CMake configures per run.** Configure-only, no compilation; measured at well under a minute locally.

**Rollback:** revert the commit. The two scripts and the job disappear together; no other lane depends on them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds `verify-test-contracts.py` to enforce test-contract labels, benchmark roles, configuration membership, duplicate names, and policy consistency.
- Adds 23 CLI mutation tests for valid, malformed, and policy-violating census data.
- Adds a `Test contract coverage` CI job for five configurations. It runs verifier self-tests, configures without building, and checks CTest census data.
- Keeps branch protection unchanged. The job reports violations but does not block merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->