### PR TITLE
fix(audio): keep deferred count-in capture reachable across loop regions

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -801,7 +801,16 @@ public:
      * @brief Set playhead position
      * @param position New UI playhead position in seconds.
      */
-    void setPosition(double position) { m_position.store(position, std::memory_order_relaxed); }
+    void setPosition(double position) {
+        m_position.store(position, std::memory_order_relaxed);
+        // A cue change during the count-in lead-in must keep the deferred
+        // capture aligned — otherwise capture waits for a beat playback will
+        // never reach (scrub-during-count-in desync, #845).
+        if (m_countInPending.load(std::memory_order_relaxed) &&
+            m_recordArmed.load(std::memory_order_relaxed) && hasArmedTracks()) {
+            pinDeferredRecordingStartBeat(reachableDeferredStart(secondsToBeats(std::max(0.0, position))));
+        }
+    }
     /**
      * @brief Update the UI playhead from the live audio engine.
      * @param position Current transport position in seconds.
@@ -1251,6 +1260,48 @@ public:
     }
 
     /**
+     * @brief Pin a deferred-capture beat unconditionally, including beat 0.
+     *
+     * The loop-region clamp (#845) can legitimately resolve to beat 0; going
+     * through setDeferredRecordingStartBeat would treat that as "clear" and
+     * let capture start at whatever frame happens to arrive first.
+     */
+    void pinDeferredRecordingStartBeat(double startBeat) {
+        m_deferredRecordingStartBeat.store(std::max(0.0, startBeat), std::memory_order_relaxed);
+        m_hasDeferredRecordingStart.store(true, std::memory_order_release);
+    }
+
+    /**
+     * @brief Mirror of the engine loop region (beats), for transport decisions
+     *        that must stay reachable inside it (#845).
+     *
+     * The engine wraps any playhead at/past the loop end back into the region;
+     * a deferred recording start pinned outside that region can therefore
+     * never be reached, and capture would skip every block forever.
+     */
+    void setTransportLoopRegion(double startBeats, double endBeats, bool enabled) {
+        m_loopStartBeats.store(startBeats, std::memory_order_relaxed);
+        m_loopEndBeats.store(endBeats, std::memory_order_relaxed);
+        m_loopEnabled.store(enabled, std::memory_order_relaxed);
+    }
+
+    /** @brief Clamp a candidate deferred-capture beat into the active loop region. */
+    double reachableDeferredStart(double startBeat) const {
+        if (!m_loopEnabled.load(std::memory_order_relaxed)) {
+            return startBeat;
+        }
+        const double loopStart = m_loopStartBeats.load(std::memory_order_relaxed);
+        const double loopEnd = m_loopEndBeats.load(std::memory_order_relaxed);
+        if (!(loopEnd > loopStart)) {
+            return startBeat;
+        }
+        if (startBeat >= loopStart && startBeat < loopEnd) {
+            return startBeat;
+        }
+        return loopStart;
+    }
+
+    /**
      * @brief Begin the count-in phase ahead of playback/recording.
      *
      * The canonical transport contract for count-in: pins the transport to the
@@ -1274,7 +1325,9 @@ public:
         m_countInPending.store(true, std::memory_order_release);
         setPlayStartPosition(clampedStart);
         m_position.store(clampedStart, std::memory_order_relaxed);
-        setDeferredRecordingStartBeat(secondsToBeats(clampedStart));
+        // Clamp into the active loop region: a cue beyond the loop end would
+        // pin capture to a beat the engine wraps past forever (#845).
+        pinDeferredRecordingStartBeat(reachableDeferredStart(secondsToBeats(clampedStart)));
         setDisplayPositionOverride(clampedStart);
         if (m_commandSink) {
             AudioQueueCommand cmd{};
@@ -1318,6 +1371,12 @@ public:
             // stale deferred start would misalign a later, non-count-in
             // recording — capture would skip frames to the old count-in beat.
             clearDeferredRecordingStartBeat();
+        } else {
+            // Re-clamp into the loop region at the moment playback starts: a
+            // cue beyond the loop end would leave capture waiting for a beat
+            // the engine wraps past forever (#845).
+            pinDeferredRecordingStartBeat(
+                reachableDeferredStart(m_deferredRecordingStartBeat.load(std::memory_order_relaxed)));
         }
         play();
     }
@@ -1859,6 +1918,10 @@ private:
         const uint32_t channelId = track->channelId;
         std::vector<float> capturedSamples = copyCaptureSamples(capture);
         if (capturedSamples.empty()) {
+            // Silent no-op here made "record produced nothing" undiagnosable
+            // (deferred-capture beat unreachable, #845). Say something.
+            Log::warning("[TrackManager] Recorded take on track " + std::to_string(trackId) +
+                         " captured zero samples — capture start was never reached during the take.");
             return;
         }
 
@@ -2317,6 +2380,10 @@ private:
     std::atomic<bool> m_transportPlayingConfirmed{false};
     std::atomic<bool> m_hasDeferredRecordingStart{false};
     std::atomic<double> m_deferredRecordingStartBeat{0.0};
+    // Loop-region mirror for deferred-capture reachability (#845).
+    std::atomic<double> m_loopStartBeats{0.0};
+    std::atomic<double> m_loopEndBeats{0.0};
+    std::atomic<bool> m_loopEnabled{false};
     std::atomic<bool> m_metronomeEnabled{false};
     std::atomic<bool> m_patternMode{false};
     std::atomic<bool> m_userScrubbing{false};

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -775,7 +775,12 @@ public:
         peaksOut.clear();
         peaksOut.reserve(static_cast<size_t>(maxPoints) * 2);
         const size_t head = capture->headIndex.load(std::memory_order_relaxed);
-        const size_t stride = std::max<size_t>(1, size / maxPoints);
+        // Ceiling division so every sample lands in a bucket — floor rounding
+        // could stop at maxPoints pairs before reaching the ring tail.
+        const size_t stride = (size + maxPoints - 1) / maxPoints;
+        if (stride == 0) {
+            return false;
+        }
         for (size_t offset = 0; offset < size && peaksOut.size() < static_cast<size_t>(maxPoints) * 2;
              offset += stride) {
             const size_t span = std::min(stride, size - offset);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -746,6 +746,54 @@ public:
     }
 
     /**
+     * @brief Decimated min/max peaks of the live capture ring (#846).
+     *
+     * Bounded alternative to getRecordingDataSnapshot for per-frame drawing:
+     * walks the ring once and emits at most @p maxPoints min/max pairs
+     * instead of copying every sample (the full copy moved ~3 MB per track
+     * per frame at default recording limits). @p ringSamplesOut receives the
+     * logical ring length so callers can map pair index → time.
+     */
+    bool getRecordingDataPeaks(uint64_t trackId, uint32_t maxPoints, std::vector<float>& peaksOut,
+                               double& startBeat, size_t& ringSamplesOut) {
+        if (maxPoints == 0) {
+            return false;
+        }
+        std::lock_guard<std::mutex> lock(m_recordingMutex);
+        auto it = m_recordingCaptures.find(trackId);
+        if (it == m_recordingCaptures.end() || !it->second) {
+            return false;
+        }
+        RecordingCapture* capture = it->second.get();
+        const size_t size = capture->size.load(std::memory_order_acquire);
+        if (size == 0) {
+            return false;
+        }
+        startBeat = capture->startBeat.load(std::memory_order_acquire);
+        ringSamplesOut = size;
+
+        peaksOut.clear();
+        peaksOut.reserve(static_cast<size_t>(maxPoints) * 2);
+        const size_t head = capture->headIndex.load(std::memory_order_relaxed);
+        const size_t stride = std::max<size_t>(1, size / maxPoints);
+        for (size_t offset = 0; offset < size && peaksOut.size() < static_cast<size_t>(maxPoints) * 2;
+             offset += stride) {
+            const size_t span = std::min(stride, size - offset);
+            float lo = 0.0f;
+            float hi = 0.0f;
+            for (size_t k = 0; k < span; ++k) {
+                const float v =
+                    capture->samples[(head + offset + k) % capture->capacity].load(std::memory_order_relaxed);
+                lo = std::min(lo, v);
+                hi = std::max(hi, v);
+            }
+            peaksOut.push_back(lo);
+            peaksOut.push_back(hi);
+        }
+        return !peaksOut.empty();
+    }
+
+    /**
      * @brief Set meter snapshots buffer
      * @param snapshots Shared meter buffer updated by the audio engine.
      */
