### PR TITLE
fix: pattern split prunes + rebases the second half — no more ghost units

### DIFF
--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -63,6 +63,52 @@ struct MidiClipPlaybackInstance {
 };
 
 /**
+ * @brief Prune a MIDI pattern to a temporal region, making it a truthful
+ *        self-contained pattern (#786).
+ *
+ * Drops notes fully outside [regionStart, regionStart + regionBeats),
+ * re-anchors straddling notes at the region start, clamps tails to the region
+ * end, and rebases the result to local origin (the pattern's lengthBeats
+ * becomes the region length). Without this, a split's second half carried the
+ * whole original pattern and only the engine's playback filter kept it honest
+ * — the editor showed notes/units that could never sound.
+ *
+ * @return true when the pattern was pruned (valid MIDI pattern).
+ */
+inline bool prunePatternToRegion(PatternManager* patternManager, PatternID patternId, double regionStart,
+                                 double regionBeats) {
+    if (!patternManager) {
+        return false;
+    }
+    auto* pattern = patternManager->getPattern(patternId);
+    if (!pattern || !pattern->isMidi() || regionBeats <= 0.0) {
+        return false;
+    }
+    const double regionEnd = regionStart + regionBeats;
+    auto& notes = pattern->getMidiNotes();
+    std::vector<MidiNote> kept;
+    kept.reserve(notes.size());
+    for (auto& note : notes) {
+        const double noteEnd = note.startBeat + note.durationBeats;
+        if (noteEnd <= regionStart || note.startBeat >= regionEnd) {
+            continue;
+        }
+        if (note.startBeat < regionStart) {
+            note.startBeat = regionStart;
+            note.durationBeats = noteEnd - regionStart;
+        }
+        if (note.startBeat + note.durationBeats > regionEnd) {
+            note.durationBeats = regionEnd - note.startBeat;
+        }
+        note.startBeat -= regionStart;
+        kept.push_back(note);
+    }
+    notes = std::move(kept);
+    pattern->lengthBeats = regionBeats;
+    return true;
+}
+
+/**
  * @brief Multi-lane playlist model with undo/redo support
  *
  * This is the canonical data model for the playlist (arrangement view).
@@ -396,12 +442,25 @@ public:
         ClipInstance newClip;
         newClip.id = ClipInstanceID::generate();
         newClip.name = clip->name;
+        newClip.startBeat = splitBeat;
+        newClip.durationBeats = clip->endBeat() - splitBeat;
         // Clone the pattern so split halves are independent (not instanced)
         // Per design philosophy: "Everything is independent by default"
+        bool rebased = false;
         if (m_patternManager) {
             PatternID clonedId = m_patternManager->clonePattern(clip->patternId);
             if (clonedId.isValid()) {
                 newClip.patternId = clonedId;
+                // Prune + rebase the clone to its region so the second half is
+                // a truthful, self-contained pattern (#786): notes fully
+                // outside the region are dropped (no ghost units), straddling
+                // notes re-anchor at the cut and are clamped to the region
+                // end, and the pattern starts at its own origin. Without this
+                // the clone carries the whole original pattern and only the
+                // engine's region filter keeps playback honest — the editor
+                // shows content the scheduler can never play.
+                rebased = prunePatternToRegion(m_patternManager, clonedId, splitBeat - clip->startBeat,
+                                               newClip.durationBeats);
             } else {
                 newClip.patternId = clip->patternId; // fallback: share if clone fails
             }
@@ -409,10 +468,10 @@ public:
             newClip.patternId = clip->patternId;
         }
         newClip.colorRGBA = clip->colorRGBA;
-        newClip.startBeat = splitBeat;
-        newClip.durationBeats = clip->endBeat() - splitBeat;
         newClip.sourceId = clip->sourceId;
-        newClip.sourceOffset = clip->sourceOffset + (splitBeat - clip->startBeat);
+        // A rebased pattern starts at its own origin; the shared-pattern
+        // fallback keeps the region-shifted offset (engine filter semantics).
+        newClip.sourceOffset = rebased ? 0.0 : (clip->sourceOffset + (splitBeat - clip->startBeat));
         newClip.sourceOffsetSeconds = clip->sourceOffsetSeconds;
         newClip.edits = clip->edits;
         newClip.edits.fadeInBeats = 0.0f; // Clear fades at split point

--- a/Tests/AestraAudio/PatternSplitRegionPruneTest.cpp
+++ b/Tests/AestraAudio/PatternSplitRegionPruneTest.cpp
@@ -1,0 +1,138 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+
+#include "Models/PatternManager.h"
+#include "Models/PlaylistModel.h"
+#include "Models/TrackManager.h"
+#include "Models/UnitManager.h"
+
+#include <cmath>
+#include <iostream>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+const MidiNote* findNote(const std::vector<MidiNote>& notes, double startBeat) {
+    for (const auto& note : notes) {
+        if (std::abs(note.startBeat - startBeat) < 0.001) {
+            return &note;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+int main() {
+    TrackManager trackManager;
+    auto& unitManager = trackManager.getUnitManager();
+    const UnitID unitKick = unitManager.createUnit("Kick", UnitType::Sampler);
+    const UnitID unitHat = unitManager.createUnit("Hat", UnitType::Sampler);
+    const UnitID unitBass = unitManager.createUnit("Bass", UnitType::Sampler);
+    if (unitKick == 0 || unitHat == 0 || unitBass == 0) {
+        std::cerr << "failed to create units\n";
+        return 1;
+    }
+
+    auto& patternManager = trackManager.getPatternManager();
+    PatternID patternId = patternManager.createPattern();
+    auto* pattern = patternManager.getPattern(patternId);
+    if (!pattern) {
+        std::cerr << "failed to create pattern\n";
+        return 1;
+    }
+    pattern->type = PatternSource::Type::Midi;
+    pattern->name = "Main Pattern";
+    pattern->lengthBeats = 4.0;
+    pattern->payload = MidiPayload{};
+    auto& notes = pattern->getMidiNotes();
+    notes.push_back(MidiNote{36, 0.0, 0.5, 1.0f, 0.0f, unitKick});   // kick in region 1
+    notes.push_back(MidiNote{42, 0.5, 0.25, 1.0f, 0.0f, unitHat});   // hat in region 1
+    notes.push_back(MidiNote{36, 1.0, 0.5, 1.0f, 0.0f, unitKick});   // kick in region 1
+    notes.push_back(MidiNote{42, 1.5, 0.25, 1.0f, 0.0f, unitHat});   // hat in region 1
+    notes.push_back(MidiNote{45, 1.75, 0.5, 1.0f, 0.0f, unitBass});  // bass straddles the cut at 2.0
+    notes.push_back(MidiNote{36, 3.5, 0.5, 1.0f, 0.0f, unitKick});   // kick in region 2
+
+    auto& playlist = trackManager.getPlaylistModel();
+    PlaylistLaneID laneId = playlist.createLane("Slice Lane");
+    ClipInstance clip;
+    clip.patternId = patternId;
+    clip.sourceId = patternId.value;
+    clip.startBeat = 0.0;
+    clip.durationBeats = 4.0;
+    clip.sourceOffset = 0.0;
+    ClipInstanceID clipId = playlist.addClip(laneId, clip);
+
+    ClipInstanceID secondId = playlist.splitClip(clipId, 2.0);
+    if (!secondId.isValid()) {
+        std::cerr << "FAIL: splitClip returned an invalid id\n";
+        return 1;
+    }
+
+    // First half keeps the original pattern, untouched.
+    ClipInstance* first = playlist.getClip(clipId);
+    if (!first || first->patternId != patternId || first->sourceOffset != 0.0 || first->durationBeats != 2.0) {
+        std::cerr << "FAIL: first half mismatch\n";
+        return 1;
+    }
+    if (notes.size() != 6) {
+        std::cerr << "FAIL: original pattern was mutated by the split (note count " << notes.size() << ")\n";
+        return 1;
+    }
+
+    // Second half: rebased, region-only clone.
+    ClipInstance* second = playlist.getClip(secondId);
+    if (!second) {
+        std::cerr << "FAIL: cannot read second clip\n";
+        return 1;
+    }
+    if (second->patternId == patternId) {
+        std::cerr << "FAIL: second half still references the original pattern\n";
+        return 1;
+    }
+    if (second->sourceOffset != 0.0) {
+        std::cerr << "FAIL: second half sourceOffset=" << second->sourceOffset << " (expected 0 after rebase)\n";
+        return 1;
+    }
+    if (second->durationBeats != 2.0) {
+        std::cerr << "FAIL: second half durationBeats=" << second->durationBeats << " (expected 2.0)\n";
+        return 1;
+    }
+    // The scheduler anchors the instance at patternStartBeat() (= startBeat -
+    // sourceOffset); a rebased second half must satisfy startBeat - sourceOffset
+    // == startBeat, i.e. the scheduler anchor equals the clip's timeline start.
+    if (std::abs(second->startBeat - second->sourceOffset - second->startBeat) > 0.001) {
+        std::cerr << "FAIL: startBeat - sourceOffset=" << (second->startBeat - second->sourceOffset)
+                  << " != startBeat=" << second->startBeat << " (scheduler anchor invariant)\n";
+        return 1;
+    }
+
+    auto* cloned = patternManager.getPattern(second->patternId);
+    if (!cloned || !cloned->isMidi()) {
+        std::cerr << "FAIL: second half pattern is not a valid MIDI pattern\n";
+        return 1;
+    }
+    if (std::abs(cloned->lengthBeats - 2.0) > 0.001) {
+        std::cerr << "FAIL: cloned pattern lengthBeats=" << cloned->lengthBeats << " (expected 2.0)\n";
+        return 1;
+    }
+    const auto& clonedNotes = cloned->getMidiNotes();
+    if (clonedNotes.size() != 2) {
+        std::cerr << "FAIL: cloned pattern has " << clonedNotes.size()
+                  << " notes (expected 2 — ghost units must be pruned)\n";
+        return 1;
+    }
+    const MidiNote* bass = findNote(clonedNotes, 0.0);
+    if (!bass || std::abs(bass->durationBeats - 0.25) > 0.001) {
+        std::cerr << "FAIL: straddling bass note not re-anchored at the cut (start 0.0, tail 0.25)\n";
+        return 1;
+    }
+    const MidiNote* tail = findNote(clonedNotes, 1.5);
+    if (!tail || std::abs(tail->durationBeats - 0.5) > 0.001) {
+        std::cerr << "FAIL: region-2 kick note not rebased to local origin (1.5)\n";
+        return 1;
+    }
+
+    std::cout << "pattern split region prune passed\n";
+    return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2386,3 +2386,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternInstanceSlotReuseTest.
     set_tests_properties(PatternInstanceSlotReuseTest PROPERTIES LABELS "audio;pattern;scheduler;regression;contract:audio")
     message(STATUS "PatternInstanceSlotReuseTest added - pattern scheduler slot reuse + clearing")
 endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternSplitRegionPruneTest.cpp")
+    add_executable(PatternSplitRegionPruneTest AestraAudio/PatternSplitRegionPruneTest.cpp)
+    target_link_libraries(PatternSplitRegionPruneTest PRIVATE AestraAudio)
+    target_include_directories(PatternSplitRegionPruneTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternSplitRegionPruneTest COMMAND PatternSplitRegionPruneTest)
+    set_tests_properties(PatternSplitRegionPruneTest PROPERTIES LABELS "audio;pattern;regression;contract:audio")
+endif()


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Fixes #786: splitting a pattern clip left the second half with a full clone of the original pattern — every unit's notes, full length — while playback applied a region filter. Result: ghost units (present in the editor, never sounding) and partial units (notes straddling the cut fired before the second clip's timeline start). The editor showed content the scheduler could never play.

Fix: `splitClip` now prunes + rebases the cloned pattern to its region:
- notes fully outside the region are dropped (ghost units' notes vanish),
- straddling notes re-anchor at the cut (the hit sounds AT the split) and clamp to the region end,
- the pattern rebases to local origin with `lengthBeats` = region length,
- the second clip's `sourceOffset` becomes 0 (rebase), so the scheduler anchor invariant `patternStartBeat() == startBeat` holds by construction.

The engine's region filter remains as defensive behavior for trim-slipped clips; it is no longer responsible for making an internally misleading model sound right. Audio-pattern second halves are untouched (they already advance in the source domain via the #746 varispeed path).

## Why

"Editor shows X, scheduler plays Y" is the worst bug class for N5. The model must be truthful: an empty unit row is UI state (deliberate quiet design), but empty musical content inside a pattern is model truth.

## Testing Performed

- New `PatternSplitRegionPruneTest` (contract:audio): 6-note/3-unit pattern, split at beat 2; asserts first half untouched, second half pruned (2 notes: re-anchored bass tail at 0.0 dur 0.25 + region-2 kick at 1.5), length 2.0, `sourceOffset` 0, scheduler anchor invariant.
  - RED on old code: `FAIL: second half sourceOffset=2 (expected 0 after rebase)` + ghost state.
  - GREEN on fix.
- Narrow family: PlaylistSplitVarispeedTest (audio-pattern varispeed split), ClipCommandsTest, ProjectDirtyStateTest, RealtimeExportParityTest, ProjectRoundTrip(Integrity), AutomationPlaybackTest — 8/8 pass.
- Full suite + app build pending in CI.

## Authority / invariant

What became the single source of truth? The pattern model itself — a clip's pattern contains exactly the notes that can sound in that clip's region; the engine filter is defensive, not load-bearing.

What now prevents that truth from drifting again? `splitClip` prunes by construction, and `PatternSplitRegionPruneTest` pins the contract (prune, re-anchor, clamp, rebase, offset-zero, anchor invariant) so any future split-path change that reintroduces ghost content fails RED.

## Producer note

Sliced patterns no longer show ghost notes in the second half — each half contains exactly what plays there.

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- MIDI patterns only; audio-pattern and plain-clip paths byte-identical (verified by PlaylistSplitVarispeedTest + parity tests).
- Clone-failure fallback (shared pattern) keeps the previous region-shift semantics — unchanged behavior.
- Re-anchored straddling notes lose their pre-cut attack by design (the hit sounds at the cut — the audio-slice semantic); pitched-sampler slide steps whose predecessor was pruned sustain from the re-anchored onset (same class as manual trim).
- Explicitly out of scope (parked for v0.8.0, founder decision): "split by unit" extraction — separate feature, own design.
