### PR TITLE
fix(audio): pattern edits during playback silence deletions, defer placements to the playhead

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -1626,6 +1626,15 @@ public:
     }
 
     /**
+     * @brief Pattern notes changed while playing (Arsenal grid / Piano Roll edits).
+     *
+     * Unlike preparePatternForArsenal() this is NOT a rewind: queued events for
+     * deleted steps drop out and additions enter at their exact frame, without
+     * re-firing notes that are currently sounding (#823).
+     */
+    void patternContentEdited() { m_patternPlaybackEngine.patternContentEdited(); }
+
+    /**
      * @brief Clear solo state across all mixer channels.
      */
     void clearAllSolos() {

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -209,6 +209,18 @@ public:
     void rewindScheduledInstances();
 
     /**
+     * @brief Pattern content changed while playing (RT-safe producer-side flag).
+     *
+     * Steps placed or removed in the Arsenal / Piano Roll call this instead of
+     * rewindScheduledInstances(): the next refill re-queues from the playhead with
+     * current note data — deletions silence immediately and additions enter at their
+     * exact frame — WITHOUT resetting the entry state. A full rewind here re-fired
+     * every currently-sounding note (audible flam on each edit) and made fresh
+     * placements sound before the playhead reached them (#823).
+     */
+    void patternContentEdited();
+
+    /**
      * @brief Remove every scheduled instance and queued event.
      *
      * For transitions that must not carry pattern content forward — leaving Arsenal, or
@@ -267,6 +279,12 @@ private:
 
     // RT-safe flush: audio thread sets this flag, non-RT maintenance drains the queue.
     std::atomic<bool> m_flushRequested{false};
+
+    // RT-safe content-edit notification: set by editors (Arsenal grid, Piano Roll)
+    // when pattern notes change during playback. refillWindow pulls each instance's
+    // scheduling frontier back to the playhead and re-queues from live data, without
+    // arming the entry catch-up.
+    std::atomic<bool> m_contentEditRequested{false};
 
     // Pre-allocated scratch buffer for refillWindow (reserved at init, never reallocates)
     std::vector<ScheduledEvent> m_scratchEvents;

--- a/AestraAudio/include/Playback/PatternPlaybackEngine.h
+++ b/AestraAudio/include/Playback/PatternPlaybackEngine.h
@@ -291,6 +291,25 @@ private:
 
     // Helpers
     uint16_t getChannelForUnit(UnitID unitId) const;
+
+    /**
+     * @brief A note currently within its gate, as recorded when its ON was scheduled.
+     *
+     * Control-thread-only bookkeeping: lets patternContentEdited() dispatch
+     * note-offs for notes that were deleted while still sounding (#823 review
+     * round 1) — deleted notes vanish from PatternSource, so the refill loop
+     * can no longer see them.
+     */
+    struct GatedNote {
+        uint32_t instanceId;
+        UnitID unitId;
+        uint8_t noteNumber;
+        uint16_t channelIdx;
+        uint64_t offFrame;
+    };
+
+    // Gated-note registry (control thread only; refilled/pruned in refillWindow).
+    std::vector<GatedNote> m_gatedNotes;
 };
 
 } // namespace Audio

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -177,6 +177,20 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
     }
     m_lastRefillFrame = currentFrame;
 
+    // Content edit while playing: pull each instance's frontier back to the
+    // playhead so this pass re-queues from live pattern data. Deletions drop
+    // out of the queue immediately and additions ahead of the playhead enter
+    // at their exact frame. The frontier stays > 0, so the entry catch-up in
+    // the loop below stays dormant — a full rewind here re-fired every
+    // currently-sounding note (flam on each grid edit) and made fresh
+    // placements sound before the playhead reached them (#823).
+    if (m_contentEditRequested.exchange(false, std::memory_order_acq_rel)) {
+        for (auto& inst : m_activeInstances) {
+            inst.scheduledThroughFrame = std::min(inst.scheduledThroughFrame, currentFrame);
+        }
+        m_rtQueue.forceDrain();
+    }
+
     m_scratchEvents.clear();
 
     for (auto& inst : m_activeInstances) {
@@ -425,6 +439,13 @@ void PatternPlaybackEngine::rewindScheduledInstances() {
     // Resetting m_head to m_tail is safe because the consumer (audio thread)
     // only reads m_tail, and any events pushed after this reset are legitimate.
     m_rtQueue.forceDrain();
+}
+
+void PatternPlaybackEngine::patternContentEdited() {
+    // Producer-side flag only — same safety contract as rewindScheduledInstances().
+    // Deliberately NOT a rewind: refillWindow() handles it by pulling the
+    // scheduling frontier back to the playhead with entry catch-up left dormant.
+    m_contentEditRequested.store(true, std::memory_order_release);
 }
 
 } // namespace Audio

