### PR TITLE
Add proportional Piano Roll selection stretching

### DIFF
--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -506,7 +506,8 @@ private:
     double hoverBeat_ = -1.0; // Snapped cursor beat for the draw-mode preview; <0 when idle
     bool hoverOnRightEdge_ = false;
     bool hoverOnLeftEdge_ = false;
-    bool hoverOnSelectionStretch_ = false;
+    bool m_hoverOnSelectionStretch = false;
+    bool m_selectionStretchChanged = false;
 
     // Alt+drag copy state
     std::vector<int> copyDragIndices_;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -485,14 +485,15 @@ private:
     // Interaction State
     enum class State : uint8_t {
         None,
-        Painting,       // Creating a new note (Drag extends duration)
-        BrushPainting,  // Ctrl+pencil drag: lay one note per snap cell crossed
-        Moving,         // Moving existing note(s)
-        Resizing,       // Resizing existing note(s) (Right edge)
-        ResizingLeft,   // Resizing from left edge (moves start, keeps end)
-        SelectingBox,   // Dragging selection rectangle
-        Erasing,        // Eraser Box/Hover
-        CopyDragging    // Alt+drag copy of selection
+        Painting,            // Creating a new note (Drag extends duration)
+        BrushPainting,       // Ctrl+pencil drag: lay one note per snap cell crossed
+        Moving,              // Moving existing note(s)
+        Resizing,            // Resizing existing note(s) (Right edge)
+        ResizingLeft,        // Resizing from left edge (moves start, keeps end)
+        StretchingSelection, // Proportionally scale selected starts and lengths
+        SelectingBox,        // Dragging selection rectangle
+        Erasing,             // Eraser Box/Hover
+        CopyDragging         // Alt+drag copy of selection
     };
     State state_ = State::None;
     // Alt held during a move/resize/paint drag: snapToGrid passes through
@@ -505,6 +506,7 @@ private:
     double hoverBeat_ = -1.0; // Snapped cursor beat for the draw-mode preview; <0 when idle
     bool hoverOnRightEdge_ = false;
     bool hoverOnLeftEdge_ = false;
+    bool hoverOnSelectionStretch_ = false;
 
     // Alt+drag copy state
     std::vector<int> copyDragIndices_;
@@ -576,6 +578,8 @@ private:
 
     // Helpers
     int findNoteAt(float localX, float localY);
+    NUIRect selectionTimeBoundsRect() const;
+    NUIRect selectionStretchHandleRect() const;
     void commitNotes();
     double snapToGrid(double beat);
     int snapPitchToScale(int pitch);

--- a/AestraUI/Widgets/PianoRollNoteLayer.cpp
+++ b/AestraUI/Widgets/PianoRollNoteLayer.cpp
@@ -662,8 +662,8 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         renderer.strokeRoundedRect(selectionBounds, 3.0f, 1.0f, accent.withAlpha(0.68f));
         const NUIRect handle = selectionStretchHandleRect();
         renderer.fillRoundedRect(handle, 3.0f,
-                                 accent.lightened(hoverOnSelectionStretch_ ? 0.24f : 0.10f)
-                                     .withAlpha(hoverOnSelectionStretch_ ? 1.0f : 0.88f));
+                                 accent.lightened(m_hoverOnSelectionStretch ? 0.24f : 0.10f)
+                                     .withAlpha(m_hoverOnSelectionStretch ? 1.0f : 0.88f));
         renderer.strokeRoundedRect(handle, 3.0f, 1.0f, NUIColor::white().withAlpha(0.82f));
     }
 
@@ -845,8 +845,8 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             hoverOnLeftEdge_ = false;
             if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
         }
