### PR TITLE
fix(audio): refresh track UI when a recorded take commits (FD-14 phase-5)

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1263,6 +1263,13 @@ public:
      * Used by the application layer to forward dirty state to AutosaveManager.
      */
     void setOnModified(std::function<void()> callback) { m_onModified = std::move(callback); }
+    /**
+     * @brief Register a callback invoked once a recorded take has committed.
+     * Fires after the take lane, clip, and ownership transaction are final, on
+     * the same (control) thread the commit ran on. The application layer uses
+     * this to refresh view-only state such as track rows.
+     */
+    void setOnTakeCommitted(std::function<void()> callback) { m_onTakeCommitted = std::move(callback); }
 
     using GraphDirtyReason = Aestra::Audio::GraphDirtyReason;
 
@@ -1816,6 +1823,10 @@ private:
                   std::to_string(channelId) + " at beat " + std::to_string(startBeat) + " with raw peak " +
                   std::to_string(rawPeak) + ", conditioned peak " + std::to_string(conditionedPeak) + ", clip gain " +
                   std::to_string(playbackGain));
+
+        if (m_onTakeCommitted) {
+            m_onTakeCommitted();
+        }
     }
 
     std::string buildRecordingTakePath(uint32_t channelId) const {
@@ -2045,6 +2056,7 @@ private:
     std::atomic<bool> m_userScrubbing{false};
     std::atomic<bool> m_modified{false};
     std::function<void()> m_onModified;
+    std::function<void()> m_onTakeCommitted;
     std::atomic<bool> m_graphDirty{true}; // Owned by TrackManager, consumed by PlaybackGraphController only
     std::atomic<uint64_t> m_requestGeneration{0};
     std::atomic<GraphDirtyReason> m_lastReason{GraphDirtyReason::TimelineChanged};

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -240,6 +240,14 @@ AestraContent::AestraContent()
     // TrackManager is owned by AestraContent, and the destructor clears this stored callback before teardown.
     m_trackManager->setStopPreviewCallback([this]() { stopSoundPreview(); });
 
+    // A committed take creates a new track-owned lane in the model; refresh the
+    // track view so the take lane row appears without a manual refresh action.
+    m_trackManager->setOnTakeCommitted([this]() {
+        if (m_trackManagerUI) {
+            m_trackManagerUI->refreshTracks();
+        }
+    });
+
     addDemoTracks();
 
     // Building the default project is not an edit (#653). addDemoTracks() calls

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -276,6 +276,38 @@ void testEachTakeCreatesALane() {
     }
 }
 
+/** FD-14 phase-5: the take-commit path notifies the UI layer so take lane
+ *  rows become visible without a manual refresh action. */
+void testTakeCommitFiresUiHook() {
+    std::cout << "[A] take commit fires the UI-refresh hook with ownership intact\n";
+    auto tm = makeRecorder();
+    int fireCount = 0;
+    tm->setOnTakeCommitted([&fireCount]() { ++fireCount; });
+
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
+
+    tm->record();
+    recordTake(*tm, 0.5);
+    recordTake(*tm, 0.5);
+
+    check(fireCount == 2, "hook fired once per committed take");
+
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track still resolvable");
+    if (track) {
+        const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+        check(takeLane.isValid(), "take lane resolved");
+        if (takeLane.isValid()) {
+            auto* lane = tm->getPlaylistModel().getLane(takeLane);
+            check(lane != nullptr && lane->trackId == trackId, "take lane owned by the recording track");
+        }
+    }
+}
+
 // ===========================================================================
 // SECTION B — post-migration acceptance (the Phase 2 RED assertions now hold)
 // ===========================================================================
@@ -534,6 +566,7 @@ int main() {
     testMultipleArmedTracksCaptureIndependently();
     testTwoArmedTracksSharingChannelCaptureIndependently();
     testEachTakeCreatesALane();
+    testTakeCommitFiresUiHook();
 
     std::cout << "Section B: post-migration acceptance\n";
     testRecordingIdentityIsTrackBased();


### PR DESCRIPTION
## Summary
The take-commit path already created track-owned lanes per take (FD-14 lane-per-take), but nothing notified the track view — take lanes appeared in the model and in command history while staying invisible in the UI until an unrelated action (delete/split/restart) forced a `refreshTracks()`.

Adds `TrackManager::setOnTakeCommitted` (fires once per committed take, after the lane/clip/ownership transaction is final, on the same control thread the commit ran on). `AestraContent` wires it to `TrackManagerUI::refreshTracks()`, completing the phase-5 chain: arm → record → take → **visible take lane** → lane indicator updates.

## Why
Phase-5 checklist item: "second pass Lane 2 → discoverability". Lane 2 existed in the model; the view never showed it.

## Testing performed
- New `testTakeCommitFiresUiHook` in RecordingBaselineTest: hook fires once per committed take (two passes → 2 fires), take lane resolved and `lane->trackId == trackId`.
- Full `ctest` suite: 261/261 passed, 1 skipped (SecAccountEndToEndSmoke, credential-gated).
- App target builds; AestraContent wiring compiles.

```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       corrective
```

## Producer note
Recording a take now instantly shows the new take lane in the track view.

## Docs updated?
No.

## Risk/rollback notes
- Callback fires on the commit/control thread only (same path as stop-recording); no audio-thread involvement.
- Single commit; revert-safe (`git revert` removes the wiring and the callback).
- Timeline minimap still doesn't auto-rebuild on take commit — `scheduleTimelineMinimapRebuild` is private; known follow-up if it proves visible during phase-5 validation.