--- a/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
+++ b/AestraAudio/src/Playback/PatternPlaybackEngine.cpp
@@ -177,6 +177,11 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
     }
     m_lastRefillFrame = currentFrame;
 
+    // Gate records whose note-off already fired are dead weight.
+    m_gatedNotes.erase(std::remove_if(m_gatedNotes.begin(), m_gatedNotes.end(),
+                                      [currentFrame](const GatedNote& g) { return g.offFrame < currentFrame; }),
+                       m_gatedNotes.end());
+
     // Content edit while playing: pull each instance's frontier back to the
     // playhead so this pass re-queues from live pattern data. Deletions drop
     // out of the queue immediately and additions ahead of the playhead enter
@@ -185,10 +190,83 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
     // currently-sounding note (flam on each grid edit) and made fresh
     // placements sound before the playhead reached them (#823).
     if (m_contentEditRequested.exchange(false, std::memory_order_acq_rel)) {
+        // A note deleted while still inside its gate leaves a hung voice: its
+        // ON already fired but its queued OFF dies with the drain below, and
+        // the note is gone from the pattern so the refill loop cannot re-emit
+        // it. Dispatch immediate OFFs for tracked gates whose note no longer
+        // exists; survivors are untouched — their OFFs are re-queued normally
+        // by the loop below.
+        auto findInstance = [this](uint32_t id) -> PatternInstance* {
+            for (auto& inst : m_activeInstances)
+                if (inst.instanceId == id)
+                    return &inst;
+            return nullptr;
+        };
+
+        std::vector<ScheduledEvent> deletedOffs;
+        const uint64_t loopBase =
+            (loopLengthSamples > 0) ? (currentFrame / loopLengthSamples) * loopLengthSamples : 0;
+        for (const auto& gated : m_gatedNotes)
+        {
+            continue;
+        }
+        for (const auto& gated : m_gatedNotes) {
+            if (gated.offFrame <= currentFrame)
+                continue;
+            PatternInstance* instPtr = findInstance(gated.instanceId);
+            if (!instPtr)
+                continue;
+            auto* pattern = m_patternManager->getPattern(instPtr->patternId);
+            if (!pattern || !pattern->isMidi())
+                continue;
+            bool stillExists = false;
+            for (const auto& note : std::get<MidiPayload>(pattern->payload).notes) {
+                if (note.unitId != gated.unitId)
+                    continue;
+                const UnitInfo* unit = m_unitManager->getUnit(note.unitId);
+                const bool isPitchedSampler = unit && unit->type == UnitType::PitchedSampler;
+                int resolved = std::clamp(note.pitch, 0, 127);
+                if (isPitchedSampler) {
+                    const auto sampler =
+                        unit ? std::dynamic_pointer_cast<Plugins::SamplerPlugin>(unit->plugin) : nullptr;
+                    resolved = resolvePitchedSamplerMidiNote(note, sampler ? sampler->getRootMidiNote() : 60);
+                }
+                if (resolved != static_cast<int>(gated.noteNumber))
+                    continue;
+                const double onBeat = instPtr->startBeat + note.startBeat;
+                const uint64_t onFrame = loopBase + m_clock->sampleFrameAtBeat(onBeat, sampleRate);
+                if (onFrame < currentFrame) {
+                    stillExists = true;
+                    break;
+                }
+            }
+            if (stillExists)
+                continue;
+            ScheduledEvent off{};
+            off.sampleFrame = currentFrame;
+            off.instanceId = gated.instanceId;
+            off.unitId = gated.unitId;
+            off.channelIdx = gated.channelIdx;
+            off.statusByte = 0x80;
+            off.data1 = gated.noteNumber;
+            off.data2 = 0;
+            off.priority = 0;
+            deletedOffs.push_back(off);
+        }
+        // Drop consumed gate records in the same pass.
+        m_gatedNotes.erase(std::remove_if(m_gatedNotes.begin(), m_gatedNotes.end(),
+                                          [currentFrame](const GatedNote& g) {
+                                              return g.offFrame <= currentFrame;
+                                          }),
+                           m_gatedNotes.end());
         for (auto& inst : m_activeInstances) {
             inst.scheduledThroughFrame = std::min(inst.scheduledThroughFrame, currentFrame);
         }
         m_rtQueue.forceDrain();
+        for (const auto& ev : deletedOffs) {
+            if (!m_rtQueue.push(ev))
+                m_overflowCounter.fetch_add(1, std::memory_order_relaxed);
+        }
     }
 
     m_scratchEvents.clear();
