### PR TITLE
fix: rack binds by channel identity — no cached chain pointer (#790 round 2)

### DIFF
--- a/AestraUI/Widgets/PluginUIController.cpp
+++ b/AestraUI/Widgets/PluginUIController.cpp
@@ -15,6 +15,9 @@
 #include "AestraLFOEditor.h"
 #include "AestraOTTEditor.h"
 
+#include "Models/TrackManager.h"
+#include "Core/MixerChannel.h"
+
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
 #endif
@@ -128,37 +131,59 @@ void PluginUIController::startScan() {
     );
 }
 
+Aestra::Audio::EffectChain* PluginUIController::resolveBoundChain(EffectChainRack* rack) {
+    for (const auto& binding : m_rackBindings) {
+        if (binding.rack == rack) {
+            Aestra::Audio::MixerChannel* channel = (binding.channelId == 0)
+                                                       ? binding.trackManager->getMasterChannel()
+                                                       : binding.trackManager->getChannelById(binding.channelId);
+            return channel ? &channel->getEffectChain() : nullptr;
+        }
+    }
+    return nullptr;
+}
+
 void PluginUIController::bindEffectRack(EffectChainRack* rack, 
-                                         Aestra::Audio::EffectChain* chain) {
-    if (!rack || !chain) return;
+                                         Aestra::Audio::TrackManager* trackManager,
+                                         uint32_t channelId) {
+    if (!rack || !trackManager) return;
     
     // One binding per rack: a re-bind (e.g. the inspector following a new
-    // selection) REPLACES the previous binding instead of appending. Stale
-    // bindings used to accumulate, and refreshRackDisplay() read the FIRST
-    // match — so the rack kept showing (and later dereferencing) a chain
-    // that had been destroyed with its channel. SEGV in getPlugin() on a
-    // normal frame update, three crashes in one day.
+    // selection) REPLACES the previous binding instead of appending. The
+    // binding holds the channel's STABLE IDENTITY, not a chain pointer: the
+    // chain is resolved fresh at refresh/callback time, so a channel deleted
+    // (or a project reloaded) mid-session can never leave the rack pointing
+    // at freed memory. Three SEGVs on 2026-08-16 plus two more after the
+    // pointer-based fix (22:04, 22:19) — getPlugin() from refreshRackDisplay
+    // on a normal frame update.
     m_rackBindings.erase(
         std::remove_if(m_rackBindings.begin(), m_rackBindings.end(),
                        [rack](const RackBinding& b) { return b.rack == rack; }),
         m_rackBindings.end());
-    m_rackBindings.push_back({rack, chain});
+    m_rackBindings.push_back({rack, trackManager, channelId});
     
     // Wire slot clicks
-    rack->setOnSlotClicked([this, chain](int slot) {
+    rack->setOnSlotClicked([this, rack](int slot) {
+        auto* chain = resolveBoundChain(rack);
+        if (!chain) return;
         auto instance = chain->getPlugin(slot);
         if (instance && (instance->hasEditor() || instance->getParameterCount() > 0)) {
             openPluginEditor(instance, nullptr);
         }
     });
     
-    rack->setOnAddPluginRequested([this, rack, chain](int slot) {
+    rack->setOnAddPluginRequested([this, rack](int slot) {
         // Remove existing menu if any
         if (m_activeMenu) {
             if (auto parent = m_activeMenu->getParent()) {
                 parent->removeChild(m_activeMenu);
             }
             m_activeMenu.reset();
+        }
+        auto* chain = resolveBoundChain(rack);
+        if (!chain) {
+            m_activeMenu.reset();
+            return;
         }
 
         // Create new dropdown
@@ -194,8 +219,11 @@ void PluginUIController::bindEffectRack(EffectChainRack* rack,
         m_activeMenu->showAt(triggerRect, flipBoundary);
 
         // Handle selection
-        m_activeMenu->onPluginSelected = [this, chain, slot](const std::string& pluginId, const std::string&) {
-            loadPluginToSlot(pluginId, chain, slot);
+        m_activeMenu->onPluginSelected = [this, rack, slot](const std::string& pluginId, const std::string&) {
+            auto* chain = resolveBoundChain(rack);
+            if (chain) {
+                loadPluginToSlot(pluginId, chain, slot);
+            }
 
             // Close menu
             if (m_activeMenu) {
@@ -217,7 +245,9 @@ void PluginUIController::bindEffectRack(EffectChainRack* rack,
         };
     });
     
-    rack->setOnSlotBypassToggled([this, chain](int slot, bool bypassed) {
+    rack->setOnSlotBypassToggled([this, rack](int slot, bool bypassed) {
+        auto* chain = resolveBoundChain(rack);
+        if (!chain) return;
         chain->setSlotBypassed(slot, bypassed);
         if (!bypassed) {
             if (auto plugin = chain->getPlugin(static_cast<size_t>(slot))) {
@@ -260,16 +290,26 @@ void PluginUIController::unbindEffectRack(EffectChainRack* rack) {
 void PluginUIController::refreshRackDisplay(EffectChainRack* rack) {
     if (!rack) return;
     
-    // Find chain binding
-    Aestra::Audio::EffectChain* chain = nullptr;
-    for (const auto& binding : m_rackBindings) {
-        if (binding.rack == rack) {
-            chain = binding.chain;
-            break;
-        }
-    }
+    // Resolve the LIVE chain for this rack. A channel deleted since the last
+    // selection change (or a project reload that replaced channels) resolves
+    // to nullptr here — the rack shows empty instead of dereferencing freed
+    // memory. This is the crash the pointer-based binding caused: getPlugin()
+    // on a chain that died with its channel, five SEGVs on 2026-08-16.
+    Aestra::Audio::EffectChain* chain = resolveBoundChain(rack);
     
-    if (!chain) return;
+    if (!chain) {
+        // No live channel: clear the rack so it can never display (or touch)
+        // a chain that no longer exists.
+        for (int i = 0; i < EffectChainRack::MAX_SLOTS; ++i) {
+            EffectChainRack::EffectSlotInfo info;
+            info.name = "Empty";
+            info.isEmpty = true;
+            info.bypassed = false;
+            info.nonFiniteOutputFault = false;
+            rack->setSlot(i, info);
+        }
+        return;
+    }
     
     // Update slot display
     for (int i = 0; i < EffectChainRack::MAX_SLOTS; ++i) {
@@ -322,7 +362,7 @@ bool PluginUIController::loadPluginToSlot(const std::string& pluginId,
     
     // Refresh any bound rack
     for (const auto& binding : m_rackBindings) {
-        if (binding.chain == chain) {
+        if (resolveBoundChain(binding.rack) == chain) {
             refreshRackDisplay(binding.rack);
         }
     }

--- a/AestraUI/Widgets/PluginUIController.h
+++ b/AestraUI/Widgets/PluginUIController.h
@@ -19,12 +19,19 @@ class NUIPlatformBridge;
 #include <memory>
 #include "Events/Connection.h"
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #ifdef AESTRAUI_ENABLE_PREMIUM_EDITORS
 #include "RumblePluginEditor.h"
 #endif
+
+namespace Aestra {
+namespace Audio {
+class TrackManager;
+}
+} // namespace Aestra
 
 namespace AestraUI {
 class UIMixerPluginDropdown;
@@ -110,11 +117,14 @@ public:
     // ==============================
     
     /**
-     * @brief Bind an EffectChainRack to an audio EffectChain
+     * @brief Bind an EffectChainRack to a mixer channel's effect chain
      * @param rack Rack widget to populate.
-     * @param chain Audio effect chain mirrored by the rack.
+     * @param trackManager Track manager owning the channel (id 0 = master).
+     * @param channelId Stable mixer channel identity — the chain is resolved
+     *        fresh at refresh/callback time so a deleted channel can never
+     *        leave the rack pointing at freed memory.
      */
-    void bindEffectRack(EffectChainRack* rack, Aestra::Audio::EffectChain* chain);
+    void bindEffectRack(EffectChainRack* rack, Aestra::Audio::TrackManager* trackManager, uint32_t channelId);
     
     /**
      * @brief Unbind effect rack
@@ -223,12 +233,21 @@ private:
     // Bound widgets
     PluginBrowserPanel* m_browser = nullptr;
     
-    // Rack bindings (rack -> chain)
+    // Rack bindings (rack -> stable channel identity). The chain is resolved
+    // fresh at use time (resolveBoundChain), never cached: a channel can die
+    // with its chain at any moment, and a raw chain pointer in the binding is
+    // what made refreshRackDisplay crash in getPlugin() — three SEGVs on
+    // 2026-08-16, two more after the first fix (22:04, 22:19).
     struct RackBinding {
         EffectChainRack* rack;
-        Aestra::Audio::EffectChain* chain;
+        Aestra::Audio::TrackManager* trackManager;
+        uint32_t channelId;
     };
     std::vector<RackBinding> m_rackBindings;
+
+    /** Resolve the live chain for a bound rack, or nullptr when the channel
+     * (or its chain) no longer exists. Channel id 0 = master channel. */
+    Aestra::Audio::EffectChain* resolveBoundChain(EffectChainRack* rack);
     
     // effectChainChanged is a scoped subscription signal for effect-chain mutations.
     std::function<void(int)> m_onScanComplete;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1377,15 +1377,16 @@ void AestraContent::onUpdate(double dt) {
                 // but let's be safe and assume we need to manage it)
 
                 if (selectedCh) {
-                    auto* channel = selectedCh->channel;
-                    if (channel) {
-                        auto mixerUI = m_mixerPanel->getMixerUI();
-                        if (mixerUI) {
-                            auto inspector = mixerUI->getInspector();
-                            if (inspector && inspector->getEffectRack()) {
-                                m_pluginController->bindEffectRack(inspector->getEffectRack().get(),
-                                                                   &channel->getEffectChain());
-                            }
+                    auto mixerUI = m_mixerPanel->getMixerUI();
+                    if (mixerUI) {
+                        auto inspector = mixerUI->getInspector();
+                        if (inspector && inspector->getEffectRack()) {
+                            // Bind by STABLE channel identity: the controller
+                            // resolves the chain fresh at refresh time, so a
+                            // deleted channel can never leave the rack pointing
+                            // at freed memory (#790).
+                            m_pluginController->bindEffectRack(inspector->getEffectRack().get(),
+                                                               m_trackManager.get(), selectedCh->id);
                         }
                     }
                 } else {

--- a/Tests/AestraUI/PluginRackBindingLifecycleTest.cpp
+++ b/Tests/AestraUI/PluginRackBindingLifecycleTest.cpp
@@ -1,19 +1,21 @@
 // © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
-// PluginRackBindingLifecycleTest — the inspector rack must follow the
-// LAST-bound chain and never hold a binding to a chain that died with its
-// channel (three SEGVs in one day: EffectChain::getPlugin from
-// refreshRackDisplay on a normal frame update).
+// PluginRackBindingLifecycleTest — the inspector rack must resolve its chain
+// FRESH from the channel's stable identity, never from a cached pointer.
 //
-// Root cause: bindEffectRack() APPENDED bindings, and refreshRackDisplay()
-// read the FIRST match — so after switching selection A -> B, the rack kept
-// displaying (and later dereferencing) chain A. When channel A was deleted,
-// chain A's memory was freed and the next fingerprint-triggered refresh
-// crashed. The fix: one binding per rack — a re-bind replaces the previous.
+// The pointer-based binding crashed five times in one day (2026-08-16,
+// 12:58/16:10/19:28 + 22:04/22:19): refreshRackDisplay() dereferenced an
+// EffectChain that died with its channel — first because re-binds appended
+// stale bindings, then (after the replace fix) because the frame's
+// fingerprint refresh can fire before the selection sync re-binds, and the
+// VM's channel pointer itself can go stale. The binding now stores the
+// channel ID and resolves the chain at refresh/callback time; a deleted
+// channel resolves to null and the rack clears to Empty.
 
 #include "PluginBrowserPanel.h"
 #include "PluginUIController.h"
 #include "Plugin/EffectChain.h"
 #include "Plugin/PluginHost.h"
+#include "Models/TrackManager.h"
 
 #include <iostream>
 #include <memory>
@@ -98,35 +100,56 @@ std::string slotName(EffectChainRack& rack, int slot) {
 
 int main() {
     auto rack = std::make_shared<EffectChainRack>();
-    EffectChain chainA;
-    EffectChain chainB;
-    chainA.insertPlugin(0, makePlugin("Alpha"));
-    chainB.insertPlugin(0, makePlugin("Beta"));
+    TrackManager trackManager;
+    MixerChannel* channelA = trackManager.addChannel("Alpha Channel");
+    MixerChannel* channelB = trackManager.addChannel("Beta Channel");
+    if (!channelA || !channelB) {
+        std::cerr << "failed to add channels\n";
+        return 1;
+    }
+    channelA->getEffectChain().insertPlugin(0, makePlugin("Alpha"));
+    channelB->getEffectChain().insertPlugin(0, makePlugin("Beta"));
+    const uint32_t idA = channelA->getChannelId();
+    const uint32_t idB = channelB->getChannelId();
 
     PluginUIController controller;
 
-    // Initial bind: the rack shows chain A's content.
-    controller.bindEffectRack(rack.get(), &chainA);
+    // Initial bind by stable id: the rack shows channel A's content.
+    controller.bindEffectRack(rack.get(), &trackManager, idA);
     controller.refreshRackDisplay(rack.get());
     expect(slotName(*rack, 0) == "Alpha", "first bind shows chain A");
 
-    // Selection switch A -> B: the rack must now show chain B. Regression:
-    // the old code appended the binding and read the FIRST match, so the rack
-    // kept showing (and dereferencing) chain A — which later crashed when
-    // channel A was deleted.
-    controller.bindEffectRack(rack.get(), &chainB);
+    // Selection switch A -> B: re-bind replaces; rack now shows B.
+    controller.bindEffectRack(rack.get(), &trackManager, idB);
     controller.refreshRackDisplay(rack.get());
-    expect(slotName(*rack, 0) == "Beta", "re-bind replaces the previous binding (rack shows chain B)");
+    expect(slotName(*rack, 0) == "Beta", "re-bind replaces the previous binding");
 
-    // Cycling back to A must work too — the replace invariant holds both ways.
-    controller.bindEffectRack(rack.get(), &chainA);
+    // Cycling back to A works.
+    controller.bindEffectRack(rack.get(), &trackManager, idA);
     controller.refreshRackDisplay(rack.get());
     expect(slotName(*rack, 0) == "Alpha", "cycling back to chain A shows A");
 
-    // Unbind clears the binding; a fresh bind afterwards works (the app uses
-    // this when the mixer selection is cleared).
+    // THE REGRESSION: channel A dies (deleted mid-session). The rack's next
+    // refresh must resolve null and clear to Empty — never dereference the
+    // freed chain. The pointer-based binding crashed here (5 SEGVs, #790).
+    trackManager.removeChannelById(idA);
+    controller.refreshRackDisplay(rack.get());
+    expect(slotName(*rack, 0) == "Empty", "deleted channel clears the rack (no stale chain)");
+
+    // Re-bind to the surviving channel still works after the deletion.
+    controller.bindEffectRack(rack.get(), &trackManager, idB);
+    controller.refreshRackDisplay(rack.get());
+    expect(slotName(*rack, 0) == "Beta", "bind after deletion shows chain B");
+
+    // Master (id 0) resolves through getMasterChannel.
+    trackManager.getMasterChannel()->getEffectChain().insertPlugin(0, makePlugin("Master"));
+    controller.bindEffectRack(rack.get(), &trackManager, 0);
+    controller.refreshRackDisplay(rack.get());
+    expect(slotName(*rack, 0) == "Master", "master channel binds and resolves");
+
+    // Unbind clears the binding; a fresh bind afterwards works.
     controller.unbindEffectRack(rack.get());
-    controller.bindEffectRack(rack.get(), &chainB);
+    controller.bindEffectRack(rack.get(), &trackManager, idB);
     controller.refreshRackDisplay(rack.get());
     expect(slotName(*rack, 0) == "Beta", "bind after unbind shows chain B");
 


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Fixes #790 (reopened): the rack crash **persisted after the first fix** — two more SEGVs on the replace-on-bind binary (22:04, 22:19), identical stack (`EffectChain::getPlugin` ← `refreshRackDisplay` ← `onUpdate`).

Why the first fix was incomplete: the binding still held a **raw chain pointer**. A channel deletion can reach a fingerprint-triggered `refreshRackDisplay` BEFORE the same frame's selection-sync re-binds (fingerprint block runs first in `onUpdate`), and the VM's `channel` pointer itself can go stale after engine-side channel replacement — so a dead chain was reachable regardless of binding hygiene.

Fix: the binding now stores the channel's **stable identity** — `{rack, TrackManager*, channelId}` — and the chain is resolved fresh at every refresh/callback (`resolveBoundChain`). A deleted channel resolves to null; the rack clears to Empty instead of dereferencing freed memory. The chain pointer is never cached anywhere in the controller. Master (id 0) resolves via `getMasterChannel()`. All rack callbacks (click, add, bypass) resolve through the same path.

## Why

Five crashes in one day, all on routine frames, all from the same stale-pointer family. The editor must never dereference a chain that died with its channel — resolution-by-identity makes that structurally impossible.

## Testing Performed

- `PluginRackBindingLifecycleTest` reworked to the id-based API, 8 checks:
  - bind/replace/cycle between channels (replace semantics preserved)
  - **the regression: `removeChannelById` on the bound channel → refresh → rack clears to Empty (no stale content, no crash)**
  - re-bind after deletion works; master (id 0) resolves; unbind + re-bind works
- Real-world RED: the two new coredumps (22:04, 22:19) on the previous fix are the failure evidence.
- Narrow UI family 4/4; full suite + app build pending in CI.

## Authority / invariant

What became the single source of truth? The chain is reachable only through a live channel resolved by stable id at use time — never through a cached pointer.

What now prevents that truth from drifting again? The binding type cannot hold a chain pointer (it holds an id + manager); the deletion regression is pinned by the test; the resolver is the single path every refresh and callback goes through.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- The rack now shows Empty for a moment after the bound channel is deleted until the selection sync re-binds — the same frame's selection block re-binds immediately when a new channel is selected; when nothing is selected it stays Empty (correct).
- `loadPluginToSlot`/`removePluginFromSlot` still take a resolved chain — callers resolve first (verified: the only caller is the add-plugin callback, now resolving fresh).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Breaking change:** `bindEffectRack` now accepts a `TrackManager*` and stable channel ID instead of a raw `EffectChain*`.
- Rack bindings resolve the live effect chain during refresh and callbacks. This prevents stale-pointer crashes after channel deletion or engine-side chain replacement.
- Missing channels clear the rack and display the Empty state. Master channel ID `0` resolves through `getMasterChannel()`.
- Click, add, bypass, refresh, and post-load paths now use the same safe resolution logic.
- Updated the lifecycle test with eight checks for replacement, cycling, deletion, rebinding, master resolution, and unbinding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->