### PR TITLE
feat(pdc): Master strip chain latency feeds the latency graph (P9/G6)

### DIFF
--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -640,6 +640,18 @@ public:
     void setTrackManager(std::shared_ptr<TrackManager> trackManager) {
         if (auto previous = m_trackManager.lock()) {
             previous->setChannelPrepareCallback(nullptr);
+            // Release latency-change callbacks captured from the previous
+            // manager: a later chain mutation on it must not solve PDC
+            // against the new manager (or a destroyed engine). The
+            // destructor only clears the current manager's callbacks.
+            for (size_t i = 0; i < previous->getChannelCount(); ++i) {
+                if (auto* channel = previous->getChannel(i)) {
+                    channel->setEffectChainLatencyCallback(nullptr);
+                }
+            }
+            if (auto* master = previous->getMasterChannel()) {
+                master->setEffectChainLatencyCallback(nullptr);
+            }
         }
         m_trackManager = std::move(trackManager);
         if (auto current = m_trackManager.lock()) {

--- a/AestraAudio/include/Core/AudioEngine.h
+++ b/AestraAudio/include/Core/AudioEngine.h
@@ -665,6 +665,12 @@ public:
                     channel->setEffectChainLatencyCallback([this]() { calculateLatencyCompensation(); });
                 }
             }
+            // The Master strip hosts plugins too: its chain latency feeds the
+            // PDC graph (P9/G6), so chain mutations must re-solve.
+            if (auto* master = current->getMasterChannel()) {
+                prepareChannel(*master);
+                master->setEffectChainLatencyCallback([this]() { calculateLatencyCompensation(); });
+            }
             calculateLatencyCompensation();
         }
     }

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2034,6 +2034,9 @@ AudioEngine::~AudioEngine() {
                 ch->setEffectChainLatencyCallback(nullptr);
             }
         }
+        if (auto* master = trackMgr->getMasterChannel()) {
+            master->setEffectChainLatencyCallback(nullptr);
+        }
     }
     stopLoudnessWorker();
     delete m_unitManagerSnapshot.load(std::memory_order_relaxed);
