### PR TITLE
ci: fix release-changelog reminder — checkout the Aestra repo for the template

### DIFF
--- a/.github/workflows/release-changelog-reminder.yml
+++ b/.github/workflows/release-changelog-reminder.yml
@@ -20,6 +20,8 @@ jobs:
     if: github.event.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the Aestra repo (workflow + issue-body template)
+        uses: actions/checkout@v4
       - name: Check out the Aestra-website draft generator
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The reminder workflow failed on the v0.7.0-alpha tag: the assemble step reads .github/release-changelog-reminder-body.md, but the workflow only checked out the Aestra-website repo. The default checkout now pulls the Aestra repo first.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```