### PR TITLE
fix(audio): headless export clears, never rewinds, scheduler instances

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -902,10 +902,10 @@ public:
      * live transport (playing flag, position, transport command). An offline
      * render (headless export) drives the engine's own transport instead, so it
      * only needs the scheduling — this leaves isPlaying/isPaused/position
-     * untouched. Callers flush() the pattern engine before and after so the
-     * render's scheduled instances do not leak into the caller's session. Callers must
-     * use clearInstances(), NOT flush(): flush only rewinds active instances, so prior
-     * content stayed scheduled and was rendered into the export alongside the timeline.
+     * untouched. Callers clearInstances() the pattern engine before and after the
+     * render so neither prior content nor this render's instances leak into the
+     * caller's session: flush() only rewinds active instances, so anything already
+     * scheduled stayed live and was rendered into the export alongside the timeline.
      */
     void scheduleTimelineForOfflineRender(double playStartPositionSeconds = 0.0) {
         scheduleTimelinePatternInstances(playStartPositionSeconds);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -903,7 +903,9 @@ public:
      * render (headless export) drives the engine's own transport instead, so it
      * only needs the scheduling — this leaves isPlaying/isPaused/position
      * untouched. Callers flush() the pattern engine before and after so the
-     * render's scheduled instances do not leak into the caller's session.
+     * render's scheduled instances do not leak into the caller's session. Callers must
+     * use clearInstances(), NOT flush(): flush only rewinds active instances, so prior
+     * content stayed scheduled and was rendered into the export alongside the timeline.
      */
     void scheduleTimelineForOfflineRender(double playStartPositionSeconds = 0.0) {
         scheduleTimelinePatternInstances(playStartPositionSeconds);

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -409,7 +409,9 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
             engine.setUnitManager(nullptr);
             engine.setChannelSlotMap(nullptr);
             engine.setTrackManager(nullptr);
-            trackManager.getPatternPlaybackEngine().flush();
+            // Remove, don't rewind: this render's instances must not survive into the
+            // caller's session (flush() would leave them scheduled and merely restarted).
+            trackManager.getPatternPlaybackEngine().clearInstances();
         }
     };
 
@@ -436,9 +438,12 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // (AudioEngine::processBlock pops scheduled notes into unit MIDI routes).
     // Schedule the committed timeline into it WITHOUT starting live transport —
     // the exporter drives the engine's own transport, so we must not mutate the
-    // caller's playing flag / position. flush() first clears any prior contents;
-    // the render guard flushes again on exit so these instances don't leak.
-    m_trackManager.getPatternPlaybackEngine().flush();
+    // caller's playing flag / position. clearInstances() first removes any prior
+    // contents; the render guard clears again on exit so these instances don't leak.
+    // flush() cannot serve here — it only REWINDS active instances (re-emit from the
+    // top, which a loop restart wants), so anything already scheduled would have been
+    // rendered into the export alongside the timeline we just asked for.
+    m_trackManager.getPatternPlaybackEngine().clearInstances();
     m_trackManager.scheduleTimelineForOfflineRender(0.0);
 
     // Setup exporter

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -408,4 +408,27 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PDCDisableClearsCompensationTest.cpp")
     )
 endif()
 
+# Headless export must contain ONLY the timeline's content. exportTo() documented that
+# guarantee but implemented it with flush(), which rewinds instances rather than removing
+# them, so anything already scheduled bled into the rendered file. The sibling
+# HeadlessExportSessionInvarianceTest covers the TRANSPORT half of the contract only.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HeadlessExportInstanceIsolationTest.cpp")
+    add_executable(HeadlessExportInstanceIsolationTest
+        HeadlessExportInstanceIsolationTest.cpp
+    )
+    target_link_libraries(HeadlessExportInstanceIsolationTest PRIVATE AestraAudio)
+    target_include_directories(HeadlessExportInstanceIsolationTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME HeadlessExportInstanceIsolationTest
+        COMMAND HeadlessExportInstanceIsolationTest
+    )
+    set_tests_properties(HeadlessExportInstanceIsolationTest PROPERTIES
+        LABELS "headless;export;engine;regression;contract:audio"
+        ENVIRONMENT "AESTRA_HEADLESS=1"
+    )
+endif()
+
 message(STATUS "Headless tests enabled - AudioEngine API implemented")

