### PR TITLE
feat(ui): lane count indicator on track header (FD-14 scope §10)

### DIFF
--- a/AestraUI/Widgets/TrackControlIcons.h
+++ b/AestraUI/Widgets/TrackControlIcons.h
@@ -27,4 +27,9 @@ inline constexpr const char* kRecordIconSvg =
 inline constexpr const char* kMonitorIconSvg =
     R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 12h3.2l2.2-5.5 3.4 11 2.2-5.5H21" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
 
+// FD-14 scope §10: lane-stack glyph for the track-header lane count
+// (three lane rows; drawn paths, so no font-glyph dependency).
+inline constexpr const char* kLaneStackIconSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="4.6" width="18" height="4.2" rx="1.1" fill="currentColor"/><rect x="3" y="9.9" width="18" height="4.2" rx="1.1" fill="currentColor"/><rect x="3" y="15.2" width="18" height="4.2" rx="1.1" fill="currentColor"/></svg>)";
+
 } // namespace AestraUI

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -200,9 +200,6 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     m_laneCountLabel->setVisible(false);
     addChild(m_laneCountLabel);
 
-    // Volume fader removed from track header to reduce clutter.
-    m_volumeFader.reset();
-
     auto configureFlatTrackButton = [](const std::shared_ptr<AestraUI::NUIButton>& button) {
         button->setStyle(AestraUI::NUIButton::Style::Text);
         button->setBackgroundColor(AestraUI::NUIColor::transparent());
@@ -527,17 +524,6 @@ void TrackUIComponent::updateUI() {
         }
     }
 
-    if (m_channel) {
-        m_volumeKnobValue = std::clamp(m_channel->getVolume(), 0.0f, 2.0f);
-    }
-
-    if (m_volumeFader) {
-        m_volumeFader->setTrackColor(themeManager.getColor("borderSubtle").withAlpha(0.36f));
-        m_volumeFader->setFillColor(themeManager.getColor("accentPrimary").withAlpha(0.72f));
-        m_volumeFader->setThumbColor(themeManager.getColor("textPrimary").withAlpha(0.92f));
-        m_volumeFader->setThumbHoverColor(themeManager.getColor("textPrimary"));
-        m_volumeFader->setValue(m_channel ? m_channel->getVolume() : 1.0f);
-    }
 }
 
 
@@ -1671,54 +1657,6 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
             AestraUI::NUISVGRenderer::render(renderer, *doc, iconRect, color);
         };
 
-        // A Playlist lane has no gain stage of its own. Only draw the knob
-        // when an explicit mixer association was supplied by another view.
-        if (m_channel) {
-            const auto& knobBounds = m_volumeKnobBounds;
-            if (!knobBounds.isEmpty()) {
-                const float cx = knobBounds.x + knobBounds.width * 0.5f;
-                const float cy = knobBounds.y + knobBounds.height * 0.5f;
-                const float r = std::min(knobBounds.width, knobBounds.height) * 0.38f;
-
-                // Arc angles: 7 o'clock (135°) to 5 o'clock (405°)
-                constexpr float ARC_START = 135.0f * 3.14159265f / 180.0f;
-                constexpr float ARC_END = 405.0f * 3.14159265f / 180.0f;
-                const float t = std::clamp(m_volumeKnobValue, 0.0f, 1.5f) / 1.5f;
-                const float currentAng = ARC_START + t * (ARC_END - ARC_START);
-
-                // Background track arc
-                const int segments = 24;
-                std::vector<AestraUI::NUIPoint> trackPoints;
-                trackPoints.reserve(segments + 1);
-                for (int i = 0; i <= segments; ++i) {
-                    float theta = ARC_START + i * (ARC_END - ARC_START) / segments;
-                    trackPoints.push_back({cx + std::cos(theta) * r, cy + std::sin(theta) * r});
-                }
-                renderer.drawPolyline(trackPoints.data(), static_cast<int>(trackPoints.size()), 2.0f,
-                                      themeManager.getCurrentTheme().textPrimary.withAlpha(0.13f));
-
-                // Active value arc
-                if (t > 0.0f) {
-                    std::vector<AestraUI::NUIPoint> activePoints;
-                    int activeSegs = std::max(1, static_cast<int>(std::round(t * segments)));
-                    activePoints.reserve(activeSegs + 1);
-                    for (int i = 0; i <= activeSegs; ++i) {
-                        float theta = ARC_START + i * (currentAng - ARC_START) / activeSegs;
-                        activePoints.push_back({cx + std::cos(theta) * r, cy + std::sin(theta) * r});
-                    }
-                    AestraUI::NUIColor knobColor = themeManager.getColor("accentPrimary");
-                    if (m_volumeKnobHovered || m_isDraggingVolumeKnob) knobColor = knobColor.withAlpha(1.0f);
-                    else knobColor = knobColor.withAlpha(0.85f);
-                    renderer.drawPolyline(activePoints.data(), static_cast<int>(activePoints.size()), 2.5f, knobColor);
-                }
-
-                // Pointer dot at current value
-                const float ptrX = cx + std::cos(currentAng) * (r * 0.72f);
-                const float ptrY = cy + std::sin(currentAng) * (r * 0.72f);
-                renderer.fillCircle({ptrX, ptrY}, 1.8f, themeManager.getCurrentTheme().textPrimary.withAlpha(0.9f));
-            }
-        }
-
         drawControlIcon(m_muteButton, kMuteIconSvg, lane->muted ? muteActive : textIdle, lane->muted, muteActive);
         drawControlIcon(m_soloButton, kSoloIconSvg, lane->solo ? soloActive : textIdle, lane->solo, soloActive);
         auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
