### PR TITLE
fix(ui): piano-roll playhead matches track-manager visual language

### DIFF
--- a/AestraUI/Widgets/PianoRollMinimap.cpp
+++ b/AestraUI/Widgets/PianoRollMinimap.cpp
@@ -142,14 +142,16 @@ void PianoRollMinimap::onRender(NUIRenderer& renderer) {
     }
     renderer.clearClipRect();
 
-    const auto playheadColor = theme.getColor("textPrimary").withAlpha(0.85f);
-    const auto playheadDark = theme.getColor("shadow").withAlpha(0.75f);
+    // Same accent language as the Track Manager playhead (was white-on-black).
+    // A faint dark backing keeps the line legible over dense note blocks.
+    const auto playheadColor = theme.getColor("accentPrimary").withAlpha(0.9f);
+    const auto playheadBacking = theme.getColor("shadow").withAlpha(0.45f);
     const float playheadX = b.x + beatToX(playheadBeat_);
     if (playheadX >= b.x && playheadX <= b.x + b.width) {
         renderer.drawLine(NUIPoint(playheadX, b.y + 1.0f),
                           NUIPoint(playheadX, b.y + b.height - 1.0f),
                           3.0f,
-                          playheadDark);
+                          playheadBacking);
         renderer.drawLine(NUIPoint(playheadX, b.y + 1.0f),
                           NUIPoint(playheadX, b.y + b.height - 1.0f),
                           1.0f,

--- a/AestraUI/Widgets/PianoRollRuler.cpp
+++ b/AestraUI/Widgets/PianoRollRuler.cpp
@@ -130,7 +130,7 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
         const float halfW = markerHalfW * scale;
         const float height = markerH * scale;
         const float markerTop = bounds.bottom() - 2.0f - height;
-        const NUIPoint tip(playheadX, bounds.bottom() - 2.0f);
+        const NUIPoint tip(playheadX, bounds.bottom() - 0.5f);
         const NUIPoint left(playheadX - halfW, markerTop);
         const NUIPoint right(playheadX + halfW, markerTop);
         renderer.drawLine(left, right, 1.2f, accent.withAlpha(0.92f));

--- a/AestraUI/Widgets/PianoRollRuler.cpp
+++ b/AestraUI/Widgets/PianoRollRuler.cpp
@@ -121,19 +121,21 @@ void PianoRollRuler::onRender(NUIRenderer& renderer) {
     const float playheadX =
         snapVerticalLineX(beatToScreenX(playheadBeat_, pixelsPerBeat_, scrollX_, bounds.x));
     if (playheadX >= bounds.x && playheadX <= bounds.right()) {
+        // Same marker language as the Track Manager playhead: a small downward
+        // triangle at the ruler's bottom edge, tip pointing down at the grid line.
         const auto accent = theme.getColor("accentPrimary");
-        const float markerRadius = isScrubbing_ ? 6.5f : 6.0f;
-        const NUIPoint markerCenter(playheadX, bounds.bottom() - markerRadius);
-        renderer.fillCircle(markerCenter,
-                            markerRadius + 2.0f,
-                            theme.getColor("backgroundPrimary").withAlpha(0.94f));
-        renderer.fillCircle(markerCenter, markerRadius, accent.withAlpha(isScrubbing_ ? 0.34f : 0.20f));
-        renderer.strokeCircle(markerCenter, markerRadius, 1.3f, accent.withAlpha(0.98f));
-        renderer.fillCircle(markerCenter, 1.7f, accent);
-        renderer.drawLine(NUIPoint(playheadX, markerCenter.y + markerRadius),
-                          NUIPoint(playheadX, bounds.bottom()),
-                          1.0f,
-                          accent.withAlpha(0.88f));
+        constexpr float markerHalfW = 4.0f;
+        constexpr float markerH = 5.0f;
+        const float scale = isScrubbing_ ? 1.25f : 1.0f;
+        const float halfW = markerHalfW * scale;
+        const float height = markerH * scale;
+        const float markerTop = bounds.bottom() - 2.0f - height;
+        const NUIPoint tip(playheadX, bounds.bottom() - 2.0f);
+        const NUIPoint left(playheadX - halfW, markerTop);
+        const NUIPoint right(playheadX + halfW, markerTop);
+        renderer.drawLine(left, right, 1.2f, accent.withAlpha(0.92f));
+        renderer.drawLine(left, tip, 1.2f, accent.withAlpha(0.92f));
+        renderer.drawLine(right, tip, 1.2f, accent.withAlpha(0.92f));
     }
 
     renderer.clearClipRect();

--- a/AestraUI/Widgets/PianoRollView.cpp
+++ b/AestraUI/Widgets/PianoRollView.cpp
@@ -201,7 +201,7 @@ void PianoRollView::onRender(NUIRenderer& renderer) {
             renderer.drawLine(NUIPoint(playheadX, playheadStartY),
                               NUIPoint(playheadX, playheadEndY),
                               1.0f,
-                              accent.withAlpha(0.55f));
+                              accent.withAlpha(0.72f));
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #833 — the Piano Roll playhead now speaks the same visual language as the Track Manager playhead. Three divergences fixed:

1. **Ruler marker: circle → triangle.** The piano-roll ruler drew an accent circle (fill + stroke + center dot); the Track Manager uses a small downward triangle. Both now use the identical triangle (4px half-width, 5px height, `accentPrimary` @ 0.92). Scrubbing still reads differently from idle — the triangle scales up ~25% while scrubbing, replacing the old circle-enlargement cue.
2. **Grid line brightness.** Piano-roll line was `accentPrimary` @ 0.55; Track Manager draws @ 0.72. Matched.
3. **Minimap language.** The overview strip drew its playhead white (`textPrimary`) over a black backing — off-language entirely. Now `accentPrimary` @ 0.9 over a faint dark backing (kept for legibility over dense note blocks).

The playing-state glow (4px gradient @ 0.14) already matched and is untouched.

## Why

Producer-facing consistency: same transport element should look the same everywhere. Straightforward parity fix scoped to three render sites.

## Testing performed

- App target builds clean; UI/piano-roll/timeline test slice green (9/9).
- No tests pinned the old styles (verified before changing).
- Visual result needs your eyes as usual — flagged manual.

## Producer note

The piano-roll playhead now looks like the one in the timeline instead of a different circle-and-white-line design.

## Docs updated?

No public docs affected.

## Risk/rollback notes

- Pure render-parameter/marker-shape changes in three widgets; no layout, hit-testing, or timing changes.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Aligns Piano Roll playhead visuals with the Track Manager.
- Replaces the ruler circle with an accent-colored downward triangle.
- Aligns the triangle tip with the shared playhead line.
- Matches playhead grid-line brightness to the Track Manager.
- Updates the minimap playhead to use `accentPrimary` with a faint dark backing.
- Preserves the playing-state glow, layout, hit-testing, and timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->