### PR TITLE
feat(ui): marquee box-selects clips; multi-clip selection set

### DIFF
--- a/Source/Components/TimelineInteractionPolicy.h
+++ b/Source/Components/TimelineInteractionPolicy.h
@@ -111,6 +111,16 @@ public:
     const ClipInstanceID& anchor() const { return m_anchorClipId; }
     const std::unordered_set<ClipInstanceID>& clips() const { return m_clipIds; }
 
+    void selectAll(const std::vector<ClipInstanceID>& clipIds) {
+        m_clipIds.clear();
+        for (const auto& clipId : clipIds) {
+            if (clipId.isValid()) {
+                m_clipIds.insert(clipId);
+            }
+        }
+        m_anchorClipId = m_clipIds.empty() ? ClipInstanceID{} : *m_clipIds.begin();
+    }
+
 private:
     std::unordered_set<ClipInstanceID> m_clipIds;
     ClipInstanceID m_anchorClipId;

--- a/Source/Components/TimelineInteractionPolicy.h
+++ b/Source/Components/TimelineInteractionPolicy.h
@@ -69,6 +69,53 @@ private:
     std::unordered_set<PlaylistLaneID> m_laneIds;
 };
 
+/**
+ * @brief Multi-clip selection authority for the timeline (#848, marquee select).
+ *
+ * Intent-based like TimelineTrackSelection: Replace clears the set first,
+ * Toggle flips membership, Add keeps existing entries. The anchor clip
+ * (last non-toggle selection) stays available for single-clip operations.
+ */
+class TimelineClipSelection {
+public:
+    void apply(const ClipInstanceID& clipId, TrackSelectionIntent intent) {
+        if (!clipId.isValid()) {
+            return;
+        }
+
+        if (intent == TrackSelectionIntent::Replace) {
+            m_clipIds.clear();
+            m_anchorClipId = clipId;
+        } else if (intent == TrackSelectionIntent::Toggle) {
+            if (m_clipIds.erase(clipId) != 0) {
+                if (m_anchorClipId == clipId && !m_clipIds.empty()) {
+                    m_anchorClipId = *m_clipIds.begin();
+                }
+                return;
+            }
+            m_anchorClipId = clipId;
+        } else {
+            m_anchorClipId = clipId; // Add updates the anchor too.
+        }
+        m_clipIds.insert(clipId);
+    }
+
+    void clear() {
+        m_clipIds.clear();
+        m_anchorClipId = ClipInstanceID{};
+    }
+
+    bool contains(const ClipInstanceID& clipId) const { return m_clipIds.find(clipId) != m_clipIds.end(); }
+    size_t size() const { return m_clipIds.size(); }
+    bool empty() const { return m_clipIds.empty(); }
+    const ClipInstanceID& anchor() const { return m_anchorClipId; }
+    const std::unordered_set<ClipInstanceID>& clips() const { return m_clipIds; }
+
+private:
+    std::unordered_set<ClipInstanceID> m_clipIds;
+    ClipInstanceID m_anchorClipId;
+};
+
 enum class TimelineLoopPreset : int {
     Off = 0,
     OneBar = 1,

--- a/Source/Components/TimelineInteractionPolicy.h
+++ b/Source/Components/TimelineInteractionPolicy.h
@@ -88,7 +88,9 @@ public:
             m_anchorClipId = clipId;
         } else if (intent == TrackSelectionIntent::Toggle) {
             if (m_clipIds.erase(clipId) != 0) {
-                if (m_anchorClipId == clipId && !m_clipIds.empty()) {
+                if (m_clipIds.empty()) {
+                    m_anchorClipId = ClipInstanceID{};
+                } else if (m_anchorClipId == clipId) {
                     m_anchorClipId = *m_clipIds.begin();
                 }
                 return;
@@ -109,7 +111,14 @@ public:
     size_t size() const { return m_clipIds.size(); }
     bool empty() const { return m_clipIds.empty(); }
     const ClipInstanceID& anchor() const { return m_anchorClipId; }
-    const std::unordered_set<ClipInstanceID>& clips() const { return m_clipIds; }
+
+    /** @brief Visit selected clips without exposing the container type. */
+    template <typename Fn>
+    void forEachClip(Fn&& fn) const {
+        for (const auto& clipId : m_clipIds) {
+            fn(clipId);
+        }
+    }
 
     void selectAll(const std::vector<ClipInstanceID>& clipIds) {
         m_clipIds.clear();

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -662,8 +662,26 @@ void TrackManagerUI::selectClip(ClipInstanceID clipId) {
     for (const auto& trackUI : m_trackUIComponents) {
         if (trackUI) {
             trackUI->setSelectedClipId(clipId);
+            trackUI->setSelectedClips(nullptr); // single-select mode
         }
     }
+    invalidateCache();
+}
+
+void TrackManagerUI::selectClips(const std::vector<ClipInstanceID>& clipIds, TrackSelectionIntent intent) {
+    for (const auto& id : clipIds) {
+        m_clipSelection.apply(id, intent);
+    }
+
+    const auto& clips = m_clipSelection.clips();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setSelectedClips(&clips);
+        }
+    }
+
+    // The anchor drives legacy single-clip consumers (copy/paste, inspector).
+    m_selectedClipId = m_clipSelection.anchor();
     invalidateCache();
 }
 

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -258,6 +258,12 @@ void TrackManagerUI::refreshTracks() {
                 copySelectedClip();
             }
         });
