### PR TITLE
fix(piano-roll): grid, transport, panel, and sampler bug triage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,11 @@ labs/reverb/listening/
 labs/reverb/tremolo/ab/
 labs/reverb/tremolo/proto/
 
+# Perf lab apparatus results and local WIP: fixtures, tools, and collected
+# runs of the Folio baseline apparatus, not source. Tracked specs/reports
+# stay tracked; the apparatus source itself lives on perf/* branches.
+labs/perf/
+
 # CTest scratch written into the SOURCE tree when ctest runs from the repo root
 # rather than from a build directory. Generated scheduling data, never source.
 /Testing/

--- a/AestraAudio/include/Plugin/SamplerPlugin.h
+++ b/AestraAudio/include/Plugin/SamplerPlugin.h
@@ -71,6 +71,7 @@ public:
     void setMaxVoices(int maxVoices) noexcept;
     void setRootMidiNote(int note) noexcept;
     void setMonoMode(bool mono) noexcept;
+    void setCutSelfMode(bool cutSelf) noexcept;
     void setGlideTimeMs(float glideTimeMs) noexcept;
     bool normalizeSample(float targetPeak = 0.95f);
     bool reverseSample();
@@ -84,6 +85,7 @@ public:
     int getMaxVoices() const noexcept { return m_maxVoices.load(std::memory_order_relaxed); }
     int getRootMidiNote() const noexcept { return m_rootMidiNote.load(std::memory_order_relaxed); }
     bool isMonoMode() const noexcept { return m_monoMode.load(std::memory_order_relaxed); }
+    bool isCutSelfMode() const noexcept { return m_cutSelfMode.load(std::memory_order_relaxed); }
     float getGlideTimeMs() const noexcept { return m_glideTimeMs.load(std::memory_order_relaxed); }
     float getAttack() const noexcept { return m_params[kParamAttack].load(std::memory_order_relaxed); }
     float getDecay() const noexcept { return m_params[kParamDecay].load(std::memory_order_relaxed); }
@@ -120,6 +122,7 @@ private:
     std::atomic<int> m_maxVoices{4};
     std::atomic<int> m_rootMidiNote{60}; // C3 default
     std::atomic<bool> m_monoMode{false};
+    std::atomic<bool> m_cutSelfMode{false};
     std::atomic<float> m_glideTimeMs{80.0f};
 
     // Voice Architecture

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -651,6 +651,20 @@ void AudioEngine::performNonRealtimeMaintenance() {
                         // writes them at different points) and schedule an epoch
                         // ahead, starving legitimate events.
                         currentFrame = m_patternMonotonicFrame.load(std::memory_order_acquire);
+                        // A transport restart cued mid-pattern (scrubbed piano-roll
+                        // playhead, pause→resume) leaves the monotonic frame at 0 —
+                        // it was reset while stopped and is only republished by the
+                        // first playing block. Refilling from that stale 0 would queue
+                        // the loop-top events, which a playhead past the loop top
+                        // would fire at the buffer edge ("starts from beat 1"). The
+                        // cued global position IS the monotonic domain start here
+                        // (iteration is 0), so refill from it instead.
+                        if (currentFrame == 0) {
+                            const uint64_t cuedPos = m_globalSamplePos.load(std::memory_order_relaxed);
+                            if (cuedPos > 0) {
+                                currentFrame = cuedPos;
+                            }
+                        }
                     }
                 }
             }
