### PR TITLE
feat(ui): track-nested collapsible lanes for takes (FD-14 phase-5)

### DIFF
--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -257,6 +257,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/AddClipCommand.cpp
     src/Commands/AttachLaneToTrackCommand.cpp
     src/Commands/CreateLaneCommand.cpp
+    src/Commands/CreateTrackWithLaneCommand.cpp
     src/Commands/DeleteLaneCommand.cpp
     src/Commands/AddNoteCommand.cpp
     src/Commands/RemoveNoteCommand.cpp
@@ -385,6 +386,7 @@ set(AESTRA_AUDIO_CORE_HEADERS
     include/Commands/AddClipCommand.h
     include/Commands/AddChannelCommand.h
     include/Commands/CreateLaneCommand.h
+    include/Commands/CreateTrackWithLaneCommand.h
     include/Commands/DuplicateClipCommand.h
     include/Commands/MoveClipCommand.h
     include/Commands/RemoveClipCommand.h

--- a/AestraAudio/CMakeLists.txt
+++ b/AestraAudio/CMakeLists.txt
@@ -257,6 +257,7 @@ set(AESTRA_AUDIO_CORE_SOURCES
     src/Commands/AddClipCommand.cpp
     src/Commands/AttachLaneToTrackCommand.cpp
     src/Commands/CreateLaneCommand.cpp
+    src/Commands/DeleteLaneCommand.cpp
     src/Commands/AddNoteCommand.cpp
     src/Commands/RemoveNoteCommand.cpp
     src/Commands/MoveNoteCommand.cpp

--- a/AestraAudio/include/Commands/CreateTrackWithLaneCommand.h
+++ b/AestraAudio/include/Commands/CreateTrackWithLaneCommand.h
@@ -1,0 +1,59 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraUUID.h"
+#include "Commands/ICommand.h"
+#include "Models/PlaylistModel.h"
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+
+/**
+ * @brief Create a lane AND its owning Track as one atomic operation (FD-14).
+ *
+ * The app creates tracks in two UI paths that must undo as ONE step: the
+ * toolbar's add-track and a file/pattern drop that appends a new row. The pair
+ * is a single user action — "make a track" — so splitting it across
+ * CreateLaneCommand + a bare TrackManager::createTrack() call left the Track
+ * behind: undoing the drop removed the lane and an orphaned Track with zero
+ * owned lanes remained, and a failed import rolled back the lane but not its
+ * Track (CodeRabbit #816).
+ *
+ * execute() creates the lane — identity-stable via createLaneWithId, same
+ * semantics as CreateLaneCommand — then its Track. undo() removes the Track
+ * first (detaching owned lanes), then the lane. redo() recreates both: the
+ * lane id is restored (transaction members still hold it), the track id is
+ * fresh (nothing references tracks by stable id from within a transaction).
+ */
+class CreateTrackWithLaneCommand : public ICommand {
+public:
+    CreateTrackWithLaneCommand(TrackManager& trackManager, const std::string& name = "");
+    ~CreateTrackWithLaneCommand() override = default;
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    std::string getName() const override { return "Create Track"; }
+    size_t getSizeInBytes() const override { return sizeof(*this) + m_name.size(); }
+    bool changesProjectState() const override { return true; }
+
+    std::string serialize() const override;
+    std::string type() const override { return "create_track_lane"; }
+
+    PlaylistLaneID getLaneId() const { return m_laneId; }
+    uint64_t getTrackId() const { return m_trackId; }
+
+private:
+    TrackManager& m_trackManager;
+    PlaylistModel& m_model;
+    std::string m_name;
+    PlaylistLaneID m_laneId;
+    uint64_t m_trackId{0};
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/DeleteLaneCommand.h
+++ b/AestraAudio/include/Commands/DeleteLaneCommand.h
@@ -46,6 +46,7 @@ private:
     std::vector<ClipInstance> m_clips;
     int m_playlistIndex{-1};
     int m_laneIdsIndex{-1};
+    bool m_wasActiveLane{false};
     bool m_executed = false;
 };
 

--- a/AestraAudio/include/Commands/DeleteLaneCommand.h
+++ b/AestraAudio/include/Commands/DeleteLaneCommand.h
@@ -1,0 +1,53 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "AestraUUID.h"
+#include "Commands/ICommand.h"
+#include "Models/PlaylistModel.h"
+
+namespace Aestra {
+namespace Audio {
+
+class TrackManager;
+
+/**
+ * @brief Delete a lane and its clips (FD-14 phase-5 lane management).
+ *
+ * Owned take lanes are detached from their Track before removal; unowned
+ * lanes are removed outright. Undo restores the lane with its ORIGINAL id,
+ * position, and ownership (createLaneWithId + moveLaneToIndex +
+ * moveLaneWithinTrack), so an undone deletion is identity-stable AND stays in
+ * its playlist/track order. Deleting a lane does not delete its patterns —
+ * same policy as Delete Clip.
+ */
+class DeleteLaneCommand : public ICommand {
+public:
+    DeleteLaneCommand(TrackManager& trackManager, PlaylistLaneID laneId);
+    ~DeleteLaneCommand() override = default;
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    std::string getName() const override { return "Delete Lane"; }
+    size_t getSizeInBytes() const override { return sizeof(*this) + m_clips.size() * sizeof(ClipInstance); }
+    bool changesProjectState() const override { return true; }
+
+    std::string serialize() const override;
+    std::string type() const override { return "delete_lane"; }
+
+    static std::shared_ptr<ICommand> deserialize(PlaylistModel& model, const std::string& data);
+
+private:
+    TrackManager& m_trackManager;
+    PlaylistLaneID m_laneId;
+    std::string m_name;
+    uint64_t m_trackId{0};
+    std::vector<ClipInstance> m_clips;
+    int m_playlistIndex{-1};
+    int m_laneIdsIndex{-1};
+    bool m_executed = false;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -868,6 +868,54 @@ public:
     }
 
     /**
+     * @brief Playlist row position of a lane (-1 when missing).
+     */
+    int getLaneIndex(const PlaylistLaneID& laneId) const {
+        std::shared_lock<std::shared_mutex> lock(m_mutex);
+        auto it = m_laneMap.find(laneId);
+        return it == m_laneMap.end() ? -1 : static_cast<int>(it->second);
+    }
+
+    /**
+     * @brief Move an existing lane to a playlist position.
+     *
+     * Undo position fidelity for lane deletion (DeleteLaneCommand): the lane
+     * keeps its id, clips, and ownership, and lands back where it was instead
+     * of appending at the end. Also maintains PlaylistLane::index across the
+     * affected span (display numbering and channel lookups read it).
+     * Out-of-range targets clamp. Returns false when the lane is missing.
+     */
+    bool moveLaneToIndex(const PlaylistLaneID& laneId, size_t targetIndex) {
+        std::unique_lock<std::shared_mutex> lock(m_mutex);
+        auto it = m_laneMap.find(laneId);
+        if (it == m_laneMap.end() || m_lanes.empty()) {
+            return false;
+        }
+        const size_t from = it->second;
+        targetIndex = std::min(targetIndex, m_lanes.size() - 1);
+        if (from == targetIndex) {
+            return true;
+        }
+
+        PlaylistLane lane = std::move(m_lanes[from]);
+        m_lanes.erase(m_lanes.begin() + from);
+        m_lanes.insert(m_lanes.begin() + targetIndex, std::move(lane));
+
+        // Keep .index truthful across the span the lane traveled.
+        const size_t lo = std::min(from, targetIndex);
+        const size_t hi = std::max(from, targetIndex);
+        for (size_t i = lo; i <= hi; ++i) {
+            m_lanes[i].index = static_cast<int>(i);
+        }
+
+        m_laneMap.clear();
+        for (size_t i = 0; i < m_lanes.size(); ++i) {
+            m_laneMap[m_lanes[i].id] = i;
+        }
+        return true;
+    }
+
+    /**
      * @brief Clear all lanes and clips
      */
     void clear() {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -383,6 +383,25 @@ public:
         return track.trackId;
     }
 
+    /** @brief Remove a Track entirely. Owned lanes are detached (trackId=0)
+     *  and remain in the playlist. Returns false when the track is missing.
+     *  Used by CreateTrackWithLaneCommand::undo() so a dropped or added track
+     *  never survives the undo of the lane it was created with. */
+    bool removeTrack(uint64_t trackId) {
+        auto it = m_tracks.find(trackId);
+        if (it == m_tracks.end()) {
+            return false;
+        }
+        for (const auto& laneId : it->second.laneIds) {
+            if (auto* lane = m_playlistModel.getLane(laneId)) {
+                lane->trackId = 0;
+            }
+        }
+        m_tracks.erase(it);
+        requestAudioGraphRebuild(GraphDirtyReason::TrackStructureChanged);
+        return true;
+    }
+
     /** @brief Find a Track by stable ID. */
     Track* getTrack(uint64_t trackId) {
         auto it = m_tracks.find(trackId);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1263,6 +1263,14 @@ public:
      * Used by the application layer to forward dirty state to AutosaveManager.
      */
     void setOnModified(std::function<void()> callback) { m_onModified = std::move(callback); }
+    /**
+     * @brief Register a callback invoked once a recorded take has committed.
+     * Fires after the take lane, clip, and ownership transaction are final, on
+     * the same (control) thread the commit ran on. The application layer uses
+     * this to refresh view-only state such as track rows.
+     * @param callback Receives the lane id the take was committed onto.
+     */
+    void setOnTakeCommitted(std::function<void(PlaylistLaneID)> callback) { m_onTakeCommitted = std::move(callback); }
 
     using GraphDirtyReason = Aestra::Audio::GraphDirtyReason;
 
@@ -1816,6 +1824,10 @@ private:
                   std::to_string(channelId) + " at beat " + std::to_string(startBeat) + " with raw peak " +
                   std::to_string(rawPeak) + ", conditioned peak " + std::to_string(conditionedPeak) + ", clip gain " +
                   std::to_string(playbackGain));
+
+        if (m_onTakeCommitted) {
+            m_onTakeCommitted(laneId);
+        }
     }
 
     std::string buildRecordingTakePath(uint32_t channelId) const {
@@ -2045,6 +2057,7 @@ private:
     std::atomic<bool> m_userScrubbing{false};
     std::atomic<bool> m_modified{false};
     std::function<void()> m_onModified;
+    std::function<void(PlaylistLaneID)> m_onTakeCommitted;
     std::atomic<bool> m_graphDirty{true}; // Owned by TrackManager, consumed by PlaybackGraphController only
     std::atomic<uint64_t> m_requestGeneration{0};
     std::atomic<GraphDirtyReason> m_lastReason{GraphDirtyReason::TimelineChanged};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -438,6 +438,29 @@ public:
         return true;
     }
 
+    /** @brief Move an owned lane to a position within its track's lane order
+     *  (undo position fidelity for DeleteLaneCommand). The lane must already
+     *  be owned by the track. Out-of-range targets clamp. */
+    bool moveLaneWithinTrack(uint64_t trackId, PlaylistLaneID laneId, size_t targetIndex) {
+        auto* track = getTrack(trackId);
+        if (!track) {
+            return false;
+        }
+        auto& laneIds = track->laneIds;
+        auto it = std::find(laneIds.begin(), laneIds.end(), laneId);
+        if (it == laneIds.end()) {
+            return false;
+        }
+        const size_t from = static_cast<size_t>(it - laneIds.begin());
+        targetIndex = std::min(targetIndex, laneIds.size() - 1);
+        if (from == targetIndex) {
+            return true;
+        }
+        laneIds.erase(it);
+        laneIds.insert(laneIds.begin() + targetIndex, laneId);
+        return true;
+    }
+
     /** @brief Set the Track's recording arm state (FD-14 #6: the authoritative
      *  recording arm lives on the Track). */
     void setTrackArmed(uint64_t trackId, bool armed) {

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -17,6 +17,7 @@
 #include "Commands/SetStepsCommand.h"
 #include "Commands/TransposePatternCommand.h"
 #include "Commands/CreateLaneCommand.h"
+#include "Commands/DeleteLaneCommand.h"
 #include "Commands/ImportAudioClipCommand.h"
 #include "IO/MiniAudioDecoder.h"
 #include "Commands/RemoveClipCommand.h"
@@ -301,6 +302,16 @@ void CommandRegistry::initialize() {
         auto nameIt = flags.find("name");
         if (nameIt != flags.end()) name = nameIt->second;
         return std::make_unique<CreateLaneCommand>(*pm, name);
+    });
+
+    reg.registerCommand("delete_lane", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
+        auto laneIt = flags.find("lane_id");
+        if (laneIt == flags.end()) return nullptr;
+        PlaylistLaneID laneId;
+        if (!AestraUUID::tryParse(laneIt->second, laneId)) return nullptr;
+        return std::make_unique<DeleteLaneCommand>(*tm, laneId);
     });
 
     // Imports the file for real. This used to record the path as the clip's

--- a/AestraAudio/src/Commands/CommandRegistry.cpp
+++ b/AestraAudio/src/Commands/CommandRegistry.cpp
@@ -17,6 +17,7 @@
 #include "Commands/SetStepsCommand.h"
 #include "Commands/TransposePatternCommand.h"
 #include "Commands/CreateLaneCommand.h"
+#include "Commands/CreateTrackWithLaneCommand.h"
 #include "Commands/DeleteLaneCommand.h"
 #include "Commands/ImportAudioClipCommand.h"
 #include "IO/MiniAudioDecoder.h"
@@ -312,6 +313,15 @@ void CommandRegistry::initialize() {
         PlaylistLaneID laneId;
         if (!AestraUUID::tryParse(laneIt->second, laneId)) return nullptr;
         return std::make_unique<DeleteLaneCommand>(*tm, laneId);
+    });
+
+    reg.registerCommand("create_track_lane", [](const auto& flags, const CommandContext& ctx) -> std::unique_ptr<ICommand> {
+        TrackManager* tm = ctx.trackManager;
+        if (!tm) return nullptr;
+        std::string name;
+        auto nameIt = flags.find("name");
+        if (nameIt != flags.end()) name = nameIt->second;
+        return std::make_unique<CreateTrackWithLaneCommand>(*tm, name);
     });
 
     // Imports the file for real. This used to record the path as the clip's

--- a/AestraAudio/src/Commands/CreateTrackWithLaneCommand.cpp
+++ b/AestraAudio/src/Commands/CreateTrackWithLaneCommand.cpp
@@ -1,0 +1,74 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/CreateTrackWithLaneCommand.h"
+
+#include "Models/TrackManager.h"
+
+#include <sstream>
+
+namespace Aestra {
+namespace Audio {
+
+CreateTrackWithLaneCommand::CreateTrackWithLaneCommand(TrackManager& trackManager, const std::string& name)
+    : m_trackManager(trackManager), m_model(trackManager.getPlaylistModel()), m_name(name) {}
+
+void CreateTrackWithLaneCommand::execute() {
+    if (m_executed) {
+        return;
+    }
+
+    // Identity-stable lane restore, same rule as CreateLaneCommand: a
+    // CommandTransaction replays execute() after an undo, and its clip member
+    // still holds the ORIGINAL lane id — a fresh id would silently drop the
+    // clip onto a lane that no longer exists.
+    m_laneId = m_model.createLaneWithId(m_laneId, m_name);
+    if (!m_laneId.isValid()) {
+        return;
+    }
+    m_trackId = m_trackManager.createTrack(m_laneId, m_name);
+    if (m_trackId == 0) {
+        // Lane created but the track mint failed: roll back so execute() is
+        // atomic — no half of the pair may outlive the other.
+        m_model.removeLane(m_laneId);
+        m_laneId = PlaylistLaneID{};
+        return;
+    }
+    m_executed = true;
+}
+
+void CreateTrackWithLaneCommand::undo() {
+    if (!m_executed) {
+        return;
+    }
+    if (m_trackId != 0) {
+        // Track first: detaches its owned lanes, then the lane itself goes.
+        m_trackManager.removeTrack(m_trackId);
+        m_trackId = 0;
+    }
+    m_model.removeLane(m_laneId);
+    m_executed = false;
+}
+
+void CreateTrackWithLaneCommand::redo() {
+    if (m_executed) {
+        return;
+    }
+    m_laneId = m_model.createLaneWithId(m_laneId, m_name);
+    if (!m_laneId.isValid()) {
+        return;
+    }
+    m_trackId = m_trackManager.createTrack(m_laneId, m_name);
+    m_executed = true;
+}
+
+std::string CreateTrackWithLaneCommand::serialize() const {
+    std::ostringstream oss;
+    oss << "{"
+        << "\"type\":\"create_track_lane\","
+        << "\"name\":\"" << m_name << "\","
+        << "\"lane_id\":\"" << m_laneId.toString() << "\""
+        << "}";
+    return oss.str();
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/DeleteLaneCommand.cpp
+++ b/AestraAudio/src/Commands/DeleteLaneCommand.cpp
@@ -1,0 +1,87 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#include "Commands/DeleteLaneCommand.h"
+
+#include "Models/TrackManager.h"
+
+#include <algorithm>
+#include <sstream>
+
+namespace Aestra {
+namespace Audio {
+
+DeleteLaneCommand::DeleteLaneCommand(TrackManager& trackManager, PlaylistLaneID laneId)
+    : m_trackManager(trackManager), m_laneId(laneId) {}
+
+void DeleteLaneCommand::execute() {
+    if (m_executed) {
+        return;
+    }
+    auto& model = m_trackManager.getPlaylistModel();
+    const PlaylistLane* lane = model.getLane(m_laneId);
+    if (!lane) {
+        return;
+    }
+    m_name = lane->name;
+    m_trackId = lane->trackId;
+    m_clips = lane->clips;
+    m_playlistIndex = model.getLaneIndex(m_laneId);
+    if (m_trackId != 0) {
+        if (const Track* track = m_trackManager.getTrack(m_trackId)) {
+            const auto it = std::find(track->laneIds.begin(), track->laneIds.end(), m_laneId);
+            if (it != track->laneIds.end()) {
+                m_laneIdsIndex = static_cast<int>(it - track->laneIds.begin());
+            }
+        }
+        m_trackManager.detachLaneFromTrack(m_trackId, m_laneId);
+    }
+    model.removeLane(m_laneId);
+    m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = true;
+}
+
+void DeleteLaneCommand::undo() {
+    if (!m_executed) {
+        return;
+    }
+    auto& model = m_trackManager.getPlaylistModel();
+    const PlaylistLaneID restored = model.createLaneWithId(m_laneId, m_name);
+    for (const auto& clip : m_clips) {
+        model.addClip(restored, clip);
+    }
+    if (m_trackId != 0) {
+        m_trackManager.attachLaneToTrack(m_trackId, restored);
+        if (m_laneIdsIndex >= 0) {
+            m_trackManager.moveLaneWithinTrack(m_trackId, restored, static_cast<size_t>(m_laneIdsIndex));
+        }
+    }
+    if (m_playlistIndex >= 0) {
+        model.moveLaneToIndex(restored, static_cast<size_t>(m_playlistIndex));
+    }
+    m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = false;
+}
+
+void DeleteLaneCommand::redo() {
+    if (m_executed) {
+        return;
+    }
+    auto& model = m_trackManager.getPlaylistModel();
+    if (m_trackId != 0) {
+        m_trackManager.detachLaneFromTrack(m_trackId, m_laneId);
+    }
+    model.removeLane(m_laneId);
+    m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+    m_executed = true;
+}
+
+std::string DeleteLaneCommand::serialize() const {
+    std::ostringstream oss;
+    oss << "{"
+        << "\"type\":\"delete_lane\","
+        << "\"lane_id\":\"" << m_laneId.toString() << "\""
+        << "}";
+    return oss.str();
+}
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/src/Commands/DeleteLaneCommand.cpp
+++ b/AestraAudio/src/Commands/DeleteLaneCommand.cpp
@@ -27,10 +27,16 @@ void DeleteLaneCommand::execute() {
     m_playlistIndex = model.getLaneIndex(m_laneId);
     if (m_trackId != 0) {
         if (const Track* track = m_trackManager.getTrack(m_trackId)) {
+            // A track's last lane cannot be deleted (UI and command policy):
+            // an owned track must keep at least its primary lane.
+            if (track->laneIds.size() <= 1) {
+                return;
+            }
             const auto it = std::find(track->laneIds.begin(), track->laneIds.end(), m_laneId);
             if (it != track->laneIds.end()) {
                 m_laneIdsIndex = static_cast<int>(it - track->laneIds.begin());
             }
+            m_wasActiveLane = track->activeLaneId == m_laneId;
         }
         m_trackManager.detachLaneFromTrack(m_trackId, m_laneId);
     }
@@ -52,6 +58,13 @@ void DeleteLaneCommand::undo() {
         m_trackManager.attachLaneToTrack(m_trackId, restored);
         if (m_laneIdsIndex >= 0) {
             m_trackManager.moveLaneWithinTrack(m_trackId, restored, static_cast<size_t>(m_laneIdsIndex));
+        }
+        // detachLaneFromTrack reassigned activeLaneId to lanes.back(); put the
+        // deleted lane back in charge when it was active before the delete.
+        if (m_wasActiveLane) {
+            if (Track* track = m_trackManager.getTrack(m_trackId)) {
+                track->activeLaneId = restored;
+            }
         }
     }
     if (m_playlistIndex >= 0) {

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -267,10 +267,11 @@ void NUIPlatformBridge::setupEventBridges() {
     // Key
     m_window->setKeyCallback([this](Aestra::KeyCode key, bool pressed, const Aestra::KeyModifiers& mods) {
         if (key == Aestra::KeyCode::CapsLock && pressed) {
-            m_capsLockLatched = !m_capsLockLatched;
-        }
-        if (mods.capsLock) {
-            m_capsLockLatched = true;
+            // Sync from the platform's live state instead of blind-toggling:
+            // a one-way "re-stick when any event reports capsLock" ratchet could
+            // leave the latch stuck true after a toggle whose key event reports
+            // pre-toggle modifier state, routing every wheel to horizontal scroll.
+            m_capsLockLatched = m_window && m_window->getCurrentModifiers().capsLock;
         }
         if (m_keyCallback) {
             m_keyCallback(convertKeyCode(key), pressed);

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -521,7 +521,7 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
 
     // 2. View-level fallback for Grid Scrolling (if Grid didn't handle it)
     if (event.wheelDelta != 0.0f) {
-        bool shift = (event.modifiers & NUIModifiers::Shift) || (event.modifiers & NUIModifiers::CapsLock);
+        bool shift = (event.modifiers & NUIModifiers::Shift);
         bool ctrl = (event.modifiers & NUIModifiers::Ctrl);
         
         if (ctrl) {

--- a/AestraUI/Widgets/TrackControlIcons.h
+++ b/AestraUI/Widgets/TrackControlIcons.h
@@ -32,4 +32,11 @@ inline constexpr const char* kMonitorIconSvg =
 inline constexpr const char* kLaneStackIconSvg =
     R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="4.6" width="18" height="4.2" rx="1.1" fill="currentColor"/><rect x="3" y="9.9" width="18" height="4.2" rx="1.1" fill="currentColor"/><rect x="3" y="15.2" width="18" height="4.2" rx="1.1" fill="currentColor"/></svg>)";
 
+// FD-14 scope §10: expansion chevrons for the track header. Up = expanded
+// (reveal lanes), down = collapsed (primary lane only).
+inline constexpr const char* kChevronUpSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 14.5 12 8.5 18 14.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
+inline constexpr const char* kChevronDownSvg =
+    R"(<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 9.5 12 15.5 18 9.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>)";
+
 } // namespace AestraUI

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -558,6 +558,32 @@ void AestraApp::buildSettingsAndDialogs() {
     m_windowManager->setSettingsDialog(settingsDialog);
     m_windowManager->setConfirmationDialog(std::make_shared<ConfirmationDialog>());
 
+    // Route destructive UI confirmations (e.g. Delete Lane on a lane with
+    // clips) through the app-owned dialog, mirroring requestClose's parenting.
+    if (auto tmUI = m_content ? m_content->getTrackManagerUI() : nullptr) {
+        tmUI->setOnConfirmDialogRequest([this](const std::string& title, const std::string& message,
+                                               const std::string& confirmLabel,
+                                               std::function<void(bool)> onResult) {
+            auto dialog = m_windowManager ? m_windowManager->getConfirmationDialog() : nullptr;
+            if (!dialog || !onResult) {
+                if (onResult) {
+                    // Fail closed: a destructive action must not run without
+                    // its confirmation surface.
+                    onResult(false);
+                }
+                return;
+            }
+            if (auto* root = m_windowManager->getRootComponent()) {
+                dialog->setBounds(root->getBounds());
+                root->removeChild(dialog);
+                root->addChild(dialog);
+            }
+            dialog->showConfirm(title, message, confirmLabel, [onResult](DialogResponse response) {
+                onResult(response == DialogResponse::Confirm);
+            });
+        });
+    }
+
     auto exportDialog = std::make_shared<ExportDialog>();
     m_windowManager->setExportDialog(exportDialog);
 
@@ -892,13 +918,16 @@ void AestraApp::restoreUIState(const UIState& uiState) {
 
     if (m_content && m_content->getTrackManagerUI()) {
         auto trackManagerUI = m_content->getTrackManagerUI();
-        if (uiState.horizontalZoom != 1.0f || uiState.scrollPositionX != 0.0f || uiState.scrollPositionY != 0.0f) {
+        if (uiState.horizontalZoom != 1.0f || uiState.scrollPositionX != 0.0f) {
             trackManagerUI->setHorizontalZoom(uiState.horizontalZoom);
             trackManagerUI->setHorizontalScroll(uiState.scrollPositionX);
-            trackManagerUI->setVerticalScroll(uiState.scrollPositionY);
+            // Deliberately NOT restoring scrollPositionY: launching into a
+            // dead session's mid-list viewport reads as "the app starts me at
+            // track N" — the track list must open at the top of a fresh
+            // default project. Vertical viewport position is transient; zoom
+            // and horizontal fit are the durable parts.
             Log::info("[UIState] Applied track view state: zoom=" + std::to_string(uiState.horizontalZoom) +
-                      ", hScroll=" + std::to_string(uiState.scrollPositionX) +
-                      ", vScroll=" + std::to_string(uiState.scrollPositionY));
+                      ", hScroll=" + std::to_string(uiState.scrollPositionX));
         }
     }
 }

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -11,6 +11,7 @@
 #include "ClipSource.h"
 #include "Commands/AddClipCommand.h"
 #include "Commands/CreateLaneCommand.h"
+#include "Commands/DeleteLaneCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/RemoveClipCommand.h"
@@ -523,15 +524,13 @@ void TrackManagerUI::layoutTracks() {
 
         float yPos = trackAreaTop + (i * (m_trackHeight + m_trackSpacing)) - m_scrollOffset;
 
-        // FD-14 §10: nested lane rows (owned lanes of an expanded track) sit
-        // visibly inside their track — whole-row indent, leaving a gutter and
-        // offsetting the row border so the nesting reads at a glance.
-        const float rowIndent = trackUI->isNestedLane() ? kNestedLaneIndent : 0.0f;
-
         // Fix: Use absolute coordinates (bounds.x, yPos).
         // AestraUI components use absolute screen coordinates.
-        float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth - 5.0f - rowIndent);
-        trackUI->setBounds(bounds.x + rowIndent, yPos, trackWidth, m_trackHeight);
+        // FD-14 §10: nested rows keep FULL-WIDTH bounds — the timeline grid
+        // must stay globally aligned across lanes (a row-x indent would shift
+        // clip snapping); nesting is expressed in the chrome instead.
+        float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth - 5.0f);
+        trackUI->setBounds(bounds.x, yPos, trackWidth, m_trackHeight);
         trackUI->setVisible(m_playlistVisible);
 
         // Zebra Striping: Ensure index is set during layout (critical for refresh persistence)
@@ -721,6 +720,17 @@ void TrackManagerUI::openTrackContextMenu(const ::AestraUI::NUIPoint& position,
             }
         });
         menu->addSeparator();
+
+        // FD-14 phase-5: take lanes accumulate with no escape hatch. Only the
+        // LAST owned lane is protected — a track must keep at least one lane;
+        // unowned lanes are always deletable.
+        const uint64_t owningTrackId = lane->trackId;
+        const auto* owningTrack = owningTrackId != 0 ? m_trackManager->getTrack(owningTrackId) : nullptr;
+        const bool deletable = owningTrack == nullptr || owningTrack->laneIds.size() > 1;
+        auto deleteLaneItem = std::make_shared<AestraUI::NUIContextMenuItem>("Delete Lane");
+        deleteLaneItem->setEnabled(deletable);
+        deleteLaneItem->setOnClick([this, laneId]() { deleteLane(laneId); });
+        menu->addItem(deleteLaneItem);
     }
 
     menu->addItem("Send Track to Audition", [onSendToAudition]() {
@@ -734,6 +744,43 @@ void TrackManagerUI::openTrackContextMenu(const ::AestraUI::NUIPoint& position,
     menu->addItem(selectAllItem);
 
     attachAndShowContextMenu(this, menu, position);
+}
+
+void TrackManagerUI::deleteLane(PlaylistLaneID laneId) {
+    if (!m_trackManager) {
+        return;
+    }
+    const auto* lane = m_trackManager->getPlaylistModel().getLane(laneId);
+    if (!lane) {
+        return;
+    }
+    const auto* track = lane->trackId != 0 ? m_trackManager->getTrack(lane->trackId) : nullptr;
+    if (track && track->laneIds.size() <= 1) {
+        return;
+    }
+    const auto executeDelete = [this, laneId]() {
+        m_trackManager->getCommandHistory().pushAndExecute(std::make_shared<DeleteLaneCommand>(*m_trackManager, laneId));
+        refreshTracks();
+        invalidateCache();
+        scheduleTimelineMinimapRebuild();
+    };
+
+    // Deleting a lane that still holds clips is destructive: ask first when a
+    // dialog channel is wired. Headless callers without one proceed directly.
+    if (!lane->clips.empty() && m_onConfirmDialogRequest) {
+        m_onConfirmDialogRequest(
+            "Delete Lane",
+            "This lane still contains " + std::to_string(lane->clips.size()) +
+                (lane->clips.size() == 1 ? " clip" : " clips") +
+                ". Deleting the lane removes them. This can be undone.",
+            "Delete Lane", [executeDelete](bool confirmed) {
+                if (confirmed) {
+                    executeDelete();
+                }
+            });
+        return;
+    }
+    executeDelete();
 }
 
 } // namespace Audio

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -10,7 +10,7 @@
 #include "AudioFileValidator.h"
 #include "ClipSource.h"
 #include "Commands/AddClipCommand.h"
-#include "Commands/CreateLaneCommand.h"
+#include "Commands/CreateTrackWithLaneCommand.h"
 #include "Commands/DeleteLaneCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/MoveClipCommand.h"
@@ -133,21 +133,21 @@ void TrackManagerUI::addTrack(const std::string& name) {
         return;
 
     // Playlist lanes are created independently from mixer inserts.
-    auto laneCmd = std::make_shared<CreateLaneCommand>(m_trackManager->getPlaylistModel(), name);
+    //
+    // FD-14: the lane AND its owning Track are one operation — "add a track" is
+    // a lane plus ownership, and undoing it removes both. A bare createTrack()
+    // after a CreateLaneCommand push left an empty Track behind on undo.
+    auto laneCmd = std::make_shared<CreateTrackWithLaneCommand>(*m_trackManager, name);
     m_trackManager->getCommandHistory().pushAndExecute(laneCmd);
 
-    // FD-14: every lane belongs to a Track. The app's add-track creates the
-    // lane AND its owning Track in one operation (ownership by stable id).
     if (laneCmd->getLaneId().isValid()) {
-        m_trackManager->createTrack(laneCmd->getLaneId(), name);
+        // Rebuild UI from model state
+        refreshTracks();
+        layoutTracks();
+        scheduleTimelineMinimapRebuild();
+        invalidateCache();
+        Log::info("Added Playlist lane via command: " + name);
     }
-
-    // Rebuild UI from model state
-    refreshTracks();
-    layoutTracks();
-    scheduleTimelineMinimapRebuild();
-    invalidateCache();
-    Log::info("Added Playlist lane via command: " + name);
 }
 
 void TrackManagerUI::refreshTracks() {

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -172,8 +172,44 @@ void TrackManagerUI::refreshTracks() {
         removeChild(trackUI);
     }
     m_trackUIComponents.clear();
+
+    // FD-14 §10/§11: render lanes grouped by owning Track — the primary lane
+    // row first, then (when expanded) the track's owned lanes nested directly
+    // under it. Collapsed tracks show only the primary row; unowned lanes
+    // stay in playlist order.
+    std::vector<PlaylistLaneID> orderedLaneIds;
+    orderedLaneIds.reserve(laneCount);
+    std::unordered_set<uint64_t> seenTracks;
     for (size_t i = 0; i < laneCount; ++i) {
-        auto laneId = playlist.getLaneId(i);
+        const auto laneId = playlist.getLaneId(i);
+        const auto* lane = playlist.getLane(laneId);
+        if (!lane) {
+            continue;
+        }
+        const auto* track = lane->trackId != 0 ? m_trackManager->getTrack(lane->trackId) : nullptr;
+        if (!track) {
+            orderedLaneIds.push_back(laneId);
+            continue;
+        }
+        if (laneId != track->laneIds.front()) {
+            continue; // Owned lane: rendered nested under its track's primary row.
+        }
+        if (seenTracks.count(track->trackId)) {
+            continue;
+        }
+        seenTracks.insert(track->trackId);
+        orderedLaneIds.push_back(laneId);
+        if (!isTrackCollapsed(track->trackId)) {
+            for (const auto& owned : track->laneIds) {
+                if (owned != laneId) {
+                    orderedLaneIds.push_back(owned);
+                }
+            }
+        }
+    }
+
+    for (size_t i = 0; i < orderedLaneIds.size(); ++i) {
+        auto laneId = orderedLaneIds[i];
         auto lane = playlist.getLane(laneId);
         if (!lane) {
             Log::warning("refreshTracks: lane " + std::to_string(i) + " is null!");
@@ -183,6 +219,20 @@ void TrackManagerUI::refreshTracks() {
         // Playlist lanes are arrangement-only; mixer inserts are managed in
         // the mixer and sources keep their own stable destinations.
         auto trackUI = std::make_shared<TrackUIComponent>(laneId, nullptr, m_trackManager.get());
+
+        // FD-14 §10 nesting: mark owned non-primary rows as nested (no record
+        // arm, indented "Lane N" label) and mirror the track's collapse state
+        // for the chevron glyph. The expansion toggle lives on the primary
+        // row of a multi-lane track.
+        const auto* owningTrack = lane->trackId != 0 ? m_trackManager->getTrack(lane->trackId) : nullptr;
+        const bool isPrimaryRow = owningTrack && !owningTrack->laneIds.empty() && owningTrack->laneIds.front() == laneId;
+        trackUI->setIsNestedLane(owningTrack != nullptr && !isPrimaryRow);
+        trackUI->setTrackCollapsed(isTrackCollapsed(lane->trackId));
+        if (owningTrack && isPrimaryRow && owningTrack->laneIds.size() > 1) {
+            trackUI->setOnExpandToggled(
+                [this, trackId = owningTrack->trackId]() { this->toggleTrackCollapsed(trackId); });
+        }
+        trackUI->updateUI();
 
         // Register callbacks
         trackUI->setOnSoloToggled([this](TrackUIComponent* soloedTrack) { this->onTrackSoloToggled(soloedTrack); });
@@ -297,6 +347,31 @@ void TrackManagerUI::refreshTracks() {
     invalidateCache(); // Invalidate cache when tracks refreshed
 
     Log::info("refreshTracks: completed, created " + std::to_string(m_trackUIComponents.size()) + " TrackUIs");
+}
+
+void TrackManagerUI::toggleTrackCollapsed(uint64_t trackId) {
+    if (isTrackCollapsed(trackId)) {
+        m_collapsedTrackIds.erase(trackId);
+    } else {
+        m_collapsedTrackIds.insert(trackId);
+    }
+    refreshTracks();
+}
+
+void TrackManagerUI::revealLane(PlaylistLaneID laneId) {
+    // Phase-5: a committed take must be discoverable. Expand the owning track
+    // so its lanes render, rebuild rows, then scroll the take lane into view.
+    const auto* lane = m_trackManager ? m_trackManager->getPlaylistModel().getLane(laneId) : nullptr;
+    if (lane && lane->trackId != 0) {
+        expandTrack(lane->trackId);
+    }
+    refreshTracks();
+    for (size_t i = 0; i < m_trackUIComponents.size(); ++i) {
+        if (m_trackUIComponents[i] && m_trackUIComponents[i]->getLaneId() == laneId) {
+            setVerticalScroll(static_cast<float>(i) * (m_trackHeight + m_trackSpacing));
+            break;
+        }
+    }
 }
 
 void TrackManagerUI::onTrackSoloToggled(TrackUIComponent* soloedTrack) {
@@ -448,10 +523,15 @@ void TrackManagerUI::layoutTracks() {
 
         float yPos = trackAreaTop + (i * (m_trackHeight + m_trackSpacing)) - m_scrollOffset;
 
+        // FD-14 §10: nested lane rows (owned lanes of an expanded track) sit
+        // visibly inside their track — whole-row indent, leaving a gutter and
+        // offsetting the row border so the nesting reads at a glance.
+        const float rowIndent = trackUI->isNestedLane() ? kNestedLaneIndent : 0.0f;
+
         // Fix: Use absolute coordinates (bounds.x, yPos).
         // AestraUI components use absolute screen coordinates.
-        float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth - 5.0f);
-        trackUI->setBounds(bounds.x, yPos, trackWidth, m_trackHeight);
+        float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth - 5.0f - rowIndent);
+        trackUI->setBounds(bounds.x + rowIndent, yPos, trackWidth, m_trackHeight);
         trackUI->setVisible(m_playlistVisible);
 
         // Zebra Striping: Ensure index is set during layout (critical for refresh persistence)

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -282,29 +282,10 @@ void TrackManagerUI::refreshTracks() {
 
         trackUI->setOnSendToAudition([this, i, lane]() {
             if (this->m_onSendToAudition) {
-                // Resolve the lane to a mixer channel position: lanes and mixer
-                // channels are separate domains (a lane can be arrangement-only
-                // or its clips routed to any channel), so the lane index is not
-                // a valid channel position (#761 review). Use the first clip's
-                // mixer channel; fall back to the lane index when unresolved.
-                uint32_t channelIndex = static_cast<uint32_t>(i);
-                for (const auto& clip : lane->clips) {
-                    if (!clip.patternId.isValid())
-                        continue;
-                    auto* pattern = this->m_trackManager->getPatternManager().getPattern(clip.patternId);
-                    if (!pattern)
-                        continue;
-                    const uint32_t channelId = pattern->getMixerChannelId();
-                    for (size_t c = 0; c < this->m_trackManager->getChannelCount(); ++c) {
-                        if (const auto* channel = this->m_trackManager->getChannel(c)) {
-                            if (channel->getChannelId() == channelId) {
-                                channelIndex = static_cast<uint32_t>(c);
-                                break;
-                            }
-                        }
-                    }
-                    break;
-                }
+                // Lanes and mixer channels are separate domains (#761 review);
+                // resolve through the shared helper so the row button and the
+                // toolbar menu audition the same channel.
+                const uint32_t channelIndex = this->resolveLaneToChannelIndex(lane, static_cast<uint32_t>(i));
                 this->m_onSendToAudition(channelIndex, lane->name);
             }
         });
@@ -348,6 +329,35 @@ void TrackManagerUI::refreshTracks() {
     invalidateCache(); // Invalidate cache when tracks refreshed
 
     Log::info("refreshTracks: completed, created " + std::to_string(m_trackUIComponents.size()) + " TrackUIs");
+}
+
+uint32_t TrackManagerUI::resolveLaneToChannelIndex(const Audio::PlaylistLane* lane, uint32_t fallbackIndex) const {
+    // Lanes and mixer channels are separate domains (a lane can be
+    // arrangement-only or its clips routed to any channel), so the lane index
+    // is not a valid channel position (#761 review). Use the first clip's
+    // mixer channel; fall back to the lane index when unresolved.
+    if (!lane) {
+        return fallbackIndex;
+    }
+    for (const auto& clip : lane->clips) {
+        if (!clip.patternId.isValid()) {
+            continue;
+        }
+        auto* pattern = m_trackManager->getPatternManager().getPattern(clip.patternId);
+        if (!pattern) {
+            continue;
+        }
+        const uint32_t channelId = pattern->getMixerChannelId();
+        for (size_t c = 0; c < m_trackManager->getChannelCount(); ++c) {
+            if (const auto* channel = m_trackManager->getChannel(c)) {
+                if (channel->getChannelId() == channelId) {
+                    return static_cast<uint32_t>(c);
+                }
+            }
+        }
+        break;
+    }
+    return fallbackIndex;
 }
 
 void TrackManagerUI::toggleTrackCollapsed(uint64_t trackId) {

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -192,7 +192,7 @@ void TrackManagerUI::refreshTracks() {
             orderedLaneIds.push_back(laneId);
             continue;
         }
-        if (laneId != track->laneIds.front()) {
+        if (track->laneIds.empty() || laneId != track->laneIds.front()) {
             continue; // Owned lane: rendered nested under its track's primary row.
         }
         if (seenTracks.count(track->trackId)) {

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -154,6 +154,13 @@ public:
     void setOnSendToAudition(std::function<void(uint32_t trackId, const std::string& trackName)> cb) {
         m_onSendToAudition = cb;
     }
+
+    // Destructive-action confirmation, routed to the app's ConfirmationDialog.
+    // When unset, destructive actions proceed without confirmation.
+    using ConfirmDialogRequest =
+        std::function<void(const std::string& title, const std::string& message, const std::string& confirmLabel,
+                           std::function<void(bool confirmed)> onResult)>;
+    void setOnConfirmDialogRequest(ConfirmDialogRequest cb) { m_onConfirmDialogRequest = std::move(cb); }
     void setOnSendSelectionToAudition(std::function<void(double startBeat, double endBeat)> cb) {
         m_onSendSelectionToAudition = cb;
     }
@@ -173,6 +180,7 @@ public:
 
     // Context Menu Helpers (v4.0)
     void openTrackContextMenu(const ::AestraUI::NUIPoint& position, std::function<void()> onSendToAudition);
+    void deleteLane(PlaylistLaneID laneId);
 
     // Snap-to-Grid control
     void setSnapEnabled(bool enabled) { m_snapEnabled = enabled; }
@@ -526,6 +534,7 @@ private:
     std::function<void(double, double)>
         m_onLoopRegionUpdate; // Called when loop region needs update (Project auto-update)
     std::function<void(uint32_t, const std::string&)> m_onSendToAudition; // Called for "Send to Audition"
+    ConfirmDialogRequest m_onConfirmDialogRequest;
     std::function<void(double, double)> m_onSendSelectionToAudition;      // Called for "Send Selection to Audition"
     std::function<void()> m_onClipLibraryChanged;
     bool m_dragPatternPreviewActive = false;

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -605,6 +605,11 @@ private:
     double snapBeatToGrid(double beat) const;        // Snap beat to nearest grid line
     double snapBeatToGridForward(double beat) const; // Snap beat to next grid line (paste-to-right)
 
+    // Resolve a lane to its first pattern's mixer channel position, falling
+    // back to fallbackIndex when the lane is missing or unresolved. Shared by
+    // the per-track audition button and the toolbar's "Send Track to Audition".
+    uint32_t resolveLaneToChannelIndex(const Audio::PlaylistLane* lane, uint32_t fallbackIndex) const;
+
     // Tool icons initialization and rendering
     void createToolIcons();
     void updateToolbarBounds();

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -280,6 +280,14 @@ public:
         layoutTracks();
     }
 
+    // FD-14 §10/§11: per-track lane collapse state (session-local, not
+    // serialized). Collapsed tracks render only their primary lane row.
+    bool isTrackCollapsed(uint64_t trackId) const { return m_collapsedTrackIds.count(trackId) > 0; }
+    void toggleTrackCollapsed(uint64_t trackId);
+    void expandTrack(uint64_t trackId) { m_collapsedTrackIds.erase(trackId); }
+    /** Expand the lane's owning track, rebuild rows, and scroll it into view. */
+    void revealLane(PlaylistLaneID laneId);
+
 protected:
     void onRender(::AestraUI::NUIRenderer& renderer) override;
     void onUpdate(double deltaTime) override;
@@ -307,6 +315,7 @@ private:
     int m_trackSpacing{3};
     float m_scrollOffset{0.0f};
     float m_targetScrollOffset{0.0f};
+    std::unordered_set<uint64_t> m_collapsedTrackIds;
     PlaylistMode m_playlistMode{PlaylistMode::Clips};
     bool m_patternMode = false; // True when Pattern (Arsenal) playback is active
 

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -105,7 +105,7 @@ void TrackManagerUI::updateInstantClipDrag(const AestraUI::NUIPoint& currentPos)
     if (trackCount > 0) {
         targetTrackIndex = std::clamp(targetTrackIndex, 0, trackCount - 1);
 
-        auto targetLaneId = playlist.getLaneId(targetTrackIndex);
+        auto targetLaneId = m_trackUIComponents[targetTrackIndex]->getLaneId();
         if (targetLaneId.isValid()) {
             playlist.moveClip(m_draggedClipId, newStartBeat, targetLaneId);
         }

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -14,7 +14,7 @@
 #include "Commands/AddChannelCommand.h"
 #include "Commands/AddClipCommand.h"
 #include "Commands/CommandTransaction.h"
-#include "Commands/CreateLaneCommand.h"
+#include "Commands/CreateTrackWithLaneCommand.h"
 #include "Commands/DuplicateClipCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/RemoveClipCommand.h"
@@ -207,16 +207,26 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
         clearDropPreview();
         return result;
     }
+    // Catch-all for every payload the playlist cannot handle (None, Custom,
+    // AudioSourceRoute): the append branch below would otherwise create a lane
+    // and a Track for a payload no handler consumes, and a rejected drop must
+    // leave no objects behind. This must run BEFORE the lane-creation branch.
+    if (data.type != AestraUI::DragDataType::File && data.type != AestraUI::DragDataType::Pattern) {
+        result.accepted = false;
+        result.message = "Unsupported drop payload";
+        clearDropPreview();
+        return result;
+    }
 
     // 2. Resolve target lane
     //
     // A drop that has to append a lane must undo as ONE step: the lane is part of
-    // the edit, not scaffolding around it. Creating it through CreateLaneCommand
+    // the edit, not scaffolding around it. Creating it through CreateTrackWithLaneCommand
     // rather than calling playlist.createLane() directly is what lets it join the
     // clip in a single transaction — otherwise Ctrl+Z removes the clip and leaves
     // an empty orphan lane the user never asked for and cannot undo away.
     PlaylistLaneID targetLaneId;
-    std::shared_ptr<CreateLaneCommand> laneCommand;
+    std::shared_ptr<CreateTrackWithLaneCommand> laneCommand;
     if (laneIndex == displayRows) {
         // When a new lane is created for a file drop, name it from the sample
         // rather than "Track N" — the moment a clip lands on a track, the track
@@ -227,7 +237,10 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             namespace fs = std::filesystem;
             laneName = fs::path(data.filePath).stem().string();
         }
-        laneCommand = std::make_shared<CreateLaneCommand>(playlist, laneName);
+        // FD-14: the lane and its owning Track are ONE command, so a failed
+        // import rolls both back and an undo removes both — never an orphaned
+        // Track left behind when its lane disappears.
+        laneCommand = std::make_shared<CreateTrackWithLaneCommand>(*m_trackManager, laneName);
         laneCommand->execute();
         targetLaneId = laneCommand->getLaneId();
         if (!targetLaneId.isValid()) {
@@ -237,8 +250,6 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
             clearDropPreview();
             return result;
         }
-        // FD-14: a new lane belongs to a new Track (ownership by stable id).
-        m_trackManager->createTrack(targetLaneId, laneName);
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
     } else {

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -173,12 +173,12 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     double timePositionBeats = snapBeatToGrid(rawTimeBeats);
 
     auto& playlist = m_trackManager->getPlaylistModel();
-    size_t laneCount = playlist.getLaneCount();
+    const int displayRows = static_cast<int>(m_trackUIComponents.size());
 
     Log::info("[TrackManagerUI] onDrop: position.y=" + std::to_string(position.y) +
-              ", laneIndex=" + std::to_string(laneIndex) + ", laneCount=" + std::to_string(laneCount));
+              ", laneIndex=" + std::to_string(laneIndex) + ", displayRows=" + std::to_string(displayRows));
 
-    if (laneIndex < 0 || laneIndex > static_cast<int>(laneCount)) {
+    if (laneIndex < 0 || laneIndex > displayRows) {
         result.accepted = false;
         result.message = "Invalid track position";
         clearDropPreview();
@@ -217,7 +217,7 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
     // an empty orphan lane the user never asked for and cannot undo away.
     PlaylistLaneID targetLaneId;
     std::shared_ptr<CreateLaneCommand> laneCommand;
-    if (laneIndex == static_cast<int>(laneCount)) {
+    if (laneIndex == displayRows) {
         // When a new lane is created for a file drop, name it from the sample
         // rather than "Track N" — the moment a clip lands on a track, the track
         // should inherit the content name.  MIDI patterns keep the sequential
@@ -242,7 +242,9 @@ AestraUI::DropResult TrackManagerUI::onDrop(const AestraUI::DragData& data, cons
 
         Log::info("[TrackManagerUI] Created new lane " + std::to_string(laneIndex) + " for drop.");
     } else {
-        targetLaneId = playlist.getLaneId(laneIndex);
+        // Display-row index, not playlist index: rows are track-grouped
+        // (FD-14 §10), so the lane must come from the row widget itself.
+        targetLaneId = m_trackUIComponents[laneIndex]->getLaneId();
     }
 
     // Undo the appended lane without recording anything: a drop that failed is not

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -63,7 +63,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragEnter(const AestraUI::DragData& dat
     m_dropTargetTime = getTimeAtPosition(position.x);
 
     // Allow dropping on existing tracks OR appending a new track
-    int trackCount = static_cast<int>(m_trackManager->getTrackCount());
+    int trackCount = static_cast<int>(m_trackUIComponents.size());
 
     // If dragging below last track, target the next available slot
     if (m_dropTargetTrack >= trackCount) {
@@ -123,7 +123,7 @@ AestraUI::DropFeedback TrackManagerUI::onDragOver(const AestraUI::DragData& data
     double snappedBeats = snapBeatToGrid(rawTimeBeats);
     double newTime = m_trackManager->getPlaylistModel().beatToSeconds(snappedBeats);
 
-    int trackCount = static_cast<int>(m_trackManager->getTrackCount());
+    int trackCount = static_cast<int>(m_trackUIComponents.size());
 
     // If dragging below last track, target the next available slot
     if (newTrack >= trackCount) {

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -519,7 +519,7 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
             invalidateCache(); // Full cache invalidation for zoom changes
             return true;
         } else if (isInTrackArea && shiftHeld) {
-            // HORIZONTAL SCROLL: Shift/Caps+wheel (and synthetic Shift from laptop horizontal wheel).
+            // HORIZONTAL SCROLL: Shift+wheel (and synthetic Shift from laptop horizontal wheel).
             auto& themeManager = AestraUI::NUIThemeManager::getInstance();
             const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
             const float gridStartX = controlAreaWidth + kTimelineGridInsetX;

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -471,7 +471,6 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
     if (event.wheelDelta != 0.0f && (isInRuler || isInTrackArea)) {
         const bool shiftHeld = (event.modifiers & AestraUI::NUIModifiers::Shift);
         const bool ctrlHeld = (event.modifiers & AestraUI::NUIModifiers::Ctrl);
-        const bool capsHeld = (event.modifiers & AestraUI::NUIModifiers::CapsLock);
 
         if (isInRuler || ctrlHeld) {
             // ZOOM: ruler wheel or Ctrl+wheel.
@@ -519,7 +518,7 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
 
             invalidateCache(); // Full cache invalidation for zoom changes
             return true;
-        } else if (isInTrackArea && (shiftHeld || capsHeld)) {
+        } else if (isInTrackArea && shiftHeld) {
             // HORIZONTAL SCROLL: Shift/Caps+wheel (and synthetic Shift from laptop horizontal wheel).
             auto& themeManager = AestraUI::NUIThemeManager::getInstance();
             const float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;

--- a/Source/Components/TrackManagerUIMath.h
+++ b/Source/Components/TrackManagerUIMath.h
@@ -22,6 +22,10 @@ constexpr float kTimelineRulerHeight = 28.0f;
 constexpr float kTimelineHorizontalScrollbarHeight = 24.0f;
 constexpr float kTimelineScrollbarWidth = 15.0f;
 
+// FD-14 §10: nested lane rows (owned lanes of an expanded track) indent this
+// far inside the track's primary row, leaving a gutter that reads as nesting.
+constexpr float kNestedLaneIndent = 24.0f;
+
 /**
  * @brief Gap between the track-controls column and the first grid pixel.
  *

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -339,6 +339,12 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         // on dark themes, recessed light bed on light themes.
         renderer.fillRect(trackBounds, themeManager.getColor("timelineBed"));
 
+        // FD-14 §10: nested lane rows carry a faint containment tint so the
+        // expanded lanes read as one block under their track.
+        if (track->isNestedLane()) {
+            renderer.fillRect(trackBounds, themeManager.getColor("accentSecondary").withAlpha(0.05f));
+        }
+
         track->renderStatic(renderer);
 
         // One pixel is enough to locate the next lane; filling the whole gap

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -564,8 +564,10 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                     if (laneId.isValid()) {
                         const PlaylistLane* lane = playlist.getLane(laneId);
                         std::string trackName = lane ? lane->name : ("Track " + std::to_string(trackIndex + 1));
-                        // Pass track index instead of lane ID internal value
-                        m_onSendToAudition(static_cast<uint32_t>(trackIndex), trackName);
+                        // Display rows are not mixer channels after lane grouping;
+                        // resolve like the per-track audition button does.
+                        const uint32_t channelIndex = resolveLaneToChannelIndex(lane, static_cast<uint32_t>(trackIndex));
+                        m_onSendToAudition(channelIndex, trackName);
                         Log::info("Sending track to Audition: " + trackName);
                     }
                 }

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -557,13 +557,17 @@ bool TrackManagerUI::handleToolbarClick(const AestraUI::NUIPoint& position) {
                     }
                 }
 
-                PlaylistLaneID laneId = playlist.getLaneId(trackIndex);
-                if (laneId.isValid()) {
-                    const PlaylistLane* lane = playlist.getLane(laneId);
-                    std::string trackName = lane ? lane->name : ("Track " + std::to_string(trackIndex + 1));
-                    // Pass track index instead of lane ID internal value
-                    m_onSendToAudition(static_cast<uint32_t>(trackIndex), trackName);
-                    Log::info("Sending track to Audition: " + trackName);
+                // Display-row index, not playlist index: rows are track-grouped
+                // (FD-14 §10), so the lane must come from the row widget itself.
+                if (trackIndex < static_cast<int>(m_trackUIComponents.size())) {
+                    PlaylistLaneID laneId = m_trackUIComponents[trackIndex]->getLaneId();
+                    if (laneId.isValid()) {
+                        const PlaylistLane* lane = playlist.getLane(laneId);
+                        std::string trackName = lane ? lane->name : ("Track " + std::to_string(trackIndex + 1));
+                        // Pass track index instead of lane ID internal value
+                        m_onSendToAudition(static_cast<uint32_t>(trackIndex), trackName);
+                        Log::info("Sending track to Audition: " + trackName);
+                    }
                 }
             }
         });
@@ -855,7 +859,11 @@ void TrackManagerUI::renderMinimapResizeCursor(AestraUI::NUIRenderer& renderer, 
 
 void TrackManagerUI::performSplitAtPosition(int laneIndex, double timeSeconds) {
     auto& playlist = m_trackManager->getPlaylistModel();
-    PlaylistLaneID laneId = playlist.getLaneId(laneIndex);
+    // Display-row index, not playlist index: rows are track-grouped
+    // (FD-14 §10), so the lane must come from the row widget itself.
+    if (laneIndex < 0 || laneIndex >= static_cast<int>(m_trackUIComponents.size()))
+        return;
+    PlaylistLaneID laneId = m_trackUIComponents[laneIndex]->getLaneId();
     if (!laneId.isValid())
         return;
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -79,6 +79,8 @@ using AestraUI::kMuteIconSvg;
 using AestraUI::kRecordIconSvg;
 using AestraUI::kSoloIconSvg;
 using AestraUI::kLaneStackIconSvg;
+using AestraUI::kChevronUpSvg;
+using AestraUI::kChevronDownSvg;
 
 bool parseTrailingTrackNumber(const std::string& trackName, uint32_t& trackNumberOut) {
     const size_t numberPos = trackName.find_last_not_of("0123456789");
@@ -241,6 +243,17 @@ TrackUIComponent::TrackUIComponent(PlaylistLaneID laneId, std::shared_ptr<MixerC
     m_recordButton->setToggleable(true);
     m_recordButton->setOnToggle([this](bool) { onRecordToggled(); });
     addChild(m_recordButton);
+
+    // FD-14 §10 expansion toggle: hit target only, glyph drawn in the control
+    // overlay. Visible on the track's primary row when it owns multiple lanes.
+    m_expandButton = std::make_shared<AestraUI::NUIButton>();
+    m_expandButton->setVisible(false);
+    m_expandButton->setOnClick([this]() {
+        if (m_onExpandToggled) {
+            m_onExpandToggled();
+        }
+    });
+    addChild(m_expandButton);
 
     updateUI();
 }
@@ -510,9 +523,20 @@ void TrackUIComponent::updateUI() {
         updateRecordTooltip();
     }
 
+    // FD-14 §10 nesting: record arm is track-exclusive, so nested lane rows
+    // carry M/S only; the expansion chevron lives on the primary row of a
+    // multi-lane track.
+    if (m_recordButton) {
+        m_recordButton->setVisible(!m_isNestedLane);
+    }
+
     if (m_laneCountLabel && m_laneCountIcon) {
         const bool isPrimaryRow = track && !track->laneIds.empty() && track->laneIds.front() == m_laneId;
-        if (isPrimaryRow && track->laneIds.size() > 1) {
+        const bool multiLaneTrack = track && track->laneIds.size() > 1;
+        if (m_expandButton) {
+            m_expandButton->setVisible(isPrimaryRow && multiLaneTrack);
+        }
+        if (isPrimaryRow && multiLaneTrack) {
             m_laneCountLabel->setText(std::to_string(track->laneIds.size()));
             m_laneCountLabel->setTextColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
             m_laneCountLabel->setVisible(true);
@@ -1659,22 +1683,57 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
 
         drawControlIcon(m_muteButton, kMuteIconSvg, lane->muted ? muteActive : textIdle, lane->muted, muteActive);
         drawControlIcon(m_soloButton, kSoloIconSvg, lane->solo ? soloActive : textIdle, lane->solo, soloActive);
-        auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
-        const bool isArmed = armTrack && armTrack->armed;
-        drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
+        // Record arm is track-exclusive (FD-14): nested lane rows carry M/S only.
+        if (!m_isNestedLane) {
+            auto* armTrack = m_trackManager ? m_trackManager->getTrackForLane(m_laneId) : nullptr;
+            const bool isArmed = armTrack && armTrack->armed;
+            drawControlIcon(m_recordButton, kRecordIconSvg, isArmed ? recordActive : textIdle, isArmed, recordActive);
+        }
+    }
+
+    // FD-14 §10 expansion chevron; visibility set during updateUI (primary row
+    // of a multi-lane track only).
+    if (m_expandButton && m_expandButton->isVisible()) {
+        const auto* doc = trackControlIcon(m_trackCollapsed ? kChevronDownSvg : kChevronUpSvg);
+        if (doc) {
+            const auto rect = m_expandButton->getBounds();
+            const float iconSize = 12.0f;
+            const AestraUI::NUIRect iconRect(std::round(rect.x + (rect.width - iconSize) * 0.5f),
+                                             std::round(rect.y + (rect.height - iconSize) * 0.5f),
+                                             iconSize, iconSize);
+            AestraUI::NUISVGRenderer::render(renderer, *doc, iconRect,
+                                             themeManager.getColor("textSecondary").withAlpha(0.42f));
+        }
+    }
+
+    // Lane-count indicator (FD-14 scope §10): TrackUIComponent::onRender does
+    // not call NUIComponent::renderChildren, so the icon/label widgets never
+    // auto-draw. Render them explicitly, like the name label and buttons.
+    if (m_laneCountIcon && m_laneCountIcon->isVisible()) {
+        m_laneCountIcon->onRender(renderer);
+    }
+    if (m_laneCountLabel && m_laneCountLabel->isVisible()) {
+        m_laneCountLabel->onRender(renderer);
     }
 
     // Track number marker (left of name): recedes as quiet metadata (Level 4).
     if (m_nameLabel && lane) {
         constexpr float stripWidth = 3.0f;
-        uint32_t trackNumber = static_cast<uint32_t>(lane->index + 1);
-        const auto laneName = m_nameLabel->getText();
-        uint32_t parsedNumber = 0;
-        if (parseTrailingTrackNumber(laneName, parsedNumber)) {
-            trackNumber = parsedNumber;
-        }
         const auto nameBounds = m_nameLabel->getBounds();
-        renderer.drawText(std::to_string(trackNumber),
+        std::string numberText;
+        if (m_isNestedLane) {
+            const auto* nestedTrack = m_trackManager ? m_trackManager->getTrack(lane->trackId) : nullptr;
+            numberText = "Lane " + std::to_string(nestedTrack ? nestedTrack->laneNumber(m_laneId) : 0);
+        } else {
+            uint32_t trackNumber = static_cast<uint32_t>(lane->index + 1);
+            const auto laneName = m_nameLabel->getText();
+            uint32_t parsedNumber = 0;
+            if (parseTrailingTrackNumber(laneName, parsedNumber)) {
+                trackNumber = parsedNumber;
+            }
+            numberText = std::to_string(trackNumber);
+        }
+        renderer.drawText(numberText,
                           AestraUI::NUIPoint(controlAreaBounds.x + stripWidth + 8.0f, nameBounds.y + 2.0f),
                           themeManager.getFontSize("xs"),
                           themeManager.getColor("textSecondary").withAlpha(m_selected ? 0.58f : 0.36f));
@@ -1785,9 +1844,19 @@ void TrackUIComponent::onResize(int width, int height) {
     const float laneIndicatorGap = 6.0f;
     const float laneIndicatorX = localButtonsXStart - laneIndicatorGap - laneIndicatorWidth;
 
+    // FD-14 §10 expansion chevron sits between the indicator and the buttons.
+    const float expandButtonW = 20.0f;
+    const float expandButtonX = laneIndicatorX - laneIndicatorGap - expandButtonW;
+    if (m_expandButton) {
+        m_expandButton->setBounds(
+            AestraUI::NUIRect(bounds.x + expandButtonX, bounds.y + localButtonsY, expandButtonW, buttonH));
+    }
+
     // Keep track number + name anchored to the left, with flexible space to buttons.
-    const float localLabelLeft = leftPad + trackNumberWidth + numberNameGap;
-    const float localInlineRight = laneIndicatorX - 8.0f;
+    // Nested lane rows (FD-14 §10) indent for the "Lane N" prefix.
+    const float laneNumberPrefixWidth = 48.0f;
+    const float localLabelLeft = leftPad + trackNumberWidth + numberNameGap + (m_isNestedLane ? laneNumberPrefixWidth : 0.0f);
+    const float localInlineRight = expandButtonX - 8.0f;
     const float localInlineWidth = std::max(0.0f, localInlineRight - localLabelLeft);
     const float localNameHeight = std::max(14.0f, layout.trackLabelHeight - 2.0f);
     const float localNameY = localButtonsY + std::max(0.0f, (buttonH - localNameHeight) * 0.5f);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -537,7 +537,11 @@ void TrackUIComponent::updateUI() {
             m_expandButton->setVisible(isPrimaryRow && multiLaneTrack);
         }
         if (isPrimaryRow && multiLaneTrack) {
-            m_laneCountLabel->setText(std::to_string(track->laneIds.size()));
+            // FD-14 §10: the counter counts the lanes NESTED under the primary
+            // row — what the stack glyph depicts and what the chevron reveals.
+            // A 3-take track reads "≡ 3", not "≡ 4" (laneIds includes the
+            // primary row itself, which is never "inside" the chevron).
+            m_laneCountLabel->setText(std::to_string(track->laneIds.size() - 1));
             m_laneCountLabel->setTextColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
             m_laneCountLabel->setVisible(true);
             m_laneCountIcon->setColor(themeManager.getColor("textSecondary").withAlpha(0.72f));
@@ -1834,8 +1838,13 @@ void TrackUIComponent::onResize(int width, int height) {
     const float trackNumberWidth = 14.0f;
     const float numberNameGap = 6.0f;
 
+    // FD-14 §10: nested rows pull their chrome inward so the lane reads as
+    // indented while the timeline grid stays globally aligned across lanes —
+    // a row-x indent would shift clip snapping against the other rows.
+    const float chromeIndent = m_isNestedLane ? kNestedLaneIndent : 0.0f;
+
     // Position relative to component origin, then add absolute offset
-    const float localButtonsXStart = controlAreaWidth - rightPad - buttonsTotalW;
+    const float localButtonsXStart = controlAreaWidth - rightPad - buttonsTotalW - chromeIndent;
     const float localButtonsY = (bounds.height - buttonH) * 0.5f;
 
     // Lane-count indicator (FD-14 scope §10) sits just left of the buttons on
@@ -1856,7 +1865,19 @@ void TrackUIComponent::onResize(int width, int height) {
     // Nested lane rows (FD-14 §10) indent for the "Lane N" prefix.
     const float laneNumberPrefixWidth = 48.0f;
     const float localLabelLeft = leftPad + trackNumberWidth + numberNameGap + (m_isNestedLane ? laneNumberPrefixWidth : 0.0f);
-    const float localInlineRight = expandButtonX - 8.0f;
+    // Reserve space only for widgets actually visible on this row: the
+    // indicator/chevron only exist on multi-lane primary rows, so hidden ones
+    // must not starve the name label down to its 40px floor.
+    const float inlineRightEdge = [&]() {
+        if (m_expandButton && m_expandButton->isVisible()) {
+            return expandButtonX;
+        }
+        if (m_laneCountIcon && m_laneCountIcon->isVisible()) {
+            return laneIndicatorX;
+        }
+        return localButtonsXStart;
+    }();
+    const float localInlineRight = inlineRightEdge - 8.0f;
     const float localInlineWidth = std::max(0.0f, localInlineRight - localLabelLeft);
     const float localNameHeight = std::max(14.0f, layout.trackLabelHeight - 2.0f);
     const float localNameY = localButtonsY + std::max(0.0f, (buttonH - localNameHeight) * 0.5f);
@@ -1989,6 +2010,7 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         handledByControls = routeControlButton(m_muteButton) || handledByControls;
         handledByControls = routeControlButton(m_soloButton) || handledByControls;
         handledByControls = routeControlButton(m_recordButton) || handledByControls;
+        handledByControls = routeControlButton(m_expandButton) || handledByControls;
 
         if (!event.cursorCaptured && isInsideBounds) {
             if (m_muteButton && m_muteButton->getBounds().contains(event.position)) {
@@ -2003,6 +2025,9 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 AestraUI::NUIComponent::showRemoteTooltip(tooltip, event.position, this);
             } else if (m_recordButton && m_recordButton->getBounds().contains(event.position)) {
                 AestraUI::NUIComponent::showRemoteTooltip(recordButtonTooltipText(), event.position, this);
+            } else if (m_expandButton && m_expandButton->getBounds().contains(event.position)) {
+                AestraUI::NUIComponent::showRemoteTooltip(m_trackCollapsed ? "Expand lanes" : "Collapse lanes",
+                                                          event.position, this);
             } else {
                 AestraUI::NUIComponent::hideRemoteTooltip(this);
             }

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -58,6 +58,10 @@ public:
     // Primary/Secondary lane status - primary draws controls, secondary only draws clip
     void setIsPrimaryForLane(bool isPrimary) { m_isPrimaryForLane = isPrimary; }
     bool isPrimaryForLane() const { return m_isPrimaryForLane; }
+    void setIsNestedLane(bool nested) { m_isNestedLane = nested; }
+    bool isNestedLane() const { return m_isNestedLane; }
+    void setTrackCollapsed(bool collapsed) { m_trackCollapsed = collapsed; }
+    void setOnExpandToggled(std::function<void()> callback) { m_onExpandToggled = std::move(callback); }
     
     // Callback for when solo is toggled (so parent can update all track UIs)
     void setOnSoloToggled(std::function<void(TrackUIComponent*)> callback) { m_onSoloToggledCallback = callback; }
@@ -173,6 +177,9 @@ private:
     bool m_selected = false; // Track selection state
     ClipInstanceID m_selectedClipId; // Persistent clip selection supplied by TrackManagerUI
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
+    bool m_isNestedLane = false; // Owned non-primary lane row (FD-14 §10 nesting)
+    bool m_trackCollapsed = false; // Owning track's collapse state (chevron glyph)
+    std::function<void()> m_onExpandToggled;
     bool m_anyPlaylistLaneSoloed = false;
     bool m_isLoading = false;
     float m_loadProgress = 0.0f;
@@ -265,6 +272,7 @@ private:
     std::shared_ptr<AestraUI::NUIButton> m_muteButton;
     std::shared_ptr<AestraUI::NUIButton> m_soloButton;
     std::shared_ptr<AestraUI::NUIButton> m_recordButton;
+    std::shared_ptr<AestraUI::NUIButton> m_expandButton;
     std::shared_ptr<AestraUI::NUIContextMenu> m_recordModeMenu;
     std::shared_ptr<AestraUI::NUIContextMenu> m_clipRoutingMenu;
 

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -153,9 +153,10 @@ AestraContent::~AestraContent() {
         m_audioEngine->setPreviewEngine(nullptr);
     }
 
-    // TrackManager may be shared outside this component; clear the stored owner callback before member teardown.
+    // TrackManager may be shared outside this component; clear the stored owner callbacks before member teardown.
     if (m_trackManager) {
         m_trackManager->setStopPreviewCallback(nullptr);
+        m_trackManager->setOnTakeCommitted(nullptr);
     }
 
     // Cancel any running plugin scan to prevent callbacks from accessing dead pointers

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -240,6 +240,15 @@ AestraContent::AestraContent()
     // TrackManager is owned by AestraContent, and the destructor clears this stored callback before teardown.
     m_trackManager->setStopPreviewCallback([this]() { stopSoundPreview(); });
 
+    // A committed take creates a new track-owned lane in the model; expand the
+    // recording track, rebuild the track view, and scroll the take lane into
+    // view (FD-14 phase-5: take lanes must be discoverable, not silent rows).
+    m_trackManager->setOnTakeCommitted([this](PlaylistLaneID laneId) {
+        if (m_trackManagerUI) {
+            m_trackManagerUI->revealLane(laneId);
+        }
+    });
+
     addDemoTracks();
 
     // Building the default project is not an edit (#653). addDemoTracks() calls

--- a/Source/Settings/ConfirmationDialog.cpp
+++ b/Source/Settings/ConfirmationDialog.cpp
@@ -22,12 +22,29 @@ void ConfirmationDialog::show(const std::string& title, const std::string& messa
     m_message = message;
     m_callback = callback;
     m_response = DialogResponse::None;
+    m_isConfirmMode = false;
     m_focusIndex = 2; // default focus on the primary action (Save)
     m_pressedButton = DialogResponse::None;
     m_isVisible = true;
     setVisible(true);
     
     Log::info("[ConfirmationDialog] Showing: " + title);
+}
+
+void ConfirmationDialog::showConfirm(const std::string& title, const std::string& message,
+                                     const std::string& confirmLabel, ResponseCallback callback) {
+    m_title = title;
+    m_message = message;
+    m_callback = callback;
+    m_response = DialogResponse::None;
+    m_isConfirmMode = true;
+    m_confirmLabel = confirmLabel.empty() ? "Confirm" : confirmLabel;
+    m_focusIndex = 1; // default focus on the primary action (Confirm)
+    m_pressedButton = DialogResponse::None;
+    m_isVisible = true;
+    setVisible(true);
+
+    Log::info("[ConfirmationDialog] Showing (confirm): " + title);
 }
 
 void ConfirmationDialog::hide() {
@@ -45,6 +62,7 @@ void ConfirmationDialog::handleResponse(DialogResponse response) {
         case DialogResponse::Save: responseStr = "Save"; break;
         case DialogResponse::DontSave: responseStr = "Don't Save"; break;
         case DialogResponse::Cancel: responseStr = "Cancel"; break;
+        case DialogResponse::Confirm: responseStr = m_confirmLabel; break;
         default: responseStr = "Unknown"; break;
     }
     Log::info("[ConfirmationDialog] User selected: " + responseStr);
@@ -57,6 +75,13 @@ void ConfirmationDialog::handleResponse(DialogResponse response) {
 }
 
 DialogResponse ConfirmationDialog::responseForFocus(int index) const {
+    if (m_isConfirmMode) {
+        switch (index) {
+            case 0: return DialogResponse::Cancel;
+            case 1: return DialogResponse::Confirm;
+            default: return DialogResponse::Confirm;
+        }
+    }
     switch (index) {
         case 0: return DialogResponse::Cancel;
         case 1: return DialogResponse::DontSave;
@@ -82,19 +107,30 @@ void ConfirmationDialog::calculateLayout() {
     m_dialogRect.width = dialogWidth;
     m_dialogRect.height = dialogHeight;
 
-    // Right-aligned button row, primary (Save) rightmost — modern convention:
-    // [ Cancel ] [ Don't Save ] [ Save ].
+    // Right-aligned button row, primary rightmost — modern convention:
+    // Save flow: [ Cancel ] [ Don't Save ] [ Save ].
+    // Confirm flow: [ Cancel ] [ Confirm ].
     const float cancelWidth = 84.0f;
-    const float dontSaveWidth = 104.0f;
+    const float confirmWidth = 110.0f;
     const float saveWidth = 96.0f;
-    const float totalWidth = cancelWidth + dontSaveWidth + saveWidth + buttonSpacing * 2.0f;
+    const float dontSaveWidth = 104.0f;
+    const float totalWidth = m_isConfirmMode
+        ? cancelWidth + confirmWidth + buttonSpacing
+        : cancelWidth + dontSaveWidth + saveWidth + buttonSpacing * 2.0f;
 
     const float buttonY = m_dialogRect.y + dialogHeight - margin - buttonHeight;
     const float startX = m_dialogRect.right() - margin - totalWidth;
 
     m_cancelButtonRect = {startX, buttonY, cancelWidth, buttonHeight};
-    m_dontSaveButtonRect = {m_cancelButtonRect.right() + buttonSpacing, buttonY, dontSaveWidth, buttonHeight};
-    m_saveButtonRect = {m_dontSaveButtonRect.right() + buttonSpacing, buttonY, saveWidth, buttonHeight};
+    if (m_isConfirmMode) {
+        // The Don't Save slot does not exist in confirm mode; keep it empty so
+        // no stale rect aliases a live button.
+        m_dontSaveButtonRect = AestraUI::NUIRect{};
+        m_saveButtonRect = {m_cancelButtonRect.right() + buttonSpacing, buttonY, confirmWidth, buttonHeight};
+    } else {
+        m_dontSaveButtonRect = {m_cancelButtonRect.right() + buttonSpacing, buttonY, dontSaveWidth, buttonHeight};
+        m_saveButtonRect = {m_dontSaveButtonRect.right() + buttonSpacing, buttonY, saveWidth, buttonHeight};
+    }
 }
 
 void ConfirmationDialog::onRender(AestraUI::NUIRenderer& renderer) {
@@ -145,24 +181,34 @@ void ConfirmationDialog::onRender(AestraUI::NUIRenderer& renderer) {
     renderer.drawTextCentered("Cancel", m_cancelButtonRect, theme.fontSizeM,
                               m_cancelHovered ? theme.textPrimary : theme.textSecondary);
 
-    // Don't Save: subtle filled + border.
-    const bool dontSavePressed = m_pressedButton == DialogResponse::DontSave;
-    renderer.fillRoundedRect(m_dontSaveButtonRect, theme.radiusM,
-                             dontSavePressed ? theme.pressed
-                                             : (m_dontSaveHovered ? theme.hover : theme.buttonBgDefault));
-    renderer.strokeRoundedRect(m_dontSaveButtonRect, theme.radiusM, theme.layout.dividerWidth,
-                               theme.borderStrong);
-    renderer.drawTextCentered("Don't Save", m_dontSaveButtonRect, theme.fontSizeM, theme.error);
+    if (m_isConfirmMode) {
+        // Confirm: primary fill, mirrors the Save slot.
+        const bool confirmPressed = m_pressedButton == DialogResponse::Confirm;
+        renderer.fillRoundedRect(m_saveButtonRect, theme.radiusM,
+                                 confirmPressed ? theme.primaryPressed
+                                                : (m_saveHovered ? theme.primaryHover : theme.primary));
+        renderer.drawTextCentered(m_confirmLabel, m_saveButtonRect, theme.fontSizeM, theme.textOnPrimary);
+    } else {
+        // Don't Save: subtle filled + border.
+        const bool dontSavePressed = m_pressedButton == DialogResponse::DontSave;
+        renderer.fillRoundedRect(m_dontSaveButtonRect, theme.radiusM,
+                                 dontSavePressed ? theme.pressed
+                                                 : (m_dontSaveHovered ? theme.hover : theme.buttonBgDefault));
+        renderer.strokeRoundedRect(m_dontSaveButtonRect, theme.radiusM, theme.layout.dividerWidth,
+                                   theme.borderStrong);
+        renderer.drawTextCentered("Don't Save", m_dontSaveButtonRect, theme.fontSizeM, theme.error);
 
-    const bool savePressed = m_pressedButton == DialogResponse::Save;
-    renderer.fillRoundedRect(m_saveButtonRect, theme.radiusM,
-                             savePressed ? theme.primaryPressed : (m_saveHovered ? theme.primaryHover : theme.primary));
-    renderer.drawTextCentered("Save", m_saveButtonRect, theme.fontSizeM, theme.textOnPrimary);
+        const bool savePressed = m_pressedButton == DialogResponse::Save;
+        renderer.fillRoundedRect(m_saveButtonRect, theme.radiusM,
+                                 savePressed ? theme.primaryPressed : (m_saveHovered ? theme.primaryHover : theme.primary));
+        renderer.drawTextCentered("Save", m_saveButtonRect, theme.fontSizeM, theme.textOnPrimary);
+    }
 
     // Keyboard focus highlight: a faint accent ring around the focused button
     // (Left/Right move it, Enter activates it).
-    const AestraUI::NUIRect focusRect =
-        (m_focusIndex == 0) ? m_cancelButtonRect : (m_focusIndex == 1) ? m_dontSaveButtonRect : m_saveButtonRect;
+    const AestraUI::NUIRect focusRect = m_isConfirmMode
+        ? (m_focusIndex == 0 ? m_cancelButtonRect : m_saveButtonRect)
+        : (m_focusIndex == 0) ? m_cancelButtonRect : (m_focusIndex == 1) ? m_dontSaveButtonRect : m_saveButtonRect;
     AestraUI::NUIRect ring = focusRect;
     ring.x -= 2.0f;
     ring.y -= 2.0f;
@@ -182,10 +228,13 @@ bool ConfirmationDialog::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     float mouseY = event.position.y;
     
     // Update hover states; hovering also moves keyboard focus so the two stay in sync.
-    m_saveHovered = m_saveButtonRect.contains(mouseX, mouseY);
-    m_dontSaveHovered = m_dontSaveButtonRect.contains(mouseX, mouseY);
     m_cancelHovered = m_cancelButtonRect.contains(mouseX, mouseY);
-    if (m_cancelHovered) m_focusIndex = 0;
+    m_dontSaveHovered = !m_isConfirmMode && m_dontSaveButtonRect.contains(mouseX, mouseY);
+    m_saveHovered = m_saveButtonRect.contains(mouseX, mouseY);
+    if (m_isConfirmMode) {
+        if (m_cancelHovered) m_focusIndex = 0;
+        else if (m_saveHovered) m_focusIndex = 1;
+    } else if (m_cancelHovered) m_focusIndex = 0;
     else if (m_dontSaveHovered) m_focusIndex = 1;
     else if (m_saveHovered) m_focusIndex = 2;
 
@@ -195,7 +244,7 @@ bool ConfirmationDialog::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     // reached whatever was underneath).
     if (event.button == AestraUI::NUIMouseButton::Left) {
         if (event.pressed) {
-            if (m_saveHovered) m_pressedButton = DialogResponse::Save;
+            if (m_saveHovered) m_pressedButton = m_isConfirmMode ? DialogResponse::Confirm : DialogResponse::Save;
             else if (m_dontSaveHovered) m_pressedButton = DialogResponse::DontSave;
             else if (m_cancelHovered) m_pressedButton = DialogResponse::Cancel;
             else if (!m_dialogRect.contains(mouseX, mouseY)) m_pressedButton = DialogResponse::Cancel; // click-outside
@@ -206,11 +255,14 @@ bool ConfirmationDialog::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             const DialogResponse armed = m_pressedButton;
             m_pressedButton = DialogResponse::None;
             // Only fire if the release lands on the same button that was pressed.
-            const bool overArmed =
-                (armed == DialogResponse::Save && m_saveHovered) ||
-                (armed == DialogResponse::DontSave && m_dontSaveHovered) ||
-                (armed == DialogResponse::Cancel &&
-                 (m_cancelHovered || !m_dialogRect.contains(mouseX, mouseY)));
+            const bool overArmed = m_isConfirmMode
+                ? (armed == DialogResponse::Confirm && m_saveHovered) ||
+                      (armed == DialogResponse::Cancel &&
+                       (m_cancelHovered || !m_dialogRect.contains(mouseX, mouseY)))
+                : (armed == DialogResponse::Save && m_saveHovered) ||
+                      (armed == DialogResponse::DontSave && m_dontSaveHovered) ||
+                      (armed == DialogResponse::Cancel &&
+                       (m_cancelHovered || !m_dialogRect.contains(mouseX, mouseY)));
             if (armed != DialogResponse::None && overArmed) {
                 handleResponse(armed);
             }
@@ -236,11 +288,13 @@ bool ConfirmationDialog::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
 
         // Left/Right move the focus highlight across the button row.
         if (event.keyCode == AestraUI::NUIKeyCode::Left) {
-            m_focusIndex = (m_focusIndex + 2) % 3; // wrap left
+            const int buttonCount = m_isConfirmMode ? 2 : 3;
+            m_focusIndex = (m_focusIndex - 1 + buttonCount) % buttonCount; // wrap left
             return true;
         }
         if (event.keyCode == AestraUI::NUIKeyCode::Right) {
-            m_focusIndex = (m_focusIndex + 1) % 3; // wrap right
+            const int buttonCount = m_isConfirmMode ? 2 : 3;
+            m_focusIndex = (m_focusIndex + 1) % buttonCount; // wrap right
             return true;
         }
 

--- a/Source/Settings/ConfirmationDialog.h
+++ b/Source/Settings/ConfirmationDialog.h
@@ -15,7 +15,8 @@ enum class DialogResponse {
     None,       // Dialog not yet answered
     Save,       // User chose to save
     DontSave,   // User chose to discard changes
-    Cancel      // User cancelled the action
+    Cancel,     // User cancelled the action
+    Confirm     // User confirmed a generic destructive action
 };
 
 /**
@@ -45,6 +46,16 @@ public:
      * @param callback Function called with user's response
      */
     void show(const std::string& title, const std::string& message, ResponseCallback callback);
+
+    /**
+     * @brief Show a generic two-button confirm dialog
+     * @param title Dialog title (e.g., "Delete Lane")
+     * @param message Dialog message (e.g., "This lane still contains 3 clips...")
+     * @param confirmLabel Label of the primary action button (e.g., "Delete Lane")
+     * @param callback Function called with user's response (Confirm or Cancel)
+     */
+    void showConfirm(const std::string& title, const std::string& message, const std::string& confirmLabel,
+                     ResponseCallback callback);
     
     /**
      * @brief Hide the dialog
@@ -67,6 +78,8 @@ private:
     ResponseCallback m_callback;
     DialogResponse m_response;
     bool m_isVisible;
+    bool m_isConfirmMode{false};
+    std::string m_confirmLabel{"Delete"};
     
     // Button hover states
     bool m_saveHovered;

--- a/Tests/AestraAudio/ClipMovementContractTest.cpp
+++ b/Tests/AestraAudio/ClipMovementContractTest.cpp
@@ -1,0 +1,143 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// Clip Movement Contract (vault: Track Lane Channel Ownership Contract §23,
+// freeze 2026-08-18 @ 30d28e4).
+//
+// A lane is not an owner of a clip; the track is the placement owner. Moving
+// a clip between lanes of the same track, or between tracks, NEVER changes
+// the clip's identity — id, pattern, and metadata survive; the placement
+// track derives from the destination lane. Lane-attached automation curves
+// are de-facto track-scoped (§23.3) and must not transfer, copy, or clone
+// when clips move.
+
+#include "Commands/CreateLaneCommand.h"
+#include "Commands/MoveClipCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+using namespace Aestra::Audio;
+
+ClipInstance makeClip() {
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.name = "Contract clip";
+    clip.startBeat = 0.0;
+    clip.durationBeats = 4.0;
+    return clip;
+}
+
+} // namespace
+
+int main() {
+    // --- cross-track move: identity stable, placement track changes --------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        auto t1PrimaryCmd = std::make_shared<CreateLaneCommand>(playlist, "Track 1");
+        t1PrimaryCmd->execute();
+        const PlaylistLaneID t1Primary = t1PrimaryCmd->getLaneId();
+        const uint64_t track1 = tracks.createTrack(t1Primary, "Track 1");
+
+        auto t1TakeCmd = std::make_shared<CreateLaneCommand>(playlist, "Take 1");
+        t1TakeCmd->execute();
+        const PlaylistLaneID t1Take = t1TakeCmd->getLaneId();
+        require(tracks.attachLaneToTrack(track1, t1Take), "Take lane did not attach");
+
+        auto t2PrimaryCmd = std::make_shared<CreateLaneCommand>(playlist, "Track 2");
+        t2PrimaryCmd->execute();
+        const PlaylistLaneID t2Primary = t2PrimaryCmd->getLaneId();
+        const uint64_t track2 = tracks.createTrack(t2Primary, "Track 2");
+
+        // Lane-attached automation bag, de-facto track-scoped (§23.3): must
+        // not follow the clip.
+        auto* takeLane = playlist.getLane(t1Take);
+        takeLane->automationCurves.emplace_back("Take gain", AutomationTarget::Custom);
+        const size_t curvesBefore = takeLane->automationCurves.size();
+
+        const ClipInstance clip = makeClip();
+        require(playlist.addClip(t1Take, clip).isValid(), "Clip was not placed on the take lane");
+
+        // Track 1 / Lane take -> Track 2 / Lane primary.
+        playlist.moveClip(clip.id, 8.0, t2Primary);
+
+        const ClipInstance* moved = playlist.getClip(clip.id);
+        require(moved != nullptr, "Cross-track move destroyed the clip identity");
+        require(moved->id == clip.id, "Cross-track move changed the clip id");
+        require(moved->startBeat == 8.0, "Cross-track move lost the arrangement position");
+        require(playlist.findClipLane(clip.id) == t2Primary, "Clip landed on the wrong lane");
+        const auto* destLane = playlist.getLane(t2Primary);
+        require(destLane && destLane->trackId == track2, "Placement track is not the destination track");
+        require(playlist.getLane(t1Take)->clips.empty(), "Clip still present in the source lane");
+        takeLane = playlist.getLane(t1Take);
+        require(takeLane->automationCurves.size() == curvesBefore, "Automation moved with the clip");
+
+        // Undo of the cross-track move restores the original placement.
+        auto moveCmd =
+            std::make_shared<MoveClipCommand>(playlist, clip.id, 0.0, t1Take, 8.0, t2Primary);
+        history.pushAndExecute(moveCmd);
+        require(history.undo(), "Undo of the cross-track move failed");
+        require(playlist.findClipLane(clip.id) == t1Take, "Undo did not restore the source lane");
+        require(playlist.getClip(clip.id)->startBeat == 0.0, "Undo did not restore the source position");
+        require(playlist.getClip(clip.id)->id == clip.id, "Undo changed the clip id");
+    }
+
+    // --- same-track lane move: identity stable, automation untouched -------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        auto primaryCmd = std::make_shared<CreateLaneCommand>(playlist, "Track 1");
+        primaryCmd->execute();
+        const PlaylistLaneID primary = primaryCmd->getLaneId();
+        const uint64_t track1 = tracks.createTrack(primary, "Track 1");
+
+        auto takeCmd = std::make_shared<CreateLaneCommand>(playlist, "Take 1");
+        takeCmd->execute();
+        const PlaylistLaneID take = takeCmd->getLaneId();
+        require(tracks.attachLaneToTrack(track1, take), "Take lane did not attach");
+
+        auto* takeLane = playlist.getLane(take);
+        takeLane->automationCurves.emplace_back();
+        const size_t curvesBefore = takeLane->automationCurves.size();
+
+        const ClipInstance clip = makeClip();
+        require(playlist.addClip(take, clip).isValid(), "Clip was not placed on the take lane");
+
+        // Same track: take lane -> primary lane.
+        playlist.moveClip(clip.id, 2.0, primary);
+
+        const ClipInstance* moved = playlist.getClip(clip.id);
+        require(moved != nullptr && moved->id == clip.id, "Same-track move changed the clip identity");
+        require(playlist.findClipLane(clip.id) == primary, "Same-track move landed on the wrong lane");
+        require(playlist.getLane(primary)->trackId == track1, "Placement track changed on a same-track move");
+        takeLane = playlist.getLane(take);
+        require(takeLane->automationCurves.size() == curvesBefore, "Automation moved with the clip");
+        require(takeLane->clips.empty(), "Clip still present in the source lane");
+
+        auto moveCmd = std::make_shared<MoveClipCommand>(playlist, clip.id, 0.0, take, 2.0, primary);
+        history.pushAndExecute(moveCmd);
+        require(history.undo(), "Undo of the same-track move failed");
+        require(playlist.findClipLane(clip.id) == take, "Undo did not restore the take lane");
+        require(playlist.getLane(take)->clips.size() == 1, "Undo did not restore the clip");
+    }
+
+    std::cout << "[PASS] ClipMovementContractTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/ClipMovementContractTest.cpp
+++ b/Tests/AestraAudio/ClipMovementContractTest.cpp
@@ -66,6 +66,7 @@ int main() {
         // Lane-attached automation bag, de-facto track-scoped (§23.3): must
         // not follow the clip.
         auto* takeLane = playlist.getLane(t1Take);
+        require(takeLane != nullptr, "Take lane is missing from the playlist");
         takeLane->automationCurves.emplace_back("Take gain", AutomationTarget::Custom);
         const size_t curvesBefore = takeLane->automationCurves.size();
 
@@ -82,8 +83,11 @@ int main() {
         require(playlist.findClipLane(clip.id) == t2Primary, "Clip landed on the wrong lane");
         const auto* destLane = playlist.getLane(t2Primary);
         require(destLane && destLane->trackId == track2, "Placement track is not the destination track");
-        require(playlist.getLane(t1Take)->clips.empty(), "Clip still present in the source lane");
+        const auto* sourceLane = playlist.getLane(t1Take);
+        require(sourceLane != nullptr, "Source lane vanished after the move");
+        require(sourceLane->clips.empty(), "Clip still present in the source lane");
         takeLane = playlist.getLane(t1Take);
+        require(takeLane != nullptr, "Take lane missing after the move");
         require(takeLane->automationCurves.size() == curvesBefore, "Automation moved with the clip");
 
         // Undo of the cross-track move restores the original placement.
@@ -92,8 +96,10 @@ int main() {
         history.pushAndExecute(moveCmd);
         require(history.undo(), "Undo of the cross-track move failed");
         require(playlist.findClipLane(clip.id) == t1Take, "Undo did not restore the source lane");
-        require(playlist.getClip(clip.id)->startBeat == 0.0, "Undo did not restore the source position");
-        require(playlist.getClip(clip.id)->id == clip.id, "Undo changed the clip id");
+        const ClipInstance* undone = playlist.getClip(clip.id);
+        require(undone != nullptr, "Clip missing after undo of the move");
+        require(undone->startBeat == 0.0, "Undo did not restore the source position");
+        require(undone->id == clip.id, "Undo changed the clip id");
     }
 
     // --- same-track lane move: identity stable, automation untouched -------
@@ -114,6 +120,7 @@ int main() {
         require(tracks.attachLaneToTrack(track1, take), "Take lane did not attach");
 
         auto* takeLane = playlist.getLane(take);
+        require(takeLane != nullptr, "Take lane is missing from the playlist");
         takeLane->automationCurves.emplace_back();
         const size_t curvesBefore = takeLane->automationCurves.size();
 
@@ -126,8 +133,11 @@ int main() {
         const ClipInstance* moved = playlist.getClip(clip.id);
         require(moved != nullptr && moved->id == clip.id, "Same-track move changed the clip identity");
         require(playlist.findClipLane(clip.id) == primary, "Same-track move landed on the wrong lane");
-        require(playlist.getLane(primary)->trackId == track1, "Placement track changed on a same-track move");
+        const auto* primaryLane = playlist.getLane(primary);
+        require(primaryLane != nullptr, "Primary lane missing after the move");
+        require(primaryLane->trackId == track1, "Placement track changed on a same-track move");
         takeLane = playlist.getLane(take);
+        require(takeLane != nullptr, "Take lane missing after the move");
         require(takeLane->automationCurves.size() == curvesBefore, "Automation moved with the clip");
         require(takeLane->clips.empty(), "Clip still present in the source lane");
 
@@ -135,7 +145,9 @@ int main() {
         history.pushAndExecute(moveCmd);
         require(history.undo(), "Undo of the same-track move failed");
         require(playlist.findClipLane(clip.id) == take, "Undo did not restore the take lane");
-        require(playlist.getLane(take)->clips.size() == 1, "Undo did not restore the clip");
+        const auto* restoredLane = playlist.getLane(take);
+        require(restoredLane != nullptr, "Take lane missing after undo");
+        require(restoredLane->clips.size() == 1, "Undo did not restore the clip");
     }
 
     std::cout << "[PASS] ClipMovementContractTest\n";

--- a/Tests/AestraAudio/DeleteLaneCommandTest.cpp
+++ b/Tests/AestraAudio/DeleteLaneCommandTest.cpp
@@ -75,6 +75,7 @@ int main() {
         require(playlist.getLaneId(0) == primaryId && playlist.getLaneId(1) == takeId &&
                     playlist.getLaneId(2) == take3Id && playlist.getLaneId(3) == tailId,
                 "Fixture playlist order is wrong");
+        tracks.getTrack(trackId)->activeLaneId = takeId;
 
         history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, takeId));
         require(playlist.getLane(takeId) == nullptr, "Take lane still present after delete");
@@ -83,6 +84,8 @@ int main() {
         require(track && track->laneIds.size() == 2 && track->laneIds[0] == primaryId &&
                     track->laneIds[1] == take3Id,
                 "Lane was not detached from the track");
+        require(track && track->activeLaneId == take3Id,
+                "Active lane did not fall back to the remaining lane after delete");
 
         require(history.undo(), "Undo of the lane delete failed");
         const PlaylistLane* restored = playlist.getLane(takeId);
@@ -99,6 +102,8 @@ int main() {
         require(playlist.getLaneId(0) == primaryId && playlist.getLaneId(1) == takeId &&
                     playlist.getLaneId(2) == take3Id && playlist.getLaneId(3) == tailId,
                 "Undo did not restore the lane's playlist position");
+        require(trackAfterUndo && trackAfterUndo->activeLaneId == takeId,
+                "Undo did not restore the active lane");
 
         require(history.redo(), "Redo of the lane delete failed");
         require(playlist.getLane(takeId) == nullptr, "Redo did not remove the lane again");
@@ -142,6 +147,35 @@ int main() {
         history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, PlaylistLaneID::generate()));
         require(playlist.getLaneCount() == lanesBefore, "A no-op delete changed the playlist");
         require(history.undo(), "Undo of a no-op delete must succeed cleanly");
+        require(playlist.getLaneCount() == lanesBefore, "Undo of a no-op delete changed the playlist");
+    }
+
+    // --- deleting a track's only lane is a no-op (command-layer policy) -------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        auto primaryCmd = std::make_shared<CreateLaneCommand>(playlist, "Track 1");
+        primaryCmd->execute();
+        const PlaylistLaneID primaryId = primaryCmd->getLaneId();
+        const uint64_t trackId = tracks.createTrack(primaryId, "Track 1");
+        const size_t lanesBefore = playlist.getLaneCount();
+
+        // The UI blocks the last lane via the context menu; the command layer
+        // enforces the same invariant so delete_lane can't strand a track with
+        // zero owned lanes (Track::laneIds/activeLaneId stay valid).
+        history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, primaryId));
+        require(playlist.getLane(primaryId) != nullptr, "A track's only lane was deleted");
+        const Track* track = tracks.getTrack(trackId);
+        require(track && track->laneIds.size() == 1 && track->laneIds[0] == primaryId,
+                "Track laneIds changed after a no-op delete");
+        require(track && track->activeLaneId == primaryId, "Active lane changed after a no-op delete");
+        require(playlist.getLaneCount() == lanesBefore, "No-op delete changed the playlist");
+
+        require(history.undo(), "Undo after a no-op delete must succeed cleanly");
+        require(playlist.getLane(primaryId) != nullptr, "Undo removed the lane after a no-op delete");
         require(playlist.getLaneCount() == lanesBefore, "Undo of a no-op delete changed the playlist");
     }
 

--- a/Tests/AestraAudio/DeleteLaneCommandTest.cpp
+++ b/Tests/AestraAudio/DeleteLaneCommandTest.cpp
@@ -1,0 +1,150 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// FD-14 phase-5: deleting a take lane is undoable and identity-stable.
+//
+// Take lanes accumulate (one per take) and the UI exposes "Delete Lane" from
+// the track context menu. The command must detach the lane from its owning
+// Track, remove the lane AND its clips, and — on undo — restore the lane with
+// its ORIGINAL id, clips, and ownership so nothing silently renumbers.
+
+#include "Commands/DeleteLaneCommand.h"
+#include "Commands/CreateLaneCommand.h"
+#include "Models/TrackManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+using namespace Aestra::Audio;
+
+ClipInstance makeClip() {
+    ClipInstance clip;
+    clip.id = ClipInstanceID::generate();
+    clip.name = "Take clip";
+    clip.startBeat = 4.0;
+    clip.durationBeats = 4.0;
+    return clip;
+}
+
+} // namespace
+
+int main() {
+    // --- deleting an owned take lane detaches, removes, restores on undo ------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        auto primaryCmd = std::make_shared<CreateLaneCommand>(playlist, "Track 1");
+        primaryCmd->execute();
+        const PlaylistLaneID primaryId = primaryCmd->getLaneId();
+        const uint64_t trackId = tracks.createTrack(primaryId, "Track 1");
+
+        auto takeCmd = std::make_shared<CreateLaneCommand>(playlist, "Take 1");
+        takeCmd->execute();
+        const PlaylistLaneID takeId = takeCmd->getLaneId();
+        require(tracks.attachLaneToTrack(trackId, takeId), "Take lane did not attach");
+
+        // A second take AFTER the deleted one, so laneIds order can prove the
+        // restored lane lands back in the middle — not appended at the end.
+        auto take3Cmd = std::make_shared<CreateLaneCommand>(playlist, "Take 3");
+        take3Cmd->execute();
+        const PlaylistLaneID take3Id = take3Cmd->getLaneId();
+        require(tracks.attachLaneToTrack(trackId, take3Id), "Third lane did not attach");
+
+        // An unowned lane AFTER everything, so playlist order can prove the
+        // restored lane returns to its original row — not the bottom.
+        auto tailCmd = std::make_shared<CreateLaneCommand>(playlist, "Orphan Tail");
+        tailCmd->execute();
+        const PlaylistLaneID tailId = tailCmd->getLaneId();
+
+        const ClipInstance clip = makeClip();
+        require(playlist.addClip(takeId, clip).isValid(), "Clip was not placed on the take lane");
+
+        // Playlist order: [primary, take, take3, tail]. laneIds: [primary, take, take3].
+        require(playlist.getLaneId(0) == primaryId && playlist.getLaneId(1) == takeId &&
+                    playlist.getLaneId(2) == take3Id && playlist.getLaneId(3) == tailId,
+                "Fixture playlist order is wrong");
+
+        history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, takeId));
+        require(playlist.getLane(takeId) == nullptr, "Take lane still present after delete");
+        require(playlist.getClip(clip.id) == nullptr, "Take clip still present after delete");
+        const Track* track = tracks.getTrack(trackId);
+        require(track && track->laneIds.size() == 2 && track->laneIds[0] == primaryId &&
+                    track->laneIds[1] == take3Id,
+                "Lane was not detached from the track");
+
+        require(history.undo(), "Undo of the lane delete failed");
+        const PlaylistLane* restored = playlist.getLane(takeId);
+        require(restored != nullptr, "Undo did not restore the take lane");
+        require(restored->id == takeId, "Undo did not restore the lane's original id");
+        require(restored->trackId == trackId, "Undo did not restore lane ownership");
+        require(restored->clips.size() == 1 && restored->clips[0].id == clip.id,
+                "Undo did not restore the take clip");
+        const Track* trackAfterUndo = tracks.getTrack(trackId);
+        require(trackAfterUndo && trackAfterUndo->laneIds.size() == 3 &&
+                    trackAfterUndo->laneIds[0] == primaryId && trackAfterUndo->laneIds[1] == takeId &&
+                    trackAfterUndo->laneIds[2] == take3Id,
+                "Undo did not restore the lane's position within the track");
+        require(playlist.getLaneId(0) == primaryId && playlist.getLaneId(1) == takeId &&
+                    playlist.getLaneId(2) == take3Id && playlist.getLaneId(3) == tailId,
+                "Undo did not restore the lane's playlist position");
+
+        require(history.redo(), "Redo of the lane delete failed");
+        require(playlist.getLane(takeId) == nullptr, "Redo did not remove the lane again");
+        require(playlist.getClip(clip.id) == nullptr, "Redo did not remove the clip again");
+    }
+
+    // --- deleting an unowned lane removes it outright, undo restores it -------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        auto laneCmd = std::make_shared<CreateLaneCommand>(playlist, "Orphan");
+        laneCmd->execute();
+        const PlaylistLaneID laneId = laneCmd->getLaneId();
+
+        const ClipInstance clip = makeClip();
+        require(playlist.addClip(laneId, clip).isValid(), "Clip was not placed on the orphan lane");
+
+        history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, laneId));
+        require(playlist.getLane(laneId) == nullptr, "Orphan lane still present after delete");
+
+        require(history.undo(), "Undo of the orphan delete failed");
+        const PlaylistLane* restored = playlist.getLane(laneId);
+        require(restored != nullptr, "Undo did not restore the orphan lane");
+        require(restored->id == laneId, "Undo did not restore the orphan lane's id");
+        require(restored->trackId == 0, "Undo re-attached the orphan lane to a track");
+        require(restored->clips.size() == 1 && restored->clips[0].id == clip.id,
+                "Undo did not restore the orphan clip");
+    }
+
+    // --- deleting an unknown lane is a safe no-op -----------------------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        const size_t lanesBefore = playlist.getLaneCount();
+        history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, PlaylistLaneID::generate()));
+        require(playlist.getLaneCount() == lanesBefore, "A no-op delete changed the playlist");
+        require(history.undo(), "Undo of a no-op delete must succeed cleanly");
+        require(playlist.getLaneCount() == lanesBefore, "Undo of a no-op delete changed the playlist");
+    }
+
+    std::cout << "[PASS] DeleteLaneCommandTest\n";
+    return 0;
+}

--- a/Tests/AestraAudio/DropTransactionTest.cpp
+++ b/Tests/AestraAudio/DropTransactionTest.cpp
@@ -20,6 +20,7 @@
 #include "Commands/AddClipCommand.h"
 #include "Commands/CommandTransaction.h"
 #include "Commands/CreateLaneCommand.h"
+#include "Commands/CreateTrackWithLaneCommand.h"
 #include "Models/TrackManager.h"
 
 #include <cstdlib>
@@ -126,9 +127,11 @@ int main() {
 
         const size_t lanesBefore = playlist.getLaneCount();
 
-        auto laneCommand = std::make_shared<CreateLaneCommand>(playlist, "Lane 1");
+        auto laneCommand = std::make_shared<CreateTrackWithLaneCommand>(tracks, "Lane 1");
         laneCommand->execute();
+        const uint64_t trackId = laneCommand->getTrackId();
         require(playlist.getLaneCount() == lanesBefore + 1, "Lane command did not append a lane");
+        require(tracks.getTrack(trackId) != nullptr, "Lane command did not create its track");
 
         // The clip cannot be placed — this stands in for a pattern that could not be
         // resolved or a source that decoded to nothing. onDrop rolls the lane back
@@ -141,7 +144,59 @@ int main() {
         laneCommand->undo();
 
         require(playlist.getLaneCount() == lanesBefore, "A failed drop left its appended lane behind");
+        require(tracks.getTrack(trackId) == nullptr, "A failed drop left its Track behind");
         require(!history.canUndo(), "A failed drop was recorded in the undo history");
+    }
+
+    // --- a drop-appended lane owns a Track; undo removes both -------------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        const size_t lanesBefore = playlist.getLaneCount();
+
+        // What onDrop does since the FD-14 pairing: one command creates the lane
+        // AND its owning Track, so neither a failed import nor an undo can strand
+        // an orphaned Track with zero lanes.
+        auto laneCommand = std::make_shared<CreateTrackWithLaneCommand>(tracks, "Dropped");
+        laneCommand->execute();
+        const PlaylistLaneID laneId = laneCommand->getLaneId();
+        const uint64_t trackId = laneCommand->getTrackId();
+        require(laneId.isValid() && trackId != 0, "Track+Lane command did not create both");
+
+        const Track* track = tracks.getTrack(trackId);
+        require(track && track->laneIds.size() == 1 && track->laneIds[0] == laneId,
+                "Track does not own its created lane");
+        const PlaylistLane* lane = playlist.getLane(laneId);
+        require(lane && lane->trackId == trackId, "Lane does not point at its owning track");
+
+        const ClipInstance clip = makeClip();
+        auto clipCommand = std::make_shared<AddClipCommand>(playlist, laneId, clip);
+        clipCommand->execute();
+
+        auto transaction = std::make_shared<CommandTransaction>("Import Audio Clip");
+        transaction->add(laneCommand);
+        transaction->add(clipCommand);
+        transaction->markExecuted();
+        require(history.pushExecuted(transaction), "The drop transaction was refused by the history");
+
+        // One Ctrl+Z removes clip, lane, AND track — no orphaned Track.
+        require(history.undo(), "Undo of the drop transaction failed");
+        require(playlist.getClip(clip.id) == nullptr, "Undo left the dropped clip behind");
+        require(playlist.getLane(laneId) == nullptr, "Undo left the appended lane behind");
+        require(tracks.getTrack(trackId) == nullptr, "Undo left an orphaned Track behind");
+        require(playlist.getLaneCount() == lanesBefore, "Undo did not restore the playlist");
+
+        // Redo restores the lane's ORIGINAL identity (the clip command still holds
+        // that id) and mints a fresh track.
+        require(history.redo(), "Redo of the drop transaction failed");
+        require(playlist.getLane(laneId) != nullptr, "Redo did not restore the lane's identity");
+        require(playlist.getClip(clip.id) != nullptr, "Redo lost the dropped clip");
+        require(playlist.findClipLane(clip.id) == laneId, "Redo restored the clip onto the wrong lane");
+        const PlaylistLane* redoneLane = playlist.getLane(laneId);
+        require(redoneLane && redoneLane->trackId != 0, "Redo did not restore lane ownership");
     }
 
     std::cout << "[PASS] DropTransactionTest\n";

--- a/Tests/AestraAudio/RecordingBaselineTest.cpp
+++ b/Tests/AestraAudio/RecordingBaselineTest.cpp
@@ -276,6 +276,44 @@ void testEachTakeCreatesALane() {
     }
 }
 
+/** FD-14 phase-5 (UI notification + nesting): the take-commit path notifies
+ *  the UI layer with the committed lane id so take lane rows become visible
+ *  and reachable without a manual refresh action. */
+void testTakeCommitFiresUiHook() {
+    std::cout << "[A] take commit fires the UI-refresh hook with ownership intact\n";
+    auto tm = makeRecorder();
+    int fireCount = 0;
+    PlaylistLaneID lastTakeLane;
+    tm->setOnTakeCommitted([&](PlaylistLaneID laneId) {
+        ++fireCount;
+        lastTakeLane = laneId;
+    });
+
+    const uint64_t trackId = armTrack(*tm, "Ch 1", 0);
+    check(trackId != 0, "track created and armed");
+    if (trackId == 0) {
+        return;
+    }
+
+    tm->record();
+    recordTake(*tm, 0.5);
+    recordTake(*tm, 0.5);
+
+    check(fireCount == 2, "hook fired once per committed take");
+
+    auto* track = tm->getTrack(trackId);
+    check(track != nullptr, "track still resolvable");
+    if (track) {
+        const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+        check(takeLane.isValid(), "take lane resolved");
+        if (takeLane.isValid()) {
+            auto* lane = tm->getPlaylistModel().getLane(takeLane);
+            check(lane != nullptr && lane->trackId == trackId, "take lane owned by the recording track");
+        }
+        check(lastTakeLane == track->laneIds.back(), "hook delivered the last committed take's lane id");
+    }
+}
+
 // ===========================================================================
 // SECTION B — post-migration acceptance (the Phase 2 RED assertions now hold)
 // ===========================================================================
@@ -534,6 +572,7 @@ int main() {
     testMultipleArmedTracksCaptureIndependently();
     testTwoArmedTracksSharingChannelCaptureIndependently();
     testEachTakeCreatesALane();
+    testTakeCommitFiresUiHook();
 
     std::cout << "Section B: post-migration acceptance\n";
     testRecordingIdentityIsTrackBased();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1362,6 +1362,35 @@ target_include_directories(RecordingBaselineTest PRIVATE
 )
 add_test(NAME RecordingBaselineTest COMMAND RecordingBaselineTest)
 set_tests_properties(RecordingBaselineTest PROPERTIES LABELS "audio;recording;baseline;contract:audio")
+
+# FD-14 phase-5: lane deletion is undoable and identity-stable (DeleteLaneCommand).
+add_executable(DeleteLaneCommandTest
+    AestraAudio/DeleteLaneCommandTest.cpp
+)
+target_link_libraries(DeleteLaneCommandTest PRIVATE AestraAudio)
+target_include_directories(DeleteLaneCommandTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+)
+add_test(NAME DeleteLaneCommandTest COMMAND DeleteLaneCommandTest)
+set_tests_properties(DeleteLaneCommandTest PROPERTIES LABELS "audio;lanes;command;contract:audio")
+
+# Clip Movement Contract (§23, freeze 2026-08-18): cross-track moves keep clip
+# identity; automation bags never follow clips.
+add_executable(ClipMovementContractTest
+    AestraAudio/ClipMovementContractTest.cpp
+)
+target_link_libraries(ClipMovementContractTest PRIVATE AestraAudio)
+target_include_directories(ClipMovementContractTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+)
+add_test(NAME ClipMovementContractTest COMMAND ClipMovementContractTest)
+set_tests_properties(ClipMovementContractTest PROPERTIES LABELS "audio;lanes;movement;contract:audio")
 set_tests_properties(RecordingPathTest PROPERTIES LABELS "audio;recording;headless;contract:application")
 
 


### PR DESCRIPTION
## Summary
Phase-5 of FD-14: lanes live **inside** their track — collapsible, deletable, moveable, with the movement contract frozen at the data-model level.

Two new commits on top of the earlier three:

1. **Lane deletion with position-stable undo** — `DeleteLaneCommand` (registered `delete_lane`): detaches owned take lanes, removes the lane + its clips. Undo restores the lane's **original id, clips, ownership, playlist row, and take order** (`PlaylistModel::moveLaneToIndex`, `TrackManager::moveLaneWithinTrack`). Patterns survive, same policy as Delete Clip.
2. **Clip movement contract (§15, vault `89a00af`)** — cross-track clip movement is identity-stable; automation stays channel/device-oriented and never transfers with clips (`Track Lane Channel Ownership Contract` §15 Automation Boundary: "must not change the identity contract of automation"). Pinned by `ClipMovementContractTest`.
3. **UI hardening pass** (review-driven):
   - Delete Lane asks before removing a lane that still holds clips (`ConfirmationDialog` gains a generic two-button confirm mode; wired app-side, **fail-closed** when no dialog surface exists).
   - Drag/drop/split/audition resolve lanes through the **row widget**, not playlist index; `onDrop` now guards/clamps on display rows — fixes an out-of-bounds when any multi-lane track is collapsed.
   - Track + nested-lane name labels flex to *visible* chrome instead of starving to a 40px floor and ellipsizing with dead space beside them.
   - **CapsLock no longer hijacks wheel scrolling** (timeline + piano roll) — the `NUIPlatformBridge` latch ratchet that stuck horizontal-scroll-on everywhere is replaced with live state sync; Shift+wheel stays horizontal.
   - Launch no longer restores vertical scroll (opens at top); nested rows render chrome-indent + containment tint; lane counter reads what the chevron reveals (`≡ N` = lanes under it, not total); expansion toggle routing fix.

## Why
Phase-5 checklist completion: take lanes accumulated with no escape hatch (delete), cross-track clip movement was broken by the row→playlist index mismatch ("can't move a clip back in"), names ellipsized with room to spare, and the CapsLock latch caused the "wheel only scrolls horizontally" bug the user hit live in-session.

## Testing performed
- `DeleteLaneCommandTest` extended: middle-lane delete undoes to exact original order in both `laneIds` and playlist row order (3-take track + trailing orphan lane fixture); active-lane fallback + restore asserted; last-lane delete is a command-layer no-op.
- `ClipMovementContractTest` (new): cross-track move keeps id/pattern/position; placement track becomes destination; automation bags untouched; undo restores original lane.
- Full `ctest`: **263/263 passed** (1 account E2E skipped, credential-gated).
- Build clean (Release, `-j2`), app relinked.

```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       corrective
```

## Producer note
Take lanes can now be deleted from the track menu — clips and all, with full undo.

## Docs updated?
No. The governing record is Aestra-Internals `Track Lane Channel Ownership Contract` @ `89a00af` — the founder's restored copy (2026-08-17), FD-14 §15 Automation Boundary covers this PR's movement/automation policy. Cited above.

## Risk/rollback notes
- Collapse state remains session-local, not serialized — no project-format change.
- Row reorder is view-only; playlist/model order untouched.
- Undo position restoration is best-effort by design (clamped when the model changed underneath); identity/clips/ownership restoration is exact.
- CapsLock behavior change: plain wheel is vertical again even with CapsLock physically on — intentional (caps is not a scroll modifier).
- Supersedes the closed #814 (callback) and #815 (indicator draw) — folded in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds nested, collapsible take lanes with indentation, lane counts, containment tinting, expansion controls, and row-based interaction handling.
- Adds safe lane deletion with confirmation, final-lane protection, owned-take detachment, and identity-preserving undo/redo.
- Preserves clip identity during cross-track and same-track lane moves while keeping track-scoped automation with its track.
- Makes track-and-lane creation atomic for track creation and drop operations, preventing orphaned tracks during failures or undo.
- Refreshes the track UI immediately after committed takes through `TrackManager::setOnTakeCommitted`.
- Corrects CapsLock and wheel-scroll behavior and improves launch-at-top vertical scrolling.
- Adds confirm-only dialogs and wiring for destructive lane actions.
- Adds coverage for take commits, lane deletion, clip movement, and drop transactions. Reported result: 263/263 tests passed; one credential-gated account E2E test was skipped. Release build completed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->