### PR TITLE
fix(ui): commit piano-roll lane edits immediately; invalidate arrangement cache on clip edits

### DIFF
--- a/AestraUI/Widgets/NUIPianoRollWidgets.h
+++ b/AestraUI/Widgets/NUIPianoRollWidgets.h
@@ -472,6 +472,10 @@ public:
     /** @brief Record an undo step for an edit applied externally (e.g. velocity lane). */
     void pushExternalEdit(const std::vector<MidiNote>& before, const std::string& description) {
         pushUndo(description, before, notes_);
+        // External edits must reach the model like every other gesture: without
+        // commitNotes() the onNotesChanged_ chain never runs, so PatternManager
+        // keeps the old value until an unrelated committing event flushes it.
+        commitNotes();
     }
 
     /** @brief Merge overlapping/touching selected notes on the same pitch into one. */

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -711,8 +711,9 @@ void AestraApp::buildMenuBar() {
         undoItem->setText(canUndo ? trackMgr->getCommandHistory().getUndoName() : "Undo");
         undoItem->setOnClick([this]() {
             if (m_content && m_content->getTrackManager()) {
-                m_content->getTrackManager()->getCommandHistory().undo();
-                m_content->refreshAfterHistoryChange();
+                // Guard on the result: a failed op must not mark the project modified.
+                if (m_content->getTrackManager()->getCommandHistory().undo())
+                    m_content->refreshAfterHistoryChange();
             }
         });
         menu->addItem(undoItem);
@@ -723,8 +724,9 @@ void AestraApp::buildMenuBar() {
         redoItem->setText(canRedo ? trackMgr->getCommandHistory().getRedoName() : "Redo");
         redoItem->setOnClick([this]() {
             if (m_content && m_content->getTrackManager()) {
-                m_content->getTrackManager()->getCommandHistory().redo();
-                m_content->refreshAfterHistoryChange();
+                // Guard on the result: a failed op must not mark the project modified.
+                if (m_content->getTrackManager()->getCommandHistory().redo())
+                    m_content->refreshAfterHistoryChange();
             }
         });
         menu->addItem(redoItem);

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -712,6 +712,7 @@ void AestraApp::buildMenuBar() {
         undoItem->setOnClick([this]() {
             if (m_content && m_content->getTrackManager()) {
                 m_content->getTrackManager()->getCommandHistory().undo();
+                m_content->refreshAfterHistoryChange();
             }
         });
         menu->addItem(undoItem);
@@ -723,6 +724,7 @@ void AestraApp::buildMenuBar() {
         redoItem->setOnClick([this]() {
             if (m_content && m_content->getTrackManager()) {
                 m_content->getTrackManager()->getCommandHistory().redo();
+                m_content->refreshAfterHistoryChange();
             }
         });
         menu->addItem(redoItem);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1097,6 +1097,10 @@ void AestraContent::setupArsenalPanels() {
 
     m_audioClipEditorPanel = std::make_shared<AudioClipEditorPanel>(m_trackManager);
     m_audioClipEditorPanel->setVisible(false);
+    m_audioClipEditorPanel->setOnClipEditsCommitted([this]() {
+        if (m_trackManagerUI)
+            m_trackManagerUI->invalidateCache();
+    });
     m_audioClipEditorPanel->setOnClose([this]() {
         if (m_audioClipEditorPanel) {
             m_audioClipEditorPanel->setVisible(false);
@@ -1312,17 +1316,7 @@ void AestraContent::setupHistoryAndTakesPanels() {
     m_historyPanel->setOnClose([this]() { toggleHistoryPanel(); });
     wireFloatingPanel(m_historyPanel, ViewType::History, &ViewState::historyRect, 240.0f, 220.0f);
     m_historyPanel->setMaximized(false);
-    m_historyPanel->setOnHistoryChanged([this]() {
-        if (m_trackManagerUI) {
-            m_trackManagerUI->refreshTracks();
-            m_trackManagerUI->invalidateCache();
-        }
-        if (m_mixerPanel)
-            m_mixerPanel->refreshChannels();
-        if (m_sequencerPanel)
-            m_sequencerPanel->refreshUnits();
-        m_trackManager->markModified();
-    });
+    m_historyPanel->setOnHistoryChanged([this]() { refreshAfterHistoryChange(); });
     // Create Takes panel — data providers and action callbacks are wired by the
     // app layer (AestraApp) because take operations need the project path and
     // the save/load safety rules that live there.
@@ -4259,6 +4253,21 @@ void AestraContent::refreshProjectViews() {
     setDirty(true);
 }
 
+void AestraContent::refreshAfterHistoryChange() {
+    if (!m_trackManager)
+        return;
+    // Refresh ALL panels — not just timeline
+    if (m_trackManagerUI) {
+        m_trackManagerUI->refreshTracks();
+        m_trackManagerUI->invalidateCache();
+    }
+    if (m_mixerPanel)
+        m_mixerPanel->refreshChannels();
+    if (m_sequencerPanel)
+        m_sequencerPanel->refreshUnits();
+    m_trackManager->markModified();
+}
+
 void AestraContent::toggleHistoryPanel() {
     if (!m_historyPanel)
         return;
@@ -4404,16 +4413,7 @@ bool AestraContent::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         }
 
         if (performed) {
-            // Refresh ALL panels — not just timeline
-            if (m_trackManagerUI) {
-                m_trackManagerUI->refreshTracks();
-                m_trackManagerUI->invalidateCache();
-            }
-            if (m_mixerPanel)
-                m_mixerPanel->refreshChannels();
-            if (m_sequencerPanel)
-                m_sequencerPanel->refreshUnits();
-            m_trackManager->markModified();
+            refreshAfterHistoryChange();
             return true; // Consume the event — don't pass to text inputs
         }
     }

--- a/Source/Core/AestraContent.h
+++ b/Source/Core/AestraContent.h
@@ -151,6 +151,15 @@ public:
     /** @brief Release notes held by computer-keyboard musical typing. */
     void releaseMusicalTypingNotes();
 
+    /**
+     * @brief Refresh every panel after an undo/redo/history mutation.
+     *
+     * Single source of truth for the post-history refresh: the keyboard
+     * shortcut path, the Edit-menu items, the window-manager shortcuts and the
+     * history panel must all invalidate the same surfaces.
+     */
+    void refreshAfterHistoryChange();
+
     /** @brief Open or close a specific workspace overlay. */
     void setViewOpen(Aestra::Audio::ViewType view, bool open);
     /** @brief Toggle visibility for a specific workspace overlay. */

--- a/Source/Core/AestraWindowManager.cpp
+++ b/Source/Core/AestraWindowManager.cpp
@@ -439,14 +439,17 @@ bool AestraWindowManager::initialize(const WindowConfig& config) {
                 this->hideActiveMenu();
             }
 
-            // Shortcuts (Undo/Redo)
+            // Shortcuts (Undo/Redo) — fallback only: AestraContent consumes these
+            // chords (and refreshes) when the history actually changed.
             bool ctrl = (currentMods & static_cast<int>(NM::Ctrl));
             if (ctrl) {
                 if (key == static_cast<int>(Aestra::KeyCode::Z) && m_content && m_content->getTrackManager()) { // Z
-                    m_content->getTrackManager()->getCommandHistory().undo();
+                    if (m_content->getTrackManager()->getCommandHistory().undo())
+                        m_content->refreshAfterHistoryChange();
                 }
                 if (key == static_cast<int>(Aestra::KeyCode::Y) && m_content && m_content->getTrackManager()) { // Y
-                    m_content->getTrackManager()->getCommandHistory().redo();
+                    if (m_content->getTrackManager()->getCommandHistory().redo())
+                        m_content->refreshAfterHistoryChange();
                 }
             }
         }

--- a/Source/Panels/AudioClipEditorPanel.cpp
+++ b/Source/Panels/AudioClipEditorPanel.cpp
@@ -333,11 +333,14 @@ void AudioClipEditorPanel::buildUI() {
         m_speedSlider,
         [](ClipEdits& edits, double value) { edits.playbackRate = static_cast<float>(value); },
         true);
-    wireSlider(m_sourceStartSlider, [this](ClipEdits& edits, double value) {
-        const double projectRate =
-            m_trackManager ? std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate()) : 48000.0;
-        edits.sourceStart = value * projectRate;
-    });
+    wireSlider(
+        m_sourceStartSlider,
+        [this](ClipEdits& edits, double value) {
+            const double projectRate =
+                m_trackManager ? std::max(1.0, m_trackManager->getPlaylistModel().getProjectSampleRate()) : 48000.0;
+            edits.sourceStart = value * projectRate;
+        },
+        true);
 
     m_muteButton->setOnToggle([this](bool muted) {
         if (m_suppressCallbacks)
@@ -671,6 +674,10 @@ void AudioClipEditorPanel::commitEditGesture() {
         auto command = std::make_shared<SetClipEditsCommand>(m_trackManager->getPlaylistModel(), m_clipId,
                                                              m_gestureStartEdits, m_workingEdits, true);
         m_trackManager->getCommandHistory().pushExecuted(command);
+        // The graph rebuild alone doesn't repaint the arrangement: without this
+        // the playlist FBO keeps drawing the pre-edit waveform indefinitely.
+        if (m_onClipEditsCommitted)
+            m_onClipEditsCommitted();
     }
 }
 
@@ -681,6 +688,8 @@ void AudioClipEditorPanel::applyDiscreteEdit(const ClipEdits& edits) {
     m_trackManager->getCommandHistory().pushAndExecute(command);
     m_trackManager->markModified();
     syncControlsFromModel();
+    if (m_onClipEditsCommitted)
+        m_onClipEditsCommitted();
 }
 
 void AudioClipEditorPanel::selectRoute(uint32_t routeId) {

--- a/Source/Panels/AudioClipEditorPanel.h
+++ b/Source/Panels/AudioClipEditorPanel.h
@@ -6,6 +6,7 @@
 #include "WindowPanel.h"
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -35,6 +36,9 @@ public:
     bool openClip(ClipInstanceID clipId);
     ClipInstanceID getClipId() const { return m_clipId; }
 
+    /** @brief Fired after committed clip edits reach the model (slider commit or discrete edit). */
+    void setOnClipEditsCommitted(std::function<void()> callback) { m_onClipEditsCommitted = std::move(callback); }
+
     void onRender(AestraUI::NUIRenderer& renderer) override;
     void onResize(int width, int height) override;
     void onUpdate(double deltaTime) override;
@@ -43,6 +47,7 @@ private:
     std::shared_ptr<TrackManager> m_trackManager;
     ClipInstanceID m_clipId;
     PatternID m_patternId;
+    std::function<void()> m_onClipEditsCommitted;
     ClipEdits m_workingEdits;
     ClipEdits m_gestureStartEdits;
     bool m_editGestureActive{false};

--- a/Tests/AestraUI/PianoRollExternalEditCommitTest.cpp
+++ b/Tests/AestraUI/PianoRollExternalEditCommitTest.cpp
@@ -1,0 +1,97 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+
+// Regression for #829: external lane edits (velocity/pan control panel) must
+// commit through onNotesChanged_ like every other gesture. Before the fix,
+// pushExternalEdit only pushed the layer-local undo step, so PatternManager
+// kept the old value until an unrelated committing event flushed it — the
+// "pan applies but nothing refreshes until I place another note" symptom.
+
+#include "NUIPianoRollWidgets.h"
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace AestraUI;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        ++g_failures;
+    }
+}
+
+MidiNote makeNote(int pitch, double startBeat) {
+    MidiNote note;
+    note.pitch = pitch;
+    note.startBeat = startBeat;
+    note.durationBeats = 1.0;
+    note.velocity = 0.8f;
+    note.pan = 0.0f;
+    return note;
+}
+
+void testPushExternalEditFiresCommit() {
+    PianoRollNoteLayer layer;
+    layer.setBounds({0.0f, 0.0f, 800.0f, 3072.0f});
+    layer.setNotes({makeNote(60, 0.0), makeNote(64, 1.0)});
+
+    int commits = 0;
+    std::vector<MidiNote> committed;
+    layer.setOnNotesChanged([&commits, &committed](const std::vector<MidiNote>& notes) {
+        ++commits;
+        committed = notes;
+    });
+
+    const auto before = layer.getNotes();
+    auto edited = before;
+    edited[0].pan = -0.5f; // what a pan-lane drag writes per frame
+    layer.setNotes(edited);
+
+    layer.pushExternalEdit(before, "Pan");
+
+    check(commits == 1, "pushExternalEdit must fire onNotesChanged_ exactly once");
+    check(committed.size() == 2, "commit must carry the full note set");
+    check(std::fabs(committed[0].pan - (-0.5f)) < 0.0001f, "committed note must carry the edited pan");
+}
+
+void testPushExternalEditVelocityCommitsAndUndoes() {
+    PianoRollNoteLayer layer;
+    layer.setBounds({0.0f, 0.0f, 800.0f, 3072.0f});
+    layer.setNotes({makeNote(62, 0.5)});
+
+    int commits = 0;
+    layer.setOnNotesChanged([&commits](const std::vector<MidiNote>&) { ++commits; });
+
+    const auto before = layer.getNotes();
+    auto edited = before;
+    edited[0].velocity = 0.25f;
+    layer.setNotes(edited);
+
+    layer.pushExternalEdit(before, "Velocity");
+
+    check(commits == 1, "velocity lane edit must commit exactly once");
+    check(layer.getNotes()[0].velocity == 0.25f, "committed velocity must be visible via getNotes()");
+
+    layer.undo();
+    check(commits == 2, "undo of an external edit must re-commit");
+    check(std::fabs(layer.getNotes()[0].velocity - 0.8f) < 0.0001f, "undo must restore the pre-edit velocity");
+}
+
+} // namespace
+
+int main() {
+    testPushExternalEditFiresCommit();
+    testPushExternalEditVelocityCommitsAndUndoes();
+
+    if (g_failures == 0) {
+        std::cout << "PianoRollExternalEditCommitTest: all checks passed\n";
+        return 0;
+    }
+    std::cerr << "PianoRollExternalEditCommitTest: " << g_failures << " failure(s)\n";
+    return 1;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2014,6 +2014,23 @@ else()
     message(STATUS "PianoRollStrokeInteractionTest skipped (AestraUI targets unavailable in this build mode)")
 endif()
 
+# Regression for #829: external lane edits (velocity/pan) must commit through
+# onNotesChanged_ so PatternManager and the refresh chain see them immediately.
+if(TARGET AestraUI_Core AND TARGET AestraUI_Platform)
+    add_executable(PianoRollExternalEditCommitTest AestraUI/PianoRollExternalEditCommitTest.cpp)
+    target_link_libraries(PianoRollExternalEditCommitTest PRIVATE AestraUI_Core AestraUI_Platform)
+    target_include_directories(PianoRollExternalEditCommitTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraUI
+        ${CMAKE_SOURCE_DIR}/AestraUI/Common
+        ${CMAKE_SOURCE_DIR}/AestraUI/Widgets
+    )
+    add_test(NAME PianoRollExternalEditCommitTest COMMAND PianoRollExternalEditCommitTest)
+    set_tests_properties(PianoRollExternalEditCommitTest
+        PROPERTIES LABELS "ui;interaction;pianoroll;regression;contract:application")
+else()
+    message(STATUS "PianoRollExternalEditCommitTest skipped (AestraUI targets unavailable in this build mode)")
+endif()
+
 # Editor-close deferred-destruction regression (#475): removeChild() during
 # event dispatch must defer and free safely (no iterator invalidation / UAF).
 if(TARGET AestraUI_Core)


### PR DESCRIPTION
## Summary

Three fixes from the same invalidation bug family (extra-session triage 2026-08-21):

1. **#829 — Piano Roll pan/velocity lane edits commit on release.** The control-panel lanes called `pushExternalEdit`, which pushed only the layer-local undo step and never `commitNotes()`. So `onNotesChanged_` → `PianoRollPanel::savePattern()` never ran, PatternManager kept the old pan/velocity, and the whole refresh chain (`refreshUnits`/`refreshPatterns`/`refreshTracks`+cache invalidation) stayed dead until an unrelated committing event — placing a note, switching units, closing the panel — flushed everything at once. That is the reported "pan applies but nothing reflects it until I place another note" symptom. Fix: `pushExternalEdit` now commits like every other gesture (one line). Covers both the pan and velocity lanes.

2. **#827 (class 1) — clip-edit transforms repaint the arrangement.** Pitch/speed/source-start/reset committed via `SetClipEditsCommand`, whose only downstream effect was an audio-graph rebuild; nothing UI-side listened, so the playlist FBO kept drawing the pre-edit waveform indefinitely. `AudioClipEditorPanel` gains an `onClipEditsCommitted` callback fired from both commit paths, wired in AestraContent to `TrackManagerUI::invalidateCache()`. Source-start (slip) also now rebuilds the editor's own preview — it previously passed `updatesWaveform=false`, so even the panel preview went stale.

3. **All undo/redo entry points now refresh identically.** The keyboard path refreshed all panels after undo/redo; the Edit menu, the window-manager fallback shortcuts and the history panel either duplicated the block or skipped it entirely (menu undo left a reversed clip's waveform on screen). Extracted `AestraContent::refreshAfterHistoryChange()` and routed all four entry points through it. No-op undos do not refresh (fallback is guarded by the command result).

Out of scope, tracked on the issues: waveform display representing gain/fades (#827 class 2 — representation gap, not staleness) and Arsenal inline-grid undo wiring (#822).

## Why

Producer hit both bugs in a real production session: per-note pan that wouldn't stick until the next note was placed, and transformed clips keeping stale waveforms. Root causes were established by code inspection and posted as issue comments before this branch.

## Testing performed

- New `PianoRollExternalEditCommitTest` (2 cases): external edit fires the commit callback exactly once and carries the edited value; undo restores the pre-edit value and re-commits. Verified red with the fix stashed, green with it applied.
- Targeted slice green: PianoRoll\* (interaction/stroke/persistence/stress), MixerSerialization, NoteCommands, NoteDiff — 9/9.
- Full default suite: **268/268 passed** (`SecAccountEndToEndSmoke` skipped as usual).
- Headless configure clean (`build-hlON-rtOFF-exOFF`); the new test target self-skips where AestraUI targets are absent.
- Arrangement-repaint behavior after slider drags is visual — flagged for manual sign-off, not claimed as automated proof.

## Producer note

Panning notes from the piano roll side panel now sticks immediately — you no longer have to place another note before hearing it.

## Docs updated?

No public docs affected.

## Risk/rollback notes

- `pushExternalEdit`'s only caller is the lane-release handler; commit-at-release matches how every other gesture already behaves (including its sort-on-commit).
- Menu/window-manager undo gained refresh-after-success guards; empty-stack presses stay free.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Piano-roll pan and velocity edits now commit on release. This triggers change notifications, saves edits, and refreshes dependent views.
- Clip edits now invalidate the arrangement cache. Source-start edits also rebuild the waveform preview.
- Undo and redo now use one refresh path and refresh views only after successful history changes.
- Added regression coverage for external Piano Roll edits. All 268 tests pass.
- Arrangement repaint behavior after slider drags still requires manual visual verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->