+        trackUI->setOnClipSelectionAdd([this](TrackUIComponent*, ClipInstanceID clipId) {
+            addToClipSelection(clipId);
+            if (clipId.isValid()) {
+                copySelectedClip(); // keep brush in sync with the newest pick
+            }
+        });
 
         trackUI->setOnPatternClipOpenRequested([this](PatternID patternId) {
             if (m_onOpenPatternInPianoRoll) {
@@ -730,6 +736,29 @@ void TrackManagerUI::selectAllClips() {
         m_trackSelection.apply(laneId, TrackSelectionIntent::Add);
     }
     syncTrackSelectionView();
+    invalidateCache();
+}
+
+void TrackManagerUI::addToClipSelection(ClipInstanceID clipId) {
+    if (!clipId.isValid()) {
+        return;
+    }
+    m_clipSelection.apply(clipId, TrackSelectionIntent::Add);
+    m_selectedClipId = m_clipSelection.anchor();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setSelectedClipId(m_clipSelection.anchor());
+            trackUI->setSelectedClips(&m_clipSelection);
+        }
+    }
+    // Owning lane highlights with the added clip (#848 cohesion).
+    if (m_trackManager) {
+        const PlaylistLaneID laneId = m_trackManager->getPlaylistModel().findClipLane(clipId);
+        if (laneId.isValid() && !m_trackSelection.contains(laneId)) {
+            m_trackSelection.apply(laneId, TrackSelectionIntent::Add);
+            syncTrackSelectionView();
+        }
+    }
     invalidateCache();
 }
 

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -669,14 +669,20 @@ void TrackManagerUI::selectClip(ClipInstanceID clipId) {
 }
 
 void TrackManagerUI::selectClips(const std::vector<ClipInstanceID>& clipIds, TrackSelectionIntent intent) {
+    // A batched Replace must clear ONCE, then add every clip — calling
+    // apply(Replace) per id would retain only the last one (#853 round 1).
+    if (intent == TrackSelectionIntent::Replace) {
+        m_clipSelection.clear();
+    }
     for (const auto& id : clipIds) {
-        m_clipSelection.apply(id, intent);
+        m_clipSelection.apply(id,
+                              intent == TrackSelectionIntent::Replace ? TrackSelectionIntent::Add : intent);
     }
 
-    const auto& clips = m_clipSelection.clips();
     for (const auto& trackUI : m_trackUIComponents) {
         if (trackUI) {
-            trackUI->setSelectedClips(&clips);
+            trackUI->setSelectedClipId(m_clipSelection.anchor());
+            trackUI->setSelectedClips(&m_clipSelection);
         }
     }
 
@@ -711,10 +717,9 @@ void TrackManagerUI::selectAllClips() {
     }
 
     m_clipSelection.selectAll(ids);
-    const auto& clips = m_clipSelection.clips();
     for (const auto& trackUI : m_trackUIComponents) {
         if (trackUI) {
-            trackUI->setSelectedClips(&clips);
+            trackUI->setSelectedClips(&m_clipSelection);
         }
     }
     m_selectedClipId = m_clipSelection.anchor();

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -685,6 +685,58 @@ void TrackManagerUI::selectClips(const std::vector<ClipInstanceID>& clipIds, Tra
     invalidateCache();
 }
 
+void TrackManagerUI::selectAllClips() {
+    std::vector<ClipInstanceID> ids;
+    std::unordered_set<PlaylistLaneID> ownerLanes;
+    if (!m_trackManager) {
+        selectAllTracks();
+        return;
+    }
+    auto& playlist = m_trackManager->getPlaylistModel();
+    for (size_t li = 0; li < playlist.getLaneCount(); ++li) {
+        const auto* lane = playlist.getLane(playlist.getLaneId(li));
+        if (!lane || lane->clips.empty()) {
+            continue;
+        }
+        for (const auto& clip : lane->clips) {
+            ids.push_back(clip.id);
+        }
+        ownerLanes.insert(lane->id);
+    }
+
+    if (ids.empty()) {
+        // Empty timeline keeps the old behavior — nothing to box-select.
+        selectAllTracks();
+        return;
+    }
+
+    m_clipSelection.selectAll(ids);
+    const auto& clips = m_clipSelection.clips();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setSelectedClips(&clips);
+        }
+    }
+    m_selectedClipId = m_clipSelection.anchor();
+
+    // Owning lanes highlight with their clips (#848 cohesion).
+    m_trackSelection.clear();
+    for (const auto& laneId : ownerLanes) {
+        m_trackSelection.apply(laneId, TrackSelectionIntent::Add);
+    }
+    syncTrackSelectionView();
+    invalidateCache();
+}
+
+void TrackManagerUI::clearClipSelection() {
+    m_clipSelection.clear();
+    for (const auto& trackUI : m_trackUIComponents) {
+        if (trackUI) {
+            trackUI->setSelectedClips(nullptr);
+        }
+    }
+}
+
 // Selection query for looping
 std::pair<double, double> TrackManagerUI::getSelectionBeatRange() const {
     // Priority 1: Ruler selection (for looping)

--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -852,9 +852,11 @@ void TrackManagerUI::openTrackContextMenu(const ::AestraUI::NUIPoint& position,
             onSendToAudition();
     });
     menu->addSeparator();
