### PR TITLE
Make Sampler ping-pong loops bidirectional

### DIFF
--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -17,6 +17,9 @@ namespace Plugins {
 
 class SamplerPlugin : public IPluginInstance {
 public:
+    // Values are persisted in sampler state; append new modes rather than renumbering these.
+    enum class LoopMode : int { OneShot = 0, Forward = 1, PingPong = 2 };
+
     SamplerPlugin();
     ~SamplerPlugin() override = default;
 
@@ -63,6 +66,7 @@ public:
     void setCoarseSemitones(float semitones) noexcept;
     void setFineTuneCents(float cents) noexcept;
     void setSampleWindow(float startNorm, float endNorm) noexcept;
+    void setLoopMode(LoopMode mode) noexcept;
     void setLoopEnabled(bool enabled) noexcept;
     void setMaxVoices(int maxVoices) noexcept;
     void setRootMidiNote(int note) noexcept;
@@ -75,7 +79,8 @@ public:
     float getFineTuneCents() const noexcept;
     float getLoopStartNorm() const noexcept { return m_loopStartNorm.load(std::memory_order_relaxed); }
     float getLoopEndNorm() const noexcept { return m_loopEndNorm.load(std::memory_order_relaxed); }
-    bool isLoopEnabled() const noexcept { return m_loopEnabled.load(std::memory_order_relaxed); }
+    LoopMode getLoopMode() const noexcept;
+    bool isLoopEnabled() const noexcept { return getLoopMode() != LoopMode::OneShot; }
     int getMaxVoices() const noexcept { return m_maxVoices.load(std::memory_order_relaxed); }
     int getRootMidiNote() const noexcept { return m_rootMidiNote.load(std::memory_order_relaxed); }
     bool isMonoMode() const noexcept { return m_monoMode.load(std::memory_order_relaxed); }
@@ -111,7 +116,7 @@ private:
     std::atomic<float> m_fineTuneCents{0.0f};
     std::atomic<float> m_loopStartNorm{0.0f};
     std::atomic<float> m_loopEndNorm{1.0f};
-    std::atomic<bool> m_loopEnabled{false}; // one-shot default
+    std::atomic<int> m_loopMode{static_cast<int>(LoopMode::OneShot)};
     std::atomic<int> m_maxVoices{4};
     std::atomic<int> m_rootMidiNote{60}; // C3 default
     std::atomic<bool> m_monoMode{false};
@@ -129,6 +134,7 @@ private:
         double position = 0.0; // Sample index
         double playbackRate = 1.0; // sample index increment/frame
         double targetPlaybackRate = 1.0;
+        int playbackDirection = 1;
         bool glideActive = false;
         EnvStage stage = EnvStage::Off;
         double stageTime = 0.0; // Seconds in current stage

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -85,8 +85,12 @@ void SamplerPlugin::setSampleWindow(float startNorm, float endNorm) noexcept {
     m_loopEndNorm.store(end, std::memory_order_relaxed);
 }
 
+void SamplerPlugin::setLoopMode(LoopMode mode) noexcept {
+    m_loopMode.store(static_cast<int>(mode), std::memory_order_relaxed);
+}
+
 void SamplerPlugin::setLoopEnabled(bool enabled) noexcept {
-    m_loopEnabled.store(enabled, std::memory_order_relaxed);
+    setLoopMode(enabled ? LoopMode::Forward : LoopMode::OneShot);
 }
 
 void SamplerPlugin::setMaxVoices(int maxVoices) noexcept {
@@ -112,6 +116,17 @@ float SamplerPlugin::getCoarseSemitones() const noexcept {
 
 float SamplerPlugin::getFineTuneCents() const noexcept {
     return m_fineTuneCents.load(std::memory_order_relaxed);
+}
+
+SamplerPlugin::LoopMode SamplerPlugin::getLoopMode() const noexcept {
+    switch (m_loopMode.load(std::memory_order_relaxed)) {
+    case static_cast<int>(LoopMode::Forward):
+        return LoopMode::Forward;
+    case static_cast<int>(LoopMode::PingPong):
+        return LoopMode::PingPong;
+    default:
+        return LoopMode::OneShot;
+    }
 }
 
 bool SamplerPlugin::initialize(double sampleRate, uint32_t maxBlockSize) {
@@ -261,6 +276,7 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
             v.position = 0.0;
             v.playbackRate = 1.0;
             v.targetPlaybackRate = 1.0;
+            v.playbackDirection = 1;
             v.glideActive = false;
             v.stageTime = 0.0;
             v.currentGain = 0.0f;
@@ -300,7 +316,10 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
     const double startFrame = startNorm * (totalFrames - 1.0);
     const double endFrame = std::max(startFrame + 1.0, endNorm * totalFrames);
     const double loopLength = std::max(1.0, endFrame - startFrame);
-    const bool loopEnabled = m_loopEnabled.load(std::memory_order_relaxed);
+    const double pingPongEndFrame = std::max(startFrame, std::min(totalFrames - 1.0, endFrame - 1.0));
+    const double pingPongSpan = pingPongEndFrame - startFrame;
+    const LoopMode loopMode = getLoopMode();
+    const bool loopEnabled = loopMode != LoopMode::OneShot;
     int activeVoiceCount = 0;
     for (const auto& v : m_voices) {
         if (v.active) {
@@ -390,15 +409,41 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
             }
 
             // Sample Lookup
-            if (v.position < startFrame) {
-                v.position = startFrame;
-            }
-            if (v.position >= endFrame) {
-                if (loopEnabled) {
+            if (loopMode == LoopMode::PingPong) {
+                // Fold any boundary overshoot into a triangle wave. This remains
+                // bounded even when extreme pitch makes one frame cross the loop
+                // multiple times, and avoids a callback-time correction loop.
+                if (pingPongSpan <= 1.0e-9) {
+                    v.position = startFrame;
+                    v.playbackDirection = 1;
+                } else if (v.playbackDirection >= 0 && v.position > pingPongEndFrame) {
+                    const double cycle = std::fmod(v.position - pingPongEndFrame, pingPongSpan * 2.0);
+                    if (cycle <= pingPongSpan) {
+                        v.position = pingPongEndFrame - cycle;
+                        v.playbackDirection = -1;
+                    } else {
+                        v.position = startFrame + (cycle - pingPongSpan);
+                        v.playbackDirection = 1;
+                    }
+                } else if (v.playbackDirection < 0 && v.position < startFrame) {
+                    const double cycle = std::fmod(startFrame - v.position, pingPongSpan * 2.0);
+                    if (cycle <= pingPongSpan) {
+                        v.position = startFrame + cycle;
+                        v.playbackDirection = 1;
+                    } else {
+                        v.position = pingPongEndFrame - (cycle - pingPongSpan);
+                        v.playbackDirection = -1;
+                    }
+                }
+            } else {
+                if (v.position < startFrame) {
+                    v.position = startFrame;
+                }
+                if (v.position >= endFrame && loopMode == LoopMode::Forward) {
                     const double offset = v.position - startFrame;
                     const double wraps = std::floor(offset / loopLength);
                     v.position = startFrame + offset - wraps * loopLength;
-                } else {
+                } else if (v.position >= endFrame) {
                     v.active = false;
                     activeVoiceCountDirty = true;
                     continue;
@@ -426,7 +471,8 @@ void SamplerPlugin::process(const float* const* inputs, float** outputs, uint32_
             R += outR * gain * v.gainR;
 
             // Advance
-            v.position += v.playbackRate;
+            v.position += v.playbackRate * static_cast<double>(
+                                                 loopMode == LoopMode::PingPong ? v.playbackDirection : 1);
         }
 
         // Guard against non-finite output: sinc interpolation at extreme
@@ -501,6 +547,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
                 voice.position = noteStartFrame;
                 voice.playbackRate = targetRate;
                 voice.targetPlaybackRate = targetRate;
+                voice.playbackDirection = 1;
                 voice.glideActive = false;
                 voice.stage = EnvStage::Attack;
                 voice.stageTime = 0.0;
@@ -556,6 +603,7 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
         freeVoice->position = noteStartFrame;
         freeVoice->playbackRate = targetRate;
         freeVoice->targetPlaybackRate = targetRate;
+        freeVoice->playbackDirection = 1;
         freeVoice->glideActive = false;
         freeVoice->stage = EnvStage::Attack;
         freeVoice->stageTime = 0.0;
@@ -669,7 +717,11 @@ std::vector<uint8_t> SamplerPlugin::saveState() const {
     json.set("fineTuneCents", Aestra::JSON(static_cast<double>(m_fineTuneCents.load(std::memory_order_relaxed))));
     json.set("loopStartNorm", Aestra::JSON(static_cast<double>(m_loopStartNorm.load(std::memory_order_relaxed))));
     json.set("loopEndNorm", Aestra::JSON(static_cast<double>(m_loopEndNorm.load(std::memory_order_relaxed))));
-    json.set("loopEnabled", Aestra::JSON(m_loopEnabled.load(std::memory_order_relaxed)));
+    const LoopMode loopMode = getLoopMode();
+    json.set("loopMode", Aestra::JSON(static_cast<double>(static_cast<int>(loopMode))));
+    // Retain the old boolean so older builds can still open new forward or
+    // bidirectional projects as an ordinary enabled loop.
+    json.set("loopEnabled", Aestra::JSON(loopMode != LoopMode::OneShot));
     json.set("maxVoices", Aestra::JSON(static_cast<double>(m_maxVoices.load(std::memory_order_relaxed))));
     json.set("rootMidiNote", Aestra::JSON(static_cast<double>(m_rootMidiNote.load(std::memory_order_relaxed))));
     json.set("monoMode", Aestra::JSON(m_monoMode.load(std::memory_order_relaxed)));
@@ -712,8 +764,15 @@ bool SamplerPlugin::loadState(const std::vector<uint8_t>& state) {
         const float endNorm = json.has("loopEndNorm") ? static_cast<float>(json["loopEndNorm"].asNumber()) : 1.0f;
         setSampleWindow(startNorm, endNorm);
     }
-    if (json.has("loopEnabled")) {
-        m_loopEnabled.store(json["loopEnabled"].asBool(), std::memory_order_relaxed);
+    // New state carries the complete mode. Historical state only had the
+    // enabled flag, which maps losslessly to one-shot or forward playback.
+    if (json.has("loopMode")) {
+        const int storedMode = static_cast<int>(json["loopMode"].asNumber());
+        setLoopMode(storedMode == static_cast<int>(LoopMode::PingPong)
+                        ? LoopMode::PingPong
+                        : (storedMode == static_cast<int>(LoopMode::Forward) ? LoopMode::Forward : LoopMode::OneShot));
+    } else if (json.has("loopEnabled")) {
+        setLoopEnabled(json["loopEnabled"].asBool());
     }
     if (json.has("maxVoices")) {
         setMaxVoices(static_cast<int>(json["maxVoices"].asNumber()));

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -961,7 +961,12 @@ void AestraContent::setupArsenalPanels() {
             return;
         }
         sampler->setSampleWindow(loopPoints.start, loopPoints.end);
-        sampler->setLoopEnabled(loopPoints.mode != SampleEditorPanel::LoopMode::OneShot);
+        const auto mode = loopPoints.mode == SampleEditorPanel::LoopMode::PingPong
+                              ? Aestra::Audio::Plugins::SamplerPlugin::LoopMode::PingPong
+                              : (loopPoints.mode == SampleEditorPanel::LoopMode::Loop
+                                     ? Aestra::Audio::Plugins::SamplerPlugin::LoopMode::Forward
+                                     : Aestra::Audio::Plugins::SamplerPlugin::LoopMode::OneShot);
+        sampler->setLoopMode(mode);
     };
     m_sampleEditorPanel->onPitchTuneChanged = [this](const SampleEditorPanel::PitchTune& pitchTune) {
         if (!m_trackManager || !m_sampleEditorUnitId) {
@@ -3812,7 +3817,17 @@ void AestraContent::syncSampleEditorToUnit(UnitID unitId) {
     SampleEditorPanel::LoopPoints loop;
     loop.start = sampler->getLoopStartNorm();
     loop.end = sampler->getLoopEndNorm();
-    loop.mode = sampler->isLoopEnabled() ? SampleEditorPanel::LoopMode::Loop : SampleEditorPanel::LoopMode::OneShot;
+    switch (sampler->getLoopMode()) {
+    case Aestra::Audio::Plugins::SamplerPlugin::LoopMode::PingPong:
+        loop.mode = SampleEditorPanel::LoopMode::PingPong;
+        break;
+    case Aestra::Audio::Plugins::SamplerPlugin::LoopMode::Forward:
+        loop.mode = SampleEditorPanel::LoopMode::Loop;
+        break;
+    case Aestra::Audio::Plugins::SamplerPlugin::LoopMode::OneShot:
+        loop.mode = SampleEditorPanel::LoopMode::OneShot;
+        break;
+    }
     m_sampleEditorPanel->setLoopPoints(loop);
 
     SampleEditorPanel::PitchTune pitch;

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -1050,7 +1050,6 @@ void SampleEditorPanel::setLoopMode(LoopMode mode) {
     }
     m_loopPoints.mode = mode;
     updateModeButtons();
-    // TODO: Ping-pong currently shares the loop engine path until sampler ping-pong playback is implemented.
     onLoopControlChanged();
     requestControlCommit();
 }

--- a/Tests/AestraAudio/SamplerLoopModeTest.cpp
+++ b/Tests/AestraAudio/SamplerLoopModeTest.cpp
@@ -1,0 +1,115 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Plugin/PluginHost.h"
+#include "Plugin/SamplerPlugin.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Aestra::Audio::MidiBuffer;
+using Aestra::Audio::Plugins::SamplerPlugin;
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::vector<float> makeRamp(uint32_t frames) {
+    std::vector<float> sample(frames);
+    for (uint32_t i = 0; i < frames; ++i) {
+        sample[i] = 0.1f + 0.8f * static_cast<float>(i) / static_cast<float>(frames - 1);
+    }
+    return sample;
+}
+
+std::vector<float> renderLoop(SamplerPlugin::LoopMode mode) {
+    constexpr uint32_t sampleRate = 1000;
+    constexpr uint32_t outputFrames = 180;
+
+    SamplerPlugin sampler;
+    require(sampler.initialize(sampleRate, outputFrames), "sampler initialization failed");
+    require(sampler.loadSampleData("loop-mode-ramp", makeRamp(128), sampleRate, 1), "ramp sample load failed");
+    sampler.setEnvelope(0.001f, 0.001f, 1.0f, 0.1f);
+    sampler.setSampleWindow(0.25f, 0.75f);
+    sampler.setLoopMode(mode);
+    sampler.setRootMidiNote(60);
+    sampler.activate();
+
+    MidiBuffer midi;
+    midi.addNoteOn(1, 60, 127, 0);
+
+    std::vector<float> left(outputFrames, 0.0f);
+    std::vector<float> right(outputFrames, 0.0f);
+    float* outputs[] = {left.data(), right.data()};
+    sampler.process(nullptr, outputs, 0, 2, outputFrames, &midi, nullptr);
+
+    for (uint32_t i = 0; i < outputFrames; ++i) {
+        require(std::isfinite(left[i]) && std::isfinite(right[i]), "loop render produced NaN or Inf");
+        require(std::abs(left[i] - right[i]) < 1.0e-6f, "mono loop render lost stereo parity");
+    }
+    return left;
+}
+
+double linearSlope(const std::vector<float>& values, size_t begin, size_t end) {
+    require(begin < end && end <= values.size(), "invalid slope window");
+    const double count = static_cast<double>(end - begin);
+    const double meanX = static_cast<double>(begin + end - 1) * 0.5;
+    double meanY = 0.0;
+    for (size_t i = begin; i < end; ++i) {
+        meanY += values[i];
+    }
+    meanY /= count;
+
+    double numerator = 0.0;
+    double denominator = 0.0;
+    for (size_t i = begin; i < end; ++i) {
+        const double dx = static_cast<double>(i) - meanX;
+        numerator += dx * (static_cast<double>(values[i]) - meanY);
+        denominator += dx * dx;
+    }
+    return denominator > 0.0 ? numerator / denominator : 0.0;
+}
+
+std::vector<uint8_t> stateBytes(const std::string& json) {
+    return std::vector<uint8_t>(json.begin(), json.end());
+}
+
+} // namespace
+
+int main() {
+    const auto forward = renderLoop(SamplerPlugin::LoopMode::Forward);
+    const auto pingPong = renderLoop(SamplerPlugin::LoopMode::PingPong);
+
+    require(linearSlope(forward, 12, 48) > 3.0e-4, "forward loop did not traverse toward its end");
+    require(linearSlope(forward, 78, 112) > 3.0e-4, "forward loop did not wrap and traverse forward again");
+
+    require(linearSlope(pingPong, 12, 48) > 3.0e-4, "bidirectional loop did not traverse forward first");
+    require(linearSlope(pingPong, 78, 112) < -3.0e-4, "bidirectional loop did not reverse at its end");
+    require(linearSlope(pingPong, 142, 174) > 3.0e-4, "bidirectional loop did not reverse again at its start");
+
+    SamplerPlugin saved;
+    saved.setLoopMode(SamplerPlugin::LoopMode::PingPong);
+    SamplerPlugin restored;
+    require(restored.loadState(saved.saveState()), "saved loop-mode state failed to load");
+    require(restored.getLoopMode() == SamplerPlugin::LoopMode::PingPong, "saved bidirectional mode was not restored");
+
+    SamplerPlugin legacyForward;
+    require(legacyForward.loadState(stateBytes(R"({"loopEnabled":true})")), "legacy enabled-loop state failed to load");
+    require(legacyForward.getLoopMode() == SamplerPlugin::LoopMode::Forward,
+            "legacy enabled-loop state did not map to forward mode");
+
+    SamplerPlugin legacyOneShot;
+    require(legacyOneShot.loadState(stateBytes(R"({"loopEnabled":false})")), "legacy one-shot state failed to load");
+    require(legacyOneShot.getLoopMode() == SamplerPlugin::LoopMode::OneShot,
+            "legacy disabled-loop state did not map to one-shot mode");
+
+    std::cout << "[PASS] SamplerLoopModeTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/SamplerLoopModeTest.cpp
+++ b/Tests/AestraAudio/SamplerLoopModeTest.cpp
@@ -3,6 +3,7 @@
 #include "Plugin/PluginHost.h"
 #include "Plugin/SamplerPlugin.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -29,13 +30,14 @@ std::vector<float> makeRamp(uint32_t frames) {
     return sample;
 }
 
-std::vector<float> renderLoop(SamplerPlugin::LoopMode mode) {
-    constexpr uint32_t sampleRate = 1000;
-    constexpr uint32_t outputFrames = 180;
+std::vector<float> renderLoop(SamplerPlugin::LoopMode mode, uint32_t sourceRate = 1000,
+                              uint32_t engineRate = 1000, uint32_t outputFrames = 180) {
+    constexpr uint32_t SAMPLE_FRAMES = 128;
 
     SamplerPlugin sampler;
-    require(sampler.initialize(sampleRate, outputFrames), "sampler initialization failed");
-    require(sampler.loadSampleData("loop-mode-ramp", makeRamp(128), sampleRate, 1), "ramp sample load failed");
+    require(sampler.initialize(engineRate, outputFrames), "sampler initialization failed");
+    require(sampler.loadSampleData("loop-mode-ramp", makeRamp(SAMPLE_FRAMES), sourceRate, 1),
+            "ramp sample load failed");
     sampler.setEnvelope(0.001f, 0.001f, 1.0f, 0.1f);
     sampler.setSampleWindow(0.25f, 0.75f);
     sampler.setLoopMode(mode);
@@ -93,6 +95,24 @@ int main() {
     require(linearSlope(pingPong, 12, 48) > 3.0e-4, "bidirectional loop did not traverse forward first");
     require(linearSlope(pingPong, 78, 112) < -3.0e-4, "bidirectional loop did not reverse at its end");
     require(linearSlope(pingPong, 142, 174) > 3.0e-4, "bidirectional loop did not reverse again at its start");
+
+    // A source/engine ratio of 131 crosses more than two 63-frame loop spans
+    // per output frame. The folded overshoot must still traverse both ways
+    // without an unbounded correction loop or invalid output.
+    constexpr uint32_t EXTREME_SOURCE_RATE = 131000;
+    constexpr uint32_t EXTREME_ENGINE_RATE = 1000;
+    constexpr uint32_t EXTREME_OUTPUT_FRAMES = 80;
+    const auto extremePingPong = renderLoop(SamplerPlugin::LoopMode::PingPong, EXTREME_SOURCE_RATE,
+                                            EXTREME_ENGINE_RATE, EXTREME_OUTPUT_FRAMES);
+    require(linearSlope(extremePingPong, 4, 12) > 3.0e-4,
+            "extreme-rate bidirectional loop did not traverse forward");
+    require(linearSlope(extremePingPong, 18, 26) < -3.0e-4,
+            "extreme-rate bidirectional loop did not reverse from its end");
+    require(linearSlope(extremePingPong, 32, 40) > 3.0e-4,
+            "extreme-rate bidirectional loop did not reverse from its start");
+    require(std::any_of(extremePingPong.begin(), extremePingPong.end(),
+                        [](float value) { return std::abs(value) > 1.0e-5f; }),
+            "extreme-rate bidirectional loop produced silence");
 
     SamplerPlugin saved;
     saved.setLoopMode(SamplerPlugin::LoopMode::PingPong);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -672,6 +672,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerStereoParityTest.cpp")
     set_tests_properties(SamplerStereoParityTest PROPERTIES LABELS "audio;sampler;regression;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerLoopModeTest.cpp")
+    add_executable(SamplerLoopModeTest AestraAudio/SamplerLoopModeTest.cpp)
+    target_link_libraries(SamplerLoopModeTest PRIVATE AestraAudio)
+    target_include_directories(SamplerLoopModeTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME SamplerLoopModeTest COMMAND SamplerLoopModeTest)
+    set_tests_properties(SamplerLoopModeTest PROPERTIES LABELS "audio;sampler;loop;regression;contract:audio")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternPlaybackTempoChangeTest.cpp")
     add_executable(PatternPlaybackTempoChangeTest AestraAudio/PatternPlaybackTempoChangeTest.cpp)
     target_link_libraries(PatternPlaybackTempoChangeTest PRIVATE AestraAudio)


### PR DESCRIPTION
## Summary

- implement true bidirectional playback for the Sample Editor's Ping-Pong mode
- preserve direction across loop boundaries with bounded overshoot folding at extreme pitch rates
- persist and restore the complete loop mode while retaining the legacy enabled-loop field
- restore the selected mode when reopening the Sample Editor
- add direct audio-direction and backward-compatibility regressions

## Why

The Sample Editor exposed One-Shot, Loop, and Ping-Pong as distinct modes, but the sampler plugin stored only a boolean and rendered every enabled loop forward. Selecting Ping-Pong therefore sounded identical to Loop and reopened as ordinary Loop.

## Testing performed

- `cmake -S . -B build-linux`
- `cmake --build build-linux --target SamplerLoopModeTest SamplerOneShotEnvelopeTest Aestra -j2`
- `ctest --test-dir build-linux -R '^(SamplerLoopModeTest|SamplerOneShotEnvelopeTest|SamplerStereoParityTest|LiveMidiInputTest|ProjectRoundTripIntegrityTest)$' --output-on-failure -j2` — 5/5 passed
- launched the Linux desktop app, loaded a real eight-second sample, opened the Sample Editor, confirmed the three playback modes and waveform layout rendered correctly, and exited cleanly with code 0
- compositor-injected clicks inside the floating panel were not treated as active-selection proof; the deterministic audio regression verifies reversal at both loop boundaries and the state regression verifies reload behavior
- `git diff --check`
- prohibited product-reference search across every changed source, test, and build file — no matches

## Producer note

Sampler ping-pong loops now play backward and forward and reopen in the selected mode.

## Docs updated?

No. This makes an existing labeled mode behave as advertised.

## Risk and rollback notes

Audio output changes only when Ping-Pong mode is selected. The callback adds bounded arithmetic and atomic reads only; latency is unchanged. Sampler state gains a numeric `loopMode` field while retaining `loopEnabled`, so historical projects map to One-Shot or forward Loop and older builds can still open new state as an enabled forward loop. Reverting `9c207876` restores the former forward-only behavior.

## Decision citation

Objective:
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: corrective
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added true bidirectional playback for sampler Ping-Pong loops. Playback now preserves direction across loop boundaries and handles extreme pitch-rate overshoot.
- Added persisted `LoopMode` state with `OneShot`, `Forward`, and `PingPong` modes. Legacy `loopEnabled` state remains supported for backward compatibility.
- Restored the selected loop mode when reopening the Sample Editor.
- Added regression coverage for playback direction, state persistence, and legacy state loading.
- Added CMake and CTest integration for the new sampler loop-mode tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->