### PR TITLE
feat(ui): timeline plane band — cropped minimap, snap-driven grid tiers

### DIFF
--- a/Source/Components/TrackManagerUI.cpp
+++ b/Source/Components/TrackManagerUI.cpp
@@ -82,7 +82,9 @@ TrackManagerUI::TrackManagerUI(std::shared_ptr<TrackManager> trackManager)
     m_scrollbar->setOnScroll([this](double position) { onScroll(position); });
     addChild(m_scrollbar);
 
-    // Timeline minimap (replaces top horizontal scrollbar).
+    // Timeline minimap (overview band above the ruler). The surface starts at
+    // the track-controls boundary so it no longer spans the toolbar corner;
+    // the bar's internal 5px offset keeps its content on the plane/grid edge.
     m_timelineMinimap = std::make_shared<AestraUI::TimelineMinimapBar>();
     m_timelineMinimap->onRequestCenterView = [this](double centerBeat) { centerTimelineViewAtBeat(centerBeat); };
     m_timelineMinimap->onRequestSetViewStart = [this](double viewStartBeat, bool isFinal) {
@@ -100,8 +102,8 @@ TrackManagerUI::TrackManagerUI(std::shared_ptr<TrackManager> trackManager)
         setDirty(true);
     };
     m_timelineMinimap->setShowModeToggles(false);
-    m_timelineMinimap->setLeadingInset(
-        AestraUI::NUIThemeManager::getInstance().getLayoutDimensions().trackControlsWidth);
+    // Cropped: bounds start at the corner boundary, so no leading inset is needed.
+    m_timelineMinimap->setLeadingInset(0.0f);
     addChild(m_timelineMinimap);
 
     // Defer track UI creation to first render for instant startup.
