### PR TITLE
ci: make the security lane contract-authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,19 @@ jobs:
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-linux.xml
 
-      - name: License verification tests
+      - name: Security contract tests
         if: steps.scope.outputs.run == 'true'
-        run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
+        # Was a hand-written list of three names, repeated identically in the
+        # Linux, Windows and macOS lanes. Three copies of a literal drift
+        # independently, and the list could only ever name what someone
+        # remembered to add — it had not grown since it was written, while the
+        # security suite reached 29 cases.
+        #
+        # --no-tests=error is load-bearing: without it, a typo in the label or a
+        # renamed contract selects nothing and ctest exits 0. A security step
+        # that silently runs zero tests is worse than no step, because it
+        # reports success.
+        run: ctest --test-dir build -L '^contract:security$' --no-tests=error --output-on-failure
 
       - name: Upload test report
         if: always() && steps.scope.outputs.run == 'true'
@@ -421,10 +431,12 @@ jobs:
         shell: bash
         run: ctest --test-dir . -C ${{env.BUILD_TYPE}} --output-on-failure --output-junit ctest-results-windows.xml
 
-      - name: License verification tests
+      - name: Security contract tests
         if: steps.scope.outputs.run == 'true'
         shell: bash
-        run: ctest --test-dir build -C ${{env.BUILD_TYPE}} -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
+        # See the Linux lane for why this is a label selector rather than a
+        # literal list. -C is retained: this is a multi-config generator.
+        run: ctest --test-dir build -C ${{env.BUILD_TYPE}} -L '^contract:security$' --no-tests=error --output-on-failure
 
       - name: Upload test report
         if: always() && steps.scope.outputs.run == 'true'
@@ -498,9 +510,19 @@ jobs:
         working-directory: build
         run: ctest --test-dir . --output-on-failure --output-junit ctest-results-macos.xml
 
-      - name: License verification tests
+      - name: Security contract tests
         if: steps.scope.outputs.run == 'true'
-        run: ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
+        # Was a hand-written list of three names, repeated identically in the
+        # Linux, Windows and macOS lanes. Three copies of a literal drift
+        # independently, and the list could only ever name what someone
+        # remembered to add — it had not grown since it was written, while the
+        # security suite reached 29 cases.
+        #
+        # --no-tests=error is load-bearing: without it, a typo in the label or a
+        # renamed contract selects nothing and ctest exits 0. A security step
+        # that silently runs zero tests is worse than no step, because it
+        # reports success.
+        run: ctest --test-dir build -L '^contract:security$' --no-tests=error --output-on-failure
 
       - name: Upload test report
         if: always() && steps.scope.outputs.run == 'true'


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

The security lane now selects by contract instead of by a hand-written list of names.

```diff
- ctest --test-dir build -R "SecLicenseGateSignature|SecLicenseProfileHardening|SecJsonParserHardening" --output-on-failure
+ ctest --test-dir build -L '^contract:security$' --no-tests=error --output-on-failure
```

Three identical copies replaced — Linux, Windows, macOS. Windows keeps `-C ${{env.BUILD_TYPE}}`; it is a multi-config generator.

Steps renamed **`License verification tests`** → **`Security contract tests`**, because the selector no longer describes licensing.

## A correction to the working hypothesis

This change was scoped expecting **27 cases in CI against 29 in maximal**, with two tests excluded by a configuration dimension that had to be named.

Measurement says otherwise. `AESTRA_CI=ON` forces `HEADLESS_ONLY=ON, UI=OFF, RUNTIME=OFF, EXPERIMENTAL=OFF` — the 215-case configuration — and in it:

| Set | Count |
| --- | ---: |
| `contract:security` in the platform CI configuration | **29** |
| `contract:security` in the maximal tree | **29** |
| Sets identical, compared by name | **yes** |
| Maximal-only security cases | **none** |
| CI-only security cases | **none** |

