### PR TITLE
fix(ui): prevent hierarchy mutation crashes during dispatch

### DIFF
--- a/AestraUI/Core/NUIApp.cpp
+++ b/AestraUI/Core/NUIApp.cpp
@@ -230,15 +230,11 @@ void NUIApp::handleMouseEvent(const NUIMouseEvent& event) {
     } else if (event.type == NUIMouseEventType::Scroll) {
         adaptiveFPS_.signalActivity(NUIAdaptiveFPS::ActivityType::Scroll);
     }
-    
-    // Dispatch event to root component
-    // The component will handle hover state internally
-    // Dispatch event to root component
-    // The component will handle hover state internally
-    NUIComponent::beginEventDispatch();
-    bool handled = rootComponent_->onMouseEvent(event);
-    NUIComponent::endEventDispatch();
-    
+
+    // Dispatch through the canonical guarded entry point so callbacks may
+    // safely rebuild component hierarchies.
+    bool handled = NUIComponent::dispatchMouseEvent(rootComponent_.get(), event);
+
     // Handle focus on click
     if (event.pressed && !handled) {
         // Only reset to root if no component handled the interaction

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -266,8 +266,21 @@ void NUIComponent::addChild(std::shared_ptr<NUIComponent> child) {
     if (!child->theme_ && theme_) {
         child->setTheme(theme_);
     }
-    
+
     setDirty();
+}
+
+bool NUIComponent::dispatchMouseEvent(NUIComponent* target, const NUIMouseEvent& event) {
+    if (!target) {
+        return false;
+    }
+
+    struct DispatchGuard {
+        DispatchGuard() { NUIComponent::beginEventDispatch(); }
+        ~DispatchGuard() { NUIComponent::endEventDispatch(); }
+    } guard;
+
+    return target->onMouseEvent(event);
 }
 
 void NUIComponent::beginEventDispatch() {

--- a/AestraUI/Core/NUIComponent.cpp
+++ b/AestraUI/Core/NUIComponent.cpp
@@ -236,11 +236,19 @@ NUIRect NUIComponent::getGlobalBounds() const {
 namespace {
 // The dispatch guard is a per-thread context: begin/endEventDispatch and the
 // hierarchy mutations they bracket all run on the same (UI) thread. Depth
-// counts nested dispatches; queued entries hold strong refs so children stay
-// alive until dispatch unwinds.
+// counts nested dispatches; queued entries preserve mutation order and hold
+// strong refs so affected children stay alive until dispatch unwinds.
 thread_local int g_eventDispatchDepth = 0;
-thread_local std::vector<std::pair<NUIComponent*, std::shared_ptr<NUIComponent>>> g_deferredRemovals;
-thread_local std::vector<std::pair<NUIComponent*, std::shared_ptr<NUIComponent>>> g_deferredAdditions;
+
+enum class DeferredHierarchyOperationType { Add, Remove, RemoveAll, BringToFront };
+
+struct DeferredHierarchyOperation {
+    DeferredHierarchyOperationType type;
+    NUIComponent* parent;
+    std::shared_ptr<NUIComponent> child;
+};
+
+thread_local std::vector<DeferredHierarchyOperation> g_deferredHierarchyOperations;
 } // namespace
 
 void NUIComponent::addChild(std::shared_ptr<NUIComponent> child) {
@@ -249,7 +257,7 @@ void NUIComponent::addChild(std::shared_ptr<NUIComponent> child) {
     // Adding a popup from a mouse callback can otherwise reallocate the
     // parent's children vector while that same vector is being iterated.
     if (g_eventDispatchDepth > 0) {
-        g_deferredAdditions.emplace_back(this, std::move(child));
+        g_deferredHierarchyOperations.push_back({DeferredHierarchyOperationType::Add, this, std::move(child)});
         return;
     }
     
@@ -291,22 +299,34 @@ void NUIComponent::endEventDispatch() {
     if (g_eventDispatchDepth > 0) {
         --g_eventDispatchDepth;
     }
-    if (g_eventDispatchDepth == 0 && !g_deferredRemovals.empty()) {
-        auto pending = std::move(g_deferredRemovals);
-        g_deferredRemovals.clear();
-        for (auto& entry : pending) {
-            if (entry.first) {
-                entry.first->removeChild(entry.second); // depth == 0 now -> immediate
-            }
-        }
+    if (g_eventDispatchDepth != 0 || g_deferredHierarchyOperations.empty()) {
+        return;
     }
-    if (g_eventDispatchDepth == 0 && !g_deferredAdditions.empty()) {
-        auto pending = std::move(g_deferredAdditions);
-        g_deferredAdditions.clear();
-        for (auto& entry : pending) {
-            if (entry.first) {
-                entry.first->addChild(entry.second); // depth == 0 now -> immediate
+
+    auto pending = std::move(g_deferredHierarchyOperations);
+    g_deferredHierarchyOperations.clear();
+    for (auto& operation : pending) {
+        switch (operation.type) {
+        case DeferredHierarchyOperationType::Add:
+            if (operation.parent) {
+                operation.parent->addChild(operation.child);
             }
+            break;
+        case DeferredHierarchyOperationType::Remove:
+            if (operation.parent) {
+                operation.parent->removeChild(operation.child);
+            }
+            break;
+        case DeferredHierarchyOperationType::RemoveAll:
+            if (operation.parent) {
+                operation.parent->removeAllChildren();
+            }
+            break;
+        case DeferredHierarchyOperationType::BringToFront:
+            if (operation.child) {
+                operation.child->bringToFront();
+            }
+            break;
         }
     }
 }
@@ -318,7 +338,7 @@ void NUIComponent::removeChild(std::shared_ptr<NUIComponent> child) {
     if (g_eventDispatchDepth > 0) {
         // Defer until the dispatch unwinds; the strong ref keeps the child alive
         // through the rest of the current event.
-        g_deferredRemovals.emplace_back(this, std::move(child));
+        g_deferredHierarchyOperations.push_back({DeferredHierarchyOperationType::Remove, this, std::move(child)});
         return;
     }
     auto it = std::find(children_.begin(), children_.end(), child);
@@ -330,6 +350,11 @@ void NUIComponent::removeChild(std::shared_ptr<NUIComponent> child) {
 }
 
 void NUIComponent::removeAllChildren() {
+    if (g_eventDispatchDepth > 0) {
+        g_deferredHierarchyOperations.push_back({DeferredHierarchyOperationType::RemoveAll, this, nullptr});
+        return;
+    }
+
     for (auto& child : children_) {
         child->parent_ = nullptr;
     }
@@ -339,7 +364,13 @@ void NUIComponent::removeAllChildren() {
 
 void NUIComponent::bringToFront() {
     if (!parent_) return;
-    
+
+    if (g_eventDispatchDepth > 0) {
+        g_deferredHierarchyOperations.push_back(
+            {DeferredHierarchyOperationType::BringToFront, parent_, shared_from_this()});
+        return;
+    }
+
     auto& store = parent_->children_;
     // Check if valid before searching
     if (store.empty()) return;

--- a/AestraUI/Core/NUIComponent.h
+++ b/AestraUI/Core/NUIComponent.h
@@ -82,12 +82,13 @@ public:
     void removeChild(std::shared_ptr<NUIComponent> child);
     void removeAllChildren();
 
-    // Event-dispatch guard. While a mouse-event dispatch is in flight (bracketed
-    // by NUIApp around the root onMouseEvent), addChild()/removeChild() defer the
-    // actual hierarchy mutation until dispatch unwinds. This prevents callbacks
-    // that open or close popups from mutating a parent's children_ mid-iteration
-    // (iterator invalidation) or freeing a component still on the call stack
-    // (use-after-free). Nestable via an internal depth counter.
+    // Canonical mouse-event entry point. All platform/app dispatch must use this
+    // rather than calling onMouseEvent() directly so hierarchy mutations are
+    // deferred until the full component traversal unwinds.
+    static bool dispatchMouseEvent(NUIComponent* target, const NUIMouseEvent& event);
+
+    // Low-level nestable guard retained for code that brackets a larger custom
+    // dispatch. Prefer dispatchMouseEvent() for a single target.
     static void beginEventDispatch();
     static void endEventDispatch();
 

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -147,11 +147,11 @@ void NUIPlatformBridge::setupEventBridges() {
                                   static_cast<float>(m_cursorService.anchorY())};
                 event.delta = {static_cast<float>(d.dx), static_cast<float>(d.dy)};
                 // Routed dispatch: ONLY the capture owner sees motion.
-                m_cursorCaptureOwner->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_cursorCaptureOwner, event);
             } else {
                 event.position = {static_cast<float>(x), static_cast<float>(y)};
                 event.delta = {deltaX, deltaY};
-                m_rootComponent->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_rootComponent, event);
             }
         }
     });
@@ -190,10 +190,18 @@ void NUIPlatformBridge::setupEventBridges() {
             event.position = {static_cast<float>(x), static_cast<float>(y)};
             // Map button
             switch (button) {
-                case Aestra::MouseButton::Left: event.button = NUIMouseButton::Left; break;
-                case Aestra::MouseButton::Right: event.button = NUIMouseButton::Right; break;
-                case Aestra::MouseButton::Middle: event.button = NUIMouseButton::Middle; break;
-                default: event.button = NUIMouseButton::None; break;
+            case Aestra::MouseButton::Left:
+                event.button = NUIMouseButton::Left;
+                break;
+            case Aestra::MouseButton::Right:
+                event.button = NUIMouseButton::Right;
+                break;
+            case Aestra::MouseButton::Middle:
+                event.button = NUIMouseButton::Middle;
+                break;
+            default:
+                event.button = NUIMouseButton::None;
+                break;
             }
             event.pressed = pressed;
             event.released = !pressed;
@@ -205,9 +213,9 @@ void NUIPlatformBridge::setupEventBridges() {
                 event.modifiers = convertModifiers(mods);
             }
             if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
-                m_cursorCaptureOwner->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_cursorCaptureOwner, event);
             } else {
-                m_rootComponent->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_rootComponent, event);
             }
         }
     });
@@ -249,9 +257,9 @@ void NUIPlatformBridge::setupEventBridges() {
             // (anchored position above); it must never leak to whatever sits
             // under the hidden physical pointer.
             if (m_cursorService.isCaptured() && m_cursorCaptureOwner) {
-                m_cursorCaptureOwner->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_cursorCaptureOwner, event);
             } else {
-                m_rootComponent->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(m_rootComponent, event);
             }
         }
     });
