### PR TITLE
feat: clip pitch in semitones, independent from speed (#746)

### DIFF
--- a/AestraAudio/include/Commands/TrimClipCommand.h
+++ b/AestraAudio/include/Commands/TrimClipCommand.h
@@ -84,15 +84,12 @@ public:
         if (m_originalWasAudio) {
             // The source read offset must never go negative: clamp the start to
             // the source-start beat (start - offset), same formula the UI drag
-            // uses, so the model can never hold an unrenderable offset.
+            // uses, so the model can never hold an unrenderable offset. The
+            // combined Speed/Pitch varispeed is the render authority (#746).
             const double secondsPerBeat = m_model.beatToSeconds(1.0);
-            float rate = clip->edits.playbackRate;
-            if (!std::isfinite(rate) || rate <= 0.0f) {
-                rate = 1.0f;
-            }
-            rate = std::clamp(rate, 0.25f, 4.0f);
+            const double varispeed = static_cast<double>(clip->edits.effectiveVarispeed());
             const double minStart =
-                m_originalStartBeat - m_originalSourceOffsetSeconds / (secondsPerBeat * rate);
+                m_originalStartBeat - m_originalSourceOffsetSeconds / (secondsPerBeat * varispeed);
             if (newStart < minStart) {
                 newStart = minStart;
             }
@@ -100,14 +97,14 @@ public:
                 return; // Clamped start swallowed the trim range - don't apply
             }
 
-            clip->durationSeconds = m_model.beatToSeconds(newEnd - newStart);
+            clip->durationSeconds = m_model.beatToSeconds(newEnd - newStart) / varispeed;
             if (newStart != m_originalStartBeat) {
                 // Left-edge trim: advance the source read position by the same
-                // musical amount (scaled by playback rate so the right edge
-                // stays pinned under varispeed). Right-edge trims leave the
+                // musical amount (scaled by varispeed so the right edge stays
+                // pinned under Speed/Pitch). Right-edge trims leave the
                 // source offset untouched.
                 clip->sourceOffsetSeconds =
-                    m_originalSourceOffsetSeconds + (newStart - m_originalStartBeat) * secondsPerBeat * rate;
+                    m_originalSourceOffsetSeconds + (newStart - m_originalStartBeat) * secondsPerBeat * varispeed;
             }
         }
 

--- a/AestraAudio/include/Core/AudioGraph.h
+++ b/AestraAudio/include/Core/AudioGraph.h
@@ -34,6 +34,7 @@ struct ClipRenderState {
     float gain{1.0f};
     float pan{0.0f};
     float playbackRate{1.0f};
+    float pitchSemitones{0.0f};
     uint64_t fadeInSamples{0};
     uint64_t fadeOutSamples{0};
 };

--- a/AestraAudio/include/IO/WaveformCache.h
+++ b/AestraAudio/include/IO/WaveformCache.h
@@ -218,6 +218,16 @@ public:
     void getPeaksForRange(uint32_t channel, SampleIndex startSample, SampleIndex endSample, uint32_t numPixels,
                           std::vector<WaveformPeak>& outPeaks) const;
 
+    /**
+     * @brief Get peaks for a source range while preserving fractional pixel boundaries
+     *
+     * Clip previews often map a timeline position to a fractional source frame. Keeping
+     * those boundaries until each pixel is formed prevents adjacent slices and zoom levels
+     * from silently re-binning the same source audio differently.
+     */
+    void getPeaksForRangePrecise(uint32_t channel, double startSample, double endSample, uint32_t numPixels,
+                                 std::vector<WaveformPeak>& outPeaks) const;
+
     /// Get a single peak for quick display
     WaveformPeak getQuickPeak(uint32_t channel, SampleIndex startSample, SampleIndex numSamples) const;
 

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -94,6 +94,19 @@ struct ClipEdits {
         return std::clamp(semitones, kMinPitchSemitones, kMaxPitchSemitones);
     }
 