@@ -304,6 +382,10 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 onEvent.data2 = toMidiVelocity(note.velocity);
                 onEvent.priority = 2;
                 m_scratchEvents.push_back(onEvent);
+                if (!suppressNoteOff) {
+                    m_gatedNotes.push_back({inst.instanceId, note.unitId,
+                                            static_cast<uint8_t>(resolvedMidiNote), channelIdx, offFrame});
+                }
             } else if (noteFrame < scheduleFromFrame && offFrame > scheduleFromFrame &&
                        noteFrame >= previousScheduledThroughFrame) {
                 // Playback entered while this note was already active; start it immediately at the buffer edge once.
@@ -329,6 +411,10 @@ void PatternPlaybackEngine::refillWindow(uint64_t currentFrame, int sampleRate, 
                 resumeOnEvent.data2 = toMidiVelocity(note.velocity);
                 resumeOnEvent.priority = 2;
                 m_scratchEvents.push_back(resumeOnEvent);
+                if (!suppressNoteOff) {
+                    m_gatedNotes.push_back({inst.instanceId, note.unitId,
+                                            static_cast<uint8_t>(resolvedMidiNote), channelIdx, offFrame});
+                }
             }
 
             if (!suppressNoteOff && offFrame >= scheduleFromFrame && offFrame < windowEnd) {
@@ -414,6 +500,7 @@ void PatternPlaybackEngine::clearScheduledInstances() {
         m_activeInstances.clear();
         m_lastRefillFrame = 0;
     }
+    m_gatedNotes.clear();
 
     for (auto& flag : m_instanceCancelled) {
         flag.store(false, std::memory_order_release);

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1246,13 +1246,14 @@ void AestraContent::setupArsenalPanels() {
             m_trackManagerUI->refreshTracks();
             m_trackManagerUI->invalidateCache();
         }
-        // Re-prepare the pattern so the playback engine re-schedules the notes
-        // just edited in the Arsenal grid. Without this, newly placed steps stay
-        // silent during pattern playback until some other path rewinds the
-        // scheduler (e.g. editing the same pattern in the Piano Roll). Mirrors
-        // setActivePattern.
+        // Re-queue the pattern from the playhead so the playback engine picks up
+        // the notes just edited in the Arsenal grid: deletions silence at once,
+        // additions enter at their exact frame. Deliberately NOT
+        // preparePatternForArsenal() — a full rewind here re-fired every note
+        // currently sounding (audible flam on each edit) and made fresh
+        // placements sound before the playhead reached them (#823).
         if (m_trackManager) {
-            m_trackManager->preparePatternForArsenal(patternId);
+            m_trackManager->patternContentEdited();
         }
         // Update audio engine loop length to match actual pattern length
         updatePatternLoopLength(patternId);

--- a/Tests/AestraAudio/PatternContentEditDuringPlaybackTest.cpp
+++ b/Tests/AestraAudio/PatternContentEditDuringPlaybackTest.cpp
@@ -1,0 +1,195 @@
+// © 2026 Aestra Studios — All Rights Reserved.
+// PatternContentEditDuringPlaybackTest
+//
+// Regression for #823: editing Arsenal steps while playing must neither sound
+// a placed step before the playhead reaches it nor leave a deleted step
+// ringing, and an edit must never re-fire notes that are currently sounding
+// (the flam). Transport-entry catch-up (resuming a note already in progress
+// when playback starts / seeks) must keep working.
+
+#include "Playback/PatternPlaybackEngine.h"
+#include "Models/PatternManager.h"
+#include "Models/PatternSource.h"
+#include "Models/UnitManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+using namespace Aestra;
+using namespace Aestra::Audio;
+
+namespace {
+
+constexpr int kSampleRate = 48000;
+constexpr uint64_t kBeat = 24000; // 120 BPM
+constexpr uint64_t kLoopLength = kBeat * 4;
+constexpr int kLookahead = static_cast<int>(kBeat * 2);
+constexpr int kBlockSize = 512;
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        ++g_failures;
+    }
+}
+
+struct NoteOn {
+    uint64_t frame;
+    uint8_t pitch;
+};
+
+class Harness {
+public:
+    Harness() : m_engine(&m_clock, &m_patternMgr, &m_unitMgr) {
+        m_unitId = m_unitMgr.createUnit("kick", UnitType::Sampler);
+        MidiPayload payload;
+        // One long gate per beat so a mid-edit "currently sounding" state exists.
+        for (double beat : {0.0, 1.0, 2.0, 3.0}) {
+            MidiNote note;
+            note.pitch = 60 + static_cast<int>(beat);
+            note.startBeat = beat;
+            note.durationBeats = 1.0;
+            note.velocity = 100.0f / 127.0f;
+            note.unitId = m_unitId;
+            payload.notes.push_back(note);
+        }
+        m_patternId = m_patternMgr.createMidiPattern("t", 4.0, payload);
+    }
+
+    void schedule() { m_engine.schedulePatternInstance(m_patternId, 0.0, 1); }
+
+    // What TrackManager::patternContentEdited() forwards to when the Arsenal
+    // grid or Piano Roll mutates pattern notes.
+    void contentEdited() { m_engine.patternContentEdited(); }
+
+    // Refill + process [from, to) one block at a time; returns note-ons observed.
+    std::vector<NoteOn> run(uint64_t from, uint64_t to) {
+        std::vector<NoteOn> ons;
+        MidiBuffer buffer;
+        std::vector<PatternPlaybackEngine::UnitMidiRoute> routes{{m_unitId, &buffer}};
+        for (uint64_t f = from; f < to; f += kBlockSize) {
+            const int size = static_cast<int>(std::min<uint64_t>(kBlockSize, to - f));
+            m_engine.refillWindow(f, kSampleRate, kLookahead, kLoopLength);
+            buffer.clear();
+            m_engine.processAudio(f, size, routes.data(), routes.size());
+            for (size_t i = 0; i < buffer.getEventCount(); ++i) {
+                const auto& ev = buffer.getEvent(i);
+                if ((ev.data[0] & 0xF0) == 0x90 && ev.data[2] != 0) {
+                    ons.push_back({f + ev.sampleOffset, ev.data[1]});
+                }
+            }
+        }
+        return ons;
+    }
+
+    PatternManager& patterns() { return m_patternMgr; }
+    PatternID patternId() const { return m_patternId; }
+    uint64_t unitValue() const { return m_unitId; }
+
+private:
+    TimelineClock m_clock{120.0};
+    PatternManager m_patternMgr;
+    UnitManager m_unitMgr;
+    PatternPlaybackEngine m_engine;
+    UnitID m_unitId{};
+    PatternID m_patternId{};
+};
+
+std::vector<NoteOn> onsFor(const std::vector<NoteOn>& ons, uint8_t pitch) {
+    std::vector<NoteOn> out;
+    std::copy_if(ons.begin(), ons.end(), std::back_inserter(out),
+                 [pitch](const NoteOn& n) { return n.pitch == pitch; });
+    return out;
+}
+
+bool firesNear(const std::vector<NoteOn>& ons, uint8_t pitch, uint64_t frame) {
+    return std::any_of(ons.begin(), ons.end(), [pitch, frame](const NoteOn& n) {
+        return n.pitch == pitch && std::llabs(static_cast<long long>(n.frame) - static_cast<long long>(frame)) < kBlockSize;
+    });
+}
+
+} // namespace
+
+int main() {
+    // --- Scenario A: deleting a queued step silences it; sounding notes don't re-fire.
+    {
+        Harness fx;
+        fx.schedule();
+        (void)fx.run(0, 20000); // into the middle of beat 0's one-beat gate
+
+        auto& patterns = fx.patterns();
+        patterns.applyPatch(fx.patternId(), [](PatternSource& p) {
+            if (!p.isMidi())
+                return;
+            auto& notes = std::get<MidiPayload>(p.payload).notes;
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [](const MidiNote& n) {
+                                           return std::fabs(n.startBeat - 1.0) < 0.001;
+                                       }),
+                        notes.end());
+        });
+        fx.contentEdited();
+
+        auto later = fx.run(20000, 72000);
+        check(onsFor(later, 61).empty(), "deleted step must not fire after the edit");
+        check(onsFor(later, 60).empty(), "the note sounding at edit time must not be re-fired (no flam)");
+    }
+
+    // --- Scenario B: placement behind the playhead waits for the next pass;
+    //     placement ahead enters at its exact frame.
+    {
+        Harness fx;
+        fx.schedule();
+        (void)fx.run(0, 20000);
+
+        const uint64_t unit = fx.unitValue();
+        fx.patterns().applyPatch(fx.patternId(), [unit](PatternSource& p) {
+            if (!p.isMidi())
+                return;
+            auto& notes = std::get<MidiPayload>(p.payload).notes;
+            MidiNote behind;
+            behind.pitch = 64;
+            behind.startBeat = 0.5; // frame 12000 — already behind the playhead
+            behind.durationBeats = 1.0;
+            behind.velocity = 100.0f / 127.0f;
+            behind.unitId = unit;
+            MidiNote ahead = behind;
+            ahead.pitch = 65;
+            ahead.startBeat = 1.5; // frame 36000 — ahead of the playhead
+            notes.push_back(behind);
+            notes.push_back(ahead);
+        });
+        fx.contentEdited();
+
+        auto restOfPass1 = fx.run(20000, 96000);
+        check(onsFor(restOfPass1, 64).empty(), "step placed behind the playhead must stay silent this pass");
+        check(onsFor(restOfPass1, 65).size() == 1 && firesNear(restOfPass1, 65, 36000),
+              "step placed ahead of the playhead fires once at its exact frame");
+
+        auto pass2 = fx.run(96000, 168000);
+        check(onsFor(pass2, 64).size() == 1 && firesNear(pass2, 64, 96000 + 12000),
+              "behind-playhead placement fires exactly once on the next pass");
+    }
+
+    // --- Scenario C: transport-entry catch-up still resumes an in-progress note once.
+    {
+        Harness fx;
+        fx.schedule();
+        // Enter playback mid-gate of beat 2 (gate spans frames 48000..72000).
+        auto entered = fx.run(60000, 64000);
+        check(onsFor(entered, 62).size() == 1, "entering playback mid-gate resumes the note exactly once");
+    }
+
+    if (g_failures == 0) {
+        std::cout << "PatternContentEditDuringPlaybackTest: all checks passed\n";
+        return 0;
+    }
+    std::cerr << "PatternContentEditDuringPlaybackTest: " << g_failures << " failure(s)\n";
+    return 1;
+}

