### PR TITLE
chore(deps): fix 5 undici CVEs in license-signing worker (override 7.29.0)

### DIFF
--- a/workers/license-signing/package-lock.json
+++ b/workers/license-signing/package-lock.json
@@ -2532,9 +2532,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/workers/license-signing/package.json
+++ b/workers/license-signing/package.json
@@ -21,5 +21,8 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.2",
     "wrangler": "^4.114.0"
+  },
+  "overrides": {
+    "undici": "7.29.0"
   }
 }


### PR DESCRIPTION
## Summary

Dependabot sweep (5 open alerts, 1 high + 4 moderate) on the default branch. All five are undici CVEs (CVE-2026-13697 high: cross-user information disclosure + parse-time crash via degenerate private cache directives; plus CRLF injection, cookie attribute injection, Cache-Control whitespace disclosure, retry-interceptor desync — all medium) in the **license-signing worker's dev toolchain**: undici 7.28.0 is a transitive dependency of `wrangler → miniflare`, which pins it exactly.

Fix: `overrides: { "undici": "7.29.0" }` in `workers/license-signing/package.json`. The override replaces miniflare's exact 7.28.0 pin at resolve time (patch-level bump, the security release), and the lockfile's resolved `node_modules/undici` is now 7.29.0. The worker code itself does not import undici — it is wrangler/miniflare's HTTP stack, used only for deploy tooling; nothing ships to users.

## Why

The high-severity CVE includes a parse-time crash vector in the private-cache directive parser; the medium CVEs cover injection/desync classes. None are reachable from the shipped product, but the CI/deploy toolchain should not carry known-vulnerable packages.

## Testing performed

- `npm run typecheck` — passes
- `npm test` (vitest) — 4 files, 57 tests, all pass
- `npm ls undici` — single resolved 7.29.0, miniflare's copy marked `overridden`
- `npm ci` compatibility: lockfile regenerated by npm; worker-ci.yml uses the same lock path

## Producer note

None

## Docs updated?

No.

## Risk/rollback notes

- The override forces undici 7.29.0 into miniflare's exact-pinned slot — a patch-level replacement of the same 7.x line; the worker's full test suite runs in worker-ci.yml on this PR.
- Rollback = revert this PR; dependabot alerts return.
- Bumping wrangler to a release whose miniflare natively uses undici ≥ 7.29 was considered but rejected: wrangler@4.123.0 resolves miniflare to a 5.x alpha. The override keeps wrangler on its pinned 4.114.0.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
