### PR TITLE
ci: allow manual dispatch of the release-changelog reminder

### DIFF
--- a/.github/workflows/release-changelog-reminder.yml
+++ b/.github/workflows/release-changelog-reminder.yml
@@ -10,6 +10,7 @@ on:
   create:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The reminder fires on tag creation; a failed run can only be re-run manually if the workflow accepts workflow_dispatch. This lets a tag whose reminder failed (v0.7.0-alpha) be re-generated against the fixed workflow (which now checks out the Aestra repo for the template).

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```