@@ -1827,9 +1765,9 @@ void TrackUIComponent::onResize(int width, int height) {
     const float buttonH = 24.0f;
     const float spacing = 2.0f;
     // Every lane owns M/S; the record arm button is track-owned and renders
-    // without a channel too. Channel-backed lanes keep their historical
-    // 4-slot reservation (the extra slot precedes the volume knob).
-    const int numButtons = m_channel ? 4 : 3;
+    // without a channel too. No volume slot in the header: volume lives in
+    // the mixer only.
+    const int numButtons = 3;
     const float buttonsTotalW = numButtons * buttonW + (numButtons - 1) * spacing;
 
     const float leftPad = 14.0f;
@@ -1866,9 +1804,6 @@ void TrackUIComponent::onResize(int width, int height) {
         m_laneCountLabel->setBounds(AestraUI::NUIRect(
             bounds.x + laneIndicatorX + 15.0f, bounds.y + localNameY, laneIndicatorWidth - 17.0f, localNameHeight));
     }
-    if (m_volumeFader) {
-        m_volumeFader->setVisible(false);
-    }
 
     float xCursor = localButtonsXStart;
     if (m_muteButton) {
@@ -1881,12 +1816,7 @@ void TrackUIComponent::onResize(int width, int height) {
     }
     if (m_recordButton) {
         m_recordButton->setBounds(AestraUI::NUIRect(bounds.x + xCursor, bounds.y + localButtonsY, buttonW, buttonH));
-        xCursor += buttonW + spacing;
     }
-    // Volume belongs to the mixer, never to a normal Playlist lane.
-    m_volumeKnobBounds = m_channel
-                             ? AestraUI::NUIRect(bounds.x + xCursor, bounds.y + localButtonsY, buttonW + 2.0f, buttonH)
-                             : AestraUI::NUIRect();
 
     AestraUI::NUIComponent::onResize(width, height);
 }
@@ -1915,17 +1845,13 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     // Early exit: If event is outside our bounds and we're not in an active operation, don't handle it
     bool isInsideBounds = bounds.contains(event.position);
     bool isActiveOperation = m_isTrimming || m_isDraggingClip || m_clipDragPotential || m_isDraggingPoint;
-    bool isControlCapture = m_isDraggingVolumeFader ||
-                            m_isDraggingVolumeKnob ||
-                            (m_muteButton && m_muteButton->isPressed()) ||
+    bool isControlCapture = (m_muteButton && m_muteButton->isPressed()) ||
                             (m_soloButton && m_soloButton->isPressed()) ||
                             (m_recordButton && m_recordButton->isPressed());
     bool controlsNeedEvents = isControlCapture ||
-                              (m_volumeFader && m_volumeFader->isHovered()) ||
                               (m_muteButton && m_muteButton->isHovered()) ||
                               (m_soloButton && m_soloButton->isHovered()) ||
-                              (m_recordButton && m_recordButton->isHovered()) ||
-                              m_volumeKnobHovered;
+                              (m_recordButton && m_recordButton->isHovered());
     
     if (!isInsideBounds && !isActiveOperation && !controlsNeedEvents) {
         return false;  // Let parent/siblings handle it (e.g., scrollbar)
@@ -1991,87 +1917,12 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 
         bool handledByControls = false;
 
-        // Volume knob mouse handling
-        {
-            const bool isOver = m_volumeKnobBounds.contains(event.position);
-            if (!event.cursorCaptured && m_volumeKnobHovered != isOver) {
-                m_volumeKnobHovered = isOver;
-                if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
-            }
-
-            if (event.pressed && event.button == AestraUI::NUIMouseButton::Left && isOver) {
-                m_isDraggingVolumeKnob = true;
-                m_volumeKnobDragStartPos = event.position;
-                m_volumeKnobDragStartValue = m_volumeKnobValue;
-
-                // Cursor capture via the unified service: hides + confines to
-                // a small anchor rect + routes motion here only + recenters, so
-                // the hidden pointer can't roam other panels (foreign hover /
-                // escape). Restores at the knob center on release.
-                if (m_platformBridge) {
-                    m_platformBridge->beginCursorCapture(
-                        this, AestraUI::NUICursorRestorePolicy::KnobCenter,
-                        static_cast<int>(event.position.x), static_cast<int>(event.position.y));
-                }
-
-                if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
-                handledByControls = true;
-            } else if (event.released && event.button == AestraUI::NUIMouseButton::Left && m_isDraggingVolumeKnob) {
-                m_isDraggingVolumeKnob = false;
-                AestraUI::NUIComponent::hideRemoteTooltip(this);
-
-                // End capture: service warps to knob center, unhides, releases
-                // confinement — in that order.
-                if (m_platformBridge) {
-                    m_platformBridge->endCursorCapture(
-                        static_cast<int>(m_volumeKnobBounds.x + m_volumeKnobBounds.width * 0.5f),
-                        static_cast<int>(m_volumeKnobBounds.y + m_volumeKnobBounds.height * 0.5f));
-                }
-
-                if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
-                handledByControls = true;
-            } else if (m_isDraggingVolumeKnob && event.button == AestraUI::NUIMouseButton::None) {
-                // Dragging: service-owned delta (up = louder). event.delta.y is
-                // down-positive, so negate to keep up = louder.
-                float dy = -event.delta.y;
-                float delta = dy * 0.008f;
-                if (event.modifiers & AestraUI::NUIModifiers::Shift) {
-                    delta *= 0.25f;
-                }
-                float newValue = std::clamp(m_volumeKnobValue + delta, 0.0f, 1.5f);
-                if (std::abs(newValue - m_volumeKnobValue) > 1e-5f) {
-                    m_volumeKnobValue = newValue;
-                    if (m_channel && m_trackManager) {
-                        m_trackManager->getCommandHistory().pushAndExecute(
-                            std::make_shared<Aestra::Audio::SetVolumeCommand>(*m_trackManager, *m_channel, newValue));
-                    }
-                    // Show tooltip at knob position
-                    int pct = static_cast<int>(std::round(newValue * 100.0f));
-                    AestraUI::NUIPoint tipPos(
-                        m_volumeKnobBounds.x + m_volumeKnobBounds.width * 0.5f,
-                        m_volumeKnobBounds.y - 4.0f);
-                    AestraUI::NUIComponent::showRemoteTooltip("Vol " + std::to_string(pct) + "%", tipPos, this, true);
-                    if (m_onCacheInvalidationCallback) m_onCacheInvalidationCallback();
-                }
-                handledByControls = true;
-            }
-        }
-
-        if (m_volumeFader) {
-            const bool isOver = m_volumeFader->getBounds().contains(event.position);
-            if (!event.cursorCaptured && m_volumeFader->isHovered() != isOver) {
-                m_volumeFader->setHovered(isOver);
-            }
-            handledByControls = m_volumeFader->onMouseEvent(event) || handledByControls;
-        }
         handledByControls = routeControlButton(m_muteButton) || handledByControls;
         handledByControls = routeControlButton(m_soloButton) || handledByControls;
         handledByControls = routeControlButton(m_recordButton) || handledByControls;
 
         if (!event.cursorCaptured && isInsideBounds) {
-            if (m_volumeFader && m_volumeFader->getBounds().contains(event.position)) {
-                AestraUI::NUIComponent::showRemoteTooltip("Track Volume", event.position, this);
-            } else if (m_muteButton && m_muteButton->getBounds().contains(event.position)) {
+            if (m_muteButton && m_muteButton->getBounds().contains(event.position)) {
                 const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(m_laneId) : nullptr;
                 const std::string tooltip =
                     lane && lane->muted && lane->solo ? "Muted • Solo is held (M)" : "Mute Track (M)";
@@ -2083,12 +1934,6 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_recordButton && m_recordButton->getBounds().contains(event.position)) {
                 AestraUI::NUIComponent::showRemoteTooltip(recordButtonTooltipText(), event.position, this);
-            } else if (m_volumeKnobHovered) {
-                int pct = static_cast<int>(std::round(m_volumeKnobValue * 100.0f));
-                AestraUI::NUIPoint tipPos(
-                    m_volumeKnobBounds.x + m_volumeKnobBounds.width * 0.5f,
-                    m_volumeKnobBounds.y - 4.0f);
-                AestraUI::NUIComponent::showRemoteTooltip("Vol " + std::to_string(pct) + "%", tipPos, this, true);
             } else {
                 AestraUI::NUIComponent::hideRemoteTooltip(this);
             }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -78,6 +78,7 @@ using AestraUI::kMonitorIconSvg;
 using AestraUI::kMuteIconSvg;
 using AestraUI::kRecordIconSvg;
 using AestraUI::kSoloIconSvg;
+using AestraUI::kLaneStackIconSvg;
 
 bool parseTrailingTrackNumber(const std::string& trackName, uint32_t& trackNumberOut) {
     const size_t numberPos = trackName.find_last_not_of("0123456789");
@@ -184,6 +185,20 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     m_nameLabel->setEllipsize(true);
     updateTrackNameColors();
     addChild(m_nameLabel);
+
+    // FD-14 scope §10 (lane visibility): the track's primary row carries a
+    // lane-stack icon + count so a multi-lane track is discoverable at a glance.
+    m_laneCountIcon = std::make_shared<AestraUI::NUIIcon>();
+    m_laneCountIcon->loadSVG(kLaneStackIconSvg);
+    m_laneCountIcon->setIconSize(13.0f, 13.0f);
+    m_laneCountIcon->setVisible(false);
+    addChild(m_laneCountIcon);
+
+    m_laneCountLabel = std::make_shared<AestraUI::NUILabel>();
+    m_laneCountLabel->setFontSize(11.0f);
+    m_laneCountLabel->setEllipsize(false);
+    m_laneCountLabel->setVisible(false);
+    addChild(m_laneCountLabel);
 
     // Volume fader removed from track header to reduce clutter.
     m_volumeFader.reset();
@@ -496,6 +511,20 @@ void TrackUIComponent::updateUI() {
 
     if (m_recordButton) {
         updateRecordTooltip();
+    }
+
+    if (m_laneCountLabel && m_laneCountIcon) {
+        const bool isPrimaryRow = track && !track->laneIds.empty() && track->laneIds.front() == m_laneId;
+        if (isPrimaryRow && track->laneIds.size() > 1) {
+            m_laneCountLabel->setText(std::to_string(track->laneIds.size()));
+            m_laneCountLabel->setTextColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
+            m_laneCountLabel->setVisible(true);
+            m_laneCountIcon->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
+            m_laneCountIcon->setVisible(true);
+        } else {
+            m_laneCountLabel->setVisible(false);
+            m_laneCountIcon->setVisible(false);
+        }
     }
 
     if (m_channel) {
@@ -1812,9 +1841,15 @@ void TrackUIComponent::onResize(int width, int height) {
     const float localButtonsXStart = controlAreaWidth - rightPad - buttonsTotalW;
     const float localButtonsY = (bounds.height - buttonH) * 0.5f;
 
+    // Lane-count indicator (FD-14 scope §10) sits just left of the buttons on
+    // the track's primary row; the name label flexes around it.
+    const float laneIndicatorWidth = 54.0f;
+    const float laneIndicatorGap = 6.0f;
+    const float laneIndicatorX = localButtonsXStart - laneIndicatorGap - laneIndicatorWidth;
+
     // Keep track number + name anchored to the left, with flexible space to buttons.
     const float localLabelLeft = leftPad + trackNumberWidth + numberNameGap;
-    const float localInlineRight = localButtonsXStart - 8.0f;
+    const float localInlineRight = laneIndicatorX - 8.0f;
     const float localInlineWidth = std::max(0.0f, localInlineRight - localLabelLeft);
     const float localNameHeight = std::max(14.0f, layout.trackLabelHeight - 2.0f);
     const float localNameY = localButtonsY + std::max(0.0f, (buttonH - localNameHeight) * 0.5f);
@@ -1823,6 +1858,13 @@ void TrackUIComponent::onResize(int width, int height) {
     // Name label - use NUIAbsolute for global coordinate system
     if (m_nameLabel) {
         m_nameLabel->setBounds(AestraUI::NUIRect(bounds.x + localLabelLeft, bounds.y + localNameY, localLabelWidth, localNameHeight));
+    }
+    if (m_laneCountLabel && m_laneCountIcon) {
+        const float laneIconY = localButtonsY + std::max(0.0f, (buttonH - 13.0f) * 0.5f);
+        m_laneCountIcon->setBounds(
+            AestraUI::NUIRect(bounds.x + laneIndicatorX, bounds.y + laneIconY, 13.0f, 13.0f));
+        m_laneCountLabel->setBounds(AestraUI::NUIRect(
+            bounds.x + laneIndicatorX + 15.0f, bounds.y + localNameY, laneIndicatorWidth - 17.0f, localNameHeight));
     }
     if (m_volumeFader) {
         m_volumeFader->setVisible(false);

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -241,7 +241,6 @@ private:
  
     // Automation Interaction State (v3.1)
     bool m_isDraggingPoint = false;
-    bool m_isDraggingVolumeFader = false;
     int m_draggedPointIndex = -1;
     int m_draggedCurveIndex = -1;
     // Point position at drag start; a release that never moved the point
@@ -263,22 +262,13 @@ private:
     std::shared_ptr<AestraUI::NUILabel> m_nameLabel;
     std::shared_ptr<AestraUI::NUILabel> m_laneCountLabel;
     std::shared_ptr<AestraUI::NUIIcon> m_laneCountIcon;
-    std::shared_ptr<AestraUI::NUISlider> m_volumeFader;
     std::shared_ptr<AestraUI::NUIButton> m_muteButton;
     std::shared_ptr<AestraUI::NUIButton> m_soloButton;
     std::shared_ptr<AestraUI::NUIButton> m_recordButton;
     std::shared_ptr<AestraUI::NUIContextMenu> m_recordModeMenu;
     std::shared_ptr<AestraUI::NUIContextMenu> m_clipRoutingMenu;
 
-    // Volume Knob (replaces route button)
-    float m_volumeKnobValue = 1.0f;
-    bool m_isDraggingVolumeKnob = false;
-    bool m_volumeKnobHovered = false;
-    AestraUI::NUIPoint m_volumeKnobDragStartPos;
-    float m_volumeKnobDragStartValue = 0.0f;
-    AestraUI::NUIRect m_volumeKnobBounds;
-
-    // Cursor capture state for volume knob (hidden cursor + lock-on)
+    // Cursor capture state for drag interactions (hidden cursor + lock-on).
     AestraUI::NUIPlatformBridge* m_platformBridge = nullptr;
     AestraUI::NUIPoint m_volumeWarpOrigin;
     float m_volumeLastDragY = 0.0f;

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -261,6 +261,8 @@ private:
 
     // UI Components
     std::shared_ptr<AestraUI::NUILabel> m_nameLabel;
+    std::shared_ptr<AestraUI::NUILabel> m_laneCountLabel;
+    std::shared_ptr<AestraUI::NUIIcon> m_laneCountIcon;
     std::shared_ptr<AestraUI::NUISlider> m_volumeFader;
     std::shared_ptr<AestraUI::NUIButton> m_muteButton;
     std::shared_ptr<AestraUI::NUIButton> m_soloButton;


### PR DESCRIPTION
## Summary

Closes the §10 lane-visibility gap tracked in #809: a user looking at a Track must immediately know it contains multiple lanes.

The track's primary row now shows a lane-stack SVG icon + owned-lane count just left of the M/S/R buttons (contract style: "≡ 3"). Single-lane tracks show nothing — no noise for the common case.

## Why

The FD-14 lane model is fully functional (tracks own lanes, record-arm materializes lanes, every lane renders as a row) but the connection between a track header and its lane rows was invisible. The contract's §10 discovers the count from the track's authoritative `laneIds` list — never derived from lane index — so it stays correct as record-arm adds lanes.

## Details

- **`TrackControlIcons.h`**: `kLaneStackIconSvg` — three rounded bars drawn as SVG paths. Deliberately not the U+2261 union glyph: the bundled Manrope/Geist fonts lack it, and an SVG icon is font-independent. The contract explicitly leaves glyph/count treatment unprescribed.
- **`TrackUIComponent`**: `m_laneCountIcon` + `m_laneCountLabel` created in the ctor, driven in `updateUI` from the resolved track (`lane->trackId` → `getTrack`), laid out in `onResize` in a fixed 54px slot left of the M/S/R cluster (name label flexes around it). Shown only on the track's primary row (`laneIds.front() == m_laneId`) and only when the count is > 1.
- Unowned/legacy lanes (trackId 0) and count ≤ 1 render nothing.

## Citation

```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       planned
```

## Producer note

Track headers now show how many lanes each track holds, so multi-lane tracks are visible at a glance.

## Testing performed

- `TrackUIComponent.cpp` syntax-checked against the UI-enabled compile db (clean)
- Headless full pass not required — UI-only change, no audio/serialization surface touched
- Visual verification is manual — folded into #809 phase-5 validation

## Also in this PR — stale volume-knob slot removed

Found during founder app testing: channel-backed lanes still reserved the historical 4th layout slot, where a ghost volume knob rendered. It ate left-click presses (hidden-cursor drag capture) before button routing — hover lit the ghost arc, clicks vanished — and could silently write SetVolumeCommand to the mixer channel on drag. The fader was already removed; the knob outlived it. Removed the whole subsystem: layout slot (4 -> 3 buttons), render block, hover/drag/tooltip mouse handling, cursor-capture path, dead fader member/handlers. Track headers are now exactly M/S/R; the rec toggle always reaches the button.

## Risk / rollback notes

- Pure additive UI: no serialization, no DSP, no command-path change. Revert is a 3-file revert.
- The indicator is static per-render — it updates via the existing UI refresh when lanes change (same path that rebuilds lane rows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added a lane-count indicator for multi-lane tracks on the primary lane row.
- Show the lane-stack icon and owned-lane count in a fixed 54px slot beside the M/S/R controls.
- Hide the indicator for single-lane, unowned, legacy, and non-primary rows.
- Source the count from the resolved track’s authoritative `laneIds` list.
- Removed the stale volume-knob slot and related interaction and tooltip handling.
- Added the public `kLaneStackIconSvg` constant.
- The change is UI-only. It does not affect serialization, DSP, or command paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
