### PR TITLE
fix: automation identity contract — v2 wire format, instance-based resolution, reorder command

### DIFF
--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -241,10 +241,12 @@ public:
             return;
         }
         auto& chain = m_channel.getEffectChain();
-        if (m_usedSwap) {
-            chain.swapPlugins(m_toSlot, m_fromSlot);
-        } else {
-            chain.movePlugin(m_toSlot, m_fromSlot);
+        // A refused revert must not leave the history believing the reorder
+        // was undone while the chain still holds the moved layout.
+        const bool reverted = m_usedSwap ? chain.swapPlugins(m_toSlot, m_fromSlot)
+                                         : chain.movePlugin(m_toSlot, m_fromSlot);
+        if (!reverted) {
+            throw std::runtime_error("MovePlugin: undo refused by the chain");
         }
         m_executed = false;
         m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);

--- a/AestraAudio/include/Commands/EffectCommands.h
+++ b/AestraAudio/include/Commands/EffectCommands.h
@@ -193,5 +193,76 @@ private:
     bool m_executed = false;
 };
 
+/**
+ * @brief Undoable reorder of a plugin within a chain (Automation Identity
+ * Contract I7).
+ *
+ * The instance identity travels with the plugin (movePlugin/swapPlugins carry
+ * it), so a reorder is a rearrangement, never a retarget: automation addressed
+ * by deviceInstanceId is untouched. Undo restores the exact original ordering
+ * and identities; redo reapplies. Nothing is minted, regenerated, or swapped
+ * as a side effect. Invalid moves throw, leaving both the chain and the
+ * command history untouched.
+ */
+class MovePluginCommand : public ICommand {
+public:
+    MovePluginCommand(TrackManager& trackManager, MixerChannel& channel, size_t fromSlot, size_t toSlot)
+        : m_trackManager(trackManager), m_channel(channel), m_fromSlot(fromSlot), m_toSlot(toSlot) {}
+
+    void execute() override {
+        auto& chain = m_channel.getEffectChain();
+        if (m_fromSlot >= EffectChain::MAX_SLOTS || m_toSlot >= EffectChain::MAX_SLOTS) {
+            throw std::runtime_error("MovePlugin: slot out of range");
+        }
+        if (m_fromSlot == m_toSlot) {
+            throw std::runtime_error("MovePlugin: source and destination are the same slot");
+        }
+        if (chain.getSlot(m_fromSlot) == nullptr || chain.getSlot(m_fromSlot)->isEmpty()) {
+            throw std::runtime_error("MovePlugin: source slot is empty");
+        }
+        const auto* target = chain.getSlot(m_toSlot);
+        const bool targetEmpty = !target || target->isEmpty();
+        if (targetEmpty) {
+            if (!chain.movePlugin(m_fromSlot, m_toSlot)) {
+                throw std::runtime_error("MovePlugin: move refused by the chain");
+            }
+            m_usedSwap = false;
+        } else {
+            if (!chain.swapPlugins(m_fromSlot, m_toSlot)) {
+                throw std::runtime_error("MovePlugin: swap refused by the chain");
+            }
+            m_usedSwap = true;
+        }
+        m_executed = true;
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+    }
+    void undo() override {
+        if (!m_executed) {
+            return;
+        }
+        auto& chain = m_channel.getEffectChain();
+        if (m_usedSwap) {
+            chain.swapPlugins(m_toSlot, m_fromSlot);
+        } else {
+            chain.movePlugin(m_toSlot, m_fromSlot);
+        }
+        m_executed = false;
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::EffectChainChanged);
+    }
+    void redo() override { execute(); }
+
+    std::string getName() const override { return "Move Plugin"; }
+    bool changesProjectState() const override { return true; }
+    std::string type() const override { return "move_plugin"; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    size_t m_fromSlot;
+    size_t m_toSlot;
+    bool m_usedSwap = false;
+    bool m_executed = false;
+};
+
 } // namespace Audio
 } // namespace Aestra