@@ -295,6 +297,7 @@ void TrackManagerUI::refreshTracks() {
         trackUI->setBeatsPerBar(m_beatsPerBar);
         trackUI->setTimelineScrollOffset(m_timelineScrollOffset);
         trackUI->setSnapSetting(m_snapSetting); // Sync snap setting for resize
+        trackUI->setSnapEnabled(m_snapEnabled); // Sync master snap toggle for resize
 
         // Pass platform bridge for cursor capture (volume knob)
         trackUI->setPlatformBridge(m_window);
@@ -495,28 +498,27 @@ void TrackManagerUI::layoutTracks() {
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const auto& layout = themeManager.getLayoutDimensions();
 
-    float headerHeight = 40.0f;
     float scrollbarWidth = kTimelineScrollbarWidth;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    float rulerHeight = kTimelineRulerHeight;
 
-    float viewportHeight = std::max(0.0f, bounds.height - headerHeight - horizontalScrollbarHeight - rulerHeight);
+    float viewportHeight = std::max(0.0f, bounds.height - kTimelineTimeBandHeight);
 
     // In v3.1, panels are floating overlays and do not affect workspace viewport directly.
     // If we wanted docking, we'd subtract their space here based on external state pointers.
 
-    // Layout timeline minimap (top, right after header, before ruler)
+    // Layout timeline minimap (top of the time band, above the ruler).
+    // Cropped to the plane column: starts where the track-controls boundary
+    // ends so the surface never spans the toolbar corner.
     if (m_timelineMinimap) {
-        float minimapWidth = std::max(0.0f, bounds.width - scrollbarWidth);
-        float minimapY = headerHeight;
+        const float minimapX = layout.trackControlsWidth;
+        float minimapWidth = std::max(0.0f, bounds.width - scrollbarWidth - minimapX);
         m_timelineMinimap->setBounds(
-            AestraUI::NUIAbsolute(bounds, 0, minimapY, minimapWidth, horizontalScrollbarHeight));
+            AestraUI::NUIAbsolute(bounds, minimapX, 0.0f, minimapWidth, kTimelineMinimapHeight));
         updateTimelineMinimap(0.0);
     }
 
-    // Layout vertical scrollbar (right side, below header, horizontal scrollbar, and ruler)
+    // Layout vertical scrollbar (right side, below the time band)
     if (m_scrollbar) {
-        float scrollbarY = headerHeight + horizontalScrollbarHeight + rulerHeight;
+        float scrollbarY = kTimelineTimeBandHeight;
         float scrollbarX = std::max(0.0f, bounds.width - scrollbarWidth);
         m_scrollbar->setBounds(AestraUI::NUIAbsolute(bounds, scrollbarX, scrollbarY, scrollbarWidth, viewportHeight));
         updateScrollbar();
@@ -524,7 +526,7 @@ void TrackManagerUI::layoutTracks() {
 
     float controlAreaWidth = layout.trackControlsWidth;
     float gridStartX = bounds.x + std::max(0.0f, controlAreaWidth + kTimelineGridInsetX);
-    float trackAreaTop = bounds.y + std::max(0.0f, headerHeight + horizontalScrollbarHeight + rulerHeight);
+    float trackAreaTop = bounds.y + std::max(0.0f, kTimelineTimeBandHeight);
 
     // === V3.0 LANE LAYOUT (Two-Rect Model) ===
     for (size_t i = 0; i < m_trackUIComponents.size(); ++i) {

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -186,7 +186,16 @@ public:
     void deleteLane(PlaylistLaneID laneId);
 
     // Snap-to-Grid control
-    void setSnapEnabled(bool enabled) { m_snapEnabled = enabled; }
+    // Choke point: propagates to every row so trim/resize honors the same
+    // master switch as move/drag.
+    void setSnapEnabled(bool enabled) {
+        if (m_snapEnabled == enabled) return;
+        m_snapEnabled = enabled;
+        for (auto& track : m_trackUIComponents) {
+            if (track) track->setSnapEnabled(enabled);
+        }
+        invalidateCache();
+    }
     bool isSnapEnabled() const { return m_snapEnabled; }
     void setSnapDivision(int division) { m_snapDivision = division; } // 1=bar, 4=beat, 16=16th
     int getSnapDivision() const { return m_snapDivision; }
@@ -322,8 +331,10 @@ private:
     ::AestraUI::NUIPlatformBridge* m_window = nullptr;
 
     // UI Layout
-    int m_trackHeight{46};
-    int m_trackSpacing{3};
+    int m_trackHeight{42};
+    // Contiguous rows (2026-08 plane redesign): the grid plane is continuous,
+    // so rows carry no seam — a quiet separator line marks each boundary.
+    int m_trackSpacing{0};
     float m_scrollOffset{0.0f};
     float m_targetScrollOffset{0.0f};
     std::unordered_set<uint64_t> m_collapsedTrackIds;
@@ -385,6 +396,9 @@ private:
     ::AestraUI::NUIRect m_paintToolBounds;
     ::AestraUI::NUIRect m_followPlayheadBounds; // Toggle button bounds
     ::AestraUI::NUIRect m_toolbarBounds;
+    // Content-sized union of every corner button (add-track through menu) in
+    // the ruler row's left cell — the hit-testable extent of the toolbar.
+    ::AestraUI::NUIRect m_toolbarCornerBounds;
 
     bool m_menuHovered = false;
     bool m_selectToolHovered = false;
@@ -638,10 +652,10 @@ private:
     bool handleLoopMarkerDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handlePlayheadDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handleSplitToolClick(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
-    // Rows render m_trackHeight tall on an m_trackHeight+m_trackSpacing stride,
-    // leaving an m_trackSpacing-px seam between them that lands inside no track's
-    // bounds. Map an otherwise-unhandled left press in that seam back to its row
-    // and select it, so clicks between rows are not silently swallowed.
+    // Rows are contiguous (m_trackSpacing == 0), but the seam handler stays:
+    // sub-pixel row boundaries can still land a press inside no track's exact
+    // bounds. Map an otherwise-unhandled left press in that sliver back to its
+    // row and select it, so clicks between rows are not silently swallowed.
     bool handleTrackSeamSelect(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     void renderMinimapResizeCursor(::AestraUI::NUIRenderer& renderer, const ::AestraUI::NUIPoint& position);
 

--- a/Source/Components/TrackManagerUI.h
+++ b/Source/Components/TrackManagerUI.h
@@ -644,6 +644,9 @@ private:
     bool handleSelectionBoxMouse(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handleTimelineWheel(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos,
                              bool isInRuler, bool isInTrackArea);
+    bool hitLoopHandle(const ::AestraUI::NUIPoint& localPos, float gridStartX, bool& hitStart) const;
+    void updateLoopHandleHover(const ::AestraUI::NUIPoint& localPos, float gridStartX);
+    bool tryBeginLoopHandleDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);
     bool handleRulerPress(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos,
                           bool isInRuler);
     bool handleRulerSelectionDrag(const ::AestraUI::NUIMouseEvent& event, const ::AestraUI::NUIPoint& localPos);

--- a/Source/Components/TrackManagerUIDragDrop.cpp
+++ b/Source/Components/TrackManagerUIDragDrop.cpp
@@ -684,12 +684,8 @@ int TrackManagerUI::getTrackAtPosition(float y) const {
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
 
     // Get ruler height and track area start
-    // MUST match renderTrackManagerDirect layout exactly:
-    // header(38) + horizontalScrollbar(24) + ruler(28)
-    float headerHeight = kTimelineHeaderHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float trackAreaY = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    // MUST match the render layout exactly: minimap(24) + ruler(28)
+    float trackAreaY = bounds.y + kTimelineTimeBandHeight;
 
     // Relative Y position in track area
     float relativeY = y - trackAreaY + m_scrollOffset;
@@ -746,11 +742,8 @@ void TrackManagerUI::renderDropPreview(AestraUI::NUIRenderer& renderer) {
     float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
 
     // Calculate track Y position - MUST match layoutTracks() calculation exactly
-    // layoutTracks uses: headerHeight(38) + horizontalScrollbarHeight(24) + rulerHeight(28)
-    float headerHeight = kTimelineHeaderHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float trackAreaStartY = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    // layoutTracks uses: minimapHeight(24) + rulerHeight(28)
+    float trackAreaStartY = bounds.y + kTimelineTimeBandHeight;
     float trackY = trackAreaStartY + (m_dropTargetTrack * (m_trackHeight + m_trackSpacing)) - m_scrollOffset;
 
     // Calculate X position from time

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -84,6 +84,11 @@ bool TrackManagerUI::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
 
     // Handle toolbar clicks (icons only, not dropdowns - they handled themselves above)
     if (event.pressed && event.button == AestraUI::NUIMouseButton::Left) {
+        // Loop markers outrank toolbar icons (their grab zones can overlap a
+        // button when a handle is scrolled over the corner column).
+        if (tryBeginLoopHandleDrag(event, localPos)) {
+            return true;
+        }
         if (handleToolbarClick(event.position)) {
             return true;
         }
@@ -575,41 +580,14 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
         float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
         // === LOOP MARKER INTERACTION (highest priority) ===
+        // Hover tracking lives in tryBeginLoopHandleDrag so the pre-toolbar
+        // dispatch path and this path share one hit-test/grab contract.
         if (m_hasRulerSelection) {
-            // Calculate marker positions
-            float loopStartX =
-                gridStartX + (static_cast<float>(m_loopStartBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
-            float loopEndX =
-                gridStartX + (static_cast<float>(m_loopEndBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
-
-            const float hitZone = 12.0f; // Hit zone around markers
-            bool nearLoopStart = std::abs(localPos.x - loopStartX) < hitZone;
-            bool nearLoopEnd = std::abs(localPos.x - loopEndX) < hitZone;
-
-            // Update hover states
-            bool wasHoveringStart = m_hoveringLoopStart;
-            bool wasHoveringEnd = m_hoveringLoopEnd;
-            m_hoveringLoopStart = nearLoopStart;
-            m_hoveringLoopEnd = nearLoopEnd;
-
-            if (wasHoveringStart != m_hoveringLoopStart || wasHoveringEnd != m_hoveringLoopEnd) {
-                invalidateCache(); // Hover state changed
-            }
-
-            // Start dragging loop marker
-            if (event.pressed && event.button == AestraUI::NUIMouseButton::Left) {
-                if (nearLoopStart) {
-                    m_isDraggingLoopStart = true;
-                    m_loopDragStartBeat = m_loopStartBeat;
-                    return true;
-                } else if (nearLoopEnd) {
-                    m_isDraggingLoopEnd = true;
-                    m_loopDragStartBeat = m_loopEndBeat;
-                    return true;
-                }
+            updateLoopHandleHover(localPos, gridStartX);
+            if (tryBeginLoopHandleDrag(event, localPos)) {
+                return true;
             }
         }
-
         // Corner dead zone: only marker hover/grab (handled above) is allowed
         // here — a click in the toolbar cell's empty remainder must never seek.
         if (!isInRuler) {
@@ -676,8 +654,71 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
     return false;
 }
 
+// Shared loop-handle hit test. Returns true when localPos sits inside a
+// handle's grab zone; hitStart reports which one. Pure — no state mutation.
+bool TrackManagerUI::hitLoopHandle(const AestraUI::NUIPoint& localPos, float gridStartX, bool& hitStart) const {
+    const float loopStartX =
+        gridStartX + (static_cast<float>(m_loopStartBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
+    const float loopEndX =
+        gridStartX + (static_cast<float>(m_loopEndBeat) * m_pixelsPerBeat) - m_timelineScrollOffset;
+
+    constexpr float hitZone = 12.0f; // Hit zone around markers
+    const bool nearLoopStart = std::abs(localPos.x - loopStartX) < hitZone;
+    const bool nearLoopEnd = std::abs(localPos.x - loopEndX) < hitZone;
+    if (nearLoopStart == nearLoopEnd) {
+        return false; // neither zone, or ambiguous double overlap
+    }
+    hitStart = nearLoopStart;
+    return true;
+}
+
+void TrackManagerUI::updateLoopHandleHover(const AestraUI::NUIPoint& localPos, float gridStartX) {
+    bool hitStart = false;
+    const bool hit = hitLoopHandle(localPos, gridStartX, hitStart);
+    const bool wasHoveringStart = m_hoveringLoopStart;
+    const bool wasHoveringEnd = m_hoveringLoopEnd;
+    m_hoveringLoopStart = hit && hitStart;
+    m_hoveringLoopEnd = hit && !hitStart;
+    if (wasHoveringStart != m_hoveringLoopStart || wasHoveringEnd != m_hoveringLoopEnd) {
+        invalidateCache(); // Hover state changed
+    }
+}
+
+bool TrackManagerUI::tryBeginLoopHandleDrag(const AestraUI::NUIMouseEvent& event,
+                                            const AestraUI::NUIPoint& localPos) {
+    // Loop markers outrank toolbar icons: a handle scrolled over the corner
+    // must stay draggable even where its grab zone overlaps a button.
+    if (!event.pressed || event.button != AestraUI::NUIMouseButton::Left) {
+        return false;
+    }
+    if (!m_playlistVisible || !m_hasRulerSelection) {
+        return false;
+    }
+    if (localPos.y < kTimelineMinimapHeight || localPos.y >= kTimelineTimeBandHeight) {
+        return false;
+    }
+
+    auto& themeManager = AestraUI::NUIThemeManager::getInstance();
+    float controlAreaWidth = themeManager.getLayoutDimensions().trackControlsWidth;
+    float gridStartX = controlAreaWidth + kTimelineGridInsetX;
+
+    updateLoopHandleHover(localPos, gridStartX);
+
+    bool hitStart = false;
+    if (!hitLoopHandle(localPos, gridStartX, hitStart)) {
+        return false;
+    }
+    if (hitStart) {
+        m_isDraggingLoopStart = true;
+        m_loopDragStartBeat = m_loopStartBeat;
+    } else {
+        m_isDraggingLoopEnd = true;
+        m_loopDragStartBeat = m_loopEndBeat;
+    }
+    return true;
+}
+
 bool TrackManagerUI::handleRulerSelectionDrag(const AestraUI::NUIMouseEvent& event, const AestraUI::NUIPoint& localPos) {
-    // Handle ruler selection dragging
     if (m_isDraggingRulerSelection) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();

--- a/Source/Components/TrackManagerUIEvents.cpp
+++ b/Source/Components/TrackManagerUIEvents.cpp
@@ -142,17 +142,23 @@ bool TrackManagerUI::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
         return true;
     }
 
-    // Layout constants
-    float headerHeight = kTimelineHeaderHeight;
+    // Layout constants — the time band is minimap row + ruler row.
     float rulerHeight = kTimelineRulerHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    AestraUI::NUIRect rulerRect(0, headerHeight + horizontalScrollbarHeight, bounds.width, rulerHeight);
+    float minimapHeight = kTimelineMinimapHeight;
+    AestraUI::NUIRect rulerRect(0, minimapHeight, bounds.width, rulerHeight);
 
     // Track area (below ruler)
-    float trackAreaTop = headerHeight + horizontalScrollbarHeight + rulerHeight;
+    float trackAreaTop = kTimelineTimeBandHeight;
     AestraUI::NUIRect trackArea(0, trackAreaTop, bounds.width, bounds.height - trackAreaTop);
 
-    bool isInRuler = rulerRect.contains(localPos);
+    // The toolbar dock occupies the ruler row's left corner; presses there are
+    // button hits, never ruler scrub/loop gestures. The corner cell's empty
+    // remainder is dead space too: ruler gestures start at the plane edge, so
+    // a click between the last button and the grid cannot scrub the playhead.
+    const float rulerContentStartX = timelineGridStartX(
+        0.0f, AestraUI::NUIThemeManager::getInstance().getLayoutDimensions().trackControlsWidth);
+    const bool isInRuler = rulerRect.contains(localPos) && localPos.x >= rulerContentStartX &&
+                           !m_toolbarCornerBounds.contains(event.position);
     bool isInTrackArea = trackArea.contains(localPos);
 
     if (handleTimelineWheel(event, localPos, isInRuler, isInTrackArea)) {
@@ -205,12 +211,9 @@ bool TrackManagerUI::handleTrackSeamSelect(const AestraUI::NUIMouseEvent& event,
         return false;
     }
 
-    const float headerHeight = kTimelineHeaderHeight;
-    const float rulerHeight = kTimelineRulerHeight;
-    const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    const float trackAreaTop = headerHeight + horizontalScrollbarHeight + rulerHeight;
+    const float trackAreaTop = kTimelineTimeBandHeight;
     if (localPos.y < trackAreaTop) {
-        return false; // header / ruler / horizontal scrollbar
+        return false; // ruler / minimap band
     }
 
     const float stride = static_cast<float>(m_trackHeight + m_trackSpacing);
@@ -378,10 +381,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
                                    m_currentTool == PlaylistTool::MultiSelect;
 
     if (startSelectionBox && !m_isDrawingSelectionBox) {
-        float headerHeight = kTimelineHeaderHeight;
-        float rulerHeight = kTimelineRulerHeight;
-        float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        float trackAreaTop = headerHeight + horizontalScrollbarHeight + rulerHeight;
+        float trackAreaTop = kTimelineTimeBandHeight;
 
         // Only start selection box in track area
         if (localPos.y > trackAreaTop) {
@@ -402,9 +402,6 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
             auto& themeManager = AestraUI::NUIThemeManager::getInstance();
             const auto& layout = themeManager.getLayoutDimensions();
 
-            float headerHeight = kTimelineHeaderHeight;
-            float rulerHeight = kTimelineRulerHeight;
-            float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
             float controlAreaWidth = layout.trackControlsWidth;
             float scrollbarWidth = kTimelineScrollbarWidth;
 
@@ -412,7 +409,7 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
 
 
 
-            float gridTopLocal = globalBounds.y + headerHeight + rulerHeight + horizontalScrollbarHeight;
+            float gridTopLocal = globalBounds.y + kTimelineTimeBandHeight;
             float gridLeftLocal = globalBounds.x + controlAreaWidth + kTimelineGridInsetX;
             float gridRightLocal = globalBounds.x + globalBounds.width - scrollbarWidth; // Corrected width calc
             float gridBottomLocal = globalBounds.y + globalBounds.height;                // Full height down
@@ -470,9 +467,6 @@ bool TrackManagerUI::handleSelectionBoxMouse(const AestraUI::NUIMouseEvent& even
 
 bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, const AestraUI::NUIPoint& localPos, bool isInRuler, bool isInTrackArea) {
     const AestraUI::NUIRect bounds = getBounds();
-    const float headerHeight = kTimelineHeaderHeight;
-    const float rulerHeight = kTimelineRulerHeight;
-    const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
     // Mouse wheel handling
     if (event.wheelDelta != 0.0f && (isInRuler || isInTrackArea)) {
         const bool shiftHeld = (event.modifiers & AestraUI::NUIModifiers::Shift);
@@ -548,7 +542,7 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
             m_targetScrollOffset += scrollDelta;
 
             // Clamp scroll offset
-            float viewportHeight = bounds.height - headerHeight - rulerHeight - horizontalScrollbarHeight;
+            float viewportHeight = bounds.height - kTimelineTimeBandHeight;
 
             const float laneCount = static_cast<float>(m_trackUIComponents.size());
             float totalContentHeight = laneCount * (m_trackHeight + m_trackSpacing);
@@ -568,7 +562,13 @@ bool TrackManagerUI::handleTimelineWheel(const AestraUI::NUIMouseEvent& event, c
 
 bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, const AestraUI::NUIPoint& localPos, bool isInRuler) {
     // === RULER INTERACTION: Loop markers, Playhead scrubbing OR timeline selection ===
-    if (isInRuler) {
+    // Loop handles may sit left of the plane edge when scrolled (the range can
+    // intersect the viewport while a handle renders over the toolbar corner's
+    // dead zone). They stay hoverable/grabbable anywhere in the ruler row;
+    // scrub, selection, and click-seek remain confined to right of that edge.
+    const bool inRulerRow =
+        localPos.y >= kTimelineMinimapHeight && localPos.y < kTimelineTimeBandHeight;
+    if (isInRuler || (inRulerRow && m_hasRulerSelection)) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
         float controlAreaWidth = layout.trackControlsWidth;
@@ -608,6 +608,12 @@ bool TrackManagerUI::handleRulerPress(const AestraUI::NUIMouseEvent& event, cons
                     return true;
                 }
             }
+        }
+
+        // Corner dead zone: only marker hover/grab (handled above) is allowed
+        // here — a click in the toolbar cell's empty remainder must never seek.
+        if (!isInRuler) {
+            return false;
         }
 
         // Right-click or Ctrl+Left-click starts ruler selection for looping
@@ -876,10 +882,7 @@ bool TrackManagerUI::handleSplitToolClick(const AestraUI::NUIMouseEvent& event, 
         float controlAreaWidth = layout.trackControlsWidth;
         float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
-        float headerHeight = kTimelineHeaderHeight;
-        float rulerHeight = kTimelineRulerHeight;
-        float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        float trackAreaTop = headerHeight + horizontalScrollbarHeight + rulerHeight;
+        float trackAreaTop = kTimelineTimeBandHeight;
 
         AestraUI::NUIRect gridBounds(bounds.x + gridStartX, bounds.y + trackAreaTop,
                                      bounds.width - controlAreaWidth - 20.0f, bounds.height - trackAreaTop);

--- a/Source/Components/TrackManagerUIMath.h
+++ b/Source/Components/TrackManagerUIMath.h
@@ -17,9 +17,16 @@ namespace Audio {
 
 // Shared by layout, rendering, hit testing, and drag math so visible and
 // interactive geometry cannot drift independently.
-constexpr float kTimelineHeaderHeight = 38.0f;
+//
+// Above the track rows sits ONE time band, top to bottom: the overview
+// minimap row (cropped to start at the track-controls boundary — it must not
+// span the toolbar corner), then the ruler row (whose left corner carries the
+// timeline toolbar). There is no separate header strip — the header died with
+// the 2026-08 plane redesign, and `timelineTrackAreaTopY` is the single place
+// that knows the band's total height.
 constexpr float kTimelineRulerHeight = 28.0f;
-constexpr float kTimelineHorizontalScrollbarHeight = 24.0f;
+constexpr float kTimelineMinimapHeight = 24.0f;
+constexpr float kTimelineTimeBandHeight = kTimelineMinimapHeight + kTimelineRulerHeight;
 constexpr float kTimelineScrollbarWidth = 15.0f;
 
 // FD-14 §10: nested lane rows (owned lanes of an expanded track) indent this
@@ -54,7 +61,7 @@ inline float timelineGridEndX(float basisOriginX, float boundsWidth) {
 
 /** @brief Resolve the first track-row pixel in the caller's stated y basis. */
 inline float timelineTrackAreaTopY(float basisOriginY) {
-    return basisOriginY + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight + kTimelineRulerHeight;
+    return basisOriginY + kTimelineTimeBandHeight;
 }
 
 /** @brief Convert a distance from the grid origin to an unclamped beat. */

--- a/Source/Components/TrackManagerUIRender.cpp
+++ b/Source/Components/TrackManagerUIRender.cpp
@@ -5,9 +5,11 @@
 
 #include "../AestraCore/include/AestraLog.h"
 #include "../AestraCore/include/AestraUnifiedProfiler.h"
+#include "../AestraUI/Common/MusicHelpers.h"
 #include "../AestraUI/Core/NUIDragDrop.h"
 #include "../AestraUI/Core/NUIThemeSystem.h"
 #include "../AestraUI/Graphics/NUIRenderer.h"
+#include "../AestraUI/Helpers/TimelineGridRenderer.h"
 #include "../AestraUI/Platform/NUIPlatformBridge.h"
 #include "AudioFileValidator.h"
 #include "ClipSource.h"
@@ -115,18 +117,15 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
     // IMPORTANT: This pass must be clipped to the track viewport; otherwise partially-visible
     // tracks can draw "above" the viewport and bleed into the ruler/corner region.
     if (m_playlistVisible) {
-        const float headerHeight = kTimelineHeaderHeight;
-        const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        const float rulerHeight = kTimelineRulerHeight;
+        const float timeBandHeight = kTimelineTimeBandHeight;
         const float scrollbarWidth = kTimelineScrollbarWidth;
 
         // Since panels are overlays, we render the playlist underneath them.
-        // If we want clipping to stop at panel borders, we'd need to subtract them here.
+        // If we want clipping to stop at panel borders, we'd have to subtract them here.
         // For v3.1 simplicity, we just fill the workspace and let overlays cover it.
 
-        const float viewportTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
-        const float viewportHeight =
-            std::max(0.0f, bounds.height - headerHeight - horizontalScrollbarHeight - rulerHeight);
+        const float viewportTop = bounds.y + timeBandHeight;
+        const float viewportHeight = std::max(0.0f, bounds.height - timeBandHeight);
         const float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth);
         const AestraUI::NUIRect viewportClip(bounds.x, viewportTop, trackWidth, viewportHeight);
 
@@ -199,16 +198,14 @@ void TrackManagerUI::onRender(AestraUI::NUIRenderer& renderer) {
         auto& themeManager = AestraUI::NUIThemeManager::getInstance();
         const auto& layout = themeManager.getLayoutDimensions();
 
-        float headerHeight = kTimelineHeaderHeight;
-        float rulerHeight = kTimelineRulerHeight;
-        float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
+        float timeBandHeight = kTimelineTimeBandHeight;
         float controlAreaWidth = layout.trackControlsWidth;
         float scrollbarWidth = kTimelineScrollbarWidth;
 
-        float gridTop = getBounds().y + headerHeight + rulerHeight + horizontalScrollbarHeight;
+        float gridTop = getBounds().y + timeBandHeight;
         float gridLeft = getBounds().x + controlAreaWidth + kTimelineGridInsetX; // gap between the controls column and the first grid pixel
         float gridWidth = getBounds().width - (controlAreaWidth + kTimelineGridInsetX) - scrollbarWidth;
-        float gridHeight = getBounds().height - (headerHeight + rulerHeight + horizontalScrollbarHeight);
+        float gridHeight = getBounds().height - timeBandHeight;
 
         AestraUI::NUIRect gridBounds(gridLeft, gridTop, gridWidth, gridHeight);
 
@@ -248,7 +245,6 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
     float gridStartX = controlAreaWidth + kTimelineGridInsetX;
 
     // Draw background (control area + full grid area - no bounds restriction)
-    AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
     const AestraUI::NUIColor gridBgColor = themeManager.getColor("timelineBed"); // pure black on dark (owner direction), recessed on light
 
     if (m_playlistVisible) {
@@ -268,60 +264,57 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         renderer.strokeRect(bounds, 1, borderColor.withAlpha(0.24f));
     }
 
-    // Header/Track Count (Static)
-    float headerAvailableWidth = bounds.width;
-    if (m_playlistVisible) {
-        std::string infoText =
-            "Tracks: " + std::to_string(m_trackManager ? m_trackManager->getTrackCount() -
-                                                             (m_trackManager->getTrackCount() > 0 ? 1 : 0)
-                                                       : 0); // Exclude preview track
-        const auto& themeProps = themeManager.getCurrentTheme();
-        const float infoFont = themeProps.fontSizeXS;
-        auto infoSize = renderer.measureText(infoText, infoFont);
-
-        // Ensure text doesn't exceed available width and position with proper margin
-        float margin = layout.panelMargin;
-        float maxTextWidth = headerAvailableWidth - 2 * margin;
-        if (infoSize.width > maxTextWidth) {
-            std::string truncatedText = infoText;
-            while (!truncatedText.empty() && renderer.measureText(truncatedText, infoFont).width > maxTextWidth) {
-                truncatedText = truncatedText.substr(0, truncatedText.length() - 1);
-            }
-            infoText = truncatedText + "...";
-            infoSize = renderer.measureText(infoText, infoFont);
-        }
-
-        const float headerHeight = kTimelineHeaderHeight;
-        const AestraUI::NUIRect headerBounds(bounds.x, bounds.y, headerAvailableWidth, headerHeight);
-        const float rightPad = layout.panelMargin + 18.0f;
-        const float textX = std::max(headerBounds.x + margin, headerBounds.right() - infoSize.width - rightPad);
-        const float textY = std::round(renderer.calculateTextY(headerBounds, infoFont));
-
-        renderer.drawText(infoText, AestraUI::NUIPoint(textX, textY), infoFont, themeManager.getColor("textSecondary").withAlpha(0.55f));
-    }
-
     // Render Static Track Content (with Viewport Culling AND Clipping)
-    constexpr float kHeaderHeight = kTimelineHeaderHeight;
-    constexpr float kHScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    constexpr float kRulerHeight = kTimelineRulerHeight;
     constexpr float kScrollbarWidth = kTimelineScrollbarWidth;
-    const float headerHeight = kHeaderHeight;
-    const float horizontalScrollbarHeight = kHScrollbarHeight;
-    const float rulerHeight = kRulerHeight;
     const float scrollbarWidth = kScrollbarWidth;
 
     // Calculate viewport bounds for culling
-    const float viewportTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
-    const float viewportHeight = std::max(0.0f, bounds.height - headerHeight - horizontalScrollbarHeight - rulerHeight);
+    const float viewportTop = bounds.y + kTimelineTimeBandHeight;
+    const float viewportHeight = std::max(0.0f, bounds.height - kTimelineTimeBandHeight);
     const float viewportBottom = viewportTop + viewportHeight;
     const float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth);
 
-    // Set clip rect to prevent tracks from rendering behind ruler/header
+    // Set clip rect to prevent tracks from rendering behind the time band
     AestraUI::NUIRect trackClipRect(bounds.x, viewportTop, trackWidth, viewportHeight);
     bool clipEnabled = false;
     if (!trackClipRect.isEmpty()) {
         renderer.setClipRect(trackClipRect);
         clipEnabled = true;
+    }
+
+    // ONE continuous grid across the entire track viewport. The timeline is a
+    // single coordinate plane: vertical bar/beat lines belong to the plane,
+    // never to individual tracks, so they are drawn once (into the FBO cache)
+    // and the rows — control areas, clips, separators — are laid over them.
+    // Restarting the lines per row is what made the arrangement read as a
+    // stack of boxed cells instead of a workspace.
+    if (m_playlistVisible && viewportHeight > 0.0f) {
+        const float planeStartX = bounds.x + gridStartX;
+        const float planeEndX = std::max(planeStartX, bounds.x + trackWidth - kTimelineGridInsetX);
+        // The plane begins at the ruler's top edge so the bar lines run
+        // through the ruler row itself — numbers read as labels attached to
+        // the grid, not a separate strip. The minimap row above stays its own
+        // surface.
+        const float planeTop = bounds.y + kTimelineMinimapHeight;
+        const float planeHeight = viewportBottom - planeTop;
+        // Same quiet arrangement grammar the per-track grid used, with bars
+        // carrying the continuity: majors obvious, beats/subdivisions whispers.
+        const AestraUI::TimelineGridStyle planeStyle{
+            0.028f, // bars
+            0.005f, // beats
+            0.0016f, // subdivisions
+            0.0f    // no empty-canvas zebra
+        };
+        // Snap drives the drawn tiers (same contract as the piano roll): a
+        // tier finer than or misaligned with the active snap is hidden, and
+        // the snap's own tier is drawn so clips land on visible lines.
+        const double planeSnapBeats = (m_snapEnabled && m_snapSetting != AestraUI::SnapGrid::None)
+                                          ? static_cast<double>(AestraUI::MusicTheory::getSnapDuration(m_snapSetting))
+                                          : 0.0;
+        AestraUI::renderTimelineGrid(renderer,
+                                     AestraUI::NUIRect(planeStartX, planeTop, planeEndX - planeStartX, planeHeight),
+                                     planeStartX, planeEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar,
+                                     themeManager.getCurrentTheme().textPrimary, planeStyle, planeSnapBeats);
     }
 
     for (size_t i = 0; i < m_trackUIComponents.size(); ++i) {
@@ -334,70 +327,40 @@ void TrackManagerUI::renderTrackManagerStatic(AestraUI::NUIRenderer& renderer) {
         if (trackBounds.bottom() < viewportTop || trackBounds.y > viewportBottom)
             continue;
 
-        // Uniform row base (owner direction: no row zebra; the bar zebra
-        // inside drawPlaylistGrid provides the only alternation). Pure black
-        // on dark themes, recessed light bed on light themes.
-        renderer.fillRect(trackBounds, themeManager.getColor("timelineBed"));
-
         // FD-14 §10: nested lane rows carry a faint containment tint so the
-        // expanded lanes read as one block under their track.
+        // expanded lanes read as one block under their track. Translucent, so
+        // the shared grid plane shows through.
         if (track->isNestedLane()) {
             renderer.fillRect(trackBounds, themeManager.getColor("accentSecondary").withAlpha(0.05f));
         }
 
         track->renderStatic(renderer);
 
-        // One pixel is enough to locate the next lane; filling the whole gap
-        // made empty arrangements read as a wall of outlined rectangles.
-        const AestraUI::NUIRect gapRect(bounds.x + gridStartX, trackBounds.bottom(),
-                                        std::max(0.0f, trackWidth - gridStartX),
-                                        static_cast<float>(m_trackSpacing));
-        renderer.fillRect(gapRect, themeManager.getColor("timelineBed"));
-        renderer.drawLine({gapRect.x, gapRect.y}, {gapRect.right(), gapRect.y}, 1.0f,
-                          themeManager.getCurrentTheme().textPrimary.withAlpha(0.006f));
+        // Row separators sit ON the plane: a quiet full-width line that says
+        // "another track" without cutting the vertical grid or forming cells.
+        renderer.drawLine({bounds.x + gridStartX, trackBounds.bottom()},
+                          {bounds.x + trackWidth, trackBounds.bottom()}, 1.0f,
+                          themeManager.getCurrentTheme().textPrimary.withAlpha(0.018f));
     }
 
-    // Clear clip rect before drawing header/ruler (they should draw fully)
+    // Clear clip rect before drawing the time band (it should draw fully)
     if (clipEnabled) {
         renderer.clearClipRect();
     }
 
-    // Header Bar (Static overlay)
-    float headerWidth = bounds.width;
+    // Time band (Static overlay): minimap row + ruler row rendered as one
+    // coherent strip. The band's bottom hairline is the single "everything
+    // below this is the timeline" cue.
     if (m_playlistVisible) {
-        AestraUI::NUIColor bgColor = themeManager.getColor("backgroundPrimary");
-        AestraUI::NUIColor borderColor = themeManager.getColor("border");
-
-        float headerHeight = kTimelineHeaderHeight;
-        AestraUI::NUIRect headerRect(bounds.x, bounds.y, headerWidth, headerHeight);
-        // Elevated header: base fill + soft vertical gradient + glass top edge.
-        // Rendered into the playlist FBO cache, so the richness is free per frame.
-        renderer.fillRect(headerRect, themeManager.getColor("recessedPanel"));
-        // Shade-only elevation — any white component reads as a sheen on this
-        // near-black chrome (owner direction: no light gradients anywhere).
-        renderer.fillRectGradient(headerRect, AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
-                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.075f),
-                                  /*vertical=*/true);
-        // Soft drop below the header so it reads as a raised surface.
-        const float shadowH = 7.0f;
-        renderer.fillRectGradient(AestraUI::NUIRect(headerRect.x, headerRect.bottom(), headerRect.width, shadowH),
-                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.22f),
-                                  AestraUI::NUIColor(0.0f, 0.0f, 0.0f, 0.0f),
-                                  /*vertical=*/true);
-        const auto headerBorder = borderColor.withAlpha(0.50f);
-        renderer.drawLine({headerRect.x, headerRect.y}, {headerRect.x, headerRect.bottom()}, 1.0f, headerBorder);
-        renderer.drawLine({headerRect.right(), headerRect.y}, {headerRect.right(), headerRect.bottom()}, 1.0f,
-                          headerBorder);
-        renderer.drawLine({headerRect.x, headerRect.bottom()}, {headerRect.right(), headerRect.bottom()}, 1.0f,
-                          headerBorder);
-
-        // Draw time ruler below header
-        float rulerHeight = kTimelineRulerHeight;
-        float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        AestraUI::NUIRect rulerRect(bounds.x, bounds.y + headerHeight + horizontalScrollbarHeight, headerWidth,
-                                    rulerHeight);
+        AestraUI::NUIRect rulerRect(bounds.x, bounds.y + kTimelineMinimapHeight, bounds.width,
+                                    kTimelineRulerHeight);
         renderTimeRuler(renderer, rulerRect);
         renderLoopMarkers(renderer, rulerRect);
+
+        const auto borderColor = themeManager.getColor("border");
+        renderer.drawLine({bounds.x, bounds.y + kTimelineTimeBandHeight},
+                          {bounds.x + bounds.width - kTimelineScrollbarWidth, bounds.y + kTimelineTimeBandHeight},
+                          1.0f, borderColor.withAlpha(0.24f));
     }
 }
 
@@ -408,18 +371,11 @@ void TrackManagerUI::renderTrackManagerDynamic(AestraUI::NUIRenderer& renderer) 
     const auto& layout = themeManager.getLayoutDimensions();
 
     if (m_playlistVisible) {
-        constexpr float kHeaderHeight = kTimelineHeaderHeight;
-        constexpr float kHScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        constexpr float kRulerHeight = kTimelineRulerHeight;
         constexpr float kScrollbarWidth = kTimelineScrollbarWidth;
-        const float headerHeight = kHeaderHeight;
-        const float horizontalScrollbarHeight = kHScrollbarHeight;
-        const float rulerHeight = kRulerHeight;
         const float scrollbarWidth = kScrollbarWidth;
 
-        const float viewportTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
-        const float viewportHeight =
-            std::max(0.0f, bounds.height - headerHeight - horizontalScrollbarHeight - rulerHeight);
+        const float viewportTop = bounds.y + kTimelineTimeBandHeight;
+        const float viewportHeight = std::max(0.0f, bounds.height - kTimelineTimeBandHeight);
         const float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth);
         const AestraUI::NUIRect viewportClip(bounds.x, viewportTop, trackWidth, viewportHeight);
 
@@ -470,11 +426,8 @@ void TrackManagerUI::renderTrackManagerDynamic(AestraUI::NUIRenderer& renderer) 
         float selStartX = gridStartX + static_cast<float>(selStartBeat * m_pixelsPerBeat) - m_timelineScrollOffset;
         float selEndX = gridStartX + static_cast<float>(selEndBeat * m_pixelsPerBeat) - m_timelineScrollOffset;
 
-        float headerHeight = kTimelineHeaderHeight;
-        float rulerHeight = kTimelineRulerHeight;
-        float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
-        float trackAreaHeight = bounds.height - (headerHeight + horizontalScrollbarHeight + rulerHeight);
+        float trackAreaTop = bounds.y + kTimelineTimeBandHeight;
+        float trackAreaHeight = bounds.height - kTimelineTimeBandHeight;
 
         float scrollbarWidth = kTimelineScrollbarWidth;
         float gridWidth = bounds.width - controlAreaWidth - scrollbarWidth - 5.0f;
@@ -511,13 +464,10 @@ void TrackManagerUI::renderChildren(AestraUI::NUIRenderer& renderer) {
     const auto& layout = themeManager.getLayoutDimensions();
     AestraUI::NUIRect bounds = getBounds();
 
-    const float headerHeight = kTimelineHeaderHeight;
-    const float rulerHeight = kTimelineRulerHeight;
-    const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
     const float scrollbarWidth = kTimelineScrollbarWidth;
 
-    const float viewportHeight = std::max(0.0f, bounds.height - headerHeight - horizontalScrollbarHeight - rulerHeight);
-    const float viewportTopAbs = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    const float viewportHeight = std::max(0.0f, bounds.height - kTimelineTimeBandHeight);
+    const float viewportTopAbs = bounds.y + kTimelineTimeBandHeight;
     const float viewportBottomAbs = viewportTopAbs + viewportHeight;
     const float trackWidth = std::max(0.0f, bounds.width - scrollbarWidth);
 
@@ -880,9 +830,10 @@ void TrackManagerUI::onResize(int width, int height) {
     invalidateCache(); // Full invalidation on resize for immediate repaint
 
     layoutTracks();
+    // Cropped minimap: bounds already start at the track-controls boundary,
+    // so no leading inset — keep this site in sync with the constructor.
     if (m_timelineMinimap) {
-        m_timelineMinimap->setLeadingInset(
-            AestraUI::NUIThemeManager::getInstance().getLayoutDimensions().trackControlsWidth);
+        m_timelineMinimap->setLeadingInset(0.0f);
     }
     // Zebra Striping: Assign row index to tracks
     for (size_t i = 0; i < m_trackUIComponents.size(); ++i) {
@@ -896,11 +847,6 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     auto borderColor = themeManager.getColor("borderSubtle");
     auto accentColor = themeManager.getColor("accentPrimary");
-
-    // Opaque near-black ruler material — identical across the full row and the
-    // grid shell so the corner over the track controls is flush by construction.
-    auto glassBg = themeManager.getColor("recessedPanel");
-    auto glassHighlight = themeManager.getColor("textPrimary").withAlpha(0.014f);
 
     auto textCol = themeManager.getColor("textSecondary").withAlpha(0.68f);
     auto majorTickCol = themeManager.getColor("gridMajor");
@@ -919,22 +865,14 @@ void TrackManagerUI::renderTimeRuler(AestraUI::NUIRenderer& renderer, const Aest
 
     AestraUI::NUIRect gridRulerRect(gridStartX, rulerBounds.y, gridWidth, rulerBounds.height);
 
-    // One material across the whole ruler row: fill the full row (including the
-    // corner over the track controls) with the ruler base so the left edge is
-    // flush with the rest of the ruler instead of showing the layer beneath.
-    renderer.fillRect(rulerBounds, glassBg);
-
-    float cornerRadius = 3.0f;
-    renderer.fillRoundedRect(gridRulerRect, cornerRadius, glassBg);
-
-    // Subtle top highlight on grid area only
-    AestraUI::NUIRect highlightRect(gridRulerRect.x, gridRulerRect.y, gridRulerRect.width, 1.0f);
-    renderer.fillRect(highlightRect, glassHighlight);
-
-    renderer.strokeRoundedRect(gridRulerRect, cornerRadius, 1.0f, borderColor.withAlpha(0.28f));
-    renderer.drawLine(AestraUI::NUIPoint(gridRulerRect.x, gridRulerRect.bottom() - 1.0f),
-                      AestraUI::NUIPoint(gridRulerRect.right(), gridRulerRect.bottom() - 1.0f), 1.0f,
-                      AestraUI::NUIColor::white().withAlpha(0.035f));
+    // The ruler is part of the coordinate plane, not a strip bolted onto it:
+    // the continuous grid's bar lines already run through this row, so the
+    // grid area gets no shell of its own — the numbers are labels attached to
+    // the grid. Only the left corner cell (the toolbar dock) gets material.
+    renderer.fillRect(AestraUI::NUIRect(rulerBounds.x, rulerBounds.y, gridStartX - rulerBounds.x, rulerBounds.height),
+                      themeManager.getColor("recessedPanel"));
+    renderer.drawLine({rulerBounds.x, rulerBounds.bottom()}, {gridStartX, rulerBounds.bottom()}, 1.0f,
+                      borderColor.withAlpha(0.24f));
 
     // === SET CLIP RECT for timeline grid area (prevents text/ticks bleeding outside) ===
     renderer.setClipRect(gridRulerRect);
@@ -1166,10 +1104,7 @@ void TrackManagerUI::renderPlayhead(AestraUI::NUIRenderer& renderer) {
     float gridEndX = gridStartX + gridWidth;
 
     // Calculate playhead boundaries
-    float headerHeight = kTimelineHeaderHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float playheadStartY = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    float playheadStartY = bounds.y + kTimelineTimeBandHeight;
 
     // In v3.1, overlays are hit-test transparent and don't affect playhead line culling directly.
     // We just cull against the workspace grid area.
@@ -1279,19 +1214,10 @@ void TrackManagerUI::updateBackgroundCache(AestraUI::NUIRenderer& renderer) {
     renderer.drawLine({textureBounds.x, textureBounds.bottom()}, {textureBounds.right(), textureBounds.bottom()}, 1.0f,
                       borderColor);
 
-    // Draw header bar
-    float headerHeight = kTimelineHeaderHeight;
-    AestraUI::NUIRect headerRect(0, 0, static_cast<float>(width), headerHeight);
-    renderer.fillRect(headerRect, bgColor);
-    renderer.drawLine({headerRect.x, headerRect.y}, {headerRect.x, headerRect.bottom()}, 1.0f, borderColor);
-    renderer.drawLine({headerRect.right(), headerRect.y}, {headerRect.right(), headerRect.bottom()}, 1.0f, borderColor);
-    renderer.drawLine({headerRect.x, headerRect.bottom()}, {headerRect.right(), headerRect.bottom()}, 1.0f,
-                      borderColor);
-
-    // Draw time ruler
+    // Draw time ruler (no header strip — the time band starts with the
+    // minimap row, cropped to the plane column, then the ruler)
     float rulerHeight = kTimelineRulerHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    AestraUI::NUIRect rulerRect(0, headerHeight + horizontalScrollbarHeight, static_cast<float>(width), rulerHeight);
+    AestraUI::NUIRect rulerRect(0, kTimelineMinimapHeight, static_cast<float>(width), rulerHeight);
 
     // Render ruler ticks (static part only - no moving elements)
     double bpm = std::max(m_trackManager->getPlaylistModel().getBPM(), 1.0);
@@ -1441,12 +1367,9 @@ void Aestra::Audio::TrackManagerUI::renderPendingImports(AestraUI::NUIRenderer& 
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();
     const auto& layout = themeManager.getLayoutDimensions();
 
-    float headerHeight = kTimelineHeaderHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
     float controlAreaWidth = layout.trackControlsWidth;
     float gridStartX = getBounds().x + controlAreaWidth + kTimelineGridInsetX;
-    float trackAreaTop = getBounds().y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    float trackAreaTop = getBounds().y + kTimelineTimeBandHeight;
 
     // Tech/Holo Colors
     AestraUI::NUIColor cyan = themeManager.getColor("accentCyan");

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -147,6 +147,12 @@ bool TrackManagerUI::isRulerPointerActive() const {
         return true;
     }
     const AestraUI::NUIRect bounds = getBounds();
+    // Hovering a loop handle claims the grab hand anywhere in the ruler row —
+    // handles may sit over the toolbar corner's dead zone when scrolled.
+    if ((m_hoveringLoopStart || m_hoveringLoopEnd) && m_lastMousePos.y >= bounds.y + kTimelineMinimapHeight &&
+        m_lastMousePos.y < bounds.y + kTimelineTimeBandHeight) {
+        return true;
+    }
     // Same geometry as the events file's ruler row, but starting after the
     // control-area column: the grab hand belongs over scrubbable ruler only.
     auto& themeManager = AestraUI::NUIThemeManager::getInstance();

--- a/Source/Components/TrackManagerUIToolbar.cpp
+++ b/Source/Components/TrackManagerUIToolbar.cpp
@@ -153,7 +153,7 @@ bool TrackManagerUI::isRulerPointerActive() const {
     const auto& layout = themeManager.getLayoutDimensions();
     const float rulerStartX = bounds.x + layout.trackControlsWidth + kTimelineGridInsetX;
     const AestraUI::NUIRect ruler(rulerStartX,
-                                  bounds.y + kTimelineHeaderHeight + kTimelineHorizontalScrollbarHeight,
+                                  bounds.y + kTimelineMinimapHeight,
                                   std::max(0.0f, bounds.width - layout.trackControlsWidth - kTimelineGridInsetX),
                                   kTimelineRulerHeight);
     return ruler.contains(m_lastMousePos);
@@ -189,13 +189,10 @@ bool TrackManagerUI::isCustomCursorActive() const {
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;
         const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
-        const float headerHeight = kTimelineHeaderHeight;
-        const float rulerHeight = kTimelineRulerHeight;
-        const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        const float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+        const float trackAreaTop = bounds.y + kTimelineTimeBandHeight;
 
         AestraUI::NUIRect gridBounds(gridStartX, trackAreaTop, bounds.width - controlAreaWidth - 20.0f,
-                                     bounds.height - headerHeight - rulerHeight - horizontalScrollbarHeight);
+                                     bounds.height - kTimelineTimeBandHeight);
         if (gridBounds.contains(m_lastMousePos)) {
             return true;
         }
@@ -247,32 +244,35 @@ void TrackManagerUI::updateToolbarBounds() {
     const auto& layout = themeManager.getLayoutDimensions();
     AestraUI::NUIRect bounds = getBounds();
 
-    constexpr float headerHeight = 40.0f;                // Unified playlist header strip (Standardized)
+    // The toolbar lives in the ruler row's left corner — the cell where the
+    // track-controls column meets the time band. It is sized by its contents
+    // (no reserved region): if the button count ever outgrows the corner, the
+    // overflow answer is a flyout, never a second row or a taller band.
+    const float rulerY = bounds.y + kTimelineMinimapHeight;
     const float innerPad = themeManager.getSpacing("s"); // 8px from edge
     const float buttonSpacing = 6.0f;                    // Standardized gap for Aestra UI philosophy
+    const float cornerWidth = layout.trackControlsWidth - innerPad;
 
     // Secondary toolbar controls are intentionally smaller than primary transport controls.
     const float buttonSize = 22.0f;
     const float iconSize = buttonSize;
 
-    // Vertical centering for 24px button in 40px header (8px top/bottom padding)
+    // Vertical centering for 22px button in the 28px ruler row.
     float currentX = bounds.x + innerPad;
-    float currentY = bounds.y + (headerHeight - buttonSize) * 0.5f;
+    float iconY = rulerY + (kTimelineRulerHeight - buttonSize) * 0.5f;
 
     // 2. Add Track (leftmost)
-    m_addTrackBounds = AestraUI::NUIRect(currentX, currentY, iconSize, iconSize);
+    m_addTrackBounds = AestraUI::NUIRect(currentX, iconY, iconSize, iconSize);
     float iconX = currentX + iconSize + buttonSpacing;
-    float iconY = currentY;
 
     // 3. Tools Module
     float toolbarX = iconX;
-    float toolbarY = iconY;
 
     const int numTools = 4; // Select, Split, MultiSelect, Paint
     float toolbarWidth = (iconSize * numTools) + (buttonSpacing * (numTools - 1));
     float toolbarHeight = iconSize;
 
-    m_toolbarBounds = AestraUI::NUIRect(toolbarX, toolbarY, toolbarWidth, toolbarHeight);
+    m_toolbarBounds = AestraUI::NUIRect(toolbarX, iconY, toolbarWidth, toolbarHeight);
 
     m_selectToolBounds = AestraUI::NUIRect(iconX, iconY, iconSize, iconSize);
     iconX += iconSize + buttonSpacing;
@@ -290,6 +290,13 @@ void TrackManagerUI::updateToolbarBounds() {
 
     // 5. Menu (rightmost)
     m_menuIconBounds = AestraUI::NUIRect(iconX, iconY, iconSize, iconSize);
+
+    // Content-sized corner container: the union of every button, so hover and
+    // hit testing describe what is actually drawn, not a reserved plate.
+    const float contentWidth = (iconX + iconSize) - currentX;
+    m_toolbarCornerBounds = AestraUI::NUIRect(
+        currentX, rulerY, std::min(contentWidth, cornerWidth), kTimelineRulerHeight);
+
     if (m_addTrackBtn) {
         m_addTrackBtn->setBounds(m_addTrackBounds);
     }
@@ -726,13 +733,10 @@ void TrackManagerUI::renderToolCursor(AestraUI::NUIRenderer& renderer, const Aes
     const auto& layout = themeManager.getLayoutDimensions();
     float controlAreaWidth = layout.trackControlsWidth;
     float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
-    float headerHeight = kTimelineHeaderHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-    float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+    float trackAreaTop = bounds.y + kTimelineTimeBandHeight;
 
     AestraUI::NUIRect gridBounds(gridStartX, trackAreaTop, bounds.width - controlAreaWidth - 20.0f,
-                                 bounds.height - headerHeight - rulerHeight - horizontalScrollbarHeight);
+                                 bounds.height - kTimelineTimeBandHeight);
 
     // If mouse is outside grid, don't render tool cursor (Main.cpp renders default arrow)
     if (!gridBounds.contains(position)) {
@@ -841,13 +845,10 @@ void TrackManagerUI::renderMinimapResizeCursor(AestraUI::NUIRenderer& renderer, 
         const auto& layout = themeManager.getLayoutDimensions();
         const float controlAreaWidth = layout.trackControlsWidth;
         const float gridStartX = bounds.x + controlAreaWidth + kTimelineGridInsetX;
-        const float headerHeight = kTimelineHeaderHeight;
-        const float rulerHeight = kTimelineRulerHeight;
-        const float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
-        const float trackAreaTop = bounds.y + headerHeight + horizontalScrollbarHeight + rulerHeight;
+        const float trackAreaTop = bounds.y + kTimelineTimeBandHeight;
 
         AestraUI::NUIRect gridBounds(gridStartX, trackAreaTop, bounds.width - controlAreaWidth - 20.0f,
-                                     bounds.height - headerHeight - rulerHeight - horizontalScrollbarHeight);
+                                     bounds.height - kTimelineTimeBandHeight);
         if (gridBounds.contains(position)) {
             return; // Tool cursor takes priority in grid area
         }

--- a/Source/Components/TrackManagerUIView.cpp
+++ b/Source/Components/TrackManagerUIView.cpp
@@ -39,12 +39,9 @@ void TrackManagerUI::updateScrollbar() {
         return;
 
     AestraUI::NUIRect bounds = getBounds();
-    float headerHeight = kTimelineHeaderHeight;
-    float rulerHeight = kTimelineRulerHeight;
-    float horizontalScrollbarHeight = kTimelineHorizontalScrollbarHeight;
 
     // In v3.1, panels are floating overlays and do not affect the scrollbar's viewport directly.
-    float viewportHeight = bounds.height - headerHeight - rulerHeight - horizontalScrollbarHeight;
+    float viewportHeight = bounds.height - kTimelineTimeBandHeight;
 
     const float laneCount = static_cast<float>(m_trackUIComponents.size());
     float totalContentHeight = laneCount * (m_trackHeight + m_trackSpacing);
@@ -71,8 +68,10 @@ float TrackManagerUI::getTimelineGridWidthPixels() const {
     const auto& layout = themeManager.getLayoutDimensions();
 
     const float controlAreaWidth = layout.trackControlsWidth;
-    const float trackWidth = m_timelineMinimap ? m_timelineMinimap->getBounds().width : getBounds().width;
-    float gridWidth = trackWidth - controlAreaWidth - 10.0f; // Match TrackUIComponent grid width
+    // Grid width is derived from the component bounds, not the minimap surface —
+    // the minimap is a cropped overview and no longer defines the plane width.
+    const float trackWidth = getBounds().width;
+    float gridWidth = trackWidth - kTimelineScrollbarWidth - controlAreaWidth - 10.0f; // Match TrackUIComponent grid width
     return std::max(0.0f, gridWidth);
 }
 

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -364,6 +364,9 @@ double TrackUIComponent::getSnapGridSizeBeats() const {
 }
 
 double TrackUIComponent::snapBeatToGrid(double beat) const {
+    // Same master switch the move/drop path honors — trim must not snap when
+    // snapping is off, even though the last setting is still remembered.
+    if (!m_snapEnabled || m_snapSetting == AestraUI::SnapGrid::None) return beat;
     double gridSize = getSnapGridSizeBeats();
     if (gridSize <= 0.0) return beat; // No snap
     return std::round(beat / gridSize) * gridSize;
@@ -1444,7 +1447,10 @@ void TrackUIComponent::renderStatic(AestraUI::NUIRenderer& renderer) {
 
         // Keep separator clean and flat; no extra chrome shadow strip.
 
-        drawPlaylistGrid(renderer, bounds);
+        // NOTE: no grid here. The beat/bar grid is drawn ONCE by
+        // TrackManagerUI across the whole viewport — the timeline is a single
+        // coordinate plane; per-row grids are what made it read as a stack of
+        // boxed cells.
     }
 
     // Render Clips (Heavy part)
@@ -1786,31 +1792,6 @@ void TrackUIComponent::renderControlOverlay(AestraUI::NUIRenderer& renderer) {
                           themeManager.getFontSize("xs"),
                           themeManager.getColor("textSecondary").withAlpha(m_selected ? 0.58f : 0.36f));
     }
-}
-
-// Draw playlist grid (beat/bar grid)
-void TrackUIComponent::drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds) {
-    AESTRA_ZONE("TrackUI_Grid");
-    auto& themeManager = AestraUI::NUIThemeManager::getInstance();
-    const auto& layout = themeManager.getLayoutDimensions();
-    const float controlAreaWidth = std::min(layout.trackControlsWidth, bounds.width);
-    const float desiredGap = 5.0f;
-    const float gridGap = std::min(desiredGap, std::max(0.0f, bounds.width - controlAreaWidth));
-    const float gridStartX = bounds.x + controlAreaWidth + gridGap;
-    const float gridEndX = bounds.right();
-
-    // The arrangement is a large empty canvas much more often than the Piano
-    // Roll, so its infrastructure recedes further while retaining the same
-    // bar > beat > subdivision grammar.
-    const AestraUI::TimelineGridStyle timelineStyle{
-        0.018f, // bars
-        0.004f, // beats
-        0.0015f, // subdivisions
-        0.0f    // no empty-canvas zebra
-    };
-    AestraUI::renderTimelineGrid(
-        renderer, bounds, gridStartX, gridEndX, m_timelineScrollOffset, m_pixelsPerBeat, m_beatsPerBar,
-        themeManager.getCurrentTheme().textPrimary, timelineStyle);
 }
 
 void TrackUIComponent::onMouseEnter() {

--- a/Source/Components/TrackUIComponent.cpp
+++ b/Source/Components/TrackUIComponent.cpp
@@ -1978,7 +1978,10 @@ bool TrackUIComponent::onMouseEvent(const AestraUI::NUIMouseEvent& event) {
     float controlAreaWidth = layout.trackControlsWidth;
     float controlAreaEndX = bounds.x + controlAreaWidth;
     float gridStartX = timelineGridStartX(bounds.x, controlAreaWidth);
-    float gridEndX = bounds.x + bounds.width - 5;
+    // Rows span width - scrollbar - 5; ending interaction at bounds.right()
+    // aligns clip grab/trim with the plane's last gridline (width - scrollbar
+    // - inset) instead of leaving a 5px strip lines draw but clips can't use.
+    float gridEndX = bounds.right();
     
     // === HOVER EDGE DETECTION (for resize cursor) ===
     // Update hover state on every mouse move (not just press)

--- a/Source/Components/TrackUIComponent.h
+++ b/Source/Components/TrackUIComponent.h
@@ -131,6 +131,7 @@ public:
     void setTimelineScrollOffset(float offset) { m_timelineScrollOffset = offset; }
     void setMaxTimelineExtent(double extent) { m_maxTimelineExtent = extent; }
     void setSnapSetting(AestraUI::SnapGrid snap) { m_snapSetting = snap; }
+    void setSnapEnabled(bool enabled) { m_snapEnabled = enabled; }
     
     // Loop state for visual rendering
     void setLoopEnabled(bool enabled) { m_loopEnabled = enabled; }
@@ -211,6 +212,9 @@ private:
     
     // Snap Setting
     AestraUI::SnapGrid m_snapSetting = AestraUI::SnapGrid::Bar;
+    // Mirrors TrackManagerUI's master snap toggle. Trim/resize must honor the
+    // same switch move/drag does, or clips "have a mind of their own".
+    bool m_snapEnabled = true;
     
     // Loop state for visual rendering
     bool m_loopEnabled = false;
@@ -341,10 +345,6 @@ private:
     PlaylistLaneID m_laneId;
     std::shared_ptr<MixerChannel> m_channel;
 
-    
-    // Playlist grid rendering
-    void drawPlaylistGrid(AestraUI::NUIRenderer& renderer, const AestraUI::NUIRect& bounds);
-    
     void showClipRoutingMenu(const ClipInstanceID& clipId, const AestraUI::NUIPoint& position);
     // Helper to draw a single clip (waveform + container) at calculated position
     void drawClipAtPosition(AestraUI::NUIRenderer& renderer, const ClipInstance& clip,

--- a/Tests/AestraUI/TimelineGeometryTest.cpp
+++ b/Tests/AestraUI/TimelineGeometryTest.cpp
@@ -37,7 +37,9 @@ int main() {
     expectNear(timelineGridStartX(17.5f, 236.0f), 258.5, 0.0001, "ruler-relative grid origin");
 
     expectNear(timelineGridEndX(80.0f, 800.0f), 865.0, 0.0001, "grid end excludes scrollbar");
-    expectNear(timelineTrackAreaTopY(40.0f), 130.0, 0.0001, "track area follows shared vertical stack");
+    // Time band = minimap row (24) + ruler row (28); the minimap surface is
+    // cropped to start at the track-controls boundary.
+    expectNear(timelineTrackAreaTopY(40.0f), 92.0, 0.0001, "track area follows shared vertical stack");
 
     // Beat conversion is deliberately unclamped: zoom anchoring and dragging
     // left of bar one must preserve negative intermediate values.


### PR DESCRIPTION
## Summary

Restores the timeline overview minimap row (24px) above the ruler after it was removed from the working tree as "dead code" while it was merely null — every consumer (`updateTimelineMinimap`, event routing, cursor claims) still existed and null-guarded. The band returns as minimap + ruler (52px total), and the minimap surface is **cropped**: its bounds start at the track-controls boundary, so it no longer spans the empty toolbar corner. Grid-width beat math is decoupled from the widget's bounds so the crop cannot shift beat mapping.

Fixes riding the same batch:

- **Playhead reset on dead space** — ruler scrub/seek/selection gestures now begin at the plane edge (`timelineGridStartX()`); clicks in the toolbar cell's empty remainder do nothing instead of snapping the playhead to 0. Loop handles remain grabbable anywhere in the ruler row, including when scrolled over the corner.
- **Snap drift between move and trim** — `TrackUIComponent::snapBeatToGrid` ignored the master snap toggle, so trim could snap while move didn't. The toggle now propagates to rows (choke point: `TrackManagerUI::setSnapEnabled`, plus refresh sync).
- **Snap-driven grid tiers** — the arrangement plane now feeds the active snap duration into `renderTimelineGrid` (the piano roll already did): tiers finer than or misaligned with snap are hidden, and snap's own tier is drawn, so clips land on visible lines. Snap=Bar collapses the plane to bar lines; None restores all tiers.

Also carried: the staged 2026-08 plane redesign on this branch (header removal, contiguous 42px rows, toolbar dock in the ruler corner) — this PR is that branch's working state made whole.

## Why

The minimap removal was collateral damage from a misread ("m_timelineMinimap stays null; every consumer null-guards" was treated as intent to delete). Owner direction was to restore it cropped, and the two interaction defects surfaced during visual verification of that restore.

## Testing performed

- Headless configure + full build (`AESTRA_HEADLESS_ONLY=ON`, `-j2`), exit 0; incremental pass with zero pending compiles
- `TimelineGeometryTest`: PASS (band height pinned at 92 = 24 + 28 + controls basis)
- ctest slice (Timeline|Geometry|Snap): 4/4 passed
- Default headless tier: **244/244 passed**, 1 skipped (`SecAccountEndToEndSmoke`, runtime-gated)
- Manual E2E with owner screenshots across four rounds: band restored → seam/cutoff diagnosed as stale re-applied inset in `onResize` → fixed → owner-confirmed clean build and visuals

## Producer note

Your timeline overview is back above the ruler — cropped to your tracks — and clips now snap onto lines you can actually see.

## Docs updated?

No public docs needed; DESIGN.md's minimap-anchor guidance already matches this behavior.

## Decision citation

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 3393b02
Kind: corrective

## Risk / rollback notes

Pure UI-layer change: no DSP, no serialization/project format, no audio paths, no CI config. Rollback = revert this commit. An unrelated `AESTRA_RECORD_PROBE` debug block (#845) in `Source/App/AestraApp.cpp` is deliberately excluded (parked in stash) and must not ride any PR from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- No breaking changes.
- Restored the 24px timeline minimap above the ruler, creating a 52px time band.
- Cropped the minimap at the track-controls boundary and unified timeline geometry around the new time band.
- Redesigned the timeline plane with 42px contiguous rows, no header, and a ruler-corner toolbar dock.
- Prevented empty toolbar gestures from resetting the playhead.
- Kept loop handles grabbable across the ruler row and prioritized their hit testing over toolbar icons.
- Aligned row interaction bounds with the plane’s right boundary.
- Propagated the master snap toggle to track rows and added snap-driven arrangement grid tiers.
- Updated rendering, drag-and-drop, scrolling, selection, toolbar, and viewport calculations.
- Updated timeline geometry tests and project-format audio fixtures.
- Headless builds and timeline, geometry, snap, and default test suites passed, with one runtime-gated skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->