### PR TITLE
fix(ui): draw lane-count indicator on track header (FD-14 §10)

### DIFF
--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1664,6 +1664,16 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
         drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
     }
 
+    // Lane-count indicator (FD-14 scope §10): TrackUIComponent::onRender does
+    // not call NUIComponent::renderChildren, so the icon/label widgets never
+    // auto-draw. Render them explicitly, like the name label and buttons.
+    if (m_laneCountIcon && m_laneCountIcon->isVisible()) {
+        m_laneCountIcon->onRender(renderer);
+    }
+    if (m_laneCountLabel && m_laneCountLabel->isVisible()) {
+        m_laneCountLabel->onRender(renderer);
+    }
+
     // Track number marker (left of name): recedes as quiet metadata (Level 4).
     if (m_nameLabel && lane) {
         constexpr float stripWidth = 3.0f;


### PR DESCRIPTION
## Summary
#812 shipped the FD-14 §10 lane-count indicator (icon + count on the track's primary row) — but it was **never drawn**. `TrackUIComponent::onRender` overrides `NUIComponent::onRender` without calling `renderChildren()`, and the indicator widgets had no explicit draw call anywhere (unlike the name label at `renderStatic` and the M/S/R button shells in `renderControlOverlay`). Widgets were created, positioned, and visibility-gated correctly — but no render pass ever drew them.

This renders the icon/label explicitly in `renderControlOverlay`, right after the button cluster, gated on `isVisible()` (which `updateUI()` already maintains).

## Why
§10: "A user must be able to look at a Track and immediately know that it contains multiple lanes." The first app-side visual validation (fresh project, two recorded takes, Track 1 owning 4 lanes) showed nothing. Only an eyeball on the app could catch this — no test exercises the NUI render path.

## Testing performed
- App target builds clean.
- Visual verification is manual (user's app session): Track 1's primary row should show `≡ 4` just left of the M/S/R buttons.

## Producer note
You can now see how many lanes a track contains right on the track header.

## Docs updated?
No.

## Risk/rollback notes
- Draw-only change; no state, model, or layout changes. Single commit, revert-safe.
- Indicator renders in the control overlay pass (viewport-culled with the buttons).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed lane-count indicators on track headers by explicitly rendering the visible icon and label in `renderControlOverlay`.
- Multiple-lane tracks now display indicators such as `≡ 4` beside the M/S/R controls.
- No breaking, state, model, or layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->