### PR TITLE
fix(ui): final 0.7.0 triage — piano roll follow, arsenal density, sample editor, reverb mode nav, search bar

### DIFF
--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -306,20 +306,19 @@ void AestraVerbEditor::syncCategoryFromMode() {
     const int modeIdx = static_cast<int>(std::round(
         getParamValue(kMode) * static_cast<float>(kModeCount - 1)));
     const int newCat = categoryForMode(std::clamp(modeIdx, 0, kModeCount - 1));
-    if (newCat == m_selectedCategory && !m_dropdownItems.empty()) return;
+    if (newCat == m_selectedCategory) return;
     if (newCat != m_selectedCategory) m_presetScroll = 0;
     m_selectedCategory = newCat;
-    m_dropdownItems.clear();
-    int modes[3] = {};
-    const int count = modesInCategory(m_selectedCategory, modes);
-    for (int i = 0; i < count; ++i) {
-        static const char* modeNames[] = {
-            "Room", "Hall", "Plate", "Cathedral", "Chamber",
-            "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
-        };
-        m_dropdownItems.push_back({modeNames[modes[i]], modes[i], {}, false});
-    }
     layoutControls();
+}
+
+void AestraVerbEditor::stepMode(int direction) {
+    const int modeIdx = static_cast<int>(std::round(
+        getParamValue(kMode) * static_cast<float>(kModeCount - 1)));
+    const int next = (modeIdx + direction + kModeCount) % kModeCount;
+    updateParameter(kMode, static_cast<float>(next) / static_cast<float>(kModeCount - 1));
+    syncCategoryFromMode();
+    setDirty(true);
 }
 
 bool AestraVerbEditor::presetIsInSelectedCategory(const PresetButton& preset) const {
@@ -397,19 +396,7 @@ void AestraVerbEditor::layoutControls() {
                                             catY, catW, catH);
     }
 
-    // Secondary algorithm selector.
-    const float ddY = b.y + 94.0f;
-    const float ddH = 30.0f;
-    m_dropdownButtonBounds = NUIRect(contentX, ddY, contentW, ddH);
-
-    // Dropdown list (positioned below button when open)
-    const float itemH = 26.0f;
-    m_dropdownListBounds = NUIRect(contentX, ddY + ddH + 2.0f, contentW, itemH * static_cast<float>(m_dropdownItems.size()));
-    for (size_t i = 0; i < m_dropdownItems.size(); ++i) {
-        m_dropdownItems[i].bounds = NUIRect(contentX, ddY + ddH + 2.0f + itemH * static_cast<float>(i), contentW, itemH);
-    }
-
-    const float mainY = b.y + 134.0f;
+    const float mainY = b.y + 100.0f; // MODE dropdown removed: content reclaims the band
     const float bodyBottom = b.y + b.height - 14.0f;
     const float bodyH = std::max(360.0f, bodyBottom - mainY);
     const float rightW = rightColWidth(b.width);
@@ -418,7 +405,7 @@ void AestraVerbEditor::layoutControls() {
     const float rightX = centerX + centerW + 18.0f;
 
     const float sectionHeaderH = 26.0f;
-    const float sectionGap = 8.0f;
+    const float sectionGap = 10.0f; // 0.7.0 triage: relaxed from 8 for breathing room
     const float sectionRowStep = std::clamp((bodyH - sectionHeaderH * 3.0f - sectionGap * 2.0f) / 11.0f,
                                             27.0f, 34.0f);
     const float toneY = mainY;
@@ -492,8 +479,8 @@ void AestraVerbEditor::layoutControls() {
     m_mixTrack = NUIRect(m_mixBounds.x + 42.0f, m_mixBounds.y + 18.0f,
                          m_mixBounds.width - 86.0f, 4.0f);
 
-    // Two-row utility deck: performance controls first, navigation and compare second.
-    const float btnGap = 6.0f;
+    // Two-row utility deck: performance controls first, mode navigation second.
+    const float btnGap = 8.0f; // 0.7.0 triage: relaxed from 6
     const float btnW = std::clamp((centerW - 24.0f - btnGap * 3.0f) * 0.25f, 42.0f, 72.0f);
     const float btnRowW = 4.0f * btnW + 3.0f * btnGap;
     const float btnStartX = centerX + (centerW - btnRowW) * 0.5f;
@@ -508,6 +495,11 @@ void AestraVerbEditor::layoutControls() {
     m_navNextBounds = NUIRect(btnStartX + (btnW + btnGap), btnRow2Y, btnW, btnH);
     m_abBoundsA = NUIRect(btnStartX + (btnW + btnGap) * 2.0f, btnRow2Y, btnW, btnH);
     m_abBoundsB = NUIRect(btnStartX + (btnW + btnGap) * 3.0f, btnRow2Y, btnW, btnH);
+    // Mode navigator center: between the arrows and the A/B compare pair.
+    const float modeLabelX = m_navNextBounds.right() + 10.0f;
+    const float modeLabelRight = m_abBoundsA.x - 10.0f;
+    m_modeLabelBounds = NUIRect(modeLabelX, btnRow2Y - 2.0f,
+                                std::max(0.0f, modeLabelRight - modeLabelX), btnH + 6.0f);
 
     m_layouting = false;
 }
@@ -748,77 +740,6 @@ void AestraVerbEditor::drawCategoryPills(NUIRenderer& renderer, NUIColor accent)
     }
 }
 
-void AestraVerbEditor::drawModeDropdown(NUIRenderer& renderer, NUIColor accent) {
-    auto& theme = NUIThemeManager::getInstance();
-    const auto& btn = m_dropdownButtonBounds;
-    const bool anyHovered = m_dropdownOpen;
-    renderer.fillRoundedRect(btn, 6.0f, verbInsetBg().withAlpha(0.96f));
-    renderer.strokeRoundedRect(btn, 6.0f, 1.0f,
-                               anyHovered ? accent.withAlpha(0.45f) : NUIColor(1, 1, 1, 0.12f));
-
-    const int modeIdx = static_cast<int>(std::round(
-        getParamValue(kMode) * static_cast<float>(kModeCount - 1)));
-    static const char* modeNames[] = {
-        "Room", "Hall", "Plate", "Cathedral", "Chamber",
-        "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
-    };
-    // Small caption so the bar reads as a labelled selector rather than a bare box.
-    // Centre the mode name on the button, then sit the caption on the SAME baseline
-    // (not independently centred) so the small "MODE" doesn't float above it.
-    const float ddNameSize = 10.5f;
-    const float ddCapSize = 8.0f;
-    const float ddNameY = opticalTextY(renderer, btn.center().y, ddNameSize);
-    const float ddBaseline = ddNameY + renderer.getFontMetrics(ddNameSize).ascent;
-    const float ddCapY = ddBaseline - renderer.getFontMetrics(ddCapSize).ascent;
-    renderer.drawText("MODE", {btn.x + 10.0f, std::round(ddCapY)}, ddCapSize,
-                      accent.withAlpha(0.52f));
-    const char* currentName = (modeIdx >= 0 && modeIdx < kModeCount) ? modeNames[modeIdx] : "Room";
-    renderer.drawText(currentName, {btn.x + 48.0f, std::round(ddNameY)}, ddNameSize,
-                      theme.getColor("textPrimary").withAlpha(0.92f));
-
-    // Split-button divider + chevron affordance on the right.
-    renderer.drawLine({std::round(btn.right() - 28.0f), btn.y + 6.0f},
-                      {std::round(btn.right() - 28.0f), btn.bottom() - 6.0f}, 1.0f, NUIColor(1, 1, 1, 0.08f));
-    static const char* kChevronDownSvg = R"svg(
-        <svg viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-    )svg";
-    static const char* kChevronUpSvg = R"svg(
-        <svg viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M1 5L5 1L9 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-    )svg";
-    static auto chevronDown = std::make_shared<NUIIcon>(kChevronDownSvg);
-    static auto chevronUp = std::make_shared<NUIIcon>(kChevronUpSvg);
-    auto& chevronIcon = m_dropdownOpen ? chevronUp : chevronDown;
-    const float chevronSize = 10.0f;
-    chevronIcon->setBounds({std::round(btn.right() - 19.0f), std::round(btn.center().y - chevronSize * 0.5f),
-                            chevronSize, chevronSize});
-    chevronIcon->setColor(accent.withAlpha(anyHovered ? 0.90f : 0.70f));
-    chevronIcon->onRender(renderer);
-
-    if (m_dropdownOpen && !m_dropdownItems.empty()) {
-        renderer.fillRoundedRect(m_dropdownListBounds, 6.0f, editorNeutral(0.027f, 0.985f));
-        renderer.strokeRoundedRect(m_dropdownListBounds, 6.0f, 1.0f, NUIColor(1, 1, 1, 0.14f));
-        for (const auto& item : m_dropdownItems) {
-            const bool isCurrent = item.mode == modeIdx;
-            if (isCurrent) {
-                renderer.fillRoundedRect({item.bounds.x + 2.0f, item.bounds.y + 1.0f,
-                                          item.bounds.width - 4.0f, item.bounds.height - 2.0f},
-                                         4.0f, accent.withAlpha(0.35f));
-            } else if (item.hovered) {
-                renderer.fillRoundedRect({item.bounds.x + 2.0f, item.bounds.y + 1.0f,
-                                          item.bounds.width - 4.0f, item.bounds.height - 2.0f},
-                                         4.0f, accent.withAlpha(0.08f));
-            }
-            renderer.drawText(item.label, {item.bounds.x + 10.0f,
-                                            std::round(renderer.calculateTextY(item.bounds, 10.0f))}, 10.0f,
-                              theme.getColor("textPrimary").withAlpha(isCurrent ? 0.96f : (item.hovered ? 0.82f : 0.60f)));
-        }
-    }
-}
-
 void AestraVerbEditor::drawKnob(NUIRenderer& renderer, const KnobControl& k, NUIColor accent) {
     auto& theme = NUIThemeManager::getInstance();
     const NUIRect knobRect = k.slider ? k.slider->getBounds() : NUIRect();
@@ -968,6 +889,38 @@ void AestraVerbEditor::drawPresetNav(NUIRenderer& renderer, NUIColor accent) {
     renderer.fillRoundedRect(m_navNextBounds, 6.0f, m_navNextHovered ? NUIColor(1, 1, 1, 0.08f) : NUIColor(0, 0, 0, 0));
     renderer.strokeRoundedRect(m_navNextBounds, 6.0f, 1.0f, m_navNextHovered ? accent.withAlpha(0.4f) : NUIColor(1, 1, 1, 0.15f));
     renderer.drawTextCentered(">", m_navNextBounds, 8.5f, theme.getColor("textPrimary").withAlpha(m_navNextHovered ? 0.9f : 0.60f));
+
+    // Mode navigator center (0.7.0 triage): a tiny MODE micro-label above the
+    // current "CATEGORY · Algorithm" pair. The arrows step through the
+    // adjacent tonal/space models; the label keeps the control discoverable
+    // without bringing the dropdown back.
+    if (m_modeLabelBounds.width > 0.0f) {
+        static const char* modeNames[] = {
+            "Room", "Hall", "Plate", "Cathedral", "Chamber",
+            "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
+        };
+        const int modeIdx = std::clamp(static_cast<int>(std::round(
+            getParamValue(kMode) * static_cast<float>(kModeCount - 1))), 0, kModeCount - 1);
+        const std::string categoryName =
+            (m_selectedCategory >= 0 && m_selectedCategory < kCategoryCount)
+                ? m_categoryPills[m_selectedCategory].label
+                : "";
+        const std::string modeName = (modeIdx >= 0 && modeIdx < kModeCount) ? modeNames[modeIdx] : "";
+        const std::string display = categoryName + " \u00b7 " + modeName;
+
+        renderer.drawTextCentered("MODE", {m_modeLabelBounds.x, m_modeLabelBounds.y,
+                                           m_modeLabelBounds.width, 10.0f},
+                                  7.5f, accent.withAlpha(0.52f));
+        std::string fitted = display;
+        const float nameSize = 10.0f;
+        while (!fitted.empty() && renderer.measureText(fitted, nameSize).width > m_modeLabelBounds.width - 8.0f) {
+            fitted.pop_back();
+        }
+        renderer.drawTextCentered(fitted, {m_modeLabelBounds.x, m_modeLabelBounds.y + 10.0f,
+                                           m_modeLabelBounds.width, 16.0f},
+                                  nameSize, theme.getColor("textPrimary").withAlpha(0.92f));
+    }
+
     renderer.fillRoundedRect(m_saveBounds, 6.0f, m_saveHovered ? accent.withAlpha(0.35f) : NUIColor(0, 0, 0, 0));
     renderer.strokeRoundedRect(m_saveBounds, 6.0f, 1.0f, m_saveHovered ? accent.withAlpha(0.5f) : NUIColor(1, 1, 1, 0.15f));
     renderer.drawTextCentered("SAVE", m_saveBounds, 9.0f, theme.getColor("textPrimary").withAlpha(m_saveHovered ? 0.92f : 0.60f));
@@ -996,7 +949,7 @@ void AestraVerbEditor::drawSectionLabels(NUIRenderer& renderer) {
     auto b = getBounds();
     const float mainX = editorContentX(b);
     const float contentW = b.width - (mainX - b.x) - kPad;
-    const float mainY = b.y + 134.0f;
+    const float mainY = b.y + 100.0f; // 0.7.0 triage: dropdown band reclaimed
     const float bodyBottom = b.y + b.height - 14.0f;
     const float bodyH = std::max(360.0f, bodyBottom - mainY);
     const float rightW = rightColWidth(b.width);
@@ -1085,7 +1038,7 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
     NUIColor accent = verbAccent();
     const float mainX = editorContentX(b);
     const float contentW = b.width - (mainX - b.x) - kPad;
-    const float mainY = b.y + 134.0f;
+    const float mainY = b.y + 100.0f; // 0.7.0 triage: dropdown band reclaimed
     const float bodyBottom = b.y + b.height - 14.0f;
     const float bodyH = std::max(360.0f, bodyBottom - mainY);
     const float rightW = rightColWidth(b.width);
@@ -1232,7 +1185,6 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
                               NUIColor(1, 1, 1, 0.78f));
         }
     }
-    drawModeDropdown(renderer, accent);
 }
 
 void AestraVerbEditor::onUpdate(double deltaTime) {
@@ -1260,16 +1212,6 @@ void AestraVerbEditor::onUpdate(double deltaTime) {
 int AestraVerbEditor::hitTestCategory(float x, float y) const {
     for (size_t i = 0; i < m_categoryPills.size(); ++i) {
         if (m_categoryPills[i].bounds.contains({x, y})) return static_cast<int>(i);
-    }
-    return -1;
-}
-
-int AestraVerbEditor::hitTestDropdown(float x, float y) const {
-    if (m_dropdownButtonBounds.contains({x, y})) return -2;
-    if (m_dropdownOpen) {
-        for (size_t i = 0; i < m_dropdownItems.size(); ++i) {
-            if (m_dropdownItems[i].bounds.contains({x, y})) return static_cast<int>(i);
-        }
     }
     return -1;
 }
@@ -1465,10 +1407,7 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
         if (!hasBounds) continue;
         const bool overKnob = sb.contains({event.position.x, event.position.y});
         const bool dragging = k.slider->isDragging();
-        // An open dropdown is a modal input layer. Keep forwarding an active
-        // drag so it can release cleanly, but do not let new presses reach a
-        // knob underneath the dropdown list.
-        if ((overKnob && !m_dropdownOpen) || dragging) {
+        if (overKnob || dragging) {
             if (k.slider->onMouseEvent(event)) return true;
         }
     }
@@ -1481,7 +1420,6 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
     const float mainY = b2.y + 128.0f;
     const auto updateHoverState = [&]() {
         const int ch = contains ? hitTestCategory(event.position.x, event.position.y) : -1;
-        const int ddh = contains ? hitTestDropdown(event.position.x, event.position.y) : -1;
         const int ph = contains ? hitTestPreset(event.position.x, event.position.y) : -1;
         const bool mixHovered = contains && hitTestMix(event.position.x, event.position.y);
         const bool bypassHovered = contains && hitTestBypass(event.position.x, event.position.y);
@@ -1497,13 +1435,12 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
         const bool abHA = abHovered && isA;
         const bool abHB = abHovered && !isA;
         const bool mixLockH = contains && hitTestMixLock(event.position.x, event.position.y);
-        if (ch == m_hoveredCategory && ddh == m_hoveredDropdownItem && ph == m_hoveredPreset && mixHovered == m_mixHovered &&
+        if (ch == m_hoveredCategory && ph == m_hoveredPreset && mixHovered == m_mixHovered &&
             bypassHovered == m_bypassHovered && freezeHovered == m_freezeHovered &&
             navPrevH == m_navPrevHovered && navNextH == m_navNextHovered &&
             saveHovered == m_saveHovered && abHA == m_abHoveredA && abHB == m_abHoveredB &&
             mixLockH == m_mixLockHovered) return;
         m_hoveredCategory = ch;
-        m_hoveredDropdownItem = ddh;
         m_hoveredPreset = ph;
         m_mixHovered = mixHovered;
         m_bypassHovered = bypassHovered;
@@ -1515,7 +1452,6 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
         m_abHoveredB = abHB;
         m_mixLockHovered = mixLockH;
         for (size_t i = 0; i < m_categoryPills.size(); ++i) m_categoryPills[i].hovered = (static_cast<int>(i) == ch);
-        for (size_t i = 0; i < m_dropdownItems.size(); ++i) m_dropdownItems[i].hovered = (static_cast<int>(i) == ddh);
         for (size_t i = 0; i < m_presets.size(); ++i) m_presets[i].hovered = (static_cast<int>(i) == ph);
         setDirty(true);
     };
@@ -1528,11 +1464,10 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
     if (!contains && !isDraggingWindow() && !m_draggingMix) {
-        if (m_hoveredCategory != -1 || m_hoveredDropdownItem != -1 || m_hoveredPreset != -1 || m_mixHovered ||
+        if (m_hoveredCategory != -1 || m_hoveredPreset != -1 || m_mixHovered ||
             m_bypassHovered || m_freezeHovered || m_navPrevHovered || m_navNextHovered ||
             m_saveHovered || m_abHoveredA || m_abHoveredB || m_mixLockHovered) {
             m_hoveredCategory = -1;
-            m_hoveredDropdownItem = -1;
             m_hoveredPreset = -1;
             m_mixHovered = false;
             m_bypassHovered = false;
@@ -1544,12 +1479,7 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
             m_abHoveredB = false;
             m_mixLockHovered = false;
             for (auto& pill : m_categoryPills) pill.hovered = false;
-            for (auto& item : m_dropdownItems) item.hovered = false;
             for (auto& preset : m_presets) preset.hovered = false;
-            setDirty(true);
-        }
-        if (m_dropdownOpen) {
-            m_dropdownOpen = false;
             setDirty(true);
         }
         return false;
@@ -1564,47 +1494,18 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
             m_mixFocused = false;
             m_selectedCategory = catIdx;
             m_presetScroll = 0;
-            m_dropdownItems.clear();
+            // Select the first algorithm of the chosen family (the mode
+            // navigator in the bottom deck steps through the rest).
             int modes[3] = {};
             const int count = modesInCategory(catIdx, modes);
-            for (int i = 0; i < count; ++i) {
-                static const char* modeNames[] = {
-                    "Room", "Hall", "Plate", "Cathedral", "Chamber",
-                    "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
-                };
-                m_dropdownItems.push_back({modeNames[modes[i]], modes[i], {}, false});
-            }
-            // Select first mode in category
             if (count > 0) {
                 updateParameter(kMode, static_cast<float>(modes[0]) / static_cast<float>(kModeCount - 1));
             }
-            m_dropdownOpen = true;
             layoutControls();
             setDirty(true);
             return true;
         }
-        // Dropdown interaction
-        const int ddIdx = hitTestDropdown(event.position.x, event.position.y);
-        if (ddIdx == -2) {
-            // Clicked dropdown button — toggle open (only if there are items)
-            if (!m_dropdownItems.empty()) m_dropdownOpen = !m_dropdownOpen;
-            setDirty(true);
-            return true;
-        }
-        if (ddIdx >= 0 && m_dropdownOpen && ddIdx < static_cast<int>(m_dropdownItems.size())) {
-            // Clicked dropdown item
-            const auto& item = m_dropdownItems[ddIdx];
-            updateParameter(kMode, static_cast<float>(item.mode) / static_cast<float>(kModeCount - 1));
-            m_dropdownOpen = false;
-            setDirty(true);
-            return true;
-        }
-        if (m_dropdownOpen && !m_dropdownButtonBounds.contains({event.position.x, event.position.y}) &&
-            !m_dropdownListBounds.contains({event.position.x, event.position.y})) {
-            m_dropdownOpen = false;
-            setDirty(true);
-            return true;
-        }
+
         // Preset click
         const int presetIdx = hitTestPreset(event.position.x, event.position.y);
         if (presetIdx >= 0) {
@@ -1633,9 +1534,7 @@ bool AestraVerbEditor::onMouseEvent(const NUIMouseEvent& event) {
         }
         int navDir = 0;
         if (hitTestPresetNav(event.position.x, event.position.y, navDir)) {
-            m_presetScroll = std::clamp(m_presetScroll + navDir, 0, maxPresetScroll());
-            layoutControls();
-            setDirty(true);
+            stepMode(navDir);
             return true;
         }
         bool isA = false;

--- a/AestraUI/Widgets/AestraVerbEditor.cpp
+++ b/AestraUI/Widgets/AestraVerbEditor.cpp
@@ -493,11 +493,14 @@ void AestraVerbEditor::layoutControls() {
     m_mixLockBounds = NUIRect(btnStartX + (btnW + btnGap) * 3.0f, btnRowY, btnW, btnH);
     m_navPrevBounds = NUIRect(btnStartX, btnRow2Y, btnW, btnH);
     m_navNextBounds = NUIRect(btnStartX + (btnW + btnGap), btnRow2Y, btnW, btnH);
-    m_abBoundsA = NUIRect(btnStartX + (btnW + btnGap) * 2.0f, btnRow2Y, btnW, btnH);
-    m_abBoundsB = NUIRect(btnStartX + (btnW + btnGap) * 3.0f, btnRow2Y, btnW, btnH);
-    // Mode navigator center: between the arrows and the A/B compare pair.
-    const float modeLabelX = m_navNextBounds.right() + 10.0f;
-    const float modeLabelRight = m_abBoundsA.x - 10.0f;
+    // A/B compare pinned to the right edge of the band; the mode label owns
+    // the space between the arrows and the compare pair (CR review: the old
+    // 4-slot geometry left the label zero width).
+    const float deckRight = btnStartX + btnRowW;
+    m_abBoundsA = NUIRect(deckRight - 2.0f * btnW - btnGap, btnRow2Y, btnW, btnH);
+    m_abBoundsB = NUIRect(deckRight - btnW, btnRow2Y, btnW, btnH);
+    const float modeLabelX = m_navNextBounds.right() + 12.0f;
+    const float modeLabelRight = m_abBoundsA.x - 12.0f;
     m_modeLabelBounds = NUIRect(modeLabelX, btnRow2Y - 2.0f,
                                 std::max(0.0f, modeLabelRight - modeLabelX), btnH + 6.0f);
 
@@ -890,37 +893,6 @@ void AestraVerbEditor::drawPresetNav(NUIRenderer& renderer, NUIColor accent) {
     renderer.strokeRoundedRect(m_navNextBounds, 6.0f, 1.0f, m_navNextHovered ? accent.withAlpha(0.4f) : NUIColor(1, 1, 1, 0.15f));
     renderer.drawTextCentered(">", m_navNextBounds, 8.5f, theme.getColor("textPrimary").withAlpha(m_navNextHovered ? 0.9f : 0.60f));
 
-    // Mode navigator center (0.7.0 triage): a tiny MODE micro-label above the
-    // current "CATEGORY · Algorithm" pair. The arrows step through the
-    // adjacent tonal/space models; the label keeps the control discoverable
-    // without bringing the dropdown back.
-    if (m_modeLabelBounds.width > 0.0f) {
-        static const char* modeNames[] = {
-            "Room", "Hall", "Plate", "Cathedral", "Chamber",
-            "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
-        };
-        const int modeIdx = std::clamp(static_cast<int>(std::round(
-            getParamValue(kMode) * static_cast<float>(kModeCount - 1))), 0, kModeCount - 1);
-        const std::string categoryName =
-            (m_selectedCategory >= 0 && m_selectedCategory < kCategoryCount)
-                ? m_categoryPills[m_selectedCategory].label
-                : "";
-        const std::string modeName = (modeIdx >= 0 && modeIdx < kModeCount) ? modeNames[modeIdx] : "";
-        const std::string display = categoryName + " \u00b7 " + modeName;
-
-        renderer.drawTextCentered("MODE", {m_modeLabelBounds.x, m_modeLabelBounds.y,
-                                           m_modeLabelBounds.width, 10.0f},
-                                  7.5f, accent.withAlpha(0.52f));
-        std::string fitted = display;
-        const float nameSize = 10.0f;
-        while (!fitted.empty() && renderer.measureText(fitted, nameSize).width > m_modeLabelBounds.width - 8.0f) {
-            fitted.pop_back();
-        }
-        renderer.drawTextCentered(fitted, {m_modeLabelBounds.x, m_modeLabelBounds.y + 10.0f,
-                                           m_modeLabelBounds.width, 16.0f},
-                                  nameSize, theme.getColor("textPrimary").withAlpha(0.92f));
-    }
-
     renderer.fillRoundedRect(m_saveBounds, 6.0f, m_saveHovered ? accent.withAlpha(0.35f) : NUIColor(0, 0, 0, 0));
     renderer.strokeRoundedRect(m_saveBounds, 6.0f, 1.0f, m_saveHovered ? accent.withAlpha(0.5f) : NUIColor(1, 1, 1, 0.15f));
     renderer.drawTextCentered("SAVE", m_saveBounds, 9.0f, theme.getColor("textPrimary").withAlpha(m_saveHovered ? 0.92f : 0.60f));
@@ -956,7 +928,7 @@ void AestraVerbEditor::drawSectionLabels(NUIRenderer& renderer) {
     const float centerW = contentW - rightW - 18.0f;
     const float rightX = mainX + centerW + 18.0f;
     constexpr float headerH = 26.0f;
-    constexpr float gap = 8.0f;
+    constexpr float gap = 10.0f; // 0.7.0 triage: relaxed from 8 (matches layoutControls)
     const float rowStep = std::clamp((bodyH - headerH * 3.0f - gap * 2.0f) / 11.0f, 27.0f, 34.0f);
     const float toneH = headerH + rowStep * 2.0f;
     const float motionY = mainY + toneH + gap;
@@ -1035,6 +1007,7 @@ void AestraVerbEditor::drawParamRow(NUIRenderer& renderer, NUIColor accent) {
 void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& contentRect) {
     (void)contentRect;
     auto b = getBounds();
+    auto& theme = NUIThemeManager::getInstance();
     NUIColor accent = verbAccent();
     const float mainX = editorContentX(b);
     const float contentW = b.width - (mainX - b.x) - kPad;
@@ -1156,6 +1129,36 @@ void AestraVerbEditor::drawContent(NUIRenderer& renderer, const NUIRect& content
             chevRight->setColor(NUIColor(1, 1, 1, hov ? 0.82f : 0.55f));
             chevRight->onRender(renderer);
         }
+
+        // Mode navigator label (0.7.0 triage): MODE micro-label above the
+        // centered "CATEGORY · Algorithm" pair, between the arrows and A/B.
+        if (m_modeLabelBounds.width > 0.0f) {
+            static const char* modeNames[] = {
+                "Room", "Hall", "Plate", "Cathedral", "Chamber",
+                "Bright Hall", "Ambience", "Scoring", "Smooth Plate"
+            };
+            const int modeIdx = std::clamp(static_cast<int>(std::round(
+                getParamValue(kMode) * static_cast<float>(kModeCount - 1))), 0, kModeCount - 1);
+            const std::string categoryName =
+                (m_selectedCategory >= 0 && m_selectedCategory < kCategoryCount)
+                    ? m_categoryPills[m_selectedCategory].label
+                    : "";
+            const std::string modeName = (modeIdx >= 0 && modeIdx < kModeCount) ? modeNames[modeIdx] : "";
+            const std::string display = categoryName + " \u00b7 " + modeName;
+
+            renderer.drawTextCentered("MODE", {m_modeLabelBounds.x, m_modeLabelBounds.y,
+                                               m_modeLabelBounds.width, 10.0f},
+                                      7.5f, accent.withAlpha(0.52f));
+            std::string fitted = display;
+            const float nameSize = 10.0f;
+            while (!fitted.empty() && renderer.measureText(fitted, nameSize).width > m_modeLabelBounds.width - 8.0f) {
+                fitted.pop_back();
+            }
+            renderer.drawTextCentered(fitted, {m_modeLabelBounds.x, m_modeLabelBounds.y + 10.0f,
+                                               m_modeLabelBounds.width, 16.0f},
+                                      nameSize, theme.getColor("textPrimary").withAlpha(0.92f));
+        }
+
         const NUIRect abBounds[] = {m_abBoundsA, m_abBoundsB};
         const char* abLabels[] = {"A", "B"};
         for (int i = 0; i < 2; ++i) {

--- a/AestraUI/Widgets/AestraVerbEditor.h
+++ b/AestraUI/Widgets/AestraVerbEditor.h
@@ -40,12 +40,6 @@ private:
         bool hovered = false;
         bool enabled = true;
     };
-    struct ModeDropdownItem {
-        std::string label;
-        int mode = 0;
-        NUIRect bounds;
-        bool hovered = false;
-    };
     struct PresetButton {
         std::string label;
         std::string tooltip;
@@ -101,6 +95,7 @@ private:
     int visiblePresetRows() const;
     int maxPresetScroll() const;
     void syncCategoryFromMode();
+    void stepMode(int direction); // Mode navigator (0.7.0 triage)
     void updateParameter(uint32_t paramId, float v);
     void applyPreset(const PresetButton& preset);
     void loadUserPresets();
@@ -119,14 +114,10 @@ private:
     std::shared_ptr<Aestra::Audio::IPluginInstance> m_instance;
     std::vector<KnobControl> m_knobs;
     std::array<CategoryPill, 4> m_categoryPills;
-    std::vector<ModeDropdownItem> m_dropdownItems;
     std::vector<PresetButton> m_presets;
     std::vector<PresetButton> m_userPresets;
     int m_presetScroll = 0;
     int m_selectedCategory = 0;
-    bool m_dropdownOpen = false;
-    NUIRect m_dropdownButtonBounds;
-    NUIRect m_dropdownListBounds;
     NUIRect m_mixBounds;
     NUIRect m_mixTrack;
     NUIRect m_bypassBounds;
@@ -137,9 +128,9 @@ private:
     NUIRect m_abBoundsA;
     NUIRect m_abBoundsB;
     NUIRect m_mixLockBounds;
+    NUIRect m_modeLabelBounds; // Mode navigator center (0.7.0 triage)
     NUIRect m_paramRowBounds[3];
     int m_hoveredCategory = -1;
-    int m_hoveredDropdownItem = -1;
     int m_hoveredPreset = -1;
     int m_focusedCategory = -1;
     int m_focusedPreset = -1;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -195,6 +195,17 @@ public:
     std::shared_ptr<NUIComponent> getActiveContextMenu() const { return m_activeContextMenu; }
     /** @brief Close and remove the currently open context menu, if any. */
     void dismissActiveContextMenu() { closeActiveContextMenu(); }
+    /** @brief Set whether the viewport follows the playhead during playback. */
+    void setFollowPlayhead(bool on) {
+        m_followPlayhead = on;
+        repaint();
+    }
+    /** @brief Current follow-playhead state (default off — playhead moves, viewport does not). */
+    bool getFollowPlayhead() const { return m_followPlayhead; }
+    /** @brief Set callback fired when the user toggles follow-playhead. */
+    void setOnFollowPlayheadChanged(std::function<void(bool)> cb) { onFollowPlayheadChanged_ = std::move(cb); }
+    /** @brief Set callback fired when the user requests "center on playhead". */
+    void setOnCenterOnPlayhead(std::function<void()> cb) { onCenterOnPlayhead_ = std::move(cb); }
     
     // Callbacks provided by view or used internally
     // void setOnToolChanged... -> Now we might just call NoteLayer directly
@@ -208,11 +219,14 @@ private:
     std::shared_ptr<NUIButton> m_eraserBtn;
     std::shared_ptr<NUIButton> m_lengthDownBtn;
     std::shared_ptr<NUIButton> m_lengthUpBtn;
+    std::shared_ptr<NUIButton> m_followBtn;
+    std::shared_ptr<NUIButton> m_centerBtn;
     std::shared_ptr<NUIDropdown> m_patternDropdown;
     std::shared_ptr<NUIDropdown> m_unitDropdown;
     std::shared_ptr<NUIDropdown> m_snapDropdown;
 
     GlobalTool activeTool_ = GlobalTool::Pencil;
+    bool m_followPlayhead = false;
     void applySnap(SnapGrid snap);
     
     // Icons
@@ -222,6 +236,8 @@ private:
     std::shared_ptr<AestraUI::NUIIcon> m_eraserIcon;
     std::shared_ptr<AestraUI::NUIIcon> m_lengthDownIcon;
     std::shared_ptr<AestraUI::NUIIcon> m_lengthUpIcon;
+    std::shared_ptr<AestraUI::NUIIcon> m_followIcon;
+    std::shared_ptr<AestraUI::NUIIcon> m_centerIcon;
 
     std::weak_ptr<PianoRollGrid> grid_;
     std::weak_ptr<PianoRollNoteLayer> notes_;
@@ -232,6 +248,8 @@ private:
     std::function<void(int unitValue)> onUnitChoiceSelected_;
     std::function<void(int rootKey, ScaleType scaleType, bool snapToScale)> onHarmonyContextChanged_;
     std::function<void()> onShowShortcutHelp_;
+    std::function<void(bool)> onFollowPlayheadChanged_;
+    std::function<void()> onCenterOnPlayhead_;
     bool m_updatingPatternDropdown = false;
     bool m_updatingUnitDropdown = false;
     bool m_updatingSnapDropdown = false;
@@ -688,6 +706,13 @@ public:
     void setOnUnitChoiceSelected(std::function<void(int unitValue)> cb);
     void setOnHarmonyContextChanged(std::function<void(int, ScaleType, bool)> cb);
     void setOnPlayheadScrubbed(std::function<void(double beat, bool active)> cb);
+    /** @brief Forward follow-playhead state/toggle to the toolbar. */
+    void setFollowPlayhead(bool on);
+    bool getFollowPlayhead() const;
+    void setOnFollowPlayheadChanged(std::function<void(bool)> cb);
+    /** @brief One-shot "center on playhead" (no continuous following). */
+    void setOnCenterOnPlayhead(std::function<void()> cb);
+    void centerOnPlayhead();
 
     void setPixelsPerBeat(float ppb);
     void setBeatsPerBar(int bpb);

--- a/AestraUI/Widgets/PianoRollToolbar.cpp
+++ b/AestraUI/Widgets/PianoRollToolbar.cpp
@@ -216,6 +216,28 @@ void PianoRollToolbar::setupUI() {
     m_lengthDownIcon = std::make_shared<NUIIcon>(minusSvg);
     m_lengthUpIcon = std::make_shared<NUIIcon>(plusSvg);
 
+    // Follow-playhead toggle (default OFF: the playhead always moves, the
+    // viewport only follows when explicitly enabled) + one-shot "center on
+    // playhead" jump. 0.7.0 triage: editing must not yank the viewport.
+    m_followBtn = std::make_shared<NUIButton>("");
+    m_followBtn->setToggleable(true);
+    m_followBtn->setTooltip("Follow playhead");
+    m_followBtn->setOnClick([this]() {
+        m_followPlayhead = !m_followPlayhead;
+        if (onFollowPlayheadChanged_) onFollowPlayheadChanged_(m_followPlayhead);
+        repaint();
+    });
+    const char* followSvg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="2.4" fill="currentColor" stroke="none"/></svg>)";
+    m_followIcon = std::make_shared<NUIIcon>(followSvg);
+
+    m_centerBtn = std::make_shared<NUIButton>("");
+    m_centerBtn->setTooltip("Center on playhead");
+    m_centerBtn->setOnClick([this]() {
+        if (onCenterOnPlayhead_) onCenterOnPlayhead_();
+    });
+    const char* centerSvg = R"(<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg>)";
+    m_centerIcon = std::make_shared<NUIIcon>(centerSvg);
+
     addChild(m_menuBtn);
     addChild(m_ptrBtn);
     addChild(m_pencilBtn);
@@ -225,6 +247,8 @@ void PianoRollToolbar::setupUI() {
     addChild(m_snapDropdown);
     addChild(m_lengthDownBtn);
     addChild(m_lengthUpBtn);
+    addChild(m_followBtn);
+    addChild(m_centerBtn);
 }
 
 void PianoRollToolbar::applySnap(SnapGrid snap) {
@@ -438,6 +462,12 @@ void PianoRollToolbar::onRender(NUIRenderer& renderer) {
     currentX += pillW + buttonSpacing;
 
     renderButton(m_lengthUpBtn, m_lengthUpIcon, false);
+
+    // Follow/center group — transport-adjacent, after the length controls.
+    currentX += 8.0f;
+    drawGroup(currentX - 3.0f, buttonSize * 2.0f + buttonSpacing + 6.0f);
+    renderButton(m_followBtn, m_followIcon, m_followPlayhead);
+    renderButton(m_centerBtn, m_centerIcon, false);
 
     // Snap selector — a real dropdown (was a dead "SNAP Beat" text pill). The
     // menu's Snap submenu and this dropdown stay in sync via applySnap().

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -745,6 +745,40 @@ void PianoRollView::setOnPatternChoiceSelected(std::function<void(int patternVal
     }
 }
 
+void PianoRollView::setFollowPlayhead(bool on) {
+    if (m_toolbar) {
+        m_toolbar->setFollowPlayhead(on);
+    }
+}
+
+bool PianoRollView::getFollowPlayhead() const {
+    return m_toolbar ? m_toolbar->getFollowPlayhead() : false;
+}
+
+void PianoRollView::setOnFollowPlayheadChanged(std::function<void(bool)> cb) {
+    if (m_toolbar) {
+        m_toolbar->setOnFollowPlayheadChanged(std::move(cb));
+    }
+}
+
+void PianoRollView::setOnCenterOnPlayhead(std::function<void()> cb) {
+    if (m_toolbar) {
+        m_toolbar->setOnCenterOnPlayhead(std::move(cb));
+    }
+}
+
+void PianoRollView::centerOnPlayhead() {
+    // One-shot jump: aim the eased scroll at the playhead (the follow target
+    // math), without arming continuous following.
+    if (m_grid) {
+        const float visibleW = m_grid->getWidth();
+        if (visibleW > 0.0f) {
+            m_targetScrollX = pianoRollFollowTargetScroll(m_scrollX, m_pixelsPerBeat, visibleW, m_playheadBeat);
+            updateScrollbars();
+        }
+    }
+}
+
 void PianoRollView::setOnUnitChoiceSelected(std::function<void(int unitValue)> cb) {
     if (m_toolbar) {
         m_toolbar->setOnUnitChoiceSelected(std::move(cb));

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -768,12 +768,15 @@ void PianoRollView::setOnCenterOnPlayhead(std::function<void()> cb) {
 }
 
 void PianoRollView::centerOnPlayhead() {
-    // One-shot jump: aim the eased scroll at the playhead (the follow target
-    // math), without arming continuous following.
+    // Explicit center action: aim the eased scroll so the playhead sits at
+    // the viewport's middle (clamped to the pattern start). The guarded
+    // follow math is for CONTINUOUS tracking — it deliberately does nothing
+    // inside its dead zone, which is wrong for a one-shot jump (CR review).
     if (m_grid) {
         const float visibleW = m_grid->getWidth();
         if (visibleW > 0.0f) {
-            m_targetScrollX = pianoRollFollowTargetScroll(m_scrollX, m_pixelsPerBeat, visibleW, m_playheadBeat);
+            const float playheadX = static_cast<float>(m_playheadBeat * m_pixelsPerBeat);
+            m_targetScrollX = std::max(0.0f, playheadX - visibleW * 0.5f);
             updateScrollbars();
         }
     }

--- a/AestraUI/Widgets/UnitNameLabel.cpp
+++ b/AestraUI/Widgets/UnitNameLabel.cpp
@@ -62,6 +62,14 @@ void UnitNameLabel::onRender(NUIRenderer& renderer) {
                       12.0f,
                       theme.getColor("textPrimary").withAlpha(0.92f));
 
+    if (m_compact) {
+        // Compact representation: name only. The type line returns at Full
+        // density (responsive contract: available width -> density ->
+        // representation).
+        renderer.clearClipRect();
+        return;
+    }
+
     std::string typeLabel;
     switch (m_unitType) {
     case Aestra::Audio::UnitType::Sampler:

--- a/AestraUI/Widgets/UnitNameLabel.h
+++ b/AestraUI/Widgets/UnitNameLabel.h
@@ -18,6 +18,8 @@ namespace AestraUI {
 class UnitNameLabel : public NUIComponent {
 public:
     explicit UnitNameLabel(const std::string& name, Aestra::Audio::UnitType type);
+    /** @brief Compact representation: name only, no type line (responsive density). */
+    void setCompact(bool compact) { m_compact = compact; repaint(); }
 
     void setUnitName(const std::string& name);
     void setUnitType(Aestra::Audio::UnitType type);
@@ -42,6 +44,7 @@ private:
     std::string m_unitName;
     Aestra::Audio::UnitType m_unitType;
     bool m_isRenaming = false;
+    bool m_compact = false;
     long long m_lastClickTimeMs = 0;
 
     std::shared_ptr<NUITextInput> m_textInput;

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -372,6 +372,20 @@ void UnitRow::drawGearIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     renderer.drawLine(NUIPoint(cx - r - 2, cy), NUIPoint(cx + r + 2, cy), 2.0f, color);
 }
 
+std::array<NUIRect, 3> UnitRow::controlPillRects(const NUIRect& controlBounds) const {
+    const bool showBars = (m_density == Density::Full);
+    const float routeW = (m_density == Density::Minimal) ? 24.0f : (m_density == Density::Compact) ? 34.0f : 42.0f;
+    const float muteW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
+    const float soloW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
+    const float pillY = controlBounds.y + controlBounds.height * 0.5f - 10.0f;
+    const float bandRight = controlBounds.right() - (showBars ? 18.0f : 4.0f);
+    return {
+        NUIRect(bandRight - soloW - 6.0f - muteW - 6.0f - routeW, pillY, routeW, 20.0f), // route
+        NUIRect(bandRight - soloW - 6.0f - muteW, pillY, muteW, 20.0f),                   // mute
+        NUIRect(bandRight - soloW, pillY, soloW, 20.0f),                                  // solo
+    };
+}
+
 void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     auto& theme = NUIThemeManager::getInstance();
     bool hasContent = !m_pluginId.empty() || !m_audioClip.empty();
@@ -392,16 +406,10 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
 
     // Name + type label are rendered by the UnitNameLabel child component.
 
-    const float pillY = centerY - 10.0f;
-    // Pill band widths follow the density tier (see layoutNameLabel).
-    const bool showBars = (m_density == Density::Full);
-    const float routeW = (m_density == Density::Minimal) ? 24.0f : (m_density == Density::Compact) ? 34.0f : 42.0f;
-    const float muteW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
-    const float soloW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
-    const float bandRight = bounds.right() - (showBars ? 18.0f : 4.0f);
-    const NUIRect routeRect(bandRight - soloW - 6.0f - muteW - 6.0f - routeW, pillY, routeW, 20.0f);
-    const NUIRect muteRect(bandRight - soloW - 6.0f - muteW, pillY, muteW, 20.0f);
-    const NUIRect soloRect(bandRight - soloW, pillY, soloW, 20.0f);
+    const auto pills = controlPillRects(bounds);
+    const NUIRect& routeRect = pills[0];
+    const NUIRect& muteRect = pills[1];
+    const NUIRect& soloRect = pills[2];
     const NUIColor routeFill = m_mixerChannelId == Aestra::Audio::MASTER_MIXER_CHANNEL_ID
                                    ? theme.getColor("surfaceTertiary")
                                    : unitAccent.withAlpha(0.16f);
@@ -414,7 +422,7 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     drawMuteIcon(renderer, muteRect, m_isMuted);
     drawSoloIcon(renderer, soloRect, m_isSolo);
 
-    if (showBars) {
+    if (m_density == Density::Full) {
         const float indicatorX = bounds.right() - 18.0f;
         for (int i = 0; i < 3; ++i) {
             const float h = 4.0f + i * 3.0f;
@@ -1010,9 +1018,10 @@ void UnitRow::handleControlClick(const NUIMouseEvent& event, const NUIRect& boun
         return;
     }
 
-    const NUIRect muteRect(bounds.width - 92.0f, bounds.height * 0.5f - 10.0f, 24.0f, 20.0f);
-    const NUIRect soloRect(bounds.width - 62.0f, bounds.height * 0.5f - 10.0f, 24.0f, 20.0f);
-    const NUIRect routeRect(bounds.width - 142.0f, bounds.height * 0.5f - 10.0f, 42.0f, 20.0f);
+    const auto pills = controlPillRects(bounds);
+    const NUIRect& muteRect = pills[1];
+    const NUIRect& soloRect = pills[2];
+    const NUIRect& routeRect = pills[0];
     const NUIPoint localPoint(localX, localY);
     if (routeRect.contains(localPoint)) {
         showMixerRoutingMenu(event.position);

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -240,7 +240,9 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
     renderer.fillRoundedRect({cardBounds.x + 1.0f, cardBounds.y + 8.0f, 4.0f, cardBounds.height - 16.0f}, 2.0f,
                              unitAccent.withAlpha(m_isEnabled ? 0.95f : 0.35f));
 
-    m_controlWidth = std::clamp(cardBounds.width * 0.38f, 220.0f, 312.0f);
+    // Density-derived control floor (responsive contract): narrow rows give
+    // the grid the width back instead of clipping it against a fixed 220.
+    m_controlWidth = std::clamp(cardBounds.width * 0.38f, controlFloorForDensity(cardBounds.width), 312.0f);
 
     NUIRect dragRect(cardBounds.x + 6.0f, cardBounds.y + 6.0f, 32.0f, cardBounds.height - 12.0f);
     drawDragHandle(renderer, dragRect);
@@ -391,9 +393,15 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     // Name + type label are rendered by the UnitNameLabel child component.
 
     const float pillY = centerY - 10.0f;
-    const NUIRect routeRect(bounds.x + bounds.width - 142.0f, pillY, 42.0f, 20.0f);
-    const NUIRect muteRect(bounds.x + bounds.width - 92.0f, pillY, 24.0f, 20.0f);
-    const NUIRect soloRect(bounds.x + bounds.width - 62.0f, pillY, 24.0f, 20.0f);
+    // Pill band widths follow the density tier (see layoutNameLabel).
+    const bool showBars = (m_density == Density::Full);
+    const float routeW = (m_density == Density::Minimal) ? 24.0f : (m_density == Density::Compact) ? 34.0f : 42.0f;
+    const float muteW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
+    const float soloW = (m_density == Density::Minimal) ? 16.0f : (m_density == Density::Compact) ? 20.0f : 24.0f;
+    const float bandRight = bounds.right() - (showBars ? 18.0f : 4.0f);
+    const NUIRect routeRect(bandRight - soloW - 6.0f - muteW - 6.0f - routeW, pillY, routeW, 20.0f);
+    const NUIRect muteRect(bandRight - soloW - 6.0f - muteW, pillY, muteW, 20.0f);
+    const NUIRect soloRect(bandRight - soloW, pillY, soloW, 20.0f);
     const NUIColor routeFill = m_mixerChannelId == Aestra::Audio::MASTER_MIXER_CHANNEL_ID
                                    ? theme.getColor("surfaceTertiary")
                                    : unitAccent.withAlpha(0.16f);
@@ -401,17 +409,20 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
         m_mixerRouteShortLabel == "!" ? theme.getColor("error").withAlpha(0.75f) : unitAccent.withAlpha(0.42f);
     renderer.fillRoundedRect(routeRect, 4.0f, routeFill);
     renderer.strokeRoundedRect(routeRect, 4.0f, 1.0f, routeStroke);
-    renderer.drawTextCentered(m_mixerRouteShortLabel, routeRect, 9.0f, theme.getColor("textPrimary").withAlpha(0.9f));
+    renderer.drawTextCentered(m_mixerRouteShortLabel, routeRect, m_density == Density::Minimal ? 7.5f : 9.0f,
+                              theme.getColor("textPrimary").withAlpha(0.9f));
     drawMuteIcon(renderer, muteRect, m_isMuted);
     drawSoloIcon(renderer, soloRect, m_isSolo);
 
-    const float indicatorX = bounds.right() - 18.0f;
-    for (int i = 0; i < 3; ++i) {
-        const float h = 4.0f + i * 3.0f;
-        const NUIRect bar(indicatorX + i * 4.0f, bounds.y + 28.0f - h * 0.5f, 2.0f, h);
-        const NUIColor color = hasContent ? theme.getColor("accentPrimary").withAlpha(0.75f - i * 0.12f)
-                                          : theme.getColor("textDisabled").withAlpha(0.28f);
-        renderer.fillRoundedRect(bar, 1.0f, color);
+    if (showBars) {
+        const float indicatorX = bounds.right() - 18.0f;
+        for (int i = 0; i < 3; ++i) {
+            const float h = 4.0f + i * 3.0f;
+            const NUIRect bar(indicatorX + i * 4.0f, bounds.y + 28.0f - h * 0.5f, 2.0f, h);
+            const NUIColor color = hasContent ? theme.getColor("accentPrimary").withAlpha(0.75f - i * 0.12f)
+                                              : theme.getColor("textDisabled").withAlpha(0.28f);
+            renderer.fillRoundedRect(bar, 1.0f, color);
+        }
     }
 }
 
@@ -747,7 +758,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
 
     auto bounds = getBounds();
     const NUIRect localDragRect(6.0f, 6.0f, 32.0f, 44.0f);
-    m_controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
+    m_controlWidth = std::clamp(bounds.width * 0.38f, controlFloorForDensity(bounds.width), 312.0f);
     const NUIRect localControlRect(42.0f, 0.0f, std::max(0.0f, m_controlWidth - 48.0f), 56.0f);
     const float separatorX = m_controlWidth;
     const NUIRect localContextRect(separatorX + 8.0f, 6.0f, std::max(0.0f, bounds.width - (separatorX + 14.0f)), 44.0f);
@@ -1310,13 +1321,32 @@ void UnitRow::layoutNameLabel() {
     if (!m_nameLabel)
         return;
     auto bounds = getBounds();
-    float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
+    // Density tiers from available width: Full >= 620, Compact >= 440,
+    // Minimal below. The control block floor follows the tier so narrow rows
+    // give the step grid the width back instead of clipping it.
+    m_density = densityForWidth(bounds.width);
+    float controlWidth = std::clamp(bounds.width * 0.38f, controlFloorForDensity(bounds.width), 312.0f);
     float labelX = 54.0f; // 42 (control block) + 12 (name indent)
-    // No 56px floor: at controlWidth 220 the floor pushed the label 38px past
-    // the route pill (which starts at controlWidth - 148). The label shrinks
-    // with the row and ellipsizes in UnitNameLabel (triage 2026-08-14).
-    float labelWidth = std::max(16.0f, controlWidth - 206.0f);
+    // The label ends before the pill band; the band width follows the tier.
+    const float pillBand = (m_density == Density::Full)     ? 142.0f
+                           : (m_density == Density::Compact) ? 110.0f
+                                                             : 74.0f;
+    float labelWidth = std::max(16.0f, (controlWidth - 48.0f) - pillBand - 6.0f);
     m_nameLabel->setBounds(NUIRect(labelX, 8.0f, labelWidth, 30.0f));
+    m_nameLabel->setCompact(m_density != Density::Full);
+}
+
+UnitRow::Density UnitRow::densityForWidth(float width) {
+    return (width >= 620.0f)   ? Density::Full
+           : (width >= 440.0f) ? Density::Compact
+                               : Density::Minimal;
+}
+
+float UnitRow::controlFloorForDensity(float width) {
+    const Density d = densityForWidth(width);
+    return (d == Density::Minimal)   ? 150.0f
+           : (d == Density::Compact) ? 180.0f
+                                     : 220.0f;
 }
 
 void UnitRow::routeToMixerChannel(uint32_t channelId) {

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -193,6 +193,12 @@ private:
     static constexpr float PAD_SPACING = 3.0f;        // Space between pads
     
     float m_controlWidth = CONTROL_WIDTH;
+    // Responsive density (0.7.0 triage): derived from row width, never
+    // hardcoded per-state. Full keeps the pill band + type line; Compact
+    // compresses pills and drops the type line; Minimal collapses to a
+    // letter-only route chip and icon mute/solo.
+    enum class Density { Full, Compact, Minimal };
+    Density m_density = Density::Full;
     
     // Step sequencer
     int m_stepCount = 16;
@@ -267,6 +273,8 @@ private:
 
     // Internal components
     std::shared_ptr<UnitNameLabel> m_nameLabel;
+    Density densityForWidth(float width);
+    float controlFloorForDensity(float width);
     std::shared_ptr<NUIContextMenu> m_rowContextMenu;
     std::shared_ptr<NUIContextMenu> m_mixerRoutingMenu;
 

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -275,6 +275,9 @@ private:
     std::shared_ptr<UnitNameLabel> m_nameLabel;
     Density densityForWidth(float width);
     float controlFloorForDensity(float width);
+    // Tier-aware pill geometry shared by rendering and hit-testing (CR review:
+    // the hit-test used fixed Full-density rects in Compact/Minimal tiers).
+    std::array<NUIRect, 3> controlPillRects(const NUIRect& controlBounds) const;
     std::shared_ptr<NUIContextMenu> m_rowContextMenu;
     std::shared_ptr<NUIContextMenu> m_mixerRoutingMenu;
 

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -1375,29 +1375,14 @@ void FileBrowser::renderStaticContent(NUIRenderer& renderer, const NUIRect& boun
     NUIRect fileBrowserBounds(bounds.x, bounds.y, bounds.width, bounds.height);
 
     renderer.fillRect(fileBrowserBounds, themeManager.getColor("backgroundPrimary"));
-    renderer.fillRect(browserLayout.searchBar, themeManager.getColor("backgroundSecondary").darkened(0.02f));
+    // Search row sits ON the surface (DESIGN.md rule 4: no recessed dark
+    // well); the single quiet divider below it explains the boundary.
     renderer.drawLine({browserLayout.searchBar.x, browserLayout.searchBar.bottom() - 1.0f},
                       {browserLayout.searchBar.right(), browserLayout.searchBar.bottom() - 1.0f},
-                      1.0f, themeManager.getColor("border").withAlpha(0.52f));
+                      1.0f, themeManager.getColor("border").withAlpha(0.30f));
 
-    const auto& themeProps = themeManager.getCurrentTheme();
-    const float cornerRadius = themeProps.radiusM;
-
-    NUIRect topClip = fileBrowserBounds;
-    topClip.height -= cornerRadius;
-    renderer.setClipRect(topClip);
-    renderer.strokeRoundedRect(fileBrowserBounds, cornerRadius, 1.0f, borderColor_);
-    renderer.clearClipRect();
-
-    NUIRect bottomClip = fileBrowserBounds;
-    bottomClip.y = fileBrowserBounds.bottom() - cornerRadius;
-    bottomClip.height = cornerRadius;
-    renderer.setClipRect(bottomClip);
-
-    renderer.drawLine(NUIPoint(fileBrowserBounds.x, bottomClip.y), NUIPoint(fileBrowserBounds.x, bottomClip.bottom()), 1.0f, borderColor_);
-    renderer.drawLine(NUIPoint(fileBrowserBounds.right(), bottomClip.y), NUIPoint(fileBrowserBounds.right(), bottomClip.bottom()), 1.0f, borderColor_);
-
-    renderer.clearClipRect();
+    // Flat square border — the curved grey top treatment is gone (0.7.0 triage).
+    renderer.strokeRect(fileBrowserBounds, 1.0f, borderColor_);
 
     renderNavigationPane(renderer, browserLayout);
     renderListHeader(renderer, browserLayout);

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -391,6 +391,9 @@ FileBrowser::FileBrowser()
     // Initialize search input
     searchInput_ = std::make_shared<NUITextInput>();
     searchInput_->setPlaceholderText("Search files and folders");
+    // The search row sits on the surface (0.7.0 triage): the input must not
+    // paint its own recessed background/border over the flattened treatment.
+    searchInput_->setBackgroundVisible(false);
     addChild(searchInput_);
 
     // Bind search callback

--- a/Source/Panels/PianoRollPanel.cpp
+++ b/Source/Panels/PianoRollPanel.cpp
@@ -138,6 +138,14 @@ PianoRollPanel::PianoRollPanel(std::shared_ptr<TrackManager> trackManager)
     m_pianoRoll->setIsPlayingCallback([this]() {
         return m_trackManager && m_trackManager->isPlaying();
     });
+    // Follow-playhead is opt-in (0.7.0 triage): the playhead always moves,
+    // the viewport tracks only when enabled; "Center on playhead" jumps once.
+    m_pianoRoll->setOnFollowPlayheadChanged([this](bool on) {
+        m_followPlayhead = on;
+    });
+    m_pianoRoll->setOnCenterOnPlayhead([this]() {
+        m_pianoRoll->centerOnPlayhead();
+    });
     m_pianoRoll->setOnPreviewNote([this](int pitch, int velocity) {
         if (m_trackManager && m_trackManager->isPlaying()) return;
         if (m_audioEngine && m_editingUnitId != 0) {
@@ -578,7 +586,11 @@ void PianoRollPanel::onUpdate(double deltaTime) {
                     if (m_trackManager->isPatternMode()) {
                         playheadBeat = std::fmod(currentBeat, patternLength);
                         if (playheadBeat < 0.0) playheadBeat += patternLength;
-                        follow = m_trackManager->isPlaying();
+                        // Follow is opt-in (0.7.0 triage): the playhead always
+                        // moves, but the viewport only tracks it when the user
+                        // enabled "Follow playhead" — editing while playing
+                        // must not yank the viewport back.
+                        follow = m_followPlayhead && m_trackManager->isPlaying();
                     } else {
                         // This editor's X axis is PATTERN-LOCAL beats; the transport reports
                         // ARRANGEMENT beats. Feeding one into the other drew a playhead that

--- a/Source/Panels/PianoRollPanel.h
+++ b/Source/Panels/PianoRollPanel.h
@@ -126,6 +126,7 @@ private:
     bool m_applyingUndoRedo{false};           // Guard flag to prevent re-entry
     bool m_switchingUnit{false};              // Guards setEditingUnit against save-echo recursion
     bool m_wasVisible{false};
+    bool m_followPlayhead{false}; // Opt-in viewport tracking (0.7.0 triage)
     double m_lastPlayheadBeat{-1.0}; // Gates idle repaint; only redraw when the playhead actually moves
 };
 

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -704,7 +704,7 @@ void SampleEditorPanel::buildUI() {
     m_voiceCountLabel = makeLabel("Voices");
     m_voiceCountValueLabel = makeLabel("4");
     m_voiceCountValueLabel->setAlignment(NUILabel::Alignment::Right);
-    m_pitchLabel = makeLabel("KEYBOARD PITCH / ROOT");
+    m_pitchLabel = makeLabel("PITCH / ROOT");
     m_pitchRootLabel = makeLabel("Root");
     m_pitchRootValueLabel = makeLabel(midiNoteName(60));
     m_pitchRootValueLabel->setAlignment(NUILabel::Alignment::Right);
@@ -940,16 +940,19 @@ void SampleEditorPanel::onResize(int width, int height) {
     const float modeAvailableW = std::max(168.0f, contentW - monoGroupW - voiceGroupW - gutter * 3.0f);
     const float modeBtnW = std::max(56.0f, std::min(82.0f, modeAvailableW / 3.0f));
     float x = cb.x + pad;
+    // Real gaps between buttons: the previous -1px overlap faked a segment
+    // container with colliding borders (DESIGN.md: dividers explain structure,
+    // they do not decorate).
     m_monoModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
-    x += monoBtnW - 1.0f;
+    x += monoBtnW + 2.0f;
     m_polyModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
-    x += monoBtnW - 1.0f;
+    x += monoBtnW + 2.0f;
     m_cutSelfModeBtn->setBounds(NUIRect(x, y, monoBtnW, rowH));
     x += monoBtnW + gutter;
     m_oneShotModeBtn->setBounds(NUIRect(x, y, modeBtnW, rowH));
-    x += modeBtnW - 1.0f;
+    x += modeBtnW + 2.0f;
     m_loopModeBtn->setBounds(NUIRect(x, y, modeBtnW, rowH));
-    x += modeBtnW - 1.0f;
+    x += modeBtnW + 2.0f;
     m_pingPongModeBtn->setBounds(NUIRect(x, y, modeBtnW, rowH));
     const float voiceX = cb.x + layoutW - pad - voiceGroupW;
     m_voiceCountLabel->setBounds(NUIRect(voiceX, y + 4.0f, voiceLabelW, labelH));
@@ -1064,11 +1067,13 @@ void SampleEditorPanel::setLoopMode(LoopMode mode) {
 
 void SampleEditorPanel::updateModeButtons() {
     auto& theme = NUIThemeManager::getInstance();
-    const auto activeBg = theme.getColor("secondary").withAlpha(0.78f);
+    // Active interaction intent is the Aestra accent (DESIGN.md color
+    // semantics); the previous secondary (electric blue) token violated it.
+    const auto activeBg = theme.getColor("accentPrimary").withAlpha(0.22f);
     const auto inactiveBg = NUIColor::transparent();
-    const auto hoverBg = theme.getColor("secondary").withAlpha(0.18f);
-    const auto borderCol = theme.getColor("secondary").withAlpha(0.40f);
-    const auto activeText = theme.getColor("textPrimary").withAlpha(0.96f);
+    const auto hoverBg = theme.getColor("accentPrimary").withAlpha(0.10f);
+    const auto borderCol = theme.getColor("borderSubtle").withAlpha(0.40f);
+    const auto activeText = theme.getColor("accentPrimary").lightened(0.25f);
     const auto inactiveText = theme.getColor("textSecondary").withAlpha(0.72f);
 
     auto styleButton = [&](const std::shared_ptr<NUIButton>& button, LoopMode mode) {
@@ -1078,12 +1083,12 @@ void SampleEditorPanel::updateModeButtons() {
         const bool active = m_loopPoints.mode == mode;
         button->setBackgroundColor(active ? activeBg : inactiveBg);
         button->setHoverColor(active ? activeBg : hoverBg);
-        button->setPressedColor(theme.getColor("secondary").withAlpha(0.9f));
+        button->setPressedColor(theme.getColor("accentPrimary").withAlpha(0.32f));
         button->setTextColor(active ? activeText : inactiveText);
         button->setCornerRadius(4.0f);
         button->setBorderEnabled(true);
         button->setBorderWidth(1.0f);
-        button->setBorderColor(active ? theme.getColor("secondary").withAlpha(0.72f) : borderCol);
+        button->setBorderColor(active ? theme.getColor("accentPrimary").withAlpha(0.55f) : borderCol);
     };
 
     styleButton(m_oneShotModeBtn, LoopMode::OneShot);
@@ -1127,23 +1132,23 @@ void SampleEditorPanel::setCutSelfMode(bool cutSelf) {
 
 void SampleEditorPanel::updateMonoPolyControls() {
     auto& theme = NUIThemeManager::getInstance();
-    const auto activeBg = theme.getColor("secondary").withAlpha(0.78f);
+    const auto activeBg = theme.getColor("accentPrimary").withAlpha(0.22f);
     const auto inactiveBg = NUIColor::transparent();
-    const auto hoverBg = theme.getColor("secondary").withAlpha(0.18f);
-    const auto activeText = theme.getColor("textPrimary").withAlpha(0.96f);
+    const auto hoverBg = theme.getColor("accentPrimary").withAlpha(0.10f);
+    const auto activeText = theme.getColor("accentPrimary").lightened(0.25f);
     const auto inactiveText = theme.getColor("textSecondary").withAlpha(0.72f);
-    const auto inactiveBorder = theme.getColor("secondary").withAlpha(0.40f);
+    const auto inactiveBorder = theme.getColor("borderSubtle").withAlpha(0.40f);
 
     auto styleButton = [&](const std::shared_ptr<NUIButton>& button, bool active) {
         if (!button) return;
         button->setBackgroundColor(active ? activeBg : inactiveBg);
         button->setHoverColor(active ? activeBg : hoverBg);
-        button->setPressedColor(theme.getColor("secondary").withAlpha(0.9f));
+        button->setPressedColor(theme.getColor("accentPrimary").withAlpha(0.32f));
         button->setTextColor(active ? activeText : inactiveText);
         button->setCornerRadius(4.0f);
         button->setBorderEnabled(true);
         button->setBorderWidth(1.0f);
-        button->setBorderColor(active ? theme.getColor("secondary").withAlpha(0.72f) : inactiveBorder);
+        button->setBorderColor(active ? theme.getColor("accentPrimary").withAlpha(0.55f) : inactiveBorder);
     };
 
     styleButton(m_monoModeBtn, m_monoMode);

--- a/Source/Panels/SampleEditorPanel.cpp
+++ b/Source/Panels/SampleEditorPanel.cpp
@@ -932,7 +932,10 @@ void SampleEditorPanel::onResize(int width, int height) {
     m_modeLabel->setBounds(NUIRect(cb.x + pad, modeRowY, contentW, labelH));
     y = modeRowY + labelH;
     const float monoBtnW = 52.0f;
-    const float monoGroupW = monoBtnW * 3.0f - 2.0f;
+    // Real gaps between the three mono buttons (2px each), not the old
+    // overlapping -1px segments — keeps modeAvailableW honest so the
+    // ping-pong button cannot drift over the voice group at min width.
+    const float monoGroupW = monoBtnW * 3.0f + 2.0f * 2.0f;
     const float voiceValueW = 24.0f;
     const float voiceSliderW = std::min(132.0f, std::max(84.0f, contentW * 0.20f));
     const float voiceLabelW = 42.0f;


### PR DESCRIPTION
## Summary

Final 0.7.0 UI triage (cut-day boundary: broken interactions, workflow corrections, overflow/adaptive-layout fixes, contained visual polish — nothing beyond these six areas).

**P0 — Piano roll playhead / viewport (workflow correction)**
Playhead movement is separated from viewport following. A new **"Follow playhead" toggle** (toolbar, default OFF) arms continuous tracking; **"Center on playhead"** jumps once. The playhead always moves; editing while playing no longer yanks the viewport back. Previously `follow = isPlaying()` unconditionally.

**P0 — Arsenal responsive units (adaptive layout)**
Unit rows implement the contract `available width → density → representation`: **Full** (≥620) keeps the type line, pill band, and level bars; **Compact** (≥440) drops the type line and compresses the pill band; **Minimal** (<440) collapses to a letter-only route chip + icon mute/solo. The control-block floor follows the tier (220/180/150), so narrow rows return width to the step grid instead of clipping it. Thresholds and floors are two small helpers, not per-state hacks.

**P1 — Sample Editor focused pass**
Active mode/voice buttons now use the Aestra accent (they used the secondary/electric-blue token, violating DESIGN.md color semantics); section header normalized ("KEYBOARD PITCH / ROOT" → "PITCH / ROOT"); the −1px button-overlap hack replaced with real gaps. Behavior untouched.

**P1 — Reverb mode navigator (per founder spec)**
The MODE dropdown is removed entirely (layout/render/hit-test/hover/open-close). The bottom deck is now BYP FRZ SAVE MIX, then **`‹ CATEGORY · Algorithm ›`** with a MODE micro-label above the centered pair; the arrows step through adjacent algorithms with wrap; category pills still select the family (first algorithm) and follow the current mode. A/B stays as the utility pair. The reclaimed vertical band moves the main content up (134→100); section gap relaxed 8→10, button gap 6→8. Presets remain in their strip.

**P1 — Search bar top treatment**
The file browser search row sits on the surface (no recessed dark well — DESIGN.md rule 4) and the curved grey top border is a flat 1px stroke. The quiet divider stays.

Resize bug: deferred per founder call — will be handled reactively when it reproduces.

## Why

Cut-day boundary: these are the accepted-in items (workflow correctness, adaptive layout, contained polish). Nothing here adds editor capabilities, new interaction paradigms, or architectural rewrites.

## Testing performed

- Full suite green (231 tests; SecAccountEndToEndSmoke skipped by design) on the final branch state.
- App builds clean across all four commits; PanelResizeLayoutTest green.
- Visual verification is manual (UI surface) — screenshots on request before merge.

## Producer note

The Piano Roll view no longer follows the playhead while you edit unless you turn Follow on, and the reverb's mode selector is now a simple `‹ ›` navigator in the bottom deck.

## Docs updated?

No public docs.

## Risk/rollback notes

- Piano roll: default behavior changed (viewport no longer auto-follows during playback). Explicit toggle + one-shot center restore the old behavior.
- Arsenal: rows render differently below 620px width (no type line below 620, compact pills below 440) — layout-only, no state or audio changes.
- Reverb: the dropdown removal is a UI-surface change; plugin architecture/behavior untouched. The mode value semantics (param kMode) are identical.
- Rollback = revert this PR.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Make piano-roll viewport following opt-in with **Follow playhead**. Add **Center on playhead** for one-shot centering.
- Add responsive Arsenal unit-row layouts for full, compact, and minimal widths.
- Improve Sample Editor labels, spacing, and interaction colors without changing behavior.
- Replace the Reverb MODE dropdown with cyclic arrow navigation. Preserve category selection and mode parameters.
- Flatten the file-browser search row and simplify its divider.
- Defer the resize issue for future reactive handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->