@@ -793,10 +807,22 @@ int AudioEngine::processBlock(float* outputBuffer, const float* inputBuffer, uin
     const bool transportRestart = m_transportRestartRequested.exchange(false, std::memory_order_acq_rel);
     const bool transportHardStop = m_transportHardStopRequested.exchange(false, std::memory_order_acq_rel);
 
-    // Pattern mode semantics: stop/restart always resets playhead to the pattern start.
+    // Pattern mode: honor a cued playhead (a scrubbed piano-roll position, or the
+    // position preserved by a pause) instead of resetting to the pattern top on every
+    // stop/restart edge. Only a cue at or past the loop end — e.g. a stale timeline
+    // position entering pattern mode — is wrapped back into the loop, matching the
+    // render path's wrap logic below.
     const bool patternModeNow = m_patternPlaybackMode.load(std::memory_order_relaxed);
     if (patternModeNow && (transportStop || transportRestart)) {
-        m_globalSamplePos.store(0, std::memory_order_relaxed);
+        const uint64_t cuedPos = m_globalSamplePos.load(std::memory_order_relaxed);
+        const double samplesPerBeat =
+            (static_cast<double>(m_sampleRate.load(std::memory_order_relaxed)) * 60.0) /
+            std::max(static_cast<double>(m_metronomeEngine.getBPM()), 1.0);
+        const uint64_t loopEndSample =
+            static_cast<uint64_t>(m_patternLengthBeats.load(std::memory_order_relaxed) * samplesPerBeat);
+        if (loopEndSample > 0 && cuedPos >= loopEndSample) {
+            m_globalSamplePos.store(cuedPos % loopEndSample, std::memory_order_relaxed);
+        }
     }
 
     // A transport restart is a semantic metronome discontinuity even when the

--- a/AestraAudio/src/Plugin/SamplerPlugin.cpp
+++ b/AestraAudio/src/Plugin/SamplerPlugin.cpp
@@ -105,6 +105,10 @@ void SamplerPlugin::setMonoMode(bool mono) noexcept {
     m_monoMode.store(mono, std::memory_order_relaxed);
 }
 
+void SamplerPlugin::setCutSelfMode(bool cutSelf) noexcept {
+    m_cutSelfMode.store(cutSelf, std::memory_order_relaxed);
+}
+
 void SamplerPlugin::setGlideTimeMs(float glideTimeMs) noexcept {
     m_glideTimeMs.store(std::clamp(glideTimeMs, 0.0f, 2000.0f), std::memory_order_relaxed);
 }
@@ -557,6 +561,23 @@ void SamplerPlugin::handleMidiEvent(const MidiBuffer::Event& event, double baseR
         }
 
         const int maxVoices = std::clamp(m_maxVoices.load(std::memory_order_relaxed), 1, kMaxVoices);
+
+        // Cut-self: a new trigger on the same note chokes any previous voice
+        // playing it, so retriggered one-shots (e.g. an 808 in an ordinary
+        // sampler) never overlap. Explicit voice-layer policy — independent
+        // of mono mode, ADSR, and unit type. Different notes stay polyphonic.
+        if (m_cutSelfMode.load(std::memory_order_relaxed)) {
+            for (auto& v : m_voices) {
+                if (v.active && v.note == note) {
+                    v.active = false;
+                    v.stage = EnvStage::Off;
+                    v.stageTime = 0.0;
+                    v.currentGain = 0.0f;
+                    v.releaseGain = 0.0f;
+                }
+            }
+        }
+
         double noteStartFrame = 0.0;
         if (currentData && currentData->channels > 0) {
             const double totalFrames = static_cast<double>(currentData->data.size() / currentData->channels);
@@ -725,6 +746,7 @@ std::vector<uint8_t> SamplerPlugin::saveState() const {
     json.set("maxVoices", Aestra::JSON(static_cast<double>(m_maxVoices.load(std::memory_order_relaxed))));
     json.set("rootMidiNote", Aestra::JSON(static_cast<double>(m_rootMidiNote.load(std::memory_order_relaxed))));
     json.set("monoMode", Aestra::JSON(m_monoMode.load(std::memory_order_relaxed)));
+    json.set("cutSelfMode", Aestra::JSON(m_cutSelfMode.load(std::memory_order_relaxed)));
     json.set("glideTimeMs", Aestra::JSON(static_cast<double>(m_glideTimeMs.load(std::memory_order_relaxed))));
 
     // Sample Path
@@ -782,6 +804,9 @@ bool SamplerPlugin::loadState(const std::vector<uint8_t>& state) {
     }
     if (json.has("monoMode")) {
         setMonoMode(json["monoMode"].asBool());
+    }
+    if (json.has("cutSelfMode")) {
+        setCutSelfMode(json["cutSelfMode"].asBool());
     }
     if (json.has("glideTimeMs")) {
         setGlideTimeMs(static_cast<float>(json["glideTimeMs"].asNumber()));

--- a/AestraUI/Helpers/TimelineGridRenderer.h
+++ b/AestraUI/Helpers/TimelineGridRenderer.h
@@ -45,7 +45,8 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
                                float pixelsPerBeat,
                                int beatsPerBar,
                                const NUIColor& ink = NUIColor::white(),
-                               const TimelineGridStyle& style = {}) {
+                               const TimelineGridStyle& style = {},
+                               double subdivisionBeats = 0.0) {
     const float gridWidth = std::max(0.0f, gridEndX - gridStartX);
     beatsPerBar = std::max(1, beatsPerBar);
     const float pixelsPerBar = pixelsPerBeat * static_cast<float>(beatsPerBar);
@@ -136,6 +137,32 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
                 const float subBeatX = barX + beat * pixelsPerBeat + halfBeatOffset;
                 if (subBeatX >= gridStartX && subBeatX <= gridEndX) {
                     drawGridLine(subBeatX, halfBeatLineAlpha);
+                }
+            }
+        }
+
+        // Optional snap-aligned subdivision tier. The caller (e.g. the piano
+        // roll grid) passes the active snap duration so every position notes
+        // snap to is actually drawn. Lines that coincide with beat or bar
+        // lines are skipped — those tiers already own them.
+        if (subdivisionBeats > 0.0 && subdivisionBeats < 0.5) {
+            const float subPixels = pixelsPerBeat * static_cast<float>(subdivisionBeats);
+            const float subAlpha = style.subdivisionLineAlpha * timelineGridLevelFade(subPixels);
+            if (subAlpha > 0.001f) {
+                const double sub = subdivisionBeats;
+                const double firstSub = std::ceil((static_cast<double>(bar) * beatsPerBar) / sub);
+                const double lastSub =
+                    std::floor((static_cast<double>(bar + 1) * beatsPerBar - 1e-9) / sub);
+                for (double k = firstSub; k <= lastSub; ++k) {
+                    const double lineBeat = k * sub;
+                    const double nearestBeat = std::round(lineBeat);
+                    const double nearestBar = std::round(lineBeat / beatsPerBar);
+                    if (std::abs(lineBeat - nearestBeat) < 1e-9 ||
+                        std::abs(lineBeat - nearestBar * beatsPerBar) < 1e-9) {
+                        continue;
+                    }
+                    const float subX = gridStartX + static_cast<float>(lineBeat * pixelsPerBeat) - scrollX;
+                    if (subX >= gridStartX && subX <= gridEndX) drawGridLine(subX, subAlpha);
                 }
             }
         }

--- a/AestraUI/Helpers/TimelineGridRenderer.h
+++ b/AestraUI/Helpers/TimelineGridRenderer.h
@@ -32,6 +32,22 @@ inline int timelineGridBarStride(float pixelsPerBeat, int beatsPerBar) {
 }
 
 /**
+ * Whether a grid tier of the given duration may be drawn under the active snap.
+ *
+ * The grid must never advertise positions the snap does not allow: a tier of
+ * duration d is only musical when the snap duration divides it evenly (e.g. at
+ * snap-to-beat a half-beat tier would show 1/2 as possible, so it is hidden).
+ * Zero/absent snap keeps every tier, which is the timeline grid's contract.
+ */
+inline bool timelineGridTierAlignedToSnap(double tierBeats, double subdivisionBeats) {
+    if (subdivisionBeats <= 0.0) {
+        return true;
+    }
+    const double ratio = tierBeats / subdivisionBeats;
+    return std::abs(ratio - std::round(ratio)) < 1e-4;
+}
+
+/**
  * Draw the canonical Track Manager timeline grid inside an arbitrary grid span.
  *
  * The power-of-two hierarchy and zebra crossfade stay stable at every zoom,
@@ -106,6 +122,8 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
     };
     const float beatLineAlpha = style.beatLineAlpha * timelineGridLevelFade(pixelsPerBeat);
     const float halfBeatLineAlpha = style.subdivisionLineAlpha * timelineGridLevelFade(pixelsPerBeat * 0.5f);
+    const bool showBeatTier = timelineGridTierAlignedToSnap(1.0, subdivisionBeats);
+    const bool showHalfBeatTier = timelineGridTierAlignedToSnap(0.5, subdivisionBeats);
 
     for (int bar = firstVisibleBar; bar <= lastVisibleBar; ++bar) {
         const float barX = gridStartX + (bar * pixelsPerBar) - scrollX;
@@ -124,14 +142,14 @@ inline void renderTimelineGrid(NUIRenderer& renderer,
             if (alpha > 0.001f) drawGridLine(barX, alpha);
         }
 
-        if (beatLineAlpha > 0.001f) {
+        if (showBeatTier && beatLineAlpha > 0.001f) {
             for (int beat = 1; beat < beatsPerBar; ++beat) {
                 const float beatX = barX + beat * pixelsPerBeat;
                 if (beatX >= gridStartX && beatX <= gridEndX) drawGridLine(beatX, beatLineAlpha);
             }
         }
 
-        if (halfBeatLineAlpha > 0.001f) {
+        if (showHalfBeatTier && halfBeatLineAlpha > 0.001f) {
             const float halfBeatOffset = pixelsPerBeat * 0.5f;
             for (int beat = 0; beat < beatsPerBar; ++beat) {
                 const float subBeatX = barX + beat * pixelsPerBeat + halfBeatOffset;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -284,6 +284,9 @@ public:
     /** @brief Set the active snap grid. */
     void setSnap(SnapGrid snap) { snap_ = snap; repaint(); }
 
+    /** @brief Beat span the grid renders subdivisions at for the active snap. */
+    double getSnapSubdivisionBeats() const { return MusicTheory::getSnapDuration(snap_); }
+
 private:
     float pixelsPerBeat_;
     float keyHeight_;
@@ -741,6 +744,7 @@ private:
     void layoutChildren();
     void updateScrollbars(); // Renamed to updateNavigation?
     void renderShortcutHelp(NUIRenderer& renderer);
+    void applyZoom(float factor, float anchorX);
 };
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/PianoRollGrid.cpp
+++ b/AestraUI/Widgets/PianoRollGrid.cpp
@@ -57,7 +57,8 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     }
 
     renderTimelineGrid(
-        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk);
+        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk,
+        {}, getSnapSubdivisionBeats());
 
     if (hoveredPitch_ >= 0 && hoveredPitch_ <= 127) {
         const float hoverY = bounds.y + (127 - hoveredPitch_) * keyHeight_ - scrollY_;

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -68,23 +68,7 @@ PianoRollView::PianoRollView()
     
     // Ruler Zoom Callback
     m_ruler->onZoomRequested = [this](float delta, float mouseX) {
-        float oldPPB = m_pixelsPerBeat;
-        float zoomFactor = (delta > 0) ? 1.15f : 0.85f;
-        float newPPB = std::clamp(oldPPB * zoomFactor, 10.0f, 500.0f);
-        
-        // Anchor logic: Keep beat under mouse stationary
-        float mouseBeat = (m_scrollX + mouseX) / oldPPB;
-        float newWorldX = mouseBeat * newPPB;
-        float newScrollX = newWorldX - mouseX;
-        
-        if (newScrollX < 0) newScrollX = 0;
-        
-        m_pixelsPerBeat = newPPB;
-        m_scrollX = newScrollX;
-        m_targetScrollX = newScrollX;
-        
-        updateScrollbars();
-        syncChildren();
+        applyZoom((delta > 0) ? 1.15f : 0.85f, mouseX);
     };
 
     m_ruler->onPlayheadScrubbed = [this](double beat, bool active) {
@@ -530,8 +514,9 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
         bool ctrl = (event.modifiers & NUIModifiers::Ctrl);
         
         if (ctrl) {
-            // Zoom (Fallback)
-            m_pixelsPerBeat = std::max(20.0f, m_pixelsPerBeat + event.wheelDelta * 5.0f);
+            // Zoom (Fallback) — same anchored, multiplicative semantics as the ruler.
+            applyZoom((event.wheelDelta > 0) ? 1.15f : 0.85f,
+                      event.position.x - getBounds().x);
         } else if (shift) {
             // H-Scroll
             m_targetScrollX = std::max(0.0f, m_targetScrollX - event.wheelDelta * 40.0f);
@@ -696,23 +681,29 @@ void PianoRollView::setPatternLengthBeats(double beats) {
     }
 }
 
+void PianoRollView::applyZoom(float factor, float anchorX) {
+    const float oldPPB = m_pixelsPerBeat;
+    const float newPPB = std::clamp(oldPPB * factor, 10.0f, 500.0f);
+    if (std::abs(newPPB - oldPPB) < 0.001f) {
+        return;
+    }
+    m_pixelsPerBeat = newPPB;
+    m_scrollX = pianoRollZoomAnchorScroll(m_scrollX, oldPPB, newPPB, anchorX);
+    m_targetScrollX = m_scrollX;
+    updateScrollbars();
+    syncChildren();
+}
+
 void PianoRollView::setPlayheadBeat(double beat, bool follow) {
     m_playheadBeat = std::max(0.0, beat);
 
     if (follow && m_grid) {
         const float visibleW = m_grid->getWidth();
         if (visibleW > 0.0f) {
-            const double visibleStart = static_cast<double>(m_scrollX) / m_pixelsPerBeat;
-            const double visibleDur = static_cast<double>(visibleW) / m_pixelsPerBeat;
-            const double leftGuard = visibleStart + visibleDur * 0.15;
-            const double rightGuard = visibleStart + visibleDur * 0.85;
-
-            if (m_playheadBeat < leftGuard || m_playheadBeat > rightGuard) {
-                const double targetStart = std::max(0.0, m_playheadBeat - visibleDur * 0.2);
-                m_scrollX = static_cast<float>(targetStart * m_pixelsPerBeat);
-                m_targetScrollX = m_scrollX;
-                updateScrollbars();
-            }
+            // Target-only update: the onUpdate ease animates the scroll, so
+            // follow never teleports or fights user/scrub scrolling.
+            m_targetScrollX = pianoRollFollowTargetScroll(m_scrollX, m_pixelsPerBeat, visibleW, m_playheadBeat);
+            updateScrollbars();
         }
     }
 

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -515,8 +515,10 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
         
         if (ctrl) {
             // Zoom (Fallback) — same anchored, multiplicative semantics as the ruler.
+            // The ruler passes grid-local X (its bounds start after the key lane);
+            // mirror that basis or the beat under the cursor drifts with the lane width.
             applyZoom((event.wheelDelta > 0) ? 1.15f : 0.85f,
-                      event.position.x - getBounds().x);
+                      event.position.x - getBounds().x - m_grid->getBounds().x);
         } else if (shift) {
             // H-Scroll
             m_targetScrollX = std::max(0.0f, m_targetScrollX - event.wheelDelta * 40.0f);
@@ -603,6 +605,9 @@ void PianoRollView::setDefaultUnitId(uint64_t unitId) {
 }
 
 void PianoRollView::setPixelsPerBeat(float ppb) {
+    if (!std::isfinite(ppb) || ppb <= 0.0f) {
+        return;
+    }
     m_pixelsPerBeat = ppb;
     updateScrollbars();
     syncChildren();

--- a/AestraUI/Widgets/PianoRollWidgetShared.h
+++ b/AestraUI/Widgets/PianoRollWidgetShared.h
@@ -75,6 +75,9 @@ inline float snapRectX(float x) {
  *        when pixels-per-beat changes from `oldPPB` to `newPPB`.
  */
 inline float pianoRollZoomAnchorScroll(float scrollX, float oldPPB, float newPPB, float anchorX) {
+    if (!std::isfinite(oldPPB) || oldPPB <= 0.0f) {
+        return scrollX;
+    }
     const float mouseBeat = (scrollX + anchorX) / oldPPB;
     return std::max(0.0f, mouseBeat * newPPB - anchorX);
 }
@@ -88,6 +91,9 @@ inline float pianoRollFollowTargetScroll(float scrollX,
                                          float pixelsPerBeat,
                                          float visibleWidth,
                                          double playheadBeat) {
+    if (!std::isfinite(pixelsPerBeat) || pixelsPerBeat <= 0.0f) {
+        return scrollX;
+    }
     const double visibleStart = static_cast<double>(scrollX) / pixelsPerBeat;
     const double visibleDur = static_cast<double>(visibleWidth) / pixelsPerBeat;
     const double leftGuard = visibleStart + visibleDur * 0.15;

--- a/AestraUI/Widgets/PianoRollWidgetShared.h
+++ b/AestraUI/Widgets/PianoRollWidgetShared.h
@@ -70,4 +70,34 @@ inline float snapRectX(float x) {
     return std::round(x);
 }
 
+/**
+ * @brief New scroll offset that keeps the beat under `anchorX` stationary
+ *        when pixels-per-beat changes from `oldPPB` to `newPPB`.
+ */
+inline float pianoRollZoomAnchorScroll(float scrollX, float oldPPB, float newPPB, float anchorX) {
+    const float mouseBeat = (scrollX + anchorX) / oldPPB;
+    return std::max(0.0f, mouseBeat * newPPB - anchorX);
+}
+
+/**
+ * @brief Scroll offset that keeps `playheadBeat` inside the visible guard
+ *        band (15%-85%), or the current offset when already inside.
+ *        Returns a *target* — callers ease toward it instead of teleporting.
+ */
+inline float pianoRollFollowTargetScroll(float scrollX,
+                                         float pixelsPerBeat,
+                                         float visibleWidth,
+                                         double playheadBeat) {
+    const double visibleStart = static_cast<double>(scrollX) / pixelsPerBeat;
+    const double visibleDur = static_cast<double>(visibleWidth) / pixelsPerBeat;
+    const double leftGuard = visibleStart + visibleDur * 0.15;
+    const double rightGuard = visibleStart + visibleDur * 0.85;
+
+    if (playheadBeat < leftGuard || playheadBeat > rightGuard) {
+        const double targetStart = std::max(0.0, playheadBeat - visibleDur * 0.2);
+        return static_cast<float>(targetStart * pixelsPerBeat);
+    }
+    return scrollX;
+}
+
 } // namespace AestraUI

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3160,6 +3160,14 @@ void AestraContent::stopFromCurrentFocus(bool hardStop) {
         if (hardStop && m_audioEngine) {
             m_audioEngine->panic();
         }
+        if (hardStop && m_trackManager) {
+            m_trackManager->setPlayStartPosition(0.0);
+            m_trackManager->setPosition(0.0);
+            m_trackManager->clearDisplayPositionOverride();
+            if (m_audioEngine) {
+                m_audioEngine->setGlobalSamplePos(0);
+            }
+        }
         return;
     }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3155,6 +3155,12 @@ void AestraContent::stopFromCurrentFocus(bool hardStop) {
     if (focus == ViewFocus::Arsenal) {
         if (m_trackManager) {
             AESTRA_LOG_DEBUG("[Arsenal] Focus-aware stop");
+            if (hardStop) {
+                // Zero the cue BEFORE the stop command goes out: stop() pushes the
+                // stored play-start into the command, and the audio thread's drain is
+                // authoritative — a UI-side rewind after the fact races it.
+                m_trackManager->setPlayStartPosition(0.0);
+            }
             m_trackManager->stopArsenalPlayback(true);
         }
         if (hardStop && m_audioEngine) {
@@ -3172,6 +3178,9 @@ void AestraContent::stopFromCurrentFocus(bool hardStop) {
     }
 
     if (m_trackManager) {
+        if (hardStop) {
+            m_trackManager->setPlayStartPosition(0.0);
+        }
         m_trackManager->stop();
     }
     if (hardStop && m_audioEngine) {

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1003,6 +1003,17 @@ void AestraContent::setupArsenalPanels() {
         }
         sampler->setMonoMode(monoMode);
     };
+    m_sampleEditorPanel->onCutSelfModeChanged = [this](bool cutSelf) {
+        if (!m_trackManager || !m_sampleEditorUnitId) {
+            return;
+        }
+        auto plugin = m_trackManager->getUnitManager().getUnitPlugin(m_sampleEditorUnitId);
+        auto sampler = std::dynamic_pointer_cast<Aestra::Audio::Plugins::SamplerPlugin>(plugin);
+        if (!sampler) {
+            return;
+        }
+        sampler->setCutSelfMode(cutSelf);
+    };
     m_sampleEditorPanel->onNormalizeRequested = [this]() {
         if (!m_trackManager || !m_sampleEditorUnitId) {
             return;
@@ -3837,6 +3848,7 @@ void AestraContent::syncSampleEditorToUnit(UnitID unitId) {
     m_sampleEditorPanel->setPitchTune(pitch);
     m_sampleEditorPanel->setVoiceCount(sampler->getMaxVoices());
     m_sampleEditorPanel->setMonoMode(sampler->isMonoMode());
+    m_sampleEditorPanel->setCutSelfMode(sampler->isCutSelfMode());
 }
 
 void AestraContent::openSampleEditorForUnit(UnitID unitId, const std::string& samplePath) {

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -175,10 +175,16 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
         }
     });
 
-    // Wire CommandHistory state-changed callback to reload pattern into UI on undo/redo
+    // Wire CommandHistory state-changed callback to reload pattern into UI on undo/redo.
+    // savePattern() sets m_applyingUndoRedo while it pushes its own commands, so a
+    // state change with that flag already set is our own save in progress — the UI
+    // already reflects the edit, and reloading would rebuild every note with
+    // selected=false, wiping the user's selection after the first committed edit.
+    // Only reload when the state change came from outside (undo/redo elsewhere).
     if (m_trackManager) {
         m_trackManager->getCommandHistory().addOnStateChanged([this]() {
             if (!m_currentPatternId.isValid()) return;
+            if (m_applyingUndoRedo) return;
             m_applyingUndoRedo = true;
             loadPattern(m_currentPatternId);
             m_applyingUndoRedo = false;

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -87,6 +87,8 @@ public:
     void applyHarmonyContextEdit(int rootKey, AestraUI::ScaleType scaleType, bool snapToScale);
     /** @brief Return the complete harmony context currently shown by the editor. */
     ScaleContext getHarmonyContext() const;
+    /** @brief Current notes as shown by the editor view (including selection state). */
+    const std::vector<AestraUI::MidiNote>& getNotes() const { return m_pianoRoll->getNotes(); }
     /**
      * @brief Bind the live audio engine used for transport/playhead sync.
      * @param engine Audio engine pointer, or nullptr to disable engine sync.

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -686,6 +686,7 @@ void SampleEditorPanel::buildUI() {
     m_pingPongModeBtn = std::make_shared<NUIButton>("Ping-Pong");
     m_monoModeBtn = std::make_shared<NUIButton>("Mono");
     m_polyModeBtn = std::make_shared<NUIButton>("Poly");
+    m_cutSelfModeBtn = std::make_shared<NUIButton>("Cut-Self");
     styleActionButton(m_normalizeBtn);
     styleActionButton(m_reverseBtn);
     styleModeButton(m_oneShotModeBtn);
@@ -693,6 +694,7 @@ void SampleEditorPanel::buildUI() {
     styleModeButton(m_pingPongModeBtn);
     styleModeButton(m_monoModeBtn);
     styleModeButton(m_polyModeBtn);
+    styleModeButton(m_cutSelfModeBtn);
     m_waveformHintLabel = makeLabel("Scroll to zoom  |  Drag handles to trim");
     m_waveformHintLabel->setTextColor(theme.getColor("textSecondary").withAlpha(0.56f));
     m_waveformHintLabel->setAlignment(NUILabel::Alignment::Right);
@@ -714,6 +716,7 @@ void SampleEditorPanel::buildUI() {
     m_pingPongModeBtn->setOnClick([this]() { setLoopMode(LoopMode::PingPong); });
     m_monoModeBtn->setOnClick([this]() { setMonoModeInternal(true, true); });
     m_polyModeBtn->setOnClick([this]() { setMonoModeInternal(false, true); });
+    m_cutSelfModeBtn->setOnClick([this]() { setCutSelfModeInternal(!m_cutSelfMode, true); });
     updateModeButtons();
     updateMonoPolyControls();
 
@@ -757,6 +760,7 @@ void SampleEditorPanel::buildUI() {
     m_contentContainer->addChild(m_pingPongModeBtn);
     m_contentContainer->addChild(m_monoModeBtn);
     m_contentContainer->addChild(m_polyModeBtn);
+    m_contentContainer->addChild(m_cutSelfModeBtn);
     m_contentContainer->addChild(m_pitchRootSlider);
     m_contentContainer->addChild(m_pitchCoarseSlider);
     m_contentContainer->addChild(m_pitchFineSlider);
@@ -926,7 +930,7 @@ void SampleEditorPanel::onResize(int width, int height) {
     m_modeLabel->setBounds(NUIRect(cb.x + pad, modeRowY, contentW, labelH));
     y = modeRowY + labelH;
     const float monoBtnW = 52.0f;
-    const float monoGroupW = monoBtnW * 2.0f - 1.0f;
+    const float monoGroupW = monoBtnW * 3.0f - 2.0f;
     const float voiceValueW = 24.0f;
     const float voiceSliderW = std::min(132.0f, std::max(84.0f, contentW * 0.20f));
     const float voiceLabelW = 42.0f;
@@ -937,6 +941,8 @@ void SampleEditorPanel::onResize(int width, int height) {
     m_monoModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
     x += monoBtnW - 1.0f;
     m_polyModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
+    x += monoBtnW - 1.0f;
+    m_cutSelfModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
     x += monoBtnW + gutter;
     m_oneShotModeBtn->setBounds(NUIRect(x, y, modeBtnW, rowH));
     x += modeBtnW - 1.0f;
@@ -1098,6 +1104,25 @@ void SampleEditorPanel::setMonoModeInternal(bool mono, bool notify) {
     }
 }
 
+void SampleEditorPanel::setCutSelfModeInternal(bool cutSelf, bool notify) {
+    if (m_cutSelfMode == cutSelf) {
+        updateMonoPolyControls();
+        return;
+    }
+
+    m_cutSelfMode = cutSelf;
+    updateMonoPolyControls();
+
+    if (notify && !m_suppressControlCallbacks) {
+        if (onCutSelfModeChanged) onCutSelfModeChanged(m_cutSelfMode);
+        requestControlCommit();
+    }
+}
+
+void SampleEditorPanel::setCutSelfMode(bool cutSelf) {
+    setCutSelfModeInternal(cutSelf, false);
+}
+
 void SampleEditorPanel::updateMonoPolyControls() {
     auto& theme = NUIThemeManager::getInstance();
     const auto activeBg = theme.getColor("secondary").withAlpha(0.78f);
@@ -1121,6 +1146,7 @@ void SampleEditorPanel::updateMonoPolyControls() {
 
     styleButton(m_monoModeBtn, m_monoMode);
     styleButton(m_polyModeBtn, !m_monoMode);
+    styleButton(m_cutSelfModeBtn, m_cutSelfMode);
 
     const int voices = getVoiceCount();
     if (m_voiceCountValueLabel) {

--- a/Source/Panels/SampleEditorPanel.h
+++ b/Source/Panels/SampleEditorPanel.h
@@ -77,6 +77,8 @@ public:
     int getVoiceCount() const;
     void setMonoMode(bool mono);
     bool isMonoMode() const { return m_monoMode; }
+    void setCutSelfMode(bool cutSelf);
+    bool isCutSelfMode() const { return m_cutSelfMode; }
 
     // Normalize and Reverse
     void normalize();
@@ -88,6 +90,7 @@ public:
     std::function<void(const PitchTune&)> onPitchTuneChanged;
     std::function<void(int)> onVoiceCountChanged;
     std::function<void(bool)> onMonoModeChanged;
+    std::function<void(bool)> onCutSelfModeChanged;
     std::function<void()> onControlCommitRequested;
     std::function<void()> onNormalizeRequested;
     std::function<void()> onReverseRequested;
@@ -111,6 +114,7 @@ private:
     // Loop
     LoopPoints m_loopPoints;
     bool m_monoMode{false};
+    bool m_cutSelfMode{false};
 
     // Pitch/Tune
     PitchTune m_pitchTune;
@@ -131,6 +135,7 @@ private:
     std::shared_ptr<AestraUI::NUIButton> m_pingPongModeBtn;
     std::shared_ptr<AestraUI::NUIButton> m_monoModeBtn;
     std::shared_ptr<AestraUI::NUIButton> m_polyModeBtn;
+    std::shared_ptr<AestraUI::NUIButton> m_cutSelfModeBtn;
     std::shared_ptr<AestraUI::NUILabel> m_waveformHintLabel;
     std::shared_ptr<AestraUI::NUILabel> m_modeLabel;
     std::shared_ptr<AestraUI::NUILabel> m_voiceCountLabel;
@@ -154,6 +159,7 @@ private:
     void onPitchControlChanged();
     void onVoiceCountControlChanged();
     void setMonoModeInternal(bool mono, bool notify);
+    void setCutSelfModeInternal(bool cutSelf, bool notify);
     void setLoopMode(LoopMode mode);
     void updateModeButtons();
     void updateMonoPolyControls();

--- a/Source/Panels/WindowPanel.cpp
+++ b/Source/Panels/WindowPanel.cpp
@@ -269,7 +269,14 @@ bool WindowPanel::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     if (!isVisible() || !isEnabled()) return false;
 
     if (event.pressed) {
-        bringToFront();
+        // The overlay layer forwards every press to every visible panel so that
+        // clicks over empty overlay area pass through to the workspace. Only
+        // raise the panel when the press actually lands inside its bounds;
+        // otherwise any click on the transport bar would pop every panel to
+        // the front.
+        if (getGlobalBounds().contains(event.position)) {
+            bringToFront();
+        }
     }
 
     if (m_resizing) {

--- a/Tests/AestraAudio/PatternTransportPositionTest.cpp
+++ b/Tests/AestraAudio/PatternTransportPositionTest.cpp
@@ -1,0 +1,318 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// PatternTransportPositionTest — regression for the piano-roll playhead bug.
+//
+// The piano roll's ruler scrub cues a playhead (setPosition + setPlayStartPosition +
+// setGlobalSamplePos) and playPatternInArsenal() pushes that exact position into the
+// transport command. The engine, however, unconditionally zeroed m_globalSamplePos on
+// every stop/restart edge while pattern mode was active:
+//
+//     if (patternModeNow && (transportStop || transportRestart)) {
+//         m_globalSamplePos.store(0, ...);
+//     }
+//
+// Live consequence: "cursor at beat 2 → play starts at beat 1". The scrubbed cue was
+// wiped on the restart edge, so playback always began at the loop top. The same wipe
+// hit pause: pause preserves the playhead via kTransportPreservePosition, but the stop
+// edge zeroed it anyway, so "pause at 2 → play resumes at 1".
+//
+// The fix: honor the pushed position. Only cues at or past the loop end (a stale
+// timeline position entering pattern mode) are wrapped back into the loop, matching the
+// render path's existing wrap logic. TrackManager::stop() already pushes the stored cue
+// position, so stop-in-pattern-mode returning to the cue (not the loop top) is the
+// consistent semantic.
+//
+// These assertions fail on the pre-fix engine: every pattern-mode play/pause/resume/stop
+// lands the playhead at 0 (or one block past it) instead of the cued position.
+
+#include "Core/AudioCommandQueue.h"
+#include "Core/AudioEngine.h"
+#include "Models/PatternManager.h"
+#include "Models/UnitManager.h"
+#include "Playback/PatternPlaybackEngine.h"
+#include "Playback/TimelineClock.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Aestra::Audio::AudioEngine;
+using Aestra::Audio::AudioQueueCommand;
+using Aestra::Audio::AudioQueueCommandType;
+using Aestra::Audio::kTransportPreservePosition;
+using Aestra::Audio::MidiBuffer;
+using Aestra::Audio::MidiNote;
+using Aestra::Audio::MidiPayload;
+using Aestra::Audio::PatternID;
+using Aestra::Audio::PatternManager;
+using Aestra::Audio::PatternPlaybackEngine;
+using Aestra::Audio::TimelineClock;
+using Aestra::Audio::UnitManager;
+
+namespace {
+
+constexpr uint32_t kFrames = 512;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kSampleRate = 48000;
+// 4-beat pattern at 120 BPM and 48 kHz: one beat = 0.5 s = 24000 samples.
+constexpr uint64_t kBeatSamples = 24000;
+constexpr uint64_t kLoopSamples = 4 * kBeatSamples; // 96000
+constexpr double kCueBeat = 2.0;                    // beat 2 of the loop
+constexpr uint64_t kCueSamples = static_cast<uint64_t>(kCueBeat * kBeatSamples); // 48000
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    std::cout << (condition ? "PASS: " : "FAIL: ") << label << "\n";
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+AudioQueueCommand makeTransportCmd(float playing, uint64_t samplePos) {
+    AudioQueueCommand cmd{};
+    cmd.type = AudioQueueCommandType::SetTransportState;
+    cmd.value1 = playing;
+    cmd.samplePos = samplePos;
+    return cmd;
+}
+
+// --- Consumer side: pattern-mode transport must honor a cued playhead. ----------
+//
+// Drives real audio callbacks with pattern mode active, exactly like the piano-roll
+// play → pause → resume flow does: the panel scrubs the ruler, which pushes the cue
+// position; playPatternInArsenal()/TrackManager then push SetTransportState with the
+// same position.
+void patternPlayHonorsScrubbedCue() {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "[play] engine initializes");
+        return;
+    }
+    engine.setPatternPlaybackMode(true, 4.0);
+    engine.setGlobalSamplePos(kCueSamples); // the ruler scrub
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+
+    // Play — the transport command carries the scrubbed cue, as playPatternInArsenal()
+    // does (startSeconds = m_position). Pre-fix, the restart edge zeroed it.
+    engine.commandQueue().push(makeTransportCmd(1.0f, kCueSamples));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    const uint64_t posAfterPlay = engine.getGlobalSamplePos();
+    check(posAfterPlay >= kCueSamples,
+          "pattern-mode play from a scrubbed cue starts at the cue, not the loop top"
+          " (got " + std::to_string(posAfterPlay) + ", expected >= " + std::to_string(kCueSamples) + ")");
+    check(posAfterPlay <= kCueSamples + kFrames,
+          "playhead advances from the cue by at most one block (no wrap or reset)");
+
+    engine.setTransportPlaying(false);
+}
+
+// Pause in pattern mode must preserve the engine's authoritative playhead (the #590
+// sentinel contract), not rewind to the loop top via the stop edge.
+void patternPausePreservesPosition() {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "[pause] engine initializes");
+        return;
+    }
+    engine.setPatternPlaybackMode(true, 4.0);
+    engine.setGlobalSamplePos(0);
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+
+    engine.commandQueue().push(makeTransportCmd(1.0f, 0));
+    for (int i = 0; i < 8; ++i) {
+        engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    }
+    const uint64_t advancedPos = engine.getGlobalSamplePos();
+    check(advancedPos >= static_cast<uint64_t>(kFrames) * 8, "playhead advanced in pattern mode");
+
+    engine.commandQueue().push(makeTransportCmd(0.0f, kTransportPreservePosition));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    check(engine.getGlobalSamplePos() == advancedPos,
+          "pattern-mode pause with the preserve sentinel keeps the playhead (no rewind to loop top)");
+    check(!engine.isTransportPlaying(), "pause stops transport");
+
+    engine.setTransportPlaying(false);
+}
+
+// Resume after a pattern-mode pause must continue from the paused position, not
+// restart at the loop top (the restart edge used to zero the playhead).
+void patternResumeFromPausedPosition() {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "[resume] engine initializes");
+        return;
+    }
+    engine.setPatternPlaybackMode(true, 4.0);
+    engine.setGlobalSamplePos(0);
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+
+    engine.commandQueue().push(makeTransportCmd(1.0f, 0));
+    for (int i = 0; i < 8; ++i) {
+        engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+    }
+    const uint64_t advancedPos = engine.getGlobalSamplePos();
+
+    engine.commandQueue().push(makeTransportCmd(0.0f, kTransportPreservePosition));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    // Resume pushes the preserved position, as TrackManager::play() does after pause.
+    engine.commandQueue().push(makeTransportCmd(1.0f, advancedPos));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    const uint64_t posAfterResume = engine.getGlobalSamplePos();
+    check(posAfterResume >= advancedPos,
+          "pattern-mode resume continues from the paused playhead (got " + std::to_string(posAfterResume) +
+              ", expected >= " + std::to_string(advancedPos) + ")");
+
+    engine.setTransportPlaying(false);
+}
+
+// Stop in pattern mode must return to the stored cue position (TrackManager::stop()
+// pushes playStartPosition), not to the loop top.
+void patternStopReturnsToCue() {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "[stop] engine initializes");
+        return;
+    }
+    engine.setPatternPlaybackMode(true, 4.0);
+    engine.setGlobalSamplePos(kCueSamples);
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+
+    engine.commandQueue().push(makeTransportCmd(1.0f, kCueSamples));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    // Stop pushes the cue position, as TrackManager::stop() does (playStartPosition).
+    engine.commandQueue().push(makeTransportCmd(0.0f, kCueSamples));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    check(engine.getGlobalSamplePos() == kCueSamples,
+          "pattern-mode stop returns to the stored cue position (got " +
+              std::to_string(engine.getGlobalSamplePos()) + ", expected " + std::to_string(kCueSamples) + ")");
+
+    engine.setTransportPlaying(false);
+}
+
+// A cue past the loop end (a stale timeline position entering pattern mode) must be
+// wrapped back into the loop, matching the render path's wrap behavior — not honored
+// as a raw out-of-range position.
+void patternCuePastLoopEndWrapsIntoLoop() {
+    AudioEngine engine;
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+    engine.setMetronomeEnabled(false);
+    if (!engine.initialize()) {
+        check(false, "[wrap] engine initializes");
+        return;
+    }
+    engine.setPatternPlaybackMode(true, 4.0);
+
+    // 5 beats = 120000 samples = 1.25 loop lengths past the start.
+    constexpr uint64_t kPastLoopSamples = 5 * kBeatSamples;
+    engine.setGlobalSamplePos(kPastLoopSamples);
+
+    std::vector<float> out(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+    engine.commandQueue().push(makeTransportCmd(1.0f, kPastLoopSamples));
+    engine.processBlock(out.data(), nullptr, kFrames, 0.0);
+
+    const uint64_t posAfterPlay = engine.getGlobalSamplePos();
+    check(posAfterPlay < kLoopSamples,
+          "pattern-mode play from a cue past the loop end wraps into the loop (got " +
+              std::to_string(posAfterPlay) + ", expected < " + std::to_string(kLoopSamples) + ")");
+
+    engine.setTransportPlaying(false);
+}
+
+// --- Scheduler contract: refill from the cue, not from the loop top. -------------
+//
+// After a mid-pattern transport restart, the audio callback's m_patternMonotonicFrame
+// is still 0 (it was reset while stopped) until the first playing block republishes it.
+// If maintenance refilled from that stale 0, the loop-top events would be queued and a
+// playhead at beat 2 would fire them at the buffer edge — "starts from beat 1" again.
+// performNonRealtimeMaintenance() must refill from the cued m_globalSamplePos instead.
+// This test pins the scheduler contract that guard relies on: refilling at the cue
+// must not schedule events that started before the cue.
+void schedulerRefillAtCueSkipsPastNotes() {
+    TimelineClock clock(120.0);
+    PatternManager patterns;
+    UnitManager units;
+    PatternPlaybackEngine scheduler(&clock, &patterns, &units);
+
+    MidiPayload payload;
+    MidiNote earlyNote;
+    earlyNote.pitch = 60;
+    earlyNote.startBeat = 0.0; // loop top — must NOT fire when cued at beat 2
+    earlyNote.durationBeats = 1.0;
+    earlyNote.velocity = 0.8f;
+    earlyNote.unitId = 1;
+    MidiNote cuedNote;
+    cuedNote.pitch = 61;
+    cuedNote.startBeat = kCueBeat; // the cued playhead
+    cuedNote.durationBeats = 1.0;
+    cuedNote.velocity = 0.8f;
+    cuedNote.unitId = 1;
+    payload.notes.push_back(earlyNote);
+    payload.notes.push_back(cuedNote);
+
+    const PatternID pid = patterns.createMidiPattern("cue-contract", 4.0, payload);
+    scheduler.schedulePatternInstance(pid, 0.0, 1);
+
+    MidiBuffer buf;
+    PatternPlaybackEngine::UnitMidiRoute routes[] = {PatternPlaybackEngine::UnitMidiRoute(1, &buf)};
+
+    // Refill at the cued frame (beat 2), as the fixed maintenance path does.
+    scheduler.refillWindow(kCueSamples, static_cast<int>(kSampleRate), 4096, kLoopSamples);
+    scheduler.processAudio(kCueSamples, static_cast<int>(kFrames), routes, 1);
+
+    bool sawEarlyNote = false;
+    bool sawCuedNote = false;
+    for (size_t i = 0; i < buf.getEventCount(); ++i) {
+        const auto& ev = buf.getEvent(i);
+        if (ev.size < 2 || (ev.data[0] & 0xF0) != 0x90) {
+            continue;
+        }
+        if (ev.data[1] == earlyNote.pitch) {
+            sawEarlyNote = true;
+        }
+        if (ev.data[1] == cuedNote.pitch) {
+            sawCuedNote = true;
+        }
+    }
+
+    check(sawCuedNote, "refill at the cue schedules the note at the cued beat");
+    check(!sawEarlyNote, "refill at the cue does NOT re-trigger notes that started before the cue");
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Pattern Transport Position (piano-roll playhead) ===\n";
+    patternPlayHonorsScrubbedCue();
+    patternPausePreservesPosition();
+    patternResumeFromPausedPosition();
+    patternStopReturnsToCue();
+    patternCuePastLoopEndWrapsIntoLoop();
+    schedulerRefillAtCueSkipsPastNotes();
+
+    std::cout << (g_failures == 0 ? "ALL PASSED\n"
+                                  : "FAILURES: " + std::to_string(g_failures) + "\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/Tests/AestraAudio/SamplerCutSelfTest.cpp
+++ b/Tests/AestraAudio/SamplerCutSelfTest.cpp
@@ -1,0 +1,305 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Cut-self / voice-choke regression: a retriggered note must choke the
+// previous voice of the same note (explicit sampler-level policy), never
+// overlap it, leave different-pitch polyphony alone, and stay disabled for
+// ordinary samples unless the user enables it.
+
+#include "Plugin/SamplerPlugin.h"
+#include "PluginHost.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockFrames = 256;
+constexpr int kBlocks = 16;
+constexpr uint8_t kNote = 60;
+constexpr uint8_t kVelocity = 110;
+constexpr int kRetriggerBlock = 1;
+// Offset 17: the 220 Hz sine peaks at global frame 272.7 (54.5 + one cycle,
+// 48000/220 = 218.18 frames), i.e. offset 17 inside the retrigger block
+// (block starts at 256). The choke cut lands on the old voice's maximum
+// value — the loudest possible step.
+constexpr int kChokeOffset = 17;
+// Offset 436: a whole number of 220 Hz cycles (48000/220 = 218.18 frames), so
+// a non-choked overlap lands in-phase and measures as a clean ~1.414x
+// amplitude boost instead of a phase-dependent fluke.
+constexpr int kInPhaseOffset = 180; // 256 + 180 = 436
+
+void writeLe16(std::ofstream& out, uint16_t value) {
+    out.put(static_cast<char>(value & 0xff));
+    out.put(static_cast<char>((value >> 8) & 0xff));
+}
+
+void writeLe32(std::ofstream& out, uint32_t value) {
+    out.put(static_cast<char>(value & 0xff));
+    out.put(static_cast<char>((value >> 8) & 0xff));
+    out.put(static_cast<char>((value >> 16) & 0xff));
+    out.put(static_cast<char>((value >> 24) & 0xff));
+}
+
+// 1 s of 220 Hz sine at 0.30 peak. A long one-shot: voices stay audible far
+// past the retrigger window, so overlap would be plainly measurable.
+bool writeMonoWav(const std::filesystem::path& path, uint32_t frames) {
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        return false;
+    }
+
+    constexpr uint16_t channels = 1;
+    constexpr uint16_t bitsPerSample = 16;
+    const uint32_t dataBytes = frames * channels * (bitsPerSample / 8);
+
+    out.write("RIFF", 4);
+    writeLe32(out, 36 + dataBytes);
+    out.write("WAVEfmt ", 8);
+    writeLe32(out, 16);
+    writeLe16(out, 1);
+    writeLe16(out, channels);
+    writeLe32(out, kSampleRate);
+    writeLe32(out, kSampleRate * channels * (bitsPerSample / 8));
+    writeLe16(out, channels * (bitsPerSample / 8));
+    writeLe16(out, bitsPerSample);
+    out.write("data", 4);
+    writeLe32(out, dataBytes);
+
+    constexpr double twoPi = 6.28318530717958647692;
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(kSampleRate);
+        const float sample = static_cast<float>(std::sin(twoPi * 220.0 * t) * 0.30);
+        const auto pcm = static_cast<int16_t>(std::clamp(sample, -1.0f, 1.0f) * 32767.0f);
+        writeLe16(out, static_cast<uint16_t>(pcm));
+    }
+
+    return true;
+}
+
+struct RenderMetrics {
+    float maxAbs = 0.0f;
+    float maxFirstDiff = 0.0f;
+    float postRetriggerMax = 0.0f;
+};
+
+// Renders noteOn(firstNote) at frame 0 and noteOn(secondNote) at
+// retriggerOffset within the retrigger block. cutSelf selects the policy.
+bool renderRetrigger(const std::filesystem::path& wavPath, bool cutSelf, uint8_t firstNote,
+                     uint8_t secondNote, int retriggerOffset, RenderMetrics* metrics, std::string* error) {
+    Plugins::SamplerPlugin sampler;
+    if (!sampler.initialize(kSampleRate, kBlockFrames)) {
+        *error = "sampler initialize failed";
+        return false;
+    }
+    if (!sampler.loadSample(wavPath.string())) {
+        *error = "sampler failed to load mono wav";
+        return false;
+    }
+    sampler.setRootMidiNote(60);
+    sampler.setMaxVoices(8);
+    sampler.setEnvelope(0.001f, 1.5f, 0.5f, 0.05f);
+    sampler.setCutSelfMode(cutSelf);
+    sampler.activate();
+
+    std::vector<float> left(kBlockFrames, 0.0f);
+    std::vector<float> right(kBlockFrames, 0.0f);
+    float* outputs[] = {left.data(), right.data()};
+
+    MidiBuffer firstMidi;
+    firstMidi.addNoteOn(1, firstNote, kVelocity, 0);
+    MidiBuffer secondMidi;
+    secondMidi.addNoteOn(1, secondNote, kVelocity, retriggerOffset);
+
+    float prevLeft = 0.0f;
+    for (int block = 0; block < kBlocks; ++block) {
+        std::fill(left.begin(), left.end(), 0.0f);
+        std::fill(right.begin(), right.end(), 0.0f);
+
+        const MidiBuffer* blockMidi = block == 0 ? &firstMidi : (block == kRetriggerBlock ? &secondMidi : nullptr);
+        sampler.process(nullptr, outputs, 0, 2, kBlockFrames, blockMidi, nullptr);
+
+        for (uint32_t i = 0; i < kBlockFrames; ++i) {
+            const float value = left[i];
+            metrics->maxAbs = std::max(metrics->maxAbs, std::abs(value));
+            if (block > 0 || i > 0) {
+                metrics->maxFirstDiff = std::max(metrics->maxFirstDiff, std::abs(value - prevLeft));
+            }
+            if (block >= kRetriggerBlock) {
+                metrics->postRetriggerMax = std::max(metrics->postRetriggerMax, std::abs(value));
+            }
+            prevLeft = value;
+        }
+    }
+
+    if (metrics->maxAbs <= 1.0e-7f) {
+        *error = "sampler output was silent";
+        return false;
+    }
+    return true;
+}
+
+// Single note rendered for the overlap-free amplitude baseline.
+bool renderSingleNote(const std::filesystem::path& wavPath, float* maxAbs, std::string* error) {
+    Plugins::SamplerPlugin sampler;
+    if (!sampler.initialize(kSampleRate, kBlockFrames)) {
+        *error = "sampler initialize failed";
+        return false;
+    }
+    if (!sampler.loadSample(wavPath.string())) {
+        *error = "sampler failed to load mono wav";
+        return false;
+    }
+    sampler.setRootMidiNote(60);
+    sampler.setMaxVoices(8);
+    sampler.setEnvelope(0.001f, 1.5f, 0.5f, 0.05f);
+    sampler.activate();
+
+    std::vector<float> left(kBlockFrames, 0.0f);
+    std::vector<float> right(kBlockFrames, 0.0f);
+    float* outputs[] = {left.data(), right.data()};
+
+    MidiBuffer midi;
+    midi.addNoteOn(1, kNote, kVelocity, 0);
+
+    for (int block = 0; block < kBlocks; ++block) {
+        std::fill(left.begin(), left.end(), 0.0f);
+        std::fill(right.begin(), right.end(), 0.0f);
+        sampler.process(nullptr, outputs, 0, 2, kBlockFrames, block == 0 ? &midi : nullptr, nullptr);
+        for (uint32_t i = 0; i < kBlockFrames; ++i) {
+            *maxAbs = std::max(*maxAbs, std::abs(left[i]));
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::error_code ec;
+    const auto tmpDir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        std::cerr << "failed to resolve temp directory: " << ec.message() << "\n";
+        return 1;
+    }
+
+    const auto uniqueId =
+        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "_" +
+        std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+    const auto wavPath = tmpDir / ("aestra_sampler_cutself_" + uniqueId + ".wav");
+    if (!writeMonoWav(wavPath, kSampleRate)) {
+        std::cerr << "failed to write mono wav\n";
+        return 1;
+    }
+
+    auto fail = [&](const std::string& message) {
+        std::cerr << "FAIL: " << message << "\n";
+        std::filesystem::remove(wavPath, ec);
+        return 1;
+    };
+
+    float singleMax = 0.0f;
+    std::string error;
+    if (!renderSingleNote(wavPath, &singleMax, &error)) {
+        return fail("single-note baseline: " + error);
+    }
+    if (singleMax <= 0.0f) {
+        return fail("single-note baseline silent");
+    }
+
+    RenderMetrics cutOn;
+    if (!renderRetrigger(wavPath, true, kNote, kNote, kChokeOffset, &cutOn, &error)) {
+        return fail("cut-self retrigger render: " + error);
+    }
+
+    // 1. Choke discontinuity: the old voice is hard-cut at the retrigger.
+    //    The cut lands at the old voice's instantaneous value (~0.9x peak);
+    //    smooth playback never steps that hard.
+    if (cutOn.maxFirstDiff <= singleMax * 0.50f) {
+        return fail("cut-self: retrigger must hard-cut the previous voice (no discontinuity seen)");
+    }
+
+    // 2. The new trigger still sounds (choke kills the OLD voice, not the new).
+    if (cutOn.postRetriggerMax < 0.10f * singleMax) {
+        return fail("cut-self: new voice was silenced by the choke");
+    }
+
+    // 3. No overlap: post-choke output stays at single-voice amplitude.
+    if (cutOn.maxAbs > singleMax * 1.10f) {
+        return fail("cut-self: output exceeded single-voice amplitude (overlap remains)");
+    }
+
+    // 4. Default (cut-self OFF): ordinary samples are untouched — retrigger
+    //    stays smooth (no choke discontinuity) and the voices overlap.
+    RenderMetrics defaultOff;
+    if (!renderRetrigger(wavPath, false, kNote, kNote, kInPhaseOffset, &defaultOff, &error)) {
+        return fail("default retrigger render: " + error);
+    }
+    if (defaultOff.maxFirstDiff > singleMax * 0.50f) {
+        return fail("default sampler: retrigger must not choke (hard discontinuity seen)");
+    }
+    if (defaultOff.maxAbs <= singleMax * 1.10f) {
+        return fail("default sampler: retrigger should overlap (no amplitude boost seen)");
+    }
+    if (cutOn.maxAbs >= defaultOff.maxAbs) {
+        return fail("cut-self must reduce retrigger amplitude vs default overlap");
+    }
+
+    // 5. Different pitches stay polyphonic even with cut-self enabled.
+    //    A 440 Hz neighbour's per-frame sine step is ~2x the 220 Hz baseline,
+    //    still far below the choke discontinuity, so 10% of singleMax cleanly
+    //    separates "smooth polyphony" from "choked".
+    RenderMetrics differentPitch;
+    if (!renderRetrigger(wavPath, true, kNote, kNote + 12, kInPhaseOffset, &differentPitch, &error)) {
+        return fail("different-pitch render: " + error);
+    }
+    if (differentPitch.maxFirstDiff > singleMax * 0.50f) {
+        return fail("cut-self: different-pitch trigger must not choke the playing voice");
+    }
+
+    // 6. State roundtrip + legacy state default.
+    {
+        Plugins::SamplerPlugin writer;
+        writer.initialize(kSampleRate, kBlockFrames);
+        if (writer.isCutSelfMode()) {
+            return fail("fresh sampler must default to cut-self disabled");
+        }
+        writer.setCutSelfMode(true);
+        const auto state = writer.saveState();
+
+        Plugins::SamplerPlugin reader;
+        reader.initialize(kSampleRate, kBlockFrames);
+        if (!reader.loadState(state)) {
+            return fail("cut-self state roundtrip load failed");
+        }
+        if (!reader.isCutSelfMode()) {
+            return fail("cut-self flag lost in state roundtrip");
+        }
+    }
+    {
+        // Older projects have no cutSelfMode key — must load as disabled.
+        Plugins::SamplerPlugin legacy;
+        legacy.initialize(kSampleRate, kBlockFrames);
+        const std::string legacyJson = "{\"params\":[0.0,0.0,0.0,0.0,0.0]}";
+        if (!legacy.loadState(std::vector<uint8_t>(legacyJson.begin(), legacyJson.end()))) {
+            return fail("legacy state load failed");
+        }
+        if (legacy.isCutSelfMode()) {
+            return fail("legacy state without cutSelfMode must default to disabled");
+        }
+    }
+
+    std::filesystem::remove(wavPath, ec);
+    std::cout << "sampler cut-self: retrigger chokes, no overlap, polyphony and ADSR unaffected\n";
+    return 0;
+}

--- a/Tests/AestraAudio/SamplerCutSelfTest.cpp
+++ b/Tests/AestraAudio/SamplerCutSelfTest.cpp
@@ -34,9 +34,10 @@ constexpr int kRetriggerBlock = 1;
 // (block starts at 256). The choke cut lands on the old voice's maximum
 // value — the loudest possible step.
 constexpr int kChokeOffset = 17;
-// Offset 436: a whole number of 220 Hz cycles (48000/220 = 218.18 frames), so
-// a non-choked overlap lands in-phase and measures as a clean ~1.414x
-// amplitude boost instead of a phase-dependent fluke.
+// Offset 436: two full 220 Hz cycles span 436.36 frames (48000/220 = 218.18
+// frames per cycle); 256 + 180 = 436 sits 0.36 frames short of the in-phase
+// point, so a non-choked overlap lands ~in-phase and measures as a clean
+// ~1.414x amplitude boost instead of a phase-dependent fluke.
 constexpr int kInPhaseOffset = 180; // 256 + 180 = 436
 
 void writeLe16(std::ofstream& out, uint16_t value) {

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -6,6 +6,7 @@
 #include "Widgets/PianoRollWidgetShared.h"
 #include <cassert>
 #include <iostream>
+#include <limits>
 
 using namespace AestraUI;
 
@@ -343,6 +344,55 @@ static void test_zoom_anchor_preserves_beat() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: Ctrl-wheel zoom anchors on grid-local X, matching the ruler path.
+// The key lane shifts the grid right of the view origin, so a view-local
+// anchor makes the beat under the cursor drift by the lane width per zoom.
+// ---------------------------------------------------------------------------
+static void test_ctrl_wheel_zoom_uses_grid_local_anchor() {
+    PianoRollView view;
+    view.setBounds({0.0f, 0.0f, 900.0f, 600.0f});
+    view.onResize(900, 600);
+    // startBeat 1.25 at 80 ppb over an 810 px grid: scrollX = 100.
+    view.setViewWindow(1.25, 810.0 / 80.0);
+
+    // Default layout: key lane 76 px, vertical scrollbar 14 px.
+    const float keyLaneWidth = 76.0f;
+    const float gridWidthPx = 900.0f - keyLaneWidth - 14.0f;
+    const float cursorViewX = 500.0f;
+
+    const auto beatAtCursor = [&]() {
+        const double ppb = static_cast<double>(gridWidthPx) / view.getViewDurationBeats();
+        return view.getViewStartBeat() + static_cast<double>(cursorViewX - keyLaneWidth) / ppb;
+    };
+    const double beatBefore = beatAtCursor();
+
+    NUIMouseEvent zoom;
+    zoom.type = NUIMouseEventType::Scroll;
+    zoom.position = {cursorViewX, 300.0f};
+    zoom.modifiers = NUIModifiers::Ctrl;
+    zoom.wheelDelta = 1.0f;
+    view.onMouseEvent(zoom);
+
+    // Guard against a vacuous pass: the zoom must actually have applied.
+    ASSERT(view.getViewDurationBeats() < 9.5, "ctrl-wheel zoom fired");
+    const double beatAfter = beatAtCursor();
+    ASSERT(std::abs(beatAfter - beatBefore) < 0.001,
+           "ctrl-wheel zoom keeps the beat under the cursor stationary (grid-local anchor)");
+
+    // Invalid pixels-per-beat must be rejected, not stored.
+    view.setPixelsPerBeat(120.0f);
+    ASSERT(std::abs(static_cast<double>(gridWidthPx) / view.getViewDurationBeats() - 120.0) < 0.001,
+           "valid pixels-per-beat is accepted");
+    view.setPixelsPerBeat(0.0f);
+    view.setPixelsPerBeat(-5.0f);
+    view.setPixelsPerBeat(std::numeric_limits<float>::quiet_NaN());
+    ASSERT(std::abs(static_cast<double>(gridWidthPx) / view.getViewDurationBeats() - 120.0) < 0.001,
+           "non-positive or non-finite pixels-per-beat is rejected");
+
+    PASS("ctrl-wheel zoom anchors on grid-local X");
+}
+
+// ---------------------------------------------------------------------------
 // Test: the grid subdivision tier matches the active snap resolution
 // ---------------------------------------------------------------------------
 static void test_grid_subdivision_matches_snap() {
@@ -449,6 +499,7 @@ int main() {
     test_harmony_context_edit_notification();
     test_follow_target_keeps_playhead_visible();
     test_zoom_anchor_preserves_beat();
+    test_ctrl_wheel_zoom_uses_grid_local_anchor();
     test_grid_subdivision_matches_snap();
     test_grid_tiers_follow_snap();
 

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -3,6 +3,7 @@
 #include "Helpers/TimelineGridRenderer.h"
 #include "Common/MusicHelpers.h"
 #include "Widgets/NUIPianoRollWidgets.h"
+#include "Widgets/PianoRollWidgetShared.h"
 #include <cassert>
 #include <iostream>
 
@@ -291,6 +292,89 @@ static void test_harmony_context_edit_notification() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: follow-playhead target keeps playback inside the visible guard
+// ---------------------------------------------------------------------------
+static void test_follow_target_keeps_playhead_visible() {
+    const float ppb = 80.0f;
+    const float visibleW = 800.0f; // 10 visible beats
+
+    // Playhead inside the 15%-85% guard → scroll unchanged (no jitter while playing).
+    float target = pianoRollFollowTargetScroll(400.0f, ppb, visibleW, 10.0);
+    ASSERT(target == 400.0f, "playhead inside guard must not move the view");
+
+    // Playhead past the right guard → target places it at 20% of view width.
+    target = pianoRollFollowTargetScroll(0.0f, ppb, visibleW, 14.0);
+    ASSERT(target == 960.0f, "right-guard follow should place playhead at 20% width");
+
+    // Playhead past the left guard (loop wrap) → same rule.
+    target = pianoRollFollowTargetScroll(800.0f, ppb, visibleW, 1.0);
+    ASSERT(target == 0.0f, "left-guard follow should place playhead at 20% width");
+
+    // Follow target never goes negative.
+    target = pianoRollFollowTargetScroll(0.0f, ppb, visibleW, 0.2);
+    ASSERT(target >= 0.0f, "follow target must clamp to zero");
+
+    PASS("follow-playhead target keeps playback inside the visible guard");
+}
+
+// ---------------------------------------------------------------------------
+// Test: zoom anchor keeps the beat under the cursor stationary
+// ---------------------------------------------------------------------------
+static void test_zoom_anchor_preserves_beat() {
+    const float scrollX = 320.0f;
+    const float anchorX = 200.0f;
+    const float oldPPB = 80.0f;
+    const float oldBeat = (scrollX + anchorX) / oldPPB;
+
+    const float factors[] = { 1.15f, 0.85f, 2.0f, 0.5f };
+    for (float factor : factors) {
+        const float newPPB = oldPPB * factor;
+        const float newScroll = pianoRollZoomAnchorScroll(scrollX, oldPPB, newPPB, anchorX);
+        const float newBeat = (newScroll + anchorX) / newPPB;
+        ASSERT(std::abs(newBeat - oldBeat) < 0.001f, "zoom must keep the anchor beat stationary");
+    }
+
+    // Extreme zoom-out floors pixels-per-beat; scroll must stay non-negative.
+    const float clampedPPB = std::clamp(oldPPB * 0.01f, 10.0f, 500.0f);
+    const float clampedScroll = pianoRollZoomAnchorScroll(scrollX, oldPPB, clampedPPB, anchorX);
+    ASSERT(clampedScroll >= 0.0f, "zoom scroll must never go negative");
+
+    PASS("zoom anchor preserves the beat under the cursor");
+}
+
+// ---------------------------------------------------------------------------
+// Test: the grid subdivision tier matches the active snap resolution
+// ---------------------------------------------------------------------------
+static void test_grid_subdivision_matches_snap() {
+    PianoRollGrid grid;
+    ASSERT(grid.getSnapSubdivisionBeats() == 1.0,
+           "default snap (Beat) must render subdivisions at one beat");
+
+    bool sawFine = false;
+    for (SnapGrid snap : MusicTheory::getSnapOptions()) {
+        grid.setSnap(snap);
+        const double sub = grid.getSnapSubdivisionBeats();
+        if (snap == SnapGrid::None) {
+            ASSERT(sub == 0.0, "None snap must disable the subdivision tier");
+            continue;
+        }
+        ASSERT(sub > 0.0 && sub <= 4.0, "every snap duration must be a positive musical span");
+        if (sub < 0.5) sawFine = true;
+
+        // A note snapped to this grid lands exactly on a drawn line: the
+        // renderer draws a subdivision line at every multiple of `sub`, and
+        // snap positions are exactly those multiples.
+        const double snapped = std::round(2.37 / sub) * sub;
+        const double k = snapped / sub;
+        ASSERT(std::abs(k - std::round(k)) < 1e-9,
+               "snapped positions must be multiples of the drawn subdivision");
+    }
+    ASSERT(sawFine, "snap options must include subdivisions finer than a beat");
+
+    PASS("grid subdivision tier matches the active snap resolution");
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 int main() {
@@ -313,6 +397,9 @@ int main() {
     test_previous_pitch_in_scale();
     test_snap_pitch_to_scale_edge_cases();
     test_harmony_context_edit_notification();
+    test_follow_target_keeps_playhead_visible();
+    test_zoom_anchor_preserves_beat();
+    test_grid_subdivision_matches_snap();
 
     std::cout << "\n=== Results: " << testsPassed << " passed, " << testsFailed << " failed ===\n";
     return testsFailed > 0 ? 1 : 0;

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -375,6 +375,56 @@ static void test_grid_subdivision_matches_snap() {
 }
 
 // ---------------------------------------------------------------------------
+// Test: grid tiers never advertise positions the snap does not allow
+// ---------------------------------------------------------------------------
+static void test_grid_tiers_follow_snap() {
+    // Without snap info (timeline contract) every tier stays visible.
+    ASSERT(timelineGridTierAlignedToSnap(1.0, 0.0), "no snap keeps the beat tier");
+    ASSERT(timelineGridTierAlignedToSnap(0.5, 0.0), "no snap keeps the half-beat tier");
+
+    const struct {
+        double sub;
+        bool beat;
+        bool half;
+    } kExpectations[] = {
+        {4.0, false, false},          // snap to bar: bars only
+        {1.0, true, false},           // snap to beat: NO 1/2 grid (the reported bug)
+        {0.5, true, true},            // snap to half
+        {0.25, true, true},           // snap to quarter
+        {0.125, true, true},          // snap to eighth
+        {0.0625, true, true},         // snap to sixteenth
+        {1.0 / 3.0, true, false},     // triplet: 0.5 is not on the 1/3 lattice
+    };
+    for (const auto& e : kExpectations) {
+        ASSERT(timelineGridTierAlignedToSnap(1.0, e.sub) == e.beat,
+               "beat tier visibility must follow the snap");
+        ASSERT(timelineGridTierAlignedToSnap(0.5, e.sub) == e.half,
+               "half-beat tier visibility must follow the snap");
+    }
+
+    // Every snap option the editor exposes must be covered by the same rule.
+    for (SnapGrid snap : MusicTheory::getSnapOptions()) {
+        const double sub = MusicTheory::getSnapDuration(snap);
+        if (sub <= 0.0) {
+            continue;
+        }
+        const bool beat = timelineGridTierAlignedToSnap(1.0, sub);
+        const bool half = timelineGridTierAlignedToSnap(0.5, sub);
+        ASSERT(beat || half || sub == 4.0, "only snap-to-bar may hide both tiers");
+        if (beat) {
+            ASSERT(std::abs(1.0 / sub - std::round(1.0 / sub)) < 1e-4,
+                   "a visible beat tier must be a multiple of the snap");
+        }
+        if (half) {
+            ASSERT(std::abs(0.5 / sub - std::round(0.5 / sub)) < 1e-4,
+                   "a visible half-beat tier must be a multiple of the snap");
+        }
+    }
+
+    PASS("grid tiers follow the active snap");
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 int main() {
@@ -400,6 +450,7 @@ int main() {
     test_follow_target_keeps_playhead_visible();
     test_zoom_anchor_preserves_beat();
     test_grid_subdivision_matches_snap();
+    test_grid_tiers_follow_snap();
 
     std::cout << "\n=== Results: " << testsPassed << " passed, " << testsFailed << " failed ===\n";
     return testsFailed > 0 ? 1 : 0;

--- a/Tests/AestraUI/PianoRollPanelPersistenceTest.cpp
+++ b/Tests/AestraUI/PianoRollPanelPersistenceTest.cpp
@@ -48,10 +48,69 @@ void testHarmonyContextRoundtripThroughPanel() {
     expect(restored.snapToScale, "loadPattern should restore the edited snap state");
 }
 
+void testSelectionSurvivesCommittedEditRoundTrip() {
+    auto trackManager = std::make_shared<TrackManager>();
+    auto& patternManager = trackManager->getPatternManager();
+
+    MidiPayload payload;
+    Aestra::Audio::MidiNote n1;
+    n1.pitch = 60; n1.startBeat = 0.0; n1.durationBeats = 1.0; n1.velocity = 0.8f;
+    Aestra::Audio::MidiNote n2;
+    n2.pitch = 64; n2.startBeat = 2.0; n2.durationBeats = 1.0; n2.velocity = 0.8f;
+    Aestra::Audio::MidiNote n3;
+    n3.pitch = 67; n3.startBeat = 4.0; n3.durationBeats = 1.0; n3.velocity = 0.8f;
+    payload.notes = {n1, n2, n3};
+    const PatternID patternId = patternManager.createMidiPattern("Selection Roundtrip", 8.0, payload);
+
+    PianoRollPanel editor(trackManager);
+    editor.loadPattern(patternId);
+
+    // Ctrl+A selects every note.
+    AestraUI::NUIKeyEvent ctrlA;
+    ctrlA.keyCode = AestraUI::NUIKeyCode::A;
+    ctrlA.modifiers = AestraUI::NUIModifiers::Ctrl;
+    ctrlA.pressed = true;
+    editor.handleKeyEvent(ctrlA);
+
+    const auto& selected = editor.getNotes();
+    expect(selected.size() == 3, "Ctrl+A should select all three notes");
+    expect(selected.size() == 3 && selected[0].selected && selected[1].selected && selected[2].selected,
+           "all notes should be selected after Ctrl+A");
+
+    // Nudge right: a committed edit that runs savePattern -> CommandHistory ->
+    // OnStateChanged. The selection must survive that round trip.
+    AestraUI::NUIKeyEvent right;
+    right.keyCode = AestraUI::NUIKeyCode::Right;
+    right.pressed = true;
+    editor.handleKeyEvent(right);
+
+    const auto& afterMove = editor.getNotes();
+    expect(afterMove.size() == 3, "committed move should not change note count");
+    expect(afterMove.size() == 3 && afterMove[0].selected && afterMove[1].selected && afterMove[2].selected,
+           "selection must survive the save/reload round trip after a committed edit");
+
+    // The edit itself must still persist (default snap = Beat, +1.0 beat).
+    const PatternSource* stored = patternManager.getPattern(patternId);
+    expect(stored != nullptr && stored->isMidi(), "edited pattern should remain available");
+    if (stored && stored->isMidi()) {
+        const auto& storedNotes = std::get<MidiPayload>(stored->payload).notes;
+        expect(storedNotes.size() == 3, "saved pattern should keep all notes");
+        expect(storedNotes.size() == 3 && std::abs(storedNotes[0].startBeat - 1.0) < 0.001,
+               "nudge should persist +1 beat to the pattern manager");
+    }
+
+    // A second committed edit must not wipe the selection either.
+    editor.handleKeyEvent(right);
+    const auto& afterSecond = editor.getNotes();
+    expect(afterSecond.size() == 3 && afterSecond[0].selected && afterSecond[1].selected && afterSecond[2].selected,
+           "selection must survive repeated committed edits");
+}
+
 } // namespace
 
 int main() {
     testHarmonyContextRoundtripThroughPanel();
+    testSelectionSurvivesCommittedEditRoundTrip();
     if (failures == 0) {
         std::cout << "PianoRollPanelPersistenceTest passed\n";
         return EXIT_SUCCESS;

--- a/Tests/AestraUI/WindowPanelRaiseTest.cpp
+++ b/Tests/AestraUI/WindowPanelRaiseTest.cpp
@@ -1,0 +1,146 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// WindowPanelRaiseTest — regression for the transport-click panel-raise bug.
+//
+// The overlay layer forwards every press to every visible floating panel so
+// that clicks over empty overlay area pass through to the workspace. A
+// WindowPanel must therefore only raise itself (bringToFront) when the press
+// actually lands inside its bounds. Before the fix, any press anywhere —
+// including a click on the transport bar's Stop button, which sits above the
+// panels — popped every visible panel to the front, so double-clicking Stop
+// in Arsenal mode raised the ARSENAL panel over the piano roll.
+
+#include "NUIComponent.h"
+#include "NUITypes.h"
+#include "WindowPanel.h"
+
+#include <iostream>
+
+using namespace AestraUI;
+using namespace Aestra::Audio;
+
+namespace {
+
+int g_failures = 0;
+void check(bool cond, const char* what) {
+    if (!cond) {
+        std::cout << "[FAIL] " << what << "\n";
+        ++g_failures;
+    }
+}
+
+NUIMouseEvent leftPress(float x, float y) {
+    NUIMouseEvent e;
+    e.type = NUIMouseEventType::Down;
+    e.pressed = true;
+    e.button = NUIMouseButton::Left;
+    e.position = {x, y};
+    return e;
+}
+
+// Deliver one press exactly like OverlayLayer does: topmost child first, stop
+// at the first panel that consumes it.
+bool dispatchPress(NUIComponent& overlay, const NUIMouseEvent& event) {
+    const auto& children = overlay.getChildren();
+    for (auto it = children.rbegin(); it != children.rend(); ++it) {
+        if ((*it)->isVisible() && (*it)->isHitTestVisible() && (*it)->onMouseEvent(event)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool isTopmost(const NUIComponent& overlay, const WindowPanel& panel) {
+    const auto& children = overlay.getChildren();
+    return !children.empty() && children.back().get() == &panel;
+}
+
+void test_press_outside_bounds_does_not_raise() {
+    NUIComponent overlay;
+    overlay.setBounds({0, 0, 900, 600});
+
+    auto panelA = std::make_shared<WindowPanel>("A");
+    panelA->setBounds({100, 100, 300, 200});
+    auto panelB = std::make_shared<WindowPanel>("B");
+    panelB->setBounds({500, 100, 300, 200});
+    overlay.addChild(panelA);
+    overlay.addChild(panelB);
+
+    // Press far away from both panels — e.g. the transport bar strip.
+    const NUIMouseEvent press = leftPress(450, 20);
+    const bool consumed = dispatchPress(overlay, press);
+    check(!consumed, "an outside press must pass through to the workspace");
+    check(isTopmost(overlay, *panelB), "topmost panel must stay topmost after an outside press");
+    check(overlay.getChildren().size() == 2, "no panel may be removed or duplicated");
+
+    std::cout << "PASS: press outside panel bounds does not raise panels\n";
+}
+
+void test_press_inside_bounds_raises_panel() {
+    NUIComponent overlay;
+    overlay.setBounds({0, 0, 900, 600});
+
+    auto panelA = std::make_shared<WindowPanel>("A");
+    panelA->setBounds({100, 100, 300, 200});
+    auto panelB = std::make_shared<WindowPanel>("B");
+    panelB->setBounds({500, 100, 300, 200});
+    overlay.addChild(panelA);
+    overlay.addChild(panelB);
+    check(isTopmost(overlay, *panelB), "sanity: last added panel is topmost");
+
+    // Press inside panel A, which is behind panel B.
+    const bool consumed = dispatchPress(overlay, leftPress(150, 150));
+    check(consumed, "an inside press must be consumed by a panel");
+    check(isTopmost(overlay, *panelA), "a press inside a panel must raise it to the front");
+}
+
+void test_press_inside_topmost_panel_stays_consumed() {
+    NUIComponent overlay;
+    overlay.setBounds({0, 0, 900, 600});
+
+    auto panelA = std::make_shared<WindowPanel>("A");
+    panelA->setBounds({100, 100, 300, 200});
+    auto panelB = std::make_shared<WindowPanel>("B");
+    panelB->setBounds({500, 100, 300, 200});
+    overlay.addChild(panelA);
+    overlay.addChild(panelB);
+
+    const bool consumed = dispatchPress(overlay, leftPress(550, 150));
+    check(consumed, "press inside the topmost panel must be consumed");
+    check(isTopmost(overlay, *panelB), "topmost panel must remain topmost");
+}
+
+void test_raise_requires_bounds_not_z_position() {
+    // A panel must not raise on a press that overlaps its z-order slot but not
+    // its bounds — the exact transport-bar scenario.
+    NUIComponent overlay;
+    overlay.setBounds({0, 0, 900, 600});
+
+    auto panelA = std::make_shared<WindowPanel>("A");
+    panelA->setBounds({100, 100, 300, 200});
+    auto panelB = std::make_shared<WindowPanel>("B");
+    panelB->setBounds({500, 100, 300, 200});
+    overlay.addChild(panelA);
+    overlay.addChild(panelB);
+
+    const bool consumed = dispatchPress(overlay, leftPress(650, 20));
+    check(!consumed, "press above the topmost panel's bounds must pass through");
+    check(isTopmost(overlay, *panelB), "no panel may be raised by an out-of-bounds press");
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== WindowPanelRaise Unit Tests ===\n\n";
+
+    test_press_outside_bounds_does_not_raise();
+    test_press_inside_bounds_raises_panel();
+    test_press_inside_topmost_panel_stays_consumed();
+    test_raise_requires_bounds_not_z_position();
+
+    if (g_failures != 0) {
+        std::cout << "\n=== Results: " << g_failures << " failed ===\n";
+        return 1;
+    }
+    std::cout << "\n=== Results: all passed ===\n";
+    return 0;
+}

--- a/Tests/AestraUI/WindowPanelRaiseTest.cpp
+++ b/Tests/AestraUI/WindowPanelRaiseTest.cpp
@@ -71,8 +71,6 @@ void test_press_outside_bounds_does_not_raise() {
     check(!consumed, "an outside press must pass through to the workspace");
     check(isTopmost(overlay, *panelB), "topmost panel must stay topmost after an outside press");
     check(overlay.getChildren().size() == 2, "no panel may be removed or duplicated");
-
-    std::cout << "PASS: press outside panel bounds does not raise panels\n";
 }
 
 void test_press_inside_bounds_raises_panel() {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -672,6 +672,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerStereoParityTest.cpp")
     set_tests_properties(SamplerStereoParityTest PROPERTIES LABELS "audio;sampler;regression;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerCutSelfTest.cpp")
+    add_executable(SamplerCutSelfTest AestraAudio/SamplerCutSelfTest.cpp)
+    target_link_libraries(SamplerCutSelfTest PRIVATE AestraAudio)
+    target_include_directories(SamplerCutSelfTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME SamplerCutSelfTest COMMAND SamplerCutSelfTest)
+    set_tests_properties(SamplerCutSelfTest PROPERTIES LABELS "audio;sampler;regression;contract:audio")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerLoopModeTest.cpp")
     add_executable(SamplerLoopModeTest AestraAudio/SamplerLoopModeTest.cpp)
     target_link_libraries(SamplerLoopModeTest PRIVATE AestraAudio)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2045,6 +2045,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/TransportPausePreservesPositi
     set_tests_properties(TransportPausePreservesPositionTest PROPERTIES LABELS "audio;engine;transport;rt-safety;contract:audio")
 endif()
 
+# Pattern Transport Position Test (piano-roll playhead cue preservation)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternTransportPositionTest.cpp")
+    add_executable(PatternTransportPositionTest AestraAudio/PatternTransportPositionTest.cpp)
+    target_link_libraries(PatternTransportPositionTest PRIVATE AestraAudio)
+    target_include_directories(PatternTransportPositionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternTransportPositionTest COMMAND PatternTransportPositionTest)
+    set_tests_properties(PatternTransportPositionTest PROPERTIES LABELS "audio;engine;transport;pattern;contract:audio")
+endif()
+
 # AudioEngine Diagnostics Test
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/AudioEngineDiagnosticsTest.cpp")
     add_executable(AudioEngineDiagnosticsTest AestraAudio/AudioEngineDiagnosticsTest.cpp)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1795,6 +1795,28 @@ else()
     message(STATUS "PanelWindowClickSwallowTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Floating panels must only raise themselves on presses inside their bounds:
+# the overlay forwards every press to every visible panel, so a transport-bar
+# click must not pop panels to the front (the Arsenal-mode double-stop bug).
+if(TARGET AestraUI_Core AND TARGET AestraUI_Platform)
+    add_executable(WindowPanelRaiseTest
+        AestraUI/WindowPanelRaiseTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Panels/WindowPanel.cpp
+    )
+    target_link_libraries(WindowPanelRaiseTest PRIVATE AestraUI_Core AestraUI_Platform)
+    target_include_directories(WindowPanelRaiseTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+        ${CMAKE_SOURCE_DIR}/Source
+        ${CMAKE_SOURCE_DIR}/Source/Panels
+    )
+    add_test(NAME WindowPanelRaiseTest COMMAND WindowPanelRaiseTest)
+    set_tests_properties(WindowPanelRaiseTest PROPERTIES LABELS "ui;input;regression;contract:application")
+else()
+    message(STATUS "WindowPanelRaiseTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # Takes/History workspace panels: command-timeline presentation + navigation,
 # takes manifest listing, actions, inline rename, non-destructive branching.
 if(TARGET AestraUI_Core)


### PR DESCRIPTION
## Summary
Bug-triage pass over the piano-roll ticket: four root-cause fixes (selection persistence, grid/zoom/follow timing, pattern-mode transport cue, sampler voice choke) plus three follow-up fixes surfaced while verifying them (arsenal hard-stop state reset, snap-consistent grid tiers, floating-panel raise bounds). One isolated commit per fix, each with a regression test, all user-verified in-app.

## Why
Each bug broke a core piano-roll/transport expectation: selection vanishing after edits, a grid that advertised positions snap could not hit, playback ignoring the scrubbed playhead, retriggered sampler voices not choking, transport clicks raising floating panels, and stale transport state after a double-stop.

## Per-bug breakdown

### BUG 1 — Selection lost after committed edits — `0c0b2349`
Every committed edit (commitNotes → savePattern → CommandHistory pushAndExecute) fired the state-changed callback, which reloaded the pattern and rebuilt every note with `selected=false` — the reload exists only for external undo/redo. The panel's own save is now skipped when `m_applyingUndoRedo` is already set, so the selection survives.
Test: `PianoRollPanelPersistenceTest` (59 lines).

### BUG 2 — Grid, zoom, and follow not aligned with timeline timing — `04595222`
Grid renders subdivisions at the active snap resolution so every snap position is a drawn line; zoom is one anchored, multiplicative path shared by ruler and Ctrl+wheel; follow-playhead eases toward its target instead of teleporting, so it no longer fights user scroll.
Test: `PianoRollInteractionTest` follow-guard, zoom-anchor, and snap-subdivision contracts (20/20).

### BUG 3 — Pattern-mode playhead cue ignored on transport start — `476fd93e`
The engine unconditionally zeroed `m_globalSamplePos` on pattern-mode stop/restart edges, wiping the scrubbed piano-roll cue: "cursor at beat 2 → play starts at beat 1". The same edge broke pause/resume (pause preserves via `kTransportPreservePosition`, but the stop edge zeroed it anyway). The engine now honors the pushed position and wraps only cues at/past the loop end, matching the render path.
Tests: `PatternTransportPositionTest` — 6 scenarios: play from scrubbed cue, pause preserves, resume from paused position, stop returns to cue, cue past loop end wraps, scheduler refill skips pre-cue notes.

### BUG 4 — Sampler retrigger without explicit cut-self choke — `dda5d81b`
Retriggering a sampler note no longer leaves the previous voice ringing: explicit cut-self voice choke in the sampler plus preview-side wiring in `AestraContent`/`SampleEditorPanel`.
Test: `SamplerCutSelfTest` (305 lines).

### Follow-up 1 — Arsenal transport state not reset on hard stop — `8714ede9`
The Arsenal branch of `stopFromCurrentFocus` lacked the timeline branch's hard-stop rewind (setPlayStartPosition(0)/setPosition(0)/clearDisplayPositionOverride/setGlobalSamplePos(0)), so a double-stop panicked the engine but left position/cue/playhead stale. Verified in-app by user.

### Follow-up 2 — Grid tiers the active snap cannot hit — `2dcc5b9d`
The grid always drew the half-beat tier, advertising positions snap cannot produce ("producers will feel tricked"). New pure helper `timelineGridTierAlignedToSnap` gates each tier on the active snap; timeline callers keep every tier.
Test: `test_grid_tiers_follow_snap` — explicit expectation table per snap option + invariants over `getSnapOptions()` (21/21).

### Follow-up 3 — Floating panels raised by out-of-bounds presses — `6427cac1`
`WindowPanel::onMouseEvent` called `bringToFront()` on every press, and the overlay layer forwards every press to every visible floating panel (pass-through design) — so transport-bar clicks outside the panels raised the ARSENAL panel over the piano roll ("stop click opens the arsenal"). Panels now raise only on presses inside their bounds.
Test: `WindowPanelRaiseTest` — 4 checks (out-of-bounds pass-through, in-bounds raise, topmost stays consumed, no raise above topmost). Proven red before the fix, green after.

### Chore — `7979c884`
`.gitignore` entries for labs/perf apparatus results.

## Testing performed
- `PianoRollPanelPersistenceTest`, `PianoRollInteractionTest`, `PatternTransportPositionTest`, `SamplerCutSelfTest`, `WindowPanelRaiseTest` — all pass.
- Full `ctest` on the branch tip: 233/235, the two "failures" being the pre-existing runtime-gated skips (`AestraWatchdogTest`, `AestraCrashTest` — Not Run, gated behind `AESTRA_ENABLE_RUNTIME_TESTS`).
- Full `Aestra` app builds (Release, core mode).
- In-app user verification: grid behavior, double-stop transport reset, panel-raise fix, pattern playhead cue (multiple runs).

## Producer note
None

## Docs updated?
No

## Risk/rollback notes
- Each fix is a single commit — revert individually if a behavior regression shows up.
- No serialization/project-format changes, no plugin/parameter-ID changes, no public docs.
- DSP touched only in the sampler cut-self choke (retrigger path) and the engine stop/restart edge (position handling); no sample-rate/latency/state-format impact.
- Real-time paths kept allocation/lock-free; the pattern-playhead change is pure position math on existing atomics.

## Decision citation

Objective: Piano Roll editing parity — rhythmic note operations
Decision: FD-09 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind: planned
Reversal: —


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Preserve piano-roll note selection across committed edits and improve grid behavior for snap-aware subdivisions, zoom anchoring, zoom validation, and playhead following.
- Honor scrubbed and paused positions in pattern-mode transport, reset Arsenal state on hard stop, and add regression coverage.
- Add sampler Cut Self mode with UI controls, persistence, and same-note voice choking while retaining polyphony for different notes.
- Raise floating panels only for in-bounds mouse presses.
- Add regression tests for transport, sampler, piano roll, panel persistence, and window-panel behavior.
- Add `.gitignore` coverage for performance-lab output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->