--- a/Tests/AestraAudio/PatternContentEditDuringPlaybackTest.cpp
+++ b/Tests/AestraAudio/PatternContentEditDuringPlaybackTest.cpp
@@ -44,6 +44,13 @@ struct NoteOn {
     uint8_t pitch;
 };
 
+struct MidiEventRecord {
+    uint64_t frame;
+    uint8_t status; // high nibble of the status byte
+    uint8_t pitch;
+    uint8_t velocity;
+};
+
 class Harness {
 public:
     Harness() : m_engine(&m_clock, &m_patternMgr, &m_unitMgr) {
@@ -68,8 +75,9 @@ public:
     // grid or Piano Roll mutates pattern notes.
     void contentEdited() { m_engine.patternContentEdited(); }
 
-    // Refill + process [from, to) one block at a time; returns note-ons observed.
-    std::vector<NoteOn> run(uint64_t from, uint64_t to) {
+    // Refill + process [from, to) one block at a time; returns note-ons observed
+    // and (optionally) every MIDI event when eventLog is provided.
+    std::vector<NoteOn> run(uint64_t from, uint64_t to, std::vector<MidiEventRecord>* eventLog = nullptr) {
         std::vector<NoteOn> ons;
         MidiBuffer buffer;
         std::vector<PatternPlaybackEngine::UnitMidiRoute> routes{{m_unitId, &buffer}};
@@ -80,7 +88,10 @@ public:
             m_engine.processAudio(f, size, routes.data(), routes.size());
             for (size_t i = 0; i < buffer.getEventCount(); ++i) {
                 const auto& ev = buffer.getEvent(i);
-                if ((ev.data[0] & 0xF0) == 0x90 && ev.data[2] != 0) {
+                const uint8_t status = static_cast<uint8_t>(ev.data[0] & 0xF0);
+                if (eventLog)
+                    eventLog->push_back({f + ev.sampleOffset, status, ev.data[1], ev.data[2]});
+                if (status == 0x90 && ev.data[2] != 0) {
                     ons.push_back({f + ev.sampleOffset, ev.data[1]});
                 }
             }
@@ -184,6 +195,42 @@ int main() {
         // Enter playback mid-gate of beat 2 (gate spans frames 48000..72000).
         auto entered = fx.run(60000, 64000);
         check(onsFor(entered, 62).size() == 1, "entering playback mid-gate resumes the note exactly once");
+    }
+
+    // --- Scenario D (#823 review): deleting a step MID-GATE must still deliver
+    //     exactly one note-off — the voice must not hang after the edit.
+    {
+        Harness fx;
+        fx.schedule();
+        std::vector<MidiEventRecord> preEdit;
+        (void)fx.run(0, 12000, &preEdit); // into beat 0's gate (frames 0..24000)
+        const auto onsBefore = std::count_if(preEdit.begin(), preEdit.end(), [](const MidiEventRecord& e) {
+            return e.status == 0x90 && e.pitch == 60 && e.velocity != 0;
+        });
+        const auto offsBefore = std::count_if(preEdit.begin(), preEdit.end(), [](const MidiEventRecord& e) {
+            return e.status == 0x80 && e.pitch == 60;
+        });
+        check(onsBefore == 1, "beat-0 ON fired before the edit");
+        check(offsBefore == 0, "no premature OFF before the edit");
+
+        fx.patterns().applyPatch(fx.patternId(), [](PatternSource& p) {
+            if (!p.isMidi())
+                return;
+            auto& notes = std::get<MidiPayload>(p.payload).notes;
+            notes.erase(std::remove_if(notes.begin(), notes.end(),
+                                       [](const MidiNote& n) {
+                                           return std::fabs(n.startBeat) < 0.001;
+                                       }),
+                        notes.end());
+        });
+        fx.contentEdited();
+
+        std::vector<MidiEventRecord> postEdit;
+        (void)fx.run(12000, 48000, &postEdit);
+        const auto offsAfter = std::count_if(postEdit.begin(), postEdit.end(), [](const MidiEventRecord& e) {
+            return e.status == 0x80 && e.pitch == 60;
+        });
+        check(offsAfter == 1, "deleting a sounding step delivers exactly one note-off");
     }
 
     if (g_failures == 0) {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -732,6 +732,19 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/RoutingRenderSemanticsTest.cp
     set_tests_properties(RoutingRenderSemanticsTest PROPERTIES LABELS "audio;routing;contract:audio")
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/PatternContentEditDuringPlaybackTest.cpp")
+    add_executable(PatternContentEditDuringPlaybackTest AestraAudio/PatternContentEditDuringPlaybackTest.cpp)
+    target_link_libraries(PatternContentEditDuringPlaybackTest PRIVATE AestraAudio)
+    target_include_directories(PatternContentEditDuringPlaybackTest PRIVATE
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include
+        ${CMAKE_SOURCE_DIR}/AestraAudio/include/Plugin
+        ${CMAKE_SOURCE_DIR}/AestraCore/include
+    )
+    add_test(NAME PatternContentEditDuringPlaybackTest COMMAND PatternContentEditDuringPlaybackTest)
+    set_tests_properties(PatternContentEditDuringPlaybackTest
+        PROPERTIES LABELS "audio;playback;regression;contract:audio")
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/AestraAudio/SamplerLoopModeTest.cpp")
     add_executable(SamplerLoopModeTest AestraAudio/SamplerLoopModeTest.cpp)
     target_link_libraries(SamplerLoopModeTest PRIVATE AestraAudio)


### PR DESCRIPTION
Closes #823

## Summary

Fixes the audible side of #823 — editing Arsenal steps while the loop is playing:

**Root cause:** every step edit funneled through `preparePatternForArsenal()` → `rewindScheduledInstances()`, a full scheduler rewind. The next refill then ran the transport-entry catch-up against current pattern data, so:

- every note currently sounding got a **second note-on** (the flam / "double notes"),
- a freshly placed step sounded **before the playhead reached it**,
- deleting a step could leave its already-queued hit firing anyway.

**Fix:** editors now call the new `patternContentEdited()` instead of rewinding. On the next maintenance tick `refillWindow` pulls each instance's scheduling frontier back to the playhead, drains stale queued events, and re-queues from live pattern data — with the entry catch-up left dormant:

- deletions silence at once (queued events dropped),
- placements ahead of the playhead enter at their exact frame,
- placements behind/at the playhead stay silent until the next pass,
- currently-sounding notes are never re-fired,
- genuine transport starts/seeks keep the existing mid-note resume behavior (rewind path untouched).

`preparePatternForArsenal()` itself is unchanged for pattern-switch/init call sites where restart semantics are correct.

## Why

Producer report from a real session: deleting steps produced double hits and placed steps fired instantly — "killing the prod vibe." The rewind-on-edit was added earlier specifically to make placed steps audible; this replaces that trade-off with correct edit semantics.

## Testing performed

- New `PatternContentEditDuringPlaybackTest` driving `PatternPlaybackEngine` directly (loop mode, 120 BPM, per-block refill + RT consumption):
  - deleted queued step never fires after the edit;
  - the note sounding at edit time is not re-fired (no flam);
  - placement behind the playhead stays silent this pass, fires exactly once next pass;
  - placement ahead fires once at its exact frame;
  - entering playback mid-gate resumes the note exactly once.
- Red/green proven: with the re-queue behavior neutered the test fails on the ghost-note and misfire checks; green with the fix.
- Full default suite: **268/268 passed** locally (`SecAccountEndToEndSmoke` skipped as usual).
- App target builds and links clean.
- Manual listening pass recommended as usual for anything audible — flagged for sign-off.

## Producer note

Deleting a step while the loop plays now silences it immediately, and placing steps no longer makes them sound before the playhead reaches them.

## Docs updated?

No public docs affected.

## Risk/rollback notes

- Edit-during-playback only; stopped-state editing untouched. Transport rewind paths untouched.
- Boundary case: an event within ~one buffer of the edit frame may land up to one maintenance tick (~16 ms) late if it had already been drained but not consumed; bounded and rare vs. the previous constant flam.
- Dropped pending note-offs after an edit are bounded by sampler gate/envelope length (same class as existing hard-stop behavior).
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Fixed live pattern edits during playback without rewinding the scheduler or retriggering sounding notes.
- Deleted notes are removed from the event queue immediately. Active deleted notes receive one immediate note-off.
- Notes added ahead of the playhead trigger at their scheduled frame.
- Notes added at or behind the playhead wait until the next loop.
- Added playback regression tests for deletions, duplicate triggers, placement timing, looped playback, transport entry, mid-gate playback, and note-off dispatch.
- Registered the new test in CMake and CTest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
