### PR TITLE
feat(routing): give Arsenal units default mixer ownership

### DIFF
--- a/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
+++ b/AestraAudio/include/Commands/AssignUnitToFirstFreeInsertCommand.h
@@ -10,7 +10,84 @@
 namespace Aestra {
 namespace Audio {
 
-/** Assign a unit to the first unused insert, atomically creating a lane and insert when necessary. */
+namespace detail {
+struct FirstFreeMixerChannelResult {
+    uint32_t channelId{MASTER_MIXER_CHANNEL_ID};
+    bool created{false};
+};
+
+/** Resolve the first mixer channel not owned by another source, creating one only when necessary. */
+inline FirstFreeMixerChannelResult selectOrCreateFirstFreeMixerChannel(TrackManager& manager, UnitID unitId,
+                                                                        const std::string& destinationName,
+                                                                        uint32_t color) {
+    std::unordered_set<uint32_t> usedChannelIds;
+    for (const UnitID otherUnitId : manager.getUnitManager().getAllUnitIDs()) {
+        if (otherUnitId == unitId)
+            continue;
+        const uint32_t channelId = manager.getUnitManager().getUnitMixerChannel(otherUnitId);
+        if (channelId != MASTER_MIXER_CHANNEL_ID) {
+            usedChannelIds.insert(channelId);
+        }
+    }
+    for (const auto& pattern : manager.getPatternManager().getAllPatterns()) {
+        if (!pattern || !pattern->isAudio())
+            continue;
+        const uint32_t channelId = pattern->getMixerChannelId();
+        if (channelId != MASTER_MIXER_CHANNEL_ID) {
+            usedChannelIds.insert(channelId);
+        }
+    }
+
+    for (size_t i = 0; i < manager.getChannelCount(); ++i) {
+        const auto* channel = manager.getChannel(i);
+        if (channel && usedChannelIds.find(channel->getChannelId()) == usedChannelIds.end()) {
+            return {channel->getChannelId(), false};
+        }
+    }
+
+    auto* channel = manager.addChannel(destinationName);
+    if (!channel)
+        return {};
+    channel->setColor(color);
+    return {channel->getChannelId(), true};
+}
+} // namespace detail
+
+/**
+ * Route a producer-facing Arsenal unit to its default mixer destination without creating Timeline placement state.
+ *
+ * Unit creation is not command-backed today, so its default route belongs to the same creation operation rather than
+ * becoming a separate Undo entry. Bootstrap callers can preserve the incoming dirty-state while still publishing the
+ * stable mixer route.
+ */
+inline bool routeUnitToFirstFreeMixerChannel(TrackManager& manager, UnitID unitId, const std::string& destinationName,
+                                             uint32_t color, bool preserveModifiedState = false) {
+    if (!manager.getUnitManager().getUnit(unitId))
+        return false;
+
+    const bool wasModified = manager.isModified();
+    const auto result = detail::selectOrCreateFirstFreeMixerChannel(manager, unitId, destinationName, color);
+    if (result.channelId == MASTER_MIXER_CHANNEL_ID) {
+        if (preserveModifiedState)
+            manager.setModified(wasModified);
+        return false;
+    }
+
+    manager.getUnitManager().setUnitMixerChannel(unitId, result.channelId);
+    if (preserveModifiedState) {
+        manager.setModified(wasModified);
+    } else {
+        manager.markModified();
+    }
+    return true;
+}
+
+/**
+ * Assign a unit to the first unused mixer channel.
+ *
+ * The legacy class name is retained to avoid widening this product change into a symbol/file rename. "Insert" here is
+ * historical only: mixer routing creates or reuses mixer channels and never creates a Timeline lane.
+ */
 class AssignUnitToFirstFreeInsertCommand final : public ICommand {
 public:
     AssignUnitToFirstFreeInsertCommand(TrackManager& manager, UnitID unitId, std::string destinationName,
@@ -27,23 +104,21 @@ public:
         }
 
         if (m_createdDestination) {
-            auto& playlist = m_manager.getPlaylistModel();
-            const auto restoredLaneId = playlist.createLaneWithId(m_laneId, m_destinationName);
-            if (restoredLaneId != m_laneId) {
-                playlist.removeLane(restoredLaneId);
+            if (!m_manager.reinsertChannel(m_detachedChannel, m_channelIndex))
                 return;
-            }
-            if (!m_manager.reinsertChannel(m_detachedChannel, m_channelIndex)) {
-                playlist.removeLane(m_laneId);
-                return;
-            }
-            if (auto* lane = playlist.getLane(m_laneId)) {
-                lane->colorRGBA = m_color;
-            }
         } else if (m_destinationChannelId == MASTER_MIXER_CHANNEL_ID) {
-            selectOrCreateDestination();
+            const size_t channelCountBefore = m_manager.getChannelCount();
+            const auto result =
+                detail::selectOrCreateFirstFreeMixerChannel(m_manager, m_unitId, m_destinationName, m_color);
+            m_destinationChannelId = result.channelId;
+            m_createdDestination = result.created;
             if (m_destinationChannelId == MASTER_MIXER_CHANNEL_ID)
                 return;
+            if (m_createdDestination) {
+                if (m_manager.getChannelCount() <= channelCountBefore)
+                    return;
+                m_channelIndex = m_manager.getChannelCount() - 1;
+            }
         }
 
         m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_destinationChannelId);
@@ -62,7 +137,6 @@ public:
                 m_manager.getUnitManager().setUnitMixerChannel(m_unitId, m_destinationChannelId);
                 return;
             }
-            m_manager.getPlaylistModel().removeLane(m_laneId);
         }
         m_manager.markModified();
         m_executed = false;
