### PR TITLE
fix(audio): stop pattern edits seizing the transport in timeline mode

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2239,10 +2239,22 @@ void AestraContent::setViewFocus(ViewFocus focus) {
         // === ENTERING TIMELINE ===
         else if (focus == ViewFocus::Timeline) {
             stopPatternClipPreview(false);
-            // Stop any running playback from previous mode
-            if (previousFocus == ViewFocus::Arsenal) {
-                if (m_trackManager && m_trackManager->isPatternMode()) {
-                    m_trackManager->stopArsenalPlayback(false);
+            // Pattern mode is mirrored in two places: AudioEngine (drives the transport's
+            // loop/wrap) and TrackManager (gates the pattern scheduler and, in play(),
+            // whether the timeline is scheduled at all). The engine mirror is cleared
+            // unconditionally below, so keying the TrackManager teardown off previousFocus
+            // — where we came FROM rather than what state we are actually IN — lets the two
+            // disagree for any path that reaches Timeline without previousFocus==Arsenal.
+            // With TrackManager left in pattern mode, play() skips BOTH the scheduler flush
+            // and scheduleTimelinePatternInstances(). Keyed off real state, matching the
+            // ENTERING AUDITION branch below, which was already written this way.
+            // (Hardening: the observed limbo in this pass came from updatePatternLoopLength,
+            // fixed separately. This asymmetry is latent, not the measured cause.)
+            const bool leavingArsenal = (previousFocus == ViewFocus::Arsenal);
+            const bool patternStillArmed = m_trackManager && m_trackManager->isPatternMode();
+            if (leavingArsenal || patternStillArmed) {
+                if (patternStillArmed) {
+                    m_trackManager->stopArsenalPlayback(false); // clears the mirror AND flushes
                 } else if (m_trackManager && m_trackManager->isPlaying()) {
                     m_trackManager->stop();
                 }
@@ -2980,6 +2992,19 @@ void AestraContent::updatePatternLoopLength(PatternID patternId) {
     // domain from the audio thread (= silence after the next wrap).
     const double barBeats = static_cast<double>(m_trackManager->getTimelineClock().getBeatsPerBar());
     double lengthBeats = std::max(barBeats, pattern->lengthBeats);
+
+    // Only Arsenal focus may put the ENGINE into pattern playback. This function runs
+    // from pattern-edit callbacks (setOnPatternEdited), and the Arsenal panel stays open
+    // across a focus change — so editing a pattern from it while the user is on the
+    // Timeline used to seize the transport: the engine looped the pattern length while
+    // TrackManager stayed in timeline mode, so play() scheduled the timeline but the
+    // transport never left the pattern's first bars and timeline audio stopped sounding.
+    // It was unrecoverable from the UI, because the user was ALREADY on Timeline, so
+    // clicking Timeline fired no focus transition to clear the flag.
+    // Creating or deleting a unit while in timeline mode is the shortest repro.
+    if (resolveTransportFocus() != ViewFocus::Arsenal) {
+        return; // Pattern loop length governs Arsenal playback only.
+    }
     m_audioEngine->setPatternPlaybackMode(true, lengthBeats);
 }
 


### PR DESCRIPTION
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## The bug (owner repro)

In **Timeline** mode, open the Arsenal panel *without* switching to Arsenal, create a unit, then delete it. The session lands in limbo — not in Arsenal, not playing the timeline, no audio from either side.

## Root cause

`AestraContent::updatePatternLoopLength()` ended with an **unconditional**:

```cpp
m_audioEngine->setPatternPlaybackMode(true, lengthBeats);
```

It runs from `setOnPatternEdited`, which fires on **any** Arsenal pattern edit. Because the Arsenal panel stays open across a focus change, editing a pattern from it while on the Timeline flipped the *engine* into pattern mode.

The result is a split brain:
- **AudioEngine** in pattern mode → transport loops the pattern length
- **TrackManager** still in timeline mode → `play()` schedules the timeline

So the timeline gets scheduled but the transport never leaves the pattern's opening bars, and timeline audio stops sounding.

It was **unrecoverable from the UI**: the user is already on Timeline, so clicking Timeline fires no focus transition, and nothing ever clears the flag.

**Fix:** only Arsenal focus may put the engine into pattern playback.

## Evidence

Measured with temporary instrumentation logging both mirrors of pattern mode plus the scheduler census (since removed — this PR contains no instrumentation).

Before, persistent and never recovering:
```
play.request toggleFocus=1 m_viewFocus=1 tmPatternMode=0 enginePatternMode=1  <<<< MIRRORS DISAGREE
```

After the same repro:
```
play.request toggleFocus=1 m_viewFocus=1 tmPatternMode=0 enginePatternMode=0 instances=0[-]
[TimelinePattern] scheduling 0 MIDI clip instances from beat 0.000000
```
Transport advances linearly (10.50 → 13.49 s) instead of wrapping at the pattern boundary.

## Also in this PR (hardening, not the measured cause)

The `ENTERING TIMELINE` teardown keyed off `previousFocus` — where we came *from* rather than what state we are *in* — so it could leave `TrackManager` in pattern mode for any path reaching Timeline by another route. Now keyed off real state, matching the `ENTERING AUDITION` branch, which was already written that way.

Stated plainly: instrumentation recorded **0** re-entrancy-guard drops, so this is latent hardening. It is not what fixed the reported bug. I had assumed the guard was the culprit; the measurement said otherwise.

## Known, NOT addressed here

The pattern scheduler accumulates duplicate instances — the Arsenal slot was observed **31 times over** (`instances=31[1,1,1,…]`), because `PatternPlaybackEngine::flush()` only *requests* a deferred drain that runs in `refillWindow()`. This is why observed audio peaks climbed across a session. It is a separate defect needing RT-safety care, and folding it in here would mix an unproven change into a proven one.

## Verification

Owner's repro re-run end-to-end on the final binary with instrumentation removed: engine stays out of pattern mode, timeline scheduling runs, transport linear.

No automated test — this needs a headless harness driving `AestraContent` focus transitions plus a live `AudioEngine`, which doesn't exist yet. The evidence here is runtime measurement, not a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restrict pattern playback activation to Arsenal focus so Timeline edits do not enable AudioEngine pattern mode.
- Harden Timeline teardown by checking the current focus and stale TrackManager pattern state.
- Runtime verification confirms that Timeline transport advances linearly after the reported reproduction.
- No automated tests were added. Duplicate pattern scheduler instances remain a separate issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->