### PR TITLE
fix: drop the legacy demo automation curve on load

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -2195,34 +2195,55 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     // 0/4/8/12 — is dropped on load so projects saved before
                     // the demo-automation removal self-heal instead of
                     // silently automating channel 1 on every playback.
-                    // Exact-shape match only: a real user curve is never
-                    // touched unless it matches all characteristics.
+                    // Exact-shape match only, at serialization-scale tolerance
+                    // (float32 storage noise ~1e-7; a real point like 0.2005
+                    // differs by 5e-4 and must survive). EVERY matching curve
+                    // is removed, wherever it sits in the lane's list.
                     if (!lane->automationCurves.empty()) {
-                        auto& curve = lane->automationCurves.back();
-                        const bool legacyDemoShape =
-                            curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Volume &&
-                            curve.mixerChannelId == 1 && std::abs(curve.getDefaultValue() - 0.8f) < 1e-3f &&
-                            curve.getPoints().size() == 4;
-                        if (legacyDemoShape) {
-                            constexpr double kDemoBeats[4] = {0.0, 4.0, 8.0, 12.0};
-                            constexpr double kDemoValues[4] = {0.5, 1.0, 0.2, 0.8};
-                            bool shapeMatches = true;
-                            for (size_t i = 0; i < 4; ++i) {
-                                const auto& pt = curve.getPoints()[i];
-                                if (std::abs(pt.beat - kDemoBeats[i]) > 1e-3 ||
-                                    std::abs(static_cast<double>(pt.value) - kDemoValues[i]) > 1e-3) {
-                                    shapeMatches = false;
-                                    break;
-                                }
+                        constexpr double kDemoBeats[4] = {0.0, 4.0, 8.0, 12.0};
+                        constexpr double kDemoValues[4] = {0.5, 1.0, 0.2, 0.8};
+                        constexpr double kDemoTolerance = 1e-6;
+                        const auto isLegacyDemoCurve = [](const AutomationCurve& curve) {
+                            return curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Volume &&
+                                   curve.mixerChannelId == 1 &&
+                                   std::abs(curve.getDefaultValue() - 0.8f) < 1e-6f &&
+                                   curve.getPoints().size() == 4;
+                        };
+                        size_t droppedCount = 0;
+                        lane->automationCurves.erase(
+                            std::remove_if(lane->automationCurves.begin(), lane->automationCurves.end(),
+                                           [&](const AutomationCurve& curve) {
+                                               if (!isLegacyDemoCurve(curve)) {
+                                                   return false;
+                                               }
+                                               const auto& pts = curve.getPoints();
+                                               for (size_t i = 0; i < 4; ++i) {
+                                                   if (std::abs(pts[i].beat - kDemoBeats[i]) > kDemoTolerance ||
+                                                       std::abs(static_cast<double>(pts[i].value) - kDemoValues[i]) >
+                                                           kDemoTolerance) {
+                                                       return false;
+                                                   }
+                                               }
+                                               ++droppedCount;
+                                               return true;
+                                           }),
+                            lane->automationCurves.end());
+                        if (droppedCount > 0) {
+                            warningLimiter.warning(
+                                ProjectLoadWarningCategory::LegacyDemoAutomation,
+                                "[ProjectLoad] Dropped " + std::to_string(droppedCount) +
+                                    " legacy demo automation curve(s) on channel 1 (pre-0.7.0 demo data).",
+                                "[ProjectLoad] Additional legacy demo automation drops suppressed.");
+                            if (!result.report) {
+                                result.report = std::make_unique<ProjectLoadReport>();
                             }
-                            if (shapeMatches) {
-                                lane->automationCurves.pop_back();
-                                warningLimiter.warning(
-                                    ProjectLoadWarningCategory::LegacyDemoAutomation,
-                                    "[ProjectLoad] Dropped the legacy demo automation curve on channel 1 "
-                                    "(pre-0.7.0 demo data).",
-                                    "[ProjectLoad] Additional legacy demo automation drops suppressed.");
-                            }
+                            result.report->issues.push_back(
+                                {LoadIssueSeverity::Warning, "legacy_demo_automation",
+                                 "Removed the legacy demo automation curve(s) on channel 1 (pre-0.7.0 demo "
+                                 "data); the project has been migrated.",
+                                 0, {}, laneName});
+                            result.migrationOutcome =
+                                combineMigrationOutcome(result.migrationOutcome, MigrationOutcome::Transformed);
                         }
                     }
                     if (lj[i].has("clips")) {

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -78,6 +78,7 @@ namespace {
         DroppedClip,
         SendRoute,
         ClipTiming,
+        LegacyDemoAutomation,
         Count
     };
 
@@ -2187,7 +2188,43 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                             lane->automationCurves.push_back(curve);
                         }
                     }
-    
+
+                    // Migration: the pre-2026-08-14 demo automation curve
+                    // (addDemoTracks-era) — channel 1 Volume, default 0.8,
+                    // exactly the four points 0.5/1.0/0.2/0.8 at beats
+                    // 0/4/8/12 — is dropped on load so projects saved before
+                    // the demo-automation removal self-heal instead of
+                    // silently automating channel 1 on every playback.
+                    // Exact-shape match only: a real user curve is never
+                    // touched unless it matches all characteristics.
+                    if (!lane->automationCurves.empty()) {
+                        auto& curve = lane->automationCurves.back();
+                        const bool legacyDemoShape =
+                            curve.getAutomationTarget() == Aestra::Audio::AutomationTarget::Volume &&
+                            curve.mixerChannelId == 1 && std::abs(curve.getDefaultValue() - 0.8f) < 1e-3f &&
+                            curve.getPoints().size() == 4;
+                        if (legacyDemoShape) {
+                            constexpr double kDemoBeats[4] = {0.0, 4.0, 8.0, 12.0};
+                            constexpr double kDemoValues[4] = {0.5, 1.0, 0.2, 0.8};
+                            bool shapeMatches = true;
+                            for (size_t i = 0; i < 4; ++i) {
+                                const auto& pt = curve.getPoints()[i];
+                                if (std::abs(pt.beat - kDemoBeats[i]) > 1e-3 ||
+                                    std::abs(static_cast<double>(pt.value) - kDemoValues[i]) > 1e-3) {
+                                    shapeMatches = false;
+                                    break;
+                                }
+                            }
+                            if (shapeMatches) {
+                                lane->automationCurves.pop_back();
+                                warningLimiter.warning(
+                                    ProjectLoadWarningCategory::LegacyDemoAutomation,
+                                    "[ProjectLoad] Dropped the legacy demo automation curve on channel 1 "
+                                    "(pre-0.7.0 demo data).",
+                                    "[ProjectLoad] Additional legacy demo automation drops suppressed.");
+                            }
+                        }
+                    }
                     if (lj[i].has("clips")) {
                         const JSON& cj = lj[i]["clips"];
     #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -1080,6 +1080,9 @@ void testProjectLoadWarningsAreBounded() {
 
 } // namespace
 
+void testLegacyDemoAutomationCurveDroppedOnLoad();
+void testLegacyDemoAutomationNearMissPreserved();
+
 int main() {
     std::cout << "=== Project Load Regression Tests ===" << std::endl;
 
@@ -1097,7 +1100,133 @@ int main() {
     testTrackColorIndexRoundtrip();
     testProjectLoadWarningsAreBounded();
     testV1AutomationCurveMigratesToInstanceId();
+    testLegacyDemoAutomationCurveDroppedOnLoad();
+    testLegacyDemoAutomationNearMissPreserved();
 
     std::cout << "=== All tests passed ===" << std::endl;
     return 0;
+}
+
+// Legacy demo automation migration: projects saved before the 2026-08-14
+// demo-automation removal carry the addDemoTracks-era curve — channel 1
+// Volume, default 0.8, points 0.5/1.0/0.2/0.8 at beats 0/4/8/12. It must be
+// dropped on load (self-heal) with a diagnostic, while a near-miss curve
+// (same channel/default, different points) must survive untouched.
+void testLegacyDemoAutomationCurveDroppedOnLoad() {
+    std::cout << "[TEST] legacy demo automation curve dropped on load..." << std::endl;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"legacy_demo_automation"};
+    const auto testDir = tempDirScope.path();
+    const std::filesystem::path testProject = testDir / "demo_curve.aes";
+
+    // Mirrors the exact saved shape found in pre-cleanup project files
+    // (e.g. "working 1.takes/main.aes", saved 2026-08-09).
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": [],
+                "automation": [
+                    {
+                        "param": 0,
+                        "targetEnum": 0,
+                        "default": 0.800000011920929,
+                        "mixerChannelId": 1,
+                        "points": [
+                            {"b": 0, "c": 0.5, "v": 0.5},
+                            {"b": 4, "c": 0.5, "v": 1},
+                            {"b": 8, "c": 0.5, "v": 0.20000000298023224},
+                            {"b": 12, "c": 0.5, "v": 0.800000011920929}
+                        ]
+                    }
+                ]
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+
+    auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+    assert(!laneIds.empty());
+    auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->automationCurves.empty() &&
+           "legacy demo curve must be dropped on load (channel 1 must not auto-automate)");
+
+    std::cout << "[TEST] legacy demo automation drop passed" << std::endl;
+}
+
+void testLegacyDemoAutomationNearMissPreserved() {
+    std::cout << "[TEST] legacy demo automation near-miss preserved..." << std::endl;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"legacy_demo_automation_nearmiss"};
+    const auto testDir = tempDirScope.path();
+    const std::filesystem::path testProject = testDir / "nearmiss.aes";
+
+    // Same channel/default/count but a different value at beat 8: a real user
+    // curve that must NOT be mistaken for the demo shape.
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": [],
+                "automation": [
+                    {
+                        "param": 0,
+                        "targetEnum": 0,
+                        "default": 0.800000011920929,
+                        "mixerChannelId": 1,
+                        "points": [
+                            {"b": 0, "c": 0.5, "v": 0.5},
+                            {"b": 4, "c": 0.5, "v": 1},
+                            {"b": 8, "c": 0.5, "v": 0.7},
+                            {"b": 12, "c": 0.5, "v": 0.800000011920929}
+                        ]
+                    }
+                ]
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+
+    auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+    assert(!laneIds.empty());
+    auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->automationCurves.size() == 1 &&
+           "near-miss curve must survive (exact-shape match only)");
+    assert(lane->automationCurves[0].getPoints().size() == 4);
+
+    std::cout << "[TEST] near-miss preservation passed" << std::endl;
 }

