### PR TITLE
fix: volume/pan commands request a graph rebuild so the fader actually works

### DIFF
--- a/AestraAudio/include/Commands/SetPanCommand.h
+++ b/AestraAudio/include/Commands/SetPanCommand.h
@@ -3,6 +3,7 @@
 
 #include "Commands/ICommand.h"
 #include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
 
 #include <memory>
 #include <string>
@@ -12,11 +13,16 @@ namespace Audio {
 
 /**
  * @brief Command to change a channel's pan position
+ *
+ * Requests an audio graph rebuild on every mutation (execute/undo/redo):
+ * the strip pan reads TrackRenderState.pan, baked into the immutable graph
+ * snapshot at build time — a pan change without a rebuild leaves the snapshot
+ * stale (the T-4 mute-bug class).
  */
 class SetPanCommand : public ICommand {
 public:
-    SetPanCommand(MixerChannel& channel, float newPan)
-        : m_channel(channel), m_newPan(newPan) {}
+    SetPanCommand(TrackManager& trackManager, MixerChannel& channel, float newPan)
+        : m_trackManager(trackManager), m_channel(channel), m_newPan(newPan) {}
 
     void execute() override {
         if (m_executed)
@@ -24,6 +30,7 @@ public:
 
         m_originalPan = m_channel.getPan();
         m_channel.setPan(m_newPan);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -32,6 +39,7 @@ public:
             return;
 
         m_channel.setPan(m_originalPan);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = false;
     }
 
@@ -40,6 +48,7 @@ public:
             return;
 
         m_channel.setPan(m_newPan);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -48,6 +57,7 @@ public:
     bool changesProjectState() const override { return true; }
 
 private:
+    TrackManager& m_trackManager;
     MixerChannel& m_channel;
     float m_newPan;
     float m_originalPan = 0.0f;

--- a/AestraAudio/include/Commands/SetVolumeCommand.h
+++ b/AestraAudio/include/Commands/SetVolumeCommand.h
@@ -3,7 +3,7 @@
 
 #include "Commands/ICommand.h"
 #include "Core/MixerChannel.h"
-#include "AestraLog.h"
+#include "Models/TrackManager.h"
 
 #include <memory>
 #include <string>
@@ -13,11 +13,17 @@ namespace Audio {
 
 /**
  * @brief Command to change a channel's volume
+ *
+ * Requests an audio graph rebuild on every mutation (execute/undo/redo):
+ * the strip gain reads TrackRenderState.volume, which is baked into the
+ * immutable graph snapshot at build time — a volume change that only updates
+ * the channel atomic leaves the snapshot stale and the fader cosmetic until
+ * an unrelated operation rebuilds the graph (the T-4 mute-bug class).
  */
 class SetVolumeCommand : public ICommand {
 public:
-    SetVolumeCommand(MixerChannel& channel, float newVolume)
-        : m_channel(channel), m_newVolume(newVolume) {}
+    SetVolumeCommand(TrackManager& trackManager, MixerChannel& channel, float newVolume)
+        : m_trackManager(trackManager), m_channel(channel), m_newVolume(newVolume) {}
 
     void execute() override {
         if (m_executed)
@@ -25,6 +31,7 @@ public:
 
         m_originalVolume = m_channel.getVolume();
         m_channel.setVolume(m_newVolume);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
         Log::info("[SetVolume] execute: " + std::to_string(m_originalVolume) + " -> " + std::to_string(m_newVolume));
     }
@@ -34,6 +41,7 @@ public:
             return;
 
         m_channel.setVolume(m_originalVolume);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = false;
         Log::info("[SetVolume] undo: " + std::to_string(m_newVolume) + " -> " + std::to_string(m_originalVolume));
     }
@@ -43,6 +51,7 @@ public:
             return;
 
         m_channel.setVolume(m_newVolume);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
         m_executed = true;
     }
 
@@ -51,6 +60,7 @@ public:
     bool changesProjectState() const override { return true; }
 
 private:
+    TrackManager& m_trackManager;
     MixerChannel& m_channel;
     float m_newVolume;
     float m_originalVolume = 0.0f;

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -273,7 +273,7 @@ void CommandRegistry::initialize() {
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
-        return std::make_unique<SetVolumeCommand>(*ch, *valueOpt);
+        return std::make_unique<SetVolumeCommand>(*tm, *ch, *valueOpt);
     });
 
     reg.registerCommand("set_pan", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
@@ -290,7 +290,7 @@ void CommandRegistry::initialize() {
         if (*trackOpt < 0) return nullptr;
         MixerChannel* ch = tm->getChannel(static_cast<size_t>(*trackOpt));
         if (!ch) return CommandRegistry::fail("no such track: " + std::string(*trackRaw));
-        return std::make_unique<SetPanCommand>(*ch, *valueOpt);
+        return std::make_unique<SetPanCommand>(*tm, *ch, *valueOpt);
     });
 
     // ===== Clip (5) =====

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -153,7 +153,7 @@ void UIMixerPanel::refreshChannels()
 
             if (std::abs(newGain - oldGain) > 0.0001f) {
                 m_trackManager->getCommandHistory().pushAndExecute(
-                    std::make_shared<Aestra::Audio::SetVolumeCommand>(*mixerChannel, newGain));
+                    std::make_shared<Aestra::Audio::SetVolumeCommand>(*m_trackManager, *mixerChannel, newGain));
                 Aestra::Log::info("[UIMixerPanel] Fader cmd: " + std::to_string(newDb) + " dB");
             }
         };
