### PR TITLE
fix: mute/solo commands request a graph rebuild so unmute applies immediately

### DIFF
--- a/AestraAudio/include/Commands/SetMuteCommand.h
+++ b/AestraAudio/include/Commands/SetMuteCommand.h
@@ -3,6 +3,7 @@
 
 #include "Commands/ICommand.h"
 #include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
 
 #include <memory>
 #include <string>
@@ -12,11 +13,17 @@ namespace Audio {
 
 /**
  * @brief Command to toggle a channel's mute state
+ *
+ * Requests an audio graph rebuild on every mutation (execute/undo/redo):
+ * TrackRenderState.mute is baked into the immutable graph snapshot, so a
+ * mute change that only updates the live RT state leaves the snapshot stale
+ * until some unrelated operation forces a rebuild (TrackManager.h:1112 —
+ * "All state mutations should call this method").
  */
 class SetMuteCommand : public ICommand {
 public:
-    SetMuteCommand(MixerChannel& channel, bool newMute)
-        : m_channel(channel), m_newMute(newMute) {}
+    SetMuteCommand(TrackManager& trackManager, MixerChannel& channel, bool newMute)
+        : m_trackManager(trackManager), m_channel(channel), m_newMute(newMute) {}
 
     void execute() override {
         if (m_executed)
@@ -24,6 +31,7 @@ public:
 
         m_originalMute = m_channel.isMuted();
         m_channel.setMute(m_newMute);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -32,6 +40,7 @@ public:
             return;
 
         m_channel.setMute(m_originalMute);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = false;
     }
 
@@ -40,6 +49,7 @@ public:
             return;
 
         m_channel.setMute(m_newMute);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -48,6 +58,7 @@ public:
     bool changesProjectState() const override { return true; }
 
 private:
+    TrackManager& m_trackManager;
     MixerChannel& m_channel;
     bool m_newMute;
     bool m_originalMute = false;

--- a/AestraAudio/include/Commands/SetSoloCommand.h
+++ b/AestraAudio/include/Commands/SetSoloCommand.h
@@ -3,6 +3,7 @@
 
 #include "Commands/ICommand.h"
 #include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
 
 #include <memory>
 #include <string>
@@ -12,11 +13,16 @@ namespace Audio {
 
 /**
  * @brief Command to toggle a channel's solo state
+ *
+ * Requests an audio graph rebuild on every mutation (execute/undo/redo):
+ * TrackRenderState.solo is baked into the immutable graph snapshot and the
+ * solo eligibility arrays are derived from it, so a solo change must refresh
+ * the snapshot immediately (TrackManager.h:1112).
  */
 class SetSoloCommand : public ICommand {
 public:
-    SetSoloCommand(MixerChannel& channel, bool newSolo)
-        : m_channel(channel), m_newSolo(newSolo) {}
+    SetSoloCommand(TrackManager& trackManager, MixerChannel& channel, bool newSolo)
+        : m_trackManager(trackManager), m_channel(channel), m_newSolo(newSolo) {}
 
     void execute() override {
         if (m_executed)
@@ -24,6 +30,7 @@ public:
 
         m_originalSolo = m_channel.isSoloed();
         m_channel.setSolo(m_newSolo);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -32,6 +39,7 @@ public:
             return;
 
         m_channel.setSolo(m_originalSolo);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = false;
     }
 
@@ -40,6 +48,7 @@ public:
             return;
 
         m_channel.setSolo(m_newSolo);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -48,6 +57,7 @@ public:
     bool changesProjectState() const override { return true; }
 
 private:
+    TrackManager& m_trackManager;
     MixerChannel& m_channel;
     bool m_newSolo;
     bool m_originalSolo = false;

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1405,9 +1405,8 @@ private:
                       " clipStart=" + std::to_string(instance.startBeat) +
                       " sourceOffset=" + std::to_string(instance.sourceOffsetBeats) +
                       " schedStart=" + std::to_string(instance.patternStartBeat()) + " " + routeSummary);
-            m_patternPlaybackEngine.schedulePatternInstance(instance.patternId, instance.patternStartBeat(),
-                                                            instanceId++, instance.sourceOffsetBeats,
-                                                            instance.durationBeats);
+            m_patternPlaybackEngine.schedulePatternInstance(instance.patternId, instance.startBeat, instanceId++,
+                                                            instance.sourceOffsetBeats, instance.durationBeats);
         }
     }
 

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -240,7 +240,7 @@ void CommandRegistry::initialize() {
         if (!trackOpt.has_value() || *trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
-        return std::make_unique<SetMuteCommand>(*ch, state);
+        return std::make_unique<SetMuteCommand>(*tm, *ch, state);
     });
 
     reg.registerCommand("solo_track", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
@@ -256,7 +256,7 @@ void CommandRegistry::initialize() {
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
-        return std::make_unique<SetSoloCommand>(*ch, state);
+        return std::make_unique<SetSoloCommand>(*tm, *ch, state);
     });
 
     reg.registerCommand("set_volume", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -165,7 +165,7 @@ void UIMixerPanel::refreshChannels()
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<Aestra::Audio::SetMuteCommand>(*mixerChannel, muted));
+                std::make_shared<Aestra::Audio::SetMuteCommand>(*m_trackManager, *mixerChannel, muted));
         };
 
         // Wire solo to CommandHistory for undo/redo
