### PR TITLE
feat(ui): PianoRoll first-class workspace via headless WorkspaceFocus model

### DIFF
--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -2039,8 +2039,8 @@ ProjectSerializer::UIState AestraApp::captureUIState() const {
     // Phase-3 workspace state: active workspace + remembered-open overlays.
     if (m_content) {
         state.viewFocus = WorkspaceFocusModel::workspaceFocusName(m_content->getViewFocus());
-        state.pianoRollOpen = m_content->getViewState().pianoRollOpen;
-        state.sequencerOpen = m_content->getViewState().sequencerOpen;
+        state.pianoRollOpen = m_content->isPianoRollOpen();
+        state.sequencerOpen = m_content->isSequencerOpen();
     }
 
     return state;
@@ -2063,12 +2063,12 @@ void AestraApp::applyUIState(const ProjectSerializer::UIState& state) {
     }
 
     // Restore persisted workspace state. Legacy files leave viewFocus empty,
-    // which keeps the default Timeline workspace.
+    // which keeps the default Timeline workspace; a malformed value likewise
+    // falls back to Timeline while still restoring the remembered-open flags.
     if (m_content) {
         ViewFocus focus = ViewFocus::Timeline;
-        if (WorkspaceFocusModel::parseWorkspaceFocus(state.viewFocus, focus)) {
-            m_content->restoreWorkspaceState(focus, state.pianoRollOpen, state.sequencerOpen);
-        }
+        WorkspaceFocusModel::parseWorkspaceFocus(state.viewFocus, focus);
+        m_content->restoreWorkspaceState(focus, state.pianoRollOpen, state.sequencerOpen);
     }
 }
 

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -2036,6 +2036,13 @@ ProjectSerializer::UIState AestraApp::captureUIState() const {
         }
     }
 
+    // Phase-3 workspace state: active workspace + remembered-open overlays.
+    if (m_content) {
+        state.viewFocus = WorkspaceFocusModel::workspaceFocusName(m_content->getViewFocus());
+        state.pianoRollOpen = m_content->getViewState().pianoRollOpen;
+        state.sequencerOpen = m_content->getViewState().sequencerOpen;
+    }
+
     return state;
 }
 
@@ -2052,6 +2059,15 @@ void AestraApp::applyUIState(const ProjectSerializer::UIState& state) {
             settingsDialog->show();
         } else {
             settingsDialog->hide();
+        }
+    }
+
+    // Restore persisted workspace state. Legacy files leave viewFocus empty,
+    // which keeps the default Timeline workspace.
+    if (m_content) {
+        ViewFocus focus = ViewFocus::Timeline;
+        if (WorkspaceFocusModel::parseWorkspaceFocus(state.viewFocus, focus)) {
+            m_content->restoreWorkspaceState(focus, state.pianoRollOpen, state.sequencerOpen);
         }
     }
 }

--- a/Source/App/MuseHostVerbs.cpp
+++ b/Source/App/MuseHostVerbs.cpp
@@ -70,15 +70,10 @@ bool lookupView(const std::string& name, ViewType& out) {
 }
 
 // The workspace modes, as protocol strings. Same contract as kViews: agents will
