### PR TITLE
hardening: real-time tripwires on the mixer mutation surface

### DIFF
--- a/AestraAudio/src/Core/MixerBus.cpp
+++ b/AestraAudio/src/Core/MixerBus.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "MixerBus.h"
 
+#include "RealtimeThreadGuard.h"
 #include "DSP/PanLaw.h"
 
 #include <algorithm>
@@ -204,28 +205,38 @@ void MixerBus::clear(float* buffer, uint32_t numFrames) {
 }
 
 void MixerBus::setGain(float gain) {
+    if (reportRealtimeMisuse("MixerBus::setGain")) return;
+
     // Clamp gain to reasonable range [0.0, 2.0]
     gain = std::max(0.0f, std::min(2.0f, gain));
     m_gain.store(gain, std::memory_order_release);
 }
 
 void MixerBus::setPan(float pan) {
+    if (reportRealtimeMisuse("MixerBus::setPan")) return;
+
     // Clamp pan to [-1.0, 1.0]
     pan = std::max(-1.0f, std::min(1.0f, pan));
     m_pan.store(pan, std::memory_order_release);
 }
 
 void MixerBus::setWidth(float width) {
+    if (reportRealtimeMisuse("MixerBus::setWidth")) return;
+
     // Clamp width [0.0 (mono) to 4.0 (super-wide)]
     width = std::max(0.0f, std::min(4.0f, width));
     m_width.store(width, std::memory_order_release);
 }
 
 void MixerBus::setMute(bool mute) {
+    if (reportRealtimeMisuse("MixerBus::setMute")) return;
+
     m_muted.store(mute, std::memory_order_release);
 }
 
 void MixerBus::setSolo(bool solo) {
+    if (reportRealtimeMisuse("MixerBus::setSolo")) return;
+
     m_soloed.store(solo, std::memory_order_release);
 }
 

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -1,6 +1,7 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
 #include "MixerChannel.h"
 
+#include "RealtimeThreadGuard.h"
 #include "AestraLog.h"
 
 #include <algorithm>