@@ -70,66 +144,18 @@ public:
 
     void redo() override { execute(); }
 
-    std::string getName() const override { return "Assign Unit to First Free Insert"; }
+    std::string getName() const override { return "Assign Unit to First Free Mixer Channel"; }
     size_t getSizeInBytes() const override { return sizeof(*this); }
     bool changesProjectState() const override { return true; }
     bool isUndoable() const override { return m_executed; }
 
 private:
-    void selectOrCreateDestination() {
-        std::unordered_set<uint32_t> usedChannelIds;
-        for (const UnitID unitId : m_manager.getUnitManager().getAllUnitIDs()) {
-            if (unitId == m_unitId)
-                continue;
-            const uint32_t channelId = m_manager.getUnitManager().getUnitMixerChannel(unitId);
-            if (channelId != MASTER_MIXER_CHANNEL_ID) {
-                usedChannelIds.insert(channelId);
-            }
-        }
-        for (const auto& pattern : m_manager.getPatternManager().getAllPatterns()) {
-            if (!pattern || !pattern->isAudio())
-                continue;
-            const uint32_t channelId = pattern->getMixerChannelId();
-            if (channelId != MASTER_MIXER_CHANNEL_ID) {
-                usedChannelIds.insert(channelId);
-            }
-        }
-
-        for (size_t i = 0; i < m_manager.getChannelCount(); ++i) {
-            const auto* channel = m_manager.getChannel(i);
-            if (channel && usedChannelIds.find(channel->getChannelId()) == usedChannelIds.end()) {
-                m_destinationChannelId = channel->getChannelId();
-                return;
-            }
-        }
-
-        auto& playlist = m_manager.getPlaylistModel();
-        m_laneId = playlist.createLane(m_destinationName);
-        if (!m_laneId.isValid())
-            return;
-
-        auto* channel = m_manager.addChannel(m_destinationName);
-        if (!channel) {
-            playlist.removeLane(m_laneId);
-            m_laneId = {};
-            return;
-        }
-
-        m_destinationChannelId = channel->getChannelId();
-        channel->setColor(m_color);
-        if (auto* lane = playlist.getLane(m_laneId)) {
-            lane->colorRGBA = m_color;
-        }
-        m_createdDestination = true;
-    }
-
     TrackManager& m_manager;
     UnitID m_unitId;
     std::string m_destinationName;
     uint32_t m_color;
     uint32_t m_previousChannelId{MASTER_MIXER_CHANNEL_ID};
     uint32_t m_destinationChannelId{MASTER_MIXER_CHANNEL_ID};
