### PR TITLE
fix(audio): reuse pattern scheduler slots and clear them reliably

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -845,7 +845,11 @@ public:
      */
     void play() {
         if (!m_patternMode.load(std::memory_order_relaxed)) {
-            m_patternPlaybackEngine.flush();
+            // Timeline playback owns the scheduler outright. flush() only rewinds, so an
+            // Arsenal instance survived into timeline playback and kept sounding under a
+            // linear transport; scheduleTimelinePatternInstances() below starts at id 2 and
+            // would never have replaced it. Clear before rebuilding the timeline set.
+            m_patternPlaybackEngine.clearInstances();
         }
         m_isPlaying.store(true, std::memory_order_relaxed);
         m_isPaused.store(false, std::memory_order_relaxed);
@@ -974,7 +978,9 @@ public:
      */
     void stopArsenalPlayback(bool keepPatternMode = false) {
         stop();
-        m_patternPlaybackEngine.flush();
+        // Arsenal playback is over: drop its instances rather than rewinding them, so
+        // nothing carries into whatever plays next.
+        m_patternPlaybackEngine.clearInstances();
         if (!keepPatternMode) {
             m_patternMode.store(false, std::memory_order_relaxed);
         }

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1183,7 +1183,13 @@ public:
         m_isPaused.store(false, std::memory_order_relaxed);
         m_position.store(startSeconds, std::memory_order_relaxed);
         m_playStartPosition.store(startSeconds, std::memory_order_relaxed);
-        m_patternPlaybackEngine.flush();
+        // Arsenal preview means "play THIS pattern alone". flush() only rewinds, so
+        // whatever was already scheduled — timeline clip instances from a previous
+        // play(), or an earlier preview — kept sounding alongside it and was mixed
+        // into offline pattern renders too (a render_pattern was measured emitting 3
+        // instances when the caller asked for one, inflating its peak by ~3 dB).
+        // Start from an empty scheduler so the preview renders exactly what was asked for.
+        m_patternPlaybackEngine.clearInstances();
 
         {
             auto* pattern = m_patternManager.getPattern(pid);

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -201,8 +201,28 @@ public:
 
     /**
      * @brief Flush queued events and rewind active instances.
+     *
+     * Rewind, NOT removal: instances stay scheduled and re-emit from the top. That is
+     * what a loop restart needs. Use clearInstances() when the content must not carry
+     * forward at all.
      */
     void flush();
+
+    /**
+     * @brief Drop every scheduled instance and queued event.
+     *
+     * For transitions that must not carry pattern content forward — leaving Arsenal, or
+     * starting timeline playback. flush() alone was insufficient there: it rewinds, so an
+     * Arsenal instance survived into timeline playback and kept sounding.
+     * Control thread only (takes the scheduler mutex); the RT path reads m_rtQueue only.
+     */
+    void clearInstances();
+
+    /**
+     * @brief Number of scheduled pattern instances (control thread).
+     * @return Count of live instances.
+     */
+    size_t getActiveInstanceCount() const;
 
     /**
      * @brief Get the number of scheduler overflows observed so far.

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -94,7 +94,6 @@ void PatternPlaybackEngine::schedulePatternInstance(PatternID pid, double startB
 
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        // Add to active instances
         PatternInstance inst;
         inst.patternId = pid;
         inst.startBeat = startBeat;
@@ -104,7 +103,20 @@ void PatternPlaybackEngine::schedulePatternInstance(PatternID pid, double startB
             durationBeats > 0.0 ? (inst.sourceStartBeat + durationBeats) : std::numeric_limits<double>::infinity();
         inst.scheduledThroughFrame = 0;
 
-        m_activeInstances.push_back(inst);
+        // An instanceId identifies a SLOT, not an occurrence — cancellation is keyed on
+        // it (m_instanceCancelled is indexed by id), so two live entries sharing an id
+        // were never individually addressable anyway. This used to push_back
+        // unconditionally: the Arsenal preview always re-arms slot 1, and nothing ever
+        // erased entries (flush() only rewinds scheduledThroughFrame), so a session
+        // accumulated dozens of overlapping copies — 31 observed in one sitting — each
+        // emitting its own events into the same units. Re-arming a slot must replace it.
+        auto existing = std::find_if(m_activeInstances.begin(), m_activeInstances.end(),
+                                     [instanceId](const PatternInstance& e) { return e.instanceId == instanceId; });
+        if (existing != m_activeInstances.end()) {
+            *existing = inst;
+        } else {
+            m_activeInstances.push_back(inst);
+        }
     }
 
     Aestra::Log::info("[PatternPlayback] Scheduled instance " + std::to_string(instanceId) + " pattern " +
@@ -373,6 +385,33 @@ void PatternPlaybackEngine::processAudio(uint64_t currentFrame, int bufferSize, 
 
         m_rtQueue.pop();
     }
+}
+
+void PatternPlaybackEngine::clearInstances() {
+    // Control thread only — takes the scheduler mutex. processAudio() consumes m_rtQueue
+    // and never reads m_activeInstances, so erasing here cannot race the audio thread.
+    if (reportRealtimeMisuse("PatternPlaybackEngine::clearInstances")) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_activeInstances.clear();
+        m_lastRefillFrame = 0;
+    }
+
+    for (auto& flag : m_instanceCancelled) {
+        flag.store(false, std::memory_order_release);
+    }
+
+    // A pending rewind is moot once the instances are gone.
+    m_flushRequested.store(false, std::memory_order_release);
+    m_rtQueue.forceDrain();
+}
+
+size_t PatternPlaybackEngine::getActiveInstanceCount() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_activeInstances.size();
 }
 
 void PatternPlaybackEngine::flush() {

--- a/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
+++ b/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
@@ -15,12 +15,14 @@
 // instances, and clearInstances() did not exist.
 
 #include "Models/PatternManager.h"
+#include "Models/TrackManager.h"
 #include "Models/UnitManager.h"
 #include "Playback/PatternPlaybackEngine.h"
 #include "Playback/TimelineClock.h"
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 
 using namespace Aestra::Audio;
 
@@ -98,6 +100,41 @@ int main() {
     // Out-of-range ids are rejected without corrupting the census.
     engine.schedulePatternInstance(patternA, 0.0, 999);
     check(engine.getActiveInstanceCount() == 1, "out-of-range instance id is rejected, census unchanged");
+
+    // --- ISOLATION: an Arsenal preview must not carry timeline clip instances. ---
+    //
+    // scheduleTimelinePatternInstances() allocates ids from 2 upward and reserves 1 for the
+    // Arsenal preview, so a timeline play() leaves ids 2..N scheduled. playPatternInArsenal()
+    // used to call flush(), which only rewinds — those clip instances stayed live and were
+    // mixed into the preview AND into offline render_pattern output. Measured directly: a
+    // render that asked for one pattern emitted three instances, inflating its peak from
+    // 0.094194 to 0.133211 (~3 dB) and breaking MuseServiceTest's half-gain ratio.
+    //
+    // Arsenal preview means "play THIS pattern alone". Assert that boundary directly rather
+    // than inferring it from a rendered level.
+    {
+        auto trackManager = std::make_shared<TrackManager>();
+        auto& tmEngine = trackManager->getPatternPlaybackEngine();
+        auto& tmPatterns = trackManager->getPatternManager();
+
+        const PatternID arsenalPattern = makePattern(tmPatterns, "arsenal");
+        const PatternID timelinePattern = makePattern(tmPatterns, "timeline");
+
+        // Stand in for what a timeline play() leaves behind: clip instances at ids 2+.
+        tmEngine.schedulePatternInstance(timelinePattern, 0.0, 2);
+        tmEngine.schedulePatternInstance(timelinePattern, 8.0, 3);
+        check(tmEngine.getActiveInstanceCount() == 2, "timeline clip instances are scheduled at ids 2+");
+
+        trackManager->playPatternInArsenal(arsenalPattern, 0.0);
+        check(tmEngine.getActiveInstanceCount() == 1,
+              "Arsenal preview starts from an EMPTY scheduler — timeline clip instances cannot "
+              "contribute to it (was 3 before the fix)");
+
+        // And the reverse boundary still holds: leaving Arsenal drops its instance too, so
+        // nothing bleeds the other way into timeline playback.
+        trackManager->stopArsenalPlayback(false);
+        check(tmEngine.getActiveInstanceCount() == 0, "leaving Arsenal drops its preview instance");
+    }
 
     if (failures == 0) {
         std::cout << "All pattern-instance slot-reuse checks passed\n";

--- a/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
+++ b/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
@@ -1,0 +1,108 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Regression: the pattern scheduler treated every schedulePatternInstance() call as a NEW
+// occurrence and appended it, while nothing ever erased entries — flush() only rewinds
+// (scheduledThroughFrame = 0) so instances re-emit from the top, which is what a loop
+// restart needs but not what leaving Arsenal needs.
+//
+// Live consequence: the Arsenal preview always re-arms slot 1, so a session accumulated
+// dozens of overlapping copies of the same instance (31 observed in one sitting), each
+// emitting its own events into the same units — layered audio, climbing peaks, and an
+// Arsenal instance that survived into timeline playback and kept sounding under a linear
+// transport.
+//
+// These assertions fail on the pre-fix engine: re-arming slot 1 five times left five live
+// instances, and clearInstances() did not exist.
+
+#include "Models/PatternManager.h"
+#include "Models/UnitManager.h"
+#include "Playback/PatternPlaybackEngine.h"
+#include "Playback/TimelineClock.h"
+
+#include <cstdint>
+#include <iostream>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const std::string& what) {
+    if (cond) {
+        std::cout << "PASS: " << what << "\n";
+    } else {
+        std::cout << "FAIL: " << what << "\n";
+        ++failures;
+    }
+}
+
+PatternID makePattern(PatternManager& pm, const std::string& name) {
+    MidiPayload payload;
+    MidiNote note;
+    note.pitch = 60;
+    note.startBeat = 0.0;
+    note.durationBeats = 1.0;
+    note.velocity = 0.8f;
+    note.unitId = 1;
+    payload.notes.push_back(note);
+    return pm.createMidiPattern(name, 4.0, payload);
+}
+
+} // namespace
+
+int main() {
+    TimelineClock clock(120.0);
+    PatternManager patterns;
+    UnitManager units;
+    PatternPlaybackEngine engine(&clock, &patterns, &units);
+
+    const PatternID patternA = makePattern(patterns, "A");
+    const PatternID patternB = makePattern(patterns, "B");
+
+    check(engine.getActiveInstanceCount() == 0, "engine starts with no instances");
+
+    // --- The bug: re-arming the SAME slot must replace, not accumulate. ---
+    for (int i = 0; i < 5; ++i) {
+        engine.schedulePatternInstance(patternA, 0.0, 1);
+    }
+    check(engine.getActiveInstanceCount() == 1,
+          "re-arming slot 1 five times leaves exactly 1 instance (was 5 before the fix)");
+
+    // Replacement must take the NEW content, not keep the stale entry.
+    engine.schedulePatternInstance(patternB, 0.0, 1);
+    check(engine.getActiveInstanceCount() == 1, "replacing slot 1 with another pattern still leaves 1 instance");
+
+    // --- Distinct slots are genuinely distinct and must still accumulate. ---
+    engine.schedulePatternInstance(patternA, 0.0, 2);
+    engine.schedulePatternInstance(patternA, 4.0, 3);
+    check(engine.getActiveInstanceCount() == 3, "distinct instance ids accumulate (1, 2, 3)");
+
+    // Re-arming one slot must not disturb the others.
+    engine.schedulePatternInstance(patternB, 8.0, 2);
+    check(engine.getActiveInstanceCount() == 3, "re-arming slot 2 does not change the census");
+
+    // --- flush() REWINDS, it does not remove. Guard that distinction explicitly:
+    // conflating the two is what let an Arsenal instance survive into timeline playback.
+    engine.flush();
+    check(engine.getActiveInstanceCount() == 3, "flush() rewinds and must NOT drop instances");
+
+    // --- clearInstances() removes outright. ---
+    engine.clearInstances();
+    check(engine.getActiveInstanceCount() == 0, "clearInstances() drops every instance");
+
+    // Usable again afterwards.
+    engine.schedulePatternInstance(patternA, 0.0, 1);
+    check(engine.getActiveInstanceCount() == 1, "scheduler still usable after clearInstances()");
+
+    // Out-of-range ids are rejected without corrupting the census.
+    engine.schedulePatternInstance(patternA, 0.0, 999);
+    check(engine.getActiveInstanceCount() == 1, "out-of-range instance id is rejected, census unchanged");
+
+    if (failures == 0) {
+        std::cout << "All pattern-instance slot-reuse checks passed\n";
+        return 0;
+    }
+    std::cout << failures << " check(s) failed\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2116,3 +2116,22 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraCore/JSONLocaleIndependenceTest.cpp
     set_tests_properties(JSONLocaleIndependenceTest PROPERTIES LABELS "core;json;locale;regression;contract:core")
     message(STATUS "JSONLocaleIndependenceTest added - JSON decimal separator locale independence")
 endif()
+
+# An instanceId identifies a scheduler SLOT, not an occurrence. Re-arming a slot used to
+# append another live copy, and nothing ever erased entries (flush() only rewinds), so the
+# Arsenal preview slot accumulated dozens of overlapping instances and survived into
+# timeline playback. Guards replacement-on-reuse, the flush/clear distinction, and clearing.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternInstanceSlotReuseTest.cpp")
+    add_executable(PatternInstanceSlotReuseTest AestraAudio/PatternInstanceSlotReuseTest.cpp)
+    target_link_libraries(PatternInstanceSlotReuseTest PRIVATE AestraAudio)
+    target_include_directories(PatternInstanceSlotReuseTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternInstanceSlotReuseTest COMMAND PatternInstanceSlotReuseTest)
+    set_tests_properties(PatternInstanceSlotReuseTest PROPERTIES LABELS "audio;pattern;scheduler;regression;contract:audio")
+    message(STATUS "PatternInstanceSlotReuseTest added - pattern scheduler slot reuse + clearing")
+endif()


### PR DESCRIPTION
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## The defect

An `instanceId` identifies a scheduler **slot**, not an occurrence — cancellation is keyed on it (`m_instanceCancelled` is indexed by id), so two live entries sharing an id were never individually addressable. `schedulePatternInstance()` appended unconditionally anyway.

And **nothing ever erased entries**. `flush()` only sets `m_flushRequested`, which `refillWindow()` turns into a *rewind* (`scheduledThroughFrame = 0`) — never a removal. `cancelPatternInstance()` *can* erase an entry — but it has **zero callers anywhere in the tree**, so nothing ever exercised that path. `m_activeInstances` grew for the life of the session.

> Correction: an earlier revision of this description said `cancelPatternInstance()` only sets an RT skip flag. It does both (flag + erase); the accurate point is that it is never called.

## Live consequence

The Arsenal preview always re-arms slot 1, so a session accumulated overlapping copies of the same instance — **31 observed in one sitting** (`instances=31[1,1,1,1,…]`) — each emitting its own events into the same units. Audio layered and measured peaks climbed across a session (1635 → 2915 → 3274).

Worse: because `flush()` rewinds rather than clears, **the Arsenal instance survived into timeline playback** and kept sounding under a linear transport, while `scheduleTimelinePatternInstances()` starts at id 2 and would never have replaced it.

## SCOPE EXPANSION (added after first review round)

This PR began as "reuse scheduler slots and clear them reliably". CI then failed `MuseServiceTest`'s
half-gain assertion, and diagnosing it surfaced a second, **pre-existing** defect that the
never-clear behaviour had been masking. Fixing it is now part of this PR, and it changes behaviour
beyond the original scope:

**Arsenal preview and `render_pattern` are now isolated from leftover timeline clip instances.**

`scheduleTimelinePatternInstances()` allocates ids from 2 upward and reserves 1 for the Arsenal
preview, so a timeline `play()` leaves ids 2..N scheduled. `playPatternInArsenal()` called `flush()`,
which only rewinds — so those clip instances stayed live and were mixed into the preview *and* into
offline `render_pattern` output. A render that asked for one pattern was measured emitting **three**
instances, inflating its peak from 0.094194 to 0.133211.

The old behaviour kept every render uniformly inflated, so the *ratio* still landed near 2 and the
gain test passed for the wrong reason. Correct clearing made the counts differ per render and
exposed it.

`playPatternInArsenal()` now clears rather than rewinds: Arsenal preview means "play THIS pattern
alone". **This is a real change to what an Arsenal preview and an offline pattern render contain.**

### Direct regression for the isolation boundary

Not only the gain-ratio evidence — three assertions drive it through `TrackManager`'s public API:

- timeline clip instances are scheduled at ids 2+
- `playPatternInArsenal()` leaves **exactly 1** instance (was 3 before the fix)
- `stopArsenalPlayback()` drops the preview instance, so nothing bleeds the other way either

Proven to bite: reverting `playPatternInArsenal()` to `flush()` fails the isolation assertion with
exit 1 while every other assertion in the file still passes — so it catches this specific defect, not
a side effect of the slot-reuse change.

## Changes

- `schedulePatternInstance()` **replaces** an entry with the same `instanceId`.
- New **`clearInstances()`** — genuine removal + queue drain + cancel-flag reset. Control-thread only under the scheduler mutex; verified RT-safe because `processAudio()` consumes `m_rtQueue` and never reads `m_activeInstances`.
- `TrackManager::play()` (timeline branch) and `stopArsenalPlayback()` now **clear** instead of rewinding — that is the path by which Arsenal audio leaked into timeline playback.
- `flush()` keeps its rewind semantics, which loop restart genuinely needs. The two operations are different, and the test pins that distinction so they can't be re-conflated.

## Test — proven to bite

`Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp`, 9 assertions.

Reverting **only** the replacement logic produces **5 failures and a non-zero exit**, including the headline `re-arming slot 1 five times leaves exactly 1 instance (was 5 before the fix)`. With the fix restored, all pass. It also asserts the flush/clear distinction explicitly, and that distinct ids still accumulate normally.

**112/112 audio-label tests pass** — no regressions.

## Live verification

In the running app, not just the unit test:

| Check | Result |
|---|---|
| Arsenal pattern playing | peak **1635** (audible baseline) |
| → switch to Timeline, stop, play | peak **0**, 0/12 audible windows, transport rolling |
| Reported repro: create + delete unit while in Timeline, then play | peak **0**, transport advancing linearly (17.62 → 19.72 s) |

The first stopped-transport reading during this check was discarded — a frozen clock makes silence meaningless, so the measurement was retaken with playback confirmed rolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Replaced active pattern instances when `schedulePatternInstance()` receives an existing `instanceId`.
- Added `clearInstances()` and `getActiveInstanceCount()` for reliable scheduler cleanup and inspection.
- Updated timeline playback and Arsenal stop, playback, and preview paths to clear stale instances.
- Preserved `flush()` rewind behavior for loop restarts.
- Added regression coverage for slot reuse, distinct IDs, clearing, flushing, and post-clear scheduling.
- Fixed Arsenal preview contamination from earlier timeline playback. Audio-label tests and the full local suite pass, including 223/223 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