There are no absences to explain, because there are none. The 27 figure was a miscount on my part in an earlier report — 27 is the number of `Sec*`-prefixed tests; the security contract also covers `LocalAccountCacheTest` and `PluginScannerSigpipeTest`, which do not carry the prefix. **29 is the whole taxonomy, and all 29 register in every lane that runs this step.**

## Required proof — three independent enumerations

Sources: `ctest --show-only=json-v1` for the census, `ctest -N -R` for the old set, `ctest -N -L` for the selected set. Compared by **test name**, never by output line count.

```text
old_regex_set = {
    SecJsonParserHardening,
    SecLicenseGateSignature,
    SecLicenseProfileHardening
}                                                        3 cases

label_selector_set == all registered contract:security  29 cases
old_regex_set ⊂ label_selector_set                      true
```

The 26 cases the old selector never named:

`LocalAccountCacheTest` · `PluginScannerSigpipeTest` · `SecAccountApiClient` · `SecAccountEndToEndSmoke` · `SecAccountSessionCache` · `SecAutosaveRecoveryGuard` · `SecCacheMtimeIntegrity` · `SecClipColorStoul` · `SecDivZero` · `SecEntitlementStore` · `SecEnvVarValidation` · `SecFlacVendorlenBounds` · `SecFreadTruncatedWav` · `SecId3Overflow` · `SecJsonDos` · `SecLicenseRefreshClient` · `SecLicenseWorkerFixture` · `SecMembershipViewModel` · `SecOutOfProcessPluginHost` · `SecPluginCacheBounds` · `SecPluginScanIsolation` · `SecPluginTrustedPath` · `SecProjectLoadHardening` · `SecSamplerPath` · `SecShellEscape` · `SecStoulCrash`

Plugin sandbox isolation, out-of-process host, WAV/FLAC/ID3 bounds, shell escaping, path traversal, entitlement handling — none of it was in the dedicated security step.

## `--no-tests=error` is load-bearing

Verified against a label matching nothing, in run mode:

| Invocation | Exit |
| --- | ---: |
| `ctest -L '^contract:securityX$' --no-tests=error` | **8** |
| `ctest -L '^contract:securityX$'` | **0** |

A renamed contract or a typo in the label would otherwise select nothing and **report success**. A security step that silently runs zero tests is worse than no step at all.

*(An earlier probe of mine used `-N`, which only lists and never triggers the flag — both invocations exited 0 and proved nothing. Re-run in run mode for the numbers above.)*

## What is unchanged

Job names and required contexts · step conditions · `permissions:` · `needs:` · `concurrency` · branch filters · test labels and bodies · the coverage guard · branch protection · the separate `-E` exclusion list in the sanitizer job.

## T3 evidence boundary

> The existing selector explicitly reran **3** cases. The label selector reruns every security contract registered in each platform configuration — measured at **29**, identical to the maximal taxonomy, with no absent cases. Green execution of the modified steps on this PR **supports** the change but does not substitute for the independent set comparison above.

The steps passing here shows the selector executes and its tests pass. It does not by itself show the selector resolves to the right set — that is what the three enumerations are for.

## Noted, not addressed

`ci.yml` line 337 carries another hardcoded list, the sanitizer job's `-E` exclusion naming four `Sec*` tests. Same drift class, different question — that one is about which tests a lane *skips*, and its migration needs its own reasoning about why those four are excluded. Out of scope.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**Risk: the dedicated step now runs 29 tests instead of 3.** They already run in the full-suite step of the same job, so this is added runtime for a re-run, not new compilation. The value is a named, isolated security signal that cannot drift from the taxonomy.

**Risk: the step now depends on label correctness.** That dependency is deliberate and is exactly what `Test contract coverage` was made required to protect — a case losing `contract:security` now fails the guard before it can quietly leave this selector.

**Rollback:** revert the commit. The three literal lists return.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated Linux, Windows, and macOS security CI to select tests with the `contract:security` label.
- Added `--no-tests=error` so empty or invalid selections fail.
- Renamed the steps to “Security contract tests.”
- Preserved the Windows multi-configuration option and existing CI settings.
- The selector now covers all 29 security contract tests instead of 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->