### PR TITLE
fix: routing contract implementation — command seam, cycle rejection, stable send IDs, master legality, render semantics

### DIFF
--- a/AestraAudio/include/Commands/AddChannelCommand.h
+++ b/AestraAudio/include/Commands/AddChannelCommand.h
@@ -42,10 +42,17 @@ public:
      * routed to the old one — and leave every command that captured a
      * `MixerChannel&` to it dangling, so add / set volume / undo / undo / redo /
      * redo wrote through freed memory.
+     *
+     * Routing Contract I8/D3: before detaching, every route pointing at this
+     * channel is captured and then resolved — mains reroute to master, sends
+     * to it are removed — so no dangling route can exist while the channel is
+     * gone. Redo restores the captured routes (round trip).
      */
     void undo() override {
         if (!m_executed) return;
         size_t index = 0;
+        captureRoutesToChannel();
+        m_manager.resetMixerRoutingDestination(m_createdChannelId);
         if (auto detached = m_manager.detachChannelById(m_createdChannelId, index)) {
             m_detached = std::move(detached);
             m_detachedIndex = index;
@@ -60,6 +67,7 @@ public:
         if (m_executed) return;
         if (m_detached) {
             if (m_manager.reinsertChannel(m_detached, m_detachedIndex)) {
+                restoreRoutesToChannel();
                 m_executed = true;
             }
             // A failed reinsert leaves m_detached intact, so a later redo can
@@ -91,6 +99,47 @@ public:
     bool changesProjectState() const override { return true; }
 
 private:
+    struct RouteSnapshot {
+        uint32_t sourceChannelId{0};
+        uint32_t mainOutputId{0};
+        std::vector<AudioRoute> sends;
+    };
+
+    void captureRoutesToChannel() {
+        if (m_routesCaptured || m_createdChannelId == 0) {
+            return;
+        }
+        for (const auto& channel : m_manager.getChannelsSnapshot()) {
+            if (!channel || channel->getChannelId() == m_createdChannelId) {
+                continue;
+            }
+            const auto sends = channel->getSends();
+            const bool routesToChannel = channel->getMainOutputId() == m_createdChannelId ||
+                                         std::any_of(sends.begin(), sends.end(), [this](const AudioRoute& route) {
+                                             return route.targetChannelId == m_createdChannelId;
+                                         });
+            if (routesToChannel) {
+                m_routes.push_back({channel->getChannelId(), channel->getMainOutputId(), sends});
+            }
+        }
+        m_routesCaptured = true;
+    }
+
+    void restoreRoutesToChannel() {
+        for (const auto& routeSnapshot : m_routes) {
+            if (auto* channel = m_manager.getChannelById(routeSnapshot.sourceChannelId)) {
+                if (routeSnapshot.mainOutputId == m_createdChannelId) {
+                    channel->setMainOutputId(routeSnapshot.mainOutputId);
+                }
+                if (!routeSnapshot.sends.empty()) {
+                    channel->replaceSends(routeSnapshot.sends);
+                }
+            }
+        }
+        m_routes.clear();
+        m_routesCaptured = false;
+    }
+
     TrackManager& m_manager;
     std::string m_name;
     bool m_executed = false;
@@ -98,6 +147,8 @@ private:
     /** The channel itself while undone, so redo restores it rather than a copy (#611). */
     std::unique_ptr<MixerChannel> m_detached;
     size_t m_detachedIndex = 0;
+    std::vector<RouteSnapshot> m_routes;
+    bool m_routesCaptured = false;
 };
 
 } // namespace Audio

--- a/AestraAudio/include/Commands/RoutingCommands.h
+++ b/AestraAudio/include/Commands/RoutingCommands.h
@@ -73,16 +73,21 @@ public:
         if (!m_manager.canRouteTo(m_channelId, m_route.targetChannelId)) {
             throw std::runtime_error("AddSend: routing loop or illegal destination");
         }
-        m_sendIndex = static_cast<int>(channel->getSends().size());
         channel->addSend(m_route);
+        // Capture the minted stable id so undo removes the right send even
+        // after other sends were added/removed around it, and redo restores
+        // the SAME id (round trip, not a new identity wearing the old slot).
+        const auto sends = channel->getSends();
+        m_sendId = sends.empty() ? 0u : sends.back().sendId;
+        m_route.sendId = m_sendId;
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
     }
     void undo() override {
-        if (m_sendIndex < 0) {
+        if (m_sendId == 0u) {
             return;
         }
         if (auto* channel = m_manager.getChannelById(m_channelId)) {
-            channel->removeSend(m_sendIndex);
+            channel->removeSend(m_sendId);
             m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         }
     }
@@ -96,34 +101,37 @@ private:
     TrackManager& m_manager;
     uint32_t m_channelId;
     AudioRoute m_route;
-    int m_sendIndex{-1};
+    uint64_t m_sendId{0};
 };
 
 /**
- * @brief Undoable removal of a send route (Routing Contract D5).
+ * @brief Undoable removal of a send route (Routing Contract D5/D2).
  *
- * Captures the removed route so undo restores the exact send at its
- * original index.
+ * Targets the stable sendId (not an index), captures the removed route, and
+ * restores it at its original position with the SAME sendId on undo.
  */
 class RemoveSendCommand : public ICommand {
 public:
-    RemoveSendCommand(TrackManager& manager, uint32_t channelId, int sendIndex)
-        : m_manager(manager), m_channelId(channelId), m_sendIndex(sendIndex) {}
+    RemoveSendCommand(TrackManager& manager, uint32_t channelId, uint64_t sendId)
+        : m_manager(manager), m_channelId(channelId), m_sendId(sendId) {}
 
     void execute() override {
         MixerChannel* channel = m_manager.getChannelById(m_channelId);
         if (!channel) {
             throw std::runtime_error("RemoveSend: channel no longer exists");
         }
-        const auto sends = channel->getSends();
-        if (m_sendIndex < 0 || m_sendIndex >= static_cast<int>(sends.size())) {
-            throw std::runtime_error("RemoveSend: send index out of range");
+        m_sendIndex = channel->findSendIndex(m_sendId);
+        if (m_sendIndex < 0) {
+            throw std::runtime_error("RemoveSend: send no longer exists");
         }
-        m_removedRoute = sends[static_cast<size_t>(m_sendIndex)];
-        channel->removeSend(m_sendIndex);
+        m_removedRoute = channel->getSends()[static_cast<size_t>(m_sendIndex)];
+        channel->removeSend(m_sendId);
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
     }
     void undo() override {
+        if (m_sendIndex < 0) {
+            return;
+        }
         if (auto* channel = m_manager.getChannelById(m_channelId)) {
             channel->insertSend(m_sendIndex, m_removedRoute);
             m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
@@ -138,44 +146,46 @@ public:
 private:
     TrackManager& m_manager;
     uint32_t m_channelId;
-    int m_sendIndex;
+    uint64_t m_sendId;
+    int m_sendIndex{-1};
     AudioRoute m_removedRoute;
 };
 
 /**
- * @brief Undoable edit of one send route (Routing Contract D5/D1).
+ * @brief Undoable edit of one send route (Routing Contract D5/D1/D2).
  *
- * Applies the full replacement route. Destination changes are validated
- * through TrackManager::canRouteTo; level/pan/tap/mute/sidechain edits
- * cannot create topology, so they skip the walk.
+ * Targets the stable sendId so edits survive index shifts caused by other
+ * send removals. Destination changes are validated through
+ * TrackManager::canRouteTo; level/pan/tap/mute/sidechain edits cannot create
+ * topology, so they skip the walk.
  */
 class EditSendCommand : public ICommand {
 public:
-    EditSendCommand(TrackManager& manager, uint32_t channelId, int sendIndex, const AudioRoute& newRoute)
-        : m_manager(manager), m_channelId(channelId), m_sendIndex(sendIndex), m_newRoute(newRoute) {}
+    EditSendCommand(TrackManager& manager, uint32_t channelId, uint64_t sendId, const AudioRoute& newRoute)
+        : m_manager(manager), m_channelId(channelId), m_sendId(sendId), m_newRoute(newRoute) {}
 
     void execute() override {
         MixerChannel* channel = m_manager.getChannelById(m_channelId);
         if (!channel) {
             throw std::runtime_error("EditSend: channel no longer exists");
         }
-        const auto sends = channel->getSends();
-        if (m_sendIndex < 0 || m_sendIndex >= static_cast<int>(sends.size())) {
-            throw std::runtime_error("EditSend: send index out of range");
+        const int sendIndex = channel->findSendIndex(m_sendId);
+        if (sendIndex < 0) {
+            throw std::runtime_error("EditSend: send no longer exists");
         }
-        m_previousRoute = sends[static_cast<size_t>(m_sendIndex)];
+        m_previousRoute = channel->getSends()[static_cast<size_t>(sendIndex)];
         if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId &&
             !m_manager.canRouteTo(m_channelId, m_newRoute.targetChannelId)) {
             throw std::runtime_error("EditSend: routing loop or illegal destination");
         }
-        channel->setSend(m_sendIndex, m_newRoute);
+        channel->setSend(m_sendId, m_newRoute);
         if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
             m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         }
     }
     void undo() override {
         if (auto* channel = m_manager.getChannelById(m_channelId)) {
-            channel->setSend(m_sendIndex, m_previousRoute);
+            channel->setSend(m_sendId, m_previousRoute);
             if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
                 m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
             }
@@ -190,7 +200,7 @@ public:
 private:
     TrackManager& m_manager;
     uint32_t m_channelId;
-    int m_sendIndex;
+    uint64_t m_sendId;
     AudioRoute m_newRoute;
     AudioRoute m_previousRoute;
 };

--- a/AestraAudio/include/Commands/RoutingCommands.h
+++ b/AestraAudio/include/Commands/RoutingCommands.h
@@ -1,0 +1,199 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Undoable reroute of a track's main output (Routing Contract D5/D1).
+ *
+ * Validates the destination through TrackManager::canRouteTo before applying:
+ * self-routes, audible cycles, and dangling destinations are rejected by
+ * throwing, which CommandHistory catches and does not record.
+ */
+class SetMainOutputCommand : public ICommand {
+public:
+    SetMainOutputCommand(TrackManager& manager, uint32_t channelId, uint32_t targetId)
+        : m_manager(manager), m_channelId(channelId), m_targetId(targetId) {}
+
+    void execute() override {
+        MixerChannel* channel = m_manager.getChannelById(m_channelId);
+        if (!channel) {
+            throw std::runtime_error("SetMainOutput: channel no longer exists");
+        }
+        if (!m_manager.canRouteTo(m_channelId, m_targetId)) {
+            throw std::runtime_error("SetMainOutput: routing loop or illegal destination");
+        }
+        m_previousId = channel->getMainOutputId();
+        channel->setMainOutputId(m_targetId);
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+    }
+    void undo() override {
+        if (m_previousId == 0u) {
+            return;
+        }
+        if (auto* channel = m_manager.getChannelById(m_channelId)) {
+            channel->setMainOutputId(m_previousId);
+            m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+        }
+    }
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Reroute Track"; }
+    bool changesProjectState() const override { return true; }
+    std::string type() const override { return "set_main_output"; }
+
+private:
+    TrackManager& m_manager;
+    uint32_t m_channelId;
+    uint32_t m_targetId;
+    uint32_t m_previousId{0u};
+};
+
+/**
+ * @brief Undoable add of a send route (Routing Contract D5/D1).
+ */
+class AddSendCommand : public ICommand {
+public:
+    AddSendCommand(TrackManager& manager, uint32_t channelId, const AudioRoute& route)
+        : m_manager(manager), m_channelId(channelId), m_route(route) {}
+
+    void execute() override {
+        MixerChannel* channel = m_manager.getChannelById(m_channelId);
+        if (!channel) {
+            throw std::runtime_error("AddSend: channel no longer exists");
+        }
+        if (!m_manager.canRouteTo(m_channelId, m_route.targetChannelId)) {
+            throw std::runtime_error("AddSend: routing loop or illegal destination");
+        }
+        m_sendIndex = static_cast<int>(channel->getSends().size());
+        channel->addSend(m_route);
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+    }
+    void undo() override {
+        if (m_sendIndex < 0) {
+            return;
+        }
+        if (auto* channel = m_manager.getChannelById(m_channelId)) {
+            channel->removeSend(m_sendIndex);
+            m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+        }
+    }
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Add Send"; }
+    bool changesProjectState() const override { return true; }
+    std::string type() const override { return "add_send"; }
+
+private:
+    TrackManager& m_manager;
+    uint32_t m_channelId;
+    AudioRoute m_route;
+    int m_sendIndex{-1};
+};
+
+/**
+ * @brief Undoable removal of a send route (Routing Contract D5).
+ *
+ * Captures the removed route so undo restores the exact send at its
+ * original index.
+ */
+class RemoveSendCommand : public ICommand {
+public:
+    RemoveSendCommand(TrackManager& manager, uint32_t channelId, int sendIndex)
+        : m_manager(manager), m_channelId(channelId), m_sendIndex(sendIndex) {}
+
+    void execute() override {
+        MixerChannel* channel = m_manager.getChannelById(m_channelId);
+        if (!channel) {
+            throw std::runtime_error("RemoveSend: channel no longer exists");
+        }
+        const auto sends = channel->getSends();
+        if (m_sendIndex < 0 || m_sendIndex >= static_cast<int>(sends.size())) {
+            throw std::runtime_error("RemoveSend: send index out of range");
+        }
+        m_removedRoute = sends[static_cast<size_t>(m_sendIndex)];
+        channel->removeSend(m_sendIndex);
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+    }
+    void undo() override {
+        if (auto* channel = m_manager.getChannelById(m_channelId)) {
+            channel->insertSend(m_sendIndex, m_removedRoute);
+            m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+        }
+    }
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Remove Send"; }
+    bool changesProjectState() const override { return true; }
+    std::string type() const override { return "remove_send"; }
+
+private:
+    TrackManager& m_manager;
+    uint32_t m_channelId;
+    int m_sendIndex;
+    AudioRoute m_removedRoute;
+};
+
+/**
+ * @brief Undoable edit of one send route (Routing Contract D5/D1).
+ *
+ * Applies the full replacement route. Destination changes are validated
+ * through TrackManager::canRouteTo; level/pan/tap/mute/sidechain edits
+ * cannot create topology, so they skip the walk.
+ */
+class EditSendCommand : public ICommand {
+public:
+    EditSendCommand(TrackManager& manager, uint32_t channelId, int sendIndex, const AudioRoute& newRoute)
+        : m_manager(manager), m_channelId(channelId), m_sendIndex(sendIndex), m_newRoute(newRoute) {}
+
+    void execute() override {
+        MixerChannel* channel = m_manager.getChannelById(m_channelId);
+        if (!channel) {
+            throw std::runtime_error("EditSend: channel no longer exists");
+        }
+        const auto sends = channel->getSends();
+        if (m_sendIndex < 0 || m_sendIndex >= static_cast<int>(sends.size())) {
+            throw std::runtime_error("EditSend: send index out of range");
+        }
+        m_previousRoute = sends[static_cast<size_t>(m_sendIndex)];
+        if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId &&
+            !m_manager.canRouteTo(m_channelId, m_newRoute.targetChannelId)) {
+            throw std::runtime_error("EditSend: routing loop or illegal destination");
+        }
+        channel->setSend(m_sendIndex, m_newRoute);
+        if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
+            m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+        }
+    }
+    void undo() override {
+        if (auto* channel = m_manager.getChannelById(m_channelId)) {
+            channel->setSend(m_sendIndex, m_previousRoute);
+            if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
+                m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
+            }
+        }
+    }
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Edit Send"; }
+    bool changesProjectState() const override { return true; }
+    std::string type() const override { return "edit_send"; }
+
+private:
+    TrackManager& m_manager;
+    uint32_t m_channelId;
+    int m_sendIndex;
+    AudioRoute m_newRoute;
+    AudioRoute m_previousRoute;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/RoutingCommands.h
+++ b/AestraAudio/include/Commands/RoutingCommands.h
@@ -11,6 +11,10 @@
 namespace Aestra {
 namespace Audio {
 
+// Engine-space master constant (Contract: 0 = model space, 0xFFFFFFFF = engine
+// space; both name the same terminal sink).
+constexpr uint32_t kMasterId = 0xFFFFFFFFu;
+
 /**
  * @brief Undoable reroute of a track's main output (Routing Contract D5/D1).
  *
@@ -69,6 +73,9 @@ public:
         MixerChannel* channel = m_manager.getChannelById(m_channelId);
         if (!channel) {
             throw std::runtime_error("AddSend: channel no longer exists");
+        }
+        if (m_route.targetChannelId == kMasterId) {
+            throw std::runtime_error("AddSend: sends to master are illegal (Contract D4)");
         }
         if (!m_manager.canRouteTo(m_channelId, m_route.targetChannelId)) {
             throw std::runtime_error("AddSend: routing loop or illegal destination");
@@ -174,9 +181,13 @@ public:
             throw std::runtime_error("EditSend: send no longer exists");
         }
         m_previousRoute = channel->getSends()[static_cast<size_t>(sendIndex)];
-        if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId &&
-            !m_manager.canRouteTo(m_channelId, m_newRoute.targetChannelId)) {
-            throw std::runtime_error("EditSend: routing loop or illegal destination");
+        if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
+            if (m_newRoute.targetChannelId == kMasterId) {
+                throw std::runtime_error("EditSend: sends to master are illegal (Contract D4)");
+            }
+            if (!m_manager.canRouteTo(m_channelId, m_newRoute.targetChannelId)) {
+                throw std::runtime_error("EditSend: routing loop or illegal destination");
+            }
         }
         channel->setSend(m_sendId, m_newRoute);
         if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {

--- a/AestraAudio/include/Commands/RoutingCommands.h
+++ b/AestraAudio/include/Commands/RoutingCommands.h
@@ -190,14 +190,17 @@ public:
             }
         }
         channel->setSend(m_sendId, m_newRoute);
-        if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
+        if (sendTopologyChanged()) {
+            // mute/sidechainOnly/postFader/destination all change the compiled
+            // topology (edges, sidechain buffers, PDC classification) — not
+            // just level/pan. Keep model and graph in step.
             m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
         }
     }
     void undo() override {
         if (auto* channel = m_manager.getChannelById(m_channelId)) {
             channel->setSend(m_sendId, m_previousRoute);
-            if (m_previousRoute.targetChannelId != m_newRoute.targetChannelId) {
+            if (sendTopologyChanged()) {
                 m_manager.requestAudioGraphRebuild(GraphDirtyReason::RoutingChanged);
             }
         }
@@ -209,6 +212,13 @@ public:
     std::string type() const override { return "edit_send"; }
 
 private:
+    bool sendTopologyChanged() const {
+        return m_previousRoute.targetChannelId != m_newRoute.targetChannelId ||
+               m_previousRoute.mute != m_newRoute.mute ||
+               m_previousRoute.sidechainOnly != m_newRoute.sidechainOnly ||
+               m_previousRoute.postFader != m_newRoute.postFader;
+    }
+
     TrackManager& m_manager;
     uint32_t m_channelId;
     uint64_t m_sendId;

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -225,6 +225,13 @@ public:
     void setGraph(const AudioGraph& graph) {
         auto preparedGraph = graph;
         finalizeAudioGraphRouting(preparedGraph);
+        // Routing Contract D1: a cyclic snapshot is corruption, not a
+        // rendering fallback. Refuse to publish it and keep the last valid
+        // graph so the audio thread never interprets an invalid topology.
+        if (preparedGraph.hasRoutingCycle) {
+            Aestra::Log::error("[AudioEngine] setGraph refused: routing cycle in snapshot; keeping previous graph");
+            return;
+        }
         prepareTrackStateForGraph(preparedGraph);
         m_state.swapGraph(preparedGraph);
         compileGraph();

--- a/AestraAudio/include/Core/AudioGraph.h
+++ b/AestraAudio/include/Core/AudioGraph.h
@@ -50,6 +50,9 @@ struct AudioRoute {
     bool postFader{true};     // Pre/Post Fader tap
     bool mute{false};         // Mute this specific send
     bool sidechainOnly{false}; // Route exists for sidechain/control input, not audible mix
+    uint64_t sendId{0};       // Stable per-channel send identity (Contract D2).
+                              // Minted by MixerChannel on creation; survives
+                              // index shifts and undo; 0 = unassigned.
 };
 
 /**

--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -231,26 +231,24 @@ public:
 
     /** @brief Get a copy of the current send list. Thread-safe: caller must not be RT. */
     std::vector<AudioRoute> getSends() const;
-    /** @brief Add a send route. */
+    /**
+     * @brief Add a send route. Mints a stable sendId when the route carries
+     * none (0); a caller-supplied nonzero sendId is preserved (undo restore).
+     */
     void addSend(const AudioRoute& route);
-    /** @brief Insert a send route at a position (undo of removeSend). */
+    /** @brief Insert a send route at a position (undo of removeSend). Preserves the route's sendId. */
     void insertSend(int index, const AudioRoute& route);
-    /** @brief Replace one send route in place (undoable edits). */
-    void setSend(int index, const AudioRoute& route);
+    /**
+     * @brief Replace the send with the given stable sendId. The replacement
+     * keeps the existing sendId (identity is owned by the channel).
+     */
+    void setSend(uint64_t sendId, const AudioRoute& route);
     /** @brief Replace all send routes from an off-audio-thread snapshot. */
     void replaceSends(const std::vector<AudioRoute>& routes);
-    /** @brief Remove a send route by index. */
-    void removeSend(int index);
-    /** @brief Update send level by index. */
-    void setSendLevel(int index, float level);
-    /** @brief Update send pan by index. */
-    void setSendPan(int index, float pan);
-    /** @brief Update send destination by index. */
-    void setSendDestination(int index, uint32_t destId);
-    /** @brief Update send pre/post fader mode by index. */
-    void setSendPostFader(int index, bool postFader);
-    /** @brief Update send audible/sidechain-only mode by index. */
-    void setSendSidechainOnly(int index, bool sidechainOnly);
+    /** @brief Remove the send with the given stable sendId. */
+    void removeSend(uint64_t sendId);
+    /** @brief Positional lookup for a stable sendId; -1 when absent. */
+    int findSendIndex(uint64_t sendId) const;
 
     /** @brief Set the effect chain snapshot for RT-safe processing (deprecated - snapshots are now owned by EffectChain). */
     void setEffectChainSnapshot(std::shared_ptr<const EffectChainSnapshot> snapshot) {
@@ -313,6 +311,9 @@ private:
     // Aux Sends / Direct Outs
     mutable std::mutex m_sendMutex;
     std::vector<AudioRoute> m_sends;
+    uint64_t m_nextSendId{1}; // Monotonic sendId mint (never reused within a channel)
+    /** @brief Positional lookup for a stable sendId; -1 when absent. Caller must hold m_sendMutex. */
+    int findSendIndexLocked(uint64_t sendId) const;
 
     void notifyInputMonitoringStateChanged() {
         std::function<void()> cb;

--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -233,6 +233,10 @@ public:
     std::vector<AudioRoute> getSends() const;
     /** @brief Add a send route. */
     void addSend(const AudioRoute& route);
+    /** @brief Insert a send route at a position (undo of removeSend). */
+    void insertSend(int index, const AudioRoute& route);
+    /** @brief Replace one send route in place (undoable edits). */
+    void setSend(int index, const AudioRoute& route);
     /** @brief Replace all send routes from an off-audio-thread snapshot. */
     void replaceSends(const std::vector<AudioRoute>& routes);
     /** @brief Remove a send route by index. */

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <ctime>
+#include <unordered_set>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -337,6 +338,63 @@ public:
     const MixerChannel* getChannelById(uint32_t channelId) const {
         const size_t index = findChannelIndexById(channelId);
         return index < m_channels.size() ? m_channels[index].get() : nullptr;
+    }
+
+    /**
+     * @brief Whether routing source -> target is legal (Routing Contract D1).
+     *
+     * Rejects self-routes and audible cycles before any mutation commits, and
+     * rejects dangling destinations. Master is a terminal sink: always a legal
+     * target, never a source. Only audible edges are followed (main outputs +
+     * unmuted non-sidechain sends) — sidechain edges cannot form audible
+     * cycles, so they do not participate.
+     */
+    bool canRouteTo(uint32_t sourceId, uint32_t targetId) const {
+        // Master has two spellings: user/model space (0, MASTER_MIXER_CHANNEL_ID)
+        // and engine space (0xFFFFFFFF). Both are the same terminal sink.
+        constexpr uint32_t kEngineMaster = 0xFFFFFFFFu;
+        if (sourceId == MASTER_MIXER_CHANNEL_ID || sourceId == kEngineMaster) {
+            return false;
+        }
+        if (targetId == MASTER_MIXER_CHANNEL_ID || targetId == kEngineMaster) {
+            return true;
+        }
+        if (sourceId == targetId) {
+            return false;
+        }
+        if (!getChannelById(sourceId) || !getChannelById(targetId)) {
+            return false;
+        }
+
+        std::vector<uint32_t> stack{targetId};
+        std::unordered_set<uint32_t> visited;
+        while (!stack.empty()) {
+            const uint32_t current = stack.back();
+            stack.pop_back();
+            if (current == sourceId) {
+                return false;
+            }
+            if (!visited.insert(current).second) {
+                continue;
+            }
+            const MixerChannel* channel = getChannelById(current);
+            if (!channel) {
+                continue;
+            }
+            const uint32_t mainOutput = channel->getMainOutputId();
+            if (mainOutput != kEngineMaster) {
+                stack.push_back(mainOutput);
+            }
+            for (const auto& send : channel->getSends()) {
+                if (send.mute || send.sidechainOnly) {
+                    continue;
+                }
+                if (send.targetChannelId != kEngineMaster) {
+                    stack.push_back(send.targetChannelId);
+                }
+            }
+        }
+        return true;
     }
 
     /** Route an audio source pattern independently from Playlist placement. */

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -46,6 +46,7 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
         return AudioGraph::kInvalidTrackIndex;
     };
 
+    size_t droppedEdgeCount = 0;
     auto addEdge = [&](size_t sourceIndex, uint32_t targetTrackId, bool sidechainOnly) {
         constexpr uint32_t kMasterOutputId = 0xFFFFFFFFu;
         if (targetTrackId == kMasterOutputId) {
@@ -54,6 +55,10 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
 
         const size_t targetIndex = findTrackIndex(targetTrackId);
         if (targetIndex == AudioGraph::kInvalidTrackIndex || targetIndex == sourceIndex) {
+            // Contract D3: with mutation-time and load-time validation this is
+            // corruption, not normal behavior. Count it and report once so a
+            // dangling model cannot silently render as a dropped route.
+            ++droppedEdgeCount;
             return;
         }
 
@@ -110,6 +115,10 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
     // Routing Contract D1: a cycle is corruption, not a rendering fallback.
     // The partial order is left as-is (never appended with leftover nodes);
     // the publish gate (AudioEngine::setGraph) refuses the snapshot.
+    if (droppedEdgeCount > 0) {
+        Aestra::Log::warning("[AudioGraph] dropped " + std::to_string(droppedEdgeCount) +
+                             " route(s) with missing or self destinations (corrupt model)");
+    }
 }
 
 AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) {

--- a/AestraAudio/src/AudioGraphBuilder.cpp
+++ b/AestraAudio/src/AudioGraphBuilder.cpp
@@ -107,19 +107,9 @@ void finalizeAudioGraphRouting(AudioGraph& graph) {
     }
 
     graph.hasRoutingCycle = graph.topologicalOrder.size() != trackCount;
-    if (graph.hasRoutingCycle) {
-        std::vector<uint8_t> visited(trackCount, 0);
-        for (const size_t index : graph.topologicalOrder) {
-            if (index < trackCount) {
-                visited[index] = 1;
-            }
-        }
-        for (size_t i = 0; i < trackCount; ++i) {
-            if (visited[i] == 0) {
-                graph.topologicalOrder.push_back(i);
-            }
-        }
-    }
+    // Routing Contract D1: a cycle is corruption, not a rendering fallback.
+    // The partial order is left as-is (never appended with leftover nodes);
+    // the publish gate (AudioEngine::setGraph) refuses the snapshot.
 }
 
 AudioGraph AudioGraphBuilder::buildFromTrackManager(TrackManager& trackManager) {

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -688,7 +688,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 evidence.set("targetMixerChannelId", JSON(static_cast<double>(targetId)));
                 evidence.set("stableSourceIdentityAvailable", JSON(true));
                 evidence.set("stableSendIdAvailable", JSON(sendId != 0));
-                if (sendId != 0) evidence.set("sendId", JSON(static_cast<double>(sendId)));
+                if (sendId != 0) evidence.set("sendId", JSON(std::to_string(sendId)));
 
                 JSON issue = JSON::object();
                 issue.set("issueCode", JSON(issueCode));
@@ -793,7 +793,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     send.set("routeType", JSON(route.sidechainOnly ? "sidechain_send" : "send"));
                     send.set("sourceNodeId", JSON(sourceNodeId));
                     send.set("sourceMixerChannelId", JSON(static_cast<double>(channelId)));
-                    send.set("sendId", JSON(static_cast<double>(route.sendId)));
+                    send.set("sendId", JSON(std::to_string(route.sendId)));
                     send.set("stableIdentityAvailable", JSON(route.sendId != 0));
                     send.set("positionalIdentityAvailable", JSON(false));
                     send.set("targetMixerChannelId",
@@ -809,7 +809,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     send.set("postFader", JSON(route.postFader));
                     send.set("muted", JSON(route.mute));
                     send.set("sidechainOnly", JSON(route.sidechainOnly));
-                    send.set("sendId", JSON(static_cast<double>(route.sendId)));
+                    send.set("sendId", JSON(std::to_string(route.sendId)));
                     sends.push(send);
                     if (!sendResolved) {
                         addUnresolved("unresolved_send_destination",
@@ -886,7 +886,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
             identityPolicy.set("units", JSON("stable_id"));
             identityPolicy.set("audioPatterns", JSON("stable_id"));
             identityPolicy.set("pluginSlots", JSON("positional"));
-            identityPolicy.set("sends", JSON("positional"));
+            identityPolicy.set("sends", JSON("stable_id"));
 
             JSON result = JSON::object();
             result.set("status", JSON(unresolvedRoutes.size() > 0 ? "degraded" : "resolved"));
@@ -1190,7 +1190,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     evidence.set("stableEndpointIdentityAvailable", JSON(sourceValid && destinationValid));
                     evidence.set("stableSendIdAvailable", JSON(mappingMatches && !main && sendId != 0));
                     if (mappingMatches && !main && sendId != 0) {
-                        evidence.set("sendId", JSON(static_cast<double>(sendId)));
+                        evidence.set("sendId", JSON(std::to_string(sendId)));
                     }
                     evidence.set("solvedCompensationSamples", JSON(static_cast<double>(solution.compensationSamples)));
                     evidence.set("appliedCompensationAvailable", JSON(appliedAvailable));
@@ -1217,7 +1217,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 edge.set("appliedCompensationSamples", JSON(static_cast<double>(appliedCompensation)));
                 edge.set("stableIdentityAvailable", JSON(mappingMatches && !main && sendId != 0));
                 if (mappingMatches && !main && sendId != 0) {
-                    edge.set("sendId", JSON(static_cast<double>(sendId)));
+                    edge.set("sendId", JSON(std::to_string(sendId)));
                 }
                 edge.set("mismatch", JSON(mismatch));
                 edges.push(edge);
@@ -1229,7 +1229,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     evidence.set("stableEndpointIdentityAvailable", JSON(sourceValid && destinationValid));
                     evidence.set("stableSendIdAvailable", JSON(mappingMatches && !main && sendId != 0));
                     if (mappingMatches && !main && sendId != 0) {
-                        evidence.set("sendId", JSON(static_cast<double>(sendId)));
+                        evidence.set("sendId", JSON(std::to_string(sendId)));
                     }
                     JSON issue = JSON::object();
                     issue.set("issueCode", JSON("sidechain_latency_compensation_unavailable"));

--- a/AestraAudio/src/Commands/MuseService.cpp
+++ b/AestraAudio/src/Commands/MuseService.cpp
@@ -682,13 +682,13 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
 
             const auto addUnresolved = [&](const char* issueCode, const char* routeType,
                                            const std::string& sourceNodeId, uint32_t targetId,
-                                           int sendIndex = -1) {
+                                           uint64_t sendId = 0) {
                 JSON evidence = JSON::object();
                 evidence.set("sourceNodeId", JSON(sourceNodeId));
                 evidence.set("targetMixerChannelId", JSON(static_cast<double>(targetId)));
                 evidence.set("stableSourceIdentityAvailable", JSON(true));
-                evidence.set("positionalIdentityAvailable", JSON(sendIndex >= 0));
-                if (sendIndex >= 0) evidence.set("sendIndex", JSON(static_cast<double>(sendIndex)));
+                evidence.set("stableSendIdAvailable", JSON(sendId != 0));
+                if (sendId != 0) evidence.set("sendId", JSON(static_cast<double>(sendId)));
 
                 JSON issue = JSON::object();
                 issue.set("issueCode", JSON(issueCode));
@@ -793,9 +793,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     send.set("routeType", JSON(route.sidechainOnly ? "sidechain_send" : "send"));
                     send.set("sourceNodeId", JSON(sourceNodeId));
                     send.set("sourceMixerChannelId", JSON(static_cast<double>(channelId)));
-                    send.set("sendIndex", JSON(static_cast<double>(sendIndex)));
-                    send.set("stableIdentityAvailable", JSON(false));
-                    send.set("positionalIdentityAvailable", JSON(true));
+                    send.set("sendId", JSON(static_cast<double>(route.sendId)));
+                    send.set("stableIdentityAvailable", JSON(route.sendId != 0));
+                    send.set("positionalIdentityAvailable", JSON(false));
                     send.set("targetMixerChannelId",
                              JSON(static_cast<double>(isMixerMasterTarget(route.targetChannelId)
                                                           ? 0u
@@ -809,12 +809,13 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     send.set("postFader", JSON(route.postFader));
                     send.set("muted", JSON(route.mute));
                     send.set("sidechainOnly", JSON(route.sidechainOnly));
+                    send.set("sendId", JSON(static_cast<double>(route.sendId)));
                     sends.push(send);
                     if (!sendResolved) {
                         addUnresolved("unresolved_send_destination",
                                       route.sidechainOnly ? "sidechain_send" : "send",
                                       sourceNodeId, route.targetChannelId,
-                                      static_cast<int>(sendIndex));
+                                      route.sendId);
                     }
                 }
             }
@@ -1074,7 +1075,8 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 uint32_t dstNodeIdx{0};
                 bool sidechain{false};
                 size_t trackIndex{0};
-                size_t sendIndex{0};
+                size_t sendIndex{0}; // positional index into the RT send-edge-delay snapshot
+                uint64_t sendId{0};  // stable send identity (Contract D2)
                 bool main{false};
             };
             std::vector<CurrentEdge> currentEdges;
@@ -1089,7 +1091,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 const auto main = topologyNodeByChannelId.find(channel->getMainOutputId());
                 if (main != topologyNodeByChannelId.end() && main->second != src->second) {
                     currentEdges.push_back({static_cast<uint32_t>(src->second), static_cast<uint32_t>(main->second),
-                                            false, trackIndex, 0, true});
+                                            false, trackIndex, 0, 0, true});
                 }
                 const auto sends = channel->getSends();
                 for (size_t sendIndex = 0; sendIndex < sends.size(); ++sendIndex) {
@@ -1102,7 +1104,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     }
                     currentEdges.push_back({static_cast<uint32_t>(src->second),
                                             static_cast<uint32_t>(destination->second), send.sidechainOnly, trackIndex,
-                                            sendIndex, false});
+                                            sendIndex, send.sendId, false});
                 }
             }
 
@@ -1159,6 +1161,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 const bool mappingMatches = currentEdgeIndex != kNoCurrentEdge;
                 bool main = false;
                 size_t sendIndex = 0;
+                uint64_t sendId = 0;
                 bool appliedAvailable = false;
                 uint32_t appliedCompensation = 0;
                 bool mismatch = !mappingMatches;
@@ -1167,6 +1170,7 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     const auto& current = currentEdges[currentEdgeIndex];
                     main = current.main;
                     sendIndex = current.sendIndex;
+                    sendId = current.sendId;
                     const auto snapshot = m_engine->getTrackEdgeDelaySnapshot(current.trackIndex);
                     if (snapshot.valid && main) {
                         appliedCompensation = snapshot.mainOutEdgeDelay.compensationSamples;
@@ -1184,9 +1188,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     evidence.set("sourceNodeId", JSON(sourceNodeId));
                     evidence.set("destinationNodeId", JSON(destinationNodeId));
                     evidence.set("stableEndpointIdentityAvailable", JSON(sourceValid && destinationValid));
-                    evidence.set("positionalIdentityAvailable", JSON(mappingMatches && !main));
-                    if (mappingMatches && !main) {
-                        evidence.set("sendIndex", JSON(static_cast<double>(sendIndex)));
+                    evidence.set("stableSendIdAvailable", JSON(mappingMatches && !main && sendId != 0));
+                    if (mappingMatches && !main && sendId != 0) {
+                        evidence.set("sendId", JSON(static_cast<double>(sendId)));
                     }
                     evidence.set("solvedCompensationSamples", JSON(static_cast<double>(solution.compensationSamples)));
                     evidence.set("appliedCompensationAvailable", JSON(appliedAvailable));
@@ -1211,9 +1215,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                 edge.set("solverCompensationSamples", JSON(static_cast<double>(solution.compensationSamples)));
                 edge.set("appliedCompensationAvailable", JSON(appliedAvailable));
                 edge.set("appliedCompensationSamples", JSON(static_cast<double>(appliedCompensation)));
-                edge.set("positionalIdentityAvailable", JSON(mappingMatches && !main));
-                if (mappingMatches && !main) {
-                    edge.set("sendIndex", JSON(static_cast<double>(sendIndex)));
+                edge.set("stableIdentityAvailable", JSON(mappingMatches && !main && sendId != 0));
+                if (mappingMatches && !main && sendId != 0) {
+                    edge.set("sendId", JSON(static_cast<double>(sendId)));
                 }
                 edge.set("mismatch", JSON(mismatch));
                 edges.push(edge);
@@ -1223,9 +1227,9 @@ std::string MuseService::handleRequest(const std::string& requestJson) {
                     evidence.set("sourceNodeId", JSON(sourceNodeId));
                     evidence.set("destinationNodeId", JSON(destinationNodeId));
                     evidence.set("stableEndpointIdentityAvailable", JSON(sourceValid && destinationValid));
-                    evidence.set("positionalIdentityAvailable", JSON(mappingMatches && !main));
-                    if (mappingMatches && !main) {
-                        evidence.set("sendIndex", JSON(static_cast<double>(sendIndex)));
+                    evidence.set("stableSendIdAvailable", JSON(mappingMatches && !main && sendId != 0));
+                    if (mappingMatches && !main && sendId != 0) {
+                        evidence.set("sendId", JSON(static_cast<double>(sendId)));
                     }
                     JSON issue = JSON::object();
                     issue.set("issueCode", JSON("sidechain_latency_compensation_unavailable"));

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2691,7 +2691,17 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
         }
     }
 
-    if (!muted) {
+    // Send processing (Routing Contract I9/V1/V2):
+    // - The mute gate applies to the main path and POST-fader sends only.
+    //   Pre-fader sends tap before the fader AND the mute gate, so a muted
+    //   source's pre-fader sends (audible and sidechain) keep delivering.
+    // - A sidechain key input follows the SOURCE's solo state: in a solo
+    //   context a non-eligible source's key is silenced.
+    // - Audible sends to a track destination are gated by the DESTINATION's
+    //   eligibility (a soloed destination receives its inputs — the process
+    //   queue already prepared ineligible upstream sources for it). Sends to
+    //   master are illegal (Contract D4) and defensively dropped.
+    {
         // Use pre-allocated member scratch buffer (no heap allocation in RT path).
         m_preparedRoutesScratch.clear();
         const size_t sendCount = std::min(track.sends.size(), static_cast<size_t>(kMaxSendsPerTrack));
@@ -2700,12 +2710,16 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
             if (send.mute) {
                 continue;
             }
-            if (!send.postFader && !hasPreFaderSend) {
+            const bool isPreFader = !send.postFader;
+            if (!isPreFader && muted) {
+                continue;
+            }
+            if (isPreFader && !hasPreFaderSend) {
                 continue;
             }
 
             PreparedSendRoute route;
-            route.source = send.postFader ? buffer.data() : state.preFaderBuffer.data();
+            route.source = isPreFader ? state.preFaderBuffer.data() : buffer.data();
             route.gainL = &state.sendGainL[sendIndex];
             route.gainR = &state.sendGainR[sendIndex];
             // PDC v2 (P4b.3): look up the per-edge compensation slot for
@@ -2715,6 +2729,10 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
                 (sendIndex < state.sendEdgeDelays.size()) ? state.sendEdgeDelays[sendIndex].get() : nullptr;
 
             if (send.sidechainOnly && send.targetChannelId != 0xFFFFFFFFu && slotMap) {
+                // Key input follows the source's solo state (Contract I9/V2).
+                if (!audibleEligible) {
+                    continue;
+                }
                 const uint32_t scDestSlot = slotMap->getSlotIndex(send.targetChannelId);
                 if (scDestSlot != ChannelSlotMap::INVALID_SLOT && scDestSlot < availableTracks &&
                     scDestSlot != trackIdx) {
@@ -2724,13 +2742,8 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
                 continue;
             }
 
-            if (!audibleEligible) {
-                continue;
-            }
-
+            // Sends to master are illegal (Contract D4); drop defensively.
             if (send.targetChannelId == 0xFFFFFFFFu) {
-                route.dest = masterBuf;
-                m_preparedRoutesScratch.push_back(route);
                 continue;
             }
 
@@ -2738,6 +2751,9 @@ void AudioEngine::mixAndMeterTrack(const TrackRenderState& track, uint32_t track
                 continue;
             }
 
+            // Audible send: gate by the DESTINATION's solo eligibility
+            // (Contract I9). An eligible destination receives its inputs even
+            // from ineligible sources; ineligible destinations stay silent.
             const uint32_t sendDestSlot = slotMap->getSlotIndex(send.targetChannelId);
             if (sendDestSlot != ChannelSlotMap::INVALID_SLOT && sendDestSlot < availableTracks &&
                 sendDestSlot != trackIdx && (!anySolo || m_rtAudibleEligible[sendDestSlot])) {
@@ -3235,14 +3251,9 @@ void AudioEngine::compileGraph() {
                                     sendGainL, sendGainR);
 
             if (send.targetChannelId == 0xFFFFFFFF) {
-                // Route to Master
-                RuntimeConnection toMaster;
-                toMaster.destinationBufferL = m_masterBufferD.data();
-                toMaster.destinationBufferR = m_masterBufferD.data() + 1;
-                toMaster.stride = 2;
-                toMaster.gainL = sendGainL;
-                toMaster.gainR = sendGainR;
-                rt.activeConnections.push_back(toMaster);
+                // Sends to master are illegal (Contract D4); drop for parity
+                // with the live send path.
+                continue;
             } else {
                 if (slotMap) {
                     uint32_t destSlot = slotMap->getSlotIndex(send.targetChannelId);

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -169,31 +169,44 @@ std::vector<AudioRoute> MixerChannel::getSends() const {
     return m_sends;
 }
 
-void MixerChannel::addSend(const AudioRoute& route) {
-    std::lock_guard<std::mutex> lock(m_sendMutex);
+namespace {
+AudioRoute sanitizeRoute(const AudioRoute& route) {
     AudioRoute sanitized = route;
     sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
     sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+    return sanitized;
+}
+} // namespace
+
+void MixerChannel::addSend(const AudioRoute& route) {
+    std::lock_guard<std::mutex> lock(m_sendMutex);
+    AudioRoute sanitized = sanitizeRoute(route);
+    if (sanitized.sendId == 0) {
+        sanitized.sendId = m_nextSendId++;
+    }
     m_sends.push_back(sanitized);
 }
 
 void MixerChannel::insertSend(int index, const AudioRoute& route) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
-    AudioRoute sanitized = route;
-    sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
-    sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+    AudioRoute sanitized = sanitizeRoute(route);
+    if (sanitized.sendId == 0) {
+        sanitized.sendId = m_nextSendId++;
+    }
     const size_t clampedIndex = std::min(static_cast<size_t>(std::max(index, 0)), m_sends.size());
     m_sends.insert(m_sends.begin() + static_cast<ptrdiff_t>(clampedIndex), sanitized);
 }
 
-void MixerChannel::setSend(int index, const AudioRoute& route) {
+void MixerChannel::setSend(uint64_t sendId, const AudioRoute& route) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        AudioRoute sanitized = route;
-        sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
-        sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
-        m_sends[static_cast<size_t>(index)] = sanitized;
+    const int index = findSendIndexLocked(sendId);
+    if (index < 0) {
+        return;
     }
+    AudioRoute sanitized = sanitizeRoute(route);
+    // Identity is owned by the channel: the replacement keeps the sendId.
+    sanitized.sendId = m_sends[static_cast<size_t>(index)].sendId;
+    m_sends[static_cast<size_t>(index)] = sanitized;
 }
 
 void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
@@ -201,53 +214,34 @@ void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
     m_sends.clear();
     m_sends.reserve(routes.size());
     for (const auto& route : routes) {
-        AudioRoute sanitized = route;
-        sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
-        sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+        AudioRoute sanitized = sanitizeRoute(route);
+        if (sanitized.sendId == 0) {
+            sanitized.sendId = m_nextSendId++;
+        }
         m_sends.push_back(sanitized);
     }
 }
 
-void MixerChannel::removeSend(int index) {
+void MixerChannel::removeSend(uint64_t sendId) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
+    const int index = findSendIndexLocked(sendId);
+    if (index >= 0) {
         m_sends.erase(m_sends.begin() + index);
     }
 }
 
-void MixerChannel::setSendLevel(int index, float level) {
+int MixerChannel::findSendIndex(uint64_t sendId) const {
     std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].gain = std::isfinite(level) ? std::clamp(level, 0.0f, 4.0f) : 0.0f;
-    }
+    return findSendIndexLocked(sendId);
 }
 
-void MixerChannel::setSendPan(int index, float pan) {
-    std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].pan = std::isfinite(pan) ? std::clamp(pan, -1.0f, 1.0f) : 0.0f;
+int MixerChannel::findSendIndexLocked(uint64_t sendId) const {
+    for (size_t i = 0; i < m_sends.size(); ++i) {
+        if (m_sends[i].sendId == sendId) {
+            return static_cast<int>(i);
+        }
     }
-}
-
-void MixerChannel::setSendDestination(int index, uint32_t destId) {
-    std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].targetChannelId = destId;
-    }
-}
-
-void MixerChannel::setSendPostFader(int index, bool postFader) {
-    std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].postFader = postFader;
-    }
-}
-
-void MixerChannel::setSendSidechainOnly(int index, bool sidechainOnly) {
-    std::lock_guard<std::mutex> lock(m_sendMutex);
-    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
-        m_sends[index].sidechainOnly = sidechainOnly;
-    }
+    return -1;
 }
 
 } // namespace Audio

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -177,6 +177,25 @@ void MixerChannel::addSend(const AudioRoute& route) {
     m_sends.push_back(sanitized);
 }
 
+void MixerChannel::insertSend(int index, const AudioRoute& route) {
+    std::lock_guard<std::mutex> lock(m_sendMutex);
+    AudioRoute sanitized = route;
+    sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
+    sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+    const size_t clampedIndex = std::min(static_cast<size_t>(std::max(index, 0)), m_sends.size());
+    m_sends.insert(m_sends.begin() + static_cast<ptrdiff_t>(clampedIndex), sanitized);
+}
+
+void MixerChannel::setSend(int index, const AudioRoute& route) {
+    std::lock_guard<std::mutex> lock(m_sendMutex);
+    if (index >= 0 && index < static_cast<int>(m_sends.size())) {
+        AudioRoute sanitized = route;
+        sanitized.gain = std::isfinite(route.gain) ? std::clamp(route.gain, 0.0f, 4.0f) : 0.0f;
+        sanitized.pan = std::isfinite(route.pan) ? std::clamp(route.pan, -1.0f, 1.0f) : 0.0f;
+        m_sends[static_cast<size_t>(index)] = sanitized;
+    }
+}
+
 void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
     std::lock_guard<std::mutex> lock(m_sendMutex);
     m_sends.clear();

--- a/AestraUI/Widgets/UIRoutingMap.cpp
+++ b/AestraUI/Widgets/UIRoutingMap.cpp
@@ -175,7 +175,7 @@ void UIRoutingMap::rebuildGraph() {
             edge.targetNodeId = sendTargetId;
             edge.type = send.sidechainOnly ? Edge::SidechainPath : Edge::SendPath;
             edge.sendLevelDb = gainToDb(send.gain);
-            edge.sendIndex = static_cast<int>(s);
+            edge.sendId = send.sendId;
             m_edges.push_back(edge);
         }
     }
@@ -1956,29 +1956,29 @@ bool UIRoutingMap::onMouseEvent(const NUIMouseEvent& event) {
             }
             if (m_hoveredEdgeIdx >= 0) {
                 const Edge& edge = m_edges[m_hoveredEdgeIdx];
-                if (edge.type != Edge::MainPath && edge.sendIndex >= 0) {
+                if (edge.type != Edge::MainPath && edge.sendId != 0) {
                     if (!m_edgeContextMenu) {
                         m_edgeContextMenu = std::make_shared<AestraUI::NUIContextMenu>();
                         m_edgeContextMenu->setCloseOnSelection(true);
                     }
                     m_edgeContextMenu->clear();
                     uint32_t srcId = edge.sourceNodeId;
-                    int sIdx = edge.sendIndex;
+                    uint64_t sId = edge.sendId;
                     // Level submenu
                     auto levelMenu = std::make_shared<AestraUI::NUIContextMenu>();
                     static const float kLevelVals[] = {-144.0f, -24.0f, -12.0f, -6.0f, 0.0f, 6.0f};
                     static const char* kLevelLabels[] = {"-inf dB", "-24 dB", "-12 dB", "-6 dB", "0 dB", "+6 dB"};
                     for (size_t li = 0; li < 6; ++li) {
-                        levelMenu->addItem(kLevelLabels[li], [this, srcId, sIdx, li]() {
-                            if (m_onEditSendLevel) m_onEditSendLevel(srcId, sIdx, kLevelVals[li]);
+                        levelMenu->addItem(kLevelLabels[li], [this, srcId, sId, li]() {
+                            if (m_onEditSendLevel) m_onEditSendLevel(srcId, sId, kLevelVals[li]);
                             m_graphDirty = true;
                             repaint();
                         });
                     }
                     m_edgeContextMenu->addSubmenu("Set Level", levelMenu);
                     m_edgeContextMenu->addSeparator();
-                    m_edgeContextMenu->addItem("Delete Send", [this, srcId, sIdx]() {
-                        if (m_onRemoveSend) m_onRemoveSend(srcId, sIdx);
+                    m_edgeContextMenu->addItem("Delete Send", [this, srcId, sId]() {
+                        if (m_onRemoveSend) m_onRemoveSend(srcId, sId);
                         m_graphDirty = true;
                         m_selectedEdgeIdx = -1;
                         repaint();
@@ -2262,11 +2262,10 @@ bool UIRoutingMap::onKeyEvent(const NUIKeyEvent& event) {
     if (event.keyCode == NUIKeyCode::Delete || event.keyCode == NUIKeyCode::Backspace) {
         if (m_selectedEdgeIdx >= 0 && m_selectedEdgeIdx < static_cast<int>(m_edges.size())) {
             const Edge& edge = m_edges[m_selectedEdgeIdx];
-            if (edge.type != Edge::MainPath && edge.sendIndex >= 0) {
+            if (edge.type != Edge::MainPath && edge.sendId != 0) {
                 uint32_t sourceId = edge.sourceNodeId;
-                int sendIdx = edge.sendIndex;
                 if (m_onRemoveSend) {
-                    m_onRemoveSend(sourceId, sendIdx);
+                    m_onRemoveSend(sourceId, edge.sendId);
                     m_graphDirty = true;
                 }
             }

--- a/AestraUI/Widgets/UIRoutingMap.h
+++ b/AestraUI/Widgets/UIRoutingMap.h
@@ -285,7 +285,7 @@ private:
     std::function<void(uint32_t)> m_onNodeMuteToggle;
     std::function<void(uint32_t)> m_onNodeSoloToggle;
     std::function<void(uint32_t, uint64_t)> m_onRemoveSend;
-    std::function<void(uint32_t, int, float)> m_onEditSendLevel;
+    std::function<void(uint32_t, uint64_t, float)> m_onEditSendLevel;
 };
 
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIRoutingMap.h
+++ b/AestraUI/Widgets/UIRoutingMap.h
@@ -64,10 +64,10 @@ public:
     void setOnNodeSoloToggle(std::function<void(uint32_t)> cb) { m_onNodeSoloToggle = std::move(cb); }
 
     /// Callback fired when a selected send edge is deleted (e.g. via Delete key).
-    void setOnRemoveSend(std::function<void(uint32_t channelId, int sendIndex)> cb) { m_onRemoveSend = std::move(cb); }
+    void setOnRemoveSend(std::function<void(uint32_t channelId, uint64_t sendId)> cb) { m_onRemoveSend = std::move(cb); }
 
     /// Callback fired when user edits a send level directly (e.g. right-click edge).
-    void setOnEditSendLevel(std::function<void(uint32_t channelId, int sendIndex, float newDb)> cb) { m_onEditSendLevel = std::move(cb); }
+    void setOnEditSendLevel(std::function<void(uint32_t channelId, uint64_t sendId, float newDb)> cb) { m_onEditSendLevel = std::move(cb); }
 
     /// Refresh live state (mute/solo/levels) from the bound view model. Cheap; call per frame.
     void refreshLiveState();
@@ -110,7 +110,7 @@ private:
         uint32_t targetNodeId{0};
         enum Type { MainPath, SendPath, SidechainPath } type{MainPath};
         float sendLevelDb{0.0f};
-        int sendIndex{-1}; // index into ChannelViewModel::sends (for send/sidechain edges)
+        uint64_t sendId{0}; // stable send identity (Contract D2); 0 = main path
         bool hovered{false};
         // Y attachment within the target node (node-local, world units).
         // Negative → use the node's default input pin. Assigned by
@@ -284,7 +284,7 @@ private:
     std::function<void(uint32_t, uint32_t, bool)> m_onAddSend;
     std::function<void(uint32_t)> m_onNodeMuteToggle;
     std::function<void(uint32_t)> m_onNodeSoloToggle;
-    std::function<void(uint32_t, int)> m_onRemoveSend;
+    std::function<void(uint32_t, uint64_t)> m_onRemoveSend;
     std::function<void(uint32_t, int, float)> m_onEditSendLevel;
 };
 

--- a/Source/App/MuseProjectLoadReport.cpp
+++ b/Source/App/MuseProjectLoadReport.cpp
@@ -10,6 +10,7 @@ const char* issueCode(const LoadIssue& issue) {
     if (issue.category == "integrity") return "integrity_mismatch";
     if (issue.category == "clip") return "missing_pattern_reference";
     if (issue.category == "unit") return "missing_unit_reference";
+    if (issue.category == "routing") return "routing_repaired";
     return "project_load_issue";
 }
 

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -2,6 +2,7 @@
 
 #include "MixerViewModel.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "Commands/RoutingCommands.h"
 #include "AudioDeviceManager.h"
 #include "../App/ServiceLocator.h"
 #include "../Core/AestraAudioController.h"
@@ -575,7 +576,7 @@ std::vector<MixerViewModel::Destination> MixerViewModel::getAvailableDestination
         if (!ch) continue;
         if (ch->id == excludeId) continue;
         if (ch->id == 0) continue; // Handled above
-        if (routeWouldCreateCycle(excludeId, ch->id)) continue;
+        if (!canRouteTo(excludeId, ch->id)) continue;
 
         dests.push_back({ch->id, ch->name});
     }
@@ -586,9 +587,6 @@ std::vector<MixerViewModel::Destination> MixerViewModel::getAvailableDestination
 void MixerViewModel::addSend(uint32_t channelId) {
     auto* ch = getChannelById(channelId);
     if (!ch) return;
-    
-    // Create new SendViewModel
-    ChannelViewModel::SendViewModel send{};
     
     // Auto-select a meaningful destination (Avoid Master if it's already the main Output)
     uint32_t defaultTarget = 0; // Fallback to Master
@@ -605,38 +603,67 @@ void MixerViewModel::addSend(uint32_t channelId) {
         }
     }
 
-    send.targetId = defaultTarget; 
+    Audio::AudioRoute route{};
+    // Map 0 -> 0xFFFFFFFF for engine
+    route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFFu : defaultTarget;
+    route.gain = 0.25f; // -12 dB leaves headroom when adding a parallel path
+    route.sidechainOnly = false;
+
+    // Update Local Model
+    ChannelViewModel::SendViewModel send{};
+    send.targetId = defaultTarget;
     send.targetName = defaultName;
-    send.gain = 0.25f; // -12 dB leaves headroom when adding a parallel path
+    send.gain = 0.25f;
     send.sidechainOnly = false;
     ch->sends.push_back(send);
 
-    // Update Engine
+    // Update Engine through the command seam (undoable, validated)
     if (auto mc = ch->channel) {
-        Audio::AudioRoute route{};
-        // Map 0 -> 0xFFFFFFFF for engine
-        route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFF : defaultTarget; 
-        route.gain = 0.25f;
-        route.sidechainOnly = false;
-        mc->addSend(route);
-        
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(std::make_shared<Audio::AddSendCommand>(*m_trackManager, channelId, route));
+        } else {
+            mc->addSend(route);
+        }
+
         graphDirty.emit();
         projectModified.emit();
     }
 }
 
 void MixerViewModel::addSidechain(uint32_t channelId) {
-    addSend(channelId);
     auto* ch = getChannelById(channelId);
-    if (!ch || ch->sends.empty())
-        return;
+    if (!ch) return;
 
-    const int sendIndex = static_cast<int>(ch->sends.size() - 1);
-    ch->sends.back().gain = 1.0f;
-    ch->sends.back().sidechainOnly = true;
-    if (auto* mc = ch->channel) {
-        mc->setSendLevel(sendIndex, 1.0f);
-        mc->setSendSidechainOnly(sendIndex, true);
+    uint32_t defaultTarget = 0;
+    std::string defaultName = "Master";
+    auto available = getAvailableDestinations(channelId);
+    for (const auto& dest : available) {
+        if (dest.id != 0) {
+            defaultTarget = dest.id;
+            defaultName = dest.name;
+            break;
+        }
+    }
+
+    Audio::AudioRoute route{};
+    route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFFu : defaultTarget;
+    route.gain = 1.0f;
+    route.sidechainOnly = true;
+
+    ChannelViewModel::SendViewModel send{};
+    send.targetId = defaultTarget;
+    send.targetName = defaultName;
+    send.gain = 1.0f;
+    send.sidechainOnly = true;
+    ch->sends.push_back(send);
+
+    if (auto mc = ch->channel) {
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(std::make_shared<Audio::AddSendCommand>(*m_trackManager, channelId, route));
+        } else {
+            mc->addSend(route);
+        }
+
         graphDirty.emit();
         projectModified.emit();
     }
@@ -645,7 +672,7 @@ void MixerViewModel::addSidechain(uint32_t channelId) {
 void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId) {
     auto* ch = getChannelById(channelId);
     if (!ch) return;
-    if (routeWouldCreateCycle(channelId, targetId)) {
+    if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;
     }
@@ -668,7 +695,11 @@ void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId) {
         route.targetChannelId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
         route.gain = 1.0f;
         route.sidechainOnly = false;
-        mc->addSend(route);
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(std::make_shared<Audio::AddSendCommand>(*m_trackManager, channelId, route));
+        } else {
+            mc->addSend(route);
+        }
         graphDirty.emit();
         projectModified.emit();
     }
@@ -702,10 +733,15 @@ void MixerViewModel::removeSend(uint32_t channelId, int sendIndex) {
     // Update Local Model
     ch->sends.erase(ch->sends.begin() + sendIndex);
 
-    // Update Engine
+    // Update Engine through the command seam (undoable)
     if (auto mc = ch->channel) {
-        mc->removeSend(sendIndex);
-        
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::RemoveSendCommand>(*m_trackManager, channelId, sendIndex));
+        } else {
+            mc->removeSend(sendIndex);
+        }
+
         graphDirty.emit();
         projectModified.emit();
     }
@@ -718,9 +754,16 @@ void MixerViewModel::setSendLevel(uint32_t channelId, int sendIndex, float linea
     linearGain = std::isfinite(linearGain) ? std::clamp(linearGain, 0.0f, 4.0f) : 0.0f;
     ch->sends[sendIndex].gain = linearGain;
 
-    // Update Engine
+    // Update Engine through the command seam (undoable)
     if (auto mc = ch->channel) {
-        mc->setSendLevel(sendIndex, linearGain);
+        if (m_commandHistory && m_trackManager) {
+            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            route.gain = linearGain;
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+        } else {
+            mc->setSendLevel(sendIndex, linearGain);
+        }
         graphDirty.emit();
         projectModified.emit();
     }
@@ -729,7 +772,7 @@ void MixerViewModel::setSendLevel(uint32_t channelId, int sendIndex, float linea
 void MixerViewModel::setSendDestination(uint32_t channelId, int sendIndex, uint32_t targetId) {
     auto* ch = getChannelById(channelId);
     if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
-    if (routeWouldCreateCycle(channelId, targetId)) {
+    if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;
     }
@@ -745,12 +788,19 @@ void MixerViewModel::setSendDestination(uint32_t channelId, int sendIndex, uint3
         ch->sends[sendIndex].targetName = target ? target->name : "Unknown";
     }
 
-    // Update Engine
+    // Update Engine through the command seam (undoable, validated)
     if (auto mc = ch->channel) {
         // Normalize 0 to 0xFFFFFFFF for engine master
-        uint32_t engineId = (targetId == 0) ? 0xFFFFFFFF : targetId;
-        mc->setSendDestination(sendIndex, engineId);
-        
+        const uint32_t engineId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
+        if (m_commandHistory && m_trackManager) {
+            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            route.targetChannelId = engineId;
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+        } else {
+            mc->setSendDestination(sendIndex, engineId);
+        }
+
         graphDirty.emit();
         projectModified.emit();
     }
@@ -763,7 +813,14 @@ void MixerViewModel::setSendPostFader(uint32_t channelId, int sendIndex, bool po
     ch->sends[sendIndex].postFader = postFader;
 
     if (auto mc = ch->channel) {
-        mc->setSendPostFader(sendIndex, postFader);
+        if (m_commandHistory && m_trackManager) {
+            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            route.postFader = postFader;
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+        } else {
+            mc->setSendPostFader(sendIndex, postFader);
+        }
         graphDirty.emit();
         projectModified.emit();
     }
@@ -776,7 +833,14 @@ void MixerViewModel::setSendSidechainOnly(uint32_t channelId, int sendIndex, boo
     ch->sends[sendIndex].sidechainOnly = sidechainOnly;
 
     if (auto mc = ch->channel) {
-        mc->setSendSidechainOnly(sendIndex, sidechainOnly);
+        if (m_commandHistory && m_trackManager) {
+            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            route.sidechainOnly = sidechainOnly;
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+        } else {
+            mc->setSendSidechainOnly(sendIndex, sidechainOnly);
+        }
         graphDirty.emit();
         projectModified.emit();
     }
@@ -785,7 +849,7 @@ void MixerViewModel::setSendSidechainOnly(uint32_t channelId, int sendIndex, boo
 void MixerViewModel::setMainOutputDestination(uint32_t channelId, uint32_t targetId) {
     auto* ch = getChannelById(channelId);
     if (!ch || ch->id == 0) return;
-    if (routeWouldCreateCycle(channelId, targetId)) {
+    if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;
     }
@@ -804,7 +868,13 @@ void MixerViewModel::setMainOutputDestination(uint32_t channelId, uint32_t targe
     }
 
     if (auto mc = ch->channel) {
-        mc->setMainOutputId(targetId == 0 ? 0xFFFFFFFFu : targetId);
+        const uint32_t engineId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(
+                std::make_shared<Audio::SetMainOutputCommand>(*m_trackManager, channelId, engineId));
+        } else {
+            mc->setMainOutputId(engineId);
+        }
         graphDirty.emit();
         projectModified.emit();
     }
@@ -841,6 +911,15 @@ std::string MixerViewModel::getRoutingWarning(uint32_t channelId) const {
     if (duplicateDestinations <= 0) return {};
     if (duplicateDestinations == 1) return "Duplicate audible route";
     return std::to_string(duplicateDestinations) + " duplicate audible routes";
+}
+
+bool MixerViewModel::canRouteTo(uint32_t sourceId, uint32_t targetId) const {
+    // Routing Contract D1: TrackManager is the single validation authority.
+    if (m_trackManager) {
+        return m_trackManager->canRouteTo(sourceId, targetId);
+    }
+    // Degraded path (no TrackManager wired): VM-local topology check.
+    return !routeWouldCreateCycle(sourceId, targetId);
 }
 
 bool MixerViewModel::routeWouldCreateCycle(uint32_t sourceId, uint32_t targetId) const {

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -274,6 +274,7 @@ void MixerViewModel::syncFromEngine(const Audio::TrackManager& trackManager,
                            uiSend.targetName = "Unknown (" + std::to_string(route.targetChannelId) + ")";
                        }
                    }
+                   uiSend.sendId = route.sendId;
                    uiSend.gain = route.gain;
                    uiSend.pan = route.pan;
                    uiSend.postFader = route.postFader;
@@ -624,6 +625,7 @@ void MixerViewModel::addSend(uint32_t channelId) {
         } else {
             mc->addSend(route);
         }
+        refreshLocalSendId(ch, mc);
 
         graphDirty.emit();
         projectModified.emit();
@@ -663,13 +665,14 @@ void MixerViewModel::addSidechain(uint32_t channelId) {
         } else {
             mc->addSend(route);
         }
+        refreshLocalSendId(ch, mc);
 
         graphDirty.emit();
         projectModified.emit();
     }
 }
 
-void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId) {
+void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId, bool sidechainOnly) {
     auto* ch = getChannelById(channelId);
     if (!ch) return;
     if (!canRouteTo(channelId, targetId)) {
@@ -687,19 +690,20 @@ void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId) {
         send.targetName = "Unknown";
     }
     send.gain = 1.0f;
-    send.sidechainOnly = false;
+    send.sidechainOnly = sidechainOnly;
     ch->sends.push_back(send);
 
     if (auto mc = ch->channel) {
         Audio::AudioRoute route{};
         route.targetChannelId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
         route.gain = 1.0f;
-        route.sidechainOnly = false;
+        route.sidechainOnly = sidechainOnly;
         if (m_commandHistory && m_trackManager) {
             m_commandHistory->pushAndExecute(std::make_shared<Audio::AddSendCommand>(*m_trackManager, channelId, route));
         } else {
             mc->addSend(route);
         }
+        refreshLocalSendId(ch, mc);
         graphDirty.emit();
         projectModified.emit();
     }
@@ -726,20 +730,22 @@ void MixerViewModel::toggleSolo(uint32_t channelId) {
     projectModified.emit();
 }
 
-void MixerViewModel::removeSend(uint32_t channelId, int sendIndex) {
+void MixerViewModel::removeSend(uint32_t channelId, uint64_t sendId) {
     auto* ch = getChannelById(channelId);
-    if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
+    if (!ch) return;
+    const int localIndex = findLocalSendIndex(*ch, sendId);
+    if (localIndex < 0) return;
 
     // Update Local Model
-    ch->sends.erase(ch->sends.begin() + sendIndex);
+    ch->sends.erase(ch->sends.begin() + localIndex);
 
-    // Update Engine through the command seam (undoable)
+    // Update Engine through the command seam (undoable, identity-stable)
     if (auto mc = ch->channel) {
         if (m_commandHistory && m_trackManager) {
             m_commandHistory->pushAndExecute(
-                std::make_shared<Audio::RemoveSendCommand>(*m_trackManager, channelId, sendIndex));
+                std::make_shared<Audio::RemoveSendCommand>(*m_trackManager, channelId, sendId));
         } else {
-            mc->removeSend(sendIndex);
+            mc->removeSend(sendId);
         }
 
         graphDirty.emit();
@@ -747,45 +753,51 @@ void MixerViewModel::removeSend(uint32_t channelId, int sendIndex) {
     }
 }
 
-void MixerViewModel::setSendLevel(uint32_t channelId, int sendIndex, float linearGain) {
+void MixerViewModel::setSendLevel(uint32_t channelId, uint64_t sendId, float linearGain) {
     auto* ch = getChannelById(channelId);
-    if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
+    if (!ch) return;
+    const int localIndex = findLocalSendIndex(*ch, sendId);
+    if (localIndex < 0) return;
 
     linearGain = std::isfinite(linearGain) ? std::clamp(linearGain, 0.0f, 4.0f) : 0.0f;
-    ch->sends[sendIndex].gain = linearGain;
+    ch->sends[static_cast<size_t>(localIndex)].gain = linearGain;
 
     // Update Engine through the command seam (undoable)
     if (auto mc = ch->channel) {
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
             route.gain = linearGain;
             m_commandHistory->pushAndExecute(
-                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            mc->setSendLevel(sendIndex, linearGain);
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
+            route.gain = linearGain;
+            mc->setSend(sendId, route);
         }
         graphDirty.emit();
         projectModified.emit();
     }
 }
 
-void MixerViewModel::setSendDestination(uint32_t channelId, int sendIndex, uint32_t targetId) {
+void MixerViewModel::setSendDestination(uint32_t channelId, uint64_t sendId, uint32_t targetId) {
     auto* ch = getChannelById(channelId);
-    if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
+    if (!ch) return;
+    const int localIndex = findLocalSendIndex(*ch, sendId);
+    if (localIndex < 0) return;
     if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;
     }
 
-    ch->sends[sendIndex].targetId = targetId;
+    ch->sends[static_cast<size_t>(localIndex)].targetId = targetId;
     m_blockedRoutingWarnings.erase(channelId);
     
     // Resolve name
     if (targetId == 0) {
-        ch->sends[sendIndex].targetName = "Master";
+        ch->sends[static_cast<size_t>(localIndex)].targetName = "Master";
     } else {
         auto* target = getChannelById(targetId);
-        ch->sends[sendIndex].targetName = target ? target->name : "Unknown";
+        ch->sends[static_cast<size_t>(localIndex)].targetName = target ? target->name : "Unknown";
     }
 
     // Update Engine through the command seam (undoable, validated)
@@ -793,12 +805,14 @@ void MixerViewModel::setSendDestination(uint32_t channelId, int sendIndex, uint3
         // Normalize 0 to 0xFFFFFFFF for engine master
         const uint32_t engineId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
             route.targetChannelId = engineId;
             m_commandHistory->pushAndExecute(
-                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            mc->setSendDestination(sendIndex, engineId);
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
+            route.targetChannelId = engineId;
+            mc->setSend(sendId, route);
         }
 
         graphDirty.emit();
@@ -806,40 +820,48 @@ void MixerViewModel::setSendDestination(uint32_t channelId, int sendIndex, uint3
     }
 }
 
-void MixerViewModel::setSendPostFader(uint32_t channelId, int sendIndex, bool postFader) {
+void MixerViewModel::setSendPostFader(uint32_t channelId, uint64_t sendId, bool postFader) {
     auto* ch = getChannelById(channelId);
-    if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
+    if (!ch) return;
+    const int localIndex = findLocalSendIndex(*ch, sendId);
+    if (localIndex < 0) return;
 
-    ch->sends[sendIndex].postFader = postFader;
+    ch->sends[static_cast<size_t>(localIndex)].postFader = postFader;
 
     if (auto mc = ch->channel) {
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
             route.postFader = postFader;
             m_commandHistory->pushAndExecute(
-                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            mc->setSendPostFader(sendIndex, postFader);
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
+            route.postFader = postFader;
+            mc->setSend(sendId, route);
         }
         graphDirty.emit();
         projectModified.emit();
     }
 }
 
-void MixerViewModel::setSendSidechainOnly(uint32_t channelId, int sendIndex, bool sidechainOnly) {
+void MixerViewModel::setSendSidechainOnly(uint32_t channelId, uint64_t sendId, bool sidechainOnly) {
     auto* ch = getChannelById(channelId);
-    if (!ch || sendIndex < 0 || sendIndex >= static_cast<int>(ch->sends.size())) return;
+    if (!ch) return;
+    const int localIndex = findLocalSendIndex(*ch, sendId);
+    if (localIndex < 0) return;
 
-    ch->sends[sendIndex].sidechainOnly = sidechainOnly;
+    ch->sends[static_cast<size_t>(localIndex)].sidechainOnly = sidechainOnly;
 
     if (auto mc = ch->channel) {
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(sendIndex)];
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
             route.sidechainOnly = sidechainOnly;
             m_commandHistory->pushAndExecute(
-                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendIndex, route));
+                std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            mc->setSendSidechainOnly(sendIndex, sidechainOnly);
+            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
+            route.sidechainOnly = sidechainOnly;
+            mc->setSend(sendId, route);
         }
         graphDirty.emit();
         projectModified.emit();
@@ -877,6 +899,26 @@ void MixerViewModel::setMainOutputDestination(uint32_t channelId, uint32_t targe
         }
         graphDirty.emit();
         projectModified.emit();
+    }
+}
+
+
+int MixerViewModel::findLocalSendIndex(const ChannelViewModel& ch, uint64_t sendId) const {
+    for (size_t i = 0; i < ch.sends.size(); ++i) {
+        if (ch.sends[i].sendId == sendId) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void MixerViewModel::refreshLocalSendId(ChannelViewModel* ch, const Audio::MixerChannel* mc) {
+    if (!ch || !mc) {
+        return;
+    }
+    const auto engineSends = mc->getSends();
+    if (!engineSends.empty() && !ch->sends.empty()) {
+        ch->sends.back().sendId = engineSends.back().sendId;
     }
 }
 

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -603,10 +603,15 @@ void MixerViewModel::addSend(uint32_t channelId) {
             break;
         }
     }
+    // Contract D4: sends to master are illegal. No non-master destination
+    // means no send — do not fall back to a master edge.
+    if (defaultTarget == 0) {
+        m_blockedRoutingWarnings[channelId] = "No send destinations available";
+        return;
+    }
 
     Audio::AudioRoute route{};
-    // Map 0 -> 0xFFFFFFFF for engine
-    route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFFu : defaultTarget;
+    route.targetChannelId = defaultTarget;
     route.gain = 0.25f; // -12 dB leaves headroom when adding a parallel path
     route.sidechainOnly = false;
 
@@ -646,9 +651,14 @@ void MixerViewModel::addSidechain(uint32_t channelId) {
             break;
         }
     }
+    // Contract D4: sends (incl. sidechain) to master are illegal.
+    if (defaultTarget == 0) {
+        m_blockedRoutingWarnings[channelId] = "No send destinations available";
+        return;
+    }
 
     Audio::AudioRoute route{};
-    route.targetChannelId = (defaultTarget == 0) ? 0xFFFFFFFFu : defaultTarget;
+    route.targetChannelId = defaultTarget;
     route.gain = 1.0f;
     route.sidechainOnly = true;
 
@@ -675,6 +685,10 @@ void MixerViewModel::addSidechain(uint32_t channelId) {
 void MixerViewModel::addSend(uint32_t channelId, uint32_t targetId, bool sidechainOnly) {
     auto* ch = getChannelById(channelId);
     if (!ch) return;
+    if (targetId == 0) {
+        m_blockedRoutingWarnings[channelId] = "Sends to master are not allowed";
+        return;
+    }
     if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;
@@ -784,6 +798,10 @@ void MixerViewModel::setSendDestination(uint32_t channelId, uint64_t sendId, uin
     if (!ch) return;
     const int localIndex = findLocalSendIndex(*ch, sendId);
     if (localIndex < 0) return;
+    if (targetId == 0) {
+        m_blockedRoutingWarnings[channelId] = "Sends to master are not allowed";
+        return;
+    }
     if (!canRouteTo(channelId, targetId)) {
         m_blockedRoutingWarnings[channelId] = "Routing loop blocked";
         return;

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -778,14 +778,15 @@ void MixerViewModel::setSendLevel(uint32_t channelId, uint64_t sendId, float lin
 
     // Update Engine through the command seam (undoable)
     if (auto mc = ch->channel) {
+        Audio::AudioRoute route;
+        if (!tryGetEngineRoute(mc, sendId, route)) {
+            return;
+        }
+        route.gain = linearGain;
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.gain = linearGain;
             m_commandHistory->pushAndExecute(
                 std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.gain = linearGain;
             mc->setSend(sendId, route);
         }
         graphDirty.emit();
@@ -822,14 +823,15 @@ void MixerViewModel::setSendDestination(uint32_t channelId, uint64_t sendId, uin
     if (auto mc = ch->channel) {
         // Normalize 0 to 0xFFFFFFFF for engine master
         const uint32_t engineId = (targetId == 0) ? 0xFFFFFFFFu : targetId;
+        Audio::AudioRoute route;
+        if (!tryGetEngineRoute(mc, sendId, route)) {
+            return;
+        }
+        route.targetChannelId = engineId;
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.targetChannelId = engineId;
             m_commandHistory->pushAndExecute(
                 std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.targetChannelId = engineId;
             mc->setSend(sendId, route);
         }
 
@@ -847,14 +849,15 @@ void MixerViewModel::setSendPostFader(uint32_t channelId, uint64_t sendId, bool 
     ch->sends[static_cast<size_t>(localIndex)].postFader = postFader;
 
     if (auto mc = ch->channel) {
+        Audio::AudioRoute route;
+        if (!tryGetEngineRoute(mc, sendId, route)) {
+            return;
+        }
+        route.postFader = postFader;
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.postFader = postFader;
             m_commandHistory->pushAndExecute(
                 std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.postFader = postFader;
             mc->setSend(sendId, route);
         }
         graphDirty.emit();
@@ -871,14 +874,15 @@ void MixerViewModel::setSendSidechainOnly(uint32_t channelId, uint64_t sendId, b
     ch->sends[static_cast<size_t>(localIndex)].sidechainOnly = sidechainOnly;
 
     if (auto mc = ch->channel) {
+        Audio::AudioRoute route;
+        if (!tryGetEngineRoute(mc, sendId, route)) {
+            return;
+        }
+        route.sidechainOnly = sidechainOnly;
         if (m_commandHistory && m_trackManager) {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.sidechainOnly = sidechainOnly;
             m_commandHistory->pushAndExecute(
                 std::make_shared<Audio::EditSendCommand>(*m_trackManager, channelId, sendId, route));
         } else {
-            auto route = mc->getSends()[static_cast<size_t>(mc->findSendIndex(sendId))];
-            route.sidechainOnly = sidechainOnly;
             mc->setSend(sendId, route);
         }
         graphDirty.emit();
@@ -921,6 +925,22 @@ void MixerViewModel::setMainOutputDestination(uint32_t channelId, uint32_t targe
 }
 
 
+// Returns the engine-side route for a sendId, or false when the engine no
+// longer holds it (undo/redo or a rejected command can leave the local
+// mirror ahead of the engine). Callers must never index getSends() with an
+// unchecked findSendIndex result.
+bool MixerViewModel::tryGetEngineRoute(const Audio::MixerChannel* mc, uint64_t sendId, Audio::AudioRoute& out) const {
+    if (!mc || sendId == 0) {
+        return false;
+    }
+    const int engineIndex = mc->findSendIndex(sendId);
+    if (engineIndex < 0) {
+        return false;
+    }
+    out = mc->getSends()[static_cast<size_t>(engineIndex)];
+    return true;
+}
+
 int MixerViewModel::findLocalSendIndex(const ChannelViewModel& ch, uint64_t sendId) const {
     for (size_t i = 0; i < ch.sends.size(); ++i) {
         if (ch.sends[i].sendId == sendId) {
@@ -935,8 +955,22 @@ void MixerViewModel::refreshLocalSendId(ChannelViewModel* ch, const Audio::Mixer
         return;
     }
     const auto engineSends = mc->getSends();
-    if (!engineSends.empty() && !ch->sends.empty()) {
-        ch->sends.back().sendId = engineSends.back().sendId;
+    if (engineSends.empty()) {
+        return;
+    }
+    // Match by identity, not position: the local entry that still has no id
+    // is the one the command just created. A rejected command leaves the
+    // engine list unchanged, so the mirror below also pops the phantom.
+    for (auto& local : ch->sends) {
+        if (local.sendId == 0) {
+            local.sendId = engineSends.back().sendId;
+            break;
+        }
+    }
+    if (ch->sends.size() > engineSends.size()) {
+        // The command was rejected (cycle/master) after the local push: drop
+        // the phantom so the mirror never outlives the engine.
+        ch->sends.resize(engineSends.size());
     }
 }
 

--- a/Source/Components/MixerViewModel.h
+++ b/Source/Components/MixerViewModel.h
@@ -274,6 +274,9 @@ public:
     /** @brief Set CommandHistory for undo/redo on plugin operations. */
     void setCommandHistory(Audio::CommandHistory* ch) { m_commandHistory = ch; }
 
+    /** @brief Set the TrackManager used for routing validation and commands. */
+    void setTrackManager(Audio::TrackManager* trackManager) { m_trackManager = trackManager; }
+
     // graphDirty and projectModified are scoped subscription signals for mixer state changes.
 
     struct Destination {
@@ -332,6 +335,9 @@ private:
     /// CommandHistory pointer for undo/redo on plugin operations (optional)
     Audio::CommandHistory* m_commandHistory = nullptr;
 
+    /// TrackManager for routing validation + command construction (optional)
+    Audio::TrackManager* m_trackManager = nullptr;
+
     /**
      * @brief Rebuild id→index map after channel list changes.
      */
@@ -350,6 +356,12 @@ private:
     void smoothMeterChannel(ChannelViewModel& channel,
                             const Audio::MeterSnapshotBuffer::MeterReadout& snapshot,
                             double deltaTime);
+    /**
+     * @brief Whether routing source -> target is legal. Delegates to the
+     * TrackManager authority when wired (Routing Contract D1); falls back to
+     * the VM-local topology walk otherwise.
+     */
+    bool canRouteTo(uint32_t sourceId, uint32_t targetId) const;
     bool routeWouldCreateCycle(uint32_t sourceId, uint32_t targetId) const;
     bool hasRoutePath(uint32_t fromId, uint32_t targetId) const;
 };

--- a/Source/Components/MixerViewModel.h
+++ b/Source/Components/MixerViewModel.h
@@ -93,6 +93,7 @@ struct ChannelViewModel {
     bool suppressClipRelatchR{false};        ///< Ignore re-latch until clip drops once
     
     struct SendViewModel {
+        uint64_t sendId{0};         // Stable identity (Contract D2); never an index
         uint32_t targetId{0};
         std::string targetName;
         float gain{1.0f};           // Linear gain
@@ -288,12 +289,12 @@ public:
     // Send Management
     void addSend(uint32_t channelId);
     void addSidechain(uint32_t channelId);
-    void addSend(uint32_t channelId, uint32_t targetId);
-    void removeSend(uint32_t channelId, int sendIndex);
-    void setSendLevel(uint32_t channelId, int sendIndex, float linearGain);
-    void setSendDestination(uint32_t channelId, int sendIndex, uint32_t targetId);
-    void setSendPostFader(uint32_t channelId, int sendIndex, bool postFader);
-    void setSendSidechainOnly(uint32_t channelId, int sendIndex, bool sidechainOnly);
+    void addSend(uint32_t channelId, uint32_t targetId, bool sidechainOnly = false);
+    void removeSend(uint32_t channelId, uint64_t sendId);
+    void setSendLevel(uint32_t channelId, uint64_t sendId, float linearGain);
+    void setSendDestination(uint32_t channelId, uint64_t sendId, uint32_t targetId);
+    void setSendPostFader(uint32_t channelId, uint64_t sendId, bool postFader);
+    void setSendSidechainOnly(uint32_t channelId, uint64_t sendId, bool sidechainOnly);
     void setMainOutputDestination(uint32_t channelId, uint32_t targetId);
     std::string getRoutingWarning(uint32_t channelId) const;
 
@@ -363,6 +364,10 @@ private:
      */
     bool canRouteTo(uint32_t sourceId, uint32_t targetId) const;
     bool routeWouldCreateCycle(uint32_t sourceId, uint32_t targetId) const;
+    /** @brief Positional index of a sendId inside a channel's local send list; -1 when absent. */
+    int findLocalSendIndex(const ChannelViewModel& ch, uint64_t sendId) const;
+    /** @brief Mirror the engine-minted sendId of the last appended send into the local model. */
+    void refreshLocalSendId(ChannelViewModel* ch, const Audio::MixerChannel* mc);
     bool hasRoutePath(uint32_t fromId, uint32_t targetId) const;
 };
 

--- a/Source/Components/MixerViewModel.h
+++ b/Source/Components/MixerViewModel.h
@@ -366,6 +366,8 @@ private:
     bool routeWouldCreateCycle(uint32_t sourceId, uint32_t targetId) const;
     /** @brief Positional index of a sendId inside a channel's local send list; -1 when absent. */
     int findLocalSendIndex(const ChannelViewModel& ch, uint64_t sendId) const;
+    /** @brief Engine-side route for a sendId; false when the engine no longer holds it. */
+    bool tryGetEngineRoute(const Audio::MixerChannel* mc, uint64_t sendId, Audio::AudioRoute& out) const;
     /** @brief Mirror the engine-minted sendId of the last appended send into the local model. */
     void refreshLocalSendId(ChannelViewModel* ch, const Audio::MixerChannel* mc);
     bool hasRoutePath(uint32_t fromId, uint32_t targetId) const;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -779,16 +779,9 @@ void AestraContent::setupMixerPanels() {
     m_routingMapPanel->setOnAddSend([this](uint32_t sourceId, uint32_t targetId, bool sidechainOnly) {
         if (m_mixerPanel) {
             if (auto vm = m_mixerPanel->getViewModel()) {
-                vm->addSend(sourceId, targetId);
-                // Set sidechain flag on the newly appended send
-                if (sidechainOnly) {
-                    if (auto* ch = vm->getChannelById(sourceId)) {
-                        if (!ch->sends.empty()) {
-                            int newIdx = static_cast<int>(ch->sends.size()) - 1;
-                            vm->setSendSidechainOnly(sourceId, newIdx, true);
-                        }
-                    }
-                }
+                // sidechainOnly is part of the route itself now (Contract D2) —
+                // no post-append positional flip.
+                vm->addSend(sourceId, targetId, sidechainOnly);
             }
         }
     });
@@ -806,18 +799,18 @@ void AestraContent::setupMixerPanels() {
             }
         }
     });
-    m_routingMapPanel->setOnRemoveSend([this](uint32_t channelId, int sendIndex) {
+    m_routingMapPanel->setOnRemoveSend([this](uint32_t channelId, uint64_t sendId) {
         if (m_mixerPanel) {
             if (auto vm = m_mixerPanel->getViewModel()) {
-                vm->removeSend(channelId, sendIndex);
+                vm->removeSend(channelId, sendId);
             }
         }
     });
-    m_routingMapPanel->setOnEditSendLevel([this](uint32_t channelId, int sendIndex, float newDb) {
+    m_routingMapPanel->setOnEditSendLevel([this](uint32_t channelId, uint64_t sendId, float newDb) {
         if (m_mixerPanel) {
             if (auto vm = m_mixerPanel->getViewModel()) {
                 float linearGain = (newDb <= -144.0f) ? 0.0f : std::pow(10.0f, newDb / 20.0f);
-                vm->setSendLevel(channelId, sendIndex, linearGain);
+                vm->setSendLevel(channelId, sendId, linearGain);
             }
         }
     });

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -2225,9 +2225,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             trackManager->getPatternManager().validateMixerChannels(mixerChannelIds);
         }
 
-        // PHASE 7: Validate send routing targets.
-        // Unresolved sends are non-fatal — the audio runtime silently ignores them
-        // via INVALID_SLOT checks. This warning helps diagnose silent routing loss.
+        // PHASE 7: Validate routing against the loaded channel set (Contract
+        // I8/I10/D3/D4). Unresolved destinations are repaired, never silently
+        // dropped later: mains reroute to master, dangling sends are removed,
+        // and sends to master (illegal since D4) are removed. Every repair
+        // produces a diagnostic.
         {
             std::unordered_set<uint32_t> validChannelIds;
             validChannelIds.insert(0xFFFFFFFFu); // master
@@ -2236,18 +2238,49 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     validChannelIds.insert(ch->getChannelId());
                 }
             }
+            auto reportRoutingIssue = [&](const std::string& message, uint64_t objectId) {
+                warningLimiter.warning(ProjectLoadWarningCategory::SendRoute, message,
+                                       "[ProjectLoad] Additional routing repair warnings suppressed.");
+                if (!result.report) {
+                    result.report = std::make_unique<ProjectLoadReport>();
+                }
+                result.report->issues.push_back({LoadIssueSeverity::Warning, "routing", message, objectId, {}, {}});
+            };
+
             for (size_t ci = 0; ci < trackManager->getChannelCount(); ++ci) {
                 auto* channel = trackManager->getChannel(ci);
                 if (!channel) continue;
+
+                // Main output: dangling destinations fail safe to master.
+                const uint32_t mainOutput = channel->getMainOutputId();
+                if (mainOutput != 0xFFFFFFFFu && !validChannelIds.count(mainOutput)) {
+                    channel->setMainOutputId(0xFFFFFFFFu);
+                    reportRoutingIssue("[ProjectLoad] Main output of '" + channel->getName() +
+                                           "' targets channel ID " + std::to_string(mainOutput) +
+                                           " which does not exist; rerouted to Master.",
+                                       channel->getChannelId());
+                }
+
+                // Sends: dangling targets and sends to master are removed.
+                std::vector<AudioRoute> keptSends;
                 for (const auto& send : channel->getSends()) {
-                    if (!validChannelIds.count(send.targetChannelId)) {
-                        warningLimiter.warning(
-                            ProjectLoadWarningCategory::SendRoute,
-                            "[ProjectLoad] Send from '" + channel->getName() +
-                                "' targets channel ID " + std::to_string(send.targetChannelId) +
-                                " which does not exist; send will be silent.",
-                            "[ProjectLoad] Additional unresolved send route warnings suppressed.");
+                    if (send.targetChannelId == 0xFFFFFFFFu) {
+                        reportRoutingIssue("[ProjectLoad] Send from '" + channel->getName() +
+                                               "' targets Master; sends to master are illegal and were removed.",
+                                           channel->getChannelId());
+                        continue;
                     }
+                    if (!validChannelIds.count(send.targetChannelId)) {
+                        reportRoutingIssue("[ProjectLoad] Send from '" + channel->getName() +
+                                               "' targets channel ID " + std::to_string(send.targetChannelId) +
+                                               " which does not exist; send was removed.",
+                                           channel->getChannelId());
+                        continue;
+                    }
+                    keptSends.push_back(send);
+                }
+                if (keptSends.size() != channel->getSends().size()) {
+                    channel->replaceSends(keptSends);
                 }
             }
         }

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -885,6 +885,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             sjs.set("postFader", JSON(send.postFader));
             sjs.set("mute", JSON(send.mute));
             sjs.set("sidechainOnly", JSON(send.sidechainOnly));
+            sjs.set("sendId", JSON(static_cast<double>(send.sendId)));
             sendsJson.push(sjs);
         }
         routingJson.set("sends", sendsJson);
@@ -935,6 +936,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                     sjs.set("postFader", JSON(send.postFader));
                     sjs.set("mute", JSON(send.mute));
                     sjs.set("sidechainOnly", JSON(send.sidechainOnly));
+                    sjs.set("sendId", JSON(static_cast<double>(send.sendId)));
                     sendsJson.push(sjs);
                 }
                 routingJson.set("sends", sendsJson);
@@ -1836,6 +1838,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             route.mute = sends[s].has("mute") && sends[s]["mute"].isBool() && sends[s]["mute"].asBool();
                             route.sidechainOnly = sends[s].has("sidechainOnly") && sends[s]["sidechainOnly"].isBool() &&
                                                   sends[s]["sidechainOnly"].asBool();
+                            // Stable send identity (Contract D2). Older projects
+                            // lack the key: 0 mints a fresh ID in addSend.
+                            route.sendId = static_cast<uint64_t>(
+                                finiteNumberOr(sends[s], "sendId", 0.0, 0.0,
+                                               static_cast<double>(std::numeric_limits<uint64_t>::max())));
                             channel->addSend(route);
                         }
                     }

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -885,7 +885,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             sjs.set("postFader", JSON(send.postFader));
             sjs.set("mute", JSON(send.mute));
             sjs.set("sidechainOnly", JSON(send.sidechainOnly));
-            sjs.set("sendId", JSON(static_cast<double>(send.sendId)));
+            sjs.set("sendId", JSON(std::to_string(send.sendId)));
             sendsJson.push(sjs);
         }
         routingJson.set("sends", sendsJson);
@@ -936,7 +936,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                     sjs.set("postFader", JSON(send.postFader));
                     sjs.set("mute", JSON(send.mute));
                     sjs.set("sidechainOnly", JSON(send.sidechainOnly));
-                    sjs.set("sendId", JSON(static_cast<double>(send.sendId)));
+                    sjs.set("sendId", JSON(std::to_string(send.sendId)));
                     sendsJson.push(sjs);
                 }
                 routingJson.set("sends", sendsJson);
@@ -1838,11 +1838,24 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             route.mute = sends[s].has("mute") && sends[s]["mute"].isBool() && sends[s]["mute"].asBool();
                             route.sidechainOnly = sends[s].has("sidechainOnly") && sends[s]["sidechainOnly"].isBool() &&
                                                   sends[s]["sidechainOnly"].asBool();
-                            // Stable send identity (Contract D2). Older projects
-                            // lack the key: 0 mints a fresh ID in addSend.
-                            route.sendId = static_cast<uint64_t>(
-                                finiteNumberOr(sends[s], "sendId", 0.0, 0.0,
-                                               static_cast<double>(std::numeric_limits<uint64_t>::max())));
+                            // Stable send identity (Contract D2). Serialized as an
+                            // exact decimal string so ids above 2^53 survive the
+                            // JSON round trip. Legacy numeric values are accepted
+                            // only inside the exact JSON-integer range; anything
+                            // else (or a missing key) is 0, which mints in addSend.
+                            route.sendId = 0;
+                            if (sends[s].has("sendId") && sends[s]["sendId"].isString()) {
+                                try {
+                                    route.sendId = std::stoull(sends[s]["sendId"].asString());
+                                } catch (const std::exception&) {
+                                    route.sendId = 0;
+                                }
+                            } else if (sends[s].has("sendId") && sends[s]["sendId"].isNumber()) {
+                                const double legacyId = sends[s]["sendId"].asNumber();
+                                if (std::isfinite(legacyId) && legacyId >= 0.0 && legacyId <= 9007199254740991.0) {
+                                    route.sendId = static_cast<uint64_t>(legacyId);
+                                }
+                            }
                             channel->addSend(route);
                         }
                     }

--- a/Source/Panels/MixerPanel.cpp
+++ b/Source/Panels/MixerPanel.cpp
@@ -33,6 +33,7 @@ MixerPanel::MixerPanel(std::shared_ptr<TrackManager> trackManager)
             }
         }));
         m_viewModel->setCommandHistory(&m_trackManager->getCommandHistory());
+        m_viewModel->setTrackManager(m_trackManager.get());
     }
     m_newMixer = std::make_shared<UIMixerPanel>(m_viewModel, m_trackManager);
     m_newMixer->setId("UIMixerPanel_Inner");

--- a/Tests/AestraAudio/ExportBounceParityTest.cpp
+++ b/Tests/AestraAudio/ExportBounceParityTest.cpp
@@ -144,24 +144,26 @@ int main() {
         trackManager->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, kDurationBeats);
     }
 
-    // Track 0 also sends to master at a non-unity, panned level. This exercises
+    // Track 0 also sends to a bus at a non-unity, panned level. This exercises
     // the send-gain stage in AudioEngine::renderTrack (snapped during offline
     // render) against the baked send connection gain AudioRenderer uses, so a
     // regression in either send path fails the master-vs-isolated comparison.
+    // (Sends to master are illegal — Contract D4 — so the send targets a bus.)
+    trackManager->addChannel("Track_0_Bus"); // index 3
     if (auto* sendChannel = trackManager->getChannel(0)) {
-        AudioRoute sendToMaster;
-        sendToMaster.targetChannelId = 0xFFFFFFFF; // Master
-        sendToMaster.gain = 0.5f;
-        sendToMaster.pan = 0.3f;
-        sendChannel->addSend(sendToMaster);
+        AudioRoute sendToBus;
+        sendToBus.targetChannelId = trackManager->getChannel(3)->getChannelId();
+        sendToBus.gain = 0.5f;
+        sendToBus.pan = 0.3f;
+        sendChannel->addSend(sendToBus);
     }
 
     // Track 3 is a return track (no clips of its own). Track 0 sends to it at a
     // non-unity, panned level: the isolated bounce must carry that content
     // through the return's strip to master, exactly like the live full-mix path
     // (#761).
-    trackManager->addChannel("Track_3_Return");
-    if (auto* returnChannel = trackManager->getChannel(3)) {
+    trackManager->addChannel("Track_3_Return"); // index 4
+    if (auto* returnChannel = trackManager->getChannel(4)) {
         AudioRoute sendToReturn;
         sendToReturn.targetChannelId = returnChannel->getChannelId();
         sendToReturn.gain = 0.5f;

--- a/Tests/AestraAudio/RoutingContractTest.cpp
+++ b/Tests/AestraAudio/RoutingContractTest.cpp
@@ -5,6 +5,7 @@
 // survive index shifts, removal, and undo; a cyclic snapshot is marked
 // corrupt by the compiler and never appended with leftover nodes.
 
+#include "Commands/AddChannelCommand.h"
 #include "Commands/RoutingCommands.h"
 #include "Core/AudioGraph.h"
 #include "Core/MixerChannel.h"
@@ -284,6 +285,112 @@ int runSendIdentityTests(Aestra::Audio::TrackManager& tm) {
     return 0;
 }
 
+int runMasterLegalityTests(Aestra::Audio::TrackManager& tm) {
+    auto* a = tm.addChannelWithId("A", 401);
+    auto* b = tm.addChannelWithId("B", 402);
+    require(a && b, "channel creation failed");
+    auto& history = tm.getCommandHistory();
+
+    // D4: sends to master (engine-space spelling) are rejected, mutate nothing,
+    // and record no undo entry.
+    {
+        Aestra::Audio::AudioRoute toMaster;
+        toMaster.targetChannelId = kMaster;
+        auto cmd = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 401, toMaster);
+        history.pushAndExecute(cmd);
+        require(a->getSends().empty(), "send to master must be rejected");
+        history.undo();
+        require(a->getSends().empty(), "rejected master send must not create an undo entry");
+    }
+
+    // D4: editing a send's destination to master is rejected.
+    {
+        Aestra::Audio::AudioRoute ok;
+        ok.targetChannelId = 402;
+        history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 401, ok));
+        const uint64_t id = a->getSends()[0].sendId;
+        auto toMaster = a->getSends()[0];
+        toMaster.targetChannelId = kMaster;
+        history.pushAndExecute(std::make_shared<Aestra::Audio::EditSendCommand>(tm, 401, id, toMaster));
+        require(a->getSends()[0].targetChannelId == 402, "send edit to master must be rejected");
+        require(a->getSends()[0].sendId == id, "rejected edit must leave the send untouched");
+        history.undo();
+        require(a->getSends().empty(), "clean unwind after rejected edit");
+    }
+
+    // D4: master cannot be a routing source.
+    {
+        auto cmd = std::make_shared<Aestra::Audio::SetMainOutputCommand>(tm, kMaster, 402);
+        history.pushAndExecute(cmd);
+        require(b->getMainOutputId() == kMaster, "master must never be rerouted");
+        history.undo();
+        require(b->getMainOutputId() == kMaster, "rejected master reroute must not create an undo entry");
+    }
+
+    // mainOutput -> master stays the normal terminal route (both spellings).
+    {
+        auto cmd = std::make_shared<Aestra::Audio::SetMainOutputCommand>(tm, 401, kMaster);
+        history.pushAndExecute(cmd);
+        require(a->getMainOutputId() == kMaster, "main to engine-space master must apply");
+        history.undo();
+        history.redo();
+        require(a->getMainOutputId() == kMaster, "main to master must round-trip");
+        history.undo();
+    }
+    require(tm.canRouteTo(401, 0), "model-space master remains a legal main target");
+
+    std::cout << "master legality cases passed\n";
+    return 0;
+}
+
+int runChannelDeletionRoutingTests(Aestra::Audio::TrackManager& tm) {
+    auto* a = tm.addChannelWithId("A", 501);
+    require(a != nullptr, "channel creation failed");
+    auto& history = tm.getCommandHistory();
+
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddChannelCommand>(tm, "B"));
+    require(tm.getChannelCount() == 2, "channel B added");
+    auto* b = tm.getChannel(1);
+    require(b != nullptr, "channel B resolved");
+    const uint32_t bId = b->getChannelId();
+
+    // Route A -> B (main + send).
+    history.pushAndExecute(std::make_shared<Aestra::Audio::SetMainOutputCommand>(tm, 501, bId));
+    Aestra::Audio::AudioRoute send;
+    send.targetChannelId = bId;
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 501, send));
+    const uint64_t sendId = a->getSends()[0].sendId;
+
+    // Undo the add: B vanishes and I8 applies atomically — no dangling routes.
+    history.undo(); // add send
+    history.undo(); // main
+    history.undo(); // add channel
+    require(tm.getChannelById(bId) == nullptr, "undo of add channel must detach B");
+    require(a->getMainOutputId() == kMaster, "undo of add channel must reroute main to master");
+    require(a->getSends().empty(), "undo of add channel must remove sends to it");
+
+    // Redo: B returns and the routes round-trip with the same send id.
+    history.redo();
+    require(tm.getChannelById(bId) != nullptr, "redo must reinsert B");
+    history.redo();
+    require(a->getMainOutputId() == bId, "redo must restore the main route");
+    history.redo();
+    const auto restored = a->getSends();
+    require(restored.size() == 1 && restored[0].targetChannelId == bId,
+            "redo must restore the send");
+    require(restored[0].sendId == sendId, "redo must restore the same send identity");
+
+    // Unwind.
+    history.undo();
+    history.undo();
+    history.undo();
+    require(a->getMainOutputId() == kMaster && a->getSends().empty(),
+            "full unwind returns to the pre-add routing state");
+
+    std::cout << "channel deletion routing cases passed\n";
+    return 0;
+}
+
 int runSnapshotCycleTests() {
     // Compiler marks a cyclic snapshot corrupt; it never appends leftover nodes.
     Aestra::Audio::AudioGraph graph;
@@ -338,6 +445,18 @@ int main() {
     {
         Aestra::Audio::TrackManager tm;
         if (int rc = runSendIdentityTests(tm); rc != 0) {
+            return rc;
+        }
+    }
+    {
+        Aestra::Audio::TrackManager tm;
+        if (int rc = runMasterLegalityTests(tm); rc != 0) {
+            return rc;
+        }
+    }
+    {
+        Aestra::Audio::TrackManager tm;
+        if (int rc = runChannelDeletionRoutingTests(tm); rc != 0) {
             return rc;
         }
     }

--- a/Tests/AestraAudio/RoutingContractTest.cpp
+++ b/Tests/AestraAudio/RoutingContractTest.cpp
@@ -1,0 +1,257 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Routing Contract regression (D5 + D1): mutation-time cycle rejection lives
+// in TrackManager::canRouteTo; routing mutations go through undoable commands
+// that validate before applying; a cyclic snapshot is marked corrupt by the
+// compiler and never appended with leftover nodes.
+
+#include "Commands/RoutingCommands.h"
+#include "Core/AudioGraph.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+namespace {
+
+#define require(cond, msg)                                        \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::cerr << "FAIL: " << msg << std::endl;            \
+            return 1;                                             \
+        }                                                         \
+    } while (0)
+
+constexpr uint32_t kMaster = 0xFFFFFFFFu;
+
+int runCanRouteToTests(Aestra::Audio::TrackManager& tm) {
+    auto* a = tm.addChannelWithId("A", 101);
+    auto* b = tm.addChannelWithId("B", 102);
+    auto* c = tm.addChannelWithId("C", 103);
+    require(a && b && c, "channel creation failed");
+
+    // Self-routes are illegal.
+    require(!tm.canRouteTo(101, 101), "self-route must be illegal");
+
+    // Master is a terminal sink: always a legal target, never a source.
+    require(tm.canRouteTo(101, kMaster), "routing to master must be legal");
+    require(!tm.canRouteTo(kMaster, 101), "master must not be a routable source");
+    require(!tm.canRouteTo(0, 101), "id 0 must not be a routable source");
+
+    // Dangling destinations are illegal.
+    require(!tm.canRouteTo(101, 999), "dangling destination must be illegal");
+    require(!tm.canRouteTo(999, 101), "dangling source must be illegal");
+
+    // A -> B is legal; B's main -> A would be a cycle for A -> B.
+    require(tm.canRouteTo(101, 102), "plain forward route must be legal");
+    b->setMainOutputId(101);
+    require(!tm.canRouteTo(101, 102), "cycle via main output must be illegal");
+    // Routing into the loop without closing one stays legal: C -> A or C -> B
+    // only feeds the loop, it never completes a path back to the source.
+    require(tm.canRouteTo(103, 101), "feeding an existing loop must stay legal");
+    require(tm.canRouteTo(103, 102), "feeding an existing loop must stay legal");
+    b->setMainOutputId(kMaster);
+
+    // Cycle via sends: C sends to B, then B sends to C is a cycle.
+    {
+        Aestra::Audio::AudioRoute sendToB;
+        sendToB.targetChannelId = 102;
+        c->addSend(sendToB);
+        require(!tm.canRouteTo(102, 103), "cycle via send must be illegal");
+        require(tm.canRouteTo(102, 101), "non-cyclic route must remain legal");
+        c->removeSend(0);
+    }
+
+    // Sidechain edges are control-only and cannot form audible cycles.
+    {
+        Aestra::Audio::AudioRoute sidechain;
+        sidechain.targetChannelId = 103;
+        sidechain.sidechainOnly = true;
+        b->addSend(sidechain);
+        require(tm.canRouteTo(103, 102), "sidechain edge must not create an audible cycle");
+        b->removeSend(0);
+    }
+
+    // Long chains: A -> B -> C. C -> A would close the loop.
+    a->setMainOutputId(102);
+    b->setMainOutputId(103);
+    require(tm.canRouteTo(101, 102), "A -> B legal in chain");
+    require(!tm.canRouteTo(103, 101), "closing the chain into A must be illegal");
+    require(!tm.canRouteTo(102, 101), "B -> A would close the chain back into itself");
+    require(tm.canRouteTo(101, 103), "A -> C is legal; C terminates at master");
+    a->setMainOutputId(kMaster);
+    b->setMainOutputId(kMaster);
+
+    std::cout << "canRouteTo contract cases passed\n";
+    return 0;
+}
+
+int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
+    auto* a = tm.addChannelWithId("A", 201);
+    auto* b = tm.addChannelWithId("B", 202);
+    require(a && b, "channel creation failed");
+    auto& history = tm.getCommandHistory();
+
+    // AddSendCommand: execute -> undo -> redo roundtrip.
+    Aestra::Audio::AudioRoute route;
+    route.targetChannelId = 202;
+    route.gain = 0.5f;
+    route.pan = 0.25f;
+    route.postFader = false;
+    {
+        auto cmd = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, route);
+        history.pushAndExecute(cmd);
+        auto sends = a->getSends();
+        require(sends.size() == 1 && sends[0].targetChannelId == 202 && sends[0].gain == 0.5f,
+                "add send command must apply the route");
+
+        history.undo();
+        require(a->getSends().empty(), "undo of add send must remove the send");
+
+        history.redo();
+        sends = a->getSends();
+        require(sends.size() == 1 && sends[0].gain == 0.5f && sends[0].pan == 0.25f &&
+                    !sends[0].postFader,
+                "redo of add send must restore the exact route");
+        history.undo();
+    }
+
+    // SetMainOutputCommand: undo restores the previous main output.
+    {
+        auto cmd = std::make_shared<Aestra::Audio::SetMainOutputCommand>(tm, 201, 202);
+        history.pushAndExecute(cmd);
+        require(a->getMainOutputId() == 202, "set main output must apply");
+        history.undo();
+        require(a->getMainOutputId() == kMaster, "undo of main output must restore master");
+        history.redo();
+        require(a->getMainOutputId() == 202, "redo of main output must reapply");
+        history.undo();
+    }
+
+    // EditSendCommand: level edit roundtrip; destination edit is validated.
+    {
+        Aestra::Audio::AudioRoute route2;
+        route2.targetChannelId = 202;
+        route2.gain = 0.5f;
+        auto addCmd = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, route2);
+        history.pushAndExecute(addCmd);
+
+        auto edited = a->getSends()[0];
+        edited.gain = 1.0f;
+        auto editCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, 0, edited);
+        history.pushAndExecute(editCmd);
+        require(a->getSends()[0].gain == 1.0f, "edit send level must apply");
+        history.undo();
+        require(a->getSends()[0].gain == 0.5f, "undo of send edit must restore previous level");
+        history.redo();
+        require(a->getSends()[0].gain == 1.0f, "redo of send edit must reapply");
+
+        // Destination edit into a cycle must be rejected: the send stays
+        // unchanged and no undo entry is recorded (pushAndExecute swallows
+        // the validation exception internally).
+        a->setMainOutputId(202); // A -> B main path
+        auto cyclic = a->getSends()[0];
+        cyclic.targetChannelId = 201; // send back to self
+        auto badCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, 0, cyclic);
+        history.pushAndExecute(badCmd);
+        require(a->getSends()[0].targetChannelId == 202, "rejected edit must not mutate the send");
+        history.undo(); // undoes the gain edit; a phantom entry would undo something else
+        auto afterReject = a->getSends();
+        require(afterReject.size() == 1 && afterReject[0].gain == 0.5f,
+                "rejected edit must not create an undo entry");
+        history.undo(); // undo add send
+        require(a->getSends().empty(), "add send must unwind cleanly");
+        a->setMainOutputId(kMaster);
+    }
+
+    // RemoveSendCommand: undo restores the exact send at its index.
+    {
+        Aestra::Audio::AudioRoute s1;
+        s1.targetChannelId = 202;
+        s1.gain = 0.3f;
+        Aestra::Audio::AudioRoute s2;
+        s2.targetChannelId = 202;
+        s2.gain = 0.7f;
+        auto add1 = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, s1);
+        auto add2 = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, s2);
+        history.pushAndExecute(add1);
+        history.pushAndExecute(add2);
+
+        auto rmCmd = std::make_shared<Aestra::Audio::RemoveSendCommand>(tm, 201, 0);
+        history.pushAndExecute(rmCmd);
+        auto sends = a->getSends();
+        require(sends.size() == 1 && sends[0].gain == 0.7f, "remove send must remove index 0");
+        history.undo();
+        sends = a->getSends();
+        require(sends.size() == 2 && sends[0].gain == 0.3f && sends[1].gain == 0.7f,
+                "undo of remove send must restore at original index");
+        history.redo();
+        sends = a->getSends();
+        require(sends.size() == 1 && sends[0].gain == 0.7f, "redo of remove send must re-remove");
+        history.undo();
+        history.undo();
+        history.undo();
+    }
+
+    std::cout << "command seam roundtrips passed\n";
+    return 0;
+}
+
+int runSnapshotCycleTests() {
+    // Compiler marks a cyclic snapshot corrupt; it never appends leftover nodes.
+    Aestra::Audio::AudioGraph graph;
+    Aestra::Audio::TrackRenderState a;
+    a.trackId = 1;
+    a.mainOutputId = 2;
+    Aestra::Audio::TrackRenderState b;
+    b.trackId = 2;
+    b.mainOutputId = 1; // cycle A <-> B
+    Aestra::Audio::TrackRenderState c;
+    c.trackId = 3;
+    c.mainOutputId = kMaster;
+    graph.tracks = {a, b, c};
+
+    Aestra::Audio::finalizeAudioGraphRouting(graph);
+    require(graph.hasRoutingCycle, "cyclic snapshot must be flagged corrupt");
+    require(graph.topologicalOrder.size() < graph.tracks.size(),
+            "cycle must not be papered over with appended leftover nodes");
+
+    // Acyclic: full order, no flag.
+    Aestra::Audio::AudioGraph clean;
+    Aestra::Audio::TrackRenderState x;
+    x.trackId = 1;
+    x.mainOutputId = 2;
+    Aestra::Audio::TrackRenderState y;
+    y.trackId = 2;
+    y.mainOutputId = kMaster;
+    clean.tracks = {x, y};
+    Aestra::Audio::finalizeAudioGraphRouting(clean);
+    require(!clean.hasRoutingCycle, "acyclic snapshot must not be flagged");
+    require(clean.topologicalOrder.size() == clean.tracks.size(), "acyclic snapshot must be fully ordered");
+
+    std::cout << "snapshot cycle handling passed\n";
+    return 0;
+}
+
+} // namespace
+
+int main() {
+    {
+        Aestra::Audio::TrackManager tm;
+        if (int rc = runCanRouteToTests(tm); rc != 0) {
+            return rc;
+        }
+    }
+    {
+        Aestra::Audio::TrackManager tm;
+        if (int rc = runCommandSeamTests(tm); rc != 0) {
+            return rc;
+        }
+    }
+    if (int rc = runSnapshotCycleTests(); rc != 0) {
+        return rc;
+    }
+    std::cout << "[PASS] RoutingContractTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/RoutingContractTest.cpp
+++ b/Tests/AestraAudio/RoutingContractTest.cpp
@@ -1,8 +1,9 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
-// Routing Contract regression (D5 + D1): mutation-time cycle rejection lives
-// in TrackManager::canRouteTo; routing mutations go through undoable commands
-// that validate before applying; a cyclic snapshot is marked corrupt by the
-// compiler and never appended with leftover nodes.
+// Routing Contract regression (D5 + D1 + D2): mutation-time cycle rejection
+// lives in TrackManager::canRouteTo; routing mutations go through undoable
+// commands that validate before applying; sends carry stable sendIds that
+// survive index shifts, removal, and undo; a cyclic snapshot is marked
+// corrupt by the compiler and never appended with leftover nodes.
 
 #include "Commands/RoutingCommands.h"
 #include "Core/AudioGraph.h"
@@ -36,8 +37,9 @@ int runCanRouteToTests(Aestra::Audio::TrackManager& tm) {
 
     // Master is a terminal sink: always a legal target, never a source.
     require(tm.canRouteTo(101, kMaster), "routing to master must be legal");
+    require(tm.canRouteTo(101, 0), "routing to model-space master must be legal");
     require(!tm.canRouteTo(kMaster, 101), "master must not be a routable source");
-    require(!tm.canRouteTo(0, 101), "id 0 must not be a routable source");
+    require(!tm.canRouteTo(0, 101), "model-space master must not be a routable source");
 
     // Dangling destinations are illegal.
     require(!tm.canRouteTo(101, 999), "dangling destination must be illegal");
@@ -58,9 +60,11 @@ int runCanRouteToTests(Aestra::Audio::TrackManager& tm) {
         Aestra::Audio::AudioRoute sendToB;
         sendToB.targetChannelId = 102;
         c->addSend(sendToB);
+        const uint64_t cSendId = c->getSends()[0].sendId;
+        require(cSendId != 0, "send must be minted a stable id");
         require(!tm.canRouteTo(102, 103), "cycle via send must be illegal");
         require(tm.canRouteTo(102, 101), "non-cyclic route must remain legal");
-        c->removeSend(0);
+        c->removeSend(cSendId);
     }
 
     // Sidechain edges are control-only and cannot form audible cycles.
@@ -69,8 +73,9 @@ int runCanRouteToTests(Aestra::Audio::TrackManager& tm) {
         sidechain.targetChannelId = 103;
         sidechain.sidechainOnly = true;
         b->addSend(sidechain);
+        const uint64_t bSendId = b->getSends()[0].sendId;
         require(tm.canRouteTo(103, 102), "sidechain edge must not create an audible cycle");
-        b->removeSend(0);
+        b->removeSend(bSendId);
     }
 
     // Long chains: A -> B -> C. C -> A would close the loop.
@@ -105,6 +110,8 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         auto sends = a->getSends();
         require(sends.size() == 1 && sends[0].targetChannelId == 202 && sends[0].gain == 0.5f,
                 "add send command must apply the route");
+        const uint64_t id = sends[0].sendId;
+        require(id != 0, "add send must mint a stable sendId");
 
         history.undo();
         require(a->getSends().empty(), "undo of add send must remove the send");
@@ -114,6 +121,7 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         require(sends.size() == 1 && sends[0].gain == 0.5f && sends[0].pan == 0.25f &&
                     !sends[0].postFader,
                 "redo of add send must restore the exact route");
+        require(sends[0].sendId == id, "redo of add send must mint the same id");
         history.undo();
     }
 
@@ -136,10 +144,11 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         route2.gain = 0.5f;
         auto addCmd = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, route2);
         history.pushAndExecute(addCmd);
+        const uint64_t id = a->getSends()[0].sendId;
 
         auto edited = a->getSends()[0];
         edited.gain = 1.0f;
-        auto editCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, 0, edited);
+        auto editCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, id, edited);
         history.pushAndExecute(editCmd);
         require(a->getSends()[0].gain == 1.0f, "edit send level must apply");
         history.undo();
@@ -153,7 +162,7 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         a->setMainOutputId(202); // A -> B main path
         auto cyclic = a->getSends()[0];
         cyclic.targetChannelId = 201; // send back to self
-        auto badCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, 0, cyclic);
+        auto badCmd = std::make_shared<Aestra::Audio::EditSendCommand>(tm, 201, id, cyclic);
         history.pushAndExecute(badCmd);
         require(a->getSends()[0].targetChannelId == 202, "rejected edit must not mutate the send");
         history.undo(); // undoes the gain edit; a phantom entry would undo something else
@@ -165,7 +174,7 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         a->setMainOutputId(kMaster);
     }
 
-    // RemoveSendCommand: undo restores the exact send at its index.
+    // RemoveSendCommand: undo restores the exact send (same id) at its index.
     {
         Aestra::Audio::AudioRoute s1;
         s1.targetChannelId = 202;
@@ -177,15 +186,20 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
         auto add2 = std::make_shared<Aestra::Audio::AddSendCommand>(tm, 201, s2);
         history.pushAndExecute(add1);
         history.pushAndExecute(add2);
+        const uint64_t id0 = a->getSends()[0].sendId;
+        const uint64_t id1 = a->getSends()[1].sendId;
+        require(id0 != id1 && id0 != 0 && id1 != 0, "sends must mint distinct stable ids");
 
-        auto rmCmd = std::make_shared<Aestra::Audio::RemoveSendCommand>(tm, 201, 0);
+        auto rmCmd = std::make_shared<Aestra::Audio::RemoveSendCommand>(tm, 201, id0);
         history.pushAndExecute(rmCmd);
         auto sends = a->getSends();
-        require(sends.size() == 1 && sends[0].gain == 0.7f, "remove send must remove index 0");
+        require(sends.size() == 1 && sends[0].gain == 0.7f, "remove send must remove by id");
         history.undo();
         sends = a->getSends();
         require(sends.size() == 2 && sends[0].gain == 0.3f && sends[1].gain == 0.7f,
                 "undo of remove send must restore at original index");
+        require(sends[0].sendId == id0 && sends[1].sendId == id1,
+                "undo of remove send must restore the same stable ids");
         history.redo();
         sends = a->getSends();
         require(sends.size() == 1 && sends[0].gain == 0.7f, "redo of remove send must re-remove");
@@ -195,6 +209,78 @@ int runCommandSeamTests(Aestra::Audio::TrackManager& tm) {
     }
 
     std::cout << "command seam roundtrips passed\n";
+    return 0;
+}
+
+int runSendIdentityTests(Aestra::Audio::TrackManager& tm) {
+    auto* a = tm.addChannelWithId("A", 301);
+    auto* b = tm.addChannelWithId("B", 302);
+    auto* c = tm.addChannelWithId("C", 303);
+    require(a && b && c, "channel creation failed");
+    auto& history = tm.getCommandHistory();
+
+    // Three sends on A; remove the FIRST; edit the LAST by its id. A
+    // positional implementation would now target the shifted send.
+    Aestra::Audio::AudioRoute r1;
+    r1.targetChannelId = 302;
+    r1.gain = 0.1f;
+    Aestra::Audio::AudioRoute r2;
+    r2.targetChannelId = 302;
+    r2.gain = 0.2f;
+    Aestra::Audio::AudioRoute r3;
+    r3.targetChannelId = 303;
+    r3.gain = 0.3f;
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 301, r1));
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 301, r2));
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 301, r3));
+
+    auto sends = a->getSends();
+    require(sends.size() == 3, "three sends expected");
+    const uint64_t idA = sends[0].sendId;
+    const uint64_t idB = sends[1].sendId;
+    const uint64_t idC = sends[2].sendId;
+    require(idA < idB && idB < idC, "send ids must be monotonically minted");
+
+    // Remove send A by id, then edit send C by id.
+    history.pushAndExecute(std::make_shared<Aestra::Audio::RemoveSendCommand>(tm, 301, idA));
+    sends = a->getSends();
+    require(sends.size() == 2 && sends[0].sendId == idB && sends[1].sendId == idC,
+            "removal by id must leave the others in order");
+
+    auto editedC = a->getSends()[1]; // idC now at index 1
+    editedC.gain = 0.9f;
+    history.pushAndExecute(std::make_shared<Aestra::Audio::EditSendCommand>(tm, 301, idC, editedC));
+    sends = a->getSends();
+    require(sends[1].gain == 0.9f && sends[1].targetChannelId == 303,
+            "edit by id must target the right send after a shift");
+    require(sends[0].gain == 0.2f, "the shifted send must be untouched");
+
+    // A new send gets a fresh id — never a reuse of the removed one.
+    Aestra::Audio::AudioRoute r4;
+    r4.targetChannelId = 302;
+    history.pushAndExecute(std::make_shared<Aestra::Audio::AddSendCommand>(tm, 301, r4));
+    sends = a->getSends();
+    require(sends.size() == 3, "third send back");
+    require(sends[2].sendId != idA && sends[2].sendId > idC, "send ids must never be reused");
+
+    // Undo back to the pre-edit state: identity survives the whole stack.
+    history.undo(); // undo r4 add
+    history.undo(); // undo edit C
+    history.undo(); // undo remove A
+    sends = a->getSends();
+    require(sends.size() == 3 && sends[0].sendId == idA && sends[1].sendId == idB &&
+                sends[2].sendId == idC,
+            "full unwind must restore every original id");
+    require(sends[0].gain == 0.1f && sends[1].gain == 0.2f && sends[2].gain == 0.3f,
+            "full unwind must restore every original route");
+
+    // Undo the three adds.
+    history.undo();
+    history.undo();
+    history.undo();
+    require(a->getSends().empty(), "sends must unwind cleanly");
+
+    std::cout << "send identity cases passed\n";
     return 0;
 }
 
