### PR TITLE
fix: persist clip trims across save and reload

### DIFF
--- a/AestraAudio/include/Commands/TrimClipCommand.h
+++ b/AestraAudio/include/Commands/TrimClipCommand.h
@@ -5,6 +5,8 @@
 #include "Models/ClipInstance.h"
 #include "Models/PlaylistModel.h"
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -13,18 +15,42 @@ namespace Audio {
 
 /**
  * @brief Command to trim a clip's start/end positions
+ *
+ * Contract (#744): a left-edge trim moves the timeline start AND advances the
+ * source read offset by the same musical amount so the right edge stays pinned;
+ * a right-edge trim changes only the visible end/duration. Both directions must
+ * go through the command history so undo, dirty state, autosave, recovery and
+ * serialization agree. For audio clips, durationSeconds is kept canonical
+ * (the serializer prefers it over beats) and the source-offset advance lands in
+ * sourceOffsetSeconds, from which the legacy beat-domain field is re-derived on
+ * load.
  */
 class TrimClipCommand : public ICommand {
 public:
     /**
-     * @brief Construct a trim command
-     * @param model The playlist model
-     * @param clipId The clip to trim
+     * @brief Lazy variant: original state is captured from the model at first
+     *        execute. Used by programmatic/CLI callers that have not mutated
+     *        the clip yet.
      * @param newStartBeat New start position (-1 = keep current)
      * @param newEndBeat New end position (-1 = keep current)
      */
     TrimClipCommand(PlaylistModel& model, ClipInstanceID clipId, double newStartBeat, double newEndBeat)
         : m_model(model), m_clipId(clipId), m_newStartBeat(newStartBeat), m_newEndBeat(newEndBeat) {}
+
+    /**
+     * @brief Explicit-variant for UI gestures that already applied the trim to
+     *        the model live (the timeline edge drag). Original state must be
+     *        captured at gesture start, not at execute — by the time the
+     *        command is pushed the model no longer holds it.
+     */
+    TrimClipCommand(PlaylistModel& model, ClipInstanceID clipId, double originalStartBeat, double originalEndBeat,
+                    double originalSourceOffsetSeconds, double originalDurationSeconds, double newStartBeat,
+                    double newEndBeat)
+        : m_model(model), m_clipId(clipId), m_originalStartBeat(originalStartBeat),
+          m_originalDuration(originalEndBeat - originalStartBeat),
+          m_originalSourceOffsetSeconds(originalSourceOffsetSeconds),
+          m_originalDurationSeconds(originalDurationSeconds), m_newStartBeat(newStartBeat), m_newEndBeat(newEndBeat),
+          m_originalCaptured(true) {}
 
     void execute() override {
         if (m_executed)
@@ -34,17 +60,55 @@ public:
         if (!clip)
             return;
 
-        // Capture original state
-        m_originalStartBeat = clip->startBeat;
-        m_originalDuration = clip->durationBeats;
+        if (!m_originalCaptured) {
+            m_originalStartBeat = clip->startBeat;
+            m_originalDuration = clip->durationBeats;
+            m_originalDurationSeconds = clip->durationSeconds;
+            m_originalSourceOffsetSeconds = clip->sourceOffsetSeconds;
+            m_originalCaptured = true;
+        }
+        if (!m_wasAudioDetermined) {
+            // Audio-ness cannot change mid-gesture; capture once, reuse for undo.
+            m_originalWasAudio = m_model.isAudioClip(*clip);
+            m_wasAudioDetermined = true;
+        }
 
-        // Apply trim
         double newStart = (m_newStartBeat < 0) ? clip->startBeat : m_newStartBeat;
         double newEnd = (m_newEndBeat < 0) ? (clip->startBeat + clip->durationBeats) : m_newEndBeat;
 
         // Validate: end must be after start
         if (newEnd <= newStart) {
-            return;  // Invalid trim range - don't apply
+            return; // Invalid trim range - don't apply
+        }
+
+        if (m_originalWasAudio) {
+            // The source read offset must never go negative: clamp the start to
+            // the source-start beat (start - offset), same formula the UI drag
+            // uses, so the model can never hold an unrenderable offset.
+            const double secondsPerBeat = m_model.beatToSeconds(1.0);
+            float rate = clip->edits.playbackRate;
+            if (!std::isfinite(rate) || rate <= 0.0f) {
+                rate = 1.0f;
+            }
+            rate = std::clamp(rate, 0.25f, 4.0f);
+            const double minStart =
+                m_originalStartBeat - m_originalSourceOffsetSeconds / (secondsPerBeat * rate);
+            if (newStart < minStart) {
+                newStart = minStart;
+            }
+            if (newEnd <= newStart) {
+                return; // Clamped start swallowed the trim range - don't apply
+            }
+
+            clip->durationSeconds = m_model.beatToSeconds(newEnd - newStart);
+            if (newStart != m_originalStartBeat) {
+                // Left-edge trim: advance the source read position by the same
+                // musical amount (scaled by playback rate so the right edge
+                // stays pinned under varispeed). Right-edge trims leave the
+                // source offset untouched.
+                clip->sourceOffsetSeconds =
+                    m_originalSourceOffsetSeconds + (newStart - m_originalStartBeat) * secondsPerBeat * rate;
+            }
         }
 
         clip->startBeat = newStart;
@@ -63,13 +127,15 @@ public:
 
         clip->startBeat = m_originalStartBeat;
         clip->durationBeats = m_originalDuration;
+        if (m_originalWasAudio) {
+            clip->durationSeconds = m_originalDurationSeconds;
+            clip->sourceOffsetSeconds = m_originalSourceOffsetSeconds;
+        }
 
         m_executed = false;
     }
 
-    void redo() override {
-        execute();
-    }
+    void redo() override { execute(); }
 
     std::string getName() const override { return "Trim Clip"; }
     size_t getSizeInBytes() const override { return sizeof(*this); }
@@ -84,6 +150,11 @@ private:
     // Original state for undo
     double m_originalStartBeat = 0.0;
     double m_originalDuration = 0.0;
+    double m_originalDurationSeconds = 0.0;
+    double m_originalSourceOffsetSeconds = 0.0;
+    bool m_originalWasAudio = false;
+    bool m_originalCaptured = false;
+    bool m_wasAudioDetermined = false;
     bool m_executed = false;
 };
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -15,6 +15,7 @@
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetSoloCommand.h"
+#include "Commands/TrimClipCommand.h"
 
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
@@ -2235,6 +2236,22 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     if (!event.pressed && event.button == AestraUI::NUIMouseButton::Left) {
         bool wasActive = m_isTrimming || m_isDraggingClip || m_clipDragPotential;
         if (m_isTrimming) {
+            // The trim was applied to the model live during the drag. Push the
+            // command now so the edit survives as unsaved work, round-trips,
+            // and can be undone (#744).
+            if (auto* clip = m_trackManager->getPlaylistModel().getClip(m_activeClipId)) {
+                auto& playlist = m_trackManager->getPlaylistModel();
+                const double originalEnd = m_trimOriginalStart + m_trimOriginalDuration;
+                const double newStart = clip->startBeat;
+                const double newEnd = clip->startBeat + clip->durationBeats;
+                if (newStart != m_trimOriginalStart || newEnd != originalEnd) {
+                    auto command = std::make_shared<TrimClipCommand>(
+                        playlist, m_activeClipId, m_trimOriginalStart, originalEnd,
+                        m_trimOriginalSourceOffsetSeconds, m_trimOriginalDurationSeconds, newStart,
+                        newEnd);
+                    m_trackManager->getCommandHistory().pushAndExecute(command);
+                }
+            }
             Log::info("Finished trimming clip");
         }
         
@@ -2283,9 +2300,27 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                         double deltaBeats = (deltaX / m_pixelsPerBeat);
                         
                         if (m_trimEdge == TrimEdge::Left) {
-                            // Trim left: move start beat and reduce duration
-                            double newStart = std::max(0.0, m_trimOriginalStart + deltaBeats);
+                            // Trim left: move start beat and reduce duration. The
+                            // left edge must never extend before the source start
+                            // (that writes a negative source read offset the
+                            // renderer cannot honor), so clamp to the source-start
+                            // beat for audio clips, using the same rate formula as
+                            // TrimClipCommand so drag and command agree.
+                            double minStart = 0.0;
+                            if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
+                                auto& playlistModel = m_trackManager->getPlaylistModel();
+                                float rate = clip.edits.playbackRate;
+                                if (!std::isfinite(rate) || rate <= 0.0f) {
+                                    rate = 1.0f;
+                                }
+                                rate = std::clamp(rate, 0.25f, 4.0f);
+                                const double secondsPerBeat = playlistModel.beatToSeconds(1.0);
+                                minStart = std::max(
+                                    0.0, m_trimOriginalStart - m_trimOriginalSourceOffsetSeconds / (secondsPerBeat * rate));
+                            }
+                            double newStart = std::max(minStart, m_trimOriginalStart + deltaBeats);
                             newStart = snapBeatToGrid(newStart); // Apply snap
+                            newStart = std::max(newStart, minStart); // Snap must not push before source start
                             
                             double endBeat = m_trimOriginalStart + m_trimOriginalDuration;
                             clip.startBeat = std::min(newStart, endBeat - 0.1); // Keep minimum duration
@@ -2478,6 +2513,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                                 if (clip.id == clickedClipId) {
                                     m_trimOriginalStart = clip.startBeat;
                                     m_trimOriginalDuration = clip.durationBeats;
+                                    m_trimOriginalSourceOffsetSeconds = clip.sourceOffsetSeconds;
+                                    m_trimOriginalDurationSeconds = clip.durationSeconds;
                                     break;
                                 }
                             }
@@ -2511,6 +2548,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                                 if (clip.id == clickedClipId) {
                                     m_trimOriginalStart = clip.startBeat;
                                     m_trimOriginalDuration = clip.durationBeats;
+                                    m_trimOriginalSourceOffsetSeconds = clip.sourceOffsetSeconds;
+                                    m_trimOriginalDurationSeconds = clip.durationSeconds;
                                     break;
                                 }
                             }

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -230,6 +230,8 @@ private:
     double m_trimOriginalStart = 0.0;         // Original trim start before drag
     double m_trimOriginalDuration = 0.0;      // Original trim duration before drag
     double m_trimOriginalEnd = 0.0;           // Original trim end before drag
