### PR TITLE
feat: Track ownership layer (FD-14 PR-1) — Track owns Lanes, routes to a Channel

### DIFF
--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -327,7 +327,6 @@ private:
     }
 };
 
-using Track = MixerChannel;
 
 } // namespace Audio
 } // namespace Aestra

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -31,6 +31,9 @@ struct PlaylistLane {
     int index = 0;
     /** @brief Clips currently placed on the lane. */
     std::vector<ClipInstance> clips;
+    /** @brief Owning Track's stable id (FD-14). 0 = unowned/legacy until the
+     *  loader migration assigns ownership. Never derived from lane index. */
+    uint64_t trackId{0};
 
     /** @brief Lane volume multiplier. */
     float volume{1.0f};

--- a/AestraAudio/include/Models/Track.h
+++ b/AestraAudio/include/Models/Track.h
@@ -1,0 +1,52 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Models/ClipInstance.h"
+#include "Core/MixerChannel.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief The user's recording and arrangement identity (FD-14).
+ *
+ * A Track owns its lanes and references its mixer Channel as the routing
+ * destination. Ownership is by STABLE ID only — never by lane index, track
+ * index, or channel index (the positional pairings FD-14 forbids).
+ *
+ *   Track ──── owns ────> Lane(s)
+ *   Track ──── routes ──> Channel
+ *   Lane  ──── belongs ──> Track
+ */
+struct Track {
+    /** Stable track identity (serialized; never positional). */
+    uint64_t trackId{0};
+    /** Mixer routing destination (MASTER_MIXER_CHANNEL_ID = master). */
+    uint32_t channelId{MASTER_MIXER_CHANNEL_ID};
+    /** User-facing name. */
+    std::string name;
+    /** Recording arm state — the authoritative recording arm (FD-14 #6). */
+    bool armed{false};
+    /** Primary/visible lane when the track is collapsed. */
+    PlaylistLaneID activeLaneId;
+    /** Owned lanes in display order; track-local numbering by position. */
+    std::vector<PlaylistLaneID> laneIds;
+
+    /** Track-local lane number (1-based position in laneIds), or 0 when the
+     * lane is not owned by this track. */
+    int laneNumber(PlaylistLaneID laneId) const {
+        for (size_t i = 0; i < laneIds.size(); ++i) {
+            if (laneIds[i] == laneId) {
+                return static_cast<int>(i) + 1;
+            }
+        }
+        return 0;
+    }
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -18,6 +18,7 @@
 #include "MeterSnapshot.h"
 #include "PatternManager.h"
 #include "PlaylistModel.h"
+#include "Track.h"
 #include "SourceManager.h"
 #include "UnitManager.h"
 
@@ -338,14 +339,6 @@ public:
      * @param index Channel index inside the current track list.
      * @return Mutable track pointer or nullptr when out of range.
      */
-    MixerChannel* getTrack(size_t index) { return getChannel(index); }
-    /**
-     * @brief Get a track by zero-based index.
-     * @param index Channel index inside the current track list.
-     * @return Const track pointer or nullptr when out of range.
-     */
-    const MixerChannel* getTrack(size_t index) const { return getChannel(index); }
-
     /** @brief Find a mixer channel by stable ID. */
     MixerChannel* getChannelById(uint32_t channelId) {
         const size_t index = findChannelIndexById(channelId);
@@ -356,6 +349,137 @@ public:
     const MixerChannel* getChannelById(uint32_t channelId) const {
         const size_t index = findChannelIndexById(channelId);
         return index < m_channels.size() ? m_channels[index].get() : nullptr;
+    }
+
+    // ==============================
+    // Tracks (FD-14 ownership layer)
+    // ==============================
+
+    /**
+     * @brief Create a Track owning the given lane (FD-14).
+     *
+     * Ownership is by stable ID: the lane's trackId is set explicitly and the
+     * track's laneIds list is appended. Never positional.
+     *
+     * @param laneId The lane the track owns (must exist).
+     * @param name Track name.
+     * @param channelId Routing destination (MASTER_MIXER_CHANNEL_ID default).
+     * @return The new track's stable id, or 0 on failure.
+     */
+    uint64_t createTrack(PlaylistLaneID laneId, const std::string& name,
+                         uint32_t channelId = MASTER_MIXER_CHANNEL_ID) {
+        auto* lane = m_playlistModel.getLane(laneId);
+        if (!lane) {
+            return 0;
+        }
+        Track track;
+        track.trackId = m_nextTrackId++;
+        track.name = name.empty() ? ("Track " + std::to_string(track.trackId)) : name;
+        track.channelId = channelId;
+        track.laneIds.push_back(laneId);
+        track.activeLaneId = laneId;
+        lane->trackId = track.trackId;
+        m_tracks[track.trackId] = std::move(track);
+        return track.trackId;
+    }
+
+    /** @brief Find a Track by stable ID. */
+    Track* getTrack(uint64_t trackId) {
+        auto it = m_tracks.find(trackId);
+        return it != m_tracks.end() ? &it->second : nullptr;
+    }
+
+    /** @brief Find a Track by stable ID (const). */
+    const Track* getTrack(uint64_t trackId) const {
+        auto it = m_tracks.find(trackId);
+        return it != m_tracks.end() ? &it->second : nullptr;
+    }
+
+    /** @brief Resolve the Track owning a lane, or nullptr when unowned. */
+    Track* getTrackForLane(PlaylistLaneID laneId) {
+        auto* lane = m_playlistModel.getLane(laneId);
+        if (!lane || lane->trackId == 0) {
+            return nullptr;
+        }
+        return getTrack(lane->trackId);
+    }
+
+    /** @brief Attach an existing lane to a Track (lane created after the
+     *  track, e.g. a recorded take). Returns false when either is invalid. */
+    bool attachLaneToTrack(uint64_t trackId, PlaylistLaneID laneId) {
+        auto* track = getTrack(trackId);
+        auto* lane = m_playlistModel.getLane(laneId);
+        if (!track || !lane) {
+            return false;
+        }
+        lane->trackId = trackId;
+        track->laneIds.push_back(laneId);
+        if (!track->activeLaneId.isValid()) {
+            track->activeLaneId = laneId;
+        }
+        return true;
+    }
+
+    /** @brief Set the Track's recording arm state (FD-14 #6: the authoritative
+     *  recording arm lives on the Track). */
+    void setTrackArmed(uint64_t trackId, bool armed) {
+        if (auto* track = getTrack(trackId)) {
+            track->armed = armed;
+        }
+    }
+
+    /** @brief Number of armed Tracks. */
+    size_t getTrackArmedCount() const {
+        size_t count = 0;
+        for (const auto& [id, track] : m_tracks) {
+            (void)id;
+            if (track.armed) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    /** @brief All tracks in stable-id order (for serialization/UI). */
+    std::vector<Track*> getTracks() {
+        std::vector<Track*> result;
+        result.reserve(m_tracks.size());
+        for (auto& [id, track] : m_tracks) {
+            (void)id;
+            result.push_back(&track);
+        }
+        // Deterministic serialization order (unordered_map iteration is not).
+        std::sort(result.begin(), result.end(),
+                  [](const Track* a, const Track* b) { return a->trackId < b->trackId; });
+        return result;
+    }
+
+    /**
+     * @brief Restore a Track from serialized state (project load).
+     *
+     * Rebuilds the exact stable ids from the file — never mints fresh ones —
+     * and re-attaches the owned lanes by their ids. Advances the minting
+     * counter past the restored id.
+     */
+    bool restoreTrack(const Track& restored) {
+        if (restored.trackId == 0 || m_tracks.count(restored.trackId) != 0) {
+            return false;
+        }
+        Track track = restored;
+        track.laneIds.clear();
+        for (const auto& laneId : restored.laneIds) {
+            auto* lane = m_playlistModel.getLane(laneId);
+            if (!lane) {
+                continue;
+            }
+            lane->trackId = restored.trackId;
+            track.laneIds.push_back(laneId);
+        }
+        m_tracks[restored.trackId] = std::move(track);
+        if (m_nextTrackId <= restored.trackId) {
+            m_nextTrackId = restored.trackId + 1;
+        }
+        return true;
     }
 
     /**
@@ -1854,6 +1978,8 @@ private:
     std::vector<std::unique_ptr<MixerChannel>> m_channels;
     std::unique_ptr<MixerChannel> m_masterChannel;
     uint32_t m_nextChannelId{1};
+    std::unordered_map<uint64_t, Track> m_tracks;
+    uint64_t m_nextTrackId{1};
     PlaylistModel m_playlistModel;
     PatternManager m_patternManager;
     SourceManager m_sourceManager;

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -18,7 +18,7 @@ namespace Audio {
 // ChannelStrip Implementation
 //=============================================================================
 
-ChannelStrip::ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackManager)
+ChannelStrip::ChannelStrip(std::shared_ptr<MixerChannel> track, TrackManager* trackManager)
     : m_track(track)
     , m_trackManager(trackManager)
 {

--- a/Source/Components/MixerView.h
+++ b/Source/Components/MixerView.h
@@ -20,19 +20,19 @@ namespace Audio {
  */
 class ChannelStrip : public AestraUI::NUIComponent {
 public:
-    ChannelStrip(std::shared_ptr<Track> track, TrackManager* trackManager = nullptr);
+    ChannelStrip(std::shared_ptr<MixerChannel> track, TrackManager* trackManager = nullptr);
     
     void onRender(AestraUI::NUIRenderer& renderer) override;
     void onResize(int width, int height) override;
     bool onMouseEvent(const AestraUI::NUIMouseEvent& event) override;
     
-    void setTrack(std::shared_ptr<Track> track) { m_track = track; }
-    std::shared_ptr<Track> getTrack() const { return m_track; }
+    void setTrack(std::shared_ptr<MixerChannel> track) { m_track = track; }
+    std::shared_ptr<MixerChannel> getTrack() const { return m_track; }
 
     void setPlatformBridge(AestraUI::NUIPlatformBridge* bridge);
 
 private:
-    std::shared_ptr<Track> m_track;
+    std::shared_ptr<MixerChannel> m_track;
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     AestraUI::NUIPlatformBridge* m_platformBridge = nullptr;
 

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -135,6 +135,12 @@ void TrackManagerUI::addTrack(const std::string& name) {
     auto laneCmd = std::make_shared<CreateLaneCommand>(m_trackManager->getPlaylistModel(), name);
     m_trackManager->getCommandHistory().pushAndExecute(laneCmd);
 
+    // FD-14: every lane belongs to a Track. The app's add-track creates the
+    // lane AND its owning Track in one operation (ownership by stable id).
+    if (laneCmd->getLaneId().isValid()) {
+        m_trackManager->createTrack(laneCmd->getLaneId(), name);
+    }
+
     // Rebuild UI from model state
     refreshTracks();
     layoutTracks();

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -237,6 +237,8 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             clearDropPreview();
             return result;
         }
+        // FD-14: a new lane belongs to a new Track (ownership by stable id).
+        m_trackManager->createTrack(targetLaneId, laneName);
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
     } else {

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1044,11 +1044,36 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
                 clipsJson.push(cjs);
             }
             ljs.set("clips", clipsJson);
+            ljs.set("trackId", JSON(static_cast<double>(lane->trackId)));
             lanesJson.push(ljs);
         }
         ++laneIndex;
     }
     root.set("lanes", lanesJson);
+    // 3b. Save Tracks (FD-14 ownership layer). The tracks array carries the
+    // stable ownership: trackId, routing channel, arm state, and owned lane
+    // ids in order. Lanes carry their trackId for cross-reference.
+    {
+        JSON tracksJson = JSON::array();
+        for (const auto* track : trackManager->getTracks()) {
+            if (!track) {
+                continue;
+            }
+            JSON tjs = JSON::object();
+            tjs.set("trackId", JSON(static_cast<double>(track->trackId)));
+            tjs.set("name", JSON(track->name));
+            tjs.set("channelId", JSON(static_cast<double>(track->channelId)));
+            tjs.set("armed", JSON(track->armed));
+            tjs.set("activeLaneId", JSON(track->activeLaneId.toString()));
+            JSON laneIdsJson = JSON::array();
+            for (const auto& laneId : track->laneIds) {
+                laneIdsJson.push(JSON(laneId.toString()));
+            }
+            tjs.set("laneIds", laneIdsJson);
+            tracksJson.push(tjs);
+        }
+        root.set("tracks", tracksJson);
+    }
 
     // 4. Save Arsenal Units
     root.set("arsenal", trackManager->getUnitManager().saveToJSON());
@@ -1938,6 +1963,10 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         // Clip ids restored from the file must stay unique — a hand-edited or
         // corrupted file with duplicates would silently break id lookups.
         std::unordered_set<AestraUUID> seenClipIds;
+        // FD-14: capture each legacy lane's OWN stored channel id (an explicit
+        // per-lane file field) so the track migration never infers ownership
+        // from array position.
+        std::unordered_map<std::string, uint32_t> legacyLaneChannelIds;
         if (root.has("lanes")) {
             const JSON& lj = root["lanes"];
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
@@ -1974,6 +2003,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                         if (std::isfinite(rawId) && rawId > 0.0 && rawId < static_cast<double>(UINT32_MAX)) {
                             storedMixerChannelId = static_cast<uint32_t>(rawId);
                         }
+                    }
+                    if (storedMixerChannelId != 0) {
+                        legacyLaneChannelIds[laneId.toString()] = storedMixerChannelId;
                     }
                     channel = trackManager->addChannelWithId(laneName, storedMixerChannelId);
                     if (!channel) {
@@ -2420,6 +2452,73 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     continuous->setFaderDb(slot, faderDb);
                     continuous->setPan(slot, channel->getPan());
                 }
+            }
+        }
+
+        // PHASE 7c: Restore Track ownership (FD-14). The "tracks" section
+        // restores exact stable ids; legacy files (no section) migrate
+        // deterministically — one Track per lane in lane order, channel =
+        // the lane's OWN stored channel id (an explicit per-lane file field,
+        // never a positional inference), master when none exists.
+        {
+            const auto laneIds = trackManager->getPlaylistModel().getLaneIDs();
+
+            if (root.has("tracks") && root["tracks"].isArray()) {
+                const JSON& tj = root["tracks"];
+                for (size_t t = 0; t < tj.size(); ++t) {
+                    if (!tj[t].isObject()) {
+                        continue;
+                    }
+                    Track track;
+                    track.trackId = static_cast<uint64_t>(
+                        finiteNumberOr(tj[t], "trackId", 0.0, 1.0, static_cast<double>(UINT64_MAX)));
+                    if (track.trackId == 0) {
+                        continue;
+                    }
+                    track.name = boundedStringOr(tj[t], "name", "", PROJECT_MAX_STRING_BYTES);
+                    track.channelId = static_cast<uint32_t>(finiteNumberOr(
+                        tj[t], "channelId", 0.0, 0.0, static_cast<double>(UINT32_MAX)));
+                    track.armed = (tj[t].has("armed") && tj[t]["armed"].isBool()) ? tj[t]["armed"].asBool()
+                                                                                  : false;
+                    if (tj[t].has("activeLaneId") && tj[t]["activeLaneId"].isString()) {
+                        AestraUUID parsedActive;
+                        if (AestraUUID::tryParse(tj[t]["activeLaneId"].asString(), parsedActive)) {
+                            track.activeLaneId = PlaylistLaneID(parsedActive);
+                        }
+                    }
+                    if (tj[t].has("laneIds") && tj[t]["laneIds"].isArray()) {
+                        const JSON& ids = tj[t]["laneIds"];
+                        for (size_t l = 0; l < ids.size(); ++l) {
+                            if (ids[l].isString()) {
+                                AestraUUID parsedLane;
+                                if (AestraUUID::tryParse(ids[l].asString(), parsedLane)) {
+                                    track.laneIds.push_back(PlaylistLaneID(parsedLane));
+                                }
+                            }
+                        }
+                    }
+                    if (!trackManager->restoreTrack(track)) {
+                        warningLimiter.warning(
+                            ProjectLoadWarningCategory::EffectChain,
+                            "[ProjectLoad] Failed to restore track '" + track.name + "' — skipped.",
+                            "[ProjectLoad] Additional track restore failures suppressed.");
+                    }
+                }
+            }
+
+            // Migration: lanes without ownership get one deterministic Track
+            // each, using the lane's OWN stored channel when one exists.
+            for (const auto& laneId : laneIds) {
+                auto* lane = trackManager->getPlaylistModel().getLane(laneId);
+                if (!lane || lane->trackId != 0) {
+                    continue;
+                }
+                uint32_t storedChannelId = MASTER_MIXER_CHANNEL_ID;
+                const auto legacyIt = legacyLaneChannelIds.find(laneId.toString());
+                if (legacyIt != legacyLaneChannelIds.end()) {
+                    storedChannelId = legacyIt->second;
+                }
+                trackManager->createTrack(laneId, lane->name, storedChannelId);
             }
         }
 

--- a/Tests/AestraAudio/TrackOwnershipTest.cpp
+++ b/Tests/AestraAudio/TrackOwnershipTest.cpp
@@ -1,0 +1,231 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// TrackOwnershipTest — FD-14 PR-1: the Track model, lane ownership, and the
+// load-time migration. Ownership is by STABLE ID only; the positional
+// pairings (lane index → channel index, etc.) are structurally absent.
+//
+//   Track ──── owns ────> Lane(s)
+//   Track ──── routes ──> Channel
+//   Lane  ──── belongs ──> Track
+
+#include "Models/TrackManager.h"
+#include "Core/MixerChannel.h"
+#include "../../Source/Core/ProjectSerializer.h"
+
+#include <cassert>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << "\n";
+        ++g_failures;
+    } else {
+        std::cout << "  PASS: " << label << "\n";
+    }
+}
+
+void testCreateTrackOwnsLane() {
+    std::cout << "[model] createTrack owns the lane\n";
+    TrackManager tm;
+    PlaylistLaneID laneId = tm.getPlaylistModel().createLane("Track 1");
+    assert(laneId.isValid());
+
+    uint64_t trackId = tm.createTrack(laneId, "Track 1");
+    check(trackId != 0, "track created");
+    Track* track = tm.getTrack(trackId);
+    check(track != nullptr, "track resolvable by id");
+    if (!track) {
+        return;
+    }
+    check(track->laneIds.size() == 1 && track->laneIds[0] == laneId, "track owns the lane");
+    check(track->activeLaneId == laneId, "first lane is the active lane");
+    auto* lane = tm.getPlaylistModel().getLane(laneId);
+    check(lane && lane->trackId == trackId, "lane's trackId points at the track");
+    check(tm.getTrackForLane(laneId) == track, "lane resolves to its track");
+    check(track->laneNumber(laneId) == 1, "track-local lane number is 1");
+    check(tm.getTrackForLane(PlaylistLaneID::generate()) == nullptr, "unknown lane resolves to null");
+}
+
+void testAttachLaneTrackLocalNumbering() {
+    std::cout << "[model] attachLaneToTrack + track-local numbering\n";
+    TrackManager tm;
+    PlaylistLaneID lane1 = tm.getPlaylistModel().createLane("T1 Lane 1");
+    PlaylistLaneID lane2 = tm.getPlaylistModel().createLane("T1 Lane 2");
+    uint64_t trackId = tm.createTrack(lane1, "Track 1");
+    check(tm.attachLaneToTrack(trackId, lane2), "second lane attached");
+    Track* track = tm.getTrack(trackId);
+    check(track && track->laneIds.size() == 2, "track owns both lanes");
+    check(track && track->laneNumber(lane1) == 1, "lane 1 keeps number 1");
+    check(track && track->laneNumber(lane2) == 2, "lane 2 gets number 2");
+    check(track && track->activeLaneId == lane1, "active lane unchanged by attach");
+
+    PlaylistLaneID other = tm.getPlaylistModel().createLane("Other");
+    uint64_t track2 = tm.createTrack(other, "Track 2");
+    check(tm.getTrack(track2)->laneNumber(other) == 1, "track 2 numbering starts at 1 independently");
+}
+
+void testTrackArmState() {
+    std::cout << "[model] track arm state (FD-14 #6)\n";
+    TrackManager tm;
+    PlaylistLaneID lane = tm.getPlaylistModel().createLane("Armed");
+    uint64_t trackId = tm.createTrack(lane, "Armed");
+    check(tm.getTrackArmedCount() == 0, "no armed tracks initially");
+    tm.setTrackArmed(trackId, true);
+    check(tm.getTrackArmedCount() == 1, "track arm counted");
+    check(tm.getTrack(trackId)->armed, "track armed flag set");
+    tm.setTrackArmed(trackId, false);
+    check(tm.getTrackArmedCount() == 0, "disarm clears");
+}
+
+void testRestoreTrackExactIds() {
+    std::cout << "[model] restoreTrack keeps stable ids\n";
+    TrackManager tm;
+    PlaylistLaneID lane1 = tm.getPlaylistModel().createLane("L1");
+    PlaylistLaneID lane2 = tm.getPlaylistModel().createLane("L2");
+    Track restored;
+    restored.trackId = 42;
+    restored.name = "Restored";
+    restored.channelId = 7;
+    restored.armed = true;
+    restored.laneIds = {lane1, lane2};
+    restored.activeLaneId = lane2;
+    check(tm.restoreTrack(restored), "track restored");
+    Track* track = tm.getTrack(42);
+    check(track != nullptr, "restored track resolvable by exact id");
+    check(track && track->laneIds.size() == 2 && track->laneIds[0] == lane1, "restored ownership");
+    check(track && track->armed && track->channelId == 7, "restored state");
+    check(tm.getPlaylistModel().getLane(lane1)->trackId == 42, "lane re-attached to restored track");
+    check(track && track->activeLaneId == lane2, "active lane restored");
+}
+
+void testSerializeRoundtrip() {
+    std::cout << "[serializer] tracks roundtrip\n";
+    const auto dir = std::filesystem::temp_directory_path() / "aestra_track_roundtrip";
+    std::filesystem::create_directories(dir);
+    const auto path = dir / "tracks.aes";
+
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(48000.0);
+    PlaylistLaneID lane1 = tm->getPlaylistModel().createLane("T1 Lane 1");
+    PlaylistLaneID lane2 = tm->getPlaylistModel().createLane("T1 Lane 2");
+    uint64_t t1 = tm->createTrack(lane1, "Track 1", 3);
+    tm->attachLaneToTrack(t1, lane2);
+    PlaylistLaneID lane3 = tm->getPlaylistModel().createLane("T2 Lane 1");
+    uint64_t t2 = tm->createTrack(lane3, "Track 2");
+    tm->setTrackArmed(t2, true);
+
+    auto saved = ProjectSerializer::serialize(tm, 120.0, 0.0, 0);
+    check(!saved.contents.empty(), "serialize produced output");
+    std::ofstream out(path);
+    out << saved.contents;
+    out.close();
+
+    auto loaded = std::make_shared<TrackManager>();
+    loaded->setOutputSampleRate(48000.0);
+    auto result = ProjectSerializer::load(path.string(), loaded);
+    check(result.ok, "load succeeded");
+
+    Track* l1 = loaded->getTrack(t1);
+    check(l1 != nullptr, "track 1 restored by exact id");
+    check(l1 && l1->name == "Track 1" && l1->channelId == 3, "track 1 state restored");
+    check(l1 && l1->laneIds.size() == 2, "track 1 owns both lanes");
+    check(l1 && l1->laneNumber(loaded->getPlaylistModel().getLaneIDs()[0]) == 1, "lane 1 numbering restored");
+    check(l1 && l1->laneNumber(loaded->getPlaylistModel().getLaneIDs()[1]) == 2, "lane 2 numbering restored");
+    Track* l2 = loaded->getTrack(t2);
+    check(l2 != nullptr && l2->armed, "track 2 restored with arm state");
+    check(l2 && l2->laneNumber(loaded->getPlaylistModel().getLaneIDs()[2]) == 1, "track 2 numbering independent");
+
+    std::filesystem::remove_all(dir);
+}
+
+void testLegacyFileMigration() {
+    std::cout << "[serializer] legacy file migration (one track per lane)\n";
+    const auto dir = std::filesystem::temp_directory_path() / "aestra_track_migration";
+    std::filesystem::create_directories(dir);
+    const auto path = dir / "legacy.aes";
+
+    // Old-format file: lanes with their own stored mixerChannelId, NO tracks
+    // section. The migration must create one Track per lane deterministically
+    // using each lane's OWN stored channel id — never positional.
+    std::string projectJson = R"({
+        "version": 1,
+        "tempo": 120.0,
+        "playhead": 0.0,
+        "sources": [],
+        "patterns": [],
+        "lanes": [
+            {
+                "name": "Lane A",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "mixerChannelId": 5,
+                "clips": [],
+                "automation": []
+            },
+            {
+                "name": "Lane B",
+                "color": "4294967295",
+                "volume": 1.0,
+                "pan": 0.0,
+                "mixerChannelId": 9,
+                "clips": [],
+                "automation": []
+            }
+        ],
+        "arsenal": {"nextId": 1, "units": []}
+    })";
+    std::ofstream out(path);
+    out << projectJson;
+    out.close();
+
+    auto loaded = std::make_shared<TrackManager>();
+    loaded->setOutputSampleRate(48000.0);
+    auto result = ProjectSerializer::load(path.string(), loaded);
+    check(result.ok, "legacy load succeeded");
+
+    const auto laneIds = loaded->getPlaylistModel().getLaneIDs();
+    check(laneIds.size() == 2, "both lanes loaded");
+    auto tracks = loaded->getTracks();
+    check(tracks.size() == 2, "one track per legacy lane");
+
+    Track* trackA = loaded->getTrackForLane(laneIds[0]);
+    Track* trackB = loaded->getTrackForLane(laneIds[1]);
+    check(trackA != nullptr && trackB != nullptr, "every lane resolves to a track");
+    check(trackA != trackB, "lanes own separate tracks");
+    check(trackA && trackA->channelId == 5, "track A routes to lane A's OWN stored channel (5)");
+    check(trackB && trackB->channelId == 9, "track B routes to lane B's OWN stored channel (9)");
+    check(trackA && trackA->laneNumber(laneIds[0]) == 1, "track A numbering starts at 1");
+    check(trackB && trackB->laneNumber(laneIds[1]) == 1, "track B numbering starts at 1");
+
+    std::filesystem::remove_all(dir);
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Track Ownership (FD-14 PR-1) ===\n";
+    testCreateTrackOwnsLane();
+    testAttachLaneTrackLocalNumbering();
+    testTrackArmState();
+    testRestoreTrackExactIds();
+    testSerializeRoundtrip();
+    testLegacyFileMigration();
+
+    if (g_failures == 0) {
+        std::cout << "Track ownership: all green.\n";
+        return 0;
+    }
+    std::cerr << g_failures << " check(s) failed.\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1293,6 +1293,29 @@ else()
 endif()
 
 # Recording Path Test (headless, no audio hardware required)
