### PR TITLE
fix(audio): source buffer lifecycle invariant — attach always re-arms waveform cache

### DIFF
--- a/AestraAudio/include/Models/ClipSource.h
+++ b/AestraAudio/include/Models/ClipSource.h
@@ -7,9 +7,10 @@
 namespace Aestra {
 namespace Audio {
 
-// Forward declaration
+// Forward declarations
 struct AudioBufferData;
 class WaveformCache;
+class SourceManager;
 
 /**
  * @brief Type-safe identifier for clip sources
@@ -78,12 +79,11 @@ public:
     void setName(const std::string& name) { m_name = name; }
     void setFilePath(const std::string& path) { m_filePath = path; }
 
-    void setBuffer(std::shared_ptr<AudioBufferData> buffer) {
-        m_buffer = std::move(buffer);
-        m_waveformCache.reset();
-        ++m_contentRevision;
-        clearFilteredVariant(); // new content invalidates any anti-aliased copy
-    }
+    // Defined in ClipSource.cpp (it needs the complete SourceManager type, and
+    // SourceManager.h already includes this header): attaching audio that flips
+    // the source from not-ready to ready must bump the owning SourceManager's
+    // revision so the timeline's waveform-cache sweep re-runs.
+    void setBuffer(std::shared_ptr<AudioBufferData> buffer);
 
     std::shared_ptr<WaveformCache> getWaveformCache() const { return m_waveformCache; }
     void setWaveformCache(std::shared_ptr<WaveformCache> cache) { m_waveformCache = std::move(cache); }
@@ -129,12 +129,22 @@ public:
     bool hasFilteredVariant() const { return m_filteredBuffer != nullptr; }
 
 private:
+    // Owning manager, bound at creation time inside SourceManager. Null for
+    // sources minted elsewhere (e.g. AuditionEngine's standalone preview
+    // source) — those have no sweep to wake, so a null owner simply skips the
+    // notification in setBuffer. Friendship rather than a public setter:
+    // ownership is a creation-time fact, not something callers rewire.
+    friend class SourceManager;
+
+    void setOwner(SourceManager* owner) { m_owner = owner; }
+
     ClipSourceID m_id;
     std::string m_name;
     std::string m_filePath;
     std::shared_ptr<AudioBufferData> m_buffer;
     std::shared_ptr<WaveformCache> m_waveformCache;
     uint64_t m_contentRevision{0};
+    SourceManager* m_owner{nullptr};
 
     // Filtered-variant slot (see threading contract above).
     std::shared_ptr<AudioBufferData> m_filteredBuffer;

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -32,6 +32,7 @@ public:
         ClipSourceID id{nextId++};
         auto source = std::make_unique<ClipSource>(id, displayName.empty() ? makeDisplayName(filePath) : displayName);
         source->setFilePath(filePath);
+        source->setOwner(this); // so a later readiness flip can bump the revision
 
         m_sources[id.value] = std::move(source);
         m_pathToId[filePath] = id;
@@ -74,12 +75,39 @@ public:
 
         auto source = std::make_unique<ClipSource>(id, displayName.empty() ? makeDisplayName(filePath) : displayName);
         source->setFilePath(filePath);
+        source->setOwner(this); // so a later readiness flip can bump the revision
 
         m_sources[id.value] = std::move(source);
         m_pathToId[filePath] = id;
         ++m_revision;
 
         return id;
+    }
+
+    /**
+     * @brief Canonical entry point for handing decoded audio to a managed source.
+     *
+     * Wraps ClipSource::setBuffer with the bookkeeping callers must not be able
+     * to forget: (re)binding ownership and moving the revision counter the
+     * timeline's waveform-cache sweep watches (TrackManagerUIRender compares it
+     * once per frame). A not-ready -> ready flip bumps through the ClipSource
+     * back-pointer; replacing the buffer of an already-ready source bumps here,
+     * because its old waveform cache was just discarded without any readiness
+     * change. A failed attach — no source, or a buffer that leaves the source
+     * unready — bumps nothing and leaves the retryable state untouched.
+     * @param source Managed source receiving the buffer (null is a no-op).
+     * @param buffer Decoded audio to attach.
+     */
+    void attachBuffer(ClipSource* source, std::shared_ptr<AudioBufferData> buffer) {
+        if (!source) {
+            return;
+        }
+        source->setOwner(this);
+        const bool wasReady = source->isValid();
+        source->setBuffer(std::move(buffer)); // bumps itself on a readiness flip
+        if (wasReady && source->isValid()) {
+            ++m_revision; // ready -> ready replacement still discards the cache
+        }
     }
 
     /**
@@ -101,11 +129,10 @@ public:
             return ClipSourceID{};
         }
 
-        source->setBuffer(std::move(buffer));
-        // Bumped unconditionally: an existing source deduped by path does not
-        // mint a new ID, but attaching a buffer still flips it to ready, which
-        // is the transition waveform-cache builders watch for.
-        ++m_revision;
+        // Canonical attach: bumps the revision whether this flips an existing
+        // path-deduped source to ready or replaces an earlier take's buffer —
+        // both are transitions waveform-cache builders watch for.
+        attachBuffer(source, std::move(buffer));
         return id;
     }
 
@@ -197,6 +224,16 @@ public:
         m_pathToId.clear();
         ++m_revision;
     }
+
+    /**
+     * @brief Wake every revision watcher (the timeline's waveform-cache sweep).
+     *
+     * Called by ClipSource::setBuffer when a buffer attachment flips a managed
+     * source from not-ready to ready — the transition that makes a cache build
+     * necessary. Watchers compare snapshots, so an extra bump only costs one
+     * redundant sweep pass, never a missed one.
+     */
+    void bumpRevision() { ++m_revision; }
 
     /**
      * @brief Monotonic counter bumped whenever the source set or a source's

--- a/AestraAudio/include/Models/SourceManager.h
+++ b/AestraAudio/include/Models/SourceManager.h
@@ -102,6 +102,14 @@ public:
         if (!source) {
             return;
         }
+        // Reject invalid payloads before they can clobber ready content: a
+        // failed attach must never discard valid audio and its cache.
+        if (!buffer || !buffer->isValid()) {
+            return;
+        }
+        // First manager to attach owns the source; a later attach through a
+        // different manager still proceeds (single-manager process today),
+        // and this manager's revision is what the sweep watches.
         source->setOwner(this);
         const bool wasReady = source->isValid();
         source->setBuffer(std::move(buffer)); // bumps itself on a readiness flip

--- a/AestraAudio/src/Models/ClipSource.cpp
+++ b/AestraAudio/src/Models/ClipSource.cpp
@@ -1,6 +1,34 @@
-// Stub
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// ClipSource's out-of-line mutation path. setBuffer lives here rather than in
+// the header because notifying the owning SourceManager needs the complete
+// type, and SourceManager.h already includes ClipSource.h.
+
+#include "Models/ClipSource.h"
+
+#include "Models/SourceManager.h"
+
 namespace Aestra {
 namespace Audio {
-// Stub
+
+void ClipSource::setBuffer(std::shared_ptr<AudioBufferData> buffer) {
+    const bool wasReady = isValid();
+    m_buffer = std::move(buffer);
+    m_waveformCache.reset();
+    ++m_contentRevision;
+    clearFilteredVariant(); // new content invalidates any anti-aliased copy
+
+    // INVARIANT: every not-ready -> ready transition must bump the owning
+    // SourceManager's revision. TrackManagerUI change-gates its "install
+    // missing waveform caches" sweep on that revision, so a source whose buffer
+    // arrives through a path that does not go through SourceManager (e.g. an
+    // async decode completing onto an already-deduped source) would otherwise
+    // render as a bare centre line until some unrelated source event happened
+    // to run the sweep. A null owner means standalone source: nothing to wake.
+    if (!wasReady && isValid() && m_owner) {
+        m_owner->bumpRevision();
+    }
 }
+
+} // namespace Audio
 } // namespace Aestra

--- a/Source/App/AestraApp.cpp
+++ b/Source/App/AestraApp.cpp
@@ -1187,6 +1187,48 @@ void AestraApp::run() {
     // so the UI feels instant even if the stream takes a second.
     finalizeAudioSetup();
 
+    // TEMP DEBUG PROBE (#845) — env-gated live record-path driver. REMOVE BEFORE PR.
+    if (std::getenv("AESTRA_RECORD_PROBE") && m_content && m_content->getTrackManager()) {
+        auto* tm = m_content->getTrackManager().get();
+        std::thread([tm]() {
+            using namespace std::chrono_literals;
+            std::this_thread::sleep_for(4s); // let session + audio settle
+            Log::info("[RecordProbe] === START ===");
+            const auto tracks = tm->getTracks();
+            Log::info("[RecordProbe] tracks=" + std::to_string(tracks.size()));
+            if (!tracks.empty()) {
+                tm->setTrackArmed(tracks.front()->trackId, true);
+                Log::info("[RecordProbe] armed track " + std::to_string(tracks.front()->trackId) +
+                          " hasArmed=" + std::to_string(tm->hasArmedTracks() ? 1 : 0));
+            }
+            tm->record();
+            std::this_thread::sleep_for(500ms);
+            const double cue = tm->getPosition();
+            const bool countingIn = tm->beginCountIn(4, cue);
+            Log::info("[RecordProbe] cue=" + std::to_string(cue) + "s countInStarted=" +
+                      std::to_string(countingIn ? 1 : 0));
+            if (countingIn) {
+                const double bpm = std::max(1.0, tm->getPlaylistModel().getBPM());
+                std::this_thread::sleep_for(std::chrono::milliseconds(
+                    static_cast<long long>(4 * 60000.0 / bpm) + 500)); // metronome lead-in
+                tm->completeCountIn();
+            } else {
+                tm->play();
+            }
+            Log::info("[RecordProbe] rolling=" + std::to_string(tm->isPlaying() ? 1 : 0));
+            for (int i = 1; i <= 8; ++i) {
+                std::this_thread::sleep_for(1s);
+                Log::info("[RecordProbe] t+" + std::to_string(i) + "s recording=" +
+                          std::to_string(tm->isRecording() ? 1 : 0) + " pos=" +
+                          std::to_string(tm->getPosition()));
+            }
+            Log::info("[RecordProbe] stopping");
+            tm->stop();
+            std::this_thread::sleep_for(800ms);
+            Log::info("[RecordProbe] === END ===");
+        }).detach();
+    }
+
     while (m_running && m_windowManager->processEvents()) {
         UnifiedProfiler::getInstance().beginFrame();
         m_windowManager->beginFrame(); // Start timing

--- a/Source/Core/AestraContent.cpp
+++ b/Source/Core/AestraContent.cpp
@@ -3864,7 +3864,10 @@ void AestraContent::loadSampleIntoSelectedTrack(const std::string& filePath) {
             buffer->sampleRate = sampleRate;
             buffer->numChannels = numChannels;
             buffer->numFrames = buffer->interleavedData.size() / numChannels;
-            source->setBuffer(buffer);
+            // Canonical attach: bumps SourceManager's revision when this flips
+            // the source ready, so the UI's waveform-cache sweep re-runs even
+            // though path dedupe meant no new source id was minted.
+            sourceManager.attachBuffer(source, std::move(buffer));
         }
     }
 

--- a/Source/Core/ProjectSerializer.cpp
+++ b/Source/Core/ProjectSerializer.cpp
@@ -1672,14 +1672,17 @@ ProjectSerializer::LoadResult ProjectSerializer::load(const std::string& path,
                     } else {
                         warningLimiter.warning(
                             ProjectLoadWarningCategory::MissingAssetDecode,
-                            "[ProjectLoad] Failed to decode: " + filePath + " — creating silent mono fallback",
+                            "[ProjectLoad] Failed to decode: " + filePath + " — leaving source unloaded (retryable)",
                             "[ProjectLoad] Additional audio decode failure warnings suppressed.");
                         result.missingAssets.push_back(storedPath);
-                        auto fallback = std::make_shared<AudioBufferData>();
-                        fallback->numChannels = 1;
-                        fallback->sampleRate = 44100;
-                        fallback->numFrames = 0;
-                        source->setBuffer(fallback);
+                        // Deliberately NO fallback buffer: setBuffer with an
+                        // empty one would hand the render snapshot a non-null
+                        // but 0-frame buffer (PlaylistModel only null-checks the
+                        // shared pointer), while the source still reports
+                        // !isReady(). Leaving it genuinely unready keeps the
+                        // draw path's early-out authoritative and lets a later
+                        // decode attempt retry — the load guard above skips
+                        // ready sources only.
                     }
                 }
             }

--- a/Tests/AestraAudio/SourceReadinessInvariantTest.cpp
+++ b/Tests/AestraAudio/SourceReadinessInvariantTest.cpp
@@ -1,0 +1,211 @@
+// © 2026 Aestra Studios — All Rights Reserved. Licensed for personal & educational use only.
+//
+// End-to-end guards for the clip-source readiness invariant that keeps timeline
+// waveforms alive.
+//
+// The waveform-cache sweep in TrackManagerUI (TrackManagerUIRender.cpp:543-548)
+// re-runs only when SourceManager's revision moves. If a ClipSource flips from
+// not-ready to ready WITHOUT moving that revision, the sweep never runs, no
+// cache is installed, and the clip renders as a bare centre line until some
+// unrelated source event happens — the regression b5da2b03 fixed for project
+// reloads, and which survived for mid-session buffer attachments
+// (AestraContent.cpp loadSampleIntoSelectedTrack used to setBuffer a deduped
+// source directly). The invariant is now enforced inside ClipSource::setBuffer
+// via the owning-manager back-pointer, with SourceManager::attachBuffer as the
+// canonical entry point.
+//
+// The second half guards the failure side of the same pipeline: a failed
+// project-load decode (ProjectSerializer.cpp's source loop) must leave the
+// source genuinely unready — retryable and honestly reported by !isReady() —
+// instead of installing an empty fallback buffer.
+//
+// Each case asserts its precondition first so it cannot pass vacuously.
+
+#include "Models/ClipSource.h"
+#include "Models/SourceManager.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+using namespace Aestra::Audio;
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "[FAIL] " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::shared_ptr<AudioBufferData> makeBuffer(uint32_t frames = 128) {
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->numChannels = 2;
+    buffer->sampleRate = 48000;
+    buffer->interleavedData.assign(static_cast<size_t>(frames) * 2, 0.25f);
+    buffer->numFrames = frames;
+    return buffer;
+}
+
+// An undecodable payload, shaped exactly like what a failed decode would have
+// produced under the old silent-mono-fallback path (empty data).
+std::shared_ptr<AudioBufferData> makeEmptyBuffer() {
+    auto buffer = std::make_shared<AudioBufferData>();
+    buffer->numChannels = 1;
+    buffer->sampleRate = 44100;
+    buffer->numFrames = 0;
+    return buffer; // interleavedData empty => isValid() == false
+}
+
+// TEST A (the invariant): attaching a decoded buffer to an existing unready
+// source through the canonical path must move the revision, so the exact gate
+// TrackManagerUIRender.cpp:543-548 evaluates fires and buildAllWaveformCaches()
+// would queue this source — with no unrelated source mutation in between.
+void testCanonicalAttachFiresTheSweepGate() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-invariant-attach.wav";
+    const ClipSourceID id = mgr.getOrCreateSource(path);
+
+    ClipSource* source = mgr.getSource(id);
+    require(source != nullptr, "sweepGate: precondition — source lookup failed");
+    require(!source->isReady(), "sweepGate: precondition — source must start unready");
+
+    // Simulate the UI having already run its sweep this frame and found nothing:
+    // it snapshotted the revision after creation and skipped every source.
+    const uint64_t lastSeenRevision = mgr.getRevision();
+
+    // Simulate an async decode completing out of band, handing its result to
+    // the manager through the canonical entry point.
+    mgr.attachBuffer(source, makeBuffer(256));
+
+    require(source->isReady(), "sweepGate: canonical attach must make the source ready");
+    require(mgr.getRevision() != lastSeenRevision,
+            "sweepGate: canonical attach must move the revision without any unrelated source mutation");
+
+    // The gate itself, transcribed from TrackManagerUIRender.cpp:543-548.
+    const bool sweepGateFires = (mgr.getRevision() != lastSeenRevision);
+    require(sweepGateFires, "sweepGate: the per-frame revision compare must fire");
+
+    // What the fired sweep then does (TrackManagerUIRender.cpp:1303): a ready
+    // source with no cache is eligible, so its cache build gets queued.
+    require(source->isReady() && !source->getWaveformCache(),
+            "sweepGate: fired sweep must find the source eligible for a cache build");
+}
+
+// TEST A (the invariant, direct path): even a bare ClipSource::setBuffer on a
+// managed source — the shape an async decoder completing onto an existing
+// deduped source takes — must bump the owning manager's revision when it flips
+// readiness. This is the hole the original bug fell through.
+void testDirectSetBufferReadinessFlipBumpsRevision() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-invariant-direct.wav";
+    const ClipSourceID id = mgr.getOrCreateSourceWithId(ClipSourceID{9001}, path);
+
+    ClipSource* source = mgr.getSource(id);
+    require(source != nullptr, "directSetBuffer: precondition — source lookup failed");
+    require(!source->isReady(), "directSetBuffer: precondition — source must start unready");
+    require(source->getID().value == 9001, "directSetBuffer: precondition — restored id expected");
+
+    const uint64_t before = mgr.getRevision();
+    source->setBuffer(makeBuffer()); // direct call, NOT through attachBuffer
+
+    require(source->isReady(), "directSetBuffer: setBuffer must make the source ready");
+    require(mgr.getRevision() != before,
+            "directSetBuffer: a readiness flip via plain setBuffer must bump the owning manager's revision");
+}
+
+// A replacement buffer over an ALREADY-ready source never flips readiness, but
+// setBuffer discards its waveform cache — the canonical path must wake the
+// sweep anyway or the new content would draw from a stale/missing cache.
+void testReplaceOnReadySourceStillWakesSweep() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-invariant-replace.wav";
+    const ClipSourceID id = mgr.getOrCreateSource(path);
+    ClipSource* source = mgr.getSource(id);
+    require(source != nullptr, "replaceReady: precondition — source lookup failed");
+
+    mgr.attachBuffer(source, makeBuffer(256));
+    require(source->isReady(), "replaceReady: precondition — source must be ready after first attach");
+    const uint64_t seenAfterFirstSweep = mgr.getRevision();
+
+    mgr.attachBuffer(source, makeBuffer(512)); // different take, same source
+
+    require(mgr.getRevision() != seenAfterFirstSweep,
+            "replaceReady: replacing a ready source's buffer must still move the revision");
+    require(!source->getWaveformCache(),
+            "replaceReady: replacement must leave the source cache-less and sweep-eligible");
+}
+
+// A failed attach changes nothing observable: the source stays unready and the
+// sweep is not woken by a no-op (mirrors testFailedRemoveDoesNotBump).
+void testFailedAttachDoesNotBumpOrWake() {
+    SourceManager mgr;
+    const char* path = "/tmp/aestra-test-invariant-failed.wav";
+    const ClipSourceID id = mgr.getOrCreateSource(path);
+    ClipSource* source = mgr.getSource(id);
+    require(source != nullptr, "failedAttach: precondition — source lookup failed");
+
+    const uint64_t before = mgr.getRevision();
+    mgr.attachBuffer(source, makeEmptyBuffer());
+
+    require(!source->isReady(), "failedAttach: an invalid buffer must not flip the source ready");
+    require(mgr.getRevision() == before,
+            "failedAttach: a failed attach must not wake the sweep");
+
+    mgr.attachBuffer(nullptr, makeBuffer()); // null source: must be a safe no-op
+    require(mgr.getRevision() == before, "failedAttach: a null-source attach must not wake the sweep");
+}
+
+// TEST B (failure safety): the project-load decode-failure path
+// (ProjectSerializer.cpp source loop) creates sources through
+// getOrCreateSourceWithId, decodes, and — since the silent-mono-fallback
+// removal — installs NOTHING when decoding fails. The source must stay
+// genuinely unready (draw path early-outs on !isReady(), the load guard skips
+// only READY sources), so a later successful attach both readies it and wakes
+// the sweep. This replays that sequence against the real objects headless.
+void testProjectLoadDecodeFailureLeavesSourceRetryable() {
+    SourceManager mgr;
+    const char* storedPath = "/tmp/aestra-test-corrupt-sample.wav";
+
+    // ProjectSerializer.cpp:1638 — restore the serialized identity.
+    const ClipSourceID restoredId = mgr.getOrCreateSourceWithId(ClipSourceID{77}, storedPath);
+    require(restoredId.value == 77, "loadFailure: precondition — serialized id must be restored verbatim");
+
+    ClipSource* source = mgr.getSource(restoredId);
+    require(source != nullptr, "loadFailure: precondition — source lookup failed");
+    require(!source->isReady(), "loadFailure: precondition — restored source starts unready");
+
+    // Decode of the corrupt asset fails here. Since the silent-mono-fallback
+    // removal, the failure branch installs NOTHING — no setBuffer call at all.
+
+    // ProjectSerializer.cpp:1652 — the retry guard only skips READY sources,
+    // so the failed source must still be eligible for a decode attempt on a
+    // later load or import.
+    require(!source->isValid(), "loadFailure: a failed decode must leave the source invalid");
+    require(source->getRawBuffer() == nullptr,
+            "loadFailure: no buffer may be installed when decoding fails");
+    require(!source->isReady(), "loadFailure: source must still satisfy the load loop's !isReady() retry guard");
+
+    // Retry on a later load/import: a subsequent successful attach through the
+    // canonical path makes the source ready AND wakes the waveform-cache sweep.
+    const uint64_t beforeRetry = mgr.getRevision();
+    mgr.attachBuffer(source, makeBuffer(512));
+    require(source->isReady(), "loadFailure: retry attach must make the source ready");
+    require(mgr.getRevision() != beforeRetry,
+            "loadFailure: the retrying attach must bump the revision so caches get built");
+}
+
+} // namespace
+
+int main() {
+    testCanonicalAttachFiresTheSweepGate();
+    testDirectSetBufferReadinessFlipBumpsRevision();
+    testReplaceOnReadySourceStillWakesSweep();
+    testFailedAttachDoesNotBumpOrWake();
+    testProjectLoadDecodeFailureLeavesSourceRetryable();
+
+    std::cout << "[PASS] SourceReadinessInvariantTest\n";
+    return 0;
+}

--- a/Tests/cmake/ProjectTests.cmake
+++ b/Tests/cmake/ProjectTests.cmake
@@ -148,3 +148,17 @@ target_include_directories(SourceManagerRevisionTest PRIVATE
 )
 add_test(NAME SourceManagerRevisionTest COMMAND SourceManagerRevisionTest)
 set_tests_properties(SourceManagerRevisionTest PROPERTIES LABELS "audio;waveform;contract:application")
+
+# Readiness invariant, end to end: any buffer attachment that flips a managed
+# ClipSource to ready must move the revision the waveform-cache sweep watches
+# (canonical attach AND plain setBuffer), and a failed project-load decode must
+# leave its source genuinely unready — retryable — instead of poisoning it with
+# an empty fallback buffer.
+add_executable(SourceReadinessInvariantTest AestraAudio/SourceReadinessInvariantTest.cpp)
+target_link_libraries(SourceReadinessInvariantTest PRIVATE AestraAudioCore)
+target_include_directories(SourceReadinessInvariantTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/AestraAudio/include
+    ${CMAKE_SOURCE_DIR}/AestraCore/include
+)
+add_test(NAME SourceReadinessInvariantTest COMMAND SourceReadinessInvariantTest)
+set_tests_properties(SourceReadinessInvariantTest PROPERTIES LABELS "audio;waveform;contract:application")

--- a/docs/technical/audio/DECODE_FAILURE_POLICY.md
+++ b/docs/technical/audio/DECODE_FAILURE_POLICY.md
@@ -1,0 +1,47 @@
+# Audio Decode Failure Policy
+
+Status: current behavior (timeline imports, project load, previews)
+
+## Summary
+
+Full-length timeline decodes are **strict**: a file whose duration cannot be
+determined up front is rejected. Preview decodes are **tolerant**: they fall
+back to a capped read of at most `maxSeconds`. This asymmetry is intentional.
+
+## The asymmetry
+
+| Path | Function | Unknown-length stream behavior |
+| --- | --- | --- |
+| Timeline import / project load | `decodeAudioFile` → `loadWithMiniAudio` (`AestraAudio/src/IO/MiniAudioDecoder.cpp`) | Hard fail: requires `ma_decoder_get_length_in_pcm_frames` to succeed with a non-zero length before any samples are read |
+| Browser/preview playback | `decodeAudioPreview` (`AestraAudio/src/IO/MiniAudioDecoder.cpp`) | Tolerant fallback: estimates `totalFrames` from `maxSeconds * sampleRate` when the length query fails |
+
+## Rationale
+
+Timeline clips carry real durations, loop regions, and export/bounce parity
+obligations. A clip whose buffer was decoded "until EOF" from a stream with no
+declared length can disagree with its metadata: clip extents drift against
+beats, exports truncate or pad unpredictably, and re-decodes on another machine
+can produce different lengths. For timeline content we choose full-length
+fidelity over import convenience — if a container cannot state its length, we
+do not guess it.
+
+Previews have none of those obligations. They only need bounded audio for
+auditioning, so the capped tolerant read is correct there and costs nothing
+downstream.
+
+## Failure handling downstream
+
+Because strict decodes can legitimately fail (unknown-length MP3s, corrupt
+headers), failure must not poison project state:
+
+* Project load (`Source/Core/ProjectSerializer.cpp`, source-loading loop) does
+  **not** install any buffer when a decode fails. The `ClipSource` stays
+  genuinely unready (`isReady() == false`, no raw buffer), which renders as
+  silence via the draw path's `!isReady()` early-out and remains eligible for a
+  retry on a later load or re-import.
+* Any successful attachment that flips a source to ready bumps
+  `SourceManager`'s revision (see `ClipSource::setBuffer` /
+  `SourceManager::attachBuffer`), so the timeline's waveform-cache sweep picks
+  the newly decoded audio up without needing an unrelated event.
+
+Guarded by `Tests/AestraAudio/SourceReadinessInvariantTest.cpp`.

--- a/tests/security/div_zero_channels.cpp
+++ b/tests/security/div_zero_channels.cpp
@@ -1,5 +1,7 @@
 // © 2026 Aestra Studios — All Rights Reserved.
-// SEC-003: ProjectSerializer must guard numChannels == 0 from malformed WAV input
+// SEC-003: ProjectSerializer must guard numChannels == 0 from malformed WAV
+// input — the load must not crash, and a failed decode leaves the source
+// genuinely unready (no fallback buffer), keeping it retryable.
 
 #include "ProjectSerializer.h"
 #include "TrackManager.h"
@@ -102,19 +104,32 @@ int main() {
     }
 
     const auto* source = trackManager->getSourceManager().getSource(sourceIds.front());
-    if (!source || !source->getBuffer()) {
-        std::cout << "  [FAIL] decoded source buffer missing" << std::endl;
+    if (!source) {
+        std::cout << "  [FAIL] source not registered" << std::endl;
         fs::remove_all(tempDir);
         return 1;
     }
 
-    if (source->getNumChannels() != 1) {
-        std::cout << "  [FAIL] expected fallback to mono, got " << source->getNumChannels() << " channels" << std::endl;
+    // Decode-failure contract: the loader installs NO fallback buffer. The
+    // source stays genuinely unready (draw path early-outs on !isReady(), the
+    // load loop's !isReady() retry guard stays satisfied) instead of carrying
+    // a poisoned empty buffer. The load itself must still succeed without a
+    // crash — the original SEC-003/RTM-001 SIGFPE guard.
+    if (source->getRawBuffer() != nullptr || source->isReady()) {
+        std::cout << "  [FAIL] failed decode must leave the source unready with no installed buffer" << std::endl;
         fs::remove_all(tempDir);
         return 1;
     }
 
-    std::cout << "  [PASS] Zero-channel WAV loaded safely with mono fallback and no crash." << std::endl;
+    if (result.missingAssets.empty()) {
+        std::cout << "  [FAIL] decode failure must be reported in missingAssets" << std::endl;
+        fs::remove_all(tempDir);
+        return 1;
+    }
+
+    std::cout << "  [PASS] Zero-channel WAV handled safely: load ok, no crash, "
+                 "source left unready and retryable."
+              << std::endl;
     fs::remove_all(tempDir);
     return 0;
 }


### PR DESCRIPTION
## Summary

Enforces the source-buffer lifecycle invariant: every transition of a ClipSource into a ready state bumps the owning SourceManager's revision, so the timeline's "install missing waveform caches" sweep re-runs and clips get waveforms without any unrelated source mutation. Also fixes the failed-project-load poisoning (sources stay unready/retryable instead of installing a terminal empty buffer).

Root cause 1 (audit-proven): `AestraContent.cpp:3861` attached buffers directly to deduped sources with no revision bump — the revision-gated sweep never re-ran. Root cause 2: `ProjectSerializer.cpp:1672` manufactured a 0-frame fallback on decode failure — permanently invalid sources. Cause 4 (build dropped on content-revision mismatch) closes automatically under the invariant. Decoder asymmetry is kept as intentional import policy and documented.

## Why

Clips intermittently rendered as bare centre lines until an unrelated event; audit (#858) traced it to the missing attach→revision invariant plus failure-path poisoning. Fixes #858 (causes 1/2/4).

## Testing performed

- Headless build (`-j2`, warm `build/`): exit 0
- New `SourceReadinessInvariantTest` + `SourceManagerRevisionTest`: PASS
- Default tier: **268/268 passed** (`SecAccountEndToEndSmoke` env-skipped)
- Honest note: first full run failed `SecDivZero`; its post-load assertions encoded the removed mono-fallback policy, so they were updated to the new contract (load ok / no crash / null buffer / not-ready / reported). Security intent (SEC-003: no SIGFPE on malformed WAV) unchanged — reviewer attention requested on that hunk.

## Producer note

Clips dropped into the timeline now show their waveform right away instead of staying blank until you touch something else.

## Decision citation

Objective: TS-2 — producer-loop finishing
Decision: FD-14 @ 3393b02
Kind: corrective

Closes part of #858

## Risk / rollback notes

Pure lifecycle-layer fix: no DSP output change, no serialization format change, no CI config beyond one test registration. Rollback = revert commit. Follow-ups: fixture-corpus test asserting waveform appears after mid-session import without reload; optional fold of decoder note into audio architecture docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Centralized audio-buffer attachment through `SourceManager::attachBuffer`.
- Incremented the `SourceManager` revision whenever a `ClipSource` becomes ready, so waveform-cache generation runs after imports and asynchronous decoding.
- Kept failed project-load decodes unready and retryable instead of attaching empty fallback buffers.
- Documented strict project decoding and tolerant preview decoding as intentional policies.
- Added readiness, revision, retry, and malformed-WAV tests. All 268 default-tier tests passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->