### PR TITLE
ci: open a site-changelog reminder issue on every release tag

### DIFF
--- a/.github/release-changelog-reminder-body.md
+++ b/.github/release-changelog-reminder-body.md
@@ -1,0 +1,25 @@
+## Release: __VERSION__
+
+The release tag was just cut. One manual step remains: compose and publish the
+site changelog on aestra.studio (the draft below is the material, not the final
+copy — vet the notes, then paste).
+
+### Checklist
+
+- [ ] Run `npm run changelog:draft` in `~/Dev/Aestra-website` (fresh draft)
+- [ ] Compose the new entry: create `src/content/changelog/010-__VERSION__.md`
+      with frontmatter (`version`, `date`, `status: released`, `order`) and the
+      producer-note bullets; renumber the older released files
+- [ ] Reset `src/content/changelog/000-unreleased.md` to a fresh active entry
+- [ ] Push to `main` (Vercel deploys automatically) and verify
+      https://aestra.studio/changelog shows the entry
+- [ ] Update `RELEASES.md` in the Aestra repo if the milestone entry is missing
+
+### Draft (generated at tag time)
+
+```
+__DRAFT__
+```
+
+> The "uncovered" list at the end of the draft are feat/fix PRs without a
+> producer note — decide per PR whether any deserve a manual entry.

--- a/.github/workflows/release-changelog-reminder.yml
+++ b/.github/workflows/release-changelog-reminder.yml
@@ -1,0 +1,71 @@
+name: Release changelog reminder
+
+# Every release tag opens a reminder issue with the site-changelog draft
+# already generated, so the human compose step (paste the notes into
+# Aestra-website/src/content/changelog/) cannot be forgotten at cut time.
+# The draft is a reminder, not an auto-publish: the producer notes still go
+# through a human before the site deploys.
+
+on:
+  create:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remind:
+    if: github.event.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the Aestra-website draft generator
+        uses: actions/checkout@v4
+        with:
+          repository: currentsuspect/Aestra-website
+          path: website
+
+      - name: Skip if a reminder is already open for this tag
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count="$(
+            gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+              --search "in:title \"${{ github.event.ref }} release: site changelog\"" \
+              --json number --jq 'length'
+          )"
+          echo "existing=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Generate the producer-note draft
+        if: steps.existing.outputs.existing == '0'
+        working-directory: website
+        run: node scripts/changelog-draft.mjs > ../changelog-draft.txt 2>&1 || true
+
+      - name: Assemble the issue body from the template
+        if: steps.existing.outputs.existing == '0'
+        run: |
+          python3 - "${{ github.event.ref }}" /tmp/reminder-body.md <<'PYEOF'
+          import sys
+          version, out_path = sys.argv[1], sys.argv[2]
+          template = open(".github/release-changelog-reminder-body.md", encoding="utf-8").read()
+          draft = open("changelog-draft.txt", encoding="utf-8").read()
+          open(out_path, "w", encoding="utf-8").write(
+              template.replace("__VERSION__", version).replace("__DRAFT__", draft.strip())
+          )
+          PYEOF
+
+      - name: Open the reminder issue
+        if: steps.existing.outputs.existing == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "${{ github.event.ref }} release: site changelog" \
+            --body-file /tmp/reminder-body.md
+
+      - name: Log when a reminder already exists
+        if: steps.existing.outputs.existing != '0'
+        run: |
+          echo "An open reminder for ${{ github.event.ref }} already exists; skipping."


### PR DESCRIPTION
## Summary

A release-process memory hook: every tag (`v*`) now opens a GitHub issue titled **"`<tag>` release: site changelog"** with the producer-note draft already generated and a compose checklist — so the human step of pasting notes into `Aestra-website/src/content/changelog/` cannot be forgotten at cut time.

How it works (verified locally, end to end):

1. `on: create: tags: ['v*']` + `ref_type == 'tag'` guard — fires on release tags only (annotated or not; the tag rules in AGENTS.md §23 still govern *how* tags are made).
2. Checks out the **public** Aestra-website repo (no token needed), runs `changelog-draft.mjs` (pure Node, no deps) — the same script fixed earlier today.
3. Assembles the issue body from `.github/release-changelog-reminder-body.md` (template with `__VERSION__`/`__DRAFT__` substitution via a small Python step).
4. Opens the issue with `GH_TOKEN` (issues: write) — no cross-repo secrets anywhere.
5. Duplicate guard: skips when an open reminder for the same tag already exists, so re-tags don't spam.

Deliberately NOT an auto-publish: the producer notes still go through a human before the site deploys. This is the "we can still vet personally but never forget" middle ground. If the full auto-write is wanted later, the generator `--write` mode is a separate change.

## Why

The cut sequence had a manual step (compose the site changelog) with no memory hook. Issues are the reminder surface that survives context switches and shows up in the normal review flow.

## Testing performed

- YAML validated; full local simulation of the draft → assembly steps with `v0.7.0-alpha`: placeholders substituted, draft embedded, zero leftover `__` tokens.
- The generator itself is the already-verified script (338 PRs / 25 notes since v0.6.0-alpha).
- First real firing will be Sunday's `v0.7.0-alpha` tag — the issue it opens is the deliverable.

## Producer note

None

## Docs updated?

No public docs; the workflow template is self-documenting.

## Risk/rollback notes

- The issue body's draft is generated at tag time; if PRs merge between the tag and the compose step, the checklist says to re-run `npm run changelog:draft` for a fresh draft (already in the checklist).
- The duplicate guard keys on the exact title — a re-tag with the same name reuses the open issue (desired).
- Revert = revert this PR; no behavior change until the next tag.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```
