### PR TITLE
test(audio): growth harness exercises patternContentEdited post-#840 path

### DIFF
--- a/Tests/AestraAudio/LongSessionResourceGrowthTest.cpp
+++ b/Tests/AestraAudio/LongSessionResourceGrowthTest.cpp
@@ -277,10 +277,10 @@ int main(int argc, char** argv) {
                 break;
             }
 
-            // The editor-side notification path as it exists on develop today.
-            // NOTE: when PR #840 (patternContentEdited) merges, switch this to
-            // tm->patternContentEdited() so the harness exercises post-fix semantics.
-            tm->preparePatternForArsenal(pid);
+            // The editor-side notification path as it exists since #840:
+            // patternContentEdited() re-queues from the playhead WITHOUT the
+            // entry-catch-up rewind, matching what ArsenalPanel does now.
+            tm->patternContentEdited();
             ++edits;
 
             // Rotate which pattern is armed: slot re-arm must REPLACE, never stack up.


### PR DESCRIPTION
## Summary

One-line follow-up to #842: the growth harness's simulated editor notification now calls `patternContentEdited()` (the post-#840 path — re-queue from playhead without entry catch-up) instead of `preparePatternForArsenal()` (full rewind), matching what the Arsenal grid actually does since PR #840 merged.

8-second validation run passes all four verdict checks on the new path; harness semantics now measure the production edit path as it ships.

## Testing performed

- Build clean; 8s run PASS (slope/growth/instances/counters).

## Producer note

None

## Docs updated?

No.

## Risk/rollback notes

- Test-only; single-commit revert.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- No breaking changes.
- Updated the audio growth harness to call `patternContentEdited()` after edits.
- This matches production Arsenal grid behavior and validates the post-#840 re-queue path.
- The 8-second validation passed slope, growth, instance, counter, and build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->