+    /** Combined varispeed factor (Speed x 2^(Pitch/12)), clamped to the render
+     *  envelope. Single authority for source-domain offset/duration math in
+     *  split, trim and the editor; mirrors ClipRenderKernel::renderClipInto
+     *  exactly, so editing math always agrees with what the renderer plays
+     *  (#746, split/trim varispeed regression). */
+    float effectiveVarispeed() const noexcept {
+        const float rate = std::isfinite(playbackRate) ? std::clamp(playbackRate, 0.25f, 4.0f) : 1.0f;
+        const float pitch = std::isfinite(pitchSemitones)
+                                ? std::clamp(pitchSemitones, kMinPitchSemitones, kMaxPitchSemitones)
+                                : 0.0f;
+        return std::clamp(rate * std::pow(2.0f, pitch / 12.0f), 0.25f, 4.0f);
+    }
+
     /**
      * Defaults for a newly created audio clip. The value-initialized defaults
      * above intentionally remain unity for legacy project fields and generic

--- a/AestraAudio/include/Models/ClipInstance.h
+++ b/AestraAudio/include/Models/ClipInstance.h
@@ -71,6 +71,10 @@ struct ClipEdits {
     float pan = 0.0f;
     bool muted = false;
     float playbackRate = 1.0f;
+    /** Musical pitch offset in semitones, independent of Speed. Rendered as
+     *  2^(st/12) folded into the same varispeed ratio as playbackRate; pitch
+     *  up plays faster/shorter like any varispeed (#746). */
+    float pitchSemitones = 0.0f;
     double sourceStart = 0.0;
 
     /** Musical varispeed control used by the Audio Clip Editor. Pitch and
@@ -109,7 +113,8 @@ struct ClipEdits {
     bool operator==(const ClipEdits& other) const {
         return fadeInBeats == other.fadeInBeats && fadeOutBeats == other.fadeOutBeats &&
                gainLinear == other.gainLinear && pan == other.pan && muted == other.muted &&
-               playbackRate == other.playbackRate && sourceStart == other.sourceStart;
+               playbackRate == other.playbackRate && pitchSemitones == other.pitchSemitones &&
+               sourceStart == other.sourceStart;
     }
     bool operator!=(const ClipEdits& other) const { return !(*this == other); }
 };

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -503,6 +503,11 @@ public:
                     std::isfinite(clip.edits.pan) ? std::clamp(clip.edits.pan, -1.0f, 1.0f) : 0.0f;
                 clipInfo.playbackRate =
                     std::isfinite(clip.edits.playbackRate) ? std::clamp(clip.edits.playbackRate, 0.25f, 4.0f) : 1.0f;
+                clipInfo.pitchSemitones =
+                    std::isfinite(clip.edits.pitchSemitones)
+                        ? std::clamp(clip.edits.pitchSemitones, ClipEdits::kMinPitchSemitones,
+                                     ClipEdits::kMaxPitchSemitones)
+                        : 0.0f;
                 const double fadeInBeats =
                     std::isfinite(clip.edits.fadeInBeats) ? std::max(0.0, static_cast<double>(clip.edits.fadeInBeats))
                                                          : 0.0;

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -421,10 +421,15 @@ public:
         clip->durationBeats = splitBeat - clip->startBeat;
         clip->edits.fadeOutBeats = 0.0f;
         if (isAudioClipUnlocked(*clip)) {
+            // Source-domain invariants under varispeed (#746): the second half
+            // must start at splitOffsetSeconds * varispeed into the source and
+            // both halves keep durationSeconds == beatToSeconds(durationBeats)
+            // / varispeed, matching what the renderer reads.
             const double splitOffsetSeconds = beatToSeconds(splitBeat - clip->startBeat);
-            newClip.sourceOffsetSeconds = clip->sourceOffsetSeconds + splitOffsetSeconds;
-            clip->durationSeconds = beatToSeconds(clip->durationBeats);
-            newClip.durationSeconds = beatToSeconds(newClip.durationBeats);
+            const double varispeed = static_cast<double>(clip->edits.effectiveVarispeed());
+            newClip.sourceOffsetSeconds = clip->sourceOffsetSeconds + splitOffsetSeconds * varispeed;
+            clip->durationSeconds = beatToSeconds(clip->durationBeats) / varispeed;
+            newClip.durationSeconds = beatToSeconds(newClip.durationBeats) / varispeed;
         }
 
         // Add new clip
@@ -464,19 +469,6 @@ public:
         snapshot->projectSampleRate = m_projectSampleRate;
 
         const double samplesPerBeat = (m_projectSampleRate * 60.0) / snapshot->bpm;
-        constexpr uint64_t kMaxSampleOffset = std::numeric_limits<uint64_t>::max();
-        const auto toSampleOffset = [](double offset, double scale) -> uint64_t {
-            constexpr uint64_t kMaxOffset = std::numeric_limits<uint64_t>::max();
-            if (!std::isfinite(offset) || offset <= 0.0 || !std::isfinite(scale) || scale <= 0.0) {
-                return 0;
-            }
-
-            const long double scaled = static_cast<long double>(offset) * static_cast<long double>(scale);
-            if (scaled >= static_cast<long double>(kMaxOffset)) {
-                return kMaxOffset;
-            }
-            return static_cast<uint64_t>(scaled);
-        };
 
         const bool anyLaneSolo = std::any_of(m_lanes.begin(), m_lanes.end(),
                                              [](const PlaylistLane& lane) { return lane.solo && !lane.muted; });
@@ -491,13 +483,7 @@ public:
                 ClipRuntimeInfo clipInfo;
                 clipInfo.startTime = static_cast<uint64_t>(clip.startBeat * samplesPerBeat);
                 clipInfo.duration = static_cast<uint64_t>(clip.durationBeats * samplesPerBeat);
-                const uint64_t canonicalSourceStart =
-                    clip.durationSeconds > 0.0 ? toSampleOffset(clip.sourceOffsetSeconds, m_projectSampleRate)
-                                               : toSampleOffset(clip.sourceOffset, samplesPerBeat);
-                const uint64_t instanceSourceStart = toSampleOffset(clip.edits.sourceStart, 1.0);
-                clipInfo.sourceStart = instanceSourceStart > kMaxSampleOffset - canonicalSourceStart
-                                           ? kMaxSampleOffset
-                                           : canonicalSourceStart + instanceSourceStart;
+                clipInfo.sourceStart = getClipSourceStartSamples(clip);
                 clipInfo.gainLinear = std::isfinite(clip.edits.gainLinear) ? clip.edits.gainLinear : 1.0f;
                 clipInfo.pan =
                     std::isfinite(clip.edits.pan) ? std::clamp(clip.edits.pan, -1.0f, 1.0f) : 0.0f;
@@ -571,6 +557,39 @@ public:
      */
     double getProjectSampleRate() const {
         return m_projectSampleRate;
+    }
+
+    /**
+     * @brief Resolve a clip's source start in project-rate samples.
+     *
+     * This is shared by the live renderer and the timeline waveform preview so
+     * split/trim offsets cannot make audio and visuals start at different source
+     * positions. The legacy beat-domain offset remains the fallback for older
+     * clips that do not have canonical audio duration metadata.
+     */
+    uint64_t getClipSourceStartSamples(const ClipInstance& clip) const {
+        constexpr uint64_t kMaxSampleOffset = std::numeric_limits<uint64_t>::max();
+        const auto toSampleOffset = [](double offset, double scale) -> uint64_t {
+            if (!std::isfinite(offset) || offset <= 0.0 || !std::isfinite(scale) || scale <= 0.0) {
+                return 0;
+            }
+
+            const long double scaled = static_cast<long double>(offset) * static_cast<long double>(scale);
+            if (scaled >= static_cast<long double>(kMaxSampleOffset)) {
+                return kMaxSampleOffset;
+            }
+            return static_cast<uint64_t>(scaled);
+        };
+
+        const double bpm = std::max(m_bpm, 1.0);
+        const double samplesPerBeat = (m_projectSampleRate * 60.0) / bpm;
+        const uint64_t canonicalSourceStart =
+            clip.durationSeconds > 0.0 ? toSampleOffset(clip.sourceOffsetSeconds, m_projectSampleRate)
+                                       : toSampleOffset(clip.sourceOffset, samplesPerBeat);
+        const uint64_t instanceSourceStart = toSampleOffset(clip.edits.sourceStart, 1.0);
+        return instanceSourceStart > kMaxSampleOffset - canonicalSourceStart
+                   ? kMaxSampleOffset
+                   : canonicalSourceStart + instanceSourceStart;
     }
 
     /**

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -569,7 +569,7 @@ public:
      */
     uint64_t getClipSourceStartSamples(const ClipInstance& clip) const {
         constexpr uint64_t kMaxSampleOffset = std::numeric_limits<uint64_t>::max();
-        const auto toSampleOffset = [](double offset, double scale) -> uint64_t {
+        const auto toSampleOffset = [kMaxSampleOffset](double offset, double scale) -> uint64_t {
             if (!std::isfinite(offset) || offset <= 0.0 || !std::isfinite(scale) || scale <= 0.0) {
                 return 0;
             }

--- a/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
+++ b/AestraAudio/include/Models/PlaylistRuntimeSnapshot.h
@@ -35,6 +35,7 @@ struct ClipRuntimeInfo {
     float gainLinear{1.0f};
     float pan{0.0f};
     float playbackRate{1.0f};
+    float pitchSemitones{0.0f};
     uint64_t fadeInSamples{0};
     uint64_t fadeOutSamples{0};
     /** Stable source-level mixer destination (0 routes directly to Master). */

--- a/AestraAudio/src/AudioRenderer.cpp
+++ b/AestraAudio/src/AudioRenderer.cpp
@@ -207,11 +207,16 @@ void AudioRenderer::renderClipAudio(double* outputBuffer, TrackRTState& state, u
         const double srcRate = clip.sourceSampleRate > 0.0 ? clip.sourceSampleRate : outputRate;
         // Mirrors ClipRenderKernel::renderClip: clip Speed (playbackRate) scales
         // the resample ratio. Without this, isolated-track bounces ignored speed
-        // while live playback and full-mix export honored it (#745).
+        // while live playback and full-mix export honored it (#745). Pitch
+        // (pitchSemitones) folds into the same envelope (#746).
         const double playbackRate =
             std::isfinite(clip.playbackRate) ? MixMath::clampD(static_cast<double>(clip.playbackRate), 0.25, 4.0)
                                              : 1.0;
-        const double ratio = (srcRate / outputRate) * playbackRate;
+        const double pitchSemitones = std::isfinite(clip.pitchSemitones)
+                                          ? MixMath::clampD(static_cast<double>(clip.pitchSemitones), -24.0, 24.0)
+                                          : 0.0;
+        const double ratio = (srcRate / outputRate) *
+                             MixMath::clampD(playbackRate * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
         double phase = clip.sampleOffset + static_cast<double>(start - clip.startSample) * ratio;
 
         if (clip.totalFrames > 0) {

--- a/AestraAudio/src/Core/ClipRenderKernel.cpp
+++ b/AestraAudio/src/Core/ClipRenderKernel.cpp
@@ -40,6 +40,7 @@ ClipRenderState makeClipRenderState(const ClipRuntimeInfo& clipInfo, double proj
     clip.gain = clipInfo.gainLinear;
     clip.pan = clipInfo.pan;
     clip.playbackRate = clipInfo.playbackRate;
+    clip.pitchSemitones = clipInfo.pitchSemitones;
     clip.fadeInSamples = clipInfo.fadeInSamples;
     clip.fadeOutSamples = clipInfo.fadeOutSamples;
     return clip;
@@ -84,7 +85,15 @@ ClipRenderResult renderClipInto(const ClipRenderState& clip, uint64_t blockStart
         const double srcRate = clip.sourceSampleRate > 0.0 ? clip.sourceSampleRate : outputRate;
         const double playbackRate =
             std::isfinite(clip.playbackRate) ? MixMath::clampD(static_cast<double>(clip.playbackRate), 0.25, 4.0) : 1.0;
-        const double ratio = (srcRate / outputRate) * playbackRate;
+        // Pitch folds into the same varispeed envelope as Speed: 2^(st/12)
+        // multiplies the rate, and the combined factor stays bounded by the
+        // existing 0.25..4.0 clamp so phase advancement stays bounded (#746).
+        const double pitchSemitones = std::isfinite(clip.pitchSemitones)
+                                          ? MixMath::clampD(static_cast<double>(clip.pitchSemitones), -24.0, 24.0)
+                                          : 0.0;
+        const double varispeed =
+            MixMath::clampD(playbackRate * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
+        const double ratio = (srcRate / outputRate) * varispeed;
 
         // Source position
         const double outputFrameOffset = static_cast<double>(start - clip.startSample);

--- a/AestraAudio/src/IO/WaveformCache.cpp
+++ b/AestraAudio/src/IO/WaveformCache.cpp
@@ -140,21 +140,31 @@ size_t WaveformCache::selectLevel(double samplesPerPixel) const {
 
 void WaveformCache::getPeaksForRange(uint32_t channel, SampleIndex startSample, SampleIndex endSample,
                                      uint32_t numPixels, std::vector<WaveformPeak>& outPeaks) const {
+    getPeaksForRangePrecise(channel, static_cast<double>(startSample), static_cast<double>(endSample), numPixels,
+                            outPeaks);
+}
+
+void WaveformCache::getPeaksForRangePrecise(uint32_t channel, double startSample, double endSample,
+                                            uint32_t numPixels, std::vector<WaveformPeak>& outPeaks) const {
     std::shared_lock<std::shared_mutex> lock(m_mutex);
 
     outPeaks.clear();
     outPeaks.resize(numPixels);
 
-    if (!m_ready.load(std::memory_order_acquire) || m_levels.empty() || numPixels == 0) {
+    if (!m_ready.load(std::memory_order_acquire) || m_levels.empty() || numPixels == 0 ||
+        !std::isfinite(startSample) || !std::isfinite(endSample)) {
         return;
     }
 
+    const double sourceFrames = static_cast<double>(m_sourceFrames);
+    startSample = std::clamp(startSample, 0.0, sourceFrames);
+    endSample = std::clamp(endSample, 0.0, sourceFrames);
     if (channel >= m_numChannels || startSample >= endSample) {
         return;
     }
 
     // Calculate samples per pixel
-    double samplesPerPixel = static_cast<double>(endSample - startSample) / numPixels;
+    const double samplesPerPixel = (endSample - startSample) / static_cast<double>(numPixels);
 
     // Select appropriate mip level: coarsest where samplesPerPeak <= samplesPerPixel
     size_t levelIdx = 0;
@@ -170,13 +180,17 @@ void WaveformCache::getPeaksForRange(uint32_t channel, SampleIndex startSample, 
 
     // Generate peaks for each pixel by merging LOD entries overlapping the pixel's sample range.
     // This avoids interpolation of min/max (which is physically meaningless) and ensures
-    // deterministic, subpixel-stable mapping.
+    // deterministic, source-anchored mapping. The fractional range is retained until the
+    // cache level is queried, so a clip split cannot reset the pixel grid at its seam.
     for (uint32_t pixel = 0; pixel < numPixels; ++pixel) {
-        double startPeakF = (startSample + pixel * samplesPerPixel) / level.samplesPerPeak;
-        double endPeakF = (startSample + (pixel + 1) * samplesPerPixel) / level.samplesPerPeak;
+        const double pixelStart = startSample + static_cast<double>(pixel) * samplesPerPixel;
+        const double pixelEnd = startSample + static_cast<double>(pixel + 1) * samplesPerPixel;
+        const double startPeakF = pixelStart / level.samplesPerPeak;
+        const double endPeakF = pixelEnd / level.samplesPerPeak;
 
         SampleIndex startPeak = static_cast<SampleIndex>(std::floor(startPeakF));
         SampleIndex endPeak = static_cast<SampleIndex>(std::ceil(endPeakF));
+        endPeak = std::max(endPeak, startPeak + 1);
         outPeaks[pixel] = level.getPeakRange(channel, startPeak, endPeak);
     }
 }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -29,6 +29,7 @@
 #include <charconv>
 #include <cmath>
 #include <chrono>
+#include <limits>
 #include <string_view>
 #include <unordered_map>
 
@@ -539,38 +540,35 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     size_t numChannels = audioData.numChannels;
     size_t totalFrames = audioData.numFrames;
 
-    // sourceStart conversion (project rate -> source rate)
-    SampleIndex sourceOffset = clip.edits.sourceStart;
     double sampleRate = source->getSampleRate();
     double bpm = m_trackManager ? m_trackManager->getPlaylistModel().getBPM() : 120.0;
     double secondsPerBeat = 60.0 / bpm;
     double clipDurationSeconds = clip.durationBeats * secondsPerBeat;
     const double timelineFrames = std::max(1.0, clipDurationSeconds * sampleRate);
-    const double playbackRate = std::isfinite(clip.edits.playbackRate)
-                                    ? std::clamp(static_cast<double>(clip.edits.playbackRate), 0.25, 4.0)
-                                    : 1.0;
-    const double pitchSemitones = std::isfinite(clip.edits.pitchSemitones)
-                                      ? std::clamp(static_cast<double>(clip.edits.pitchSemitones), -24.0, 24.0)
-                                      : 0.0;
+
+    // Use the same project-rate source start as the runtime snapshot. This is
+    // what keeps a split/trim waveform on the same source region as playback,
+    // including legacy beat-domain clips and instance-level slips.
+    const auto& playlist = m_trackManager->getPlaylistModel();
+    const double projectSampleRate = playlist.getProjectSampleRate();
+    if (!std::isfinite(projectSampleRate) || projectSampleRate <= 0.0) return;
+    const double scaledSourceOffset =
+        static_cast<double>(playlist.getClipSourceStartSamples(clip)) * (sampleRate / projectSampleRate);
+    if (!std::isfinite(scaledSourceOffset) || scaledSourceOffset < 0.0 ||
+        scaledSourceOffset >= static_cast<double>(totalFrames)) {
+        return;
+    }
     // Pitch and speed share the varispeed envelope, matching the render path
     // (ClipRenderKernel) so the preview consumes source frames like the audio.
-    const double varispeed = std::clamp(playbackRate * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
-
-    double projectSampleRate = m_trackManager ? m_trackManager->getPlaylistModel().getProjectSampleRate() : 48000.0;
-    size_t scaledSourceOffset = static_cast<size_t>(std::round(static_cast<double>(sourceOffset) * (sampleRate / projectSampleRate)));
-    if (scaledSourceOffset >= totalFrames) {
-        scaledSourceOffset = 0;
-    }
+    const double varispeed = static_cast<double>(clip.edits.effectiveVarispeed());
 
     const double visibleOutputStart = static_cast<double>(offsetRatio) * timelineFrames;
     const double visibleOutputEnd = static_cast<double>(offsetRatio + visibleRatio) * timelineFrames;
-    const double exactStart = static_cast<double>(scaledSourceOffset) + visibleOutputStart * varispeed;
-    const double exactEnd = static_cast<double>(scaledSourceOffset) + visibleOutputEnd * varispeed;
-    size_t startFrame = static_cast<size_t>(exactStart);
-    size_t endFrame = static_cast<size_t>(exactEnd);
-    startFrame = std::min(startFrame, totalFrames);
-    endFrame = std::min(endFrame, totalFrames);
-    if (startFrame >= endFrame) return;
+    const double exactStart = scaledSourceOffset + visibleOutputStart * varispeed;
+    const double exactEnd = scaledSourceOffset + visibleOutputEnd * varispeed;
+    const double sourceStart = std::clamp(exactStart, 0.0, static_cast<double>(totalFrames));
+    const double sourceEnd = std::clamp(exactEnd, 0.0, static_cast<double>(totalFrames));
+    if (sourceStart >= sourceEnd) return;
 
     // The clip rectangle stays fixed on the timeline while varispeed changes
     // how quickly source frames are consumed. If the source ends before this
@@ -579,7 +577,7 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     AestraUI::NUIRect audibleBounds = bounds;
     const double visibleOutputFrames = visibleOutputEnd - visibleOutputStart;
     const double availableOutputEnd =
-        (static_cast<double>(totalFrames) - static_cast<double>(scaledSourceOffset)) / varispeed;
+        (static_cast<double>(totalFrames) - scaledSourceOffset) / varispeed;
     if (visibleOutputFrames > 0.0 && availableOutputEnd < visibleOutputEnd) {
         const double audibleOutputFrames = std::max(0.0, availableOutputEnd - visibleOutputStart);
         audibleBounds.width *= static_cast<float>(std::clamp(audibleOutputFrames / visibleOutputFrames, 0.0, 1.0));
@@ -587,23 +585,14 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     if (audibleBounds.width <= 0.0f)
         return;
 
-    size_t visibleFrames = endFrame - startFrame;
-    if (visibleFrames == 0) return;
-
     // Waveform ink base is the clip hue at full brightness; deriveWaveformInk()
     // lifts it bright + near-opaque so the wave reads boldly over the fill.
     const bool clipSelected = (clip.id == m_selectedClipId);
     const AestraUI::NUIColor clipTint = AestraUI::waveformTintTone(resolveClipDisplayColor(clip), clipSelected);
 
-    const double samplesPerPixel = static_cast<double>(visibleFrames) / static_cast<double>(audibleBounds.width);
-
-    // Deep zoom: fewer source samples than pixels — draw the actual sample
-    // curve with sub-sample positioning instead of a peak envelope
-    if (samplesPerPixel <= 1.0) {
-        drawSampleWaveform(renderer, audibleBounds, audioData, exactStart,
-                           std::min(exactEnd, static_cast<double>(totalFrames)), clipTint);
-        return;
-    }
+    // Keep source-frame coordinates fractional until bins are formed. This makes
+    // the deep and cached paths use identical pixel geometry at every zoom level.
+    const double samplesPerPixel = (sourceEnd - sourceStart) / static_cast<double>(audibleBounds.width);
 
     // One peak column per pixel: filled-strip rendering needs full density,
     // and the mip cache makes per-pixel queries cheap at any zoom
@@ -616,9 +605,9 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     if (samplesPerPixel < static_cast<double>(Aestra::Audio::WaveformCache::DEFAULT_BASE_SAMPLES_PER_PEAK)) {
         // Zoomed past the finest mip level: compute peaks directly from the
         // buffer. Bounded work — at most base-mip samples per visible pixel.
-        computeDirectPeaks(audioData, 0, startFrame, endFrame, numBars, m_waveformPeaksL);
+        computeDirectPeaks(audioData, 0, sourceStart, sourceEnd, numBars, m_waveformPeaksL);
         if (numChannels > 1) {
-            computeDirectPeaks(audioData, 1, startFrame, endFrame, numBars, m_waveformPeaksR);
+            computeDirectPeaks(audioData, 1, sourceStart, sourceEnd, numBars, m_waveformPeaksR);
         }
     } else {
         // Normal zoom: precomputed mip peaks only; no per-render scanning
@@ -632,9 +621,9 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
             return;
         }
 
-        waveformCache->getPeaksForRange(0, startFrame, endFrame, numBars, m_waveformPeaksL);
+        waveformCache->getPeaksForRangePrecise(0, sourceStart, sourceEnd, numBars, m_waveformPeaksL);
         if (numChannels > 1) {
-            waveformCache->getPeaksForRange(1, startFrame, endFrame, numBars, m_waveformPeaksR);
+            waveformCache->getPeaksForRangePrecise(1, sourceStart, sourceEnd, numBars, m_waveformPeaksR);
         }
     }
 
@@ -747,109 +736,50 @@ void TrackUIComponent::drawCombinedWaveform(AestraUI::NUIRenderer& renderer, con
 }
 
 void TrackUIComponent::computeDirectPeaks(const Aestra::Audio::AudioBufferData& buffer, uint32_t channel,
-                                          size_t startFrame, size_t endFrame, int numColumns,
+                                          double startFrame, double endFrame, int numColumns,
                                           std::vector<Aestra::Audio::WaveformPeak>& outPeaks) {
     outPeaks.clear();
     if (numColumns <= 0 || buffer.numChannels == 0 || buffer.numFrames == 0) return;
 
-    endFrame = std::min(endFrame, static_cast<size_t>(buffer.numFrames));
+    if (!std::isfinite(startFrame) || !std::isfinite(endFrame)) return;
+    startFrame = std::clamp(startFrame, 0.0, static_cast<double>(buffer.numFrames));
+    endFrame = std::clamp(endFrame, 0.0, static_cast<double>(buffer.numFrames));
     if (startFrame >= endFrame) return;
     channel = std::min(channel, buffer.numChannels - 1);
 
     const float* data = buffer.interleavedData.data();
     const size_t stride = buffer.numChannels;
-    const double framesPerColumn = static_cast<double>(endFrame - startFrame) / static_cast<double>(numColumns);
+    const double framesPerColumn = (endFrame - startFrame) / static_cast<double>(numColumns);
+    const auto readSample = [data, stride, channel](size_t frame) {
+        const float sample = data[frame * stride + channel];
+        return std::isfinite(sample) ? sample : 0.0f;
+    };
 
     outPeaks.reserve(static_cast<size_t>(numColumns));
     for (int col = 0; col < numColumns; ++col) {
-        size_t f0 = startFrame + static_cast<size_t>(static_cast<double>(col) * framesPerColumn);
-        size_t f1 = startFrame + static_cast<size_t>(static_cast<double>(col + 1) * framesPerColumn);
-        f0 = std::min(f0, endFrame - 1);
-        f1 = std::max(std::min(f1, endFrame), f0 + 1);
+        const double pixelStart = startFrame + static_cast<double>(col) * framesPerColumn;
+        const double pixelEnd = startFrame + static_cast<double>(col + 1) * framesPerColumn;
+        size_t f0 = static_cast<size_t>(std::floor(pixelStart));
+        size_t f1 = static_cast<size_t>(std::ceil(pixelEnd));
+        f0 = std::min(f0, static_cast<size_t>(buffer.numFrames) - 1);
+        f1 = std::max(std::min(f1, static_cast<size_t>(buffer.numFrames)), f0 + 1);
 
-        float minVal = data[f0 * stride + channel];
+        float minVal = readSample(f0);
         float maxVal = minVal;
         double sumSq = 0.0;
         for (size_t f = f0; f < f1; ++f) {
-            const float s = data[f * stride + channel];
+            const float s = readSample(f);
             minVal = std::min(minVal, s);
             maxVal = std::max(maxVal, s);
             sumSq += static_cast<double>(s) * s;
         }
 
-        const uint32_t count = static_cast<uint32_t>(f1 - f0);
+        const uint32_t count = static_cast<uint32_t>(
+            std::min<size_t>(f1 - f0, std::numeric_limits<uint32_t>::max()));
         const float rms = static_cast<float>(std::sqrt(sumSq / static_cast<double>(count)));
         outPeaks.emplace_back(minVal, maxVal, rms, count);
         outPeaks.back().sanitize();
     }
-}
-
-void TrackUIComponent::drawSampleWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds,
-                                          const Aestra::Audio::AudioBufferData& buffer, double startFrame,
-                                          double endFrame, const AestraUI::NUIColor& tint) {
-    const size_t numChannels = buffer.numChannels;
-    if (numChannels == 0 || buffer.numFrames == 0 || endFrame <= startFrame) return;
-    if (bounds.width <= 0.0f || bounds.height <= 0.0f) return;
-
-    const double pixelsPerSample = static_cast<double>(bounds.width) / (endFrame - startFrame);
-
-    const WaveformInk ink = deriveWaveformInk(tint);
-    const AestraUI::NUIColor lineColor = ink.rms.withAlpha(0.92f);
-    const AestraUI::NUIColor& centerLineColor = ink.centerLine;
-
-    long long firstFrame = static_cast<long long>(std::floor(startFrame));
-    long long lastFrame = static_cast<long long>(std::ceil(endFrame));
-    firstFrame = std::max(firstFrame, 0LL);
-    lastFrame = std::min(lastFrame, static_cast<long long>(buffer.numFrames) - 1);
-    if (lastFrame < firstFrame) return;
-
-    const float* data = buffer.interleavedData.data();
-    const size_t stride = numChannels;
-
-    auto drawLane = [&](float laneY, float laneH, int channel) {
-        const float centerY = laneY + laneH * 0.5f;
-        const float halfDrawH = std::max(1.0f, laneH * 0.5f - 2.0f);
-
-        m_waveformTopPts.clear();
-        for (long long f = firstFrame; f <= lastFrame; ++f) {
-            float s;
-            if (channel < 0) {
-                // Combined lane: mean of all channels
-                double acc = 0.0;
-                for (size_t ch = 0; ch < numChannels; ++ch) {
-                    acc += data[static_cast<size_t>(f) * stride + ch];
-                }
-                s = static_cast<float>(acc / static_cast<double>(numChannels));
-            } else {
-                s = data[static_cast<size_t>(f) * stride + static_cast<size_t>(channel)];
-            }
-            if (std::isnan(s) || std::isinf(s)) s = 0.0f;
-            s = std::max(-1.0f, std::min(1.0f, s));
-
-            float px = bounds.x + static_cast<float>((static_cast<double>(f) - startFrame) * pixelsPerSample);
-            px = std::max(bounds.x, std::min(bounds.x + bounds.width, px));
-            m_waveformTopPts.emplace_back(px, centerY - s * halfDrawH);
-        }
-
-        if (m_waveformTopPts.size() >= 2) {
-            renderer.drawPolyline(m_waveformTopPts.data(), static_cast<int>(m_waveformTopPts.size()), 1.5f,
-                                  lineColor);
-        }
-
-        // Sample dots once samples are far enough apart to read individually
-        if (pixelsPerSample >= 6.0) {
-            for (const auto& p : m_waveformTopPts) {
-                renderer.fillRect(AestraUI::NUIRect(p.x - 1.5f, p.y - 1.5f, 3.0f, 3.0f), lineColor);
-            }
-        }
-
-        renderer.drawLine(AestraUI::NUIPoint(bounds.x, centerY), AestraUI::NUIPoint(bounds.x + bounds.width, centerY),
-                          1.0f, centerLineColor);
-    };
-
-    // One combined lane, matching the peak-envelope path. Splitting L/R here
-    // would make the waveform layout jump as zoom crosses the LOD threshold.
-    drawLane(bounds.y, bounds.height, numChannels >= 2 ? -1 : 0);
 }
 
 AestraUI::NUIColor TrackUIComponent::resolveClipDisplayColor(const ClipInstance& clip) const {
@@ -877,7 +807,8 @@ AestraUI::NUIColor TrackUIComponent::resolveClipDisplayColor(const ClipInstance&
 }
 
 void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds,
-                                            const AestraUI::NUIRect& fullClipBounds, const ClipInstance& clip) {
+                                            const AestraUI::NUIRect& fullClipBounds, const ClipInstance& clip,
+                                            bool seamLeft, bool seamRight) {
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
 
     const float clipRadius = themeManager.getRadius("s");
@@ -926,6 +857,20 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
     renderer.fillRoundedRect(clipBounds, clipRadius, themeManager.getColor("backgroundPrimary"));
     renderer.fillRoundedRect(clipBounds, clipRadius, tintFill);
 
+    // Adjacent slices share a timeline edge, but rounded corners and antialiasing
+    // can expose the grid between their independently rendered bodies. Square the
+    // internal sides and overlap by one pixel so a visual split stays gapless.
+    constexpr float kSeamOverlap = 1.0f;
+    const float seamFillWidth = clipRadius + kSeamOverlap;
+    if (seamLeft) {
+        renderer.fillRect({clipBounds.x - kSeamOverlap, clipBounds.y,
+                           seamFillWidth + kSeamOverlap, clipBounds.height}, tintFill);
+    }
+    if (seamRight) {
+        renderer.fillRect({clipBounds.right() - seamFillWidth, clipBounds.y,
+                           seamFillWidth + kSeamOverlap, clipBounds.height}, tintFill);
+    }
+
     AestraUI::NUIColor borderColor = clipBase.lightened(0.10f).withAlpha(clipSelected ? 0.94f : 0.58f);
     float borderWidth = 1.0f;
 
@@ -957,7 +902,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
 
 // Distinct dark header scrim + filename, drawn on top of the full-height waveform.
 void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds,
-                                            const ClipInstance& clip) {
+                                            const ClipInstance& clip, bool seamLeft, bool seamRight) {
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const float clipRadius = themeManager.getRadius("s");
     constexpr float kClipHeaderHeight = 15.0f;
@@ -971,15 +916,28 @@ void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, con
     }
     const bool clipSelected = (clip.id == m_selectedClipId);
 
-    const AestraUI::NUIRect headerRect(clipBounds.x + 1.0f, clipBounds.y + 1.0f,
-                                       std::max(0.0f, clipBounds.width - 2.0f), kClipHeaderHeight);
+    const float headerLeft = clipBounds.x + (seamLeft ? 0.0f : 1.0f);
+    const float headerRight = clipBounds.right() - (seamRight ? 0.0f : 1.0f);
+    const AestraUI::NUIRect headerRect(headerLeft, clipBounds.y + 1.0f,
+                                       std::max(0.0f, headerRight - headerLeft), kClipHeaderHeight);
     // Own opaque title strip (the waveform lives below it, not behind it), with a
     // divider so the label band reads as its own section.
-    renderer.fillRoundedRect(headerRect, clipRadius - 1.0f,
-                             themeManager.getColor("backgroundPrimary").withAlpha(clipSelected ? 0.98f : 0.94f));
+    const auto headerFill = themeManager.getColor("backgroundPrimary").withAlpha(clipSelected ? 0.98f : 0.94f);
+    renderer.fillRoundedRect(headerRect, clipRadius - 1.0f, headerFill);
+    constexpr float kSeamOverlap = 1.0f;
+    const float seamFillWidth = clipRadius + kSeamOverlap;
+    if (seamLeft) {
+        renderer.fillRect({clipBounds.x - kSeamOverlap, headerRect.y,
+                           seamFillWidth + kSeamOverlap, headerRect.height}, headerFill);
+    }
+    if (seamRight) {
+        renderer.fillRect({clipBounds.right() - seamFillWidth, headerRect.y,
+                           seamFillWidth + kSeamOverlap, headerRect.height}, headerFill);
+    }
     renderer.drawLine(
-        AestraUI::NUIPoint(clipBounds.x + 2.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
-        AestraUI::NUIPoint(clipBounds.right() - 2.0f, clipBounds.y + kClipHeaderHeight + 1.0f),
+        AestraUI::NUIPoint(clipBounds.x + (seamLeft ? 0.0f : 2.0f), clipBounds.y + kClipHeaderHeight + 1.0f),
+        AestraUI::NUIPoint(clipBounds.right() - (seamRight ? 0.0f : 2.0f),
+                           clipBounds.y + kClipHeaderHeight + 1.0f),
         1.0f, themeManager.getCurrentTheme().textPrimary.withAlpha(0.16f));
 
     const std::string displayName = truncateClipLabel(sampleName, clipBounds.width - 16.0f, 6.0f);
@@ -1053,6 +1011,21 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
             float clipWidth = clipEndX - clipStartX;
             
             if (clipWidth > 0) {
+                bool seamLeft = false;
+                bool seamRight = false;
+                if (m_trackManager) {
+                    auto& playlist = m_trackManager->getPlaylistModel();
+                    if (const PlaylistLane* lane = playlist.getLane(m_laneId)) {
+                        constexpr double kSeamToleranceBeats = 1.0e-6;
+                        for (const auto& otherClip : lane->clips) {
+                            if (otherClip.id == clip.id) continue;
+                            seamLeft = seamLeft || std::abs(otherClip.endBeat() - clip.startBeat) <= kSeamToleranceBeats;
+                            seamRight = seamRight || std::abs(clip.endBeat() - otherClip.startBeat) <= kSeamToleranceBeats;
+                            if (seamLeft && seamRight) break;
+                        }
+                    }
+                }
+
                 const AestraUI::NUIRect fullClipBounds(
                     waveformStartX,
                     bounds.y + 2,
@@ -1084,21 +1057,23 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                 if (isPattern) {
                     drawPatternClipForClip(renderer, insetClippedClipBounds, insetFullClipBounds, clip);
                 } else {
-                    drawSampleClipForClip(renderer, insetClippedClipBounds, insetFullClipBounds, clip);
+                    drawSampleClipForClip(renderer, insetClippedClipBounds, insetFullClipBounds, clip, seamLeft, seamRight);
                     // The label gets its own reserved strip at the top; the waveform
                     // fills the whole area BELOW it (bold + gained, so it's full, not
                     // squashed under the label).
                     constexpr float kHeaderStripH = 16.0f;
-                    const float waveformPad = 3.0f;
+                    const float waveformPadLeft = seamLeft ? 0.0f : 3.0f;
+                    const float waveformPadRight = seamRight ? 0.0f : 3.0f;
+                    constexpr float waveformPadBottom = 3.0f;
                     const float waveTop = insetClippedClipBounds.y + kHeaderStripH;
                     const AestraUI::NUIRect waveformInsideClip(
-                        insetClippedClipBounds.x + waveformPad,
+                        insetClippedClipBounds.x + waveformPadLeft,
                         waveTop + 1.0f,
-                        std::max(1.0f, insetClippedClipBounds.width - waveformPad * 2.0f),
-                        std::max(1.0f, (insetClippedClipBounds.bottom() - waveformPad) - (waveTop + 1.0f))
+                        std::max(1.0f, insetClippedClipBounds.width - waveformPadLeft - waveformPadRight),
+                        std::max(1.0f, (insetClippedClipBounds.bottom() - waveformPadBottom) - (waveTop + 1.0f))
                     );
                     drawWaveformForClip(renderer, waveformInsideClip, clip, offsetRatio, visibleRatio);
-                    drawSampleClipHeader(renderer, insetClippedClipBounds, clip);
+                    drawSampleClipHeader(renderer, insetClippedClipBounds, clip, seamLeft, seamRight);
                 }
                 if (clip.id == m_selectedClipId) {
                     drawPianoRollStyleSelection(renderer, insetClippedClipBounds,
@@ -2328,19 +2303,10 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                             double minStart = 0.0;
                             if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
                                 auto& playlistModel = m_trackManager->getPlaylistModel();
-                                float rate = clip.edits.playbackRate;
-                                if (!std::isfinite(rate) || rate <= 0.0f) {
-                                    rate = 1.0f;
-                                }
-                                rate = std::clamp(rate, 0.25f, 4.0f);
-                                const float pitchSemitones =
-                                    std::isfinite(clip.edits.pitchSemitones)
-                                        ? std::clamp(clip.edits.pitchSemitones, -24.0f, 24.0f)
-                                        : 0.0f;
-                                rate = std::clamp(rate * std::pow(2.0f, pitchSemitones / 12.0f), 0.25f, 4.0f);
                                 const double secondsPerBeat = playlistModel.beatToSeconds(1.0);
+                                const double varispeed = clip.edits.effectiveVarispeed();
                                 minStart = std::max(
-                                    0.0, m_trimOriginalStart - m_trimOriginalSourceOffsetSeconds / (secondsPerBeat * rate));
+                                    0.0, m_trimOriginalStart - m_trimOriginalSourceOffsetSeconds / (secondsPerBeat * varispeed));
                             }
                             double newStart = std::max(minStart, m_trimOriginalStart + deltaBeats);
                             newStart = snapBeatToGrid(newStart); // Apply snap
@@ -2351,7 +2317,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                             clip.durationBeats = endBeat - clip.startBeat;
                             if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
                                 clip.durationSeconds =
-                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats);
+                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats) /
+                                    clip.edits.effectiveVarispeed();
                             }
                         } else if (m_trimEdge == TrimEdge::Right) {
                             // Trim right: change end position (duration)
@@ -2361,7 +2328,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                             clip.durationBeats = std::max(0.1, newEnd - clip.startBeat);
                             if (m_trackManager && m_trackManager->getPlaylistModel().isAudioClip(clip)) {
                                 clip.durationSeconds =
-                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats);
+                                    m_trackManager->getPlaylistModel().beatToSeconds(clip.durationBeats) /
+                                    clip.edits.effectiveVarispeed();
                             }
                         }
                         

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -549,6 +549,12 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     const double playbackRate = std::isfinite(clip.edits.playbackRate)
                                     ? std::clamp(static_cast<double>(clip.edits.playbackRate), 0.25, 4.0)
                                     : 1.0;
+    const double pitchSemitones = std::isfinite(clip.edits.pitchSemitones)
+                                      ? std::clamp(static_cast<double>(clip.edits.pitchSemitones), -24.0, 24.0)
+                                      : 0.0;
+    // Pitch and speed share the varispeed envelope, matching the render path
+    // (ClipRenderKernel) so the preview consumes source frames like the audio.
+    const double varispeed = std::clamp(playbackRate * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
 
     double projectSampleRate = m_trackManager ? m_trackManager->getPlaylistModel().getProjectSampleRate() : 48000.0;
     size_t scaledSourceOffset = static_cast<size_t>(std::round(static_cast<double>(sourceOffset) * (sampleRate / projectSampleRate)));
@@ -558,8 +564,8 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
 
     const double visibleOutputStart = static_cast<double>(offsetRatio) * timelineFrames;
     const double visibleOutputEnd = static_cast<double>(offsetRatio + visibleRatio) * timelineFrames;
-    const double exactStart = static_cast<double>(scaledSourceOffset) + visibleOutputStart * playbackRate;
-    const double exactEnd = static_cast<double>(scaledSourceOffset) + visibleOutputEnd * playbackRate;
+    const double exactStart = static_cast<double>(scaledSourceOffset) + visibleOutputStart * varispeed;
+    const double exactEnd = static_cast<double>(scaledSourceOffset) + visibleOutputEnd * varispeed;
     size_t startFrame = static_cast<size_t>(exactStart);
     size_t endFrame = static_cast<size_t>(exactEnd);
     startFrame = std::min(startFrame, totalFrames);
@@ -573,7 +579,7 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
     AestraUI::NUIRect audibleBounds = bounds;
     const double visibleOutputFrames = visibleOutputEnd - visibleOutputStart;
     const double availableOutputEnd =
-        (static_cast<double>(totalFrames) - static_cast<double>(scaledSourceOffset)) / playbackRate;
+        (static_cast<double>(totalFrames) - static_cast<double>(scaledSourceOffset)) / varispeed;
     if (visibleOutputFrames > 0.0 && availableOutputEnd < visibleOutputEnd) {
         const double audibleOutputFrames = std::max(0.0, availableOutputEnd - visibleOutputStart);
         audibleBounds.width *= static_cast<float>(std::clamp(audibleOutputFrames / visibleOutputFrames, 0.0, 1.0));
@@ -2327,6 +2333,11 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                                     rate = 1.0f;
                                 }
                                 rate = std::clamp(rate, 0.25f, 4.0f);
+                                const float pitchSemitones =
+                                    std::isfinite(clip.edits.pitchSemitones)
+                                        ? std::clamp(clip.edits.pitchSemitones, -24.0f, 24.0f)
+                                        : 0.0f;
+                                rate = std::clamp(rate * std::pow(2.0f, pitchSemitones / 12.0f), 0.25f, 4.0f);
                                 const double secondsPerBeat = playlistModel.beatToSeconds(1.0);
                                 minStart = std::max(
                                     0.0, m_trimOriginalStart - m_trimOriginalSourceOffsetSeconds / (secondsPerBeat * rate));

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -305,22 +305,20 @@ private:
                               const std::vector<Aestra::Audio::WaveformPeak>& peaksR, size_t numChannels,
                               const AestraUI::NUIColor& tint);
 
-    // Deep-zoom helpers: render finer than the peak cache's base mip level.
-    // Both read bounded sample ranges directly from the (immutable) source buffer.
-    void drawSampleWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds,
-                            const Aestra::Audio::AudioBufferData& buffer, double startFrame, double endFrame,
-                            const AestraUI::NUIColor& tint);
+    // Deep-zoom helper: render finer than the peak cache's base mip level using the
+    // same fractional source-frame bins as the cached path.
     static void computeDirectPeaks(const Aestra::Audio::AudioBufferData& buffer, uint32_t channel,
-                                   size_t startFrame, size_t endFrame, int numColumns,
+                                   double startFrame, double endFrame, int numColumns,
                                    std::vector<Aestra::Audio::WaveformPeak>& outPeaks);
 
     // Sample clip container
     void drawSampleClip(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds);
     void drawSampleClipForClip(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds,
-                                const AestraUI::NUIRect& fullClipBounds, const ClipInstance& clip);
+                                const AestraUI::NUIRect& fullClipBounds, const ClipInstance& clip,
+                                bool seamLeft, bool seamRight);
     // Header scrim + label, drawn AFTER the waveform so it stays readable over it.
     void drawSampleClipHeader(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds,
-                              const ClipInstance& clip);
+                              const ClipInstance& clip, bool seamLeft, bool seamRight);
 
     // Pattern clip rendering
     void drawPatternClipForClip(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& clipBounds,

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1002,6 +1002,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 ejs.set("pan", JSON(static_cast<double>(clip.edits.pan)));
                 ejs.set("muted", JSON(clip.edits.muted));
                 ejs.set("playbackRate", JSON(static_cast<double>(clip.edits.playbackRate)));
+                ejs.set("pitchSemitones", JSON(static_cast<double>(clip.edits.pitchSemitones)));
                 ejs.set("fadeIn", JSON(clip.edits.fadeInBeats));
                 ejs.set("fadeOut", JSON(clip.edits.fadeOutBeats));
                 ejs.set("sourceStart", JSON(static_cast<double>(clip.edits.sourceStart)));
@@ -2187,6 +2188,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                     clip.edits.muted = ej.has("muted") && ej["muted"].isBool() && ej["muted"].asBool();
                                     clip.edits.playbackRate = static_cast<float>(
                                         finiteNumberOr(ej, "playbackRate", 1.0, 0.01, 100.0));
+                                    clip.edits.pitchSemitones = static_cast<float>(
+                                        finiteNumberOr(ej, "pitchSemitones", 0.0, -24.0, 24.0));
                                     clip.edits.fadeInBeats = finiteNumberOr(ej, "fadeIn", 0.0, 0.0, 1000000.0);
                                     clip.edits.fadeOutBeats = finiteNumberOr(ej, "fadeOut", 0.0, 0.0, 1000000.0);
                                     clip.edits.sourceStart = finiteNumberOr(ej, "sourceStart", 0.0, 0.0, 1.0e15);

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1002,7 +1002,11 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 ejs.set("pan", JSON(static_cast<double>(clip.edits.pan)));
                 ejs.set("muted", JSON(clip.edits.muted));
                 ejs.set("playbackRate", JSON(static_cast<double>(clip.edits.playbackRate)));
-                ejs.set("pitchSemitones", JSON(static_cast<double>(clip.edits.pitchSemitones)));
+                const float persistedPitch = std::isfinite(clip.edits.pitchSemitones)
+                                                 ? std::clamp(clip.edits.pitchSemitones, ClipEdits::kMinPitchSemitones,
+                                                              ClipEdits::kMaxPitchSemitones)
+                                                 : 0.0f;
+                ejs.set("pitchSemitones", JSON(static_cast<double>(persistedPitch)));
                 ejs.set("fadeIn", JSON(clip.edits.fadeInBeats));
                 ejs.set("fadeOut", JSON(clip.edits.fadeOutBeats));
                 ejs.set("sourceStart", JSON(static_cast<double>(clip.edits.sourceStart)));

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -100,7 +100,7 @@ std::string formatGainDb(float linear) {
 bool editsEqual(const ClipEdits& a, const ClipEdits& b) {
     return a.fadeInBeats == b.fadeInBeats && a.fadeOutBeats == b.fadeOutBeats && a.gainLinear == b.gainLinear &&
            a.pan == b.pan && a.muted == b.muted && a.playbackRate == b.playbackRate &&
-           a.sourceStart == b.sourceStart;
+           a.pitchSemitones == b.pitchSemitones && a.sourceStart == b.sourceStart;
 }
 
 } // namespace
@@ -175,17 +175,19 @@ void AudioClipEditorPanel::buildUI() {
     m_fadeInLabel = makeLabel("Fade in");
     m_fadeOutLabel = makeLabel("Fade out");
     m_pitchLabel = makeLabel("Pitch");
+    m_speedLabel = makeLabel("Speed");
     m_sourceStartLabel = makeLabel("Start");
     m_gainValueLabel = makeLabel("-5.0 dB", 10.0f);
     m_panValueLabel = makeLabel("Center", 10.0f);
     m_fadeInValueLabel = makeLabel("0.00 beats", 10.0f);
     m_fadeOutValueLabel = makeLabel("0.00 beats", 10.0f);
-    m_pitchValueLabel = makeLabel("0.0 st  •  1.00x", 10.0f);
+    m_pitchValueLabel = makeLabel("0.0 st", 10.0f);
+    m_speedValueLabel = makeLabel("1.00x", 10.0f);
     m_sourceStartValueLabel = makeLabel("0.000 s", 10.0f);
     m_waveformHintLabel = makeLabel("Scroll to zoom • edits are non-destructive", 10.0f);
     m_waveformHintLabel->setAlignment(NUILabel::Alignment::Right);
     for (const auto& value : {m_gainValueLabel, m_panValueLabel, m_fadeInValueLabel, m_fadeOutValueLabel,
-                              m_pitchValueLabel, m_sourceStartValueLabel}) {
+                              m_pitchValueLabel, m_speedValueLabel, m_sourceStartValueLabel}) {
         value->setAlignment(NUILabel::Alignment::Right);
     }
 
@@ -193,8 +195,9 @@ void AudioClipEditorPanel::buildUI() {
     m_panSlider = makeSlider("Clip pan", -1.0, 1.0, 0.0);
     m_fadeInSlider = makeSlider("Fade in", 0.0, 4.0, 0.0);
     m_fadeOutSlider = makeSlider("Fade out", 0.0, 4.0, 0.0);
-    m_pitchSlider = makeSlider("Clip pitch (varispeed)", ClipEdits::kMinPitchSemitones, ClipEdits::kMaxPitchSemitones,
-                               0.0, pitchAccent());
+    m_pitchSlider = makeSlider("Clip pitch", ClipEdits::kMinPitchSemitones, ClipEdits::kMaxPitchSemitones, 0.0,
+                               pitchAccent());
+    m_speedSlider = makeSlider("Clip speed", 0.25, 4.0, 1.0);
     m_sourceStartSlider = makeSlider("Source start", 0.0, 1.0, 0.0);
     m_muteButton = std::make_shared<NUIButton>("Mute clip");
     m_muteButton->setToggleable(true);
@@ -242,9 +245,11 @@ void AudioClipEditorPanel::buildUI() {
     wireSlider(m_fadeOutSlider, [](ClipEdits& edits, double value) { edits.fadeOutBeats = static_cast<float>(value); });
     wireSlider(
         m_pitchSlider,
-        [](ClipEdits& edits, double value) {
-            edits.playbackRate = ClipEdits::playbackRateFromSemitones(static_cast<float>(value));
-        },
+        [](ClipEdits& edits, double value) { edits.pitchSemitones = static_cast<float>(value); },
+        true);
+    wireSlider(
+        m_speedSlider,
+        [](ClipEdits& edits, double value) { edits.playbackRate = static_cast<float>(value); },
         true);
     wireSlider(m_sourceStartSlider, [this](ClipEdits& edits, double value) {
         const double projectRate =
@@ -292,7 +297,7 @@ void AudioClipEditorPanel::buildUI() {
         // changes nothing audible.
         if (m_workingEdits.gainLinear == 1.0f && m_workingEdits.fadeInBeats == 0.0f &&
             m_workingEdits.fadeOutBeats == 0.0f && m_workingEdits.playbackRate == 1.0f &&
-            m_workingEdits.sourceStart == 0.0)
+            m_workingEdits.pitchSemitones == 0.0f && m_workingEdits.sourceStart == 0.0)
             return;
         auto command = std::make_shared<CommitAudioClipEditsCommand>(*m_trackManager, m_clipId);
         m_trackManager->getCommandHistory().pushAndExecute(command);
@@ -391,7 +396,12 @@ void AudioClipEditorPanel::rebuildWaveform() {
         buffer->numChannels == 1 ? "Mono" : (buffer->numChannels == 2 ? "Stereo" : "Multichannel");
     const float playbackRate =
         std::isfinite(m_workingEdits.playbackRate) ? std::clamp(m_workingEdits.playbackRate, 0.25f, 4.0f) : 1.0f;
-    const double outputDurationSeconds = buffer->durationSeconds() / playbackRate;
+    const float pitchSemitones =
+        std::isfinite(m_workingEdits.pitchSemitones)
+            ? std::clamp(m_workingEdits.pitchSemitones, ClipEdits::kMinPitchSemitones, ClipEdits::kMaxPitchSemitones)
+            : 0.0f;
+    const double varispeed = static_cast<double>(playbackRate) * std::pow(2.0, pitchSemitones / 12.0);
+    const double outputDurationSeconds = buffer->durationSeconds() / varispeed;
     m_sourceMetaLabel->setText(
         formatFixed(buffer->durationSeconds(), 2) + " s source  •  " + formatFixed(outputDurationSeconds, 2) +
         " s output  •  " + std::to_string(buffer->sampleRate) + " Hz  •  " + channelText + "  •  " +
@@ -430,7 +440,7 @@ void AudioClipEditorPanel::rebuildWaveform() {
         const size_t sampleStride = std::max<size_t>(1, framesPerBucket / 256);
         for (size_t outputFrame = begin; outputFrame < end; outputFrame += sampleStride) {
             const double phase =
-                static_cast<double>(sourceStartFrame) + static_cast<double>(outputFrame) * playbackRate;
+                static_cast<double>(sourceStartFrame) + static_cast<double>(outputFrame) * varispeed;
             if (phase >= static_cast<double>(sourceEndFrame))
                 continue;
             const size_t frame = static_cast<size_t>(phase);
@@ -450,7 +460,7 @@ void AudioClipEditorPanel::rebuildWaveform() {
         m_waveformData.push_back(minimum);
     }
     m_waveform->setWaveformData(m_waveformData);
-    m_waveformTitleLabel->setText(std::abs(playbackRate - 1.0f) < 1.0e-5f
+    m_waveformTitleLabel->setText(std::abs(varispeed - 1.0) < 1.0e-5
                                       ? "WAVEFORM"
                                       : "PITCHED WAVEFORM  •  " + formatFixed(outputDurationSeconds, 2) + " s");
 }
@@ -517,7 +527,8 @@ void AudioClipEditorPanel::syncControlsFromModel() {
     m_fadeOutSlider->setRange(0.0, fadeMaximum);
     m_fadeInSlider->setValue(std::min<double>(m_workingEdits.fadeInBeats, fadeMaximum));
     m_fadeOutSlider->setValue(std::min<double>(m_workingEdits.fadeOutBeats, fadeMaximum));
-    m_pitchSlider->setValue(ClipEdits::semitonesFromPlaybackRate(m_workingEdits.playbackRate));
+    m_pitchSlider->setValue(m_workingEdits.pitchSemitones);
+    m_speedSlider->setValue(m_workingEdits.playbackRate);
     const double projectRate = std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate());
     const double sourceStartSeconds = std::max(0.0, m_workingEdits.sourceStart) / projectRate;
     const double sourceStartMaximum = std::max(0.001, m_sourceDurationSeconds);
@@ -540,10 +551,10 @@ void AudioClipEditorPanel::updateValueLabels() {
     }
     m_fadeInValueLabel->setText(formatFixed(m_workingEdits.fadeInBeats, 2) + " beats");
     m_fadeOutValueLabel->setText(formatFixed(m_workingEdits.fadeOutBeats, 2) + " beats");
-    const float pitchSemitones = ClipEdits::semitonesFromPlaybackRate(m_workingEdits.playbackRate);
+    const float pitchSemitones = m_workingEdits.pitchSemitones;
     const std::string pitchSign = pitchSemitones > 0.049f ? "+" : "";
-    m_pitchValueLabel->setText(pitchSign + formatFixed(pitchSemitones, 1) + " st  •  " +
-                               formatFixed(m_workingEdits.playbackRate, 2) + "x");
+    m_pitchValueLabel->setText(pitchSign + formatFixed(pitchSemitones, 1) + " st");
+    m_speedValueLabel->setText(formatFixed(m_workingEdits.playbackRate, 2) + "x");
     const double projectRate =
         m_trackManager ? std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate()) : 48000.0;
     m_sourceStartValueLabel->setText(formatFixed(std::max(0.0, m_workingEdits.sourceStart) / projectRate, 3) + " s");
@@ -655,6 +666,7 @@ void AudioClipEditorPanel::onResize(int width, int height) {
     layoutControl(left, controlsTop + 78.0f, m_gainLabel, m_gainSlider, m_gainValueLabel);
     layoutControl(left, controlsTop + 124.0f, m_panLabel, m_panSlider, m_panValueLabel);
     layoutControl(left, controlsTop + 170.0f, m_pitchLabel, m_pitchSlider, m_pitchValueLabel);
+    layoutControl(left, controlsTop + 216.0f, m_speedLabel, m_speedSlider, m_speedValueLabel);
     layoutControl(right, controlsTop + 78.0f, m_fadeInLabel, m_fadeInSlider, m_fadeInValueLabel);
     layoutControl(right, controlsTop + 124.0f, m_fadeOutLabel, m_fadeOutSlider, m_fadeOutValueLabel);
     layoutControl(right, controlsTop + 170.0f, m_sourceStartLabel, m_sourceStartSlider, m_sourceStartValueLabel);

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -310,11 +310,11 @@ void AudioClipEditorPanel::buildUI() {
         m_waveformTitleLabel, m_waveformHintLabel,     m_instanceLabel,
         m_toneSectionLabel,   m_timingSectionLabel,    m_gainLabel,
         m_panLabel,           m_fadeInLabel,           m_fadeOutLabel,
-        m_pitchLabel,         m_sourceStartLabel,      m_gainValueLabel,
-        m_panValueLabel,      m_fadeInValueLabel,      m_fadeOutValueLabel,
-        m_pitchValueLabel,    m_sourceStartValueLabel, m_gainSlider,
-        m_panSlider,          m_fadeInSlider,          m_fadeOutSlider,
-        m_pitchSlider,        m_sourceStartSlider,     m_muteButton,
+        m_pitchLabel,         m_speedLabel,            m_sourceStartLabel,      m_gainValueLabel,
+        m_panValueLabel,      m_fadeInValueLabel,      m_fadeOutValueLabel,     m_pitchValueLabel,
+        m_speedValueLabel,    m_sourceStartValueLabel, m_gainSlider,             m_panSlider,
+        m_fadeInSlider,       m_fadeOutSlider,         m_pitchSlider,            m_speedSlider,
+        m_sourceStartSlider,  m_muteButton,
         m_normalizeButton,    m_resetButton,           m_makeUniqueButton,
         m_reverseButton,      m_commitButton};
     for (const auto& child : children) {
@@ -400,7 +400,8 @@ void AudioClipEditorPanel::rebuildWaveform() {
         std::isfinite(m_workingEdits.pitchSemitones)
             ? std::clamp(m_workingEdits.pitchSemitones, ClipEdits::kMinPitchSemitones, ClipEdits::kMaxPitchSemitones)
             : 0.0f;
-    const double varispeed = static_cast<double>(playbackRate) * std::pow(2.0, pitchSemitones / 12.0);
+    const double varispeed =
+        std::clamp(static_cast<double>(playbackRate) * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
     const double outputDurationSeconds = buffer->durationSeconds() / varispeed;
     m_sourceMetaLabel->setText(
         formatFixed(buffer->durationSeconds(), 2) + " s source  •  " + formatFixed(outputDurationSeconds, 2) +

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -67,12 +67,14 @@ private:
     std::shared_ptr<AestraUI::NUILabel> m_fadeInLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeOutLabel;
     std::shared_ptr<AestraUI::NUILabel> m_pitchLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_speedLabel;
     std::shared_ptr<AestraUI::NUILabel> m_sourceStartLabel;
     std::shared_ptr<AestraUI::NUILabel> m_gainValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_panValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeInValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_fadeOutValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_pitchValueLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_speedValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_sourceStartValueLabel;
     std::shared_ptr<AestraUI::NUILabel> m_waveformHintLabel;
     std::shared_ptr<AestraUI::NUISlider> m_gainSlider;
@@ -80,6 +82,7 @@ private:
     std::shared_ptr<AestraUI::NUISlider> m_fadeInSlider;
     std::shared_ptr<AestraUI::NUISlider> m_fadeOutSlider;
     std::shared_ptr<AestraUI::NUISlider> m_pitchSlider;
+    std::shared_ptr<AestraUI::NUISlider> m_speedSlider;
     std::shared_ptr<AestraUI::NUISlider> m_sourceStartSlider;
     std::shared_ptr<AestraUI::NUIButton> m_muteButton;
     std::shared_ptr<AestraUI::NUIButton> m_normalizeButton;

--- a/Tests/AestraAudio/PlaylistSplitVarispeedTest.cpp
+++ b/Tests/AestraAudio/PlaylistSplitVarispeedTest.cpp
@@ -1,0 +1,194 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// PlaylistSplitVarispeedTest — split and trim must keep the audio clip's
+// source-domain invariants when Speed/Pitch varispeed != 1 (#746 regression,
+// user report: "slicing pitched clips is not slicing as intended").
+//
+// Contract under test (canonical audio-clip fields, see TrimClipCommand):
+//   durationSeconds      == beatToSeconds(durationBeats) / varispeed
+//   sourceOffsetSeconds  == original + trimmedBeats * beatToSeconds(1) * varispeed
+// where varispeed = clamp(speed * 2^(pitch/12), 0.25, 4). The renderer reads
+// these two fields directly (ClipRenderService::resolveClipRegion), so a
+// split/trim that ignores varispeed plays the second half at the wrong source
+// position and for the wrong length.
+//
+// Model-level regression gate: fast, deterministic, no audio rendering. The
+// end-to-end splice-null proof lives in RealtimeExportParityTest
+// (runSplitVarispeedParityCase).
+
+#include "GoldenAudio/GoldenAudioHarness.h"
+#include "Commands/TrimClipCommand.h"
+#include "Models/PlaylistModel.h"
+
+#include <cmath>
+#include <iostream>
+
+using namespace Aestra::Audio;
+using namespace GoldenAudio;
+
+namespace {
+
+constexpr double kBeats = 4.0; // 2 s at 120 BPM
+constexpr double kSecondsPerBeat = 0.5; // 120 BPM
+constexpr double kTau = 6.28318530717958647692;
+
+bool nearEq(double a, double b, double tol = 1e-9) {
+    return std::abs(a - b) <= tol;
+}
+
+struct CaseResult {
+    int failures = 0;
+    void check(bool cond, const std::string& what) {
+        if (!cond) {
+            ++failures;
+            std::cout << "    FAIL: " << what << "\n";
+        }
+    }
+};
+
+// Build a one-track session whose clip spans beat 0..kBeats (2 s of 440 Hz).
+std::shared_ptr<TrackManager> buildSession(const SessionConfig& cfg) {
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+    const uint32_t totalFrames = static_cast<uint32_t>(cfg.sampleRate) * 2;
+    std::vector<float> sine(static_cast<size_t>(totalFrames) * cfg.channels, 0.0f);
+    for (uint32_t i = 0; i < totalFrames; ++i) {
+        const float v = static_cast<float>(std::sin(kTau * 440.0 * static_cast<double>(i) / cfg.sampleRate)) * 0.3f;
+        sine[static_cast<size_t>(i) * cfg.channels] = v;
+        sine[static_cast<size_t>(i) * cfg.channels + 1] = v;
+    }
+    addAudioTrack(*tm, "SplitVarispeed", sine, totalFrames, cfg);
+    return tm;
+}
+
+ClipInstanceID firstClipId(PlaylistModel& model) {
+    const auto laneId = model.getLaneId(0);
+    const auto* lane = model.getLane(laneId);
+    if (!lane || lane->clips.empty()) {
+        return ClipInstanceID();
+    }
+    return lane->clips.front().id;
+}
+
+void applyVarispeed(PlaylistModel& model, float speed, float pitchSemitones) {
+    ClipEdits edits;
+    edits.playbackRate = speed;
+    edits.pitchSemitones = pitchSemitones;
+    const ClipInstanceID id = firstClipId(model);
+    if (!model.setClipEdits(id, edits)) {
+        std::cout << "    FAIL: setClipEdits\n";
+    }
+}
+
+const ClipInstance* getClip(PlaylistModel& model, ClipInstanceID id) {
+    return model.getClip(id);
+}
+
+// Split at beat 2 (half the clip). With varispeed v:
+//   left  half: durationSeconds == 1 s / v
+//   right half: sourceOffsetSeconds == 1 s * v, durationSeconds == 1 s / v
+bool runSplitCase(const SessionConfig& cfg, float speed, float pitchSemitones, const char* label,
+                  CaseResult& out) {
+    std::cout << "TEST: split " << label << "\n";
+    auto tm = buildSession(cfg);
+    auto& model = tm->getPlaylistModel();
+    applyVarispeed(model, speed, pitchSemitones);
+    const ClipInstanceID id = firstClipId(model);
+    if (!id.isValid()) {
+        out.check(false, "no clip on lane 0");
+        return false;
+    }
+
+    const ClipInstanceID secondId = model.splitClip(id, 2.0);
+    out.check(secondId.isValid(), "splitClip returned invalid id");
+
+    const auto* left = getClip(model, id);
+    const auto* right = getClip(model, secondId);
+    if (!left || !right) {
+        out.check(false, "split halves not found");
+        return false;
+    }
+
+    out.check(nearEq(left->durationBeats, 2.0), "left durationBeats");
+    out.check(nearEq(right->durationBeats, 2.0), "right durationBeats");
+    out.check(nearEq(right->startBeat, 2.0), "right startBeat");
+
+    const double varispeed =
+        std::clamp(speed * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
+    // Split at beat 2 of 4: each half is 2 beats = 1 s at 120 BPM.
+    out.check(nearEq(left->durationSeconds, 1.0 / varispeed),
+              "left durationSeconds (source seconds)");
+    out.check(nearEq(right->sourceOffsetSeconds, 1.0 * varispeed),
+              "right sourceOffsetSeconds advances by 1 s * varispeed");
+    out.check(nearEq(right->durationSeconds, 1.0 / varispeed),
+              "right durationSeconds (source seconds)");
+    out.check(nearEq(left->sourceOffsetSeconds, 0.0), "left sourceOffsetSeconds unchanged");
+
+    const double expectedSourceStartSamples = 1.0 * varispeed * cfg.sampleRate;
+    out.check(model.getClipSourceStartSamples(*right) == static_cast<uint64_t>(expectedSourceStartSamples),
+              "right runtime/visual source start matches split offset");
+    return true;
+}
+
+// Left-edge trim of 1 beat via TrimClipCommand (lazy variant):
+//   durationSeconds == 1.5 s / v, sourceOffsetSeconds == 0.5 s * v
+bool runTrimCase(const SessionConfig& cfg, float speed, float pitchSemitones, const char* label,
+                 CaseResult& out) {
+    std::cout << "TEST: trim " << label << "\n";
+    auto tm = buildSession(cfg);
+    auto& model = tm->getPlaylistModel();
+    applyVarispeed(model, speed, pitchSemitones);
+    const ClipInstanceID id = firstClipId(model);
+    if (!id.isValid()) {
+        out.check(false, "no clip on lane 0");
+        return false;
+    }
+
+    TrimClipCommand command(model, id, 1.0, -1.0);
+    command.execute();
+    const auto* clip = getClip(model, id);
+    if (!clip) {
+        out.check(false, "clip missing after trim");
+        return false;
+    }
+
+    const double varispeed =
+        std::clamp(speed * std::pow(2.0, pitchSemitones / 12.0), 0.25, 4.0);
+    out.check(nearEq(clip->startBeat, 1.0), "trim startBeat");
+    out.check(nearEq(clip->durationBeats, 3.0), "trim durationBeats");
+    out.check(nearEq(clip->durationSeconds, 3.0 * kSecondsPerBeat / varispeed),
+              "trim durationSeconds (source seconds)");
+    out.check(nearEq(clip->sourceOffsetSeconds, kSecondsPerBeat * varispeed),
+              "trim sourceOffsetSeconds advance");
+
+    command.undo();
+    const auto* restored = getClip(model, id);
+    out.check(restored != nullptr, "clip present after undo");
+    if (restored) {
+        out.check(nearEq(restored->startBeat, 0.0), "undo startBeat");
+        out.check(nearEq(restored->durationBeats, kBeats), "undo durationBeats");
+        out.check(nearEq(restored->durationSeconds, kBeats * kSecondsPerBeat), "undo durationSeconds");
+        out.check(nearEq(restored->sourceOffsetSeconds, 0.0), "undo sourceOffsetSeconds");
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    const SessionConfig cfg;
+    std::cout << "\n=== Playlist Split/Trim Varispeed Tests ===\n\n";
+
+    CaseResult result;
+    runSplitCase(cfg, 1.0f, 12.0f, "pitch +12 (varispeed 2)", result);
+    runSplitCase(cfg, 2.0f, 0.0f, "speed 2x (varispeed 2)", result);
+    runSplitCase(cfg, 1.0f, 0.0f, "unity control (varispeed 1)", result);
+    runTrimCase(cfg, 1.0f, 12.0f, "pitch +12 (varispeed 2)", result);
+    runTrimCase(cfg, 1.0f, 0.0f, "unity control (varispeed 1)", result);
+
+    if (result.failures == 0) {
+        std::cout << "\nAll PlaylistSplitVarispeed tests passed.\n";
+        return 0;
+    }
+    std::cout << "\n" << result.failures << " PlaylistSplitVarispeed assertion(s) failed.\n";
+    return 1;
+}

--- a/Tests/AestraAudio/RealtimeExportParityTest.cpp
+++ b/Tests/AestraAudio/RealtimeExportParityTest.cpp
@@ -389,6 +389,133 @@ bool runIsolatedSpeedParityCase(const SessionConfig& cfg, const fs::path& tempRo
     return pass;
 }
 
+// -----------------------------------------------------------------------------
+// Case 5: splitting a varispeed clip must not change what the track plays —
+// the two halves spliced together must equal the un-split clip outside the
+// engine's mandatory 128-frame clip-edge fades (kClipEdgeFadeSamples /
+// CLIP_EDGE_FADE_SAMPLES, both render paths apply them at every clip
+// boundary). User report: "slicing pitched clips is not slicing as intended".
+// -----------------------------------------------------------------------------
+bool runSplitVarispeedParityCase(const SessionConfig& cfg, const fs::path& tempRoot, float speed,
+                                 float pitchSemitones, double splitBeat) {
+    // 3 s source: the clip (2 s of timeline at varispeed 2) consumes only the
+    // first 2 s of source, so the right half after a beat-2 split has audible
+    // content — the region the offset bug played at the wrong position.
+    const uint32_t totalFrames = cfg.sampleRate * 3;
+
+    auto buildSplitSession = [&](bool split) -> std::shared_ptr<TrackManager> {
+        auto tm = std::make_shared<TrackManager>();
+        tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+        addAudioTrack(*tm, "SplitVarispeed", makeSine(440.0, 0.30f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+        const auto laneId = tm->getPlaylistModel().getLaneId(0);
+        const auto* lane = tm->getPlaylistModel().getLane(laneId);
+        if (!lane || lane->clips.empty()) {
+            return nullptr;
+        }
+        ClipEdits edits;
+        edits.playbackRate = speed;
+        edits.pitchSemitones = pitchSemitones;
+        if (!tm->getPlaylistModel().setClipEdits(lane->clips.front().id, edits)) {
+            return nullptr;
+        }
+        if (split && !tm->getPlaylistModel().splitClip(lane->clips.front().id, splitBeat).isValid()) {
+            return nullptr;
+        }
+        return tm;
+    };
+
+    const auto whole = buildSplitSession(false);
+    const auto split = buildSplitSession(true);
+    if (!whole || !split) {
+        std::cerr << "split parity session construction failed\n";
+        return false;
+    }
+
+    auto bounceTrack = [&](const std::shared_ptr<TrackManager>& tm, const std::string& name) -> std::vector<float> {
+        AudioEngine engine;
+        prepareEngine(engine, tm, cfg);
+        warmupEngine(engine, cfg);
+        const fs::path outPath = tempRoot / ("parity_" + name + ".wav");
+        std::vector<float> decoded;
+        if (!engine.bounceRangeToWav(0.0, kBeats, outPath.string(), 0)) {
+            return decoded;
+        }
+        uint32_t sr = 0, ch = 0;
+        if (!decodeAudioFile(outPath.string(), decoded, sr, ch) || sr != cfg.sampleRate || ch != cfg.channels) {
+            decoded.clear();
+        }
+        return decoded;
+    };
+
+    const std::vector<float> wholeBounce = bounceTrack(whole, "split_whole");
+    const std::vector<float> splitBounce = bounceTrack(split, "split_halves");
+    if (wholeBounce.empty() || splitBounce.empty()) {
+        std::cerr << "split parity bounce failed\n";
+        return false;
+    }
+
+    const size_t trimStart = static_cast<size_t>(cfg.blockSize) * 4 * cfg.channels;
+    const size_t n = std::min(wholeBounce.size(), splitBounce.size());
+    if (n <= trimStart) {
+        std::cerr << "not enough overlap to compare split parity\n";
+        return false;
+    }
+
+    // Exclude the 128-frame clip-edge fades both render paths apply at the
+    // splice point: the split creates clip edges where the whole clip has
+    // continuous content. Everything else must be bit-identical.
+    const size_t splitFrame = static_cast<size_t>(splitBeat * cfg.sampleRate * 60.0 / cfg.bpm);
+    constexpr uint32_t kEdgeFade = 128;
+    const size_t fadeLo = (splitFrame > kEdgeFade) ? splitFrame - kEdgeFade : 0;
+    const size_t fadeHi = std::min(splitFrame + kEdgeFade, n / cfg.channels);
+
+    auto maskedCompare = [&](const std::vector<float>& a, const std::vector<float>& b) {
+        double sumSq = 0.0;
+        size_t compared = 0;
+        double maxAbs = 0.0;
+        size_t firstMismatch = SIZE_MAX;
+        for (size_t f = trimStart / cfg.channels; f < n / cfg.channels; ++f) {
+            if (f >= fadeLo && f < fadeHi) {
+                continue;
+            }
+            for (uint32_t c = 0; c < cfg.channels; ++c) {
+                const double da = a[f * cfg.channels + c];
+                const double db = b[f * cfg.channels + c];
+                const double err = std::abs(da - db);
+                if (err > maxAbs) {
+                    maxAbs = err;
+                }
+                if (err > 1e-6 && firstMismatch == SIZE_MAX) {
+                    firstMismatch = f;
+                }
+                sumSq += err * err;
+                ++compared;
+            }
+        }
+        const double rms = std::sqrt(sumSq / static_cast<double>(compared));
+        const double rmsDb = 20.0 * std::log10(std::max(rms, 1e-15));
+        return std::make_tuple(rmsDb, maxAbs, firstMismatch, compared);
+    };
+
+    const auto [rmsDb, maxAbs, firstMismatch, compared] =
+        maskedCompare(wholeBounce, splitBounce);
+    const bool pass = (rmsDb <= -120.0) && (maxAbs <= 1e-6);
+    const std::string label = "Split_Splice_Speed" + std::to_string(speed) + "x_Pitch" +
+                              std::to_string(pitchSemitones) + "st_vs_Whole";
+    std::cout << (pass ? "[PASS] " : "[FAIL] ") << label << "  rmsErr=" << rmsDb
+              << " dB  maxAbsErr=" << maxAbs << "  compared=" << compared << " frames";
+    if (!pass) {
+        std::cout << "  firstMismatch=" << firstMismatch << " (" << (firstMismatch / static_cast<double>(cfg.sampleRate))
+                  << " s)";
+    }
+    std::cout << "\n";
+    std::cout << "  (fade zone excluded: frames " << fadeLo << ".." << fadeHi - 1
+              << " around the splice at " << splitFrame << ")\n";
+    std::cout << "  whole bounce frames: " << wholeBounce.size() / cfg.channels
+              << ", split bounce frames: " << splitBounce.size() / cfg.channels << "\n";
+    return pass;
+}
+
 } // namespace
 
 int main() {
@@ -417,6 +544,11 @@ int main() {
     // Pitch cases (#746): pure pitch, pitch cancelling speed, and interplay.
     for (const auto& [speed, pitch] : {std::pair{1.0f, 12.0f}, {2.0f, -12.0f}, {0.5f, 7.0f}}) {
         if (!runIsolatedSpeedParityCase(cfg, tempRoot, speed, pitch)) ++failures;
+    }
+    // Split cases: splicing the halves must equal the un-split clip, under
+    // pitch varispeed and under speed varispeed (split at beat 2 of 4).
+    for (const auto& [speed, pitch] : {std::pair{1.0f, 12.0f}, {2.0f, 0.0f}}) {
+        if (!runSplitVarispeedParityCase(cfg, tempRoot, speed, pitch, 2.0)) ++failures;
     }
 
     fs::remove_all(tempRoot, ec);

--- a/Tests/AestraAudio/RealtimeExportParityTest.cpp
+++ b/Tests/AestraAudio/RealtimeExportParityTest.cpp
@@ -311,25 +311,27 @@ bool runCrossSampleRateCase(const SessionConfig& liveCfg, const fs::path& tempRo
 }
 
 // -----------------------------------------------------------------------------
-// Case 4: isolated-track bounce honors clip Speed (playbackRate) — parity
-// with live playback of the same session (#745)
+// Case 4: isolated-track bounce honors clip Speed (playbackRate) and Pitch
+// (pitchSemitones) — parity with live playback of the same session (#745, #746)
 // -----------------------------------------------------------------------------
-bool runIsolatedSpeedParityCase(const SessionConfig& cfg, const fs::path& tempRoot, float speed) {
+bool runIsolatedSpeedParityCase(const SessionConfig& cfg, const fs::path& tempRoot, float speed,
+                                float pitchSemitones = 0.0f) {
     const uint32_t totalFrames = cfg.sampleRate * kSeconds;
 
-    // One-track session with the clip sped up/down. The edit is applied before
-    // engine prepare, so the compiled graph carries playbackRate.
+    // One-track session with the clip sped up/down and/or pitched. The edits
+    // are applied before engine prepare, so the compiled graph carries them.
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
     addAudioTrack(*tm, "SpeedA", makeSine(440.0, 0.30f, totalFrames, cfg.sampleRate), totalFrames, cfg);
     const auto laneId = tm->getPlaylistModel().getLaneId(0);
     const auto* lane = tm->getPlaylistModel().getLane(laneId);
     if (!lane || lane->clips.empty()) {
-        std::cerr << "no clip on lane 0; cannot apply speed\n";
+        std::cerr << "no clip on lane 0; cannot apply edits\n";
         return false;
     }
     ClipEdits edits;
     edits.playbackRate = speed;
+    edits.pitchSemitones = pitchSemitones;
     if (!tm->getPlaylistModel().setClipEdits(lane->clips.front().id, edits)) {
         std::cerr << "setClipEdits failed\n";
         return false;
@@ -376,9 +378,12 @@ bool runIsolatedSpeedParityCase(const SessionConfig& cfg, const fs::path& tempRo
 
     DiffReport r = compareBuffers(rt, iso, cfg.channels, cfg.sampleRate, 1e-6);
     const bool pass = (r.rmsErrorDb <= -120.0) && (r.maxAbsError <= 1e-6);
-    printReport("Isolated_Bounce_Speed" + std::to_string(speed) + "x_vs_Live", r, pass,
-                "isolated bounce at speed " + std::to_string(speed) +
-                    " must equal live playback at the same speed (RMS <= -120 dB, maxAbs <= 1e-6)");
+    const std::string label = "Isolated_Bounce_Speed" + std::to_string(speed) + "x_Pitch" +
+                              std::to_string(pitchSemitones) + "st_vs_Live";
+    printReport(label, r, pass,
+                "isolated bounce at speed " + std::to_string(speed) + " / pitch " +
+                    std::to_string(pitchSemitones) +
+                    " st must equal live playback with the same edits (RMS <= -120 dB, maxAbs <= 1e-6)");
     std::cout << "  live frames: " << realtime.size() / cfg.channels
               << ", isolated bounce frames: " << bounced.size() / cfg.channels << "\n";
     return pass;
@@ -408,6 +413,10 @@ int main() {
     if (!runCrossSampleRateCase(cfg, tempRoot)) ++failures;
     for (float speed : {2.0f, 0.5f}) {
         if (!runIsolatedSpeedParityCase(cfg, tempRoot, speed)) ++failures;
+    }
+    // Pitch cases (#746): pure pitch, pitch cancelling speed, and interplay.
+    for (const auto& [speed, pitch] : {std::pair{1.0f, 12.0f}, {2.0f, -12.0f}, {0.5f, 7.0f}}) {
+        if (!runIsolatedSpeedParityCase(cfg, tempRoot, speed, pitch)) ++failures;
     }
 
     fs::remove_all(tempRoot, ec);

--- a/Tests/AestraAudio/WaveformCacheTest.cpp
+++ b/Tests/AestraAudio/WaveformCacheTest.cpp
@@ -187,7 +187,26 @@ bool testVisibleRangeClipping() {
     return true;
 }
 
-// 6. Cache sharing (same source identity -> shared ClipSource cache)
+// 6. Fractional source-frame bins stay source anchored
+bool testPreciseRangeMapping() {
+    const std::vector<float> data = {0.10f, 0.20f, 0.30f, 0.40f, 0.50f, 0.60f};
+    WaveformCache cache;
+    cache.buildFromRaw(data.data(), static_cast<SampleIndex>(data.size()), 1, 1, 1);
+
+    std::vector<WaveformPeak> peaks;
+    cache.getPeaksForRangePrecise(0, 1.25, 5.25, 4, peaks);
+    if (peaks.size() != 4) return fail("precise mapping: expected four peaks");
+    if (!approxEqual(peaks[0].min, 0.20f) || !approxEqual(peaks[0].max, 0.30f))
+        return fail("precise mapping: first pixel reset at fractional start");
+    if (!approxEqual(peaks[1].min, 0.30f) || !approxEqual(peaks[1].max, 0.40f))
+        return fail("precise mapping: second pixel boundary");
+    if (!approxEqual(peaks[3].min, 0.50f) || !approxEqual(peaks[3].max, 0.60f))
+        return fail("precise mapping: final pixel boundary");
+
+    return true;
+}
+
+// 7. Cache sharing (same source identity -> shared ClipSource cache)
 bool testCacheSharing() {
     ClipSource source(ClipSourceID{1}, "Test");
     std::vector<float> data = {0.1f, -0.2f, 0.3f, -0.4f};
@@ -341,6 +360,7 @@ int main() {
     ok &= testLodAggregation();
     ok &= testLodSelection();
     ok &= testVisibleRangeClipping();
+    ok &= testPreciseRangeMapping();
     ok &= testCacheSharing();
     ok &= testSourceRevisionTracksBufferContent();
     ok &= testFailureSafety();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1312,6 +1312,19 @@ target_include_directories(RealtimeExportParityTest PRIVATE
 add_test(NAME RealtimeExportParityTest COMMAND RealtimeExportParityTest)
 set_tests_properties(RealtimeExportParityTest PROPERTIES LABELS "audio;quality;export;parity;integrity;s-tier;contract:audio" TIMEOUT 180)
 
+# Playlist Split/Trim Varispeed — split/trim keep source-domain invariants
+# (durationSeconds, sourceOffsetSeconds) under Speed/Pitch varispeed (#746).
+add_executable(PlaylistSplitVarispeedTest AestraAudio/PlaylistSplitVarispeedTest.cpp)
+target_link_libraries(PlaylistSplitVarispeedTest PRIVATE AestraAudio)
+target_include_directories(PlaylistSplitVarispeedTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME PlaylistSplitVarispeedTest COMMAND PlaylistSplitVarispeedTest)
+set_tests_properties(PlaylistSplitVarispeedTest PROPERTIES LABELS "audio;model;split;trim;varispeed;contract:audio" TIMEOUT 60)
+
 # RT Allocation Trap — overrides operator new/delete in the test binary and
 # renders a session; asserts ZERO steady-state heap activity on the audio
 # callback path (thread marked by ScopedRealtimeAudioThread in processBlock).

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -783,6 +783,7 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     assert(std::abs(clip->durationSeconds - 1.0) < 1.0e-9);
     auto persistedEdits = clip->edits;
     persistedEdits.playbackRate = 1.75f;
+    persistedEdits.pitchSemitones = 5.0f;
     persistedEdits.sourceStart = 1234.5;
     assert(playlist.setClipEdits(clipId, persistedEdits));
 
@@ -803,6 +804,7 @@ void testAudioClipPlacementHelperPersistsClipAndDurationSeconds() {
     assert(loadedLane->clips.size() == 1);
     assert(std::abs(loadedLane->clips[0].edits.gainLinear - Aestra::Audio::DEFAULT_AUDIO_CLIP_GAIN_LINEAR) < 1.0e-7f);
     assert(std::abs(loadedLane->clips[0].edits.playbackRate - 1.75f) < 1.0e-7f);
+    assert(std::abs(loadedLane->clips[0].edits.pitchSemitones - 5.0f) < 1.0e-7f);
     assert(std::abs(loadedLane->clips[0].edits.sourceStart - 1234.5) < 1.0e-9);
     assert(std::abs(loadedLane->clips[0].durationSeconds - 1.0) < 1.0e-9);
     assert(std::abs(loadedLane->clips[0].durationBeats - 2.0) < 1.0e-9);

--- a/Tests/Research/SessionResamplingTruthTest.cpp
+++ b/Tests/Research/SessionResamplingTruthTest.cpp
@@ -1032,6 +1032,64 @@ void runEngineDefaultContrast(AR::CheckSession& t) {
 
 } // namespace
 
+// =============================================================================
+// Case 3c: clip Pitch (semitones) — 2^(st/12) folds into the varispeed ratio (#746)
+// =============================================================================
+void runPitchVarispeedCase(AR::CheckSession& t) {
+    std::printf("\n--- clip pitch (semitones): folds into the varispeed ratio ---\n");
+    GA::SessionConfig cfg;
+    cfg.sampleRate = 48000;
+    const uint32_t srcRate = 48000; // same-rate session: pure varispeed, no SRC interference
+    const uint32_t srcFrames = static_cast<uint32_t>(kClipSeconds * srcRate);
+    const AR::Signal clip = AR::makeSine(srcRate, srcFrames, kToneHz, kAmp);
+
+    const auto applyEdits = [](const std::shared_ptr<TrackManager>& tm, const ClipEdits& edits) {
+        const auto laneId = tm->getPlaylistModel().getLaneId(0);
+        const auto* lane = tm->getPlaylistModel().getLane(laneId);
+        if (!lane || lane->clips.empty())
+            return false;
+        return tm->getPlaylistModel().setClipEdits(lane->clips.front().id, edits);
+    };
+
+    // Split invariance: pitch +12 st at speed 1x must render identically to
+    // pitch 0 at speed 2x — the same varispeed ratio drives the same phase math.
+    auto tmPitch = buildSession("pitch12", clip, cfg);
+    ClipEdits pitchEdits;
+    pitchEdits.pitchSemitones = 12.0f;
+    if (t.expect("pitch: setClipEdits(pitch +12) succeeds", applyEdits(tmPitch, pitchEdits))) {
+        const AR::Signal pitched = renderSessionRealtime(tmPitch, cfg, srcFrames * 2 + 4800,
+                                                         Interp::InterpolationQuality::Sinc64);
+
+        auto tmSpeed = buildSession("speed2x", clip, cfg);
+        ClipEdits speedEdits;
+        speedEdits.playbackRate = 2.0f;
+        if (t.expect("pitch: setClipEdits(speed 2x) succeeds", applyEdits(tmSpeed, speedEdits))) {
+            const AR::Signal sped = renderSessionRealtime(tmSpeed, cfg, srcFrames * 2 + 4800,
+                                                          Interp::InterpolationQuality::Sinc64);
+            const size_t n = std::min(pitched.samples.size(), sped.samples.size());
+            const AR::Signal pWin = window(pitched, kWinSkip, n - kWinSkip);
+            const AR::Signal sWin = window(sped, kWinSkip, n - kWinSkip);
+            const AR::DiffReport d = AR::diff(pWin, sWin, 1e-4);
+            std::printf("[MEASURE] pitch+12st vs speed2x: maxErr=%.3e rmsErr=%.1f dB\n", d.maxAbsError, d.rmsErrorDb);
+            t.expect("pitch: +12 st at 1x nulls against 0 st at 2x (same varispeed ratio)",
+                     d.rmsErrorDb < -120.0 && d.maxAbsError < 1e-6,
+                     "rmsErrDb=" + std::to_string(d.rmsErrorDb) + " maxAbs=" + std::to_string(d.maxAbsError));
+        }
+
+        // The pitched tone lands one octave up: 2000 Hz present, 1000 Hz gone.
+        // The clip plays 2x faster, so the audible content spans 0.75 s.
+        const uint32_t pitchEnd =
+            std::min<uint32_t>(static_cast<uint32_t>(pitched.samples.size()) - kWinSkip, 30000u);
+        const double expectedAmp = kAmp * static_cast<double>(PanLaw::kEqualPowerCenterGain);
+        const double amp2k = AR::toneAmplitude(pitched, 0, 2000.0, kWinSkip, pitchEnd);
+        const double amp1k = AR::toneAmplitude(pitched, 0, kToneHz, kWinSkip, pitchEnd);
+        std::printf("[MEASURE] pitch+12st: amp@2k=%.4f (expect ~%.4f), amp@1k=%.2e\n", amp2k, expectedAmp, amp1k);
+        t.expect("pitch: +12 st moves the tone from 1 kHz to 2 kHz",
+                 amp2k > 0.9 * expectedAmp && amp1k < 0.1 * expectedAmp,
+                 "amp2k=" + std::to_string(amp2k) + " amp1k=" + std::to_string(amp1k));
+    }
+}
+
 int main() {
     std::printf("============================================================\n");
     std::printf("  Aestra Audio Research Bench — Session Resampling Truth\n");
@@ -1050,6 +1108,7 @@ int main() {
     }
     runFallbackTransitionCase(t);
     runImpulseCases(t);
+    runPitchVarispeedCase(t);
     runIsolatedBounceCase(t, tempRoot);
     runExportParityCases(t, tempRoot);
     runPreviewCases(t, tempRoot);


### PR DESCRIPTION
## Summary

Adds independent clip-level pitch in semitones and makes sliced audio clips visually gapless and source-aligned in the timeline.

## Why

The timeline waveform was using a different source offset and different pixel binning from playback. After a split, the audio could be correct while the waveform restarted from the source beginning, exposed a seam, or changed shape as zoom crossed the cache boundary.

## What changed

- Keeps Speed and Pitch as separate clip edits while using one bounded combined varispeed authority for playback, preview, split, trim, and duration math.
- Resolves the waveform source start from the same canonical clip snapshot used by runtime audio, including legacy offsets and instance slips.
- Reworks waveform collection around exact fractional source-frame ranges. Direct peaks and cached mip peaks now use the same source-anchored pixel bins, and all zoom levels use the same filled min/max/RMS renderer.
- Removes the alternate deep-zoom line renderer that caused visual language and binning to jump at high zoom.
- Squares and overlaps internal clip sides and removes internal waveform padding so adjacent slices render without a visual gap.
- Normalizes persisted pitch values, clamps combined editor varispeed, and registers the Speed controls with the clip editor surface.

## Root cause

The old renderer rounded source ranges before drawing and independently rebuilt pixel bins for each visible slice. The cache path then merged source-aligned mip entries while the deep path scanned a separately rounded range. That made a split boundary and zoom transition visually discontinuous even though the audio source range was continuous.

## Testing performed

- `cmake --build build-linux -j2 --target AestraWaveformCacheTest PlaylistSplitVarispeedTest Aestra`
- `./build-linux/Tests/AestraWaveformCacheTest` — PASS
- `ctest --test-dir build-linux --output-on-failure -R '^(RealtimeExportParityTest|PlaylistSplitVarispeedTest)$'` — 2/2 PASS
- `ctest --test-dir build-linux --output-on-failure` — 237/237 PASS
- Manual rebuilt-desktop run with the supplied WAV: adjacent split clips touched without a visible seam and retained one waveform renderer across the visible zoom range.

## Producer note

Now you can split an audio clip without the waveform restarting or showing a gap, and pitch it independently from speed.

## Docs updated?

No.

## Risk/rollback notes

- Audio rendering remains source-offset and varispeed compatible; this change does not alter the audio samples or add realtime work.
- Waveform rendering now preserves source amplitude differences between slices instead of normalizing each slice independently.
- Project serialization remains backward-compatible; missing pitch fields still load as zero.
- Rollback: revert commit `8b7bb6f8`; no migration is required.

### Decision citation

Objective:  N3 — producer-loop scenario in CI
Decision:   FD-12 @ e437eefeb4c729f700020e4561142e0c26dbada0
Kind:       planned


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds independent clip-level pitch control in semitones. Existing projects default to `0` semitones and retain prior behavior.
- Combines pitch with playback speed in live rendering, isolated bounce, preview, duration, audible bounds, and trim calculations.
- Adds separate Pitch and Speed controls to the Audio Clip Editor and timeline.
- Persists `pitchSemitones` through runtime state and project serialization with bounds of `-24` to `24` semitones.
- Keeps sliced clip waveforms source-aligned and improves fractional waveform range mapping and seam rendering.
- Clamps pitch and combined varispeed to supported limits.
- Adds tests for render parity, octave pitch shifting, split and trim behavior, waveform mapping, serialization round trips, and legacy compatibility.
- All 236 tests pass, including Linux build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->