### PR TITLE
fix(ui): mixer input-monitor toggle marks project dirty (#806)

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -393,6 +393,7 @@ set(AESTRA_AUDIO_CORE_HEADERS
     include/Commands/SetPanCommand.h
     include/Commands/SetMuteCommand.h
     include/Commands/SetSoloCommand.h
+    include/Commands/SetMonitoringCommand.h
     include/Commands/AddNoteCommand.h
     include/Commands/RemoveNoteCommand.h
     include/Commands/MoveNoteCommand.h

--- a/AestraAudio/include/Commands/SetMonitoringCommand.h
+++ b/AestraAudio/include/Commands/SetMonitoringCommand.h
@@ -1,0 +1,68 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to toggle a channel's input-monitoring arm state
+ *
+ * Mirrors SetMuteCommand: the mixer slot is the input-monitoring trigger
+ * (FD-14 #6), and routing the toggle through the command history gives the
+ * project dirty flag and undo/redo parity with mute/solo/pan. The engine
+ * monitor-route snapshot refreshes through setArmed's own notification.
+ */
+class SetMonitoringCommand : public ICommand {
+public:
+    SetMonitoringCommand(TrackManager& trackManager, MixerChannel& channel, bool newArmed)
+        : m_trackManager(trackManager), m_channel(channel), m_newArmed(newArmed) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+
+        m_originalArmed = m_channel.isArmed();
+        m_channel.setArmed(m_newArmed);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+
+        m_channel.setArmed(m_originalArmed);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+
+        m_channel.setArmed(m_newArmed);
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
+        m_executed = true;
+    }
+
+    std::string getName() const override { return m_newArmed ? "Enable Input Monitoring" : "Disable Input Monitoring"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    bool m_newArmed;
+    bool m_originalArmed = false;
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -11,6 +11,7 @@
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetSoloCommand.h"
 #include "Commands/SetPanCommand.h"
+#include "Commands/SetMonitoringCommand.h"
 #include "TrackManager.h"
 #include "PluginManager.h"
 #include "Commands/PluginCommands.h"
@@ -186,6 +187,16 @@ void UIMixerPanel::refreshChannels()
 
             m_trackManager->getCommandHistory().pushAndExecute(
                 std::make_shared<Aestra::Audio::SetPanCommand>(*m_trackManager, *mixerChannel, pan));
+        };
+
+        // Wire input monitoring to CommandHistory for undo/redo + dirty parity
+        strip->onMonitorToggled = [this, chId](bool monitored) {
+            if (!m_trackManager) return;
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
+            if (!mixerChannel) return;
+
+            m_trackManager->getCommandHistory().pushAndExecute(
+                std::make_shared<Aestra::Audio::SetMonitoringCommand>(*m_trackManager, *mixerChannel, monitored));
         };
 
         m_strips.push_back(strip);

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -324,9 +324,10 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
         channel->monitored = monitored;
         invalidateStaticCache();
 
-        if (auto mc = channel->channel) {
-            mc->setArmed(monitored);
-        }
+        // Engine side goes through the command history (SetMonitoringCommand)
+        // for dirty/undo parity with mute/solo/pan. The snapshot refresh
+        // rides setArmed's own notification.
+        if (onMonitorToggled) onMonitorToggled(monitored);
     };
     addChild(m_buttons);
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -65,6 +65,7 @@ public:
     std::function<void(bool muted)> onMuteChanged;
     std::function<void(bool soloed)> onSoloChanged;
     std::function<void(float pan)> onPanChanged;
+    std::function<void(bool monitored)> onMonitorToggled;
 
 private:
     uint32_t m_channelId{0};

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -414,6 +414,7 @@ void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
         channel->setMonitoringEnabled(false);
         if (m_trackManager) {
             m_trackManager->publishInputMonitoringSnapshot();
+            m_trackManager->markModified();
         }
         updateUI();
         repaint();
@@ -422,6 +423,7 @@ void TrackUIComponent::showRecordModeMenu(const AestraUI::NUIPoint& position) {
         channel->setMonitoringEnabled(true);
         if (m_trackManager) {
             m_trackManager->publishInputMonitoringSnapshot();
+            m_trackManager->markModified();
         }
         updateUI();
         repaint();

--- a/Tests/Commands/MixerCommandsTest.cpp
+++ b/Tests/Commands/MixerCommandsTest.cpp
@@ -6,6 +6,7 @@
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetSoloCommand.h"
+#include "Commands/SetMonitoringCommand.h"
 #include "Commands/CommandHistory.h"
 #include "Core/MixerChannel.h"
 #include "Models/TrackManager.h"
@@ -357,6 +358,60 @@ void testSetSoloRedoCycle() {
 // Integration test: mixer commands with CommandHistory
 // =============================================================================
 
+void testSetMonitoringCommand() {
+    std::cout << "TEST: SetMonitoringCommand... ";
+
+    MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
+    channel.setArmed(false);
+
+    SetMonitoringCommand cmd(trackManager, channel, true);
+    cmd.execute();
+
+    assert(channel.isArmed() == true);
+    assert(cmd.getName() == "Enable Input Monitoring");
+    assert(trackManager.consumePendingGraphRebuild() == true);
+
+    cmd.undo();
+    assert(channel.isArmed() == false);
+    assert(trackManager.consumePendingGraphRebuild() == true);
+
+    cmd.redo();
+    assert(channel.isArmed() == true);
+    assert(trackManager.consumePendingGraphRebuild() == true);
+
+    SetMonitoringCommand disableCmd(trackManager, channel, false);
+    disableCmd.execute();
+    assert(disableCmd.getName() == "Disable Input Monitoring");
+    assert(channel.isArmed() == false);
+
+    std::cout << "✅ PASS\n";
+}
+
+void testMonitoringToggleMarksProjectModified() {
+    std::cout << "TEST: monitoring toggle marks project modified (#806)... ";
+
+    MixerChannel channel("Test Channel", 0);
+    TrackManager trackManager;
+    channel.setArmed(false);
+    trackManager.setModified(false);
+    assert(trackManager.isModified() == false);
+
+    // The mixer slot toggle must run through the manager's own history so the
+    // dirty flag and undo both engage, matching mute/solo/pan.
+    trackManager.getCommandHistory().pushAndExecute(
+        std::make_shared<SetMonitoringCommand>(trackManager, channel, true));
+
+    assert(channel.isArmed() == true);
+    assert(trackManager.isModified() == true);
+
+    trackManager.getCommandHistory().undo();
+    assert(channel.isArmed() == false);
+    assert(trackManager.isModified() == true);
+
+    std::cout << "✅ PASS\n";
+}
+
 void testMixerCommandsWithHistory() {
     std::cout << "TEST: Mixer commands with CommandHistory integration... ";
 
@@ -428,6 +483,9 @@ int main() {
     testSetSoloDoubleExecuteNoOp();
     testSetSoloUndoBeforeExecuteNoOp();
     testSetSoloRedoCycle();
+
+    testSetMonitoringCommand();
+    testMonitoringToggleMarksProjectModified();
 
     testMixerCommandsWithHistory();
 


### PR DESCRIPTION
## Summary

Fixes #806 — the mixer input-monitor toggle never marked the project dirty, so the state could be silently lost on close.

### Root cause
Mute/solo/pan mark dirty because they run through `CommandHistory` (whose state-change hook calls `TrackManager::markModified`). The monitor toggle bypassed that entirely: `UIMixerStrip` set the view-model flag and called the engine's `setArmed()` directly, so no command was recorded and the dirty flag never fired. The monitor state *is* serialized — the toggle just never triggered a save.

### Fix
- **`SetMonitoringCommand`** — new command mirroring `SetMuteCommand` exactly (state capture, `requestAudioGraphRebuild(MixerStateChanged)`, `changesProjectState() = true`).
- **`UIMixerStrip`** — exposes an outgoing `onMonitorToggled` callback (like `onMuteChanged`/`onSoloChanged`); the engine write moves out of the strip.
- **`UIMixerPanel`** — wires the toggle into the manager's command history: dirty flag, undo, and redo parity with mute/solo/pan. The RT monitor-route snapshot still refreshes via `setArmed`'s own notification.
- **`TrackUIComponent`** right-click monitoring menu — same parity gap in the track-header path; now calls `markModified` after changing `monitoringEnabled`.

### Tests
`MixerCommandsTest` additions:
- `SetMonitoringCommand` lifecycle: execute/undo/redo + graph-rebuild assertions + names.
- `testMonitoringToggleMarksProjectModified` — pins the #806 contract: a toggle through the manager's own history flips `isModified()` (previously direct `setArmed` never did), undo restores armed state.

## Why

Pre-existing parity gap in the FD-14 #6 monitoring surface: everything else in the mixer head persisted through the command path; the monitor toggle was the one control that didn't. Filed as #806.

## Citation

```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       corrective
```

## Producer note

Toggling input monitoring on a mixer channel now counts as a project change — undo works and the state survives closing the project.

## Testing performed

- Headless build (`AESTRA_HEADLESS_ONLY=ON`, core mode) + MixerCommandsTest
- Full ctest suite on the same build
- UI TUs (`UIMixerStrip`, `UIMixerPanel`, `TrackUIComponent`) syntax-checked against the UI-enabled compile db
- Visual/route behavior is manual — folded into #809 phase-5 validation

## Risk / rollback notes

- No serialization format change (armed/monitorInput fields untouched — only the dirty trigger changed).
- Undo now also resets the mixer monitor button state — a behavior improvement, watch for surprise during phase-5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Added `SetMonitoringCommand` to route mixer input-monitor toggles through command history.
- Added execute, undo, redo, audio-graph rebuild, and project dirty-state support.
- Updated mixer UI and track-header menu actions to mark monitoring changes as modified.
- Added tests for command behavior, graph rebuilds, naming, undo/redo, and dirty-state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->