@@ -175,7 +175,7 @@ void UIMixerPanel::refreshChannels()
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<Aestra::Audio::SetSoloCommand>(*mixerChannel, soloed));
+                std::make_shared<Aestra::Audio::SetSoloCommand>(*m_trackManager, *mixerChannel, soloed));
         };
 
         // Wire pan to CommandHistory for undo/redo

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -59,7 +59,7 @@ ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackMana
     m_muteButton->setOnToggle([this](bool toggled) {
         if (m_track && m_trackManager) {
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<SetMuteCommand>(*m_track, toggled));
+                std::make_shared<SetMuteCommand>(*m_trackManager, *m_track, toggled));
         }
     });
     // Initialize state
@@ -71,7 +71,7 @@ ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackMana
     m_soloButton->setOnToggle([this](bool toggled) {
         if (m_track && m_trackManager) {
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<SetSoloCommand>(*m_track, toggled));
+                std::make_shared<SetSoloCommand>(*m_trackManager, *m_track, toggled));
         }
     });
     // Initialize state

--- a/Tests/AestraAudio/MuteSoloCommandRebuildTest.cpp
+++ b/Tests/AestraAudio/MuteSoloCommandRebuildTest.cpp
@@ -1,0 +1,94 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "AudioGraphBuilder.h"
+#include "Commands/SetMuteCommand.h"
+#include "Commands/SetSoloCommand.h"
+#include "Models/TrackManager.h"
+
+#include <iostream>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+const TrackRenderState* findTrack(const AudioGraph& graph, uint32_t channelId) {
+    for (const auto& track : graph.tracks) {
+        if (track.trackId == channelId) {
+            return &track;
+        }
+    }
+    return nullptr;
+}
+
+bool drainAndCheck(TrackManager& trackManager, uint32_t channelId, bool expectMuted, bool expectSoloed,
+                   const char* step) {
+    // PlaybackGraphController::drainIfDirty() consumes the pending flag and
+    // rebuilds the published graph from current channel state.
+    if (!trackManager.consumePendingGraphRebuild()) {
+        std::cerr << "FAIL[" << step << "]: no pending graph rebuild after the command\n";
+        return false;
+    }
+    auto graph = AudioGraphBuilder::buildFromTrackManager(trackManager);
+    const TrackRenderState* track = findTrack(graph, channelId);
+    if (!track || track->mute != expectMuted || track->solo != expectSoloed) {
+        std::cerr << "FAIL[" << step << "]: published snapshot mismatch (mute=" << (track ? track->mute : false)
+                  << " solo=" << (track ? track->solo : false) << ")\n";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    TrackManager trackManager;
+    MixerChannel* channel = trackManager.addChannel("Mute Rebuild Test");
+    if (!channel) {
+        std::cerr << "failed to add channel\n";
+        return 1;
+    }
+    const uint32_t channelId = channel->getChannelId();
+    if (channelId == 0) {
+        std::cerr << "expected a non-master channel id\n";
+        return 1;
+    }
+
+    auto& history = trackManager.getCommandHistory();
+
+    // Regression for #782: the mute command must request a graph rebuild, or
+    // the published snapshot keeps the old mute state until an unrelated
+    // operation forces a rebuild — unmute stays inaudible.
+    history.pushAndExecute(std::make_shared<SetMuteCommand>(trackManager, *channel, true));
+    if (!drainAndCheck(trackManager, channelId, true, false, "mute")) {
+        return 1;
+    }
+
+    history.pushAndExecute(std::make_shared<SetMuteCommand>(trackManager, *channel, false));
+    if (!drainAndCheck(trackManager, channelId, false, false, "unmute")) {
+        return 1;
+    }
+
+    // Undo of the unmute must request another rebuild and restore the muted
+    // published snapshot.
+    history.undo();
+    if (!drainAndCheck(trackManager, channelId, true, false, "undo-unmute")) {
+        return 1;
+    }
+    history.redo();
+    if (!drainAndCheck(trackManager, channelId, false, false, "redo-unmute")) {
+        return 1;
+    }
+
+    // Solo: same contract — the published snapshot must follow immediately.
+    history.pushAndExecute(std::make_shared<SetSoloCommand>(trackManager, *channel, true));
+    if (!drainAndCheck(trackManager, channelId, false, true, "solo")) {
+        return 1;
+    }
+    history.pushAndExecute(std::make_shared<SetSoloCommand>(trackManager, *channel, false));
+    if (!drainAndCheck(trackManager, channelId, false, false, "unsolo")) {
+        return 1;
+    }
+
+    std::cout << "mute/solo command rebuild passed\n";
+    return 0;
+}

--- a/Tests/AestraAudio/PatternSliceSchedulingTest.cpp
+++ b/Tests/AestraAudio/PatternSliceSchedulingTest.cpp
@@ -1,0 +1,154 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Models/PatternManager.h"
+#include "Models/PlaylistModel.h"
+#include "Models/TrackManager.h"
+#include "Models/UnitManager.h"
+#include "Playback/PatternPlaybackEngine.h"
+#include "Playback/TimelineClock.h"
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+struct ObservedNoteOn {
+    uint64_t frame;
+    uint8_t pitch;
+};
+
+std::vector<ObservedNoteOn> collectAllNoteOns(PatternPlaybackEngine& playback, int sampleRate, double beats,
+                                              UnitID unitId) {
+    PatternPlaybackEngine::UnitMidiRoute route{unitId, nullptr};
+    std::vector<ObservedNoteOn> hits;
+    constexpr uint32_t kBlock = 128;
+    const uint64_t totalFrames = static_cast<uint64_t>(beats * (sampleRate * 60.0 / 120.0));
+    uint64_t frame = 0;
+    while (frame < totalFrames) {
+        MidiBuffer buffer;
+        route.midiBuffer = &buffer;
+        playback.processAudio(frame, kBlock, &route, 1);
+        for (size_t i = 0; i < buffer.getEventCount(); ++i) {
+            const auto& event = buffer.getEvent(i);
+            if ((event.data[0] & 0xF0) == 0x90 && event.data[1] > 0 && event.data[2] > 0) {
+                hits.push_back({frame, event.data[1]});
+            }
+        }
+        frame += kBlock;
+    }
+    return hits;
+}
+
+bool hasNoteNear(const std::vector<ObservedNoteOn>& hits, uint8_t pitch, uint64_t nearFrame, uint64_t tolerance) {
+    for (const auto& hit : hits) {
+        if (hit.pitch != pitch) {
+            continue;
+        }
+        const uint64_t delta = hit.frame > nearFrame ? hit.frame - nearFrame : nearFrame - hit.frame;
+        if (delta <= tolerance) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool hasNoteInsideWindow(const std::vector<ObservedNoteOn>& hits, uint8_t pitch, uint64_t centerFrame,
+                         uint64_t tolerance) {
+    for (const auto& hit : hits) {
+        if (hit.pitch != pitch) {
+            continue;
+        }
+        const uint64_t delta = hit.frame > centerFrame ? hit.frame - centerFrame : centerFrame - hit.frame;
+        if (delta <= tolerance) {
+            std::cerr << "pitch " << static_cast<int>(pitch) << " note-on at frame " << hit.frame
+                      << " — inside rejected window around " << centerFrame << "\n";
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    constexpr int sampleRate = 48000;
+    constexpr double kBeatFrames = 24000.0; // 120 BPM
+    constexpr uint8_t pitchInFirstRegion = 60;
+    constexpr uint8_t pitchInSecondRegion = 62;
+
+    TimelineClock clock(120.0);
+    TrackManager trackManager;
+    auto& unitManager = trackManager.getUnitManager();
+    const UnitID unitId = unitManager.createUnit("Slice Unit", UnitType::Sampler);
+    if (unitId == 0) {
+        std::cerr << "failed to create unit\n";
+        return 1;
+    }
+
+    auto& patternManager = trackManager.getPatternManager();
+    PatternID patternId = patternManager.createPattern();
+    auto* pattern = patternManager.getPattern(patternId);
+    if (!pattern) {
+        std::cerr << "failed to create pattern\n";
+        return 1;
+    }
+    pattern->type = PatternSource::Type::Midi;
+    pattern->name = "Slice Pattern";
+    pattern->lengthBeats = 4.0;
+    pattern->payload = MidiPayload{};
+    auto& notes = std::get<MidiPayload>(pattern->payload).notes;
+    notes.push_back(MidiNote{pitchInFirstRegion, 0.5, 0.5, 1.0f, 0.0f, unitId});
+    notes.push_back(MidiNote{pitchInSecondRegion, 2.5, 0.5, 1.0f, 0.0f, unitId});
+
+    auto& playlist = trackManager.getPlaylistModel();
+    PlaylistLaneID laneId = playlist.createLane("Slice Lane");
+    ClipInstance clip;
+    clip.patternId = patternId;
+    clip.sourceId = patternId.value;
+    clip.startBeat = 0.0;
+    clip.durationBeats = 4.0;
+    clip.sourceOffset = 0.0;
+    ClipInstanceID clipId = playlist.addClip(laneId, clip);
+    if (!clipId.isValid()) {
+        std::cerr << "failed to add pattern clip\n";
+        return 1;
+    }
+
+    // Split at beat 2: the second half must start at timeline beat 2 and play
+    // the pattern region [2, 4) — not restart the original pattern region.
+    ClipInstanceID secondId = playlist.splitClip(clipId, 2.0);
+    if (!secondId.isValid()) {
+        std::cerr << "failed to split pattern clip\n";
+        return 1;
+    }
+
+    auto& playback = trackManager.getPatternPlaybackEngine();
+    playback.clearScheduledInstances();
+    trackManager.play();
+    playback.refillWindow(0, sampleRate, static_cast<uint64_t>(8.0 * kBeatFrames));
+
+    const uint64_t tolerance = 128;
+    const auto hits = collectAllNoteOns(playback, sampleRate, 8.0, unitId);
+    // First half: note at pattern beat 0.5 fires at timeline beat 0.5.
+    if (!hasNoteNear(hits, pitchInFirstRegion, static_cast<uint64_t>(0.5 * kBeatFrames), tolerance)) {
+        std::cerr << "FAIL: first half note not placed at beat 0.5\n";
+        return 1;
+    }
+    // Second half: note at pattern beat 2.5 must fire at timeline beat
+    // 2 + 2.5 = 4.5 (correct), never at 2.5 (bug: second slice was anchored at
+    // the original clip start instead of the split point).
+    if (!hasNoteNear(hits, pitchInSecondRegion, static_cast<uint64_t>(4.5 * kBeatFrames), tolerance)) {
+        std::cerr << "FAIL: second half note not placed at beat 4.5\n";
+        return 1;
+    }
+    if (hasNoteInsideWindow(hits, pitchInSecondRegion, static_cast<uint64_t>(2.5 * kBeatFrames), tolerance)) {
+        std::cerr << "FAIL: second half note fired at the unsliced pattern position (beat 2.5)\n";
+        return 1;
+    }
+
+    std::cout << "pattern slice scheduling passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -772,6 +772,20 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternSliceSchedulingTest.cp
     set_tests_properties(PatternSliceSchedulingTest PROPERTIES LABELS "audio;pattern;regression;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/MuteSoloCommandRebuildTest.cpp")
+    add_executable(MuteSoloCommandRebuildTest AestraAudio/MuteSoloCommandRebuildTest.cpp)
+    target_link_libraries(MuteSoloCommandRebuildTest PRIVATE AestraAudio)
+    target_include_directories(MuteSoloCommandRebuildTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME MuteSoloCommandRebuildTest COMMAND MuteSoloCommandRebuildTest)
+    set_tests_properties(MuteSoloCommandRebuildTest PROPERTIES LABELS "audio;mixer;regression;contract:audio")
+endif()
+
 # Sinc Interpolator Benchmark
 add_executable(AestraSincBenchmark AestraAudio/SincBenchmark.cpp)
 target_link_libraries(AestraSincBenchmark PRIVATE AestraAudioCore)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -758,6 +758,20 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternPlaybackTempoChangeTes
     set_tests_properties(PatternPlaybackTempoChangeTest PROPERTIES LABELS "audio;transport;pattern;regression;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternSliceSchedulingTest.cpp")
+    add_executable(PatternSliceSchedulingTest AestraAudio/PatternSliceSchedulingTest.cpp)
+    target_link_libraries(PatternSliceSchedulingTest PRIVATE AestraAudio)
+    target_include_directories(PatternSliceSchedulingTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternSliceSchedulingTest COMMAND PatternSliceSchedulingTest)
+    set_tests_properties(PatternSliceSchedulingTest PROPERTIES LABELS "audio;pattern;regression;contract:audio")
+endif()
+
 # Sinc Interpolator Benchmark
 add_executable(AestraSincBenchmark AestraAudio/SincBenchmark.cpp)
 target_link_libraries(AestraSincBenchmark PRIVATE AestraAudioCore)

--- a/Tests/Commands/MixerCommandsTest.cpp
+++ b/Tests/Commands/MixerCommandsTest.cpp
@@ -8,6 +8,7 @@
 #include "Commands/SetSoloCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
 
 #include <cassert>
 #include <iostream>
@@ -182,18 +183,24 @@ void testSetMuteCommand() {
     std::cout << "TEST: SetMuteCommand... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setMute(false);
 
-    SetMuteCommand cmd(channel, true);
+    SetMuteCommand cmd(trackManager, channel, true);
     cmd.execute();
 
     assert(channel.isMuted() == true);
     assert(cmd.getName() == "Mute");
+    // A mute mutation must request a graph rebuild: TrackRenderState.mute is
+    // baked into the immutable snapshot, so the live RT command alone leaves
+    // the audible gate (track.mute || state.mute) stale (#782).
+    assert(trackManager.hasPendingGraphRebuild() == true);
 
     cmd.undo();
     assert(channel.isMuted() == false);
+    assert(trackManager.hasPendingGraphRebuild() == true);
 
-    SetMuteCommand unmuteCmd(channel, false);
+    SetMuteCommand unmuteCmd(trackManager, channel, false);
     unmuteCmd.execute();
     assert(unmuteCmd.getName() == "Unmute");
 
@@ -204,9 +211,10 @@ void testSetMuteDoubleExecuteNoOp() {
     std::cout << "TEST: SetMuteCommand double execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setMute(false);
 
-    SetMuteCommand cmd(channel, true);
+    SetMuteCommand cmd(trackManager, channel, true);
     cmd.execute();
     assert(channel.isMuted() == true);
 
@@ -223,9 +231,10 @@ void testSetMuteUndoBeforeExecuteNoOp() {
     std::cout << "TEST: SetMuteCommand undo before execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setMute(true);
 
-    SetMuteCommand cmd(channel, false);
+    SetMuteCommand cmd(trackManager, channel, false);
     cmd.undo(); // Before execute - no-op
 
     assert(channel.isMuted() == true); // Still muted
@@ -237,9 +246,10 @@ void testSetMuteRedoCycle() {
     std::cout << "TEST: SetMuteCommand redo cycle... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setMute(false);
 
-    SetMuteCommand cmd(channel, true);
+    SetMuteCommand cmd(trackManager, channel, true);
     cmd.execute();
     assert(channel.isMuted() == true);
 
@@ -260,9 +270,10 @@ void testSetSoloCommand() {
     std::cout << "TEST: SetSoloCommand... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setSolo(false);
 
-    SetSoloCommand cmd(channel, true);
+    SetSoloCommand cmd(trackManager, channel, true);
     cmd.execute();
 
     assert(channel.isSoloed() == true);
@@ -271,7 +282,7 @@ void testSetSoloCommand() {
     cmd.undo();
     assert(channel.isSoloed() == false);
 
-    SetSoloCommand unsoloCmd(channel, false);
+    SetSoloCommand unsoloCmd(trackManager, channel, false);
     unsoloCmd.execute();
     assert(unsoloCmd.getName() == "Unsolo");
 
@@ -282,9 +293,10 @@ void testSetSoloDoubleExecuteNoOp() {
     std::cout << "TEST: SetSoloCommand double execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setSolo(false);
 
-    SetSoloCommand cmd(channel, true);
+    SetSoloCommand cmd(trackManager, channel, true);
     cmd.execute();
     assert(channel.isSoloed() == true);
 
@@ -301,9 +313,10 @@ void testSetSoloUndoBeforeExecuteNoOp() {
     std::cout << "TEST: SetSoloCommand undo before execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setSolo(true);
 
-    SetSoloCommand cmd(channel, false);
+    SetSoloCommand cmd(trackManager, channel, false);
     cmd.undo(); // Before execute - no-op
 
     assert(channel.isSoloed() == true); // Still soloed
@@ -315,9 +328,10 @@ void testSetSoloRedoCycle() {
     std::cout << "TEST: SetSoloCommand redo cycle... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setSolo(false);
 
-    SetSoloCommand cmd(channel, true);
+    SetSoloCommand cmd(trackManager, channel, true);
     cmd.execute();
     assert(channel.isSoloed() == true);
 
@@ -338,6 +352,7 @@ void testMixerCommandsWithHistory() {
     std::cout << "TEST: Mixer commands with CommandHistory integration... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setVolume(0.5f);
     channel.setPan(0.0f);
     channel.setMute(false);
@@ -348,8 +363,8 @@ void testMixerCommandsWithHistory() {
     // Push all four command types
     history.pushAndExecute(std::make_shared<SetVolumeCommand>(channel, 0.8f));
     history.pushAndExecute(std::make_shared<SetPanCommand>(channel, -0.3f));
-    history.pushAndExecute(std::make_shared<SetMuteCommand>(channel, true));
-    history.pushAndExecute(std::make_shared<SetSoloCommand>(channel, true));
+    history.pushAndExecute(std::make_shared<SetMuteCommand>(trackManager, channel, true));
+    history.pushAndExecute(std::make_shared<SetSoloCommand>(trackManager, channel, true));
 
     assert(approxEqual(channel.getVolume(), 0.8f));
     assert(approxEqual(channel.getPan(), -0.3f));

--- a/Tests/Commands/MixerCommandsTest.cpp
+++ b/Tests/Commands/MixerCommandsTest.cpp
@@ -193,12 +193,13 @@ void testSetMuteCommand() {
     assert(cmd.getName() == "Mute");
     // A mute mutation must request a graph rebuild: TrackRenderState.mute is
     // baked into the immutable snapshot, so the live RT command alone leaves
-    // the audible gate (track.mute || state.mute) stale (#782).
-    assert(trackManager.hasPendingGraphRebuild() == true);
+    // the audible gate (track.mute || state.mute) stale (#782). Consume
+    // between operations so each lifecycle path is proven independently.
+    assert(trackManager.consumePendingGraphRebuild() == true);
 
     cmd.undo();
     assert(channel.isMuted() == false);
-    assert(trackManager.hasPendingGraphRebuild() == true);
+    assert(trackManager.consumePendingGraphRebuild() == true);
 
     SetMuteCommand unmuteCmd(trackManager, channel, false);
     unmuteCmd.execute();


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Fixes #782: unmuting a channel did not become audible until an unrelated operation (e.g. slicing) forced a graph rebuild. Mute did work — because the graph snapshot happened to be rebuilt by the drag that placed the clip — so the bug only showed on the way back.

Root cause: the audible gate is `track.mute || state.mute` (AudioEngine). `SetMuteCommand`/`SetSoloCommand` updated the live RT state (`state.mute` via the command queue) but never requested a graph rebuild, so the snapshot half (`track.mute`, baked at AudioGraphBuilder build time) stayed stale. This violates the documented rule at TrackManager.h:1112 — "All state mutations should call requestAudioGraphRebuild" — and mirrors the D5 command-seam lesson: mutations must notify through the command layer.

Fix: both commands now hold `TrackManager&` and request `requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged)` on execute/undo/redo, matching the `EffectCommands.h` precedent. Call sites updated: UIMixerPanel, MixerView, CommandRegistry (mute_track/solo_track verbs).

## Why

A stale mute state means the producer hears silence the mixer says is unmuted — a trust-killing divergence on the record path's sibling (the solo/mute gate family already pinned for master clips in #771). Correctness, not polish.

## Testing Performed

- New `MuteSoloCommandRebuildTest` (contract:audio): full command → pending-rebuild → controller drain → published-snapshot lifecycle for mute, unmute, undo, redo, solo, unsolo.
  - RED on buggy code: `FAIL[unmute]: no pending graph rebuild after the command`.
  - GREEN on fix: full lifecycle passes.
- `MixerCommandsTest` updated for the new ctor + asserts `hasPendingGraphRebuild` after execute and undo.
- Full ctest 254/254 pass (1 skipped by design); full app + all test targets build clean (`-j2`).

## Authority / invariant

What became the single source of truth? Every mute/solo mutation requests a graph rebuild through the command seam; the published snapshot can no longer diverge from channel state.

What now prevents that truth from drifting again? The rebuild contract is asserted in two tests (command-level `hasPendingGraphRebuild` + published-snapshot lifecycle); the command ctor makes the manager mandatory, so a future call site cannot silently skip the rebuild.

## Producer note

Unmuting a channel now takes effect immediately instead of staying silent until another edit refreshes the mix.

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- Header-only commands gain a `TrackManager&` param — all construction sites updated (4 found via grep, incl. the Muse `mute_track`/`solo_track` registry).
- Rebuild requests are a coalescing flag — mute storms (e.g. undo of a bulk mute) are safe by design.
- Master channel (id 0) untouched: `MixerChannel::setMute` already skips the RT command for master; the rebuild makes the snapshot follow it consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** `SetMuteCommand` and `SetSoloCommand` now require a `TrackManager&`.
- Mute and solo commands now request an audio graph rebuild during execute, undo, and redo. Unmute and unsolo changes now reach playback and visualization immediately.
- Timeline MIDI slices now schedule at each clip’s absolute `startBeat`.
- Updated command construction sites and tests for the new command API.
- Added regression tests for mute/solo rebuilds and pattern-slice scheduling. All 254 tests passed, with one intentional skip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->