-        if (hoverOnSelectionStretch_) {
-            hoverOnSelectionStretch_ = false;
+        if (m_hoverOnSelectionStretch) {
+            m_hoverOnSelectionStretch = false;
             if (platformBridge_)
                 platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
             repaint();
@@ -893,8 +893,8 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     if (state_ == State::None && !event.pressed && !event.released) {
         const bool onSelectionStretch =
             tool_ != GlobalTool::Eraser && selectionStretchHandleRect().contains(event.position);
-        if (hoverOnSelectionStretch_ != onSelectionStretch) {
-            hoverOnSelectionStretch_ = onSelectionStretch;
+        if (m_hoverOnSelectionStretch != onSelectionStretch) {
+            m_hoverOnSelectionStretch = onSelectionStretch;
             repaint();
         }
         if (onSelectionStretch) {
@@ -1028,10 +1028,11 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
         // whereas an ordinary note-edge drag still resizes lengths only.
         if (tool_ != GlobalTool::Eraser && selectionStretchHandleRect().contains(event.position)) {
             state_ = State::StretchingSelection;
+            m_selectionStretchChanged = false;
             dragStartPos_ = event.position;
             dragStartScrollX_ = scrollX_;
             dragStartNotes_ = notes_;
-            hoverOnSelectionStretch_ = true;
+            m_hoverOnSelectionStretch = true;
             if (platformBridge_)
                 platformBridge_->setCursorStyle(NUICursorStyle::ResizeEW);
             repaint();
@@ -1481,6 +1482,17 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
                     notes_[i].startBeat = anchorBeat + (original.startBeat - anchorBeat) * factor;
                     notes_[i].durationBeats = std::max(0.125, original.durationBeats * factor);
                 }
+                m_selectionStretchChanged = false;
+                for (size_t i = 0; i < notes_.size() && i < dragStartNotes_.size(); ++i) {
+                    const auto& original = dragStartNotes_[i];
+                    if (!original.selected || original.isDeleted)
+                        continue;
+                    if (std::abs(notes_[i].startBeat - original.startBeat) > 0.000001 ||
+                        std::abs(notes_[i].durationBeats - original.durationBeats) > 0.000001) {
+                        m_selectionStretchChanged = true;
+                        break;
+                    }
+                }
             }
             repaint();
             return true;
@@ -1540,13 +1552,17 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             const std::string description = state_ == State::CopyDragging
                                                 ? "Alt+Drag Copy"
                                                 : (state_ == State::StretchingSelection ? "Stretch Selection" : "Edit");
-            pushUndo(description, dragStartNotes_, notes_);
+            const bool shouldCommit = state_ != State::StretchingSelection || m_selectionStretchChanged;
+            if (shouldCommit)
+                pushUndo(description, dragStartNotes_, notes_);
             state_ = State::None;
             paintingNoteIndex_ = -1;
             copyDragIndices_.clear();
-            hoverOnSelectionStretch_ = false;
+            m_hoverOnSelectionStretch = false;
+            m_selectionStretchChanged = false;
             if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
-            commitNotes();
+            if (shouldCommit)
+                commitNotes();
             repaint();
             return true;
         }

--- a/AestraUI/Widgets/PianoRollNoteLayer.cpp
+++ b/AestraUI/Widgets/PianoRollNoteLayer.cpp
@@ -13,6 +13,11 @@
 
 namespace AestraUI {
 
+namespace {
+constexpr float SELECTION_STRETCH_HANDLE_WIDTH = 9.0f;
+constexpr float SELECTION_STRETCH_HANDLE_HEIGHT = 16.0f;
+} // namespace
+
 // =============================================================================
 // PianoRollNoteLayer (split from NUIPianoRollWidgets.cpp)
 // =============================================================================
@@ -648,6 +653,20 @@ void PianoRollNoteLayer::onRender(NUIRenderer& renderer) {
         }
     }
 
+    // A multi-note selection exposes one time-transform frame. Dragging the
+    // right handle scales both note spacing and note lengths around the
+    // earliest selected start, preserving the phrase's internal rhythm.
+    const NUIRect selectionBounds = selectionTimeBoundsRect();
+    if (selectionBounds.width > 0.0f && selectionBounds.height > 0.0f) {
+        const auto accent = themeManager.getColor("accentSecondary");
+        renderer.strokeRoundedRect(selectionBounds, 3.0f, 1.0f, accent.withAlpha(0.68f));
+        const NUIRect handle = selectionStretchHandleRect();
+        renderer.fillRoundedRect(handle, 3.0f,
+                                 accent.lightened(hoverOnSelectionStretch_ ? 0.24f : 0.10f)
+                                     .withAlpha(hoverOnSelectionStretch_ ? 1.0f : 0.88f));
+        renderer.strokeRoundedRect(handle, 3.0f, 1.0f, NUIColor::white().withAlpha(0.82f));
+    }
+
     // Draw-mode preview: a translucent phantom of the note a click would place,
     // tracking the snapped cursor cell so placement reads before you commit it.
     // Only while the pencil hovers empty space — never over an existing note.
@@ -781,6 +800,42 @@ int PianoRollNoteLayer::findNoteAt(float localX, float localY) {
     return findNoteAtLocal(notes_, localX, localY, pixelsPerBeat_, keyHeight_);
 }
 
+NUIRect PianoRollNoteLayer::selectionTimeBoundsRect() const {
+    size_t selectedCount = 0;
+    double startBeat = std::numeric_limits<double>::max();
+    double endBeat = 0.0;
+    int highestPitch = 0;
+    int lowestPitch = 127;
+
+    for (const auto& note : notes_) {
+        if (!note.selected || note.isDeleted)
+            continue;
+        ++selectedCount;
+        startBeat = std::min(startBeat, note.startBeat);
+        endBeat = std::max(endBeat, note.startBeat + note.durationBeats);
+        highestPitch = std::max(highestPitch, note.pitch);
+        lowestPitch = std::min(lowestPitch, note.pitch);
+    }
+    if (selectedCount < 2 || endBeat <= startBeat)
+        return NUIRect(0.0f, 0.0f, 0.0f, 0.0f);
+
+    const auto bounds = getBounds();
+    const float left = bounds.x + static_cast<float>(startBeat * pixelsPerBeat_) - scrollX_;
+    const float right = bounds.x + static_cast<float>(endBeat * pixelsPerBeat_) - scrollX_;
+    const float top = bounds.y + static_cast<float>(127 - highestPitch) * keyHeight_ - scrollY_ + 1.0f;
+    const float bottom = bounds.y + static_cast<float>(128 - lowestPitch) * keyHeight_ - scrollY_ - 1.0f;
+    return NUIRect(left, top, std::max(1.0f, right - left), std::max(1.0f, bottom - top));
+}
+
+NUIRect PianoRollNoteLayer::selectionStretchHandleRect() const {
+    const NUIRect selection = selectionTimeBoundsRect();
+    if (selection.width <= 0.0f || selection.height <= 0.0f)
+        return NUIRect(0.0f, 0.0f, 0.0f, 0.0f);
+    return NUIRect(selection.right() - SELECTION_STRETCH_HANDLE_WIDTH * 0.5f,
+                   selection.y + (selection.height - SELECTION_STRETCH_HANDLE_HEIGHT) * 0.5f,
+                   SELECTION_STRETCH_HANDLE_WIDTH, SELECTION_STRETCH_HANDLE_HEIGHT);
+}
+
 bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     if (state_ == State::None && !getBounds().contains(event.position)) {
         // Reset hover when leaving bounds
@@ -789,6 +844,12 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             hoverOnRightEdge_ = false;
             hoverOnLeftEdge_ = false;
             if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
+        }
+        if (hoverOnSelectionStretch_) {
+            hoverOnSelectionStretch_ = false;
+            if (platformBridge_)
+                platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
+            repaint();
         }
         if (hoveredPitch_ != -1) {
             hoveredPitch_ = -1;
@@ -810,8 +871,8 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     // double as the fine toggle there. Recomputed every event so it can never
     // go stale between gestures.
     fineDrag_ = (event.modifiers & NUIModifiers::Alt) &&
-                (state_ == State::Painting || state_ == State::Moving ||
-                 state_ == State::Resizing || state_ == State::ResizingLeft);
+                (state_ == State::Painting || state_ == State::Moving || state_ == State::Resizing ||
+                 state_ == State::ResizingLeft || state_ == State::StretchingSelection);
 
     // The Note Properties popup is modal within the layer while open.
     if (propNoteIndex_ >= 0) {
@@ -830,6 +891,22 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
 
     // --- HOVER / SMART CURSOR (no button activity) ---
     if (state_ == State::None && !event.pressed && !event.released) {
+        const bool onSelectionStretch =
+            tool_ != GlobalTool::Eraser && selectionStretchHandleRect().contains(event.position);
+        if (hoverOnSelectionStretch_ != onSelectionStretch) {
+            hoverOnSelectionStretch_ = onSelectionStretch;
+            repaint();
+        }
+        if (onSelectionStretch) {
+            hoveredNoteIndex_ = -1;
+            hoverOnRightEdge_ = false;
+            hoverOnLeftEdge_ = false;
+            hoverBeat_ = -1.0;
+            if (platformBridge_)
+                platformBridge_->setCursorStyle(NUICursorStyle::ResizeEW);
+            return true;
+        }
+
         int hitIdx = findNoteAt(localX, localY);
         // Track the snapped beat the cursor sits on so the pencil can render a
         // phantom of the note a click would place. Only meaningful over empty
@@ -945,6 +1022,22 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
     // --- LEFT CLICK HANDLING ---
     if (event.pressed && event.button == NUIMouseButton::Left) {
         setFocused(true); // Gain keyboard focus for shortcuts
+
+        // The shared handle takes precedence over the right edge of the last
+        // selected note. Its gesture changes the complete phrase timing,
+        // whereas an ordinary note-edge drag still resizes lengths only.
+        if (tool_ != GlobalTool::Eraser && selectionStretchHandleRect().contains(event.position)) {
+            state_ = State::StretchingSelection;
+            dragStartPos_ = event.position;
+            dragStartScrollX_ = scrollX_;
+            dragStartNotes_ = notes_;
+            hoverOnSelectionStretch_ = true;
+            if (platformBridge_)
+                platformBridge_->setCursorStyle(NUICursorStyle::ResizeEW);
+            repaint();
+            return true;
+        }
+
         int clickedIndex = findNoteAt(localX, localY);
 
         // The platform never sets event.doubleClick, so detect it here: a
@@ -1363,8 +1456,35 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             }
             repaint();
             return true;
-        }
-        else if (state_ == State::CopyDragging) {
+        } else if (state_ == State::StretchingSelection) {
+            double anchorBeat = std::numeric_limits<double>::max();
+            double originalEndBeat = 0.0;
+            double minimumFactor = 0.0;
+            for (const auto& note : dragStartNotes_) {
+                if (!note.selected || note.isDeleted)
+                    continue;
+                anchorBeat = std::min(anchorBeat, note.startBeat);
+                originalEndBeat = std::max(originalEndBeat, note.startBeat + note.durationBeats);
+                minimumFactor = std::max(minimumFactor, 0.125 / std::max(0.125, note.durationBeats));
+            }
+
+            const double originalSpan = originalEndBeat - anchorBeat;
+            if (std::isfinite(anchorBeat) && originalSpan > 0.0001) {
+                const double cursorBeat = std::max(anchorBeat, static_cast<double>(localX) / pixelsPerBeat_);
+                const double targetEndBeat =
+                    std::max(anchorBeat + originalSpan * minimumFactor, snapToGrid(cursorBeat));
+                const double factor = std::max(minimumFactor, (targetEndBeat - anchorBeat) / originalSpan);
+                for (size_t i = 0; i < notes_.size() && i < dragStartNotes_.size(); ++i) {
+                    const auto& original = dragStartNotes_[i];
+                    if (!original.selected || original.isDeleted)
+                        continue;
+                    notes_[i].startBeat = anchorBeat + (original.startBeat - anchorBeat) * factor;
+                    notes_[i].durationBeats = std::max(0.125, original.durationBeats * factor);
+                }
+            }
+            repaint();
+            return true;
+        } else if (state_ == State::CopyDragging) {
             float dx = (event.position.x - dragStartPos_.x) + (scrollX_ - dragStartScrollX_);
             float dy = (event.position.y - dragStartPos_.y) + (scrollY_ - dragStartScrollY_);
 
@@ -1412,14 +1532,19 @@ bool PianoRollNoteLayer::onMouseEvent(const NUIMouseEvent& event) {
             // Update Memory
             if (state_ == State::Painting && paintingNoteIndex_ != -1) {
                 lastNoteDuration_ = notes_[paintingNoteIndex_].durationBeats;
-            } else if (state_ == State::Resizing || state_ == State::ResizingLeft) {
+            } else if (state_ == State::Resizing || state_ == State::ResizingLeft ||
+                       state_ == State::StretchingSelection) {
                 for (const auto& n : notes_) { if (n.selected) { lastNoteDuration_ = n.durationBeats; break; } }
             }
 
-            pushUndo(state_ == State::CopyDragging ? "Alt+Drag Copy" : "Edit", dragStartNotes_, notes_);
+            const std::string description = state_ == State::CopyDragging
+                                                ? "Alt+Drag Copy"
+                                                : (state_ == State::StretchingSelection ? "Stretch Selection" : "Edit");
+            pushUndo(description, dragStartNotes_, notes_);
             state_ = State::None;
             paintingNoteIndex_ = -1;
             copyDragIndices_.clear();
+            hoverOnSelectionStretch_ = false;
             if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
             commitNotes();
             repaint();

--- a/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
@@ -146,6 +146,12 @@ void testSelectionHandleStretchesPhraseTimingAsOneEdit() {
     // 4, vertically centred on the selection frame; drag it to beat 8.
     constexpr float HANDLE_Y = 1572.0f;
     check(layer.onMouseEvent(mouseDown(320.0f, HANDLE_Y, NUIMouseButton::Left)),
+          "unchanged selection stretch press should be handled");
+    check(layer.onMouseEvent(mouseUp(320.0f, HANDLE_Y, NUIMouseButton::Left)),
+          "unchanged selection stretch release should be handled");
+    check(commits == 0, "an unchanged selection stretch should not commit");
+
+    check(layer.onMouseEvent(mouseDown(320.0f, HANDLE_Y, NUIMouseButton::Left)),
           "selection stretch handle press should be handled");
     check(layer.onMouseEvent(mouseDrag(640.0f, HANDLE_Y, NUIMouseButton::Left)),
           "selection stretch drag should be handled");

--- a/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
@@ -123,11 +123,56 @@ void testRightDragEraseIsOneUndoableStroke() {
     check(layer.getNotes().size() == 3, "one undo should restore the complete erase stroke");
 }
 
+void testSelectionHandleStretchesPhraseTimingAsOneEdit() {
+    PianoRollNoteLayer layer;
+    layer.setBounds({0.0f, 0.0f, 800.0f, 3072.0f});
+    layer.setSnap(SnapGrid::Beat);
+
+    MidiNote root;
+    root.pitch = 60;
+    root.startBeat = 0.0;
+    root.durationBeats = 1.0;
+    root.selected = true;
+    MidiNote upper = root;
+    upper.pitch = 64;
+    upper.startBeat = 2.0;
+    upper.durationBeats = 2.0;
+    layer.setNotes({root, upper});
+
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+
+    // The two selected notes span beats 0..4. Their shared handle sits at beat
+    // 4, vertically centred on the selection frame; drag it to beat 8.
+    constexpr float HANDLE_Y = 1572.0f;
+    check(layer.onMouseEvent(mouseDown(320.0f, HANDLE_Y, NUIMouseButton::Left)),
+          "selection stretch handle press should be handled");
+    check(layer.onMouseEvent(mouseDrag(640.0f, HANDLE_Y, NUIMouseButton::Left)),
+          "selection stretch drag should be handled");
+    check(layer.onMouseEvent(mouseUp(640.0f, HANDLE_Y, NUIMouseButton::Left)),
+          "selection stretch release should be handled");
+
+    const auto& stretched = layer.getNotes();
+    check(stretched.size() == 2, "selection stretch must preserve note count");
+    check(std::abs(stretched[0].startBeat - 0.0) < 0.001 && std::abs(stretched[0].durationBeats - 2.0) < 0.001,
+          "selection stretch should keep the anchor and scale its length");
+    check(std::abs(stretched[1].startBeat - 4.0) < 0.001 && std::abs(stretched[1].durationBeats - 4.0) < 0.001,
+          "selection stretch should scale later starts and lengths proportionally");
+    check(commits == 1, "selection stretch should commit once on release");
+
+    layer.undo();
+    const auto& restored = layer.getNotes();
+    check(std::abs(restored[0].durationBeats - 1.0) < 0.001 && std::abs(restored[1].startBeat - 2.0) < 0.001 &&
+              std::abs(restored[1].durationBeats - 2.0) < 0.001,
+          "one undo should restore the complete phrase timing");
+}
+
 } // namespace
 
 int main() {
     testChordBrushPaintsCompleteTriadsAsOneEdit();
     testRightDragEraseIsOneUndoableStroke();
+    testSelectionHandleStretchesPhraseTimingAsOneEdit();
 
     if (g_failures == 0) {
         std::cout << "Piano Roll stroke interaction tests passed\n";


### PR DESCRIPTION
## Summary

- draw a shared transform frame around multi-note Piano Roll selections
- add a right-side handle that proportionally scales note starts and lengths around the earliest selected start
- keep the gesture snapped by default, allow Alt-held fine positioning, and commit it as one undoable edit
- cover the real pointer gesture, proportional result, commit count, and undo restoration

## Why

Dragging an individual selected note edge resized every selected note's duration, but there was no way to stretch or compress a complete phrase while preserving its internal rhythm. This adds the missing phrase-level time transform without introducing a separate editing mode.

## Testing performed

- `cmake --build build-linux --target Aestra PianoRollInteractionTest PianoRollStrokeInteractionTest PianoRollPanelPersistenceTest -j2`
- `ctest --test-dir build-linux -R '^(PianoRollInteractionTest|PianoRollStrokeInteractionTest|PianoRollPanelPersistenceTest)$' --output-on-failure -j2` — 3/3 passed
- `git diff --cached --check`
- searched changed files for prohibited inspiration references — no matches
- running-app visual confirmation: created and selected a real phrase, confirmed the shared frame/hover handle, dragged it, and observed proportional note spacing/length changes plus automatic pattern-length growth
- application exited cleanly with code 0 and cleared its crash flag

## Producer note

You can now stretch a selected Piano Roll phrase while preserving its internal timing.

## Docs updated?

No. The visible handle and cursor affordance expose the interaction in context.

## Risk / rollback

- UI interaction only; DSP, latency, project format, and plugin state are unchanged
- note edits continue through the existing Piano Roll save and undo paths
- the transform clamps every note to the existing 0.125-beat minimum
- rollback: revert `d572bc0e`

## Decision citation

Objective: Piano Roll editing parity — phrase-level time transforms
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: planned
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added proportional stretching for multi-note Piano Roll selections with a shared frame and right-side handle.
- Preserved internal rhythm by scaling note starts and durations from the earliest selected start.
- Added grid snapping, Alt-held fine positioning, minimum note lengths, edge scrolling, and one-step undo support.
- Added interaction coverage for proportional stretching, single-commit undo, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->