### PR TITLE
fix(mixer): master insert bypass sync honors the optimistic dirty flag

### DIFF
--- a/Source/Components/MixerViewModel.cpp
+++ b/Source/Components/MixerViewModel.cpp
@@ -144,11 +144,22 @@ void MixerViewModel::syncFromEngine(const Audio::TrackManager& trackManager,
                     vm.isEmpty = false;
                     vm.name = slot->plugin->getInfo().name;
                     if (vm.name.empty()) vm.name = "Plugin";
-                    vm.bypassed = slot->bypassed.load();
+                    // Same optimistic-bypass contract as channel inserts: a UI
+                    // bypass toggle is preserved until the engine confirms it,
+                    // so the strip does not flicker for one sync cycle.
+                    const bool engineBypassed = slot->bypassed.load();
+                    if (vm.bypassDirty) {
+                        if (vm.bypassed == engineBypassed) {
+                            vm.bypassDirty = false;
+                        }
+                    } else {
+                        vm.bypassed = engineBypassed;
+                    }
                     vm.mix = slot->dryWetMix.load();
                 } else {
                     vm.isEmpty = true;
                     vm.name.clear();
+                    vm.bypassDirty = false;
                 }
             }
             m_master->fxCount = fxCount;


### PR DESCRIPTION
## Summary

One-cycle optimistic-sync parity for Master insert bypass (follow-up from PR #767's human review, finding #5).

Channel inserts preserve an optimistic UI bypass toggle (`bypassDirty`) until the engine confirms it — `setInsertBypass` sets `vm.bypassed` + `vm.bypassDirty = true`, and the sync block keeps the UI value until the engine's state matches, then clears the flag. The Master sync block (added in #767) wrote `vm.bypassed` straight from the engine every sync, so a Master insert bypass toggle could visually flicker back for one sync cycle before the confirm landed. No new semantics: the master block now mirrors the channel contract, and empty slots reset the dirty flag.

## Why

Master is a plugin host with the same insert UI as channels; its sync state machine should be the same one. A known one-cycle flicker is not worth carrying into the milestone.

## Testing performed

- App builds clean.
- The sync logic mirrors the channel block that is exercised by the existing mixer command tests; no engine/audio behavior changes (view-model state only).

## Producer note

None

## Docs updated?

No.

## Risk/rollback notes

- View-model-only change; no audio path, no serialization.
- Revert = revert this PR.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