@@ -185,7 +185,7 @@ void UIMixerPanel::refreshChannels()
             if (!mixerChannel) return;
 
             m_trackManager->getCommandHistory().pushAndExecute(
-                std::make_shared<Aestra::Audio::SetPanCommand>(*mixerChannel, pan));
+                std::make_shared<Aestra::Audio::SetPanCommand>(*m_trackManager, *mixerChannel, pan));
         };
 
         m_strips.push_back(strip);

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -32,7 +32,7 @@ ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackMana
             // Don't set volume manually — let the command do it
             if (std::abs(newVol - oldVol) > 0.0001f) {
                 m_trackManager->getCommandHistory().pushAndExecute(
-                    std::make_shared<SetVolumeCommand>(*m_track, newVol));
+                    std::make_shared<SetVolumeCommand>(*m_trackManager, *m_track, newVol));
                 Aestra::Log::info("[MixerView] Vol cmd: " + std::to_string(oldVol) + " -> " + std::to_string(newVol));
             }
         }
@@ -48,7 +48,7 @@ ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackMana
             float oldPan = m_track->getPan();
             if (std::abs(newPan - oldPan) > 0.0001f) {
                 m_trackManager->getCommandHistory().pushAndExecute(
-                    std::make_shared<SetPanCommand>(*m_track, newPan));
+                    std::make_shared<SetPanCommand>(*m_trackManager, *m_track, newPan));
             }
         }
     });

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -335,7 +335,7 @@ double TrackUIComponent::snapBeatToGrid(double beat) const {
 void TrackUIComponent::onVolumeChanged(float volume) {
     if (m_channel && m_trackManager) {
         m_trackManager->getCommandHistory().pushAndExecute(
-            std::make_shared<SetVolumeCommand>(*m_channel, volume));
+            std::make_shared<SetVolumeCommand>(*m_trackManager, *m_channel, volume));
         Log::info("Lane " + m_laneId.toString() + " volume: " + std::to_string(volume));
     }
 }
@@ -343,7 +343,7 @@ void TrackUIComponent::onVolumeChanged(float volume) {
 void TrackUIComponent::onPanChanged(float pan) {
     if (m_channel && m_trackManager) {
         m_trackManager->getCommandHistory().pushAndExecute(
-            std::make_shared<SetPanCommand>(*m_channel, pan));
+            std::make_shared<SetPanCommand>(*m_trackManager, *m_channel, pan));
         Log::info("Lane " + m_laneId.toString() + " pan: " + std::to_string(pan));
     }
 }
