### PR TITLE
Improve Arsenal routing and one-shot workflow

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -723,13 +723,12 @@ private:
     void renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
                      bool& srcActiveThisBlock);
 
-
     void renderTrackUnits(uint32_t mixerChannelId, std::vector<double>& buffer, const RenderContext& ctx);
     float processTrackEffects(const TrackRenderState& track, uint32_t trackIdx, std::vector<double>& buffer,
                               uint32_t numFrames);
     void mixAndMeterTrack(const TrackRenderState& track, uint32_t trackIdx, uint32_t slot, TrackRTState& state,
                           std::vector<double>& buffer, const RenderContext& ctx, double volTarget, double panTarget,
-                          float trackSidechainPeak, bool muted, bool audibleEligible);
+                          float trackSidechainPeak, bool muted, bool audibleEligible, bool receivesAudibleRoute);
     void renderTrack(const AudioGraph& graph, size_t orderedIndex, const RenderContext& ctx, bool& srcActiveThisBlock);
     void prepareTrackStateForGraph(const AudioGraph& graph);
     void applyPendingCommands();

--- a/AestraAudio/include/DSP/PanLaw.h
+++ b/AestraAudio/include/DSP/PanLaw.h
@@ -25,6 +25,25 @@ inline void equalPower(double pan, double gain, double& leftGain, double& rightG
     rightGain = std::sin(p * static_cast<double>(kHalfPi)) * gain;
 }
 
+/**
+ * Balance an existing stereo signal without changing its level at centre.
+ *
+ * Unlike equalPower(), which places a mono source in a stereo field and is
+ * therefore -3 dB per leg at centre, a stereo balance control must leave both
+ * legs at unity when centred. This is the appropriate law for mixer sends and
+ * channels that are receiving an already-panned stereo route.
+ */
+inline void stereoBalance(double pan, double gain, double& leftGain, double& rightGain) noexcept {
+    const double clampedPan = std::clamp(pan, -1.0, 1.0);
+    if (clampedPan < 0.0) {
+        leftGain = gain;
+        rightGain = std::cos(-clampedPan * static_cast<double>(kHalfPi)) * gain;
+    } else {
+        leftGain = std::cos(clampedPan * static_cast<double>(kHalfPi)) * gain;
+        rightGain = gain;
+    }
+}
+
 } // namespace PanLaw
 } // namespace Audio
 } // namespace Aestra

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -64,6 +64,10 @@ inline double clampD(double v, double lo, double hi) {
 inline void fastPanGainsD(double pan, double vol, double& gainL, double& gainR) {
     PanLaw::equalPower(pan, vol, gainL, gainR);
 }
+
+inline void fastStereoBalanceGainsD(double pan, double vol, double& gainL, double& gainR) {
+    PanLaw::stereoBalance(pan, vol, gainL, gainR);
+}
 } // namespace
 
 AudioRenderer::AudioRenderer() {}
@@ -360,7 +364,13 @@ void AudioRenderer::processTrackEffects(const RenderTrack& track, AudioGraphStat
         }
 
         double gainL, gainR;