@@ -3890,7 +3893,14 @@ void AudioEngine::calculateLatencyCompensation() {
     {
         LatencyGraph::Node masterNode;
         masterNode.channelId = kMasterSentinelId;
-        masterNode.intrinsicLatency = 0; // P9 (G6) will populate from master FX.
+        // P9 (G6): the Master strip is a plugin host; its insert-chain latency
+        // delays every path uniformly, so it cancels out of per-track and
+        // per-edge compensation but must surface in project/monitoring
+        // latency. (Device output latency remains parked at the solver.)
+        masterNode.intrinsicLatency = 0;
+        if (auto* master = trackManager->getMasterChannel()) {
+            masterNode.intrinsicLatency = master->getEffectChain().getTotalLatency();
+        }
         masterNode.muted = false;
         masterNode.domain = LatencyDomain::FullyCompensated;
         graph.nodes.push_back(masterNode);

--- a/AestraAudio/src/Core/LatencyTopology.cpp
+++ b/AestraAudio/src/Core/LatencyTopology.cpp
@@ -197,7 +197,9 @@ SolvedLatencyTopology solveLatency(const LatencyGraph& graph) {
     }
 
     topology.projectAlignmentLatency = maxAlignment;
-    // P9 (G6) will add master FX + device output to monitoring latency.
+    // P9 (G6): master-FX latency reaches this value through the master node's
+    // intrinsic latency (uniform across all paths). Device output latency
+    // remains parked here as the outstanding P9 piece.
     topology.monitoringLatency = maxAlignment;
 
     return topology;

--- a/Tests/AestraAudio/LatencyCompensationTest.cpp
+++ b/Tests/AestraAudio/LatencyCompensationTest.cpp
@@ -3,6 +3,8 @@
 
 #include "AudioEngine.h"
 #include "Models/TrackManager.h"
+#include "Plugin/EffectChain.h"
+#include "Plugin/PluginHost.h"
 
 #include <cassert>
 #include <iostream>
@@ -13,6 +15,70 @@ using namespace Aestra::Audio;
 constexpr uint32_t kSampleRate = 48000;
 constexpr uint32_t kFrames = 256;
 constexpr uint32_t kChannels = 2;
+
+// Minimal plugin reporting a fixed intrinsic latency (PDC input).
+class FixedLatencyPlugin : public IPluginInstance {
+public:
+    explicit FixedLatencyPlugin(uint32_t latency) : m_latency(latency) {
+        m_info.id = "aestra.test.fixed_latency";
+        m_info.name = "FixedLatency";
+        m_info.vendor = "Aestra Test";
+        m_info.version = "1.0";
+        m_info.category = "Test";
+        m_info.format = PluginFormat::Internal;
+        m_info.type = PluginType::Effect;
+        m_info.numAudioInputs = 2;
+        m_info.numAudioOutputs = 2;
+    }
+    bool initialize(double, uint32_t) override { return true; }
+    void shutdown() override {}
+    void activate() override {}
+    void deactivate() override {}
+    bool isActive() const override { return true; }
+    void process(const float* const* inputs, float** outputs, uint32_t numInputChannels,
+                 uint32_t numOutputChannels, uint32_t numFrames, const MidiBuffer* = nullptr,
+                 MidiBuffer* = nullptr) override {
+        if (!outputs || !outputs[0] || !outputs[1]) {
+            return;
+        }
+        // Dry pass-through: latency reporting is what this plugin is for.
+        if (inputs && inputs[0] && inputs[1]) {
+            for (uint32_t k = 0; k < numFrames; ++k) {
+                outputs[0][k] = inputs[0][k];
+                outputs[1][k] = inputs[1][k];
+            }
+        } else {
+            for (uint32_t k = 0; k < numFrames; ++k) {
+                outputs[0][k] = 0.0f;
+                outputs[1][k] = 0.0f;
+            }
+        }
+    }
+    std::vector<PluginParameter> getParameters() const override { return {}; }
+    uint32_t getParameterCount() const override { return 0; }
+    float getParameter(uint32_t) const override { return 0.0f; }
+    void setParameter(uint32_t, float) override {}
+    std::string getParameterDisplay(uint32_t) const override { return {}; }
+    std::vector<uint8_t> saveState() const override { return {}; }
+    bool loadState(const std::vector<uint8_t>&) override { return true; }
+    bool hasEditor() const override { return false; }
+    bool openEditor(void*) override { return false; }
+    void closeEditor() override {}
+    bool isEditorOpen() const override { return false; }
+    std::pair<int, int> getEditorSize() const override { return {0, 0}; }
+    bool resizeEditor(int, int) override { return false; }
+    const PluginInfo& getInfo() const override { return m_info; }
+    uint32_t getLatencySamples() const override { return m_latency; }
+    uint32_t getTailSamples() const override { return 0; }
+    WatchdogStats getWatchdogStats() const override { return {}; }
+    void resetWatchdog() override {}
+    bool isBypassedByWatchdog() const override { return false; }
+    bool isCrashed() const override { return false; }
+
+private:
+    PluginInfo m_info{};
+    uint32_t m_latency{0};
+};
 
 void testPDCInitialization() {
     std::cout << "Test: PDC initializes correctly...\n";
@@ -108,6 +174,52 @@ void testPDCMultipleTracks() {
     std::cout << "  [PASS] Multiple tracks initialize with zero latency\n";
 }
 
+// P9 (G6): the Master strip's chain latency feeds the PDC graph. Inserting a
+// latency plugin on Master must raise the project latency (and re-solve via
+// the latency-change callback); removing it must return to zero.
+void testPDCMasterChainLatency() {
+    std::cout << "Test: master chain latency surfaces in project latency...\n";
+
+    auto trackManager = std::make_shared<TrackManager>();
+    trackManager->addChannel("Track 1");
+    auto* master = trackManager->getMasterChannel();
+    assert(master != nullptr);
+
+    AudioEngine engine;
+    engine.setTrackManager(trackManager);
+    engine.setSampleRate(kSampleRate);
+    engine.setBufferConfig(kFrames, kChannels);
+
+    assert(engine.getMaxProjectLatency() == 0);
+    assert(engine.isLatencyCompensationEnabled() == true);
+
+    // Master plugin with 128 samples of latency: project latency must follow.
+    auto latencyPlugin = std::make_shared<FixedLatencyPlugin>(128);
+    assert(master->getEffectChain().insertPlugin(0, latencyPlugin));
+    assert(engine.getMaxProjectLatency() == 128);
+
+    // A second master plugin adds its latency to the path (128 + 64).
+    assert(master->getEffectChain().insertPlugin(1, std::make_shared<FixedLatencyPlugin>(64)));
+    assert(engine.getMaxProjectLatency() == 192);
+
+    // Removal re-solves back down.
+    assert(master->getEffectChain().removePlugin(1) != nullptr);
+    assert(engine.getMaxProjectLatency() == 128);
+    assert(master->getEffectChain().removePlugin(0) != nullptr);
+    assert(engine.getMaxProjectLatency() == 0);
+
+    // Track latency is unaffected by the master path: the master's 128 is
+    // uniform, so a 64-latency track still aligns against it with its own
+    // compensation, and the project latency reflects the longest path.
+    auto* track = trackManager->getChannel(0);
+    assert(track != nullptr);
+    assert(master->getEffectChain().insertPlugin(0, std::make_shared<FixedLatencyPlugin>(128)));
+    assert(track->getEffectChain().insertPlugin(0, std::make_shared<FixedLatencyPlugin>(64)));
+    assert(engine.getMaxProjectLatency() == 192); // 64 + 128 on the single path
+
+    std::cout << "  [PASS] Master chain latency tracked, callback re-solves on mutation\n";
+}
+
 int main() {
     std::cout << "=== Plugin Delay Compensation (PDC) Tests ===\n\n";
 
@@ -116,6 +228,7 @@ int main() {
     testPDCEnableDisable();
     testPDCCallbackOnPluginInsert();
     testPDCMultipleTracks();
+    testPDCMasterChainLatency();
 
     std::cout << "\n=== All PDC Tests Passed ===\n";
     return 0;

--- a/Tests/Headless/PDCBranchingConvergenceTest.cpp
+++ b/Tests/Headless/PDCBranchingConvergenceTest.cpp
@@ -206,6 +206,50 @@ void testNoCycleWarning() {
     EXPECT_TRUE(t.warnings.empty());
 }
 
+// P9 (G6): the Master strip's insert-chain latency must surface in project
+// and monitoring latency while cancelling out of per-track/per-edge
+// compensation — it delays every path uniformly, so no track may be delayed
+// further to "align" with it.
+void testMasterIntrinsicLatency() {
+    std::printf("[PDCBranchingConvergenceTest] master intrinsic latency: uniform, cancels from compensation...\n");
+    constexpr uint32_t kMasterLatency = 128;
+
+    LatencyGraph direct;
+    direct.generation = 1;
+    // channelId is a label; edges reference node *indices* (0, 1 here).
+    direct.nodes.push_back({kA, 0, false, LatencyDomain::FullyCompensated});
+    direct.nodes.push_back({kMaster, kMasterLatency, false, LatencyDomain::FullyCompensated});
+    direct.edges.push_back({0, 1, false});
+
+    const auto t = solveLatency(direct);
+    EXPECT_EQ(findNode(t, kA)->totalPathLatency, kMasterLatency);
+    EXPECT_EQ(t.projectAlignmentLatency, kMasterLatency);
+    EXPECT_EQ(t.monitoringLatency, kMasterLatency);
+    // The whole point: master latency must NOT delay the source track.
+    EXPECT_EQ(findNode(t, kA)->outputCompensationSamples, 0u);
+    EXPECT_EQ(findEdge(t, 0, 1)->compensationSamples, 0u);
+    EXPECT_EQ(findNode(t, kMaster)->outputCompensationSamples, 0u);
+
+    // Through a bus: A(0) -> Bus(100) -> Master(128). totalPath(A) = 228,
+    // alignment = 228, compensation still zero everywhere on the path.
+    LatencyGraph chained;
+    chained.generation = 2;
+    chained.nodes.push_back({kA, 0, false, LatencyDomain::FullyCompensated});
+    chained.nodes.push_back({kBus1, 100, false, LatencyDomain::FullyCompensated});
+    chained.nodes.push_back({kMaster, kMasterLatency, false, LatencyDomain::FullyCompensated});
+    chained.edges.push_back({0, 1, false});
+    chained.edges.push_back({1, 2, false});
+
+    const auto tc = solveLatency(chained);
+    EXPECT_EQ(findNode(tc, kA)->totalPathLatency, 228u);
+    EXPECT_EQ(tc.projectAlignmentLatency, 228u);
+    EXPECT_EQ(tc.monitoringLatency, 228u);
+    EXPECT_EQ(findNode(tc, kA)->outputCompensationSamples, 0u);
+    EXPECT_EQ(findNode(tc, kBus1)->outputCompensationSamples, 0u);
+    EXPECT_EQ(findEdge(tc, 0, 1)->compensationSamples, 0u);
+    EXPECT_EQ(findEdge(tc, 1, 2)->compensationSamples, 0u);
+}
+
 } // namespace
 
 int main() {
@@ -218,6 +262,7 @@ int main() {
     testEdgeCompensationDelaysFastBranch();
     testReconvergenceAlignmentArithmetic();
     testNoCycleWarning();
+    testMasterIntrinsicLatency();
 
     if (g_failures == 0) {
         std::printf("=== PDCBranchingConvergenceTest: all checks passed ===\n");


### PR DESCRIPTION
## Summary

PDC P9 (G6): the Master strip's insert-chain latency now feeds the plugin-delay-compensation graph. This was the deferred follow-up from PR #767, parked in code as "P9 (G6) will populate it with real master-FX latency" (AudioEngine.cpp) and "P9 (G6) will add master FX + device output to monitoring latency" (LatencyTopology.cpp).

Changes:
- `calculateLatencyCompensation()` populates the synthetic master node's `intrinsicLatency` from `getMasterChannel()->getEffectChain().getTotalLatency()`.
- The master chain's latency-change callback is wired (alongside the channel callbacks in `setTrackManager`, cleared in the destructor), so plugin insert/remove/bypass on Master re-solves PDC immediately.
- Solver comment updated: master-FX latency now reaches `monitoringLatency` through the node's intrinsic latency; device-output latency remains the outstanding P9 piece.

Why it's safe: master latency delays every path uniformly, so it cancels out of per-track output compensation and per-edge compensation (the solver test pins this: a latency plugin on Master raises `projectAlignmentLatency`/`monitoringLatency` but adds zero compensation anywhere). What changes observably: `getMaxProjectLatency()` (and the published topology) now report the project's true end-to-end latency when Master hosts latency plugins.

## Why

PDC exists to keep parallel paths sample-aligned AND to report the project's true latency. Master plugins were processed (PR #767) but invisible to the latency model: the project latency stayed wrong with a latency plugin on Master, and plugin changes on Master never triggered a re-solve.

## Testing performed

- New solver case in PDCBranchingConvergenceTest (the P4a correctness gate): master intrinsic 128 — direct (A→Master) and chained (A→Bus100→Master128) graphs — asserts totalPath/alignment/monitoring include master latency while output and edge compensation stay zero (no double-delay of tracks).
- New engine case in LatencyCompensationTest: FixedLatencyPlugin (reporting 128/64) inserted on Master → `getMaxProjectLatency()` follows (0 → 128 → 192 → 128 → 0 through insert/insert/remove/remove), proving the latency-change callback re-solves; combined track(64)+master(128) case asserts the longest-path total.
- Full suite green (0 failures; SecAccountEndToEndSmoke skipped by design).

## Producer note

None

## Docs updated?

No public docs. Internal PDC-v2 design note (Aestra-Internals) already describes G6.

## Risk/rollback notes

- Reverting #767's master-as-plugin-host work would orphan this PR; they are one feature family. Rollback = revert both.
- The solver's behavior for existing projects is unchanged when Master has no plugins (intrinsic 0, same as before).
- Device-output latency in monitoring latency remains parked (needs the driver-reported hardware latency).

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Master effect-chain latency now contributes to PDC through the synthetic Master node.
- PDC re-solves when Master plugins are inserted, removed, or bypassed.
- Master latency updates project alignment and monitoring latency without adding per-track or per-edge compensation.
- Added tests for direct paths, bus-routed paths, Master plugin changes, and combined track/Master latency.
- Clarified that device-output latency remains outstanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->