--- a/Tests/Headless/CMakeLists.txt
+++ b/Tests/Headless/CMakeLists.txt
@@ -412,23 +412,23 @@ endif()
 # guarantee but implemented it with flush(), which rewinds instances rather than removing
 # them, so anything already scheduled bled into the rendered file. The sibling
 # HeadlessExportSessionInvarianceTest covers the TRANSPORT half of the contract only.
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/HeadlessExportInstanceIsolationTest.cpp")
-    add_executable(HeadlessExportInstanceIsolationTest
-        HeadlessExportInstanceIsolationTest.cpp
-    )
-    target_link_libraries(HeadlessExportInstanceIsolationTest PRIVATE AestraAudio)
-    target_include_directories(HeadlessExportInstanceIsolationTest PRIVATE
-        ${CMAKE_SOURCE_DIR}/Source
-        ${CMAKE_SOURCE_DIR}/AestraAudio/include
-        ${CMAKE_SOURCE_DIR}/AestraCore/include
-    )
-    add_test(NAME HeadlessExportInstanceIsolationTest
-        COMMAND HeadlessExportInstanceIsolationTest
-    )
-    set_tests_properties(HeadlessExportInstanceIsolationTest PROPERTIES
-        LABELS "headless;export;engine;regression;contract:audio"
-        ENVIRONMENT "AESTRA_HEADLESS=1"
-    )
-endif()
+# Deliberately unguarded: this regression test is part of the repo, and silently omitting
+# it on configuration would drop the isolation guarantee without failing loudly.
+add_executable(HeadlessExportInstanceIsolationTest
+    HeadlessExportInstanceIsolationTest.cpp
+)
+target_link_libraries(HeadlessExportInstanceIsolationTest PRIVATE AestraAudio)
+target_include_directories(HeadlessExportInstanceIsolationTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME HeadlessExportInstanceIsolationTest
+    COMMAND HeadlessExportInstanceIsolationTest
+)
+set_tests_properties(HeadlessExportInstanceIsolationTest PROPERTIES
+    LABELS "headless;export;engine;regression;contract:audio"
+    ENVIRONMENT "AESTRA_HEADLESS=1"
+)
 
 message(STATUS "Headless tests enabled - AudioEngine API implemented")