-        fastPanGainsD(panTarget, volTarget, gainL, gainR);
+        const bool receivesAudibleRoute =
+            track.trackIndex < graph.audibleIncoming.size() && !graph.audibleIncoming[track.trackIndex].empty();
+        if (receivesAudibleRoute) {
+            fastStereoBalanceGainsD(panTarget, volTarget, gainL, gainR);
+        } else {
+            fastPanGainsD(panTarget, volTarget, gainL, gainR);
+        }
         state.gainL.setTarget(gainL);
         state.gainR.setTarget(gainR);
     }

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -78,6 +78,15 @@ void AudioRenderer::renderBlock(const Context& ctx, AudioGraphState& state, Audi
     auto* snaps = engineRef.m_meterSnapshotsRaw.load(std::memory_order_relaxed);
     auto* slotMap = engineRef.m_channelSlotMapRaw.load(std::memory_order_relaxed);
 
+    // Clear every track once before routing begins. Clearing inside
+    // renderClipAudio would erase audio already accumulated from an upstream
+    // track when a destination is processed later in topological order.
+    for (const auto& track : state.renderTracks) {
+        if (track.selfBuffer) {
+            std::memset(track.selfBuffer + ctx.bufferOffset * 2, 0, ctx.numFrames * 2 * sizeof(double));
+        }
+    }
+
     // Iterate through topologically sorted render tracks
     for (const auto& track : state.renderTracks) {
         if (track.trackIndex >= state.trackStates.size())
@@ -161,7 +170,6 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
                                     AudioEngine& engineRef) {
     uint32_t numFrames = ctx.numFrames;
     uint32_t bufferOffset = ctx.bufferOffset;
-    std::memset(outputBuffer + bufferOffset * 2, 0, numFrames * 2 * sizeof(double));
     if (state.mute)
         return;
 

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -1,10 +1,10 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "AudioEngine.h"
-#include "Core/ClipRenderKernel.h"
 
 #include "../../AestraCore/include/AestraLog.h"
 #include "../../AestraCore/include/AestraMath.h"
 #include "AuditionEngine.h"
+#include "Core/ClipRenderKernel.h"
 #include "DSP/PanLaw.h"
 #include "EffectChain.h" // [NEW]
 #include "GarbageCollector.h"
@@ -137,6 +137,10 @@ inline double dbToLinearD(double db) {
 
 inline void fastPanGainsD(double pan, double vol, double& gainL, double& gainR) {
     PanLaw::equalPower(pan, vol, gainL, gainR);
+}
+
+inline void fastStereoBalanceGainsD(double pan, double vol, double& gainL, double& gainR) {
+    PanLaw::stereoBalance(pan, vol, gainL, gainR);
 }
 
 inline void addMidiPanic(Aestra::Audio::MidiBuffer& buf) {
@@ -2228,8 +2232,6 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
     }
 }
 
-
-
 void AudioEngine::renderClips(const std::vector<ClipRenderState>& clips, double* destination, const RenderContext& ctx,
                               bool& srcActiveThisBlock) {
     // Verbatim clip-rendering phase moved out of renderTrack(); same ctx
@@ -2351,7 +2353,8 @@ float AudioEngine::processTrackEffects(const TrackRenderState& track, uint32_t t
 
 void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t trackIdx, uint32_t slot, TrackRTState& state,
                                    std::vector<double>& buffer, const RenderContext& ctx, double volTarget,
-                                   double panTarget, float trackSidechainPeak, bool muted, bool audibleEligible) {
+                                   double panTarget, float trackSidechainPeak, bool muted, bool audibleEligible,
+                                   bool receivesAudibleRoute) {
     // Verbatim output stage moved out of renderTrack(): plugin-delay
     // compensation, routing to master/destination + sends (with the peak/RMS
     // accumulation interleaved in the mix loop), and the meter snapshot write.
@@ -2387,7 +2390,11 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
 
     // Route post-fader output to the selected main destination and any audible sends.
     double tL, tR;
-    fastPanGainsD(panTarget, volTarget, tL, tR);
+    if (receivesAudibleRoute) {
+        fastStereoBalanceGainsD(panTarget, volTarget, tL, tR);
+    } else {
+        fastPanGainsD(panTarget, volTarget, tL, tR);
+    }
     state.gainL.setTarget(tL);
     state.gainR.setTarget(tR);
     state.gainL.beginRamp(numFrames);
@@ -2726,8 +2733,8 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
         for (size_t sendIndex = 0; sendIndex < sendCount; ++sendIndex) {
             double targetL = 0.0;
             double targetR = 0.0;
-            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
-                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
+            fastStereoBalanceGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
+                                    static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
             state.sendGainL[sendIndex].current = targetL;
             state.sendGainL[sendIndex].target = targetL;
             state.sendGainR[sendIndex].current = targetR;
@@ -2742,8 +2749,8 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
             }
             double targetL = 0.0;
             double targetR = 0.0;
-            fastPanGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
-                          static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
+            fastStereoBalanceGainsD(clampD(static_cast<double>(track.sends[sendIndex].pan), -1.0, 1.0),
+                                    static_cast<double>(track.sends[sendIndex].gain), targetL, targetR);
             state.sendGainL[sendIndex].setTarget(targetL);
             state.sendGainR[sendIndex].setTarget(targetR);
             state.sendGainL[sendIndex].beginRamp(numFrames);
@@ -2774,8 +2781,10 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
 
     // Output stage (PDC + routing/sends + metering) — verbatim extraction,
     // see mixAndMeterTrack() directly above.
+    const bool receivesAudibleRoute =
+        orderedIndex < graph.audibleIncoming.size() && !graph.audibleIncoming[orderedIndex].empty();
     mixAndMeterTrack(track, trackIdx, slot, state, buffer, ctx, volTarget, panTarget, trackSidechainPeak, muted,
-                     audibleEligible);
+                     audibleEligible, receivesAudibleRoute);
 }
 
 TrackRTState& AudioEngine::ensureTrackState(uint32_t trackIndex) {
@@ -2928,8 +2937,8 @@ void AudioEngine::compileGraph() {
 
             double sendGainL = 0.0;
             double sendGainR = 0.0;
-            fastPanGainsD(clampD(static_cast<double>(send.pan), -1.0, 1.0), static_cast<double>(send.gain), sendGainL,
-                          sendGainR);
+            fastStereoBalanceGainsD(clampD(static_cast<double>(send.pan), -1.0, 1.0), static_cast<double>(send.gain),
+                                    sendGainL, sendGainR);
 
             if (send.targetChannelId == 0xFFFFFFFF) {
                 // Route to Master

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2878,8 +2878,12 @@ void AudioEngine::compileGraph() {
     auto graphRead = m_state.activeGraphRead();
     const auto& graph = graphRead.get(); // Fixed method name
 
-    // Iterate Tracks directly from the graph snapshot
-    for (const auto& tr : graph.tracks) {
+    // Compile in routing order so each destination consumes all upstream audio
+    // before its result is forwarded to the next hop.
+    for (const size_t orderedIndex : graph.topologicalOrder) {
+        if (orderedIndex >= graph.tracks.size())
+            continue;
+        const auto& tr = graph.tracks[orderedIndex];
         const uint32_t idx = tr.trackIndex;
 
         // Safety Check

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -56,14 +56,6 @@ const MidiNote* findNextActiveStepForUnit(const MidiPayload& midi, const MidiNot
     return nullptr;
 }
 
-int resolveSamplerRootMidiNote(const UnitInfo* unit) {
-    if (!unit) {
-        return 60;
-    }
-    auto sampler = std::dynamic_pointer_cast<Plugins::SamplerPlugin>(unit->plugin);
-    return sampler ? sampler->getRootMidiNote() : 60;
-}
-
 int resolvePitchedSamplerMidiNote(const MidiNote& note, int rootMidiNote) {
     if (note.pitchOffset == 0 && note.pitch > 0 && note.pitch != rootMidiNote) {
         return std::clamp(note.pitch, 0, 127);
@@ -231,13 +223,17 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
 
             const UnitInfo* unit = m_unitManager->getUnit(note.unitId);
             const bool isPitchedSampler = unit && unit->type == UnitType::PitchedSampler;
+            const auto sampler = unit ? std::dynamic_pointer_cast<Plugins::SamplerPlugin>(unit->plugin) : nullptr;
+            const bool runsToSampleEnd = unit && unit->type == UnitType::Sampler && sampler &&
+                                         !sampler->isLoopEnabled();
             const int resolvedMidiNote = isPitchedSampler
-                                             ? resolvePitchedSamplerMidiNote(note, resolveSamplerRootMidiNote(unit))
+                                             ? resolvePitchedSamplerMidiNote(note,
+                                                                             sampler ? sampler->getRootMidiNote() : 60)
                                              : std::clamp(note.pitch, 0, 127);
             double noteBeat = inst.startBeat + note.startBeat;
             uint64_t noteFrame = loopBase + m_clock->sampleFrameAtBeat(noteBeat, sampleRate);
             double offBeat = std::min(noteBeat + note.durationBeats, inst.startBeat + inst.sourceEndBeat);
-            bool suppressNoteOff = false;
+            bool suppressNoteOff = runsToSampleEnd;
 
             if (isPitchedSampler) {
                 const double gate = std::clamp(static_cast<double>(note.gate), 0.1, 2.0);

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -947,8 +947,9 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             if (bounds.contains(event.position)) {
                 // Right-drag across a step grid erases every crossed pad.
                 // Outside the grid, right-click keeps the row context menu.
-                if (localContextRect.contains(localPoint) && usesStepSequencerForType(m_type) && !shouldUseNoteRoll() &&
-                    m_patternId.isValid() && m_trackManager) {
+                const bool hasContent = !m_audioClip.empty() || !m_pluginId.empty();
+                if (localContextRect.contains(localPoint) && hasContent && usesStepSequencerForType(m_type) &&
+                    !shouldUseNoteRoll() && m_patternId.isValid() && m_trackManager) {
                     const int stepIndex = resolveGridStep(localPoint, localGridRect);
                     if (stepIndex >= 0 && stepIndex < m_stepCount) {
                         float velocity = kDefaultStepVelocity;

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -763,8 +763,11 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         float relativeX = position.x - gridBounds.x;
         float availWidth = gridBounds.width;
         float stepWidth = gridStepWidth(availWidth);
+        if (stepWidth <= 0.0f || relativeX < 0.0f || relativeX >= availWidth) {
+            return -1;
+        }
         float contentX = relativeX + m_scrollX;
-        return static_cast<int>(contentX / stepWidth);
+        return static_cast<int>(std::floor(contentX / stepWidth));
     };
 
     // === Scroll Handling ===
@@ -824,18 +827,22 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         invalidateVisuals();
     }
 
-    // === Velocity-drag session (Sampler step grid) ===
+    // === Step-grid gesture session ===
     if (m_velEditStep >= 0) {
         if (event.released || event.type == NUIMouseEventType::Up) {
-            // Release: a click that never moved vertically toggles the step
-            // (place was already done on press; remove if it pre-existed).
-            if (!m_velEditMoved && m_velEditWasActive) {
-                removeStepNote(m_velEditStep);
+            // A stationary left click toggles the initial step. Empty steps
+            // were placed on press for immediate feedback; active ones are
+            // removed here once we know the gesture was not a velocity edit.
+            if (m_stepGestureMode == StepGestureMode::Pending && m_velEditWasActive) {
+                m_stepGestureChanged |= removeStepNote(m_velEditStep);
             }
-            if (m_onPatternEdited && m_patternId.isValid()) {
-                m_onPatternEdited(m_patternId); // reschedule audio once, on release
+            if (m_stepGestureChanged && m_onPatternEdited && m_patternId.isValid()) {
+                m_onPatternEdited(m_patternId);
             }
             m_velEditStep = -1;
+            m_stepGestureLastStep = -1;
+            m_stepGestureMode = StepGestureMode::None;
+            m_stepGestureChanged = false;
             invalidateVisuals();
             return true;
         }
@@ -844,17 +851,36 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                                    (event.type == NUIMouseEventType::Drag || event.type == NUIMouseEventType::Move ||
                                     event.button == NUIMouseButton::None);
         if (isPointerMove) {
+            const float dx = event.position.x - m_stepGestureStartX;
             const float dy = m_velEditStartY - event.position.y; // up = louder
-            if (!m_velEditMoved && std::abs(dy) > 3.0f) {
-                m_velEditMoved = true;
-                if (!m_velEditWasActive) {
-                    // We placed on press; a drag now edits that fresh note.
+            if (m_stepGestureMode == StepGestureMode::Pending && std::max(std::abs(dx), std::abs(dy)) > 3.0f) {
+                if (std::abs(dx) >= std::abs(dy)) {
+                    m_stepGestureMode = m_velEditWasActive ? StepGestureMode::Erase : StepGestureMode::Paint;
+                    if (m_stepGestureMode == StepGestureMode::Erase) {
+                        m_stepGestureChanged |= removeStepNote(m_velEditStep);
+                    }
+                } else {
+                    m_stepGestureMode = StepGestureMode::Velocity;
                 }
             }
-            if (m_velEditMoved) {
+
+            if (m_stepGestureMode == StepGestureMode::Paint || m_stepGestureMode == StepGestureMode::Erase) {
+                const int currentStep = resolveGridStep(localPoint, localGridRect);
+                if (currentStep >= 0 && currentStep < m_stepCount && currentStep != m_stepGestureLastStep) {
+                    const int first = std::min(m_stepGestureLastStep, currentStep);
+                    const int last = std::max(m_stepGestureLastStep, currentStep);
+                    for (int step = first; step <= last; ++step) {
+                        m_stepGestureChanged |=
+                            m_stepGestureMode == StepGestureMode::Paint ? placeStepNote(step) : removeStepNote(step);
+                    }
+                    m_stepGestureLastStep = currentStep;
+                    invalidateVisuals();
+                }
+            } else if (m_stepGestureMode == StepGestureMode::Velocity) {
                 // Full row height ≈ full velocity range.
                 const float vel = m_velEditBaseVelocity + dy / 90.0f;
                 setStepNoteVelocity(m_velEditStep, vel);
+                m_stepGestureChanged = true;
                 invalidateVisuals();
             }
             return true;
@@ -884,23 +910,25 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     handleControlClick(event, localControlRect);
                     return true;
                 } else if (localContextRect.contains(localPoint)) {
-                    // Loaded Sampler step grid: arm a velocity-drag session.
-                    // A vertical drag sets the step's velocity; a plain click
-                    // toggles it on release. Empty units / pitched / note-roll
-                    // fall through to the classic toggle.
+                    // Loaded step grids support one continuous gesture:
+                    // vertical movement edits velocity, horizontal movement
+                    // paints or erases, and a stationary click toggles.
                     const bool hasContent = !m_audioClip.empty() || !m_pluginId.empty();
-                    if (m_type == Aestra::Audio::UnitType::Sampler && !shouldUseNoteRoll() && hasContent &&
+                    if (usesStepSequencerForType(m_type) && !shouldUseNoteRoll() && hasContent &&
                         m_patternId.isValid() && m_trackManager) {
                         const int step = resolveGridStep(localPoint, localGridRect);
                         if (step >= 0 && step < m_stepCount) {
                             float vel = kDefaultStepVelocity;
                             const bool active = stepHasNote(step, vel);
                             m_velEditStep = step;
+                            m_stepGestureLastStep = step;
+                            m_stepGestureStartX = event.position.x;
                             m_velEditStartY = event.position.y;
-                            m_velEditMoved = false;
+                            m_stepGestureMode = StepGestureMode::Pending;
                             m_velEditWasActive = active;
+                            m_stepGestureChanged = false;
                             if (!active) {
-                                placeStepNote(step); // show immediately; kept unless click-removed
+                                m_stepGestureChanged = placeStepNote(step);
                                 vel = kDefaultStepVelocity;
                             }
                             m_velEditBaseVelocity = vel;
@@ -917,38 +945,23 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         // === Right-click (row body, outside name label which is handled by UnitNameLabel child) ===
         if (event.button == NUIMouseButton::Right) {
             if (bounds.contains(event.position)) {
-                // On a step pad with a note: right-click deletes it (FL-style).
-                // Anywhere else on the row keeps the context menu.
-                if (localContextRect.contains(localPoint) && !shouldUseNoteRoll() && m_patternId.isValid() &&
-                    m_trackManager) {
+                // Right-drag across a step grid erases every crossed pad.
+                // Outside the grid, right-click keeps the row context menu.
+                if (localContextRect.contains(localPoint) && usesStepSequencerForType(m_type) && !shouldUseNoteRoll() &&
+                    m_patternId.isValid() && m_trackManager) {
                     const int stepIndex = resolveGridStep(localPoint, localGridRect);
                     if (stepIndex >= 0 && stepIndex < m_stepCount) {
-                        bool removed = false;
-                        m_trackManager->getPatternManager().applyPatch(
-                            m_patternId, [this, stepIndex, &removed](Aestra::Audio::PatternSource& p) {
-                                if (!p.isMidi())
-                                    return;
-                                auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
-                                const double targetBeat = stepIndex * 0.25;
-                                auto it =
-                                    std::find_if(midi.notes.begin(), midi.notes.end(),
-                                                 [this, targetBeat](const Aestra::Audio::MidiNote& n) {
-                                                     const double endBeat =
-                                                         std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
-                                                     return n.unitId == m_unitId && targetBeat >= n.startBeat - 0.01 &&
-                                                            targetBeat < endBeat - 0.01;
-                                                 });
-                                if (it != midi.notes.end()) {
-                                    midi.notes.erase(it);
-                                    removed = true;
-                                }
-                            });
-                        if (removed) {
-                            if (m_onPatternEdited)
-                                m_onPatternEdited(m_patternId);
-                            invalidateVisuals();
-                            return true;
-                        }
+                        float velocity = kDefaultStepVelocity;
+                        m_velEditStep = stepIndex;
+                        m_stepGestureLastStep = stepIndex;
+                        m_stepGestureStartX = event.position.x;
+                        m_velEditStartY = event.position.y;
+                        m_velEditBaseVelocity = velocity;
+                        m_velEditWasActive = stepHasNote(stepIndex, velocity);
+                        m_stepGestureMode = StepGestureMode::Erase;
+                        m_stepGestureChanged = removeStepNote(stepIndex);
+                        invalidateVisuals();
+                        return true;
                     }
                 }
                 showRowContextMenu(event.position);
@@ -1025,8 +1038,8 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
 
     // === Double-click to load sample (EMPTY units only) ===
     // With a sample loaded, rapid taps are step programming — treating any two
-    // grid clicks within 400ms as "open the file picker" made fast FL-style
-    // tap-tap placement randomly hijack the second click.
+    // grid clicks within 400ms as "open the file picker" made fast rhythmic
+    // tap placement randomly hijack the second click.
     auto now = std::chrono::steady_clock::now();
     long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
     bool isDoubleClick = (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -219,16 +219,20 @@ private:
     bool m_isDropHighlighted = false;
     NUIPoint m_dragStartPos;
 
-    // Velocity-drag session (Sampler step grid). A press arms a step; a
-    // vertical drag sets its velocity, a click without vertical movement
-    // toggles the step (place empty / remove active) on release.
+    // Step gesture session. A vertical drag edits velocity; a horizontal drag
+    // paints from an empty starting pad or erases from an active one. Right
+    // drag always erases. A click without movement keeps toggle semantics.
+    enum class StepGestureMode { None, Pending, Velocity, Paint, Erase };
     static constexpr float kDefaultStepVelocity = 100.0f / 127.0f;
     static constexpr float kMinStepVelocity = 0.05f;
-    int m_velEditStep = -1;         // -1 = no session
-    float m_velEditStartY = 0.0f;   // pointer Y at press
+    StepGestureMode m_stepGestureMode = StepGestureMode::None;
+    int m_velEditStep = -1; // initial step; -1 = no session
+    int m_stepGestureLastStep = -1;
+    float m_stepGestureStartX = 0.0f;
+    float m_velEditStartY = 0.0f;
     float m_velEditBaseVelocity = kDefaultStepVelocity;
-    bool m_velEditMoved = false;    // crossed the drag threshold → velocity edit
     bool m_velEditWasActive = false; // step already had a note at press
+    bool m_stepGestureChanged = false;
 
     long long m_lastClipClickTimeMs = 0; // For double-click on clip/waveform area
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -972,6 +972,7 @@ void AestraContent::setupArsenalPanels() {
         if (!sampler) {
             return;
         }
+        sampler->setRootMidiNote(pitchTune.rootMidiNote);
         sampler->setCoarseSemitones(static_cast<float>(pitchTune.coarse));
         sampler->setFineTuneCents(pitchTune.fine);
     };
@@ -2493,16 +2494,9 @@ void AestraContent::setArsenalPanelVisible(bool visible) {
     if (visible) {
         // Calculate initial position on first show (if position is at origin)
         if (m_viewState.sequencerRect.x == 0 && m_viewState.sequencerRect.y == 0) {
-            AestraUI::NUIRect safe = computeSafeRect();
-            // Position below title bar with some margin
-            float titleBarHeight = 35.0f;
-            float margin = 10.0f;
-            m_viewState.sequencerRect.x = margin;
-            m_viewState.sequencerRect.y = titleBarHeight + safe.y + margin;
-
-            // Clamp to allowed area
             AestraUI::NUIRect allowed = computeAllowedRectForPanels();
-            m_viewState.sequencerRect = clampRectToAllowed(m_viewState.sequencerRect, allowed);
+            m_viewState.sequencerRect = {
+                allowed.x, allowed.y, allowed.width, std::min(300.0f, allowed.height)};
         }
 
         m_viewState.sequencerRect = clampRectToAllowed(m_viewState.sequencerRect, computeAllowedRectForPanels());
@@ -3822,6 +3816,7 @@ void AestraContent::syncSampleEditorToUnit(UnitID unitId) {
     m_sampleEditorPanel->setLoopPoints(loop);
 
     SampleEditorPanel::PitchTune pitch;
+    pitch.rootMidiNote = sampler->getRootMidiNote();
     pitch.coarse = static_cast<int>(std::round(sampler->getCoarseSemitones()));
     pitch.fine = sampler->getFineTuneCents();
     m_sampleEditorPanel->setPitchTune(pitch);

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -980,8 +980,10 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
 
     // Draw step indicators
     for (int i = 0; i < m_stepCount; ++i) {
-        float stepX = gridStartX + (i * stepWidth) - m_gridScrollX + 2.0f;
-        float indicatorWidth = stepWidth - 4.0f;
+        const float stepOriginX = gridStartX + (i * stepWidth) - m_gridScrollX;
+        const float cellGap = 3.0f;
+        const float stepX = stepOriginX + cellGap * 0.5f;
+        const float indicatorWidth = std::max(1.0f, stepWidth - cellGap);
         if (stepX > gridCard.right()) break;
         if (stepX + stepWidth < gridCard.x) continue;
 
@@ -1022,7 +1024,8 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
                                    theme.getColor("borderSubtle").withAlpha(0.6f));
 
         if (isBarStart) {
-            const NUIRect labelRect(stepX, indicatorY, stepWidth * static_cast<float>(stepsPerBar), indicatorHeight);
+            const NUIRect labelRect(stepOriginX, indicatorY,
+                                    stepWidth * static_cast<float>(stepsPerBar), indicatorHeight);
             renderer.drawTextCentered(std::to_string((i / stepsPerBar) + 1), labelRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
         }
     }

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -27,7 +27,7 @@ constexpr float kSampleEditorMinPanelW = 500.0f;
 constexpr float kSampleEditorMinContentH = 480.0f;
 constexpr float kSampleEditorMinPanelH = kSampleEditorMinContentH + 28.0f;
 constexpr float kSampleEditorModeRowH = 36.0f;
-constexpr float kSampleEditorPitchRowH = 64.0f;
+constexpr float kSampleEditorPitchRowH = 92.0f;
 constexpr float kSampleEditorADSRH = 140.0f;
 constexpr float kSampleEditorButtonRowH = 36.0f;
 constexpr float kSampleEditorWaveformMinH = 120.0f;
@@ -37,6 +37,14 @@ constexpr float kTwoPi = 6.28318530718f;
 float remapClamped(float value, float inMin, float inMax, float outMin, float outMax) {
     const float t = std::clamp((value - inMin) / std::max(0.001f, inMax - inMin), 0.0f, 1.0f);
     return outMin + t * (outMax - outMin);
+}
+
+std::string midiNoteName(int midiNote) {
+    static constexpr const char* kPitchNames[] = {"C", "C#", "D", "D#", "E", "F",
+                                                  "F#", "G", "G#", "A", "A#", "B"};
+    const int clamped = std::clamp(midiNote, 0, 127);
+    return std::string(kPitchNames[clamped % 12]) + std::to_string(clamped / 12 - 2) +
+           " (" + std::to_string(clamped) + ")";
 }
 
 // Perceptual (logarithmic) time mapping for the envelope handles. The linear
@@ -660,9 +668,12 @@ void SampleEditorPanel::buildUI() {
     };
 
     // Pitch/Tune controls
+    m_pitchRootSlider = makeSlider("Root", 0.0, 127.0, 60.0);
     m_pitchCoarseSlider = makeSlider("Coarse", -24.0, 24.0, 0.0);
     m_pitchFineSlider = makeSlider("Fine", -100.0, 100.0, 0.0);
     m_voiceCountSlider = makeSlider("Voices", 1.0, 8.0, 4.0);
+    m_pitchRootSlider->setSnapValue(1.0);
+    m_pitchRootSlider->setSliderThickness(4.0f);
     m_pitchCoarseSlider->setSliderThickness(8.0f);
     m_pitchFineSlider->setSliderThickness(4.0f);
     m_voiceCountSlider->setSliderThickness(4.0f);
@@ -689,7 +700,10 @@ void SampleEditorPanel::buildUI() {
     m_voiceCountLabel = makeLabel("Voices");
     m_voiceCountValueLabel = makeLabel("4");
     m_voiceCountValueLabel->setAlignment(NUILabel::Alignment::Right);
-    m_pitchLabel = makeLabel("KEYBOARD PITCH");
+    m_pitchLabel = makeLabel("KEYBOARD PITCH / ROOT");
+    m_pitchRootLabel = makeLabel("Root");
+    m_pitchRootValueLabel = makeLabel(midiNoteName(60));
+    m_pitchRootValueLabel->setAlignment(NUILabel::Alignment::Right);
     m_pitchCoarseLabel = makeLabel("Coarse");
     m_pitchFineLabel = makeLabel("Fine");
     m_adsrLabel = makeLabel("ENVELOPE");
@@ -704,8 +718,10 @@ void SampleEditorPanel::buildUI() {
     updateMonoPolyControls();
 
     auto pitchChanged = [this]() { onPitchControlChanged(); };
+    m_pitchRootSlider->setOnValueChange([this, pitchChanged](double) { pitchChanged(); });
     m_pitchCoarseSlider->setOnValueChange([this, pitchChanged](double) { pitchChanged(); });
     m_pitchFineSlider->setOnValueChange([this, pitchChanged](double) { pitchChanged(); });
+    m_pitchRootSlider->setOnDragEnd([this]() { requestControlCommit(); });
     m_pitchCoarseSlider->setOnDragEnd([this]() { requestControlCommit(); });
     m_pitchFineSlider->setOnDragEnd([this]() { requestControlCommit(); });
     m_voiceCountSlider->setOnValueChange([this](double) { onVoiceCountControlChanged(); });
@@ -731,6 +747,8 @@ void SampleEditorPanel::buildUI() {
     m_contentContainer->addChild(m_voiceCountLabel);
     m_contentContainer->addChild(m_voiceCountValueLabel);
     m_contentContainer->addChild(m_pitchLabel);
+    m_contentContainer->addChild(m_pitchRootLabel);
+    m_contentContainer->addChild(m_pitchRootValueLabel);
     m_contentContainer->addChild(m_pitchCoarseLabel);
     m_contentContainer->addChild(m_pitchFineLabel);
     m_contentContainer->addChild(m_adsrLabel);
@@ -739,6 +757,7 @@ void SampleEditorPanel::buildUI() {
     m_contentContainer->addChild(m_pingPongModeBtn);
     m_contentContainer->addChild(m_monoModeBtn);
     m_contentContainer->addChild(m_polyModeBtn);
+    m_contentContainer->addChild(m_pitchRootSlider);
     m_contentContainer->addChild(m_pitchCoarseSlider);
     m_contentContainer->addChild(m_pitchFineSlider);
     m_contentContainer->addChild(m_voiceCountSlider);
@@ -843,9 +862,11 @@ void SampleEditorPanel::setLoopPoints(const LoopPoints& lp) {
 void SampleEditorPanel::setPitchTune(const PitchTune& pt) {
     m_pitchTune = pt;
     m_suppressControlCallbacks = true;
+    m_pitchRootSlider->setValue(static_cast<double>(pt.rootMidiNote));
     m_pitchCoarseSlider->setValue(static_cast<double>(pt.coarse));
     m_pitchFineSlider->setValue(pt.fine);
     m_suppressControlCallbacks = false;
+    m_pitchRootValueLabel->setText(midiNoteName(pt.rootMidiNote));
 }
 
 void SampleEditorPanel::setVoiceCount(int voices) {
@@ -932,6 +953,14 @@ void SampleEditorPanel::onResize(int width, int height) {
     m_pitchLabel->setBounds(NUIRect(cb.x + pad, pitchRowY, contentW, labelH));
     y = pitchRowY + labelH;
     const float pitchLabelW = 56.0f;
+    const float pitchValueW = 64.0f;
+    m_pitchRootLabel->setBounds(NUIRect(cb.x + pad, y + 4.0f, pitchLabelW, labelH));
+    m_pitchRootSlider->setBounds(
+        NUIRect(cb.x + pad + pitchLabelW + gutter, y,
+                contentW - pitchLabelW - pitchValueW - gutter * 2.0f, rowH));
+    m_pitchRootValueLabel->setBounds(
+        NUIRect(cb.x + layoutW - pad - pitchValueW, y + 4.0f, pitchValueW, labelH));
+    y += rowH + gutter;
     m_pitchCoarseLabel->setBounds(NUIRect(cb.x + pad, y + 4.0f, pitchLabelW, labelH));
     m_pitchCoarseSlider->setBounds(NUIRect(cb.x + pad + pitchLabelW + gutter, y, contentW - pitchLabelW - gutter, rowH));
     y += rowH + gutter;
@@ -1122,8 +1151,10 @@ void SampleEditorPanel::onPitchControlChanged() {
     if (m_suppressControlCallbacks) {
         return;
     }
+    m_pitchTune.rootMidiNote = static_cast<int>(std::round(m_pitchRootSlider->getValue()));
     m_pitchTune.coarse = static_cast<int>(m_pitchCoarseSlider->getValue());
     m_pitchTune.fine = static_cast<float>(m_pitchFineSlider->getValue());
+    m_pitchRootValueLabel->setText(midiNoteName(m_pitchTune.rootMidiNote));
 
     if (onPitchTuneChanged) onPitchTuneChanged(m_pitchTune);
 }

--- a/Source/Panels/SampleEditorPanel.h
+++ b/Source/Panels/SampleEditorPanel.h
@@ -28,7 +28,7 @@ class ADSRDisplayComponent;
  * - Waveform display with horizontal zoom
  * - ADSR envelope (Attack, Decay, Sustain, Release) with visual curve display
  * - Loop points (start/end) with mode toggle: one-shot, loop, ping-pong
- * - Pitch/tune control (coarse ±24 st + fine ±100 cents)
+ * - Keyboard pitch controls (root note, coarse ±24 st, fine ±100 cents)
  * - Normalize and Reverse buttons
  */
 class SampleEditorPanel : public WindowPanel {
@@ -66,7 +66,8 @@ public:
 
     // Pitch/tune
     struct PitchTune {
-        int coarse{0};   // ±24 semitones
+        int rootMidiNote{60}; // C3 default
+        int coarse{0};        // ±24 semitones
         float fine{0.0f}; // ±100 cents
     };
 
@@ -120,6 +121,7 @@ private:
 
     std::shared_ptr<AestraUI::NUISlider> m_pitchCoarseSlider;
     std::shared_ptr<AestraUI::NUISlider> m_pitchFineSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_pitchRootSlider;
     std::shared_ptr<AestraUI::NUISlider> m_voiceCountSlider;
 
     std::shared_ptr<AestraUI::NUIButton> m_normalizeBtn;
@@ -134,6 +136,8 @@ private:
     std::shared_ptr<AestraUI::NUILabel> m_voiceCountLabel;
     std::shared_ptr<AestraUI::NUILabel> m_voiceCountValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_pitchLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_pitchRootLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_pitchRootValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_pitchCoarseLabel;
     std::shared_ptr<AestraUI::NUILabel> m_pitchFineLabel;
     std::shared_ptr<AestraUI::NUILabel> m_adsrLabel;

--- a/Tests/Headless/LiveMidiInputTest.cpp
+++ b/Tests/Headless/LiveMidiInputTest.cpp
@@ -43,6 +43,34 @@ Stats analyze(const std::vector<float>& interleaved) {
     }
     return stats;
 }
+
+double toneAmplitude(const std::vector<float>& interleaved, double frequency, uint32_t sampleRate,
+                     size_t skipFrames = 1024) {
+    const size_t frameCount = interleaved.size() / 2;
+    if (frameCount <= skipFrames) {
+        return 0.0;
+    }
+    double real = 0.0;
+    double imag = 0.0;
+    const double omega = 2.0 * 3.14159265358979 * frequency / static_cast<double>(sampleRate);
+    for (size_t frame = skipFrames; frame < frameCount; ++frame) {
+        const double sample = static_cast<double>(interleaved[frame * 2]);
+        const double phase = omega * static_cast<double>(frame);
+        real += sample * std::cos(phase);
+        imag -= sample * std::sin(phase);
+    }
+    return 2.0 * std::sqrt(real * real + imag * imag) / static_cast<double>(frameCount - skipFrames);
+}
+
+bool hasMidiEvent(const Aestra::Audio::MidiBuffer& midi, uint8_t status, uint8_t pitch) {
+    for (size_t index = 0; index < midi.getEventCount(); ++index) {
+        const auto& event = midi.getEvent(index);
+        if ((event.data[0] & 0xF0u) == status && event.data[1] == pitch) {
+            return true;
+        }
+    }
+    return false;
+}
 } // namespace
 
 int main() {
@@ -78,7 +106,7 @@ int main() {
                 "loadSampleData failed");
     }
 
-    UnitID unitId = unitManager.createUnit("Live Sampler", UnitGroup::Synth);
+    UnitID unitId = unitManager.createUnit("Live Sampler", UnitType::Sampler);
     unitManager.attachPlugin(unitId, "com.Aestrastudios.sampler", sampler);
     unitManager.setUnitEnabled(unitId, true);
     unitManager.setUnitMixerChannel(unitId, MASTER_MIXER_CHANNEL_ID); // route directly to master in Arsenal mode
@@ -141,13 +169,63 @@ int main() {
     const auto chordStats = analyze(chordAudio);
     require(!chordStats.hasInvalid, "Chord audio contains NaN/Inf");
     require(chordStats.peak > 1.0e-4f, "Chord produced silence");
+    const double rootAmplitude = toneAmplitude(chordAudio, 220.0, sampleRate);
+    const double fifthFrequency = 220.0 * std::pow(2.0, 7.0 / 12.0);
+    const double fifthAmplitude = toneAmplitude(chordAudio, fifthFrequency, sampleRate);
+    const double rootOnlyFifthLeak = toneAmplitude(noteAudio, fifthFrequency, sampleRate);
+    require(rootAmplitude > 1.0e-3, "Chord render is missing its root frequency");
+    require(fifthAmplitude > 1.0e-3, "Chord render is missing its transposed fifth");
+    require(fifthAmplitude > rootOnlyFifthLeak * 4.0,
+            "Transposed fifth is not distinguishable from root-only spectral leakage");
     engine.postLiveMidiEvent(unitId, kNoteOff, kMiddleC, 0);
     engine.postLiveMidiEvent(unitId, kNoteOff, kMiddleC + 7, 0);
     renderBlocks(112, nullptr);
 
-    // ---------------- 5. Events for unknown units are dropped harmlessly.
-    require(engine.postLiveMidiEvent(unitId + 999, kNoteOn, kMiddleC, 100),
-            "unknown-unit event rejected at queue");
+    // ---------------- 5. Pattern one-shots preserve Piano Roll pitch and play
+    // through their natural sample end instead of being gated by the short
+    // visual note length. Looping sampler modes still receive note-offs.
+    PatternID chordPattern = patternManager.createPattern();
+    auto* pattern = patternManager.getPattern(chordPattern);
+    require(pattern != nullptr, "Failed to create chord pattern");
+    pattern->type = PatternSource::Type::Midi;
+    pattern->lengthBeats = 4.0;
+    pattern->payload = MidiPayload{};
+    auto& chordNotes = std::get<MidiPayload>(pattern->payload).notes;
+    MidiNote rootNote;
+    rootNote.pitch = kMiddleC;
+    rootNote.startBeat = 0.0;
+    rootNote.durationBeats = 0.25;
+    rootNote.velocity = 1.0f;
+    rootNote.unitId = unitId;
+    chordNotes.push_back(rootNote);
+    MidiNote fifthNote = rootNote;
+    fifthNote.pitch = kMiddleC + 7;
+    chordNotes.push_back(fifthNote);
+
+    PatternPlaybackEngine chordScheduler(&clock, &patternManager, &unitManager);
+    chordScheduler.schedulePatternInstance(chordPattern, 0.0, 1);
+    chordScheduler.refillWindow(0, sampleRate, sampleRate);
+    MidiBuffer scheduledMidi;
+    PatternPlaybackEngine::UnitMidiRoute scheduledRoute{unitId, &scheduledMidi};
+    chordScheduler.processAudio(0, sampleRate, &scheduledRoute, 1);
+    require(hasMidiEvent(scheduledMidi, kNoteOn, kMiddleC), "Pattern chord lost its root pitch");
+    require(hasMidiEvent(scheduledMidi, kNoteOn, kMiddleC + 7), "Pattern chord lost its fifth pitch");
+    require(!hasMidiEvent(scheduledMidi, kNoteOff, kMiddleC), "One-shot root was gated by Piano Roll note length");
+    require(!hasMidiEvent(scheduledMidi, kNoteOff, kMiddleC + 7), "One-shot fifth was gated by Piano Roll note length");
+
+    sampler->setLoopEnabled(true);
+    PatternPlaybackEngine loopScheduler(&clock, &patternManager, &unitManager);
+    loopScheduler.schedulePatternInstance(chordPattern, 0.0, 2);
+    loopScheduler.refillWindow(0, sampleRate, sampleRate);
+    MidiBuffer loopMidi;
+    PatternPlaybackEngine::UnitMidiRoute loopRoute{unitId, &loopMidi};
+    loopScheduler.processAudio(0, sampleRate, &loopRoute, 1);
+    require(hasMidiEvent(loopMidi, kNoteOff, kMiddleC), "Looping root lost its Piano Roll note-off");
+    require(hasMidiEvent(loopMidi, kNoteOff, kMiddleC + 7), "Looping fifth lost its Piano Roll note-off");
+    sampler->setLoopEnabled(false);
+
+    // ---------------- 6. Events for unknown units are dropped harmlessly.
+    require(engine.postLiveMidiEvent(unitId + 999, kNoteOn, kMiddleC, 100), "unknown-unit event rejected at queue");
     std::vector<float> unknownUnit;
     renderBlocks(16, &unknownUnit);
     const auto unknownStats = analyze(unknownUnit);

--- a/Tests/Headless/RoutingSendPanParityTest.cpp
+++ b/Tests/Headless/RoutingSendPanParityTest.cpp
@@ -14,9 +14,12 @@
 // deterministic generator plugin as the signal source — no clips, no audio
 // hardware, no file I/O on the verification path.
 
+#include "../AestraAudio/GoldenAudio/GoldenAudioHarness.h"
 #include "Core/AudioEngine.h"
 #include "Core/AudioGraph.h"
 #include "Core/AudioGraphBuilder.h"
+#include "Core/AudioGraphState.h"
+#include "Core/AudioRenderer.h"
 #include "Core/MixerChannel.h"
 #include "Models/TrackManager.h"
 #include "Plugin/EffectChain.h"
@@ -282,6 +285,120 @@ std::vector<float> renderMainChain(size_t destinationCount) {
     return captured;
 }
 
+std::shared_ptr<TrackManager> buildClipMainChain(size_t destinationCount, uint32_t totalFrames) {
+    GoldenAudio::SessionConfig config;
+    config.sampleRate = kSampleRate;
+    config.blockSize = kBlockFrames;
+    config.channels = kChannels;
+
+    std::vector<float> source(static_cast<size_t>(totalFrames) * kChannels, 0.0f);
+    for (uint32_t frame = 0; frame < totalFrames; ++frame) {
+        source[static_cast<size_t>(frame) * 2] = sourceL(frame);
+        source[static_cast<size_t>(frame) * 2 + 1] = sourceR(frame);
+    }
+
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
+    GoldenAudio::addAudioTrack(*trackManager, "renderer-route-source", source, totalFrames, config);
+
+    MixerChannel* previous = trackManager->getChannel(0);
+    EXPECT_TRUE(previous != nullptr);
+    for (size_t index = 0; previous && index < destinationCount; ++index) {
+        MixerChannel* destination = trackManager->addChannel("renderer-route-destination");
+        EXPECT_TRUE(destination != nullptr);
+        if (!destination) {
+            break;
+        }
+        previous->setMainOutputId(destination->getChannelId());
+        previous = destination;
+    }
+    return trackManager;
+}
+
+std::vector<float> renderClipMainChainLive(size_t destinationCount, uint32_t totalFrames) {
+    GoldenAudio::SessionConfig config;
+    config.sampleRate = kSampleRate;
+    config.blockSize = kBlockFrames;
+    config.channels = kChannels;
+
+    auto trackManager = buildClipMainChain(destinationCount, totalFrames);
+    AudioEngine engine;
+    GoldenAudio::prepareEngine(engine, trackManager, config);
+    engine.setTransportPlaying(true);
+    return GoldenAudio::renderBlocks(engine, totalFrames, config);
+}
+
+std::vector<float> renderClipMainChainOffline(size_t destinationCount, uint32_t totalFrames) {
+    GoldenAudio::SessionConfig config;
+    config.sampleRate = kSampleRate;
+    config.blockSize = kBlockFrames;
+    config.channels = kChannels;
+
+    auto trackManager = buildClipMainChain(destinationCount, totalFrames);
+    AudioEngine engine;
+    GoldenAudio::prepareEngine(engine, trackManager, config);
+    AudioGraph graph = AudioGraphBuilder::buildFromTrackManager(*trackManager);
+
+    std::vector<std::vector<double>> trackBuffers(
+        graph.tracks.size(), std::vector<double>(static_cast<size_t>(kBlockFrames) * kChannels, 0.0));
+    std::vector<double> masterBuffer(static_cast<size_t>(kBlockFrames) * kChannels, 0.0);
+    AudioGraphState state;
+    state.trackStates.resize(graph.tracks.size());
+    state.renderTracks.reserve(graph.tracks.size());
+
+    for (const size_t orderedIndex : graph.topologicalOrder) {
+        EXPECT_TRUE(orderedIndex < graph.tracks.size());
+        if (orderedIndex >= graph.tracks.size()) {
+            continue;
+        }
+        const auto& graphTrack = graph.tracks[orderedIndex];
+        RenderTrack renderTrack;
+        renderTrack.trackIndex = graphTrack.trackIndex;
+        renderTrack.selfBuffer = trackBuffers[graphTrack.trackIndex].data();
+
+        RuntimeConnection output;
+        output.stride = 2;
+        if (graphTrack.mainOutputId == kMasterId) {
+            output.destinationBufferL = masterBuffer.data();
+            output.destinationBufferR = masterBuffer.data() + 1;
+        } else {
+            const size_t destinationIndex = graphTrack.mainOutputId < graph.trackIndexById.size()
+                                                ? graph.trackIndexById[graphTrack.mainOutputId]
+                                                : AudioGraph::kInvalidTrackIndex;
+            EXPECT_TRUE(destinationIndex != AudioGraph::kInvalidTrackIndex);
+            if (destinationIndex == AudioGraph::kInvalidTrackIndex) {
+                continue;
+            }
+            output.destinationBufferL = trackBuffers[destinationIndex].data();
+            output.destinationBufferR = trackBuffers[destinationIndex].data() + 1;
+        }
+        renderTrack.activeConnections.push_back(output);
+        state.renderTracks.push_back(std::move(renderTrack));
+    }
+
+    AudioRenderer renderer;
+    std::vector<float> captured;
+    captured.reserve(static_cast<size_t>(totalFrames) * kChannels);
+    for (uint64_t rendered = 0; rendered < totalFrames; rendered += kBlockFrames) {
+        const uint32_t frames = static_cast<uint32_t>(std::min<uint64_t>(kBlockFrames, totalFrames - rendered));
+        std::fill(masterBuffer.begin(), masterBuffer.end(), 0.0);
+        AudioRenderer::Context context;
+        context.masterBuffer = masterBuffer.data();
+        context.numFrames = frames;
+        context.bufferOffset = 0;
+        context.globalPos = rendered;
+        context.sampleRate = kSampleRate;
+        context.graph = &graph;
+        context.isOffline = true;
+        renderer.renderBlock(context, state, engine);
+        for (uint32_t frame = 0; frame < frames; ++frame) {
+            captured.push_back(static_cast<float>(masterBuffer[static_cast<size_t>(frame) * 2]));
+            captured.push_back(static_cast<float>(masterBuffer[static_cast<size_t>(frame) * 2 + 1]));
+        }
+    }
+    return captured;
+}
+
 double maxAbsDiff(const std::vector<float>& a, const std::vector<float>& b) {
     if (a.size() != b.size() || a.empty()) {
         return 1e9;
@@ -370,6 +487,30 @@ void testCentredMainRoutingPreservesLevelAcrossHops() {
     }
 }
 
+void testOfflineRendererMatchesLiveCentredRouting() {
+    std::printf("[RoutingSendPanParityTest] offline renderer matches live centred routing...\n");
+    constexpr uint32_t totalBlocks = kWarmupBlocks + kMeasureBlocks;
+    constexpr uint32_t totalFrames = totalBlocks * kBlockFrames;
+    const size_t firstMeasuredSample = static_cast<size_t>(kWarmupBlocks) * kBlockFrames * kChannels;
+
+    for (const size_t destinations : {size_t{0}, size_t{2}}) {
+        const std::vector<float> live = renderClipMainChainLive(destinations, totalFrames);
+        const std::vector<float> offline = renderClipMainChainOffline(destinations, totalFrames);
+        EXPECT_TRUE(live.size() == offline.size());
+        if (live.size() != offline.size() || live.size() <= firstMeasuredSample) {
+            continue;
+        }
+        const std::vector<float> liveMeasured(live.begin() + static_cast<ptrdiff_t>(firstMeasuredSample), live.end());
+        const std::vector<float> offlineMeasured(offline.begin() + static_cast<ptrdiff_t>(firstMeasuredSample),
+                                                 offline.end());
+        const double diff = maxAbsDiff(liveMeasured, offlineMeasured);
+        if (diff > 1e-6) {
+            reportFailure("offline renderer/live centred route parity",
+                          std::to_string(destinations) + " destination(s), max abs diff " + std::to_string(diff));
+        }
+    }
+}
+
 // #262 acceptance: the engine's batched send loop must match a naive
 // per-sample reference computed directly from the deterministic source.
 void testBatchedSendMatchesPerSampleReference() {
@@ -412,6 +553,7 @@ int main() {
     testPreFaderSendMatchesBalanceReference();
     testCentredPostFaderSendPreservesLevel();
     testCentredMainRoutingPreservesLevelAcrossHops();
+    testOfflineRendererMatchesLiveCentredRouting();
     testBatchedSendMatchesPerSampleReference();
 
     if (g_failures == 0) {

--- a/Tests/Headless/RoutingSendPanParityTest.cpp
+++ b/Tests/Headless/RoutingSendPanParityTest.cpp
@@ -1,12 +1,9 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 // RoutingSendPanParityTest — acceptance tests for routing BUG-3 (#261) and BUG-5 (#262).
 //
-// #261: Send pan must use the same pan law as main mixer pan.
-//   * A pre-fader send at pan P, unity gain, must produce sample-identical
-//     master output to routing the track's main output at pan P.
-//   * A post-fader send stacks the source's main pan stage on top; with the
-//     source panned center the send output must equal the direct path scaled
-//     by exactly the center gain of the shared law (cos(π/4)).
+// #261: Send pan must balance an existing stereo signal without attenuating
+// it at centre. A centred unity post-fader send must therefore match the
+// source's direct centred output exactly.
 //
 // #262: Batched send processing must match a naive per-sample reference.
 //   * The test recomputes the expected send output sample-by-sample from the
@@ -53,11 +50,11 @@ void reportFailure(const char* what, const std::string& detail) {
     ++g_failures;
 }
 
-#define EXPECT_TRUE(expr)                                                                                              \
-    do {                                                                                                               \
-        if (!(expr)) {                                                                                                 \
-            reportFailure(#expr, std::string(__FILE__) + ":" + std::to_string(__LINE__));                              \
-        }                                                                                                              \
+#define EXPECT_TRUE(expr)                                                                 \
+    do {                                                                                  \
+        if (!(expr)) {                                                                    \
+            reportFailure(#expr, std::string(__FILE__) + ":" + std::to_string(__LINE__)); \
+        }                                                                                 \
     } while (0)
 
 // Deterministic stateless noise: pure function of the global sample index so
@@ -81,13 +78,18 @@ float sourceR(uint64_t n) {
     return static_cast<float>(noiseAt(n)) * -0.5f;
 }
 
-// Replicates the engine's shared pan law (fastPanGainsD in AudioEngine.cpp)
-// including its float intermediate, so reference gains match to double
-// precision. Any future divergence between main/send law breaks the tests.
-void referencePanGains(double pan, double vol, double& gainL, double& gainR) {
-    float p = (static_cast<float>(pan) + 1.0f) * 0.5f;
-    gainL = static_cast<double>(std::cos(p * 1.57079632679f)) * vol;
-    gainR = static_cast<double>(std::sin(p * 1.57079632679f)) * vol;
+// Replicates the stereo balance law used by sends and routed destination
+// channels. Centre is unity on both legs; moving away from centre attenuates
+// only the opposite leg.
+void referenceBalanceGains(double pan, double gain, double& gainL, double& gainR) {
+    const double clampedPan = std::clamp(pan, -1.0, 1.0);
+    if (clampedPan < 0.0) {
+        gainL = gain;
+        gainR = std::cos(-clampedPan * 1.57079632679) * gain;
+    } else {
+        gainL = std::cos(clampedPan * 1.57079632679) * gain;
+        gainR = gain;
+    }
 }
 
 // Minimal signal-generator plugin: ignores input, writes the deterministic
@@ -211,8 +213,61 @@ std::vector<float> renderConfig(float mainPan, const SendSpec& send) {
     std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
     for (uint32_t b = 0; b < kWarmupBlocks; ++b) {
         std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, kBlockFrames, static_cast<double>(b * kBlockFrames) / kSampleRate);
+    }
+
+    std::vector<float> captured;
+    captured.reserve(static_cast<size_t>(kMeasureBlocks) * kBlockFrames * kChannels);
+    for (uint32_t b = 0; b < kMeasureBlocks; ++b) {
+        std::fill(block.begin(), block.end(), 0.0f);
+        const uint32_t absBlock = kWarmupBlocks + b;
         engine.processBlock(block.data(), nullptr, kBlockFrames,
-                            static_cast<double>(b * kBlockFrames) / kSampleRate);
+                            static_cast<double>(absBlock * kBlockFrames) / kSampleRate);
+        captured.insert(captured.end(), block.begin(), block.end());
+    }
+    return captured;
+}
+
+// Render a source through N centred mixer destinations before Master. The
+// first channel still uses the source pan law; every destination is balancing
+// an already-stereo route and must not add another centre attenuation.
+std::vector<float> renderMainChain(size_t destinationCount) {
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
+
+    MixerChannel* source = trackManager->addChannel("source");
+    EXPECT_TRUE(source != nullptr);
+    if (!source) {
+        return {};
+    }
+    EXPECT_TRUE(source->getEffectChain().insertPlugin(0, std::make_shared<GeneratorPlugin>()));
+
+    MixerChannel* previous = source;
+    for (size_t index = 0; index < destinationCount; ++index) {
+        MixerChannel* destination = trackManager->addChannel("destination");
+        EXPECT_TRUE(destination != nullptr);
+        if (!destination) {
+            return {};
+        }
+        previous->setMainOutputId(destination->getChannelId());
+        previous = destination;
+    }
+
+    AudioEngine engine;
+    engine.setTrackManager(trackManager);
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockFrames, kChannels);
+    trackManager->buildAndShareSlotMap();
+    if (auto slotMap = trackManager->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*trackManager));
+    engine.setSafetyLimiterEnabled(false);
+
+    std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    for (uint32_t b = 0; b < kWarmupBlocks; ++b) {
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, kBlockFrames, static_cast<double>(b * kBlockFrames) / kSampleRate);
     }
 
     std::vector<float> captured;
@@ -246,70 +301,71 @@ double peakAbs(const std::vector<float>& v) {
     return peak;
 }
 
-// #261 acceptance: a pre-fader unity send at pan P must be sample-identical to
-// the main path at pan P — same taps, same law, same smoothers.
-void testPreFaderSendMatchesMainPan() {
-    std::printf("[RoutingSendPanParityTest] pre-fader send pan matches main pan across sweep...\n");
-    // Extremes, center, one symmetric pair, one asymmetric point. Each pan
-    // value costs two full engine fixtures (~1.6s), so keep the sweep lean.
+// A pre-fader send reads the raw stereo source, so compare it directly with
+// the balance-law reference rather than the source channel's pan stage.
+void testPreFaderSendMatchesBalanceReference() {
+    std::printf("[RoutingSendPanParityTest] pre-fader send matches stereo balance reference...\n");
     const float sweep[] = {-1.0f, -0.5f, 0.0f, 0.25f, 1.0f};
     for (float pan : sweep) {
-        SendSpec none;
-        std::vector<float> mainOut = renderConfig(pan, none);
-
         SendSpec preSend;
         preSend.enabled = true;
         preSend.gain = 1.0f;
         preSend.pan = pan;
         preSend.postFader = false;
-        // Deliberately different main pan on the send config: the pre-fader
-        // send must not be affected by the source's own pan stage.
         std::vector<float> sendOut = renderConfig(0.7f, preSend);
 
-        EXPECT_TRUE(!mainOut.empty() && !sendOut.empty());
-        EXPECT_TRUE(peakAbs(mainOut) > 1e-4); // Signal actually flowed
-        const double diff = maxAbsDiff(mainOut, sendOut);
-        if (diff > 1e-9) {
-            reportFailure("pre-fader send == main pan",
-                          "pan " + std::to_string(pan) + " max abs diff " + std::to_string(diff));
+        EXPECT_TRUE(!sendOut.empty());
+        EXPECT_TRUE(peakAbs(sendOut) > 1e-4);
+        double gainL = 0.0;
+        double gainR = 0.0;
+        referenceBalanceGains(pan, 1.0, gainL, gainR);
+        double maxDiff = 0.0;
+        const uint64_t firstSample = static_cast<uint64_t>(kWarmupBlocks) * kBlockFrames;
+        for (uint32_t i = 0; i < kMeasureBlocks * kBlockFrames; ++i) {
+            const uint64_t n = firstSample + i;
+            maxDiff = std::max(maxDiff, std::abs(static_cast<double>(sendOut[static_cast<size_t>(i) * 2]) -
+                                                 static_cast<double>(sourceL(n)) * gainL));
+            maxDiff = std::max(maxDiff, std::abs(static_cast<double>(sendOut[static_cast<size_t>(i) * 2 + 1]) -
+                                                 static_cast<double>(sourceR(n)) * gainR));
+        }
+        if (maxDiff > 1e-6) {
+            reportFailure("pre-fader send balance reference",
+                          "pan " + std::to_string(pan) + " max abs diff " + std::to_string(maxDiff));
         }
     }
 }
 
-// #261 acceptance (post-fader): with the source panned center, a post-fader
-// unity send at pan P equals the direct path at pan P scaled by exactly the
-// shared law's center gain. Any law mismatch changes that scale factor.
-void testPostFaderSendStacksSameLaw() {
-    std::printf("[RoutingSendPanParityTest] post-fader send stacks the same law on top of center main pan...\n");
-    double centerL = 0.0;
-    double centerR = 0.0;
-    referencePanGains(0.0, 1.0, centerL, centerR);
+void testCentredPostFaderSendPreservesLevel() {
+    std::printf("[RoutingSendPanParityTest] centred post-fader send preserves source level...\n");
+    SendSpec none;
+    const std::vector<float> direct = renderConfig(0.0f, none);
 
-    const float sweep[] = {-0.5f, 0.25f};
-    for (float pan : sweep) {
-        SendSpec none;
-        std::vector<float> mainOut = renderConfig(pan, none);
+    SendSpec postSend;
+    postSend.enabled = true;
+    postSend.gain = 1.0f;
+    postSend.pan = 0.0f;
+    postSend.postFader = true;
+    const std::vector<float> routed = renderConfig(0.0f, postSend);
 
-        SendSpec postSend;
-        postSend.enabled = true;
-        postSend.gain = 1.0f;
-        postSend.pan = pan;
-        postSend.postFader = true;
-        std::vector<float> sendOut = renderConfig(0.0f, postSend);
+    EXPECT_TRUE(!direct.empty() && !routed.empty());
+    EXPECT_TRUE(peakAbs(direct) > 1e-4);
+    const double diff = maxAbsDiff(direct, routed);
+    if (diff > 1e-9) {
+        reportFailure("centred post-fader send preserves level", "max abs diff " + std::to_string(diff));
+    }
+}
 
-        EXPECT_TRUE(!mainOut.empty() && !sendOut.empty());
-        EXPECT_TRUE(peakAbs(mainOut) > 1e-4);
-
-        double maxDiff = 0.0;
-        for (size_t i = 0; i + 1 < mainOut.size(); i += 2) {
-            const double expectL = static_cast<double>(mainOut[i]) * centerL;
-            const double expectR = static_cast<double>(mainOut[i + 1]) * centerR;
-            maxDiff = std::max(maxDiff, std::abs(static_cast<double>(sendOut[i]) - expectL));
-            maxDiff = std::max(maxDiff, std::abs(static_cast<double>(sendOut[i + 1]) - expectR));
-        }
-        if (maxDiff > 1e-6) {
-            reportFailure("post-fader send == main pan * center gain",
-                          "pan " + std::to_string(pan) + " max abs diff " + std::to_string(maxDiff));
+void testCentredMainRoutingPreservesLevelAcrossHops() {
+    std::printf("[RoutingSendPanParityTest] centred main routing preserves level across hops...\n");
+    const std::vector<float> direct = renderMainChain(0);
+    EXPECT_TRUE(!direct.empty());
+    EXPECT_TRUE(peakAbs(direct) > 1e-4);
+    for (size_t destinations = 1; destinations <= 3; ++destinations) {
+        const std::vector<float> routed = renderMainChain(destinations);
+        const double diff = maxAbsDiff(direct, routed);
+        if (diff > 1e-9) {
+            reportFailure("centred main route hop parity",
+                          std::to_string(destinations) + " destination(s), max abs diff " + std::to_string(diff));
         }
     }
 }
@@ -332,7 +388,7 @@ void testBatchedSendMatchesPerSampleReference() {
 
     double gainL = 0.0;
     double gainR = 0.0;
-    referencePanGains(static_cast<double>(sendPan), static_cast<double>(sendGain), gainL, gainR);
+    referenceBalanceGains(static_cast<double>(sendPan), static_cast<double>(sendGain), gainL, gainR);
 
     double maxDiff = 0.0;
     const uint64_t firstSample = static_cast<uint64_t>(kWarmupBlocks) * kBlockFrames;
@@ -353,8 +409,9 @@ void testBatchedSendMatchesPerSampleReference() {
 int main() {
     std::printf("=== RoutingSendPanParityTest (routing BUG-3 #261, BUG-5 #262) ===\n");
 
-    testPreFaderSendMatchesMainPan();
-    testPostFaderSendStacksSameLaw();
+    testPreFaderSendMatchesBalanceReference();
+    testCentredPostFaderSendPreservesLevel();
+    testCentredMainRoutingPreservesLevelAcrossHops();
     testBatchedSendMatchesPerSampleReference();
 
     if (g_failures == 0) {


### PR DESCRIPTION
## Summary

- preserve centered signal level across mixer routing destinations and sends
- give Arsenal a compact first-open size, aligned ruler cells, and drag paint/erase gestures
- let non-looping Sampler one-shots play to their natural tail from Piano Roll patterns
- expose the Sampler root MIDI note in the sample editor

## Why

Centered audio was being attenuated again at every mixer hop because routed stereo signals reused the mono equal-power pan law. Arsenal also lacked continuous step gestures and opened larger than the intended compact working size. Piano Roll note lengths were cutting off slower or transposed one-shots before their samples finished, and the sample editor did not expose the existing root-note state.

## Testing performed

- `cmake --build build-linux -j2`
- `cmake --build build-linux --target Aestra LiveMidiInputTest RoutingSendPanParityTest PianoRollInteractionTest -j2`
- `ctest --test-dir build-linux -R '^(RoutingSendPanParityTest|LiveMidiInputTest|SamplerOneShotEnvelopeTest|HardwareMidiInputTest|PianoRollInteractionTest|PianoRollEdgeCaseStressTest|NoteDiffTest|UnitMixerRoutingTest|ArsenalProcessingContextRoutingTest|ArsenalExportLiveParityTest|RealtimeExportParityTest|ExportBounceParityTest|RoutingGraphTest|HeadlessOfflineRenderer|OfflineRenderRegressionTest)$' --output-on-failure -j2` — 15/15 passed
- manually launched the desktop app and verified Arsenal first-open sizing, continuous paint, continuous erase, refresh behavior, and clean shutdown

## Producer note

Routing through more mixer channels no longer lowers the sound, and Arsenal one-shots now keep their intended pitch and full tail.

## Docs updated?

None. No public documentation claim changed.

## Risk and rollback notes

The audio behavior change is limited to already-routed stereo balance and send paths; source-track pan semantics remain unchanged. One-shot note-off suppression is limited to ordinary non-looping Sampler patterns, while looped Sampler and pitched-sampler gate behavior remains intact. Reverting `a351b4c3` restores the prior behavior.

## Decision citation

Objective:
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: corrective
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserved centered signal levels for routed tracks and sends with stereo-balance gain handling.
- Improved Arsenal with compact sizing, aligned step indicators, and paint/erase drag gestures.
- Allowed non-looping Sampler one-shots to play through their natural tails from Piano Roll patterns.
- Added Sampler root MIDI note controls and pitch synchronization in the sample editor.
- Expanded routing and one-shot playback tests, with builds, targeted tests, and manual UI checks passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->