### PR TITLE
feat: piano roll selection subdivision by snap

### DIFF
--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -445,6 +445,14 @@ public:
     /** @brief Merge overlapping/touching selected notes on the same pitch into one. */
     void glueSelectedNotes();
 
+    /**
+     * @brief Split selected notes into consecutive cells of the current snap duration.
+     *
+     * The final cell retains any remainder so the operation never changes a
+     * note's start, end, pitch, expression, or unit routing.
+     */
+    void subdivideSelectedNotes();
+
     /** @brief Add slight random velocity variation to the selected notes. */
     void humanizeSelectedVelocities();
 

--- a/AestraUI/Widgets/PianoRollNoteLayer.cpp
+++ b/AestraUI/Widgets/PianoRollNoteLayer.cpp
@@ -244,6 +244,53 @@ void PianoRollNoteLayer::glueSelectedNotes() {
     repaint();
 }
 
+void PianoRollNoteLayer::subdivideSelectedNotes() {
+    constexpr double kSubdivisionEpsilon = 1.0e-9;
+    const double snapDuration = MusicTheory::getSnapDuration(snap_);
+    if (!std::isfinite(snapDuration) || snapDuration <= kSubdivisionEpsilon) return;
+
+    auto oldNotes = notes_;
+    std::vector<MidiNote> rebuilt;
+    rebuilt.reserve(notes_.size());
+    bool changed = false;
+
+    for (const auto& note : notes_) {
+        const bool canSubdivide = note.selected && !note.isDeleted && std::isfinite(note.startBeat) &&
+                                  std::isfinite(note.durationBeats) &&
+                                  note.durationBeats > snapDuration + kSubdivisionEpsilon;
+        if (!canSubdivide) {
+            rebuilt.push_back(note);
+            continue;
+        }
+
+        double remaining = note.durationBeats;
+        double segmentStart = note.startBeat;
+        while (remaining > snapDuration + kSubdivisionEpsilon) {
+            MidiNote segment = note;
+            segment.startBeat = segmentStart;
+            segment.durationBeats = snapDuration;
+            segment.selected = true;
+            rebuilt.push_back(segment);
+            segmentStart += snapDuration;
+            remaining -= snapDuration;
+        }
+
+        MidiNote finalSegment = note;
+        finalSegment.startBeat = segmentStart;
+        finalSegment.durationBeats = remaining;
+        finalSegment.selected = true;
+        rebuilt.push_back(finalSegment);
+        changed = true;
+    }
+
+    if (!changed) return;
+
+    notes_ = std::move(rebuilt);
+    pushUndo("Subdivide", oldNotes, notes_);
+    commitNotes();
+    repaint();
+}
+
 void PianoRollNoteLayer::strumSelectedNotes(double spreadBeats) {
     std::vector<int> selected;
     for (size_t i = 0; i < notes_.size(); ++i) {
@@ -1612,13 +1659,18 @@ bool PianoRollNoteLayer::onKeyEvent(const NUIKeyEvent& event) {
         }
 
         // Q: quantize selected note starts to the grid. Ctrl+G: glue selected
-        // notes on the same pitch into one. Both are no-ops without a selection.
+        // notes on the same pitch into one. Ctrl+Shift+G performs the inverse
+        // rhythmic operation, splitting selected notes by the current snap.
         if (!ctrl && event.keyCode == NUIKeyCode::Q) {
             quantizeSelectedNotes();
             return true;
         }
         if (ctrl && event.keyCode == NUIKeyCode::G) {
-            glueSelectedNotes();
+            if (event.modifiers & NUIModifiers::Shift) {
+                subdivideSelectedNotes();
+            } else {
+                glueSelectedNotes();
+            }
             return true;
         }
 

--- a/AestraUI/Widgets/PianoRollToolbar.cpp
+++ b/AestraUI/Widgets/PianoRollToolbar.cpp
@@ -115,6 +115,11 @@ void PianoRollToolbar::setupUI() {
         }
         menu->addSubmenu("Strum Selection", strumMenu);
 
+        // --- SUBDIVIDE ---
+        menu->addItem("Subdivide Selection", [this]() {
+            if (auto n = notes_.lock()) n->subdivideSelectedNotes();
+        });
+
         // --- HUMANIZE ---
         menu->addItem("Humanize Velocity", [this]() {
             if (auto n = notes_.lock()) n->humanizeSelectedVelocities();

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -237,7 +237,7 @@ void PianoRollView::renderShortcutHelp(NUIRenderer& renderer) {
     };
     static constexpr Entry kKeys[] = {
         {"Q", "quantize note starts"},
-        {"Ctrl+G", "glue same-pitch runs"},
+        {"Ctrl+G / Ctrl+Shift+G", "glue runs / subdivide by snap"},
         {"Ctrl+L", "connect notes (legato)"},
         {"Ctrl+Z / Y", "undo / redo"},
         {"Ctrl+C / V / D", "copy / paste / duplicate"},

--- a/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollStrokeInteractionTest.cpp
@@ -49,6 +49,14 @@ NUIMouseEvent mouseUp(float x, float y, NUIMouseButton button, NUIModifiers modi
     return event;
 }
 
+NUIKeyEvent keyPress(NUIKeyCode keyCode, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIKeyEvent event;
+    event.keyCode = keyCode;
+    event.modifiers = modifiers;
+    event.pressed = true;
+    return event;
+}
+
 float pitchRowCenter(int pitch) {
     return static_cast<float>(127 - pitch) * 24.0f + 12.0f;
 }
@@ -173,12 +181,103 @@ void testSelectionHandleStretchesPhraseTimingAsOneEdit() {
           "one undo should restore the complete phrase timing");
 }
 
+void testSubdivideSelectionUsesSnapAndPreservesNoteData() {
+    PianoRollNoteLayer layer;
+    layer.setSnap(SnapGrid::Quarter);
+
+    MidiNote selected;
+    selected.pitch = 60;
+    selected.startBeat = 0.125;
+    selected.durationBeats = 0.75;
+    selected.velocity = 0.61f;
+    selected.pan = -0.3f;
+    selected.unitId = 42;
+    selected.selected = true;
+
+    MidiNote untouched = selected;
+    untouched.pitch = 64;
+    untouched.startBeat = 2.0;
+    untouched.durationBeats = 1.0;
+    untouched.selected = false;
+    layer.setNotes({selected, untouched});
+
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+    check(layer.onKeyEvent(keyPress(NUIKeyCode::G, NUIModifiers::Ctrl | NUIModifiers::Shift)),
+          "Ctrl+Shift+G should route to subdivision");
+
+    const auto& notes = layer.getNotes();
+    check(notes.size() == 4, "subdivision should replace one three-cell note without touching other notes");
+    for (double beat : {0.125, 0.375, 0.625}) {
+        const auto fragment = std::find_if(notes.begin(), notes.end(), [beat](const MidiNote& note) {
+            return note.pitch == 60 && std::abs(note.startBeat - beat) < 0.001;
+        });
+        check(fragment != notes.end(), "subdivision should preserve each sequential segment start");
+        if (fragment != notes.end()) {
+            check(std::abs(fragment->durationBeats - 0.25) < 0.001,
+                  "subdivision should use the current snap duration");
+            check(fragment->selected && std::abs(fragment->velocity - 0.61f) < 0.001f &&
+                      std::abs(fragment->pan + 0.3f) < 0.001f && fragment->unitId == 42,
+                  "subdivision should preserve selected-note expression and routing");
+        }
+    }
+    check(std::any_of(notes.begin(), notes.end(), [](const MidiNote& note) {
+              return note.pitch == 64 && !note.selected && std::abs(note.startBeat - 2.0) < 0.001 &&
+                     std::abs(note.durationBeats - 1.0) < 0.001;
+          }),
+          "subdivision should leave unselected notes unchanged");
+    check(commits == 1, "subdivision should commit once");
+
+    layer.undo();
+    const auto& restored = layer.getNotes();
+    check(restored.size() == 2, "one undo should restore the original selected note");
+    const auto original = std::find_if(restored.begin(), restored.end(), [](const MidiNote& note) {
+        return note.pitch == 60;
+    });
+    check(original != restored.end() && std::abs(original->startBeat - 0.125) < 0.001 &&
+              std::abs(original->durationBeats - 0.75) < 0.001,
+          "undo should restore the original note timing");
+}
+
+void testSubdividePreservesPartialTailAndHonorsNoSnap() {
+    PianoRollNoteLayer layer;
+    layer.setSnap(SnapGrid::Quarter);
+
+    MidiNote note;
+    note.pitch = 72;
+    note.startBeat = 1.0;
+    note.durationBeats = 0.6;
+    note.selected = true;
+    layer.setNotes({note});
+    layer.subdivideSelectedNotes();
+
+    const auto& subdivided = layer.getNotes();
+    check(subdivided.size() == 3, "a partial final grid cell should become its own note");
+    check(std::abs(subdivided[0].durationBeats - 0.25) < 0.001 &&
+              std::abs(subdivided[1].durationBeats - 0.25) < 0.001 &&
+              std::abs(subdivided[2].durationBeats - 0.1) < 0.001,
+          "subdivision should retain the exact final remainder");
+    check(std::abs(subdivided.back().startBeat + subdivided.back().durationBeats - 1.6) < 0.001,
+          "subdivision should preserve the selected note's original end");
+
+    layer.undo();
+    layer.setSnap(SnapGrid::None);
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+    layer.subdivideSelectedNotes();
+    check(layer.getNotes().size() == 1 && std::abs(layer.getNotes()[0].durationBeats - 0.6) < 0.001,
+          "subdivision should not invent a grid when snapping is disabled");
+    check(commits == 0, "a no-snap subdivision should not create an edit");
+}
+
 } // namespace
 
 int main() {
     testChordBrushPaintsCompleteTriadsAsOneEdit();
     testRightDragEraseIsOneUndoableStroke();
     testSelectionHandleStretchesPhraseTimingAsOneEdit();
+    testSubdivideSelectionUsesSnapAndPreservesNoteData();
+    testSubdividePreservesPartialTailAndHonorsNoSnap();
 
     if (g_failures == 0) {
         std::cout << "Piano Roll stroke interaction tests passed\n";


### PR DESCRIPTION
## Summary

- add Subdivide Selection to the Piano Roll: Ctrl+Shift+G (or the toolbar menu) splits each selected note into consecutive cells of the current snap duration
- keep the final partial cell as its own note so a note's start, end, pitch, velocity, pan, and unit routing never change
- commit the whole operation as one undoable edit; no-op when snapping is off or a note already fits in one cell
- cover cell layout, expression/routing preservation, partial-tail handling, commit count, and undo restoration in the stroke interaction test

## Why

Glue (Ctrl+G) merges same-pitch runs into one note; there was no inverse operation to break a long note into snap-aligned pieces. Subdivide gives producers the rhythmic inverse without leaving the Piano Roll.

## Testing performed

- `cmake --build build-linux --target PianoRollStrokeInteractionTest -j2`
- `ctest --test-dir build-linux -R '^(PianoRollInteractionTest|PianoRollStrokeInteractionTest|PianoRollPanelPersistenceTest)$' --output-on-failure -j2` — 3/3 passed
- `git diff --check` — clean
- searched changed files for prohibited product-reference strings — no matches

## Producer note

You can now split a selected Piano Roll note into snap-sized pieces.

## Docs updated?

No. The shortcut help overlay already lists Ctrl+G; the updated line covers the new Ctrl+Shift+G variant.

## Risk / rollback

- UI interaction only; DSP, latency, project format, and plugin state are unchanged
- note edits continue through the existing Piano Roll save and undo paths
- the operation preserves exact note timing and expression; only the count of notes changes
- rollback: revert `e408bc04`

## Decision citation

Objective: Piano Roll editing parity — rhythmic note operations
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: planned
Reversal: —


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added **Subdivide Selection** to the Piano Roll through the toolbar menu and `Ctrl+Shift+G`.
- Splits selected notes into current snap-duration cells while preserving timing, pitch, velocity, pan, unit routing, and final partial cells.
- Records the operation as one undoable edit. The operation does nothing when snapping is disabled or notes already fit within one cell.
- Updated shortcut help and added coverage for splitting, metadata preservation, partial tails, undo, and no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->