### PR TITLE
Persist Piano Roll harmony context

### DIFF
--- a/AestraAudio/include/Music/ScaleContext.h
+++ b/AestraAudio/include/Music/ScaleContext.h
@@ -58,6 +58,18 @@ inline int clampRootKey(int key) {
 }
 
 /**
+ * @brief Store a normalized pattern override, or clear it when all values are defaults.
+ */
+inline void assignScaleContextOverride(std::optional<ScaleContext>& target, ScaleContext context) {
+    context.rootKey = clampRootKey(context.rootKey);
+    if (context.hasNonDefaultValues()) {
+        target = context;
+    } else {
+        target.reset();
+    }
+}
+
+/**
  * @brief Convert ScaleKind to string for serialization
  */
 inline std::string scaleKindToString(ScaleKind kind) {

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -178,6 +178,17 @@ public:
     void setOnUnitChoiceSelected(std::function<void(int unitValue)> cb) {
         onUnitChoiceSelected_ = std::move(cb);
     }
+    /** @brief Set the harmony context without treating the update as a user edit. */
+    void setHarmonyContext(int rootKey, ScaleType scaleType, bool snapToScale);
+    /** @brief Apply a user-originated harmony edit and notify the owning panel. */
+    void applyHarmonyContextEdit(int rootKey, ScaleType scaleType, bool snapToScale);
+    int getRootKey() const { return m_rootKey; }
+    ScaleType getScaleType() const { return m_scaleType; }
+    bool getSnapToScale() const { return m_snapToScale; }
+    /** @brief Set callback fired when the user edits root, scale, or scale snapping. */
+    void setOnHarmonyContextChanged(std::function<void(int, ScaleType, bool)> cb) {
+        onHarmonyContextChanged_ = std::move(cb);
+    }
     /** @brief Set callback fired by the menu's "Keyboard Shortcuts" item. */
     void setOnShowShortcutHelp(std::function<void()> cb) { onShowShortcutHelp_ = std::move(cb); }
     /** @brief Get the currently open context menu, if any. */
@@ -219,11 +230,15 @@ private:
     std::function<void(int barsDelta)> onAdjustPatternLength_;
     std::function<void(int patternValue)> onPatternChoiceSelected_;
     std::function<void(int unitValue)> onUnitChoiceSelected_;
+    std::function<void(int rootKey, ScaleType scaleType, bool snapToScale)> onHarmonyContextChanged_;
     std::function<void()> onShowShortcutHelp_;
     bool m_updatingPatternDropdown = false;
     bool m_updatingUnitDropdown = false;
     bool m_updatingSnapDropdown = false;
     SnapGrid m_currentSnap = SnapGrid::Beat;
+    int m_rootKey = 0;
+    ScaleType m_scaleType = ScaleType::Chromatic;
+    bool m_snapToScale = false;
 
     void closeActiveContextMenu();
     
@@ -653,6 +668,7 @@ public:
     void setOnAdjustPatternLength(std::function<void(int barsDelta)> cb);
     void setOnPatternChoiceSelected(std::function<void(int patternValue)> cb);
     void setOnUnitChoiceSelected(std::function<void(int unitValue)> cb);
+    void setOnHarmonyContextChanged(std::function<void(int, ScaleType, bool)> cb);
     void setOnPlayheadScrubbed(std::function<void(double beat, bool active)> cb);
 
     void setPixelsPerBeat(float ppb);

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -678,6 +678,10 @@ public:
     void setTool(GlobalTool tool);
     void setScale(int root, ScaleType type);
     void setSnapToScale(bool enabled);
+    void applyHarmonyContextEdit(int root, ScaleType type, bool snapToScale);
+    int getRootKey() const;
+    ScaleType getScaleType() const;
+    bool getSnapToScale() const;
 
     /** @brief Set platform bridge for cursor style changes (forwarded to note layer). */
     void setPlatformBridge(NUIPlatformBridge* bridge);

--- a/AestraUI/Widgets/PianoRollToolbar.cpp
+++ b/AestraUI/Widgets/PianoRollToolbar.cpp
@@ -69,9 +69,8 @@ void PianoRollToolbar::setupUI() {
         auto rootMenu = std::make_shared<NUIContextMenu>();
         auto roots = MusicTheory::getRootNames();
         for (size_t i = 0; i < roots.size(); ++i) {
-            rootMenu->addItem(roots[i], [this, i]() {
-                if (auto g = grid_.lock()) g->setRootKey(static_cast<int>(i));
-                if (auto n = notes_.lock()) n->setRootKey(static_cast<int>(i));
+            rootMenu->addRadioItem(roots[i], "piano-roll-root", m_rootKey == static_cast<int>(i), [this, i]() {
+                applyHarmonyContextEdit(static_cast<int>(i), m_scaleType, m_snapToScale);
             });
         }
         menu->addSubmenu("Root Key", rootMenu);
@@ -80,22 +79,16 @@ void PianoRollToolbar::setupUI() {
         auto scaleMenu = std::make_shared<NUIContextMenu>();
         auto scales = MusicTheory::getScales();
         for (size_t i = 0; i < scales.size(); ++i) {
-            scaleMenu->addItem(scales[i].name, [this, i]() {
-                if (auto g = grid_.lock()) g->setScaleType(static_cast<ScaleType>(i));
-                if (auto n = notes_.lock()) n->setScaleType(static_cast<ScaleType>(i));
+            scaleMenu->addRadioItem(scales[i].name, "piano-roll-scale",
+                                    m_scaleType == static_cast<ScaleType>(i), [this, i]() {
+                applyHarmonyContextEdit(m_rootKey, static_cast<ScaleType>(i), m_snapToScale);
             });
         }
         menu->addSubmenu("Scale Type", scaleMenu);
 
         // --- SNAP TO SCALE TOGGLE ---
-        bool snapToScaleActive = false;
-        if (auto n = notes_.lock()) {
-            snapToScaleActive = n->getSnapToScale();
-        }
-        menu->addCheckbox("Snap to Scale", snapToScaleActive, [this](bool) {
-            if (auto n = notes_.lock()) {
-                n->setSnapToScale(!n->getSnapToScale());
-            }
+        menu->addCheckbox("Snap to Scale", m_snapToScale, [this](bool enabled) {
+            applyHarmonyContextEdit(m_rootKey, m_scaleType, enabled);
         });
 
         // --- CHORD MODE TOGGLE (pencil stamps a diatonic triad) ---
@@ -276,6 +269,31 @@ void PianoRollToolbar::setUnitChoices(const std::vector<PatternChoice>& choices,
     m_unitDropdown->setSelectedByValue(selectedValue);
     m_updatingUnitDropdown = false;
     repaint();
+}
+
+void PianoRollToolbar::setHarmonyContext(int rootKey, ScaleType scaleType, bool snapToScale) {
+    const int scaleIndex = std::clamp(static_cast<int>(scaleType), 0, static_cast<int>(ScaleType::Count) - 1);
+    m_rootKey = std::clamp(rootKey, 0, 11);
+    m_scaleType = static_cast<ScaleType>(scaleIndex);
+    m_snapToScale = snapToScale;
+
+    if (auto grid = grid_.lock()) {
+        grid->setRootKey(m_rootKey);
+        grid->setScaleType(m_scaleType);
+    }
+    if (auto notes = notes_.lock()) {
+        notes->setRootKey(m_rootKey);
+        notes->setScaleType(m_scaleType);
+        notes->setSnapToScale(m_snapToScale);
+    }
+    repaint();
+}
+
+void PianoRollToolbar::applyHarmonyContextEdit(int rootKey, ScaleType scaleType, bool snapToScale) {
+    setHarmonyContext(rootKey, scaleType, snapToScale);
+    if (onHarmonyContextChanged_) {
+        onHarmonyContextChanged_(m_rootKey, m_scaleType, m_snapToScale);
+    }
 }
 
 

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -644,6 +644,22 @@ void PianoRollView::setSnapToScale(bool enabled) {
     m_toolbar->setHarmonyContext(m_toolbar->getRootKey(), m_toolbar->getScaleType(), enabled);
 }
 
+void PianoRollView::applyHarmonyContextEdit(int root, ScaleType type, bool snapToScale) {
+    if (m_toolbar) m_toolbar->applyHarmonyContextEdit(root, type, snapToScale);
+}
+
+int PianoRollView::getRootKey() const {
+    return m_toolbar ? m_toolbar->getRootKey() : 0;
+}
+
+ScaleType PianoRollView::getScaleType() const {
+    return m_toolbar ? m_toolbar->getScaleType() : ScaleType::Chromatic;
+}
+
+bool PianoRollView::getSnapToScale() const {
+    return m_toolbar && m_toolbar->getSnapToScale();
+}
+
 void PianoRollView::setOnHarmonyContextChanged(std::function<void(int, ScaleType, bool)> cb) {
     if (m_toolbar) m_toolbar->setOnHarmonyContextChanged(std::move(cb));
 }

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -635,20 +635,17 @@ void PianoRollView::setTool(GlobalTool tool) {
 }
 
 void PianoRollView::setScale(int root, ScaleType type) {
-    if (m_grid) {
-        m_grid->setRootKey(root);
-        m_grid->setScaleType(type);
-    }
-    if (m_notes) {
-        m_notes->setRootKey(root);
-        m_notes->setScaleType(type);
-    }
+    const bool snapToScale = m_notes && m_notes->getSnapToScale();
+    if (m_toolbar) m_toolbar->setHarmonyContext(root, type, snapToScale);
 }
 
 void PianoRollView::setSnapToScale(bool enabled) {
-    if (m_notes) {
-        m_notes->setSnapToScale(enabled);
-    }
+    if (!m_toolbar) return;
+    m_toolbar->setHarmonyContext(m_toolbar->getRootKey(), m_toolbar->getScaleType(), enabled);
+}
+
+void PianoRollView::setOnHarmonyContextChanged(std::function<void(int, ScaleType, bool)> cb) {
+    if (m_toolbar) m_toolbar->setOnHarmonyContextChanged(std::move(cb));
 }
 
 void PianoRollView::setPlatformBridge(NUIPlatformBridge* bridge) {

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -49,6 +49,34 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
     m_pianoRoll->setOnNotesChanged([this](const std::vector<AestraUI::MidiNote>&) {
         savePattern();
     });
+    m_pianoRoll->setOnHarmonyContextChanged([this](int rootKey, AestraUI::ScaleType scaleType, bool snapToScale) {
+        if (!m_trackManager || !m_currentPatternId.isValid()) return;
+
+        ScaleContext context;
+        context.rootKey = clampRootKey(rootKey);
+        context.scaleKind = static_cast<ScaleKind>(static_cast<int>(scaleType));
+        context.snapToScale = snapToScale;
+
+        auto& patternManager = m_trackManager->getPatternManager();
+        const auto* pattern = patternManager.getPattern(m_currentPatternId);
+        if (!pattern || !pattern->isMidi()) return;
+
+        std::optional<ScaleContext> desired;
+        assignScaleContextOverride(desired, context);
+        const bool unchanged = (!desired && !pattern->scaleOverride) ||
+                               (desired && pattern->scaleOverride &&
+                                desired->rootKey == pattern->scaleOverride->rootKey &&
+                                desired->scaleKind == pattern->scaleOverride->scaleKind &&
+                                desired->snapToScale == pattern->scaleOverride->snapToScale);
+        if (unchanged) return;
+
+        patternManager.applyPatch(m_currentPatternId, [desired](PatternSource& mutablePattern) {
+            mutablePattern.scaleOverride = desired;
+        });
+        if (m_onPatternEdited) {
+            m_onPatternEdited(m_currentPatternId);
+        }
+    });
     m_pianoRoll->setPatternLengthBeats(m_patternDurationBeats);
     m_pianoRoll->setOnAdjustPatternLength([this](int barsDelta) {
         adjustPatternLengthBars(barsDelta);

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -214,6 +214,22 @@ void PianoRollPanel::setBeatsPerBar(int bpb) {
     }
 }
 
+void PianoRollPanel::applyHarmonyContextEdit(int rootKey, AestraUI::ScaleType scaleType, bool snapToScale) {
+    if (m_pianoRoll) {
+        m_pianoRoll->applyHarmonyContextEdit(rootKey, scaleType, snapToScale);
+    }
+}
+
+ScaleContext PianoRollPanel::getHarmonyContext() const {
+    ScaleContext context;
+    if (m_pianoRoll) {
+        context.rootKey = m_pianoRoll->getRootKey();
+        context.scaleKind = static_cast<ScaleKind>(static_cast<int>(m_pianoRoll->getScaleType()));
+        context.snapToScale = m_pianoRoll->getSnapToScale();
+    }
+    return context;
+}
+
 void PianoRollPanel::onResize(int width, int height) {
     WindowPanel::onResize(width, height);
 }

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -83,6 +83,10 @@ public:
      * @param bpb Beats per bar.
      */
     void setBeatsPerBar(int bpb);
+    /** @brief Apply one complete harmony edit through the editor view. */
+    void applyHarmonyContextEdit(int rootKey, AestraUI::ScaleType scaleType, bool snapToScale);
+    /** @brief Return the complete harmony context currently shown by the editor. */
+    ScaleContext getHarmonyContext() const;
     /**
      * @brief Bind the live audio engine used for transport/playhead sync.
      * @param engine Audio engine pointer, or nullptr to disable engine sync.

--- a/Tests/AestraAudio/ScaleContextTest.cpp
+++ b/Tests/AestraAudio/ScaleContextTest.cpp
@@ -110,6 +110,27 @@ static void test_optional_behavior() {
     PASS("optional behavior");
 }
 
+static void test_pattern_override_assignment() {
+    std::optional<ScaleContext> stored;
+
+    ScaleContext edited;
+    edited.rootKey = 9;
+    edited.scaleKind = ScaleKind::Minor;
+    edited.snapToScale = true;
+    assignScaleContextOverride(stored, edited);
+    ASSERT(stored.has_value(), "a non-default harmony edit should create a pattern override");
+    ASSERT(stored->rootKey == 9 && stored->scaleKind == ScaleKind::Minor && stored->snapToScale,
+           "the complete harmony context should be stored together");
+
+    edited.rootKey = 99;
+    assignScaleContextOverride(stored, edited);
+    ASSERT(stored->rootKey == 11, "stored harmony roots should be normalized");
+
+    assignScaleContextOverride(stored, ScaleContext::defaultContext());
+    ASSERT(!stored.has_value(), "restoring every default should remove the redundant override");
+    PASS("pattern harmony override stores, normalizes, and clears atomically");
+}
+
 // -----------------------------------------------------------------------------
 // Main
 // -----------------------------------------------------------------------------
@@ -121,6 +142,7 @@ int main() {
     test_scaleKind_roundtrip();
     test_rootKey_range();
     test_optional_behavior();
+    test_pattern_override_assignment();
 
     std::cout << "\n=== Results: " << testsPassed << " passed, " << testsFailed << " failed ===\n";
     return testsFailed > 0 ? 1 : 0;

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -2,6 +2,7 @@
 #include "Helpers/PianoRollInteraction.h"
 #include "Helpers/TimelineGridRenderer.h"
 #include "Common/MusicHelpers.h"
+#include "Widgets/NUIPianoRollWidgets.h"
 #include <cassert>
 #include <iostream>
 
@@ -252,6 +253,43 @@ static void test_snap_pitch_to_scale_edge_cases() {
     PASS("snapPitchToScale edge cases documented");
 }
 
+static void test_harmony_context_edit_notification() {
+    PianoRollToolbar toolbar;
+    auto grid = std::make_shared<PianoRollGrid>();
+    auto notes = std::make_shared<PianoRollNoteLayer>();
+    toolbar.setGrid(grid);
+    toolbar.setNoteLayer(notes);
+
+    int notificationCount = 0;
+    int notifiedRoot = -1;
+    ScaleType notifiedScale = ScaleType::Chromatic;
+    bool notifiedSnap = false;
+    toolbar.setOnHarmonyContextChanged([&](int root, ScaleType scale, bool snap) {
+        ++notificationCount;
+        notifiedRoot = root;
+        notifiedScale = scale;
+        notifiedSnap = snap;
+    });
+
+    toolbar.setHarmonyContext(9, ScaleType::Minor, false);
+    ASSERT(notificationCount == 0, "loading harmony context must not masquerade as a user edit");
+    ASSERT(toolbar.getRootKey() == 9 && toolbar.getScaleType() == ScaleType::Minor,
+           "loaded harmony context should become the toolbar authority");
+
+    toolbar.applyHarmonyContextEdit(9, ScaleType::Minor, true);
+    ASSERT(notificationCount == 1, "a harmony edit should notify the owning panel exactly once");
+    ASSERT(notifiedRoot == 9 && notifiedScale == ScaleType::Minor && notifiedSnap,
+           "harmony notification should carry the complete context");
+    ASSERT(notes->getSnapToScale(), "harmony edit should update the note layer before notification");
+
+    toolbar.applyHarmonyContextEdit(99, ScaleType::Count, false);
+    ASSERT(toolbar.getRootKey() == 11,
+           "out-of-range root edits should clamp before reaching persistent state");
+    ASSERT(toolbar.getScaleType() == ScaleType::Blues,
+           "out-of-range scale edits should clamp before reaching persistent state");
+    PASS("Piano Roll harmony edits publish one complete, normalized context");
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -274,6 +312,7 @@ int main() {
     test_next_pitch_in_scale();
     test_previous_pitch_in_scale();
     test_snap_pitch_to_scale_edge_cases();
+    test_harmony_context_edit_notification();
 
     std::cout << "\n=== Results: " << testsPassed << " passed, " << testsFailed << " failed ===\n";
     return testsFailed > 0 ? 1 : 0;

--- a/Tests/AestraUI/PianoRollPanelPersistenceTest.cpp
+++ b/Tests/AestraUI/PianoRollPanelPersistenceTest.cpp
@@ -1,0 +1,61 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Models/PatternSource.h"
+#include "Models/TrackManager.h"
+#include "Music/ScaleContext.h"
+#include "PianoRollPanel.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void testHarmonyContextRoundtripThroughPanel() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& patternManager = trackManager->getPatternManager();
+    const PatternID patternId = patternManager.createMidiPattern("Harmony Roundtrip", 4.0, MidiPayload{});
+
+    PianoRollPanel editor(trackManager);
+    editor.loadPattern(patternId);
+    editor.applyHarmonyContextEdit(9, AestraUI::ScaleType::Minor, true);
+
+    const PatternSource* stored = patternManager.getPattern(patternId);
+    expect(stored != nullptr, "edited pattern should remain available");
+    expect(stored && stored->scaleOverride.has_value(), "panel edit should persist a scale override");
+    if (stored && stored->scaleOverride) {
+        expect(stored->scaleOverride->rootKey == 9, "stored root should match the view edit");
+        expect(stored->scaleOverride->scaleKind == ScaleKind::Minor, "stored scale should match the view edit");
+        expect(stored->scaleOverride->snapToScale, "stored snap state should match the view edit");
+    }
+
+    PianoRollPanel reloadedEditor(trackManager);
+    reloadedEditor.loadPattern(patternId);
+    const ScaleContext restored = reloadedEditor.getHarmonyContext();
+    expect(restored.rootKey == 9, "loadPattern should restore the edited root");
+    expect(restored.scaleKind == ScaleKind::Minor, "loadPattern should restore the edited scale");
+    expect(restored.snapToScale, "loadPattern should restore the edited snap state");
+}
+
+} // namespace
+
+int main() {
+    testHarmonyContextRoundtripThroughPanel();
+    if (failures == 0) {
+        std::cout << "PianoRollPanelPersistenceTest passed\n";
+        return EXIT_SUCCESS;
+    }
+    std::cerr << "PianoRollPanelPersistenceTest: " << failures << " failure(s)\n";
+    return EXIT_FAILURE;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1680,9 +1680,9 @@ endif()
 
 # PianoRollInteraction Test - tests for pure helper functions
 # Guard on target presence because headless/CI disables AestraUI targets.
-if(TARGET AestraUI_Core)
+if(TARGET AestraUI_Core AND TARGET AestraUI_Platform)
     add_executable(PianoRollInteractionTest AestraUI/PianoRollInteractionTest.cpp)
-    target_link_libraries(PianoRollInteractionTest PRIVATE AestraUI_Core)
+    target_link_libraries(PianoRollInteractionTest PRIVATE AestraUI_Core AestraUI_Platform)
     target_include_directories(PianoRollInteractionTest PRIVATE
         ${CMAKE_SOURCE_DIR}/AestraUI
         ${CMAKE_SOURCE_DIR}/AestraUI/Common
@@ -1690,7 +1690,7 @@ if(TARGET AestraUI_Core)
     add_test(NAME PianoRollInteractionTest COMMAND PianoRollInteractionTest)
     set_tests_properties(PianoRollInteractionTest PROPERTIES LABELS "ui;interaction;contract:application")
 else()
-    message(STATUS "PianoRollInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
+    message(STATUS "PianoRollInteractionTest skipped (AestraUI targets unavailable in this build mode)")
 endif()
 
 # Editor-close deferred-destruction regression (#475): removeChild() during

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1693,6 +1693,37 @@ else()
     message(STATUS "PianoRollInteractionTest skipped (AestraUI targets unavailable in this build mode)")
 endif()
 
+# Piano Roll harmony edits must traverse the real panel/view callback into
+# PatternManager and reload as one complete context.
+if(TARGET AestraUI_Core AND TARGET AestraUI_Platform)
+    add_executable(PianoRollPanelPersistenceTest
+        AestraUI/PianoRollPanelPersistenceTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/WindowPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/PianoRollPanel.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Components/TimelineMinimapBar.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Components/TimelineMinimapRenderer.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Components/TimelineSummaryCache.cpp
+    )
+    target_link_libraries(PianoRollPanelPersistenceTest PRIVATE AestraUI_Core AestraUI_Platform AestraAudio)
+    target_include_directories(PianoRollPanelPersistenceTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/Source/Core
+        ${CMAKE_SOURCE_DIR}/Source/Panels
+        ${CMAKE_SOURCE_DIR}/Source/Components
+    )
+    add_test(NAME PianoRollPanelPersistenceTest COMMAND PianoRollPanelPersistenceTest)
+    set_tests_properties(PianoRollPanelPersistenceTest PROPERTIES
+        LABELS "ui;pianoroll;persistence;regression;contract:application")
+endif()
+
 # Editor-close deferred-destruction regression (#475): removeChild() during
 # event dispatch must defer and free safely (no iterator invalidation / UAF).
 if(TARGET AestraUI_Core)


### PR DESCRIPTION
## Summary

- persist Piano Roll root, scale, and scale-snap edits into the pattern's existing harmony context
- restore the complete harmony context when the pattern is reopened
- show the active root and scale as radio selections in the settings menu
- normalize roots and clear redundant default overrides without changing the project schema

## Why

The Piano Roll settings menu previously changed only the live grid and note layer. The project model was never updated, so harmony guidance silently returned to C/Chromatic with scale snapping off whenever the pattern was reloaded.

## Testing performed

- `cmake --build build-linux --target Aestra ScaleContextTest PianoRollInteractionTest -j2`
- `ctest --test-dir build-linux -R '^(ScaleContextTest|PianoRollInteractionTest|ProjectFixtureCorpusTest)$' --output-on-failure -j2` — 3/3 passed
- manually changed Pattern 1 from C/Chromatic to A/Minor, closed and reopened the Piano Roll, and verified the A root radio and A-minor row highlighting were restored
- desktop app shut down cleanly with exit code 0 and cleared its crash flag

## Producer note

Piano Roll harmony choices now stay with the pattern when you reopen it.

## Docs updated?

None. This corrects existing behavior and does not add a new public project format.

## Risk and rollback notes

The change writes only the existing optional pattern scale context and removes it again when every value is at the default. It does not alter MIDI notes, audio rendering, or the serialized schema. Reverting `fc10b038` restores the previous presentation-only controls.

## Decision citation

Objective:
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: corrective
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Persist Piano Roll root, scale, and scale-snap settings in the pattern’s existing harmony context.
- Restore the complete harmony context when reopening a pattern.
- Show active root and scale selections in the settings menu.
- Centralize harmony-context updates across the toolbar, view, grid, and note layer.
- Normalize root values and remove redundant default overrides without changing the project schema.
- Add coverage for context persistence, UI synchronization, value clamping, and default reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->