+    double m_trimOriginalSourceOffsetSeconds = 0.0; // Original source offset (audio) before drag
+    double m_trimOriginalDurationSeconds = 0.0;     // Original duration (seconds, audio) before drag
     float m_trimDragStartX = 0.0f;            // Mouse X when trim started
     static constexpr float TRIM_EDGE_WIDTH = 8.0f;  // Pixels for edge hit detection
     

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -76,6 +76,7 @@ namespace {
         AutomationTarget,
         DroppedClip,
         SendRoute,
+        ClipTiming,
         Count
     };
 
@@ -2127,9 +2128,34 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                             finiteNumberOr(cj[c], "duration", 0.0, 0.0, 1000000.0);
                                         clip.durationSeconds = legacyDurationBeats * 60.0 / std::max(result.tempo, 1.0);
                                     }
-                                    clip.sourceOffsetSeconds =
-                                        finiteNumberOr(cj[c], "sourceOffsetSeconds", 0.0, 0.0, 1000000.0);
-                                    if (clip.sourceOffsetSeconds <= 0.0) {
+                                    const bool hadNegativeSourceOffset =
+                                        cj[c].has("sourceOffsetSeconds") && cj[c]["sourceOffsetSeconds"].isNumber() &&
+                                        std::isfinite(cj[c]["sourceOffsetSeconds"].asNumber()) &&
+                                        cj[c]["sourceOffsetSeconds"].asNumber() < 0.0;
+                                    if (hadNegativeSourceOffset) {
+                                        clip.sourceOffsetSeconds = 0.0;
+                                        ++result.negativeAudioClipOffsetsCorrected;
+                                        const std::string clipReference = clip.id.toString();
+                                        warningLimiter.warning(
+                                            ProjectLoadWarningCategory::ClipTiming,
+                                            "[ProjectLoad] Audio clip " + clipReference +
+                                                " had a negative source offset; clamped to 0 because source material "
+                                                "before time zero does not exist",
+                                            "[ProjectLoad] Additional negative audio clip source-offset warnings "
+                                            "suppressed.");
+                                        if (!result.report) {
+                                            result.report = std::make_unique<ProjectLoadReport>();
+                                        }
+                                        result.report->issues.push_back(
+                                            {LoadIssueSeverity::Warning, "clip_timing",
+                                             "Audio clip had a negative source offset; clamped to zero because source "
+                                             "material before time zero does not exist",
+                                             0, clipReference, laneName});
+                                    } else {
+                                        clip.sourceOffsetSeconds =
+                                            finiteNumberOr(cj[c], "sourceOffsetSeconds", 0.0, 0.0, 1000000.0);
+                                    }
+                                    if (!hadNegativeSourceOffset && clip.sourceOffsetSeconds <= 0.0) {
                                         const double legacySourceOffsetBeats =
                                             finiteNumberOr(cj[c], "sourceOffset", 0.0, 0.0, 1000000.0);
                                         clip.sourceOffsetSeconds =
@@ -2294,6 +2320,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             combineMigrationOutcome(result.migrationOutcome, MigrationOutcome::Transformed);
         Log::info("[ProjectLoad] Split " + std::to_string(result.legacyAudioPatternsSplit) +
                   " legacy audio pattern(s) across mixer channels — project must be saved to keep the split");
+    }
+    if (result.negativeAudioClipOffsetsCorrected > 0) {
+        result.migrationOutcome = combineMigrationOutcome(result.migrationOutcome, MigrationOutcome::Transformed);
+        Log::warning("[ProjectLoad] Corrected " + std::to_string(result.negativeAudioClipOffsetsCorrected) +
+                     " negative audio clip source offset(s) — project must be saved to keep the correction");
     }
 
     result.ok = true;

--- a/Source/Core/ProjectSerializer.h
+++ b/Source/Core/ProjectSerializer.h
@@ -124,6 +124,11 @@ public:
         /// not in the file, which is why such a load reports `Transformed`.
         size_t legacyAudioPatternsSplit{0};
 
+        /// Audio clips whose persisted source offset was negative. Source
+        /// material before time zero cannot be reconstructed, so load clamps
+        /// these offsets to zero, reports a warning, and requires a resave.
+        size_t negativeAudioClipOffsetsCorrected{0};
+
         std::string errorMessage;
         std::vector<std::string> missingAssets;
         std::vector<MissingPlugin> missingPlugins;

--- a/Tests/AestraAudio/ProjectDirtyStateTest.cpp
+++ b/Tests/AestraAudio/ProjectDirtyStateTest.cpp
@@ -16,6 +16,7 @@
 #include "Commands/AddClipCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/RemoveClipCommand.h"
+#include "Commands/TrimClipCommand.h"
 #include "Models/TrackManager.h"
 
 #include <cstdlib>
@@ -70,8 +71,7 @@ int main() {
         const PlaylistLaneID laneId = playlist.createLane("Lane");
         tracks.setModified(false);
 
-        tracks.getCommandHistory().pushAndExecute(
-            std::make_shared<AddClipCommand>(playlist, laneId, makeClip(0.0)));
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<AddClipCommand>(playlist, laneId, makeClip(0.0)));
         require(tracks.isModified(), "Adding a clip must mark the project modified");
     }
 