--- a/Tests/Headless/HeadlessExportInstanceIsolationTest.cpp
+++ b/Tests/Headless/HeadlessExportInstanceIsolationTest.cpp
@@ -1,0 +1,146 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// HeadlessExportInstanceIsolationTest
+//
+// HeadlessMusicGenerator::exportTo() claims, in both its own comments and
+// TrackManager::scheduleTimelineForOfflineRender()'s docs, that the pattern engine is
+// cleared before the render and again on exit "so the render's scheduled instances do not
+// leak". It implemented that with flush() — which only REWINDS active instances
+// (scheduledThroughFrame = 0, re-emit from the top) and never removes them.
+//
+// Consequence: anything already scheduled when exportTo() is called — an Arsenal preview,
+// clip instances from a previous play() — was still live during the render and got mixed
+// into the exported file alongside the timeline the caller asked for. The export contained
+// audio that is not in the arrangement.
+//
+// SCOPE: this test owns the INPUT half of the contract — prior scheduler state cannot
+// contaminate the render. The OUTPUT half (the caller's session is unchanged afterwards,
+// including its scheduled-instance count) is owned by HeadlessExportSessionInvarianceTest.
+//
+// That sibling existed throughout and stayed green, because its header asserted the
+// no-leak guarantee in prose while every check only compared the transport triple —
+// nothing in it COULD fail when instances leaked. Coverage exists only where an
+// assertion can fail for the behaviour being claimed.
+//
+// This test renders the same project twice — once clean, once with a deliberately audible
+// foreign instance pre-scheduled — and requires the two exports to be byte-identical.
+// Against the pre-fix implementation the second render contains the foreign pattern and
+// the files differ.
+
+#include "Core/AudioEngine.h"
+#include "Headless/HeadlessMusicGenerator.h"
+#include "Models/TrackManager.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const std::string& what) {
+    if (cond) {
+        std::cout << "PASS: " << what << "\n";
+    } else {
+        std::cout << "FAIL: " << what << "\n";
+        ++failures;
+    }
+}
+
+std::vector<uint8_t> readAll(const std::filesystem::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+// A loud, dense pattern on a REAL unit — a contaminant that cannot be missed if it leaks.
+// Using an existing unit matters: notes routed to a nonexistent unit would be silent and
+// the test would pass without proving anything.
+PatternID makeForeignPattern(TrackManager& tm, UnitID unitId) {
+    MidiPayload payload;
+    for (int i = 0; i < 8; ++i) {
+        MidiNote n;
+        n.pitch = 72; // distinct from the project's kick
+        n.startBeat = i * 0.5;
+        n.durationBeats = 0.5;
+        n.velocity = 1.0f;
+        n.unitId = unitId;
+        payload.notes.push_back(n);
+    }
+    return tm.getPatternManager().createMidiPattern("foreign", 4.0, payload);
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    const fs::path cleanPath = fs::temp_directory_path() / "aestra_export_isolation_clean.wav";
+    const fs::path dirtyPath = fs::temp_directory_path() / "aestra_export_isolation_dirty.wav";
+    fs::remove(cleanPath);
+    fs::remove(dirtyPath);
+
+    AudioEngine engine;
+    TrackManager trackManager;
+    HeadlessMusicGenerator gen(engine, trackManager);
+
+    gen.createProject("isolation")
+        .setTempo(120.0)
+        .setSampleRate(48000)
+        .createPattern("Kick", 16)
+        .addNote(0, 36, 100, 1.0)
+        .addNote(8, 36, 100, 1.0)
+        .addClipToPlaylist("Kick", 0.0, 4.0);
+
+    // First export also commits the project, which is what creates the units.
+    check(gen.exportTo(cleanPath.string(), 48000, AudioExporter::BitDepth::PCM_16),
+          "clean export succeeds");
+    const std::vector<uint8_t> cleanBytes = readAll(cleanPath);
+    check(cleanBytes.size() > 1024, "clean export wrote a non-trivial WAV");
+
+    // NOTE: the OUTPUT half — that the export leaves no instances behind in the caller's
+    // session — is asserted by HeadlessExportSessionInvarianceTest, which owns
+    // "the caller's session is unchanged afterwards". It is deliberately not duplicated
+    // here so the two tests have non-overlapping ownership. Both failed on the red run;
+    // one lifecycle bug, two observable consequences.
+
+    // Now contaminate: schedule a foreign, audible instance the way a leftover Arsenal
+    // preview or a previous play() would have, then export the SAME project again.
+    const auto unitIds = trackManager.getUnitManager().getAllUnitIDs();
+    check(!unitIds.empty(), "committed project created at least one unit to route to");
+    if (!unitIds.empty()) {
+        const PatternID foreign = makeForeignPattern(trackManager, unitIds.front());
+        // Relative, not absolute: whether the previous export left instances behind is the
+        // SIBLING test's concern. This precondition must hold either way so that a failure
+        // here can only mean contamination, never leakage.
+        const size_t beforeSchedule = trackManager.getPatternPlaybackEngine().getActiveInstanceCount();
+        trackManager.getPatternPlaybackEngine().schedulePatternInstance(foreign, 0.0, 7);
+        check(trackManager.getPatternPlaybackEngine().getActiveInstanceCount() == beforeSchedule + 1,
+              "foreign instance is scheduled before the export");
+
+        check(gen.exportTo(dirtyPath.string(), 48000, AudioExporter::BitDepth::PCM_16),
+              "export with a foreign instance pending succeeds");
+        const std::vector<uint8_t> dirtyBytes = readAll(dirtyPath);
+
+        // THE ASSERTION: the export contains the timeline's content and nothing else.
+        // Re-export is idempotent (HeadlessExportSessionInvarianceTest covers that), so
+        // any difference here is the foreign pattern bleeding into the render.
+        check(dirtyBytes.size() == cleanBytes.size(), "exports have identical length");
+        check(dirtyBytes == cleanBytes,
+              "export contains ONLY the timeline's content — a pre-scheduled foreign "
+              "instance must not reach the rendered file");
+    }
+
+    fs::remove(cleanPath);
+    fs::remove(dirtyPath);
+
+    if (failures == 0) {
+        std::cout << "All headless export isolation checks passed\n";
+        return 0;
+    }
+    std::cout << failures << " check(s) failed\n";
+    return 1;
+}

--- a/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
+++ b/Tests/Headless/HeadlessExportSessionInvarianceTest.cpp
@@ -5,14 +5,23 @@
 // is a synchronous offline render that must not mutate the caller's live
 // session. It schedules the timeline into the pattern-playback engine via
 // TrackManager::scheduleTimelineForOfflineRender() — NOT play() — so the
-// transport flags and position are left untouched, and its RenderStateGuard
-// flushes the pattern engine on every exit path so the render's scheduled
-// instances do not leak.
+// transport flags and position are left untouched, and its RenderStateGuard clears the
+// pattern engine on every exit path so the render's scheduled instances do not leak.
 //
-// This test snapshots (isPlaying, isPaused, position) before exportTo() and
-// asserts they are unchanged afterward, on BOTH the success path and a forced
-// failure path (empty output path — the exporter rejects it after the engine
-// wiring is already in place, exercising the guard's cleanup on failure).
+// SCOPE: this test owns the OUTPUT half of that contract — the caller's session is
+// unchanged after exportTo() returns. It snapshots (isPlaying, isPaused, position,
+// scheduledInstances) before the export and asserts they are unchanged afterward, on
+// BOTH the success path and a forced failure path (empty output path — the exporter
+// rejects it after the engine wiring is already in place, exercising the guard's
+// cleanup on failure).
+//
+// The scheduledInstances field was added after a real leak survived beside this test:
+// the header claimed the no-leak guarantee while every assertion only checked the
+// transport triple, so nothing here COULD fail when instances leaked. A test only
+// covers behaviour an assertion can fail for.
+//
+// The INPUT half — that prior scheduler state cannot contaminate the render — is owned
+// by HeadlessExportInstanceIsolationTest. The two do not overlap.
 
 #include "Core/AudioEngine.h"
 #include "Headless/HeadlessMusicGenerator.h"
@@ -39,10 +48,16 @@ struct TransportSnapshot {
     bool playing;
     bool paused;
     double position;
+    // The caller's SCHEDULER state is part of its session too. Leaving this out is what
+    // let a real leak survive next to a green "session invariance" test: exportTo() left
+    // its own pattern instances scheduled in the caller afterwards, and nothing here
+    // could fail because of it.
+    size_t scheduledInstances;
 };
 
 TransportSnapshot snapshot(const TrackManager& tm) {
-    return {tm.isPlaying(), tm.isPaused(), tm.getPosition()};
+    return {tm.isPlaying(), tm.isPaused(), tm.getPosition(),
+            tm.getPatternPlaybackEngine().getActiveInstanceCount()};
 }
 
 void requireUnchanged(const TrackManager& tm, const TransportSnapshot& before, const char* path) {
@@ -53,6 +68,8 @@ void requireUnchanged(const TrackManager& tm, const TransportSnapshot& before, c
             (std::string("export must not change isPaused (") + path + ")").c_str());
     require(std::abs(after.position - before.position) < 1e-9,
             (std::string("export must not change transport position (") + path + ")").c_str());
+    require(after.scheduledInstances == before.scheduledInstances,
+            (std::string("export must not leave scheduled pattern instances behind (") + path + ")").c_str());
 }
 
 // Builds a small but genuinely audible project on the given engine/manager.


### PR DESCRIPTION
Decision:   FD-12 @ a30696a
Kind:       corrective
Reversal:   —

## Summary

`HeadlessMusicGenerator::exportTo()` scheduled the timeline into the pattern-playback engine using `flush()`, which **rewinds** active instances (`scheduledThroughFrame = 0`, re-emit from the top) instead of removing them. This broke the documented headless-export contract in both directions:

1. **Input contamination:** anything already scheduled in the caller's session — an Arsenal preview, clip instances from a previous `play()` — stayed live during the render and was mixed into the exported file alongside the timeline. The export contained audio that is not in the arrangement.
2. **Output leakage:** the render's own instances remained scheduled in the caller's session after `exportTo()` returned. The old `HeadlessExportSessionInvarianceTest` never caught this because its assertions only compared the transport triple; nothing could fail when instances leaked.

The fix replaces both `flush()` calls with `clearInstances()`, which erases active instances outright, and corrects the `TrackManager::scheduleTimelineForOfflineRender()` documentation that claimed flush-based clearing would prevent leakage.

**Contract now:** a headless export is isolated from prior scheduler state and leaves the caller's scheduler state unchanged when it completes.

## Why

The previous implementation documented a guarantee it did not implement. `flush()` was chosen for its conventional "clear everything" connotation, but this engine's `flush()` is a rewind (needed for loop restarts), not a removal. This bug family is exactly why the `flush()` → `rewindScheduledInstances()` / `clearInstances()` → `clearScheduledInstances()` semantic rename is scheduled next.

## Testing performed

### Test ownership (independent halves, no overlap)

| Test | Owns | Assertion that fails on unfixed code |
| --- | --- | --- |
| `HeadlessExportInstanceIsolationTest` | INPUT half: prior scheduler state cannot contaminate the render | `export contains ONLY the timeline's content` — schedules a foreign audible instance (8-note pattern on a real unit, distinct pitch) before the export, requires the dirty export to be byte-identical to the clean one |
| `HeadlessExportSessionInvarianceTest` | OUTPUT half: the caller's session is unchanged afterward | `export must not leave scheduled pattern instances behind` — snapshot now includes `scheduledInstances` in addition to `isPlaying`/`isPaused`/position, on both success and forced-failure paths |

The isolation test uses a **relative** precondition (`activeInstanceCount == beforeSchedule + 1`) because whether a previous export leaked is the sibling test's concern — an absolute `== 1` precondition would make this test fail for the wrong defect.

### Red/green transcript (recreated against this branch, build-linux, Release)

Unfixed implementation (both flush() call sites restored):

```text
ctest --test-dir build-linux -R "HeadlessExport" --output-on-failure
    Start 191: HeadlessExportSessionInvarianceTest ***Failed
[FAIL] export must not leave scheduled pattern instances behind (success)
    Start 205: HeadlessExportInstanceIsolationTest ***Failed
FAIL: export contains ONLY the timeline's content — a pre-scheduled foreign instance must not reach the rendered file
1 check(s) failed
50% tests passed, 2 tests failed out of 4
```

Fixed implementation (this branch):

```text
ctest --test-dir build-linux -R "HeadlessExport" --output-on-failure
100% tests passed out of 4
```

### Full suite

```text
cmake --build build-linux -j2        # full supported build, Release, Aestra_CORE_MODE=ON
ctest --test-dir build-linux --output-on-failure
100% tests passed out of 224
```

## Producer note

None.

## Docs updated

`TrackManager.h` inline documentation corrected (see Summary). No public docs touched.

## Risk / rollback notes

- Scope is 5 files: the fix, the doc correction, the new test, the extended session-invariance test, and its CMake registration. No other files changed in `07c92d8e..HEAD`.
- Reverting is a clean `git revert` of the fix commit; both tests will fail again as shown in the red transcript.
- Pre-existing dirty submodules (`vst3sdk` content, `freetype_local` gitlink) were intentionally left untouched and are not part of this PR.
