### PR TITLE
feat: track-header record arm + mixer input monitor — FD-14 #6 UI half

### DIFF
--- a/AestraUI/Widgets/UIMixerButtonRow.cpp
+++ b/AestraUI/Widgets/UIMixerButtonRow.cpp
@@ -19,9 +19,10 @@ namespace {
     constexpr float BTN_GAP = 5.0f;
     constexpr float BTN_RADIUS = 8.0f;
 
-    // Mute/solo/record glyphs come from TrackControlIcons.h, shared with the
+    // Mute/solo/monitor glyphs come from TrackControlIcons.h, shared with the
     // arrangement track headers so both surfaces speak one icon language by
-    // construction rather than by matching copies.
+    // construction rather than by matching copies. FD-14 #6: the strip's third
+    // slot is input monitoring — record arm lives on the Track only.
 
     // Parsed once, then rasterized+cached per size/tint by NUISVGRenderer, so the
     // per-frame cost is a single texture draw.
@@ -51,7 +52,7 @@ void UIMixerButtonRow::cacheThemeColors()
 
     m_muteOn = theme.getColor("muted");
     m_soloOn = theme.getColor("soloed");
-    m_armOn = theme.getColor("armed");
+    m_monitorOn = theme.getColor("armed");
 }
 
 void UIMixerButtonRow::layoutButtons()
@@ -97,10 +98,10 @@ void UIMixerButtonRow::setSoloed(bool soloed)
     requestInvalidate();
 }
 
-void UIMixerButtonRow::setArmed(bool armed)
+void UIMixerButtonRow::setMonitored(bool monitored)
 {
-    if (m_armed == armed) return;
-    m_armed = armed;
+    if (m_monitored == monitored) return;
+    m_monitored = monitored;
     requestInvalidate();
 }
 
@@ -112,7 +113,7 @@ void UIMixerButtonRow::onResize(int width, int height)
 
 void UIMixerButtonRow::onRender(NUIRenderer& renderer)
 {
-    static constexpr const char* icons[kButtonCount] = {kMuteIconSvg, kSoloIconSvg, kRecordIconSvg};
+    static constexpr const char* icons[kButtonCount] = {kMuteIconSvg, kSoloIconSvg, kMonitorIconSvg};
     auto& theme = NUIThemeManager::getInstance();
 
     for (int i = 0; i < kButtonCount; ++i) {
@@ -132,8 +133,8 @@ void UIMixerButtonRow::onRender(NUIRenderer& renderer)
             activeBg = m_soloOn;
             if (active) textColor = m_textOnBright;
         } else if (i == 2) {
-            active = m_armed;
-            activeBg = m_armOn;
+            active = m_monitored;
+            activeBg = m_monitorOn;
             if (active) textColor = m_textOnRed;
         }
 
@@ -199,7 +200,7 @@ bool UIMixerButtonRow::onMouseEvent(const NUIMouseEvent& event)
                 std::string text;
                 if (m_hovered == 0) text = "Mute";
                 else if (m_hovered == 1) text = "Solo";
-                else if (m_hovered == 2) text = "Record Arm";
+                else if (m_hovered == 2) text = "Input Monitor";
                 
                 const auto& rect = m_buttonBounds[m_hovered];
                 NUIPoint center(rect.x + rect.width * 0.5f, rect.y + rect.height + 8.0f);
@@ -237,9 +238,9 @@ bool UIMixerButtonRow::onMouseEvent(const NUIMouseEvent& event)
                 requestInvalidate();
                 if (onSoloToggled) onSoloToggled(m_soloed, event.modifiers);
             } else if (wasPressed == 2) {
-                m_armed = !m_armed;
+                m_monitored = !m_monitored;
                 requestInvalidate();
-                if (onArmToggled) onArmToggled(m_armed);
+                if (onMonitorToggled) onMonitorToggled(m_monitored);
             }
             return true;
         }

--- a/AestraUI/Widgets/UIMixerButtonRow.h
+++ b/AestraUI/Widgets/UIMixerButtonRow.h
@@ -26,18 +26,16 @@ public:
 
     void setMuted(bool muted);
     void setSoloed(bool soloed);
-    void setArmed(bool armed);
     void setMonitored(bool monitored);
 
     bool isMuted() const { return m_muted; }
     bool isSoloed() const { return m_soloed; }
-    bool isArmed() const { return m_armed; }
+    bool isMonitored() const { return m_monitored; }
 
-    // Callbacks fire after internal state changes.
     // Callbacks fire after internal state changes.
     std::function<void(bool)> onMuteToggled;
     std::function<void(bool, NUIModifiers)> onSoloToggled;
