### PR TITLE
fix(serialization): lane channel state resolves by track identity, not position

### DIFF
--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -927,7 +927,6 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
 
     // 3. Save Lanes and Clips
     JSON lanesJson = JSON::array();
-    size_t laneIndex = 0;
     for (const auto& laneId : playlist.getLaneIDs()) {
         if (const auto* lane = playlist.getLane(laneId)) {
             JSON ljs = JSON::object();
@@ -939,7 +938,13 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             ljs.set("pan", JSON(lane->pan));
             ljs.set("mute", JSON(lane->muted));
             ljs.set("solo", JSON(lane->solo));
-            if (const auto* channel = trackManager->getChannel(laneIndex)) {
+            // FD-14 §contract: lane channel state resolves through explicit
+            // ownership — the lane's Track, then the track's channel id.
+            // Never by lane position: lane order is creation/append order and
+            // can diverge from channel order (take lanes, track-first setups).
+            const auto* laneTrack = trackManager->getTrackForLane(laneId);
+            const auto* channel = laneTrack ? trackManager->getChannelById(laneTrack->channelId) : nullptr;
+            if (channel) {
                 // MixerChannel state not covered by PlaylistLane
                 ljs.set("mixerChannelId", JSON(static_cast<double>(channel->getChannelId())));
                 ljs.set("soloSafe", JSON(channel->isSoloSafe()));
@@ -1048,7 +1053,6 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             ljs.set("trackId", JSON(static_cast<double>(lane->trackId)));
             lanesJson.push(ljs);
         }
-        ++laneIndex;
     }
     root.set("lanes", lanesJson);
     // 3b. Save Tracks (FD-14 ownership layer). The tracks array carries the

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -22,6 +22,7 @@
 // weakened — if an assertion fails here, the migration broke an invariant.
 
 #include "../../Source/Core/ProjectSerializer.h"
+#include "AestraJSON.h"
 #include "../Support/TestTempDirectory.h"
 #include "Core/MixerChannel.h"
 #include "Models/TrackManager.h"
@@ -425,6 +426,84 @@ void testTakeLaneOwnershipRoundTrips() {
     check(loadedLaneIds.size() == 2, "playlist holds the same two lanes after load");
 }
 
+void testLaneChannelStateFollowsTrackIdentity() {
+    std::cout << "[B] lane channel state resolves through track identity, not position\n";
+    auto tm = makeRecorder();
+    // Lane creation order differs from channel creation order: track B is
+    // created first but lives on the playlist's second lane. A positional
+    // lane->channel pairing would write B's state into lane A's JSON.
+    const PlaylistLaneID laneA = tm->getPlaylistModel().createLane("A");
+    const PlaylistLaneID laneB = tm->getPlaylistModel().createLane("B");
+    MixerChannel* chB = tm->addChannel("ChB");
+    MixerChannel* chA = tm->addChannel("ChA");
+    check(chB != nullptr && chA != nullptr, "channels created");
+    if (!chB || !chA) {
+        return;
+    }
+    chB->setInputChannelIndex(1);
+    chA->setInputChannelIndex(0);
+    const uint64_t trackB = tm->createTrack(laneB, "Track B", chB->getChannelId());
+    const uint64_t trackA = tm->createTrack(laneA, "Track A", chA->getChannelId());
+    check(trackB != 0 && trackA != 0, "tracks created");
+    if (trackB == 0 || trackA == 0) {
+        return;
+    }
+    chA->setVolume(0.25f);
+    chB->setVolume(0.75f);
+    chA->setArmed(true);
+    chB->setArmed(false);
+
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingBaselineRoundTrip"};
+    const std::string path = (dir.path() / "identity.aes").string();
+    tm->setRecordingProjectPath(path);
+    const auto ser = ProjectSerializer::serialize(tm, kBpm, 0.0, 2);
+    check(ser.ok && !ser.contents.empty(), "project serialized");
+    if (!ser.ok) {
+        return;
+    }
+
+    // Wire pin: each lane JSON carries ITS OWN channel's id and state.
+    const Aestra::JSON root = Aestra::JSON::parse(ser.contents);
+    check(root.has("lanes") && root["lanes"].isArray() && root["lanes"].size() == 2, "lanes array on the wire");
+    if (root.has("lanes") && root["lanes"].isArray()) {
+        const Aestra::JSON& lanesJson = root["lanes"];
+        for (size_t i = 0; i < lanesJson.size(); ++i) {
+            if (!lanesJson[i].has("name") || !lanesJson[i].has("mixerChannelId") || !lanesJson[i].has("armed")) {
+                continue;
+            }
+            const std::string laneName = lanesJson[i]["name"].asString();
+            if (laneName == "A") {
+                check(lanesJson[i]["mixerChannelId"].asNumber() == static_cast<double>(chA->getChannelId()),
+                      "lane A carries channel A's id on the wire");
+                check(lanesJson[i]["armed"].asBool(), "lane A carries channel A's armed state");
+            } else if (laneName == "B") {
+                check(lanesJson[i]["mixerChannelId"].asNumber() == static_cast<double>(chB->getChannelId()),
+                      "lane B carries channel B's id on the wire");
+                check(!lanesJson[i]["armed"].asBool(), "lane B carries channel B's armed state");
+            }
+        }
+    }
+
+    // Round-trip: after load, each lane's channel is its OWN channel.
+    check(ProjectSerializer::writeAtomically(path, ser.contents), "project written");
+    auto tm2 = makeRecorder();
+    const auto result = ProjectSerializer::load(path, tm2);
+    check(result.ok, "project loaded");
+    if (!result.ok) {
+        return;
+    }
+    auto* loadedLaneA = tm2->getPlaylistModel().getLane(laneA);
+    auto* loadedTrackA = tm2->getTrackForLane(laneA);
+    check(loadedLaneA != nullptr && loadedTrackA != nullptr, "lane A and its track loaded");
+    if (loadedTrackA) {
+        auto* loadedChA = tm2->getChannelById(static_cast<uint32_t>(loadedTrackA->channelId));
+        check(loadedChA != nullptr && loadedChA->getChannelId() == chA->getChannelId(),
+              "lane A resolves to channel A after load");
+        check(loadedChA != nullptr && loadedChA->getVolume() == 0.25f, "lane A keeps channel A's volume");
+        check(loadedChA != nullptr && loadedChA->isArmed(), "lane A keeps channel A's armed state");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -442,6 +521,7 @@ int main() {
     testLanesOwnedAndGrouped();
     testTrackEntityHoldsArm();
     testTakeLaneOwnershipRoundTrips();
+    testLaneChannelStateFollowsTrackIdentity();
 
     std::cout << "\n";
     if (g_failures == 0) {

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -462,26 +462,35 @@ void testLaneChannelStateFollowsTrackIdentity() {
         return;
     }
 
-    // Wire pin: each lane JSON carries ITS OWN channel's id and state.
+    // Wire pin: each lane JSON carries ITS OWN channel's id and state. Missing
+    // fields or missing lanes are failures, never skips — a regression that
+    // drops a lane's channel state must fail loudly.
     const Aestra::JSON root = Aestra::JSON::parse(ser.contents);
     check(root.has("lanes") && root["lanes"].isArray() && root["lanes"].size() == 2, "lanes array on the wire");
     if (root.has("lanes") && root["lanes"].isArray()) {
         const Aestra::JSON& lanesJson = root["lanes"];
+        bool sawA = false;
+        bool sawB = false;
         for (size_t i = 0; i < lanesJson.size(); ++i) {
-            if (!lanesJson[i].has("name") || !lanesJson[i].has("mixerChannelId") || !lanesJson[i].has("armed")) {
+            const bool complete = lanesJson[i].has("name") && lanesJson[i].has("mixerChannelId") && lanesJson[i].has("armed");
+            check(complete, "lane " + std::to_string(i) + " carries the full channel-state set on the wire");
+            if (!complete) {
                 continue;
             }
             const std::string laneName = lanesJson[i]["name"].asString();
             if (laneName == "A") {
+                sawA = true;
                 check(lanesJson[i]["mixerChannelId"].asNumber() == static_cast<double>(chA->getChannelId()),
                       "lane A carries channel A's id on the wire");
                 check(lanesJson[i]["armed"].asBool(), "lane A carries channel A's armed state");
             } else if (laneName == "B") {
+                sawB = true;
                 check(lanesJson[i]["mixerChannelId"].asNumber() == static_cast<double>(chB->getChannelId()),
                       "lane B carries channel B's id on the wire");
                 check(!lanesJson[i]["armed"].asBool(), "lane B carries channel B's armed state");
             }
         }
+        check(sawA && sawB, "both lanes present on the wire with their own channel state");
     }
 
     // Round-trip: after load, each lane's channel is its OWN channel.
@@ -501,6 +510,16 @@ void testLaneChannelStateFollowsTrackIdentity() {
               "lane A resolves to channel A after load");
         check(loadedChA != nullptr && loadedChA->getVolume() == 0.25f, "lane A keeps channel A's volume");
         check(loadedChA != nullptr && loadedChA->isArmed(), "lane A keeps channel A's armed state");
+    }
+    auto* loadedLaneB = tm2->getPlaylistModel().getLane(laneB);
+    auto* loadedTrackB = tm2->getTrackForLane(laneB);
+    check(loadedLaneB != nullptr && loadedTrackB != nullptr, "lane B and its track loaded");
+    if (loadedTrackB) {
+        auto* loadedChB = tm2->getChannelById(static_cast<uint32_t>(loadedTrackB->channelId));
+        check(loadedChB != nullptr && loadedChB->getChannelId() == chB->getChannelId(),
+              "lane B resolves to channel B after load");
+        check(loadedChB != nullptr && loadedChB->getVolume() == 0.75f, "lane B keeps channel B's volume");
+        check(loadedChB != nullptr && !loadedChB->isArmed(), "lane B keeps channel B's unarmed state");
     }
 }
 


### PR DESCRIPTION
## Summary

FD-14's ownership contract section 2 forbids `lane-index → channel-index` pairing; the save path still did it. `ProjectSerializer` resolved each lane's channel by *position* (`getChannel(laneIndex)`) when writing the lane's channel state. That order diverges from channel order the moment tracks are created out of lane order or a take lane is appended to the playlist — so the lane JSON could carry a **different** channel's `mixerChannelId`, `armed`, `monitorInput`, input index, width, sends, and effect-chain state.

### Fix
- The lane's channel now resolves through explicit ownership: **lane → its Track → track's channelId → getChannelById**. Never position.
- Unowned lanes (should not exist post-load-migration) write no channel state; the `tracks` array remains the ownership authority.

### Proof
- New Section B acceptance in `RecordingBaselineTest`: lanes created in order A,B with channels created in order B,A — asserts each lane's wire JSON carries its **own** channel id/armed state, and the reloaded project resolves each lane to its own channel (volume + armed).
- Failure path verified: the new assertions fail 4× against the positional code and pass on this fix.
- `ProjectRoundTripTest`, `ProjectCompatibilityPolicyTest`, `ProjectFixtureCorpusTest`, `ProjectValueFidelityTest`, `TrackOwnershipTest`, `RecordingPathTest` — all green.

## Why

The pairing is the exact anti-pattern FD-14's contract (§2 forbidden pairings, §6 flagged item) exists to remove — and it is observable today: a recorded take lane appended at the end of the playlist writes the *last* channel's state into the take lane's JSON.

## Citation

```text
Objective: TS-2
Decision:   FD-14 @ 2bdd978
Kind:       corrective
Reversal:   —
```

## Producer note

None

## Risk / rollback notes

- Serialization change is write-side only + round-trip verified; the loader already tolerates absent per-lane channel state (new-format files don't read it).
- Old readers: a lane JSON with correctly-attributed channel state is strictly more correct than the positional one; `mixerChannelId` remains a real channel id as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Resolve lane channel state through the owning track’s `channelId`, instead of lane position.
- Leave channel state empty for unowned lanes.
- Add acceptance coverage for different lane and channel creation orders, including serialization and reload checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->