@@ -347,7 +355,7 @@ void NUIPlatformBridge::setupEventBridges() {
                 event.wheelDelta = 0.0f;
                 event.cursorCaptured = true;
                 event.synthetic = true; // "stop", not "accept" — see NUIMouseEvent
-                owner->onMouseEvent(event);
+                NUIComponent::dispatchMouseEvent(owner, event);
             }
         }
         if (m_focusCallback) {
@@ -411,7 +419,7 @@ bool NUIPlatformBridge::processEvents() {
                 mods.capsLock = mods.capsLock || m_capsLockLatched;
                 event.modifiers = convertModifiers(mods);
             }
-            m_rootComponent->onMouseEvent(event);
+            NUIComponent::dispatchMouseEvent(m_rootComponent, event);
         }
     }
     return m_window ? m_window->pollEvents() : false;

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -259,7 +259,7 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.position = AestraUI::NUIPoint(static_cast<float>(x), static_cast<float>(y));
             event.button = AestraUI::NUIMouseButton::None;
             event.pressed = false;
-            m_recoveryDialog->onMouseEvent(event);
+            AestraUI::NUIComponent::dispatchMouseEvent(m_recoveryDialog.get(), event);
             return;
         }
 
@@ -269,10 +269,10 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             event.position = AestraUI::NUIPoint(static_cast<float>(x), static_cast<float>(y));
             event.button = AestraUI::NUIMouseButton::None;
             event.pressed = false;