-    std::function<void(bool)> onArmToggled;
+    std::function<void(bool)> onMonitorToggled;
 
     // Used by cached parents to invalidate their static layer on hover/press changes.
     std::function<void()> onInvalidateRequested;
@@ -47,7 +45,7 @@ private:
 
     bool m_muted{false};
     bool m_soloed{false};
-    bool m_armed{false};
+    bool m_monitored{false};
 
     int m_hovered{-1};
     int m_pressed{-1};
@@ -64,7 +62,7 @@ private:
 
     NUIColor m_muteOn;
     NUIColor m_soloOn;
-    NUIColor m_armOn;
+    NUIColor m_monitorOn;
 
     void cacheThemeColors();
     void layoutButtons();

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -314,17 +314,18 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
         // Fire undo/redo callback
         if (onSoloChanged) onSoloChanged(soloed);
     };
-    m_buttons->onArmToggled = [this](bool armed) {
+    m_buttons->onMonitorToggled = [this](bool monitored) {
         if (!m_viewModel) return;
         auto* channel = m_viewModel->getChannelById(m_channelId);
         if (!channel || channel->id == 0) return;
 
-        // v3.0: Recording is handled by PlaylistModel/TrackManager transport logic, not MixerChannel.
-        channel->armed = armed;
+        // FD-14 #6: the mixer slot is input monitoring, not record arm. The
+        // engine's monitor routes gate on channel armed + monitorInput.
+        channel->monitored = monitored;
         invalidateStaticCache();
 
         if (auto mc = channel->channel) {
-            mc->setArmed(armed);
+            mc->setArmed(monitored);
         }
     };
     addChild(m_buttons);
@@ -671,7 +672,9 @@ void UIMixerStrip::onUpdate(double deltaTime)
     if (m_buttons && m_buttons->isVisible()) {
         m_buttons->setMuted(channel->muted);
         m_buttons->setSoloed(channel->soloed);
-        m_buttons->setArmed(channel->armed);
+        // The monitor button reflects the engine's arm flag — post-FD-14 #6
+        // that flag is the input-monitoring gate, never a recording control.
+        m_buttons->setMonitored(channel->armed);
     }
 
     if (m_trimKnob && m_trimKnob->isVisible() && !m_trimKnob->isDragging()) {

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -393,6 +393,7 @@ void TrackUIComponent::onRecordToggled() {
     if (!track) return;
     const bool armed = m_recordButton && m_recordButton->isToggled();
     m_trackManager->setTrackArmed(track->trackId, armed);
+    m_trackManager->markModified();
     Log::info("Track " + std::to_string(track->trackId) + " armed: " + (armed ? "ON" : "OFF"));
     updateUI();
     repaint();

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -218,8 +218,8 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     m_soloButton->setTooltip("Solo Track (S)");
     addChild(m_soloButton);
 
-    // Recording is armed from mixer inserts. A Playlist lane only receives a
-    // record control when an explicit mixer association is supplied.
+    // FD-14 #6: record arm lives on the Track (setTrackArmed). The button is
+    // the track's arm control; input monitoring is the right-click menu.
     if (m_channel) {
         m_recordButton = std::make_shared<AestraUI::NUIButton>();
         m_recordButton->setText("");
@@ -388,17 +388,15 @@ void TrackUIComponent::onSoloToggled() {
 
 
 void TrackUIComponent::onRecordToggled() {
-    if (m_channel) {
-        const bool armed = m_recordButton && m_recordButton->isToggled();
-        m_channel->setArmed(armed);
-        if (m_trackManager) {
-            m_trackManager->publishInputMonitoringSnapshot();
-        }
-        Log::info("Lane " + m_laneId.toString() + " armed: " + (armed ? "ON" : "OFF"));
-        updateUI();
-        repaint();
-        if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
-    }
+    if (!m_trackManager) return;
+    auto* track = m_trackManager->getTrackForLane(m_laneId);
+    if (!track) return;
+    const bool armed = m_recordButton && m_recordButton->isToggled();
+    m_trackManager->setTrackArmed(track->trackId, armed);
+    Log::info("Track " + std::to_string(track->trackId) + " armed: " + (armed ? "ON" : "OFF"));
+    updateUI();
+    repaint();
+    if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
 }
 
 void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
@@ -409,7 +407,7 @@ void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
     detachContextMenu(m_recordModeMenu);
     m_recordModeMenu = std::make_shared<AestraUI::NUIContextMenu>();
     m_recordModeMenu->setOnHide([this]() { detachContextMenu(m_recordModeMenu); });
-    m_recordModeMenu->addRadioItem("Arm Only", "record_mode", !m_channel->isMonitoringEnabled(), [this]() {
+    m_recordModeMenu->addRadioItem("Input Monitoring: Off", "record_mode", !m_channel->isMonitoringEnabled(), [this]() {
         if (!m_channel) return;
         m_channel->setMonitoringEnabled(false);
         if (m_trackManager) {
@@ -418,7 +416,7 @@ void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
         updateUI();
         repaint();
     });
-    m_recordModeMenu->addRadioItem("Arm + Monitor", "record_mode", m_channel->isMonitoringEnabled(), [this]() {
+    m_recordModeMenu->addRadioItem("Input Monitoring: On", "record_mode", m_channel->isMonitoringEnabled(), [this]() {
         if (!m_channel) return;
         m_channel->setMonitoringEnabled(true);
         if (m_trackManager) {
@@ -435,8 +433,8 @@ void TrackUIComponent::updateRecordTooltip() {
         return;
     }
 
-    const char* modeText = m_channel->isMonitoringEnabled() ? "Arm + Monitor" : "Arm Only";
-    m_recordButton->setTooltip(std::string("Arm for Recording (O) • Right-click: ") + modeText);
+    const char* monitorText = m_channel->isMonitoringEnabled() ? "On" : "Off";
+    m_recordButton->setTooltip(std::string("Arm for Recording (O) • Right-click: Input Monitoring: ") + monitorText);
 }
 
 
@@ -468,9 +466,10 @@ void TrackUIComponent::updateUI() {
     };
 
     const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
+    const auto* track = lane ? m_trackManager->getTrack(lane->trackId) : nullptr;
     configureStatusButton(m_muteButton, lane && lane->muted, themeManager.getColor("muted"));
     configureStatusButton(m_soloButton, lane && lane->solo, themeManager.getColor("soloed"));
-    configureStatusButton(m_recordButton, m_channel && m_channel->isArmed(), themeManager.getColor("armed"));
+    configureStatusButton(m_recordButton, track && track->armed, themeManager.getColor("armed"));
 
     if (m_recordButton) {
         updateRecordTooltip();
@@ -1671,9 +1670,9 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         drawControlIcon(m_muteButton, kMuteIconSvg, lane->muted ? muteActive : textIdle, lane->muted, muteActive);
         drawControlIcon(m_soloButton, kSoloIconSvg, lane->solo ? soloActive : textIdle, lane->solo, soloActive);
         if (m_channel) {
-            drawControlIcon(m_recordButton, m_channel->isMonitoringEnabled() ? kMonitorIconSvg : kRecordIconSvg,
-                            m_channel->isArmed() ? recordActive : textIdle,
-                            m_channel->isArmed(), recordActive);
+            auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
+            const bool isArmed = armTrack && armTrack->armed;
+            drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
         }
     }
 

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1968,6 +1968,10 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
         // per-lane file field) so the track migration never infers ownership
         // from array position.
         std::unordered_map<std::string, uint32_t> legacyLaneChannelIds;
+        // FD-14 #6/#8: legacy lane JSON carries the channel's armed flag per
+        // lane (an explicit per-lane file field); the track migration uses it
+        // to preserve recording-arm intent onto the created tracks.
+        std::unordered_map<std::string, bool> legacyLaneArmed;
         if (root.has("lanes")) {
             const JSON& lj = root["lanes"];
         #if defined(AESTRA_ENABLE_PROJECT_LOAD_LOGS)
@@ -1997,6 +2001,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     continue;
                 }
                 MixerChannel* channel = nullptr;
+                if (lj[i].has("armed") && lj[i]["armed"].isBool()) {
+                    legacyLaneArmed[laneId.toString()] = lj[i]["armed"].asBool();
+                }
                 if (!hasIndependentMixerChannels) {
                     uint32_t storedMixerChannelId = 0;
                     if (lj[i].has("mixerChannelId") && lj[i]["mixerChannelId"].isNumber()) {
@@ -2565,7 +2572,9 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
             }
 
             // Migration: lanes without ownership get one deterministic Track
-            // each, using the lane's OWN stored channel when one exists.
+            // each, using the lane's OWN stored channel when one exists. The
+            // legacy per-lane armed flag migrates onto the created track so
+            // pre-FD-14 recording arm is preserved, never silently dropped.
             for (const auto& laneId : laneIds) {
                 auto* lane = trackManager->getPlaylistModel().getLane(laneId);
                 if (!lane || lane->trackId != 0) {
@@ -2576,7 +2585,11 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 if (legacyIt != legacyLaneChannelIds.end()) {
                     storedChannelId = legacyIt->second;
                 }
-                trackManager->createTrack(laneId, lane->name, storedChannelId);
+                const uint64_t createdTrackId = trackManager->createTrack(laneId, lane->name, storedChannelId);
+                const auto armedIt = legacyLaneArmed.find(laneId.toString());
+                if (createdTrackId != 0 && armedIt != legacyLaneArmed.end() && armedIt->second) {
+                    trackManager->setTrackArmed(createdTrackId, true);
+                }
             }
         }
 

--- a/Tests/Integration/ProjectCompatibilityPolicyTest.cpp
+++ b/Tests/Integration/ProjectCompatibilityPolicyTest.cpp
@@ -365,7 +365,19 @@ void assertV2PositionalMixerSemantics(TrackManager& tracks, const std::string& g
             require(channel->isSoloSafe() == expected[i].soloSafe, at + " channel solo-safe");
             require(channel->isArmed() == expected[i].armed, at + " channel armed");
         }
+
+        // FD-14 #6/#8: the legacy lane `armed` flag migrates onto the lane's
+        // created Track, so pre-FD-14 recording-arm intent survives the
+        // ownership migration instead of silently vanishing.
+        const auto* track = tracks.getTrackForLane(ids[i]);
+        require(track != nullptr, at + " track missing (FD-14 ownership)");
+        if (track) {
+            require(track->armed == expected[i].armed, at + " track armed must inherit legacy lane armed");
+        }
     }
+
+    require(tracks.hasArmedTracks(),
+            generation + ": migrated armed track must satisfy hasArmedTracks()");
 
     // Routing is a separate concern from level state: it must survive the
     // topology change with its target still resolving to the intended channel.


### PR DESCRIPTION
## Summary

FD-14 Phase 3, UI half (#6): record-arm belongs exclusively to the Track; the mixer's record button is removed, not duplicated. This PR also completes #8's migration obligation: pre-FD-14 projects keep their recording-arm intent after the ownership migration instead of silently loading with nothing armed.

### Track header arm
- The track-header record button now arms the **Track** (`setTrackArmed(trackId)`), reflects `track->armed`, and no longer touches the channel.
- The channel-arm path in the header is gone. The right-click menu is now explicitly **Input Monitoring: On/Off** (it controls `monitoringEnabled`); the tooltip says so.

### Mixer strip
- The strip's record button is removed as a recording control. The slot is now the explicit **input monitoring** trigger: it toggles the channel arm flag, which the engine still gates monitor routes on (`publishInputMonitoringSnapshot` requires `isArmed() && isMonitoringEnabled()` — the contract's "kept only if some non-recording path genuinely needs it — verify" answers: monitoring genuinely needs it).
- Button row: mute/solo/monitor glyphs, monitor tooltip, `setMonitored` state. No engine or monitoring behavior changed — this is UI surface only.

### Serialization (FD-14 #8 completion)
- Legacy files (no `tracks` section) previously lost their recording arm: the channel's `armed` flag was orphaned by the ownership migration. The loader now captures each legacy lane's **own stored `armed` field** (an explicit per-lane file field — never positional) and applies it to the track created for that lane.
- The retired channel `armed` flag is still read (monitoring gate, backward compat); nothing writes it into the mixer strip UI anymore.

## Why

FD-14 #6: two record controls with ambiguous semantics, neither authoritative. After #803 moved recording identity to the Track, the UI still armed channels — the button would arm a channel nobody reads for recording. Track-header arm + explicit monitoring trigger removes the duplication without a monitoring redesign (FD-14 #10).

## Testing performed

- `ProjectCompatibilityPolicyTest` — new assertions on the v2 positional fixture (lane 1 armed:true → its migrated track armed, others unarmed, `hasArmedTracks()` true) on **direct load and the migrated re-save**.
- `ProjectFixtureCorpusTest`, `RecordingBaselineTest` (16/16), `RecordingPathTest`, `TrackOwnershipTest` — green.
- Headless Release build, `-j1` (low-RAM box): 0 errors.

## Producer note

Arming for recording now happens on the track header — the mixer's record button is now an input-monitor toggle.

## Risk / rollback notes

- UI-only files (track header, mixer button row/strip) validated by the CI UI compile lane; headless tests cover the serializer migration.
- Legacy arm migration rule is per-lane deterministic: lanes sharing a channel each arm their own track (mirrors the new per-track capture model, pinned by the #803 shared-channel regression test).
- The mixer monitor toggle goes through `MixerChannel::setArmed` → `notifyInputMonitoringStateChanged` → `publishInputMonitoringSnapshot`, so RT monitor routes refresh immediately — verified post-review, no parity gap.

## Citation

```text
Objective: TS-2
Decision:   FD-14 @ 2bdd978
Kind:       planned
Reversal:   —
```
