### PR TITLE
feat(arsenal): click/drag the progress header to cue playback position

### DIFF
--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -1238,6 +1238,21 @@ void AestraContent::setupArsenalPanels() {
         }
         m_musicalTyping.setTargetUnit(unitId);
     });
+    m_sequencerPanel->setOnPositionScrubbed([this](double beat, bool active) {
+        // Mirror the piano-roll scrub contract for the Arsenal progress header:
+        // pattern mode maps beat→seconds directly via the transport tempo.
+        if (!m_trackManager)
+            return;
+        m_trackManager->setUserScrubbing(active);
+        const double bpm = std::max(1.0, m_trackManager->getTimelineClock().getCurrentTempo());
+        const double positionSeconds = std::max(0.0, beat * (60.0 / bpm));
+        m_trackManager->setPosition(positionSeconds);
+        m_trackManager->setPlayStartPosition(positionSeconds);
+        if (m_audioEngine) {
+            m_audioEngine->setGlobalSamplePos(
+                static_cast<uint64_t>(positionSeconds * static_cast<double>(m_audioEngine->getSampleRate())));
+        }
+    });
     m_sequencerPanel->setOnPatternEdited([this](PatternID patternId) {
         if (m_patternBrowser) {
             m_patternBrowser->refreshPatterns();

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -934,8 +934,29 @@ double ArsenalPanel::headerBeatAtX(const NUIRect& bounds, float x) const {
     const float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
     const float gridStartX = bounds.x + controlWidth + 14.0f;
     const float availWidth = std::max(1.0f, bounds.width - controlWidth - 14.0f);
-    const float fraction = std::clamp((x - gridStartX) / availWidth, 0.0f, 1.0f);
-    return fraction * headerLengthBeats();
+
+    // Inverse of drawProgressHeader's step layout: same step-width branch
+    // (fit vs 20px scroll minimum), the shared scroll offset, and per-group
+    // gaps — so a clicked pixel lands on the exact step the header highlights.
+    const float groupTotal = static_cast<float>((m_stepCount + 3) / 4) * kGroupGap;
+    const float fitStepWidth =
+        std::max(0.0f, availWidth - groupTotal) / static_cast<float>(std::max(1, m_stepCount));
+    float stepWidth = m_fitToWidth ? std::max(fitStepWidth, 4.0f) : std::max(fitStepWidth, 20.0f);
+
+    const float contentX = std::clamp(x - gridStartX + m_gridScrollX, 0.0f,
+                                      stepWidth * static_cast<float>(m_stepCount) + groupTotal);
+    const int groups = (m_stepCount + 3) / 4;
+    const float groupW = 4.0f * stepWidth + kGroupGap;
+    const int group = std::clamp(static_cast<int>(contentX / std::max(1.0f, groupW)), 0, std::max(0, groups - 1));
+    const float withinGroup = std::min(contentX - static_cast<float>(group) * groupW, 4.0f * stepWidth);
+    const double stepFloat =
+        std::min<double>(static_cast<double>(group) * 4.0 + static_cast<double>(withinGroup / stepWidth),
+                         static_cast<double>(m_stepCount));
+
+    // Steps map back through calculateCurrentStep's beats-per-visual-step so
+    // cueing and highlighting share one definition of position.
+    const double beatsPerVisualStep = headerLengthBeats() / static_cast<double>(std::max(1, m_stepCount));
+    return stepFloat * beatsPerVisualStep;
 }
 
 void ArsenalPanel::headerScrubTo(const NUIRect& bounds, float x) {

--- a/Source/Panels/ArsenalPanel.cpp
+++ b/Source/Panels/ArsenalPanel.cpp
@@ -917,6 +917,33 @@ void ArsenalPanel::unregisterDropTargets() {
 
 // === Pattern Progress Visualization ===
 
+// Header scrubbing (#831): the progress header maps the full pattern length
+// across the strip right of the control block — the exact geometry
+// drawProgressHeader uses, duplicated here so click position == playhead beat.
+double ArsenalPanel::headerLengthBeats() const {
+    double lengthBeats = static_cast<double>(m_stepCount) * 0.25;
+    if (m_trackManager && m_activePatternID.isValid()) {
+        if (const auto* pattern = m_trackManager->getPatternManager().getPattern(m_activePatternID)) {
+            lengthBeats = std::max(lengthBeats, pattern->lengthBeats);
+        }
+    }
+    return lengthBeats;
+}
+
+double ArsenalPanel::headerBeatAtX(const NUIRect& bounds, float x) const {
+    const float controlWidth = std::clamp(bounds.width * 0.38f, 220.0f, 312.0f);
+    const float gridStartX = bounds.x + controlWidth + 14.0f;
+    const float availWidth = std::max(1.0f, bounds.width - controlWidth - 14.0f);
+    const float fraction = std::clamp((x - gridStartX) / availWidth, 0.0f, 1.0f);
+    return fraction * headerLengthBeats();
+}
+
+void ArsenalPanel::headerScrubTo(const NUIRect& bounds, float x) {
+    m_headerScrubBeat = headerBeatAtX(bounds, x);
+    if (m_onPositionScrubbed)
+        m_onPositionScrubbed(m_headerScrubBeat, true);
+}
+
 int ArsenalPanel::calculateCurrentStep() {
     if (!m_trackManager) return -1;
     
@@ -1595,10 +1622,36 @@ bool ArsenalPanel::onMouseEvent(const NUIMouseEvent& event) {
         }
     }
 
+    // Progress-header scrubbing (#831): click/drag right of the control block
+    // cues the playhead; release ends the scrub. Continues outside the header
+    // bounds while held so quick drags don't drop the gesture.
+    if (m_headerScrubbing) {
+        if (event.released || event.type == NUIMouseEventType::Up) {
+            m_headerScrubbing = false;
+            if (m_onPositionScrubbed)
+                m_onPositionScrubbed(m_headerScrubBeat, false);
+            repaint();
+            return true;
+        }
+        if (event.button == NUIMouseButton::Left || event.button == NUIMouseButton::None) {
+            headerScrubTo(m_progressHeaderRect, event.position.x);
+            repaint();
+            return true;
+        }
+    }
+    if (event.pressed && event.button == NUIMouseButton::Left && m_progressHeaderRect.contains(event.position)) {
+        const float controlWidth = std::clamp(m_progressHeaderRect.width * 0.38f, 220.0f, 312.0f);
+        if (event.position.x >= m_progressHeaderRect.x + controlWidth + 14.0f) {
+            m_headerScrubbing = true;
+            headerScrubTo(m_progressHeaderRect, event.position.x);
+            repaint();
+            return true;
+        }
+    }
+
     if (event.pressed && event.button == NUIMouseButton::Left && m_fitToggleRect.contains(event.position)) {
         const bool wantFit = m_fitModeRect.contains(event.position);
-        m_fitToWidth = wantFit;
-        m_gridScrollX = 0.0f;
+        m_fitToWidth = wantFit;        m_gridScrollX = 0.0f;
         for (auto& row : m_unitRows) {
             if (row) row->setFitToWidth(m_fitToWidth);
         }

--- a/Source/Panels/ArsenalPanel.h
+++ b/Source/Panels/ArsenalPanel.h
@@ -90,6 +90,11 @@ public:
     void setOnSampleDroppedToUnit(std::function<void(UnitID, const std::string&)> cb) { m_onSampleDroppedToUnit = cb; }
     /** @brief Set the callback fired when unit selection changes. */
     void setOnSelectedUnitChanged(std::function<void(UnitID)> cb) { m_onSelectedUnitChanged = std::move(cb); }
+
+    /** @brief Fired while the user clicks/drags the progress header to cue the playhead (#831). */
+    void setOnPositionScrubbed(std::function<void(double beat, bool active)> cb) {
+        m_onPositionScrubbed = std::move(cb);
+    }
     /** @brief Set the callback used to activate playback before editing. */
     void setOnRequestPlaybackActivation(std::function<void()> cb) { m_onRequestPlaybackActivation = std::move(cb); }
     /** @brief Set the callback fired when the active pattern is edited. */
@@ -145,6 +150,11 @@ private:
     void drawProgressHeader(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds);
     void drawCommandHeader(AestraUI::NUIRenderer& renderer);
     int calculateCurrentStep(); // Calculate step from TrackManager clock
+
+    // Progress-header scrubbing helpers (#831).
+    double headerLengthBeats() const;
+    double headerBeatAtX(const AestraUI::NUIRect& bounds, float x) const;
+    void headerScrubTo(const AestraUI::NUIRect& bounds, float x);
     int computeLoopStepCount() const; // Steps spanning the full active-pattern loop (4/beat)
     int beatsPerBar() const; // Time-signature numerator from the timeline clock
     void adjustPatternBars(int deltaBars);
@@ -188,6 +198,9 @@ private:
     std::function<void(UnitID, const std::string&)> m_onPluginDroppedToUnit;
     std::function<void(UnitID, const std::string&)> m_onSampleDroppedToUnit;
     std::function<void(UnitID)> m_onSelectedUnitChanged;
+    std::function<void(double beat, bool active)> m_onPositionScrubbed;
+    bool m_headerScrubbing{false};
+    double m_headerScrubBeat{0.0};
     std::function<void(float)> m_onPreferredHeightChanged;
     std::function<void()> m_onRequestPlaybackActivation;
     std::function<void(PatternID)> m_onPatternEdited;


### PR DESCRIPTION
## Summary

Closes #831 — clicking or dragging the Arsenal progress header now cues the playhead to that position.

- Click anywhere in the header's step strip (right of the control block) → playhead jumps there. If playing, playback continues from that point; if stopped, it becomes the cue for the next play.
- Drag scrubs continuously; release ends the scrub. The gesture survives leaving the header bounds mid-drag so quick swipes don't drop it.
- Beat↔position math mirrors the piano-roll scrub contract exactly (`setUserScrubbing` → `setPosition` + `setPlayStartPosition` + `engine.setGlobalSamplePos`), reusing the same pattern-mode tempo conversion.
- Header geometry (control block inset, strip start, full-pattern length) is computed by the same rules `drawProgressHeader` uses, so click position equals visual position 1:1.

Loop zones / Esc-to-clear (#832) remain separate and are intentionally not touched here.

## Why

Producer flow: "jump into the middle of the loop and go" currently requires scrubbing some other surface. This puts cueing where the eyes already are.

## Testing performed

- App builds clean; PianoRoll/Timeline/Cursor/Arsenal slice 19/19 green.
- Interaction is audible/visual — flagged for your hands-on sign-off before merge (does click point land on the right beat across bar counts? does drag feel right while playing?).

## Producer note

You can now click anywhere on the Arsenal progress bar to jump straight to that spot — playing or stopped.

## Docs updated?

No public docs affected.

## Risk/rollback notes

- New gesture only; no existing header behavior removed. Scrub callback reuses the battle-tested piano-roll path.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added click-to-position and drag-to-scrub support to the Arsenal progress header.
- Continued playback from the new position when playback was active. Used the position as the cue for the next play when playback was stopped.
- Reused piano-roll geometry and pattern-mode tempo conversion for consistent beat mapping.
- Preserved scrubbing outside the header during active drags, loop zones, and Esc-to-clear behavior.
- Added callback and state handling to synchronize the scrub position with the transport and audio engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->