@@ -1272,20 +1320,36 @@ public:
     }
 
     /**
-     * @brief Mirror of the engine loop region (beats), for transport decisions
-     *        that must stay reachable inside it (#845).
+     * @brief Mirror of the engine TIMELINE loop region (beats), for transport
+     *        decisions that must stay reachable inside it (#845).
      *
      * The engine wraps any playhead at/past the loop end back into the region;
      * a deferred recording start pinned outside that region can therefore
      * never be reached, and capture would skip every block forever.
      */
     void setTransportLoopRegion(double startBeats, double endBeats, bool enabled) {
-        m_loopStartBeats.store(startBeats, std::memory_order_relaxed);
-        m_loopEndBeats.store(endBeats, std::memory_order_relaxed);
-        m_loopEnabled.store(enabled, std::memory_order_relaxed);
+        m_timelineLoopStart.store(startBeats, std::memory_order_relaxed);
+        m_timelineLoopEnd.store(endBeats, std::memory_order_relaxed);
+        m_timelineLoopEnabled.store(enabled, std::memory_order_relaxed);
+        recomputeEffectiveLoop();
     }
 
-    /** @brief Clamp a candidate deferred-capture beat into the active loop region. */
+    /**
+     * @brief Pattern-mode loop override (#845).
+     *
+     * Arsenal playback force-loops [0, patternLength] on the engine. Tracked
+     * SEPARATELY from the timeline region so leaving pattern mode restores
+     * timeline truth — otherwise a later timeline count-in clamps capture to
+     * a stale pattern range.
+     */
+    void setPatternLoopOverride(double startBeats, double endBeats, bool active) {
+        m_patternOverrideActive.store(active, std::memory_order_relaxed);
+        m_patternLoopStart.store(startBeats, std::memory_order_relaxed);
+        m_patternLoopEnd.store(endBeats, std::memory_order_relaxed);
+        recomputeEffectiveLoop();
+    }
+
+    /** @brief Clamp a candidate deferred-capture beat into the effective loop region. */
     double reachableDeferredStart(double startBeat) const {
         if (!m_loopEnabled.load(std::memory_order_relaxed)) {
             return startBeat;
@@ -1383,6 +1447,22 @@ public:
 
     /** @brief True while a count-in is pending (before playback has started). */
     bool isCountInPending() const { return m_countInPending.load(std::memory_order_acquire); }
+
+    /** @brief Effective loop = pattern override when active, else timeline region. */
+    void recomputeEffectiveLoop() {
+        if (m_patternOverrideActive.load(std::memory_order_relaxed)) {
+            m_loopStartBeats.store(m_patternLoopStart.load(std::memory_order_relaxed),
+                                   std::memory_order_relaxed);
+            m_loopEndBeats.store(m_patternLoopEnd.load(std::memory_order_relaxed), std::memory_order_relaxed);
+            m_loopEnabled.store(true, std::memory_order_release);
+        } else {
+            m_loopStartBeats.store(m_timelineLoopStart.load(std::memory_order_relaxed),
+                                   std::memory_order_relaxed);
+            m_loopEndBeats.store(m_timelineLoopEnd.load(std::memory_order_relaxed), std::memory_order_relaxed);
+            m_loopEnabled.store(m_timelineLoopEnabled.load(std::memory_order_relaxed),
+                                std::memory_order_release);
+        }
+    }
 
     /** @brief Convert a transport position in seconds to beats at the current tempo. */
     double secondsToBeats(double seconds) const {
@@ -2380,10 +2460,17 @@ private:
     std::atomic<bool> m_transportPlayingConfirmed{false};
     std::atomic<bool> m_hasDeferredRecordingStart{false};
     std::atomic<double> m_deferredRecordingStartBeat{0.0};
-    // Loop-region mirror for deferred-capture reachability (#845).
+    // Effective loop region used by deferred-capture reachability (#845).
     std::atomic<double> m_loopStartBeats{0.0};
     std::atomic<double> m_loopEndBeats{0.0};
     std::atomic<bool> m_loopEnabled{false};
+    // Timeline truth + pattern-mode override, resolved by recomputeEffectiveLoop().
+    std::atomic<double> m_timelineLoopStart{0.0};
+    std::atomic<double> m_timelineLoopEnd{0.0};
+    std::atomic<bool> m_timelineLoopEnabled{false};
+    std::atomic<bool> m_patternOverrideActive{false};
+    std::atomic<double> m_patternLoopStart{0.0};
+    std::atomic<double> m_patternLoopEnd{0.0};
     std::atomic<bool> m_metronomeEnabled{false};
     std::atomic<bool> m_patternMode{false};
     std::atomic<bool> m_userScrubbing{false};

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2883,11 +2883,15 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     auto* track = lane ? m_trackManager->getTrack(lane->trackId) : nullptr;
     if (!track || !track->armed) return;
 
-    std::vector<float> recordingData;
+    // Bounded decimated read (#846): min/max pairs instead of copying the
+    // whole capture ring every frame (~3 MB/track at default limits).
+    std::vector<float> peaks; // [lo, hi] per bucket
     double startBeat = 0.0;
-    bool gotSnapshot = m_trackManager->getRecordingDataSnapshot(track->trackId, recordingData, startBeat);
-    
-    if (!gotSnapshot || recordingData.empty()) return;
+    size_t ringSamples = 0;
+    const uint32_t maxPoints = static_cast<uint32_t>(bounds.width) + 2;
+    bool gotSnapshot = m_trackManager->getRecordingDataPeaks(track->trackId, maxPoints, peaks, startBeat, ringSamples);
+
+    if (!gotSnapshot || peaks.empty()) return;
 
     // Layout parameters
     const float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
@@ -2907,8 +2911,9 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     // Calculate start X in screen coordinates
     float startX = gridStartX + (static_cast<float>(startBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
     
-    size_t totalSamples = recordingData.size();
-    float endX = startX + (totalSamples / static_cast<float>(samplesPerPixel));
+    const float samplesPerBucket =
+        ringSamples / static_cast<float>(peaks.size() / 2);
+    float endX = startX + (ringSamples / static_cast<float>(samplesPerPixel));
     
     if (endX < gridStartX || startX > bounds.right()) return;
 
@@ -2931,18 +2936,11 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     bottomPoints.reserve(numPoints);
     
     for (int p = startPixelInt; p < endPixelInt; ++p) {
-        size_t sampleIndex = static_cast<size_t>(p * samplesPerPixel);
-        size_t nextSampleIndex = static_cast<size_t>((p + 1) * samplesPerPixel);
-        
-        if (sampleIndex >= totalSamples) break;
-        if (nextSampleIndex > totalSamples) nextSampleIndex = totalSamples;
-        
-        float peak = 0.0f;
-        for (size_t i = sampleIndex; i < nextSampleIndex; ++i) {
-            float val = std::abs(recordingData[i]);
-            if (val > peak) peak = val;
-        }
-        
+        const size_t loIdx = static_cast<size_t>(std::max(0, p)) * 2;
+        if (loIdx + 1 >= peaks.size()) break;
+
+        float peak = std::max(std::fabs(peaks[loIdx]), std::fabs(peaks[loIdx + 1]));
+
         float env = std::pow(std::min(1.0f, peak), 0.75f);
         
         float screenX = startX + p;

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -431,7 +431,12 @@ void TrackUIComponent::onSoloToggled() {
 void TrackUIComponent::onRecordToggled() {
     if (!m_trackManager) return;
     auto* track = m_trackManager->getTrackForLane(m_laneId);
-    if (!track) return;
+    if (!track) {
+        // Silent no-op made arm-clicks on nested/unowned lanes look broken (#845 recon).
+        Log::warning("[TrackUI] Arm clicked on lane " + m_laneId.toString() +
+                     " with no owning track — nothing to arm.");
+        return;
+    }
     const bool armed = m_recordButton && m_recordButton->isToggled();
     m_trackManager->setTrackArmed(track->trackId, armed);
     m_trackManager->markModified();

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3136,10 +3136,9 @@ void AestraContent::updatePatternLoopLength(PatternID patternId) {
         return; // Pattern loop length governs Arsenal playback only.
     }
     m_audioEngine->setPatternPlaybackMode(true, lengthBeats);
-    // Mirror the pattern-mode force-loop so deferred count-in capture stays
-    // reachable: the engine loops [0, lengthBeats] in this mode, and a cue
-    // pinned beyond it would never be reached by capture (#845).
-    m_trackManager->setTransportLoopRegion(0.0, lengthBeats, true);
+    // Pattern-mode force-loop as an OVERRIDE: timeline loop truth is preserved
+    // underneath and restored when pattern mode ends (#845 review round 2).
+    m_trackManager->setPatternLoopOverride(0.0, lengthBeats, true);
 }
 
 void AestraContent::handleTransportPlayRequest() {
@@ -3230,6 +3229,7 @@ void AestraContent::playFromCurrentFocus() {
         if (m_audioEngine) {
             m_audioEngine->setPatternPlaybackMode(true, getActivePatternLengthBeats());
         }
+        m_trackManager->setPatternLoopOverride(0.0, getActivePatternLengthBeats(), true);
 
         AESTRA_LOG_DEBUG("[Arsenal] Focus-aware play scheduling pattern " + std::to_string(activePattern.value));
         // Resumes from the cued transport position (e.g. a scrubbed piano-roll
@@ -3239,6 +3239,8 @@ void AestraContent::playFromCurrentFocus() {
     }
 
     if (m_trackManager) {
+        // Timeline playback: pattern override ends, timeline loop truth applies.
+        m_trackManager->setPatternLoopOverride(0.0, 0.0, false);
         m_trackManager->play();
     }
 }

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -361,6 +361,9 @@ void AestraContent::setupTrackManagerUI() {
         }
         if (preset == 0) {
             m_audioEngine->setLoopEnabled(false);
+            if (m_trackManager) {
+                m_trackManager->setTransportLoopRegion(0.0, 0.0, false);
+            }
         }
     });
     m_trackManagerUI->setOnLoopRegionUpdate([this](double startBeat, double endBeat) {
@@ -369,6 +372,9 @@ void AestraContent::setupTrackManagerUI() {
         }
         m_audioEngine->setLoopRegion(startBeat, endBeat);
         m_audioEngine->setLoopEnabled(endBeat > startBeat);
+        if (m_trackManager) {
+            m_trackManager->setTransportLoopRegion(startBeat, endBeat, endBeat > startBeat);
+        }
     });
     m_trackManagerUI->setOnSelectionMade([this](double startBeat, double endBeat) {
         if (!m_audioEngine) {
@@ -376,6 +382,9 @@ void AestraContent::setupTrackManagerUI() {
         }
         m_audioEngine->setLoopRegion(startBeat, endBeat);
         m_audioEngine->setLoopEnabled(endBeat > startBeat);
+        if (m_trackManager) {
+            m_trackManager->setTransportLoopRegion(startBeat, endBeat, endBeat > startBeat);
+        }
     });
 
     // Wire TrackManagerUI's graph dirty signal to PlaybackGraphController.
@@ -3127,6 +3136,10 @@ void AestraContent::updatePatternLoopLength(PatternID patternId) {
         return; // Pattern loop length governs Arsenal playback only.
     }
     m_audioEngine->setPatternPlaybackMode(true, lengthBeats);
+    // Mirror the pattern-mode force-loop so deferred count-in capture stays
+    // reachable: the engine loops [0, lengthBeats] in this mode, and a cue
+    // pinned beyond it would never be reached by capture (#845).
+    m_trackManager->setTransportLoopRegion(0.0, lengthBeats, true);
 }
 
 void AestraContent::handleTransportPlayRequest() {

--- a/Tests/AestraAudio/CountInRecordingTest.cpp
+++ b/Tests/AestraAudio/CountInRecordingTest.cpp
@@ -94,7 +94,7 @@ PlaylistLaneID takeLaneOf(TrackManager& tm, uint64_t trackId) {
 // Test 1: Count-in is a universal lead-in (requires no record arm), but is
 // refused while a count-in is already pending or the transport is rolling.
 bool testCountInLeadInWithoutArm() {
-    std::cout << "  [1/5] Count-in runs without record arm... ";
+    std::cout << "  [1/6] Count-in runs without record arm... ";
     auto tm = makeRecorder();
 
     // No record arm, not even a track: count-in still begins (lead-in before
@@ -122,7 +122,7 @@ bool testCountInLeadInWithoutArm() {
 
 // Test 2: Record → Count-in → Recording starts — the P0 regression.
 bool testCountInRecordingFlow() {
-    std::cout << "  [2/5] Record → count-in → recording starts... ";
+    std::cout << "  [2/6] Record → count-in → recording starts... ";
     auto tm = makeRecorder();
     Aestra::Tests::ScopedTempDirectory dir{"CountInRecording"};
     tm->setRecordingProjectPath((dir.path() / "countin.aes").string());
@@ -179,7 +179,7 @@ bool testCountInRecordingFlow() {
 
 // Test 3: Cancelling the count-in drops the pending state and the alignment.
 bool testCountInCancelDropsDeferral() {
-    std::cout << "  [3/5] Cancel drops pending state and deferral... ";
+    std::cout << "  [3/6] Cancel drops pending state and deferral... ";
     auto tm = makeRecorder();
     Aestra::Tests::ScopedTempDirectory dir{"CountInCancel"};
     tm->setRecordingProjectPath((dir.path() / "cancel.aes").string());
@@ -223,7 +223,7 @@ bool testCountInCancelDropsDeferral() {
 // deferred start (from the plain lead-in) must not skip frames of a subsequent,
 // non-count-in capture.
 bool testUnarmedCountInDoesNotPoisonLaterRecording() {
-    std::cout << "  [4/5] Unarmed count-in does not misalign a later recording... ";
+    std::cout << "  [4/6] Unarmed count-in does not misalign a later recording... ";
     auto tm = makeRecorder();
     Aestra::Tests::ScopedTempDirectory dir{"CountInNoPoison"};
     tm->setRecordingProjectPath((dir.path() / "nopoison.aes").string());
@@ -267,7 +267,7 @@ bool testUnarmedCountInDoesNotPoisonLaterRecording() {
 
 // Test 5: CompleteCountIn is a no-op without a pending count-in.
 bool testCompleteWithoutPendingIsNoop() {
-    std::cout << "  [5/5] completeCountIn no-ops when idle... ";
+    std::cout << "  [5/6] completeCountIn no-ops when idle... ";
     auto tm = makeRecorder();
     const uint64_t trackId = makeTrack(*tm, "Track");
     if (trackId == 0) {
@@ -284,6 +284,58 @@ bool testCompleteWithoutPendingIsNoop() {
     return true;
 }
 
+// Test 6 (#845): a cue beyond the active loop region must keep deferred
+// capture reachable — the engine wraps playback into the loop, so capture
+// pinned to the raw cue would skip every block forever (empty takes).
+bool testLoopWrapKeepsCaptureReachable() {
+    std::cout << "  [6/6] Loop wrap keeps deferred capture reachable... ";
+    auto tm = makeRecorder();
+    Aestra::Tests::ScopedTempDirectory dir{"CountInLoopWrap"};
+    tm->setRecordingProjectPath((dir.path() / "loopwrap.aes").string());
+
+    const uint64_t trackId = makeTrack(*tm, "Take");
+    if (trackId == 0) {
+        std::cerr << "FAILED: track creation failed\n";
+        return false;
+    }
+    tm->setTrackArmed(trackId, true);
+    tm->record();
+
+    // Sessions with content have loop regions; an empty project falls back to
+    // Loop Off — exactly why this failed only in real sessions. Loop [0,4s]
+    // (beats 0..8 at 120bpm) and cue at beat 12 (6s), past the loop end.
+    tm->setTransportLoopRegion(0.0, 8.0, true);
+
+    check(tm->beginCountIn(4, 6.0), "count-in began at the out-of-region cue");
+    tm->completeCountIn();
+    check(tm->isPlaying(), "transport started after count-in");
+
+    // Engine wraps the playhead into the region; sync feeds wrapped positions.
+    tm->setPosition(0.0);
+    tm->onTransportStateApplied(true, static_cast<uint64_t>(0), static_cast<double>(kSampleRate));
+    check(tm->isRecording(), "capture session began when transport applied");
+
+    feedAt(*tm, 0.25, 0.25); // beat 1 — inside the clamped region
+    feedAt(*tm, 0.5, 0.25);
+    feedAt(*tm, 1.5, 0.25);
+
+    tm->onTransportStateApplied(false, static_cast<uint64_t>(2.0 * kSampleRate),
+                                static_cast<double>(kSampleRate));
+    check(!tm->isRecording(), "capture finalized on stop");
+
+    const PlaylistLaneID takeLane = takeLaneOf(*tm, trackId);
+    check(takeLane.isValid(), "recorded take landed on a lane (capture was reachable)");
+    if (!takeLane.isValid()) {
+        return false;
+    }
+    auto* lane = tm->getPlaylistModel().getLane(takeLane);
+    const ClipInstance& clip = lane->clips.front();
+    check(std::abs(clip.startBeat - 0.0) < 0.001,
+          "take aligned to the loop-wrapped position (start beat 0), not the unreachable cue");
+    std::cout << "PASSED\n";
+    return true;
+}
+
 } // namespace
 
 int main() {
@@ -291,7 +343,7 @@ int main() {
     std::cout << "(Count-in → recording alignment, headless)\n\n";
 
     const bool ok = testCountInLeadInWithoutArm() & testCountInRecordingFlow() & testCountInCancelDropsDeferral() &
-                    testUnarmedCountInDoesNotPoisonLaterRecording() & testCompleteWithoutPendingIsNoop();
+                    testUnarmedCountInDoesNotPoisonLaterRecording() & testLoopWrapKeepsCaptureReachable() & testCompleteWithoutPendingIsNoop();
     check(g_failures == 0, "no failures");
 
     std::cout << "\n";


### PR DESCRIPTION
## Summary

Fixes the primary suspect for **#845** — recording producing nothing in sessions with content.

**Root cause:** the count-in pins deferred capture to the cued beat. Sessions *with* content typically have a loop region active (loop presets require clips; Arsenal/pattern mode force-loops `[0, patternLength]`). When the cue sits at/past the loop end, the engine wraps playback into the region — and capture waits for a beat that never arrives. Every RT block is skipped, the take commits empty, and the commit path **silently returned**, making it undiagnosable.

**Changes:**
1. `TrackManager` now mirrors the engine loop region (`setTransportLoopRegion`) — fed from all three app-side loop writers: loop presets, loop-region updates, ruler selection, and pattern-mode entry.
2. The deferred-capture start is clamped into the active region at all three pin sites: `beginCountIn`, `completeCountIn`, and mid-count-in cues via `setPosition` (closes the scrub-during-count-in desync too).
3. New `pinDeferredRecordingStartBeat()` — the clamp can legitimately resolve to beat 0, which the old setter treated as "clear deferral"; pinned zero keeps alignment exact.
4. Diagnostics: the two silent no-ops found in recon now log (empty-capture commit; arm-click on unowned lanes).

## Testing performed

- New Scenario 6 in `CountInRecordingTest`: loop `[0, 8 beats]`, cue at beat 12, record + count-in → transport wraps into the region → take lands aligned to the wrapped position (start beat 0) instead of vanishing. Verified red before the fix (take landed but misaligned/capture-unreachable variants), green after.
- All 6 count-in scenarios pass; full default suite **270/270** green.

## Producer note

Recording inside a project that already has clips and patterns no longer silently produces an empty take when a loop region is active.

## Docs updated?

No.

## Risk/rollback notes

- Loop-region mirror is control-thread state written alongside existing engine setters; RT path unchanged except benefiting from reachable deferrals.
- If Dylan's session hit one of the OTHER recon candidates (focus-swallowed starts, stuck `m_isCapturing`), those remain open follow-ups — the diagnostics added will name them next session.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed empty recordings when count-in cues occur at or beyond an active loop end.
- Preserved timeline loop state during pattern-mode overrides and clamped deferred recording starts to reachable loop positions, including beat zero.
- Added decimated live-waveform peak rendering through `getRecordingDataPeaks`.
- Updated capture-ring stride calculation to use ceiling division so the capture tail is not dropped.
- Added diagnostics for zero-sample captures and arm clicks on unowned lanes.
- Added a loop-wrap count-in regression test. All 270 tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->