-// hardcode these, so renaming one is a breaking change.
+// hardcode these, so renaming one is a breaking change. Single source of truth:
+// WorkspaceFocusModel::workspaceFocusName (includes the PianoRoll workspace).
 const char* focusName(::ViewFocus focus) {
-    switch (focus) {
-    case ::ViewFocus::Arsenal:    return "arsenal";
-    case ::ViewFocus::Timeline:   return "timeline";
-    case ::ViewFocus::Audition:   return "audition";
-    case ::ViewFocus::RoutingMap: return "routingMap";
-    }
-    return "unknown";
+    return WorkspaceFocusModel::workspaceFocusName(focus);
 }
 
 HostVerbArg viewArg() {

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -25,6 +25,7 @@ set(Aestra_SOURCES
 	Core/AestraRootComponent.cpp
 	Core/AestraContent.h
 	Core/AestraContent.cpp
+	Core/WorkspaceFocus.h
 	Core/MusicalTypingController.h
 	Core/MusicalTypingController.cpp
 	Core/ProjectDocumentState.h

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2374,10 +2374,10 @@ void AestraContent::setViewFocus(ViewFocus focus) {
                 m_routingMapPanel->bringToFront();
                 m_routingMapPanel->setDirty(true);
             }
-            // Keep mixer visible so user still sees context
-            if (m_mixerPanel && m_viewState.mixerOpen) {
-                m_mixerPanel->setVisible(true);
-            }
+            // Keep mixer visible so user still sees context. The centralized
+            // visibility rules also hide the piano roll and sequencer and
+            // unregister sequencer drop targets for the map's isolation.
+            applyOverlayPanelVisibility(focus);
             AESTRA_LOG_DEBUG("[ViewFocus] Entering Routing Map");
         }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -267,26 +267,13 @@ AestraContent::AestraContent()
     // Create Focus Toggle Buttons
     auto& theme = AestraUI::NUIThemeManager::getInstance();
     const auto& themeProps = theme.getCurrentTheme();
-    m_viewToggle =
-        std::make_shared<AestraUI::NUISegmentedControl>(std::vector<std::string>{"Arsenal", "Timeline", "Audition"});
+    m_viewToggle = std::make_shared<AestraUI::NUISegmentedControl>(
+        std::vector<std::string>(WorkspaceFocusModel::kSegmentLabels.begin(),
+                                 WorkspaceFocusModel::kSegmentLabels.end()));
     m_viewToggle->setCornerRadius(themeProps.radiusL);             // tokenized: 12.0
     m_viewToggle->setAccentColor(theme.getColor("primary"));        // tokenized: theme accent
     m_viewToggle->setOnSelectionChanged([this](size_t index) {
-        ViewFocus newFocus;
-        switch (index) {
-        case 0:
-            newFocus = ViewFocus::Arsenal;
-            break;
-        case 1:
-            newFocus = ViewFocus::Timeline;
-            break;
-        case 2:
-            newFocus = ViewFocus::Audition;
-            break;
-        default:
-            newFocus = ViewFocus::Timeline;
-            break;
-        }
+        ViewFocus newFocus = WorkspaceFocusModel::focusForSegmentIndex(index);
         setViewFocus(newFocus);
 
         // Auto-open Arsenal panel when switching TO Arsenal mode
@@ -2182,26 +2169,20 @@ void AestraContent::setViewFocus(ViewFocus focus) {
 
     m_viewFocus = focus;
 
-    auto applyOverlayPanelVisibility = [this](bool auditionMode) {
-        if (auditionMode) {
-            if (m_mixerPanel)
-                m_mixerPanel->setVisible(false);
-            if (m_pianoRollPanel)
-                m_pianoRollPanel->setVisible(false);
-            if (m_sequencerPanel) {
-                m_sequencerPanel->setVisible(false);
-                m_sequencerPanel->unregisterDropTargets();
-            }
-            return;
-        }
-
+    auto applyOverlayPanelVisibility = [this](ViewFocus activeFocus) {
+        // Overlay visibility is derived from remembered-open state + active
+        // focus (see WorkspaceFocusModel::derivePanelVisibility). RoutingMap
+        // never reaches here: its branch manages its own panel and mixer.
+        const WorkspaceFocusModel::WorkspacePanelVisibility vis =
+            WorkspaceFocusModel::derivePanelVisibility(activeFocus, m_viewState.mixerOpen,
+                                                       m_viewState.pianoRollOpen, m_viewState.sequencerOpen);
         if (m_mixerPanel)
-            m_mixerPanel->setVisible(m_viewState.mixerOpen);
+            m_mixerPanel->setVisible(vis.mixer);
         if (m_pianoRollPanel)
-            m_pianoRollPanel->setVisible(m_viewState.pianoRollOpen);
+            m_pianoRollPanel->setVisible(vis.pianoRoll);
         if (m_sequencerPanel) {
-            m_sequencerPanel->setVisible(m_viewState.sequencerOpen);
-            if (m_viewState.sequencerOpen) {
+            m_sequencerPanel->setVisible(vis.sequencer);
+            if (vis.sequencer) {
                 m_sequencerPanel->registerDropTargets(true);
             } else {
                 m_sequencerPanel->unregisterDropTargets();
@@ -2358,7 +2339,7 @@ void AestraContent::setViewFocus(ViewFocus focus) {
             m_auditionPanel->setVisible(true);
             if (m_trackManagerUI)
                 m_trackManagerUI->setVisible(false);
-            applyOverlayPanelVisibility(true);
+            applyOverlayPanelVisibility(focus);
 
             // POLISH: Hide Transport, Pattern Browser, and Visualizers for immersion
             if (m_transportBar)
@@ -2371,6 +2352,17 @@ void AestraContent::setViewFocus(ViewFocus focus) {
                 m_audioVisualizer->setVisible(false);
 
             AESTRA_LOG_DEBUG("[ViewFocus] Entering Audition Mode");
+        }
+        // === ENTERING PIANO ROLL ===
+        else if (focus == ViewFocus::PianoRoll) {
+            // PianoRoll is an ordinary workspace: pure visibility change, no
+            // transport/engine mutation (no stop/play/panic/position/mode
+            // changes, no pattern-clip-preview teardown, no scheduled-instance
+            // clearing). Overlay visibility (including the piano roll itself)
+            // is derived from remembered-open state by the global block below.
+            if (m_trackManagerUI)
+                m_trackManagerUI->setVisible(true);
+            AESTRA_LOG_DEBUG("[ViewFocus] Entering Piano Roll");
         }
         // === ENTERING ROUTING MAP ===
         else if (focus == ViewFocus::RoutingMap) {
@@ -2420,7 +2412,7 @@ void AestraContent::setViewFocus(ViewFocus focus) {
                 m_waveformVisualizer->setVisible(true);
             if (m_audioVisualizer)
                 m_audioVisualizer->setVisible(true);
-            applyOverlayPanelVisibility(false);
+            applyOverlayPanelVisibility(focus);
         } else if (isAudition) {
             // Audition Mode - Hide Distractions
             if (m_transportBar)
@@ -2431,17 +2423,14 @@ void AestraContent::setViewFocus(ViewFocus focus) {
                 m_waveformVisualizer->setVisible(false);
             if (m_audioVisualizer)
                 m_audioVisualizer->setVisible(false);
-            applyOverlayPanelVisibility(true);
+            applyOverlayPanelVisibility(focus);
         }
 
         // Sync segment control to reflect the new focus
         if (m_viewToggle) {
-            size_t idx = 0;
-            if (focus == ViewFocus::Arsenal) idx = 0;
-            else if (focus == ViewFocus::Timeline) idx = 1;
-            else if (focus == ViewFocus::Audition) idx = 2;
             // RoutingMap doesn't map to a toggle segment; leave prior selection
-            if (focus != ViewFocus::RoutingMap) {
+            size_t idx = 0;
+            if (WorkspaceFocusModel::segmentIndexForFocus(focus, idx)) {
                 m_viewToggle->setSelectedIndex(idx);
             }
         }
@@ -2455,16 +2444,29 @@ void AestraContent::setViewFocus(ViewFocus focus) {
         m_transportBar->setViewToggled(Audio::ViewType::Sequencer, focus == ViewFocus::Arsenal);
     }
 
-    // Hot-swap playback if needed (only for Arsenal/Timeline swap, not Audition or RoutingMap)
-    bool isRoutingMapTransition = (focus == ViewFocus::RoutingMap || previousFocus == ViewFocus::RoutingMap);
-    if (wasPlaying && m_transportBar && !isRoutingMapTransition &&
-        focus != ViewFocus::Audition && previousFocus != ViewFocus::Audition) {
+    // Hot-swap playback on focus switch. Only Arsenal<->Timeline re-arms the
+    // transport (pattern == arrangement); Audition and RoutingMap transitions
+    // and every ordinary workspace transition (incl. PianoRoll pairs) leave
+    // playback/scheduled-instances untouched.
+    const auto transitionKind = WorkspaceFocusModel::classifyTransition(focus, previousFocus);
+    if (wasPlaying && m_transportBar &&
+        transitionKind == WorkspaceFocusModel::WorkspaceTransitionKind::PlaybackHotSwap) {
         AESTRA_LOG_DEBUG("[Focus] Hot-swapping playback mode");
         m_transportBar->stop();
         m_transportBar->play();
     }
 
     isUpdating = false;
+}
+
+void AestraContent::restoreWorkspaceState(ViewFocus focus, bool pianoRollOpen, bool sequencerOpen) {
+    // Restore remembered-open flags first, then the workspace focus. Because
+    // setViewFocus caches engine mode/mirrors keyed off `wasPlaying` and the
+    // current focus, restoring focus first would have the overlay visibility
+    // derive from the pre-restore flags.
+    m_viewState.pianoRollOpen = pianoRollOpen;
+    m_viewState.sequencerOpen = sequencerOpen;
+    setViewFocus(focus);
 }
 
 void AestraContent::setArsenalPanelVisible(bool visible) {
@@ -2914,13 +2916,15 @@ void AestraContent::stopPatternClipPreview(bool restoreTimelineUi) {
 
 ViewFocus AestraContent::resolveTransportFocus() const {
     if (m_viewToggle) {
-        switch (m_viewToggle->getSelectedIndex()) {
-        case 0:
+        const ViewFocus segmentFocus =
+            WorkspaceFocusModel::focusForSegmentIndex(m_viewToggle->getSelectedIndex());
+        switch (segmentFocus) {
+        case ViewFocus::Arsenal:
             return ViewFocus::Arsenal;
-        case 2:
+        case ViewFocus::Audition:
             return ViewFocus::Audition;
-        case 1:
         default:
+            // Timeline and PianoRoll share the arrangement transport context.
             return ViewFocus::Timeline;
         }
     }
@@ -3200,6 +3204,12 @@ void AestraContent::openPatternInPianoRoll(PatternID patternId) {
     m_viewState.pianoRollRect = AestraUI::NUIRect(editorX, editorY, editorWidth, editorHeight);
     m_pianoRollPanel->loadPattern(patternId);
     setViewOpen(Audio::ViewType::PianoRoll, true);
+    // Contextual pattern navigation reaches the PianoRoll workspace through the
+    // same single control point as the segmented control. This is an ordinary
+    // (pure-visibility) transition: it never touches playback/engine state.
+    if (m_viewFocus != ViewFocus::PianoRoll) {
+        setViewFocus(ViewFocus::PianoRoll);
+    }
 }
 
 Aestra::Audio::UnitID AestraContent::resolveEditingUnitForPattern(PatternID patternId) const {
@@ -4280,15 +4290,18 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
     if (event.keyCode == AestraUI::NUIKeyCode::Space) {
         ViewFocus transportFocus = m_viewFocus;
         if (m_viewToggle) {
-            switch (m_viewToggle->getSelectedIndex()) {
-            case 0:
+            const ViewFocus segmentFocus =
+                WorkspaceFocusModel::focusForSegmentIndex(m_viewToggle->getSelectedIndex());
+            switch (segmentFocus) {
+            case ViewFocus::Arsenal:
                 transportFocus = ViewFocus::Arsenal;
                 break;
-            case 2:
+            case ViewFocus::Audition:
                 transportFocus = ViewFocus::Audition;
                 break;
-            case 1:
+            case ViewFocus::Timeline:
             default:
+                // PianoRoll shares the arrangement transport context.
                 transportFocus = ViewFocus::Timeline;
                 break;
             }

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -214,8 +214,10 @@ public:
     void setViewFocus(ViewFocus focus);
     /** @brief Get the active workspace mode. */
     ViewFocus getViewFocus() const { return m_viewFocus; }
-    /** @brief Get the remembered-open overlay state (for project persistence). */
-    const ViewState& getViewState() const { return m_viewState; }
+    /** @brief Whether the piano-roll overlay is remembered-open (for persistence). */
+    bool isPianoRollOpen() const { return m_viewState.pianoRollOpen; }
+    /** @brief Whether the sequencer overlay is remembered-open (for persistence). */
+    bool isSequencerOpen() const { return m_viewState.sequencerOpen; }
     /**
      * @brief Restore persisted workspace state (project load).
      * Restores the remembered-open overlay flags, then applies the workspace

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -80,16 +80,10 @@ namespace AestraUI {
     class PluginBrowserPanel;
 }
 
-/**
- * @brief View focus - which part of the UI is emphasized
- * Arsenal, Timeline, and Audition are the three main modes
- */
-enum class ViewFocus {
-    Arsenal,     // Pattern construction/sound design
-    Timeline,    // Arrangement/composition
-    Audition,    // Album listening/reference/DSP preview
-    RoutingMap   // Full-panel routing visualization
-};
+// ViewFocus and the workspace-focus model (segment mapping, transition
+// classification, visibility derivation) live in WorkspaceFocus.h — a pure,
+// headless-constructible module shared by the app and the table-driven tests.
+#include "WorkspaceFocus.h"
 
 /**
  * @brief Playback scope - what the transport will play
@@ -220,6 +214,15 @@ public:
     void setViewFocus(ViewFocus focus);
     /** @brief Get the active workspace mode. */
     ViewFocus getViewFocus() const { return m_viewFocus; }
+    /** @brief Get the remembered-open overlay state (for project persistence). */
+    const ViewState& getViewState() const { return m_viewState; }
+    /**
+     * @brief Restore persisted workspace state (project load).
+     * Restores the remembered-open overlay flags, then applies the workspace
+     * focus through the single control point. Optional on load: callers that
+     * have no persisted state simply keep the defaults.
+     */
+    void restoreWorkspaceState(ViewFocus focus, bool pianoRollOpen, bool sequencerOpen);
 
     /** @brief Explicitly show or hide the Arsenal panel. */
     void setArsenalPanelVisible(bool visible);

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "ProjectSerializer.h"
 #include "ProjectMigrations.h"
+#include "WorkspaceFocus.h"
 #include "AestraFile.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "MiniAudioDecoder.h"
@@ -1026,6 +1027,13 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
         settings.set("activePage", JSON(uiState->settingsDialogActivePage));
         ui.set("settingsDialog", settings);
 
+        // Phase-3 workspace state (optional on load; written on every save).
+        if (!uiState->viewFocus.empty()) {
+            ui.set("viewFocus", JSON(uiState->viewFocus));
+        }
+        ui.set("pianoRollOpen", JSON(uiState->pianoRollOpen));
+        ui.set("sequencerOpen", JSON(uiState->sequencerOpen));
+
         JSON panels = JSON::array();
         for (const auto& p : uiState->panels) {
             JSON pj = JSON::object();
@@ -1456,6 +1464,24 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             if (sd.has("activePage") && sd["activePage"].isString()) {
                 uiState.settingsDialogActivePage = sd["activePage"].asString();
             }
+        }
+
+        // Phase-3 workspace state: all keys optional (pre-phase-3 files keep the
+        // historical defaults: Timeline focus, overlays closed).
+        if (ui.has("viewFocus") && ui["viewFocus"].isString()) {
+            const std::string focusName = ui["viewFocus"].asString();
+            if (focusName.size() <= 32) {
+                ViewFocus parsed;
+                if (WorkspaceFocusModel::parseWorkspaceFocus(focusName, parsed)) {
+                    uiState.viewFocus = focusName;
+                }
+            }
+        }
+        if (ui.has("pianoRollOpen") && ui["pianoRollOpen"].isBool()) {
+            uiState.pianoRollOpen = ui["pianoRollOpen"].asBool();
+        }
+        if (ui.has("sequencerOpen") && ui["sequencerOpen"].isBool()) {
+            uiState.sequencerOpen = ui["sequencerOpen"].asBool();
         }
 
         if (ui.has("panels") && ui["panels"].isArray()) {

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -66,6 +66,16 @@ public:
         bool settingsDialogVisible{false};
         std::string settingsDialogActivePage;
         std::vector<PanelState> panels;
+
+        // Phase-3 workspace state. All three are OPTIONAL in project files:
+        // files saved before they existed load with the historical defaults
+        // (Timeline workspace, overlays closed) — see the loader's has() guards.
+        // `viewFocus` matches WorkspaceFocusModel::workspaceFocusName
+        // ("arsenal|timeline|audition|routingMap|pianoRoll"); empty means the
+        // loader keeps the default Timeline focus.
+        std::string viewFocus;
+        bool pianoRollOpen{false};
+        bool sequencerOpen{false};
     };
 
     /**

--- a/Source/Core/WorkspaceFocus.h
+++ b/Source/Core/WorkspaceFocus.h
@@ -1,0 +1,213 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+/**
+ * @file WorkspaceFocus.h
+ * @brief Pure, headless-constructible workspace-focus model.
+ *
+ * Phase-3 "workspace panel ownership": the segmented control, ViewFocus
+ * transitions, and overlay-panel visibility all key off this single model so
+ * the segment index<->focus mapping, transition classification, and
+ * remembered-open derivation are table-testable without constructing
+ * AestraContent (which cannot be built headlessly; see
+ * Tests/AestraAudio/ProjectDirtyStateTest.cpp).
+ *
+ * The model owns no state; all functions are pure. ViewFocus stays an
+ * app-level, global-scope enum so existing protocol/file users keep compiling
+ * unchanged (the protocol strings live here too, next to the enum).
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+/**
+ * @brief View focus - which workspace is emphasized.
+ * Arsenal, Timeline, and Audition are the three main modes; RoutingMap is a
+ * full-panel overlay; PianoRoll is a first-class workspace reachable from the
+ * segmented control and from contextual pattern navigation.
+ */
+enum class ViewFocus {
+    Arsenal,    // Pattern construction/sound design
+    Timeline,   // Arrangement/composition
+    Audition,   // Album listening/reference/DSP preview
+    RoutingMap, // Full-panel routing visualization
+    PianoRoll   // Pattern editing workspace
+};
+
+namespace WorkspaceFocusModel {
+
+/**
+ * @brief Canonical segmented-control segments, in displayed order.
+ * Segment 3 (PianoRoll) is the phase-3 addition. The array is capture-by-value
+ * at NUISegmentedControl construction, so a fourth segment must be present
+ * here up front.
+ */
+inline constexpr size_t kSegmentCount = 4;
+inline constexpr std::array<const char*, kSegmentCount> kSegmentLabels = {"Arsenal", "Timeline", "Audition",
+                                                                          "PianoRoll"};
+
+/** @brief True when the focus owns a segmented-control segment. */
+inline constexpr bool hasSegment(ViewFocus focus) {
+    return focus != ViewFocus::RoutingMap;
+}
+
+/**
+ * @brief Segment index -> focus.
+ * Out-of-range indices fall back to Timeline, matching the pre-existing toggle
+ * default behavior.
+ */
+inline ViewFocus focusForSegmentIndex(size_t index) {
+    switch (index) {
+    case 0:
+        return ViewFocus::Arsenal;
+    case 1:
+        return ViewFocus::Timeline;
+    case 2:
+        return ViewFocus::Audition;
+    case 3:
+        return ViewFocus::PianoRoll;
+    default:
+        return ViewFocus::Timeline;
+    }
+}
+
+/**
+ * @brief Focus -> segment index.
+ * @return True when the focus owns a segment (outIndex is written). False for
+ * foci without one (RoutingMap) — callers leave the prior selection untouched.
+ */
+inline bool segmentIndexForFocus(ViewFocus focus, size_t& outIndex) {
+    switch (focus) {
+    case ViewFocus::Arsenal:
+        outIndex = 0;
+        return true;
+    case ViewFocus::Timeline:
+        outIndex = 1;
+        return true;
+    case ViewFocus::Audition:
+        outIndex = 2;
+        return true;
+    case ViewFocus::PianoRoll:
+        outIndex = 3;
+        return true;
+    case ViewFocus::RoutingMap:
+        return false;
+    }
+    return false;
+}
+
+/**
+ * @brief What a focus switch is allowed to mutate.
+ * This is the single source of truth used by the transport paths in
+ * AestraContent. Ordinary transitions (including every PianoRoll pair) are
+ * pure visibility changes: no playback, pause, position, scheduled-instance,
+ * or engine-mode mutation.
+ */
+enum class WorkspaceTransitionKind {
+    PlaybackHotSwap, // Arsenal<->Timeline: re-arm pattern/arrangement transport (stop + play)
+    Audition,        // enters or exits Audition: full teardown + audition engine
+    RoutingMap,      // enters or exits RoutingMap: overlay only
+    Ordinary         // everything else: pure visibility, zero transport/engine mutation
+};
+
+/** @brief Classify a current<->previous focus pair. */
+inline WorkspaceTransitionKind classifyTransition(ViewFocus current, ViewFocus previous) {
+    if (current == ViewFocus::Audition || previous == ViewFocus::Audition) {
+        return WorkspaceTransitionKind::Audition;
+    }
+    if (current == ViewFocus::RoutingMap || previous == ViewFocus::RoutingMap) {
+        return WorkspaceTransitionKind::RoutingMap;
+    }
+    const bool currentIsDaw = (current == ViewFocus::Arsenal || current == ViewFocus::Timeline);
+    const bool previousIsDaw = (previous == ViewFocus::Arsenal || previous == ViewFocus::Timeline);
+    if (currentIsDaw && previousIsDaw) {
+        return WorkspaceTransitionKind::PlaybackHotSwap;
+    }
+    return WorkspaceTransitionKind::Ordinary;
+}
+
+/** @brief True when either side of the transition is Audition. */
+inline bool isAuditionTransition(ViewFocus current, ViewFocus previous) {
+    return classifyTransition(current, previous) == WorkspaceTransitionKind::Audition;
+}
+
+/** @brief True when either side of the transition is RoutingMap. */
+inline bool isRoutingMapTransition(ViewFocus current, ViewFocus previous) {
+    return classifyTransition(current, previous) == WorkspaceTransitionKind::RoutingMap;
+}
+
+/** @brief True for ordinary (pure-visibility) transitions, including PianoRoll pairs. */
+inline bool isOrdinaryWorkspaceTransition(ViewFocus current, ViewFocus previous) {
+    return classifyTransition(current, previous) == WorkspaceTransitionKind::Ordinary;
+}
+
+/**
+ * @brief Effective overlay-panel visibility for a focus, derived from the
+ *        remembered-open state. Ordinary workspaces (Timeline/Arsenal/
+ *        PianoRoll) restore overlays from remembered-open; Audition hides
+ *        everything; RoutingMap shows only the mixer over its own map panel.
+ */
+struct WorkspacePanelVisibility {
+    bool mixer = false;
+    bool pianoRoll = false;
+    bool sequencer = false;
+};
+
+inline WorkspacePanelVisibility derivePanelVisibility(ViewFocus focus, bool mixerOpen, bool pianoRollOpen,
+                                                      bool sequencerOpen) {
+    if (focus == ViewFocus::Audition) {
+        return {false, false, false};
+    }
+    if (focus == ViewFocus::RoutingMap) {
+        return {mixerOpen, false, false};
+    }
+    return {mixerOpen, pianoRollOpen, sequencerOpen};
+}
+
+/**
+ * @brief Stable protocol/persistence name for a focus. Agents and project files
+ *        hardcode these strings; renaming one is a breaking change.
+ */
+inline const char* workspaceFocusName(ViewFocus focus) {
+    switch (focus) {
+    case ViewFocus::Arsenal:
+        return "arsenal";
+    case ViewFocus::Timeline:
+        return "timeline";
+    case ViewFocus::Audition:
+        return "audition";
+    case ViewFocus::RoutingMap:
+        return "routingMap";
+    case ViewFocus::PianoRoll:
+        return "pianoRoll";
+    }
+    return "unknown";
+}
+
+/** @brief Parse a persisted/protocol focus name (case-sensitive, matching workspaceFocusName). */
+inline bool parseWorkspaceFocus(const std::string& name, ViewFocus& out) {
+    if (name == "arsenal") {
+        out = ViewFocus::Arsenal;
+        return true;
+    }
+    if (name == "timeline") {
+        out = ViewFocus::Timeline;
+        return true;
+    }
+    if (name == "audition") {
+        out = ViewFocus::Audition;
+        return true;
+    }
+    if (name == "routingMap") {
+        out = ViewFocus::RoutingMap;
+        return true;
+    }
+    if (name == "pianoRoll") {
+        out = ViewFocus::PianoRoll;
+        return true;
+    }
+    return false;
+}
+
+} // namespace WorkspaceFocusModel

--- a/Source/Core/WorkspaceFocus.h
+++ b/Source/Core/WorkspaceFocus.h
@@ -121,7 +121,7 @@ inline WorkspaceTransitionKind classifyTransition(ViewFocus current, ViewFocus p
     }
     const bool currentIsDaw = (current == ViewFocus::Arsenal || current == ViewFocus::Timeline);
     const bool previousIsDaw = (previous == ViewFocus::Arsenal || previous == ViewFocus::Timeline);
-    if (currentIsDaw && previousIsDaw) {
+    if (current != previous && currentIsDaw && previousIsDaw) {
         return WorkspaceTransitionKind::PlaybackHotSwap;
     }
     return WorkspaceTransitionKind::Ordinary;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -105,6 +105,36 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripTest.cpp")
     set_tests_properties(ProjectRoundTripTest AutosaveRoundTripTest PROPERTIES LABELS "integration;serialization;contract:durability")
 endif()
 
+# Workspace-state roundtrip test (phase-3): the optional viewFocus/pianoRollOpen/
+# sequencerOpen UIState fields roundtrip, legacy files keep default, malformed
+# focus names are dropped. Serialization is AGENTS.md §12 high-risk; this runs
+# on every CI build alongside the other ProjectSerializer roundtrips.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/WorkspaceStateRoundTripTest.cpp")
+    add_executable(WorkspaceStateRoundTripTest
+        Integration/WorkspaceStateRoundTripTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(WorkspaceStateRoundTripTest PRIVATE AestraAudio)
+    target_include_directories(WorkspaceStateRoundTripTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/Tests
+    )
+    add_test(NAME WorkspaceStateRoundTripTest COMMAND WorkspaceStateRoundTripTest)
+    set_tests_properties(WorkspaceStateRoundTripTest PROPERTIES LABELS "integration;serialization;workspace;contract:durability")
+endif()
+
 # Session Recovery Test (autosave + crash flag + recovery flow)
 add_executable(ProjectDocumentStateTest Integration/ProjectDocumentStateTest.cpp)
 target_include_directories(ProjectDocumentStateTest PRIVATE
@@ -112,6 +142,17 @@ target_include_directories(ProjectDocumentStateTest PRIVATE
 )
 add_test(NAME ProjectDocumentStateTest COMMAND ProjectDocumentStateTest)
 set_tests_properties(ProjectDocumentStateTest PROPERTIES LABELS "unit;project;identity;recovery;contract:durability")
+
+# Workspace-focus model contract test (phase-3): pure, headless-constructible
+# segment mapping, transition classification, and visibility derivation. No
+# libraries — compiles straight against Source/Core, so it runs in every CI
+# lane including headless.
+add_executable(WorkspaceFocusModelTest Integration/WorkspaceFocusModelTest.cpp)
+target_include_directories(WorkspaceFocusModelTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/Source/Core
+)
+add_test(NAME WorkspaceFocusModelTest COMMAND WorkspaceFocusModelTest)
+set_tests_properties(WorkspaceFocusModelTest PROPERTIES LABELS "unit;workspace;focus;contract:unit")
 
 add_executable(ProjectLifecycleInteractionTest
     Integration/ProjectLifecycleInteractionTest.cpp

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -152,7 +152,7 @@ target_include_directories(WorkspaceFocusModelTest PRIVATE
     ${CMAKE_SOURCE_DIR}/Source/Core
 )
 add_test(NAME WorkspaceFocusModelTest COMMAND WorkspaceFocusModelTest)
-set_tests_properties(WorkspaceFocusModelTest PROPERTIES LABELS "unit;workspace;focus;contract:unit")
+set_tests_properties(WorkspaceFocusModelTest PROPERTIES LABELS "unit;workspace;focus;contract:core")
 
 add_executable(ProjectLifecycleInteractionTest
     Integration/ProjectLifecycleInteractionTest.cpp

--- a/Tests/Integration/WorkspaceFocusModelTest.cpp
+++ b/Tests/Integration/WorkspaceFocusModelTest.cpp
@@ -1,0 +1,148 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "WorkspaceFocus.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << "\n";
+        std::exit(1);
+    }
+}
+
+void testSegmentMapping() {
+    // Every segment index maps to the canonical focus, and every focus with a
+    // segment round-trips back to the same index. RoutingMap owns no segment.
+    require(WorkspaceFocusModel::focusForSegmentIndex(0) == ViewFocus::Arsenal, "segment 0 must be Arsenal");
+    require(WorkspaceFocusModel::focusForSegmentIndex(1) == ViewFocus::Timeline, "segment 1 must be Timeline");
+    require(WorkspaceFocusModel::focusForSegmentIndex(2) == ViewFocus::Audition, "segment 2 must be Audition");
+    require(WorkspaceFocusModel::focusForSegmentIndex(3) == ViewFocus::PianoRoll, "segment 3 must be PianoRoll");
+    require(WorkspaceFocusModel::focusForSegmentIndex(99) == ViewFocus::Timeline,
+            "out-of-range segment must fall back to Timeline");
+
+    const ViewFocus kSegmentFoci[] = {ViewFocus::Arsenal, ViewFocus::Timeline, ViewFocus::Audition,
+                                      ViewFocus::PianoRoll};
+    for (size_t index = 0; index < WorkspaceFocusModel::kSegmentCount; ++index) {
+        size_t back = 99;
+        require(WorkspaceFocusModel::segmentIndexForFocus(kSegmentFoci[index], back),
+                "segment focus must own an index");
+        require(back == index, "focus -> segment index must round-trip");
+    }
+
+    size_t unused = 99;
+    require(!WorkspaceFocusModel::segmentIndexForFocus(ViewFocus::RoutingMap, unused),
+            "RoutingMap must not own a segment");
+    require(unused == 99, "failed lookup must leave the output untouched");
+}
+
+void testTransitionClassification() {
+    const ViewFocus kAllFoci[] = {ViewFocus::Arsenal, ViewFocus::Timeline, ViewFocus::Audition, ViewFocus::RoutingMap,
+                                  ViewFocus::PianoRoll};
+
+    for (ViewFocus current : kAllFoci) {
+        for (ViewFocus previous : kAllFoci) {
+            const auto kind = WorkspaceFocusModel::classifyTransition(current, previous);
+
+            const bool anyAudition = (current == ViewFocus::Audition || previous == ViewFocus::Audition);
+            const bool anyRoutingMap = (current == ViewFocus::RoutingMap || previous == ViewFocus::RoutingMap);
+            const bool bothDaw = (current == ViewFocus::Arsenal || current == ViewFocus::Timeline) &&
+                                 (previous == ViewFocus::Arsenal || previous == ViewFocus::Timeline);
+
+            if (anyAudition) {
+                require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::Audition,
+                        "any Audition pair must classify as Audition");
+            } else if (anyRoutingMap) {
+                require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::RoutingMap,
+                        "any RoutingMap pair must classify as RoutingMap");
+            } else if (bothDaw) {
+                require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::PlaybackHotSwap,
+                        "Arsenal/Timeline pairs must classify as PlaybackHotSwap");
+            } else {
+                require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::Ordinary,
+                        "remaining pairs must classify as Ordinary");
+            }
+        }
+    }
+
+    // PianoRoll pairs are ordinary: switching into/out of the piano roll must
+    // never re-arm the transport (the phase-3 ruling).
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::PianoRoll, ViewFocus::Timeline),
+            "PianoRoll <- Timeline must be ordinary");
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::Timeline, ViewFocus::PianoRoll),
+            "Timeline <- PianoRoll must be ordinary");
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::PianoRoll, ViewFocus::Arsenal),
+            "PianoRoll <- Arsenal must be ordinary");
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::PianoRoll, ViewFocus::PianoRoll),
+            "PianoRoll self-switch must be ordinary");
+    require(!WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::Arsenal, ViewFocus::Timeline),
+            "Arsenal <-> Timeline must NOT be ordinary (hot-swap)");
+    require(WorkspaceFocusModel::isAuditionTransition(ViewFocus::PianoRoll, ViewFocus::Audition),
+            "leaving Audition into PianoRoll must classify as Audition");
+    require(WorkspaceFocusModel::isRoutingMapTransition(ViewFocus::PianoRoll, ViewFocus::RoutingMap),
+            "routing-map pairs must classify as RoutingMap even with PianoRoll");
+}
+
+void testPanelVisibility() {
+    // Ordinary workspaces (Arsenal/Timeline/PianoRoll) restore every overlay
+    // from remembered-open; Audition hides everything; RoutingMap shows only
+    // the mixer over its own map.
+    for (ViewFocus focus : {ViewFocus::Arsenal, ViewFocus::Timeline, ViewFocus::PianoRoll}) {
+        const auto vis = WorkspaceFocusModel::derivePanelVisibility(focus, true, true, true);
+        require(vis.mixer && vis.pianoRoll && vis.sequencer,
+                "ordinary workspace must restore all remembered-open overlays");
+    }
+
+    const auto audition = WorkspaceFocusModel::derivePanelVisibility(ViewFocus::Audition, true, true, true);
+    require(!audition.mixer && !audition.pianoRoll && !audition.sequencer,
+            "Audition must hide all overlays regardless of remembered-open");
+
+    const auto routing = WorkspaceFocusModel::derivePanelVisibility(ViewFocus::RoutingMap, true, true, true);
+    require(routing.mixer && !routing.pianoRoll && !routing.sequencer, "RoutingMap must show only the mixer");
+
+    // The piano roll only appears when remembered-open (phase-3 ruling).
+    const auto prClosed = WorkspaceFocusModel::derivePanelVisibility(ViewFocus::PianoRoll, true, false, true);
+    require(prClosed.mixer && !prClosed.pianoRoll && prClosed.sequencer,
+            "PianoRoll workspace shows the piano roll iff pianoRollOpen");
+}
+
+void testNames() {
+    require(std::string(WorkspaceFocusModel::workspaceFocusName(ViewFocus::Arsenal)) == "arsenal",
+            "Arsenal protocol name");
+    require(std::string(WorkspaceFocusModel::workspaceFocusName(ViewFocus::Timeline)) == "timeline",
+            "Timeline protocol name");
+    require(std::string(WorkspaceFocusModel::workspaceFocusName(ViewFocus::Audition)) == "audition",
+            "Audition protocol name");
+    require(std::string(WorkspaceFocusModel::workspaceFocusName(ViewFocus::RoutingMap)) == "routingMap",
+            "RoutingMap protocol name");
+    require(std::string(WorkspaceFocusModel::workspaceFocusName(ViewFocus::PianoRoll)) == "pianoRoll",
+            "PianoRoll protocol name");
+
+    const ViewFocus kAllFoci[] = {ViewFocus::Arsenal, ViewFocus::Timeline, ViewFocus::Audition, ViewFocus::RoutingMap,
+                                  ViewFocus::PianoRoll};
+    for (ViewFocus focus : kAllFoci) {
+        ViewFocus parsed = ViewFocus::Timeline;
+        require(WorkspaceFocusModel::parseWorkspaceFocus(WorkspaceFocusModel::workspaceFocusName(focus), parsed),
+                "parse must accept every focus name");
+        require(parsed == focus, "focus name must round-trip");
+    }
+
+    ViewFocus parsed = ViewFocus::Timeline;
+    require(!WorkspaceFocusModel::parseWorkspaceFocus("timelime", parsed), "typo'd focus name must not parse");
+    require(!WorkspaceFocusModel::parseWorkspaceFocus("", parsed), "empty focus name must not parse");
+}
+
+} // namespace
+
+int main() {
+    testSegmentMapping();
+    testTransitionClassification();
+    testPanelVisibility();
+    testNames();
+    std::cout << "WorkspaceFocusModelTest: all checks passed\n";
+    return 0;
+}

--- a/Tests/Integration/WorkspaceFocusModelTest.cpp
+++ b/Tests/Integration/WorkspaceFocusModelTest.cpp
@@ -52,6 +52,7 @@ void testTransitionClassification() {
             const bool anyRoutingMap = (current == ViewFocus::RoutingMap || previous == ViewFocus::RoutingMap);
             const bool bothDaw = (current == ViewFocus::Arsenal || current == ViewFocus::Timeline) &&
                                  (previous == ViewFocus::Arsenal || previous == ViewFocus::Timeline);
+            const bool distinctDawSwap = bothDaw && current != previous;
 
             if (anyAudition) {
                 require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::Audition,
@@ -59,9 +60,12 @@ void testTransitionClassification() {
             } else if (anyRoutingMap) {
                 require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::RoutingMap,
                         "any RoutingMap pair must classify as RoutingMap");
-            } else if (bothDaw) {
+            } else if (distinctDawSwap) {
                 require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::PlaybackHotSwap,
-                        "Arsenal/Timeline pairs must classify as PlaybackHotSwap");
+                        "distinct Arsenal/Timeline pairs must classify as PlaybackHotSwap");
+            } else if (bothDaw) {
+                require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::Ordinary,
+                        "Arsenal/Timeline self-switches must stay ordinary (no hot-swap)");
             } else {
                 require(kind == WorkspaceFocusModel::WorkspaceTransitionKind::Ordinary,
                         "remaining pairs must classify as Ordinary");
@@ -79,6 +83,10 @@ void testTransitionClassification() {
             "PianoRoll <- Arsenal must be ordinary");
     require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::PianoRoll, ViewFocus::PianoRoll),
             "PianoRoll self-switch must be ordinary");
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::Arsenal, ViewFocus::Arsenal),
+            "Arsenal self-switch must be ordinary (no hot-swap)");
+    require(WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::Timeline, ViewFocus::Timeline),
+            "Timeline self-switch must be ordinary (no hot-swap)");
     require(!WorkspaceFocusModel::isOrdinaryWorkspaceTransition(ViewFocus::Arsenal, ViewFocus::Timeline),
             "Arsenal <-> Timeline must NOT be ordinary (hot-swap)");
     require(WorkspaceFocusModel::isAuditionTransition(ViewFocus::PianoRoll, ViewFocus::Audition),

--- a/Tests/Integration/WorkspaceStateRoundTripTest.cpp
+++ b/Tests/Integration/WorkspaceStateRoundTripTest.cpp
@@ -100,10 +100,11 @@ int main() {
                 "legacy file must keep overlays closed");
     }
 
-    // --- Malformed focus name is ignored (defaults preserved).
+    // --- Malformed focus name still restores flags (focus falls back to Timeline).
     {
         ProjectSerializer::UIState ui;
         ui.viewFocus = "notAFocus";
+        ui.pianoRollOpen = true;
         const std::string contents = serializeWithUI(makeManager(), ui);
         const auto path = tempDir / "bad-focus.aes";
         require(ProjectSerializer::writeAtomically(path.string(), contents), "atomic write failed");
@@ -113,6 +114,11 @@ int main() {
         require(result.ok, "file with malformed focus must load cleanly");
         require(!result.ui.has_value() || result.ui->viewFocus.empty(),
                 "malformed focus must be dropped (default Timeline)");
+        // The app restore path (AestraApp::applyUIState) is not headless;
+        // the serializer contract is that the flag still survives alongside a
+        // malformed focus, so the caller can apply it with the Timeline fallback.
+        require(result.ui.has_value() && result.ui->pianoRollOpen,
+                "pianoRollOpen must survive alongside a malformed focus");
     }
 
     std::cout << "[PASS] WorkspaceStateRoundTripTest\n";

--- a/Tests/Integration/WorkspaceStateRoundTripTest.cpp
+++ b/Tests/Integration/WorkspaceStateRoundTripTest.cpp
@@ -1,0 +1,120 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Phase-3 workspace-state roundtrip: the optional viewFocus/pianoRollOpen/
+// sequencerOpen UIState fields must survive serialize -> load, and legacy
+// files (no workspace keys) must load with the historical defaults (empty
+// viewFocus = Timeline, overlays closed) without failing.
+
+#include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+std::string serializeWithUI(const std::shared_ptr<Aestra::Audio::TrackManager>& tm,
+                            const ProjectSerializer::UIState& ui) {
+    auto ser = ProjectSerializer::serialize(tm, 120.0, 0.0, 2, &ui);
+    require(ser.ok, "serialize with UIState failed");
+    require(!ser.contents.empty(), "serialize produced empty contents");
+    return ser.contents;
+}
+
+} // namespace
+
+int main() {
+    using namespace Aestra;
+    using namespace Aestra::Audio;
+
+    const Tests::ScopedTempDirectory tempDirScope{"WorkspaceStateRoundTrip"};
+    const auto& tempDir = tempDirScope.path();
+
+    auto makeManager = []() {
+        auto tm = std::make_shared<TrackManager>();
+        tm->getPlaylistModel().setPatternManager(&tm->getPatternManager());
+        return tm;
+    };
+
+    // --- Roundtrip: pianoRoll workspace + remembered-open overlays.
+    {
+        ProjectSerializer::UIState ui;
+        ui.viewFocus = "pianoRoll";
+        ui.pianoRollOpen = true;
+        ui.sequencerOpen = true;
+
+        const std::string contents = serializeWithUI(makeManager(), ui);
+        const auto path = tempDir / "pianoRoll-workspace.aes";
+        require(ProjectSerializer::writeAtomically(path.string(), contents), "atomic write failed");
+
+        auto tm = makeManager();
+        const auto result = ProjectSerializer::load(path.string(), tm);
+        require(result.ok, "load failed for pianoRoll workspace file");
+        require(result.ui.has_value(), "UIState missing from load result");
+        require(result.ui->viewFocus == "pianoRoll", "viewFocus did not roundtrip");
+        require(result.ui->pianoRollOpen, "pianoRollOpen did not roundtrip");
+        require(result.ui->sequencerOpen, "sequencerOpen did not roundtrip");
+    }
+
+    // --- Roundtrip: every persisted focus name.
+    for (const std::string focusName : {"arsenal", "timeline", "audition", "routingMap", "pianoRoll"}) {
+        ProjectSerializer::UIState ui;
+        ui.viewFocus = focusName;
+        const std::string contents = serializeWithUI(makeManager(), ui);
+        const auto path = tempDir / ("focus-" + focusName + ".aes");
+        require(ProjectSerializer::writeAtomically(path.string(), contents), "atomic write failed");
+
+        auto tm = makeManager();
+        const auto result = ProjectSerializer::load(path.string(), tm);
+        require(result.ok, "load failed for focus name " + focusName);
+        require(result.ui.has_value() && result.ui->viewFocus == focusName,
+                "focus name " + focusName + " did not roundtrip");
+    }
+
+    // --- Legacy compatibility: file with no ui/workspace keys -> defaults.
+    {
+        // serialize(..., /*uiState=*/nullptr) omits the whole "ui" section —
+        // exactly what a pre-phase-3 file looks like.
+        auto ser = ProjectSerializer::serialize(makeManager(), 120.0, 0.0, 2, nullptr);
+        require(ser.ok, "legacy serialize failed");
+        const auto path = tempDir / "legacy-no-ui.aes";
+        require(ProjectSerializer::writeAtomically(path.string(), ser.contents), "legacy atomic write failed");
+
+        auto tm = makeManager();
+        const auto result = ProjectSerializer::load(path.string(), tm);
+        require(result.ok, "legacy file (no ui section) must load cleanly");
+        require(!result.ui.has_value() || result.ui->viewFocus.empty(),
+                "legacy file must not restore a workspace focus");
+        require(!result.ui.has_value() || (!result.ui->pianoRollOpen && !result.ui->sequencerOpen),
+                "legacy file must keep overlays closed");
+    }
+
+    // --- Malformed focus name is ignored (defaults preserved).
+    {
+        ProjectSerializer::UIState ui;
+        ui.viewFocus = "notAFocus";
+        const std::string contents = serializeWithUI(makeManager(), ui);
+        const auto path = tempDir / "bad-focus.aes";
+        require(ProjectSerializer::writeAtomically(path.string(), contents), "atomic write failed");
+
+        auto tm = makeManager();
+        const auto result = ProjectSerializer::load(path.string(), tm);
+        require(result.ok, "file with malformed focus must load cleanly");
+        require(!result.ui.has_value() || result.ui->viewFocus.empty(),
+                "malformed focus must be dropped (default Timeline)");
+    }
+
+    std::cout << "[PASS] WorkspaceStateRoundTripTest\n";
+    return 0;
+}

--- a/docs/technical/settings_view_state_map.md
+++ b/docs/technical/settings_view_state_map.md
@@ -96,9 +96,18 @@ was open" or leaving Audition cannot put it back. This is not a bug in
 from one and two from the other. `view.current` gains a field; nothing loses the
 restore semantics it needs.
 
-Also unexposed today: `m_viewFocus` (Arsenal / Timeline / Audition / RoutingMap),
-which is the state that *causes* the divergence. An agent cannot currently see
-it.
+Also unexposed today: `m_viewFocus` (Arsenal / Timeline / Audition / RoutingMap /
+PianoRoll), which is the state that *causes* the divergence. An agent cannot
+currently see it.
+
+**Update (phase-3, workspace-panel ownership):** the active workspace and the
+remembered-open overlay flags ARE now persisted in the `.aes` project file as
+optional `ui.viewFocus` / `ui.pianoRollOpen` / `ui.sequencerOpen` keys
+(`ProjectSerializer::UIState`), and reapplied through `AestraApp::applyUIState`
+→ `AestraContent::restoreWorkspaceState`. Muse sees them as before: only
+`view.current` still lacks the focus field the B1 resolution proposes — the
+`viewFocus` protocol string now exists (`WorkspaceFocusModel::workspaceFocusName`),
+so the field can be added without introducing a new verb.
 
 ---
 

--- a/docs/technical/settings_view_state_map.md
+++ b/docs/technical/settings_view_state_map.md
@@ -104,10 +104,11 @@ currently see it.
 remembered-open overlay flags ARE now persisted in the `.aes` project file as
 optional `ui.viewFocus` / `ui.pianoRollOpen` / `ui.sequencerOpen` keys
 (`ProjectSerializer::UIState`), and reapplied through `AestraApp::applyUIState`
-→ `AestraContent::restoreWorkspaceState`. Muse sees them as before: only
-`view.current` still lacks the focus field the B1 resolution proposes — the
-`viewFocus` protocol string now exists (`WorkspaceFocusModel::workspaceFocusName`),
-so the field can be added without introducing a new verb.
+→ `AestraContent::restoreWorkspaceState`. Muse `view.current` reports the active
+workspace through its `focus` field, whose protocol string now lives in
+`WorkspaceFocusModel::workspaceFocusName` (adds `pianoRoll`); the B1 `status`
+field resolution can also consume that dedicated verb without relying on a
+`viewFocus` key.
 
 ---
 


### PR DESCRIPTION
Decision: FD-12 @ a30696a
Kind: corrective
Reversal: —

## Summary

Workspace 3 in the scheduler-isolation sequence: **workspace-panel ownership**.
The Piano Roll becomes a first-class `ViewFocus` workspace instead of a secondary
overlay. A new pure, headless-constructible model (`Source/Core/WorkspaceFocus.h`)
is the single source of truth for the segment index↔focus mapping, transition
classification, and remembered-open overlay visibility — so the behaviors are
table-testable instead of requiring a constructed `AstraContent`.

- 4th segmented-control segment (`Arsenal | Timeline | Audition | PianoRoll`).
- `PianoRoll` added to `ViewFocus` (new member, value 4; existing values unchanged).
- Entering/leaving PianoRoll is an **ordinary, pure-visibility transition**: no
  playback, pause, position, scheduled-instance, or engine-mode mutation. The
  playback hot-swap now fires only for `Arsenal<->Timeline` (classified
  `PlaybackHotSwap`); Audition/RouterMap/ordinary transitions are untouched.
- `openPatternInPianoRoll` (contextual navigation) reaches the PianoRoll
  workspace through the same `setViewFocus(PianoRoll)` control point.
- Project persistence: optional `ui.viewFocus` / `ui.pianoRollOpen` /
  `ui.sequencerOpen` keys. Pre-workspace files load with the historical defaults
  (Timeline, overlays closed); malformed values are dropped.
- Muse `focusMap` delegates to the shared model (adds `pianoRoll`).

## Why

The overlay-as-workspace behavior left display vs. workspace ambiguous: the panel
opened while `m_viewFocus` stayed wherever it was, and the hot-swap would have
re-armed the transport the moment PianoRoll became a focus. Hoisting the policy
into a tidy model makes those lanes testable and keeps every focus switch lawful.

## Testing performed

- `cmake --build build-linux --target Aestra` (and full test build, `-j2`) — OK.
- New `WorkspaceFocusModelTest` — table-driven:
  - segment index↔focus mapping (all 4 segments, out-of-range fallback,
    RoutingMap has no segment),
  - 5×5 transition classification (Audition/RoutingMap dominance,
    Arsenal<->Timeline hot-swap, all PianoRoll pairs ordinary),
  - remembered-open visibility derivation,
  - protocol focus names round-trip.
- New `WorkspaceStateRoundTripTest` — `viewFocus`/`pianoRollOpen`/`sequencerOpen`
  roundtrip for every focus name; legacy fixture (no `ui` section) keeps the
  defaults; malformed focus name is dropped.
- Full suite: **226/226 passed** (`ctest --test-dir build-linux --output-on-failure`).
- Manual audit of every `ViewFocus` switch: no ordinary transition path calls
  `rewindScheduledInstances()` / `clearScheduledInstances()`; `stopPatternClipPreview`
  and the hot-swap do not fire on PianoRoll transitions; Audition and RoutingMap
  behavior unchanged.

## Producer note

None for 0.5.0-min side of things.

## Docs updated

- `docs/technical/settings_view_state_map.md` — workspace focus + remembered-open
  flags now persisted; protocol focus name lives in `WorkspaceFocusModel`.

## Risk / rollback notes

- **Known edge (documented, not fixed):** entering the PianoRoll workspace from
  the Arsenal leaves the engine's pattern mode armed — the phase-3 ruling forbids
  ordinary transitions from mutating engine mode. Any later Timeline station
  de-arms it (the Timeline branch heals pattern-armed state); pressing play
  directly from the PianoRoll workspace re-uses the armed pattern transport.
- Rollback: revert the model wiring + persistence keys; projects without the new
  keys are unaffected.
- Formatting: new hunks clang-format-clean; pre-existing repo drift (older clang
  version) untouched.

## Files changed

- `Source/Core/WorkspaceFocus.h` — new pure model (`ViewFocus` + `PianoRoll`).
- `Source/Core/AestraContent.h/.cpp` — model wiring, 4th segment, PianoRoll
  workspace, transport/hot-swap/visibility via model, `restoreWorkspaceState`.
- `Source/App/MuseHostVerbs.cpp` — `focusName` via model.
- `Source/Core/ProjectSerializer.h/.cpp`, `Source/App/AstraApp.cpp` — optional
  workspace persistence + capture/apply.
- `Tests/Integration/WorkspaceFocusModelTest.cpp`,
  `Tests/Integration/WorkspaceStateRoundTripTest.cpp`, `Tests/CMakeLists.txt`.
- `docs/technical/settings_view_state_map.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds PianoRoll as a first-class workspace with centralized focus mapping, transition handling, overlay visibility, and protocol names.
- Treats PianoRoll navigation as a visibility-only change. Playback hot-swaps apply only between Arsenal and Timeline.
- Persists and restores `viewFocus`, `pianoRollOpen`, and `sequencerOpen` while preserving legacy defaults and retaining overlay flags for invalid focus values.
- Routes PianoRoll navigation and RoutingMap visibility through the workspace model.
- Updates Muse focus mapping and workspace-state documentation.
- Adds model and serialization round-trip coverage. All 226 tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->