### PR TITLE
ci: allow workflow_dispatch past the reminder's tag guard

### DIFF
--- a/.github/workflows/release-changelog-reminder.yml
+++ b/.github/workflows/release-changelog-reminder.yml
@@ -18,7 +18,9 @@ permissions:
 
 jobs:
   remind:
-    if: github.event.ref_type == 'tag'
+    # Tag creates fire the reminder; workflow_dispatch allows re-running a
+    # reminder (e.g. after a failed run) against any ref.
+    if: github.event.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the Aestra repo (workflow + issue-body template)


### PR DESCRIPTION
The reminder job skips on dispatch events (ref_type is 'branch'), so the manual re-run produced a skipped run. Accept workflow_dispatch explicitly — a dispatched run generates the draft since the last released site entry, the correct window for a mid-cycle reminder.

## Decision citation

```
Objective:
Decision:   FD-12 @ e437eef
Kind:       corrective
```