### PR TITLE
test: fix stale slice expectation after the split-prune rebase

### DIFF
--- a/Tests/AestraAudio/PatternSliceSchedulingTest.cpp
+++ b/Tests/AestraAudio/PatternSliceSchedulingTest.cpp
@@ -137,15 +137,18 @@ int main() {
         std::cerr << "FAIL: first half note not placed at beat 0.5\n";
         return 1;
     }
-    // Second half: note at pattern beat 2.5 must fire at timeline beat
-    // 2 + 2.5 = 4.5 (correct), never at 2.5 (bug: second slice was anchored at
-    // the original clip start instead of the split point).
-    if (!hasNoteNear(hits, pitchInSecondRegion, static_cast<uint64_t>(4.5 * kBeatFrames), tolerance)) {
-        std::cerr << "FAIL: second half note not placed at beat 4.5\n";
+    // Second half: after the split-prune fix (#787), the second half's pattern
+    // is a REBASED region clone (notes at local origin, sourceOffset 0), so the
+    // note originally at pattern beat 2.5 sits at local beat 0.5 and fires at
+    // timeline beat 2.0 + 0.5 = 2.5 — the musically correct slice position.
+    // The pre-prune expectation (4.5 = split + full-pattern coordinate) pinned
+    // the intermediate model and is superseded by the rebase.
+    if (!hasNoteNear(hits, pitchInSecondRegion, static_cast<uint64_t>(2.5 * kBeatFrames), tolerance)) {
+        std::cerr << "FAIL: second half note not placed at beat 2.5 (split + rebased local offset)\n";
         return 1;
     }
-    if (hasNoteInsideWindow(hits, pitchInSecondRegion, static_cast<uint64_t>(2.5 * kBeatFrames), tolerance)) {
-        std::cerr << "FAIL: second half note fired at the unsliced pattern position (beat 2.5)\n";
+    if (hasNoteInsideWindow(hits, pitchInSecondRegion, static_cast<uint64_t>(4.5 * kBeatFrames), tolerance)) {
+        std::cerr << "FAIL: second half note fired at the pre-rebase full-pattern position (beat 4.5)\n";
         return 1;
     }
 


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Updates `PatternSliceSchedulingTest`'s second-half expectation to match the split-prune model (#787).

When #784's scheduling fix was written, a split's second half carried a full-pattern clone and the region filter selected content — so a note originally at pattern beat 2.5 in the second region fired at split + 2.5 = 4.5. #787 (merged after) changed the model: the second half is now a REBASED region clone (notes at local origin, `sourceOffset` 0), so the same note sits at local beat 0.5 and correctly fires at split + 0.5 = **2.5**. The old expectation pinned the intermediate model and fails on develop (and on any branch whose base has both fixes — including #788's CI).

The test now expects 2.5 and rejects 4.5, with comments documenting the interplay.

## Why

A stale test on develop fails every PR whose base carries both fixes — the current #788 CI failure is exactly this.

## Testing Performed

- Updated expectation: RED on the stale assertion (reproduced locally on develop: `FAIL: second half note not placed at beat 4.5`), GREEN after the update (`pattern slice scheduling passed`).
- Pattern family 7/7 (incl. PatternSplitRegionPruneTest, PatternInstanceSlotReuseTest, transport position tests).

## Producer note

None

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- Test-only change; no production code touched. The audible behavior (note at 2.5) is pinned by both this test and the prune test's model assertions.
- Note for the record: the original #784/#785 branches were tangled (the T-4 branch was cut from the T-5 branch), which is why develop carried both fixes before #784's own merge. Final develop state is correct; this PR cleans up the one stale expectation the tangle exposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `PatternSliceSchedulingTest` to match the split-prune model.
- The rebased second-half region now fires at beat `2.5`; the test rejects the obsolete position `4.5`.
- Test-only change. No production code or public declarations changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->