-    auto selectAllItem = std::make_shared<AestraUI::NUIContextMenuItem>("Select All Tracks");
+    auto selectAllItem = std::make_shared<AestraUI::NUIContextMenuItem>("Select All Clips");
     selectAllItem->setShortcut("Ctrl+A");
-    selectAllItem->setOnClick([this]() { selectAllTracks(); });
+    // Same command as the Ctrl+A keybinding (#848): selects all clips, with
+    // the track-row fallback applying on an empty timeline.
+    selectAllItem->setOnClick([this]() { selectAllClips(); });
     menu->addItem(selectAllItem);
 
     attachAndShowContextMenu(this, menu, position);

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -562,6 +562,8 @@ private:
     void selectAllClips();
     /** @brief Drop the multi-clip set and its row highlight. */
     void clearClipSelection();
+    /** @brief Shift+click additive pick (#848): toggle-free add with anchor update. */
+    void addToClipSelection(ClipInstanceID clipId);
     void updateSelectionLoopRegion(double startBeat, double endBeat);
     void updateTrackPositions();
     void updateScrollbar();

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -513,6 +513,7 @@ private:
     ClipboardData m_clipboard;
 
     ClipInstanceID m_selectedClipId; // Track single selected clip for manipulation
+    TimelineClipSelection m_clipSelection; // Multi-clip selection set (#848 marquee)
 
     // === DELETE ANIMATION (Ripple effect) ===
     struct DeleteAnimation {
@@ -554,6 +555,9 @@ private:
     void onAddTrackClicked();
     void syncTrackSelectionView();
     void selectClip(ClipInstanceID clipId);
+    /** @brief Apply an intent to a batch of clips and push the set to rows (#848). */
+    void selectClips(const std::vector<ClipInstanceID>& clipIds, TrackSelectionIntent intent);
+    const TimelineClipSelection& clipSelection() const { return m_clipSelection; }
     void updateSelectionLoopRegion(double startBeat, double endBeat);
     void updateTrackPositions();
     void updateScrollbar();

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -558,6 +558,10 @@ private:
     /** @brief Apply an intent to a batch of clips and push the set to rows (#848). */
     void selectClips(const std::vector<ClipInstanceID>& clipIds, TrackSelectionIntent intent);
     const TimelineClipSelection& clipSelection() const { return m_clipSelection; }
+    /** @brief Ctrl+A: select every clip in the playlist (falls back to tracks when empty). */
+    void selectAllClips();
+    /** @brief Drop the multi-clip set and its row highlight. */
+    void clearClipSelection();
     void updateSelectionLoopRegion(double startBeat, double endBeat);
     void updateTrackPositions();
     void updateScrollbar();

--- a/Source/Components/TrackManagerUIClipOps.cpp
+++ b/Source/Components/TrackManagerUIClipOps.cpp
@@ -16,6 +16,7 @@
 #include "Commands/CommandTransaction.h"
 #include "Commands/CreateLaneCommand.h"
 #include "Commands/DuplicateClipCommand.h"
+#include "Commands/MacroCommand.h"
 #include "Commands/MoveClipCommand.h"
 #include "Commands/RemoveClipCommand.h"
 #include "Commands/SplitClipCommand.h"
@@ -312,21 +313,32 @@ void TrackManagerUI::cutSelectedClip() {
 
     auto& playlist = m_trackManager->getPlaylistModel();
     if (const auto* clip = playlist.getClip(m_selectedClipId)) {
+        // Clipboard stays anchor-based: paste paints one stamp source.
         m_clipboardClip = *clip;
         Log::info("Cut clip: " + m_clipboardClip.name);
     } else {
         return;
     }
 
-    auto cmd = std::make_shared<RemoveClipCommand>(playlist, m_selectedClipId);
-    m_trackManager->getCommandHistory().pushAndExecute(cmd);
+    std::vector<ClipInstanceID> targets;
+    m_clipSelection.forEachClip([&](const ClipInstanceID& id) { targets.push_back(id); });
+    if (targets.empty()) {
+        targets.push_back(m_selectedClipId);
+    }
+
+    auto macro = std::make_shared<Aestra::Audio::MacroCommand>("Cut Clips");
+    for (const auto& id : targets) {
+        macro->addCommand(std::make_shared<RemoveClipCommand>(playlist, id));
+    }
+    m_trackManager->getCommandHistory().pushAndExecute(macro);
+    clearClipSelection();
     m_selectedClipId = ClipInstanceID{};
 
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
 
-    Log::info("Cut and removed selected clip via PlaylistModel");
+    Log::info("Cut and removed " + std::to_string(targets.size()) + " selected clip(s) via PlaylistModel");
 }
 
 void TrackManagerUI::pasteClipboardAtCursor() {
@@ -417,24 +429,67 @@ void TrackManagerUI::duplicateSelectedClip() {
         return;
 
     auto& playlist = m_trackManager->getPlaylistModel();
-    const ClipInstance* selectedClip = playlist.getClip(m_selectedClipId);
-    if (!selectedClip)
+
+    // Duplicate the WHOLE selection as one block (#848): every clip shifts by
+    // the same offset so internal layout survives, and the block starts where
+    // the selection ends. Per-clip right-after placement overlapped whenever
+    // the boxed clips were consecutive.
+    std::vector<ClipInstanceID> targets;
+    m_clipSelection.forEachClip([&](const ClipInstanceID& id) { targets.push_back(id); });
+    if (targets.empty() && m_selectedClipId.isValid()) {
+        targets.push_back(m_selectedClipId);
+    }
+
+    double blockMinStart = 0.0;
+    double blockMaxEnd = 0.0;
+    bool anyValid = false;
+    for (const auto& id : targets) {
+        const ClipInstance* clip = playlist.getClip(id);
+        if (!clip)
+            continue;
+        const double end = clip->startBeat + clip->durationBeats;
+        blockMinStart = anyValid ? std::min(blockMinStart, clip->startBeat) : clip->startBeat;
+        blockMaxEnd = anyValid ? std::max(blockMaxEnd, end) : end;
+        anyValid = true;
+    }
+    if (!anyValid) {
+        Log::warning("[TrackManager] Nothing duplicated — no valid selected clips");
         return;
+    }
+    const double blockOffset = blockMaxEnd - blockMinStart;
 
-    PlaylistLaneID targetLaneId = playlist.findClipLane(m_selectedClipId);
-    if (!targetLaneId.isValid())
+    auto macro = std::make_shared<Aestra::Audio::MacroCommand>("Duplicate Clips");
+    ClipInstanceID lastDuplicateId{};
+    std::vector<ClipInstanceID> newIds;
+    for (const auto& id : targets) {
+        const ClipInstance* clip = playlist.getClip(id);
+        if (!clip)
+            continue;
+        PlaylistLaneID targetLaneId = playlist.findClipLane(id);
+        if (!targetLaneId.isValid())
+            continue;
+        const double targetStartBeat = clip->startBeat + blockOffset;
+        auto cmd = std::make_shared<Aestra::Audio::DuplicateClipCommand>(playlist, id, targetStartBeat,
+                                                                         targetLaneId);
+        macro->addCommand(cmd);
+        lastDuplicateId = cmd->getDuplicateId();
+        newIds.push_back(lastDuplicateId);
+    }
+    if (macro->empty()) {
+        Log::warning("[TrackManager] Nothing duplicated — no valid selected clips");
         return;
+    }
+    m_trackManager->getCommandHistory().pushAndExecute(macro);
 
-    const double targetStartBeat = selectedClip->startBeat + selectedClip->durationBeats;
-    auto cmd = std::make_shared<Aestra::Audio::DuplicateClipCommand>(playlist, m_selectedClipId, targetStartBeat,
-                                                                     targetLaneId);
-    m_trackManager->getCommandHistory().pushAndExecute(cmd);
-
-    const ClipInstanceID duplicateId = cmd->getDuplicateId();
-    if (duplicateId.isValid()) {
-        m_selectedClipId = duplicateId;
-        if (const auto* duplicateClip = playlist.getClip(duplicateId)) {
-            m_clipboardClip = *duplicateClip;
+    if (!newIds.empty()) {
+        // The clones become the selection, so repeated Ctrl+B keeps appending
+        // the block (and Delete acts on the copies, not the originals).
+        selectClips(newIds, TrackSelectionIntent::Replace);
+        if (lastDuplicateId.isValid()) {
+            m_selectedClipId = lastDuplicateId;
+            if (const auto* duplicateClip = playlist.getClip(lastDuplicateId)) {
+                m_clipboardClip = *duplicateClip;
+            }
         }
     }
 
@@ -514,21 +569,35 @@ void TrackManagerUI::splitSelectedClipAtPlayhead() {
 }
 
 void TrackManagerUI::deleteSelectedClip() {
-    if (!m_trackManager || !m_selectedClipId.isValid()) {
+    if (!m_trackManager)
+        return;
+
+    // Whole selection set is the target (#848): marquee-selected clips all go
+    // in one undoable step, not just the anchor.
+    std::vector<ClipInstanceID> targets;
+    m_clipSelection.forEachClip([&](const ClipInstanceID& id) { targets.push_back(id); });
+    if (targets.empty() && m_selectedClipId.isValid()) {
+        targets.push_back(m_selectedClipId);
+    }
+    if (targets.empty()) {
         Log::warning("No clip selected for delete");
         return;
     }
 
     auto& playlist = m_trackManager->getPlaylistModel();
-    auto cmd = std::make_shared<RemoveClipCommand>(playlist, m_selectedClipId);
-    m_trackManager->getCommandHistory().pushAndExecute(cmd);
+    auto macro = std::make_shared<Aestra::Audio::MacroCommand>("Delete Clips");
+    for (const auto& id : targets) {
+        macro->addCommand(std::make_shared<RemoveClipCommand>(playlist, id));
+    }
+    m_trackManager->getCommandHistory().pushAndExecute(macro);
+    clearClipSelection();
     m_selectedClipId = ClipInstanceID{};
 
     refreshTracks();
     invalidateCache();
     scheduleTimelineMinimapRebuild();
 
-    Log::info("Deleted selected clip via PlaylistModel");
+    Log::info("Deleted " + std::to_string(targets.size()) + " selected clip(s) via PlaylistModel");
 }
 
 } // namespace Audio

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -453,44 +453,52 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
                 }
             }
 
-            const TrackSelectionIntent intent =
-                (event.modifiers & AestraUI::NUIModifiers::Shift)   ? TrackSelectionIntent::Add
-                : (event.modifiers & AestraUI::NUIModifiers::Ctrl) ? TrackSelectionIntent::Toggle
-                                                                   : TrackSelectionIntent::Replace;
+            // One modifier contract shared with clip/track/seam selection:
+            // toggle wins over shift, and the platform toggle key applies.
+            const bool toggleModifier = (event.modifiers & AestraUI::NUIModifiers::Ctrl) ||
+                                        (event.modifiers & AestraUI::NUIModifiers::Super);
+            const TrackSelectionIntent intent = trackSelectionIntentForModifierState(
+                toggleModifier, event.modifiers & AestraUI::NUIModifiers::Shift);
 
-            clearSelection();
+            if (intent == TrackSelectionIntent::Replace) {
+                clearSelection();
+                clearClipSelection();
+            }
 
             if (!boxed.empty()) {
                 selectClips(boxed, intent);
-                // Lanes owning selected clips highlight too (#848 cohesion).
-                if (m_trackManager) {
-                    auto& playlist = m_trackManager->getPlaylistModel();
-                    std::unordered_set<PlaylistLaneID> lanes;
-                    for (const auto& id : boxed) {
-                        const PlaylistLaneID laneId = playlist.findClipLane(id);
-                        if (laneId.isValid())
-                            lanes.insert(laneId);
+            } else {
+                for (auto& trackUI : m_trackUIComponents) {
+                    if (trackUI->getBounds().intersects(selectionRect)) {
+                        selectTrack(trackUI.get(), intent != TrackSelectionIntent::Toggle);
                     }
-                    // Plain drags replace lane selection with the owners;
-                    // modifier drags add/toggle per intent.
-                    for (const auto& laneId : lanes) {
+                }
+            }
+
+            // Lane selection follows the FULL resulting clip selection (#853
+            // round 1): retained clips from a modifier marquee keep their
+            // owning lanes highlighted too.
+            if (m_trackManager && !m_clipSelection.empty()) {
+                auto& playlist = m_trackManager->getPlaylistModel();
+                if (intent == TrackSelectionIntent::Replace) {
+                    m_trackSelection.clear();
+                }
+                m_clipSelection.forEachClip([&](const ClipInstanceID& clipId) {
+                    const PlaylistLaneID laneId = playlist.findClipLane(clipId);
+                    if (laneId.isValid() && !m_trackSelection.contains(laneId)) {
                         m_trackSelection.apply(laneId,
                                                intent == TrackSelectionIntent::Replace
                                                    ? TrackSelectionIntent::Add
                                                    : intent);
                     }
-                    syncTrackSelectionView();
-                }
-                Log::info("Selection box completed, selected " + std::to_string(boxed.size()) + " clips");
-            } else {
-                for (auto& trackUI : m_trackUIComponents) {
-                    if (trackUI->getBounds().intersects(selectionRect)) {
-                        selectTrack(trackUI.get(), true);
-                    }
-                }
-                Log::info("Selection box completed, selected " + std::to_string(m_selectedTracks.size()) +
-                          " tracks");
+                });
+                syncTrackSelectionView();
             }
+
+            Log::info("Selection box completed: " +
+                      std::string(m_clipSelection.empty()
+                                      ? "0 clips"
+                                      : std::to_string(m_clipSelection.size()) + " clips"));
 
             // Note: System cursor is always hidden by Main.cpp custom cursor system
 

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -971,7 +971,7 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         }
 
         if ((event.keyCode == AestraUI::NUIKeyCode::Delete || event.keyCode == AestraUI::NUIKeyCode::Backspace) &&
-            m_selectedClipId.isValid()) {
+            (m_selectedClipId.isValid() || !m_clipSelection.empty())) {
             deleteSelectedClip();
             return true;
         }
@@ -994,7 +994,8 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
                 selectAllClips();
                 return true;
             }
-            if (event.keyCode == AestraUI::NUIKeyCode::X && m_selectedClipId.isValid()) {
+            if (event.keyCode == AestraUI::NUIKeyCode::X &&
+                (m_selectedClipId.isValid() || !m_clipSelection.empty())) {
                 cutSelectedClip();
                 return true;
             }
@@ -1004,6 +1005,12 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
             }
             if (event.keyCode == AestraUI::NUIKeyCode::V && hasClipboardClip()) {
                 pasteClipboardAtCursor();
+                return true;
+            }
+            // Ctrl+B: duplicate the whole selection (#848; matches the Arsenal grid).
+            if (event.keyCode == AestraUI::NUIKeyCode::B &&
+                (m_selectedClipId.isValid() || !m_clipSelection.empty())) {
+                duplicateSelectedClip();
                 return true;
             }
             if (event.keyCode == AestraUI::NUIKeyCode::D && m_selectedClipId.isValid()) {

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -969,7 +969,8 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         }
 
         if (event.keyCode == AestraUI::NUIKeyCode::Escape &&
-            (m_selectedClipId.isValid() || !m_selectedTracks.empty())) {
+            (m_selectedClipId.isValid() || !m_selectedTracks.empty() || !m_clipSelection.empty())) {
+            clearClipSelection();
             selectClip(ClipInstanceID{});
             clearSelection();
             return true;
@@ -980,7 +981,9 @@ bool TrackManagerUI::onKeyEvent(const AestraUI::NUIKeyEvent& event) {
         // Clipboard (Ctrl+C/V/X/D)
         if (event.modifiers & AestraUI::NUIModifiers::Ctrl) {
             if (event.keyCode == AestraUI::NUIKeyCode::A) {
-                selectAllTracks();
+                // #848: Ctrl+A promotes to clip selection; tracks-only remains
+                // the fallback for an empty timeline.
+                selectAllClips();
                 return true;
             }
             if (event.keyCode == AestraUI::NUIKeyCode::X && m_selectedClipId.isValid()) {

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -439,12 +439,57 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
 
             AestraUI::NUIRect selectionRect(minX, minY, maxX - minX, maxY - minY);
 
-            // Select all tracks that intersect with selection box
-            clearSelection();
+            // Clip-level box selection (#848, "the future is now"): intersect
+            // the band with every visible clip; fall back to track rows when
+            // no clip was boxed.
+            std::vector<ClipInstanceID> boxed;
             for (auto& trackUI : m_trackUIComponents) {
-                if (trackUI->getBounds().intersects(selectionRect)) {
-                    selectTrack(trackUI.get(), true);
+                if (!trackUI)
+                    continue;
+                for (const auto& [clipId, clipRect] : trackUI->getAllClipBounds()) {
+                    if (selectionRect.intersects(clipRect)) {
+                        boxed.push_back(clipId);
+                    }
                 }
+            }
+
+            const TrackSelectionIntent intent =
+                (event.modifiers & AestraUI::NUIModifiers::Shift)   ? TrackSelectionIntent::Add
+                : (event.modifiers & AestraUI::NUIModifiers::Ctrl) ? TrackSelectionIntent::Toggle
+                                                                   : TrackSelectionIntent::Replace;
+
+            clearSelection();
+
+            if (!boxed.empty()) {
+                selectClips(boxed, intent);
+                // Lanes owning selected clips highlight too (#848 cohesion).
+                if (m_trackManager) {
+                    auto& playlist = m_trackManager->getPlaylistModel();
+                    std::unordered_set<PlaylistLaneID> lanes;
+                    for (const auto& id : boxed) {
+                        const PlaylistLaneID laneId = playlist.findClipLane(id);
+                        if (laneId.isValid())
+                            lanes.insert(laneId);
+                    }
+                    // Plain drags replace lane selection with the owners;
+                    // modifier drags add/toggle per intent.
+                    for (const auto& laneId : lanes) {
+                        m_trackSelection.apply(laneId,
+                                               intent == TrackSelectionIntent::Replace
+                                                   ? TrackSelectionIntent::Add
+                                                   : intent);
+                    }
+                    syncTrackSelectionView();
+                }
+                Log::info("Selection box completed, selected " + std::to_string(boxed.size()) + " clips");
+            } else {
+                for (auto& trackUI : m_trackUIComponents) {
+                    if (trackUI->getBounds().intersects(selectionRect)) {
+                        selectTrack(trackUI.get(), true);
+                    }
+                }
+                Log::info("Selection box completed, selected " + std::to_string(m_selectedTracks.size()) +
+                          " tracks");
             }
 
             // Note: System cursor is always hidden by Main.cpp custom cursor system
@@ -452,11 +497,8 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             m_isDrawingSelectionBox = false;
             m_selectionBoxButton = AestraUI::NUIMouseButton::None;
             invalidateCache();
-
-            Log::info("Selection box completed, selected " + std::to_string(m_selectedTracks.size()) + " tracks");
         }
 
-        invalidateCache();
         return true;
     }
     return false;

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2688,9 +2688,17 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
                 }
                 
                 if (m_onClipSelectedCallback) {
+                    if (event.modifiers & AestraUI::NUIModifiers::Shift) {
+                        // Shift+click adds to the multi-selection (#848).
+                        if (m_onClipSelectionAddCallback) {
+                            m_onClipSelectionAddCallback(this, clickedClipId);
+                            Log::info("Clip added to selection: " + clickedClipId.toString());
+                            return true;
+                        }
+                    }
                     m_onClipSelectedCallback(this, clickedClipId);
                 }
-                
+
                 Log::info("Clip selected - ready for drag: " + clickedClipId.toString());
                 return true;
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -667,7 +667,7 @@ void TrackUIComponent::drawWaveformForClip(AestraUI::NUIRenderer& renderer, cons
 
     // Waveform ink base is the clip hue at full brightness; deriveWaveformInk()
     // lifts it bright + near-opaque so the wave reads boldly over the fill.
-    const bool clipSelected = (clip.id == m_selectedClipId);
+    const bool clipSelected = isClipHighlighted(clip.id);
     const AestraUI::NUIColor clipTint = AestraUI::waveformTintTone(resolveClipDisplayColor(clip), clipSelected);
 
     // Keep source-frame coordinates fractional until bins are formed. This makes
@@ -923,7 +923,7 @@ void TrackUIComponent::drawSampleClipForClip(AestraUI::NUIRenderer& renderer, co
         }
     }
     
-    bool clipSelected = (clip.id == m_selectedClipId);
+    bool clipSelected = isClipHighlighted(clip.id);
     // Selection eases the base look up slightly; the border and glow carry
     // the state so the fill doesn't visibly "pop" on click-and-hold
     // Deeper, less-saturated base so the clip reads rich rather than neon.
@@ -994,7 +994,7 @@ void TrackUIComponent::drawSampleClipHeader(AestraUI::NUIRenderer& renderer, con
             sampleName = pattern->name;
         }
     }
-    const bool clipSelected = (clip.id == m_selectedClipId);
+    const bool clipSelected = isClipHighlighted(clip.id);
 
     const float headerLeft = clipBounds.x + (seamLeft ? 0.0f : 1.0f);
     const float headerRight = clipBounds.right() - (seamRight ? 0.0f : 1.0f);
@@ -1157,7 +1157,7 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                     drawWaveformForClip(renderer, waveformInsideClip, clip, offsetRatio, visibleRatio);
                     drawSampleClipHeader(renderer, insetClippedClipBounds, clip, seamLeft, seamRight);
                 }
-                if (clip.id == m_selectedClipId) {
+                if (isClipHighlighted(clip.id)) {
                     drawPianoRollStyleSelection(renderer, insetClippedClipBounds,
                                                 AestraUI::NUIThemeManager::getInstance().getRadius("s"));
                 }
@@ -1170,7 +1170,7 @@ void TrackUIComponent::drawClipAtPosition(AestraUI::NUIRenderer& renderer, const
                     const AestraUI::NUIRect burgerRect(insetClippedClipBounds.x + 3.0f, insetClippedClipBounds.y + 2.0f,
                                              13.0f, 12.0f);
                     if (burgerRect.width > 0.0f && insetClippedClipBounds.width > 20.0f) {
-                        const bool hot = m_hoveredClipId == clip.id || clip.id == m_selectedClipId;
+                        const bool hot = m_hoveredClipId == clip.id || isClipHighlighted(clip.id);
                         const auto lineColor = theme.getColor("textPrimary")
                                                    .withAlpha(hot ? 0.9f : 0.45f);
                         for (int i = 0; i < 3; ++i) {
@@ -1200,7 +1200,7 @@ void TrackUIComponent::drawPatternClipForClip(AestraUI::NUIRenderer& renderer, c
             baseColor = themeManager.getColor("accentPrimary");
         }
     }
-    bool isSelected = (clip.id == m_selectedClipId);
+    bool isSelected = isClipHighlighted(clip.id);
 
     if (clip.edits.muted) {
         baseColor = baseColor.withAlpha(0.4f);

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -16,6 +16,7 @@
 #include "NUIDragDrop.h"
 #include <memory>
 #include <map>
+#include <unordered_set>
 
 namespace AestraUI {
 class NUIPlatformBridge;
@@ -112,6 +113,22 @@ public:
         }
     }
     ClipInstanceID getSelectedClipId() const { return m_selectedClipId; }
+    /**
+     * @brief Non-owning view of the parent's multi-clip selection (#848).
+     *
+     * When set, every clip in the set renders highlighted (marquee/box
+     * select); when null, only the single anchor id does.
+     */
+    void setSelectedClips(const std::unordered_set<ClipInstanceID>* selected) {
+        if (m_selectedClips != selected) {
+            m_selectedClips = selected;
+            setDirty(true);
+        }
+    }
+    /** @brief True when the clip should render as selected (multi-set or anchor). */
+    bool isClipHighlighted(const ClipInstanceID& clipId) const {
+        return (m_selectedClips && m_selectedClips->count(clipId) != 0) || clipId == m_selectedClipId;
+    }
     /** @brief Supply the parent-computed Playlist solo aggregate for this render pass. */
     void setAnyPlaylistLaneSoloed(bool anySoloed) { m_anyPlaylistLaneSoloed = anySoloed; }
     
@@ -176,6 +193,7 @@ private:
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     bool m_selected = false; // Track selection state
     ClipInstanceID m_selectedClipId; // Persistent clip selection supplied by TrackManagerUI
+    const std::unordered_set<ClipInstanceID>* m_selectedClips{nullptr}; // Multi-select view (#848)
     ClipInstanceID m_hoveredClipId; // Clip under the pointer (hamburger affordance)
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
     bool m_isNestedLane = false; // Owned non-primary lane row (FD-14 §10 nesting)

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -112,6 +112,10 @@ public:
         }
     }
     ClipInstanceID getSelectedClipId() const { return m_selectedClipId; }
+    /** @brief Shift+click additive pick (#848): fired instead of the replace callback. */
+    void setOnClipSelectionAdd(std::function<void(TrackUIComponent*, ClipInstanceID)> callback) {
+        m_onClipSelectionAddCallback = std::move(callback);
+    }
     /**
      * @brief Non-owning view of the parent's multi-clip selection (#848).
      *
@@ -211,6 +215,7 @@ private:
     std::function<bool()> m_isSplitToolActiveCallback;
     std::function<void(TrackUIComponent*, double)> m_onSplitRequestedCallback;
     std::function<void(TrackUIComponent*, ClipInstanceID)> m_onClipSelectedCallback;
+    std::function<void(TrackUIComponent*, ClipInstanceID)> m_onClipSelectionAddCallback;
     std::function<void(PatternID)> m_onPatternClipOpenRequested;
     std::function<void(ClipInstanceID)> m_onAudioClipOpenRequested;
     std::function<void(PatternID)> m_onPatternClipDragStarted;

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -16,7 +16,6 @@
 #include "NUIDragDrop.h"
 #include <memory>
 #include <map>
-#include <unordered_set>
 
 namespace AestraUI {
 class NUIPlatformBridge;
@@ -116,10 +115,10 @@ public:
     /**
      * @brief Non-owning view of the parent's multi-clip selection (#848).
      *
-     * When set, every clip in the set renders highlighted (marquee/box
+     * When set, every clip in the selection renders highlighted (marquee/box
      * select); when null, only the single anchor id does.
      */
-    void setSelectedClips(const std::unordered_set<ClipInstanceID>* selected) {
+    void setSelectedClips(const TimelineClipSelection* selected) {
         if (m_selectedClips != selected) {
             m_selectedClips = selected;
             setDirty(true);
@@ -127,7 +126,7 @@ public:
     }
     /** @brief True when the clip should render as selected (multi-set or anchor). */
     bool isClipHighlighted(const ClipInstanceID& clipId) const {
-        return (m_selectedClips && m_selectedClips->count(clipId) != 0) || clipId == m_selectedClipId;
+        return (m_selectedClips && m_selectedClips->contains(clipId)) || clipId == m_selectedClipId;
     }
     /** @brief Supply the parent-computed Playlist solo aggregate for this render pass. */
     void setAnyPlaylistLaneSoloed(bool anySoloed) { m_anyPlaylistLaneSoloed = anySoloed; }
@@ -193,7 +192,7 @@ private:
     TrackManager* m_trackManager; // For coordinating solo exclusivity
     bool m_selected = false; // Track selection state
     ClipInstanceID m_selectedClipId; // Persistent clip selection supplied by TrackManagerUI
-    const std::unordered_set<ClipInstanceID>* m_selectedClips{nullptr}; // Multi-select view (#848)
+    const TimelineClipSelection* m_selectedClips{nullptr}; // Multi-select view (#848)
     ClipInstanceID m_hoveredClipId; // Clip under the pointer (hamburger affordance)
     bool m_isPrimaryForLane = true; // Primary draws control area, secondary only draws clip
     bool m_isNestedLane = false; // Owned non-primary lane row (FD-14 §10 nesting)


### PR DESCRIPTION
## Summary

**The future is now**: dragging a selection box on the Track Manager now actually selects the clips inside it — the "(future)" note in the code is retired.

- **`TimelineClipSelection`** (beside `TimelineTrackSelection`, same intent pattern): Replace / Add(Shift) / Toggle(Ctrl) membership set with an anchor clip for legacy single-clip consumers.
- **Marquee finalize**: intersects the band against every visible clip's cached bounds (`getAllClipBounds`) and populates the set; falls back to track-row selection only when no clip was boxed. Modifier keys work during the drag.
- **Lane cohesion**: lanes owning selected clips highlight via `m_trackSelection` (plain drag replaces owners, modifiers add/toggle).
- **Highlighting**: `TrackUIComponent::isClipHighlighted()` — rows receive a non-owning view of the parent's set; all six render sites now ask it instead of comparing one id.
- **Bonus (#847 residue)**: removed a surviving per-move `invalidateCache()` in the marquee drag path — multi-select still rebuilt the whole timeline FBO every move even after the pointer-warp fix.

## Why

#848 + your session feedback: Ctrl+A selected tracks, box select selected nothing. Clips are the thing producers actually box-select.

## Testing performed

- Build clean; Timeline/PianoRoll/Cursor slice 9/9 green.
- Full interaction matrix needs your hands: plain box = replace; Shift = additive; Ctrl = toggle; boxed lanes highlight; existing single-click/delete/Make Unique unchanged.

## Producer note

Drag a box around any group of patterns or audio clips on the timeline and they're all selected — delete, duplicate and friends act on the whole bunch.

## Docs updated?

No.

## Risk/rollback notes

- UI-layer state only; no serialization/DSP/RT surface.
- Legacy single-clip consumers keep working through the anchor (`m_selectedClipId` still maintained).
- Copy/paste stays anchor-based by design (multi-clip clipboard is separate scope); auto-copy-on-select side effect gated to anchor path.
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added `TimelineClipSelection` for replace, additive, and toggle selection.
- Marquee selection now selects intersecting clips and supports Shift and Ctrl/Super modifiers.
- Added Ctrl+A and Esc selection commands.
- Highlighted selected clips and lanes across timeline renderers.
- Updated cut, delete, and duplication to operate on the full selection as one undoable block.
- Preserved existing single-clip, Make Unique, copy, and paste behavior.
- Removed per-move cache invalidation from marquee dragging.
- Verified a clean build and passing Timeline, PianoRoll, and Cursor tests. Full interaction-matrix testing remains manual.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->