-            m_confirmationDialog->onMouseEvent(event);
+            AestraUI::NUIComponent::dispatchMouseEvent(m_confirmationDialog.get(), event);
             return;
         }
-        
+
         // Drag & Drop (convert to float for NUI)
         if (m_content) {
             AestraUI::NUIDragDropManager::getInstance().updateDrag(AestraUI::NUIPoint(static_cast<float>(x), static_cast<float>(y)));
@@ -287,11 +287,12 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             AestraUI::NUIMouseEvent event;
             event.type = pressed ? AestraUI::NUIMouseEventType::Down : AestraUI::NUIMouseEventType::Up;
             event.position = AestraUI::NUIPoint(static_cast<float>(m_lastMouseX), static_cast<float>(m_lastMouseY));
-            event.button = (button == 0) ? AestraUI::NUIMouseButton::Left :
-                          (button == 1) ? AestraUI::NUIMouseButton::Right : AestraUI::NUIMouseButton::Middle;
+            event.button = (button == 0)   ? AestraUI::NUIMouseButton::Left
+                           : (button == 1) ? AestraUI::NUIMouseButton::Right
+                                           : AestraUI::NUIMouseButton::Middle;
             event.pressed = pressed;
             event.released = !pressed;
-            m_recoveryDialog->onMouseEvent(event);
+            AestraUI::NUIComponent::dispatchMouseEvent(m_recoveryDialog.get(), event);
             return; // Block all other mouse handling while recovery dialog is shown
         }
 