@@ -1978,7 +1978,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                     m_volumeKnobValue = newValue;
                     if (m_channel && m_trackManager) {
                         m_trackManager->getCommandHistory().pushAndExecute(
-                            std::make_shared<Aestra::Audio::SetVolumeCommand>(*m_channel, newValue));
+                            std::make_shared<Aestra::Audio::SetVolumeCommand>(*m_trackManager, *m_channel, newValue));
                     }
                     // Show tooltip at knob position
                     int pct = static_cast<int>(std::round(newValue * 100.0f));

--- a/Tests/AestraAudio/MuteSoloCommandRebuildTest.cpp
+++ b/Tests/AestraAudio/MuteSoloCommandRebuildTest.cpp
@@ -2,7 +2,9 @@
 
 #include "AudioGraphBuilder.h"
 #include "Commands/SetMuteCommand.h"
+#include "Commands/SetPanCommand.h"
 #include "Commands/SetSoloCommand.h"
+#include "Commands/SetVolumeCommand.h"
 #include "Models/TrackManager.h"
 
 #include <iostream>
@@ -89,6 +91,49 @@ int main() {
         return 1;
     }
 
-    std::cout << "mute/solo command rebuild passed\n";
+    // Volume: the strip gain reads the SNAPSHOT (track.volume), so a volume
+    // command without a rebuild leaves the fader cosmetic until an unrelated
+    // edit rebuilds the graph. Regression for the cosmetic-fader report.
+    history.pushAndExecute(std::make_shared<SetVolumeCommand>(trackManager, *channel, 0.25f));
+    if (!drainAndCheck(trackManager, channelId, false, false, "volume")) {
+        return 1;
+    }
+    {
+        auto graph = AudioGraphBuilder::buildFromTrackManager(trackManager);
+        const TrackRenderState* track = findTrack(graph, channelId);
+        if (!track || std::abs(track->volume - 0.25f) > 0.0001f) {
+            std::cerr << "FAIL[volume]: snapshot volume does not reflect the command ("
+                      << (track ? track->volume : -1.0f) << ")\n";
+            return 1;
+        }
+    }
+    history.undo();
+    if (!drainAndCheck(trackManager, channelId, false, false, "undo-volume")) {
+        return 1;
+    }
+    {
+        auto graph = AudioGraphBuilder::buildFromTrackManager(trackManager);
+        const TrackRenderState* track = findTrack(graph, channelId);
+        if (!track || std::abs(track->volume - 1.0f) > 0.0001f) {
+            std::cerr << "FAIL[undo-volume]: snapshot volume not restored\n";
+            return 1;
+        }
+    }
+
+    // Pan: same contract.
+    history.pushAndExecute(std::make_shared<SetPanCommand>(trackManager, *channel, 0.5f));
+    if (!drainAndCheck(trackManager, channelId, false, false, "pan")) {
+        return 1;
+    }
+    {
+        auto graph = AudioGraphBuilder::buildFromTrackManager(trackManager);
+        const TrackRenderState* track = findTrack(graph, channelId);
+        if (!track || std::abs(track->pan - 0.5f) > 0.0001f) {
+            std::cerr << "FAIL[pan]: snapshot pan does not reflect the command\n";
+            return 1;
+        }
+    }
+
+    std::cout << "mute/solo/volume/pan command rebuild passed\n";
     return 0;
 }

