### PR TITLE
Make Piano Roll strokes chord-aware

### DIFF
--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -571,8 +571,10 @@ private:
     void auditionStop();
 
     // Paint-brush: stamp one snapped note at the cursor cell if empty, used for
-    // Ctrl+pencil drag strokes. Returns true if a note was added.
+    // Shift+pencil drag strokes. Chord mode stamps the active triad. Returns
+    // true if at least one note was added.
     bool paintBrushAt(float localX, float localY);
+    bool eraseStrokeChanged_ = false;
 };
 
 // -----------------------------------------------------------------------------

--- a/AestraUI/Widgets/PianoRollNoteLayer.cpp
+++ b/AestraUI/Widgets/PianoRollNoteLayer.cpp
@@ -102,26 +102,29 @@ std::vector<int> PianoRollNoteLayer::buildTriad(int rootPitch) const {
 
 bool PianoRollNoteLayer::paintBrushAt(float localX, float localY) {
     const double snappedBeat = snapToGrid(std::max(0.0, static_cast<double>(localX) / pixelsPerBeat_));
-    const int pitch = snapPitchToScale(std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127));
+    const int rootPitch = snapPitchToScale(std::clamp(127 - static_cast<int>(localY / keyHeight_), 0, 127));
+    const std::vector<int> strokePitches = chordMode_ ? buildTriad(rootPitch) : std::vector<int>{rootPitch};
+    bool changed = false;
 
-    // One note per cell: skip if a note already starts on this pitch+beat so a
-    // jittery drag doesn't stack duplicates.
-    for (const auto& n : notes_) {
-        if (n.isDeleted) continue;
-        if (n.pitch == pitch && std::abs(n.startBeat - snappedBeat) < 0.001) return false;
+    for (const int pitch : strokePitches) {
+        const bool occupied = std::any_of(notes_.begin(), notes_.end(), [pitch, snappedBeat](const MidiNote& note) {
+            return !note.isDeleted && note.pitch == pitch && std::abs(note.startBeat - snappedBeat) < 0.001;
+        });
+        if (occupied) continue;
+
+        MidiNote note;
+        note.pitch = pitch;
+        note.startBeat = snappedBeat;
+        note.durationBeats = lastNoteDuration_;
+        note.velocity = lastNoteVelocity_;
+        note.unitId = defaultUnitId_;
+        note.selected = true;
+        note.animationScale = 1.0f;
+        notes_.push_back(note);
+        auditionPitch(pitch);
+        changed = true;
     }
-
-    MidiNote note;
-    note.pitch = pitch;
-    note.startBeat = snappedBeat;
-    note.durationBeats = lastNoteDuration_;
-    note.velocity = lastNoteVelocity_;
-    note.unitId = defaultUnitId_;
-    note.selected = true; // the whole stroke ends up selected
-    note.animationScale = 1.0f;
-    notes_.push_back(note);
-    auditionPitch(pitch);
-    return true;
+    return changed;
 }
 
 void PianoRollNoteLayer::connectSelectedNotes() {
@@ -905,30 +908,38 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     // --- RIGHT CLICK / ERASER (FAST ERASE) ---
     if (event.button == NUIMouseButton::Right) {
         if (event.pressed) {
-             state_ = State::Erasing;
-             
-             // Delete immediately on press
-             int idx = findNoteAt(localX, localY);
-             if (idx != -1) {
-                 auto oldNotes = notes_;
-                 notes_.erase(notes_.begin() + idx);
-                 pushUndo("Delete Note", oldNotes, notes_);
-                 commitNotes();
-                 repaint();
-             }
+            state_ = State::Erasing;
+            dragStartNotes_ = notes_;
+            eraseStrokeChanged_ = false;
+
+            const int idx = findNoteAt(localX, localY);
+            if (idx != -1) {
+                notes_.erase(notes_.begin() + idx);
+                eraseStrokeChanged_ = true;
+                repaint();
+            }
+            return true;
         }
-        if (event.released) state_ = State::None;
+        if (event.released && state_ == State::Erasing) {
+            if (eraseStrokeChanged_) {
+                pushUndo("Erase Stroke", dragStartNotes_, notes_);
+                commitNotes();
+            }
+            state_ = State::None;
+            eraseStrokeChanged_ = false;
+            repaint();
+            return true;
+        }
     }
     
     if (state_ == State::Erasing && !event.released) {
-         int idx = findNoteAt(localX, localY);
-         if (idx != -1 && !notes_[idx].isDeleted) {
-             auto oldNotes = notes_;
-             notes_.erase(notes_.begin() + idx);
-             commitNotes();
-             repaint();
-         }
-         return true;
+        int idx = findNoteAt(localX, localY);
+        if (idx != -1 && !notes_[idx].isDeleted) {
+            notes_.erase(notes_.begin() + idx);
+            eraseStrokeChanged_ = true;
+            repaint();
+        }
+        return true;
     }
 
     // --- LEFT CLICK HANDLING ---

--- a/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
@@ -1,0 +1,136 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+#include "NUIPianoRollWidgets.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        ++g_failures;
+    }
+}
+
+NUIMouseEvent mouseDown(float x, float y, NUIMouseButton button, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = button;
+    event.modifiers = modifiers;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent mouseDrag(float x, float y, NUIMouseButton button, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Drag;
+    event.position = {x, y};
+    event.button = button;
+    event.modifiers = modifiers;
+    return event;
+}
+
+NUIMouseEvent mouseUp(float x, float y, NUIMouseButton button, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Up;
+    event.position = {x, y};
+    event.button = button;
+    event.modifiers = modifiers;
+    event.released = true;
+    return event;
+}
+
+float pitchRowCenter(int pitch) {
+    return static_cast<float>(127 - pitch) * 24.0f + 12.0f;
+}
+
+bool hasNote(const std::vector<MidiNote>& notes, int pitch, double beat) {
+    return std::any_of(notes.begin(), notes.end(), [pitch, beat](const MidiNote& note) {
+        return note.pitch == pitch && std::abs(note.startBeat - beat) < 0.001;
+    });
+}
+
+void testChordBrushPaintsCompleteTriadsAsOneEdit() {
+    PianoRollNoteLayer layer;
+    layer.setBounds({0.0f, 0.0f, 800.0f, 3072.0f});
+    layer.setTool(GlobalTool::Pencil);
+    layer.setSnap(SnapGrid::Beat);
+    layer.setRootKey(0);
+    layer.setScaleType(ScaleType::Major);
+    layer.setChordMode(true);
+
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+    const float y = pitchRowCenter(60);
+    check(layer.onMouseEvent(mouseDown(10.0f, y, NUIMouseButton::Left, NUIModifiers::Shift)),
+          "chord brush press should be handled");
+    check(layer.onMouseEvent(mouseDrag(90.0f, y, NUIMouseButton::Left, NUIModifiers::Shift)),
+          "chord brush drag should be handled");
+    check(layer.onMouseEvent(mouseUp(90.0f, y, NUIMouseButton::Left, NUIModifiers::Shift)),
+          "chord brush release should be handled");
+
+    const auto& notes = layer.getNotes();
+    check(notes.size() == 6, "two crossed cells should contain two complete triads");
+    for (double beat : {0.0, 1.0}) {
+        check(hasNote(notes, 60, beat), "each brushed chord should contain its root");
+        check(hasNote(notes, 64, beat), "each brushed chord should contain its third");
+        check(hasNote(notes, 67, beat), "each brushed chord should contain its fifth");
+    }
+    check(commits == 1, "a chord brush gesture should commit once on release");
+
+    layer.undo();
+    check(layer.getNotes().empty(), "one undo should remove the complete chord brush gesture");
+}
+
+void testRightDragEraseIsOneUndoableStroke() {
+    PianoRollNoteLayer layer;
+    layer.setBounds({0.0f, 0.0f, 800.0f, 3072.0f});
+    layer.setSnap(SnapGrid::Beat);
+    std::vector<MidiNote> notes;
+    for (double beat : {0.0, 1.0, 2.0}) {
+        MidiNote note;
+        note.pitch = 60;
+        note.startBeat = beat;
+        note.durationBeats = 1.0;
+        notes.push_back(note);
+    }
+    layer.setNotes(notes);
+
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+    const float y = pitchRowCenter(60);
+    check(layer.onMouseEvent(mouseDown(10.0f, y, NUIMouseButton::Right)),
+          "erase stroke press should be handled");
+    check(layer.onMouseEvent(mouseDrag(90.0f, y, NUIMouseButton::Right)),
+          "erase stroke should consume the second note");
+    check(layer.onMouseEvent(mouseDrag(170.0f, y, NUIMouseButton::Right)),
+          "erase stroke should consume the third note");
+    check(layer.onMouseEvent(mouseUp(170.0f, y, NUIMouseButton::Right)),
+          "erase stroke release should be handled");
+
+    check(layer.getNotes().empty(), "right-drag should erase every crossed note");
+    check(commits == 1, "an erase stroke should commit once on release");
+    layer.undo();
+    check(layer.getNotes().size() == 3, "one undo should restore the complete erase stroke");
+}
+
+} // namespace
+
+int main() {
+    testChordBrushPaintsCompleteTriadsAsOneEdit();
+    testRightDragEraseIsOneUndoableStroke();
+
+    if (g_failures == 0) {
+        std::cout << "Piano Roll stroke interaction tests passed\n";
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1693,6 +1693,21 @@ else()
     message(STATUS "PianoRollInteractionTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+if(TARGET AestraUI_Core AND TARGET AestraUI_Platform)
+    add_executable(PianoRollStrokeInteractionTest AestraUI/PianoRollStrokeInteractionTest.cpp)
+    target_link_libraries(PianoRollStrokeInteractionTest PRIVATE AestraUI_Core AestraUI_Platform)
+    target_include_directories(PianoRollStrokeInteractionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Common
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+    )
+    add_test(NAME PianoRollStrokeInteractionTest COMMAND PianoRollStrokeInteractionTest)
+    set_tests_properties(PianoRollStrokeInteractionTest
+        PROPERTIES LABELS "ui;interaction;pianoroll;regression;contract:application")
+else()
+    message(STATUS "PianoRollStrokeInteractionTest skipped (AestraUI targets unavailable in this build mode)")
+endif()
+
 # Editor-close deferred-destruction regression (#475): removeChild() during
 # event dispatch must defer and free safely (no iterator invalidation / UAF).
 if(TARGET AestraUI_Core)


### PR DESCRIPTION
## Summary

- make Shift-drag painting honor Piano Roll chord mode and stamp complete triads in every crossed cell
- keep chord brush cells duplicate-safe when part of a chord already exists
- commit right-drag deletion once per stroke so one undo restores every erased note
- add direct press/drag/release regression coverage for both gestures

## Why

Chord mode applied only to discrete clicks; using the existing drag brush unexpectedly fell back to single notes. Right-drag erase also committed each deletion piecemeal, so its undo behavior did not match the gesture the producer performed.

## Testing performed

- `cmake --build build-linux --target Aestra PianoRollInteractionTest PianoRollStrokeInteractionTest -j2`
- `ctest --test-dir build-linux -R '^(PianoRollStrokeInteractionTest|PianoRollInteractionTest|PianoRollEdgeCaseStressTest|NoteDiffTest)$' --output-on-failure -j2` — 4/4 passed
- launched the desktop app, confirmed chord mode remains reachable in the Piano Roll settings, and shut down cleanly with exit code 0
- the deterministic stroke regression is the gesture acceptance evidence; virtual-pointer absolute coordinates were not treated as proof

## Producer note

You can now Shift-drag to paint chords in the Piano Roll and undo a whole drag erase at once.

## Docs updated?

None. The interaction is covered by in-app labeling and regression tests.

## Risk and rollback notes

The change is confined to UI-thread note editing. MIDI playback, DSP, project serialization, and real-time paths are unchanged. Reverting `9dd8a6f0` restores the former single-note brush and piecemeal erase commits.

## Decision citation

Objective:
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: corrective
Reversal:
