### PR TITLE
release: v0.7.0-alpha prep — version bumps, PR count, automation claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
 
-331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+338 PRs merged (#624–#775). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 > **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
 
@@ -185,15 +185,11 @@ The public repository is currently on a `0.x` pre-beta line. The release target 
 
 ### Automation
 
-- Plugin instances carry permanent identities in the chain state (#667 slice 1), so automation and saved state
-  survive chain edits without aliasing.
-- Automation lanes are actually automatable: the first click on an empty lane creates a neutral Volume
-  curve bound to the lane's channel, and edits rebuild the audio graph and mark the project dirty.
+- Automation targets the plugin instance it was drawn for, never the slot it occupied — chain
+  reordering keeps curves bound to their plugin (#766).
+- Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's
+  channel, and edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
-
-> Cut-time gate: instance-targeted automation (curves address the plugin instance rather than the slot)
-> is #766, still open at this writing. If it merges before the cut, restore the stronger claim; if not,
-> the entry above is the accurate one.
 - Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/aestra-core/cmake/AestraCoreMode.cmake")
 	include(${CMAKE_SOURCE_DIR}/aestra-core/cmake/AestraCoreMode.cmake)
 endif()
 
-project(AESTRA VERSION 0.1.0 LANGUAGES C CXX)
+project(AESTRA VERSION 0.7.0 LANGUAGES C CXX)
 
 # Ensure CTest discovery/registration works from the build root.
 include(CTest)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,7 +25,7 @@ v1.0.0                  — initial public release
 | `v0.4.0-alpha`       | Superseded | 2026-05-20 | Hardening milestone: security audit, audio quality session, repo hygiene mega-pass |
 | `v0.5.0-alpha`       | Superseded | 2026-05-23 | Takes system, CLAP parameters, audio quality, CI hardening, 11 PRs merged |
 | `v0.6.0-alpha`       | Superseded | 2026-05-29 | Security & RT hardening, plugin host crash resilience, callback-safety architecture, 26 PRs merged |
-| `v0.7.0-alpha`       | Current   | 2026-08-16 | Routing & automation correctness, Master plugin host, PDC master latency, piano-roll workflow, reliability gates, 331 PRs merged |
+| `v0.7.0-alpha`       | Current   | 2026-08-16 | Routing & automation correctness, Master plugin host, PDC master latency, piano-roll workflow, reliability gates, 338 PRs merged |
 
 ---
 
@@ -33,7 +33,7 @@ v1.0.0                  — initial public release
 
 ### v0.7.0-alpha — Routing, Automation & Hosting Milestone (Aug 2026)
 
-331 PRs merged (#624–#771). The milestone's story is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+338 PRs merged (#624–#775). The milestone's story is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 **Routing & Mixing** — Unity gain law across live, export, isolated bounce, audition, and monitoring; single-store fader/pan; routing command seam with cycle rejection and stable send IDs; Master as a plugin host with chain latency in the PDC graph; master clips obey the live solo gate (isolation contract pinned both ways).
 
@@ -45,7 +45,7 @@ v1.0.0                  — initial public release
 
 **Reliability** — Security/durability/realtime contract lanes CI-authoritative; decision-citation and test-contract gates; plugin hosting compiled in CI, Windows plugins sandboxed; four review rounds (20 findings) on the triage branch; undici CVEs cleaned.
 
-**PRs merged** — #624–#771 (331 PRs).
+**PRs merged** — #624–#775 (338 PRs).
 
 ### v0.6.0-alpha — Security & RT Hardening (May 2026)
 

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -6,7 +6,7 @@
 ; =========================================================
 
 #define MyAppName        "Aestra"
-#define MyAppVersion     "1.1.0"
+#define MyAppVersion     "0.7.0"
 #define MyAppPublisher   "Aestra Studios"
 #define MyAppURL         "https://Aestra-daw.com"
 #define MyAppExeName     "AestraDAW.exe"

--- a/meta/CHANGELOGS/CHANGELOG_2026Q3.md
+++ b/meta/CHANGELOGS/CHANGELOG_2026Q3.md
@@ -4,7 +4,7 @@ All notable changes for Aestra in Q3 2026 are documented here.
 
 ## v0.7.0-alpha — Routing, Automation & Hosting Milestone (2026-08-16)
 
-331 PRs merged (#624–#771). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
+338 PRs merged (#624–#775). The story of this milestone is coherence: routing and gain staging are correct end to end, automation lanes are actually automatable, the Master channel is a real plugin host whose latency sits in the compensation graph, and the piano roll grew from an editor into a workflow.
 
 > **Versions, clarified.** `v0.7.0-alpha` is the *application release version*. It is unrelated to `ProjectSerializer::PROJECT_VERSION_CURRENT` (the project/file format version, currently 3): the format version changes only when the `.aes` format itself changes, never on a release bump.
 
@@ -18,15 +18,11 @@ All notable changes for Aestra in Q3 2026 are documented here.
 
 ### Automation
 
-- Plugin instances carry permanent identities in the chain state (#667 slice 1), so automation and saved state
-  survive chain edits without aliasing.
-- Automation lanes are actually automatable: the first click on an empty lane creates a neutral Volume
-  curve bound to the lane's channel, and edits rebuild the audio graph and mark the project dirty.
+- Automation targets the plugin instance it was drawn for, never the slot it occupied — chain
+  reordering keeps curves bound to their plugin (#766).
+- Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's
+  channel, and edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
-
-> Cut-time gate: instance-targeted automation (curves address the plugin instance rather than the slot)
-> is #766, still open at this writing. If it merges before the cut, restore the stronger claim; if not,
-> the entry above is the accurate one.
 - Empty lanes are automatable: the first click creates a neutral Volume curve bound to the lane's channel; edits rebuild the audio graph and mark the project dirty.
 - Leftover demo automation removed from the default project and from previously saved projects.
 


### PR DESCRIPTION
Release-prep for the 0.7.0-alpha cut: CMake project version 0.1.0 -> 0.7.0, installer MyAppVersion 1.1.0 -> 0.7.0 (premature-major identity fix), milestone PR count corrected to the actual 338 (#624-#775), automation claim upgraded to the merged instance-targeted reality (the cut-time gate note is removed). Version-distinction note preserved: application version vs PROJECT_VERSION_CURRENT (.aes format).

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```