### PR TITLE
feat: QoL sweep — count-in, unified cursors, piano-roll domain, recording cleanup

### DIFF
--- a/AestraAudio/include/Commands/MakeClipPatternUniqueCommand.h
+++ b/AestraAudio/include/Commands/MakeClipPatternUniqueCommand.h
@@ -57,6 +57,9 @@ public:
             m_manager.getPatternManager().setPatternMixerChannel(m_uniquePatternId, sourceMixerChannelId);
         }
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+        // Live playback: scheduled instances still hold the old PatternID —
+        // refresh them so the clip plays its own (unique) pattern immediately.
+        m_manager.refreshTimelinePatternInstances();
         m_executed = true;
     }
 
@@ -71,14 +74,14 @@ public:
             m_detachedPattern = m_manager.getPatternManager().detachPattern(m_uniquePatternId);
         }
         m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+        m_manager.refreshTimelinePatternInstances();
         m_executed = false;
     }
 
     void redo() override {
-        if (m_executed)
-            return;
+        // execute() owns the executed-state transition; a failed redo (clip
+        // gone, pattern missing) must not mark the command executed.
         execute();
-        m_executed = true;
     }
 
     std::string getName() const override { return "Make Pattern Unique"; }

--- a/AestraAudio/include/Commands/MakeClipPatternUniqueCommand.h
+++ b/AestraAudio/include/Commands/MakeClipPatternUniqueCommand.h
@@ -1,0 +1,101 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/TrackManager.h"
+
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Give one Playlist clip its own pattern identity, preserving contents.
+ *
+ * Works for MIDI and audio patterns alike: the pattern data is cloned under a
+ * new id ("... copy" naming follows PatternManager::clonePattern) and the clip
+ * is repointed at the clone. Other clips keep referencing the original.
+ */
+class MakeClipPatternUniqueCommand final : public ICommand {
+public:
+    MakeClipPatternUniqueCommand(TrackManager& manager, ClipInstanceID clipId)
+        : m_manager(manager), m_clipId(clipId) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+        const auto* clip = m_manager.getPlaylistModel().getClip(m_clipId);
+        if (!clip || !clip->patternId.isValid())
+            return;
+        const auto* sourcePattern = m_manager.getPatternManager().getPattern(clip->patternId);
+        if (!sourcePattern)
+            return;
+
+        // Capture before cloning: the source pointer can be invalidated by the
+        // clone's store mutation.
+        const uint32_t sourceMixerChannelId = sourcePattern->getMixerChannelId();
+
+        if (!m_originalPatternId.isValid()) {
+            m_originalPatternId = clip->patternId;
+        }
+        if (m_detachedPattern) {
+            if (!m_manager.getPatternManager().reinsertPattern(m_detachedPattern))
+                return;
+        } else {
+            m_uniquePatternId = m_manager.getPatternManager().clonePattern(m_originalPatternId);
+            if (!m_uniquePatternId.isValid())
+                return;
+        }
+        if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_uniquePatternId)) {
+            m_detachedPattern = m_manager.getPatternManager().detachPattern(m_uniquePatternId);
+            return;
+        }
+
+        // Preserve per-pattern mixer routing when the source had one.
+        if (sourceMixerChannelId != 0) {
+            m_manager.getPatternManager().setPatternMixerChannel(m_uniquePatternId, sourceMixerChannelId);
+        }
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+        auto* clip = m_manager.getPlaylistModel().getClip(m_clipId);
+        if (clip && clip->patternId == m_uniquePatternId) {
+            if (!m_manager.getPlaylistModel().setClipPattern(m_clipId, m_originalPatternId)) {
+                return;
+            }
+            m_detachedPattern = m_manager.getPatternManager().detachPattern(m_uniquePatternId);
+        }
+        m_manager.requestAudioGraphRebuild(GraphDirtyReason::TimelineChanged);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+        execute();
+        m_executed = true;
+    }
+
+    std::string getName() const override { return "Make Pattern Unique"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+    /** @brief The cloned pattern id (valid after execute). */
+    PatternID uniquePatternId() const { return m_uniquePatternId; }
+
+private:
+    TrackManager& m_manager;
+    ClipInstanceID m_clipId;
+    PatternID m_originalPatternId;
+    PatternID m_uniquePatternId;
+    std::unique_ptr<PatternSource> m_detachedPattern;
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Commands/SetTrimCommand.h
+++ b/AestraAudio/include/Commands/SetTrimCommand.h
@@ -1,0 +1,74 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+
+#include <memory>
+#include <string>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Command to change a channel's trim offset (dB).
+ *
+ * Trim is consumed on the RT side through the ContinuousParamBuffer (like the
+ * fader/pan readouts), so execute/undo/redo push both the MixerChannel member
+ * (serialized project state) and the buffer slot (live RT value), then request
+ * a graph rebuild for parity with the other mixer mutations.
+ */
+class SetTrimCommand : public ICommand {
+public:
+    SetTrimCommand(TrackManager& trackManager, MixerChannel& channel, uint32_t slotIndex, float newTrimDb)
+        : m_trackManager(trackManager), m_channel(channel), m_slotIndex(slotIndex), m_newTrimDb(newTrimDb) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+
+        m_originalTrimDb = m_channel.getTrimDb();
+        apply(m_newTrimDb);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+
+        apply(m_originalTrimDb);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+
+        apply(m_newTrimDb);
+        m_executed = true;
+    }
+
+    std::string getName() const override { return "Set Trim"; }
+    size_t getSizeInBytes() const override { return sizeof(*this); }
+    bool changesProjectState() const override { return true; }
+
+private:
+    void apply(float trimDb) {
+        m_channel.setTrimDb(trimDb);
+        if (auto* continuous = m_trackManager.getContinuousParams().get()) {
+            continuous->setTrimDb(m_slotIndex, trimDb);
+        }
+        m_trackManager.requestAudioGraphRebuild(GraphDirtyReason::MixerStateChanged);
+    }
+
+    TrackManager& m_trackManager;
+    MixerChannel& m_channel;
+    uint32_t m_slotIndex;
+    float m_newTrimDb;
+    float m_originalTrimDb{0.0f};
+    bool m_executed{false};
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraAudio/include/Core/AudioCommandQueue.h
+++ b/AestraAudio/include/Core/AudioCommandQueue.h
@@ -27,6 +27,8 @@ enum class AudioQueueCommandType : uint8_t {
     StartPreview,
     StopPreview,
     SetMetronomeEnabled,
+    MetronomeCountInStart, // value1 = beats to count
+    MetronomeCountInStop,
     AuditionUnit, // trackIndex = unitId, value1 = velocity
 };
 

--- a/AestraAudio/include/Core/MixerChannel.h
+++ b/AestraAudio/include/Core/MixerChannel.h
@@ -150,6 +150,10 @@ public:
     void setWidth(float width);
     /** @brief Get stereo width. */
     float getWidth() const { return m_width.load(); }
+    /** @brief Set the channel trim offset (dB, pre-fader gain stage). */
+    void setTrimDb(float trimDb) { m_trimDb.store(trimDb); }
+    /** @brief Get the channel trim offset in dB. */
+    float getTrimDb() const { return m_trimDb.load(); }
     /** @brief Set mute state. */
     void setMute(bool mute);
     /** @brief Check mute state. */
@@ -273,6 +277,7 @@ private:
     std::atomic<float> m_volume{1.0f};
     std::atomic<float> m_pan{0.0f};
     std::atomic<float> m_width{1.0f};
+    std::atomic<float> m_trimDb{0.0f};
     std::atomic<bool> m_muted{false};
     std::atomic<bool> m_soloed{false};
     std::atomic<bool> m_soloSafe{false};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <mutex>
 #include <sstream>
 #include <thread>
@@ -1988,21 +1989,25 @@ private:
      * persists a dangling reference.
      * @param keepCheck Optional external keep predicate (app-supplied project
      *        reference check).
-     * @return Number of recording files removed.
+     * @return std::nullopt when the call was refused as realtime misuse (the
+     *         audio thread must never touch the filesystem — callers should log
+     *         and treat it as "not attempted", distinct from a successful
+     *         cleanup that removed zero files). Otherwise the number of files
+     *         removed.
      */
 public:
-    size_t cleanupOrphanedRecordings(const std::function<bool(const std::string&)>& keepCheck = {}) {
+    std::optional<size_t> cleanupOrphanedRecordings(const std::function<bool(const std::string&)>& keepCheck = {}) {
         namespace fs = std::filesystem;
         if (reportRealtimeMisuse("TrackManager::cleanupOrphanedRecordings")) {
-            return 0;
+            return std::nullopt;
         }
         if (m_isCapturing.load(std::memory_order_relaxed)) {
-            return 0;
+            return size_t{0};
         }
         const fs::path root = recordingRootDirectory();
         std::error_code ec;
         if (!fs::exists(root, ec) || !fs::is_directory(root, ec)) {
-            return 0;
+            return size_t{0};
         }
 
         auto normalized = [](const std::string& p) { return fs::path(p).lexically_normal().generic_string(); };

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1119,6 +1119,24 @@ public:
     }
 
     /**
+     * @brief Re-schedule timeline pattern instances from the current playhead
+     *        without stopping playback.
+     *
+     * Called after mutations that add or change timeline clips while playing
+     * (e.g. duplication): the scheduler's instance set was built at play() time
+     * and would otherwise only notice the new clip at the next loop wrap.
+     * Already-played material stays silent; anything ahead of the playhead is
+     * picked up immediately.
+     */
+    void refreshTimelinePatternInstances() {
+        if (!m_isPlaying.load(std::memory_order_relaxed) || m_patternMode.load(std::memory_order_relaxed)) {
+            return;
+        }
+        m_patternPlaybackEngine.clearScheduledInstances();
+        scheduleTimelinePatternInstances(m_position.load(std::memory_order_relaxed));
+    }
+
+    /**
      * @brief Start transport playback from the current UI position.
      */
     void play() {

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1228,6 +1228,87 @@ public:
         clearDeferredRecordingStartBeat();
     }
 
+    /**
+     * @brief Begin the count-in phase ahead of playback/recording.
+     *
+     * The canonical transport contract for count-in: pins the transport to the
+     * requested start position, defers recording capture (when armed) to the
+     * beat where playback will begin — so recorded material is aligned to the
+     * post-count-in position — and starts the engine's metronome count-in
+     * through the command sink. The app polls the engine for count-in
+     * completion and calls completeCountIn() when the metronome finishes.
+     * Count-in is a universal lead-in: it runs before playback whether or not
+     * a take is armed. When recording is armed, the pinned start also defers
+     * capture to the post-count-in beat.
+     * @param beats Number of metronome beats to count (>= 1).
+     * @param startSeconds Transport position playback (and capture) starts at.
+     * @return False when no count-in can start (already pending or rolling).
+     */
+    bool beginCountIn(uint32_t beats, double startSeconds) {
+        if (m_countInPending.load(std::memory_order_relaxed) || m_isPlaying.load(std::memory_order_relaxed)) {
+            return false;
+        }
+        const double clampedStart = std::max(0.0, startSeconds);
+        m_countInPending.store(true, std::memory_order_release);
+        setPlayStartPosition(clampedStart);
+        m_position.store(clampedStart, std::memory_order_relaxed);
+        setDeferredRecordingStartBeat(secondsToBeats(clampedStart));
+        setDisplayPositionOverride(clampedStart);
+        if (m_commandSink) {
+            AudioQueueCommand cmd{};
+            cmd.type = AudioQueueCommandType::MetronomeCountInStart;
+            cmd.value1 = static_cast<float>(std::max<uint32_t>(1, beats));
+            m_commandSink(cmd);
+        }
+        return true;
+    }
+
+    /**
+     * @brief Cancel a pending count-in and drop its deferred capture alignment.
+     */
+    void cancelCountIn() {
+        if (m_commandSink) {
+            AudioQueueCommand cmd{};
+            cmd.type = AudioQueueCommandType::MetronomeCountInStop;
+            m_commandSink(cmd);
+        }
+        clearDeferredRecordingStartBeat();
+        clearDisplayPositionOverride();
+        clearNextCapturePlacementStartBeat();
+        m_countInPending.store(false, std::memory_order_release);
+    }
+
+    /**
+     * @brief Finish the count-in phase and start playback at the pinned
+     *        position. Called by the app once the engine's count-in metronome
+     *        has finished, so recording (when armed) begins exactly where the
+     *        count-in ended.
+     */
+    void completeCountIn() {
+        if (!m_countInPending.load(std::memory_order_relaxed)) {
+            return;
+        }
+        m_countInPending.store(false, std::memory_order_release);
+        clearDisplayPositionOverride();
+        clearNextCapturePlacementStartBeat();
+        if (!m_recordArmed.load(std::memory_order_relaxed) || !hasArmedTracks()) {
+            // No capture will follow this count-in (plain playback). Leaving a
+            // stale deferred start would misalign a later, non-count-in
+            // recording — capture would skip frames to the old count-in beat.
+            clearDeferredRecordingStartBeat();
+        }
+        play();
+    }
+
+    /** @brief True while a count-in is pending (before playback has started). */
+    bool isCountInPending() const { return m_countInPending.load(std::memory_order_acquire); }
+
+    /** @brief Convert a transport position in seconds to beats at the current tempo. */
+    double secondsToBeats(double seconds) const {
+        const double bpm = std::max(1.0, m_playlistModel.getBPM());
+        return std::max(0.0, seconds) * bpm / 60.0;
+    }
+
     void clearDeferredRecordingStartBeat() {
         m_hasDeferredRecordingStart.store(false, std::memory_order_release);
         m_deferredRecordingStartBeat.store(0.0, std::memory_order_relaxed);
@@ -1886,6 +1967,94 @@ private:
         }
     }
 
+    /**
+     * @brief Remove recording files that no session can reference anymore.
+     *
+     * Recording lifecycle: captured audio is held in-memory until the take
+     * commits, at which point a WAV is written and a take (source → pattern →
+     * clip) lands on the armed track's lane. A WAV becomes a cleanup candidate
+     * only at session boundaries (project close/new/open, app exit), where the
+     * undo history is being discarded and a redo can no longer resurrect the
+     * take. A candidate is KEPT when:
+     *  - a live lane clip still references it (kept audio is ownable/audible), or
+     *  - keepCheck(path) returns true (the app says an on-disk project still
+     *    references it — a saved project owns its recording assets), or
+     *  - recording is still in progress (the WAV may be mid-write).
+     * Candidates are *.wav files directly under the recording root. Registered
+     * sources pointing at removed files are dropped so a later save never
+     * persists a dangling reference.
+     * @param keepCheck Optional external keep predicate (app-supplied project
+     *        reference check).
+     * @return Number of recording files removed.
+     */
+public:
+    size_t cleanupOrphanedRecordings(const std::function<bool(const std::string&)>& keepCheck = {}) {
+        namespace fs = std::filesystem;
+        if (m_isCapturing.load(std::memory_order_relaxed)) {
+            return 0;
+        }
+        const fs::path root = recordingRootDirectory();
+        std::error_code ec;
+        if (!fs::exists(root, ec) || !fs::is_directory(root, ec)) {
+            return 0;
+        }
+
+        auto normalized = [](const std::string& p) { return fs::path(p).lexically_normal().generic_string(); };
+
+        std::unordered_set<std::string> keep;
+        const auto markKept = [&](const std::string& p) {
+            if (!p.empty()) {
+                keep.insert(normalized(p));
+            }
+        };
+
+        // Live model: every path a lane clip can reach through pattern → source.
+        for (const auto& laneId : m_playlistModel.getLaneIDs()) {
+            auto* lane = m_playlistModel.getLane(laneId);
+            if (!lane) {
+                continue;
+            }
+            for (const auto& clip : lane->clips) {
+                auto* pattern = m_patternManager.getPattern(clip.patternId);
+                if (!pattern || !pattern->isAudio()) {
+                    continue;
+                }
+                const auto& payload = std::get<AudioSlicePayload>(pattern->payload);
+                if (const auto* source = m_sourceManager.getSource(payload.audioSourceId)) {
+                    markKept(source->getFilePath());
+                }
+            }
+        }
+
+        size_t removed = 0;
+        for (const auto& entry : fs::directory_iterator(root, ec)) {
+            if (!entry.is_regular_file(ec) || entry.path().extension() != ".wav") {
+                continue;
+            }
+            const std::string path = entry.path().string();
+            if (keep.count(normalized(path)) > 0) {
+                continue;
+            }
+            if (keepCheck && keepCheck(path)) {
+                continue;
+            }
+            if (fs::remove(entry.path(), ec)) {
+                ++removed;
+                // Drop the registration so a later save never persists a
+                // dangling recording source.
+                if (const ClipSourceID sid = m_sourceManager.findSourceByPath(path); sid.isValid()) {
+                    m_sourceManager.removeSource(sid);
+                }
+            }
+        }
+
+        if (removed > 0) {
+            Log::info("[TrackManager] Recording cleanup removed " + std::to_string(removed) + " orphaned file(s) from " +
+                      root.string());
+        }
+        return removed;
+    }
+
     std::string buildRecordingTakePath(uint32_t channelId) const {
         namespace fs = std::filesystem;
         fs::path root = recordingRootDirectory();
@@ -2105,6 +2274,7 @@ private:
     std::atomic<bool> m_isPaused{false};
     std::atomic<bool> m_recordArmed{false};
     std::atomic<bool> m_isCapturing{false};
+    std::atomic<bool> m_countInPending{false};
     std::atomic<bool> m_transportPlayingConfirmed{false};
     std::atomic<bool> m_hasDeferredRecordingStart{false};
     std::atomic<double> m_deferredRecordingStartBeat{0.0};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1210,6 +1210,9 @@ public:
         } else {
             m_recordingCaptureAccepting.store(false, std::memory_order_release);
             clearNextCapturePlacementStartBeat();
+            // Disarmed before capture began: never leave a count-in's deferred
+            // start around for a later, unrelated recording.
+            clearDeferredRecordingStartBeat();
         }
     }
     /**
@@ -1990,6 +1993,9 @@ private:
 public:
     size_t cleanupOrphanedRecordings(const std::function<bool(const std::string&)>& keepCheck = {}) {
         namespace fs = std::filesystem;
+        if (reportRealtimeMisuse("TrackManager::cleanupOrphanedRecordings")) {
+            return 0;
+        }
         if (m_isCapturing.load(std::memory_order_relaxed)) {
             return 0;
         }
@@ -2055,6 +2061,7 @@ public:
         return removed;
     }
 
+private:
     std::string buildRecordingTakePath(uint32_t channelId) const {
         namespace fs = std::filesystem;
         fs::path root = recordingRootDirectory();

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -314,12 +314,18 @@ void AudioEngine::applyPendingCommands() {
         case AudioQueueCommandType::SetMetronomeEnabled:
             setMetronomeEnabled(static_cast<bool>(cmd.value1));
             break;
-        case AudioQueueCommandType::MetronomeCountInStart:
+        case AudioQueueCommandType::MetronomeCountInStart: {
             // Clamp before the float→unsigned narrowing: negative/NaN/oversized
             // value1 on the shared command surface must not reach the cast or
-            // the RT metronome unchanged.
-            startMetronomeCountIn(static_cast<uint32_t>(std::clamp(cmd.value1, 1.0f, 1024.0f)));
+            // the RT metronome unchanged (std::clamp propagates NaN).
+            const float requestedBeats = cmd.value1;
+            const uint32_t beats =
+                (std::isfinite(requestedBeats) && requestedBeats >= 1.0f)
+                    ? static_cast<uint32_t>(std::min(requestedBeats, 1024.0f))
+                    : 1u;
+            startMetronomeCountIn(beats);
             break;
+        }
         case AudioQueueCommandType::MetronomeCountInStop:
             stopMetronomeCountIn();
             break;

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -314,6 +314,12 @@ void AudioEngine::applyPendingCommands() {
         case AudioQueueCommandType::SetMetronomeEnabled:
             setMetronomeEnabled(static_cast<bool>(cmd.value1));
             break;
+        case AudioQueueCommandType::MetronomeCountInStart:
+            startMetronomeCountIn(static_cast<uint32_t>(cmd.value1));
+            break;
+        case AudioQueueCommandType::MetronomeCountInStop:
+            stopMetronomeCountIn();
+            break;
         case AudioQueueCommandType::SetTrackVolume: {
             const uint32_t trackIndex = resolveTrackIndex(cmd);
             if (trackIndex == ChannelSlotMap::INVALID_SLOT)

--- a/AestraAudio/src/Core/AudioEngine.cpp
+++ b/AestraAudio/src/Core/AudioEngine.cpp
@@ -315,7 +315,10 @@ void AudioEngine::applyPendingCommands() {
             setMetronomeEnabled(static_cast<bool>(cmd.value1));
             break;
         case AudioQueueCommandType::MetronomeCountInStart:
-            startMetronomeCountIn(static_cast<uint32_t>(cmd.value1));
+            // Clamp before the float→unsigned narrowing: negative/NaN/oversized
+            // value1 on the shared command surface must not reach the cast or
+            // the RT metronome unchanged.
+            startMetronomeCountIn(static_cast<uint32_t>(std::clamp(cmd.value1, 1.0f, 1024.0f)));
             break;
         case AudioQueueCommandType::MetronomeCountInStop:
             stopMetronomeCountIn();

--- a/AestraPlat/include/AestraPlatform.h
+++ b/AestraPlat/include/AestraPlatform.h
@@ -281,6 +281,10 @@ public:
     virtual void setHitTestCallback(HitTestCallback callback) = 0;
     /** @brief Set the mouse-move callback. */
     virtual void setMouseMoveCallback(std::function<void(int x, int y)> callback) = 0;
+    /** @brief Set the callback fired when the mouse enters the window. Default no-op. */
+    virtual void setMouseEnterCallback(std::function<void()> callback) {}
+    /** @brief Set the callback fired when the mouse leaves the window. Default no-op. */
+    virtual void setMouseLeaveCallback(std::function<void()> callback) {}
     /** @brief Set the mouse-button callback. */
     virtual void
     setMouseButtonCallback(std::function<void(MouseButton button, bool pressed, int x, int y)> callback) = 0;

--- a/AestraPlat/src/Linux/PlatformWindowLinux.cpp
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.cpp
@@ -169,6 +169,14 @@ bool PlatformWindowLinux::pollEvents() {
                     }
                     rememberRestoreBoundsIfNormal();
                     break;
+                case SDL_WINDOWEVENT_ENTER:
+                    if (m_mouseEnterCallback)
+                        m_mouseEnterCallback();
+                    break;
+                case SDL_WINDOWEVENT_LEAVE:
+                    if (m_mouseLeaveCallback)
+                        m_mouseLeaveCallback();
+                    break;
                 }
             }
             break;

--- a/AestraPlat/src/Linux/PlatformWindowLinux.h
+++ b/AestraPlat/src/Linux/PlatformWindowLinux.h
@@ -74,6 +74,8 @@ public:
     // Event callbacks
     void setHitTestCallback(HitTestCallback callback) override { m_hitTestCallback = callback; }
     void setMouseMoveCallback(std::function<void(int x, int y)> callback) override { m_mouseMoveCallback = callback; }
+    void setMouseEnterCallback(std::function<void()> callback) override { m_mouseEnterCallback = callback; }
+    void setMouseLeaveCallback(std::function<void()> callback) override { m_mouseLeaveCallback = callback; }
     void setMouseButtonCallback(std::function<void(MouseButton button, bool pressed, int x, int y)> callback) override {
         m_mouseButtonCallback = callback;
     }
@@ -119,6 +121,8 @@ private:
     // Callbacks
     HitTestCallback m_hitTestCallback;
     std::function<void(int, int)> m_mouseMoveCallback;
