### PR TITLE
fix(test): make FilterTest non-interactive by default

### DIFF
--- a/Tests/AestraAudio/FilterTest.cpp
+++ b/Tests/AestraAudio/FilterTest.cpp
@@ -18,7 +18,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
+#include <string>
 #include <vector>
 
 using namespace Aestra::Audio;
@@ -354,7 +356,29 @@ void interactiveAudioTest() {
     std::cout << "\nâœ“ Audio stream stopped" << std::endl;
 }
 
-int main() {
+// Interactive playback is opt-in. A registered CTest case must never depend on
+// stdin being non-interactive: under a runner, an IDE, a local terminal or an
+// agent harness, stdin can be open and the prompt below would wait forever.
+//
+// The failure mode is a hang, not a failure. A failing test names the broken
+// assertion; a hanging test consumes the runner until something else kills it,
+// and the report says "timeout" — which points at infrastructure rather than at
+// the line that asked a question nobody was there to answer. See #720.
+namespace {
+
+bool interactiveRequested(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "--interactive") {
+            return true;
+        }
+    }
+    const char* env = std::getenv("AESTRA_FILTER_INTERACTIVE");
+    return env != nullptr && std::string(env) == "1";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
     std::cout << "========================================" << std::endl;
     std::cout << "  AestraAudio - Filter Test" << std::endl;
     std::cout << "========================================" << std::endl;
@@ -376,13 +400,13 @@ int main() {
     }
     std::cout << "========================================" << std::endl;
 
-    // Interactive audio test
-    std::cout << "\nRun interactive audio test? (y/n): ";
-    char choice;
-    std::cin >> choice;
-
-    if (choice == 'y' || choice == 'Y') {
+    // Interactive audio test — opt-in only, and never reached by CTest.
+    if (interactiveRequested(argc, argv)) {
         interactiveAudioTest();
+    } else {
+        std::cout << "\n(interactive playback skipped; pass --interactive or set "
+                     "AESTRA_FILTER_INTERACTIVE=1)"
+                  << std::endl;
     }
 
     return allPassed ? 0 : 1;


### PR DESCRIPTION
## Decision citation

Objective:  —
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

Closes #720.

## Summary

`FilterTest` read `std::cin` from `main()` to ask whether to run interactive playback. Playback is now opt-in via `--interactive` or `AESTRA_FILTER_INTERACTIVE=1`, and the default path never touches stdin.

## Why it mattered even though CI was green

It did not hang in CI only because stdin there is not a TTY, so the extraction failed and execution fell through to the return. Anywhere stdin is **open and never delivers** — a terminal, an IDE test runner, an agent harness — the test waited forever.

The failure mode is a **hang, not a failure**. A failing test names the broken assertion. A hanging test consumes the runner until something else kills it, and the report says "timeout" — which points at infrastructure rather than at the line that asked a question nobody was there to answer.

## Measured before and after

Stdin held open by a process that never writes and never closes, timing **only the binary**:

| Build | Exit | Elapsed |
| --- | ---: | ---: |
| before | **124** | **20s — hung to the timeout** |
| after | **0** | **0s** |

The old behaviour was rebuilt from a stash of this change specifically to reproduce the defect rather than assert it from reading.

*(A first attempt used `sh -c "sleep 300 | binary"`, which times the whole pipeline — `sleep` dominates and the result says nothing about the binary. Redone with the binary reading from a held-open descriptor so only it is measured.)*

## Acceptance criteria

- [x] Normal CTest execution never reads from `stdin`
- [x] Existing deterministic audio assertions remain unchanged — low-pass, high-pass, band-pass, resonance, stability, and the `allPassed ? 0 : 1` exit contract
- [x] Interactive playback available only through `--interactive` or `AESTRA_FILTER_INTERACTIVE=1`
- [x] Non-interactive execution exits deterministically on every environment, including terminals and agent runners
- [x] `AestraFilterTest` remains `contract:audio`
- [x] No broader filter or DSP changes

The only remaining `std::cin` read is inside `interactiveAudioTest()`, now unreachable without the opt-in.

## On the contract

`contract:audio` is unchanged and correct. This is **execution safety**, not classification — what the test protects is still rendered-signal behaviour. Changing the label would have been the wrong response to a hang.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [x] No
- [ ] Not needed

## Risk / Rollback Notes

**No behavioural risk to the assertions.** `main()` gains an `argc/argv` signature and a gate; the five test functions and their exit contract are untouched.

**One behaviour change for humans**: running the binary directly no longer prompts. It prints one line naming the two ways to get playback back.

**Rollback:** revert the commit — which restores the prompt and the hang.
