### PR TITLE
fix(ui): piano-roll grid ink, placeholder justification, browser search row

### DIFF
--- a/AestraUI/Base/NUITextInput.cpp
+++ b/AestraUI/Base/NUITextInput.cpp
@@ -725,10 +725,13 @@ void NUITextInput::drawPlaceholder(NUIRenderer& renderer)
     float fontSize = themeManager.getFontSize("m");
     float textY = std::round(renderer.calculateTextY(textRect, fontSize));
 
-    // Always center placeholder regardless of justification setting
-    // This allows placeholder to be centered while typing remains left-aligned
     auto textSize = renderer.measureText(placeholderText_, fontSize);
-    float textX = std::round(textRect.x + (textRect.width - textSize.width) / 2.0f);
+    float textX = std::round(textRect.x);
+    if (justification_ == Justification::Center) {
+        textX = std::round(textRect.x + (textRect.width - textSize.width) / 2.0f);
+    } else if (justification_ == Justification::Right) {
+        textX = std::round(textRect.right() - textSize.width);
+    }
 
     // Draw placeholder with reduced opacity if not already handled by color
     const NUIColor color = isEnabled() ? placeholderColor_ : NUIThemeManager::getInstance().getColor("textDisabled");

--- a/AestraUI/Widgets/PianoRollControlPanel.cpp
+++ b/AestraUI/Widgets/PianoRollControlPanel.cpp
@@ -174,8 +174,8 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     auto b = getBounds();
     auto& themeManager = NUIThemeManager::getInstance();
     
-    const auto panelBg = themeManager.getColor("backgroundSecondary").darkened(0.025f);
-    const auto border = themeManager.getColor("border").withAlpha(0.52f);
+    const auto panelBg = themeManager.getColor("backgroundPrimary");
+    const auto border = themeManager.getColor("border").withAlpha(0.28f);
     renderer.fillRect(b, panelBg);
     renderer.drawLine(NUIPoint(b.x, b.y), NUIPoint(b.right(), b.y), 1.0f, border);
     
@@ -220,8 +220,13 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     renderer.setClipRect(contentRect);
 
     const float startX = contentRect.x;
+    TimelineGridStyle gridStyle;
+    gridStyle.barLineAlpha = 0.02f;
+    gridStyle.beatLineAlpha = 0.005f;
+    gridStyle.subdivisionLineAlpha = 0.002f;
+    gridStyle.zebraAlpha = 0.006f;
     renderTimelineGrid(renderer, contentRect, startX, contentRect.right(), scrollX_, pixelsPerBeat_, beatsPerBar_,
-                       themeManager.getCurrentTheme().textPrimary);
+                       themeManager.getCurrentTheme().textPrimary, gridStyle);
 
     const float availH = std::max(1.0f, b.height - 28.0f);
     const float bottomY = b.bottom() - 8.0f;
@@ -235,16 +240,11 @@ void PianoRollControlPanel::onRender(NUIRenderer& renderer) {
     renderer.drawLine(NUIPoint(contentRect.x, bottomY), NUIPoint(contentRect.right(), bottomY), 1.0f, guideColor);
 
     const float patternEndX = startX + static_cast<float>(layer->getTotalDurationBeats() * pixelsPerBeat_) - scrollX_;
-    if (patternEndX < contentRect.right()) {
-        const float shadeX = std::max(contentRect.x, patternEndX);
-        renderer.fillRect(NUIRect(shadeX, contentRect.y, contentRect.right() - shadeX, contentRect.height),
-                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
-    }
     if (patternEndX >= contentRect.x && patternEndX <= contentRect.right()) {
         renderer.drawLine(NUIPoint(patternEndX, contentRect.y),
                           NUIPoint(patternEndX, contentRect.bottom()),
-                          2.0f,
-                          themeManager.getColor("accentPrimary").withAlpha(0.58f));
+                          1.0f,
+                          themeManager.getColor("accentPrimary").withAlpha(0.34f));
     }
     
     // 2. Render the lane stems: velocity rises from the floor; pan hangs off

--- a/AestraUI/Widgets/PianoRollGrid.cpp
+++ b/AestraUI/Widgets/PianoRollGrid.cpp
@@ -28,11 +28,11 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
     renderer.fillRect(bounds, theme.getColor("timelineBed"));
 
     const auto gridInk = theme.getCurrentTheme().textPrimary;
-    const auto accidentalRow = gridInk.withAlpha(0.032f);
-    const auto rootRow = theme.getColor("accentPrimary").withAlpha(0.055f);
+    const auto accidentalRow = gridInk.withAlpha(0.018f);
+    const auto rootRow = theme.getColor("accentPrimary").withAlpha(0.035f);
     // Out-of-scale rows recede toward the bed's own polarity, not toward black.
-    const auto outOfScaleRow = gridInk.withAlpha(0.10f);
-    const auto rowLine = gridInk.withAlpha(0.045f);
+    const auto outOfScaleRow = gridInk.withAlpha(0.025f);
+    const auto rowLine = gridInk.withAlpha(0.020f);
 
     int startPitch = 127 - static_cast<int>(scrollY_ / keyHeight_);
     int endPitch = 127 - static_cast<int>((scrollY_ + bounds.height) / keyHeight_);
@@ -56,9 +56,13 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
         renderer.drawLine(NUIPoint(bounds.x, y), NUIPoint(bounds.right(), y), 1.0f, rowLine);
     }
 
