### PR TITLE
feat: selection-based step editing for the Arsenal step sequencer

### DIFF
--- a/AestraUI/Widgets/UnitNameLabel.h
+++ b/AestraUI/Widgets/UnitNameLabel.h
@@ -23,6 +23,8 @@ public:
 
     void setUnitName(const std::string& name);
     void setUnitType(Aestra::Audio::UnitType type);
+    /** @brief True while an inline rename is active (row key handling must not steal Delete/Backspace). */
+    bool isRenaming() const { return m_isRenaming; }
 
     /** @brief Callback fired on double-click to open the unit/plugin editor. */
     std::function<void()> m_onOpenEditor;

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -1013,8 +1013,10 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                                                       now.time_since_epoch())
                                                       .count();
                                 const bool isDoubleClick =
-                                    (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
+                                    ((nowMs - m_lastClipClickTimeMs < 400) && m_lastClipClickStep == step) ||
+                                    event.doubleClick;
                                 m_lastClipClickTimeMs = nowMs;
+                                m_lastClipClickStep = step;
                                 if (isDoubleClick) {
                                     if (m_onLoadUnitSample) {
                                         m_onLoadUnitSample(m_unitId);
@@ -1161,8 +1163,10 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
     if (usesStepSequencerForType(m_type)) {
         auto now = std::chrono::steady_clock::now();
         long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-        const bool isDoubleClick = (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
+        const bool isDoubleClick =
+            ((nowMs - m_lastClipClickTimeMs < 400) && m_lastClipClickStep == -1) || event.doubleClick;
         m_lastClipClickTimeMs = nowMs;
+        m_lastClipClickStep = -1;
         if (isDoubleClick && m_audioClip.empty() && m_pluginId.empty()) {
             if (m_onLoadUnitSample) {
                 m_onLoadUnitSample(m_unitId);

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -228,8 +228,8 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
         cardBg = theme.getColor("accentPrimary").withAlpha(0.18f);
         border = theme.getColor("accentPrimary").withAlpha(0.95f);
     } else if (m_isSelected) {
-        cardBg = unitAccent.withAlpha(0.10f);
-        border = unitAccent.withAlpha(0.72f);
+        cardBg = unitAccent.withAlpha(0.06f);
+        border = unitAccent.withAlpha(0.28f);
     } else if (m_isHovered) {
         cardBg = theme.getColor("surfaceRaised");
         border = theme.getColor("accentPrimary").withAlpha(0.22f);
@@ -255,7 +255,7 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
                       NUIPoint(separatorX, cardBounds.y + cardBounds.height - 8.0f), 1.0f,
                       theme.getColor("borderSubtle").withAlpha(0.55f));
 
-    NUIRect contextRect(separatorX + 8.0f, cardBounds.y + 6.0f, cardBounds.right() - separatorX - 14.0f,
+    NUIRect contextRect(separatorX + 8.0f, cardBounds.y + 6.0f, cardBounds.right() - separatorX - 2.0f,
                         cardBounds.height - 12.0f);
     drawContextBlock(renderer, contextRect);
     renderer.clearClipRect();
@@ -263,7 +263,7 @@ void UnitRow::drawContent(NUIRenderer& renderer) {
 
 void UnitRow::drawDragHandle(NUIRenderer& renderer, const NUIRect& bounds) {
     auto& theme = NUIThemeManager::getInstance();
-    const NUIColor gripColor = theme.getColor("textSecondary").withAlpha(m_isHovered ? 0.78f : 0.45f);
+    const NUIColor gripColor = theme.getColor("textSecondary").withAlpha(m_isHovered || m_isSelected ? 0.70f : 0.28f);
     const float clusterX = bounds.x + bounds.width * 0.5f - 3.0f;
     const float clusterY = bounds.y + bounds.height * 0.5f - 6.0f;
     for (int row = 0; row < 3; ++row) {
@@ -310,12 +310,17 @@ void UnitRow::drawArmIcon(NUIRenderer& renderer, const NUIRect& bounds, bool act
     }
 }
 
-void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active) {
+void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active, bool engaged) {
     auto& theme = NUIThemeManager::getInstance();
 
     NUIColor bgColor = active ? theme.getColor("warning") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
-    NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
+    NUIColor textColor = active
+                             ? theme.getContrastColor(bgColor)
+                             : (engaged ? theme.getColor("textSecondary")
+                                        : theme.getColor("textDisabled").withAlpha(0.55f));
+    NUIColor borderColor = active ? bgColor
+                                  : (engaged ? theme.getColor("textDisabled")
+                                             : theme.getColor("textDisabled").withAlpha(0.40f));
 
     // Circular Button
     float radius = theme.getRadius("xs") * 2.0f;
@@ -331,12 +336,17 @@ void UnitRow::drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool ac
     renderer.drawTextCentered("M", bounds, 10.0f, textColor);
 }
 
-void UnitRow::drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active) {
+void UnitRow::drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active, bool engaged) {
     auto& theme = NUIThemeManager::getInstance();
 
     NUIColor bgColor = active ? theme.getColor("success") : theme.getColor("backgroundPrimary");
-    NUIColor textColor = active ? theme.getContrastColor(bgColor) : theme.getColor("textSecondary");
-    NUIColor borderColor = active ? bgColor : theme.getColor("textDisabled");
+    NUIColor textColor = active
+                             ? theme.getContrastColor(bgColor)
+                             : (engaged ? theme.getColor("textSecondary")
+                                        : theme.getColor("textDisabled").withAlpha(0.55f));
+    NUIColor borderColor = active ? bgColor
+                                  : (engaged ? theme.getColor("textDisabled")
+                                             : theme.getColor("textDisabled").withAlpha(0.40f));
 
     // Circular Button
     float radius = theme.getRadius("xs") * 2.0f;
@@ -388,21 +398,17 @@ std::array<NUIRect, 3> UnitRow::controlPillRects(const NUIRect& controlBounds) c
 
 void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     auto& theme = NUIThemeManager::getInstance();
-    bool hasContent = !m_pluginId.empty() || !m_audioClip.empty();
-    if (!hasContent && m_patternId.isValid()) {
-        if (auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId); pattern && pattern->isMidi()) {
-            const auto& midi = std::get<Aestra::Audio::MidiPayload>(pattern->payload);
-            hasContent = std::any_of(midi.notes.begin(), midi.notes.end(), [this](const Aestra::Audio::MidiNote& note) {
-                return note.unitId == m_unitId || note.unitId == 0;
-            });
-        }
-    }
-    const float centerY = bounds.y + bounds.height * 0.5f;
     const float nameX = bounds.x + 12.0f;
     const NUIColor unitAccent = colorFromUnitValue(m_color);
+    const bool engaged = m_isHovered || m_isSelected;
 
-    renderer.fillCircle(NUIPoint(nameX, bounds.y + 18.0f), 3.0f,
-                        m_isEnabled ? unitAccent : theme.getColor("textDisabled"));
+    // Center the status dot on the primary name line ("Sampler 2"), using the
+    // same line-height metric the renderer uses for vertical text centering,
+    // so it reads as part of the label, not a top-attached status indicator.
+    const float nameTopY = m_nameLabel ? m_nameLabel->getBounds().y + 3.0f : bounds.y + 11.0f;
+    const float nameLineCenterY = nameTopY + renderer.getFontMetrics(12.0f).lineHeight * 0.5f;
+    renderer.fillCircle(NUIPoint(nameX, nameLineCenterY), 3.0f,
+                        m_isEnabled ? unitAccent : theme.getColor("textDisabled").withAlpha(0.45f));
 
     // Name + type label are rendered by the UnitNameLabel child component.
 
@@ -412,26 +418,17 @@ void UnitRow::drawControlBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     const NUIRect& soloRect = pills[2];
     const NUIColor routeFill = m_mixerChannelId == Aestra::Audio::MASTER_MIXER_CHANNEL_ID
                                    ? theme.getColor("surfaceTertiary")
-                                   : unitAccent.withAlpha(0.16f);
+                                   : unitAccent.withAlpha(engaged ? 0.16f : 0.07f);
     const NUIColor routeStroke =
-        m_mixerRouteShortLabel == "!" ? theme.getColor("error").withAlpha(0.75f) : unitAccent.withAlpha(0.42f);
+        m_mixerRouteShortLabel == "!" ? theme.getColor("error").withAlpha(0.75f)
+                                      : unitAccent.withAlpha(engaged ? 0.42f : 0.20f);
     renderer.fillRoundedRect(routeRect, 4.0f, routeFill);
     renderer.strokeRoundedRect(routeRect, 4.0f, 1.0f, routeStroke);
     renderer.drawTextCentered(m_mixerRouteShortLabel, routeRect, m_density == Density::Minimal ? 7.5f : 9.0f,
-                              theme.getColor("textPrimary").withAlpha(0.9f));
-    drawMuteIcon(renderer, muteRect, m_isMuted);
-    drawSoloIcon(renderer, soloRect, m_isSolo);
+                              theme.getColor("textPrimary").withAlpha(engaged ? 0.9f : 0.45f));
+    drawMuteIcon(renderer, muteRect, m_isMuted, engaged);
+    drawSoloIcon(renderer, soloRect, m_isSolo, engaged);
 
-    if (m_density == Density::Full) {
-        const float indicatorX = bounds.right() - 18.0f;
-        for (int i = 0; i < 3; ++i) {
-            const float h = 4.0f + i * 3.0f;
-            const NUIRect bar(indicatorX + i * 4.0f, bounds.y + 28.0f - h * 0.5f, 2.0f, h);
-            const NUIColor color = hasContent ? theme.getColor("accentPrimary").withAlpha(0.75f - i * 0.12f)
-                                              : theme.getColor("textDisabled").withAlpha(0.28f);
-            renderer.fillRoundedRect(bar, 1.0f, color);
-        }
-    }
 }
 
 void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
@@ -457,7 +454,7 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     // === Step Grid Layout ===
     float availWidth = timelineStrip.width;
     float stepWidth = gridStepWidth(availWidth);
-    float totalWidth = stepWidth * m_stepCount;
+    float totalWidth = stepWidth * m_stepCount + static_cast<float>((m_stepCount + 3) / 4) * kStepGroupGap;
 
     // Clamp scroll
     float maxScroll = std::max(0.0f, totalWidth - availWidth);
@@ -512,8 +509,8 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
     const NUIColor playheadAccent = theme.getColor("accentPrimary");
 
     if (m_type == Aestra::Audio::UnitType::Sampler && !noteRollMode) {
-        const NUIColor inactiveFill = theme.getColor("surfaceTertiary");
-        const NUIColor inactiveStroke = theme.getColor("border").withAlpha(0.10f);
+        const NUIColor inactiveFill = theme.getColor("surfaceTertiary").lightened(0.05f);
+        const NUIColor inactiveStroke = theme.getColor("border").withAlpha(0.14f);
         const NUIColor activeFill = theme.getColor("primary");
         const float cellGap = 3.0f;
         const float cellRadius = 3.0f;
@@ -521,7 +518,8 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
         const float cellY = timelineStrip.y + (timelineStrip.height - cellHeight) * 0.5f;
 
         for (int step = 0; step < m_stepCount; ++step) {
-            const float cellX = timelineStrip.x + (step * stepWidth) - m_scrollX + (cellGap * 0.5f);
+            const float cellX = timelineStrip.x + (step * stepWidth) + static_cast<float>(step / 4) * kStepGroupGap - m_scrollX +
+                        (cellGap * 0.5f);
             // Do not exceed the step advance in narrow layouts (triage 2026-08-14).
             const float cellWidth = std::min(stepWidth, std::max(2.0f, stepWidth - cellGap));
             if (cellX + cellWidth < timelineStrip.x || cellX > timelineStrip.right()) {
@@ -530,10 +528,17 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
 
             const bool isActive = std::binary_search(activeSteps.begin(), activeSteps.end(), step);
             const bool isPlayhead = (step == playStep);
+            const bool isSelected = isStepSelected(step);
             NUIRect cellRect(cellX, cellY, cellWidth, cellHeight);
             NUIColor cellFill = isActive ? activeFill : inactiveFill;
+            if (((step / 4) & 1) != 0) {
+                cellFill = NUIColor::lerp(cellFill, theme.getColor("accentPrimary"), 0.10f);
+            }
             if (isPlayhead && isActive) {
                 cellFill = activeFill.lightened(0.35f); // note lights up under the playhead
+            }
+            if (isSelected) {
+                cellFill = cellFill.lightened(0.28f); // selection brightens the note
             }
             if (isActive) {
                 // Velocity meter: dim base + a brighter bar rising from the
@@ -548,21 +553,35 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
                 renderer.fillRoundedRect(cellRect, cellRadius, cellFill);
             }
             renderer.strokeRoundedRect(cellRect, cellRadius, 1.0f, inactiveStroke);
+            if (isActive && !isSelected) {
+                // Subtle inner rim keeps adjacent active pads legible as
+                // individual steps instead of one merged bar.
+                renderer.strokeRoundedRect(cellRect, cellRadius, 1.0f,
+                                           activeFill.lightened(0.25f).withAlpha(0.30f));
+            }
+            if (isSelected) {
+                // Selection halo: expanded light ring, distinct from the
+                // playhead (on-edge accent ring) and the active rim.
+                const NUIRect haloRect(cellRect.x - 1.5f, cellRect.y - 1.5f,
+                                       cellRect.width + 3.0f, cellRect.height + 3.0f);
+                renderer.strokeRoundedRect(haloRect, cellRadius + 1.5f, 1.5f,
+                                           theme.getColor("textPrimary").withAlpha(0.9f));
+            }
+            if ((step + 1) % 4 == 0 && step + 1 < m_stepCount) {
+                const float seamX = cellRect.right() + (cellGap + kStepGroupGap) * 0.5f;
+                renderer.drawLine(NUIPoint(seamX, timelineStrip.y + 2.0f),
+                                  NUIPoint(seamX, timelineStrip.bottom() - 2.0f), 1.0f,
+                                  theme.getColor("border").withAlpha(0.18f));
+            }
             if (isPlayhead) {
                 renderer.strokeRoundedRect(cellRect, cellRadius, 1.5f,
                                            playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
             }
 
-            if ((step + 1) % 4 == 0 && step + 1 < m_stepCount) {
-                const float markerX = cellRect.right() + (cellGap * 0.5f);
-                renderer.drawLine(NUIPoint(markerX, timelineStrip.y + 2.0f),
-                                  NUIPoint(markerX, timelineStrip.bottom() - 2.0f), 1.0f,
-                                  theme.getColor("border").withAlpha(0.12f));
-            }
         }
     } else if (m_type == Aestra::Audio::UnitType::PitchedSampler) {
-        const NUIColor inactiveFill = theme.getColor("surfaceTertiary");
-        const NUIColor inactiveStroke = theme.getColor("border").withAlpha(0.10f);
+        const NUIColor inactiveFill = theme.getColor("surfaceTertiary").lightened(0.05f);
+        const NUIColor inactiveStroke = theme.getColor("border").withAlpha(0.14f);
         const NUIColor activeFill = theme.getColor("primary");
         const NUIColor pitchText = theme.getColor("textSecondary").withAlpha(0.72f);
         const float cellGap = 3.0f;
@@ -575,7 +594,8 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
 
         std::vector<NUIPoint> slidePoints;
         for (int step = 0; step < m_stepCount; ++step) {
-            const float cellX = timelineStrip.x + (step * stepWidth) - m_scrollX + (cellGap * 0.5f);
+            const float cellX = timelineStrip.x + (step * stepWidth) + static_cast<float>(step / 4) * kStepGroupGap - m_scrollX +
+                        (cellGap * 0.5f);
             // Do not exceed the step advance in narrow layouts (triage 2026-08-14).
             const float cellWidth = std::min(stepWidth, std::max(2.0f, stepWidth - cellGap));
             if (cellX + cellWidth < timelineStrip.x || cellX > timelineStrip.right()) {
@@ -583,13 +603,32 @@ void UnitRow::drawContextBlock(NUIRenderer& renderer, const NUIRect& bounds) {
             }
             const bool isActive = std::binary_search(activeSteps.begin(), activeSteps.end(), step);
             const bool isPlayhead = (step == playStep);
+            const bool isSelected = isStepSelected(step);
             NUIRect cellRect(cellX, topY, cellWidth, topHeight);
             NUIColor cellFill = isActive ? activeFill : inactiveFill;
+            if (((step / 4) & 1) != 0) {
+                cellFill = NUIColor::lerp(cellFill, theme.getColor("accentPrimary"), 0.10f);
+            }
             if (isPlayhead && isActive) {
                 cellFill = activeFill.lightened(0.35f);
             }
+            if (isSelected) {
+                cellFill = cellFill.lightened(0.28f); // selection brightens the note
+            }
             renderer.fillRoundedRect(cellRect, 3.0f, cellFill);
             renderer.strokeRoundedRect(cellRect, 3.0f, 1.0f, inactiveStroke);
+            if (isSelected) {
+                const NUIRect haloRect(cellRect.x - 1.5f, cellRect.y - 1.5f,
+                                       cellRect.width + 3.0f, cellRect.height + 3.0f);
+                renderer.strokeRoundedRect(haloRect, 4.5f, 1.5f,
+                                           theme.getColor("textPrimary").withAlpha(0.9f));
+            }
+            if ((step + 1) % 4 == 0 && step + 1 < m_stepCount) {
+                const float seamX = cellRect.right() + (cellGap + kStepGroupGap) * 0.5f;
+                renderer.drawLine(NUIPoint(seamX, timelineStrip.y + 2.0f),
+                                  NUIPoint(seamX, timelineStrip.bottom() - 2.0f), 1.0f,
+                                  theme.getColor("border").withAlpha(0.18f));
+            }
             if (isPlayhead) {
                 renderer.strokeRoundedRect(cellRect, 3.0f, 1.5f, playheadAccent.withAlpha(isActive ? 0.95f : 0.45f));
             }
@@ -769,7 +808,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     m_controlWidth = std::clamp(bounds.width * 0.38f, controlFloorForDensity(bounds.width), 312.0f);
     const NUIRect localControlRect(42.0f, 0.0f, std::max(0.0f, m_controlWidth - 48.0f), 56.0f);
     const float separatorX = m_controlWidth;
-    const NUIRect localContextRect(separatorX + 8.0f, 6.0f, std::max(0.0f, bounds.width - (separatorX + 14.0f)), 44.0f);
+    const NUIRect localContextRect(separatorX + 8.0f, 6.0f, std::max(0.0f, bounds.width - (separatorX + 2.0f)), 44.0f);
     // Step math must use the same geometry the pads are DRAWN with:
     // drawContextBlock insets the context rect by 6px lane padding before
     // laying out steps. Resolving against the un-inset rect skewed the step
@@ -787,8 +826,20 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         if (stepWidth <= 0.0f || relativeX < 0.0f || relativeX >= availWidth) {
             return -1;
         }
-        float contentX = relativeX + m_scrollX;
-        return static_cast<int>(std::floor(contentX / stepWidth));
+        // Exact pad containment: 4-step groups carry a structural gap, and the
+        // 3px lane gap between pads is not clickable — only the drawn cell
+        // itself registers (bounded, 32 steps max -> trivial loop).
+        constexpr float kCellGap = 3.0f;
+        const float contentX = relativeX + m_scrollX;
+        for (int s = 0; s < m_stepCount; ++s) {
+            const float slotLeft = s * stepWidth + static_cast<float>(s / 4) * kStepGroupGap;
+            const float cellLeft = slotLeft + kCellGap * 0.5f;
+            const float cellWidth = std::min(stepWidth, std::max(2.0f, stepWidth - kCellGap));
+            if (contentX >= cellLeft && contentX < cellLeft + cellWidth) {
+                return s;
+            }
+        }
+        return -1;
     };
 
     // === Scroll Handling ===
@@ -851,11 +902,23 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
     // === Step-grid gesture session ===
     if (m_velEditStep >= 0) {
         if (event.released || event.type == NUIMouseEventType::Up) {
-            // A stationary left click toggles the initial step. Empty steps
-            // were placed on press for immediate feedback; active ones are
-            // removed here once we know the gesture was not a velocity edit.
-            if (m_stepGestureMode == StepGestureMode::Pending && m_velEditWasActive) {
-                m_stepGestureChanged |= removeStepNote(m_velEditStep);
+            // A stationary click selects only when it lands on an already-
+            // placed note — placing a new note (press on an empty pad) must
+            // never hijack the selection. Paint is placement-only; velocity
+            // drags on pre-existing notes select them like a click would.
+            if (m_stepGestureMode == StepGestureMode::Pending && m_stepGestureWasActive) {
+                applyClickSelection(m_velEditStep, m_stepGestureShiftHeld);
+            } else if (m_stepGestureMode == StepGestureMode::Velocity && m_stepGestureWasActive) {
+                applyClickSelection(m_velEditStep, false);
+            } else if (m_stepGestureMode == StepGestureMode::Erase) {
+                // Right-drag erase: drop erased steps from the selection.
+                m_selectedSteps.erase(
+                    std::remove_if(m_selectedSteps.begin(), m_selectedSteps.end(), [this](int s) {
+                        float v = kDefaultStepVelocity;
+                        return !stepHasNote(s, v);
+                    }),
+                    m_selectedSteps.end());
+                notifyStepSelectionChanged();
             }
             if (m_stepGestureChanged && m_onPatternEdited && m_patternId.isValid()) {
                 m_onPatternEdited(m_patternId);
@@ -876,10 +939,11 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
             const float dy = m_velEditStartY - event.position.y; // up = louder
             if (m_stepGestureMode == StepGestureMode::Pending && std::max(std::abs(dx), std::abs(dy)) > 3.0f) {
                 if (std::abs(dx) >= std::abs(dy)) {
-                    m_stepGestureMode = m_velEditWasActive ? StepGestureMode::Erase : StepGestureMode::Paint;
-                    if (m_stepGestureMode == StepGestureMode::Erase) {
-                        m_stepGestureChanged |= removeStepNote(m_velEditStep);
-                    }
+                    // Horizontal drag paints from any starting pad. Erasing is
+                    // now Delete/Backspace (selection-based editing), so a
+                    // drag from an active note extends the phrase instead of
+                    // destroying it.
+                    m_stepGestureMode = StepGestureMode::Paint;
                 } else {
                     m_stepGestureMode = StepGestureMode::Velocity;
                 }
@@ -931,14 +995,33 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     handleControlClick(event, localControlRect);
                     return true;
                 } else if (localContextRect.contains(localPoint)) {
-                    // Loaded step grids support one continuous gesture:
+                    // Step grids support one continuous gesture on every pad:
                     // vertical movement edits velocity, horizontal movement
-                    // paints or erases, and a stationary click toggles.
-                    const bool hasContent = !m_audioClip.empty() || !m_pluginId.empty();
-                    if (usesStepSequencerForType(m_type) && !shouldUseNoteRoll() && hasContent &&
-                        m_patternId.isValid() && m_trackManager) {
+                    // paints, and a stationary click creates/selects. The
+                    // pattern (not a loaded sample) is what makes pads real —
+                    // notes-only units must edit identically to loaded ones.
+                    if (usesStepSequencerForType(m_type) && !shouldUseNoteRoll() && m_patternId.isValid() &&
+                        m_trackManager) {
                         const int step = resolveGridStep(localPoint, localGridRect);
                         if (step >= 0 && step < m_stepCount) {
+                            // Double-click on a unit without a sample opens the
+                            // file picker (fast onboarding). Units with a
+                            // sample treat rapid taps as step programming.
+                            if (m_audioClip.empty() && m_pluginId.empty()) {
+                                auto now = std::chrono::steady_clock::now();
+                                long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                                      now.time_since_epoch())
+                                                      .count();
+                                const bool isDoubleClick =
+                                    (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
+                                m_lastClipClickTimeMs = nowMs;
+                                if (isDoubleClick) {
+                                    if (m_onLoadUnitSample) {
+                                        m_onLoadUnitSample(m_unitId);
+                                    }
+                                    return true;
+                                }
+                            }
                             float vel = kDefaultStepVelocity;
                             const bool active = stepHasNote(step, vel);
                             m_velEditStep = step;
@@ -946,8 +1029,9 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                             m_stepGestureStartX = event.position.x;
                             m_velEditStartY = event.position.y;
                             m_stepGestureMode = StepGestureMode::Pending;
-                            m_velEditWasActive = active;
                             m_stepGestureChanged = false;
+                            m_stepGestureShiftHeld = (event.modifiers & NUIModifiers::Shift) != 0;
+                            m_stepGestureWasActive = active;
                             if (!active) {
                                 m_stepGestureChanged = placeStepNote(step);
                                 vel = kDefaultStepVelocity;
@@ -966,10 +1050,18 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
         // === Right-click (row body, outside name label which is handled by UnitNameLabel child) ===
         if (event.button == NUIMouseButton::Right) {
             if (bounds.contains(event.position)) {
+                if (localControlRect.contains(localPoint)) {
+                    const auto pills = controlPillRects(localControlRect);
+                    if (pills[0].contains(localPoint)) {
+                        showMixerRoutingMenu(event.position);
+                        return true;
+                    }
+                }
+
                 // Right-drag across a step grid erases every crossed pad.
-                // Outside the grid, right-click keeps the row context menu.
-                const bool hasContent = !m_audioClip.empty() || !m_pluginId.empty();
-                if (localContextRect.contains(localPoint) && hasContent && usesStepSequencerForType(m_type) &&
+                // Right-click raises the row context menu only from the name
+                // label (far left) — the grid never opens menus.
+                if (localContextRect.contains(localPoint) && usesStepSequencerForType(m_type) &&
                     !shouldUseNoteRoll() && m_patternId.isValid() && m_trackManager) {
                     const int stepIndex = resolveGridStep(localPoint, localGridRect);
                     if (stepIndex >= 0 && stepIndex < m_stepCount) {
@@ -979,14 +1071,16 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                         m_stepGestureStartX = event.position.x;
                         m_velEditStartY = event.position.y;
                         m_velEditBaseVelocity = velocity;
-                        m_velEditWasActive = stepHasNote(stepIndex, velocity);
                         m_stepGestureMode = StepGestureMode::Erase;
                         m_stepGestureChanged = removeStepNote(stepIndex);
                         invalidateVisuals();
                         return true;
                     }
                 }
-                showRowContextMenu(event.position);
+                // Row context menu lives on the far-left text (name) area only.
+                if (m_nameLabel && m_nameLabel->getBounds().contains(localPoint)) {
+                    showRowContextMenu(event.position);
+                }
                 return true;
             }
         }
@@ -1022,18 +1116,18 @@ void UnitRow::handleControlClick(const NUIMouseEvent& event, const NUIRect& boun
     const NUIRect& muteRect = pills[1];
     const NUIRect& soloRect = pills[2];
     const NUIRect& routeRect = pills[0];
-    const NUIPoint localPoint(localX, localY);
-    if (routeRect.contains(localPoint)) {
+    const NUIPoint rowLocalPoint(rowLocalX, rowLocalY);
+    if (routeRect.contains(rowLocalPoint)) {
         showMixerRoutingMenu(event.position);
         return;
     }
-    if (muteRect.contains(localPoint)) {
+    if (muteRect.contains(rowLocalPoint)) {
         m_manager.setUnitMute(m_unitId, !m_isMuted);
         updateState();
         invalidateVisuals();
         return;
     }
-    if (soloRect.contains(localPoint)) {
+    if (soloRect.contains(rowLocalPoint)) {
         m_manager.setUnitSolo(m_unitId, !m_isSolo);
         updateState();
         invalidateVisuals();
@@ -1059,46 +1153,286 @@ void UnitRow::handleContextClick(const NUIMouseEvent& event, const NUIRect& boun
         return;
     }
 
-    // === Double-click to load sample (EMPTY units only) ===
-    // With a sample loaded, rapid taps are step programming — treating any two
-    // grid clicks within 400ms as "open the file picker" made fast rhythmic
-    // tap placement randomly hijack the second click.
-    auto now = std::chrono::steady_clock::now();
-    long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-    bool isDoubleClick = (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
-    m_lastClipClickTimeMs = nowMs;
-
-    if (isDoubleClick && m_audioClip.empty() && m_pluginId.empty()) {
-        // Empty unit: double-click is a shortcut to give it a sample.
-        if (m_onLoadUnitSample)
-            m_onLoadUnitSample(m_unitId);
+    // === Step-grid rows: clicks that miss a pad do nothing ===
+    // Selection-based editing only creates/selects on a real pad hit; lane
+    // padding and cell gaps are dead space now (they used to toggle the
+    // nearest pad, which made left-clicks erase active notes). Double-click
+    // on a unit without a sample still opens the file picker.
+    if (usesStepSequencerForType(m_type)) {
+        auto now = std::chrono::steady_clock::now();
+        long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+        const bool isDoubleClick = (nowMs - m_lastClipClickTimeMs < 400) || event.doubleClick;
+        m_lastClipClickTimeMs = nowMs;
+        if (isDoubleClick && m_audioClip.empty() && m_pluginId.empty()) {
+            if (m_onLoadUnitSample) {
+                m_onLoadUnitSample(m_unitId);
+            }
+        }
         return;
     }
+}
 
-    // === Single click: Grid Interaction - Toggle Steps ===
-    float relativeX = localPoint.x;
-    float availWidth = bounds.width;
-    float stepWidth = gridStepWidth(availWidth);
+bool UnitRow::isStepSelected(int step) const {
+    return std::binary_search(m_selectedSteps.begin(), m_selectedSteps.end(), step);
+}
 
-    float contentX = relativeX + m_scrollX;
-    int stepIndex = static_cast<int>(contentX / stepWidth);
-
-    if (stepIndex >= 0 && stepIndex < m_stepCount && m_patternId.isValid()) {
-        // Plain toggle: place if empty, remove if present. Silent — the running
-        // loop hot-swaps the change on its next pass, which is the wanted
-        // feedback. (The Sampler grid arms a velocity-drag session instead and
-        // never reaches here; this path covers pitched samplers + fallbacks.)
-        float dummy = kDefaultStepVelocity;
-        if (stepHasNote(stepIndex, dummy)) {
-            removeStepNote(stepIndex);
-        } else {
-            placeStepNote(stepIndex);
+void UnitRow::applyClickSelection(int step, bool additive) {
+    if (step < 0 || step >= m_stepCount) {
+        return;
+    }
+    if (additive) {
+        if (!isStepSelected(step)) {
+            m_selectedSteps.push_back(step);
+            std::sort(m_selectedSteps.begin(), m_selectedSteps.end());
+            notifyStepSelectionChanged();
+            invalidateVisuals();
         }
-        if (m_onPatternEdited) {
-            m_onPatternEdited(m_patternId);
-        }
+    } else if (m_selectedSteps.size() != 1 || m_selectedSteps[0] != step) {
+        m_selectedSteps = {step};
+        notifyStepSelectionChanged();
         invalidateVisuals();
     }
+}
+
+void UnitRow::applyRangeSelection(int firstStep, int lastStep) {
+    firstStep = std::max(0, firstStep);
+    lastStep = std::min(m_stepCount - 1, lastStep);
+    if (lastStep < firstStep) {
+        return;
+    }
+    m_selectedSteps.clear();
+    for (int s = firstStep; s <= lastStep; ++s) {
+        m_selectedSteps.push_back(s);
+    }
+    notifyStepSelectionChanged();
+    invalidateVisuals();
+}
+
+void UnitRow::notifyStepSelectionChanged() {
+    if (m_onStepSelectionChanged) {
+        m_onStepSelectionChanged(m_unitId, m_selectedSteps);
+    }
+}
+
+void UnitRow::duplicateSelection() {
+    if (m_selectedSteps.empty() || !m_patternId.isValid() || !m_trackManager) {
+        return;
+    }
+    const int minStep = *std::min_element(m_selectedSteps.begin(), m_selectedSteps.end());
+    const int maxStep = *std::max_element(m_selectedSteps.begin(), m_selectedSteps.end());
+    const int span = maxStep - minStep + 1; // occupied span → duplicate starts right after it
+
+    std::vector<int> newSelection;
+    bool changed = false;
+    m_trackManager->getPatternManager().applyPatch(m_patternId,
+        [this, span, &newSelection, &changed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) {
+                return;
+            }
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            const auto covers = [&midi](Aestra::Audio::UnitID unitId, double beat) {
+                for (const auto& n : midi.notes) {
+                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                    if (n.unitId == unitId && beat >= n.startBeat - 0.01 && beat < endBeat - 0.01) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            for (const int step : m_selectedSteps) {
+                const int dstStep = step + span;
+                if (dstStep >= m_stepCount) {
+                    continue; // clipped at the pattern end — never grows the loop silently
+                }
+                const double srcBeat = step * 0.25;
+                const double dstBeat = dstStep * 0.25;
+                const Aestra::Audio::MidiNote* src = nullptr;
+                for (const auto& n : midi.notes) {
+                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                    if (n.unitId == m_unitId && srcBeat >= n.startBeat - 0.01 && srcBeat < endBeat - 0.01) {
+                        src = &n;
+                        break;
+                    }
+                }
+                if (!src || covers(m_unitId, dstBeat)) {
+                    continue; // no source note, or destination already occupied
+                }
+                Aestra::Audio::MidiNote copy = *src; // pitch/duration/velocity preserved
+                copy.startBeat = dstBeat;
+                midi.notes.push_back(copy);
+                newSelection.push_back(dstStep);
+                changed = true;
+            }
+        });
+    if (!changed) {
+        return;
+    }
+    m_selectedSteps = std::move(newSelection); // sorted: constant offset over a sorted selection
+    notifyStepSelectionChanged();
+    invalidateVisuals();
+    if (m_onPatternEdited) {
+        m_onPatternEdited(m_patternId);
+    }
+}
+
+void UnitRow::deleteSelection() {
+    if (m_selectedSteps.empty() || !m_patternId.isValid() || !m_trackManager) {
+        return;
+    }
+    bool changed = false;
+    m_trackManager->getPatternManager().applyPatch(m_patternId,
+        [this, &changed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) {
+                return;
+            }
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            const auto stepCovered = [this](const Aestra::Audio::MidiNote& n) {
+                if (n.unitId != m_unitId) {
+                    return false;
+                }
+                const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                for (const int s : m_selectedSteps) {
+                    const double beat = s * 0.25;
+                    if (beat >= n.startBeat - 0.01 && beat < endBeat - 0.01) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            const size_t before = midi.notes.size();
+            midi.notes.erase(std::remove_if(midi.notes.begin(), midi.notes.end(), stepCovered), midi.notes.end());
+            changed = midi.notes.size() != before;
+        });
+    m_selectedSteps.clear();
+    notifyStepSelectionChanged();
+    invalidateVisuals();
+    if (changed && m_onPatternEdited) {
+        m_onPatternEdited(m_patternId);
+    }
+}
+
+void UnitRow::moveSelection(int stepDelta) {
+    if (m_selectedSteps.empty() || !m_patternId.isValid() || !m_trackManager) {
+        return;
+    }
+    const int dir = stepDelta > 0 ? 1 : -1;
+    bool changed = false;
+    std::vector<int> newSelection;
+    m_trackManager->getPatternManager().applyPatch(m_patternId,
+        [this, dir, &newSelection, &changed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) {
+                return;
+            }
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            // Process in movement direction so vacated slots are reusable and
+            // blocked cascades resolve (right: high→low; left: low→high).
+            std::vector<int> ordered = m_selectedSteps;
+            if (dir > 0) {
+                std::sort(ordered.rbegin(), ordered.rend());
+            } else {
+                std::sort(ordered.begin(), ordered.end());
+            }
+
+            const auto occupiedBy = [&midi](Aestra::Audio::UnitID uid, double beat) {
+                for (const auto& n : midi.notes) {
+                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                    if (n.unitId == uid && beat >= n.startBeat - 0.01 && beat < endBeat - 0.01) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            const auto findAt = [&midi](Aestra::Audio::UnitID uid, double beat) {
+                for (auto it = midi.notes.begin(); it != midi.notes.end(); ++it) {
+                    const double endBeat = std::max(it->startBeat + 0.25, it->startBeat + it->durationBeats);
+                    if (it->unitId == uid && beat >= it->startBeat - 0.01 && beat < endBeat - 0.01) {
+                        return it;
+                    }
+                }
+                return midi.notes.end();
+            };
+
+            for (const int step : ordered) {
+                const int dst = step + dir;
+                const double srcBeat = step * 0.25;
+                const double dstBeat = dst * 0.25;
+                if (dst < 0 || dst >= m_stepCount || occupiedBy(m_unitId, dstBeat)) {
+                    newSelection.push_back(step); // stuck: note (or empty slot) stays put
+                    continue;
+                }
+                auto it = findAt(m_unitId, srcBeat);
+                if (it == midi.notes.end()) {
+                    newSelection.push_back(dst); // empty selected slot moves freely
+                    continue;
+                }
+                Aestra::Audio::MidiNote copy = *it; // pitch/duration/velocity preserved
+                copy.startBeat = dstBeat;
+                midi.notes.erase(it);
+                midi.notes.push_back(copy);
+                newSelection.push_back(dst);
+                changed = true;
+            }
+        });
+    std::sort(newSelection.begin(), newSelection.end());
+    const bool selectionChanged = newSelection != m_selectedSteps;
+    m_selectedSteps = std::move(newSelection);
+    if (selectionChanged) {
+        notifyStepSelectionChanged();
+    }
+    invalidateVisuals();
+    if (changed && m_onPatternEdited) {
+        m_onPatternEdited(m_patternId);
+    }
+}
+
+void UnitRow::nudgeSelectionVelocity(float delta) {
+    if (m_selectedSteps.empty() || !m_patternId.isValid() || !m_trackManager) {
+        return;
+    }
+    bool changed = false;
+    m_trackManager->getPatternManager().applyPatch(m_patternId,
+        [this, delta, &changed](Aestra::Audio::PatternSource& p) {
+            if (!p.isMidi()) {
+                return;
+            }
+            auto& midi = std::get<Aestra::Audio::MidiPayload>(p.payload);
+            for (const int step : m_selectedSteps) {
+                const double beat = step * 0.25;
+                for (auto& n : midi.notes) {
+                    const double endBeat = std::max(n.startBeat + 0.25, n.startBeat + n.durationBeats);
+                    if (n.unitId == m_unitId && beat >= n.startBeat - 0.01 && beat < endBeat - 0.01) {
+                        const float v = std::clamp(n.velocity + delta, kMinStepVelocity, 1.0f);
+                        if (v != n.velocity) {
+                            n.velocity = v;
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        });
+    invalidateVisuals();
+    if (changed && m_onPatternEdited) {
+        m_onPatternEdited(m_patternId);
+    }
+}
+
+void UnitRow::selectAllNotes() {
+    if (!m_patternId.isValid() || !m_trackManager) {
+        return;
+    }
+    std::vector<int> steps;
+    for (int s = 0; s < m_stepCount; ++s) {
+        float v = kDefaultStepVelocity;
+        if (stepHasNote(s, v)) {
+            steps.push_back(s);
+        }
+    }
+    if (steps == m_selectedSteps) {
+        return;
+    }
+    m_selectedSteps = std::move(steps);
+    notifyStepSelectionChanged();
+    invalidateVisuals();
 }
 
 bool UnitRow::stepHasNote(int step, float& velocityOut) const {
@@ -1194,7 +1528,55 @@ void UnitRow::setStepNoteVelocity(int step, float velocity) {
 bool UnitRow::onKeyEvent(const NUIKeyEvent& event) {
     // Key events are forwarded to children automatically by NUIComponent.
     // The UnitNameLabel (when renaming) receives them via its NUITextInput child.
-    (void)event;
+    if (!event.pressed) {
+        return false;
+    }
+    if (m_nameLabel && m_nameLabel->isRenaming()) {
+        return false; // typing a name — Delete/Backspace belong to the text field
+    }
+
+    const bool isStepGrid = usesStepSequencerForType(m_type) && !shouldUseNoteRoll() &&
+                            m_patternId.isValid() && m_trackManager;
+    if (!isStepGrid) {
+        return false;
+    }
+
+    const bool ctrl = (event.modifiers & NUIModifiers::Ctrl) != 0;
+    if (ctrl && event.keyCode == NUIKeyCode::B) {
+        if (!event.repeat) {
+            duplicateSelection();
+        }
+        return true;
+    }
+    if (!ctrl && (event.keyCode == NUIKeyCode::Delete || event.keyCode == NUIKeyCode::Backspace)) {
+        deleteSelection();
+        return true;
+    }
+    if (!ctrl && (event.keyCode == NUIKeyCode::Left || event.keyCode == NUIKeyCode::Right)) {
+        // Move mirrors the horizontal drag axis: selected notes shift one step.
+        moveSelection(event.keyCode == NUIKeyCode::Right ? 1 : -1);
+        return true;
+    }
+    if (!ctrl && (event.keyCode == NUIKeyCode::Up || event.keyCode == NUIKeyCode::Down)) {
+        // Velocity mirrors the vertical drag axis: Up louder, Down quieter.
+        nudgeSelectionVelocity(event.keyCode == NUIKeyCode::Up ? kVelocityNudgeStep : -kVelocityNudgeStep);
+        return true;
+    }
+    if (ctrl && event.keyCode == NUIKeyCode::A) {
+        if (!event.repeat) {
+            selectAllNotes(); // Ctrl+A: select the active notes (empty slots stay unselected)
+        }
+        return true;
+    }
+    if (!ctrl && event.keyCode == NUIKeyCode::Escape) {
+        // Esc dismisses the selection — intuitive way out of the editing grammar.
+        if (!m_selectedSteps.empty()) {
+            m_selectedSteps.clear();
+            notifyStepSelectionChanged();
+            invalidateVisuals();
+        }
+        return true;
+    }
     return false;
 }
 

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -273,6 +273,7 @@ private:
     bool m_stepGestureChanged = false;
 
     long long m_lastClipClickTimeMs = 0; // For double-click on clip/waveform area
+    int m_lastClipClickStep = -1;        // Step of the last grid press; -1 = miss / non-grid
 
     // === Helpers ===
     void drawContent(NUIRenderer& renderer); // Main drawing logic (cached)

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -31,6 +31,10 @@ public:
     UnitRow(std::shared_ptr<Aestra::Audio::TrackManager> trackManager, Aestra::Audio::UnitManager& manager, Aestra::Audio::UnitID unitId, Aestra::Audio::PatternID patternId);
     ~UnitRow() override;
 
+    // Structural 4-step group gap shared by rows and the Arsenal header ruler.
+    // Keep in sync with ArsenalPanel's kGroupGap.
+    static constexpr float kStepGroupGap = 2.0f;
+
     void onRender(NUIRenderer& renderer) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
@@ -150,6 +154,26 @@ public:
      */
     bool isSelected() const { return m_isSelected; }
 
+    /**
+     * @brief Set the selected step indices for this row. The panel owns the
+     *        source of truth (it survives row rebuilds) and pushes it back
+     *        here; rows only draw and edit against it.
+     * @param steps Sorted step indices to mark as selected.
+     */
+    void setStepSelection(const std::vector<int>& steps) {
+        m_selectedSteps = steps;
+        invalidateVisuals();
+    }
+    /**
+     * @brief Callback fired whenever this row's step selection changes.
+     * @param unitId The unit owning the selection.
+     * @param steps The new sorted selection.
+     */
+    std::function<void(Aestra::Audio::UnitID, const std::vector<int>&)> m_onStepSelectionChanged;
+    void setOnStepSelectionChanged(std::function<void(Aestra::Audio::UnitID, const std::vector<int>&)> cb) {
+        m_onStepSelectionChanged = std::move(cb);
+    }
+
 private:
     std::shared_ptr<Aestra::Audio::TrackManager> m_trackManager;
     Aestra::Audio::UnitManager& m_manager;
@@ -207,13 +231,21 @@ private:
 
     // Pad width for the current fit mode: fit shrinks to show every step,
     // scroll mode keeps a readable minimum and lets m_scrollX page the grid.
+    // The 4-step group gap is carved out of the available width so fit mode
+    // still shows the whole loop exactly (content = stepWidth * N + gaps).
     float gridStepWidth(float availWidth) const {
-        const float w = availWidth / static_cast<float>(std::max(1, m_stepCount));
+        const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kStepGroupGap;
+        const float w = std::max(0.0f, availWidth - groupTotal) / static_cast<float>(std::max(1, m_stepCount));
         return m_fitToWidth ? std::max(w, 4.0f) : std::max(w, PAD_MIN_SIZE);
     }
     std::function<void(float)> m_onGridScroll; // Panel-owned shared scroll (see setOnGridScroll)
     NUIRect m_viewport{}; // Panel list viewport; empty = unrestricted
     int m_hoveredStep = -1;
+    // Step selection (selection-based editing): sorted step indices. The
+    // panel mirrors this per active unit so it survives row rebuilds.
+    std::vector<int> m_selectedSteps;
+    bool m_stepGestureShiftHeld = false; // Shift state captured at grid press
+    bool m_stepGestureWasActive = false; // pressed step already had a note at press
     
     // Minimap pitch scroll
     float m_minimapPitchOffset = 0.0f; // Scroll offset for pitch viewport
@@ -231,13 +263,13 @@ private:
     enum class StepGestureMode { None, Pending, Velocity, Paint, Erase };
     static constexpr float kDefaultStepVelocity = 100.0f / 127.0f;
     static constexpr float kMinStepVelocity = 0.05f;
+    static constexpr float kVelocityNudgeStep = 0.05f; // Up/Down arrow velocity nudge
     StepGestureMode m_stepGestureMode = StepGestureMode::None;
     int m_velEditStep = -1; // initial step; -1 = no session
     int m_stepGestureLastStep = -1;
     float m_stepGestureStartX = 0.0f;
     float m_velEditStartY = 0.0f;
     float m_velEditBaseVelocity = kDefaultStepVelocity;
-    bool m_velEditWasActive = false; // step already had a note at press
     bool m_stepGestureChanged = false;
 
     long long m_lastClipClickTimeMs = 0; // For double-click on clip/waveform area
@@ -264,11 +296,22 @@ private:
     bool removeStepNote(int step);                         // remove note at step
     void setStepNoteVelocity(int step, float velocity);    // set velocity of note at step
 
+    // Selection-based editing helpers.
+    bool isStepSelected(int step) const;
+    void applyClickSelection(int step, bool additive); // click / shift-click select
+    void applyRangeSelection(int firstStep, int lastStep); // select painted range
+    void notifyStepSelectionChanged();
+    void duplicateSelection(); // Ctrl+B: copy selection just after its occupied span
+    void deleteSelection();    // Delete/Backspace: remove every selected step
+    void moveSelection(int stepDelta);         // Left/Right: move selected notes (per-step, cascading)
+    void nudgeSelectionVelocity(float delta);  // Up/Down: velocity nudge on selected notes
+    void selectAllNotes();                     // Ctrl+A: select every step that has a note
+
     // Icon drawing helpers
     void drawPowerIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active);
     void drawArmIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active);
-    void drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active);
-    void drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active);
+    void drawMuteIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active, bool engaged = true);
+    void drawSoloIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active, bool engaged = true);
     void drawGearIcon(NUIRenderer& renderer, const NUIRect& bounds, bool active); // [NEW]
 
     // Internal components

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -20,6 +20,10 @@ constexpr int kArsenalMaxPatternBars = 16;
 constexpr int kArsenalMinPatternSteps = 16; // One bar at 1/16 resolution
 constexpr int kArsenalMaxPatternSteps = 256; // 16 bars at 1/16 resolution
 constexpr float kGroupGap = UnitRow::kStepGroupGap;
+// Bottom padding reserved in the unit-list scroll extent so the last row never
+// sits flush against the panel edge. One definition for preferred height and
+// both scroll computations — they used to disagree by this amount.
+constexpr float kArsenalListBottomPadding = 40.0f + 12.0f;
 
 const char* unitTypeDisplayName(UnitType type) {
     switch (type) {
@@ -223,12 +227,13 @@ int ArsenalPanel::computeLoopStepCount() const {
 
 float ArsenalPanel::computeGridMaxScrollX() const {
     if (m_fitToWidth) return 0.0f; // Whole loop shown → nothing to scroll
-    // Mirrors the UnitRow grid geometry (control block + context paddings +
-    // min 20px pads) so the shared scroll clamps against the real content.
+    // Mirrors the UnitRow grid geometry (control block + 8px context inset +
+    // 6px lane padding + min 20px pads) so the shared scroll clamps against
+    // the real content.
     const float width = m_progressHeaderRect.width;
     if (width <= 0.0f) return 0.0f;
     const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
-    const float availWidth = std::max(1.0f, width - controlWidth - 30.0f);
+    const float availWidth = std::max(1.0f, width - controlWidth - 14.0f);
     const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
     const float stepWidth = std::max(std::max(0.0f, availWidth - groupTotal) /
                                          static_cast<float>(std::max(1, m_stepCount)),
@@ -260,7 +265,7 @@ void ArsenalPanel::followGridPlayhead() {
     const float width = m_progressHeaderRect.width;
     if (width <= 0.0f) return;
     const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
-    const float availWidth = std::max(1.0f, width - controlWidth - 30.0f);
+    const float availWidth = std::max(1.0f, width - controlWidth - 14.0f);
     const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
     const float stepWidth = std::max(std::max(0.0f, availWidth - groupTotal) /
                                          static_cast<float>(std::max(1, m_stepCount)),
@@ -449,7 +454,8 @@ void ArsenalPanel::refreshUnits() {
     syncRowSelection();
     if (m_onPreferredHeightChanged) {
         const float preferredHeight = getTitleBarHeight() + 136.0f +
-                                      static_cast<float>(m_unitRows.size()) * (56.0f + 8.0f);
+                                      static_cast<float>(m_unitRows.size()) * (56.0f + 8.0f) +
+                                      kArsenalListBottomPadding;
         m_onPreferredHeightChanged(preferredHeight);
     }
     if (shouldRestoreDropTargets) {
@@ -825,7 +831,8 @@ void ArsenalPanel::onUpdate(double dt) {
     const float reservedHeight = COMMAND_HEADER_HEIGHT + PROGRESS_HEADER_HEIGHT + 32.0f;
     const float viewportHeight = std::max(0.0f,
         (m_listContainer ? m_listContainer->getBounds().height : 0.0f) - reservedHeight);
-    const float contentHeight = static_cast<float>(m_unitRows.size()) * (56.0f + 8.0f);
+    const float contentHeight =
+        static_cast<float>(m_unitRows.size()) * (56.0f + 8.0f) + kArsenalListBottomPadding;
     const float maxScroll = std::max(0.0f, contentHeight - viewportHeight);
     m_targetScrollY = safeClampPanelScroll(m_targetScrollY, maxScroll);
     m_scrollY = safeClampPanelScroll(m_scrollY, maxScroll);
@@ -975,8 +982,8 @@ void ArsenalPanel::adjustPatternBars(int deltaBars) {
     }
 }
 
-void ArsenalPanel::adjustPatternSteps(int deltaSteps) {
-    if (!m_trackManager || !m_activePatternID.isValid() || deltaSteps == 0) {
+void ArsenalPanel::adjustPatternSteps(int deltaBars) {
+    if (!m_trackManager || !m_activePatternID.isValid() || deltaBars == 0) {
         return;
     }
 
@@ -990,10 +997,17 @@ void ArsenalPanel::adjustPatternSteps(int deltaSteps) {
         static_cast<int>(std::lround(std::max(0.25, pattern->lengthBeats) / 0.25)),
         kArsenalMinPatternSteps,
         kArsenalMaxPatternSteps);
-    // Snap to the 16-step bar grid so Bars and Steps can never contradict
-    // each other (e.g. a 63-step pattern would read as "4 Bars / 63 Steps").
-    const int barAlignedSteps = ((currentSteps + 15) / 16) * 16;
-    const int nextSteps = std::clamp(barAlignedSteps + deltaSteps, kArsenalMinPatternSteps, kArsenalMaxPatternSteps);
+    // Snap to the nearest bar so Bars and Steps can never contradict each
+    // other (e.g. a 63-step pattern would read as "4 Bars / 63 Steps") and
+    // "+" never skips past the next bar (a 20-step pattern used to jump
+    // straight to 48). The bar size follows the pattern's time signature,
+    // like the ruler hairlines — fixed 16-step bars would disagree with Bars
+    // display outside 4/4.
+    const int stepsPerBar = beatsPerBar() * 4;
+    const int barAlignedSteps =
+        std::max(stepsPerBar, ((currentSteps + stepsPerBar / 2) / stepsPerBar) * stepsPerBar);
+    const int nextSteps = std::clamp(barAlignedSteps + deltaBars * stepsPerBar, kArsenalMinPatternSteps,
+                                     kArsenalMaxPatternSteps);
     const double nextLengthBeats = static_cast<double>(nextSteps) * 0.25;
     if (std::abs(nextLengthBeats - pattern->lengthBeats) < 0.001) {
         return;
@@ -1020,7 +1034,7 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     // inset + 6px lane padding, so header pads line up with row pads exactly)
     const float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
     const float gridStartX = bounds.x + controlWidth + 14.0f;
-    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 30.0f);
+    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 14.0f);
 
     double lengthBeats = static_cast<double>(m_stepCount) * 0.25;
     UnitType selectedType = UnitType::Sampler;
@@ -1103,6 +1117,12 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
         renderer.drawTextCentered("+", m_stepsIncrementRect, themeProps.fontSizeXS,
                                   stepsIncEnabled ? pillText : disabledText);
     } else {
+        // Clear the step hit rects: the mouse handler gates on width > 0, so
+        // stale rects from a previously selected step unit would stay
+        // clickable and adjust the pattern length behind a MIDI/Audio unit.
+        m_stepsDecrementRect = NUIRect{};
+        m_stepsValueRect = NUIRect{};
+        m_stepsIncrementRect = NUIRect{};
         const float contentBadgeWidth = contentLabel == "Note Roll" ? 74.0f : 62.0f;
         const NUIRect contentBadge(m_barsIncrementRect.right() + 8.0f, leftCard.y + 4.0f, contentBadgeWidth,
                                    leftCard.height - 8.0f);
@@ -1513,12 +1533,12 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         const auto stepsIncHit = expandHitRect(m_stepsIncrementRect, 4.0f);
         if (m_stepsDecrementRect.width > 0.0f && stepsDecHit.contains(event.position) &&
             m_stepCount > kArsenalMinPatternSteps) {
-            adjustPatternSteps(-16);
+            adjustPatternSteps(-1);
             return true;
         }
         if (m_stepsIncrementRect.width > 0.0f && stepsIncHit.contains(event.position) &&
             m_stepCount < kArsenalMaxPatternSteps) {
-            adjustPatternSteps(16);
+            adjustPatternSteps(1);
             return true;
         }
     }
@@ -1559,7 +1579,7 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         }
         
         // Fallback: scroll the unit list
-        float contentHeight = (m_unitRows.size() * (56.0f + 8.0f)) + 40.0f + 12.0f; 
+        float contentHeight = (m_unitRows.size() * (56.0f + 8.0f)) + kArsenalListBottomPadding;
         float viewportHeight = m_listContainer ? m_listContainer->getBounds().height : 100.0f;
         float maxScroll = std::max(0.0f, contentHeight - viewportHeight);
         

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -17,6 +17,9 @@ namespace Audio {
 namespace {
 constexpr int kArsenalMinPatternBars = 1;
 constexpr int kArsenalMaxPatternBars = 16;
+constexpr int kArsenalMinPatternSteps = 16; // One bar at 1/16 resolution
+constexpr int kArsenalMaxPatternSteps = 256; // 16 bars at 1/16 resolution
+constexpr float kGroupGap = UnitRow::kStepGroupGap;
 
 const char* unitTypeDisplayName(UnitType type) {
     switch (type) {
@@ -225,16 +228,25 @@ float ArsenalPanel::computeGridMaxScrollX() const {
     const float width = m_progressHeaderRect.width;
     if (width <= 0.0f) return 0.0f;
     const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
-    const float availWidth = std::max(1.0f, width - controlWidth - 26.0f);
-    const float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
-    return std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) - availWidth);
+    const float availWidth = std::max(1.0f, width - controlWidth - 30.0f);
+    const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
+    const float stepWidth = std::max(std::max(0.0f, availWidth - groupTotal) /
+                                         static_cast<float>(std::max(1, m_stepCount)),
+                                     20.0f);
+    return std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) + groupTotal - availWidth);
 }
 
-void ArsenalPanel::scrollGridBy(float deltaPx) {
+void ArsenalPanel::scrollGridBy(float deltaPx, bool userScroll) {
     const float clamped = std::clamp(m_gridScrollX + deltaPx, 0.0f, computeGridMaxScrollX());
     m_gridScrollX = clamped;
     for (auto& row : m_unitRows) {
         if (row) row->setScrollX(clamped);
+    }
+    if (userScroll) {
+        // Interaction-only scroll affordance: a quiet thumb fades out ~1.2s
+        // after the last user scroll. Playhead follow never flashes it.
+        m_lastUserGridScroll = std::chrono::steady_clock::now();
+        m_scrollIndicatorAlpha = 1.0f;
     }
     repaint();
 }
@@ -248,9 +260,12 @@ void ArsenalPanel::followGridPlayhead() {
     const float width = m_progressHeaderRect.width;
     if (width <= 0.0f) return;
     const float controlWidth = std::clamp(width * 0.38f, 220.0f, 312.0f);
-    const float availWidth = std::max(1.0f, width - controlWidth - 26.0f);
-    const float stepWidth = std::max(availWidth / static_cast<float>(std::max(1, m_stepCount)), 20.0f);
-    const float maxScroll = std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) - availWidth);
+    const float availWidth = std::max(1.0f, width - controlWidth - 30.0f);
+    const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
+    const float stepWidth = std::max(std::max(0.0f, availWidth - groupTotal) /
+                                         static_cast<float>(std::max(1, m_stepCount)),
+                                     20.0f);
+    const float maxScroll = std::max(0.0f, stepWidth * static_cast<float>(m_stepCount) + groupTotal - availWidth);
     if (maxScroll <= 0.0f) return; // Whole loop fits: nothing to follow
 
     const float stepLeft = static_cast<float>(playStep) * stepWidth;
@@ -264,7 +279,7 @@ void ArsenalPanel::followGridPlayhead() {
     // Page to the playing bar's start so a full musical bar reads at once.
     const int stepsPerBar = beatsPerBar() * 4;
     const float barLeft = static_cast<float>((playStep / stepsPerBar) * stepsPerBar) * stepWidth;
-    scrollGridBy(std::clamp(barLeft, 0.0f, maxScroll) - m_gridScrollX);
+    scrollGridBy(std::clamp(barLeft, 0.0f, maxScroll) - m_gridScrollX, false);
 }
 
 void ArsenalPanel::refreshUnits() {
@@ -284,6 +299,13 @@ void ArsenalPanel::refreshUnits() {
     auto& unitMgr = m_trackManager->getUnitManager();
     auto unitIDs = unitMgr.getAllUnitIDs();
 
+    // Drop the step selection if its owning unit no longer exists.
+    if (m_selectionUnitId == 0 ||
+        std::find(unitIDs.begin(), unitIDs.end(), m_selectionUnitId) == unitIDs.end()) {
+        m_selectionUnitId = 0;
+        m_selectedSteps.clear();
+    }
+
     if (m_selectedUnitId == 0 || std::find(unitIDs.begin(), unitIDs.end(), m_selectedUnitId) == unitIDs.end()) {
         m_selectedUnitId = unitIDs.empty() ? 0 : unitIDs.front();
     }
@@ -294,6 +316,9 @@ void ArsenalPanel::refreshUnits() {
     for (size_t i = 0; i < unitIDs.size(); ++i) {
         auto row = std::make_shared<UnitRow>(m_trackManager, unitMgr, unitIDs[i], m_activePatternID);
         row->setSelected(unitIDs[i] == m_selectedUnitId);
+        if (unitIDs[i] == m_selectionUnitId) {
+            row->setStepSelection(m_selectedSteps);
+        }
         
         // Set step count
         row->setStepCount(m_stepCount);
@@ -366,6 +391,17 @@ void ArsenalPanel::refreshUnits() {
                 m_onPatternEdited(patternId);
             }
         });
+        row->setOnStepSelectionChanged([this](UnitID id, const std::vector<int>& steps) {
+            // One step-selection context at a time: adopt the reporting row's
+            // selection and clear every other row.
+            m_selectionUnitId = id;
+            m_selectedSteps = steps;
+            for (auto& other : m_unitRows) {
+                if (other) {
+                    other->setStepSelection(other->getUnitId() == id ? steps : std::vector<int>{});
+                }
+            }
+        });
         row->setOnOpenPatternEditor([this](PatternID patternId) {
             if (m_onRequestPatternEditor) {
                 m_onRequestPatternEditor(patternId);
@@ -411,6 +447,11 @@ void ArsenalPanel::refreshUnits() {
     layoutUnits();
     scrollGridBy(0.0f); // Re-clamp the shared scroll for the (possibly new) loop length
     syncRowSelection();
+    if (m_onPreferredHeightChanged) {
+        const float preferredHeight = getTitleBarHeight() + 136.0f +
+                                      static_cast<float>(m_unitRows.size()) * (56.0f + 8.0f);
+        m_onPreferredHeightChanged(preferredHeight);
+    }
     if (shouldRestoreDropTargets) {
         registerDropTargets(true);
     }
@@ -642,9 +683,16 @@ void ArsenalPanel::drawCommandHeader(NUIRenderer& renderer) {
 
     auto& theme = NUIThemeManager::getInstance();
     const auto& themeProps = theme.getCurrentTheme();
-    renderer.fillRoundedRect(m_commandHeaderRect, themeProps.radiusM,
+
+    // Pattern zone: command header and progress ruler share one parent card so
+    // the pattern reads as a single unit above the child unit rows.
+    const float zoneBottom = m_progressHeaderRect.height > 0.0f ? m_progressHeaderRect.bottom() + 8.0f
+                                                                : m_commandHeaderRect.bottom();
+    const NUIRect parentZone(m_commandHeaderRect.x, m_commandHeaderRect.y, m_commandHeaderRect.width,
+                             std::max(0.0f, zoneBottom - m_commandHeaderRect.y));
+    renderer.fillRoundedRect(parentZone, themeProps.radiusM,
                              theme.getColor("backgroundSecondary").withAlpha(0.97f));
-    renderer.strokeRoundedRect(m_commandHeaderRect, themeProps.radiusM, 1.0f,
+    renderer.strokeRoundedRect(parentZone, themeProps.radiusM, 1.0f,
                                theme.getColor("borderSubtle").withAlpha(0.42f));
 
     const float iconX = m_commandHeaderRect.x + 15.0f;
@@ -678,7 +726,7 @@ void ArsenalPanel::drawCommandHeader(NUIRenderer& renderer) {
     const float textMaxX = m_fitToggleRect.width > 0.0f ? m_fitToggleRect.x - 8.0f : m_commandHeaderRect.right() - 8.0f;
     if (textMaxX > textX) {
         renderer.setClipRect({textX, m_commandHeaderRect.y + 8.0f, textMaxX - textX, 36.0f});
-        renderer.drawText(patternName, {textX, m_commandHeaderRect.y + 10.0f}, themeProps.fontSizeS,
+        renderer.drawText(patternName, {textX, m_commandHeaderRect.y + 10.0f}, themeProps.fontSizeS + 2.0f,
                           theme.getColor("textPrimary").withAlpha(0.96f));
         if (!selectedName.empty()) {
             renderer.drawText(selectedName, {textX, m_commandHeaderRect.y + 28.0f}, 8.5f,
@@ -687,18 +735,38 @@ void ArsenalPanel::drawCommandHeader(NUIRenderer& renderer) {
         renderer.clearClipRect();
     }
 
-    // View toggle: reflects current mode (accent = Fit, muted = Scroll).
+    // View toggle: FIT | SCROLL segmented control. The active mode is subtly
+    // highlighted; both modes are two viewport strategies of the same grid.
     if (m_fitToggleRect.width > 0.0f) {
         const float radius = themeProps.radiusS;
-        const NUIColor fill = m_fitToWidth ? theme.getColor("accentPrimary").withAlpha(0.18f)
-                                           : theme.getColor("surfaceTertiary").withAlpha(0.85f);
-        const NUIColor stroke = m_fitToWidth ? theme.getColor("accentPrimary").withAlpha(0.5f)
-                                             : theme.getColor("borderSubtle").withAlpha(0.5f);
-        const NUIColor text = m_fitToWidth ? theme.getColor("accentPrimary")
-                                           : theme.getColor("textSecondary").withAlpha(0.9f);
-        renderer.fillRoundedRect(m_fitToggleRect, radius, fill);
-        renderer.strokeRoundedRect(m_fitToggleRect, radius, 1.0f, stroke);
-        renderer.drawTextCentered(m_fitToWidth ? "FIT" : "SCROLL", m_fitToggleRect, themeProps.fontSizeMicro, text);
+        const NUIColor containerFill = theme.getColor("surfaceTertiary").withAlpha(0.85f);
+        const NUIColor containerStroke = theme.getColor("borderSubtle").withAlpha(0.5f);
+        renderer.fillRoundedRect(m_fitToggleRect, radius, containerFill);
+        renderer.strokeRoundedRect(m_fitToggleRect, radius, 1.0f, containerStroke);
+
+        const NUIColor activeFill = theme.getColor("accentPrimary").withAlpha(0.16f);
+        const NUIColor activeText = theme.getColor("accentPrimary").withAlpha(0.95f);
+        const NUIColor idleText = theme.getColor("textSecondary").withAlpha(0.85f);
+
+        if (m_fitModeRect.width > 0.0f) {
+            if (m_fitToWidth) {
+                renderer.fillRoundedRect(m_fitModeRect, themeProps.radiusXS, activeFill);
+            }
+            renderer.drawTextCentered("FIT", m_fitModeRect, themeProps.fontSizeMicro,
+                                      m_fitToWidth ? activeText : idleText);
+        }
+        if (m_scrollModeRect.width > 0.0f) {
+            if (!m_fitToWidth) {
+                renderer.fillRoundedRect(m_scrollModeRect, themeProps.radiusXS, activeFill);
+            }
+            renderer.drawTextCentered("SCROLL", m_scrollModeRect, themeProps.fontSizeMicro,
+                                      m_fitToWidth ? idleText : activeText);
+        }
+
+        const float dividerX = m_fitToggleRect.x + m_fitToggleRect.width * 0.5f;
+        renderer.drawLine(NUIPoint(dividerX, m_fitToggleRect.y + 5.0f),
+                          NUIPoint(dividerX, m_fitToggleRect.bottom() - 5.0f), 1.0f,
+                          theme.getColor("borderSubtle").withAlpha(0.6f));
     }
 }
 
@@ -720,6 +788,8 @@ void ArsenalPanel::layoutUnits() {
     // View toggle (Fit whole loop <-> readable + scroll) sits just left of Add.
     constexpr float fitW = 84.0f;
     m_fitToggleRect = {m_addUnitButtonRect.x - 8.0f - fitW, buttonY, fitW, buttonH};
+    m_fitModeRect = {m_fitToggleRect.x, m_fitToggleRect.y, fitW * 0.5f, m_fitToggleRect.height};
+    m_scrollModeRect = {m_fitModeRect.right(), m_fitToggleRect.y, fitW * 0.5f, m_fitToggleRect.height};
 
     m_progressHeaderRect = {startX, m_commandHeaderRect.bottom() + 8.0f, width, PROGRESS_HEADER_HEIGHT};
     float yPos = m_progressHeaderRect.bottom() + 8.0f - m_scrollY;
@@ -769,6 +839,24 @@ void ArsenalPanel::onUpdate(double dt) {
     } else if (std::abs(delta) > 0.0f) {
         m_scrollY = m_targetScrollY;
         layoutUnits();
+    }
+
+    // Interaction-only scroll affordance: fade the quiet thumb out ~1.2s
+    // after the last user scroll (drawProgressHeader renders it).
+    if (m_scrollIndicatorAlpha > 0.01f) {
+        const double ageSec =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - m_lastUserGridScroll).count();
+        const float next = std::max(0.0f, 1.0f - static_cast<float>(ageSec / 1.2));
+        if (next != m_scrollIndicatorAlpha) {
+            m_scrollIndicatorAlpha = next;
+            if (auto parent = getParent()) {
+                parent->repaint();
+            } else {
+                repaint();
+            }
+        }
+    } else {
+        m_scrollIndicatorAlpha = 0.0f;
     }
 
     followGridPlayhead();
@@ -887,6 +975,41 @@ void ArsenalPanel::adjustPatternBars(int deltaBars) {
     }
 }
 
+void ArsenalPanel::adjustPatternSteps(int deltaSteps) {
+    if (!m_trackManager || !m_activePatternID.isValid() || deltaSteps == 0) {
+        return;
+    }
+
+    auto& patternManager = m_trackManager->getPatternManager();
+    auto* pattern = patternManager.getPattern(m_activePatternID);
+    if (!pattern) {
+        return;
+    }
+
+    const int currentSteps = std::clamp(
+        static_cast<int>(std::lround(std::max(0.25, pattern->lengthBeats) / 0.25)),
+        kArsenalMinPatternSteps,
+        kArsenalMaxPatternSteps);
+    // Snap to the 16-step bar grid so Bars and Steps can never contradict
+    // each other (e.g. a 63-step pattern would read as "4 Bars / 63 Steps").
+    const int barAlignedSteps = ((currentSteps + 15) / 16) * 16;
+    const int nextSteps = std::clamp(barAlignedSteps + deltaSteps, kArsenalMinPatternSteps, kArsenalMaxPatternSteps);
+    const double nextLengthBeats = static_cast<double>(nextSteps) * 0.25;
+    if (std::abs(nextLengthBeats - pattern->lengthBeats) < 0.001) {
+        return;
+    }
+
+    patternManager.applyPatch(m_activePatternID, [nextLengthBeats](PatternSource& source) {
+        source.lengthBeats = nextLengthBeats;
+    });
+    m_trackManager->preparePatternForArsenal(m_activePatternID);
+    refreshUnits();
+    repaint();
+    if (m_onPatternEdited) {
+        m_onPatternEdited(m_activePatternID);
+    }
+}
+
 void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& bounds) {
     auto& theme = NUIThemeManager::getInstance();
     
@@ -897,7 +1020,7 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     // inset + 6px lane padding, so header pads line up with row pads exactly)
     const float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
     const float gridStartX = bounds.x + controlWidth + 14.0f;
-    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 26.0f);
+    const float availWidth = std::max(0.0f, bounds.width - controlWidth - 30.0f);
 
     double lengthBeats = static_cast<double>(m_stepCount) * 0.25;
     UnitType selectedType = UnitType::Sampler;
@@ -933,7 +1056,7 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     const float pillRadius = themeProps.radiusS;
     const auto disabledText = theme.getColor("textDisabled");
 
-    const NUIRect leftCard(bounds.x + 4.0f, bounds.y + 1.0f, std::max(216.0f, controlWidth - 10.0f), bounds.height - 2.0f);
+    const NUIRect leftCard(bounds.x + 4.0f, bounds.y + 1.0f, std::max(272.0f, controlWidth - 10.0f), bounds.height - 2.0f);
     renderer.fillRoundedRect(leftCard, cardRadius, theme.getColor("backgroundSecondary").withAlpha(0.92f));
     renderer.strokeRoundedRect(leftCard, cardRadius, 1.0f, theme.getColor("borderSubtle").withAlpha(0.45f));
 
@@ -957,25 +1080,50 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
     renderer.strokeRoundedRect(m_barsIncrementRect, pillRadius, 1.0f, pillStroke);
     renderer.drawTextCentered("+", m_barsIncrementRect, themeProps.fontSizeXS, incEnabled ? pillText : disabledText);
 
-    const float contentBadgeWidth = contentLabel == "Note Roll" ? 74.0f : 62.0f;
-    const NUIRect contentBadge(m_barsIncrementRect.right() + 8.0f, leftCard.y + 4.0f, contentBadgeWidth, leftCard.height - 8.0f);
-    drawArsenalChip(renderer,
-                    contentBadge,
-                    contentLabel,
-                    theme.getColor("surfaceTertiary").withAlpha(0.78f),
-                    theme.getColor("borderSubtle").withAlpha(0.5f),
-                    theme.getColor("textSecondary").withAlpha(0.9f),
-                    themeProps.fontSizeMicro);
+    const bool stepType = selectedType == UnitType::Sampler || selectedType == UnitType::PitchedSampler;
+    if (stepType) {
+        m_stepsDecrementRect = NUIRect(m_barsIncrementRect.right() + 8.0f, leftCard.y + 4.0f, compactHitArea,
+                                       leftCard.height - 8.0f);
+        m_stepsValueRect = NUIRect(m_stepsDecrementRect.right() + 4.0f, leftCard.y + 4.0f, 66.0f,
+                                   leftCard.height - 8.0f);
+        m_stepsIncrementRect = NUIRect(m_stepsValueRect.right() + 4.0f, leftCard.y + 4.0f, compactHitArea,
+                                       leftCard.height - 8.0f);
+        const bool stepsDecEnabled = m_stepCount > kArsenalMinPatternSteps;
+        const bool stepsIncEnabled = m_stepCount < kArsenalMaxPatternSteps;
+        renderer.fillRoundedRect(m_stepsDecrementRect, pillRadius, pillFill);
+        renderer.strokeRoundedRect(m_stepsDecrementRect, pillRadius, 1.0f, pillStroke);
+        renderer.drawTextCentered("-", m_stepsDecrementRect, themeProps.fontSizeXS,
+                                  stepsDecEnabled ? pillText : disabledText);
+        renderer.fillRoundedRect(m_stepsValueRect, pillRadius, pillFill);
+        renderer.strokeRoundedRect(m_stepsValueRect, pillRadius, 1.0f, pillStroke);
+        renderer.drawTextCentered(std::to_string(m_stepCount) + " Steps", m_stepsValueRect, themeProps.fontSizeMicro,
+                                  pillText);
+        renderer.fillRoundedRect(m_stepsIncrementRect, pillRadius, pillFill);
+        renderer.strokeRoundedRect(m_stepsIncrementRect, pillRadius, 1.0f, pillStroke);
+        renderer.drawTextCentered("+", m_stepsIncrementRect, themeProps.fontSizeXS,
+                                  stepsIncEnabled ? pillText : disabledText);
+    } else {
+        const float contentBadgeWidth = contentLabel == "Note Roll" ? 74.0f : 62.0f;
+        const NUIRect contentBadge(m_barsIncrementRect.right() + 8.0f, leftCard.y + 4.0f, contentBadgeWidth,
+                                   leftCard.height - 8.0f);
+        drawArsenalChip(renderer,
+                        contentBadge,
+                        contentLabel,
+                        theme.getColor("surfaceTertiary").withAlpha(0.78f),
+                        theme.getColor("borderSubtle").withAlpha(0.5f),
+                        theme.getColor("textSecondary").withAlpha(0.9f),
+                        themeProps.fontSizeMicro);
+    }
     const NUIRect gridCard(gridStartX - 2.0f, bounds.y + 1.0f, std::max(0.0f, availWidth + 4.0f), bounds.height - 2.0f);
-    renderer.fillRoundedRect(gridCard, cardRadius, theme.getColor("backgroundSecondary").withAlpha(0.82f));
-    renderer.strokeRoundedRect(gridCard, cardRadius, 1.0f, theme.getColor("borderSubtle").withAlpha(0.42f));
 
     // Same step width formula as the rows + the shared scroll offset, so the
     // header ruler and every row grid stay in lockstep. Fit mode shrinks pads
     // to show the whole loop; scroll mode keeps a readable 20px minimum.
-    const float fitStepWidth = availWidth / static_cast<float>(std::max(1, m_stepCount));
+    const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
+    const float fitStepWidth =
+        std::max(0.0f, availWidth - groupTotal) / static_cast<float>(std::max(1, m_stepCount));
     float stepWidth = m_fitToWidth ? std::max(fitStepWidth, 4.0f) : std::max(fitStepWidth, 20.0f);
-    const float totalWidth = stepWidth * static_cast<float>(m_stepCount);
+    const float totalWidth = stepWidth * static_cast<float>(m_stepCount) + groupTotal;
     const float maxScrollX = std::max(0.0f, totalWidth - availWidth);
     m_gridScrollX = std::clamp(m_gridScrollX, 0.0f, maxScrollX);
     float indicatorHeight = PROGRESS_HEADER_HEIGHT - 10.0f;
@@ -987,7 +1135,7 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
 
     // Draw step indicators
     for (int i = 0; i < m_stepCount; ++i) {
-        const float stepOriginX = gridStartX + (i * stepWidth) - m_gridScrollX;
+        const float stepOriginX = gridStartX + (i * stepWidth) + static_cast<float>(i / 4) * kGroupGap - m_gridScrollX;
         const float cellGap = 3.0f;
         const float stepX = stepOriginX + cellGap * 0.5f;
         const float indicatorWidth = std::max(1.0f, stepWidth - cellGap);
@@ -997,7 +1145,7 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
         NUIRect indicatorRect(stepX, indicatorY, indicatorWidth, indicatorHeight);
 
         // Base color: more visible background
-        NUIColor bgColor = theme.getColor("surfaceTertiary").withAlpha(0.5f);
+        NUIColor bgColor = theme.getColor("surfaceTertiary").withAlpha(0.66f);
 
         // Bar/beat markers (4 steps = 1 beat at 1/16 resolution)
         const bool isBeatStart = (i % 4 == 0);
@@ -1006,6 +1154,9 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
             bgColor = bgColor.lightened(0.16f);
         } else if (isBeatStart) {
             bgColor = bgColor.lightened(0.08f);
+        }
+        if (((i / 4) & 1) != 0) {
+            bgColor = NUIColor::lerp(bgColor, theme.getColor("accentPrimary"), 0.10f);
         }
 
         renderer.fillRoundedRect(indicatorRect, indicatorRadius, bgColor);
@@ -1030,24 +1181,31 @@ void ArsenalPanel::drawProgressHeader(NUIRenderer& renderer, const NUIRect& boun
         renderer.strokeRoundedRect(indicatorRect, indicatorRadius, 0.5f,
                                    theme.getColor("borderSubtle").withAlpha(0.6f));
 
+        // Subtle structural landmark at each group boundary (4/8/12/...).
+        if ((i + 1) % 4 == 0 && i + 1 < m_stepCount) {
+            const float seamX = stepOriginX + stepWidth + kGroupGap * 0.5f;
+            renderer.drawLine(NUIPoint(seamX, gridCard.y + 4.0f),
+                              NUIPoint(seamX, gridCard.bottom() - 4.0f), 1.0f,
+                              theme.getColor("border").withAlpha(0.18f));
+        }
+
         if (isBarStart) {
-            const NUIRect labelRect(stepOriginX, indicatorY,
-                                    stepWidth * static_cast<float>(stepsPerBar), indicatorHeight);
-            renderer.drawTextCentered(std::to_string((i / stepsPerBar) + 1), labelRect, 7.5f, theme.getColor("textSecondary").withAlpha(0.88f));
+            renderer.drawTextCentered(std::to_string((i / stepsPerBar) + 1), indicatorRect, 7.5f,
+                                      theme.getColor("textSecondary").withAlpha(0.88f));
         }
     }
 
-    // Scroll indicator: show which slice of the loop the grids are viewing.
-    if (maxScrollX > 0.0f) {
+    // Interaction-only scroll position affordance. No rail, no scroll-specific
+    // decoration: a low-contrast thumb appears while the user is scrolling and
+    // fades out shortly after, keeping the ruler and rows one surface.
+    if (maxScrollX > 0.0f && m_scrollIndicatorAlpha > 0.01f) {
         const float trackX = gridCard.x + 3.0f;
         const float trackWidth = std::max(0.0f, gridCard.width - 6.0f);
-        const float trackY = gridCard.bottom() - 4.0f;
-        renderer.fillRoundedRect({trackX, trackY, trackWidth, 2.5f}, 1.25f,
-                                 theme.getColor("borderSubtle").withAlpha(0.55f));
+        const float thumbY = gridCard.bottom() - 3.5f;
         const float thumbWidth = std::max(16.0f, trackWidth * (availWidth / totalWidth));
         const float thumbX = trackX + (trackWidth - thumbWidth) * (m_gridScrollX / maxScrollX);
-        renderer.fillRoundedRect({thumbX, trackY, thumbWidth, 2.5f}, 1.25f,
-                                 theme.getColor("accentPrimary").withAlpha(0.75f));
+        renderer.fillRoundedRect({thumbX, thumbY, thumbWidth, 2.0f}, 1.0f,
+                                 theme.getColor("textSecondary").withAlpha(0.30f * m_scrollIndicatorAlpha));
     }
 
     renderer.clearClipRect();
@@ -1317,7 +1475,8 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
     }
 
     if (event.pressed && event.button == NUIMouseButton::Left && m_fitToggleRect.contains(event.position)) {
-        m_fitToWidth = !m_fitToWidth;
+        const bool wantFit = m_fitModeRect.contains(event.position);
+        m_fitToWidth = wantFit;
         m_gridScrollX = 0.0f;
         for (auto& row : m_unitRows) {
             if (row) row->setFitToWidth(m_fitToWidth);
@@ -1347,6 +1506,19 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         }
         if (incHitRect.contains(event.position) && bars < kArsenalMaxPatternBars) {
             adjustPatternBars(1);
+            return true;
+        }
+
+        const auto stepsDecHit = expandHitRect(m_stepsDecrementRect, 4.0f);
+        const auto stepsIncHit = expandHitRect(m_stepsIncrementRect, 4.0f);
+        if (m_stepsDecrementRect.width > 0.0f && stepsDecHit.contains(event.position) &&
+            m_stepCount > kArsenalMinPatternSteps) {
+            adjustPatternSteps(-16);
+            return true;
+        }
+        if (m_stepsIncrementRect.width > 0.0f && stepsIncHit.contains(event.position) &&
+            m_stepCount < kArsenalMaxPatternSteps) {
+            adjustPatternSteps(16);
             return true;
         }
     }

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -141,7 +141,7 @@ private:
     int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (4/beat)
     int beatsPerBar() const; // Time-signature numerator from the timeline clock
     void adjustPatternBars(int deltaBars);
-    void adjustPatternSteps(int deltaSteps);
+    void adjustPatternSteps(int deltaBars);
     void createUnitOfType(UnitType type);
     void drawUnitTypePicker(AestraUI::NUIRenderer& renderer);
 

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -3,6 +3,7 @@
 
 #include "WindowPanel.h"
 #include "TrackManager.h"
+#include <chrono>
 #include "../AestraUI/Widgets/UnitRow.h"
 #include "../AestraUI/Widgets/UnitColorPicker.h"
 #include "NUIComponent.h"
@@ -95,6 +96,10 @@ public:
     /** @brief Get the currently selected unit identifier. */
     UnitID getSelectedUnitId() const { return m_selectedUnitId; }
 
+    void setOnPreferredHeightChanged(std::function<void(float)> callback) {
+        m_onPreferredHeightChanged = std::move(callback);
+    }
+
 private:
     std::shared_ptr<TrackManager> m_trackManager;
     
@@ -122,7 +127,7 @@ private:
     bool m_fitToWidth = true; // Fit whole loop to width vs readable-min + scroll
     int m_stepCount = 16; // Default step count
     void layoutUnits();
-    void scrollGridBy(float deltaPx); // Clamp + broadcast the shared grid scroll
+    void scrollGridBy(float deltaPx, bool userScroll = true); // Clamp + broadcast the shared grid scroll
     float computeGridMaxScrollX() const;
     void followGridPlayhead(); // Keep the playing bar in view unless the user scrolled away
     
@@ -136,6 +141,7 @@ private:
     int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (4/beat)
     int beatsPerBar() const; // Time-signature numerator from the timeline clock
     void adjustPatternBars(int deltaBars);
+    void adjustPatternSteps(int deltaSteps);
     void createUnitOfType(UnitType type);
     void drawUnitTypePicker(AestraUI::NUIRenderer& renderer);
 
@@ -151,6 +157,8 @@ private:
     };
     std::optional<PatternClipboard> m_clipboard;
     UnitID m_selectedUnitId = 0; // Currently selected unit for copy/paste
+    UnitID m_selectionUnitId = 0; // Unit owning the current step selection (survives row rebuilds)
+    std::vector<int> m_selectedSteps; // Selected step indices for m_selectionUnitId
 
     void createLayout();
     void onAddUnit();
@@ -173,6 +181,7 @@ private:
     std::function<void(UnitID, const std::string&)> m_onPluginDroppedToUnit;
     std::function<void(UnitID, const std::string&)> m_onSampleDroppedToUnit;
     std::function<void(UnitID)> m_onSelectedUnitChanged;
+    std::function<void(float)> m_onPreferredHeightChanged;
     std::function<void()> m_onRequestPlaybackActivation;
     std::function<void(PatternID)> m_onPatternEdited;
     std::function<void(PatternID)> m_onActivePatternChanged;
@@ -180,6 +189,10 @@ private:
     bool m_showUnitTypePicker = false;
     AestraUI::NUIRect m_addUnitButtonRect{};
     AestraUI::NUIRect m_fitToggleRect{};
+    AestraUI::NUIRect m_fitModeRect{};
+    AestraUI::NUIRect m_scrollModeRect{};
+    float m_scrollIndicatorAlpha = 0.0f;
+    std::chrono::steady_clock::time_point m_lastUserGridScroll{};
     AestraUI::NUIRect m_commandHeaderRect{};
     AestraUI::NUIRect m_progressHeaderRect{};
     AestraUI::NUIRect m_listViewportRect{}; // Visible area for unit rows (scroll clip + hit-test)
@@ -187,6 +200,9 @@ private:
     AestraUI::NUIRect m_barsDecrementRect{};
     AestraUI::NUIRect m_barsValueRect{};
     AestraUI::NUIRect m_barsIncrementRect{};
+    AestraUI::NUIRect m_stepsDecrementRect{};
+    AestraUI::NUIRect m_stepsValueRect{};
+    AestraUI::NUIRect m_stepsIncrementRect{};
 };
 
 } // namespace Audio

--- a/Tests/AestraUI/UnitRowStepSelectionTest.cpp
+++ b/Tests/AestraUI/UnitRowStepSelectionTest.cpp
@@ -8,11 +8,9 @@
 #include "TrackManager.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <memory>
-#include <thread>
 #include <vector>
 
 using namespace AestraUI;
@@ -291,9 +289,9 @@ void testClickOnEmptyPlacesWithoutSelecting() {
     check(capturedSelection == std::vector<int>{1}, "placing a note does not select it");
 
     // Shift+click on an empty pad: same — placement is not selection.
-    // Step outside the 400ms double-click-load window first (sample-less rows
-    // treat two rapid taps as "open the file picker", by design).
-    std::this_thread::sleep_for(std::chrono::milliseconds(450));
+    // Within the 400ms double-click window on purpose: rapid taps on
+    // DIFFERENT pads must not pair into "open the file picker" — the
+    // double-click identity is per-step, so this still places.
     const float x2 = cellCenterX(6);
     NUIMouseEvent shiftPress = leftPress(x2, 28.0f);
     shiftPress.modifiers = NUIModifiers::Shift;

--- a/Tests/AestraUI/UnitRowStepSelectionTest.cpp
+++ b/Tests/AestraUI/UnitRowStepSelectionTest.cpp
@@ -1,0 +1,497 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// Regression coverage for selection-based step editing: click-to-select
+// grammar (no click-to-delete), Ctrl+B span duplication, Delete/Backspace
+// removal, and the duplicate-becomes-selection contract.
+
+#include "UnitRow.h"
+#include "PatternSource.h"
+#include "TrackManager.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cout << "[FAIL] " << message << "\n";
+        ++g_failures;
+    }
+}
+
+NUIKeyEvent keyPress(NUIKeyCode key, NUIModifiers modifiers = NUIModifiers::None) {
+    NUIKeyEvent event;
+    event.keyCode = key;
+    event.modifiers = modifiers;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent leftPress(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.pressed = true;
+    return event;
+}
+
+NUIMouseEvent leftRelease(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Up;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    event.released = true;
+    return event;
+}
+
+NUIMouseEvent dragTo(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Drag;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Left;
+    return event;
+}
+
+NUIMouseEvent rightPress(float x, float y) {
+    NUIMouseEvent event;
+    event.type = NUIMouseEventType::Down;
+    event.position = {x, y};
+    event.button = NUIMouseButton::Right;
+    event.pressed = true;
+    return event;
+}
+
+// Geometry mirror for a 700x56 row (m_controlWidth = 700*0.38 = 266,
+// separator at 266, context inset 8, lane padding 6, group gap 2, 16 steps):
+// cell centers must match resolveGridStep's drawn-pad containment exactly.
+float cellCenterX(int step) {
+    const float controlWidth = 700.0f * 0.38f;
+    const float gridX = controlWidth + 8.0f + 6.0f;
+    const float avail = 700.0f - (controlWidth + 2.0f) - 8.0f - 12.0f;
+    const float stepWidth = (avail - ((16 + 3) / 4) * 2.0f) / 16.0f;
+    return gridX + step * stepWidth + (step / 4) * 2.0f + stepWidth * 0.5f;
+}
+
+float cellGapX(int step) {
+    return cellCenterX(step) + (cellCenterX(1) - cellCenterX(0)) * 0.5f;
+}
+
+struct Fixture {
+    std::shared_ptr<Aestra::Audio::TrackManager> tm{std::make_shared<Aestra::Audio::TrackManager>()};
+    Aestra::Audio::UnitID unitId{0};
+    Aestra::Audio::PatternID patternId{};
+    std::shared_ptr<UnitRow> row;
+
+    Fixture() {
+        auto& unitMgr = tm->getUnitManager();
+        unitId = unitMgr.createUnit("Test", Aestra::Audio::UnitType::Sampler);
+        patternId = tm->getPatternManager().createPattern();
+        tm->getPatternManager().applyPatch(patternId, [](Aestra::Audio::PatternSource& p) {
+            p.type = Aestra::Audio::PatternSource::Type::Midi;
+            p.lengthBeats = 4.0;
+            p.payload = Aestra::Audio::MidiPayload{};
+        });
+        row = std::make_shared<UnitRow>(tm, unitMgr, unitId, patternId);
+        row->setStepCount(16);
+        row->updateState();
+    }
+
+    void addNote(int step, float velocity = 100.0f / 127.0f) {
+        tm->getPatternManager().applyPatch(patternId, [this, step, velocity](Aestra::Audio::PatternSource& p) {
+            Aestra::Audio::MidiNote note;
+            note.pitch = 60; // root — keeps the step grid (not note-roll) mode
+            note.startBeat = step * 0.25;
+            note.durationBeats = 0.25;
+            note.velocity = velocity;
+            note.unitId = unitId;
+            p.getMidiNotes().push_back(note);
+        });
+    }
+
+    std::vector<int> stepsForUnit() const {
+        std::vector<int> steps;
+        const auto* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) {
+            return steps;
+        }
+        for (const auto& n : pattern->getMidiNotes()) {
+            if (n.unitId == unitId) {
+                steps.push_back(static_cast<int>(std::lround(n.startBeat / 0.25)));
+            }
+        }
+        std::sort(steps.begin(), steps.end());
+        return steps;
+    }
+
+    float velocityAt(int step) const {
+        const auto* pattern = tm->getPatternManager().getPattern(patternId);
+        if (!pattern || !pattern->isMidi()) {
+            return -1.0f;
+        }
+        for (const auto& n : pattern->getMidiNotes()) {
+            if (n.unitId == unitId && n.startBeat == step * 0.25) {
+                return n.velocity;
+            }
+        }
+        return -1.0f;
+    }
+};
+
+void testDuplicateUsesOccupiedSpan() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(3, 0.80f);
+    f.addNote(4);
+
+    std::vector<int> capturedSelection;
+    int patternEditedCount = 0;
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+    f.row->setOnPatternEdited([&](Aestra::Audio::PatternID) { ++patternEditedCount; });
+
+    f.row->setStepSelection({1, 3, 4});
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::B, NUIModifiers::Ctrl)), "Ctrl+B handled");
+
+    check(f.stepsForUnit() == std::vector<int>({1, 3, 4, 5, 7, 8}),
+          "duplicate lands right after the occupied span (1,3,4 -> 5,7,8)");
+    check(capturedSelection == std::vector<int>({5, 7, 8}), "duplicated notes become the selection");
+    check(patternEditedCount == 1, "one pattern-edit notification per duplicate");
+    check(std::abs(f.velocityAt(7) - 0.80f) < 0.001f, "duplicate preserves velocity");
+}
+
+void testRepeatedDuplicateBuildsPhrases() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(2);
+    f.row->setStepSelection({1, 2});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::B, NUIModifiers::Ctrl)); // -> 3,4
+    f.row->onKeyEvent(keyPress(NUIKeyCode::B, NUIModifiers::Ctrl)); // -> 5,6
+    check(f.stepsForUnit() == std::vector<int>({1, 2, 3, 4, 5, 6}),
+          "repeated Ctrl+B builds the phrase step by step");
+}
+
+void testDuplicateSkipsOccupiedDestination() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(3);
+    f.addNote(4);
+    f.addNote(5); // occupies the would-be duplicate slot
+    f.row->setStepSelection({1, 3, 4});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::B, NUIModifiers::Ctrl));
+    check(f.stepsForUnit() == std::vector<int>({1, 3, 4, 5, 7, 8}),
+          "duplicate skips occupied destinations without clobbering");
+}
+
+void testDeleteRemovesOnlySelectedNotes() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(3);
+    f.addNote(4);
+    f.addNote(9);
+    f.row->setStepSelection({1, 3, 4});
+
+    std::vector<int> capturedSelection{1, 3, 4};
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Delete)), "Delete handled");
+    check(f.stepsForUnit() == std::vector<int>({9}), "Delete removes only the selected notes");
+    check(capturedSelection.empty(), "selection cleared after delete");
+}
+
+void testBackspaceConsumedWithEmptySelection() {
+    Fixture f;
+    f.row->setStepSelection({});
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Backspace)), "Backspace consumed on a step grid");
+    check(f.stepsForUnit().empty(), "no notes with empty selection");
+}
+
+// The reported regression: a unit whose pattern has notes but no loaded
+// sample still draws pads, but the old interaction gate required content, so
+// every click fell into the legacy toggle — left-click ERASED active notes
+// and drags never painted. All four tests below run on a notes-only row.
+void setupMouseRow(const std::shared_ptr<UnitRow>& row) {
+    row->setBounds(0.0f, 0.0f, 700.0f, 56.0f);
+    row->updateState();
+}
+
+void testLeftClickSelectsInsteadOfErasing() {
+    Fixture f;
+    f.addNote(2);
+    setupMouseRow(f.row);
+
+    std::vector<int> capturedSelection;
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    const float x = cellCenterX(2);
+    check(f.row->onMouseEvent(leftPress(x, 28.0f)), "press on active note handled");
+    check(f.row->onMouseEvent(leftRelease(x, 28.0f)), "release handled");
+    check(f.stepsForUnit() == std::vector<int>({2}), "left-click on a note never erases it");
+    check(capturedSelection == std::vector<int>({2}), "left-click selects the note");
+}
+
+void testGapClickDoesNotToggleNeighbor() {
+    Fixture f;
+    f.addNote(2);
+    setupMouseRow(f.row);
+
+    const float x = cellGapX(2);
+    f.row->onMouseEvent(leftPress(x, 28.0f));
+    f.row->onMouseEvent(leftRelease(x, 28.0f));
+    check(f.stepsForUnit() == std::vector<int>({2}), "gap click does not toggle the adjacent pad");
+}
+
+void testPaintDragWorksWithoutSample() {
+    Fixture f;
+    setupMouseRow(f.row);
+
+    std::vector<int> capturedSelection{-1};
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    const float y = 28.0f;
+    check(f.row->onMouseEvent(leftPress(cellCenterX(4), y)), "press on empty pad handled");
+    f.row->onMouseEvent(dragTo(cellCenterX(5), y));
+    f.row->onMouseEvent(dragTo(cellCenterX(6), y));
+    f.row->onMouseEvent(dragTo(cellCenterX(7), y));
+    f.row->onMouseEvent(leftRelease(cellCenterX(7), y));
+
+    check(f.stepsForUnit() == std::vector<int>({4, 5, 6, 7}), "left-drag paints the crossed range");
+    check(capturedSelection == std::vector<int>{-1},
+          "painted pads are placed, not auto-selected (placement never hijacks selection)");
+}
+
+void testClickOnEmptyPlacesWithoutSelecting() {
+    Fixture f;
+    f.addNote(1);
+    setupMouseRow(f.row);
+
+    std::vector<int> capturedSelection{1}; // setStepSelection never notifies — mirror the pushed state
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    f.row->setStepSelection({1});
+
+    // Plain click on an empty pad: places, selection untouched.
+    const float x = cellCenterX(4);
+    f.row->onMouseEvent(leftPress(x, 28.0f));
+    f.row->onMouseEvent(leftRelease(x, 28.0f));
+    check(f.stepsForUnit() == std::vector<int>({1, 4}), "click on empty pad places a note");
+    check(capturedSelection == std::vector<int>{1}, "placing a note does not select it");
+
+    // Shift+click on an empty pad: same — placement is not selection.
+    // Step outside the 400ms double-click-load window first (sample-less rows
+    // treat two rapid taps as "open the file picker", by design).
+    std::this_thread::sleep_for(std::chrono::milliseconds(450));
+    const float x2 = cellCenterX(6);
+    NUIMouseEvent shiftPress = leftPress(x2, 28.0f);
+    shiftPress.modifiers = NUIModifiers::Shift;
+    NUIMouseEvent shiftRelease = leftRelease(x2, 28.0f);
+    shiftRelease.modifiers = NUIModifiers::Shift;
+    f.row->onMouseEvent(shiftPress);
+    f.row->onMouseEvent(shiftRelease);
+    check(f.stepsForUnit() == std::vector<int>({1, 4, 6}), "shift+click on empty pad places a note");
+    check(capturedSelection == std::vector<int>{1}, "shift-placement does not select either");
+}
+
+void testEscClearsSelection() {
+    Fixture f;
+    f.addNote(2);
+    f.addNote(5);
+
+    std::vector<int> capturedSelection{2, 5};
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    f.row->setStepSelection({2, 5});
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Escape)), "Esc handled");
+    check(capturedSelection.empty(), "Esc dismisses the selection");
+    check(f.stepsForUnit() == std::vector<int>({2, 5}), "Esc never touches notes");
+}
+
+void testRightClickErasesCell() {
+    Fixture f;
+    f.addNote(2);
+    setupMouseRow(f.row);
+
+    check(f.row->onMouseEvent(rightPress(cellCenterX(2), 28.0f)), "right-click on pad handled");
+    check(f.stepsForUnit().empty(), "right-click on a pad erases it (no context menu on the grid)");
+}
+
+void testDoubleClickLoadsSampleOnNotesOnlyRow() {
+    Fixture f;
+    setupMouseRow(f.row);
+
+    int loadCount = 0;
+    f.row->setOnLoadUnitSample([&](Aestra::Audio::UnitID) { ++loadCount; });
+
+    const float x = cellCenterX(2);
+    f.row->onMouseEvent(leftPress(x, 28.0f));
+    f.row->onMouseEvent(leftRelease(x, 28.0f));
+    f.row->onMouseEvent(leftPress(x, 28.0f));
+    check(loadCount == 1, "double-click on a sample-less unit opens the file picker");
+}
+
+void testArrowKeysMoveSelectedNotes() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(3);
+    f.addNote(4);
+
+    std::vector<int> capturedSelection;
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    f.row->setStepSelection({1, 3, 4});
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Right)), "Right arrow handled");
+    check(f.stepsForUnit() == std::vector<int>({2, 4, 5}), "Right moves the selected notes one step");
+    check(capturedSelection == std::vector<int>({2, 4, 5}), "selection follows the moved notes");
+
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Left)), "Left arrow handled");
+    check(f.stepsForUnit() == std::vector<int>({1, 3, 4}), "Left moves them back");
+    check(capturedSelection == std::vector<int>({1, 3, 4}), "selection follows back");
+}
+
+void testMoveCascadesThroughAdjacentSelection() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(2);
+    f.row->setStepSelection({1, 2});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Right));
+    check(f.stepsForUnit() == std::vector<int>({2, 3}),
+          "adjacent selected notes cascade into each other's vacated slots");
+}
+
+void testMoveBlockedByUnselectedWall() {
+    Fixture f;
+    f.addNote(2);
+    f.addNote(3); // wall — not selected
+
+    std::vector<int> capturedSelection{2};
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    f.row->setStepSelection({2});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Right));
+    check(f.stepsForUnit() == std::vector<int>({2, 3}), "move blocked by an unselected note");
+    check(capturedSelection == std::vector<int>({2}), "blocked note stays selected in place");
+}
+
+void testMoveCascadeBlockedByWall() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(2);
+    f.addNote(3);
+    f.row->setStepSelection({1, 2});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Right));
+    check(f.stepsForUnit() == std::vector<int>({1, 2, 3}), "wall blocks the whole cascade");
+}
+
+void testMoveClampedAtGridEdges() {
+    Fixture f;
+    f.addNote(0);
+    f.addNote(15);
+    f.row->setStepSelection({0, 15});
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Left));
+    check(f.stepsForUnit() == std::vector<int>({0, 14}),
+          "Left clamps step 0 but still moves step 15 (per-step independence)");
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Right));
+    check(f.stepsForUnit() == std::vector<int>({1, 15}),
+          "Right clamps step 15 but still moves step 0");
+}
+
+void testArrowVelocityNudge() {
+    Fixture f;
+    f.addNote(2, 0.50f);
+    f.row->setStepSelection({2});
+
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Up));
+    check(std::abs(f.velocityAt(2) - 0.55f) < 0.001f, "Up nudges velocity louder");
+
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Down));
+    f.row->onKeyEvent(keyPress(NUIKeyCode::Down));
+    check(std::abs(f.velocityAt(2) - 0.45f) < 0.001f, "Down nudges velocity quieter");
+
+    for (int i = 0; i < 30; ++i) {
+        f.row->onKeyEvent(keyPress(NUIKeyCode::Down));
+    }
+    check(std::abs(f.velocityAt(2) - 0.05f) < 0.001f, "velocity clamps at the minimum");
+}
+
+void testArrowsConsumedWithEmptySelection() {
+    Fixture f;
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Right)), "Right consumed on a step grid");
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::Up)), "Up consumed on a step grid");
+    check(f.stepsForUnit().empty(), "no notes created by arrows with empty selection");
+}
+
+void testCtrlASelectsActiveNotes() {
+    Fixture f;
+    f.addNote(1);
+    f.addNote(3);
+    f.addNote(4);
+
+    std::vector<int> capturedSelection;
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    check(f.row->onKeyEvent(keyPress(NUIKeyCode::A, NUIModifiers::Ctrl)), "Ctrl+A handled");
+    check(capturedSelection == std::vector<int>({1, 3, 4}), "Ctrl+A selects the active notes only");
+    check(f.stepsForUnit() == std::vector<int>({1, 3, 4}), "Ctrl+A never edits notes");
+}
+
+void testCtrlAWithNoNotesClearsSelection() {
+    Fixture f;
+    f.row->setStepSelection({2, 5});
+
+    std::vector<int> capturedSelection{2, 5};
+    f.row->setOnStepSelectionChanged(
+        [&](Aestra::Audio::UnitID, const std::vector<int>& steps) { capturedSelection = steps; });
+
+    f.row->onKeyEvent(keyPress(NUIKeyCode::A, NUIModifiers::Ctrl));
+    check(capturedSelection.empty(), "Ctrl+A with no notes leaves nothing selected");
+}
+
+} // namespace
+
+int main() {
+    testDuplicateUsesOccupiedSpan();
+    testRepeatedDuplicateBuildsPhrases();
+    testDuplicateSkipsOccupiedDestination();
+    testDeleteRemovesOnlySelectedNotes();
+    testBackspaceConsumedWithEmptySelection();
+    testLeftClickSelectsInsteadOfErasing();
+    testGapClickDoesNotToggleNeighbor();
+    testPaintDragWorksWithoutSample();
+    testClickOnEmptyPlacesWithoutSelecting();
+    testRightClickErasesCell();
+    testDoubleClickLoadsSampleOnNotesOnlyRow();
+    testArrowKeysMoveSelectedNotes();
+    testMoveCascadesThroughAdjacentSelection();
+    testMoveBlockedByUnselectedWall();
+    testMoveCascadeBlockedByWall();
+    testMoveClampedAtGridEdges();
+    testArrowVelocityNudge();
+    testArrowsConsumedWithEmptySelection();
+    testCtrlASelectsActiveNotes();
+    testCtrlAWithNoNotesClearsSelection();
+    testEscClearsSelection();
+
+    if (g_failures == 0) {
+        std::cout << "UnitRowStepSelectionTest: all checks passed\n";
+        return 0;
+    }
+    std::cout << "UnitRowStepSelectionTest: " << g_failures << " failure(s)\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1929,6 +1929,25 @@ else()
     message(STATUS "PanelResizeLayoutTest skipped (AestraUI_Core target unavailable in this build mode)")
 endif()
 
+# Selection-based step editing regression: click-to-select grammar, Ctrl+B
+# span duplication, Delete/Backspace removal (2026-08-17).
+if(TARGET AestraUI_Core AND TARGET AestraAudio)
+    add_executable(UnitRowStepSelectionTest AestraUI/UnitRowStepSelectionTest.cpp)
+    target_link_libraries(UnitRowStepSelectionTest PRIVATE AestraUI_Core AestraAudio)
+    target_include_directories(UnitRowStepSelectionTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Core
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME UnitRowStepSelectionTest COMMAND UnitRowStepSelectionTest)
+    set_tests_properties(UnitRowStepSelectionTest PROPERTIES LABELS "ui;interaction;regression;contract:application")
+else()
+    message(STATUS "UnitRowStepSelectionTest skipped (AestraUI_Core target unavailable in this build mode)")
+endif()
+
 # The inspector rack must follow the LAST-bound chain: bindEffectRack() used
 # to append bindings and refreshRackDisplay() read the first match, so a
 # selection switch left the rack bound to a chain that died with its channel


### PR DESCRIPTION
## Decision citation

Objective:  N3 — producer-loop scenario (core editing workflow)
Decision:   FD-01 @ 210f9c6
Kind:       planned
Reversal:   —

## Summary

Selection-based step editing for the Arsenal step sequencer. Replaces click-to-toggle with a coherent editing grammar, in line with the "refine existing signals" direction — no new UI, the grid just behaves like a real editor.

**Grammar**
- Click an **already-placed** note → select it. Placement (click/paint on empty pads) never hijacks the selection.
- Shift+click → additive, non-contiguous selection
- Ctrl+B → duplicate the selection right after its occupied span ({1,3,4} → {5,7,8}); duplicates become the selection; pitch/duration/velocity preserved; occupied destinations skipped
- Delete/Backspace → remove all selected notes (one undo entry)
- ←/→ → move selected notes one step (per-step independence: unselected notes are walls, cascades resolve, edges clamp; selection follows)
- ↑/↓ → velocity nudge ±0.05 on selected notes
- Ctrl+A → select all **active** notes (not empty slots)
- Esc → dismiss the selection

**Behavior fixes along the way**
- Left-drag always paints (dragging from an active note extends the phrase — it used to erase)
- Right-drag erases; right-click no longer raises the context menu on the grid — the row menu now lives on the far-left name area only
- Step grids are editable on notes-only units (a pattern with notes but no loaded sample used to fall into a legacy toggle that erased on click, and paint did nothing)
- Gap/padding clicks are dead space instead of toggling the nearest pad (that was the second left-click-erase path)
- Double-click on a sample-less unit still opens the file picker

## Why

The founder spec: "click = create/select, never toggle". The toggle path was a silent trap (clicking between adjacent notes erased them), and selection unlocks bulk ops (move/duplicate/delete/velocity) that the toggle could never express. Core editing surface of the producer loop — the work the first promise (FD-01) exists to make trustworthy.

## Testing performed

- New `UnitRowStepSelectionTest` (headless, through the public surface): 18 checks — span duplication, selection adoption, cascade/wall/edge-clamp moves, velocity nudge, Ctrl+A active-notes-only, Esc, placement-never-selects, paint-places-without-selecting, notes-only-row interaction. All pass.
- `ctest -R 'Arsenal|PanelResizeLayoutTest|WindowPanelRaiseTest|UnitRowStepSelection'` — all pass
- `Aestra` build: green; `git diff --check`: clean

## Producer note

Now you can select steps and move, duplicate, or delete them with the keyboard.

## Docs updated

No.

## Risk/rollback notes

- Left-drag erase is gone by design (Delete/Backspace + right-drag erase remain) — intentional per founder spec
- Up/Down velocity nudge is a small addition beyond the letter of the ask (mirrors the grid's vertical drag axis); trivial to drop
- Each key press is its own undo entry; holding an arrow produces one entry per step
- Unit selection (row highlight) is still menu-driven — clicking steps doesn't select the row; the step halo marks the editing context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added selection-based editing for Arsenal step sequencer notes. Users can select, multi-select, duplicate, delete, move, adjust velocity, select all, and clear selections.
- Updated grid interactions. Left-drag paints, right-drag erases, gap clicks do nothing, and the row context menu opens only from the unit-name area.
- Enabled editing for notes-only units without a loaded sample. Double-clicking these units still opens the sample picker.
- Added grouped step spacing, selection highlights, synchronized scrolling, fit/scroll controls, progress markers, adjustable step counts, and improved mute/solo states.
- Added preferred-height notifications and exposed unit rename state through `UnitNameLabel::isRenaming()`.
- Added 18 headless regression checks for selection, editing, mouse interaction, sample-less rows, and keyboard behavior. Build and diff validation pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->