### PR TITLE
refactor(audio): rename pattern scheduler flush()/clearInstances() to express intent

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -1069,7 +1069,7 @@ private:
     std::atomic<uint64_t> m_patternMonotonicFrame{0};
     // Last loop length (samples) used for a maintenance refill. Only touched
     // on the maintenance thread; a change (BPM / sample-rate) means queued
-    // timestamps are in a stale domain and the pattern engine must flush.
+    // timestamps are in a stale domain and the pattern engine must rewind.
     uint64_t m_lastRefillLoopLenSamples{0};
 
     // Test Tone State

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -845,11 +845,12 @@ public:
      */
     void play() {
         if (!m_patternMode.load(std::memory_order_relaxed)) {
-            // Timeline playback owns the scheduler outright. flush() only rewinds, so an
-            // Arsenal instance survived into timeline playback and kept sounding under a
-            // linear transport; scheduleTimelinePatternInstances() below starts at id 2 and
-            // would never have replaced it. Clear before rebuilding the timeline set.
-            m_patternPlaybackEngine.clearInstances();
+            // Timeline playback owns the scheduler outright. rewindScheduledInstances() only
+            // rewinds, so an Arsenal instance survived into timeline playback and kept
+            // sounding under a linear transport; scheduleTimelinePatternInstances() below
+            // starts at id 2 and would never have replaced it. Clear before rebuilding the
+            // timeline set.
+            m_patternPlaybackEngine.clearScheduledInstances();
         }
         m_isPlaying.store(true, std::memory_order_relaxed);
         m_isPaused.store(false, std::memory_order_relaxed);
@@ -902,10 +903,11 @@ public:
      * live transport (playing flag, position, transport command). An offline
      * render (headless export) drives the engine's own transport instead, so it
      * only needs the scheduling — this leaves isPlaying/isPaused/position
-     * untouched. Callers clearInstances() the pattern engine before and after the
-     * render so neither prior content nor this render's instances leak into the
-     * caller's session: flush() only rewinds active instances, so anything already
-     * scheduled stayed live and was rendered into the export alongside the timeline.
+     * untouched. Callers clearScheduledInstances() the pattern engine before and after
+     * the render so neither prior content nor this render's instances leak into the
+     * caller's session: rewindScheduledInstances() only rewinds active instances, so
+     * anything already scheduled stayed live and was rendered into the export alongside
+     * the timeline.
      */
     void scheduleTimelineForOfflineRender(double playStartPositionSeconds = 0.0) {
         scheduleTimelinePatternInstances(playStartPositionSeconds);
@@ -982,7 +984,7 @@ public:
         stop();
         // Arsenal playback is over: drop its instances rather than rewinding them, so
         // nothing carries into whatever plays next.
-        m_patternPlaybackEngine.clearInstances();
+        m_patternPlaybackEngine.clearScheduledInstances();
         if (!keepPatternMode) {
             m_patternMode.store(false, std::memory_order_relaxed);
         }
@@ -1185,13 +1187,13 @@ public:
         m_isPaused.store(false, std::memory_order_relaxed);
         m_position.store(startSeconds, std::memory_order_relaxed);
         m_playStartPosition.store(startSeconds, std::memory_order_relaxed);
-        // Arsenal preview means "play THIS pattern alone". flush() only rewinds, so
-        // whatever was already scheduled — timeline clip instances from a previous
-        // play(), or an earlier preview — kept sounding alongside it and was mixed
+        // Arsenal preview means "play THIS pattern alone". rewindScheduledInstances() only
+        // rewinds, so whatever was already scheduled — timeline clip instances from a
+        // previous play(), or an earlier preview — kept sounding alongside it and was mixed
         // into offline pattern renders too (a render_pattern was measured emitting 3
         // instances when the caller asked for one, inflating its peak by ~3 dB).
         // Start from an empty scheduler so the preview renders exactly what was asked for.
-        m_patternPlaybackEngine.clearInstances();
+        m_patternPlaybackEngine.clearScheduledInstances();
 
         {
             auto* pattern = m_patternManager.getPattern(pid);
@@ -1209,12 +1211,12 @@ public:
     }
 
     /**
-     * @brief Flush the Arsenal scheduler before arming a pattern for playback.
+     * @brief Rewind the Arsenal scheduler before arming a pattern for playback.
      * @param pid Pattern identifier prepared for playback.
      */
     void preparePatternForArsenal(PatternID pid) {
         (void)pid;
-        m_patternPlaybackEngine.flush();
+        m_patternPlaybackEngine.rewindScheduledInstances();
     }
 
     /**

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -179,7 +179,7 @@ public:
      * @param currentFrame Current transport frame. In looped pattern mode this
      *        is MONOTONIC (iteration * loopLengthSamples + wrapped position) so
      *        the window can pre-schedule the next iteration's events before the
-     *        wrap — flushing at the wrap and rescheduling on the next UI tick
+     *        wrap — rewinding at the wrap and rescheduling on the next UI tick
      *        made every loop's downbeat land late by the maintenance latency.
      * @param sampleRate Active sample rate.
      * @param lookaheadSamples Number of frames to schedule ahead.
@@ -200,23 +200,23 @@ public:
     void processAudio(uint64_t currentFrame, int bufferSize, const UnitMidiRoute* routes, size_t routeCount) noexcept;
 
     /**
-     * @brief Flush queued events and rewind active instances.
+     * @brief Rewind queued events and all scheduled instances.
      *
      * Rewind, NOT removal: instances stay scheduled and re-emit from the top. That is
-     * what a loop restart needs. Use clearInstances() when the content must not carry
-     * forward at all.
+     * what a loop restart needs. Use clearScheduledInstances() when the content must not
+     * carry forward at all.
      */
-    void flush();
+    void rewindScheduledInstances();
 
     /**
-     * @brief Drop every scheduled instance and queued event.
+     * @brief Remove every scheduled instance and queued event.
      *
      * For transitions that must not carry pattern content forward — leaving Arsenal, or
-     * starting timeline playback. flush() alone was insufficient there: it rewinds, so an
-     * Arsenal instance survived into timeline playback and kept sounding.
+     * starting timeline playback. rewindScheduledInstances() alone was insufficient there:
+     * it rewinds, so an Arsenal instance survived into timeline playback and kept sounding.
      * Control thread only (takes the scheduler mutex); the RT path reads m_rtQueue only.
      */
-    void clearInstances();
+    void clearScheduledInstances();
 
     /**
      * @brief Number of scheduled pattern instances (control thread).

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -2045,7 +2045,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     TrackManager& trackManager;
                     std::vector<float>& block;
                     ~TransportGuard() {
-                        // Full Arsenal teardown: stop, flush the scheduled
+                        // Full Arsenal teardown: stop, clear the scheduled
                         // instance, and leave pattern mode — a lingering
                         // pattern-mode flag or instance would bleed into the
                         // next timeline play/render.

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -578,10 +578,10 @@ void AudioEngine::setPatternPlaybackMode(bool enabled, double lengthBeats) {
     // A loop-length change while playing shifts the monotonic scheduling
     // domain (iteration * loopLen + pos) on both threads at once; already
     // queued events were stamped in the OLD domain and would never come due.
-    // Flush so the scheduler re-queues everything in the new domain.
+    // Rewind so the scheduler re-queues everything in the new domain.
     if (enabled && (!wasEnabled || std::abs(oldLength - lengthBeats) > 1e-9)) {
         if (auto* patEng = m_patternEngine.load(std::memory_order_acquire)) {
-            patEng->flush();
+            patEng->rewindScheduledInstances();
         }
     }
 }
@@ -624,19 +624,19 @@ void AudioEngine::performNonRealtimeMaintenance() {
                 if (loopLenSamples > 0) {
                     // BPM or sample-rate changes re-scale the sample domain:
                     // queued event timestamps and scheduledThroughFrame were
-                    // computed against the old loopLenSamples — flush so they
+                    // computed against the old loopLenSamples — rewind so they
                     // re-queue in the new domain (length-in-beats changes are
-                    // already flushed by setPatternPlaybackMode).
+                    // already rewound by setPatternPlaybackMode).
                     if (m_lastRefillLoopLenSamples != 0 && m_lastRefillLoopLenSamples != loopLenSamples) {
                         // m_patternMonotonicFrame is still encoded in the OLD
                         // loop-length domain until the audio callback republishes
                         // it (which it does every block, from the same BPM /
                         // length source). Refilling now with the new loopLen but
-                        // the stale frame would schedule an epoch ahead, so flush
+                        // the stale frame would schedule an epoch ahead, so rewind
                         // and DEFER this refill one maintenance tick — the next
                         // tick reads a coherent new-domain frame. The lookahead
                         // (~85ms) dwarfs one tick (~16ms), so no underrun.
-                        patEng->flush();
+                        patEng->rewindScheduledInstances();
                         m_lastRefillLoopLenSamples = loopLenSamples;
                         deferRefill = true; // skip the refill below this tick
                     } else {
@@ -813,7 +813,7 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     if (transportHardStop) {
         auto* pe = m_patternEngine.load(std::memory_order_relaxed);
         if (pe)
-            pe->flush();
+            pe->rewindScheduledInstances();
 
         resetCachedSamplerVoicesRt();
 
@@ -830,21 +830,21 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     //     m_fadeSamplesRemaining = FADE_OUT_SAMPLES;
     // }
 
-    // Flush Pattern Engine on Stop to prevent stale events.
+    // Rewind Pattern Engine on Stop to prevent stale events.
     // NOTE: normal stop does NOT cut one-shots (tails are allowed).
     if (transportStop) {
         auto* pe = m_patternEngine.load(std::memory_order_relaxed);
         if (pe)
-            pe->flush();
+            pe->rewindScheduledInstances();
     }
 
     // On transport restart (play start or seek):
-    // - flush pattern queue
+    // - rewind pattern queue
     // - in pattern mode, cut any still-playing one-shots so the loop restarts audibly
     if (transportRestart) {
         auto* pe = m_patternEngine.load(std::memory_order_relaxed);
         if (pe)
-            pe->flush();
+            pe->rewindScheduledInstances();
 
         if (patternModeNow) {
             resetCachedSamplerVoicesRt();
@@ -1023,13 +1023,13 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
 
             if (patternMode) {
                 // Pattern events are scheduled in a monotonic loop domain, so
-                // advance the epoch instead of flushing pre-scheduled events.
+                // advance the epoch instead of rewinding pre-scheduled events.
                 m_patternLoopIteration.fetch_add(1, std::memory_order_release);
             } else if (isPlaying) {
-                // Timeline loops keep the flush-on-wrap behavior.
+                // Timeline loops keep the rewind-on-wrap behavior.
                 auto* pe = m_patternEngine.load(std::memory_order_relaxed);
                 if (pe)
-                    pe->flush();
+                    pe->rewindScheduledInstances();
             }
             m_globalSamplePos.store(loopStartSample, std::memory_order_relaxed);
             renderGraph(graph, numFrames - loopSplitFrame, loopSplitFrame, patternFrame(loopStartSample));
@@ -3003,10 +3003,10 @@ void AudioEngine::panic() {
         }
     }
 
-    // 4. Flush pattern engine
+    // 4. Rewind pattern engine
     auto* pe = m_patternEngine.load(std::memory_order_relaxed);
     if (pe)
-        pe->flush();
+        pe->rewindScheduledInstances();
 }
 
 void AudioEngine::requestVoiceResetOnPatternChange() {

--- a/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
+++ b/AestraAudio/src/Headless/HeadlessMusicGenerator.cpp
@@ -52,7 +52,7 @@ HeadlessMusicGenerator& HeadlessMusicGenerator::setTempo(double bpm) {
     m_tempo = bpm;
     m_trackManager.getPlaylistModel().setBPM(bpm);
     m_trackManager.getTimelineClock().setTempo(bpm);
-    m_trackManager.getPatternPlaybackEngine().flush();
+    m_trackManager.getPatternPlaybackEngine().rewindScheduledInstances();
     m_engine.setBPM(static_cast<float>(bpm));
     return *this;
 }
@@ -396,7 +396,7 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // synchronous export leaves the caller's engine and session unchanged:
     //  - engine wiring (weak TrackManager ref, raw UnitManager*, owned slot map,
     //    graph copy, pattern-engine pointer) is cleared;
-    //  - the pattern-playback engine is flushed so the timeline instances this
+    //  - the pattern-playback engine is cleared so the timeline instances this
     //    render scheduled do not leak into the caller's TrackManager.
     // The transport flags/position are never touched (see
     // scheduleTimelineForOfflineRender below), so there is nothing else to undo.
@@ -410,8 +410,9 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
             engine.setChannelSlotMap(nullptr);
             engine.setTrackManager(nullptr);
             // Remove, don't rewind: this render's instances must not survive into the
-            // caller's session (flush() would leave them scheduled and merely restarted).
-            trackManager.getPatternPlaybackEngine().clearInstances();
+            // caller's session (rewindScheduledInstances() would leave them scheduled and
+            // merely restarted).
+            trackManager.getPatternPlaybackEngine().clearScheduledInstances();
         }
     };
 
@@ -438,12 +439,12 @@ bool HeadlessMusicGenerator::exportTo(const std::string& outputPath,
     // (AudioEngine::processBlock pops scheduled notes into unit MIDI routes).
     // Schedule the committed timeline into it WITHOUT starting live transport —
     // the exporter drives the engine's own transport, so we must not mutate the
-    // caller's playing flag / position. clearInstances() first removes any prior
+    // caller's playing flag / position. clearScheduledInstances() first removes any prior
     // contents; the render guard clears again on exit so these instances don't leak.
-    // flush() cannot serve here — it only REWINDS active instances (re-emit from the
-    // top, which a loop restart wants), so anything already scheduled would have been
-    // rendered into the export alongside the timeline we just asked for.
-    m_trackManager.getPatternPlaybackEngine().clearInstances();
+    // rewindScheduledInstances() cannot serve here — it only REWINDS active instances
+    // (re-emit from the top, which a loop restart wants), so anything already scheduled
+    // would have been rendered into the export alongside the timeline we just asked for.
+    m_trackManager.getPatternPlaybackEngine().clearScheduledInstances();
     m_trackManager.scheduleTimelineForOfflineRender(0.0);
 
     // Setup exporter

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -107,9 +107,10 @@ void PatternPlaybackEngine::schedulePatternInstance(PatternID pid, double startB
         // it (m_instanceCancelled is indexed by id), so two live entries sharing an id
         // were never individually addressable anyway. This used to push_back
         // unconditionally: the Arsenal preview always re-arms slot 1, and nothing ever
-        // erased entries (flush() only rewinds scheduledThroughFrame), so a session
-        // accumulated dozens of overlapping copies — 31 observed in one sitting — each
-        // emitting its own events into the same units. Re-arming a slot must replace it.
+        // erased entries (rewindScheduledInstances() only rewinds scheduledThroughFrame),
+        // so a session accumulated dozens of overlapping copies — 31 observed in one
+        // sitting — each emitting its own events into the same units. Re-arming a slot
+        // must replace it.
         auto existing = std::find_if(m_activeInstances.begin(), m_activeInstances.end(),
                                      [instanceId](const PatternInstance& e) { return e.instanceId == instanceId; });
         if (existing != m_activeInstances.end()) {
@@ -387,10 +388,10 @@ void PatternPlaybackEngine::processAudio(uint64_t currentFrame, int bufferSize, 
     }
 }
 
-void PatternPlaybackEngine::clearInstances() {
+void PatternPlaybackEngine::clearScheduledInstances() {
     // Control thread only — takes the scheduler mutex. processAudio() consumes m_rtQueue
     // and never reads m_activeInstances, so erasing here cannot race the audio thread.
-    if (reportRealtimeMisuse("PatternPlaybackEngine::clearInstances")) {
+    if (reportRealtimeMisuse("PatternPlaybackEngine::clearScheduledInstances")) {
         return;
     }
 
@@ -414,7 +415,7 @@ size_t PatternPlaybackEngine::getActiveInstanceCount() const {
     return m_activeInstances.size();
 }
 
-void PatternPlaybackEngine::flush() {
+void PatternPlaybackEngine::rewindScheduledInstances() {
     // RT-safe: set atomic flag for deferred processing by non-RT maintenance.
     // The SPSC queue and m_activeInstances are only safely mutable from the
     // control thread, so actual drain/reset happens in refillWindow().

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -963,7 +963,7 @@ void AestraApp::connectAudioToUI() {
                 if (auto trackManager = m_content->getTrackManager()) {
                     trackManager->getPlaylistModel().setBPM(bpm);
                     trackManager->getTimelineClock().setTempo(bpm);
-                    trackManager->getPatternPlaybackEngine().flush();
+                    trackManager->getPatternPlaybackEngine().rewindScheduledInstances();
                 }
                 if (auto trackManagerUI = m_content->getTrackManagerUI()) {
                     trackManagerUI->invalidateCache();
@@ -1620,7 +1620,7 @@ ProjectSerializer::LoadResult AestraApp::applyLoadedProject(const std::string& p
         if (auto trackManager = m_content->getTrackManager()) {
             trackManager->getPlaylistModel().setBPM(result.tempo);
             trackManager->getTimelineClock().setTempo(result.tempo);
-            trackManager->getPatternPlaybackEngine().flush();
+            trackManager->getPatternPlaybackEngine().rewindScheduledInstances();
             trackManager->setPosition(result.playhead);
             trackManager->setPlayStartPosition(result.playhead);
             trackManager->getCommandHistory().clear();

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1194,8 +1194,9 @@ void AestraContent::setupArsenalPanels() {
         }
         // Re-prepare the pattern so the playback engine re-schedules the notes
         // just edited in the Arsenal grid. Without this, newly placed steps stay
-        // silent during pattern playback until some other path flushes (e.g.
-        // editing the same pattern in the Piano Roll). Mirrors setActivePattern.
+        // silent during pattern playback until some other path rewinds the
+        // scheduler (e.g. editing the same pattern in the Piano Roll). Mirrors
+        // setActivePattern.
         if (m_trackManager) {
             m_trackManager->preparePatternForArsenal(patternId);
         }
@@ -2245,16 +2246,17 @@ void AestraContent::setViewFocus(ViewFocus focus) {
             // unconditionally below, so keying the TrackManager teardown off previousFocus
             // — where we came FROM rather than what state we are actually IN — lets the two
             // disagree for any path that reaches Timeline without previousFocus==Arsenal.
-            // With TrackManager left in pattern mode, play() skips BOTH the scheduler flush
-            // and scheduleTimelinePatternInstances(). Keyed off real state, matching the
-            // ENTERING AUDITION branch below, which was already written this way.
+            // With TrackManager left in pattern mode, play() skips BOTH the scheduler
+            // clear and scheduleTimelinePatternInstances(). Keyed off real state,
+            // matching the ENTERING AUDITION branch below, which was already written
+            // this way.
             // (Hardening: the observed limbo in this pass came from updatePatternLoopLength,
             // fixed separately. This asymmetry is latent, not the measured cause.)
             const bool leavingArsenal = (previousFocus == ViewFocus::Arsenal);
             const bool patternStillArmed = m_trackManager && m_trackManager->isPatternMode();
             if (leavingArsenal || patternStillArmed) {
                 if (patternStillArmed) {
-                    m_trackManager->stopArsenalPlayback(false); // clears the mirror AND flushes
+                    m_trackManager->stopArsenalPlayback(false); // clears the mirror AND the scheduler
                 } else if (m_trackManager && m_trackManager->isPlaying()) {
                     m_trackManager->stop();
                 }

--- a/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
+++ b/Tests/AestraAudio/ArsenalExportLiveParityTest.cpp
@@ -155,7 +155,7 @@ ScenarioResult runScenario(const std::filesystem::path& tempRoot,
     engine.setGlobalSamplePos(0);
     engine.setMetronomeEnabled(false);
     engine.setAuditionModeEnabled(false);
-    tm->getPatternPlaybackEngine().flush();
+    tm->getPatternPlaybackEngine().rewindScheduledInstances();
     tm->getPatternPlaybackEngine().schedulePatternInstance(patternId, 0.0, 1);
     engine.setTransportPlaying(true);
 
@@ -282,7 +282,7 @@ void runMixedScenario(const std::filesystem::path& tempRoot, float trackVolume) 
     engine.setGlobalSamplePos(0);
     engine.setMetronomeEnabled(false);
     engine.setAuditionModeEnabled(false);
-    tm->getPatternPlaybackEngine().flush();
+    tm->getPatternPlaybackEngine().rewindScheduledInstances();
     tm->getPatternPlaybackEngine().schedulePatternInstance(previewPatternId, 0.0, 1);
     tm->getPatternPlaybackEngine().schedulePatternInstance(trackPatternId, 0.0, 2);
     engine.setTransportPlaying(true);
@@ -409,7 +409,7 @@ void runIsolatedBounceScenario(const std::filesystem::path& tempRoot) {
     engine.setGlobalSamplePos(0);
     engine.setMetronomeEnabled(false);
     engine.setAuditionModeEnabled(false);
-    tm->getPatternPlaybackEngine().flush();
+    tm->getPatternPlaybackEngine().rewindScheduledInstances();
     tm->getPatternPlaybackEngine().schedulePatternInstance(track0PatId, 0.0, 1);
 
     // Full bounce (trackId=-1): Arsenal on track 0 audible.

--- a/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
+++ b/Tests/AestraAudio/PatternInstanceSlotReuseTest.cpp
@@ -1,9 +1,9 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 //
 // Regression: the pattern scheduler treated every schedulePatternInstance() call as a NEW
-// occurrence and appended it, while nothing ever erased entries — flush() only rewinds
-// (scheduledThroughFrame = 0) so instances re-emit from the top, which is what a loop
-// restart needs but not what leaving Arsenal needs.
+// occurrence and appended it, while nothing ever erased entries — rewindScheduledInstances()
+// only rewinds (scheduledThroughFrame = 0) so instances re-emit from the top, which is what
+// a loop restart needs but not what leaving Arsenal needs.
 //
 // Live consequence: the Arsenal preview always re-arms slot 1, so a session accumulated
 // dozens of overlapping copies of the same instance (31 observed in one sitting), each
@@ -12,7 +12,7 @@
 // transport.
 //
 // These assertions fail on the pre-fix engine: re-arming slot 1 five times left five live
-// instances, and clearInstances() did not exist.
+// instances, and clearScheduledInstances() did not exist.
 
 #include "Models/PatternManager.h"
 #include "Models/TrackManager.h"
@@ -84,18 +84,21 @@ int main() {
     engine.schedulePatternInstance(patternB, 8.0, 2);
     check(engine.getActiveInstanceCount() == 3, "re-arming slot 2 does not change the census");
 
-    // --- flush() REWINDS, it does not remove. Guard that distinction explicitly:
-    // conflating the two is what let an Arsenal instance survive into timeline playback.
-    engine.flush();
-    check(engine.getActiveInstanceCount() == 3, "flush() rewinds and must NOT drop instances");
+    // --- rewindScheduledInstances() REWINDS, it does not remove. Guard that distinction
+    // explicitly: conflating the two is what let an Arsenal instance survive into timeline
+    // playback.
+    engine.rewindScheduledInstances();
+    check(engine.getActiveInstanceCount() == 3,
+          "rewindScheduledInstances() rewinds and must NOT drop instances");
 
-    // --- clearInstances() removes outright. ---
-    engine.clearInstances();
-    check(engine.getActiveInstanceCount() == 0, "clearInstances() drops every instance");
+    // --- clearScheduledInstances() removes outright. ---
+    engine.clearScheduledInstances();
+    check(engine.getActiveInstanceCount() == 0, "clearScheduledInstances() drops every instance");
 
     // Usable again afterwards.
     engine.schedulePatternInstance(patternA, 0.0, 1);
-    check(engine.getActiveInstanceCount() == 1, "scheduler still usable after clearInstances()");
+    check(engine.getActiveInstanceCount() == 1,
+          "scheduler still usable after clearScheduledInstances()");
 
     // Out-of-range ids are rejected without corrupting the census.
     engine.schedulePatternInstance(patternA, 0.0, 999);
@@ -105,9 +108,10 @@ int main() {
     //
     // scheduleTimelinePatternInstances() allocates ids from 2 upward and reserves 1 for the
     // Arsenal preview, so a timeline play() leaves ids 2..N scheduled. playPatternInArsenal()
-    // used to call flush(), which only rewinds — those clip instances stayed live and were
-    // mixed into the preview AND into offline render_pattern output. Measured directly: a
-    // render that asked for one pattern emitted three instances, inflating its peak from
+    // used to call rewindScheduledInstances(), which only rewinds — those clip instances
+    // stayed live and were mixed into the preview AND into offline render_pattern output.
+    // Measured directly: a render that asked for one pattern emitted three instances,
+    // inflating its peak from
     // 0.094194 to 0.133211 (~3 dB) and breaking MuseServiceTest's half-gain ratio.
     //
     // Arsenal preview means "play THIS pattern alone". Assert that boundary directly rather

--- a/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
+++ b/Tests/AestraAudio/PatternPlaybackTempoChangeTest.cpp
@@ -57,14 +57,14 @@ int main() {
     playback.refillWindow(0, sampleRate, sampleRate * 3);
 
     clock.setTempo(60.0);
-    playback.flush();
+    playback.rewindScheduledInstances();
     playback.refillWindow(0, sampleRate, sampleRate * 3);
 
     MidiBuffer midiAtOldTempoFrame;
     PatternPlaybackEngine::UnitMidiRoute route{unitId, &midiAtOldTempoFrame};
     playback.processAudio(sampleRate, 128, &route, 1);
     if (hasNoteOn(midiAtOldTempoFrame, pitch)) {
-        std::cerr << "stale note-on fired at old 120 BPM frame after tempo flush\n";
+        std::cerr << "stale note-on fired at old 120 BPM frame after tempo rewind\n";
         return 1;
     }
 

--- a/Tests/Headless/HeadlessExportInstanceIsolationTest.cpp
+++ b/Tests/Headless/HeadlessExportInstanceIsolationTest.cpp
@@ -4,8 +4,8 @@
 // HeadlessMusicGenerator::exportTo() claims, in both its own comments and
 // TrackManager::scheduleTimelineForOfflineRender()'s docs, that the pattern engine is
 // cleared before the render and again on exit "so the render's scheduled instances do not
-// leak". It implemented that with flush() — which only REWINDS active instances
-// (scheduledThroughFrame = 0, re-emit from the top) and never removes them.
+// leak". It implemented that with rewindScheduledInstances() — which only REWINDS active
+// instances (scheduledThroughFrame = 0, re-emit from the top) and never removes them.
 //
 // Consequence: anything already scheduled when exportTo() is called — an Arsenal preview,
 // clip instances from a previous play() — was still live during the render and got mixed

--- a/Tests/Headless/RumbleArsenalAudibleTest.cpp
+++ b/Tests/Headless/RumbleArsenalAudibleTest.cpp
@@ -100,7 +100,7 @@ int main() {
     engine.setGlobalSamplePos(0);
     engine.setTransportPlaying(true);
 
-    playbackEngine.flush();
+    playbackEngine.rewindScheduledInstances();
     playbackEngine.schedulePatternInstance(patternId, 0.0, 1);
 
     std::vector<float> output(blockSize * channels, 0.0f);


### PR DESCRIPTION
## Summary

Renames the pattern scheduler API on `PatternPlaybackEngine` so each method says what it does:

| Before | After | Semantics |
| ------ | ----- | --------- |
| `flush()` | `rewindScheduledInstances()` | Rewind, NOT removal: instances stay scheduled and re-emit from the top (what a loop restart needs) |
| `clearInstances()` | `clearScheduledInstances()` | Remove every scheduled instance and queued event (what leaving Arsenal / starting timeline / export isolation needs) |

All declarations, definitions, call sites (AudioEngine transport roles, TrackManager play/stopArsenal/arsenal preview, HeadlessMusicGenerator setTempo + export clears, AestraApp tempo/load paths) and directly-stale comments updated. Tests renamed to the new symbols; the assertions themselves are untouched and keep protecting both semantics.

## Why

The original `flush()` name was dangerous because its conventional meaning suggested disposal, while the implementation actually performed a rewind. The AS-736 export-isolation work made this hazard load-bearing: a caller reaching for "clear" could grab rewind semantics and leak Arsenal instances into a timeline render. The renamed API encodes the distinction reviewers and callers were tripping over.

## Testing performed

- Focused: `PatternInstanceSlotReuseTest`, `PatternPlaybackTempoChangeTest`, `ArsenalExportLiveParityTest` — all pass
- Full suite: 224/224 pass (`ctest --test-dir build-linux`)
- `RumbleArsenalAudibleTest` renamed but not buildable here (premium-gated, requires `AestraPremiumPlugins`); change is a pure 1:1 symbol rename
- No audio output, latency, or state-format change: this is a rename only

## Producer note

None

## Docs updated?

No (internal API only; no public docs reference these symbols)

## Risk / rollback notes

- Pure mechanical rename; `git log -S` searchable for both old names should return zero hits outside CLAP's unrelated `params.flush()` and denormal-flush helpers
- Private member `m_flushRequested` intentionally left as-is (implementation detail, out of scope)
- Rollback: revert both commits; no migration needed

Decision: FD-12 @ a30696a
Kind: corrective
Reversal: —

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking API change:** Renamed `flush()` to `rewindScheduledInstances()` and `clearInstances()` to `clearScheduledInstances()` in `PatternPlaybackEngine`.
- Updated production call sites, comments, and tests across transport, track management, tempo changes, headless export, and application loading.
- Clarified that rewinding preserves scheduled instances, while clearing removes scheduled instances and queued events.
- Preserved runtime behavior, audio output, latency, and state formats.
- Focused tests and the full suite pass: **224/224 tests**. `RumbleArsenalAudibleTest` could not build because it requires premium-gated plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->