### PR TITLE
feat: track-based recording identity — FD-14 Phase 3

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -255,6 +255,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/RenderAudioClipCommand.cpp
     src/Commands/ImportAudioClipCommand.cpp
     src/Commands/AddClipCommand.cpp
+    src/Commands/AttachLaneToTrackCommand.cpp
     src/Commands/CreateLaneCommand.cpp
     src/Commands/AddNoteCommand.cpp
     src/Commands/RemoveNoteCommand.cpp

--- a/AestraAudio/include/Commands/AttachLaneToTrackCommand.h
+++ b/AestraAudio/include/Commands/AttachLaneToTrackCommand.h
@@ -1,0 +1,45 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraUUID.h"
+#include "Commands/ICommand.h"
+#include "Models/PlaylistModel.h"
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+
+/**
+ * @brief Attach an existing lane to its owning Track (FD-14 ownership).
+ *
+ * Joins CreateLaneCommand in a take's transaction so lane ownership is part
+ * of the same undoable step: undo detaches the lane from the track before
+ * CreateLaneCommand removes the lane, keeping track->laneIds consistent.
+ * Ownership is by stable ids only — never positional.
+ */
+class AttachLaneToTrackCommand : public ICommand {
+public:
+    AttachLaneToTrackCommand(TrackManager& trackManager, uint64_t trackId, PlaylistLaneID laneId);
+    ~AttachLaneToTrackCommand() override = default;
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    std::string getName() const override { return "Attach Lane To Track"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    std::string serialize() const override;
+    std::string type() const override { return "attach_lane_to_track"; }
+
+private:
+    TrackManager& m_trackManager;
+    uint64_t m_trackId{0};
+    PlaylistLaneID m_laneId;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -4,6 +4,7 @@
 #include "../Commands/CommandHistory.h"
 #include "../Commands/CommandTransaction.h"
 #include "../Commands/CreateLaneCommand.h"
+#include "../Commands/AttachLaneToTrackCommand.h"
 #include "../Core/AudioCommandQueue.h"
 #include "../Core/AudioTelemetry.h"
 #include "../Core/ChannelSlotMap.h"
@@ -62,6 +63,7 @@ public:
         std::atomic<uint64_t> totalCapturedFrames{0};
         std::atomic<bool> hasStarted{false};
         int inputIndex{-1};
+        uint64_t trackId{0};
     };
 
     struct RtInputMonitorRoute {
@@ -416,6 +418,24 @@ public:
         track->laneIds.push_back(laneId);
         if (!track->activeLaneId.isValid()) {
             track->activeLaneId = laneId;
+        }
+        return true;
+    }
+
+    /** @brief Detach a lane from its Track (undo of attachLaneToTrack).
+     *  Returns false when either id is invalid or the lane is not owned by
+     *  the track. */
+    bool detachLaneFromTrack(uint64_t trackId, PlaylistLaneID laneId) {
+        auto* track = getTrack(trackId);
+        auto* lane = m_playlistModel.getLane(laneId);
+        if (!track || !lane || lane->trackId != trackId) {
+            return false;
+        }
+        lane->trackId = 0;
+        auto& lanes = track->laneIds;
+        lanes.erase(std::remove(lanes.begin(), lanes.end(), laneId), lanes.end());
+        if (track->activeLaneId == laneId) {
+            track->activeLaneId = lanes.empty() ? PlaylistLaneID{} : lanes.back();
         }
         return true;
     }
@@ -1116,7 +1136,7 @@ public:
     void scheduleTimelineForOfflineRender(double playStartPositionSeconds = 0.0) {
         scheduleTimelinePatternInstances(playStartPositionSeconds);
     }
-    bool hasArmedTracks() const { return getArmedTrackCount() > 0; }
+    bool hasArmedTracks() const { return getTrackArmedCount() > 0; }
 
     /**
      * @brief Toggle record-arm state and manage capture session lifetime.
@@ -1567,8 +1587,12 @@ private:
         m_recordingCaptureAccepting.store(false, std::memory_order_release);
         m_recordingCaptures.clear();
         const size_t maxSamplesPerCapture = maxRecordingSamplesPerCapture();
-        for (const auto& channel : m_channels) {
-            if (!channel || !channel->isArmed()) {
+        for (const auto& [trackId, track] : m_tracks) {
+            if (!track.armed) {
+                continue;
+            }
+            auto* channel = getChannelById(track.channelId);
+            if (!channel) {
                 continue;
             }
             const int requestedInput = channel->getInputChannelIndex();
@@ -1584,6 +1608,7 @@ private:
             capture->totalCapturedFrames.store(0, std::memory_order_relaxed);
             capture->hasStarted.store(false, std::memory_order_relaxed);
             capture->inputIndex = requestedInput;
+            capture->trackId = trackId;
             m_recordingCaptures[channel->getChannelId()] = std::move(capture);
         }
         m_recordingSessionStartBeat = getCurrentTransportBeat();
@@ -1603,7 +1628,7 @@ private:
         m_recordingCaptureAccepting.store(true, std::memory_order_release);
         m_isCapturing.store(true, std::memory_order_relaxed);
         publishRecordingCaptureSnapshot();
-        Log::info("[TrackManager] Recording session started. Armed tracks: " + std::to_string(getArmedTrackCount()) +
+        Log::info("[TrackManager] Recording session started. Armed tracks: " + std::to_string(getTrackArmedCount()) +
                   ", input channels: " + std::to_string(m_inputChannelCount));
     }
 
@@ -1650,14 +1675,21 @@ private:
         Log::info("[TrackManager] Recording session stopped. Captured tracks: " + std::to_string(captures.size()));
 
         for (const auto& [channelId, capture] : captures) {
+            (void)channelId;
             if (capture) {
-                commitRecordingTake(channelId, *capture, sessionStartBeat, sessionUsesPlacementOverride);
+                commitRecordingTake(capture->trackId, *capture, sessionStartBeat, sessionUsesPlacementOverride);
             }
         }
     }
 
-    void commitRecordingTake(uint32_t channelId, const RecordingCapture& capture, double fallbackStartBeat,
+    void commitRecordingTake(uint64_t trackId, const RecordingCapture& capture, double fallbackStartBeat,
                              bool forcePlacementStartBeat) {
+        auto* track = getTrack(trackId);
+        if (!track) {
+            Log::warning("[TrackManager] Could not resolve Track for recorded take: " + std::to_string(trackId));
+            return;
+        }
+        const uint32_t channelId = track->channelId;
         std::vector<float> capturedSamples = copyCaptureSamples(capture);
         if (capturedSamples.empty()) {
             return;
@@ -1665,7 +1697,7 @@ private:
 
         if (!getChannelById(channelId)) {
             Log::warning("[TrackManager] Could not resolve mixer insert for recorded take " +
-                         std::to_string(channelId));
+                         std::to_string(channelId) + " (track " + std::to_string(trackId) + ")");
             return;
         }
 
@@ -1758,11 +1790,28 @@ private:
             return;
         }
 
+        // The take lane is owned by the recording Track (FD-14): the lane
+        // joins the track in the same undoable step as its creation, so undo
+        // detaches and removes it atomically.
+        auto attachLane = std::make_shared<AttachLaneToTrackCommand>(*this, trackId, laneId);
+        attachLane->execute();
+        auto* ownedLane = m_playlistModel.getLane(laneId);
+        if (!ownedLane || ownedLane->trackId != trackId) {
+            attachLane->undo();
+            addClip->undo();
+            createLane->undo();
+            m_patternManager.removePattern(patternId);
+            Log::error("[TrackManager] Failed to attach recorded take lane to track " + std::to_string(trackId));
+            return;
+        }
+
         auto transaction = std::make_shared<CommandTransaction>("Record Take");
         transaction->add(createLane);
         transaction->add(addClip);
+        transaction->add(attachLane);
         transaction->markExecuted();
         if (!m_commandHistory.pushExecuted(transaction)) {
+            attachLane->undo();
             addClip->undo();
             createLane->undo();
             m_patternManager.removePattern(patternId);
@@ -1911,16 +1960,6 @@ private:
                 sample *= scale;
             }
         }
-    }
-
-    size_t getArmedTrackCount() const {
-        size_t count = 0;
-        for (const auto& channel : m_channels) {
-            if (channel && channel->isArmed()) {
-                ++count;
-            }
-        }
-        return count;
     }
 
     size_t findChannelIndexById(uint32_t channelId) const {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1,13 +1,13 @@
 #pragma once
-#include "../Core/GraphDirtyReason.h"
 #include "../Commands/AddClipCommand.h"
+#include "../Commands/AttachLaneToTrackCommand.h"
 #include "../Commands/CommandHistory.h"
 #include "../Commands/CommandTransaction.h"
 #include "../Commands/CreateLaneCommand.h"
-#include "../Commands/AttachLaneToTrackCommand.h"
 #include "../Core/AudioCommandQueue.h"
 #include "../Core/AudioTelemetry.h"
 #include "../Core/ChannelSlotMap.h"
+#include "../Core/GraphDirtyReason.h"
 #include "../Core/MixerChannel.h"
 #include "../DSP/ContinuousParamBuffer.h"
 #include "../DSP/PanLaw.h"
@@ -19,8 +19,8 @@
 #include "MeterSnapshot.h"
 #include "PatternManager.h"
 #include "PlaylistModel.h"
-#include "Track.h"
 #include "SourceManager.h"
+#include "Track.h"
 #include "UnitManager.h"
 
 #include <algorithm>
@@ -30,7 +30,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <ctime>
-#include <unordered_set>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -41,6 +40,7 @@
 #include <sstream>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace Aestra {
@@ -323,8 +323,7 @@ public:
             return false;
         }
         const size_t clamped = std::min(index, m_channels.size());
-        m_channels.insert(m_channels.begin() + static_cast<std::ptrdiff_t>(clamped),
-                          std::move(channel));
+        m_channels.insert(m_channels.begin() + static_cast<std::ptrdiff_t>(clamped), std::move(channel));
         requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
         m_modified.store(true, std::memory_order_relaxed);
         if (!m_channelSlotMap) {
@@ -368,8 +367,7 @@ public:
      * @param channelId Routing destination (MASTER_MIXER_CHANNEL_ID default).
      * @return The new track's stable id, or 0 on failure.
      */
-    uint64_t createTrack(PlaylistLaneID laneId, const std::string& name,
-                         uint32_t channelId = MASTER_MIXER_CHANNEL_ID) {
+    uint64_t createTrack(PlaylistLaneID laneId, const std::string& name, uint32_t channelId = MASTER_MIXER_CHANNEL_ID) {
         auto* lane = m_playlistModel.getLane(laneId);
         if (!lane) {
             return 0;
@@ -469,8 +467,7 @@ public:
             result.push_back(&track);
         }
         // Deterministic serialization order (unordered_map iteration is not).
-        std::sort(result.begin(), result.end(),
-                  [](const Track* a, const Track* b) { return a->trackId < b->trackId; });
+        std::sort(result.begin(), result.end(), [](const Track* a, const Track* b) { return a->trackId < b->trackId; });
         return result;
     }
 
@@ -670,14 +667,14 @@ public:
 
     /**
      * @brief Get a copy of the currently captured waveform for one armed track.
-     * @param channelId Target channel identifier.
+     * @param trackId Target track identifier.
      * @param recordingData Output buffer for captured samples.
      * @param startBeat Output start beat for the returned capture.
      * @return True when captured waveform data exists for the target track.
      */
-    bool getRecordingDataSnapshot(uint32_t channelId, std::vector<float>& recordingData, double& startBeat) {
+    bool getRecordingDataSnapshot(uint64_t trackId, std::vector<float>& recordingData, double& startBeat) {
         std::lock_guard<std::mutex> lock(m_recordingMutex);
-        auto it = m_recordingCaptures.find(channelId);
+        auto it = m_recordingCaptures.find(trackId);
         if (it == m_recordingCaptures.end() || !it->second) {
             return false;
         }
@@ -1248,7 +1245,8 @@ public:
      */
     void markModified() {
         m_modified.store(true, std::memory_order_relaxed);
-        if (m_onModified) m_onModified();
+        if (m_onModified)
+            m_onModified();
     }
     /**
      * @brief Override the project modified flag.
@@ -1281,31 +1279,23 @@ public:
     /**
      * @brief Check if a rebuild has been requested (non-consuming).
      */
-    bool hasPendingGraphRebuild() const {
-        return m_graphDirty.load(std::memory_order_acquire);
-    }
+    bool hasPendingGraphRebuild() const { return m_graphDirty.load(std::memory_order_acquire); }
 
     /**
      * @brief Get the request generation counter (non-consuming).
      */
-    uint64_t graphRebuildRequestGeneration() const {
-        return m_requestGeneration.load(std::memory_order_relaxed);
-    }
+    uint64_t graphRebuildRequestGeneration() const { return m_requestGeneration.load(std::memory_order_relaxed); }
 
     /**
      * @brief Get the last reason for a rebuild request (non-consuming).
      */
-    GraphDirtyReason lastGraphDirtyReason() const {
-        return m_lastReason.load(std::memory_order_relaxed);
-    }
+    GraphDirtyReason lastGraphDirtyReason() const { return m_lastReason.load(std::memory_order_relaxed); }
 
     /**
      * @brief Consume and clear pending rebuild request.
      * ONLY PlaybackGraphController should call this.
      */
-    bool consumePendingGraphRebuild() {
-        return m_graphDirty.exchange(false, std::memory_order_acq_rel);
-    }
+    bool consumePendingGraphRebuild() { return m_graphDirty.exchange(false, std::memory_order_acq_rel); }
 
     /**
      * @brief Push effect chain snapshots for all channels.
@@ -1501,7 +1491,8 @@ private:
         const uint32_t inactive = 1u - m_activeRecordingCaptureSnapshot.load(std::memory_order_relaxed);
         auto& snap = m_recordingCaptureSnapshots[inactive];
         uint32_t count = 0;
-        for (const auto& [channelId, capture] : m_recordingCaptures) {
+        for (const auto& [captureTrackId, capture] : m_recordingCaptures) {
+            (void)captureTrackId;
             if (!capture) {
                 continue;
             }
@@ -1609,7 +1600,7 @@ private:
             capture->hasStarted.store(false, std::memory_order_relaxed);
             capture->inputIndex = requestedInput;
             capture->trackId = trackId;
-            m_recordingCaptures[channel->getChannelId()] = std::move(capture);
+            m_recordingCaptures[trackId] = std::move(capture);
         }
         m_recordingSessionStartBeat = getCurrentTransportBeat();
         m_recordingSessionUsesPlacementOverride = m_hasNextCapturePlacementStartBeat.load(std::memory_order_relaxed);
@@ -1656,7 +1647,7 @@ private:
         m_recordingCaptureRouteCounts[1].store(0, std::memory_order_release);
         m_activeRecordingCaptureSnapshot.store(0, std::memory_order_release);
 
-        std::unordered_map<uint32_t, std::unique_ptr<RecordingCapture>> captures;
+        std::unordered_map<uint64_t, std::unique_ptr<RecordingCapture>> captures;
         double sessionStartBeat = 0.0;
         bool sessionUsesPlacementOverride = false;
         {
@@ -2058,7 +2049,7 @@ private:
     std::atomic<uint64_t> m_requestGeneration{0};
     std::atomic<GraphDirtyReason> m_lastReason{GraphDirtyReason::TimelineChanged};
     mutable std::mutex m_recordingMutex;
-    std::unordered_map<uint32_t, std::unique_ptr<RecordingCapture>> m_recordingCaptures;
+    std::unordered_map<uint64_t, std::unique_ptr<RecordingCapture>> m_recordingCaptures;
     std::atomic<uint32_t> m_recordingWriters{0};
     std::atomic<bool> m_recordingCaptureAccepting{false};
     std::array<std::atomic<float>, 8> m_inputPeaks{};

--- a/AestraAudio/src/Commands/AttachLaneToTrackCommand.cpp
+++ b/AestraAudio/src/Commands/AttachLaneToTrackCommand.cpp
@@ -1,0 +1,47 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/AttachLaneToTrackCommand.h"
+
+#include "Models/TrackManager.h"
+
+#include <sstream>
+
+namespace Aestra {
+namespace Audio {
+
+AttachLaneToTrackCommand::AttachLaneToTrackCommand(TrackManager& trackManager, uint64_t trackId, PlaylistLaneID laneId)
+    : m_trackManager(trackManager), m_trackId(trackId), m_laneId(laneId) {}
+
+void AttachLaneToTrackCommand::execute() {
+    if (m_executed) {
+        return;
+    }
+    m_executed = m_trackManager.attachLaneToTrack(m_trackId, m_laneId);
+}
+
+void AttachLaneToTrackCommand::undo() {
+    if (!m_executed) {
+        return;
+    }
+    m_trackManager.detachLaneFromTrack(m_trackId, m_laneId);
+    m_executed = false;
+}
+
+void AttachLaneToTrackCommand::redo() {
+    if (m_executed) {
+        return;
+    }
+    m_executed = m_trackManager.attachLaneToTrack(m_trackId, m_laneId);
+}
+
+std::string AttachLaneToTrackCommand::serialize() const {
+    std::ostringstream oss;
+    oss << "{"
+        << "\"type\":\"attach_lane_to_track\","
+        << "\"track_id\":" << m_trackId << ","
+        << "\"lane_id\":\"" << m_laneId.toString() << "\""
+        << "}";
+    return oss.str();
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2789,11 +2789,13 @@ void TrackUIComponent::renderAutomationLayer(AestraUI::NUIRenderer& renderer, co
 void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds, float controlAreaWidth) {
     if (!m_trackManager || !m_channel) return;
     if (!m_trackManager->isRecording()) return;
-    if (!m_channel->isArmed()) return;
+    auto* lane = m_trackManager->getPlaylistModel().getLane(m_laneId);
+    auto* track = lane ? m_trackManager->getTrack(lane->trackId) : nullptr;
+    if (!track || !track->armed) return;
 
     std::vector<float> recordingData;
     double startBeat = 0.0;
-    bool gotSnapshot = m_trackManager->getRecordingDataSnapshot(m_channel->getChannelId(), recordingData, startBeat);
+    bool gotSnapshot = m_trackManager->getRecordingDataSnapshot(track->trackId, recordingData, startBeat);
     
     if (!gotSnapshot || recordingData.empty()) return;
 

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -1,26 +1,30 @@
 // © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
-// RecordingBaselineTest — Phase 2 of the Track/Lane/Channel migration (vault:
-// "Track Lane Channel Ownership Contract").
+// RecordingBaselineTest — Phase 2 baseline + Phase 3 acceptance of the
+// Track/Lane/Channel migration (vault: "Track Lane Channel Ownership Contract").
 //
-// This file captures CURRENT behavior as a regression baseline. Two sections:
+// Phase 2 (pre-migration) captured CURRENT behavior as a regression baseline:
 //
 //   SECTION A — surviving invariants: behavior that MUST hold after the
 //               migration (recorded audio routes to the armed channel; one
 //               undoable transaction; dirty state; multi-arm independence;
 //               one lane per take).
 //
-//   SECTION B — expected-to-change behavior: the current reality the
-//               migration removes (channel-based recording identity; lanes
-//               without ownership; flat ungrouped lanes; no Track entity).
-//               These assertions are intentionally RED against the future
-//               architecture — when the migration lands they are replaced by
-//               the new acceptance, they are NOT "fixed" by weakening them.
+//   SECTION B — expected-to-change behavior, intentionally RED against the
+//               future architecture (channel-based recording identity; lanes
+//               without ownership; no Track entity).
 //
-// Nothing here may be changed to make the baseline pass. If a Section A
-// assertion fails after the migration, the migration broke an invariant.
+// Phase 3 landed the migration. Section A is unchanged in its assertions and
+// arms TRACKS (the arming surface moved, the invariants did not). Each track
+// is created with one lane, so a recorded take is the track's NEXT lane
+// (track-local numbering). Section B was replaced by the new acceptance:
+// recording identity is track-based, lanes are owned and track-local
+// numbered, and the Track entity carries the arm. Nothing in Section A may be
+// weakened — if an assertion fails here, the migration broke an invariant.
 
-#include "Models/TrackManager.h"
+#include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
 #include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
 
 #include <cmath>
 #include <cstdint>
@@ -52,7 +56,7 @@ std::shared_ptr<TrackManager> makeRecorder() {
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(kSampleRate));
     tm->getPlaylistModel().setBPM(kBpm);
-    tm->setInputChannelCount(1);
+    tm->setInputChannelCount(2);
     tm->setMaxRecordingSeconds(5.0);
     return tm;
 }
@@ -72,33 +76,73 @@ void feedInput(TrackManager& tm, double seconds) {
     }
 }
 
+/** Create a lane, a channel, a Track owning the lane and routing to the
+ *  channel, and arm the Track (FD-14: the Track's arm is authoritative).
+ *  Mirrors the app: a track is born with one lane. */
+uint64_t armTrack(TrackManager& tm, const std::string& channelName, int inputIndex) {
+    const PlaylistLaneID laneId = tm.getPlaylistModel().createLane(channelName);
+    MixerChannel* ch = tm.addChannel(channelName);
+    if (!ch) {
+        return 0;
+    }
+    ch->setInputChannelIndex(inputIndex);
+    const uint64_t trackId = tm.createTrack(laneId, channelName, ch->getChannelId());
+    if (trackId != 0) {
+        tm.setTrackArmed(trackId, true);
+    }
+    return trackId;
+}
+
+/** The lane holding a recorded take clip, or an invalid id. */
+PlaylistLaneID takeLaneOf(TrackManager& tm, uint64_t trackId) {
+    auto* track = tm.getTrack(trackId);
+    if (!track) {
+        return {};
+    }
+    for (const auto& laneId : track->laneIds) {
+        auto* lane = tm.getPlaylistModel().getLane(laneId);
+        if (lane && !lane->clips.empty()) {
+            return laneId;
+        }
+    }
+    return {};
+}
+
+void recordTake(TrackManager& tm, double seconds) {
+    tm.onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
+    feedInput(tm, seconds);
+    tm.onTransportStateApplied(false, static_cast<uint64_t>(seconds * kSampleRate), static_cast<double>(kSampleRate));
+}
+
 size_t laneCount(TrackManager& tm) {
     return tm.getPlaylistModel().getLaneIDs().size();
 }
 
 // ===========================================================================
-// SECTION A — surviving invariants (must stay green after the migration)
+// SECTION A — surviving invariants (armed via Tracks; assertions unchanged)
 // ===========================================================================
 
-void testTakeRoutesToArmedChannel() {
-    std::cout << "[A] take routes to the armed channel\n";
+void testTakeRoutesToArmedTrackChannel() {
+    std::cout << "[A] take routes to the armed track's channel\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 5");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
-
-    tm->record();
-    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-    feedInput(*tm, 1.0);
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
-
-    const auto laneIds = tm->getPlaylistModel().getLaneIDs();
-    check(laneIds.size() == 1, "one take creates one lane");
-    if (laneIds.empty()) {
+    const uint64_t trackId = armTrack(*tm, "Guitar", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
         return;
     }
-    auto* lane = tm->getPlaylistModel().getLane(laneIds[0]);
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track resolvable by id");
+
+    tm->record();
+    recordTake(*tm, 1.0);
+
+    const PlaylistLaneID takeLaneId = takeLaneOf(*tm, trackId);
+    check(takeLaneId.isValid(), "one take creates one take lane");
+    if (!takeLaneId.isValid()) {
+        return;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLaneId);
+    check(lane != nullptr, "take lane is on the playlist");
     check(lane && !lane->clips.empty(), "take clip is on the lane");
     if (!lane || lane->clips.empty()) {
         return;
@@ -107,179 +151,270 @@ void testTakeRoutesToArmedChannel() {
     auto* pattern = patternManager.getPattern(lane->clips[0].patternId);
     check(pattern != nullptr, "take clip references a pattern");
     if (pattern) {
-        check(pattern->getMixerChannelId() == ch->getChannelId(),
-              "take pattern routes to the armed channel (id " + std::to_string(ch->getChannelId()) + ")");
+        check(pattern->getMixerChannelId() == track->channelId,
+              "take pattern routes to the armed track's channel (id " + std::to_string(track->channelId) + ")");
     }
 }
 
 void testRecordingIsOneUndoableTransaction() {
     std::cout << "[A] recording is one undoable transaction\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 1");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
 
     tm->record();
-    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-    feedInput(*tm, 1.0);
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
-
-    check(laneCount(*tm) == 1, "take committed before undo");
+    recordTake(*tm, 1.0);
+    check(tm->getCommandHistory().canUndo(), "take committed before undo");
+    check(laneCount(*tm) == 2, "setup lane plus one take lane");
     check(tm->getCommandHistory().undo(), "undo of the take succeeds");
-    check(laneCount(*tm) == 0, "undo removes the take's lane");
+    check(laneCount(*tm) == 1, "undo removes the take's lane");
+    check(!takeLaneOf(*tm, trackId).isValid(), "undo leaves no take lane on the track");
     check(tm->getCommandHistory().redo(), "redo restores the take");
-    check(laneCount(*tm) == 1, "redo restores the take's lane");
+    check(laneCount(*tm) == 2, "redo restores the take's lane");
+    check(takeLaneOf(*tm, trackId).isValid(), "redo restores the take lane on the track");
 }
 
 void testDirtyStateUpdated() {
     std::cout << "[A] dirty state updated by recording\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 1");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
 
-    tm->setModified(false);
     tm->record();
-    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-    feedInput(*tm, 1.0);
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
-
+    recordTake(*tm, 1.0);
     check(tm->isModified(), "project is dirty after a recorded take");
 }
 
-void testMultipleArmedChannelsCaptureIndependently() {
-    std::cout << "[A] multiple armed channels capture independently\n";
+void testMultipleArmedTracksCaptureIndependently() {
+    std::cout << "[A] multiple armed tracks capture independently\n";
     auto tm = makeRecorder();
-    tm->setInputChannelCount(2);
-    MixerChannel* ch1 = tm->addChannel("Ch 1");
-    ch1->setArmed(true);
-    ch1->setInputChannelIndex(0);
-    MixerChannel* ch2 = tm->addChannel("Ch 2");
-    ch2->setArmed(true);
-    ch2->setInputChannelIndex(1);
+    const uint64_t track1 = armTrack(*tm, "Ch 1", 0);
+    const uint64_t track2 = armTrack(*tm, "Ch 2", 1);
+    check(track1 != 0 && track2 != 0, "two tracks created and armed");
 
     tm->record();
-    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-    feedInput(*tm, 1.0);
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
+    recordTake(*tm, 1.0);
 
-    check(laneCount(*tm) == 2, "two armed channels produce two take lanes");
+    auto* t1 = tm->getTrack(track1);
+    auto* t2 = tm->getTrack(track2);
+    check(t1 && t2, "both tracks resolvable");
+    check(t1 && t1->laneIds.size() == 2, "track 1 owns its setup lane plus one take lane");
+    check(t2 && t2->laneIds.size() == 2, "track 2 owns its setup lane plus one take lane");
+    if (t1 && t2 && t1->laneIds.size() == 2 && t2->laneIds.size() == 2) {
+        const PlaylistLaneID take1 = takeLaneOf(*tm, track1);
+        const PlaylistLaneID take2 = takeLaneOf(*tm, track2);
+        check(take1.isValid() && take2.isValid(), "each armed track captured a take");
+        check(take1 != take2, "each take lane is distinct");
+        check(t1->laneIds[1] == take1 && t2->laneIds[1] == take2, "each take landed on its own track's lane");
+    }
 }
 
 void testEachTakeCreatesALane() {
-    std::cout << "[A] each take creates a lane\n";
+    std::cout << "[A] each take creates a track-local lane\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 1");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
 
     // Arm ONCE: the app keeps record-armed across takes; each play/stop
     // pass captures and commits its own take.
     tm->record();
     for (int pass = 1; pass <= 2; ++pass) {
-        tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-        feedInput(*tm, 1.0);
-        tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                    static_cast<double>(kSampleRate));
+        recordTake(*tm, 1.0);
     }
-    check(laneCount(*tm) == 2, "two recording passes create two lanes");
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track still resolvable");
+    if (track) {
+        check(track->laneIds.size() == 3, "two recording passes create two take lanes");
+        const PlaylistLaneID take1 = takeLaneOf(*tm, trackId);
+        check(take1.isValid(), "first take lane exists");
+        if (take1.isValid()) {
+            check(track->laneNumber(take1) == 2, "first take lane is track-local lane 2");
+            check(track->laneIds.size() == 3, "take lanes accumulate track-locally");
+        }
+    }
 }
 
 // ===========================================================================
-// SECTION B — expected-to-change (RED against the future architecture)
+// SECTION B — post-migration acceptance (the Phase 2 RED assertions now hold)
 // ===========================================================================
 
-void testRecordingIdentityIsChannelBased() {
-    std::cout << "[B] recording identity is channel-based (expected to change)\n";
+void testRecordingIdentityIsTrackBased() {
+    std::cout << "[B] recording identity is track-based\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 5");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
-
-    // The arm state that drives recording lives on the CHANNEL.
-    tm->record();
-    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-    feedInput(*tm, 1.0);
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
-
-    const auto laneIds = tm->getPlaylistModel().getLaneIDs();
-    check(laneIds.size() == 1, "take landed on a lane");
-    if (laneIds.empty()) {
+    const uint64_t trackId = armTrack(*tm, "Guitar", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
         return;
     }
-    auto* lane = tm->getPlaylistModel().getLane(laneIds[0]);
-    // Current reality: the lane's only tie to the armed channel is the
-    // pattern's OWN routing — the lane itself carries no ownership. Post
-    // migration, the lane must be reachable as the track's lane.
+
+    tm->record();
+    recordTake(*tm, 1.0);
+
+    const PlaylistLaneID takeLaneId = takeLaneOf(*tm, trackId);
+    check(takeLaneId.isValid(), "take landed on a lane");
+    if (!takeLaneId.isValid()) {
+        return;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLaneId);
     check(lane != nullptr, "lane exists");
     if (!lane) {
         return;
     }
-    check(lane->name.find("Ch 5") == std::string::npos,
-          "lane name is the take name, not the armed channel/track (no ownership naming today)");
+    check(lane->trackId == trackId, "lane is owned by the recording track");
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "recording track resolvable");
+    if (track) {
+        check(track->laneNumber(lane->id) == 2, "take lane is track-local lane 2 (after the born-with lane)");
+    }
+    check(tm->getTrackForLane(lane->id) == track, "lane resolves to its track");
 }
 
-void testLanesHaveNoOwnership() {
-    std::cout << "[B] lanes have no ownership (expected to change)\n";
+void testLanesOwnedAndGrouped() {
+    std::cout << "[B] lanes are owned and grouped by track\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 1");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
 
     tm->record();
     for (int pass = 1; pass <= 2; ++pass) {
-        tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
-        feedInput(*tm, 1.0);
-        tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                    static_cast<double>(kSampleRate));
+        recordTake(*tm, 1.0);
     }
 
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track resolvable");
+    if (!track) {
+        return;
+    }
+    check(track->laneIds.size() == 3, "all three lanes group under the same track");
     const auto laneIds = tm->getPlaylistModel().getLaneIDs();
-    check(laneIds.size() == 2, "two flat lanes after two passes");
-    // Current reality: nothing groups these lanes — they are independent
-    // playlist rows. Post migration, both must resolve to the SAME track.
+    check(laneIds.size() == 3, "playlist holds the same three lanes");
+    for (const auto& laneId : laneIds) {
+        auto* lane = tm->getPlaylistModel().getLane(laneId);
+        check(lane && lane->trackId == trackId, "every lane carries the track's stable id");
+    }
+    check(track->laneNumber(track->laneIds[0]) == 1 && track->laneNumber(track->laneIds[1]) == 2 &&
+              track->laneNumber(track->laneIds[2]) == 3,
+          "lanes have consecutive track-local numbers");
 }
 
-void testNoTrackEntity() {
-    std::cout << "[B] no Track entity exists (expected to change)\n";
+void testTrackEntityHoldsArm() {
+    std::cout << "[B] the Track entity holds the recording arm\n";
     auto tm = makeRecorder();
-    MixerChannel* ch = tm->addChannel("Ch 1");
-    ch->setArmed(true);
-    ch->setInputChannelIndex(0);
+    check(tm->getTrackArmedCount() == 0, "no armed tracks initially");
+    check(tm->getTracks().empty(), "no tracks exist before arming");
 
-    // Current reality: record() is a GLOBAL toggle; there is no per-track
-    // arm, no per-track capture, no track id anywhere in the recording path.
-    // Post migration, arming and recording are track-scoped operations.
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created");
+    if (trackId == 0) {
+        return;
+    }
+    check(tm->getTrackArmedCount() == 1, "arm is model state on the track");
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr && track->armed, "track carries the armed flag");
+    check(tm->getTracks().size() == 1, "track listed by the manager");
+
+    // Channel arming alone no longer starts a capture: the track is the only
+    // recording control. With the track disarmed, no take may be committed.
+    tm->setTrackArmed(trackId, false);
+    if (auto* ch = tm->getChannelById(track->channelId)) {
+        ch->setArmed(true);
+    }
     tm->record();
-    check(tm->isRecordArmed(), "record arm is a global transport toggle today");
-    check(!tm->getCommandHistory().canUndo(), "arming alone creates no model state");
+    recordTake(*tm, 1.0);
+    check(laneCount(*tm) == 1, "channel arm alone produces no take");
+    check(!takeLaneOf(*tm, trackId).isValid(), "disarmed track captures nothing");
+}
+
+void testTakeLaneOwnershipRoundTrips() {
+    std::cout << "[B] take lane ownership survives project round-trip\n";
+    auto tm = makeRecorder();
+    const uint64_t trackId = armTrack(*tm, "Guitar", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
+
+    tm->record();
+    recordTake(*tm, 1.0);
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track resolvable before save");
+    if (!track) {
+        return;
+    }
+    check(track->laneIds.size() == 2, "setup lane plus one take lane before save");
+    const PlaylistLaneID takeLaneId = takeLaneOf(*tm, trackId);
+    check(takeLaneId.isValid(), "take lane exists before save");
+    if (!takeLaneId.isValid()) {
+        return;
+    }
+    check(track->laneNumber(takeLaneId) == 2, "take lane is track-local lane 2 before save");
+
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingBaselineRoundTrip"};
+    const std::string path = (dir.path() / "roundtrip.aes").string();
+    tm->setRecordingProjectPath(path);
+    const bool saved = ProjectSerializer::save(path, tm, kBpm, 0.0);
+    check(saved, "project saved");
+    if (!saved) {
+        return;
+    }
+
+    auto tm2 = makeRecorder();
+    const auto result = ProjectSerializer::load(path, tm2);
+    check(result.ok, "project loaded");
+    if (!result.ok) {
+        return;
+    }
+
+    auto* loadedTrack = tm2->getTrack(trackId);
+    check(loadedTrack != nullptr, "loaded track keeps the same track id");
+    if (!loadedTrack) {
+        return;
+    }
+    check(loadedTrack->laneIds.size() == 2, "loaded track owns setup lane plus take lane");
+    const PlaylistLaneID loadedTakeLaneId = takeLaneOf(*tm2, trackId);
+    check(loadedTakeLaneId.isValid(), "take lane resolves after load");
+    if (loadedTakeLaneId.isValid()) {
+        check(loadedTrack->laneNumber(loadedTakeLaneId) == 2, "take lane keeps track-local lane 2 after load");
+        check(tm2->getTrackForLane(loadedTakeLaneId) == loadedTrack, "loaded lane resolves to its track");
+    }
+    const auto loadedLaneIds = tm2->getPlaylistModel().getLaneIDs();
+    check(loadedLaneIds.size() == 2, "playlist holds the same two lanes after load");
 }
 
 } // namespace
 
 int main() {
-    std::cout << "=== Recording Baseline (Phase 2) ===\n";
+    std::cout << "=== Recording Baseline (Phase 2 + Phase 3 acceptance) ===\n";
     std::cout << "Section A: surviving invariants\n";
-    testTakeRoutesToArmedChannel();
+    testTakeRoutesToArmedTrackChannel();
     testRecordingIsOneUndoableTransaction();
     testDirtyStateUpdated();
-    testMultipleArmedChannelsCaptureIndependently();
+    testMultipleArmedTracksCaptureIndependently();
     testEachTakeCreatesALane();
 
-    std::cout << "Section B: expected-to-change (RED against the future)\n";
-    testRecordingIdentityIsChannelBased();
-    testLanesHaveNoOwnership();
-    testNoTrackEntity();
+    std::cout << "Section B: post-migration acceptance\n";
+    testRecordingIdentityIsTrackBased();
+    testLanesOwnedAndGrouped();
+    testTrackEntityHoldsArm();
+    testTakeLaneOwnershipRoundTrips();
 
     std::cout << "\n";
     if (g_failures == 0) {
-        std::cout << "Baseline: current behavior captured, all green.\n";
+        std::cout << "Track/Lane/Channel migration: all green.\n";
         return 0;
     }
-    std::cerr << g_failures << " baseline check(s) failed — investigate before Phase 3.\n";
+    std::cerr << g_failures << " check(s) failed.\n";
     return 1;
 }

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -215,6 +215,38 @@ void testMultipleArmedTracksCaptureIndependently() {
     }
 }
 
+void testTwoArmedTracksSharingChannelCaptureIndependently() {
+    std::cout << "[A] two armed tracks sharing one channel capture independently\n";
+    auto tm = makeRecorder();
+    const PlaylistLaneID lane1 = tm->getPlaylistModel().createLane("Shared A");
+    const PlaylistLaneID lane2 = tm->getPlaylistModel().createLane("Shared B");
+    MixerChannel* ch = tm->addChannel("Shared");
+    if (!ch) {
+        check(false, "shared channel created");
+        return;
+    }
+    ch->setInputChannelIndex(0);
+    const uint64_t track1 = tm->createTrack(lane1, "Shared A", ch->getChannelId());
+    const uint64_t track2 = tm->createTrack(lane2, "Shared B", ch->getChannelId());
+    tm->setTrackArmed(track1, true);
+    tm->setTrackArmed(track2, true);
+
+    tm->record();
+    recordTake(*tm, 1.0);
+
+    auto* t1 = tm->getTrack(track1);
+    auto* t2 = tm->getTrack(track2);
+    check(t1 && t2, "both tracks resolvable");
+    check(t1 && t1->laneIds.size() == 2, "track 1 owns setup lane plus its take");
+    check(t2 && t2->laneIds.size() == 2, "track 2 owns setup lane plus its take");
+    if (t1 && t2 && t1->laneIds.size() == 2 && t2->laneIds.size() == 2) {
+        const PlaylistLaneID take1 = takeLaneOf(*tm, track1);
+        const PlaylistLaneID take2 = takeLaneOf(*tm, track2);
+        check(take1.isValid() && take2.isValid(), "both tracks got their own take despite the shared channel");
+        check(take1 != take2, "takes are on distinct lanes");
+    }
+}
+
 void testEachTakeCreatesALane() {
     std::cout << "[A] each take creates a track-local lane\n";
     auto tm = makeRecorder();
@@ -402,6 +434,7 @@ int main() {
     testRecordingIsOneUndoableTransaction();
     testDirtyStateUpdated();
     testMultipleArmedTracksCaptureIndependently();
+    testTwoArmedTracksSharingChannelCaptureIndependently();
     testEachTakeCreatesALane();
 
     std::cout << "Section B: post-migration acceptance\n";

--- a/Tests/AestraAudio/RecordingPathTest.cpp
+++ b/Tests/AestraAudio/RecordingPathTest.cpp
@@ -2,10 +2,12 @@
 // RecordingPathTest — Validates the recording state machine, arming, and session lifecycle.
 // Note: Full capture path (processInput → WAV) requires AudioDeviceManager input channels
 // which are hardware-dependent. This test covers the public recording API state machine.
+// Phase 3 (FD-14): the recording arm lives on the Track; channel arming alone
+// no longer starts a capture session (it remains a monitoring control).
 
-#include "Models/TrackManager.h"
 #include "Core/MixerChannel.h"
 #include "IO/MiniAudioDecoder.h"
+#include "Models/TrackManager.h"
 
 #include <cmath>
 #include <filesystem>
@@ -20,28 +22,61 @@ namespace {
 constexpr uint32_t kSampleRate = 48000;
 constexpr double kBpm = 120.0;
 
-// Test 1: Track arming / disarming
-bool testTrackArming() {
-    std::cout << "  [1/3] Track arming/disarming... ";
+std::shared_ptr<TrackManager> makeRecorder() {
     auto tm = std::make_shared<TrackManager>();
     tm->setOutputSampleRate(static_cast<double>(kSampleRate));
     tm->getPlaylistModel().setBPM(kBpm);
+    tm->setInputChannelCount(1);
+    tm->setMaxRecordingSeconds(5.0);
+    return tm;
+}
 
-    tm->addChannel("Test Track");
-    MixerChannel* ch = tm->getChannel(0);
-    if (!ch) { std::cerr << "FAILED: channel null\n"; return false; }
+/** Create a lane, a channel, and a Track owning the lane and routing to the
+ *  channel. Returns 0 on failure (caller decides whether to arm). */
+uint64_t makeTrack(TrackManager& tm, const std::string& name) {
+    const PlaylistLaneID laneId = tm.getPlaylistModel().createLane(name);
+    MixerChannel* ch = tm.addChannel(name);
+    if (!ch) {
+        return 0;
+    }
+    ch->setInputChannelIndex(0);
+    return tm.createTrack(laneId, name, ch->getChannelId());
+}
 
-    // Arm/disarm via channel
-    ch->setArmed(true);
-    if (!ch->isArmed()) { std::cerr << "FAILED: not armed\n"; return false; }
-    ch->setArmed(false);
-    if (ch->isArmed()) { std::cerr << "FAILED: still armed\n"; return false; }
+// Test 1: Track arming / disarming
+bool testTrackArming() {
+    std::cout << "  [1/3] Track arming/disarming... ";
+    auto tm = makeRecorder();
+
+    const uint64_t trackId = makeTrack(*tm, "Test Track");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+
+    // Arm/disarm via the Track's stable id (FD-14: the authoritative arm).
+    tm->setTrackArmed(trackId, true);
+    if (tm->getTrackArmedCount() != 1) {
+        std::cerr << "FAILED: not armed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, false);
+    if (tm->getTrackArmedCount() != 0) {
+        std::cerr << "FAILED: still armed\n";
+        return false;
+    }
 
     // Arm/disarm via TrackManager record() toggle
     tm->record();
-    if (!tm->isRecordArmed()) { std::cerr << "FAILED: TM not armed\n"; return false; }
+    if (!tm->isRecordArmed()) {
+        std::cerr << "FAILED: TM not armed\n";
+        return false;
+    }
     tm->record();
-    if (tm->isRecordArmed()) { std::cerr << "FAILED: TM still armed\n"; return false; }
+    if (tm->isRecordArmed()) {
+        std::cerr << "FAILED: TM still armed\n";
+        return false;
+    }
 
     std::cout << "PASSED\n";
     return true;
@@ -50,18 +85,21 @@ bool testTrackArming() {
 // Test 2: Recording session lifecycle (transport → begin/finalize capture)
 bool testRecordingSessionLifecycle() {
     std::cout << "  [2/3] Recording session lifecycle... ";
-    auto tm = std::make_shared<TrackManager>();
-    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
-    tm->getPlaylistModel().setBPM(kBpm);
-    tm->setMaxRecordingSeconds(5.0);
+    auto tm = makeRecorder();
 
-    tm->addChannel("Armed Track");
-    MixerChannel* ch = tm->getChannel(0);
-    ch->setArmed(true);
+    const uint64_t trackId = makeTrack(*tm, "Armed Track");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, true); // track arm gates the capture session
 
     // Record arm
     tm->record();
-    if (!tm->isRecordArmed()) { std::cerr << "FAILED: not armed\n"; return false; }
+    if (!tm->isRecordArmed()) {
+        std::cerr << "FAILED: not armed\n";
+        return false;
+    }
 
     // Transport starts playing → begins capture session
     tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
@@ -72,8 +110,7 @@ bool testRecordingSessionLifecycle() {
     }
 
     // Transport stops → finalizes capture session (position 2.0s)
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(2.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(2.0 * kSampleRate), static_cast<double>(kSampleRate));
     if (tm->isRecording()) {
         std::cerr << "FAILED: still recording after transport stop\n";
         return false;
@@ -86,13 +123,17 @@ bool testRecordingSessionLifecycle() {
 // Test 3: Unarmed tracks don't start capture session
 bool testUnarmedNoCapture() {
     std::cout << "  [3/3] Unarmed track → no capture session... ";
-    auto tm = std::make_shared<TrackManager>();
-    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
-    tm->getPlaylistModel().setBPM(kBpm);
+    auto tm = makeRecorder();
 
-    tm->addChannel("Unarmed Track");
-    MixerChannel* ch = tm->getChannel(0);
-    ch->setArmed(false);
+    const uint64_t trackId = makeTrack(*tm, "Unarmed Track");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    // Deliberately NOT armed. Channel arming alone must not gate a capture.
+    if (auto* ch = tm->getChannelById(tm->getTrack(trackId)->channelId)) {
+        ch->setArmed(true);
+    }
 
     // Even if we toggle record arm and start transport, no armed tracks = no capture
     tm->record();
@@ -104,8 +145,7 @@ bool testUnarmedNoCapture() {
         return false;
     }
 
-    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
-                                static_cast<double>(kSampleRate));
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate), static_cast<double>(kSampleRate));
     tm->record(); // disarm
 
     std::cout << "PASSED\n";


### PR DESCRIPTION
## Decision citation

Objective: TS-2
Decision:   FD-14 @ 2bdd978
Kind:       planned
Reversal:   —

## Summary

Phase 3 of the Track/Lane/Channel migration (vault: *Track Lane Channel Ownership Contract*, FD-14): recording identity moves from the mixer **channel** to the **Track**.

Engine:
- `beginCaptureSession()` now selects captures from **armed Tracks** (FD-14 #4) — resolving each track's channel; the channel's `armed` flag is retired as a recording control (it remains a monitoring control, verified: input-monitor routing at `TrackManager.h` gating on `isArmed() && isMonitoringEnabled()`).
- `commitRecordingTake()` is now `commitRecordingTake(trackId, ...)`: the take routes to the track's channel and lands on the **next track-local lane** (FD-14 #5), owned by the track (lane `trackId`), numbered track-locally.
- New `AttachLaneToTrackCommand` joins the take's undo transaction (`CreateLaneCommand` + `AddClipCommand` + attach): undo detaches and removes atomically; new `detachLaneFromTrack` backs it.
- `hasArmedTracks()`/logs now count **real Track arm state**; the old channel-counting `getArmedTrackCount()` is deleted.

Tests:
- `RecordingBaselineTest` Section A unchanged in assertion strength, now armed via Tracks; Section B replaced by the new acceptance (track identity, lane ownership + grouping, Track holds the arm, channel-arm-alone produces no take, and take-lane ownership round-trips through project save/load with stable ids).
- `RecordingPathTest` migrated to track arming for its state-machine coverage.

## Why

Phase 1 proved recording identity was the channel with takes on unowned lanes; Phase 2 froze the baseline (#798). This PR is the FD-14-authorised implementation: takes are now Track-scoped, Track-local laned, and owned — so they serialize and round-trip without the loader minting orphan tracks per lane.

## Testing performed

- Headless build (core mode), full `ctest` suite
- `RecordingBaselineTest`: all Section A invariants + new Section B acceptance green
- `RecordingPathTest`: state machine green
- Take-lane ownership round-trip: record → save → load → same track ids, same lane ownership, no orphan tracks

## Producer note

Recording now goes to lanes that belong to your track — takes are grouped under the track that recorded them instead of floating loose lines.

## Docs updated

No public docs. Vault landing note follows the merge (Aestra-Internals).

## Risk/rollback notes

- Channel arm no longer gates recording anywhere; UI that still arms channels for recording must move to `setTrackArmed` (tracked separately — FD-14 #6 UI work, mixer Record button removal is NOT in this PR).
- `RecordingCapture` gained a `trackId` field — no wire format change.
- Project format: no version change (tracks/lane `trackId` already serialized by #799); take lanes now carry ownership, which the existing loader restores.
- Rollback: revert; baseline Section A tests pin the invariants either way.