--- a/Tests/Integration/ProjectLoadRegressionTest.cpp
+++ b/Tests/Integration/ProjectLoadRegressionTest.cpp
@@ -1082,6 +1082,8 @@ void testProjectLoadWarningsAreBounded() {
 
 void testLegacyDemoAutomationCurveDroppedOnLoad();
 void testLegacyDemoAutomationNearMissPreserved();
+void testLegacyDemoAutomationMixedLane();
+void testLegacyDemoAutomationCloseNearMissPreserved();
 
 int main() {
     std::cout << "=== Project Load Regression Tests ===" << std::endl;
@@ -1102,6 +1104,8 @@ int main() {
     testV1AutomationCurveMigratesToInstanceId();
     testLegacyDemoAutomationCurveDroppedOnLoad();
     testLegacyDemoAutomationNearMissPreserved();
+    testLegacyDemoAutomationMixedLane();
+    testLegacyDemoAutomationCloseNearMissPreserved();
 
     std::cout << "=== All tests passed ===" << std::endl;
     return 0;
@@ -1229,4 +1233,140 @@ void testLegacyDemoAutomationNearMissPreserved() {
     assert(lane->automationCurves[0].getPoints().size() == 4);
 
     std::cout << "[TEST] near-miss preservation passed" << std::endl;
+}
+
+// A matching legacy curve followed by a real user curve: BOTH must be
+// evaluated — the legacy one is dropped, the user curve survives (the
+// migration filters the whole lane, not just the last curve).
+void testLegacyDemoAutomationMixedLane() {
+    std::cout << "[TEST] legacy demo automation mixed lane..." << std::endl;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"legacy_demo_automation_mixed"};
+    const auto testDir = tempDirScope.path();
+    const std::filesystem::path testProject = testDir / "mixed.aes";
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": [],
+                "automation": [
+                    {
+                        "param": 0,
+                        "targetEnum": 0,
+                        "default": 0.800000011920929,
+                        "mixerChannelId": 1,
+                        "points": [
+                            {"b": 0, "c": 0.5, "v": 0.5},
+                            {"b": 4, "c": 0.5, "v": 1},
+                            {"b": 8, "c": 0.5, "v": 0.20000000298023224},
+                            {"b": 12, "c": 0.5, "v": 0.800000011920929}
+                        ]
+                    },
+                    {
+                        "param": 0,
+                        "targetEnum": 0,
+                        "default": 0.6,
+                        "mixerChannelId": 2,
+                        "points": [
+                            {"b": 0, "c": 0.0, "v": 0.6},
+                            {"b": 8, "c": 0.0, "v": 0.9}
+                        ]
+                    }
+                ]
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(result.migrationOutcome == Aestra::MigrationOutcome::Transformed &&
+           "demo-curve removal must mark the load as transformed");
+
+    auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+    assert(!laneIds.empty());
+    auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->automationCurves.size() == 1 &&
+           "legacy curve dropped, user curve survives (filter, not last-only)");
+    assert(lane->automationCurves[0].mixerChannelId == 2 && "the surviving curve is the user's");
+
+    std::cout << "[TEST] mixed lane passed" << std::endl;
+}
+
+// A near-miss within the OLD 1e-3 tolerance (0.2005 vs 0.2) must survive:
+// the match threshold covers float32 serialization noise only (~1e-7), not
+// real user values.
+void testLegacyDemoAutomationCloseNearMissPreserved() {
+    std::cout << "[TEST] legacy demo automation close near-miss preserved..." << std::endl;
+
+    const Aestra::Tests::ScopedTempDirectory tempDirScope{"legacy_demo_automation_close"};
+    const auto testDir = tempDirScope.path();
+    const std::filesystem::path testProject = testDir / "close.aes";
+
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Track 1",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "clips": [],
+                "automation": [
+                    {
+                        "param": 0,
+                        "targetEnum": 0,
+                        "default": 0.800000011920929,
+                        "mixerChannelId": 1,
+                        "points": [
+                            {"b": 0, "c": 0.5, "v": 0.5},
+                            {"b": 4, "c": 0.5, "v": 1},
+                            {"b": 8, "c": 0.5, "v": 0.2005},
+                            {"b": 12, "c": 0.5, "v": 0.800000011920929}
+                        ]
+                    }
+                ]
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+
+    std::ofstream out(testProject);
+    out << projectJson;
+    out.close();
+
+    auto trackManager = std::make_shared<TrackManager>();
+    auto result = ProjectSerializer::load(testProject.string(), trackManager);
+    assert(result.ok);
+    assert(result.migrationOutcome != Aestra::MigrationOutcome::Transformed &&
+           "a close near-miss must not trigger the migration");
+
+    auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+    assert(!laneIds.empty());
+    auto* lane = trackManager->getPlaylistModel().getLane(laneIds[0]);
+    assert(lane);
+    assert(lane->automationCurves.size() == 1 &&
+           "close near-miss (0.2005) must survive the exact-shape match");
+    assert(lane->automationCurves[0].getPoints()[2].value == 0.2005f);
+
+    std::cout << "[TEST] close near-miss passed" << std::endl;
 }


### PR DESCRIPTION
Objective:  —
Decision:   FD-12 @ e437eef
Kind:       corrective
Reversal:   —

## Summary

Fixes the founder's "channel 1 auto automates channel 1" report. Projects saved before the 2026-08-14 demo-automation removal carry the addDemoTracks-era curve — channel 1 Volume, default 0.8, exactly the points 0.5/1.0/0.2/0.8 at beats 0/4/8/12. Confirmed live in `working 1.takes/main.aes` and `33.takes/main.aes` (both saved 2026-08-09).

The loader now drops exact-shape matches on load with a diagnostic (LegacyDemoAutomation warning category), so pre-fix projects self-heal instead of silently automating channel 1. Near-miss curves (same channel/default, different points) survive untouched — exact-shape match only.

## Testing Performed

- ProjectLoadRegressionTest: drop case (exact demo shape → empty automation on the lane) + near-miss case (one changed value → curve survives).
  - RED on the unpatched loader (assertion: legacy demo curve must be dropped).
  - GREEN with the migration.
- Full suite + app build pending in CI.

## Producer note

Projects saved before the demo-automation cleanup no longer carry ghost automation on channel 1.

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed

## Risk / Rollback Notes

- Serializer change (load path only, additive): exact-shape match is precise (target + channel + default + 4 points + values within 1e-3); a real user curve on channel 1 cannot match unless it is byte-identical to the demo shape.
- The two live project files heal on next open (and persist clean on next save).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Remove the exact legacy demo automation curve during project loading.
- Record a `LegacyDemoAutomation` warning diagnostic when the curve is removed.
- Preserve near-miss curves that differ from the historical shape.
- Add regression tests for removal and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->