@@ -26,14 +27,20 @@ MixerChannel::~MixerChannel() {
 }
 
 void MixerChannel::setName(const std::string& name) {
+    if (reportRealtimeMisuse("MixerChannel::setName")) return;
+
     m_name = name;
 }
 
 void MixerChannel::setColor(uint32_t color) {
+    if (reportRealtimeMisuse("MixerChannel::setColor")) return;
+
     m_color = color;
 }
 
 void MixerChannel::setVolume(float volume) {
+    if (reportRealtimeMisuse("MixerChannel::setVolume")) return;
+
     const float previous = m_volume.exchange(volume);
     if (m_mixerBus)
         m_mixerBus->setGain(volume);
@@ -47,6 +54,8 @@ void MixerChannel::setVolume(float volume) {
 }
 
 void MixerChannel::setPan(float pan) {
+    if (reportRealtimeMisuse("MixerChannel::setPan")) return;
+
     const float previous = m_pan.exchange(pan);
     if (m_mixerBus)
         m_mixerBus->setPan(pan);
@@ -60,12 +69,16 @@ void MixerChannel::setPan(float pan) {
 }
 
 void MixerChannel::setWidth(float width) {
+    if (reportRealtimeMisuse("MixerChannel::setWidth")) return;
+
     m_width.store(width);
     if (m_mixerBus)
         m_mixerBus->setWidth(width);
 }
 
 void MixerChannel::setMute(bool mute) {
+    if (reportRealtimeMisuse("MixerChannel::setMute")) return;
+
     const bool previous = m_muted.exchange(mute);
     if (m_mixerBus)
         m_mixerBus->setMute(mute);
@@ -79,6 +92,8 @@ void MixerChannel::setMute(bool mute) {
 }
 
 void MixerChannel::setSolo(bool solo) {
+    if (reportRealtimeMisuse("MixerChannel::setSolo")) return;
+
     const bool previous = m_soloed.exchange(solo);
     if (m_mixerBus)
         m_mixerBus->setSolo(solo);
@@ -92,6 +107,8 @@ void MixerChannel::setSolo(bool solo) {
 }
 
 void MixerChannel::setSoloSafe(bool safe) {
+    if (reportRealtimeMisuse("MixerChannel::setSoloSafe")) return;
+
     m_soloSafe.store(safe);
     // Solo safe doesn't affect internal bus logic directly,
     // it's used by the AudioEngine to decide suppression.
@@ -198,6 +215,8 @@ void MixerChannel::insertSend(int index, const AudioRoute& route) {
 }
 
 void MixerChannel::setSend(uint64_t sendId, const AudioRoute& route) {
+    if (reportRealtimeMisuse("MixerChannel::setSend")) return;
+
     std::lock_guard<std::mutex> lock(m_sendMutex);
     const int index = findSendIndexLocked(sendId);
     if (index < 0) {
@@ -210,6 +229,8 @@ void MixerChannel::setSend(uint64_t sendId, const AudioRoute& route) {
 }
 
 void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
+    if (reportRealtimeMisuse("MixerChannel::replaceSends")) return;
+
     std::lock_guard<std::mutex> lock(m_sendMutex);
     m_sends.clear();
     m_sends.reserve(routes.size());
@@ -223,6 +244,8 @@ void MixerChannel::replaceSends(const std::vector<AudioRoute>& routes) {
 }
 
 void MixerChannel::removeSend(uint64_t sendId) {
+    if (reportRealtimeMisuse("MixerChannel::removeSend")) return;
+
     std::lock_guard<std::mutex> lock(m_sendMutex);
     const int index = findSendIndexLocked(sendId);
     if (index >= 0) {

--- a/AestraAudio/src/Core/MixerChannel.cpp
+++ b/AestraAudio/src/Core/MixerChannel.cpp
@@ -196,6 +196,7 @@ AudioRoute sanitizeRoute(const AudioRoute& route) {
 } // namespace
 
 void MixerChannel::addSend(const AudioRoute& route) {
+    if (reportRealtimeMisuse("MixerChannel::addSend")) return;
     std::lock_guard<std::mutex> lock(m_sendMutex);
     AudioRoute sanitized = sanitizeRoute(route);
     if (sanitized.sendId == 0) {
@@ -205,6 +206,7 @@ void MixerChannel::addSend(const AudioRoute& route) {
 }
 
 void MixerChannel::insertSend(int index, const AudioRoute& route) {
+    if (reportRealtimeMisuse("MixerChannel::insertSend")) return;
     std::lock_guard<std::mutex> lock(m_sendMutex);
     AudioRoute sanitized = sanitizeRoute(route);
     if (sanitized.sendId == 0) {

--- a/Tests/AestraAudio/RTGuardConsolidationTest.cpp
+++ b/Tests/AestraAudio/RTGuardConsolidationTest.cpp
@@ -27,12 +27,17 @@
 
 #include "RealtimeThreadGuard.h"   // canonical: ScopedRealtimeAudioThread / isRealtimeAudioThread
 #include "AudioThreadConstraints.h" // app-layer constraint macros + AudioThreadStats
+#include "Core/MixerChannel.h"
 
 #include <cstdio>
+#include <string>
 
 using namespace Aestra::Audio;
 
 static int g_failures = 0;
+static const char* g_firedApi = nullptr;
+
+static void onMisuse(const char* apiName) noexcept { g_firedApi = apiName; }
 
 #define CHECK(cond)                                                            \
     do {                                                                       \
@@ -90,6 +95,40 @@ int main() {
         CHECK(isRealtimeAudioThread()); // still RT after inner exits
     }
     CHECK(!isRealtimeAudioThread());
+
+    // ── Mixer mutation tripwires (T-2 coverage audit) ───────────────────────
+    // The mixer setter surface must refuse mutations from the audio thread:
+    // the graph snapshot is the audio thread's view, and a stray setter call
+    // from inside the callback is a real-time violation that would otherwise
+    // go unnoticed. Off the audio thread, behavior is unchanged.
+    {
+        MixerChannel channel("Tripwire Test", 1);
+        channel.setMute(false);
+
+        CHECK(!isRealtimeAudioThread());
+        channel.setMute(true); // off-thread: normal mutation
+        CHECK(channel.isMuted() == true);
+
+        const char* firedApi = nullptr;
+        g_firedApi = nullptr;
+        setRealtimeMisuseHandler(onMisuse);
+
+        channel.setMute(true); // off-thread: no report (state unchanged)
+        CHECK(g_firedApi == nullptr);
+
+        {
+            ScopedRealtimeAudioThread rtScope;
+            CHECK(isRealtimeAudioThread());
+            channel.setMute(false); // on-thread: must report + refuse
+        }
+        firedApi = g_firedApi;
+        CHECK(firedApi != nullptr && std::string(firedApi) == "MixerChannel::setMute");
+        CHECK(channel.isMuted() == true); // mutation refused on the audio thread
+
+        setRealtimeMisuseHandler(nullptr);
+        channel.setMute(false); // off-thread again: works
+        CHECK(channel.isMuted() == false);
+    }
 
     if (g_failures == 0) {
         std::puts("RTGuardConsolidationTest: PASS");

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1422,6 +1422,7 @@ set_tests_properties(RTAllocationTrapTest PROPERTIES LABELS "audio;rt-safety;int
 # Header-only: RealtimeThreadGuard.h + AudioThreadConstraints.h define everything
 # inline, so no link deps (avoids dragging in the plugin registry link chain).
 add_executable(RTGuardConsolidationTest AestraAudio/RTGuardConsolidationTest.cpp)
+target_link_libraries(RTGuardConsolidationTest PRIVATE AestraAudio)
 target_include_directories(RTGuardConsolidationTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include
     ${CMAKE_SOURCE_DIR}/AestraCore/include


### PR DESCRIPTION
Objective:  TS-1 — v0.7.1 trust sprint: UI↔engine seam correctness
Decision:   FD-13 @ 73fea7c
Kind:       planned
Reversal:   —

## Summary

T-2 of the v0.7.1 trust sprint — R1 real-time guard hardening. The audit (also in this milestone) proved the dual-guard consolidation already happened (single TLS flag, both callback layers marked, enforcement on engine/chain/playback APIs). The one real coverage gap: the **mixer mutation surface** — `MixerChannel`/`MixerBus` setters had no real-time tripwires.

This change adds `reportRealtimeMisuse` tripwires to 16 setters (`MixerChannel::setName/setColor/setVolume/setPan/setWidth/setMute/setSolo/setSoloSafe/setSend/replaceSends/removeSend`, `MixerBus::setGain/setPan/setWidth/setMute/setSolo`). On the audio thread they report through the misuse handler and REFUSE the mutation (the EffectChain pattern); off the audio thread, behavior is byte-identical.

## Why

The audio thread's view of mixer state is the graph snapshot; a stray setter call from inside the callback is exactly the class of mistake that previously went unnoticed until a session glitched. A tripwire at the mutation point makes it a hard, reported failure.

## Testing Performed

- `RTGuardConsolidationTest` extended: on the marked thread, `MixerChannel::setMute` fires the handler with the API name and refuses the mutation; off-thread, state changes normally and no report fires.
  - RED on unguarded code: handler never fires, mutation applies on the audio thread (2 failed checks).
  - GREEN with the guards.
- Full suite: **258/258 pass**, app builds clean (-j2).

## Authority / invariant

What became the single source of truth? The mutation layer refuses real-time misuse at the setter boundary — the graph snapshot is the audio thread's only write surface.

What now prevents that truth from drifting again? The tripwires are in the same API family as the EffectChain guards and are pinned by the extended RTGuardConsolidationTest; the audit record (R1 resolution) names the coverage.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed (audit record lives in Aestra-Internals: Architectural Risks R1/R2 resolved)

## Risk / Rollback Notes

- Off-thread behavior unchanged (guards return false off the audio thread; verified by the existing RTGuardConsolidationTest suite + full ctest).
- No audio-thread caller of these setters exists today (grep-verified: the audio thread reads channel atomics and the graph snapshot only) — the tripwires are purely preventive.
- B-007 allocation-macro wiring and a custom clang-tidy compile-time rule remain accepted follow-ups (recorded in the audit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added real-time misuse checks to 16 `MixerChannel` and `MixerBus` mutation setters. Audio-thread calls now report misuse and refuse the mutation.
- Preserved existing off-thread behavior and state updates.
- Extended `RTGuardConsolidationTest` to verify reporting, mutation refusal, and normal off-thread operation. Linked the test with `AestraAudio`.
- The full test suite passes 258/258, and the application builds successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->