@@ -299,14 +300,15 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
             AestraUI::NUIMouseEvent event;
             event.type = pressed ? AestraUI::NUIMouseEventType::Down : AestraUI::NUIMouseEventType::Up;
             event.position = AestraUI::NUIPoint(static_cast<float>(m_lastMouseX), static_cast<float>(m_lastMouseY));
-            event.button = (button == 0) ? AestraUI::NUIMouseButton::Left :
-                          (button == 1) ? AestraUI::NUIMouseButton::Right : AestraUI::NUIMouseButton::Middle;
+            event.button = (button == 0)   ? AestraUI::NUIMouseButton::Left
+                           : (button == 1) ? AestraUI::NUIMouseButton::Right
+                                           : AestraUI::NUIMouseButton::Middle;
             event.pressed = pressed;
             event.released = !pressed;
-            m_confirmationDialog->onMouseEvent(event);
+            AestraUI::NUIComponent::dispatchMouseEvent(m_confirmationDialog.get(), event);
             return;
         }
-        
+
         if (!pressed) { // Release
             if (m_content) {
                 AestraUI::NUIDragDropManager::getInstance().endDrag(AestraUI::NUIPoint((float)m_lastMouseX, (float)m_lastMouseY)); // Fixed arg

--- a/Tests/AestraUI/EditorCloseDeferredTest.cpp
+++ b/Tests/AestraUI/EditorCloseDeferredTest.cpp
@@ -6,8 +6,8 @@
 // children_ mid-iteration (iterator invalidation) and, with a weak_ptr close
 // capture, freed the editor while it was still on the call stack (use-after-
 // free). The fix defers hierarchy mutations while an event dispatch is in flight
-// (NUIComponent::begin/endEventDispatch) and flushes it when the dispatch
-// unwinds. These tests exercise that directly at the NUIComponent level.
+// and flushes them when the dispatch unwinds. These tests exercise both the
+// canonical dispatch entry point used by the platform bridge and nested guards.
 
 #include "NUIComponent.h"
 #include "NUITypes.h"
@@ -25,6 +25,7 @@ namespace {
 class SelfCloser : public NUIComponent {
 public:
     bool sawEvent = false;
+    size_t childCountAfterRemoval = 0;
     bool onMouseEvent(const NUIMouseEvent&) override {
         sawEvent = true;
         if (auto* parent = getParent()) {
@@ -34,8 +35,33 @@ public:
                     break;
                 }
             }
+            childCountAfterRemoval = parent->getChildren().size();
         }
         return false; // don't consume — force the parent loop to continue past a removed child
+    }
+};
+
+// Mirrors TrackManagerUI::refreshTracks(): remove every existing row and add a
+// replacement generation from inside the row's mouse callback.
+class HierarchyRebuilder : public NUIComponent {
+public:
+    std::shared_ptr<NUIComponent> replacementA = std::make_shared<NUIComponent>();
+    std::shared_ptr<NUIComponent> replacementB = std::make_shared<NUIComponent>();
+    size_t childCountDuringCallback = 0;
+
+    bool onMouseEvent(const NUIMouseEvent&) override {
+        auto* parent = getParent();
+        if (!parent) {
+            return false;
+        }
+
+        for (const auto& child : parent->getChildren()) {
+            parent->removeChild(child);
+        }
+        parent->addChild(replacementA);
+        parent->addChild(replacementB);
+        childCountDuringCallback = parent->getChildren().size();
+        return true;
     }
 };
 
@@ -58,25 +84,21 @@ void testSelfRemovalDuringDispatchIsSafe() {
     root->addChild(keep);
 
     std::weak_ptr<NUIComponent> wa = a, wb = b;
-    SelfCloser* ap = a.get();
-    SelfCloser* bp = b.get();
-    a.reset();
-    b.reset(); // only root holds a and b now
 
     NUIMouseEvent ev;
     ev.pressed = true;
     ev.button = NUIMouseButton::Left;
 
-    NUIComponent::beginEventDispatch();
-    root->onMouseEvent(ev); // iterates children; a and b remove themselves mid-loop
-    // Removal is deferred: still present, still alive during dispatch.
-    check(root->getChildren().size() == 3, "children preserved during dispatch");
-    check(!wa.expired() && !wb.expired(), "self-closers alive during dispatch");
-    check(ap->sawEvent && bp->sawEvent, "both self-closers received the event");
-    NUIComponent::endEventDispatch(); // flush deferred removals
+    NUIComponent::dispatchMouseEvent(root.get(), ev); // both children remove themselves mid-traversal
+
+    check(a->childCountAfterRemoval == 3 && b->childCountAfterRemoval == 3,
+          "canonical dispatch defers removal during traversal");
+    check(a->sawEvent && b->sawEvent, "both self-closers received the event");
 
     check(root->getChildren().size() == 1, "self-closers removed after dispatch");
     check(root->getChildren().front() == keep, "the kept child remains");
+    a.reset();
+    b.reset();
     check(wa.expired() && wb.expired(), "removed editors freed (no retain cycle)");
 }
 
@@ -129,6 +151,31 @@ void testAdditionDuringDispatchIsDeferred() {
     check(popup->getParent() == root.get(), "deferred popup parent assigned after dispatch");
 }
 
+void testHierarchyRebuildDuringCanonicalDispatchIsSafe() {
+    auto root = std::make_shared<NUIComponent>();
+    auto oldRow = std::make_shared<NUIComponent>();
+    auto rebuilder = std::make_shared<HierarchyRebuilder>();
+    root->addChild(oldRow);
+    root->addChild(rebuilder); // frontmost: handles the event first
+
+    std::weak_ptr<NUIComponent> oldRowWeak = oldRow;
+    std::weak_ptr<NUIComponent> rebuilderWeak = rebuilder;
+
+    NUIMouseEvent ev;
+    ev.pressed = true;
+    ev.button = NUIMouseButton::Left;
+    check(NUIComponent::dispatchMouseEvent(root.get(), ev), "hierarchy rebuild event handled");
+
+    check(rebuilder->childCountDuringCallback == 2, "old hierarchy preserved until callback returns");
+    check(root->getChildren().size() == 2, "replacement hierarchy installed after dispatch");
+    check(root->getChildren()[0] == rebuilder->replacementA && root->getChildren()[1] == rebuilder->replacementB,
+          "replacement hierarchy keeps insertion order");
+
+    oldRow.reset();
+    rebuilder.reset();
+    check(oldRowWeak.expired() && rebuilderWeak.expired(), "old hierarchy released after guarded rebuild");
+}
+
 } // namespace
 
 int main() {
@@ -136,6 +183,7 @@ int main() {
     testRemoveOutsideDispatchIsImmediate();
     testNestedDispatchDepth();
     testAdditionDuringDispatchIsDeferred();
+    testHierarchyRebuildDuringCanonicalDispatchIsSafe();
 
     if (g_failures > 0) {
         std::cout << g_failures << " check(s) failed\n";

--- a/Tests/AestraUI/EditorCloseDeferredTest.cpp
+++ b/Tests/AestraUI/EditorCloseDeferredTest.cpp
@@ -25,7 +25,7 @@ namespace {
 class SelfCloser : public NUIComponent {
 public:
     bool sawEvent = false;
-    size_t childCountAfterRemoval = 0;
+    size_t m_childCountAfterRemoval = 0;
     bool onMouseEvent(const NUIMouseEvent&) override {
         sawEvent = true;
         if (auto* parent = getParent()) {
@@ -35,7 +35,7 @@ public:
                     break;
                 }
             }
-            childCountAfterRemoval = parent->getChildren().size();
+            m_childCountAfterRemoval = parent->getChildren().size();
         }
         return false; // don't consume — force the parent loop to continue past a removed child
     }
@@ -45,9 +45,9 @@ public:
 // replacement generation from inside the row's mouse callback.
 class HierarchyRebuilder : public NUIComponent {
 public:
-    std::shared_ptr<NUIComponent> replacementA = std::make_shared<NUIComponent>();
-    std::shared_ptr<NUIComponent> replacementB = std::make_shared<NUIComponent>();
-    size_t childCountDuringCallback = 0;
+    std::shared_ptr<NUIComponent> m_replacementA = std::make_shared<NUIComponent>();
+    std::shared_ptr<NUIComponent> m_replacementB = std::make_shared<NUIComponent>();
+    size_t m_childCountDuringCallback = 0;
 
     bool onMouseEvent(const NUIMouseEvent&) override {
         auto* parent = getParent();
@@ -58,10 +58,60 @@ public:
         for (const auto& child : parent->getChildren()) {
             parent->removeChild(child);
         }
-        parent->addChild(replacementA);
-        parent->addChild(replacementB);
-        childCountDuringCallback = parent->getChildren().size();
+        parent->addChild(m_replacementA);
+        parent->addChild(m_replacementB);
+        m_childCountDuringCallback = parent->getChildren().size();
         return true;
+    }
+};
+
+class AddThenRemoveChild : public NUIComponent {
+public:
+    std::shared_ptr<NUIComponent> m_transientChild = std::make_shared<NUIComponent>();
+    size_t m_childCountDuringCallback = 0;
+
+    bool onMouseEvent(const NUIMouseEvent&) override {
+        auto* parent = getParent();
+        if (!parent) {
+            return false;
+        }
+
+        parent->addChild(m_transientChild);
+        parent->removeChild(m_transientChild);
+        m_childCountDuringCallback = parent->getChildren().size();
+        return true;
+    }
+};
+
+class RemoveAllChildrenOnEvent : public NUIComponent {
+public:
+    size_t m_childCountDuringCallback = 0;
+
+    bool onMouseEvent(const NUIMouseEvent&) override {
+        auto* parent = getParent();
+        if (!parent) {
+            return false;
+        }
+
+        parent->removeAllChildren();
+        m_childCountDuringCallback = parent->getChildren().size();
+        return false;
+    }
+};
+
+class BringToFrontOnEvent : public NUIComponent {
+public:
+    bool m_wasFrontmostDuringCallback = false;
+
+    bool onMouseEvent(const NUIMouseEvent&) override {
+        auto* parent = getParent();
+        if (!parent) {
+            return false;
+        }
+
+        bringToFront();
+        m_wasFrontmostDuringCallback = parent->getChildren().back().get() == this;
+        return false;
     }
 };
 
@@ -91,7 +141,7 @@ void testSelfRemovalDuringDispatchIsSafe() {
 
     NUIComponent::dispatchMouseEvent(root.get(), ev); // both children remove themselves mid-traversal
 
-    check(a->childCountAfterRemoval == 3 && b->childCountAfterRemoval == 3,
+    check(a->m_childCountAfterRemoval == 3 && b->m_childCountAfterRemoval == 3,
           "canonical dispatch defers removal during traversal");
     check(a->sawEvent && b->sawEvent, "both self-closers received the event");
 
@@ -166,14 +216,64 @@ void testHierarchyRebuildDuringCanonicalDispatchIsSafe() {
     ev.button = NUIMouseButton::Left;
     check(NUIComponent::dispatchMouseEvent(root.get(), ev), "hierarchy rebuild event handled");
 
-    check(rebuilder->childCountDuringCallback == 2, "old hierarchy preserved until callback returns");
+    check(rebuilder->m_childCountDuringCallback == 2, "old hierarchy preserved until callback returns");
     check(root->getChildren().size() == 2, "replacement hierarchy installed after dispatch");
-    check(root->getChildren()[0] == rebuilder->replacementA && root->getChildren()[1] == rebuilder->replacementB,
+    check(root->getChildren()[0] == rebuilder->m_replacementA && root->getChildren()[1] == rebuilder->m_replacementB,
           "replacement hierarchy keeps insertion order");
 
     oldRow.reset();
     rebuilder.reset();
     check(oldRowWeak.expired() && rebuilderWeak.expired(), "old hierarchy released after guarded rebuild");
+}
+
+void testInterleavedAddThenRemovePreservesOrder() {
+    auto root = std::make_shared<NUIComponent>();
+    auto mutator = std::make_shared<AddThenRemoveChild>();
+    root->addChild(mutator);
+
+    NUIMouseEvent ev;
+    ev.pressed = true;
+    ev.button = NUIMouseButton::Left;
+    check(NUIComponent::dispatchMouseEvent(root.get(), ev), "add-then-remove event handled");
+
+    check(mutator->m_childCountDuringCallback == 1, "add and remove stay deferred during callback");
+    check(root->getChildren().size() == 1 && root->getChildren().front() == mutator,
+          "add-then-remove drains in original order");
+    check(mutator->m_transientChild->getParent() == nullptr, "transient child remains detached after ordered drain");
+}
+
+void testRemoveAllDuringDispatchIsDeferred() {
+    auto root = std::make_shared<NUIComponent>();
+    auto sibling = std::make_shared<NUIComponent>();
+    auto mutator = std::make_shared<RemoveAllChildrenOnEvent>();
+    root->addChild(sibling);
+    root->addChild(mutator);
+
+    NUIMouseEvent ev;
+    ev.pressed = true;
+    ev.button = NUIMouseButton::Left;
+    NUIComponent::dispatchMouseEvent(root.get(), ev);
+
+    check(mutator->m_childCountDuringCallback == 2, "removeAllChildren preserves hierarchy during callback");
+    check(root->getChildren().empty(), "removeAllChildren drains after dispatch");
+    check(sibling->getParent() == nullptr && mutator->getParent() == nullptr,
+          "removeAllChildren clears parent links after dispatch");
+}
+
+void testBringToFrontDuringDispatchIsDeferred() {
+    auto root = std::make_shared<NUIComponent>();
+    auto mutator = std::make_shared<BringToFrontOnEvent>();
+    auto sibling = std::make_shared<NUIComponent>();
+    root->addChild(mutator);
+    root->addChild(sibling);
+
+    NUIMouseEvent ev;
+    ev.pressed = true;
+    ev.button = NUIMouseButton::Left;
+    NUIComponent::dispatchMouseEvent(root.get(), ev);
+
+    check(!mutator->m_wasFrontmostDuringCallback, "bringToFront preserves ordering during callback");
+    check(root->getChildren().back() == mutator, "bringToFront drains after dispatch");
 }
 
 } // namespace
@@ -184,6 +284,9 @@ int main() {
     testNestedDispatchDepth();
     testAdditionDuringDispatchIsDeferred();
     testHierarchyRebuildDuringCanonicalDispatchIsSafe();
+    testInterleavedAddThenRemovePreservesOrder();
+    testRemoveAllDuringDispatchIsDeferred();
+    testBringToFrontDuringDispatchIsDeferred();
 
     if (g_failures > 0) {
         std::cout << g_failures << " check(s) failed\n";


### PR DESCRIPTION
## Summary

- Add one canonical, RAII-guarded mouse-dispatch entry point to `NUIComponent`.
- Route root, cursor-capture, synthetic, and modal-dialog platform events through that guard.
- Defer hierarchy mutations in one FIFO operation queue until the outermost event traversal unwinds.
- Add regressions that rebuild, clear, reorder, and interleave additions/removals from inside mouse callbacks.

## Why

`NUIComponent` already had deferred hierarchy-mutation machinery, but active platform dispatch called `onMouseEvent()` directly without activating its dispatch-depth guard. Deleting a clip could synchronously call `refreshTracks()`, replace child components while the parent was traversing them, and leave stale iterators or component pointers. Heap corruption was then detected later in unrelated cleanup code.

## Authority / invariant

`NUIComponent::dispatchMouseEvent()` is the canonical mouse-dispatch authority. Its nestable RAII guard keeps `children_` stable for the full traversal, while every public hierarchy mutator (`addChild`, `removeChild`, `removeAllChildren`, and `bringToFront`) enters one ordered deferred-operation queue. The outermost unwind drains that queue in original call order, preventing platform routes or future hierarchy APIs from reintroducing mid-traversal mutation.

## Decision citation

Objective:  —
Decision:   FD-01 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind:       corrective
Reversal:   —

## Testing performed

- `cmake --build build-linux --target EditorCloseDeferredTest Aestra -j2`
- `ctest --test-dir build-linux -R '^EditorCloseDeferredTest$' --output-on-failure -j2`
- `ctest --test-dir build-linux -L '^ui$' --output-on-failure -j2` — 28/28 passed
- UI-enabled ASan/UBSan `EditorCloseDeferredTest` — passed
- Manual desktop validation loaded the original `12.aes`, completed 41 delete/undo cycles and 83 total hierarchy rebuilds without a crash, then shut down normally and cleared the crash flag.
- A separate live session deleted each of the four original clips and continued through paste, drag, and further delete/rebuild interactions before a clean exit.

## Producer note

Deleting clips no longer risks crashing Aestra during timeline refreshes.

## Docs updated?

No. This is an internal UI lifecycle correction.

## Risk and rollback

The change affects mouse-event entry points and hierarchy mutation timing during dispatch, while preserving nested child routing and event-handling return values. The guard is nestable and exception-safe, and regression coverage verifies FIFO ordering for all public hierarchy mutators. Roll back the commits on this branch if dispatch behavior regresses.