-    PlaylistLaneID m_laneId;
     std::unique_ptr<MixerChannel> m_detachedChannel;
     size_t m_channelIndex{0};
     bool m_capturedPreviousRoute{false};
@@ -137,7 +163,7 @@ private:
     bool m_executed{false};
 };
 
-/** Execute and record first-free routing, reporting whether project state changed. */
+/** Execute and record first-free mixer routing, reporting whether project state changed. */
 inline bool assignUnitToFirstFreeInsert(TrackManager& manager, UnitID unitId, const std::string& destinationName,
                                         uint32_t color) {
     auto command = std::make_shared<AssignUnitToFirstFreeInsertCommand>(manager, unitId, destinationName, color);

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -152,6 +152,11 @@ ArsenalPanel::ArsenalPanel(std::shared_ptr<TrackManager> trackManager)
         if (unitMgr.getUnitCount() == 0) {
             UnitID defaultUnit = unitMgr.createUnit("Sampler 1", UnitType::Sampler);
             unitMgr.setUnitEnabled(defaultUnit, true);
+            if (const auto* unit = unitMgr.getUnit(defaultUnit)) {
+                const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
+                // Bootstrap routing belongs to the pristine default project, not to user edit history.
+                routeUnitToFirstFreeMixerChannel(*m_trackManager, defaultUnit, destinationName, unit->color, true);
+            }
         }
     }
 