@@ -246,6 +332,12 @@ int main() {
     {
         Aestra::Audio::TrackManager tm;
         if (int rc = runCommandSeamTests(tm); rc != 0) {
+            return rc;
+        }
+    }
+    {
+        Aestra::Audio::TrackManager tm;
+        if (int rc = runSendIdentityTests(tm); rc != 0) {
             return rc;
         }
     }

--- a/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
+++ b/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
@@ -191,8 +191,9 @@ struct Fixture {
     PatternID patternId{};
 
     explicit Fixture(const std::string& tag) {
-        sampleRoot = "/tmp/Aestra_tests/RoutingSemantics_" + tag + "_" +
-                     std::to_string(reinterpret_cast<uintptr_t>(this));
+        sampleRoot = (std::filesystem::temp_directory_path() / "Aestra_tests" /
+                      ("RoutingSemantics_" + tag + "_" + std::to_string(reinterpret_cast<uintptr_t>(this))))
+                         .string();
         std::error_code ec;
         std::filesystem::create_directories(std::filesystem::path(sampleRoot).parent_path(), ec);
         tm = std::make_shared<TrackManager>();
@@ -299,7 +300,11 @@ void testV1PreFaderSurvivesMute() {
     // Route exists in the compiled topology (audibleDownstream edge).
     {
         AudioGraph graph = AudioGraphBuilder::buildFromTrackManager(*fx.tm);
-        const size_t srcIdx = graph.trackIndexById[fx.src->getChannelId()];
+        const uint32_t srcChannelId = fx.src->getChannelId();
+        require(srcChannelId < graph.trackIndexById.size(), "V1: source id must be in the graph index");
+        const size_t srcIdx = graph.trackIndexById[srcChannelId];
+        require(srcIdx != AudioGraph::kInvalidTrackIndex && srcIdx < graph.audibleDownstream.size(),
+                "V1: source must resolve to a graph track");
         bool found = false;
         for (const size_t dest : graph.audibleDownstream[srcIdx]) {
             if (graph.tracks[dest].trackId == fx.dst->getChannelId()) {

--- a/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
+++ b/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -192,6 +193,8 @@ struct Fixture {
     explicit Fixture(const std::string& tag) {
         sampleRoot = "/tmp/Aestra_tests/RoutingSemantics_" + tag + "_" +
                      std::to_string(reinterpret_cast<uintptr_t>(this));
+        std::error_code ec;
+        std::filesystem::create_directories(std::filesystem::path(sampleRoot).parent_path(), ec);
         tm = std::make_shared<TrackManager>();
         tm->setOutputSampleRate(static_cast<double>(kSampleRate));
         tm->getPlaylistModel().setBPM(120.0);

--- a/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
+++ b/Tests/AestraAudio/RoutingRenderSemanticsTest.cpp
@@ -1,0 +1,525 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Routing Render Semantics (Contract V1-V3): render-level verification that
+// the audio actually delivered matches the routing contract —
+//   V1: pre-fader sends survive the source mute gate; post-fader sends die.
+//   V2: sidechain key input follows the source's solo state and never enters
+//       the destination's audible mix.
+//   V3: combined — muted source + solo context + pre-fader sidechain: the
+//       tap happens pre-mute, but the solo gate still silences the key.
+// All assertions are on rendered buffers, not on code branches.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraph.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
+#include "Plugin/PluginManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace Aestra;
+using namespace Aestra::Audio;
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockSize = 256;
+constexpr uint32_t kChannels = 2;
+constexpr double kRenderSeconds = 0.5;
+constexpr uint32_t kRenderFrames = static_cast<uint32_t>(kRenderSeconds * kSampleRate);
+constexpr double kTonePeak = 0.55;
+constexpr double kKeyScale = 2.0; // SidechainGainPlugin output = input * (1 + kKeyScale * keyPeak)
+
+int g_failures = 0;
+
+#define require(cond, msg)                                        \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::cerr << "FAIL: " << msg << std::endl;            \
+            ++g_failures;                                         \
+            return;                                               \
+        }                                                         \
+    } while (0)
+
+double toneAmplitude(const std::vector<float>& interleaved, double frequency, uint32_t sampleRate,
+                     size_t skipFrames = 2048) {
+    const size_t frameCount = interleaved.size() / 2;
+    if (frameCount <= skipFrames) {
+        return 0.0;
+    }
+    double real = 0.0;
+    double imag = 0.0;
+    const double omega = 2.0 * 3.14159265358979 * frequency / static_cast<double>(sampleRate);
+    for (size_t frame = skipFrames; frame < frameCount; ++frame) {
+        const double sample = static_cast<double>(interleaved[frame * 2]);
+        const double phase = omega * static_cast<double>(frame);
+        real += sample * std::cos(phase);
+        imag -= sample * std::sin(phase);
+    }
+    return 2.0 * std::sqrt(real * real + imag * imag) / static_cast<double>(frameCount - skipFrames);
+}
+
+bool writeToneWav(const std::string& path, double frequency, double peak, uint32_t frames) {
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        return false;
+    }
+    const uint32_t dataBytes = frames * 2 * sizeof(int16_t);
+    out.write("RIFF", 4);
+    const uint32_t riffSize = 36 + dataBytes;
+    out.write(reinterpret_cast<const char*>(&riffSize), 4);
+    out.write("WAVEfmt ", 8);
+    const uint32_t fmtChunk = 16;
+    out.write(reinterpret_cast<const char*>(&fmtChunk), 4);
+    const uint16_t format = 1;
+    out.write(reinterpret_cast<const char*>(&format), 2);
+    const uint16_t channels = 1;
+    out.write(reinterpret_cast<const char*>(&channels), 2);
+    out.write(reinterpret_cast<const char*>(&kSampleRate), 4);
+    const uint32_t byteRate = kSampleRate * 2;
+    out.write(reinterpret_cast<const char*>(&byteRate), 4);
+    const uint16_t blockAlign = 2;
+    out.write(reinterpret_cast<const char*>(&blockAlign), 2);
+    const uint16_t bits = 16;
+    out.write(reinterpret_cast<const char*>(&bits), 2);
+    out.write("data", 4);
+    out.write(reinterpret_cast<const char*>(&dataBytes), 4);
+    for (uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(kSampleRate);
+        const float sample = static_cast<float>(std::sin(2.0 * 3.14159265358979 * frequency * t) * peak);
+        const int16_t pcm = static_cast<int16_t>(std::clamp(sample, -1.0f, 1.0f) * 32767.0f);
+        out.write(reinterpret_cast<const char*>(&pcm), 2);
+    }
+    return out.good();
+}
+
+// Test plugin: output = input * (1 + kKeyScale * keyPeak). The sidechain key
+// input arrives as extra input channels (EffectChain appends sidechain after
+// the audio channels for plugins declaring enough inputs). Observing the
+// destination's output amplitude therefore reports whether the key input
+// actually arrived — without the key, output equals input.
+class SidechainGainPlugin : public IPluginInstance {
+public:
+    SidechainGainPlugin() {
+        m_info.id = "aestra.test.sidechain_gain";
+        m_info.name = "SidechainGain";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 4; // 2 audio + 2 sidechain
+        m_info.numAudioOutputs = 2;
+    }
+
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override { m_active = true; }
+    void deactivate() override { m_active = false; }
+    bool isActive() const override { return m_active; }
+
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                 uint32_t numOutputChannels, uint32_t numFrames,
+                 const MidiBuffer* = nullptr, MidiBuffer* = nullptr) override {
+        double keyPeak = 0.0;
+        const bool hasSidechain = inputs && numInputChannels >= 4 && inputs[2] && inputs[3];
+        if (hasSidechain) {
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                keyPeak = std::max(keyPeak, std::max(std::abs(static_cast<double>(inputs[2][i])),
+                                                     std::abs(static_cast<double>(inputs[3][i]))));
+            }
+        }
+        const float scale = static_cast<float>(1.0 + kKeyScale * keyPeak);
+        const uint32_t channels = std::min(numOutputChannels, 2u);
+        for (uint32_t c = 0; c < channels; ++c) {
+            if (inputs && inputs[c] && outputs && outputs[c]) {
+                for (uint32_t i = 0; i < numFrames; ++i) {
+                    outputs[c][i] = inputs[c][i] * scale;
+                }
+            } else if (outputs && outputs[c]) {
+                std::memset(outputs[c], 0, sizeof(float) * numFrames);
+            }
+        }
+    }
+
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+private:
+    PluginInfo m_info{};
+    bool m_active = false;
+};
+
+struct Fixture {
+    std::shared_ptr<TrackManager> tm;
+    AudioEngine engine;
+    std::string sampleRoot;
+
+    MixerChannel* src{nullptr};  // 220 Hz tone source
+    MixerChannel* dst{nullptr};  // destination (bus)
+    UnitID srcUnit{0};
+    UnitID dstUnit{0};
+    PatternID patternId{};
+
+    explicit Fixture(const std::string& tag) {
+        sampleRoot = "/tmp/Aestra_tests/RoutingSemantics_" + tag + "_" +
+                     std::to_string(reinterpret_cast<uintptr_t>(this));
+        tm = std::make_shared<TrackManager>();
+        tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+        tm->getPlaylistModel().setBPM(120.0);
+
+        src = tm->addChannelWithId("Src", 101);
+        dst = tm->addChannelWithId("Dst", 102);
+        tm->addChannelWithId("Other", 103);
+    }
+
+    void initEngine() {
+        engine.setTrackManager(tm);
+        engine.initialize();
+        engine.setSampleRate(kSampleRate);
+        engine.setBufferConfig(kBlockSize, kChannels);
+        engine.setBPM(120.0f);
+    }
+
+    UnitID addUnit(MixerChannel* channel, const std::string& wavName, double frequency) {
+        const std::string path = sampleRoot + "_" + wavName + ".wav";
+        if (!writeToneWav(path, frequency, kTonePeak, kSampleRate)) {
+            std::cerr << "FAIL: could not write tone wav " << path << std::endl;
+            std::exit(1);
+        }
+        auto& units = tm->getUnitManager();
+        const UnitID id = units.createUnit(wavName, UnitType::Sampler);
+        units.setUnitAudioClip(id, path);
+        units.setUnitEnabled(id, true);
+        units.setUnitGain(id, 1.0f);
+        units.setUnitMixerChannel(id, channel->getChannelId());
+        return id;
+    }
+
+    void schedulePattern() {
+        auto& units = tm->getUnitManager();
+        const std::vector<UnitID> allUnits = units.getAllUnitIDs();
+        auto& patterns = tm->getPatternManager();
+        patternId = patterns.createPattern();
+        auto* pattern = patterns.getPattern(patternId);
+        pattern->type = PatternSource::Type::Midi;
+        pattern->lengthBeats = 8.0;
+        pattern->payload = MidiPayload{};
+        auto& notes = std::get<MidiPayload>(pattern->payload).notes;
+        for (const UnitID id : allUnits) {
+            notes.push_back(MidiNote{60, 0.0, 7.5, 120.0f, 0.0f, id});
+        }
+    }
+
+    void startEngine() {
+        engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+        if (auto slotMap = tm->getChannelSlotMapShared()) {
+            engine.setChannelSlotMap(slotMap);
+        }
+        engine.setUnitManager(&tm->getUnitManager());
+        engine.setPatternPlaybackEngine(&tm->getPatternPlaybackEngine());
+        engine.setPatternPlaybackMode(true, 8.0);
+        engine.setGlobalSamplePos(0);
+        engine.setMetronomeEnabled(false);
+        engine.setAuditionModeEnabled(false);
+        tm->getPatternPlaybackEngine().rewindScheduledInstances();
+        tm->getPatternPlaybackEngine().schedulePatternInstance(patternId, 0.0, 1);
+        engine.setTransportPlaying(true);
+    }
+
+    // Render to master; returns interleaved samples.
+    std::vector<float> render() {
+        std::vector<float> out(static_cast<size_t>(kBlockSize) * kChannels, 0.0f);
+        std::vector<float> samples;
+        samples.reserve(static_cast<size_t>(kRenderFrames) * kChannels);
+        uint32_t rendered = 0;
+        while (rendered < kRenderFrames) {
+            tm->getPatternPlaybackEngine().refillWindow(rendered, static_cast<int>(kSampleRate),
+                                                        static_cast<int>(kSampleRate));
+            const uint32_t frames = std::min(kBlockSize, kRenderFrames - rendered);
+            std::fill(out.begin(), out.end(), 0.0f);
+            engine.processBlock(out.data(), nullptr, frames, 0.0);
+            samples.insert(samples.end(), out.begin(), out.begin() + static_cast<std::ptrdiff_t>(frames * kChannels));
+            rendered += frames;
+        }
+        engine.setTransportPlaying(false);
+        return samples;
+    }
+
+    void stop() { engine.setTransportPlaying(false); }
+};
+
+// ============================================================================
+// V1 — pre-fader send vs mute
+// ============================================================================
+void testV1PreFaderSurvivesMute() {
+    Fixture fx("v1");
+    fx.initEngine();
+    fx.srcUnit = fx.addUnit(fx.src, "src", 220.0);
+    fx.schedulePattern();
+
+    // Src -> master (main); Src pre-fader send -> Dst; Dst -> master.
+    AudioRoute send;
+    send.targetChannelId = fx.dst->getChannelId();
+    send.gain = 1.0f;
+    send.postFader = false;
+    fx.src->addSend(send);
+
+    // Route exists in the compiled topology (audibleDownstream edge).
+    {
+        AudioGraph graph = AudioGraphBuilder::buildFromTrackManager(*fx.tm);
+        const size_t srcIdx = graph.trackIndexById[fx.src->getChannelId()];
+        bool found = false;
+        for (const size_t dest : graph.audibleDownstream[srcIdx]) {
+            if (graph.tracks[dest].trackId == fx.dst->getChannelId()) {
+                found = true;
+            }
+        }
+        require(found, "V1: send edge must exist in the compiled topology");
+    }
+
+    fx.startEngine();
+    std::vector<float> unmuted = fx.render();
+    const double unmutedAmp = toneAmplitude(unmuted, 220.0, kSampleRate);
+    require(unmutedAmp > 1e-3, "V1: unmuted source must reach master");
+
+    fx.src->setMute(true);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> mutedPreFader = fx.render();
+    const double mutedAmp = toneAmplitude(mutedPreFader, 220.0, kSampleRate);
+    require(mutedAmp > 1e-3, "V1: muted source pre-fader send must still deliver audio");
+    fx.stop();
+
+    std::cout << "V1 pre-fader survives mute: unmuted=" << unmutedAmp << " muted=" << mutedAmp << "\n";
+    // Unmuted master carries source main + send (2x tone); muted carries the
+    // send path alone (~0.5x). Require the send path to be a substantial
+    // fraction — the point is the signal is NOT silenced by mute.
+    if (mutedAmp < unmutedAmp * 0.3) {
+        std::cerr << "FAIL: V1: pre-fader send level collapsed under mute\n";
+        ++g_failures;
+    }
+}
+
+void testV1PostFaderDiesOnMute() {
+    Fixture fx("v1post");
+    fx.initEngine();
+    fx.srcUnit = fx.addUnit(fx.src, "src", 220.0);
+    fx.schedulePattern();
+
+    AudioRoute send;
+    send.targetChannelId = fx.dst->getChannelId();
+    send.gain = 1.0f;
+    send.postFader = true;
+    fx.src->addSend(send);
+
+    fx.startEngine();
+    std::vector<float> unmuted = fx.render();
+    const double unmutedAmp = toneAmplitude(unmuted, 220.0, kSampleRate);
+    require(unmutedAmp > 1e-3, "V1-post: unmuted post-fader send must reach master");
+
+    fx.src->setMute(true);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> muted = fx.render();
+    const double mutedAmp = toneAmplitude(muted, 220.0, kSampleRate);
+    require(mutedAmp < 1e-4, "V1-post: muted source post-fader send must be silent");
+    fx.stop();
+
+    std::cout << "V1 post-fader dies on mute: unmuted=" << unmutedAmp << " muted=" << mutedAmp << "\n";
+}
+
+// ============================================================================
+// V2 — solo + sidechain
+// ============================================================================
+void testV2SidechainNeverEntersAudibleMix() {
+    Fixture fx("v2mix");
+    fx.initEngine();
+    fx.srcUnit = fx.addUnit(fx.src, "src", 220.0); // sidechain key source
+    fx.dstUnit = fx.addUnit(fx.dst, "dst", 440.0); // destination's own signal
+    fx.schedulePattern();
+
+    // Dst -> master. Src main -> master too (own audible path, distinct freq).
+    AudioRoute sidechain;
+    sidechain.targetChannelId = fx.dst->getChannelId();
+    sidechain.gain = 1.0f;
+    sidechain.sidechainOnly = true;
+    fx.src->addSend(sidechain);
+
+    // Without a sidechain consumer the destination output must be IDENTICAL
+    // with and without the sidechain edge — the key never enters the mix.
+    fx.startEngine();
+    std::vector<float> withEdge = fx.render();
+    fx.stop();
+
+    fx.src->removeSend(fx.src->getSends()[0].sendId);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> withoutEdge = fx.render();
+    fx.stop();
+
+    const double ampWith = toneAmplitude(withEdge, 440.0, kSampleRate);
+    const double ampWithout = toneAmplitude(withoutEdge, 440.0, kSampleRate);
+    require(std::abs(ampWith - ampWithout) < 1e-6,
+            "V2: sidechain edge must never contribute to the destination's audible mix");
+    require(ampWith > 1e-3, "V2: destination's own signal must render");
+    std::cout << "V2 key never in mix: with=" << ampWith << " without=" << ampWithout << "\n";
+}
+
+void testV2KeyFollowsSourceSoloState() {
+    Fixture fx("v2solo");
+    fx.initEngine();
+    fx.srcUnit = fx.addUnit(fx.src, "src", 220.0); // sidechain key source
+    fx.dstUnit = fx.addUnit(fx.dst, "dst", 440.0); // destination own signal
+    fx.schedulePattern();
+
+    AudioRoute sidechain;
+    sidechain.targetChannelId = fx.dst->getChannelId();
+    sidechain.gain = 1.0f;
+    sidechain.sidechainOnly = true;
+    fx.src->addSend(sidechain);
+    require(fx.dst->getEffectChain().insertPlugin(0, std::make_shared<SidechainGainPlugin>()),
+            "V2: sidechain observer plugin inserted");
+
+    // Baseline: no solo — key flows; Dst output scaled by the key.
+    fx.startEngine();
+    std::vector<float> noSolo = fx.render();
+    const double noSoloAmp = toneAmplitude(noSolo, 440.0, kSampleRate);
+    require(noSoloAmp > 1e-3, "V2: destination signal must render");
+
+    // Solo Dst only: Dst eligible, Src not -> key silenced (follows source).
+    fx.dst->setSolo(true);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> dstSoloed = fx.render();
+    const double dstSoloAmp = toneAmplitude(dstSoloed, 440.0, kSampleRate);
+    require(dstSoloAmp > 1e-3, "V2: soloed destination must still render its own signal");
+
+    // Solo Src too: key flows again.
+    fx.src->setSolo(true);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> bothSoloed = fx.render();
+    const double bothSoloAmp = toneAmplitude(bothSoloed, 440.0, kSampleRate);
+    require(bothSoloAmp > 1e-3, "V2: both soloed must render");
+    fx.stop();
+
+    std::cout << "V2 key follows solo state: noSolo=" << noSoloAmp << " dstSolo=" << dstSoloAmp
+              << " bothSolo=" << bothSoloAmp << "\n";
+    // The key-scaled output must be measurably louder than the key-silenced
+    // one. Sampler gain staging makes the key scale ~1.15x, so discriminate
+    // at 0.92/0.95 rather than assuming a doubling.
+    require(dstSoloAmp < noSoloAmp * 0.92, "V2: non-soloed source key must be silenced in solo context");
+    require(bothSoloAmp > noSoloAmp * 0.95, "V2: soloed source key must flow again");
+}
+
+// ============================================================================
+// V3 — muted + solo context + pre-fader sidechain
+// ============================================================================
+void testV3CombinedOrdering() {
+    Fixture fx("v3");
+    fx.initEngine();
+    fx.srcUnit = fx.addUnit(fx.src, "src", 220.0);
+    fx.dstUnit = fx.addUnit(fx.dst, "dst", 440.0);
+    fx.schedulePattern();
+
+    AudioRoute sidechain;
+    sidechain.targetChannelId = fx.dst->getChannelId();
+    sidechain.gain = 1.0f;
+    sidechain.sidechainOnly = true;
+    sidechain.postFader = false; // pre-fader tap
+    fx.src->addSend(sidechain);
+    require(fx.dst->getEffectChain().insertPlugin(0, std::make_shared<SidechainGainPlugin>()),
+            "V3: sidechain observer plugin inserted");
+
+    // V3a: muted source, NO solo context -> pre-fader tap bypasses the mute
+    // gate, key arrives, destination output scaled.
+    fx.src->setMute(true);
+    fx.startEngine();
+    std::vector<float> mutedNoSolo = fx.render();
+    const double mutedNoSoloAmp = toneAmplitude(mutedNoSolo, 440.0, kSampleRate);
+    require(mutedNoSoloAmp > 1e-3, "V3a: destination must render");
+    fx.stop();
+
+    // V3b: muted source + solo context (Dst soloed, Src not) -> solo gate
+    // beats the pre-fader tap; key silenced.
+    fx.dst->setSolo(true);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> mutedSolo = fx.render();
+    const double mutedSoloAmp = toneAmplitude(mutedSolo, 440.0, kSampleRate);
+    require(mutedSoloAmp > 1e-3, "V3b: soloed destination must render its own signal");
+    fx.stop();
+
+    // V3c: muted source + POST-fader sidechain, no solo -> mute gate beats
+    // the tap; key silenced.
+    {
+        const auto sends = fx.src->getSends();
+        auto post = sends[0];
+        post.postFader = true;
+        fx.src->setSend(sends[0].sendId, post);
+    }
+    fx.dst->setSolo(false);
+    fx.engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*fx.tm));
+    fx.startEngine();
+    std::vector<float> mutedPost = fx.render();
+    const double mutedPostAmp = toneAmplitude(mutedPost, 440.0, kSampleRate);
+    require(mutedPostAmp > 1e-3, "V3c: destination must render");
+    fx.stop();
+
+    std::cout << "V3 ordering: muted+noSolo(preFader)=" << mutedNoSoloAmp
+              << " muted+solo(preFader)=" << mutedSoloAmp << " muted(postFader)=" << mutedPostAmp << "\n";
+    require(mutedSoloAmp < mutedNoSoloAmp * 0.92,
+            "V3: solo gate must silence the pre-fader key of a non-soloed muted source");
+    require(mutedPostAmp < mutedNoSoloAmp * 0.92,
+            "V3: mute gate must silence a post-fader key");
+}
+
+} // namespace
+
+int main() {
+    if (!PluginManager::getInstance().initialize()) {
+        std::cerr << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+    testV1PreFaderSurvivesMute();
+    testV1PostFaderDiesOnMute();
+    testV2SidechainNeverEntersAudibleMix();
+    testV2KeyFollowsSourceSoloState();
+    testV3CombinedOrdering();
+
+    if (g_failures == 0) {
+        std::cout << "[PASS] RoutingRenderSemanticsTest\n";
+        return 0;
+    }
+    std::cerr << g_failures << " RoutingRenderSemantics test(s) failed\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -684,6 +684,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerCutSelfTest.cpp")
     set_tests_properties(SamplerCutSelfTest PROPERTIES LABELS "audio;sampler;regression;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/RoutingContractTest.cpp")
+    add_executable(RoutingContractTest AestraAudio/RoutingContractTest.cpp)
+    target_link_libraries(RoutingContractTest PRIVATE AestraAudio)
+    target_include_directories(RoutingContractTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME RoutingContractTest COMMAND RoutingContractTest)
+    set_tests_properties(RoutingContractTest PROPERTIES LABELS "audio;routing;contract:audio")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerLoopModeTest.cpp")
     add_executable(SamplerLoopModeTest AestraAudio/SamplerLoopModeTest.cpp)
     target_link_libraries(SamplerLoopModeTest PRIVATE AestraAudio)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -696,6 +696,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/RoutingContractTest.cpp")
     set_tests_properties(RoutingContractTest PROPERTIES LABELS "audio;routing;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/RoutingRenderSemanticsTest.cpp")
+    add_executable(RoutingRenderSemanticsTest AestraAudio/RoutingRenderSemanticsTest.cpp)
+    target_link_libraries(RoutingRenderSemanticsTest PRIVATE AestraAudio)
+    target_include_directories(RoutingRenderSemanticsTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME RoutingRenderSemanticsTest COMMAND RoutingRenderSemanticsTest)
+    set_tests_properties(RoutingRenderSemanticsTest PROPERTIES LABELS "audio;routing;contract:audio")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerLoopModeTest.cpp")
     add_executable(SamplerLoopModeTest AestraAudio/SamplerLoopModeTest.cpp)
     target_link_libraries(SamplerLoopModeTest PRIVATE AestraAudio)

--- a/Tests/Commands/LatencyReportTest.cpp
+++ b/Tests/Commands/LatencyReportTest.cpp
@@ -163,11 +163,14 @@ void testBranchCompensationAndSidechainLimitation() {
               "main branch exposes matched solver and RT compensation");
         check((*sendEdge)["solverCompensationSamples"].asNumber() == 0.0 &&
                   (*sendEdge)["appliedCompensationSamples"].asNumber() == 0.0 &&
-                  (*sendEdge)["positionalIdentityAvailable"].asBool() && (*sendEdge)["sendIndex"].asNumber() == 0.0,
-              "send branch exposes positional identity and applied delay");
+                  (*sendEdge)["stableIdentityAvailable"].asBool() && (*sendEdge)["sendId"].asNumber() != 0.0,
+              "send branch exposes stable send identity and applied delay");
     }
 
