### PR TITLE
feat(arsenal): step-grid edits participate in undo/redo

### DIFF
--- a/AestraAudio/include/Commands/EditPatternNotesCommand.h
+++ b/AestraAudio/include/Commands/EditPatternNotesCommand.h
@@ -1,0 +1,80 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+#pragma once
+
+#include "Commands/ICommand.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <string>
+#include <vector>
+
+namespace Aestra {
+namespace Audio {
+
+/**
+ * @brief Undoable whole-vector replacement of a MIDI pattern's notes
+ *
+ * One command per editing gesture (place/paint, erase, step velocity,
+ * move/delete/duplicate selection, paste). The editor mutates the pattern
+ * directly, snapshots the notes before and after, and pushes this command as
+ * already executed — so a whole drag coalesces into a single undo step while
+ * still routing through the shared CommandHistory (#822).
+ */
+class EditPatternNotesCommand final : public ICommand {
+public:
+    EditPatternNotesCommand(PatternManager& patternManager, PatternID patternId,
+                            std::vector<MidiNote> notesBefore, std::vector<MidiNote> notesAfter,
+                            std::string name = "Edit Notes")
+        : m_patternManager(patternManager), m_patternId(patternId),
+          m_notesBefore(std::move(notesBefore)), m_notesAfter(std::move(notesAfter)),
+          m_name(std::move(name)), m_executed(true) {}
+
+    void execute() override {
+        if (m_executed)
+            return;
+        apply(m_notesAfter);
+        m_executed = true;
+    }
+
+    void undo() override {
+        if (!m_executed)
+            return;
+        apply(m_notesBefore);
+        m_executed = false;
+    }
+
+    void redo() override {
+        if (m_executed)
+            return;
+        apply(m_notesAfter);
+        m_executed = true;
+    }
+
+    std::string getName() const override { return m_name; }
+    bool changesProjectState() const override { return true; }
+
+    size_t getSizeInBytes() const override {
+        // Real footprint: CommandHistory's LRU budget counts these honestly.
+        return sizeof(*this) + m_notesBefore.capacity() * sizeof(MidiNote) +
+               m_notesAfter.capacity() * sizeof(MidiNote) + m_name.capacity();
+    }
+
+private:
+    void apply(const std::vector<MidiNote>& notes) {
+        m_patternManager.applyPatch(m_patternId, [&notes](PatternSource& pattern) {
+            if (!pattern.isMidi())
+                return;
+            std::get<MidiPayload>(pattern.payload).notes = notes;
+        });
+    }
+
+    PatternManager& m_patternManager;
+    PatternID m_patternId;
+    std::vector<MidiNote> m_notesBefore;
+    std::vector<MidiNote> m_notesAfter;
+    std::string m_name;
+    bool m_executed;
+};
+
+} // namespace Audio
+} // namespace Aestra

--- a/AestraUI/Widgets/UnitRow.cpp
+++ b/AestraUI/Widgets/UnitRow.cpp
@@ -4,6 +4,7 @@
 #include "../../AestraCore/include/AestraLog.h"
 #include "AudioEngine.h"
 #include "Commands/AssignUnitToFirstFreeInsertCommand.h"
+#include "Commands/EditPatternNotesCommand.h"
 #include "Commands/SetUnitMixerChannelCommand.h"
 #include "NUIRenderer.h"
 #include "NUIThemeSystem.h"
@@ -920,6 +921,15 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     m_selectedSteps.end());
                 notifyStepSelectionChanged();
             }
+            if (m_stepGestureChanged && m_trackManager && m_patternId.isValid()) {
+                const char* label = m_stepGestureMode == StepGestureMode::Velocity ? "Step Velocity"
+                                    : m_stepGestureMode == StepGestureMode::Erase ? "Erase Steps"
+                                    : m_stepGestureMode == StepGestureMode::Paint ? "Paint Steps"
+                                                                                  : "Place Step";
+                // One command per gesture: the whole drag undoes in a single step.
+                pushNotesEditCommand(std::move(m_gestureNotesBefore), label);
+            }
+            m_gestureNotesBefore.clear();
             if (m_stepGestureChanged && m_onPatternEdited && m_patternId.isValid()) {
                 m_onPatternEdited(m_patternId);
             }
@@ -1026,6 +1036,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                             }
                             float vel = kDefaultStepVelocity;
                             const bool active = stepHasNote(step, vel);