+    std::function<void()> m_mouseEnterCallback;
+    std::function<void()> m_mouseLeaveCallback;
     std::function<void(MouseButton, bool, int, int)> m_mouseButtonCallback;
     std::function<void(float)> m_mouseWheelCallback;
     std::function<void(KeyCode, bool, const KeyModifiers&)> m_keyCallback;

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -755,9 +755,25 @@ LRESULT PlatformWindowWin32::handleMessage(UINT msg, WPARAM wParam, LPARAM lPara
     case WM_MOUSEMOVE: {
         int x = GET_X_LPARAM(lParam);
         int y = GET_Y_LPARAM(lParam);
+        // Arm mouse-leave tracking the first time the pointer is inside so
+        // WM_MOUSELEAVE fires when it exits (TrackMouseEvent is one-shot).
+        if (!m_mouseTrackingLeave) {
+            TRACKMOUSEEVENT tme{sizeof(tme), TME_LEAVE, m_hwnd, 0};
+            TrackMouseEvent(&tme);
+            m_mouseTrackingLeave = true;
+            if (m_mouseEnterCallback)
+                m_mouseEnterCallback();
+        }
         if (m_mouseMoveCallback) {
             m_mouseMoveCallback(x, y);
         }
+        return 0;
+    }
+
+    case WM_MOUSELEAVE: {
+        m_mouseTrackingLeave = false;
+        if (m_mouseLeaveCallback)
+            m_mouseLeaveCallback();
         return 0;
     }
 

--- a/AestraPlat/src/Win32/PlatformWindowWin32.cpp
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.cpp
@@ -746,6 +746,15 @@ LRESULT PlatformWindowWin32::handleMessage(UINT msg, WPARAM wParam, LPARAM lPara
         // Forward NC mouse moves to the app so software cursors don't freeze over Title Bar
         POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
         ScreenToClient(m_hwnd, &pt);
+        // Track both client and nonclient areas with one shared leave state:
+        // moving onto the title bar must not read as leaving the window.
+        if (!m_mouseTrackingLeave) {
+            TRACKMOUSEEVENT tme{sizeof(tme), static_cast<DWORD>(TME_LEAVE | TME_NONCLIENT), m_hwnd, 0};
+            TrackMouseEvent(&tme);
+            m_mouseTrackingLeave = true;
+            if (m_mouseEnterCallback)
+                m_mouseEnterCallback();
+        }
         if (m_mouseMoveCallback) {
             m_mouseMoveCallback(pt.x, pt.y);
         }
@@ -756,9 +765,10 @@ LRESULT PlatformWindowWin32::handleMessage(UINT msg, WPARAM wParam, LPARAM lPara
         int x = GET_X_LPARAM(lParam);
         int y = GET_Y_LPARAM(lParam);
         // Arm mouse-leave tracking the first time the pointer is inside so
-        // WM_MOUSELEAVE fires when it exits (TrackMouseEvent is one-shot).
+        // WM_MOUSELEAVE / WM_NCMOUSELEAVE fire when it exits (one-shot).
+        // TME_NONCLIENT keeps title-bar moves inside the tracked window.
         if (!m_mouseTrackingLeave) {
-            TRACKMOUSEEVENT tme{sizeof(tme), TME_LEAVE, m_hwnd, 0};
+            TRACKMOUSEEVENT tme{sizeof(tme), static_cast<DWORD>(TME_LEAVE | TME_NONCLIENT), m_hwnd, 0};
             TrackMouseEvent(&tme);
             m_mouseTrackingLeave = true;
             if (m_mouseEnterCallback)
@@ -770,7 +780,8 @@ LRESULT PlatformWindowWin32::handleMessage(UINT msg, WPARAM wParam, LPARAM lPara
         return 0;
     }
 
-    case WM_MOUSELEAVE: {
+    case WM_MOUSELEAVE:
+    case WM_NCMOUSELEAVE: {
         m_mouseTrackingLeave = false;
         if (m_mouseLeaveCallback)
             m_mouseLeaveCallback();

--- a/AestraPlat/src/Win32/PlatformWindowWin32.h
+++ b/AestraPlat/src/Win32/PlatformWindowWin32.h
@@ -66,6 +66,8 @@ public:
 
     void setHitTestCallback(HitTestCallback callback) override { m_hitTestCallback = callback; }
     void setMouseMoveCallback(std::function<void(int, int)> callback) override { m_mouseMoveCallback = callback; }
+    void setMouseEnterCallback(std::function<void()> callback) override { m_mouseEnterCallback = callback; }
+    void setMouseLeaveCallback(std::function<void()> callback) override { m_mouseLeaveCallback = callback; }
     void setMouseButtonCallback(std::function<void(MouseButton, bool, int, int)> callback) override {
         m_mouseButtonCallback = callback;
     }
@@ -119,10 +121,13 @@ private:
 
     // Cursor state
     bool m_cursorVisible = true;
+    bool m_mouseTrackingLeave = false;
 
     // Event callbacks
     HitTestCallback m_hitTestCallback;
     std::function<void(int, int)> m_mouseMoveCallback;
+    std::function<void()> m_mouseEnterCallback;
+    std::function<void()> m_mouseLeaveCallback;
     std::function<void(MouseButton, bool, int, int)> m_mouseButtonCallback;
     std::function<void(float)> m_mouseWheelCallback;
     std::function<void(KeyCode, bool, const KeyModifiers&)> m_keyCallback;

--- a/AestraUI/Base/NUISlider.cpp
+++ b/AestraUI/Base/NUISlider.cpp
@@ -220,6 +220,8 @@ void NUISlider::onMouseEnter()
 {
     if (platformBridge_ && platformBridge_->getCursorStyle() == NUICursorStyle::Hidden) return;
     isHovered_ = true;
+    // Hand/grab affordance: the control is draggable.
+    if (platformBridge_) platformBridge_->setCursorStyle(NUICursorStyle::Grab);
     setDirty(true);
 }
 
@@ -227,6 +229,7 @@ void NUISlider::onMouseLeave()
 {
     if (platformBridge_ && platformBridge_->getCursorStyle() == NUICursorStyle::Hidden) return;
     isHovered_ = false;
+    if (platformBridge_ && !isDragging_) platformBridge_->setCursorStyle(NUICursorStyle::Arrow);
     setDirty(true);
 }
 

--- a/AestraUI/Core/NUICursorRegistry.h
+++ b/AestraUI/Core/NUICursorRegistry.h
@@ -1,0 +1,70 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// NUICursorRegistry — the single canonical source of cursor artwork.
+//
+// Every interaction cursor in the app resolves through this registry so the
+// same interaction uses the same asset regardless of which editor or component
+// renders it. Prefer these SVG glyphs over ad-hoc drawLine/vector cursor
+// artwork.
+//
+// - nuiCursorSvg(style): the overlay cursor glyphs (drawn by the app's custom
+//   cursor renderer). High-contrast white-on-black by default.
+// - nuiTrimResizeCursorSvg(): a tintable horizontal-stretch glyph for
+//   components that paint their own cursor (e.g. the track trim edge), using
+//   currentColor so NUIIcon::setColor drives the tone.
+
+#pragma once
+
+#include "../Platform/NUICursorStyle.h"
+
+namespace AestraUI {
+
+/** @brief Canonical SVG for an interaction cursor style, or nullptr for styles
+ *  with no dedicated glyph (the caller falls back to the default cursor). */
+inline const char* nuiCursorSvg(NUICursorStyle style) {
+    switch (style) {
+    case NUICursorStyle::Arrow:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M5 2L5 18L9 14L12 21L14 20L11 13L17 13L5 2Z\" fill=\"white\" stroke=\"black\" stroke-width=\"1.5\"/></svg>";
+    case NUICursorStyle::Hand:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M7 12.5V9.5C7 8.95 7.45 8.5 8 8.5C8.55 8.5 9 8.95 9 9.5V12.2H9.6V5C9.6 4.45 10.05 4 10.6 4C11.15 4 11.6 4.45 11.6 5V12.2H12.2V3.2C12.2 2.65 12.65 2.2 13.2 2.2C13.75 2.2 14.2 2.65 14.2 3.2V12.2H14.8V6.2C14.8 5.65 15.25 5.2 15.8 5.2C16.35 5.2 16.8 5.65 16.8 6.2V14.1C16.8 17.35 14.15 20 10.9 20H10.6C7.9 20 5.7 17.8 5.7 15.1V12.5C5.7 11.95 6.15 11.5 6.7 11.5C6.93 11.5 7.14 11.58 7.3 11.72C7.32 11.74 7.33 11.75 7.35 11.77C7.56 11.96 7.7 12.22 7.7 12.5H7Z\" fill=\"white\" stroke=\"black\" stroke-width=\"1.15\" stroke-linejoin=\"round\"/></svg>";
+    case NUICursorStyle::Grab:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M12 6V3C12 2.45 12.45 2 13 2C13.55 2 14 2.45 14 3V10H15V4C15 3.45 15.45 3 16 3C16.55 3 17 3.45 17 4V10H18V5C18 4.45 18.45 4 19 4C19.55 4 20 4.45 20 5V15C20 18.31 17.31 21 14 21H12C8.69 21 6 18.31 6 15V12C6 11.45 6.45 11 7 11C7.55 11 8 11.45 8 12V14H9V6C9 5.45 9.45 5 10 5C10.55 5 11 5.45 11 6V10H12V6Z\" fill=\"white\" stroke=\"black\" stroke-width=\"1\"/></svg>";
+    case NUICursorStyle::Grabbing:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M9.5 5.8C9.5 5.14 10.04 4.6 10.7 4.6C11.36 4.6 11.9 5.14 11.9 5.8V9.1H12.5V4.7C12.5 4.04 13.04 3.5 13.7 3.5C14.36 3.5 14.9 4.04 14.9 4.7V9.1H15.5V6.4C15.5 5.74 16.04 5.2 16.7 5.2C17.36 5.2 17.9 5.74 17.9 6.4V11.7C17.9 15.73 14.63 19 10.6 19C7.51 19 5 16.49 5 13.4V10.7C5 10.04 5.54 9.5 6.2 9.5C6.86 9.5 7.4 10.04 7.4 10.7V12.9H8V7C8 6.34 8.54 5.8 9.2 5.8H9.5Z\" fill=\"white\" stroke=\"black\" stroke-width=\"1.2\" stroke-linejoin=\"round\"/>"
+               "<path d=\"M7.9 14.3C8.05 15.72 9.25 16.8 10.7 16.8C12.28 16.8 13.56 15.52 13.56 13.94V12.7H7.8V13.5C7.8 13.77 7.84 14.04 7.9 14.3Z\" fill=\"black\" fill-opacity=\"0.16\"/></svg>";
+    case NUICursorStyle::IBeam:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M9 4H11M15 4H13M11 4V20M13 4V20M11 4C11 4 11 4 12 4C13 4 13 4 13 4M11 20H9M15 20H13M11 20C11 20 11 20 12 20C13 20 13 20 13 20\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\"/>"
+               "<path d=\"M9 4H11M15 4H13M11 4V20M13 4V20M11 4C11 4 11 4 12 4C13 4 13 4 13 4M11 20H9M15 20H13M11 20C11 20 11 20 12 20C13 20 13 20 13 20\" stroke=\"black\" stroke-width=\"3\" stroke-linecap=\"round\" opacity=\"0.3\"/></svg>";
+    case NUICursorStyle::ResizeEW:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M18 12L22 12M22 12L19 9M22 12L19 15M6 12L2 12M2 12L5 9M2 12L5 15M12 6V18\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>"
+               "<path d=\"M18 12L22 12M22 12L19 9M22 12L19 15M6 12L2 12M2 12L5 9M2 12L5 15M12 6V18\" stroke=\"black\" stroke-width=\"3\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"0.3\"/></svg>";
+    case NUICursorStyle::ResizeNS:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M12 6L12 2M12 2L9 5M12 2L15 5M12 18L12 22M12 22L9 19M12 22L15 19M6 12H18\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>"
+               "<path d=\"M12 6L12 2M12 2L9 5M12 2L15 5M12 18L12 22M12 22L9 19M12 22L15 19M6 12H18\" stroke=\"black\" stroke-width=\"3\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"0.3\"/></svg>";
+    case NUICursorStyle::ResizeNESW:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M16 8L22 2M22 2H18M22 2V6M8 16L2 22M2 22H6M2 22V18M9 15L15 9\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>"
+               "<path d=\"M16 8L22 2M22 2H18M22 2V6M8 16L2 22M2 22H6M2 22V18M9 15L15 9\" stroke=\"black\" stroke-width=\"3\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"0.3\"/></svg>";
+    case NUICursorStyle::ResizeNWSE:
+        return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+               "<path d=\"M8 8L2 2M2 2H6M2 2V6M16 16L22 22M22 22H18M22 22V18M9 9L15 15\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>"
+               "<path d=\"M8 8L2 2M2 2H6M2 2V6M16 16L22 22M22 22H18M22 22V18M9 9L15 15\" stroke=\"black\" stroke-width=\"3\" stroke-linecap=\"round\" stroke-linejoin=\"round\" opacity=\"0.3\"/></svg>";
+    default:
+        return nullptr;
+    }
+}
+
+/** @brief Tintable horizontal-stretch glyph for component-drawn cursors
+ *  (currentColor follows NUIIcon::setColor). */
+inline const char* nuiTrimResizeCursorSvg() {
+    return "<svg viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+           "<path d=\"M18 12L22 12M22 12L19 9M22 12L19 15M6 12L2 12M2 12L5 9M2 12L5 15M12 6V18\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>";
+}
+
+} // namespace AestraUI

--- a/AestraUI/Platform/NUICursorStyle.h
+++ b/AestraUI/Platform/NUICursorStyle.h
@@ -1,0 +1,36 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// NUICursorStyle — the canonical cursor-style enumeration.
+//
+// Split out of NUIPlatformBridge.h so cursor consumers (the cursor registry,
+// the custom-cursor renderer) can reference the canonical style set without
+// pulling in the whole platform bridge. NUIPlatformBridge.h re-includes this,
+// so existing `enum class NUICursorStyle` usages are unchanged.
+
+#pragma once
+
+#include <cstdint>
+
+namespace AestraUI {
+
+/**
+ * Cursor styles for setCursorStyle()
+ */
+enum class NUICursorStyle {
+    Arrow,          // Default arrow cursor
+    Hand,           // Pointing hand (for clickable elements)
+    IBeam,          // Text input cursor
+    Wait,           // Loading/busy cursor (hourglass/spinner)
+    WaitArrow,      // Arrow with loading indicator
+    Crosshair,      // Precision crosshair
+    ResizeNS,       // North-South resize (vertical)
+    ResizeEW,       // East-West resize (horizontal)
+    ResizeNESW,     // Diagonal resize (NE-SW)
+    ResizeNWSE,     // Diagonal resize (NW-SE)
+    ResizeAll,      // Move/all directions
+    NotAllowed,     // Disabled/not allowed
+    Grab,           // Open hand (ready to grab)
+    Grabbing,       // Closed hand (currently grabbing)
+    Hidden          // No cursor visible
+};
+
+} // namespace AestraUI

--- a/AestraUI/Platform/NUIPlatformBridge.cpp
+++ b/AestraUI/Platform/NUIPlatformBridge.cpp
@@ -120,7 +120,6 @@ void NUIPlatformBridge::setupEventBridges() {
         if (rootInputBlocked) {
             return;
         }
-
         // Forward to root component for hover effects
         if (m_rootComponent) {
             NUIMouseEvent event;
@@ -217,6 +216,20 @@ void NUIPlatformBridge::setupEventBridges() {
             } else {
                 NUIComponent::dispatchMouseEvent(m_rootComponent, event);
             }
+        }
+    });
+
+    // Window enter/leave: forwarded to the app layer (AestraWindowManager) so
+    // it can release component cursor styles and stranded drag captures when
+    // the pointer exits the window.
+    m_window->setMouseEnterCallback([this]() {
+        if (m_mouseEnterCallback) {
+            m_mouseEnterCallback();
+        }
+    });
+    m_window->setMouseLeaveCallback([this]() {
+        if (m_mouseLeaveCallback) {
+            m_mouseLeaveCallback();
         }
     });
 
@@ -528,6 +541,14 @@ bool NUIPlatformBridge::makeContextCurrent() {
 
 void NUIPlatformBridge::setMouseMoveCallback(std::function<void(int, int)> callback) {
     m_mouseMoveCallback = callback;
+}
+
+void NUIPlatformBridge::setMouseEnterCallback(std::function<void()> callback) {
+    m_mouseEnterCallback = std::move(callback);
+}
+
+void NUIPlatformBridge::setMouseLeaveCallback(std::function<void()> callback) {
+    m_mouseLeaveCallback = std::move(callback);
 }
 
 void NUIPlatformBridge::setMouseButtonCallback(std::function<void(int, bool)> callback) {

--- a/AestraUI/Platform/NUIPlatformBridge.h
+++ b/AestraUI/Platform/NUIPlatformBridge.h
@@ -3,6 +3,7 @@
 
 #include "../../AestraPlat/include/AestraPlatform.h"
 #include "NUICursorService.h"
+#include "NUICursorStyle.h"
 #include "NUITypes.h"
 #include <functional>
 
@@ -11,27 +12,6 @@ namespace AestraUI {
 // Forward declarations
 class NUIRenderer;
 class NUIComponent;
-
-/**
- * Cursor styles for setCursorStyle()
- */
-enum class NUICursorStyle {
-    Arrow,          // Default arrow cursor
-    Hand,           // Pointing hand (for clickable elements)
-    IBeam,          // Text input cursor
-    Wait,           // Loading/busy cursor (hourglass/spinner)
-    WaitArrow,      // Arrow with loading indicator
-    Crosshair,      // Precision crosshair
-    ResizeNS,       // North-South resize (vertical)
-    ResizeEW,       // East-West resize (horizontal)
-    ResizeNESW,     // Diagonal resize (NE-SW)
-    ResizeNWSE,     // Diagonal resize (NW-SE)
-    ResizeAll,      // Move/all directions
-    NotAllowed,     // Disabled/not allowed
-    Grab,           // Open hand (ready to grab)
-    Grabbing,       // Closed hand (currently grabbing)
-    Hidden          // No cursor visible
-};
 
 /**
  * Bridge between AestraPlat and AestraUI
@@ -82,6 +62,8 @@ public:
     
     // Event callbacks (AestraUI-style - simplified)
     void setMouseMoveCallback(std::function<void(int, int)> callback);
+    void setMouseEnterCallback(std::function<void()> callback);
+    void setMouseLeaveCallback(std::function<void()> callback);
     void setMouseButtonCallback(std::function<void(int, bool)> callback);
     void setMouseWheelCallback(std::function<void(float)> callback);
     /** Block root-component pointer/text dispatch while an external modal owns input. */
@@ -146,6 +128,8 @@ public:
     bool isCursorCaptureOwner(const NUIComponent* c) const {
         return m_cursorService.isCaptured() && m_cursorCaptureOwner == c;
     }
+    /** True while a drag capture is active (the pointer is intentionally hidden). */
+    bool isCursorCaptured() const { return m_cursorService.isCaptured(); }
 
 private:
     // NUICursorHost backing for m_cursorService: hide/show ride the existing
@@ -219,6 +203,8 @@ private:
     
     // AestraUI-style callbacks
     std::function<void(int, int)> m_mouseMoveCallback;
+    std::function<void()> m_mouseEnterCallback;
+    std::function<void()> m_mouseLeaveCallback;
     std::function<void(int, bool)> m_mouseButtonCallback;
     std::function<void(float)> m_mouseWheelCallback;
     std::function<bool()> m_rootInputBlockedCallback;

--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -12,6 +12,8 @@
 
 namespace AestraUI {
 
+class NUIPlatformBridge; // forward decl (platform bridge for cursor styling)
+
 using PianoRollTool = GlobalTool;
 
 // -----------------------------------------------------------------------------
@@ -66,6 +68,11 @@ public:
 
     void onRender(NUIRenderer& renderer) override;
     bool onMouseEvent(const NUIMouseEvent& event) override;
+    void onMouseEnter() override;
+    void onMouseLeave() override;
+
+    /** @brief Set the platform bridge for hover cursor styling (rubberband). */
+    void setPlatformBridge(NUIPlatformBridge* bridge) { m_platformBridge = bridge; }
 
     /** @brief Set the visible beat window represented by the viewport. */
     void setView(double startBeat, double durationBeat, bool preserveEdge = false);
@@ -80,6 +87,8 @@ public:
     std::function<void(double start, double duration)> onViewChanged; // For Pan/Zoom
 
 private:
+    void updateHoverCursor(const NUIMouseEvent& event);
+
     std::vector<MidiNote> notes_;
     double startBeat_ = 0.0;
     double viewDuration_ = 4.0;
@@ -95,6 +104,8 @@ private:
     double dragStartDuration_;
     
     bool isHovered_ = false;
+
+    NUIPlatformBridge* m_platformBridge = nullptr;
     
     // Helpers
     float beatToX(double beat) const;
@@ -716,6 +727,9 @@ public:
 
     void setPixelsPerBeat(float ppb);
     void setBeatsPerBar(int bpb);
+    /** @brief Scrollable domain end in beats (16-bar empty floor, dynamic with
+     *  content — Track Manager parity). */
+    double getScrollDomainEndBeats() const { return m_scrollDomainEndBeats; }
 
     // Global Control API
     void setTool(GlobalTool tool);
@@ -739,6 +753,7 @@ private:
     std::shared_ptr<PianoRollToolbar> m_toolbar;
     
     std::shared_ptr<NUIScrollbar> m_vScroll; // Vertical Scrollbar still standard
+    std::shared_ptr<NUIScrollbar> m_hScroll; // Horizontal Scrollbar (timeline parity)
 
     float m_keyLaneWidth;
     float m_rulerHeight;
@@ -754,6 +769,10 @@ private:
     double m_playheadBeat = 0.0;
     double m_totalDurationBeats = 400.0;
     double m_patternLengthBeats = 8.0;
+    // Scrollable domain (bars the user can traverse), mirroring the Track
+    // Manager's smart domain: 16 bars when empty, growing with content.
+    double m_scrollDomainEndBeats = 0.0;
+    int m_beatsPerBar = 4;
     bool m_showLocalMinimap = true;
     bool m_showShortcutHelp = false;
 
@@ -768,6 +787,8 @@ private:
     void syncChildren();
     void layoutChildren();
     void updateScrollbars(); // Renamed to updateNavigation?
+    void updateScrollbarDomain();
+    float horizontalScrollMax() const;
     void renderShortcutHelp(NUIRenderer& renderer);
     void applyZoom(float factor, float anchorX);
 };

--- a/AestraUI/Widgets/PianoRollMinimap.cpp
+++ b/AestraUI/Widgets/PianoRollMinimap.cpp
@@ -212,7 +212,9 @@ void PianoRollMinimap::onMouseEnter() {
 }
 
 void PianoRollMinimap::onMouseLeave() {
-    if (m_platformBridge) {
+    // Preserve the interaction cursor while a drag is active; only a parked
+    // pointer yields to the default.
+    if (m_platformBridge && !isDragging_) {
         m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
     }
     NUIComponent::onMouseLeave();
@@ -273,6 +275,9 @@ bool PianoRollMinimap::onMouseEvent(const NUIMouseEvent& event) {
         isDragging_ = false;
         isResizingL_ = false;
         isResizingR_ = false;
+        // Re-resolve the cursor for the release position now that the drag
+        // flags are clear (updateHoverCursor skips while dragging).
+        updateHoverCursor(event);
         return true;
     }
     else if (!event.pressed && isDragging_) {

--- a/AestraUI/Widgets/PianoRollMinimap.cpp
+++ b/AestraUI/Widgets/PianoRollMinimap.cpp
@@ -3,6 +3,7 @@
 #include "NUIPianoRollWidgets.h"
 #include "NUIRenderer.h"
 #include "NUIThemeSystem.h"
+#include "../Platform/NUIPlatformBridge.h"
 #include "PianoRollWidgetShared.h"
 #include <algorithm>
 #include <cmath>
@@ -82,7 +83,7 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
     auto b = getBounds();
     auto& theme = NUIThemeManager::getInstance();
     
-    const auto panelBg = theme.getColor("backgroundPrimary").darkened(0.03f);
+    const auto panelBg = theme.getColor("recessedPanel");
     const auto border = theme.getColor("border").withAlpha(0.48f);
     renderer.fillRoundedRect(NUIRect(b.x + 4.0f, b.y + 3.0f, b.width - 8.0f, b.height - 6.0f), 5.0f, panelBg);
     renderer.strokeRoundedRect(NUIRect(b.x + 4.0f, b.y + 3.0f, b.width - 8.0f, b.height - 6.0f), 5.0f, 1.0f, border);
@@ -92,11 +93,14 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
     float w = beatToX(viewDuration_);
     NUIRect viewRect(x1, b.y + 2, w, b.height - 4);
     
-    auto thumbCol = theme.getColor("accentPrimary").withAlpha(0.13f);
-    auto borderCol = theme.getColor("accentPrimary").withAlpha(0.72f);
+    // Navigation chrome, matching the Track Manager minimap: the viewport is a
+    // neutral frame (transparent fill, grey outline, light edge grips) — not a
+    // purple range. Semantic accent colors are reserved for musical content.
+    const auto viewOutline = NUIColor(0.31f, 0.33f, 0.37f, 1.0f);
+    const auto viewHandle = NUIColor(0.62f, 0.64f, 0.68f, 0.92f);
     
-    renderer.fillRoundedRect(viewRect, 5.0f, thumbCol);
-    renderer.strokeRoundedRect(viewRect, 5.0f, 1.0f, borderCol);
+    renderer.fillRoundedRect(viewRect, 5.0f, NUIColor::transparent());
+    renderer.strokeRoundedRect(viewRect, 5.0f, 1.0f, viewOutline);
 
     renderer.setClipRect(NUIRect(b.x + 2.0f, b.y + 2.0f, b.width - 4.0f, b.height - 4.0f));
     int minPitch = 127;
@@ -138,23 +142,28 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
     }
     renderer.clearClipRect();
 
-    const auto playheadColor = NUIThemeManager::getInstance().getColor("accentPrimary");
+    const auto playheadColor = theme.getColor("textPrimary").withAlpha(0.85f);
+    const auto playheadDark = theme.getColor("shadow").withAlpha(0.75f);
     const float playheadX = b.x + beatToX(playheadBeat_);
     if (playheadX >= b.x && playheadX <= b.x + b.width) {
         renderer.drawLine(NUIPoint(playheadX, b.y + 1.0f),
                           NUIPoint(playheadX, b.y + b.height - 1.0f),
-                          2.0f,
-                          playheadColor.withAlpha(0.9f));
+                          3.0f,
+                          playheadDark);
+        renderer.drawLine(NUIPoint(playheadX, b.y + 1.0f),
+                          NUIPoint(playheadX, b.y + b.height - 1.0f),
+                          1.0f,
+                          playheadColor);
     }
     
-    // Handles (Visual only, logic in mouse)
-    const float handleW = 4.0f;
-    const float handleH = std::max(8.0f, b.height - 8.0f);
-    const auto handleFill = borderCol.withAlpha(0.5f);
-    NUIRect leftHandle(x1 + 2.0f, b.y + 4.0f, handleW, handleH);
-    NUIRect rightHandle(x1 + w - 6.0f, b.y + 4.0f, handleW, handleH);
-    renderer.fillRoundedRect(leftHandle, 2.0f, handleFill);
-    renderer.fillRoundedRect(rightHandle, 2.0f, handleFill);
+    // Edge grips — rubberband handles, styled like the Track Manager minimap:
+    // slim vertical bars just inside the viewport frame, vertically centred.
+    const float gripW = 2.0f;
+    const float gripH = std::min(10.0f, std::max(4.0f, viewRect.height - 4.0f));
+    const float gripY = viewRect.y + (viewRect.height - gripH) * 0.5f;
+    const auto gripColor = viewHandle;
+    renderer.fillRoundedRect(NUIRect(viewRect.x + 2.0f, gripY, gripW, gripH), 1.0f, gripColor);
+    renderer.fillRoundedRect(NUIRect(viewRect.right() - gripW - 2.0f, gripY, gripW, gripH), 1.0f, gripColor);
 
     // Bottom border to anchor the overview visually to the ruler beneath it.
     // Color-matched to the ruler tick marks (use the theme border with stronger alpha).
@@ -164,7 +173,53 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
                       theme.getColor("border").withAlpha(0.82f));
 }
 
+void PianoRollMinimap::updateHoverCursor(const NUIMouseEvent& event) {
+    if (!m_platformBridge) {
+        return;
+    }
+    if (isDragging_) {
+        return; // keep the interaction cursor while dragging; next move re-resolves
+    }
+    if (!getBounds().contains(event.position)) {
+        m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
+        return;
+    }
+
+    const auto b = getBounds();
+    const float localX = event.position.x - b.x;
+    const float localY = event.position.y - b.y;
+    const float x1 = beatToX(startBeat_);
+    const float w = beatToX(viewDuration_);
+    constexpr float kHandleW = 10.0f;
+    const NUIRect leftGrip(x1 + 2.0f, 4.0f, kHandleW, b.height - 8.0f);
+    const NUIRect rightGrip(x1 + w - kHandleW - 2.0f, 4.0f, kHandleW, b.height - 8.0f);
+    const NUIRect bar(x1, 2.0f, w, b.height - 4.0f);
+    const NUIPoint localPos(localX, localY);
+
+    // Rubberband affordance: resize cursor on the edge grips, grab on the bar,
+    // default elsewhere (Track Manager minimap behavior).
+    if (leftGrip.contains(localPos) || rightGrip.contains(localPos)) {
+        m_platformBridge->setCursorStyle(NUICursorStyle::ResizeEW);
+    } else if (bar.contains(localPos)) {
+        m_platformBridge->setCursorStyle(NUICursorStyle::Grab);
+    } else {
+        m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
+    }
+}
+
+void PianoRollMinimap::onMouseEnter() {
+    NUIComponent::onMouseEnter();
+}
+
+void PianoRollMinimap::onMouseLeave() {
+    if (m_platformBridge) {
+        m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
+    }
+    NUIComponent::onMouseLeave();
+}
+
 bool PianoRollMinimap::onMouseEvent(const NUIMouseEvent& event) {
+    updateHoverCursor(event);
     if (!getBounds().contains(event.position) && !isDragging_) return false;
 
     auto b = getBounds();
@@ -174,7 +229,9 @@ bool PianoRollMinimap::onMouseEvent(const NUIMouseEvent& event) {
     float x1 = beatToX(startBeat_);
     float w = beatToX(viewDuration_);
     float x2 = x1 + w;
-    const float handleW = 8.0f;
+    // Rubbery edge grips: generous hit area (~10px) so resizing the viewport
+    // is easy to grab, mirroring the Track Manager minimap handles.
+    const float handleW = 10.0f;
     const float handleH = std::max(8.0f, b.height - 8.0f);
     const NUIRect leftHandleRect(x1 + 2.0f, 4.0f, handleW, handleH);
     const NUIRect rightHandleRect(x1 + w - handleW - 2.0f, 4.0f, handleW, handleH);

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -69,7 +69,22 @@ PianoRollView::PianoRollView()
     // Initial default layout config
     m_minimap->setVisible(true);
     m_vScroll->setVisible(true);
-    
+
+    m_hScroll = std::make_shared<NUIScrollbar>(NUIScrollbar::Orientation::Horizontal);
+    m_hScroll->setOrientation(NUIScrollbar::Orientation::Horizontal);
+    {
+        auto& theme = NUIThemeManager::getInstance();
+        m_hScroll->setArrowSize(0.0f);
+        m_hScroll->setBorderWidth(0.0f);
+        m_hScroll->setBorderRadius(8.0f);
+        m_hScroll->setTrackColor(theme.getColor("surfaceRaised").withAlpha(0.55f));
+        m_hScroll->setThumbColor(theme.getColor("textPrimary").withAlpha(0.30f));
+        m_hScroll->setThumbHoverColor(theme.getColor("textPrimary").withAlpha(0.48f));
+        m_hScroll->setThumbPressedColor(theme.getColor("accentPrimary").withAlpha(0.68f));
+        m_hScroll->setMinimumThumbSize(0.06);
+        m_hScroll->setVisible(true);
+    }
+
     // Ruler Zoom Callback
     m_ruler->onZoomRequested = [this](float delta, float mouseX) {
         const float zoomDelta = std::clamp(delta, -4.0f, 4.0f);
@@ -105,6 +120,13 @@ PianoRollView::PianoRollView()
         float maxScroll = std::max(0.0f, totalH - visibleH);
         m_targetScrollY = safeClampRange(static_cast<float>(val), 0.0f, maxScroll);
     });
+
+    // Horizontal scrollbar drives the target scroll across the scrollable
+    // domain (16-bar empty floor, growing with content — Track Manager parity).
+    m_hScroll->setOnScroll([this](double val) {
+        const float maxScrollX = horizontalScrollMax();
+        m_targetScrollX = safeClampRange(static_cast<float>(val), 0.0f, maxScrollX);
+    });
     
     addChild(m_keys);
     addChild(m_ruler);
@@ -113,6 +135,7 @@ PianoRollView::PianoRollView()
     addChild(m_controls);
     addChild(m_minimap);
     addChild(m_vScroll);
+    addChild(m_hScroll);
     addChild(m_toolbar); // Top (Render Last)
 }
 
@@ -316,7 +339,7 @@ void PianoRollView::onUpdate(double deltaTime) {
     const float visibleH = m_grid ? m_grid->getHeight() : 0.0f;
     const float maxScrollY = std::max(0.0f, totalH - visibleH);
     m_targetScrollY = safeClampRange(m_targetScrollY, 0.0f, maxScrollY);
-    m_targetScrollX = std::max(0.0f, m_targetScrollX);
+    m_targetScrollX = safeClampRange(m_targetScrollX, 0.0f, horizontalScrollMax());
 
     bool changed = false;
     const float ease = 1.0f - std::exp(-static_cast<float>(deltaTime) * 18.0f);
@@ -365,8 +388,9 @@ void PianoRollView::layoutChildren() {
     float topTotalH = toolbarH + miniMapH + minimapGap + rulerH;
 
     float keyW = std::max(40.0f, m_keyLaneWidth);
+    const float hScrollH = 12.0f; // Horizontal scrollbar row below the grid
     float contentW = std::max(0.0f, b.width - keyW - sbSize);
-    float contentH = std::max(0.0f, b.height - topTotalH - m_controlPanelHeight); // Subtract control panel
+    float contentH = std::max(0.0f, b.height - topTotalH - m_controlPanelHeight - hScrollH); // Subtract control panel
 
     // 1. Minimap (Top)
     m_minimap->setVisible(m_showLocalMinimap);
@@ -387,17 +411,62 @@ void PianoRollView::layoutChildren() {
     
     // 5. V-Scroll (Right, spans Grid height only)
     m_vScroll->setBounds(NUIRect(b.x + b.width - sbSize, b.y + topTotalH, sbSize, contentH));
+
+    // 5b. H-Scroll (below the grid, spans the content width)
+    if (m_hScroll) {
+        m_hScroll->setBounds(NUIRect(b.x + keyW, b.y + topTotalH + contentH, contentW, hScrollH));
+    }
     
     // 6. Control Panel (Bottom) - Spans Full Width (Keys + Content)
     // Ensures "Control" sidebar aligns with Keys
-    m_controls->setBounds(NUIRect(b.x, b.y + topTotalH + contentH, b.width, m_controlPanelHeight));
+    m_controls->setBounds(NUIRect(b.x, b.y + topTotalH + contentH + hScrollH, b.width, m_controlPanelHeight));
     
     updateScrollbars();
     syncChildren();
 }
 
+float PianoRollView::horizontalScrollMax() const {
+    const float visibleW = m_grid ? m_grid->getWidth() : 0.0f;
+    const float totalW = static_cast<float>(std::max(0.0, m_scrollDomainEndBeats)) * m_pixelsPerBeat;
+    return std::max(0.0f, totalW - visibleW);
+}
+
+void PianoRollView::updateScrollbarDomain() {
+    // Track Manager parity: 16 bars when empty, dynamic padding with content.
+    const double beatsPerBarD = static_cast<double>(std::max(1, m_beatsPerBar));
+    const double contentEnd = std::max(0.0, m_totalDurationBeats);
+    const bool hasContent = m_notes && !m_notes->getNotes().empty();
+
+    double requiredEnd;
+    if (!hasContent) {
+        // Empty: fixed 16-bar floor (matches the Track Manager timeline).
+        requiredEnd = beatsPerBarD * 16.0;
+    } else {
+        const double clipBars = contentEnd / beatsPerBarD;
+        double padBars;
+        if (clipBars < 16.0) {
+            padBars = 8.0;
+        } else if (clipBars < 64.0) {
+            padBars = clipBars * 0.25;
+        } else {
+            padBars = clipBars * 0.125;
+        }
+        requiredEnd = contentEnd + beatsPerBarD * padBars;
+    }
+
+    if (m_scrollDomainEndBeats <= 0.0 || requiredEnd > m_scrollDomainEndBeats + 1e-3) {
+        m_scrollDomainEndBeats = requiredEnd;
+    } else if (requiredEnd < m_scrollDomainEndBeats - 1e-3) {
+        // Shrink is allowed once content exists (Track Manager parity); the
+        // 16-bar floor applies to the empty case only.
+        m_scrollDomainEndBeats = std::max(requiredEnd, 0.0);
+    }
+}
+
 void PianoRollView::updateScrollbars() {
-    float totalBeats = static_cast<float>(std::max(4.0, m_totalDurationBeats));
+    updateScrollbarDomain();
+
+    float totalBeats = static_cast<float>(m_scrollDomainEndBeats);
     float visibleW = m_grid->getWidth();
     double viewDur = visibleW / m_pixelsPerBeat;
     double start = m_scrollX / m_pixelsPerBeat;
@@ -405,6 +474,12 @@ void PianoRollView::updateScrollbars() {
     if (m_minimap && m_showLocalMinimap) {
         m_minimap->setTotalDuration(totalBeats);
         m_minimap->setView(start, viewDur);
+    }
+
+    if (m_hScroll) {
+        const double totalW = static_cast<double>(m_scrollDomainEndBeats) * m_pixelsPerBeat;
+        m_hScroll->setRangeLimit(0.0, totalW);
+        m_hScroll->setCurrentRange(m_scrollX, visibleW);
     }
 
     // Vertical
@@ -527,10 +602,13 @@ bool PianoRollView::onMouseEvent(const NUIMouseEvent& event) {
         if (ctrl) {
             // Zoom (Fallback) — same anchored, multiplicative semantics as the ruler.
             // The ruler passes grid-local X (its bounds start after the key lane);
-            // mirror that basis or the beat under the cursor drifts with the lane width.
+            // mirror that basis or the beat under the cursor drifts with the lane
+            // width. Bounds are window-absolute, so grid-local X is the event X
+            // minus the grid's own origin — subtracting getBounds() as well would
+            // double-count the view position and desync the anchor whenever the
+            // piano-roll panel sits away from the window origin.
             const float zoomDelta = std::clamp(event.wheelDelta, -4.0f, 4.0f);
-            applyZoom(std::pow(1.15f, zoomDelta),
-                      event.position.x - getBounds().x - m_grid->getBounds().x);
+            applyZoom(std::pow(1.15f, zoomDelta), event.position.x - m_grid->getBounds().x);
         } else if (shift) {
             // H-Scroll
             m_targetScrollX = std::max(0.0f, m_targetScrollX - event.wheelDelta * 40.0f);
@@ -576,6 +654,8 @@ void PianoRollView::setNotes(const std::vector<MidiNote>& notes) {
     if (m_minimap) {
         m_minimap->setNotes(notes);
     }
+    // Content changed → the scrollable domain floor/growth may change.
+    updateScrollbars();
 }
 
 void PianoRollView::setGhostPatterns(const std::vector<PianoRollNoteLayer::GhostPattern>& ghosts) {
@@ -626,10 +706,12 @@ void PianoRollView::setPixelsPerBeat(float ppb) {
 }
 
 void PianoRollView::setBeatsPerBar(int bpb) {
+    m_beatsPerBar = std::max(1, bpb);
     if (m_grid) m_grid->setBeatsPerBar(bpb);
     if (m_ruler) m_ruler->setBeatsPerBar(bpb);
     if (m_notes) m_notes->setBeatsPerBar(bpb);
     if (m_controls) m_controls->setBeatsPerBar(bpb);
+    updateScrollbarDomain();
 }
 
 void PianoRollView::setTool(GlobalTool tool) {
@@ -668,6 +750,7 @@ void PianoRollView::setOnHarmonyContextChanged(std::function<void(int, ScaleType
 
 void PianoRollView::setPlatformBridge(NUIPlatformBridge* bridge) {
     if (m_notes) m_notes->setPlatformBridge(bridge);
+    if (m_minimap) m_minimap->setPlatformBridge(bridge);
 }
 
 void PianoRollView::setPatternName(const std::string& name) {
@@ -806,10 +889,7 @@ void PianoRollView::applyEdgeAutoScroll(float scrollX, float scrollY) {
     const float totalH = 128.0f * m_keyHeight;
     const float visibleH = m_grid ? m_grid->getHeight() : 0.0f;
     const float maxScrollY = std::max(0.0f, totalH - visibleH);
-    const float visibleW = m_grid ? m_grid->getWidth() : 0.0f;
-    const double dynamicTotalBeats = std::max(std::max(4.0, m_totalDurationBeats), getViewDurationBeats() + 8.0);
-    const float totalW = static_cast<float>(dynamicTotalBeats) * m_pixelsPerBeat;
-    const float maxScrollX = std::max(0.0f, totalW - visibleW);
+    const float maxScrollX = horizontalScrollMax();
 
     m_scrollX = safeClampScroll(scrollX, maxScrollX);
     m_scrollY = safeClampScroll(scrollY, maxScrollY);

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -711,7 +711,9 @@ void PianoRollView::setBeatsPerBar(int bpb) {
     if (m_ruler) m_ruler->setBeatsPerBar(bpb);
     if (m_notes) m_notes->setBeatsPerBar(bpb);
     if (m_controls) m_controls->setBeatsPerBar(bpb);
-    updateScrollbarDomain();
+    // Full refresh so the h-scrollbar and minimap pick up the new domain
+    // immediately (updateScrollbarDomain alone only mutates the value).
+    updateScrollbars();
 }
 
 void PianoRollView::setTool(GlobalTool tool) {

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -592,4 +592,17 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
     return false;
 }
 
+void UIMixerFader::onMouseEnter()
+{
+    // Hand/grab affordance: the fader is draggable (mixer hand-tool parity).
+    if (m_platformBridge) m_platformBridge->setCursorStyle(NUICursorStyle::Grab);
+    NUIComponent::onMouseEnter();
+}
+
+void UIMixerFader::onMouseLeave()
+{
+    if (m_platformBridge && !m_dragging) m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
+    NUIComponent::onMouseLeave();
+}
+
 } // namespace AestraUI

--- a/AestraUI/Widgets/UIMixerFader.cpp
+++ b/AestraUI/Widgets/UIMixerFader.cpp
@@ -594,9 +594,13 @@ bool UIMixerFader::onMouseEvent(const NUIMouseEvent& event)
 
 void UIMixerFader::onMouseEnter()
 {
-    // Hand/grab affordance: the fader is draggable (mixer hand-tool parity).
-    if (m_platformBridge) m_platformBridge->setCursorStyle(NUICursorStyle::Grab);
     NUIComponent::onMouseEnter();
+    // Hand/grab affordance: the fader is draggable (mixer hand-tool parity).
+    // Never override a Hidden cursor mid-capture (captured fader drags keep
+    // the pointer hidden via the cursor service).
+    if (m_platformBridge && m_platformBridge->getCursorStyle() != NUICursorStyle::Hidden) {
+        m_platformBridge->setCursorStyle(NUICursorStyle::Grab);
+    }
 }
 
 void UIMixerFader::onMouseLeave()

--- a/AestraUI/Widgets/UIMixerFader.h
+++ b/AestraUI/Widgets/UIMixerFader.h
@@ -36,6 +36,8 @@ public:
     void onThemeChanged(const NUIThemeProperties& theme) override { cacheThemeColors(); NUIComponent::onThemeChanged(theme); }
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
+    void onMouseEnter() override;
+    void onMouseLeave() override;
 
     void setRangeDb(float minDb, float maxDb);
     void setDefaultDb(float db) { m_defaultDb = db; }

--- a/AestraUI/Widgets/UIMixerPanel.cpp
+++ b/AestraUI/Widgets/UIMixerPanel.cpp
@@ -11,6 +11,7 @@
 #include "Commands/SetMuteCommand.h"
 #include "Commands/SetSoloCommand.h"
 #include "Commands/SetPanCommand.h"
+#include "Commands/SetTrimCommand.h"
 #include "Commands/SetMonitoringCommand.h"
 #include "TrackManager.h"
 #include "PluginManager.h"
@@ -187,6 +188,18 @@ void UIMixerPanel::refreshChannels()
 
             m_trackManager->getCommandHistory().pushAndExecute(
                 std::make_shared<Aestra::Audio::SetPanCommand>(*m_trackManager, *mixerChannel, pan));
+        };
+
+        // Wire trim to CommandHistory for undo/redo + serialization parity.
+        // The slot index comes from the strip's view model (same buffer the
+        // knob writes for the live RT value).
+        strip->onTrimChanged = [this, chId](float db, uint32_t slotIndex) {
+            if (!m_trackManager) return;
+            auto* mixerChannel = m_trackManager->getChannelById(chId);
+            if (!mixerChannel) return;
+
+            m_trackManager->getCommandHistory().pushAndExecute(
+                std::make_shared<Aestra::Audio::SetTrimCommand>(*m_trackManager, *mixerChannel, slotIndex, db));
         };
 
         // Wire input monitoring to CommandHistory for undo/redo + dirty parity

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -31,14 +31,17 @@ namespace {
     constexpr float SECTION_GAP = 8.0f;
     constexpr float METER_W = 22.0f;
     constexpr float MASTER_METER_W = 36.0f;
-    // Technical master readouts are contextual (meter hover/interaction), not
-    // a permanent dashboard below the signal controls.
+    // Technical master readouts (held peak dBFS, integrated LUFS, gain) are a
+    // permanent fixture under the master's meter/fader columns — the master
+    // strip has no footer, so this is the strip's live level dashboard.
     constexpr float MASTER_LABEL_H = 12.0f;
     constexpr float MASTER_VALUE_H = 14.0f;
     constexpr float MASTER_BLOCK_H = MASTER_LABEL_H + MASTER_VALUE_H;  // 26
-    // Two stacked blocks plus bottom slack. With only 4px of slack the second
-    // value landed on the strip's bottom edge and was not drawn at all.
-    constexpr float MASTER_READOUT_H = 0.0f;
+    // The master reserves a labelled Peak/LUFS/Gain block at the foot of the
+    // strip (its footer is hidden, so the space is otherwise dead). Two stacked
+    // blocks plus bottom slack: with only 4px of slack the second value landed
+    // on the strip's bottom edge and was not drawn at all.
+    constexpr float MASTER_READOUT_H = MASTER_BLOCK_H * 2.0f + 14.0f;
 
     constexpr float SELECT_TOP_H = 3.0f;
     constexpr float MIXER_MIN_CHANNEL_HEIGHT = 220.0f;

--- a/AestraUI/Widgets/UIMixerStrip.cpp
+++ b/AestraUI/Widgets/UIMixerStrip.cpp
@@ -240,6 +240,10 @@ UIMixerStrip::UIMixerStrip(uint32_t channelId,
 
         channel->trimDb = db;
         m_continuousParams->setTrimDb(channel->slotIndex, db);
+
+        // Undo/redo parity with pan: route through the command history so the
+        // serialized MixerChannel state and the RT buffer move together.
+        if (onTrimChanged) onTrimChanged(db, channel->slotIndex);
     };
     addChild(m_trimKnob);
 

--- a/AestraUI/Widgets/UIMixerStrip.h
+++ b/AestraUI/Widgets/UIMixerStrip.h
@@ -65,6 +65,8 @@ public:
     std::function<void(bool muted)> onMuteChanged;
     std::function<void(bool soloed)> onSoloChanged;
     std::function<void(float pan)> onPanChanged;
+    /** @brief Trim knob moved: (trimDb, slotIndex). Wired to SetTrimCommand. */
+    std::function<void(float db, uint32_t slotIndex)> onTrimChanged;
     std::function<void(bool monitored)> onMonitorToggled;
 
 private:

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -645,12 +645,17 @@ void AestraApp::buildMenuBar() {
                                                        sizeof("Aestra Project\0*.aes\0All Files\0*.*\0") - 1);
                 const std::string pickedPath = utils->openFileDialog("Open Project", filter);
                 if (!pickedPath.empty() && std::filesystem::exists(pickedPath)) {
-                    // Leaving the current session: discard its unsaved takes
-                    // BEFORE the document path switch (the keep-check below
-                    // still sees the old project file).
-                    cleanupUnreferencedRecordings();
+                    // Old session's keeper path: captured BEFORE the load, so
+                    // discarded-take cleanup (run only on a successful switch)
+                    // keeps exactly the previous project's recordings.
+                    const std::string oldKeeperPath = m_documentState.canonicalPath();
                     auto result = loadProjectFromPath(pickedPath);
-                    if (!result.ok) {
+                    if (result.ok) {
+                        // Cleanup runs only after the transition SUCCEEDED: the
+                        // old session's redo history may still require its WAVs
+                        // if the new project failed to load.
+                        cleanupUnreferencedRecordings(oldKeeperPath);
+                    } else {
                         Log::error("Failed to load project: " + pickedPath + " (" + result.errorMessage + ")");
                     }
                 }
@@ -1374,7 +1379,7 @@ void AestraApp::startMuseSocketIfConfigured() {
     }
 }
 
-void AestraApp::cleanupUnreferencedRecordings() {
+void AestraApp::cleanupUnreferencedRecordings(const std::string& keeperProjectPath) {
     if (!m_content) {
         return;
     }
@@ -1384,8 +1389,10 @@ void AestraApp::cleanupUnreferencedRecordings() {
     }
     // A saved project owns its recording assets: anything the on-disk project
     // file still references is kept. For an unsaved session the keeper is
-    // absent, so discarded takes become cleanup candidates.
-    const std::string projectPath = m_documentState.canonicalPath();
+    // absent, so discarded takes become cleanup candidates. The keeper file can
+    // be overridden to the PREVIOUS project path after a successful Open, when
+    // the document path has already switched to the newly loaded project.
+    const std::string projectPath = !keeperProjectPath.empty() ? keeperProjectPath : m_documentState.canonicalPath();
     std::function<bool(const std::string&)> keepCheck;
     if (!projectPath.empty()) {
         keepCheck = [projectPath](const std::string& path) {

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1399,7 +1399,17 @@ void AestraApp::cleanupUnreferencedRecordings(const std::string& keeperProjectPa
             return pathAppearsInFile(projectPath, path);
         };
     }
-    trackManager->cleanupOrphanedRecordings(keepCheck);
+    const auto removed = trackManager->cleanupOrphanedRecordings(keepCheck);
+    if (!removed.has_value()) {
+        // Realtime misuse: refused rather than attempted (never expected on the
+        // UI thread). Observable instead of silently conflated with a
+        // zero-file cleanup.
+        Log::warning("[AestraApp] Recording cleanup refused: called from the realtime thread");
+        return;
+    }
+    if (*removed > 0) {
+        Log::info("[AestraApp] Removed " + std::to_string(*removed) + " orphaned recording file(s)");
+    }
 }
 
 void AestraApp::shutdown() {

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -31,6 +31,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <chrono>
 #include "../Core/AudioSettingsStore.h"
 #include "PlaylistMixer.h"
@@ -66,6 +67,26 @@ void syncRecordingProjectPath(const std::shared_ptr<AestraContent>& content, con
     if (auto trackManager = content->getTrackManager()) {
         trackManager->setRecordingProjectPath(projectPath);
     }
+}
+
+/** @brief True when @p filePath's text contains @p needle (generic path form).
+ *
+ *  Project/autosave JSON stores recording paths as generic (forward-slash)
+ *  strings. A contains-check is deliberately permissive: a false positive
+ *  merely keeps a recording file, never deletes one. */
+bool pathAppearsInFile(const std::string& filePath, const std::string& needle) {
+    std::error_code ec;
+    if (!std::filesystem::exists(filePath, ec)) {
+        return false;
+    }
+    std::ifstream in(filePath, std::ios::in | std::ios::binary);
+    if (!in) {
+        return false;
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    const std::string generic = std::filesystem::path(needle).generic_string();
+    return buffer.str().find(generic) != std::string::npos;
 }
 
 }
@@ -606,6 +627,8 @@ void AestraApp::buildMenuBar() {
 
         menu->addItem("New Project", [this]() {
             if (m_content && m_content->getTrackManager()) m_content->getTrackManager()->stop();
+            // Leave the old session: discards its unsaved/unreferenced takes.
+            cleanupUnreferencedRecordings();
             if (m_content) m_content->resetToDefaultProject();
             clearProjectLoadReport();
             m_documentState.startUntitled(autosavePathOrEmpty());
@@ -622,6 +645,10 @@ void AestraApp::buildMenuBar() {
                                                        sizeof("Aestra Project\0*.aes\0All Files\0*.*\0") - 1);
                 const std::string pickedPath = utils->openFileDialog("Open Project", filter);
                 if (!pickedPath.empty() && std::filesystem::exists(pickedPath)) {
+                    // Leaving the current session: discard its unsaved takes
+                    // BEFORE the document path switch (the keep-check below
+                    // still sees the old project file).
+                    cleanupUnreferencedRecordings();
                     auto result = loadProjectFromPath(pickedPath);
                     if (!result.ok) {
                         Log::error("Failed to load project: " + pickedPath + " (" + result.errorMessage + ")");
@@ -1157,6 +1184,17 @@ void AestraApp::run() {
 
         {
             AESTRA_ZONE("UI_Update");
+
+            // AestraContent is the root content (a raw pointer on the root
+            // component, not a child in the NUI tree), so nothing else pumps
+            // its per-frame update. Without this full-cadence call nothing
+            // drives updatePendingCountIn (count-in → recording start),
+            // sound-preview pumping, or the mixer view-model resync — and it
+            // must live here (not in render), because render is idle-elided.
+            if (m_content) {
+                m_content->onUpdate(m_windowManager ? m_windowManager->getDeltaTime() : (1.0 / 60.0));
+            }
+
             // Sync Transport State
             if (m_audioController->getEngine() && m_content && m_content->getTrackManager()) {
                 auto engine = m_audioController->getEngine();
@@ -1336,6 +1374,27 @@ void AestraApp::startMuseSocketIfConfigured() {
     }
 }
 
+void AestraApp::cleanupUnreferencedRecordings() {
+    if (!m_content) {
+        return;
+    }
+    auto trackManager = m_content->getTrackManager();
+    if (!trackManager) {
+        return;
+    }
+    // A saved project owns its recording assets: anything the on-disk project
+    // file still references is kept. For an unsaved session the keeper is
+    // absent, so discarded takes become cleanup candidates.
+    const std::string projectPath = m_documentState.canonicalPath();
+    std::function<bool(const std::string&)> keepCheck;
+    if (!projectPath.empty()) {
+        keepCheck = [projectPath](const std::string& path) {
+            return pathAppearsInFile(projectPath, path);
+        };
+    }
+    trackManager->cleanupOrphanedRecordings(keepCheck);
+}
+
 void AestraApp::shutdown() {
     Log::info("[SHUTDOWN] Entering shutdown function...");
     Aestra::AppLifecycle::instance().transitionTo(Aestra::AppState::ShuttingDown);
@@ -1354,6 +1413,13 @@ void AestraApp::shutdown() {
         m_autoSaveManager.forceAutosave();
     }
     m_autoSaveManager.shutdown();
+
+    // NOTE: recording cleanup intentionally does NOT run here. Shutdown still
+    // serves crash recovery until clearCrashFlag() (below) — deleting discarded
+    // takes now would leave the just-written emergency autosave referencing
+    // files that no longer exist if this process dies before the flag clears.
+    // Discarded takes are removed at the next project new/open transition,
+    // where no recovery is pending and the on-disk project is the keeper.
 
     // Save preferences and UI state (Issue #120)
     Preferences::instance().save();

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -142,8 +142,10 @@ private:
      *  boundaries, where no crash recovery is pending and the on-disk project
      *  is the keeper — never at shutdown, which may still serve recovery.
      *  Files referenced by a live clip or by the saved project on disk are
-     *  always kept. */
-    void cleanupUnreferencedRecordings();
+     *  always kept. @p keeperProjectPath overrides the project file consulted
+     *  as the on-disk keeper (used after a successful Open, where the document
+     *  path has already moved to the newly loaded project). */
+    void cleanupUnreferencedRecordings(const std::string& keeperProjectPath = "");
     static std::string getRecoveryMarkerPath(const std::string& autosavePath);
     static std::string readCrashFlagToken();
     static std::string readRecoveryOriginalProjectPath(const std::string& recoveryMarkerPath,

--- a/Source/App/AestraApp.h
+++ b/Source/App/AestraApp.h
@@ -137,6 +137,13 @@ private:
     void applyUIState(const ProjectSerializer::UIState& state);
     void updateWindowTitle();
     void startExport();
+    /** @brief Delete recording files this session can no longer reference
+     *  (discarded takes in unsaved projects). Runs at project New/Open
+     *  boundaries, where no crash recovery is pending and the on-disk project
+     *  is the keeper — never at shutdown, which may still serve recovery.
+     *  Files referenced by a live clip or by the saved project on disk are
+     *  always kept. */
+    void cleanupUnreferencedRecordings();
     static std::string getRecoveryMarkerPath(const std::string& autosavePath);
     static std::string readCrashFlagToken();
     static std::string readRecoveryOriginalProjectPath(const std::string& recoveryMarkerPath,

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -2054,10 +2054,17 @@ bool FileBrowser::handleListMouse(const NUIMouseEvent& event, const std::vector<
                 }
             }
 
-            // Grabbable row: file/dir rows are draggable into the timeline and
-            // clickable — surface the hand tool (Track Manager minimap parity).
+            // Cursor affordance aligned with the actual drag initiation gate
+            // (handleDragInitiation: non-directory, non-placeholder, allowed
+            // files only): Grab on rows that can start a drag, Hand on other
+            // selectable rows, Arrow elsewhere.
             if (m_platformBridge) {
-                m_platformBridge->setCursorStyle(hoveredIndex_ >= 0 ? NUICursorStyle::Grab : NUICursorStyle::Arrow);
+                const FileItem* hoveredItem =
+                    hoveredIndex_ >= 0 && hoveredIndex_ < static_cast<int>(view.size()) ? view[hoveredIndex_] : nullptr;
+                const bool canDrag = hoveredItem && !hoveredItem->isDirectory && !hoveredItem->isPlaceholder &&
+                                     FileFilter::isAllowed(hoveredItem->path);
+                m_platformBridge->setCursorStyle(canDrag ? NUICursorStyle::Grab
+                                                         : hoveredItem ? NUICursorStyle::Hand : NUICursorStyle::Arrow);
             }
 
 	        // Context menu (right-click)

--- a/Source/Components/FileBrowser.cpp
+++ b/Source/Components/FileBrowser.cpp
@@ -2004,6 +2004,7 @@ bool FileBrowser::handleListMouse(const NUIMouseEvent& event, const std::vector<
                 hoveredIndex_ = -1;
                 setDirty(true); // hover overlay only — no cache rebuild
             }
+            if (m_platformBridge) m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
             if (!browserLayout.navPane.contains(event.position)) {
                 AestraUI::NUIComponent::hideRemoteTooltip(this);
             }
@@ -2051,6 +2052,12 @@ bool FileBrowser::handleListMouse(const NUIMouseEvent& event, const std::vector<
                 if (item && item->isTruncated) {
                     AestraUI::NUIComponent::showRemoteTooltip(item->name, event.position, this);
                 }
+            }
+
+            // Grabbable row: file/dir rows are draggable into the timeline and
+            // clickable — surface the hand tool (Track Manager minimap parity).
+            if (m_platformBridge) {
+                m_platformBridge->setCursorStyle(hoveredIndex_ >= 0 ? NUICursorStyle::Grab : NUICursorStyle::Arrow);
             }
 
 	        // Context menu (right-click)
@@ -2418,6 +2425,7 @@ void FileBrowser::onMouseLeave() {
         setDirty(true); // hover overlay only — no cache rebuild
     }
     NUIComponent::hideRemoteTooltip(this);
+    if (m_platformBridge) m_platformBridge->setCursorStyle(NUICursorStyle::Arrow);
     NUIComponent::onMouseLeave();
 }
 

--- a/Source/Components/FileBrowser.h
+++ b/Source/Components/FileBrowser.h
@@ -21,6 +21,7 @@ namespace AestraUI {
 
 class NUIContextMenu;
 class NUITextInput;
+class NUIPlatformBridge;
 
 /**
  * File type enumeration for proper icon display
@@ -105,6 +106,9 @@ public:
     bool onMouseEvent(const NUIMouseEvent& event) override;
     bool onKeyEvent(const NUIKeyEvent& event) override;
     void onMouseLeave() override;
+
+    /** @brief Set the platform bridge for hover cursor styling (grab on rows). */
+    void setPlatformBridge(NUIPlatformBridge* bridge) { m_platformBridge = bridge; }
     
     // File browser functionality
     void setCurrentPath(const std::string& path);
@@ -422,6 +426,7 @@ public:
 	    // Hover state
 	    int hoveredIndex_;
 	    NUIPoint lastMousePos_{0.0f, 0.0f};
+	    NUIPlatformBridge* m_platformBridge = nullptr;
     
 	    // Search/filter state
 	    std::shared_ptr<NUITextInput> searchInput_; // Replaced searchQuery_, searchBoxFocused_, searchCaretBlinkTime_, searchCaretVisible_

--- a/Source/Components/MixerView.cpp
+++ b/Source/Components/MixerView.cpp
@@ -84,6 +84,9 @@ ChannelStrip::ChannelStrip(std::shared_ptr<MixerChannel> track, TrackManager* tr
 void ChannelStrip::setPlatformBridge(AestraUI::NUIPlatformBridge* bridge)
 {
     m_platformBridge = bridge;
+    if (m_volumeFader) {
+        m_volumeFader->setPlatformBridge(bridge);
+    }
     if (m_panKnob) {
         m_panKnob->setPlatformBridge(bridge);
     }

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -541,6 +541,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
 
     // Edge hover (resize affordance + cursor hint).
     hoverOnResizeEdge_ = false;
+    hoverOnViewport_ = false;
     if (!viewRect.isEmpty() && layout.mapRect.contains(event.position)) {
         if (event.position.y >= viewRect.y && event.position.y <= viewRect.bottom()) {
             const float dxL = std::fabs(event.position.x - viewRect.x);
@@ -550,6 +551,9 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
                 hoverOnResizeEdge_ = true;
                 hoverResizeEdge_ =
                     (dxL <= dxR) ? TimelineMinimapResizeEdge::Left : TimelineMinimapResizeEdge::Right;
+            } else if (viewRect.contains(event.position)) {
+                // Bar body: the viewport itself is the pan/grab interaction.
+                hoverOnViewport_ = true;
             }
         }
     }

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -496,6 +496,8 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
 
     if (!layout.mapRect.contains(event.position) && dragKind_ == DragKind::None) {
         hoverOnViewport_ = false;
+        hoverOnResizeEdge_ = false;
+        cursorHint_ = TimelineMinimapCursorHint::Default;
         return NUIComponent::onMouseEvent(event);
     }
 

--- a/Source/Components/TimelineMinimapBar.cpp
+++ b/Source/Components/TimelineMinimapBar.cpp
@@ -385,6 +385,7 @@ void TimelineMinimapBar::onMouseLeave()
     hoverInMap_ = false;
     hoverToggleIndex_ = -1;
     hoverOnResizeEdge_ = false;
+    hoverOnViewport_ = false;
     AestraUI::NUIComponent::hideRemoteTooltip(this);
     if (dragKind_ == DragKind::ResizeLeft || dragKind_ == DragKind::ResizeRight) {
         cursorHint_ = TimelineMinimapCursorHint::ResizeHorizontal;
@@ -408,6 +409,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
         hoverInMap_ = false;
         hoverToggleIndex_ = -1;
         hoverOnResizeEdge_ = false;
+        hoverOnViewport_ = false;
         cursorHint_ = TimelineMinimapCursorHint::Default;
         AestraUI::NUIComponent::hideRemoteTooltip(this);
         repaint();
@@ -480,6 +482,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
     const TimelineSummary* s = (model_.summary) ? model_.summary->summary : nullptr;
     if (!s) {
         hoverOnResizeEdge_ = false;
+        hoverOnViewport_ = false;
         cursorHint_ = (dragKind_ == DragKind::ResizeLeft || dragKind_ == DragKind::ResizeRight)
                           ? TimelineMinimapCursorHint::ResizeHorizontal
                           : TimelineMinimapCursorHint::Default;
@@ -492,6 +495,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
     }
 
     if (!layout.mapRect.contains(event.position) && dragKind_ == DragKind::None) {
+        hoverOnViewport_ = false;
         return NUIComponent::onMouseEvent(event);
     }
 
@@ -500,6 +504,7 @@ bool TimelineMinimapBar::onMouseEvent(const NUIMouseEvent& event)
     const double denom = domainEnd - domainStart;
     if (!(denom > 1e-9)) {
         hoverOnResizeEdge_ = false;
+        hoverOnViewport_ = false;
         cursorHint_ = TimelineMinimapCursorHint::Default;
         if (dragKind_ != DragKind::None && event.released && event.button == NUIMouseButton::Left) {
             dragKind_ = DragKind::None;

--- a/Source/Components/TimelineMinimapBar.h
+++ b/Source/Components/TimelineMinimapBar.h
@@ -42,9 +42,10 @@ public:
     TimelineMinimapCursorHint getCursorHint() const { return cursorHint_; }
     /** @brief True while the viewport bar body is the interaction (pan/grab)
      *  — hover inside the bar, or actively dragging it. Resize edges are
-     *  excluded (their hint is ResizeHorizontal). */
+     *  excluded (their hint is ResizeHorizontal). Gated on visibility: a hidden
+     *  minimap stops receiving events and its hover state freezes. */
     bool isViewportPanActive() const {
-        return dragKind_ == DragKind::Viewport || hoverOnViewport_;
+        return isVisible() && (dragKind_ == DragKind::Viewport || hoverOnViewport_);
     }
     /** @brief Enable or disable the top-left mode toggles. */
     void setShowModeToggles(bool show) { showModeToggles_ = show; repaint(); }

--- a/Source/Components/TimelineMinimapBar.h
+++ b/Source/Components/TimelineMinimapBar.h
@@ -40,6 +40,12 @@ public:
     const TimelineMinimapModel& getModel() const { return model_; }
     /** @brief Get the current cursor hint for the host UI. */
     TimelineMinimapCursorHint getCursorHint() const { return cursorHint_; }
+    /** @brief True while the viewport bar body is the interaction (pan/grab)
+     *  — hover inside the bar, or actively dragging it. Resize edges are
+     *  excluded (their hint is ResizeHorizontal). */
+    bool isViewportPanActive() const {
+        return dragKind_ == DragKind::Viewport || hoverOnViewport_;
+    }
     /** @brief Enable or disable the top-left mode toggles. */
     void setShowModeToggles(bool show) { showModeToggles_ = show; repaint(); }
     /** @brief Set an additional leading inset applied before the minimap content. */
@@ -86,6 +92,7 @@ private:
     TimelineMinimapCursorHint cursorHint_{TimelineMinimapCursorHint::Default};
     TimelineMinimapResizeEdge hoverResizeEdge_{TimelineMinimapResizeEdge::Left};
     bool hoverOnResizeEdge_ = false;
+    bool hoverOnViewport_ = false;
 
     DragKind dragKind_ = DragKind::None;
     NUIPoint dragStartPos_{};

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -126,6 +126,9 @@ public:
     void setOnCursorVisibilityChanged(std::function<void(bool)> callback) { m_onCursorVisibilityChanged = callback; }
     bool isMinimapResizeCursorActive() const;
     bool isCustomCursorActive() const; // Returns true if any tool/resize cursor is active
+    /** @brief True while the timeline ruler row is the interaction (playhead
+     *  scrub, loop markers, ruler selection) — grab-hand cursor territory. */
+    bool isRulerPointerActive() const;
 
     // View Toggle Callbacks (v3.1)
     void setOnToggleMixer(std::function<void()> cb) { m_onToggleMixer = cb; }
@@ -362,6 +365,9 @@ private:
     std::shared_ptr<::AestraUI::NUIIcon> m_multiSelectToolIcon;
     std::shared_ptr<::AestraUI::NUIIcon> m_paintToolIcon;  // Paint/stamp tool icon
     std::shared_ptr<::AestraUI::NUIIcon> m_moveCursorIcon; // Move (4-way arrow) cursor for Paint tool hovering clips
+    std::shared_ptr<::AestraUI::NUIIcon> m_trimCursorIcon; // Canonical horizontal stretch cursor (registry SVG)
+    std::shared_ptr<::AestraUI::NUIIcon> m_resizeCursorIcon; // Canonical ResizeEW registry glyph (minimap resize)
+    std::shared_ptr<::AestraUI::NUIIcon> m_grabCursorIcon; // Canonical hand glyph (ruler/minimap-pan grab)
 
     std::shared_ptr<::AestraUI::NUIContextMenu> m_activeContextMenu; // Keep track for cleanup
 

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -438,6 +438,10 @@ void TrackManagerUI::duplicateSelectedClip() {
         }
     }
 
+    // While playing, the scheduler's instance set was built at play() time —
+    // without a reschedule the duplicated pattern stays silent until loop wrap.
+    m_trackManager->refreshTimelinePatternInstances();
+
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
@@ -456,6 +460,10 @@ void TrackManagerUI::onPaintClip(TrackUIComponent* trackComp, double beat) {
     auto cmd = std::make_shared<Aestra::Audio::AddClipCommand>(m_trackManager->getPlaylistModel(),
                                                                trackComp->getLaneId(), newClip);
     m_trackManager->getCommandHistory().pushAndExecute(cmd);
+
+    // Painted clips must be audible immediately while playing (same scheduler
+    // refresh as duplication).
+    m_trackManager->refreshTimelinePatternInstances();
 
     refreshTracks();
     invalidateCache();

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -135,9 +135,15 @@ bool TrackManagerUI::isMinimapResizeCursorActive() const {
 }
 
 bool TrackManagerUI::isRulerPointerActive() const {
-    // While scrubbing/loop-dragging the grab stays even if the pointer leaves
-    // the ruler row.
-    if (m_isDraggingPlayhead || m_isDraggingLoopStart || m_isDraggingLoopEnd) {
+    // A hidden timeline receives no mouse events, so m_lastMousePos freezes at
+    // whatever position it had when the view switched — gating on visibility
+    // keeps a frozen ruler hit from suppressing the cursor in other views.
+    if (!isVisible()) {
+        return false;
+    }
+    // While scrubbing/loop/selection-dragging the grab stays even if the
+    // pointer leaves the ruler row (selection drags extend below the ruler).
+    if (m_isDraggingPlayhead || m_isDraggingLoopStart || m_isDraggingLoopEnd || m_isDraggingRulerSelection) {
         return true;
     }
     const AestraUI::NUIRect bounds = getBounds();
@@ -150,6 +156,11 @@ bool TrackManagerUI::isRulerPointerActive() const {
 
 bool TrackManagerUI::isCustomCursorActive() const {
     // Check if any custom cursor should be displayed (for exclusive cursor rendering)
+    // A hidden timeline receives no events, so every hover state below is frozen
+    // — never claim the cursor from a view that isn't on screen.
+    if (!isVisible()) {
+        return false;
+    }
 
     // 1. Trim edge hover/active
     for (const auto& trackUI : m_trackUIComponents) {

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -6,6 +6,7 @@
 #include "../AestraCore/include/AestraLog.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraUI/Core/NUIDragDrop.h"
+#include "../AestraUI/Core/NUICursorRegistry.h"
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
@@ -85,6 +86,15 @@ void TrackManagerUI::createToolIcons() {
     const char* moveSvg =
         R"(<svg viewBox="0 0 24 24" fill="currentColor"><path d="M11.05 2.2h1.9v19.6h-1.9z"/><path d="M2.2 11.05h19.6v1.9H2.2z"/><path d="M12 1 15.1 5.2H8.9L12 1zm0 22-3.1-4.2h6.2L12 23zM1 12l4.2-3.1v6.2L1 12zm22 0-4.2 3.1V8.9L23 12z"/></svg>)";
     m_moveCursorIcon = std::make_shared<AestraUI::NUIIcon>(moveSvg);
+
+    // Trim-edge stretch cursor: the canonical registry glyph (tinted at render
+    // time), replacing the old ad-hoc drawLine arrow construction.
+    m_trimCursorIcon = std::make_shared<AestraUI::NUIIcon>(AestraUI::nuiTrimResizeCursorSvg());
+    // Minimap window-resize cursor: the canonical high-contrast ResizeEW glyph.
+    m_resizeCursorIcon = std::make_shared<AestraUI::NUIIcon>(AestraUI::nuiCursorSvg(AestraUI::NUICursorStyle::ResizeEW));
+    // Ruler / minimap-pan hand cursor: the canonical grab glyph.
+    m_grabCursorIcon = std::make_shared<AestraUI::NUIIcon>(AestraUI::nuiCursorSvg(AestraUI::NUICursorStyle::Grab));
+
     if (!m_addTrackBtn) {
         m_addTrackBtn = std::make_shared<AestraUI::NUIButton>("");
         m_addTrackBtn->setBackgroundColor(AestraUI::NUIColor::transparent());
@@ -122,6 +132,20 @@ void TrackManagerUI::setCurrentTool(PlaylistTool tool) {
 bool TrackManagerUI::isMinimapResizeCursorActive() const {
     return m_timelineMinimap && m_timelineMinimap->isVisible() &&
            m_timelineMinimap->getCursorHint() == AestraUI::TimelineMinimapCursorHint::ResizeHorizontal;
+}
+
+bool TrackManagerUI::isRulerPointerActive() const {
+    // While scrubbing/loop-dragging the grab stays even if the pointer leaves
+    // the ruler row.
+    if (m_isDraggingPlayhead || m_isDraggingLoopStart || m_isDraggingLoopEnd) {
+        return true;
+    }
+    const AestraUI::NUIRect bounds = getBounds();
+    // Same geometry as the events file's ruler row: below the header +
+    // horizontal scrollbar, ruler-height tall, full width.
+    const AestraUI::NUIRect ruler(bounds.x, bounds.y + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight,
+                                  bounds.width, kTimelineRulerHeight);
+    return ruler.contains(m_lastMousePos);
 }
 
 bool TrackManagerUI::isCustomCursorActive() const {
@@ -168,6 +192,16 @@ bool TrackManagerUI::isCustomCursorActive() const {
             m_timelineMinimap->getCursorHint() == AestraUI::TimelineMinimapCursorHint::ResizeHorizontal) {
             return true;
         }
+    }
+
+    // 4. Minimap viewport bar body (pan) → grab hand.
+    if (m_timelineMinimap && m_timelineMinimap->isVisible() && m_timelineMinimap->isViewportPanActive()) {
+        return true;
+    }
+
+    // 5. Ruler scrub/loop/selection zone → grab hand.
+    if (isRulerPointerActive()) {
+        return true;
     }
 
     return false;
@@ -636,30 +670,32 @@ void TrackManagerUI::renderToolCursor(AestraUI::NUIRenderer& renderer, const Aes
     }
 
     if (isHoveringTrimEdge) {
-        // Render horizontal resize cursor (⬌)
+        // Render horizontal resize cursor — the canonical registry glyph,
+        // tinted for the neutral/trimming states.
         auto& theme = AestraUI::NUIThemeManager::getInstance();
         AestraUI::NUIColor cursorColor =
             isTrimming ? theme.getColor("accentCyan") : theme.getColor("textPrimary").withAlpha(0.78f);
 
-        // Draw left-right arrows (simple ⬌ shape)
-        float cx = position.x;
-        float cy = position.y;
-        float arrowSize = 8.0f;
-
-        // Left arrow
-        renderer.drawLine({cx - arrowSize * 2, cy}, {cx - arrowSize, cy}, 2.0f, cursorColor);
-        renderer.drawLine({cx - arrowSize * 2, cy}, {cx - arrowSize * 1.5f, cy - arrowSize * 0.5f}, 2.0f, cursorColor);
-        renderer.drawLine({cx - arrowSize * 2, cy}, {cx - arrowSize * 1.5f, cy + arrowSize * 0.5f}, 2.0f, cursorColor);
-
-        // Right arrow
-        renderer.drawLine({cx + arrowSize, cy}, {cx + arrowSize * 2, cy}, 2.0f, cursorColor);
-        renderer.drawLine({cx + arrowSize * 2, cy}, {cx + arrowSize * 1.5f, cy - arrowSize * 0.5f}, 2.0f, cursorColor);
-        renderer.drawLine({cx + arrowSize * 2, cy}, {cx + arrowSize * 1.5f, cy + arrowSize * 0.5f}, 2.0f, cursorColor);
-
-        // Center bar
-        renderer.drawLine({cx - arrowSize, cy}, {cx + arrowSize, cy}, 2.0f, cursorColor);
+        if (m_trimCursorIcon) {
+            m_trimCursorIcon->setColor(cursorColor);
+            AestraUI::NUIRect iconRect(position.x - 9, position.y - 9, 18, 18);
+            m_trimCursorIcon->setBounds(iconRect);
+            m_trimCursorIcon->onRender(renderer);
+        }
 
         return; // Skip other tool cursors when resize cursor is active
+    }
+
+    // Ruler scrub/loop zone and minimap viewport-pan → grab hand (the draggable
+    // navigation surfaces). Trim (above), split/paint tools and minimap-edge
+    // resize all take precedence over this.
+    if (isRulerPointerActive() || (m_timelineMinimap && m_timelineMinimap->isVisible() &&
+                                   m_timelineMinimap->isViewportPanActive())) {
+        if (m_grabCursorIcon) {
+            m_grabCursorIcon->setBounds(AestraUI::NUIRect(position.x - 9, position.y - 9, 18, 18));
+            m_grabCursorIcon->onRender(renderer);
+        }
+        return;
     }
 
     // Only render if tool requires custom cursor
@@ -820,43 +856,13 @@ void TrackManagerUI::renderMinimapResizeCursor(AestraUI::NUIRenderer& renderer, 
         return;
     }
 
-    // Render custom resize cursor (system cursor always hidden by Main.cpp)
-
-    auto& themeManager = AestraUI::NUIThemeManager::getInstance();
-    const AestraUI::NUIColor active = themeManager.getColor("borderActive").withAlpha(0.95f);
-    const AestraUI::NUIColor shadow(0.0f, 0.0f, 0.0f, 0.70f);
-
-    const float size = 18.0f;
-    const float half = size * 0.5f;
-    const float a = 5.0f; // Slightly larger arrow head for crispness
-
-    const float x = std::floor(position.x) + 0.5f; // Align to pixel grid
-    const float y = std::floor(position.y) + 0.5f;
-
-    // Crisp White
-    const AestraUI::NUIColor white(1.0f, 1.0f, 1.0f, 1.0f);
-    // Dark shadow for contrast
-    const AestraUI::NUIColor arrowShadow(0.0f, 0.0f, 0.0f, 0.8f);
-
-    // Shadow (outline)
-    constexpr float kShadowWidth = 4.0f;
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x + half, y), kShadowWidth, arrowShadow);
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x - half + a, y - a), kShadowWidth,
-                      arrowShadow);
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x - half + a, y + a), kShadowWidth,
-                      arrowShadow);
-    renderer.drawLine(AestraUI::NUIPoint(x + half, y), AestraUI::NUIPoint(x + half - a, y - a), kShadowWidth,
-                      arrowShadow);
-    renderer.drawLine(AestraUI::NUIPoint(x + half, y), AestraUI::NUIPoint(x + half - a, y + a), kShadowWidth,
-                      arrowShadow);
-
-    // Foreground (White)
-    constexpr float kLineWidth = 2.0f;
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x + half, y), kLineWidth, white);
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x - half + a, y - a), kLineWidth, white);
-    renderer.drawLine(AestraUI::NUIPoint(x - half, y), AestraUI::NUIPoint(x - half + a, y + a), kLineWidth, white);
-    renderer.drawLine(AestraUI::NUIPoint(x + half, y), AestraUI::NUIPoint(x + half - a, y - a), kLineWidth, white);
-    renderer.drawLine(AestraUI::NUIPoint(x + half, y), AestraUI::NUIPoint(x + half - a, y + a), kLineWidth, white);
+    // Render custom resize cursor — the canonical ResizeEW registry glyph
+    // (system cursor always hidden by Main.cpp). Same asset the custom-cursor
+    // overlay uses for horizontal resize everywhere.
+    if (m_resizeCursorIcon) {
+        m_resizeCursorIcon->setBounds(AestraUI::NUIRect(position.x - 9, position.y - 9, 18, 18));
+        m_resizeCursorIcon->onRender(renderer);
+    }
 }
 
 void TrackManagerUI::performSplitAtPosition(int laneIndex, double timeSeconds) {

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -147,10 +147,15 @@ bool TrackManagerUI::isRulerPointerActive() const {
         return true;
     }
     const AestraUI::NUIRect bounds = getBounds();
-    // Same geometry as the events file's ruler row: below the header +
-    // horizontal scrollbar, ruler-height tall, full width.
-    const AestraUI::NUIRect ruler(bounds.x, bounds.y + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight,
-                                  bounds.width, kTimelineRulerHeight);
+    // Same geometry as the events file's ruler row, but starting after the
+    // control-area column: the grab hand belongs over scrubbable ruler only.
+    auto& themeManager = AestraUI::NUIThemeManager::getInstance();
+    const auto& layout = themeManager.getLayoutDimensions();
+    const float rulerStartX = bounds.x + layout.trackControlsWidth + kTimelineGridInsetX;
+    const AestraUI::NUIRect ruler(rulerStartX,
+                                  bounds.y + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight,
+                                  std::max(0.0f, bounds.width - layout.trackControlsWidth - kTimelineGridInsetX),
+                                  kTimelineRulerHeight);
     return ruler.contains(m_lastMousePos);
 }
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1028,8 +1028,10 @@ void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, con
                                    ? (metrics.ascent + metrics.descent)
                                    : kClipLabelFontSize;
         const float textY = headerRect.y + (headerRect.height - textBoxH) * 0.5f;
+        // Name starts after the hamburger affordance zone (top-left glyph).
+        constexpr float kHamburgerOffset = 15.0f;
         renderer.drawText(displayName,
-                          AestraUI::NUIPoint(clipBounds.x + 6.0f, textY),
+                          AestraUI::NUIPoint(clipBounds.x + 6.0f + kHamburgerOffset, textY),
                           kClipLabelFontSize,
                           themeManager.getCurrentTheme().textPrimary.withAlpha(clipSelected ? 0.95f : 0.85f));
     }
@@ -1246,9 +1248,11 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
         // Centred in the header band rather than offset from the clip's top edge:
         // headerHeight is clamped, so a fixed offset drifts as the band resizes and
         // left the label flush against the band's lower edge at short clip heights.
+        // Name starts after the hamburger affordance zone (top-left glyph).
         constexpr float kClipLabelFontSize = 9.5f;
+        constexpr float kHamburgerOffset = 15.0f;
         renderer.drawText(displayName,
-                          AestraUI::NUIPoint(clipBounds.x + 10.0f,
+                          AestraUI::NUIPoint(clipBounds.x + 10.0f + kHamburgerOffset,
                                              renderer.calculateTextY(headerRect, kClipLabelFontSize)),
                           kClipLabelFontSize, themeManager.getCurrentTheme().textPrimary);
     }

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2557,8 +2557,10 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             if (clickedClipId.isValid()) {
                 // Hamburger affordance (top-left corner): opens the full
                 // contextual menu — checked before trim/drag/open so the
-                // affordance always wins inside its generous hit zone.
-                {
+                // affordance always wins inside its generous hit zone. Gated by
+                // the same visible-width condition as the rendered glyph, so
+                // narrow/partially-clipped clips keep drag + editor gestures.
+                if (clickedClipBounds.width > 20.0f) {
                     const auto& clipBounds = m_allClipBounds[clickedClipId];
                     const AestraUI::NUIRect burgerRect(clipBounds.x + 3.0f - 4.0f, clipBounds.y + 2.0f - 3.0f,
                                              13.0f + 8.0f, 12.0f + 6.0f);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -11,6 +11,7 @@
 #include "MeterSnapshot.h"
 #include "ChannelSlotMap.h"
 #include "NUIContextMenu.h"
+#include "Commands/MakeClipPatternUniqueCommand.h"
 #include "Commands/SetVolumeCommand.h"
 #include "Commands/SetPanCommand.h"
 #include "Commands/SetMuteCommand.h"
@@ -303,6 +304,20 @@ void TrackUIComponent::showClipRoutingMenu(const ClipInstanceID& clipId, const A
         addAction("Cut", "Ctrl+X", [parentManager]() { parentManager->cutSelectedClip(); });
         addAction("Copy", "Ctrl+C", [parentManager]() { parentManager->copySelectedClip(); });
         addAction("Duplicate", "Ctrl+D", [parentManager]() { parentManager->duplicateSelectedClip(); });
+        if (pattern && m_trackManager) {
+            // Break shared pattern identity for this clip only (Extra Session
+            // 2026-08-21: duplicate → make unique workflow).
+            addAction("Make Unique", "", [this, clipId]() {
+                if (!m_trackManager)
+                    return;
+                auto cmd = std::make_shared<Aestra::Audio::MakeClipPatternUniqueCommand>(*m_trackManager, clipId);
+                m_trackManager->getCommandHistory().pushAndExecute(cmd);
+                repaint();
+                if (m_onCacheInvalidationCallback) {
+                    m_onCacheInvalidationCallback();
+                }
+            });
+        }
     }
 
     if (pattern && pattern->isAudio()) {
@@ -2672,7 +2687,14 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 m_onClipSelectedCallback(this, clickedClipId);
             }
 
-            showClipRoutingMenu(clickedClipId, event.position);
+            if (event.modifiers & AestraUI::NUIModifiers::Shift) {
+                // Shift+right-click keeps the full contextual menu (routing,
+                // cut/copy/duplicate, editors) while plain right-click takes
+                // the fast path: immediate undoable delete.
+                showClipRoutingMenu(clickedClipId, event.position);
+            } else if (auto parentMgr = dynamic_cast<TrackManagerUI*>(getParent())) {
+                parentMgr->deleteSelectedClip();
+            }
             return true;
         }
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1159,6 +1159,26 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                     drawPianoRollStyleSelection(renderer, insetClippedClipBounds,
                                                 AestraUI::NUIThemeManager::getInstance().getRadius("s"));
                 }
+
+                // Hamburger affordance (top-left of the clip): opens the full
+                // contextual menu — the home for the actions right-click used
+                // to carry before right-click became fast-delete.
+                {
+                    const auto& theme = AestraUI::NUIThemeManager::getInstance();
+                    const AestraUI::NUIRect burgerRect(insetClippedClipBounds.x + 3.0f, insetClippedClipBounds.y + 2.0f,
+                                             13.0f, 12.0f);
+                    if (burgerRect.width > 0.0f && insetClippedClipBounds.width > 20.0f) {
+                        const bool hot = m_hoveredClipId == clip.id || clip.id == m_selectedClipId;
+                        const auto lineColor = theme.getColor("textPrimary")
+                                                   .withAlpha(hot ? 0.9f : 0.45f);
+                        for (int i = 0; i < 3; ++i) {
+                            const float ly = burgerRect.y + 2.0f + i * 3.5f;
+                            renderer.drawLine(AestraUI::NUIPoint(burgerRect.x + 1.5f, ly),
+                                              AestraUI::NUIPoint(burgerRect.x + burgerRect.width - 1.5f, ly),
+                                              1.4f, lineColor);
+                        }
+                    }
+                }
             }
         }
     }
@@ -1978,6 +1998,8 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         for (const auto& [clipId, clipBounds] : m_allClipBounds) {
             if (!clipBounds.contains(event.position)) continue;
             
+            m_hoveredClipId = clipId;
+
             float leftEdge = clipBounds.x;
             float rightEdge = clipBounds.x + clipBounds.width;
             
@@ -1998,10 +2020,16 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             }
         }
         
+        if (newHoverEdge == TrimEdge::None) {
+            m_hoveredClipId = ClipInstanceID{};
+        }
+
         if (m_hoverTrimEdge != newHoverEdge) {
             m_hoverTrimEdge = newHoverEdge;
             repaint(); // Trigger redraw for cursor feedback
         }
+    } else if (!isInsideBounds && !m_isTrimming) {
+        m_hoveredClipId = ClipInstanceID{};
     }
     
     // Keep button hover/press state accurate even when leaving the track row.
@@ -2523,6 +2551,27 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
             
             // Check if clicking on any clip for drag initiation or trimming
             if (clickedClipId.isValid()) {
+                // Hamburger affordance (top-left corner): opens the full
+                // contextual menu — checked before trim/drag/open so the
+                // affordance always wins inside its generous hit zone.
+                {
+                    const auto& clipBounds = m_allClipBounds[clickedClipId];
+                    const AestraUI::NUIRect burgerRect(clipBounds.x + 3.0f - 4.0f, clipBounds.y + 2.0f - 3.0f,
+                                             13.0f + 8.0f, 12.0f + 6.0f);
+                    if (event.pressed && event.button == AestraUI::NUIMouseButton::Left &&
+                        burgerRect.contains(event.position)) {
+                        m_activeClipId = clickedClipId;
+                        if (m_onTrackSelectedCallback) {
+                            m_onTrackSelectedCallback(this, selectionIntentFor(event));
+                        }
+                        if (m_onClipSelectedCallback) {
+                            m_onClipSelectedCallback(this, clickedClipId);
+                        }
+                        showClipRoutingMenu(clickedClipId, event.position);
+                        return true;
+                    }
+                }
+
                 auto now = std::chrono::steady_clock::now();
                 const long long nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
                 const bool manualDoubleClick =

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -176,6 +176,7 @@ private:
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     bool m_selected = false; // Track selection state
     ClipInstanceID m_selectedClipId; // Persistent clip selection supplied by TrackManagerUI
+    ClipInstanceID m_hoveredClipId; // Clip under the pointer (hamburger affordance)
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
     bool m_isNestedLane = false; // Owned non-primary lane row (FD-14 §10 nesting)
     bool m_trackCollapsed = false; // Owning track's collapse state (chevron glyph)

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -2528,6 +2528,14 @@ void AestraContent::setViewFocus(ViewFocus focus) {
 
         // Force layout update immediately to apply new visibility and margins
         onResize(getBounds().width, getBounds().height);
+
+        // Panels hidden by this switch stop receiving events, so any hover
+        // cursor they set (grab/resize) would linger app-wide via the bridge
+        // override. Reset to the default; the panel under the pointer re-claims
+        // its own style on the next move.
+        if (m_platformBridge) {
+            m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
+        }
     }
 
     // Update transport bar mode indicator (mode only, no panel visibility)

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -7,6 +7,12 @@
 // Include panel headers FIRST to define complete types before AestraContent.h forward declarations
 #include "AestraContent.h"
 
+namespace {
+// Frames (≈1s at 60fps) the app waits for the engine to actually start the
+// count-in metronome before degrading to plain playback (e.g. no live stream).
+constexpr int kCountInStartupFrameLimit = 60;
+} // namespace
+
 #include "../AestraUI/Widgets/PluginBrowserPanel.h"
 #include "../AestraUI/Widgets/PluginUIController.h"
 #include "../AestraUI/Widgets/UIMixerInspector.h"
@@ -477,14 +483,29 @@ void AestraContent::setupTransportBar() {
         stopSoundPreview();
     });
     m_transportBar->setOnRecord([this](bool recording) {
-        if (m_trackManager) {
-            bool isRecordArmed = m_trackManager->isRecordArmed();
-            if (recording != isRecordArmed) {
-                m_trackManager->record();
+        if (!m_trackManager) {
+            return;
+        }
+        const bool isRecordArmed = m_trackManager->isRecordArmed();
+        if (recording != isRecordArmed) {
+            m_trackManager->record();
+        }
+        if (recording && !m_trackManager->hasArmedTracks()) {
+            showToast("No armed tracks — recording will capture nothing. Arm a track in the playlist.");
+            return;
+        }
+        if (!recording) {
+            // Disarming cancels any pending count-in so the transport does not
+            // start rolling (and "record") after the count-in finishes.
+            if (m_trackManager->isCountInPending()) {
+                clearPendingCountIn();
             }
-            if (recording && !m_trackManager->hasArmedTracks()) {
-                showToast("No armed tracks — recording will capture nothing. Arm a track in the playlist.");
-            }
+            return;
+        }
+        // Count-in enabled: pressing Record enters the count-in phase and
+        // recording begins automatically at the post-count-in position.
+        if (m_countInEnabled && !isTransportRolling()) {
+            handleTransportPlayRequest();
         }
     });
     m_transportBar->setOnMetronomeToggle([this](bool enabled) {
@@ -2889,13 +2910,13 @@ PatternID AestraContent::getActivePatternID() const {
 
 void AestraContent::clearPendingCountIn() {
     if (m_trackManager) {
-        m_trackManager->clearDeferredRecordingStartBeat();
-        m_trackManager->clearDisplayPositionOverride();
-        m_trackManager->clearNextCapturePlacementStartBeat();
+        m_trackManager->cancelCountIn();
     }
     if (m_audioEngine) {
         m_audioEngine->stopMetronomeCountIn();
     }
+    m_countInFullyStarted = false;
+    m_countInStartupFrames = 0;
 
     if (m_forcedMetronomeForCountIn && m_trackManager) {
         m_trackManager->enableMetronome(false);
@@ -2908,8 +2929,6 @@ void AestraContent::clearPendingCountIn() {
     }
 
     m_forcedMetronomeForCountIn = false;
-    m_pendingCountIn = false;
-    m_pendingCountInTargetSeconds = 0.0;
 }
 
 void AestraContent::startPatternClipPreview(PatternID patternId) {
@@ -2995,26 +3014,41 @@ ViewFocus AestraContent::resolveTransportFocus() const {
 }
 
 bool AestraContent::isTransportRolling() const {
-    if (m_pendingCountIn || (m_audioEngine && m_audioEngine->isMetronomeCountInActive())) {
+    if (m_trackManager && (m_trackManager->isCountInPending() || m_trackManager->isPlaying())) {
         return true;
     }
-
-    const bool trackManagerPlaying = m_trackManager && m_trackManager->isPlaying();
+    if (m_audioEngine && m_audioEngine->isMetronomeCountInActive()) {
+        return true;
+    }
     const bool transportBarPlaying = m_transportBar && m_transportBar->getState() == TransportState::Playing;
-    return trackManagerPlaying || transportBarPlaying;
+    return transportBarPlaying;
 }
 
 void AestraContent::updatePendingCountIn() {
-    if (!m_pendingCountIn || !m_trackManager) {
+    if (!m_trackManager || !m_trackManager->isCountInPending()) {
         return;
     }
 
-    if (m_audioEngine && m_audioEngine->isMetronomeCountInActive()) {
+    // The count-in command travels to the engine through the audio command
+    // queue, so isMetronomeCountInActive() stays false for a block or two
+    // after beginCountIn. Treating "still false" as "finished" made the
+    // transport start immediately with no count-in at all. Instead: wait
+    // until the engine has actually started clicking, then complete once it
+    // stops (with a degrade timer in case the stream never applies it).
+    const bool countInActive = m_audioEngine && m_audioEngine->isMetronomeCountInActive();
+    if (countInActive) {
+        m_countInFullyStarted = true;
+        m_countInStartupFrames = 0;
         return;
     }
 
-    m_trackManager->clearDisplayPositionOverride();
-    m_trackManager->clearNextCapturePlacementStartBeat();
+    if (!m_countInFullyStarted) {
+        if (++m_countInStartupFrames <= kCountInStartupFrameLimit) {
+            return; // engine may not have applied the command yet
+        }
+        AESTRA_LOG_WARNING("[AestraContent] Count-in never started on the engine; degrading to plain playback.");
+    }
+
     if (m_forcedMetronomeForCountIn) {
         m_trackManager->enableMetronome(false);
         if (m_audioEngine) {
@@ -3025,9 +3059,9 @@ void AestraContent::updatePendingCountIn() {
         }
         m_forcedMetronomeForCountIn = false;
     }
-    m_pendingCountIn = false;
-    m_pendingCountInTargetSeconds = 0.0;
-    m_trackManager->play();
+    m_countInFullyStarted = false;
+    m_countInStartupFrames = 0;
+    m_trackManager->completeCountIn();
     stopSoundPreview();
 }
 
@@ -3083,35 +3117,32 @@ void AestraContent::handleTransportPlayRequest() {
         return;
     }
 
-    if (!isTransportRolling()) {
+    // Engine truth only: TransportBar::play() latches its button state BEFORE
+    // firing this callback, so isTransportRolling() (which includes the bar
+    // latch) is already true here on a fresh press. Consulting it would make
+    // the count-in branch below dead — the transport would latch "playing"
+    // and neither count in nor start (#count-in).
+    const bool engineRolling = m_trackManager->isPlaying() || m_trackManager->isCountInPending() ||
+                               (m_audioEngine && m_audioEngine->isMetronomeCountInActive());
+    if (!engineRolling) {
+        m_trackManager->cancelCountIn();
         if (m_audioEngine) {
             m_audioEngine->stopMetronomeCountIn();
         }
-        m_trackManager->clearDeferredRecordingStartBeat();
-        m_trackManager->clearDisplayPositionOverride();
-        m_trackManager->clearNextCapturePlacementStartBeat();
-        m_pendingCountIn = false;
-        m_pendingCountInTargetSeconds = 0.0;
     }
 
-    if (!m_countInEnabled || !m_trackManager->isRecordArmed() || !m_trackManager->hasArmedTracks()) {
+    if (!m_countInEnabled) {
         clearPendingCountIn();
         playFromCurrentFocus();
         return;
     }
 
-    const int beatsPerBar = m_transportBar ? std::max(1, m_transportBar->getTimeSignature()) : 4;
-    const double requestedStartSeconds = std::max(0.0, m_trackManager->getPosition());
-
-    if (isTransportRolling()) {
+    if (engineRolling) {
         return;
     }
 
-    m_pendingCountIn = true;
-    m_pendingCountInTargetSeconds = requestedStartSeconds;
-    m_trackManager->setPlayStartPosition(requestedStartSeconds);
-    m_trackManager->setPosition(requestedStartSeconds);
-    m_trackManager->setDisplayPositionOverride(requestedStartSeconds);
+    const int beatsPerBar = m_transportBar ? std::max(1, m_transportBar->getTimeSignature()) : 4;
+    const double requestedStartSeconds = std::max(0.0, m_trackManager->getPosition());
 
     if (m_audioEngine && !m_audioEngine->isMetronomeEnabled()) {
         m_trackManager->enableMetronome(true);
@@ -3124,11 +3155,12 @@ void AestraContent::handleTransportPlayRequest() {
         m_forcedMetronomeForCountIn = false;
     }
 
-    if (m_audioEngine) {
-        m_audioEngine->stopMetronomeCountIn();
-        m_audioEngine->startMetronomeCountIn(static_cast<uint32_t>(beatsPerBar));
-    } else {
-        m_pendingCountIn = false;
+    // The count-in machine (TrackManager) pins the position, defers recording
+    // capture to the post-count-in beat, and starts the engine metronome.
+    m_countInFullyStarted = false;
+    m_countInStartupFrames = 0;
+    if (!m_trackManager->beginCountIn(static_cast<uint32_t>(beatsPerBar), requestedStartSeconds)) {
+        clearPendingCountIn();
         playFromCurrentFocus();
     }
 }
@@ -3334,6 +3366,12 @@ void AestraContent::setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) {
     }
     if (m_pianoRollPanel) {
         m_pianoRollPanel->setPlatformBridge(bridge);
+    }
+    if (m_fileBrowser) {
+        m_fileBrowser->setPlatformBridge(bridge);
+    }
+    if (m_transportBar) {
+        m_transportBar->setPlatformBridge(bridge);
     }
 }
 

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -482,9 +482,12 @@ private:
     bool m_patternClipPreviewActive{false};
     Aestra::Audio::PatternID m_previewPatternId{};
     bool m_countInEnabled{false};
-    bool m_pendingCountIn{false};
     bool m_forcedMetronomeForCountIn{false};
-    double m_pendingCountInTargetSeconds{0.0};
+    // Count-in completion gate: the engine applies the start command
+    // asynchronously (a block or two), so the app waits for the metronome to
+    // be observed ACTIVE before treating its absence as "finished".
+    bool m_countInFullyStarted{false};
+    int m_countInStartupFrames{0};
 
     std::shared_ptr<Aestra::Audio::SampleEditorPanel> m_sampleEditorPanel;
     std::shared_ptr<Aestra::Audio::AudioClipEditorPanel> m_audioClipEditorPanel;

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -15,6 +15,7 @@
 
 #include "../AestraUI/Graphics/OpenGL/NUIRendererGL.h"
 #include "../AestraUI/Core/NUIDragDrop.h"
+#include "../AestraUI/Core/NUICursorRegistry.h"
 #include "../AestraCore/include/AestraLog.h"
 
 #include <cmath>
@@ -277,6 +278,22 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
         if (m_content) {
             AestraUI::NUIDragDropManager::getInstance().updateDrag(AestraUI::NUIPoint(static_cast<float>(x), static_cast<float>(y)));
         }
+    });
+
+    // Window enter/exit lifecycle. Leaving the window releases any component
+    // cursor style and any drag capture that may have missed its release (e.g.
+    // a drag released outside the window), so the next interaction never
+    // inherits a stale resize/grab cursor or an invisible pointer. The
+    // per-frame resolveCursorState() is the guaranteed backstop.
+    m_window->setMouseEnterCallback([this]() {});
+    m_window->setMouseLeaveCallback([this]() {
+        if (!m_window) {
+            return;
+        }
+        if (m_window->isCursorCaptured()) {
+            m_window->cancelCursorCapture();
+        }
+        m_window->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
     });
 
     m_window->setMouseButtonCallback([this](int button, bool pressed) { // Fixed signature
@@ -748,6 +765,8 @@ double AestraWindowManager::endFrame() {
 void AestraWindowManager::render() {
     if (!m_renderer || !m_rootComponent) return;
 
+    resolveCursorState();
+
     auto& themeManager = NUIThemeManager::getInstance();
     // CRITICAL: Force alpha = 1.0 to prevent DWM "Sheet of Glass" transparency.
     // The custom title bar uses DwmExtendFrameIntoClientArea which makes alpha < 1 transparent.
@@ -806,75 +825,55 @@ void AestraWindowManager::render() {
 // Custom Software Cursor
 // ==============================
 
+void AestraWindowManager::resolveCursorState() {
+    if (!m_useCustomCursor || !m_window) {
+        return;
+    }
+
+    // Self-heal a stranded Hidden style: a drag capture that lost its release
+    // leaves the bridge style Hidden with no active capture — no custom cursor
+    // draws and the native cursor stays hidden (= the invisible-pointer
+    // failure). Reset to Arrow so every frame resolves to a known state.
+    if (m_window->getCursorStyle() == AestraUI::NUICursorStyle::Hidden && !m_window->isCursorCaptured()) {
+        m_window->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
+    }
+
+    const AestraUI::NUICursorStyle style = m_window->getCursorStyle();
+    bool trackManagerHasCustomCursor = false;
+    if (m_content && m_content->getTrackManagerUI()) {
+        trackManagerHasCustomCursor = m_content->getTrackManagerUI()->isCustomCursorActive();
+    }
+
+    // Native cursor visibility must exactly track whether the pointer is being
+    // drawn (custom overlay or the TrackManager tool cursor) or intentionally
+    // hidden by an active drag capture. Any other state shows the native
+    // cursor — the guaranteed fallback.
+    const bool hideNative =
+        m_window->isCursorCaptured() ||
+        (m_windowFocused && (trackManagerHasCustomCursor || style != AestraUI::NUICursorStyle::Hidden));
+    if (hideNative != m_cachedNativeCursorHidden) {
+        m_cachedNativeCursorHidden = hideNative;
+        m_window->setCursorVisible(!hideNative);
+    }
+}
+
 void AestraWindowManager::initializeCustomCursors() {
-    // Arrow cursor
-    m_cursorArrow = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M5 2L5 18L9 14L12 21L14 20L11 13L17 13L5 2Z" fill="white" stroke="black" stroke-width="1.5"/>
-        </svg>
-    )");
+    const auto mk = [](AestraUI::NUICursorStyle style) {
+        return std::make_shared<AestraUI::NUIIcon>(AestraUI::nuiCursorSvg(style));
+    };
 
-    // Pointing hand cursor
-    m_cursorHandPointing = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M7 12.5V9.5C7 8.95 7.45 8.5 8 8.5C8.55 8.5 9 8.95 9 9.5V12.2H9.6V5C9.6 4.45 10.05 4 10.6 4C11.15 4 11.6 4.45 11.6 5V12.2H12.2V3.2C12.2 2.65 12.65 2.2 13.2 2.2C13.75 2.2 14.2 2.65 14.2 3.2V12.2H14.8V6.2C14.8 5.65 15.25 5.2 15.8 5.2C16.35 5.2 16.8 5.65 16.8 6.2V14.1C16.8 17.35 14.15 20 10.9 20H10.6C7.9 20 5.7 17.8 5.7 15.1V12.5C5.7 11.95 6.15 11.5 6.7 11.5C6.93 11.5 7.14 11.58 7.3 11.72C7.32 11.74 7.33 11.75 7.35 11.77C7.56 11.96 7.7 12.22 7.7 12.5H7Z" fill="white" stroke="black" stroke-width="1.15" stroke-linejoin="round"/>
-        </svg>
-    )");
-
-    // Open-hand grab cursor
-    m_cursorHand = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 6V3C12 2.45 12.45 2 13 2C13.55 2 14 2.45 14 3V10H15V4C15 3.45 15.45 3 16 3C16.55 3 17 3.45 17 4V10H18V5C18 4.45 18.45 4 19 4C19.55 4 20 4.45 20 5V15C20 18.31 17.31 21 14 21H12C8.69 21 6 18.31 6 15V12C6 11.45 6.45 11 7 11C7.55 11 8 11.45 8 12V14H9V6C9 5.45 9.45 5 10 5C10.55 5 11 5.45 11 6V10H12V6Z" fill="white" stroke="black" stroke-width="1"/>
-        </svg>
-    )");
-
-    // Closed-hand grabbing cursor
-    m_cursorHandGrabbing = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9.5 5.8C9.5 5.14 10.04 4.6 10.7 4.6C11.36 4.6 11.9 5.14 11.9 5.8V9.1H12.5V4.7C12.5 4.04 13.04 3.5 13.7 3.5C14.36 3.5 14.9 4.04 14.9 4.7V9.1H15.5V6.4C15.5 5.74 16.04 5.2 16.7 5.2C17.36 5.2 17.9 5.74 17.9 6.4V11.7C17.9 15.73 14.63 19 10.6 19C7.51 19 5 16.49 5 13.4V10.7C5 10.04 5.54 9.5 6.2 9.5C6.86 9.5 7.4 10.04 7.4 10.7V12.9H8V7C8 6.34 8.54 5.8 9.2 5.8H9.5Z" fill="white" stroke="black" stroke-width="1.2" stroke-linejoin="round"/>
-            <path d="M7.9 14.3C8.05 15.72 9.25 16.8 10.7 16.8C12.28 16.8 13.56 15.52 13.56 13.94V12.7H7.8V13.5C7.8 13.77 7.84 14.04 7.9 14.3Z" fill="black" fill-opacity="0.16"/>
-        </svg>
-    )");
-
-    // I-Beam cursor
-    m_cursorIBeam = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4H11M15 4H13M11 4V20M13 4V20M11 4C11 4 11 4 12 4C13 4 13 4 13 4M11 20H9M15 20H13M11 20C11 20 11 20 12 20C13 20 13 20 13 20" stroke="white" stroke-width="2" stroke-linecap="round"/>
-            <path d="M9 4H11M15 4H13M11 4V20M13 4V20M11 4C11 4 11 4 12 4C13 4 13 4 13 4M11 20H9M15 20H13M11 20C11 20 11 20 12 20C13 20 13 20 13 20" stroke="black" stroke-width="3" stroke-linecap="round" opacity="0.3"/>
-        </svg>
-    )");
-
-    // Horizontal resize cursor
-    m_cursorResizeH = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M18 12L22 12M22 12L19 9M22 12L19 15M6 12L2 12M2 12L5 9M2 12L5 15M12 6V18" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M18 12L22 12M22 12L19 9M22 12L19 15M6 12L2 12M2 12L5 9M2 12L5 15M12 6V18" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.3"/>
-        </svg>
-    )");
-
-    // Vertical resize cursor
-    m_cursorResizeV = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 6L12 2M12 2L9 5M12 2L15 5M12 18L12 22M12 22L9 19M12 22L15 19M6 12H18" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M12 6L12 2M12 2L9 5M12 2L15 5M12 18L12 22M12 22L9 19M12 22L15 19M6 12H18" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.3"/>
-        </svg>
-    )");
-
-    // Diagonal resize cursor (NE-SW)
-    m_cursorResizeDiagNESW = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16 8L22 2M22 2H18M22 2V6M8 16L2 22M2 22H6M2 22V18M9 15L15 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M16 8L22 2M22 2H18M22 2V6M8 16L2 22M2 22H6M2 22V18M9 15L15 9" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.3"/>
-        </svg>
-    )");
-
-    // Diagonal resize cursor (NW-SE)
-    m_cursorResizeDiagNWSE = std::make_shared<AestraUI::NUIIcon>(R"(
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M8 8L2 2M2 2H6M2 2V6M16 16L22 22M22 22H18M22 22V18M9 9L15 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M8 8L2 2M2 2H6M2 2V6M16 16L22 22M22 22H18M22 22V18M9 9L15 15" stroke="black" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.3"/>
-        </svg>
-    )");
+    // Canonical cursor artwork comes from NUICursorRegistry — the single
+    // source for every interaction cursor, so resize in one editor uses the
+    // same asset as resize anywhere else.
+    m_cursorArrow = mk(AestraUI::NUICursorStyle::Arrow);
+    m_cursorHandPointing = mk(AestraUI::NUICursorStyle::Hand);
+    m_cursorHand = mk(AestraUI::NUICursorStyle::Grab);
+    m_cursorHandGrabbing = mk(AestraUI::NUICursorStyle::Grabbing);
+    m_cursorIBeam = mk(AestraUI::NUICursorStyle::IBeam);
+    m_cursorResizeH = mk(AestraUI::NUICursorStyle::ResizeEW);
+    m_cursorResizeV = mk(AestraUI::NUICursorStyle::ResizeNS);
+    m_cursorResizeDiagNESW = mk(AestraUI::NUICursorStyle::ResizeNESW);
+    m_cursorResizeDiagNWSE = mk(AestraUI::NUICursorStyle::ResizeNWSE);
 
     Log::info("Custom cursor icons initialized");
     m_useCustomCursor = true;

--- a/Source/Core/AestraWindowManager.h
+++ b/Source/Core/AestraWindowManager.h
@@ -206,6 +206,10 @@ private:
     // Cursor
     bool m_useCustomCursor{true};
     bool m_windowFocused{true};
+    /** @brief Centre cursor-state resolution: every frame the cursor resolves to
+     *  exactly one known state, and a hidden native pointer without a drawn
+     *  custom cursor (the invisible-cursor failure) self-heals. */
+    void resolveCursorState();
     std::shared_ptr<AestraUI::NUIIcon> m_cursorArrow;
     std::shared_ptr<AestraUI::NUIIcon> m_cursorHandPointing;
     std::shared_ptr<AestraUI::NUIIcon> m_cursorHand;
@@ -216,6 +220,7 @@ private:
     std::shared_ptr<AestraUI::NUIIcon> m_cursorResizeDiagNESW;
     std::shared_ptr<AestraUI::NUIIcon> m_cursorResizeDiagNWSE;
     AestraUI::NUICursorStyle m_activeCursorStyle{AestraUI::NUICursorStyle::Arrow};
+    bool m_cachedNativeCursorHidden{false};
 
     // Input State
     std::function<void(TransportAction)> m_transportCallback;

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -885,6 +885,7 @@ ProjectSerializer::SerializeResult ProjectSerializer::serialize(const std::share
         mjs.set("monitorInput", JSON(channel->isMonitoringEnabled()));
         mjs.set("inputChannelIndex", JSON(static_cast<double>(channel->getInputChannelIndex())));
         mjs.set("width", JSON(static_cast<double>(channel->getWidth())));
+        mjs.set("trim", JSON(static_cast<double>(channel->getTrimDb())));
         mjs.set("trackColorIndex", JSON(static_cast<double>(channel->getTrackColorIndex())));
 
         JSON routingJson = JSON::object();
@@ -1877,6 +1878,8 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                 channel->setInputChannelIndex(
                     static_cast<int>(finiteNumberOr(channels[i], "inputChannelIndex", -1.0, -2.0, 1024.0)));
                 channel->setWidth(static_cast<float>(finiteNumberOr(channels[i], "width", 1.0, 0.0, 4.0)));
+                channel->setTrimDb(
+                    static_cast<float>(finiteNumberOr(channels[i], "trim", 0.0, -24.0, 24.0)));
                 channel->setTrackColorIndex(
                     static_cast<int>(finiteNumberOr(channels[i], "trackColorIndex", -1.0, -1.0, 1024.0)));
 
@@ -2521,6 +2524,7 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                                           : 20.0f * std::log10(linearVol);
                     continuous->setFaderDb(slot, faderDb);
                     continuous->setPan(slot, channel->getPan());
+                    continuous->setTrimDb(slot, channel->getTrimDb());
                 }
             }
         }

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -1379,8 +1379,16 @@ AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const 
             filename = filename.substr(0, lastDot);
         }
 
-        // Empty Arsenal: dropping a sample creates its own sampler unit
-        // (find sample → drag → playing, no procedural unit setup).
+        // Drop resolution by POSITION: over a unit row → replace that unit's
+        // sound (new sound, old unit). Over empty space → create a new sampler
+        // unit for the sample (new sound, new unit).
+        targetUnit = 0;
+        for (const auto& row : m_unitRows) {
+            if (row && row->isVisible() && row->getBounds().contains(position)) {
+                targetUnit = row->getUnitId();
+                break;
+            }
+        }
         if (targetUnit == 0) {
             targetUnit = unitMgr.createUnit(filename, UnitType::Sampler);
             if (targetUnit == 0) {

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -1311,17 +1311,23 @@ AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const 
             return result;
         }
 
-        if (targetUnit == 0) {
-            result.accepted = false;
-            result.message = "No Arsenal unit available";
-            return result;
-        }
-
         auto& unitMgr = m_trackManager->getUnitManager();
         std::string filename = data.filePath.substr(data.filePath.find_last_of("/\\") + 1);
         const auto lastDot = filename.find_last_of('.');
         if (lastDot != std::string::npos) {
             filename = filename.substr(0, lastDot);
+        }
+
+        // Empty Arsenal: dropping a sample creates its own sampler unit
+        // (find sample → drag → playing, no procedural unit setup).
+        if (targetUnit == 0) {
+            targetUnit = unitMgr.createUnit(filename, UnitType::Sampler);
+            if (targetUnit == 0) {
+                result.accepted = false;
+                result.message = "Could not create an Arsenal unit";
+                return result;
+            }
+            unitMgr.setUnitEnabled(targetUnit, true);
         }
 
         unitMgr.setUnitName(targetUnit, filename);

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -671,6 +671,9 @@ void ArsenalPanel::onRender(NUIRenderer& renderer) {
     drawCommandHeader(renderer);
     if (m_listContainer && isVisible()) drawProgressHeader(renderer, m_progressHeaderRect);
 
+    // Drag-hover ghost draws above the panel surfaces.
+    renderDragPreview(renderer);
+
     // The custom header surfaces are drawn after WindowPanel's child pass.
     if (m_addUnitBtn) m_addUnitBtn->onRender(renderer);
 
@@ -1279,7 +1282,20 @@ AestraUI::DropFeedback ArsenalPanel::onDragEnter(const AestraUI::DragData& data,
 }
 
 AestraUI::DropFeedback ArsenalPanel::onDragOver(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) {
-    (void)position;
+    // Drag-hover ghost state: a sample over empty Arsenal space previews the
+    // new unit it would create.
+    m_dragPreviewActive = isAudioFileDrag(data);
+    m_dragPreviewPos = position;
+    if (isAudioFileDrag(data)) {
+        const auto lastSlash = data.filePath.find_last_of("/\\");
+        std::string filename = data.filePath.substr(lastSlash + 1);
+        const auto lastDot = filename.find_last_of('.');
+        if (lastDot != std::string::npos) {
+            filename = filename.substr(0, lastDot);
+        }
+        m_dragPreviewName = filename;
+    }
+    repaint();
     if (isInstrumentPluginDrag(data) || isAudioFileDrag(data)) {
         return AestraUI::DropFeedback::Copy;
     }
@@ -1287,6 +1303,51 @@ AestraUI::DropFeedback ArsenalPanel::onDragOver(const AestraUI::DragData& data, 
 }
 
 void ArsenalPanel::onDragLeave() {
+    m_dragPreviewActive = false;
+    repaint();
+}
+
+void ArsenalPanel::renderDragPreview(AestraUI::NUIRenderer& renderer) {
+    if (!m_dragPreviewActive) {
+        return;
+    }
+    // Suppress the ghost where an existing unit row would receive the drop
+    // (replacement target — rows show their own feedback).
+    for (const auto& row : m_unitRows) {
+        if (row && row->isVisible() && row->getBounds().contains(m_dragPreviewPos)) {
+            return;
+        }
+    }
+
+    auto& theme = NUIThemeManager::getInstance();
+    const float ghostW = std::max(160.0f, getBounds().width - 48.0f);
+    const NUIRect ghost(m_dragPreviewPos.x - 8.0f, m_dragPreviewPos.y - 24.0f, ghostW, 52.0f);
+
+    // Dashed outline reads as "proposed", not existing content.
+    const auto outline = theme.getColor("accentPrimary").withAlpha(0.85f);
+    constexpr float kDash = 7.0f;
+    constexpr float kGap = 5.0f;
+    auto dashedH = [&](float x0, float x1, float y) {
+        for (float x = x0; x < x1; x += kDash + kGap) {
+            renderer.drawLine(NUIPoint(x, y), NUIPoint(std::min(x + kDash, x1), y), 1.6f, outline);
+        }
+    };
+    auto dashedV = [&](float y0, float y1, float x) {
+        for (float y = y0; y < y1; y += kDash + kGap) {
+            renderer.drawLine(NUIPoint(x, y), NUIPoint(x, std::min(y + kDash, y1)), 1.6f, outline);
+        }
+    };
+    dashedH(ghost.x, ghost.right(), ghost.y);
+    dashedH(ghost.x, ghost.right(), ghost.bottom());
+    dashedV(ghost.y, ghost.bottom(), ghost.x);
+    dashedV(ghost.y, ghost.bottom(), ghost.right());
+
+    const std::string label = "+ New Sampler Unit — " + m_dragPreviewName;
+    const auto textSize = renderer.measureText(label, 10.5f);
+    renderer.drawText(label,
+                      NUIPoint(ghost.x + (ghost.width - textSize.width) * 0.5f,
+                               ghost.y + (ghost.height - textSize.height) * 0.5f),
+                      10.5f, theme.getColor("textPrimary").withAlpha(0.9f));
 }
 
 AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const AestraUI::NUIPoint& position) {

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -1383,8 +1383,13 @@ AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const 
         // sound (new sound, old unit). Over empty space → create a new sampler
         // unit for the sample (new sound, new unit).
         targetUnit = 0;
+        const bool pointerInListViewport = m_listViewportRect.contains(position);
         for (const auto& row : m_unitRows) {
-            if (row && row->isVisible() && row->getBounds().contains(position)) {
+            // Visibility alone isn't enough: a scrolled-out row's bounds can
+            // still contain the pointer. Require the row inside the visible
+            // list viewport so drops on empty space never replace an
+            // off-screen unit.
+            if (row && row->isVisible() && pointerInListViewport && row->getBounds().contains(position)) {
                 targetUnit = row->getUnitId();
                 break;
             }
@@ -1397,6 +1402,12 @@ AestraUI::DropResult ArsenalPanel::onDrop(const AestraUI::DragData& data, const 
                 return result;
             }
             unitMgr.setUnitEnabled(targetUnit, true);
+            // Route the fresh unit like every other creation path — otherwise
+            // the dropped sample loads into a unit with no mixer destination.
+            if (const auto* unit = unitMgr.getUnit(targetUnit)) {
+                const std::string destinationName = unit->name.empty() ? "Mixer Channel" : unit->name;
+                routeUnitToFirstFreeMixerChannel(*m_trackManager, targetUnit, destinationName, unit->color);
+            }
         }
 
         unitMgr.setUnitName(targetUnit, filename);

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -26,6 +26,9 @@ public:
 
     /** @brief Render the Arsenal panel and unit rows. */
     void onRender(AestraUI::NUIRenderer& renderer) override;
+    /** @brief Drag-hover ghost: dashed "new unit" outline while dragging a
+     *  sample over empty Arsenal space. */
+    void renderDragPreview(AestraUI::NUIRenderer& renderer);
     /** @brief Relayout the panel after a resize. */
     void onResize(int width, int height) override;
     /** @brief Advance Arsenal playback state and UI sync. */
@@ -124,6 +127,10 @@ private:
     float m_targetScrollY = 0.0f;
     float m_gridScrollX = 0.0f; // Shared horizontal step-grid scroll (header + all rows)
     bool m_gridFollowSuspended = false; // User scrolled away while playing; stop chasing them
+    // Drag-hover ghost state (sample over empty Arsenal space → new-unit outline)
+    bool m_dragPreviewActive = false;
+    AestraUI::NUIPoint m_dragPreviewPos;
+    std::string m_dragPreviewName;
     bool m_fitToWidth = true; // Fit whole loop to width vs readable-min + scroll
     int m_stepCount = 16; // Default step count
     void layoutUnits();

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -1034,4 +1034,15 @@ bool TransportBar::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     return handled;
 }
 
+void TransportBar::onMouseLeave() {
+    // Release the hand cursor when the pointer leaves the bar, so it cannot
+    // linger app-wide (the window-manager bridge override otherwise keeps the
+    // last style until another component claims it).
+    if (m_platformBridge) {
+        m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
+    }
+    AestraUI::NUIComponent::hideRemoteTooltip(this);
+    AestraUI::NUIComponent::onMouseLeave();
+}
+
 } // namespace Aestra

--- a/Source/Panels/TransportBar.cpp
+++ b/Source/Panels/TransportBar.cpp
@@ -7,6 +7,7 @@
 #include "TransportBar.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
 #include "../AestraCore/include/AestraLog.h"
+#include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include <sstream>
 #include <iomanip>
 #include <cmath>
@@ -211,9 +212,12 @@ void TransportBar::createIcons() {
     m_stopIcon->setColorFromTheme("primary");
     
     // Record icon (Solid Circle) - Vibrant Red
+    // Shrunk from r=9 (18px, ~4× the visual area of Play/Stop) to a 12px
+    // footprint that matches the Stop square, so the transport controls read
+    // as one intentionally-weighted set rather than a dominant red dot.
     const char* recordSvg = R"(
         <svg viewBox="0 0 24 24" fill="currentColor">
-            <circle cx="12" cy="12" r="9"/>
+            <circle cx="12" cy="12" r="6"/>
         </svg>
     )";
     m_recordIcon = std::make_shared<AestraUI::NUIIcon>(recordSvg);
@@ -603,8 +607,6 @@ void TransportBar::renderButtonIcons(AestraUI::NUIRenderer& renderer) {
     float spacing = layout.transportButtonSpacing;
     float centerOffsetY = (bounds.height - buttonSize) / 2.0f;
     float x = padding;
-    
-    const float iconSize = 18.0f; // Reduced from 24 to 18 for better padding in 28px button
 
     // Helper to render universal Glass Box button. Passing a label switches it
     // to the inline "tiny icon + micro-label" form used by DAW-specific
@@ -1020,10 +1022,14 @@ bool TransportBar::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     for (const auto& [button, text] : tooltipButtons) {
         if (updateTooltipForButton(button, text)) {
             AestraUI::NUIComponent::showRemoteTooltip(text, event.position, this);
+            // Hand tool on clickable transport controls (consistent with the
+            // grab-affordance sweep across draggable surfaces).
+            if (m_platformBridge) m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Hand);
             return handled;
         }
     }
 
+    if (m_platformBridge) m_platformBridge->setCursorStyle(AestraUI::NUICursorStyle::Arrow);
     AestraUI::NUIComponent::hideRemoteTooltip(this);
     return handled;
 }

--- a/Source/Panels/TransportBar.h
+++ b/Source/Panels/TransportBar.h
@@ -108,6 +108,8 @@ public:
 
     /** @brief Set the platform bridge for hover cursor styling (hand on buttons). */
     void setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) { m_platformBridge = bridge; }
+    /** @brief Release hover cursor + tooltip when the pointer leaves the bar. */
+    void onMouseLeave() override;
 
 private:
     // UI Components

--- a/Source/Panels/TransportBar.h
+++ b/Source/Panels/TransportBar.h
@@ -26,6 +26,8 @@
 #include <functional>
 #include <string>
 
+namespace AestraUI { class NUIPlatformBridge; }
+
 namespace Aestra {
 
 /**
@@ -104,6 +106,9 @@ public:
         The KEYS status pill hides instead of rendering underneath them. */
     void setRightReservedWidth(float width);
 
+    /** @brief Set the platform bridge for hover cursor styling (hand on buttons). */
+    void setPlatformBridge(AestraUI::NUIPlatformBridge* bridge) { m_platformBridge = bridge; }
+
 private:
     // UI Components
     std::shared_ptr<AestraUI::NUIButton> m_playButton;
@@ -152,6 +157,7 @@ private:
     std::function<void(float)> m_onTempoChange;
     std::function<void(bool)> m_onMetronomeToggle;
     std::function<void(int)> m_onTimeSignatureChange;
+    AestraUI::NUIPlatformBridge* m_platformBridge = nullptr;
     
     // Tool/Scale Callbacks
     std::function<void(AestraUI::GlobalTool)> m_onToolChanged;

--- a/Tests/AestraAudio/CountInEngineTest.cpp
+++ b/Tests/AestraAudio/CountInEngineTest.cpp
@@ -1,0 +1,145 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// CountInEngineTest — engine-side count-in lifecycle through the command queue.
+//
+// The count-in / recording sweep: AestraContent pushes MetronomeCountInStart via
+// the audio command queue, the engine renders the configured beats headless, and
+// the count-in clears when done — that clearing is what the app polls to finish
+// the count-in and start playback/recording. This test pins the engine half.
+
+#include "Core/AudioEngine.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t kFrames = 256;
+constexpr uint32_t kChannels = 2;
+
+int g_failures = 0;
+
+bool require(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++g_failures;
+    }
+    return condition;
+}
+
+std::unique_ptr<AudioEngine> makeEngine(float bpm = 120.0f) {
+    auto engine = std::make_unique<AudioEngine>();
+    engine->setSampleRate(kSampleRate);
+    engine->setBufferConfig(kFrames, kChannels);
+    engine->setSafetyLimiterEnabled(false);
+    engine->setAuditionModeEnabled(false);
+    engine->setMetronomeEnabled(false); // Count-in must work even when off.
+    engine->setBPM(bpm);
+    require(engine->initialize(), "AudioEngine initialization failed");
+    return engine;
+}
+
+std::vector<float> renderBlock(AudioEngine& engine) {
+    std::vector<float> output(static_cast<size_t>(kFrames) * kChannels, 0.0f);
+    engine.processBlock(output.data(), nullptr, kFrames, 0.0);
+    return output;
+}
+
+float peakMagnitude(const std::vector<float>& samples) {
+    float peak = 0.0f;
+    for (float sample : samples) {
+        peak = std::max(peak, std::abs(sample));
+    }
+    return peak;
+}
+
+void testCountInActivatesAndCompletes() {
+    std::cout << "  [1/3] Count-in activates and completes via command queue... ";
+    auto engine = makeEngine(); // 120 bpm → 24000 samples/beat.
+
+    AudioQueueCommand start{};
+    start.type = AudioQueueCommandType::MetronomeCountInStart;
+    start.value1 = 4.0f; // 4 beats
+    require(engine->commandQueue().push(start), "count-in command queued");
+
+    // The command is applied on the RT drain (a block or two later), then the
+    // count-in stays active for the configured beats.
+    renderBlock(*engine);
+    renderBlock(*engine);
+    require(engine->isMetronomeCountInActive(), "count-in activates from the queued command");
+
+    // 4 beats × 24000 = 96000 samples = 375 blocks. Render until it clears.
+    constexpr uint32_t kMaxBlocks = 420; // margin past 375
+    for (uint32_t i = 0; i < kMaxBlocks && engine->isMetronomeCountInActive(); ++i) {
+        renderBlock(*engine);
+    }
+    require(!engine->isMetronomeCountInActive(), "count-in clears after the configured beats");
+
+    std::cout << "PASSED\n";
+}
+
+void testCountInStopClearsImmediately() {
+    std::cout << "  [2/3] Count-in can be stopped (cancel path)... ";
+    auto engine = makeEngine();
+    AudioQueueCommand start{};
+    start.type = AudioQueueCommandType::MetronomeCountInStart;
+    start.value1 = 8.0f;
+    require(engine->commandQueue().push(start), "count-in command queued");
+    renderBlock(*engine);
+    renderBlock(*engine); // the RT drain applies the start
+    require(engine->isMetronomeCountInActive(), "count-in active");
+
+    AudioQueueCommand stop{};
+    stop.type = AudioQueueCommandType::MetronomeCountInStop;
+    require(engine->commandQueue().push(stop), "count-in stop queued");
+    renderBlock(*engine); // pump so the RT drains the stop
+    renderBlock(*engine); // stop latches immediately once drained
+    require(!engine->isMetronomeCountInActive(), "count-in cleared by the stop command");
+
+    std::cout << "PASSED\n";
+}
+
+void testCountInRefusedWithZeroBeats() {
+    std::cout << "  [3/3] Zero-beat request degrades to one beat, then clears... ";
+    auto engine = makeEngine();
+    AudioQueueCommand start{};
+    start.type = AudioQueueCommandType::MetronomeCountInStart;
+    start.value1 = 0.0f; // clamped to 1
+    require(engine->commandQueue().push(start), "zero-beat command queued");
+    renderBlock(*engine);
+    renderBlock(*engine); // the RT drain applies the clamped request
+    require(engine->isMetronomeCountInActive(), "count-in active after clamped request");
+
+    constexpr uint32_t kOneBeatBlocks = 24000 / kFrames + 4; // 94 + margin
+    for (uint32_t i = 0; i < kOneBeatBlocks && engine->isMetronomeCountInActive(); ++i) {
+        renderBlock(*engine);
+    }
+    require(!engine->isMetronomeCountInActive(), "one-beat count-in completed");
+
+    std::cout << "PASSED\n";
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Count-In Engine Tests ===\n";
+    std::cout << "(Command-queue count-in lifecycle, no audio hardware)\n\n";
+
+    testCountInActivatesAndCompletes();
+    testCountInStopClearsImmediately();
+    testCountInRefusedWithZeroBeats();
+
+    std::cout << "\n";
+    if (g_failures > 0) {
+        std::cout << "FAILED: " << g_failures << " assertion(s).\n";
+        return 1;
+    }
+    std::cout << "All count-in engine tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/CountInEngineTest.cpp
+++ b/Tests/AestraAudio/CountInEngineTest.cpp
@@ -51,14 +51,6 @@ std::vector<float> renderBlock(AudioEngine& engine) {
     return output;
 }
 
-float peakMagnitude(const std::vector<float>& samples) {
-    float peak = 0.0f;
-    for (float sample : samples) {
-        peak = std::max(peak, std::abs(sample));
-    }
-    return peak;
-}
-
 void testCountInActivatesAndCompletes() {
     std::cout << "  [1/3] Count-in activates and completes via command queue... ";
     auto engine = makeEngine(); // 120 bpm → 24000 samples/beat.
@@ -105,7 +97,7 @@ void testCountInStopClearsImmediately() {
     std::cout << "PASSED\n";
 }
 
-void testCountInRefusedWithZeroBeats() {
+void testZeroBeatRequestClampsToOneBeat() {
     std::cout << "  [3/3] Zero-beat request degrades to one beat, then clears... ";
     auto engine = makeEngine();
     AudioQueueCommand start{};
@@ -133,7 +125,7 @@ int main() {
 
     testCountInActivatesAndCompletes();
     testCountInStopClearsImmediately();
-    testCountInRefusedWithZeroBeats();
+    testZeroBeatRequestClampsToOneBeat();
 
     std::cout << "\n";
     if (g_failures > 0) {

--- a/Tests/AestraAudio/CountInRecordingTest.cpp
+++ b/Tests/AestraAudio/CountInRecordingTest.cpp
@@ -94,7 +94,7 @@ PlaylistLaneID takeLaneOf(TrackManager& tm, uint64_t trackId) {
 // Test 1: Count-in is a universal lead-in (requires no record arm), but is
 // refused while a count-in is already pending or the transport is rolling.
 bool testCountInLeadInWithoutArm() {
-    std::cout << "  [1/4] Count-in runs without record arm... ";
+    std::cout << "  [1/5] Count-in runs without record arm... ";
     auto tm = makeRecorder();
 
     // No record arm, not even a track: count-in still begins (lead-in before
@@ -122,7 +122,7 @@ bool testCountInLeadInWithoutArm() {
 
 // Test 2: Record → Count-in → Recording starts — the P0 regression.
 bool testCountInRecordingFlow() {
-    std::cout << "  [2/4] Record → count-in → recording starts... ";
+    std::cout << "  [2/5] Record → count-in → recording starts... ";
     auto tm = makeRecorder();
     Aestra::Tests::ScopedTempDirectory dir{"CountInRecording"};
     tm->setRecordingProjectPath((dir.path() / "countin.aes").string());
@@ -179,7 +179,7 @@ bool testCountInRecordingFlow() {
 
 // Test 3: Cancelling the count-in drops the pending state and the alignment.
 bool testCountInCancelDropsDeferral() {
-    std::cout << "  [3/4] Cancel drops pending state and deferral... ";
+    std::cout << "  [3/5] Cancel drops pending state and deferral... ";
     auto tm = makeRecorder();
     Aestra::Tests::ScopedTempDirectory dir{"CountInCancel"};
     tm->setRecordingProjectPath((dir.path() / "cancel.aes").string());

--- a/Tests/AestraAudio/CountInRecordingTest.cpp
+++ b/Tests/AestraAudio/CountInRecordingTest.cpp
@@ -1,0 +1,304 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// CountInRecordingTest — Count-in → recording contract.
+//
+// Regression for the count-in/recording sweep: "Record → Count-in → Recording
+// starts". The count-in state machine lives on TrackManager (the canonical
+// transport contract) so this runs headless, no audio hardware required.
+//
+// Covered:
+//   - beginCountIn() is a universal lead-in (no record arm required).
+//   - Record (arm) → count-in pending → completeCountIn() starts playback.
+//   - The deferred recording start aligns capture to the post-count-in beat:
+//     samples fed before the target beat are not captured; the committed take
+//     starts exactly on it.
+//   - cancelCountIn() drops the pending count-in and the deferred alignment.
+//   - A non-armed count-in must not leave a stale deferred start that would
+//     misalign a later, non-count-in recording.
+
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "../Support/TestTempDirectory.h"
+
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr double kBpm = 120.0; // 2 beats/second
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (!condition) {
+        std::cerr << "  FAIL: " << label << "\n";
+        ++g_failures;
+    } else {
+        std::cout << "  PASS: " << label << "\n";
+    }
+}
+
+std::shared_ptr<TrackManager> makeRecorder() {
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+    tm->getPlaylistModel().setBPM(kBpm);
+    tm->setInputChannelCount(1);
+    tm->setMaxRecordingSeconds(5.0);
+    return tm;
+}
+
+/** Create a lane, a channel, and a Track owning the lane and routing to the
+ *  channel. Returns 0 on failure (caller decides whether to arm). */
+uint64_t makeTrack(TrackManager& tm, const std::string& name) {
+    const PlaylistLaneID laneId = tm.getPlaylistModel().createLane(name);
+    MixerChannel* ch = tm.addChannel(name);
+    if (!ch) {
+        return 0;
+    }
+    ch->setInputChannelIndex(0);
+    return tm.createTrack(laneId, name, ch->getChannelId());
+}
+
+/** Feed a block of frames at a given transport position (simulates the engine
+ *  advancing to that position before the block). */
+void feedAt(TrackManager& tm, double positionSeconds, double blockSeconds) {
+    tm.setPosition(positionSeconds);
+    const uint32_t frames = static_cast<uint32_t>(blockSeconds * static_cast<double>(kSampleRate));
+    std::vector<float> input(frames);
+    for (uint32_t i = 0; i < frames; ++i) {
+        input[i] = 0.25f * std::sin(2.0 * 3.14159265 * 440.0 * static_cast<double>(i) / static_cast<double>(kSampleRate));
+    }
+    tm.processInput(input.data(), frames);
+}
+
+/** The lane holding a recorded take clip, or an invalid id. */
+PlaylistLaneID takeLaneOf(TrackManager& tm, uint64_t trackId) {
+    auto* track = tm.getTrack(trackId);
+    if (!track) {
+        return {};
+    }
+    for (const auto& laneId : track->laneIds) {
+        auto* lane = tm.getPlaylistModel().getLane(laneId);
+        if (lane && !lane->clips.empty()) {
+            return laneId;
+        }
+    }
+    return {};
+}
+
+// Test 1: Count-in is a universal lead-in (requires no record arm), but is
+// refused while a count-in is already pending or the transport is rolling.
+bool testCountInLeadInWithoutArm() {
+    std::cout << "  [1/4] Count-in runs without record arm... ";
+    auto tm = makeRecorder();
+
+    // No record arm, not even a track: count-in still begins (lead-in before
+    // playback). With no capture armed it degrades to a plain count-in + play.
+    check(tm->beginCountIn(4, 0.0), "accepted with no record arm");
+    check(tm->isCountInPending(), "count-in pending after begin");
+    tm->cancelCountIn();
+    check(!tm->isCountInPending(), "no longer pending after cancel");
+
+    const uint64_t trackId = makeTrack(*tm, "Track");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    check(tm->beginCountIn(4, 0.0), "accepted with an unarmed track");
+    check(!tm->beginCountIn(4, 0.0), "refused while already pending");
+    tm->completeCountIn();
+    check(tm->isPlaying(), "transport started after the count-in completed");
+    check(!tm->isCountInPending(), "pending cleared after completion");
+    check(!tm->beginCountIn(4, 0.0), "refused while transport is rolling");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 2: Record → Count-in → Recording starts — the P0 regression.
+bool testCountInRecordingFlow() {
+    std::cout << "  [2/4] Record → count-in → recording starts... ";
+    auto tm = makeRecorder();
+    Aestra::Tests::ScopedTempDirectory dir{"CountInRecording"};
+    tm->setRecordingProjectPath((dir.path() / "countin.aes").string());
+
+    const uint64_t trackId = makeTrack(*tm, "Take");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, true);
+    tm->record(); // Record press arms the transport.
+
+    // Pressing Play (with count-in) pins the position and starts the 4-beat
+    // count-in; the transport must NOT be rolling yet.
+    check(tm->beginCountIn(4, 1.0), "count-in began at 1.0s (beat 2.0)");
+    check(tm->isCountInPending(), "transport is in the count-in phase");
+    check(!tm->isPlaying(), "transport not rolling during count-in");
+
+    // Engine count-in metronome finished → app calls completeCountIn().
+    tm->completeCountIn();
+    check(tm->isPlaying(), "transport starts after count-in");
+    check(!tm->isCountInPending(), "count-in cleared after completion");
+
+    // Engine confirms transport rolling; capture begins. To prove the
+    // deferred alignment contract, the capture starts BEFORE the transport has
+    // reached the target beat — the block fed there must not be recorded.
+    tm->setPosition(0.75);
+    tm->onTransportStateApplied(true, static_cast<uint64_t>(0.75 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+    check(tm->isRecording(), "capture session began when transport applied");
+
+    feedAt(*tm, 0.75, 0.25);  // beat 1.5 → below deferred 2.0, must be skipped
+    feedAt(*tm, 1.0, 0.25);   // beat 2.0 → capture starts
+    feedAt(*tm, 1.25, 0.25);  // beat 2.5 → captured
+
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.5 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+    check(!tm->isRecording(), "capture finalized on stop");
+
+    const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+    check(takeLane.isValid(), "recorded take landed on a lane");
+    if (!takeLane.isValid()) {
+        return false;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLane);
+    const ClipInstance& clip = lane->clips.front();
+    // 0.5s captured (beats 2.0→3.0) — the 0.25s fed before the target was cut.
+    check(std::abs(clip.startBeat - 2.0) < 0.001, "take aligned to the post-count-in beat (start 2.0)");
+    check(std::abs(clip.durationBeats - 1.0) < 0.001, "take length excludes pre-count-in audio (1.0 beat)");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 3: Cancelling the count-in drops the pending state and the alignment.
+bool testCountInCancelDropsDeferral() {
+    std::cout << "  [3/4] Cancel drops pending state and deferral... ";
+    auto tm = makeRecorder();
+    Aestra::Tests::ScopedTempDirectory dir{"CountInCancel"};
+    tm->setRecordingProjectPath((dir.path() / "cancel.aes").string());
+
+    const uint64_t trackId = makeTrack(*tm, "Take");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, true);
+    tm->record();
+    check(tm->beginCountIn(4, 1.0), "count-in began");
+    tm->cancelCountIn();
+    check(!tm->isCountInPending(), "pending state cleared");
+
+    // A subsequent plain play must not defer recording.
+    tm->setPosition(0.5);
+    tm->onTransportStateApplied(true, static_cast<uint64_t>(0.5 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+    feedAt(*tm, 0.5, 0.25);
+    feedAt(*tm, 0.75, 0.25);
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+
+    const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+    check(takeLane.isValid(), "take committed after cancel + play");
+    if (!takeLane.isValid()) {
+        return false;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLane);
+    const ClipInstance& clip = lane->clips.front();
+    // 0.5s from beat 1.0 → 2.0, no deferral involved.
+    check(std::abs(clip.startBeat - 1.0) < 0.001, "no deleted deferral — take starts at play position");
+    check(std::abs(clip.durationBeats - 1.0) < 0.001, "full 0.5s captured");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 4: A non-armed count-in must not poison a later recording — the stale
+// deferred start (from the plain lead-in) must not skip frames of a subsequent,
+// non-count-in capture.
+bool testUnarmedCountInDoesNotPoisonLaterRecording() {
+    std::cout << "  [4/5] Unarmed count-in does not misalign a later recording... ";
+    auto tm = makeRecorder();
+    Aestra::Tests::ScopedTempDirectory dir{"CountInNoPoison"};
+    tm->setRecordingProjectPath((dir.path() / "nopoison.aes").string());
+
+    // Plain lead-in at 1.0s (beat 2.0), with no record arm and no armed track.
+    check(tm->beginCountIn(4, 1.0), "unarmed count-in began");
+    tm->completeCountIn();
+    check(!tm->isCountInPending(), "count-in completed");
+
+    // Now arm a track and record from a DIFFERENT position, without count-in.
+    const uint64_t trackId = makeTrack(*tm, "Take");
+    check(trackId != 0, "track created");
+    if (trackId == 0) {
+        return false;
+    }
+    tm->setTrackArmed(trackId, true);
+    tm->record(); // arm the transport
+
+    tm->setPosition(0.5);
+    tm->onTransportStateApplied(true, static_cast<uint64_t>(0.5 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+    feedAt(*tm, 0.5, 0.25); // beat 1.0 → 1.5
+    feedAt(*tm, 0.75, 0.25); // beat 1.5 → 2.0
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(1.0 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+
+    const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+    check(takeLane.isValid(), "take committed after the plain lead-in");
+    if (!takeLane.isValid()) {
+        return false;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLane);
+    const ClipInstance& clip = lane->clips.front();
+    // Full 0.5s at beat 1.0 — the stale beat-2.0 deferral must be gone.
+    check(std::abs(clip.startBeat - 1.0) < 0.001, "capture starts at the new play position, not the old count-in beat");
+    check(std::abs(clip.durationBeats - 1.0) < 0.001, "no frames skipped by a stale deferral");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 5: CompleteCountIn is a no-op without a pending count-in.
+bool testCompleteWithoutPendingIsNoop() {
+    std::cout << "  [5/5] completeCountIn no-ops when idle... ";
+    auto tm = makeRecorder();
+    const uint64_t trackId = makeTrack(*tm, "Track");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, true);
+    tm->record();
+    tm->completeCountIn();
+    check(!tm->isCountInPending(), "no pending state appeared");
+    check(!tm->isPlaying(), "transport did not start unexpectedly");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Count-In Recording Tests ===\n";
+    std::cout << "(Count-in → recording alignment, headless)\n\n";
+
+    const bool ok = testCountInLeadInWithoutArm() & testCountInRecordingFlow() & testCountInCancelDropsDeferral() &
+                    testUnarmedCountInDoesNotPoisonLaterRecording() & testCompleteWithoutPendingIsNoop();
+    check(g_failures == 0, "no failures");
+
+    std::cout << "\n";
+    if (!ok || g_failures > 0) {
+        std::cout << "FAILED: " << g_failures << " count-in recording assertions failed.\n";
+        return 1;
+    }
+    std::cout << "All count-in recording tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/MixerSerializationTest.cpp
+++ b/Tests/AestraAudio/MixerSerializationTest.cpp
@@ -1,0 +1,92 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// MixerSerializationTest — session-fidelity contract for mixer knob state.
+//
+// Extra Session 2026-08-21: "If a parameter changes the sound of a session,
+// reopening the project must reproduce that sound state." Trim, pan and width
+// are the mixer knobs this pins down.
+
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "../../Source/Core/ProjectSerializer.h"
+#include "../Support/TestTempDirectory.h"
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr double kBpm = 120.0;
+constexpr uint32_t kSampleRate = 48000;
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << "\n";
+        ++g_failures;
+    } else {
+        std::cout << "PASS: " << label << "\n";
+    }
+}
+
+bool near(float a, float b, float eps = 0.001f) {
+    return std::abs(a - b) < eps;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Mixer Serialization Tests ===\n";
+    std::cout << "(Trim/Pan/Width survive save/reopen)\n\n";
+
+    Aestra::Tests::ScopedTempDirectory dir{"MixerSerialization"};
+    const std::string projectPath = (dir.path() / "mixer.aes").string();
+
+    auto saved = std::make_shared<TrackManager>();
+    saved->setOutputSampleRate(static_cast<double>(kSampleRate));
+    MixerChannel* ch = saved->addChannel("Lead");
+    check(ch != nullptr, "channel created");
+    if (!ch) {
+        return 1;
+    }
+
+    // Non-default knob positions (the values a producer would actually set).
+    const float kTrimDb = -3.5f;
+    const float kPan = 0.25f;
+    const float kWidth = 1.75f;
+    const float kVolume = 0.8f;
+    ch->setTrimDb(kTrimDb);
+    ch->setPan(kPan);
+    ch->setWidth(kWidth);
+    ch->setVolume(kVolume);
+
+    const bool okSave = ProjectSerializer::save(projectPath, saved, kBpm, 0.0);
+    check(okSave, "project saved");
+
+    auto loaded = std::make_shared<TrackManager>();
+    loaded->setOutputSampleRate(static_cast<double>(kSampleRate));
+    const auto result = ProjectSerializer::load(projectPath, loaded);
+    check(result.ok, "project loaded");
+    if (result.ok) {
+        check(loaded->getChannelCount() == 1, "one channel after load");
+        auto* loadedChannel = loaded->getChannel(0);
+        check(loadedChannel != nullptr, "loaded channel resolvable");
+        if (loadedChannel) {
+            check(near(loadedChannel->getTrimDb(), kTrimDb), "trim survives save/reopen");
+            check(near(loadedChannel->getPan(), kPan), "pan survives save/reopen");
+            check(near(loadedChannel->getWidth(), kWidth), "width survives save/reopen");
+            check(near(loadedChannel->getVolume(), kVolume), "volume survives save/reopen");
+        }
+    }
+
+    std::cout << "\n";
+    if (g_failures > 0) {
+        std::cout << "FAILED: " << g_failures << " assertion(s).\n";
+        return 1;
+    }
+    std::cout << "All mixer serialization tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/MixerSerializationTest.cpp
+++ b/Tests/AestraAudio/MixerSerializationTest.cpp
@@ -32,7 +32,7 @@ void check(bool condition, const std::string& label) {
     }
 }
 
-bool near(float a, float b, float eps = 0.001f) {
+bool valuesClose(float a, float b, float eps = 0.001f) {
     return std::abs(a - b) < eps;
 }
 
@@ -75,10 +75,10 @@ int main() {
         auto* loadedChannel = loaded->getChannel(0);
         check(loadedChannel != nullptr, "loaded channel resolvable");
         if (loadedChannel) {
-            check(near(loadedChannel->getTrimDb(), kTrimDb), "trim survives save/reopen");
-            check(near(loadedChannel->getPan(), kPan), "pan survives save/reopen");
-            check(near(loadedChannel->getWidth(), kWidth), "width survives save/reopen");
-            check(near(loadedChannel->getVolume(), kVolume), "volume survives save/reopen");
+            check(valuesClose(loadedChannel->getTrimDb(), kTrimDb), "trim survives save/reopen");
+            check(valuesClose(loadedChannel->getPan(), kPan), "pan survives save/reopen");
+            check(valuesClose(loadedChannel->getWidth(), kWidth), "width survives save/reopen");
+            check(valuesClose(loadedChannel->getVolume(), kVolume), "volume survives save/reopen");
         }
     }
 

--- a/Tests/AestraAudio/RecordingCleanupTest.cpp
+++ b/Tests/AestraAudio/RecordingCleanupTest.cpp
@@ -14,6 +14,7 @@
 
 #include "Core/MixerChannel.h"
 #include "Models/TrackManager.h"
+#include "../../Source/Core/ProjectSerializer.h"
 #include "../Support/TestTempDirectory.h"
 
 #include <cmath>
@@ -22,6 +23,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -171,7 +173,7 @@ bool testDiscardedTakeRemoved() {
 
 // Test 3: An on-disk project reference keeps a discarded take.
 bool testProjectReferenceKeeps() {
-    std::cout << "  [3/5] On-disk reference keeps the WAV... ";
+    std::cout << "  [3/5] On-disk reference keeps the WAV (real project-file scan)... ";
     Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupReferenced"};
     const std::string projectPath = (dir.path() / "referenced.aes").string();
     auto tm = makeRecorder(projectPath);
@@ -183,8 +185,13 @@ bool testProjectReferenceKeeps() {
     tm->record();
     recordTake(*tm, 0.5);
 
-    // Simulate a saved project that still references the take: the app's
-    // keepCheck scans the on-disk .aes for the recording path.
+    // Save the project the way AestraApp does: sources[] persists the take's
+    // path in generic (forward-slash) form. Then discard the take.
+    const bool saved = ProjectSerializer::save(projectPath, tm, kBpm, 0.0);
+    check(saved, "project saved with the take");
+    if (!saved) {
+        return false;
+    }
     const std::string wavPath = [&] {
         std::error_code ec;
         for (const auto& e : std::filesystem::directory_iterator(recordingsDir(projectPath), ec)) {
@@ -196,11 +203,22 @@ bool testProjectReferenceKeeps() {
     }();
     check(!wavPath.empty(), "recorded WAV path resolved");
     tm->getCommandHistory().undo();
-    std::function<bool(const std::string&)> keep = [wavPath](const std::string& p) {
-        return p == wavPath;
+
+    // Exercise the app's real keeper flow (AestraApp::cleanupUnreferencedRecordings
+    // → pathAppearsInFile): keep the WAV when the on-disk project text contains its
+    // generic serialized path. This catches serialized-path vs scan mismatches.
+    const auto keeper = [&projectPath](const std::string& p) -> bool {
+        const std::string generic = std::filesystem::path(p).generic_string();
+        std::ifstream in(projectPath, std::ios::in | std::ios::binary);
+        if (!in) {
+            return false;
+        }
+        std::ostringstream buffer;
+        buffer << in.rdbuf();
+        return buffer.str().find(generic) != std::string::npos;
     };
-    const size_t removed = tm->cleanupOrphanedRecordings(keep);
-    check(removed == 0, "referenced discard kept");
+    const size_t removed = tm->cleanupOrphanedRecordings(keeper);
+    check(removed == 0, "project-referenced discard kept");
     check(wavCount(recordingsDir(projectPath)) == 1, "WAV still on disk");
 
     std::cout << "PASSED\n";

--- a/Tests/AestraAudio/RecordingCleanupTest.cpp
+++ b/Tests/AestraAudio/RecordingCleanupTest.cpp
@@ -1,0 +1,270 @@
+// © 2025 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+// RecordingCleanupTest — reference-aware recording file cleanup.
+//
+// Regression for the recording-lifecycle sweep: WAVs accumulate in the
+// Recordings folder when takes are discarded. cleanupOrphanedRecordings() may
+// only remove files no live clip references and no on-disk project references,
+// and only when recording is not in progress.
+//
+// Covered:
+//   - a committed (kept) take's WAV survives cleanup,
+//   - an undone (discarded) take's WAV is removed and its source dropped,
+//   - an on-disk project reference (keepCheck) keeps a discard,
+//   - cleanup no-ops while recording is in progress.
+
+#include "Core/MixerChannel.h"
+#include "Models/TrackManager.h"
+#include "../Support/TestTempDirectory.h"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr double kBpm = 120.0;
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label) {
+    if (!condition) {
+        std::cerr << "  FAIL: " << label << "\n";
+        ++g_failures;
+    } else {
+        std::cout << "  PASS: " << label << "\n";
+    }
+}
+
+std::shared_ptr<TrackManager> makeRecorder(const std::string& projectPath) {
+    auto tm = std::make_shared<TrackManager>();
+    tm->setOutputSampleRate(static_cast<double>(kSampleRate));
+    tm->getPlaylistModel().setBPM(kBpm);
+    tm->setInputChannelCount(1);
+    tm->setMaxRecordingSeconds(5.0);
+    tm->setRecordingProjectPath(projectPath);
+    return tm;
+}
+
+uint64_t armTrack(TrackManager& tm, const std::string& name) {
+    const PlaylistLaneID laneId = tm.getPlaylistModel().createLane(name);
+    MixerChannel* ch = tm.addChannel(name);
+    if (!ch) {
+        return 0;
+    }
+    ch->setInputChannelIndex(0);
+    const uint64_t trackId = tm.createTrack(laneId, name, ch->getChannelId());
+    if (trackId != 0) {
+        tm.setTrackArmed(trackId, true);
+    }
+    return trackId;
+}
+
+void feedInput(TrackManager& tm, double seconds) {
+    const uint32_t frames = static_cast<uint32_t>(seconds * static_cast<double>(kSampleRate));
+    std::vector<float> input(frames);
+    for (uint32_t i = 0; i < frames; ++i) {
+        input[i] = 0.25f * std::sin(2.0 * 3.14159265 * 440.0 * static_cast<double>(i) / static_cast<double>(kSampleRate));
+    }
+    tm.processInput(input.data(), frames);
+}
+
+/** Record a take: transport on → capture → transport off → commit. */
+void recordTake(TrackManager& tm, double seconds) {
+    tm.onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
+    feedInput(tm, seconds);
+    tm.onTransportStateApplied(false, static_cast<uint64_t>(seconds * kSampleRate), static_cast<double>(kSampleRate));
+}
+
+std::string recordingsDir(const std::string& projectPath) {
+    return (std::filesystem::path(projectPath).parent_path() / "Recordings").string();
+}
+
+size_t wavCount(const std::string& dir) {
+    std::error_code ec;
+    size_t n = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+        if (entry.is_regular_file(ec) && entry.path().extension() == ".wav") {
+            ++n;
+        }
+    }
+    return n;
+}
+
+// Test 1: A committed take's WAV survives cleanup.
+bool testKeptTakeSurvives() {
+    std::cout << "  [1/5] Committed take survives cleanup... ";
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupKept"};
+    const std::string projectPath = (dir.path() / "kept.aes").string();
+    auto tm = makeRecorder(projectPath);
+
+    const uint64_t trackId = armTrack(*tm, "Guitar");
+    check(trackId != 0, "track created");
+    if (trackId == 0) {
+        return false;
+    }
+    tm->record();
+    recordTake(*tm, 0.5);
+    check(wavCount(recordingsDir(projectPath)) == 1, "one WAV written after take");
+    check(tm->isRecording() == false, "capture finalized");
+
+    const size_t removed = tm->cleanupOrphanedRecordings({});
+    check(removed == 0, "no orphaned recordings removed");
+    check(wavCount(recordingsDir(projectPath)) == 1, "kept take's WAV still on disk");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 2: An undone (discarded) take's WAV is removed.
+bool testDiscardedTakeRemoved() {
+    std::cout << "  [2/5] Discarded take removed... ";
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupDiscard"};
+    const std::string projectPath = (dir.path() / "discard.aes").string();
+    auto tm = makeRecorder(projectPath);
+
+    const uint64_t trackId = armTrack(*tm, "Guitar");
+    if (trackId == 0) {
+        return false;
+    }
+    tm->record();
+    recordTake(*tm, 0.5);
+    check(wavCount(recordingsDir(projectPath)) == 1, "one WAV after take");
+
+    // User discards the take (undo). The clip/lane are peeled off; the WAV
+    // remains on disk (nothing deleted at undo time — redo must still work).
+    tm->getCommandHistory().undo();
+    check(wavCount(recordingsDir(projectPath)) == 1, "undo alone leaves the WAV for redo");
+
+    const std::string realWavPath = [&] {
+        const std::string dirPath = recordingsDir(projectPath);
+        std::error_code ec;
+        for (const auto& e : std::filesystem::directory_iterator(dirPath, ec)) {
+            if (e.path().extension() == ".wav") {
+                return e.path().string();
+            }
+        }
+        return std::string{};
+    }();
+    check(!realWavPath.empty(), "discarded WAV path resolved");
+    check(tm->getSourceManager().findSourceByPath(realWavPath).isValid(), "WAV registered as a source");
+
+    // Session boundary: history is being discarded, so the take is unreachable.
+    const size_t removed = tm->cleanupOrphanedRecordings({});
+    check(removed == 1, "discarded take's WAV removed");
+    check(wavCount(recordingsDir(projectPath)) == 0, "no recording files remain");
+
+    // The orphaned source registration must be dropped too (no dangling save).
+    check(tm->getSourceManager().findSourceByPath(realWavPath).isValid() == false,
+          "orphaned source registration dropped");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 3: An on-disk project reference keeps a discarded take.
+bool testProjectReferenceKeeps() {
+    std::cout << "  [3/5] On-disk reference keeps the WAV... ";
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupReferenced"};
+    const std::string projectPath = (dir.path() / "referenced.aes").string();
+    auto tm = makeRecorder(projectPath);
+
+    const uint64_t trackId = armTrack(*tm, "Guitar");
+    if (trackId == 0) {
+        return false;
+    }
+    tm->record();
+    recordTake(*tm, 0.5);
+
+    // Simulate a saved project that still references the take: the app's
+    // keepCheck scans the on-disk .aes for the recording path.
+    const std::string wavPath = [&] {
+        std::error_code ec;
+        for (const auto& e : std::filesystem::directory_iterator(recordingsDir(projectPath), ec)) {
+            if (e.path().extension() == ".wav") {
+                return e.path().string();
+            }
+        }
+        return std::string{};
+    }();
+    check(!wavPath.empty(), "recorded WAV path resolved");
+    tm->getCommandHistory().undo();
+    std::function<bool(const std::string&)> keep = [wavPath](const std::string& p) {
+        return p == wavPath;
+    };
+    const size_t removed = tm->cleanupOrphanedRecordings(keep);
+    check(removed == 0, "referenced discard kept");
+    check(wavCount(recordingsDir(projectPath)) == 1, "WAV still on disk");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 4: Cleanup no-ops while recording is in progress.
+bool testNoCleanupWhileCapturing() {
+    std::cout << "  [4/5] No cleanup while recording... ";
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupInFlight"};
+    const std::string projectPath = (dir.path() / "inflight.aes").string();
+    auto tm = makeRecorder(projectPath);
+
+    const uint64_t trackId = armTrack(*tm, "Guitar");
+    if (trackId == 0) {
+        return false;
+    }
+    tm->record();
+    tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
+    check(tm->isRecording(), "capture in progress");
+    const size_t removed = tm->cleanupOrphanedRecordings({});
+    check(removed == 0, "cleanup refused during capture");
+
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(0.5 * kSampleRate), static_cast<double>(kSampleRate));
+    std::cout << "PASSED\n";
+    return true;
+}
+
+// Test 5: Cleanup only touches files under the recording root.
+bool testScopedToRecordingRoot() {
+    std::cout << "  [5/5] Cleanup scoped to the recording root... ";
+    Aestra::Tests::ScopedTempDirectory dir{"RecordingCleanupScope"};
+    const std::string projectPath = (dir.path() / "scope.aes").string();
+    auto tm = makeRecorder(projectPath);
+
+    // Unrelated audio files next to the recording root must never be touched.
+    const std::string outsider = (dir.path() / "keepme.wav").string();
+    {
+        std::ofstream out(outsider, std::ios::binary | std::ios::trunc);
+        out << "not a recording";
+    }
+    const size_t removed = tm->cleanupOrphanedRecordings({});
+    check(removed == 0, "no recordings to remove");
+    check(std::filesystem::exists(outsider), "unrelated WAV untouched");
+
+    std::cout << "PASSED\n";
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "=== Recording Cleanup Tests ===\n";
+    std::cout << "(Reference-aware recording file lifecycle, headless)\n\n";
+
+    const bool ok = testKeptTakeSurvives() & testDiscardedTakeRemoved() & testProjectReferenceKeeps() &
+                    testNoCleanupWhileCapturing() & testScopedToRecordingRoot();
+    check(g_failures == 0, "no failures");
+
+    std::cout << "\n";
+    if (!ok || g_failures > 0) {
+        std::cout << "FAILED: " << g_failures << " recording cleanup assertions failed.\n";
+        return 1;
+    }
+    std::cout << "All recording cleanup tests passed.\n";
+    return 0;
+}

--- a/Tests/AestraAudio/RecordingCleanupTest.cpp
+++ b/Tests/AestraAudio/RecordingCleanupTest.cpp
@@ -117,7 +117,7 @@ bool testKeptTakeSurvives() {
     check(wavCount(recordingsDir(projectPath)) == 1, "one WAV written after take");
     check(tm->isRecording() == false, "capture finalized");
 
-    const size_t removed = tm->cleanupOrphanedRecordings({});
+    const size_t removed = tm->cleanupOrphanedRecordings({}).value();
     check(removed == 0, "no orphaned recordings removed");
     check(wavCount(recordingsDir(projectPath)) == 1, "kept take's WAV still on disk");
 
@@ -159,7 +159,7 @@ bool testDiscardedTakeRemoved() {
     check(tm->getSourceManager().findSourceByPath(realWavPath).isValid(), "WAV registered as a source");
 
     // Session boundary: history is being discarded, so the take is unreachable.
-    const size_t removed = tm->cleanupOrphanedRecordings({});
+    const size_t removed = tm->cleanupOrphanedRecordings({}).value();
     check(removed == 1, "discarded take's WAV removed");
     check(wavCount(recordingsDir(projectPath)) == 0, "no recording files remain");
 
@@ -217,7 +217,7 @@ bool testProjectReferenceKeeps() {
         buffer << in.rdbuf();
         return buffer.str().find(generic) != std::string::npos;
     };
-    const size_t removed = tm->cleanupOrphanedRecordings(keeper);
+    const size_t removed = tm->cleanupOrphanedRecordings(keeper).value();
     check(removed == 0, "project-referenced discard kept");
     check(wavCount(recordingsDir(projectPath)) == 1, "WAV still on disk");
 
@@ -239,8 +239,9 @@ bool testNoCleanupWhileCapturing() {
     tm->record();
     tm->onTransportStateApplied(true, 0, static_cast<double>(kSampleRate));
     check(tm->isRecording(), "capture in progress");
-    const size_t removed = tm->cleanupOrphanedRecordings({});
-    check(removed == 0, "cleanup refused during capture");
+    const auto removed = tm->cleanupOrphanedRecordings({});
+    check(!removed.has_value() || *removed == 0,
+          "cleanup refused or no-op while capture is in progress (never a partial run)");
 
     tm->onTransportStateApplied(false, static_cast<uint64_t>(0.5 * kSampleRate), static_cast<double>(kSampleRate));
     std::cout << "PASSED\n";
@@ -260,7 +261,7 @@ bool testScopedToRecordingRoot() {
         std::ofstream out(outsider, std::ios::binary | std::ios::trunc);
         out << "not a recording";
     }
-    const size_t removed = tm->cleanupOrphanedRecordings({});
+    const size_t removed = tm->cleanupOrphanedRecordings({}).value();
     check(removed == 0, "no recordings to remove");
     check(std::filesystem::exists(outsider), "unrelated WAV untouched");
 

--- a/Tests/AestraUI/PianoRollInteractionTest.cpp
+++ b/Tests/AestraUI/PianoRollInteractionTest.cpp
@@ -349,8 +349,15 @@ static void test_zoom_anchor_preserves_beat() {
 // anchor makes the beat under the cursor drift by the lane width per zoom.
 // ---------------------------------------------------------------------------
 static void test_ctrl_wheel_zoom_uses_grid_local_anchor() {
+    // Regression: the Ctrl+wheel zoom must anchor to the beat under the cursor
+    // even when the piano-roll panel sits AWAY from the window origin. Bounds
+    // are window-absolute, so the grid-local anchor is the event X minus the
+    // grid's own origin — subtracting the view position as well double-counted
+    // it and desynced the anchor by the panel's offset (bar 2 → bar 7 on
+    // zoom-out). The view at x=0 could never catch that.
     PianoRollView view;
-    view.setBounds({0.0f, 0.0f, 900.0f, 600.0f});
+    constexpr float kViewOffsetX = 412.0f; // panel sits 412 px into the window
+    view.setBounds({kViewOffsetX, 0.0f, 900.0f, 600.0f});
     view.onResize(900, 600);
     // startBeat 1.25 at 80 ppb over an 810 px grid: scrollX = 100.
     view.setViewWindow(1.25, 810.0 / 80.0);
@@ -358,17 +365,18 @@ static void test_ctrl_wheel_zoom_uses_grid_local_anchor() {
     // Default layout: key lane 76 px, vertical scrollbar 14 px.
     const float keyLaneWidth = 76.0f;
     const float gridWidthPx = 900.0f - keyLaneWidth - 14.0f;
-    const float cursorViewX = 500.0f;
+    const float gridLocalCursorX = 500.0f; // 500 px into the grid
+    const float cursorWindowX = kViewOffsetX + keyLaneWidth + gridLocalCursorX;
 
     const auto beatAtCursor = [&]() {
         const double ppb = static_cast<double>(gridWidthPx) / view.getViewDurationBeats();
-        return view.getViewStartBeat() + static_cast<double>(cursorViewX - keyLaneWidth) / ppb;
+        return view.getViewStartBeat() + static_cast<double>(gridLocalCursorX) / ppb;
     };
     const double beatBefore = beatAtCursor();
 
     NUIMouseEvent zoom;
     zoom.type = NUIMouseEventType::Scroll;
-    zoom.position = {cursorViewX, 300.0f};
+    zoom.position = {cursorWindowX, 300.0f};
     zoom.modifiers = NUIModifiers::Ctrl;
     zoom.wheelDelta = 1.0f;
     view.onMouseEvent(zoom);
@@ -378,6 +386,14 @@ static void test_ctrl_wheel_zoom_uses_grid_local_anchor() {
     const double beatAfter = beatAtCursor();
     ASSERT(std::abs(beatAfter - beatBefore) < 0.001,
            "ctrl-wheel zoom keeps the beat under the cursor stationary (grid-local anchor)");
+
+    // Zoom out from the same anchor and check again.
+    zoom.wheelDelta = -1.0f;
+    view.onMouseEvent(zoom);
+    ASSERT(view.getViewDurationBeats() > 10.0, "ctrl-wheel zoom-out fired");
+    const double beatAfterOut = beatAtCursor();
+    ASSERT(std::abs(beatAfterOut - beatBefore) < 0.001,
+           "ctrl-wheel zoom-out keeps the beat under the cursor stationary");
 
     // Invalid pixels-per-beat must be rejected, not stored.
     view.setPixelsPerBeat(120.0f);
@@ -389,7 +405,7 @@ static void test_ctrl_wheel_zoom_uses_grid_local_anchor() {
     ASSERT(std::abs(static_cast<double>(gridWidthPx) / view.getViewDurationBeats() - 120.0) < 0.001,
            "non-positive or non-finite pixels-per-beat is rejected");
 
-    PASS("ctrl-wheel zoom anchors on grid-local X");
+    PASS("ctrl-wheel zoom anchors on grid-local X (off-origin panel)");
 }
 
 // ---------------------------------------------------------------------------
@@ -475,6 +491,47 @@ static void test_grid_tiers_follow_snap() {
 }
 
 // ---------------------------------------------------------------------------
+// Scrollable-domain parity with the Track Manager timeline
+// ---------------------------------------------------------------------------
+
+static void test_scroll_domain_floor_and_growth() {
+    PianoRollView view;
+    view.setBounds({0.0f, 0.0f, 900.0f, 600.0f});
+    view.onResize(900, 600);
+    view.setBeatsPerBar(4);
+
+    // Empty: fixed 16-bar floor (64 beats @ 4/4), regardless of the (short)
+    // default pattern length.
+    view.setTotalDurationBeats(16.0);
+    view.setNotes({});
+    ASSERT(std::abs(view.getScrollDomainEndBeats() - 64.0) < 0.001,
+           "empty piano roll scroll domain is 16 bars");
+
+    // Content appears: dynamic padding (short content < 16 bars → +8 bars),
+    // matching the Track Manager's smart domain. A 4-bar pattern becomes 12.
+    AestraUI::MidiNote n;
+    n.startBeat = 0.0; n.durationBeats = 1.0; n.pitch = 60; n.velocity = 100;
+    view.setNotes({n});
+    ASSERT(std::abs(view.getScrollDomainEndBeats() - 48.0) < 0.001,
+           "content-bearing domain is pattern end + 8 bars");
+
+    // Long content (>= 64 bars) pads by 12.5%: 80 bars → 90 bars.
+    view.setTotalDurationBeats(320.0);
+    view.setNotes({n});
+    ASSERT(std::abs(view.getScrollDomainEndBeats() - 360.0) < 0.001,
+           "long content grows the domain by 12.5%");
+
+    // Time signature changes recompute the empty floor (3/4 → 48 beats).
+    view.setTotalDurationBeats(12.0);
+    view.setNotes({});
+    view.setBeatsPerBar(3);
+    ASSERT(std::abs(view.getScrollDomainEndBeats() - 48.0) < 0.001,
+           "empty floor follows the beat-per-bar count");
+
+    PASS("scroll domain: 16-bar empty floor + dynamic content growth");
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 int main() {
@@ -502,6 +559,7 @@ int main() {
     test_ctrl_wheel_zoom_uses_grid_local_anchor();
     test_grid_subdivision_matches_snap();
     test_grid_tiers_follow_snap();
+    test_scroll_domain_floor_and_growth();
 
     std::cout << "\n=== Results: " << testsPassed << " passed, " << testsFailed << " failed ===\n";
     return testsFailed > 0 ? 1 : 0;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1349,16 +1349,10 @@ target_link_libraries(CountInRecordingTest PRIVATE AestraAudio)
 target_include_directories(CountInRecordingTest PRIVATE
     ${CMAKE_SOURCE_DIR}/AestraAudio/include
     ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
     ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
-    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
     ${CMAKE_SOURCE_DIR}/AestraCore/include
     ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Tests
 )
 add_test(NAME CountInRecordingTest COMMAND CountInRecordingTest)
 set_tests_properties(CountInRecordingTest PROPERTIES LABELS "audio;recording;count-in;regression;contract:audio")
@@ -1367,6 +1361,7 @@ set_tests_properties(CountInRecordingTest PROPERTIES LABELS "audio;recording;cou
 # takes survive, discarded takes are removed only at session boundaries.
 add_executable(RecordingCleanupTest
     AestraAudio/RecordingCleanupTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
 )
 target_link_libraries(RecordingCleanupTest PRIVATE AestraAudio)
 target_include_directories(RecordingCleanupTest PRIVATE

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1375,6 +1375,24 @@ target_include_directories(RecordingCleanupTest PRIVATE
 add_test(NAME RecordingCleanupTest COMMAND RecordingCleanupTest)
 set_tests_properties(RecordingCleanupTest PROPERTIES LABELS "audio;recording;cleanup;regression;contract:audio")
 
+# Mixer knob state fidelity (Extra Session 2026-08-21): trim/pan/width must
+# survive save/reopen exactly.
+add_executable(MixerSerializationTest
+    AestraAudio/MixerSerializationTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+)
+target_link_libraries(MixerSerializationTest PRIVATE AestraAudio)
+target_include_directories(MixerSerializationTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Tests
+)
+add_test(NAME MixerSerializationTest COMMAND MixerSerializationTest)
+set_tests_properties(MixerSerializationTest PROPERTIES LABELS "audio;mixer;serialization;regression;contract:audio")
+
 # Phase 2 baseline of the Track/Lane/Channel migration (vault: ownership
 # the current channel-based reality that the migration intentionally changes.
 add_executable(RecordingBaselineTest

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1339,6 +1339,47 @@ target_include_directories(RecordingPathTest PRIVATE
 add_test(NAME RecordingPathTest COMMAND RecordingPathTest)
 set_tests_properties(RecordingPathTest PROPERTIES LABELS "audio;recording;regression;contract:audio")
 
+# Count-in → recording contract (the count-in/recording sweep): Record → Count-in
+# → Recording starts, with capture aligned to the post-count-in beat.
+add_executable(CountInRecordingTest
+    AestraAudio/CountInRecordingTest.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Core/ProjectSerializer.cpp
+)
+target_link_libraries(CountInRecordingTest PRIVATE AestraAudio)
+target_include_directories(CountInRecordingTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/DSP
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/IO
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Drivers
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Commands
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Headless
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+)
+add_test(NAME CountInRecordingTest COMMAND CountInRecordingTest)
+set_tests_properties(CountInRecordingTest PROPERTIES LABELS "audio;recording;count-in;regression;contract:audio")
+
+# Reference-aware recording file cleanup (the recording-lifecycle sweep): kept
+# takes survive, discarded takes are removed only at session boundaries.
+add_executable(RecordingCleanupTest
+    AestraAudio/RecordingCleanupTest.cpp
+)
+target_link_libraries(RecordingCleanupTest PRIVATE AestraAudio)
+target_include_directories(RecordingCleanupTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Models
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+    ${CMAKE_SOURCE_DIR}/Source
+    ${CMAKE_SOURCE_DIR}/Tests
+)
+add_test(NAME RecordingCleanupTest COMMAND RecordingCleanupTest)
+set_tests_properties(RecordingCleanupTest PROPERTIES LABELS "audio;recording;cleanup;regression;contract:audio")
+
 # Phase 2 baseline of the Track/Lane/Channel migration (vault: ownership
 # the current channel-based reality that the migration intentionally changes.
 add_executable(RecordingBaselineTest
@@ -1451,6 +1492,20 @@ target_include_directories(MetronomeRestartTest PRIVATE
 )
 add_test(NAME MetronomeRestartTest COMMAND MetronomeRestartTest)
 set_tests_properties(MetronomeRestartTest PROPERTIES LABELS "audio;metronome;transport;regression;contract:audio" TIMEOUT 120)
+
+# Count-in lifecycle through the audio command queue (count-in/recording sweep):
+# the engine renders the configured count-in beats and clears when done — the
+# signal the app polls to start recording.
+add_executable(CountInEngineTest AestraAudio/CountInEngineTest.cpp)
+target_link_libraries(CountInEngineTest PRIVATE AestraAudio)
+target_include_directories(CountInEngineTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Core
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include/Playback
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME CountInEngineTest COMMAND CountInEngineTest)
+set_tests_properties(CountInEngineTest PROPERTIES LABELS "audio;metronome;count-in;record;regression;contract:audio" TIMEOUT 120)
 
 # Realtime/Export Parity — realtime processBlock output vs offline
 # bounceRangeToWav output for the same session, plus the preview-ducking


### PR DESCRIPTION
## Decision citation

Objective:  TS-2 — producer-loop finishing
Decision:   FD-14 @ 89a00af
Kind:       corrective

## Summary

QoL/UX sweep — transport, cursor system, piano roll, mixer, recording lifecycle. 3 commits:

1. **Count-in + recording cleanup** — count-in is now a canonical TrackManager state machine, driven through new audio command types, and a universal lead-in (works without record-arm; recording still aligns to the post-count-in beat when armed). A non-armed count-in clears its deferred start so it can't misalign a later plain recording. Recorded WAVs become reference-aware: discarded takes (no live clip, no on-disk project reference) are removed at project New/Open boundaries; crash recovery is protected by deliberately **not** cleaning at shutdown.
2. **Unified cursor system + hand-tool sweep + piano-roll domain** — canonical cursor registry (single SVG source; ad-hoc drawLine glyphs removed), per-frame `resolveCursorState()` that makes the invisible-pointer failure impossible, platform mouse enter/leave, and grab/hand cursors on sliders, mixer faders, file-browser rows, transport buttons, the timeline ruler, and minimap viewport bodies. Piano roll gets Track-Manager-parity scroll domain (16-bar empty floor, dynamic) + a horizontal scrollbar + fixed off-origin Ctrl+wheel zoom anchor.
3. **App wiring** — `AestraContent::onUpdate` was never pumped (root content, not in the NUI tree); this resurrects count-in completion, sound-preview pumping, and mixer resync. Record-press enters count-in, the count-in completion waits for the engine to actually start clicking.

2. **Unified cursor system + hand-tool sweep + piano-roll domain** — canonical cursor registry (single SVG source; ad-hoc drawLine glyphs removed), per-frame `resolveCursorState()` that makes the invisible-pointer failure impossible, platform mouse enter/leave, and grab/hand cursors on sliders, mixer faders, file-browser rows, transport buttons, the timeline ruler, and minimap viewport bodies. Piano roll gets Track-Manager-parity scroll domain (16-bar empty floor, dynamic) + a horizontal scrollbar + fixed off-origin Ctrl+wheel zoom anchor.
3. **App wiring** — `AestraContent::onUpdate` was never pumped (root content, not in the NUI tree); this resurrects count-in completion, sound-preview pumping, and mixer resync. Record-press enters count-in, the count-in completion waits for the engine to actually start clicking.
4. **Extra Session triage batch** — mixer Trim serialized (+ SetTrimCommand undo/redo + load→RT buffer), Make Unique for MIDI/audio patterns in the clip menu, right-click clip = immediate delete (Shift+right-click keeps the full menu), sample dropped into an empty Arsenal auto-creates a sampler unit, and duplicated/painted clips are audible immediately while playing.

Also included: Master strip readout restored (held peak / integrated LUFS / gain), record icon matched to Play/Stop footprint.

## Why

Count-in didn't count in (never entered **and** completed instantly), custom cursors could strand invisible, recorded WAVs accumulated forever, piano-roll zoom/scroll didn't anchor or bound like the Track Manager, and the Master's live readout was zero-height.

## Testing performed

- `CountInRecordingTest` — 5/5 pass (universal lead-in, Record→Count-in→Recording starts + capture aligned, cancel, stale-deferral no-poison); the no-poison case provably fails without the fix.
- `CountInEngineTest` (command-queue count-in activates on block 2, audible, clears after N beats, stop honored) — 3/3.
- `RecordingCleanupTest` (kept/discarded/disk-referenced/in-flight/scoped) — 5/5.
- `PianoRollInteractionTest` (23 incl. off-origin zoom-anchor regression that fails on the old math) — 23/23.
- Focused `ctest` over recording/transport/cursor/piano/minimap — 14/14; broad `ctest -LE runtime|hardware|experimental|unstable` otherwise green.

**Pre-existing local failures (CI fresh verification, not caused by this change):** `SecLicenseProfileHardening`, `SecFreadTruncatedWav`, `SecProjectLoadHardening` fail in this core-mode box but pass on develop CI; the change touches none of the involved code (license parser, metronome WAV loader, ProjectSerializer).

## Producer note

Count-in now actually counts you in before recording, most draggable/mixer/transport/file controls show a hand cursor, and discarded takes stop piling up on disk. Mixer Trim now remembers where you left it after save/reopen (pan and width are covered too), duplicated patterns play right away instead of waiting for the loop, right-click on a clip deletes it instantly, and you can drag a sample straight into an empty Arsenal to start working.

## Risk / rollback notes

- The `AestraContent::onUpdate` pump reinstates the whole content update tree — a broad behavior change (the correct one); worth a manual session for preview/mixer/live count-in.
- Recording cleanup runs at project New/Open (safe: no pending recovery); recovery after a *crash* can still surface a missing-asset warning for an explicitly discarded take (consistent with any moved/deleted asset).
- Hand cursor on all sliders may feel strong on tiny knobs — trivial to scope down.
- Clang-format: new lines conform; some touched files carry pre-existing baseline deviations left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Added validated count-in and recording lifecycle handling, including cancellation, deferred starts, reference-aware cleanup, and crash-recovery protection.
- Unified cursor behavior across platforms and interactive controls.
- Improved piano-roll scrolling, minimap interaction, and Ctrl-wheel zoom anchoring.
- Added undoable clip “Make Unique” and mixer trim commands with project serialization.
- Improved timeline scheduling, mixer display, audio-file drops, clip actions, and transport feedback.
- Added regression tests for count-in, recording cleanup, mixer serialization, piano-roll behavior, and engine flows.
- Local validation reports 266/266 tests passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