-    source->removeSend(0);
+    const auto sourceSends = source->getSends();
+    if (!sourceSends.empty()) {
+        source->removeSend(sourceSends[0].sendId);
+    }
     send.sidechainOnly = true;
     source->addSend(send);
     fx.engine.calculateLatencyCompensation();
@@ -178,9 +181,9 @@ void testBranchCompensationAndSidechainLimitation() {
               hasIssueCode(degraded["uncompensatedPaths"], "sidechain_latency_compensation_unavailable"),
           "sidechain path is explicitly reported as uncompensated");
     check(degraded["uncompensatedPaths"][0]["evidence"]["stableEndpointIdentityAvailable"].asBool() &&
-              degraded["uncompensatedPaths"][0]["evidence"]["positionalIdentityAvailable"].asBool() &&
-              degraded["uncompensatedPaths"][0]["evidence"]["sendIndex"].asNumber() == 0.0,
-          "uncompensated sidechain evidence identifies stable endpoints and positional send");
+              degraded["uncompensatedPaths"][0]["evidence"]["stableSendIdAvailable"].asBool() &&
+              degraded["uncompensatedPaths"][0]["evidence"]["sendId"].asNumber() != 0.0,
+          "uncompensated sidechain evidence identifies stable endpoints and send identity");
 }
 
 void testPendingSolveStaysObservational() {
@@ -272,7 +275,10 @@ void testRoutingEditIsReportedWithoutCascading() {
     // Remove the *first* send behind the published solve. Every later send
     // shifts down a slot, which is precisely the case positional pairing got
     // wrong: it reported every subsequent edge as unmappable.
-    source->removeSend(0);
+    const auto preEditSends = source->getSends();
+    if (!preEditSends.empty()) {
+        source->removeSend(preEditSends[0].sendId);
+    }
 
     JSON response = call(fx.service, R"({"id":11,"verb":"get_latency_report"})");
     JSON& report = response["result"];

--- a/Tests/Commands/LatencyReportTest.cpp
+++ b/Tests/Commands/LatencyReportTest.cpp
@@ -163,7 +163,7 @@ void testBranchCompensationAndSidechainLimitation() {
               "main branch exposes matched solver and RT compensation");
         check((*sendEdge)["solverCompensationSamples"].asNumber() == 0.0 &&
                   (*sendEdge)["appliedCompensationSamples"].asNumber() == 0.0 &&
-                  (*sendEdge)["stableIdentityAvailable"].asBool() && (*sendEdge)["sendId"].asNumber() != 0.0,
+                  (*sendEdge)["stableIdentityAvailable"].asBool() && !(*sendEdge)["sendId"].asString().empty(),
               "send branch exposes stable send identity and applied delay");
     }
 
@@ -182,7 +182,7 @@ void testBranchCompensationAndSidechainLimitation() {
           "sidechain path is explicitly reported as uncompensated");
     check(degraded["uncompensatedPaths"][0]["evidence"]["stableEndpointIdentityAvailable"].asBool() &&
               degraded["uncompensatedPaths"][0]["evidence"]["stableSendIdAvailable"].asBool() &&
-              degraded["uncompensatedPaths"][0]["evidence"]["sendId"].asNumber() != 0.0,
+              !degraded["uncompensatedPaths"][0]["evidence"]["sendId"].asString().empty(),
           "uncompensated sidechain evidence identifies stable endpoints and send identity");
 }
 

