### PR TITLE
perf(recording): decimated peaks for the live capture waveform

### DIFF
--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -786,16 +786,29 @@ public:
              offset += stride) {
             const size_t span = std::min(stride, size - offset);
             // Seed from the first sample: zero-init would report a false bound
-            // for positive-only or negative-only buckets.
-            const float first =
-                capture->samples[(head + offset) % capture->capacity].load(std::memory_order_relaxed);
-            float lo = first;
-            float hi = first;
-            for (size_t k = 1; k < span; ++k) {
+            // for positive-only or negative-only buckets. Non-finite input
+            // samples (driver glitches) are skipped rather than poisoning the
+            // pair — they are a render/capture concern, not signal.
+            bool seeded = false;
+            float lo = 0.0f;
+            float hi = 0.0f;
+            for (size_t k = 0; k < span; ++k) {
                 const float v =
                     capture->samples[(head + offset + k) % capture->capacity].load(std::memory_order_relaxed);
+                if (!std::isfinite(v)) {
+                    continue;
+                }
+                if (!seeded) {
+                    lo = v;
+                    hi = v;
+                    seeded = true;
+                    continue;
+                }
                 lo = std::min(lo, v);
                 hi = std::max(hi, v);
+            }
+            if (!seeded) {
+                continue; // all-non-finite bucket contributes no pair
             }
             peaksOut.push_back(lo);
             peaksOut.push_back(hi);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -808,7 +808,14 @@ public:
                 hi = std::max(hi, v);
             }
             if (!seeded) {
-                continue; // all-non-finite bucket contributes no pair
+                // All-non-finite span: emit a NaN pair as an explicit skipped
+                // slot. Dropping the pair entirely would shift every later
+                // bucket's screen position left (#854 round 2) — the renderer
+                // ignores non-finite pairs, so timing stays correct.
+                constexpr float nanPair = std::numeric_limits<float>::quiet_NaN();
+                peaksOut.push_back(nanPair);
+                peaksOut.push_back(nanPair);
+                continue;
             }
             peaksOut.push_back(lo);
             peaksOut.push_back(hi);

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -746,6 +746,60 @@ public:
     }
 
     /**
+     * @brief Decimated min/max peaks of the live capture ring (#846, #849).
+     *
+     * Bounded alternative to getRecordingDataSnapshot for per-frame drawing:
+     * walks the ring once and emits at most @p maxPoints min/max pairs instead
+     * of copying every sample (the full copy moved ~3 MB per track per frame
+     * at default recording limits — a measurable render-heat contributor).
+     * @p ringSamplesOut receives the logical ring length so callers can map
+     * bucket index → time.
+     */
+    bool getRecordingDataPeaks(uint64_t trackId, uint32_t maxPoints, std::vector<float>& peaksOut,
+                               double& startBeat, size_t& ringSamplesOut) {
+        if (maxPoints == 0) {
+            return false;
+        }
+        std::lock_guard<std::mutex> lock(m_recordingMutex);
+        auto it = m_recordingCaptures.find(trackId);
+        if (it == m_recordingCaptures.end() || !it->second) {
+            return false;
+        }
+        RecordingCapture* capture = it->second.get();
+        const size_t size = capture->size.load(std::memory_order_acquire);
+        if (size == 0) {
+            return false;
+        }
+        startBeat = capture->startBeat.load(std::memory_order_acquire);
+        ringSamplesOut = size;
+
+        peaksOut.clear();
+        peaksOut.reserve(static_cast<size_t>(maxPoints) * 2);
+        const size_t head = capture->headIndex.load(std::memory_order_relaxed);
+        // Ceiling division: every sample lands in a bucket so the ring tail
+        // can never be dropped by rounding.
+        const size_t stride = (size + maxPoints - 1) / maxPoints;
+        if (stride == 0) {
+            return false;
+        }
+        for (size_t offset = 0; offset < size && peaksOut.size() < static_cast<size_t>(maxPoints) * 2;
+             offset += stride) {
+            const size_t span = std::min(stride, size - offset);
+            float lo = 0.0f;
+            float hi = 0.0f;
+            for (size_t k = 0; k < span; ++k) {
+                const float v =
+                    capture->samples[(head + offset + k) % capture->capacity].load(std::memory_order_relaxed);
+                lo = std::min(lo, v);
+                hi = std::max(hi, v);
+            }
+            peaksOut.push_back(lo);
+            peaksOut.push_back(hi);
+        }
+        return !peaksOut.empty();
+    }
+
+    /**
      * @brief Set meter snapshots buffer
      * @param snapshots Shared meter buffer updated by the audio engine.
      */