-    renderTimelineGrid(
-        renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk,
-        {}, getSnapSubdivisionBeats());
+    TimelineGridStyle gridStyle;
+    gridStyle.barLineAlpha = 0.02f;
+    gridStyle.beatLineAlpha = 0.005f;
+    gridStyle.subdivisionLineAlpha = 0.002f;
+    gridStyle.zebraAlpha = 0.006f;
+    renderTimelineGrid(renderer, bounds, bounds.x, bounds.right(), scrollX_, pixelsPerBeat_, beatsPerBar_, gridInk,
+                       gridStyle, getSnapSubdivisionBeats());
 
     if (hoveredPitch_ >= 0 && hoveredPitch_ <= 127) {
         const float hoverY = bounds.y + (127 - hoveredPitch_) * keyHeight_ - scrollY_;
@@ -77,16 +81,11 @@ void PianoRollGrid::onRender(NUIRenderer& renderer) {
 
     const float patternEndX =
         beatToScreenX(totalDurationBeats_, pixelsPerBeat_, scrollX_, bounds.x);
-    if (patternEndX < bounds.right()) {
-        const float shadeX = std::max(bounds.x, patternEndX);
-        renderer.fillRect(NUIRect(shadeX, bounds.y, bounds.right() - shadeX, bounds.height),
-                          NUIThemeManager::getInstance().getCurrentTheme().textPrimary.withAlpha(0.14f));
-    }
     if (patternEndX >= bounds.x && patternEndX <= bounds.right()) {
         renderer.drawLine(NUIPoint(patternEndX, bounds.y),
                           NUIPoint(patternEndX, bounds.bottom()),
-                          2.0f,
-                          theme.getColor("accentPrimary").withAlpha(0.58f));
+                          1.0f,
+                          theme.getColor("accentPrimary").withAlpha(0.34f));
     }
 
     renderer.clearClipRect();

--- a/AestraUI/Widgets/PianoRollToolbar.cpp
+++ b/AestraUI/Widgets/PianoRollToolbar.cpp
@@ -133,9 +133,8 @@ void PianoRollToolbar::setupUI() {
         auto b = m_menuBtn->getBounds();
         if (auto* parent = getParent()) {
             parent->addChild(m_activeContextMenu);
-            const auto pb = parent->getBounds();
-            menu->showAt(static_cast<int>(b.x - pb.x),
-                         static_cast<int>(b.y - pb.y + b.height + 2.0f));
+            menu->showAt(static_cast<int>(b.x),
+                         static_cast<int>(b.y + b.height + 2.0f));
         } else {
             addChild(m_activeContextMenu);
             menu->showAt(static_cast<int>(b.x), static_cast<int>(b.y + b.height + 2.0f));

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -72,7 +72,8 @@ PianoRollView::PianoRollView()
     
     // Ruler Zoom Callback
     m_ruler->onZoomRequested = [this](float delta, float mouseX) {
-        applyZoom((delta > 0) ? 1.15f : 0.85f, mouseX);
+        const float zoomDelta = std::clamp(delta, -4.0f, 4.0f);
+        applyZoom(std::pow(1.15f, zoomDelta), mouseX);
     };
 
     m_ruler->onPlayheadScrubbed = [this](double beat, bool active) {
@@ -144,7 +145,9 @@ void PianoRollView::onRender(NUIRenderer& renderer) {
                       9.0f,
                       theme.getColor("textSecondary").withAlpha(0.62f));
 
+    renderer.setClipRect(bounds);
     NUIComponent::onRender(renderer);
+    renderer.clearClipRect();
 
     // Draw playhead
     if (m_grid && m_ruler) {
@@ -525,7 +528,8 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
             // Zoom (Fallback) — same anchored, multiplicative semantics as the ruler.
             // The ruler passes grid-local X (its bounds start after the key lane);
             // mirror that basis or the beat under the cursor drifts with the lane width.
-            applyZoom((event.wheelDelta > 0) ? 1.15f : 0.85f,
+            const float zoomDelta = std::clamp(event.wheelDelta, -4.0f, 4.0f);
+            applyZoom(std::pow(1.15f, zoomDelta),
                       event.position.x - getBounds().x - m_grid->getBounds().x);
         } else if (shift) {
             // H-Scroll

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -39,7 +39,7 @@ constexpr float kPreviewPanelHeight = 72.0f;
 constexpr float kCompactNavWidth = 52.0f;
 constexpr float kCompactNavStartWidth = 320.0f;
 constexpr float kExpandedNavStartWidth = 440.0f;
-constexpr float BROWSER_SEARCH_ROW_H = 34.0f;
+constexpr float BROWSER_SEARCH_ROW_H = 56.0f;
 constexpr float BROWSER_TOP_PAD = 7.0f;
 constexpr float BROWSER_CONTENT_GAP = 8.0f;
 constexpr float BROWSER_NAV_ROW_H = 30.0f;
@@ -413,12 +413,18 @@ FileBrowser::FileBrowser()
     searchInput_->setMaxLength(512);
     searchInput_->setTextColor(themeManager.getColor("textPrimary"));
     searchInput_->setPlaceholderColor(themeManager.getColor("textSecondary").withAlpha(0.56f));
-    searchInput_->setPadding(6.0f);
+    searchInput_->setJustification(NUITextInput::Justification::Left);
+    searchInput_->setPadding(4.0f);
     searchInput_->setBorderRadius(5.0f);
     searchInput_->setBackgroundColor(themeManager.getColor("backgroundPrimary"));
     searchInput_->setBorderColor(themeManager.getColor("borderSubtle").withAlpha(0.62f));
     searchInput_->setFocusedBorderColor(themeManager.getColor("focusRing"));
     searchInput_->setBorderWidth(1.0f);
+
+    searchIcon_ = std::make_shared<NUIIcon>();
+    searchIcon_->loadSVG(R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M10.4 3.2a7.2 7.2 0 1 0 4.55 12.78l4.03 4.03 1.7-1.7-4.03-4.03A7.2 7.2 0 0 0 10.4 3.2Zm0 2.4a4.8 4.8 0 1 1 0 9.6 4.8 4.8 0 0 1 0-9.6Z"/></svg>)");
+    searchIcon_->setIconSize(15.0f, 15.0f);
+    searchIcon_->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
 
     // Initialize icons with improved visibility for Liminal Dark v2.0
     // Use inline SVG content for reliable icon loading
@@ -523,8 +529,6 @@ FileBrowser::FileBrowser()
     selectedColor_ = themeManager.getColor("accentPrimary");
 
     hoverColor_ = themeManager.getColor("buttonBgHover").withAlpha(0.72f);
-    borderColor_ = themeManager.getColor("glassBorder");
-
     // Perform initial layout now that all members (icons, search input) are initialized
     // This initializes scrollbarTrackHeight_ and other layout vars needed by updateScrollbarVisibility
     onResize(static_cast<int>(getWidth()), static_cast<int>(getHeight()));
@@ -892,8 +896,8 @@ FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
 
     BrowserLayout layout;
     layout.searchBar = NUIRect(bounds.x, bounds.y, std::max(0.0f, effectiveW), searchH);
-    layout.search = NUIRect(bounds.x + 30.0f, bounds.y + 4.0f,
-                            std::max(0.0f, effectiveW - 64.0f), searchH - 8.0f);
+    layout.search = NUIRect(bounds.x + 26.0f, bounds.y + 4.0f,
+                            std::max(0.0f, effectiveW - 60.0f), searchH - 8.0f);
     layout.navPane = NUIRect(bounds.x, contentY, navW, contentH);
     layout.listHeader = NUIRect(listX, contentY, listW, BROWSER_LIST_HEADER_H);
     const float previewH = previewPanelVisible_ ? std::min(kPreviewPanelHeight, contentH) : 0.0f;
@@ -907,7 +911,9 @@ FileBrowser::BrowserLayout FileBrowser::computeBrowserLayout() const {
     layout.filterButton = NUIRect(layout.sortButton.x - 24.0f, chromeY, 22.0f, 24.0f);
     layout.pathLabel = NUIRect(layout.upButton.right() + 7.0f, chromeY,
                                std::max(0.0f, layout.filterButton.x - layout.upButton.right() - 11.0f), 24.0f);
-    layout.searchActionButton = NUIRect(layout.searchBar.right() - 30.0f, layout.searchBar.y + 4.0f, 26.0f, 26.0f);
+    layout.searchActionButton = NUIRect(layout.searchBar.right() - 30.0f,
+                                        layout.searchBar.y + (layout.searchBar.height - 26.0f) * 0.5f,
+                                        26.0f, 26.0f);
     layout.navWidth = navW;
     return layout;
 }
@@ -1385,8 +1391,6 @@ void FileBrowser::renderStaticContent(NUIRenderer& renderer, const NUIRect& boun
                       1.0f, themeManager.getColor("border").withAlpha(0.30f));
 
     // Flat square border — the curved grey top treatment is gone (0.7.0 triage).
-    renderer.strokeRect(fileBrowserBounds, 1.0f, borderColor_);
-
     renderNavigationPane(renderer, browserLayout);
     renderListHeader(renderer, browserLayout);
     renderFileList(renderer);
@@ -1525,11 +1529,14 @@ void FileBrowser::onRender(NUIRenderer& renderer) {
         auto& themeManager = NUIThemeManager::getInstance();
         const BrowserLayout layout = computeBrowserLayout();
         const NUIRect search = layout.searchBar;
+        if (searchIcon_) {
+            searchIcon_->setBounds({search.x + 6.0f, search.y + (search.height - 15.0f) * 0.5f, 15.0f, 15.0f});
+            searchIcon_->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
+            searchIcon_->onRender(renderer);
+        }
+
         const NUIColor iconColor = themeManager.getColor("textSecondary").withAlpha(0.58f);
-        const float cx = search.x + 15.0f;
         const float cy = search.y + search.height * 0.5f;
-        renderer.strokeCircle({cx, cy - 1.0f}, 4.6f, 1.3f, iconColor);
-        renderer.drawLine({cx + 3.7f, cy + 2.7f}, {cx + 7.2f, cy + 6.2f}, 1.3f, iconColor);
 
         const float fx = layout.searchActionButton.x + layout.searchActionButton.width * 0.5f;
         if (!searchInput_->getText().empty()) {
@@ -1637,7 +1644,8 @@ void FileBrowser::onResize(int width, int height) {
         searchInput_->setBorderColor(themeManager.getColor("borderSubtle").withAlpha(0.62f));
         searchInput_->setFocusedBorderColor(themeManager.getColor("focusRing"));
         searchInput_->setPlaceholderColor(themeManager.getColor("textSecondary").withAlpha(0.56f));
-        searchInput_->setPadding(6.0f);
+        searchInput_->setJustification(NUITextInput::Justification::Left);
+        searchInput_->setPadding(4.0f);
         searchInput_->setBorderRadius(5.0f);
         searchInput_->setBorderWidth(1.0f);
     }
@@ -3042,7 +3050,6 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
     const NUIColor selectedRow = themeManager.getColor("accentPrimary").withAlpha(previewPanelVisible_ ? 0.0f
                                                                                                        : 0.065f);
     const NUIColor secondarySelectedRow = themeManager.getColor("accentPrimary").withAlpha(0.035f);
-    const NUIColor gridLine = themeManager.getColor("gridMinor").withAlpha(0.045f);
     const NUIColor text = themeManager.getColor("textPrimary").withAlpha(0.82f);
     const NUIColor folderText = themeManager.getColor("textPrimary").withAlpha(0.92f);
     const NUIColor muted = themeManager.getColor("textSecondary").withAlpha(0.56f);
@@ -3067,8 +3074,6 @@ void FileBrowser::renderFileList(NUIRenderer& renderer) {
         // Hover wash is drawn by renderHoverOverlays() OUTSIDE the FBO cache —
         // hover must never invalidate the cache (rebuilding the whole list per
         // row crossing cost ~11 ms/frame of the mouse-active render budget).
-        renderer.drawLine({itemRect.x, itemRect.bottom()}, {itemRect.right(), itemRect.bottom()}, 1.0f, gridLine);
-
         const FileItem* item = view[i];
         if (!item) continue;
         const bool playbackActive = !activePlaybackPath_.empty() && mapKeyForPath(item->path) == activePlaybackPath_;

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -421,10 +421,15 @@ FileBrowser::FileBrowser()
     searchInput_->setFocusedBorderColor(themeManager.getColor("focusRing"));
     searchInput_->setBorderWidth(1.0f);
 
-    searchIcon_ = std::make_shared<NUIIcon>();
-    searchIcon_->loadSVG(R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M10.4 3.2a7.2 7.2 0 1 0 4.55 12.78l4.03 4.03 1.7-1.7-4.03-4.03A7.2 7.2 0 0 0 10.4 3.2Zm0 2.4a4.8 4.8 0 1 1 0 9.6 4.8 4.8 0 0 1 0-9.6Z"/></svg>)");
-    searchIcon_->setIconSize(15.0f, 15.0f);
-    searchIcon_->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
+    m_searchIcon = std::make_shared<NUIIcon>();
+    // Search icon (magnifier), split across literals to respect the column limit
+    const char* searchSvg =
+        R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M10.4 3.2a7.2 7.2 0 1 0 4.55 12.78l4.03 )"
+        R"(4.03 1.7-1.7-4.03-4.03A7.2 7.2 0 0 0 10.4 3.2Zm0 2.4a4.8 4.8 0 1 1 0 9.6 4.8 4.8 )"
+        R"(0 0 1 0-9.6Z"/></svg>)";
+    m_searchIcon->loadSVG(searchSvg);
+    m_searchIcon->setIconSize(15.0f, 15.0f);
+    m_searchIcon->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
 
     // Initialize icons with improved visibility for Liminal Dark v2.0
     // Use inline SVG content for reliable icon loading
@@ -1529,10 +1534,10 @@ void FileBrowser::onRender(NUIRenderer& renderer) {
         auto& themeManager = NUIThemeManager::getInstance();
         const BrowserLayout layout = computeBrowserLayout();
         const NUIRect search = layout.searchBar;
-        if (searchIcon_) {
-            searchIcon_->setBounds({search.x + 6.0f, search.y + (search.height - 15.0f) * 0.5f, 15.0f, 15.0f});
-            searchIcon_->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
-            searchIcon_->onRender(renderer);
+        if (m_searchIcon) {
+            m_searchIcon->setBounds({search.x + 6.0f, search.y + (search.height - 15.0f) * 0.5f, 15.0f, 15.0f});
+            m_searchIcon->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
+            m_searchIcon->onRender(renderer);
         }
 
         const NUIColor iconColor = themeManager.getColor("textSecondary").withAlpha(0.58f);

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -499,7 +499,7 @@ public:
     bool sortAscending_;
     
     // Icons
-    std::shared_ptr<NUIIcon> searchIcon_;
+    std::shared_ptr<NUIIcon> m_searchIcon;
     std::shared_ptr<NUIIcon> folderIcon_;
     std::shared_ptr<NUIIcon> folderOpenIcon_;
     std::shared_ptr<NUIIcon> audioFileIcon_;

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -499,6 +499,7 @@ public:
     bool sortAscending_;
     
     // Icons
+    std::shared_ptr<NUIIcon> searchIcon_;
     std::shared_ptr<NUIIcon> folderIcon_;
     std::shared_ptr<NUIIcon> folderOpenIcon_;
     std::shared_ptr<NUIIcon> audioFileIcon_;
@@ -524,7 +525,6 @@ public:
     NUIColor textColor_;
     NUIColor selectedColor_;
     NUIColor hoverColor_;
-    NUIColor borderColor_;
     
     // Navigation history
     std::vector<std::string> navHistory_;

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -897,6 +897,23 @@ void AestraContent::setupArsenalPanels() {
     // Create Arsenal panel
     m_sequencerPanel = std::make_shared<ArsenalPanel>(m_trackManager);
     m_sequencerPanel->setPatternBrowser(m_patternBrowser.get());
+    m_sequencerPanel->setOnPreferredHeightChanged([this](float preferredHeight) {
+        if (!m_sequencerPanel || m_sequencerPanel->isMaximized()) {
+            return;
+        }
+        const auto allowed = computeAllowedRectForPanels();
+        auto rect = m_viewState.sequencerRect;
+        rect.width = std::max(rect.width, 520.0f);
+        const float desiredHeight = std::clamp(preferredHeight, 220.0f, allowed.height);
+        if (std::abs(rect.height - desiredHeight) < 0.5f) {
+            return;
+        }
+        rect.height = desiredHeight;
+        rect = clampRectToAllowed(rect, allowed);
+        m_viewState.sequencerRect = rect;
+        m_sequencerPanel->setBounds(rect);
+        setDirty(true);
+    });
 
     m_sampleEditorPanel = std::make_shared<SampleEditorPanel>(m_trackManager);
     m_sampleEditorPanel->setVisible(false);
@@ -1247,7 +1264,7 @@ void AestraContent::setupArsenalPanels() {
     m_sequencerPanel->setVisible(false);
     m_sequencerPanel->unregisterDropTargets();
     m_sequencerPanel->setOnClose([this]() { setArsenalPanelVisible(false); });
-    wireFloatingPanel(m_sequencerPanel, ViewType::Sequencer, &ViewState::sequencerRect, 520.0f, 260.0f);
+    wireFloatingPanel(m_sequencerPanel, ViewType::Sequencer, &ViewState::sequencerRect, 520.0f, 220.0f);
     m_overlayLayer->addChild(m_sequencerPanel);
 }
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -904,12 +904,18 @@ void AestraContent::setupArsenalPanels() {
         const auto allowed = computeAllowedRectForPanels();
         auto rect = m_viewState.sequencerRect;
         rect.width = std::max(rect.width, 520.0f);
-        const float desiredHeight = std::clamp(preferredHeight, 220.0f, allowed.height);
-        if (std::abs(rect.height - desiredHeight) < 0.5f) {
+        // std::clamp requires lo <= hi: on short layouts the 220 floor must
+        // shrink with the allowed height.
+        const float floorHeight = std::min(220.0f, allowed.height);
+        const float desiredHeight = std::clamp(preferredHeight, floorHeight, allowed.height);
+        rect.height = desiredHeight;
+        // Normalize against the allowed rect BEFORE the equality check, so an
+        // out-of-bounds request cannot masquerade as a settled layout.
+        rect = clampRectToAllowed(rect, allowed);
+        if (std::abs(rect.height - m_viewState.sequencerRect.height) < 0.5f &&
+            std::abs(rect.width - m_viewState.sequencerRect.width) < 0.5f) {
             return;
         }
-        rect.height = desiredHeight;
-        rect = clampRectToAllowed(rect, allowed);
         m_viewState.sequencerRect = rect;
         m_sequencerPanel->setBounds(rect);
         setDirty(true);


### PR DESCRIPTION
## Summary

UI-polish batch from the founder session (committed 2026-08-17, replayed onto the updated base). Eight files, all presentation/interaction — no engine, no serialization:

- **Piano-roll grid & chrome quieter:** row inks and timeline-grid alphas dropped via `TimelineGridStyle` so the grid recedes under notes (Grid, ControlPanel, Toolbar, View). End-of-pattern shade removed; render is clip-rect guarded.
- **Placeholders honor justification:** `NUITextInput` placeholder now follows `Justification` (left/center/right) instead of always centering; browser search input is left-justified.
- **Browser search affordance:** search row taller (34 → 56), inline search icon, tighter padding, layout adjusted.
- **Sequencer panel auto-height:** panel resizes to content-preferred height, clamped to the allowed rect and directly inside the floating-panel wiring (min height 220); marks dirty on change.
- **Toolbar interactions:** context menu uses non-parent-relative position, zoom wheel is continuous and clamped (`pow(1.15, Δ)`).

## Why

Producer-loop feel — the grid should sit under the notes, the browser search should be a comfortable target, and the sequencer should size itself instead of leaving dead space. Same "low cognitive load" direction as FD-01/FD-09.

## Citation

```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-01 @ 89a00af
Kind:       planned
```

## Producer note

The piano-roll grid is quieter under your notes, the browser search field is taller with an icon, and the sequencer panel sizes itself to its content.

## Testing performed

- Branch is the founder's in-app WIP; no engine or serialization files touched.
- Compile validation rides the CI matrix (Linux UI/App lane + Windows + macOS).
- No headless test changes — zero test-adjacent files.

## Risk / rollback notes

- Pure UI presentation changes; worst case is visual regression, rollback is reverting the single commit.
- Sequencer auto-height hooks into `wireFloatingPanel` behavior — flagged for a quick look during #809 phase-5 validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Reduced piano-roll grid and timeline visual intensity. Removed end-of-pattern shading and guarded boundary rendering within the visible area.
- Aligned input placeholders with their configured justification.
- Improved browser search layout with a taller row, inline icon, left-aligned text, and flatter borders.
- Updated the sequencer panel to follow preferred content height within bounded limits, with a 220-pixel minimum.
- Improved toolbar behavior with absolute context-menu positioning and smooth, clamped zoom-wheel scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->