--- a/AestraAudio/include/Core/AutomationCurve.h
+++ b/AestraAudio/include/Core/AutomationCurve.h
@@ -58,11 +58,15 @@ struct AutomationCurve {
     float defaultValue{0.0f};
 
     // Plugin-parameter addressing — meaningful only when target == Custom.
-    // effectSlot indexes the lane's channel effect chain; paramId is the
-    // plugin's stable parameter id (stability guaranteed per AGENTS.md §19).
+    // deviceInstanceId is the semantic target (Automation Identity Contract):
+    // which plugin instance, resolved through the chain snapshot's
+    // findSlotByInstanceId. effectSlot is LEGACY — kept only for v1 project
+    // migration and older-build compatibility; it never participates in
+    // resolution. paramId is the plugin's stable parameter id (AGENTS.md §19).
     // The engine applies Custom curves to Internal-format plugins only:
     // their parameter storage is atomic, so per-block setParameter from the
     // render thread is RT-safe; third-party formats need host param queues.
+    uint64_t deviceInstanceId{0};
     uint32_t effectSlot{0};
     uint32_t paramId{0};
 

--- a/AestraAudio/include/Plugin/EffectChain.h
+++ b/AestraAudio/include/Plugin/EffectChain.h
@@ -155,7 +155,11 @@ public:
     // on-disk layout changes and add a migration branch in loadState() so older
     // chains keep loading. loadState() reads this byte and dispatches on it rather
     // than hard-rejecting anything != the current version.
-    static constexpr uint8_t kStateFormatVersion = 1;
+    //
+    // v2 (Automation Identity Contract I4/I5): every occupied slot carries its
+    // 8-byte instance id after the hasPlugin flag. v1 payloads (no ids) still
+    // load and mint (migration rule).
+    static constexpr uint8_t kStateFormatVersion = 2;
 
     EffectChain();
     ~EffectChain();

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2983,12 +2983,20 @@ void AudioEngine::renderTrack(const AudioGraph& graph, size_t orderedIndex, cons
                 // and manual edits share one smoother and never cascade into
                 // double-smoothing. Every internal effect honors this (Drift
                 // was the last to gain per-sample Mix/Pitch smoothing).
-                if (track.effectChainSnapshot && curve.effectSlot < EffectChainSnapshot::MAX_SLOTS) {
-                    const auto& slot = track.effectChainSnapshot->slot(curve.effectSlot);
-                    if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {
-                        const float value = curve.getValueAtBeat(currentBeat);
-                        if (std::isfinite(value)) {
-                            slot.plugin->setParameter(curve.paramId, value);
+                // Automation Identity Contract: resolve by instance id, never
+                // by slot position. A curve whose instance is gone (dangling)
+                // is skipped — it is never re-pointed at whatever now occupies
+                // a slot.
+                if (track.effectChainSnapshot && curve.deviceInstanceId != 0) {
+                    const size_t slotIndex =
+                        track.effectChainSnapshot->findSlotByInstanceId(curve.deviceInstanceId);
+                    if (slotIndex < EffectChainSnapshot::MAX_SLOTS) {
+                        const auto& slot = track.effectChainSnapshot->slot(slotIndex);
+                        if (slot.plugin && slot.plugin->getInfo().format == PluginFormat::Internal) {
+                            const float value = curve.getValueAtBeat(currentBeat);
+                            if (std::isfinite(value)) {
+                                slot.plugin->setParameter(curve.paramId, value);
+                            }
                         }
                     }
                 }

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -642,6 +642,7 @@ void EffectChainSnapshot::process(float** buffer, uint32_t numChannels, uint32_t
             continue;
         }
 
+
         float dryWet = slot.dryWetMix;
 
         const PluginInfo& pluginInfo = plugin->getInfo();

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <atomic>
 #include <limits>
+#include <unordered_set>
 #include <cmath>
 #include <cstring>
 
@@ -741,6 +742,11 @@ std::vector<uint8_t> EffectChain::saveState() const {
         if (slot.hasMissingPlugin()) {
             state.push_back(1); // Has plugin flag
 
+            // v2: the placeholder's identity travels with it (Contract I6).
+            const uint64_t placeholderId = slot.instanceId;
+            state.insert(state.end(), reinterpret_cast<const uint8_t*>(&placeholderId),
+                         reinterpret_cast<const uint8_t*>(&placeholderId) + sizeof(placeholderId));
+
             uint32_t idLen = static_cast<uint32_t>(slot.missingPluginId.size());
             state.insert(state.end(), reinterpret_cast<const uint8_t*>(&idLen),
                          reinterpret_cast<const uint8_t*>(&idLen) + sizeof(idLen));
@@ -765,6 +771,11 @@ std::vector<uint8_t> EffectChain::saveState() const {
         }
 
         state.push_back(1); // Has plugin flag
+
+        // v2: the instance identity travels with the instance (Contract I4).
+        const uint64_t slotInstanceId = slot.instanceId;
+        state.insert(state.end(), reinterpret_cast<const uint8_t*>(&slotInstanceId),
+                     reinterpret_cast<const uint8_t*>(&slotInstanceId) + sizeof(slotInstanceId));
 
         // Save plugin ID
         const auto& info = slot.plugin->getInfo();
@@ -826,8 +837,38 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
     size_t offset = 5;
 
+    std::unordered_set<uint64_t> seenLoadedIds;
+    const auto resolveSlotIdentity = [&](uint64_t wireId, size_t slotIndex) -> uint64_t {
+        if (version >= 2 && wireId != 0) {
+            if (!seenLoadedIds.insert(wireId).second) {
+                // Duplicate id in a v2 payload is corrupt: mint a fresh identity
+                // so the two slots never share one (Contract I5).
+                Aestra::Log::warning("[EffectChain] duplicate instance id " + std::to_string(wireId) +
+                                     " in v2 state on slot " + std::to_string(slotIndex) +
+                                     "; minting a fresh identity");
+                return mintPluginInstanceId();
+            }
+            reserveMintedPluginInstanceId(wireId);
+            return wireId;
+        }
+        if (version >= 2) {
+            Aestra::Log::warning("[EffectChain] v2 state carries no instance id on slot " +
+                                 std::to_string(slotIndex) + "; minting (corrupt payload)");
+        }
+        return mintPluginInstanceId();
+    };
+
     for (size_t i = 0; i < MAX_SLOTS && offset < state.size(); ++i) {
         uint8_t hasPlugin = state[offset++];
+
+        uint64_t wireInstanceId = 0;
+        if (hasPlugin && version >= 2) {
+            if (offset + sizeof(uint64_t) > state.size()) {
+                return false;
+            }
+            std::memcpy(&wireInstanceId, &state[offset], sizeof(wireInstanceId));
+            offset += sizeof(wireInstanceId);
+        }
 
         if (!hasPlugin) {
             m_slots[i].plugin = nullptr;
@@ -899,12 +940,10 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
 
             m_slots[i].plugin = std::move(instance);
             m_slots[i].clearMissingPlugin();
-            // v1 chains predate identity, so there is nothing on the wire to
-            // restore — mint. Reserving would be wrong here for the same reason:
-            // there is no persisted id that a future mint could collide with.
-            // When v2 lands, this is the branch that reads the stored id and
-            // calls reserveMintedPluginInstanceId instead (#667).
-            m_slots[i].instanceId = mintPluginInstanceId();
+            // v2 restores the persisted identity (reserving it against future
+            // mints); v1 predates identity and mints. A v2 payload with a
+            // missing/duplicate id mints with a diagnostic (Contract I5).
+            m_slots[i].instanceId = resolveSlotIdentity(wireInstanceId, i);
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();
@@ -923,8 +962,9 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
             m_slots[i].missingPluginState = std::move(pluginState);
             // A placeholder is an occupant, so it gets an identity like any
             // other (#647/#667). Automation addressed to a plugin that failed to
-            // load has to survive the round trip exactly as the placeholder does.
-            m_slots[i].instanceId = mintPluginInstanceId();
+            // load has to survive the round trip exactly as the placeholder does
+            // (Contract I6): v2 restores the persisted id, v1 mints.
+            m_slots[i].instanceId = resolveSlotIdentity(wireInstanceId, i);
             m_slots[i].bypassed.store(bypassed);
             m_slots[i].dryWetMix.store(dryWet);
             m_slots[i].faultState = std::make_shared<EffectSlotFaultState>();

--- a/AestraAudio/src/Plugin/EffectChain.cpp
+++ b/AestraAudio/src/Plugin/EffectChain.cpp
@@ -841,13 +841,25 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
     std::unordered_set<uint64_t> seenLoadedIds;
     const auto resolveSlotIdentity = [&](uint64_t wireId, size_t slotIndex) -> uint64_t {
         if (version >= 2 && wireId != 0) {
+            // UINT64_MAX is the sentinel reserveMintedPluginInstanceId refuses
+            // by design; a payload carrying it is corrupt, same as a duplicate.
+            if (wireId == std::numeric_limits<uint64_t>::max()) {
+                Aestra::Log::warning("[EffectChain] reserved instance id " + std::to_string(wireId) +
+                                     " in v2 state on slot " + std::to_string(slotIndex) +
+                                     "; minting a fresh identity");
+                const uint64_t fresh = mintPluginInstanceId();
+                seenLoadedIds.insert(fresh);
+                return fresh;
+            }
             if (!seenLoadedIds.insert(wireId).second) {
                 // Duplicate id in a v2 payload is corrupt: mint a fresh identity
                 // so the two slots never share one (Contract I5).
                 Aestra::Log::warning("[EffectChain] duplicate instance id " + std::to_string(wireId) +
                                      " in v2 state on slot " + std::to_string(slotIndex) +
                                      "; minting a fresh identity");
-                return mintPluginInstanceId();
+                const uint64_t fresh = mintPluginInstanceId();
+                seenLoadedIds.insert(fresh);
+                return fresh;
             }
             reserveMintedPluginInstanceId(wireId);
             return wireId;
@@ -856,7 +868,9 @@ bool EffectChain::loadState(const std::vector<uint8_t>& state, PluginManager& ma
             Aestra::Log::warning("[EffectChain] v2 state carries no instance id on slot " +
                                  std::to_string(slotIndex) + "; minting (corrupt payload)");
         }
-        return mintPluginInstanceId();
+        const uint64_t fresh = mintPluginInstanceId();
+        seenLoadedIds.insert(fresh);
+        return fresh;
     };
 
     for (size_t i = 0; i < MAX_SLOTS && offset < state.size(); ++i) {

--- a/AestraAudio/src/Plugin/PluginManager.cpp
+++ b/AestraAudio/src/Plugin/PluginManager.cpp
@@ -187,6 +187,14 @@ PluginInstancePtr PluginManager::createInstance(const PluginInfo& info) {
 PluginInstancePtr PluginManager::createInstanceById(const std::string& pluginId) {
     const PluginInfo* info = findPlugin(pluginId);
     if (!info) {
+        // Internal plugins are registered with the InternalPluginRegistry, which
+        // is the authority for their availability. A project may reference one
+        // registered after the last scan (tests, dynamically added built-ins),
+        // so fall back to the registry directly — still gated by availability.
+        auto& registry = InternalPluginRegistry::instance();
+        if (registry.isRegisteredPlugin(pluginId) && registry.isPluginAvailable(pluginId)) {
+            return registry.createInstance(pluginId);
+        }
         return nullptr;
     }
     return createInstance(*info);

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -1173,6 +1173,20 @@ void MixerViewModel::moveInsert(uint32_t channelId, int fromSlot, int toSlot) {
     
     if (fromSlot == toSlot) return;
 
+    // Validate the source BEFORE touching the view model: MovePluginCommand
+    // rejects empty sources (including missing-plugin placeholders, which are
+    // occupied but not movable). Swapping the local inserts first would leave
+    // the view model changed while the engine move is refused.
+    if (fromSlot < 0 || fromSlot >= (int)ch->inserts.size()) return;
+    const auto& sourceVm = ch->inserts[fromSlot];
+    if (sourceVm.isEmpty) return;
+    if (auto mc = ch->channel) {
+        if (mc->getEffectChain().getSlot(static_cast<size_t>(fromSlot)) == nullptr ||
+            mc->getEffectChain().getSlot(static_cast<size_t>(fromSlot))->isEmpty()) {
+            return;
+        }
+    }
+
     // Update Local (Swap/Move)
     std::swap(ch->inserts[fromSlot], ch->inserts[toSlot]);
 

--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 
 #include "MixerViewModel.h"
+#include "Commands/EffectCommands.h"
 #include "../AestraCore/include/AestraLog.h"
 #include "Commands/RoutingCommands.h"
 #include "AudioDeviceManager.h"
@@ -1175,27 +1176,22 @@ void MixerViewModel::moveInsert(uint32_t channelId, int fromSlot, int toSlot) {
     // Update Local (Swap/Move)
     std::swap(ch->inserts[fromSlot], ch->inserts[toSlot]);
 
-    // Update Engine
+    // Update Engine through the command seam (undoable; identities travel with
+    // the instances — automation never retargets on reorder).
     if (auto mc = ch->channel) {
-        auto& chain = mc->getEffectChain();
-        const auto* targetSlotPtr = chain.getSlot(toSlot);
-        
-        // Since we already swapped locally, we assume engine handles it.
-        // We check target slot state *before* logic if possible, but weak ptr makes it tricky.
-        // Let's assume we want to swap if target has plugin, move if empty.
-        
-        // However, EffectChain API is locked.
-        // If we call movePlugin(from, to) and it fails (occupied), we should try swapPlugins.
-        // But checking `isEmpty()` first is safer.
-        
-        bool targetEmpty = (!targetSlotPtr || targetSlotPtr->isEmpty());
-        
-        if (targetEmpty) {
-            chain.movePlugin(fromSlot, toSlot);
+        if (m_commandHistory && m_trackManager) {
+            m_commandHistory->pushAndExecute(std::make_shared<Audio::MovePluginCommand>(
+                *m_trackManager, *mc, static_cast<size_t>(fromSlot), static_cast<size_t>(toSlot)));
         } else {
-            chain.swapPlugins(fromSlot, toSlot);
+            auto& chain = mc->getEffectChain();
+            const auto* targetSlotPtr = chain.getSlot(toSlot);
+            const bool targetEmpty = (!targetSlotPtr || targetSlotPtr->isEmpty());
+            if (targetEmpty) {
+                chain.movePlugin(fromSlot, toSlot);
+            } else {
+                chain.swapPlugins(fromSlot, toSlot);
+            }
         }
-        
         graphDirty.emit();
         projectModified.emit();
     }

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -981,10 +981,12 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 cj.set("mixerChannelId", JSON(static_cast<double>(curve.mixerChannelId)));
                 cj.set("default", JSON(curve.getDefaultValue()));
                 if (curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Custom) {
-                    // Plugin-parameter address (older builds ignore unknown keys;
-                    // loads without them default to slot 0 / param 0).
+                    // Plugin-parameter address. instanceId is the authoritative
+                    // decimal-string identity (Automation Identity Contract);
+                    // slot stays for older-build compatibility and v1 readers.
                     cj.set("slot", JSON(static_cast<double>(curve.effectSlot)));
                     cj.set("paramId", JSON(static_cast<double>(curve.paramId)));
+                    cj.set("instanceId", JSON(std::to_string(curve.deviceInstanceId)));
                 }
 
                 JSON ptsJson = JSON::array();
@@ -2126,6 +2128,31 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             // slot to the effect-chain size, paramId defensively.
                             curve.effectSlot = static_cast<uint32_t>(finiteNumberOr(aj[a], "slot", 0.0, 0.0, 9.0));
                             curve.paramId = static_cast<uint32_t>(finiteNumberOr(aj[a], "paramId", 0.0, 0.0, 1.0e6));
+                            // Automation Identity Contract: a v2 curve carries
+                            // its exact instance id. A v1 curve (no key)
+                            // migrates exactly once: the slot's minted instance
+                            // id, resolved against the already-loaded chains.
+                            // Empty slots yield 0 — the curve is preserved as
+                            // dangling (diagnostic), never re-pointed.
+                            if (aj[a].has("instanceId") && aj[a]["instanceId"].isString()) {
+                                try {
+                                    curve.deviceInstanceId = std::stoull(aj[a]["instanceId"].asString());
+                                } catch (const std::exception&) {
+                                    curve.deviceInstanceId = 0;
+                                }
+                            } else if (curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Custom) {
+                                if (auto* targetChannel = trackManager->getChannelById(curve.mixerChannelId)) {
+                                    curve.deviceInstanceId =
+                                        targetChannel->getEffectChain().getSlotInstanceId(curve.effectSlot);
+                                }
+                                if (curve.deviceInstanceId == 0) {
+                                    warningLimiter.warning(
+                                        ProjectLoadWarningCategory::AutomationTarget,
+                                        "[ProjectLoad] Automation curve '" + param +
+                                            "' targets an empty insert slot; preserved as dangling.",
+                                        "[ProjectLoad] Additional dangling automation curve warnings suppressed.");
+                                }
+                            }
 
                             if (!aj[a].has("points") || !aj[a]["points"].isArray()) continue;
                             const JSON& pts = aj[a]["points"];

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -2135,10 +2136,30 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             // Empty slots yield 0 — the curve is preserved as
                             // dangling (diagnostic), never re-pointed.
                             if (aj[a].has("instanceId") && aj[a]["instanceId"].isString()) {
-                                try {
-                                    curve.deviceInstanceId = std::stoull(aj[a]["instanceId"].asString());
-                                } catch (const std::exception&) {
-                                    curve.deviceInstanceId = 0;
+                                // Untrusted input: digits-only parse. std::stoull
+                                // would accept "-1" (wraps to UINT64_MAX, which the
+                                // chain refuses by design) and "12abc" (trailing
+                                // junk silently attaching the curve to id 12).
+                                const std::string rawId = aj[a]["instanceId"].asString();
+                                const bool digitsOnly =
+                                    !rawId.empty() &&
+                                    std::all_of(rawId.begin(), rawId.end(), [](unsigned char c) { return std::isdigit(c) != 0; });
+                                if (digitsOnly) {
+                                    curve.deviceInstanceId = std::stoull(rawId);
+                                    if (curve.deviceInstanceId == std::numeric_limits<uint64_t>::max()) {
+                                        warningLimiter.warning(
+                                            ProjectLoadWarningCategory::AutomationTarget,
+                                            "[ProjectLoad] Automation curve '" + param +
+                                                "' carries the reserved max instance id; preserved as dangling.",
+                                            "[ProjectLoad] Additional reserved-instance-id warnings suppressed.");
+                                        curve.deviceInstanceId = 0;
+                                    }
+                                } else {
+                                    warningLimiter.warning(
+                                        ProjectLoadWarningCategory::AutomationTarget,
+                                        "[ProjectLoad] Automation curve '" + param +
+                                            "' carries a malformed instance id; preserved as dangling.",
+                                        "[ProjectLoad] Additional malformed instance-id warnings suppressed.");
                                 }
                             } else if (curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Custom) {
                                 if (auto* targetChannel = trackManager->getChannelById(curve.mixerChannelId)) {

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -257,6 +257,7 @@ void AudioClipEditorPanel::buildUI() {
     m_fadeInValueLabel = makeLabel("0.00 beats", 11.5f);
     m_fadeOutValueLabel = makeLabel("0.00 beats", 11.5f);
     m_pitchValueLabel = makeLabel("0.0 st  •  1.00x", 11.5f);
+    m_speedValueLabel = makeLabel("1.00x", 11.5f);
     m_sourceStartValueLabel = makeLabel("0.000 s", 11.5f);
     m_waveformHintLabel = makeLabel("Scroll to zoom • edits are non-destructive", 11.0f);
     m_waveformHintLabel->setAlignment(NUILabel::Alignment::Right);
@@ -271,6 +272,7 @@ void AudioClipEditorPanel::buildUI() {
     m_fadeOutSlider = makeSlider("Fade out", 0.0, 4.0, 0.0);
     m_pitchSlider = makeSlider("Clip pitch (varispeed)", ClipEdits::kMinPitchSemitones, ClipEdits::kMaxPitchSemitones,
                                0.0, true);
+    m_speedSlider = makeSlider("Speed", 0.25, 4.0, 1.0);
     m_sourceStartSlider = makeSlider("Source start", 0.0, 1.0, 0.0);
     m_muteButton = std::make_shared<NUIButton>("Mute clip");
     m_muteButton->setToggleable(true);

--- a/Tests/AestraAudio/AutomationIdentityResolutionTest.cpp
+++ b/Tests/AestraAudio/AutomationIdentityResolutionTest.cpp
@@ -1,0 +1,366 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Automation Identity Resolution (Contract I2/I3/I8/I10): the curve targets
+// the INSTANCE, so reordering and swapping never retarget it, a removed
+// target leaves the curve dangling (never re-pointed), and a placeholder
+// target stays attached. All assertions are on rendered audio.
+
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraph.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Core/AutomationCurve.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
+#include "Plugin/PluginManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace Aestra;
+using namespace Aestra::Audio;
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockFrames = 256;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kRenderFrames = static_cast<uint32_t>(1.0 * kSampleRate); // 1 s
+constexpr uint32_t kSpbAt120 = kSampleRate * 60 / 120; // 24000 samples per beat
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+double rmsOf(const std::vector<float>& samples, size_t begin, size_t end) {
+    double acc = 0.0;
+    size_t n = 0;
+    for (size_t i = begin; i < end && i < samples.size(); i += 2) {
+        acc += static_cast<double>(samples[i]) * static_cast<double>(samples[i]);
+        ++n;
+    }
+    return n > 0 ? std::sqrt(acc / static_cast<double>(n)) : 0.0;
+}
+
+// Generator on both channels (constant amplitude).
+class GeneratorPlugin : public IPluginInstance {
+public:
+    GeneratorPlugin() {
+        m_info.id = "aestra.test.identity.gen";
+        m_info.name = "Gen";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override {}
+    void deactivate() override {}
+    bool isActive() const override { return true; }
+    void process(const float* const* inputs, float** outputs, uint32_t, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* = nullptr, MidiBuffer* = nullptr) override {
+        for (uint32_t c = 0; c < numOutputChannels; ++c) {
+            if (!outputs[c]) {
+                continue;
+            }
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                const double t = static_cast<double>(i) / static_cast<double>(kSampleRate);
+                outputs[c][i] = static_cast<float>(std::sin(2.0 * 3.14159265358979 * 220.0 * t) * 0.25);
+            }
+        }
+    }
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+protected:
+    PluginInfo m_info{};
+};
+
+// Gain on param 0: setParameter(0, v) scales the output by v.
+class GainPlugin : public GeneratorPlugin {
+public:
+    GainPlugin() { m_info.id = "aestra.test.identity.gain"; }
+    void setParameter(uint32_t id, float value) override {
+        if (id == 0) {
+            m_gain = value;
+        }
+    }
+    float getParameter(uint32_t id) const override { return id == 0 ? m_gain : 0.0f; }
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* m = nullptr,
+                 MidiBuffer* o = nullptr) override {
+        GeneratorPlugin::process(inputs, outputs, numInputChannels, numOutputChannels, numFrames, m, o);
+        for (uint32_t c = 0; c < numOutputChannels; ++c) {
+            if (!outputs[c]) {
+                continue;
+            }
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                outputs[c][i] *= m_gain;
+            }
+        }
+    }
+
+private:
+    float m_gain = 1.0f;
+};
+
+// Inert: setParameter is a no-op. If automation were retargeted onto this
+// plugin, the rendered output would NOT fade.
+class InertPlugin : public GeneratorPlugin {
+public:
+    InertPlugin() { m_info.id = "aestra.test.identity.inert"; }
+};
+
+struct Fixture {
+    std::shared_ptr<TrackManager> tm;
+    MixerChannel* src{nullptr};
+    AudioEngine engine;
+    AutomationCurve curve;
+    uint64_t gainId{0};
+    uint64_t inertId{0};
+
+    Fixture() {
+        tm = std::make_shared<TrackManager>();
+        tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+        src = tm->addChannel("src");
+        require(src->getEffectChain().insertPlugin(0, std::make_shared<GeneratorPlugin>()), "generator inserted");
+        require(src->getEffectChain().insertPlugin(1, std::make_shared<GainPlugin>()), "gain inserted");
+        require(src->getEffectChain().insertPlugin(2, std::make_shared<InertPlugin>()), "inert inserted");
+        gainId = src->getEffectChain().getSlotInstanceId(1);
+        inertId = src->getEffectChain().getSlotInstanceId(2);
+
+        // Curve: gain 1.0 for the first half, 0.0 for the second.
+        curve = AutomationCurve("gain", AutomationTarget::Custom);
+        curve.deviceInstanceId = gainId;
+        curve.paramId = 0;
+        curve.setDefaultValue(1.0f);
+        curve.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
+        curve.addPoint(0.5, 1.0f, kSpbAt120, 0.5f);
+        curve.addPoint(1.0, 0.0f, kSpbAt120, 0.5f);
+
+        auto& playlist = tm->getPlaylistModel();
+        playlist.setProjectSampleRate(static_cast<double>(kSampleRate));
+        playlist.setBPM(120.0);
+        const auto laneId = playlist.createLane("lane0");
+        auto* lane = playlist.getLane(laneId);
+        require(lane != nullptr, "lane created");
+        lane->automationCurves.push_back(curve);
+        lane->automationCurves.back().mixerChannelId = src->getChannelId();
+    }
+
+    // Baseline render WITHOUT any automation: a flat constant tone rules out
+    // global fades/mix artifacts before the identity cases are judged.
+    void renderBaseline() {
+        // Clear every lane's curves (the fixture created one lane with ours).
+        auto& playlist = tm->getPlaylistModel();
+        const auto laneIds = playlist.getLaneIDs();
+        for (const auto& laneId : laneIds) {
+            if (auto* lane = playlist.getLane(laneId)) {
+                lane->automationCurves.clear();
+            }
+        }
+        startEngine();
+        std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+        std::vector<float> samples;
+        for (uint32_t rendered = 0; rendered < kRenderFrames; rendered += kBlockFrames) {
+            std::fill(block.begin(), block.end(), 0.0f);
+            engine.processBlock(block.data(), nullptr, kBlockFrames,
+                                static_cast<double>(rendered) / kSampleRate);
+            samples.insert(samples.end(), block.begin(), block.end());
+        }
+        engine.setTransportPlaying(false);
+        const double early = rmsOf(samples, 4096, 32000);
+        const double late = rmsOf(samples, 72000, 92000);
+        std::cout << "baseline: early=" << early << " late=" << late << "\n";
+    }
+
+    void startEngine() {
+        engine.setTrackManager(tm);
+        engine.setSampleRate(kSampleRate);
+        engine.setBufferConfig(kBlockFrames, kChannels);
+        tm->buildAndShareSlotMap();
+        if (auto slotMap = tm->getChannelSlotMapShared()) {
+            engine.setChannelSlotMap(slotMap);
+        }
+        engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+        engine.setSafetyLimiterEnabled(false);
+        engine.setTransportPlaying(true);
+    }
+
+    // Render and compare early (gain 1.0) vs late (gain 0.0) RMS.
+    void renderExpectFade(const std::string& tag) {
+        std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+        std::vector<float> samples;
+        samples.reserve(static_cast<size_t>(kRenderFrames) * kChannels);
+        for (uint32_t rendered = 0; rendered < kRenderFrames; rendered += kBlockFrames) {
+            std::fill(block.begin(), block.end(), 0.0f);
+            engine.processBlock(block.data(), nullptr, kBlockFrames,
+                                static_cast<double>(rendered) / kSampleRate);
+            samples.insert(samples.end(), block.begin(), block.end());
+        }
+        engine.setTransportPlaying(false);
+        const double early = rmsOf(samples, 4096, 32000);
+        const double late = rmsOf(samples, 72000, 92000);
+        std::cout << tag << ": early=" << early << " late=" << late << "\n";
+        require(early > 1e-3, tag + ": early region is silent");
+        require(late < 0.02 * early, tag + ": automation did not follow the instance");
+    }
+
+    void renderExpectNoFade(const std::string& tag) {
+        std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+        std::vector<float> samples;
+        samples.reserve(static_cast<size_t>(kRenderFrames) * kChannels);
+        for (uint32_t rendered = 0; rendered < kRenderFrames; rendered += kBlockFrames) {
+            std::fill(block.begin(), block.end(), 0.0f);
+            engine.processBlock(block.data(), nullptr, kBlockFrames,
+                                static_cast<double>(rendered) / kSampleRate);
+            samples.insert(samples.end(), block.begin(), block.end());
+        }
+        engine.setTransportPlaying(false);
+        const double early = rmsOf(samples, 4096, 24000);
+        const double late = rmsOf(samples, 72000, 92000);
+        std::cout << tag << ": early=" << early << " late=" << late << "\n";
+        require(early > 1e-3, tag + ": early region is silent");
+        require(late > 0.8 * early, tag + ": dangling curve must not retarget (output changed)");
+    }
+};
+
+void testReorderDoesNotRetarget() {
+    // Move the gain plugin from slot 1 to the empty slot 3. The curve targets
+    // the instance, so it must still drive the gain and fade the output.
+    Fixture fx;
+    require(fx.src->getEffectChain().movePlugin(1, 3), "movePlugin to empty slot succeeds");
+    require(fx.src->getEffectChain().getSlotInstanceId(3) == fx.gainId,
+            "movePlugin carries the identity with the instance");
+    fx.startEngine();
+    fx.renderExpectFade("reorder");
+}
+
+void testSwapDoesNotRetarget() {
+    // Exchange gain (slot 1) with inert (slot 2). Positional targeting would
+    // now drive the inert plugin; instance targeting keeps driving the gain.
+    Fixture fx;
+    require(fx.src->getEffectChain().swapPlugins(1, 2), "swapPlugins succeeds");
+    require(fx.src->getEffectChain().getSlotInstanceId(2) == fx.gainId,
+            "swap carries the identity with the instance");
+    fx.startEngine();
+    fx.renderExpectFade("swap");
+}
+
+void testRemoveTargetLeavesCurveDangling() {
+    // Remove the gain plugin. The curve keeps its (now dangling) instance id
+    // and must not drive the inert plugin that now sits at slot 1.
+    Fixture fx;
+    require(fx.src->getEffectChain().removePlugin(1) != nullptr, "gain plugin removed");
+    fx.startEngine();
+    fx.renderExpectNoFade("remove");
+    // The curve still names the removed instance — never re-pointed.
+    require(fx.curve.deviceInstanceId == fx.gainId, "removed target keeps its identity");
+}
+
+void testPlaceholderTargetStaysAttached() {
+    // A placeholder at slot 1 (unknown plugin restored from a crafted v2
+    // blob). A curve on the placeholder's id must stay attached: the snapshot
+    // resolves the target to the placeholder slot, and a save/load cycle
+    // keeps it there. Resolution of a missing plugin is a skip, never a
+    // retarget (covered by the remove case at render level).
+    EffectChain chain;
+    {
+        std::vector<uint8_t> blob{'N', 'E', 'C', 2, static_cast<uint8_t>(EffectChain::MAX_SLOTS)};
+        const auto put = [&blob](const void* data, size_t n) {
+            const auto* bytes = static_cast<const uint8_t*>(data);
+            blob.insert(blob.end(), bytes, bytes + n);
+        };
+        for (size_t slot = 0; slot < EffectChain::MAX_SLOTS; ++slot) {
+            const bool occupied = slot == 1;
+            blob.push_back(occupied ? 1 : 0);
+            if (!occupied) {
+                continue;
+            }
+            const uint64_t wireId = 424242;
+            put(&wireId, sizeof(wireId));
+            const std::string missingId = "aestra.test.identity.missing";
+            const uint32_t idLen = static_cast<uint32_t>(missingId.size());
+            put(&idLen, sizeof(idLen));
+            blob.insert(blob.end(), missingId.begin(), missingId.end());
+            const uint8_t bypass = 0;
+            blob.push_back(bypass);
+            const float dryWet = 1.0f;
+            put(&dryWet, sizeof(dryWet));
+            const uint32_t stateLen = 0;
+            put(&stateLen, sizeof(stateLen));
+        }
+        std::vector<std::string> missing;
+        require(chain.loadState(blob, PluginManager::getInstance(), &missing),
+                "placeholder chain loads");
+        require(missing.size() == 1, "one placeholder created");
+    }
+    require(chain.getSlotInstanceId(1) == 424242, "placeholder restored the wire identity");
+
+    AutomationCurve curve("gain", AutomationTarget::Custom);
+    curve.deviceInstanceId = 424242;
+    curve.paramId = 0;
+    const auto snapshot = chain.getSnapshot();
+    require(snapshot != nullptr, "snapshot published");
+    require(snapshot->findSlotByInstanceId(curve.deviceInstanceId) == 1,
+            "the curve's target resolves to the placeholder slot");
+
+    // Save/load keeps the placeholder and its identity; the curve stays attached.
+    EffectChain reloaded;
+    std::vector<std::string> missing2;
+    require(reloaded.loadState(chain.saveState(), PluginManager::getInstance(), &missing2),
+            "resaved placeholder chain loads");
+    require(reloaded.getSlotInstanceId(1) == 424242, "placeholder identity survived the round trip");
+    const auto snapshot2 = reloaded.getSnapshot();
+    require(snapshot2->findSlotByInstanceId(curve.deviceInstanceId) == 1,
+            "the curve's target survives the round trip");
+}
+
+} // namespace
+
+int main() {
+    if (!PluginManager::getInstance().initialize()) {
+        std::cerr << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+    {
+        Fixture fx;
+        fx.renderBaseline();
+    }
+    testReorderDoesNotRetarget();
+    testSwapDoesNotRetarget();
+    testRemoveTargetLeavesCurveDangling();
+    testPlaceholderTargetStaysAttached();
+    std::cout << "[PASS] AutomationIdentityResolutionTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/AutomationIdentityResolutionTest.cpp
+++ b/Tests/AestraAudio/AutomationIdentityResolutionTest.cpp
@@ -146,6 +146,7 @@ struct Fixture {
     MixerChannel* src{nullptr};
     AudioEngine engine;
     AutomationCurve curve;
+    const AutomationCurve* laneCurve{nullptr}; // the lane's COPY (what renders)
     uint64_t gainId{0};
     uint64_t inertId{0};
 
@@ -176,6 +177,7 @@ struct Fixture {
         require(lane != nullptr, "lane created");
         lane->automationCurves.push_back(curve);
         lane->automationCurves.back().mixerChannelId = src->getChannelId();
+        laneCurve = &lane->automationCurves.back();
     }
 
     // Baseline render WITHOUT any automation: a flat constant tone rules out
@@ -284,8 +286,11 @@ void testRemoveTargetLeavesCurveDangling() {
     require(fx.src->getEffectChain().removePlugin(1) != nullptr, "gain plugin removed");
     fx.startEngine();
     fx.renderExpectNoFade("remove");
-    // The curve still names the removed instance — never re-pointed.
-    require(fx.curve.deviceInstanceId == fx.gainId, "removed target keeps its identity");
+    // The lane's curve (what actually renders) still names the removed
+    // instance — never re-pointed. Assert on the lane copy, not the fixture's
+    // own member, which nothing mutates.
+    require(fx.laneCurve != nullptr && fx.laneCurve->deviceInstanceId == fx.gainId,
+            "removed target keeps its identity");
 }
 
 void testPlaceholderTargetStaysAttached() {

--- a/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
+++ b/Tests/AestraAudio/EffectChainInstanceIdentityTest.cpp
@@ -363,27 +363,146 @@ std::vector<uint8_t> serializeChainWithOccupantInSlotZero() {
     return chain.saveState();
 }
 
-void testLoadMintsIdentityForRestoredSlots() {
-    // Before this, loadState never touched instanceId, so every plugin in a
-    // freshly opened project came back with identity 0 — i.e. unaddressable, and
-    // indistinguishable from an empty slot to findSlotByInstanceId.
+// --- v2 serialization (Automation Identity Contract I4/I5/I6/I9) ------------
+
+/// Build a raw chain-state blob by hand so tests can pin version-specific
+/// behavior (v1 = no ids, v2 = ids) without depending on saveState's current
+/// version. Empty slots are hasPlugin=0; occupied slots carry pluginId +
+/// bypass + dryWet + empty plugin state.
+std::vector<uint8_t> buildChainBlob(uint8_t version,
+                                    const std::vector<std::pair<uint64_t, std::string>>& occupiedSlots) {
+    std::vector<uint8_t> state{'N', 'E', 'C', version, static_cast<uint8_t>(EffectChain::MAX_SLOTS)};
+    const auto put = [&state](const void* data, size_t n) {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        state.insert(state.end(), bytes, bytes + n);
+    };
+    size_t cursor = 0;
+    for (size_t slot = 0; slot < EffectChain::MAX_SLOTS; ++slot) {
+        if (cursor < occupiedSlots.size() && occupiedSlots[cursor].first == 0 && false) {
+            // unreachable; kept for clarity of the loop shape
+        }
+        // occupiedSlots entries are indexed by slot position
+        if (slot < occupiedSlots.size()) {
+            const auto& [instanceId, pluginId] = occupiedSlots[slot];
+            state.push_back(1);
+            if (version >= 2) {
+                put(&instanceId, sizeof(instanceId));
+            }
+            const uint32_t idLen = static_cast<uint32_t>(pluginId.size());
+            put(&idLen, sizeof(idLen));
+            state.insert(state.end(), pluginId.begin(), pluginId.end());
+            const uint8_t bypass = 0;
+            state.push_back(bypass);
+            const float dryWet = 1.0f;
+            put(&dryWet, sizeof(dryWet));
+            const uint32_t stateLen = 0;
+            put(&stateLen, sizeof(stateLen));
+        } else {
+            state.push_back(0);
+        }
+    }
+    return state;
+}
+
+void testSaveLoadRoundTripPreservesIdentity() {
+    // v2: the identity travels with the instance (Contract I4/I9). A save/load
+    // cycle must restore the exact ids — the serialization gap D2 taught us to
+    // look for. (v1 minted; v2 must not.)
     EffectChain source;
     source.insertPlugin(0, makePlugin("aestra.test.identity.unregistered.a"));
     source.insertPlugin(3, makePlugin("aestra.test.identity.unregistered.b"));
+    const uint64_t idA = source.getSlotInstanceId(0);
+    const uint64_t idB = source.getSlotInstanceId(3);
+    check(source.saveState()[3] == EffectChain::kStateFormatVersion,
+          "saved state carries the current format version (v2)");
     const std::vector<uint8_t> blob = source.saveState();
 
     EffectChain restored;
     std::vector<std::string> missing;
     check(restored.loadState(blob, PluginManager::getInstance(), &missing),
-          "the serialized chain loads");
+          "the v2 chain loads");
+    check(restored.getSlotInstanceId(0) == idA,
+          "round trip preserves the first instance identity exactly");
+    check(restored.getSlotInstanceId(3) == idB,
+          "round trip preserves the second instance identity exactly");
+    check(restored.findSlotByInstanceId(idA) == 0 && restored.findSlotByInstanceId(idB) == 3,
+          "restored identities resolve to their slots");
+}
 
+void testV1StateStillLoadsAndMints() {
+    // v1 payloads predate identity: they load and mint (migration rule I5).
+    const std::vector<uint8_t> blob = buildChainBlob(
+        1, {{0, "aestra.test.identity.unregistered.a"}, {0, "aestra.test.identity.unregistered.b"}});
+    EffectChain restored;
+    std::vector<std::string> missing;
+    check(restored.loadState(blob, PluginManager::getInstance(), &missing),
+          "a v1 chain still loads");
     const uint64_t a = restored.getSlotInstanceId(0);
-    const uint64_t b = restored.getSlotInstanceId(3);
-    check(a != 0, "a restored occupant has an identity");
-    check(b != 0, "every restored occupant has one, not just the first");
-    check(a != b, "restored occupants get distinct identities");
-    check(restored.findSlotByInstanceId(a) == 0, "a restored identity resolves to its slot");
-    check(restored.findSlotByInstanceId(b) == 3, "and so does the second");
+    const uint64_t b = restored.getSlotInstanceId(1);
+    check(a != 0 && b != 0, "v1 occupants mint identities");
+    check(a != b, "v1 occupants mint distinct identities");
+}
+
+void testV2MissingIdMintsFresh() {
+    // A v2 payload with id 0 on an occupied slot is corrupt: mint with a
+    // diagnostic rather than leaving the slot unaddressable (Contract I5).
+    const std::vector<uint8_t> blob =
+        buildChainBlob(2, {{0, "aestra.test.identity.unregistered.a"}});
+    EffectChain restored;
+    std::vector<std::string> missing;
+    check(restored.loadState(blob, PluginManager::getInstance(), &missing),
+          "a v2 chain with a missing id still loads");
+    check(restored.getSlotInstanceId(0) != 0, "the corrupt slot mints a fresh identity");
+}
+
+void testV2DuplicateIdMintsFresh() {
+    // Two slots sharing one id is corrupt: the duplicate mints so lookups can
+    // never be ambiguous (Contract I5).
+    const std::vector<uint8_t> blob = buildChainBlob(
+        2, {{42, "aestra.test.identity.unregistered.a"}, {42, "aestra.test.identity.unregistered.b"}});
+    EffectChain restored;
+    std::vector<std::string> missing;
+    check(restored.loadState(blob, PluginManager::getInstance(), &missing),
+          "a v2 chain with a duplicate id still loads");
+    check(restored.getSlotInstanceId(0) != restored.getSlotInstanceId(1),
+          "the duplicate slot mints a distinct identity");
+    check(restored.getSlotInstanceId(0) == 42, "the first occupant keeps its id");
+}
+
+void testPlaceholderIdentitySurvivesRoundTrip() {
+    // A placeholder is an occupant with an identity (Contract I6). Saving a
+    // chain with a missing-plugin placeholder and reloading must restore the
+    // SAME id, so automation addressed to the failed plugin survives.
+    const std::vector<uint8_t> blob = buildChainBlob(
+        2, {{77, "aestra.test.identity.does.not.exist"}});
+    EffectChain first;
+    std::vector<std::string> missing;
+    check(first.loadState(blob, PluginManager::getInstance(), &missing),
+          "the placeholder chain loads");
+    check(first.getSlotInstanceId(0) == 77, "the placeholder restored its wire id");
+
+    const std::vector<uint8_t> resaved = first.saveState();
+    EffectChain second;
+    std::vector<std::string> missing2;
+    check(second.loadState(resaved, PluginManager::getInstance(), &missing2),
+          "the resaved placeholder chain loads");
+    check(second.getSlotInstanceId(0) == 77,
+          "placeholder identity survives a full save/load cycle");
+}
+
+void testLoadedIdsAreReservedAgainstFutureMints() {
+    // Ids restored from a v2 payload must be reserved so a mint later in the
+    // session can never collide with them (I5 + the #528 guard pattern).
+    const std::vector<uint8_t> blob = buildChainBlob(
+        2, {{9000, "aestra.test.identity.unregistered.a"}});
+    EffectChain restored;
+    std::vector<std::string> missing;
+    check(restored.loadState(blob, PluginManager::getInstance(), &missing),
+          "the v2 chain loads");
+
+    restored.insertPlugin(1, makePlugin("aestra.test.identity.unregistered.b"));
+    check(restored.getSlotInstanceId(1) > 9000,
+          "a mint after loading v2 ids never collides with a restored id");
 }
 
 void testLoadClearsIdentityOnSerializedEmptySlots() {
@@ -601,7 +720,12 @@ int main() {
     testMintNeverReturnsZero();
     testResetPreservesIdentities();
     testSnapshotCarriesIdentity();
-    testLoadMintsIdentityForRestoredSlots();
+    testSaveLoadRoundTripPreservesIdentity();
+    testV1StateStillLoadsAndMints();
+    testV2MissingIdMintsFresh();
+    testV2DuplicateIdMintsFresh();
+    testPlaceholderIdentitySurvivesRoundTrip();
+    testLoadedIdsAreReservedAgainstFutureMints();
     testLoadClearsIdentityOnSerializedEmptySlots();
     testUndoOfRemoveRestoresTheSameIdentity();
     testRedoOfAddKeepsTheOriginalIdentity();

--- a/Tests/AestraAudio/EffectChainMissingPluginTest.cpp
+++ b/Tests/AestraAudio/EffectChainMissingPluginTest.cpp
@@ -41,6 +41,7 @@ void check(bool condition, const std::string& what) {
 
 struct SlotRecord {
     bool present = false;
+    uint64_t instanceId = 0; // v2 wire identity
     std::string id;
     bool bypassed = false;
     float dryWet = 1.0f;
@@ -63,6 +64,7 @@ std::vector<uint8_t> buildBlob(const std::vector<SlotRecord>& slots) {
             continue;
         }
         out.push_back(1);
+        appendRaw(out, s.instanceId); // v2: identity travels with the instance
         appendRaw(out, static_cast<uint32_t>(s.id.size()));
         out.insert(out.end(), s.id.begin(), s.id.end());
         out.push_back(s.bypassed ? 1 : 0);
@@ -90,6 +92,12 @@ bool parseBlob(const std::vector<uint8_t>& blob, std::vector<SlotRecord>& out) {
 
         SlotRecord r;
         r.present = true;
+        // v2: skip/read the 8-byte instance id.
+        if (blob[3] >= 2) {
+            if (off + sizeof(uint64_t) > blob.size()) return false;
+            std::memcpy(&r.instanceId, &blob[off], sizeof(uint64_t));
+            off += sizeof(uint64_t);
+        }
         uint32_t idLen = 0;
         if (off + sizeof(idLen) > blob.size()) return false;
         std::memcpy(&idLen, &blob[off], sizeof(idLen));
@@ -134,9 +142,9 @@ int main() {
     // The core invariant: a chain of unavailable plugins survives load/save.
     // ---------------------------------------------------------------------
     std::vector<SlotRecord> original(EffectChain::MAX_SLOTS);
-    original[0] = {true, kMissingA, true, 0.375f, bytes({0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01})};
-    original[3] = {true, kMissingB, false, 1.0f, bytes({0x11, 0x22})};
-    original[7] = {true, kMissingA, false, 0.0f, {}}; // empty opaque state is legal
+    original[0] = {true, 1234, kMissingA, true, 0.375f, bytes({0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01})};
+    original[3] = {true, 5678, kMissingB, false, 1.0f, bytes({0x11, 0x22})};
+    original[7] = {true, 9012, kMissingA, false, 0.0f, {}}; // empty opaque state is legal
 
     const std::vector<uint8_t> blob0 = buildBlob(original);
 
@@ -230,7 +238,7 @@ int main() {
         EffectChain chain;
         chain.prepare(48000.0, 512);
         std::vector<SlotRecord> recs(EffectChain::MAX_SLOTS);
-        recs[0] = {true, kMissingA, false, 1.0f, bytes({0x01})};
+        recs[0] = {true, 0, kMissingA, false, 1.0f, bytes({0x01})};
         check(chain.loadState(buildBlob(recs), manager()), "occupancy: loadState ok");
 
         check(!chain.isSlotEmpty(0), "a placeholder slot does not report itself free");
@@ -249,8 +257,8 @@ int main() {
         EffectChain chain;
         chain.prepare(48000.0, 512);
         std::vector<SlotRecord> recs(EffectChain::MAX_SLOTS);
-        recs[0] = {true, kMissingA, false, 1.0f, bytes({0xAA})};
-        recs[1] = {true, kMissingB, false, 1.0f, bytes({0xBB})};
+        recs[0] = {true, 0, kMissingA, false, 1.0f, bytes({0xAA})};
+        recs[1] = {true, 0, kMissingB, false, 1.0f, bytes({0xBB})};
         check(chain.loadState(buildBlob(recs), manager()), "mixed: loadState ok");
         check(chain.getMissingPluginCount() == 2, "mixed: two placeholders to start");
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -74,6 +74,30 @@ add_test(NAME TestTempDirectoryStressTest COMMAND TestTempDirectoryStressTest)
 set_tests_properties(TestTempDirectoryStressTest PROPERTIES LABELS "support;infrastructure;contract:core")
 
 # Project RoundTrip Test
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/AutomationLifecycleTest.cpp")
+    add_executable(AutomationLifecycleTest
+        Integration/AutomationLifecycleTest.cpp
+        ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+    )
+    target_link_libraries(AutomationLifecycleTest PRIVATE AestraAudio)
+    target_include_directories(AutomationLifecycleTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+        ${CMAKE_SOURCE_DIR}/Source
+    )
+    add_test(NAME AutomationLifecycleTest COMMAND AutomationLifecycleTest)
+    set_tests_properties(AutomationLifecycleTest PROPERTIES LABELS "integration;automation;serialization;contract:durability")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Integration/ProjectRoundTripTest.cpp")
     add_executable(ProjectRoundTripTest
         Integration/ProjectRoundTripTest.cpp

--- a/Tests/Headless/AutomationPlaybackTest.cpp
+++ b/Tests/Headless/AutomationPlaybackTest.cpp
@@ -191,7 +191,8 @@ struct Rendered {
 // that insert, sets the playlist BPM to `renderBpm`, and renders `beats` beats.
 // An optional extra effect is inserted at chain slot 1 (after the generator).
 Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double renderBpm, double beats,
-                              std::shared_ptr<IPluginInstance> slot1Fx = nullptr) {
+                              std::shared_ptr<IPluginInstance> slot1Fx = nullptr,
+                              std::function<void(AutomationCurve&, MixerChannel&)> fixup = nullptr) {
     auto trackManager = std::make_shared<TrackManager>();
     trackManager->setOutputSampleRate(static_cast<double>(kSampleRate));
 
@@ -211,6 +212,9 @@ Rendered renderWithAutomation(const std::vector<AutomationCurve>& curves, double
     lane->automationCurves = curves;
     for (auto& curve : lane->automationCurves) {
         curve.mixerChannelId = src->getChannelId();
+        if (fixup) {
+            fixup(curve, *src);
+        }
     }
 
     AudioEngine engine;
@@ -351,13 +355,15 @@ int main() {
     {
         AutomationCurve param("Gain", AutomationTarget::Custom);
         param.setDefaultValue(1.0f);
-        param.effectSlot = 1;
         param.paramId = 0;
         param.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
         param.addPoint(2.0, 1.0f, kSpbAt120, 0.5f);
         param.addPoint(4.0, 0.0f, kSpbAt120, 0.5f);
-        const auto r =
-            renderWithAutomation({param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::Internal));
+        const auto r = renderWithAutomation(
+            {param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::Internal),
+            [](AutomationCurve& curve, MixerChannel& channel) {
+                curve.deviceInstanceId = channel.getEffectChain().getSlotInstanceId(1);
+            });
         require(!r.hasInvalid, "param: output contains NaN/Inf");
         const double loud = rmsWindow(r.left, 0.5, 1.5, 120.0);
         const double mid = rmsWindow(r.left, 2.9, 3.1, 120.0);
@@ -374,11 +380,14 @@ int main() {
     {
         AutomationCurve param("Gain", AutomationTarget::Custom);
         param.setDefaultValue(1.0f);
-        param.effectSlot = 1;
         param.paramId = 0;
         param.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
         param.addPoint(4.0, 0.0f, kSpbAt120, 0.5f);
-        const auto r = renderWithAutomation({param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::VST3));
+        const auto r = renderWithAutomation(
+            {param}, 120.0, 6.0, std::make_shared<GainParamPlugin>(PluginFormat::VST3),
+            [](AutomationCurve& curve, MixerChannel& channel) {
+                curve.deviceInstanceId = channel.getEffectChain().getSlotInstanceId(1);
+            });
         require(!r.hasInvalid, "guard: output contains NaN/Inf");
         const double early = rmsWindow(r.left, 0.5, 1.5, 120.0);
         const double late = rmsWindow(r.left, 4.5, 5.5, 120.0);

--- a/Tests/Integration/AutomationLifecycleTest.cpp
+++ b/Tests/Integration/AutomationLifecycleTest.cpp
@@ -19,6 +19,7 @@
 #include "Plugin/PluginHost.h"
 #include "Plugin/PluginManager.h"
 #include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 
 #include <algorithm>
 #include <cmath>
@@ -28,7 +29,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 using namespace Aestra;
@@ -306,9 +306,8 @@ int main() {
     // Stage 4: save -> load. (trackId, deviceInstanceId, parameterId) must be
     // exact; the chain restores live (registered) plugins with their ids.
     // =========================================================================
-    const auto tempRoot = std::filesystem::temp_directory_path() /
-                          ("aestra_automation_lifecycle_" + std::to_string(::getpid()));
-    std::filesystem::create_directories(tempRoot);
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"automation_lifecycle"};
+    const auto tempRoot = tempDirScope.path();
     const auto projectPath = tempRoot / "lifecycle.aes";
     require(ProjectSerializer::save(projectPath.string(), tm, 120.0, 0.0), "stage4: save");
 

--- a/Tests/Integration/AutomationLifecycleTest.cpp
+++ b/Tests/Integration/AutomationLifecycleTest.cpp
@@ -1,0 +1,408 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// Automation Lifecycle Test (Automation Identity Contract I1-I11):
+//
+//   create -> reorder -> automate -> save -> load -> reorder -> undo -> redo
+//
+// with (trackId, deviceInstanceId, parameterId) asserted at every stage, plus
+// a rendered-output check after the whole cycle. Both structural identity and
+// rendered audio are verified so a false failure localizes to one level.
+
+#include "Commands/EffectCommands.h"
+#include "Core/AudioEngine.h"
+#include "Core/AudioGraphBuilder.h"
+#include "Core/AutomationCurve.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "Plugin/BuiltInPlugins.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/InternalPluginRegistry.h"
+#include "Plugin/PluginHost.h"
+#include "Plugin/PluginManager.h"
+#include "../../Source/Core/ProjectSerializer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using namespace Aestra;
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kBlockFrames = 256;
+constexpr uint32_t kChannels = 2;
+constexpr uint32_t kRenderFrames = static_cast<uint32_t>(1.0 * kSampleRate);
+constexpr uint32_t kSpbAt120 = kSampleRate * 60 / 120;
+
+void require(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "[FAIL] " << msg << "\n";
+        std::exit(1);
+    }
+}
+
+double rmsOf(const std::vector<float>& samples, size_t begin, size_t end) {
+    double acc = 0.0;
+    size_t n = 0;
+    for (size_t i = begin; i < end && i < samples.size(); i += 2) {
+        acc += static_cast<double>(samples[i]) * static_cast<double>(samples[i]);
+        ++n;
+    }
+    return n > 0 ? std::sqrt(acc / static_cast<double>(n)) : 0.0;
+}
+
+// --- registered test plugins: project load restores them LIVE --------------
+
+class LifecycleGeneratorPlugin : public IPluginInstance {
+public:
+    LifecycleGeneratorPlugin() {
+        m_info.id = "aestra.test.lifecycle.gen";
+        m_info.name = "LifecycleGen";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override {}
+    void deactivate() override {}
+    bool isActive() const override { return true; }
+    void process(const float* const* inputs, float** outputs, uint32_t, uint32_t numOutputChannels,
+                 uint32_t numFrames, const MidiBuffer* = nullptr, MidiBuffer* = nullptr) override {
+        for (uint32_t c = 0; c < numOutputChannels; ++c) {
+            if (!outputs[c]) {
+                continue;
+            }
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                const double t = static_cast<double>(i) / static_cast<double>(kSampleRate);
+                outputs[c][i] = static_cast<float>(std::sin(2.0 * 3.14159265358979 * 220.0 * t) * 0.25);
+            }
+        }
+    }
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return 0; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+protected:
+    PluginInfo m_info{};
+};
+
+// Gain on param 0.
+class LifecycleGainPlugin : public LifecycleGeneratorPlugin {
+public:
+    LifecycleGainPlugin() { m_info.id = "aestra.test.lifecycle.gain"; }
+    void setParameter(uint32_t id, float value) override {
+        if (id == 0) {
+            m_gain = value;
+        }
+    }
+    float getParameter(uint32_t id) const override { return id == 0 ? m_gain : 0.0f; }
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* m = nullptr,
+                 MidiBuffer* o = nullptr) override {
+        LifecycleGeneratorPlugin::process(inputs, outputs, numInputChannels, numOutputChannels, numFrames, m, o);
+        for (uint32_t c = 0; c < numOutputChannels; ++c) {
+            if (!outputs[c]) {
+                continue;
+            }
+            for (uint32_t i = 0; i < numFrames; ++i) {
+                outputs[c][i] *= m_gain;
+            }
+        }
+    }
+
+private:
+    float m_gain = 1.0f;
+};
+
+class LifecycleInertPlugin : public LifecycleGeneratorPlugin {
+public:
+    LifecycleInertPlugin() { m_info.id = "aestra.test.lifecycle.inert"; }
+};
+
+void registerTestPlugins() {
+    static bool s_registered = false;
+    if (s_registered) {
+        return;
+    }
+    auto& registry = InternalPluginRegistry::instance();
+    registry.registerPlugin(InternalPluginRegistry::Registration{
+        LifecycleGeneratorPlugin{}.getInfo(),
+        [] { return std::make_shared<LifecycleGeneratorPlugin>(); },
+        [] { return true; },
+    });
+    registry.registerPlugin(InternalPluginRegistry::Registration{
+        LifecycleGainPlugin{}.getInfo(),
+        [] { return std::make_shared<LifecycleGainPlugin>(); },
+        [] { return true; },
+    });
+    registry.registerPlugin(InternalPluginRegistry::Registration{
+        LifecycleInertPlugin{}.getInfo(),
+        [] { return std::make_shared<LifecycleInertPlugin>(); },
+        [] { return true; },
+    });
+    s_registered = true;
+}
+
+// --- structural helpers ------------------------------------------------------
+
+// Slot order as a vector of plugin ids (empty slots skipped).
+std::vector<std::string> chainOrder(EffectChain& chain) {
+    std::vector<std::string> order;
+    for (size_t i = 0; i < EffectChain::MAX_SLOTS; ++i) {
+        const auto* slot = chain.getSlot(i);
+        if (slot && slot->plugin) {
+            order.push_back(slot->plugin->getInfo().id);
+        }
+    }
+    return order;
+}
+
+std::string join(const std::vector<std::string>& v) {
+    std::string out;
+    for (const auto& s : v) {
+        out += s + ",";
+    }
+    return out;
+}
+
+uint64_t instanceIdAt(EffectChain& chain, const std::string& pluginId) {
+    for (size_t i = 0; i < EffectChain::MAX_SLOTS; ++i) {
+        const auto* slot = chain.getSlot(i);
+        if (slot && slot->plugin && slot->plugin->getInfo().id == pluginId) {
+            return chain.getSlotInstanceId(i);
+        }
+    }
+    return 0;
+}
+
+// --- render helper (interleaved windows: sample index = 2 * position) --------
+
+struct Rendered {
+    double early = 0.0;
+    double late = 0.0;
+};
+
+Rendered renderFadeCheck(std::shared_ptr<TrackManager> tm) {
+    AudioEngine engine;
+    engine.setTrackManager(tm);
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kBlockFrames, kChannels);
+    tm->buildAndShareSlotMap();
+    if (auto slotMap = tm->getChannelSlotMapShared()) {
+        engine.setChannelSlotMap(slotMap);
+    }
+    engine.setGraph(AudioGraphBuilder::buildFromTrackManager(*tm));
+    engine.setSafetyLimiterEnabled(false);
+    engine.setTransportPlaying(true);
+
+    std::vector<float> block(static_cast<size_t>(kBlockFrames) * kChannels, 0.0f);
+    std::vector<float> samples;
+    samples.reserve(static_cast<size_t>(kRenderFrames) * kChannels);
+    for (uint32_t rendered = 0; rendered < kRenderFrames; rendered += kBlockFrames) {
+        std::fill(block.begin(), block.end(), 0.0f);
+        engine.processBlock(block.data(), nullptr, kBlockFrames, static_cast<double>(rendered) / kSampleRate);
+        samples.insert(samples.end(), block.begin(), block.end());
+    }
+    engine.setTransportPlaying(false);
+    // Curve drops to 0 at beat 1.0 = position 24000 = sample index 48000.
+    Rendered out;
+    out.early = rmsOf(samples, 4096, 32000);
+    out.late = rmsOf(samples, 72000, 92000);
+    return out;
+}
+
+} // namespace
+
+int main() {
+    if (!PluginManager::getInstance().initialize()) {
+        std::cerr << "FAIL: plugin manager initialize\n";
+        return 1;
+    }
+    registerTestPlugins();
+
+    const std::string kGen = "aestra.test.lifecycle.gen";
+    const std::string kGain = "aestra.test.lifecycle.gain";
+    const std::string kInert = "aestra.test.lifecycle.inert";
+
+    // =========================================================================
+    // Stage 1: create — channel + generator/gain/inert; capture identities.
+    // =========================================================================
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+    auto& playlist = tm->getPlaylistModel();
+    playlist.setProjectSampleRate(static_cast<double>(kSampleRate));
+    playlist.setBPM(120.0);
+    auto* channel = tm->addChannelWithId("Lifecycle", 41);
+    require(channel != nullptr, "channel created");
+    auto& chain = channel->getEffectChain();
+    require(chain.insertPlugin(0, std::make_shared<LifecycleGeneratorPlugin>()), "gen inserted");
+    require(chain.insertPlugin(1, std::make_shared<LifecycleGainPlugin>()), "gain inserted");
+    require(chain.insertPlugin(2, std::make_shared<LifecycleInertPlugin>()), "inert inserted");
+    const uint64_t genId = instanceIdAt(chain, kGen);
+    const uint64_t gainId = instanceIdAt(chain, kGain);
+    const uint64_t inertId = instanceIdAt(chain, kInert);
+    require(genId != 0 && gainId != 0 && inertId != 0, "stage1: identities minted");
+    require(genId != gainId && gainId != inertId, "stage1: identities distinct");
+    require(join(chainOrder(chain)) == kGen + "," + kGain + "," + kInert + ",",
+            "stage1: initial order gen,gain,inert");
+
+    // =========================================================================
+    // Stage 2: reorder (move to empty) via the command seam.
+    // =========================================================================
+    auto& history = tm->getCommandHistory();
+    history.pushAndExecute(
+        std::make_shared<MovePluginCommand>(*tm, *channel, 1, 3)); // gain 1 -> 3 (empty)
+    require(join(chainOrder(chain)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage2: order after move-to-empty is gen,inert,gain");
+    require(instanceIdAt(chain, kGain) == gainId, "stage2: gain identity unchanged by move");
+
+    // =========================================================================
+    // Stage 3: automate — curve targets (trackId, deviceInstanceId, parameterId).
+    // =========================================================================
+    const auto laneId = playlist.createLane("Lane 1");
+    auto* lane = playlist.getLane(laneId);
+    require(lane != nullptr, "lane created");
+    AutomationCurve curve("gain", AutomationTarget::Custom);
+    curve.deviceInstanceId = gainId;
+    curve.paramId = 0;
+    curve.setDefaultValue(1.0f);
+    curve.addPoint(0.0, 1.0f, kSpbAt120, 0.5f);
+    curve.addPoint(0.5, 1.0f, kSpbAt120, 0.5f);
+    curve.addPoint(1.0, 0.0f, kSpbAt120, 0.5f);
+    lane->automationCurves.push_back(curve);
+    lane->automationCurves.back().mixerChannelId = 41;
+
+    // =========================================================================
+    // Stage 4: save -> load. (trackId, deviceInstanceId, parameterId) must be
+    // exact; the chain restores live (registered) plugins with their ids.
+    // =========================================================================
+    const auto tempRoot = std::filesystem::temp_directory_path() /
+                          ("aestra_automation_lifecycle_" + std::to_string(::getpid()));
+    std::filesystem::create_directories(tempRoot);
+    const auto projectPath = tempRoot / "lifecycle.aes";
+    require(ProjectSerializer::save(projectPath.string(), tm, 120.0, 0.0), "stage4: save");
+
+    auto tm2 = std::make_shared<TrackManager>();
+    tm2->setOutputSampleRate(static_cast<double>(kSampleRate));
+    auto& playlist2 = tm2->getPlaylistModel();
+    playlist2.setProjectSampleRate(static_cast<double>(kSampleRate));
+    playlist2.setBPM(120.0);
+    auto result = ProjectSerializer::load(projectPath.string(), tm2);
+    require(result.ok, "stage4: load");
+
+    auto* channel2 = tm2->getChannelById(41);
+    require(channel2 != nullptr, "stage4: channel restored (trackId)");
+    auto& chain2 = channel2->getEffectChain();
+    require(join(chainOrder(chain2)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage4: chain order survives the round trip");
+    require(instanceIdAt(chain2, kGen) == genId && instanceIdAt(chain2, kGain) == gainId &&
+                instanceIdAt(chain2, kInert) == inertId,
+            "stage4: every instance identity survives the round trip exactly");
+    const auto laneIds2 = playlist2.getLaneIDs();
+    require(!laneIds2.empty(), "stage4: lane restored");
+    auto* lane2 = playlist2.getLane(laneIds2[0]);
+    require(lane2 != nullptr && lane2->automationCurves.size() == 1, "stage4: curve restored");
+    const auto& curve2 = lane2->automationCurves[0];
+    require(curve2.mixerChannelId == 41, "stage4: trackId exact");
+    require(curve2.deviceInstanceId == gainId, "stage4: deviceInstanceId exact");
+    require(curve2.paramId == 0, "stage4: parameterId exact");
+
+    // =========================================================================
+    // Stage 5: reorder the LOADED project (swap path: 3 <-> 1 via occupied move).
+    // =========================================================================
+    auto& history2 = tm2->getCommandHistory();
+    history2.pushAndExecute(
+        std::make_shared<MovePluginCommand>(*tm2, *channel2, 3, 1)); // gain 3 -> 1 (empty now)
+    require(join(chainOrder(chain2)) == kGen + "," + kGain + "," + kInert + ",",
+            "stage5: order after move-back is gen,gain,inert");
+    require(instanceIdAt(chain2, kGain) == gainId, "stage5: identity follows the instance");
+
+    history2.pushAndExecute(
+        std::make_shared<MovePluginCommand>(*tm2, *channel2, 1, 2)); // occupied -> swap
+    require(join(chainOrder(chain2)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage5: swap gives gen,inert,gain");
+    require(instanceIdAt(chain2, kGain) == gainId && instanceIdAt(chain2, kInert) == inertId,
+            "stage5: swap carries identities with the instances");
+
+    // =========================================================================
+    // Stage 6: undo restores the EXACT pre-operation ordering and identities.
+    // =========================================================================
+    history2.undo(); // undo the swap
+    require(join(chainOrder(chain2)) == kGen + "," + kGain + "," + kInert + ",",
+            "stage6: undo of swap restores gen,gain,inert");
+    require(instanceIdAt(chain2, kGain) == gainId && instanceIdAt(chain2, kInert) == inertId,
+            "stage6: undo restores every identity");
+    history2.undo(); // undo the move-back
+    require(join(chainOrder(chain2)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage6: undo of move restores gen,inert,gain");
+
+    // =========================================================================
+    // Stage 7: redo reapplies the exact post-operation ordering and identities.
+    // =========================================================================
+    history2.redo();
+    require(join(chainOrder(chain2)) == kGen + "," + kGain + "," + kInert + ",",
+            "stage7: redo of move reapplies gen,gain,inert");
+    history2.redo();
+    require(join(chainOrder(chain2)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage7: redo of swap reapplies gen,inert,gain");
+    require(instanceIdAt(chain2, kGain) == gainId && instanceIdAt(chain2, kInert) == inertId &&
+                instanceIdAt(chain2, kGen) == genId,
+            "stage7: redo leaves every identity untouched");
+
+    // =========================================================================
+    // Stage 8: a rejected move leaves chain AND history untouched.
+    // =========================================================================
+    const auto orderBeforeReject = chainOrder(chain2);
+    history2.pushAndExecute(std::make_shared<MovePluginCommand>(*tm2, *channel2, 2, 2));
+    require(join(chainOrder(chain2)) == join(orderBeforeReject),
+            "stage8: rejected move leaves the chain untouched");
+    history2.undo(); // must undo the last GOOD command (the swap), not a phantom
+    require(join(chainOrder(chain2)) == kGen + "," + kGain + "," + kInert + ",",
+            "stage8: rejected move recorded no undo entry");
+    history2.redo();
+    require(join(chainOrder(chain2)) == kGen + "," + kInert + "," + kGain + ",",
+            "stage8: redo returns to the pre-reject state");
+
+    // =========================================================================
+    // Stage 9: rendered output — after the whole lifecycle the curve still
+    // drives the GAIN instance (fade follows identity, not position).
+    // =========================================================================
+    const Rendered rendered = renderFadeCheck(tm2);
+    std::cout << "render: early=" << rendered.early << " late=" << rendered.late << "\n";
+    require(rendered.early > 1e-3, "stage9: early region is silent");
+    require(rendered.late < 0.02 * rendered.early,
+            "stage9: automation still drives the instance after the full lifecycle");
+
+    std::cout << "[PASS] AutomationLifecycleTest\n";
+    return 0;
+}

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -16,7 +16,6 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
-#include <unistd.h>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -898,9 +897,8 @@ void testTrackColorIndexRoundtrip() {
 void testV1AutomationCurveMigratesToInstanceId() {
     std::cout << "[TEST] v1 automation curve migrates to instance identity..." << std::endl;
 
-    auto testDir = std::filesystem::temp_directory_path() /
-                   ("aestra_v1_automation_migration_" + std::to_string(::getpid()));
-    std::filesystem::create_directories(testDir);
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"v1_automation_migration"};
+    const auto testDir = tempDirScope.path();
     const std::filesystem::path testProject = testDir / "v1_migration.aes";
 
     // A v1 chain-state blob: one occupied slot (unknown plugin id -> placeholder

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -14,6 +14,9 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <unistd.h>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -887,6 +890,128 @@ void testTrackColorIndexRoundtrip() {
     std::cout << "[PASS] trackColorIndex survives save/load roundtrip" << std::endl;
 }
 
+
+// Automation Identity Contract migration: a v1 project (curve carries only a
+// positional slot) gets its curves re-targeted to the chain's MINTED instance
+// ids exactly once at load. The saved v2 project carries the instanceId key;
+// a second load restores it directly (no re-migration, no drift).
+void testV1AutomationCurveMigratesToInstanceId() {
+    std::cout << "[TEST] v1 automation curve migrates to instance identity..." << std::endl;
+
+    auto testDir = std::filesystem::temp_directory_path() /
+                   ("aestra_v1_automation_migration_" + std::to_string(::getpid()));
+    std::filesystem::create_directories(testDir);
+    const std::filesystem::path testProject = testDir / "v1_migration.aes";
+
+    // A v1 chain-state blob: one occupied slot (unknown plugin id -> placeholder
+    // with a minted identity on load), no instance ids on the wire.
+    std::vector<uint8_t> blob{'N', 'E', 'C', 1, static_cast<uint8_t>(EffectChain::MAX_SLOTS)};
+    const auto put = [&blob](const void* data, size_t n) {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        blob.insert(blob.end(), bytes, bytes + n);
+    };
+    blob.push_back(1); // slot 0 occupied
+    const std::string pluginId = "aestra.test.v1.missing.plugin";
+    const uint32_t idLen = static_cast<uint32_t>(pluginId.size());
+    put(&idLen, sizeof(idLen));
+    blob.insert(blob.end(), pluginId.begin(), pluginId.end());
+    const uint8_t bypass = 0;
+    blob.push_back(bypass);
+    const float dryWet = 1.0f;
+    put(&dryWet, sizeof(dryWet));
+    const uint32_t stateLen = 0;
+    put(&stateLen, sizeof(stateLen));
+    for (size_t s = 1; s < EffectChain::MAX_SLOTS; ++s) {
+        blob.push_back(0);
+    }
+    std::string chainHex;
+    {
+        std::ostringstream hex;
+        for (uint8_t b : blob) {
+            hex << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(b);
+        }
+        chainHex = hex.str();
+    }
+
+    const std::string projectJson = std::string(R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "mixerChannels": [{
+            "id": 41,
+            "name": "Track 1",
+            "color": "4294967295",
+            "volume": 1.0,
+            "pan": 0.0,
+            "routing": {"mainOutputId": 0},
+            "effectChainStateHex": ")" + chainHex + R"("
+        }],
+        "lanes": [{
+            "name": "Lane 1",
+            "color": "4294967295",
+            "volume": 1.0,
+            "pan": 0.0,
+            "clips": [],
+            "automation": [{
+                "param": "cutoff",
+                "targetEnum": 255,
+                "mixerChannelId": 41,
+                "default": 0.7,
+                "slot": 0,
+                "paramId": 17,
+                "points": [{"b": 0.0, "v": 0.33, "c": 0.5}]
+            }]
+        }],
+        "arsenal": {"nextId": 1, "units": []}
+    })");
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+
+    auto* channel = trackManager->getChannel(0);
+    assert(channel != nullptr);
+    const uint64_t mintedId = channel->getEffectChain().getSlotInstanceId(0);
+    assert(mintedId != 0);
+
+    auto* lane = trackManager->getPlaylistModel().getLane(
+        trackManager->getPlaylistModel().getLaneIDs()[0]);
+    assert(lane != nullptr && lane->automationCurves.size() == 1);
+    const uint64_t migratedId = lane->automationCurves[0].deviceInstanceId;
+    assert(migratedId == mintedId);
+    assert(lane->automationCurves[0].paramId == 17);
+    assert(lane->automationCurves[0].effectSlot == 0);
+
+    // Save (v2) and reload: the instanceId key is on the wire now, so the
+    // second load restores the SAME id without re-migrating.
+    const std::string saved =
+        ProjectSerializer::serialize(trackManager, 120.0, 0.0, 0).contents;
+    assert(saved.find("instanceId") != std::string::npos);
+
+    const std::filesystem::path testProject2 = testDir / "v2_migration.aes";
+    std::ofstream out2(testProject2);
+    out2 << saved;
+    out2.close();
+
+    auto trackManager2 = std::make_shared<TrackManager>();
+    auto result2 = ProjectSerializer::load(testProject2.string(), trackManager2);
+    assert(result2.ok);
+    auto* channel2 = trackManager2->getChannel(0);
+    auto* lane2 = trackManager2->getPlaylistModel().getLane(
+        trackManager2->getPlaylistModel().getLaneIDs()[0]);
+    assert(channel2 != nullptr && lane2 != nullptr);
+    assert(lane2->automationCurves[0].deviceInstanceId == migratedId);
+    assert(channel2->getEffectChain().getSlotInstanceId(0) == mintedId);
+
+    std::cout << "[PASS] v1 automation curve migrates to instance identity exactly once" << std::endl;
+}
+
 void testProjectLoadWarningsAreBounded() {
     std::cout << "[TEST] Project load warnings are bounded..." << std::endl;
 
@@ -973,6 +1098,7 @@ int main() {
     testMixerLaneStateNumbersClampBeforeCast();
     testTrackColorIndexRoundtrip();
     testProjectLoadWarningsAreBounded();
+    testV1AutomationCurveMigratesToInstanceId();
 
     std::cout << "=== All tests passed ===" << std::endl;
     return 0;

--- a/Tests/Integration/ProjectValueFidelityTest.cpp
+++ b/Tests/Integration/ProjectValueFidelityTest.cpp
@@ -254,6 +254,7 @@ void assertAllValues(Aestra::Audio::TrackManager& tm, const ProjectSerializer::L
         require(param.getAutomationTarget() == AutomationTarget::Custom, tag("param curve target"));
         requireExactF(param.getDefaultValue(), 0.7f, tag("param curve default"));
         require(param.effectSlot == 3, tag("param curve effectSlot"));
+        require(param.deviceInstanceId == 0x1000000000001ull, tag("param curve instanceId"));
         require(param.paramId == 17, tag("param curve paramId"));
         require(param.points.size() == 1, tag("param curve point count"));
         if (param.points.size() == 1) {
@@ -373,10 +374,11 @@ int main() {
         vol.addPoint(kAutoBeatFar, 0.9f, samplesPerBeat, 0.5f);
         lane->automationCurves.push_back(vol);
 
-        // Plugin-parameter curve: slot/paramId addressing must roundtrip.
+        // Plugin-parameter curve: (instanceId, paramId) addressing must roundtrip.
         AutomationCurve param("cutoff", AutomationTarget::Custom);
         param.setDefaultValue(0.7f);
-        param.effectSlot = 3;
+        param.effectSlot = 3; // legacy position retained for compat
+        param.deviceInstanceId = 0x1000000000001ull; // beyond 2^48; exact identity
         param.paramId = 17;
         param.addPoint(1.0, 0.33f, samplesPerBeat, 0.5f);
         lane->automationCurves.push_back(param);

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -254,6 +254,7 @@ target_include_directories(AutomationIdentityResolutionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraCore/include
 )
 add_test(NAME AutomationIdentityResolutionTest COMMAND AutomationIdentityResolutionTest)
+set_tests_properties(AutomationIdentityResolutionTest PROPERTIES LABELS "audio;automation;contract:audio")
 
 # Master strip is a plugin host like any other channel (triage 2026-08-14):
 # processing on the summed master buffer + save/load roundtrip + old-project

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -255,3 +255,21 @@ target_include_directories(AutomationIdentityResolutionTest PRIVATE
 )
 add_test(NAME AutomationIdentityResolutionTest COMMAND AutomationIdentityResolutionTest)
 
+# Master strip is a plugin host like any other channel (triage 2026-08-14):
+# processing on the summed master buffer + save/load roundtrip + old-project
+# compatibility.
+add_executable(MasterEffectChainTest
+    AestraAudio/MasterEffectChainTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+)
+target_link_libraries(MasterEffectChainTest PRIVATE AestraAudio)
+target_include_directories(MasterEffectChainTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Tests
+)
+add_test(NAME MasterEffectChainTest COMMAND MasterEffectChainTest)
+set_tests_properties(MasterEffectChainTest PROPERTIES LABELS "audio;plugins;mixer;regression;persistence;contract:plugins")
+

--- a/Tests/cmake/PluginTests.cmake
+++ b/Tests/cmake/PluginTests.cmake
@@ -245,20 +245,13 @@ target_include_directories(EffectChainInstanceIdentityTest PRIVATE
 add_test(NAME EffectChainInstanceIdentityTest COMMAND EffectChainInstanceIdentityTest)
 set_tests_properties(EffectChainInstanceIdentityTest PROPERTIES LABELS "audio;plugins;automation;regression;contract:plugins")
 
-# Master strip is a plugin host like any other channel (triage 2026-08-14):
-# processing on the summed master buffer + save/load roundtrip + old-project
-# compatibility.
-add_executable(MasterEffectChainTest
-    AestraAudio/MasterEffectChainTest.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
-)
-target_link_libraries(MasterEffectChainTest PRIVATE AestraAudio)
-target_include_directories(MasterEffectChainTest PRIVATE
+# Automation Identity Resolution Test (contract I2/I3/I8/I10)
+add_executable(AutomationIdentityResolutionTest AestraAudio/AutomationIdentityResolutionTest.cpp)
+target_link_libraries(AutomationIdentityResolutionTest PRIVATE AestraAudio)
+target_include_directories(AutomationIdentityResolutionTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include
     ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
     ${CMAKE_SOURCE_DIR}/AestraCore/include
-    ${CMAKE_SOURCE_DIR}/Source
-    ${CMAKE_SOURCE_DIR}/Tests
 )
-add_test(NAME MasterEffectChainTest COMMAND MasterEffectChainTest)
-set_tests_properties(MasterEffectChainTest PROPERTIES LABELS "audio;plugins;mixer;regression;persistence;contract:plugins")
+add_test(NAME AutomationIdentityResolutionTest COMMAND AutomationIdentityResolutionTest)
+


### PR DESCRIPTION
## Summary

The automation identity contract implementation (`Aestra-Internals: 03 Audio Engine/Automation Identity Contract.md`). Three commits, one per contract phase: the chain-state wire format carries instance identity, automation resolves by `deviceInstanceId` instead of positional slot, and reorder becomes a command — with the full lifecycle invariant suite closing the contract.

## Why

Automation targeted plugins by `(trackId, effectSlot, paramId)` — positional. Reordering the FX chain silently retargeted curves to whichever plugin now occupied the slot. The chain already carried stable instance identity internally; the failures were serialization (identity did not survive save/load), resolution (positional at render time), and undoability (reorder was not a command). This PR closes all three.

## What changed (3 commits)

1. **Wire-format v2 identity** (`50f0a918`): `kStateFormatVersion` 1→2; every occupied slot (live plugin or missing-plugin placeholder) serializes its 8-byte instanceId. Load restores v2 ids via `reserveMintedPluginInstanceId`; missing/duplicate ids in a v2 payload are corrupt and mint with a diagnostic; v1 payloads still load and mint (migration rule). Placeholders round-trip their identity exactly like live plugins.
2. **Instance-based resolution** (`f3ed0044`): `AutomationCurve.deviceInstanceId`; the renderer resolves Custom curves via the chain snapshot's `findSlotByInstanceId`; `effectSlot` demoted to a legacy field (migration + older-build compat only, never resolution). A dangling curve (instance gone) is skipped, never re-pointed. The serializer carries `instanceId` as an exact decimal string; v1 curves migrate exactly once at load (slot → minted id, empty slots preserved dangling with a diagnostic).
3. **Reorder command + lifecycle closure** (`7dedbe44`): `MovePluginCommand` (move-to-empty or swap) with exact undo/redo of ordering and identities; no minting or side-effect swapping; invalid moves throw leaving chain AND history untouched; every path rebuilds the graph. `PluginManager::createInstanceById` falls back to the InternalPluginRegistry when the scanner misses an internal plugin (still availability-gated). The `AutomationLifecycleTest` exercises the whole lifecycle — create → reorder → automate → save → load → reorder → undo → redo — asserting `(trackId, deviceInstanceId, parameterId)` at every stage, structurally and at the rendered-output level.

## Testing performed

- `AutomationIdentityResolutionTest` (render-level): reorder and swap never retarget the curve; removing the target leaves it dangling with identity intact (output provably unaffected); a placeholder target stays attached across save/load.
- `AutomationLifecycleTest` (integration, full lifecycle): structural identity at every stage + final rendered check that automation still drives the instance after the whole cycle; rejected move leaves chain and history untouched.
- `EffectChainInstanceIdentityTest` extended: v2 round-trip identity-exact, v1 mint path, missing/duplicate id handling, placeholder round-trip, reserve-against-future-mints.
- v1 migration pinned exactly-once (`ProjectLoadRegressionTest`); wide ids (2^53+1) round-trip through serializer and Muse diagnostics.
- Full suite: 240/240 ctest. App builds. `git diff --check` clean.
- Branch rebased onto `develop` at the merged routing baseline (`846ddd31`); the rebase surfaced and resolved the stale base's VM dependency before publication.

## Producer note

None

## Docs updated

- `Aestra-Internals: 03 Audio Engine/Automation Identity Contract.md` (contract + implementation status; internal vault, not this repo).

## Risk / rollback notes

- **Behavior change**: automation targeting is now instance-based — legacy v1 projects migrate their curves once at load (deterministic, pinned by test). Effect-chain save format bumped to v2 (additive per-slot id; v1 payloads still load).
- The offline/bounce render path resolves automation through the same graph snapshot, so it inherits instance resolution; no separate offline path needed for the curve lookup.
- UI is not headless-testable (#666): the mixer's insert reorder now goes through a command (undoable) — manual pass recommended.
- Rollback: the three commits are separable; commit 1 alone fixes persistence, commit 2 the retarget bug, commit 3 undoability.

Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** Automation now targets plugins by `deviceInstanceId`, not by effect-slot position. Dangling curves remain unresolved after chain changes.
- Updated effect-chain serialization to v2 with persisted 8-byte instance IDs. Legacy v1 data remains loadable through migration.
- Added identity validation, duplicate-ID recovery, placeholder support, and internal-plugin registry fallback during restoration.
- Added `MovePluginCommand` with validation, undo/redo support, move-or-swap behavior, and audio-graph rebuilds.
- Updated project serialization and rendering to preserve instance-based automation.
- Added broad coverage for migration, serialization, placeholders, reordering, lifecycle behavior, rendering, and wide IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->