--- a/AestraAudio/include/Models/TrackManager.h
+++ b/AestraAudio/include/Models/TrackManager.h
@@ -785,9 +785,13 @@ public:
         for (size_t offset = 0; offset < size && peaksOut.size() < static_cast<size_t>(maxPoints) * 2;
              offset += stride) {
             const size_t span = std::min(stride, size - offset);
-            float lo = 0.0f;
-            float hi = 0.0f;
-            for (size_t k = 0; k < span; ++k) {
+            // Seed from the first sample: zero-init would report a false bound
+            // for positive-only or negative-only buckets.
+            const float first =
+                capture->samples[(head + offset) % capture->capacity].load(std::memory_order_relaxed);
+            float lo = first;
+            float hi = first;
+            for (size_t k = 1; k < span; ++k) {
                 const float v =
                     capture->samples[(head + offset + k) % capture->capacity].load(std::memory_order_relaxed);
                 lo = std::min(lo, v);

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2943,33 +2943,31 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
         if (spanEndX <= viewLeft) continue;
         if (spanStartX >= viewRight) break;
 
-        // Signed envelope (#854 round 2): a bucket pair is [min, max] around
-        // the center line, so each side renders only the portion that actually
-        // extends beyond center. The old abs() math pushed a positive-only
-        // bucket's envelope BELOW center and mirrored it wrongly.
+        // Signed envelope (#854 round 2): render the bucket's TRUE interval
+        // [min, max] — clamped to ±1 — without mirroring to center.
+        // Non-finite pairs are skipped slots from the reader: they keep their
+        // timing slot but draw nothing (#845/#846).
         const float loRaw = peaks[b * 2];
         const float hiRaw = peaks[b * 2 + 1];
-        if (!std::isfinite(loRaw) || !std::isfinite(hiRaw)) continue;
+        if (!std::isfinite(loRaw) || !std::isfinite(hiRaw)) {
+            continue;
+        }
 
-        const float hiC = std::clamp(std::max(loRaw, hiRaw), -1.0f, 1.0f); // upper extent
-        const float loC = std::clamp(std::min(loRaw, hiRaw), -1.0f, 1.0f); // lower extent
+        const float hiC = std::clamp(std::max(loRaw, hiRaw), -1.0f, 1.0f);
+        const float loC = std::clamp(std::min(loRaw, hiRaw), -1.0f, 1.0f);
 
         const float xL = static_cast<float>(std::max(spanStartX, viewLeft));
         const float xR = static_cast<float>(std::min(spanEndX, viewRight));
         const float width = std::max(1.0f, xR - xL);
 
-        if (hiC > 0.0f) {
-            const float height = hiC * halfHeight;
-            renderer.fillRect(AestraUI::NUIRect(xL, centerY - height, width, height), topFill);
-            renderer.drawLine(AestraUI::NUIPoint(xL, centerY - height),
-                              AestraUI::NUIPoint(xR, centerY - height), 1.0f, peakLine);
-        }
-        if (loC < 0.0f) {
-            const float depth = -loC * halfHeight;
-            renderer.fillRect(AestraUI::NUIRect(xL, centerY, width, depth), bottomFill);
-            renderer.drawLine(AestraUI::NUIPoint(xL, centerY + depth),
-                              AestraUI::NUIPoint(xR, centerY + depth), 1.0f, peakLine);
-        }
+        // True interval band: top edge at the max extent, bottom edge at the
+        // min extent. Extends to centerY only when the interval crosses zero.
+        const float yHi = centerY - hiC * halfHeight;
+        const float yLo = centerY - loC * halfHeight;
+
+        renderer.fillRect(AestraUI::NUIRect(xL, yHi, width, yLo - yHi), topFill);
+        renderer.drawLine(AestraUI::NUIPoint(xL, yHi), AestraUI::NUIPoint(xR, yHi), 1.0f, peakLine);
+        renderer.drawLine(AestraUI::NUIPoint(xL, yLo), AestraUI::NUIPoint(xR, yLo), 1.0f, peakLine);
 
         lastCenterX = xR;
         drewAny = true;

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2878,11 +2878,15 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     auto* track = lane ? m_trackManager->getTrack(lane->trackId) : nullptr;
     if (!track || !track->armed) return;
 
-    std::vector<float> recordingData;
+    // Bounded decimated read (#846/#849): min/max pairs instead of copying
+    // the whole capture ring every frame (~3 MB/track at default limits).
+    std::vector<float> peaks; // [lo, hi] per bucket
     double startBeat = 0.0;
-    bool gotSnapshot = m_trackManager->getRecordingDataSnapshot(track->trackId, recordingData, startBeat);
-    
-    if (!gotSnapshot || recordingData.empty()) return;
+    size_t ringSamples = 0;
+    const uint32_t maxPoints = static_cast<uint32_t>(bounds.width) + 2;
+    bool gotSnapshot = m_trackManager->getRecordingDataPeaks(track->trackId, maxPoints, peaks, startBeat, ringSamples);
+
+    if (!gotSnapshot || peaks.empty()) return;
 
     // Layout parameters
     const float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
@@ -2902,8 +2906,7 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     // Calculate start X in screen coordinates
     float startX = gridStartX + (static_cast<float>(startBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
     
-    size_t totalSamples = recordingData.size();
-    float endX = startX + (totalSamples / static_cast<float>(samplesPerPixel));
+    float endX = startX + (ringSamples / static_cast<float>(samplesPerPixel));
     
     if (endX < gridStartX || startX > bounds.right()) return;
 
@@ -2926,18 +2929,11 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     bottomPoints.reserve(numPoints);
     
     for (int p = startPixelInt; p < endPixelInt; ++p) {
-        size_t sampleIndex = static_cast<size_t>(p * samplesPerPixel);
-        size_t nextSampleIndex = static_cast<size_t>((p + 1) * samplesPerPixel);
-        
-        if (sampleIndex >= totalSamples) break;
-        if (nextSampleIndex > totalSamples) nextSampleIndex = totalSamples;
-        
-        float peak = 0.0f;
-        for (size_t i = sampleIndex; i < nextSampleIndex; ++i) {
-            float val = std::abs(recordingData[i]);
-            if (val > peak) peak = val;
-        }
-        
+        const size_t loIdx = static_cast<size_t>(std::max(0, p)) * 2;
+        if (loIdx + 1 >= peaks.size()) break;
+
+        float peak = std::max(std::fabs(peaks[loIdx]), std::fabs(peaks[loIdx + 1]));
+
         float env = std::pow(std::min(1.0f, peak), 0.75f);
         
         float screenX = startX + p;

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2910,75 +2910,67 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     
     if (endX < gridStartX || startX > bounds.right()) return;
 
-    // Drawing Loop (Decimated)
-    AestraUI::NUIColor waveColor = AestraUI::NUIThemeManager::getInstance().getColor("error"); // Red for recording
-    
-    std::vector<AestraUI::NUIPoint> topPoints;
-    std::vector<AestraUI::NUIPoint> bottomPoints;
-    
-    float visibleStartPixel = std::max(gridStartX, startX) - startX;
-    float visibleEndPixel = std::min(bounds.right(), endX) - startX;
-    
-    if (visibleEndPixel <= visibleStartPixel) return;
-    
-    int startPixelInt = static_cast<int>(visibleStartPixel);
-    int endPixelInt = static_cast<int>(visibleEndPixel);
+    // Drawing Loop — one filled envelope per decimated bucket (#846/#849).
+    const AestraUI::NUIColor waveColor = AestraUI::NUIThemeManager::getInstance().getColor("error"); // Red for recording
 
-    // Iterate BUCKETS (not pixels): each pair spans
-    // samplesPerBucket/samplesPerPixel screen pixels, so a recording shorter
-    // or longer than the viewport still maps to the correct region (#854).
     const size_t bucketCount = peaks.size() / 2;
-    const double samplesPerBucket =
-        static_cast<double>(ringSamples) / static_cast<double>(std::max<size_t>(1, bucketCount));
-    const double pixelsPerBucket = samplesPerBucket / samplesPerPixel;
+    // Same stride as getRecordingDataPeaks (ceiling), so spans line up with
+    // the extracted ranges exactly.
+    const size_t bucketStride = (ringSamples + maxPoints - 1) / maxPoints;
+    if (bucketStride == 0 || bucketCount == 0) return;
 
-    topPoints.reserve(bucketCount + 1);
-    bottomPoints.reserve(bucketCount + 1);
+    const AestraUI::NUIColor topFill = waveColor.withAlpha(0.35f);
+    const AestraUI::NUIColor bottomFill = waveColor.withAlpha(0.14f);
+    const AestraUI::NUIColor peakLine = waveColor.withAlpha(0.55f);
+    const AestraUI::NUIColor centerLine = waveColor.withAlpha(0.15f);
+
+    bool drewAny = false;
+    float lastCenterX = 0.0f;
 
     for (size_t b = 0; b < bucketCount; ++b) {
-        const double bucketStartX = startX + static_cast<double>(b) * pixelsPerBucket;
-        const double bucketEndX = bucketStartX + pixelsPerBucket;
-        if (bucketEndX < gridStartX || bucketStartX > bounds.right()) continue;
+        const size_t spanStart = b * bucketStride;
+        const size_t spanEnd = std::min(spanStart + bucketStride, ringSamples);
+        if (spanStart >= ringSamples) break;
+
+        const double spanStartX =
+            startX + static_cast<double>(spanStart) / samplesPerPixel;
+        const double spanEndX =
+            startX + static_cast<double>(spanEnd) / samplesPerPixel;
+
+        // Viewport culling in time space.
+        const double viewLeft = static_cast<double>(gridStartX);
+        const double viewRight = static_cast<double>(bounds.right());
+        if (spanEndX <= viewLeft) continue;
+        if (spanStartX >= viewRight) break;
 
         const float lo = peaks[b * 2];
         const float hi = peaks[b * 2 + 1];
         float peak = std::max(std::fabs(lo), std::fabs(hi));
-
         float env = std::pow(std::min(1.0f, peak), 0.75f);
 
-        const float screenX = static_cast<float>(
-            std::clamp(bucketStartX, static_cast<double>(gridStartX), static_cast<double>(bounds.right())));
-        float topY = centerY - env * halfHeight;
-        float bottomY = centerY + env * halfHeight;
-        
-        if (bottomY - topY < 1.0f) {
-            topY = centerY - 0.5f;
-            bottomY = centerY + 0.5f;
-        }
-        
-        topPoints.push_back(AestraUI::NUIPoint(screenX, topY));
-        bottomPoints.push_back(AestraUI::NUIPoint(screenX, bottomY));
+        const float xL = static_cast<float>(std::max(spanStartX, viewLeft));
+        const float xR = static_cast<float>(std::min(spanEndX, viewRight));
+        const float width = std::max(1.0f, xR - xL);
+
+        const float loY = centerY - std::fabs(lo) * halfHeight;
+        const float hiY = centerY - std::fabs(hi) * halfHeight;
+        const float topY = std::min(loY, hiY) - 0.5f;
+        const float bottomY = centerY + std::fabs(hi) * halfHeight + 0.5f;
+
+        // Filled envelope across the whole bucket span: continuous waveform,
+        // no isolated bars or gaps when a bucket covers several pixels.
+        renderer.fillRect(AestraUI::NUIRect(xL, topY, width, centerY - topY), topFill);
+        renderer.fillRect(AestraUI::NUIRect(xL, centerY, width, bottomY - centerY), bottomFill);
+        renderer.drawLine(AestraUI::NUIPoint(xL, topY), AestraUI::NUIPoint(xR, topY), 1.0f, peakLine);
+
+        lastCenterX = xR;
+        drewAny = true;
     }
-    
-    if (!topPoints.empty()) {
-        const AestraUI::NUIColor topFill = waveColor.withAlpha(0.35f);
-        const AestraUI::NUIColor bottomFill = waveColor.withAlpha(0.14f);
-        const AestraUI::NUIColor peakLine = waveColor.withAlpha(0.55f);
-        const AestraUI::NUIColor centerLine = waveColor.withAlpha(0.15f);
 
-        for (size_t i = 0; i < topPoints.size(); ++i) {
-            const float x = topPoints[i].x;
-            const float topY = topPoints[i].y;
-            const float bottomY = bottomPoints[i].y;
-
-            renderer.drawLine(AestraUI::NUIPoint(x, centerY), AestraUI::NUIPoint(x, topY), 1.0f, topFill);
-            renderer.drawLine(AestraUI::NUIPoint(x, centerY), AestraUI::NUIPoint(x, bottomY), 1.0f, bottomFill);
-            renderer.drawLine(AestraUI::NUIPoint(x, topY), AestraUI::NUIPoint(x, bottomY), 1.0f, peakLine);
-        }
-
+    if (drewAny) {
         renderer.drawLine(
-            AestraUI::NUIPoint(topPoints.front().x, centerY),
-            AestraUI::NUIPoint(topPoints.back().x, centerY),
+            AestraUI::NUIPoint(static_cast<float>(std::max(gridStartX, startX)), centerY),
+            AestraUI::NUIPoint(lastCenterX, centerY),
             1.0f,
             centerLine
         );

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2923,20 +2923,31 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
     
     int startPixelInt = static_cast<int>(visibleStartPixel);
     int endPixelInt = static_cast<int>(visibleEndPixel);
-    
-    size_t numPoints = endPixelInt - startPixelInt;
-    topPoints.reserve(numPoints);
-    bottomPoints.reserve(numPoints);
-    
-    for (int p = startPixelInt; p < endPixelInt; ++p) {
-        const size_t loIdx = static_cast<size_t>(std::max(0, p)) * 2;
-        if (loIdx + 1 >= peaks.size()) break;
 
-        float peak = std::max(std::fabs(peaks[loIdx]), std::fabs(peaks[loIdx + 1]));
+    // Iterate BUCKETS (not pixels): each pair spans
+    // samplesPerBucket/samplesPerPixel screen pixels, so a recording shorter
+    // or longer than the viewport still maps to the correct region (#854).
+    const size_t bucketCount = peaks.size() / 2;
+    const double samplesPerBucket =
+        static_cast<double>(ringSamples) / static_cast<double>(std::max<size_t>(1, bucketCount));
+    const double pixelsPerBucket = samplesPerBucket / samplesPerPixel;
+
+    topPoints.reserve(bucketCount + 1);
+    bottomPoints.reserve(bucketCount + 1);
+
+    for (size_t b = 0; b < bucketCount; ++b) {
+        const double bucketStartX = startX + static_cast<double>(b) * pixelsPerBucket;
+        const double bucketEndX = bucketStartX + pixelsPerBucket;
+        if (bucketEndX < gridStartX || bucketStartX > bounds.right()) continue;
+
+        const float lo = peaks[b * 2];
+        const float hi = peaks[b * 2 + 1];
+        float peak = std::max(std::fabs(lo), std::fabs(hi));
 
         float env = std::pow(std::min(1.0f, peak), 0.75f);
-        
-        float screenX = startX + p;
+
+        const float screenX = static_cast<float>(
+            std::clamp(bucketStartX, static_cast<double>(gridStartX), static_cast<double>(bounds.right())));
         float topY = centerY - env * halfHeight;
         float bottomY = centerY + env * halfHeight;
         

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -2943,25 +2943,33 @@ void TrackUIComponent::drawLiveWaveform(AestraUI::NUIRenderer& renderer, const A
         if (spanEndX <= viewLeft) continue;
         if (spanStartX >= viewRight) break;
 
-        const float lo = peaks[b * 2];
-        const float hi = peaks[b * 2 + 1];
-        float peak = std::max(std::fabs(lo), std::fabs(hi));
-        float env = std::pow(std::min(1.0f, peak), 0.75f);
+        // Signed envelope (#854 round 2): a bucket pair is [min, max] around
+        // the center line, so each side renders only the portion that actually
+        // extends beyond center. The old abs() math pushed a positive-only
+        // bucket's envelope BELOW center and mirrored it wrongly.
+        const float loRaw = peaks[b * 2];
+        const float hiRaw = peaks[b * 2 + 1];
+        if (!std::isfinite(loRaw) || !std::isfinite(hiRaw)) continue;
+
+        const float hiC = std::clamp(std::max(loRaw, hiRaw), -1.0f, 1.0f); // upper extent
+        const float loC = std::clamp(std::min(loRaw, hiRaw), -1.0f, 1.0f); // lower extent
 
         const float xL = static_cast<float>(std::max(spanStartX, viewLeft));
         const float xR = static_cast<float>(std::min(spanEndX, viewRight));
         const float width = std::max(1.0f, xR - xL);
 
-        const float loY = centerY - std::fabs(lo) * halfHeight;
-        const float hiY = centerY - std::fabs(hi) * halfHeight;
-        const float topY = std::min(loY, hiY) - 0.5f;
-        const float bottomY = centerY + std::fabs(hi) * halfHeight + 0.5f;
-
-        // Filled envelope across the whole bucket span: continuous waveform,
-        // no isolated bars or gaps when a bucket covers several pixels.
-        renderer.fillRect(AestraUI::NUIRect(xL, topY, width, centerY - topY), topFill);
-        renderer.fillRect(AestraUI::NUIRect(xL, centerY, width, bottomY - centerY), bottomFill);
-        renderer.drawLine(AestraUI::NUIPoint(xL, topY), AestraUI::NUIPoint(xR, topY), 1.0f, peakLine);
+        if (hiC > 0.0f) {
+            const float height = hiC * halfHeight;
+            renderer.fillRect(AestraUI::NUIRect(xL, centerY - height, width, height), topFill);
+            renderer.drawLine(AestraUI::NUIPoint(xL, centerY - height),
+                              AestraUI::NUIPoint(xR, centerY - height), 1.0f, peakLine);
+        }
+        if (loC < 0.0f) {
+            const float depth = -loC * halfHeight;
+            renderer.fillRect(AestraUI::NUIRect(xL, centerY, width, depth), bottomFill);
+            renderer.drawLine(AestraUI::NUIPoint(xL, centerY + depth),
+                              AestraUI::NUIPoint(xR, centerY + depth), 1.0f, peakLine);
+        }
 
         lastCenterX = xR;
         drewAny = true;


### PR DESCRIPTION
## Summary

Fixes the render-cost half of **#846** and feeds **#849**: `drawLiveWaveform` copied the ENTIRE capture ring every frame while recording — at default limits that's ~3 MB per armed track per frame (15s × 48kHz), a measurable render-heat and frame-time contributor during exactly the sessions Dylan reported running hot.

Replaces it with `getRecordingDataPeaks(trackId, maxPoints, …)`: one bounded walk of the ring emitting at most `width+2` min/max pairs, ceiling-division stride so no tail samples drop. The drawing loop consumes pairs directly instead of re-decimating per pixel from a full copy.

Also keeps the drawn waveform identical to what gets committed: both read the same capture ring under the same mutex protocol.

## Why

#849: audio engine exonerated by #842's harness; renderer suspected. This was the single largest per-frame cost found in the record path. (The marquee per-move FBO rebuild — the timeline-side equivalent — already fell in PR #850/#853.)

## Testing performed

- Build clean; CountInRecordingTest 6/6 (capture contract untouched); Timeline/PianoRoll/Cursor slice + count-in = 11/11 green.
- Full default suite 270/270 on this base earlier in the cycle; visual smoothness of the live wave needs your eyes as usual.

## Producer note

The red live-input waveform while recording now costs almost nothing to draw — long recording sessions stop cooking the render side.

## Docs updated?

No.

## Risk/rollback notes

- Draw-only change; capture/commit path untouched (`drawn == committed` guarantee preserved by reading the same ring).
- Single-commit revert is clean rollback.

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 89a00af
Kind: corrective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- `getRecordingDataPeaks` now returns bounded min/max buckets and preserves timing for non-finite samples.
- `drawLiveWaveform` renders signed, finite waveform envelopes with matching ceiling-stride mapping and viewport culling.
- Deferred recording now follows timeline and pattern loop regions during count-in and scrubbing.
- Bounded decimation reduces per-frame render work while keeping waveform data consistent with capture data.
- Capture and commit paths remain unchanged.
- Clean build and 11/11 targeted tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->