+# FD-14 PR-1: Track model + lane ownership + load-time migration.
+add_executable(TrackOwnershipTest
+    AestraAudio/TrackOwnershipTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+)
+target_link_libraries(TrackOwnershipTest PRIVATE AestraAudio)
+target_include_directories(TrackOwnershipTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+)
+add_test(NAME TrackOwnershipTest COMMAND TrackOwnershipTest)
+set_tests_properties(TrackOwnershipTest PROPERTIES LABELS "audio;tracks;migration;contract:audio")
+
 add_executable(RecordingPathTest
     AestraAudio/RecordingPathTest.cpp
     ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp

--- a/Tests/Integration/ProjectIdentityStabilityTest.cpp
+++ b/Tests/Integration/ProjectIdentityStabilityTest.cpp
@@ -158,6 +158,10 @@ int main() {
     PlaylistLaneID laneBId = playlist1.createLane("Identity B");
     auto* chanB = tm1->addChannel("Identity B");
     require(laneAId.isValid() && laneBId.isValid() && chanA && chanB, "setup: lanes/channels");
+    // FD-14: lanes belong to Tracks. The fixture creates the ownership layer
+    // the model now expects, with explicit channel associations.
+    tm1->createTrack(laneAId, "Identity A", chanA->getChannelId());
+    tm1->createTrack(laneBId, "Identity B", chanB->getChannelId());
 
     MidiPayload midi;
     MidiNote note;
@@ -227,6 +231,7 @@ int main() {
 
         PlaylistLaneID freshLane = tm2->getPlaylistModel().createLane("PostLoad");
         require(freshLane.isValid(), "post-load lane create failed");
+        tm2->createTrack(freshLane, "PostLoad");
         auto laneIds2 = collectLaneIds(*tm2);
         require(std::count(laneIds2.begin(), laneIds2.end(), freshLane.toString()) == 1,
                 "post-load lane ID must be unique");

--- a/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
+++ b/Tests/Integration/ProjectRoundTripIntegrityTest.cpp
@@ -191,6 +191,8 @@ void testSourcesLanesClipsPatternsRoundTrip() {
     auto lane = playlist.getLane(laneId);
     lane->volume = 0.8f;
     lane->pan = -0.3f;
+    // FD-14: lanes belong to Tracks — the fixture builds the ownership model.
+    tm1->createTrack(laneId, "Test Lane");
 
     auto& patternManager = tm1->getPatternManager();
     Aestra::Audio::MidiPayload payload;
@@ -472,8 +474,11 @@ void testMultipleRoundTripCycles() {
     std::filesystem::path testProject = testDir / "project.aes";
 
     auto tm1 = std::make_shared<Aestra::Audio::TrackManager>();
-    tm1->getPlaylistModel().createLane("Track 1");
-    tm1->getPlaylistModel().createLane("Track 2");
+    Aestra::Audio::PlaylistLaneID lane1 = tm1->getPlaylistModel().createLane("Track 1");
+    Aestra::Audio::PlaylistLaneID lane2 = tm1->getPlaylistModel().createLane("Track 2");
+    // FD-14: lanes belong to Tracks — the fixture builds the ownership model.
+    tm1->createTrack(lane1, "Track 1");
+    tm1->createTrack(lane2, "Track 2");
 
     std::string save1 = serializeProject(*tm1, 128.0, 2.0);
 


### PR DESCRIPTION
Objective:  TS-2 — v0.7.1 producer-loop finishing
Decision:   FD-14 @ 210f9c6
Kind:       planned
Reversal:   —

## Summary

PR-1 of the FD-14 Track/Lane/Channel ownership migration. Introduces the first real ownership layer: **Track owns Lanes by stable ID; Track routes to a Channel; Lane belongs to a Track.** No positional pairings anywhere (the contract's forbidden patterns are structurally absent).

- `Models/Track.h` (new): `{trackId, channelId, name, armed, activeLaneId, laneIds[]}` + track-local lane numbering.
- `PlaylistLane` gains `trackId` (ownership reference).
- `TrackManager`: `createTrack` / `getTrack` / `getTrackForLane` / `attachLaneToTrack` / `setTrackArmed` / `getTrackArmedCount` / `restoreTrack` (exact-id restore for loads).
- **Legacy `using Track = MixerChannel` alias removed** (zero callers) + legacy `getTrack(size_t)` removed — the name `Track` now means the FD-14 entity.
- Serializer: additive `tracks` array + per-lane `trackId`; load restores exact ids; **legacy files migrate deterministically — one Track per lane, channel = the lane's OWN stored `mixerChannelId`** (captured per-lane from the file, never positional).
- App wiring: `addTrack` and file-drop lane creation now create the lane AND its owning Track.

## Why

FD-14's Phase 1 proved Track doesn't exist architecturally. This PR inserts the ownership layer without touching routing (patterns keep their destinations), recording identity (PR-2), or the automation contract. Baseline Section A remains untouched; Section B gains its first flipped acceptance via the new TrackOwnershipTest.

## Testing Performed

- New `TrackOwnershipTest` (contract:audio), **31/31 green**: model ownership, attach + track-local numbering, arm state, exact-id restore, serialize roundtrip (ids/ownership/numbering/arm/channel), legacy migration (one track per lane, own stored channels, independent numbering).
- `ProjectIdentityStabilityTest` fixed-point case exposed a determinism bug: `getTracks()` iterated an unordered_map — track order differed between saves. Fixed: sorted by trackId. Byte-identical fixed point restored.
- Legacy-alias straggler found by the build: `MixerView::ChannelStrip` used `shared_ptr<Track>` (the alias) — now `shared_ptr<MixerChannel>` (it IS a channel strip).
- Full suite + app build pending in CI.

## Authority / invariant

What became the single source of truth? Lane ownership lives in `lane.trackId` + `Track.laneIds` — stable IDs, set explicitly at creation/restore, never derived from indices.

What now prevents that truth from drifting again? The ownership API is the only path that mutates either side; `TrackOwnershipTest` pins ownership, numbering, restore and migration; the legacy alias removal makes a second `Track` meaning impossible.

## Producer note

None

## Docs Updated?

- [ ] Yes
- [ ] No
- [x] Not needed (contract + FD-14 in Aestra-Internals)

## Risk / Rollback Notes

- Additive serialization (old files load via migration; new files carry the tracks section). No format bump.
- Deterministic track serialization order pinned by the identity fixed-point test.
- The `Track` alias removal is verified by the full build (MixerView was the one straggler, fixed to `MixerChannel`).
- Recording identity still channel-based until PR-2 — recorded take lanes are unowned until then (attached in PR-2 by the armed track).
- App addTrack's track creation is direct (not yet command-backed); PR-2/3 makes the full add-track+record path transaction-coherent.