@@ -85,9 +85,27 @@ int main() {
         PlaylistLaneID laneId;
         const ClipInstanceID clipId = seedClip(tracks, laneId);
 
-        tracks.getCommandHistory().pushAndExecute(
-            std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
         require(tracks.isModified(), "Completing a clip move must mark the project modified");
+    }
+
+    // Trim completion (TrackUIComponent trim release) pushes a TrimClipCommand
+    // and nothing else (#744). Trimming a clip is an edit; it must survive as
+    // unsaved work — this is the exact gap that let trims vanish through
+    // autosave/recovery before the gesture was wired through the history.
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        PlaylistLaneID laneId;
+        const ClipInstanceID clipId = seedClip(tracks, laneId);
+
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<TrimClipCommand>(playlist, clipId, 1.0, 4.0));
+        require(tracks.isModified(), "Completing a clip trim must mark the project modified");
+
+        tracks.setModified(false);
+        require(tracks.getCommandHistory().undo(), "Undo of a clip trim should succeed");
+        require(tracks.isModified(), "Undo of a trim must mark the project modified");
     }
 
     // Cut (TrackManagerUI::cutSelectedClip) and delete
@@ -153,8 +171,7 @@ int main() {
         int onModifiedCount = 0;
         tracks.setOnModified([&onModifiedCount]() { onModifiedCount++; });
 
-        tracks.getCommandHistory().pushAndExecute(
-            std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
+        tracks.getCommandHistory().pushAndExecute(std::make_shared<MoveClipCommand>(playlist, clipId, 8.0, laneId));
         require(onModifiedCount == 1, "The modified hook must fire once per history-driven edit");
     }
 
@@ -175,8 +192,7 @@ int main() {
 
         tracks.getCommandHistory().pushAndExecute(std::make_shared<RemoveClipCommand>(playlist, clipId));
         require(panelRefreshCount == 1, "A panel listener must be notified of history changes");
-        require(tracks.isModified(),
-                "Registering a panel listener must not displace project dirty tracking");
+        require(tracks.isModified(), "Registering a panel listener must not displace project dirty tracking");
     }
 
     // -------------------------------------------------------------------
@@ -208,9 +224,8 @@ int main() {
         for (int i = 1; i <= 50; ++i) {
             tracks.addChannel("Channel " + std::to_string(i));
         }
-        require(tracks.isModified(),
-                "addChannel must still mark the project modified — the defect is not "
-                "that addChannel dirties, it is that construction never cleared");
+        require(tracks.isModified(), "addChannel must still mark the project modified — the defect is not "
+                                     "that addChannel dirties, it is that construction never cleared");
 
         // What the constructor now does after populating.
         tracks.setModified(false);
@@ -218,8 +233,7 @@ int main() {
 
         // A real user edit through the very same path must dirty it again.
         tracks.addChannel("User added this one");
-        require(tracks.isModified(),
-                "A channel added after construction must mark the project modified");
+        require(tracks.isModified(), "A channel added after construction must mark the project modified");
     }
 
     std::cout << "[PASS] ProjectDirtyStateTest\n";

--- a/Tests/Commands/ClipCommandsTest.cpp
+++ b/Tests/Commands/ClipCommandsTest.cpp
@@ -413,7 +413,7 @@ void testTrimClipCommandAudioContract(const std::string& dir) {
 int main() {
     std::cout << "\n=== Aestra Clip Commands Test ===\n";
 
-    const std::string renderDir = std::string(std::filesystem::temp_directory_path()) + "/aestra-clipcmd-trim";
+    const std::string renderDir = std::filesystem::temp_directory_path().string() + "/aestra-clipcmd-trim";
 
     testTrimClipCommand();
     testTrimClipCommandAudioContract(renderDir);

--- a/Tests/Commands/ClipCommandsTest.cpp
+++ b/Tests/Commands/ClipCommandsTest.cpp
@@ -2,17 +2,64 @@
 // Clip Commands Unit Tests
 // Tests: TrimClipCommand, DuplicateClipCommand, RemoveClipCommand
 
-#include "Commands/TrimClipCommand.h"
+#include "Commands/AddClipCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/RemoveClipCommand.h"
-#include "Commands/AddClipCommand.h"
+#include "Commands/TrimClipCommand.h"
 #include "Models/ClipInstance.h"
+#include "Models/ClipSource.h"
+#include "Models/PatternSource.h"
 #include "Models/PlaylistModel.h"
+#include "Models/TrackManager.h"
 
 #include <cassert>
+#include <cstdio>
+#include <filesystem>
 #include <iostream>
+#include <memory>
 
 using namespace Aestra::Audio;
+
+namespace {
+
+/** Build source -> audio pattern -> clip exactly as the import path does. */
+ClipInstanceID seedAudioClip(TrackManager& tracks, PlaylistLaneID& laneOut, const std::string& renderDir) {
+    auto& playlist = tracks.getPlaylistModel();
+    playlist.setPatternManager(&tracks.getPatternManager());
+    tracks.setRecordingProjectPath(renderDir);
+
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->sampleRate = 48000;
+    buffer->numChannels = 2;
+    buffer->numFrames = 4800;
+    buffer->interleavedData.assign(4800 * 2, 0.0f);
+
+    const ClipSourceID sourceId =
+        tracks.getSourceManager().createRecordedSource(renderDir + "/source.wav", "source", buffer);
+
+    AudioSlicePayload payload;
+    payload.audioSourceId = sourceId;
+    AudioSlice slice;
+    slice.startSamples = 0.0;
+    slice.lengthSamples = static_cast<double>(buffer->numFrames);
+    payload.slices.push_back(slice);
+
+    const PatternID patternId = tracks.getPatternManager().createAudioPattern("source", 4.0, payload);
+
+    laneOut = playlist.createLane("Lane");
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.startBeat = 4.0;
+    clip.durationBeats = 4.0;
+    clip.durationSeconds = playlist.beatToSeconds(4.0);
+    clip.sourceOffsetSeconds = 0.0;
+    clip.patternId = patternId;
+    clip.edits = ClipEdits::forNewAudioClip();
+    playlist.addClip(laneOut, clip);
+    return clip.id;
+}
+
+} // namespace
 
 void testTrimClipCommand() {
     std::cout << "TEST: TrimClipCommand... ";
@@ -36,7 +83,7 @@ void testTrimClipCommand() {
     ClipInstance* trimmed = model.getClip(clip.id);
     assert(trimmed != nullptr);
     assert(trimmed->startBeat == 6.0);
-    assert(trimmed->durationBeats == 4.0);  // 10 - 6 = 4
+    assert(trimmed->durationBeats == 4.0); // 10 - 6 = 4
 
     cmd.undo();
     assert(trimmed->startBeat == 4.0);
@@ -238,10 +285,138 @@ void testRemoveClipCommandPreservesClipData() {
     std::cout << "✅ PASS\n";
 }
 
+void testTrimClipCommandAudioContract(const std::string& dir) {
+    std::cout << "TEST: TrimClipCommand audio contract (duration + source offset + undo)... ";
+
+    auto tracks = std::make_unique<TrackManager>();
+    auto& playlist = tracks->getPlaylistModel();
+    PlaylistLaneID laneId;
+    const ClipInstanceID clipId = seedAudioClip(*tracks, laneId, dir);
+
+    const double secondsPerBeat = playlist.beatToSeconds(1.0);
+
+    // Left-edge trim: start 4 -> 6, end 8. Right edge stays pinned, so the
+    // source read offset advances by the trimmed musical amount.
+    {
+        TrimClipCommand cmd(playlist, clipId, 4.0, 8.0, 0.0, playlist.beatToSeconds(4.0), 6.0, 8.0);
+        cmd.execute();
+
+        ClipInstance* trimmed = playlist.getClip(clipId);
+        assert(trimmed->startBeat == 6.0);
+        assert(trimmed->durationBeats == 2.0);
+        assert(trimmed->durationSeconds == playlist.beatToSeconds(2.0));
+        assert(trimmed->sourceOffsetSeconds == 2.0 * secondsPerBeat);
+
+        cmd.undo();
+        assert(trimmed->startBeat == 4.0);
+        assert(trimmed->durationBeats == 4.0);
+        assert(trimmed->durationSeconds == playlist.beatToSeconds(4.0));
+        assert(trimmed->sourceOffsetSeconds == 0.0);
+
+        cmd.redo();
+        assert(trimmed->startBeat == 6.0);
+        assert(trimmed->durationBeats == 2.0);
+        assert(trimmed->durationSeconds == playlist.beatToSeconds(2.0));
+        assert(trimmed->sourceOffsetSeconds == 2.0 * secondsPerBeat);
+    }
+
+    // Right-edge trim: end 8 -> 6. Visible end only; source offset untouched.
+    {
+        ClipInstance* fresh = playlist.getClip(clipId);
+        fresh->startBeat = 4.0;
+        fresh->durationBeats = 4.0;
+        fresh->durationSeconds = playlist.beatToSeconds(4.0);
+        fresh->sourceOffsetSeconds = 0.0;
+
+        TrimClipCommand cmd(playlist, clipId, 4.0, 8.0, 0.0, playlist.beatToSeconds(4.0), 4.0, 6.0);
+        cmd.execute();
+
+        ClipInstance* trimmed = playlist.getClip(clipId);
+        assert(trimmed->startBeat == 4.0);
+        assert(trimmed->durationBeats == 2.0);
+        assert(trimmed->durationSeconds == playlist.beatToSeconds(2.0));
+        assert(trimmed->sourceOffsetSeconds == 0.0);
+    }
+
+    // Left-edge trim under varispeed: the source advance scales with the
+    // playback rate so the right edge stays pinned.
+    {
+        ClipInstance* fresh = playlist.getClip(clipId);
+        fresh->startBeat = 4.0;
+        fresh->durationBeats = 4.0;
+        fresh->durationSeconds = playlist.beatToSeconds(4.0);
+        fresh->sourceOffsetSeconds = 0.0;
+        fresh->edits.playbackRate = 1.0f;
+
+        TrimClipCommand cmd(playlist, clipId, 4.0, 8.0, 0.0, playlist.beatToSeconds(4.0), 5.0, 8.0);
+        cmd.execute();
+
+        ClipInstance* trimmed = playlist.getClip(clipId);
+        assert(trimmed->sourceOffsetSeconds == 1.0 * secondsPerBeat); // rate 1.0
+
+        trimmed->edits.playbackRate = 2.0f;
+        TrimClipCommand fastCmd(playlist, clipId, 4.0, 8.0, 0.0, playlist.beatToSeconds(4.0), 5.0, 8.0);
+        fastCmd.execute();
+        assert(trimmed->sourceOffsetSeconds == 2.0 * secondsPerBeat); // scaled by rate
+    }
+
+    // Left-edge extension must never write a negative source offset: dragging
+    // earlier than the source start clamps to the source-start beat instead.
+    {
+        ClipInstance* fresh = playlist.getClip(clipId);
+        fresh->startBeat = 4.0;
+        fresh->durationBeats = 4.0;
+        fresh->durationSeconds = playlist.beatToSeconds(4.0);
+        fresh->sourceOffsetSeconds = 0.0;
+        fresh->edits.playbackRate = 1.0f;
+
+        // Source starts at beat 4.0; an extension to beat 2.0 is illegal.
+        TrimClipCommand cmd(playlist, clipId, 4.0, 8.0, 0.0, playlist.beatToSeconds(4.0), 2.0, 8.0);
+        cmd.execute();
+
+        ClipInstance* trimmed = playlist.getClip(clipId);
+        assert(trimmed->startBeat == 4.0);
+        assert(trimmed->durationBeats == 4.0);
+        assert(trimmed->durationSeconds == playlist.beatToSeconds(4.0));
+        assert(trimmed->sourceOffsetSeconds == 0.0);
+    }
+
+    // The clamp respects an existing source offset: a clip already trimmed in
+    // by one beat can extend back to its source start, but no further.
+    {
+        ClipInstance* fresh = playlist.getClip(clipId);
+        fresh->startBeat = 4.0;
+        fresh->durationBeats = 4.0;
+        fresh->durationSeconds = playlist.beatToSeconds(4.0);
+        fresh->sourceOffsetSeconds = 1.0 * secondsPerBeat; // source start at beat 3.0
+        fresh->edits.playbackRate = 1.0f;
+
+        // Extend to beat 3.0: legal, source offset falls to zero.
+        TrimClipCommand cmd(playlist, clipId, 4.0, 8.0, 1.0 * secondsPerBeat,
+                            playlist.beatToSeconds(4.0), 3.0, 8.0);
+        cmd.execute();
+        ClipInstance* trimmed = playlist.getClip(clipId);
+        assert(trimmed->startBeat == 3.0);
+        assert(trimmed->sourceOffsetSeconds == 0.0);
+
+        // Extend past the source start to beat 2.0: clamped to 3.0, offset 0.
+        TrimClipCommand past(playlist, clipId, 4.0, 8.0, 1.0 * secondsPerBeat,
+                             playlist.beatToSeconds(4.0), 2.0, 8.0);
+        past.execute();
+        assert(trimmed->startBeat == 3.0);
+        assert(trimmed->sourceOffsetSeconds == 0.0);
+    }
+
+    std::cout << "✅ PASS\n";
+}
+
 int main() {
     std::cout << "\n=== Aestra Clip Commands Test ===\n";
 
+    const std::string renderDir = std::string(std::filesystem::temp_directory_path()) + "/aestra-clipcmd-trim";
+
     testTrimClipCommand();
+    testTrimClipCommandAudioContract(renderDir);
     testDuplicateClipCommand();
 
     testRemoveClipCommand();

--- a/Tests/Integration/ProjectRoundTripTest.cpp
+++ b/Tests/Integration/ProjectRoundTripTest.cpp
@@ -3,6 +3,7 @@
 #include "../../Source/Core/ProjectSerializer.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "../Support/TestTempDirectory.h"
+#include "Commands/TrimClipCommand.h"
 #include "Models/ClipSource.h"
 #include "Models/PatternSource.h"
 #include "Models/TrackManager.h"
@@ -80,6 +81,7 @@ int main() {
     const auto wavPath = tempDir / "test.wav";
     const auto projectPath = tempDir / "project.aes";
     const auto autosavePath = tempDir / "autosave.aes";
+    const auto negativeOffsetPath = tempDir / "negative-offset.aes";
 
     std::cout << "[INFO] TempDir: " << tempDir.string() << "\n";
     std::cout << "[INFO] Writing WAV...\n";
@@ -140,6 +142,8 @@ int main() {
     require(clipId.isValid(), "Failed to add clip from pattern");
 
     if (auto* clip = playlist1.getClip(clipId)) {
+        clip->durationSeconds = playlist1.beatToSeconds(4.0);
+        clip->sourceOffsetSeconds = 0.0;
         clip->edits.gainLinear = 0.9f;
         clip->edits.pan = 0.1f;
         clip->edits.muted = false;
@@ -148,6 +152,17 @@ int main() {
         clip->edits.fadeOutBeats = 0.0;
         clip->edits.sourceStart = 0.0;
     }
+
+    // Exercise the same explicit command variant used when the UI releases a
+    // live left-edge trim, then carry that state through both save paths.
+    const double expectedTrimStartBeat = 1.0;
+    const double expectedTrimDurationBeats = 3.0;
+    const double expectedTrimDurationSeconds = playlist1.beatToSeconds(expectedTrimDurationBeats);
+    const double expectedTrimSourceOffsetSeconds = playlist1.beatToSeconds(expectedTrimStartBeat);
+    tm1->setModified(false);
+    tm1->getCommandHistory().pushAndExecute(std::make_shared<TrimClipCommand>(
+        playlist1, clipId, 0.0, 4.0, 0.0, playlist1.beatToSeconds(4.0), expectedTrimStartBeat, 4.0));
+    require(tm1->isModified(), "UI-style trim command did not dirty the project before serialization");
 
     channel1->setMainOutputId(channel2Src->getChannelId());
     AudioRoute audibleSend{};
@@ -169,11 +184,13 @@ int main() {
     channel1->addSend(sidechainSend);
 
     // --- Autosave-style path: serialize compact (indent=0) + atomic write
+    std::string autosaveContents;
     {
         std::cout << "[INFO] Serializing (indent=0) + atomic write (autosave)...\n";
         auto ser = ProjectSerializer::serialize(tm1, 128.0, 1.234, 0);
         require(ser.ok, "ProjectSerializer::serialize failed");
         require(!ser.contents.empty(), "ProjectSerializer::serialize produced empty output");
+        autosaveContents = ser.contents;
         require(ProjectSerializer::writeAtomically(autosavePath.string(), ser.contents),
                 "ProjectSerializer::writeAtomically failed");
         std::cout << "[INFO] Autosave written: " << autosavePath.string() << " (" << ser.contents.size() << " bytes)\n";
@@ -221,8 +238,14 @@ int main() {
 
     require(loadedLane1->clips.size() == 1, "Clip count mismatch after load");
     const auto& loadedClip = loadedLane1->clips[0];
-    require(std::abs(loadedClip.startBeat - 0.0) < 1e-9, "Clip start mismatch after load");
-    require(std::abs(loadedClip.durationBeats - 4.0) < 1e-9, "Clip duration mismatch after load");
+    require(std::abs(loadedClip.startBeat - expectedTrimStartBeat) < 1e-9,
+            "Trimmed clip start mismatch after canonical load");
+    require(std::abs(loadedClip.durationBeats - expectedTrimDurationBeats) < 1e-9,
+            "Trimmed clip beat duration mismatch after canonical load");
+    require(std::abs(loadedClip.durationSeconds - expectedTrimDurationSeconds) < 1e-9,
+            "Trimmed clip second duration mismatch after canonical load");
+    require(std::abs(loadedClip.sourceOffsetSeconds - expectedTrimSourceOffsetSeconds) < 1e-9,
+            "Trimmed clip source offset mismatch after canonical load");
     require(std::abs(loadedClip.edits.gainLinear - 0.9f) < 1e-6f, "Clip gain mismatch after load");
 
     PlaylistLaneID loadedLane2Id = playlist2.getLaneId(1);
@@ -289,6 +312,52 @@ int main() {
             "Autosave audible send mismatch");
     require(autosaveSends[1].postFader == true && autosaveSends[1].sidechainOnly == true,
             "Autosave sidechain send mismatch");
+
+    const auto* autosaveLane = tm3->getPlaylistModel().getLane(tm3->getPlaylistModel().getLaneId(0));
+    require(autosaveLane != nullptr && autosaveLane->clips.size() == 1, "Autosave trimmed clip missing");
+    const auto& autosaveClip = autosaveLane->clips[0];
+    require(std::abs(autosaveClip.startBeat - expectedTrimStartBeat) < 1e-9,
+            "Trimmed clip start mismatch after autosave load");
+    require(std::abs(autosaveClip.durationSeconds - expectedTrimDurationSeconds) < 1e-9,
+            "Trimmed clip duration mismatch after autosave load");
+    require(std::abs(autosaveClip.sourceOffsetSeconds - expectedTrimSourceOffsetSeconds) < 1e-9,
+            "Trimmed clip source offset mismatch after autosave load");
+
+    // Historical builds could persist a negative sourceOffsetSeconds after a
+    // left-edge extension. Such a file cannot reveal source material before
+    // time zero: load must clamp, warn observably, and require a corrective save.
+    const std::string offsetKey = "\"sourceOffsetSeconds\":";
+    const size_t offsetKeyAt = autosaveContents.find(offsetKey);
+    require(offsetKeyAt != std::string::npos, "Serialized audio clip source offset missing");
+    const size_t offsetValueAt = offsetKeyAt + offsetKey.size();
+    const size_t offsetValueEnd = autosaveContents.find_first_of(",}", offsetValueAt);
+    require(offsetValueEnd != std::string::npos, "Serialized audio clip source offset terminator missing");
+    autosaveContents.replace(offsetValueAt, offsetValueEnd - offsetValueAt, "-0.5");
+    require(ProjectSerializer::writeAtomically(negativeOffsetPath.string(), autosaveContents),
+            "Failed to write legacy negative-offset project");
+
+    auto tm4 = std::make_shared<TrackManager>();
+    tm4->getPlaylistModel().setPatternManager(&tm4->getPatternManager());
+    const auto negativeOffsetLoad = ProjectSerializer::load(negativeOffsetPath.string(), tm4);
+    require(negativeOffsetLoad.ok, "Legacy negative-offset project failed to load");
+    require(negativeOffsetLoad.negativeAudioClipOffsetsCorrected == 1,
+            "Legacy negative source offset correction was not counted");
+    require(negativeOffsetLoad.requiresSaveAfterLoad(),
+            "Legacy negative source offset correction did not require a resave");
+    const auto* correctedLane = tm4->getPlaylistModel().getLane(tm4->getPlaylistModel().getLaneId(0));
+    require(correctedLane != nullptr && correctedLane->clips.size() == 1, "Corrected negative-offset clip missing");
+    require(std::abs(correctedLane->clips[0].sourceOffsetSeconds) < 1e-12,
+            "Legacy negative source offset was not clamped to zero");
+    bool sawClipTimingWarning = false;
+    if (negativeOffsetLoad.report) {
+        for (const auto& issue : negativeOffsetLoad.report->issues) {
+            if (issue.category == "clip_timing" && issue.referenceId == correctedLane->clips[0].id.toString()) {
+                sawClipTimingWarning = true;
+                break;
+            }
+        }
+    }
+    require(sawClipTimingWarning, "Legacy negative source offset correction was not reported structurally");
 
     std::cout << "[PASS] ProjectRoundTripTest\n";
     return 0;


### PR DESCRIPTION
## Summary

- Finalize clip trims through `TrimClipCommand` when the UI gesture ends.
- Preserve beat bounds, second duration, and source offset across execute, undo, redo, save, autosave, and reload.
- Clamp historically invalid negative audio source offsets during load, emit a structured warning, and require a corrective resave.
- Add focused command, dirty-state, and project-roundtrip regressions.

## Why

The live trim gesture changed clip fields directly but did not consistently enter command history or mark the canonical project dirty. That allowed autosave to contain newer trim state while the user-selected project remained old. Historical left-edge extensions could also persist a negative source offset that cannot represent real source material.

## Decision citation

Objective:  —
Decision:   FD-01 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind:       corrective
Reversal:   —

## Testing performed

- `cmake --build build-linux --target ProjectRoundTripTest ClipCommandsTest ProjectDirtyStateTest Aestra -j2`
- `ctest --test-dir build-linux -R '^(ProjectRoundTripTest|AutosaveRoundTripTest|ClipCommandsTest|ProjectDirtyStateTest)$' --output-on-failure -j2`
- ASan/UBSan `ProjectRoundTripTest`
- Full configured `build-linux` tree compiled successfully during combined validation.

## Producer note

Now you can trim clips and have those edits survive saving and reopening a project.

## Docs updated?

No. This corrects existing behavior and does not introduce a new workflow.

## Risk and rollback

Persistence is high-risk, so the on-disk schema is unchanged. The loader only repairs negative `sourceOffsetSeconds` values to zero, reports the repair, and requests a resave. Rollback is the single commit on this branch.
