### PR TITLE
docs: v0.7.0-alpha release text — changelog, quarterly, releases, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
 
-331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 > **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
 
@@ -185,7 +185,15 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ### Automation
 
-- Automation targets the instance it was drawn for, never the slot it occupied — chain reordering keeps curves bound to their plugin.
+- Plugin instances carry permanent identities in the chain state (#667 slice 1), so automation and saved state
+  survive chain edits without aliasing.
+- Automation lanes are actually automatable: the first click on an empty lane creates a neutral Volume
+  curve bound to the lane's channel, and edits rebuild the audio graph and mark the project dirty.
+- Leftover demo automation removed from the default project and from previously saved projects.
+
+> Cut-time gate: instance-targeted automation (curves address the plugin instance rather than the slot)
+> is #766, still open at this writing. If it merges before the cut, restore the stronger claim; if not,
+> the entry above is the accurate one.
 - Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,43 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ---
 
+## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
+
+331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+
+> **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
+
+### Routing & Mixing Correctness
+
+- Unity gain law end to end: channel strips use the stereo-balance law, so routing a signal through any mixer channel no longer attenuates it — and the same law governs live playback, offline export, isolated bounce, audition preview, and input monitoring (parity pinned by tests).
+- Fader and pan applied once: one UI gesture no longer writes two stores that the engine multiplied (−6 dB on the fader used to play at −12 dB).
+- Routing command seam with mutation-time cycle rejection, stable send IDs, and master-legality enforcement; render-path semantics match the routing contract (V1/V2/V3) with live/offline parity.
+- Master channel is a valid plugin host: insert chains process on the master bus before the fader and safety limiter, persist in the project file, and their latency feeds the plugin-delay-compensation graph (reported project latency is now the real end-to-end delay).
+- Master-routed clips obey the live solo gate; isolated-track bounce renders only the selected track's stage and excludes the master stage by design — both halves of the isolation contract are pinned by tests.
+
+### Automation
+
+- Automation targets the instance it was drawn for, never the slot it occupied — chain reordering keeps curves bound to their plugin.
+- Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
+- Leftover demo automation removed from the default project and from previously saved projects.
+
+### Piano Roll & Sequencing
+
+- Selection subdivision by snap, proportional selection stretching, chord-aware stroke input, harmony context persistence, contextual editor workspace, playhead alignment in timeline mode, and bidirectional sampler ping-pong loops.
+
+### UI & Editing
+
+- Design constitution pass across mixer, browser, timeline, and arsenal.
+- Audio Clip editor: musical pitching, trim persistence, live waveform updates, resize-safe layout.
+- Timeline geometry has a single authority for grid and x→beat conversion.
+
+### Reliability & Hardening
+
+- Security, durability, and realtime contract lanes are CI-authoritative; test contract coverage and founder decision citations are enforced gates.
+- Plugin hosting compiles in CI; Windows plugins run sandboxed out-of-process; CLAP SDK vendored.
+- The routing/automation/master/UI triage branch went through four review rounds (human + CodeRabbit) with 20 findings addressed before merge.
+- License-signing worker dependencies cleaned (undici CVEs).
+
 ## [Unreleased]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Paths that are covered by tests and verified end to end:
 Aestra also exposes a **scriptable control surface** — see [Muse](#muse-the-control-surface) below.
 
 > **A note on documentation currency.** The narrative documents below lag the code by
-> some margin: the roadmap describes repo state as of January 2026, and `CHANGELOG.md`
-> stops at v0.4.0-alpha in May. Several hundred commits have landed since. Until they are
-> refreshed, `git log` and the test suite are the honest sources, and this section is
+> some margin: the roadmap describes repo state as of January 2026. `CHANGELOG.md` is
+> current through the v0.7.0-alpha milestone, and where a document and the code
+> disagree, `git log` and the test suite are the honest sources — this section is
 > written from them rather than from the documents.
 
 - [docs/technical/testing_ci.md](docs/technical/testing_ci.md) — CI posture and test lanes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -33,7 +33,7 @@ v1.0.0                  — initial public release
 
 ### v0.7.0-alpha — Routing, Automation & Hosting Milestone (Aug 2026)
 
-331 PRs merged (#624–#771). The milestone's story is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+331 PRs merged (#624–#771). The milestone's story is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 **Routing & Mixing** — Unity gain law across live, export, isolated bounce, audition, and monitoring; single-store fader/pan; routing command seam with cycle rejection and stable send IDs; Master as a plugin host with chain latency in the PDC graph; master clips obey the live solo gate (isolation contract pinned both ways).
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,11 +24,28 @@ v1.0.0                  — initial public release
 | `v1.0.0`             | Deleted   | —          | Premature — do not recreate until release |
 | `v0.4.0-alpha`       | Superseded | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
 | `v0.5.0-alpha`       | Superseded | 2026-05-23 | Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs merged |
-| `v0.6.0-alpha`       | Current   | 2026-05-29 | Security & RT hardening, plugin host crash resilience, callback-safety architecture, 26 PRs merged |
+| `v0.6.0-alpha`       | Superseded | 2026-05-29 | Security & RT hardening, plugin host crash resilience, callback-safety architecture, 26 PRs merged |
+| `v0.7.0-alpha`       | Current   | 2026-08-16 | Routing & automation correctness, Master plugin host, PDC master latency, piano-roll workflow, reliability gates, 331 PRs merged |
 
 ---
 
 ## Milestone History
+
+### v0.7.0-alpha — Routing, Automation & Hosting Milestone (Aug 2026)
+
+331 PRs merged (#624–#771). The milestone's story is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+
+**Routing & Mixing** — Unity gain law across live, export, isolated bounce, audition, and monitoring; single-store fader/pan; routing command seam with cycle rejection and stable send IDs; Master as a plugin host with chain latency in the PDC graph; master clips obey the live solo gate (isolation contract pinned both ways).
+
+**Automation** — Instance-identity contract (curves follow the plugin, not the slot); automatable empty lanes; demo automation removed from default and saved projects.
+
+**Piano Roll** — Subdivision, proportional stretching, chord-aware strokes, harmony persistence, contextual editor.
+
+**UI** — Design constitution pass; Audio Clip editor pitching/trim/waveform/resize; timeline geometry authority.
+
+**Reliability** — Security/durability/realtime contract lanes CI-authoritative; decision-citation and test-contract gates; plugin hosting compiled in CI, Windows plugins sandboxed; four review rounds (20 findings) on the triage branch; undici CVEs cleaned.
+
+**PRs merged** — #624–#771 (331 PRs).
 
 ### v0.6.0-alpha — Security & RT Hardening (May 2026)
 

--- a/meta/CHANGELOGS/CHANGELOG_2026Q3.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q3.md
@@ -1,0 +1,40 @@
+# Changelog — 2026 Q3 (June–August)
+
+All notable changes for Aestra in Q3 2026 are documented here.
+
+## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
+
+331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+
+> **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
+
+### Routing & Mixing Correctness
+
+- Unity gain law end to end: channel strips use the stereo-balance law, so routing a signal through any mixer channel no longer attenuates it — and the same law governs live playback, offline export, isolated bounce, audition preview, and input monitoring (parity pinned by tests).
+- Fader and pan applied once: one UI gesture no longer writes two stores that the engine multiplied (−6 dB on the fader used to play at −12 dB).
+- Routing command seam with mutation-time cycle rejection, stable send IDs, and master-legality enforcement; render-path semantics match the routing contract (V1/V2/V3) with live/offline parity.
+- Master channel is a valid plugin host: insert chains process on the master bus before the fader and safety limiter, persist in the project file, and their latency feeds the plugin-delay-compensation graph (reported project latency is now the real end-to-end delay).
+- Master-routed clips obey the live solo gate; isolated-track bounce renders only the selected track's stage and excludes the master stage by design — both halves of the isolation contract are pinned by tests.
+
+### Automation
+
+- Automation targets the instance it was drawn for, never the slot it occupied — chain reordering keeps curves bound to their plugin.
+- Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
+- Leftover demo automation removed from the default project and from previously saved projects.
+
+### Piano Roll & Sequencing
+
+- Selection subdivision by snap, proportional selection stretching, chord-aware stroke input, harmony context persistence, contextual editor workspace, playhead alignment in timeline mode, and bidirectional sampler ping-pong loops.
+
+### UI & Editing
+
+- Design constitution pass across mixer, browser, timeline, and arsenal.
+- Audio Clip editor: musical pitching, trim persistence, live waveform updates, resize-safe layout.
+- Timeline geometry has a single authority for grid and x→beat conversion.
+
+### Reliability & Hardening
+
+- Security, durability, and realtime contract lanes are CI-authoritative; test contract coverage and founder decision citations are enforced gates.
+- Plugin hosting compiles in CI; Windows plugins run sandboxed out-of-process; CLAP SDK vendored.
+- The routing/automation/master/UI triage branch went through four review rounds (human + CodeRabbit) with 20 findings addressed before merge.
+- License-signing worker dependencies cleaned (undici CVEs).

--- a/meta/CHANGELOGS/CHANGELOG_2026Q3.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q3.md
@@ -4,7 +4,7 @@ All notable changes for Aestra in Q3 2026 are documented here.
 
 ## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
 
-331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation targets the instance it was drawn for, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 > **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
 
@@ -18,7 +18,15 @@ All notable changes for Aestra in Q3 2026 are documented here.
 
 ### Automation
 
-- Automation targets the instance it was drawn for, never the slot it occupied — chain reordering keeps curves bound to their plugin.
+- Plugin instances carry permanent identities in the chain state (#667 slice 1), so automation and saved state
+  survive chain edits without aliasing.
+- Automation lanes are actually automatable: the first click on an empty lane creates a neutral Volume
+  curve bound to the lane's channel, and edits rebuild the audio graph and mark the project dirty.
+- Leftover demo automation removed from the default project and from previously saved projects.
+
+> Cut-time gate: instance-targeted automation (curves address the plugin instance rather than the slot)
+> is #766, still open at this writing. If it merges before the cut, restore the stronger claim; if not,
+> the entry above is the accurate one.
 - Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
 


### PR DESCRIPTION
## Summary

Release-text drafting for the Sunday v0.7.0-alpha milestone cut — prose only, no code, no feature work. Audit conclusions (from the #3 pass):

- **Authoritative version**: RELEASES.md (current v0.6.0-alpha, 2026-05-29). Next per §23 = MINOR milestone bump → **v0.7.0-alpha**. 331 PRs merged since the last tag (#624–#771).
- **CHANGELOG.md was NOT stale** (v0.5.0/v0.6.0 present) — the README note claiming it stopped at v0.4.0 was the stale part. Fixed the note instead.
- **installer.iss = 1.1.0 and CMake project version = 0.1.0** remain for the #4 cut (version bumps happen at cut time, per the plan).

Changes:
- `CHANGELOG.md`: v0.7.0-alpha entry (Routing, Automation & Hosting Milestone) inserted above `[Unreleased]` (left untouched).
- `meta/CHANGELOGS/CHANGELOG_2026Q3.md`: new quarterly file mirroring the Q2 format.
- `RELEASES.md`: v0.7.0-alpha tag row (Current) + milestone history entry.
- `README.md`: currency note updated.

Both entries explicitly preserve the version distinction: **v0.7.0-alpha = application release version; `PROJECT_VERSION_CURRENT` (3) = project/file format version, changes only with the .aes format, never on a release bump.**

Release-oriented prose: themes and what became reliable (routing/mixing correctness, identity-safe automation, master hosting + PDC, piano roll, reliability gates), not a PR diary. No unestablished claims — every theme is grounded in the merged PR list and today's verified work.

## Why

Sunday should be mechanical: merge the remaining code PRs, merge this, bump versions, tag. Not a writing session.

## Testing performed

- `docs-check` / Check Documentation Quality CI will validate on this PR.
- No code, build, or test impact.

## Producer note

None

## Docs updated?

Yes — this PR is the docs change.

## Risk/rollback notes

- The PR-range endpoint (#771) should be re-checked at cut time; if more PRs land before the cut, extend the range in the same PR or at merge.
- `[Unreleased]` in CHANGELOG.md intentionally untouched — its historical content is not reorganized by this PR.
- Revert = revert this PR; no code involved.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