@@ -368,6 +373,10 @@ void ArsenalPanel::refreshUnits() {
             if (!m_trackManager) return;
             UnitID newId = m_trackManager->getUnitManager().duplicateUnit(id);
             if (newId != 0) {
+                if (const auto* unit = m_trackManager->getUnitManager().getUnit(newId)) {
+                    const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
+                    routeUnitToFirstFreeMixerChannel(*m_trackManager, newId, destinationName, unit->color);
+                }
                 m_selectedUnitId = newId;
                 refreshUnits();
             }
@@ -413,6 +422,10 @@ void ArsenalPanel::createUnitOfType(UnitType type) {
                         type == UnitType::PitchedSampler ? "808 " :
                         type == UnitType::Instrument ? "MIDI " : "Audio ") + std::to_string(count);
     m_selectedUnitId = m_trackManager->getUnitManager().createUnit(name, type);
+    if (const auto* unit = m_trackManager->getUnitManager().getUnit(m_selectedUnitId)) {
+        const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
+        routeUnitToFirstFreeMixerChannel(*m_trackManager, m_selectedUnitId, destinationName, unit->color);
+    }
     if (m_onSelectedUnitChanged) {
         m_onSelectedUnitChanged(m_selectedUnitId);
     }
@@ -434,6 +447,10 @@ bool ArsenalPanel::removeSelectedUnit() {
         unitMgr.removeUnit(oldId);
         removeUnitNotes(oldId);
         UnitID newId = unitMgr.createUnit();
+        if (const auto* unit = unitMgr.getUnit(newId)) {
+            const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
+            routeUnitToFirstFreeMixerChannel(*m_trackManager, newId, destinationName, unit->color);
+        }
         m_selectedUnitId = newId;
         refreshUnits();
         if (m_onSelectedUnitChanged && m_selectedUnitId != 0) {
@@ -1414,7 +1431,7 @@ bool ArsenalPanel::onKeyEvent(const NUIKeyEvent& event) {
         const auto* unit = m_trackManager->getUnitManager().getUnit(m_selectedUnitId);
         if (!unit)
             return false;
-        const std::string destinationName = unit->name.empty() ? "Mixer Insert" : unit->name;
+        const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
         assignUnitToFirstFreeInsert(*m_trackManager, m_selectedUnitId, destinationName, unit->color);
         return true;
     }

--- a/Tests/AestraAudio/UnitMixerRoutingTest.cpp
+++ b/Tests/AestraAudio/UnitMixerRoutingTest.cpp
@@ -106,29 +106,56 @@ int main() {
     require(postDeleteInsert && postDeleteInsert->getName() == "Channel 2",
             "Default channel name reused a deleted channel number");
 
+    auto defaultRouteTracksOwner = std::make_unique<TrackManager>();
+    auto& defaultRouteTracks = *defaultRouteTracksOwner;
+    const UnitID defaultRouteUnit =
+        defaultRouteTracks.getUnitManager().createUnit("Default Route", UnitType::Instrument);
+    defaultRouteTracks.setModified(false);
+    require(routeUnitToFirstFreeMixerChannel(defaultRouteTracks, defaultRouteUnit, "Default Route", 0xFF336699, true),
+            "Default Arsenal route could not create a mixer destination");
+    const uint32_t defaultRouteChannelId =
+        defaultRouteTracks.getUnitManager().getUnitMixerChannel(defaultRouteUnit);
+    require(defaultRouteChannelId != MASTER_MIXER_CHANNEL_ID &&
+                defaultRouteTracks.getChannelById(defaultRouteChannelId) != nullptr,
+            "Default Arsenal route did not resolve to a stable mixer channel");
+    require(defaultRouteTracks.getChannelCount() == 1 && defaultRouteTracks.getPlaylistModel().getLaneCount() == 0,
+            "Default Arsenal routing coupled mixer ownership to Timeline placement");
+    require(!defaultRouteTracks.isModified(), "Bootstrap Arsenal routing dirtied the pristine project");
+    require(routeUnitToFirstFreeMixerChannel(defaultRouteTracks, defaultRouteUnit, "Default Route", 0xFF336699, true) &&
+                defaultRouteTracks.getUnitManager().getUnitMixerChannel(defaultRouteUnit) == defaultRouteChannelId &&
+                defaultRouteTracks.getChannelCount() == 1,
+            "Repeating default Arsenal routing did not remain stable");
+
+    auto userRouteTracksOwner = std::make_unique<TrackManager>();
+    auto& userRouteTracks = *userRouteTracksOwner;
+    const UnitID userRouteUnit = userRouteTracks.getUnitManager().createUnit("User Route", UnitType::Sampler);
+    userRouteTracks.setModified(false);
+    require(routeUnitToFirstFreeMixerChannel(userRouteTracks, userRouteUnit, "User Route", 0xFF224466),
+            "User-created Arsenal unit could not acquire a mixer destination");
+    require(userRouteTracks.isModified(), "User-created Arsenal routing did not dirty the project");
+    require(userRouteTracks.getPlaylistModel().getLaneCount() == 0,
+            "User-created Arsenal routing manufactured a Timeline lane");
+
     auto firstFreeTracksOwner = std::make_unique<TrackManager>();
     auto& firstFreeTracks = *firstFreeTracksOwner;
     const UnitID firstFreeUnit = firstFreeTracks.getUnitManager().createUnit("Bass", UnitType::Instrument);
     firstFreeTracks.getCommandHistory().pushAndExecute(
         std::make_shared<AssignUnitToFirstFreeInsertCommand>(firstFreeTracks, firstFreeUnit, "Bass", 0xFF336699));
-    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 1,
-            "First-free route did not atomically create its insert and lane");
+    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 0,
+            "First-free mixer routing created Timeline placement state");
     const uint32_t createdDestinationId = firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit);
-    const auto createdLaneId = firstFreeTracks.getPlaylistModel().getLaneId(0);
     require(createdDestinationId != MASTER_MIXER_CHANNEL_ID &&
-                firstFreeTracks.getChannel(0)->getColor() == 0xFF336699 &&
-                firstFreeTracks.getPlaylistModel().getLane(createdLaneId)->colorRGBA == 0xFF336699,
-            "First-free route did not apply destination identity and color");
+                firstFreeTracks.getChannel(0)->getColor() == 0xFF336699,
+            "First-free route did not apply mixer destination identity and color");
     require(firstFreeTracks.getCommandHistory().undo(), "First-free route undo was unavailable");
     require(firstFreeTracks.getChannelCount() == 0 && firstFreeTracks.getPlaylistModel().getLaneCount() == 0 &&
                 firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == MASTER_MIXER_CHANNEL_ID,
-            "First-free route undo left created project state behind");
+            "First-free route undo left mixer or Timeline state behind");
     require(firstFreeTracks.getCommandHistory().redo(), "First-free route redo was unavailable");
