### PR TITLE
fix(audio): master-routed clips obey the live solo gate

### DIFF
--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -2403,7 +2403,15 @@ void AudioEngine::renderGraph(const AudioGraph& graph, uint32_t numFrames, uint3
 
     // Sources routed to Master bypass mixer inserts but still share the same
     // transport, clip-edit, resampling, and safety path as insert-routed clips.
-    renderClips(graph.masterClips, masterBuf, ctx, srcActiveThisBlock);
+    // Solo gate (isolated-bounce contract, 2026-08-14): solo determines which
+    // track content is audible in the live mix, and the master stage obeys the
+    // active solo gate exactly like master-routed units. Master clips have no
+    // soloable owner (mixerChannelId 0 = Master, which is never soloed), so any
+    // active solo silences them. Isolated-track bounce excludes the master
+    // stage entirely by design — this gate is live-path only.
+    if (!ctx.anySolo) {
+        renderClips(graph.masterClips, masterBuf, ctx, srcActiveThisBlock);
+    }
 
     if (unitSnapshot) {
         for (const auto& unit : unitSnapshot->units) {

--- a/Tests/AestraAudio/RealtimeExportParityTest.cpp
+++ b/Tests/AestraAudio/RealtimeExportParityTest.cpp
@@ -516,6 +516,100 @@ bool runSplitVarispeedParityCase(const SessionConfig& cfg, const fs::path& tempR
     return pass;
 }
 
+// -----------------------------------------------------------------------------
+// Case 6: isolated-track bounce excludes the master stage entirely
+// (isolated-bounce contract, 2026-08-14). A master-routed clip (997 Hz) and a
+// channel clip (440 Hz) share the session; bouncing the channel in isolation
+// must deliver the 440 Hz tone and NOT the 997 Hz master content.
+// -----------------------------------------------------------------------------
+bool runIsolatedBounceExcludesMasterClips(const SessionConfig& cfg, const fs::path& tempRoot) {
+    constexpr double kMasterToneHz = 997.0;
+    constexpr double kChannelToneHz = 440.0;
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(cfg.sampleRate));
+
+    // Channel clip: 440 Hz sine via the standard harness (routes to channel 1).
+    addAudioTrack(*tm, "ChannelA", makeSine(kChannelToneHz, 0.30f, totalFrames, cfg.sampleRate), totalFrames, cfg);
+
+    // Master clip: same construction but the pattern targets mixerChannelId 0.
+    {
+        auto buffer = std::make_shared<AudioBufferData>();
+        buffer->sampleRate = cfg.sampleRate;
+        buffer->numChannels = cfg.channels;
+        buffer->numFrames = totalFrames;
+        buffer->interleavedData = makeSine(kMasterToneHz, 0.25f, totalFrames, cfg.sampleRate);
+
+        const std::string path =
+            (std::filesystem::temp_directory_path() / "aestra_rt_export_parity_master_clip.wav").string();
+        ClipSourceID sourceId = tm->getSourceManager().createRecordedSource(path, "MasterClip", buffer);
+
+        AudioSlicePayload payload;
+        payload.audioSourceId = sourceId;
+        payload.durationSeconds = static_cast<double>(totalFrames) / cfg.sampleRate;
+        payload.slices.push_back({0.0, payload.durationSeconds, 0.0, static_cast<double>(totalFrames)});
+
+        PlaylistLaneID laneId = tm->getPlaylistModel().createLane("MasterLane");
+        const double durationBeats = payload.durationSeconds * (static_cast<double>(cfg.bpm) / 60.0);
+        PatternID patternId = tm->getPatternManager().createAudioPattern("MasterClip", durationBeats, payload);
+        tm->getPatternManager().setPatternMixerChannel(patternId, 0);
+        const ClipInstanceID clipId = tm->getPlaylistModel().addClipFromPattern(laneId, patternId, 0.0, durationBeats);
+        if (!tm->getPlaylistModel().setClipEdits(clipId, ClipEdits{})) {
+            std::cerr << "setClipEdits (master clip) failed\n";
+            return false;
+        }
+    }
+
+    // Isolated-track bounce of the channel (trackId 0).
+    AudioEngine bounceEngine;
+    prepareEngine(bounceEngine, tm, cfg);
+    warmupEngine(bounceEngine, cfg);
+    const fs::path outPath = tempRoot / "parity_isolated_excludes_master.wav";
+    if (!bounceEngine.bounceRangeToWav(0.0, kBeats, outPath.string(), 0)) {
+        std::cerr << "isolated bounceRangeToWav failed\n";
+        return false;
+    }
+    std::vector<float> bounced;
+    uint32_t sr = 0, ch = 0;
+    if (!decodeAudioFile(outPath.string(), bounced, sr, ch)) {
+        std::cerr << "failed to decode isolated bounce\n";
+        return false;
+    }
+    if (sr != cfg.sampleRate || ch != cfg.channels) {
+        std::cerr << "isolated bounce format mismatch\n";
+        return false;
+    }
+
+    // Steady-region correlation with each tone: amplitude estimate via
+    // sine/cosine projection (both tones are separable by construction).
+    const size_t firstFrame = static_cast<size_t>(cfg.blockSize) * 4;
+    const size_t endFrame = static_cast<size_t>(totalFrames) - 256;
+    const auto toneAmplitude = [&](double freq) {
+        double sinAcc = 0.0, cosAcc = 0.0;
+        for (size_t n = firstFrame; n < endFrame; ++n) {
+            const double phase = kTau * freq * static_cast<double>(n) / sr;
+            const double s = static_cast<double>(bounced[n * 2]);
+            sinAcc += s * std::sin(phase);
+            cosAcc += s * std::cos(phase);
+        }
+        const double count = static_cast<double>(endFrame - firstFrame);
+        return 2.0 * std::sqrt(sinAcc * sinAcc + cosAcc * cosAcc) / count;
+    };
+
+    const double channelAmp = toneAmplitude(kChannelToneHz);
+    const double masterAmp = toneAmplitude(kMasterToneHz);
+    const bool pass = channelAmp > 0.15 && masterAmp < 0.005;
+    std::cout << (pass ? "[PASS]" : "[FAIL]") << " Isolated_Bounce_Excludes_MasterClips"
+              << " channel440=" << channelAmp << " master997=" << masterAmp << "\n";
+    if (!pass) {
+        std::cerr << "  contract: isolated bounce renders only the selected track's stage;"
+                     " master content must be absent\n";
+    }
+    return pass;
+}
+
+
 } // namespace
 
 int main() {
@@ -541,6 +635,7 @@ int main() {
     for (float speed : {2.0f, 0.5f}) {
         if (!runIsolatedSpeedParityCase(cfg, tempRoot, speed)) ++failures;
     }
+    if (!runIsolatedBounceExcludesMasterClips(cfg, tempRoot)) ++failures;
     // Pitch cases (#746): pure pitch, pitch cancelling speed, and interplay.
     for (const auto& [speed, pitch] : {std::pair{1.0f, 12.0f}, {2.0f, -12.0f}, {0.5f, 7.0f}}) {
         if (!runIsolatedSpeedParityCase(cfg, tempRoot, speed, pitch)) ++failures;

--- a/Tests/Headless/RoutingMasterDirectParityTest.cpp
+++ b/Tests/Headless/RoutingMasterDirectParityTest.cpp
@@ -128,6 +128,47 @@ double rmsRange(const std::vector<float>& interleaved, size_t firstFrame, size_t
     return std::sqrt(sumSq / static_cast<double>(endSample - firstSample));
 }
 
+// Isolated-bounce contract, live half (2026-08-14): solo determines which
+// track content is audible in the live mix, and the master stage obeys the
+// active solo gate like master-routed units. Master clips have no soloable
+// owner (mixerChannelId 0 = Master, never soloed), so ANY active solo
+// silences them. The bounce half (master stage excluded from isolated-track
+// bounce) is pinned in RealtimeExportParityTest.
+void testMasterClipsRespectSolo() {
+    std::printf("[RoutingMasterDirectParityTest] master-routed clips obey the live solo gate...\n");
+    GoldenAudio::SessionConfig cfg;
+    const uint32_t totalFrames = cfg.sampleRate * kSeconds;
+    const std::vector<float> tone = makeTone(totalFrames, cfg.sampleRate);
+
+    // Baseline: no solo -> the master clip is audible.
+    const std::vector<float> noSolo = render(buildSession(0, tone, totalFrames, cfg), cfg);
+    const double noSoloRms = rmsRange(noSolo, static_cast<size_t>(cfg.blockSize) * 4,
+                                      static_cast<size_t>(totalFrames) - 256, cfg.channels);
+    EXPECT_TRUE(noSoloRms > 1e-4);
+    if (noSoloRms <= 1e-4) {
+        return;
+    }
+
+    // Another track soloed -> the master clip must be silent (the soloed
+    // track has no clips, so the whole output is silent).
+    auto soloSession = buildSession(0, tone, totalFrames, cfg);
+    auto* soloChannel = soloSession->getChannel(0);
+    EXPECT_TRUE(soloChannel != nullptr);
+    if (!soloChannel) {
+        return;
+    }
+    soloChannel->setSolo(true);
+    const std::vector<float> soloOut = render(soloSession, cfg);
+    const double soloRms = rmsRange(soloOut, static_cast<size_t>(cfg.blockSize) * 4,
+                                    static_cast<size_t>(totalFrames) - 256, cfg.channels);
+    EXPECT_TRUE(soloRms < 1e-5);
+    if (soloRms >= 1e-5) {
+        return;
+    }
+
+    std::printf("[RoutingMasterDirectParityTest] PASS: no-solo rms=%.6f, soloed rms=%.6f\n", noSoloRms, soloRms);
+}
+
 void testMasterDirectMatchesChannelRouted() {
     std::printf("[RoutingMasterDirectParityTest] master-direct clip == channel-routed clip at unity...\n");
     GoldenAudio::SessionConfig cfg;
@@ -187,6 +228,7 @@ int main() {
     std::printf("=== RoutingMasterDirectParityTest (routing/gain BUG-3 triage 2026-08-14) ===\n");
     try {
         testMasterDirectMatchesChannelRouted();
+        testMasterClipsRespectSolo();
     } catch (const std::exception& e) {
         reportFailure("fixture setup", e.what());
     }


### PR DESCRIPTION
## Summary

Isolated-bounce contract, live half (Option A of the deliberate decision): **solo determines which track content is audible in the live mix; isolated-track bounce renders only the selected track's own stage and excludes the master stage entirely.**

The isolated-bounce side of the contract already held (master clips AND master units are excluded by design, per `rendersClips`/`processArsenalUnits`/AudioExporter.h). The live side was inconsistent: master-routed clips ignored the solo gate while master-routed units respected it.

Changes:
- `AudioEngine::renderGraph` gates `renderClips(graph.masterClips, ...)` on `!ctx.anySolo`. Master clips have no soloable owner (mixerChannelId 0 = Master, never soloed), so any active solo silences them — the same rule master units already follow. Live-path only; the bounce renderer is untouched.
- Regression tests pin both halves:
  - `RoutingMasterDirectParityTest::testMasterClipsRespectSolo` — no solo → master clip audible (rms 0.177); another track soloed → master clip silent (rms 0.000000).
  - `RealtimeExportParityTest::runIsolatedBounceExcludesMasterClips` — session with a 440 Hz channel clip + a 997 Hz master clip; isolated bounce of the channel delivers 440 (amp 0.30) and NOT 997 (amp 6.7e-05).

## Why

The contract was implicit and half-enforced. Soloing a track kept master-stage clips playing live while the same content disappeared from an isolated bounce — the two features disagreed about what "isolated" means. The fix makes the code match its documented semantics (AudioExporter.h: "isolated-track bounce intentionally skips the master stage") instead of redefining the bounce to accommodate a live-path inconsistency.

## Testing performed

- Full suite green (0 failures; SecAccountEndToEndSmoke skipped by design).
- New tests above with measured values; no bounce-renderer changes (architecture untouched per the contract).

## Producer note

Soloing a track now silences clips routed straight to the Master, matching what an isolated bounce of that track delivers.

## Docs updated?

No public docs. The contract is now stated in code comments at both enforcement points.

## Risk/rollback notes

- Behavior change: with any track soloed, master-routed clips are silent (previously audible). This matches DAW convention and the master-units rule.
- Rollback = revert this PR; the solo test then fails, which is the point.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