--- a/Tests/Commands/ProjectLoadReportTest.cpp
+++ b/Tests/Commands/ProjectLoadReportTest.cpp
@@ -191,6 +191,70 @@ int main() {
     check(response["status"].asString() == "validation_error",
           "get_project_load_report rejects arguments");
 
+    // 9. Routing repair at load (Contract I8/D3/D4): dangling mains reroute to
+    // master; dangling sends and sends to master are removed with diagnostics.
+    {
+        Aestra::Tests::ScopedTempDirectory repairTemp("routing_repair");
+        auto source = makeTracks();
+        auto* ch1 = source->addChannelWithId("A", 71);
+        auto* ch2 = source->addChannelWithId("B", 72);
+        check(ch1 != nullptr && ch2 != nullptr, "routing repair fixture channels created");
+        if (ch1 && ch2) {
+            ch1->setMainOutputId(72);
+            Aestra::Audio::AudioRoute send;
+            send.targetChannelId = 72;
+            ch1->addSend(send);
+
+            const std::filesystem::path path = repairTemp.path() / "dangling.aes";
+            check(ProjectSerializer::save(path.string(), source, 120.0, 0.0),
+                  "routing repair fixture saved");
+            if (std::filesystem::exists(path)) {
+                // Corrupt the saved routing: dangling main, send to master, dangling send.
+                std::ifstream in(path);
+                std::stringstream buffer;
+                buffer << in.rdbuf();
+                JSON root = JSON::parse(buffer.str());
+                for (size_t ci = 0; ci < root["mixerChannels"].size(); ++ci) {
+                    JSON& ch = root["mixerChannels"][ci];
+                    if (ch["id"].asNumber() == 71.0) {
+                        ch["routing"]["mainOutputId"] = 999999.0;
+                        ch["routing"]["sends"][0]["targetId"] = 0.0; // master
+                        JSON extra = JSON::object();
+                        extra.set("targetId", JSON(999999.0));
+                        extra.set("gain", JSON(1.0));
+                        extra.set("pan", JSON(0.0));
+                        extra.set("postFader", JSON(true));
+                        extra.set("mute", JSON(false));
+                        extra.set("sidechainOnly", JSON(false));
+                        ch["routing"]["sends"].push(extra);
+                    }
+                }
+                std::ofstream out(path);
+                out << root.toString();
+                out.close();
+
+                auto repairedTracks = makeTracks();
+                auto repairedResult = ProjectSerializer::load(path.string(), repairedTracks);
+                JSON repairedReport =
+                    makeMuseProjectLoadReport(repairedResult, MuseProjectLoadOrigin::Canonical);
+                check(repairedResult.ok, "corrupt-routing project still loads");
+                auto* repairedA = repairedTracks->getChannel(0);
+                check(repairedA != nullptr &&
+                          repairedA->getMainOutputId() == 0xFFFFFFFFu,
+                      "dangling main output rerouted to master at load");
+                check(repairedA != nullptr && repairedA->getSends().empty(),
+                      "master send and dangling send removed at load");
+                bool routingIssueReported = false;
+                for (size_t wi = 0; wi < repairedReport["warnings"].size(); ++wi) {
+                    if (repairedReport["warnings"][wi]["issueCode"].asString() == "routing_repaired") {
+                        routingIssueReported = true;
+                    }
+                }
+                check(routingIssueReported, "routing repairs are surfaced as diagnostics");
+            }
+        }
+    }
+
     if (g_failures == 0) {
         std::cout << "All ProjectLoadReport tests passed\n";
         return 0;

--- a/Tests/Commands/ProjectLoadReportTest.cpp
+++ b/Tests/Commands/ProjectLoadReportTest.cpp
@@ -191,6 +191,34 @@ int main() {
     check(response["status"].asString() == "validation_error",
           "get_project_load_report rejects arguments");
 
+    // 8b. Wide send ids survive the project round trip exactly (Contract D2:
+    // ids above 2^53 must not be mangled by JSON doubles).
+    {
+        Aestra::Tests::ScopedTempDirectory wideTemp("wide_send_id");
+        auto wideSource = makeTracks();
+        auto* wideChannel = wideSource->addChannelWithId("Wide", 81);
+        auto* wideTarget = wideSource->addChannelWithId("WideTarget", 82);
+        check(wideChannel != nullptr && wideTarget != nullptr, "wide-id fixture channels created");
+        if (wideChannel && wideTarget) {
+            Aestra::Audio::AudioRoute wideSend;
+            wideSend.targetChannelId = wideTarget->getChannelId(); // master sends are illegal (D4)
+            wideSend.sendId = 9007199254740993ull;
+            wideChannel->addSend(wideSend);
+            const std::filesystem::path widePath = wideTemp.path() / "wide.aes";
+            check(ProjectSerializer::save(widePath.string(), wideSource, 120.0, 0.0),
+                  "wide-id project saved");
+            if (std::filesystem::exists(widePath)) {
+                auto wideTracks = makeTracks();
+                auto wideResult = ProjectSerializer::load(widePath.string(), wideTracks);
+                check(wideResult.ok, "wide-id project loads");
+                auto* loadedWide = wideTracks->getChannel(0);
+                check(loadedWide != nullptr && loadedWide->getSends().size() == 1 &&
+                          loadedWide->getSends()[0].sendId == 9007199254740993ull,
+                      "a send id above 2^53 survives the project round trip exactly");
+            }
+        }
+    }
+
     // 9. Routing repair at load (Contract I8/D3/D4): dangling mains reroute to
     // master; dangling sends and sends to master are removed with diagnostics.
     {

--- a/Tests/Commands/RoutingGraphTest.cpp
+++ b/Tests/Commands/RoutingGraphTest.cpp
@@ -90,6 +90,12 @@ int main() {
     masterSend.pan = -0.2f;
     masterSend.postFader = false;
     drums->addSend(masterSend);
+    // A send id beyond 2^53 - 1 must survive Muse diagnostics exactly (the
+    // stable-id contract is durable; doubles cannot carry it).
+    AudioRoute wideIdSend{};
+    wideIdSend.targetChannelId = bus->getChannelId();
+    wideIdSend.sendId = 9007199254740993ull;
+    drums->addSend(wideIdSend);
     AudioRoute busSidechain{};
     busSidechain.targetChannelId = bus->getChannelId();
     busSidechain.sidechainOnly = true;
@@ -129,7 +135,7 @@ int main() {
               graph["unresolvedRoutes"].size() == 0,
           "resolved project-model topology reports no unresolved routes");
     check(graph["sources"].size() == 2 && graph["destinations"].size() == 3 &&
-              graph["mainRoutes"].size() == 2 && graph["sends"].size() == 2,
+              graph["mainRoutes"].size() == 2 && graph["sends"].size() == 3,
           "graph exposes sources, destinations, main paths, and sends");
 
     JSON* drumsDestination = findByString(graph["destinations"], "nodeId", "mixer:41");
@@ -170,15 +176,23 @@ int main() {
     check(drumsMain != nullptr && (*drumsMain)["resolved"].asBool() &&
               (*drumsMain)["destinationNodeId"].asString() == "mixer:77",
           "main route resolves stable mixer destination");
+    bool wideIdExact = false;
+    for (size_t si = 0; si < graph["sends"].size(); ++si) {
+        if (graph["sends"][si].has("sendId") &&
+            graph["sends"][si]["sendId"].asString() == "9007199254740993") {
+            wideIdExact = true;
+        }
+    }
+    check(wideIdExact, "a send id above 2^53 survives diagnostics exactly");
     JSON& send = graph["sends"][0];
     check(send["destinationNodeId"].asString() == "master" &&
               send["routeType"].asString() == "send" &&
               send["stableIdentityAvailable"].asBool() &&
-              send["sendId"].asNumber() != 0.0 &&
+              !send["sendId"].asString().empty() &&
               !send["positionalIdentityAvailable"].asBool() &&
               !send["postFader"].asBool(),
           "send exposes topology and stable send identity");
-    JSON& sidechain = graph["sends"][1];
+    JSON& sidechain = graph["sends"][2];
     check(sidechain["destinationNodeId"].asString() == "mixer:77" &&
               sidechain["routeType"].asString() == "sidechain_send" &&
               sidechain["sidechainOnly"].asBool(),

--- a/Tests/Commands/RoutingGraphTest.cpp
+++ b/Tests/Commands/RoutingGraphTest.cpp
@@ -173,11 +173,11 @@ int main() {
     JSON& send = graph["sends"][0];
     check(send["destinationNodeId"].asString() == "master" &&
               send["routeType"].asString() == "send" &&
-              send["sendIndex"].asNumber() == 0.0 &&
-              !send["stableIdentityAvailable"].asBool() &&
-              send["positionalIdentityAvailable"].asBool() &&
+              send["stableIdentityAvailable"].asBool() &&
+              send["sendId"].asNumber() != 0.0 &&
+              !send["positionalIdentityAvailable"].asBool() &&
               !send["postFader"].asBool(),
-          "send exposes topology and positional identity");
+          "send exposes topology and stable send identity");
     JSON& sidechain = graph["sends"][1];
     check(sidechain["destinationNodeId"].asString() == "mixer:77" &&
               sidechain["routeType"].asString() == "sidechain_send" &&

--- a/Tests/Headless/PDCEngineEdgeConstructionTest.cpp
+++ b/Tests/Headless/PDCEngineEdgeConstructionTest.cpp
@@ -374,7 +374,10 @@ void testApplyPassClearsStaleSendDelays() {
     EXPECT_EQ(first.sendEdgeDelays[0].compensationSamples, 0u);
 
     // Remove the send and recompute. The slot's compensation must go to zero.
-    trackC->removeSend(0);
+    const auto trackCSends = trackC->getSends();
+    if (!trackCSends.empty()) {
+        trackC->removeSend(trackCSends[0].sendId);
+    }
     fx.engine.calculateLatencyCompensation();
     const auto second = fx.engine.getTrackEdgeDelaySnapshot(0);
     EXPECT_TRUE(second.valid);

--- a/Tests/Headless/RoutingSendPanParityTest.cpp
+++ b/Tests/Headless/RoutingSendPanParityTest.cpp
@@ -180,9 +180,11 @@ std::vector<float> renderConfig(float mainPan, const SendSpec& send) {
 
     MixerChannel* src = trackManager->addChannel("src");
     MixerChannel* sink = trackManager->addChannel("sink");
+    MixerChannel* bus = trackManager->addChannel("bus");
     EXPECT_TRUE(src != nullptr);
     EXPECT_TRUE(sink != nullptr);
-    if (!src || !sink) {
+    EXPECT_TRUE(bus != nullptr);
+    if (!src || !sink || !bus) {
         return {};
     }
 
@@ -192,8 +194,10 @@ std::vector<float> renderConfig(float mainPan, const SendSpec& send) {
 
     if (send.enabled) {
         src->setMainOutputId(sink->getChannelId()); // Keep the direct path out of the master mix
+        // Sends to master are illegal (Contract D4): route the send into a
+        // bus that feeds master, preserving the measurement path.
         AudioRoute route;
-        route.targetChannelId = kMasterId;
+        route.targetChannelId = bus->getChannelId();
         route.gain = send.gain;
         route.pan = send.pan;
         route.postFader = send.postFader;

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -527,40 +527,44 @@ void testUnresolvedRouteTargetNonFatal() {
     auto trackManager = std::make_shared<TrackManager>();
     auto result = ProjectSerializer::load(testProject.string(), trackManager);
 
-    // Load must succeed — unresolved sends must not cause errors.
+    // Load must succeed — routing repair must not cause errors.
     assert(result.ok);
 
-    // Verify the channel was created and has the sends (both the
-    // unresolvable and the resolvable master send).
+    // Verify the channel was created. Both sends are illegal under the
+    // routing contract and are repaired at load: the send to nonexistent
+    // channel 99 is a dangling route (D3) and the send to master (targetId 0)
+    // is forbidden (D4). Neither survives; both are diagnosed.
     assert(trackManager->getChannelCount() == 1);
     auto* channel = trackManager->getChannel(0);
     assert(channel != nullptr);
 
     const auto sends = channel->getSends();
-    assert(sends.size() == 2);
+    assert(sends.empty());
 
-    // The unresolvable send to channel 99 is preserved in the channel
-    // but silently ignored by the audio runtime (INVALID_SLOT check).
-    // ProjectSerializer logs a warning for unresolved send targets during load.
-    bool foundUnresolvable = false;
-    bool foundMaster = false;
-    for (const auto& send : sends) {
-        if (send.targetChannelId == 99) {
-            foundUnresolvable = true;
-        }
-        if (send.targetChannelId == 0xFFFFFFFFu) {
-            foundMaster = true;
+    bool danglingDiagnosed = false;
+    bool masterDiagnosed = false;
+    if (result.report) {
+        for (const auto& issue : result.report->issues) {
+            if (issue.category == "routing") {
+                if (issue.message.find("which does not exist") != std::string::npos) {
+                    danglingDiagnosed = true;
+                }
+                if (issue.message.find("sends to master are illegal") != std::string::npos) {
+                    masterDiagnosed = true;
+                }
+            }
         }
     }
-    assert(foundUnresolvable);
-    assert(foundMaster);
+    assert(danglingDiagnosed);
+    assert(masterDiagnosed);
 
-    // Verify that saving and reloading preserves the routing (no data loss).
+    // Verify that saving and reloading stays clean (no resurrected bad routes).
     std::string saved = ProjectSerializer::serialize(trackManager, 120.0, 0.0, 0).contents;
     assert(!saved.empty());
-    assert(saved.find("\"targetId\": 99") != std::string::npos || saved.find("\"targetId\":99") != std::string::npos);
+    assert(saved.find("\"targetId\": 99") == std::string::npos &&
+           saved.find("\"targetId\":99") == std::string::npos);
 
-    // Load the re-saved project and verify routing is still preserved.
+    // Load the re-saved project and verify routing is still clean.
     std::filesystem::path testProject2 = testDir / "project2.aes";
     std::ofstream out2(testProject2);
     out2 << saved;
@@ -572,13 +576,12 @@ void testUnresolvedRouteTargetNonFatal() {
 
     auto* channel2 = trackManager2->getChannel(0);
     assert(channel2 != nullptr);
-    const auto sends2 = channel2->getSends();
-    assert(sends2.size() == 2);
+    assert(channel2->getSends().empty());
 
     // Verify the mainOutputId is stable after round-trip
     assert(channel2->getMainOutputId() == channel->getMainOutputId());
 
-    std::cout << "[PASS] Unresolved send routing targets are non-fatal" << std::endl;
+    std::cout << "[PASS] Unresolved and master send routes are repaired at load (non-fatal)" << std::endl;
 }
 
 void testV1FixtureMigratesToCurrentVersion() {
@@ -941,7 +944,7 @@ void testProjectLoadWarningsAreBounded() {
         if (entry.message.find("Send from '") != std::string::npos) {
             ++sendWarnings;
         }
-        if (entry.message.find("Additional unresolved send route warnings suppressed") != std::string::npos) {
+        if (entry.message.find("Additional routing repair warnings suppressed") != std::string::npos) {
             ++suppressedWarnings;
         }
     }


### PR DESCRIPTION
## Summary

The routing contract implementation (`Aestra-Internals: 03 Audio Engine/Routing Contract.md`): routing mutations become undoable validated commands, cycles are rejected at mutation time (not discovered at render), sends get stable identity, dangling routes and master-route illegality are enforced everywhere, and the render path now realizes the pinned pre-fader/mute/solo/sidechain semantics.

## Why

Routing was mutated directly from the view model (no undo, no validation seam), cycles were "handled" by appending leftover nodes to the render order, sends were identified by array position (the same identity flaw automation has), and the renderer silently dropped dangling routes. The contract codifies the semantics; this PR makes the code realize them.

## What changed (6 commits)

1. **D5/D1 — command seam + mutation-time cycle rejection**: `TrackManager::canRouteTo` is the single validation authority (self/cycle/dangling rejected; master terminal; both master spellings). New `RoutingCommands.h` (SetMainOutput/AddSend/RemoveSend/EditSend) — all undoable, validated, rebuild-aware. `AudioEngine::setGraph` refuses cyclic snapshots; the compiler no longer papers over cycles.
2. **D2 — stable send IDs**: `AudioRoute.sendId` minted per channel, preserved through undo/redo (round trip), serialization (legacy projects mint on load), UI callbacks and Muse evidence. All positional send setters deleted.
3. **D3/D4 — dangling prevention + master legality**: add-channel undo applies the I8 deletion policy atomically with route round-trip on redo; compiler reports dropped edges; load-time repairs (dangling main → master, dangling/master sends removed) with diagnostics (`routing_repaired`); sends to master rejected at command/VM/load layers; master never a routing source.
4. **V1–V3 — render semantics verified + fixed**: the render path proved three divergences from the contract — pre-fader sends died on mute (send loop sat inside the mute gate), sidechain key input ignored solo state, audible sends gated by source eligibility instead of destination. All fixed; new `RoutingRenderSemanticsTest` pins each with render-level buffer assertions (test plugin observes the sidechain key through the destination output).
5. **Parity**: the offline bounce path drops master-target sends to match D4; two legacy tests rewired from master sends to real buses.

## Testing performed

- `RoutingContractTest` (canRouteTo contract cases, command round-trips, send identity: monotonic mint / edit-after-shift / no reuse / full unwind, master legality, add-channel undo/redo routing round-trip, snapshot cycle handling).
- `RoutingRenderSemanticsTest` (V1 pre/post-fader vs mute, V2 solo+sidechain incl. bit-identical "key never in mix", V3 ordering) — assertions on rendered buffers, not branches.
- `LatencyReportTest`/`RoutingGraphTest`/`ProjectLoadReportTest`/`ProjectLoadRegressionTest`/`PDCEngineEdgeConstructionTest` updated to stable send identity and the repair contract.
- Full suite: 238/238 ctest. App builds. `git diff --check` clean.

## Producer note

Routing changes are now undoable — Ctrl+Z works on reroutes and sends, and routing loops are blocked instead of silently breaking audio.

## Docs updated

- `Aestra-Internals: 03 Audio Engine/Routing Contract.md` (contract + implementation status; internal vault, not this repo).

## Risk / rollback notes

- **Behavior change**: pre-fader sends now survive source mute (contract-correct, DAW-standard; previously they went silent). Soloed destinations now receive their inputs from non-soloed sources. Sends to master are no longer creatable (legacy projects have them removed at load with diagnostics).
- The offline/bounce render path still needs a pre-fader tap parity check against the live path (flagged in the contract doc; the offline path routes sends post-effects).
- UI is not headless-testable (#666): mixer/routing-map interactions need a manual pass.
- Revert strategy: the six commits are separable; D5/D1 (commit 1) is the foundation, V1–V3 (commit 6) the render-semantics fixes.

Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Breaking change:** Send operations now use stable `uint64_t sendId` values instead of positional send indices.
- Routing mutations now use undoable commands with centralized validation and cycle rejection.
- Master sends, self-routes, and dangling routes are blocked or repaired during project load.
- Send IDs persist through editing, undo/redo, serialization, and routing reports, including IDs above `2^53`.
- Live rendering now follows the defined mute, solo, pre-fader, post-fader, and sidechain rules.
- Added routing contract, render semantics, and load-repair regression tests. All 238 tests pass.
- Manual UI testing remains required. Offline pre-fader tap parity still needs verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->