-    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 1 &&
+    require(firstFreeTracks.getChannelCount() == 1 && firstFreeTracks.getPlaylistModel().getLaneCount() == 0 &&
                 firstFreeTracks.getChannel(0)->getChannelId() == createdDestinationId &&
-                firstFreeTracks.getPlaylistModel().getLaneId(0) == createdLaneId &&
                 firstFreeTracks.getUnitManager().getUnitMixerChannel(firstFreeUnit) == createdDestinationId,
-            "First-free route redo did not restore stable identities atomically");
+            "First-free route redo did not restore the stable mixer identity without Timeline coupling");
 
     auto patternOccupiedTracksOwner = std::make_unique<TrackManager>();
     auto& patternOccupiedTracks = *patternOccupiedTracksOwner;
@@ -178,6 +205,7 @@ int main() {
             "Ctrl+L routing helper did not route the selected unit");
     const size_t shortcutChannelCount = shortcutTracks.getChannelCount();
     const size_t shortcutLaneCount = shortcutTracks.getPlaylistModel().getLaneCount();
+    require(shortcutLaneCount == 0, "Ctrl+L mixer routing created Timeline placement state");
     require(!assignUnitToFirstFreeInsert(shortcutTracks, 0, "Missing", 0xFFFFFFFF),
             "Ctrl+L routing helper handled a missing selection");
     require(!assignUnitToFirstFreeInsert(shortcutTracks, shortcutUnit + 999, "Missing", 0xFFFFFFFF),


### PR DESCRIPTION
Objective: Phase 4 — Arsenal→mixer default routing
Decision: FD-12 @ a30696a
Kind: planned

## Objective

Complete the Phase 4 Arsenal→mixer product decision after the workspace/editor boundary correction in #740.

## Product decision

Producer-facing Arsenal units automatically take the first mixer channel not already owned by another unit or audio source. If none is free, routing creates a mixer channel only. Explicit routing to Master or shared channels remains available.

## Authority / invariant

- A unit/source owns its stable mixer destination.
- A Playlist lane owns placement only.
- Mixer routing must never create, move, or delete a Timeline lane.
- Moving clips must never change routing.
- New and duplicated Arsenal units get a distinct first-free mixer destination by default.
- Bootstrap default routing preserves the pristine project's dirty state.
- Low-level `UnitManager::createUnit()` still fails safe to Master; the producer-facing Arsenal boundary applies the default route.
- No serialization format changes.

## Changes

- Factor first-free mixer selection into a shared channel-only helper.
- Remove Playlist-lane creation/removal from first-free routing execute/undo/redo.
- Route the Arsenal bootstrap, Add Unit, duplicate, and last-unit-reset creation paths to first-free mixer channels.
- Preserve dirty state for bootstrap routing; user-created routes remain project edits.
- Keep the legacy internal `AssignUnitToFirstFreeInsertCommand` symbol/file name to avoid widening this product change into a cosmetic migration; its visible command name now says Mixer Channel.
- Extend `UnitMixerRoutingTest` to pin no-Timeline coupling, stable undo/redo identity, bootstrap dirty-state preservation, idempotence, and explicit Ctrl+L lane independence.

## Testing

- `UnitMixerRoutingTest` updated for the new routing contract.
- Full CI pending on this PR.

## Risk / rollback

The change affects only default/explicit first-free routing structure. Stable mixer channel IDs and persistence remain unchanged. Rollback is a revert of this PR; projects saved before/after remain loadable because the serialized routing schema does not change.