### PR TITLE
fix(ui): stop the piano roll playhead drifting in timeline mode

### DIFF
--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -530,7 +530,20 @@ void PianoRollPanel::onUpdate(double deltaTime) {
                         if (playheadBeat < 0.0) playheadBeat += patternLength;
                         follow = m_trackManager->isPlaying();
                     } else {
-                        playheadBeat = std::max(0.0, currentBeat);
+                        // This editor's X axis is PATTERN-LOCAL beats; the transport reports
+                        // ARRANGEMENT beats. Feeding one into the other drew a playhead that
+                        // drifted across the pattern and off its end — at 8.6s (17.2 beats) it
+                        // sat past bar 5 of a 2-bar pattern — asserting a playback position
+                        // that does not exist in this editor, then vanishing off the right.
+                        //
+                        // Timeline playback of a pattern happens through clip instances placed
+                        // on lanes, each with its own offset into the source; this panel edits
+                        // the pattern itself and resolves no clip, so there is no single honest
+                        // pattern-local position to show. Park at the pattern start rather than
+                        // display a false one. (Mapping a clip under the playhead back into
+                        // pattern-local beats would be the richer behaviour, and needs the clip
+                        // lookup this panel deliberately does not carry.)
+                        playheadBeat = 0.0;
                     }
                 }
             }


### PR DESCRIPTION
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## The defect

The piano roll's X axis is **pattern-local** beats; the transport reports **arrangement** beats. In timeline mode the panel fed one straight into the other:

```cpp
playheadBeat = std::max(0.0, currentBeat);   // absolute arrangement beat
```

So the playhead drifted across the pattern and off its end. Measured live: at **8.62 s (17.2 beats)** it sat past bar 5 of a 2-bar pattern, then vanished off the right edge — asserting a playback position that does not exist in this editor.

## Why park rather than map

Timeline playback of a pattern happens through **clip instances** placed on lanes, each with its own offset into the source. This panel edits the pattern itself and resolves no clip, so there is no single honest pattern-local position to show — the same pattern may be playing at three different offsets at once.

Parking at the pattern start states "this editor is not what's playing" rather than inventing a position. Mapping a clip under the playhead back into pattern-local beats would be the richer behaviour, and needs clip lookup this panel deliberately does not carry; noted in the comment rather than half-built here.

Pattern mode is untouched — it still wraps `fmod(currentBeat, patternLength)` and follows playback.

## Verification

Pixel-diffed live, **with the transport clock as a validity control** — a frozen clock makes "nothing moved" meaningless, and an earlier run in this series was invalidated exactly that way:

| Mode | Clock (control) | Piano roll grid |
|---|---|---|
| Timeline | changed (rolling) | **unchanged** — no drift |
| Pattern / Arsenal | changed (rolling) | **changed**, bbox x 4–205 — still tracks in bars 1–2 |

## No automated test

This needs a headless `PianoRollPanel` harness (`TrackManager` + `PianoRollView` + a live `AudioEngine` position source), which doesn't exist — `PianoRollInteractionTest` only covers pure helpers. The evidence here is runtime measurement, not a test. Same gap flagged on #732; worth building the harness once rather than per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)