### PR TITLE
fix: lane index stays positional; automation defaults bind by ownership, not position (FD-14)

### DIFF
--- a/AestraAudio/include/Models/PlaylistModel.h
+++ b/AestraAudio/include/Models/PlaylistModel.h
@@ -858,9 +858,14 @@ public:
         // Remove the lane
         m_lanes.erase(m_lanes.begin() + laneIdx);
 
-        // Rebuild lane map with correct indices
+        // Rebuild lane map with correct indices. PlaylistLane::index is
+        // display metadata consumed by the track-number marker and the
+        // automation-curve default channel pairing; after an erasure it must
+        // stay positional or a later lane reads a stale index (wrong channel,
+        // colliding numbers — #816 follow-up).
         m_laneMap.clear();
         for (size_t i = 0; i < m_lanes.size(); ++i) {
+            m_lanes[i].index = static_cast<int>(i);
             m_laneMap[m_lanes[i].id] = i;
         }
 

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -423,6 +423,20 @@ public:
         return getTrack(lane->trackId);
     }
 
+    /**
+     * @brief Stable routing channel for a lane's automation defaults:
+     * lane → owning Track → track channelId (FD-14 §15 — never by lane
+     * position). Returns 0 when the lane is unowned, its Track is gone, or
+     * the track's channel does not exist; callers fall back to master.
+     */
+    uint32_t resolveLaneChannelId(PlaylistLaneID laneId) {
+        const Track* track = getTrackForLane(laneId);
+        if (!track) {
+            return 0;
+        }
+        return getChannelById(track->channelId) ? track->channelId : 0;
+    }
+
     /** @brief Attach an existing lane to a Track (lane created after the
      *  track, e.g. a recorded take). Returns false when either is invalid. */
     bool attachLaneToTrack(uint64_t trackId, PlaylistLaneID laneId) {

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2125,15 +2125,19 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                     event.pressed && event.button == AestraUI::NUIMouseButton::Left;
                 if (isLeftPress && lane->automationCurves.empty()) {
                     // First point on an empty lane: create the default Volume
-                    // curve bound to this lane's paired mixer channel (the
-                    // same lane-index -> channel pairing the serializer uses).
-                    // defaultValue 1.0 keeps an empty curve neutral — the old
-                    // default of 0.0 silenced the channel until a point was
-                    // added. Press-only: pointer moves (hover) must not
-                    // insert a curve into the project model.
+                    // curve bound to this lane's routing channel. FD-14 §15:
+                    // automation targets must never resolve through lane
+                    // POSITION (getChannel(lane->index)) — they resolve by
+                    // ownership: lane -> owning Track -> track channelId,
+                    // master when the lane is unowned. defaultValue 1.0 keeps
+                    // an empty curve neutral — the old default of 0.0 silenced
+                    // the channel until a point was added. Press-only: pointer
+                    // moves (hover) must not insert a curve into the model.
                     AutomationCurve curve("Volume", AutomationTarget::Volume);
                     curve.setDefaultValue(1.0f);
-                    if (const auto* ch = m_trackManager->getChannel(static_cast<size_t>(lane->index))) {
+                    const uint32_t resolvedId = m_trackManager->resolveLaneChannelId(lane->id);
+                    const uint32_t defaultChannelId = resolvedId != 0 ? resolvedId : MASTER_MIXER_CHANNEL_ID;
+                    if (const auto* ch = m_trackManager->getChannelById(defaultChannelId)) {
                         curve.mixerChannelId = ch->getChannelId();
                     }
                     lane->automationCurves.push_back(std::move(curve));

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -942,8 +942,9 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
             // ownership — the lane's Track, then the track's channel id.
             // Never by lane position: lane order is creation/append order and
             // can diverge from channel order (take lanes, track-first setups).
-            const auto* laneTrack = trackManager->getTrackForLane(laneId);
-            const auto* channel = laneTrack ? trackManager->getChannelById(laneTrack->channelId) : nullptr;
+            const uint32_t resolvedChannelId = trackManager->resolveLaneChannelId(laneId);
+            const auto* channel = resolvedChannelId != 0 ? trackManager->getChannelById(resolvedChannelId)
+                                                         : nullptr;
             if (channel) {
                 // MixerChannel state not covered by PlaylistLane
                 ljs.set("mixerChannelId", JSON(static_cast<double>(channel->getChannelId())));

--- a/Tests/AestraAudio/DeleteLaneCommandTest.cpp
+++ b/Tests/AestraAudio/DeleteLaneCommandTest.cpp
@@ -179,6 +179,52 @@ int main() {
         require(playlist.getLaneCount() == lanesBefore, "Undo of a no-op delete changed the playlist");
     }
 
+    // --- lane display indices stay positional across delete/create -------------
+    {
+        auto tracksOwner = std::make_unique<TrackManager>();
+        auto& tracks = *tracksOwner;
+        auto& playlist = tracks.getPlaylistModel();
+        auto& history = tracks.getCommandHistory();
+
+        // Three lanes, indices 0/1/2.
+        auto mk = [&](const std::string& name) {
+            auto cmd = std::make_shared<CreateLaneCommand>(playlist, name);
+            cmd->execute();
+            return cmd->getLaneId();
+        };
+        const PlaylistLaneID l0 = mk("Track 1");
+        const PlaylistLaneID l1 = mk("Take 2");
+        const PlaylistLaneID l2 = mk("Take 3");
+        require(playlist.getLane(l0)->index == 0 && playlist.getLane(l1)->index == 1 &&
+                    playlist.getLane(l2)->index == 2,
+                "Fixture lane indices are wrong");
+
+        // Deleting the first lane must shift the survivors' indices: the UI
+        // reads lane->index for the track number marker and for the automation
+        // curve's default channel pairing — a stale index pairs a lane with
+        // the wrong mixer channel.
+        history.pushAndExecute(std::make_shared<DeleteLaneCommand>(tracks, l0));
+        require(playlist.getLane(l1)->index == 0 && playlist.getLane(l2)->index == 1,
+                "Surviving lanes kept stale indices after a delete");
+
+        // A new lane gets index == size; with reindexing it can no longer
+        // collide with a survivor's stale index (two lanes, one channel).
+        const PlaylistLaneID l3 = mk("Take 4");
+        require(playlist.getLane(l3)->index == 2 && playlist.getLane(l2)->index == 1,
+                "New lane collided with a survivor's stale index");
+
+        // Undo restores the deleted lane to its original row; indices follow.
+        require(history.undo(), "Undo of the delete failed");
+        require(playlist.getLane(l0)->index == 0 && playlist.getLane(l1)->index == 1 &&
+                    playlist.getLane(l2)->index == 2 && playlist.getLane(l3)->index == 3,
+                "Indices are wrong after undo");
+
+        require(history.redo(), "Redo of the delete failed");
+        require(playlist.getLane(l1)->index == 0 && playlist.getLane(l2)->index == 1 &&
+                    playlist.getLane(l3)->index == 2,
+                "Indices are wrong after redo");
+    }
+
     std::cout << "[PASS] DeleteLaneCommandTest\n";
     return 0;
 }

--- a/Tests/AestraAudio/TrackOwnershipTest.cpp
+++ b/Tests/AestraAudio/TrackOwnershipTest.cpp
@@ -224,6 +224,14 @@ void testResolveLaneChannelId() {
     check(trackId != 0, "track created routing to channel 7");
     check(tm.resolveLaneChannelId(laneId) == 7, "owned lane resolves through track channelId — not position");
 
+    // Track exists but its channelId does not resolve to a MixerChannel:
+    // the resolver must return 0, never hand a dead id to the caller as if
+    // it were live (branch shared with the serializer's channel state save).
+    PlaylistLaneID deadLaneId = tm.getPlaylistModel().createLane("Lane 2");
+    uint64_t deadTrackId = tm.createTrack(deadLaneId, "Track 2", 99);
+    check(deadTrackId != 0, "track with nonexistent channel created");
+    check(tm.resolveLaneChannelId(deadLaneId) == 0, "track with dead channel resolves to 0");
+
     tm.removeTrack(trackId);
     check(tm.resolveLaneChannelId(laneId) == 0, "lane outliving its removed track resolves to 0");
 

--- a/Tests/AestraAudio/TrackOwnershipTest.cpp
+++ b/Tests/AestraAudio/TrackOwnershipTest.cpp
@@ -211,6 +211,25 @@ void testLegacyFileMigration() {
     std::filesystem::remove_all(dir);
 }
 
+void testResolveLaneChannelId() {
+    std::cout << "[model] lane channel resolves through track identity, never position\n";
+    TrackManager tm;
+    PlaylistLaneID laneId = tm.getPlaylistModel().createLane("Lane 1");
+
+    check(tm.resolveLaneChannelId(laneId) == 0, "unowned lane resolves to 0 (caller falls back to master)");
+
+    MixerChannel* channel = tm.addChannelWithId("Insert 7", 7);
+    check(channel != nullptr && channel->getChannelId() == 7, "test channel 7 exists");
+    uint64_t trackId = tm.createTrack(laneId, "Track 1", 7);
+    check(trackId != 0, "track created routing to channel 7");
+    check(tm.resolveLaneChannelId(laneId) == 7, "owned lane resolves through track channelId — not position");
+
+    tm.removeTrack(trackId);
+    check(tm.resolveLaneChannelId(laneId) == 0, "lane outliving its removed track resolves to 0");
+
+    check(tm.resolveLaneChannelId(PlaylistLaneID::generate()) == 0, "missing lane resolves to 0");
+}
+
 } // namespace
 
 int main() {
@@ -221,6 +240,7 @@ int main() {
     testRestoreTrackExactIds();
     testSerializeRoundtrip();
     testLegacyFileMigration();
+    testResolveLaneChannelId();
 
     if (g_failures == 0) {
         std::cout << "Track ownership: all green.\n";


### PR DESCRIPTION
```text
Objective: TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       corrective
```

## Summary

Two coupled defects, both under FD-14:

1. **`PlaylistLane::index` went stale after lane deletion.** `removeLane()` rebuilt the lane map but never reindexed survivors — the track-number marker showed wrong numbers, and the automation default channel pairing could resolve to the wrong mixer channel, persisting a wrong `mixerChannelId` into the project file. New lanes could even collide with a survivor's stale index (two lanes, one channel).

2. **The automation default pairing violated FD-14 §15's Automation Boundary.** §15 names the exact forbidden pattern: *"an empty automation lane could resolve its target through `getChannel(lane->index)`"* — that code was live in `TrackUIComponent`. The reindex fix alone would have made the forbidden coupling *accurate*; this PR removes it.

## Why

`index` is display metadata consumed by the track-number marker and (formerly) the automation pairing; it is never serialized — load re-derives it via `createLaneWithId`, so the reindex fix heals stale files at load with zero format change.

## Changes

- `PlaylistModel::removeLane()` reindexes survivors in the same loop that rebuilds the lane map
- New `TrackManager::resolveLaneChannelId()`: lane → owning Track → track `channelId` (0 when unowned/missing) — one resolver shared by the serializer and the UI
- `ProjectSerializer`: lane channel state resolves through the helper (behavior identical)
- `TrackUIComponent`: default Volume curve on an empty lane binds to the lane's Track's routing channel, master when unowned — never `lane->index`

## Testing

- New DeleteLaneCommandTest scenario: delete → survivors shift, create-after-delete collision check, undo, redo (fails on old code)
- New TrackOwnershipTest scenario pins `resolveLaneChannelId` (unowned → 0, owned → track channel, after `removeTrack` → 0, missing lane → 0)
- Full build + 263/263 ctest pass

## Producer note

None

## Docs updated?

No

## Risk / rollback

- No serialization format change (`index` was never persisted; automation curves store explicit `mixerChannelId`)
- Behavior change is strictly corrective: take lanes now default-bind automation to their Track's routing channel instead of a positional channel that could belong to a different track
- Rollback: revert the branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Reindex surviving playlist lanes after deletion to keep lane indices and track-number markers correct.
- Resolve automation channels through lane ownership with `TrackManager::resolveLaneChannelId()`. Use master channel `0` when ownership is unavailable.
- Update the UI and serializer to use channel ownership instead of lane position.
- Add regression tests for deletion, creation, undo/redo, collision detection, and channel resolution.
- Full build passes with 263/263 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->