### PR TITLE
docs: housekeeping for the v0.7.0-alpha cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 
 Aestra is on a public `0.x` pre-beta line. The roadmap target is **v1 Beta in December 2026**.
 
-As of July 2026 the repo is in active engineering mode rather than release-polish mode.
-Paths that are covered by tests and verified end to end:
+As of the v0.7.0-alpha milestone (August 2026) the repo is in active engineering
+mode rather than release-polish mode. Paths that are covered by tests and verified
+end to end:
 
 - Built-in plugin discovery through the normal manager/factory path
 - `Aestra Rumble` instantiation, state save/restore, and project round-trips
@@ -23,6 +24,14 @@ Paths that are covered by tests and verified end to end:
 - Offline render of a pattern or an arranged timeline to WAV
 - Out-of-process plugin hosting on POSIX, including CLAP note-port dialect negotiation
 - Hardware MIDI input, and automation that reaches the audio path
+- Routing and gain staging: a signal routed through any mixer channel keeps its level,
+  and live playback, offline export, isolated bounce, audition preview, and input
+  monitoring share one gain law
+- The Master channel as a plugin host, with insert chains processed on the master bus
+  and their latency fed into the plugin-delay-compensation graph
+- Automation lanes: automatable end to end, with edits reaching the audio path
+- The isolation contract: solo governs the live mix, and isolated-track bounce renders
+  only the selected track's stage
 - Project and plugin persistence coverage in the confidence suite
 
 Aestra also exposes a **scriptable control surface** — see [Muse](#muse-the-control-surface) below.
@@ -124,7 +133,7 @@ There is also a helper script:
 ./scripts/run-confidence-suite.sh
 ```
 
-A full local configure registers around 190 tests, including the security suite under
+A full local configure registers 250 tests, including the security suite under
 `tests/security`.
 
 **What CI compiles, and where**, since this is easy to assume wrongly:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -31,7 +31,7 @@ On first launch, Aestra will:
 
 1. Initialize the audio engine (WASAPI on Windows, Linux audio stack where supported)
 2. Load the default theme
-3. Create a new empty project
+3. Create a new project (with starter tracks)
 
 ## 🖥️ Understanding the Interface
 

--- a/docs/meta/DOCUMENTATION_INDEX.md
+++ b/docs/meta/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # 📚 Aestra Documentation Index
 
 ![Documentation](https://img.shields.io/badge/Documentation-Complete-brightgreen)
-![Version](https://img.shields.io/badge/Version-1.1.0-blue)
+![Version](https://img.shields.io/badge/Version-0.7.0--alpha-blue)
 
 Welcome to the comprehensive documentation hub for **Aestra**! This guide helps you navigate our extensive documentation and find exactly what you need.
 
@@ -157,8 +157,8 @@ This documentation is actively maintained and updated:
 
 ---
 
-**Last Updated**: March 2026  
-**Version**: 1.1.0  
+**Last Updated**: August 2026  
+**Version**: 0.7.0-alpha  
 **Maintainer**: Dylan Makori / Aestra Studios
 
 *For questions about this documentation, please open an issue or contact us directly.*

--- a/docs/technical/v1_beta_task_list.md
+++ b/docs/technical/v1_beta_task_list.md
@@ -174,18 +174,19 @@ Completed since early January:
 
 **Done means:** basic per-track/per-lane mix controls exist and export matches playback.
 
-- `[P0][G-001]` Per-lane or per-track volume control (clear mapping to engine).
-- `[P0][G-002]` Pan control.
-- `[P0][G-003]` Mute/solo with correct precedence (solo overrides mute rules).
-- `[P0][G-004]` Master fader and a safety limiter/clip guard stage for Beta.
-- `[P0][G-005]` Metering: stable RMS/peak meters with smoothing; no UI stutter.
-- `[P1][G-006]` Track naming + color persistence.
+- `[x][P0][G-001]` Per-lane/per-track volume wired to the mixer fader and the graph (PR #767). ✅
+- `[x][P0][G-002]` Pan control on strips; single-store pan staging (#767). ✅
+- `[x][P0][G-003]` Mute/solo precedence enforced in the render graph (solo overrides mute) (#765). ✅
+- `[x][P0][G-004]` Master fader (continuous slot) + safety limiter with cubic-Hermite knee (v0.6.0). ✅
+- `[x][P0][G-005]` Stable peak/RMS metering with smoothing; K-weight true-peak (v0.6.0). ✅
+- `[x][P1][G-006]` Track naming and palette color persist across save/load (#767). ✅
 - `[P1][G-007]` Basic routing policy documented (even if it’s “no sends for Beta”).
-- `[P0][G-008]` Core routing primitives: master send on/off, subgroup-only output, FX sends, sidechain-only sends, and explicit pre/post send behavior.
-- `[P0][G-009]` Routing visibility: inspector or mini-matrix must show source, audible destinations, master-send state, send mode, and sidechain-only state with no hidden routing assumptions.
-- `[P0][G-010]` Routing safety rules: detect duplicate audible routes, prevent feedback loops, and warn on ambiguous routing states before they become trust-breaking mix bugs.
+- `[x][P0][G-008]` Routing command seam: main output, subgroup output, FX sends, sidechain-only sends, pre/post fader, stable send IDs (#765). ✅
+- `[x][P0][G-009]` UIRoutingMap mini-matrix shows destinations, master-send state, send mode, sidechain-only (#765). ✅
+- `[x][P0][G-010]` Mutation-time cycle rejection and duplicate-route detection in the routing command seam (#765). ✅
 - `[P0][G-011]` Solo/mute/cue semantics locked: define solo-in-place vs cue behavior and keep it consistent through groups, returns, sends, and sidechain paths.
 - `[P0][G-012]` PDC for routing graph: sends, buses, sidechains, master FX, recording, and export all remain aligned under high-latency plugins.
+  - Status: per-edge compensation + master-FX latency in the PDC graph done (PRs #730, #769); export parity proven by RealtimeExportParityTest. Recording-path alignment still pending.
 - `[P0][G-013]` Internal print/export respects routing: bus print, internal recording, stem export, and project reopen all preserve the same routing graph and audible result.
 - `[P1][G-014]` Mono/stereo routing discipline: mono sources, stereo tracks, returns, panning, polarity, and collapse/summing behave predictably even if full multichannel routing is deferred.
 - `[P1][G-015]` One-click routing actions: create bus from selection, create FX return, route selected to bus only, and sidechain selected to target.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -277,6 +277,9 @@ nav:
       - Overview: api/index.md
   - 📋 Changelog:
       - Release Notes: https://github.com/currentsuspect/Aestra/blob/main/CHANGELOG.md
+      - 2026 Q3: https://github.com/currentsuspect/Aestra/blob/main/meta/CHANGELOGS/CHANGELOG_2026Q3.md
+      - 2026 Q2: https://github.com/currentsuspect/Aestra/blob/main/meta/CHANGELOGS/CHANGELOG_2026Q2.md
+      - 2026 Q1: https://github.com/currentsuspect/Aestra/blob/main/meta/CHANGELOGS/CHANGELOG_2026Q1.md
       - 2025 Q1: https://github.com/currentsuspect/Aestra/blob/main/meta/CHANGELOGS/CHANGELOG_2025Q1.md
   - 🌐 Community:
       - Code of Conduct: community/code-of-conduct.md


### PR DESCRIPTION
## Summary

Docs housekeeping for Sunday's v0.7.0-alpha cut — Saturday pass, release-oriented only. No code, no feature work.

Findings and fixes:

1. **`docs/technical/v1_beta_task_list.md`** — the routing/mixing release-bar items were implemented but unchecked. Marked complete with evidence: per-track volume/pan/mute-solo, master fader + safety limiter, metering, naming/color persistence, routing primitives, routing visibility, routing safety (`[x]` + ✅, PR references). G-012 (PDC) annotated as partially done: per-edge compensation + master-FX latency landed (#730, #769); recording-path alignment still pending — deliberately left unchecked. G-007 (routing policy doc) untouched: the routing contract lives in the private vault, so the public item genuinely remains open.
2. **`docs/meta/DOCUMENTATION_INDEX.md`** — badge + footer claimed **Version 1.1.0** (same premature-major class as the `installer.iss` finding). Now 0.7.0-alpha; Last Updated → August 2026.
3. **`docs/getting-started/quickstart.md`** — first launch creates a project with starter tracks, not an empty project.
4. **`mkdocs.yml`** — changelog nav listed only 2025 Q1; now includes 2026 Q1/Q2/Q3 (the new quarterly file from #772).

Deliberately not touched: `docs/audits/` (historical records; the equal-power/pan-law mentions there describe what was true when the audit was written) and `docs/technical/roadmap.md` (self-dated internal memo, already honestly flagged in the README).

## Why

The cut's docs should not claim routing/PDC/master items are still pending, and should not carry a 1.1.0 version identity. The README and docs-check lanes are the gate.

## Testing performed

- `check-docs` / Check Documentation Quality CI will validate on this PR (docs-only).
- No build or test impact.

## Producer note

None

## Docs updated?

Yes — this PR is the docs change.

## Risk/rollback notes

- The task-list ✅ marks are the only judgment calls; each cites the PR that completed it, and G-012/G-007 are explicitly left open.
- Revert = revert this PR.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
