### PR TITLE
fix(ui): track header arm button renders for every owned track

### DIFF
--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -219,15 +219,16 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     addChild(m_soloButton);
 
     // FD-14 #6: record arm lives on the Track (setTrackArmed). The button is
-    // the track's arm control; input monitoring is the right-click menu.
-    if (m_channel) {
-        m_recordButton = std::make_shared<AestraUI::NUIButton>();
-        m_recordButton->setText("");
-        configureFlatTrackButton(m_recordButton);
-        m_recordButton->setToggleable(true);
-        m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
-        addChild(m_recordButton);
-    }
+    // the track's arm control for every owned lane — it must not depend on a
+    // mixer channel being passed in, because the playlist builds components
+    // without one (TrackManagerUI.cpp). Input monitoring stays on the
+    // right-click menu, gated on a resolvable channel.
+    m_recordButton = std::make_shared<AestraUI::NUIButton>();
+    m_recordButton->setText("");
+    configureFlatTrackButton(m_recordButton);
+    m_recordButton->setToggleable(true);
+    m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
+    addChild(m_recordButton);
 
     updateUI();
 }
@@ -401,25 +402,24 @@ void TrackUIComponent::onRecordToggled() {
 }
 
 void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
-    if (!m_channel) {
+    auto* channel = resolveMonitorChannel();
+    if (!channel) {
         return;
     }
 
     detachContextMenu(m_recordModeMenu);
     m_recordModeMenu = std::make_shared<AestraUI::NUIContextMenu>();
     m_recordModeMenu->setOnHide([this]() { detachContextMenu(m_recordModeMenu); });
-    m_recordModeMenu->addRadioItem("Input Monitoring: Off", "record_mode", !m_channel->isMonitoringEnabled(), [this]() {
-        if (!m_channel) return;
-        m_channel->setMonitoringEnabled(false);
+    m_recordModeMenu->addRadioItem("Input Monitoring: Off", "record_mode", !channel->isMonitoringEnabled(), [this, channel]() {
+        channel->setMonitoringEnabled(false);
         if (m_trackManager) {
             m_trackManager->publishInputMonitoringSnapshot();
         }
         updateUI();
         repaint();
     });
-    m_recordModeMenu->addRadioItem("Input Monitoring: On", "record_mode", m_channel->isMonitoringEnabled(), [this]() {
-        if (!m_channel) return;
-        m_channel->setMonitoringEnabled(true);
+    m_recordModeMenu->addRadioItem("Input Monitoring: On", "record_mode", channel->isMonitoringEnabled(), [this, channel]() {
+        channel->setMonitoringEnabled(true);
         if (m_trackManager) {
             m_trackManager->publishInputMonitoringSnapshot();
         }
@@ -429,13 +429,31 @@ void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
     attachAndShowContextMenu(this, m_recordModeMenu, position);
 }
 
+MixerChannel* TrackUIComponent::resolveMonitorChannel() const {
+    if (m_channel) {
+        return m_channel.get();
+    }
+    if (!m_trackManager) {
+        return nullptr;
+    }
+    auto* track = m_trackManager->getTrackForLane(m_laneId);
+    if (!track) {
+        return nullptr;
+    }
+    return m_trackManager->getChannelById(static_cast<uint32_t>(track->channelId));
+}
+
 void TrackUIComponent::updateRecordTooltip() {
-    if (!m_recordButton || !m_channel) {
+    if (!m_recordButton) {
         return;
     }
 
-    const char* monitorText = m_channel->isMonitoringEnabled() ? "On" : "Off";
-    m_recordButton->setTooltip(std::string("Arm for Recording (O) • Right-click: Input Monitoring: ") + monitorText);
+    if (auto* channel = resolveMonitorChannel()) {
+        const char* monitorText = channel->isMonitoringEnabled() ? "On" : "Off";
+        m_recordButton->setTooltip(std::string("Arm for Recording (O) • Right-click: Input Monitoring: ") + monitorText);
+    } else {
+        m_recordButton->setTooltip("Arm for Recording (O)");
+    }
 }
 
 
@@ -1670,11 +1688,9 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 
         drawControlIcon(m_muteButton, kMuteIconSvg, lane->muted ? muteActive : textIdle, lane->muted, muteActive);
         drawControlIcon(m_soloButton, kSoloIconSvg, lane->solo ? soloActive : textIdle, lane->solo, soloActive);
-        if (m_channel) {
-            auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
-            const bool isArmed = armTrack && armTrack->armed;
-            drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
-        }
+        auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
+        const bool isArmed = armTrack && armTrack->armed;
+        drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
     }
 
     // Track number marker (left of name): recedes as quiet metadata (Level 4).

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -443,17 +443,19 @@ MixerChannel* TrackUIComponent::resolveMonitorChannel() const {
     return m_trackManager->getChannelById(static_cast<uint32_t>(track->channelId));
 }
 
+std::string TrackUIComponent::recordButtonTooltipText() const {
+    if (auto* channel = resolveMonitorChannel()) {
+        const char* monitorText = channel->isMonitoringEnabled() ? "On" : "Off";
+        return std::string("Arm for Recording (O) • Right-click: Input Monitoring: ") + monitorText;
+    }
+    return "Arm for Recording (O)";
+}
+
 void TrackUIComponent::updateRecordTooltip() {
     if (!m_recordButton) {
         return;
     }
-
-    if (auto* channel = resolveMonitorChannel()) {
-        const char* monitorText = channel->isMonitoringEnabled() ? "On" : "Off";
-        m_recordButton->setTooltip(std::string("Arm for Recording (O) • Right-click: Input Monitoring: ") + monitorText);
-    } else {
-        m_recordButton->setTooltip("Arm for Recording (O)");
-    }
+    m_recordButton->setTooltip(recordButtonTooltipText());
 }
 
 
@@ -1793,7 +1795,10 @@ void TrackUIComponent::onResize(int width, int height) {
     const float buttonW = 24.0f;
     const float buttonH = 24.0f;
     const float spacing = 2.0f;
-    const int numButtons = m_channel ? 4 : 2; // Playlist lanes only own M/S.
+    // Every lane owns M/S; the record arm button is track-owned and renders
+    // without a channel too. Channel-backed lanes keep their historical
+    // 4-slot reservation (the extra slot precedes the volume knob).
+    const int numButtons = m_channel ? 4 : 3;
     const float buttonsTotalW = numButtons * buttonW + (numButtons - 1) * spacing;
 
     const float leftPad = 14.0f;
@@ -2033,7 +2038,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                     lane && lane->muted && lane->solo ? "Solo held • Track is muted (S)" : "Solo Track (S)";
                 AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_recordButton && m_recordButton->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Arm Track for Recording (O)", event.position, this);
+                AestraUI::NUIComponent::showRemoteTooltip(recordButtonTooltipText(), event.position, this);
             } else if (m_volumeKnobHovered) {
                 int pct = static_cast<int>(std::round(m_volumeKnobValue * 100.0f));
                 AestraUI::NUIPoint tipPos(

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -289,6 +289,7 @@ private:
     void onRecordToggled();
     void showRecordModeMenu(const AestraUI::NUIPoint& position);
     void updateRecordTooltip();
+    std::string recordButtonTooltipText() const;
     MixerChannel* resolveMonitorChannel() const;
 
     void drawWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds,

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -289,6 +289,7 @@ private:
     void onRecordToggled();
     void showRecordModeMenu(const AestraUI::NUIPoint& position);
     void updateRecordTooltip();
+    MixerChannel* resolveMonitorChannel() const;
 
     void drawWaveform(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds,
                      float offsetRatio = 0.0f, float visibleRatio = 1.0f);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -472,6 +472,9 @@ void AestraContent::setupTransportBar() {
             if (recording != isRecordArmed) {
                 m_trackManager->record();
             }
+            if (recording && !m_trackManager->hasArmedTracks()) {
+                showToast("No armed tracks — recording will capture nothing. Arm a track in the playlist.");
+            }
         }
     });
     m_transportBar->setOnMetronomeToggle([this](bool enabled) {


### PR DESCRIPTION
## Summary

Bug reported by the user against the merged FD-14 arm work: **no icon on the track, and recording produces ghost sessions.**

### Root cause (one bug, two symptoms)
- The track-header arm button (#804) was gated on `m_channel` — but the playlist builds `TrackUIComponent` with a **nullptr** channel (`TrackManagerUI.cpp:185`). The button never rendered.
- With the mixer record button removed by #804, the app had **no working record-arm control anywhere**. Pressing record therefore armed a transport that could never capture — visually "recording" (blinking REC), capturing nothing, no explanation. That is the ghost recording.

### Fix
1. **Arm button renders for every owned lane** — no channel required; arm state and icon come from `track->armed` (which was already the single source of truth in the engine).
2. **Monitoring menu/tooltip resolve the channel through the track** (`track->channelId → getChannelById`) when the constructor channel is absent, so right-click monitoring still works on tracked lanes.
3. **Honest no-arm record**: pressing record with zero armed tracks now toasts *"No armed tracks — recording will capture nothing"* instead of silently running an empty session. Pre-roll arming is preserved (the session still arms, so arming during the count-in still captures).

### Verification
- Both edited TUs pass `-fsyntax-only` against the UI-enabled build (full UI compile runs on the CI Linux UI lane).
- Engine no-arm behavior is already pinned headlessly: `RecordingBaselineTest::testRecordingIdentityIsTrackBased` asserts channel arm alone produces no take.
- Existing arm path unchanged: `onRecordToggled` → `setTrackArmed` + `markModified` (c97de20a).

## Why

The FD-14 #6 UI half shipped the arm semantics but the control itself never rendered — the sprint claim "track header arm" was false in the running app. This completes it.

## Citation

```text
Objective: TS-2
Decision:   FD-15 @ b6ea067
Kind:       planned
Reversal:   —
```

## Producer note

Every track now has a record-arm button in its header, and the transport warns you when you try to record with nothing armed.

## Risk / rollback notes

- UI-only change (track header + transport toast). Rollback = revert the single commit.
- The (O) shortcut in the arm tooltip has no keybinding anywhere in the app — pre-existing copy, not touched here.
- Full UI render validation is the CI UI lane; this box cannot run the app.