+                            m_gestureNotesBefore = currentPatternNotes();
                             m_velEditStep = step;
                             m_stepGestureLastStep = step;
                             m_stepGestureStartX = event.position.x;
@@ -1068,6 +1079,7 @@ bool UnitRow::onMouseEvent(const NUIMouseEvent& event) {
                     const int stepIndex = resolveGridStep(localPoint, localGridRect);
                     if (stepIndex >= 0 && stepIndex < m_stepCount) {
                         float velocity = kDefaultStepVelocity;
+                        m_gestureNotesBefore = currentPatternNotes();
                         m_velEditStep = stepIndex;
                         m_stepGestureLastStep = stepIndex;
                         m_stepGestureStartX = event.position.x;
@@ -1228,6 +1240,7 @@ void UnitRow::duplicateSelection() {
 
     std::vector<int> newSelection;
     bool changed = false;
+    const auto notesBefore = currentPatternNotes();
     m_trackManager->getPatternManager().applyPatch(m_patternId,
         [this, span, &newSelection, &changed](Aestra::Audio::PatternSource& p) {
             if (!p.isMidi()) {
@@ -1271,6 +1284,7 @@ void UnitRow::duplicateSelection() {
     if (!changed) {
         return;
     }
+    pushNotesEditCommand(notesBefore, "Duplicate Steps");
     m_selectedSteps = std::move(newSelection); // sorted: constant offset over a sorted selection
     notifyStepSelectionChanged();
     invalidateVisuals();
@@ -1283,6 +1297,7 @@ void UnitRow::deleteSelection() {
     if (m_selectedSteps.empty() || !m_patternId.isValid() || !m_trackManager) {
         return;
     }
+    const auto notesBefore = currentPatternNotes();
     bool changed = false;
     m_trackManager->getPatternManager().applyPatch(m_patternId,
         [this, &changed](Aestra::Audio::PatternSource& p) {
@@ -1307,6 +1322,9 @@ void UnitRow::deleteSelection() {
             midi.notes.erase(std::remove_if(midi.notes.begin(), midi.notes.end(), stepCovered), midi.notes.end());
             changed = midi.notes.size() != before;
         });
+    if (changed) {
+        pushNotesEditCommand(notesBefore, "Delete Steps");
+    }
     m_selectedSteps.clear();
     notifyStepSelectionChanged();
     invalidateVisuals();
@@ -1322,6 +1340,7 @@ void UnitRow::moveSelection(int stepDelta) {
     const int dir = stepDelta > 0 ? 1 : -1;
     bool changed = false;
     std::vector<int> newSelection;
+    const auto notesBefore = currentPatternNotes();
     m_trackManager->getPatternManager().applyPatch(m_patternId,
         [this, dir, &newSelection, &changed](Aestra::Audio::PatternSource& p) {
             if (!p.isMidi()) {
@@ -1380,6 +1399,9 @@ void UnitRow::moveSelection(int stepDelta) {
     std::sort(newSelection.begin(), newSelection.end());
     const bool selectionChanged = newSelection != m_selectedSteps;
     m_selectedSteps = std::move(newSelection);
+    if (changed) {
+        pushNotesEditCommand(notesBefore, "Move Steps");
+    }
     if (selectionChanged) {
         notifyStepSelectionChanged();
     }
@@ -1394,6 +1416,7 @@ void UnitRow::nudgeSelectionVelocity(float delta) {
         return;
     }
     bool changed = false;
+    const auto notesBefore = currentPatternNotes();
     m_trackManager->getPatternManager().applyPatch(m_patternId,
         [this, delta, &changed](Aestra::Audio::PatternSource& p) {
             if (!p.isMidi()) {
@@ -1415,6 +1438,9 @@ void UnitRow::nudgeSelectionVelocity(float delta) {
             }
         });
     invalidateVisuals();
+    if (changed) {
+        pushNotesEditCommand(notesBefore, "Step Velocity");
+    }
     if (changed && m_onPatternEdited) {
         m_onPatternEdited(m_patternId);
     }
@@ -1456,6 +1482,34 @@ bool UnitRow::stepHasNote(int step, float& velocityOut) const {
         }
     }
     return false;
+}
+
+std::vector<Aestra::Audio::MidiNote> UnitRow::currentPatternNotes() const {
+    if (!m_trackManager || !m_patternId.isValid())
+        return {};
+    const auto* pattern = m_trackManager->getPatternManager().getPattern(m_patternId);
+    if (!pattern || !pattern->isMidi())
+        return {};
+    return std::get<Aestra::Audio::MidiPayload>(pattern->payload).notes;
+}
+
+void UnitRow::pushNotesEditCommand(std::vector<Aestra::Audio::MidiNote> before, const char* name) {
+    if (!m_trackManager || !m_patternId.isValid())
+        return;
+    auto after = currentPatternNotes();
+    const bool unchanged = after.size() == before.size() &&
+                           std::equal(after.begin(), after.end(), before.begin(),
+                                      [](const Aestra::Audio::MidiNote& a, const Aestra::Audio::MidiNote& b) {
+                                          return a.pitch == b.pitch && a.startBeat == b.startBeat &&
+                                                 a.durationBeats == b.durationBeats &&
+                                                 a.velocity == b.velocity && a.pan == b.pan &&
+                                                 a.unitId == b.unitId && a.gate == b.gate && a.slide == b.slide;
+                                      });
+    if (unchanged)
+        return; // gesture mutated nothing undoable
+    auto command = std::make_shared<Aestra::Audio::EditPatternNotesCommand>(
+        m_trackManager->getPatternManager(), m_patternId, std::move(before), std::move(after), name);
+    m_trackManager->getCommandHistory().pushExecuted(command);
 }
 
 bool UnitRow::placeStepNote(int step) {

--- a/AestraUI/Widgets/UnitRow.h
+++ b/AestraUI/Widgets/UnitRow.h
@@ -271,6 +271,9 @@ private:
     float m_velEditStartY = 0.0f;
     float m_velEditBaseVelocity = kDefaultStepVelocity;
     bool m_stepGestureChanged = false;
+    // Notes snapshot taken when the gesture starts; on release the whole drag
+    // becomes one EditPatternNotesCommand (single undo step per gesture).
+    std::vector<Aestra::Audio::MidiNote> m_gestureNotesBefore;
 
     long long m_lastClipClickTimeMs = 0; // For double-click on clip/waveform area
     int m_lastClipClickStep = -1;        // Step of the last grid press; -1 = miss / non-grid
@@ -296,6 +299,11 @@ private:
     bool placeStepNote(int step);                          // place at root + default velocity
     bool removeStepNote(int step);                         // remove note at step
     void setStepNoteVelocity(int step, float velocity);    // set velocity of note at step
+
+    // Snapshot of the pattern's MIDI notes for undo bookkeeping (#822).
+    std::vector<Aestra::Audio::MidiNote> currentPatternNotes() const;
+    // Wrap a completed gesture's before/after snapshots into one undoable command.
+    void pushNotesEditCommand(std::vector<Aestra::Audio::MidiNote> before, const char* name);
 
     // Selection-based editing helpers.
     bool isStepSelected(int step) const;

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -2,6 +2,8 @@
 #include "ArsenalPanel.h"
 
 #include "Commands/AssignUnitToFirstFreeInsertCommand.h"
+#include "Commands/EditPatternNotesCommand.h"
+#include "Commands/SetPatternLengthCommand.h"
 #include "PatternBrowserPanel.h" // For m_patternBrowser
 #include "../AestraUI/Widgets/PluginBrowserPanel.h"
 #include "NUIButton.h"
@@ -974,9 +976,8 @@ void ArsenalPanel::adjustPatternBars(int deltaBars) {
         return;
     }
 
-    patternManager.applyPatch(m_activePatternID, [nextLengthBeats](PatternSource& source) {
-        source.lengthBeats = nextLengthBeats;
-    });
+    auto lengthCommand = std::make_shared<SetPatternLengthCommand>(patternManager, m_activePatternID, nextLengthBeats);
+    m_trackManager->getCommandHistory().pushAndExecute(lengthCommand);
     m_trackManager->preparePatternForArsenal(m_activePatternID);
     refreshUnits();
     repaint();
@@ -1016,9 +1017,8 @@ void ArsenalPanel::adjustPatternSteps(int deltaBars) {
         return;
     }
 
-    patternManager.applyPatch(m_activePatternID, [nextLengthBeats](PatternSource& source) {
-        source.lengthBeats = nextLengthBeats;
-    });
+    auto lengthCommand = std::make_shared<SetPatternLengthCommand>(patternManager, m_activePatternID, nextLengthBeats);
+    m_trackManager->getCommandHistory().pushAndExecute(lengthCommand);
     m_trackManager->preparePatternForArsenal(m_activePatternID);
     refreshUnits();
     repaint();
@@ -1518,6 +1518,12 @@ void ArsenalPanel::pastePattern() {
     
     auto& pm = m_trackManager->getPatternManager();
     
+    std::vector<MidiNote> notesBefore;
+    if (const auto* pattern = pm.getPattern(m_activePatternID)) {
+        if (pattern->isMidi())
+            notesBefore = std::get<MidiPayload>(pattern->payload).notes;
+    }
+
     pm.applyPatch(m_activePatternID, [this](PatternSource& p) {
         if (!p.isMidi()) return;
         auto& midi = std::get<MidiPayload>(p.payload);
@@ -1528,7 +1534,16 @@ void ArsenalPanel::pastePattern() {
             midi.notes.push_back(note);
         }
     });
-    
+
+    std::vector<MidiNote> notesAfter;
+    if (const auto* pattern = pm.getPattern(m_activePatternID)) {
+        if (pattern->isMidi())
+            notesAfter = std::get<MidiPayload>(pattern->payload).notes;
+    }
+    auto command = std::make_shared<EditPatternNotesCommand>(pm, m_activePatternID, std::move(notesBefore),
+                                                             std::move(notesAfter), "Paste Notes");
+    m_trackManager->getCommandHistory().pushExecuted(command);
+
     refreshUnits();
     if (m_onPatternEdited) {
         m_onPatternEdited(m_activePatternID);

--- a/Tests/Commands/EditPatternNotesCommandTest.cpp
+++ b/Tests/Commands/EditPatternNotesCommandTest.cpp
@@ -1,0 +1,148 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// EditPatternNotesCommand Unit Tests
+// Tests: whole-vector notes swap — already-executed push (undo/redo roundtrip),
+// field/order fidelity, CommandHistory integration, non-MIDI pattern safety.
+// Regression for #822: Arsenal grid gestures must be undoable.
+
+#include "Commands/EditPatternNotesCommand.h"
+#include "Commands/CommandHistory.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+
+#include <cassert>
+#include <iostream>
+
+using namespace Aestra::Audio;
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define PASS(msg) do { std::cout << "PASS: " << msg << "\n"; testsPassed++; } while(0)
+#define FAIL(msg) do { std::cout << "FAIL: " << msg << "\n"; testsFailed++; } while(0)
+#define ASSERT(cond, msg) do { if (!(cond)) { FAIL(msg); return; } } while(0)
+
+namespace {
+
+MidiNote makeNote(int pitch, double startBeat, uint64_t unitId) {
+    MidiNote note;
+    note.pitch = pitch;
+    note.startBeat = startBeat;
+    note.durationBeats = 0.25;
+    note.velocity = 0.8f;
+    note.pan = -0.5f;
+    note.unitId = unitId;
+    note.gate = 0.5f;
+    note.slide = true;
+    return note;
+}
+
+} // namespace
+
+void test_already_executed_undo_redo_roundtrip() {
+    PatternManager pm;
+    PatternID pid = pm.createMidiPattern("test", 4.0, MidiPayload{});
+    const MidiNote first = makeNote(60, 0.0, 7);
+    {
+        pm.applyPatch(pid, [&first](PatternSource& p) {
+            std::get<MidiPayload>(p.payload).notes.push_back(first);
+        });
+    }
+    const auto before = std::get<MidiPayload>(pm.getPattern(pid)->payload).notes;
+
+    // The gesture path: mutate directly, then push the command as executed.
+    const MidiNote second = makeNote(64, 1.0, 7);
+    pm.applyPatch(pid, [&second](PatternSource& p) {
+        std::get<MidiPayload>(p.payload).notes.push_back(second);
+    });
+
+    EditPatternNotesCommand cmd(pm, pid, before,
+                                std::get<MidiPayload>(pm.getPattern(pid)->payload).notes, "Paint Steps");
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.size() == 2,
+           "pattern holds both notes after direct mutation");
+
+    cmd.undo();
+    {
+        const auto& notes = std::get<MidiPayload>(pm.getPattern(pid)->payload).notes;
+        ASSERT(notes.size() == 1, "undo restores the before vector");
+        ASSERT(notes[0].pitch == 60 && notes[0].startBeat == 0.0 && notes[0].unitId == 7,
+               "undo restores the exact remaining note");
+    }
+
+    cmd.redo();
+    {
+        const auto& notes = std::get<MidiPayload>(pm.getPattern(pid)->payload).notes;
+        ASSERT(notes.size() == 2, "redo re-applies the after vector");
+        ASSERT(notes[1].pan == -0.5f && notes[1].gate == 0.5f && notes[1].slide,
+               "redo preserves every note field, not just pitch/start");
+    }
+    PASS("already-executed undo/redo roundtrip");
+}
+
+void test_order_fidelity() {
+    // Undo must restore exact vector order: scheduling and step occupancy
+    // checks scan linearly with topmost-wins semantics.
+    PatternManager pm;
+    PatternID pid = pm.createMidiPattern("test", 4.0, MidiPayload{});
+    const std::vector<MidiNote> ordered{makeNote(60, 0.0, 1), makeNote(62, 0.0, 2), makeNote(64, 0.0, 3)};
+    pm.applyPatch(pid, [&ordered](PatternSource& p) {
+        std::get<MidiPayload>(p.payload).notes = ordered;
+    });
+
+    std::vector<MidiNote> reversed{ordered.rbegin(), ordered.rend()};
+    pm.applyPatch(pid, [&reversed](PatternSource& p) { std::get<MidiPayload>(p.payload).notes = reversed; });
+    EditPatternNotesCommand cmd(pm, pid, ordered, reversed, "Reorder");
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.front().pitch == 64,
+           "after-vector held verbatim");
+    cmd.undo();
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.front().pitch == 60,
+           "undo restores original order, not a canonical sort");
+    cmd.redo();
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.front().pitch == 64,
+           "redo re-applies the exact after order");
+    PASS("vector order fidelity");
+}
+
+void test_command_history_integration() {
+    PatternManager pm;
+    PatternID pid = pm.createMidiPattern("test", 4.0, MidiPayload{});
+    CommandHistory history;
+
+    const auto before = std::vector<MidiNote>{makeNote(60, 0.0, 7)};
+    pm.applyPatch(pid, [&before](PatternSource& p) { std::get<MidiPayload>(p.payload).notes = before; });
+
+    // Gesture: add a note, push as executed.
+    std::vector<MidiNote> after = before;
+    after.push_back(makeNote(67, 2.0, 7));
+    pm.applyPatch(pid, [&after](PatternSource& p) { std::get<MidiPayload>(p.payload).notes = after; });
+    history.pushExecuted(std::make_shared<EditPatternNotesCommand>(pm, pid, before, after, "Place Step"));
+    ASSERT(history.canUndo(), "pushed gesture is undoable");
+
+    history.undo();
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.size() == 1, "history.undo restores before");
+
+    history.redo();
+    ASSERT(std::get<MidiPayload>(pm.getPattern(pid)->payload).notes.size() == 2, "history.redo restores after");
+    PASS("CommandHistory integration");
+}
+
+void test_non_midi_pattern_is_safe_noop() {
+    PatternManager pm;
+    PatternID pid; // invalid / no pattern backing
+    std::vector<MidiNote> before{makeNote(60, 0.0, 7)};
+
+    EditPatternNotesCommand cmd(pm, pid, before, {}, "Edit Notes");
+    cmd.undo(); // must not crash or corrupt state
+    cmd.redo();
+    cmd.undo();
+    PASS("invalid/non-midi target is a safe no-op");
+}
+
+int main() {
+    test_already_executed_undo_redo_roundtrip();
+    test_order_fidelity();
+    test_command_history_integration();
+    test_non_midi_pattern_is_safe_noop();
+
+    std::cout << "\nEditPatternNotesCommandTest: " << testsPassed << " passed, " << testsFailed << " failed\n";
+    return testsFailed == 0 ? 0 : 1;
+}

--- a/Tests/cmake/CommandsTests.cmake
+++ b/Tests/cmake/CommandsTests.cmake
@@ -58,6 +58,17 @@ target_include_directories(NoteCommandsTest PRIVATE
 add_test(NAME NoteCommandsTest COMMAND NoteCommandsTest)
 set_tests_properties(NoteCommandsTest PROPERTIES LABELS "commands;phase2;contract:application")
 
+# EditPatternNotesCommand (#822): Arsenal grid gestures push one whole-vector
+# notes command per gesture so Ctrl+Z restores them.
+add_executable(EditPatternNotesCommandTest Commands/EditPatternNotesCommandTest.cpp)
+target_link_libraries(EditPatternNotesCommandTest PRIVATE AestraAudioCore)
+target_include_directories(EditPatternNotesCommandTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME EditPatternNotesCommandTest COMMAND EditPatternNotesCommandTest)
+set_tests_properties(EditPatternNotesCommandTest PROPERTIES LABELS "commands;phase2;regression;contract:application")
+
 # NoteDiff Test (headless diffing logic for piano roll save path)
 add_executable(NoteDiffTest Commands/NoteDiffTest.cpp)
 target_link_libraries(NoteDiffTest PRIVATE AestraAudioCore)


### PR DESCRIPTION
## Summary

Fixes #822 — Arsenal/Piano-roll edits now participate in undo/redo.

The Arsenal inline step-grid mutated pattern data directly via `PatternManager::applyPatch` and never touched the shared `CommandHistory`. Every edit path was affected: place/paint, right-drag erase, velocity drag, arrow-key move, velocity nudge, Ctrl+B duplicate, Delete, paste, and Bars/Steps adjustments. Worse, because grid edits bypassed the history, **Ctrl+Z after an Arsenal edit silently undid some unrelated earlier command while the grid edit persisted**.

Changes:

1. **New `EditPatternNotesCommand`** (header-only, follows `SetClipEditsCommand`'s already-executed convention): whole-vector before/after notes swap. One command per gesture, so a full paint-drag coalesces into a single undo step.
2. **UnitRow gesture wiring**: the step-gesture session snapshots notes at press (left or right) and pushes one command at release when something changed; keyboard/menu edits (delete/duplicate/move/nudge selection) snapshot before mutation and push after.
3. **ArsenalPanel**: paste pushes `EditPatternNotesCommand`; Bars/Steps buttons now use the existing `SetPatternLengthCommand` instead of a raw `applyPatch` (the undoable command already existed unused on this path).
4. **No new refresh wiring needed for undo**: undo/redo already flows through `refreshAfterHistoryChange()` → `refreshUnits()`, which rebuilds rows from PatternManager. It had nothing to do until now because no commands were ever pushed.

Out of scope, noted on #822: unit deletion's note wipe stays uncommanded (unit deletion itself has no undo), and per-note piano-roll window editing was already commanded.

## Why

Producer hit this in a real session: no recovery path for any Arsenal edit except manual repair. Root cause confirmed by code inspection and posted on the issue before coding.

## Testing performed

- New `EditPatternNotesCommandTest` (4 cases): already-executed undo/redo roundtrip with full field fidelity (pan/gate/slide/unitId), vector-order fidelity (undo must not canonicalize order), CommandHistory integration (pushExecuted → undo/redo), invalid/non-MIDI target safe no-op.
- Full default suite: **268/268 passed** locally (`SecAccountEndToEndSmoke` skipped as usual); app target links clean.
- **Manual sign-off in the running app**: place/paint/erase/velocity/move/delete/duplicate all undo and redo correctly; one keypress per gesture.
- Known test-harness note: the first run of the new test had a failure caused by the test itself misusing the already-executed convention (calling `execute()` on an executed command); fixed the test, not the command.

## Producer note

Ctrl+Z now works on Arsenal step edits — painting, erasing, moving and velocity tweaks can all be undone and redone.

## Docs updated?

No public docs affected.

## Risk/rollback notes

- Commands carry full notes vectors per gesture; step patterns are small and CommandHistory already enforces a 100MB LRU budget with honest size accounting from `getSizeInBytes()`.
- Synchronous state-change listeners fire during push from inside mouse handlers — audited: mixer/history/piano-roll listeners don't rebuild UnitRows; row rebuild only happens on undo via keyboard path, outside event handlers.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added `EditPatternNotesCommand` to support undo/redo for complete MIDI note-vector edits.
- Connected Arsenal and piano-roll edits to `CommandHistory`, including note creation, deletion, movement, duplication, pasting, velocity changes, and erasing.
- Routed Bars and Steps changes through `SetPatternLengthCommand`.
- Added command-history tests for note preservation, round trips, integration, and safe no-op behavior.
- Registered the new test target with CTest.
- No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->