--- a/Tests/Commands/DeleteTrackUndoTest.cpp
+++ b/Tests/Commands/DeleteTrackUndoTest.cpp
@@ -89,8 +89,8 @@ int main() {
 
     // Give the doomed track state that only lives in the object, so a
     // re-created replacement would be detectably different.
-    history.pushAndExecute(std::make_shared<SetVolumeCommand>(*victim, 0.25f));
-    history.pushAndExecute(std::make_shared<SetPanCommand>(*victim, -0.5f));
+    history.pushAndExecute(std::make_shared<SetVolumeCommand>(manager, *victim, 0.25f));
+    history.pushAndExecute(std::make_shared<SetPanCommand>(manager, *victim, -0.5f));
     check(almostEqual(victim->getVolume(), 0.25f), "fixture: volume applied");
     check(almostEqual(victim->getPan(), -0.5f), "fixture: pan applied");
 
@@ -193,7 +193,7 @@ int main() {
         check(channel != nullptr, "add created a channel");
         const uint32_t addedId = channel->getChannelId();
 
-        addHistory.pushAndExecute(std::make_shared<SetVolumeCommand>(*channel, 0.4f));
+        addHistory.pushAndExecute(std::make_shared<SetVolumeCommand>(added, *channel, 0.4f));
         check(almostEqual(channel->getVolume(), 0.4f), "volume applied to the added channel");
 
         check(addHistory.undo(), "undo of the volume change");

--- a/Tests/Commands/MixerCommandsTest.cpp
+++ b/Tests/Commands/MixerCommandsTest.cpp
@@ -28,9 +28,10 @@ void testSetVolumeCommand() {
     std::cout << "TEST: SetVolumeCommand... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setVolume(0.5f);
 
-    SetVolumeCommand cmd(channel, 0.8f);
+    SetVolumeCommand cmd(trackManager, channel, 0.8f);
     cmd.execute();
 
     assert(approxEqual(channel.getVolume(), 0.8f));
@@ -49,9 +50,10 @@ void testSetVolumeDoubleExecuteNoOp() {
     std::cout << "TEST: SetVolumeCommand double execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setVolume(0.3f);
 
-    SetVolumeCommand cmd(channel, 0.9f);
+    SetVolumeCommand cmd(trackManager, channel, 0.9f);
     cmd.execute();
     assert(approxEqual(channel.getVolume(), 0.9f));
 
@@ -70,9 +72,10 @@ void testSetVolumeUndoBeforeExecuteNoOp() {
     std::cout << "TEST: SetVolumeCommand undo before execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setVolume(0.5f);
 
-    SetVolumeCommand cmd(channel, 0.8f);
+    SetVolumeCommand cmd(trackManager, channel, 0.8f);
     // Undo before execute should be no-op
     cmd.undo();
 
@@ -86,7 +89,8 @@ void testSetVolumeCommandMetadata() {
     std::cout << "TEST: SetVolumeCommand metadata... ";
 
     MixerChannel channel("Test Channel", 0);
-    SetVolumeCommand cmd(channel, 0.7f);
+    TrackManager trackManager;
+    SetVolumeCommand cmd(trackManager, channel, 0.7f);
 
     assert(cmd.changesProjectState() == true);
     assert(cmd.getSizeInBytes() > 0);
@@ -102,9 +106,10 @@ void testSetPanCommand() {
     std::cout << "TEST: SetPanCommand... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setPan(0.0f);  // Center
 
-    SetPanCommand cmd(channel, -0.5f);  // Pan left
+    SetPanCommand cmd(trackManager, channel, -0.5f);  // Pan left
     cmd.execute();
 
     assert(approxEqual(channel.getPan(), -0.5f));
@@ -123,17 +128,18 @@ void testSetPanBoundaryValues() {
     std::cout << "TEST: SetPanCommand boundary values... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
 
     // Full left
     channel.setPan(0.0f);
-    SetPanCommand leftCmd(channel, -1.0f);
+    SetPanCommand leftCmd(trackManager, channel, -1.0f);
     leftCmd.execute();
     assert(approxEqual(channel.getPan(), -1.0f));
     leftCmd.undo();
     assert(approxEqual(channel.getPan(), 0.0f));
 
     // Full right
-    SetPanCommand rightCmd(channel, 1.0f);
+    SetPanCommand rightCmd(trackManager, channel, 1.0f);
     rightCmd.execute();
     assert(approxEqual(channel.getPan(), 1.0f));
     rightCmd.undo();
@@ -146,9 +152,10 @@ void testSetPanDoubleExecuteNoOp() {
     std::cout << "TEST: SetPanCommand double execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setPan(0.0f);
 
-    SetPanCommand cmd(channel, 0.75f);
+    SetPanCommand cmd(trackManager, channel, 0.75f);
     cmd.execute();
     assert(approxEqual(channel.getPan(), 0.75f));
 
@@ -165,9 +172,10 @@ void testSetPanUndoBeforeExecuteNoOp() {
     std::cout << "TEST: SetPanCommand undo before execute no-op... ";
 
     MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
     channel.setPan(0.3f);
 
-    SetPanCommand cmd(channel, -0.8f);
+    SetPanCommand cmd(trackManager, channel, -0.8f);
     cmd.undo(); // Before execute - no-op
 
     assert(approxEqual(channel.getPan(), 0.3f));
@@ -362,8 +370,8 @@ void testMixerCommandsWithHistory() {
     CommandHistory history;
 
     // Push all four command types
-    history.pushAndExecute(std::make_shared<SetVolumeCommand>(channel, 0.8f));
-    history.pushAndExecute(std::make_shared<SetPanCommand>(channel, -0.3f));
+    history.pushAndExecute(std::make_shared<SetVolumeCommand>(trackManager, channel, 0.8f));
+    history.pushAndExecute(std::make_shared<SetPanCommand>(trackManager, channel, -0.3f));
     history.pushAndExecute(std::make_shared<SetMuteCommand>(trackManager, channel, true));
     history.pushAndExecute(std::make_shared<SetSoloCommand>(trackManager, channel, true));
 


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Fixes #795 — the channel fader was cosmetic: "when i route to a channel the volume slider doesn't even work."

Root cause: the strip gain reads `track.volume`/`track.pan` from the IMMUTABLE graph snapshot (AudioEngine.cpp:2957-2958). `SetVolumeCommand`/`SetPanCommand` updated the channel atomic and queued the RT command — but never requested a graph rebuild, and `mixAndMeterTrack` OVERWRITES the RT smoother targets with snapshot-derived values every block (AudioEngine.cpp:2643-2652). The fader position changed; the audible gain never moved until an unrelated edit rebuilt the graph. Same class as #782 (mute/solo): the 08-14 gain-staging fix made the strip snapshot-only, and the missing refresh was invisible until a workflow without incidental rebuilds (route → move fader → listen) exposed it.

Fix: both commands gain `TrackManager&` and request `requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged)` on execute/undo/redo — the T-4 pattern. All construction sites updated (UIMixerPanel, MixerView, TrackUIComponent, CommandRegistry, tests).

## Why

A mixer whose fader doesn't mix is a trust-killing core-loop bug for N5.

## Testing Performed

- `MuteSoloCommandRebuildTest` extended with volume/pan lifecycle cases: command → pending rebuild → drain → snapshot reflects the new value; undo restores.
  - RED on the unpatched commands: `FAIL[volume]: no pending graph rebuild after the command`.
  - GREEN on fix.
- `MixerCommandsTest` + `DeleteTrackUndoTest` updated for the new ctor; all pass.
- Full suite + app build pending in CI.

## Authority / invariant

What became the single source of truth? Every mixer strip mutation (volume, pan, mute, solo) requests a graph rebuild through the command seam; the snapshot cannot diverge from channel state.

What now prevents that truth from drifting again? The rebuild contract is asserted in `MuteSoloCommandRebuildTest` for all four command families; the command ctors make the manager mandatory.

## Producer note

Channel faders and pans now actually change the sound — no more moving a slider and hearing nothing.

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- Same risk profile as the T-4 mute/solo change: header-only commands gain a mandatory manager; rebuild requests coalesce (safe under fader drags — one flag, drained once per frame).
- Recording-visibility and automation-authoring items from the same session remain separate (tracked in #795's body).
